### PR TITLE
Add context menu for books in Tauri apps

### DIFF
--- a/apps/readest-app/src/utils/os.ts
+++ b/apps/readest-app/src/utils/os.ts
@@ -1,0 +1,8 @@
+export const FILE_REVEAL_LABELS = {
+  macos: 'Reveal in Finder',
+  windows: 'Reveal in File Explorer',
+  linux: 'Reveal in Folder',
+  default: 'Reveal in Folder',
+};
+
+export type FILE_REVEAL_PLATFORMS = keyof typeof FILE_REVEAL_LABELS;


### PR DESCRIPTION
Currently two menu items in the context menu:
1. Reveal in Folder
2. Delete

![image](https://github.com/user-attachments/assets/88bb5f19-2559-455d-913a-071dcd447e75)
