### PR TITLE
Don't fallback to Noto Sans JP, use serif fallbacks

### DIFF
--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -95,7 +95,7 @@ export const SANS_SERIF_FONTS = ['Roboto', 'Noto Sans', 'Open Sans', 'Helvetica'
 
 export const MONOSPACE_FONTS = ['Fira Code', 'Lucida Console', 'Consolas', 'Courier New'];
 
-export const FALLBACK_FONTS = ['Noto Serif JP', 'MiSans L3'];
+export const FALLBACK_FONTS = ['MiSans L3'];
 
 export const WINDOWS_FONTS = [
   'Arial',


### PR DESCRIPTION
It's safe to use 'MiSans L3' as fallbacks because it has only rare chars in GB18030 L3