### PR TITLE
Add Dockerfile to selfhost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM node:22-slim
+
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="${PATH}:${PNPM_HOME}"
+
+RUN npm install --global pnpm
+
+# Install necessary packages
+RUN apt update -y && apt install -y --no-install-recommends \
+    libwebkit2gtk-4.1-dev \
+    build-essential \
+    curl \
+    wget \
+    file \
+    libxdo-dev \
+    libssl-dev \
+    libayatana-appindicator3-dev \
+    librsvg2-dev \
+    ca-certificates \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Rust and Cargo
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+COPY . /app
+
+WORKDIR /app
+
+RUN pnpm install
+
+RUN pnpm --filter @readest/readest-app setup-pdfjs
+
+WORKDIR /app/apps/readest-app
+
+RUN pnpm build-web
+
+ENTRYPOINT ["pnpm", "start-web"]


### PR DESCRIPTION
Add a Dockerfile to be able to self host the web version of readest.

This can be built locally using:

```bash
git clone https://github.com/readest/readest.git
cd readest
git submodule update --init --recursive
docker build -t readest .
```

And can be run using:

```bash
docker build -t readest .
```
