### PR TITLE
fix: styles

### DIFF
--- a/apps/readest-app/src/app/reader/components/settings/SettingsDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/settings/SettingsDialog.tsx
@@ -64,7 +64,7 @@ const SettingsDialog: React.FC<{ bookKey: string; config: BookConfig }> = ({ boo
         isOpen={true}
         onClose={handleClose}
         className='modal-open'
-        boxClassName='sm:min-w-[480px]'
+        boxClassName='sm:min-w-[520px]'
         header={
           <div className='flex w-full items-center justify-between'>
             <button
@@ -76,12 +76,12 @@ const SettingsDialog: React.FC<{ bookKey: string; config: BookConfig }> = ({ boo
             >
               <MdArrowBackIosNew />
             </button>
-            <div className='dialog-tabs flex h-10 max-w-[100%] flex-grow items-center justify-around pl-4'>
+            <div className='dialog-tabs flex h-10 max-w-[100%] flex-grow items-center pl-4 gap-2'>
               {tabConfig.map(({ tab, icon: Icon, label }) => (
                 <button
                   key={tab}
                   className={clsx(
-                    'btn btn-ghost text-base-content h-8 min-h-8',
+                    'btn btn-ghost text-base-content btn-sm',
                     activePanel === tab ? 'btn-active' : '',
                   )}
                   onClick={() => setActivePanel(tab)}

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -7,6 +7,7 @@
   --foreground: #171717;
   border-radius: 10px;
   scrollbar-gutter: auto !important;
+  overscroll-behavior: none;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -35,6 +36,7 @@ body {
     sans-serif;
   border-radius: 10px;
   background-color: transparent;
+  cursor: default;
 }
 
 @layer utilities {


### PR DESCRIPTION
1. 修复滚动bug （我自己测试了常用的多个页面没问题，可能有我不知道的页面，需要回归下其他页面）
    

https://github.com/user-attachments/assets/c6d64248-b3ab-412a-ad09-e090d46dcd3b


2. 修复字体设置 dialog 的样式bug

https://github.com/user-attachments/assets/c2443ce0-6c1c-42c6-905b-dda83afd95fe


3. 移除字体设置 dialog 的 tab 按钮 `justify-around`, 改为左对齐（个人感觉视觉更好些）
4. 将页面的 cursor 样式默认为 箭头，不然设置页面的文字鼠标hover也会变成文本选择样式
![MVIMG_20250306_173217](https://github.com/user-attachments/assets/bbd44e6d-9a31-4637-9839-137b740444b9)
