### PR TITLE
Fixes the scrollbar gutter issue for DaisyUI

### DIFF
--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -10,6 +10,8 @@
   overscroll-behavior: none;
 }
 
+/* Fixes the scrollbar gutter issue for DaisyUI */
+/* https://github.com/saadeghi/daisyui/issues/3040#issuecomment-2250530354 */
 :root:has(
     :is(
         .modal-open,

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -10,6 +10,17 @@
   overscroll-behavior: none;
 }
 
+:root:has(
+    :is(
+        .modal-open,
+        .modal:target,
+        .modal-toggle:checked + .modal,
+        .modal[open]
+      )
+  ) {
+  scrollbar-gutter: unset !important;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #222222;


### PR DESCRIPTION
When the Settings are opened, because daisyui has set scrollbar-gullter, the <html> will have an extra virtual scrollbar, causing the page style to be abnormal.

![image](https://github.com/user-attachments/assets/92f6ec77-2738-4fcf-aa9e-62ee321cc2e2)
