### PR TITLE
Fix filename with quotes

### DIFF
--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -71,7 +71,8 @@ fn set_window_open_with_files(app: &AppHandle, files: Vec<PathBuf>) {
     let files = files
         .into_iter()
         .map(|f| {
-            let file = f.to_string_lossy()
+            let file = f
+                .to_string_lossy()
                 .replace("\\", "\\\\")
                 .replace("\"", "\\\"");
             format!("\"{file}\"",)

--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -71,7 +71,9 @@ fn set_window_open_with_files(app: &AppHandle, files: Vec<PathBuf>) {
     let files = files
         .into_iter()
         .map(|f| {
-            let file = f.to_string_lossy().replace("\\", "\\\\");
+            let file = f.to_string_lossy()
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"");
             format!("\"{file}\"",)
         })
         .collect::<Vec<_>>()


### PR DESCRIPTION
When opening a file with double quotes in the name from file manager (without importing), it just opens the application (book shelf).
Filename example: `Title – "Subtitle" - Author.epub`

This only happens when opening the book from Finder (Open With) or:
```
open -a Readest.app "Title – \"Subtitle\" - Author.epub"
```
but it works with:
```
/Applications/Readest.app/Contents/MacOS/readest "Title – \"Subtitle\" - Author.epub"

Allowed file in fs_scope: "Title – \"Subtitle\" - Author.epub"
Allowed file in asset_protocol_scope: "Title – \"Subtitle\" - Author.epub"
Window is ready, proceeding to handle files.
```