### PR TITLE
add more aggressive overrides for background and text colour

### DIFF
--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -99,6 +99,12 @@ const getColorStyles = (
 ) => {
   const { bg, fg, primary, isDarkMode } = themeCode;
   const colorStyles = `
+    * {
+      ${overrideColor ? `background-color: transparent !important;` : ''}
+    }
+    p, h1, h2, h3, h4, h5, h6 {
+      ${overrideColor ? `color: ${fg} !important;` : ''}
+    }
     html {
       --theme-bg-color: ${bg};
       --theme-fg-color: ${fg};
@@ -107,9 +113,6 @@ const getColorStyles = (
     }
     html, body {
       color: ${fg};
-    }
-    div, p, span, pre {
-      ${overrideColor ? `background-color: ${bg} !important;` : ''}
     }
     a:any-link {
       ${overrideColor ? `color: ${primary};` : isDarkMode ? `color: lightblue;` : ''}

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -99,12 +99,6 @@ const getColorStyles = (
 ) => {
   const { bg, fg, primary, isDarkMode } = themeCode;
   const colorStyles = `
-    * {
-      ${overrideColor ? `background-color: transparent !important;` : ''}
-    }
-    p, h1, h2, h3, h4, h5, h6 {
-      ${overrideColor ? `color: ${fg} !important;` : ''}
-    }
     html {
       --theme-bg-color: ${bg};
       --theme-fg-color: ${fg};
@@ -113,6 +107,10 @@ const getColorStyles = (
     }
     html, body {
       color: ${fg};
+    }
+    div, p, span, pre , h1, h2, h3, h4, h5, h6 {
+      ${overrideColor ? `background-color: ${bg} !important;` : ''}
+      ${overrideColor ? `color: ${fg} !important;` : ''}
     }
     a:any-link {
       ${overrideColor ? `color: ${primary};` : isDarkMode ? `color: lightblue;` : ''}


### PR DESCRIPTION
Adding more style overrides for Manning epubs that have coloured titles, hopefully this doesn't negatively interact with other books.

no override
![image](https://github.com/user-attachments/assets/84480f75-2f59-4bf8-b601-7624dd87ab9d)

old override
![image](https://github.com/user-attachments/assets/df86727c-1a8b-43a7-ad55-63af6a2f3cfe)

new override
![image](https://github.com/user-attachments/assets/64d71fd4-fb24-4e29-ae14-c802b5cfd702)
