### PR TITLE
add vscode settings to include inlayhints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,4 +4,13 @@
     "packages/tauri/Cargo.toml",
     "apps/readest-app/src-tauri/Cargo.toml"
   ],
+  // "editor.formatOnSave": true, // uncomment to add format on save
+  "typescript.inlayHints.parameterNames.enabled": "all",
+  "typescript.inlayHints.variableTypes.enabled": true,
+  "typescript.inlayHints.propertyDeclarationTypes.enabled": true,
+  "typescript.inlayHints.functionLikeReturnTypes.enabled": true,
+  "typescript.inlayHints.enumMemberValues.enabled": true,
+  "javascript.validate.enable": false,
+  "javascript.format.enable": false,
+  "typescript.format.enable": false,
 }


### PR DESCRIPTION
This is a suggested edit, no worries if you don't think its appropriate, but it adds ghost text type hints in for typescript, like we're used to in Rust.

![image](https://github.com/user-attachments/assets/66785a59-3ff0-4b03-be12-6d05f2f64989)
