### PR TITLE
fix: correct spelling 'Themeing' to 'Theming' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Stay tuned for continuous improvements and updates! Contributions and suggestion
 
 ![Wikipedia](./data/screenshots/wikipedia_vertical.png)
 
-![Themeing Dark Mode](./data/screenshots/theming_dark_mode.png)
+![Theming Dark Mode](./data/screenshots/theming_dark_mode.png)
 
 ---
 


### PR DESCRIPTION
## Changes  
  
### 1. Fix spelling error in README.md  
- Correct "Themeing Dark Mode" to "Theming Dark Mode"