### PR TITLE
[WIP] feat: implement OpenAI TTS client and integrate with TTS controller

### DIFF
--- a/apps/readest-app/src/libs/openaiTTS.ts
+++ b/apps/readest-app/src/libs/openaiTTS.ts
@@ -1,0 +1,274 @@
+import {LRUCache} from '@/utils/lru';
+import {md5} from 'js-md5';
+
+export interface OpenAITTSPayload {
+  model: string;
+  text: string;
+  voice: string;
+  speed?: number;
+  lang_code?: string;
+}
+
+// name is like "alloy"
+// id is like "af_alloy"
+// lang is like "a" for english, "e" for spanish
+export interface OpenAITTSVoice {
+  name: string;
+  id: string;
+  lang: string;
+}
+
+const hashPayload = (payload: OpenAITTSPayload): string => {
+  const base = JSON.stringify(payload);
+  return md5(base);
+};
+
+export class OpenAISpeechTTS {
+  private baseURL: string;
+  // TODO: add type to cache
+  static audioCache = new LRUCache<string, ArrayBuffer>(200);
+  static voicesCache: OpenAITTSVoice[] = [];
+  static modelsCache: string[] = [];
+
+  constructor(baseURL: string = 'http://localhost:8880') {
+    this.baseURL = baseURL;
+  }
+
+  async init(): Promise<boolean> {
+    try {
+      // First check if the service is accessible by trying to fetch models
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => {
+        controller.abort(new Error('Health check timeout after 5 seconds'));
+      }, 5000);  // 5 second timeout for health check
+
+      const response = await fetch(`${this.baseURL}/v1/models`, {
+        method: 'GET',
+        headers: {
+          'Accept': 'application/json',
+        },
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        console.warn(`OpenAI TTS service not accessible at ${this.baseURL}: ${
+            response.status} ${response.statusText}`);
+        return false;
+      }
+
+      // If health check passes, fetch voices and models
+      await Promise.all([
+        this.#fetchVoices(),
+        this.#fetchModels(),
+      ]);
+
+      console.log(
+          `OpenAI TTS service initialized successfully at ${this.baseURL}`);
+      return true;
+    } catch (error) {
+      console.warn(
+          `Failed to initialize OpenAI TTS service at ${this.baseURL}:`, error);
+      return false;
+    }
+  }
+
+  async create(payload: OpenAITTSPayload): Promise<Response> {
+    return this.#fetchOpenAISpeech(payload);
+  }
+
+  async createAudio(payload: OpenAITTSPayload): Promise<Blob> {
+    const cacheKey = hashPayload(payload);
+    if (OpenAISpeechTTS.audioCache.has(cacheKey)) {
+      return new Blob(
+          [OpenAISpeechTTS.audioCache.get(cacheKey)!], {type: 'audio/mpeg'});
+    }
+
+    try {
+      const response = await this.create(payload);
+      const arrayBuffer = await response.arrayBuffer();
+      OpenAISpeechTTS.audioCache.set(cacheKey, arrayBuffer);
+
+      const contentType = 'audio/mpeg';  // default to mp3
+      return new Blob([arrayBuffer], {type: contentType});
+    } catch (error) {
+      console.error('Failed to create audio with OpenAI TTS:', error);
+      throw new Error(`OpenAI TTS audio generation failed: ${
+          error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  async getVoices(): Promise<OpenAITTSVoice[]> {
+    if (OpenAISpeechTTS.voicesCache.length === 0) {
+      await this.#fetchVoices();
+    }
+    return OpenAISpeechTTS.voicesCache;
+  }
+
+  async getModels(): Promise<string[]> {
+    if (OpenAISpeechTTS.modelsCache.length === 0) {
+      await this.#fetchModels();
+    }
+    return OpenAISpeechTTS.modelsCache;
+  }
+
+  // Helper method to infer language from voice ID
+  #inferLanguageFromVoiceId(voiceId: string): string{return voiceId[0] ?? 'e'}
+
+  #langMap: Record<string, string> = {
+    a: 'en-US',  // American English
+    b: 'en-GB',  // British English
+    e: 'es-ES',  // Spanish (Spain)
+    f: 'fr-FR',  // French (France)
+    h: 'hi-IN',  // Hindi (India)
+    i: 'it-IT',  // Italian
+    p: 'pt-BR',  // Portuguese (Brazilian)
+    j: 'ja-JP',  // Japanese
+    z: 'zh-CN',  // Mandarin Chinese (Simplified, China)
+  };
+
+  #getVoiceProperName(voice: string): string {
+    const fullLang = this.#langMap[voice[0] ?? 'a'] ?? 'Unknown Language';
+    const name = voice.replace(/^[a-z]+_/, '').replace(/_/g, ' ');
+    return `${name} (${fullLang})`;
+  };
+
+  async #fetchVoices(): Promise<OpenAITTSVoice[]> {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => {
+        controller.abort(new Error('Fetch voices timeout after 5 seconds'));
+      }, 5000);  // 5 second timeout
+
+      const response = await fetch(`${this.baseURL}/v1/audio/voices`, {
+        method: 'GET',
+        headers: {
+          'Accept': 'application/json',
+        },
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch voices: ${response.status} ${
+            response.statusText}`);
+      }
+
+      const data = await response.json();
+
+      const voices: OpenAITTSVoice[] = [];
+      if (data.voices && Array.isArray(data.voices)) {
+        for (const voice of data.voices) {
+          if (typeof voice === 'string') {
+            // Handle simple string array format like ["af_heart", "af_sarah",
+            // ...]
+            voices.push({
+              name: this.#getVoiceProperName(voice),
+              id: voice,
+              lang: this.#inferLanguageFromVoiceId(voice),
+            });
+          }
+        }
+      }
+
+      OpenAISpeechTTS.voicesCache = voices;
+      return voices;
+    } catch (error) {
+      console.warn('Failed to fetch voices from OpenAI TTS service:', error);
+      return [];
+    }
+  }
+
+  async #fetchModels(): Promise<string[]> {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => {
+        controller.abort(new Error('Fetch models timeout after 5 seconds'));
+      }, 5000);  // 5 second timeout
+
+      const response = await fetch(`${this.baseURL}/v1/models`, {
+        method: 'GET',
+        headers: {
+          'Accept': 'application/json',
+        },
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch models: ${response.status} ${
+            response.statusText}`);
+      }
+
+      const data = await response.json();
+
+      const models: string[] = [];
+      if (data.data && Array.isArray(data.data)) {
+        for (const model of data.data) {
+          models.push(model.id);
+        }
+      }
+
+      // set default models if none found
+      OpenAISpeechTTS.modelsCache = models.length > 0 ? models : ['kokoro'];
+      return OpenAISpeechTTS.modelsCache;
+    } catch (error) {
+      console.warn('Failed to fetch models from OpenAI TTS service:', error);
+      // Return default model if fetch fails
+      OpenAISpeechTTS.modelsCache = ['kokoro'];
+      return OpenAISpeechTTS.modelsCache;
+    }
+  }
+
+  async #fetchOpenAISpeech(payload: OpenAITTSPayload): Promise<Response> {
+    const requestBody = {
+      model: payload.model || 'kokoro',
+      input: payload.text,
+      voice: payload.voice,
+      response_format: 'mp3',
+      speed: payload.speed || 1.0,
+      lang_code: payload.lang_code || 'a',
+      stream: false,
+    };
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort(new Error('Request timeout after 30 seconds'));
+    }, 30000);  // 30 second timeout
+
+    try {
+      const response = await fetch(`${this.baseURL}/v1/audio/speech`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'audio/*',
+        },
+        body: JSON.stringify(requestBody),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => 'Unknown error');
+        throw new Error(`OpenAI TTS API error: ${response.status} ${
+            response.statusText} - ${errorText}`);
+      }
+
+      return response;
+    } catch (error) {
+      clearTimeout(timeoutId);
+
+      // Handle specific abort errors
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error(
+            'OpenAI TTS request was aborted (likely due to timeout)');
+      }
+
+      throw error;
+    }
+  }
+}

--- a/apps/readest-app/src/services/tts/OpenAITTSClient.ts
+++ b/apps/readest-app/src/services/tts/OpenAITTSClient.ts
@@ -1,0 +1,317 @@
+import {OpenAISpeechTTS, OpenAITTSPayload} from '@/libs/openaiTTS';
+import {getUserLocale} from '@/utils/misc';
+import {parseSSMLMarks} from '@/utils/ssml';
+
+import {TTSClient, TTSMessageEvent} from './TTSClient';
+import {TTSController} from './TTSController';
+import {TTSUtils} from './TTSUtils';
+import {TTSGranularity, TTSVoice, TTSVoicesGroup} from './types';
+
+export class OpenAITTSClient implements TTSClient {
+  name = 'openai-tts';
+  initialized = false;
+  controller?: TTSController;
+
+  #voices: TTSVoice[] = [];
+  #primaryLang = 'en';
+  #speakingLang = '';
+  #currentVoiceId = '';
+  #rate = 1.0;
+  // openAI does not support pitch adjustment
+  // #pitch = 1.0;
+  #model = 'kokoro';
+  #openaiTTS: OpenAISpeechTTS;
+  #audioElement: HTMLAudioElement|null = null;
+  #isPlaying = false;
+  #pausedAt = 0;
+  #startedAt = 0;
+
+  constructor(controller?: TTSController, baseURL?: string) {
+    this.controller = controller;
+    this.#openaiTTS = new OpenAISpeechTTS(baseURL);
+  }
+
+  async init() {
+    const success = await this.#openaiTTS.init();
+    if (success) {
+      this.#voices = await this.#openaiTTS.getVoices();
+      this.#currentVoiceId = this.#voices[0]?.id || 'af_heart';
+
+      console.log('OpenAI TTS client initialized successfully');
+      this.initialized = true;
+    } else {
+      console.error('Failed to initialize OpenAI TTS client');
+      this.initialized = false
+    }
+
+    return this.initialized;
+  }
+
+  async shutdown(): Promise<void> {
+    await this.stopInternal();
+  }
+
+  async *
+      speak(ssml: string, signal: AbortSignal, preload = false):
+          AsyncIterable<TTSMessageEvent> {
+    const {marks} = parseSSMLMarks(ssml, this.#primaryLang);
+    const voiceId = this.#currentVoiceId
+
+    if (preload) {
+      // Preload the first 2 marks immediately and the rest in the background
+      const maxImmediate = 2;
+      for (let i = 0; i < Math.min(maxImmediate, marks.length); i++) {
+        const mark = marks[i]!;
+        const {language: voiceLang} = mark;
+        const lang = await this.#getVoiceLangCode(voiceId);
+        this.#speakingLang = voiceLang;
+
+        await this.#openaiTTS
+            .createAudio(this.#getPayload(mark.text, voiceId, lang))
+            .catch((err) => {
+              console.warn('Error preloading mark', i, err);
+            });
+      }
+      if (marks.length > maxImmediate) {
+        (async () => {
+          for (let i = maxImmediate; i < marks.length; i++) {
+            const mark = marks[i]!;
+            try {
+              const lang = await this.#getVoiceLangCode(voiceId);
+              await this.#openaiTTS.createAudio(
+                  this.#getPayload(mark.text, voiceId, lang));
+            } catch (err) {
+              console.warn('Error preloading mark (bg)', i, err);
+            }
+          }
+        })();
+      }
+
+      yield {
+        code: 'end',
+        message: 'Preload finished',
+      } as TTSMessageEvent;
+
+      return;
+    }
+    else {
+      await this.stopInternal();
+    }
+
+    for (const mark of marks) {
+      if (signal.aborted) {
+        yield {
+          code: 'error',
+          message: 'Aborted',
+        } as TTSMessageEvent;
+        break;
+      }
+      try {
+        const lang = await this.#getVoiceLangCode(voiceId);
+        const blob = await this.#openaiTTS.createAudio(
+            this.#getPayload(mark.text, voiceId, lang),
+        );
+        const url = URL.createObjectURL(blob);
+        this.#audioElement = new Audio(url);
+        const audio = this.#audioElement;
+        audio.setAttribute('x-webkit-airplay', 'deny');
+        audio.preload = 'auto';
+
+        this.controller?.dispatchSpeakMark(mark);
+
+        yield {
+          code: 'boundary',
+          message: `Start chunk: ${mark.name}`,
+          mark: mark.name,
+        } as TTSMessageEvent;
+
+        const result = await new Promise<TTSMessageEvent>((resolve) => {
+          const cleanUp = () => {
+            audio.onended = null;
+            audio.onerror = null;
+            audio.pause();
+            audio.src = '';
+            URL.revokeObjectURL(url);
+          };
+          audio.onended = () => {
+            cleanUp();
+            if (signal.aborted) {
+              resolve({code: 'error', message: 'Aborted'});
+            } else {
+              resolve({code: 'end', message: `Chunk finished: ${mark.name}`});
+            }
+          };
+          audio.onerror = (e) => {
+            cleanUp();
+            console.warn('Audio playback error:', e);
+            resolve({code: 'error', message: 'Audio playback error'});
+          };
+          if (signal.aborted) {
+            cleanUp();
+            resolve({code: 'error', message: 'Aborted'});
+            return;
+          }
+          this.#isPlaying = true;
+          audio.play().catch((err) => {
+            cleanUp();
+            console.error('Failed to play audio:', err);
+            resolve(
+                {code: 'error', message: 'Playback failed: ' + err.message});
+          });
+        });
+
+        this.#isPlaying = false;
+
+        if (result.code === 'error') {
+          yield result;
+          break;
+        }
+
+        yield result;
+      } catch (error) {
+        yield {
+          code: 'error',
+          message: `TTS error: ${error}`,
+        } as TTSMessageEvent;
+        break;
+      }
+    }
+
+    yield {
+      code: 'end',
+      message: 'All chunks finished',
+    } as TTSMessageEvent;
+  }
+
+  async pause(): Promise<boolean> {
+    if (this.#audioElement && this.#isPlaying) {
+      this.#audioElement.pause();
+      this.#pausedAt = Date.now() - this.#startedAt;
+      this.#isPlaying = false;
+      return true;
+    }
+    return false;
+  }
+
+  async resume(): Promise<boolean> {
+    if (this.#audioElement && !this.#isPlaying) {
+      try {
+        await this.#audioElement.play();
+        this.#startedAt = Date.now() - this.#pausedAt;
+        this.#isPlaying = true;
+        return true;
+      } catch (error) {
+        console.error('Resume error:', error);
+        return false;
+      }
+    }
+    return false;
+  }
+
+  async stop(): Promise<void> {
+    await this.stopInternal();
+  }
+
+  private async stopInternal(): Promise<void> {
+    if (this.#audioElement) {
+      this.#audioElement.pause();
+      this.#audioElement.src = '';
+      this.#audioElement = null;
+    }
+    this.#isPlaying = false;
+    this.#pausedAt = 0;
+    this.#startedAt = 0;
+  }
+
+  setPrimaryLang(lang: string): void {
+    this.#primaryLang = lang;
+  }
+
+  async setRate(rate: number): Promise<void> {
+    // OpenAI compatible API uses 'speed' parameter (0.25 to 4.0)
+    this.#rate = Math.max(0.25, Math.min(4.0, rate));
+  }
+
+  async setPitch(pitch: number): Promise<void> {
+    // OpenAI TTS doesn't support pitch adjustment
+    void pitch;
+  }
+
+  async setVoice(voice: string): Promise<void> {
+    this.#currentVoiceId = voice;
+  }
+
+  async getAllVoices(): Promise<TTSVoice[]> {
+    return this.#voices;
+  }
+
+  async getVoices(lang: string): Promise<TTSVoicesGroup[]> {
+    const locale = lang === 'en' ? getUserLocale(lang) || lang : lang;
+    const voices = await this.getAllVoices();
+    const filteredVoices = voices.filter(
+        (v) => v.name.includes(locale) ||
+            (lang === 'en' && ['en-US', 'en-GB'].includes(v.lang)),
+    );
+
+    const voicesGroup: TTSVoicesGroup = {
+      id: `openai-tts`,
+      name: `OpenAI Compatible TTS`,
+      voices: filteredVoices.sort(TTSUtils.sortVoicesFunc),
+      disabled: !this.initialized || filteredVoices.length === 0,
+    };
+
+    return [voicesGroup];
+  }
+
+  getGranularities(): TTSGranularity[] {
+    return ['sentence'];
+  }
+
+  getVoiceId(): string {
+    return this.#currentVoiceId;
+  }
+
+  getSpeakingLang(): string {
+    return this.#speakingLang;
+  }
+
+  /////////////////////////////////////////////////////////////////
+  // Additional methods specific to OpenAI TTS                   //
+  /////////////////////////////////////////////////////////////////
+
+  async setModel(model: string): Promise<void> {
+    const availableModels = await this.#openaiTTS.getModels();
+    if (availableModels.includes(model)) {
+      this.#model = model;
+    }
+  }
+
+  #getPayload =
+      (text: string, voiceId: string, lang: string): OpenAITTSPayload => {
+        return {
+          model: this.#model,
+          text: text,
+          voice: voiceId,
+          speed: this.#rate,
+          lang_code: lang,
+        };
+      };
+
+  #getVoiceLangCode = async(lang: string): Promise<string> => {
+    const preferredVoiceId = TTSUtils.getPreferredVoice(this.name, lang);
+    const preferredVoice = this.#voices.find((v) => v.id === preferredVoiceId);
+    const defaultVoice = preferredVoice ?
+        preferredVoice :
+        (await this.getVoices(lang))[0]?.voices[0] || null;
+
+    return defaultVoice?.lang || 'a';
+  };
+
+  async getModels(): Promise<string[]> {
+    return await this.#openaiTTS.getModels();
+  }
+
+  getCurrentModel(): string {
+    return this.#model;
+  }
+}

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -5,6 +5,7 @@ import { Overlayer } from 'foliate-js/overlayer.js';
 import { TTSGranularity, TTSHighlightOptions, TTSMark, TTSVoice } from './types';
 import { createRejecttFilter } from '@/utils/node';
 import { WebSpeechClient } from './WebSpeechClient';
+import {OpenAITTSClient} from './OpenAITTSClient';
 import { NativeTTSClient } from './NativeTTSClient';
 import { EdgeTTSClient } from './EdgeTTSClient';
 import { TTSUtils } from './TTSUtils';
@@ -35,15 +36,18 @@ export class TTSController extends EventTarget {
   ttsClient: TTSClient;
   ttsWebClient: TTSClient;
   ttsEdgeClient: TTSClient;
-  ttsNativeClient: TTSClient | null = null;
+  ttsOpenAIClient: TTSClient;
+  ttsNativeClient: TTSClient|null = null;
   ttsWebVoices: TTSVoice[] = [];
   ttsEdgeVoices: TTSVoice[] = [];
+  ttsOpenAIVoices: TTSVoice[] = [];
   ttsNativeVoices: TTSVoice[] = [];
 
   constructor(appService: AppService | null, view: FoliateView) {
     super();
     this.ttsWebClient = new WebSpeechClient(this);
     this.ttsEdgeClient = new EdgeTTSClient(this);
+    this.ttsOpenAIClient = new OpenAITTSClient(this);
     // TODO: implement native TTS client for iOS and PC
     if (appService?.isAndroidApp) {
       this.ttsNativeClient = new NativeTTSClient(this);
@@ -57,6 +61,9 @@ export class TTSController extends EventTarget {
     const availableClients = [];
     if (await this.ttsEdgeClient.init()) {
       availableClients.push(this.ttsEdgeClient);
+    }
+    if (await this.ttsOpenAIClient.init()) {
+      availableClients.push(this.ttsOpenAIClient);
     }
     if (this.ttsNativeClient && (await this.ttsNativeClient.init())) {
       availableClients.push(this.ttsNativeClient);
@@ -77,6 +84,7 @@ export class TTSController extends EventTarget {
     }
     this.ttsWebVoices = await this.ttsWebClient.getAllVoices();
     this.ttsEdgeVoices = await this.ttsEdgeClient.getAllVoices();
+    this.ttsOpenAIVoices = await this.ttsOpenAIClient.getAllVoices();
   }
 
   #getHighlighter(options: TTSHighlightOptions) {
@@ -304,6 +312,7 @@ export class TTSController extends EventTarget {
 
   async setPrimaryLang(lang: string) {
     if (this.ttsEdgeClient.initialized) this.ttsEdgeClient.setPrimaryLang(lang);
+    if (this.ttsOpenAIClient.initialized) this.ttsOpenAIClient.setPrimaryLang(lang);
     if (this.ttsWebClient.initialized) this.ttsWebClient.setPrimaryLang(lang);
     if (this.ttsNativeClient?.initialized) this.ttsNativeClient?.setPrimaryLang(lang);
   }
@@ -317,9 +326,10 @@ export class TTSController extends EventTarget {
   async getVoices(lang: string) {
     const ttsWebVoices = await this.ttsWebClient.getVoices(lang);
     const ttsEdgeVoices = await this.ttsEdgeClient.getVoices(lang);
+    const ttsOpenAIVoices = await this.ttsOpenAIClient.getVoices(lang);
     const ttsNativeVoices = (await this.ttsNativeClient?.getVoices(lang)) ?? [];
 
-    const voicesGroups = [...ttsNativeVoices, ...ttsEdgeVoices, ...ttsWebVoices];
+    const voicesGroups = [...ttsNativeVoices, ...ttsEdgeVoices, ...ttsOpenAIVoices, ...ttsWebVoices];
     return voicesGroups;
   }
 
@@ -328,11 +338,17 @@ export class TTSController extends EventTarget {
     const useEdgeTTS = !!this.ttsEdgeVoices.find(
       (voice) => (voiceId === '' || voice.id === voiceId) && !voice.disabled,
     );
+    const useOpenAITTS = !!this.ttsOpenAIVoices.find(
+        (voice) => (voiceId === '' || voice.id === voiceId) && !voice.disabled,
+    );
     const useNativeTTS = !!this.ttsNativeVoices.find(
       (voice) => (voiceId === '' || voice.id === voiceId) && !voice.disabled,
     );
     if (useEdgeTTS) {
       this.ttsClient = this.ttsEdgeClient;
+      await this.ttsClient.setRate(this.ttsRate);
+    } else if (useOpenAITTS) {
+      this.ttsClient = this.ttsOpenAIClient;
       await this.ttsClient.setRate(this.ttsRate);
     } else if (useNativeTTS) {
       if (!this.ttsNativeClient) {
@@ -374,6 +390,9 @@ export class TTSController extends EventTarget {
     }
     if (this.ttsEdgeClient.initialized) {
       await this.ttsEdgeClient.shutdown();
+    }
+    if (this.ttsOpenAIClient.initialized) {
+      await this.ttsOpenAIClient.shutdown();
     }
     if (this.ttsNativeClient?.initialized) {
       await this.ttsNativeClient.shutdown();

--- a/apps/readest-app/src/services/tts/index.ts
+++ b/apps/readest-app/src/services/tts/index.ts
@@ -2,6 +2,7 @@ export * from './types';
 export * from './TTSClient';
 export * from './WebSpeechClient';
 export * from './EdgeTTSClient';
+export * from './OpenAITTSClient';
 export * from './NativeTTSClient';
 export * from './TTSController';
 export * from './TTSData';


### PR DESCRIPTION
I wasn't sure this project accepts PR form outsiders. This is currently WIP, but works fine when I build for web-dev `pnpm dev-web`. I have tested in with my locally running [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI) model which implements OpenAI compatible API. The logic is copy-pasted from EdgeTTS. But lacks the following : 

- [ ] Configurable endpoint and api key
- [ ] Testing with OpenAI or something else that claims to be OpenAI compatible 
- [ ] clean up kokoro specific assumptions

Also for some reason it wont even connect to the TTS engine when I build the macOS application. I'll figure it out.
