### PR TITLE
feat: support author sorting (last name first), closes #1799

### DIFF
--- a/apps/readest-app/src/app/library/components/Bookshelf.tsx
+++ b/apps/readest-app/src/app/library/components/Bookshelf.tsx
@@ -239,8 +239,8 @@ const Bookshelf: React.FC<BookshelfProps> = ({
         const bTitle = formatTitle(b.title);
         return aTitle.localeCompare(bTitle, uiLanguage || navigator.language);
       case 'author':
-        const aAuthors = formatAuthors(a.author);
-        const bAuthors = formatAuthors(b.author);
+        const aAuthors = formatAuthors(['ar', 'bo', 'de', 'en', 'es', 'fr', 'hi', 'it', 'nl', 'pl', 'pt', 'ru', 'th', 'tr', 'uk'].includes (a?.primaryLanguage || 'en') ? `${a.author.split(' ').at(-1)} ${a.author.split(' ').slice(0, -1).join(' ')}` : a.author);
+        const bAuthors = formatAuthors(['ar', 'bo', 'de', 'en', 'es', 'fr', 'hi', 'it', 'nl', 'pl', 'pt', 'ru', 'th', 'tr', 'uk'].includes (b?.primaryLanguage || 'en') ? `${b.author.split(' ').at(-1)} ${b.author.split(' ').slice(0, -1).join(' ')}` : b.author);
         return aAuthors.localeCompare(bAuthors, uiLanguage || navigator.language);
       case 'updated':
         return new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime();

--- a/apps/readest-app/src/app/library/components/Bookshelf.tsx
+++ b/apps/readest-app/src/app/library/components/Bookshelf.tsx
@@ -239,8 +239,8 @@ const Bookshelf: React.FC<BookshelfProps> = ({
         const bTitle = formatTitle(b.title);
         return aTitle.localeCompare(bTitle, uiLanguage || navigator.language);
       case 'author':
-        const aAuthors = formatAuthors(['ar', 'bo', 'de', 'en', 'es', 'fr', 'hi', 'it', 'nl', 'pl', 'pt', 'ru', 'th', 'tr', 'uk'].includes (a?.primaryLanguage || 'en') ? `${a.author.split(' ').at(-1)} ${a.author.split(' ').slice(0, -1).join(' ')}` : a.author);
-        const bAuthors = formatAuthors(['ar', 'bo', 'de', 'en', 'es', 'fr', 'hi', 'it', 'nl', 'pl', 'pt', 'ru', 'th', 'tr', 'uk'].includes (b?.primaryLanguage || 'en') ? `${b.author.split(' ').at(-1)} ${b.author.split(' ').slice(0, -1).join(' ')}` : b.author);
+        const aAuthors = formatAuthors(a.author, a?.primaryLanguage || 'en', true);
+        const bAuthors = formatAuthors(b.author, b?.primaryLanguage || 'en', true);
         return aAuthors.localeCompare(bAuthors, uiLanguage || navigator.language);
       case 'updated':
         return new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime();

--- a/apps/readest-app/src/utils/book.ts
+++ b/apps/readest-app/src/utils/book.ts
@@ -91,21 +91,38 @@ export const flattenContributors = (
       : formatLanguageMap(contributors?.name);
 };
 
+// prettier-ignore
+const LASTNAME_AUTHOR_SORT_LANGS = [ 'ar', 'bo', 'de', 'en', 'es', 'fr', 'hi', 'it', 'nl', 'pl', 'pt', 'ru', 'th', 'tr', 'uk' ];
+
+const formatAuthorName = (name: string, lastNameFirst: boolean) => {
+  if (!name) return '';
+  const parts = name.split(' ');
+  if (lastNameFirst && parts.length > 1) {
+    return `${parts[parts.length - 1]}, ${parts.slice(0, -1).join(' ')}`;
+  }
+  return name;
+};
+
 export const formatAuthors = (
   contributors: string | string[] | Contributor | Contributor[],
   bookLang?: string | string[],
+  sortAs?: boolean,
 ) => {
   const langCode = getBookLangCode(bookLang) || 'en';
+  const lastNameFirst = !!sortAs && LASTNAME_AUTHOR_SORT_LANGS.includes(langCode);
   return Array.isArray(contributors)
     ? listFormater(langCode === 'zh', langCode).format(
         contributors.map((contributor) =>
-          typeof contributor === 'string' ? contributor : formatLanguageMap(contributor?.name),
+          typeof contributor === 'string'
+            ? formatAuthorName(contributor, lastNameFirst)
+            : formatAuthorName(formatLanguageMap(contributor?.name), lastNameFirst),
         ),
       )
     : typeof contributors === 'string'
-      ? contributors
-      : formatLanguageMap(contributors?.name);
+      ? formatAuthorName(contributors, lastNameFirst)
+      : formatAuthorName(formatLanguageMap(contributors?.name), lastNameFirst);
 };
+
 export const formatTitle = (title: string | LanguageMap) => {
   return typeof title === 'string' ? title : formatLanguageMap(title);
 };


### PR DESCRIPTION
In case of sorting the books by the name of the author, I have put the family name first in the following languages:

- Arabic
- German
- English
- Spanish
- French
- Hindi
- Italian
- Dutch
- Polish
- Portuguese
- Russian
- Thai
- Tibetan
- Turkish
- Ukrainian