### PR TITLE
fix: docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN npm install --global pnpm
 RUN apt update -y && apt install -y --no-install-recommends \
     libwebkit2gtk-4.1-dev \
     build-essential \
+    git \
     curl \
     wget \
     file \
@@ -26,6 +27,8 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 COPY . /app
 
 WORKDIR /app
+
+RUN git submodule update --init --recursive
 
 RUN pnpm install
 


### PR DESCRIPTION
FIX: docker build ERROR:
```bash
[+] Building 192.5s (11/14)                                                                                           docker:default
 => [internal] load build definition from Dockerfile                                                                            0.0s
 => => transferring dockerfile: 818B                                                                                            0.0s
 => [internal] load metadata for docker.io/library/node:22-slim                                                                 2.2s
 => [internal] load .dockerignore                                                                                               0.0s
 => => transferring context: 2B                                                                                                 0.0s
 => CACHED [ 1/10] FROM docker.io/library/node:22-slim@sha256:752ea8a2f758c34002a0461bd9f1cee4f9a3c36d48494586f60ffce1fc708e0e  0.0s
 => [internal] load build context                                                                                               0.6s
 => => transferring context: 70.27MB                                                                                            0.6s
 => [ 2/10] RUN npm install --global pnpm                                                                                       6.4s
 => [ 3/10] RUN apt update -y && apt install -y --no-install-recommends     libwebkit2gtk-4.1-dev     build-essential     cu  109.7s
 => [ 4/10] RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y                                        69.7s
 => [ 5/10] COPY . /app                                                                                                         3.1s
 => [ 6/10] WORKDIR /app                                                                                                        0.0s
 => ERROR [ 7/10] RUN pnpm install                                                                                              1.3s
------
 > [ 7/10] RUN pnpm install:
0.603 Scope: all 2 workspace projects
1.020 /app/apps/readest-app:
1.020  ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  In apps/readest-app: "foliate-js@workspace:*" is in the dependencies but no package named "foliate-js" is present in the workspace
1.020
1.020 This error happened while installing a direct dependency of /app/apps/readest-app
1.020
1.020 Packages found in the workspace:
------
Dockerfile:30
--------------------
  28 |     WORKDIR /app
  29 |
  30 | >>> RUN pnpm install
  31 |
  32 |     RUN pnpm --filter @readest/readest-app setup-pdfjs
--------------------
ERROR: failed to solve: process "/bin/sh -c pnpm install" did not complete successfully: exit code: 1
```