### PR TITLE
refactor: use safe insets from native for Android, closes #1793 and closes #1886

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -198,6 +198,7 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
                 }
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                @Suppress("DEPRECATION")
                 window.setDecorFitsSystemWindows(false)
                 val controller = window.insetsController
                 if (controller != null) {
@@ -228,7 +229,7 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
                 }
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 val compatController = WindowCompat.getInsetsController(window, decorView)
-                compatController?.let {
+                compatController.let {
                     it.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
                     if (!isDarkMode) {
                         it.isAppearanceLightStatusBars = true
@@ -259,7 +260,9 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
                     }
                 }.reduce { acc, flag -> acc or flag }
             }
+            @Suppress("DEPRECATION")
             window.statusBarColor = Color.TRANSPARENT
+            @Suppress("DEPRECATION")
             window.navigationBarColor = Color.TRANSPARENT
             ret.put("success", true)
         } catch (e: Exception) {
@@ -365,5 +368,60 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
           }
       }
       invoke.resolve()
+    }
+
+    private fun getStatusBarHeightInternal(): Int {
+        val resourceId = activity.resources.getIdentifier("status_bar_height", "dimen", "android")
+        return if (resourceId > 0) activity.resources.getDimensionPixelSize(resourceId) else 0
+    }
+
+    private fun getNavigationBarHeight(): Int {
+        val resourceId = activity.resources.getIdentifier("navigation_bar_height", "dimen", "android")
+        return if (resourceId > 0) activity.resources.getDimensionPixelSize(resourceId) else 0
+    }
+
+    private fun hasNavigationBar(): Boolean {
+        val resourceId = activity.resources.getIdentifier("config_showNavigationBar", "bool", "android")
+        return if (resourceId > 0) {
+            activity.resources.getBoolean(resourceId)
+        } else {
+            !android.view.ViewConfiguration.get(activity).hasPermanentMenuKey()
+        }
+    }
+
+    @Command
+    fun get_safe_area_insets(invoke: Invoke) {
+        val ret = JSObject()
+        try {
+            val rootView = activity.findViewById<View>(android.R.id.content)
+            val windowInsets = androidx.core.view.ViewCompat.getRootWindowInsets(rootView)
+
+            if (windowInsets != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val insets = windowInsets.getInsets(
+                    WindowInsetsCompat.Type.systemBars() or
+                    WindowInsetsCompat.Type.displayCutout()
+                )
+                val density = activity.resources.displayMetrics.density
+                ret.put("top", insets.top / density)
+                ret.put("right", insets.right / density)
+                ret.put("bottom", insets.bottom / density)
+                ret.put("left", insets.left / density)
+            } else {
+                val statusBarHeight = getStatusBarHeightInternal()
+                val navBarHeight = getNavigationBarHeight()
+                val density = activity.resources.displayMetrics.density
+                ret.put("top", statusBarHeight / density)
+                ret.put("right", 0)
+                ret.put("bottom", if (hasNavigationBar()) navBarHeight / density else 0)
+                ret.put("left", 0)
+            }
+        } catch (e: Exception) {
+            ret.put("error", e.message)
+            ret.put("top", 0)
+            ret.put("right", 0)
+            ret.put("bottom", 0)
+            ret.put("left", 0)
+        }
+        invoke.resolve(ret)
     }
 }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/build.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/build.rs
@@ -14,6 +14,7 @@ const COMMANDS: &[&str] = &[
     "iap_purchase_product",
     "iap_restore_purchases",
     "get_system_color_scheme",
+    "get_safe_area_insets",
 ];
 
 fn main() {

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/commands/get_safe_area_insets.toml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/commands/get_safe_area_insets.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-safe-area-insets"
+description = "Enables the get_safe_area_insets command without any pre-configured scope."
+commands.allow = ["get_safe_area_insets"]
+
+[[permission]]
+identifier = "deny-get-safe-area-insets"
+description = "Denies the get_safe_area_insets command without any pre-configured scope."
+commands.deny = ["get_safe_area_insets"]

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/reference.md
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/reference.md
@@ -19,6 +19,7 @@ Default permissions for the plugin
 - `allow-iap-purchase-product`
 - `allow-iap-restore-purchases`
 - `allow-get-system-color-scheme`
+- `allow-get-safe-area-insets`
 
 ## Permission Table
 
@@ -103,6 +104,32 @@ Enables the copy_uri_to_path command without any pre-configured scope.
 <td>
 
 Denies the copy_uri_to_path command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`native-bridge:allow-get-safe-area-insets`
+
+</td>
+<td>
+
+Enables the get_safe_area_insets command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`native-bridge:deny-get-safe-area-insets`
+
+</td>
+<td>
+
+Denies the get_safe_area_insets command without any pre-configured scope.
 
 </td>
 </tr>

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/default.toml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/default.toml
@@ -16,4 +16,5 @@ permissions = [
   "allow-iap-purchase-product",
   "allow-iap-restore-purchases",
   "allow-get-system-color-scheme",
+  "allow-get-safe-area-insets",
 ]

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/schemas/schema.json
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/schemas/schema.json
@@ -331,6 +331,18 @@
           "markdownDescription": "Denies the copy_uri_to_path command without any pre-configured scope."
         },
         {
+          "description": "Enables the get_safe_area_insets command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-safe-area-insets",
+          "markdownDescription": "Enables the get_safe_area_insets command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_safe_area_insets command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-safe-area-insets",
+          "markdownDescription": "Denies the get_safe_area_insets command without any pre-configured scope."
+        },
+        {
           "description": "Enables the get_status_bar_height command without any pre-configured scope.",
           "type": "string",
           "const": "allow-get-status-bar-height",
@@ -475,10 +487,10 @@
           "markdownDescription": "Denies the use_background_audio command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-auth-with-safari`\n- `allow-auth-with-custom-tab`\n- `allow-copy-uri-to-path`\n- `allow-use-background-audio`\n- `allow-install-package`\n- `allow-set-system-ui-visibility`\n- `allow-get-status-bar-height`\n- `allow-get-sys-fonts-list`\n- `allow-intercept-keys`\n- `allow-lock-screen-orientation`\n- `allow-iap-initialize`\n- `allow-iap-fetch-products`\n- `allow-iap-purchase-product`\n- `allow-iap-restore-purchases`\n- `allow-get-system-color-scheme`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-auth-with-safari`\n- `allow-auth-with-custom-tab`\n- `allow-copy-uri-to-path`\n- `allow-use-background-audio`\n- `allow-install-package`\n- `allow-set-system-ui-visibility`\n- `allow-get-status-bar-height`\n- `allow-get-sys-fonts-list`\n- `allow-intercept-keys`\n- `allow-lock-screen-orientation`\n- `allow-iap-initialize`\n- `allow-iap-fetch-products`\n- `allow-iap-purchase-product`\n- `allow-iap-restore-purchases`\n- `allow-get-system-color-scheme`\n- `allow-get-safe-area-insets`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-auth-with-safari`\n- `allow-auth-with-custom-tab`\n- `allow-copy-uri-to-path`\n- `allow-use-background-audio`\n- `allow-install-package`\n- `allow-set-system-ui-visibility`\n- `allow-get-status-bar-height`\n- `allow-get-sys-fonts-list`\n- `allow-intercept-keys`\n- `allow-lock-screen-orientation`\n- `allow-iap-initialize`\n- `allow-iap-fetch-products`\n- `allow-iap-purchase-product`\n- `allow-iap-restore-purchases`\n- `allow-get-system-color-scheme`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-auth-with-safari`\n- `allow-auth-with-custom-tab`\n- `allow-copy-uri-to-path`\n- `allow-use-background-audio`\n- `allow-install-package`\n- `allow-set-system-ui-visibility`\n- `allow-get-status-bar-height`\n- `allow-get-sys-fonts-list`\n- `allow-intercept-keys`\n- `allow-lock-screen-orientation`\n- `allow-iap-initialize`\n- `allow-iap-fetch-products`\n- `allow-iap-purchase-product`\n- `allow-iap-restore-purchases`\n- `allow-get-system-color-scheme`\n- `allow-get-safe-area-insets`"
         }
       ]
     }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/commands.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/commands.rs
@@ -119,3 +119,10 @@ pub(crate) async fn get_system_color_scheme<R: Runtime>(
 ) -> Result<GetSystemColorSchemeResponse> {
     app.native_bridge().get_system_color_scheme()
 }
+
+#[command]
+pub(crate) async fn get_safe_area_insets<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<GetSafeAreaInsetsResponse> {
+    app.native_bridge().get_safe_area_insets()
+}

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/desktop.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/desktop.rs
@@ -102,4 +102,8 @@ impl<R: Runtime> NativeBridge<R> {
     pub fn get_system_color_scheme(&self) -> crate::Result<GetSystemColorSchemeResponse> {
         Err(crate::Error::UnsupportedPlatformError)
     }
+
+    pub fn get_safe_area_insets(&self) -> crate::Result<GetSafeAreaInsetsResponse> {
+        Err(crate::Error::UnsupportedPlatformError)
+    }
 }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/lib.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/lib.rs
@@ -52,6 +52,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::iap_purchase_product,
             commands::iap_restore_purchases,
             commands::get_system_color_scheme,
+            commands::get_safe_area_insets,
         ])
         .setup(|app, api| {
             #[cfg(mobile)]

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/mobile.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/mobile.rs
@@ -161,3 +161,11 @@ impl<R: Runtime> NativeBridge<R> {
             .map_err(Into::into)
     }
 }
+
+impl<R: Runtime> NativeBridge<R> {
+    pub fn get_safe_area_insets(&self) -> crate::Result<GetSafeAreaInsetsResponse> {
+        self.0
+            .run_mobile_plugin("get_safe_area_insets", ())
+            .map_err(Into::into)
+    }
+}

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
@@ -158,3 +158,12 @@ pub struct IAPRestorePurchasesResponse {
 pub struct GetSystemColorSchemeResponse {
     pub color_scheme: String, // "light" or "dark"
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetSafeAreaInsetsResponse {
+    pub top: f64,
+    pub bottom: f64,
+    pub left: f64,
+    pub right: f64,
+}

--- a/apps/readest-app/src/app/auth/page.tsx
+++ b/apps/readest-app/src/app/auth/page.tsx
@@ -67,7 +67,7 @@ export default function AuthPage() {
   const router = useRouter();
   const { login } = useAuth();
   const { envConfig, appService } = useEnv();
-  const { isDarkMode } = useThemeStore();
+  const { isDarkMode, safeAreaInsets } = useThemeStore();
   const { isTrafficLightVisible } = useTrafficLightStore();
   const { settings, setSettings, saveSettings } = useSettingsStore();
   const [port, setPort] = useState<number | null>(null);
@@ -351,10 +351,10 @@ export default function AuthPage() {
       )}
     >
       <div
-        className={clsx(
-          'flex h-full w-full flex-col items-center overflow-y-auto',
-          appService?.hasSafeAreaInset && 'pt-[env(safe-area-inset-top)]',
-        )}
+        className={clsx('flex h-full w-full flex-col items-center overflow-y-auto')}
+        style={{
+          paddingTop: `${safeAreaInsets?.top || 0}px`,
+        }}
       >
         <div
           ref={headerRef}

--- a/apps/readest-app/src/app/library/components/Bookshelf.tsx
+++ b/apps/readest-app/src/app/library/components/Bookshelf.tsx
@@ -8,6 +8,7 @@ import { PiPlus } from 'react-icons/pi';
 import { Book, BooksGroup } from '@/types/book';
 import { LibraryCoverFitType, LibraryViewModeType } from '@/types/settings';
 import { useEnv } from '@/context/EnvContext';
+import { useThemeStore } from '@/store/themeStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useLibraryStore } from '@/store/libraryStore';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -53,6 +54,7 @@ const Bookshelf: React.FC<BookshelfProps> = ({
   const searchParams = useSearchParams();
   const { appService } = useEnv();
   const { settings } = useSettingsStore();
+  const { safeAreaInsets } = useThemeStore();
   const [loading, setLoading] = useState(false);
   const [showSelectModeActions, setShowSelectModeActions] = useState(false);
   const [showDeleteAlert, setShowDeleteAlert] = useState(false);
@@ -346,7 +348,12 @@ const Bookshelf: React.FC<BookshelfProps> = ({
           <Spinner loading />
         </div>
       )}
-      <div className='fixed bottom-0 left-0 right-0 z-40 pb-[calc(env(safe-area-inset-bottom)+16px)]'>
+      <div
+        className='fixed bottom-0 left-0 right-0 z-40'
+        style={{
+          paddingBottom: `${(safeAreaInsets?.bottom || 0) + 16}px`,
+        }}
+      >
         {isSelectMode && showSelectModeActions && (
           <div
             className={clsx(
@@ -425,10 +432,10 @@ const Bookshelf: React.FC<BookshelfProps> = ({
       )}
       {showDeleteAlert && (
         <div
-          className={clsx(
-            'fixed bottom-0 left-0 right-0 z-50 flex justify-center',
-            'pb-[calc(env(safe-area-inset-bottom)+16px)]',
-          )}
+          className={clsx('fixed bottom-0 left-0 right-0 z-50 flex justify-center')}
+          style={{
+            paddingBottom: `${(safeAreaInsets?.bottom || 0) + 16}px`,
+          }}
         >
           <Alert
             title={_('Confirm Deletion')}

--- a/apps/readest-app/src/app/library/components/LibraryHeader.tsx
+++ b/apps/readest-app/src/app/library/components/LibraryHeader.tsx
@@ -13,7 +13,6 @@ import { useThemeStore } from '@/store/themeStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useLibraryStore } from '@/store/libraryStore';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
-import { useSafeAreaInsets } from '@/hooks/useSafeAreaInsets';
 import { useTrafficLightStore } from '@/store/trafficLightStore';
 import { navigateToLibrary } from '@/utils/nav';
 import { debounce } from '@/utils/debounce';
@@ -59,7 +58,7 @@ const LibraryHeader: React.FC<LibraryHeaderProps> = ({
   const headerRef = useRef<HTMLDivElement>(null);
   const iconSize18 = useResponsiveSize(18);
   const iconSize20 = useResponsiveSize(20);
-  const insets = useSafeAreaInsets();
+  const { safeAreaInsets: insets } = useThemeStore();
 
   useShortcuts({
     onToggleSelectMode,

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -24,6 +24,7 @@ import { getCurrentWebview } from '@tauri-apps/api/webview';
 
 import { useEnv } from '@/context/EnvContext';
 import { useAuth } from '@/context/AuthContext';
+import { useThemeStore } from '@/store/themeStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useLibraryStore } from '@/store/libraryStore';
 import { useSettingsStore } from '@/store/settingsStore';
@@ -32,7 +33,6 @@ import { useTheme } from '@/hooks/useTheme';
 import { useUICSS } from '@/hooks/useUICSS';
 import { useDemoBooks } from './hooks/useDemoBooks';
 import { useBooksSync } from './hooks/useBooksSync';
-import { useSafeAreaInsets } from '@/hooks/useSafeAreaInsets';
 import { useScreenWakeLock } from '@/hooks/useScreenWakeLock';
 import { useOpenWithBooks } from '@/hooks/useOpenWithBooks';
 import { lockScreenOrientation } from '@/utils/bridge';
@@ -73,7 +73,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     setCheckLastOpenBooks,
   } = useLibraryStore();
   const _ = useTranslation();
-  const insets = useSafeAreaInsets();
+  const { safeAreaInsets: insets } = useThemeStore();
   const { settings, setSettings, saveSettings } = useSettingsStore();
   const [loading, setLoading] = useState(false);
   const isInitiating = useRef(false);

--- a/apps/readest-app/src/app/reader/components/BooksGrid.tsx
+++ b/apps/readest-app/src/app/reader/components/BooksGrid.tsx
@@ -2,11 +2,11 @@ import clsx from 'clsx';
 import React, { useEffect } from 'react';
 
 import { useEnv } from '@/context/EnvContext';
+import { useThemeStore } from '@/store/themeStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useReaderStore } from '@/store/readerStore';
 import { useSidebarStore } from '@/store/sidebarStore';
 import { useBookDataStore } from '@/store/bookDataStore';
-import { useSafeAreaInsets } from '@/hooks/useSafeAreaInsets';
 import { getGridTemplate, getInsetEdges } from '@/utils/grid';
 import { getViewInsets } from '@/utils/insets';
 import FoliateViewer from './FoliateViewer';
@@ -34,7 +34,7 @@ const BooksGrid: React.FC<BooksGridProps> = ({ bookKeys, onCloseBook }) => {
   const { sideBarBookKey } = useSidebarStore();
   const { isFontLayoutSettingsDialogOpen, setFontLayoutSettingsDialogOpen } = useSettingsStore();
 
-  const screenInsets = useSafeAreaInsets();
+  const { safeAreaInsets: screenInsets } = useThemeStore();
   const aspectRatio = window.innerWidth / window.innerHeight;
   const gridTemplate = getGridTemplate(bookKeys.length, aspectRatio);
 

--- a/apps/readest-app/src/app/reader/components/Ribbon.tsx
+++ b/apps/readest-app/src/app/reader/components/Ribbon.tsx
@@ -1,17 +1,20 @@
 import clsx from 'clsx';
 import React from 'react';
+import { useThemeStore } from '@/store/themeStore';
 
 interface RibbonProps {
   width: string;
 }
 
 const Ribbon: React.FC<RibbonProps> = ({}) => {
+  const { safeAreaInsets } = useThemeStore();
+
   return (
     <div
-      className={clsx(
-        'ribbon absolute inset-0 z-10 flex w-8 justify-center sm:w-6',
-        'h-[calc(env(safe-area-inset-top)+44px)]',
-      )}
+      className={clsx('ribbon absolute inset-0 z-10 flex w-8 justify-center sm:w-6')}
+      style={{
+        height: `${(safeAreaInsets?.top || 0) + 44}px`,
+      }}
     >
       <svg
         width='100%'

--- a/apps/readest-app/src/app/reader/components/notebook/Notebook.tsx
+++ b/apps/readest-app/src/app/reader/components/notebook/Notebook.tsx
@@ -25,7 +25,7 @@ const MAX_NOTEBOOK_WIDTH = 0.45;
 
 const Notebook: React.FC = ({}) => {
   const _ = useTranslation();
-  const { updateAppTheme } = useThemeStore();
+  const { updateAppTheme, safeAreaInsets } = useThemeStore();
   const { envConfig, appService } = useEnv();
   const { settings } = useSettingsStore();
   const { sideBarBookKey } = useSidebarStore();
@@ -196,7 +196,6 @@ const Notebook: React.FC = ({}) => {
           'notebook-container bg-base-200 right-0 z-20 flex min-w-60 select-none flex-col',
           'font-sans text-base font-normal sm:text-sm',
           appService?.isIOSApp ? 'h-[100vh]' : 'h-full',
-          appService?.hasSafeAreaInset && 'pt-[env(safe-area-inset-top)]',
           appService?.hasRoundedWindow && 'rounded-window-top-right rounded-window-bottom-right',
           !isNotebookPinned && 'shadow-2xl',
         )}
@@ -205,6 +204,7 @@ const Notebook: React.FC = ({}) => {
           width: `${notebookWidth}`,
           maxWidth: `${MAX_NOTEBOOK_WIDTH * 100}%`,
           position: isNotebookPinned ? 'relative' : 'absolute',
+          paddingTop: `${safeAreaInsets?.top || 0}px`,
         }}
       >
         <style jsx>{`

--- a/apps/readest-app/src/app/reader/components/sidebar/Content.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/Content.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import React, { useEffect, useState } from 'react';
 
 import { BookDoc } from '@/libs/document';
-import { useEnv } from '@/context/EnvContext';
+import { useThemeStore } from '@/store/themeStore';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { OverlayScrollbarsComponent } from 'overlayscrollbars-react';
 import 'overlayscrollbars/overlayscrollbars.css';
@@ -15,7 +15,7 @@ const SidebarContent: React.FC<{
   bookDoc: BookDoc;
   sideBarBookKey: string;
 }> = ({ bookDoc, sideBarBookKey }) => {
-  const { appService } = useEnv();
+  const { safeAreaInsets } = useThemeStore();
   const { getConfig, setConfig } = useBookDataStore();
   const config = getConfig(sideBarBookKey);
   const [activeTab, setActiveTab] = useState(config?.viewSettings?.sideBarTab || 'toc');
@@ -75,10 +75,10 @@ const SidebarContent: React.FC<{
         </OverlayScrollbarsComponent>
       </div>
       <div
-        className={clsx(
-          'flex-shrink-0',
-          appService?.hasSafeAreaInset && 'pb-[calc(env(safe-area-inset-bottom)/2)]',
-        )}
+        className='flex-shrink-0'
+        style={{
+          paddingBottom: `${(safeAreaInsets?.bottom || 0) / 2}px`,
+        }}
       >
         <TabNavigation activeTab={activeTab} onTabChange={handleTabChange} />
       </div>

--- a/apps/readest-app/src/app/reader/components/sidebar/SideBar.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/SideBar.tsx
@@ -29,7 +29,7 @@ const SideBar: React.FC<{
   onGoToLibrary: () => void;
 }> = ({ onGoToLibrary }) => {
   const { appService } = useEnv();
-  const { updateAppTheme } = useThemeStore();
+  const { updateAppTheme, safeAreaInsets } = useThemeStore();
   const { settings } = useSettingsStore();
   const { sideBarBookKey } = useSidebarStore();
   const { getBookData } = useBookDataStore();
@@ -186,7 +186,6 @@ const SideBar: React.FC<{
           'sidebar-container bg-base-200 z-20 flex min-w-60 select-none flex-col',
           appService?.isIOSApp ? 'h-[100vh]' : 'h-full',
           'transition-[padding-top] duration-300',
-          appService?.hasSafeAreaInset && 'pt-[env(safe-area-inset-top)]',
           appService?.hasRoundedWindow && 'rounded-window-top-left rounded-window-bottom-left',
           !isSideBarPinned && 'shadow-2xl',
         )}
@@ -195,6 +194,7 @@ const SideBar: React.FC<{
           width: `${sideBarWidth}`,
           maxWidth: `${MAX_SIDEBAR_WIDTH * 100}%`,
           position: isSideBarPinned ? 'relative' : 'absolute',
+          paddingTop: `${safeAreaInsets?.top || 0}px`,
         }}
       >
         <style jsx>{`

--- a/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useEnv } from '@/context/EnvContext';
+import { useThemeStore } from '@/store/themeStore';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useReaderStore } from '@/store/readerStore';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -27,6 +28,7 @@ interface TTSControlProps {
 const TTSControl: React.FC<TTSControlProps> = ({ bookKey }) => {
   const _ = useTranslation();
   const { appService } = useEnv();
+  const { safeAreaInsets } = useThemeStore();
   const { getBookData } = useBookDataStore();
   const { getView, getProgress, getViewSettings } = useReaderStore();
   const { setViewSettings, setTTSEnabled } = useReaderStore();
@@ -429,10 +431,13 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey }) => {
           className={clsx(
             'absolute h-12 w-12',
             viewSettings?.rtl ? 'left-6' : 'right-6',
-            appService?.hasSafeAreaInset
-              ? 'bottom-[calc(env(safe-area-inset-bottom)+70px)]'
-              : 'bottom-[70px] sm:bottom-14',
+            !appService?.hasSafeAreaInset && 'bottom-[70px] sm:bottom-14',
           )}
+          style={{
+            bottom: appService?.hasSafeAreaInset
+              ? `${(safeAreaInsets?.bottom || 0) + 70}px`
+              : undefined,
+          }}
         >
           <TTSIcon isPlaying={isPlaying} ttsInited={ttsClientsInited} onClick={togglePopup} />
         </div>

--- a/apps/readest-app/src/app/user/page.tsx
+++ b/apps/readest-app/src/app/user/page.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation';
 import { useEnv } from '@/context/EnvContext';
 import { useAuth } from '@/context/AuthContext';
 import { useTheme } from '@/hooks/useTheme';
+import { useThemeStore } from '@/store/themeStore';
 import { useQuotaStats } from '@/hooks/useQuotaStats';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useSettingsStore } from '@/store/settingsStore';
@@ -58,6 +59,7 @@ const ProfilePage = () => {
   const { envConfig, appService } = useEnv();
   const { token, user, logout } = useAuth();
   const { settings, setSettings, saveSettings } = useSettingsStore();
+  const { safeAreaInsets } = useThemeStore();
 
   const [loading, setLoading] = useState(false);
   const [availablePlans, setAvailablePlans] = useState<AvailablePlan[]>([]);
@@ -345,10 +347,10 @@ const ProfilePage = () => {
       )}
     >
       <div
-        className={clsx(
-          'flex h-full w-full flex-col items-center overflow-y-auto',
-          appService?.hasSafeAreaInset && 'pt-[env(safe-area-inset-top)]',
-        )}
+        className={clsx('flex h-full w-full flex-col items-center overflow-y-auto')}
+        style={{
+          paddingTop: `${safeAreaInsets?.top || 0}px`,
+        }}
       >
         <ProfileHeader onGoBack={handleGoBack} />
         <div className='w-full min-w-60 max-w-4xl py-10'>

--- a/apps/readest-app/src/components/Dialog.tsx
+++ b/apps/readest-app/src/components/Dialog.tsx
@@ -41,7 +41,7 @@ const Dialog: React.FC<DialogProps> = ({
   onClose,
 }) => {
   const { appService } = useEnv();
-  const { systemUIVisible, statusBarHeight } = useThemeStore();
+  const { systemUIVisible, statusBarHeight, safeAreaInsets } = useThemeStore();
   const { acquireBackKeyInterception, releaseBackKeyInterception } = useDeviceControlStore();
   const [isFullHeightInMobile, setIsFullHeightInMobile] = useState(!snapHeight);
   const [isRtl] = useState(() => getDirFromUILanguage() === 'rtl');
@@ -179,7 +179,7 @@ const Dialog: React.FC<DialogProps> = ({
         style={{
           paddingTop:
             appService?.hasSafeAreaInset && isFullHeightInMobile
-              ? `max(env(safe-area-inset-top), ${systemUIVisible ? statusBarHeight : 0}px)`
+              ? `${Math.max(safeAreaInsets?.top || 0, systemUIVisible ? statusBarHeight : 0)}px`
               : '0px',
           ...(isMobile ? { height: snapHeight ? `${snapHeight * 100}%` : '100%', bottom: 0 } : {}),
         }}

--- a/apps/readest-app/src/components/Providers.tsx
+++ b/apps/readest-app/src/components/Providers.tsx
@@ -6,12 +6,14 @@ import { AuthProvider } from '@/context/AuthContext';
 import { useEnv } from '@/context/EnvContext';
 import { CSPostHogProvider } from '@/context/PHContext';
 import { SyncProvider } from '@/context/SyncContext';
-import { useDefaultIconSize } from '@/hooks/useResponsiveSize';
 import { initSystemThemeListener } from '@/store/themeStore';
+import { useDefaultIconSize } from '@/hooks/useResponsiveSize';
+import { useSafeAreaInsets } from '@/hooks/useSafeAreaInsets';
 
 const Providers = ({ children }: { children: React.ReactNode }) => {
   const { appService } = useEnv();
   const iconSize = useDefaultIconSize();
+  useSafeAreaInsets(); // Initialize safe area insets
 
   useEffect(() => {
     if (appService) {

--- a/apps/readest-app/src/components/Spinner.tsx
+++ b/apps/readest-app/src/components/Spinner.tsx
@@ -1,19 +1,21 @@
 import clsx from 'clsx';
 import React from 'react';
+import { useThemeStore } from '@/store/themeStore';
 import { useTranslation } from '@/hooks/useTranslation';
 
 const Spinner: React.FC<{
   loading: boolean;
 }> = ({ loading }) => {
   const _ = useTranslation();
+  const { safeAreaInsets } = useThemeStore();
   if (!loading) return null;
 
   return (
     <div
-      className={clsx(
-        'absolute left-1/2 -translate-x-1/2 transform text-center',
-        'top-4 pt-[calc(env(safe-area-inset-top)+64px)]',
-      )}
+      className={clsx('absolute left-1/2 top-4 -translate-x-1/2 transform text-center')}
+      style={{
+        paddingTop: `${(safeAreaInsets?.top || 0) + 64}px`,
+      }}
       role='status'
     >
       <span className='loading loading-dots loading-lg'></span>

--- a/apps/readest-app/src/components/Toast.tsx
+++ b/apps/readest-app/src/components/Toast.tsx
@@ -1,10 +1,12 @@
 import clsx from 'clsx';
 import React, { useEffect, useRef, useState } from 'react';
+import { useThemeStore } from '@/store/themeStore';
 import { eventDispatcher } from '@/utils/event';
 
 export type ToastType = 'info' | 'success' | 'warning' | 'error';
 
 export const Toast = () => {
+  const { safeAreaInsets } = useThemeStore();
   const [toastMessage, setToastMessage] = useState('');
   const toastType = useRef<ToastType>('info');
   const toastTimeout = useRef(5000);
@@ -52,9 +54,12 @@ export const Toast = () => {
         className={clsx(
           'toast toast-center toast-middle z-50 w-auto max-w-screen-sm',
           toastClassMap[toastType.current],
-          toastClassMap[toastType.current].includes('toast-top') &&
-            'top-[calc(44px+env(safe-area-inset-top))]',
         )}
+        style={{
+          top: toastClassMap[toastType.current].includes('toast-top')
+            ? `${(safeAreaInsets?.top || 0) + 44}px`
+            : undefined,
+        }}
       >
         <div
           className={clsx(

--- a/apps/readest-app/src/components/metadata/BookDetailModal.tsx
+++ b/apps/readest-app/src/components/metadata/BookDetailModal.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { Book } from '@/types/book';
 import { BookMetadata } from '@/libs/document';
 import { useEnv } from '@/context/EnvContext';
+import { useThemeStore } from '@/store/themeStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useMetadataEdit } from './useMetadataEdit';
@@ -45,6 +46,7 @@ const BookDetailModal: React.FC<BookDetailModalProps> = ({
   handleBookMetadataUpdate,
 }) => {
   const _ = useTranslation();
+  const { safeAreaInsets } = useThemeStore();
   const [loading, setLoading] = useState(false);
   const [activeDeleteAction, setActiveDeleteAction] = useState<DeleteAction | null>(null);
   const [editMode, setEditMode] = useState(false);
@@ -239,10 +241,10 @@ const BookDetailModal: React.FC<BookDetailModalProps> = ({
 
         {activeDeleteAction && currentDeleteConfig && (
           <div
-            className={clsx(
-              'fixed bottom-0 left-0 right-0 z-50 flex justify-center',
-              'pb-[calc(env(safe-area-inset-bottom)+16px)]',
-            )}
+            className={clsx('fixed bottom-0 left-0 right-0 z-50 flex justify-center')}
+            style={{
+              paddingBottom: `${(safeAreaInsets?.bottom || 0) + 16}px`,
+            }}
           >
             <Alert
               title={currentDeleteConfig.title}

--- a/apps/readest-app/src/hooks/useTheme.ts
+++ b/apps/readest-app/src/hooks/useTheme.ts
@@ -38,7 +38,7 @@ export const useTheme = ({
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [appService?.isAndroidApp]);
 
   const handleSystemUIVisibility = useCallback(() => {
     if (!appService?.isMobileApp) return;

--- a/apps/readest-app/src/store/themeStore.ts
+++ b/apps/readest-app/src/store/themeStore.ts
@@ -5,6 +5,7 @@ import { getSystemColorScheme } from '@/utils/bridge';
 import { CustomTheme, Palette, ThemeMode } from '@/styles/themes';
 import { EnvConfigType, isWebAppPlatform } from '@/services/environment';
 import { SystemSettings } from '@/types/settings';
+import { Insets } from '@/types/misc';
 
 interface ThemeState {
   themeMode: ThemeMode;
@@ -15,6 +16,7 @@ interface ThemeState {
   systemUIVisible: boolean;
   statusBarHeight: number;
   systemUIAlwaysHidden: boolean;
+  safeAreaInsets: Insets | null;
   setSystemUIAlwaysHidden: (hidden: boolean) => void;
   setStatusBarHeight: (height: number) => void;
   showSystemUI: () => void;
@@ -30,6 +32,7 @@ interface ThemeState {
     isDelete?: boolean,
   ) => void;
   handleSystemThemeChange: (isDark: boolean) => void;
+  updateSafeAreaInsets: (insets: Insets) => void;
 }
 
 const getInitialThemeMode = (): ThemeMode => {
@@ -64,6 +67,7 @@ export const useThemeStore = create<ThemeState>((set, get) => {
     systemUIVisible: false,
     statusBarHeight: 24,
     systemUIAlwaysHidden: false,
+    safeAreaInsets: null,
     showSystemUI: () => set({ systemUIVisible: true }),
     dismissSystemUI: () => set({ systemUIVisible: false }),
     setStatusBarHeight: (height: number) => set({ statusBarHeight: height }),
@@ -121,6 +125,9 @@ export const useThemeStore = create<ThemeState>((set, get) => {
       const mode = get().themeMode;
       const isDarkMode = mode === 'dark' || (mode === 'auto' && systemIsDarkMode);
       set({ systemIsDarkMode, isDarkMode });
+    },
+    updateSafeAreaInsets: (insets) => {
+      set({ safeAreaInsets: insets });
     },
   };
 });

--- a/apps/readest-app/src/utils/bridge.ts
+++ b/apps/readest-app/src/utils/bridge.ts
@@ -57,6 +57,14 @@ export interface GetSystemColorSchemeResponse {
   error?: string;
 }
 
+export interface GetSafeAreaInsetsResponse {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+  error?: string;
+}
+
 export async function copyURIToPath(request: CopyURIRequest): Promise<CopyURIResponse> {
   const result = await invoke<CopyURIResponse>('plugin:native-bridge|copy_uri_to_path', {
     payload: request,
@@ -127,6 +135,13 @@ export async function lockScreenOrientation(request: LockScreenRequest): Promise
 export async function getSystemColorScheme(): Promise<GetSystemColorSchemeResponse> {
   const result = await invoke<GetSystemColorSchemeResponse>(
     'plugin:native-bridge|get_system_color_scheme',
+  );
+  return result;
+}
+
+export async function getSafeAreaInsets(): Promise<GetSafeAreaInsetsResponse> {
+  const result = await invoke<GetSafeAreaInsetsResponse>(
+    'plugin:native-bridge|get_safe_area_insets',
   );
   return result;
 }


### PR DESCRIPTION
On Android safe-area-inset-* values in css are always 0px in some versions of WebView 139 due to https://issues.chromium.org/issues/40699457