### PR TITLE
txt: nest chapters inside volumes when converting to epub

### DIFF
--- a/apps/readest-app/src/utils/txt.ts
+++ b/apps/readest-app/src/utils/txt.ts
@@ -13,6 +13,7 @@ interface Chapter {
   title: string;
   content: string;
   text: string;
+  isVolume: boolean;
 }
 
 interface Txt2EpubOptions {
@@ -197,7 +198,7 @@ export class TxtToEpubConverter {
           const formattedSegment = formatSegment(chunks.join('\n'));
           const title = `${chapters.length + 1}`;
           const content = `<h2>${title}</h2><p>${formattedSegment}</p>`;
-          chapters.push({ title, content, text: chunks.join('\n') });
+          chapters.push({ title, content, text: chunks.join('\n'), isVolume: false});
         }
         continue;
       }
@@ -219,6 +220,7 @@ export class TxtToEpubConverter {
           title: escapeXml(title),
           content: `${headTitle}<p>${formattedSegment}</p>`,
           text: content,
+          isVolume: isVolume
         });
       }
 
@@ -233,6 +235,7 @@ export class TxtToEpubConverter {
           title: escapeXml(segmentTitle),
           content: `<h3></h3><p>${formattedSegment}</p>`,
           text: initialContent,
+          isVolume: false
         });
       }
       chapters.push(...segmentChapters);
@@ -261,20 +264,32 @@ export class TxtToEpubConverter {
     await zipWriter.add('META-INF/container.xml', new TextReader(containerXml), zipWriteOptions);
 
     // Create navigation points for TOC
-    const navPoints = chapters
-      .map((chapter, index) => {
-        const id = `chapter${index + 1}`;
-        const playOrder = index + 1;
-        return `
-        <navPoint id="navPoint-${id}" playOrder="${playOrder}">
-          <navLabel>
-            <text>${chapter.title}</text>
-          </navLabel>
-          <content src="./OEBPS/${id}.xhtml" />
-        </navPoint>
-      `.trim();
-      })
-      .join('\n');
+    let isNested = false;
+    let navPoints = ``;
+    for (let i = 0; i < chapters.length; i++) {
+      const id = `chapter${i + 1}`;
+      const playOrder = i + 1;
+      if (chapters[i]!.isVolume && isNested) {
+        navPoints += `\n</navPoint>`;
+        isNested = !isNested;
+      }
+      navPoints += `
+<navPoint id="navPoint-${id}" playOrder="${playOrder}">
+<navLabel>
+<text>${chapters[i]!.title}</text>
+</navLabel>
+<content src="./OEBPS/${id}.xhtml" />`;
+      if (chapters[i]!.isVolume && !isNested) {
+        isNested = !isNested;
+      }
+      else {
+        navPoints += `\n</navPoint>`;
+      }
+    }
+    if (isNested) {
+      navPoints += `\n</navPoint>`;
+    }
+    navPoints = navPoints.trim();
 
     // Add NCX file (table of contents)
     const tocNcx = `<?xml version="1.0" encoding="UTF-8"?>

--- a/apps/readest-app/src/utils/txt.ts
+++ b/apps/readest-app/src/utils/txt.ts
@@ -270,26 +270,22 @@ export class TxtToEpubConverter {
       const id = `chapter${i + 1}`;
       const playOrder = i + 1;
       if (chapters[i]!.isVolume && isNested) {
-        navPoints += `\n</navPoint>`;
+        navPoints += `</navPoint>\n`;
         isNested = !isNested;
       }
-      navPoints += `
-<navPoint id="navPoint-${id}" playOrder="${playOrder}">
-<navLabel>
-<text>${chapters[i]!.title}</text>
-</navLabel>
-<content src="./OEBPS/${id}.xhtml" />`;
+      navPoints += `<navPoint id="navPoint-${id}" playOrder="${playOrder}">\n` +
+                   `<navLabel><text>${chapters[i]!.title}</text></navLabel>\n` +
+                   `<content src="./OEBPS/${id}.xhtml" />\n`;
       if (chapters[i]!.isVolume && !isNested) {
         isNested = !isNested;
       }
       else {
-        navPoints += `\n</navPoint>`;
+        navPoints += `</navPoint>\n`;
       }
     }
     if (isNested) {
-      navPoints += `\n</navPoint>`;
+      navPoints += `</navPoint>`;
     }
-    navPoints = navPoints.trim();
 
     // Add NCX file (table of contents)
     const tocNcx = `<?xml version="1.0" encoding="UTF-8"?>

--- a/apps/readest-app/src/utils/txt.ts
+++ b/apps/readest-app/src/utils/txt.ts
@@ -198,7 +198,7 @@ export class TxtToEpubConverter {
           const formattedSegment = formatSegment(chunks.join('\n'));
           const title = `${chapters.length + 1}`;
           const content = `<h2>${title}</h2><p>${formattedSegment}</p>`;
-          chapters.push({ title, content, text: chunks.join('\n'), isVolume: false});
+          chapters.push({ title, content, text: chunks.join('\n'), isVolume: false });
         }
         continue;
       }
@@ -220,7 +220,7 @@ export class TxtToEpubConverter {
           title: escapeXml(title),
           content: `${headTitle}<p>${formattedSegment}</p>`,
           text: content,
-          isVolume: isVolume
+          isVolume: isVolume,
         });
       }
 
@@ -235,7 +235,7 @@ export class TxtToEpubConverter {
           title: escapeXml(segmentTitle),
           content: `<h3></h3><p>${formattedSegment}</p>`,
           text: initialContent,
-          isVolume: false
+          isVolume: false,
         });
       }
       chapters.push(...segmentChapters);
@@ -273,13 +273,13 @@ export class TxtToEpubConverter {
         navPoints += `</navPoint>\n`;
         isNested = !isNested;
       }
-      navPoints += `<navPoint id="navPoint-${id}" playOrder="${playOrder}">\n` +
-                   `<navLabel><text>${chapters[i]!.title}</text></navLabel>\n` +
-                   `<content src="./OEBPS/${id}.xhtml" />\n`;
+      navPoints +=
+        `<navPoint id="navPoint-${id}" playOrder="${playOrder}">\n` +
+        `<navLabel><text>${chapters[i]!.title}</text></navLabel>\n` +
+        `<content src="./OEBPS/${id}.xhtml" />\n`;
       if (chapters[i]!.isVolume && !isNested) {
         isNested = !isNested;
-      }
-      else {
+      } else {
         navPoints += `</navPoint>\n`;
       }
     }


### PR DESCRIPTION
Readest can already detect if a chapter title is a volume title. This patch takes that info and nests chapters inside volumes when converting txt to epub.


PS: I nuked the indentation of `<navPoint>` part as I can't seem to make the multiline string indentation look pretty while keeping the logic minimum. I need some suggestions restore the indentation, if you want it prettified. 

Screenshot
<img width="238" height="345" alt="image" src="https://github.com/user-attachments/assets/a52b7864-eba0-4bba-9f9b-a9f876188f82" />

Mini demo
https://pastebin.com/7chM6Ch0