### PR TITLE
chore: stop cloud feature from displaying when no user logged in.

### DIFF
--- a/apps/readest-app/src/app/library/components/BookItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookItem.tsx
@@ -9,11 +9,9 @@ import {
 import { Book } from '@/types/book';
 import { useEnv } from '@/context/EnvContext';
 import { useAuth } from '@/context/AuthContext';
-import { useRouter } from 'next/navigation';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
 import { LibraryCoverFitType, LibraryViewModeType } from '@/types/settings';
-import { navigateToLogin } from '@/utils/nav';
 import { formatAuthors } from '@/utils/book';
 import ReadingProgress from './ReadingProgress';
 import BookCover from '@/components/BookCover';
@@ -42,7 +40,6 @@ const BookItem: React.FC<BookItemProps> = ({
   showBookDetailsModal,
 }) => {
   const _ = useTranslation();
-  const router = useRouter();
   const { user } = useAuth();
   const { appService } = useEnv();
   const iconSize15 = useResponsiveSize(15);
@@ -141,15 +138,12 @@ const BookItem: React.FC<BookItemProps> = ({
                 ></div>
               )
             ) : (
-              (!book.uploadedAt || (book.uploadedAt && !book.downloadedAt)) && (
+              (!book.uploadedAt || (book.uploadedAt && !book.downloadedAt)) &&
+              user && (
                 <button
                   className='show-cloud-button -m-2 p-2'
                   onPointerDown={(e) => e.stopPropagation()}
                   onClick={() => {
-                    if (!user) {
-                      navigateToLogin(router);
-                      return;
-                    }
                     if (!book.uploadedAt) {
                       handleBookUpload(book);
                     } else if (!book.downloadedAt) {

--- a/apps/readest-app/src/app/library/components/BookshelfItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookshelfItem.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import { useCallback } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { navigateToLibrary, navigateToReader, showReaderWindow } from '@/utils/nav';
+import { useAuth } from '@/context/AuthContext';
 import { useEnv } from '@/context/EnvContext';
 import { useLibraryStore } from '@/store/libraryStore';
 import { useSettingsStore } from '@/store/settingsStore';
@@ -104,6 +105,7 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
   const { envConfig, appService } = useEnv();
   const { settings } = useSettingsStore();
   const { updateBook } = useLibraryStore();
+  const { user } = useAuth();
 
   const showBookDetailsModal = useCallback(async (book: Book) => {
     if (await makeBookAvailable(book)) {
@@ -219,10 +221,10 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
     menu.append(selectBookMenuItem);
     menu.append(showBookDetailsMenuItem);
     menu.append(showBookInFinderMenuItem);
-    if (book.uploadedAt && !book.downloadedAt) {
+    if (book.uploadedAt && !book.downloadedAt && user) {
       menu.append(downloadBookMenuItem);
     }
-    if (!book.uploadedAt && book.downloadedAt) {
+    if (!book.uploadedAt && book.downloadedAt && user) {
       menu.append(uploadBookMenuItem);
     }
     menu.append(deleteBookMenuItem);

--- a/apps/readest-app/src/components/metadata/BookDetailView.tsx
+++ b/apps/readest-app/src/components/metadata/BookDetailView.tsx
@@ -21,6 +21,7 @@ import {
 import BookCover from '@/components/BookCover';
 import Dropdown from '../Dropdown';
 import MenuItem from '../MenuItem';
+import { useAuth } from '@/context/AuthContext';
 
 interface BookDetailViewProps {
   book: Book;
@@ -45,6 +46,7 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({
   onDownload,
   onUpload,
 }) => {
+  const { user } = useAuth();
   const _ = useTranslation();
 
   return (
@@ -86,13 +88,14 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({
                     transient
                     label={_('Remove from Cloud & Device')}
                     onClick={onDelete}
+                    disabled={!user || !book.uploadedAt || !book.downloadedAt}
                   />
                   <MenuItem
                     noIcon
                     transient
                     label={_('Remove from Cloud Only')}
                     onClick={onDeleteCloudBackup}
-                    disabled={!book.uploadedAt}
+                    disabled={!user || !book.uploadedAt}
                   />
                   <MenuItem
                     noIcon
@@ -104,12 +107,12 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({
                 </div>
               </Dropdown>
             )}
-            {book.uploadedAt && onDownload && (
+            {book.uploadedAt && user && onDownload && (
               <button onClick={onDownload}>
                 <MdOutlineCloudDownload className='fill-base-content' />
               </button>
             )}
-            {book.downloadedAt && onUpload && (
+            {book.downloadedAt && user && onUpload && (
               <button onClick={onUpload}>
                 <MdOutlineCloudUpload className='fill-base-content' />
               </button>


### PR DESCRIPTION
Book detail view:
1. Upload and download buttons no longer show up when no user logged in.
2. `Remove from Device & Cloud` and `Remove from Cloud Only` gray out when no user logged in.
3. `Remove from Device & Cloud` and `Remove from Cloud Only` gray out when book is not uploaded when user logged in.
4. `Remove from Device & Cloud` option grays out when book is not downloaded when user logged in.

Other:
1. `Upload book` or `Download book` no longer shows up in desktop right click context menu when no user logged in.
2. Upload or download cloud icon for book item no longer shows up when no user logged in.
