### PR TITLE
compat: disable customize root dir for macOS App Store builds

### DIFF
--- a/apps/readest-app/src/services/nativeAppService.ts
+++ b/apps/readest-app/src/services/nativeAppService.ts
@@ -348,7 +348,9 @@ export class NativeAppService extends BaseAppService {
   // orientation lock is not supported on iPad
   override hasOrientationLock =
     (OS_TYPE === 'ios' && getOSPlatform() === 'ios') || OS_TYPE === 'android';
-  override canCustomizeRootDir = OS_TYPE !== 'ios';
+  // CustomizeRootDir has a blocker on macOS App Store builds due to Security Scoped Resource restrictions.
+  // See: https://github.com/tauri-apps/tauri/issues/3716
+  override canCustomizeRootDir = process.env['NEXT_PUBLIC_DIST_CHANNEL'] !== 'appstore';
   override distChannel = (process.env['NEXT_PUBLIC_DIST_CHANNEL'] || 'readest') as DistChannel;
 
   private execDir?: string = undefined;


### PR DESCRIPTION
CustomizeRootDir has a blocker on macOS App Store builds due to Security Scoped Resource restrictions. See: https://github.com/tauri-apps/tauri/issues/3716