### PR TITLE
fix: add more elements to color overrides

### DIFF
--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -132,9 +132,10 @@ const getColorStyles = (
       background-color: var(--theme-bg-color, transparent);
       background: var(--background-set, none);
     }
-    section, div, p, font, h1, h2, h3, h4, h5, h6 {
+    section, div, p, font, h1, h2, h3, h4, h5, h6, li, span {
       ${overrideColor ? `background-color: ${bg} !important;` : ''}
       ${overrideColor ? `color: ${fg} !important;` : ''}
+      ${overrideColor ? `border-color: ${fg} !important;` : ''}
     }
     pre, span { /* inline code blocks */
       ${overrideColor ? `background-color: ${bg} !important;` : ''}


### PR DESCRIPTION
<details>
<summary>before</summary>
<img width="1915" height="769" alt="before" src="https://github.com/user-attachments/assets/fbf7d953-7810-4526-8665-4e0e7d9c8f29" />

</details>

<details>
<summary>after</summary>
<img width="1915" height="769" alt="after" src="https://github.com/user-attachments/assets/3036051b-9990-4f75-9013-67d994e5be4a" />

</details>