### PR TITLE
fix(css): support at rules of CSS and fix CSS formatter

### DIFF
--- a/apps/readest-app/package.json
+++ b/apps/readest-app/package.json
@@ -71,7 +71,6 @@
     "aws4fetch": "^1.0.20",
     "clsx": "^2.1.1",
     "cors": "^2.8.5",
-    "cssbeautify": "^0.3.1",
     "dayjs": "^1.11.13",
     "foliate-js": "workspace:*",
     "franc-min": "^6.2.0",

--- a/apps/readest-app/src/components/settings/MiscPanel.tsx
+++ b/apps/readest-app/src/components/settings/MiscPanel.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import cssbeautify from 'cssbeautify';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { useEnv } from '@/context/EnvContext';
@@ -9,7 +8,7 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { useResetViewSettings } from '@/hooks/useResetSettings';
 import { SettingsPanelPanelProp } from './SettingsDialog';
 import { getStyles } from '@/utils/style';
-import cssValidate from '@/utils/css';
+import { validateCSS, formatCSS } from '@/utils/css';
 
 type CSSType = 'book' | 'reader';
 
@@ -47,11 +46,11 @@ const MiscPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const validateCSS = (cssInput: string): { isValid: boolean; error?: string } => {
+  const handleValidateCSS = (cssInput: string): { isValid: boolean; error?: string } => {
     if (!cssInput.trim()) return { isValid: true };
 
     try {
-      const { isValid, error } = cssValidate(cssInput);
+      const { isValid, error } = validateCSS(cssInput);
       if (!isValid) {
         return { isValid: false, error: error || 'Invalid CSS' };
       }
@@ -71,24 +70,20 @@ const MiscPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset 
       setDraftContentStylesheet(cssInput);
       setDraftContentStylesheetSaved(false);
 
-      const { isValid, error } = validateCSS(cssInput);
+      const { isValid, error } = handleValidateCSS(cssInput);
       setContentError(isValid ? null : error || 'Invalid CSS');
     } else {
       setDraftUIStylesheet(cssInput);
       setDraftUIStylesheetSaved(false);
 
-      const { isValid, error } = validateCSS(cssInput);
+      const { isValid, error } = handleValidateCSS(cssInput);
       setUIError(isValid ? null : error || 'Invalid CSS');
     }
   };
 
   const applyStyles = (type: CSSType, clear = false) => {
     const cssInput = type === 'book' ? draftContentStylesheet : draftUIStylesheet;
-    const formattedCSS = cssbeautify(clear ? '' : cssInput, {
-      indent: '  ',
-      openbrace: 'end-of-line',
-      autosemicolon: true,
-    });
+    const formattedCSS = formatCSS(clear ? '' : cssInput);
 
     if (type === 'book') {
       setDraftContentStylesheet(formattedCSS);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,9 +122,6 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.5
-      cssbeautify:
-        specifier: ^0.3.1
-        version: 0.3.1
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -3833,10 +3830,6 @@ packages:
 
   css-selector-tokenizer@0.8.0:
     resolution: {integrity: sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==}
-
-  cssbeautify@0.3.1:
-    resolution: {integrity: sha512-ljnSOCOiMbklF+dwPbpooyB78foId02vUrTDogWzu6ca2DCNB7Kc/BHEGBnYOlUYtwXvSW0mWTwaiO2pwFIoRg==}
-    hasBin: true
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -11624,8 +11617,6 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       fastparse: 1.1.2
-
-  cssbeautify@0.3.1: {}
 
   cssesc@3.0.0: {}
 


### PR DESCRIPTION
The previous CSS validation was implemented manually using regular expressions and string splitting. This approach was fragile, difficult to maintain, and could not handle modern CSS syntax such as at-rules (@media, @keyframes) or complex selectors.

This PR replaces the manual implementation with `postcss`, a robust and industry-standard CSS parser. If PostCSS can successfully parse the CSS string, it is considered valid; otherwise, it throws an error, which is caught and reported.

This change provides several key benefits:
- Greatly improves the reliability and accuracy of CSS validation.
- Supports a much wider range of modern CSS syntax.
- Simplifies the codebase and improves maintainability.
- Provides more specific and helpful error messages from PostCSS.

> [!IMPORTANT]
> I've added the postcss dependency to package.json, but I'm unable to update the lock file from my current environment. The lock file (package-lock.json or yarn.lock) will need to be regenerated.