### PR TITLE
compat: support .fb.zip files as FBZ format

### DIFF
--- a/apps/readest-app/src/libs/document.ts
+++ b/apps/readest-app/src/libs/document.ts
@@ -195,6 +195,7 @@ export class DocumentLoader {
   private isFBZ(): boolean {
     return (
       this.file.type === 'application/x-zip-compressed-fb2' ||
+      this.file.name.endsWith('.fb.zip') ||
       this.file.name.endsWith('.fb2.zip') ||
       this.file.name.endsWith(`.${EXTS.FBZ}`)
     );


### PR DESCRIPTION
Although .fb.zip is not an officially recognized extension, many FBZ files use this format, so it's now treated as FBZ for compatibility.