### PR TITLE
fix(layout): Fix popup menu for RTL languages

### DIFF
--- a/apps/readest-app/src/components/Providers.tsx
+++ b/apps/readest-app/src/components/Providers.tsx
@@ -15,6 +15,7 @@ import { useDefaultIconSize } from '@/hooks/useResponsiveSize';
 import { useBackgroundTexture } from '@/hooks/useBackgroundTexture';
 import { useEinkMode } from '@/hooks/useEinkMode';
 import { getLocale } from '@/utils/misc';
+import { getDirFromUILanguage } from '@/utils/rtl';
 
 const Providers = ({ children }: { children: React.ReactNode }) => {
   const { envConfig, appService } = useEnv();
@@ -28,6 +29,13 @@ const Providers = ({ children }: { children: React.ReactNode }) => {
   useEffect(() => {
     const handlerLanguageChanged = (lng: string) => {
       document.documentElement.lang = lng;
+      // Set RTL class on document for targeted styling without affecting layout
+      const dir = getDirFromUILanguage();
+      if (dir === 'rtl') {
+        document.documentElement.classList.add('ui-rtl');
+      } else {
+        document.documentElement.classList.remove('ui-rtl');
+      }
     };
 
     const locale = getLocale();

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -172,6 +172,35 @@ foliate-view {
   transform: translateX(0);
 }
 
+.ui-rtl .dropdown-left::before,
+.ui-rtl .dropdown-left::after {
+  left: auto;
+  right: 20px;
+}
+
+.ui-rtl .dropdown-right::before,
+.ui-rtl .dropdown-right::after {
+  right: auto;
+  left: 20px;
+}
+
+.ui-rtl .dropdown-end > :where(.dropdown-content) {
+  inset-inline-end: auto;
+  inset-inline-start: 0;
+}
+
+.ui-rtl .settings-menu,
+.ui-rtl .view-menu {
+  inset-inline-end: auto;
+  inset-inline-start: 0;
+}
+
+.ui-rtl .dropdown-content,
+.ui-rtl .settings-menu,
+.ui-rtl .view-menu {
+  direction: rtl;
+}
+
 .dropdown-content.no-triangle::before,
 .dropdown-content.no-triangle::after {
   display: none;


### PR DESCRIPTION
**Before**:
<img width="2736" height="1702" alt="fa-before" src="https://github.com/user-attachments/assets/57c9b576-72d2-4f6c-9606-d37de3994bcc" />

**After**:
<img width="2736" height="1705" alt="image_2025-10-25_21-48-11" src="https://github.com/user-attachments/assets/d5709a90-7826-43c8-ba7f-6a7c0a3d25f5" />

✅ Tested on:
✔️ Web (Desktop & Mobile [`pnpm dev-web`])
✔️ Windows [`pnpm tauri dev`]