### PR TITLE
feat: add text stroke width setting

### DIFF
--- a/apps/readest-app/src/components/settings/FontPanel.tsx
+++ b/apps/readest-app/src/components/settings/FontPanel.tsx
@@ -144,6 +144,7 @@ const FontPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset 
   const [sansSerifFont, setSansSerifFont] = useState(viewSettings.sansSerifFont);
   const [monospaceFont, setMonospaceFont] = useState(viewSettings.monospaceFont);
   const [fontWeight, setFontWeight] = useState(viewSettings.fontWeight);
+  const [textStrokeWidth, setTextStrokeWidth] = useState(viewSettings.textStrokeWidth);
 
   const [customFonts, setCustomFonts] = useState<string[]>(getFontFamilies());
   const [CJKFonts, setCJKFonts] = useState<string[]>(() => {
@@ -163,6 +164,7 @@ const FontPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset 
       sansSerifFont: setSansSerifFont,
       monospaceFont: setMonospaceFont,
       fontWeight: setFontWeight,
+      textStrokeWidth: setTextStrokeWidth,
     });
     getAllFonts().forEach((font) => {
       if (removeFont(font.id)) {
@@ -254,6 +256,11 @@ const FontPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset 
   }, [fontWeight]);
 
   useEffect(() => {
+    saveViewSettings(envConfig, bookKey, 'textStrokeWidth', textStrokeWidth);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [textStrokeWidth]);
+
+  useEffect(() => {
     saveViewSettings(envConfig, bookKey, 'serifFont', serifFont);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serifFont]);
@@ -339,6 +346,22 @@ const FontPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset 
               min={100}
               max={900}
               step={100}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className='w-full'>
+        <h2 className='mb-2 font-medium'>{_('Text Stroke Width')}</h2>
+        <div className='card border-base-200 border shadow'>
+          <div className='divide-base-200 divide-y'>
+            <NumberInput
+              label={_('Text Stroke Width')}
+              value={textStrokeWidth}
+              onChange={setTextStrokeWidth}
+              min={0}
+              max={10}
+              step={1}
             />
           </div>
         </div>

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -121,6 +121,7 @@ export const DEFAULT_BOOK_FONT: BookFont = {
   defaultFontSize: 16,
   minimumFontSize: 8,
   fontWeight: 400,
+  textStrokeWidth: 0,
 };
 
 export const DEFAULT_BOOK_LAYOUT: BookLayout = {

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -152,6 +152,7 @@ export interface BookFont {
   defaultFontSize: number;
   minimumFontSize: number;
   fontWeight: number;
+  textStrokeWidth: number;
 }
 
 export interface ViewConfig {

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -25,6 +25,7 @@ const getFontStyles = (
   fontSize: number,
   minFontSize: number,
   fontWeight: number,
+  textStrokeWidth: number,
   overrideFont: boolean,
 ) => {
   const lastSerifFonts = ['Georgia', 'Times New Roman'];
@@ -57,10 +58,12 @@ const getFontStyles = (
       --font-size: ${fontSize}px;
       --min-font-size: ${minFontSize}px;
       --font-weight: ${fontWeight};
+      --webkit-text-stroke-width: ${textStrokeWidth / 100}em;
     }
     html, body {
       font-size: ${fontSize}px !important;
       font-weight: ${fontWeight};
+      -webkit-text-stroke-width: ${textStrokeWidth / 100}em;
       -webkit-text-size-adjust: none;
       text-size-adjust: none;
     }
@@ -548,6 +551,7 @@ export const getStyles = (viewSettings: ViewSettings, themeCode?: ThemeCode) => 
     viewSettings.defaultFontSize! * fontScale * zoomScale,
     viewSettings.minimumFontSize!,
     viewSettings.fontWeight!,
+    viewSettings.textStrokeWidth!,
     viewSettings.overrideFont!,
   );
   const colorStyles = getColorStyles(


### PR DESCRIPTION
This patch uses css rule `-webkit-text-stroke-width` to provide an alternative way to adjust font weight for non-variable fonts.

PS: This feature remains untranslated as I don't know how to do it. Plus, I wonder if this feature should be called `Font Stroke Width` or `Font Weight Enhancement` to fit in the context of the font panel.