### PR TITLE
fix(txt): register style.css to content.opf

### DIFF
--- a/apps/readest-app/src/utils/txt.ts
+++ b/apps/readest-app/src/utils/txt.ts
@@ -385,6 +385,7 @@ export class TxtToEpubConverter {
     }
 
     const tocManifest = `<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>`;
+    const styleManifest = `<item id="css" href="style.css" media-type="text/css"/>`;
 
     // Add content.opf file
     const contentOpf = `<?xml version="1.0" encoding="UTF-8"?>
@@ -396,9 +397,9 @@ export class TxtToEpubConverter {
           <dc:identifier id="book-id">${identifier}</dc:identifier>
         </metadata>
         <manifest>
-          <item id="css" href="style.css" media-type="text/css"/>
           ${manifest}
           ${tocManifest}
+          ${styleManifest}
         </manifest>
         <spine toc="ncx">
           ${spine}


### PR DESCRIPTION
This PR registers `style.css` to `content.opf` when converting txt file to epub file. Without the registration, the render is blocked while waiting the css content to just fail, causing long loading time between chapters.
<img width="479" height="331" alt="2,100 ms" src="https://github.com/user-attachments/assets/2636dea0-a301-45fd-8679-ba349d2b410c" />
