### PR TITLE
add rust and node deps to the nix devshell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ fastlane/report.xml
 
 *.koplugin.zip
 
+# nix
+result*

--- a/ops/flake.lock
+++ b/ops/flake.lock
@@ -60,6 +60,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1765003156,
+        "narHash": "sha256-k4YrPUhRj7Ciq385vREU57RHiDFycY5RaJwdCOmsLhU=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "e8361cc010853d17740a63aae00385061ac9de51",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -148,8 +169,26 @@
       "inputs": {
         "android": "android",
         "devshell": "devshell_2",
+        "fenix": "fenix",
         "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_3"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1764925941,
+        "narHash": "sha256-zldc1SrUIhGMdQp+0woSqvBS51Mi8PW6JukONBQXZBY=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "2cbf3587d36dfc7b701ebb744d3dd5064355d04f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -8,9 +8,13 @@
     android = {
       url = "github:tadfisher/android-nixpkgs/stable";
     };
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, android, devshell }:
+  outputs = { self, nixpkgs, flake-utils, android, devshell, fenix }:
     {
       overlay = final: prev: {
         inherit (self.packages.${final.system}) android-sdk android-studio;
@@ -20,11 +24,15 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         inherit (nixpkgs) lib;
+        inherit (pkgs.lib) optionals;
+        inherit (pkgs.stdenv) isDarwin;
+
         pkgs = import nixpkgs {
           inherit system;
           config.allowUnfree = true;
           overlays = [
             devshell.overlays.default
+            fenix.overlays.default
             self.overlay
           ];
         };
@@ -32,76 +40,154 @@
         androidConditionalPackages = if pkgs.system != "aarch64-darwin" then [ pkgs.android-studio ] else [ ];
         commonPackages = with pkgs; [
           pnpm
+          nodejs_22
+          clang
+          pkg-config
+          (pkgs.fenix.complete.withComponents [
+            "cargo"
+            "clippy"
+            "rust-src"
+            "rustc"
+            "rustfmt"
+          ])
+          pkgs.rust-analyzer-nightly
+          xdg-utils
         ];
-        mkCommonSHell = { name, extraPackages ? [], extraEnv ? [] }:
+
+        systemDeps = with pkgs; [
+          at-spi2-atk
+          atkmm
+          cairo
+          fontconfig
+          fontconfig.out
+          freetype
+          gdk-pixbuf
+          glib
+          gtk3
+          gtk4
+          harfbuzz
+          librsvg
+          libsoup_3
+          openssl
+          pango
+          zlib
+        ] ++ (optionals (!isDarwin) [
+          webkitgtk_4_1
+        ]) ++ (optionals isDarwin [
+          darwin.libiconv
+        ]);
+        getDev = pkg: if pkg ? dev then pkg.dev else pkg;
+        getLib = pkg: if pkg ? lib then pkg.lib else pkg;
+
+        pkgConfigPath = lib.makeSearchPath "lib/pkgconfig" (map getDev systemDeps);
+        libPath = lib.makeLibraryPath (map getLib systemDeps);
+
+        mkCommonShell =
+          { name
+          , extraPackages ? [ ]
+          , extraEnv ? [
+              {
+                name = "PKG_CONFIG_PATH";
+                value = pkgConfigPath;
+              }
+              {
+                name = "RUSTFLAGS";
+                value = "-C link-arg=-Wl,-rpath,${libPath}";
+              }
+              {
+                name = "LIBRARY_PATH";
+                value = libPath;
+              }
+            ] ++ (optionals isDarwin [
+              {
+                name = "RUSTFLAGS";
+                eval = "\"-L framework=$DEVSHELL_DIR/Library/Frameworks\"";
+              }
+              {
+                name = "RUSTDOCFLAGS";
+                eval = "\"-L framework=$DEVSHELL_DIR/Library/Frameworks\"";
+              }
+              {
+                name = "PATH";
+                prefix =
+                  let
+                    inherit (pkgs) xcbuild;
+                  in
+                  lib.makeBinPath [
+                    xcbuild
+                    "${xcbuild}/Toolchains/XcodeDefault.xctoolchain"
+                  ];
+              }
+            ])
+          }:
           pkgs.devshell.mkShell {
             inherit name;
             packages = commonPackages ++ extraPackages;
             env = extraEnv;
           };
+      in
+      {
+        packages = {
+          android-sdk = android.sdk.${system} (sdkPkgs: with sdkPkgs; [
+            # Useful packages for building and testing.
+            build-tools-34-0-0
+            cmdline-tools-latest
+            emulator
+            platform-tools
+            platforms-android-34
+            ndk-26-1-10909125
+          ]
+          ++ lib.optionals (system == "aarch64-darwin") [
+            system-images-android-34-google-apis-arm64-v8a
+            system-images-android-34-google-apis-playstore-arm64-v8a
+          ]
+          ++ lib.optionals (system == "x86_64-darwin" || system == "x86_64-linux") [
+            system-images-android-34-google-apis-x86-64
+            system-images-android-34-google-apis-playstore-x86-64
+          ]);
+        } // lib.optionalAttrs (system == "x86_64-linux") {
+          # Android Studio in nixpkgs is currently packaged for x86_64-linux only.
+          android-studio = pkgs.androidStudioPackages.stable;
+        };
 
-      in {
-          packages = {
-            android-sdk = android.sdk.${system} (sdkPkgs: with sdkPkgs; [
-              # Useful packages for building and testing.
-              build-tools-34-0-0
-              cmdline-tools-latest
-              emulator
-              platform-tools
-              platforms-android-34
-              ndk-26-1-10909125
-            ]
-            ++ lib.optionals (system == "aarch64-darwin") [
-              system-images-android-34-google-apis-arm64-v8a
-              system-images-android-34-google-apis-playstore-arm64-v8a
-            ]
-            ++ lib.optionals (system == "x86_64-darwin" || system == "x86_64-linux") [
-              system-images-android-34-google-apis-x86-64
-              system-images-android-34-google-apis-playstore-x86-64
-            ]);
-          } // lib.optionalAttrs (system == "x86_64-linux") {
-            # Android Studio in nixpkgs is currently packaged for x86_64-linux only.
-            android-studio = pkgs.androidStudioPackages.stable;
+        devShells = {
+          web = mkCommonShell {
+            name = "readest-dev";
           };
 
-          devShells = {
-            web = mkCommonSHell {
-              name = "readest-dev";
-            };
+          ios = mkCommonShell {
+            name = "readest-ios";
+            extraPackages = [ pkgs.cocoapods ];
+          };
 
-            ios = mkCommonSHell {
-              name = "readest-ios";
-              extraPackages = [ pkgs.cocoapods ];
-            };
+          android = mkCommonShell {
+            name = "readest-android";
+            extraPackages = [
+              pkgs.android-sdk
+              pkgs.gradle
+              pkgs.jdk
+            ] ++ androidConditionalPackages;
+            extraEnv = [
+              {
+                name = "ANDROID_HOME";
+                value = "${pkgs.android-sdk}/share/android-sdk";
+              }
+              {
+                name = "ANDROID_SDK_ROOT";
+                value = "${pkgs.android-sdk}/share/android-sdk";
+              }
+              {
+                name = "NDK_HOME";
+                value = "${pkgs.android-sdk}/share/android-sdk/ndk/26.1.10909125";
+              }
+              {
+                name = "JAVA_HOME";
+                value = pkgs.jdk.home;
+              }
+            ];
+          };
 
-            android = mkCommonSHell {
-              name = "readest-android";
-              extraPackages = [
-                pkgs.android-sdk
-                pkgs.gradle
-                pkgs.jdk
-              ] ++ androidConditionalPackages;
-              extraEnv = [
-                {
-                  name = "ANDROID_HOME";
-                  value = "${pkgs.android-sdk}/share/android-sdk";
-                }
-                {
-                  name = "ANDROID_SDK_ROOT";
-                  value = "${pkgs.android-sdk}/share/android-sdk";
-                }
-                {
-                  name = "NDK_HOME";
-                  value = "${pkgs.android-sdk}/share/android-sdk/ndk/26.1.10909125";
-                }
-                {
-                  name = "JAVA_HOME";
-                  value = pkgs.jdk.home;
-                }
-              ];
-            };
-
-            default = self.devShells.${system}.web;
+          default = self.devShells.${system}.web;
         };
       });
 }


### PR DESCRIPTION
this should add the remaining deps (a rust toolchain and nodejs 22, plus all required libraries to build with and link for tauri) to the nix development shell!

with these changes, I am able to enter the devshell and build+run the full tauri dev setup on linux and darwin!

bare minimum steps using this after a fresh clone:
```bash
git submodule update --init --recursive
pnpm install
pnpm --filter @readest/readest-app setup-vendors

# run just the web version
pnpm dev-web

# build and run tauri build
pnpm tauri dev
```

this does not fully solve the actual production release builds via the nix env, but that is handled by CI anyways at the moment for all platforms!