### PR TITLE
feat(ui): Added showFooterOnNavigationPanel option

### DIFF
--- a/apps/readest-app/src/app/reader/components/ProgressInfo.tsx
+++ b/apps/readest-app/src/app/reader/components/ProgressInfo.tsx
@@ -16,6 +16,7 @@ interface PageInfoProps {
   horizontalGap: number;
   contentInsets: Insets;
   gridInsets: Insets;
+  fullHeight?: boolean; 
 }
 
 const ProgressInfoView: React.FC<PageInfoProps> = ({
@@ -26,6 +27,7 @@ const ProgressInfoView: React.FC<PageInfoProps> = ({
   horizontalGap,
   contentInsets,
   gridInsets,
+  fullHeight = false,
 }) => {
   const _ = useTranslation();
   const { appService } = useEnv();
@@ -112,7 +114,7 @@ const ProgressInfoView: React.FC<PageInfoProps> = ({
         aria-hidden='true'
         className={clsx(
           'flex items-center justify-between',
-          isVertical ? 'h-full' : 'h-[52px] w-full',
+          isVertical ? 'h-full' : (fullHeight ? 'h-full w-full' : 'h-[52px] w-full'),
         )}
       >
         {viewSettings.showRemainingTime ? (

--- a/apps/readest-app/src/app/reader/components/footerbar/NavigationPanel.tsx
+++ b/apps/readest-app/src/app/reader/components/footerbar/NavigationPanel.tsx
@@ -8,6 +8,7 @@ import { useReaderStore } from '@/store/readerStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { ViewSettings } from '@/types/book';
 import { NavigationHandlers } from './types';
+import ProgressInfoView from '../ProgressInfo'
 import Button from '@/components/Button';
 import Slider from '@/components/Slider';
 
@@ -33,12 +34,27 @@ export const NavigationPanel: React.FC<NavigationPanelProps> = ({
   sliderHeight,
 }) => {
   const _ = useTranslation();
-  const { getView } = useReaderStore();
+  const { getProgress, getView, getViewSettings } = useReaderStore();
   const view = getView(bookKey);
 
   const [progressValue, setProgressValue] = React.useState(
     progressValid ? progressFraction * 100 : 0,
   );
+
+  const progress = getProgress(bookKey);
+  const { section, pageinfo, timeinfo } = progress || {};
+  const gridInsets = {
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  };
+  const contentInsets = {
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  };
 
   useEffect(() => {
     if (progressValid) {
@@ -61,6 +77,9 @@ export const NavigationPanel: React.FC<NavigationPanelProps> = ({
       ? 'pointer-events-auto translate-y-0 pb-4 pt-8 ease-out'
       : 'pointer-events-none invisible translate-y-full overflow-hidden pb-0 pt-0 ease-in',
   );
+
+  if (!viewSettings)
+    viewSettings = getViewSettings(bookKey) ?? undefined;
 
   return (
     <div className={classes} style={{ bottom: mobileBottomOffset }}>
@@ -139,6 +158,18 @@ export const NavigationPanel: React.FC<NavigationPanelProps> = ({
           label={getNavigationLabel(viewSettings?.rtl, _('Next Section'), _('Previous Section'))}
         />
       </div>
+      {viewSettings && viewSettings.showFooterOnNavigationPanel && (
+        <ProgressInfoView
+          bookKey={bookKey}
+          section={section}
+          pageinfo={pageinfo}
+          timeinfo={timeinfo}
+          horizontalGap={viewSettings.gapPercent}
+          contentInsets={contentInsets}
+          gridInsets={gridInsets}
+          fullHeight={true}
+        />
+      )}
     </div>
   );
 };

--- a/apps/readest-app/src/components/settings/LayoutPanel.tsx
+++ b/apps/readest-app/src/components/settings/LayoutPanel.tsx
@@ -72,6 +72,7 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
   const [showProgressInfo, setShowProgressInfo] = useState(viewSettings.showProgressInfo);
   const [progressStyle, setProgressStyle] = useState(viewSettings.progressStyle);
   const [screenOrientation, setScreenOrientation] = useState(viewSettings.screenOrientation);
+  const [showFooterOnNavigationPanel, setShowFooterOnNavigationPanel] = useState(viewSettings.showFooterOnNavigationPanel)
   const resetToDefaults = useResetViewSettings();
 
   const handleReset = () => {
@@ -105,6 +106,7 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
       showRemainingPages: setShowRemainingPages,
       showProgressInfo: setShowProgressInfo,
       showMarginsOnScroll: setShowMarginsOnScroll,
+      showFooterOnNavigationPanel: setShowFooterOnNavigationPanel
     });
   };
 
@@ -371,6 +373,11 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [screenOrientation]);
+
+  useEffect(() => {
+    saveViewSettings(envConfig, bookKey, 'showFooterOnNavigationPanel', showFooterOnNavigationPanel, false, false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showFooterOnNavigationPanel]);
 
   const langCode = getBookLangCode(bookData?.bookDoc?.metadata?.language);
   const mightBeRTLBook = MIGHT_BE_RTL_LANGS.includes(langCode) || isCJKEnv();
@@ -702,6 +709,15 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
                 className='toggle'
                 checked={showBarsOnScroll}
                 onChange={() => setShowBarsOnScroll(!showBarsOnScroll)}
+              />
+            </div>
+            <div className='config-item'>
+              <span className=''>{_('Show Footer On Navigation Panel')}</span>
+              <input
+                type='checkbox'
+                className='toggle'
+                checked={showFooterOnNavigationPanel}
+                onChange={() => setShowFooterOnNavigationPanel(!showFooterOnNavigationPanel)}
               />
             </div>
           </div>

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -226,6 +226,7 @@ export const DEFAULT_VIEW_CONFIG: ViewConfig = {
   showProgressInfo: true,
   showMarginsOnScroll: false,
   progressStyle: 'fraction',
+  showFooterOnNavigationPanel: false,
 };
 
 export const DEFAULT_TTS_CONFIG: TTSConfig = {

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -187,6 +187,7 @@ export interface ViewConfig {
   showBarsOnScroll: boolean;
   showMarginsOnScroll: boolean;
   progressStyle: 'percentage' | 'fraction';
+  showFooterOnNavigationPanel: boolean;
 }
 
 export interface TTSConfig {


### PR DESCRIPTION
This adds an option to show the footer (ProgressInfoView) on the mobile NavigationPanel.  Just trying to add an option for my question in https://github.com/readest/readest/discussions/2608 :wink:.  There's a screenshot in that thread.

I've not done much development work in these frameworks, so apologies if anything is not up to standard!  I'm happy to make any tweaks you'd like.

Thanks very much!