### PR TITLE
fix(android): don't navigate back with the back button for more predictable navigation

### DIFF
--- a/apps/readest-app/src/app/reader/components/Reader.tsx
+++ b/apps/readest-app/src/app/reader/components/Reader.tsx
@@ -57,7 +57,7 @@ const Reader: React.FC<{ ids?: string }> = ({ ids }) => {
   const { settings } = useSettingsStore();
   const { libraryLoaded } = useLibrary();
   const { sideBarBookKey } = useSidebarStore();
-  const { hoveredBookKey, getView } = useReaderStore();
+  const { hoveredBookKey } = useReaderStore();
   const { showSystemUI, dismissSystemUI } = useThemeStore();
   const { getScreenBrightness, setScreenBrightness } = useDeviceControlStore();
   const { acquireBackKeyInterception, releaseBackKeyInterception } = useDeviceControlStore();
@@ -100,14 +100,11 @@ const Reader: React.FC<{ ids?: string }> = ({ ids }) => {
   }, [appService]);
 
   const handleKeyDown = (event: CustomEvent) => {
-    const view = getView(sideBarBookKey!);
     if (event.detail.keyName === 'Back') {
       if (getIsSideBarVisible()) {
         setSideBarVisible(false);
       } else if (getIsNotebookVisible()) {
         setNotebookVisible(false);
-      } else if (view?.history.canGoBack) {
-        view.history.back();
       } else {
         eventDispatcher.dispatch('close-reader');
         router.back();


### PR DESCRIPTION
This will revert the link navigation with back button in #2454. 
This will close #2833 and more user reports that found back link navigation confusing.