### PR TITLE
fix(login): Fix login message field

### DIFF
--- a/apps/readest.koplugin/main.lua
+++ b/apps/readest.koplugin/main.lua
@@ -252,7 +252,7 @@ function ReadestSync:doLogin(email, password, menu)
         })
     else
         UIManager:show(InfoMessage:new{
-            text = _("Login failed: ") .. (response.message or "Unknown error"),
+            text = _("Login failed: ") .. (response.msg or "Unknown error"),
             timeout = 3,
         })
     end


### PR DESCRIPTION
Fix the invalid field used in login failed screen.
How to test `http https://readest.supabase.co/auth/v1/token email=user@example.com password='123' grant_type==password apikey:'YOURAPIKEY'`

 It returns: 
 ```
{
    "code": 400,
    "error_code": "invalid_credentials",
    "msg": "Invalid login credentials"
}
 ```