### PR TITLE
TTS: footnotes anchors and superscript filtering

### DIFF
--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -111,8 +111,8 @@ export class TTSController extends EventTarget {
     await this.view.initTTS(
       granularity,
       createRejectFilter({
-        tags: ['rt', 'sup'],
-        contents: [{ tag: 'a', content: /^\d+$/ }],
+        tags: ['rt'],
+        contents: [{ tag: 'a', content: /^[\[\(]?[\*\d]+[\)\]]?$/}],
       }),
       this.#getHighlighter(),
     );


### PR DESCRIPTION
<ins>Footnotes anchors</ins> : filter not only the basic format (text [23](https://github.com/)), but also the following formats that are frequently encountered : text [[23]](https://github.com/), text [(23)](https://github.com/), text [*23](https://github.com/), text [[*23]](https://github.com/), text [(*23)](https://github.com/).

<ins>Superscript text</ins> : completely remove the filtering.