### PR TITLE
fix(opds): temporary workaround for self-signed cert for OPDS server, closes #2871

### DIFF
--- a/apps/readest-app/src-tauri/src/transfer_file.rs
+++ b/apps/readest-app/src-tauri/src/transfer_file.rs
@@ -108,6 +108,7 @@ pub async fn download_file(
     headers: HashMap<String, String>,
     body: Option<String>,
     single_threaded: Option<bool>,
+    skip_ssl_verification: Option<bool>,
     on_progress: Channel<ProgressPayload>,
 ) -> Result<()> {
     use futures::stream::{self, StreamExt};
@@ -116,7 +117,10 @@ pub async fn download_file(
 
     const PART_SIZE: u64 = 1024 * 1024;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::ClientBuilder::new()
+        .danger_accept_invalid_certs(skip_ssl_verification.unwrap_or(false))
+        .danger_accept_invalid_hostnames(skip_ssl_verification.unwrap_or(false))
+        .build()?;
     let force_single = single_threaded.unwrap_or(false);
 
     async fn single_threaded_download(

--- a/apps/readest-app/src/app/opds/page.tsx
+++ b/apps/readest-app/src/app/opds/page.tsx
@@ -443,6 +443,7 @@ export default function BrowserPage() {
               url: downloadUrl,
               headers,
               singleThreaded: true,
+              skipSslVerification: true,
               onProgress,
             });
             const { library, setLibrary } = useLibraryStore.getState();
@@ -498,6 +499,7 @@ export default function BrowserPage() {
           cfp: '',
           url: downloadUrl,
           singleThreaded: true,
+          skipSslVerification: true,
           headers,
         });
         return await appService.getImageURL(cachedPath);

--- a/apps/readest-app/src/app/opds/utils/opdsReq.ts
+++ b/apps/readest-app/src/app/opds/utils/opdsReq.ts
@@ -215,6 +215,7 @@ export const probeAuth = async (
   const res = await fetch(fetchURL, {
     method: 'HEAD',
     headers,
+    danger: { acceptInvalidCerts: true, acceptInvalidHostnames: true },
   });
 
   // Check if authentication is required
@@ -275,6 +276,7 @@ export const fetchWithAuth = async (
     ...options,
     method: options.method || 'GET',
     headers,
+    danger: { acceptInvalidCerts: true, acceptInvalidHostnames: true },
   });
 
   // Handle authentication if needed
@@ -302,6 +304,7 @@ export const fetchWithAuth = async (
           ...options,
           method: options.method || 'GET',
           headers: useProxy ? headers : { ...headers, Authorization: authHeader },
+          danger: { acceptInvalidCerts: true, acceptInvalidHostnames: true },
         });
       }
     }

--- a/apps/readest-app/src/libs/storage.ts
+++ b/apps/readest-app/src/libs/storage.ts
@@ -111,6 +111,7 @@ type DownloadFileParams = {
   url?: string;
   headers?: Record<string, string>;
   singleThreaded?: boolean;
+  skipSslVerification?: boolean;
   onProgress?: ProgressHandler;
 };
 
@@ -121,6 +122,7 @@ export const downloadFile = async ({
   url,
   headers,
   singleThreaded,
+  skipSslVerification,
   onProgress,
 }: DownloadFileParams) => {
   try {
@@ -150,7 +152,15 @@ export const downloadFile = async ({
       const file = await webDownload(downloadUrl, onProgress, headers);
       await appService.writeFile(dst, 'None', await file.arrayBuffer());
     } else {
-      await tauriDownload(downloadUrl, dst, onProgress, headers, undefined, singleThreaded);
+      await tauriDownload(
+        downloadUrl,
+        dst,
+        onProgress,
+        headers,
+        undefined,
+        singleThreaded,
+        skipSslVerification,
+      );
     }
   } catch (error) {
     console.error(`File '${dst}' download failed:`, error);

--- a/apps/readest-app/src/utils/transfer.ts
+++ b/apps/readest-app/src/utils/transfer.ts
@@ -123,6 +123,7 @@ export const tauriDownload = async (
   headers?: Record<string, string>,
   body?: string,
   singleThreaded?: boolean,
+  skipSslVerification?: boolean,
 ): Promise<void> => {
   const ids = new Uint32Array(1);
   window.crypto.getRandomValues(ids);
@@ -141,5 +142,6 @@ export const tauriDownload = async (
     onProgress,
     body,
     singleThreaded,
+    skipSslVerification,
   });
 };


### PR DESCRIPTION
Related to https://github.com/seanmonstar/reqwest/issues/1554

Note that this workaround only affects HTTPS requests to OPDS servers, so the security exposure should be limited.