### PR TITLE
fix: prevent splitting multi-byte UTF-8 characters in makeSafeFilename

### DIFF
--- a/apps/readest-app/src/utils/misc.ts
+++ b/apps/readest-app/src/utils/misc.ts
@@ -24,7 +24,7 @@ export const makeSafeFilename = (filename: string, replacement = '_') => {
   let utf8Bytes = encoder.encode(safeName);
 
   while (utf8Bytes.length > maxFilenameBytes) {
-    safeName = safeName.slice(0, -1);
+    safeName = Array.from(safeName).slice(0, -1).join('');
     utf8Bytes = encoder.encode(safeName);
   }
 


### PR DESCRIPTION
## Problem Summary

The `makeSafeFilename` function in `apps/readest-app/src/utils/misc.ts` has a critical bug that corrupts filenames containing multi-byte Unicode characters (Traditional Chinese in my test case) when truncating to meet the 250-byte limit. 

**Root Cause**: Line 27 uses `safeName.slice(0, -1)` which naively removes one JavaScript string character.  This can split a multi-byte UTF-8 character in half, creating invalid UTF-8 sequences that cause filesystem operations to fail with "invalid filename" errors. Note that the files can be imported correctly by (1) entering "Files" app; (2) tap the book we want to import; (3) "share" button and tap *readest*.

## 🔧 The Fix

**File**:  `apps/readest-app/src/utils/misc.ts`

Replace lines 26-29:

```typescript
// BEFORE:
while (utf8Bytes. length > maxFilenameBytes) {
  safeName = safeName.slice(0, -1);  // ❌ Can split multi-byte characters
  utf8Bytes = encoder.encode(safeName);
}

// AFTER:
while (utf8Bytes. length > maxFilenameBytes) {
  safeName = Array. from(safeName).slice(0, -1).join('');  // ✅ Removes full Unicode code points
  utf8Bytes = encoder.encode(safeName);
}
```

**Why this works**: `Array.from(safeName)` converts the string into an array of complete Unicode code points (grapheme clusters), ensuring we never split multi-byte characters.

## ⚠️ IMPORTANT:  Testing Request

**The original bug reporter (@JackyHe398) does not have a proper testing environment and requests thorough testing before merging.**

Please test ALL scenarios below before merging this PR. 

## Test Cases to Verify

### Test Case 1: Long Traditional Chinese Filenames (Primary Bug)
Test with these actual filenames that triggered the bug:
```
榎宮祐 - NO GAME NO LIFE 遊戲人生 02 遊戲玩家兄妹似乎盯上獸耳娘的國家了.epub
榎宮祐 - NO GAME NO LIFE 遊戲人生 03 遊戲玩家兄妹的另一半似乎消失了……？.epub
榎宮祐 - NO GAME NO LIFE 遊戲人生 04 遊戲玩家兄妹遭遇現實戀愛遊戲而逃之夭夭了. epub
榎宮祐 - NO GAME NO LIFE 遊戲人生 10 遊戲玩家兄妹似乎被迫為過去付出代價.epub
榎宮祐 - NO GAME NO LIFE 遊戲人生 11 遊戲玩家兄妹似乎必須成為情侶才能離開.epub
```

**Test steps**:
1. Create dummy EPUB files with these exact filenames
2. Select all 5+ books for **batch import** (not "Share to Readest")
3. Verify ALL books import successfully without "invalid filename" errors
4. Verify filenames are properly truncated (if needed) without corruption

### Test Case 2: Japanese Characters (3-byte UTF-8)
```
日本語のファイル名がとても長い場合にどうなるかをテストするための本のタイトルです日本語のファイル名がとても長い場合にどうなるかをテストするための本のタイトルです日本語のファイル名がとても長い場合にどうなるかをテストするための本のタイトルです日本語のファイル名がとても長い場合にどうなるかをテストするための本のタイトルです.epub
```

### Test Case 3: Emoji and 4-byte UTF-8 Characters
```
📚 My Book Collection 📖 with lots of emojis 🎉🎊🎈🎁🌟✨💫⭐🌠🌌🌃🌆🌇🌉🌁🏙️🌄🌅🌠🌌🌃🌆🌇🌉🌁🏙️🌄🌅🌠🌌🌃🌆🌇🌉🌁🏙️🌄🌅🌠🌌🌃🌆🌇🌉🌁🏙️🌄🌅. epub
```

### Test Case 4: Mixed Multi-byte Characters
```
English中文日本語한글MixedVeryLongFilenameTestEnglish中文日本語한글MixedVeryLongFilenameTestEnglish中文日本語한글MixedVeryLongFilenameTestEnglish中文日本語한글MixedVeryLongFilenameTest.epub
```

## Context

This issue was discovered when batch importing multiple books with long Traditional Chinese filenames (such as volumes from the 'NO GAME NO LIFE' series). The error message was:  "Failed to copy file: The item couldn't be saved because the file name is invalid."

**Note**: This bug affects any language using multi-byte UTF-8 characters (Chinese, Japanese, Korean, emoji, etc.) but is most commonly triggered by Traditional Chinese due to typical light novel naming conventions.

## Expected Behavior After Fix

- All books with long Unicode filenames should import successfully in batch mode
- Truncated filenames should remain valid UTF-8
- No "invalid filename" errors during batch imports
- Both "Share to Readest" and batch import methods work consistently