### PR TITLE
Prevent caching from blocking code updates in dev environment

### DIFF
--- a/apps/readest-app/next.config.mjs
+++ b/apps/readest-app/next.config.mjs
@@ -55,7 +55,9 @@ const nextConfig = {
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable',
+            value: isDev
+              ? 'public, max-age=0, must-revalidate'
+              : 'public, max-age=31536000, immutable',
           },
         ],
       },


### PR DESCRIPTION
I was frustrated that changes I made to client code would not always show up when I went to test in the browser. It can be addressed by opening devtools and checking 'Disable Cache', but another more foolproof way can be to conditionally change the `Cache-Control` header to disallow caching when running in a dev environment. For me this improves the developer quality of life. Here is the change if you would consider taking it as a contribution. If there is an other preferred way of handling this situation, I would be happy to learn.

Testing:
- In development mode (`pnpm dev-web`) validated JS files are served with `Cache-Control: public, max-age=0, must-revalidate` header using browser devtools
- Validated in dev mode, code updates are applied automatically without needing to disable cache manually
- Create and serve a local production web build of readest-app:
```
cd apps\readest-app
pnpm build-web
pnpm start-web
```
- Validate in production build, JS files are served with `Cache-Control: public, max-age=31536000, immutable`



