### PR TITLE
Change setup command for vendors in CONTRIBUTING.md to reflect additional vendor files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,8 @@ git submodule update --init --recursive
 ```bash
 # might need to rerun this when code is updated
 pnpm install
-# copy pdfjs-dist to Next.js public directory
-pnpm --filter @readest/readest-app setup-pdfjs
+# copy vendors dist libs to public directory
+pnpm --filter @readest/readest-app setup-vendors
 ```
 
 #### 3. Verify Dependencies Installation


### PR DESCRIPTION
I ran into the same issue as https://github.com/readest/readest/issues/2637

It seems the CONTRIBUTING.md wasn't updated to note additional dependencies besides `pdf-js` needed to be setup.