### PR TITLE
feat(statistics): Phase 2 - Aggregation Methods

### DIFF
--- a/apps/readest-app/src/app/reader/components/BookSessionTracker.tsx
+++ b/apps/readest-app/src/app/reader/components/BookSessionTracker.tsx
@@ -22,7 +22,7 @@ const BookSessionTracker: React.FC<BookSessionTrackerProps> = ({ bookKey }) => {
   const { envConfig } = useEnv();
 
   // Extract book hash (id) from bookKey - bookDataStore uses id as key, not full bookKey
-  const bookId = bookKey.split('-')[0]!;
+  const bookId = bookKey.split('-')[0] ?? bookKey;
 
   // Subscribe to actual data values (not getter functions) so effects re-run when data changes
   const viewState = useReaderStore((state) => state.viewStates[bookKey]);

--- a/apps/readest-app/src/app/reader/components/BookSessionTracker.tsx
+++ b/apps/readest-app/src/app/reader/components/BookSessionTracker.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useEnv } from '@/context/EnvContext';
+import { useReaderStore } from '@/store/readerStore';
+import { useBookDataStore } from '@/store/bookDataStore';
+import { useStatisticsStore } from '@/store/statisticsStore';
+
+interface BookSessionTrackerProps {
+  bookKey: string;
+}
+
+/**
+ * Component that tracks reading sessions for a specific book.
+ * This component doesn't render anything visible, it just manages
+ * the reading session lifecycle for statistics tracking.
+ */
+const BookSessionTracker: React.FC<BookSessionTrackerProps> = ({ bookKey }) => {
+  const { envConfig } = useEnv();
+
+  // Extract book hash (id) from bookKey - bookDataStore uses id as key, not full bookKey
+  const bookId = bookKey.split('-')[0]!;
+
+  // Subscribe to actual data values (not getter functions) so effects re-run when data changes
+  const viewState = useReaderStore((state) => state.viewStates[bookKey]);
+  const bookData = useBookDataStore((state) => state.booksData[bookId]);
+  const progress = useReaderStore((state) => state.viewStates[bookKey]?.progress);
+
+  // Subscribe to specific values to ensure re-renders when they change
+  const config = useStatisticsStore((state) => state.config);
+  const loaded = useStatisticsStore((state) => state.loaded);
+  const { startSession, updateSessionActivity, endSession, saveStatistics } = useStatisticsStore();
+
+  const IDLE_TIMEOUT_MS = (config.idleTimeoutMinutes || 5) * 60 * 1000;
+
+  // Start session when the book view is initialized
+  useEffect(() => {
+    console.log('[BookSessionTracker] Effect check for', bookKey, {
+      trackingEnabled: config.trackingEnabled,
+      loaded,
+      viewStateInited: viewState?.inited,
+      hasBookData: !!bookData,
+      hasBook: !!bookData?.book,
+      bookId,
+    });
+
+    if (!config.trackingEnabled || !loaded) {
+      console.log('[BookSessionTracker] Early return: tracking disabled or not loaded');
+      return;
+    }
+
+    // Wait for the view to be initialized
+    if (!viewState?.inited || !bookData?.book) {
+      console.log('[BookSessionTracker] Early return: view not inited or no book data');
+      return;
+    }
+
+    // Don't start if session already exists - use getState() to avoid dependency on activeSessions
+    const currentActiveSessions = useStatisticsStore.getState().activeSessions;
+    if (currentActiveSessions[bookKey]) {
+      console.log('[BookSessionTracker] Session already exists for', bookKey);
+      return;
+    }
+
+    const metaHash = bookData.book.metaHash;
+    const pageInfo = progress?.pageinfo;
+    const currentPage = pageInfo?.current || 1;
+    const totalPages = pageInfo?.total || 1;
+    const progressPercent = totalPages > 0 ? currentPage / totalPages : 0;
+
+    startSession(bookKey, bookId, metaHash, progressPercent, currentPage, totalPages);
+
+    console.log('[BookSessionTracker] Started session for', bookKey, 'bookId:', bookId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    bookKey,
+    bookId,
+    config.trackingEnabled,
+    loaded,
+    viewState?.inited,
+    bookData?.book,
+    progress?.pageinfo,
+    startSession,
+  ]);
+
+  // Track progress changes and reset idle timer
+  useEffect(() => {
+    if (!config.trackingEnabled || !loaded) return;
+
+    // Check for active session using getState() to avoid dependency loops
+    const currentActiveSessions = useStatisticsStore.getState().activeSessions;
+    if (!currentActiveSessions[bookKey]) return;
+
+    if (!progress?.pageinfo) return;
+
+    const pageInfo = progress.pageinfo;
+    const currentPage = pageInfo.current || 1;
+    const totalPages = pageInfo.total || 1;
+    const progressPercent = totalPages > 0 ? currentPage / totalPages : 0;
+
+    updateSessionActivity(bookKey, progressPercent, currentPage);
+  }, [bookKey, config.trackingEnabled, loaded, progress?.pageinfo, updateSessionActivity]);
+
+  // Idle timeout handler - reset timer when progress changes
+  useEffect(() => {
+    if (!config.trackingEnabled || !loaded) return;
+
+    // Check for active session using getState()
+    const currentActiveSessions = useStatisticsStore.getState().activeSessions;
+    if (!currentActiveSessions[bookKey]) return;
+
+    const idleTimer = setTimeout(async () => {
+      console.log('[BookSessionTracker] Idle timeout for', bookKey);
+      const session = endSession(bookKey, 'idle');
+      if (session) {
+        console.log('[BookSessionTracker] Saving after idle timeout...');
+        await saveStatistics(envConfig);
+        console.log('[BookSessionTracker] Save completed after idle timeout');
+      }
+    }, IDLE_TIMEOUT_MS);
+
+    return () => clearTimeout(idleTimer);
+  }, [
+    bookKey,
+    config.trackingEnabled,
+    loaded,
+    progress?.pageinfo,
+    endSession,
+    saveStatistics,
+    envConfig,
+    IDLE_TIMEOUT_MS,
+  ]);
+
+  // Handle visibility change (for mobile background)
+  useEffect(() => {
+    if (!config.trackingEnabled || !loaded) return;
+
+    const handleVisibilityChange = () => {
+      // Get fresh state from stores when visibility changes
+      const { activeSessions, loaded: statsLoaded } = useStatisticsStore.getState();
+
+      // Don't handle visibility changes if statistics aren't loaded
+      if (!statsLoaded) return;
+
+      if (document.visibilityState === 'hidden') {
+        if (activeSessions[bookKey]) {
+          console.log('[BookSessionTracker] App hidden, ending session for', bookKey);
+          const session = endSession(bookKey, 'idle');
+          if (session) {
+            saveStatistics(envConfig);
+          }
+        }
+      } else if (document.visibilityState === 'visible') {
+        const currentViewState = useReaderStore.getState().viewStates[bookKey];
+        const currentBookData = useBookDataStore.getState().booksData[bookId];
+        const currentProgress = currentViewState?.progress;
+
+        if (currentViewState?.inited && currentBookData?.book && !activeSessions[bookKey]) {
+          console.log('[BookSessionTracker] App visible, restarting session for', bookKey);
+          const metaHash = currentBookData.book.metaHash;
+          const pageInfo = currentProgress?.pageinfo;
+          const currentPage = pageInfo?.current || 1;
+          const totalPages = pageInfo?.total || 1;
+          const progressPercent = totalPages > 0 ? currentPage / totalPages : 0;
+
+          startSession(bookKey, bookId, metaHash, progressPercent, currentPage, totalPages);
+        }
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [
+    bookKey,
+    bookId,
+    config.trackingEnabled,
+    loaded,
+    endSession,
+    startSession,
+    saveStatistics,
+    envConfig,
+  ]);
+
+  // End session when component unmounts (book closed)
+  useEffect(() => {
+    return () => {
+      // Use getState() to get fresh state during cleanup
+      const currentActiveSessions = useStatisticsStore.getState().activeSessions;
+      if (currentActiveSessions[bookKey]) {
+        console.log('[BookSessionTracker] Component unmounting, ending session for', bookKey);
+        const session = endSession(bookKey, 'closed');
+        if (session) {
+          saveStatistics(envConfig);
+        }
+      }
+    };
+  }, [bookKey, endSession, saveStatistics, envConfig]);
+
+  // This component doesn't render anything visible
+  return null;
+};
+
+export default BookSessionTracker;

--- a/apps/readest-app/src/app/reader/components/BooksGrid.tsx
+++ b/apps/readest-app/src/app/reader/components/BooksGrid.tsx
@@ -23,6 +23,7 @@ import FootnotePopup from './FootnotePopup';
 import HintInfo from './HintInfo';
 import ReadingRuler from './ReadingRuler';
 import DoubleBorder from './DoubleBorder';
+import StatisticsDebug from './StatisticsDebug';
 
 interface BooksGridProps {
   bookKeys: string[];
@@ -81,6 +82,8 @@ const BooksGrid: React.FC<BooksGridProps> = ({ bookKeys, onCloseBook }) => {
       role='main'
       aria-label={_('Books Content')}
     >
+      {/* TODO: Remove StatisticsDebug before production */}
+      {process.env['NODE_ENV'] === 'development' && <StatisticsDebug />}
       {bookKeys.map((bookKey, index) => {
         const bookData = getBookData(bookKey);
         const config = getConfig(bookKey);

--- a/apps/readest-app/src/app/reader/components/BooksGrid.tsx
+++ b/apps/readest-app/src/app/reader/components/BooksGrid.tsx
@@ -12,6 +12,7 @@ import { getViewInsets } from '@/utils/insets';
 import SearchResultsNav from './sidebar/SearchResultsNav';
 import BooknotesNav from './sidebar/BooknotesNav';
 import FoliateViewer from './FoliateViewer';
+import BookSessionTracker from './BookSessionTracker';
 import SectionInfo from './SectionInfo';
 import HeaderBar from './HeaderBar';
 import FooterBar from './footerbar/FooterBar';
@@ -115,6 +116,7 @@ const BooksGrid: React.FC<BooksGridProps> = ({ bookKeys, onCloseBook }) => {
               appService?.hasRoundedWindow && 'rounded-window',
             )}
           >
+            <BookSessionTracker bookKey={bookKey} />
             {isBookmarked && !hoveredBookKey && <Ribbon width={`${horizontalGapPercent}%`} />}
             <HeaderBar
               bookKey={bookKey}

--- a/apps/readest-app/src/app/reader/components/StatisticsDebug.tsx
+++ b/apps/readest-app/src/app/reader/components/StatisticsDebug.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useStatisticsStore } from '@/store/statisticsStore';
+
+/**
+ * Temporary debug component for viewing statistics data.
+ * TODO: Remove this component before production release.
+ */
+const StatisticsDebug: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+
+  // Update timestamp every second when panel is open
+  useEffect(() => {
+    if (!isOpen) return;
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, [isOpen]);
+
+  const sessions = useStatisticsStore((state) => state.sessions);
+  const dailySummaries = useStatisticsStore((state) => state.dailySummaries);
+  const bookStats = useStatisticsStore((state) => state.bookStats);
+  const userStats = useStatisticsStore((state) => state.userStats);
+  const activeSessions = useStatisticsStore((state) => state.activeSessions);
+  const { getCalendarData, computeStreaks, recomputeAllStats } = useStatisticsStore();
+
+  const formatDuration = (seconds: number): string => {
+    const hours = Math.floor(seconds / 3600);
+    const mins = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+    if (hours > 0) {
+      return `${hours}h ${mins}m ${secs}s`;
+    }
+    return `${mins}m ${secs}s`;
+  };
+
+  const handleRefreshStreaks = () => {
+    computeStreaks();
+  };
+
+  const handleRecomputeAll = () => {
+    recomputeAllStats();
+  };
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={() => setIsOpen(true)}
+        className='fixed bottom-20 right-4 z-50 rounded-full bg-orange-500 px-3 py-1 text-xs font-bold text-white shadow-lg hover:bg-orange-600'
+        title='Open Statistics Debug'
+      >
+        📊 Stats
+      </button>
+    );
+  }
+
+  const calendarData = getCalendarData();
+  const activeSessionsList = Object.entries(activeSessions);
+
+  return (
+    <div className='fixed bottom-20 right-4 z-50 max-h-[70vh] w-96 overflow-auto rounded-lg border border-gray-300 bg-white p-4 text-xs shadow-xl dark:border-gray-600 dark:bg-gray-800'>
+      <div className='mb-3 flex items-center justify-between'>
+        <h3 className='text-sm font-bold'>📊 Statistics Debug</h3>
+        <button
+          onClick={() => setIsOpen(false)}
+          className='text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* User Stats */}
+      <section className='mb-3'>
+        <h4 className='mb-1 font-semibold text-blue-600 dark:text-blue-400'>User Stats</h4>
+        <div className='grid grid-cols-2 gap-1 text-gray-700 dark:text-gray-300'>
+          <span>Total Reading:</span>
+          <span className='font-mono'>{formatDuration(userStats.totalReadingTime)}</span>
+          <span>Sessions:</span>
+          <span className='font-mono'>{userStats.totalSessions}</span>
+          <span>Pages Read:</span>
+          <span className='font-mono'>{userStats.totalPagesRead}</span>
+          <span>Books Started:</span>
+          <span className='font-mono'>{userStats.totalBooksStarted}</span>
+          <span>Books Completed:</span>
+          <span className='font-mono'>{userStats.totalBooksCompleted}</span>
+          <span>Current Streak:</span>
+          <span className='font-mono'>{userStats.currentStreak} days</span>
+          <span>Longest Streak:</span>
+          <span className='font-mono'>{userStats.longestStreak} days</span>
+          <span>Last Read:</span>
+          <span className='font-mono'>{userStats.lastReadDate || 'Never'}</span>
+        </div>
+      </section>
+
+      {/* Active Sessions */}
+      <section className='mb-3'>
+        <h4 className='mb-1 font-semibold text-green-600 dark:text-green-400'>
+          Active Sessions ({activeSessionsList.length})
+        </h4>
+        {activeSessionsList.length === 0 ? (
+          <p className='italic text-gray-500'>No active sessions</p>
+        ) : (
+          <ul className='space-y-1'>
+            {activeSessionsList.map(([key, session]) => (
+              <li key={key} className='rounded bg-green-50 p-1 dark:bg-green-900/30'>
+                <div className='font-mono text-[10px]'>{key.slice(0, 20)}...</div>
+                <div className='text-gray-600 dark:text-gray-400'>
+                  Page {session.startPage} → {session.lastPage} | Started{' '}
+                  {Math.floor((now - session.startTime) / 1000)}s ago
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Recent Sessions */}
+      <section className='mb-3'>
+        <h4 className='mb-1 font-semibold text-purple-600 dark:text-purple-400'>
+          Recent Sessions ({sessions.length} total)
+        </h4>
+        {sessions.length === 0 ? (
+          <p className='italic text-gray-500'>No completed sessions</p>
+        ) : (
+          <ul className='space-y-1'>
+            {sessions
+              .slice(-5)
+              .reverse()
+              .map((session) => (
+                <li key={session.id} className='rounded bg-purple-50 p-1 dark:bg-purple-900/30'>
+                  <div className='font-mono text-[10px]'>{session.bookHash.slice(0, 16)}...</div>
+                  <div className='text-gray-600 dark:text-gray-400'>
+                    {formatDuration(session.duration)} | Pages {session.startPage}-{session.endPage}{' '}
+                    | {new Date(session.startTime).toLocaleTimeString()}
+                  </div>
+                </li>
+              ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Daily Summaries */}
+      <section className='mb-3'>
+        <h4 className='mb-1 font-semibold text-orange-600 dark:text-orange-400'>
+          Daily Summaries ({Object.keys(dailySummaries).length} days)
+        </h4>
+        {Object.keys(dailySummaries).length === 0 ? (
+          <p className='italic text-gray-500'>No daily data</p>
+        ) : (
+          <ul className='space-y-1'>
+            {Object.entries(dailySummaries)
+              .sort(([a], [b]) => b.localeCompare(a))
+              .slice(0, 5)
+              .map(([date, summary]) => (
+                <li key={date} className='rounded bg-orange-50 p-1 dark:bg-orange-900/30'>
+                  <span className='font-mono'>{date}</span>:{' '}
+                  <span className='text-gray-600 dark:text-gray-400'>
+                    {formatDuration(summary.totalDuration)} | {summary.sessionsCount} sessions |{' '}
+                    {summary.totalPages} pages
+                  </span>
+                </li>
+              ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Book Stats */}
+      <section className='mb-3'>
+        <h4 className='mb-1 font-semibold text-teal-600 dark:text-teal-400'>
+          Book Stats ({Object.keys(bookStats).length} books)
+        </h4>
+        {Object.keys(bookStats).length === 0 ? (
+          <p className='italic text-gray-500'>No book stats</p>
+        ) : (
+          <ul className='space-y-1'>
+            {Object.entries(bookStats)
+              .slice(0, 3)
+              .map(([hash, stats]) => (
+                <li key={hash} className='rounded bg-teal-50 p-1 dark:bg-teal-900/30'>
+                  <div className='font-mono text-[10px]'>{hash.slice(0, 16)}...</div>
+                  <div className='text-gray-600 dark:text-gray-400'>
+                    {formatDuration(stats.totalReadingTime)} | {stats.totalSessions} sessions |{' '}
+                    {stats.totalPagesRead} pages
+                  </div>
+                </li>
+              ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Calendar Data (current year) */}
+      <section className='mb-3'>
+        <h4 className='mb-1 font-semibold text-indigo-600 dark:text-indigo-400'>
+          Calendar Data ({Object.keys(calendarData).length} days this year)
+        </h4>
+        {Object.keys(calendarData).length === 0 ? (
+          <p className='italic text-gray-500'>No calendar data</p>
+        ) : (
+          <div className='font-mono text-[10px] text-gray-600 dark:text-gray-400'>
+            {Object.entries(calendarData)
+              .sort(([a], [b]) => b.localeCompare(a))
+              .slice(0, 5)
+              .map(([date, duration]) => `${date}: ${formatDuration(duration)}`)
+              .join(' | ')}
+          </div>
+        )}
+      </section>
+
+      {/* Actions */}
+      <section className='flex gap-2 border-t border-gray-200 pt-2 dark:border-gray-600'>
+        <button
+          onClick={handleRefreshStreaks}
+          className='rounded bg-blue-500 px-2 py-1 text-white hover:bg-blue-600'
+        >
+          Refresh Streaks
+        </button>
+        <button
+          onClick={handleRecomputeAll}
+          className='rounded bg-red-500 px-2 py-1 text-white hover:bg-red-600'
+        >
+          Recompute All
+        </button>
+        <button
+          onClick={() => console.log(useStatisticsStore.getState())}
+          className='rounded bg-gray-500 px-2 py-1 text-white hover:bg-gray-600'
+        >
+          Log to Console
+        </button>
+      </section>
+    </div>
+  );
+};
+
+export default StatisticsDebug;

--- a/apps/readest-app/src/store/statisticsStore.ts
+++ b/apps/readest-app/src/store/statisticsStore.ts
@@ -37,6 +37,21 @@ const getDayOfWeek = (timestamp: number): number => {
   return new Date(timestamp).getDay();
 };
 
+// Helper to get days difference between two dates
+const getDaysDifference = (date1: string, date2: string): number => {
+  const d1 = new Date(date1);
+  const d2 = new Date(date2);
+  const diffTime = Math.abs(d2.getTime() - d1.getTime());
+  return Math.floor(diffTime / (1000 * 60 * 60 * 24));
+};
+
+// Helper to get yesterday's date string
+const getYesterdayString = (): string => {
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  return getDateString(yesterday.getTime());
+};
+
 interface StatisticsStore {
   // State
   sessions: ReadingSession[];
@@ -65,6 +80,11 @@ interface StatisticsStore {
   getDailySummary: (date: string) => DailyReadingSummary | null;
   getSessionsForBook: (bookHash: string, limit?: number) => ReadingSession[];
   getRecentSessions: (limit?: number) => ReadingSession[];
+  getCalendarData: (year?: number) => Record<string, number>;
+
+  // Aggregation
+  computeStreaks: () => void;
+  recomputeAllStats: () => void;
 
   // Persistence
   loadStatistics: (envConfig: EnvConfigType) => Promise<void>;
@@ -319,6 +339,215 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
     return get().sessions.slice(-limit).reverse();
   },
 
+  getCalendarData: (year) => {
+    const { dailySummaries } = get();
+    const targetYear = year ?? new Date().getFullYear();
+    const result: Record<string, number> = {};
+
+    // Get all dates for the target year
+    Object.entries(dailySummaries).forEach(([date, summary]) => {
+      if (date.startsWith(String(targetYear))) {
+        result[date] = summary.totalDuration;
+      }
+    });
+
+    return result;
+  },
+
+  computeStreaks: () => {
+    const { dailySummaries, userStats } = get();
+    const today = getDateString();
+    const yesterday = getYesterdayString();
+
+    // Get sorted dates that have reading activity
+    const readingDates = Object.keys(dailySummaries)
+      .filter((date) => dailySummaries[date]!.totalDuration > 0)
+      .sort();
+
+    if (readingDates.length === 0) {
+      set((state) => ({
+        userStats: {
+          ...state.userStats,
+          currentStreak: 0,
+          longestStreak: 0,
+        },
+      }));
+      return;
+    }
+
+    // Calculate current streak (must include today or yesterday)
+    let currentStreak = 0;
+    const lastReadDate = readingDates[readingDates.length - 1]!;
+
+    if (lastReadDate === today || lastReadDate === yesterday) {
+      currentStreak = 1;
+      let checkDate = lastReadDate;
+
+      // Count consecutive days backwards
+      for (let i = readingDates.length - 2; i >= 0; i--) {
+        const prevDate = readingDates[i]!;
+        const daysDiff = getDaysDifference(prevDate, checkDate);
+
+        if (daysDiff === 1) {
+          currentStreak++;
+          checkDate = prevDate;
+        } else {
+          break;
+        }
+      }
+    }
+
+    // Calculate longest streak
+    let longestStreak = 1;
+    let tempStreak = 1;
+
+    for (let i = 1; i < readingDates.length; i++) {
+      const daysDiff = getDaysDifference(readingDates[i - 1]!, readingDates[i]!);
+
+      if (daysDiff === 1) {
+        tempStreak++;
+        longestStreak = Math.max(longestStreak, tempStreak);
+      } else {
+        tempStreak = 1;
+      }
+    }
+
+    // Only update if values changed
+    if (currentStreak !== userStats.currentStreak || longestStreak !== userStats.longestStreak) {
+      set((state) => ({
+        userStats: {
+          ...state.userStats,
+          currentStreak,
+          longestStreak,
+        },
+      }));
+    }
+  },
+
+  recomputeAllStats: () => {
+    const { sessions } = get();
+
+    if (sessions.length === 0) {
+      set({
+        dailySummaries: {},
+        bookStats: {},
+        userStats: DEFAULT_USER_STATISTICS,
+      });
+      return;
+    }
+
+    // Rebuild daily summaries
+    const newDailySummaries: Record<string, DailyReadingSummary> = {};
+
+    // Rebuild book stats
+    const newBookStats: Record<string, BookStatistics> = {};
+
+    // Rebuild user stats
+    let totalReadingTime = 0;
+    let totalPagesRead = 0;
+    const uniqueBooks = new Set<string>();
+    const readingByHour = new Array(24).fill(0) as number[];
+    const readingByDayOfWeek = new Array(7).fill(0) as number[];
+
+    sessions.forEach((session) => {
+      const dateStr = getDateString(session.startTime);
+      const hour = getHour(session.startTime);
+      const dayOfWeek = getDayOfWeek(session.startTime);
+
+      // Update daily summary
+      const existing = newDailySummaries[dateStr];
+      if (existing) {
+        existing.totalDuration += session.duration;
+        existing.totalPages += session.pagesRead;
+        existing.sessionsCount += 1;
+        if (!existing.booksRead.includes(session.bookHash)) {
+          existing.booksRead.push(session.bookHash);
+        }
+      } else {
+        newDailySummaries[dateStr] = {
+          date: dateStr,
+          totalDuration: session.duration,
+          totalPages: session.pagesRead,
+          sessionsCount: 1,
+          booksRead: [session.bookHash],
+        };
+      }
+
+      // Update book stats
+      const bookStat = newBookStats[session.bookHash];
+      if (bookStat) {
+        bookStat.totalReadingTime += session.duration;
+        bookStat.totalSessions += 1;
+        bookStat.totalPagesRead += session.pagesRead;
+        bookStat.lastReadAt = Math.max(bookStat.lastReadAt, session.endTime);
+        if (session.endProgress >= 0.99 && !bookStat.completedAt) {
+          bookStat.completedAt = session.endTime;
+        }
+      } else {
+        newBookStats[session.bookHash] = {
+          bookHash: session.bookHash,
+          metaHash: session.metaHash,
+          totalReadingTime: session.duration,
+          totalSessions: 1,
+          totalPagesRead: session.pagesRead,
+          averageSessionDuration: session.duration,
+          averageReadingSpeed:
+            session.duration > 0 ? session.pagesRead / (session.duration / 3600) : 0,
+          firstReadAt: session.startTime,
+          lastReadAt: session.endTime,
+          completedAt: session.endProgress >= 0.99 ? session.endTime : undefined,
+        };
+      }
+
+      // Update user totals
+      totalReadingTime += session.duration;
+      totalPagesRead += session.pagesRead;
+      uniqueBooks.add(session.bookHash);
+      readingByHour[hour] += session.duration;
+      readingByDayOfWeek[dayOfWeek] += session.duration;
+    });
+
+    // Calculate averages for book stats
+    Object.values(newBookStats).forEach((stat) => {
+      stat.averageSessionDuration = stat.totalReadingTime / stat.totalSessions;
+      stat.averageReadingSpeed =
+        stat.totalReadingTime > 0 ? stat.totalPagesRead / (stat.totalReadingTime / 3600) : 0;
+    });
+
+    // Count completed books
+    const completedBooks = Object.values(newBookStats).filter((bs) => bs.completedAt).length;
+
+    // Calculate average daily reading time
+    const daysWithReading = Object.keys(newDailySummaries).length;
+    const averageDailyReadingTime = daysWithReading > 0 ? totalReadingTime / daysWithReading : 0;
+
+    // Get last read date
+    const sortedDates = Object.keys(newDailySummaries).sort();
+    const lastReadDate = sortedDates[sortedDates.length - 1] || '';
+
+    set({
+      dailySummaries: newDailySummaries,
+      bookStats: newBookStats,
+      userStats: {
+        totalReadingTime,
+        totalBooksStarted: uniqueBooks.size,
+        totalBooksCompleted: completedBooks,
+        totalPagesRead,
+        totalSessions: sessions.length,
+        currentStreak: 0, // Will be computed by computeStreaks
+        longestStreak: 0, // Will be computed by computeStreaks
+        lastReadDate,
+        averageSessionDuration: sessions.length > 0 ? totalReadingTime / sessions.length : 0,
+        averageDailyReadingTime,
+        readingByHour,
+        readingByDayOfWeek,
+      },
+    });
+
+    // Compute streaks after rebuilding
+    get().computeStreaks();
+  },
+
   loadStatistics: async (envConfig) => {
     try {
       const appService = await envConfig.getAppService();
@@ -341,6 +570,9 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
         config: { ...DEFAULT_STATISTICS_CONFIG, ...data.config },
         loaded: true,
       });
+
+      // Compute streaks on load (in case days have passed since last session)
+      get().computeStreaks();
 
       console.log(
         '[Statistics] Loaded statistics data, now have',

--- a/apps/readest-app/src/store/statisticsStore.ts
+++ b/apps/readest-app/src/store/statisticsStore.ts
@@ -1,0 +1,379 @@
+import { create } from 'zustand';
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  ReadingSession,
+  DailyReadingSummary,
+  BookStatistics,
+  UserStatistics,
+  StatisticsConfig,
+  ActiveSession,
+  StatisticsData,
+  DEFAULT_STATISTICS_CONFIG,
+  DEFAULT_USER_STATISTICS,
+  DEFAULT_STATISTICS_DATA,
+  CURRENT_STATISTICS_VERSION,
+} from '@/types/statistics';
+import { EnvConfigType } from '@/services/environment';
+
+const STATISTICS_FILENAME = 'statistics.json';
+
+// Helper to get date string in YYYY-MM-DD format (local timezone)
+const getDateString = (timestamp: number = Date.now()): string => {
+  const date = new Date(timestamp);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+// Helper to get hour from timestamp (0-23)
+const getHour = (timestamp: number): number => {
+  return new Date(timestamp).getHours();
+};
+
+// Helper to get day of week from timestamp (0=Sunday)
+const getDayOfWeek = (timestamp: number): number => {
+  return new Date(timestamp).getDay();
+};
+
+interface StatisticsStore {
+  // State
+  sessions: ReadingSession[];
+  dailySummaries: Record<string, DailyReadingSummary>;
+  bookStats: Record<string, BookStatistics>;
+  userStats: UserStatistics;
+  config: StatisticsConfig;
+  activeSessions: Record<string, ActiveSession>;
+  loaded: boolean;
+
+  // Session lifecycle
+  startSession: (
+    bookKey: string,
+    bookHash: string,
+    metaHash: string | undefined,
+    progress: number,
+    page: number,
+    totalPages: number,
+  ) => void;
+  updateSessionActivity: (bookKey: string, progress: number, page: number) => void;
+  endSession: (bookKey: string, reason: 'closed' | 'idle' | 'switched') => ReadingSession | null;
+  endAllSessions: () => void;
+
+  // Data access
+  getBookStatistics: (bookHash: string) => BookStatistics | null;
+  getDailySummary: (date: string) => DailyReadingSummary | null;
+  getSessionsForBook: (bookHash: string, limit?: number) => ReadingSession[];
+  getRecentSessions: (limit?: number) => ReadingSession[];
+
+  // Persistence
+  loadStatistics: (envConfig: EnvConfigType) => Promise<void>;
+  saveStatistics: (envConfig: EnvConfigType) => Promise<void>;
+
+  // Config
+  setConfig: (config: Partial<StatisticsConfig>) => void;
+}
+
+export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
+  sessions: [],
+  dailySummaries: {},
+  bookStats: {},
+  userStats: DEFAULT_USER_STATISTICS,
+  config: DEFAULT_STATISTICS_CONFIG,
+  activeSessions: {},
+  loaded: false,
+
+  startSession: (bookKey, bookHash, metaHash, progress, page, totalPages) => {
+    const { config, activeSessions } = get();
+    if (!config.trackingEnabled) return;
+
+    // If there's already an active session for this book key, don't start a new one
+    if (activeSessions[bookKey]) {
+      return;
+    }
+
+    const now = Date.now();
+    const session: ActiveSession = {
+      bookKey,
+      bookHash,
+      metaHash,
+      startTime: now,
+      startProgress: progress,
+      startPage: page,
+      lastActivityTime: now,
+      lastProgress: progress,
+      lastPage: page,
+      totalPages,
+    };
+
+    set((state) => ({
+      activeSessions: {
+        ...state.activeSessions,
+        [bookKey]: session,
+      },
+    }));
+
+    console.log('[Statistics] Started session for', bookKey, 'at page', page);
+  },
+
+  updateSessionActivity: (bookKey, progress, page) => {
+    const { activeSessions, config } = get();
+    if (!config.trackingEnabled) return;
+
+    const session = activeSessions[bookKey];
+    if (!session) return;
+
+    set((state) => ({
+      activeSessions: {
+        ...state.activeSessions,
+        [bookKey]: {
+          ...session,
+          lastActivityTime: Date.now(),
+          lastProgress: progress,
+          lastPage: page,
+        },
+      },
+    }));
+  },
+
+  endSession: (bookKey, _reason) => {
+    const { activeSessions, config, dailySummaries, bookStats } = get();
+    if (!config.trackingEnabled) return null;
+
+    const activeSession = activeSessions[bookKey];
+    if (!activeSession) return null;
+
+    const now = Date.now();
+    const duration = Math.floor((now - activeSession.startTime) / 1000);
+
+    // Don't record sessions shorter than minimum
+    if (duration < config.minimumSessionSeconds) {
+      set((state) => {
+        const newActiveSessions = { ...state.activeSessions };
+        delete newActiveSessions[bookKey];
+        return { activeSessions: newActiveSessions };
+      });
+      console.log('[Statistics] Session too short, discarding', duration, 'seconds');
+      return null;
+    }
+
+    const pagesRead = Math.max(0, activeSession.lastPage - activeSession.startPage);
+
+    const session: ReadingSession = {
+      id: uuidv4(),
+      bookHash: activeSession.bookHash,
+      metaHash: activeSession.metaHash,
+      startTime: activeSession.startTime,
+      endTime: now,
+      duration,
+      startProgress: activeSession.startProgress,
+      endProgress: activeSession.lastProgress,
+      startPage: activeSession.startPage,
+      endPage: activeSession.lastPage,
+      pagesRead,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    // Update daily summary
+    const dateStr = getDateString(activeSession.startTime);
+    const existingSummary = dailySummaries[dateStr];
+    const updatedSummary: DailyReadingSummary = existingSummary
+      ? {
+          ...existingSummary,
+          totalDuration: existingSummary.totalDuration + duration,
+          totalPages: existingSummary.totalPages + pagesRead,
+          sessionsCount: existingSummary.sessionsCount + 1,
+          booksRead: existingSummary.booksRead.includes(session.bookHash)
+            ? existingSummary.booksRead
+            : [...existingSummary.booksRead, session.bookHash],
+        }
+      : {
+          date: dateStr,
+          totalDuration: duration,
+          totalPages: pagesRead,
+          sessionsCount: 1,
+          booksRead: [session.bookHash],
+        };
+
+    // Update book statistics
+    const existingBookStats = bookStats[session.bookHash];
+    const updatedBookStats: BookStatistics = existingBookStats
+      ? {
+          ...existingBookStats,
+          totalReadingTime: existingBookStats.totalReadingTime + duration,
+          totalSessions: existingBookStats.totalSessions + 1,
+          totalPagesRead: existingBookStats.totalPagesRead + pagesRead,
+          averageSessionDuration:
+            (existingBookStats.totalReadingTime + duration) / (existingBookStats.totalSessions + 1),
+          averageReadingSpeed:
+            (existingBookStats.totalPagesRead + pagesRead) /
+            ((existingBookStats.totalReadingTime + duration) / 3600),
+          lastReadAt: now,
+          completedAt: session.endProgress >= 0.99 ? now : existingBookStats.completedAt,
+        }
+      : {
+          bookHash: session.bookHash,
+          metaHash: session.metaHash,
+          totalReadingTime: duration,
+          totalSessions: 1,
+          totalPagesRead: pagesRead,
+          averageSessionDuration: duration,
+          averageReadingSpeed: pagesRead / (duration / 3600) || 0,
+          firstReadAt: now,
+          lastReadAt: now,
+          completedAt: session.endProgress >= 0.99 ? now : undefined,
+        };
+
+    set((state) => {
+      const newActiveSessions = { ...state.activeSessions };
+      delete newActiveSessions[bookKey];
+
+      // Update user stats
+      const hour = getHour(activeSession.startTime);
+      const dayOfWeek = getDayOfWeek(activeSession.startTime);
+      const newReadingByHour = [...state.userStats.readingByHour];
+      const newReadingByDayOfWeek = [...state.userStats.readingByDayOfWeek];
+      newReadingByHour[hour] = (newReadingByHour[hour] || 0) + duration;
+      newReadingByDayOfWeek[dayOfWeek] = (newReadingByDayOfWeek[dayOfWeek] || 0) + duration;
+
+      const newTotalReadingTime = state.userStats.totalReadingTime + duration;
+      const newTotalSessions = state.userStats.totalSessions + 1;
+      const newTotalPagesRead = state.userStats.totalPagesRead + pagesRead;
+
+      // Count unique books started
+      const uniqueBooks = new Set(state.sessions.map((s) => s.bookHash));
+      uniqueBooks.add(session.bookHash);
+
+      // Count completed books
+      const completedBooks = Object.values({
+        ...state.bookStats,
+        [session.bookHash]: updatedBookStats,
+      }).filter((bs) => bs.completedAt).length;
+
+      return {
+        activeSessions: newActiveSessions,
+        sessions: [...state.sessions, session],
+        dailySummaries: {
+          ...state.dailySummaries,
+          [dateStr]: updatedSummary,
+        },
+        bookStats: {
+          ...state.bookStats,
+          [session.bookHash]: updatedBookStats,
+        },
+        userStats: {
+          ...state.userStats,
+          totalReadingTime: newTotalReadingTime,
+          totalSessions: newTotalSessions,
+          totalPagesRead: newTotalPagesRead,
+          totalBooksStarted: uniqueBooks.size,
+          totalBooksCompleted: completedBooks,
+          averageSessionDuration: newTotalReadingTime / newTotalSessions,
+          lastReadDate: dateStr,
+          readingByHour: newReadingByHour,
+          readingByDayOfWeek: newReadingByDayOfWeek,
+        },
+      };
+    });
+
+    console.log('[Statistics] Ended session for', bookKey, 'duration:', duration, 'seconds');
+    return session;
+  },
+
+  endAllSessions: () => {
+    const { activeSessions, endSession } = get();
+    Object.keys(activeSessions).forEach((bookKey) => {
+      endSession(bookKey, 'closed');
+    });
+  },
+
+  getBookStatistics: (bookHash) => {
+    return get().bookStats[bookHash] || null;
+  },
+
+  getDailySummary: (date) => {
+    return get().dailySummaries[date] || null;
+  },
+
+  getSessionsForBook: (bookHash, limit = 100) => {
+    return get()
+      .sessions.filter((s) => s.bookHash === bookHash)
+      .slice(-limit);
+  },
+
+  getRecentSessions: (limit = 10) => {
+    return get().sessions.slice(-limit).reverse();
+  },
+
+  loadStatistics: async (envConfig) => {
+    try {
+      const appService = await envConfig.getAppService();
+      let data: StatisticsData;
+
+      if (await appService.exists(STATISTICS_FILENAME, 'Settings')) {
+        const content = await appService.readFile(STATISTICS_FILENAME, 'Settings', 'text');
+        data = JSON.parse(content as string) as StatisticsData;
+        console.log('[Statistics] Loaded from file:', data.sessions?.length || 0, 'sessions');
+      } else {
+        data = DEFAULT_STATISTICS_DATA;
+        console.log('[Statistics] No file found, using defaults');
+      }
+
+      set({
+        sessions: data.sessions || [],
+        dailySummaries: data.dailySummaries || {},
+        bookStats: data.bookStats || {},
+        userStats: { ...DEFAULT_USER_STATISTICS, ...data.userStats },
+        config: { ...DEFAULT_STATISTICS_CONFIG, ...data.config },
+        loaded: true,
+      });
+
+      console.log(
+        '[Statistics] Loaded statistics data, now have',
+        get().sessions.length,
+        'sessions',
+      );
+    } catch (error) {
+      console.error('[Statistics] Failed to load statistics:', error);
+      set({
+        ...DEFAULT_STATISTICS_DATA,
+        loaded: true,
+      });
+    }
+  },
+
+  saveStatistics: async (envConfig) => {
+    try {
+      const appService = await envConfig.getAppService();
+      const { sessions, dailySummaries, bookStats, userStats, config } = get();
+
+      console.log('[Statistics] Saving with', sessions.length, 'sessions');
+
+      const data: StatisticsData = {
+        version: CURRENT_STATISTICS_VERSION,
+        sessions,
+        dailySummaries,
+        bookStats,
+        userStats,
+        config,
+        lastUpdated: Date.now(),
+      };
+
+      await appService.writeFile(STATISTICS_FILENAME, 'Settings', JSON.stringify(data, null, 2));
+
+      console.log('[Statistics] Saved statistics data successfully');
+    } catch (error) {
+      console.error('[Statistics] Failed to save statistics:', error);
+    }
+  },
+
+  setConfig: (configUpdate) => {
+    set((state) => ({
+      config: {
+        ...state.config,
+        ...configUpdate,
+      },
+    }));
+  },
+}));

--- a/apps/readest-app/src/store/statisticsStore.ts
+++ b/apps/readest-app/src/store/statisticsStore.ts
@@ -503,8 +503,8 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
       totalReadingTime += session.duration;
       totalPagesRead += session.pagesRead;
       uniqueBooks.add(session.bookHash);
-      readingByHour[hour] += session.duration;
-      readingByDayOfWeek[dayOfWeek] += session.duration;
+      readingByHour[hour] = (readingByHour[hour] ?? 0) + session.duration;
+      readingByDayOfWeek[dayOfWeek] = (readingByDayOfWeek[dayOfWeek] ?? 0) + session.duration;
     });
 
     // Calculate averages for book stats

--- a/apps/readest-app/src/store/statisticsStore.ts
+++ b/apps/readest-app/src/store/statisticsStore.ts
@@ -136,7 +136,7 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
     }));
   },
 
-  endSession: (bookKey, _reason) => {
+  endSession: (bookKey, reason) => {
     const { activeSessions, config, dailySummaries, bookStats } = get();
     if (!config.trackingEnabled) return null;
 
@@ -153,7 +153,12 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
         delete newActiveSessions[bookKey];
         return { activeSessions: newActiveSessions };
       });
-      console.log('[Statistics] Session too short, discarding', duration, 'seconds');
+      console.log(
+        '[Statistics] Session too short, discarding',
+        duration,
+        'seconds, reason:',
+        reason,
+      );
       return null;
     }
 
@@ -219,7 +224,7 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
           totalSessions: 1,
           totalPagesRead: pagesRead,
           averageSessionDuration: duration,
-          averageReadingSpeed: pagesRead / (duration / 3600) || 0,
+          averageReadingSpeed: duration > 0 ? pagesRead / (duration / 3600) : 0,
           firstReadAt: now,
           lastReadAt: now,
           completedAt: session.endProgress >= 0.99 ? now : undefined,
@@ -277,7 +282,15 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
       };
     });
 
-    console.log('[Statistics] Ended session for', bookKey, 'duration:', duration, 'seconds');
+    console.log(
+      '[Statistics] Ended session for',
+      bookKey,
+      'reason:',
+      reason,
+      'duration:',
+      duration,
+      'seconds',
+    );
     return session;
   },
 

--- a/apps/readest-app/src/types/statistics.ts
+++ b/apps/readest-app/src/types/statistics.ts
@@ -1,0 +1,127 @@
+// Reading session - individual reading period for a book
+export interface ReadingSession {
+  id: string; // UUID
+  bookHash: string; // Book identifier
+  metaHash?: string; // For aggregating book versions
+
+  startTime: number; // Session start (ms timestamp)
+  endTime: number; // Session end (ms timestamp)
+  duration: number; // Duration in seconds
+
+  startProgress: number; // Progress at start (0-1)
+  endProgress: number; // Progress at end (0-1)
+  startPage: number; // Page at start
+  endPage: number; // Page at end
+  pagesRead: number; // Pages read in session
+
+  createdAt: number;
+  updatedAt: number;
+}
+
+// Daily reading summary
+export interface DailyReadingSummary {
+  date: string; // YYYY-MM-DD
+  totalDuration: number; // Seconds read
+  totalPages: number;
+  sessionsCount: number;
+  booksRead: string[]; // Book hashes
+}
+
+// Book-specific statistics
+export interface BookStatistics {
+  bookHash: string;
+  metaHash?: string;
+  totalReadingTime: number; // Seconds
+  totalSessions: number;
+  totalPagesRead: number;
+  averageSessionDuration: number;
+  averageReadingSpeed: number; // Pages per hour
+  firstReadAt: number;
+  lastReadAt: number;
+  completedAt?: number;
+}
+
+// User statistics
+export interface UserStatistics {
+  totalReadingTime: number;
+  totalBooksStarted: number;
+  totalBooksCompleted: number;
+  totalPagesRead: number;
+  totalSessions: number;
+
+  currentStreak: number; // Consecutive days
+  longestStreak: number;
+  lastReadDate: string; // YYYY-MM-DD
+
+  averageSessionDuration: number;
+  averageDailyReadingTime: number;
+
+  readingByHour: number[]; // 24 elements (0-23)
+  readingByDayOfWeek: number[]; // 7 elements (0=Sunday)
+}
+
+// Configuration
+export interface StatisticsConfig {
+  trackingEnabled: boolean;
+  idleTimeoutMinutes: number; // Default: 5
+  minimumSessionSeconds: number; // Default: 30
+}
+
+// Active session tracking (not persisted)
+export interface ActiveSession {
+  bookKey: string;
+  bookHash: string;
+  metaHash?: string;
+  startTime: number;
+  startProgress: number;
+  startPage: number;
+  lastActivityTime: number;
+  lastProgress: number;
+  lastPage: number;
+  totalPages: number;
+}
+
+// Storage format
+export interface StatisticsData {
+  version: number;
+  sessions: ReadingSession[];
+  dailySummaries: Record<string, DailyReadingSummary>;
+  bookStats: Record<string, BookStatistics>;
+  userStats: UserStatistics;
+  config: StatisticsConfig;
+  lastUpdated: number;
+}
+
+// Default values
+export const DEFAULT_STATISTICS_CONFIG: StatisticsConfig = {
+  trackingEnabled: true,
+  idleTimeoutMinutes: 5,
+  minimumSessionSeconds: 30,
+};
+
+export const DEFAULT_USER_STATISTICS: UserStatistics = {
+  totalReadingTime: 0,
+  totalBooksStarted: 0,
+  totalBooksCompleted: 0,
+  totalPagesRead: 0,
+  totalSessions: 0,
+  currentStreak: 0,
+  longestStreak: 0,
+  lastReadDate: '',
+  averageSessionDuration: 0,
+  averageDailyReadingTime: 0,
+  readingByHour: new Array(24).fill(0),
+  readingByDayOfWeek: new Array(7).fill(0),
+};
+
+export const CURRENT_STATISTICS_VERSION = 1;
+
+export const DEFAULT_STATISTICS_DATA: StatisticsData = {
+  version: CURRENT_STATISTICS_VERSION,
+  sessions: [],
+  dailySummaries: {},
+  bookStats: {},
+  userStats: DEFAULT_USER_STATISTICS,
+  config: DEFAULT_STATISTICS_CONFIG,
+  lastUpdated: Date.now(),
+};


### PR DESCRIPTION
## Summary

Adds Phase 2 of the reading statistics feature: aggregation methods for computing derived statistics from session data.

**Depends on:** PR #3156 (Phase 1 - Session Tracking) - this PR should be merged after Phase 1

## Changes

Three new methods added to `statisticsStore.ts`:

1. **`getCalendarData(year?)`** - Returns a `Record<string, number>` of date → reading duration for displaying calendar heatmaps or activity visualizations

2. **`computeStreaks()`** - Calculates current and longest reading streaks:
   - Current streak: consecutive days ending today or yesterday
   - Longest streak: historical maximum consecutive reading days
   - Updates `userStats.currentStreak` and `userStats.longestStreak`

3. **`recomputeAllStats()`** - Rebuilds all aggregated statistics from the raw sessions array:
   - Useful for data migration, corruption recovery, or recalculating after session deletions
   - Rebuilds: `dailySummaries`, `bookStats`, and `userStats`
   - Automatically calls `computeStreaks()` after rebuilding

## Implementation Details

- Added helper functions: `getDaysDifference()` and `getYesterdayString()`
- `computeStreaks()` is now called during `loadStatistics()` to update streak data when the app starts (handles cases where days have passed since last session)
- All methods follow existing Zustand patterns with immutable state updates

## Testing

- All existing tests pass
- Methods can be tested via console in dev tools:
  ```js
  const stats = useStatisticsStore.getState();
  stats.getCalendarData(2025);  // Get year's reading data
  stats.computeStreaks();        // Recalculate streaks
  stats.recomputeAllStats();     // Full rebuild
  ```

