### PR TITLE
feat(statistics): Phase 3 - Statistics UI Page

### DIFF
--- a/apps/readest-app/src/app/library/components/SettingsMenu.tsx
+++ b/apps/readest-app/src/app/library/components/SettingsMenu.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { PiUserCircle, PiUserCircleCheck, PiGear } from 'react-icons/pi';
+import { PiUserCircle, PiUserCircleCheck, PiGear, PiChartBar } from 'react-icons/pi';
 import { PiSun, PiMoon } from 'react-icons/pi';
 import { TbSunMoon } from 'react-icons/tb';
 import { MdCloudSync } from 'react-icons/md';
@@ -184,6 +184,11 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ setIsDropdownOpen }) => {
     setSettingsDialogOpen(true);
   };
 
+  const openStatistics = () => {
+    router.push('/statistics');
+    setIsDropdownOpen?.(false);
+  };
+
   const handleSetSavedBookCoverForLockScreen = async () => {
     if (!(await requestStoragePermission()) && appService?.distChannel === 'readest') return;
 
@@ -349,6 +354,7 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ setIsDropdownOpen }) => {
         Icon={themeMode === 'dark' ? PiMoon : themeMode === 'light' ? PiSun : TbSunMoon}
         onClick={cycleThemeMode}
       />
+      <MenuItem label={_('Reading Statistics')} Icon={PiChartBar} onClick={openStatistics} />
       <MenuItem label={_('Settings')} Icon={PiGear} onClick={openSettingsDialog} />
       {appService?.canCustomizeRootDir && (
         <>

--- a/apps/readest-app/src/app/reader/components/BookSessionTracker.tsx
+++ b/apps/readest-app/src/app/reader/components/BookSessionTracker.tsx
@@ -22,7 +22,7 @@ const BookSessionTracker: React.FC<BookSessionTrackerProps> = ({ bookKey }) => {
   const { envConfig } = useEnv();
 
   // Extract book hash (id) from bookKey - bookDataStore uses id as key, not full bookKey
-  const bookId = bookKey.split('-')[0]!;
+  const bookId = bookKey.split('-')[0] ?? bookKey;
 
   // Subscribe to actual data values (not getter functions) so effects re-run when data changes
   const viewState = useReaderStore((state) => state.viewStates[bookKey]);

--- a/apps/readest-app/src/app/reader/components/BookSessionTracker.tsx
+++ b/apps/readest-app/src/app/reader/components/BookSessionTracker.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useEnv } from '@/context/EnvContext';
+import { useReaderStore } from '@/store/readerStore';
+import { useBookDataStore } from '@/store/bookDataStore';
+import { useStatisticsStore } from '@/store/statisticsStore';
+
+interface BookSessionTrackerProps {
+  bookKey: string;
+}
+
+/**
+ * Component that tracks reading sessions for a specific book.
+ * This component doesn't render anything visible, it just manages
+ * the reading session lifecycle for statistics tracking.
+ */
+const BookSessionTracker: React.FC<BookSessionTrackerProps> = ({ bookKey }) => {
+  const { envConfig } = useEnv();
+
+  // Extract book hash (id) from bookKey - bookDataStore uses id as key, not full bookKey
+  const bookId = bookKey.split('-')[0]!;
+
+  // Subscribe to actual data values (not getter functions) so effects re-run when data changes
+  const viewState = useReaderStore((state) => state.viewStates[bookKey]);
+  const bookData = useBookDataStore((state) => state.booksData[bookId]);
+  const progress = useReaderStore((state) => state.viewStates[bookKey]?.progress);
+
+  // Subscribe to specific values to ensure re-renders when they change
+  const config = useStatisticsStore((state) => state.config);
+  const loaded = useStatisticsStore((state) => state.loaded);
+  const { startSession, updateSessionActivity, endSession, saveStatistics } = useStatisticsStore();
+
+  const IDLE_TIMEOUT_MS = (config.idleTimeoutMinutes || 5) * 60 * 1000;
+
+  // Start session when the book view is initialized
+  useEffect(() => {
+    console.log('[BookSessionTracker] Effect check for', bookKey, {
+      trackingEnabled: config.trackingEnabled,
+      loaded,
+      viewStateInited: viewState?.inited,
+      hasBookData: !!bookData,
+      hasBook: !!bookData?.book,
+      bookId,
+    });
+
+    if (!config.trackingEnabled || !loaded) {
+      console.log('[BookSessionTracker] Early return: tracking disabled or not loaded');
+      return;
+    }
+
+    // Wait for the view to be initialized
+    if (!viewState?.inited || !bookData?.book) {
+      console.log('[BookSessionTracker] Early return: view not inited or no book data');
+      return;
+    }
+
+    // Don't start if session already exists - use getState() to avoid dependency on activeSessions
+    const currentActiveSessions = useStatisticsStore.getState().activeSessions;
+    if (currentActiveSessions[bookKey]) {
+      console.log('[BookSessionTracker] Session already exists for', bookKey);
+      return;
+    }
+
+    const metaHash = bookData.book.metaHash;
+    const pageInfo = progress?.pageinfo;
+    const currentPage = pageInfo?.current || 1;
+    const totalPages = pageInfo?.total || 1;
+    const progressPercent = totalPages > 0 ? currentPage / totalPages : 0;
+
+    startSession(bookKey, bookId, metaHash, progressPercent, currentPage, totalPages);
+
+    console.log('[BookSessionTracker] Started session for', bookKey, 'bookId:', bookId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    bookKey,
+    bookId,
+    config.trackingEnabled,
+    loaded,
+    viewState?.inited,
+    bookData?.book,
+    progress?.pageinfo,
+    startSession,
+  ]);
+
+  // Track progress changes and reset idle timer
+  useEffect(() => {
+    if (!config.trackingEnabled || !loaded) return;
+
+    // Check for active session using getState() to avoid dependency loops
+    const currentActiveSessions = useStatisticsStore.getState().activeSessions;
+    if (!currentActiveSessions[bookKey]) return;
+
+    if (!progress?.pageinfo) return;
+
+    const pageInfo = progress.pageinfo;
+    const currentPage = pageInfo.current || 1;
+    const totalPages = pageInfo.total || 1;
+    const progressPercent = totalPages > 0 ? currentPage / totalPages : 0;
+
+    updateSessionActivity(bookKey, progressPercent, currentPage);
+  }, [bookKey, config.trackingEnabled, loaded, progress?.pageinfo, updateSessionActivity]);
+
+  // Idle timeout handler - reset timer when progress changes
+  useEffect(() => {
+    if (!config.trackingEnabled || !loaded) return;
+
+    // Check for active session using getState()
+    const currentActiveSessions = useStatisticsStore.getState().activeSessions;
+    if (!currentActiveSessions[bookKey]) return;
+
+    const idleTimer = setTimeout(async () => {
+      console.log('[BookSessionTracker] Idle timeout for', bookKey);
+      const session = endSession(bookKey, 'idle');
+      if (session) {
+        console.log('[BookSessionTracker] Saving after idle timeout...');
+        await saveStatistics(envConfig);
+        console.log('[BookSessionTracker] Save completed after idle timeout');
+      }
+    }, IDLE_TIMEOUT_MS);
+
+    return () => clearTimeout(idleTimer);
+  }, [
+    bookKey,
+    config.trackingEnabled,
+    loaded,
+    progress?.pageinfo,
+    endSession,
+    saveStatistics,
+    envConfig,
+    IDLE_TIMEOUT_MS,
+  ]);
+
+  // Handle visibility change (for mobile background)
+  useEffect(() => {
+    if (!config.trackingEnabled || !loaded) return;
+
+    const handleVisibilityChange = () => {
+      // Get fresh state from stores when visibility changes
+      const { activeSessions, loaded: statsLoaded } = useStatisticsStore.getState();
+
+      // Don't handle visibility changes if statistics aren't loaded
+      if (!statsLoaded) return;
+
+      if (document.visibilityState === 'hidden') {
+        if (activeSessions[bookKey]) {
+          console.log('[BookSessionTracker] App hidden, ending session for', bookKey);
+          const session = endSession(bookKey, 'idle');
+          if (session) {
+            saveStatistics(envConfig);
+          }
+        }
+      } else if (document.visibilityState === 'visible') {
+        const currentViewState = useReaderStore.getState().viewStates[bookKey];
+        const currentBookData = useBookDataStore.getState().booksData[bookId];
+        const currentProgress = currentViewState?.progress;
+
+        if (currentViewState?.inited && currentBookData?.book && !activeSessions[bookKey]) {
+          console.log('[BookSessionTracker] App visible, restarting session for', bookKey);
+          const metaHash = currentBookData.book.metaHash;
+          const pageInfo = currentProgress?.pageinfo;
+          const currentPage = pageInfo?.current || 1;
+          const totalPages = pageInfo?.total || 1;
+          const progressPercent = totalPages > 0 ? currentPage / totalPages : 0;
+
+          startSession(bookKey, bookId, metaHash, progressPercent, currentPage, totalPages);
+        }
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [
+    bookKey,
+    bookId,
+    config.trackingEnabled,
+    loaded,
+    endSession,
+    startSession,
+    saveStatistics,
+    envConfig,
+  ]);
+
+  // End session when component unmounts (book closed)
+  useEffect(() => {
+    return () => {
+      // Use getState() to get fresh state during cleanup
+      const currentActiveSessions = useStatisticsStore.getState().activeSessions;
+      if (currentActiveSessions[bookKey]) {
+        console.log('[BookSessionTracker] Component unmounting, ending session for', bookKey);
+        const session = endSession(bookKey, 'closed');
+        if (session) {
+          saveStatistics(envConfig);
+        }
+      }
+    };
+  }, [bookKey, endSession, saveStatistics, envConfig]);
+
+  // This component doesn't render anything visible
+  return null;
+};
+
+export default BookSessionTracker;

--- a/apps/readest-app/src/app/reader/components/BooksGrid.tsx
+++ b/apps/readest-app/src/app/reader/components/BooksGrid.tsx
@@ -23,6 +23,7 @@ import FootnotePopup from './FootnotePopup';
 import HintInfo from './HintInfo';
 import ReadingRuler from './ReadingRuler';
 import DoubleBorder from './DoubleBorder';
+import StatisticsDebug from './StatisticsDebug';
 
 interface BooksGridProps {
   bookKeys: string[];
@@ -81,6 +82,8 @@ const BooksGrid: React.FC<BooksGridProps> = ({ bookKeys, onCloseBook }) => {
       role='main'
       aria-label={_('Books Content')}
     >
+      {/* TODO: Remove StatisticsDebug before production */}
+      {process.env['NODE_ENV'] === 'development' && <StatisticsDebug />}
       {bookKeys.map((bookKey, index) => {
         const bookData = getBookData(bookKey);
         const config = getConfig(bookKey);

--- a/apps/readest-app/src/app/reader/components/BooksGrid.tsx
+++ b/apps/readest-app/src/app/reader/components/BooksGrid.tsx
@@ -12,6 +12,7 @@ import { getViewInsets } from '@/utils/insets';
 import SearchResultsNav from './sidebar/SearchResultsNav';
 import BooknotesNav from './sidebar/BooknotesNav';
 import FoliateViewer from './FoliateViewer';
+import BookSessionTracker from './BookSessionTracker';
 import SectionInfo from './SectionInfo';
 import HeaderBar from './HeaderBar';
 import FooterBar from './footerbar/FooterBar';
@@ -115,6 +116,7 @@ const BooksGrid: React.FC<BooksGridProps> = ({ bookKeys, onCloseBook }) => {
               appService?.hasRoundedWindow && 'rounded-window',
             )}
           >
+            <BookSessionTracker bookKey={bookKey} />
             {isBookmarked && !hoveredBookKey && <Ribbon width={`${horizontalGapPercent}%`} />}
             <HeaderBar
               bookKey={bookKey}

--- a/apps/readest-app/src/app/reader/components/StatisticsDebug.tsx
+++ b/apps/readest-app/src/app/reader/components/StatisticsDebug.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useStatisticsStore } from '@/store/statisticsStore';
+
+/**
+ * Temporary debug component for viewing statistics data.
+ * TODO: Remove this component before production release.
+ */
+const StatisticsDebug: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+
+  // Update timestamp every second when panel is open
+  useEffect(() => {
+    if (!isOpen) return;
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, [isOpen]);
+
+  const sessions = useStatisticsStore((state) => state.sessions);
+  const dailySummaries = useStatisticsStore((state) => state.dailySummaries);
+  const bookStats = useStatisticsStore((state) => state.bookStats);
+  const userStats = useStatisticsStore((state) => state.userStats);
+  const activeSessions = useStatisticsStore((state) => state.activeSessions);
+  const { getCalendarData, computeStreaks, recomputeAllStats } = useStatisticsStore();
+
+  const formatDuration = (seconds: number): string => {
+    const hours = Math.floor(seconds / 3600);
+    const mins = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+    if (hours > 0) {
+      return `${hours}h ${mins}m ${secs}s`;
+    }
+    return `${mins}m ${secs}s`;
+  };
+
+  const handleRefreshStreaks = () => {
+    computeStreaks();
+  };
+
+  const handleRecomputeAll = () => {
+    recomputeAllStats();
+  };
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={() => setIsOpen(true)}
+        className='fixed bottom-20 right-4 z-50 rounded-full bg-orange-500 px-3 py-1 text-xs font-bold text-white shadow-lg hover:bg-orange-600'
+        title='Open Statistics Debug'
+      >
+        📊 Stats
+      </button>
+    );
+  }
+
+  const calendarData = getCalendarData();
+  const activeSessionsList = Object.entries(activeSessions);
+
+  return (
+    <div className='fixed bottom-20 right-4 z-50 max-h-[70vh] w-96 overflow-auto rounded-lg border border-gray-300 bg-white p-4 text-xs shadow-xl dark:border-gray-600 dark:bg-gray-800'>
+      <div className='mb-3 flex items-center justify-between'>
+        <h3 className='text-sm font-bold'>📊 Statistics Debug</h3>
+        <button
+          onClick={() => setIsOpen(false)}
+          className='text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* User Stats */}
+      <section className='mb-3'>
+        <h4 className='mb-1 font-semibold text-blue-600 dark:text-blue-400'>User Stats</h4>
+        <div className='grid grid-cols-2 gap-1 text-gray-700 dark:text-gray-300'>
+          <span>Total Reading:</span>
+          <span className='font-mono'>{formatDuration(userStats.totalReadingTime)}</span>
+          <span>Sessions:</span>
+          <span className='font-mono'>{userStats.totalSessions}</span>
+          <span>Pages Read:</span>
+          <span className='font-mono'>{userStats.totalPagesRead}</span>
+          <span>Books Started:</span>
+          <span className='font-mono'>{userStats.totalBooksStarted}</span>
+          <span>Books Completed:</span>
+          <span className='font-mono'>{userStats.totalBooksCompleted}</span>
+          <span>Current Streak:</span>
+          <span className='font-mono'>{userStats.currentStreak} days</span>
+          <span>Longest Streak:</span>
+          <span className='font-mono'>{userStats.longestStreak} days</span>
+          <span>Last Read:</span>
+          <span className='font-mono'>{userStats.lastReadDate || 'Never'}</span>
+        </div>
+      </section>
+
+      {/* Active Sessions */}
+      <section className='mb-3'>
+        <h4 className='mb-1 font-semibold text-green-600 dark:text-green-400'>
+          Active Sessions ({activeSessionsList.length})
+        </h4>
+        {activeSessionsList.length === 0 ? (
+          <p className='italic text-gray-500'>No active sessions</p>
+        ) : (
+          <ul className='space-y-1'>
+            {activeSessionsList.map(([key, session]) => (
+              <li key={key} className='rounded bg-green-50 p-1 dark:bg-green-900/30'>
+                <div className='font-mono text-[10px]'>{key.slice(0, 20)}...</div>
+                <div className='text-gray-600 dark:text-gray-400'>
+                  Page {session.startPage} → {session.lastPage} | Started{' '}
+                  {Math.floor((now - session.startTime) / 1000)}s ago
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Recent Sessions */}
+      <section className='mb-3'>
+        <h4 className='mb-1 font-semibold text-purple-600 dark:text-purple-400'>
+          Recent Sessions ({sessions.length} total)
+        </h4>
+        {sessions.length === 0 ? (
+          <p className='italic text-gray-500'>No completed sessions</p>
+        ) : (
+          <ul className='space-y-1'>
+            {sessions
+              .slice(-5)
+              .reverse()
+              .map((session) => (
+                <li key={session.id} className='rounded bg-purple-50 p-1 dark:bg-purple-900/30'>
+                  <div className='font-mono text-[10px]'>{session.bookHash.slice(0, 16)}...</div>
+                  <div className='text-gray-600 dark:text-gray-400'>
+                    {formatDuration(session.duration)} | Pages {session.startPage}-{session.endPage}{' '}
+                    | {new Date(session.startTime).toLocaleTimeString()}
+                  </div>
+                </li>
+              ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Daily Summaries */}
+      <section className='mb-3'>
+        <h4 className='mb-1 font-semibold text-orange-600 dark:text-orange-400'>
+          Daily Summaries ({Object.keys(dailySummaries).length} days)
+        </h4>
+        {Object.keys(dailySummaries).length === 0 ? (
+          <p className='italic text-gray-500'>No daily data</p>
+        ) : (
+          <ul className='space-y-1'>
+            {Object.entries(dailySummaries)
+              .sort(([a], [b]) => b.localeCompare(a))
+              .slice(0, 5)
+              .map(([date, summary]) => (
+                <li key={date} className='rounded bg-orange-50 p-1 dark:bg-orange-900/30'>
+                  <span className='font-mono'>{date}</span>:{' '}
+                  <span className='text-gray-600 dark:text-gray-400'>
+                    {formatDuration(summary.totalDuration)} | {summary.sessionsCount} sessions |{' '}
+                    {summary.totalPages} pages
+                  </span>
+                </li>
+              ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Book Stats */}
+      <section className='mb-3'>
+        <h4 className='mb-1 font-semibold text-teal-600 dark:text-teal-400'>
+          Book Stats ({Object.keys(bookStats).length} books)
+        </h4>
+        {Object.keys(bookStats).length === 0 ? (
+          <p className='italic text-gray-500'>No book stats</p>
+        ) : (
+          <ul className='space-y-1'>
+            {Object.entries(bookStats)
+              .slice(0, 3)
+              .map(([hash, stats]) => (
+                <li key={hash} className='rounded bg-teal-50 p-1 dark:bg-teal-900/30'>
+                  <div className='font-mono text-[10px]'>{hash.slice(0, 16)}...</div>
+                  <div className='text-gray-600 dark:text-gray-400'>
+                    {formatDuration(stats.totalReadingTime)} | {stats.totalSessions} sessions |{' '}
+                    {stats.totalPagesRead} pages
+                  </div>
+                </li>
+              ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Calendar Data (current year) */}
+      <section className='mb-3'>
+        <h4 className='mb-1 font-semibold text-indigo-600 dark:text-indigo-400'>
+          Calendar Data ({Object.keys(calendarData).length} days this year)
+        </h4>
+        {Object.keys(calendarData).length === 0 ? (
+          <p className='italic text-gray-500'>No calendar data</p>
+        ) : (
+          <div className='font-mono text-[10px] text-gray-600 dark:text-gray-400'>
+            {Object.entries(calendarData)
+              .sort(([a], [b]) => b.localeCompare(a))
+              .slice(0, 5)
+              .map(([date, duration]) => `${date}: ${formatDuration(duration)}`)
+              .join(' | ')}
+          </div>
+        )}
+      </section>
+
+      {/* Actions */}
+      <section className='flex gap-2 border-t border-gray-200 pt-2 dark:border-gray-600'>
+        <button
+          onClick={handleRefreshStreaks}
+          className='rounded bg-blue-500 px-2 py-1 text-white hover:bg-blue-600'
+        >
+          Refresh Streaks
+        </button>
+        <button
+          onClick={handleRecomputeAll}
+          className='rounded bg-red-500 px-2 py-1 text-white hover:bg-red-600'
+        >
+          Recompute All
+        </button>
+        <button
+          onClick={() => console.log(useStatisticsStore.getState())}
+          className='rounded bg-gray-500 px-2 py-1 text-white hover:bg-gray-600'
+        >
+          Log to Console
+        </button>
+      </section>
+    </div>
+  );
+};
+
+export default StatisticsDebug;

--- a/apps/readest-app/src/app/statistics/components/BookStats.tsx
+++ b/apps/readest-app/src/app/statistics/components/BookStats.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { PiClock, PiCalendar, PiCaretDown, PiBook } from 'react-icons/pi';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useLibraryStore } from '@/store/libraryStore';
+import { BookStatistics } from '@/types/statistics';
+import { Book } from '@/types/book';
+
+interface BookStatsProps {
+  bookStats: Record<string, BookStatistics>;
+}
+
+type SortField = 'lastReadAt' | 'totalReadingTime' | 'totalSessions';
+type SortOrder = 'asc' | 'desc';
+
+const formatDuration = (seconds: number): string => {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+};
+
+const formatDate = (timestamp: number): string => {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+};
+
+interface BookStatsItemProps {
+  book: Book | undefined;
+  stats: BookStatistics;
+}
+
+const BookStatsItem: React.FC<BookStatsItemProps> = ({ book, stats }) => {
+  const _ = useTranslation();
+
+  return (
+    <div className='bg-base-100 hover:bg-base-100/80 flex items-center gap-3 rounded-lg p-3 transition-colors'>
+      {/* Book cover or placeholder */}
+      <div className='bg-base-300 flex h-16 w-12 flex-shrink-0 items-center justify-center overflow-hidden rounded'>
+        {book?.coverImageUrl ? (
+          <img src={book.coverImageUrl} alt={book.title} className='h-full w-full object-cover' />
+        ) : (
+          <PiBook className='text-base-content/30' size={24} />
+        )}
+      </div>
+
+      {/* Book info */}
+      <div className='min-w-0 flex-1'>
+        <h4 className='text-base-content truncate text-sm font-medium'>
+          {book?.title || _('Unknown Book')}
+        </h4>
+        <p className='text-base-content/60 truncate text-xs'>{book?.author || '-'}</p>
+
+        <div className='mt-1 flex items-center gap-3 text-xs'>
+          <span className='text-base-content/50 flex items-center gap-1'>
+            <PiClock size={12} />
+            {formatDuration(stats.totalReadingTime)}
+          </span>
+          <span className='text-base-content/50 flex items-center gap-1'>
+            <PiCalendar size={12} />
+            {formatDate(stats.lastReadAt)}
+          </span>
+          {stats.completedAt && (
+            <span className='badge badge-success badge-xs'>{_('Completed')}</span>
+          )}
+        </div>
+      </div>
+
+      {/* Stats summary */}
+      <div className='text-right'>
+        <div className='text-base-content text-sm font-semibold'>
+          {stats.totalSessions} {stats.totalSessions === 1 ? _('session') : _('sessions')}
+        </div>
+        <div className='text-base-content/50 text-xs'>
+          {_('Avg: {{duration}}', { duration: formatDuration(stats.averageSessionDuration) })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const BookStats: React.FC<BookStatsProps> = ({ bookStats }) => {
+  const _ = useTranslation();
+  const { library } = useLibraryStore();
+  const [sortField, setSortField] = useState<SortField>('lastReadAt');
+  const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+  const [showAll, setShowAll] = useState(false);
+
+  const bookMap = useMemo(() => {
+    const map = new Map<string, Book>();
+    library.forEach((book) => map.set(book.hash, book));
+    return map;
+  }, [library]);
+
+  const sortedBooks = useMemo(() => {
+    const entries = Object.entries(bookStats);
+
+    entries.sort((a, b) => {
+      const [, statsA] = a;
+      const [, statsB] = b;
+
+      let comparison = 0;
+      switch (sortField) {
+        case 'lastReadAt':
+          comparison = statsA.lastReadAt - statsB.lastReadAt;
+          break;
+        case 'totalReadingTime':
+          comparison = statsA.totalReadingTime - statsB.totalReadingTime;
+          break;
+        case 'totalSessions':
+          comparison = statsA.totalSessions - statsB.totalSessions;
+          break;
+      }
+
+      return sortOrder === 'desc' ? -comparison : comparison;
+    });
+
+    return entries;
+  }, [bookStats, sortField, sortOrder]);
+
+  const displayedBooks = showAll ? sortedBooks : sortedBooks.slice(0, 5);
+
+  const handleSortChange = (field: SortField) => {
+    if (sortField === field) {
+      setSortOrder(sortOrder === 'desc' ? 'asc' : 'desc');
+    } else {
+      setSortField(field);
+      setSortOrder('desc');
+    }
+  };
+
+  if (sortedBooks.length === 0) {
+    return (
+      <div className='bg-base-200 rounded-xl p-4'>
+        <h3 className='text-base-content mb-4 font-semibold'>{_('Books Read')}</h3>
+        <div className='py-8 text-center'>
+          <PiBook size={48} className='text-base-content/20 mx-auto mb-2' />
+          <p className='text-base-content/50 text-sm'>{_('No reading history yet')}</p>
+          <p className='text-base-content/40 text-xs'>
+            {_('Start reading to see your book statistics')}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='bg-base-200 rounded-xl p-4'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h3 className='text-base-content font-semibold'>
+          {_('Books Read')} ({sortedBooks.length})
+        </h3>
+
+        {/* Sort dropdown */}
+        <div className='dropdown dropdown-end'>
+          <button className='btn btn-ghost btn-xs gap-1'>
+            {sortField === 'lastReadAt'
+              ? _('Recent')
+              : sortField === 'totalReadingTime'
+                ? _('Time')
+                : _('Sessions')}
+            <PiCaretDown size={12} />
+          </button>
+          <ul className='menu dropdown-content bg-base-300 rounded-box z-10 w-32 p-2 shadow'>
+            <li>
+              <button
+                className={sortField === 'lastReadAt' ? 'active' : ''}
+                onClick={() => handleSortChange('lastReadAt')}
+              >
+                {_('Recent')}
+              </button>
+            </li>
+            <li>
+              <button
+                className={sortField === 'totalReadingTime' ? 'active' : ''}
+                onClick={() => handleSortChange('totalReadingTime')}
+              >
+                {_('Time Spent')}
+              </button>
+            </li>
+            <li>
+              <button
+                className={sortField === 'totalSessions' ? 'active' : ''}
+                onClick={() => handleSortChange('totalSessions')}
+              >
+                {_('Sessions')}
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Book list */}
+      <div className='space-y-2'>
+        {displayedBooks.map(([bookHash, stats]) => (
+          <BookStatsItem key={bookHash} book={bookMap.get(bookHash)} stats={stats} />
+        ))}
+      </div>
+
+      {/* Show more button */}
+      {sortedBooks.length > 5 && (
+        <button className='btn btn-ghost btn-sm mt-4 w-full' onClick={() => setShowAll(!showAll)}>
+          {showAll ? _('Show less') : _('Show all ({{count}})', { count: sortedBooks.length })}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default BookStats;

--- a/apps/readest-app/src/app/statistics/components/ReadingCalendar.tsx
+++ b/apps/readest-app/src/app/statistics/components/ReadingCalendar.tsx
@@ -43,6 +43,13 @@ const formatDuration = (seconds: number): string => {
   return `${minutes}m`;
 };
 
+// Parse YYYY-MM-DD string as LOCAL date (not UTC)
+// new Date('2026-02-03') parses as UTC, causing timezone issues
+const parseDateString = (dateStr: string): Date => {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year!, month! - 1, day);
+};
+
 const generateCalendarData = (
   year: number,
   dailySummaries: Record<string, DailyReadingSummary>,
@@ -102,7 +109,7 @@ const getMonthLabels = (weeks: DayCell[][]): { label: string; index: number }[] 
     const dayInYear = week.find((d) => d.isCurrentMonth);
     if (!dayInYear) return;
 
-    const date = new Date(dayInYear.date);
+    const date = parseDateString(dayInYear.date);
     const month = date.getMonth();
 
     if (month !== lastMonth && dayInYear.dayOfMonth <= 7) {

--- a/apps/readest-app/src/app/statistics/components/ReadingCalendar.tsx
+++ b/apps/readest-app/src/app/statistics/components/ReadingCalendar.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import clsx from 'clsx';
+import { useState, useMemo } from 'react';
+import { useTranslation } from '@/hooks/useTranslation';
+import { DailyReadingSummary } from '@/types/statistics';
+
+interface ReadingCalendarProps {
+  year: number;
+  dailySummaries: Record<string, DailyReadingSummary>;
+  onYearChange?: (year: number) => void;
+}
+
+interface DayCell {
+  date: string;
+  dayOfMonth: number;
+  duration: number; // seconds
+  isCurrentMonth: boolean;
+  isToday: boolean;
+}
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+const DAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
+// Get color intensity based on reading duration (in seconds)
+const getColorClass = (duration: number): string => {
+  if (duration === 0) return 'bg-base-300';
+  if (duration < 15 * 60) return 'bg-success/30'; // < 15 min
+  if (duration < 30 * 60) return 'bg-success/50'; // < 30 min
+  if (duration < 60 * 60) return 'bg-success/70'; // < 1 hour
+  return 'bg-success'; // 1+ hour
+};
+
+const formatDuration = (seconds: number): string => {
+  if (seconds === 0) return 'No reading';
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+};
+
+const generateCalendarData = (
+  year: number,
+  dailySummaries: Record<string, DailyReadingSummary>,
+): DayCell[][] => {
+  const weeks: DayCell[][] = [];
+  const today = new Date().toISOString().split('T')[0]!;
+
+  // Start from the first day of the year
+  const startDate = new Date(year, 0, 1);
+  // Adjust to start from the Sunday of that week
+  const startDay = startDate.getDay();
+  startDate.setDate(startDate.getDate() - startDay);
+
+  // End at the last day of the year
+  const endDate = new Date(year, 11, 31);
+  // Adjust to end at the Saturday of that week
+  const endDay = endDate.getDay();
+  endDate.setDate(endDate.getDate() + (6 - endDay));
+
+  let currentWeek: DayCell[] = [];
+  const currentDate = new Date(startDate);
+
+  while (currentDate <= endDate) {
+    const dateStr = currentDate.toISOString().split('T')[0]!;
+    const summary = dailySummaries[dateStr];
+    const isCurrentYear = currentDate.getFullYear() === year;
+
+    currentWeek.push({
+      date: dateStr,
+      dayOfMonth: currentDate.getDate(),
+      duration: summary?.totalDuration || 0,
+      isCurrentMonth: isCurrentYear,
+      isToday: dateStr === today,
+    });
+
+    if (currentWeek.length === 7) {
+      weeks.push(currentWeek);
+      currentWeek = [];
+    }
+
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+
+  if (currentWeek.length > 0) {
+    weeks.push(currentWeek);
+  }
+
+  return weeks;
+};
+
+const getMonthLabels = (weeks: DayCell[][]): { label: string; index: number }[] => {
+  const labels: { label: string; index: number }[] = [];
+  let lastMonth = -1;
+
+  weeks.forEach((week, weekIndex) => {
+    // Find a day in the current year in this week
+    const dayInYear = week.find((d) => d.isCurrentMonth);
+    if (!dayInYear) return;
+
+    const date = new Date(dayInYear.date);
+    const month = date.getMonth();
+
+    if (month !== lastMonth && dayInYear.dayOfMonth <= 7) {
+      labels.push({ label: MONTHS[month]!, index: weekIndex });
+      lastMonth = month;
+    }
+  });
+
+  return labels;
+};
+
+const ReadingCalendar: React.FC<ReadingCalendarProps> = ({
+  year,
+  dailySummaries,
+  onYearChange,
+}) => {
+  const _ = useTranslation();
+  const [hoveredDay, setHoveredDay] = useState<DayCell | null>(null);
+  const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
+
+  const weeks = useMemo(() => generateCalendarData(year, dailySummaries), [year, dailySummaries]);
+  const monthLabels = useMemo(() => getMonthLabels(weeks), [weeks]);
+
+  const handleMouseEnter = (day: DayCell, event: React.MouseEvent) => {
+    setHoveredDay(day);
+    const rect = event.currentTarget.getBoundingClientRect();
+    setTooltipPosition({
+      x: rect.left + rect.width / 2,
+      y: rect.top - 8,
+    });
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredDay(null);
+  };
+
+  const currentYear = new Date().getFullYear();
+  const canGoForward = year < currentYear;
+  const canGoBackward = year > currentYear - 5; // Allow going back 5 years
+
+  return (
+    <div className='bg-base-200 rounded-xl p-4'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h3 className='text-base-content font-semibold'>{_('Reading Activity')}</h3>
+        <div className='flex items-center gap-2'>
+          <button
+            className='btn btn-ghost btn-sm'
+            onClick={() => onYearChange?.(year - 1)}
+            disabled={!canGoBackward}
+          >
+            ←
+          </button>
+          <span className='text-base-content/70 min-w-[60px] text-center text-sm font-medium'>
+            {year}
+          </span>
+          <button
+            className='btn btn-ghost btn-sm'
+            onClick={() => onYearChange?.(year + 1)}
+            disabled={!canGoForward}
+          >
+            →
+          </button>
+        </div>
+      </div>
+
+      {/* Month labels */}
+      <div className='mb-1 flex'>
+        <div className='w-6' /> {/* Spacer for day labels */}
+        <div className='relative flex-1'>
+          {monthLabels.map(({ label, index }) => (
+            <span
+              key={`${label}-${index}`}
+              className='text-base-content/50 absolute text-xs'
+              style={{ left: `${(index / weeks.length) * 100}%` }}
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Calendar grid */}
+      <div className='flex'>
+        {/* Day labels */}
+        <div className='flex w-6 flex-col justify-around pr-1'>
+          {DAYS.map((day, i) => (
+            <span
+              key={i}
+              className={clsx(
+                'text-base-content/50 text-center text-xs',
+                i % 2 === 1 ? 'visible' : 'invisible',
+              )}
+            >
+              {day}
+            </span>
+          ))}
+        </div>
+
+        {/* Weeks grid */}
+        <div className='flex flex-1 gap-[2px] overflow-x-auto'>
+          {weeks.map((week, weekIndex) => (
+            <div key={weekIndex} className='flex flex-col gap-[2px]'>
+              {week.map((day) => (
+                <div
+                  key={day.date}
+                  className={clsx(
+                    'h-3 w-3 rounded-sm transition-colors',
+                    getColorClass(day.duration),
+                    day.isToday && 'ring-primary ring-1 ring-offset-1',
+                    !day.isCurrentMonth && 'opacity-30',
+                    'hover:ring-base-content/30 cursor-pointer hover:ring-1',
+                  )}
+                  onMouseEnter={(e) => handleMouseEnter(day, e)}
+                  onMouseLeave={handleMouseLeave}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className='mt-4 flex items-center justify-end gap-2'>
+        <span className='text-base-content/50 text-xs'>{_('Less')}</span>
+        <div className='bg-base-300 h-3 w-3 rounded-sm' />
+        <div className='bg-success/30 h-3 w-3 rounded-sm' />
+        <div className='bg-success/50 h-3 w-3 rounded-sm' />
+        <div className='bg-success/70 h-3 w-3 rounded-sm' />
+        <div className='bg-success h-3 w-3 rounded-sm' />
+        <span className='text-base-content/50 text-xs'>{_('More')}</span>
+      </div>
+
+      {/* Tooltip */}
+      {hoveredDay && (
+        <div
+          className='bg-base-300 text-base-content pointer-events-none fixed z-50 rounded px-2 py-1 text-xs shadow-lg'
+          style={{
+            left: tooltipPosition.x,
+            top: tooltipPosition.y,
+            transform: 'translate(-50%, -100%)',
+          }}
+        >
+          <div className='font-medium'>{hoveredDay.date}</div>
+          <div className='text-base-content/70'>{formatDuration(hoveredDay.duration)}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ReadingCalendar;

--- a/apps/readest-app/src/app/statistics/components/ReadingCalendar.tsx
+++ b/apps/readest-app/src/app/statistics/components/ReadingCalendar.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { useState, useMemo } from 'react';
 import { useTranslation } from '@/hooks/useTranslation';
 import { DailyReadingSummary } from '@/types/statistics';
+import { getLocalDateString } from '@/utils/format';
 
 interface ReadingCalendarProps {
   year: number;
@@ -47,7 +48,7 @@ const generateCalendarData = (
   dailySummaries: Record<string, DailyReadingSummary>,
 ): DayCell[][] => {
   const weeks: DayCell[][] = [];
-  const today = new Date().toISOString().split('T')[0]!;
+  const today = getLocalDateString();
 
   // Start from the first day of the year
   const startDate = new Date(year, 0, 1);
@@ -65,7 +66,7 @@ const generateCalendarData = (
   const currentDate = new Date(startDate);
 
   while (currentDate <= endDate) {
-    const dateStr = currentDate.toISOString().split('T')[0]!;
+    const dateStr = getLocalDateString(currentDate);
     const summary = dailySummaries[dateStr];
     const isCurrentYear = currentDate.getFullYear() === year;
 

--- a/apps/readest-app/src/app/statistics/components/StatisticsHeader.tsx
+++ b/apps/readest-app/src/app/statistics/components/StatisticsHeader.tsx
@@ -1,0 +1,51 @@
+import clsx from 'clsx';
+import { useRef } from 'react';
+import { IoArrowBack } from 'react-icons/io5';
+import { useEnv } from '@/context/EnvContext';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useTrafficLightStore } from '@/store/trafficLightStore';
+import WindowButtons from '@/components/WindowButtons';
+
+interface StatisticsHeaderProps {
+  onGoBack: () => void;
+}
+
+const StatisticsHeader: React.FC<StatisticsHeaderProps> = ({ onGoBack }) => {
+  const _ = useTranslation();
+  const { appService } = useEnv();
+  const { isTrafficLightVisible } = useTrafficLightStore();
+  const headerRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div
+      ref={headerRef}
+      className={clsx(
+        'bg-base-100/80 fixed z-30 flex w-full items-center justify-between py-2 pe-6 ps-4 backdrop-blur-sm',
+        appService?.hasTrafficLight && 'pt-11',
+      )}
+    >
+      <div className='flex items-center gap-4'>
+        <button
+          aria-label={_('Go Back')}
+          onClick={onGoBack}
+          className={clsx('btn btn-ghost h-12 min-h-12 w-12 p-0 sm:h-8 sm:min-h-8 sm:w-8')}
+        >
+          <IoArrowBack className='text-base-content' />
+        </button>
+        <h1 className='text-base-content text-lg font-semibold'>{_('Reading Statistics')}</h1>
+      </div>
+
+      {appService?.hasWindowBar && (
+        <WindowButtons
+          headerRef={headerRef}
+          showMinimize={!isTrafficLightVisible}
+          showMaximize={!isTrafficLightVisible}
+          showClose={!isTrafficLightVisible}
+          onClose={onGoBack}
+        />
+      )}
+    </div>
+  );
+};
+
+export default StatisticsHeader;

--- a/apps/readest-app/src/app/statistics/components/StatsOverview.tsx
+++ b/apps/readest-app/src/app/statistics/components/StatsOverview.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import { PiClock, PiBooks, PiFlame, PiFileText } from 'react-icons/pi';
 import { useTranslation } from '@/hooks/useTranslation';
 import { UserStatistics, DailyReadingSummary } from '@/types/statistics';
+import { getLocalDateString } from '@/utils/format';
 
 interface StatsOverviewProps {
   stats: UserStatistics;
@@ -48,8 +49,8 @@ const getMonthDateRange = (): { start: string; end: string } => {
   const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
 
   return {
-    start: start.toISOString().split('T')[0]!,
-    end: end.toISOString().split('T')[0]!,
+    start: getLocalDateString(start),
+    end: getLocalDateString(end),
   };
 };
 

--- a/apps/readest-app/src/app/statistics/components/StatsOverview.tsx
+++ b/apps/readest-app/src/app/statistics/components/StatsOverview.tsx
@@ -1,0 +1,96 @@
+import clsx from 'clsx';
+import { PiClock, PiBooks, PiFlame, PiFileText } from 'react-icons/pi';
+import { useTranslation } from '@/hooks/useTranslation';
+import { UserStatistics, DailyReadingSummary } from '@/types/statistics';
+
+interface StatsOverviewProps {
+  stats: UserStatistics;
+  dailySummaries: Record<string, DailyReadingSummary>;
+}
+
+interface StatCardProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  subtitle?: string;
+  className?: string;
+}
+
+const StatCard: React.FC<StatCardProps> = ({ icon, label, value, subtitle, className }) => {
+  return (
+    <div
+      className={clsx(
+        'bg-base-200 flex flex-col rounded-xl p-4 shadow-sm transition-shadow hover:shadow-md',
+        className,
+      )}
+    >
+      <div className='text-base-content/60 mb-2'>{icon}</div>
+      <div className='text-base-content/70 text-sm font-medium'>{label}</div>
+      <div className='text-base-content text-2xl font-bold'>{value}</div>
+      {subtitle && <div className='text-base-content/50 mt-1 text-xs'>{subtitle}</div>}
+    </div>
+  );
+};
+
+const formatDuration = (seconds: number): string => {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+};
+
+const getMonthDateRange = (): { start: string; end: string } => {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), 1);
+  const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+
+  return {
+    start: start.toISOString().split('T')[0]!,
+    end: end.toISOString().split('T')[0]!,
+  };
+};
+
+const StatsOverview: React.FC<StatsOverviewProps> = ({ stats, dailySummaries }) => {
+  const _ = useTranslation();
+
+  // Calculate pages this month
+  const { start, end } = getMonthDateRange();
+  const pagesThisMonth = Object.entries(dailySummaries)
+    .filter(([date]) => date >= start && date <= end)
+    .reduce((sum, [, summary]) => sum + summary.totalPages, 0);
+
+  return (
+    <div className='grid grid-cols-2 gap-4'>
+      <StatCard
+        icon={<PiClock size={24} />}
+        label={_('Total Reading Time')}
+        value={formatDuration(stats.totalReadingTime)}
+        subtitle={_('{{sessions}} sessions', { sessions: stats.totalSessions })}
+      />
+      <StatCard
+        icon={<PiBooks size={24} />}
+        label={_('Books Completed')}
+        value={String(stats.totalBooksCompleted)}
+        subtitle={_('{{started}} books started', { started: stats.totalBooksStarted })}
+      />
+      <StatCard
+        icon={<PiFlame size={24} />}
+        label={_('Current Streak')}
+        value={_('{{days}} days', { days: stats.currentStreak })}
+        subtitle={_('Longest: {{days}} days', { days: stats.longestStreak })}
+        className={stats.currentStreak > 0 ? 'border-2 border-orange-400/30' : ''}
+      />
+      <StatCard
+        icon={<PiFileText size={24} />}
+        label={_('Pages This Month')}
+        value={String(pagesThisMonth)}
+        subtitle={_('Total: {{total}} pages', { total: stats.totalPagesRead })}
+      />
+    </div>
+  );
+};
+
+export default StatsOverview;

--- a/apps/readest-app/src/app/statistics/components/StreakDisplay.tsx
+++ b/apps/readest-app/src/app/statistics/components/StreakDisplay.tsx
@@ -17,6 +17,13 @@ const getDateString = (date: Date): string => {
   return `${year}-${month}-${day}`;
 };
 
+// Parse YYYY-MM-DD string as LOCAL date (not UTC)
+// new Date('2026-02-03') parses as UTC, causing timezone issues
+const parseDateString = (dateStr: string): Date => {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year!, month! - 1, day);
+};
+
 const StreakDisplay: React.FC<StreakDisplayProps> = ({
   currentStreak,
   longestStreak,
@@ -88,7 +95,7 @@ const StreakDisplay: React.FC<StreakDisplayProps> = ({
       {/* Mini streak calendar */}
       <div className='mt-4 flex justify-center gap-2'>
         {last7Days.map((date, i) => {
-          const dayDate = new Date(date);
+          const dayDate = parseDateString(date);
           const dayName = dayDate.toLocaleDateString('en-US', { weekday: 'short' }).charAt(0);
           const isInStreak =
             hasActiveStreak &&

--- a/apps/readest-app/src/app/statistics/components/StreakDisplay.tsx
+++ b/apps/readest-app/src/app/statistics/components/StreakDisplay.tsx
@@ -68,7 +68,7 @@ const StreakDisplay: React.FC<StreakDisplayProps> = ({
           <div>
             <div className='text-base-content text-3xl font-bold'>{currentStreak}</div>
             <div className='text-base-content/60 text-sm'>
-              {currentStreak === 1 ? _('day streak') : _('day streak')}
+              {currentStreak === 1 ? _('day streak') : _('days streak')}
             </div>
           </div>
         </div>

--- a/apps/readest-app/src/app/statistics/components/StreakDisplay.tsx
+++ b/apps/readest-app/src/app/statistics/components/StreakDisplay.tsx
@@ -1,0 +1,130 @@
+import { useMemo } from 'react';
+import clsx from 'clsx';
+import { PiFlame } from 'react-icons/pi';
+import { useTranslation } from '@/hooks/useTranslation';
+
+interface StreakDisplayProps {
+  currentStreak: number;
+  longestStreak: number;
+  lastReadDate: string;
+}
+
+const getDateString = (date: Date): string => {
+  return date.toISOString().split('T')[0]!;
+};
+
+const StreakDisplay: React.FC<StreakDisplayProps> = ({
+  currentStreak,
+  longestStreak,
+  lastReadDate,
+}) => {
+  const _ = useTranslation();
+
+  const { today, yesterday, last7Days } = useMemo(() => {
+    const now = new Date();
+    const yesterdayDate = new Date(now);
+    yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+
+    const days = Array.from({ length: 7 }, (_, i) => {
+      const date = new Date(now);
+      date.setDate(date.getDate() - (6 - i));
+      return getDateString(date);
+    });
+
+    return {
+      today: getDateString(now),
+      yesterday: getDateString(yesterdayDate),
+      last7Days: days,
+    };
+  }, []);
+
+  const isActiveToday = lastReadDate === today;
+  const isActiveYesterday = lastReadDate === yesterday;
+  const hasActiveStreak = currentStreak > 0;
+
+  return (
+    <div
+      className={clsx(
+        'bg-base-200 rounded-xl p-4',
+        hasActiveStreak && 'border-2 border-orange-400/30',
+      )}
+    >
+      <div className='flex items-center justify-between'>
+        <div className='flex items-center gap-3'>
+          <div
+            className={clsx(
+              'flex h-12 w-12 items-center justify-center rounded-full',
+              hasActiveStreak ? 'bg-orange-400/20' : 'bg-base-300',
+            )}
+          >
+            <PiFlame
+              size={28}
+              className={clsx(
+                hasActiveStreak ? 'text-orange-400' : 'text-base-content/40',
+                hasActiveStreak && 'animate-pulse',
+              )}
+            />
+          </div>
+          <div>
+            <div className='text-base-content text-3xl font-bold'>{currentStreak}</div>
+            <div className='text-base-content/60 text-sm'>
+              {currentStreak === 1 ? _('day streak') : _('day streak')}
+            </div>
+          </div>
+        </div>
+
+        <div className='text-right'>
+          <div className='text-base-content/70 text-sm'>{_('Longest streak')}</div>
+          <div className='text-base-content text-xl font-semibold'>
+            {_('{{days}} days', { days: longestStreak })}
+          </div>
+        </div>
+      </div>
+
+      {/* Mini streak calendar */}
+      <div className='mt-4 flex justify-center gap-2'>
+        {last7Days.map((date, i) => {
+          const dayDate = new Date(date);
+          const dayName = dayDate.toLocaleDateString('en-US', { weekday: 'short' }).charAt(0);
+          const isInStreak =
+            hasActiveStreak &&
+            ((isActiveToday && i >= 7 - currentStreak) ||
+              (isActiveYesterday && i >= 6 - currentStreak && i < 6) ||
+              lastReadDate === date);
+
+          return (
+            <div key={date} className='flex flex-col items-center gap-1'>
+              <span className='text-base-content/50 text-xs'>{dayName}</span>
+              <div
+                className={clsx(
+                  'flex h-8 w-8 items-center justify-center rounded-full text-xs font-medium transition-colors',
+                  date === today && 'ring-primary ring-2 ring-offset-1',
+                  isInStreak ? 'bg-orange-400 text-white' : 'bg-base-300 text-base-content/60',
+                )}
+              >
+                {dayDate.getDate()}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Status message */}
+      <div className='mt-3 text-center'>
+        {hasActiveStreak ? (
+          isActiveToday ? (
+            <span className='text-success text-sm'>{_("You've read today! Keep it up!")}</span>
+          ) : (
+            <span className='text-warning text-sm'>{_('Read today to maintain your streak!')}</span>
+          )
+        ) : (
+          <span className='text-base-content/50 text-sm'>
+            {_('Start reading to begin a streak!')}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default StreakDisplay;

--- a/apps/readest-app/src/app/statistics/components/StreakDisplay.tsx
+++ b/apps/readest-app/src/app/statistics/components/StreakDisplay.tsx
@@ -9,8 +9,12 @@ interface StreakDisplayProps {
   lastReadDate: string;
 }
 
+// Use local timezone to match statisticsStore date format
 const getDateString = (date: Date): string => {
-  return date.toISOString().split('T')[0]!;
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 };
 
 const StreakDisplay: React.FC<StreakDisplayProps> = ({

--- a/apps/readest-app/src/app/statistics/components/TimeDistribution.tsx
+++ b/apps/readest-app/src/app/statistics/components/TimeDistribution.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useState } from 'react';
+import clsx from 'clsx';
+import { useTranslation } from '@/hooks/useTranslation';
+import { UserStatistics } from '@/types/statistics';
+
+interface TimeDistributionProps {
+  stats: UserStatistics;
+}
+
+type ViewMode = 'hour' | 'day';
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const formatDuration = (seconds: number): string => {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+};
+
+const formatHour = (hour: number): string => {
+  if (hour === 0) return '12am';
+  if (hour === 12) return '12pm';
+  if (hour < 12) return `${hour}am`;
+  return `${hour - 12}pm`;
+};
+
+const TimeDistribution: React.FC<TimeDistributionProps> = ({ stats }) => {
+  const _ = useTranslation();
+  const [viewMode, setViewMode] = useState<ViewMode>('hour');
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+
+  const data = viewMode === 'hour' ? stats.readingByHour : stats.readingByDayOfWeek;
+  const labels = viewMode === 'hour' ? HOURS.map(formatHour) : DAYS;
+  const maxValue = Math.max(...data, 1);
+
+  // Find peak time
+  const peakIndex = data.indexOf(Math.max(...data));
+  const peakLabel = labels[peakIndex];
+  const peakValue = data[peakIndex] || 0;
+
+  return (
+    <div className='bg-base-200 rounded-xl p-4'>
+      <div className='mb-4 flex items-center justify-between'>
+        <div>
+          <h3 className='text-base-content font-semibold'>{_('Reading Time')}</h3>
+          {peakValue > 0 && (
+            <p className='text-base-content/60 text-sm'>
+              {_('Peak: {{time}}', { time: peakLabel })}
+            </p>
+          )}
+        </div>
+        <div className='flex gap-1'>
+          <button
+            className={clsx('btn btn-xs', viewMode === 'hour' ? 'btn-primary' : 'btn-ghost')}
+            onClick={() => setViewMode('hour')}
+          >
+            {_('By Hour')}
+          </button>
+          <button
+            className={clsx('btn btn-xs', viewMode === 'day' ? 'btn-primary' : 'btn-ghost')}
+            onClick={() => setViewMode('day')}
+          >
+            {_('By Day')}
+          </button>
+        </div>
+      </div>
+
+      <div className='relative'>
+        {/* Bar chart */}
+        <div className={clsx('flex items-end gap-[2px]', viewMode === 'hour' ? 'h-24' : 'h-32')}>
+          {data.map((value, index) => {
+            const height = (value / maxValue) * 100;
+            const isHovered = hoveredIndex === index;
+            const isPeak = index === peakIndex && value > 0;
+
+            return (
+              <div
+                key={index}
+                className='relative flex flex-1 flex-col items-center'
+                onMouseEnter={() => setHoveredIndex(index)}
+                onMouseLeave={() => setHoveredIndex(null)}
+              >
+                {/* Bar */}
+                <div
+                  className={clsx(
+                    'w-full rounded-t transition-all duration-200',
+                    isPeak ? 'bg-primary' : 'bg-primary/60',
+                    isHovered && 'brightness-110',
+                    value === 0 && 'bg-base-300',
+                  )}
+                  style={{
+                    height: `${Math.max(height, value > 0 ? 4 : 2)}%`,
+                    minHeight: value > 0 ? '4px' : '2px',
+                  }}
+                />
+
+                {/* Tooltip */}
+                {isHovered && (
+                  <div
+                    className='bg-base-300 text-base-content pointer-events-none absolute bottom-full z-10 mb-1 whitespace-nowrap rounded px-2 py-1 text-xs shadow-lg'
+                    style={{ transform: 'translateX(0)' }}
+                  >
+                    <div className='font-medium'>{labels[index]}</div>
+                    <div className='text-base-content/70'>{formatDuration(value)}</div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* X-axis labels */}
+        <div
+          className={clsx('mt-2 flex', viewMode === 'hour' ? 'justify-between' : 'justify-around')}
+        >
+          {viewMode === 'hour' ? (
+            // Show every 6 hours for hourly view
+            <>
+              <span className='text-base-content/50 text-xs'>12am</span>
+              <span className='text-base-content/50 text-xs'>6am</span>
+              <span className='text-base-content/50 text-xs'>12pm</span>
+              <span className='text-base-content/50 text-xs'>6pm</span>
+              <span className='text-base-content/50 text-xs'>12am</span>
+            </>
+          ) : (
+            // Show all days for weekly view
+            DAYS.map((day, i) => (
+              <span
+                key={day}
+                className={clsx(
+                  'text-xs',
+                  i === peakIndex && data[i]! > 0
+                    ? 'text-primary font-medium'
+                    : 'text-base-content/50',
+                )}
+              >
+                {day}
+              </span>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Summary */}
+      {viewMode === 'day' && (
+        <div className='mt-4 grid grid-cols-2 gap-2 text-center'>
+          <div className='bg-base-300/50 rounded-lg p-2'>
+            <div className='text-base-content/60 text-xs'>{_('Weekdays')}</div>
+            <div className='text-base-content text-sm font-semibold'>
+              {formatDuration(data.slice(1, 6).reduce((a, b) => a + b, 0))}
+            </div>
+          </div>
+          <div className='bg-base-300/50 rounded-lg p-2'>
+            <div className='text-base-content/60 text-xs'>{_('Weekends')}</div>
+            <div className='text-base-content text-sm font-semibold'>
+              {formatDuration((data[0] || 0) + (data[6] || 0))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TimeDistribution;

--- a/apps/readest-app/src/app/statistics/components/TrendChart.tsx
+++ b/apps/readest-app/src/app/statistics/components/TrendChart.tsx
@@ -123,8 +123,10 @@ const TrendChart: React.FC<TrendChartProps> = ({
   // Create smooth path using cardinal spline interpolation
   const createPath = () => {
     if (points.length < 2) return '';
+    const firstPoint = points[0];
+    if (!firstPoint) return '';
 
-    let path = `M ${points[0]!.x} ${points[0]!.y}`;
+    let path = `M ${firstPoint.x} ${firstPoint.y}`;
 
     for (let i = 0; i < points.length - 1; i++) {
       const p0 = points[Math.max(0, i - 1)]!;

--- a/apps/readest-app/src/app/statistics/components/TrendChart.tsx
+++ b/apps/readest-app/src/app/statistics/components/TrendChart.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import clsx from 'clsx';
 import { useTranslation } from '@/hooks/useTranslation';
 import { DailyReadingSummary } from '@/types/statistics';
+import { getLocalDateString } from '@/utils/format';
 
 interface TrendChartProps {
   dailySummaries: Record<string, DailyReadingSummary>;
@@ -38,7 +39,7 @@ const getDateRangeData = (
     for (let i = 6; i >= 0; i--) {
       const date = new Date(today);
       date.setDate(date.getDate() - i);
-      const dateStr = date.toISOString().split('T')[0]!;
+      const dateStr = getLocalDateString(date);
       const summary = dailySummaries[dateStr];
 
       data.push({
@@ -59,13 +60,13 @@ const getDateRangeData = (
       for (let j = 0; j < 7; j++) {
         const date = new Date(weekStart);
         date.setDate(date.getDate() + j);
-        const dateStr = date.toISOString().split('T')[0]!;
+        const dateStr = getLocalDateString(date);
         const summary = dailySummaries[dateStr];
         totalDuration += summary?.totalDuration || 0;
       }
 
       data.push({
-        date: weekStart.toISOString().split('T')[0]!,
+        date: getLocalDateString(weekStart),
         label: `${weekStart.getMonth() + 1}/${weekStart.getDate()}`,
         value: totalDuration,
       });
@@ -79,14 +80,14 @@ const getDateRangeData = (
       let totalDuration = 0;
       const currentDate = new Date(monthDate);
       while (currentDate <= monthEnd) {
-        const dateStr = currentDate.toISOString().split('T')[0]!;
+        const dateStr = getLocalDateString(currentDate);
         const summary = dailySummaries[dateStr];
         totalDuration += summary?.totalDuration || 0;
         currentDate.setDate(currentDate.getDate() + 1);
       }
 
       data.push({
-        date: monthDate.toISOString().split('T')[0]!,
+        date: getLocalDateString(monthDate),
         label: monthDate.toLocaleDateString('en-US', { month: 'short' }),
         value: totalDuration,
       });

--- a/apps/readest-app/src/app/statistics/components/TrendChart.tsx
+++ b/apps/readest-app/src/app/statistics/components/TrendChart.tsx
@@ -1,0 +1,277 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import { useTranslation } from '@/hooks/useTranslation';
+import { DailyReadingSummary } from '@/types/statistics';
+
+interface TrendChartProps {
+  dailySummaries: Record<string, DailyReadingSummary>;
+  dateRange: 'week' | 'month' | 'year';
+  onDateRangeChange?: (range: 'week' | 'month' | 'year') => void;
+}
+
+interface DataPoint {
+  date: string;
+  label: string;
+  value: number;
+}
+
+const formatDuration = (seconds: number): string => {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+};
+
+const getDateRangeData = (
+  dailySummaries: Record<string, DailyReadingSummary>,
+  range: 'week' | 'month' | 'year',
+): DataPoint[] => {
+  const data: DataPoint[] = [];
+  const today = new Date();
+
+  if (range === 'week') {
+    // Last 7 days
+    for (let i = 6; i >= 0; i--) {
+      const date = new Date(today);
+      date.setDate(date.getDate() - i);
+      const dateStr = date.toISOString().split('T')[0]!;
+      const summary = dailySummaries[dateStr];
+
+      data.push({
+        date: dateStr,
+        label: date.toLocaleDateString('en-US', { weekday: 'short' }),
+        value: summary?.totalDuration || 0,
+      });
+    }
+  } else if (range === 'month') {
+    // Last 30 days, grouped by week
+    for (let i = 4; i >= 0; i--) {
+      const weekEnd = new Date(today);
+      weekEnd.setDate(weekEnd.getDate() - i * 7);
+      const weekStart = new Date(weekEnd);
+      weekStart.setDate(weekStart.getDate() - 6);
+
+      let totalDuration = 0;
+      for (let j = 0; j < 7; j++) {
+        const date = new Date(weekStart);
+        date.setDate(date.getDate() + j);
+        const dateStr = date.toISOString().split('T')[0]!;
+        const summary = dailySummaries[dateStr];
+        totalDuration += summary?.totalDuration || 0;
+      }
+
+      data.push({
+        date: weekStart.toISOString().split('T')[0]!,
+        label: `${weekStart.getMonth() + 1}/${weekStart.getDate()}`,
+        value: totalDuration,
+      });
+    }
+  } else {
+    // Last 12 months
+    for (let i = 11; i >= 0; i--) {
+      const monthDate = new Date(today.getFullYear(), today.getMonth() - i, 1);
+      const monthEnd = new Date(today.getFullYear(), today.getMonth() - i + 1, 0);
+
+      let totalDuration = 0;
+      const currentDate = new Date(monthDate);
+      while (currentDate <= monthEnd) {
+        const dateStr = currentDate.toISOString().split('T')[0]!;
+        const summary = dailySummaries[dateStr];
+        totalDuration += summary?.totalDuration || 0;
+        currentDate.setDate(currentDate.getDate() + 1);
+      }
+
+      data.push({
+        date: monthDate.toISOString().split('T')[0]!,
+        label: monthDate.toLocaleDateString('en-US', { month: 'short' }),
+        value: totalDuration,
+      });
+    }
+  }
+
+  return data;
+};
+
+const TrendChart: React.FC<TrendChartProps> = ({
+  dailySummaries,
+  dateRange,
+  onDateRangeChange,
+}) => {
+  const _ = useTranslation();
+  const [hoveredPoint, setHoveredPoint] = useState<DataPoint | null>(null);
+
+  const data = useMemo(
+    () => getDateRangeData(dailySummaries, dateRange),
+    [dailySummaries, dateRange],
+  );
+
+  const maxValue = Math.max(...data.map((d) => d.value), 1);
+  const chartHeight = 120;
+  const chartWidth = 280;
+  const padding = { top: 10, right: 10, bottom: 30, left: 10 };
+
+  const points = data.map((d, i) => ({
+    ...d,
+    x: padding.left + (i / (data.length - 1 || 1)) * (chartWidth - padding.left - padding.right),
+    y: padding.top + (1 - d.value / maxValue) * (chartHeight - padding.top - padding.bottom),
+  }));
+
+  // Create smooth path using cardinal spline interpolation
+  const createPath = () => {
+    if (points.length < 2) return '';
+
+    let path = `M ${points[0]!.x} ${points[0]!.y}`;
+
+    for (let i = 0; i < points.length - 1; i++) {
+      const p0 = points[Math.max(0, i - 1)]!;
+      const p1 = points[i]!;
+      const p2 = points[i + 1]!;
+      const p3 = points[Math.min(points.length - 1, i + 2)]!;
+
+      const tension = 0.3;
+      const cp1x = p1.x + ((p2.x - p0.x) * tension) / 3;
+      const cp1y = p1.y + ((p2.y - p0.y) * tension) / 3;
+      const cp2x = p2.x - ((p3.x - p1.x) * tension) / 3;
+      const cp2y = p2.y - ((p3.y - p1.y) * tension) / 3;
+
+      path += ` C ${cp1x} ${cp1y}, ${cp2x} ${cp2y}, ${p2.x} ${p2.y}`;
+    }
+
+    return path;
+  };
+
+  // Create area fill path
+  const createAreaPath = () => {
+    const linePath = createPath();
+    if (!linePath) return '';
+
+    const lastPoint = points[points.length - 1]!;
+    const firstPoint = points[0]!;
+    const bottom = chartHeight - padding.bottom;
+
+    return `${linePath} L ${lastPoint.x} ${bottom} L ${firstPoint.x} ${bottom} Z`;
+  };
+
+  const totalDuration = data.reduce((sum, d) => sum + d.value, 0);
+
+  return (
+    <div className='bg-base-200 rounded-xl p-4'>
+      <div className='mb-4 flex items-center justify-between'>
+        <div>
+          <h3 className='text-base-content font-semibold'>{_('Reading Trend')}</h3>
+          <p className='text-base-content/60 text-sm'>
+            {_('Total: {{duration}}', { duration: formatDuration(totalDuration) })}
+          </p>
+        </div>
+        <div className='flex gap-1'>
+          {(['week', 'month', 'year'] as const).map((range) => (
+            <button
+              key={range}
+              className={clsx('btn btn-xs', dateRange === range ? 'btn-primary' : 'btn-ghost')}
+              onClick={() => onDateRangeChange?.(range)}
+            >
+              {range === 'week' ? _('Week') : range === 'month' ? _('Month') : _('Year')}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className='relative'>
+        <svg
+          viewBox={`0 0 ${chartWidth} ${chartHeight}`}
+          className='w-full'
+          style={{ maxHeight: `${chartHeight}px` }}
+        >
+          {/* Grid lines */}
+          <g className='text-base-content/10'>
+            {[0, 0.25, 0.5, 0.75, 1].map((ratio) => {
+              const y = padding.top + (1 - ratio) * (chartHeight - padding.top - padding.bottom);
+              return (
+                <line
+                  key={ratio}
+                  x1={padding.left}
+                  y1={y}
+                  x2={chartWidth - padding.right}
+                  y2={y}
+                  stroke='currentColor'
+                  strokeWidth={0.5}
+                  strokeDasharray={ratio > 0 && ratio < 1 ? '2,2' : undefined}
+                />
+              );
+            })}
+          </g>
+
+          {/* Area fill */}
+          <path d={createAreaPath()} className='fill-primary/20' />
+
+          {/* Line */}
+          <path
+            d={createPath()}
+            fill='none'
+            className='stroke-primary'
+            strokeWidth={2}
+            strokeLinecap='round'
+            strokeLinejoin='round'
+          />
+
+          {/* Data points */}
+          {points.map((point, i) => (
+            <g key={i}>
+              <circle
+                cx={point.x}
+                cy={point.y}
+                r={hoveredPoint?.date === point.date ? 5 : 3}
+                className={clsx(
+                  'transition-all',
+                  hoveredPoint?.date === point.date
+                    ? 'fill-primary'
+                    : 'fill-base-100 stroke-primary',
+                )}
+                strokeWidth={2}
+                onMouseEnter={() => setHoveredPoint(point)}
+                onMouseLeave={() => setHoveredPoint(null)}
+                style={{ cursor: 'pointer' }}
+              />
+            </g>
+          ))}
+
+          {/* X-axis labels */}
+          <g className='text-base-content/60'>
+            {points.map((point, i) => (
+              <text
+                key={i}
+                x={point.x}
+                y={chartHeight - 5}
+                textAnchor='middle'
+                fontSize={10}
+                fill='currentColor'
+              >
+                {point.label}
+              </text>
+            ))}
+          </g>
+        </svg>
+
+        {/* Tooltip */}
+        {hoveredPoint && (
+          <div
+            className='bg-base-300 text-base-content pointer-events-none absolute rounded px-2 py-1 text-xs shadow-lg'
+            style={{
+              left: `${((points.find((p) => p.date === hoveredPoint.date)?.x || 0) / chartWidth) * 100}%`,
+              top: `${(points.find((p) => p.date === hoveredPoint.date)?.y || 0) - 30}px`,
+              transform: 'translateX(-50%)',
+            }}
+          >
+            <div className='font-medium'>{formatDuration(hoveredPoint.value)}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TrendChart;

--- a/apps/readest-app/src/app/statistics/components/TrendChart.tsx
+++ b/apps/readest-app/src/app/statistics/components/TrendChart.tsx
@@ -35,7 +35,7 @@ const getDateRangeData = (
   const today = new Date();
 
   if (range === 'week') {
-    // Last 7 days
+    // Daily view: Last 7 days, one point per day
     for (let i = 6; i >= 0; i--) {
       const date = new Date(today);
       date.setDate(date.getDate() - i);
@@ -49,7 +49,7 @@ const getDateRangeData = (
       });
     }
   } else if (range === 'month') {
-    // Last 30 days, grouped by week
+    // Weekly view: Last 5 weeks, one point per week
     for (let i = 4; i >= 0; i--) {
       const weekEnd = new Date(today);
       weekEnd.setDate(weekEnd.getDate() - i * 7);
@@ -72,7 +72,7 @@ const getDateRangeData = (
       });
     }
   } else {
-    // Last 12 months
+    // Monthly view: Last 12 months, one point per month
     for (let i = 11; i >= 0; i--) {
       const monthDate = new Date(today.getFullYear(), today.getMonth() - i, 1);
       const monthEnd = new Date(today.getFullYear(), today.getMonth() - i + 1, 0);
@@ -177,7 +177,7 @@ const TrendChart: React.FC<TrendChartProps> = ({
               className={clsx('btn btn-xs', dateRange === range ? 'btn-primary' : 'btn-ghost')}
               onClick={() => onDateRangeChange?.(range)}
             >
-              {range === 'week' ? _('Week') : range === 'month' ? _('Month') : _('Year')}
+              {range === 'week' ? _('Daily') : range === 'month' ? _('Weekly') : _('Monthly')}
             </button>
           ))}
         </div>

--- a/apps/readest-app/src/app/statistics/layout.tsx
+++ b/apps/readest-app/src/app/statistics/layout.tsx
@@ -1,0 +1,10 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Reading Statistics',
+  description: 'View your reading statistics and progress',
+};
+
+export default function StatisticsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/apps/readest-app/src/app/statistics/page.tsx
+++ b/apps/readest-app/src/app/statistics/page.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import clsx from 'clsx';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { OverlayScrollbarsComponent } from 'overlayscrollbars-react';
+import 'overlayscrollbars/overlayscrollbars.css';
+
+import { useEnv } from '@/context/EnvContext';
+import { useTheme } from '@/hooks/useTheme';
+import { useThemeStore } from '@/store/themeStore';
+import { useStatisticsStore } from '@/store/statisticsStore';
+import { useTranslation } from '@/hooks/useTranslation';
+import { navigateToLibrary } from '@/utils/nav';
+
+import BottomNav from '@/components/BottomNav';
+import StatisticsHeader from './components/StatisticsHeader';
+import StatsOverview from './components/StatsOverview';
+import StreakDisplay from './components/StreakDisplay';
+import ReadingCalendar from './components/ReadingCalendar';
+import TrendChart from './components/TrendChart';
+import TimeDistribution from './components/TimeDistribution';
+import BookStats from './components/BookStats';
+
+const StatisticsPage = () => {
+  const _ = useTranslation();
+  const router = useRouter();
+  const { envConfig, appService } = useEnv();
+  const { safeAreaInsets, isRoundedWindow } = useThemeStore();
+  const { loadStatistics, saveStatistics, loaded, userStats, dailySummaries, bookStats } =
+    useStatisticsStore();
+
+  const [calendarYear, setCalendarYear] = useState(() => new Date().getFullYear());
+  const [trendRange, setTrendRange] = useState<'week' | 'month' | 'year'>('week');
+
+  useTheme({ systemUIVisible: false });
+
+  // Always reload from file when statistics page mounts
+  // This ensures we get fresh data even if store was cached (hot reload)
+  useEffect(() => {
+    loadStatistics(envConfig);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [envConfig]);
+
+  // Save statistics periodically when the page is active
+  useEffect(() => {
+    if (!loaded) return;
+
+    const saveInterval = setInterval(() => {
+      saveStatistics(envConfig);
+    }, 60000); // Save every minute
+
+    return () => clearInterval(saveInterval);
+  }, [loaded, saveStatistics, envConfig]);
+
+  const handleGoBack = () => {
+    saveStatistics(envConfig);
+    navigateToLibrary(router);
+  };
+
+  if (!appService) {
+    return <div className='bg-base-100 full-height' />;
+  }
+
+  const isMobile = appService.isMobile;
+
+  return (
+    <div
+      className={clsx(
+        'statistics-page bg-base-100 full-height inset-0 flex select-none flex-col overflow-hidden',
+        appService.hasRoundedWindow && isRoundedWindow && 'window-border rounded-window',
+      )}
+    >
+      <StatisticsHeader onGoBack={handleGoBack} />
+
+      <OverlayScrollbarsComponent
+        defer
+        className='flex-1'
+        options={{ scrollbars: { autoHide: 'scroll' } }}
+      >
+        <div
+          className='mx-auto max-w-4xl space-y-6 px-4 pb-24 pt-16'
+          style={{
+            paddingTop: `calc(56px + ${safeAreaInsets?.top || 0}px + ${appService.hasTrafficLight ? 24 : 0}px)`,
+            paddingBottom: isMobile ? 'calc(80px + env(safe-area-inset-bottom))' : '24px',
+          }}
+        >
+          {/* Overview Cards */}
+          <StatsOverview stats={userStats} dailySummaries={dailySummaries} />
+
+          {/* Streak Display */}
+          <StreakDisplay
+            currentStreak={userStats.currentStreak}
+            longestStreak={userStats.longestStreak}
+            lastReadDate={userStats.lastReadDate}
+          />
+
+          {/* Reading Calendar */}
+          <ReadingCalendar
+            year={calendarYear}
+            dailySummaries={dailySummaries}
+            onYearChange={setCalendarYear}
+          />
+
+          {/* Charts Grid */}
+          <div className='grid gap-6 md:grid-cols-2'>
+            <TrendChart
+              dailySummaries={dailySummaries}
+              dateRange={trendRange}
+              onDateRangeChange={setTrendRange}
+            />
+            <TimeDistribution stats={userStats} />
+          </div>
+
+          {/* Book Statistics */}
+          <BookStats bookStats={bookStats} />
+
+          {/* Empty state */}
+          {userStats.totalSessions === 0 && (
+            <div className='bg-base-200 rounded-xl p-8 text-center'>
+              <h3 className='text-base-content mb-2 text-lg font-semibold'>
+                {_('No reading data yet')}
+              </h3>
+              <p className='text-base-content/60 mb-4'>
+                {_('Start reading a book to see your statistics here')}
+              </p>
+              <button className='btn btn-primary' onClick={handleGoBack}>
+                {_('Go to Library')}
+              </button>
+            </div>
+          )}
+        </div>
+      </OverlayScrollbarsComponent>
+
+      {/* Bottom navigation for mobile */}
+      {isMobile && <BottomNav />}
+    </div>
+  );
+};
+
+export default StatisticsPage;

--- a/apps/readest-app/src/components/BottomNav.tsx
+++ b/apps/readest-app/src/components/BottomNav.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import clsx from 'clsx';
+import { useRouter, usePathname } from 'next/navigation';
+import { PiBooks, PiChartBar, PiUserCircle } from 'react-icons/pi';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import { useResponsiveSize } from '@/hooks/useResponsiveSize';
+import { useThemeStore } from '@/store/themeStore';
+
+const BottomNav: React.FC = () => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const _ = useTranslation();
+  const iconSize = useResponsiveSize(22);
+  const { safeAreaInsets: insets } = useThemeStore();
+
+  const tabs = [
+    { path: '/library', icon: PiBooks, label: _('Library') },
+    { path: '/statistics', icon: PiChartBar, label: _('Statistics') },
+    { path: '/user', icon: PiUserCircle, label: _('Profile') },
+  ];
+
+  const isActive = (tabPath: string) => {
+    if (tabPath === '/library') {
+      return pathname === '/library' || pathname === '/';
+    }
+    return pathname?.startsWith(tabPath);
+  };
+
+  return (
+    <nav
+      className='btm-nav btm-nav-sm bg-base-200 border-base-300 z-50 border-t'
+      style={{
+        paddingBottom: insets?.bottom ? `${insets.bottom}px` : '0px',
+        height: `calc(56px + ${insets?.bottom || 0}px)`,
+      }}
+    >
+      {tabs.map((tab) => (
+        <button
+          key={tab.path}
+          className={clsx(
+            'text-base-content/60 transition-colors',
+            isActive(tab.path) && 'active text-primary',
+          )}
+          onClick={() => router.push(tab.path)}
+          aria-label={tab.label}
+        >
+          <tab.icon size={iconSize} />
+          <span className='btm-nav-label text-xs'>{tab.label}</span>
+        </button>
+      ))}
+    </nav>
+  );
+};
+
+export default BottomNav;

--- a/apps/readest-app/src/store/statisticsStore.ts
+++ b/apps/readest-app/src/store/statisticsStore.ts
@@ -37,6 +37,21 @@ const getDayOfWeek = (timestamp: number): number => {
   return new Date(timestamp).getDay();
 };
 
+// Helper to get days difference between two dates
+const getDaysDifference = (date1: string, date2: string): number => {
+  const d1 = new Date(date1);
+  const d2 = new Date(date2);
+  const diffTime = Math.abs(d2.getTime() - d1.getTime());
+  return Math.floor(diffTime / (1000 * 60 * 60 * 24));
+};
+
+// Helper to get yesterday's date string
+const getYesterdayString = (): string => {
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  return getDateString(yesterday.getTime());
+};
+
 interface StatisticsStore {
   // State
   sessions: ReadingSession[];
@@ -65,6 +80,11 @@ interface StatisticsStore {
   getDailySummary: (date: string) => DailyReadingSummary | null;
   getSessionsForBook: (bookHash: string, limit?: number) => ReadingSession[];
   getRecentSessions: (limit?: number) => ReadingSession[];
+  getCalendarData: (year?: number) => Record<string, number>;
+
+  // Aggregation
+  computeStreaks: () => void;
+  recomputeAllStats: () => void;
 
   // Persistence
   loadStatistics: (envConfig: EnvConfigType) => Promise<void>;
@@ -319,6 +339,215 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
     return get().sessions.slice(-limit).reverse();
   },
 
+  getCalendarData: (year) => {
+    const { dailySummaries } = get();
+    const targetYear = year ?? new Date().getFullYear();
+    const result: Record<string, number> = {};
+
+    // Get all dates for the target year
+    Object.entries(dailySummaries).forEach(([date, summary]) => {
+      if (date.startsWith(String(targetYear))) {
+        result[date] = summary.totalDuration;
+      }
+    });
+
+    return result;
+  },
+
+  computeStreaks: () => {
+    const { dailySummaries, userStats } = get();
+    const today = getDateString();
+    const yesterday = getYesterdayString();
+
+    // Get sorted dates that have reading activity
+    const readingDates = Object.keys(dailySummaries)
+      .filter((date) => dailySummaries[date]!.totalDuration > 0)
+      .sort();
+
+    if (readingDates.length === 0) {
+      set((state) => ({
+        userStats: {
+          ...state.userStats,
+          currentStreak: 0,
+          longestStreak: 0,
+        },
+      }));
+      return;
+    }
+
+    // Calculate current streak (must include today or yesterday)
+    let currentStreak = 0;
+    const lastReadDate = readingDates[readingDates.length - 1]!;
+
+    if (lastReadDate === today || lastReadDate === yesterday) {
+      currentStreak = 1;
+      let checkDate = lastReadDate;
+
+      // Count consecutive days backwards
+      for (let i = readingDates.length - 2; i >= 0; i--) {
+        const prevDate = readingDates[i]!;
+        const daysDiff = getDaysDifference(prevDate, checkDate);
+
+        if (daysDiff === 1) {
+          currentStreak++;
+          checkDate = prevDate;
+        } else {
+          break;
+        }
+      }
+    }
+
+    // Calculate longest streak
+    let longestStreak = 1;
+    let tempStreak = 1;
+
+    for (let i = 1; i < readingDates.length; i++) {
+      const daysDiff = getDaysDifference(readingDates[i - 1]!, readingDates[i]!);
+
+      if (daysDiff === 1) {
+        tempStreak++;
+        longestStreak = Math.max(longestStreak, tempStreak);
+      } else {
+        tempStreak = 1;
+      }
+    }
+
+    // Only update if values changed
+    if (currentStreak !== userStats.currentStreak || longestStreak !== userStats.longestStreak) {
+      set((state) => ({
+        userStats: {
+          ...state.userStats,
+          currentStreak,
+          longestStreak,
+        },
+      }));
+    }
+  },
+
+  recomputeAllStats: () => {
+    const { sessions } = get();
+
+    if (sessions.length === 0) {
+      set({
+        dailySummaries: {},
+        bookStats: {},
+        userStats: DEFAULT_USER_STATISTICS,
+      });
+      return;
+    }
+
+    // Rebuild daily summaries
+    const newDailySummaries: Record<string, DailyReadingSummary> = {};
+
+    // Rebuild book stats
+    const newBookStats: Record<string, BookStatistics> = {};
+
+    // Rebuild user stats
+    let totalReadingTime = 0;
+    let totalPagesRead = 0;
+    const uniqueBooks = new Set<string>();
+    const readingByHour = new Array(24).fill(0) as number[];
+    const readingByDayOfWeek = new Array(7).fill(0) as number[];
+
+    sessions.forEach((session) => {
+      const dateStr = getDateString(session.startTime);
+      const hour = getHour(session.startTime);
+      const dayOfWeek = getDayOfWeek(session.startTime);
+
+      // Update daily summary
+      const existing = newDailySummaries[dateStr];
+      if (existing) {
+        existing.totalDuration += session.duration;
+        existing.totalPages += session.pagesRead;
+        existing.sessionsCount += 1;
+        if (!existing.booksRead.includes(session.bookHash)) {
+          existing.booksRead.push(session.bookHash);
+        }
+      } else {
+        newDailySummaries[dateStr] = {
+          date: dateStr,
+          totalDuration: session.duration,
+          totalPages: session.pagesRead,
+          sessionsCount: 1,
+          booksRead: [session.bookHash],
+        };
+      }
+
+      // Update book stats
+      const bookStat = newBookStats[session.bookHash];
+      if (bookStat) {
+        bookStat.totalReadingTime += session.duration;
+        bookStat.totalSessions += 1;
+        bookStat.totalPagesRead += session.pagesRead;
+        bookStat.lastReadAt = Math.max(bookStat.lastReadAt, session.endTime);
+        if (session.endProgress >= 0.99 && !bookStat.completedAt) {
+          bookStat.completedAt = session.endTime;
+        }
+      } else {
+        newBookStats[session.bookHash] = {
+          bookHash: session.bookHash,
+          metaHash: session.metaHash,
+          totalReadingTime: session.duration,
+          totalSessions: 1,
+          totalPagesRead: session.pagesRead,
+          averageSessionDuration: session.duration,
+          averageReadingSpeed:
+            session.duration > 0 ? session.pagesRead / (session.duration / 3600) : 0,
+          firstReadAt: session.startTime,
+          lastReadAt: session.endTime,
+          completedAt: session.endProgress >= 0.99 ? session.endTime : undefined,
+        };
+      }
+
+      // Update user totals
+      totalReadingTime += session.duration;
+      totalPagesRead += session.pagesRead;
+      uniqueBooks.add(session.bookHash);
+      readingByHour[hour] += session.duration;
+      readingByDayOfWeek[dayOfWeek] += session.duration;
+    });
+
+    // Calculate averages for book stats
+    Object.values(newBookStats).forEach((stat) => {
+      stat.averageSessionDuration = stat.totalReadingTime / stat.totalSessions;
+      stat.averageReadingSpeed =
+        stat.totalReadingTime > 0 ? stat.totalPagesRead / (stat.totalReadingTime / 3600) : 0;
+    });
+
+    // Count completed books
+    const completedBooks = Object.values(newBookStats).filter((bs) => bs.completedAt).length;
+
+    // Calculate average daily reading time
+    const daysWithReading = Object.keys(newDailySummaries).length;
+    const averageDailyReadingTime = daysWithReading > 0 ? totalReadingTime / daysWithReading : 0;
+
+    // Get last read date
+    const sortedDates = Object.keys(newDailySummaries).sort();
+    const lastReadDate = sortedDates[sortedDates.length - 1] || '';
+
+    set({
+      dailySummaries: newDailySummaries,
+      bookStats: newBookStats,
+      userStats: {
+        totalReadingTime,
+        totalBooksStarted: uniqueBooks.size,
+        totalBooksCompleted: completedBooks,
+        totalPagesRead,
+        totalSessions: sessions.length,
+        currentStreak: 0, // Will be computed by computeStreaks
+        longestStreak: 0, // Will be computed by computeStreaks
+        lastReadDate,
+        averageSessionDuration: sessions.length > 0 ? totalReadingTime / sessions.length : 0,
+        averageDailyReadingTime,
+        readingByHour,
+        readingByDayOfWeek,
+      },
+    });
+
+    // Compute streaks after rebuilding
+    get().computeStreaks();
+  },
+
   loadStatistics: async (envConfig) => {
     try {
       const appService = await envConfig.getAppService();
@@ -341,6 +570,9 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
         config: { ...DEFAULT_STATISTICS_CONFIG, ...data.config },
         loaded: true,
       });
+
+      // Compute streaks on load (in case days have passed since last session)
+      get().computeStreaks();
 
       console.log(
         '[Statistics] Loaded statistics data, now have',

--- a/apps/readest-app/src/store/statisticsStore.ts
+++ b/apps/readest-app/src/store/statisticsStore.ts
@@ -1,0 +1,379 @@
+import { create } from 'zustand';
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  ReadingSession,
+  DailyReadingSummary,
+  BookStatistics,
+  UserStatistics,
+  StatisticsConfig,
+  ActiveSession,
+  StatisticsData,
+  DEFAULT_STATISTICS_CONFIG,
+  DEFAULT_USER_STATISTICS,
+  DEFAULT_STATISTICS_DATA,
+  CURRENT_STATISTICS_VERSION,
+} from '@/types/statistics';
+import { EnvConfigType } from '@/services/environment';
+
+const STATISTICS_FILENAME = 'statistics.json';
+
+// Helper to get date string in YYYY-MM-DD format (local timezone)
+const getDateString = (timestamp: number = Date.now()): string => {
+  const date = new Date(timestamp);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+// Helper to get hour from timestamp (0-23)
+const getHour = (timestamp: number): number => {
+  return new Date(timestamp).getHours();
+};
+
+// Helper to get day of week from timestamp (0=Sunday)
+const getDayOfWeek = (timestamp: number): number => {
+  return new Date(timestamp).getDay();
+};
+
+interface StatisticsStore {
+  // State
+  sessions: ReadingSession[];
+  dailySummaries: Record<string, DailyReadingSummary>;
+  bookStats: Record<string, BookStatistics>;
+  userStats: UserStatistics;
+  config: StatisticsConfig;
+  activeSessions: Record<string, ActiveSession>;
+  loaded: boolean;
+
+  // Session lifecycle
+  startSession: (
+    bookKey: string,
+    bookHash: string,
+    metaHash: string | undefined,
+    progress: number,
+    page: number,
+    totalPages: number,
+  ) => void;
+  updateSessionActivity: (bookKey: string, progress: number, page: number) => void;
+  endSession: (bookKey: string, reason: 'closed' | 'idle' | 'switched') => ReadingSession | null;
+  endAllSessions: () => void;
+
+  // Data access
+  getBookStatistics: (bookHash: string) => BookStatistics | null;
+  getDailySummary: (date: string) => DailyReadingSummary | null;
+  getSessionsForBook: (bookHash: string, limit?: number) => ReadingSession[];
+  getRecentSessions: (limit?: number) => ReadingSession[];
+
+  // Persistence
+  loadStatistics: (envConfig: EnvConfigType) => Promise<void>;
+  saveStatistics: (envConfig: EnvConfigType) => Promise<void>;
+
+  // Config
+  setConfig: (config: Partial<StatisticsConfig>) => void;
+}
+
+export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
+  sessions: [],
+  dailySummaries: {},
+  bookStats: {},
+  userStats: DEFAULT_USER_STATISTICS,
+  config: DEFAULT_STATISTICS_CONFIG,
+  activeSessions: {},
+  loaded: false,
+
+  startSession: (bookKey, bookHash, metaHash, progress, page, totalPages) => {
+    const { config, activeSessions } = get();
+    if (!config.trackingEnabled) return;
+
+    // If there's already an active session for this book key, don't start a new one
+    if (activeSessions[bookKey]) {
+      return;
+    }
+
+    const now = Date.now();
+    const session: ActiveSession = {
+      bookKey,
+      bookHash,
+      metaHash,
+      startTime: now,
+      startProgress: progress,
+      startPage: page,
+      lastActivityTime: now,
+      lastProgress: progress,
+      lastPage: page,
+      totalPages,
+    };
+
+    set((state) => ({
+      activeSessions: {
+        ...state.activeSessions,
+        [bookKey]: session,
+      },
+    }));
+
+    console.log('[Statistics] Started session for', bookKey, 'at page', page);
+  },
+
+  updateSessionActivity: (bookKey, progress, page) => {
+    const { activeSessions, config } = get();
+    if (!config.trackingEnabled) return;
+
+    const session = activeSessions[bookKey];
+    if (!session) return;
+
+    set((state) => ({
+      activeSessions: {
+        ...state.activeSessions,
+        [bookKey]: {
+          ...session,
+          lastActivityTime: Date.now(),
+          lastProgress: progress,
+          lastPage: page,
+        },
+      },
+    }));
+  },
+
+  endSession: (bookKey, _reason) => {
+    const { activeSessions, config, dailySummaries, bookStats } = get();
+    if (!config.trackingEnabled) return null;
+
+    const activeSession = activeSessions[bookKey];
+    if (!activeSession) return null;
+
+    const now = Date.now();
+    const duration = Math.floor((now - activeSession.startTime) / 1000);
+
+    // Don't record sessions shorter than minimum
+    if (duration < config.minimumSessionSeconds) {
+      set((state) => {
+        const newActiveSessions = { ...state.activeSessions };
+        delete newActiveSessions[bookKey];
+        return { activeSessions: newActiveSessions };
+      });
+      console.log('[Statistics] Session too short, discarding', duration, 'seconds');
+      return null;
+    }
+
+    const pagesRead = Math.max(0, activeSession.lastPage - activeSession.startPage);
+
+    const session: ReadingSession = {
+      id: uuidv4(),
+      bookHash: activeSession.bookHash,
+      metaHash: activeSession.metaHash,
+      startTime: activeSession.startTime,
+      endTime: now,
+      duration,
+      startProgress: activeSession.startProgress,
+      endProgress: activeSession.lastProgress,
+      startPage: activeSession.startPage,
+      endPage: activeSession.lastPage,
+      pagesRead,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    // Update daily summary
+    const dateStr = getDateString(activeSession.startTime);
+    const existingSummary = dailySummaries[dateStr];
+    const updatedSummary: DailyReadingSummary = existingSummary
+      ? {
+          ...existingSummary,
+          totalDuration: existingSummary.totalDuration + duration,
+          totalPages: existingSummary.totalPages + pagesRead,
+          sessionsCount: existingSummary.sessionsCount + 1,
+          booksRead: existingSummary.booksRead.includes(session.bookHash)
+            ? existingSummary.booksRead
+            : [...existingSummary.booksRead, session.bookHash],
+        }
+      : {
+          date: dateStr,
+          totalDuration: duration,
+          totalPages: pagesRead,
+          sessionsCount: 1,
+          booksRead: [session.bookHash],
+        };
+
+    // Update book statistics
+    const existingBookStats = bookStats[session.bookHash];
+    const updatedBookStats: BookStatistics = existingBookStats
+      ? {
+          ...existingBookStats,
+          totalReadingTime: existingBookStats.totalReadingTime + duration,
+          totalSessions: existingBookStats.totalSessions + 1,
+          totalPagesRead: existingBookStats.totalPagesRead + pagesRead,
+          averageSessionDuration:
+            (existingBookStats.totalReadingTime + duration) / (existingBookStats.totalSessions + 1),
+          averageReadingSpeed:
+            (existingBookStats.totalPagesRead + pagesRead) /
+            ((existingBookStats.totalReadingTime + duration) / 3600),
+          lastReadAt: now,
+          completedAt: session.endProgress >= 0.99 ? now : existingBookStats.completedAt,
+        }
+      : {
+          bookHash: session.bookHash,
+          metaHash: session.metaHash,
+          totalReadingTime: duration,
+          totalSessions: 1,
+          totalPagesRead: pagesRead,
+          averageSessionDuration: duration,
+          averageReadingSpeed: pagesRead / (duration / 3600) || 0,
+          firstReadAt: now,
+          lastReadAt: now,
+          completedAt: session.endProgress >= 0.99 ? now : undefined,
+        };
+
+    set((state) => {
+      const newActiveSessions = { ...state.activeSessions };
+      delete newActiveSessions[bookKey];
+
+      // Update user stats
+      const hour = getHour(activeSession.startTime);
+      const dayOfWeek = getDayOfWeek(activeSession.startTime);
+      const newReadingByHour = [...state.userStats.readingByHour];
+      const newReadingByDayOfWeek = [...state.userStats.readingByDayOfWeek];
+      newReadingByHour[hour] = (newReadingByHour[hour] || 0) + duration;
+      newReadingByDayOfWeek[dayOfWeek] = (newReadingByDayOfWeek[dayOfWeek] || 0) + duration;
+
+      const newTotalReadingTime = state.userStats.totalReadingTime + duration;
+      const newTotalSessions = state.userStats.totalSessions + 1;
+      const newTotalPagesRead = state.userStats.totalPagesRead + pagesRead;
+
+      // Count unique books started
+      const uniqueBooks = new Set(state.sessions.map((s) => s.bookHash));
+      uniqueBooks.add(session.bookHash);
+
+      // Count completed books
+      const completedBooks = Object.values({
+        ...state.bookStats,
+        [session.bookHash]: updatedBookStats,
+      }).filter((bs) => bs.completedAt).length;
+
+      return {
+        activeSessions: newActiveSessions,
+        sessions: [...state.sessions, session],
+        dailySummaries: {
+          ...state.dailySummaries,
+          [dateStr]: updatedSummary,
+        },
+        bookStats: {
+          ...state.bookStats,
+          [session.bookHash]: updatedBookStats,
+        },
+        userStats: {
+          ...state.userStats,
+          totalReadingTime: newTotalReadingTime,
+          totalSessions: newTotalSessions,
+          totalPagesRead: newTotalPagesRead,
+          totalBooksStarted: uniqueBooks.size,
+          totalBooksCompleted: completedBooks,
+          averageSessionDuration: newTotalReadingTime / newTotalSessions,
+          lastReadDate: dateStr,
+          readingByHour: newReadingByHour,
+          readingByDayOfWeek: newReadingByDayOfWeek,
+        },
+      };
+    });
+
+    console.log('[Statistics] Ended session for', bookKey, 'duration:', duration, 'seconds');
+    return session;
+  },
+
+  endAllSessions: () => {
+    const { activeSessions, endSession } = get();
+    Object.keys(activeSessions).forEach((bookKey) => {
+      endSession(bookKey, 'closed');
+    });
+  },
+
+  getBookStatistics: (bookHash) => {
+    return get().bookStats[bookHash] || null;
+  },
+
+  getDailySummary: (date) => {
+    return get().dailySummaries[date] || null;
+  },
+
+  getSessionsForBook: (bookHash, limit = 100) => {
+    return get()
+      .sessions.filter((s) => s.bookHash === bookHash)
+      .slice(-limit);
+  },
+
+  getRecentSessions: (limit = 10) => {
+    return get().sessions.slice(-limit).reverse();
+  },
+
+  loadStatistics: async (envConfig) => {
+    try {
+      const appService = await envConfig.getAppService();
+      let data: StatisticsData;
+
+      if (await appService.exists(STATISTICS_FILENAME, 'Settings')) {
+        const content = await appService.readFile(STATISTICS_FILENAME, 'Settings', 'text');
+        data = JSON.parse(content as string) as StatisticsData;
+        console.log('[Statistics] Loaded from file:', data.sessions?.length || 0, 'sessions');
+      } else {
+        data = DEFAULT_STATISTICS_DATA;
+        console.log('[Statistics] No file found, using defaults');
+      }
+
+      set({
+        sessions: data.sessions || [],
+        dailySummaries: data.dailySummaries || {},
+        bookStats: data.bookStats || {},
+        userStats: { ...DEFAULT_USER_STATISTICS, ...data.userStats },
+        config: { ...DEFAULT_STATISTICS_CONFIG, ...data.config },
+        loaded: true,
+      });
+
+      console.log(
+        '[Statistics] Loaded statistics data, now have',
+        get().sessions.length,
+        'sessions',
+      );
+    } catch (error) {
+      console.error('[Statistics] Failed to load statistics:', error);
+      set({
+        ...DEFAULT_STATISTICS_DATA,
+        loaded: true,
+      });
+    }
+  },
+
+  saveStatistics: async (envConfig) => {
+    try {
+      const appService = await envConfig.getAppService();
+      const { sessions, dailySummaries, bookStats, userStats, config } = get();
+
+      console.log('[Statistics] Saving with', sessions.length, 'sessions');
+
+      const data: StatisticsData = {
+        version: CURRENT_STATISTICS_VERSION,
+        sessions,
+        dailySummaries,
+        bookStats,
+        userStats,
+        config,
+        lastUpdated: Date.now(),
+      };
+
+      await appService.writeFile(STATISTICS_FILENAME, 'Settings', JSON.stringify(data, null, 2));
+
+      console.log('[Statistics] Saved statistics data successfully');
+    } catch (error) {
+      console.error('[Statistics] Failed to save statistics:', error);
+    }
+  },
+
+  setConfig: (configUpdate) => {
+    set((state) => ({
+      config: {
+        ...state.config,
+        ...configUpdate,
+      },
+    }));
+  },
+}));

--- a/apps/readest-app/src/store/statisticsStore.ts
+++ b/apps/readest-app/src/store/statisticsStore.ts
@@ -503,8 +503,8 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
       totalReadingTime += session.duration;
       totalPagesRead += session.pagesRead;
       uniqueBooks.add(session.bookHash);
-      readingByHour[hour] += session.duration;
-      readingByDayOfWeek[dayOfWeek] += session.duration;
+      readingByHour[hour] = (readingByHour[hour] ?? 0) + session.duration;
+      readingByDayOfWeek[dayOfWeek] = (readingByDayOfWeek[dayOfWeek] ?? 0) + session.duration;
     });
 
     // Calculate averages for book stats

--- a/apps/readest-app/src/store/statisticsStore.ts
+++ b/apps/readest-app/src/store/statisticsStore.ts
@@ -136,7 +136,7 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
     }));
   },
 
-  endSession: (bookKey, _reason) => {
+  endSession: (bookKey, reason) => {
     const { activeSessions, config, dailySummaries, bookStats } = get();
     if (!config.trackingEnabled) return null;
 
@@ -153,7 +153,12 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
         delete newActiveSessions[bookKey];
         return { activeSessions: newActiveSessions };
       });
-      console.log('[Statistics] Session too short, discarding', duration, 'seconds');
+      console.log(
+        '[Statistics] Session too short, discarding',
+        duration,
+        'seconds, reason:',
+        reason,
+      );
       return null;
     }
 
@@ -219,7 +224,7 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
           totalSessions: 1,
           totalPagesRead: pagesRead,
           averageSessionDuration: duration,
-          averageReadingSpeed: pagesRead / (duration / 3600) || 0,
+          averageReadingSpeed: duration > 0 ? pagesRead / (duration / 3600) : 0,
           firstReadAt: now,
           lastReadAt: now,
           completedAt: session.endProgress >= 0.99 ? now : undefined,
@@ -277,7 +282,15 @@ export const useStatisticsStore = create<StatisticsStore>((set, get) => ({
       };
     });
 
-    console.log('[Statistics] Ended session for', bookKey, 'duration:', duration, 'seconds');
+    console.log(
+      '[Statistics] Ended session for',
+      bookKey,
+      'reason:',
+      reason,
+      'duration:',
+      duration,
+      'seconds',
+    );
     return session;
   },
 

--- a/apps/readest-app/src/types/statistics.ts
+++ b/apps/readest-app/src/types/statistics.ts
@@ -1,0 +1,127 @@
+// Reading session - individual reading period for a book
+export interface ReadingSession {
+  id: string; // UUID
+  bookHash: string; // Book identifier
+  metaHash?: string; // For aggregating book versions
+
+  startTime: number; // Session start (ms timestamp)
+  endTime: number; // Session end (ms timestamp)
+  duration: number; // Duration in seconds
+
+  startProgress: number; // Progress at start (0-1)
+  endProgress: number; // Progress at end (0-1)
+  startPage: number; // Page at start
+  endPage: number; // Page at end
+  pagesRead: number; // Pages read in session
+
+  createdAt: number;
+  updatedAt: number;
+}
+
+// Daily reading summary
+export interface DailyReadingSummary {
+  date: string; // YYYY-MM-DD
+  totalDuration: number; // Seconds read
+  totalPages: number;
+  sessionsCount: number;
+  booksRead: string[]; // Book hashes
+}
+
+// Book-specific statistics
+export interface BookStatistics {
+  bookHash: string;
+  metaHash?: string;
+  totalReadingTime: number; // Seconds
+  totalSessions: number;
+  totalPagesRead: number;
+  averageSessionDuration: number;
+  averageReadingSpeed: number; // Pages per hour
+  firstReadAt: number;
+  lastReadAt: number;
+  completedAt?: number;
+}
+
+// User statistics
+export interface UserStatistics {
+  totalReadingTime: number;
+  totalBooksStarted: number;
+  totalBooksCompleted: number;
+  totalPagesRead: number;
+  totalSessions: number;
+
+  currentStreak: number; // Consecutive days
+  longestStreak: number;
+  lastReadDate: string; // YYYY-MM-DD
+
+  averageSessionDuration: number;
+  averageDailyReadingTime: number;
+
+  readingByHour: number[]; // 24 elements (0-23)
+  readingByDayOfWeek: number[]; // 7 elements (0=Sunday)
+}
+
+// Configuration
+export interface StatisticsConfig {
+  trackingEnabled: boolean;
+  idleTimeoutMinutes: number; // Default: 5
+  minimumSessionSeconds: number; // Default: 30
+}
+
+// Active session tracking (not persisted)
+export interface ActiveSession {
+  bookKey: string;
+  bookHash: string;
+  metaHash?: string;
+  startTime: number;
+  startProgress: number;
+  startPage: number;
+  lastActivityTime: number;
+  lastProgress: number;
+  lastPage: number;
+  totalPages: number;
+}
+
+// Storage format
+export interface StatisticsData {
+  version: number;
+  sessions: ReadingSession[];
+  dailySummaries: Record<string, DailyReadingSummary>;
+  bookStats: Record<string, BookStatistics>;
+  userStats: UserStatistics;
+  config: StatisticsConfig;
+  lastUpdated: number;
+}
+
+// Default values
+export const DEFAULT_STATISTICS_CONFIG: StatisticsConfig = {
+  trackingEnabled: true,
+  idleTimeoutMinutes: 5,
+  minimumSessionSeconds: 30,
+};
+
+export const DEFAULT_USER_STATISTICS: UserStatistics = {
+  totalReadingTime: 0,
+  totalBooksStarted: 0,
+  totalBooksCompleted: 0,
+  totalPagesRead: 0,
+  totalSessions: 0,
+  currentStreak: 0,
+  longestStreak: 0,
+  lastReadDate: '',
+  averageSessionDuration: 0,
+  averageDailyReadingTime: 0,
+  readingByHour: new Array(24).fill(0),
+  readingByDayOfWeek: new Array(7).fill(0),
+};
+
+export const CURRENT_STATISTICS_VERSION = 1;
+
+export const DEFAULT_STATISTICS_DATA: StatisticsData = {
+  version: CURRENT_STATISTICS_VERSION,
+  sessions: [],
+  dailySummaries: {},
+  bookStats: {},
+  userStats: DEFAULT_USER_STATISTICS,
+  config: DEFAULT_STATISTICS_CONFIG,
+  lastUpdated: Date.now(),
+};

--- a/apps/readest-app/src/utils/format.ts
+++ b/apps/readest-app/src/utils/format.ts
@@ -1,0 +1,30 @@
+/**
+ * Format a duration in seconds to a human-readable string.
+ * @param seconds - Duration in seconds
+ * @returns Formatted string like "2h 30m" or "45m"
+ */
+export const formatDuration = (seconds: number): string => {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+};
+
+/**
+ * Format a date relative to now (Today, Yesterday, X days ago, etc.)
+ * @param timestamp - Unix timestamp in milliseconds
+ * @returns Formatted relative date string
+ */
+export const formatRelativeDate = (timestamp: number): string => {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+};

--- a/apps/readest-app/src/utils/format.ts
+++ b/apps/readest-app/src/utils/format.ts
@@ -1,4 +1,18 @@
 /**
+ * Get date string in YYYY-MM-DD format using LOCAL timezone.
+ * This matches the format used in statisticsStore for session dates.
+ * DO NOT use toISOString() as it returns UTC which causes timezone mismatches.
+ * @param date - Date object (defaults to now)
+ * @returns Date string in YYYY-MM-DD format
+ */
+export const getLocalDateString = (date: Date = new Date()): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+/**
  * Format a duration in seconds to a human-readable string.
  * @param seconds - Duration in seconds
  * @returns Formatted string like "2h 30m" or "45m"


### PR DESCRIPTION
## Summary

Adds Phase 3 of the reading statistics feature: a dedicated `/statistics` page with visualization components.

**Depends on:** PR #3158 (Phase 2 - Aggregation Methods)

## New Route

`/statistics` - Dedicated page for viewing reading statistics

## Components Added

| Component | Description |
|-----------|-------------|
| **StatsOverview** | 4 summary cards: Total reading time, Books completed, Current streak, Pages this month |
| **StreakDisplay** | Large streak counter with flame icon, longest streak, 7-day activity dots |
| **ReadingCalendar** | year heatmap showing reading activity by day |
| **TimeDistribution** | Bar chart toggling between "By Hour" (24h) and "By Day" (weekly) views |
| **TrendChart** | Line/bar chart with week/month/year range selector |
| **BookStats** | Sortable list of books with cover images, reading time, and last read date |
| **StatisticsHeader** | Header with back button and window controls |
| **BottomNav** | Mobile bottom navigation bar (Library, Statistics, Profile) |

I am open to feedback regarding these components and start a discussion of what other visuals are desired.

## Screenshots

<img width="1694" height="1029" alt="image" src="https://github.com/user-attachments/assets/147c6055-d1fc-4d0c-a5c5-c746ac0e83f0" />

<img width="909" height="962" alt="image" src="https://github.com/user-attachments/assets/a87e8bcb-ce87-4279-be28-2a4fec416d6d" />

<img width="1696" height="1028" alt="image" src="https://github.com/user-attachments/assets/96ab6059-ed44-40b3-b88c-98ce9bc8fe91" />


## Testing

1. Run `pnpm tauri dev`
2. Navigate to `/statistics` (or use BottomNav on mobile)
3. Read some books to generate data, then view the statistics
