### PR TITLE
fix: delay context menu to prevent broken input loop on macOS, closes #3324

### DIFF
--- a/apps/readest-app/src/hooks/useLongPress.ts
+++ b/apps/readest-app/src/hooks/useLongPress.ts
@@ -140,7 +140,9 @@ export const useLongPress = (
       if (onContextMenu) {
         e.preventDefault();
         e.stopPropagation();
-        onContextMenu();
+        setTimeout(() => {
+          onContextMenu();
+        }, 100);
       }
       reset();
     },


### PR DESCRIPTION
When a native context menu is triggered via right-click, the menu.popup() call immediately takes control and disrupts the browser's pointer event flow. This prevents the pointerUp event from being delivered, leaving the input event loop in an inconsistent state where the first tap after dismissing the menu is not captured.

The fix adds a 100ms delay before showing the context menu, allowing the browser's input loop to complete the pointerUp event for the right-click before the native menu interferes.