### PR TITLE
fix(notebook): close searchbar when adding or editing an annotation

### DIFF
--- a/apps/readest-app/src/app/reader/components/notebook/Notebook.tsx
+++ b/apps/readest-app/src/app/reader/components/notebook/Notebook.tsx
@@ -92,6 +92,14 @@ const Notebook: React.FC = ({}) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    if (!isNotebookVisible || notebookNewAnnotation || notebookEditAnnotation) {
+      setIsSearchBarVisible(false);
+      setSearchResults(null);
+      setSearchTerm('');
+    }
+  }, [isNotebookVisible, notebookNewAnnotation, notebookEditAnnotation]);
+
   const handleNotebookResize = (newWidth: string) => {
     setNotebookWidth(newWidth);
     settings.globalReadSettings.notebookWidth = newWidth;


### PR DESCRIPTION
## Description
This PR fixes a bug where the Notebook's search bar would remain active and steal focus when reopening the sidebar to create a new annotation or when trying to edit an existing one.

## Problem
The `Notebook`  component preserved its local isSearchBarVisible state even when the sidebar was closed. If a user closed the sidebar while searching and then later selected a word to annotate, the sidebar would reopen with the search bar still active.

This caused two main issues:

1. **Focus Stealing:** The search input would automatically steal focus (via its auto-focus useEffect), preventing the user from typing their note immediately.
2. **Hidden UI** The NoteEditor would remain hidden because it is conditionally rendered only when the search bar is inactive.

Additionally, if a user had the search bar active and clicked "Edit" on an existing annotation, the search bar did not close. Consequently, the NoteEditor remained hidden, making it impossible to edit the note until the search bar was manually dismissed.

## Solution
Added a useEffect hook in `Notebook.tsx` to clear the search state whenever:

- The notebook is closed.
- A new annotation is initiated.
- An existing note is edited.
