### PR TITLE
fix: respect fixed translation quota in UI stats and DeepL provider

### DIFF
--- a/apps/readest-app/src/services/translators/providers/deepl.ts
+++ b/apps/readest-app/src/services/translators/providers/deepl.ts
@@ -2,9 +2,8 @@ import { getAPIBaseUrl } from '@/services/environment';
 import { stubTranslation as _ } from '@/utils/misc';
 import { ErrorCodes, TranslationProvider } from '../types';
 import { UserPlan } from '@/types/quota';
-import { getSubscriptionPlan } from '@/utils/access';
+import { getSubscriptionPlan, getTranslationQuota } from '@/utils/access';
 import { normalizeToShortLang } from '@/utils/lang';
-import { DEFAULT_DAILY_TRANSLATION_QUOTA } from '@/services/constants';
 import { saveDailyUsage } from '../utils';
 
 const DEEPL_API_ENDPOINT = getAPIBaseUrl() + '/deepl/translate';
@@ -44,7 +43,7 @@ export const deeplProvider: TranslationProvider = {
       use_cache: useCache,
     });
 
-    const quota = DEFAULT_DAILY_TRANSLATION_QUOTA[userPlan];
+    const quota = getTranslationQuota(userPlan);
     try {
       const response = await fetch(DEEPL_API_ENDPOINT, { method: 'POST', headers, body });
 

--- a/apps/readest-app/src/utils/access.ts
+++ b/apps/readest-app/src/utils/access.ts
@@ -47,11 +47,18 @@ export const getStoragePlanData = (token: string) => {
   };
 };
 
+export const getTranslationQuota = (plan: UserPlan): number => {
+  const fixedQuota = parseInt(process.env['NEXT_PUBLIC_TRANSLATION_FIXED_QUOTA'] || '0');
+  return (
+    fixedQuota || DEFAULT_DAILY_TRANSLATION_QUOTA[plan] || DEFAULT_DAILY_TRANSLATION_QUOTA['free']
+  );
+};
+
 export const getTranslationPlanData = (token: string) => {
   const data = jwtDecode<Token>(token) || {};
   const plan: UserPlan = data['plan'] || 'free';
   const usage = getDailyUsage() || 0;
-  const quota = DEFAULT_DAILY_TRANSLATION_QUOTA[plan];
+  const quota = getTranslationQuota(plan);
 
   return {
     plan,
@@ -63,9 +70,7 @@ export const getTranslationPlanData = (token: string) => {
 export const getDailyTranslationPlanData = (token: string) => {
   const data = jwtDecode<Token>(token) || {};
   const plan = data['plan'] || 'free';
-  const fixedQuota = parseInt(process.env['NEXT_PUBLIC_TRANSLATION_FIXED_QUOTA'] || '0');
-  const quota =
-    fixedQuota || DEFAULT_DAILY_TRANSLATION_QUOTA[plan] || DEFAULT_DAILY_TRANSLATION_QUOTA['free'];
+  const quota = getTranslationQuota(plan);
 
   return {
     plan,


### PR DESCRIPTION
This PR ensures that the translation quota is consistently respected across both the UI (statistics display) and the translation providers (specifically DeepL). Previously, the DeepL provider was hardcoded to a 10K limit, and the UI did not always reflect the variable correctly. This fix introduces a unified helper and updates the relevant components to use it.