### PR TITLE
Fix: Non-ASCII characters break OPDS Catalog auth

### DIFF
--- a/apps/readest-app/src/app/opds/utils/opdsReq.ts
+++ b/apps/readest-app/src/app/opds/utils/opdsReq.ts
@@ -176,8 +176,10 @@ export const createDigestAuth = async (
  * Create Basic Authorization header
  */
 export const createBasicAuth = (username: string, password: string): string => {
-  const credentials = btoa(`${username}:${password}`);
-  return `Basic ${credentials}`;
+  const credentials = `${username}:${password}`;
+  const utf8Bytes = new TextEncoder().encode(credentials);
+  const encoded = btoa(String.fromCharCode(...utf8Bytes));
+  return `Basic ${encoded}`;
 };
 
 /**


### PR DESCRIPTION
`btoa` does not correctly encode non-ASCII characters, this results in incorrect login credentials passed along when adding a new catalog if the username or password includes non-ASCII characters.

Replaced `btoa` with [TextEncoder](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder), manually tested on web client.