### PR TITLE
fix(footnote): add overflow-wrap to footnote popup to prevent long words from overflowing

### DIFF
--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -473,6 +473,7 @@ export const getFootnoteStyles = () => `
 
   body {
     padding: 1em !important;
+    overflow-wrap: break-word;
   }
 
   a:any-link {


### PR DESCRIPTION
The change adds overflow-wrap: break-word to the footnote popup body styles, which ensures long unbreakable strings (like URLs or long words) wrap properly instead of overflowing the popup container.

closes #3468