### PR TITLE
fix(reader): apply alwaysOnTop to all windows and on reader init, closes #3482

### DIFF
--- a/apps/readest-app/src/app/reader/page.tsx
+++ b/apps/readest-app/src/app/reader/page.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { useOpenWithBooks } from '@/hooks/useOpenWithBooks';
 import { useSettingsStore } from '@/store/settingsStore';
 import { checkForAppUpdates, checkAppReleaseNotes } from '@/helpers/updater';
+import { tauriHandleSetAlwaysOnTop } from '@/utils/window';
 import Reader from './components/Reader';
 
 // This is only used for the Tauri app in the app router
@@ -24,6 +25,9 @@ export default function Page() {
         checkAppReleaseNotes();
       }
     };
+    if (appService?.hasWindow && settings.alwaysOnTop) {
+      tauriHandleSetAlwaysOnTop(settings.alwaysOnTop);
+    }
     doCheckAppUpdates();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appService?.hasUpdater, settings.autoCheckUpdates]);

--- a/apps/readest-app/src/utils/window.ts
+++ b/apps/readest-app/src/utils/window.ts
@@ -1,4 +1,4 @@
-import { getCurrentWindow } from '@tauri-apps/api/window';
+import { getAllWindows, getCurrentWindow } from '@tauri-apps/api/window';
 import { emitTo, TauriEvent } from '@tauri-apps/api/event';
 import { exit } from '@tauri-apps/plugin-process';
 import { type as osType } from '@tauri-apps/plugin-os';
@@ -76,8 +76,8 @@ export const tauriHandleToggleFullScreen = async () => {
 };
 
 export const tauriHandleSetAlwaysOnTop = async (isAlwaysOnTop: boolean) => {
-  const currentWindow = getCurrentWindow();
-  await currentWindow.setAlwaysOnTop(isAlwaysOnTop);
+  const windows = await getAllWindows();
+  await Promise.all(windows.map((w) => w.setAlwaysOnTop(isAlwaysOnTop)));
 };
 
 export const tauriGetAlwaysOnTop = async () => {


### PR DESCRIPTION
## Summary

- **Apply `alwaysOnTop` on reader window init**: when a book is opened in a new window, `reader/page.tsx` now applies the setting on mount so the new window correctly inherits it (previously only `library/page.tsx` did this)
- **Apply to all windows**: `tauriHandleSetAlwaysOnTop` now uses `getAllWindows()` to set the flag on every open window, so toggling from the library also affects any open reader windows

The setting remains accessible via the command palette (`Cmd+K` → "Always on Top") from within the reader.

## Test plan

- [ ] Enable Always on Top from the library settings menu, then open a book in a new window — the reader window should also be always on top
- [ ] Toggle Always on Top from the library while a reader window is open — both windows should update
- [ ] Toggle via command palette from within the reader — both windows should update

🤖 Generated with [Claude Code](https://claude.com/claude-code)