### PR TITLE
fix(i18n): handle POSIX locale values in getLocale(), closes #3518

### DIFF
--- a/apps/readest-app/src/app/user/components/PlanCard.tsx
+++ b/apps/readest-app/src/app/user/components/PlanCard.tsx
@@ -29,9 +29,10 @@ const PlanCard: React.FC<PlanCardProps> = ({
 }) => {
   const _ = useTranslation();
   const { price, currency } = plan;
-  const formattedPrice = new Intl.NumberFormat(getLocale(), { style: 'currency', currency }).format(
-    price / 100,
-  );
+  const formattedPrice = new Intl.NumberFormat(getLocale(), {
+    style: 'currency',
+    currency,
+  }).format(price / 100);
 
   return (
     <div

--- a/apps/readest-app/src/utils/misc.ts
+++ b/apps/readest-app/src/utils/misc.ts
@@ -32,7 +32,11 @@ export const makeSafeFilename = (filename: string, replacement = '_') => {
 };
 
 export const getLocale = () => {
-  return localStorage?.getItem('i18nextLng') || navigator?.language || '';
+  const locale = localStorage?.getItem('i18nextLng') || navigator?.language || '';
+  // POSIX locale values (e.g. 'C', 'C.UTF-8', 'POSIX') are not valid BCP 47
+  // tags and would cause Intl/toLocaleString to throw — fall back to en-US
+  if (!locale || /^(C|POSIX)(\..*)?$/i.test(locale)) return 'en-US';
+  return locale;
 };
 
 export const getUserLang = () => {


### PR DESCRIPTION
When LANG=C.UTF-8, navigator.language can return 'C' which is not a valid BCP 47 tag, causing Intl.NumberFormat and toLocaleString to throw. Normalize POSIX values (C, C.UTF-8, POSIX) to 'en-US' at the source.