### PR TITLE
Update docker db schema to match FileRecords

### DIFF
--- a/docker/volumes/db/init/schema.sql
+++ b/docker/volumes/db/init/schema.sql
@@ -84,6 +84,7 @@ CREATE TABLE public.files (
   file_key text NOT NULL,
   file_size bigint NOT NULL,
   created_at timestamp with time zone NULL DEFAULT now(),
+  updated_at timestamp with time zone NULL DEFAULT now(),
   deleted_at timestamp with time zone NULL,
   CONSTRAINT files_pkey PRIMARY KEY (id),
   CONSTRAINT files_file_key_key UNIQUE (file_key),


### PR DESCRIPTION
In #2636, FileRecord was defined to have updated_at field which is expected to exist in the database. But the local dev setup is missing this field.

This diff adds an updated_at column to match the expectation