### PR TITLE
fix(export): apply block quote syntax to every line in annotation export, closes #3534

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -1118,5 +1118,17 @@
   "Increase font size": "تكبير حجم الخط",
   "Focus": "تركيز",
   "Theme color": "لون السمة",
-  "Import failed": "فشل الاستيراد"
+  "Import failed": "فشل الاستيراد",
+  "Available Formatters:": "المُنسّقات المتاحة:",
+  "Format date": "تنسيق التاريخ",
+  "Markdown block quote (> per line)": "اقتباس Markdown (> لكل سطر)",
+  "Newlines to <br>": "أسطر جديدة إلى <br>",
+  "Change case": "تغيير حالة الأحرف",
+  "Trim whitespace": "إزالة المسافات",
+  "Truncate to n characters": "اقتطاع إلى n حرف",
+  "Replace text": "استبدال النص",
+  "Fallback value": "القيمة الاحتياطية",
+  "Get length": "الحصول على الطول",
+  "First/last element": "العنصر الأول/الأخير",
+  "Join array": "دمج المصفوفة"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1070,5 +1070,17 @@
   "Increase font size": "ফন্টের আকার বাড়ান",
   "Focus": "ফোকাস",
   "Theme color": "থিম রঙ",
-  "Import failed": "আমদানি ব্যর্থ"
+  "Import failed": "আমদানি ব্যর্থ",
+  "Available Formatters:": "উপলব্ধ ফরম্যাটার:",
+  "Format date": "তারিখ ফরম্যাট",
+  "Markdown block quote (> per line)": "Markdown ব্লক কোট (প্রতি লাইনে >)",
+  "Newlines to <br>": "নতুন লাইন থেকে <br>",
+  "Change case": "অক্ষরের কেস পরিবর্তন",
+  "Trim whitespace": "শূন্যস্থান ছাঁটা",
+  "Truncate to n characters": "n অক্ষরে সংক্ষিপ্ত করুন",
+  "Replace text": "টেক্সট প্রতিস্থাপন",
+  "Fallback value": "ফলব্যাক মান",
+  "Get length": "দৈর্ঘ্য নিন",
+  "First/last element": "প্রথম/শেষ উপাদান",
+  "Join array": "অ্যারে যুক্ত করুন"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1058,5 +1058,17 @@
   "Increase font size": "ཡིག་གཟུགས་ཆེ་རུ་གཏོང་བ",
   "Focus": "དམིགས་གཏད",
   "Theme color": "བརྗོད་དོན་ཚོན་མདོག",
-  "Import failed": "ནང་འདྲེན་མི་ཐུབ།"
+  "Import failed": "ནང་འདྲེན་མི་ཐུབ།",
+  "Available Formatters:": "སྒྲིག་བཟོ་ཆས་ཡོད་པ།:",
+  "Format date": "ཚེས་གྲངས་སྒྲིག་བཟོ",
+  "Markdown block quote (> per line)": "Markdown དྲིལ་བསྡུ་འདྲེན་ (མི་ལྟར་ > )",
+  "Newlines to <br>": "གསར་བརྗེ་ <br> ལ་བསྒྱུར",
+  "Change case": "ཡིག་གཟུགས་བསྒྱུར",
+  "Trim whitespace": "སྟོང་ཆ་གཙང་བཟོ",
+  "Truncate to n characters": "n ཡི་གེར་ཐུང་དུ་བཅད",
+  "Replace text": "ཡི་གེ་བརྗེ་བ",
+  "Fallback value": "ཚབ་ཀྱི་གྲངས་ཀ",
+  "Get length": "རིང་ཚད་ལེན",
+  "First/last element": "དང་པོ/མཇུག་གི་རྒྱུ་ཆ",
+  "Join array": "ཚོ་སྒྲིག་སྦྲེལ"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1070,5 +1070,17 @@
   "Increase font size": "Schriftgröße vergrößern",
   "Focus": "Fokus",
   "Theme color": "Themenfarbe",
-  "Import failed": "Import fehlgeschlagen"
+  "Import failed": "Import fehlgeschlagen",
+  "Available Formatters:": "Verfügbare Formatierer:",
+  "Format date": "Datum formatieren",
+  "Markdown block quote (> per line)": "Markdown-Blockzitat (> pro Zeile)",
+  "Newlines to <br>": "Zeilenumbrüche zu <br>",
+  "Change case": "Groß-/Kleinschreibung ändern",
+  "Trim whitespace": "Leerzeichen entfernen",
+  "Truncate to n characters": "Auf n Zeichen kürzen",
+  "Replace text": "Text ersetzen",
+  "Fallback value": "Ersatzwert",
+  "Get length": "Länge ermitteln",
+  "First/last element": "Erstes/letztes Element",
+  "Join array": "Array verbinden"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1070,5 +1070,17 @@
   "Increase font size": "Αύξηση μεγέθους γραμματοσειράς",
   "Focus": "Εστίαση",
   "Theme color": "Χρώμα θέματος",
-  "Import failed": "Η εισαγωγή απέτυχε"
+  "Import failed": "Η εισαγωγή απέτυχε",
+  "Available Formatters:": "Διαθέσιμοι μορφοποιητές:",
+  "Format date": "Μορφοποίηση ημερομηνίας",
+  "Markdown block quote (> per line)": "Παράθεση Markdown (> ανά γραμμή)",
+  "Newlines to <br>": "Αλλαγές γραμμής σε <br>",
+  "Change case": "Αλλαγή πεζών/κεφαλαίων",
+  "Trim whitespace": "Αφαίρεση κενών",
+  "Truncate to n characters": "Περικοπή σε n χαρακτήρες",
+  "Replace text": "Αντικατάσταση κειμένου",
+  "Fallback value": "Εναλλακτική τιμή",
+  "Get length": "Λήψη μήκους",
+  "First/last element": "Πρώτο/τελευταίο στοιχείο",
+  "Join array": "Ένωση πίνακα"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1082,5 +1082,17 @@
   "Increase font size": "Aumentar tamaño de fuente",
   "Focus": "Enfoque",
   "Theme color": "Color del tema",
-  "Import failed": "Error de importación"
+  "Import failed": "Error de importación",
+  "Available Formatters:": "Formateadores disponibles:",
+  "Format date": "Formatear fecha",
+  "Markdown block quote (> per line)": "Cita en bloque Markdown (> por línea)",
+  "Newlines to <br>": "Saltos de línea a <br>",
+  "Change case": "Cambiar mayúsculas/minúsculas",
+  "Trim whitespace": "Recortar espacios",
+  "Truncate to n characters": "Truncar a n caracteres",
+  "Replace text": "Reemplazar texto",
+  "Fallback value": "Valor alternativo",
+  "Get length": "Obtener longitud",
+  "First/last element": "Primer/último elemento",
+  "Join array": "Unir array"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1070,5 +1070,17 @@
   "Increase font size": "افزایش اندازه قلم",
   "Focus": "تمرکز",
   "Theme color": "رنگ پوسته",
-  "Import failed": "وارد کردن ناموفق بود"
+  "Import failed": "وارد کردن ناموفق بود",
+  "Available Formatters:": "قالب‌بندهای موجود:",
+  "Format date": "قالب‌بندی تاریخ",
+  "Markdown block quote (> per line)": "نقل‌قول Markdown (> در هر خط)",
+  "Newlines to <br>": "خطوط جدید به <br>",
+  "Change case": "تغییر بزرگی/کوچکی حروف",
+  "Trim whitespace": "حذف فاصله‌ها",
+  "Truncate to n characters": "کوتاه کردن به n نویسه",
+  "Replace text": "جایگزینی متن",
+  "Fallback value": "مقدار پیش‌فرض",
+  "Get length": "دریافت طول",
+  "First/last element": "عنصر اول/آخر",
+  "Join array": "پیوستن آرایه"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1082,5 +1082,17 @@
   "Increase font size": "Augmenter la taille de police",
   "Focus": "Focus",
   "Theme color": "Couleur du thème",
-  "Import failed": "Échec de l'importation"
+  "Import failed": "Échec de l'importation",
+  "Available Formatters:": "Formateurs disponibles :",
+  "Format date": "Formater la date",
+  "Markdown block quote (> per line)": "Citation Markdown (> par ligne)",
+  "Newlines to <br>": "Retours à la ligne en <br>",
+  "Change case": "Changer la casse",
+  "Trim whitespace": "Supprimer les espaces",
+  "Truncate to n characters": "Tronquer à n caractères",
+  "Replace text": "Remplacer le texte",
+  "Fallback value": "Valeur par défaut",
+  "Get length": "Obtenir la longueur",
+  "First/last element": "Premier/dernier élément",
+  "Join array": "Joindre le tableau"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1082,5 +1082,17 @@
   "Increase font size": "הגדל גודל גופן",
   "Focus": "מיקוד",
   "Theme color": "צבע ערכת נושא",
-  "Import failed": "הייבוא נכשל"
+  "Import failed": "הייבוא נכשל",
+  "Available Formatters:": "מעצבים זמינים:",
+  "Format date": "עיצוב תאריך",
+  "Markdown block quote (> per line)": "ציטוט Markdown (> בכל שורה)",
+  "Newlines to <br>": "שורות חדשות ל-<br>",
+  "Change case": "שינוי רישיות",
+  "Trim whitespace": "חיתוך רווחים",
+  "Truncate to n characters": "קיצוץ ל-n תווים",
+  "Replace text": "החלפת טקסט",
+  "Fallback value": "ערך חלופי",
+  "Get length": "קבלת אורך",
+  "First/last element": "אלמנט ראשון/אחרון",
+  "Join array": "חיבור מערך"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1070,5 +1070,17 @@
   "Increase font size": "फ़ॉन्ट आकार बढ़ाएँ",
   "Focus": "फ़ोकस",
   "Theme color": "थीम रंग",
-  "Import failed": "आयात विफल"
+  "Import failed": "आयात विफल",
+  "Available Formatters:": "उपलब्ध फ़ॉर्मेटर:",
+  "Format date": "तारीख फ़ॉर्मेट करें",
+  "Markdown block quote (> per line)": "Markdown ब्लॉक कोट (> प्रति पंक्ति)",
+  "Newlines to <br>": "नई पंक्तियाँ <br> में",
+  "Change case": "केस बदलें",
+  "Trim whitespace": "रिक्त स्थान हटाएँ",
+  "Truncate to n characters": "n अक्षरों तक छोटा करें",
+  "Replace text": "टेक्स्ट बदलें",
+  "Fallback value": "फ़ॉलबैक मान",
+  "Get length": "लंबाई प्राप्त करें",
+  "First/last element": "पहला/अंतिम तत्व",
+  "Join array": "ऐरे जोड़ें"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1058,5 +1058,17 @@
   "Increase font size": "Perbesar ukuran font",
   "Focus": "Fokus",
   "Theme color": "Warna tema",
-  "Import failed": "Impor gagal"
+  "Import failed": "Impor gagal",
+  "Available Formatters:": "Formatter Tersedia:",
+  "Format date": "Format tanggal",
+  "Markdown block quote (> per line)": "Kutipan blok Markdown (> per baris)",
+  "Newlines to <br>": "Baris baru ke <br>",
+  "Change case": "Ubah huruf besar/kecil",
+  "Trim whitespace": "Pangkas spasi",
+  "Truncate to n characters": "Potong ke n karakter",
+  "Replace text": "Ganti teks",
+  "Fallback value": "Nilai cadangan",
+  "Get length": "Dapatkan panjang",
+  "First/last element": "Elemen pertama/terakhir",
+  "Join array": "Gabungkan array"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1082,5 +1082,17 @@
   "Increase font size": "Aumenta dimensione carattere",
   "Focus": "Messa a fuoco",
   "Theme color": "Colore del tema",
-  "Import failed": "Importazione fallita"
+  "Import failed": "Importazione fallita",
+  "Available Formatters:": "Formattatori disponibili:",
+  "Format date": "Formatta data",
+  "Markdown block quote (> per line)": "Citazione Markdown (> per riga)",
+  "Newlines to <br>": "A capo in <br>",
+  "Change case": "Cambia maiuscole/minuscole",
+  "Trim whitespace": "Rimuovi spazi",
+  "Truncate to n characters": "Tronca a n caratteri",
+  "Replace text": "Sostituisci testo",
+  "Fallback value": "Valore predefinito",
+  "Get length": "Ottieni lunghezza",
+  "First/last element": "Primo/ultimo elemento",
+  "Join array": "Unisci array"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1058,5 +1058,17 @@
   "Increase font size": "文字サイズを拡大",
   "Focus": "フォーカス",
   "Theme color": "テーマカラー",
-  "Import failed": "インポートに失敗しました"
+  "Import failed": "インポートに失敗しました",
+  "Available Formatters:": "利用可能なフォーマッター:",
+  "Format date": "日付のフォーマット",
+  "Markdown block quote (> per line)": "Markdown引用ブロック (行ごとに >)",
+  "Newlines to <br>": "改行を <br> に変換",
+  "Change case": "大文字/小文字の変更",
+  "Trim whitespace": "空白を除去",
+  "Truncate to n characters": "n文字に切り詰め",
+  "Replace text": "テキストを置換",
+  "Fallback value": "フォールバック値",
+  "Get length": "長さを取得",
+  "First/last element": "最初/最後の要素",
+  "Join array": "配列を結合"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1058,5 +1058,17 @@
   "Increase font size": "글꼴 크기 늘리기",
   "Focus": "초점",
   "Theme color": "테마 색상",
-  "Import failed": "가져오기 실패"
+  "Import failed": "가져오기 실패",
+  "Available Formatters:": "사용 가능한 포맷터:",
+  "Format date": "날짜 형식",
+  "Markdown block quote (> per line)": "Markdown 인용 블록 (줄마다 >)",
+  "Newlines to <br>": "줄바꿈을 <br>로 변환",
+  "Change case": "대소문자 변경",
+  "Trim whitespace": "공백 제거",
+  "Truncate to n characters": "n자로 자르기",
+  "Replace text": "텍스트 바꾸기",
+  "Fallback value": "기본값",
+  "Get length": "길이 가져오기",
+  "First/last element": "첫 번째/마지막 요소",
+  "Join array": "배열 합치기"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1058,5 +1058,17 @@
   "Increase font size": "Besarkan saiz fon",
   "Focus": "Fokus",
   "Theme color": "Warna tema",
-  "Import failed": "Import gagal"
+  "Import failed": "Import gagal",
+  "Available Formatters:": "Pemformat Tersedia:",
+  "Format date": "Format tarikh",
+  "Markdown block quote (> per line)": "Petikan blok Markdown (> setiap baris)",
+  "Newlines to <br>": "Baris baharu ke <br>",
+  "Change case": "Tukar huruf besar/kecil",
+  "Trim whitespace": "Pangkas ruang kosong",
+  "Truncate to n characters": "Potong kepada n aksara",
+  "Replace text": "Ganti teks",
+  "Fallback value": "Nilai lalai",
+  "Get length": "Dapatkan panjang",
+  "First/last element": "Elemen pertama/terakhir",
+  "Join array": "Gabung tatasusunan"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1070,5 +1070,17 @@
   "Increase font size": "Lettergrootte vergroten",
   "Focus": "Focus",
   "Theme color": "Themakleur",
-  "Import failed": "Import mislukt"
+  "Import failed": "Import mislukt",
+  "Available Formatters:": "Beschikbare opmaak:",
+  "Format date": "Datum opmaken",
+  "Markdown block quote (> per line)": "Markdown-blokcitaat (> per regel)",
+  "Newlines to <br>": "Regeleinden naar <br>",
+  "Change case": "Hoofdlettergebruik wijzigen",
+  "Trim whitespace": "Witruimte verwijderen",
+  "Truncate to n characters": "Inkorten tot n tekens",
+  "Replace text": "Tekst vervangen",
+  "Fallback value": "Terugvalwaarde",
+  "Get length": "Lengte ophalen",
+  "First/last element": "Eerste/laatste element",
+  "Join array": "Array samenvoegen"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1094,5 +1094,17 @@
   "Increase font size": "Zwiększ rozmiar czcionki",
   "Focus": "Fokus",
   "Theme color": "Kolor motywu",
-  "Import failed": "Import nie powiódł się"
+  "Import failed": "Import nie powiódł się",
+  "Available Formatters:": "Dostępne formatery:",
+  "Format date": "Formatuj datę",
+  "Markdown block quote (> per line)": "Cytat blokowy Markdown (> na linię)",
+  "Newlines to <br>": "Nowe linie na <br>",
+  "Change case": "Zmień wielkość liter",
+  "Trim whitespace": "Przytnij spacje",
+  "Truncate to n characters": "Skróć do n znaków",
+  "Replace text": "Zamień tekst",
+  "Fallback value": "Wartość zastępcza",
+  "Get length": "Pobierz długość",
+  "First/last element": "Pierwszy/ostatni element",
+  "Join array": "Połącz tablicę"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1082,5 +1082,17 @@
   "Increase font size": "Aumentar tamanho da fonte",
   "Focus": "Foco",
   "Theme color": "Cor do tema",
-  "Import failed": "Falha na importação"
+  "Import failed": "Falha na importação",
+  "Available Formatters:": "Formatadores disponíveis:",
+  "Format date": "Formatar data",
+  "Markdown block quote (> per line)": "Citação Markdown (> por linha)",
+  "Newlines to <br>": "Quebras de linha para <br>",
+  "Change case": "Alterar maiúsculas/minúsculas",
+  "Trim whitespace": "Remover espaços",
+  "Truncate to n characters": "Truncar para n caracteres",
+  "Replace text": "Substituir texto",
+  "Fallback value": "Valor padrão",
+  "Get length": "Obter comprimento",
+  "First/last element": "Primeiro/último elemento",
+  "Join array": "Juntar array"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1094,5 +1094,17 @@
   "Increase font size": "Увеличить размер шрифта",
   "Focus": "Фокус",
   "Theme color": "Цвет темы",
-  "Import failed": "Ошибка импорта"
+  "Import failed": "Ошибка импорта",
+  "Available Formatters:": "Доступные форматеры:",
+  "Format date": "Форматировать дату",
+  "Markdown block quote (> per line)": "Цитата Markdown (> для каждой строки)",
+  "Newlines to <br>": "Переносы строк в <br>",
+  "Change case": "Изменить регистр",
+  "Trim whitespace": "Удалить пробелы",
+  "Truncate to n characters": "Обрезать до n символов",
+  "Replace text": "Заменить текст",
+  "Fallback value": "Значение по умолчанию",
+  "Get length": "Получить длину",
+  "First/last element": "Первый/последний элемент",
+  "Join array": "Объединить массив"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1070,5 +1070,17 @@
   "Increase font size": "අකුරු ප්‍රමාණය වැඩි කරන්න",
   "Focus": "අවධානය",
   "Theme color": "තේමා වර්ණය",
-  "Import failed": "ආයාත කිරීම අසාර්ථකයි"
+  "Import failed": "ආයාත කිරීම අසාර්ථකයි",
+  "Available Formatters:": "ලබාගත හැකි ආකෘතිකරණ:",
+  "Format date": "දිනය ආකෘතිකරණය",
+  "Markdown block quote (> per line)": "Markdown බ්ලොක් උද්ධෘතය (පේළියකට >)",
+  "Newlines to <br>": "නව පේළි <br> වෙත",
+  "Change case": "අකුරු ප්‍රමාණය වෙනස් කරන්න",
+  "Trim whitespace": "හිස්තැන් කපන්න",
+  "Truncate to n characters": "n අක්ෂර දක්වා කෙටි කරන්න",
+  "Replace text": "පෙළ ප්‍රතිස්ථාපනය",
+  "Fallback value": "විකල්ප අගය",
+  "Get length": "දිග ලබාගන්න",
+  "First/last element": "පළමු/අවසාන මූලද්‍රව්‍යය",
+  "Join array": "අරාව සම්බන්ධ කරන්න"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1094,5 +1094,17 @@
   "Increase font size": "Povečaj pisavo",
   "Focus": "Fokus",
   "Theme color": "Barva teme",
-  "Import failed": "Uvoz ni uspel"
+  "Import failed": "Uvoz ni uspel",
+  "Available Formatters:": "Razpoložljivi oblikovalci:",
+  "Format date": "Oblikuj datum",
+  "Markdown block quote (> per line)": "Markdown citatni blok (> na vrstico)",
+  "Newlines to <br>": "Nove vrstice v <br>",
+  "Change case": "Spremeni velikost črk",
+  "Trim whitespace": "Odstrani presledke",
+  "Truncate to n characters": "Skrajšaj na n znakov",
+  "Replace text": "Zamenjaj besedilo",
+  "Fallback value": "Nadomestna vrednost",
+  "Get length": "Pridobi dolžino",
+  "First/last element": "Prvi/zadnji element",
+  "Join array": "Združi polje"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1070,5 +1070,17 @@
   "Increase font size": "Öka teckenstorlek",
   "Focus": "Fokus",
   "Theme color": "Temafärg",
-  "Import failed": "Importen misslyckades"
+  "Import failed": "Importen misslyckades",
+  "Available Formatters:": "Tillgängliga formaterare:",
+  "Format date": "Formatera datum",
+  "Markdown block quote (> per line)": "Markdown-blockcitat (> per rad)",
+  "Newlines to <br>": "Radbrytningar till <br>",
+  "Change case": "Ändra skiftläge",
+  "Trim whitespace": "Ta bort blanksteg",
+  "Truncate to n characters": "Korta till n tecken",
+  "Replace text": "Ersätt text",
+  "Fallback value": "Standardvärde",
+  "Get length": "Hämta längd",
+  "First/last element": "Första/sista elementet",
+  "Join array": "Sammanfoga array"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1070,5 +1070,17 @@
   "Increase font size": "எழுத்துரு அளவை அதிகரி",
   "Focus": "குவியம்",
   "Theme color": "தீம் நிறம்",
-  "Import failed": "இறக்குமதி தோல்வி"
+  "Import failed": "இறக்குமதி தோல்வி",
+  "Available Formatters:": "கிடைக்கும் வடிவமைப்பிகள்:",
+  "Format date": "தேதி வடிவமைப்பு",
+  "Markdown block quote (> per line)": "Markdown மேற்கோள் தொகுதி (ஒவ்வொரு வரிக்கும் >)",
+  "Newlines to <br>": "புதிய வரிகளை <br> ஆக",
+  "Change case": "எழுத்து வகை மாற்றம்",
+  "Trim whitespace": "வெற்றிடங்களை நீக்கு",
+  "Truncate to n characters": "n எழுத்துகளுக்கு சுருக்கு",
+  "Replace text": "உரையை மாற்று",
+  "Fallback value": "இயல்புநிலை மதிப்பு",
+  "Get length": "நீளத்தைப் பெறு",
+  "First/last element": "முதல்/கடைசி உறுப்பு",
+  "Join array": "அணியை இணை"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1058,5 +1058,17 @@
   "Increase font size": "เพิ่มขนาดตัวอักษร",
   "Focus": "โฟกัส",
   "Theme color": "สีธีม",
-  "Import failed": "นำเข้าล้มเหลว"
+  "Import failed": "นำเข้าล้มเหลว",
+  "Available Formatters:": "ตัวจัดรูปแบบที่ใช้ได้:",
+  "Format date": "จัดรูปแบบวันที่",
+  "Markdown block quote (> per line)": "บล็อกอ้างอิง Markdown (> ต่อบรรทัด)",
+  "Newlines to <br>": "ขึ้นบรรทัดใหม่เป็น <br>",
+  "Change case": "เปลี่ยนตัวพิมพ์",
+  "Trim whitespace": "ตัดช่องว่าง",
+  "Truncate to n characters": "ตัดให้เหลือ n ตัวอักษร",
+  "Replace text": "แทนที่ข้อความ",
+  "Fallback value": "ค่าสำรอง",
+  "Get length": "ดึงความยาว",
+  "First/last element": "องค์ประกอบแรก/สุดท้าย",
+  "Join array": "รวมอาร์เรย์"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1070,5 +1070,17 @@
   "Increase font size": "Yazı tipi boyutunu büyüt",
   "Focus": "Odak",
   "Theme color": "Tema rengi",
-  "Import failed": "İçe aktarma başarısız"
+  "Import failed": "İçe aktarma başarısız",
+  "Available Formatters:": "Kullanılabilir Biçimlendiriciler:",
+  "Format date": "Tarih biçimlendir",
+  "Markdown block quote (> per line)": "Markdown blok alıntı (satır başına >)",
+  "Newlines to <br>": "Satır sonlarını <br> yap",
+  "Change case": "Büyük/küçük harf değiştir",
+  "Trim whitespace": "Boşlukları kırp",
+  "Truncate to n characters": "n karaktere kısalt",
+  "Replace text": "Metni değiştir",
+  "Fallback value": "Yedek değer",
+  "Get length": "Uzunluk al",
+  "First/last element": "İlk/son öğe",
+  "Join array": "Diziyi birleştir"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1094,5 +1094,17 @@
   "Increase font size": "Збільшити розмір шрифту",
   "Focus": "Фокус",
   "Theme color": "Колір теми",
-  "Import failed": "Помилка імпорту"
+  "Import failed": "Помилка імпорту",
+  "Available Formatters:": "Доступні форматери:",
+  "Format date": "Форматувати дату",
+  "Markdown block quote (> per line)": "Цитата Markdown (> для кожного рядка)",
+  "Newlines to <br>": "Переноси рядків у <br>",
+  "Change case": "Змінити регістр",
+  "Trim whitespace": "Видалити пробіли",
+  "Truncate to n characters": "Обрізати до n символів",
+  "Replace text": "Замінити текст",
+  "Fallback value": "Значення за замовчуванням",
+  "Get length": "Отримати довжину",
+  "First/last element": "Перший/останній елемент",
+  "Join array": "Об'єднати масив"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1058,5 +1058,17 @@
   "Increase font size": "Tăng cỡ chữ",
   "Focus": "Tiêu điểm",
   "Theme color": "Màu chủ đề",
-  "Import failed": "Nhập thất bại"
+  "Import failed": "Nhập thất bại",
+  "Available Formatters:": "Bộ định dạng có sẵn:",
+  "Format date": "Định dạng ngày",
+  "Markdown block quote (> per line)": "Trích dẫn khối Markdown (> mỗi dòng)",
+  "Newlines to <br>": "Xuống dòng thành <br>",
+  "Change case": "Đổi chữ hoa/thường",
+  "Trim whitespace": "Cắt khoảng trắng",
+  "Truncate to n characters": "Cắt ngắn còn n ký tự",
+  "Replace text": "Thay thế văn bản",
+  "Fallback value": "Giá trị dự phòng",
+  "Get length": "Lấy độ dài",
+  "First/last element": "Phần tử đầu/cuối",
+  "Join array": "Nối mảng"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1058,5 +1058,17 @@
   "Increase font size": "放大字号",
   "Focus": "焦点",
   "Theme color": "主题颜色",
-  "Import failed": "导入失败"
+  "Import failed": "导入失败",
+  "Available Formatters:": "可用格式化器：",
+  "Format date": "格式化日期",
+  "Markdown block quote (> per line)": "Markdown 引用块（每行 >）",
+  "Newlines to <br>": "换行转为 <br>",
+  "Change case": "更改大小写",
+  "Trim whitespace": "去除空格",
+  "Truncate to n characters": "截断为 n 个字符",
+  "Replace text": "替换文本",
+  "Fallback value": "默认值",
+  "Get length": "获取长度",
+  "First/last element": "第一个/最后一个元素",
+  "Join array": "合并数组"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1058,5 +1058,17 @@
   "Increase font size": "放大字型",
   "Focus": "焦點",
   "Theme color": "主題顏色",
-  "Import failed": "匯入失敗"
+  "Import failed": "匯入失敗",
+  "Available Formatters:": "可用格式化器：",
+  "Format date": "格式化日期",
+  "Markdown block quote (> per line)": "Markdown 引用區塊（每行 >）",
+  "Newlines to <br>": "換行轉為 <br>",
+  "Change case": "變更大小寫",
+  "Trim whitespace": "去除空格",
+  "Truncate to n characters": "截斷為 n 個字元",
+  "Replace text": "取代文字",
+  "Fallback value": "預設值",
+  "Get length": "取得長度",
+  "First/last element": "第一個/最後一個元素",
+  "Join array": "合併陣列"
 }

--- a/apps/readest-app/src/__tests__/utils/note.test.ts
+++ b/apps/readest-app/src/__tests__/utils/note.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { renderNoteTemplate, validateNoteTemplate, NoteTemplateData } from '../../utils/note';
+import {
+  renderNoteTemplate,
+  validateNoteTemplate,
+  formatBlockQuote,
+  NoteTemplateData,
+} from '../../utils/note';
 
 describe('renderNoteTemplate', () => {
   const sampleData: NoteTemplateData = {
@@ -325,6 +330,23 @@ describe('renderNoteTemplate', () => {
     });
   });
 
+  describe('Blockquote filter', () => {
+    it('should prefix every line with > in templates', () => {
+      const data: NoteTemplateData = {
+        ...sampleData,
+        chapters: [
+          {
+            title: 'Ch1',
+            annotations: [{ text: 'Line 1\nLine 2\nLine 3' }],
+          },
+        ],
+      };
+      const template = '{{ chapters[0].annotations[0].text | blockquote }}';
+      const result = renderNoteTemplate(template, data);
+      expect(result).toBe('> Line 1\n> Line 2\n> Line 3');
+    });
+  });
+
   describe('Newline to BR filter', () => {
     it('should convert newlines to br tags', () => {
       const dataWithNewlines: NoteTemplateData = {
@@ -568,5 +590,26 @@ describe('validateNoteTemplate', () => {
     const template = 'Just plain text without any template syntax';
     const result = validateNoteTemplate(template);
     expect(result.isValid).toBe(true);
+  });
+});
+
+describe('formatBlockQuote', () => {
+  it('should prefix every line with > for multi-line text', () => {
+    const text = 'Nothing must happen to you\nNo, what am I saying\nEverything must happen to you';
+    expect(formatBlockQuote(text)).toBe(
+      '> Nothing must happen to you\n> No, what am I saying\n> Everything must happen to you',
+    );
+  });
+
+  it('should handle single-line text', () => {
+    expect(formatBlockQuote('Hello')).toBe('> Hello');
+  });
+
+  it('should handle empty string', () => {
+    expect(formatBlockQuote('')).toBe('> ');
+  });
+
+  it('should preserve empty lines within the quote', () => {
+    expect(formatBlockQuote('First\n\nThird')).toBe('> First\n> \n> Third');
   });
 });

--- a/apps/readest-app/src/app/reader/components/annotator/ExportMarkdownDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/ExportMarkdownDialog.tsx
@@ -7,7 +7,7 @@ import { useReaderStore } from '@/store/readerStore';
 import { BookNote, BooknoteGroup, NoteExportConfig } from '@/types/book';
 import { DEFAULT_NOTE_EXPORT_CONFIG } from '@/services/constants';
 import { saveViewSettings } from '@/helpers/settings';
-import { renderNoteTemplate } from '@/utils/note';
+import { renderNoteTemplate, formatBlockQuote } from '@/utils/note';
 import Dialog from '@/components/Dialog';
 
 interface ExportMarkdownDialogProps {
@@ -175,7 +175,7 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
         for (const note of group.booknotes) {
           // Add quote
           if (exportConfig.includeQuotes && note.text) {
-            lines.push(`> ${note.text}`);
+            lines.push(formatBlockQuote(note.text));
           }
 
           // Add note
@@ -489,6 +489,60 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
                         <li className='ml-8'>
                           <code className='bg-base-300 rounded px-1'>annotation.timestamp</code> -{' '}
                           {_('Annotation time')}
+                        </li>
+                      </ul>
+                    </div>
+                    <div>
+                      <p className='mb-2 font-bold'>{_('Available Formatters:')}</p>
+                      <ul className='space-y-1 font-mono'>
+                        <li>
+                          <code className='bg-base-300 rounded px-1'>date</code> /{' '}
+                          <code className='bg-base-300 rounded px-1'>{"date('%Y-%m-%d')"}</code> -{' '}
+                          {_('Format date')}
+                        </li>
+                        <li>
+                          <code className='bg-base-300 rounded px-1'>blockquote</code> -{' '}
+                          {_('Markdown block quote (> per line)')}
+                        </li>
+                        <li>
+                          <code className='bg-base-300 rounded px-1'>nl2br</code> -{' '}
+                          {_('Newlines to <br>')}
+                        </li>
+                        <li>
+                          <code className='bg-base-300 rounded px-1'>upper</code> /{' '}
+                          <code className='bg-base-300 rounded px-1'>lower</code> /{' '}
+                          <code className='bg-base-300 rounded px-1'>capitalize</code> /{' '}
+                          <code className='bg-base-300 rounded px-1'>title</code> -{' '}
+                          {_('Change case')}
+                        </li>
+                        <li>
+                          <code className='bg-base-300 rounded px-1'>trim</code> -{' '}
+                          {_('Trim whitespace')}
+                        </li>
+                        <li>
+                          <code className='bg-base-300 rounded px-1'>truncate(n)</code> -{' '}
+                          {_('Truncate to n characters')}
+                        </li>
+                        <li>
+                          <code className='bg-base-300 rounded px-1'>{"replace('a', 'b')"}</code> -{' '}
+                          {_('Replace text')}
+                        </li>
+                        <li>
+                          <code className='bg-base-300 rounded px-1'>default(val)</code> -{' '}
+                          {_('Fallback value')}
+                        </li>
+                        <li>
+                          <code className='bg-base-300 rounded px-1'>length</code> -{' '}
+                          {_('Get length')}
+                        </li>
+                        <li>
+                          <code className='bg-base-300 rounded px-1'>first</code> /{' '}
+                          <code className='bg-base-300 rounded px-1'>last</code> -{' '}
+                          {_('First/last element')}
+                        </li>
+                        <li>
+                          <code className='bg-base-300 rounded px-1'>{"join(', ')"}</code> -{' '}
+                          {_('Join array')}
                         </li>
                       </ul>
                     </div>

--- a/apps/readest-app/src/utils/note.ts
+++ b/apps/readest-app/src/utils/note.ts
@@ -214,6 +214,22 @@ env.addFilter('nl2br', (value: string) => {
 });
 
 /**
+ * Formats text as a markdown block quote, prefixing every line with `> `.
+ */
+export function formatBlockQuote(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n');
+}
+
+// Add 'blockquote' filter (prefix every line with > for markdown block quotes)
+env.addFilter('blockquote', (value: string) => {
+  if (!value || typeof value !== 'string') return '';
+  return formatBlockQuote(value);
+});
+
+/**
  * Renders a Jinja2/Nunjucks template with the given data
  * @param template The template string in Jinja2/Nunjucks syntax
  * @param data The data to render the template with


### PR DESCRIPTION
Add formatBlockQuote utility and blockquote nunjucks filter so both default and custom template exports prefix every line with `>`. Document all available formatters in the custom template help panel.