### PR TITLE
fix(koplugin): prevent resurrecting deleted highlights and duplicate overlays on notes pull

### DIFF
--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -682,7 +682,6 @@ const Annotator: React.FC<{ bookKey: string }> = ({ bookKey }) => {
     const color = settings.globalReadSettings.highlightStyles[style];
     setSelectedStyle(style);
     setSelectedColor(color);
-    console.log('Adding annotation:', cfi, 'style:', style, 'color:', color);
     const annotation: BookNote = {
       id: uniqueId(),
       type: 'annotation',

--- a/apps/readest-app/src/app/reader/hooks/useNotesSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useNotesSync.ts
@@ -177,7 +177,7 @@ export const useNotesSync = (bookKey: string) => {
       convertedNotes.forEach((note) => {
         if (note.cfi) {
           const index = getIndexFromCfi(note.cfi);
-          if (index === view?.renderer.primaryIndex) {
+          if (!note.deletedAt && index === view?.renderer.primaryIndex) {
             view.addAnnotation(note);
           }
         }


### PR DESCRIPTION
Guard useNotesSync pull to avoid resurrecting locally-deleted annotations and duplicate overlays.

The sync pull path was re-adding incoming annotations into the view unconditionally (commit 76b239f), which could:
- resurrect locally-deleted highlights
- create duplicate overlay visuals when a local annotation already existed

This change guards the convertedNotes handling so incoming notes:
- do not overwrite newer local edits or deletedAt
- remove overlays for incoming deletions
- skip adding overlays when an equivalent local, non-deleted annotation already exists

Closes #3621 