### PR TITLE
feat(tts): add CAMB AI as a TTS engine option

### DIFF
--- a/apps/readest-app/src/__tests__/services/tts-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller.test.ts
@@ -26,6 +26,12 @@ vi.mock('@/services/tts/NativeTTSClient', () => ({
   }),
 }));
 
+vi.mock('@/services/tts/CambAITTSClient', () => ({
+  CambAITTSClient: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    Object.assign(this, createMockTTSClient('camb-ai'));
+  }),
+}));
+
 vi.mock('@/services/tts/TTSUtils', () => ({
   TTSUtils: {
     getPreferredClient: vi.fn().mockReturnValue(null),
@@ -353,14 +359,18 @@ describe('TTSController', () => {
       const edgeVoices: TTSVoicesGroup[] = [
         { id: 'eg', name: 'Edge', voices: [{ id: 'e1', name: 'E1', lang: 'en-US' }] },
       ];
+      const cambVoices: TTSVoicesGroup[] = [
+        { id: 'cg', name: 'CAMB AI', voices: [{ id: 'c1', name: 'C1', lang: 'en-US' }] },
+      ];
       const webVoices: TTSVoicesGroup[] = [
         { id: 'wg', name: 'Web', voices: [{ id: 'w1', name: 'W1', lang: 'en-US' }] },
       ];
       vi.mocked(controller.ttsEdgeClient.getVoices).mockResolvedValue(edgeVoices);
+      vi.mocked(controller.ttsCambClient.getVoices).mockResolvedValue(cambVoices);
       vi.mocked(controller.ttsWebClient.getVoices).mockResolvedValue(webVoices);
 
       const result = await controller.getVoices('en');
-      expect(result).toEqual([...edgeVoices, ...webVoices]);
+      expect(result).toEqual([...cambVoices, ...edgeVoices, ...webVoices]);
     });
 
     test('includes native voices when available', async () => {
@@ -373,6 +383,7 @@ describe('TTSController', () => {
       ];
       vi.mocked(c.ttsNativeClient!.getVoices).mockResolvedValue(nativeVoices);
       vi.mocked(c.ttsEdgeClient.getVoices).mockResolvedValue([]);
+      vi.mocked(c.ttsCambClient.getVoices).mockResolvedValue([]);
       vi.mocked(c.ttsWebClient.getVoices).mockResolvedValue([]);
 
       const result = await c.getVoices('en');

--- a/apps/readest-app/src/app/api/tts/camb/route.ts
+++ b/apps/readest-app/src/app/api/tts/camb/route.ts
@@ -1,0 +1,180 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { validateUserAndToken } from '@/utils/access';
+
+const CAMB_AI_API_BASE = 'https://client.camb.ai/apis';
+
+const getCambApiKey = (): string | undefined => {
+  return process.env['CAMB_API_KEY'];
+};
+
+// Cache voices and languages server-side (they rarely change)
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+let voicesCache: { data: unknown; timestamp: number } | null = null;
+let languagesCache: { data: unknown; timestamp: number } | null = null;
+
+export async function POST(request: NextRequest) {
+  const { user, token } = await validateUserAndToken(request.headers.get('authorization'));
+  if (!user || !token) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 403 });
+  }
+
+  const apiKey = getCambApiKey();
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: { message: 'CAMB AI API key not configured', type: 'configuration_error' } },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const body = await request.json();
+    const { text, language = 'en-us', voice_id, rate = 1.0, speech_model = 'mars-flash' } = body;
+
+    if (!text || typeof text !== 'string') {
+      return NextResponse.json(
+        { error: { message: 'Missing or invalid "text" field', type: 'invalid_request_error' } },
+        { status: 400 },
+      );
+    }
+
+    if (!voice_id || typeof voice_id !== 'number') {
+      return NextResponse.json(
+        {
+          error: { message: 'Missing or invalid "voice_id" field', type: 'invalid_request_error' },
+        },
+        { status: 400 },
+      );
+    }
+
+    const response = await fetch(`${CAMB_AI_API_BASE}/tts-stream`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+      },
+      body: JSON.stringify({
+        text,
+        language,
+        voice_id,
+        speech_model,
+        output_configuration: { format: 'mp3' },
+        voice_settings: { speaking_rate: rate },
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => 'Unknown error');
+      return NextResponse.json(
+        { error: { message: `CAMB AI API error: ${errorText}`, type: 'upstream_error' } },
+        { status: response.status },
+      );
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return new NextResponse(arrayBuffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'audio/mpeg',
+        'Content-Length': arrayBuffer.byteLength.toString(),
+      },
+    });
+  } catch (error) {
+    console.error('CAMB AI TTS API error:', error);
+    return NextResponse.json(
+      {
+        error: {
+          message: error instanceof Error ? error.message : 'Internal server error',
+          type: 'internal_error',
+        },
+      },
+      { status: 500 },
+    );
+  }
+}
+
+async function filterVoicesByLang(
+  voices: Array<{ language: number; [key: string]: unknown }>,
+  lang: string,
+  apiKey: string,
+): Promise<Array<{ language: number; [key: string]: unknown }>> {
+  const langResponse = await fetch(`${CAMB_AI_API_BASE}/target-languages`, {
+    headers: { 'x-api-key': apiKey },
+  });
+  if (!langResponse.ok) return voices;
+  const langData = await langResponse.json();
+  const langList = Array.isArray(langData) ? langData : (langData.languages ?? []);
+  const langMap = new Map<number, string>();
+  for (const l of langList) {
+    langMap.set(l.id, (l.short_name as string).toLowerCase());
+  }
+  return voices.filter((v) => {
+    const shortName = langMap.get(v.language) || '';
+    return shortName.startsWith(lang.toLowerCase());
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const apiKey = getCambApiKey();
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: { message: 'CAMB AI API key not configured', type: 'configuration_error' } },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const query = request.nextUrl.searchParams;
+    const action = query.get('action') || 'voices';
+    const now = Date.now();
+
+    if (action === 'languages') {
+      if (languagesCache && now - languagesCache.timestamp < CACHE_TTL_MS) {
+        return NextResponse.json({ languages: languagesCache.data });
+      }
+      const response = await fetch(`${CAMB_AI_API_BASE}/target-languages`, {
+        headers: { 'x-api-key': apiKey },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch languages: ${response.status}`);
+      }
+      const raw = await response.json();
+      const languages = Array.isArray(raw) ? raw : (raw.languages ?? []);
+      languagesCache = { data: languages, timestamp: now };
+      return NextResponse.json({ languages });
+    }
+
+    if (voicesCache && now - voicesCache.timestamp < CACHE_TTL_MS) {
+      let voices = voicesCache.data as Array<{ language: number; [key: string]: unknown }>;
+      const lang = query.get('lang') || '';
+      if (lang) {
+        voices = await filterVoicesByLang(voices, lang, apiKey);
+      }
+      return NextResponse.json({ voices });
+    }
+
+    const response = await fetch(`${CAMB_AI_API_BASE}/list-voices`, {
+      headers: { 'x-api-key': apiKey },
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch voices: ${response.status}`);
+    }
+    const raw = await response.json();
+    let voices: Array<{ language: number; [key: string]: unknown }> = Array.isArray(raw)
+      ? raw
+      : (raw.voices ?? []);
+    voicesCache = { data: voices, timestamp: now };
+
+    const lang = query.get('lang') || '';
+    if (lang) {
+      voices = await filterVoicesByLang(voices, lang, apiKey);
+    }
+
+    return NextResponse.json({ voices });
+  } catch (error) {
+    console.error('CAMB AI voices API error:', error);
+    return NextResponse.json(
+      { error: { message: 'Failed to fetch voices', type: 'internal_error' } },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/readest-app/src/libs/cambAI.ts
+++ b/apps/readest-app/src/libs/cambAI.ts
@@ -1,0 +1,129 @@
+import { md5 } from 'js-md5';
+import { LRUCache } from '@/utils/lru';
+import { fetchWithAuth } from '@/utils/fetch';
+import { getNodeAPIBaseUrl } from '@/services/environment';
+import { TTSVoice } from '@/services/tts/types';
+
+export type CambAISpeechModel = 'mars-flash' | 'mars-pro' | 'mars-instruct';
+
+export interface CambAITTSPayload {
+  text: string;
+  language: string;
+  voiceId: number;
+  rate: number;
+  model?: CambAISpeechModel;
+}
+
+interface CambAIVoiceResponse {
+  id: number;
+  voice_name: string;
+  gender: number | null;
+  age: number | null;
+  language: number | null;
+  description: string | null;
+  is_published: boolean | null;
+}
+
+interface CambAILanguageResponse {
+  id: number;
+  language: string;
+  short_name: string;
+}
+
+const hashPayload = (payload: CambAITTSPayload): string => {
+  const base = JSON.stringify(payload);
+  return md5(base);
+};
+
+export class CambAISpeechTTS {
+  private static audioCache = new LRUCache<string, Blob>(200);
+  private static audioUrlCache = new LRUCache<string, string>(200, (_, url) => {
+    if (url.startsWith('blob:')) {
+      URL.revokeObjectURL(url);
+    }
+  });
+  private static languageMap: Map<number, string> | null = null;
+  private static voicesCache: TTSVoice[] | null = null;
+
+  static voices: TTSVoice[] = [];
+
+  private async fetchViaProxy(payload: CambAITTSPayload): Promise<Response> {
+    const url = getNodeAPIBaseUrl() + '/tts/camb';
+    const response = await fetchWithAuth(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        text: payload.text,
+        language: payload.language,
+        voice_id: payload.voiceId,
+        rate: payload.rate,
+        speech_model: payload.model || 'mars-flash',
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`CAMB AI TTS request failed: ${response.status} ${response.statusText}`);
+    }
+    return response;
+  }
+
+  async create(payload: CambAITTSPayload): Promise<Response> {
+    return this.fetchViaProxy(payload);
+  }
+
+  async createAudioUrl(payload: CambAITTSPayload): Promise<string> {
+    const cacheKey = hashPayload(payload);
+    if (CambAISpeechTTS.audioUrlCache.has(cacheKey)) {
+      return CambAISpeechTTS.audioUrlCache.get(cacheKey)!;
+    }
+    const res = await this.create(payload);
+    const arrayBuffer = await res.arrayBuffer();
+    const blob = new Blob([arrayBuffer], { type: 'audio/mpeg' });
+    const objectUrl = URL.createObjectURL(blob);
+    CambAISpeechTTS.audioCache.set(cacheKey, blob);
+    CambAISpeechTTS.audioUrlCache.set(cacheKey, objectUrl);
+    return objectUrl;
+  }
+
+  static async fetchLanguageMap(): Promise<Map<number, string>> {
+    if (CambAISpeechTTS.languageMap) return CambAISpeechTTS.languageMap;
+
+    const url = getNodeAPIBaseUrl() + '/tts/camb?action=languages';
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch CAMB AI languages: ${response.status}`);
+    }
+    const data = (await response.json()) as { languages: CambAILanguageResponse[] };
+    const map = new Map<number, string>();
+    for (const lang of data.languages) {
+      map.set(lang.id, lang.short_name.toLowerCase());
+    }
+    CambAISpeechTTS.languageMap = map;
+    return map;
+  }
+
+  static async fetchVoices(): Promise<TTSVoice[]> {
+    if (CambAISpeechTTS.voicesCache) return CambAISpeechTTS.voicesCache;
+
+    const url = getNodeAPIBaseUrl() + '/tts/camb?action=voices';
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch CAMB AI voices: ${response.status}`);
+    }
+    const raw = await response.json();
+    // CAMB API may return a raw array or { voices: [...] }
+    const voiceList: CambAIVoiceResponse[] = Array.isArray(raw) ? raw : (raw.voices ?? []);
+    const languageMap = await CambAISpeechTTS.fetchLanguageMap();
+
+    const voices: TTSVoice[] = voiceList
+      .filter((v): v is CambAIVoiceResponse & { language: number } => v.language !== null)
+      .map((v) => ({
+        id: String(v.id),
+        name: v.voice_name,
+        lang: languageMap.get(v.language) || 'en-us',
+      }));
+
+    CambAISpeechTTS.voicesCache = voices;
+    CambAISpeechTTS.voices = voices;
+    return voices;
+  }
+}

--- a/apps/readest-app/src/services/tts/CambAITTSClient.ts
+++ b/apps/readest-app/src/services/tts/CambAITTSClient.ts
@@ -1,0 +1,335 @@
+import { TTSClient, TTSMessageEvent } from './TTSClient';
+import { CambAISpeechTTS, CambAITTSPayload } from '@/libs/cambAI';
+import { TTSGranularity, TTSVoice, TTSVoicesGroup } from './types';
+import { parseSSMLMarks } from '@/utils/ssml';
+import { TTSController } from './TTSController';
+import { TTSUtils } from './TTSUtils';
+import { AppService } from '@/types/system';
+
+export class CambAITTSClient implements TTSClient {
+  name = 'camb-ai';
+  initialized = false;
+  controller?: TTSController;
+  appService?: AppService | null;
+
+  #voices: TTSVoice[] = [];
+  #primaryLang = 'en';
+  #speakingLang = '';
+  #currentVoiceId = '';
+  #rate = 1.0;
+
+  #cambTTS: CambAISpeechTTS | null = null;
+  #audioElement: HTMLAudioElement | null = null;
+  #isPlaying = false;
+  #pausedAt = 0;
+  #startedAt = 0;
+  #fadeCompensation: number | null = null;
+
+  constructor(controller?: TTSController, appService?: AppService | null) {
+    this.controller = controller;
+    this.appService = appService;
+  }
+
+  async init() {
+    this.#cambTTS = new CambAISpeechTTS();
+    try {
+      this.#voices = await CambAISpeechTTS.fetchVoices();
+      this.initialized = this.#voices.length > 0;
+    } catch (err) {
+      console.warn('Failed to initialize CAMB AI TTS:', err);
+      this.initialized = false;
+    }
+    return this.initialized;
+  }
+
+  getPayload = (lang: string, text: string, voiceId: string): CambAITTSPayload => {
+    return {
+      text,
+      language: this.#toLangLocale(lang),
+      voiceId: Number(voiceId),
+      rate: this.#rate,
+    };
+  };
+
+  #toLangLocale(lang: string): string {
+    // Convert BCP-47 (en-US) to CAMB format (en-us)
+    const normalized = lang.toLowerCase();
+    if (normalized.includes('-')) return normalized;
+    // Map 2-char codes to common locale
+    const defaults: Record<string, string> = {
+      en: 'en-us',
+      fr: 'fr-fr',
+      de: 'de-de',
+      es: 'es-es',
+      it: 'it-it',
+      pt: 'pt-br',
+      ja: 'ja-jp',
+      ko: 'ko-kr',
+      zh: 'zh-cn',
+      ar: 'ar-sa',
+      hi: 'hi-in',
+      ru: 'ru-ru',
+    };
+    return defaults[normalized] || `${normalized}-${normalized}`;
+  }
+
+  getVoiceIdFromLang = async (lang: string) => {
+    const preferredVoiceId = TTSUtils.getPreferredVoice(this.name, lang);
+    const preferredVoice = this.#voices.find((v) => v.id === preferredVoiceId);
+    if (preferredVoice) return preferredVoice.id;
+
+    const availableVoices = (await this.getVoices(lang))[0]?.voices || [];
+    const defaultVoice: TTSVoice | null = availableVoices[0] || null;
+    return defaultVoice?.id || this.#currentVoiceId;
+  };
+
+  async *speak(ssml: string, signal: AbortSignal, preload = false) {
+    const { marks } = parseSSMLMarks(ssml, this.#primaryLang);
+
+    if (preload) {
+      const maxImmediate = 2;
+      for (let i = 0; i < Math.min(maxImmediate, marks.length); i++) {
+        if (signal.aborted) break;
+        const mark = marks[i]!;
+        const { language: voiceLang } = mark;
+        const voiceId = await this.getVoiceIdFromLang(voiceLang);
+        this.#currentVoiceId = voiceId;
+        await this.#cambTTS
+          ?.createAudioUrl(this.getPayload(voiceLang, mark.text, voiceId))
+          .catch((err) => {
+            console.warn('Error preloading CAMB AI mark', i, err);
+          });
+      }
+      if (marks.length > maxImmediate) {
+        (async () => {
+          for (let i = maxImmediate; i < marks.length; i++) {
+            const mark = marks[i]!;
+            try {
+              if (signal.aborted) break;
+              const { language: voiceLang } = mark;
+              const voiceId = await this.getVoiceIdFromLang(voiceLang);
+              await this.#cambTTS?.createAudioUrl(this.getPayload(voiceLang, mark.text, voiceId));
+            } catch (err) {
+              console.warn('Error preloading CAMB AI mark (bg)', i, err);
+            }
+          }
+        })();
+      }
+
+      yield {
+        code: 'end',
+        message: 'Preload finished',
+      } as TTSMessageEvent;
+
+      return;
+    }
+
+    await this.stopInternal();
+    if (!this.#audioElement) {
+      this.#audioElement = new Audio();
+    }
+    const audio = this.#audioElement;
+    audio.setAttribute('x-webkit-airplay', 'deny');
+    audio.preload = 'auto';
+
+    for (const mark of marks) {
+      this.controller?.dispatchSpeakMark(mark);
+      let abortHandler: null | (() => void) = null;
+      try {
+        const { language: voiceLang } = mark;
+        const voiceId = await this.getVoiceIdFromLang(voiceLang);
+        this.#speakingLang = voiceLang;
+        const audioUrl = await this.#cambTTS?.createAudioUrl(
+          this.getPayload(voiceLang, mark.text, voiceId),
+        );
+        if (signal.aborted) {
+          yield { code: 'error', message: 'Aborted' } as TTSMessageEvent;
+          break;
+        }
+
+        yield {
+          code: 'boundary',
+          message: `Start chunk: ${mark.name}`,
+          mark: mark.name,
+        } as TTSMessageEvent;
+
+        const result = await new Promise<TTSMessageEvent>((resolve) => {
+          const cleanUp = () => {
+            audio.onended = null;
+            audio.onerror = null;
+            audio.src = '';
+          };
+          let resolved = false;
+          const handleEnded = () => {
+            if (resolved) return;
+            resolved = true;
+            cleanUp();
+            resolve({ code: 'end', message: `Chunk finished: ${mark.name}` });
+          };
+
+          abortHandler = () => {
+            cleanUp();
+            resolve({ code: 'error', message: 'Aborted' });
+          };
+          if (signal.aborted) {
+            abortHandler();
+            return;
+          } else {
+            signal.addEventListener('abort', abortHandler);
+          }
+          audio.onended = handleEnded;
+          audio.onerror = (e) => {
+            cleanUp();
+            console.warn('CAMB AI audio playback error:', e);
+            resolve({ code: 'error', message: 'Audio playback error' });
+          };
+          this.#isPlaying = true;
+          audio.src = audioUrl || '';
+          if (!this.appService?.isLinuxApp) {
+            audio.playbackRate = this.#rate;
+          }
+          audio
+            .play()
+            .then(() => {
+              if (this.appService?.isLinuxApp) {
+                audio.playbackRate = this.#rate;
+              }
+            })
+            .catch((err) => {
+              cleanUp();
+              console.error('Failed to play CAMB AI audio:', err);
+              resolve({ code: 'error', message: 'Playback failed: ' + err.message });
+            });
+        });
+        yield result;
+      } catch (error) {
+        if (error instanceof Error && error.message === 'No audio data received.') {
+          console.warn('No audio data received for:', mark.text);
+          yield { code: 'end', message: `Chunk finished: ${mark.name}` } as TTSMessageEvent;
+          continue;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn('CAMB AI TTS error for mark:', mark.text, message);
+        yield { code: 'error', message } as TTSMessageEvent;
+        break;
+      } finally {
+        if (abortHandler) {
+          signal.removeEventListener('abort', abortHandler);
+        }
+      }
+    }
+    await this.stopInternal();
+  }
+
+  async pause() {
+    if (!this.#isPlaying || !this.#audioElement) return true;
+    this.#pausedAt = this.#audioElement.currentTime - this.#startedAt;
+    await this.#audioElement.pause();
+    this.#isPlaying = false;
+    return true;
+  }
+
+  #getFadeCompensation() {
+    if (this.#fadeCompensation !== null) return this.#fadeCompensation;
+
+    const userAgent = navigator.userAgent;
+    const isSafari = /Safari/.test(userAgent) && !/Chrome/.test(userAgent);
+    const isIOS = /iPad|iPhone|iPod/.test(userAgent);
+    if (isSafari || isIOS) {
+      this.#fadeCompensation = 0.2;
+    } else {
+      this.#fadeCompensation = 0.0;
+    }
+
+    return this.#fadeCompensation;
+  }
+
+  async resume() {
+    if (this.#isPlaying || !this.#audioElement) return true;
+    const fadeCompensation = this.#getFadeCompensation();
+    this.#audioElement.currentTime = Math.max(0, this.#audioElement.currentTime - fadeCompensation);
+    await this.#audioElement.play();
+    this.#isPlaying = true;
+    this.#startedAt = this.#audioElement.currentTime - this.#pausedAt;
+    return true;
+  }
+
+  async stop() {
+    await this.stopInternal();
+  }
+
+  private async stopInternal() {
+    this.#isPlaying = false;
+    this.#pausedAt = 0;
+    this.#startedAt = 0;
+    if (this.#audioElement) {
+      this.#audioElement.pause();
+      this.#audioElement.currentTime = 0;
+      if (this.#audioElement?.onended) {
+        this.#audioElement.onended(new Event('stopped'));
+      }
+      this.#audioElement.src = '';
+    }
+  }
+
+  async setRate(rate: number) {
+    this.#rate = rate;
+  }
+
+  async setPitch(_pitch: number) {
+    // CAMB AI does not support pitch adjustment
+  }
+
+  async setVoice(voice: string) {
+    const selectedVoice = this.#voices.find((v) => v.id === voice);
+    if (selectedVoice) {
+      this.#currentVoiceId = selectedVoice.id;
+    }
+  }
+
+  async getAllVoices(): Promise<TTSVoice[]> {
+    this.#voices.forEach((voice) => {
+      voice.disabled = !this.initialized;
+    });
+    return this.#voices;
+  }
+
+  async getVoices(lang: string) {
+    const locale = lang.toLowerCase();
+    const voices = await this.getAllVoices();
+    const filteredVoices = voices.filter(
+      (v) => v.lang.startsWith(locale) || v.lang.split('-')[0] === locale.split('-')[0],
+    );
+
+    const voicesGroup: TTSVoicesGroup = {
+      id: 'camb-ai',
+      name: 'CAMB AI',
+      voices: filteredVoices.sort(TTSUtils.sortVoicesFunc),
+      disabled: !this.initialized || filteredVoices.length === 0,
+    };
+
+    return [voicesGroup];
+  }
+
+  setPrimaryLang(lang: string) {
+    this.#primaryLang = lang;
+  }
+
+  getGranularities(): TTSGranularity[] {
+    return ['sentence'];
+  }
+
+  getVoiceId(): string {
+    return this.#currentVoiceId;
+  }
+
+  getSpeakingLang(): string {
+    return this.#speakingLang;
+  }
+
+  async shutdown(): Promise<void> {
+    this.initialized = false;
+    this.#audioElement = null;
+    this.#voices = [];
+  }
+}

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -7,6 +7,7 @@ import { createRejectFilter } from '@/utils/node';
 import { WebSpeechClient } from './WebSpeechClient';
 import { NativeTTSClient } from './NativeTTSClient';
 import { EdgeTTSClient } from './EdgeTTSClient';
+import { CambAITTSClient } from './CambAITTSClient';
 import { TTSUtils } from './TTSUtils';
 import { TTSClient } from './TTSClient';
 import { isValidLang } from '@/utils/lang';
@@ -41,9 +42,11 @@ export class TTSController extends EventTarget {
   ttsClient: TTSClient;
   ttsWebClient: TTSClient;
   ttsEdgeClient: TTSClient;
+  ttsCambClient: TTSClient;
   ttsNativeClient: TTSClient | null = null;
   ttsWebVoices: TTSVoice[] = [];
   ttsEdgeVoices: TTSVoice[] = [];
+  ttsCambVoices: TTSVoice[] = [];
   ttsNativeVoices: TTSVoice[] = [];
   ttsTargetLang: string = '';
 
@@ -59,6 +62,7 @@ export class TTSController extends EventTarget {
     super();
     this.ttsWebClient = new WebSpeechClient(this);
     this.ttsEdgeClient = new EdgeTTSClient(this, appService);
+    this.ttsCambClient = new CambAITTSClient(this, appService);
     // TODO: implement native TTS client for iOS and PC
     if (appService?.isAndroidApp) {
       this.ttsNativeClient = new NativeTTSClient(this);
@@ -75,6 +79,10 @@ export class TTSController extends EventTarget {
     const availableClients = [];
     if (await this.ttsEdgeClient.init()) {
       availableClients.push(this.ttsEdgeClient);
+    }
+    if (await this.ttsCambClient.init()) {
+      availableClients.push(this.ttsCambClient);
+      this.ttsCambVoices = await this.ttsCambClient.getAllVoices();
     }
     if (this.ttsNativeClient && (await this.ttsNativeClient.init())) {
       availableClients.push(this.ttsNativeClient);
@@ -471,6 +479,7 @@ export class TTSController extends EventTarget {
 
   async setPrimaryLang(lang: string) {
     if (this.ttsEdgeClient.initialized) this.ttsEdgeClient.setPrimaryLang(lang);
+    if (this.ttsCambClient.initialized) this.ttsCambClient.setPrimaryLang(lang);
     if (this.ttsWebClient.initialized) this.ttsWebClient.setPrimaryLang(lang);
     if (this.ttsNativeClient?.initialized) this.ttsNativeClient?.setPrimaryLang(lang);
   }
@@ -484,9 +493,10 @@ export class TTSController extends EventTarget {
   async getVoices(lang: string) {
     const ttsWebVoices = await this.ttsWebClient.getVoices(lang);
     const ttsEdgeVoices = await this.ttsEdgeClient.getVoices(lang);
+    const ttsCambVoices = await this.ttsCambClient.getVoices(lang);
     const ttsNativeVoices = (await this.ttsNativeClient?.getVoices(lang)) ?? [];
 
-    const voicesGroups = [...ttsNativeVoices, ...ttsEdgeVoices, ...ttsWebVoices];
+    const voicesGroups = [...ttsNativeVoices, ...ttsCambVoices, ...ttsEdgeVoices, ...ttsWebVoices];
     return voicesGroups;
   }
 
@@ -495,11 +505,17 @@ export class TTSController extends EventTarget {
     const useEdgeTTS = !!this.ttsEdgeVoices.find(
       (voice) => (voiceId === '' || voice.id === voiceId) && !voice.disabled,
     );
+    const useCambTTS = !!this.ttsCambVoices.find(
+      (voice) => (voiceId === '' || voice.id === voiceId) && !voice.disabled,
+    );
     const useNativeTTS = !!this.ttsNativeVoices.find(
       (voice) => (voiceId === '' || voice.id === voiceId) && !voice.disabled,
     );
     if (useEdgeTTS) {
       this.ttsClient = this.ttsEdgeClient;
+      await this.ttsClient.setRate(this.ttsRate);
+    } else if (useCambTTS) {
+      this.ttsClient = this.ttsCambClient;
       await this.ttsClient.setRate(this.ttsRate);
     } else if (useNativeTTS) {
       if (!this.ttsNativeClient) {
@@ -554,6 +570,9 @@ export class TTSController extends EventTarget {
     }
     if (this.ttsEdgeClient.initialized) {
       await this.ttsEdgeClient.shutdown();
+    }
+    if (this.ttsCambClient.initialized) {
+      await this.ttsCambClient.shutdown();
     }
     if (this.ttsNativeClient?.initialized) {
       await this.ttsNativeClient.shutdown();


### PR DESCRIPTION
## Summary

- Adds CAMB AI (camb.ai) as a new TTS engine alongside Edge TTS, Web Speech, and Native TTS
- CAMB AI provides high-quality neural TTS with 140+ languages via their MARS models
- Voices are fetched from the CAMB AI API and appear as a selectable group in the voice picker
- Audio synthesis is proxied through a server-side API route to keep the API key secure

CAMB AI is the localization engine of choice for brands like the Premier League, the NBA, NASCAR, and the Australian Open. We'd love to be added as a TTS option in Readest and are happy to answer any questions or make adjustments to fit the project's needs.

## Changes

- **`src/libs/cambAI.ts`** -- Low-level API wrapper with LRU audio caching
- **`src/services/tts/CambAITTSClient.ts`** -- TTSClient implementation (follows EdgeTTSClient pattern)
- **`src/app/api/tts/camb/route.ts`** -- Server-side proxy route with response caching
- **`src/services/tts/TTSController.ts`** -- Registers the new client in the controller
- **`src/__tests__/services/tts-controller.test.ts`** -- Updated tests for the new client

## Configuration

Requires a `CAMB_API_KEY` environment variable (obtain from https://studio.camb.ai).

## Test plan

- [ ] Set `CAMB_API_KEY` in `.env` / `.env.web`
- [ ] Run `pnpm dev-web`, open a book, and open the TTS voice picker
- [ ] Verify CAMB AI voices appear in the dropdown
- [ ] Select a CAMB AI voice and confirm audio plays
- [ ] Switch back to Edge TTS and confirm it still works
- [ ] Run `pnpm test` and confirm no regressions