### PR TITLE
feat(library): align grid hover highlight corner radius

### DIFF
--- a/apps/readest-app/src/app/library/components/BookshelfItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookshelfItem.tsx
@@ -393,7 +393,7 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
         className={clsx(
           'visible-focus-inset-2 group',
           mode === 'grid' &&
-            'sm:hover:bg-base-300/50 flex h-full flex-col px-0 py-2 sm:px-4 sm:py-4',
+            'sm:hover:bg-base-300/50 flex h-full flex-col px-0 py-2 sm:rounded-md sm:px-4 sm:py-4',
           mode === 'list' && 'border-base-300 flex flex-col border-b py-2',
           appService?.isMobileApp && 'no-context-menu',
           pressing && mode === 'grid' ? 'not-eink:scale-95' : 'scale-100',


### PR DESCRIPTION
this pr adds:
- adjustment of the library grid item hover highlight radius to better match the book cover corner treatment

<img width="188" height="291" alt="image" src="https://github.com/user-attachments/assets/47d82bcf-156f-45b1-ae88-af1dd14e8ad6" />
