### PR TITLE
Updating Hardcover progress sync logic (Issue #3775)

### DIFF
--- a/apps/readest-app/src/__tests__/services/hardcover/HardcoverClient.test.ts
+++ b/apps/readest-app/src/__tests__/services/hardcover/HardcoverClient.test.ts
@@ -598,4 +598,118 @@ describe('HardcoverClient', () => {
       calls.some((call: { query: string }) => call.query.includes('mutation UpdateUserBook')),
     ).toBe(false);
   });
+
+  test('should throw when insert_user_book returns a null user_book', async () => {
+    const book = { title: 'Test Book', author: 'Test Author' } as Book;
+    const config = { progress: [25, 100] } as BookConfig;
+
+    vi.spyOn(clientApi, 'fetchBookContext').mockResolvedValue({
+      editionId: 101,
+      pages: 100,
+      bookId: 202,
+      bookPages: 100,
+      userBook: null,
+    } as TestBookContext);
+
+    vi.spyOn(clientApi, 'request').mockImplementation(async (query) => {
+      if (String(query).includes('mutation InsertUserBook')) {
+        return { insert_user_book: { error: 'conflict', user_book: null } };
+      }
+      return {};
+    });
+
+    await expect(client.pushProgress(book, config)).rejects.toThrow('insert_user_book failed');
+  });
+
+  test('should skip progress push when Hardcover edition page count is unknown', async () => {
+    const book = { createdAt: 1711737600000, metadata: { isbn: '1234567890' } } as Book;
+    const config = { progress: [25, 100] } as BookConfig;
+
+    vi.spyOn(clientApi, 'ensureBookInLibrary').mockResolvedValue({
+      editionId: 101,
+      pages: null,
+      bookId: 202,
+      bookPages: null,
+      userBook: { id: 303, status_id: 2, user_book_reads: [] },
+    } as TestBookContext);
+    const requestSpy = vi.spyOn(clientApi, 'request').mockResolvedValue({});
+
+    await client.pushProgress(book, config);
+
+    const requestCalls = requestSpy.mock.calls as RequestSpyCall[];
+    const insertReadCall = requestCalls.find((call) =>
+      String(call[0]).includes('mutation InsertRead'),
+    );
+    const updateReadCall = requestCalls.find((call) =>
+      String(call[0]).includes('mutation UpdateRead'),
+    );
+    expect(insertReadCall).toBeUndefined();
+    expect(updateReadCall).toBeUndefined();
+  });
+
+  test('should apply edition preference when resolving context via title search', async () => {
+    const book = { title: 'Test Book', author: 'Test Author' } as Book;
+
+    // authenticate
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: { me: { id: 1 } } }),
+    });
+    // QUERY_SEARCH_BOOK
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          data: {
+            search: {
+              results: [{ id: 202, pages: 300, featured_edition_id: 101 }],
+            },
+          },
+        }),
+    });
+    // QUERY_GET_BOOK_USER_DATA
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          data: {
+            editions: [
+              {
+                book: {
+                  id: 202,
+                  pages: 300,
+                  user_books: [
+                    {
+                      id: 303,
+                      status_id: 2,
+                      edition: { id: 404, pages: 310, reading_format_id: 1 },
+                      user_book_reads: [
+                        {
+                          id: 505,
+                          started_at: '2026-03-29',
+                          edition: { id: 606, pages: 400, reading_format_id: 1 },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        }),
+    });
+
+    const context = await clientApi.fetchBookContext(book);
+
+    expect(context).toMatchObject({
+      editionId: 606,
+      pages: 400,
+      bookId: 202,
+      bookPages: 300,
+      userBook: { id: 303 },
+    });
+  });
 });

--- a/apps/readest-app/src/services/hardcover/HardcoverClient.ts
+++ b/apps/readest-app/src/services/hardcover/HardcoverClient.ts
@@ -7,6 +7,7 @@ import {
   QUERY_GET_USER_ID,
   QUERY_SEARCH_BOOK,
   QUERY_GET_EDITION,
+  QUERY_GET_BOOK_USER_DATA,
   MUTATION_INSERT_USER_BOOK,
   MUTATION_UPDATE_USER_BOOK,
   MUTATION_INSERT_READ,
@@ -74,11 +75,15 @@ export class HardcoverClient {
     return !!edition && edition.reading_format_id !== 2;
   }
 
-  private getHardcoverProgressPages(current: number, total: number, context: BookContext): number {
+  private getHardcoverProgressPages(
+    current: number,
+    total: number,
+    context: BookContext,
+  ): number | null {
     const boundedCurrent = Math.min(Math.max(current, 0), total);
     const hardcoverTotal = context.pages ?? context.bookPages ?? 0;
     if (total <= 0 || hardcoverTotal <= 0) {
-      return boundedCurrent;
+      return null;
     }
 
     const scaledPages = Math.round((boundedCurrent / total) * hardcoverTotal);
@@ -364,7 +369,57 @@ export class HardcoverClient {
     }
 
     if (book.title && book.author) {
-      return this.searchBookByTitle(book.title, book.author);
+      const titleContext = await this.searchBookByTitle(book.title, book.author);
+      if (!titleContext || !this.userId) return titleContext;
+
+      const bookResult = await this.request<
+        { book_id: number; user_id: number },
+        {
+          editions?: Array<{
+            book: {
+              id: number;
+              pages: number | null;
+              user_books?: Array<{
+                id: number;
+                status_id: number;
+                edition?: {
+                  id: number;
+                  pages: number | null;
+                  reading_format_id?: number | null;
+                } | null;
+                user_book_reads?: Array<{
+                  id: number;
+                  started_at: string | null;
+                  edition?: {
+                    id: number;
+                    pages: number | null;
+                    reading_format_id?: number | null;
+                  } | null;
+                }>;
+              }>;
+            };
+          }>;
+        }
+      >(QUERY_GET_BOOK_USER_DATA, { book_id: titleContext.bookId, user_id: this.userId });
+
+      const bookData = bookResult.editions?.[0]?.book;
+      if (!bookData) return titleContext;
+
+      const userBook = bookData.user_books?.[0];
+      const activeRead = userBook?.user_book_reads?.[0];
+      const selectedEdition =
+        (this.isReadableEdition(activeRead?.edition) ? activeRead?.edition : null) ??
+        (this.isReadableEdition(userBook?.edition) ? userBook?.edition : null);
+
+      return {
+        ...titleContext,
+        editionId: selectedEdition?.id ?? titleContext.editionId,
+        pages: selectedEdition?.pages ?? titleContext.pages,
+        bookPages: bookData.pages ?? titleContext.bookPages,
+        userBook: userBook
+          ? { ...userBook, user_book_reads: userBook.user_book_reads ?? [] }
+          : null,
+      };
     }
 
     return null;
@@ -409,10 +464,11 @@ export class HardcoverClient {
       { object: { book_id: number; edition_id: number; status_id: number } },
       {
         insert_user_book: {
+          error?: string | null;
           user_book: {
             id: number;
             user_book_reads?: ActiveRead[];
-          };
+          } | null;
         };
       }
     >(MUTATION_INSERT_USER_BOOK, {
@@ -423,12 +479,19 @@ export class HardcoverClient {
       },
     });
 
+    const newUserBook = data.insert_user_book?.user_book;
+    if (!newUserBook?.id) {
+      throw new Error(
+        `Hardcover insert_user_book failed: ${data.insert_user_book?.error ?? 'no user_book returned'}`,
+      );
+    }
+
     return {
       ...context,
       userBook: {
-        id: data.insert_user_book.user_book.id,
+        id: newUserBook.id,
         status_id: isReading ? 2 : 1,
-        user_book_reads: data.insert_user_book.user_book.user_book_reads ?? [],
+        user_book_reads: newUserBook.user_book_reads ?? [],
       },
     };
   }
@@ -447,6 +510,7 @@ export class HardcoverClient {
     const localPagesRead = Math.min(Math.max(current, 0), total);
     const percent = total > 0 ? (localPagesRead / total) * 100 : 0;
     const progressPages = this.getHardcoverProgressPages(current, total, context);
+    if (progressPages === null) return;
     const activeRead = context.userBook.user_book_reads?.[0];
     const startedAt = this.formatDay(new Date(book.createdAt || Date.now()));
 

--- a/apps/readest-app/src/services/hardcover/hardcover-graphql.ts
+++ b/apps/readest-app/src/services/hardcover/hardcover-graphql.ts
@@ -54,6 +54,42 @@ query GetEdition($isbn: [String!]!, $user_id: Int!) {
 }
 `;
 
+export const QUERY_GET_BOOK_USER_DATA = `
+query GetBookUserData($book_id: Int!, $user_id: Int!) {
+  editions(
+    where: { book_id: { _eq: $book_id } }
+    limit: 1
+  ) {
+    book {
+      id
+      pages
+      user_books(where: { user_id: { _eq: $user_id } }) {
+        id
+        status_id
+        edition {
+          id
+          pages
+          reading_format_id
+        }
+        user_book_reads(
+          where: { finished_at: { _is_null: true } }
+          order_by: { started_at: desc }
+          limit: 1
+        ) {
+          id
+          started_at
+          edition {
+            id
+            pages
+            reading_format_id
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
 export const MUTATION_INSERT_USER_BOOK = `
 mutation InsertUserBook($object: UserBookCreateInput!) {
   insert_user_book(object: $object) {


### PR DESCRIPTION
## Summary

Fixes two bugs in Hardcover progress syncing and adds correctness improvements found during review.

## What Changed

### Percentage-based progress

Progress is now mapped as a percentage onto the Hardcover edition's page count rather than sending the raw local page number. This keeps sync accurate when Readest and Hardcover have editions with different page totals.

If the Hardcover edition has no known page count, the sync skips rather than sending meaningless data.

### Better edition selection

When resolving which edition to sync against, Readest now prefers:

1. The user's active `user_book_read` edition
2. The user's linked `user_book` edition
3. The ISBN-matched edition

Audiobook editions are excluded. This now applies to both ISBN and title+author search paths.

### First-sync UI bug

When a book was added or promoted to `currently reading`, progress appeared in the Hardcover journal but not the main UI until a second sync. Fixed by reading the active read back from the create/update mutation response and hydrating it immediately.

### Null-guard on insert failure

If Hardcover rejects an `insert_user_book` call, the client now throws a descriptive error instead of crashing on a null property access.

## Validation

- 13/13 unit tests passing
- `pnpm lint` clean
- `pnpm format:check` clean
- All GraphQL field names verified against `hardcover-docs/schema.graphql`

## Commits

- `feat(hardcover): sync progress by edition percentage`
- `fix(hardcover): reuse active read on first sync`
- `style(hardcover): apply formatting fixes`
- `fix(hardcover): address adversarial review findings`