### PR TITLE
fix(opds): improve robustness of Content-Disposition filename parsing

### DIFF
--- a/apps/readest-app/src/app/opds/utils/opdsReq.ts
+++ b/apps/readest-app/src/app/opds/utils/opdsReq.ts
@@ -274,19 +274,36 @@ export const probeFilename = async (headers: Record<string, string>) => {
       /filename\*\s*=\s*(?:utf-8|UTF-8)'[^']*'([^;\s]+)/i,
     );
     if (extendedMatch?.[1]) {
-      return decodeURIComponent(extendedMatch[1]);
+      try {
+        return decodeURIComponent(extendedMatch[1]);
+      } catch (e) {
+        // If decoding fails, ignore and proceed to the next format
+        console.warn('Failed to decode filename*', e);
+      }
     }
 
-    // 2. Try standard format with quotes (supports spaces)
-    const quotedMatch = contentDisposition.match(/filename\s*=\s*["']([^"']+)["']/i);
-    if (quotedMatch?.[1]) {
-      return decodeURIComponent(quotedMatch[1]);
+    // 2. Try standard quoted format (supports spaces, apostrophes, and escaped quotes)
+    const quotedMatch = contentDisposition.match(/filename\s*=\s*(["'])((?:(?!\1)[^\\]|\\.)*)\1/i);
+    if (quotedMatch?.[2]) {
+      // Unescape characters (e.g., \" becomes ")
+      const unescaped = quotedMatch[2].replace(/\\(.)/g, '$1');
+      try {
+        // Attempt to decode in case the server incorrectly applied URL encoding
+        return decodeURIComponent(unescaped);
+      } catch {
+        // If decoding fails (e.g., literal '%' symbols), return the unescaped string as-is
+        return unescaped;
+      }
     }
 
     // 3. Fallback: standard format without quotes
     const plainMatch = contentDisposition.match(/filename\s*=\s*([^;\s]+)/i);
     if (plainMatch?.[1]) {
-      return decodeURIComponent(plainMatch[1]);
+      try {
+        return decodeURIComponent(plainMatch[1]);
+      } catch {
+        return plainMatch[1];
+      }
     }
   }
 


### PR DESCRIPTION
This is a follow-up to #3812 to handle additional edge cases in the `Content-Disposition` header that were previously overlooked.

**Changes:**
*   **Apostrophe & Quote Handling:** Updated the regex to use backreferences (`\1`). This ensures that if a filename is wrapped in double quotes, it correctly captures internal single quotes (e.g., `"my dog's house.jpg"`) instead of truncating them.
*   **Escape Character Support:** Added logic to unescape backslash-escaped characters (e.g., `\"` becomes `"`).
*   **Crash Prevention:** Wrapped `decodeURIComponent` calls in `try/catch` blocks. Some servers incorrectly send literal `%` characters (e.g., `filename="report_100%.pdf"`) which causes `decodeURIComponent` to throw a fatal `URIError`. The logic now falls back to the raw string in these cases.
*   **RFC 5987 Logging:** Added a warning log if the preferred extended format fails to decode, allowing the parser to proceed to standard formats.

**Why this is needed:**
While #3812 fixed basic spaces, the parser would still fail on filenames containing apostrophes or literal percentage signs, the latter of which could cause the application to crash during the download process.