### PR TITLE
feat: auto-download new items from subscribed OPDS catalogs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "packages/foliate-js"]
 	path = packages/foliate-js
-	url = https://github.com/readest/foliate-js.git
+	url = https://github.com/johannesmauerer/foliate-js.git
 [submodule "packages/tauri"]
 	path = packages/tauri
 	url = https://github.com/readest/tauri.git

--- a/apps/readest-app/src/__tests__/services/opds-sync-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/opds-sync-service.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getFeed } from 'foliate-js/opds.js';
+import type { OPDSFeed } from '@/types/opds';
+import { collectNewEntries, getAcquisitionLink } from '@/services/opdsSyncService';
+
+vi.mock('@/services/environment', () => ({
+  isWebAppPlatform: vi.fn(() => false),
+  isTauriAppPlatform: vi.fn(() => true),
+  getAPIBaseUrl: () => '/api',
+  getNodeAPIBaseUrl: () => '/node-api',
+}));
+
+vi.mock('@tauri-apps/plugin-http', () => ({
+  fetch: vi.fn(),
+}));
+
+vi.mock('@/libs/storage', () => ({
+  downloadFile: vi.fn().mockResolvedValue({ 'content-disposition': '' }),
+}));
+
+const MIME_XML = 'application/xml';
+const parseXML = (xml: string): Document =>
+  new DOMParser().parseFromString(xml, MIME_XML as DOMParserSupportedType);
+
+const makeAcquisitionFeed = (entries: Array<{ id: string; title: string; href: string }>) => {
+  const entryXml = entries
+    .map(
+      (e) => `
+    <entry>
+      <title>${e.title}</title>
+      <id>${e.id}</id>
+      <updated>2026-01-15T10:00:00.000Z</updated>
+      <link href="${e.href}" type="application/epub+zip"
+            rel="http://opds-spec.org/acquisition"/>
+    </entry>`,
+    )
+    .join('');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:opds="http://opds-spec.org/2010/catalog">
+  <id>urn:test:feed</id>
+  <title>Test Feed</title>
+  <updated>2026-01-15T10:00:00.000Z</updated>
+  ${entryXml}
+</feed>`;
+};
+
+const makeNavigationFeed = (links: Array<{ title: string; href: string }>) => {
+  const entryXml = links
+    .map(
+      (l) => `
+    <entry>
+      <title>${l.title}</title>
+      <link rel="subsection" href="${l.href}"
+            type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
+      <updated>2026-01-15T10:00:00.000Z</updated>
+    </entry>`,
+    )
+    .join('');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>urn:test:nav</id>
+  <title>Navigation</title>
+  <updated>2026-01-15T10:00:00.000Z</updated>
+  ${entryXml}
+</feed>`;
+};
+
+describe('OPDS sync service', () => {
+  describe('collectNewEntries', () => {
+    it('should return all entries when downloadedIds is empty', () => {
+      const xml = makeAcquisitionFeed([
+        { id: 'urn:shelf:issue:aaa', title: 'Issue 1', href: '/dl/aaa' },
+        { id: 'urn:shelf:issue:bbb', title: 'Issue 2', href: '/dl/bbb' },
+      ]);
+      const doc = parseXML(xml);
+      const feed = getFeed(doc) as OPDSFeed;
+
+      const newEntries = collectNewEntries(feed, new Set());
+      expect(newEntries).toHaveLength(2);
+    });
+
+    it('should skip already-downloaded entries', () => {
+      const xml = makeAcquisitionFeed([
+        { id: 'urn:shelf:issue:aaa', title: 'Issue 1', href: '/dl/aaa' },
+        { id: 'urn:shelf:issue:bbb', title: 'Issue 2', href: '/dl/bbb' },
+        { id: 'urn:shelf:issue:ccc', title: 'Issue 3', href: '/dl/ccc' },
+      ]);
+      const doc = parseXML(xml);
+      const feed = getFeed(doc) as OPDSFeed;
+
+      const downloaded = new Set(['urn:shelf:issue:aaa', 'urn:shelf:issue:bbb']);
+      const newEntries = collectNewEntries(feed, downloaded);
+      expect(newEntries).toHaveLength(1);
+      expect(newEntries[0]!.metadata.id).toBe('urn:shelf:issue:ccc');
+    });
+
+    it('should skip entries without an id', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>No ID Entry</title>
+    <link href="/dl/noId" type="application/epub+zip"
+          rel="http://opds-spec.org/acquisition"/>
+  </entry>
+</feed>`;
+      const doc = parseXML(xml);
+      const feed = getFeed(doc) as OPDSFeed;
+
+      const newEntries = collectNewEntries(feed, new Set());
+      expect(newEntries).toHaveLength(0);
+    });
+
+    it('should return empty when all entries are already downloaded', () => {
+      const xml = makeAcquisitionFeed([
+        { id: 'urn:shelf:issue:aaa', title: 'Issue 1', href: '/dl/aaa' },
+      ]);
+      const doc = parseXML(xml);
+      const feed = getFeed(doc) as OPDSFeed;
+
+      const downloaded = new Set(['urn:shelf:issue:aaa']);
+      const newEntries = collectNewEntries(feed, downloaded);
+      expect(newEntries).toHaveLength(0);
+    });
+  });
+
+  describe('getAcquisitionLink', () => {
+    it('should find the acquisition link from a publication', () => {
+      const xml = makeAcquisitionFeed([
+        { id: 'urn:test:1', title: 'Test Book', href: '/download/book.epub' },
+      ]);
+      const doc = parseXML(xml);
+      const feed = getFeed(doc) as OPDSFeed;
+      const pub = feed.publications![0]!;
+
+      const acqLink = getAcquisitionLink(pub);
+
+      expect(acqLink).toBeDefined();
+      expect(acqLink!.href).toBe('/download/book.epub');
+      expect(acqLink!.type).toBe('application/epub+zip');
+    });
+
+    it('should return undefined for a publication without acquisition links', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test</title>
+  <entry>
+    <title>Preview Only</title>
+    <id>urn:test:preview</id>
+    <link href="/preview" type="text/html" rel="alternate"/>
+  </entry>
+</feed>`;
+      const doc = parseXML(xml);
+      const feed = getFeed(doc) as OPDSFeed;
+      // This entry has no acquisition link, so it ends up as navigation
+      // Let's test with a publication that has non-acquisition links
+      expect(feed.publications).toBeUndefined();
+    });
+  });
+
+  describe('isNavigationFeed', () => {
+    it('should identify navigation feeds (no publications)', () => {
+      const xml = makeNavigationFeed([
+        { title: 'Series A', href: '/series/a.xml' },
+        { title: 'Series B', href: '/series/b.xml' },
+      ]);
+      const doc = parseXML(xml);
+      const feed = getFeed(doc) as OPDSFeed;
+
+      const isNav = !feed.publications?.length && !!feed.navigation?.length;
+      expect(isNav).toBe(true);
+    });
+
+    it('should identify acquisition feeds (has publications)', () => {
+      const xml = makeAcquisitionFeed([{ id: 'urn:test:1', title: 'Book', href: '/dl/book' }]);
+      const doc = parseXML(xml);
+      const feed = getFeed(doc) as OPDSFeed;
+
+      const isNav = !feed.publications?.length && !!feed.navigation?.length;
+      expect(isNav).toBe(false);
+    });
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/opds-feed.test.ts
+++ b/apps/readest-app/src/__tests__/utils/opds-feed.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { getFeed } from 'foliate-js/opds.js';
+import { getFeed, getPublication } from 'foliate-js/opds.js';
+import type { OPDSFeed, OPDSPublication } from '@/types/opds';
 
 const MIME_XML = 'application/xml';
 
@@ -124,6 +125,15 @@ describe('OPDS feed parsing', () => {
       expect(feed.navigation![1].title).toBe('Non-Fiction/');
     });
 
+    it('should parse entry id and updated fields from publications', () => {
+      const doc = parseXML(copypartyRootFeed);
+      const feed = getFeed(doc);
+
+      // The book entry has an <updated> element but no <id>
+      expect(feed.publications).toBeDefined();
+      expect(feed.publications![0].metadata.updated).toBe('2025-11-02T17:50:21Z');
+    });
+
     it('should handle navigation entry after publications', () => {
       // Reverse order: publications first, then navigation
       const reverseFeed = `<?xml version="1.0" encoding="UTF-8"?>
@@ -154,6 +164,80 @@ describe('OPDS feed parsing', () => {
       expect(feed.navigation).toBeDefined();
       expect(feed.navigation!).toHaveLength(1);
       expect(feed.navigation![0].title).toBe('Sub/');
+    });
+  });
+
+  describe('entry id and updated parsing', () => {
+    const shelfFeed = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:opds="http://opds-spec.org/2010/catalog">
+  <id>urn:shelf:series:stratechery</id>
+  <title>Shelf — Stratechery</title>
+  <updated>2026-01-15T10:30:00.000Z</updated>
+  <entry>
+    <title>Issue One</title>
+    <id>urn:shelf:issue:abc123</id>
+    <updated>2026-01-15T10:30:00.000Z</updated>
+    <published>2026-01-14T00:00:00.000Z</published>
+    <link href="/dl/abc123.token"
+          type="application/epub+zip"
+          rel="http://opds-spec.org/acquisition"/>
+  </entry>
+  <entry>
+    <title>Issue Two</title>
+    <id>urn:shelf:issue:def456</id>
+    <updated>2026-01-16T08:00:00.000Z</updated>
+    <link href="/dl/def456.token"
+          type="application/epub+zip"
+          rel="http://opds-spec.org/acquisition"/>
+  </entry>
+</feed>`;
+
+    it('should parse id and updated on publications', () => {
+      const doc = parseXML(shelfFeed);
+      const feed = getFeed(doc);
+
+      expect(feed.publications).toHaveLength(2);
+      expect(feed.publications![0].metadata.id).toBe('urn:shelf:issue:abc123');
+      expect(feed.publications![0].metadata.updated).toBe('2026-01-15T10:30:00.000Z');
+      expect(feed.publications![0].metadata.published).toBe('2026-01-14T00:00:00.000Z');
+      expect(feed.publications![1].metadata.id).toBe('urn:shelf:issue:def456');
+      expect(feed.publications![1].metadata.updated).toBe('2026-01-16T08:00:00.000Z');
+    });
+
+    it('should parse id and updated on the feed itself', () => {
+      const doc = parseXML(shelfFeed);
+      const feed = getFeed(doc) as OPDSFeed;
+
+      expect(feed.metadata.id).toBe('urn:shelf:series:stratechery');
+      expect(feed.metadata.updated).toBe('2026-01-15T10:30:00.000Z');
+    });
+
+    it('should parse id and updated via getPublication directly', () => {
+      const doc = parseXML(shelfFeed);
+      const entry = doc.querySelector('entry')!;
+      const pub = getPublication(entry) as OPDSPublication;
+
+      expect(pub.metadata.id).toBe('urn:shelf:issue:abc123');
+      expect(pub.metadata.updated).toBe('2026-01-15T10:30:00.000Z');
+    });
+
+    it('should handle entries without id or updated gracefully', () => {
+      const minimalFeed = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Minimal</title>
+  <entry>
+    <title>No ID Book</title>
+    <link rel="http://opds-spec.org/acquisition"
+          href="book.epub" type="application/epub+zip"/>
+  </entry>
+</feed>`;
+      const doc = parseXML(minimalFeed);
+      const feed = getFeed(doc);
+
+      expect(feed.publications).toHaveLength(1);
+      expect(feed.publications![0].metadata.id).toBeUndefined();
+      expect(feed.publications![0].metadata.updated).toBeUndefined();
     });
   });
 });

--- a/apps/readest-app/src/app/library/hooks/useBooksSync.ts
+++ b/apps/readest-app/src/app/library/hooks/useBooksSync.ts
@@ -4,8 +4,11 @@ import { useSync } from '@/hooks/useSync';
 import { useEnv } from '@/context/EnvContext';
 import { useAuth } from '@/context/AuthContext';
 import { useLibraryStore } from '@/store/libraryStore';
+import { useSettingsStore } from '@/store/settingsStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { SYNC_BOOKS_INTERVAL_SEC } from '@/services/constants';
+import { syncAllOPDSCatalogs } from '@/services/opdsSyncService';
+import { saveSysSettings } from '@/helpers/settings';
 import { throttle } from '@/utils/throttle';
 import { debounce } from '@/utils/debounce';
 import { eventDispatcher } from '@/utils/event';
@@ -13,7 +16,7 @@ import { eventDispatcher } from '@/utils/event';
 export const useBooksSync = () => {
   const _ = useTranslation();
   const { user } = useAuth();
-  const { appService } = useEnv();
+  const { envConfig, appService } = useEnv();
   const { library, isSyncing, libraryLoaded } = useLibraryStore();
   const { setLibrary, setIsSyncing, setSyncProgress } = useLibraryStore();
   const { useSyncInited, syncedBooks, syncBooks, lastSyncedAtBooks } = useSync();
@@ -185,5 +188,61 @@ export const useBooksSync = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [syncedBooks, updateLibrary, debouncedUpdateLibrary]);
 
-  return { pullLibrary, pushLibrary };
+  const isSyncingOPDSRef = useRef(false);
+
+  const pullOPDSCatalogs = useCallback(
+    async (verbose = false) => {
+      if (!appService || !libraryLoaded) return;
+      if (isSyncingOPDSRef.current) return;
+
+      const { settings } = useSettingsStore.getState();
+      const catalogs = settings.opdsCatalogs ?? [];
+      const hasAutoDownload = catalogs.some((c) => c.autoDownload && !c.disabled);
+      if (!hasAutoDownload) return;
+
+      try {
+        isSyncingOPDSRef.current = true;
+        const librarySnapshot = [...useLibraryStore.getState().library];
+        const { newBooks, totalNewBooks, updatedCatalogs } = await syncAllOPDSCatalogs(
+          catalogs,
+          appService,
+          librarySnapshot,
+        );
+
+        if (totalNewBooks > 0) {
+          // Merge new books into the current store state (which may have changed during sync)
+          const currentLibrary = useLibraryStore.getState().library;
+          const existingHashes = new Set(currentLibrary.map((b) => b.hash));
+          const uniqueNewBooks = newBooks.filter((b) => !existingHashes.has(b.hash));
+          if (uniqueNewBooks.length > 0) {
+            const merged = [...uniqueNewBooks, ...currentLibrary];
+            setLibrary(merged);
+            appService.saveLibraryBooks(merged);
+          }
+        }
+
+        saveSysSettings(envConfig, 'opdsCatalogs', updatedCatalogs);
+
+        if (verbose && totalNewBooks > 0) {
+          eventDispatcher.dispatch('toast', {
+            type: 'info',
+            message: _('{{count}} new item(s) downloaded from OPDS', { count: totalNewBooks }),
+          });
+        }
+      } catch (error) {
+        console.error('OPDS sync error:', error);
+      } finally {
+        isSyncingOPDSRef.current = false;
+      }
+    },
+    [_, envConfig, appService, libraryLoaded, setLibrary],
+  );
+
+  // Trigger OPDS sync on startup (after library is loaded)
+  useEffect(() => {
+    if (!libraryLoaded) return;
+    pullOPDSCatalogs();
+  }, [libraryLoaded, pullOPDSCatalogs]);
+
+  return { pullLibrary, pushLibrary, pullOPDSCatalogs };
 };

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -166,13 +166,19 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
   useOpenWithBooks();
   useTransferQueue(libraryLoaded);
 
-  const { pullLibrary, pushLibrary } = useBooksSync();
+  const { pullLibrary, pushLibrary, pullOPDSCatalogs } = useBooksSync();
   const { isDragging } = useDragDropImport();
 
   usePullToRefresh(
     scrollRef,
-    pullLibrary.bind(null, false, true),
-    pullLibrary.bind(null, true, true),
+    async () => {
+      await pullLibrary(false, true);
+      await pullOPDSCatalogs(true);
+    },
+    async () => {
+      await pullLibrary(true, true);
+      await pullOPDSCatalogs(true);
+    },
   );
   useScreenWakeLock(settings.screenWakeLock);
 

--- a/apps/readest-app/src/app/opds/components/CatelogManager.tsx
+++ b/apps/readest-app/src/app/opds/components/CatelogManager.tsx
@@ -2,7 +2,16 @@
 
 import clsx from 'clsx';
 import { useState } from 'react';
-import { IoAdd, IoTrash, IoOpenOutline, IoBook, IoEyeOff, IoEye, IoPencil } from 'react-icons/io5';
+import {
+  IoAdd,
+  IoTrash,
+  IoOpenOutline,
+  IoBook,
+  IoEyeOff,
+  IoEye,
+  IoPencil,
+  IoCloudDownloadOutline,
+} from 'react-icons/io5';
 import { useRouter } from 'next/navigation';
 import { useEnv } from '@/context/EnvContext';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -68,6 +77,7 @@ const EMPTY_NEW_CATALOG = {
   password: '',
   customHeadersInput: '',
   proxyConsent: false,
+  autoDownload: false,
 };
 
 export function CatalogManager() {
@@ -157,6 +167,7 @@ export function CatalogManager() {
       customHeaders: hasOPDSCustomHeaders(parsedHeaders.headers)
         ? parsedHeaders.headers
         : undefined,
+      autoDownload: newCatalog.autoDownload || undefined,
     };
 
     if (editingCatalogId) {
@@ -183,6 +194,7 @@ export function CatalogManager() {
       password: catalog.password || '',
       customHeadersInput: formatOPDSCustomHeadersInput(catalog.customHeaders),
       proxyConsent: false,
+      autoDownload: catalog.autoDownload || false,
     });
     setEditingCatalogId(catalog.id);
     setShowAddDialog(true);
@@ -198,6 +210,10 @@ export function CatalogManager() {
 
   const handleRemoveCatalog = (id: string) => {
     saveCatalogs(catalogs.filter((c) => c.id !== id));
+  };
+
+  const handleToggleAutoDownload = (id: string) => {
+    saveCatalogs(catalogs.map((c) => (c.id === id ? { ...c, autoDownload: !c.autoDownload } : c)));
   };
 
   const handleOpenCatalog = (catalog: OPDSCatalog) => {
@@ -295,6 +311,20 @@ export function CatalogManager() {
                         </p>
                       )}
                     </div>
+                  </div>
+                  <div className='mt-2 flex items-center gap-2'>
+                    <label className='label cursor-pointer gap-2 p-0'>
+                      <input
+                        type='checkbox'
+                        className='toggle toggle-sm toggle-primary'
+                        checked={!!catalog.autoDownload}
+                        onChange={() => handleToggleAutoDownload(catalog.id)}
+                      />
+                      <span className='label-text text-xs'>
+                        <IoCloudDownloadOutline className='mr-1 inline h-3.5 w-3.5' />
+                        {_('Auto-download')}
+                      </span>
+                    </label>
                   </div>
                   <div className='card-actions mt-4 justify-end'>
                     <button
@@ -534,6 +564,26 @@ export function CatalogManager() {
                     rows={2}
                     disabled={isValidating}
                   />
+                </div>
+
+                <div className='form-control'>
+                  <label className='label cursor-pointer justify-start gap-3 p-0'>
+                    <input
+                      type='checkbox'
+                      className='toggle toggle-sm toggle-primary'
+                      checked={newCatalog.autoDownload}
+                      onChange={(e) =>
+                        setNewCatalog({ ...newCatalog, autoDownload: e.target.checked })
+                      }
+                      disabled={isValidating}
+                    />
+                    <div>
+                      <span className='label-text'>{_('Auto-download new items')}</span>
+                      <p className='text-base-content/60 text-xs'>
+                        {_('Automatically download new publications when the app syncs')}
+                      </p>
+                    </div>
+                  </label>
                 </div>
 
                 <div className='modal-action'>

--- a/apps/readest-app/src/services/opdsSyncService.ts
+++ b/apps/readest-app/src/services/opdsSyncService.ts
@@ -1,0 +1,296 @@
+import { getFeed, isOPDSCatalog } from 'foliate-js/opds.js';
+import type { Book } from '@/types/book';
+import type { AppService } from '@/types/system';
+import type { OPDSCatalog, OPDSFeed, OPDSPublication, OPDSLink } from '@/types/opds';
+import { REL } from '@/types/opds';
+import { downloadFile } from '@/libs/storage';
+import { getFileExtFromMimeType } from '@/libs/document';
+import { isWebAppPlatform } from '@/services/environment';
+import {
+  fetchWithAuth,
+  probeAuth,
+  needsProxy,
+  getProxiedURL,
+  probeFilename,
+} from '@/app/opds/utils/opdsReq';
+import { resolveURL, parseMediaType, getFileExtFromPath } from '@/app/opds/utils/opdsUtils';
+import { normalizeOPDSCustomHeaders } from '@/app/opds/utils/customHeaders';
+import { READEST_OPDS_USER_AGENT } from '@/services/constants';
+
+const MAX_CRAWL_DEPTH = 3;
+
+const MIME_XML = 'application/xml';
+
+/**
+ * Find the first acquisition link on a publication.
+ */
+export function getAcquisitionLink(pub: OPDSPublication): OPDSLink | undefined {
+  return pub.links.find((link) => {
+    const rels = Array.isArray(link.rel) ? link.rel : [link.rel ?? ''];
+    return rels.some((r) => r.startsWith(REL.ACQ));
+  });
+}
+
+/**
+ * Collect publications from a feed that haven't been downloaded yet.
+ */
+export function collectNewEntries(feed: OPDSFeed, downloadedIds: Set<string>): OPDSPublication[] {
+  const allPubs: OPDSPublication[] = [
+    ...(feed.publications ?? []),
+    ...(feed.groups?.flatMap((g) => g.publications ?? []) ?? []),
+  ];
+  return allPubs.filter((pub) => {
+    const entryId = pub.metadata.id;
+    if (!entryId) return false;
+    if (!getAcquisitionLink(pub)) return false;
+    return !downloadedIds.has(entryId);
+  });
+}
+
+/**
+ * Fetch and parse an OPDS feed URL, returning the parsed feed and its base URL.
+ */
+async function fetchFeed(
+  url: string,
+  username: string,
+  password: string,
+  customHeaders: Record<string, string>,
+): Promise<{ feed: OPDSFeed; baseURL: string } | null> {
+  const useProxy = isWebAppPlatform();
+  const res = await fetchWithAuth(url, username, password, useProxy, {}, customHeaders);
+  if (!res.ok) {
+    console.error(`OPDS sync: failed to fetch ${url}: ${res.status} ${res.statusText}`);
+    return null;
+  }
+
+  const responseURL = res.url;
+  const text = await res.text();
+
+  if (text.startsWith('<')) {
+    const doc = new DOMParser().parseFromString(text, MIME_XML as DOMParserSupportedType);
+    const { localName } = doc.documentElement;
+
+    if (localName === 'feed') {
+      return { feed: getFeed(doc) as OPDSFeed, baseURL: responseURL };
+    }
+    // HTML auto-discovery: try to find an OPDS link in the head
+    const htmlDoc = new DOMParser().parseFromString(text, 'text/html' as DOMParserSupportedType);
+    const link = htmlDoc.head
+      ? Array.from(htmlDoc.head.querySelectorAll('link')).find((el) =>
+          isOPDSCatalog(el.getAttribute('type') ?? ''),
+        )
+      : null;
+    if (link?.getAttribute('href')) {
+      const resolvedURL = resolveURL(link.getAttribute('href')!, responseURL);
+      return fetchFeed(resolvedURL, username, password, customHeaders);
+    }
+  } else {
+    // OPDS 2.0 JSON
+    try {
+      const feed = JSON.parse(text) as OPDSFeed;
+      return { feed, baseURL: responseURL };
+    } catch {
+      // not valid JSON
+    }
+  }
+
+  console.error(`OPDS sync: could not parse feed at ${url}`);
+  return null;
+}
+
+/**
+ * Recursively crawl navigation feeds to find all acquisition feeds.
+ * Returns all publications found across all acquisition feeds.
+ */
+async function crawlFeed(
+  url: string,
+  username: string,
+  password: string,
+  customHeaders: Record<string, string>,
+  downloadedIds: Set<string>,
+  depth: number,
+): Promise<{ publications: OPDSPublication[]; baseURL: string }[]> {
+  if (depth > MAX_CRAWL_DEPTH) return [];
+
+  const result = await fetchFeed(url, username, password, customHeaders);
+  if (!result) return [];
+
+  const { feed, baseURL } = result;
+  const results: { publications: OPDSPublication[]; baseURL: string }[] = [];
+
+  // Collect publications from this feed
+  const newPubs = collectNewEntries(feed, downloadedIds);
+  if (newPubs.length > 0) {
+    results.push({ publications: newPubs, baseURL });
+  }
+
+  // If this is a navigation feed, crawl child links
+  if (feed.navigation?.length) {
+    for (const navItem of feed.navigation) {
+      if (navItem.href) {
+        const childURL = resolveURL(navItem.href, baseURL);
+        const childResults = await crawlFeed(
+          childURL,
+          username,
+          password,
+          customHeaders,
+          downloadedIds,
+          depth + 1,
+        );
+        results.push(...childResults);
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Download a single publication and import it into the library.
+ */
+async function downloadAndImport(
+  pub: OPDSPublication,
+  baseURL: string,
+  catalog: OPDSCatalog,
+  appService: AppService,
+  books: Book[],
+): Promise<Book | null> {
+  const acqLink = getAcquisitionLink(pub);
+  if (!acqLink) return null;
+
+  const url = resolveURL(acqLink.href, baseURL);
+  const username = catalog.username ?? '';
+  const password = catalog.password ?? '';
+  const customHeaders = normalizeOPDSCustomHeaders(catalog.customHeaders);
+  const useProxy = needsProxy(url);
+
+  let downloadUrl = useProxy ? getProxiedURL(url, '', true, customHeaders) : url;
+  const headers: Record<string, string> = {
+    'User-Agent': READEST_OPDS_USER_AGENT,
+    Accept: '*/*',
+    ...(!useProxy ? customHeaders : {}),
+  };
+
+  if (username || password) {
+    const authHeader = await probeAuth(url, username, password, useProxy, customHeaders);
+    if (authHeader) {
+      if (!useProxy) {
+        headers['Authorization'] = authHeader;
+      }
+      downloadUrl = useProxy ? getProxiedURL(url, authHeader, true, customHeaders) : url;
+    }
+  }
+
+  const parsed = parseMediaType(acqLink.type);
+  const pathname = decodeURIComponent(new URL(url).pathname);
+  const ext = getFileExtFromMimeType(parsed?.mediaType) || getFileExtFromPath(pathname);
+  const basename = pathname.replaceAll('/', '_');
+  const filename = ext ? `${basename}.${ext}` : basename;
+  let dstFilePath = await appService.resolveFilePath(filename, 'Cache');
+
+  const responseHeaders = await downloadFile({
+    appService,
+    dst: dstFilePath,
+    cfp: '',
+    url: downloadUrl,
+    headers,
+    singleThreaded: true,
+    skipSslVerification: true,
+  });
+
+  const probedFilename = await probeFilename(responseHeaders);
+  if (probedFilename) {
+    const newFilePath = await appService.resolveFilePath(probedFilename, 'Cache');
+    await appService.copyFile(dstFilePath, newFilePath, 'None');
+    await appService.deleteFile(dstFilePath, 'None');
+    dstFilePath = newFilePath;
+  }
+
+  try {
+    const book = await appService.importBook(dstFilePath, books);
+    return book;
+  } catch (importError) {
+    console.error(`OPDS sync: failed to import ${pub.metadata.title}:`, importError);
+    return null;
+  }
+}
+
+/**
+ * Sync a single OPDS catalog: crawl its feeds, find new entries, download and import them.
+ * Returns the list of newly imported books and the updated catalog with new downloadedEntryIds.
+ */
+export async function syncOPDSCatalog(
+  catalog: OPDSCatalog,
+  appService: AppService,
+  books: Book[],
+): Promise<{ newBooks: Book[]; updatedCatalog: OPDSCatalog }> {
+  const downloadedIds = new Set(catalog.downloadedEntryIds ?? []);
+  const customHeaders = normalizeOPDSCustomHeaders(catalog.customHeaders);
+  const username = catalog.username ?? '';
+  const password = catalog.password ?? '';
+
+  const feedResults = await crawlFeed(
+    catalog.url,
+    username,
+    password,
+    customHeaders,
+    downloadedIds,
+    0,
+  );
+
+  const newBooks: Book[] = [];
+  const newIds: string[] = [];
+
+  for (const { publications, baseURL } of feedResults) {
+    for (const pub of publications) {
+      const book = await downloadAndImport(pub, baseURL, catalog, appService, books);
+      if (book) {
+        newBooks.push(book);
+      }
+      // Mark as downloaded even if import failed, to avoid retrying bad entries
+      if (pub.metadata.id) {
+        newIds.push(pub.metadata.id);
+      }
+    }
+  }
+
+  const updatedCatalog: OPDSCatalog = {
+    ...catalog,
+    lastCheckedAt: Date.now(),
+    downloadedEntryIds: [...(catalog.downloadedEntryIds ?? []), ...newIds],
+  };
+
+  return { newBooks, updatedCatalog };
+}
+
+/**
+ * Sync all OPDS catalogs that have autoDownload enabled.
+ * Returns the total number of new books imported.
+ */
+export async function syncAllOPDSCatalogs(
+  catalogs: OPDSCatalog[],
+  appService: AppService,
+  books: Book[],
+): Promise<{ newBooks: Book[]; totalNewBooks: number; updatedCatalogs: OPDSCatalog[] }> {
+  const updatedCatalogs = [...catalogs];
+  let totalNewBooks = 0;
+  const allNewBooks: Book[] = [];
+
+  for (let i = 0; i < updatedCatalogs.length; i++) {
+    const catalog = updatedCatalogs[i]!;
+    if (!catalog.autoDownload || catalog.disabled) continue;
+
+    try {
+      const { newBooks, updatedCatalog } = await syncOPDSCatalog(catalog, appService, books);
+      updatedCatalogs[i] = updatedCatalog;
+      totalNewBooks += newBooks.length;
+      allNewBooks.push(...newBooks);
+    } catch (error) {
+      console.error(`OPDS sync: error syncing catalog "${catalog.name}":`, error);
+      // Update lastCheckedAt even on failure so we don't hammer a broken feed
+      updatedCatalogs[i] = { ...catalog, lastCheckedAt: Date.now() };
+    }
+  }
+
+  return { newBooks: allNewBooks, totalNewBooks, updatedCatalogs };
+}

--- a/apps/readest-app/src/types/opds.ts
+++ b/apps/readest-app/src/types/opds.ts
@@ -24,10 +24,15 @@ export interface OPDSCatalog {
   username?: string;
   password?: string;
   customHeaders?: Record<string, string>;
+  autoDownload?: boolean;
+  lastCheckedAt?: number;
+  downloadedEntryIds?: string[];
 }
 
 export interface OPDSFeed {
   metadata: {
+    id?: string;
+    updated?: string;
     title?: string;
     subtitle?: string;
   };
@@ -40,6 +45,8 @@ export interface OPDSFeed {
 
 export interface OPDSPublication {
   metadata: {
+    id?: string;
+    updated?: string;
     title: string;
     subtitle?: string;
     author?: OPDSPerson[];


### PR DESCRIPTION
Add opt-in auto-download per OPDS catalog. When enabled, new publications are downloaded on app startup and pull-to-refresh. Dedup via Atom <id>.

- Extend foliate-js parser to surface entry id/updated fields
- Add subscription state to OPDSCatalog type
- New headless opdsSyncService with navigation feed crawling
- Auto-download toggle in CatalogManager UI
- Wire sync into startup and pull-to-refresh hooks
- 16 new test cases

Built with an AI code agent.

Closes #3836