### PR TITLE
feat(kosync): defer push after resume

### DIFF
--- a/apps/readest-app/src/app/reader/hooks/useKOSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useKOSync.ts
@@ -11,6 +11,8 @@ import { debounce } from '@/utils/debounce';
 import { eventDispatcher } from '@/utils/event';
 import { getCFIFromXPointer, XCFI } from '@/utils/xcfi';
 
+import { useWindowActiveChanged } from './useWindowActiveChanged';
+
 type SyncState = 'idle' | 'checking' | 'conflict' | 'synced' | 'error';
 
 export interface SyncDetails {
@@ -252,53 +254,75 @@ export const useKOSync = (bookKey: string) => {
     [bookKey, appService, kosyncClient, settings.kosync, progress],
   );
 
+  // use a ref to track the current push/pull functions so they can change without triggering effects
+  const syncRefs = useRef({ pushProgress, pullProgress });
+  useEffect(() => {
+    syncRefs.current = { pushProgress, pullProgress };
+  }, [pushProgress, pullProgress]);
+
   useEffect(() => {
     const handlePushProgress = (event: CustomEvent) => {
+      const { pushProgress } = syncRefs.current;
       if (event.detail.bookKey !== bookKey) return;
       pushProgress();
       pushProgress.flush();
     };
     const handleFlush = (event: CustomEvent) => {
+      const { pushProgress } = syncRefs.current;
       if (event.detail.bookKey !== bookKey) return;
       pushProgress.flush();
     };
     eventDispatcher.on('push-kosync', handlePushProgress);
     eventDispatcher.on('flush-kosync', handleFlush);
     return () => {
+      const { pushProgress } = syncRefs.current;
       eventDispatcher.off('push-kosync', handlePushProgress);
       eventDispatcher.off('flush-kosync', handleFlush);
       pushProgress.flush();
     };
-  }, [bookKey, pushProgress]);
+  }, [bookKey]);
 
   useEffect(() => {
     const handlePullProgress = (event: CustomEvent) => {
       if (event.detail.bookKey !== bookKey) return;
+      const { pullProgress } = syncRefs.current;
       pullProgress();
     };
     eventDispatcher.on('pull-kosync', handlePullProgress);
     return () => {
       eventDispatcher.off('pull-kosync', handlePullProgress);
     };
-  }, [bookKey, pullProgress]);
+  }, [bookKey]);
 
   // Pull: pull progress once when the book is opened
   useEffect(() => {
     if (!appService || !kosyncClient || !progress?.location) return;
     if (hasPulledOnce.current) return;
 
-    pullProgress();
-  }, [appService, kosyncClient, progress?.location, pushProgress, pullProgress]);
+    syncRefs.current.pullProgress();
+  }, [appService, kosyncClient, progress?.location]);
 
   // Push: auto-push progress when progress changes with a debounce
   useEffect(() => {
     if (syncState === 'synced' && progress) {
       const { strategy, enabled } = settings.kosync;
       if (strategy !== 'receive' && enabled) {
-        pushProgress();
+        syncRefs.current.pushProgress();
       }
     }
-  }, [progress, syncState, settings.kosync, pushProgress]);
+  }, [progress, syncState, settings.kosync]);
+
+  useWindowActiveChanged((isActive) => {
+    const { pushProgress, pullProgress } = syncRefs.current;
+
+    if (isActive) {
+      hasPulledOnce.current = false;
+      pullProgress();
+    } else {
+      pushProgress();
+      pushProgress.flush?.();
+    }
+  });
 
   const resolveWithLocal = () => {
     pushProgress();

--- a/apps/readest-app/src/app/reader/hooks/useKOSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useKOSync.ts
@@ -320,7 +320,7 @@ export const useKOSync = (bookKey: string) => {
       pullProgress();
     } else {
       pushProgress();
-      pushProgress.flush?.();
+      pushProgress.flush();
     }
   });
 

--- a/apps/readest-app/src/app/reader/hooks/useWindowActiveChanged.ts
+++ b/apps/readest-app/src/app/reader/hooks/useWindowActiveChanged.ts
@@ -1,0 +1,62 @@
+// used to execute a callback when the "active" state of the current window changes.
+// On web abd mobile, "active" means "is visible". On desktop, the 'visibilitychange'
+// event is unrelaible, so "active" means "has focus".
+
+import { useEffect, useRef } from 'react';
+import environment from '@/services/environment';
+
+export type ActiveCallback = (isActive: boolean) => void;
+
+type Cleanup = () => void;
+async function activeChangedDesktop(onChange: ActiveCallback): Promise<Cleanup> {
+  const { getCurrentWindow } = await import('@tauri-apps/api/window');
+  const appWindow = getCurrentWindow();
+
+  const unFocus = await appWindow.listen('tauri://focus', () => onChange(true));
+  const unBlur = await appWindow.listen('tauri://blur', () => onChange(false));
+  return () => {
+    unFocus();
+    unBlur();
+  };
+}
+async function activeChangedOther(onChange: ActiveCallback): Promise<Cleanup> {
+  const handler = () => onChange(document.visibilityState === 'visible');
+
+  document.addEventListener('visibilitychange', handler);
+  return () => document.removeEventListener('visibilitychange', handler);
+}
+
+export function useWindowActiveChanged(callback: ActiveCallback) {
+  const onActiveChanged = useRef<ActiveCallback>(callback);
+  useEffect(() => {
+    onActiveChanged.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    let isAlive = true;
+    let unsub: Cleanup | undefined;
+    const onChange = (isActive: boolean) => {
+      onActiveChanged.current?.(isActive);
+    };
+
+    environment
+      .getAppService()
+      .then(({ isDesktopApp }) => {
+        return isDesktopApp ? activeChangedDesktop : activeChangedOther;
+      })
+      .then((sub) => sub(onChange))
+      .then((cleanup) => {
+        if (isAlive) {
+          unsub = cleanup;
+        } else {
+          // component was already unmounted, just clean up immediately
+          cleanup();
+        }
+      });
+
+    return () => {
+      isAlive = false;
+      unsub?.();
+    };
+  }, []);
+}

--- a/apps/readest-app/src/app/reader/hooks/useWindowActiveChanged.ts
+++ b/apps/readest-app/src/app/reader/hooks/useWindowActiveChanged.ts
@@ -1,9 +1,10 @@
 // used to execute a callback when the "active" state of the current window changes.
-// On web abd mobile, "active" means "is visible". On desktop, the 'visibilitychange'
-// event is unrelaible, so "active" means "has focus".
+// On web and mobile, "active" means "is visible". On desktop, the 'visibilitychange'
+// event is unreliable, so "active" means "has focus".
 
 import { useEffect, useRef } from 'react';
-import environment from '@/services/environment';
+
+import { useEnv } from '@/context/EnvContext';
 
 export type ActiveCallback = (isActive: boolean) => void;
 
@@ -12,11 +13,10 @@ async function activeChangedDesktop(onChange: ActiveCallback): Promise<Cleanup> 
   const { getCurrentWindow } = await import('@tauri-apps/api/window');
   const appWindow = getCurrentWindow();
 
-  const unFocus = await appWindow.listen('tauri://focus', () => onChange(true));
-  const unBlur = await appWindow.listen('tauri://blur', () => onChange(false));
+  const unlisten = await appWindow.onFocusChanged(({ payload: isActive }) => onChange(isActive));
+
   return () => {
-    unFocus();
-    unBlur();
+    unlisten();
   };
 }
 async function activeChangedOther(onChange: ActiveCallback): Promise<Cleanup> {
@@ -28,6 +28,10 @@ async function activeChangedOther(onChange: ActiveCallback): Promise<Cleanup> {
 
 export function useWindowActiveChanged(callback: ActiveCallback) {
   const onActiveChanged = useRef<ActiveCallback>(callback);
+  const { appService } = useEnv();
+
+  const subscribe = appService?.isDesktopApp ? activeChangedDesktop : activeChangedOther;
+
   useEffect(() => {
     onActiveChanged.current = callback;
   }, [callback]);
@@ -39,12 +43,7 @@ export function useWindowActiveChanged(callback: ActiveCallback) {
       onActiveChanged.current?.(isActive);
     };
 
-    environment
-      .getAppService()
-      .then(({ isDesktopApp }) => {
-        return isDesktopApp ? activeChangedDesktop : activeChangedOther;
-      })
-      .then((sub) => sub(onChange))
+    subscribe(onChange)
       .then((cleanup) => {
         if (isAlive) {
           unsub = cleanup;
@@ -52,11 +51,14 @@ export function useWindowActiveChanged(callback: ActiveCallback) {
           // component was already unmounted, just clean up immediately
           cleanup();
         }
+      })
+      .catch((e) => {
+        console.error('Could not listen for window active changes', e);
       });
 
     return () => {
       isAlive = false;
       unsub?.();
     };
-  }, []);
+  }, [subscribe]);
 }


### PR DESCRIPTION
After "resuming" the app, defer `pushProgress` until after the first `pullProgress`. This mirrors what happens on first opening a book.

Fixes #3888 .

Implementation details:
Introduces a new hook, `useWindowActiveChanged`, to abstract out the decision about what makes a window "active" or not. On most platforms, the standard DOM `visibilitychange` event is used, but this event is unreliable on desktop platforms. (On macOS it only fires when the window is actually maximized or minimized, and on Windows it just never fires at all). On those platforms we use the Tauri focus/blur events instead.

Uses a ref to maintain the latest `pushProgress` and `pullProgress` functions. This allows the `useEffect` calls to drop their dependencies on those functions, which means less subscribe/unsubscribe churn.