### PR TITLE
fix(kosync): CWA sometimes sends 400 for auth failure

### DIFF
--- a/apps/readest-app/src/services/sync/KOSyncClient.ts
+++ b/apps/readest-app/src/services/sync/KOSyncClient.ts
@@ -95,7 +95,8 @@ export class KOSyncClient {
     };
 
     let response = await attempt();
-    if (response.status === 401) {
+    // some versions of CWA return status code 400 for auth failure, so check for both.
+    if (response.status === 401 || response.status === 400) {
       // traditional auth failed; attempt one more time with HTTP auth
       this.usesHttpAuth = true;
 


### PR DESCRIPTION
Current versions of CWA respond with status 400 for auth failures (except on the initial /users/auth request). This change treats 400 as a (potential) auth failure in addition to 401 to mitigate.