### PR TITLE
fix(reader): pinned notebook stays open on note click; responsive trackpad swipes

### DIFF
--- a/apps/readest-app/src/__tests__/utils/debounce.test.ts
+++ b/apps/readest-app/src/__tests__/utils/debounce.test.ts
@@ -144,6 +144,63 @@ describe('debounce', () => {
   });
 
   // -----------------------------------------------------------------------
+  // leading: true
+  // -----------------------------------------------------------------------
+  describe('leading: true', () => {
+    it('fires immediately on the first call', () => {
+      const fn = vi.fn();
+      const debounced = debounce(fn, 100, { leading: true });
+      debounced('first');
+      expect(fn).toHaveBeenCalledOnce();
+      expect(fn).toHaveBeenCalledWith('first');
+    });
+
+    it('ignores subsequent calls during the silence window', () => {
+      const fn = vi.fn();
+      const debounced = debounce(fn, 100, { leading: true });
+      debounced('first');
+      for (let i = 0; i < 10; i++) {
+        vi.advanceTimersByTime(50);
+        debounced(`burst-${i}`);
+      }
+      // Despite continuous calls every 50ms resetting the timer,
+      // only the first one fires.
+      expect(fn).toHaveBeenCalledOnce();
+      expect(fn).toHaveBeenCalledWith('first');
+    });
+
+    it('allows the next call to fire after the silence window elapses', () => {
+      const fn = vi.fn();
+      const debounced = debounce(fn, 100, { leading: true });
+      debounced('first');
+      vi.advanceTimersByTime(150); // window elapses with no new calls
+      debounced('second');
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(fn).toHaveBeenLastCalledWith('second');
+    });
+
+    it('extends the silence window on each call', () => {
+      const fn = vi.fn();
+      const debounced = debounce(fn, 100, { leading: true });
+      debounced('first');
+      expect(fn).toHaveBeenCalledOnce();
+      // Keep calling at 50ms intervals — each resets the cooldown timer,
+      // so even after >100ms total, the cooldown is still active.
+      vi.advanceTimersByTime(50);
+      debounced();
+      vi.advanceTimersByTime(50);
+      debounced();
+      vi.advanceTimersByTime(50);
+      debounced();
+      expect(fn).toHaveBeenCalledOnce();
+      vi.advanceTimersByTime(100); // finally silence elapses
+      debounced('next');
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(fn).toHaveBeenLastCalledWith('next');
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Edge cases
   // -----------------------------------------------------------------------
   describe('edge cases', () => {

--- a/apps/readest-app/src/app/reader/components/notebook/Header.tsx
+++ b/apps/readest-app/src/app/reader/components/notebook/Header.tsx
@@ -36,7 +36,7 @@ const NotebookHeader: React.FC<{
           title={isPinned ? _('Unpin Notebook') : _('Pin Notebook')}
           onClick={handleTogglePin}
           className={clsx(
-            'btn btn-ghost btn-circle hidden h-6 min-h-6 w-6 sm:flex',
+            'notebook-pin-btn btn btn-ghost btn-circle hidden h-6 min-h-6 w-6 sm:flex',
             isPinned ? 'bg-base-300' : 'bg-base-300/65',
           )}
         >

--- a/apps/readest-app/src/app/reader/components/notebook/Notebook.tsx
+++ b/apps/readest-app/src/app/reader/components/notebook/Notebook.tsx
@@ -68,9 +68,10 @@ const Notebook: React.FC = ({}) => {
   );
 
   const onNavigateEvent = async () => {
-    const pinButton = document.querySelector('.sidebar-pin-btn');
+    const pinButton = document.querySelector('.notebook-pin-btn');
     const isPinButtonHidden = !pinButton || window.getComputedStyle(pinButton).display === 'none';
-    if (isPinButtonHidden) {
+    const pinned = useNotebookStore.getState().isNotebookPinned;
+    if (isPinButtonHidden || !pinned) {
       setNotebookVisible(false);
     }
   };

--- a/apps/readest-app/src/app/reader/hooks/useIframeEvents.ts
+++ b/apps/readest-app/src/app/reader/hooks/useIframeEvents.ts
@@ -20,12 +20,16 @@ export const useMouseEvent = (
   useEffect(() => {
     handlePageFlipRef.current = handlePageFlip;
   }, [handlePageFlip]);
+  // Use a leading-edge debounce so trackpad two-finger swipes feel responsive:
+  // the first wheel event in a gesture flips the page immediately and further
+  // events (including inertia tails) are swallowed until 500ms of silence.
   const debounceFlip = useMemo(
     () =>
       debounce(
         (msg: MessageEvent | React.MouseEvent<HTMLDivElement, MouseEvent>) =>
           handlePageFlipRef.current(msg),
-        100,
+        500,
+        { leading: true },
       ),
     [],
   );

--- a/apps/readest-app/src/utils/debounce.ts
+++ b/apps/readest-app/src/utils/debounce.ts
@@ -1,10 +1,15 @@
 interface DebounceOptions {
   emitLast?: boolean;
+  leading?: boolean;
 }
 
 /**
  * Debounces a function by waiting `delay` ms after the last call before executing it.
  * If `emitLast` is false, it cancels the call instead of delaying it.
+ * If `leading` is true, fires immediately on the first call and ignores subsequent
+ * calls until `delay` ms of silence has elapsed — useful for burst-style inputs
+ * (e.g. trackpad wheel events with inertia) where the user expects an immediate
+ * response per gesture rather than a delay until the burst ends.
  *
  * @returns A debounced function with additional `flush` and `cancel` methods.
  */
@@ -17,6 +22,20 @@ export const debounce = <T extends (...args: Parameters<T>) => void | Promise<vo
   let lastArgs: Parameters<T> | null = null;
 
   const debounced = (...args: Parameters<T>): void => {
+    if (options.leading) {
+      const shouldFire = !timeout;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      timeout = setTimeout(() => {
+        timeout = null;
+      }, delay);
+      if (shouldFire) {
+        func(...args);
+      }
+      return;
+    }
+
     lastArgs = args;
     if (timeout) {
       clearTimeout(timeout);


### PR DESCRIPTION
## Summary

Fixes two issues reported in #3923:

- **Pinned notebook closes on note selection.** The notebook's navigate-event handler was querying `.sidebar-pin-btn` — the _sidebar's_ pin button, which isn't in the DOM unless the sidebar itself is open. So clicking a note while the sidebar was closed always treated the pin button as hidden and closed the panel, even though the notebook was pinned. Fix: query the notebook's own pin button (new `notebook-pin-btn` class) and also read `isNotebookPinned` directly from the Zustand store to avoid the stale-closure issue from the once-registered listener.
- **Slow trackpad two-finger swipe response.** The wheel handler used a 100ms trailing debounce (`emitLast: true`), so a single swipe waited for the entire event stream (including the inertia tail) to stop before flipping the page — noticeable on Windows trackpads where inertia runs for hundreds of ms. Fix: add a `leading: true` option to the `debounce` utility that fires immediately on the first call and swallows the rest until the silence window elapses, and use it for wheel-driven pagination with a 500ms window (long enough to cover one gesture + inertia).

Closes #3923.

## Test plan

- [x] `pnpm test` — 3190 tests pass (4 new `leading: true` cases for `debounce`)
- [x] `pnpm lint` — clean
- [ ] Manual: desktop, pin the notebook, click an annotation → notebook stays open and view scrolls to the cfi.
- [ ] Manual: desktop, unpin the notebook, click an annotation → notebook closes (unchanged).
- [ ] Manual: mobile, click an annotation → notebook closes (unchanged).
- [ ] Manual: trackpad, two-finger swipe left/right and up/down → page flips immediately, once per gesture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)