### PR TITLE
Add VCS browser URL to appdata.xml

### DIFF
--- a/data/metainfo/appdata.xml
+++ b/data/metainfo/appdata.xml
@@ -55,6 +55,7 @@
   <url type="bugtracker">https://github.com/readest/readest/issues</url>
   <url type="help">https://github.com/readest/readest/wiki</url>
   <url type="donation">https://github.com/sponsors/readest</url>
+  <url type="vcs-browser">https://github.com/readest/readest</url>
 
   <launchable type="desktop-id">com.bilingify.readest.desktop</launchable>
 


### PR DESCRIPTION
This is now recommended in flatpak. See warning in https://github.com/flathub/com.bilingify.readest/pull/20#issuecomment-4322583486