### PR TITLE
fix(rsvp): unicode-aware ORP calculation for non-Latin scripts

### DIFF
--- a/apps/readest-app/src/__tests__/services/rsvp-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/rsvp-controller.test.ts
@@ -117,6 +117,49 @@ describe('RSVPController', () => {
     });
   });
 
+  describe('ORP calculation', () => {
+    test('places ORP near the start of short Latin words', () => {
+      const doc = makeDoc('Hello world');
+      const view = createMockView(0, [doc]);
+      const controller = new RSVPController(view, 'test-book-abc123');
+      controller.start();
+
+      const words = controller.currentState.words;
+      // 5-letter words: ORP at index 1
+      expect(words[0]!.orpIndex).toBe(1);
+      expect(words[1]!.orpIndex).toBe(1);
+    });
+
+    test('places ORP based on letter count for Cyrillic words', () => {
+      // "Привет" = 6 letters, "мир" = 3 letters
+      const doc = makeDoc('Привет мир');
+      const view = createMockView(0, [doc]);
+      const controller = new RSVPController(view, 'test-book-abc123');
+      controller.start();
+
+      const words = controller.currentState.words;
+      expect(words[0]!.text).toBe('Привет');
+      // 6-letter word should have ORP at index 2 (same as Latin "Hellos")
+      expect(words[0]!.orpIndex).toBe(2);
+      expect(words[1]!.text).toBe('мир');
+      // 3-letter word: ORP at index 0
+      expect(words[1]!.orpIndex).toBe(0);
+    });
+
+    test('places ORP based on letter count for accented Latin words', () => {
+      // "naïve" = 5 letters with combining/precomposed diacritic
+      const doc = makeDoc('naïve');
+      const view = createMockView(0, [doc]);
+      const controller = new RSVPController(view, 'test-book-abc123');
+      controller.start();
+
+      const words = controller.currentState.words;
+      expect(words[0]!.text).toBe('naïve');
+      // Should be treated as a 5-letter word, ORP at index 1
+      expect(words[0]!.orpIndex).toBe(1);
+    });
+  });
+
   describe('duplicate word blank insertion', () => {
     test('inserts blank between two consecutive identical words', () => {
       const doc = makeDoc('the the cat');

--- a/apps/readest-app/src/services/rsvp/RSVPController.ts
+++ b/apps/readest-app/src/services/rsvp/RSVPController.ts
@@ -738,7 +738,7 @@ export class RSVPController extends EventTarget {
       return Math.floor(word.length / 2);
     }
 
-    const cleanWord = word.replace(/[^\w]/g, '');
+    const cleanWord = word.replace(/[^\p{L}\p{N}_]/gu, '');
     const len = cleanWord.length;
 
     if (len <= 1) return 0;


### PR DESCRIPTION
## Summary
- Fixes #3958: in speed reading mode, the focus letter is always the first letter for Cyrillic / other non-Latin scripts.
- Root cause: `calculateORP()` in `RSVPController.ts` cleans the word with `word.replace(/[^\w]/g, '')` to count letters, but JavaScript's `\w` is ASCII-only by default. For Cyrillic words like "Привет" the regex strips every character, so `len` becomes 0 and the `len <= 1` branch returns index 0 — always highlighting the first letter.
- Fix: switch the cleaning regex to `/[^\p{L}\p{N}_]/gu` so letters and numbers from every Unicode script (Cyrillic, Greek, Arabic, accented Latin, etc.) count toward the word length.

## Test plan
- [x] `pnpm test src/__tests__/services/rsvp-controller.test.ts` — added three new ORP cases (short Latin, Cyrillic "Привет"/"мир", accented "naïve"); the Cyrillic case fails on `main` and passes after the fix
- [x] `pnpm test` — full suite (3262 passed)
- [x] `pnpm lint` — clean