### PR TITLE
fix(rsvp): cross-device resume seeding + mobile slider drag

### DIFF
--- a/apps/readest-app/src/__tests__/components/rsvp-overlay-context.test.tsx
+++ b/apps/readest-app/src/__tests__/components/rsvp-overlay-context.test.tsx
@@ -138,3 +138,59 @@ describe('RSVPOverlay — context panel performance', () => {
     expect(current!.getAttribute('role')).toBeNull();
   });
 });
+
+describe('RSVPOverlay — progress bar drag on mobile', () => {
+  afterEach(() => cleanup());
+
+  test('horizontal drag starting on the progress bar does not trigger a speed swipe', () => {
+    const words = Array.from({ length: 100 }, (_, i) => ({
+      text: `w${i}`,
+      orpIndex: 0,
+      pauseMultiplier: 1,
+    }));
+    const state = buildState({ words, currentIndex: 10 });
+
+    const { container, controller } = renderOverlay(state);
+    const slider = container.querySelector('[role="slider"]') as HTMLElement;
+    expect(slider).not.toBeNull();
+
+    // Simulate a horizontal touch drag long enough to clear SWIPE_THRESHOLD (50px).
+    fireEvent.touchStart(slider, { touches: [{ clientX: 50, clientY: 400 }] });
+    fireEvent.touchEnd(slider, {
+      changedTouches: [{ clientX: 200, clientY: 400 }],
+    });
+
+    expect(controller.increaseSpeed).not.toHaveBeenCalled();
+    expect(controller.decreaseSpeed).not.toHaveBeenCalled();
+  });
+
+  test('horizontal drag starting on a footer button does not trigger a speed swipe', () => {
+    const state = buildState({
+      words: [{ text: 'a', orpIndex: 0, pauseMultiplier: 1 }],
+      currentIndex: 0,
+    });
+    const { container, controller } = renderOverlay(state);
+    // Pick any control inside `.rsvp-controls` (e.g. the play/pause button).
+    const playButton = container.querySelector('[aria-label="Play"]') as HTMLElement;
+    expect(playButton).not.toBeNull();
+
+    fireEvent.touchStart(playButton, { touches: [{ clientX: 50, clientY: 400 }] });
+    fireEvent.touchEnd(playButton, {
+      changedTouches: [{ clientX: 200, clientY: 400 }],
+    });
+
+    expect(controller.increaseSpeed).not.toHaveBeenCalled();
+    expect(controller.decreaseSpeed).not.toHaveBeenCalled();
+  });
+
+  test('progress bar uses touch-action: none so pointer capture survives on mobile', () => {
+    const state = buildState({
+      words: [{ text: 'a', orpIndex: 0, pauseMultiplier: 1 }],
+      currentIndex: 0,
+    });
+    const { container } = renderOverlay(state);
+    const slider = container.querySelector('[role="slider"]') as HTMLElement;
+    expect(slider).not.toBeNull();
+    expect(slider.style.touchAction).toBe('none');
+  });
+});

--- a/apps/readest-app/src/__tests__/services/rsvp-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/rsvp-controller.test.ts
@@ -211,17 +211,13 @@ describe('RSVPController', () => {
     });
 
     test('falls back to start of synced chapter when rsvpPosition is in a different chapter than location', () => {
-      // buildRsvpExitConfigUpdate pins location = rsvpPosition.cfi at RSVP exit,
-      // so a cross-chapter mismatch between the synced pair means stale/inconsistent
-      // state. The location CFI is the trustworthy signal — fall back to its
-      // section start so Resume lands at word 0 of the chapter the user is in.
       const doc = makeDoc('hello world');
       const view = createMockView(0, [doc]);
       const controller = new RSVPController(view, 'test-book-abc123');
 
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const stalePosition = { cfi: 'epubcfi(/6/4!/4/2/1:0)', wordText: 'stale' };
-      const currentLocation = 'epubcfi(/6/8!/4/2/1:0)'; // different spine section
+      const currentLocation = 'epubcfi(/6/8!/4/2/1:0)';
 
       controller.seedPosition(stalePosition, currentLocation);
 
@@ -245,7 +241,6 @@ describe('RSVPController', () => {
       const controller = new RSVPController(view, 'test-book-abc123');
 
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      // rsvpPosition (chapter 4), location (chapter 8), local stale (chapter 2) — all different.
       controller.seedPosition(
         { cfi: 'epubcfi(/6/4!/4/2/1:0)', wordText: 'fresh' },
         'epubcfi(/6/8!/4/2/1:0)',

--- a/apps/readest-app/src/__tests__/services/rsvp-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/rsvp-controller.test.ts
@@ -1,6 +1,8 @@
-import { describe, test, expect, vi } from 'vitest';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { RSVPController } from '@/services/rsvp/RSVPController';
 import { FoliateView } from '@/types/view';
+
+const POSITION_KEY = 'readest_rsvp_pos_test';
 
 function makeTextNode(text: string): Text {
   return { nodeType: Node.TEXT_NODE, textContent: text } as unknown as Text;
@@ -157,6 +159,148 @@ describe('RSVPController', () => {
       expect(words[0]!.text).toBe('naïve');
       // Should be treated as a 5-letter word, ORP at index 1
       expect(words[0]!.orpIndex).toBe(1);
+    });
+  });
+
+  describe('seedPosition', () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    test('overwrites stale local position with cloud-synced position', () => {
+      // Device B has a stale local entry from a previous session.
+      const stale = { cfi: 'epubcfi(/6/4!/4/2/1:0)', wordText: 'stale' };
+      localStorage.setItem(POSITION_KEY, JSON.stringify(stale));
+
+      const doc = makeDoc('hello world');
+      const view = createMockView(0, [doc]);
+      const controller = new RSVPController(view, 'test-book-abc123');
+
+      // Cloud-synced position arrives via BookConfig.rsvpPosition.
+      const fresh = { cfi: 'epubcfi(/6/8!/4/2/1:0)', wordText: 'fresh' };
+      controller.seedPosition(fresh);
+
+      expect(JSON.parse(localStorage.getItem(POSITION_KEY)!)).toEqual(fresh);
+    });
+
+    test('writes provided position when localStorage is empty', () => {
+      const doc = makeDoc('hello world');
+      const view = createMockView(0, [doc]);
+      const controller = new RSVPController(view, 'test-book-abc123');
+
+      const position = { cfi: 'epubcfi(/6/8!/4/2/1:0)', wordText: 'fresh' };
+      controller.seedPosition(position);
+
+      expect(JSON.parse(localStorage.getItem(POSITION_KEY)!)).toEqual(position);
+    });
+
+    test('skips redundant write when value already matches', () => {
+      const position = { cfi: 'epubcfi(/6/8!/4/2/1:0)', wordText: 'same' };
+      localStorage.setItem(POSITION_KEY, JSON.stringify(position));
+
+      const doc = makeDoc('hello world');
+      const view = createMockView(0, [doc]);
+      const controller = new RSVPController(view, 'test-book-abc123');
+
+      const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+      controller.seedPosition(position);
+
+      const positionWrites = setItemSpy.mock.calls.filter(([key]) => key === POSITION_KEY);
+      expect(positionWrites).toHaveLength(0);
+      setItemSpy.mockRestore();
+    });
+
+    test('falls back to start of synced chapter when rsvpPosition is in a different chapter than location', () => {
+      // buildRsvpExitConfigUpdate pins location = rsvpPosition.cfi at RSVP exit,
+      // so a cross-chapter mismatch between the synced pair means stale/inconsistent
+      // state. The location CFI is the trustworthy signal — fall back to its
+      // section start so Resume lands at word 0 of the chapter the user is in.
+      const doc = makeDoc('hello world');
+      const view = createMockView(0, [doc]);
+      const controller = new RSVPController(view, 'test-book-abc123');
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const stalePosition = { cfi: 'epubcfi(/6/4!/4/2/1:0)', wordText: 'stale' };
+      const currentLocation = 'epubcfi(/6/8!/4/2/1:0)'; // different spine section
+
+      controller.seedPosition(stalePosition, currentLocation);
+
+      expect(JSON.parse(localStorage.getItem(POSITION_KEY)!)).toEqual({
+        cfi: 'epubcfi(/6/8)',
+        wordText: '',
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[RSVP]'),
+        expect.objectContaining({ rsvpCfi: stalePosition.cfi, locationCfi: currentLocation }),
+      );
+      warnSpy.mockRestore();
+    });
+
+    test('section-start fallback overwrites a stale local entry on chapter mismatch', () => {
+      const stale = { cfi: 'epubcfi(/6/2!/4/2/1:0)', wordText: 'stale' };
+      localStorage.setItem(POSITION_KEY, JSON.stringify(stale));
+
+      const doc = makeDoc('hello world');
+      const view = createMockView(0, [doc]);
+      const controller = new RSVPController(view, 'test-book-abc123');
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      // rsvpPosition (chapter 4), location (chapter 8), local stale (chapter 2) — all different.
+      controller.seedPosition(
+        { cfi: 'epubcfi(/6/4!/4/2/1:0)', wordText: 'fresh' },
+        'epubcfi(/6/8!/4/2/1:0)',
+      );
+
+      expect(JSON.parse(localStorage.getItem(POSITION_KEY)!)).toEqual({
+        cfi: 'epubcfi(/6/8)',
+        wordText: '',
+      });
+      warnSpy.mockRestore();
+    });
+
+    test('skips redundant write when section-start fallback already matches stored value', () => {
+      const fallback = { cfi: 'epubcfi(/6/8)', wordText: '' };
+      localStorage.setItem(POSITION_KEY, JSON.stringify(fallback));
+
+      const doc = makeDoc('hello world');
+      const view = createMockView(0, [doc]);
+      const controller = new RSVPController(view, 'test-book-abc123');
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+      controller.seedPosition(
+        { cfi: 'epubcfi(/6/4!/4/2/1:0)', wordText: 'fresh' },
+        'epubcfi(/6/8!/4/2/1:0)',
+      );
+
+      const positionWrites = setItemSpy.mock.calls.filter(([key]) => key === POSITION_KEY);
+      expect(positionWrites).toHaveLength(0);
+      setItemSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    test('seeds normally when rsvpPosition and location share a spine section', () => {
+      const doc = makeDoc('hello world');
+      const view = createMockView(0, [doc]);
+      const controller = new RSVPController(view, 'test-book-abc123');
+
+      const position = { cfi: 'epubcfi(/6/8!/4/2/1:0)', wordText: 'fresh' };
+      const currentLocation = 'epubcfi(/6/8!/4/2/3:5)'; // same spine, different offset
+
+      controller.seedPosition(position, currentLocation);
+
+      expect(JSON.parse(localStorage.getItem(POSITION_KEY)!)).toEqual(position);
+    });
+
+    test('seeds normally when no current location is provided', () => {
+      const doc = makeDoc('hello world');
+      const view = createMockView(0, [doc]);
+      const controller = new RSVPController(view, 'test-book-abc123');
+
+      const position = { cfi: 'epubcfi(/6/4!/4/2/1:0)', wordText: 'fresh' };
+      controller.seedPosition(position);
+
+      expect(JSON.parse(localStorage.getItem(POSITION_KEY)!)).toEqual(position);
     });
   });
 

--- a/apps/readest-app/src/app/reader/components/rsvp/RSVPControl.tsx
+++ b/apps/readest-app/src/app/reader/components/rsvp/RSVPControl.tsx
@@ -230,11 +230,13 @@ const RSVPControl: React.FC<RSVPControlProps> = ({ bookKey, gridInsets }) => {
         });
       }
 
-      // Seed localStorage from cloud-synced BookConfig when this device has no local position.
-      // This restores RSVP progress saved on another device after a sync.
-      const configPos = getConfig(bookKey)?.rsvpPosition;
+      // Seed localStorage from cloud-synced BookConfig so a fresh cross-device
+      // rsvpPosition can override a stale local entry. seedPosition guards against
+      // a corrupt synced pair (rsvpPosition.cfi in a different chapter than location).
+      const config = getConfig(bookKey);
+      const configPos = config?.rsvpPosition;
       if (configPos) {
-        controller.seedPosition(configPos);
+        controller.seedPosition(configPos, config?.location ?? progress?.location ?? null);
       }
 
       // Set current CFI for position tracking

--- a/apps/readest-app/src/app/reader/components/rsvp/RSVPOverlay.tsx
+++ b/apps/readest-app/src/app/reader/components/rsvp/RSVPOverlay.tsx
@@ -350,6 +350,14 @@ const RSVPOverlay: React.FC<RSVPOverlayProps> = ({
   const handleTouchEnd = (event: React.TouchEvent) => {
     if (event.changedTouches.length !== 1) return;
 
+    // Touches starting on the header or footer controls (progress bar, buttons,
+    // dropdowns) own their own gestures — never let a horizontal drag here be
+    // hijacked as a speed-change swipe, or a tap as a region tap.
+    const target = event.target as HTMLElement;
+    if (target.closest('.rsvp-controls') || target.closest('.rsvp-header')) {
+      return;
+    }
+
     const touch = event.changedTouches[0]!;
     const deltaX = touch.clientX - touchStartX.current;
     const deltaY = touch.clientY - touchStartY.current;
@@ -365,11 +373,6 @@ const RSVPOverlay: React.FC<RSVPOverlayProps> = ({
     }
 
     if (Math.abs(deltaX) < TAP_THRESHOLD && Math.abs(deltaY) < TAP_THRESHOLD && duration < 300) {
-      const target = event.target as HTMLElement;
-      if (target.closest('.rsvp-controls') || target.closest('.rsvp-header')) {
-        return;
-      }
-
       const screenWidth = window.innerWidth;
       const tapX = touch.clientX;
 
@@ -455,7 +458,12 @@ const RSVPOverlay: React.FC<RSVPOverlayProps> = ({
     if (!isDraggingProgressBar.current) return;
     isDraggingProgressBar.current = false;
     setIsProgressBarDragging(false);
-    event.currentTarget.releasePointerCapture(event.pointerId);
+    // pointercancel can fire after the browser has already released the
+    // capture itself (e.g. multitouch, app backgrounding), so calling
+    // releasePointerCapture unconditionally would throw NotFoundError.
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
     if (wasPlayingBeforeDrag.current) setTimeout(() => controller.resume(), 50);
   };
 
@@ -748,6 +756,10 @@ const RSVPOverlay: React.FC<RSVPOverlayProps> = ({
             aria-valuemin={0}
             aria-valuemax={100}
             className='relative h-2 cursor-pointer overflow-visible rounded bg-gray-500/30'
+            // touch-action: none keeps mobile browsers from claiming the
+            // gesture for scroll/pan, which would fire pointercancel and
+            // break the drag-to-seek pointer capture mid-gesture.
+            style={{ touchAction: 'none' }}
             onPointerDown={handleProgressBarPointerDown}
             onPointerMove={handleProgressBarPointerMove}
             onPointerUp={handleProgressBarPointerUp}

--- a/apps/readest-app/src/services/rsvp/RSVPController.ts
+++ b/apps/readest-app/src/services/rsvp/RSVPController.ts
@@ -218,11 +218,44 @@ export class RSVPController extends EventTarget {
     localStorage.removeItem(`${POSITION_KEY_PREFIX}${this.bookId}`);
   }
 
-  seedPosition(position: RsvpPosition): void {
+  seedPosition(position: RsvpPosition, currentLocationCfi?: string | null): void {
     const storageKey = `${POSITION_KEY_PREFIX}${this.bookId}`;
-    if (!localStorage.getItem(storageKey)) {
-      localStorage.setItem(storageKey, JSON.stringify(position));
+
+    // buildRsvpExitConfigUpdate pins location = rsvpPosition.cfi at RSVP exit,
+    // so a synced pair pointing at different spine sections means stale/inconsistent
+    // state. Trust the location CFI (the user's actual reading position) and fall
+    // back to its section start — Resume then lands at word 0 of the synced chapter
+    // rather than at a wrong-chapter rsvpPosition or a leftover stale local entry.
+    if (
+      currentLocationCfi &&
+      position.cfi &&
+      !this.isSameSection(position.cfi, currentLocationCfi)
+    ) {
+      console.warn(
+        '[RSVP] Synced rsvpPosition is in a different chapter than location; resetting resume to start of synced chapter',
+        { rsvpCfi: position.cfi, locationCfi: currentLocationCfi },
+      );
+      const fallback: RsvpPosition = {
+        cfi: RSVPController.deriveSectionStartCfi(currentLocationCfi),
+        wordText: '',
+      };
+      const serializedFallback = JSON.stringify(fallback);
+      if (localStorage.getItem(storageKey) === serializedFallback) return;
+      localStorage.setItem(storageKey, serializedFallback);
+      return;
     }
+
+    const serialized = JSON.stringify(position);
+    if (localStorage.getItem(storageKey) === serialized) return;
+    localStorage.setItem(storageKey, serialized);
+  }
+
+  // Strip the in-document path from a content CFI (everything after '!') to
+  // produce a section-only CFI like `epubcfi(/6/8)`. Per foliate-js epubcfi
+  // compare semantics, this orders before any content CFI in the same section,
+  // so findWordIndexByCfi() resolves it to the first word of the chapter.
+  private static deriveSectionStartCfi(cfi: string): string {
+    return cfi.replace(/!.*\)$/, ')');
   }
 
   getStoredPosition(): RsvpPosition | null {

--- a/apps/readest-app/src/services/rsvp/RSVPController.ts
+++ b/apps/readest-app/src/services/rsvp/RSVPController.ts
@@ -16,6 +16,9 @@ const PUNCTUATION_PAUSE_KEY_PREFIX = 'readest_rsvp_pause_';
 const POSITION_KEY_PREFIX = 'readest_rsvp_pos_';
 const SPLIT_HYPHENS_KEY = 'readest_rsvp_split_hyphens';
 
+// Section-only CFI (no '!') sorts before any word CFI in that section.
+const stripCfiPath = (cfi: string): string => cfi.replace(/!.*\)$/, ')');
+
 export class RSVPController extends EventTarget {
   private view: FoliateView;
   private bookId: string; // Book hash without session suffix, for persistent storage
@@ -219,43 +222,26 @@ export class RSVPController extends EventTarget {
   }
 
   seedPosition(position: RsvpPosition, currentLocationCfi?: string | null): void {
-    const storageKey = `${POSITION_KEY_PREFIX}${this.bookId}`;
+    const key = `${POSITION_KEY_PREFIX}${this.bookId}`;
+    let final = position;
 
-    // buildRsvpExitConfigUpdate pins location = rsvpPosition.cfi at RSVP exit,
-    // so a synced pair pointing at different spine sections means stale/inconsistent
-    // state. Trust the location CFI (the user's actual reading position) and fall
-    // back to its section start — Resume then lands at word 0 of the synced chapter
-    // rather than at a wrong-chapter rsvpPosition or a leftover stale local entry.
+    // Cross-chapter mismatch means stale sync (exit pins them together);
+    // fall back to the start of the location's chapter.
     if (
       currentLocationCfi &&
       position.cfi &&
       !this.isSameSection(position.cfi, currentLocationCfi)
     ) {
-      console.warn(
-        '[RSVP] Synced rsvpPosition is in a different chapter than location; resetting resume to start of synced chapter',
-        { rsvpCfi: position.cfi, locationCfi: currentLocationCfi },
-      );
-      const fallback: RsvpPosition = {
-        cfi: RSVPController.deriveSectionStartCfi(currentLocationCfi),
-        wordText: '',
-      };
-      const serializedFallback = JSON.stringify(fallback);
-      if (localStorage.getItem(storageKey) === serializedFallback) return;
-      localStorage.setItem(storageKey, serializedFallback);
-      return;
+      console.warn('[RSVP] rsvpPosition chapter mismatch; resetting to start of synced chapter', {
+        rsvpCfi: position.cfi,
+        locationCfi: currentLocationCfi,
+      });
+      final = { cfi: stripCfiPath(currentLocationCfi), wordText: '' };
     }
 
-    const serialized = JSON.stringify(position);
-    if (localStorage.getItem(storageKey) === serialized) return;
-    localStorage.setItem(storageKey, serialized);
-  }
-
-  // Strip the in-document path from a content CFI (everything after '!') to
-  // produce a section-only CFI like `epubcfi(/6/8)`. Per foliate-js epubcfi
-  // compare semantics, this orders before any content CFI in the same section,
-  // so findWordIndexByCfi() resolves it to the first word of the chapter.
-  private static deriveSectionStartCfi(cfi: string): string {
-    return cfi.replace(/!.*\)$/, ')');
+    const serialized = JSON.stringify(final);
+    if (localStorage.getItem(key) === serialized) return;
+    localStorage.setItem(key, serialized);
   }
 
   getStoredPosition(): RsvpPosition | null {


### PR DESCRIPTION
## Summary                                             

  Two unrelated RSVP fixes that were bothering me.       
  
  ### 1. Seed local position from synced `BookConfig` on resume                 
                                                         
  When RSVP starts, the controller seeds its `localStorage` position from the   
  cloud-synced `BookConfig.rsvpPosition`. Two prior issues:
                                                                                
  - **Stale local entry blocked fresh sync.** `seedPosition()` no-op'd whenever 
    any local entry existed, so a fresh `rsvpPosition` synced in from another   
    device never overwrote a stale local one — Resume kept landing at the old   
  spot.                                                                         
  - **Corrupt synced pair could land in the wrong chapter.**                    
    `buildRsvpExitConfigUpdate` pins `BookConfig.location` to `rsvpPosition.cfi`
    at RSVP exit, so the two should always reference the same spine section. If 
  a                                                                             
    sync race produces a pair where they don't, the old code would seed the     
    mismatched `rsvpPosition` and Resume into the wrong chapter.                
                                                         
  Changes:                                                                      
  - `RSVPController.seedPosition(position, currentLocationCfi?)` always
    overwrites the local entry (skipping only redundant identical writes), and  
    when `currentLocationCfi` points to a different spine section than          
    `position.cfi`, falls back to the section-start CFI of `currentLocationCfi` 
    (`epubcfi(/6/8)` form) and warns. The stripped CFI sorts before any         
    in-section word CFI per foliate-js epubcfi compare, so                      
  `findWordIndexByCfi()`                                                        
    resolves it to word 0 of the synced chapter.                                
  - `RSVPControl.handleStart` passes                                            
    `config?.location ?? progress?.location ?? null` into `seedPosition` so the 
    controller can detect the mismatch.                                         
                                                                                
  ### 2. Make the RSVP progress bar draggable on mobile                         
                                                                                
  Three coordinated fixes so the overlay's seek bar works reliably under touch: 
  
  - Add `touch-action: none` on the slider so the mobile browser stops claiming 
    the gesture for scroll/pan and firing `pointercancel` mid-drag.
  - Hoist the `.rsvp-controls` / `.rsvp-header` exclusion to the top of the     
    overlay's `touchend` handler so a successful drag isn't immediately
    re-interpreted as a speed-change swipe.                                     
  - Guard `releasePointerCapture` with `hasPointerCapture` so a `pointercancel`
    arriving after the browser has already released capture (multitouch, app    
    backgrounding) no longer throws `NotFoundError`.