### PR TITLE
fix(rsvp): split em-dash and en-dash compound words

### DIFF
--- a/apps/readest-app/src/__tests__/services/rsvp-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/rsvp-controller.test.ts
@@ -299,6 +299,28 @@ describe('RSVPController', () => {
     });
   });
 
+  describe('em-dash and en-dash splitting', () => {
+    test('splits compound word joined by em-dash into separate words', () => {
+      const doc = makeDoc('best—of all possible—worlds');
+      const view = createMockView(0, [doc]);
+      const controller = new RSVPController(view, 'test-book-abc123');
+      controller.start();
+
+      const words = controller.currentState.words.map((w) => w.text);
+      expect(words).toEqual(['best—', 'of', 'all', 'possible—', 'worlds']);
+    });
+
+    test('splits compound word joined by en-dash into separate words', () => {
+      const doc = makeDoc('pages 10–15 covered');
+      const view = createMockView(0, [doc]);
+      const controller = new RSVPController(view, 'test-book-abc123');
+      controller.start();
+
+      const words = controller.currentState.words.map((w) => w.text);
+      expect(words).toEqual(['pages', '10–', '15', 'covered']);
+    });
+  });
+
   describe('duplicate word blank insertion', () => {
     test('inserts blank between two consecutive identical words', () => {
       const doc = makeDoc('the the cat');

--- a/apps/readest-app/src/__tests__/services/rsvp-utils.test.ts
+++ b/apps/readest-app/src/__tests__/services/rsvp-utils.test.ts
@@ -240,6 +240,43 @@ describe('rsvp/utils', () => {
       const words = splitTextIntoWords('你好 世界');
       expect(words.length).toBeGreaterThan(0);
     });
+
+    test('splits on em-dash without surrounding spaces', () => {
+      expect(splitTextIntoWords('alpha—beta')).toEqual(['alpha—', 'beta']);
+    });
+
+    test('splits on en-dash without surrounding spaces', () => {
+      expect(splitTextIntoWords('alpha–beta')).toEqual(['alpha–', 'beta']);
+    });
+
+    test('attaches em-dash with surrounding spaces to preceding word', () => {
+      expect(splitTextIntoWords('alpha — beta')).toEqual(['alpha', '—', 'beta']);
+    });
+
+    test('splits multiple em-dashes in a single token', () => {
+      expect(splitTextIntoWords('one—two—three')).toEqual(['one—', 'two—', 'three']);
+    });
+
+    test('splits sentence with em-dash inside compound word', () => {
+      expect(splitTextIntoWords('It was the best—of all possible—worlds.')).toEqual([
+        'It',
+        'was',
+        'the',
+        'best—',
+        'of',
+        'all',
+        'possible—',
+        'worlds.',
+      ]);
+    });
+
+    test('preserves trailing em-dash attached to its word', () => {
+      expect(splitTextIntoWords('cliffhanger—')).toEqual(['cliffhanger—']);
+    });
+
+    test('preserves leading em-dash as its own token', () => {
+      expect(splitTextIntoWords('—continued')).toEqual(['—', 'continued']);
+    });
   });
 
   describe('getHyphenParts', () => {

--- a/apps/readest-app/src/services/rsvp/RSVPController.ts
+++ b/apps/readest-app/src/services/rsvp/RSVPController.ts
@@ -865,7 +865,7 @@ export class RSVPController extends EventTarget {
     const baseMs = 60000 / wpm;
     let duration = baseMs * word.pauseMultiplier;
 
-    if (/[.!?,;:]$/.test(word.text)) {
+    if (/[.!?,;:–—]$/.test(word.text)) {
       duration += this.state.punctuationPauseMs;
     }
 

--- a/apps/readest-app/src/services/rsvp/utils.ts
+++ b/apps/readest-app/src/services/rsvp/utils.ts
@@ -226,14 +226,45 @@ function segmentWithJieba(text: string): string[] {
 }
 
 /**
+ * Split a token on em-dash (—) and en-dash (–), keeping the dash attached to
+ * the preceding non-empty segment so downstream pause logic still sees it as
+ * trailing punctuation. A leading dash with no preceding word is emitted as
+ * its own token.
+ *
+ * Examples:
+ *   "best—of"        → ["best—", "of"]
+ *   "10–15"          → ["10–", "15"]
+ *   "cliffhanger—"   → ["cliffhanger—"]
+ *   "—continued"     → ["—", "continued"]
+ */
+function splitOnLongDashes(token: string): string[] {
+  if (!/[–—]/.test(token)) return [token];
+  const parts = token.split(/([–—])/);
+  const result: string[] = [];
+  for (const part of parts) {
+    if (!part) continue;
+    if (/^[–—]$/.test(part) && result.length > 0) {
+      result[result.length - 1] = result[result.length - 1] + part;
+    } else {
+      result.push(part);
+    }
+  }
+  return result;
+}
+
+/**
  * Split text into words, handling both CJK and non-CJK text
  */
 export function splitTextIntoWords(text: string, language?: string): string[] {
   const hasCJK = containsCJK(text);
 
   if (!hasCJK) {
-    // Use space-based splitting for non-CJK text
-    return text.split(/(\s+)/).filter((w) => w.trim().length > 0);
+    // Use space-based splitting for non-CJK text, then split on em/en-dashes so
+    // compound phrases like "word—word" don't flash as a single unreadable run.
+    return text
+      .split(/(\s+)/)
+      .filter((w) => w.trim().length > 0)
+      .flatMap(splitOnLongDashes);
   }
 
   // For CJK text, use semantic segmentation


### PR DESCRIPTION
## Summary
- Speed-read (RSVP) flashed words joined by em-dash (—) or en-dash (–) as a single unreadable compound token (e.g. `best—of`).
- Non-CJK tokens are now split on em/en-dashes inside `splitTextIntoWords`, with the dash kept attached to the preceding word so it acts as terminal punctuation.
- The pause regex in `getWordDisplayDuration` now includes `–—`, so RSVP pauses on em/en-dash like it does on commas and periods.

Closes #4022

## Test plan
- [x] `pnpm test` (all 3416 tests pass; 7 new utils cases + 2 new controller cases for em/en-dash splitting)
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] Manual: open a book containing em-dash compounds in RSVP mode and verify each side of the dash flashes as its own word with a small pause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)