### PR TITLE
refactor(settings): move Keep Screen Awake to Behavior > Device

### DIFF
--- a/apps/readest-app/src/app/library/components/SettingsMenu.tsx
+++ b/apps/readest-app/src/app/library/components/SettingsMenu.tsx
@@ -55,7 +55,6 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
   const [isAutoCheckUpdates, setIsAutoCheckUpdates] = useState(settings.autoCheckUpdates);
   const [isAlwaysOnTop, setIsAlwaysOnTop] = useState(settings.alwaysOnTop);
   const [isAlwaysShowStatusBar, setIsAlwaysShowStatusBar] = useState(settings.alwaysShowStatusBar);
-  const [isScreenWakeLock, setIsScreenWakeLock] = useState(settings.screenWakeLock);
   const [isOpenLastBooks, setIsOpenLastBooks] = useState(settings.openLastBooks);
   const [isAutoImportBooksOnOpen, setIsAutoImportBooksOnOpen] = useState(
     settings.autoImportBooksOnOpen,
@@ -151,12 +150,6 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
     const newValue = !settings.autoCheckUpdates;
     saveSysSettings(envConfig, 'autoCheckUpdates', newValue);
     setIsAutoCheckUpdates(newValue);
-  };
-
-  const toggleScreenWakeLock = () => {
-    const newValue = !settings.screenWakeLock;
-    saveSysSettings(envConfig, 'screenWakeLock', newValue);
-    setIsScreenWakeLock(newValue);
   };
 
   const toggleOpenLastBooks = () => {
@@ -398,11 +391,6 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
           onClick={toggleAlwaysShowStatusBar}
         />
       )}
-      <MenuItem
-        label={_('Keep Screen Awake')}
-        toggled={isScreenWakeLock}
-        onClick={toggleScreenWakeLock}
-      />
       {appService?.isAndroidApp && (
         <MenuItem
           label={_(_('Background Read Aloud'))}

--- a/apps/readest-app/src/components/settings/ControlPanel.tsx
+++ b/apps/readest-app/src/components/settings/ControlPanel.tsx
@@ -49,6 +49,7 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
   const [isEink, setIsEink] = useState(viewSettings.isEink);
   const [isColorEink, setIsColorEink] = useState(viewSettings.isColorEink);
   const [autoScreenBrightness, setAutoScreenBrightness] = useState(settings.autoScreenBrightness);
+  const [screenWakeLock, setScreenWakeLock] = useState(settings.screenWakeLock);
   const [allowScript, setAllowScript] = useState(viewSettings.allowScript);
 
   const resetToDefaults = useResetViewSettings();
@@ -187,6 +188,12 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
     saveSysSettings(envConfig, 'autoScreenBrightness', autoScreenBrightness);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoScreenBrightness]);
+
+  useEffect(() => {
+    if (screenWakeLock === settings.screenWakeLock) return;
+    saveSysSettings(envConfig, 'screenWakeLock', screenWakeLock);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [screenWakeLock]);
 
   useEffect(() => {
     if (viewSettings.allowScript === allowScript) return;
@@ -411,49 +418,56 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
         </div>
       </div>
 
-      {(appService?.isMobileApp || appService?.appPlatform === 'web') && (
-        <div className='w-full' data-setting-id='settings.control.einkMode'>
-          <h2 className='mb-2 font-medium'>{_('Device')}</h2>
-          <div className='card border-base-200 bg-base-100 border shadow'>
-            <div className='divide-base-200 divide-y'>
-              {(appService?.isAndroidApp || appService?.appPlatform === 'web') && (
-                <div className='config-item'>
-                  <span className=''>{_('E-Ink Mode')}</span>
-                  <input
-                    type='checkbox'
-                    className='toggle'
-                    checked={isEink}
-                    onChange={() => setIsEink(!isEink)}
-                  />
-                </div>
-              )}
-              {(appService?.isAndroidApp || appService?.appPlatform === 'web') && (
-                <div className='config-item' data-setting-id='settings.control.colorEinkMode'>
-                  <span className=''>{_('Color E-Ink Mode')}</span>
-                  <input
-                    type='checkbox'
-                    className='toggle'
-                    disabled={!isEink}
-                    checked={isColorEink}
-                    onChange={() => setIsColorEink(!isColorEink)}
-                  />
-                </div>
-              )}
-              {appService?.isMobileApp && (
-                <div className='config-item'>
-                  <span className=''>{_('System Screen Brightness')}</span>
-                  <input
-                    type='checkbox'
-                    className='toggle'
-                    checked={autoScreenBrightness}
-                    onChange={() => setAutoScreenBrightness(!autoScreenBrightness)}
-                  />
-                </div>
-              )}
+      <div className='w-full' data-setting-id='settings.control.device'>
+        <h2 className='mb-2 font-medium'>{_('Device')}</h2>
+        <div className='card border-base-200 bg-base-100 border shadow'>
+          <div className='divide-base-200 divide-y'>
+            {(appService?.isAndroidApp || appService?.appPlatform === 'web') && (
+              <div className='config-item' data-setting-id='settings.control.einkMode'>
+                <span className=''>{_('E-Ink Mode')}</span>
+                <input
+                  type='checkbox'
+                  className='toggle'
+                  checked={isEink}
+                  onChange={() => setIsEink(!isEink)}
+                />
+              </div>
+            )}
+            {(appService?.isAndroidApp || appService?.appPlatform === 'web') && (
+              <div className='config-item' data-setting-id='settings.control.colorEinkMode'>
+                <span className=''>{_('Color E-Ink Mode')}</span>
+                <input
+                  type='checkbox'
+                  className='toggle'
+                  disabled={!isEink}
+                  checked={isColorEink}
+                  onChange={() => setIsColorEink(!isColorEink)}
+                />
+              </div>
+            )}
+            {appService?.isMobileApp && (
+              <div className='config-item'>
+                <span className=''>{_('System Screen Brightness')}</span>
+                <input
+                  type='checkbox'
+                  className='toggle'
+                  checked={autoScreenBrightness}
+                  onChange={() => setAutoScreenBrightness(!autoScreenBrightness)}
+                />
+              </div>
+            )}
+            <div className='config-item' data-setting-id='settings.control.screenWakeLock'>
+              <span className=''>{_('Keep Screen Awake')}</span>
+              <input
+                type='checkbox'
+                className='toggle'
+                checked={screenWakeLock}
+                onChange={() => setScreenWakeLock(!screenWakeLock)}
+              />
             </div>
           </div>
         </div>
-      )}
+      </div>
 
       <div className='w-full' data-setting-id='settings.control.allowJavascript'>
         <h2 className='mb-2 font-medium'>{_('Security')}</h2>

--- a/apps/readest-app/src/services/commandRegistry.ts
+++ b/apps/readest-app/src/services/commandRegistry.ts
@@ -484,6 +484,12 @@ const controlPanelItems = [
     section: 'Device',
   },
   {
+    id: 'settings.control.screenWakeLock',
+    labelKey: _('Keep Screen Awake'),
+    keywords: ['screen', 'wake', 'lock', 'awake', 'sleep', 'display'],
+    section: 'Device',
+  },
+  {
     id: 'settings.control.allowJavascript',
     labelKey: _('Allow JavaScript'),
     keywords: ['javascript', 'js', 'script', 'security', 'allow'],


### PR DESCRIPTION
## Summary
- Move the **Keep Screen Awake** toggle out of the library settings dropdown and into **Settings → Behavior → Device**, where related device-level toggles (E-Ink Mode, System Screen Brightness) already live.
- Make the Behavior panel's Device section render on all platforms now that it has a universally relevant option (previously gated to mobile/web).
- Add a matching command palette entry (`settings.control.screenWakeLock`) so the setting stays discoverable via search; the existing quick-toggle action is retained.

## Test plan
- [x] `pnpm test` passes
- [x] `pnpm lint` clean
- [x] Library menu no longer shows "Keep Screen Awake"
- [x] Settings → Behavior → Device shows the toggle on desktop, web, mobile
- [x] Toggling persists `settings.screenWakeLock` and the wake lock activates while reading
- [x] Command palette: searching "keep screen awake" surfaces both the settings entry (opens panel) and the action (quick toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)