### PR TITLE
feat(koplugin): support deletePluginSettings hook

### DIFF
--- a/apps/readest.koplugin/main.lua
+++ b/apps/readest.koplugin/main.lua
@@ -381,4 +381,10 @@ function ReadestSync:onCloseWidget()
     end
 end
 
+function ReadestSync:deletePluginSettings()
+    G_reader_settings:delSetting("readest_sync")
+    self.settings = self.default_settings
+    return true
+end
+
 return ReadestSync


### PR DESCRIPTION
## Summary
- Implements the `deletePluginSettings` hook introduced in [koreader/koreader#15240](https://github.com/koreader/koreader/pull/15240), invoked when the user deletes the plugin via KOReader's plugin manager with **Also delete plugin settings** checked.
- Removes the `readest_sync` entry from `G_reader_settings` (Supabase auth tokens, user identity, `auto_sync` flag, `last_sync_at`) and resets `self.settings` to defaults so the running instance stays consistent until restart.

## Test plan
- [ ] Install on a KOReader build with PR #15240 merged, sign in, toggle `auto_sync`, then long-press the plugin in **Plugin management → Readest Sync**, tick **Also delete plugin settings**, and confirm.
- [ ] Verify the `readest_sync` block is gone from `koreader/settings.reader.lua` after the prompt to restart.
- [ ] On a KOReader build without PR #15240, confirm the plugin still loads and behaves normally (the hook is dormant).

Closes #4039

🤖 Generated with [Claude Code](https://claude.com/claude-code)