### PR TITLE
fix(docker): correct Kong gateway port for client build arg

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -123,7 +123,7 @@ services:
       context: ..
       target: production-stage
       args:
-        NEXT_PUBLIC_SUPABASE_URL: http://${HOST_IP}:7000
+        NEXT_PUBLIC_SUPABASE_URL: http://${HOST_IP}:${KONG_HTTP_PORT:-8000}
         NEXT_PUBLIC_SUPABASE_ANON_KEY: ${ANON_KEY}
         NEXT_PUBLIC_APP_PLATFORM: web
         NEXT_PUBLIC_API_BASE_URL: http://${HOST_IP}:3000


### PR DESCRIPTION
## Summary
- The web client's `NEXT_PUBLIC_SUPABASE_URL` build arg in `docker/compose.yaml` pointed at port `7000`, but Kong is exposed on `KONG_HTTP_PORT` (default `8000`), so browser-side Supabase calls failed in the self-hosted Docker setup.
- Updated to `http://${HOST_IP}:${KONG_HTTP_PORT:-8000}` so the URL tracks the configured port and falls back to `8000` if the env var is unset.

Closes #4035

## Test plan
- [x] `docker compose config` resolves `NEXT_PUBLIC_SUPABASE_URL` to `http://<HOST_IP>:8000` with default env
- [ ] Self-hosted web client can reach Supabase auth endpoints from the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)