### PR TITLE
fix(reader): dismiss annotation popup on section info / progress bar tap

### DIFF
--- a/apps/readest-app/src/app/reader/components/ProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/ProgressBar.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { formatNumber, formatProgress } from '@/utils/progress';
 import { saveViewSettings } from '@/helpers/settings';
+import { eventDispatcher } from '@/utils/event';
 import { SIZE_PER_LOC, SIZE_PER_TIME_UNIT } from '@/services/constants';
 import type { ProgressBarMode } from '@/types/book.ts';
 import StatusInfo from './StatusInfo.tsx';
@@ -163,7 +164,10 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
         isScrolled && !isVertical && 'bg-base-100',
         isMobile ? 'pointer-events-auto' : 'pointer-events-none',
       )}
-      onClick={() => cycleProgressInfoModes()}
+      onClick={() => {
+        if (eventDispatcher.dispatchSync('iframe-single-click')) return;
+        cycleProgressInfoModes();
+      }}
       aria-label={[
         progress
           ? _('On {{current}} of {{total}} page', {

--- a/apps/readest-app/src/app/reader/components/SectionInfo.tsx
+++ b/apps/readest-app/src/app/reader/components/SectionInfo.tsx
@@ -5,6 +5,7 @@ import { useEnv } from '@/context/EnvContext';
 import { useThemeStore } from '@/store/themeStore';
 import { useReaderStore } from '@/store/readerStore';
 import { useTranslation } from '@/hooks/useTranslation';
+import { eventDispatcher } from '@/utils/event';
 
 interface SectionInfoProps {
   bookKey: string;
@@ -39,9 +40,15 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
   );
 
   const handleNotchClick = () => {
+    if (eventDispatcher.dispatchSync('iframe-single-click')) return;
     if (isScrolled) {
       getView(bookKey)?.renderer.scrollToAnchor?.(0, 'anchor', true);
     }
+  };
+
+  const handleSectionClick = () => {
+    if (eventDispatcher.dispatchSync('iframe-single-click')) return;
+    setHoveredBookKey(bookKey);
   };
 
   return (
@@ -67,7 +74,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
         )}
         role='none'
         tabIndex={-1}
-        onClick={() => setHoveredBookKey(bookKey)}
+        onClick={handleSectionClick}
         style={
           isVertical
             ? {


### PR DESCRIPTION
## Summary
- Tapping the section info or progress bar overlays did not dismiss an open annotation popup, because the dismiss flow listens for `iframe-single-click`, which only fires from inside the foliate iframe. These overlays sit above the iframe and intercept taps before the iframe sees them.
- Dispatch `iframe-single-click` first in `SectionInfo` and `ProgressBar` click handlers; if a popup consumes it (existing `useTextSelector` handler dismisses popup/selection and returns `true`), skip the original action.

## Test plan
- [x] Select text to open the annotation popup, then tap the section info bar at the top — popup dismisses; tap again to toggle the toolbar.
- [x] Select text to open the annotation popup, then tap the progress bar at the bottom — popup dismisses; tap again cycles progress info modes.
- [x] Tap a highlight to show the popup, tap section info / progress bar — popup dismisses without re-triggering the highlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)