### PR TITLE
fix(reader): revert footer visibility when tap-to-toggle disabled

### DIFF
--- a/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
@@ -1,0 +1,123 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ProgressBar from '@/app/reader/components/ProgressBar';
+import { DEFAULT_VIEW_CONFIG } from '@/services/constants';
+import type { ViewSettings } from '@/types/book';
+
+const saveViewSettings = vi.fn();
+
+let currentViewSettings: ViewSettings;
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: { isMobile: false, hasSafeAreaInset: false } }),
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    getProgress: () => null,
+    getViewSettings: () => currentViewSettings,
+    getView: () => ({ renderer: { page: 0, pages: 0 } }),
+  }),
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({
+    getBookData: () => ({ isFixedLayout: false }),
+  }),
+}));
+
+vi.mock('@/helpers/settings', () => ({
+  saveViewSettings: (...args: unknown[]) => saveViewSettings(...args),
+}));
+
+vi.mock('@/utils/event', () => ({
+  eventDispatcher: { dispatchSync: () => false },
+}));
+
+vi.mock('@/app/reader/components/StatusInfo.tsx', () => ({
+  default: () => null,
+}));
+
+const baseSettings: ViewSettings = {
+  ...DEFAULT_VIEW_CONFIG,
+} as ViewSettings;
+
+const renderProgressBar = () =>
+  render(
+    <ProgressBar
+      bookKey='book-1'
+      horizontalGap={0}
+      contentInsets={{ top: 0, right: 0, bottom: 0, left: 0 }}
+      gridInsets={{ top: 0, right: 0, bottom: 0, left: 0 }}
+    />,
+  );
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  saveViewSettings.mockClear();
+});
+
+describe('ProgressBar — tap-to-toggle disabled reverts hidden footer', () => {
+  it("resets progressInfoMode to 'all' when the user disables tapToToggleFooter while mode was 'none'", () => {
+    // Simulate a user who tapped the footer to dismiss it (mode='none')
+    // while tapToToggleFooter was on. Now they have it switched off.
+    currentViewSettings = {
+      ...baseSettings,
+      tapToToggleFooter: false,
+      progressInfoMode: 'none',
+    } as ViewSettings;
+
+    renderProgressBar();
+
+    // The persisted progressInfoMode should be reset to the default
+    // ('all') so the footer reverts to its default visibility.
+    const persistCalls = saveViewSettings.mock.calls.filter(
+      (args) => args[2] === 'progressInfoMode',
+    );
+    expect(persistCalls.length).toBeGreaterThanOrEqual(1);
+    const lastCall = persistCalls[persistCalls.length - 1]!;
+    expect(lastCall[3]).toBe('all');
+  });
+
+  it("does not overwrite mode when tapToToggleFooter is on (user's cycled state stays)", () => {
+    currentViewSettings = {
+      ...baseSettings,
+      tapToToggleFooter: true,
+      progressInfoMode: 'none',
+    } as ViewSettings;
+
+    renderProgressBar();
+
+    // initial save mirrors the existing mode; importantly we never see
+    // a save with 'all' overriding the user's tap-cycled choice.
+    const persistCalls = saveViewSettings.mock.calls.filter(
+      (args) => args[2] === 'progressInfoMode',
+    );
+    expect(persistCalls.every((args) => args[3] === 'none')).toBe(true);
+  });
+
+  it("leaves mode untouched when tapToToggleFooter is off but mode is already 'all'", () => {
+    currentViewSettings = {
+      ...baseSettings,
+      tapToToggleFooter: false,
+      progressInfoMode: 'all',
+    } as ViewSettings;
+
+    renderProgressBar();
+
+    const persistCalls = saveViewSettings.mock.calls.filter(
+      (args) => args[2] === 'progressInfoMode',
+    );
+    // Either no save or a save matching the existing 'all' value — never
+    // a transition through some intermediate state.
+    expect(persistCalls.every((args) => args[3] === 'all')).toBe(true);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/ProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/ProgressBar.tsx
@@ -146,6 +146,18 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [progressBarMode]);
 
+  // Self-heal a stuck "none" (or partial) mode left over from a prior
+  // tap-to-toggle session. Without this, dismissing the footer via tap
+  // and then disabling the toggle in settings would leave the footer
+  // permanently hidden — the user's only way back to a visible footer
+  // would be to re-enable the toggle and tap through the cycle.
+  useEffect(() => {
+    if (!viewSettings.tapToToggleFooter && progressBarMode !== 'all') {
+      setProgressBarMode('all');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewSettings.tapToToggleFooter]);
+
   const isMobile = appService?.isMobile || window.innerWidth < 640;
   const showStatusInfo =
     (progressBarMode === 'all' ||


### PR DESCRIPTION
## Summary

Reported UX issue: with **Tap to toggle footer** enabled, tapping the footer cycles through display modes including \"none\" (footer hidden). The cycled mode is persisted to view settings. Disabling the toggle in settings afterward leaves the footer permanently hidden — there's no UI path to bring it back, since the cycle that produced the hidden state is now unreachable.

## Fix

`ProgressBar.tsx` now resets \`progressInfoMode\` to the default \`'all'\` whenever \`tapToToggleFooter\` is off and the current mode isn't already \`'all'\`. Self-heals both at mount (book opened with the stuck state) and on the toggle transition during a session. The existing save effect persists the reset back to view settings.

## Test plan

- [x] Unit test covers the reset (`src/__tests__/components/ProgressBar.test.tsx`, 3 cases)
- [x] `pnpm test` — 3498 passed
- [x] `pnpm lint` — clean
- [x] Manual: enable Tap to toggle footer → tap until footer hides → open Settings → disable Tap to toggle footer → footer should reappear with default content

🤖 Generated with [Claude Code](https://claude.com/claude-code)