### PR TITLE
feat(reader): support deeplink and web link in annotation export

### DIFF
--- a/apps/readest-app/src/__tests__/utils/note.test.ts
+++ b/apps/readest-app/src/__tests__/utils/note.test.ts
@@ -518,6 +518,45 @@ describe('renderNoteTemplate', () => {
     });
   });
 
+  describe('Annotation link variants', () => {
+    const linkData: NoteTemplateData = {
+      title: 'Book',
+      author: 'Author',
+      exportDate: '2024-01-15',
+      chapters: [
+        {
+          title: 'Ch1',
+          annotations: [
+            {
+              text: 'quote',
+              webLink: 'https://web.readest.com/o/book/abc/annotation/n1',
+              appLink: 'readest://book/abc/annotation/n1',
+              link: 'https://web.readest.com/o/book/abc/annotation/n1',
+            },
+          ],
+        },
+      ],
+    };
+
+    it('should render annotation.webLink', () => {
+      const template = '{{ chapters[0].annotations[0].webLink }}';
+      const result = renderNoteTemplate(template, linkData);
+      expect(result).toBe('https://web.readest.com/o/book/abc/annotation/n1');
+    });
+
+    it('should render annotation.appLink with readest:// scheme', () => {
+      const template = '{{ chapters[0].annotations[0].appLink }}';
+      const result = renderNoteTemplate(template, linkData);
+      expect(result).toBe('readest://book/abc/annotation/n1');
+    });
+
+    it('should still render legacy annotation.link', () => {
+      const template = '{{ chapters[0].annotations[0].link }}';
+      const result = renderNoteTemplate(template, linkData);
+      expect(result).toBe('https://web.readest.com/o/book/abc/annotation/n1');
+    });
+  });
+
   describe('Whitespace handling', () => {
     it('should trim blocks correctly', () => {
       const template = `Start

--- a/apps/readest-app/src/app/reader/components/annotator/ExportMarkdownDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/ExportMarkdownDialog.tsx
@@ -8,7 +8,7 @@ import { BookNote, BooknoteGroup, NoteExportConfig } from '@/types/book';
 import { DEFAULT_NOTE_EXPORT_CONFIG } from '@/services/constants';
 import { saveViewSettings } from '@/helpers/settings';
 import { renderNoteTemplate, formatBlockQuote } from '@/utils/note';
-import { buildAnnotationWebUrl } from '@/utils/deeplink';
+import { buildAnnotationAppUrl, buildAnnotationWebUrl } from '@/utils/deeplink';
 import Dialog from '@/components/Dialog';
 
 interface ExportMarkdownDialogProps {
@@ -67,7 +67,7 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
 {% if annotation.note %}
 **${_('Note:')}** {{ annotation.note }}
 {% endif %}
-*{% if annotation.link %}[${_('Page:')} {{ annotation.page }}]({{ annotation.link }}){% else %}${_('Page:')} {{ annotation.page }}{% endif %} · ${_('Time:')} {{ annotation.timestamp | date('%Y-%m-%d %H:%M') }}*
+*{% if annotation.appLink %}[${_('Page:')} {{ annotation.page }}]({{ annotation.appLink }}){% else %}${_('Page:')} {{ annotation.page }}{% endif %} · ${_('Time:')} {{ annotation.timestamp | date('%Y-%m-%d %H:%M') }}*
 {% endfor %}
 
 ---
@@ -130,6 +130,8 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
             cfi: note.cfi,
             bookHash,
             link: buildAnnotationWebUrl({ bookHash, noteId: note.id, cfi: note.cfi }),
+            webLink: buildAnnotationWebUrl({ bookHash, noteId: note.id, cfi: note.cfi }),
+            appLink: buildAnnotationAppUrl({ bookHash, noteId: note.id, cfi: note.cfi }),
             text: note.text || '',
             note: note.note || '',
             style: note.style,
@@ -239,7 +241,8 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
   // Convert markdown to HTML for preview
   const htmlPreview = useMemo(() => {
     if (!markdownPreview) return '';
-    return marked.parse(markdownPreview);
+    const html = marked.parse(markdownPreview) as string;
+    return html.replace(/<a href=/g, '<a target="_blank" rel="noopener noreferrer" href=');
   }, [markdownPreview]);
 
   const handleToggle = (field: keyof NoteExportConfig) => {
@@ -506,6 +509,14 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
                         <li className='ml-8'>
                           <code className='bg-base-300 rounded px-1'>annotation.timestamp</code> -{' '}
                           {_('Annotation time')}
+                        </li>
+                        <li className='ml-8'>
+                          <code className='bg-base-300 rounded px-1'>annotation.appLink</code> -{' '}
+                          {_('App deeplink (readest://)')}
+                        </li>
+                        <li className='ml-8'>
+                          <code className='bg-base-300 rounded px-1'>annotation.webLink</code> -{' '}
+                          {_('Universal web link (https://)')}
                         </li>
                       </ul>
                     </div>

--- a/apps/readest-app/src/utils/note.ts
+++ b/apps/readest-app/src/utils/note.ts
@@ -11,6 +11,8 @@ export type NoteTemplateData = {
       cfi?: string;
       bookHash?: string;
       link?: string;
+      webLink?: string;
+      appLink?: string;
       text: string;
       note?: string;
       style?: string;


### PR DESCRIPTION
## Summary
- Expose `annotation.appLink` (`readest://`) and `annotation.webLink` (`https://web.readest.com`) in the custom export template, so users can pick which scheme they want for in-template links.
- Switch the shipped default custom template to emit `annotation.appLink` so exported notes open the native app by default. The non-template export mode keeps the universal `https` link as before, and the legacy `annotation.link` variable still works as an alias for `webLink`.
- Make the export preview's anchor tags open in a new tab (`target="_blank" rel="noopener noreferrer"`) so clicking a `[Page: N]` link no longer replaces the dialog/page.

## Test plan
- [ ] `pnpm test` (unit tests, including new `Annotation link variants` suite in `note.test.ts`)
- [ ] `pnpm lint`
- [ ] Open the Export Annotations dialog with at least one annotation; confirm the default custom template renders `[Page: N](readest://book/.../annotation/...)`
- [ ] In the preview, click a page link and confirm it opens in a new tab
- [ ] Toggle off "Use Custom Template" and confirm default-mode export still uses the `https://web.readest.com/...` link
- [ ] Edit the template to use `{{ annotation.webLink }}` and confirm the preview shows the `https` URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)