### PR TITLE
chore(i18n): translate replica-sync File-toast strings

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -1429,10 +1429,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "تستخدم حزم MDict ملفات .mdx؛ ملفات .mdd و .css المرافقة اختيارية.",
   "Dictionary name": "اسم القاموس",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "لا يمكن تشغيل هذا الصوت هنا — يستخدم القاموس تنسيقًا قديمًا. جرّب قاموسًا يستخدم صوت Opus أو MP3 أو WAV.",
-  "Dictionary uploaded: {{title}}": "تم رفع القاموس: {{title}}",
-  "Dictionary downloaded: {{title}}": "تم تنزيل القاموس: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "تم حذف النسخة السحابية للقاموس: {{title}}",
-  "Failed to upload dictionary: {{title}}": "فشل رفع القاموس: {{title}}",
-  "Failed to download dictionary: {{title}}": "فشل تنزيل القاموس: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "فشل حذف النسخة السحابية للقاموس: {{title}}"
+  "File uploaded: {{title}}": "تم تحميل الملف: {{title}}",
+  "File downloaded: {{title}}": "تم تنزيل الملف: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "تم حذف النسخة السحابية للملف: {{title}}",
+  "Failed to upload file: {{title}}": "فشل تحميل الملف: {{title}}",
+  "Failed to download file: {{title}}": "فشل تنزيل الملف: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "فشل في حذف النسخة السحابية للملف: {{title}}"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1333,10 +1333,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict বান্ডেল .mdx ফাইল ব্যবহার করে; সহগামী .mdd ও .css ফাইল ঐচ্ছিক।",
   "Dictionary name": "অভিধানের নাম",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "এই অডিও এখানে চালানো যাচ্ছে না — অভিধানটি একটি পুরনো ফর্ম্যাট ব্যবহার করছে। Opus, MP3 বা WAV অডিও সহ একটি ব্যবহার করে দেখুন।",
-  "Dictionary uploaded: {{title}}": "অভিধান আপলোড করা হয়েছে: {{title}}",
-  "Dictionary downloaded: {{title}}": "অভিধান ডাউনলোড করা হয়েছে: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "অভিধানের ক্লাউড কপি মুছে ফেলা হয়েছে: {{title}}",
-  "Failed to upload dictionary: {{title}}": "অভিধান আপলোড করতে ব্যর্থ: {{title}}",
-  "Failed to download dictionary: {{title}}": "অভিধান ডাউনলোড করতে ব্যর্থ: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "অভিধানের ক্লাউড কপি মুছতে ব্যর্থ: {{title}}"
+  "File uploaded: {{title}}": "ফাইল আপলোড হয়েছে: {{title}}",
+  "File downloaded: {{title}}": "ফাইল ডাউনলোড হয়েছে: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "ফাইলের ক্লাউড অনুলিপি মুছে ফেলা হয়েছে: {{title}}",
+  "Failed to upload file: {{title}}": "ফাইল আপলোড ব্যর্থ: {{title}}",
+  "Failed to download file: {{title}}": "ফাইল ডাউনলোড ব্যর্থ: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "ফাইলের ক্লাউড অনুলিপি মুছতে ব্যর্থ: {{title}}"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1309,10 +1309,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict གི་ཡིག་ཆས་ཚོགས་ཀྱིས་ .mdx ཡིག་ཆ་སྤྱོད། སྦྲེལ་མཐུན་ .mdd དང་ .css ཡིག་ཆ་ཡིན་ན་འདེམས་ཆོག",
   "Dictionary name": "ཚིག་མཛོད་མིང་།",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "སྒྲ་འདི་འདིར་སྒྲོག་མི་ཐུབ — ཚིག་མཛོད་འདིས་རྩིས་མེད་པའི་རྣམ་པ་སྤྱོད། Opus, MP3, ཡང་ན་ WAV གི་སྒྲ་ལྡན་པ་ཞིག་ལ་འདེམས་སྡུར་གྱིས།",
-  "Dictionary uploaded: {{title}}": "ཚིག་མཛོད་སྤར་འཇུག་ཟིན། {{title}}",
-  "Dictionary downloaded: {{title}}": "ཚིག་མཛོད་ཕབ་ལེན་ཟིན། {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "སྤྲིན་ཐོག་གི་ཚིག་མཛོད་འདྲ་བཤུས་སུབ་ཟིན། {{title}}",
-  "Failed to upload dictionary: {{title}}": "ཚིག་མཛོད་སྤར་འཇུག་ལ་ཐུབ་མ་སོང་། {{title}}",
-  "Failed to download dictionary: {{title}}": "ཚིག་མཛོད་ཕབ་ལེན་ལ་ཐུབ་མ་སོང་། {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "སྤྲིན་ཐོག་གི་ཚིག་མཛོད་འདྲ་བཤུས་སུབ་ཐུབ་མ་སོང་། {{title}}"
+  "File uploaded: {{title}}": "ཡིག་ཆ་སྤྲད་ཟིན། {{title}}",
+  "File downloaded: {{title}}": "ཡིག་ཆ་ཕབ་ལེན་བྱས་ཟིན། {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "ཡིག་ཆའི་སྤྲི་དོན་གྱི་འདྲ་བཤུས་བསུབ་ཟིན། {{title}}",
+  "Failed to upload file: {{title}}": "ཡིག་ཆ་སྤྲད་མ་ཐུབ། {{title}}",
+  "Failed to download file: {{title}}": "ཡིག་ཆ་ཕབ་ལེན་བྱས་མ་ཐུབ། {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "ཡིག་ཆའི་སྤྲི་དོན་གྱི་འདྲ་བཤུས་བསུབ་ཐུབ་མེད། {{title}}"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1333,10 +1333,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict-Bundles verwenden .mdx-Dateien; begleitende .mdd- und .css-Dateien sind optional.",
   "Dictionary name": "Wörterbuchname",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Diese Audio kann hier nicht abgespielt werden — das Wörterbuch verwendet ein veraltetes Format. Probieren Sie ein Wörterbuch mit Opus-, MP3- oder WAV-Audio.",
-  "Dictionary uploaded: {{title}}": "Wörterbuch hochgeladen: {{title}}",
-  "Dictionary downloaded: {{title}}": "Wörterbuch heruntergeladen: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Cloud-Kopie des Wörterbuchs gelöscht: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Fehler beim Hochladen des Wörterbuchs: {{title}}",
-  "Failed to download dictionary: {{title}}": "Fehler beim Herunterladen des Wörterbuchs: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Fehler beim Löschen der Cloud-Kopie des Wörterbuchs: {{title}}"
+  "File uploaded: {{title}}": "Datei hochgeladen: {{title}}",
+  "File downloaded: {{title}}": "Datei heruntergeladen: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Cloud-Kopie der Datei gelöscht: {{title}}",
+  "Failed to upload file: {{title}}": "Fehler beim Hochladen der Datei: {{title}}",
+  "Failed to download file: {{title}}": "Fehler beim Herunterladen der Datei: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Fehler beim Löschen der Cloud-Kopie der Datei: {{title}}"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1333,10 +1333,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Τα πακέτα MDict χρησιμοποιούν αρχεία .mdx· τα συνοδευτικά αρχεία .mdd και .css είναι προαιρετικά.",
   "Dictionary name": "Όνομα λεξικού",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Αυτός ο ήχος δεν μπορεί να αναπαραχθεί εδώ — το λεξικό χρησιμοποιεί ξεπερασμένη μορφή. Δοκιμάστε ένα λεξικό με ήχο Opus, MP3 ή WAV.",
-  "Dictionary uploaded: {{title}}": "Το λεξικό μεταφορτώθηκε: {{title}}",
-  "Dictionary downloaded: {{title}}": "Το λεξικό κατέβηκε: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Διαγράφηκε το αντίγραφο cloud του λεξικού: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Αποτυχία μεταφόρτωσης λεξικού: {{title}}",
-  "Failed to download dictionary: {{title}}": "Αποτυχία λήψης λεξικού: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Αποτυχία διαγραφής αντιγράφου cloud του λεξικού: {{title}}"
+  "File uploaded: {{title}}": "Το αρχείο με τίτλο {{title}} ανέβηκε",
+  "File downloaded: {{title}}": "Το αρχείο με τίτλο {{title}} κατέβηκε",
+  "Deleted cloud copy of the file: {{title}}": "Διαγράφηκε το αντίγραφο του αρχείου: {{title}}",
+  "Failed to upload file: {{title}}": "Αποτυχία ανέβασμα αρχείου: {{title}}",
+  "Failed to download file: {{title}}": "Αποτυχία λήψης αρχείου: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Αποτυχία διαγραφής του αντιγράφου του αρχείου: {{title}}"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1357,10 +1357,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Los paquetes MDict usan archivos .mdx; los archivos .mdd y .css complementarios son opcionales.",
   "Dictionary name": "Nombre del diccionario",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Este audio no se puede reproducir aquí — el diccionario usa un formato obsoleto. Prueba uno con audio Opus, MP3 o WAV.",
-  "Dictionary uploaded: {{title}}": "Diccionario subido: {{title}}",
-  "Dictionary downloaded: {{title}}": "Diccionario descargado: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Copia en la nube del diccionario eliminada: {{title}}",
-  "Failed to upload dictionary: {{title}}": "No se pudo subir el diccionario: {{title}}",
-  "Failed to download dictionary: {{title}}": "No se pudo descargar el diccionario: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "No se pudo eliminar la copia en la nube del diccionario: {{title}}"
+  "File uploaded: {{title}}": "Archivo subido: {{title}}",
+  "File downloaded: {{title}}": "Archivo descargado: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Copia en la nube del archivo eliminada: {{title}}",
+  "Failed to upload file: {{title}}": "Error al subir archivo: {{title}}",
+  "Failed to download file: {{title}}": "Error al descargar archivo: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Error al eliminar la copia en la nube del archivo: {{title}}"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1333,10 +1333,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "بسته‌های MDict از فایل‌های .mdx استفاده می‌کنند؛ فایل‌های همراه .mdd و .css اختیاری هستند.",
   "Dictionary name": "نام فرهنگ‌نامه",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "این صدا اینجا قابل پخش نیست — فرهنگ‌نامه از قالبی قدیمی استفاده می‌کند. فرهنگ‌نامه‌ای با صدای Opus، MP3 یا WAV را امتحان کنید.",
-  "Dictionary uploaded: {{title}}": "فرهنگ لغت بارگذاری شد: {{title}}",
-  "Dictionary downloaded: {{title}}": "فرهنگ لغت دانلود شد: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "نسخهٔ ابری فرهنگ لغت حذف شد: {{title}}",
-  "Failed to upload dictionary: {{title}}": "بارگذاری فرهنگ لغت ناموفق بود: {{title}}",
-  "Failed to download dictionary: {{title}}": "دانلود فرهنگ لغت ناموفق بود: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "حذف نسخهٔ ابری فرهنگ لغت ناموفق بود: {{title}}"
+  "File uploaded: {{title}}": "فایل «{{title}}» آپلود شد.",
+  "File downloaded: {{title}}": "فایل «{{title}}» دانلود شد.",
+  "Deleted cloud copy of the file: {{title}}": "نسخه‌ی ابری فایل «{{title}}» حذف شد.",
+  "Failed to upload file: {{title}}": "آپلود فایل «{{title}}» ناموفق بود.",
+  "Failed to download file: {{title}}": "دانلود فایل «{{title}}» ناموفق بود.",
+  "Failed to delete cloud copy of the file: {{title}}": "حذف نسخه‌ی ابری فایل «{{title}}» ناموفق بود."
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1357,10 +1357,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Les bundles MDict utilisent des fichiers .mdx ; les fichiers .mdd et .css associés sont facultatifs.",
   "Dictionary name": "Nom du dictionnaire",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Cet audio ne peut pas être lu ici — le dictionnaire utilise un format obsolète. Essayez-en un avec un audio Opus, MP3 ou WAV.",
-  "Dictionary uploaded: {{title}}": "Dictionnaire importé : {{title}}",
-  "Dictionary downloaded: {{title}}": "Dictionnaire téléchargé : {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Copie cloud du dictionnaire supprimée : {{title}}",
-  "Failed to upload dictionary: {{title}}": "Échec de l'envoi du dictionnaire : {{title}}",
-  "Failed to download dictionary: {{title}}": "Échec du téléchargement du dictionnaire : {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Échec de la suppression de la copie cloud du dictionnaire : {{title}}"
+  "File uploaded: {{title}}": "Fichier téléchargé : {{title}}",
+  "File downloaded: {{title}}": "Fichier téléchargé : {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Suppression de la copie cloud du fichier : {{title}}",
+  "Failed to upload file: {{title}}": "Échec du téléchargement du fichier : {{title}}",
+  "Failed to download file: {{title}}": "Échec du téléchargement du fichier : {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Échec de la suppression de la copie cloud du fichier : {{title}}"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1357,10 +1357,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "חבילות MDict משתמשות בקובצי .mdx; קובצי .mdd ו‑.css נלווים הם אופציונליים.",
   "Dictionary name": "שם המילון",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "לא ניתן להשמיע את השמע הזה כאן — המילון משתמש בפורמט מיושן. נסה מילון עם שמע Opus, MP3 או WAV.",
-  "Dictionary uploaded: {{title}}": "המילון הועלה: {{title}}",
-  "Dictionary downloaded: {{title}}": "המילון הורד: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "עותק הענן של המילון נמחק: {{title}}",
-  "Failed to upload dictionary: {{title}}": "העלאת המילון נכשלה: {{title}}",
-  "Failed to download dictionary: {{title}}": "הורדת המילון נכשלה: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "מחיקת עותק הענן של המילון נכשלה: {{title}}"
+  "File uploaded: {{title}}": "הקובץ הועלה: {{title}}",
+  "File downloaded: {{title}}": "קובץ הורד: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "עותק הענן של הקובץ נמחק: {{title}}",
+  "Failed to upload file: {{title}}": "העלאת הקובץ נכשלה: {{title}}",
+  "Failed to download file: {{title}}": "הורדת הקובץ נכשלה: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "מחיקת עותק הענן של הקובץ נכשלה: {{title}}"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1333,10 +1333,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict बंडल .mdx फ़ाइलों का उपयोग करते हैं; साथ की .mdd और .css फ़ाइलें वैकल्पिक हैं।",
   "Dictionary name": "शब्दकोश का नाम",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "यह ऑडियो यहाँ नहीं चलाया जा सकता — शब्दकोश पुराने प्रारूप का उपयोग करता है। Opus, MP3 या WAV ऑडियो वाला कोई आज़माएँ।",
-  "Dictionary uploaded: {{title}}": "शब्दकोश अपलोड हो गया: {{title}}",
-  "Dictionary downloaded: {{title}}": "शब्दकोश डाउनलोड हो गया: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "शब्दकोश की क्लाउड कॉपी हटाई गई: {{title}}",
-  "Failed to upload dictionary: {{title}}": "शब्दकोश अपलोड करने में विफल: {{title}}",
-  "Failed to download dictionary: {{title}}": "शब्दकोश डाउनलोड करने में विफल: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "शब्दकोश की क्लाउड कॉपी हटाने में विफल: {{title}}"
+  "File uploaded: {{title}}": "फ़ाइल अपलोड की गई: {{title}}",
+  "File downloaded: {{title}}": "फ़ाइल डाउनलोड की गई: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "फ़ाइल की क्लाउड प्रति हटाई गई: {{title}}",
+  "Failed to upload file: {{title}}": "फ़ाइल अपलोड करने में विफल: {{title}}",
+  "Failed to download file: {{title}}": "फ़ाइल डाउनलोड करने में विफल: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "फ़ाइल की क्लाउड प्रति हटाने में विफल: {{title}}"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1333,10 +1333,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Az MDict csomagok .mdx fájlokat használnak; a kísérő .mdd és .css fájlok opcionálisak.",
   "Dictionary name": "Szótár neve",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Ez a hang itt nem játszható le — a szótár elavult formátumot használ. Próbálj olyat, amely Opus, MP3 vagy WAV hangot tartalmaz.",
-  "Dictionary uploaded: {{title}}": "Szótár feltöltve: {{title}}",
-  "Dictionary downloaded: {{title}}": "Szótár letöltve: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "A szótár felhőbeli másolata törölve: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Nem sikerült feltölteni a szótárat: {{title}}",
-  "Failed to download dictionary: {{title}}": "Nem sikerült letölteni a szótárat: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Nem sikerült törölni a szótár felhőbeli másolatát: {{title}}"
+  "File uploaded: {{title}}": "Fájl feltöltve: {{title}}",
+  "File downloaded: {{title}}": "Fájl letöltve: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Fájl felhőmásolata törölve: {{title}}",
+  "Failed to upload file: {{title}}": "A fájl feltöltése sikertelen: {{title}}",
+  "Failed to download file: {{title}}": "Fájl letöltése sikertelen: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Fájl felhőmásolatának törlése sikertelen: {{title}}"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1309,10 +1309,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Paket MDict menggunakan berkas .mdx; berkas .mdd dan .css pendamping bersifat opsional.",
   "Dictionary name": "Nama kamus",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Audio ini tidak dapat diputar di sini — kamus menggunakan format usang. Coba kamus dengan audio Opus, MP3, atau WAV.",
-  "Dictionary uploaded: {{title}}": "Kamus diunggah: {{title}}",
-  "Dictionary downloaded: {{title}}": "Kamus diunduh: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Salinan cloud kamus dihapus: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Gagal mengunggah kamus: {{title}}",
-  "Failed to download dictionary: {{title}}": "Gagal mengunduh kamus: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Gagal menghapus salinan cloud kamus: {{title}}"
+  "File uploaded: {{title}}": "File diunggah: {{title}}",
+  "File downloaded: {{title}}": "File diunduh: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Salinan cloud file dihapus: {{title}}",
+  "Failed to upload file: {{title}}": "Gagal mengunggah file: {{title}}",
+  "Failed to download file: {{title}}": "Gagal mengunduh file: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Gagal menghapus salinan cloud file: {{title}}"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1357,10 +1357,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "I pacchetti MDict usano file .mdx; i file .mdd e .css di accompagnamento sono facoltativi.",
   "Dictionary name": "Nome del dizionario",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Questo audio non può essere riprodotto qui — il dizionario usa un formato obsoleto. Prova un dizionario con audio Opus, MP3 o WAV.",
-  "Dictionary uploaded: {{title}}": "Dizionario caricato: {{title}}",
-  "Dictionary downloaded: {{title}}": "Dizionario scaricato: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Copia cloud del dizionario eliminata: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Caricamento del dizionario non riuscito: {{title}}",
-  "Failed to download dictionary: {{title}}": "Download del dizionario non riuscito: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Eliminazione della copia cloud del dizionario non riuscita: {{title}}"
+  "File uploaded: {{title}}": "File caricato: {{title}}",
+  "File downloaded: {{title}}": "File scaricato: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Copia cloud del file eliminata: {{title}}",
+  "Failed to upload file: {{title}}": "Caricamento file non riuscito: {{title}}",
+  "Failed to download file: {{title}}": "Download file non riuscito: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Impossibile eliminare la copia cloud del file: {{title}}"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1309,10 +1309,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict バンドルは .mdx ファイルを使用します。付属の .mdd および .css ファイルは任意です。",
   "Dictionary name": "辞書名",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "この音声はここで再生できません — 辞書が古い形式を使用しています。Opus、MP3、または WAV 音声を使用する辞書を試してください。",
-  "Dictionary uploaded: {{title}}": "辞書をアップロードしました: {{title}}",
-  "Dictionary downloaded: {{title}}": "辞書をダウンロードしました: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "辞書のクラウドコピーを削除しました: {{title}}",
-  "Failed to upload dictionary: {{title}}": "辞書のアップロードに失敗しました: {{title}}",
-  "Failed to download dictionary: {{title}}": "辞書のダウンロードに失敗しました: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "辞書のクラウドコピーの削除に失敗しました: {{title}}"
+  "File uploaded: {{title}}": "ファイルがアップロードされました：{{title}}",
+  "File downloaded: {{title}}": "ファイルがダウンロードされました：{{title}}",
+  "Deleted cloud copy of the file: {{title}}": "ファイルのクラウドコピーを削除しました：{{title}}",
+  "Failed to upload file: {{title}}": "ファイルのアップロードに失敗しました：{{title}}",
+  "Failed to download file: {{title}}": "ファイルのダウンロードに失敗しました：{{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "ファイルのクラウドコピーの削除に失敗しました：{{title}}"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1309,10 +1309,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict 번들은 .mdx 파일을 사용합니다. 동반된 .mdd 및 .css 파일은 선택 사항입니다.",
   "Dictionary name": "사전 이름",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "여기서는 이 오디오를 재생할 수 없습니다 — 사전이 오래된 형식을 사용합니다. Opus, MP3 또는 WAV 오디오 사전을 사용해 보세요.",
-  "Dictionary uploaded: {{title}}": "사전 업로드 완료: {{title}}",
-  "Dictionary downloaded: {{title}}": "사전 다운로드 완료: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "사전의 클라우드 사본을 삭제했습니다: {{title}}",
-  "Failed to upload dictionary: {{title}}": "사전 업로드 실패: {{title}}",
-  "Failed to download dictionary: {{title}}": "사전 다운로드 실패: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "사전의 클라우드 사본 삭제 실패: {{title}}"
+  "File uploaded: {{title}}": "파일 업로드됨: {{title}}",
+  "File downloaded: {{title}}": "파일 다운로드됨: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "파일의 클라우드 사본이 삭제됨: {{title}}",
+  "Failed to upload file: {{title}}": "파일 업로드 실패: {{title}}",
+  "Failed to download file: {{title}}": "파일 다운로드 실패: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "파일의 클라우드 사본 삭제에 실패했습니다: {{title}}"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1309,10 +1309,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Bungkusan MDict menggunakan fail .mdx; fail .mdd dan .css yang menyertainya adalah pilihan.",
   "Dictionary name": "Nama kamus",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Audio ini tidak boleh dimainkan di sini — kamus menggunakan format lapuk. Cuba kamus dengan audio Opus, MP3 atau WAV.",
-  "Dictionary uploaded: {{title}}": "Kamus dimuat naik: {{title}}",
-  "Dictionary downloaded: {{title}}": "Kamus dimuat turun: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Salinan awan kamus dipadam: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Gagal memuat naik kamus: {{title}}",
-  "Failed to download dictionary: {{title}}": "Gagal memuat turun kamus: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Gagal memadam salinan awan kamus: {{title}}"
+  "File uploaded: {{title}}": "Fail dimuat naik: {{title}}",
+  "File downloaded: {{title}}": "Fail dimuat turun: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Salinan awan fail dipadam: {{title}}",
+  "Failed to upload file: {{title}}": "Gagal memuat naik fail: {{title}}",
+  "Failed to download file: {{title}}": "Gagal memuat turun fail: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Gagal memadam salinan awan fail: {{title}}"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1333,10 +1333,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict-bundels gebruiken .mdx-bestanden; bijbehorende .mdd- en .css-bestanden zijn optioneel.",
   "Dictionary name": "Naam van woordenboek",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Deze audio kan hier niet worden afgespeeld — het woordenboek gebruikt een verouderd formaat. Probeer een woordenboek met Opus-, MP3- of WAV-audio.",
-  "Dictionary uploaded: {{title}}": "Woordenboek geüpload: {{title}}",
-  "Dictionary downloaded: {{title}}": "Woordenboek gedownload: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Cloudkopie van het woordenboek verwijderd: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Uploaden van woordenboek mislukt: {{title}}",
-  "Failed to download dictionary: {{title}}": "Downloaden van woordenboek mislukt: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Verwijderen van cloudkopie van het woordenboek mislukt: {{title}}"
+  "File uploaded: {{title}}": "Bestand geüpload: {{title}}",
+  "File downloaded: {{title}}": "Bestand gedownload: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Verwijderde cloudkopie van het bestand: {{title}}",
+  "Failed to upload file: {{title}}": "Uploaden van bestand mislukt: {{title}}",
+  "Failed to download file: {{title}}": "Downloaden van bestand mislukt: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Verwijderen van cloudkopie van het bestand is mislukt: {{title}}"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1381,10 +1381,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Pakiety MDict używają plików .mdx; towarzyszące pliki .mdd i .css są opcjonalne.",
   "Dictionary name": "Nazwa słownika",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Tego dźwięku nie można odtworzyć tutaj — słownik używa przestarzałego formatu. Spróbuj słownika z dźwiękiem Opus, MP3 lub WAV.",
-  "Dictionary uploaded: {{title}}": "Słownik przesłany: {{title}}",
-  "Dictionary downloaded: {{title}}": "Słownik pobrany: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Usunięto kopię słownika w chmurze: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Nie udało się przesłać słownika: {{title}}",
-  "Failed to download dictionary: {{title}}": "Nie udało się pobrać słownika: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Nie udało się usunąć kopii słownika w chmurze: {{title}}"
+  "File uploaded: {{title}}": "Plik przesłany: {{title}}",
+  "File downloaded: {{title}}": "Plik pobrany: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Usunięto kopię pliku w chmurze: {{title}}",
+  "Failed to upload file: {{title}}": "Nie udało się przesłać pliku: {{title}}",
+  "Failed to download file: {{title}}": "Nie udało się pobrać pliku: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Nie udało się usunąć kopii pliku w chmurze: {{title}}"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1357,10 +1357,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Os pacotes MDict usam arquivos .mdx; os arquivos .mdd e .css que os acompanham são opcionais.",
   "Dictionary name": "Nome do dicionário",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Este áudio não pode ser reproduzido aqui — o dicionário usa um formato obsoleto. Tente um dicionário com áudio Opus, MP3 ou WAV.",
-  "Dictionary uploaded: {{title}}": "Dicionário carregado: {{title}}",
-  "Dictionary downloaded: {{title}}": "Dicionário baixado: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Cópia na nuvem do dicionário excluída: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Falha ao carregar o dicionário: {{title}}",
-  "Failed to download dictionary: {{title}}": "Falha ao baixar o dicionário: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Falha ao excluir a cópia na nuvem do dicionário: {{title}}"
+  "File uploaded: {{title}}": "Arquivo enviado: {{title}}",
+  "File downloaded: {{title}}": "Arquivo baixado: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Cópia na nuvem do arquivo excluída: {{title}}",
+  "Failed to upload file: {{title}}": "Falha ao enviar arquivo: {{title}}",
+  "Failed to download file: {{title}}": "Falha ao baixar arquivo: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Falha ao excluir cópia na nuvem do arquivo: {{title}}"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1357,10 +1357,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Os pacotes MDict usam ficheiros .mdx; os ficheiros .mdd e .css que os acompanham são opcionais.",
   "Dictionary name": "Nome do dicionário",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Este áudio não pode ser reproduzido aqui — o dicionário usa um formato obsoleto. Experimenta um dicionário com áudio Opus, MP3 ou WAV.",
-  "Dictionary uploaded: {{title}}": "Dicionário carregado: {{title}}",
-  "Dictionary downloaded: {{title}}": "Dicionário transferido: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Cópia na nuvem do dicionário eliminada: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Falha ao carregar o dicionário: {{title}}",
-  "Failed to download dictionary: {{title}}": "Falha ao transferir o dicionário: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Falha ao eliminar a cópia na nuvem do dicionário: {{title}}"
+  "File uploaded: {{title}}": "Arquivo enviado: {{title}}",
+  "File downloaded: {{title}}": "Arquivo baixado: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Cópia na nuvem do arquivo excluída: {{title}}",
+  "Failed to upload file: {{title}}": "Falha ao enviar arquivo: {{title}}",
+  "Failed to download file: {{title}}": "Falha ao baixar arquivo: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Falha ao excluir cópia na nuvem do arquivo: {{title}}"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1357,10 +1357,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Pachetele MDict folosesc fișiere .mdx; fișierele .mdd și .css însoțitoare sunt opționale.",
   "Dictionary name": "Numele dicționarului",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Acest audio nu poate fi redat aici — dicționarul folosește un format învechit. Încearcă unul cu audio Opus, MP3 sau WAV.",
-  "Dictionary uploaded: {{title}}": "Dicționar încărcat: {{title}}",
-  "Dictionary downloaded: {{title}}": "Dicționar descărcat: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Copia din cloud a dicționarului a fost ștearsă: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Încărcarea dicționarului a eșuat: {{title}}",
-  "Failed to download dictionary: {{title}}": "Descărcarea dicționarului a eșuat: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Ștergerea copiei din cloud a dicționarului a eșuat: {{title}}"
+  "File uploaded: {{title}}": "Fișier încărcat: {{title}}",
+  "File downloaded: {{title}}": "Fișier descărcat: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Copia din cloud a fișierului a fost ștearsă: {{title}}",
+  "Failed to upload file: {{title}}": "Nu s-a putut încărca fișierul: {{title}}",
+  "Failed to download file: {{title}}": "Nu s-a putut descărca fișierul: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Nu s-a putut șterge copia din cloud a fișierului: {{title}}"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1381,10 +1381,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Пакеты MDict используют файлы .mdx; сопутствующие файлы .mdd и .css необязательны.",
   "Dictionary name": "Название словаря",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Этот звук невозможно воспроизвести здесь — словарь использует устаревший формат. Попробуйте словарь с аудио Opus, MP3 или WAV.",
-  "Dictionary uploaded: {{title}}": "Словарь загружен: {{title}}",
-  "Dictionary downloaded: {{title}}": "Словарь скачан: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Облачная копия словаря удалена: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Не удалось загрузить словарь: {{title}}",
-  "Failed to download dictionary: {{title}}": "Не удалось скачать словарь: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Не удалось удалить облачную копию словаря: {{title}}"
+  "File uploaded: {{title}}": "Файл загружен: {{title}}",
+  "File downloaded: {{title}}": "Файл скачан: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Удалена облачная копия файла: {{title}}",
+  "Failed to upload file: {{title}}": "Не удалось загрузить файл: {{title}}",
+  "Failed to download file: {{title}}": "Не удалось скачать файл: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Не удалось удалить копию файла в облаке: {{title}}"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1333,10 +1333,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict පැකේජ .mdx ගොනු භාවිතා කරයි; සහායක .mdd සහ .css ගොනු විකල්පීය වේ.",
   "Dictionary name": "ශබ්දකෝෂයේ නම",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "මෙම ශබ්දය මෙහි වාදනය කළ නොහැක — ශබ්දකෝෂය යල් පැන ගිය ආකෘතියක් භාවිතා කරයි. Opus, MP3 හෝ WAV ශබ්ද සහිත එකක් උත්සාහ කරන්න.",
-  "Dictionary uploaded: {{title}}": "ශබ්දකෝෂය උඩුගත කළා: {{title}}",
-  "Dictionary downloaded: {{title}}": "ශබ්දකෝෂය බාගත කළා: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "ශබ්දකෝෂයේ ක්ලවුඩ් පිටපත මකා දැම්මා: {{title}}",
-  "Failed to upload dictionary: {{title}}": "ශබ්දකෝෂය උඩුගත කිරීමට අසමත් වුණා: {{title}}",
-  "Failed to download dictionary: {{title}}": "ශබ්දකෝෂය බාගත කිරීමට අසමත් වුණා: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "ශබ්දකෝෂයේ ක්ලවුඩ් පිටපත මකා දැමීමට අසමත් වුණා: {{title}}"
+  "File uploaded: {{title}}": "ගොනුව උඩුගත විය: {{title}}",
+  "File downloaded: {{title}}": "ගොනුව බාගන්නා ලදී: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "ගොනුවේ cloud පිටපත මකා දමන ලදී: {{title}}",
+  "Failed to upload file: {{title}}": "ගොනුව උඩුගත කිරීමට අසමත්: {{title}}",
+  "Failed to download file: {{title}}": "ගොනුව බාගැනීමට අසමත්: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "ගොනුවේ cloud පිටපත මකා දැමීමට අසමත්: {{title}}"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1381,10 +1381,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Paketi MDict uporabljajo datoteke .mdx; spremne datoteke .mdd in .css so neobvezne.",
   "Dictionary name": "Ime slovarja",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Tega zvoka tukaj ni mogoče predvajati — slovar uporablja zastarelo obliko. Poskusite slovar z zvokom Opus, MP3 ali WAV.",
-  "Dictionary uploaded: {{title}}": "Slovar naložen: {{title}}",
-  "Dictionary downloaded: {{title}}": "Slovar prenesen: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Kopija slovarja v oblaku izbrisana: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Nalaganje slovarja ni uspelo: {{title}}",
-  "Failed to download dictionary: {{title}}": "Prenos slovarja ni uspel: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Brisanje kopije slovarja v oblaku ni uspelo: {{title}}"
+  "File uploaded: {{title}}": "Datoteka naložena: {{title}}",
+  "File downloaded: {{title}}": "Datoteka prenesena: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Izbrisana kopija datoteke v oblaku: {{title}}",
+  "Failed to upload file: {{title}}": "Nalaganje datoteke ni uspelo: {{title}}",
+  "Failed to download file: {{title}}": "Prenos datoteke ni uspel: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Brisanje kopije datoteke v oblaku ni uspelo: {{title}}"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1333,10 +1333,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict-paket använder .mdx-filer; medföljande .mdd- och .css-filer är valfria.",
   "Dictionary name": "Ordbokens namn",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Det här ljudet kan inte spelas upp här — ordboken använder ett föråldrat format. Prova en ordbok med Opus-, MP3- eller WAV-ljud.",
-  "Dictionary uploaded: {{title}}": "Ordlista uppladdad: {{title}}",
-  "Dictionary downloaded: {{title}}": "Ordlista nedladdad: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Molnkopia av ordlistan borttagen: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Det gick inte att ladda upp ordlistan: {{title}}",
-  "Failed to download dictionary: {{title}}": "Det gick inte att ladda ned ordlistan: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Det gick inte att ta bort molnkopian av ordlistan: {{title}}"
+  "File uploaded: {{title}}": "Fil uppladdad: {{title}}",
+  "File downloaded: {{title}}": "Fil nedladdad: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Raderade molnkopia av fil: {{title}}",
+  "Failed to upload file: {{title}}": "Kunde inte ladda upp fil: {{title}}",
+  "Failed to download file: {{title}}": "Kunde inte ladda ner fil: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Kunde inte radera molnkopia av fil: {{title}}"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1333,10 +1333,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict தொகுப்புகள் .mdx கோப்புகளைப் பயன்படுத்துகின்றன; இணைந்த .mdd மற்றும் .css கோப்புகள் விருப்பமானவை.",
   "Dictionary name": "அகராதியின் பெயர்",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "இந்த ஒலியை இங்கே இயக்க இயலவில்லை — அகராதி காலாவதியான வடிவத்தைப் பயன்படுத்துகிறது. Opus, MP3 அல்லது WAV ஒலி உள்ள ஒன்றை முயற்சிக்கவும்.",
-  "Dictionary uploaded: {{title}}": "அகராதி பதிவேற்றப்பட்டது: {{title}}",
-  "Dictionary downloaded: {{title}}": "அகராதி பதிவிறக்கப்பட்டது: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "அகராதியின் கிளவுட் நகல் நீக்கப்பட்டது: {{title}}",
-  "Failed to upload dictionary: {{title}}": "அகராதியை பதிவேற்ற முடியவில்லை: {{title}}",
-  "Failed to download dictionary: {{title}}": "அகராதியை பதிவிறக்க முடியவில்லை: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "அகராதியின் கிளவுட் நகலை நீக்க முடியவில்லை: {{title}}"
+  "File uploaded: {{title}}": "கோப்பு பதிவேற்றப்பட்டது: {{title}}",
+  "File downloaded: {{title}}": "கோப்பு பதிவிறக்கப்பட்டது: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "கோப்பின் cloud நகல் நீக்கப்பட்டது: {{title}}",
+  "Failed to upload file: {{title}}": "கோப்பை பதிவேற்ற முடியவில்லை: {{title}}",
+  "Failed to download file: {{title}}": "கோப்பை பதிவிறக்க முடியவில்லை: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "கோப்பின் cloud நகலை நீக்க முடியவில்லை: {{title}}"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1309,10 +1309,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "ชุด MDict ใช้ไฟล์ .mdx ส่วนไฟล์ .mdd และ .css ที่มาด้วยกันเป็นทางเลือก",
   "Dictionary name": "ชื่อพจนานุกรม",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "ไม่สามารถเล่นเสียงนี้ที่นี่ได้ — พจนานุกรมใช้รูปแบบที่ล้าสมัย ลองใช้พจนานุกรมที่มีเสียง Opus, MP3 หรือ WAV",
-  "Dictionary uploaded: {{title}}": "อัปโหลดพจนานุกรมแล้ว: {{title}}",
-  "Dictionary downloaded: {{title}}": "ดาวน์โหลดพจนานุกรมแล้ว: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "ลบสำเนาคลาวด์ของพจนานุกรมแล้ว: {{title}}",
-  "Failed to upload dictionary: {{title}}": "อัปโหลดพจนานุกรมไม่สำเร็จ: {{title}}",
-  "Failed to download dictionary: {{title}}": "ดาวน์โหลดพจนานุกรมไม่สำเร็จ: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "ลบสำเนาคลาวด์ของพจนานุกรมไม่สำเร็จ: {{title}}"
+  "File uploaded: {{title}}": "อัปโหลดไฟล์แล้ว: {{title}}",
+  "File downloaded: {{title}}": "ดาวน์โหลดไฟล์แล้ว: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "ลบสำเนาไฟล์บนคลาวด์แล้ว: {{title}}",
+  "Failed to upload file: {{title}}": "ไม่สามารถอัปโหลดไฟล์: {{title}}",
+  "Failed to download file: {{title}}": "ไม่สามารถดาวน์โหลดไฟล์: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "ไม่สามารถลบสำเนาไฟล์บนคลาวด์: {{title}}"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1333,10 +1333,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict paketleri .mdx dosyalarını kullanır; eşlik eden .mdd ve .css dosyaları isteğe bağlıdır.",
   "Dictionary name": "Sözlük adı",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Bu ses burada oynatılamıyor — sözlük eski bir biçim kullanıyor. Opus, MP3 veya WAV sesi olan bir sözlük deneyin.",
-  "Dictionary uploaded: {{title}}": "Sözlük yüklendi: {{title}}",
-  "Dictionary downloaded: {{title}}": "Sözlük indirildi: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Sözlüğün bulut kopyası silindi: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Sözlük yüklenemedi: {{title}}",
-  "Failed to download dictionary: {{title}}": "Sözlük indirilemedi: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Sözlüğün bulut kopyası silinemedi: {{title}}"
+  "File uploaded: {{title}}": "Dosya yüklendi: {{title}}",
+  "File downloaded: {{title}}": "Dosya indirildi: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Dosyanın bulut kopyası silindi: {{title}}",
+  "Failed to upload file: {{title}}": "Dosya yüklenemedi: {{title}}",
+  "Failed to download file: {{title}}": "Dosya indirilemedi: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Dosyanın bulut kopyasını silme başarısız oldu: {{title}}"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1381,10 +1381,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Пакунки MDict використовують файли .mdx; супутні файли .mdd і .css є необов’язковими.",
   "Dictionary name": "Назва словника",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Це аудіо не можна відтворити тут — словник використовує застарілий формат. Спробуйте словник з аудіо Opus, MP3 або WAV.",
-  "Dictionary uploaded: {{title}}": "Словник завантажено: {{title}}",
-  "Dictionary downloaded: {{title}}": "Словник звантажено: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Копію словника у хмарі видалено: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Не вдалося завантажити словник: {{title}}",
-  "Failed to download dictionary: {{title}}": "Не вдалося звантажити словник: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Не вдалося видалити копію словника у хмарі: {{title}}"
+  "File uploaded: {{title}}": "Файл завантажено: {{title}}",
+  "File downloaded: {{title}}": "Файл завантажено: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Видалено хмарну копію файлу: {{title}}",
+  "Failed to upload file: {{title}}": "Не вдалося завантажити файл: {{title}}",
+  "Failed to download file: {{title}}": "Не вдалося завантажити файл: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Не вдалося видалити копію файлу в хмарі: {{title}}"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1333,10 +1333,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict to‘plamlari .mdx fayllaridan foydalanadi; hamroh .mdd va .css fayllari ixtiyoriy.",
   "Dictionary name": "Lug‘at nomi",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Bu audio bu yerda ijro etilmaydi — lug‘at eskirgan formatdan foydalanadi. Opus, MP3 yoki WAV audioli lug‘atni sinab ko‘ring.",
-  "Dictionary uploaded: {{title}}": "Lug'at yuklandi: {{title}}",
-  "Dictionary downloaded: {{title}}": "Lug'at yuklab olindi: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Lug'atning bulutdagi nusxasi o'chirildi: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Lug'atni yuklab bo'lmadi: {{title}}",
-  "Failed to download dictionary: {{title}}": "Lug'atni yuklab olib bo'lmadi: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Lug'atning bulutdagi nusxasini o'chirib bo'lmadi: {{title}}"
+  "File uploaded: {{title}}": "Fayl yuklandi: {{title}}",
+  "File downloaded: {{title}}": "Fayl yuklab olindi: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Faylning bulutdagi nusxasi oʻchirildi: {{title}}",
+  "Failed to upload file: {{title}}": "Faylni yuklab boʻlmadi: {{title}}",
+  "Failed to download file: {{title}}": "Faylni yuklab boʻlmadi: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Faylning bulutdagi nusxasini oʻchirib boʻlmadi: {{title}}"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1309,10 +1309,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "Gói MDict sử dụng tệp .mdx; các tệp .mdd và .css đi kèm là tùy chọn.",
   "Dictionary name": "Tên từ điển",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "Không thể phát âm thanh này tại đây — từ điển dùng định dạng đã lỗi thời. Hãy thử từ điển có âm thanh Opus, MP3 hoặc WAV.",
-  "Dictionary uploaded: {{title}}": "Đã tải lên từ điển: {{title}}",
-  "Dictionary downloaded: {{title}}": "Đã tải xuống từ điển: {{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "Đã xoá bản sao đám mây của từ điển: {{title}}",
-  "Failed to upload dictionary: {{title}}": "Không thể tải lên từ điển: {{title}}",
-  "Failed to download dictionary: {{title}}": "Không thể tải xuống từ điển: {{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "Không thể xoá bản sao đám mây của từ điển: {{title}}"
+  "File uploaded: {{title}}": "Tệp đã tải lên: {{title}}",
+  "File downloaded: {{title}}": "Tệp đã tải về: {{title}}",
+  "Deleted cloud copy of the file: {{title}}": "Đã xóa bản sao đám mây của tệp: {{title}}",
+  "Failed to upload file: {{title}}": "Không thể tải lên tệp: {{title}}",
+  "Failed to download file: {{title}}": "Không thể tải về tệp: {{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "Không thể xóa bản sao đám mây của tệp: {{title}}"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1309,10 +1309,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict 包使用 .mdx 文件;附带的 .mdd 和 .css 文件可选。",
   "Dictionary name": "词典名称",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "此处无法播放该音频 — 此词典使用过时格式。请尝试使用 Opus、MP3 或 WAV 音频的词典。",
-  "Dictionary uploaded: {{title}}": "词典已上传:{{title}}",
-  "Dictionary downloaded: {{title}}": "词典已下载:{{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "已删除词典的云端副本:{{title}}",
-  "Failed to upload dictionary: {{title}}": "词典上传失败:{{title}}",
-  "Failed to download dictionary: {{title}}": "词典下载失败:{{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "词典云端副本删除失败:{{title}}"
+  "File uploaded: {{title}}": "文件已上传：{{title}}",
+  "File downloaded: {{title}}": "文件已下载：{{title}}",
+  "Deleted cloud copy of the file: {{title}}": "已删除文件云副本：{{title}}",
+  "Failed to upload file: {{title}}": "上传文件失败：{{title}}",
+  "Failed to download file: {{title}}": "下载文件失败：{{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "未能删除文件云副本：{{title}}"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1309,10 +1309,10 @@
   "MDict bundles use .mdx files; companion .mdd and .css files are optional.": "MDict 套件使用 .mdx 檔案;附帶的 .mdd 與 .css 檔案為選用。",
   "Dictionary name": "辭典名稱",
   "This audio can't play here — the dictionary uses an outdated format. Try one with Opus, MP3, or WAV audio.": "無法在此播放此音訊 — 此辭典使用過時格式。請改用提供 Opus、MP3 或 WAV 音訊的辭典。",
-  "Dictionary uploaded: {{title}}": "詞典已上傳:{{title}}",
-  "Dictionary downloaded: {{title}}": "詞典已下載:{{title}}",
-  "Deleted cloud copy of the dictionary: {{title}}": "已刪除詞典的雲端副本:{{title}}",
-  "Failed to upload dictionary: {{title}}": "詞典上傳失敗:{{title}}",
-  "Failed to download dictionary: {{title}}": "詞典下載失敗:{{title}}",
-  "Failed to delete cloud copy of the dictionary: {{title}}": "詞典雲端副本刪除失敗:{{title}}"
+  "File uploaded: {{title}}": "檔案已上傳：{{title}}",
+  "File downloaded: {{title}}": "檔案已下載：{{title}}",
+  "Deleted cloud copy of the file: {{title}}": "已刪除檔案的雲端副本：{{title}}",
+  "Failed to upload file: {{title}}": "檔案上傳失敗：{{title}}",
+  "Failed to download file: {{title}}": "檔案下載失敗：{{title}}",
+  "Failed to delete cloud copy of the file: {{title}}": "未能刪除檔案的雲端副本：{{title}}"
 }


### PR DESCRIPTION
## Summary

Translates the six \"File ...\" transfer-toast strings introduced in #4077 across all 33 locales:

- \`File uploaded: {{title}}\`
- \`File downloaded: {{title}}\`
- \`Deleted cloud copy of the file: {{title}}\`
- \`Failed to upload file: {{title}}\`
- \`Failed to download file: {{title}}\`
- \`Failed to delete cloud copy of the file: {{title}}\`

Each translation models the locale's existing \"Book ...\" copy with **book → file/document** and **backup → copy**, so tone and verb choice match what users already see for book-transfer toasts.

## Test plan

- [x] \`pnpm i18n:extract\` clean (no remaining \`__STRING_NOT_TRANSLATED__\` markers)
- [x] \`pnpm lint\` clean
- [x] \`en/translation.json\` untouched (per project rule: en holds only plural variants + proper nouns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)