### PR TITLE
fix(layout): center fixed modals above the on-screen keyboard on Android

### DIFF
--- a/apps/readest-app/src/app/layout.tsx
+++ b/apps/readest-app/src/app/layout.tsx
@@ -67,6 +67,15 @@ export const viewport: Viewport = {
   maximumScale: 1,
   userScalable: false,
   viewportFit: 'cover',
+  // Make Android Chrome's layout viewport shrink when the on-screen
+  // keyboard opens (matches iOS behavior). Without this, Android's
+  // default `interactive-widget=resizes-visual` keeps the layout
+  // viewport at full screen height while only the visual viewport
+  // shrinks — causing fixed `inset-0`-centered modals (passphrase
+  // prompt, group picker, etc.) to render under the keyboard. With
+  // `resizes-content`, `100vh` / flex centering naturally targets
+  // the available space above the keyboard.
+  interactiveWidget: 'resizes-content',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/apps/readest-app/src/pages/_app.tsx
+++ b/apps/readest-app/src/pages/_app.tsx
@@ -9,9 +9,16 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <Head>
+        {/*
+         * `interactive-widget=resizes-content` makes Android Chrome
+         * shrink the layout viewport when the on-screen keyboard
+         * opens (matches iOS default behavior). Without it, the
+         * layout viewport stays full-height and `fixed inset-0`-
+         * centered modals render under the keyboard.
+         */}
         <meta
           name='viewport'
-          content='minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, user-scalable=no, viewport-fit=cover'
+          content='minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content'
         />
         <meta name='application-name' content='Readest' />
         <meta name='apple-mobile-web-app-capable' content='yes' />


### PR DESCRIPTION
## Summary

Adds \`interactive-widget=resizes-content\` to the viewport meta so Android Chrome shrinks the **layout** viewport when the on-screen keyboard opens — matching iOS Safari's default behavior. Without this, every \`fixed inset-0\` flex-centered modal in the app (PassphrasePrompt, GroupingModal, etc.) renders behind the keyboard on Android, while the same modals work correctly on iOS.

## Why one-line meta beats per-modal JS

The instinct is to add a \`useKeyboardInset\` hook backed by the Visual Viewport API and translate each modal up by half the keyboard height. That works but:

- Every modal-with-input has to opt in (current + future).
- Adds a JS listener and a re-render to each prompt.
- Doesn't help non-modal layouts that happen to use \`100vh\` / flex centering.

\`interactive-widget=resizes-content\` makes the browser do the work: layout viewport tracks the visible area, every existing \`100vh\` / \`flex items-center\` rule auto-targets the available space, no JS, no opt-in. iOS already behaves this way; the change only affects Android Chrome.

## Test plan

- [ ] Android Chrome: focus the OPDS catalog Username/Password fields → modal stays visible above the keyboard
- [ ] Android Chrome: long-press a book → Group → Create New Group → input visible above the keyboard
- [ ] iOS Safari: regression check — same modals still center correctly
- [ ] Desktop: no behavior change (the meta is a no-op without a keyboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)