### PR TITLE
fix(epub): accept EPUBs with malformed first ZIP local file header

### DIFF
--- a/apps/readest-app/src/__tests__/libs/document.test.ts
+++ b/apps/readest-app/src/__tests__/libs/document.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { DocumentLoader } from '@/libs/document';
+
+if (typeof globalThis['CSS'] === 'undefined') {
+  (globalThis as Record<string, unknown>)['CSS'] = {
+    escape: (s: string) => s.replace(/([^\w-])/g, '\\$1'),
+  };
+}
+
+if (!customElements.get('foliate-paginator')) {
+  customElements.define(
+    'foliate-paginator',
+    class extends HTMLElement {
+      override setAttribute() {}
+      override addEventListener() {}
+      open() {}
+    },
+  );
+}
+
+vi.mock('foliate-js/paginator.js', () => ({}));
+
+const loadFixtureBytes = (name: string): Uint8Array => {
+  const epubPath = resolve(__dirname, `../fixtures/data/${name}`);
+  return new Uint8Array(readFileSync(epubPath));
+};
+
+describe('DocumentLoader.open', () => {
+  it('opens an EPUB whose first local file header has a non-standard signature byte', async () => {
+    // Some EPUB writers in the wild produce a malformed first local file header
+    // signature - PK\x03\x02 instead of the spec-mandated PK\x03\x04.
+    // The archive is otherwise valid: zip.js reads every entry via the central
+    // directory at the end of the file. We must not reject it at the magic-bytes gate.
+    const bytes = loadFixtureBytes('repro-3688.epub');
+    expect([bytes[0], bytes[1], bytes[2], bytes[3]]).toEqual([0x50, 0x4b, 0x03, 0x04]);
+
+    const malformed = bytes.slice();
+    malformed[3] = 0x02;
+
+    const file = new File([malformed], 'malformed-header.epub', {
+      type: 'application/epub+zip',
+    });
+    const result = await new DocumentLoader(file).open();
+
+    expect(result.book).toBeTruthy();
+    expect(result.format).toBe('EPUB');
+  }, 15000);
+});

--- a/apps/readest-app/src/libs/document.ts
+++ b/apps/readest-app/src/libs/document.ts
@@ -125,7 +125,11 @@ export class DocumentLoader {
 
   private async isZip(): Promise<boolean> {
     const arr = new Uint8Array(await this.file.slice(0, 4).arrayBuffer());
-    return arr[0] === 0x50 && arr[1] === 0x4b && arr[2] === 0x03 && arr[3] === 0x04;
+    // Standard local file header signature is PK\x03\x04, but some non-conformant
+    // EPUB writers emit malformed bytes (e.g., PK\x03\x02) on the first entry.
+    // The archive is still readable via the central directory, so don't gate on
+    // the 4th byte. PK\x03 alone is enough to identify a local file header.
+    return arr[0] === 0x50 && arr[1] === 0x4b && arr[2] === 0x03;
   }
 
   private async isPDF(): Promise<boolean> {


### PR DESCRIPTION
## Summary

Some EPUB writers emit a non-standard ZIP local file header signature on the first entry — bytes like `PK\x03\x02` instead of the spec's `PK\x03\x04`. The archive is otherwise valid: `@zip.js/zip.js`, system `unzip`, and Apple Books all read it via the End of Central Directory record at the tail, and most desktop readers open the file fine.

readest's `DocumentLoader.isZip()` did a strict 4-byte signature match, so the file got rejected at the magic-bytes gate before `zip.js` was even called. With no other format matching, the loader returned `book: null` and the user saw "Failed to open the book file: Unsupported or corrupted book file".

## Root cause

`apps/readest-app/src/libs/document.ts:127`

```ts
return arr[0] === 0x50 && arr[1] === 0x4b && arr[2] === 0x03 && arr[3] === 0x04;
```

The `arr[3] === 0x04` check is too strict. `PK\x03` alone uniquely identifies a local file header — no other ZIP record signature (`PK\x01\x02`, `PK\x05\x06`, `PK\x06\x06`, `PK\x06\x07`, `PK\x07\x08`) starts with `PK\x03`. Dropping the 4th-byte check matches what every tolerant ZIP parser already does.

## Fix

Loosen the gate to `PK\x03`. zip.js handles the rest via the central directory.

## Test

New unit test in `apps/readest-app/src/__tests__/libs/document.test.ts` patches the existing 2.5 KB `repro-3688.epub` fixture's 4th byte from `0x04` to `0x02` in memory and asserts `DocumentLoader.open()` returns a non-null EPUB. Confirmed failing before the fix, passing after.

## Test plan

- [x] `pnpm test` — 4086 passing, no regressions
- [x] `pnpm lint` — tsgo + biome clean
- [x] End-to-end in browser: imported a real-world EPUB with this defect via `pnpm dev-web`, the cover appeared in the bookshelf, and the reader opened it to the dedication page rendering the actual content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)