### PR TITLE
fix(i18n): localize quota reset countdown time units

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -1435,7 +1435,6 @@
   "Failed to download file: {{title}}": "فشل تنزيل الملف: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "فشل في حذف النسخة السحابية للملف: {{title}}",
   "{{percentage}}% used": "تم استخدام {{percentage}}٪",
-  "Resets in {{duration}}": "يُعاد التعيين خلال {{duration}}",
   "Set PIN…": "تعيين رمز PIN…",
   "Require a 4-digit PIN to open Readest": "اطلب رمز PIN مكوّن من 4 أرقام لفتح Readest",
   "Change PIN…": "تغيير رمز PIN…",
@@ -1493,5 +1492,6 @@
   "App settings": "إعدادات التطبيق",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "السمة وألوان التظليل والتكاملات (KOSync وReadwise وHardcover) وترتيب القواميس",
   "Required while Dictionaries sync is enabled": "مطلوب أثناء تفعيل مزامنة القواميس",
-  "Unavailable": "غير متاح"
+  "Unavailable": "غير متاح",
+  "Resets in {{hours}} hr {{minutes}} min": "يُعاد الضبط خلال {{hours}} س {{minutes}} د"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1339,7 +1339,6 @@
   "Failed to download file: {{title}}": "ফাইল ডাউনলোড ব্যর্থ: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "ফাইলের ক্লাউড অনুলিপি মুছতে ব্যর্থ: {{title}}",
   "{{percentage}}% used": "{{percentage}}% ব্যবহৃত",
-  "Resets in {{duration}}": "{{duration}} এ রিসেট হবে",
   "Set PIN…": "PIN সেট করুন…",
   "Require a 4-digit PIN to open Readest": "Readest খুলতে একটি ৪-সংখ্যার PIN প্রয়োজন করুন",
   "Change PIN…": "PIN পরিবর্তন করুন…",
@@ -1397,5 +1396,6 @@
   "App settings": "অ্যাপ সেটিংস",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "থিম, হাইলাইট রং, ইন্টিগ্রেশন (KOSync, Readwise, Hardcover) এবং অভিধানের ক্রম",
   "Required while Dictionaries sync is enabled": "অভিধান সিঙ্ক সক্রিয় থাকাকালীন প্রয়োজনীয়",
-  "Unavailable": "অনুপলব্ধ"
+  "Unavailable": "অনুপলব্ধ",
+  "Resets in {{hours}} hr {{minutes}} min": "{{hours}} ঘ {{minutes}} মি পরে রিসেট হবে"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1315,7 +1315,6 @@
   "Failed to download file: {{title}}": "ཡིག་ཆ་ཕབ་ལེན་བྱས་མ་ཐུབ། {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "ཡིག་ཆའི་སྤྲི་དོན་གྱི་འདྲ་བཤུས་བསུབ་ཐུབ་མེད། {{title}}",
   "{{percentage}}% used": "སྤྱོད་ཟིན་ {{percentage}}%",
-  "Resets in {{duration}}": "{{duration}} ནང་སླར་གསོ་བྱེད།",
   "Set PIN…": "PIN སྒྲིག་པ་…",
   "Require a 4-digit PIN to open Readest": "Readest ཁ་ཕྱེ་བར་ཨང་གྲངས་ ༤ ཡོད་པའི་ PIN ཞིག་དགོས",
   "Change PIN…": "PIN བརྗེ་བ་…",
@@ -1373,5 +1372,6 @@
   "App settings": "མཉེན་ཆས་སྒྲིག་འགོད།",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "བརྗོད་གཞི། གསལ་རྟགས་ཁ་དོག ཟུང་འབྲེལ་ (KOSync, Readwise, Hardcover) དང་ཚིག་མཛོད་ཀྱི་གོ་རིམ།",
   "Required while Dictionaries sync is enabled": "ཚིག་མཛོད་ཁག་མཉམ་འགྲོ་སྤྱོད་སྐབས་དགོས་མཁོ་ཡོད།",
-  "Unavailable": "བཀོལ་མི་ཐུབ།"
+  "Unavailable": "བཀོལ་མི་ཐུབ།",
+  "Resets in {{hours}} hr {{minutes}} min": "{{hours}} ཆུ་ཚོད་ {{minutes}} སྐར་མ་ནང་སླར་གསོ་བྱེད།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1339,7 +1339,6 @@
   "Failed to download file: {{title}}": "Fehler beim Herunterladen der Datei: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Fehler beim Löschen der Cloud-Kopie der Datei: {{title}}",
   "{{percentage}}% used": "{{percentage}}% verbraucht",
-  "Resets in {{duration}}": "Setzt sich in {{duration}} zurück",
   "Set PIN…": "PIN festlegen…",
   "Require a 4-digit PIN to open Readest": "Eine 4-stellige PIN zum Öffnen von Readest verlangen",
   "Change PIN…": "PIN ändern…",
@@ -1397,5 +1396,6 @@
   "App settings": "App-Einstellungen",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Design, Hervorhebungsfarben, Integrationen (KOSync, Readwise, Hardcover) und Wörterbuchreihenfolge",
   "Required while Dictionaries sync is enabled": "Erforderlich, solange die Synchronisierung von Wörterbüchern aktiviert ist",
-  "Unavailable": "Nicht verfügbar"
+  "Unavailable": "Nicht verfügbar",
+  "Resets in {{hours}} hr {{minutes}} min": "Zurückgesetzt in {{hours}} Std. {{minutes}} Min."
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1339,7 +1339,6 @@
   "Failed to download file: {{title}}": "Αποτυχία λήψης αρχείου: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Αποτυχία διαγραφής του αντιγράφου του αρχείου: {{title}}",
   "{{percentage}}% used": "{{percentage}}% σε χρήση",
-  "Resets in {{duration}}": "Επαναφορά σε {{duration}}",
   "Set PIN…": "Ορισμός PIN…",
   "Require a 4-digit PIN to open Readest": "Απαιτείται 4ψήφιο PIN για το άνοιγμα του Readest",
   "Change PIN…": "Αλλαγή PIN…",
@@ -1397,5 +1396,6 @@
   "App settings": "Ρυθμίσεις εφαρμογής",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Θέμα, χρώματα επισήμανσης, ενσωματώσεις (KOSync, Readwise, Hardcover) και σειρά λεξικών",
   "Required while Dictionaries sync is enabled": "Απαιτείται όσο είναι ενεργός ο συγχρονισμός Λεξικών",
-  "Unavailable": "Μη διαθέσιμο"
+  "Unavailable": "Μη διαθέσιμο",
+  "Resets in {{hours}} hr {{minutes}} min": "Επαναφορά σε {{hours}} ώρ. {{minutes}} λεπ."
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1363,7 +1363,6 @@
   "Failed to download file: {{title}}": "Error al descargar archivo: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Error al eliminar la copia en la nube del archivo: {{title}}",
   "{{percentage}}% used": "{{percentage}}% usado",
-  "Resets in {{duration}}": "Se restablece en {{duration}}",
   "Set PIN…": "Establecer PIN…",
   "Require a 4-digit PIN to open Readest": "Requerir un PIN de 4 dígitos para abrir Readest",
   "Change PIN…": "Cambiar PIN…",
@@ -1421,5 +1420,6 @@
   "App settings": "Ajustes de la aplicación",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, colores de resaltado, integraciones (KOSync, Readwise, Hardcover) y orden de los diccionarios",
   "Required while Dictionaries sync is enabled": "Necesario mientras la sincronización de Diccionarios esté activada",
-  "Unavailable": "No disponible"
+  "Unavailable": "No disponible",
+  "Resets in {{hours}} hr {{minutes}} min": "Se restablece en {{hours}} h {{minutes}} min"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1339,7 +1339,6 @@
   "Failed to download file: {{title}}": "دانلود فایل «{{title}}» ناموفق بود.",
   "Failed to delete cloud copy of the file: {{title}}": "حذف نسخه‌ی ابری فایل «{{title}}» ناموفق بود.",
   "{{percentage}}% used": "{{percentage}}٪ استفاده شده",
-  "Resets in {{duration}}": "بازنشانی در {{duration}}",
   "Set PIN…": "تنظیم PIN…",
   "Require a 4-digit PIN to open Readest": "برای باز کردن Readest یک PIN چهار رقمی الزامی شود",
   "Change PIN…": "تغییر PIN…",
@@ -1397,5 +1396,6 @@
   "App settings": "تنظیمات برنامه",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "پوسته، رنگ‌های هایلایت، یکپارچه‌سازی‌ها (KOSync، Readwise، Hardcover) و ترتیب فرهنگ‌لغت‌ها",
   "Required while Dictionaries sync is enabled": "هنگام فعال‌بودن همگام‌سازی فرهنگ‌لغت‌ها لازم است",
-  "Unavailable": "در دسترس نیست"
+  "Unavailable": "در دسترس نیست",
+  "Resets in {{hours}} hr {{minutes}} min": "تنظیم مجدد در {{hours}} ساعت {{minutes}} دقیقه"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1363,7 +1363,6 @@
   "Failed to download file: {{title}}": "Échec du téléchargement du fichier : {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Échec de la suppression de la copie cloud du fichier : {{title}}",
   "{{percentage}}% used": "{{percentage}} % utilisés",
-  "Resets in {{duration}}": "Réinitialisation dans {{duration}}",
   "Set PIN…": "Définir le PIN…",
   "Require a 4-digit PIN to open Readest": "Exiger un PIN à 4 chiffres pour ouvrir Readest",
   "Change PIN…": "Modifier le PIN…",
@@ -1421,5 +1420,6 @@
   "App settings": "Paramètres de l’application",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Thème, couleurs de surlignage, intégrations (KOSync, Readwise, Hardcover) et ordre des dictionnaires",
   "Required while Dictionaries sync is enabled": "Requis tant que la synchronisation des dictionnaires est activée",
-  "Unavailable": "Indisponible"
+  "Unavailable": "Indisponible",
+  "Resets in {{hours}} hr {{minutes}} min": "Réinitialisation dans {{hours}} h {{minutes}} min"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1363,7 +1363,6 @@
   "Failed to download file: {{title}}": "הורדת הקובץ נכשלה: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "מחיקת עותק הענן של הקובץ נכשלה: {{title}}",
   "{{percentage}}% used": "נוצלו {{percentage}}%",
-  "Resets in {{duration}}": "מתאפס בעוד {{duration}}",
   "Set PIN…": "הגדר PIN…",
   "Require a 4-digit PIN to open Readest": "דרוש PIN בן 4 ספרות כדי לפתוח את Readest",
   "Change PIN…": "שנה PIN…",
@@ -1421,5 +1420,6 @@
   "App settings": "הגדרות אפליקציה",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "ערכת נושא, צבעי הדגשה, שילובים (KOSync, Readwise, Hardcover) וסדר המילונים",
   "Required while Dictionaries sync is enabled": "נדרש כל עוד סנכרון המילונים מופעל",
-  "Unavailable": "לא זמין"
+  "Unavailable": "לא זמין",
+  "Resets in {{hours}} hr {{minutes}} min": "מתאפס בעוד {{hours}} ש׳ {{minutes}} ד׳"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1339,7 +1339,6 @@
   "Failed to download file: {{title}}": "फ़ाइल डाउनलोड करने में विफल: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "फ़ाइल की क्लाउड प्रति हटाने में विफल: {{title}}",
   "{{percentage}}% used": "{{percentage}}% उपयोग किया गया",
-  "Resets in {{duration}}": "{{duration}} में रीसेट होगा",
   "Set PIN…": "PIN सेट करें…",
   "Require a 4-digit PIN to open Readest": "Readest खोलने के लिए 4-अंकों का PIN आवश्यक करें",
   "Change PIN…": "PIN बदलें…",
@@ -1397,5 +1396,6 @@
   "App settings": "ऐप सेटिंग्स",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "थीम, हाइलाइट रंग, एकीकरण (KOSync, Readwise, Hardcover) और शब्दकोश क्रम",
   "Required while Dictionaries sync is enabled": "शब्दकोश सिंक सक्षम होने पर आवश्यक",
-  "Unavailable": "अनुपलब्ध"
+  "Unavailable": "अनुपलब्ध",
+  "Resets in {{hours}} hr {{minutes}} min": "{{hours}} घं {{minutes}} मि में रीसेट"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1339,7 +1339,6 @@
   "Failed to download file: {{title}}": "Fájl letöltése sikertelen: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Fájl felhőmásolatának törlése sikertelen: {{title}}",
   "{{percentage}}% used": "{{percentage}}% felhasználva",
-  "Resets in {{duration}}": "Visszaáll {{duration}} múlva",
   "Set PIN…": "PIN beállítása…",
   "Require a 4-digit PIN to open Readest": "4 jegyű PIN megkövetelése a Readest megnyitásához",
   "Change PIN…": "PIN módosítása…",
@@ -1397,5 +1396,6 @@
   "App settings": "Alkalmazásbeállítások",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Téma, kiemelési színek, integrációk (KOSync, Readwise, Hardcover) és szótárak sorrendje",
   "Required while Dictionaries sync is enabled": "Szükséges, amíg a Szótárak szinkronizálása be van kapcsolva",
-  "Unavailable": "Nem elérhető"
+  "Unavailable": "Nem elérhető",
+  "Resets in {{hours}} hr {{minutes}} min": "Visszaállás {{hours}} ó {{minutes}} p múlva"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1315,7 +1315,6 @@
   "Failed to download file: {{title}}": "Gagal mengunduh file: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Gagal menghapus salinan cloud file: {{title}}",
   "{{percentage}}% used": "{{percentage}}% terpakai",
-  "Resets in {{duration}}": "Disetel ulang dalam {{duration}}",
   "Set PIN…": "Atur PIN…",
   "Require a 4-digit PIN to open Readest": "Wajibkan PIN 4 digit untuk membuka Readest",
   "Change PIN…": "Ubah PIN…",
@@ -1373,5 +1372,6 @@
   "App settings": "Pengaturan aplikasi",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, warna sorotan, integrasi (KOSync, Readwise, Hardcover), dan urutan kamus",
   "Required while Dictionaries sync is enabled": "Diperlukan saat sinkronisasi Kamus diaktifkan",
-  "Unavailable": "Tidak tersedia"
+  "Unavailable": "Tidak tersedia",
+  "Resets in {{hours}} hr {{minutes}} min": "Direset dalam {{hours}} j {{minutes}} mnt"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1363,7 +1363,6 @@
   "Failed to download file: {{title}}": "Download file non riuscito: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Impossibile eliminare la copia cloud del file: {{title}}",
   "{{percentage}}% used": "{{percentage}}% utilizzato",
-  "Resets in {{duration}}": "Si reimposta tra {{duration}}",
   "Set PIN…": "Imposta PIN…",
   "Require a 4-digit PIN to open Readest": "Richiedi un PIN di 4 cifre per aprire Readest",
   "Change PIN…": "Cambia PIN…",
@@ -1421,5 +1420,6 @@
   "App settings": "Impostazioni app",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, colori delle evidenziazioni, integrazioni (KOSync, Readwise, Hardcover) e ordine dei dizionari",
   "Required while Dictionaries sync is enabled": "Necessario mentre la sincronizzazione dei Dizionari è attiva",
-  "Unavailable": "Non disponibile"
+  "Unavailable": "Non disponibile",
+  "Resets in {{hours}} hr {{minutes}} min": "Si reimposta tra {{hours}} h {{minutes}} min"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1315,7 +1315,6 @@
   "Failed to download file: {{title}}": "ファイルのダウンロードに失敗しました：{{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "ファイルのクラウドコピーの削除に失敗しました：{{title}}",
   "{{percentage}}% used": "{{percentage}}% 使用済み",
-  "Resets in {{duration}}": "{{duration}}でリセット",
   "Set PIN…": "PINを設定…",
   "Require a 4-digit PIN to open Readest": "Readestを開くのに4桁のPINを要求する",
   "Change PIN…": "PINを変更…",
@@ -1373,5 +1372,6 @@
   "App settings": "アプリ設定",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "テーマ、ハイライトの色、連携 (KOSync、Readwise、Hardcover)、辞書の順序",
   "Required while Dictionaries sync is enabled": "辞書の同期が有効な間は必須",
-  "Unavailable": "利用不可"
+  "Unavailable": "利用不可",
+  "Resets in {{hours}} hr {{minutes}} min": "{{hours}}時間{{minutes}}分でリセット"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1315,7 +1315,6 @@
   "Failed to download file: {{title}}": "파일 다운로드 실패: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "파일의 클라우드 사본 삭제에 실패했습니다: {{title}}",
   "{{percentage}}% used": "{{percentage}}% 사용됨",
-  "Resets in {{duration}}": "{{duration}} 후 재설정",
   "Set PIN…": "PIN 설정…",
   "Require a 4-digit PIN to open Readest": "Readest를 열 때 4자리 PIN 요구",
   "Change PIN…": "PIN 변경…",
@@ -1373,5 +1372,6 @@
   "App settings": "앱 설정",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "테마, 하이라이트 색상, 연동 (KOSync, Readwise, Hardcover), 사전 순서",
   "Required while Dictionaries sync is enabled": "사전 동기화가 켜져 있는 동안 필요",
-  "Unavailable": "사용 불가"
+  "Unavailable": "사용 불가",
+  "Resets in {{hours}} hr {{minutes}} min": "{{hours}}시간 {{minutes}}분 후 재설정"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1315,7 +1315,6 @@
   "Failed to download file: {{title}}": "Gagal memuat turun fail: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Gagal memadam salinan awan fail: {{title}}",
   "{{percentage}}% used": "{{percentage}}% telah digunakan",
-  "Resets in {{duration}}": "Set semula dalam {{duration}}",
   "Set PIN…": "Tetapkan PIN…",
   "Require a 4-digit PIN to open Readest": "Wajibkan PIN 4 digit untuk membuka Readest",
   "Change PIN…": "Tukar PIN…",
@@ -1373,5 +1372,6 @@
   "App settings": "Tetapan aplikasi",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, warna sorotan, integrasi (KOSync, Readwise, Hardcover), dan susunan kamus",
   "Required while Dictionaries sync is enabled": "Diperlukan semasa penyegerakan Kamus didayakan",
-  "Unavailable": "Tidak tersedia"
+  "Unavailable": "Tidak tersedia",
+  "Resets in {{hours}} hr {{minutes}} min": "Set semula dalam {{hours}} j {{minutes}} min"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1339,7 +1339,6 @@
   "Failed to download file: {{title}}": "Downloaden van bestand mislukt: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Verwijderen van cloudkopie van het bestand is mislukt: {{title}}",
   "{{percentage}}% used": "{{percentage}}% gebruikt",
-  "Resets in {{duration}}": "Reset over {{duration}}",
   "Set PIN…": "PIN instellen…",
   "Require a 4-digit PIN to open Readest": "4-cijferige PIN vereisen om Readest te openen",
   "Change PIN…": "PIN wijzigen…",
@@ -1397,5 +1396,6 @@
   "App settings": "App-instellingen",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Thema, markeringskleuren, integraties (KOSync, Readwise, Hardcover) en woordenboekvolgorde",
   "Required while Dictionaries sync is enabled": "Vereist zolang synchronisatie van Woordenboeken is ingeschakeld",
-  "Unavailable": "Niet beschikbaar"
+  "Unavailable": "Niet beschikbaar",
+  "Resets in {{hours}} hr {{minutes}} min": "Reset over {{hours}} u {{minutes}} min"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1387,7 +1387,6 @@
   "Failed to download file: {{title}}": "Nie udało się pobrać pliku: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Nie udało się usunąć kopii pliku w chmurze: {{title}}",
   "{{percentage}}% used": "Wykorzystano {{percentage}}%",
-  "Resets in {{duration}}": "Resetuje się za {{duration}}",
   "Set PIN…": "Ustaw PIN…",
   "Require a 4-digit PIN to open Readest": "Wymagaj 4-cyfrowego PIN-u do otwarcia Readest",
   "Change PIN…": "Zmień PIN…",
@@ -1445,5 +1444,6 @@
   "App settings": "Ustawienia aplikacji",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Motyw, kolory podświetleń, integracje (KOSync, Readwise, Hardcover) oraz kolejność słowników",
   "Required while Dictionaries sync is enabled": "Wymagane, gdy włączona jest synchronizacja Słowników",
-  "Unavailable": "Niedostępne"
+  "Unavailable": "Niedostępne",
+  "Resets in {{hours}} hr {{minutes}} min": "Resetuje się za {{hours}} godz. {{minutes}} min"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1364,7 +1364,6 @@
   "Failed to download file: {{title}}": "Falha ao baixar arquivo: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Falha ao excluir cópia na nuvem do arquivo: {{title}}",
   "{{percentage}}% used": "{{percentage}}% utilizado",
-  "Resets in {{duration}}": "Redefine em {{duration}}",
   "Set PIN…": "Definir PIN…",
   "Require a 4-digit PIN to open Readest": "Exigir um PIN de 4 dígitos para abrir o Readest",
   "Change PIN…": "Alterar PIN…",
@@ -1421,5 +1420,6 @@
   "Manage Fonts": "Gerenciar fontes",
   "Wrong sync passphrase — synced credentials could not be decrypted": "Senha de sincronização incorreta — não foi possível descriptografar as credenciais sincronizadas",
   "Sync passphrase data on the server was reset. Re-encrypting your credentials under the new passphrase…": "Os dados da senha de sincronização no servidor foram redefinidos. Recriptografando suas credenciais com a nova senha…",
-  "Failed to decrypt synced credentials": "Falha ao descriptografar credenciais sincronizadas"
+  "Failed to decrypt synced credentials": "Falha ao descriptografar credenciais sincronizadas",
+  "Resets in {{hours}} hr {{minutes}} min": "Redefine em {{hours}} h {{minutes}} min"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1363,7 +1363,6 @@
   "Failed to download file: {{title}}": "Falha ao baixar arquivo: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Falha ao excluir cópia na nuvem do arquivo: {{title}}",
   "{{percentage}}% used": "{{percentage}}% utilizado",
-  "Resets in {{duration}}": "Repõe em {{duration}}",
   "Set PIN…": "Definir PIN…",
   "Require a 4-digit PIN to open Readest": "Exigir um PIN de 4 dígitos para abrir o Readest",
   "Change PIN…": "Alterar PIN…",
@@ -1421,5 +1420,6 @@
   "App settings": "Configurações do app",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, cores de destaque, integrações (KOSync, Readwise, Hardcover) e ordem dos dicionários",
   "Required while Dictionaries sync is enabled": "Necessário enquanto a sincronização de Dicionários estiver ativada",
-  "Unavailable": "Indisponível"
+  "Unavailable": "Indisponível",
+  "Resets in {{hours}} hr {{minutes}} min": "Repõe em {{hours}} h {{minutes}} min"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1363,7 +1363,6 @@
   "Failed to download file: {{title}}": "Nu s-a putut descărca fișierul: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Nu s-a putut șterge copia din cloud a fișierului: {{title}}",
   "{{percentage}}% used": "{{percentage}}% utilizat",
-  "Resets in {{duration}}": "Se resetează în {{duration}}",
   "Set PIN…": "Setează PIN…",
   "Require a 4-digit PIN to open Readest": "Solicită un PIN de 4 cifre pentru a deschide Readest",
   "Change PIN…": "Schimbă PIN…",
@@ -1421,5 +1420,6 @@
   "App settings": "Setări aplicație",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Temă, culorile evidențierilor, integrări (KOSync, Readwise, Hardcover) și ordinea dicționarelor",
   "Required while Dictionaries sync is enabled": "Necesar cât timp sincronizarea Dicționarelor este activată",
-  "Unavailable": "Indisponibil"
+  "Unavailable": "Indisponibil",
+  "Resets in {{hours}} hr {{minutes}} min": "Se resetează în {{hours}} h {{minutes}} min"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1387,7 +1387,6 @@
   "Failed to download file: {{title}}": "Не удалось скачать файл: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Не удалось удалить копию файла в облаке: {{title}}",
   "{{percentage}}% used": "Использовано {{percentage}}%",
-  "Resets in {{duration}}": "Сброс через {{duration}}",
   "Set PIN…": "Установить PIN…",
   "Require a 4-digit PIN to open Readest": "Запрашивать 4-значный PIN при открытии Readest",
   "Change PIN…": "Изменить PIN…",
@@ -1445,5 +1444,6 @@
   "App settings": "Настройки приложения",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Тема, цвета выделений, интеграции (KOSync, Readwise, Hardcover) и порядок словарей",
   "Required while Dictionaries sync is enabled": "Требуется, пока включена синхронизация Словарей",
-  "Unavailable": "Недоступно"
+  "Unavailable": "Недоступно",
+  "Resets in {{hours}} hr {{minutes}} min": "Сброс через {{hours}} ч {{minutes}} мин"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1339,7 +1339,6 @@
   "Failed to download file: {{title}}": "ගොනුව බාගැනීමට අසමත්: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "ගොනුවේ cloud පිටපත මකා දැමීමට අසමත්: {{title}}",
   "{{percentage}}% used": "{{percentage}}% භාවිතයි",
-  "Resets in {{duration}}": "{{duration}}කින් යළි පිහිටුවයි",
   "Set PIN…": "PIN සකසන්න…",
   "Require a 4-digit PIN to open Readest": "Readest විවෘත කිරීමට ඉලක්කම් 4ක PIN එකක් ඉල්ලන්න",
   "Change PIN…": "PIN වෙනස් කරන්න…",
@@ -1397,5 +1396,6 @@
   "App settings": "යෙදුමේ සැකසුම්",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "තේමාව, උද්දීපන වර්ණ, ඒකාබද්ධතා (KOSync, Readwise, Hardcover) සහ ශබ්දකෝෂ අනුපිළිවෙල",
   "Required while Dictionaries sync is enabled": "ශබ්දකෝෂ සමමුහූර්තය සක්‍රිය වී ඇති විට අවශ්‍යයි",
-  "Unavailable": "ලද නොහැක"
+  "Unavailable": "ලද නොහැක",
+  "Resets in {{hours}} hr {{minutes}} min": "{{hours}} පැ {{minutes}} මි කින් යළි පිහිටුවයි"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1387,7 +1387,6 @@
   "Failed to download file: {{title}}": "Prenos datoteke ni uspel: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Brisanje kopije datoteke v oblaku ni uspelo: {{title}}",
   "{{percentage}}% used": "{{percentage}} % uporabljeno",
-  "Resets in {{duration}}": "Ponastavi se čez {{duration}}",
   "Set PIN…": "Nastavi PIN…",
   "Require a 4-digit PIN to open Readest": "Za odpiranje Readest zahtevaj 4-mestni PIN",
   "Change PIN…": "Spremeni PIN…",
@@ -1445,5 +1444,6 @@
   "App settings": "Nastavitve aplikacije",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, barve označb, integracije (KOSync, Readwise, Hardcover) in vrstni red slovarjev",
   "Required while Dictionaries sync is enabled": "Zahtevano, dokler je sinhronizacija Slovarjev omogočena",
-  "Unavailable": "Ni na voljo"
+  "Unavailable": "Ni na voljo",
+  "Resets in {{hours}} hr {{minutes}} min": "Ponastavi se čez {{hours}} h {{minutes}} min"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1339,7 +1339,6 @@
   "Failed to download file: {{title}}": "Kunde inte ladda ner fil: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Kunde inte radera molnkopia av fil: {{title}}",
   "{{percentage}}% used": "{{percentage}} % använt",
-  "Resets in {{duration}}": "Återställs om {{duration}}",
   "Set PIN…": "Ange PIN…",
   "Require a 4-digit PIN to open Readest": "Kräv en 4-siffrig PIN för att öppna Readest",
   "Change PIN…": "Ändra PIN…",
@@ -1397,5 +1396,6 @@
   "App settings": "Appinställningar",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, markeringsfärger, integrationer (KOSync, Readwise, Hardcover) och ordbokens ordning",
   "Required while Dictionaries sync is enabled": "Krävs så länge synkronisering av Ordböcker är aktiverad",
-  "Unavailable": "Ej tillgänglig"
+  "Unavailable": "Ej tillgänglig",
+  "Resets in {{hours}} hr {{minutes}} min": "Återställs om {{hours}} tim {{minutes}} min"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1339,7 +1339,6 @@
   "Failed to download file: {{title}}": "கோப்பை பதிவிறக்க முடியவில்லை: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "கோப்பின் cloud நகலை நீக்க முடியவில்லை: {{title}}",
   "{{percentage}}% used": "{{percentage}}% பயன்படுத்தப்பட்டது",
-  "Resets in {{duration}}": "{{duration}} இல் மீட்டமைக்கப்படும்",
   "Set PIN…": "PIN ஐ அமை…",
   "Require a 4-digit PIN to open Readest": "Readest ஐ திறக்க 4-இலக்க PIN ஐ கேள்",
   "Change PIN…": "PIN ஐ மாற்று…",
@@ -1397,5 +1396,6 @@
   "App settings": "ஆப் அமைப்புகள்",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "தீம், ஹைலைட் வண்ணங்கள், ஒருங்கிணைப்புகள் (KOSync, Readwise, Hardcover) மற்றும் அகராதி வரிசை",
   "Required while Dictionaries sync is enabled": "அகராதிகள் ஒத்திசைவு இயக்கத்தில் இருக்கும்போது தேவை",
-  "Unavailable": "கிடைக்கவில்லை"
+  "Unavailable": "கிடைக்கவில்லை",
+  "Resets in {{hours}} hr {{minutes}} min": "{{hours}} மணி {{minutes}} நிமிடத்தில் மீட்டமைக்கப்படும்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1315,7 +1315,6 @@
   "Failed to download file: {{title}}": "ไม่สามารถดาวน์โหลดไฟล์: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "ไม่สามารถลบสำเนาไฟล์บนคลาวด์: {{title}}",
   "{{percentage}}% used": "ใช้ไปแล้ว {{percentage}}%",
-  "Resets in {{duration}}": "รีเซ็ตใน {{duration}}",
   "Set PIN…": "ตั้งค่า PIN…",
   "Require a 4-digit PIN to open Readest": "ต้องใช้ PIN 4 หลักเพื่อเปิด Readest",
   "Change PIN…": "เปลี่ยน PIN…",
@@ -1373,5 +1372,6 @@
   "App settings": "การตั้งค่าแอป",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "ธีม สีไฮไลต์ การเชื่อมต่อ (KOSync, Readwise, Hardcover) และลำดับพจนานุกรม",
   "Required while Dictionaries sync is enabled": "จำเป็นเมื่อเปิดใช้การซิงค์พจนานุกรม",
-  "Unavailable": "ไม่พร้อมใช้งาน"
+  "Unavailable": "ไม่พร้อมใช้งาน",
+  "Resets in {{hours}} hr {{minutes}} min": "รีเซ็ตใน {{hours}} ชม. {{minutes}} นาที"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1339,7 +1339,6 @@
   "Failed to download file: {{title}}": "Dosya indirilemedi: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Dosyanın bulut kopyasını silme başarısız oldu: {{title}}",
   "{{percentage}}% used": "%{{percentage}} kullanıldı",
-  "Resets in {{duration}}": "{{duration}} sonra sıfırlanır",
   "Set PIN…": "PIN Belirle…",
   "Require a 4-digit PIN to open Readest": "Readest'i açmak için 4 haneli PIN iste",
   "Change PIN…": "PIN Değiştir…",
@@ -1397,5 +1396,6 @@
   "App settings": "Uygulama ayarları",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, vurgu renkleri, entegrasyonlar (KOSync, Readwise, Hardcover) ve sözlük sırası",
   "Required while Dictionaries sync is enabled": "Sözlük eşitlemesi etkinken gereklidir",
-  "Unavailable": "Kullanılamıyor"
+  "Unavailable": "Kullanılamıyor",
+  "Resets in {{hours}} hr {{minutes}} min": "{{hours}} sa {{minutes}} dk içinde sıfırlanır"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1387,7 +1387,6 @@
   "Failed to download file: {{title}}": "Не вдалося завантажити файл: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Не вдалося видалити копію файлу в хмарі: {{title}}",
   "{{percentage}}% used": "Використано {{percentage}}%",
-  "Resets in {{duration}}": "Скидання через {{duration}}",
   "Set PIN…": "Установити PIN…",
   "Require a 4-digit PIN to open Readest": "Вимагати 4-значний PIN для відкриття Readest",
   "Change PIN…": "Змінити PIN…",
@@ -1445,5 +1444,6 @@
   "App settings": "Налаштування застосунку",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Тема, кольори виділень, інтеграції (KOSync, Readwise, Hardcover) і порядок словників",
   "Required while Dictionaries sync is enabled": "Потрібне, доки увімкнено синхронізацію Словників",
-  "Unavailable": "Недоступно"
+  "Unavailable": "Недоступно",
+  "Resets in {{hours}} hr {{minutes}} min": "Скидання через {{hours}} год {{minutes}} хв"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1340,7 +1340,6 @@
   "Failed to download file: {{title}}": "Faylni yuklab boʻlmadi: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Faylning bulutdagi nusxasini oʻchirib boʻlmadi: {{title}}",
   "{{percentage}}% used": "{{percentage}}% ishlatilgan",
-  "Resets in {{duration}}": "{{duration}} dan keyin tiklanadi",
   "Set PIN…": "PIN o'rnatish…",
   "Require a 4-digit PIN to open Readest": "Readest'ni ochish uchun 4 xonali PIN talab qilish",
   "Change PIN…": "PIN'ni o'zgartirish…",
@@ -1397,5 +1396,6 @@
   "Manage Fonts": "Shriftlarni boshqarish",
   "Wrong sync passphrase — synced credentials could not be decrypted": "Sinxronlash paroli notoʻgʻri — sinxronlangan hisob maʼlumotlari shifrini ochib boʻlmadi",
   "Sync passphrase data on the server was reset. Re-encrypting your credentials under the new passphrase…": "Serverdagi sinxronlash paroli maʼlumotlari tiklandi. Hisob maʼlumotlaringiz yangi parol bilan qayta shifrlanmoqda…",
-  "Failed to decrypt synced credentials": "Sinxronlangan hisob maʼlumotlari shifrini ochib boʻlmadi"
+  "Failed to decrypt synced credentials": "Sinxronlangan hisob maʼlumotlari shifrini ochib boʻlmadi",
+  "Resets in {{hours}} hr {{minutes}} min": "{{hours}} soat {{minutes}} daqiqada tiklanadi"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1315,7 +1315,6 @@
   "Failed to download file: {{title}}": "Không thể tải về tệp: {{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "Không thể xóa bản sao đám mây của tệp: {{title}}",
   "{{percentage}}% used": "Đã dùng {{percentage}}%",
-  "Resets in {{duration}}": "Đặt lại sau {{duration}}",
   "Set PIN…": "Đặt mã PIN…",
   "Require a 4-digit PIN to open Readest": "Yêu cầu mã PIN 4 chữ số để mở Readest",
   "Change PIN…": "Thay đổi mã PIN…",
@@ -1373,5 +1372,6 @@
   "App settings": "Cài đặt ứng dụng",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Chủ đề, màu tô sáng, tích hợp (KOSync, Readwise, Hardcover) và thứ tự từ điển",
   "Required while Dictionaries sync is enabled": "Bắt buộc khi đồng bộ Từ điển đang bật",
-  "Unavailable": "Không khả dụng"
+  "Unavailable": "Không khả dụng",
+  "Resets in {{hours}} hr {{minutes}} min": "Đặt lại sau {{hours}} g {{minutes}} ph"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1315,7 +1315,6 @@
   "Failed to download file: {{title}}": "下载文件失败：{{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "未能删除文件云副本：{{title}}",
   "{{percentage}}% used": "已使用 {{percentage}}%",
-  "Resets in {{duration}}": "{{duration}}后重置",
   "Set PIN…": "设置 PIN 码…",
   "Require a 4-digit PIN to open Readest": "打开 Readest 时需要输入 4 位 PIN 码",
   "Change PIN…": "更改 PIN 码…",
@@ -1373,5 +1372,6 @@
   "App settings": "应用设置",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "主题、高亮颜色、第三方集成（KOSync、Readwise、Hardcover）以及词典顺序",
   "Required while Dictionaries sync is enabled": "启用词典同步时必需",
-  "Unavailable": "不可用"
+  "Unavailable": "不可用",
+  "Resets in {{hours}} hr {{minutes}} min": "{{hours}} 小时 {{minutes}} 分钟后重置"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1315,7 +1315,6 @@
   "Failed to download file: {{title}}": "檔案下載失敗：{{title}}",
   "Failed to delete cloud copy of the file: {{title}}": "未能刪除檔案的雲端副本：{{title}}",
   "{{percentage}}% used": "已使用 {{percentage}}%",
-  "Resets in {{duration}}": "{{duration}}後重設",
   "Set PIN…": "設定 PIN 碼…",
   "Require a 4-digit PIN to open Readest": "開啟 Readest 時需要輸入 4 位 PIN 碼",
   "Change PIN…": "變更 PIN 碼…",
@@ -1373,5 +1372,6 @@
   "App settings": "應用程式設定",
   "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "主題、螢光標記顏色、第三方整合（KOSync、Readwise、Hardcover）以及詞典順序",
   "Required while Dictionaries sync is enabled": "啟用詞典同步時必須",
-  "Unavailable": "無法使用"
+  "Unavailable": "無法使用",
+  "Resets in {{hours}} hr {{minutes}} min": "{{hours}} 小時 {{minutes}} 分鐘後重設"
 }

--- a/apps/readest-app/src/components/Quota.tsx
+++ b/apps/readest-app/src/components/Quota.tsx
@@ -1,8 +1,6 @@
 import clsx from 'clsx';
-import dayjs from 'dayjs';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from '@/hooks/useTranslation';
-import '@/utils/time';
 
 type QuotaProps = {
   quotas: {
@@ -44,9 +42,11 @@ const Quota: React.FC<QuotaProps> = ({ quotas, showProgress, className, labelCla
         }
 
         const showResetRow = showProgress && quota.resetAt;
-        const resetIn = showResetRow
-          ? dayjs.duration(Math.max(0, quota.resetAt! - now)).format('H [hr] m [min]')
-          : '';
+        const totalMinutes = showResetRow
+          ? Math.floor(Math.max(0, quota.resetAt! - now) / 60_000)
+          : 0;
+        const resetHours = Math.floor(totalMinutes / 60);
+        const resetMinutes = totalMinutes % 60;
 
         return (
           <div key={quota.name} className='w-full'>
@@ -85,7 +85,12 @@ const Quota: React.FC<QuotaProps> = ({ quotas, showProgress, className, labelCla
                 )}
               >
                 <span>{_('{{percentage}}% used', { percentage: usagePercentageRounded })}</span>
-                <span>{_('Resets in {{duration}}', { duration: resetIn })}</span>
+                <span>
+                  {_('Resets in {{hours}} hr {{minutes}} min', {
+                    hours: resetHours,
+                    minutes: resetMinutes,
+                  })}
+                </span>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

- The quota "Resets in" countdown on the user page formatted its duration via `dayjs.duration().format('H [hr] m [min]')`, baking English `hr` / `min` literals into the rendered string. Non-English locales got mixed output like `18 hr 6 min后重置`.
- Move the unit literals into the translation key itself — `Resets in {{hours}} hr {{minutes}} min` — so each locale controls word order and abbreviation. Compute hours/minutes inline; drop the unused `dayjs` / `@/utils/time` imports in `Quota.tsx`.
- Translated the new key for all 33 shipped locales (zh-CN: `{{hours}} 小时 {{minutes}} 分钟后重置`, etc.); `pnpm i18n:extract` removed the now-unused `Resets in {{duration}}` key.

## Test plan

- [x] `pnpm test` (4096 passed)
- [x] `pnpm lint`
- [x] Verified zh-CN renders e.g. `18 小时 6 分钟后重置`

🤖 Generated with [Claude Code](https://claude.com/claude-code)