### PR TITLE
fix(koreader-sync): populate chapter field on synced annotations

### DIFF
--- a/apps/readest.koplugin/syncannotations.lua
+++ b/apps/readest.koplugin/syncannotations.lua
@@ -300,6 +300,10 @@ function SyncAnnotations:pull(ui, settings, client, book_hash, meta_hash, dialog
 
                 -- Resolve KOReader page number from xpointer
                 local pageno = ui.document:getPageFromXPointer(xp0) or note.page
+                -- Resolve chapter title so downstream tools can group by chapter,
+                -- matching native KOReader highlight creation behavior.
+                local chapter = ui.toc and ui.toc:getTocTitleByPage(xp0) or nil
+                if chapter == "" then chapter = nil end
 
                 if note_type == "bookmark" then
                     if existing_bookmarks[xp0] then goto continue end
@@ -309,6 +313,7 @@ function SyncAnnotations:pull(ui, settings, client, book_hash, meta_hash, dialog
                         page = xp0,
                         text = note.text or "",
                         note = note.note or "",
+                        chapter = chapter,
                         pageno = pageno,
                         datetime = datetime_str,
                         datetime_updated = datetime_updated_str,
@@ -335,6 +340,7 @@ function SyncAnnotations:pull(ui, settings, client, book_hash, meta_hash, dialog
                         note = note.note or "",
                         drawer = drawer,
                         color = READEST_TO_KO_COLOR[note.color] or "yellow",
+                        chapter = chapter,
                         pageno = pageno,
                         datetime = datetime_str,
                         datetime_updated = datetime_updated_str,


### PR DESCRIPTION
## Summary

- Resolve and stamp the `chapter` field on annotations and bookmarks inserted into KOReader via Readest sync, matching native KOReader highlight-creation behavior.
- Fixes downstream chapter grouping in tools like [obsidian-koreader-highlights](https://github.com/t5k6/obsidian-koreader-highlights) and KOReader's built-in Markdown exporter, which previously rendered Readest-synced items as "Chapter Unknown" or omitted chapter headings.

Closes #4133.

## What changed

In `apps/readest.koplugin/syncannotations.lua` (pull path), resolve the chapter title via `ui.toc:getTocTitleByPage(xp0)` — the same call `ReaderHighlight` uses when creating native highlights — and add the resulting `chapter` field to both the annotation and bookmark item tables. Empty results and missing `ui.toc` are normalized to `nil`.

## Why this approach

- **Mirrors native behavior.** KOReader's `ReaderHighlight` populates `chapter` via `self.ui.toc:getTocTitleByPage(pg_or_xp)` at highlight-creation time. Using the same call here means Readest-synced items become indistinguishable in shape from natively-created ones.
- **Defensive.** Guards against `ui.toc` being unavailable (returns `nil`) and against empty-string TOC misses (normalized to `nil` so absent ≠ literal empty).
- **Minimal surface.** Six-line diff, no schema or API changes.

## Test plan

- [ ] Sync a Readest-side highlight into a KOReader device that has the Readest plugin installed
- [ ] Confirm the resulting entry in `<book>.sdr/metadata.epub.lua` includes `["chapter"] = "<title>"`
- [ ] Confirm a Readest-side bookmark inserts with the chapter field as well
- [ ] Confirm books without a resolvable TOC (or front/back matter positions) don't error — `chapter` should be omitted/`nil`, not crash

I don't have a Readest dev environment set up locally — running `pnpm build` per CONTRIBUTING wouldn't exercise the Lua plugin path anyway. Happy to add a spec if `syncannotations` is expected to be covered.