### PR TITLE
feat(android): upgrade in-process WebView on devices stuck on old system WebView

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "packages/js-mdict"]
 	path = packages/js-mdict
 	url = https://github.com/readest/js-mdict.git
+[submodule "apps/readest-app/src-tauri/plugins/tauri-plugin-webview-upgrade"]
+	path = apps/readest-app/src-tauri/plugins/tauri-plugin-webview-upgrade
+	url = https://github.com/readest/tauri-plugin-webview-upgrade.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-webdriver",
  "tauri-plugin-websocket",
+ "tauri-plugin-webview-upgrade",
  "tauri-plugin-window-state",
  "thiserror 2.0.18",
  "tokio",
@@ -7864,6 +7865,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
+]
+
+[[package]]
+name = "tauri-plugin-webview-upgrade"
+version = "0.1.0"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/apps/readest-app/src-tauri/Cargo.toml
+++ b/apps/readest-app/src-tauri/Cargo.toml
@@ -56,6 +56,7 @@ tauri-plugin-haptics = "2"
 tauri-plugin-persisted-scope = "2"
 tauri-plugin-native-bridge = { path = "./plugins/tauri-plugin-native-bridge" }
 tauri-plugin-native-tts = { path = "./plugins/tauri-plugin-native-tts" }
+tauri-plugin-webview-upgrade = { path = "./plugins/tauri-plugin-webview-upgrade" }
 tauri-plugin-websocket = "2"
 tauri-plugin-sharekit = "0.3"
 tauri-plugin-device-info = "1.0.1"

--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -191,7 +191,8 @@ pub fn run() {
         .plugin(tauri_plugin_device_info::init())
         .plugin(tauri_plugin_turso::init())
         .plugin(tauri_plugin_native_bridge::init())
-        .plugin(tauri_plugin_native_tts::init());
+        .plugin(tauri_plugin_native_tts::init())
+        .plugin(tauri_plugin_webview_upgrade::init());
 
     #[cfg(desktop)]
     let builder = builder.plugin(

--- a/apps/readest-app/src-tauri/tauri.conf.json
+++ b/apps/readest-app/src-tauri/tauri.conf.json
@@ -172,6 +172,10 @@
         "https://download.readest.com/releases/latest.json",
         "https://github.com/readest/readest/releases/latest/download/latest.json"
       ]
+    },
+    "webview-upgrade": {
+      "minUpgradeMajor": 121,
+      "minSupportedMajor": 92
     }
   }
 }


### PR DESCRIPTION
On Android devices whose system WebView is locked to an old Chromium build (Huawei phones, Moaan / Onyx / Kobo e-ink readers, AOSP forks without Play Store, etc.), the reader bundle renders as a blank screen. The plugin bootstraps before Application.onCreate via androidx.startup and redirects the in-process WebView loader to a recent com.google.android.webview when the user has one sideloaded — opening the only window in which WebViewUpgrade can swap the provider, before Tauri/Wry creates any WebView.

Thresholds (minUpgradeMajor / minSupportedMajor) come from plugins.webview-upgrade in tauri.conf.json and are baked into Kotlin constants at Gradle build time. Below the supported threshold with no upgrade option, the plugin shows a localized AlertDialog (15 languages, English fallback) prompting the user to install Android System WebView.

Plugin source: https://github.com/readest/tauri-plugin-webview-upgrade