### PR TITLE
fix(dev): rewrite HMR WebSocket URL in Tauri mobile dev

### DIFF
--- a/apps/readest-app/src/app/layout.tsx
+++ b/apps/readest-app/src/app/layout.tsx
@@ -72,12 +72,67 @@ export const viewport: Viewport = {
   // unrecognized key on every page load, so we keep it out of SSR.
 };
 
+// In Tauri mobile dev the page origin doesn't match the dev server, so
+// Next.js's `getSocketUrl` builds an unreachable HMR URL (see
+// `next/dist/client/dev/hot-reloader/get-socket-url.js`):
+//   - iOS sim:        page at `tauri://localhost`        → `wss://localhost/_next/...`
+//     (no port, non-http scheme falls through to `wss:`)
+//   - Android emul.:  page at `http://tauri.localhost`   → `ws://tauri.localhost/_next/...`
+//     (`tauri.localhost` is intercepted by Tauri's asset handler, but
+//     WebSocket frames bypass the interceptor and the dev server is on the
+//     host machine, reachable from the emulator as `10.0.2.2`)
+// Rewrite the WebSocket constructor before the HMR client runs.
+// When `--host <ip>` is passed, tauri-cli exports `TAURI_DEV_HOST=<ip>`
+// before invoking `beforeDevCommand`, so we forward that as `devHost` and
+// use it for the rewrite (the dev server must also bind to the same address
+// — typically `next dev -H 0.0.0.0`).
+function patchTauriHmrWebSocket(devHost?: string) {
+  const isIosTauriProxy = location.protocol === 'tauri:' && location.hostname === 'localhost';
+  const isAndroidTauriProxy =
+    location.protocol === 'http:' && location.hostname === 'tauri.localhost';
+  if (!isIosTauriProxy && !isAndroidTauriProxy) return;
+
+  // Priority: explicit --host > platform default loopback alias.
+  // iOS Simulator can reach the host's localhost directly.
+  // Android emulator reaches the host machine via 10.0.2.2.
+  const hmrHost = devHost
+    ? `${devHost}:3000`
+    : isIosTauriProxy
+      ? 'localhost:3000'
+      : '10.0.2.2:3000';
+  const brokenHostPattern = /^wss?:\/\/(localhost|tauri\.localhost)(?=\/_next\/)/;
+
+  const OriginalWebSocket = window.WebSocket;
+  class PatchedWebSocket extends OriginalWebSocket {
+    constructor(url: string | URL, protocols?: string | string[]) {
+      const urlStr = url instanceof URL ? url.href : url;
+      const rewritten =
+        typeof urlStr === 'string' && brokenHostPattern.test(urlStr)
+          ? urlStr.replace(brokenHostPattern, `ws://${hmrHost}`)
+          : url;
+      super(rewritten, protocols);
+    }
+  }
+  window.WebSocket = PatchedWebSocket;
+}
+
+const shouldInjectDevHmrPatch =
+  process.env['NODE_ENV'] === 'development' && process.env['NEXT_PUBLIC_APP_PLATFORM'] === 'tauri';
+const devHmrPatchScript = `(${patchTauriHmrWebSocket.toString()})(${JSON.stringify(
+  process.env['TAURI_DEV_HOST'],
+)});`;
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html
       lang='en'
       className={process.env['NEXT_PUBLIC_APP_PLATFORM'] === 'tauri' ? 'edge-to-edge' : ''}
     >
+      {shouldInjectDevHmrPatch ? (
+        <head>
+          <script dangerouslySetInnerHTML={{ __html: devHmrPatchScript }} />
+        </head>
+      ) : null}
       <body>
         <ViewTransitions>
           <EnvProvider>


### PR DESCRIPTION
## Summary
- Fixes blank screen in `pnpm tauri ios dev` / `pnpm tauri android dev` (closes #4150).
- Root cause: in Tauri mobile proxy mode the page origin doesn't match the dev server, so Next.js's `getSocketUrl` (in `next/dist/client/dev/hot-reloader/get-socket-url.js`) builds an HMR URL that can't reach the dev server:
  - iOS sim — page at `tauri://localhost` → `wss://localhost/_next/webpack-hmr` (no port; non-http scheme falls through to `wss:`).
  - Android emulator — page at `http://tauri.localhost` → `ws://tauri.localhost/_next/webpack-hmr` (`tauri.localhost` is intercepted by Tauri's asset handler, but WebSocket frames bypass the interceptor).
- The HMR client retries forever, never connects, and the Turbopack runtime's chunk loader never finishes wiring up — page stays blank.

## Fix
- `src/app/layout.tsx`: a dev-only `<head>` inline script that subclasses `window.WebSocket` and rewrites the broken HMR URL to the reachable dev server before the HMR client runs:
  - iOS Simulator → `ws://localhost:3000/_next/...`
  - Android emulator → `ws://10.0.2.2:3000/_next/...`
- The patch function is real TS in source (type-checked, lint-checked); it's serialized to inline JS at SSR via `.toString()`.
- `TAURI_DEV_HOST` is forwarded as the function argument so `--host <ip>` routes HMR through the LAN address. The function is a no-op outside Tauri mobile proxy mode (so desktop Tauri dev and any future direct-load path are unaffected).
- Gated by `NODE_ENV === 'development' && NEXT_PUBLIC_APP_PLATFORM === 'tauri'` — prod and web bundles get nothing.

## Caveat for `--host`
When `--host <ip>` is passed, tauri-cli exports `TAURI_DEV_HOST` and rewrites devUrl, but does **not** change how `next dev` binds. To make `--host` work end-to-end you also need the dev server on the LAN — e.g. `next dev -H 0.0.0.0`. Not changing the dev script here since the default (`pnpm tauri {ios,android} dev`) is the more common path and works without it.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` — 4182 passed, 8 skipped
- [x] Confirmed in iOS Simulator (iPhone 16 Pro, iOS 26): `pnpm tauri ios dev` now boots into "Start your library" instead of a blank screen; HMR WebSocket connects to `ws://localhost:3000`.
- [x] Confirm on Android emulator: `pnpm tauri android dev` boots into the app and HMR connects to `ws://10.0.2.2:3000`.
- [x] Confirm `pnpm tauri {ios,android} dev --host <lan-ip>` with `next dev -H 0.0.0.0` routes HMR through the LAN IP.
- [x] Confirm desktop `pnpm tauri dev` and web `pnpm dev-web` are unaffected (patch should be inert there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)