### PR TITLE
fix(opds): show summary as book description, closes #4156

### DIFF
--- a/apps/readest-app/src/__tests__/utils/opds-feed.test.ts
+++ b/apps/readest-app/src/__tests__/utils/opds-feed.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { getFeed, getPublication } from 'foliate-js/opds.js';
-import type { OPDSFeed, OPDSPublication } from '@/types/opds';
+import { SYMBOL, type OPDSFeed, type OPDSPublication } from '@/types/opds';
 
 const MIME_XML = 'application/xml';
 
@@ -220,6 +220,33 @@ describe('OPDS feed parsing', () => {
 
       expect(pub.metadata.id).toBe('urn:shelf:issue:abc123');
       expect(pub.metadata.updated).toBe('2026-01-15T10:30:00.000Z');
+    });
+
+    // Regression test for https://github.com/readest/readest/issues/4156
+    // CWA (and other OPDS 1.x servers) place the book description in
+    // <entry><summary>. foliate-js attaches it under SYMBOL.CONTENT, so the
+    // SYMBOL exported from @/types/opds must be the same Symbol instance the
+    // parser writes — otherwise PublicationView reads undefined and the
+    // description disappears from the book details page.
+    it('should expose <summary> via SYMBOL.CONTENT for OPDS 1.x feeds', () => {
+      const opds1Feed = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>CWA Library</title>
+  <entry>
+    <title>A Book With A Summary</title>
+    <summary>A short blurb describing the book, set by the OPDS server in &lt;summary&gt;.</summary>
+    <link rel="http://opds-spec.org/acquisition"
+          href="book.epub" type="application/epub+zip"/>
+  </entry>
+</feed>`;
+      const doc = parseXML(opds1Feed);
+      const feed = getFeed(doc) as OPDSFeed;
+
+      expect(feed.publications).toHaveLength(1);
+      const metadata = feed.publications![0]!.metadata;
+      const content = metadata[SYMBOL.CONTENT];
+      expect(content).toBeDefined();
+      expect(content!.value).toContain('A short blurb describing the book');
     });
 
     it('should handle entries without id or updated gracefully', () => {

--- a/apps/readest-app/src/types/opds.ts
+++ b/apps/readest-app/src/types/opds.ts
@@ -1,3 +1,10 @@
+// SYMBOL must be re-exported from foliate-js so consumers read the same Symbol
+// instances that the parser writes onto publication metadata. Declaring fresh
+// `Symbol('content')` calls here would produce different identities, and
+// `metadata[SYMBOL.CONTENT]` would silently return undefined — losing the book
+// description for OPDS 1.x feeds where it lives in <summary>.
+import { SYMBOL as FOLIATE_SYMBOL } from 'foliate-js/opds.js';
+
 export const REL = {
   ACQ: 'http://opds-spec.org/acquisition',
   FACET: 'http://opds-spec.org/facet',
@@ -11,13 +18,7 @@ export const REL = {
   STREAM: 'http://vaemendis.net/opds-pse/stream',
 } as const;
 
-const SUMMARY = Symbol('summary');
-const CONTENT = Symbol('content');
-
-export const SYMBOL = {
-  SUMMARY,
-  CONTENT,
-} as const;
+export const SYMBOL = FOLIATE_SYMBOL as { SUMMARY: symbol; CONTENT: symbol };
 
 export interface OPDSCatalog {
   id: string;


### PR DESCRIPTION
## Summary
- OPDS book descriptions disappeared from the book details page starting in 0.11.1 for OPDS 1.x servers (e.g. CWA) that put the description in `<entry><summary>` (#4156).
- Root cause: `src/types/opds.ts` declared its own `Symbol('content')` / `Symbol('summary')`, distinct from foliate-js's symbols of the same name. Symbols are unique per call, so `publication.metadata?.[SYMBOL.CONTENT]` always returned `undefined`. The bug was previously masked by foliate-js also writing a plain-string `content` field; that fallback was dropped upstream in #14 (shipped via #3951), exposing the mismatch.
- Fix: re-export `SYMBOL` from `foliate-js/opds.js` in `src/types/opds.ts` so the type module and the parser share the same Symbol identities. No consumer changes needed — `PublicationView` and `NavigationCard` already read through `@/types/opds`.

## Test plan
- [x] Added a regression test in `src/__tests__/utils/opds-feed.test.ts` that builds an OPDS 1.x feed with `<summary>` and asserts `metadata[SYMBOL.CONTENT]` is populated.
- [x] `pnpm test` — 4183 passed / 8 skipped.
- [x] `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)