### PR TITLE
fix(koplugin): harden cover-download subprocess against Adreno exit crash

### DIFF
--- a/apps/readest.koplugin/library/syncbooks.lua
+++ b/apps/readest.koplugin/library/syncbooks.lua
@@ -592,16 +592,32 @@ function M.downloadCover(book, opts, cb)
 
             local pid, parent_read_fd = FFIUtil.runInSubProcess(
                 function(_child_pid, child_write_fd)
-                    local socket     = require("socket")
-                    local http       = require("socket.http")
-                    local socketutil = require("socketutil")
-                    local ltn12      = require("ltn12")
-
+                    -- Runs in a forked child. Two hard rules, both to keep
+                    -- KOReader alive on Boox / Adreno devices (issue #4165):
+                    --
+                    --  1. No Lua error may escape this function. An uncaught
+                    --     error unwinds back to KOReader's android_main,
+                    --     which terminates the child through the libc exit()
+                    --     path — running __cxa_finalize.
+                    --  2. Terminate via _exit(), never exit(): __cxa_finalize
+                    --     runs the destructor of the GL driver inherited from
+                    --     the parent, which segfaults on Adreno and takes the
+                    --     whole app down with it.
+                    --
+                    -- A network failure in http.request is exactly the kind
+                    -- of error rule 1 guards against, so wrap the body.
                     local result
-                    local f, ferr = io.open(dst, "wb")
-                    if not f then
-                        result = "error:open:" .. tostring(ferr)
-                    else
+                    local ok, err = pcall(function()
+                        local socket     = require("socket")
+                        local http       = require("socket.http")
+                        local socketutil = require("socketutil")
+                        local ltn12      = require("ltn12")
+
+                        local f, ferr = io.open(dst, "wb")
+                        if not f then
+                            result = "error:open:" .. tostring(ferr)
+                            return
+                        end
                         socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
                         local code = socket.skip(1, http.request{
                             url     = url,
@@ -616,8 +632,16 @@ function M.downloadCover(book, opts, cb)
                         else
                             result = "error:http:" .. tostring(code)
                         end
+                    end)
+                    if not ok then
+                        result = "error:exception:" .. tostring(err)
                     end
-                    FFIUtil.writeToFD(child_write_fd, result, true)
+                    pcall(FFIUtil.writeToFD, child_write_fd, result or "error:unknown", true)
+
+                    -- Hard exit, bypassing libc atexit handlers (rule 2).
+                    local ffi = require("ffi")
+                    pcall(ffi.cdef, "void _exit(int status);")
+                    ffi.C._exit(0)
                 end,
                 true)  -- with_pipe = true
 


### PR DESCRIPTION
## Summary

Addresses #4165 — KOReader crashes when browsing a folder inside the Readest Library on Boox / Adreno devices.

## Root cause

Browsing a folder forks a child per cloud cover via `syncbooks.downloadCover`. The attached crash log is a native `SIGSEGV` in `libGLESv2_adreno.so`, reached via `exit()` → `__cxa_finalize`:

```
#10 __cxa_finalize
#11 exit
#12+ libluajit ... lua_pcall ... android_main
```

`__cxa_finalize` runs destructors registered with `__cxa_atexit` — including one belonging to the Adreno GL driver the parent loaded for rendering. The forked child inherits that registration; when the child terminates through libc `exit()`, the driver's destructor runs and segfaults, because it tears down GL/EGL state that is invalid in the forked child. `_exit()`, by contrast, terminates immediately and runs **no** atexit handlers.

The crashing processes are the short-lived children (three distinct PIDs, each "Process uptime: 0s"). This is Adreno-specific, which is why it couldn't be reproduced on a non-Adreno Android 16 device.

## Fix

In the cover-download child (`library/syncbooks.lua`):
- Terminate with **`ffi.C._exit(0)`** — `_exit` skips `__cxa_finalize`, so the Adreno destructor never runs. This is the load-bearing change.
- Wrap the body in `pcall` (supporting change) so a network error in `http.request` can't unwind past that `_exit` call, and always write a result to the pipe so the parent's poll doesn't hang.

## Scope / honesty note

This **deterministically eliminates the child-side crash** in the reported tombstone — `_exit` not running `__cxa_finalize` is a POSIX guarantee.

The reporter's symptom is the **parent** KOReader exiting. A child segfault doesn't kill a parent on its own; the most likely link is the child's Adreno destructor tearing down / closing GPU state shared across the `fork()`, which would fault the parent on its next render. If that's the mechanism, skipping the destructor fixes the parent death too — but that link isn't provable from the log alone. The commit therefore does **not** auto-close #4165; it should be confirmed on an affected device first.

## Test plan

- [x] `pnpm test:lua` — 135 passing (this path isn't harness-testable)
- [x] `pnpm lint:lua` — clean
- [ ] Manual (Boox / Adreno): browse a Library folder with cloud covers — covers download, no crash, KOReader stays alive
- [ ] Manual: cover download with a network failure — child reports the error, no crash

No unit test: the fork + network path isn't reproducible in the busted harness, consistent with the other network methods in this file.

## Related (not in this PR)

`localscanner.fullSidecarWalk` forks via the same pattern and has the same latent exit crash on rescan; left for a separate change since it isn't the reported trigger and its subprocess return-value handling needs its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)