### PR TITLE
Fix sonarqube findings

### DIFF
--- a/apps/readest-app/src/__tests__/services/app-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/app-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as nodePath from 'node:path';
 import { BaseDir, FileSystem, ResolvedPath } from '@/types/system';
 import { DatabaseOpts, DatabaseService } from '@/types/database';
 import { SchemaType } from '@/services/database/migrate';
@@ -144,7 +145,7 @@ function createMockFs(): FileSystem {
       atime: null,
       birthtime: null,
     }),
-    getPrefix: vi.fn().mockResolvedValue('/base/books'),
+    getPrefix: vi.fn().mockResolvedValue(nodePath.join('base', 'books')),
   };
 }
 
@@ -185,7 +186,7 @@ describe('BaseAppService', () => {
     test('sets localBooksDir from fs.getPrefix', async () => {
       await service.prepareBooksDir();
       expect(mockFs.getPrefix).toHaveBeenCalledWith('Books');
-      expect(service.localBooksDir).toBe('/base/books');
+      expect(service.localBooksDir).toBe(nodePath.join('base', 'books'));
     });
   });
 
@@ -258,12 +259,12 @@ describe('BaseAppService', () => {
   describe('resolveFilePath', () => {
     test('combines prefix with path', async () => {
       const result = await service.resolveFilePath('test.json', 'Data');
-      expect(result).toBe('/base/books/test.json');
+      expect(result).toBe(nodePath.join('base', 'books', 'test.json'));
     });
 
     test('returns just prefix when path is empty', async () => {
       const result = await service.resolveFilePath('', 'Data');
-      expect(result).toBe('/base/books');
+      expect(result).toBe(nodePath.join('base', 'books'));
     });
   });
 

--- a/apps/readest-app/src/__tests__/utils/txt-converter.test.ts
+++ b/apps/readest-app/src/__tests__/utils/txt-converter.test.ts
@@ -56,7 +56,7 @@ type TxtConverterFlowPrivateAPI = TxtConverterPrivateAPI & {
 
 const getBufferSize = (input?: BufferSource): number => {
   if (!input) return 0;
-  return input instanceof ArrayBuffer ? input.byteLength : input.byteLength;
+  return input.byteLength;
 };
 
 describe('TxtToEpubConverter', () => {

--- a/apps/readest-app/src/app/reader/components/NotebookToggler.tsx
+++ b/apps/readest-app/src/app/reader/components/NotebookToggler.tsx
@@ -34,13 +34,7 @@ const NotebookToggler: React.FC<NotebookTogglerProps> = ({ bookKey }) => {
   };
   return (
     <Button
-      icon={
-        sideBarBookKey == bookKey && isNotebookVisible ? (
-          <LuNotebookPen size={iconSize16} className='text-base-content' />
-        ) : (
-          <LuNotebookPen size={iconSize16} className='text-base-content' />
-        )
-      }
+      icon={<LuNotebookPen size={iconSize16} className='text-base-content' />}
       onClick={handleToggleSidebar}
       label={_('Notebook')}
     ></Button>

--- a/apps/readest-app/src/hooks/useFileSelector.ts
+++ b/apps/readest-app/src/hooks/useFileSelector.ts
@@ -91,7 +91,7 @@ export const useFileSelector = (appService: AppService | null, _: (key: string) 
     try {
       if (isTauriAppPlatform()) {
         const filePaths = await selectFileTauri(options, appService, _);
-        const files = await processTauriFiles(filePaths);
+        const files = processTauriFiles(filePaths);
         return { files };
       } else {
         const webFiles = await selectFileWeb(options);

--- a/apps/readest-app/src/pages/api/sync.ts
+++ b/apps/readest-app/src/pages/api/sync.ts
@@ -232,8 +232,8 @@ export async function POST(req: NextRequest) {
       });
 
       // Separate into inserts and updates
-      const toInsert: (DBBook | DBBookConfig | DBBookConfig)[] = [];
-      const toUpdate: (DBBook | DBBookConfig | DBBookConfig)[] = [];
+      const toInsert: (DBBook | DBBookConfig)[] = [];
+      const toUpdate: (DBBook | DBBookConfig)[] = [];
       const batchAuthoritativeRecords: BookDataRecord[] = [];
 
       for (const { original, db: dbRec } of dbRecords) {

--- a/apps/readest-app/src/services/appService.ts
+++ b/apps/readest-app/src/services/appService.ts
@@ -23,6 +23,7 @@ import { CustomTextureInfo } from '@/styles/textures';
 import { CustomFont, CustomFontInfo } from '@/styles/fonts';
 import type { ImportedDictionary } from './dictionaries/types';
 import type { SelectedFile } from '@/hooks/useFileSelector';
+import * as nodePath from 'node:path';
 
 import * as BookSvc from './bookService';
 import * as CloudSvc from './cloudService';
@@ -157,7 +158,7 @@ export abstract class BaseAppService implements AppService {
 
   async resolveFilePath(path: string, base: BaseDir): Promise<string> {
     const prefix = await this.fs.getPrefix(base);
-    return path ? `${prefix}/${path}` : prefix;
+    return path ? nodePath.join(prefix, path) : prefix;
   }
 
   async readDirectory(path: string, base: BaseDir): Promise<FileItem[]> {

--- a/apps/readest-app/src/services/cloudService.ts
+++ b/apps/readest-app/src/services/cloudService.ts
@@ -46,7 +46,7 @@ export async function deleteBook(
     for (const fp of fps) {
       const cfp = `${CLOUD_BOOKS_SUBDIR}/${fp}`;
       try {
-        deleteCloudFile(cfp);
+        await deleteCloudFile(cfp);
       } catch (error) {
         console.log('Failed to delete uploaded file:', error);
       }

--- a/apps/readest-app/src/services/nodeAppService.ts
+++ b/apps/readest-app/src/services/nodeAppService.ts
@@ -109,9 +109,20 @@ const getPathResolver = ({ customRootDir }: { customRootDir?: string } = {}) => 
           'Dictionaries',
         ];
         const leafDir = dataDirs.includes(base) ? '' : base;
-        return leafDir ? `${customRootDir}/${leafDir}` : customRootDir!;
+        return leafDir ? nodePath.join(customRootDir!, leafDir) : customRootDir!;
       }
     : undefined;
+
+  const buildFilePath = (
+    customPath: string | undefined,
+    subDir: string,
+    fp: string | undefined,
+  ): string => {
+    const filePath = fp ? fp : '';
+    return customPath
+      ? nodePath.join(customPath, subDir, filePath)
+      : nodePath.join(subDir, filePath);
+  };
 
   return (fp: string, base: BaseDir): ResolvedPath => {
     const custom = getCustomBasePrefix?.(base);
@@ -120,7 +131,7 @@ const getPathResolver = ({ customRootDir }: { customRootDir?: string } = {}) => 
         return {
           baseDir: 0,
           basePrefix: async () => custom ?? getAppConfigDir(),
-          fp: custom ? `${custom}${fp ? `/${fp}` : ''}` : fp,
+          fp: custom ? nodePath.join(custom, fp ? fp : '') : fp,
           base,
         };
       case 'Cache':
@@ -134,52 +145,42 @@ const getPathResolver = ({ customRootDir }: { customRootDir?: string } = {}) => 
         return {
           baseDir: 0,
           basePrefix: async () => custom ?? getAppLogDir(),
-          fp: custom ? `${custom}${fp ? `/${fp}` : ''}` : fp,
+          fp: custom ? nodePath.join(custom, fp ? fp : '') : fp,
           base,
         };
       case 'Data':
         return {
           baseDir: 0,
           basePrefix: async () => custom ?? getAppDataDir(),
-          fp: custom
-            ? `${custom}/${DATA_SUBDIR}${fp ? `/${fp}` : ''}`
-            : `${DATA_SUBDIR}${fp ? `/${fp}` : ''}`,
+          fp: buildFilePath(custom, DATA_SUBDIR, fp),
           base,
         };
       case 'Books':
         return {
           baseDir: 0,
           basePrefix: async () => custom ?? getAppDataDir(),
-          fp: custom
-            ? `${custom}/${LOCAL_BOOKS_SUBDIR}${fp ? `/${fp}` : ''}`
-            : `${LOCAL_BOOKS_SUBDIR}${fp ? `/${fp}` : ''}`,
+          fp: buildFilePath(custom, LOCAL_BOOKS_SUBDIR, fp),
           base,
         };
       case 'Fonts':
         return {
           baseDir: 0,
           basePrefix: async () => custom ?? getAppDataDir(),
-          fp: custom
-            ? `${custom}/${LOCAL_FONTS_SUBDIR}${fp ? `/${fp}` : ''}`
-            : `${LOCAL_FONTS_SUBDIR}${fp ? `/${fp}` : ''}`,
+          fp: buildFilePath(custom, LOCAL_FONTS_SUBDIR, fp),
           base,
         };
       case 'Images':
         return {
           baseDir: 0,
           basePrefix: async () => custom ?? getAppDataDir(),
-          fp: custom
-            ? `${custom}/${LOCAL_IMAGES_SUBDIR}${fp ? `/${fp}` : ''}`
-            : `${LOCAL_IMAGES_SUBDIR}${fp ? `/${fp}` : ''}`,
+          fp: buildFilePath(custom, LOCAL_IMAGES_SUBDIR, fp),
           base,
         };
       case 'Dictionaries':
         return {
           baseDir: 0,
           basePrefix: async () => custom ?? getAppDataDir(),
-          fp: custom
-            ? `${custom}/${LOCAL_DICTIONARIES_SUBDIR}${fp ? `/${fp}` : ''}`
-            : `${LOCAL_DICTIONARIES_SUBDIR}${fp ? `/${fp}` : ''}`,
+          fp: buildFilePath(custom, LOCAL_DICTIONARIES_SUBDIR, fp),
           base,
         };
       case 'None':

--- a/apps/readest-app/src/services/tts/EdgeTTSClient.ts
+++ b/apps/readest-app/src/services/tts/EdgeTTSClient.ts
@@ -245,7 +245,7 @@ export class EdgeTTSClient implements TTSClient {
   async pause() {
     if (!this.#isPlaying || !this.#audioElement) return true;
     this.#pausedAt = this.#audioElement.currentTime - this.#startedAt;
-    await this.#audioElement.pause();
+    this.#audioElement.pause();
     this.#isPlaying = false;
     return true;
   }

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -270,7 +270,7 @@ export class TTSController extends EventTarget {
 
   async preloadSSML(ssml: string | undefined, signal: AbortSignal) {
     if (!ssml) return;
-    const iter = await this.ttsClient.speak(ssml, signal, true);
+    const iter = this.ttsClient.speak(ssml, signal, true);
     for await (const _ of iter);
   }
 


### PR DESCRIPTION
## Changes
Started by addressing the matters discussed in issue #4108:
* remove a few unnecessary `await`s
* add one `await` which was missing on a Promise
* simplify conditionals that return the same value in both cases
* remove a duplicated type declaration

When running `pnpm test` afterwards, 4 tests in `node-app-service.test.ts` were failing due to a mismatch in some expected vs received paths. The mismatch was coming from the expected path using Windows' `/` path separator, while the received path used POSIX's `\` path separator. Therefore, I added a second commit to:
* refactor NodeAppService and AppService methods to not have path concatenation hardcoded, but resolved using node's `path.join`; this achieves platform-independent path resolution and enables unit tests to pass on Windows as well

## Testing
* `pnpm build`
* `pnpm test`