### PR TITLE
fix(tests): materialize zip.js blob before wrapping in File for case-mismatch fixture

### DIFF
--- a/apps/readest-app/src/__tests__/document/document-loader-epub-case.test.ts
+++ b/apps/readest-app/src/__tests__/document/document-loader-epub-case.test.ts
@@ -47,7 +47,8 @@ const createCaseMismatchEpub = async () => {
   );
 
   const blob = await writer.close();
-  return new File([blob], 'case-mismatch.epub', { type: 'application/epub+zip' });
+  const arrayBuffer = await blob.arrayBuffer();
+  return new File([arrayBuffer], 'case-mismatch.epub', { type: 'application/epub+zip' });
 };
 
 describe('DocumentLoader EPUB zip lookup', () => {


### PR DESCRIPTION

The case-mismatch EPUB fixture builds an archive with @zip.js/zip.js' BlobWriter and then wraps the resulting Blob into a File:

  const blob = await writer.close();
  new File([blob], 'case-mismatch.epub', ...);

Under vitest's happy-dom/jsdom, the File/Blob polyfill does not correctly pull bytes out of a nested Blob part produced by zip.js. The outer File reports a non-zero size, but the bytes BlobReader sees in DocumentLoader (libs/document.ts: 'new BlobReader(this.file)') are not a valid ZIP — getEntries() yields nothing, open() falls through with book = null, and the test crashes at:

  TypeError: Cannot read properties of null (reading 'sections')

Materialize the zip bytes into a plain ArrayBuffer first, then construct the File from that. ArrayBuffer parts go through the polyfill cleanly because they don't require recursive Blob unwrapping, so zip.js reads a real archive and the test passes:

  const arrayBuffer = await blob.arrayBuffer();
  new File([arrayBuffer], 'case-mismatch.epub', ...);

This brings the fixture in line with the rest of the test suite (paginator-expand, page-progress-epub, toc-cfi-mapping, ...) which already use ArrayBuffer-based File construction. No production code is affected: real browsers handle nested-Blob File construction correctly.