### PR TITLE
fix(opds): send Basic auth preemptively for optional-auth servers

### DIFF
--- a/apps/readest-app/src/__tests__/utils/opds-req.test.ts
+++ b/apps/readest-app/src/__tests__/utils/opds-req.test.ts
@@ -17,6 +17,22 @@ vi.mock('@tauri-apps/plugin-http', () => ({
   fetch: vi.fn(),
 }));
 
+type FakeResponseInit = {
+  status?: number;
+  body?: string;
+  wwwAuthenticate?: string;
+};
+
+const makeResponse = ({ status = 200, body = '', wwwAuthenticate }: FakeResponseInit = {}) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: {
+    get: (name: string) =>
+      name.toLowerCase() === 'www-authenticate' ? (wwwAuthenticate ?? null) : null,
+  },
+  text: async () => body,
+});
+
 describe('opdsReq', () => {
   let needsProxy: typeof import('@/app/opds/utils/opdsReq').needsProxy;
   let getProxiedURL: typeof import('@/app/opds/utils/opdsReq').getProxiedURL;
@@ -107,6 +123,77 @@ describe('opdsReq', () => {
       const url = 'https://standardebooks.org/opds/all';
       const proxied = getProxiedURL(url);
       expect(proxied).toContain('/node-api/opds/proxy');
+    });
+  });
+
+  describe('fetchWithAuth', () => {
+    let fetchWithAuth: typeof import('@/app/opds/utils/opdsReq').fetchWithAuth;
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      const opdsReq = await import('@/app/opds/utils/opdsReq');
+      fetchWithAuth = opdsReq.fetchWithAuth;
+      fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('sends Basic auth on the first request when credentials are provided', async () => {
+      // Servers that allow anonymous access return 200 without a challenge.
+      // The credentials must be sent preemptively or the user keeps seeing
+      // guest content (issue #4202).
+      fetchMock.mockResolvedValue(makeResponse({ status: 200, body: '<feed/>' }));
+
+      await fetchWithAuth('https://opds.example.com/feed', 'alice', 's3cret', false);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const init = fetchMock.mock.calls[0]![1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers['Authorization']).toBe(`Basic ${btoa('alice:s3cret')}`);
+    });
+
+    it('does not send an Authorization header when no credentials are provided', async () => {
+      fetchMock.mockResolvedValue(makeResponse({ status: 200, body: '<feed/>' }));
+
+      await fetchWithAuth('https://opds.example.com/feed', undefined, undefined, false);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const init = fetchMock.mock.calls[0]![1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers['Authorization']).toBeUndefined();
+    });
+
+    it('passes preemptive auth through the proxy URL when useProxy is true', async () => {
+      fetchMock.mockResolvedValue(makeResponse({ status: 200, body: '<feed/>' }));
+
+      await fetchWithAuth('https://opds.example.com/feed', 'alice', 's3cret', true);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const proxyUrl = fetchMock.mock.calls[0]![0] as string;
+      const auth = new URL(proxyUrl, 'https://web.readest.com').searchParams.get('auth');
+      expect(auth).toBe(`Basic ${btoa('alice:s3cret')}`);
+    });
+
+    it('retries with Digest auth when the server issues a Digest challenge', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          makeResponse({
+            status: 401,
+            wwwAuthenticate: 'Digest realm="opds", nonce="abc123", qop="auth"',
+          }),
+        )
+        .mockResolvedValueOnce(makeResponse({ status: 200, body: '<feed/>' }));
+
+      const res = await fetchWithAuth('https://opds.example.com/feed', 'alice', 's3cret', false);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const init = fetchMock.mock.calls[1]![1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers['Authorization']).toMatch(/^Digest /);
+      expect(res.status).toBe(200);
     });
   });
 });

--- a/apps/readest-app/src/app/opds/utils/opdsReq.ts
+++ b/apps/readest-app/src/app/opds/utils/opdsReq.ts
@@ -331,14 +331,23 @@ export const fetchWithAuth = async (
   const finalPassword = password || urlPassword;
   const normalizedCustomHeaders = normalizeOPDSCustomHeaders(customHeaders);
 
+  // Send Basic auth preemptively when credentials are available. Servers that
+  // allow anonymous access (e.g. Calibre-Web) return 200 without a challenge,
+  // so the user keeps seeing guest content unless the auth header is included
+  // on the first request. Digest auth can't be sent preemptively (it needs the
+  // server's nonce), so Digest servers still fall through to the retry below.
+  const preemptiveAuth =
+    finalUsername && finalPassword ? createBasicAuth(finalUsername, finalPassword) : null;
+
   const fetchURL = useProxy
-    ? getProxiedURL(cleanUrl, '', false, normalizedCustomHeaders)
+    ? getProxiedURL(cleanUrl, preemptiveAuth || '', false, normalizedCustomHeaders)
     : cleanUrl;
   const headers: Record<string, string> = {
     'User-Agent': READEST_OPDS_USER_AGENT,
     Accept: 'application/atom+xml, application/xml, text/xml, */*',
     ...(!useProxy ? normalizedCustomHeaders : {}),
     ...(options.headers as Record<string, string>),
+    ...(preemptiveAuth && !useProxy ? { Authorization: preemptiveAuth } : {}),
   };
 
   const fetch = isTauriAppPlatform() ? tauriFetch : window.fetch;
@@ -368,7 +377,9 @@ export const fetchWithAuth = async (
         authHeader = createBasicAuth(finalUsername, finalPassword);
       }
 
-      if (authHeader) {
+      // Skip the retry when it would just repeat the preemptive Basic header
+      // we already sent (the credentials are simply wrong in that case).
+      if (authHeader && authHeader !== preemptiveAuth) {
         const finalUrl = useProxy
           ? getProxiedURL(cleanUrl, authHeader, false, normalizedCustomHeaders)
           : fetchURL;


### PR DESCRIPTION
## Problem

Fixes #4202

OPDS servers configured to allow anonymous access (e.g. the actively-maintained Calibre-Web-NextGen fork) return `200` with guest content and **never** issue a `WWW-Authenticate` challenge. `fetchWithAuth` only attached the user's credentials on a `401`/`403` retry, so a user who entered valid login details kept seeing only guest-visible content — their own shelves were missing.

## Fix

`fetchWithAuth` now sends a `Basic` `Authorization` header on the **first** request whenever credentials are available:

- **Non-proxy** (Android/desktop — the reporter's environment): the header is attached directly to the request.
- **Proxy** (web): credentials are passed through the proxy URL's `auth` parameter.
- **Digest auth**: unchanged — it still falls through to the challenge-driven retry, since Digest can't be sent preemptively (it needs the server's nonce). The retry is skipped when it would merely repeat the preemptive `Basic` header (i.e. the credentials are simply wrong).

Download paths (`probeAuth`) were already unaffected — that path returns a `Basic` header unconditionally.

## Tests

Added 4 `fetchWithAuth` tests (preemptive Basic, proxy preemptive auth, no-credentials, Digest retry). 2 fail before the fix, all pass after.

- `pnpm test` — 4297 passed
- `pnpm lint` — clean (tsgo + biome + lua)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
