### PR TITLE
fix(ios): refresh appearance on system light/dark change

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
@@ -463,6 +463,7 @@ class NativeBridgePlugin: Plugin {
   private var currentOrientationMask: UIInterfaceOrientationMask = .all
   private var originalDelegate: UIApplicationDelegate?
   private var webViewLifecycleManager: WebViewLifecycleManager?
+  private var traitChangeRegistered = false
 
   @objc public override func load(webview: WKWebView) {
     self.webView = webview
@@ -471,6 +472,14 @@ class NativeBridgePlugin: Plugin {
     webViewLifecycleManager = WebViewLifecycleManager()
     webViewLifecycleManager?.startMonitoring(webView: webview)
     logger.log("NativeBridgePlugin: WebView lifecycle monitoring activated")
+
+    // The WKWebView never fires the `prefers-color-scheme` media query
+    // `change` event while the app stays foregrounded, so observe the
+    // native appearance and push changes to JS instead. Registration is
+    // deferred because the window scene may not be connected yet.
+    DispatchQueue.main.async { [weak self] in
+      self?.registerTraitChangeObserverIfNeeded()
+    }
 
     NotificationCenter.default.addObserver(
       self,
@@ -509,6 +518,48 @@ class NativeBridgePlugin: Plugin {
   @objc func appDidBecomeActive() {
     if volumeKeyHandler != nil {
       activateVolumeKeyInterception()
+    }
+    registerTraitChangeObserverIfNeeded()
+    // Fallback for iOS < 17 (no `registerForTraitChanges`): re-check the
+    // appearance whenever the app becomes active, e.g. after toggling
+    // dark mode from Control Center.
+    notifyColorSchemeChange()
+  }
+
+  // Resolves the foreground window scene. Its trait collection reflects
+  // the real system appearance and is unaffected by the per-window
+  // `overrideUserInterfaceStyle` that `set_system_ui_visibility` applies.
+  private func foregroundWindowScene() -> UIWindowScene? {
+    let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+    return scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+  }
+
+  private func systemColorScheme() -> String {
+    let userInterfaceStyle =
+      foregroundWindowScene()?.traitCollection.userInterfaceStyle
+      ?? UITraitCollection.current.userInterfaceStyle
+    return (userInterfaceStyle == .dark) ? "dark" : "light"
+  }
+
+  private func registerTraitChangeObserverIfNeeded() {
+    guard !traitChangeRegistered, #available(iOS 17.0, *) else { return }
+    guard let windowScene = foregroundWindowScene() else { return }
+    traitChangeRegistered = true
+    MainActor.assumeIsolated {
+      windowScene.registerForTraitChanges([UITraitUserInterfaceStyle.self]) {
+        [weak self] (_: UIWindowScene, _: UITraitCollection) in
+        self?.notifyColorSchemeChange()
+      }
+    }
+  }
+
+  private func notifyColorSchemeChange() {
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self, let webView = self.webView else { return }
+      let colorScheme = self.systemColorScheme()
+      webView.evaluateJavaScript(
+        "try { window.onNativeColorSchemeChange && window.onNativeColorSchemeChange('\(colorScheme)'); } catch (_) {}",
+        completionHandler: nil)
     }
   }
 
@@ -887,9 +938,9 @@ class NativeBridgePlugin: Plugin {
   }
 
   @objc public func get_system_color_scheme(_ invoke: Invoke) {
-    let userInterfaceStyle = UITraitCollection.current.userInterfaceStyle
-    let colorScheme = (userInterfaceStyle == .dark) ? "dark" : "light"
-    invoke.resolve(["colorScheme": colorScheme])
+    DispatchQueue.main.async { [weak self] in
+      invoke.resolve(["colorScheme": self?.systemColorScheme() ?? "light"])
+    }
   }
 
   @objc public func get_screen_brightness(_ invoke: Invoke) {

--- a/apps/readest-app/src/__tests__/store/theme-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/theme-store.test.ts
@@ -25,11 +25,13 @@ vi.mock('@/services/environment', () => ({
   isWebAppPlatform: vi.fn(() => false),
 }));
 
-import { useThemeStore, loadDataTheme } from '@/store/themeStore';
+import { useThemeStore, loadDataTheme, initSystemThemeListener } from '@/store/themeStore';
+import type { AppService } from '@/types/system';
 
 describe('themeStore', () => {
   beforeEach(() => {
     localStorage.clear();
+    delete window.onNativeColorSchemeChange;
     // Reset store to initial state
     useThemeStore.setState({
       themeMode: 'auto',
@@ -254,6 +256,36 @@ describe('themeStore', () => {
       document.documentElement.removeAttribute('data-theme');
       loadDataTheme();
       expect(document.documentElement.getAttribute('data-theme')).toBeNull();
+    });
+  });
+
+  describe('initSystemThemeListener', () => {
+    const makeAppService = (overrides: Partial<AppService> = {}) =>
+      ({ isIOSApp: false, hasWindow: false, isLinuxApp: false, ...overrides }) as AppService;
+
+    test('registers window.onNativeColorSchemeChange on iOS', () => {
+      initSystemThemeListener(makeAppService({ isIOSApp: true }));
+      expect(typeof window.onNativeColorSchemeChange).toBe('function');
+    });
+
+    test('does not register the native callback on non-iOS platforms', () => {
+      initSystemThemeListener(makeAppService({ isIOSApp: false }));
+      expect(window.onNativeColorSchemeChange).toBeUndefined();
+    });
+
+    test('native color scheme change updates the theme store in auto mode', () => {
+      useThemeStore.setState({ themeMode: 'auto', systemIsDarkMode: false, isDarkMode: false });
+      initSystemThemeListener(makeAppService({ isIOSApp: true }));
+
+      window.onNativeColorSchemeChange!('dark');
+      expect(useThemeStore.getState().systemIsDarkMode).toBe(true);
+      expect(useThemeStore.getState().isDarkMode).toBe(true);
+      expect(localStorage.getItem('systemIsDarkMode')).toBe('true');
+
+      window.onNativeColorSchemeChange!('light');
+      expect(useThemeStore.getState().systemIsDarkMode).toBe(false);
+      expect(useThemeStore.getState().isDarkMode).toBe(false);
+      expect(localStorage.getItem('systemIsDarkMode')).toBe('false');
     });
   });
 

--- a/apps/readest-app/src/store/themeStore.ts
+++ b/apps/readest-app/src/store/themeStore.ts
@@ -11,6 +11,7 @@ import { Insets } from '@/types/misc';
 declare global {
   interface Window {
     __READEST_IS_EINK?: boolean;
+    onNativeColorSchemeChange?: (colorScheme: 'light' | 'dark') => void;
   }
 }
 
@@ -166,6 +167,12 @@ export const initSystemThemeListener = (appService: AppService) => {
   if (typeof window === 'undefined' || !appService) return;
 
   const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  const applySystemTheme = (systemIsDarkMode: boolean) => {
+    if (typeof window !== 'undefined' && localStorage) {
+      localStorage.setItem('systemIsDarkMode', systemIsDarkMode ? 'true' : 'false');
+    }
+    useThemeStore.getState().handleSystemThemeChange(systemIsDarkMode);
+  };
   const updateColorTheme = async () => {
     let systemIsDarkMode;
     if (appService.isIOSApp) {
@@ -174,10 +181,7 @@ export const initSystemThemeListener = (appService: AppService) => {
     } else {
       systemIsDarkMode = mediaQuery.matches;
     }
-    if (typeof window !== 'undefined' && localStorage) {
-      localStorage.setItem('systemIsDarkMode', systemIsDarkMode ? 'true' : 'false');
-    }
-    useThemeStore.getState().handleSystemThemeChange(systemIsDarkMode);
+    applySystemTheme(systemIsDarkMode);
   };
 
   const updateWindowTheme = async () => {
@@ -191,5 +195,16 @@ export const initSystemThemeListener = (appService: AppService) => {
   mediaQuery?.addEventListener('change', updateColorTheme);
   document.addEventListener('visibilitychange', updateColorTheme);
   window.addEventListener('resize', updateWindowTheme);
+
+  // iOS WKWebView never fires the `prefers-color-scheme` media query
+  // `change` event while the app stays foregrounded (e.g. toggling dark
+  // mode from Control Center), so the native plugin pushes the new
+  // appearance through this callback instead.
+  if (appService.isIOSApp) {
+    window.onNativeColorSchemeChange = (colorScheme) => {
+      applySystemTheme(colorScheme === 'dark');
+    };
+  }
+
   updateColorTheme();
 };


### PR DESCRIPTION
## Summary

Fixes #4057 — on iOS, changing the system appearance (light/dark) from Control Center did not refresh the reader while the app stayed foregrounded. This is a reopen of #3698; PR #3704 did not fully fix it.

**Root cause:** `set_system_ui_visibility` sets `keyWindow.overrideUserInterfaceStyle` to match the app's theme. That override pins the `WKWebView`'s trait collection, so the `prefers-color-scheme` media query never fires a `change` event, and `get_system_color_scheme` (which read the webview's trait) returned the stale pinned value. In `auto` mode the app could never observe a system appearance change after launch.

**Fix:** detect the appearance at the `UIWindowScene` level, which sits *above* the per-window override and reflects the real system appearance.

- `NativeBridgePlugin.swift`
  - `registerForTraitChanges` on the foreground `UIWindowScene` (iOS 17+) pushes changes to JS via `window.onNativeColorSchemeChange`.
  - `appDidBecomeActive` re-checks as a fallback for iOS 15/16 (covers the Control Center case).
  - `get_system_color_scheme` reads the window scene's trait collection instead of the pinned webview.
- `themeStore.ts` — `initSystemThemeListener` registers `window.onNativeColorSchemeChange` on iOS to apply the pushed scheme.

## Test plan

- [x] `pnpm test` — unit tests pass (new tests for the native callback wiring in `theme-store.test.ts`)
- [x] `pnpm lint`, `pnpm fmt:check`, `pnpm clippy:check` pass
- [x] Verified on iOS simulator (iPhone 16 Pro, iOS 18.5): app launches in the system appearance, and toggling dark→light→dark with the app foregrounded refreshes it each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)