### PR TITLE
ci(release): use cargo tauri CLI for Linux bundler

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,6 +313,10 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=8192'
         with:
           projectPath: apps/readest-app
+          # On Linux, build with the Rust `cargo tauri` CLI installed in the
+          # step above so the new (truly-portable AppImage) bundler is used.
+          # Without this, tauri-action falls back to the npm @tauri-apps/cli.
+          tauriScript: ${{ matrix.config.release == 'linux' && 'cargo tauri' || '' }}
           releaseId: ${{ needs.get-release.outputs.release_id }}
           releaseBody: ${{ needs.get-release.outputs.release_note }}
           args: ${{ matrix.config.args || '' }}


### PR DESCRIPTION
## Problem

The release workflow installs the Rust-based `tauri-cli` from the
`feat/truly-portable-appimage` branch for Linux builds:

```yaml
- name: Override tauri-cli with custom AppImage format (Linux)
  if: matrix.config.release == 'linux'
  run: cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --force
```

…but the `tauri-apps/tauri-action` step right after it had no
`tauriScript` input. Without it, tauri-action falls back to the npm
`@tauri-apps/cli`, so the custom truly-portable AppImage bundler was
never actually used.

This was flagged by Tauri maintainer @FabianLars in
tauri-apps/tauri#9662 ([comment](https://github.com/tauri-apps/tauri/issues/9662#issuecomment-4485753367)).

## Fix

Set `tauriScript` to `cargo tauri` for the Linux matrix entries so the
just-installed Rust CLI is used. macOS/Windows resolve to an empty
string and keep using the npm CLI as before.

Can only be verified for real on the next release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)