### PR TITLE
fix(send): make recent-activity status labels translatable

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -1603,5 +1603,10 @@
   "Process incoming items on this device": "معالجة العناصر الواردة على هذا الجهاز",
   "Email books to your library": "إرسال الكتب إلى مكتبتك بالبريد الإلكتروني",
   "Email a book or document to this address from an approved sender below.": "أرسل كتابًا أو مستندًا إلى هذا العنوان من مُرسِل معتمد أدناه.",
-  "Download and import books emailed to your address.": "تنزيل واستيراد الكتب المُرسَلة إلى عنوانك عبر البريد الإلكتروني."
+  "Download and import books emailed to your address.": "تنزيل واستيراد الكتب المُرسَلة إلى عنوانك عبر البريد الإلكتروني.",
+  "System Dictionary": "قاموس النظام",
+  "System": "النظام",
+  "System dictionary integration is coming soon on this platform.": "تكامل قاموس النظام قادم قريباً على هذه المنصة.",
+  "Waiting to be processed": "في انتظار المعالجة",
+  "Processing…": "جارٍ المعالجة…"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1491,5 +1491,10 @@
   "Process incoming items on this device": "এই ডিভাইসে আগত আইটেমগুলি প্রক্রিয়া করুন",
   "Email books to your library": "আপনার লাইব্রেরিতে বই ইমেল করুন",
   "Email a book or document to this address from an approved sender below.": "নিচের অনুমোদিত কোনো প্রেরক থেকে এই ঠিকানায় একটি বই বা নথি ইমেল করুন।",
-  "Download and import books emailed to your address.": "আপনার ঠিকানায় ইমেল করা বই ডাউনলোড ও আমদানি করুন।"
+  "Download and import books emailed to your address.": "আপনার ঠিকানায় ইমেল করা বই ডাউনলোড ও আমদানি করুন।",
+  "System Dictionary": "সিস্টেম অভিধান",
+  "System": "সিস্টেম",
+  "System dictionary integration is coming soon on this platform.": "এই প্ল্যাটফর্মে সিস্টেম অভিধান ইন্টিগ্রেশন শীঘ্রই আসছে।",
+  "Waiting to be processed": "প্রক্রিয়াকরণের অপেক্ষায়",
+  "Processing…": "প্রক্রিয়াকরণ হচ্ছে…"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1463,5 +1463,10 @@
   "Process incoming items on this device": "སྒྲིག་ཆས་འདིའི་སྟེང་ནང་འབྱོར་གྱི་དངོས་པོ་སྒྲིག་སྦྱོར་བྱེད།",
   "Email books to your library": "ཁྱེད་ཀྱི་དཔེ་མཛོད་ལ་དེབ་གློག་འཕྲིན་གྱིས་སྐུར།",
   "Email a book or document to this address from an approved sender below.": "འོག་གི་ཆོག་མཆན་ཐོབ་པའི་སྐུར་མཁན་ཞིག་ནས་དཔེ་ཆའམ་ཡིག་ཆ་ཞིག་ཁ་བྱང་འདིར་གློག་འཕྲིན་གྱིས་སྐུར་རོགས།",
-  "Download and import books emailed to your address.": "ཁྱེད་ཀྱི་ཁ་བྱང་ལ་གློག་འཕྲིན་གྱིས་སྐུར་བའི་དཔེ་ཆ་རྣམས་ཕབ་ལེན་དང་ནང་འདྲེན་བྱེད།"
+  "Download and import books emailed to your address.": "ཁྱེད་ཀྱི་ཁ་བྱང་ལ་གློག་འཕྲིན་གྱིས་སྐུར་བའི་དཔེ་ཆ་རྣམས་ཕབ་ལེན་དང་ནང་འདྲེན་བྱེད།",
+  "System Dictionary": "མ་ལག་ཚིག་མཛོད",
+  "System": "མ་ལག",
+  "System dictionary integration is coming soon on this platform.": "སྡོམ་གཞི་འདིའི་ནང་མ་ལག་ཚིག་མཛོད་མཐུན་སྒྲིལ་གྱི་ནུས་པ་མྱུར་དུ་འབྱུང་ངེས།",
+  "Waiting to be processed": "སྦྱོར་སྦྱང་གི་སྒུག་ནས།",
+  "Processing…": "སྦྱོར་སྦྱང་བྱེད་བཞིན་པ…"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1491,5 +1491,10 @@
   "Process incoming items on this device": "Eingehende Elemente auf diesem Gerät verarbeiten",
   "Email books to your library": "Bücher an deine Bibliothek per E-Mail senden",
   "Email a book or document to this address from an approved sender below.": "Senden Sie ein Buch oder Dokument von einem genehmigten Absender unten per E-Mail an diese Adresse.",
-  "Download and import books emailed to your address.": "Bücher herunterladen und importieren, die an Ihre Adresse gesendet wurden."
+  "Download and import books emailed to your address.": "Bücher herunterladen und importieren, die an Ihre Adresse gesendet wurden.",
+  "System Dictionary": "Systemwörterbuch",
+  "System": "System",
+  "System dictionary integration is coming soon on this platform.": "Die Integration des Systemwörterbuchs ist auf dieser Plattform bald verfügbar.",
+  "Waiting to be processed": "Wartet auf Verarbeitung",
+  "Processing…": "Wird verarbeitet…"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1491,5 +1491,10 @@
   "Process incoming items on this device": "Επεξεργασία εισερχόμενων στοιχείων σε αυτή τη συσκευή",
   "Email books to your library": "Στείλτε βιβλία στη βιβλιοθήκη σας μέσω email",
   "Email a book or document to this address from an approved sender below.": "Στείλτε ένα βιβλίο ή έγγραφο σε αυτή τη διεύθυνση από εγκεκριμένο αποστολέα παρακάτω.",
-  "Download and import books emailed to your address.": "Λήψη και εισαγωγή βιβλίων που στάλθηκαν με email στη διεύθυνσή σας."
+  "Download and import books emailed to your address.": "Λήψη και εισαγωγή βιβλίων που στάλθηκαν με email στη διεύθυνσή σας.",
+  "System Dictionary": "Λεξικό συστήματος",
+  "System": "Σύστημα",
+  "System dictionary integration is coming soon on this platform.": "Η ενσωμάτωση λεξικού συστήματος έρχεται σύντομα σε αυτή την πλατφόρμα.",
+  "Waiting to be processed": "Αναμονή για επεξεργασία",
+  "Processing…": "Επεξεργασία…"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1519,5 +1519,10 @@
   "Process incoming items on this device": "Procesar elementos entrantes en este dispositivo",
   "Email books to your library": "Enviar libros a tu biblioteca por correo electrónico",
   "Email a book or document to this address from an approved sender below.": "Envía un libro o documento a esta dirección desde un remitente aprobado de abajo.",
-  "Download and import books emailed to your address.": "Descarga e importa los libros enviados por correo a tu dirección."
+  "Download and import books emailed to your address.": "Descarga e importa los libros enviados por correo a tu dirección.",
+  "System Dictionary": "Diccionario del sistema",
+  "System": "Sistema",
+  "System dictionary integration is coming soon on this platform.": "La integración del diccionario del sistema estará disponible próximamente en esta plataforma.",
+  "Waiting to be processed": "Esperando ser procesado",
+  "Processing…": "Procesando…"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1491,5 +1491,10 @@
   "Process incoming items on this device": "پردازش موارد ورودی روی این دستگاه",
   "Email books to your library": "ارسال کتاب‌ها با ایمیل به کتابخانه‌تان",
   "Email a book or document to this address from an approved sender below.": "از فرستندهٔ تأییدشدهٔ زیر، کتاب یا سندی را به این نشانی ایمیل کنید.",
-  "Download and import books emailed to your address.": "دانلود و وارد کردن کتاب‌هایی که به نشانی شما ایمیل شده‌اند."
+  "Download and import books emailed to your address.": "دانلود و وارد کردن کتاب‌هایی که به نشانی شما ایمیل شده‌اند.",
+  "System Dictionary": "فرهنگ‌نامه سیستم",
+  "System": "سیستم",
+  "System dictionary integration is coming soon on this platform.": "یکپارچه‌سازی فرهنگ‌نامه سیستم به‌زودی در این پلتفرم در دسترس قرار می‌گیرد.",
+  "Waiting to be processed": "در انتظار پردازش",
+  "Processing…": "در حال پردازش…"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1519,5 +1519,10 @@
   "Process incoming items on this device": "Traiter les éléments entrants sur cet appareil",
   "Email books to your library": "Envoyer des livres vers votre bibliothèque par e-mail",
   "Email a book or document to this address from an approved sender below.": "Envoyez un livre ou un document à cette adresse depuis un expéditeur approuvé ci-dessous.",
-  "Download and import books emailed to your address.": "Téléchargez et importez les livres envoyés par e-mail à votre adresse."
+  "Download and import books emailed to your address.": "Téléchargez et importez les livres envoyés par e-mail à votre adresse.",
+  "System Dictionary": "Dictionnaire système",
+  "System": "Système",
+  "System dictionary integration is coming soon on this platform.": "L’intégration du dictionnaire système arrive bientôt sur cette plateforme.",
+  "Waiting to be processed": "En attente de traitement",
+  "Processing…": "Traitement…"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1519,5 +1519,10 @@
   "Process incoming items on this device": "עיבוד פריטים נכנסים במכשיר זה",
   "Email books to your library": "שליחת ספרים אל הספרייה שלך באימייל",
   "Email a book or document to this address from an approved sender below.": "שלחו ספר או מסמך לכתובת זו משולח מאושר מהרשימה למטה.",
-  "Download and import books emailed to your address.": "הורדה וייבוא של ספרים שנשלחו לכתובת שלך בדוא״ל."
+  "Download and import books emailed to your address.": "הורדה וייבוא של ספרים שנשלחו לכתובת שלך בדוא״ל.",
+  "System Dictionary": "מילון המערכת",
+  "System": "מערכת",
+  "System dictionary integration is coming soon on this platform.": "שילוב מילון המערכת יהיה זמין בקרוב בפלטפורמה זו.",
+  "Waiting to be processed": "ממתין לעיבוד",
+  "Processing…": "מעבד…"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1491,5 +1491,10 @@
   "Process incoming items on this device": "इस डिवाइस पर आने वाली वस्तुओं को प्रोसेस करें",
   "Email books to your library": "अपनी लाइब्रेरी में किताबें ईमेल करें",
   "Email a book or document to this address from an approved sender below.": "नीचे दिए गए किसी अनुमोदित प्रेषक से इस पते पर कोई पुस्तक या दस्तावेज़ ईमेल करें।",
-  "Download and import books emailed to your address.": "आपके पते पर ईमेल की गई पुस्तकें डाउनलोड और आयात करें।"
+  "Download and import books emailed to your address.": "आपके पते पर ईमेल की गई पुस्तकें डाउनलोड और आयात करें।",
+  "System Dictionary": "सिस्टम शब्दकोश",
+  "System": "सिस्टम",
+  "System dictionary integration is coming soon on this platform.": "इस प्लेटफ़ॉर्म पर सिस्टम शब्दकोश एकीकरण जल्द ही आ रहा है।",
+  "Waiting to be processed": "संसाधन की प्रतीक्षा में",
+  "Processing…": "संसाधित किया जा रहा है…"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1491,5 +1491,10 @@
   "Process incoming items on this device": "Bejövő elemek feldolgozása ezen az eszközön",
   "Email books to your library": "Küldjön könyveket a könyvtárába e-mailben",
   "Email a book or document to this address from an approved sender below.": "Küldjön egy könyvet vagy dokumentumot erre a címre egy lent jóváhagyott feladótól.",
-  "Download and import books emailed to your address.": "Az e-mailben a címedre küldött könyvek letöltése és importálása."
+  "Download and import books emailed to your address.": "Az e-mailben a címedre küldött könyvek letöltése és importálása.",
+  "System Dictionary": "Rendszerszótár",
+  "System": "Rendszer",
+  "System dictionary integration is coming soon on this platform.": "A rendszerszótár integrációja hamarosan elérhető lesz ezen a platformon.",
+  "Waiting to be processed": "Feldolgozásra vár",
+  "Processing…": "Feldolgozás…"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1463,5 +1463,10 @@
   "Process incoming items on this device": "Proses item masuk di perangkat ini",
   "Email books to your library": "Kirim buku ke perpustakaan Anda melalui email",
   "Email a book or document to this address from an approved sender below.": "Kirim buku atau dokumen melalui email ke alamat ini dari pengirim yang disetujui di bawah.",
-  "Download and import books emailed to your address.": "Unduh dan impor buku yang dikirim melalui email ke alamat Anda."
+  "Download and import books emailed to your address.": "Unduh dan impor buku yang dikirim melalui email ke alamat Anda.",
+  "System Dictionary": "Kamus Sistem",
+  "System": "Sistem",
+  "System dictionary integration is coming soon on this platform.": "Integrasi kamus sistem akan segera hadir di platform ini.",
+  "Waiting to be processed": "Menunggu untuk diproses",
+  "Processing…": "Memproses…"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1519,5 +1519,10 @@
   "Process incoming items on this device": "Elabora gli elementi in arrivo su questo dispositivo",
   "Email books to your library": "Invia libri alla tua libreria via email",
   "Email a book or document to this address from an approved sender below.": "Invia un libro o un documento a questo indirizzo da un mittente approvato qui sotto.",
-  "Download and import books emailed to your address.": "Scarica e importa i libri inviati via e-mail al tuo indirizzo."
+  "Download and import books emailed to your address.": "Scarica e importa i libri inviati via e-mail al tuo indirizzo.",
+  "System Dictionary": "Dizionario di sistema",
+  "System": "Sistema",
+  "System dictionary integration is coming soon on this platform.": "L’integrazione del dizionario di sistema arriverà presto su questa piattaforma.",
+  "Waiting to be processed": "In attesa di elaborazione",
+  "Processing…": "Elaborazione…"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1463,5 +1463,10 @@
   "Process incoming items on this device": "このデバイスで受信アイテムを処理",
   "Email books to your library": "本をメールでライブラリに送信",
   "Email a book or document to this address from an approved sender below.": "下記の承認済み送信者から、書籍やドキュメントをこのアドレスにメールで送信します。",
-  "Download and import books emailed to your address.": "あなたのアドレスにメールで送られた書籍をダウンロードして取り込みます。"
+  "Download and import books emailed to your address.": "あなたのアドレスにメールで送られた書籍をダウンロードして取り込みます。",
+  "System Dictionary": "システム辞書",
+  "System": "システム",
+  "System dictionary integration is coming soon on this platform.": "システム辞書の統合は、このプラットフォームでまもなく利用可能になります。",
+  "Waiting to be processed": "処理待ち",
+  "Processing…": "処理中…"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1463,5 +1463,10 @@
   "Process incoming items on this device": "이 기기에서 수신 항목 처리",
   "Email books to your library": "책을 이메일로 라이브러리에 보내기",
   "Email a book or document to this address from an approved sender below.": "아래의 승인된 발신자에서 책이나 문서를 이 주소로 이메일로 보내세요.",
-  "Download and import books emailed to your address.": "이 주소로 이메일로 보낸 책을 다운로드하여 가져옵니다."
+  "Download and import books emailed to your address.": "이 주소로 이메일로 보낸 책을 다운로드하여 가져옵니다.",
+  "System Dictionary": "시스템 사전",
+  "System": "시스템",
+  "System dictionary integration is coming soon on this platform.": "이 플랫폼에서 시스템 사전 통합이 곧 제공됩니다.",
+  "Waiting to be processed": "처리 대기 중",
+  "Processing…": "처리 중…"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1463,5 +1463,10 @@
   "Process incoming items on this device": "Proses item masuk pada peranti ini",
   "Email books to your library": "Hantar buku ke perpustakaan anda melalui e-mel",
   "Email a book or document to this address from an approved sender below.": "E-melkan buku atau dokumen ke alamat ini daripada penghantar yang diluluskan di bawah.",
-  "Download and import books emailed to your address.": "Muat turun dan import buku yang dihantar melalui e-mel ke alamat anda."
+  "Download and import books emailed to your address.": "Muat turun dan import buku yang dihantar melalui e-mel ke alamat anda.",
+  "System Dictionary": "Kamus Sistem",
+  "System": "Sistem",
+  "System dictionary integration is coming soon on this platform.": "Penyepaduan kamus sistem akan tiba tidak lama lagi di platform ini.",
+  "Waiting to be processed": "Menunggu untuk diproses",
+  "Processing…": "Memproses…"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1491,5 +1491,10 @@
   "Process incoming items on this device": "Inkomende items op dit apparaat verwerken",
   "Email books to your library": "Boeken per e-mail naar je bibliotheek sturen",
   "Email a book or document to this address from an approved sender below.": "E-mail een boek of document naar dit adres vanaf een goedgekeurde afzender hieronder.",
-  "Download and import books emailed to your address.": "Download en importeer boeken die naar je adres zijn gemaild."
+  "Download and import books emailed to your address.": "Download en importeer boeken die naar je adres zijn gemaild.",
+  "System Dictionary": "Systeemwoordenboek",
+  "System": "Systeem",
+  "System dictionary integration is coming soon on this platform.": "Integratie van het systeemwoordenboek komt binnenkort beschikbaar op dit platform.",
+  "Waiting to be processed": "Wacht op verwerking",
+  "Processing…": "Bezig met verwerken…"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1547,5 +1547,10 @@
   "Process incoming items on this device": "Przetwarzaj przychodzące elementy na tym urządzeniu",
   "Email books to your library": "Wysyłaj książki do swojej biblioteki przez e-mail",
   "Email a book or document to this address from an approved sender below.": "Wyślij książkę lub dokument na ten adres od zatwierdzonego nadawcy poniżej.",
-  "Download and import books emailed to your address.": "Pobieraj i importuj książki wysłane e-mailem na Twój adres."
+  "Download and import books emailed to your address.": "Pobieraj i importuj książki wysłane e-mailem na Twój adres.",
+  "System Dictionary": "Słownik systemowy",
+  "System": "System",
+  "System dictionary integration is coming soon on this platform.": "Integracja słownika systemowego wkrótce pojawi się na tej platformie.",
+  "Waiting to be processed": "Oczekuje na przetworzenie",
+  "Processing…": "Przetwarzanie…"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1519,5 +1519,10 @@
   "Process incoming items on this device": "Processar itens recebidos neste dispositivo",
   "Email books to your library": "Enviar livros para a sua biblioteca por e-mail",
   "Email a book or document to this address from an approved sender below.": "Envie um livro ou documento para este endereço de um remetente aprovado abaixo.",
-  "Download and import books emailed to your address.": "Baixe e importe livros enviados por e-mail para o seu endereço."
+  "Download and import books emailed to your address.": "Baixe e importe livros enviados por e-mail para o seu endereço.",
+  "System Dictionary": "Dicionário do sistema",
+  "System": "Sistema",
+  "System dictionary integration is coming soon on this platform.": "A integração com o dicionário do sistema chegará em breve nesta plataforma.",
+  "Waiting to be processed": "Aguardando processamento",
+  "Processing…": "Processando…"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1519,5 +1519,10 @@
   "Process incoming items on this device": "Processar itens recebidos neste dispositivo",
   "Email books to your library": "Enviar livros para a sua biblioteca por e-mail",
   "Email a book or document to this address from an approved sender below.": "Envie um livro ou documento para este endereço a partir de um remetente aprovado abaixo.",
-  "Download and import books emailed to your address.": "Transfira e importe livros enviados por e-mail para o seu endereço."
+  "Download and import books emailed to your address.": "Transfira e importe livros enviados por e-mail para o seu endereço.",
+  "System Dictionary": "Dicionário do sistema",
+  "System": "Sistema",
+  "System dictionary integration is coming soon on this platform.": "A integração com o dicionário do sistema chegará em breve nesta plataforma.",
+  "Waiting to be processed": "Aguardando processamento",
+  "Processing…": "A processar…"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1519,5 +1519,10 @@
   "Process incoming items on this device": "Procesează elementele primite pe acest dispozitiv",
   "Email books to your library": "Trimiteți cărți în biblioteca dvs. prin e-mail",
   "Email a book or document to this address from an approved sender below.": "Trimite o carte sau un document la această adresă de la un expeditor aprobat de mai jos.",
-  "Download and import books emailed to your address.": "Descarcă și importă cărțile trimise prin e-mail la adresa ta."
+  "Download and import books emailed to your address.": "Descarcă și importă cărțile trimise prin e-mail la adresa ta.",
+  "System Dictionary": "Dicționarul sistemului",
+  "System": "Sistem",
+  "System dictionary integration is coming soon on this platform.": "Integrarea cu dicționarul sistemului va fi disponibilă în curând pe această platformă.",
+  "Waiting to be processed": "În așteptarea procesării",
+  "Processing…": "Se procesează…"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1547,5 +1547,10 @@
   "Process incoming items on this device": "Обрабатывать входящие элементы на этом устройстве",
   "Email books to your library": "Отправляйте книги в свою библиотеку по электронной почте",
   "Email a book or document to this address from an approved sender below.": "Отправьте книгу или документ на этот адрес от одобренного отправителя из списка ниже.",
-  "Download and import books emailed to your address.": "Загружайте и импортируйте книги, отправленные на ваш адрес по электронной почте."
+  "Download and import books emailed to your address.": "Загружайте и импортируйте книги, отправленные на ваш адрес по электронной почте.",
+  "System Dictionary": "Системный словарь",
+  "System": "Система",
+  "System dictionary integration is coming soon on this platform.": "Интеграция системного словаря скоро появится на этой платформе.",
+  "Waiting to be processed": "Ожидает обработки",
+  "Processing…": "Обработка…"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1491,5 +1491,10 @@
   "Process incoming items on this device": "මෙම උපාංගයේ පැමිණෙන අයිතම සකසන්න",
   "Email books to your library": "ඔබේ පුස්තකාලයට පොත් විද්‍යුත් තැපැල් කරන්න",
   "Email a book or document to this address from an approved sender below.": "පහත අනුමත එවන්නෙකුගෙන් මෙම ලිපිනයට පොතක් හෝ ලේඛනයක් විද්‍යුත් තැපෑලෙන් එවන්න.",
-  "Download and import books emailed to your address.": "ඔබේ ලිපිනයට විද්‍යුත් තැපෑලෙන් එවූ පොත් බාගත කර ආයාත කරන්න."
+  "Download and import books emailed to your address.": "ඔබේ ලිපිනයට විද්‍යුත් තැපෑලෙන් එවූ පොත් බාගත කර ආයාත කරන්න.",
+  "System Dictionary": "පද්ධතියේ ශබ්දකෝෂය",
+  "System": "පද්ධතිය",
+  "System dictionary integration is coming soon on this platform.": "මෙම වේදිකාවේ පද්ධති ශබ්දකෝෂ ඒකාබද්ධතාව ඉක්මනින් පැමිණේ.",
+  "Waiting to be processed": "සැකසීමට බලාපොරොත්තු වෙමින්",
+  "Processing…": "සැකසෙමින්…"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1547,5 +1547,10 @@
   "Process incoming items on this device": "Obdelaj dohodne elemente na tej napravi",
   "Email books to your library": "Pošiljajte knjige v svojo knjižnico po e-pošti",
   "Email a book or document to this address from an approved sender below.": "Pošljite knjigo ali dokument na ta naslov od odobrenega pošiljatelja spodaj.",
-  "Download and import books emailed to your address.": "Prenesite in uvozite knjige, poslane na vaš naslov po e-pošti."
+  "Download and import books emailed to your address.": "Prenesite in uvozite knjige, poslane na vaš naslov po e-pošti.",
+  "System Dictionary": "Sistemski slovar",
+  "System": "Sistem",
+  "System dictionary integration is coming soon on this platform.": "Integracija sistemskega slovarja bo kmalu na voljo na tej platformi.",
+  "Waiting to be processed": "Čaka na obdelavo",
+  "Processing…": "Obdelovanje…"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1491,5 +1491,10 @@
   "Process incoming items on this device": "Bearbeta inkommande objekt på den här enheten",
   "Email books to your library": "Skicka böcker till ditt bibliotek via e-post",
   "Email a book or document to this address from an approved sender below.": "Mejla en bok eller ett dokument till den här adressen från en godkänd avsändare nedan.",
-  "Download and import books emailed to your address.": "Ladda ner och importera böcker som mejlats till din adress."
+  "Download and import books emailed to your address.": "Ladda ner och importera böcker som mejlats till din adress.",
+  "System Dictionary": "Systemets ordbok",
+  "System": "System",
+  "System dictionary integration is coming soon on this platform.": "Integration med systemets ordbok kommer snart till denna plattform.",
+  "Waiting to be processed": "Väntar på bearbetning",
+  "Processing…": "Bearbetar…"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1491,5 +1491,10 @@
   "Process incoming items on this device": "இந்தச் சாதனத்தில் உள்வரும் உருப்படிகளைச் செயலாக்கு",
   "Email books to your library": "உங்கள் நூலகத்திற்குப் புத்தகங்களை மின்னஞ்சல் செய்யவும்",
   "Email a book or document to this address from an approved sender below.": "கீழே உள்ள அங்கீகரிக்கப்பட்ட அனுப்புநரிடமிருந்து இந்த முகவரிக்கு ஒரு புத்தகம் அல்லது ஆவணத்தை மின்னஞ்சல் செய்யவும்.",
-  "Download and import books emailed to your address.": "உங்கள் முகவரிக்கு மின்னஞ்சல் செய்யப்பட்ட புத்தகங்களைப் பதிவிறக்கி இறக்குமதி செய்யவும்."
+  "Download and import books emailed to your address.": "உங்கள் முகவரிக்கு மின்னஞ்சல் செய்யப்பட்ட புத்தகங்களைப் பதிவிறக்கி இறக்குமதி செய்யவும்.",
+  "System Dictionary": "கணினி அகராதி",
+  "System": "கணினி",
+  "System dictionary integration is coming soon on this platform.": "இந்த தளத்தில் கணினி அகராதி ஒருங்கிணைப்பு விரைவில் வரும்.",
+  "Waiting to be processed": "செயலாக்கத்திற்காகக் காத்திருக்கிறது",
+  "Processing…": "செயலாக்கப்படுகிறது…"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1463,5 +1463,10 @@
   "Process incoming items on this device": "ประมวลผลรายการที่เข้ามาบนอุปกรณ์นี้",
   "Email books to your library": "ส่งหนังสือทางอีเมลไปยังคลังของคุณ",
   "Email a book or document to this address from an approved sender below.": "ส่งหนังสือหรือเอกสารทางอีเมลไปยังที่อยู่นี้จากผู้ส่งที่อนุมัติด้านล่าง",
-  "Download and import books emailed to your address.": "ดาวน์โหลดและนำเข้าหนังสือที่ส่งทางอีเมลมายังที่อยู่ของคุณ"
+  "Download and import books emailed to your address.": "ดาวน์โหลดและนำเข้าหนังสือที่ส่งทางอีเมลมายังที่อยู่ของคุณ",
+  "System Dictionary": "พจนานุกรมของระบบ",
+  "System": "ระบบ",
+  "System dictionary integration is coming soon on this platform.": "การผสานพจนานุกรมของระบบจะมาถึงในไม่ช้าบนแพลตฟอร์มนี้",
+  "Waiting to be processed": "รอการประมวลผล",
+  "Processing…": "กำลังประมวลผล…"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1491,5 +1491,10 @@
   "Process incoming items on this device": "Gelen öğeleri bu cihazda işle",
   "Email books to your library": "Kitapları kitaplığınıza e-postayla gönderin",
   "Email a book or document to this address from an approved sender below.": "Aşağıdaki onaylı bir göndericiden bu adrese bir kitap veya belge e-postayla gönderin.",
-  "Download and import books emailed to your address.": "Adresinize e-postayla gönderilen kitapları indirip içe aktarın."
+  "Download and import books emailed to your address.": "Adresinize e-postayla gönderilen kitapları indirip içe aktarın.",
+  "System Dictionary": "Sistem Sözlüğü",
+  "System": "Sistem",
+  "System dictionary integration is coming soon on this platform.": "Sistem sözlüğü entegrasyonu yakında bu platformda kullanıma sunulacak.",
+  "Waiting to be processed": "İşlenmeyi bekliyor",
+  "Processing…": "İşleniyor…"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1547,5 +1547,10 @@
   "Process incoming items on this device": "Обробляти вхідні елементи на цьому пристрої",
   "Email books to your library": "Надсилайте книги до своєї бібліотеки електронною поштою",
   "Email a book or document to this address from an approved sender below.": "Надішліть книгу або документ на цю адресу від схваленого відправника зі списку нижче.",
-  "Download and import books emailed to your address.": "Завантажуйте та імпортуйте книги, надіслані на вашу адресу електронною поштою."
+  "Download and import books emailed to your address.": "Завантажуйте та імпортуйте книги, надіслані на вашу адресу електронною поштою.",
+  "System Dictionary": "Системний словник",
+  "System": "Система",
+  "System dictionary integration is coming soon on this platform.": "Інтеграція системного словника незабаром з’явиться на цій платформі.",
+  "Waiting to be processed": "Очікує на обробку",
+  "Processing…": "Обробка…"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1491,5 +1491,10 @@
   "Process incoming items on this device": "Bu qurilmada kiruvchi elementlarni qayta ishlash",
   "Email books to your library": "Kitoblarni kutubxonangizga e-pochta orqali yuborish",
   "Email a book or document to this address from an approved sender below.": "Quyidagi tasdiqlangan jo‘natuvchidan ushbu manzilga kitob yoki hujjatni e-pochta orqali yuboring.",
-  "Download and import books emailed to your address.": "Manzilingizga e-pochta orqali yuborilgan kitoblarni yuklab oling va import qiling."
+  "Download and import books emailed to your address.": "Manzilingizga e-pochta orqali yuborilgan kitoblarni yuklab oling va import qiling.",
+  "System Dictionary": "Tizim lug‘ati",
+  "System": "Tizim",
+  "System dictionary integration is coming soon on this platform.": "Tizim lug‘ati integratsiyasi tez orada ushbu platformada paydo bo‘ladi.",
+  "Waiting to be processed": "Qayta ishlanishi kutilmoqda",
+  "Processing…": "Qayta ishlanmoqda…"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1463,5 +1463,10 @@
   "Process incoming items on this device": "Xử lý các mục đến trên thiết bị này",
   "Email books to your library": "Gửi sách vào thư viện của bạn qua email",
   "Email a book or document to this address from an approved sender below.": "Gửi sách hoặc tài liệu qua email đến địa chỉ này từ người gửi đã được phê duyệt bên dưới.",
-  "Download and import books emailed to your address.": "Tải xuống và nhập sách được gửi qua email đến địa chỉ của bạn."
+  "Download and import books emailed to your address.": "Tải xuống và nhập sách được gửi qua email đến địa chỉ của bạn.",
+  "System Dictionary": "Từ điển hệ thống",
+  "System": "Hệ thống",
+  "System dictionary integration is coming soon on this platform.": "Tích hợp từ điển hệ thống sẽ sớm có mặt trên nền tảng này.",
+  "Waiting to be processed": "Đang chờ xử lý",
+  "Processing…": "Đang xử lý…"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1463,5 +1463,10 @@
   "Process incoming items on this device": "在此设备上处理接收的项目",
   "Email books to your library": "通过电子邮件将图书发送到您的书库",
   "Email a book or document to this address from an approved sender below.": "从下方已批准的发件人，将图书或文档通过电子邮件发送到此地址。",
-  "Download and import books emailed to your address.": "下载并导入通过电子邮件发送到您地址的图书。"
+  "Download and import books emailed to your address.": "下载并导入通过电子邮件发送到您地址的图书。",
+  "System Dictionary": "系统词典",
+  "System": "系统",
+  "System dictionary integration is coming soon on this platform.": "即将在此平台支持系统词典集成。",
+  "Waiting to be processed": "等待处理",
+  "Processing…": "处理中…"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1463,5 +1463,10 @@
   "Process incoming items on this device": "在此裝置上處理接收的項目",
   "Email books to your library": "透過電子郵件將書籍傳送到您的書庫",
   "Email a book or document to this address from an approved sender below.": "從下方已核准的寄件者，將書籍或文件透過電子郵件傳送到此地址。",
-  "Download and import books emailed to your address.": "下載並匯入透過電子郵件傳送到您地址的書籍。"
+  "Download and import books emailed to your address.": "下載並匯入透過電子郵件傳送到您地址的書籍。",
+  "System Dictionary": "系統字典",
+  "System": "系統",
+  "System dictionary integration is coming soon on this platform.": "即將在此平臺支援系統字典整合。",
+  "Waiting to be processed": "等待處理",
+  "Processing…": "處理中…"
 }

--- a/apps/readest-app/src/components/settings/integrations/SendToReadestForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/SendToReadestForm.tsx
@@ -346,9 +346,10 @@ const SendToReadestForm: React.FC<SendToReadestFormProps> = ({ onBack }) => {
                         {item.filename || item.url || _('Untitled')}
                       </SettingLabel>
                       <span className='text-base-content/60 text-[0.8em]'>
-                        {item.status === 'failed'
-                          ? item.error || _('Failed')
-                          : _(activityStatusLabel(item.status))}
+                        {item.status === 'done' && _('Added to your library')}
+                        {item.status === 'pending' && _('Waiting to be processed')}
+                        {item.status === 'claimed' && _('Processing…')}
+                        {item.status === 'failed' && (item.error || _('Failed'))}
                       </span>
                     </div>
                   </div>
@@ -372,18 +373,5 @@ const SendToReadestForm: React.FC<SendToReadestFormProps> = ({ onBack }) => {
     </div>
   );
 };
-
-function activityStatusLabel(status: DBSendInboxItem['status']): string {
-  switch (status) {
-    case 'done':
-      return 'Added to your library';
-    case 'pending':
-      return 'Waiting to be processed';
-    case 'claimed':
-      return 'Processing…';
-    default:
-      return 'Failed';
-  }
-}
 
 export default SendToReadestForm;


### PR DESCRIPTION
## Summary

The Send to Readest recent-activity status labels (Added to your library / Waiting to be processed / Processing… / Failed) went through `_(activityStatusLabel(item.status))` — a dynamic key the i18next-scanner cannot extract — so non-English locales rendered them in English.

Inlines the four literal `_()` calls into the JSX so the scanner picks them up.

## What changed

- Inline the status switch in `SendToReadestForm.tsx` (drop the helper function).
- Translate the 2 missing keys (`Waiting to be processed`, `Processing…`) across all 33 non-English locales — the other two (`Added to your library`, `Failed`) were already extracted via other call sites.
- Sweep in the 3 pre-existing untranslated `System Dictionary` keys from #4219 that the i18n extractor surfaced — the file would otherwise still have `__STRING_NOT_TRANSLATED__` placeholders.

## Test plan

- [x] `pnpm test` — 4389 pass / 0 fail
- [x] `pnpm lint` — tsgo + Biome clean
- [x] `pnpm format:check` — clean
- [x] `grep -r '__STRING_NOT_TRANSLATED__' public/locales/` — zero remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)