### PR TITLE
feat(send): auto-seed the allowlist with the user's account email

### DIFF
--- a/apps/readest-app/src/pages/api/send/address.ts
+++ b/apps/readest-app/src/pages/api/send/address.ts
@@ -7,6 +7,7 @@ import {
   buildSendAddress,
   sanitizeSlug,
   isReservedSlug,
+  normalizeSenderEmail,
 } from '@/services/send/sendAddress';
 import { SEND_EMAIL_DOMAIN } from '@/services/constants';
 import type { DBSendAddress } from '@/types/sendRecords';
@@ -50,6 +51,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!created) {
       return res.status(500).json({ error: 'Could not allocate an address' });
     }
+    // Auto-seed the allowlist with the user's account email so the most common
+    // first send ("email it to yourself") works without a separate approval.
+    // Best-effort: address creation succeeds even if the seed insert fails.
+    if (user.email) {
+      await seedOwnEmail(supabase, user.id, user.email);
+    }
     return res.status(200).json({ address: fullAddress(created), enabled: true });
   }
 
@@ -92,6 +99,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   return res.status(405).json({ error: 'Method not allowed' });
+}
+
+async function seedOwnEmail(
+  supabase: ReturnType<typeof createSupabaseAdminClient>,
+  userId: string,
+  email: string,
+): Promise<void> {
+  const normalized = normalizeSenderEmail(email);
+  if (!normalized) return;
+  await supabase
+    .from('send_allowed_senders')
+    .upsert(
+      { user_id: userId, email: normalized, status: 'approved' },
+      { onConflict: 'user_id,email' },
+    );
 }
 
 async function insertWithRetry(


### PR DESCRIPTION
## Summary

The Email Worker rejects mail from senders that are not in the user's approved-sender allowlist. With an empty allowlist the very first send ("email it to yourself") bounces with an approval-pending notice — wrong first impression.

This seeds the caller's verified account email as `approved` at the moment the user's `send_addresses` row is lazily created (first `/api/send/address` GET).

## Behavior

- Triggers only on lazy address creation (not on rotation, not on subsequent GETs of an existing address).
- Idempotent: the existing `UNIQUE (user_id, email)` constraint + `onConflict: 'user_id,email'` upsert means seeding twice (or with a sender the user has since added themselves) is a no-op.
- Best-effort: address creation still succeeds if the seed insert fails.

## Test plan

- [x] `pnpm test` — 4389 pass / 0 fail
- [x] `pnpm lint` — tsgo + Biome clean
- [x] `pnpm format:check` — clean
- [x] Manual: new user → first settings open → approved-senders shows the account email pre-approved → email-yourself works on the first try

🤖 Generated with [Claude Code](https://claude.com/claude-code)