### PR TITLE
chore(worktree): copy gen/apple per-worktree so iOS dev builds the worktree's source

### DIFF
--- a/apps/readest-app/scripts/worktree-new.ts
+++ b/apps/readest-app/scripts/worktree-new.ts
@@ -240,8 +240,41 @@ if (fs.existsSync(androidGenDir)) {
   });
 }
 
-// Symlink Tauri gen/apple and gen/schemas from the main worktree
-for (const sub of ['apple', 'schemas', 'android/keystore.properties']) {
+// Copy Tauri iOS gen from the bare repo, skipping rebuildable artifacts so
+// the worktree owns its own Xcode project. `project.yml` and the Xcode build
+// script walk up to `../../src` / `../../Cargo.toml`, which now resolve to
+// the worktree's Rust source instead of the bare repo's — so `pnpm tauri ios
+// dev` from a worktree actually builds the worktree's code. Symlinking
+// silently routed every iOS build through the bare repo, even when running
+// `pnpm tauri ios dev` from a worktree path.
+//
+// Skipped: `build/` (~300 MB of Xcode derived output), `Externals/<arch>/
+// {debug,release}/` (Rust static libs — rebuilt against the worktree's
+// src-tauri), per-user Xcode state, and `Pods/` (defensive; Readest's iOS
+// uses SPM, not Cocoapods).
+const appleGenDir = path.join(genDir, 'apple');
+const srcAppleGen = path.join(srcAppDir, 'src-tauri', 'gen', 'apple');
+if (fs.existsSync(srcAppleGen) && !fs.existsSync(appleGenDir)) {
+  console.error('\n--- Copying Tauri iOS gen ---');
+  fs.cpSync(srcAppleGen, appleGenDir, {
+    recursive: true,
+    dereference: false,
+    filter: (src) => {
+      const rel = path.relative(srcAppleGen, src);
+      if (rel === 'build' || rel.startsWith('build/')) return false;
+      if (/^Externals\/[^/]+\/(debug|release)(\/|$)/.test(rel)) return false;
+      if (rel.endsWith('/xcuserdata') || rel.includes('/xcuserdata/')) return false;
+      if (rel.endsWith('.xcuserstate')) return false;
+      if (rel === 'Pods' || rel.startsWith('Pods/')) return false;
+      return true;
+    },
+  });
+}
+
+// Symlink the remaining shared gen dirs (schemas are generated at build time
+// and don't differ per branch; keystore.properties is signing config that
+// must stay identical across worktrees to produce matching APKs).
+for (const sub of ['schemas', 'android/keystore.properties']) {
   const src = path.join(srcAppDir, 'src-tauri', 'gen', sub);
   const dst = path.join(genDir, sub);
   if (fs.existsSync(src) && !fs.existsSync(dst)) {


### PR DESCRIPTION
## Summary

Worktrees set up by \`pnpm worktree:new\` symlinked \`src-tauri/gen/apple\` back to the bare repo. The Xcode "Run Script" build phase (\`pnpm tauri ios xcode-script\`) walks up from \`Readest.xcodeproj\` to find \`Cargo.toml\`, but the symlink target resolves to the bare repo's \`src-tauri\` — so \`pnpm tauri ios dev\` from a worktree silently built the **bare repo's** Rust source, not the worktree's. Worktree-based iOS work was effectively impossible.

Switch to a filtered copy. \`project.yml\` references \`../../src\` and the xcode-script walks up to \`../../Cargo.toml\`; with the project copied into the worktree, both paths resolve to the worktree's source. Mirrors what the script already does for Android (\`tauri android init\` per worktree).

## What's copied vs skipped

Copied verbatim from the bare repo:
- \`Readest.xcodeproj/\` (signing config, scheme, target settings)
- \`project.yml\` (XcodeGen source of truth)
- \`Sources/Readest/\` (Tauri-generated Swift glue)
- \`Assets.xcassets/\`, \`Readest_iOS/Info.plist\`, entitlements, \`LaunchScreen.storyboard\`
- \`Externals/\` directory structure (subdirs added on first build)

Skipped (rebuildable / huge / per-user):
- \`build/\` — ~300 MB of Xcode derived output
- \`Externals/<arch>/{debug,release}/\` — Rust static libs, rebuilt against the worktree's \`src-tauri\` on first build. The \`target/\` symlink the script already sets up keeps the Rust object cache shared, so the rebuild is mostly link-only.
- \`xcuserdata/\`, \`*.xcuserstate\` — per-user Xcode state
- \`Pods/\` — defensive; Readest's iOS uses SPM, not Cocoapods

Result: ~2.7 MB copy, ~30 ms locally, no \`pod install\`, no \`tauri ios init\`.

## One-time fix for existing worktrees

Existing worktrees still have the symlink. To convert in place:

\`\`\`bash
cd <worktree>/apps/readest-app
rm src-tauri/gen/apple   # removes the symlink, not a directory
rsync -a \\
  --exclude='build/' \\
  --exclude='Externals/*/debug' \\
  --exclude='Externals/*/release' \\
  --exclude='**/xcuserdata' \\
  --exclude='*.xcuserstate' \\
  /Users/chrox/dev/readest/apps/readest-app/src-tauri/gen/apple/ \\
  src-tauri/gen/apple/
\`\`\`

## Test plan

- [x] \`pnpm lint\` passes (tsgo + biome)
- [x] Filter unit-tested on 16 path cases (build/Externals/xcuserdata/Pods all excluded; project.yml/pbxproj/Sources/Externals top-level kept)
- [x] Smoke test: \`pnpm worktree:new test/ios-copy-smoke\` against modified script produces a real directory (not a symlink), 2.9 MB, with all critical files present and \`project.yml\`'s \`../../src\` resolving to the test worktree's \`src-tauri/src\`
- [x] Real device test: \`pnpm tauri ios dev "iPhone 16 Pro"\` from a worktree built with the modified script picks up an edit to \`src-tauri/src/lib.rs\` in that worktree (vs the bare repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)