### PR TITLE
fix(migration): skip migrate20251029 silently on fresh installs

### DIFF
--- a/apps/readest-app/src/services/nativeAppService.ts
+++ b/apps/readest-app/src/services/nativeAppService.ts
@@ -665,10 +665,20 @@ export class NativeAppService extends BaseAppService {
     const rootPath = await this.resolveFilePath('..', 'Data');
     const newDir = await this.fs.getPrefix('Images');
     const oldDir = await join(rootPath, 'Images', 'Readest', 'Images');
+    const dirToDelete = await join(rootPath, 'Images', 'Readest');
+
+    // Skip silently on fresh installs that never had the legacy layout.
+    // copyFiles / deleteDir would otherwise throw `os error 2` when the
+    // old directory does not exist, which is harmless but noisy.
+    if (!(await this.fs.exists(oldDir, 'None'))) {
+      console.log('Migration 20251029: legacy Images/Readest/Images not found, skipping.');
+      return;
+    }
 
     await copyFiles(this, oldDir, newDir);
 
-    const dirToDelete = await join(rootPath, 'Images', 'Readest');
-    await this.deleteDir(dirToDelete, 'None', true);
+    if (await this.fs.exists(dirToDelete, 'None')) {
+      await this.deleteDir(dirToDelete, 'None', true);
+    }
   }
 }


### PR DESCRIPTION
## Problem

`NativeAppService.migrate20251029` unconditionally calls `copyFiles()` and `deleteDir()` on the legacy `Images/Readest/Images` path:

```ts
async migrate20251029() {
  console.log('Running migration 20251029 to update paths in Images dir...');
  const rootPath = await this.resolveFilePath('..', 'Data');
  const newDir = await this.fs.getPrefix('Images');
  const oldDir = await join(rootPath, 'Images', 'Readest', 'Images');

  await copyFiles(this, oldDir, newDir);

  const dirToDelete = await join(rootPath, 'Images', 'Readest');
  await this.deleteDir(dirToDelete, 'None', true);
}
```

On a fresh install where that legacy directory never existed, both calls bubble up an OS error (`os error 2` / ENOENT). `runMigrations()` does catch it, so functionally nothing breaks (`migrationVersion` is still advanced afterwards), but every fresh install logs a misleading red error on first launch:

```
Error migrating to version 20251029: ...os error 2...
```

This is a red herring for new users who check the dev console, and noise for anyone debugging unrelated startup issues.

## Fix

Probe `fs.exists(oldDir)` up front. If the legacy directory is absent, log an informational message and return — there is genuinely nothing to migrate. Also guard `deleteDir()` with the same existence check, in case `copyFiles` partially completed or the cleanup target was already removed by an earlier run.

```ts
if (!(await this.fs.exists(oldDir, 'None'))) {
  console.log('Migration 20251029: legacy Images/Readest/Images not found, skipping.');
  return;
}

await copyFiles(this, oldDir, newDir);

if (await this.fs.exists(dirToDelete, 'None')) {
  await this.deleteDir(dirToDelete, 'None', true);
}
```

## Scope and behavior

- No behavior change on machines that actually have the legacy `Images/Readest/Images` layout — they still copy and delete exactly as before.
- Fresh-install machines now log one informational `console.log` instead of a misleading `console.error`.
- `migrationVersion` advancement is unchanged (already happened in `runMigrations` regardless of this function's outcome).
- +12 / -2 lines, single function, no new dependencies.