### PR TITLE
fix(eink): restore [data-eink='true'] button rule grouping

### DIFF
--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -565,6 +565,10 @@ input[type='range'].slider-input {
 }
 
 [data-eink='true'] button,
+[data-eink='true'] .btn {
+  color: theme('colors.base-content') !important;
+}
+
 /* btn-contrast — a solid, high-contrast CTA: base-content background with a
    base-100 label. Theme-neutral (unlike the colored btn-primary); fits the
    minimalist themes and is already e-ink-correct. */
@@ -575,10 +579,6 @@ input[type='range'].slider-input {
 }
 .btn-contrast:hover {
   opacity: 0.9;
-}
-
-[data-eink='true'] .btn {
-  color: theme('colors.base-content') !important;
 }
 
 [data-eink='true'] .btn-primary,


### PR DESCRIPTION

## Summary
PR #4230 inadvertently split the `[data-eink='true'] button, [data-eink='true'] .btn` rule by inserting the new `.btn-contrast` block in the middle of the
selector list. The result: in e-ink mode, every `<button class="btn">` ends up with both `background-color: base-content` and `color: base-content` (the second
wins on specificity 0,2,0 vs 0,1,1), so any react-icons child rendered with `fill: currentColor` becomes the same color as the button background — toolbar/popup
 buttons appear as solid black (light) or solid white (dark) squares.

## Fix
One-hunk regroup: put the new `.btn-contrast` block **after** the existing eink button/.btn selector list, restoring the pre-#4230 grouping.

## Repro
- Enable E-Ink Mode in settings (any non-color e-ink preset)
- Open any book → select text → annotation toolbar buttons render as solid blocks
- Open settings panels → `.btn` actions inside also affected

## Verification
With the fix, all toolbar/popup buttons recover their icon glyphs; `.btn-contrast` continues to render as the intended solid high-contrast CTA in both modes. No
 other selectors touched.

## Regression range
Introduced by #4230 (commit `0b18de05`, 2026-05-20). Reproducible on `web.readest.com` and all native shells from that build onward.
