### PR TITLE
fix: Docker image tagging, production runtime, dev compose, and Codespace support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "Readest",
+  // Initialize only the submodules required for Docker builds.
+  // tauri/tauri-plugins are skipped here since they're only needed for desktop builds.
+  "postCreateCommand": "git submodule update --init packages/foliate-js packages/simplecc-wasm"
+}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -130,8 +130,10 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/readest
           tags: |
             type=raw,value=main,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
             type=sha,prefix=sha-
 
       - name: Extract image metadata (GHCR + Docker Hub)
@@ -144,8 +146,10 @@ jobs:
             docker.io/${{ secrets.DOCKERHUB_USERNAME }}/readest
           tags: |
             type=raw,value=main,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-            type=raw,value=${{ github.event.release.tag_name }},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
             type=sha,prefix=sha-
 
       - name: Create manifest list and push (GHCR only)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ COPY apps/readest-app/package.json ./apps/readest-app/
 COPY patches/ ./patches/
 COPY packages/ ./packages/
 RUN --mount=type=cache,id=pnpm,sharing=locked,target=/pnpm/store pnpm install --frozen-lockfile
+RUN test -f packages/foliate-js/vendor/pdfjs/annotation_layer_builder.css \
+    && test -d packages/simplecc-wasm/dist/web \
+    || { printf '\nERROR: Required git submodules are not initialized in the source directory.\nEnsure submodules are initialized before running docker build.\nRun: git submodule update --init packages/foliate-js packages/simplecc-wasm\n\n'; exit 1; }
 RUN pnpm --filter @readest/readest-app setup-vendors
 
 FROM docker.io/library/node:24-slim@sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e AS development-stage
@@ -50,15 +53,7 @@ ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 RUN corepack prepare pnpm@11.1.1 --activate
 WORKDIR /app
-# Only copy what next start needs — omit source, Rust, tests, patches, etc.
-COPY --from=build /app/package.json /app/package.json
-COPY --from=build /app/pnpm-workspace.yaml /app/pnpm-workspace.yaml
-COPY --from=build /app/node_modules /app/node_modules
-COPY --from=build /app/apps/readest-app/package.json /app/apps/readest-app/package.json
-COPY --from=build /app/apps/readest-app/next.config.mjs /app/apps/readest-app/next.config.mjs
-COPY --from=build /app/apps/readest-app/node_modules /app/apps/readest-app/node_modules
-COPY --from=build /app/apps/readest-app/.next /app/apps/readest-app/.next
-COPY --from=build /app/apps/readest-app/public /app/apps/readest-app/public
+COPY --from=build /app /app
 WORKDIR /app/apps/readest-app
 ENTRYPOINT ["pnpm", "start-web", "-H", "0.0.0.0"]
 EXPOSE 3000

--- a/docker/README.md
+++ b/docker/README.md
@@ -63,12 +63,18 @@ replace `your-dockerhub-username` with the Docker Hub namespace that publishes y
 for official images, use the namespace configured for this repository's Docker Hub publishing secrets.
 
 published tags:
-- `latest`: published from release events
+- `latest`: rolling image from the default branch and from release events
 - `<release-tag>` (for example `v1.2.3`): published from release events
 - `main`: rolling image from the default branch
 - `sha-<commit>`: immutable commit tag
 
 ### Build locally instead of pulling
+
+> **Prerequisites for local builds**: the `packages/foliate-js` and `packages/simplecc-wasm` git submodules must be initialized before building:
+> ```bash
+> git submodule update --init packages/foliate-js packages/simplecc-wasm
+> ```
+> In GitHub Codespaces this is done automatically via `.devcontainer/devcontainer.json`.
 
 ```bash
 cd docker
@@ -82,16 +88,13 @@ docker compose -f compose.yaml -f compose.build.yaml up --build -d
 
 ### Hot Reload (development)
 
-to develop using the compose stack, use local builds (`compose.yaml` + `compose.build.yaml`) and set the build target on `client` to `development-stage` in `compose.build.yaml`, which runs the next.js dev server. to enable hot reload, uncomment the `volumes` block in the `client` service in `compose.yaml`:
+> **Prerequisites**: submodules must be initialized (see above).
 
-```yaml
-volumes:
-  - ../:/app
-  - /app/node_modules
-  - /app/apps/readest-app/node_modules
-  - /app/apps/readest-app/public/vendor
-  - /app/apps/readest-app/.next
-  - /app/packages/foliate-js/node_modules
+to develop using the compose stack, use `compose.dev.yaml` which sets the build target to `development-stage` (Next.js dev server) and mounts your local repo for hot reload:
+
+```bash
+cd docker
+docker compose -f compose.yaml -f compose.dev.yaml up --build -d
 ```
 
 the first mount overlays your local repo into the container. the remaining anonymous volumes shadow the directories that were pre-built inside the image, so the container's installed deps and vendor assets are used instead of what's on your host.

--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -1,0 +1,24 @@
+# Overlay on top of compose.yaml.
+# Usage (from the docker/ directory):
+#   docker compose -f compose.yaml -f compose.dev.yaml up --build -d
+services:
+  client:
+    build:
+      context: ..
+      target: development-stage
+      args:
+        NEXT_PUBLIC_APP_PLATFORM: web
+    environment:
+      # Required so pnpm does not abort when purging node_modules without a TTY
+      CI: "true"
+    # Mount the source code for hot reload.
+    # Anonymous volumes shadow pre-built dirs inside the image so the
+    # container's installed deps and vendor assets are used instead of
+    # what's on the host.
+    volumes:
+      - ../:/app
+      - /app/node_modules
+      - /app/apps/readest-app/node_modules
+      - /app/apps/readest-app/public/vendor
+      - /app/apps/readest-app/.next
+      - /app/packages/foliate-js/node_modules

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -124,14 +124,6 @@ services:
     restart: unless-stopped
     ports:
       - "3000:3000"
-#    to enable hot reload, mount the source code as a volume, and artifacts as anon volumes
-#    volumes:
-#      - ../:/app
-#      - /app/node_modules
-#      - /app/apps/readest-app/node_modules
-#      - /app/apps/readest-app/public/vendor
-#      - /app/apps/readest-app/.next
-#      - /app/packages/foliate-js/node_modules
     environment:
       SUPABASE_URL: http://kong:8000
       SUPABASE_PUBLIC_URL: http://${HOST_IP}:${KONG_HTTP_PORT:-8000}


### PR DESCRIPTION

## Summary

Fixes three Docker bugs and adds three developer-experience improvements.

## Changes

### 1. Docker image `latest` tag (`docker-image.yml`)
`latest` was only published on release events. Added `type=raw,value=latest,enable={{is_default_branch}}` so `latest` always tracks the `main` branch on every push.

This should be the case until at least we release this. Since, until then there exists no latest tag.

### 2. Semver release tags (`docker-image.yml`)
On each release (e.g. `v0.11.1`) the image is now tagged with:
- `0.11.1` — exact version
- `0.11` — major.minor

Tags are gated with `enable=${{ github.event_name == 'release' }}` so they only fire on release events.

### 3. Production stage runtime fix (`Dockerfile`)
Replaced selective file copying with `COPY --from=build /app /app` so no runtime files are ever missing.

### 4. Dev compose overlay (`docker/compose.dev.yaml`)
New overlay file for running the dev stack with hot-reload mounts:
```bash
cd docker
docker compose -f compose.yaml -f compose.dev.yaml up --build -d
```

### 5. Codespace submodule support (`.devcontainer/devcontainer.json`)
Automatically runs `git submodule update --init packages/foliate-js packages/simplecc-wasm` on Codespace creation to prevent the cryptic postcss build failure.

### 6. Dockerfile submodule guard (`Dockerfile`)
Fails immediately with a clear error if submodules aren't initialized, instead of the obscure postcss error downstream.

I also tested this multiple times in codespace dev containers to make sure everything is running good. 🤚 Thanks for your attention. 
