### PR TITLE
fix(layout): use 100vh fallback for .full-height to unbreak old Chromium WebView

### DIFF
--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -74,7 +74,7 @@ body {
 }
 
 .full-height {
-  height: -webkit-fill-available;
+  height: 100vh;
 }
 
 @supports (height: 100dvh) {


### PR DESCRIPTION
## Summary

Closes #4274.

PR #2582 set `.full-height { height: -webkit-fill-available }` as the fallback before the `@supports (height: 100dvh)` upgrade. On pre-108 Chromium Android WebView (still shipped on a lot of MTK Android 12 devices that can't update Android System WebView) that property evaluates to the parent's intrinsic content height rather than viewport-fill — `.library-page.full-height` collapses to ~52 px (the nav bar) and the bookshelf is clipped by the parent's `overflow: hidden`.

Replace the fallback with `height: 100vh`. Universal support, correct viewport-fill on every browser. The `@supports (height: 100dvh)` rule still upgrades to dvh on modern browsers (Safari 15.4+, Chrome 108+), keeping URL-bar-aware behaviour where it's available.

## Diff

```diff
 .full-height {
-  height: -webkit-fill-available;
+  height: 100vh;
 }
 @supports (height: 100dvh) {
   .full-height { height: 100dvh; }
 }
 :root.edge-to-edge .full-height { height: 100vh !important; }
```

## Trade-off (per #4274 discussion, Option A confirmed)

iOS Safari < 15.4 will overflow under the dynamic URL bar by ~50 px when on `.full-height` pages — dvh has been available on Safari since 15.4 (March 2022), so the affected slice is small in 2026.

## Test plan

- [x] On Chrome 101 WebView (MTK Android 12, no Play Services): library page now renders the full bookshelf instead of just the nav bar
- [x] On modern Safari / Chrome: still upgrades to `100dvh` via `@supports`, no visual change
- [x] No other selectors touched, no JS changes