### PR TITLE
fix: respect Android Back / Esc inside Settings sub-pages and Import-from-Folder dialog

### DIFF
--- a/apps/readest-app/src/app/library/components/ImportFromFolderDialog.tsx
+++ b/apps/readest-app/src/app/library/components/ImportFromFolderDialog.tsx
@@ -140,13 +140,22 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
   const [folderMode, setFolderMode] = useState<'keep' | 'flatten'>(initialFolderMode);
   const [picking, setPicking] = useState(false);
 
-  // Enter to confirm. Escape is handled by <Dialog> via onClose.
+  // Enter to confirm, Escape / Android Back to cancel. We must wire
+  // `onCancel` even though <Dialog> also listens for Back, because
+  // `useKeyDownActions` registers its own `native-key-down` listener that
+  // returns `true` (consuming the event) on every Back keypress — if we
+  // leave `onCancel` undefined the handler swallows Back without doing
+  // anything, and the Dialog's own listener never gets a chance to run.
   useKeyDownActions({
     onConfirm: () => {
       // Block the Enter shortcut while a folder pick is in flight so
       // we don't dispatch a confirm with a stale directory.
       if (picking) return;
       handleConfirm();
+    },
+    onCancel: () => {
+      if (picking) return;
+      onCancel();
     },
   });
 

--- a/apps/readest-app/src/components/settings/FontPanel.tsx
+++ b/apps/readest-app/src/components/settings/FontPanel.tsx
@@ -25,6 +25,7 @@ import { getSysFontsList } from '@/utils/bridge';
 import { isCJKStr } from '@/utils/lang';
 import { isTauriAppPlatform } from '@/services/environment';
 import { useResetViewSettings } from '@/hooks/useResetSettings';
+import { useKeyDownActions } from '@/hooks/useKeyDownActions';
 import { saveViewSettings } from '@/helpers/settings';
 import { SettingsPanelPanelProp } from './SettingsDialog';
 import { BoxedList, NavigationRow, SettingLabel, SettingsRow } from './primitives';
@@ -170,6 +171,19 @@ const FontPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset 
   const handleBackToMain = () => {
     setFontPanelView('main-fonts');
   };
+
+  // Android Back / Esc: when the Custom Fonts sub-page is open, intercept
+  // and step back to main-fonts instead of letting <Dialog>'s own listener
+  // close the entire Settings dialog. This works because
+  // `useKeyDownActions` registers its sync `native-key-down` listener
+  // *after* <Dialog>'s, and `dispatchSync` walks listeners LIFO — so when
+  // enabled this hook claims the Back press first and `return true`
+  // consumes it; when disabled (sub-page closed) Back falls through to
+  // <Dialog> and closes the dialog as before.
+  useKeyDownActions({
+    enabled: fontPanelView === 'custom-fonts',
+    onCancel: handleBackToMain,
+  });
 
   useEffect(() => {
     onRegisterReset(handleReset);

--- a/apps/readest-app/src/components/settings/IntegrationsPanel.tsx
+++ b/apps/readest-app/src/components/settings/IntegrationsPanel.tsx
@@ -14,6 +14,7 @@ import {
 import { useEnv } from '@/context/EnvContext';
 import { useAuth } from '@/context/AuthContext';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useKeyDownActions } from '@/hooks/useKeyDownActions';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useCustomOPDSStore } from '@/store/customOPDSStore';
 import { useWebDAVSyncStore } from '@/store/webdavSyncStore';
@@ -56,6 +57,20 @@ const IntegrationsPanel: React.FC = () => {
   const isWebDAVSyncing = useWebDAVSyncStore((s) => s.isSyncing);
 
   const [subPage, setSubPage] = useState<SubPage>(null);
+
+  // Android Back / Esc: when any integrations sub-page (KOSync, WebDAV,
+  // Readwise, Hardcover, OPDS, Send-to-Readest) is open, intercept and
+  // step back to the integrations list instead of letting <Dialog>'s
+  // listener close the whole Settings dialog. The hook registers its
+  // sync `native-key-down` listener *after* <Dialog>'s, and
+  // `dispatchSync` walks listeners LIFO — so this one claims Back first
+  // when enabled and `return true` consumes the event. When subPage is
+  // null the hook is disabled and Back falls through to close the dialog
+  // as before.
+  useKeyDownActions({
+    enabled: subPage !== null,
+    onCancel: () => setSubPage(null),
+  });
 
   const toggleDiscordPresence = () => {
     const discordRichPresenceEnabled = !settings.discordRichPresenceEnabled;

--- a/apps/readest-app/src/components/settings/LangPanel.tsx
+++ b/apps/readest-app/src/components/settings/LangPanel.tsx
@@ -12,6 +12,7 @@ import {
   isTranslatorAvailable,
 } from '@/services/translators';
 import { useResetViewSettings } from '@/hooks/useResetSettings';
+import { useKeyDownActions } from '@/hooks/useKeyDownActions';
 import { TRANSLATED_LANGS, TRANSLATOR_LANGS } from '@/services/constants';
 import { ConvertChineseVariant } from '@/types/book';
 import { SettingsPanelPanelProp } from './SettingsDialog';
@@ -49,6 +50,15 @@ const LangPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset 
     viewSettings.convertChineseVariant,
   );
   const [showCustomDictionaries, setShowCustomDictionaries] = useState(false);
+
+  // Android Back / Esc: when the Manage Dictionaries sub-page is open,
+  // intercept and step back to the language list instead of letting
+  // <Dialog>'s listener close the whole Settings dialog. See the matching
+  // comment in FontPanel.tsx for the LIFO-dispatch reasoning.
+  useKeyDownActions({
+    enabled: showCustomDictionaries,
+    onCancel: () => setShowCustomDictionaries(false),
+  });
 
   // Deep-link: callers (e.g. the dictionary popup's manage icon) can set
   // activeSettingsItemId to `'settings.language.dictionaries.manage'` to


### PR DESCRIPTION
## Summary

Two related Android-Back / Esc regressions in dialogs that use `useKeyDownActions`. The hook registers a sync `native-key-down` listener that returns `true` on every Back press, which can either swallow the event (no `onCancel` wired) or steal it from a parent <Dialog> that wanted to handle it.

### Bug 1 — Import-from-Folder dialog: Back / Esc do nothing

`ImportFromFolderDialog` calls `useKeyDownActions` for the Enter shortcut without an `onCancel`. The hook still consumes Back, so Android Back and Escape are silently dropped inside the dialog.

Fix: wire `onCancel` to the existing `onCancel` callback (with the same picking-in-flight guard as Enter).

### Bug 2 — Settings sub-pages: Back closes the whole dialog

`FontPanel`, `LangPanel`, and `IntegrationsPanel` render in-place sub-views based on local/store state:

- FontPanel → Custom Fonts
- LangPanel → Custom Dictionaries
- IntegrationsPanel → KOSync / WebDAV / Readwise / Hardcover / OPDS / Send-to-Readest

Pressing Android Back (or Escape) while one of these sub-pages was open closed the entire Settings dialog, because only <Dialog>'s own `native-key-down` listener handled the event and there was no sub-page interceptor.

Fix: mount a `useKeyDownActions` hook at each parent panel, gated on the sub-page being open, that calls the existing "go back" handler. `dispatchSync` walks listeners LIFO, so the panel-level hook (registered after <Dialog>'s) claims Back first while a sub-page is open and `return true` consumes it. Once the sub-page closes the hook is disabled and Back falls through to <Dialog> as before, closing the whole Settings dialog.

All logic stays in the three parent panels — the seven sub-page components are untouched, and a single hook in IntegrationsPanel covers all six integrations sub-pages.

## Test plan

- Open Library → Import from Folder; press Esc / Android Back → dialog closes (previously did nothing).
- Open Settings → Font → Manage Fonts; press Android Back → returns to Font main panel, Settings stays open. Press Back again → Settings closes.
- Open Settings → Language → Manage Dictionaries; same expected behavior.
- Open Settings → Integrations → tap any of KOSync / WebDAV / Readwise / Hardcover / OPDS / Send-to-Readest; same expected behavior for each.
- `pnpm -w format:check`, `tsgo --noEmit`, `biome lint .`, and the full vitest suite (4569 tests) pass via the pre-push hook.