### PR TITLE
fix(reader): keep New Chat button visible above Android nav bar and force theme contrast

### DIFF
--- a/apps/readest-app/src/app/reader/components/sidebar/ChatHistoryView.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/ChatHistoryView.tsx
@@ -225,16 +225,26 @@ const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({ bookKey }) => {
         )}
       </div>
 
-      {/* Floating New Chat button at bottom right */}
-      <div className='absolute bottom-4 right-4'>
+      {/* Floating New Chat button at bottom right.
+          Use safe-area-inset-bottom so it doesn't get hidden behind the
+          Android gesture pill / iOS home indicator on mobile.
+          Use btn-primary colors to guarantee a visible contrast across
+          both light and dark themes (previously bg-base-300 / text-base-content
+          could collapse to a near-invisible solid black pill on some themes). */}
+      <div
+        className='pointer-events-none absolute right-4'
+        style={{
+          bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)',
+        }}
+      >
         <button
           onClick={handleNewConversation}
           className={clsx(
-            'flex items-center gap-2 rounded-full px-4 py-2',
-            'bg-base-300 text-base-content',
-            'hover:bg-base-content/10',
-            'border-base-content/10 border',
-            'shadow-sm',
+            'pointer-events-auto flex items-center gap-2 rounded-full px-4 py-2',
+            'bg-primary text-primary-content',
+            'hover:bg-primary/90',
+            'border-primary/20 border',
+            'shadow-md',
             'transition-all duration-200 ease-out',
             'active:scale-[0.97]',
           )}


### PR DESCRIPTION
## Summary

The floating **New Chat** button in the chat history sidebar had two issues on mobile:

1. **Hidden behind the system gesture bar.** On Android (e.g. Pixel 9 with the gesture pill) the button rendered underneath the navigation indicator because its position used a plain `bottom-4` with no safe-area inset.
2. **Invisible / unreadable pill.** With `bg-base-300` / `text-base-content`, in some themes / inheritance contexts the pill collapsed to a near-solid-black shape with the icon and label disappearing into the background — it just looked like a black blob in the bottom-right corner.

## Repro (before)

- Android Pixel 9 emulator, dark theme, open a book, slide out the left sidebar, switch to the **Chat History** view.
- The "New Chat" pill in the bottom-right is partially covered by the gesture bar and shows up as a solid black shape with no visible "+" or text.

<!-- BEFORE SCREENSHOT: drag-and-drop the broken-state screenshot here. GitHub will host it automatically. -->
<img width="466" height="1080" alt="image" src="https://github.com/user-attachments/assets/d6237a65-f1c3-444c-946c-5ac9b30f2a12" />


## Fix

- Offset the wrapper by `env(safe-area-inset-bottom) + 1rem` so the button always sits above the Android gesture pill / iOS home indicator.
- Switch the button to `bg-primary` / `text-primary-content` with `shadow-md` and `border-primary/20`, guaranteeing strong contrast across every theme. The icon and label are now always visible.
- Add `pointer-events-none` to the positioning wrapper and `pointer-events-auto` to the button itself, so the floating layer never accidentally blocks list interaction below.

No behavioral change: clicking the button still calls `handleNewConversation` → opens the Notebook → switches to the AI tab.

## Files touched

- `apps/readest-app/src/app/reader/components/sidebar/ChatHistoryView.tsx`

## After screenshot

<!-- AFTER SCREENSHOT (optional): drag-and-drop a screenshot of the fixed state here. -->
<img width="398" height="922" alt="image" src="https://github.com/user-attachments/assets/656c87e3-f18d-4b00-90ed-48eff0d3d3b0" />


## Test plan

- `pnpm format:check` — clean.
- `pnpm lint` (`tsgo --noEmit && biome lint .`) — clean.
- `pnpm test` (4569 tests) — all passing locally on the pre-push hook.
- Manual: Pixel 9 emulator, dark theme. The "New Chat" pill is now a primary-colored capsule with a visible `+` icon and label, and is lifted above the gesture pill.
