### PR TITLE
fix(ios): don't crash app init when Storefront region code is unavailable

### DIFF
--- a/apps/readest-app/src/services/nativeAppService.ts
+++ b/apps/readest-app/src/services/nativeAppService.ts
@@ -492,9 +492,18 @@ export class NativeAppService extends BaseAppService {
     }
     if (this.isIOSApp) {
       this.isOnlineCatalogsAccessible = this.distChannel !== 'appstore';
-      const res = await getStorefrontRegionCode();
-      if (res.regionCode) {
-        this.storefrontRegionCode = res.regionCode;
+      try {
+        const res = await getStorefrontRegionCode();
+        if (res?.regionCode) {
+          this.storefrontRegionCode = res.regionCode;
+        }
+      } catch (err) {
+        // Storefront.current is nil on simulators without a signed-in
+        // App Store account, and may also fail on real devices with no
+        // StoreKit configuration. Treat as "unknown region" — we leave
+        // storefrontRegionCode as null and let downstream features that
+        // depend on region degrade gracefully.
+        console.warn('[nativeAppService] getStorefrontRegionCode failed:', err);
       }
     }
     await this.prepareBooksDir();


### PR DESCRIPTION
## Summary

On iOS, `getStorefrontRegionCode` (StoreKit `Storefront.current`) rejects whenever the storefront is unavailable — most commonly on simulators without a signed-in App Store account, but also on real devices that are signed out, where StoreKit hasn't initialized yet, or where parental controls / managed-distribution policies block storefront access.

The call sits inside `NativeAppService.loadSettings` initialization, immediately before `prepareBooksDir()`. Because the `await` wasn't guarded, a single rejection here aborted the rest of app initialization and surfaced as a top-level

```
[browser] ⨯ unhandledRejection: ...
```

in the webview console, leaving the user-visible startup in a partial state.

## Fix

Wrap the call in `try/catch` and treat any failure as 'unknown region':
- leave `storefrontRegionCode` as `null` so downstream region-gated features (e.g. catalog availability checks) degrade gracefully;
- log a `console.warn` so the failure is still observable;
- additionally guard against an unexpected empty resolve shape via `res?.regionCode`.

## Risk

Minimal. The successful path is unchanged. The failing path goes from 'abort init + unhandledRejection' to 'region stays null, init continues normally', which matches the documented behaviour for region-unaware downstream code.

## Repro

1. Run the iOS build on a simulator without an App Store account, **or** sign out of the App Store on a real device.
2. Cold-launch the app.
3. Before this fix: `unhandledRejection` in the webview console; further startup steps after `getStorefrontRegionCode` are skipped.
4. After this fix: warning logged; startup completes normally.