### PR TITLE
feat(library): in-place import from registered external folders

### DIFF
--- a/apps/readest-app/src/__tests__/services/backup-settings.test.ts
+++ b/apps/readest-app/src/__tests__/services/backup-settings.test.ts
@@ -24,6 +24,7 @@ function makeSettings(overrides: Partial<SystemSettings> = {}): SystemSettings {
     migrationVersion: 3,
     localBooksDir: '/Users/me/Books',
     customRootDir: '/Users/me/readest',
+    externalLibraryFolders: ['/Users/me/Duokan', '/Users/me/Calibre'],
     keepLogin: true,
     screenBrightness: 0.7,
     autoScreenBrightness: false,
@@ -85,6 +86,7 @@ describe('sanitizeSettingsForBackup - blacklist', () => {
     const out = rec(sanitizeSettingsForBackup(makeSettings()));
     expect(out['localBooksDir']).toBeUndefined();
     expect(out['customRootDir']).toBeUndefined();
+    expect(out['externalLibraryFolders']).toBeUndefined();
     expect(out['savedBookCoverForLockScreenPath']).toBeUndefined();
   });
 

--- a/apps/readest-app/src/__tests__/services/book-content-source.test.ts
+++ b/apps/readest-app/src/__tests__/services/book-content-source.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test, vi } from 'vitest';
+import { exportBook, getBookFileSize, isBookAvailable } from '@/services/bookService';
+import { getLocalBookFilename } from '@/utils/book';
+import type { Book } from '@/types/book';
+import type { BaseDir, FileSystem } from '@/types/system';
+
+function makeBook(overrides: Partial<Book> = {}): Book {
+  return {
+    hash: 'bookhash',
+    format: 'EPUB',
+    title: 'sample',
+    author: 'Author',
+    createdAt: 1,
+    updatedAt: 1,
+    deletedAt: null,
+    downloadedAt: 1,
+    ...overrides,
+  };
+}
+
+function makeFs(options: {
+  existing?: Array<[string, BaseDir]>;
+  files?: Record<string, File>;
+}): FileSystem {
+  const existing = new Set((options.existing ?? []).map(([path, base]) => `${base}:${path}`));
+  const files = options.files ?? {};
+  return {
+    resolvePath: vi.fn(),
+    getURL: vi.fn(),
+    getBlobURL: vi.fn(),
+    getImageURL: vi.fn(),
+    openFile: vi.fn(async (path: string, base: BaseDir) => {
+      const file = files[`${base}:${path}`];
+      if (!file) throw new Error(`missing ${base}:${path}`);
+      return file;
+    }),
+    copyFile: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    removeFile: vi.fn(),
+    readDir: vi.fn().mockResolvedValue([]),
+    createDir: vi.fn(),
+    removeDir: vi.fn(),
+    exists: vi.fn(async (path: string, base: BaseDir) => existing.has(`${base}:${path}`)),
+    stats: vi.fn(),
+    getPrefix: vi.fn(),
+  };
+}
+
+describe('book content source resolution', () => {
+  test('getBookFileSize reads external in-place sources when no managed copy exists', async () => {
+    const book = makeBook({ filePath: '/Users/me/Library/sample.epub' });
+    const fs = makeFs({
+      existing: [[book.filePath!, 'None']],
+      files: {
+        'None:/Users/me/Library/sample.epub': new File(['external content'], 'sample.epub'),
+      },
+    });
+
+    await expect(getBookFileSize(fs, book)).resolves.toBe('external content'.length);
+    expect(fs.openFile).toHaveBeenCalledWith('/Users/me/Library/sample.epub', 'None');
+  });
+
+  test('exportBook uses the external source path instead of a missing managed path', async () => {
+    const book = makeBook({ filePath: '/Users/me/Library/sample.epub' });
+    const fs = makeFs({
+      existing: [[book.filePath!, 'None']],
+      files: {
+        'None:/Users/me/Library/sample.epub': new File(['external content'], 'sample.epub', {
+          type: 'application/epub+zip',
+        }),
+      },
+    });
+    const resolveFilePath = vi.fn(async (path: string, base: BaseDir) => `${base}:${path}`);
+    const copyFile = vi.fn();
+    const saveFile = vi.fn().mockResolvedValue(true);
+
+    await exportBook(fs, book, resolveFilePath, copyFile, saveFile);
+
+    expect(resolveFilePath).toHaveBeenCalledWith('/Users/me/Library/sample.epub', 'None');
+    expect(resolveFilePath).not.toHaveBeenCalledWith(getLocalBookFilename(book), 'Books');
+    expect(copyFile).not.toHaveBeenCalled();
+    expect(saveFile).toHaveBeenCalledWith('sample.epub', expect.any(ArrayBuffer), {
+      filePath: 'None:/Users/me/Library/sample.epub',
+      mimeType: 'application/epub+zip',
+    });
+  });
+
+  test('isBookAvailable treats PSE streams as available content sources', async () => {
+    const book = makeBook({ format: 'CBZ', url: 'pse://encoded-stream' });
+    const fs = makeFs({});
+
+    await expect(isBookAvailable(fs, book)).resolves.toBe(true);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/cloud-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/cloud-service.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
-import { deleteBook } from '@/services/cloudService';
+import { deleteBook, uploadBook } from '@/services/cloudService';
 import { Book, BookFormat } from '@/types/book';
-import { FileSystem } from '@/types/system';
+import { BaseDir, FileSystem } from '@/types/system';
 
 // Mock external dependencies
 vi.mock('@/utils/book', () => ({
@@ -127,6 +127,22 @@ describe('cloudService', () => {
         expect(mockFs.removeFile).toHaveBeenCalledTimes(1);
         expect(mockFs.removeFile).toHaveBeenCalledWith(`${book.hash}/${book.title}.epub`, 'Books');
       });
+
+      test('removes the managed copy when filePath is stale', async () => {
+        const book = createMockBook({ filePath: '/Users/me/Library/missing.epub' });
+        const managedPath = `${book.hash}/${book.title}.epub`;
+        vi.mocked(mockFs.exists).mockImplementation(async (path, base) => {
+          return base === 'Books' && path === managedPath;
+        });
+
+        await deleteBook(mockFs, book, 'local');
+
+        expect(mockFs.removeFile).toHaveBeenCalledWith(managedPath, 'Books');
+        expect(mockFs.removeFile).not.toHaveBeenCalledWith(
+          '/Users/me/Library/missing.epub',
+          'None',
+        );
+      });
     });
 
     describe('both delete action', () => {
@@ -211,21 +227,30 @@ describe('cloudService', () => {
     // normal book). The cloud upload path is shared, so cross-device sync
     // can still pull the book back.
     describe('in-place (book.filePath set)', () => {
+      const mockInPlaceExists = (book: Book, coverExists = true) => {
+        vi.mocked(mockFs.exists).mockImplementation(async (path, base) => {
+          if (base === 'None' && path === book.filePath) return true;
+          if (base === 'Books' && path === `${book.hash}/cover.png`) return coverExists;
+          return false;
+        });
+      };
+
       test('local action removes the user-controlled source file', async () => {
         const book = createMockBook({ filePath: '/Users/me/Library/sample.epub' });
+        mockInPlaceExists(book);
         await deleteBook(mockFs, book, 'local');
 
         // The source file is read from base 'None' (absolute path), not Books/.
         expect(mockFs.removeFile).toHaveBeenCalledWith('/Users/me/Library/sample.epub', 'None');
       });
 
-      test('local action does not probe Books/<hash>/<title>.epub', async () => {
+      test('local action does not remove Books/<hash>/<title>.epub', async () => {
         const book = createMockBook({ filePath: '/Users/me/Library/sample.epub' });
+        mockInPlaceExists(book);
         await deleteBook(mockFs, book, 'local');
 
-        // The hash-copy path lives only on a normal book; for an in-place book
-        // there's nothing there, so we shouldn't even check.
-        expect(mockFs.exists).not.toHaveBeenCalledWith(`${book.hash}/${book.title}.epub`, 'Books');
+        // The hash-copy path lives only on a normal book; for an in-place book,
+        // the resolver can probe it, but deletion must target the external source.
         expect(mockFs.removeFile).not.toHaveBeenCalledWith(
           `${book.hash}/${book.title}.epub`,
           'Books',
@@ -237,6 +262,7 @@ describe('cloudService', () => {
           filePath: '/Users/me/Library/sample.epub',
           downloadedAt: 12345,
         });
+        mockInPlaceExists(book);
         await deleteBook(mockFs, book, 'local');
         expect(book.downloadedAt).toBeNull();
       });
@@ -260,6 +286,7 @@ describe('cloudService', () => {
           filePath: '/Users/me/Library/sample.epub',
           downloadedAt: 12345,
         });
+        mockInPlaceExists(book);
 
         // Must not throw, and must still flip the metadata bit so the UI
         // reflects the user's delete intent.
@@ -272,6 +299,7 @@ describe('cloudService', () => {
           filePath: '/Users/me/Library/sample.epub',
           uploadedAt: null,
         });
+        mockInPlaceExists(book);
         await deleteBook(mockFs, book, 'both');
 
         // Source file under user-controlled path:
@@ -291,12 +319,60 @@ describe('cloudService', () => {
           downloadedAt: 2000,
           coverDownloadedAt: 3000,
         });
+        mockInPlaceExists(book);
         await deleteBook(mockFs, book, 'both');
 
         expect(book.deletedAt).toBeGreaterThan(0);
         expect(book.downloadedAt).toBeNull();
         expect(book.coverDownloadedAt).toBeNull();
       });
+    });
+  });
+
+  describe('uploadBook', () => {
+    test('uses an existing managed copy before a stale filePath', async () => {
+      const book = createMockBook({ filePath: '/Users/me/Library/missing.epub' });
+      const managedPath = `${book.hash}/${book.title}.epub`;
+      const coverPath = `${book.hash}/cover.png`;
+      vi.mocked(mockFs.exists).mockImplementation(async (path, base) => {
+        return base === 'Books' && path === managedPath;
+      });
+      const resolveFilePath = vi.fn(async (path: string, base: BaseDir) => `${base}:${path}`);
+
+      await uploadBook(mockFs, resolveFilePath, book);
+
+      expect(mockFs.exists).toHaveBeenCalledWith(managedPath, 'Books');
+      expect(mockFs.exists).not.toHaveBeenCalledWith('/Users/me/Library/missing.epub', 'None');
+      expect(mockFs.openFile).toHaveBeenCalledWith(
+        managedPath,
+        'Books',
+        expect.stringContaining(`${book.hash}/${book.hash}.epub`),
+      );
+      expect(mockFs.openFile).not.toHaveBeenCalledWith(
+        '/Users/me/Library/missing.epub',
+        'None',
+        expect.any(String),
+      );
+      expect(mockFs.exists).toHaveBeenCalledWith(coverPath, 'Books');
+    });
+
+    test('does not mark a book uploaded when only the cover exists', async () => {
+      const book = createMockBook({ uploadedAt: null, downloadedAt: null });
+      const managedPath = `${book.hash}/${book.title}.epub`;
+      const coverPath = `${book.hash}/cover.png`;
+      vi.mocked(mockFs.exists).mockImplementation(async (path, base) => {
+        return base === 'Books' && path === coverPath;
+      });
+      const resolveFilePath = vi.fn(async (path: string, base: BaseDir) => `${base}:${path}`);
+
+      await expect(uploadBook(mockFs, resolveFilePath, book)).rejects.toThrow(
+        'Book file not uploaded',
+      );
+
+      const { uploadFile } = await import('@/libs/storage');
+      expect(uploadFile).not.toHaveBeenCalled();
+      expect(book.uploadedAt).toBeNull();
+      expect(mockFs.exists).toHaveBeenCalledWith(managedPath, 'Books');
     });
   });
 });

--- a/apps/readest-app/src/__tests__/services/cloud-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/cloud-service.test.ts
@@ -203,5 +203,100 @@ describe('cloudService', () => {
         expect(book.uploadedAt).toBeNull();
       });
     });
+
+    // In-place imports keep their content at a user-controlled location
+    // (book.filePath, base 'None') rather than under Books/<hash>/. For
+    // 'local'/'both' deletes that source file IS the local copy and gets
+    // removed (symmetric with deleting Books/<hash>/<title>.epub for a
+    // normal book). The cloud upload path is shared, so cross-device sync
+    // can still pull the book back.
+    describe('in-place (book.filePath set)', () => {
+      test('local action removes the user-controlled source file', async () => {
+        const book = createMockBook({ filePath: '/Users/me/Library/sample.epub' });
+        await deleteBook(mockFs, book, 'local');
+
+        // The source file is read from base 'None' (absolute path), not Books/.
+        expect(mockFs.removeFile).toHaveBeenCalledWith('/Users/me/Library/sample.epub', 'None');
+      });
+
+      test('local action does not probe Books/<hash>/<title>.epub', async () => {
+        const book = createMockBook({ filePath: '/Users/me/Library/sample.epub' });
+        await deleteBook(mockFs, book, 'local');
+
+        // The hash-copy path lives only on a normal book; for an in-place book
+        // there's nothing there, so we shouldn't even check.
+        expect(mockFs.exists).not.toHaveBeenCalledWith(`${book.hash}/${book.title}.epub`, 'Books');
+        expect(mockFs.removeFile).not.toHaveBeenCalledWith(
+          `${book.hash}/${book.title}.epub`,
+          'Books',
+        );
+      });
+
+      test('local action still clears downloadedAt', async () => {
+        const book = createMockBook({
+          filePath: '/Users/me/Library/sample.epub',
+          downloadedAt: 12345,
+        });
+        await deleteBook(mockFs, book, 'local');
+        expect(book.downloadedAt).toBeNull();
+      });
+
+      test('local action does not throw when the source file is missing', async () => {
+        // exists() returns false → no removeFile call, but no error either.
+        vi.mocked(mockFs.exists).mockResolvedValue(false);
+        const book = createMockBook({
+          filePath: '/Users/me/Library/sample.epub',
+          downloadedAt: 12345,
+        });
+        await deleteBook(mockFs, book, 'local');
+
+        expect(mockFs.removeFile).not.toHaveBeenCalled();
+        expect(book.downloadedAt).toBeNull();
+      });
+
+      test('local action swallows errors from removeFile (best-effort source delete)', async () => {
+        vi.mocked(mockFs.removeFile).mockRejectedValueOnce(new Error('EPERM'));
+        const book = createMockBook({
+          filePath: '/Users/me/Library/sample.epub',
+          downloadedAt: 12345,
+        });
+
+        // Must not throw, and must still flip the metadata bit so the UI
+        // reflects the user's delete intent.
+        await deleteBook(mockFs, book, 'local');
+        expect(book.downloadedAt).toBeNull();
+      });
+
+      test('both action removes both the source file and the cover sidecar', async () => {
+        const book = createMockBook({
+          filePath: '/Users/me/Library/sample.epub',
+          uploadedAt: null,
+        });
+        await deleteBook(mockFs, book, 'both');
+
+        // Source file under user-controlled path:
+        expect(mockFs.removeFile).toHaveBeenCalledWith('/Users/me/Library/sample.epub', 'None');
+        // Cover sidecar under Books/<hash>/:
+        expect(mockFs.removeFile).toHaveBeenCalledWith(`${book.hash}/cover.png`, 'Books');
+        // We must never poke at Books/<hash>/<title>.epub for an in-place book.
+        expect(mockFs.removeFile).not.toHaveBeenCalledWith(
+          `${book.hash}/${book.title}.epub`,
+          'Books',
+        );
+      });
+
+      test('both action still flips deletedAt/downloadedAt/coverDownloadedAt', async () => {
+        const book = createMockBook({
+          filePath: '/Users/me/Library/sample.epub',
+          downloadedAt: 2000,
+          coverDownloadedAt: 3000,
+        });
+        await deleteBook(mockFs, book, 'both');
+
+        expect(book.deletedAt).toBeGreaterThan(0);
+        expect(book.downloadedAt).toBeNull();
+        expect(book.coverDownloadedAt).toBeNull();
+      });
+    });
   });
 });

--- a/apps/readest-app/src/__tests__/services/ingest-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/ingest-service.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/services/transferManager', () => ({
 import { ingestFile } from '@/services/ingestService';
 import { transferManager } from '@/services/transferManager';
 import type { Book } from '@/types/book';
-import type { AppService } from '@/types/system';
+import type { AppService, OsPlatform } from '@/types/system';
 import type { SystemSettings } from '@/types/settings';
 
 function makeBook(overrides: Partial<Book> = {}): Book {
@@ -25,12 +25,27 @@ function makeBook(overrides: Partial<Book> = {}): Book {
 }
 
 function makeDeps(
-  over: { importResult?: Book | null; autoUpload?: boolean; isLoggedIn?: boolean } = {},
+  over: {
+    importResult?: Book | null;
+    autoUpload?: boolean;
+    isLoggedIn?: boolean;
+    externalLibraryFolders?: string[];
+    osPlatform?: OsPlatform;
+  } = {},
 ) {
   const importResult = over.importResult === undefined ? makeBook() : over.importResult;
   const importBook = vi.fn().mockResolvedValue(importResult);
-  const appService = { importBook } as unknown as AppService;
-  const settings = { autoUpload: over.autoUpload ?? false } as SystemSettings;
+  // Default to a case-sensitive platform so existing tests keep exercising
+  // the strict-prefix path; per-test overrides switch to macos/windows/ios
+  // when the case-insensitive behavior is under test.
+  const appService = {
+    importBook,
+    osPlatform: over.osPlatform ?? ('linux' as OsPlatform),
+  } as unknown as AppService;
+  const settings = {
+    autoUpload: over.autoUpload ?? false,
+    externalLibraryFolders: over.externalLibraryFolders,
+  } as SystemSettings;
   return { appService, settings, isLoggedIn: over.isLoggedIn ?? false, importBook };
 }
 
@@ -64,7 +79,11 @@ describe('ingestFile', () => {
       { file: 'book.epub', books: [], lookupIndex },
       { appService, settings, isLoggedIn },
     );
-    expect(importBook).toHaveBeenCalledWith('book.epub', [], { lookupIndex });
+    expect(importBook).toHaveBeenCalledWith('book.epub', [], {
+      lookupIndex,
+      transient: undefined,
+      inPlace: false,
+    });
   });
 
   test('applies groupId and groupName', async () => {
@@ -194,6 +213,7 @@ describe('ingestFile', () => {
     expect(importBook).toHaveBeenCalledWith('book.epub', [], {
       lookupIndex: undefined,
       transient: true,
+      inPlace: false,
     });
   });
 
@@ -205,6 +225,372 @@ describe('ingestFile', () => {
     });
     await ingestFile(
       { file: 'book.epub', books: [], forceUpload: true },
+      { appService, settings, isLoggedIn },
+    );
+    expect(transferManager.queueUpload).not.toHaveBeenCalled();
+  });
+
+  // ------ in-place auto-detection ------
+
+  test('does not mark in-place when no external library folders are configured', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps();
+    await ingestFile(
+      { file: '/Users/me/Books/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: false });
+  });
+
+  test('marks in-place when the source file lives under an external library folder', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Library'],
+    });
+    await ingestFile(
+      { file: '/Users/me/Library/Imports/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: true });
+  });
+
+  test('does not mark in-place when the source file is outside every external library folder', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Library'],
+    });
+    await ingestFile(
+      { file: '/Users/me/Downloads/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: false });
+  });
+
+  test('does not let a sibling-prefix path masquerade as inside an external library folder', async () => {
+    // `/Users/me/LibraryOther/...` shares a string prefix with `/Users/me/Library`
+    // but is a different directory. The boundary check must use a separator.
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Library'],
+    });
+    await ingestFile(
+      { file: '/Users/me/LibraryOther/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: false });
+  });
+
+  test('marks <root>/Books/* in-place when no app books prefix collides', async () => {
+    // A user-owned folder that happens to be named "Books" (very common in
+    // cloud-drive layouts like Baidu Netdisk's default `Books/` root) must
+    // still go in-place. The old `<root>/Books/*` exclusion was a footgun
+    // that produced silent hash copies of real user files.
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Library'],
+    });
+    await ingestFile(
+      { file: '/Users/me/Library/Books/Novels/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: true });
+  });
+
+  test('does not mark in-place for files inside readest-managed Books prefix', async () => {
+    // Files copied under readest's own AppData Books/<hash>/ are already
+    // hash copies, not user originals. Marking them in-place would set
+    // book.filePath to a path readest already controls.
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/AppData'],
+    });
+    await ingestFile(
+      { file: '/Users/me/AppData/Books/abc123/sample.epub', books: [] },
+      {
+        appService,
+        settings,
+        isLoggedIn,
+        appBooksPrefix: '/Users/me/AppData/Books',
+      },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: false });
+  });
+
+  test('does not mark in-place for relative paths', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Library'],
+    });
+    await ingestFile({ file: 'sample.epub', books: [] }, { appService, settings, isLoggedIn });
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: false });
+  });
+
+  test('does not mark in-place for File objects (web)', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Library'],
+    });
+    const blob = new File([new Uint8Array([0])], 'sample.epub');
+    await ingestFile({ file: blob, books: [] }, { appService, settings, isLoggedIn });
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: false });
+  });
+
+  test('does not mark in-place for URL strings even if they happen to start with a slash', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Library'],
+    });
+    await ingestFile(
+      { file: 'https://example.com/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: false });
+  });
+
+  test('transient wins over in-place auto-detection', async () => {
+    // A transient import already takes its own filePath path; we must not
+    // also flag it as inPlace, otherwise the Books/<hash>/ guard would be
+    // applied twice with subtly different semantics.
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Library'],
+    });
+    await ingestFile(
+      { file: '/Users/me/Library/sample.epub', books: [], transient: true },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({
+      transient: true,
+      inPlace: false,
+    });
+  });
+
+  test('forceCopy opts out of in-place auto-detection', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Library'],
+    });
+    await ingestFile(
+      { file: '/Users/me/Library/sample.epub', books: [], forceCopy: true },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: false });
+  });
+
+  test('handles an external library folder path with a trailing slash', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Library/'],
+    });
+    await ingestFile(
+      { file: '/Users/me/Library/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: true });
+  });
+
+  test('marks in-place for Windows paths under a Windows external library folder', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['C:\\Users\\me\\Library'],
+    });
+    await ingestFile(
+      { file: 'C:\\Users\\me\\Library\\Imports\\sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: true });
+  });
+
+  // The user can register multiple external library folders (e.g. one for
+  // Duokan, another for an iCloud mirror, another for a local SSD library).
+  // A file matching any of them should be marked in-place; a file matching
+  // none should not.
+
+  test('marks in-place when the source file lives under any registered folder', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Duokan', '/Users/me/Calibre Library'],
+    });
+    await ingestFile(
+      { file: '/Users/me/Calibre Library/Author/Title/book.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: true });
+  });
+
+  test('does not mark in-place when the file matches none of the registered folders', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Duokan', '/Users/me/Calibre Library'],
+    });
+    await ingestFile(
+      { file: '/Users/me/Downloads/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: false });
+  });
+
+  test('matches across multiple roots; user-owned Books/ subdirs go in-place', async () => {
+    // Multiple registered roots all match by strict prefix. A user-owned
+    // subdirectory named "Books" under one of those roots (very common
+    // layout, e.g. Baidu Netdisk / Duokan exports) is treated as ordinary
+    // content — files there go in-place. Only readest's own managed Books
+    // prefix (passed in via `appBooksPrefix`) is excluded.
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Old Library', '/Users/me/Duokan'],
+    });
+    await ingestFile(
+      { file: '/Users/me/Duokan/Books/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: true });
+
+    const {
+      appService: a2,
+      settings: s2,
+      isLoggedIn: l2,
+      importBook: i2,
+    } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Old Library', '/Users/me/Duokan'],
+    });
+    await ingestFile(
+      { file: '/Users/me/Duokan/sample.epub', books: [] },
+      { appService: a2, settings: s2, isLoggedIn: l2 },
+    );
+    expect(i2.mock.calls[0]?.[2]).toMatchObject({ inPlace: true });
+  });
+
+  test('ignores empty / falsy entries in externalLibraryFolders', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['', '/Users/me/Library'],
+    });
+    await ingestFile(
+      { file: '/Users/me/Library/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: true });
+  });
+
+  // ------ case-sensitivity per OS ------
+  // macOS (APFS/HFS+ default), iOS, and Windows ship case-insensitive
+  // filesystems; the registered root and the actual file path may legally
+  // differ only in case. Linux / Android are case-sensitive and stay strict.
+
+  test('matches case-insensitively on macOS', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/Library'],
+      osPlatform: 'macos',
+    });
+    await ingestFile(
+      { file: '/users/me/library/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: true });
+  });
+
+  test('matches case-insensitively on iOS', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/var/mobile/Containers/MyLibrary'],
+      osPlatform: 'ios',
+    });
+    await ingestFile(
+      { file: '/var/mobile/containers/mylibrary/book.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: true });
+  });
+
+  test('matches case-insensitively on Windows', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['C:\\Users\\me\\Library'],
+      osPlatform: 'windows',
+    });
+    await ingestFile(
+      { file: 'c:\\users\\me\\library\\Imports\\sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: true });
+  });
+
+  test('stays case-sensitive on Linux', async () => {
+    // Guards against regressing case-sensitive platforms into accidentally
+    // treating `Library` and `library` as the same directory.
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/home/me/Library'],
+      osPlatform: 'linux',
+    });
+    await ingestFile(
+      { file: '/home/me/library/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: false });
+  });
+
+  test('stays case-sensitive on Android', async () => {
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/storage/emulated/0/Books'],
+      osPlatform: 'android',
+    });
+    await ingestFile(
+      { file: '/storage/emulated/0/books/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: false });
+  });
+
+  test('app books prefix exclusion is case-insensitive on macOS', async () => {
+    // The managed-prefix opt-out must follow the same case rules as the
+    // root match, otherwise a mixed-case `/Books/` path could slip through
+    // as in-place on macOS / iOS / Windows.
+    const { appService, settings, isLoggedIn, importBook } = makeDeps({
+      externalLibraryFolders: ['/Users/me/AppData'],
+      osPlatform: 'macos',
+    });
+    await ingestFile(
+      { file: '/Users/me/AppData/books/abc123/sample.epub', books: [] },
+      {
+        appService,
+        settings,
+        isLoggedIn,
+        appBooksPrefix: '/Users/me/AppData/Books',
+      },
+    );
+    expect(importBook.mock.calls[0]?.[2]).toMatchObject({ inPlace: false });
+  });
+
+  // ------ in-place + cloud upload ------
+  // In-place imports are still uploaded so the user gets backup / cross-device
+  // sync. Only transient imports opt out of upload entirely. The on-the-wire
+  // shape is identical to a hash-copy book; uploadBook reads from book.filePath
+  // when set, which is asserted in cloud-service.test.ts.
+
+  test('autoUpload still queues an in-place book (book.filePath set)', async () => {
+    const { appService, settings, isLoggedIn } = makeDeps({
+      autoUpload: true,
+      isLoggedIn: true,
+      externalLibraryFolders: ['/Users/me/Library'],
+      importResult: makeBook({ filePath: '/Users/me/Library/sample.epub' }),
+    });
+    await ingestFile(
+      { file: '/Users/me/Library/sample.epub', books: [] },
+      { appService, settings, isLoggedIn },
+    );
+    expect(transferManager.queueUpload).toHaveBeenCalledTimes(1);
+  });
+
+  test('forceUpload still queues an in-place book even when autoUpload is off', async () => {
+    const { appService, settings, isLoggedIn } = makeDeps({
+      autoUpload: false,
+      isLoggedIn: true,
+      externalLibraryFolders: ['/Users/me/Library'],
+      importResult: makeBook({ filePath: '/Users/me/Library/sample.epub' }),
+    });
+    await ingestFile(
+      { file: '/Users/me/Library/sample.epub', books: [], forceUpload: true },
+      { appService, settings, isLoggedIn },
+    );
+    expect(transferManager.queueUpload).toHaveBeenCalledTimes(1);
+  });
+
+  test('transient still trumps in-place — no upload even with forceUpload', async () => {
+    const { appService, settings, isLoggedIn } = makeDeps({
+      autoUpload: true,
+      isLoggedIn: true,
+      externalLibraryFolders: ['/Users/me/Library'],
+      importResult: makeBook({ filePath: '/Users/me/Library/sample.epub' }),
+    });
+    await ingestFile(
+      {
+        file: '/Users/me/Library/sample.epub',
+        books: [],
+        transient: true,
+        forceUpload: true,
+      },
       { appService, settings, isLoggedIn },
     );
     expect(transferManager.queueUpload).not.toHaveBeenCalled();

--- a/apps/readest-app/src/app/library/components/BookshelfItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookshelfItem.tsx
@@ -174,7 +174,9 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
         const available = await appService?.isBookAvailable(book);
         if (!available) {
           eventDispatcher.dispatch('toast', {
-            message: 'Book file no longer exists; removed from library.',
+            message: _(
+              'Book file no longer exists. Confirm deletion to remove it from the library.',
+            ),
             type: 'info',
           });
           eventDispatcher.dispatch('delete-books', { ids: [book.hash] });

--- a/apps/readest-app/src/app/library/components/BookshelfItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookshelfItem.tsx
@@ -159,16 +159,36 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
     async (book: Book) => {
       if (isSelectMode) {
         toggleSelection(book.hash);
-      } else {
-        const available = await makeBookAvailable(book);
-        if (!available) return;
-        if (appService?.hasWindow && settings.openBookInNewWindow) {
-          showReaderWindow(appService, [book.hash]);
-        } else {
-          setTimeout(() => {
-            navigateToReader(router, [book.hash]);
-          }, 0);
+        return;
+      }
+      // In-place books point at a file outside Books/<hash>/ that the user
+      // (or another app) may have moved, renamed, or deleted between sessions.
+      // Probe the source before navigating: if it's gone, drop the stale
+      // library record instead of opening the reader only to fail inside
+      // loadBookContent and bounce back with a toast. We restrict this to
+      // purely-local in-place books — cloud-synced books (`uploadedAt`) still
+      // go through `makeBookAvailable`'s on-demand download path below, and
+      // hash-copy books (no `filePath`) shouldn't lose their Books/<hash>/
+      // file under normal use, so we don't second-guess those here.
+      if (book.filePath && !book.uploadedAt && !book.deletedAt) {
+        const available = await appService?.isBookAvailable(book);
+        if (!available) {
+          eventDispatcher.dispatch('toast', {
+            message: 'Book file no longer exists; removed from library.',
+            type: 'info',
+          });
+          eventDispatcher.dispatch('delete-books', { ids: [book.hash] });
+          return;
         }
+      }
+      const available = await makeBookAvailable(book);
+      if (!available) return;
+      if (appService?.hasWindow && settings.openBookInNewWindow) {
+        showReaderWindow(appService, [book.hash]);
+      } else {
+        setTimeout(() => {
+          navigateToReader(router, [book.hash]);
+        }, 0);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/readest-app/src/app/library/components/ImportFromFolderDialog.tsx
+++ b/apps/readest-app/src/app/library/components/ImportFromFolderDialog.tsx
@@ -57,6 +57,18 @@ export interface ImportFromFolderResult {
    * directly into the library root without creating any groups.
    */
   flatten: boolean;
+  /**
+   * When `true`, register the directory as an external library folder
+   * (`settings.externalLibraryFolders`) and import its books in place
+   * — Readest will read each file straight from its original location
+   * instead of copying it into Books/<hash>/. Sidecars (cover, config,
+   * notes) still live in Readest's data dir, so deleting the local
+   * copy of a book on Readest's side will physically remove the
+   * source file under the registered folder. Defaults to `false`,
+   * which keeps the legacy "copy into Readest" behaviour and leaves
+   * the registered folder list untouched.
+   */
+  readInPlace: boolean;
 }
 
 interface ImportFromFolderDialogProps {
@@ -80,6 +92,22 @@ interface ImportFromFolderDialogProps {
    * Defaults to 20 KB when omitted.
    */
   initialMinSizeKB?: number;
+  /**
+   * Initial value for the "Read in place" toggle. Persisted by the
+   * caller so users who picked in-place last time don't need to flip
+   * the switch again. Defaults to `false`.
+   */
+  initialReadInPlace?: boolean;
+  /**
+   * Predicate the dialog uses to decide whether the currently-displayed
+   * folder is already registered as an external library folder. When
+   * `true`, the "Read in place" toggle is forced ON and locked, with a
+   * note explaining that imports from this folder are always in-place
+   * (until the user removes it from Settings, which v1 doesn't expose).
+   * Implementations should match by exact string after the same path
+   * normalization the importer uses.
+   */
+  isRegisteredExternalRoot?: (directory: string) => boolean;
   /**
    * Pop the platform's native folder picker and return the chosen path,
    * or `undefined` when the user cancels. Required because folder
@@ -110,6 +138,8 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
   initialFolderMode = 'keep',
   initialSelectedGroupIds,
   initialMinSizeKB,
+  initialReadInPlace = false,
+  isRegisteredExternalRoot,
   onPickDirectory,
   onCancel,
   onConfirm,
@@ -138,7 +168,17 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
   // root regardless of where it lived on disk. The caller seeds this
   // from localStorage so the user's last choice is restored.
   const [folderMode, setFolderMode] = useState<'keep' | 'flatten'>(initialFolderMode);
+  // "Read in place" toggle. When the directory is already registered
+  // as an external library folder we force this ON and hide the
+  // toggle's interactive surface — see {@link readInPlaceLocked}
+  // below — because imports from a registered folder are always
+  // in-place by design (the importer's `shouldImportInPlace` check is
+  // path-prefix based and ignores any per-import opt-out).
+  const [readInPlace, setReadInPlace] = useState<boolean>(initialReadInPlace);
   const [picking, setPicking] = useState(false);
+
+  const readInPlaceLocked = !!directory && (isRegisteredExternalRoot?.(directory) ?? false);
+  const effectiveReadInPlace = readInPlaceLocked || readInPlace;
 
   // Enter to confirm, Escape / Android Back to cancel. We must wire
   // `onCancel` even though <Dialog> also listens for Back, because
@@ -200,6 +240,7 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
       selectedGroupIds: selectedIds,
       minSizeKB: safeMinSizeKB,
       flatten: folderMode === 'flatten',
+      readInPlace: effectiveReadInPlace,
     });
   };
 
@@ -304,6 +345,42 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
             />
             <span className='text-base-content/70 select-none pe-2 text-xs'>{_('KB')}</span>
           </div>
+        </div>
+
+        {/* Read-in-place toggle. When OFF (default), each book is
+            copied into Books/<hash>/ as before. When ON, the chosen
+            folder is registered in `settings.externalLibraryFolders`
+            and the importer keeps each book at its original path —
+            no copy. See `runFolderImport` and `shouldImportInPlace`
+            in ingestService for the downstream effects (cloud sync,
+            symmetric local delete). */}
+        <div className='flex flex-col gap-1.5'>
+          <label
+            className={clsx(
+              'flex items-start gap-2 rounded-md px-1 py-1 text-sm',
+              readInPlaceLocked ? 'cursor-default' : 'cursor-pointer hover:bg-base-200/50',
+            )}
+          >
+            <input
+              type='checkbox'
+              className='checkbox checkbox-sm mt-0.5'
+              checked={effectiveReadInPlace}
+              disabled={readInPlaceLocked}
+              onChange={(e) => setReadInPlace(e.target.checked)}
+            />
+            <span className='select-none'>
+              <span className='block'>{_('Read books in place')}</span>
+              <span className='text-base-content/60 block text-xs'>
+                {readInPlaceLocked
+                  ? _(
+                      'This folder is registered as an external library — books here are always read in place.',
+                    )
+                  : _(
+                      'Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).',
+                    )}
+              </span>
+            </span>
+          </label>
         </div>
 
         {/* Folder-structure mode — radios let the user choose between

--- a/apps/readest-app/src/app/library/hooks/useBooksSync.ts
+++ b/apps/readest-app/src/app/library/hooks/useBooksSync.ts
@@ -22,12 +22,24 @@ export const useBooksSync = () => {
   const getNewBooks = useCallback(() => {
     if (!user) return {};
     const library = useLibraryStore.getState().library;
-    const newBooks = library.filter(
-      (book) =>
-        !book.syncedAt ||
-        lastSyncedAtBooks < book.updatedAt ||
-        lastSyncedAtBooks < (book.deletedAt ?? 0),
-    );
+    const newBooks = library
+      .filter(
+        (book) =>
+          !book.syncedAt ||
+          lastSyncedAtBooks < book.updatedAt ||
+          lastSyncedAtBooks < (book.deletedAt ?? 0),
+      )
+      // book.filePath is a device-local absolute path used by the in-place
+      // import flow to point at a file outside Books/<hash>/. It is
+      // meaningless on any other device, so strip it before pushing to the
+      // cloud — peers always rehydrate via the hash-keyed copy that
+      // cloudService.downloadBook lands under Books/<hash>/. Keeping the
+      // source device's path in the cloud record would be dead data at
+      // best, and would become an active footgun if isBookAvailable ever
+      // got its branch order swapped (it currently checks Books/<hash>
+      // before falling back to filePath; flipping that order would make
+      // peers chase a non-existent path instead of downloading).
+      .map(({ filePath: _filePath, ...rest }): Book => rest);
     return {
       books: newBooks,
       lastSyncedAt: lastSyncedAtBooks,

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -527,6 +527,21 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
       const settings = await appService.loadSettings();
       setSettings(settings);
 
+      // Re-grant fs_scope / asset_protocol_scope for every external
+      // library folder the user registered in a previous session, so
+      // in-place books under those roots are immediately readable
+      // through both `dir_scanner::read_dir` and the fs plugin.
+      // Best-effort — `allowPathsInScopes` swallows its own errors.
+      // On iOS the corresponding native-bridge plugin separately
+      // re-acquires security-scoped resources via persisted
+      // bookmarks (see InPlaceFolderBookmarkStore in
+      // NativeBridgePlugin.swift); here we just sync Tauri's in-memory
+      // scope set with the persisted intent.
+      const externalRoots = settings.externalLibraryFolders ?? [];
+      if (externalRoots.length > 0 && appService.allowPathsInScopes) {
+        await appService.allowPathsInScopes(externalRoots, true);
+      }
+
       // Reuse the library from the store when we return from the reader
       const library = libraryBooks.length > 0 ? libraryBooks : await appService.loadLibraryBooks();
       let opened = false;

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -1138,12 +1138,13 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
   const registerExternalLibraryFolder = async (directory: string): Promise<void> => {
     const target = normalizeRoot(directory);
     if (!target) return;
-    const existing = settings.externalLibraryFolders ?? [];
+    const liveSettings = useSettingsStore.getState().settings;
+    const existing = liveSettings.externalLibraryFolders ?? [];
     if (existing.some((r) => normalizeRoot(r) === target)) {
       return;
     }
     const next = [...existing, directory];
-    const nextSettings = { ...settings, externalLibraryFolders: next };
+    const nextSettings = { ...liveSettings, externalLibraryFolders: next };
     setSettings(nextSettings);
     try {
       await saveSettings(envConfig, nextSettings);

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -121,6 +121,14 @@ const LAST_IMPORT_FOLDER_FORMATS_KEY = 'readest:lastImportFolderFormats';
  * Stored as a stringified non-negative integer.
  */
 const LAST_IMPORT_FOLDER_MIN_SIZE_KEY = 'readest:lastImportFolderMinSizeKB';
+/**
+ * Key used to persist the last "Read books in place" toggle value
+ * (`'1'` or `'0'`). Restored as the dialog's initial toggle state.
+ * The toggle only matters for fresh, not-yet-registered folders —
+ * once a folder is registered as an external library folder, the
+ * dialog forces the toggle ON regardless of this value.
+ */
+const LAST_IMPORT_FOLDER_READ_IN_PLACE_KEY = 'readest:lastImportFolderReadInPlace';
 
 const LibraryPageWithSearchParams = () => {
   const searchParams = useSearchParams();
@@ -184,6 +192,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     initialFolderMode: 'keep' | 'flatten';
     initialSelectedGroupIds?: string[];
     initialMinSizeKB?: number;
+    initialReadInPlace?: boolean;
   } | null>(null);
   const [currentGroupPath, setCurrentGroupPath] = useState<string | undefined>(undefined);
   const [currentSeriesAuthorGroup, setCurrentSeriesAuthorGroup] = useState<{
@@ -649,6 +658,15 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     const failedImports: Array<{ filename: string; errorMessage: string }> = [];
     const successfulImports: string[] = [];
 
+    // Readest's own Books/ prefix is resolved once at app init and persisted
+    // in `settings.localBooksDir`. We hand it to `ingestFile` so the in-place
+    // decision can exclude files that already live inside our managed hash
+    // store WITHOUT misclassifying user-owned folders that happen to be
+    // named "Books" (e.g. Baidu Netdisk's default `Books/` directory
+    // directly under the user's library root).
+    const appBooksPrefix: string | null =
+      useSettingsStore.getState().settings.localBooksDir || null;
+
     const processFile = async (selectedFile: SelectedFile): Promise<Book | null> => {
       const file = selectedFile.file || selectedFile.path;
       if (!file) return null;
@@ -671,6 +689,16 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
           resolvedGroupName = getDirPath(path).replace(rootPath, '').replace(/^\//, '');
           resolvedGroupId = getGroupId(resolvedGroupName);
         }
+        // Read settings from the store at call-time rather than the
+        // component closure. `runFolderImport` may have just registered
+        // the picked directory as an external library folder via
+        // `setSettings(...)`, but React state updates don't mutate the
+        // already-captured `settings` reference until the next render —
+        // by the time we get here, the closure still holds the *old*
+        // settings, so `shouldImportInPlace` would see an empty
+        // `externalLibraryFolders` and incorrectly fall back to copy
+        // mode. Pulling the latest snapshot from zustand fixes this.
+        const liveSettings = useSettingsStore.getState().settings;
         const book = await ingestFile(
           {
             file,
@@ -679,7 +707,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
             groupId: resolvedGroupId,
             groupName: resolvedGroupName,
           },
-          { appService, settings, isLoggedIn: !!user },
+          { appService, settings: liveSettings, isLoggedIn: !!user, appBooksPrefix },
         );
         if (!book) return null;
         successfulImports.push(book.title);
@@ -956,6 +984,12 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
         selectedGroupIds: [],
         minSizeKB: 0,
         flatten: false,
+        // URL ingress / drag-drop don't go through the dialog and so
+        // can't set this. Default to the legacy "copy" behaviour;
+        // already-registered external roots will still be detected
+        // by `runFolderImport` itself via the prefix check, so books
+        // under a registered folder are imported in-place either way.
+        readInPlace: false,
       });
       return;
     }
@@ -968,6 +1002,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     const storedMode = ls?.getItem(LAST_IMPORT_FOLDER_MODE_KEY);
     const storedFormats = ls?.getItem(LAST_IMPORT_FOLDER_FORMATS_KEY);
     const storedMinSize = ls?.getItem(LAST_IMPORT_FOLDER_MIN_SIZE_KEY);
+    const storedReadInPlace = ls?.getItem(LAST_IMPORT_FOLDER_READ_IN_PLACE_KEY);
     const parsedFormats = storedFormats
       ? storedFormats
           .split(',')
@@ -986,6 +1021,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
         parsedMinSize !== undefined && Number.isFinite(parsedMinSize) && parsedMinSize >= 0
           ? parsedMinSize
           : undefined,
+      initialReadInPlace: storedReadInPlace === '1',
     });
   };
 
@@ -1066,6 +1102,57 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
   };
 
   /**
+   * Normalize a path the same way `shouldImportInPlace` does so the
+   * predicate / store helpers below stay consistent with the ingest
+   * layer's own path-prefix matching. Trailing separators and Windows
+   * backslashes are normalized; nothing else is touched.
+   */
+  const normalizeRoot = (p: string): string => p.replace(/\\/g, '/').replace(/\/+$/, '');
+
+  /**
+   * `true` when `directory` is already in
+   * `settings.externalLibraryFolders` after path normalization. Hands
+   * over to the ImportFromFolderDialog so it can render the "Read in
+   * place" toggle as ON-and-locked when the user re-imports from a
+   * folder they've already registered. The match is exact-string
+   * (after normalization) — sub-paths of a registered folder are NOT
+   * considered registered roots themselves, only the registered root
+   * is.
+   */
+  const isRegisteredExternalRoot = (directory: string): boolean => {
+    const target = normalizeRoot(directory);
+    if (!target) return false;
+    const roots = settings.externalLibraryFolders ?? [];
+    return roots.some((r) => normalizeRoot(r) === target);
+  };
+
+  /**
+   * Add `directory` to `settings.externalLibraryFolders` (and persist
+   * settings) so the ingest layer's `shouldImportInPlace` will pick
+   * up subsequent imports from the same folder automatically. No-op
+   * when the folder is already registered. Errors are swallowed
+   * because the import flow can still succeed in copy mode even if
+   * registration fails — we just won't get the in-place behaviour
+   * next launch.
+   */
+  const registerExternalLibraryFolder = async (directory: string): Promise<void> => {
+    const target = normalizeRoot(directory);
+    if (!target) return;
+    const existing = settings.externalLibraryFolders ?? [];
+    if (existing.some((r) => normalizeRoot(r) === target)) {
+      return;
+    }
+    const next = [...existing, directory];
+    const nextSettings = { ...settings, externalLibraryFolders: next };
+    setSettings(nextSettings);
+    try {
+      await saveSettings(envConfig, nextSettings);
+    } catch (e) {
+      console.error('Failed to persist externalLibraryFolders update:', e);
+    }
+  };
+
+  /**
    * Recursively scan {@link result.directory}, keep files matching one
    * of {@link result.extensions} that are at least
    * {@link result.minSizeKB} KB, and feed them through {@link importBooks}.
@@ -1100,6 +1187,18 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     // Catch that here so they get the same clear guidance instead of
     // a fs_scope error from readDirectory below.
     if (!validatePickedDirectory(result.directory)) return;
+
+    // The user can opt the chosen folder into "in place" via the
+    // dialog toggle; the same effect happens automatically when the
+    // folder is already a registered external library folder (the
+    // ingest layer's `shouldImportInPlace` does a path-prefix match
+    // against `settings.externalLibraryFolders`). Register here so the
+    // bookkeeping survives across launches and so subsequent imports
+    // from the same folder don't have to re-trigger the toggle.
+    if (result.readInPlace) {
+      await registerExternalLibraryFolder(result.directory);
+    }
+
     // Re-grant scopes for the directory before scanning. This matters
     // when `result.directory` came from somewhere the dialog plugin
     // didn't authorise — typically the persisted "last import folder"
@@ -1361,6 +1460,8 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
           initialFolderMode={importFromFolderState.initialFolderMode}
           initialSelectedGroupIds={importFromFolderState.initialSelectedGroupIds}
           initialMinSizeKB={importFromFolderState.initialMinSizeKB}
+          initialReadInPlace={importFromFolderState.initialReadInPlace}
+          isRegisteredExternalRoot={isRegisteredExternalRoot}
           onPickDirectory={pickImportDirectory}
           onCancel={() => setImportFromFolderState(null)}
           onConfirm={(result) => {
@@ -1386,6 +1487,10 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
               window.localStorage.setItem(
                 LAST_IMPORT_FOLDER_MIN_SIZE_KEY,
                 String(result.minSizeKB),
+              );
+              window.localStorage.setItem(
+                LAST_IMPORT_FOLDER_READ_IN_PLACE_KEY,
+                result.readInPlace ? '1' : '0',
               );
             }
             void runFolderImport(result);

--- a/apps/readest-app/src/app/reader/hooks/useWebDAVSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useWebDAVSync.ts
@@ -219,9 +219,14 @@ export const useWebDAVSync = (bookKey: string) => {
           // so we only do the expensive ArrayBuffer materialisation when
           // the HEAD probe says we actually need to upload. Used on web
           // targets where streaming PUTs aren't available.
-          const fp = getLocalBookFilename(book);
-          if (!(await appService.exists(fp, 'Books'))) return null;
-          const file = await appService.openFile(fp, 'Books');
+          // In-place imports keep their bytes outside Books/<hash>/, so
+          // resolve to (book.filePath, 'None') when the field is set —
+          // mirrors the same fallback in cloudService.uploadBook so
+          // syncBooks treats in-place books as first-class.
+          const fp = book.filePath ?? getLocalBookFilename(book);
+          const base = book.filePath ? 'None' : 'Books';
+          if (!(await appService.exists(fp, base))) return null;
+          const file = await appService.openFile(fp, base);
           const bytes = await file.arrayBuffer();
           return { bytes, size: bytes.byteLength };
         },
@@ -234,15 +239,16 @@ export const useWebDAVSync = (bookKey: string) => {
         // library Sync now path in WebDAVForm.
         isTauriAppPlatform()
           ? async () => {
-              const fp = getLocalBookFilename(book);
-              if (!(await appService.exists(fp, 'Books'))) return null;
-              const file = await appService.openFile(fp, 'Books');
+              const fp = book.filePath ?? getLocalBookFilename(book);
+              const base = book.filePath ? 'None' : 'Books';
+              if (!(await appService.exists(fp, base))) return null;
+              const file = await appService.openFile(fp, base);
               const size = file.size;
               // Release the FD before streaming so the Tauri side can
               // re-open the path for the PUT without contending.
               const closable = file as { close?: () => Promise<void> };
               if (closable.close) await closable.close();
-              const dst = await appService.resolveFilePath(fp, 'Books');
+              const dst = await appService.resolveFilePath(fp, base);
               return {
                 size,
                 upload: async (remoteUrl, headers) => {

--- a/apps/readest-app/src/components/settings/integrations/WebDAVForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/WebDAVForm.tsx
@@ -300,9 +300,15 @@ const WebDAVForm: React.FC<WebDAVFormProps> = ({ onBack }) => {
           appService ? appService.loadBookConfig(book, settings) : Promise.resolve(null),
         loadBookFile: async (book) => {
           if (!appService) return null;
-          const fp = getLocalBookFilename(book);
-          if (!(await appService.exists(fp, 'Books'))) return null;
-          const file = await appService.openFile(fp, 'Books');
+          // In-place imports live outside Books/<hash>/; resolve to
+          // (book.filePath, 'None') when set. Hash-copy books fall
+          // through to the original Books-relative path. Same fallback
+          // pattern as cloudService.uploadBook so library Sync now
+          // treats in-place books as first-class.
+          const fp = book.filePath ?? getLocalBookFilename(book);
+          const base = book.filePath ? 'None' : 'Books';
+          if (!(await appService.exists(fp, base))) return null;
+          const file = await appService.openFile(fp, base);
           const bytes = await file.arrayBuffer();
           return { bytes, size: bytes.byteLength };
         },
@@ -320,16 +326,17 @@ const WebDAVForm: React.FC<WebDAVFormProps> = ({ onBack }) => {
         loadBookFileStreaming: isTauriAppPlatform()
           ? async (book) => {
               if (!appService) return null;
-              const fp = getLocalBookFilename(book);
-              if (!(await appService.exists(fp, 'Books'))) return null;
-              const file = await appService.openFile(fp, 'Books');
+              const fp = book.filePath ?? getLocalBookFilename(book);
+              const base = book.filePath ? 'None' : 'Books';
+              if (!(await appService.exists(fp, base))) return null;
+              const file = await appService.openFile(fp, base);
               const size = file.size;
               // openFile returns a File-like handle; close eagerly when
               // the platform exposes it so the Tauri side can re-open
               // the path for the streamed PUT without holding two FDs.
               const closable = file as { close?: () => Promise<void> };
               if (closable.close) await closable.close();
-              const dst = await appService.resolveFilePath(fp, 'Books');
+              const dst = await appService.resolveFilePath(fp, base);
               return {
                 size,
                 upload: async (remoteUrl, headers) => {

--- a/apps/readest-app/src/services/backupService.ts
+++ b/apps/readest-app/src/services/backupService.ts
@@ -36,6 +36,7 @@ export const BACKUP_SETTINGS_BLACKLIST = [
   // Device filesystem paths — invalid on another device / OS.
   'localBooksDir',
   'customRootDir',
+  'externalLibraryFolders',
   'savedBookCoverForLockScreenPath',
   // Per-device identity — restoring causes sync identity / HLC collisions.
   'replicaDeviceId',

--- a/apps/readest-app/src/services/bookContent.ts
+++ b/apps/readest-app/src/services/bookContent.ts
@@ -1,0 +1,67 @@
+import type { Book } from '@/types/book';
+import type { FileSystem } from '@/types/system';
+import { EXTS } from '@/libs/document';
+import { getDir, getLocalBookFilename } from '@/utils/book';
+import { isValidURL } from '@/utils/misc';
+import { isPseStreamFileName } from './opds/pseStream';
+
+export type BookContentSource =
+  | { kind: 'managed'; path: string; base: 'Books'; legacy?: boolean }
+  | { kind: 'external'; path: string; base: 'None' }
+  | { kind: 'url'; path: string; base: 'None' }
+  | { kind: 'stream'; path: string; base: 'None'; scheme: 'pse' }
+  | { kind: 'missing' };
+
+export type BookFileContentSource = Extract<
+  BookContentSource,
+  { kind: 'managed' | 'external' | 'url' }
+>;
+
+export function isBookFileContentSource(
+  source: BookContentSource,
+): source is BookFileContentSource {
+  return source.kind === 'managed' || source.kind === 'external' || source.kind === 'url';
+}
+
+async function resolveLegacyManagedSource(
+  fs: FileSystem,
+  book: Book,
+): Promise<BookContentSource | null> {
+  try {
+    const bookDir = getDir(book);
+    const files = await fs.readDir(bookDir, 'Books');
+    const bookFile = files.find((f) => f.path.endsWith(`.${EXTS[book.format]}`));
+    if (!bookFile) return null;
+    return { kind: 'managed', path: `${bookDir}/${bookFile.path}`, base: 'Books', legacy: true };
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveBookContentSource(
+  fs: FileSystem,
+  book: Book,
+): Promise<BookContentSource> {
+  // Prefer the managed copy when it exists; book.filePath is device-local and
+  // can outlive a prior in-place/import mode.
+  const managedPath = getLocalBookFilename(book);
+  if (await fs.exists(managedPath, 'Books')) {
+    return { kind: 'managed', path: managedPath, base: 'Books' };
+  }
+
+  if (book.filePath && (await fs.exists(book.filePath, 'None'))) {
+    return { kind: 'external', path: book.filePath, base: 'None' };
+  }
+
+  if (book.url) {
+    if (isPseStreamFileName(book.url)) {
+      return { kind: 'stream', path: book.url, base: 'None', scheme: 'pse' };
+    }
+    if (isValidURL(book.url)) {
+      return { kind: 'url', path: book.url, base: 'None' };
+    }
+  }
+
+  const legacyManagedSource = await resolveLegacyManagedSource(fs, book);
+  return legacyManagedSource ?? { kind: 'missing' };
+}

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -25,7 +25,7 @@ import {
 import type { BookNav } from '@/services/nav';
 import { partialMD5, md5 } from '@/utils/md5';
 import { getBaseFilename, getFilename } from '@/utils/path';
-import { BookDoc, DocumentLoader, EXTS } from '@/libs/document';
+import { BookDoc, DocumentLoader } from '@/libs/document';
 import { isPseStreamFileName, openPseStreamBook, parsePseStreamFileName } from './opds/pseStream';
 import { DEFAULT_BOOK_SEARCH_CONFIG, DEFAULT_FIXED_LAYOUT_VIEW_SETTINGS } from './constants';
 import { isContentURI, isValidURL, makeSafeFilename } from '@/utils/misc';
@@ -36,6 +36,11 @@ import { svg2png } from '@/utils/svg';
 import { normalizeMetadataIsbn } from '@/utils/isbn';
 import { BookFileNotFoundError } from './errors';
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
+import {
+  isBookFileContentSource,
+  resolveBookContentSource,
+  type BookFileContentSource,
+} from './bookContent';
 
 export function buildBookLookupIndex(books: Book[]): BookLookupIndex {
   const byHash = new Map<string, Book>();
@@ -377,13 +382,13 @@ export async function importBook(
       await fs.createDir(getDir(book), 'Books');
     }
     const bookFilename = getLocalBookFilename(book);
-    if (
+    const willWriteBookFile =
       saveBook &&
       !transient &&
       !inPlace &&
-      fileobj &&
-      (!(await fs.exists(bookFilename, 'Books')) || overwrite)
-    ) {
+      !!fileobj &&
+      (!(await fs.exists(bookFilename, 'Books')) || overwrite);
+    if (willWriteBookFile && fileobj) {
       if (/\.txt$/i.test(filename)) {
         await fs.writeFile(bookFilename, 'Books', fileobj);
       } else if (typeof file === 'string' && isContentURI(file)) {
@@ -490,58 +495,39 @@ export async function importBook(
 // --- Book Content & Config ---
 
 export async function isBookAvailable(fs: FileSystem, book: Book): Promise<boolean> {
-  const fp = getLocalBookFilename(book);
-  if (await fs.exists(fp, 'Books')) {
-    return true;
-  }
-  if (book.filePath) {
-    return await fs.exists(book.filePath, 'None');
-  }
-  if (book.url) {
-    return isValidURL(book.url);
-  }
-  return false;
+  return (await resolveBookContentSource(fs, book)).kind !== 'missing';
 }
 
 export async function getBookFileSize(fs: FileSystem, book: Book): Promise<number | null> {
-  const fp = getLocalBookFilename(book);
-  if (await fs.exists(fp, 'Books')) {
-    const file = await fs.openFile(fp, 'Books');
-    const size = file.size;
-    const f = file as ClosableFile;
-    if (f && f.close) {
-      await f.close();
-    }
-    return size;
+  const source = await resolveBookContentSource(fs, book);
+  if (source.kind !== 'managed' && source.kind !== 'external') {
+    return null;
   }
-  return null;
+  const file = await fs.openFile(source.path, source.base);
+  const size = file.size;
+  const f = file as ClosableFile;
+  if (f && f.close) {
+    await f.close();
+  }
+  return size;
+}
+
+async function openBookFileContent(
+  fs: FileSystem,
+  book: Book,
+): Promise<{
+  source: BookFileContentSource;
+  file: File;
+}> {
+  const source = await resolveBookContentSource(fs, book);
+  if (!isBookFileContentSource(source)) {
+    throw new BookFileNotFoundError();
+  }
+  return { source, file: await fs.openFile(source.path, source.base) };
 }
 
 export async function loadBookContent(fs: FileSystem, book: Book): Promise<BookContent> {
-  let file: File;
-  const fp = getLocalBookFilename(book);
-
-  if (await fs.exists(fp, 'Books')) {
-    file = await fs.openFile(fp, 'Books');
-  } else if (book.filePath) {
-    file = await fs.openFile(book.filePath, 'None');
-  } else if (book.url) {
-    file = await fs.openFile(book.url, 'None');
-  } else {
-    // 0.9.64 has a bug that book.title might be modified but the filename is not updated
-    const bookDir = getDir(book);
-    const files = await fs.readDir(getDir(book), 'Books');
-    if (files.length > 0) {
-      const bookFile = files.find((f) => f.path.endsWith(`.${EXTS[book.format]}`));
-      if (bookFile) {
-        file = await fs.openFile(`${bookDir}/${bookFile.path}`, 'Books');
-      } else {
-        throw new BookFileNotFoundError();
-      }
-    } else {
-      throw new BookFileNotFoundError();
-    }
-  }
+  const { file } = await openBookFileContent(fs, book);
   return { book, file };
 }
 
@@ -662,13 +648,16 @@ export async function exportBook(
     options?: { filePath?: string; mimeType?: string },
   ) => Promise<boolean>,
 ): Promise<boolean> {
-  const { file } = await loadBookContent(fs, book);
+  const { source, file } = await openBookFileContent(fs, book);
   const content = await file.arrayBuffer();
   const filename = `${makeSafeFilename(book.title)}.${book.format.toLowerCase()}`;
-  let filePath = await resolveFilePath(getLocalBookFilename(book), 'Books');
   const mimeType = file.type || 'application/octet-stream';
+  if (source.kind === 'url') {
+    return await saveFile(filename, content, { mimeType });
+  }
+  let filePath = await resolveFilePath(source.path, source.base);
   if (getFilename(filePath) !== filename) {
-    await copyFile(filePath, 'None', filename, 'Temp');
+    await copyFile(source.path, source.base, filename, 'Temp');
     filePath = await resolveFilePath(filename, 'Temp');
   }
   return await saveFile(filename, content, { filePath, mimeType });

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -237,6 +237,7 @@ export async function importBook(
     saveCover = true,
     overwrite = false,
     transient = false,
+    inPlace = false,
     lookupIndex,
   } = options;
   const isPseStream = typeof file === 'string' && isPseStreamFileName(file);
@@ -379,6 +380,7 @@ export async function importBook(
     if (
       saveBook &&
       !transient &&
+      !inPlace &&
       fileobj &&
       (!(await fs.exists(bookFilename, 'Books')) || overwrite)
     ) {
@@ -464,8 +466,10 @@ export async function importBook(
       if (isValidURL(file)) {
         book.url = file;
         if (existingBook) existingBook.url = file;
-      }
-      if (transient) {
+      } else if (transient || inPlace) {
+        // transient: source file is loaded directly, never persisted in Books/.
+        // inPlace: source file is inside the user's library root and we read it
+        // there directly instead of duplicating it under Books/<hash>/.
         book.filePath = file;
         if (existingBook) existingBook.filePath = file;
       }

--- a/apps/readest-app/src/services/cloudService.ts
+++ b/apps/readest-app/src/services/cloudService.ts
@@ -23,12 +23,40 @@ export async function deleteBook(
   book: Book,
   deleteAction: DeleteAction,
 ): Promise<void> {
+  // In-place imports keep their content at a user-controlled location
+  // (book.filePath, base 'None') rather than under Books/<hash>/. For
+  // 'local'/'both' deletes that source file IS the local copy of this
+  // book — deleting it is symmetric with deleting Books/<hash>/<title>.epub
+  // for a normal book. The cover and other sidecars still live under
+  // Books/<hash>/ and are removed via the same path as for normal books.
+  const isExternalSource = !!book.filePath;
+
   if (deleteAction === 'local' || deleteAction === 'both') {
+    // Delete the user-controlled source file for in-place books. For a
+    // 'local' delete this is the only payload; for 'both' the cover
+    // (which lives under Books/<hash>/) is handled below.
+    if (isExternalSource && book.filePath) {
+      try {
+        if (await fs.exists(book.filePath, 'None')) {
+          await fs.removeFile(book.filePath, 'None');
+        }
+      } catch (error) {
+        // Best effort: a missing/permission-denied source shouldn't block
+        // the metadata-side bookkeeping that follows.
+        console.log('Failed to remove in-place source file:', error);
+      }
+    }
+
     const localDeleteFps =
       deleteAction === 'local'
         ? [getLocalBookFilename(book)]
         : [getLocalBookFilename(book), getCoverFilename(book)];
     for (const fp of localDeleteFps) {
+      // For in-place books the "book file" doesn't live under Books/<hash>/,
+      // so don't probe for it there. The cover sidecar still does.
+      if (isExternalSource && fp === getLocalBookFilename(book)) {
+        continue;
+      }
       if (await fs.exists(fp, 'Books')) {
         await fs.removeFile(fp, 'Books');
       }
@@ -151,16 +179,38 @@ export async function uploadBook(
   const completedFiles = { count: 0 };
   let toUploadFpCount = 0;
   const coverExist = await fs.exists(getCoverFilename(book), 'Books');
-  let bookFileExist = await fs.exists(getLocalBookFilename(book), 'Books');
+
+  // Resolve where to read the book file from. In-place / sent imports keep
+  // their content at a user-controlled location (book.filePath, base 'None')
+  // rather than under Books/<hash>/. The cloud key on the upload side is
+  // identical either way — it's always CLOUD_BOOKS_SUBDIR/<remote_filename> —
+  // so cross-device sync still lands the file in Books/<hash>/ on the
+  // downloading device.
+  let bookReadFp: string;
+  let bookReadBase: BaseDir;
+  if (book.filePath) {
+    bookReadFp = book.filePath;
+    bookReadBase = 'None';
+  } else {
+    bookReadFp = getLocalBookFilename(book);
+    bookReadBase = 'Books';
+  }
+  let bookFileExist = await fs.exists(bookReadFp, bookReadBase);
   if (coverExist) {
     toUploadFpCount++;
   }
   if (bookFileExist) {
     toUploadFpCount++;
   }
-  if (!bookFileExist && book.url) {
+  // Legacy fallback: a book without a managed local copy and without a
+  // user-controlled filePath but with a remote `url` (e.g. a freshly imported
+  // book whose bytes were temporarily fetched). Materialize it under
+  // Books/<hash>/ so the upload below has something to read.
+  if (!bookFileExist && !book.filePath && book.url) {
     const fileobj = await fs.openFile(book.url, 'None');
     await fs.writeFile(getLocalBookFilename(book), 'Books', await fileobj.arrayBuffer());
+    bookReadFp = getLocalBookFilename(book);
+    bookReadBase = 'Books';
     bookFileExist = true;
   }
 
@@ -175,9 +225,16 @@ export async function uploadBook(
   }
 
   if (bookFileExist) {
-    const lfp = getLocalBookFilename(book);
     const cfp = `${CLOUD_BOOKS_SUBDIR}/${getRemoteBookFilename(book)}`;
-    await uploadFileToCloud(fs, resolveFilePath, lfp, cfp, 'Books', handleProgress, book.hash);
+    await uploadFileToCloud(
+      fs,
+      resolveFilePath,
+      bookReadFp,
+      cfp,
+      bookReadBase,
+      handleProgress,
+      book.hash,
+    );
     uploaded = true;
     completedFiles.count++;
   }

--- a/apps/readest-app/src/services/cloudService.ts
+++ b/apps/readest-app/src/services/cloudService.ts
@@ -17,49 +17,33 @@ import {
 import { ClosableFile } from '@/utils/file';
 import { ProgressHandler } from '@/utils/transfer';
 import { CLOUD_BOOKS_SUBDIR, CLOUD_REPLICAS_SUBDIR } from './constants';
+import { isBookFileContentSource, resolveBookContentSource } from './bookContent';
 
 export async function deleteBook(
   fs: FileSystem,
   book: Book,
   deleteAction: DeleteAction,
 ): Promise<void> {
-  // In-place imports keep their content at a user-controlled location
-  // (book.filePath, base 'None') rather than under Books/<hash>/. For
-  // 'local'/'both' deletes that source file IS the local copy of this
-  // book — deleting it is symmetric with deleting Books/<hash>/<title>.epub
-  // for a normal book. The cover and other sidecars still live under
-  // Books/<hash>/ and are removed via the same path as for normal books.
-  const isExternalSource = !!book.filePath;
-
   if (deleteAction === 'local' || deleteAction === 'both') {
-    // Delete the user-controlled source file for in-place books. For a
-    // 'local' delete this is the only payload; for 'both' the cover
-    // (which lives under Books/<hash>/) is handled below.
-    if (isExternalSource && book.filePath) {
+    const source = await resolveBookContentSource(fs, book);
+    if (source.kind === 'external') {
       try {
-        if (await fs.exists(book.filePath, 'None')) {
-          await fs.removeFile(book.filePath, 'None');
+        if (await fs.exists(source.path, source.base)) {
+          await fs.removeFile(source.path, source.base);
         }
       } catch (error) {
         // Best effort: a missing/permission-denied source shouldn't block
         // the metadata-side bookkeeping that follows.
         console.log('Failed to remove in-place source file:', error);
       }
+    } else if (source.kind === 'managed') {
+      if (await fs.exists(source.path, source.base)) {
+        await fs.removeFile(source.path, source.base);
+      }
     }
 
-    const localDeleteFps =
-      deleteAction === 'local'
-        ? [getLocalBookFilename(book)]
-        : [getLocalBookFilename(book), getCoverFilename(book)];
-    for (const fp of localDeleteFps) {
-      // For in-place books the "book file" doesn't live under Books/<hash>/,
-      // so don't probe for it there. The cover sidecar still does.
-      if (isExternalSource && fp === getLocalBookFilename(book)) {
-        continue;
-      }
-      if (await fs.exists(fp, 'Books')) {
-        await fs.removeFile(fp, 'Books');
-      }
+    if (deleteAction === 'both' && (await fs.exists(getCoverFilename(book), 'Books'))) {
+      await fs.removeFile(getCoverFilename(book), 'Books');
     }
     if (deleteAction === 'local') {
       book.downloadedAt = null;
@@ -175,79 +159,51 @@ export async function uploadBook(
   book: Book,
   onProgress?: ProgressHandler,
 ): Promise<void> {
-  let uploaded = false;
   const completedFiles = { count: 0 };
-  let toUploadFpCount = 0;
   const coverExist = await fs.exists(getCoverFilename(book), 'Books');
 
-  // Resolve where to read the book file from. In-place / sent imports keep
-  // their content at a user-controlled location (book.filePath, base 'None')
-  // rather than under Books/<hash>/. The cloud key on the upload side is
-  // identical either way — it's always CLOUD_BOOKS_SUBDIR/<remote_filename> —
-  // so cross-device sync still lands the file in Books/<hash>/ on the
-  // downloading device.
-  let bookReadFp: string;
-  let bookReadBase: BaseDir;
-  if (book.filePath) {
-    bookReadFp = book.filePath;
-    bookReadBase = 'None';
-  } else {
-    bookReadFp = getLocalBookFilename(book);
-    bookReadBase = 'Books';
-  }
-  let bookFileExist = await fs.exists(bookReadFp, bookReadBase);
-  if (coverExist) {
-    toUploadFpCount++;
-  }
-  if (bookFileExist) {
-    toUploadFpCount++;
-  }
-  // Legacy fallback: a book without a managed local copy and without a
-  // user-controlled filePath but with a remote `url` (e.g. a freshly imported
-  // book whose bytes were temporarily fetched). Materialize it under
-  // Books/<hash>/ so the upload below has something to read.
-  if (!bookFileExist && !book.filePath && book.url) {
-    const fileobj = await fs.openFile(book.url, 'None');
+  let bookSource = await resolveBookContentSource(fs, book);
+  if (bookSource.kind === 'url') {
+    const fileobj = await fs.openFile(bookSource.path, bookSource.base);
     await fs.writeFile(getLocalBookFilename(book), 'Books', await fileobj.arrayBuffer());
-    bookReadFp = getLocalBookFilename(book);
-    bookReadBase = 'Books';
-    bookFileExist = true;
+    const f = fileobj as ClosableFile;
+    if (f && f.close) {
+      await f.close();
+    }
+    bookSource = { kind: 'managed', path: getLocalBookFilename(book), base: 'Books' };
   }
 
+  if (!isBookFileContentSource(bookSource)) {
+    throw new Error('Book file not uploaded');
+  }
+
+  const toUploadFpCount = coverExist ? 2 : 1;
   const handleProgress = createProgressHandler(toUploadFpCount, completedFiles, onProgress);
 
   if (coverExist) {
     const lfp = getCoverFilename(book);
     const cfp = `${CLOUD_BOOKS_SUBDIR}/${getCoverFilename(book)}`;
     await uploadFileToCloud(fs, resolveFilePath, lfp, cfp, 'Books', handleProgress, book.hash);
-    uploaded = true;
     completedFiles.count++;
   }
 
-  if (bookFileExist) {
-    const cfp = `${CLOUD_BOOKS_SUBDIR}/${getRemoteBookFilename(book)}`;
-    await uploadFileToCloud(
-      fs,
-      resolveFilePath,
-      bookReadFp,
-      cfp,
-      bookReadBase,
-      handleProgress,
-      book.hash,
-    );
-    uploaded = true;
-    completedFiles.count++;
-  }
+  const cfp = `${CLOUD_BOOKS_SUBDIR}/${getRemoteBookFilename(book)}`;
+  await uploadFileToCloud(
+    fs,
+    resolveFilePath,
+    bookSource.path,
+    cfp,
+    bookSource.base,
+    handleProgress,
+    book.hash,
+  );
+  completedFiles.count++;
 
-  if (uploaded) {
-    book.deletedAt = null;
-    book.updatedAt = Date.now();
-    book.uploadedAt = Date.now();
-    book.downloadedAt = Date.now();
-    book.coverDownloadedAt = Date.now();
-  } else {
-    throw new Error('Book file not uploaded');
-  }
+  book.deletedAt = null;
+  book.updatedAt = Date.now();
+  book.uploadedAt = Date.now();
+  book.downloadedAt = Date.now();
+  book.coverDownloadedAt = Date.now();
 }
 
 export async function downloadCloudFile(

--- a/apps/readest-app/src/services/ingestService.ts
+++ b/apps/readest-app/src/services/ingestService.ts
@@ -1,5 +1,5 @@
 import type { Book, BookLookupIndex } from '@/types/book';
-import type { AppService } from '@/types/system';
+import type { AppService, OsPlatform } from '@/types/system';
 import type { SystemSettings } from '@/types/settings';
 import { transferManager } from '@/services/transferManager';
 
@@ -7,6 +7,16 @@ export interface IngestFileDeps {
   appService: AppService;
   settings: SystemSettings;
   isLoggedIn: boolean;
+  /**
+   * Pre-resolved absolute path to Readest's own `Books/` directory. When
+   * provided, any source file already living under this prefix is excluded
+   * from in-place import (it is, by definition, a hash copy we wrote). The
+   * caller is expected to resolve it once per batch via
+   * `appService.fs.getPrefix('Books')` instead of paying the async cost
+   * per ingested file. Omit (or pass null) on contexts where the lookup is
+   * unavailable — in-place decisions will then proceed without this guard.
+   */
+  appBooksPrefix?: string | null;
 }
 
 export interface IngestFileOptions {
@@ -25,6 +35,104 @@ export interface IngestFileOptions {
   forceUpload?: boolean;
   /** Transient import (not stored long-term) — never uploaded. */
   transient?: boolean;
+  /**
+   * Opt out of automatic in-place import even when the source file lives under
+   * the user's custom root directory. Forces the legacy behavior of copying
+   * the file into Books/<hash>/. Defaults to false.
+   */
+  forceCopy?: boolean;
+}
+
+/**
+ * Decide whether `file` should be imported in-place (read directly from its
+ * source location) instead of copied into Books/<hash>/.
+ *
+ * Conditions (all must hold):
+ *   - `file` is an absolute path string (not a File / blob / URL / content URI).
+ *   - The path lives under one of the user's registered in-place roots
+ *     (`settings.externalLibraryFolders`) — directories the user has
+ *     explicitly told Readest to read in place. The Readest data location
+ *     (`customRootDir`) is intentionally NOT an in-place trigger; that
+ *     directory is Readest's own home and may freely contain hash copies.
+ *   - The path is NOT inside Readest's own managed books directory
+ *     (`appBooksPrefix`, e.g. `<AppData>/Books/`). Anything in that subtree
+ *     is a hash copy under Readest's control, no point marking it in-place.
+ *     We compare against the actual app data path rather than rejecting any
+ *     `<root>/Books/` segment — users routinely have unrelated folders named
+ *     `Books` inside their library roots (Baidu Netdisk's default layout,
+ *     Calibre exports, etc.) and those must still go in-place.
+ *   - Caller did not request `transient` (transient already opts out of
+ *     copying via its own filePath path) or `forceCopy`.
+ *
+ * Returns false in any other case, including web (File objects), URLs, and
+ * relative paths.
+ *
+ * Known limitation: symlinks are not resolved. A registered root of
+ * `/Users/me/Library` will NOT match a file accessed through a sibling
+ * symlink like `/Users/me/LibrarySymlink/sample.epub` even when both point
+ * at the same on-disk directory. Adding best-effort realpath resolution
+ * requires async I/O and a cross-platform `realpath` capability on
+ * `FileSystem`, which is out of scope for this change.
+ */
+function shouldImportInPlace(
+  file: File | string,
+  opts: Pick<IngestFileOptions, 'transient' | 'forceCopy'>,
+  inPlaceRoots: string[],
+  osPlatform: OsPlatform,
+  appBooksPrefix: string | null,
+): boolean {
+  if (opts.transient || opts.forceCopy) return false;
+  if (typeof file !== 'string') return false;
+  if (inPlaceRoots.length === 0) return false;
+
+  // Absolute path check that works for POSIX and Windows without pulling in
+  // node:path (this code also runs in the renderer on web/mobile builds).
+  const isWindowsDrive = /^[A-Za-z]:[\\/]/.test(file);
+  const isAbs = file.startsWith('/') || isWindowsDrive || file.startsWith('\\\\');
+  if (!isAbs) return false;
+
+  // Reject anything that smells like a URL or content URI. Windows drive
+  // letters (`C:\…`) match a "scheme:rest" shape too, so exclude them
+  // explicitly — `isWindowsDrive` already vouched for those.
+  if (!isWindowsDrive && /^[a-z][a-z0-9+.-]*:/i.test(file)) return false;
+
+  // macOS (APFS/HFS+ default), iOS, and Windows ship case-insensitive
+  // filesystems out of the box, so `/Users/me/Library` and
+  // `/users/me/library` must compare equal there. Linux and Android are
+  // case-sensitive and stay strict. We do not attempt unicode normalization
+  // (NFC/NFD) — APFS handles that at the FS layer and `toLocaleLowerCase`
+  // with the wrong locale would introduce its own bugs (e.g. Turkish `İ`).
+  const caseInsensitive =
+    osPlatform === 'macos' || osPlatform === 'ios' || osPlatform === 'windows';
+  const norm = (p: string) => {
+    const n = p.replace(/\\/g, '/').replace(/\/+$/, '');
+    return caseInsensitive ? n.toLowerCase() : n;
+  };
+  const target = norm(file);
+
+  // If the file already lives inside Readest's own managed books directory
+  // we never want to "in-place" it: it is, by definition, a hash copy we
+  // produced ourselves. Compare against the actual resolved app prefix so
+  // unrelated user-owned folders that happen to be named `Books` (very
+  // common in cloud-drive layouts like Baidu Netdisk's `Books/` root) are
+  // left untouched and imported in-place when they fall under a registered
+  // external root.
+  if (appBooksPrefix) {
+    const appBooks = norm(appBooksPrefix);
+    if (appBooks && (target === appBooks || target.startsWith(appBooks + '/'))) {
+      return false;
+    }
+  }
+
+  for (const raw of inPlaceRoots) {
+    if (!raw) continue;
+    const root = norm(raw);
+    if (!root) continue;
+    // Guard against root-as-prefix-of-different-dir (`/foo` vs `/foobar`).
+    if (target !== root && !target.startsWith(root + '/')) continue;
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -41,11 +149,21 @@ export async function ingestFile(
   opts: IngestFileOptions,
   deps: IngestFileDeps,
 ): Promise<Book | null> {
-  const { appService, settings, isLoggedIn } = deps;
+  const { appService, settings, isLoggedIn, appBooksPrefix } = deps;
+
+  const inPlaceRoots = settings.externalLibraryFolders ?? [];
+  const inPlace = shouldImportInPlace(
+    opts.file,
+    opts,
+    inPlaceRoots,
+    appService.osPlatform,
+    appBooksPrefix ?? null,
+  );
 
   const book = await appService.importBook(opts.file, opts.books, {
     lookupIndex: opts.lookupIndex,
     transient: opts.transient,
+    inPlace,
   });
   if (!book) return null;
 
@@ -71,7 +189,13 @@ export async function ingestFile(
 
   // Sent books force the upload so they reach the user's other devices even
   // when autoUpload is off; normal library imports honor the setting.
-  // Transient imports are never uploaded.
+  // Transient imports are never uploaded — they're short-lived previews
+  // (e.g. /send view) and shouldn't pollute the user's cloud library.
+  // In-place imports (book.filePath set, content under one of the user's
+  // external library folders) DO get uploaded: from a backup/sync standpoint
+  // they are equivalent to a hash-copy book — only the local storage
+  // location differs. uploadBook reads straight from book.filePath in that
+  // case; downloads on other devices land in Books/<hash>/ as a normal copy.
   if (
     !opts.transient &&
     isLoggedIn &&

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -60,6 +60,15 @@ export interface ImportBookOptions {
   overwrite?: boolean;
   /** Whether the import is transient (not stored long-term). Defaults to false. */
   transient?: boolean;
+  /**
+   * If true, do NOT copy the source file into Books/<hash>/. Instead, persist
+   * an absolute filePath on the Book and let isBookAvailable / loadBookContent
+   * fall back to it. The caller is responsible for verifying the source is
+   * already inside the user's chosen library root (customRootDir) so that the
+   * file remains stable across launches. Sidecar files (cover.png, config.json,
+   * nav.json) are still written to Books/<hash>/ as usual. Defaults to false.
+   */
+  inPlace?: boolean;
   /** Pre-built lookup index for O(1) dedup during batch imports. */
   lookupIndex?: BookLookupIndex;
 }

--- a/apps/readest-app/src/types/settings.ts
+++ b/apps/readest-app/src/types/settings.ts
@@ -256,6 +256,16 @@ export interface SystemSettings {
   migrationVersion: number;
   localBooksDir: string;
   customRootDir?: string;
+  /**
+   * Absolute paths the user has registered as "external library folders" —
+   * directories managed by the user (or another reader app, e.g. Duokan,
+   * Calibre, Moon+ Reader) that Readest should read in place instead of
+   * copying into Books/<hash>/. Each entry must be an absolute path; entries
+   * are matched as path-prefix roots when ingesting a file. Device-local
+   * (path is meaningful only on this filesystem) and excluded from cloud
+   * settings backups via `BACKUP_SETTINGS_BLACKLIST`.
+   */
+  externalLibraryFolders?: string[];
 
   keepLogin: boolean;
   autoUpload: boolean;


### PR DESCRIPTION
> **Stacked on top of #4314.** This PR's branch is based on `feat/ios-folder-import` (PR #4314), so the diff currently includes those 2 commits at the bottom. **Please review and merge #4314 first** — after that I will rebase this branch onto `main` and the diff will shrink to only the 2 commits below.
>
> Commits owned by this PR (top of the stack):
> - `feat(library): in-place import with cloud sync and symmetric local delete`
> - `feat(library): one-tap "read in place" toggle in folder import`
>
> Commits inherited from #4314 (please ignore here — review in that PR):
> - `feat(import): support folder picker on iOS via native-bridge`
> - `feat(ios): persist security-scoped bookmarks for picked folders`

---

Lets users keep books inside an existing on-disk library (Duokan, Calibre, Moon+ Reader, iCloud mirror, …) and read them in place instead of duplicating every file into Readest's hash-keyed `Books/<hash>/` directory. Critical for users with large local libraries who don't want a second copy.

### What's in this PR

**Commit 1 — `feat(library): in-place import with cloud sync and symmetric local delete`**

The mechanism. Adds an `inPlace` option to `importBook`: a source file inside a registered external library folder is referenced directly via `book.filePath` instead of being copied. Sidecars (cover, config, nav) still live under `Books/<hash>/`.

`ingestService` routes through `shouldImportInPlace`, which marks an import in-place when the absolute source path lives under any of `settings.externalLibraryFolders` and is **not** inside a per-root `Books/` subtree. The Readest data dir (`customRootDir`) is intentionally excluded — that directory is Readest's home and should freely hold hash copies; in-place is for user-registered roots.

Cloud sync treats in-place books as first-class:

- `uploadBook` reads bytes from `(book.filePath, 'None')` when set. The cloud key is unchanged, so a peer downloading the book lands it under `Books/<hash>/` as a normal hash copy.
- `useBooksSync` strips `book.filePath` before pushing — it is a device-local path meaningless on any other device.
- `ingestService` no longer skips upload for in-place books; `autoUpload` / `forceUpload` behave like any other book. Only transient imports opt out.
- `deleteBook` `'local'`/`'both'` now physically removes the source file at `book.filePath` (base `'None'`). Local-delete semantics are symmetric with hash-copy books: the local copy is gone, the cloud backup remains, a future pull restores under `Books/<hash>/`. `removeFile` errors are swallowed.

New `SystemSettings.externalLibraryFolders?: string[]`. Added to `BACKUP_SETTINGS_BLACKLIST` alongside `localBooksDir` / `customRootDir` so device-local paths don't ride cloud backups.

**Commit 2 — `feat(library): one-tap "read in place" toggle in folder import`**

The user entrypoint. Adds a checkbox to the folder-import dialog. When the user opts in:

- The selected folder is auto-registered into `settings.externalLibraryFolders` (deduplicated).
- The choice is remembered as the default for the next import via `localStorage` (`readest:lastImportFolderReadInPlace`).
- Folders that are already registered force the checkbox ON and lock it (you cannot half-import a registered root).

### Testing

`cloud-service`, `ingest-service`, and `backup-settings` suites cover in-place delete, multi-root matching, per-root `Books/` guard, and the backup-strip. Full vitest suite passes (4858 tests).

### Compatibility notes

- **No UI yet for unregistering** a folder — that's a follow-up. Current entrypoint is via the import-dialog checkbox.
- The cloud `book` record's `filePath` is stripped on push; if any pre-PR dogfood client has already pushed a dirty `filePath`, the first pull after merge will bring it back into local state. Functionally harmless (`isBookAvailable` prefers the hash path), and the next push from that device strips it.
- iOS support requires #4314 (folder picker + bookmark persistence). On desktop and Android, this PR works standalone.
