### PR TITLE
fix(file-picker): unblock .mrexpt and other custom extensions on Android

### DIFF
--- a/apps/readest-app/src/hooks/useFileSelector.ts
+++ b/apps/readest-app/src/hooks/useFileSelector.ts
@@ -45,9 +45,17 @@ const selectFileTauri = async (
   appService: AppService,
   _: (key: string) => string,
 ): Promise<string[]> => {
+  // Android's SAF picker filters by MIME type. Niche/custom extensions
+  // (e.g. ".mrexpt" from Moon+ Reader) have no registered MIME and would
+  // appear greyed-out, so for those cases we ask the native side for an
+  // unfiltered picker and re-apply the extension whitelist on the
+  // resulting paths below. We extend the same treatment to 'generic'
+  // selections because callers there typically pass arbitrary extensions
+  // that SAF likewise cannot match (e.g. mrexpt, txt).
   const noFilter =
     appService?.isIOSApp ||
-    (appService?.isAndroidApp && (options.type === 'books' || options.type === 'dictionaries'));
+    (appService?.isAndroidApp &&
+      (options.type === 'books' || options.type === 'dictionaries' || options.type === 'generic'));
   const exts = noFilter ? [] : options.extensions || [];
   const title = options.dialogTitle || _('Select Files');
   let files = (await appService?.selectFiles(_(title), exts)) || [];


### PR DESCRIPTION
The Moon+ Reader import flow asks for .mrexpt files via the 'generic' preset. On Android, Tauri routes that to the Storage Access Framework picker, which filters by MIME type. Extensions without a registered MIME (such as .mrexpt) end up greyed-out and unselectable.

Books and dictionaries already bypass this by using an unfiltered picker and re-applying the extension whitelist client-side. Extend the same treatment to the 'generic' preset so callers can request arbitrary extensions reliably on Android. iOS already had no SAF restriction.