### PR TITLE
fix(fxl): align TTS highlight overlay with scaled iframe coords

### DIFF
--- a/apps/readest-app/src/__tests__/document/fixed-layout-overlayer-viewbox.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-overlayer-viewbox.test.ts
@@ -1,0 +1,75 @@
+// Regression test for: TTS highlight overlay is off the text boxes in
+// fixed-layout EPUBs when the page is scaled up.
+//
+// In non-PDF fixed-layout, the iframe is visually scaled with `transform:
+// scale(N)` while its internal layout keeps native dimensions. The SVG
+// overlayer sits next to the iframe at the scaled size, but
+// `range.getClientRects()` inside the iframe returns positions in the
+// iframe's native coord system. Without a matching `viewBox`, the SVG draws
+// rects in CSS pixels and the highlight lands at scale-1 displacement from
+// the actual text.
+//
+// The fix sets `viewBox="0 0 width height"` on the overlayer SVG so its
+// coordinate system stays aligned with the iframe contents at any scale.
+import { describe, expect, it } from 'vitest';
+
+import { applyOverlayerViewBox } from 'foliate-js/fixed-layout.js';
+
+const makeOverlayer = () => {
+  const attrs: Record<string, string> = {};
+  return {
+    element: {
+      setAttribute: (name: string, value: string) => {
+        attrs[name] = value;
+      },
+      removeAttribute: (name: string) => {
+        delete attrs[name];
+      },
+      getAttribute: (name: string) => attrs[name] ?? null,
+      _attrs: attrs,
+    },
+  };
+};
+
+describe('applyOverlayerViewBox', () => {
+  it('sets viewBox to native iframe dimensions for transform-scaled frames', () => {
+    const overlayer = makeOverlayer();
+    applyOverlayerViewBox({ width: 558, height: 711 }, overlayer);
+
+    expect(overlayer.element.getAttribute('viewBox')).toBe('0 0 558 711');
+    expect(overlayer.element.getAttribute('preserveAspectRatio')).toBe('none');
+  });
+
+  it('removes viewBox when frame uses onZoom (PDF text-layer rendered at scale)', () => {
+    const overlayer = makeOverlayer();
+    // pre-populate to simulate switching from EPUB-style frame to PDF frame
+    overlayer.element.setAttribute('viewBox', '0 0 558 711');
+    overlayer.element.setAttribute('preserveAspectRatio', 'none');
+
+    applyOverlayerViewBox({ width: 558, height: 711, onZoom: () => {} }, overlayer);
+
+    expect(overlayer.element.getAttribute('viewBox')).toBeNull();
+    expect(overlayer.element.getAttribute('preserveAspectRatio')).toBeNull();
+  });
+
+  it('accepts scroll-mode frames keyed by vpWidth/vpHeight', () => {
+    const overlayer = makeOverlayer();
+    applyOverlayerViewBox({ vpWidth: 800, vpHeight: 1200 }, overlayer);
+
+    expect(overlayer.element.getAttribute('viewBox')).toBe('0 0 800 1200');
+  });
+
+  it('is a no-op when the frame has no dimensions', () => {
+    const overlayer = makeOverlayer();
+    applyOverlayerViewBox({}, overlayer);
+
+    expect(overlayer.element.getAttribute('viewBox')).toBeNull();
+  });
+
+  it('tolerates missing overlayer or element', () => {
+    expect(() => applyOverlayerViewBox({ width: 100, height: 100 }, null)).not.toThrow();
+    expect(() =>
+      applyOverlayerViewBox({ width: 100, height: 100 }, { element: null }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Non-PDF fixed-layout EPUBs visually scale the iframe via `transform: scale(N)` while internal layout keeps native dimensions, so `getClientRects()` inside the iframe returns *unscaled* coords. The overlayer SVG, sized in CSS pixels with no `viewBox`, drew rects at scale-1 displacement from the real text — TTS highlights and annotations floated off the line.
- Bumps `foliate-js` to set a matching `viewBox="0 0 width height"` on the overlayer SVG for transform-scaled frames, and clears it for PDF (`onZoom`) frames whose text layer already produces scaled rects. Applied from spread `transform()`, scroll-mode `#renderScrollPage`, and the `create-overlayer` attach callbacks so the very first attach is correct too.
- Adds a regression test (`fixed-layout-overlayer-viewbox.test.ts`) covering spread frames, PDF `onZoom` frames, scroll-mode `vpWidth/vpHeight` frames, dimensionless frames, and null overlayer guards.

## Test plan
- [x] `pnpm test` — 4877 passed, 8 skipped, 0 failures
- [x] `pnpm lint` — clean
- [x] Live in dev server: TTS started on a scaled fixed-layout EPUB — highlight now sits pixel-perfect on the spoken line (verified via Chrome MCP; before fix the rect was at ~(643, 668), after fix ~(718, 890), matching the scaled text position)

🤖 Generated with [Claude Code](https://claude.com/claude-code)