### PR TITLE
fix(sync): skip replica upload when not authenticated

### DIFF
--- a/apps/readest-app/src/__tests__/services/sync/replicaBinaryUpload.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/replicaBinaryUpload.test.ts
@@ -7,7 +7,12 @@ vi.mock('@/services/transferManager', () => ({
   },
 }));
 
+vi.mock('@/utils/access', () => ({
+  getAccessToken: vi.fn().mockResolvedValue('mock-token'),
+}));
+
 import { transferManager } from '@/services/transferManager';
+import { getAccessToken } from '@/utils/access';
 import { queueDictionaryBinaryUpload } from '@/services/sync/replicaBinaryUpload';
 import { clearReplicaAdapters, registerReplicaAdapter } from '@/services/sync/replicaRegistry';
 import { dictionaryAdapter } from '@/services/sync/adapters/dictionary';
@@ -16,6 +21,7 @@ import type { AppService } from '@/types/system';
 
 const mockIsReady = transferManager.isReady as ReturnType<typeof vi.fn>;
 const mockQueueReplicaUpload = transferManager.queueReplicaUpload as ReturnType<typeof vi.fn>;
+const mockGetAccessToken = getAccessToken as ReturnType<typeof vi.fn>;
 
 const makeFakeAppService = (sizes: Record<string, number>) => ({
   openFile: vi.fn(async (path: string) => ({
@@ -37,6 +43,7 @@ const baseDict = (overrides: Partial<ImportedDictionary> = {}): ImportedDictiona
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockGetAccessToken.mockResolvedValue('mock-token');
   clearReplicaAdapters();
   registerReplicaAdapter(dictionaryAdapter);
 });
@@ -60,6 +67,15 @@ describe('queueDictionaryBinaryUpload', () => {
 
   test('no-ops when TransferManager is not initialized', async () => {
     mockIsReady.mockReturnValue(false);
+    const fakeAppService = makeFakeAppService({}) as unknown as AppService;
+    const result = await queueDictionaryBinaryUpload(baseDict(), fakeAppService);
+    expect(result).toBe(null);
+    expect(mockQueueReplicaUpload).not.toHaveBeenCalled();
+  });
+
+  test('no-ops when user is not authenticated', async () => {
+    mockIsReady.mockReturnValue(true);
+    mockGetAccessToken.mockResolvedValue(null);
     const fakeAppService = makeFakeAppService({}) as unknown as AppService;
     const result = await queueDictionaryBinaryUpload(baseDict(), fakeAppService);
     expect(result).toBe(null);

--- a/apps/readest-app/src/services/sync/replicaBinaryUpload.ts
+++ b/apps/readest-app/src/services/sync/replicaBinaryUpload.ts
@@ -1,5 +1,6 @@
 import { transferManager } from '@/services/transferManager';
 import { getReplicaAdapter } from './replicaRegistry';
+import { getAccessToken } from '@/utils/access';
 import type { AppService, BaseDir } from '@/types/system';
 import type { ReplicaTransferFile } from '@/store/transferStore';
 import type { ClosableFile } from '@/utils/file';
@@ -55,6 +56,7 @@ export const queueReplicaBinaryUpload = async <T extends ReplicaBinaryRecord>(
   appService: AppService,
 ): Promise<string | null> => {
   if (!record.contentId) return null;
+  if (!(await getAccessToken())) return null;
   if (!transferManager.isReady()) return null;
 
   const adapter = getReplicaAdapter<T>(kind);


### PR DESCRIPTION
## Summary
Fixes "Please log in to continue" error when importing fonts or images locally without logging in. The user does not want to log in — they are only importing locally, so why should they be forced to log in?

## Root Cause
`queueReplicaBinaryUpload` did not check authentication status before enqueuing uploads. Unauthenticated users would trigger cloud uploads, which then fail with "Not authenticated" when `fetchWithAuth` cannot get a token.

## Changes
- Add `getAccessToken()` check at the entry of `queueReplicaBinaryUpload`
- Unauthenticated users now get `null` immediately, skipping the upload queue entirely
- Updated `replicaBinaryUpload.test.ts` with proper `getAccessToken` mock and added a test for the unauthenticated case

## Testing
- Import font/images locally without logging in — no more "Please log in to continue" error
- Existing authenticated upload flow remains unchanged