### PR TITLE
fix(library): wrap select-mode action bar on small screens

### DIFF
--- a/apps/readest-app/src/app/library/components/SelectModeActions.tsx
+++ b/apps/readest-app/src/app/library/components/SelectModeActions.tsx
@@ -51,9 +51,9 @@ const SelectModeActions: React.FC<SelectModeActionsProps> = ({
         className={clsx(
           'text-base-content text-xs shadow-lg',
           'not-eink:bg-base-300 eink:bg-base-100 eink:border eink:border-base-content',
-          'mx-auto w-fit rounded-lg p-4',
-          'flex items-center justify-center space-x-6',
-          'max-[350px]:grid max-[350px]:grid-cols-3 max-[350px]:gap-x-10 max-[350px]:gap-y-2 max-[350px]:space-x-0',
+          'mx-auto w-fit max-w-[calc(100vw-1rem)] rounded-lg p-4',
+          'flex items-center justify-center gap-x-6',
+          'max-sm:grid max-sm:grid-cols-3 max-sm:gap-x-6 max-sm:gap-y-3',
         )}
       >
         <button


### PR DESCRIPTION
## Summary
- Long-form translations (e.g. German "Gruppieren", "Löschen", "Abbrechen") pushed the 6-button select-mode action bar past the right edge on typical phones, because the existing grid fallback only kicked in below 350px width.
- Switch to a 3×2 grid below the `sm:` breakpoint (<640px) so all phones and small tablets get the wrapped layout.
- Clamp the bar to `max-w-[calc(100vw-1rem)]` so it can never extend past the viewport, and normalize `space-x-6` → `gap-x-6` so the same gap utility applies to both flex and grid modes.

## Test plan
- [x] Library → enter select-mode on a small viewport (<640px) and confirm all 6 actions (Open / Group / Status / Details / Delete / Cancel) are visible in a 3×2 grid.
- [x] Verify in a long-translation locale (e.g. German) on a ~390px phone width that nothing overflows.
- [x] Verify on ≥640px viewports the single-row flex layout still renders correctly.
- [x] Verify in E-ink mode the bordered/no-shadow style still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)