### PR TITLE
fix(tauri): skip runtime-config.js injection in static export

### DIFF
--- a/apps/readest-app/src/app/layout.tsx
+++ b/apps/readest-app/src/app/layout.tsx
@@ -123,6 +123,13 @@ const devHmrPatchScript = `(${patchTauriHmrWebSocket.toString()})(${JSON.stringi
   process.env['TAURI_DEV_HOST'],
 )});`;
 
+// `/runtime-config.js` is a dynamic route handler that only exists in the
+// web/Docker build. The Tauri build is statically exported (`output:
+// 'export'`), so the file isn't emitted — the request would return the SPA
+// fallback HTML and crash with `Unexpected token '<'`. All runtime-config
+// consumers fall back to `NEXT_PUBLIC_*` envs baked at build time on Tauri.
+const shouldInjectRuntimeConfig = process.env['NEXT_PUBLIC_APP_PLATFORM'] === 'web';
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html
@@ -130,7 +137,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       className={process.env['NEXT_PUBLIC_APP_PLATFORM'] === 'tauri' ? 'edge-to-edge' : ''}
     >
       <head>
-        <Script src='/runtime-config.js' strategy='beforeInteractive' />
+        {shouldInjectRuntimeConfig ? (
+          <Script src='/runtime-config.js' strategy='beforeInteractive' />
+        ) : null}
         {shouldInjectDevHmrPatch ? (
           <script dangerouslySetInnerHTML={{ __html: devHmrPatchScript }} />
         ) : null}

--- a/apps/readest-app/src/pages/_document.tsx
+++ b/apps/readest-app/src/pages/_document.tsx
@@ -1,6 +1,9 @@
 import { Html, Head, Main, NextScript } from 'next/document';
 import Script from 'next/script';
 
+// Only the web/Docker build serves `/runtime-config.js`. See app/layout.tsx.
+const shouldInjectRuntimeConfig = process.env['NEXT_PUBLIC_APP_PLATFORM'] === 'web';
+
 export default function Document() {
   return (
     <Html lang='en'>
@@ -8,7 +11,9 @@ export default function Document() {
       <body>
         {/* beforeInteractive must live in _document (not _app) to guarantee the
             script runs before any client-side module evaluation. */}
-        <Script src='/runtime-config.js' strategy='beforeInteractive' />
+        {shouldInjectRuntimeConfig ? (
+          <Script src='/runtime-config.js' strategy='beforeInteractive' />
+        ) : null}
         <Main />
         <NextScript />
       </body>


### PR DESCRIPTION
## Summary

- The Tauri build uses `output: 'export'`, so the `/runtime-config.js` dynamic route handler is never emitted. Requesting it returns the SPA fallback HTML and crashes with `Unexpected token '<'`.
- Gate the `<Script src="/runtime-config.js" />` injection (in both `app/layout.tsx` and `pages/_document.tsx`) on `NEXT_PUBLIC_APP_PLATFORM === 'web'`.
- Tauri consumers already fall back to the `NEXT_PUBLIC_*` envs baked in at build time, so no runtime-config is needed there.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] Launch Tauri dev/build and confirm no `Unexpected token '<'` error on startup
- [x] Launch web build and confirm `/runtime-config.js` still loads and overrides env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)