### PR TITLE
feat(reader): add disableSwipe option to disable swipe-to-paginate

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -1737,8 +1737,6 @@
   "Sync failed.": "فشلت المزامنة.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "لم يعد ملف الكتاب موجودًا. أكّد الحذف لإزالته من المكتبة.",
   "Read books in place": "قراءة الكتب في مكانها",
-  "This folder is registered as an external library — books here are always read in place.": "هذا المجلد مسجَّل كمكتبة خارجية — تُقرأ الكتب هنا في مكانها دائمًا.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "أبقِ الكتب في مكانها. لا تنسخ أي كتاب إلى المكتبة لتوفير المساحة. تتم مزامنة ملفات الكتب مع السحابة إذا كان الرفع التلقائي مفعَّلًا. مفيد للمكتبات التي يديرها تطبيق آخر (Duokan، Calibre، Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "لا يسمح iOS باستيراد جذر \"على iPhone الخاص بي\". افتحه واختر مجلدًا فرعيًا محددًا (مثل Readest، Downloads)، ثم حاول مرة أخرى.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "تعذّر قراءة هذا المجلد. لا يمكن فحص بعض مواقع iOS (مثل جذر \"على iPhone الخاص بي\" أو المستوى الأعلى لـ iCloud Drive) — يرجى اختيار مجلد فرعي محدد والمحاولة مرة أخرى.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "تعذّر قراءة هذا المجلد. يرجى اختيار المجلد مرة أخرى، أو اختيار موقع مختلف.",
@@ -1770,5 +1768,8 @@
   "{{count}} dictionary is unsupported and disabled_few": "{{count}} قواميس غير مدعومة ومعطلة",
   "{{count}} dictionary is unsupported and disabled_many": "{{count}} قاموساً غير مدعوماً ومعطلاً",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} قاموس غير مدعوم ومعطل",
-  "No new dictionaries were imported": "لم يتم استيراد أي قواميس جديدة"
+  "No new dictionaries were imported": "لم يتم استيراد أي قواميس جديدة",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "اقرأ الكتب من مجلداتها الأصلية بدلاً من نسخها إلى المكتبة. يوفر مساحة على القرص؛ ولا يزال الرفع التلقائي إلى السحابة يعمل إذا كان مفعلاً.",
+  "This folder is an external library. Books here are always read in place.": "هذا المجلد هو مكتبة خارجية. تُقرأ الكتب هنا دائمًا من مكانها.",
+  "Swipe to Paginate": "اسحب لتصفح الصفحات"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1617,8 +1617,6 @@
   "Sync failed.": "সিঙ্ক ব্যর্থ।",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "বইয়ের ফাইলটি আর নেই। লাইব্রেরি থেকে এটি সরাতে মুছে ফেলার বিষয়টি নিশ্চিত করুন।",
   "Read books in place": "বই যেখানে আছে সেখানেই পড়ুন",
-  "This folder is registered as an external library — books here are always read in place.": "এই ফোল্ডারটি একটি বাহ্যিক লাইব্রেরি হিসাবে নিবন্ধিত — এখানকার বইগুলি সবসময় যেখানে আছে সেখানেই পড়া হয়।",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "বইগুলিকে যেখানে আছে সেখানেই রাখুন। স্থান সাশ্রয়ের জন্য কোনো বই লাইব্রেরিতে কপি করবেন না। স্বয়ংক্রিয় আপলোড সক্রিয় থাকলে বইয়ের ফাইলগুলি ক্লাউডে সিঙ্ক হবে। অন্য অ্যাপ (Duokan, Calibre, Moon+ Reader) দ্বারা পরিচালিত লাইব্রেরির জন্য উপকারী।",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS \"On My iPhone\" রুট আমদানি করতে দেয় না। এটি খুলুন এবং একটি নির্দিষ্ট সাবফোল্ডার (যেমন Readest, Downloads) নির্বাচন করুন, তারপর আবার চেষ্টা করুন।",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "এই ফোল্ডারটি পড়া যায়নি। কিছু iOS অবস্থান (যেমন \"On My iPhone\" রুট বা iCloud Drive-এর শীর্ষ স্তর) স্ক্যান করা যায় না — অনুগ্রহ করে একটি নির্দিষ্ট সাবফোল্ডার নির্বাচন করে আবার চেষ্টা করুন।",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "এই ফোল্ডারটি পড়া যায়নি। অনুগ্রহ করে আবার ফোল্ডারটি নির্বাচন করুন, অথবা একটি ভিন্ন অবস্থান নির্বাচন করুন।",
@@ -1646,5 +1644,8 @@
   "Unsupported dictionary: {{reason}}": "অসমর্থিত অভিধান: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_one": "{{count}}টি অভিধান অসমর্থিত এবং নিষ্ক্রিয়",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}}টি অভিধান অসমর্থিত এবং নিষ্ক্রিয়",
-  "No new dictionaries were imported": "কোনো নতুন অভিধান আমদানি করা হয়নি"
+  "No new dictionaries were imported": "কোনো নতুন অভিধান আমদানি করা হয়নি",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "বইগুলিকে লাইব্রেরিতে অনুলিপি করার পরিবর্তে তাদের মূল ফোল্ডার থেকে পড়ুন। ডিস্ক স্পেস সঞ্চয় করে; সক্ষম থাকলে ক্লাউড স্বয়ংক্রিয়-আপলোড এখনও কাজ করে।",
+  "This folder is an external library. Books here are always read in place.": "এই ফোল্ডারটি একটি বহিরাগত লাইব্রেরি। এখানে বইগুলি সর্বদা মূল স্থানে পড়া হয়।",
+  "Swipe to Paginate": "পৃষ্ঠা পরিবর্তনে সোয়াইপ করুন"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1587,8 +1587,6 @@
   "Sync failed.": "མཉམ་སྦྲེལ་མ་ཐུབ།",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "དཔེ་ཆའི་ཡིག་ཆ་མི་འདུག དཔེ་མཛོད་ནས་སུབ་པར་ངེས་པར་གཏན་འཁེལ་གནང་རོགས།",
   "Read books in place": "དཔེ་ཆ་ས་གནས་སུ་ཀློག",
-  "This folder is registered as an external library — books here are always read in place.": "ཡིག་སྣོད་འདི་ཕྱི་རོལ་གྱི་དཔེ་མཛོད་དུ་ཐོ་འགོད་བྱས་ཡོད — འདི་རུ་ཡོད་པའི་དཔེ་ཆ་རྣམས་རྟག་ཏུ་ས་གནས་སུ་ཀློག་གི་ཡོད།",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "དཔེ་ཆ་རྣམས་ས་གནས་སུ་བཞག དགོས་ངེས་མེད་པ་གོ་ས་ཉར་ཚགས་ཀྱི་ཆེད་དུ་དཔེ་མཛོད་དུ་ཕབ་ལེན་མི་བྱེད། རང་འགུལ་འཇུག་ཐུབ་ན་དཔེ་ཆའི་ཡིག་ཆ་སྤྲིན་ལ་མཐུན་སྦྱོར་བྱེད་ངེས། སྔོན་ཆད་མཉེན་ཆས་གཞན་གྱིས་སྐྱོང་བའི་དཔེ་མཛོད་ལ་ཕན་ཐོགས་ཆེ (Duokan, Calibre, Moon+ Reader)",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS ཀྱིས་ \"On My iPhone\" རྩ་བ་ནང་འདྲེན་བྱེད་པ་མི་ཆོག ཁ་ཕྱེ་ནས་ནང་ཡིག་སྣོད་གཏན་འཁེལ་ཅན་ཞིག་འདེམས་རོགས (དཔེར་ན Readest, Downloads) དེ་ནས་ཡང་བསྐྱར་ཚོད་ལྟ་གནང་།",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "ཡིག་སྣོད་འདི་ཀློག་མ་ཐུབ། iOS ཀྱི་ས་གནས་ཁག་ཅིག (\"On My iPhone\" རྩ་བའམ་ iCloud Drive གི་མཐོ་རིམ་ལྟ་བུ) ཞིབ་འཇུག་མི་ཐུབ — ནང་ཡིག་སྣོད་གཏན་འཁེལ་ཅན་ཞིག་འདེམས་ནས་ཡང་བསྐྱར་ཚོད་ལྟ་གནང་རོགས།",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "ཡིག་སྣོད་འདི་ཀློག་མ་ཐུབ། ཡང་བསྐྱར་ཡིག་སྣོད་འདེམས་པའམ་ས་གནས་གཞན་ཞིག་འདེམས་རོགས།",
@@ -1615,5 +1613,8 @@
   "App service is not available": "ཉེར་སྤྱོད་ཞབས་ཞུ་ཐོབ་མི་ཐུབ།",
   "Unsupported dictionary: {{reason}}": "རྒྱབ་སྐྱོར་མེད་པའི་ཚིག་མཛོད། {{reason}}",
   "{{count}} dictionary is unsupported and disabled_other": "ཚིག་མཛོད་ {{count}} ལ་རྒྱབ་སྐྱོར་མེད་ཅིང་སྤོ་ཟུར་བྱས་ཡོད།",
-  "No new dictionaries were imported": "ཚིག་མཛོད་གསར་པ་ནང་འདྲེན་མ་བྱུང་།"
+  "No new dictionaries were imported": "ཚིག་མཛོད་གསར་པ་ནང་འདྲེན་མ་བྱུང་།",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "དཔེ་ཆ་དཔེ་མཛོད་དུ་ཕབ་ལེན་མི་བྱེད་པར་ཁོ་ཚོའི་ཐོག་མའི་ཡིག་སྣོད་ནས་ཀློག་པ། སྒྲིག་ཆས་ས་ཆ་ཉར་ཚགས་བྱེད་པ། སྔོན་ཆད་སྤྲིན་གྱི་རང་འགུལ་སྦྱར་འཇུག་གནས་སྟངས་ཡོད་ན་འདས་ལྡན་པ་ཡིན།",
+  "This folder is an external library. Books here are always read in place.": "ཡིག་སྣོད་འདི་ནི་ཕྱི་ཕྱོགས་ཀྱི་དཔེ་མཛོད་ཡིན། འདིར་ཡོད་པའི་དཔེ་ཆ་རྣམས་རྟག་ཏུ་རང་གི་ས་གནས་སུ་ཀློག་པ་ཡིན།",
+  "Swipe to Paginate": "མཆོངས་གཤིབ་ཀྱིས་ཤོག་ངོས་སྒྱུར་བ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1617,8 +1617,6 @@
   "Sync failed.": "Synchronisierung fehlgeschlagen.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Die Buchdatei existiert nicht mehr. Bestätige das Löschen, um sie aus der Bibliothek zu entfernen.",
   "Read books in place": "Bücher direkt am Speicherort lesen",
-  "This folder is registered as an external library — books here are always read in place.": "Dieser Ordner ist als externe Bibliothek registriert — Bücher hier werden immer direkt am Speicherort gelesen.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Lass die Bücher dort, wo sie sind. Kopiere keine Bücher in die Bibliothek, um Speicherplatz zu sparen. Buchdateien werden weiterhin in die Cloud synchronisiert, wenn Auto-Upload aktiviert ist. Nützlich für Bibliotheken, die von einer anderen App verwaltet werden (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS erlaubt nicht den Import des Stammverzeichnisses „Auf meinem iPhone\". Öffne es und wähle einen bestimmten Unterordner (z. B. Readest, Downloads) und versuche es erneut.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Dieser Ordner konnte nicht gelesen werden. Einige iOS-Speicherorte (wie das Stammverzeichnis „Auf meinem iPhone\" oder die oberste Ebene von iCloud Drive) können nicht durchsucht werden — bitte wähle einen bestimmten Unterordner und versuche es erneut.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Dieser Ordner konnte nicht gelesen werden. Bitte wähle den Ordner erneut oder einen anderen Speicherort.",
@@ -1646,5 +1644,8 @@
   "Unsupported dictionary: {{reason}}": "Nicht unterstütztes Wörterbuch: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} Wörterbuch wird nicht unterstützt und ist deaktiviert",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} Wörterbücher werden nicht unterstützt und sind deaktiviert",
-  "No new dictionaries were imported": "Keine neuen Wörterbücher importiert"
+  "No new dictionaries were imported": "Keine neuen Wörterbücher importiert",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Liest Bücher aus ihren ursprünglichen Ordnern, anstatt sie in die Bibliothek zu kopieren. Spart Speicherplatz; Cloud-Auto-Upload funktioniert weiterhin, falls aktiviert.",
+  "This folder is an external library. Books here are always read in place.": "Dieser Ordner ist eine externe Bibliothek. Bücher hier werden immer am Originalort gelesen.",
+  "Swipe to Paginate": "Wischen zum Blättern"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1617,8 +1617,6 @@
   "Sync failed.": "Ο συγχρονισμός απέτυχε.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Το αρχείο του βιβλίου δεν υπάρχει πλέον. Επιβεβαιώστε τη διαγραφή για να το αφαιρέσετε από τη βιβλιοθήκη.",
   "Read books in place": "Ανάγνωση βιβλίων στη θέση τους",
-  "This folder is registered as an external library — books here are always read in place.": "Αυτός ο φάκελος είναι καταχωρημένος ως εξωτερική βιβλιοθήκη — τα βιβλία εδώ διαβάζονται πάντα στη θέση τους.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Διατηρήστε τα βιβλία εκεί που βρίσκονται. Μην αντιγράφετε κανένα βιβλίο στη βιβλιοθήκη για εξοικονόμηση χώρου. Τα αρχεία βιβλίων συγχρονίζονται στο cloud αν είναι ενεργοποιημένη η αυτόματη μεταφόρτωση. Χρήσιμο για βιβλιοθήκες που διαχειρίζεται άλλη εφαρμογή (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "Το iOS δεν επιτρέπει την εισαγωγή της ρίζας «Στο iPhone μου». Ανοίξτε την και επιλέξτε έναν συγκεκριμένο υποφάκελο (π.χ. Readest, Downloads), και δοκιμάστε ξανά.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Αδύνατη η ανάγνωση αυτού του φακέλου. Ορισμένες τοποθεσίες iOS (όπως η ρίζα «Στο iPhone μου» ή το ανώτατο επίπεδο του iCloud Drive) δεν μπορούν να σαρωθούν — επιλέξτε έναν συγκεκριμένο υποφάκελο και δοκιμάστε ξανά.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Αδύνατη η ανάγνωση αυτού του φακέλου. Επιλέξτε ξανά τον φάκελο ή διαλέξτε διαφορετική τοποθεσία.",
@@ -1646,5 +1644,8 @@
   "Unsupported dictionary: {{reason}}": "Μη υποστηριζόμενο λεξικό: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} λεξικό δεν υποστηρίζεται και είναι απενεργοποιημένο",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} λεξικά δεν υποστηρίζονται και είναι απενεργοποιημένα",
-  "No new dictionaries were imported": "Δεν εισήχθησαν νέα λεξικά"
+  "No new dictionaries were imported": "Δεν εισήχθησαν νέα λεξικά",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Διαβάστε βιβλία από τους αρχικούς τους φακέλους αντί να τα αντιγράφετε στη βιβλιοθήκη. Εξοικονομεί χώρο στο δίσκο· η αυτόματη μεταφόρτωση στο cloud εξακολουθεί να λειτουργεί εάν είναι ενεργοποιημένη.",
+  "This folder is an external library. Books here are always read in place.": "Αυτός ο φάκελος είναι εξωτερική βιβλιοθήκη. Τα βιβλία εδώ διαβάζονται πάντα στη θέση τους.",
+  "Swipe to Paginate": "Σύρετε για Σελιδοποίηση"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1647,8 +1647,6 @@
   "Sync failed.": "Sincronización fallida.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "El archivo del libro ya no existe. Confirma la eliminación para quitarlo de la biblioteca.",
   "Read books in place": "Leer libros en su ubicación",
-  "This folder is registered as an external library — books here are always read in place.": "Esta carpeta está registrada como biblioteca externa — los libros aquí siempre se leen en su ubicación.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Mantén los libros donde están. No copies ningún libro en la biblioteca para ahorrar espacio. Los archivos siguen sincronizándose con la nube si la subida automática está activada. Útil para bibliotecas gestionadas por otra aplicación (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS no permite importar la raíz «En mi iPhone». Ábrela y elige una subcarpeta específica (p. ej. Readest, Downloads), e inténtalo de nuevo.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "No se pudo leer esta carpeta. Algunas ubicaciones de iOS (como la raíz «En mi iPhone» o el nivel superior de iCloud Drive) no se pueden escanear — elige una subcarpeta específica e inténtalo de nuevo.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "No se pudo leer esta carpeta. Vuelve a seleccionar la carpeta o elige una ubicación diferente.",
@@ -1677,5 +1675,8 @@
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} diccionario no es compatible y está deshabilitado",
   "{{count}} dictionary is unsupported and disabled_many": "{{count}} diccionarios no son compatibles y están deshabilitados",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} diccionarios no son compatibles y están deshabilitados",
-  "No new dictionaries were imported": "No se importaron diccionarios nuevos"
+  "No new dictionaries were imported": "No se importaron diccionarios nuevos",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Lee los libros desde sus carpetas originales en lugar de copiarlos a la biblioteca. Ahorra espacio en disco; la carga automática en la nube sigue funcionando si está habilitada.",
+  "This folder is an external library. Books here are always read in place.": "Esta carpeta es una biblioteca externa. Los libros aquí siempre se leen desde su ubicación original.",
+  "Swipe to Paginate": "Deslizar para Pasar Página"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1617,8 +1617,6 @@
   "Sync failed.": "همگام‌سازی ناموفق بود.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "فایل کتاب دیگر وجود ندارد. حذف را تأیید کنید تا از کتابخانه حذف شود.",
   "Read books in place": "خواندن کتاب‌ها در محل خود",
-  "This folder is registered as an external library — books here are always read in place.": "این پوشه به‌عنوان کتابخانه خارجی ثبت شده است — کتاب‌های اینجا همیشه در محل خود خوانده می‌شوند.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "کتاب‌ها را در محل خود نگه دارید. برای صرفه‌جویی در فضا، هیچ کتابی را به کتابخانه کپی نکنید. اگر بارگذاری خودکار فعال باشد، فایل‌های کتاب همچنان با ابر همگام‌سازی می‌شوند. مفید برای کتابخانه‌هایی که توسط برنامه دیگری مدیریت می‌شوند (Duokan، Calibre، Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS اجازه واردکردن ریشه «روی iPhone من» را نمی‌دهد. آن را باز کنید و یک زیرپوشه مشخص (مثلاً Readest، Downloads) انتخاب کنید و دوباره امتحان کنید.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "خواندن این پوشه ممکن نشد. برخی مکان‌های iOS (مانند ریشه «روی iPhone من» یا سطح بالای iCloud Drive) قابل پویش نیستند — لطفاً یک زیرپوشه مشخص انتخاب کنید و دوباره امتحان کنید.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "خواندن این پوشه ممکن نشد. لطفاً پوشه را دوباره انتخاب کنید یا مکان متفاوتی برگزینید.",
@@ -1646,5 +1644,8 @@
   "Unsupported dictionary: {{reason}}": "فرهنگ لغت پشتیبانی‌نشده: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} فرهنگ لغت پشتیبانی نمی‌شود و غیرفعال است",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} فرهنگ لغت پشتیبانی نمی‌شوند و غیرفعال‌اند",
-  "No new dictionaries were imported": "هیچ فرهنگ لغت جدیدی وارد نشد"
+  "No new dictionaries were imported": "هیچ فرهنگ لغت جدیدی وارد نشد",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "کتاب‌ها را به جای کپی‌کردن در کتابخانه، از پوشه‌های اصلی‌شان بخوانید. در فضای دیسک صرفه‌جویی می‌کند؛ بارگذاری خودکار ابری در صورت فعال بودن همچنان کار می‌کند.",
+  "This folder is an external library. Books here are always read in place.": "این پوشه یک کتابخانه‌ی بیرونی است. کتاب‌های این پوشه همیشه از همان مکان خوانده می‌شوند.",
+  "Swipe to Paginate": "کشیدن برای ورق زدن"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1647,8 +1647,6 @@
   "Sync failed.": "Échec de la synchronisation.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Le fichier du livre n'existe plus. Confirmez la suppression pour le retirer de la bibliothèque.",
   "Read books in place": "Lire les livres à leur emplacement",
-  "This folder is registered as an external library — books here are always read in place.": "Ce dossier est enregistré comme bibliothèque externe — les livres ici sont toujours lus à leur emplacement.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Conservez les livres à leur emplacement. Ne copiez aucun livre dans la bibliothèque pour économiser de l'espace. Les fichiers de livres se synchronisent toujours dans le cloud si l'envoi automatique est activé. Utile pour les bibliothèques gérées par une autre application (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS n'autorise pas l'importation de la racine « Sur mon iPhone ». Ouvrez-la et choisissez un sous-dossier spécifique (par exemple Readest, Downloads), puis réessayez.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Impossible de lire ce dossier. Certains emplacements iOS (comme la racine « Sur mon iPhone » ou le niveau supérieur d'iCloud Drive) ne peuvent pas être analysés — choisissez un sous-dossier spécifique et réessayez.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Impossible de lire ce dossier. Sélectionnez à nouveau le dossier ou choisissez un autre emplacement.",
@@ -1677,5 +1675,8 @@
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} dictionnaire n’est pas pris en charge et est désactivé",
   "{{count}} dictionary is unsupported and disabled_many": "{{count}} dictionnaires ne sont pas pris en charge et sont désactivés",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} dictionnaires ne sont pas pris en charge et sont désactivés",
-  "No new dictionaries were imported": "Aucun nouveau dictionnaire n’a été importé"
+  "No new dictionaries were imported": "Aucun nouveau dictionnaire n’a été importé",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Lit les livres depuis leur dossier d’origine au lieu de les copier dans la bibliothèque. Économise de l’espace disque ; l’envoi automatique vers le cloud continue de fonctionner s’il est activé.",
+  "This folder is an external library. Books here are always read in place.": "Ce dossier est une bibliothèque externe. Les livres y sont toujours lus depuis leur emplacement d’origine.",
+  "Swipe to Paginate": "Glisser pour Tourner la Page"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1647,8 +1647,6 @@
   "Sync failed.": "הסנכרון נכשל.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "קובץ הספר אינו קיים יותר. אשר את המחיקה כדי להסיר אותו מהספרייה.",
   "Read books in place": "קרא ספרים במקומם",
-  "This folder is registered as an external library — books here are always read in place.": "תיקייה זו רשומה כספרייה חיצונית — ספרים כאן נקראים תמיד במקומם.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "שמור את הספרים במקומם. אל תעתיק שום ספר לספרייה כדי לחסוך מקום. קבצי ספרים עדיין יסונכרנו לענן אם ההעלאה האוטומטית מופעלת. שימושי לספריות המנוהלות על ידי אפליקציה אחרת (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS אינו מאפשר ייבוא של שורש \"ב-iPhone שלי\". פתח אותו ובחר תת-תיקייה ספציפית (לדוגמה Readest, Downloads), ונסה שוב.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "לא ניתן לקרוא תיקייה זו. מיקומים מסוימים ב-iOS (כמו שורש \"ב-iPhone שלי\" או הרמה העליונה של iCloud Drive) אינם ניתנים לסריקה — אנא בחר תת-תיקייה ספציפית ונסה שוב.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "לא ניתן לקרוא תיקייה זו. אנא בחר את התיקייה שוב, או בחר מיקום אחר.",
@@ -1677,5 +1675,8 @@
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} מילון אינו נתמך ומושבת",
   "{{count}} dictionary is unsupported and disabled_two": "{{count}} מילונים אינם נתמכים ומושבתים",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} מילונים אינם נתמכים ומושבתים",
-  "No new dictionaries were imported": "לא יובאו מילונים חדשים"
+  "No new dictionaries were imported": "לא יובאו מילונים חדשים",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "קריאת ספרים מתיקיותיהם המקוריות במקום העתקתם לספרייה. חוסך מקום בדיסק; העלאה אוטומטית לענן עדיין פועלת אם היא מופעלת.",
+  "This folder is an external library. Books here are always read in place.": "תיקייה זו היא ספרייה חיצונית. הספרים בה נקראים תמיד ממיקומם המקורי.",
+  "Swipe to Paginate": "החלקה להחלפת עמוד"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1617,8 +1617,6 @@
   "Sync failed.": "सिंक विफल हुआ।",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "पुस्तक फ़ाइल अब मौजूद नहीं है। लाइब्रेरी से हटाने के लिए हटाने की पुष्टि करें।",
   "Read books in place": "पुस्तकें वहीं पढ़ें जहाँ हैं",
-  "This folder is registered as an external library — books here are always read in place.": "यह फ़ोल्डर बाहरी लाइब्रेरी के रूप में पंजीकृत है — यहाँ की पुस्तकें हमेशा वहीं पढ़ी जाती हैं।",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "पुस्तकों को वहीं रखें जहाँ वे हैं। जगह बचाने के लिए कोई भी पुस्तक लाइब्रेरी में कॉपी न करें। यदि स्वतः अपलोड सक्षम है तो पुस्तक फ़ाइलें क्लाउड में सिंक होती रहेंगी। किसी अन्य ऐप (Duokan, Calibre, Moon+ Reader) द्वारा प्रबंधित लाइब्रेरी के लिए उपयोगी।",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS \"On My iPhone\" रूट को आयात करने की अनुमति नहीं देता। इसे खोलें और एक विशिष्ट सब-फ़ोल्डर (जैसे Readest, Downloads) चुनें, फिर पुनः प्रयास करें।",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "इस फ़ोल्डर को नहीं पढ़ा जा सका। कुछ iOS स्थान (जैसे \"On My iPhone\" रूट या iCloud Drive का शीर्ष-स्तर) स्कैन नहीं किए जा सकते — कृपया एक विशिष्ट सब-फ़ोल्डर चुनें और पुनः प्रयास करें।",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "इस फ़ोल्डर को नहीं पढ़ा जा सका। कृपया फ़ोल्डर पुनः चुनें या कोई अन्य स्थान चुनें।",
@@ -1646,5 +1644,8 @@
   "Unsupported dictionary: {{reason}}": "असमर्थित शब्दकोश: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} शब्दकोश असमर्थित और अक्षम है",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} शब्दकोश असमर्थित और अक्षम हैं",
-  "No new dictionaries were imported": "कोई नया शब्दकोश आयात नहीं किया गया"
+  "No new dictionaries were imported": "कोई नया शब्दकोश आयात नहीं किया गया",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "पुस्तकों को लाइब्रेरी में कॉपी करने के बजाय उनके मूल फ़ोल्डर से पढ़ें। डिस्क स्थान बचाता है; क्लाउड ऑटो-अपलोड सक्षम होने पर भी काम करता है।",
+  "This folder is an external library. Books here are always read in place.": "यह फ़ोल्डर एक बाहरी लाइब्रेरी है। यहाँ की पुस्तकें हमेशा अपने मूल स्थान पर ही पढ़ी जाती हैं।",
+  "Swipe to Paginate": "पन्ना बदलने के लिए स्वाइप करें"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1617,8 +1617,6 @@
   "Sync failed.": "A szinkronizálás sikertelen.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "A könyvfájl már nem létezik. Erősítsd meg a törlést a könyvtárból való eltávolításhoz.",
   "Read books in place": "Könyvek olvasása a helyükön",
-  "This folder is registered as an external library — books here are always read in place.": "Ez a mappa külső könyvtárként van regisztrálva — az itt lévő könyveket mindig a helyükön olvassuk.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Hagyd a könyveket ott, ahol vannak. Helymegtakarítás érdekében ne másolj egyetlen könyvet sem a könyvtárba. A könyvfájlok továbbra is szinkronizálódnak a felhőbe, ha az automatikus feltöltés be van kapcsolva. Hasznos olyan könyvtárakhoz, amelyeket más alkalmazás kezel (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "Az iOS nem teszi lehetővé az „iPhone-omon\" gyökér importálását. Nyisd meg, és válassz egy konkrét almappát (pl. Readest, Downloads), majd próbáld újra.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Nem sikerült olvasni ezt a mappát. Egyes iOS helyek (mint az „iPhone-omon\" gyökér vagy az iCloud Drive legfelső szintje) nem szkennelhetők — kérlek, válassz egy konkrét almappát, és próbáld újra.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Nem sikerült olvasni ezt a mappát. Kérlek, válaszd ki újra a mappát, vagy válassz másik helyet.",
@@ -1646,5 +1644,8 @@
   "Unsupported dictionary: {{reason}}": "Nem támogatott szótár: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} szótár nem támogatott, és le van tiltva",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} szótár nem támogatott, és le van tiltva",
-  "No new dictionaries were imported": "Nem importáltunk új szótárakat"
+  "No new dictionaries were imported": "Nem importáltunk új szótárakat",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Olvassa a könyveket az eredeti mappáikból, ahelyett, hogy a könyvtárba másolná őket. Lemezterületet takarít meg; a felhő automatikus feltöltése továbbra is működik, ha engedélyezve van.",
+  "This folder is an external library. Books here are always read in place.": "Ez a mappa egy külső könyvtár. Az itt található könyvek mindig a saját helyükön nyílnak meg.",
+  "Swipe to Paginate": "Lapozás húzással"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1587,8 +1587,6 @@
   "Sync failed.": "Sinkronisasi gagal.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Berkas buku sudah tidak ada. Konfirmasi penghapusan untuk menghapusnya dari pustaka.",
   "Read books in place": "Baca buku di tempat",
-  "This folder is registered as an external library — books here are always read in place.": "Folder ini terdaftar sebagai pustaka eksternal — buku di sini selalu dibaca di tempat.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Biarkan buku tetap di tempatnya. Jangan menyalin buku apa pun ke pustaka untuk menghemat ruang. Berkas buku tetap disinkronkan ke cloud jika unggah otomatis diaktifkan. Berguna untuk pustaka yang dikelola oleh aplikasi lain (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS tidak mengizinkan impor root \"Di iPhone Saya\". Buka, lalu pilih subfolder tertentu (mis. Readest, Downloads), dan coba lagi.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Tidak dapat membaca folder ini. Beberapa lokasi iOS (seperti root \"Di iPhone Saya\" atau level teratas iCloud Drive) tidak dapat dipindai — silakan pilih subfolder tertentu lalu coba lagi.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Tidak dapat membaca folder ini. Silakan pilih folder lagi, atau pilih lokasi lain.",
@@ -1615,5 +1613,8 @@
   "App service is not available": "Layanan aplikasi tidak tersedia",
   "Unsupported dictionary: {{reason}}": "Kamus tidak didukung: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} kamus tidak didukung dan dinonaktifkan",
-  "No new dictionaries were imported": "Tidak ada kamus baru yang diimpor"
+  "No new dictionaries were imported": "Tidak ada kamus baru yang diimpor",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Baca buku dari folder aslinya alih-alih menyalinnya ke perpustakaan. Menghemat ruang disk; unggah otomatis ke awan tetap berfungsi jika diaktifkan.",
+  "This folder is an external library. Books here are always read in place.": "Folder ini adalah pustaka eksternal. Buku di sini selalu dibaca di tempat aslinya.",
+  "Swipe to Paginate": "Geser untuk Pindah Halaman"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1647,8 +1647,6 @@
   "Sync failed.": "Sincronizzazione non riuscita.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Il file del libro non esiste più. Conferma l'eliminazione per rimuoverlo dalla libreria.",
   "Read books in place": "Leggi i libri in loco",
-  "This folder is registered as an external library — books here are always read in place.": "Questa cartella è registrata come libreria esterna — i libri qui vengono sempre letti in loco.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Lascia i libri dove sono. Non copiare alcun libro nella libreria per risparmiare spazio. I file dei libri vengono comunque sincronizzati sul cloud se il caricamento automatico è abilitato. Utile per librerie gestite da un'altra app (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS non consente di importare la radice «Sul mio iPhone». Aprila e scegli una sottocartella specifica (es. Readest, Downloads), quindi riprova.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Impossibile leggere questa cartella. Alcune posizioni iOS (come la radice «Sul mio iPhone» o il livello superiore di iCloud Drive) non possono essere scansionate — scegli una sottocartella specifica e riprova.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Impossibile leggere questa cartella. Seleziona di nuovo la cartella o scegli una posizione diversa.",
@@ -1677,5 +1675,8 @@
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} dizionario non è supportato ed è disattivato",
   "{{count}} dictionary is unsupported and disabled_many": "{{count}} dizionari non sono supportati e sono disattivati",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} dizionari non sono supportati e sono disattivati",
-  "No new dictionaries were imported": "Nessun nuovo dizionario importato"
+  "No new dictionaries were imported": "Nessun nuovo dizionario importato",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Legge i libri dalle loro cartelle originali invece di copiarli nella libreria. Risparmia spazio su disco; il caricamento automatico sul cloud continua a funzionare se attivato.",
+  "This folder is an external library. Books here are always read in place.": "Questa cartella è una libreria esterna. I libri vengono sempre letti dalla loro posizione originale.",
+  "Swipe to Paginate": "Scorri per Sfogliare"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1587,8 +1587,6 @@
   "Sync failed.": "同期に失敗しました。",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "書籍ファイルはもう存在しません。ライブラリから削除するには、削除を確定してください。",
   "Read books in place": "書籍をその場所のまま読む",
-  "This folder is registered as an external library — books here are always read in place.": "このフォルダは外部ライブラリとして登録されています — ここの書籍は常に元の場所で読まれます。",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "書籍をそのままの場所に保ちます。容量を節約するためライブラリには書籍をコピーしません。自動アップロードが有効ならクラウドへの同期は引き続き行われます。他のアプリ (Duokan、Calibre、Moon+ Reader) で管理しているライブラリに便利です。",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS では「この iPhone 内」のルートを取り込むことができません。それを開いて特定のサブフォルダ (例: Readest, Downloads) を選び、もう一度お試しください。",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "このフォルダを読み取れませんでした。一部の iOS の場所 (「この iPhone 内」のルートや iCloud Drive の最上位など) はスキャンできません — 特定のサブフォルダを選んでもう一度お試しください。",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "このフォルダを読み取れませんでした。フォルダを選び直すか、別の場所を選択してください。",
@@ -1615,5 +1613,8 @@
   "App service is not available": "アプリサービスは利用できません",
   "Unsupported dictionary: {{reason}}": "非対応の辞書：{{reason}}",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} 件の辞書が非対応のため無効になっています",
-  "No new dictionaries were imported": "新しい辞書は読み込まれませんでした"
+  "No new dictionaries were imported": "新しい辞書は読み込まれませんでした",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "ライブラリにコピーせず、元のフォルダから直接書籍を読み込みます。ディスク容量を節約でき、自動アップロードが有効ならクラウド同期も引き続き機能します。",
+  "This folder is an external library. Books here are always read in place.": "このフォルダは外部ライブラリです。ここの書籍は常に元の場所から読み込まれます。",
+  "Swipe to Paginate": "スワイプでページ送り"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1587,8 +1587,6 @@
   "Sync failed.": "동기화에 실패했습니다.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "도서 파일이 더 이상 존재하지 않습니다. 라이브러리에서 제거하려면 삭제를 확인하세요.",
   "Read books in place": "원래 위치에서 도서 읽기",
-  "This folder is registered as an external library — books here are always read in place.": "이 폴더는 외부 라이브러리로 등록되어 있습니다 — 이곳의 도서는 항상 원래 위치에서 읽힙니다.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "도서를 원래 위치에 그대로 둡니다. 공간 절약을 위해 라이브러리에는 도서를 복사하지 않습니다. 자동 업로드가 활성화되어 있으면 도서 파일은 클라우드와 계속 동기화됩니다. 다른 앱 (Duokan, Calibre, Moon+ Reader) 으로 관리하는 라이브러리에 유용합니다.",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS에서는 \"내 iPhone\" 루트를 가져올 수 없습니다. 해당 항목을 열어 특정 하위 폴더 (예: Readest, Downloads) 를 선택한 후 다시 시도하세요.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "이 폴더를 읽을 수 없습니다. 일부 iOS 위치 (예: \"내 iPhone\" 루트 또는 iCloud Drive 최상위) 는 스캔할 수 없습니다 — 특정 하위 폴더를 선택한 후 다시 시도해 주세요.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "이 폴더를 읽을 수 없습니다. 폴더를 다시 선택하거나 다른 위치를 선택해 주세요.",
@@ -1615,5 +1613,8 @@
   "App service is not available": "앱 서비스를 사용할 수 없습니다",
   "Unsupported dictionary: {{reason}}": "지원되지 않는 사전: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}}개의 사전이 지원되지 않아 비활성화되었습니다",
-  "No new dictionaries were imported": "가져온 새 사전이 없습니다"
+  "No new dictionaries were imported": "가져온 새 사전이 없습니다",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "도서를 라이브러리에 복사하지 않고 원래 폴더에서 직접 읽어옵니다. 디스크 공간을 절약하며, 자동 업로드가 켜져 있으면 클라우드 동기화도 그대로 작동합니다.",
+  "This folder is an external library. Books here are always read in place.": "이 폴더는 외부 라이브러리입니다. 여기 도서는 항상 원래 위치에서 읽힙니다.",
+  "Swipe to Paginate": "스와이프로 페이지 넘기기"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1587,8 +1587,6 @@
   "Sync failed.": "Penyegerakan gagal.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Fail buku sudah tidak wujud. Sahkan pemadaman untuk mengeluarkannya daripada perpustakaan.",
   "Read books in place": "Baca buku di tempatnya",
-  "This folder is registered as an external library — books here are always read in place.": "Folder ini didaftarkan sebagai perpustakaan luaran — buku di sini sentiasa dibaca di tempatnya.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Biarkan buku di tempatnya. Jangan salin sebarang buku ke dalam perpustakaan untuk menjimatkan ruang. Fail buku tetap disegerakkan ke awan jika muat naik automatik diaktifkan. Berguna untuk perpustakaan yang diuruskan oleh aplikasi lain (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS tidak membenarkan import root \"Pada iPhone Saya\". Buka dan pilih subfolder tertentu (cth. Readest, Downloads), kemudian cuba lagi.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Tidak dapat membaca folder ini. Sesetengah lokasi iOS (seperti root \"Pada iPhone Saya\" atau aras tertinggi iCloud Drive) tidak boleh diimbas — sila pilih subfolder tertentu dan cuba lagi.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Tidak dapat membaca folder ini. Sila pilih folder semula, atau pilih lokasi yang berbeza.",
@@ -1615,5 +1613,8 @@
   "App service is not available": "Perkhidmatan aplikasi tidak tersedia",
   "Unsupported dictionary: {{reason}}": "Kamus tidak disokong: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} kamus tidak disokong dan dilumpuhkan",
-  "No new dictionaries were imported": "Tiada kamus baharu diimport"
+  "No new dictionaries were imported": "Tiada kamus baharu diimport",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Baca buku dari folder asalnya tanpa menyalinnya ke perpustakaan. Menjimatkan ruang cakera; muat naik automatik ke awan masih berfungsi jika diaktifkan.",
+  "This folder is an external library. Books here are always read in place.": "Folder ini ialah perpustakaan luaran. Buku di sini sentiasa dibaca di lokasi asalnya.",
+  "Swipe to Paginate": "Leret untuk Tukar Halaman"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1617,8 +1617,6 @@
   "Sync failed.": "Synchronisatie mislukt.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Het boekbestand bestaat niet meer. Bevestig verwijdering om het uit de bibliotheek te halen.",
   "Read books in place": "Boeken op hun plek lezen",
-  "This folder is registered as an external library — books here are always read in place.": "Deze map is geregistreerd als externe bibliotheek — boeken hier worden altijd op hun plek gelezen.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Laat de boeken staan waar ze zijn. Kopieer geen boeken naar de bibliotheek om ruimte te besparen. Boekbestanden synchroniseren nog steeds naar de cloud als automatisch uploaden is ingeschakeld. Handig voor bibliotheken die door een andere app worden beheerd (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS staat het importeren van de root „Op mijn iPhone\" niet toe. Open deze en kies een specifieke submap (bijv. Readest, Downloads), en probeer het opnieuw.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Kan deze map niet lezen. Sommige iOS-locaties (zoals de root „Op mijn iPhone\" of het hoogste niveau van iCloud Drive) kunnen niet worden gescand — kies een specifieke submap en probeer het opnieuw.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Kan deze map niet lezen. Kies de map opnieuw of selecteer een andere locatie.",
@@ -1646,5 +1644,8 @@
   "Unsupported dictionary: {{reason}}": "Niet-ondersteund woordenboek: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} woordenboek wordt niet ondersteund en is uitgeschakeld",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} woordenboeken worden niet ondersteund en zijn uitgeschakeld",
-  "No new dictionaries were imported": "Er zijn geen nieuwe woordenboeken geïmporteerd"
+  "No new dictionaries were imported": "Er zijn geen nieuwe woordenboeken geïmporteerd",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Lees boeken vanuit hun oorspronkelijke mappen in plaats van ze naar de bibliotheek te kopiëren. Bespaart schijfruimte; automatische uploads naar de cloud blijven werken als ze ingeschakeld zijn.",
+  "This folder is an external library. Books here are always read in place.": "Deze map is een externe bibliotheek. De boeken hier worden altijd op hun oorspronkelijke locatie gelezen.",
+  "Swipe to Paginate": "Vegen om door te bladeren"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1677,8 +1677,6 @@
   "Sync failed.": "Synchronizacja nieudana.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Plik książki już nie istnieje. Potwierdź usunięcie, aby usunąć ją z biblioteki.",
   "Read books in place": "Czytaj książki w ich lokalizacji",
-  "This folder is registered as an external library — books here are always read in place.": "Ten folder jest zarejestrowany jako biblioteka zewnętrzna — książki tutaj są zawsze czytane w ich lokalizacji.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Zostaw książki tam, gdzie są. Nie kopiuj żadnej książki do biblioteki, aby zaoszczędzić miejsce. Pliki książek nadal synchronizują się z chmurą, jeśli automatyczne przesyłanie jest włączone. Przydatne dla bibliotek zarządzanych przez inną aplikację (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS nie pozwala importować katalogu głównego „Na moim iPhonie\". Otwórz go i wybierz konkretny podfolder (np. Readest, Downloads), a następnie spróbuj ponownie.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Nie udało się odczytać tego folderu. Niektórych lokalizacji iOS (jak katalog główny „Na moim iPhonie\" lub najwyższy poziom iCloud Drive) nie można skanować — wybierz konkretny podfolder i spróbuj ponownie.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Nie udało się odczytać tego folderu. Wybierz folder ponownie lub wybierz inną lokalizację.",
@@ -1708,5 +1706,8 @@
   "{{count}} dictionary is unsupported and disabled_few": "{{count}} słowniki są nieobsługiwane i wyłączone",
   "{{count}} dictionary is unsupported and disabled_many": "{{count}} słowników jest nieobsługiwanych i wyłączonych",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} słowników jest nieobsługiwanych i wyłączonych",
-  "No new dictionaries were imported": "Nie zaimportowano żadnych nowych słowników"
+  "No new dictionaries were imported": "Nie zaimportowano żadnych nowych słowników",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Odczytuj książki z ich pierwotnych folderów zamiast kopiować je do biblioteki. Oszczędza miejsce na dysku; automatyczne przesyłanie do chmury nadal działa, jeśli jest włączone.",
+  "This folder is an external library. Books here are always read in place.": "Ten folder jest zewnętrzną biblioteką. Książki są w nim zawsze otwierane w ich pierwotnej lokalizacji.",
+  "Swipe to Paginate": "Przesuń, aby przewinąć stronę"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1647,8 +1647,6 @@
   "Sync failed.": "Sincronização falhou.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "O arquivo do livro não existe mais. Confirme a exclusão para removê-lo da biblioteca.",
   "Read books in place": "Ler livros no local",
-  "This folder is registered as an external library — books here are always read in place.": "Esta pasta está registrada como biblioteca externa — os livros aqui são sempre lidos no local.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Mantenha os livros onde estão. Não copie nenhum livro para a biblioteca para economizar espaço. Os arquivos continuam sincronizando com a nuvem se o envio automático estiver ativado. Útil para bibliotecas gerenciadas por outro aplicativo (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "O iOS não permite importar a raiz \"No meu iPhone\". Abra-a e escolha uma subpasta específica (por exemplo, Readest, Downloads), e tente novamente.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Não foi possível ler esta pasta. Alguns locais do iOS (como a raiz \"No meu iPhone\" ou o nível superior do iCloud Drive) não podem ser verificados — escolha uma subpasta específica e tente novamente.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Não foi possível ler esta pasta. Selecione novamente a pasta ou escolha um local diferente.",
@@ -1677,5 +1675,8 @@
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} dicionário não é suportado e está desativado",
   "{{count}} dictionary is unsupported and disabled_many": "{{count}} dicionários não são suportados e estão desativados",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} dicionários não são suportados e estão desativados",
-  "No new dictionaries were imported": "Nenhum dicionário novo foi importado"
+  "No new dictionaries were imported": "Nenhum dicionário novo foi importado",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Lê os livros a partir das pastas originais em vez de copiá-los para a biblioteca. Economiza espaço em disco; o envio automático para a nuvem continua funcionando se estiver ativado.",
+  "This folder is an external library. Books here are always read in place.": "Esta pasta é uma biblioteca externa. Os livros aqui são sempre lidos no local original.",
+  "Swipe to Paginate": "Deslizar para Virar Página"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1647,8 +1647,6 @@
   "Sync failed.": "Sincronização falhou.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "O ficheiro do livro já não existe. Confirme a eliminação para removê-lo da biblioteca.",
   "Read books in place": "Ler livros no local",
-  "This folder is registered as an external library — books here are always read in place.": "Esta pasta está registada como biblioteca externa — os livros aqui são sempre lidos no local.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Mantenha os livros onde estão. Não copie nenhum livro para a biblioteca para poupar espaço. Os ficheiros continuam a sincronizar com a nuvem se o envio automático estiver ativado. Útil para bibliotecas geridas por outra aplicação (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "O iOS não permite importar a raiz «No meu iPhone». Abra-a e escolha uma subpasta específica (por exemplo, Readest, Downloads), e tente novamente.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Não foi possível ler esta pasta. Alguns locais do iOS (como a raiz «No meu iPhone» ou o nível superior do iCloud Drive) não podem ser analisados — escolha uma subpasta específica e tente novamente.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Não foi possível ler esta pasta. Selecione novamente a pasta ou escolha um local diferente.",
@@ -1677,5 +1675,8 @@
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} dicionário não é suportado e está desativado",
   "{{count}} dictionary is unsupported and disabled_many": "{{count}} dicionários não são suportados e estão desativados",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} dicionários não são suportados e estão desativados",
-  "No new dictionaries were imported": "Nenhum dicionário novo foi importado"
+  "No new dictionaries were imported": "Nenhum dicionário novo foi importado",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Lê os livros a partir das pastas originais em vez de os copiar para a biblioteca. Poupa espaço em disco; o envio automático para a nuvem continua a funcionar se estiver ativado.",
+  "This folder is an external library. Books here are always read in place.": "Esta pasta é uma biblioteca externa. Os livros aqui são sempre lidos no local original.",
+  "Swipe to Paginate": "Deslizar para Mudar de Página"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1647,8 +1647,6 @@
   "Sync failed.": "Sincronizarea a eșuat.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Fișierul cărții nu mai există. Confirmați ștergerea pentru a-l elimina din bibliotecă.",
   "Read books in place": "Citește cărțile la locul lor",
-  "This folder is registered as an external library — books here are always read in place.": "Acest dosar este înregistrat ca bibliotecă externă — cărțile de aici sunt întotdeauna citite la locul lor.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Lăsați cărțile unde sunt. Nu copiați nicio carte în bibliotecă pentru a economisi spațiu. Fișierele cărților se sincronizează în continuare cu cloud-ul dacă încărcarea automată este activată. Util pentru bibliotecile gestionate de altă aplicație (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS nu permite importul rădăcinii „Pe iPhone-ul meu\". Deschideți-o și alegeți un subdosar specific (de ex. Readest, Downloads), apoi încercați din nou.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Nu s-a putut citi acest dosar. Unele locații iOS (cum ar fi rădăcina „Pe iPhone-ul meu\" sau nivelul superior al iCloud Drive) nu pot fi scanate — alegeți un subdosar specific și încercați din nou.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Nu s-a putut citi acest dosar. Alegeți dosarul din nou sau selectați altă locație.",
@@ -1677,5 +1675,8 @@
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} dicționar nu este acceptat și este dezactivat",
   "{{count}} dictionary is unsupported and disabled_few": "{{count}} dicționare nu sunt acceptate și sunt dezactivate",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} de dicționare nu sunt acceptate și sunt dezactivate",
-  "No new dictionaries were imported": "Nu au fost importate dicționare noi"
+  "No new dictionaries were imported": "Nu au fost importate dicționare noi",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Citește cărțile din folderele lor originale în loc să le copieze în bibliotecă. Economisește spațiu pe disc; încărcarea automată în cloud funcționează în continuare dacă este activată.",
+  "This folder is an external library. Books here are always read in place.": "Acest folder este o bibliotecă externă. Cărțile de aici sunt întotdeauna citite din locația originală.",
+  "Swipe to Paginate": "Glisare pentru a Schimba Pagina"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1677,8 +1677,6 @@
   "Sync failed.": "Синхронизация не удалась.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Файл книги больше не существует. Подтвердите удаление, чтобы убрать её из библиотеки.",
   "Read books in place": "Читать книги по месту",
-  "This folder is registered as an external library — books here are always read in place.": "Эта папка зарегистрирована как внешняя библиотека — книги здесь всегда читаются по месту.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Оставляйте книги там, где они находятся. Не копируйте книги в библиотеку, чтобы экономить место. Файлы книг по-прежнему синхронизируются с облаком, если включена автозагрузка. Полезно для библиотек, которыми управляет другое приложение (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS не позволяет импортировать корень «На моём iPhone». Откройте его и выберите конкретную подпапку (например, Readest, Downloads), затем повторите попытку.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Не удалось прочитать эту папку. Некоторые местоположения iOS (например, корень «На моём iPhone» или верхний уровень iCloud Drive) сканировать нельзя — выберите конкретную подпапку и попробуйте снова.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Не удалось прочитать эту папку. Выберите папку заново или укажите другое местоположение.",
@@ -1708,5 +1706,8 @@
   "{{count}} dictionary is unsupported and disabled_few": "{{count}} словаря не поддерживаются и отключены",
   "{{count}} dictionary is unsupported and disabled_many": "{{count}} словарей не поддерживаются и отключены",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} словарей не поддерживаются и отключены",
-  "No new dictionaries were imported": "Новые словари не были импортированы"
+  "No new dictionaries were imported": "Новые словари не были импортированы",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Читать книги из их исходных папок вместо копирования в библиотеку. Экономит место на диске; автозагрузка в облако по-прежнему работает, если включена.",
+  "This folder is an external library. Books here are always read in place.": "Эта папка — внешняя библиотека. Книги в ней всегда открываются по исходному пути.",
+  "Swipe to Paginate": "Смахивание для перелистывания"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1617,8 +1617,6 @@
   "Sync failed.": "සමමුහුර්තකරණය අසාර්ථකයි.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "පොත් ගොනුව තවදුරටත් නොපවතී. පුස්තකාලයෙන් ඉවත් කිරීමට මැකීම තහවුරු කරන්න.",
   "Read books in place": "පොත් එතැනම කියවන්න",
-  "This folder is registered as an external library — books here are always read in place.": "මෙම ෆෝල්ඩරය බාහිර පුස්තකාලයක් ලෙස ලියාපදිංචි කර ඇත — මෙහි ඇති පොත් සෑම විටම එතැනම කියවනු ලැබේ.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "පොත් ඇති තැනම තබන්න. ඉඩ ඉතිරි කිරීමට කිසිදු පොතක් පුස්තකාලයට පිටපත් නොකරන්න. ස්වයංක්‍රීය උඩුගත කිරීම සක්‍රීය නම් පොත් ගොනු තවමත් වලාකුළට සමමුහුර්ත වේ. වෙනත් යෙදුමක් (Duokan, Calibre, Moon+ Reader) මගින් කළමනාකරණය කරන පුස්තකාල සඳහා ප්‍රයෝජනවත්.",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS \"On My iPhone\" මූලය ආයාත කිරීමට ඉඩ නොදේ. එය විවෘත කර නිශ්චිත උප-ෆෝල්ඩරයක් (උදා. Readest, Downloads) තෝරාගෙන, නැවත උත්සාහ කරන්න.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "මෙම ෆෝල්ඩරය කියවිය නොහැකි විය. සමහර iOS ස්ථාන (\"On My iPhone\" මූලය හෝ iCloud Drive හි ඉහළම මට්ටම වැනි) පරිලෝකනය කළ නොහැක — කරුණාකර නිශ්චිත උප-ෆෝල්ඩරයක් තෝරා නැවත උත්සාහ කරන්න.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "මෙම ෆෝල්ඩරය කියවිය නොහැකි විය. කරුණාකර ෆෝල්ඩරය නැවත තෝරන්න, හෝ වෙනත් ස්ථානයක් තෝරන්න.",
@@ -1646,5 +1644,8 @@
   "Unsupported dictionary: {{reason}}": "සහාය නොදක්වන ශබ්දකෝෂය: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_one": "ශබ්දකෝෂ {{count}}ක් සහාය නොදක්වන අතර අක්‍රිය කර ඇත",
   "{{count}} dictionary is unsupported and disabled_other": "ශබ්දකෝෂ {{count}}ක් සහාය නොදක්වන අතර අක්‍රිය කර ඇත",
-  "No new dictionaries were imported": "නව ශබ්දකෝෂ ආයාත කර නැත"
+  "No new dictionaries were imported": "නව ශබ්දකෝෂ ආයාත කර නැත",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "පොත් පුස්තකාලයට පිටපත් කරනවාට වඩා ඒවායේ මුල් ෆෝල්ඩරවලින් කියවන්න. තැටි ඉඩ ඉතිරි කරයි; සක්‍රිය නම් වලාකුළු ස්වයංක්‍රීය උඩුගත කිරීම තවමත් ක්‍රියා කරයි.",
+  "This folder is an external library. Books here are always read in place.": "මෙම ෆෝල්ඩරය බාහිර පුස්තකාලයකි. මෙහි ඇති පොත් සැමවිටම ඔවුන්ගේ මුල් ස්ථානයේ සිට කියවනු ලැබේ.",
+  "Swipe to Paginate": "පිටු මාරුවට ස්වයිප් කරන්න"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1677,8 +1677,6 @@
   "Sync failed.": "Sinhronizacija ni uspela.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Datoteka knjige ne obstaja več. Potrdite izbris, da jo odstranite iz knjižnice.",
   "Read books in place": "Beri knjige na mestu",
-  "This folder is registered as an external library — books here are always read in place.": "Ta mapa je registrirana kot zunanja knjižnica — knjige tukaj se vedno berejo na mestu.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Pustite knjige tam, kjer so. Ne kopirajte nobene knjige v knjižnico, da prihranite prostor. Datoteke knjig se še vedno sinhronizirajo v oblak, če je samodejno nalaganje omogočeno. Uporabno za knjižnice, ki jih upravlja druga aplikacija (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS ne dovoljuje uvoza korena »V mojem iPhonu«. Odprite ga in izberite določeno podmapo (npr. Readest, Downloads), nato poskusite znova.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Te mape ni bilo mogoče prebrati. Nekaterih iOS lokacij (kot je koren »V mojem iPhonu« ali najvišja raven iCloud Drive) ni mogoče skenirati — izberite določeno podmapo in poskusite znova.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Te mape ni bilo mogoče prebrati. Izberite mapo znova ali izberite drugo lokacijo.",
@@ -1708,5 +1706,8 @@
   "{{count}} dictionary is unsupported and disabled_two": "{{count}} slovarja nista podprta in sta onemogočena",
   "{{count}} dictionary is unsupported and disabled_few": "{{count}} slovarji niso podprti in so onemogočeni",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} slovarjev ni podprtih in so onemogočeni",
-  "No new dictionaries were imported": "Novi slovarji niso bili uvoženi"
+  "No new dictionaries were imported": "Novi slovarji niso bili uvoženi",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Berite knjige iz njihovih izvirnih map, namesto da bi jih kopirali v knjižnico. Prihrani prostor na disku; samodejno nalaganje v oblak še naprej deluje, če je omogočeno.",
+  "This folder is an external library. Books here are always read in place.": "Ta mapa je zunanja knjižnica. Knjige v njej se vedno berejo na izvirnem mestu.",
+  "Swipe to Paginate": "Drsanje za listanje"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1617,8 +1617,6 @@
   "Sync failed.": "Synkroniseringen misslyckades.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Bokfilen finns inte längre. Bekräfta borttagningen för att ta bort den från biblioteket.",
   "Read books in place": "Läs böcker på plats",
-  "This folder is registered as an external library — books here are always read in place.": "Den här mappen är registrerad som ett externt bibliotek — böckerna här läses alltid på plats.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Behåll böckerna där de är. Kopiera inga böcker till biblioteket för att spara utrymme. Bokfiler synkroniseras fortfarande till molnet om automatisk uppladdning är aktiverad. Användbart för bibliotek som hanteras av en annan app (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS tillåter inte import av roten ”På min iPhone”. Öppna den och välj en specifik undermapp (t.ex. Readest, Downloads), och försök igen.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Det gick inte att läsa den här mappen. Vissa iOS-platser (som roten ”På min iPhone” eller den översta nivån i iCloud Drive) kan inte skannas — välj en specifik undermapp och försök igen.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Det gick inte att läsa den här mappen. Välj mappen igen eller välj en annan plats.",
@@ -1646,5 +1644,8 @@
   "Unsupported dictionary: {{reason}}": "Ordbok stöds inte: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} ordbok stöds inte och är inaktiverad",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} ordböcker stöds inte och är inaktiverade",
-  "No new dictionaries were imported": "Inga nya ordböcker importerades"
+  "No new dictionaries were imported": "Inga nya ordböcker importerades",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Läs böcker direkt från deras ursprungsmappar i stället för att kopiera dem till biblioteket. Sparar diskutrymme; automatisk uppladdning till molnet fungerar fortfarande om den är aktiverad.",
+  "This folder is an external library. Books here are always read in place.": "Den här mappen är ett externt bibliotek. Böckerna här läses alltid från sin ursprungsplats.",
+  "Swipe to Paginate": "Svep för att Bläddra"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1617,8 +1617,6 @@
   "Sync failed.": "ஒத்திசைவு தோல்வி.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "புத்தக கோப்பு இனி இல்லை. நூலகத்திலிருந்து அதை அகற்ற நீக்குதலை உறுதிப்படுத்தவும்.",
   "Read books in place": "புத்தகங்களை அவற்றின் இடத்திலேயே வாசிக்கவும்",
-  "This folder is registered as an external library — books here are always read in place.": "இந்த கோப்புறை வெளி நூலகமாக பதிவு செய்யப்பட்டுள்ளது — இங்குள்ள புத்தகங்கள் எப்போதும் அவற்றின் இடத்திலேயே வாசிக்கப்படும்.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "புத்தகங்களை அவற்றின் இடத்திலேயே வைக்கவும். இடத்தை மிச்சப்படுத்த நூலகத்திற்கு எந்த புத்தகத்தையும் நகலெடுக்க வேண்டாம். தானியக்க பதிவேற்றம் இயக்கப்பட்டிருந்தால் புத்தக கோப்புகள் இன்னும் கிளவுட்டுடன் ஒத்திசைக்கப்படும். வேறு பயன்பாட்டால் (Duokan, Calibre, Moon+ Reader) நிர்வகிக்கப்படும் நூலகங்களுக்கு பயனுள்ளது.",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS \"On My iPhone\" மூலத்தை இறக்குமதி செய்ய அனுமதிக்காது. அதைத் திறந்து குறிப்பிட்ட துணை-கோப்புறையை (எ.கா. Readest, Downloads) தேர்ந்தெடுத்து, மீண்டும் முயற்சிக்கவும்.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "இந்தக் கோப்புறையை வாசிக்க முடியவில்லை. சில iOS இடங்கள் (எ.கா. \"On My iPhone\" மூலம் அல்லது iCloud Drive இன் மிக மேல் நிலை) ஸ்கேன் செய்ய முடியாது — தயவுசெய்து குறிப்பிட்ட துணை-கோப்புறையைத் தேர்ந்தெடுத்து மீண்டும் முயற்சிக்கவும்.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "இந்தக் கோப்புறையை வாசிக்க முடியவில்லை. தயவுசெய்து கோப்புறையை மீண்டும் தேர்ந்தெடுக்கவும் அல்லது வேறு இடத்தைத் தேர்ந்தெடுக்கவும்.",
@@ -1646,5 +1644,8 @@
   "Unsupported dictionary: {{reason}}": "ஆதரிக்கப்படாத அகராதி: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} அகராதி ஆதரிக்கப்படவில்லை மற்றும் முடக்கப்பட்டுள்ளது",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} அகராதிகள் ஆதரிக்கப்படவில்லை மற்றும் முடக்கப்பட்டுள்ளன",
-  "No new dictionaries were imported": "புதிய அகராதிகள் எதுவும் இறக்குமதி செய்யப்படவில்லை"
+  "No new dictionaries were imported": "புதிய அகராதிகள் எதுவும் இறக்குமதி செய்யப்படவில்லை",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "புத்தகங்களை நூலகத்திற்கு நகலெடுக்காமல், அவற்றின் அசல் கோப்புறைகளில் இருந்தே வாசிக்கவும். வட்டக் கொள்ளளவை சேமிக்கும்; இயக்கப்பட்டிருந்தால் கிளவுட் தானியங்கு பதிவேற்றம் இன்னும் வேலை செய்யும்.",
+  "This folder is an external library. Books here are always read in place.": "இந்த கோப்புறை ஒரு வெளிப்புற நூலகம். இங்குள்ள புத்தகங்கள் எப்போதும் அவற்றின் அசல் இடத்திலேயே வாசிக்கப்படும்.",
+  "Swipe to Paginate": "பக்கம் மாற்ற ஸ்வைப் செய்யவும்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1587,8 +1587,6 @@
   "Sync failed.": "ซิงค์ไม่สำเร็จ",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "ไฟล์หนังสือไม่มีอยู่อีกแล้ว ยืนยันการลบเพื่อนำออกจากห้องสมุด",
   "Read books in place": "อ่านหนังสือในที่ที่อยู่",
-  "This folder is registered as an external library — books here are always read in place.": "โฟลเดอร์นี้ลงทะเบียนเป็นห้องสมุดภายนอก — หนังสือที่นี่จะถูกอ่านในที่ที่อยู่เสมอ",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "เก็บหนังสือไว้ที่เดิม ไม่คัดลอกหนังสือใด ๆ ไปยังห้องสมุดเพื่อประหยัดพื้นที่ ไฟล์หนังสือยังคงซิงค์ไปยังคลาวด์หากเปิดอัปโหลดอัตโนมัติไว้ มีประโยชน์สำหรับห้องสมุดที่จัดการโดยแอปอื่น (Duokan, Calibre, Moon+ Reader)",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS ไม่อนุญาตให้นำเข้ารูท \"On My iPhone\" ให้เปิดและเลือกโฟลเดอร์ย่อยที่เฉพาะเจาะจง (เช่น Readest, Downloads) แล้วลองอีกครั้ง",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "อ่านโฟลเดอร์นี้ไม่ได้ บางตำแหน่งของ iOS (เช่นรูท \"On My iPhone\" หรือระดับบนสุดของ iCloud Drive) ไม่สามารถสแกนได้ — โปรดเลือกโฟลเดอร์ย่อยที่เฉพาะเจาะจงแล้วลองอีกครั้ง",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "อ่านโฟลเดอร์นี้ไม่ได้ โปรดเลือกโฟลเดอร์อีกครั้ง หรือเลือกตำแหน่งอื่น",
@@ -1615,5 +1613,8 @@
   "App service is not available": "บริการแอปไม่พร้อมใช้งาน",
   "Unsupported dictionary: {{reason}}": "พจนานุกรมที่ไม่รองรับ: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_other": "พจนานุกรม {{count}} รายการไม่รองรับและถูกปิดใช้งาน",
-  "No new dictionaries were imported": "ไม่มีพจนานุกรมใหม่ถูกนำเข้า"
+  "No new dictionaries were imported": "ไม่มีพจนานุกรมใหม่ถูกนำเข้า",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "อ่านหนังสือจากโฟลเดอร์ต้นฉบับโดยตรงแทนการคัดลอกเข้าคลังหนังสือ ช่วยประหยัดพื้นที่ดิสก์ การอัปโหลดอัตโนมัติไปยังคลาวด์ยังคงทำงานหากเปิดใช้งานอยู่",
+  "This folder is an external library. Books here are always read in place.": "โฟลเดอร์นี้เป็นคลังหนังสือภายนอก หนังสือในนี้จะถูกเปิดอ่านจากตำแหน่งเดิมเสมอ",
+  "Swipe to Paginate": "ปัดเพื่อเปลี่ยนหน้า"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1617,8 +1617,6 @@
   "Sync failed.": "Eşitleme başarısız.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Kitap dosyası artık mevcut değil. Kitaplıktan kaldırmak için silmeyi onaylayın.",
   "Read books in place": "Kitapları yerinde oku",
-  "This folder is registered as an external library — books here are always read in place.": "Bu klasör harici kitaplık olarak kaydedildi — buradaki kitaplar her zaman yerinde okunur.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Kitapları olduğu yerde bırakın. Yer kazanmak için kitaplığa hiçbir kitap kopyalamayın. Otomatik yükleme etkinse kitap dosyaları yine de buluta eşitlenir. Başka bir uygulamayla (Duokan, Calibre, Moon+ Reader) yönetilen kitaplıklar için kullanışlıdır.",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS, \"iPhone'umda\" kökünü içe aktarmaya izin vermez. Onu açıp belirli bir alt klasör (ör. Readest, Downloads) seçtikten sonra tekrar deneyin.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Bu klasör okunamadı. Bazı iOS konumları (\"iPhone'umda\" kökü veya iCloud Drive üst düzeyi gibi) taranamaz — lütfen belirli bir alt klasör seçip tekrar deneyin.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Bu klasör okunamadı. Lütfen klasörü yeniden seçin veya farklı bir konum seçin.",
@@ -1646,5 +1644,8 @@
   "Unsupported dictionary: {{reason}}": "Desteklenmeyen sözlük: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} sözlük desteklenmiyor ve devre dışı bırakıldı",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} sözlük desteklenmiyor ve devre dışı bırakıldı",
-  "No new dictionaries were imported": "Yeni sözlük içe aktarılmadı"
+  "No new dictionaries were imported": "Yeni sözlük içe aktarılmadı",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Kitapları kitaplığa kopyalamak yerine orijinal klasörlerinden okuyun. Disk alanından tasarruf sağlar; etkinleştirilmişse bulut otomatik yüklemesi yine de çalışır.",
+  "This folder is an external library. Books here are always read in place.": "Bu klasör harici bir kitaplıktır. İçindeki kitaplar her zaman bulundukları yerden okunur.",
+  "Swipe to Paginate": "Sayfa Çevirmek için Kaydır"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1677,8 +1677,6 @@
   "Sync failed.": "Синхронізація не вдалася.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Файл книги більше не існує. Підтвердьте видалення, щоб прибрати її з бібліотеки.",
   "Read books in place": "Читати книги на місці",
-  "This folder is registered as an external library — books here are always read in place.": "Цю теку зареєстровано як зовнішню бібліотеку — книги тут завжди читаються на місці.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Залишайте книги там, де вони є. Не копіюйте жодної книги до бібліотеки, щоб заощадити місце. Файли книг продовжують синхронізуватися з хмарою, якщо ввімкнено автозавантаження. Корисно для бібліотек, якими керує інший застосунок (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS не дозволяє імпортувати корінь «На моєму iPhone». Відкрийте її та оберіть конкретну підтеку (наприклад Readest, Downloads), а потім спробуйте ще раз.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Не вдалося прочитати цю теку. Деякі розташування iOS (як-от корінь «На моєму iPhone» або верхній рівень iCloud Drive) не можна сканувати — оберіть конкретну підтеку та спробуйте знову.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Не вдалося прочитати цю теку. Виберіть теку ще раз або оберіть інше розташування.",
@@ -1708,5 +1706,8 @@
   "{{count}} dictionary is unsupported and disabled_few": "{{count}} словники не підтримуються і вимкнено",
   "{{count}} dictionary is unsupported and disabled_many": "{{count}} словників не підтримуються і вимкнено",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} словників не підтримуються і вимкнено",
-  "No new dictionaries were imported": "Нові словники не імпортовано"
+  "No new dictionaries were imported": "Нові словники не імпортовано",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Читайте книги з їхніх початкових тек, замість копіювання до бібліотеки. Заощаджує місце на диску; автозавантаження до хмари продовжує працювати, якщо ввімкнено.",
+  "This folder is an external library. Books here are always read in place.": "Ця тека — зовнішня бібліотека. Книги в ній завжди читаються з початкового розташування.",
+  "Swipe to Paginate": "Гортання для перегортання"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1617,8 +1617,6 @@
   "Sync failed.": "Sinxronlash muvaffaqiyatsiz.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Kitob fayli endi mavjud emas. Kutubxonadan olib tashlash uchun o‘chirishni tasdiqlang.",
   "Read books in place": "Kitoblarni joyida o‘qish",
-  "This folder is registered as an external library — books here are always read in place.": "Bu papka tashqi kutubxona sifatida ro‘yxatdan o‘tkazilgan — bu yerdagi kitoblar har doim joyida o‘qiladi.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Kitoblarni o‘z joyida qoldiring. Joyni tejash uchun hech qaysi kitobni kutubxonaga ko‘chirmaslik. Avto-yuklash yoqilgan bo‘lsa, kitob fayllari hali ham bulutga sinxronlanadi. Boshqa ilova (Duokan, Calibre, Moon+ Reader) tomonidan boshqariladigan kutubxonalar uchun foydali.",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS \"On My iPhone\" ildizini import qilishga ruxsat bermaydi. Uni oching va aniq kichik papkani (masalan, Readest, Downloads) tanlang, so‘ng qayta urinib ko‘ring.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Ushbu papkani o‘qib bo‘lmadi. Ba’zi iOS joylari (\"On My iPhone\" ildizi yoki iCloud Drive yuqori darajasi kabi) skanerlab bo‘lmaydi — iltimos, aniq kichik papkani tanlang va qayta urinib ko‘ring.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Ushbu papkani o‘qib bo‘lmadi. Iltimos, papkani qayta tanlang yoki boshqa joyni tanlang.",
@@ -1646,5 +1644,8 @@
   "Unsupported dictionary: {{reason}}": "Qo‘llab-quvvatlanmaydigan lug‘at: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_one": "{{count}} ta lug‘at qo‘llab-quvvatlanmaydi va o‘chirilgan",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} ta lug‘at qo‘llab-quvvatlanmaydi va o‘chirilgan",
-  "No new dictionaries were imported": "Yangi lug‘atlar import qilinmadi"
+  "No new dictionaries were imported": "Yangi lug‘atlar import qilinmadi",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Kitoblarni kutubxonaga ko‘chirish o‘rniga ularning asl papkalaridan o‘qing. Disk joyini tejaydi; yoqilgan bo‘lsa, bulutga avtomatik yuklash hamon ishlaydi.",
+  "This folder is an external library. Books here are always read in place.": "Bu papka tashqi kutubxonadir. Bu yerdagi kitoblar har doim o‘z joyidan o‘qiladi.",
+  "Swipe to Paginate": "Sahifani aylantirish uchun suring"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1587,8 +1587,6 @@
   "Sync failed.": "Đồng bộ thất bại.",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "Tệp sách không còn tồn tại. Xác nhận xóa để gỡ nó khỏi thư viện.",
   "Read books in place": "Đọc sách tại chỗ",
-  "This folder is registered as an external library — books here are always read in place.": "Thư mục này được đăng ký là thư viện ngoài — sách tại đây luôn được đọc tại chỗ.",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "Giữ sách ở nguyên vị trí. Không sao chép sách nào vào thư viện để tiết kiệm dung lượng. Các tệp sách vẫn được đồng bộ lên đám mây nếu bật tự động tải lên. Hữu ích cho thư viện được quản lý bởi ứng dụng khác (Duokan, Calibre, Moon+ Reader).",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS không cho phép nhập gốc \"Trên iPhone của tôi\". Hãy mở nó và chọn một thư mục con cụ thể (ví dụ Readest, Downloads), rồi thử lại.",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "Không thể đọc thư mục này. Một số vị trí iOS (như gốc \"Trên iPhone của tôi\" hoặc cấp cao nhất của iCloud Drive) không thể quét — vui lòng chọn một thư mục con cụ thể rồi thử lại.",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "Không thể đọc thư mục này. Vui lòng chọn thư mục lại, hoặc chọn vị trí khác.",
@@ -1615,5 +1613,8 @@
   "App service is not available": "Dịch vụ ứng dụng không khả dụng",
   "Unsupported dictionary: {{reason}}": "Từ điển không được hỗ trợ: {{reason}}",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} từ điển không được hỗ trợ và đã bị vô hiệu hóa",
-  "No new dictionaries were imported": "Không có từ điển mới nào được nhập"
+  "No new dictionaries were imported": "Không có từ điển mới nào được nhập",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Đọc sách trực tiếp từ thư mục gốc thay vì sao chép vào thư viện. Tiết kiệm dung lượng đĩa; tự động tải lên đám mây vẫn hoạt động nếu được bật.",
+  "This folder is an external library. Books here are always read in place.": "Thư mục này là thư viện ngoài. Sách trong đây luôn được đọc tại vị trí gốc.",
+  "Swipe to Paginate": "Vuốt để Sang Trang"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1587,8 +1587,6 @@
   "Sync failed.": "同步失败。",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "图书文件已不存在。确认删除以将其从书库中移除。",
   "Read books in place": "原位读取图书",
-  "This folder is registered as an external library — books here are always read in place.": "此文件夹已注册为外部书库 — 这里的图书始终在原位读取。",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "保留图书的原始位置。不复制任何图书到书库以节省空间。如启用自动上传,图书文件仍会同步到云端。适用于由其他应用(Duokan、Calibre、Moon+ Reader)管理的书库。",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS 不允许导入“我的 iPhone”根目录。请打开它并选择具体的子文件夹(如 Readest、Downloads),然后重试。",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "无法读取此文件夹。部分 iOS 位置(如“我的 iPhone”根目录或 iCloud Drive 顶层)无法扫描 — 请选择具体的子文件夹后重试。",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "无法读取此文件夹。请重新选择该文件夹,或选择其他位置。",
@@ -1615,5 +1613,8 @@
   "App service is not available": "应用服务不可用",
   "Unsupported dictionary: {{reason}}": "不支持的词典：{{reason}}",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} 个词典不受支持，已停用",
-  "No new dictionaries were imported": "未导入任何新词典"
+  "No new dictionaries were imported": "未导入任何新词典",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "直接从图书的原始文件夹读取,无需复制到书库。可节省磁盘空间;若启用了自动上传,云端同步仍正常工作。",
+  "This folder is an external library. Books here are always read in place.": "此文件夹是外部书库,其中的图书始终在原位置读取。",
+  "Swipe to Paginate": "滑动翻页"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1587,8 +1587,6 @@
   "Sync failed.": "同步失敗。",
   "Book file no longer exists. Confirm deletion to remove it from the library.": "圖書檔案已不存在。確認刪除以從書庫中移除。",
   "Read books in place": "原位閱讀圖書",
-  "This folder is registered as an external library — books here are always read in place.": "此資料夾已註冊為外部書庫 — 這裡的圖書始終在原位閱讀。",
-  "Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).": "將圖書保留在原處。不複製任何圖書到書庫以節省空間。若已啟用自動上傳,圖書檔案仍會同步到雲端。適用於由其他應用程式(Duokan、Calibre、Moon+ Reader)管理的書庫。",
   "iOS doesn't allow importing the \"On My iPhone\" root. Open it and pick a specific subfolder (e.g. Readest, Downloads), then try again.": "iOS 不允許匯入「我的 iPhone」根目錄。請開啟它並選擇具體的子資料夾(例如 Readest、Downloads),然後再試一次。",
   "Couldn't read this folder. Some iOS locations (like the \"On My iPhone\" root or iCloud Drive top-level) can't be scanned — please pick a specific subfolder and try again.": "無法讀取此資料夾。部分 iOS 位置(例如「我的 iPhone」根目錄或 iCloud Drive 最上層)無法掃描 — 請選擇具體的子資料夾後再試一次。",
   "Couldn't read this folder. Please pick the folder again, or choose a different location.": "無法讀取此資料夾。請重新選擇該資料夾,或選擇其他位置。",
@@ -1615,5 +1613,8 @@
   "App service is not available": "應用程式服務無法使用",
   "Unsupported dictionary: {{reason}}": "不支援的字典：{{reason}}",
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} 個字典不受支援,已停用",
-  "No new dictionaries were imported": "未匯入任何新字典"
+  "No new dictionaries were imported": "未匯入任何新字典",
+  "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "直接從原始資料夾讀取書籍,不複製到書庫。可節省磁碟空間;若已啟用自動上傳,雲端同步仍正常運作。",
+  "This folder is an external library. Books here are always read in place.": "此資料夾是外部書庫,其中的書籍一律從原位置讀取。",
+  "Swipe to Paginate": "滑動翻頁"
 }

--- a/apps/readest-app/src/app/library/components/ImportFromFolderDialog.tsx
+++ b/apps/readest-app/src/app/library/components/ImportFromFolderDialog.tsx
@@ -372,11 +372,9 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
               <span className='block'>{_('Read books in place')}</span>
               <span className='text-base-content/60 block text-xs'>
                 {readInPlaceLocked
-                  ? _(
-                      'This folder is registered as an external library — books here are always read in place.',
-                    )
+                  ? _('This folder is an external library. Books here are always read in place.')
                   : _(
-                      'Keep books where they are. Copy no book into the library to save space. Book files still sync to cloud if auto-upload is enabled. Useful for libraries managed by another app (Duokan, Calibre, Moon+ Reader).',
+                      'Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.',
                     )}
               </span>
             </span>

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -571,6 +571,11 @@ const FoliateViewer: React.FC<{
       } else {
         view.renderer.removeAttribute('animated');
       }
+      if (viewSettings.disableSwipe) {
+        view.renderer.setAttribute('no-swipe', '');
+      } else {
+        view.renderer.removeAttribute('no-swipe');
+      }
       if (appService?.isAndroidApp) {
         if (eink) {
           view.renderer.setAttribute('eink', '');

--- a/apps/readest-app/src/app/reader/hooks/usePagination.ts
+++ b/apps/readest-app/src/app/reader/hooks/usePagination.ts
@@ -394,6 +394,7 @@ export const usePagination = (
       const bookData = getBookData(bookKey);
       const viewSettings = getViewSettings(bookKey);
       if (!bookData?.isFixedLayout || viewSettings?.scrolled) return false;
+      if (viewSettings?.disableSwipe) return false;
       if (isPanningView(viewRef.current, viewSettings)) return false;
 
       const { deltaX, deltaY, deltaT } = detail;

--- a/apps/readest-app/src/components/settings/ControlPanel.tsx
+++ b/apps/readest-app/src/components/settings/ControlPanel.tsx
@@ -33,6 +33,7 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
     viewSettings.showPaginationButtons,
   );
   const [isDisableClick, setIsDisableClick] = useState(viewSettings.disableClick);
+  const [isDisableSwipe, setIsDisableSwipe] = useState(viewSettings.disableSwipe);
   const [fullscreenClickArea, setFullscreenClickArea] = useState(viewSettings.fullscreenClickArea);
   const [swapClickArea, setSwapClickArea] = useState(viewSettings.swapClickArea);
   const [isDisableDoubleClick, setIsDisableDoubleClick] = useState(viewSettings.disableDoubleClick);
@@ -61,6 +62,7 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
       hideScrollbar: setHideScrollbar,
       showPaginationButtons: setShowPaginationButtons,
       disableClick: setIsDisableClick,
+      disableSwipe: setIsDisableSwipe,
       swapClickArea: setSwapClickArea,
       animated: setAnimated,
       isEink: setIsEink,
@@ -128,6 +130,19 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
     saveViewSettings(envConfig, bookKey, 'disableClick', isDisableClick, false, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDisableClick]);
+
+  useEffect(() => {
+    saveViewSettings(envConfig, bookKey, 'disableSwipe', isDisableSwipe, false, false);
+    // The renderer reads `no-swipe` at touchmove/touchend time, so we have to
+    // push the attribute through immediately rather than waiting for the next
+    // recreateViewer pass.
+    if (isDisableSwipe) {
+      getView(bookKey)?.renderer.setAttribute('no-swipe', '');
+    } else {
+      getView(bookKey)?.renderer.removeAttribute('no-swipe');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDisableSwipe]);
 
   useEffect(() => {
     saveViewSettings(envConfig, bookKey, 'disableDoubleClick', isDisableDoubleClick, false, false);
@@ -266,6 +281,12 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
           label={appService?.isMobileApp ? _('Tap to Paginate') : _('Click to Paginate')}
           checked={!isDisableClick}
           onChange={() => setIsDisableClick(!isDisableClick)}
+        />
+        <SettingsSwitchRow
+          label={_('Swipe to Paginate')}
+          checked={!isDisableSwipe}
+          onChange={() => setIsDisableSwipe(!isDisableSwipe)}
+          data-setting-id='settings.control.swipeToPaginate'
         />
         <SettingsSwitchRow
           label={appService?.isMobileApp ? _('Tap Both Sides') : _('Click Both Sides')}

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -235,6 +235,7 @@ export const DEFAULT_BOOK_LAYOUT: BookLayout = {
   scrolled: false,
   noContinuousScroll: false,
   disableClick: false,
+  disableSwipe: false,
   fullscreenClickArea: false,
   swapClickArea: false,
   disableDoubleClick: false,

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -177,6 +177,7 @@ export interface BookLayout {
   scrolled: boolean;
   noContinuousScroll: boolean;
   disableClick: boolean;
+  disableSwipe: boolean;
   fullscreenClickArea: boolean;
   swapClickArea: boolean;
   disableDoubleClick: boolean;


### PR DESCRIPTION
Issue #4288: users with hardware page-turn buttons (e.g. e-ink readers) want to disable swipe-to-paginate so accidental finger drags during highlight selection don't flip the page mid-annotation. The existing "Tap to Paginate" toggle only covers taps; swipe was always on.

- New `disableSwipe: boolean` on `BookLayout` (default `false`, declared right after `disableClick`).
- foliate-js submodule bump: paginator gates `#onTouchMove` and `#onTouchEnd`'s snap-to-page on a new `no-swipe` attribute, so native touch behaviour (text selection) stays intact.
- `FoliateViewer` sets/removes the `no-swipe` attribute alongside `animated`, and the `ControlPanel` toggle pushes the change to the live renderer so it takes effect without a viewer reset.
- The fixed-layout swipe interceptor in `usePagination` also bails when `disableSwipe` is on, covering both reflowable and fixed- layout books.
- New "Swipe to Paginate" UI row directly below "Tap to Paginate"; both can be off simultaneously.
- i18n: 33 locales translated.

Also polish: rephrase the two helper texts under "Read books in place" in `ImportFromFolderDialog`. The previous copy ("Copy no book into the library to save space.") used an awkward double-negative; the new wording is clearer and the locked variant drops "registered as" / em-dash for a plain two-sentence form. i18n updated.

Closes #4288