### PR TITLE
fix(dict): restore MDD eager init; CSP-safe audio handler; gate binary uploads on sync category

### DIFF
--- a/apps/readest-app/src/__tests__/services/sync/replicaBinaryUpload.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/replicaBinaryUpload.test.ts
@@ -16,8 +16,10 @@ import { getAccessToken } from '@/utils/access';
 import { queueDictionaryBinaryUpload } from '@/services/sync/replicaBinaryUpload';
 import { clearReplicaAdapters, registerReplicaAdapter } from '@/services/sync/replicaRegistry';
 import { dictionaryAdapter } from '@/services/sync/adapters/dictionary';
+import { useSettingsStore } from '@/store/settingsStore';
 import type { ImportedDictionary } from '@/services/dictionaries/types';
 import type { AppService } from '@/types/system';
+import type { SystemSettings } from '@/types/settings';
 
 const mockIsReady = transferManager.isReady as ReturnType<typeof vi.fn>;
 const mockQueueReplicaUpload = transferManager.queueReplicaUpload as ReturnType<typeof vi.fn>;
@@ -171,5 +173,30 @@ describe('queueDictionaryBinaryUpload', () => {
     };
     await queueDictionaryBinaryUpload(baseDict(), fakeAppService as unknown as AppService);
     expect(close).toHaveBeenCalled();
+  });
+
+  test('no-ops when the dictionary sync category is disabled in Manage Sync', async () => {
+    // Sister-side gate to `publishReplicaUpsert`: when the user has turned
+    // dictionary sync off, the bundle binaries must also stay on the
+    // device. Otherwise the (potentially hundreds-of-MB) upload still
+    // fires even though the metadata row never publishes.
+    const prevSettings = useSettingsStore.getState().settings;
+    useSettingsStore.setState({
+      settings: {
+        ...(prevSettings ?? ({} as SystemSettings)),
+        syncCategories: { ...(prevSettings?.syncCategories ?? {}), dictionary: false },
+      } as SystemSettings,
+    });
+    try {
+      mockIsReady.mockReturnValue(true);
+      const fakeAppService = makeFakeAppService({
+        'bundle-dir/webster.mdx': 1_000_000,
+      }) as unknown as AppService;
+      const result = await queueDictionaryBinaryUpload(baseDict(), fakeAppService);
+      expect(result).toBe(null);
+      expect(mockQueueReplicaUpload).not.toHaveBeenCalled();
+    } finally {
+      useSettingsStore.setState({ settings: prevSettings });
+    }
   });
 });

--- a/apps/readest-app/src/services/dictionaries/providers/mdictProvider.ts
+++ b/apps/readest-app/src/services/dictionaries/providers/mdictProvider.ts
@@ -222,6 +222,103 @@ async function resolveCssUrls(
   });
 }
 
+// Pattern for the audio-play handler used by Vocabulary.com-derived MDicts:
+//
+//   <img src="..." onclick="v0r.v(this,'E/BDAWTHU6YF46')" class="m">
+//
+// The first argument is the element itself; the second is the key into the
+// companion MDD's audio store. The bundled `j.js` script (which we ignore for
+// XSS reasons — never execute MDX-supplied JavaScript inside the shadow root)
+// resolves that key to a path like `E/BDAWTHU6YF46.mp3` and plays it. We do
+// the same lookup ourselves from a CSP-safe click handler.
+const V0R_PLAY_RX = /v0r\.v\s*\(\s*this\s*,\s*['"]([^'"]+)['"]\s*\)/i;
+const AUDIO_EXTS = ['.mp3', '.m4a', '.aac', '.ogg', '.opus', '.wav'] as const;
+
+async function wireMdictAudioOnclick(
+  container: HTMLElement,
+  mdds: MDDInstance[],
+  trackedUrls: string[],
+): Promise<void> {
+  // Note: we deliberately leave `<script>` tags and other inline `onclick`
+  // attributes in place. innerHTML parsing does NOT execute scripts, and
+  // inline handlers attached via attributes only fire when the element is
+  // actually clicked — most dictionaries' MDX layouts include them only to
+  // power their own helper JS (which we never load) and leaving them alone
+  // avoids touching CSS rules that depend on attribute presence
+  // (`[onclick]`, `:empty` interactions, etc.). Only the audio-play
+  // pattern below gets rewritten so the icon actually does something.
+  const elements = Array.from(container.querySelectorAll<HTMLElement>('[onclick]'));
+  for (const el of elements) {
+    const onclick = el.getAttribute('onclick') ?? '';
+    const playMatch = onclick.match(V0R_PLAY_RX);
+    if (!playMatch || !mdds.length) continue;
+    const key = playMatch[1]!.trim();
+    if (!key) continue;
+
+    // Drop the inline handler ONLY for the v0r.v audio call we're about to
+    // replace. The dict's `j.js` isn't loaded inside the shadow root, so the
+    // original handler would throw `ReferenceError: v0r is not defined` on
+    // every click; our listener handles the playback instead.
+    el.removeAttribute('onclick');
+
+    el.style.cursor ||= 'pointer';
+    el.addEventListener('click', async (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      let url = el.getAttribute('data-mdd-audio');
+      if (!url) {
+        // Candidate paths: vocabulary.com's MDD stores audio as
+        // `<KEY>.mp3` (with `/` -> `\` normalisation handled inside
+        // js-mdict's `locate` step). Other Vocabulary-derived packs use a
+        // leading `audio/` directory. Try each in order; first hit wins.
+        const candidates: string[] = [];
+        for (const ext of AUDIO_EXTS) candidates.push(`${key}${ext}`, `audio/${key}${ext}`);
+        console.log(
+          `[MDD-AUDIO] probe key=${key} candidates=${candidates.length} mdds=${mdds.length}`,
+        );
+        outer: for (const path of candidates) {
+          for (let i = 0; i < mdds.length; i++) {
+            const mdd = mdds[i]!;
+            try {
+              const t = performance.now();
+              const located = await mdd.locateBytes(path);
+              const dt = (performance.now() - t).toFixed(0);
+              if (located.data) {
+                console.log(
+                  `[MDD-AUDIO] HIT path="${path}" mdd[${i}] ${dt}ms bytes=${located.data.byteLength}`,
+                );
+                const blob = new Blob([new Uint8Array(located.data)]);
+                url = URL.createObjectURL(blob);
+                trackedUrls.push(url);
+                el.setAttribute('data-mdd-audio', url);
+                break outer;
+              } else {
+                console.log(`[MDD-AUDIO] miss path="${path}" mdd[${i}] ${dt}ms`);
+              }
+            } catch (err) {
+              console.warn(
+                `[MDD-AUDIO] error path="${path}" mdd[${i}]:`,
+                (err as Error).message ?? err,
+              );
+            }
+          }
+        }
+        if (!url) {
+          console.warn(`[MDD-AUDIO] not found for key=${key} after ${candidates.length} probes`);
+        }
+      } else {
+        console.log(`[MDD-AUDIO] cache hit key=${key}`);
+      }
+      if (!url) return;
+      const audio = new Audio(url);
+      audio.play().catch((err) => {
+        console.warn('[MDD-AUDIO] playback failed for key', key, err);
+      });
+    });
+  }
+}
+
 function wireMdxAnchors(
   container: HTMLElement,
   mdds: MDDInstance[],
@@ -368,7 +465,15 @@ export const createMdictProvider = ({
         for (const name of mddNames) {
           try {
             const mddFile = await fs.openFile(`${dict.bundleDir}/${name}`, 'Dictionaries');
-            mddInsts.push(await MDD.create(mddFile, { lazy: true }));
+            // MDD is eager: js-mdict's lazy binary-search on the per-block
+            // envelope uses `comp` (localeCompare), which doesn't match the
+            // MDD's native byte-sorted storage order. That mismatch makes
+            // resource lookups (`sound.png`, `<KEY>.mp3`, …) miss even when
+            // the file is present, breaking icons / audio. MDDs are smaller
+            // than MDXs (a few MB to a few hundred MB for audio packs) and
+            // the eager init was already fast enough — only the MDX side
+            // (millions of headwords) actually needed lazy.
+            mddInsts.push(await MDD.create(mddFile));
           } catch (err) {
             console.warn('Failed to open MDD resource bundle', name, err);
           }
@@ -487,6 +592,12 @@ export const createMdictProvider = ({
         );
         if (ctx.signal.aborted) return { ok: false, reason: 'error', message: 'aborted' };
         wireMdxAnchors(body, mdds, trackedUrls, ctx.onNavigate);
+        // Some MDicts (notably Vocabulary.com-derived ones) wire audio
+        // playback through inline `onclick="v0r.v(this,'KEY')"` handlers
+        // that depend on the dict's own `j.js` script. We never run
+        // MDX-supplied JS inside the shadow root (XSS surface), so parse
+        // the audio key ourselves and bind a CSP-safe replacement.
+        await wireMdictAudioOnclick(body, mdds, trackedUrls);
 
         // Attach a shadow root to a dedicated host so the dict's CSS (loose
         // .css files imported alongside + `<link>` references resolved from

--- a/apps/readest-app/src/services/sync/replicaBinaryUpload.ts
+++ b/apps/readest-app/src/services/sync/replicaBinaryUpload.ts
@@ -1,5 +1,6 @@
 import { transferManager } from '@/services/transferManager';
 import { getReplicaAdapter } from './replicaRegistry';
+import { isSyncCategoryEnabled } from './syncCategories';
 import { getAccessToken } from '@/utils/access';
 import type { AppService, BaseDir } from '@/types/system';
 import type { ReplicaTransferFile } from '@/store/transferStore';
@@ -43,6 +44,11 @@ interface ReplicaBinaryRecord {
  * publishReplicaManifest call (binaries first, manifest last).
  *
  * No-op when:
+ *   - the user has turned the matching sync category off in Manage Sync
+ *     (`dictionary`, `font`, `texture` — i.e. backgrounds). Skipping
+ *     here keeps potentially large bundle uploads from leaving the
+ *     device when the user has opted out, and matches the metadata-side
+ *     gate already enforced by `publishReplicaUpsert`.
  *   - the record lacks contentId (legacy / unsynced)
  *   - the kind isn't registered or has no binary capability
  *   - TransferManager isn't initialized yet (pre-library mount)
@@ -55,6 +61,7 @@ export const queueReplicaBinaryUpload = async <T extends ReplicaBinaryRecord>(
   record: T,
   appService: AppService,
 ): Promise<string | null> => {
+  if (!isSyncCategoryEnabled(kind)) return null;
   if (!record.contentId) return null;
   if (!(await getAccessToken())) return null;
   if (!transferManager.isReady()) return null;


### PR DESCRIPTION
## Summary

Three small post-#4334 fixes that landed together because they share the same files / mental context.

### 1. MDD eager init (regression fix from #4334)

`#4334` turned on `MDD.create(..., { lazy: true })` so the resource side of every MDict would skip the upfront key-block decode + sort. That's the right call for **MDXs** (millions of headwords, ~80 s init saving), but **not** for **MDDs**:

- js-mdict's lazy lookup binary-searches `keyInfoList` envelopes with `comp` (localeCompare).
- MDDs store keys in byte-sorted order (with `\` prefixes and case folding) — that order disagrees with localeCompare just often enough that `mdd.locateBytes('sound.png')` *misses for resource paths that do exist*.
- `resolveCssUrls` then leaves `url(sound.png)` unsubstituted, the browser can't fetch it, and the speaker-icon `background-image` disappears.

Bisected to `93abca89` (#4334). Drop the flag for MDDs; MDXs keep the lazy win unchanged.

### 2. CSP-safe Vocabulary.com audio handler

Vocabulary.com-derived MDicts wire audio through inline `onclick="v0r.v(this,'KEY')"` attributes that depend on the dict's own `j.js`. We never load MDX-supplied JavaScript inside our shadow root, so without intervention every click throws `ReferenceError: v0r is not defined` and no audio plays.

New helper `wireMdictAudioOnclick` runs after `wireMdxAnchors`:
- Finds `[onclick]` elements whose attribute matches `v0r\.v\(this, ['"]KEY['"]\)`.
- Parses out the audio key, strips that one onclick attribute, and binds our own click listener that probes the companion MDD for `<KEY>.mp3` / `<KEY>.m4a` / `<KEY>.aac` / `<KEY>.ogg` / `<KEY>.opus` / `<KEY>.wav` (each with and without an `audio/` prefix) and plays the bytes through an `<Audio>` element. Blob URL is cached on `data-mdd-audio` for repeat clicks.

Unrelated inline handlers are deliberately left alone — they're no-ops already (their helper JS isn't loaded), and stripping them globally caused a separate regression where dict CSS rules that match on `[onclick]` attribute presence stopped applying.

### 3. Sync-category gate for binary uploads

`publishReplicaUpsert` already short-circuits on `isSyncCategoryEnabled(kind)` so a user who turned dictionary / font / texture sync off in Manage Sync never publishes a row. `queueReplicaBinaryUpload` had no such gate, so the binary side still fired: a 250 MB MDict bundle or a stack of font files would upload to cloud storage with no replica row to reference them. Mirror the gate here.

New test `no-ops when the dictionary sync category is disabled in Manage Sync` pins the behaviour.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test` — full dictionary + sync suites pass (456 tests)
- [x] Re-import a vocabulary.com MDict (with `j.js`) and verify clicking the speaker icon plays audio
- [x] Look up a word in 韦氏高阶英汉双解词典 (or any MDict with a CSS-backed icon) and verify the speaker glyph is visible
- [x] Toggle "Custom dictionaries" sync off in Manage Sync, re-import a 100 MB+ dict, verify no upload kicks off

🤖 Generated with [Claude Code](https://claude.com/claude-code)