### PR TITLE
fix(reader): keep Android paginated text selection from jumping back to first rendered section

### DIFF
--- a/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
@@ -189,8 +189,12 @@ export const useTextSelector = (
 
     const sel = doc.getSelection() as Selection;
     if (isValidSelection(sel)) {
-      if (!selectionPosition.current) {
-        selectionPosition.current = view?.renderer?.start || null;
+      if (selectionPosition.current === null) {
+        // Save the absolute container scroll, not `renderer.start` — the
+        // latter is section-relative, so restoring it as `containerPosition`
+        // snaps multi-section paginated views back to the first rendered
+        // section (#873-related Android regression).
+        selectionPosition.current = view?.renderer?.containerPosition ?? null;
       }
       makeSelection(sel, index, false);
     } else {
@@ -206,8 +210,7 @@ export const useTextSelector = (
     const viewSettings = getViewSettings(bookKey);
     if (viewSettings?.scrolled) return;
 
-    if (isTextSelected.current && view?.renderer?.containerPosition && selectionPosition.current) {
-      console.warn('Keep container position', selectionPosition.current);
+    if (isTextSelected.current && view?.renderer && selectionPosition.current !== null) {
       view.renderer.containerPosition = selectionPosition.current;
     }
   };


### PR DESCRIPTION
## Summary
- Android-only, paginated-mode regression: long-pressing to select text on the last rendered section and dragging the OS selection handle would snap the page back several sections to the first rendered one.
- Root cause is in the workaround for #873 in `useTextSelector.ts`: it saved `view.renderer.start` (section-relative offset) and wrote it back to `view.renderer.containerPosition` (absolute multi-view scroll). On the first rendered section those values coincide; after paginating forward, `start` is small while `containerPosition` is large, so restoring `containerPosition = start` jumps to the beginning of the rendered range.
- Fix: save and restore the same `containerPosition` value. Also tighten guards to `?? null` / `!== null` so a legitimate `0` isn't dropped.

Verified with in-app diagnostic logs on Android (captured `start: 360`, `containerPosition: 15480`; the handler was forcing scroll from ~15000 back to 360 on every drag tick).

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (4896 pass)
- [x] Android: paginate forward several sections, long-press a word on the last rendered section, drag both handles — selection extends in place, no section jump
- [x] Android: long-press on the first rendered section — no regression
- [x] Android scrolled mode — no regression (handler short-circuits as before)
- [x] iOS / Web / macOS — no regression (handler short-circuits as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)