### PR TITLE
test(reader): de-flake scrolled-mode backward-preload precondition (#4112)

### DIFF
--- a/apps/readest-app/src/__tests__/document/paginator-scrolled.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/paginator-scrolled.browser.test.ts
@@ -197,11 +197,17 @@ describe('Paginator scrolled mode (browser)', () => {
       return null;
     };
 
-    // 1) Navigate to M so #display preloads F above it.
+    // 1) Navigate to M so #display preloads F above it. Assert the loaded set
+    //    the instant #display stabilizes: #display only pulls in the immediate
+    //    previous section (F), and the scroll-handler backward buffer stays
+    //    suppressed while #stabilizing. Everything below — up to the goTo(F)
+    //    that is meant to prepend F-1 — runs synchronously, so the eager
+    //    backward buffer can't pull F-1 in early and steal the measurement.
+    //    (Waiting for the fill to settle first is racy: once #stabilizing ends
+    //    the minPages backward buffer may pull F-1 in — readest/readest#4112.)
     const stabilized = waitForStabilized(paginator);
     await paginator.goTo({ index: M, anchor: 0 });
     await stabilized;
-    await waitForFillComplete(paginator);
 
     // F is loaded as the top view; F-1 has not been pulled in yet.
     const loadedIndices = () => paginator.getContents().map((c) => c.index);
@@ -251,12 +257,18 @@ describe('Paginator scrolled mode (browser)', () => {
     expect(F).toBeGreaterThan(0);
     const M = F + 1;
 
-    // Navigate to M (preloads F above it); F-1 is not loaded yet.
+    // Navigate to M (preloads F above it). Assert F-1 is not loaded the instant
+    // #display stabilizes — #display only pulls in the immediate previous
+    // section (F), and the scroll-handler backward buffer is suppressed while
+    // #stabilizing. Asserting after the fill settles is racy: once
+    // stabilization ends the eager minPages backward buffer may pull F-1 in
+    // (readest/readest#4112). It doing so later is fine — that is exactly what
+    // we want once we navigate back, below.
     const stabilized = waitForStabilized(paginator);
     await paginator.goTo({ index: M, anchor: 0 });
     await stabilized;
-    await waitForFillComplete(paginator);
     expect(paginator.getContents().map((c) => c.index)).not.toContain(F - 1);
+    await waitForFillComplete(paginator);
 
     // Navigate one section back to F. The previous section (F-1) must be
     // pre-loaded so the user can immediately scroll up into it.


### PR DESCRIPTION
## Problem

`paginator-scrolled.browser.test.ts` was failing intermittently on CI
(`AssertionError: expected [ 1, 2, 3, 4, 5 ] to not include 2`) while passing
locally — a flaky test, not a behaviour regression.

## Root cause

Both #4112 scrolled-mode preload tests assert that `F-1` is **not loaded** after
navigating to section `M`, to prove that navigating *back* to `F` is what
triggers the backward preload. They checked this **after**
`waitForFillComplete()`.

The scrolled-mode preload has an eager backward buffer (`minPages = 5`) that
keeps loading sections behind the viewport on scroll events. It is suppressed
while `#display` is stabilizing, but once the fill settles and stray scroll
events fire it pulls `F-1` (and `F-2`) in. CI's timing hit that window; local
timing usually did not. The buffer is **intended** #4112 behaviour — only the
test's timing assumption was wrong.

## Fix

Move the "F-1 not loaded" assertion to the deterministic instant — right after
`await stabilized`, where `#display` has loaded only the immediate-previous
section and the backward buffer is provably suppressed — instead of after
`waitForFillComplete()`. Applied to both #4112 tests (the failing one and its
sibling, which shared the identical latent flake).

Production paginator code is untouched.

## Testing

- `pnpm test:browser` — 150 passed / 1 skipped (was 1 failed); `paginator-scrolled`
  passed 12/12 consecutive runs.
- A throwaway probe confirmed the mechanism: at `#stabilized` `F-1` is absent;
  forcing post-fill scroll events makes the eager buffer load it.
- `pnpm test` (4927 passed) and `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
