### PR TITLE
test(rsvp): stop RSVPController tests leaking real timers into teardown

### DIFF
--- a/apps/readest-app/src/__tests__/services/rsvp-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/rsvp-controller.test.ts
@@ -48,6 +48,23 @@ function createMockView(primaryIndex: number, docs: Document[]): FoliateView {
 }
 
 describe('RSVPController', () => {
+  // start() schedules a countdown (setInterval) which then schedules the
+  // recurring word-advance (setTimeout). These tests assert synchronously and
+  // never stop the controller, so on the real clock those timers fire ~1.5s
+  // later — after the test file's jsdom env has been torn down — and throw an
+  // unhandled error from emitStateChange's dispatchEvent (a stale-realm
+  // CustomEvent), failing the whole run intermittently on CI. Fake only the
+  // timer functions so they can never fire on the real clock; useRealTimers in
+  // afterEach discards any still-pending fakes. Date/performance stay real, so
+  // the CFI/position assertions are unaffected.
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval'] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   describe('start()', () => {
     test('extracts words from primary spine document only', () => {
       const ch1Doc = makeDoc('Hello world');


### PR DESCRIPTION
## Problem

`test_web_app` failed on `main` with an **unhandled error** — no test assertion
failed (4929 tests passed), but vitest fails the run on the unhandled error:

```
TypeError: Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.
 ❯ RSVPController.emitStateChange  src/services/rsvp/RSVPController.ts:962
 ❯ RSVPController.advanceToNextWord src/services/rsvp/RSVPController.ts:799
 ❯ Timeout._onTimeout              src/services/rsvp/RSVPController.ts:774  →  processTimers
This error originated in "src/__tests__/services/rsvp-controller.test.ts"
```

## Root cause

`rsvp-controller.test.ts` calls `controller.start()` in ~20 tests and never
stops the controller. `start()` schedules a countdown (`setInterval`, 500ms ×3)
that then schedules the recurring word-advance (`setTimeout`). On the **real**
clock those timers fire ~1.5s later — after the test file's jsdom environment is
torn down — so `emitStateChange`'s `dispatchEvent(new CustomEvent(...))` runs
against a stale realm and throws. It's intermittent because it depends on
whether a leaked timer fires before the realm/process is gone.

## Fix

Fake only the timer functions (`setTimeout`/`setInterval` + their clears) for
this suite via `vi.useFakeTimers({ toFake: [...] })` in `beforeEach`, and
`vi.useRealTimers()` in `afterEach` (which discards any still-pending fakes). The
tests assert synchronously and never advance playback, so faking the timers
changes no assertion; `Date`/`performance` stay real so CFI/position checks are
unaffected. Production code is untouched.

## Testing

- `rsvp-controller.test.ts` — 27/27 pass.
- `pnpm test` — 279 files / 4929 passed, **0 errors** (the `Errors: 1 error`
  from the failing run is gone).
- `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
