### PR TITLE
feat(dictionary): import companion MDD files that share the MDX prefix

### DIFF
--- a/apps/readest-app/src/__tests__/services/dictionaries/groupBundlesByStem.test.ts
+++ b/apps/readest-app/src/__tests__/services/dictionaries/groupBundlesByStem.test.ts
@@ -1,0 +1,90 @@
+/**
+ * groupBundlesByStem — MDict companion-MDD attachment.
+ *
+ * A single MDX often ships its resources across several MDD files named with a
+ * shared prefix (`Name.mdd`, `Name-01.mdd`, `Name.1.mdd`, …) — images in one,
+ * scripts in another, audio in a third. The importer must attach every MDD
+ * whose stem starts with the MDX stem (at a separator boundary) to that MDX
+ * bundle; `.css` is pooled by name-independent rule (unchanged).
+ */
+import { describe, it, expect } from 'vitest';
+import { groupBundlesByStem } from '@/services/dictionaries/dictionaryService';
+import type { SelectedFile } from '@/hooks/useFileSelector';
+
+const sf = (name: string): SelectedFile => ({ path: `/books/${name}` });
+
+const mdictBundle = (files: string[]) => {
+  const { bundles, orphans } = groupBundlesByStem(files.map(sf));
+  const mdict = bundles.find((b) => b.kind === 'mdict');
+  return {
+    mdx: mdict && mdict.kind === 'mdict' ? mdict.mdx.name : null,
+    mdds: mdict && mdict.kind === 'mdict' ? mdict.mdd.map((m) => m.name).sort() : [],
+    css: mdict && mdict.kind === 'mdict' ? mdict.css.map((c) => c.name).sort() : [],
+    bundleCount: bundles.filter((b) => b.kind === 'mdict').length,
+    orphans: orphans.map((o) => o.name).sort(),
+  };
+};
+
+describe('groupBundlesByStem — MDict companion MDDs', () => {
+  it('attaches dash-numbered companion MDDs (vocabulary.com layout)', () => {
+    const r = mdictBundle([
+      'Vocabulary.com Dictionary.mdx',
+      'Vocabulary.com Dictionary.mdd',
+      'Vocabulary.com Dictionary-01.mdd',
+      'Vocabulary.com Dictionary-02.mdd',
+      'Vocabulary.com Dictionary-03.mdd',
+    ]);
+    expect(r.mdx).toBe('Vocabulary.com Dictionary.mdx');
+    expect(r.mdds).toEqual([
+      'Vocabulary.com Dictionary-01.mdd',
+      'Vocabulary.com Dictionary-02.mdd',
+      'Vocabulary.com Dictionary-03.mdd',
+      'Vocabulary.com Dictionary.mdd',
+    ]);
+    expect(r.orphans).toEqual([]);
+  });
+
+  it('attaches dot-numbered companion MDDs (.1/.2 convention)', () => {
+    const r = mdictBundle(['Base.mdx', 'Base.mdd', 'Base.1.mdd', 'Base.2.mdd']);
+    expect(r.mdds).toEqual(['Base.1.mdd', 'Base.2.mdd', 'Base.mdd']);
+    expect(r.orphans).toEqual([]);
+  });
+
+  it('still attaches the single exact-stem MDD (existing behavior)', () => {
+    const r = mdictBundle(['Base.mdx', 'Base.mdd']);
+    expect(r.mdds).toEqual(['Base.mdd']);
+    expect(r.orphans).toEqual([]);
+  });
+
+  it('does not merge an unrelated MDD that only shares a word prefix', () => {
+    // `dict` is a prefix of `dictionary-words` as a string, but the next char
+    // ('i') is not a separator, so it must NOT attach.
+    const r = mdictBundle(['dict.mdx', 'dict.mdd', 'dictionary-words.mdd']);
+    expect(r.mdds).toEqual(['dict.mdd']);
+    expect(r.orphans).toEqual(['dictionary-words.mdd']);
+  });
+
+  it('attaches a companion MDD to the longest matching MDX prefix', () => {
+    const { bundles } = groupBundlesByStem(
+      ['dict.mdx', 'dictionary.mdx', 'dictionary-01.mdd'].map(sf),
+    );
+    const dictionary = bundles.find((b) => b.kind === 'mdict' && b.mdx.name === 'dictionary.mdx');
+    const dict = bundles.find((b) => b.kind === 'mdict' && b.mdx.name === 'dict.mdx');
+    expect(
+      dictionary && dictionary.kind === 'mdict' ? dictionary.mdd.map((m) => m.name) : null,
+    ).toEqual(['dictionary-01.mdd']);
+    expect(dict && dict.kind === 'mdict' ? dict.mdd.map((m) => m.name) : null).toEqual([]);
+  });
+
+  it('pools .css of any name onto the MDict bundle (unchanged)', () => {
+    const r = mdictBundle(['Base.mdx', 'Base-01.mdd', 'arbitrary-name.css']);
+    expect(r.mdds).toEqual(['Base-01.mdd']);
+    expect(r.css).toEqual(['arbitrary-name.css']);
+  });
+
+  it('orphans companion MDDs when no MDX is present', () => {
+    const r = mdictBundle(['Base-01.mdd', 'Base-02.mdd']);
+    expect(r.bundleCount).toBe(0);
+    expect(r.orphans).toEqual(['Base-01.mdd', 'Base-02.mdd']);
+  });
+});

--- a/apps/readest-app/src/services/dictionaries/dictionaryService.ts
+++ b/apps/readest-app/src/services/dictionaries/dictionaryService.ts
@@ -114,13 +114,30 @@ function classify(source: SelectedFile): SourceFile {
 }
 
 /**
+ * True when `mddStem` is a numbered companion of the MDict bundle keyed by
+ * `bundleStem` — i.e. `bundleStem` followed by a separator (`Name-01`,
+ * `Name.1`, `Name 2`, …). A non-alphanumeric boundary is required so a
+ * different word can't match (`dict` must not claim `dictionary-words`). The
+ * exact-stem `Name.mdd` is already attached by the stem pass, so an exact
+ * match returns false here.
+ */
+function isCompanionMddStem(bundleStem: string, mddStem: string): boolean {
+  if (mddStem === bundleStem) return false;
+  if (!mddStem.startsWith(bundleStem)) return false;
+  const boundary = mddStem.charAt(bundleStem.length);
+  return boundary !== '' && !/[a-z0-9]/i.test(boundary);
+}
+
+/**
  * Group a flat list of selected files into StarDict and MDict bundles by
  * stem. Files that don't belong to any complete bundle land in `orphans`.
  *
  * Rules:
  *  - StarDict bundle = exactly one `.ifo` + one `.idx` + one `.dict` or
  *    `.dict.dz` (sharing a stem). `.syn` is optional.
- *  - MDict bundle = one `.mdx` + zero or more `.mdd` (sharing a stem).
+ *  - MDict bundle = one `.mdx` + zero or more `.mdd` whose stem starts with the
+ *    `.mdx` stem at a separator boundary (`Name.mdd`, `Name-01.mdd`,
+ *    `Name.1.mdd`); each `.mdd` attaches to the longest matching `.mdx`.
  *  - DICT (dictd) bundle = one `.index` + one `.dict` or `.dict.dz`
  *    (sharing a stem). Note: `.idx` (StarDict) and `.index` (DICT) differ
  *    only by spelling — the StarDict branch wins when both are present.
@@ -164,6 +181,26 @@ export function groupBundlesByStem(files: SelectedFile[]): GroupResult {
     } else {
       orphans.push(...group);
     }
+  }
+
+  // Attach numbered companion MDDs. A single MDX often splits its resources
+  // across several MDD files sharing its filename prefix (e.g. images in one,
+  // scripts in another, audio in a third); the stem pass above only catches the
+  // exact-stem `Name.mdd`. Rescue the rest from `orphans`, attaching each to the
+  // MDict bundle whose stem is the longest matching prefix.
+  const mdictForMdd = bundles
+    .filter((b): b is MDictGroup => b.kind === 'mdict')
+    .sort((a, b) => b.stem.length - a.stem.length);
+  if (mdictForMdd.length > 0) {
+    const stillOrphaned: SourceFile[] = [];
+    for (const f of orphans) {
+      const target =
+        f.ext === 'mdd' ? mdictForMdd.find((b) => isCompanionMddStem(b.stem, f.stem)) : undefined;
+      if (target) target.mdd.push(f);
+      else stillOrphaned.push(f);
+    }
+    orphans.length = 0;
+    orphans.push(...stillOrphaned);
   }
 
   // Distribute all loose `.css` files across the MDict bundles in this


### PR DESCRIPTION
## Summary

Closes #4245.

Lets a single MDict dictionary import its resources when they're split across **multiple companion `.mdd` files** that share the `.mdx` filename prefix — the common packaging for large dictionaries (images in one MDD, scripts in another, audio in a third).

### The problem
The importer's `groupBundlesByStem` only paired an `.mdx` with `.mdd` files of the **exact same stem**, so a layout like:

```
Vocabulary.com Dictionary.mdx
Vocabulary.com Dictionary.mdd       ← images/css (attached)
Vocabulary.com Dictionary-01.mdd    ← images       (dropped as orphan)
Vocabulary.com Dictionary-02.mdd    ← scripts      (dropped as orphan)
Vocabulary.com Dictionary-03.mdd    ← 148k mp3s    (dropped as orphan)
```
attached only the first MDD. The audio MDD was never loaded, so word-audio lookups always missed (`[MDD-AUDIO] … miss … mdds=1`).

### The fix
`groupBundlesByStem` now attaches every `.mdd` whose stem starts with an `.mdx` stem **at a separator boundary** (`Name.mdd`, `Name-01.mdd`, `Name.1.mdd`, …). When prefixes overlap, the **longest** matching `.mdx` wins. The separator-boundary check prevents false merges (e.g. `dict.mdx` must not claim `dictionary-words.mdd`). Implemented as a focused post-pass that rescues orphan MDDs — existing StarDict/DICT/Slob/single-MDD/`.css`-pooling behavior is untouched.

### Why nothing else needed changing
The rest of the pipeline already treats `files.mdd` as a list: the runtime provider opens every MDD and probes each for resources, `contentId` mixes the full sorted filename list, and replica sync enumerates all MDDs for binary upload and reconstructs `files.mdd[]` from the downloaded manifest. So **multi-MDD bundles sync across devices with no further changes.**

### Notes
- **`contentId` is unchanged** (kept as-is by design): it mixes the sorted filename list, so a multi-MDD import gets a stable cross-device id. A consequence is that re-importing an existing single-MDD bundle as a multi-MDD bundle produces a *new* id (dedup matches on `contentId`), so it arrives as a new bundle rather than replacing the old one — delete the stale single-MDD import after re-importing.

## Test plan
- New `groupBundlesByStem.test.ts`: dash-numbered (`-NN`) and dot-numbered (`.N`) companions attach; exact-stem single MDD still attaches; no false merge on shared word prefix; longest-prefix wins; `.css` of any name still pools; companion MDDs orphan when no MDX is present.
- `pnpm test` — full suite green (5008 passed); `pnpm lint` — clean.
