### PR TITLE
fix(reader): show full bookmark ribbon in scrolled mode header

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/components/Ribbon.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/Ribbon.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import Ribbon from '@/app/reader/components/Ribbon';
+
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({ safeAreaInsets: { top: 48, right: 0, bottom: 0, left: 0 } }),
+}));
+
+describe('Ribbon', () => {
+  it('stacks above the scrolled-mode notch mask so the full ribbon stays visible', () => {
+    // In scrolled mode SectionInfo paints a `bg-base-100` `notch-area` mask over the
+    // top safe-area strip at z-10. The ribbon renders earlier in the DOM, so it must
+    // sit on a higher layer than z-10 or its upper (unsafe-area) half gets covered.
+    const { container } = render(<Ribbon width='5%' />);
+    const ribbon = container.querySelector('.ribbon') as HTMLElement;
+
+    expect(ribbon).not.toBeNull();
+    expect(ribbon.classList.contains('z-10')).toBe(false);
+    expect(ribbon.classList.contains('z-20')).toBe(true);
+    // Decorative only: taps must fall through to the notch mask's scroll-to-top.
+    expect(ribbon.classList.contains('pointer-events-none')).toBe(true);
+  });
+
+  it('spans the safe-area inset plus the header bar height', () => {
+    const { container } = render(<Ribbon width='5%' />);
+    const ribbon = container.querySelector('.ribbon') as HTMLElement;
+
+    expect(ribbon.style.height).toBe('92px'); // 48px safe-area top + 44px header bar
+  });
+});

--- a/apps/readest-app/src/app/reader/components/Ribbon.tsx
+++ b/apps/readest-app/src/app/reader/components/Ribbon.tsx
@@ -9,9 +9,13 @@ interface RibbonProps {
 const Ribbon: React.FC<RibbonProps> = ({}) => {
   const { safeAreaInsets } = useThemeStore();
 
+  // z-20 keeps the ribbon above the scrolled-mode `notch-area` mask (z-10 in
+  // SectionInfo) so its upper safe-area half isn't covered.
   return (
     <div
-      className={clsx('ribbon absolute inset-0 z-10 flex w-8 justify-center sm:w-6')}
+      className={clsx(
+        'ribbon pointer-events-none absolute inset-0 z-20 flex w-8 justify-center sm:w-6',
+      )}
       style={{
         height: `${(safeAreaInsets?.top || 0) + 44}px`,
       }}


### PR DESCRIPTION
## Problem

In **scrolled** reading mode, the bookmark ribbon's top half (the safe-area / unsafe-area portion) was hidden — only the lower ~44px showed below the notch. The ribbon should display fully in the header.

## Root cause

`SectionInfo` paints a solid `bg-base-100` **`notch-area`** mask over the top safe-area strip, but only in scrolled mode:

```tsx
// SectionInfo.tsx
<div className={clsx('notch-area absolute left-0 right-0 top-0 z-10',
                     isScrolled && !isVertical && 'bg-base-100')}
     style={{ height: `${topInset}px` }} />
```

The `Ribbon` was also `z-10` but renders **earlier** in the DOM (`BooksGrid` renders the ribbon before `SectionInfo`). With equal `z-index`, the later element wins, so the mask painted over the ribbon's upper half. In paginated mode the mask has no background, so the ribbon showed fully — which is why the bug was scrolled-mode only.

## Fix

- Raise the ribbon to `z-20` so the whole ribbon stays visible above the notch mask.
- Mark it `pointer-events-none` so the now-on-top ribbon doesn't swallow taps in its corner — they still fall through to the notch mask's scroll-to-top handler.

## Testing

- Added `src/__tests__/app/reader/components/Ribbon.test.tsx` (failed before the change, passes now): asserts the ribbon stacks above `z-10`, is `pointer-events-none`, and spans `safe-area-top + 44px`.
- `pnpm test` — full suite green.
- `pnpm lint` — Biome + tsgo clean.

> Note: this is an iOS safe-area-specific visual fix; verified via the root-cause analysis and unit test (web/desktop targets report zero insets so they can't exercise it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)