### PR TITLE
fix(release): don't clobber latest.json with a 404 "Not Found" body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,7 +273,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd apps/readest-app/
-          curl -sL https://github.com/readest/readest/releases/latest/download/latest.json -o latest.json
+          # Use -f so curl fails on HTTP errors instead of writing the 404 body
+          # ("Not Found") into latest.json and clobbering the release asset with
+          # invalid JSON, which then breaks tauri-action's updater merge on every
+          # subsequent build.
+          if ! curl -fsSL https://github.com/readest/readest/releases/latest/download/latest.json -o latest.json; then
+            echo "::error::Failed to download existing latest.json; aborting to avoid clobbering the release asset."
+            exit 1
+          fi
+          if ! jq empty latest.json 2>/dev/null; then
+            echo "::error::Existing latest.json is not valid JSON; aborting."
+            exit 1
+          fi
 
           version=${{ needs.get-release.outputs.release_version }}
           universial_apk_url="https://github.com/readest/readest/releases/download/${{ needs.get-release.outputs.release_tag }}/Readest_${version}_universal.apk"
@@ -379,7 +390,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          curl -sL https://github.com/readest/readest/releases/latest/download/latest.json -o latest.json
+          # Use -f so curl fails on HTTP errors instead of writing the 404 body
+          # ("Not Found") into latest.json and clobbering the release asset with
+          # invalid JSON, which then breaks tauri-action's updater merge on every
+          # subsequent build.
+          if ! curl -fsSL https://github.com/readest/readest/releases/latest/download/latest.json -o latest.json; then
+            echo "::error::Failed to download existing latest.json; aborting to avoid clobbering the release asset."
+            exit 1
+          fi
+          if ! jq empty latest.json 2>/dev/null; then
+            echo "::error::Existing latest.json is not valid JSON; aborting."
+            exit 1
+          fi
 
           version=${{ needs.get-release.outputs.release_version }}
           arch=${{ matrix.config.arch }}


### PR DESCRIPTION
## Problem

The 0.11.2 release run failed on **every** `build-tauri` matrix leg with:

```
Unexpected token 'N', "Not Found" is not valid JSON
```

…right after each leg had already uploaded its bundles. The release ended up with a `latest.json` asset whose entire content was the 9-byte string `Not Found`.

### Root cause

The Android and Windows-portable jobs fetch the existing updater manifest to merge their platform entries in:

```bash
curl -sL https://github.com/readest/readest/releases/latest/download/latest.json -o latest.json
gh release upload <tag> latest.json --clobber
```

`curl -sL` **without `-f`** writes the server's 404 body (`Not Found`) into the file and exits `0`. When the manifest isn't there yet (the Android leg can win the race against the desktop legs that create it), the 404 page gets clobbered onto the release as `latest.json`.

`tauri-action`'s updater step (`src/upload-version-json.ts`) then downloads the existing `latest.json` and runs `JSON.parse(...).platforms` to merge new platforms. `JSON.parse("Not Found")` throws the error above — on every leg, deterministically — which is why a plain retry never recovered. (0.11.1 succeeded only because the desktop legs usually win the race and write valid JSON first.)

## Fix

In both `latest.json` steps:

- Use `curl -fsSL` so an HTTP error **fails the step** instead of writing the error body.
- Validate the download with `jq empty` before merging, so a corrupt/empty manifest can never be `--clobber`'d onto the release.

This turns a silent release-poisoning bug into a loud, self-healing failure.

## Note / possible follow-up

The underlying race (Android/Windows merge steps depend on the desktop `tauri-action` legs having already uploaded `latest.json`) still exists — this PR makes it fail safely rather than corrupt. A more robust follow-up would gate the merge steps after the desktop builds (e.g. a separate job that `needs: build-tauri`) or retry until a valid manifest exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)