### PR TITLE
fix(metainfo): declare desktop and mobile device support

### DIFF
--- a/data/metainfo/appdata.xml
+++ b/data/metainfo/appdata.xml
@@ -59,6 +59,16 @@
 
   <launchable type="desktop-id">com.bilingify.readest.desktop</launchable>
 
+  <requires>
+    <display_length compare="ge">360</display_length>
+  </requires>
+
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <control>touch</control>
+  </supports>
+
   <releases>
     <release version="0.11.2" date="2026-05-31">
       <description>


### PR DESCRIPTION
## What

Declare AppStream device-support relations in `data/metainfo/appdata.xml` so software stores list Readest for both **Desktop** and **Mobile**.

## Why

The metainfo declared no `<requires>`/`<supports>` relations. Stores derive the device badges from these tags, so on Flathub Readest currently shows up as **Desktop only**, while comparable readers such as [KOReader](https://flathub.org/apps/rocks.koreader.KOReader) (which declares them) show both Desktop and Mobile.

Readest is adaptive and genuinely runs on desktop (keyboard/mouse) and on phones/tablets (touch), so advertising both is accurate.

## Change

```xml
<requires>
  <display_length compare="ge">360</display_length>
</requires>

<supports>
  <control>keyboard</control>
  <control>pointing</control>
  <control>touch</control>
</supports>
```

Per the [Flathub MetaInfo guidelines](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines): a `ge 360` `display_length` baseline plus `touch` marks the app mobile-capable, while `keyboard`/`pointing` keep the Desktop badge.

## Verification

- `xmllint --noout` — well-formed.
- Confirmed `npm run update-metadata` (`scripts/sync-release-notes.sh`) preserves these tags on regeneration — they live outside the `<releases>` block that script rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
