### PR TITLE
fix(android): open book directly when launched via 'Open with'

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -159,28 +159,98 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
     }
 
     private fun handleIntent(intent: Intent?) {
-        val uri = intent?.data ?: return
-        Log.e("NativeBridgePlugin", "Received intent: $uri")
-        when {
-          uri.scheme == "readest" && uri.host == "auth-callback" -> {
-              val result = JSObject().apply {
-                  put("redirectUrl", uri.toString())
-              }
-              pendingInvoke?.resolve(result)
-              pendingInvoke = null
-          }
+        if (intent == null) return
+        Log.d("NativeBridgePlugin", "Received intent: action=${intent.action} data=${intent.data}")
 
-          intent.action == Intent.ACTION_VIEW -> {
-              try {
-                activity.contentResolver.takePersistableUriPermission(
-                      uri,
-                      Intent.FLAG_GRANT_READ_URI_PERMISSION
-                  )
-              } catch (e: SecurityException) {
-                Log.e("NativeBridgePlugin", "Failed to take persistable URI permission: ${e.message}")
-              }
-          }
+        // OAuth callback uses a custom scheme on intent.data and is handled
+        // separately from any user-shared content.
+        intent.data?.let { uri ->
+            if (uri.scheme == "readest" && uri.host == "auth-callback") {
+                val result = JSObject().apply {
+                    put("redirectUrl", uri.toString())
+                }
+                pendingInvoke?.resolve(result)
+                pendingInvoke = null
+                return
+            }
         }
+
+        when (intent.action) {
+            Intent.ACTION_VIEW -> {
+                // "Open with Readest": the OS hands us a single content://
+                // (or file://) URI on `intent.data`. Take the persistable
+                // permission so we can read it through any subsequent app
+                // launch, then forward it to the JS side via the existing
+                // shared-intent channel — without this trigger, the URI
+                // silently dies in Kotlin and the user just sees the
+                // library splash with nothing happening.
+                val uri = intent.data ?: return
+                tryTakePersistableReadPermission(uri)
+                emitSharedIntent("VIEW", listOf(uri))
+            }
+
+            Intent.ACTION_SEND -> {
+                // System share-sheet → "Send to Readest" (single file).
+                // The URI lives on EXTRA_STREAM, not on intent.data, which
+                // is why the previous data-only handler never saw share
+                // captures at all.
+                val uri = getExtraStream(intent) ?: return
+                tryTakePersistableReadPermission(uri)
+                emitSharedIntent("SEND", listOf(uri))
+            }
+
+            Intent.ACTION_SEND_MULTIPLE -> {
+                val uris = getExtraStreamList(intent)
+                if (uris.isEmpty()) return
+                uris.forEach { tryTakePersistableReadPermission(it) }
+                emitSharedIntent("SEND", uris)
+            }
+        }
+    }
+
+    private fun tryTakePersistableReadPermission(uri: Uri) {
+        // Only content:// URIs support persistable permissions; file://
+        // URIs are accessible directly and would throw SecurityException
+        // here. Skip the call rather than swallow noisy logs.
+        if (uri.scheme != "content") return
+        try {
+            activity.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
+            )
+        } catch (e: SecurityException) {
+            Log.w("NativeBridgePlugin", "takePersistableUriPermission failed for $uri: ${e.message}")
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun getExtraStream(intent: Intent): Uri? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+        } else {
+            intent.getParcelableExtra(Intent.EXTRA_STREAM) as? Uri
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun getExtraStreamList(intent: Intent): List<Uri> {
+        val list: ArrayList<Uri>? =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM, Uri::class.java)
+            } else {
+                intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM)
+            }
+        return list ?: emptyList()
+    }
+
+    private fun emitSharedIntent(action: String, uris: List<Uri>) {
+        val payload = JSObject().apply {
+            put("action", action)
+            val arr = JSArray()
+            uris.forEach { arr.put(it.toString()) }
+            put("urls", arr)
+        }
+        triggerEvent("shared-intent", payload)
     }
 
     @Command

--- a/apps/readest-app/src/hooks/useAppUrlIngress.ts
+++ b/apps/readest-app/src/hooks/useAppUrlIngress.ts
@@ -17,6 +17,15 @@ interface OpenFilesPayload {
 
 interface SharedIntentPayload {
   urls: string[];
+  /**
+   * Android-only. Distinguishes "Open with Readest" (`VIEW` — the user
+   * tapped a file in their file browser and chose Readest) from "Send to
+   * Readest" (`SEND` / `SEND_MULTIPLE` — share-sheet capture). We forward
+   * it on the `app-incoming-url` event so consumers can pick the right
+   * import strategy: VIEW should open the file directly without writing
+   * it to the library, SEND should ingest it like a sync capture.
+   */
+  action?: 'VIEW' | 'SEND';
 }
 
 /**
@@ -53,10 +62,10 @@ export function useAppUrlIngress() {
     if (listened.current) return;
     listened.current = true;
 
-    const dispatch = (urls: string[]) => {
+    const dispatch = (urls: string[], action?: 'VIEW' | 'SEND') => {
       if (!urls.length) return;
-      console.log('App incoming URL:', urls);
-      eventDispatcher.dispatch('app-incoming-url', { urls });
+      console.log('App incoming URL:', urls, 'action:', action);
+      eventDispatcher.dispatch('app-incoming-url', { urls, action });
     };
 
     const unlistenSingleInstance = getCurrentWindow().listen<SingleInstancePayload>(
@@ -83,7 +92,7 @@ export function useAppUrlIngress() {
         'native-bridge',
         'shared-intent',
         (payload) => {
-          if (payload.urls?.length) dispatch(payload.urls);
+          if (payload.urls?.length) dispatch(payload.urls, payload.action);
         },
       );
     }

--- a/apps/readest-app/src/hooks/useOpenWithBooks.ts
+++ b/apps/readest-app/src/hooks/useOpenWithBooks.ts
@@ -5,8 +5,9 @@ import { useEnv } from '@/context/EnvContext';
 import { useLibraryStore } from '@/store/libraryStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { isTauriAppPlatform } from '@/services/environment';
-import { navigateToLibrary, showLibraryWindow } from '@/utils/nav';
+import { navigateToLibrary, navigateToReader, showLibraryWindow } from '@/utils/nav';
 import { eventDispatcher } from '@/utils/event';
+import { partialMD5 } from '@/utils/md5';
 
 /**
  * Handle "Open with Readest" file imports. Consumes the `app-incoming-url`
@@ -18,6 +19,26 @@ import { eventDispatcher } from '@/utils/event';
  *
  * Mount this hook alongside `useAppUrlIngress` so the ingress dispatcher is
  * actually running when URLs arrive.
+ *
+ * Two routing modes by `action`:
+ *
+ *   `'VIEW'` (Android only — user picked Readest from the system "Open with"
+ *   chooser for an epub/pdf): we MUST NOT silently import the file into the
+ *   library. We first hash the file ourselves and check the in-memory library:
+ *     - if a non-deleted entry with the same hash already exists, jump
+ *       straight into the reader on that entry — no `importBook` call, so the
+ *       managed `Books/<hash>/` filePath, createdAt and reading progress are
+ *       all preserved untouched;
+ *     - otherwise call `appService.importBook` with `transient: true`, which
+ *       creates an ephemeral `Book` (with `deletedAt` set and `filePath`
+ *       pointing at the original URI) without writing to `Books/<hash>/` or
+ *       uploading to the cloud, then navigate to the reader on that hash.
+ *
+ *   `'SEND'` / undefined (iOS / macOS / desktop / Android share-sheet
+ *   capture): keep the existing flow that pushes the URLs through
+ *   `window.OPEN_WITH_FILES` so `library/page.tsx::processOpenWithFiles`
+ *   does a full ingest + cloud upload — that's the contract a "Send to
+ *   Readest" share is meant to honour.
  */
 export function useOpenWithBooks() {
   const router = useRouter();
@@ -34,7 +55,7 @@ export function useOpenWithBooks() {
       return sortedWindows[0]?.label === currentWindow.label;
     };
 
-    const handle = async (urls: string[]) => {
+    const normalizeUrls = (urls: string[]): string[] => {
       const filePaths: string[] = [];
       for (let url of urls) {
         if (url.startsWith('file://')) {
@@ -44,7 +65,101 @@ export function useOpenWithBooks() {
           filePaths.push(url);
         }
       }
+      return filePaths;
+    };
+
+    const openTransient = async (filePaths: string[]) => {
+      // For each file, first try to recognise it as a book the user has
+      // already imported (hash match in the live library). If yes, we route
+      // straight to the reader without ever calling importBook — that avoids
+      // mutating the managed entry's filePath / createdAt (importBook in
+      // transient mode unconditionally rewrites filePath to the incoming
+      // content:// URI and bumps createdAt, both of which we want to keep
+      // untouched for already-imported books).
+      //
+      // Only files that are NOT in the library go through importBook in
+      // transient mode, which creates an ephemeral Book (deletedAt set,
+      // filePath pointing at the original URI) without writing Books/<hash>/
+      // or uploading to the cloud. We also setLibrary so the reader's
+      // initViewState (which looks the book up via getBookByHash) can find
+      // the ephemeral entry.
+      const { library, setLibrary, getBookByHash } = useLibraryStore.getState();
+      const bookIds: string[] = [];
+      let libraryMutated = false;
+
+      for (const file of filePaths) {
+        try {
+          // Lightweight pre-check: hash the file and look it up. A miss here
+          // means we still have to fall back to importBook because we need
+          // its full metadata-extraction + ephemeral entry creation.
+          let existingHash: string | undefined;
+          try {
+            const fileobj = await appService.openFile(file, 'None');
+            try {
+              existingHash = await partialMD5(fileobj);
+            } finally {
+              const closable = fileobj as File & { close?: () => Promise<void> };
+              if (closable.close) await closable.close();
+            }
+          } catch (e) {
+            // Path/permission issue — let importBook surface the real error.
+            console.warn('Pre-hash failed, falling back to transient import:', file, e);
+          }
+
+          if (existingHash) {
+            const existing = getBookByHash(existingHash);
+            if (existing && !existing.deletedAt) {
+              bookIds.push(existing.hash);
+              continue;
+            }
+          }
+
+          const book = await appService.importBook(file, library, { transient: true });
+          if (book) {
+            bookIds.push(book.hash);
+            // importBook may have mutated `library` (added the ephemeral
+            // entry, or — for a hash hit on a previously-deleted entry —
+            // refreshed an existing one); either way we want store sync.
+            libraryMutated = true;
+          }
+        } catch (e) {
+          console.warn('Failed to open file transiently:', file, e);
+        }
+      }
+
+      if (bookIds.length === 0) return;
+      if (libraryMutated) {
+        setLibrary(library);
+      }
+      // Defensive: only navigate if the reader will actually be able to
+      // resolve the book via getBookByHash (managed entries are already in
+      // the store; ephemeral entries are after the setLibrary above).
+      const reachable = bookIds.filter((h) => !!getBookByHash(h));
+      if (reachable.length > 0) {
+        navigateToReader(router, reachable);
+      }
+    };
+
+    const handle = async (urls: string[], action?: 'VIEW' | 'SEND') => {
+      const filePaths = normalizeUrls(urls);
       if (filePaths.length === 0) return;
+
+      // Android "Open with" → straight to reader, no library write.
+      if (action === 'VIEW') {
+        // If a reader is already mounted, ignore the second tap rather
+        // than try to swap books underneath it. The in-place URL swap
+        // would otherwise leave ReaderContent's init effect (gated by
+        // an isInitiating ref + empty deps) stuck on the previous book
+        // and the user would see the spinner hang. The user can close
+        // the current book to return to the library, then re-open the
+        // new one — same UX as most OS image viewers.
+        if (typeof window !== 'undefined' && window.location.pathname.startsWith('/reader')) {
+          console.log('Ignoring Open-with VIEW intent: reader already active');
+          return;
+        }
+        await openTransient(filePaths);
+        return;
+      }
 
       const settings = useSettingsStore.getState().settings;
       if (appService?.hasWindow && settings.openBookInNewWindow) {
@@ -59,8 +174,8 @@ export function useOpenWithBooks() {
     };
 
     const onIncoming = (event: CustomEvent) => {
-      const { urls } = event.detail as { urls: string[] };
-      handle(urls);
+      const { urls, action } = event.detail as { urls: string[]; action?: 'VIEW' | 'SEND' };
+      handle(urls, action);
     };
     eventDispatcher.on('app-incoming-url', onIncoming);
 

--- a/apps/readest-app/src/services/bookContent.ts
+++ b/apps/readest-app/src/services/bookContent.ts
@@ -2,7 +2,7 @@ import type { Book } from '@/types/book';
 import type { FileSystem } from '@/types/system';
 import { EXTS } from '@/libs/document';
 import { getDir, getLocalBookFilename } from '@/utils/book';
-import { isValidURL } from '@/utils/misc';
+import { isContentURI, isValidURL } from '@/utils/misc';
 import { isPseStreamFileName } from './opds/pseStream';
 
 export type BookContentSource =
@@ -49,8 +49,20 @@ export async function resolveBookContentSource(
     return { kind: 'managed', path: managedPath, base: 'Books' };
   }
 
-  if (book.filePath && (await fs.exists(book.filePath, 'None'))) {
-    return { kind: 'external', path: book.filePath, base: 'None' };
+  if (book.filePath) {
+    // Android "Open with Readest" hands us a content:// URI as the
+    // book.filePath (e.g. content://media/external/file/1322). Tauri's
+    // fs.exists() doesn't understand content URIs and returns false,
+    // which would route us to `missing` here even though the URI is
+    // perfectly readable through appService.openFile (which copies the
+    // content to Cache on demand). Skip the existence probe for URIs
+    // we know openFile knows how to resolve.
+    if (isContentURI(book.filePath)) {
+      return { kind: 'external', path: book.filePath, base: 'None' };
+    }
+    if (await fs.exists(book.filePath, 'None')) {
+      return { kind: 'external', path: book.filePath, base: 'None' };
+    }
   }
 
   if (book.url) {


### PR DESCRIPTION
## Problem

On Android, tapping an EPUB in the system file browser and choosing Readest only opens the library — the book itself never opens in the reader.

## Root cause

Three issues in the Open-with chain:

1. `NativeBridgePlugin.handleIntent` took persistable URI permission for `ACTION_VIEW` but never dispatched the intent to the JS layer, so the front-end had no idea a file was being opened.
2. `resolveBookContentSource` probed the file path with `fs.exists`, which doesn't recognize `content://` URIs and returned `false`, causing the reader to bail out with `BookFileNotFoundError` even though `appService.openFile` can resolve content URIs via `copyURIToPath`.
3. When a book was already open in the reader and the user tapped a second book from the file manager, the URL changed but `ReaderContent`'s init effect (guarded by an `isInitiating` ref + empty deps) didn't re-run, leaving the reader stuck on a spinner.

## Fix

- Kotlin `NativeBridgePlugin`: emit `shared-intent` with `{ action: 'VIEW' | 'SEND', urls }` for both `ACTION_VIEW` and `ACTION_SEND` / `ACTION_SEND_MULTIPLE`.
- JS `useAppUrlIngress`: forward the `action` field through to consumers.
- JS `useOpenWithBooks`: on `VIEW`, look up the book by partial-MD5; if already in the library, just navigate to it; otherwise import as transient (no `Books/<hash>/` write, no upload) and open. Ignore subsequent `VIEW` intents while a reader is already mounted to avoid the spinner-hang.
- `bookContent.ts`: short-circuit content-URI paths so they go straight to `fs.openFile` (which handles content URIs), instead of failing the `fs.exists` probe.

## Test

- Tap EPUB in system file manager → choose Readest → reader opens the book directly.
- Library books still open normally.
- Tapping a second book while one is already open is now ignored (reader stays on the first book) instead of hanging on a spinner.