### PR TITLE
fix(reader): stop footer progress info painting a stray focus ring (#4397)

### DIFF
--- a/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
@@ -178,3 +178,26 @@ describe('ProgressBar — fixed-layout remaining pages', () => {
     );
   });
 });
+
+describe('ProgressBar — decorative footer is not focusable', () => {
+  it('does not make the progress info container focusable (no stray focus ring)', () => {
+    // The footer info is a decorative role="presentation" element. A negative
+    // tabindex made it focusable, so long-pressing it on Android focused the
+    // div and the WebView painted its default focus ring as a persistent line
+    // across the bottom of the page (issue #4397). A decorative element must
+    // not be focusable so it can never receive a focus ring.
+    currentViewSettings = {
+      ...baseSettings,
+      progressInfoMode: 'all',
+    } as ViewSettings;
+    currentProgress = makeProgress(2, 5);
+    currentBookData = { isFixedLayout: false };
+    currentRenderer = { page: 1, pages: 4 };
+
+    const { container } = renderProgressBar();
+
+    const progressInfo = container.querySelector('.progressinfo');
+    expect(progressInfo).not.toBeNull();
+    expect(progressInfo!.hasAttribute('tabindex')).toBe(false);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/ProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/ProgressBar.tsx
@@ -188,7 +188,6 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
   return (
     <div
       role='presentation'
-      tabIndex={-1}
       className={clsx(
         'progressinfo absolute bottom-0 flex items-center justify-between font-sans',
         isEink ? 'text-sm font-normal' : 'text-neutral-content text-xs font-extralight',


### PR DESCRIPTION
## Problem

Closes #4397. On Android, long-pressing the footer left a strange horizontal line across the bottom of the page that persisted across page turns (only cleared by double-tapping the footer and turning the page again).

## Root cause

The always-on page-info footer (`ProgressBar.tsx`, rendered as `.progressinfo`) is a decorative `role='presentation'` element, but it carried `tabIndex={-1}`, which made it focusable. Long-pressing it on Android focused the div and the WebView painted its default focus ring (`outline: auto`, matching `:focus-visible`). Because the element is pinned `absolute bottom-0` at book-view width, the ring rendered as a content-column-wide box across the bottom of **every** page until focus cleared.

It is **not** a range/slider input — those are `opacity-0` / `visibility:hidden`. The visible artifact is the focus ring on the footer div itself.

## Fix

Remove the `tabIndex` so the decorative element can no longer receive focus:

- `onClick` (tap-to-cycle progress mode / dismiss annotation popup) still fires — click events don't require focusability.
- Nothing focuses `.progressinfo` programmatically, and no ancestor has a real `tabindex` to grab focus instead (verified: focus falls through to `<body>`).
- `role='presentation'` and the translated `aria-label` are untouched, so screen-reader output is unchanged (a negative tabindex was never a tab stop anyway).

Device-agnostic, so it also covers the e-ink case that couldn't be reproduced.

## Testing

- Added a regression test asserting `.progressinfo` is not focusable (no `tabindex` attribute) — confirmed it fails before the change and passes after.
- `pnpm test` — full suite passes (5096 passed, 8 skipped).
- `pnpm lint` (tsgo + Biome) — clean.
- Verified live in the dev app: after the change, focusing `.progressinfo` falls through to `<body>`, so the stray ring can no longer appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)