### PR TITLE
fix(reader): suppress Android image callout freezing the image viewer

### DIFF
--- a/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+import ImageViewer from '@/app/reader/components/ImageViewer';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+// useKeyDownActions pulls in EnvContext + device store; not under test here.
+vi.mock('@/hooks/useKeyDownActions', () => ({
+  useKeyDownActions: () => {},
+}));
+
+// ZoomControls reaches into the theme store and Tauri window APIs; stub it out.
+vi.mock('@/app/reader/components/ZoomControls', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+afterEach(cleanup);
+
+const gridInsets = { top: 0, right: 0, bottom: 0, left: 0 };
+
+describe('ImageViewer', () => {
+  it('suppresses the native image callout on the zoomed image', () => {
+    // The WebView's native long-press image callout collides with the
+    // viewer's own pinch/pan handlers on Android and freezes the app. The
+    // zoomed <img> must live under a `.no-context-menu` ancestor so the
+    // global `.no-context-menu img { -webkit-touch-callout: none }` rule
+    // disables that callout. Mirrors the book-cover fix (PR #4345).
+    const { container } = render(
+      <ImageViewer src='blob:test-image' onClose={vi.fn()} gridInsets={gridInsets} />,
+    );
+
+    const calloutSafeImage = container.querySelector('.no-context-menu img');
+    expect(calloutSafeImage).toBeTruthy();
+  });
+});

--- a/apps/readest-app/src/app/reader/components/ImageViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/ImageViewer.tsx
@@ -367,12 +367,15 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
   if (!src) return null;
 
   return (
+    // `no-context-menu` suppresses the WebView's native long-press image
+    // callout (via the `.no-context-menu img` rule). On Android it otherwise
+    // collides with the pinch/pan handlers below and freezes the app.
     <div
       ref={containerRef}
       tabIndex={-1}
       role='button'
       aria-label={_('Image viewer')}
-      className='fixed inset-0 z-50 flex items-center justify-center outline-none'
+      className='no-context-menu fixed inset-0 z-50 flex items-center justify-center outline-none'
       onKeyDown={handleKeyDown}
       onWheel={handleWheel}
       onTouchMove={onTouchMove}


### PR DESCRIPTION
## Summary

Fixes #4420 — on Android, **previewing/zooming an image freezes the entire app** (only a restart recovers it).

Long-pressing the image in the zoom viewer triggers the WebView's native image callout (context menu / drag / magnifier) at the same time as the viewer's own pinch/pan/zoom touch handlers, and the collision locks up the app. This is the **same root cause** as the book-cover freeze fixed in #4345: `-webkit-touch-callout: none` does **not** inherit, so the suppression class has to sit on an ancestor of the `<img>`.

## Fix

Add the existing `.no-context-menu` class to the `ImageViewer` root container. The global `.no-context-menu img { -webkit-touch-callout: none; -webkit-user-drag: none; user-select: none }` rule (in `globals.css`) then reaches the zoomed image and disables the native callout.

Applied unconditionally — unlike the bookshelf (which gated on mobile because its container holds selectable title text), the viewer has no selectable text, and the change is harmless on desktop (`-webkit-touch-callout` is a no-op there and right-click "Save image as…" still works).

## Test

- Added `ImageViewer.test.tsx` asserting the zoomed image renders under a `.no-context-menu` ancestor, so the callout-suppression rule reaches it. Confirmed it fails before the fix and passes after.
- `pnpm test` — full suite green (5107 passed). `pnpm lint` — clean.

> [!NOTE]
> Verified by code inspection + unit test, not on a physical Android device. The fix mirrors the previously-confirmed #4345 callout fix. If the freeze turns out to be reproducible from pinch-zoom **without** a long-press, that would point at a separate cause (e.g. the `requestAnimationFrame` churn in `onTouchMove`) and would need a device repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)