### PR TITLE
fix(reader): keep table background matching the page in dark mode (#4419)

### DIFF
--- a/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
@@ -639,6 +639,33 @@ describe('getColorStyles branches (via getStyles)', () => {
     );
   });
 
+  it('does not tint table descendants in dark mode when overrideColor is false (#4419)', () => {
+    const vs = makeViewSettings({ overrideColor: false });
+    const theme = makeThemeCode({ isDarkMode: true, bg: '#1a1a1a', fg: '#e0e0e0' });
+    const css = getStyles(vs, theme);
+    // When the user has NOT enabled color override, the `blockquote, table *`
+    // rule must not paint a tinted background on table descendants. Otherwise
+    // plain tables — and the invisible spacer cells some books use for vertical
+    // layout — render with a color different from the page background, and the
+    // spacing between words appears to change in dark mode. Regression from
+    // #4055; the #4028 zebra-row legibility case is now handled by the
+    // light-background rewriters from #4392. See issue #4419.
+    const match = css.match(/blockquote,\s*table\s*\*\s*\{([^}]*)\}/);
+    expect(match).not.toBeNull();
+    expect(match![1]).not.toContain('color-mix');
+  });
+
+  it('still tints blockquotes in dark mode when overrideColor is false', () => {
+    const vs = makeViewSettings({ overrideColor: false });
+    const theme = makeThemeCode({ isDarkMode: true, bg: '#1a1a1a', fg: '#e0e0e0' });
+    const css = getStyles(vs, theme);
+    // The standalone `blockquote` rule keeps its dark-mode tint regardless of
+    // overrideColor — only the shared `table *` part is gated.
+    expect(css).toMatch(
+      /blockquote\s*\{[^}]*background:\s*color-mix\(in srgb,\s*#1a1a1a\s*80%,\s*#000\)/,
+    );
+  });
+
   it('makes svg/img backgrounds transparent when overrideColor is true', () => {
     const vs = makeViewSettings({ overrideColor: true });
     const theme = makeThemeCode();

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -258,9 +258,16 @@ const getColorStyles = (
     blockquote {
       ${isDarkMode ? `background: color-mix(in srgb, ${bg} 80%, #000);` : ''}
     }
+    /* Only tint table descendants when the user has opted into color override.
+       By default, leave them transparent so a plain table (and the invisible
+       spacer cells some books use for vertical layout) keeps the page
+       background instead of a different shade. Illegible light/zebra table
+       backgrounds are handled separately by the dark-mode light-background
+       rewriters (getDarkModeLightBackgroundOverrides / transformStylesheet).
+       See #4419 (and #2377, which this gate originally fixed). */
     blockquote, table * {
-      ${isDarkMode ? `background: color-mix(in srgb, ${bg} 80%, #000);` : ''}
-      ${isDarkMode ? `background-color: color-mix(in srgb, ${bg} 80%, #000);` : ''}
+      ${isDarkMode && overrideColor ? `background: color-mix(in srgb, ${bg} 80%, #000);` : ''}
+      ${isDarkMode && overrideColor ? `background-color: color-mix(in srgb, ${bg} 80%, #000);` : ''}
     }
     /* override inline hardcoded text color */
     font[color="#000000"], font[color="#000"], font[color="black"],


### PR DESCRIPTION
Closes #4419

## Problem

In dark mode, tables rendered with a background a few shades off the page background, even when the book's content had no table background of its own. On vertical writing-mode 目录/TOC pages, the spacing between words also appeared to change when entering dark mode.

## Root cause

`getColorStyles` in `src/utils/style.ts` tinted **all** table descendants in dark mode, ungated:

```css
blockquote, table * { background-color: color-mix(in srgb, ${bg} 80%, #000); }
```

This rule has regressed twice:

- **#2377** (PR #2379) originally gated it on `overrideColor` — "avoid overriding table background by default".
- **#4055** (`cead0f42e`, closes #4028/#4029) **removed** the gate to darken illegible white zebra-stripe rows — re-introducing the bug.
- **#4392** (`176b950c9`) later added dark-mode light-background rewriters (`getDarkModeLightBackgroundOverrides` for inline styles + the `transformStylesheet` dark-mode block for stylesheet rules) that map only *actually-light* backgrounds → page `bg`. This now handles the #4028 legibility case surgically, so the blanket tint is no longer needed by default.

The "spacing changes" symptom shares the same root cause: those vertical-TOC books lay the directory out as a `<table>` with empty spacer `<td>`s and `<span class="space">▉</span>` spacers (the ▉ glyph, U+2589, is a blank glyph in the book's custom "space" font — pure advance width, no outline). The blanket rule paints a background onto those spacer cells/spans, so the previously-invisible gaps show up as tinted blocks. It's the painted background, not text color, that reveals them.

I confirmed this with a live browser reproduction using the reporter's EPUB + its real "space" font: page bg was `rgb(28,28,28)` while cells **and the spacer spans** computed to `#161616`. With the fix they resolve to `transparent`, so the page background shows through and the table/spacing match the (correct) light-mode rendering.

## Fix

Restore the `overrideColor` gate on the shared `table *` part (a minimal revert of the #4055 hunk), keeping #4055's unrelated `td, th` text-wrapping improvement and the intended unconditional `blockquote` tint. Added a comment so it doesn't regress a third time.

## Tests

- New failing-then-passing test: `table *` is not tinted in dark mode when `overrideColor` is false (#4419).
- Guard test: blockquotes stay tinted in dark mode when `overrideColor` is false.
- Existing test (table tinted when `overrideColor` is true) still passes.
- `pnpm test` (full suite) and `pnpm lint` (tsgo + Biome) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)