### PR TITLE
fix(reader): keep paginated page background inside its column (#4394)

### DIFF
--- a/apps/readest-app/src/__tests__/document/paginator-background-segments.test.ts
+++ b/apps/readest-app/src/__tests__/document/paginator-background-segments.test.ts
@@ -43,24 +43,27 @@ describe('computeBackgroundSegments', () => {
     expect(segments).toEqual([{ start: 0, size: 430, bg: 'rgb(0, 0, 0)' }]);
   });
 
-  it('stretches a centered page into the full-bleed gutters (inset > 0)', () => {
-    // Desktop-style: container is inset 50px inside a 430px background.
+  it('keeps a centered page inside its content area (inset > 0)', () => {
+    // Desktop-style: container is inset 50px inside a 430px background. The page
+    // background stays inside its column [50, 380] — it must NOT bleed into the
+    // outer margin gutters, so the page stays centered (readest#4394).
     const views = [{ size: 330, bg: 'rgb(0, 0, 0)' }];
     const segments = computeBackgroundSegments(views, 0, 430, 50, 330);
-    // Extends out to both background edges so the page is full-bleed.
-    expect(segments).toEqual([{ start: 0, size: 430, bg: 'rgb(0, 0, 0)' }]);
+    expect(segments).toEqual([{ start: 50, size: 330, bg: 'rgb(0, 0, 0)' }]);
   });
 
-  it('gives each section its own full-bleed half in a two-up spread', () => {
+  it('keeps each section inside its own column in a two-up spread', () => {
     const views = [
       { size: 215, bg: 'rgb(255, 0, 0)' },
       { size: 215, bg: 'rgb(0, 0, 255)' },
     ];
     // bg 500 wide, container 430 inset 35 → seam at 35 + 215 = 250.
     const segments = computeBackgroundSegments(views, 0, 500, 35, 430);
+    // Each page fills its column up to the seam; neither bleeds into its outer
+    // gutter ([0, 35] and [465, 500] stay as symmetric margins).
     expect(segments).toEqual([
-      { start: 0, size: 250, bg: 'rgb(255, 0, 0)' }, // left page bleeds into left gutter
-      { start: 250, size: 250, bg: 'rgb(0, 0, 255)' }, // right page bleeds into right gutter
+      { start: 35, size: 215, bg: 'rgb(255, 0, 0)' },
+      { start: 250, size: 215, bg: 'rgb(0, 0, 255)' },
     ]);
   });
 
@@ -73,6 +76,35 @@ describe('computeBackgroundSegments', () => {
     // Scrolled to the middle view.
     const segments = computeBackgroundSegments(views, 430, 430, 0, 430);
     expect(segments).toEqual([{ start: 0, size: 430, bg: 'rgb(1, 1, 1)' }]);
+  });
+
+  // Regression test for readest/readest#4394. Backgrounds used to bleed into the
+  // outer margin gutter on the side they touched, so a mixed two-up spread — a
+  // transparent cover (no segment) beside a body-coloured title page — filled
+  // the right gutter with colour while the left gutter stayed the plain margin.
+  // The spread then looked shifted off-centre (badly so on wide screens, where
+  // each gutter is ~250px). Each page now stays inside its own column.
+  it('keeps symmetric margins when only the right page of a two-up spread is colored', () => {
+    const views = [
+      { size: 215, bg: '' }, // left page — transparent cover image, no segment
+      { size: 215, bg: 'rgb(255, 228, 63)' }, // right page — yellow title
+    ];
+    // bg 500 wide, container 430 inset 35 → seam at 35 + 215 = 250.
+    const segments = computeBackgroundSegments(views, 0, 500, 35, 430);
+    // The yellow page stops at the content edge (465); it must NOT bleed into
+    // the right gutter [465, 500] while the transparent left gutter shows white.
+    expect(segments).toEqual([{ start: 250, size: 215, bg: 'rgb(255, 228, 63)' }]);
+  });
+
+  it('keeps symmetric margins when only the left page of a two-up spread is colored', () => {
+    const views = [
+      { size: 215, bg: 'rgb(255, 228, 63)' }, // left page — yellow
+      { size: 215, bg: '' }, // right page — transparent, no segment
+    ];
+    const segments = computeBackgroundSegments(views, 0, 500, 35, 430);
+    // The yellow page starts at the content edge (35); it must NOT bleed into
+    // the left gutter [0, 35] while the transparent right gutter shows white.
+    expect(segments).toEqual([{ start: 35, size: 215, bg: 'rgb(255, 228, 63)' }]);
   });
 });
 


### PR DESCRIPTION
Fixes #4394.

## Problem

In paginated multi-column mode a coloured page's background bled into the **outer margin gutter** on the side it touched, while an adjacent transparent / full-page-image page did not. On a cover spread this looked lopsided — the cover's left gutter stayed white while the yellow title page's background spilled into the right gutter — and on a wide screen (where each gutter is ~250px) the whole spread read as shifted off-centre with a "massive white blank gap" (the regression reported in #4394).

## Root cause

`computeBackgroundSegments` (foliate-js `paginator.js`) positioned each page's background segment to track its content, then **stretched** any segment touching a container edge out to the background edge (`start = 0` / `end = bgSize`), i.e. into the outer gutter. A body-coloured page bled into its gutter; a transparent/image page didn't, so mixed spreads became asymmetric.

The outer gutters themselves (the `--_outer-min-left/right` grid tracks) are intentional — they keep the left/right margins symmetric with the inter-column gap — so the fix leaves the grid alone.

## Fix

Clamp each background segment to the content area `[containerStart, containerEnd]` instead of stretching it into the gutter, so a coloured page stays inside its own column. In single-column mode the gutters are zero, so backgrounds still fill the viewport edge to edge (matching 0.10.6).

- `packages/foliate-js` bumped to `cc86688` (the clamp change).
- Updated the `computeBackgroundSegments` regression tests (the inset>0 "centered page" and "two-up spread" cases now assert the confined behaviour; the inset=0 swipe-flash tests are unchanged).

## Verification

- `pnpm test` (10/10 in the segment suite, full suite green) and `pnpm lint` pass.
- Verified live: on the cover spread the yellow title segment now ends at the column edge (`1023`) instead of the viewport edge (`1040`), giving a symmetric outer gutter on both sides; the grid is unchanged (`17px 16px 974px 16px 17px`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)