### PR TITLE
fix(eink): keep dropdown-toggle label legible under e-ink (#4435)

### DIFF
--- a/apps/readest-app/src/__tests__/styles/eink-dropdown-toggle.test.ts
+++ b/apps/readest-app/src/__tests__/styles/eink-dropdown-toggle.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression guard for issue #4435 (button display under the e-ink screen).
+ *
+ * The Android "Choose New Folder" selector in the Change Data Location dialog is
+ * a `Dropdown` whose toggle carries `dropdown-toggle ... btn btn-ghost
+ * btn-outline`. Under `[data-eink='true']`, globals.css inverts `.btn-outline`
+ * to a solid fill (`background: base-content`, `color: base-100`). The dedicated
+ * `[data-eink='true'] .dropdown-toggle` rule then neutralizes the background
+ * back to transparent — but it used to leave the inverted white (`base-100`)
+ * text untouched, so the label became white-on-transparent (white-on-white):
+ * an empty-looking outlined box.
+ *
+ * Invariant: the e-ink `.dropdown-toggle` rule must reset BOTH the background
+ * (transparent) AND the text color (base-content), so a transparent-background
+ * toggle keeps a legible dark label regardless of any fill class it also wears.
+ */
+describe('e-ink dropdown-toggle legibility', () => {
+  const css = readFileSync(resolve(process.cwd(), 'src/styles/globals.css'), 'utf8');
+
+  const block = (() => {
+    const selector = "[data-eink='true'] .dropdown-toggle";
+    const start = css.indexOf(selector);
+    expect(start, `expected globals.css to define ${selector}`).toBeGreaterThanOrEqual(0);
+    const open = css.indexOf('{', start);
+    const close = css.indexOf('}', open);
+    return css.slice(open + 1, close);
+  })();
+
+  it('neutralizes the toggle background to transparent', () => {
+    expect(block).toMatch(/background-color:\s*theme\('colors\.transparent'\)/);
+  });
+
+  it('resets the toggle text color to base-content so it stays legible', () => {
+    expect(block).toMatch(/color:\s*theme\('colors\.base-content'\)/);
+  });
+});

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -604,6 +604,11 @@ input[type='range'].slider-input {
 
 [data-eink='true'] .dropdown-toggle {
   background-color: theme('colors.transparent') !important;
+  /* A toggle that also carries a fill class (e.g. btn-outline) gets its label
+     inverted to base-100 by the rule above; with the background neutralized to
+     transparent that leaves white-on-white. Keep the text base-content so the
+     label stays legible (issue #4435). */
+  color: theme('colors.base-content') !important;
 }
 
 [data-eink='true'] .opds-navigation .card {


### PR DESCRIPTION
## Problem

Under e-ink on Android, the **New Data Location** selector in the *Change Data Location* dialog rendered as an empty outlined box — its "Choose New Folder" label was invisible. Reported in #4435 (follow-up to #4396).

<img width="480" alt="empty box under e-ink" src="https://github.com/user-attachments/assets/0f3dfa1f-b7fd-4740-9ba6-d461d2861bc8" />

## Root cause (CSS cascade)

That selector is a `Dropdown` whose toggle `<button>` carries `dropdown-toggle … btn btn-ghost btn-outline`. Under `[data-eink='true']`:

- `.btn-outline` inverts to a solid fill: `background: base-content`, **`color: base-100` (white)**.
- The dedicated `[data-eink='true'] .dropdown-toggle` rule forces `background: transparent` — same specificity, later in source, so it **wins the background** (neutralizing the fill) but only reset the background, **not the text color**.
- Net result: white label on a transparent (white) surface → white-on-white. The border (still from `.btn-outline`) survives, which is why an empty *outlined* box appears.

This is the only `Dropdown` in the app that passes `btn-outline`; all others use `btn-ghost`, so nothing else was affected.

## Fix

One declaration added to the existing e-ink rule — a transparent-background toggle must keep dark text regardless of any fill class it also wears:

```css
[data-eink='true'] .dropdown-toggle {
  background-color: theme('colors.transparent') !important;
  color: theme('colors.base-content') !important;  /* ← #4435 */
}
```

I kept the fix in the global e-ink rule rather than dropping `btn-outline` from the component (as the earlier #4396/#4422 cancel-button fix did) because removing `btn-outline` would also drop the bordered selector look on **normal** themes — the desktop variant intentionally relies on it. This change is e-ink-gated, so normal themes are untouched, and it covers any future `dropdown-toggle` + fill-class combination.

## Test

jsdom can't compute stylesheet cascade, so I added a `globals.css` invariant guard (`eink-dropdown-toggle.test.ts`) asserting the e-ink `.dropdown-toggle` rule resets **both** background (transparent) and text color (base-content) — same fs-read precedent as `pdfjs-wasm-assets.test.ts`. Confirmed it fails before the fix, passes after.

## Verification

- `pnpm test` (full suite) — 5129 passed
- `pnpm lint` — tsgo + Biome clean
- No `src-tauri/` or koplugin Lua changes.

Closes #4435

🤖 Generated with [Claude Code](https://claude.com/claude-code)