### PR TITLE
fix(reader): show KOReader progress-synced as a top-right hint (#4461)

### DIFF
--- a/apps/readest-app/src/app/reader/hooks/useKOSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useKOSync.ts
@@ -152,10 +152,9 @@ export const useKOSync = (bookKey: string) => {
         view.goToFraction(remoteFraction);
       }
     }
-    eventDispatcher.dispatch('toast', {
+    eventDispatcher.dispatch('hint', {
+      bookKey,
       message: _('Reading Progress Synced'),
-      type: 'info',
-      timeout: 2000,
     });
   };
 


### PR DESCRIPTION
## Summary

Fixes #4461. KOReader sync displayed the "Reading Progress Synced" notification as a **centered info toast** that blocks the text for fast readers, while Readest's own cloud sync uses an unobtrusive **top-right hint**. This makes KOReader sync use the same hint.

### Root cause
In `useKOSync.ts`, `applyRemoteProgress` dispatched a `'toast'` event with `type: 'info'`, which `Toast.tsx` renders `toast-center toast-middle` (centered, blocking). Readest sync (`useProgressSync.ts`) instead dispatches a `'hint'` event, which `HintInfo.tsx` renders pinned to the top-right with a ~2s auto-dismiss.

### Fix
Route the notification through the same `'hint'` event that `useProgressSync` uses (passing `bookKey`, which `HintInfo` filters on). This single dispatch site covers both KOSync paths that apply remote progress — the auto-apply (`receive`/`silent`) flow and the conflict-resolved "use remote" flow. The interactive conflict-resolution dialog (`KOSyncResolver`) is intentionally unchanged since it requires user input.

```diff
-    eventDispatcher.dispatch('toast', {
+    eventDispatcher.dispatch('hint', {
+      bookKey,
       message: _('Reading Progress Synced'),
-      type: 'info',
-      timeout: 2000,
     });
```

### Verification
- `pnpm lint` — Biome + tsgo clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)