### PR TITLE
fix(reader): stop zoomed image pan from flickering on desktop (#4451)

### DIFF
--- a/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
 
 import ImageViewer from '@/app/reader/components/ImageViewer';
 
@@ -35,5 +35,47 @@ describe('ImageViewer', () => {
 
     const calloutSafeImage = container.querySelector('.no-context-menu img');
     expect(calloutSafeImage).toBeTruthy();
+  });
+
+  // Desktop-only flicker (#4451): the drag pan must keep tracking the pointer
+  // even after it leaves the (moving) image, mirroring how the touch path
+  // tracks on the full-screen container. Binding the move/up handlers to the
+  // <img> meant the pointer crossing the image boundary aborted/restarted the
+  // drag, producing the flicker. The drag now tracks on `window`.
+  const zoomIn = (img: Element) => {
+    // Double-click on a fresh viewer zooms to scale=2 so panning is enabled.
+    fireEvent.doubleClick(img);
+  };
+
+  it('keeps panning when the pointer leaves the image (tracks on window)', () => {
+    const { container } = render(
+      <ImageViewer src='blob:test-image' onClose={vi.fn()} gridInsets={gridInsets} />,
+    );
+    const img = container.querySelector('img')!;
+    zoomIn(img);
+
+    fireEvent.mouseDown(img, { clientX: 100, clientY: 100 });
+    // Pointer moves while no longer over the image element — handled on window.
+    fireEvent.mouseMove(window, { clientX: 160, clientY: 130 });
+
+    // position = (60, 30); transform divides the translate by scale (2).
+    expect(img.style.transform).toContain('scale(2)');
+    expect(img.style.transform).toContain('translate(30px, 15px)');
+  });
+
+  it('disables the transform transition while dragging to avoid lag flicker', () => {
+    const { container } = render(
+      <ImageViewer src='blob:test-image' onClose={vi.fn()} gridInsets={gridInsets} />,
+    );
+    const img = container.querySelector('img')!;
+    zoomIn(img);
+
+    expect(img.style.transition).not.toBe('none');
+
+    fireEvent.mouseDown(img, { clientX: 100, clientY: 100 });
+    expect(img.style.transition).toBe('none');
+
+    fireEvent.mouseUp(window);
+    expect(img.style.transition).not.toBe('none');
   });
 });

--- a/apps/readest-app/src/app/reader/components/ImageViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/ImageViewer.tsx
@@ -196,23 +196,29 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
     dragStart.current = { x: e.clientX - position.x, y: e.clientY - position.y };
   };
 
-  const handleImageMouseMove = (e: React.MouseEvent) => {
-    if (!isDragging || scale <= 1) return;
-    e.preventDefault();
+  // Track the drag on `window` (not the moving <img>) so the pan keeps
+  // following the pointer even when it crosses the image boundary. Binding the
+  // move/up handlers to the image meant the cursor leaving the lagging image
+  // aborted and restarted the drag, which flickered on desktop (#4451). This
+  // mirrors the touch path, which tracks on the full-screen container.
+  useEffect(() => {
+    if (!isDragging) return;
 
-    wasDragging.current = true;
-    const newX = e.clientX - dragStart.current.x;
-    const newY = e.clientY - dragStart.current.y;
+    const handleMouseMove = (e: MouseEvent) => {
+      wasDragging.current = true;
+      setPosition({ x: e.clientX - dragStart.current.x, y: e.clientY - dragStart.current.y });
+    };
+    const handleMouseUp = () => {
+      setIsDragging(false);
+    };
 
-    setPosition({ x: newX, y: newY });
-  };
-
-  const handleImageMouseUp = (e: React.MouseEvent) => {
-    if (isDragging) {
-      e.stopPropagation();
-    }
-    setIsDragging(false);
-  };
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isDragging]);
 
   const onTouchStart = (e: React.TouchEvent) => {
     const touches = e.touches;
@@ -445,9 +451,6 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
           sizes='100vw'
           onClick={handleImageClick}
           onMouseDown={handleImageMouseDown}
-          onMouseMove={handleImageMouseMove}
-          onMouseUp={handleImageMouseUp}
-          onMouseLeave={handleImageMouseUp}
           onDoubleClick={onDoubleClick}
           style={{
             width: 'auto',
@@ -455,7 +458,14 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
             maxWidth: '100%',
             maxHeight: '100%',
             transform: `scale(${scale}) translate(${position.x / scale}px, ${position.y / scale}px)`,
-            transition: 'transform 0.05s ease-out',
+            // No transition while dragging: the 0.05s ease made the image lag
+            // behind the cursor, which flickered on desktop (#4451). Keep the
+            // smoothing only for discrete zoom (buttons, double-click, wheel).
+            transition: isDragging ? 'none' : 'transform 0.05s ease-out',
+            // Promote to a GPU layer so transform changes don't repaint the
+            // page (the `transform-gpu` class is overridden by this inline
+            // transform, so its hint is lost).
+            willChange: 'transform',
             cursor: cursorStyle,
           }}
         />


### PR DESCRIPTION
## Problem

Fixes #4451. On **desktop**, zooming an image and then dragging it makes the image flicker instead of panning smoothly. On iPhone it's fine.

## Root cause

A mouse/touch event-target asymmetry — which is exactly why it was desktop-only:

- **Touch (mobile, works):** the pan handlers are bound to the outer full-screen container, so tracking continues across the whole screen.
- **Mouse (desktop, flickers):** the pan handlers (`onMouseMove`/`onMouseUp`/`onMouseLeave`) were bound to the `<img>` itself. The image *moves* during a drag, and `transition: transform 0.05s ease-out` made it visually lag behind the cursor — so the pointer kept crossing outside the image's lagging hit-region, firing `onMouseLeave` → `setIsDragging(false)`, which repeatedly aborted and restarted the drag. That's the flicker.

A secondary contributor: the `transform-gpu` class was dead — the inline `style.transform` overrides it, so the intended GPU-compositing hint was lost.

## Fix

1. **Track the drag on `window`** during `isDragging` (add/remove `mousemove`/`mouseup` in an effect), keeping only `onMouseDown` on the image to initiate — mirroring the robust touch-on-container path.
2. **No transition while dragging:** `transition: isDragging ? 'none' : 'transform 0.05s ease-out'` so the pan is 1:1; smoothing is preserved for discrete zoom (buttons, double-click, wheel).
3. **`will-change: transform`** so transform changes composite on the GPU instead of repainting.

Post-drag click-to-close still works without the old `mouseup` `stopPropagation`: the synthesized `click` lands on the image (`handleImageClick`) or, if released on the backdrop, the container (`handleContainerClick`), and both early-return on `wasDragging.current`.

## Tests

Added two tests in `ImageViewer.test.tsx` that reproduced the bug first (failed pre-fix), then passed: a `window` pointer-move keeps the pan tracking, and the transform transition is `none` while dragging.

- `pnpm test` — full suite green
- `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)