### PR TITLE
fix(reader): dismiss annotation popup when selection clears

### DIFF
--- a/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
@@ -185,10 +185,11 @@ export const useTextSelector = (
     // selectionchange for touch/pen input to pick up native text selections.
     const isAndroid = osPlatform === 'android' && appService?.isAndroidApp;
     const isTouchInput = lastPointerType.current === 'touch' || lastPointerType.current === 'pen';
-    if (!isAndroid && !isTouchInput) return;
 
     const sel = doc.getSelection() as Selection;
     if (isValidSelection(sel)) {
+      // On desktop with mouse, defer to pointerup for valid selections.
+      if (!isAndroid && !isTouchInput) return;
       if (selectionPosition.current === null) {
         // Save the absolute container scroll, not `renderer.start` — the
         // latter is section-relative, so restoring it as `containerPosition`
@@ -198,6 +199,12 @@ export const useTextSelector = (
       }
       makeSelection(sel, index, false);
     } else {
+      // Selection cleared (e.g. clicking outside the selection).
+      // Dismiss immediately on all platforms.
+      if (isTextSelected.current) {
+        handleDismissPopup();
+        isTextSelected.current = false;
+      }
       selectionPosition.current = null;
     }
   };


### PR DESCRIPTION
## Bug

With text selected and the annotation popup visible, clicking on text outside the selection and holding the mouse button clears the selection in the browser, but the popup remains visible even after releasing the mouse. A second click-and-release is required to dismiss it.

## Cause

`handleSelectionchange` returned early for desktop mouse input, so emptying the selection never cleared the React state or dismissed the popup.

## Fix

Move the desktop-mouse guard into the `isValidSelection` branch only, so the "selection became empty" path executes on all platforms. The popup now dismisses immediately when the selection clears.

Screenshots:

- **Before**
<img width="984" height="771" alt="before" src="https://github.com/user-attachments/assets/994313a2-4f2b-4d84-adcb-4b3aefc6530e" />

- **After**
<img width="984" height="771" alt="after" src="https://github.com/user-attachments/assets/6032ec5e-5ec8-43d2-9417-c2266ac25e1b" />
