### PR TITLE
fix(reader): Android long-press swallowed by hidden page-nav buttons

### DIFF
--- a/apps/readest-app/src/app/reader/components/PageNavigationButtons.tsx
+++ b/apps/readest-app/src/app/reader/components/PageNavigationButtons.tsx
@@ -111,7 +111,10 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
         </button>
         <button
           onClick={handleGoLeftPage}
-          className='flex h-20 w-20 items-center justify-center focus:outline-none'
+          className={clsx(
+            'flex h-20 w-20 items-center justify-center focus:outline-none',
+            !isPageNavigationButtonsVisible && appService?.isAndroidApp && 'h-4 w-4',
+          )}
           aria-hidden={false}
           aria-label={getLeftPageLabel()}
           tabIndex={0}
@@ -139,7 +142,10 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
       >
         <button
           onClick={handleGoRightPage}
-          className='flex h-20 w-20 items-center justify-center focus:outline-none'
+          className={clsx(
+            'flex h-20 w-20 items-center justify-center focus:outline-none',
+            !isPageNavigationButtonsVisible && appService?.isAndroidApp && 'h-4 w-4',
+          )}
           aria-hidden={false}
           aria-label={getRightPageLabel()}
           tabIndex={0}


### PR DESCRIPTION
## Problem

On Android, long-pressing the **first or last word of the bottom two lines** of a page does nothing — no highlight, no toolbar. Middle words on the same lines work fine.
<img width="398" height="894" alt="image" src="https://github.com/user-attachments/assets/6013caa3-4559-4370-bc47-f0b9faf074c1" />


## Root cause

`PageNavigationButtons` renders four 80x80 navigation buttons that stay mounted on top of the foliate viewer even when not visible (`opacity-0`). On non-Android platforms they're given `pointer-events: none` while hidden, but on Android that breaks touch propagation into the iframe, so the existing code instead shrinks the **prev-section / next-section** buttons to `h-4 w-4` while hidden.

The **prev-page / next-page** buttons were missing this `h-4 w-4` fallback, so on Android they stayed 80x80 and covered two hot zones in the lower-left and lower-right of the page. Long-press touches landing inside those zones were eaten by the invisible buttons and never reached the foliate iframe — which is why the first/last words of the bottom lines couldn't be selected.

## Fix

Apply the same \`!isPageNavigationButtonsVisible && appService?.isAndroidApp && 'h-4 w-4'\` fallback to the prev-page and next-page buttons, so all four navigation buttons behave consistently while hidden on Android.

## Verification

Tested on Android (Pixel emulator + physical device): long-pressing the first/last word of the bottom lines now correctly highlights the word and opens the annotation toolbar. Navigation button behavior when visible is unchanged.