### PR TITLE
fix(updater): disable in-app updater inside Flatpak sandbox

### DIFF
--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -415,8 +415,18 @@ pub fn run() {
             #[cfg(not(target_os = "linux"))]
             let is_appimage = false;
 
+            // Flatpak mounts the app directory read-only, so the bundled updater can
+            // download but never apply an update. Disable it and leave updates to the
+            // Flatpak runtime. Detect via FLATPAK_ID or the /.flatpak-info sandbox file.
             #[cfg(desktop)]
-            let updater_disabled = std::env::var("READEST_DISABLE_UPDATER").is_ok();
+            let updater_disabled = {
+                #[cfg(target_os = "linux")]
+                let is_flatpak = std::env::var("FLATPAK_ID").is_ok()
+                    || std::path::Path::new("/.flatpak-info").exists();
+                #[cfg(not(target_os = "linux"))]
+                let is_flatpak = false;
+                std::env::var("READEST_DISABLE_UPDATER").is_ok() || is_flatpak
+            };
             #[cfg(not(desktop))]
             let updater_disabled = false;
 


### PR DESCRIPTION
## Problem

Closes #4440.

The Flatpak build (`com.bilingify.readest` on Flathub) triggers the in-app updater on launch. The user can download a new version, but the install never applies — Flatpak mounts the app directory read-only, so the bundled Tauri updater cannot overwrite the binary. The user is left on the old build with no working install path, while `flatpak update` (the correct channel) reports "Nothing to do".

Update management inside a Flatpak sandbox belongs to the Flatpak runtime / system package manager, not the bundled updater.

## Fix

Detect the Flatpak sandbox at startup via `FLATPAK_ID` or the `/.flatpak-info` file, and fold it into the existing `updater_disabled` flag in `src-tauri/src/lib.rs` — the same path already used by the `READEST_DISABLE_UPDATER` env var.

```rust
#[cfg(desktop)]
let updater_disabled = {
    #[cfg(target_os = "linux")]
    let is_flatpak = std::env::var("FLATPAK_ID").is_ok()
        || std::path::Path::new("/.flatpak-info").exists();
    #[cfg(not(target_os = "linux"))]
    let is_flatpak = false;
    std::env::var("READEST_DISABLE_UPDATER").is_ok() || is_flatpak
};
```

This flows through the existing `window.__READEST_UPDATER_DISABLED` → `hasUpdater` chain, so in Flatpak:
- the auto-update check is skipped,
- the "Check for Updates" menu item and About-window button are hidden,
- `checkAppReleaseNotes()` still runs, so users get informational "what's new" notes without any install attempt.

No new globals or app-service fields were added — it reuses the established disable mechanism. `is_flatpak` is scoped inside the `#[cfg(desktop)]` block so there's no unused-variable warning on android/ios.

## Verification

Rust-only change:
- `pnpm fmt:check` — clean
- `pnpm clippy:check` — no warnings from the `Readest` crate
- `pnpm test` — 5138 passed (full suite, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)