### PR TITLE
feat(metadata): show file path for in-place imported books

### DIFF
--- a/apps/readest-app/src/__tests__/components/BookDetailView.test.tsx
+++ b/apps/readest-app/src/__tests__/components/BookDetailView.test.tsx
@@ -13,7 +13,9 @@ vi.mock('@/store/settingsStore', () => ({
   useSettingsStore: () => ({
     settings: {
       metadataSeriesCollapsed: true,
-      metadataOthersCollapsed: true,
+      // The "File Path" entry lives under the Metadata section; tests below
+      // depend on it being expanded by default so the row is in the DOM.
+      metadataOthersCollapsed: false,
       metadataDescriptionCollapsed: true,
     },
   }),
@@ -98,5 +100,26 @@ describe('BookDetailView delete dropdown layout', () => {
     // It should keep position: relative via the !relative override so it
     // anchors against the centered parent.
     expect(menu!.className).toContain('!relative');
+  });
+});
+
+describe('BookDetailView file path row', () => {
+  // book.filePath is only set for in-place imports (and OS-handed paths like
+  // Android "Open with Readest"). Hash-copy imports leave it undefined, so
+  // surfacing it lets users tell the two storage modes apart at a glance.
+  it('shows the actual file path when book.filePath is set', () => {
+    const filePath = '/Users/me/Library/Books/sample.epub';
+    const { getByText } = renderView({ book: makeBook({ filePath }) });
+
+    expect(getByText('File Path')).toBeTruthy();
+    const value = getByText(filePath);
+    expect(value).toBeTruthy();
+    // Long paths must remain hoverable for the full string.
+    expect(value.getAttribute('title')).toBe(filePath);
+  });
+
+  it('omits the file path row for hash-copy books (no filePath)', () => {
+    const { queryByText } = renderView({ book: makeBook() });
+    expect(queryByText('File Path')).toBeNull();
   });
 });

--- a/apps/readest-app/src/components/metadata/BookDetailView.tsx
+++ b/apps/readest-app/src/components/metadata/BookDetailView.tsx
@@ -222,6 +222,21 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({
                     {metadata?.identifier || _('Unknown')}
                   </p>
                 </div>
+                {/*
+                  Only books imported in-place (or files opened directly via the
+                  OS, e.g. Android "Open with Readest") keep a `filePath`; books
+                  copied into Books/<hash>/ have it left undefined. Surfacing the
+                  path lets the user verify which on-disk file the entry points at
+                  and tell apart in-place vs hash-copy imports at a glance.
+                */}
+                {book.filePath && (
+                  <div className='col-span-2 overflow-hidden sm:col-span-3'>
+                    <span className='font-bold'>{_('File Path')}</span>
+                    <p className='text-neutral-content text-sm break-all' title={book.filePath}>
+                      {book.filePath}
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Why

Books imported in-place point at a file the user keeps under one of their external library folders (`book.filePath` is set), as opposed to hash-copy imports that live anonymously under `Books/<hash>/`. The book details view didn't surface where an entry actually lives on disk, so users had no way to tell the two storage modes apart at a glance, or locate the source file when they wanted to back it up, move it, or share it.

## What

Add a 'File Path' row at the bottom of the metadata grid in `BookDetailView`. The row only renders when `book.filePath` is set, so it stays out of the way for hash-copy books. The path spans the full row width (`sm:col-span-3`), uses `break-all` so long paths wrap cleanly inside the card, and exposes the unwrapped path via a `title` attribute for hover.

This reuses the existing `book.filePath` field, which is already the project-wide signal for in-place / external-source imports (cloud upload, WebDAV sync, content-source resolution all branch on it). No new types, no migrations.

<img width="398" height="922" alt="image" src="https://github.com/user-attachments/assets/a74c8c5b-46ad-49d3-a99c-3b599a660c6a" />


## Tests

Two unit tests in `BookDetailView.test.tsx` covering both branches:
- `book.filePath` set → row is rendered with the path text and matching `title`.
- `book.filePath` unset (hash-copy) → row is absent.

Local `pnpm test` (5140 tests) green; format/lint clean.