### PR TITLE
chore(deps): bump shell-quote to 1.8.4 and qs to 6.15.2 for security

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,8 @@ overrides:
   lodash-es: '>=4.18.0'
   postcss: 8.5.14
   basic-ftp: '>=5.3.0'
-  qs: '>=6.14.2'
+  qs: '>=6.15.2'
+  shell-quote: '>=1.8.4'
   '@babel/runtime': '>=7.26.10'
   '@babel/helpers': '>=7.26.10'
   mdast-util-gfm-autolink-literal: 2.0.1
@@ -7331,8 +7332,8 @@ packages:
   pure-rand@8.4.0:
     resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   query-selector-shadow-dom@1.0.1:
@@ -7792,8 +7793,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shiki@3.23.0:
@@ -13269,7 +13270,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -13585,7 +13586,7 @@ snapshots:
       minimatch: 10.2.5
       p-map: 7.0.4
       resolve: 1.22.12
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       subarg: 1.0.0
 
   crc-32@1.2.2: {}
@@ -14338,7 +14339,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -14673,7 +14674,7 @@ snapshots:
       extend: 3.0.2
       gaxios: 7.1.4
       google-auth-library: 10.6.2
-      qs: 6.15.1
+      qs: 6.15.2
       url-template: 2.0.8
     transitivePeerDependencies:
       - supports-color
@@ -16489,7 +16490,7 @@ snapshots:
 
   pure-rand@8.4.0: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -17072,7 +17073,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shiki@3.23.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,7 +41,8 @@ overrides:
   lodash-es: '>=4.18.0'
   postcss: 8.5.14
   basic-ftp: '>=5.3.0'
-  qs: '>=6.14.2'
+  qs: '>=6.15.2'
+  shell-quote: '>=1.8.4'
   '@babel/runtime': '>=7.26.10'
   '@babel/helpers': '>=7.26.10'
   mdast-util-gfm-autolink-literal: 2.0.1


### PR DESCRIPTION
## Summary

Raises the pnpm overrides in `pnpm-workspace.yaml` so patched transitive versions are resolved, closing two Dependabot advisories. Diff is scoped to exactly the two vulnerable packages.

- **shell-quote `>=1.8.4`** — fixes [GHSA-w7jw-789q-3m8p](https://github.com/ljharb/shell-quote/security/advisories/GHSA-w7jw-789q-3m8p) / CVE-2026-9277 (**critical**). `quote()` failed to escape line terminators in object `.op` values, allowing shell command injection. Pulled in transitively via `cpx2`.
- **qs `>=6.15.2`** — fixes [GHSA-q8mj-m7cp-5q26](https://github.com/ljharb/qs/security/advisories/GHSA-q8mj-m7cp-5q26) / CVE-2026-8723 (**medium**). `qs.stringify` throws `TypeError` (DoS) on `null`/`undefined` entries in comma-format arrays with `encodeValuesOnly`. The existing `>=6.14.2` pin still permitted the vulnerable `6.15.1`, so it's bumped to `>=6.15.2`. Pulled in transitively via `express`, `body-parser`, `googleapis-common`.

## Dependabot alerts

- https://github.com/readest/readest/security/dependabot/237 (shell-quote)
- https://github.com/readest/readest/security/dependabot/235 (qs)

## Verification

- `pnpm why -r shell-quote` → only `shell-quote@1.8.4`
- `pnpm why -r qs` → only `qs@6.15.2`
- `pnpm lint` — passes
- `pnpm test` — 5166 passed, 8 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)