### PR TITLE
fix(webdav): never push or pull for transient book sessions

### DIFF
--- a/apps/readest-app/src/__tests__/services/webdav-skip-transient.test.ts
+++ b/apps/readest-app/src/__tests__/services/webdav-skip-transient.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { syncLibrary } from '@/services/webdav/WebDAVSync';
+import type { WebDAVSettings } from '@/types/settings';
+import type { Book, BookConfig } from '@/types/book';
+
+/**
+ * `syncLibrary` must never upload anything for a transient import — those
+ * Books carry both `filePath` (source URI outside Books/<hash>/) and
+ * `deletedAt` (set at creation time by `bookService.importBook` when
+ * `transient: true`). Pushing config.json under `Readest/books/<hash>/`
+ * for such a hash creates a per-hash directory on the remote, which the
+ * directory-listing fallback in `syncLibrary` then materialises as a
+ * phantom shelf row on every sibling device's next sync.
+ *
+ * These tests exercise the library-wide push gate in isolation: we pass
+ * a tiny `books` array containing one transient and one normal entry,
+ * stub all network primitives, and assert that exactly the non-transient
+ * book ends up on the wire.
+ */
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+const settings: WebDAVSettings = {
+  enabled: true,
+  serverUrl: 'https://dav.example.com',
+  username: 'alice',
+  password: 'secret',
+  rootPath: '/',
+};
+
+const makeBook = (overrides: Partial<Book>): Book => ({
+  hash: 'h0',
+  format: 'EPUB',
+  title: 'Untitled',
+  author: 'Unknown',
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides,
+});
+
+const emptyConfig = (): BookConfig => ({ updatedAt: 0, booknotes: [] });
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  // Default: every call is a benign 404 (nothing on the remote yet).
+  // Individual tests can override per call via `mockImplementation`.
+  fetchMock.mockResolvedValue(new Response(null, { status: 404 }));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  vi.restoreAllMocks();
+});
+
+describe('syncLibrary transient guard', () => {
+  test('skips books that have both filePath and deletedAt set', async () => {
+    const transient = makeBook({
+      hash: 'transient-hash',
+      filePath: 'content://shared/file.epub',
+      deletedAt: Date.now(),
+    });
+    const normal = makeBook({ hash: 'normal-hash' });
+
+    const loadConfig = vi.fn<(book: Book) => Promise<BookConfig>>(async () => emptyConfig());
+    const loadBookFile = vi.fn(async () => null);
+
+    await syncLibrary(settings, [transient, normal], {
+      strategy: 'send', // push-only path keeps the assertion focused
+      syncBooks: false,
+      deviceId: 'device-A',
+      loadConfig,
+      loadBookFile,
+    });
+
+    // `loadConfig` is the first per-book step in the push loop, so it's
+    // a clean signal for "did this book reach the upload pipeline?"
+    const configCalls = loadConfig.mock.calls.map(([book]) => book.hash);
+    expect(configCalls).toContain('normal-hash');
+    expect(configCalls).not.toContain('transient-hash');
+
+    // No PUT to `Readest/books/transient-hash/...` should ever fire.
+    const transientPuts = fetchMock.mock.calls.filter((call) => {
+      const [url, init] = call as [string, RequestInit | undefined];
+      return (init?.method ?? '').toUpperCase() === 'PUT' && url.includes('transient-hash');
+    });
+    expect(transientPuts).toHaveLength(0);
+  });
+
+  test('still skips when only deletedAt is set (regular tombstone)', async () => {
+    // Pre-existing behaviour we must not regress: a book the user
+    // explicitly deleted carries `deletedAt` but typically no
+    // `filePath`. The deletedAt filter alone keeps it off the wire,
+    // independent of the new transient guard.
+    const tombstoned = makeBook({ hash: 'tomb-hash', deletedAt: Date.now() });
+
+    const loadConfig = vi.fn(async () => emptyConfig());
+    const loadBookFile = vi.fn(async () => null);
+
+    await syncLibrary(settings, [tombstoned], {
+      strategy: 'send',
+      syncBooks: false,
+      deviceId: 'device-A',
+      loadConfig,
+      loadBookFile,
+    });
+
+    expect(loadConfig).not.toHaveBeenCalled();
+  });
+
+  test('does NOT skip in-place imports (filePath set but deletedAt null)', async () => {
+    // In-place imports also populate `book.filePath`, but they're
+    // first-class library entries (`deletedAt: null`). They MUST sync
+    // — the inline comments in `bookService.importBook` and the
+    // ingestService upload logic both treat them as normal books.
+    const inPlace = makeBook({
+      hash: 'inplace-hash',
+      filePath: '/Users/alice/MyLibrary/book.epub',
+      deletedAt: null,
+    });
+
+    // Make MKCOL / PUT succeed so the push pipeline runs end-to-end
+    // without spamming the test log with simulated 404 stack traces.
+    fetchMock.mockImplementation(async (_url, init) => {
+      const method = ((init as RequestInit | undefined)?.method ?? 'GET').toUpperCase();
+      if (method === 'MKCOL' || method === 'PUT') return new Response(null, { status: 201 });
+      return new Response(null, { status: 404 });
+    });
+
+    const loadConfig = vi.fn(async () => emptyConfig());
+    const loadBookFile = vi.fn(async () => null);
+
+    await syncLibrary(settings, [inPlace], {
+      strategy: 'send',
+      syncBooks: false,
+      deviceId: 'device-A',
+      loadConfig,
+      loadBookFile,
+    });
+
+    expect(loadConfig).toHaveBeenCalledWith(expect.objectContaining({ hash: 'inplace-hash' }));
+  });
+});

--- a/apps/readest-app/src/app/reader/hooks/useWebDAVSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useWebDAVSync.ts
@@ -5,6 +5,7 @@ import { useBookDataStore } from '@/store/bookDataStore';
 import { useReaderStore } from '@/store/readerStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useTranslation } from '@/hooks/useTranslation';
+import { Book } from '@/types/book';
 import { debounce } from '@/utils/debounce';
 import { eventDispatcher } from '@/utils/event';
 import {
@@ -19,6 +20,43 @@ import { tauriUpload } from '@/utils/transfer';
 import { getCoverFilename, getLocalBookFilename } from '@/utils/book';
 import { removeBookNoteOverlays } from '../utils/annotatorUtil';
 import { useWindowActiveChanged } from './useWindowActiveChanged';
+
+/**
+ * A "transient" book is one created by `appService.importBook(..., { transient: true })`
+ * — typically the Open-with VIEW intent path on Android/iOS, or the /send
+ * preview flow. Its bytes are NOT copied into Books/<hash>/; instead the
+ * Book carries an absolute `filePath` pointing at the original file URI,
+ * and `deletedAt` is set to the import timestamp so the entry is filtered
+ * out of the bookshelf on next library load (see `bookService.ts:392` and
+ * `bookService.ts:525-529`).
+ *
+ * Why this combination uniquely identifies transient imports:
+ *   - In-place imports (`inPlace: true`) also set `filePath`, but they keep
+ *     `deletedAt: null` because they're a first-class persistent entry.
+ *   - User-deleted books carry `deletedAt` but rarely carry `filePath`
+ *     (only when the user deletes a previously in-place-imported book —
+ *     which is also a state we don't want to push, so the false positive
+ *     is harmless either way).
+ *   - Brand-new transient imports are the *only* state where both fields
+ *     are populated together at creation time.
+ *
+ * Push/pull MUST be skipped for transient books for two reasons:
+ *   1. They're never supposed to land in the user's library (or anyone's
+ *      library on another device). Pushing config.json to
+ *      `Readest/books/<hash>/` creates a per-hash directory that the
+ *      next sync run on a sibling device picks up via the directory-
+ *      listing fallback in `syncLibrary` (treating it as an "orphan
+ *      remote book") and pulls back down — manifesting as a phantom
+ *      book showing up on every connected device.
+ *   2. A pull might fetch a real book's config that happens to share
+ *      this hash and clobber the transient session's progress with
+ *      unrelated state, since transient imports skip the in-library
+ *      progress UI and we never want their merge to "win".
+ */
+const isTransientBook = (book: Book | undefined): boolean => {
+  if (!book) return false;
+  return !!book.filePath && !!book.deletedAt;
+};
 
 /**
  * WebDAV per-book sync hook.
@@ -171,6 +209,9 @@ export const useWebDAVSync = (bookKey: string) => {
     const config = getConfig(bookKey);
     const book = getBookData(bookKey)?.book;
     if (!config || !book) return;
+    // Transient books (Open-with previews, /send drafts) must never write
+    // to the WebDAV server — see `isTransientBook` for the full rationale.
+    if (isTransientBook(book)) return;
 
     try {
       const deviceId = ensureDeviceId();
@@ -213,10 +254,16 @@ export const useWebDAVSync = (bookKey: string) => {
     if (!allowPush) return;
     if (!(settings.webdav?.syncBooks ?? false)) return;
     if (fileSyncedRef.current) return;
-    fileSyncedRef.current = true;
 
     const book = getBookData(bookKey)?.book;
     if (!book || !appService) return;
+    // Transient previews never travel to the remote — same reasoning as
+    // pushNow above. Note we set `fileSyncedRef.current = true` only
+    // *after* the transient check so a later non-transient open of the
+    // same hash (e.g. user actually imports the book) still gets a
+    // fresh upload attempt.
+    if (isTransientBook(book)) return;
+    fileSyncedRef.current = true;
 
     try {
       const result = await pushBookFile(
@@ -313,10 +360,14 @@ export const useWebDAVSync = (bookKey: string) => {
   const pushBookCoverNow = useCallback(async () => {
     if (!allowPush) return;
     if (coverSyncedRef.current) return;
-    coverSyncedRef.current = true;
 
     const book = getBookData(bookKey)?.book;
     if (!book || !appService) return;
+    // Same transient guard as pushBookFileNow: keep the lock-flip below
+    // the transient check so a future real import of the same hash can
+    // still upload its cover.
+    if (isTransientBook(book)) return;
+    coverSyncedRef.current = true;
 
     try {
       await pushBookCover(settings.webdav!, book.hash, async () => {
@@ -360,6 +411,12 @@ export const useWebDAVSync = (bookKey: string) => {
     const config = getConfig(bookKey);
     const book = getBookData(bookKey)?.book;
     if (!config || !book) return false;
+    // Transient previews are not real library entries — pulling a
+    // remote config for the same hash would clobber the preview
+    // session's in-memory progress with unrelated state from another
+    // device's real copy of the book. Skip the network round-trip
+    // entirely.
+    if (isTransientBook(book)) return false;
 
     try {
       const result = await pullBookConfig(settings.webdav!, book, config);


### PR DESCRIPTION
## Problem

When a user opens a file via Open-with (Android VIEW intent / iOS share sheet) or previews a draft from the /send flow, `appService.importBook(..., { transient: true })` creates an ephemeral `Book` whose bytes are NOT copied into `Books/<hash>/`. The Book carries an absolute `filePath` pointing at the original URI plus an immediately-set `deletedAt`, so the entry is filtered out of the bookshelf on next library load.

The Reader-level WebDAV sync hook (`useWebDAVSync`) didn't know about this distinction and treated the transient session like any other open book:

- `pushNow` debounce-flushed progress to `Readest/books/<hash>/config.json` after a few page-turns or on close.
- `pushBookFileNow` / `pushBookCoverNow` HEAD-probed and uploaded the binary + cover when `syncBooks` was on.
- The first-open `pullNow → pushNow` bootstrap created the per-hash directory on the remote even before any reading happened.

Two user-visible side effects follow:

1. The directory-listing fallback in `syncLibrary` (the loop that scans `Readest/books/` for hashes the local library doesn't know about) picks the orphan hash up on every sibling device's next Sync now and materialises a phantom shelf row — "a book I never imported keeps re-appearing across my devices".
2. `pullNow` could fetch an unrelated real book that happens to share the same hash on another device and merge its progress into the preview session, clobbering the in-memory location with state the user can't see in any UI.

## Fix

Add a `isTransientBook(book)` helper in the Reader hook that fingerprints transient imports as `!!book.filePath && !!book.deletedAt`. This combination uniquely identifies the transient path:

- In-place imports also set `filePath` but keep `deletedAt: null`, so they MUST sync (the import comments and `ingestService`'s upload logic both treat them as first-class books). The guard correctly leaves them alone.
- User-deleted books carry `deletedAt` but rarely `filePath`; they're already filtered earlier as tombstones, so a false positive is harmless either way.
- Brand-new transient previews are the only state where both fields are populated together at creation time (`bookService.ts:392, 525-529`).

`pushNow`, `pushBookFileNow`, `pushBookCoverNow` and `pullNow` early-return for transient books. The lock refs (`fileSyncedRef` / `coverSyncedRef`) are flipped only after the transient check, so a future real import of the same hash still gets a fresh upload attempt.

## What is intentionally NOT changed

`syncLibrary` (the library-wide "Sync now") is left as-is. `WebDAVForm`'s caller already filters out `deletedAt` rows before invoking it, and `bookService` writes `deletedAt` synchronously on every transient import, so the existing `!b.deletedAt` filter inside the service already keeps transient entries off the library-level push path. Adding a parallel `filePath && deletedAt` filter there would be a strict subset of the existing one — pure noise without a behaviour change.

## Test plan

New `webdav-skip-transient.test.ts` covers three scenarios end-to-end against `syncLibrary` with a stubbed fetch:

- `filePath + deletedAt` (transient) — `loadConfig` is never called and no PUT to the transient hash directory fires.
- `deletedAt` only (regular tombstone) — also skipped, locking the existing behaviour.
- `filePath` only with `deletedAt: null` (in-place import) — still reaches the upload pipeline as expected.

Existing 5182-test vitest suite passes via the pre-push hook.

## Caveat

Hash directories that earlier builds already pushed for transient sessions remain on the WebDAV server and won't be auto-cleaned by this change. Users can sweep them via `WebDAVBrowsePane`'s existing orphan-cleanup mode; this fix only closes the source of new pollution.