### PR TITLE
fix(sync): flush pending Readest cloud push when the reader closes

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
@@ -276,4 +276,37 @@ describe('useProgressSync', () => {
     await advance(1500);
     expect(pullCallCount()).toBe(callsBeforeRefresh + 2);
   });
+
+  test('sync-book-progress flushes the pending cloud push on book close', async () => {
+    // Reproduces issue #4532: the reader is closed inside the 3s auto-sync
+    // debounce window, so the pending Readest cloud push would otherwise be
+    // dropped on unmount and never reach the cloud.
+    // Mount: the empty pull settles and opens the gate (configPulled = true).
+    const { rerender } = renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+    expect(pushCallCount()).toBe(0);
+
+    // User paginates to a new position — this arms the 3s auto-sync debounce.
+    h.state.progress = { location: 'cfi-loc-next' };
+    await act(async () => {
+      rerender();
+      await flushMicrotasks();
+    });
+    // The debounce has not fired yet, so nothing has been pushed.
+    expect(pushCallCount()).toBe(0);
+
+    // Closing the reader dispatches sync-book-progress within the debounce
+    // window — before the 3s timer would have fired.
+    await act(async () => {
+      const listeners = h.eventListeners.get('sync-book-progress');
+      listeners?.forEach((fn) =>
+        fn(new CustomEvent('sync-book-progress', { detail: { bookKey: 'h1-view1' } })),
+      );
+      await flushMicrotasks();
+    });
+
+    // The pending push is flushed immediately — Device A's last local position
+    // reaches the cloud before the reader tears down.
+    expect(pushCallCount()).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
@@ -130,9 +130,24 @@ export const useProgressSync = (bookKey: string) => {
     }
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleAutoSync = useCallback(
+    debounce(() => {
+      syncConfig();
+    }, SYNC_PROGRESS_INTERVAL_SEC * 1000),
+    [],
+  );
+
   const handleSyncBookProgress = async (event: CustomEvent) => {
     const { bookKey: syncBookKey } = event.detail;
     if (syncBookKey === bookKey) {
+      // Flush any pending debounced push first so the latest local progress
+      // reaches the cloud before we (re)pull. This covers the book-close case
+      // (issue #4532): the reader can tear down inside the SYNC_PROGRESS_INTERVAL_SEC
+      // auto-sync window, which would otherwise drop the pending push and leave
+      // other devices on the previous cloud-synced position. Must run while the
+      // gate below is still open so syncConfig takes the push branch.
+      handleAutoSync.flush();
       // Manual pull-to-refresh: tear down any prior retry chain so the new
       // attempt starts fresh, rather than being short-circuited by the
       // "retry already pending" guard in pullWithRetry.
@@ -143,7 +158,8 @@ export const useProgressSync = (bookKey: string) => {
     }
   };
 
-  // Push: ad-hoc push when the book is closed
+  // Push: flush the pending push + pull when the book is closed or the user
+  // taps the manual Sync button.
   useEffect(() => {
     eventDispatcher.on('sync-book-progress', handleSyncBookProgress);
     return () => {
@@ -151,14 +167,6 @@ export const useProgressSync = (bookKey: string) => {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bookKey]);
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleAutoSync = useCallback(
-    debounce(() => {
-      syncConfig();
-    }, SYNC_PROGRESS_INTERVAL_SEC * 1000),
-    [],
-  );
 
   // Push: auto-push progress when progress changes with a debounce
   useEffect(() => {


### PR DESCRIPTION
## Problem

Closes #4532.

When a book is closed within the `SYNC_PROGRESS_INTERVAL_SEC` (3s) auto-sync debounce window, the latest reading position is saved to local `config.json` but the pending **Readest cloud push is dropped** on teardown — so other devices keep showing the previous cloud-synced position until the book is reopened.

Root cause: on close, `ReaderContent.saveBookConfig` dispatches `sync-book-progress`, but its handler in `useProgressSync.ts` only **pulled** (reset `configPulled`, called `pullWithRetry()`) despite the "ad-hoc push on book close" comment. The only Readest cloud **push** is the debounced `handleAutoSync`, which never fires if the reader unmounts first. KOSync already handles this with a close-time `pushProgress.flush()`; the Readest cloud path had no equivalent.

## Fix

Flush the pending debounced push at the start of `handleSyncBookProgress`, **before** the pull gate is reset:

- `syncConfig()` reads `configPulled.current` synchronously, and `flush()` invokes it synchronously — so flushing while the gate is still open takes the **push** branch, then the handler resets the gate and pulls. Net effect: push-then-pull.
- `flush()` is a no-op when nothing is pending, so the no-change-since-open case is unaffected.
- The manual Sync button shares this event and now becomes a proper two-way sync (push local, then pull remote).

This is independent from the separate `configPulled.current` gate issue where newer server-side configs from a push response are discarded.

## Testing

- Added a failing-then-passing unit test: closing the reader inside the debounce window now flushes the cloud push immediately instead of dropping it.
- `pnpm test` — 5189 passed, 8 skipped ✅
- `pnpm lint` (tsgo + Biome) — clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)