### PR TITLE
fix(reader): hide footnote aside border again when custom fonts are loaded (#4438)

### DIFF
--- a/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
@@ -790,13 +790,26 @@ describe('custom @font-face inlining (via getStyles)', () => {
     expect(css).toContain('blob:http://localhost/my-test-font');
   });
 
-  it('inlines the @font-face rules ahead of the rest of the stylesheet', () => {
+  it('keeps @namespace epub ahead of every @font-face rule (#4438)', () => {
     const vs = makeViewSettings();
     const css = getStyles(vs, theme, [makeCustomFont()]);
-    // Paginator writes this CSS into the iframe before its first paint,
-    // so the custom @font-face must precede the font-family declarations
-    // that reference it (layout styles begin with `@namespace epub`).
-    expect(css.indexOf('@font-face')).toBeLessThan(css.indexOf('@namespace epub'));
+    // A `@namespace` rule is only honored when it precedes all style and
+    // `@font-face` rules; a misplaced one is silently ignored, which drops
+    // the namespaced `aside[epub|type~="footnote"]` selector and reveals the
+    // footnote aside's border as a stray horizontal line (#4438). The custom
+    // `@font-face` rules must therefore come after the namespace declaration.
+    expect(css).toContain('@namespace epub');
+    expect(css).toContain('@font-face');
+    expect(css.indexOf('@namespace epub')).toBeLessThan(css.indexOf('@font-face'));
+  });
+
+  it('still inlines custom @font-face ahead of the font-family declarations', () => {
+    const vs = makeViewSettings();
+    const css = getStyles(vs, theme, [makeCustomFont()]);
+    // Paginator writes this CSS into the iframe before its first paint, so the
+    // custom `@font-face` rules should still precede the `--serif`/`--sans-serif`
+    // font lists that reference them.
+    expect(css.indexOf('@font-face')).toBeLessThan(css.indexOf('--serif:'));
   });
 
   it('emits one @font-face per loaded font', () => {

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -347,7 +347,6 @@ const getPageLayoutStyles = (
   writingMode: string,
   vertical: boolean,
 ) => `
-  @namespace epub "http://www.idpf.org/2007/ops";
   html {
     --margin-top: ${marginTop}px;
     --margin-right: ${marginRight}px;
@@ -867,7 +866,13 @@ export const getStyles = (
   const warichuStyles = getWarichuStyles();
   const rubyStyles = getRubyStyles();
   const userStylesheet = viewSettings.userStylesheet!;
-  return `${customFontFaces}\n${pageLayoutStyles}\n${paragraphLayoutStyles}\n${fontStyles}\n${colorStyles}\n${translationStyles}\n${warichuStyles}\n${rubyStyles}\n${userStylesheet}`;
+  // The `@namespace` declaration must lead the stylesheet: a `@namespace` rule
+  // placed after any style or `@font-face` rule is invalid and silently ignored,
+  // which drops the namespaced `aside[epub|type~="footnote"]` selector and lets
+  // the footnote aside's border show as a stray horizontal line (#4438). Keep it
+  // ahead of the inlined custom `@font-face` rules.
+  const epubNamespace = `@namespace epub "http://www.idpf.org/2007/ops";`;
+  return `${epubNamespace}\n${customFontFaces}\n${pageLayoutStyles}\n${paragraphLayoutStyles}\n${fontStyles}\n${colorStyles}\n${translationStyles}\n${warichuStyles}\n${rubyStyles}\n${userStylesheet}`;
 };
 
 // Build a CSS chunk of `@font-face` rules for the given user custom


### PR DESCRIPTION
## Summary

Fixes #4438 — a v0.11.4 regression where a stray horizontal line appears below the footnote/annotation marker.

The footnote `<aside epub:type="footnote">` carries `border: 3px #333 double` in the book's CSS, and Readest hides it with a namespaced selector:

```css
@namespace epub "http://www.idpf.org/2007/ops";
aside[epub|type~="footnote"] { display: none; }
```

PR #4383 (inline custom `@font-face` rules) changed the stylesheet assembly in `getStyles` to prepend `${customFontFaces}` **before** `${pageLayoutStyles}` — and the `@namespace epub` declaration lived *inside* `getPageLayoutStyles`.

Per the CSS spec, a `@namespace` rule is honored **only if it precedes every style and `@font-face` rule**; a misplaced one is silently ignored. The inlined `@font-face` rules pushed `@namespace` down, so it was dropped, the namespaced `aside[epub|type~="footnote"]` selector became invalid, `display: none` never applied, and the aside's double border rendered as the horizontal line.

This only affected users **with custom fonts loaded** — otherwise `customFontFaces` is empty and `@namespace` stayed first, which matches "worked in previous versions."

## Fix

Hoist the `@namespace epub` declaration to the very front of the assembled stylesheet (ahead of the inlined custom `@font-face` rules) and remove it from `getPageLayoutStyles`. Custom faces still precede the `--serif`/`--sans-serif` font lists that reference them, preserving #4383's first-paint behavior.

## Verification

- **Reproduced and confirmed in real Chromium** against the reported book's actual CSS, loaded as XHTML: the v0.11.4 ordering renders the aside as `display: block` with `border-top: 3px double` (the line); the fixed ordering renders it `display: none` (no line).
  - Gotcha: `epub:type` is a *namespaced* attribute only under XHTML/XML parsing (how foliate loads EPUB content), so the repro must use `data:application/xhtml+xml` — `page.setContent` parses as HTML and won't reproduce.
- Test-first: corrected the existing test that asserted the buggy order (`@font-face` before `@namespace`), added a `#4438` regression test, and kept a test ensuring custom `@font-face` still precedes the font-family lists.
- `pnpm test` → 5213 passed, 8 skipped. `pnpm lint` → clean. No `src-tauri`/koplugin changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)