### PR TITLE
ci: single, workspace-aware rust-cache for build_tauri_app

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -300,8 +300,19 @@ jobs:
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: tauri-cargo
+          # cache-workspace-crates caches the path/workspace crates too: the
+          # vendored tauri fork (packages/tauri, packages/tauri-plugins, wired
+          # via [patch.crates-io]) and the local src-tauri/plugins/*. These are
+          # workspace members that rust-cache prunes by default, so the whole
+          # tauri stack — plus every crates.io plugin that depends on the
+          # patched `tauri` — rebuilt on every run. They change only
+          # sporadically (pinned submodules), so caching them is a big win.
+          # The key is bumped (-ws) so the old workspace-crate-less cache is
+          # invalidated and the next run repopulates it with the workspace
+          # crates included.
+          key: tauri-cargo-ws
           cache-all-crates: 'true'
+          cache-workspace-crates: 'true'
 
       - name: Cache apt packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -297,6 +297,10 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           toolchain: stable
+          # Disable this action's built-in rust-cache so the explicit
+          # Swatinem/rust-cache below is the single cache (it's the one
+          # configured with cache-workspace-crates for the vendored tauri fork).
+          cache: false
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:


### PR DESCRIPTION
Two related changes to `build_tauri_app`'s Rust caching.

## 1. Cache the vendored tauri workspace crates

`build_tauri_app` recompiled the entire tauri stack on every run, even with a 100% cache hit on everything else.

**Root cause:** the project uses a *vendored fork* of tauri, wired in the root `Cargo.toml`:

```toml
[patch.crates-io]
tauri = { path = "packages/tauri/crates/tauri" }                  # packages/tauri submodule
tauri-plugin-fs = { path = "packages/tauri-plugins/plugins/fs" }  # packages/tauri-plugins submodule
```

plus four local `src-tauri/plugins/*` path crates. So `tauri`, `tauri-build`, `tauri-codegen`, `tauri-macros`, `tauri-runtime`, `tauri-runtime-wry`, `tauri-utils` and the plugins are all **workspace members**, which `rust-cache` prunes from the cache by default (`cache-workspace-crates: false`). Every crates.io plugin that depends on the patched `tauri` then rebuilds transitively; unrelated deps stay cached.

**Fix:** `cache-workspace-crates: 'true'` (upstream recommends it for "a workspace that contains libraries that are only updated **sporadically**" — exactly these pinned submodules), and bump the key `tauri-cargo → tauri-cargo-ws` (rust-cache won't re-save on a full key match, and the option isn't part of the key, so without the bump it'd be a no-op). cargo's fingerprints still rebuild anything whose source actually changed.

## 2. Keep a single rust-cache

`build_tauri_app` ran **two** rust-cache actions: `actions-rust-lang/setup-rust-toolchain`'s built-in one (`cache-workspace-crates: false`) on top of the explicit `Swatinem/rust-cache`. They doubled cache storage and competed over the shared `target/`. Set `cache: false` on `setup-rust-toolchain` so the explicit, workspace-aware cache is the only one.

**Note:** the first run after merge is a full rebuild (new key → cache miss) that repopulates the cache; subsequent runs reuse the cached tauri stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)