### PR TITLE
fix(reader): texture the scrolled-mode top inset mask

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/components/SectionInfo.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/SectionInfo.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import SectionInfo from '@/app/reader/components/SectionInfo';
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: { isAndroidApp: false, isMobile: true } }),
+}));
+
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({ systemUIVisible: false, statusBarHeight: 0 }),
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    hoveredBookKey: '',
+    getView: () => null,
+    getViewSettings: () => ({ marginTopPx: 44 }),
+    setHoveredBookKey: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+const baseProps = {
+  bookKey: 'book-1',
+  section: 'Chapter 1',
+  showDoubleBorder: false,
+  isScrolled: true,
+  isVertical: false,
+  isEink: false,
+  horizontalGap: 5,
+  contentInsets: { top: 89, right: 0, bottom: 0, left: 0 },
+  gridInsets: { top: 45, right: 0, bottom: 0, left: 0 },
+};
+
+describe('SectionInfo notch mask', () => {
+  it('spans the grid cell and clips to the top inset so its texture aligns with the viewer (#4486)', () => {
+    // The scrolled-mode notch mask hides content scrolling under the status bar,
+    // but must not occlude the background texture. Its texture ::before only
+    // tile-aligns with .foliate-viewer::before (background-size cover/contain
+    // resolves against the element box) if the notch shares the viewer's paint
+    // box: full grid cell, with the visible/hit area clipped to the inset strip.
+    const { container } = render(<SectionInfo {...baseProps} />);
+    const notch = container.querySelector('.notch-area') as HTMLElement;
+
+    expect(notch).not.toBeNull();
+    expect(notch.classList.contains('inset-0')).toBe(true);
+    expect(notch.classList.contains('notch-masked')).toBe(true);
+    expect(notch.classList.contains('bg-base-100')).toBe(true);
+    expect(notch.style.clipPath).toBe('inset(0 0 calc(100% - 45px) 0)');
+  });
+
+  it('keeps the notch transparent and untextured in paginated mode', () => {
+    const { container } = render(<SectionInfo {...baseProps} isScrolled={false} />);
+    const notch = container.querySelector('.notch-area') as HTMLElement;
+
+    expect(notch.classList.contains('notch-masked')).toBe(false);
+    expect(notch.classList.contains('bg-base-100')).toBe(false);
+  });
+
+  it('keeps the notch transparent and untextured in vertical scrolled mode', () => {
+    const { container } = render(<SectionInfo {...baseProps} isVertical={true} />);
+    const notch = container.querySelector('.notch-area') as HTMLElement;
+
+    expect(notch.classList.contains('notch-masked')).toBe(false);
+    expect(notch.classList.contains('bg-base-100')).toBe(false);
+  });
+});

--- a/apps/readest-app/src/__tests__/styles/textures.test.ts
+++ b/apps/readest-app/src/__tests__/styles/textures.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mountBackgroundTexture, unmountBackgroundTexture } from '@/styles/textures';
+
+afterEach(() => {
+  unmountBackgroundTexture(document);
+});
+
+describe('mountBackgroundTexture', () => {
+  it('covers the scrolled-mode notch mask so the top inset strip is textured (#4486)', () => {
+    mountBackgroundTexture(document, {
+      id: 'paper',
+      name: 'Paper',
+      url: '/images/paper-texture.png',
+    });
+
+    const style = document.getElementById('background-texture');
+    expect(style?.textContent).toContain('.notch-masked::before');
+  });
+});

--- a/apps/readest-app/src/app/reader/components/SectionInfo.tsx
+++ b/apps/readest-app/src/app/reader/components/SectionInfo.tsx
@@ -56,14 +56,20 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
     <>
       <div
         className={clsx(
-          'notch-area absolute left-0 right-0 top-0 z-10',
-          isScrolled && !isVertical && 'bg-base-100',
+          // Spans the grid cell and clips down to the top inset strip so the
+          // texture ::before (.notch-masked, see styles/textures.ts) shares
+          // .foliate-viewer::before's paint box — background-size cover/contain
+          // resolves against the element box, so a strip-sized box would
+          // mis-tile at the seam (#4486). clip-path also clips hit-testing,
+          // keeping the click target the inset strip only.
+          'notch-area absolute inset-0 z-10',
+          isScrolled && !isVertical && 'notch-masked bg-base-100',
         )}
         role='none'
         tabIndex={-1}
         onClick={handleNotchClick}
         style={{
-          height: `${topInset}px`,
+          clipPath: `inset(0 0 calc(100% - ${topInset}px) 0)`,
         }}
       />
       <div

--- a/apps/readest-app/src/styles/textures.ts
+++ b/apps/readest-app/src/styles/textures.ts
@@ -94,7 +94,7 @@ const createTextureCSS = (texture: BackgroundTexture) => {
     }
 
     body::before, .sidebar-container::before, .notebook-container::before,
-    .foliate-viewer::before {
+    .foliate-viewer::before, .notch-masked::before {
       content: "";
       position: absolute;
       top: 0;


### PR DESCRIPTION
Closes #4486

## Problem

In scrolled mode with a background texture, the top safe-area (unsafe header) strip renders as a flat untextured block (reporter's screenshot, and reproduced on a Xiaomi 13):

The `notch-area` div in `SectionInfo` masks the top inset with opaque `bg-base-100` at `z-10` so content scrolling under the status bar is hidden — but the texture paints at the z-0 layer (`.foliate-viewer::before`), so the mask occludes it.

## Fix

- Give the mask its own texture overlay: add `.notch-masked::before` to the texture CSS in `styles/textures.ts` (gated to the scrolled-horizontal case via a conditional class, so the paginated/vertical transparent notch is untouched).
- Make the notch element span the grid cell (`inset-0`) and clip its visible/hit area down to the inset strip with `clip-path: inset(0 0 calc(100% - topInset) 0)`. `background-size: cover/contain` resolves against the element box, so sharing the viewer's paint box is what keeps the mask's texture tiles aligned with `.foliate-viewer::before` at the seam. `clip-path` also clips hit-testing, so the click target stays the inset strip, exactly as before.
- `mix-blend-mode: multiply` blends against the notch's own opaque `bg-base-100` inside its z-10 stacking context — identical color math to the viewer area below.

## Verification on a Xiaomi 13 (fuxi)

Drove the installed app over adb + CDP with scrolled mode + Leaves texture (`cover`):

- Before: flat strip over the inset; the strip→texture boundary measures row-to-row MAE 11913 (hard seam).
- After applying the exact CSS this change produces: the strip renders the texture and the same boundary measures MAE 230 — the level of ordinary adjacent texture rows, i.e. pixel-continuous tiles.
- `elementsFromPoint`: the notch is hit-testable inside the strip and absent from the stack mid-screen, so content taps are unaffected.

## Tests

- `SectionInfo.test.tsx`: notch spans the cell, clips to the inset, and carries `notch-masked` only in scrolled horizontal mode (transparent notch in paginated/vertical stays untextured).
- `textures.test.ts`: mounted texture CSS covers `.notch-masked::before`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)