### PR TITLE
fix(reader): keep dark-mode page body transparent so the bg texture shows

### DIFF
--- a/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
@@ -580,6 +580,24 @@ describe('getColorStyles branches (via getStyles)', () => {
     expect(css).toContain('body.theme-dark');
   });
 
+  it('keeps body.theme-dark transparent in dark mode so the host background texture is not occluded (#4446)', () => {
+    const vs = makeViewSettings({ overrideColor: false, backgroundTextureId: 'leaves' });
+    const theme = makeThemeCode({ isDarkMode: true, bg: '#1a1a1a', fg: '#e0e0e0' });
+    const css = getStyles(vs, theme);
+    expect(css).toMatch(/body\.theme-dark\s*\{\s*background-color: transparent !important;/);
+    expect(css).not.toMatch(/body\.theme-dark\s*\{\s*background-color: #1a1a1a !important/);
+    // #4392 inline light-callout overrides must keep forcing the theme bg
+    expect(css).toContain('background-color: #fff"]');
+    expect(css).toContain('background-color: #1a1a1a !important');
+  });
+
+  it('keeps body.theme-dark transparent even without a texture (docBackground is captured once per section load)', () => {
+    const vs = makeViewSettings({ overrideColor: false, backgroundTextureId: 'none' });
+    const theme = makeThemeCode({ isDarkMode: true, bg: '#1a1a1a', fg: '#e0e0e0' });
+    const css = getStyles(vs, theme);
+    expect(css).toMatch(/body\.theme-dark\s*\{\s*background-color: transparent !important;/);
+  });
+
   it('does not add inline white background overrides in light mode', () => {
     const vs = makeViewSettings({ overrideColor: false });
     const theme = makeThemeCode({ isDarkMode: false });

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -191,8 +191,14 @@ const getDarkModeLightBackgroundOverrides = (bg: string) => `
     *[style*="background: rgb(255"], *[style*="background:rgb(255"] {
       background-color: ${bg} !important;
     }
+    /* Force transparent, not the theme bg: the dark page fill already comes from
+       the paginator container / reader grid cell, while an opaque body paints over
+       the host background texture (#4446) — and foliate captures docBackground once
+       per section load, so the body must stay transparent regardless of texture
+       state. Book-forced light page backgrounds still get neutralized (#4392) since
+       the theme-dark fill shows through. */
     body.theme-dark {
-      background-color: ${bg} !important;
+      background-color: transparent !important;
     }
 `;
 


### PR DESCRIPTION
Closes #4446 (the remaining dark-mode case; the light-mode case was fixed by #4417).

## Symptom

With a background texture selected in dark mode, the texture is absent from the whole reader page in paginated mode, and absent from the main text area in scrolled mode (while header/footer strips still show it).

## Root cause

`176b950c9` (#4392, shipped v0.11.4) added a dark-mode catch-all:

```css
body.theme-dark { background-color: ${bg} !important; }
```

This paints every section iframe's body with the opaque theme bg, which:

1. directly occludes the host texture layer (`.foliate-viewer::before`, z-0 under the foliate view tree — same occlusion model as #4399), and
2. poisons foliate's `docBackground` capture (`getBackground` reads the body's computed background at section load), so `textureAwareBackground` keeps the paginated `#background` segments and scrolled view-element backgrounds opaque as well.

In scrolled mode the iframes only cover the text column, so the header/footer strips kept their texture — hence the asymmetry.

## Fix

Force `transparent` instead of the theme bg. The dark page fill already comes from the paginator container (`fallbackBg`) / reader grid cell, so the no-texture rendering is visually identical, and #4392's purpose is preserved: book-forced light page backgrounds are still neutralized because the theme-dark fill shows through. The inline light-callout overrides and the stylesheet rewriter from #4392 are untouched.

The rule is deliberately **not** gated on a texture being active: foliate captures `docBackground` once per section load and `setStyles` never re-captures, so a texture-gated body background would go stale when toggling a texture mid-session.

## Verification

- New unit tests (failing before the fix) in `style-get-styles.test.ts`; full suite + lint + format pass.
- Verified live on a Xiaomi 2211133C (Android 16, WebView 147): with the fix, the load-time capture resolves transparent, the paginated segment list comes out empty, and the texture renders in both paginated and scrolled dark mode. Confirmed independently on-device by @chrox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)