### PR TITLE
fix(android): launch installed dictionary for system lookup, closes #4559

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -1842,5 +1842,7 @@
   "Look up": "بحث",
   "Search on Goodreads": "البحث في Goodreads",
   "Reference Pages": "صفحات مرجعية",
-  "Reference Page Count": "عدد الصفحات المرجعية"
+  "Reference Page Count": "عدد الصفحات المرجعية",
+  "Lookup app reset. The next lookup will ask again.": "تمت إعادة تعيين تطبيق البحث. سيُطلب منك الاختيار في المرة التالية.",
+  "System Lookup App": "تطبيق البحث في النظام"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1710,5 +1710,7 @@
   "Look up": "খুঁজুন",
   "Search on Goodreads": "Goodreads-এ অনুসন্ধান করুন",
   "Reference Pages": "রেফারেন্স পৃষ্ঠা",
-  "Reference Page Count": "রেফারেন্স পৃষ্ঠার সংখ্যা"
+  "Reference Page Count": "রেফারেন্স পৃষ্ঠার সংখ্যা",
+  "Lookup app reset. The next lookup will ask again.": "লুকআপ অ্যাপ রিসেট করা হয়েছে। পরবর্তী লুকআপে আবার জিজ্ঞাসা করা হবে।",
+  "System Lookup App": "সিস্টেম লুকআপ অ্যাপ"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1677,5 +1677,7 @@
   "Look up": "འཚོལ་བ།",
   "Search on Goodreads": "Goodreads ནང་འཚོལ།",
   "Reference Pages": "དཔེ་སྟོན་ཤོག་ངོས།",
-  "Reference Page Count": "དཔེ་སྟོན་ཤོག་ངོས་ཀྱི་གྲངས།"
+  "Reference Page Count": "དཔེ་སྟོན་ཤོག་ངོས་ཀྱི་གྲངས།",
+  "Lookup app reset. The next lookup will ask again.": "འཚོལ་བཤེར་ཉེར་སྤྱོད་བསྐྱར་སྒྲིག་བྱས་ཟིན། རྗེས་མའི་འཚོལ་བཤེར་སྐབས་སླར་ཡང་འདྲི་ངེས།",
+  "System Lookup App": "རྒྱུད་ཁོངས་འཚོལ་བཤེར་ཉེར་སྤྱོད།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1710,5 +1710,7 @@
   "Look up": "Nachschlagen",
   "Search on Goodreads": "Auf Goodreads suchen",
   "Reference Pages": "Referenzseiten",
-  "Reference Page Count": "Anzahl der Referenzseiten"
+  "Reference Page Count": "Anzahl der Referenzseiten",
+  "Lookup app reset. The next lookup will ask again.": "Nachschlage-App zurückgesetzt. Bei der nächsten Suche wird erneut gefragt.",
+  "System Lookup App": "System-Nachschlage-App"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1710,5 +1710,7 @@
   "Look up": "Αναζήτηση",
   "Search on Goodreads": "Αναζήτηση στο Goodreads",
   "Reference Pages": "Σελίδες αναφοράς",
-  "Reference Page Count": "Αριθμός σελίδων αναφοράς"
+  "Reference Page Count": "Αριθμός σελίδων αναφοράς",
+  "Lookup app reset. The next lookup will ask again.": "Η εφαρμογή αναζήτησης επαναφέρθηκε. Στην επόμενη αναζήτηση θα ερωτηθείτε ξανά.",
+  "System Lookup App": "Εφαρμογή αναζήτησης συστήματος"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1743,5 +1743,7 @@
   "Look up": "Buscar",
   "Search on Goodreads": "Buscar en Goodreads",
   "Reference Pages": "Páginas de referencia",
-  "Reference Page Count": "Número de páginas de referencia"
+  "Reference Page Count": "Número de páginas de referencia",
+  "Lookup app reset. The next lookup will ask again.": "Se restableció la app de búsqueda. La próxima vez se preguntará de nuevo.",
+  "System Lookup App": "App de búsqueda del sistema"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1710,5 +1710,7 @@
   "Look up": "جستجو",
   "Search on Goodreads": "جستجو در Goodreads",
   "Reference Pages": "صفحات مرجع",
-  "Reference Page Count": "تعداد صفحات مرجع"
+  "Reference Page Count": "تعداد صفحات مرجع",
+  "Lookup app reset. The next lookup will ask again.": "برنامهٔ جستجو بازنشانی شد. در جستجوی بعدی دوباره پرسیده می‌شود.",
+  "System Lookup App": "برنامهٔ جستجوی سیستم"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1743,5 +1743,7 @@
   "Look up": "Rechercher",
   "Search on Goodreads": "Rechercher sur Goodreads",
   "Reference Pages": "Pages de référence",
-  "Reference Page Count": "Nombre de pages de référence"
+  "Reference Page Count": "Nombre de pages de référence",
+  "Lookup app reset. The next lookup will ask again.": "Application de recherche réinitialisée. La prochaine recherche redemandera.",
+  "System Lookup App": "Application de recherche système"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1743,5 +1743,7 @@
   "Look up": "חיפוש",
   "Search on Goodreads": "חיפוש ב-Goodreads",
   "Reference Pages": "עמודי ייחוס",
-  "Reference Page Count": "מספר עמודי ייחוס"
+  "Reference Page Count": "מספר עמודי ייחוס",
+  "Lookup app reset. The next lookup will ask again.": "אפליקציית החיפוש אופסה. בחיפוש הבא תוצג שאלה שוב.",
+  "System Lookup App": "אפליקציית חיפוש מערכת"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1710,5 +1710,7 @@
   "Look up": "खोजें",
   "Search on Goodreads": "Goodreads पर खोजें",
   "Reference Pages": "संदर्भ पृष्ठ",
-  "Reference Page Count": "संदर्भ पृष्ठ संख्या"
+  "Reference Page Count": "संदर्भ पृष्ठ संख्या",
+  "Lookup app reset. The next lookup will ask again.": "लुकअप ऐप रीसेट कर दिया गया। अगली बार फिर से पूछा जाएगा।",
+  "System Lookup App": "सिस्टम लुकअप ऐप"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1710,5 +1710,7 @@
   "Look up": "Keresés",
   "Search on Goodreads": "Keresés a Goodreadson",
   "Reference Pages": "Referenciaoldalak",
-  "Reference Page Count": "Referenciaoldalak száma"
+  "Reference Page Count": "Referenciaoldalak száma",
+  "Lookup app reset. The next lookup will ask again.": "A keresőalkalmazás visszaállítva. A következő keresésnél újra rákérdez.",
+  "System Lookup App": "Rendszer keresőalkalmazás"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1677,5 +1677,7 @@
   "Look up": "Cari",
   "Search on Goodreads": "Cari di Goodreads",
   "Reference Pages": "Halaman referensi",
-  "Reference Page Count": "Jumlah halaman referensi"
+  "Reference Page Count": "Jumlah halaman referensi",
+  "Lookup app reset. The next lookup will ask again.": "Aplikasi pencarian disetel ulang. Pencarian berikutnya akan menanyakan lagi.",
+  "System Lookup App": "Aplikasi pencarian sistem"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1743,5 +1743,7 @@
   "Look up": "Cerca",
   "Search on Goodreads": "Cerca su Goodreads",
   "Reference Pages": "Pagine di riferimento",
-  "Reference Page Count": "Numero di pagine di riferimento"
+  "Reference Page Count": "Numero di pagine di riferimento",
+  "Lookup app reset. The next lookup will ask again.": "App di ricerca reimpostata. Alla prossima ricerca verrà richiesto di nuovo.",
+  "System Lookup App": "App di ricerca di sistema"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1677,5 +1677,7 @@
   "Look up": "調べる",
   "Search on Goodreads": "Goodreadsで検索",
   "Reference Pages": "参照ページ",
-  "Reference Page Count": "参照ページ数"
+  "Reference Page Count": "参照ページ数",
+  "Lookup app reset. The next lookup will ask again.": "検索アプリをリセットしました。次回の検索時に再度確認します。",
+  "System Lookup App": "システム検索アプリ"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1677,5 +1677,7 @@
   "Look up": "찾기",
   "Search on Goodreads": "Goodreads에서 검색",
   "Reference Pages": "참조 페이지",
-  "Reference Page Count": "참조 페이지 수"
+  "Reference Page Count": "참조 페이지 수",
+  "Lookup app reset. The next lookup will ask again.": "검색 앱을 초기화했습니다. 다음 검색 시 다시 묻습니다.",
+  "System Lookup App": "시스템 검색 앱"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1677,5 +1677,7 @@
   "Look up": "Cari",
   "Search on Goodreads": "Cari di Goodreads",
   "Reference Pages": "Halaman rujukan",
-  "Reference Page Count": "Bilangan halaman rujukan"
+  "Reference Page Count": "Bilangan halaman rujukan",
+  "Lookup app reset. The next lookup will ask again.": "Apl carian ditetapkan semula. Carian seterusnya akan bertanya lagi.",
+  "System Lookup App": "Apl carian sistem"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1710,5 +1710,7 @@
   "Look up": "Opzoeken",
   "Search on Goodreads": "Zoeken op Goodreads",
   "Reference Pages": "Referentiepagina's",
-  "Reference Page Count": "Aantal referentiepagina's"
+  "Reference Page Count": "Aantal referentiepagina's",
+  "Lookup app reset. The next lookup will ask again.": "Opzoekapp gereset. De volgende keer wordt het opnieuw gevraagd.",
+  "System Lookup App": "Systeem-opzoekapp"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1776,5 +1776,7 @@
   "Look up": "Wyszukaj",
   "Search on Goodreads": "Szukaj w Goodreads",
   "Reference Pages": "Strony referencyjne",
-  "Reference Page Count": "Liczba stron referencyjnych"
+  "Reference Page Count": "Liczba stron referencyjnych",
+  "Lookup app reset. The next lookup will ask again.": "Zresetowano aplikację wyszukiwania. Przy następnym wyszukiwaniu zapyta ponownie.",
+  "System Lookup App": "Aplikacja wyszukiwania systemowego"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1743,5 +1743,7 @@
   "Look up": "Pesquisar",
   "Search on Goodreads": "Pesquisar no Goodreads",
   "Reference Pages": "Páginas de referência",
-  "Reference Page Count": "Número de páginas de referência"
+  "Reference Page Count": "Número de páginas de referência",
+  "Lookup app reset. The next lookup will ask again.": "App de busca redefinido. Na próxima busca, será perguntado novamente.",
+  "System Lookup App": "App de busca do sistema"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1743,5 +1743,7 @@
   "Look up": "Pesquisar",
   "Search on Goodreads": "Pesquisar no Goodreads",
   "Reference Pages": "Páginas de referência",
-  "Reference Page Count": "Número de páginas de referência"
+  "Reference Page Count": "Número de páginas de referência",
+  "Lookup app reset. The next lookup will ask again.": "App de pesquisa redefinida. Na próxima pesquisa será perguntado novamente.",
+  "System Lookup App": "App de pesquisa do sistema"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1743,5 +1743,7 @@
   "Look up": "Caută",
   "Search on Goodreads": "Caută pe Goodreads",
   "Reference Pages": "Pagini de referință",
-  "Reference Page Count": "Numărul paginilor de referință"
+  "Reference Page Count": "Numărul paginilor de referință",
+  "Lookup app reset. The next lookup will ask again.": "Aplicația de căutare a fost resetată. La următoarea căutare se va întreba din nou.",
+  "System Lookup App": "Aplicație de căutare a sistemului"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1776,5 +1776,7 @@
   "Look up": "Найти",
   "Search on Goodreads": "Искать в Goodreads",
   "Reference Pages": "Страницы бумажной книги",
-  "Reference Page Count": "Число страниц бумажной книги"
+  "Reference Page Count": "Число страниц бумажной книги",
+  "Lookup app reset. The next lookup will ask again.": "Приложение для поиска сброшено. При следующем поиске запрос появится снова.",
+  "System Lookup App": "Системное приложение для поиска"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1710,5 +1710,7 @@
   "Look up": "සොයන්න",
   "Search on Goodreads": "Goodreads හි සොයන්න",
   "Reference Pages": "යොමු පිටු",
-  "Reference Page Count": "යොමු පිටු ගණන"
+  "Reference Page Count": "යොමු පිටු ගණන",
+  "Lookup app reset. The next lookup will ask again.": "සෙවුම් යෙදුම යළි සකසන ලදී. ඊළඟ සෙවුමේදී නැවත අසනු ඇත.",
+  "System Lookup App": "පද්ධති සෙවුම් යෙදුම"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1776,5 +1776,7 @@
   "Look up": "Poišči",
   "Search on Goodreads": "Išči v Goodreads",
   "Reference Pages": "Referenčne strani",
-  "Reference Page Count": "Število referenčnih strani"
+  "Reference Page Count": "Število referenčnih strani",
+  "Lookup app reset. The next lookup will ask again.": "Aplikacija za iskanje je ponastavljena. Ob naslednjem iskanju bo znova vprašala.",
+  "System Lookup App": "Sistemska aplikacija za iskanje"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1710,5 +1710,7 @@
   "Look up": "Slå upp",
   "Search on Goodreads": "Sök på Goodreads",
   "Reference Pages": "Referenssidor",
-  "Reference Page Count": "Antal referenssidor"
+  "Reference Page Count": "Antal referenssidor",
+  "Lookup app reset. The next lookup will ask again.": "Uppslagsappen återställd. Nästa sökning frågar igen.",
+  "System Lookup App": "Systemets uppslagsapp"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1710,5 +1710,7 @@
   "Look up": "தேடு",
   "Search on Goodreads": "Goodreads இல் தேடு",
   "Reference Pages": "குறிப்புப் பக்கங்கள்",
-  "Reference Page Count": "குறிப்புப் பக்கங்களின் எண்ணிக்கை"
+  "Reference Page Count": "குறிப்புப் பக்கங்களின் எண்ணிக்கை",
+  "Lookup app reset. The next lookup will ask again.": "தேடல் செயலி மீட்டமைக்கப்பட்டது. அடுத்த தேடலில் மீண்டும் கேட்கப்படும்.",
+  "System Lookup App": "கணினி தேடல் செயலி"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1677,5 +1677,7 @@
   "Look up": "ค้นหา",
   "Search on Goodreads": "ค้นหาใน Goodreads",
   "Reference Pages": "หน้าอ้างอิง",
-  "Reference Page Count": "จำนวนหน้าอ้างอิง"
+  "Reference Page Count": "จำนวนหน้าอ้างอิง",
+  "Lookup app reset. The next lookup will ask again.": "รีเซ็ตแอปค้นหาแล้ว การค้นหาครั้งถัดไปจะถามอีกครั้ง",
+  "System Lookup App": "แอปค้นหาของระบบ"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1710,5 +1710,7 @@
   "Look up": "Ara",
   "Search on Goodreads": "Goodreads'te ara",
   "Reference Pages": "Referans sayfaları",
-  "Reference Page Count": "Referans sayfa sayısı"
+  "Reference Page Count": "Referans sayfa sayısı",
+  "Lookup app reset. The next lookup will ask again.": "Arama uygulaması sıfırlandı. Sonraki aramada tekrar sorulacak.",
+  "System Lookup App": "Sistem arama uygulaması"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1776,5 +1776,7 @@
   "Look up": "Знайти",
   "Search on Goodreads": "Шукати в Goodreads",
   "Reference Pages": "Сторінки паперової книги",
-  "Reference Page Count": "Кількість сторінок паперової книги"
+  "Reference Page Count": "Кількість сторінок паперової книги",
+  "Lookup app reset. The next lookup will ask again.": "Застосунок для пошуку скинуто. Під час наступного пошуку буде запит знову.",
+  "System Lookup App": "Системний застосунок для пошуку"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1710,5 +1710,7 @@
   "Look up": "Qidirish",
   "Search on Goodreads": "Goodreads'da qidirish",
   "Reference Pages": "Bosma sahifalar",
-  "Reference Page Count": "Bosma sahifalar soni"
+  "Reference Page Count": "Bosma sahifalar soni",
+  "Lookup app reset. The next lookup will ask again.": "Qidiruv ilovasi tiklandi. Keyingi qidiruvda yana so‘raladi.",
+  "System Lookup App": "Tizim qidiruv ilovasi"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1677,5 +1677,7 @@
   "Look up": "Tra cứu",
   "Search on Goodreads": "Tìm trên Goodreads",
   "Reference Pages": "Trang tham chiếu",
-  "Reference Page Count": "Số trang tham chiếu"
+  "Reference Page Count": "Số trang tham chiếu",
+  "Lookup app reset. The next lookup will ask again.": "Đã đặt lại ứng dụng tra cứu. Lần tra cứu tiếp theo sẽ hỏi lại.",
+  "System Lookup App": "Ứng dụng tra cứu hệ thống"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1677,5 +1677,7 @@
   "Look up": "查询",
   "Search on Goodreads": "在 Goodreads 中搜索",
   "Reference Pages": "参考页码",
-  "Reference Page Count": "参考总页数"
+  "Reference Page Count": "参考总页数",
+  "Lookup app reset. The next lookup will ask again.": "已重置查词应用。下次查词时将再次询问。",
+  "System Lookup App": "系统查词应用"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1677,5 +1677,7 @@
   "Look up": "查詢",
   "Search on Goodreads": "在 Goodreads 搜尋",
   "Reference Pages": "參考頁碼",
-  "Reference Page Count": "參考總頁數"
+  "Reference Page Count": "參考總頁數",
+  "Lookup app reset. The next lookup will ask again.": "已重設查詞應用程式。下次查詞時將再次詢問。",
+  "System Lookup App": "系統查詞應用程式"
 }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/AndroidManifest.xml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/AndroidManifest.xml
@@ -1,3 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Make dictionary / text-processing apps (Eudic, 欧路词典, GoldenDict,
+         Pleco, etc.) visible to queryIntentActivities under Android 11+
+         package-visibility filtering. Without this declaration only the
+         automatically-visible apps (web browsers) resolve
+         ACTION_PROCESS_TEXT, so dictionary lookups land in the system
+         browser on some OEM ROMs even when a dictionary is installed
+         (issue #4559). -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.PROCESS_TEXT" />
+            <data android:mimeType="text/plain" />
+        </intent>
+    </queries>
+
+    <application>
+        <!-- Receives the EXTRA_CHOSEN_COMPONENT callback from the
+             browser-excluding dictionary chooser so the user's pick is
+             remembered and launched directly on subsequent lookups. -->
+        <receiver
+            android:name="com.readest.native_bridge.LookupChoiceReceiver"
+            android:exported="false" />
+    </application>
 </manifest>

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/LookupChoiceReceiver.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/LookupChoiceReceiver.kt
@@ -1,0 +1,38 @@
+package com.readest.native_bridge
+
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+
+/** Plain (non-encrypted) prefs file holding the remembered lookup app. */
+internal const val LOOKUP_PREFS_NAME = "readest_lookup_dictionary_v1"
+internal const val LOOKUP_PREF_PACKAGE = "package"
+internal const val LOOKUP_PREF_CLASS = "class"
+
+/**
+ * Receives the `EXTRA_CHOSEN_COMPONENT` callback fired by the
+ * browser-excluding dictionary chooser (see
+ * [NativeBridgePlugin.show_lookup_popover]). The system reports which
+ * activity the user tapped; we persist it so the next lookup launches
+ * that dictionary directly instead of re-showing the chooser — the
+ * app-managed equivalent of the system's "Always" affordance, which
+ * `ACTION_CHOOSER` itself doesn't offer.
+ */
+class LookupChoiceReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val chosen = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(Intent.EXTRA_CHOSEN_COMPONENT, ComponentName::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(Intent.EXTRA_CHOSEN_COMPONENT) as? ComponentName
+        } ?: return
+
+        context.getSharedPreferences(LOOKUP_PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(LOOKUP_PREF_PACKAGE, chosen.packageName)
+            .putString(LOOKUP_PREF_CLASS, chosen.className)
+            .apply()
+    }
+}

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/LookupDispatch.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/LookupDispatch.kt
@@ -1,0 +1,81 @@
+package com.readest.native_bridge
+
+/**
+ * Pure decision logic for routing a dictionary `ACTION_PROCESS_TEXT`
+ * lookup, factored out of [NativeBridgePlugin.show_lookup_popover] so it
+ * can be unit-tested without an Android framework or device.
+ *
+ * The problem this solves (issue #4559): on some OEM ROMs (VIVO / iQOO
+ * OriginOS) the system browser registers an activity for
+ * `ACTION_PROCESS_TEXT` and is the system default, so a plain
+ * `startActivity` hands the selected word to the browser instead of a
+ * dictionary app. A web browser handling "process text" is never what a
+ * "dictionary lookup" wants, so we filter browsers out of the handler
+ * set and route to a real dictionary instead.
+ */
+
+/** A resolved `ACTION_PROCESS_TEXT` handler activity. */
+data class LookupHandler(val packageName: String, val className: String)
+
+/** How [NativeBridgePlugin.show_lookup_popover] should dispatch the intent. */
+sealed class LookupDispatch {
+    /** No app handles the lookup (or only browsers do) — surface the "no dictionary app" hint. */
+    object Unavailable : LookupDispatch()
+
+    /**
+     * No browser is hijacking the intent — dispatch implicitly and let
+     * the OS do exactly what it does today (single handler goes straight
+     * through; multiple handlers show the system disambiguation dialog
+     * with its native "Just once / Always" buttons).
+     */
+    object DispatchImplicit : LookupDispatch()
+
+    /** Exactly one dictionary remains (or one was remembered) — launch it directly. */
+    data class DispatchExplicit(val handler: LookupHandler) : LookupDispatch()
+
+    /**
+     * Several dictionaries remain behind a browser default — show a
+     * chooser that excludes [exclude] (the browser handlers) so the
+     * browser can't be picked, and remember whatever the user taps.
+     */
+    data class DispatchChooser(val exclude: List<LookupHandler>) : LookupDispatch()
+}
+
+/**
+ * Decide how to dispatch the lookup.
+ *
+ * @param handlers every activity that resolves `ACTION_PROCESS_TEXT` for the word.
+ * @param browserPackages package names of installed web browsers (apps that
+ *   handle an `https` `ACTION_VIEW` + `CATEGORY_BROWSABLE` intent).
+ * @param remembered a dictionary the user previously chose from the
+ *   browser-excluding chooser, or `null`. Honored only if it still appears
+ *   among [handlers] as a non-browser handler.
+ */
+fun decideLookupDispatch(
+    handlers: List<LookupHandler>,
+    browserPackages: Set<String>,
+    remembered: LookupHandler?,
+): LookupDispatch {
+    if (handlers.isEmpty()) return LookupDispatch.Unavailable
+
+    val browsers = handlers.filter { it.packageName in browserPackages }
+    val dictionaries = handlers.filter { it.packageName !in browserPackages }
+
+    // No browser among the handlers: nothing to filter out, so preserve
+    // the existing system-driven behavior (incl. the native "Always"
+    // affordance) untouched.
+    if (browsers.isEmpty()) return LookupDispatch.DispatchImplicit
+
+    return when (dictionaries.size) {
+        0 -> LookupDispatch.Unavailable
+        1 -> LookupDispatch.DispatchExplicit(dictionaries[0])
+        else -> {
+            // A remembered dictionary is only valid if it still resolves
+            // the intent (the app could have been uninstalled or stopped
+            // registering ACTION_PROCESS_TEXT).
+            val saved = remembered?.takeIf { it in dictionaries }
+            if (saved != null) LookupDispatch.DispatchExplicit(saved)
+            else LookupDispatch.DispatchChooser(browsers)
+        }
+    }
+}

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -2,6 +2,9 @@ package com.readest.native_bridge
 
 import android.Manifest
 import android.app.Activity
+import android.app.PendingIntent
+import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.util.Log
@@ -1014,22 +1017,26 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
      * intent (Android 6.0+). This is the same dispatch the system
      * "selection toolbar" uses for "Translate" / "Define" actions, so
      * any third-party dictionary that registers the intent (ColorDict,
-     * GoldenDict, 欧路, Pleco, etc.) shows up without extra work on
+     * GoldenDict, 欧路词典, Pleco, etc.) shows up without extra work on
      * our side.
      *
-     * Important: we deliberately do NOT wrap the intent with
-     * `Intent.createChooser`. Chooser-style dialogs always re-prompt
-     * (no "Always use this app" affordance), which the user found
-     * annoying when they have a single preferred dictionary. Plain
-     * `startActivity(intent)` instead surfaces the standard system
-     * disambiguation dialog with the "Just once / Always" buttons —
-     * picking "Always" makes subsequent lookups go straight to that
-     * app. When only one app handles the intent, Android skips the
-     * picker entirely and launches it directly.
+     * Routing is decided by [decideLookupDispatch], which filters out
+     * web browsers so an OEM browser that registers `ACTION_PROCESS_TEXT`
+     * (VIVO / iQOO OriginOS — issue #4559) can't swallow the lookup:
      *
-     * If no app is installed that responds to the intent, returns
-     * `unavailable: true` instead of throwing — the TS layer surfaces
-     * a hint rather than a generic error in that case.
+     * - **No browser among the handlers** → dispatch implicitly, exactly
+     *   as before. A single handler goes straight through; multiple
+     *   handlers raise the system disambiguation dialog with its native
+     *   "Just once / Always" buttons.
+     * - **Browser + a single dictionary** → launch the dictionary
+     *   directly (explicit component), bypassing the browser default.
+     * - **Browser + several dictionaries** → show a chooser that excludes
+     *   the browser(s) and remember whichever dictionary the user taps
+     *   (see [startBrowserExcludingChooser] / [LookupChoiceReceiver]) so
+     *   later lookups launch it directly.
+     * - **Only a browser (no dictionary installed)** → returns
+     *   `unavailable: true` so the TS layer hints to install a dictionary
+     *   instead of dumping the user into the browser.
      */
     @Command
     fun show_lookup_popover(invoke: Invoke) {
@@ -1048,27 +1055,41 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
                 putExtra(Intent.EXTRA_PROCESS_TEXT_READONLY, true)
             }
 
-            // Probe for handlers before dispatching. An ActivityNotFound
-            // crash is a worse UX than a quiet "no dictionary app"
-            // result; surface the empty case explicitly.
             val pm = activity.packageManager
-            val handlers = pm.queryIntentActivities(intent, 0)
-            if (handlers.isEmpty()) {
-                val ret = JSObject()
-                ret.put("success", false)
-                ret.put("unavailable", true)
-                return invoke.resolve(ret)
+            val handlers = pm.queryIntentActivities(intent, 0).map {
+                LookupHandler(it.activityInfo.packageName, it.activityInfo.name)
             }
+            val browserPackages = queryBrowserPackages(pm)
+            val remembered = readRememberedDictionary()
 
-            // FLAG_ACTIVITY_NEW_TASK is required because `activity`
-            // here is the plugin's host activity context — without it,
-            // some OEM ROMs reject the dispatch with "Calling
-            // startActivity() from outside of an Activity context".
-            // The system disambiguation dialog still appears (with the
-            // Always/Just once buttons) for multi-handler cases; for
-            // single-handler cases it goes straight through.
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            activity.startActivity(intent)
+            when (val dispatch = decideLookupDispatch(handlers, browserPackages, remembered)) {
+                is LookupDispatch.Unavailable -> {
+                    val ret = JSObject()
+                    ret.put("success", false)
+                    ret.put("unavailable", true)
+                    return invoke.resolve(ret)
+                }
+                // FLAG_ACTIVITY_NEW_TASK is required because `activity`
+                // here is the plugin's host activity context — without it
+                // some OEM ROMs reject the dispatch with "Calling
+                // startActivity() from outside of an Activity context".
+                is LookupDispatch.DispatchImplicit -> {
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    activity.startActivity(intent)
+                }
+                is LookupDispatch.DispatchExplicit -> {
+                    intent.setClassName(dispatch.handler.packageName, dispatch.handler.className)
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    activity.startActivity(intent)
+                }
+                is LookupDispatch.DispatchChooser -> {
+                    // We only reach here when the remembered app (if any)
+                    // was stale — otherwise it would have been launched
+                    // directly. Drop it so a fresh pick replaces it.
+                    if (remembered != null) clearRememberedDictionary()
+                    startBrowserExcludingChooser(intent, dispatch.exclude)
+                }
+            }
 
             val ret = JSObject()
             ret.put("success", true)
@@ -1077,6 +1098,98 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
             Log.e("NativeBridgePlugin", "show_lookup_popover failed", e)
             invoke.reject("Failed to look up word: ${e.message}")
         }
+    }
+
+    /**
+     * Package names of installed web browsers — apps with an activity
+     * that handles a web `ACTION_VIEW` + `CATEGORY_BROWSABLE` intent.
+     * Such apps are always visible under Android 11+ package-visibility
+     * rules, so no extra `<queries>` entry is needed here.
+     */
+    private fun queryBrowserPackages(pm: PackageManager): Set<String> {
+        val probe = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.example.com"))
+            .addCategory(Intent.CATEGORY_BROWSABLE)
+        return pm.queryIntentActivities(probe, 0)
+            .map { it.activityInfo.packageName }
+            .toSet()
+    }
+
+    private fun lookupPrefs() =
+        activity.getSharedPreferences(LOOKUP_PREFS_NAME, Context.MODE_PRIVATE)
+
+    private fun readRememberedDictionary(): LookupHandler? {
+        val prefs = lookupPrefs()
+        val pkg = prefs.getString(LOOKUP_PREF_PACKAGE, null) ?: return null
+        val cls = prefs.getString(LOOKUP_PREF_CLASS, null) ?: return null
+        return LookupHandler(pkg, cls)
+    }
+
+    private fun clearRememberedDictionary() {
+        lookupPrefs().edit().remove(LOOKUP_PREF_PACKAGE).remove(LOOKUP_PREF_CLASS).apply()
+    }
+
+    /**
+     * Show the system chooser for [target] with the browser [exclude]
+     * components filtered out (`EXTRA_EXCLUDE_COMPONENTS`, API 24+), and
+     * register an `IntentSender` so the user's pick comes back via
+     * [LookupChoiceReceiver] and is remembered. `ACTION_CHOOSER` has no
+     * native "Always" button, so this re-implements that affordance.
+     */
+    private fun startBrowserExcludingChooser(target: Intent, exclude: List<LookupHandler>) {
+        val callback = Intent(activity, LookupChoiceReceiver::class.java)
+        // FLAG_MUTABLE so the system can fill in EXTRA_CHOSEN_COMPONENT on Android 12+.
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE else 0
+        val pending = PendingIntent.getBroadcast(activity, 0, callback, flags)
+
+        val chooser = Intent.createChooser(target, null, pending.intentSender).apply {
+            putExtra(
+                Intent.EXTRA_EXCLUDE_COMPONENTS,
+                exclude.map { ComponentName(it.packageName, it.className) }.toTypedArray(),
+            )
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        activity.startActivity(chooser)
+    }
+
+    /**
+     * Report the dictionary app currently remembered for the
+     * browser-excluding chooser (see [show_lookup_popover]), so the
+     * settings UI can offer a "reset" affordance. Resolves with
+     * `{ packageName, label }` when one is remembered and still
+     * installed, or `{}` otherwise (clearing a stale entry on the way).
+     */
+    @Command
+    fun get_lookup_dictionary(invoke: Invoke) {
+        val ret = JSObject()
+        val remembered = readRememberedDictionary() ?: return invoke.resolve(ret)
+        try {
+            val pm = activity.packageManager
+            val appInfo = pm.getApplicationInfo(remembered.packageName, 0)
+            ret.put("packageName", remembered.packageName)
+            ret.put("label", pm.getApplicationLabel(appInfo).toString())
+        } catch (e: PackageManager.NameNotFoundException) {
+            // App was uninstalled — drop the stale memory and report none.
+            clearRememberedDictionary()
+        } catch (e: Exception) {
+            Log.e("NativeBridgePlugin", "get_lookup_dictionary failed", e)
+        }
+        invoke.resolve(ret)
+    }
+
+    /** Forget the remembered dictionary app so the next lookup re-prompts. */
+    @Command
+    fun clear_lookup_dictionary(invoke: Invoke) {
+        val ret = JSObject()
+        try {
+            clearRememberedDictionary()
+            ret.put("success", true)
+        } catch (e: Exception) {
+            Log.e("NativeBridgePlugin", "clear_lookup_dictionary failed", e)
+            ret.put("success", false)
+            ret.put("error", e.message ?: "unknown")
+        }
+        invoke.resolve(ret)
     }
 
     /**

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/test/java/LookupDispatchTest.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/test/java/LookupDispatchTest.kt
@@ -1,0 +1,91 @@
+package com.readest.native_bridge
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [decideLookupDispatch] — the browser-exclusion routing
+ * for dictionary lookups (issue #4559). Runs on the host JVM; no Android
+ * framework or device required.
+ */
+class LookupDispatchTest {
+    private val eudic = LookupHandler("com.eusoft.eudic", ".LookupActivity")
+    private val goldendict = LookupHandler("org.goldendict.android", ".MainActivity")
+    private val vivoBrowser = LookupHandler("com.vivo.browser", ".BrowserActivity")
+    private val browsers = setOf("com.vivo.browser", "com.android.chrome")
+
+    @Test
+    fun noHandlers_isUnavailable() {
+        assertEquals(
+            LookupDispatch.Unavailable,
+            decideLookupDispatch(emptyList(), browsers, remembered = null),
+        )
+    }
+
+    @Test
+    fun noBrowserPresent_dispatchesImplicitly() {
+        // Two dictionaries, no browser hijacking: leave it to the OS
+        // (preserves the native "Just once / Always" behavior).
+        assertEquals(
+            LookupDispatch.DispatchImplicit,
+            decideLookupDispatch(listOf(eudic, goldendict), browsers, remembered = null),
+        )
+    }
+
+    @Test
+    fun browserOnly_isUnavailable() {
+        // The VIVO case with no dictionary installed: don't dump the user
+        // into the browser — report unavailable so the TS layer hints.
+        assertEquals(
+            LookupDispatch.Unavailable,
+            decideLookupDispatch(listOf(vivoBrowser), browsers, remembered = null),
+        )
+    }
+
+    @Test
+    fun browserPlusOneDictionary_launchesDictionaryDirectly() {
+        assertEquals(
+            LookupDispatch.DispatchExplicit(eudic),
+            decideLookupDispatch(listOf(vivoBrowser, eudic), browsers, remembered = null),
+        )
+    }
+
+    @Test
+    fun browserPlusTwoDictionaries_noMemory_choosesExcludingBrowser() {
+        assertEquals(
+            LookupDispatch.DispatchChooser(listOf(vivoBrowser)),
+            decideLookupDispatch(
+                listOf(vivoBrowser, eudic, goldendict),
+                browsers,
+                remembered = null,
+            ),
+        )
+    }
+
+    @Test
+    fun browserPlusTwoDictionaries_validMemory_launchesRememberedDirectly() {
+        assertEquals(
+            LookupDispatch.DispatchExplicit(goldendict),
+            decideLookupDispatch(
+                listOf(vivoBrowser, eudic, goldendict),
+                browsers,
+                remembered = goldendict,
+            ),
+        )
+    }
+
+    @Test
+    fun browserPlusTwoDictionaries_staleMemory_fallsBackToChooser() {
+        // Remembered app is no longer among the live handlers (uninstalled
+        // / stopped registering) → ignore it and re-prompt.
+        val stale = LookupHandler("com.removed.dict", ".Main")
+        assertEquals(
+            LookupDispatch.DispatchChooser(listOf(vivoBrowser)),
+            decideLookupDispatch(
+                listOf(vivoBrowser, eudic, goldendict),
+                browsers,
+                remembered = stale,
+            ),
+        )
+    }
+}

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/build.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/build.rs
@@ -21,6 +21,8 @@ const COMMANDS: &[&str] = &[
     "get_external_sdcard_path",
     "open_external_url",
     "show_lookup_popover",
+    "get_lookup_dictionary",
+    "clear_lookup_dictionary",
     "select_directory",
     "get_storefront_region_code",
     "register_listener",

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/commands/clear_lookup_dictionary.toml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/commands/clear_lookup_dictionary.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-clear-lookup-dictionary"
+description = "Enables the clear_lookup_dictionary command without any pre-configured scope."
+commands.allow = ["clear_lookup_dictionary"]
+
+[[permission]]
+identifier = "deny-clear-lookup-dictionary"
+description = "Denies the clear_lookup_dictionary command without any pre-configured scope."
+commands.deny = ["clear_lookup_dictionary"]

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/commands/get_lookup_dictionary.toml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/commands/get_lookup_dictionary.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-lookup-dictionary"
+description = "Enables the get_lookup_dictionary command without any pre-configured scope."
+commands.allow = ["get_lookup_dictionary"]
+
+[[permission]]
+identifier = "deny-get-lookup-dictionary"
+description = "Denies the get_lookup_dictionary command without any pre-configured scope."
+commands.deny = ["get_lookup_dictionary"]

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/reference.md
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/reference.md
@@ -26,6 +26,8 @@ Default permissions for the plugin
 - `allow-get-external-sdcard-path`
 - `allow-open-external-url`
 - `allow-show-lookup-popover`
+- `allow-get-lookup-dictionary`
+- `allow-clear-lookup-dictionary`
 - `allow-select-directory`
 - `allow-get-storefront-region-code`
 - `allow-request-manage-storage-permission`
@@ -182,6 +184,32 @@ Denies the check_permissions command without any pre-configured scope.
 <tr>
 <td>
 
+`native-bridge:allow-clear-lookup-dictionary`
+
+</td>
+<td>
+
+Enables the clear_lookup_dictionary command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`native-bridge:deny-clear-lookup-dictionary`
+
+</td>
+<td>
+
+Denies the clear_lookup_dictionary command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `native-bridge:allow-clear-sync-passphrase`
 
 </td>
@@ -279,6 +307,32 @@ Enables the get_external_sdcard_path command without any pre-configured scope.
 <td>
 
 Denies the get_external_sdcard_path command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`native-bridge:allow-get-lookup-dictionary`
+
+</td>
+<td>
+
+Enables the get_lookup_dictionary command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`native-bridge:deny-get-lookup-dictionary`
+
+</td>
+<td>
+
+Denies the get_lookup_dictionary command without any pre-configured scope.
 
 </td>
 </tr>

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/default.toml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/default.toml
@@ -23,6 +23,8 @@ permissions = [
   "allow-get-external-sdcard-path",
   "allow-open-external-url",
   "allow-show-lookup-popover",
+  "allow-get-lookup-dictionary",
+  "allow-clear-lookup-dictionary",
   "allow-select-directory",
   "allow-get-storefront-region-code",
   "allow-request-manage-storage-permission",

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/schemas/schema.json
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/schemas/schema.json
@@ -355,6 +355,18 @@
           "markdownDescription": "Denies the check_permissions command without any pre-configured scope."
         },
         {
+          "description": "Enables the clear_lookup_dictionary command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-clear-lookup-dictionary",
+          "markdownDescription": "Enables the clear_lookup_dictionary command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the clear_lookup_dictionary command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-clear-lookup-dictionary",
+          "markdownDescription": "Denies the clear_lookup_dictionary command without any pre-configured scope."
+        },
+        {
           "description": "Enables the clear_sync_passphrase command without any pre-configured scope.",
           "type": "string",
           "const": "allow-clear-sync-passphrase",
@@ -401,6 +413,18 @@
           "type": "string",
           "const": "deny-get-external-sdcard-path",
           "markdownDescription": "Denies the get_external_sdcard_path command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_lookup_dictionary command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-lookup-dictionary",
+          "markdownDescription": "Enables the get_lookup_dictionary command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_lookup_dictionary command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-lookup-dictionary",
+          "markdownDescription": "Denies the get_lookup_dictionary command without any pre-configured scope."
         },
         {
           "description": "Enables the get_safe_area_insets command without any pre-configured scope.",
@@ -751,10 +775,10 @@
           "markdownDescription": "Denies the use_background_audio command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-auth-with-safari`\n- `allow-auth-with-custom-tab`\n- `allow-copy-uri-to-path`\n- `allow-use-background-audio`\n- `allow-install-package`\n- `allow-set-system-ui-visibility`\n- `allow-get-status-bar-height`\n- `allow-get-sys-fonts-list`\n- `allow-intercept-keys`\n- `allow-lock-screen-orientation`\n- `allow-iap-is-available`\n- `allow-iap-initialize`\n- `allow-iap-fetch-products`\n- `allow-iap-purchase-product`\n- `allow-iap-restore-purchases`\n- `allow-get-system-color-scheme`\n- `allow-get-safe-area-insets`\n- `allow-get-screen-brightness`\n- `allow-set-screen-brightness`\n- `allow-get-external-sdcard-path`\n- `allow-open-external-url`\n- `allow-show-lookup-popover`\n- `allow-select-directory`\n- `allow-get-storefront-region-code`\n- `allow-request-manage-storage-permission`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-check-permissions`\n- `allow-request-permissions`\n- `allow-checkPermissions`\n- `allow-requestPermissions`\n- `allow-set-sync-passphrase`\n- `allow-get-sync-passphrase`\n- `allow-clear-sync-passphrase`\n- `allow-is-sync-keychain-available`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-auth-with-safari`\n- `allow-auth-with-custom-tab`\n- `allow-copy-uri-to-path`\n- `allow-use-background-audio`\n- `allow-install-package`\n- `allow-set-system-ui-visibility`\n- `allow-get-status-bar-height`\n- `allow-get-sys-fonts-list`\n- `allow-intercept-keys`\n- `allow-lock-screen-orientation`\n- `allow-iap-is-available`\n- `allow-iap-initialize`\n- `allow-iap-fetch-products`\n- `allow-iap-purchase-product`\n- `allow-iap-restore-purchases`\n- `allow-get-system-color-scheme`\n- `allow-get-safe-area-insets`\n- `allow-get-screen-brightness`\n- `allow-set-screen-brightness`\n- `allow-get-external-sdcard-path`\n- `allow-open-external-url`\n- `allow-show-lookup-popover`\n- `allow-get-lookup-dictionary`\n- `allow-clear-lookup-dictionary`\n- `allow-select-directory`\n- `allow-get-storefront-region-code`\n- `allow-request-manage-storage-permission`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-check-permissions`\n- `allow-request-permissions`\n- `allow-checkPermissions`\n- `allow-requestPermissions`\n- `allow-set-sync-passphrase`\n- `allow-get-sync-passphrase`\n- `allow-clear-sync-passphrase`\n- `allow-is-sync-keychain-available`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-auth-with-safari`\n- `allow-auth-with-custom-tab`\n- `allow-copy-uri-to-path`\n- `allow-use-background-audio`\n- `allow-install-package`\n- `allow-set-system-ui-visibility`\n- `allow-get-status-bar-height`\n- `allow-get-sys-fonts-list`\n- `allow-intercept-keys`\n- `allow-lock-screen-orientation`\n- `allow-iap-is-available`\n- `allow-iap-initialize`\n- `allow-iap-fetch-products`\n- `allow-iap-purchase-product`\n- `allow-iap-restore-purchases`\n- `allow-get-system-color-scheme`\n- `allow-get-safe-area-insets`\n- `allow-get-screen-brightness`\n- `allow-set-screen-brightness`\n- `allow-get-external-sdcard-path`\n- `allow-open-external-url`\n- `allow-show-lookup-popover`\n- `allow-select-directory`\n- `allow-get-storefront-region-code`\n- `allow-request-manage-storage-permission`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-check-permissions`\n- `allow-request-permissions`\n- `allow-checkPermissions`\n- `allow-requestPermissions`\n- `allow-set-sync-passphrase`\n- `allow-get-sync-passphrase`\n- `allow-clear-sync-passphrase`\n- `allow-is-sync-keychain-available`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-auth-with-safari`\n- `allow-auth-with-custom-tab`\n- `allow-copy-uri-to-path`\n- `allow-use-background-audio`\n- `allow-install-package`\n- `allow-set-system-ui-visibility`\n- `allow-get-status-bar-height`\n- `allow-get-sys-fonts-list`\n- `allow-intercept-keys`\n- `allow-lock-screen-orientation`\n- `allow-iap-is-available`\n- `allow-iap-initialize`\n- `allow-iap-fetch-products`\n- `allow-iap-purchase-product`\n- `allow-iap-restore-purchases`\n- `allow-get-system-color-scheme`\n- `allow-get-safe-area-insets`\n- `allow-get-screen-brightness`\n- `allow-set-screen-brightness`\n- `allow-get-external-sdcard-path`\n- `allow-open-external-url`\n- `allow-show-lookup-popover`\n- `allow-get-lookup-dictionary`\n- `allow-clear-lookup-dictionary`\n- `allow-select-directory`\n- `allow-get-storefront-region-code`\n- `allow-request-manage-storage-permission`\n- `allow-register-listener`\n- `allow-remove-listener`\n- `allow-check-permissions`\n- `allow-request-permissions`\n- `allow-checkPermissions`\n- `allow-requestPermissions`\n- `allow-set-sync-passphrase`\n- `allow-get-sync-passphrase`\n- `allow-clear-sync-passphrase`\n- `allow-is-sync-keychain-available`"
         }
       ]
     }

--- a/apps/readest-app/src/__tests__/services/dictionaries/systemDictionary.test.ts
+++ b/apps/readest-app/src/__tests__/services/dictionaries/systemDictionary.test.ts
@@ -33,6 +33,8 @@ vi.mock('@tauri-apps/api/window', () => ({
 }));
 
 import {
+  clearRememberedLookupApp,
+  getRememberedLookupApp,
   invokeSystemDictionary,
   isSystemDictionarySupported,
 } from '@/services/dictionaries/systemDictionary';
@@ -98,6 +100,53 @@ describe('invokeSystemDictionary — native dispatch', () => {
 
     expect(ok).toBe(false);
     expect(invokeMock).not.toHaveBeenCalled();
+  });
+});
+
+const GET_LOOKUP_CMD = 'plugin:native-bridge|get_lookup_dictionary';
+const CLEAR_LOOKUP_CMD = 'plugin:native-bridge|clear_lookup_dictionary';
+
+describe('getRememberedLookupApp — Android-only remembered dictionary', () => {
+  it('returns the remembered app on Android', async () => {
+    appService.value = flags('android');
+    invokeMock.mockResolvedValueOnce({ packageName: 'com.eusoft.eudic', label: 'Eudic' });
+
+    const app = await getRememberedLookupApp();
+
+    expect(app).toEqual({ packageName: 'com.eusoft.eudic', label: 'Eudic' });
+    expect(invokeMock).toHaveBeenCalledWith(GET_LOOKUP_CMD);
+  });
+
+  it('returns null when nothing is remembered (empty response)', async () => {
+    appService.value = flags('android');
+    invokeMock.mockResolvedValueOnce({});
+
+    expect(await getRememberedLookupApp()).toBeNull();
+  });
+
+  it('is a no-op on non-Android platforms', async () => {
+    appService.value = flags('ios');
+
+    expect(await getRememberedLookupApp()).toBeNull();
+    expect(invokeMock).not.toHaveBeenCalledWith(GET_LOOKUP_CMD);
+  });
+});
+
+describe('clearRememberedLookupApp — Android-only reset', () => {
+  it('invokes the clear command on Android', async () => {
+    appService.value = flags('android');
+
+    await clearRememberedLookupApp();
+
+    expect(invokeMock).toHaveBeenCalledWith(CLEAR_LOOKUP_CMD);
+  });
+
+  it('is a no-op on non-Android platforms', async () => {
+    appService.value = flags('ios');
+
+    await clearRememberedLookupApp();
+
+    expect(invokeMock).not.toHaveBeenCalledWith(CLEAR_LOOKUP_CMD);
   });
 });
 

--- a/apps/readest-app/src/components/settings/CustomDictionaries.tsx
+++ b/apps/readest-app/src/components/settings/CustomDictionaries.tsx
@@ -31,8 +31,11 @@ import { eventDispatcher } from '@/utils/event';
 import { evictProvider, isSystemDictionaryEnabled } from '@/services/dictionaries/registry';
 import { BUILTIN_PROVIDER_IDS } from '@/services/dictionaries/types';
 import {
+  clearRememberedLookupApp,
+  getRememberedLookupApp,
   isSystemDictionaryAvailable,
   isSystemDictionarySupported,
+  type RememberedLookupApp,
 } from '@/services/dictionaries/systemDictionary';
 import { queueDictionaryBinaryUpload } from '@/services/sync/replicaBinaryUpload';
 import type { ImportedDictionary, WebSearchEntry } from '@/services/dictionaries/types';
@@ -266,6 +269,30 @@ const CustomDictionaries: React.FC<CustomDictionariesProps> = ({ onBack }) => {
 
   const { selectFiles } = useFileSelector(appService, _);
   const [importing, setImporting] = useState(false);
+  // Android only: the dictionary app remembered for the browser-excluding
+  // system-lookup chooser (issue #4559). Stays null on every other platform
+  // and whenever nothing has been remembered, so the reset row below only
+  // surfaces for the narrow case that can get "stuck" on one app.
+  const [rememberedLookupApp, setRememberedLookupApp] = useState<RememberedLookupApp | null>(null);
+  useEffect(() => {
+    if (!appService?.isAndroidApp) return;
+    let cancelled = false;
+    void getRememberedLookupApp().then((app) => {
+      if (!cancelled) setRememberedLookupApp(app);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [appService]);
+  const handleResetLookupApp = async () => {
+    await clearRememberedLookupApp();
+    setRememberedLookupApp(null);
+    eventDispatcher.dispatch('toast', {
+      type: 'info',
+      message: _('Lookup app reset. The next lookup will ask again.'),
+      timeout: 4000,
+    });
+  };
   // Edit and Delete are mutually-exclusive row affordances. Toggling one on
   // turns the other off so the trailing column never shows two icons at once.
   const [isDeleteMode, setIsDeleteMode] = useState(false);
@@ -806,6 +833,33 @@ const CustomDictionaries: React.FC<CustomDictionariesProps> = ({ onBack }) => {
           <span className='line-clamp-1'>{_('Add Web Search')}</span>
         </button>
       </div>
+
+      {/* Reset the remembered system-lookup app. Only rendered on Android
+          when a dictionary has actually been remembered from the
+          browser-excluding chooser (issue #4559), so the user can switch
+          to another installed dictionary without uninstalling. */}
+      {rememberedLookupApp && (
+        <div
+          className={clsx(
+            'eink-bordered mt-4 flex items-center justify-between gap-3',
+            'border-base-200 bg-base-100 rounded-lg border px-4 py-3',
+          )}
+        >
+          <div className='min-w-0'>
+            <div className='text-base-content text-sm font-medium'>{_('System Lookup App')}</div>
+            <div className='text-base-content/60 line-clamp-1 text-xs'>
+              {rememberedLookupApp.label}
+            </div>
+          </div>
+          <button
+            type='button'
+            onClick={handleResetLookupApp}
+            className='btn btn-ghost btn-sm eink-bordered shrink-0'
+          >
+            {_('Reset')}
+          </button>
+        </div>
+      )}
 
       <Tips className='mt-4'>
         <li>{_('StarDict bundles need .ifo, .idx, and .dict.dz files (.syn optional).')}</li>

--- a/apps/readest-app/src/services/dictionaries/systemDictionary.ts
+++ b/apps/readest-app/src/services/dictionaries/systemDictionary.ts
@@ -211,3 +211,45 @@ export const invokeSystemDictionary = async (
     return false;
   }
 };
+
+/** The dictionary app remembered for the Android browser-excluding chooser. */
+export interface RememberedLookupApp {
+  packageName: string;
+  /** Human-readable app label (e.g. "Eudic"), resolved natively. */
+  label: string;
+}
+
+/**
+ * Android only: the dictionary app the user previously picked from the
+ * browser-excluding lookup chooser (issue #4559), or `null` when none is
+ * remembered or the platform isn't Android. The settings UI uses this to
+ * offer a "reset" affordance so the user can switch dictionaries without
+ * having to uninstall the remembered one.
+ */
+export const getRememberedLookupApp = async (): Promise<RememberedLookupApp | null> => {
+  if (!isTauriAppPlatform()) return null;
+  if (getSystemDictionaryOS() !== 'android') return null;
+  try {
+    const res = await invoke<{ packageName?: string; label?: string }>(
+      'plugin:native-bridge|get_lookup_dictionary',
+    );
+    if (res?.packageName && res.label) {
+      return { packageName: res.packageName, label: res.label };
+    }
+    return null;
+  } catch (error) {
+    console.warn('[systemDictionary] get_lookup_dictionary failed', error);
+    return null;
+  }
+};
+
+/** Android only: forget the remembered lookup dictionary app. */
+export const clearRememberedLookupApp = async (): Promise<void> => {
+  if (!isTauriAppPlatform()) return;
+  if (getSystemDictionaryOS() !== 'android') return;
+  try {
+    await invoke('plugin:native-bridge|clear_lookup_dictionary');
+  } catch (error) {
+    console.warn('[systemDictionary] clear_lookup_dictionary failed', error);
+  }
+};


### PR DESCRIPTION
## Problem

On VIVO / iQOO (OriginOS), the **System Dictionary** lookup opened the OEM browser (`com.vivo.browser`) instead of an installed dictionary like Eudic / 欧路词典 — even with the dictionary installed (issue #4559). Two compounding Android causes:

1. **Package-visibility filtering (primary).** The app is `targetSdk 36`, but the native-bridge manifest had **no `<queries>` for `ACTION_PROCESS_TEXT`**. Under Android 11+ filtering, `queryIntentActivities(PROCESS_TEXT)` only returns *auto-visible* apps — web browsers qualify (the web-intent exception), arbitrary dictionary apps do **not**. So the query returned just the browser, and the lookup launched it. Confirmed by the reporter's `adb logcat` (`Displayed com.vivo.browser/.BrowserActivity`).
2. **Browser hijack (secondary).** Even when visible, an OEM browser that registers `ACTION_PROCESS_TEXT` can be the system default and swallow a plain `startActivity`.

## Fix

- **`AndroidManifest.xml`** — add a `<queries>` declaration for `ACTION_PROCESS_TEXT` (`text/plain`) so dictionary apps become visible (mirrors the existing native-tts `TTS_SERVICE` pattern). This alone is the high-confidence primary fix.
- **`LookupDispatch.kt`** (new, pure + JUnit-tested) — `decideLookupDispatch(handlers, browserPackages, remembered)` filters web browsers out of the handler set:
  - no browser among handlers → unchanged implicit dispatch (keeps the system's native "Just once / Always")
  - browser + **one** dictionary → launch it directly (explicit component, bypasses the browser default)
  - browser + **several** dictionaries → chooser that excludes browsers
  - **only** a browser installed → return `unavailable` so the user gets the "install a dictionary" hint instead of being dumped in the browser
- **Remember-the-pick** — `ACTION_CHOOSER` has no native "Always" button, so the browser-excluding chooser passes an `IntentSender`; the system returns `EXTRA_CHOSEN_COMPONENT` to `LookupChoiceReceiver`, which persists the choice. Subsequent lookups launch it directly — smooth one-tap after the first pick.
- **Reset** — `get_lookup_dictionary` / `clear_lookup_dictionary` commands back an **Android-only** "System Lookup App" reset row in the dictionary settings, shown only when an app is actually remembered (no clutter otherwise). Translated across all 33 locales.

Non-VIVO devices are unchanged: with no browser among the handlers, dispatch is byte-for-byte as before.

## Tests / verification

- ✅ `gradlew testFossDebugUnitTest` — 7 JUnit cases for `decideLookupDispatch`; Kotlin compiles
- ✅ `pnpm test` (5319) · `pnpm lint` (Biome + tsgo) · `pnpm format:check` · `cargo fmt --check`
- ✅ `cargo build -p tauri-plugin-native-bridge` — validates `build.rs` + permission wiring (autogenerated permission TOMLs / schema / reference regenerated)

## Caveat

I couldn't test on a physical VIVO device. The `<queries>` fix fully explains "only the browser shows" (the `targetSdk 36` + missing-queries asymmetry). The one remaining unknown is whether Eudic on that ROM registers `ACTION_PROCESS_TEXT` — if it does, it now launches directly; if it registers a different intent scheme, no `PROCESS_TEXT`-based fix can reach it, but the browser will at least no longer be wrongly launched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)