### PR TITLE
fix(ci): correct nightly Linux AppImage collect path

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -361,7 +361,12 @@ jobs:
                 appimage_name="Readest_${version}_aarch64.AppImage"
                 key="linux-aarch64-appimage"
               fi
-              add_entry "${bundle}/${rust_target}/release/bundle/appimage/${appimage_name}" "$appimage_name" "$key"
+              # The Linux leg builds with `cargo tauri build` WITHOUT `--target`
+              # (no matrix args), so cargo emits bundles under target/release/
+              # (host-target default) — NOT target/<triple>/release/ like the
+              # macOS/Windows legs, which DO pass `--target`. So there is no
+              # ${rust_target} subdir here.
+              add_entry "${bundle}/release/bundle/appimage/${appimage_name}" "$appimage_name" "$key"
               ;;
             *)
               echo "::error::unknown release leg: $release"; exit 1


### PR DESCRIPTION
## Problem

The first [Nightly Readest run](https://github.com/readest/readest/actions/runs/27503387960) failed on **both** Linux legs (x86_64 and aarch64) at the **collect artifacts + build manifest fragment** step:

```
::error::missing artifact or signature for linux-x86_64-appimage: target/x86_64-unknown-linux-gnu/release/bundle/appimage/Readest_0.11.4-2026061423_amd64.AppImage
```

The build itself succeeded — the AppImage was produced fine, just at a different path. The job log shows:

```
Info Readest_0.11.4-2026061423_amd64.AppImage (.../target/release/bundle/appimage/Readest_0.11.4-2026061423_amd64.AppImage)
```

## Root cause

The Linux matrix entries have no `args`, so `cargo tauri build` runs **without** `--target`. Cargo then emits bundles under `target/release/bundle/` (the host-target default), **not** `target/<triple>/release/bundle/`.

The macOS/Windows legs **do** pass `--target …`, so they legitimately get the `<triple>` subdir and their collect steps pass (macOS and windows-aarch64 succeeded in the same run). But the collect step reused `${rust_target}` for the Linux AppImage path too, so it looked under `target/x86_64-unknown-linux-gnu/release/bundle/appimage/` where nothing exists.

`release.yml` doesn't hit this because `tauri-action` locates the bundle automatically — only the nightly workflow's manual collect step hardcodes the path.

## Fix

Drop the `${rust_target}` subdir from the Linux AppImage path so it points at the host-target default location where the bundle actually lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)