### PR TITLE
fix(nightly): publish latest.json via directory rclone copy

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -428,10 +428,14 @@ jobs:
           echo "Assembled latest.json:"
           jq '{version, platforms: (.platforms | keys)}' latest.json
 
-          # Atomic promote: upload to a temp key, then server-side move so
-          # readers never observe a half-written latest.json.
-          rclone copyto latest.json "$base/latest.json.tmp"
-          rclone moveto "$base/latest.json.tmp" "$base/latest.json"
+          # Promote the manifest with a directory `rclone copy`, exactly like the
+          # stable release flow writes releases/latest.json (upload-to-r2.yml).
+          # A single-file `rclone copyto`/`moveto` first issues a CreateBucket
+          # probe (PUT /<bucket>) that the object-scoped R2 token can't satisfy
+          # (403 AccessDenied); a directory copy PUTs the object directly. R2
+          # PutObject is atomic, so readers never observe a half-written manifest.
+          mkdir -p promote && cp latest.json promote/latest.json
+          rclone copy promote "$base/"
 
       - name: prune old nightly folders (keep newest 7)
         run: |


### PR DESCRIPTION
## Problem

The nightly **`assemble-manifest`** job failed at *assemble + atomically promote latest.json* with `403 AccessDenied`, so `nightly/latest.json` was never published (the per-version artifacts and manifest fragments uploaded fine).

## Root cause

The promote step used a **single-file** `rclone copyto` + `moveto`. Before a single-file upload, rclone issues a **CreateBucket** probe (`PUT /<bucket>`) to "ensure the bucket exists." The `RELEASE_R2_*` token is scoped to **Object Read & Write**, which cannot create buckets → `403 AccessDenied`.

The build legs and the stable release flow (`upload-to-r2.yml`) were never affected because they write with a **directory** `rclone copy`, which `PutObject`s the target key directly and skips the CreateBucket probe.

Verified against the live bucket with the current token:

```
rclone copy DIR/  -> PUT /readest-releases/.../latest.json  -> 200 OK
rclone copyto FILE -> PUT /readest-releases (CreateBucket)  -> 403 AccessDenied
                      <Error><Code>AccessDenied</Code>...
```

## Fix

Promote `nightly/latest.json` the same way `upload-to-r2.yml` writes `releases/latest.json` — copy a one-file directory into `nightly/`. R2 `PutObject` is atomic, so the previous `.tmp` + server-side `moveto` added nothing.

```diff
-          rclone copyto latest.json "$base/latest.json.tmp"
-          rclone moveto "$base/latest.json.tmp" "$base/latest.json"
+          mkdir -p promote && cp latest.json promote/latest.json
+          rclone copy promote "$base/"
```

No infra change needed — the Object-R&W token is correct (least-privilege); the workflow just needed to stop relying on bucket creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)