### PR TITLE
feat(settings): move update & telemetry controls into Settings → Behavior

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -1863,8 +1863,6 @@
   "Resume audio": "استئناف متابعة الصوت",
   "Following audio": "يتابع الصوت",
   " · estimated": " · تقديري",
-  "Nightly Builds (Unstable)": "إصدارات ليلية (غير مستقرة)",
-  "Early daily builds; may be unstable": "إصدارات يومية مبكرة؛ قد تكون غير مستقرة",
   "Downloading Word Wise data…": "جارٍ تنزيل بيانات Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "إظهار تلميح قصير بلغتك الأم فوق الكلمات الصعبة.",
@@ -1881,5 +1879,9 @@
   "Hint Language": "لغة التلميح",
   "Data": "البيانات",
   "Download data packs automatically when needed.": "تنزيل حزم البيانات تلقائيًا عند الحاجة.",
-  "Failed to check for updates": "فشل التحقق من التحديثات"
+  "Failed to check for updates": "فشل التحقق من التحديثات",
+  "Update": "تحديث",
+  "Nightly Builds": "إصدارات ليلية",
+  "Early daily builds": "إصدارات يومية مبكرة",
+  "Privacy": "الخصوصية"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1731,8 +1731,6 @@
   "Resume audio": "আবার অনুসরণ করুন",
   "Following audio": "অডিও অনুসরণ করছে",
   " · estimated": " · আনুমানিক",
-  "Nightly Builds (Unstable)": "নাইটলি বিল্ড (অস্থিতিশীল)",
-  "Early daily builds; may be unstable": "প্রাথমিক দৈনিক বিল্ড; অস্থিতিশীল হতে পারে",
   "Downloading Word Wise data…": "Word Wise ডেটা ডাউনলোড হচ্ছে…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "কঠিন শব্দের উপরে মাতৃভাষায় একটি সংক্ষিপ্ত ইঙ্গিত দেখান।",
@@ -1749,5 +1747,9 @@
   "Hint Language": "ইঙ্গিতের ভাষা",
   "Data": "ডেটা",
   "Download data packs automatically when needed.": "প্রয়োজনে স্বয়ংক্রিয়ভাবে ডেটা প্যাক ডাউনলোড করুন।",
-  "Failed to check for updates": "আপডেট পরীক্ষা করতে ব্যর্থ"
+  "Failed to check for updates": "আপডেট পরীক্ষা করতে ব্যর্থ",
+  "Update": "আপডেট",
+  "Nightly Builds": "নাইটলি বিল্ড",
+  "Early daily builds": "প্রাথমিক দৈনিক বিল্ড",
+  "Privacy": "গোপনীয়তা"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1698,8 +1698,6 @@
   "Resume audio": "རྗེས་འདེད་མུ་མཐུད།",
   "Following audio": "སྒྲ་གདངས་རྗེས་འདེད་བྱེད་བཞིན་པ།",
   " · estimated": " · ཚོད་དཔག",
-  "Nightly Builds (Unstable)": "ཉིན་ལྟར་བཟོ་སྐྲུན། (བརྟན་པོ་མིན)",
-  "Early daily builds; may be unstable": "ཉིན་ལྟར་བཟོ་སྐྲུན་སྔ་མོ། བརྟན་པོ་མེད་སྲིད།",
   "Downloading Word Wise data…": "Word Wise གཞི་གྲངས་ཕབ་ལེན་བྱེད་བཞིན་པ།…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "ཚིག་དཀའ་མོའི་སྟེང་དུ་རང་སྐད་ནང་མཚོན་བྱེད་ཐུང་ངུ་ཞིག་སྟོན།",
@@ -1716,5 +1714,9 @@
   "Hint Language": "མཚོན་བྱེད་སྐད་ཡིག",
   "Data": "གཞི་གྲངས།",
   "Download data packs automatically when needed.": "དགོས་མཁོ་བྱུང་སྐབས་གཞི་གྲངས་ཐུམ་སྒྲིལ་རང་འགུལ་གྱིས་ཕབ་ལེན་བྱེད།",
-  "Failed to check for updates": "གསར་སྒྱུར་ཞིབ་བཤེར་མ་ཐུབ།"
+  "Failed to check for updates": "གསར་སྒྱུར་ཞིབ་བཤེར་མ་ཐུབ།",
+  "Update": "གསར་སྒྱུར།",
+  "Nightly Builds": "མཚན་མོའི་བཟོ་སྐྲུན།",
+  "Early daily builds": "སྔ་མོའི་ཉིན་རེའི་བཟོ་སྐྲུན།",
+  "Privacy": "གསང་དོན།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1731,8 +1731,6 @@
   "Resume audio": "Wieder folgen",
   "Following audio": "Folgt dem Audio",
   " · estimated": " · geschätzt",
-  "Nightly Builds (Unstable)": "Nightly-Builds (instabil)",
-  "Early daily builds; may be unstable": "Frühe tägliche Builds; können instabil sein",
   "Downloading Word Wise data…": "Word-Wise-Daten werden heruntergeladen…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Zeigt einen kurzen Hinweis in der Muttersprache über schwierigen Wörtern an.",
@@ -1749,5 +1747,9 @@
   "Hint Language": "Hinweissprache",
   "Data": "Daten",
   "Download data packs automatically when needed.": "Datenpakete bei Bedarf automatisch herunterladen.",
-  "Failed to check for updates": "Suche nach Updates fehlgeschlagen"
+  "Failed to check for updates": "Suche nach Updates fehlgeschlagen",
+  "Update": "Aktualisierung",
+  "Nightly Builds": "Nightly-Builds",
+  "Early daily builds": "Frühe tägliche Builds",
+  "Privacy": "Datenschutz"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1731,8 +1731,6 @@
   "Resume audio": "Συνέχιση ήχου",
   "Following audio": "Ακολουθεί τον ήχο",
   " · estimated": " · κατ' εκτίμηση",
-  "Nightly Builds (Unstable)": "Νυχτερινές εκδόσεις (ασταθείς)",
-  "Early daily builds; may be unstable": "Πρώιμες ημερήσιες εκδόσεις· ενδέχεται να είναι ασταθείς",
   "Downloading Word Wise data…": "Λήψη δεδομένων Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Εμφάνιση σύντομης υπόδειξης στη μητρική σας γλώσσα πάνω από δύσκολες λέξεις.",
@@ -1749,5 +1747,9 @@
   "Hint Language": "Γλώσσα υπόδειξης",
   "Data": "Δεδομένα",
   "Download data packs automatically when needed.": "Αυτόματη λήψη πακέτων δεδομένων όταν χρειάζεται.",
-  "Failed to check for updates": "Αποτυχία ελέγχου για ενημερώσεις"
+  "Failed to check for updates": "Αποτυχία ελέγχου για ενημερώσεις",
+  "Update": "Ενημέρωση",
+  "Nightly Builds": "Νυχτερινές εκδόσεις",
+  "Early daily builds": "Πρώιμες καθημερινές εκδόσεις",
+  "Privacy": "Απόρρητο"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1764,8 +1764,6 @@
   "Resume audio": "Reanudar audio",
   "Following audio": "Siguiendo el audio",
   " · estimated": " · estimado",
-  "Nightly Builds (Unstable)": "Versiones nightly (inestables)",
-  "Early daily builds; may be unstable": "Versiones diarias anticipadas; pueden ser inestables",
   "Downloading Word Wise data…": "Descargando datos de Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Muestra una breve ayuda en tu idioma encima de las palabras difíciles.",
@@ -1782,5 +1780,9 @@
   "Hint Language": "Idioma de las ayudas",
   "Data": "Datos",
   "Download data packs automatically when needed.": "Descargar los paquetes de datos automáticamente cuando sea necesario.",
-  "Failed to check for updates": "No se pudo buscar actualizaciones"
+  "Failed to check for updates": "No se pudo buscar actualizaciones",
+  "Update": "Actualización",
+  "Nightly Builds": "Compilaciones nocturnas",
+  "Early daily builds": "Compilaciones diarias anticipadas",
+  "Privacy": "Privacidad"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1731,8 +1731,6 @@
   "Resume audio": "ادامهٔ دنبال‌کردن صدا",
   "Following audio": "در حال دنبال‌کردن صدا",
   " · estimated": " · تخمینی",
-  "Nightly Builds (Unstable)": "نسخه‌های شبانه (ناپایدار)",
-  "Early daily builds; may be unstable": "نسخه‌های روزانهٔ اولیه؛ ممکن است ناپایدار باشند",
   "Downloading Word Wise data…": "در حال دانلود داده‌های Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "نمایش راهنمایی کوتاه به زبان مادری بالای واژه‌های دشوار.",
@@ -1749,5 +1747,9 @@
   "Hint Language": "زبان راهنمایی",
   "Data": "داده",
   "Download data packs automatically when needed.": "دانلود خودکار بسته‌های داده در صورت نیاز.",
-  "Failed to check for updates": "بررسی به‌روزرسانی‌ها ناموفق بود"
+  "Failed to check for updates": "بررسی به‌روزرسانی‌ها ناموفق بود",
+  "Update": "به‌روزرسانی",
+  "Nightly Builds": "نسخه‌های شبانه",
+  "Early daily builds": "نسخه‌های روزانهٔ آزمایشی",
+  "Privacy": "حریم خصوصی"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1764,8 +1764,6 @@
   "Resume audio": "Reprendre l'audio",
   "Following audio": "Suit l'audio",
   " · estimated": " · estimé",
-  "Nightly Builds (Unstable)": "Versions nightly (instables)",
-  "Early daily builds; may be unstable": "Versions quotidiennes anticipées ; peuvent être instables",
   "Downloading Word Wise data…": "Téléchargement des données Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Affiche une courte explication dans votre langue au-dessus des mots difficiles.",
@@ -1782,5 +1780,9 @@
   "Hint Language": "Langue des explications",
   "Data": "Données",
   "Download data packs automatically when needed.": "Télécharger automatiquement les packs de données si nécessaire.",
-  "Failed to check for updates": "Échec de la recherche de mises à jour"
+  "Failed to check for updates": "Échec de la recherche de mises à jour",
+  "Update": "Mise à jour",
+  "Nightly Builds": "Versions nocturnes",
+  "Early daily builds": "Versions quotidiennes anticipées",
+  "Privacy": "Confidentialité"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1764,8 +1764,6 @@
   "Resume audio": "חידוש מעקב",
   "Following audio": "עוקב אחר השמע",
   " · estimated": " · משוער",
-  "Nightly Builds (Unstable)": "גרסאות לילה (לא יציבות)",
-  "Early daily builds; may be unstable": "גרסאות יומיות מוקדמות; עשויות להיות לא יציבות",
   "Downloading Word Wise data…": "מוריד נתוני Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "הצגת רמז קצר בשפת האם מעל מילים קשות.",
@@ -1782,5 +1780,9 @@
   "Hint Language": "שפת הרמז",
   "Data": "נתונים",
   "Download data packs automatically when needed.": "הורדת חבילות נתונים אוטומטית בעת הצורך.",
-  "Failed to check for updates": "בדיקת העדכונים נכשלה"
+  "Failed to check for updates": "בדיקת העדכונים נכשלה",
+  "Update": "עדכון",
+  "Nightly Builds": "גרסאות לילה",
+  "Early daily builds": "גרסאות יומיות מוקדמות",
+  "Privacy": "פרטיות"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1731,8 +1731,6 @@
   "Resume audio": "ऑडियो फिर से अनुसरण करें",
   "Following audio": "ऑडियो का अनुसरण कर रहा है",
   " · estimated": " · अनुमानित",
-  "Nightly Builds (Unstable)": "नाइटली बिल्ड (अस्थिर)",
-  "Early daily builds; may be unstable": "शुरुआती दैनिक बिल्ड; अस्थिर हो सकते हैं",
   "Downloading Word Wise data…": "Word Wise डेटा डाउनलोड हो रहा है…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "कठिन शब्दों के ऊपर मातृभाषा में एक संक्षिप्त संकेत दिखाएँ।",
@@ -1749,5 +1747,9 @@
   "Hint Language": "संकेत भाषा",
   "Data": "डेटा",
   "Download data packs automatically when needed.": "ज़रूरत पड़ने पर डेटा पैक स्वतः डाउनलोड करें।",
-  "Failed to check for updates": "अपडेट की जाँच करने में विफल"
+  "Failed to check for updates": "अपडेट की जाँच करने में विफल",
+  "Update": "अपडेट",
+  "Nightly Builds": "नाइटली बिल्ड",
+  "Early daily builds": "प्रारंभिक दैनिक बिल्ड",
+  "Privacy": "गोपनीयता"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1731,8 +1731,6 @@
   "Resume audio": "Követés folytatása",
   "Following audio": "Hangot követi",
   " · estimated": " · becsült",
-  "Nightly Builds (Unstable)": "Éjszakai buildek (instabil)",
-  "Early daily builds; may be unstable": "Korai napi buildek; instabilak lehetnek",
   "Downloading Word Wise data…": "Word Wise-adatok letöltése…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Rövid, anyanyelvi tipp megjelenítése a nehéz szavak felett.",
@@ -1749,5 +1747,9 @@
   "Hint Language": "Tippek nyelve",
   "Data": "Adatok",
   "Download data packs automatically when needed.": "Adatcsomagok automatikus letöltése, amikor szükséges.",
-  "Failed to check for updates": "A frissítések keresése sikertelen"
+  "Failed to check for updates": "A frissítések keresése sikertelen",
+  "Update": "Frissítés",
+  "Nightly Builds": "Éjszakai buildek",
+  "Early daily builds": "Korai napi buildek",
+  "Privacy": "Adatvédelem"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1698,8 +1698,6 @@
   "Resume audio": "Lanjutkan mengikuti",
   "Following audio": "Mengikuti audio",
   " · estimated": " · perkiraan",
-  "Nightly Builds (Unstable)": "Build Harian (Tidak Stabil)",
-  "Early daily builds; may be unstable": "Build harian awal; mungkin tidak stabil",
   "Downloading Word Wise data…": "Mengunduh data Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Tampilkan petunjuk singkat dalam bahasa ibu di atas kata-kata sulit.",
@@ -1716,5 +1714,9 @@
   "Hint Language": "Bahasa Petunjuk",
   "Data": "Data",
   "Download data packs automatically when needed.": "Unduh paket data secara otomatis saat diperlukan.",
-  "Failed to check for updates": "Gagal memeriksa pembaruan"
+  "Failed to check for updates": "Gagal memeriksa pembaruan",
+  "Update": "Pembaruan",
+  "Nightly Builds": "Build Nightly",
+  "Early daily builds": "Build harian awal",
+  "Privacy": "Privasi"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1764,8 +1764,6 @@
   "Resume audio": "Riprendi audio",
   "Following audio": "Segue l'audio",
   " · estimated": " · stimato",
-  "Nightly Builds (Unstable)": "Versioni nightly (instabili)",
-  "Early daily builds; may be unstable": "Versioni giornaliere anticipate; potrebbero essere instabili",
   "Downloading Word Wise data…": "Download dei dati Word Wise in corso…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Mostra un breve suggerimento nella tua lingua sopra le parole difficili.",
@@ -1782,5 +1780,9 @@
   "Hint Language": "Lingua dei suggerimenti",
   "Data": "Dati",
   "Download data packs automatically when needed.": "Scarica automaticamente i pacchetti dati quando necessario.",
-  "Failed to check for updates": "Impossibile verificare la presenza di aggiornamenti"
+  "Failed to check for updates": "Impossibile verificare la presenza di aggiornamenti",
+  "Update": "Aggiornamento",
+  "Nightly Builds": "Build notturne",
+  "Early daily builds": "Build giornaliere anticipate",
+  "Privacy": "Privacy"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1698,8 +1698,6 @@
   "Resume audio": "音声に再追従",
   "Following audio": "音声に追従中",
   " · estimated": " · 推定",
-  "Nightly Builds (Unstable)": "ナイトリービルド（不安定版）",
-  "Early daily builds; may be unstable": "毎日配信の先行ビルド。不安定な場合があります",
   "Downloading Word Wise data…": "Word Wise データをダウンロード中…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "難しい単語の上に母国語の短いヒントを表示します。",
@@ -1716,5 +1714,9 @@
   "Hint Language": "ヒント言語",
   "Data": "データ",
   "Download data packs automatically when needed.": "必要に応じてデータパックを自動的にダウンロードします。",
-  "Failed to check for updates": "更新の確認に失敗しました"
+  "Failed to check for updates": "更新の確認に失敗しました",
+  "Update": "アップデート",
+  "Nightly Builds": "ナイトリービルド",
+  "Early daily builds": "毎日の先行ビルド",
+  "Privacy": "プライバシー"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1698,8 +1698,6 @@
   "Resume audio": "오디오 다시 따라가기",
   "Following audio": "오디오 따라가는 중",
   " · estimated": " · 추정",
-  "Nightly Builds (Unstable)": "나이틀리 빌드(불안정)",
-  "Early daily builds; may be unstable": "매일 배포되는 미리보기 빌드로, 불안정할 수 있습니다",
   "Downloading Word Wise data…": "Word Wise 데이터 다운로드 중…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "어려운 단어 위에 모국어로 된 짧은 힌트를 표시합니다.",
@@ -1716,5 +1714,9 @@
   "Hint Language": "힌트 언어",
   "Data": "데이터",
   "Download data packs automatically when needed.": "필요할 때 데이터 팩을 자동으로 다운로드합니다.",
-  "Failed to check for updates": "업데이트 확인에 실패했습니다"
+  "Failed to check for updates": "업데이트 확인에 실패했습니다",
+  "Update": "업데이트",
+  "Nightly Builds": "야간 빌드",
+  "Early daily builds": "매일 제공되는 미리 보기 빌드",
+  "Privacy": "개인정보 보호"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1698,8 +1698,6 @@
   "Resume audio": "Sambung ikut audio",
   "Following audio": "Mengikut audio",
   " · estimated": " · anggaran",
-  "Nightly Builds (Unstable)": "Binaan Harian (Tidak Stabil)",
-  "Early daily builds; may be unstable": "Binaan harian awal; mungkin tidak stabil",
   "Downloading Word Wise data…": "Memuat turun data Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Tunjukkan petunjuk ringkas dalam bahasa ibunda di atas perkataan sukar.",
@@ -1716,5 +1714,9 @@
   "Hint Language": "Bahasa Petunjuk",
   "Data": "Data",
   "Download data packs automatically when needed.": "Muat turun pakej data secara automatik apabila diperlukan.",
-  "Failed to check for updates": "Gagal menyemak kemas kini"
+  "Failed to check for updates": "Gagal menyemak kemas kini",
+  "Update": "Kemas kini",
+  "Nightly Builds": "Binaan Nightly",
+  "Early daily builds": "Binaan harian awal",
+  "Privacy": "Privasi"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1731,8 +1731,6 @@
   "Resume audio": "Audio hervatten",
   "Following audio": "Volgt audio",
   " · estimated": " · geschat",
-  "Nightly Builds (Unstable)": "Nightly-builds (onstabiel)",
-  "Early daily builds; may be unstable": "Vroege dagelijkse builds; kunnen onstabiel zijn",
   "Downloading Word Wise data…": "Word Wise-gegevens downloaden…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Toon een korte hint in je moedertaal boven moeilijke woorden.",
@@ -1749,5 +1747,9 @@
   "Hint Language": "Hinttaal",
   "Data": "Gegevens",
   "Download data packs automatically when needed.": "Download gegevenspakketten automatisch wanneer nodig.",
-  "Failed to check for updates": "Controleren op updates mislukt"
+  "Failed to check for updates": "Controleren op updates mislukt",
+  "Update": "Update",
+  "Nightly Builds": "Nightly-builds",
+  "Early daily builds": "Vroege dagelijkse builds",
+  "Privacy": "Privacy"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1797,8 +1797,6 @@
   "Resume audio": "Wznów podążanie",
   "Following audio": "Podąża za dźwiękiem",
   " · estimated": " · szacowane",
-  "Nightly Builds (Unstable)": "Wersje nocne (niestabilne)",
-  "Early daily builds; may be unstable": "Wczesne codzienne wersje; mogą być niestabilne",
   "Downloading Word Wise data…": "Pobieranie danych Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Pokazuj krótką podpowiedź w języku ojczystym nad trudnymi słowami.",
@@ -1815,5 +1813,9 @@
   "Hint Language": "Język podpowiedzi",
   "Data": "Dane",
   "Download data packs automatically when needed.": "Pobieraj pakiety danych automatycznie w razie potrzeby.",
-  "Failed to check for updates": "Nie udało się sprawdzić aktualizacji"
+  "Failed to check for updates": "Nie udało się sprawdzić aktualizacji",
+  "Update": "Aktualizacja",
+  "Nightly Builds": "Kompilacje nocne",
+  "Early daily builds": "Wczesne kompilacje dzienne",
+  "Privacy": "Prywatność"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1764,8 +1764,6 @@
   "Resume audio": "Retomar áudio",
   "Following audio": "Seguindo o áudio",
   " · estimated": " · estimado",
-  "Nightly Builds (Unstable)": "Versões nightly (instáveis)",
-  "Early daily builds; may be unstable": "Versões diárias antecipadas; podem ser instáveis",
   "Downloading Word Wise data…": "Baixando dados do Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Mostra uma breve dica no seu idioma acima das palavras difíceis.",
@@ -1782,5 +1780,9 @@
   "Hint Language": "Idioma das dicas",
   "Data": "Dados",
   "Download data packs automatically when needed.": "Baixar pacotes de dados automaticamente quando necessário.",
-  "Failed to check for updates": "Falha ao verificar atualizações"
+  "Failed to check for updates": "Falha ao verificar atualizações",
+  "Update": "Atualização",
+  "Nightly Builds": "Compilações noturnas",
+  "Early daily builds": "Compilações diárias antecipadas",
+  "Privacy": "Privacidade"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1764,8 +1764,6 @@
   "Resume audio": "Retomar áudio",
   "Following audio": "A seguir o áudio",
   " · estimated": " · estimado",
-  "Nightly Builds (Unstable)": "Versões nightly (instáveis)",
-  "Early daily builds; may be unstable": "Versões diárias antecipadas; podem ser instáveis",
   "Downloading Word Wise data…": "A transferir dados do Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Mostra uma breve dica na sua língua por cima das palavras difíceis.",
@@ -1782,5 +1780,9 @@
   "Hint Language": "Idioma das dicas",
   "Data": "Dados",
   "Download data packs automatically when needed.": "Transferir pacotes de dados automaticamente quando necessário.",
-  "Failed to check for updates": "Falha ao procurar atualizações"
+  "Failed to check for updates": "Falha ao procurar atualizações",
+  "Update": "Atualização",
+  "Nightly Builds": "Compilações noturnas",
+  "Early daily builds": "Compilações diárias antecipadas",
+  "Privacy": "Privacidade"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1764,8 +1764,6 @@
   "Resume audio": "Reia urmărirea",
   "Following audio": "Urmărește audio",
   " · estimated": " · estimat",
-  "Nightly Builds (Unstable)": "Versiuni nightly (instabile)",
-  "Early daily builds; may be unstable": "Versiuni zilnice timpurii; pot fi instabile",
   "Downloading Word Wise data…": "Se descarcă datele Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Afișează un scurt indiciu în limba maternă deasupra cuvintelor dificile.",
@@ -1782,5 +1780,9 @@
   "Hint Language": "Limba indiciilor",
   "Data": "Date",
   "Download data packs automatically when needed.": "Descarcă automat pachetele de date când este necesar.",
-  "Failed to check for updates": "Verificarea actualizărilor a eșuat"
+  "Failed to check for updates": "Verificarea actualizărilor a eșuat",
+  "Update": "Actualizare",
+  "Nightly Builds": "Versiuni nightly",
+  "Early daily builds": "Versiuni zilnice timpurii",
+  "Privacy": "Confidențialitate"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1797,8 +1797,6 @@
   "Resume audio": "Возобновить слежение",
   "Following audio": "Следует за аудио",
   " · estimated": " · примерно",
-  "Nightly Builds (Unstable)": "Ночные сборки (нестабильные)",
-  "Early daily builds; may be unstable": "Ранние ежедневные сборки; могут быть нестабильными",
   "Downloading Word Wise data…": "Загрузка данных Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Показывать краткую подсказку на родном языке над сложными словами.",
@@ -1815,5 +1813,9 @@
   "Hint Language": "Язык подсказок",
   "Data": "Данные",
   "Download data packs automatically when needed.": "Автоматически загружать пакеты данных при необходимости.",
-  "Failed to check for updates": "Не удалось проверить обновления"
+  "Failed to check for updates": "Не удалось проверить обновления",
+  "Update": "Обновление",
+  "Nightly Builds": "Ночные сборки",
+  "Early daily builds": "Ранние ежедневные сборки",
+  "Privacy": "Конфиденциальность"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1731,8 +1731,6 @@
   "Resume audio": "නැවත අනුගමනය කරන්න",
   "Following audio": "ශ්‍රව්‍යය අනුගමනය කරයි",
   " · estimated": " · ඇස්තමේන්තුගත",
-  "Nightly Builds (Unstable)": "රාත්‍රික නිකුතු (අස්ථිර)",
-  "Early daily builds; may be unstable": "මුල් දෛනික නිකුතු; අස්ථිර විය හැක",
   "Downloading Word Wise data…": "Word Wise දත්ත බාගත වෙමින්…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "අසීරු වචන ඉහළින් මව්බසින් කෙටි ඉඟියක් පෙන්වන්න.",
@@ -1749,5 +1747,9 @@
   "Hint Language": "ඉඟි භාෂාව",
   "Data": "දත්ත",
   "Download data packs automatically when needed.": "අවශ්‍ය විට දත්ත පැකේජ ස්වයංක්‍රීයව බාගන්න.",
-  "Failed to check for updates": "යාවත්කාලීන සඳහා පරීක්ෂා කිරීමට අසමත් විය"
+  "Failed to check for updates": "යාවත්කාලීන සඳහා පරීක්ෂා කිරීමට අසමත් විය",
+  "Update": "යාවත්කාලීන කිරීම",
+  "Nightly Builds": "රාත්‍රී නිකුතු",
+  "Early daily builds": "මුල් දෛනික නිකුතු",
+  "Privacy": "පෞද්ගලිකත්වය"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1797,8 +1797,6 @@
   "Resume audio": "Nadaljuj sledenje",
   "Following audio": "Sledi zvoku",
   " · estimated": " · ocenjeno",
-  "Nightly Builds (Unstable)": "Nočne različice (nestabilne)",
-  "Early daily builds; may be unstable": "Zgodnje dnevne različice; lahko so nestabilne",
   "Downloading Word Wise data…": "Prenašanje podatkov Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Nad težkimi besedami prikaži kratek namig v maternem jeziku.",
@@ -1815,5 +1813,9 @@
   "Hint Language": "Jezik namigov",
   "Data": "Podatki",
   "Download data packs automatically when needed.": "Samodejno prenesi pakete podatkov, ko je to potrebno.",
-  "Failed to check for updates": "Preverjanje posodobitev ni uspelo"
+  "Failed to check for updates": "Preverjanje posodobitev ni uspelo",
+  "Update": "Posodobitev",
+  "Nightly Builds": "Nočne gradnje",
+  "Early daily builds": "Zgodnje dnevne gradnje",
+  "Privacy": "Zasebnost"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1731,8 +1731,6 @@
   "Resume audio": "Återuppta ljud",
   "Following audio": "Följer ljudet",
   " · estimated": " · uppskattat",
-  "Nightly Builds (Unstable)": "Nattliga versioner (instabila)",
-  "Early daily builds; may be unstable": "Tidiga dagliga versioner; kan vara instabila",
   "Downloading Word Wise data…": "Laddar ner Word Wise-data…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Visa en kort ledtråd på ditt modersmål ovanför svåra ord.",
@@ -1749,5 +1747,9 @@
   "Hint Language": "Språk för ledtrådar",
   "Data": "Data",
   "Download data packs automatically when needed.": "Ladda ner datapaket automatiskt vid behov.",
-  "Failed to check for updates": "Det gick inte att söka efter uppdateringar"
+  "Failed to check for updates": "Det gick inte att söka efter uppdateringar",
+  "Update": "Uppdatering",
+  "Nightly Builds": "Nattliga versioner",
+  "Early daily builds": "Tidiga dagliga versioner",
+  "Privacy": "Integritet"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1731,8 +1731,6 @@
   "Resume audio": "மீண்டும் பின்தொடர்",
   "Following audio": "ஆடியோவைப் பின்தொடர்கிறது",
   " · estimated": " · தோராயமாக",
-  "Nightly Builds (Unstable)": "நைட்லி பதிப்புகள் (நிலையற்றவை)",
-  "Early daily builds; may be unstable": "ஆரம்ப தினசரி பதிப்புகள்; நிலையற்றதாக இருக்கலாம்",
   "Downloading Word Wise data…": "Word Wise தரவு பதிவிறக்கப்படுகிறது…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "கடினமான சொற்களுக்கு மேல் தாய்மொழியில் ஒரு சிறிய குறிப்பைக் காட்டு.",
@@ -1749,5 +1747,9 @@
   "Hint Language": "குறிப்பு மொழி",
   "Data": "தரவு",
   "Download data packs automatically when needed.": "தேவைப்படும்போது தரவுத் தொகுப்புகளைத் தானாகப் பதிவிறக்கு.",
-  "Failed to check for updates": "புதுப்பிப்புகளைச் சரிபார்க்க முடியவில்லை"
+  "Failed to check for updates": "புதுப்பிப்புகளைச் சரிபார்க்க முடியவில்லை",
+  "Update": "புதுப்பிப்பு",
+  "Nightly Builds": "இரவு உருவாக்கங்கள்",
+  "Early daily builds": "ஆரம்ப தினசரி உருவாக்கங்கள்",
+  "Privacy": "தனியுரிமை"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1698,8 +1698,6 @@
   "Resume audio": "ติดตามเสียงต่อ",
   "Following audio": "กำลังติดตามเสียง",
   " · estimated": " · โดยประมาณ",
-  "Nightly Builds (Unstable)": "รุ่นทดสอบรายวัน (ไม่เสถียร)",
-  "Early daily builds; may be unstable": "รุ่นทดสอบรายวันช่วงแรก อาจไม่เสถียร",
   "Downloading Word Wise data…": "กำลังดาวน์โหลดข้อมูล Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "แสดงคำใบ้สั้น ๆ ในภาษาแม่เหนือคำที่ยาก",
@@ -1716,5 +1714,9 @@
   "Hint Language": "ภาษาของคำใบ้",
   "Data": "ข้อมูล",
   "Download data packs automatically when needed.": "ดาวน์โหลดชุดข้อมูลโดยอัตโนมัติเมื่อจำเป็น",
-  "Failed to check for updates": "ตรวจหาอัปเดตไม่สำเร็จ"
+  "Failed to check for updates": "ตรวจหาอัปเดตไม่สำเร็จ",
+  "Update": "อัปเดต",
+  "Nightly Builds": "บิลด์รายคืน",
+  "Early daily builds": "บิลด์รายวันรุ่นแรก",
+  "Privacy": "ความเป็นส่วนตัว"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1731,8 +1731,6 @@
   "Resume audio": "Sesi takibe devam et",
   "Following audio": "Sesi takip ediyor",
   " · estimated": " · tahmini",
-  "Nightly Builds (Unstable)": "Gecelik Sürümler (Kararsız)",
-  "Early daily builds; may be unstable": "Erken günlük sürümler; kararsız olabilir",
   "Downloading Word Wise data…": "Word Wise verileri indiriliyor…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Zor sözcüklerin üzerinde ana dilde kısa bir ipucu göster.",
@@ -1749,5 +1747,9 @@
   "Hint Language": "İpucu Dili",
   "Data": "Veri",
   "Download data packs automatically when needed.": "Gerektiğinde veri paketlerini otomatik olarak indir.",
-  "Failed to check for updates": "Güncellemeler denetlenemedi"
+  "Failed to check for updates": "Güncellemeler denetlenemedi",
+  "Update": "Güncelleme",
+  "Nightly Builds": "Gecelik sürümler",
+  "Early daily builds": "Erken günlük sürümler",
+  "Privacy": "Gizlilik"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1797,8 +1797,6 @@
   "Resume audio": "Відновити стеження",
   "Following audio": "Стежить за аудіо",
   " · estimated": " · приблизно",
-  "Nightly Builds (Unstable)": "Нічні збірки (нестабільні)",
-  "Early daily builds; may be unstable": "Ранні щоденні збірки; можуть бути нестабільними",
   "Downloading Word Wise data…": "Завантаження даних Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Показувати коротку підказку рідною мовою над складними словами.",
@@ -1815,5 +1813,9 @@
   "Hint Language": "Мова підказок",
   "Data": "Дані",
   "Download data packs automatically when needed.": "Автоматично завантажувати пакети даних за потреби.",
-  "Failed to check for updates": "Не вдалося перевірити оновлення"
+  "Failed to check for updates": "Не вдалося перевірити оновлення",
+  "Update": "Оновлення",
+  "Nightly Builds": "Нічні збірки",
+  "Early daily builds": "Ранні щоденні збірки",
+  "Privacy": "Конфіденційність"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1731,8 +1731,6 @@
   "Resume audio": "Ergashishni davom ettirish",
   "Following audio": "Audioga ergashmoqda",
   " · estimated": " · taxminiy",
-  "Nightly Builds (Unstable)": "Tungi yig'malar (Beqaror)",
-  "Early daily builds; may be unstable": "Erta kunlik yig'malar; beqaror bo'lishi mumkin",
   "Downloading Word Wise data…": "Word Wise ma'lumotlari yuklab olinmoqda…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Qiyin so'zlar ustida ona tilida qisqa maslahat ko'rsatish.",
@@ -1749,5 +1747,9 @@
   "Hint Language": "Maslahat tili",
   "Data": "Ma'lumotlar",
   "Download data packs automatically when needed.": "Kerak bo'lganda ma'lumotlar to'plamlarini avtomatik yuklab olish.",
-  "Failed to check for updates": "Yangilanishlarni tekshirib bo'lmadi"
+  "Failed to check for updates": "Yangilanishlarni tekshirib bo'lmadi",
+  "Update": "Yangilanish",
+  "Nightly Builds": "Tungi buildlar",
+  "Early daily builds": "Erta kunlik buildlar",
+  "Privacy": "Maxfiylik"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1698,8 +1698,6 @@
   "Resume audio": "Tiếp tục theo âm thanh",
   "Following audio": "Đang theo âm thanh",
   " · estimated": " · ước tính",
-  "Nightly Builds (Unstable)": "Bản dựng hằng đêm (Không ổn định)",
-  "Early daily builds; may be unstable": "Bản dựng hằng ngày sớm; có thể không ổn định",
   "Downloading Word Wise data…": "Đang tải dữ liệu Word Wise…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "Hiển thị gợi ý ngắn bằng tiếng mẹ đẻ phía trên các từ khó.",
@@ -1716,5 +1714,9 @@
   "Hint Language": "Ngôn ngữ gợi ý",
   "Data": "Dữ liệu",
   "Download data packs automatically when needed.": "Tự động tải gói dữ liệu khi cần.",
-  "Failed to check for updates": "Không kiểm tra được bản cập nhật"
+  "Failed to check for updates": "Không kiểm tra được bản cập nhật",
+  "Update": "Cập nhật",
+  "Nightly Builds": "Bản dựng hằng đêm",
+  "Early daily builds": "Bản dựng hằng ngày sớm",
+  "Privacy": "Quyền riêng tư"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1698,8 +1698,6 @@
   "Resume audio": "恢复跟随",
   "Following audio": "正在跟随音频",
   " · estimated": " · 估算",
-  "Nightly Builds (Unstable)": "每夜构建版（不稳定）",
-  "Early daily builds; may be unstable": "每日抢先构建，可能不稳定",
   "Downloading Word Wise data…": "正在下载 Word Wise 数据…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "在生词上方显示简短的母语提示。",
@@ -1716,5 +1714,9 @@
   "Hint Language": "提示语言",
   "Data": "数据",
   "Download data packs automatically when needed.": "需要时自动下载数据包。",
-  "Failed to check for updates": "检查更新失败"
+  "Failed to check for updates": "检查更新失败",
+  "Update": "更新",
+  "Nightly Builds": "每夜构建版",
+  "Early daily builds": "每日抢先构建版",
+  "Privacy": "隐私"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1698,8 +1698,6 @@
   "Resume audio": "恢復跟隨",
   "Following audio": "正在跟隨音訊",
   " · estimated": " · 估算",
-  "Nightly Builds (Unstable)": "每夜建置版（不穩定）",
-  "Early daily builds; may be unstable": "每日搶先建置，可能不穩定",
   "Downloading Word Wise data…": "正在下載 Word Wise 資料…",
   "Word Wise": "Word Wise",
   "Show a short native-language hint above difficult words.": "在生難字上方顯示簡短的母語提示。",
@@ -1716,5 +1714,9 @@
   "Hint Language": "提示語言",
   "Data": "資料",
   "Download data packs automatically when needed.": "需要時自動下載資料包。",
-  "Failed to check for updates": "檢查更新失敗"
+  "Failed to check for updates": "檢查更新失敗",
+  "Update": "更新",
+  "Nightly Builds": "每夜建置版",
+  "Early daily builds": "每日搶先建置版",
+  "Privacy": "隱私"
 }

--- a/apps/readest-app/src/app/library/components/SettingsMenu.tsx
+++ b/apps/readest-app/src/app/library/components/SettingsMenu.tsx
@@ -22,7 +22,6 @@ import { useResponsiveSize } from '@/hooks/useResponsiveSize';
 import { useTransferQueue } from '@/hooks/useTransferQueue';
 import { navigateToLogin, navigateToProfile } from '@/utils/nav';
 import { tauriHandleSetAlwaysOnTop, tauriHandleToggleFullScreen } from '@/utils/window';
-import { optInTelemetry, optOutTelemetry } from '@/utils/telemetry';
 import { setAboutDialogVisible } from '@/components/AboutWindow';
 import { setMigrateDataDirDialogVisible } from '@/app/library/components/MigrateDataWindow';
 import { requestStoragePermission } from '@/utils/permission';
@@ -54,15 +53,12 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
   const { themeMode, setThemeMode } = useThemeStore();
   const { settings, setSettingsDialogOpen } = useSettingsStore();
   const [isAutoUpload, setIsAutoUpload] = useState(settings.autoUpload);
-  const [isAutoCheckUpdates, setIsAutoCheckUpdates] = useState(settings.autoCheckUpdates);
-  const [isNightlyChannel, setIsNightlyChannel] = useState(settings.updateChannel === 'nightly');
   const [isAlwaysOnTop, setIsAlwaysOnTop] = useState(settings.alwaysOnTop);
   const [isAlwaysShowStatusBar, setIsAlwaysShowStatusBar] = useState(settings.alwaysShowStatusBar);
   const [isOpenLastBooks, setIsOpenLastBooks] = useState(settings.openLastBooks);
   const [isAutoImportBooksOnOpen, setIsAutoImportBooksOnOpen] = useState(
     settings.autoImportBooksOnOpen,
   );
-  const [isTelemetryEnabled, setIsTelemetryEnabled] = useState(settings.telemetryEnabled);
   const [alwaysInForeground, setAlwaysInForeground] = useState(settings.alwaysInForeground);
   const [savedBookCoverForLockScreen, setSavedBookCoverForLockScreen] = useState(
     settings.savedBookCoverForLockScreen || '',
@@ -156,33 +152,10 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
     setIsAutoImportBooksOnOpen(newValue);
   };
 
-  const toggleAutoCheckUpdates = () => {
-    const newValue = !settings.autoCheckUpdates;
-    saveSysSettings(envConfig, 'autoCheckUpdates', newValue);
-    setIsAutoCheckUpdates(newValue);
-  };
-
-  const toggleNightlyChannel = () => {
-    const newValue = !isNightlyChannel;
-    saveSysSettings(envConfig, 'updateChannel', newValue ? 'nightly' : 'stable');
-    setIsNightlyChannel(newValue);
-  };
-
   const toggleOpenLastBooks = () => {
     const newValue = !settings.openLastBooks;
     saveSysSettings(envConfig, 'openLastBooks', newValue);
     setIsOpenLastBooks(newValue);
-  };
-
-  const toggleTelemetry = () => {
-    const newValue = !settings.telemetryEnabled;
-    saveSysSettings(envConfig, 'telemetryEnabled', newValue);
-    setIsTelemetryEnabled(newValue);
-    if (newValue) {
-      optInTelemetry();
-    } else {
-      optOutTelemetry();
-    }
   };
 
   const handleUpgrade = () => {
@@ -392,21 +365,6 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
           onClick={toggleOpenLastBooks}
         />
       )}
-      {appService?.hasUpdater && (
-        <MenuItem
-          label={_('Check Updates on Start')}
-          toggled={isAutoCheckUpdates}
-          onClick={toggleAutoCheckUpdates}
-        />
-      )}
-      {appService?.hasUpdater && (
-        <MenuItem
-          label={_('Nightly Builds (Unstable)')}
-          description={isNightlyChannel ? _('Early daily builds; may be unstable') : ''}
-          toggled={isNightlyChannel}
-          onClick={toggleNightlyChannel}
-        />
-      )}
       <hr aria-hidden='true' className='border-base-200 my-1' />
       {appService?.hasWindow && (
         <MenuItem
@@ -486,12 +444,6 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
       )}
       {isWebAppPlatform() && <MenuItem label={_('Download Readest')} onClick={downloadReadest} />}
       <MenuItem label={_('About Readest')} onClick={showAboutReadest} />
-      <MenuItem
-        label={_('Help improve Readest')}
-        description={isTelemetryEnabled ? _('Sharing anonymized statistics') : ''}
-        toggled={isTelemetryEnabled}
-        onClick={toggleTelemetry}
-      />
     </Menu>
   );
 };

--- a/apps/readest-app/src/components/UpdaterWindow.tsx
+++ b/apps/readest-app/src/components/UpdaterWindow.tsx
@@ -77,17 +77,6 @@ const TAURI_UPDATER_KEYS = new Set([
   'windows-aarch64',
 ]);
 
-// Render a nightly stamp (e.g. "0.11.4-2026061406") in a human form. Returns
-// the input unchanged for plain semver versions so stable releases display
-// normally.
-const formatVersionLabel = (v: string): string => {
-  const m = v.match(/^(\d+\.\d+\.\d+)-(\d{4})(\d{2})(\d{2})(\d{2})$/);
-  if (!m) return v;
-  const [, base, y, mo, d, h] = m;
-  const date = new Date(Number(y), Number(mo) - 1, Number(d));
-  return `Nightly · ${base} (${date.toLocaleDateString()}, ${h}:00)`;
-};
-
 export const UpdaterContent = ({
   latestVersion,
   lastVersion,
@@ -557,7 +546,7 @@ export const UpdaterContent = ({
               </h2>
               <p className='mb-2'>
                 {_('Readest {{newVersion}} is available (installed version {{currentVersion}}).', {
-                  newVersion: formatVersionLabel(newVersion),
+                  newVersion,
                   currentVersion,
                 })}
               </p>

--- a/apps/readest-app/src/components/settings/ControlPanel.tsx
+++ b/apps/readest-app/src/components/settings/ControlPanel.tsx
@@ -23,6 +23,7 @@ import PageTurnerSettings from './PageTurnerSettings';
 import AnnotationToolbarCustomizer from './AnnotationToolbarCustomizer';
 import { DEFAULT_ANNOTATION_TOOLBAR_ITEMS } from '@/utils/annotationToolbar';
 import { canShareText } from '@/utils/share';
+import { optInTelemetry, optOutTelemetry } from '@/utils/telemetry';
 
 const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }) => {
   const _ = useTranslation();
@@ -63,6 +64,9 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
   );
   const [screenWakeLock, setScreenWakeLock] = useState(settings.screenWakeLock);
   const [allowScript, setAllowScript] = useState(viewSettings.allowScript);
+  const [isAutoCheckUpdates, setIsAutoCheckUpdates] = useState(settings.autoCheckUpdates);
+  const [isNightlyChannel, setIsNightlyChannel] = useState(settings.updateChannel === 'nightly');
+  const [isTelemetryEnabled, setIsTelemetryEnabled] = useState(settings.telemetryEnabled);
 
   const resetToDefaults = useResetViewSettings();
   const pageTurnerResetRef = useRef<() => void>(() => {});
@@ -249,6 +253,29 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
     saveViewSettings(envConfig, bookKey, 'copyToNotebook', copyToNotebook, false, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [copyToNotebook]);
+
+  const toggleAutoCheckUpdates = () => {
+    const newValue = !isAutoCheckUpdates;
+    saveSysSettings(envConfig, 'autoCheckUpdates', newValue);
+    setIsAutoCheckUpdates(newValue);
+  };
+
+  const toggleNightlyChannel = () => {
+    const newValue = !isNightlyChannel;
+    saveSysSettings(envConfig, 'updateChannel', newValue ? 'nightly' : 'stable');
+    setIsNightlyChannel(newValue);
+  };
+
+  const toggleTelemetry = () => {
+    const newValue = !isTelemetryEnabled;
+    saveSysSettings(envConfig, 'telemetryEnabled', newValue);
+    setIsTelemetryEnabled(newValue);
+    if (newValue) {
+      optInTelemetry();
+    } else {
+      optOutTelemetry();
+    }
+  };
 
   const getQuickActionOptions = () => {
     return [
@@ -443,6 +470,23 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
         />
       </BoxedList>
 
+      {appService?.hasUpdater && (
+        <BoxedList title={_('Update')} data-setting-id='settings.control.checkUpdates'>
+          <SettingsSwitchRow
+            label={_('Check Updates on Start')}
+            checked={isAutoCheckUpdates}
+            onChange={toggleAutoCheckUpdates}
+          />
+          <SettingsSwitchRow
+            label={_('Nightly Builds')}
+            description={isNightlyChannel ? _('Early daily builds') : ''}
+            checked={isNightlyChannel}
+            onChange={toggleNightlyChannel}
+            data-setting-id='settings.control.nightlyChannel'
+          />
+        </BoxedList>
+      )}
+
       <BoxedList title={_('Security')} data-setting-id='settings.control.allowJavascript'>
         <SettingsSwitchRow
           label={_('Allow JavaScript')}
@@ -450,6 +494,15 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
           checked={allowScript}
           disabled={bookData?.book?.format !== 'EPUB'}
           onChange={() => setAllowScript(!allowScript)}
+        />
+      </BoxedList>
+
+      <BoxedList title={_('Privacy')} data-setting-id='settings.control.telemetry'>
+        <SettingsSwitchRow
+          label={_('Help improve Readest')}
+          description={isTelemetryEnabled ? _('Sharing anonymized statistics') : ''}
+          checked={isTelemetryEnabled}
+          onChange={toggleTelemetry}
         />
       </BoxedList>
     </div>


### PR DESCRIPTION
## What

Moves the update and telemetry toggles out of the library **Settings menu** into the **Settings → Behavior** panel (where global app settings already live, e.g. Keep Screen Awake), and tidies their presentation.

- **"Update"** boxed-list (gated on `hasUpdater`): *Check Updates on Start* + *Nightly Builds*.
- **"Privacy"** boxed-list: *Help improve Readest* (telemetry).
- Behavior section order: **Update → Security → Privacy**.
- Rename **"Nightly Builds (Unstable)" → "Nightly Builds"** and drop the *"; may be unstable"* note. The nightly channel stays **off by default** (`updateChannel: 'stable'`).
- **Software Update** dialog now shows the **full version name** (e.g. `0.11.4-2026061506`) instead of a parsed date — removed `formatVersionLabel`.
- Removed the now-dead state/handlers/import from `SettingsMenu.tsx`.

## i18n

Extracted the new keys (`Update`, `Privacy`, `Nightly Builds`, `Early daily builds`) and translated them across all 33 locales. The scanner also removed the stale `Nightly Builds (Unstable)` / `Early daily builds; may be unstable` keys.

## Verification

- `pnpm lint` (tsgo + Biome): pass
- `pnpm test`: 5640 passed, 8 skipped
- Verified live on a Xiaomi 13 (HyperOS, arm64) via a devtools build:
  - Settings menu no longer shows the three items.
  - Behavior shows **Update → Security → Privacy**; Nightly row reads **"Nightly Builds" / "Early daily builds"**, off by default.
  - Software Update dialog: *"Readest 0.11.4-2026061506 is available (installed version 0.11.4)."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)