### PR TITLE
fix(footer): keep reader toolbar stable across orientation changes

### DIFF
--- a/apps/readest-app/src/app/reader/components/footerbar/FooterBar.tsx
+++ b/apps/readest-app/src/app/reader/components/footerbar/FooterBar.tsx
@@ -195,12 +195,28 @@ const FooterBar: React.FC<FooterBarProps> = ({
   const footerBarRef = useRef<HTMLDivElement>(null);
   useSpatialNavigation(footerBarRef, isVisible);
 
-  // Force the mobile footer bar on mobile tablets/foldables in portrait mode
-  // where the viewport width exceeds the `sm:` (640px) breakpoint. Phones
-  // (innerWidth < 640) are intentionally excluded so their styling and panel
-  // slide-down animation remain exactly as before — see #3742 / #3746.
-  const forceMobileLayout =
-    !!appService?.isMobile && window.innerWidth >= 640 && window.innerWidth <= window.innerHeight;
+  // Always use the mobile footer bar on mobile devices (phones, tablets, and
+  // foldables on iOS / Android). Previously this flag also factored in the
+  // current viewport's portrait/landscape state — it was only true when
+  // `innerWidth <= innerHeight`. That made the entire bottom toolbar swap
+  // contents on every orientation change: a phone in landscape (or a
+  // foldable in landscape) would suddenly drop the brightness / font /
+  // color / progress panels and render the desktop layout instead, then
+  // swing back to the mobile panels when rotated to portrait. Users
+  // expect rotating the device to leave the toolbar alone, so we no
+  // longer key off orientation here.
+  //
+  // Phones in landscape (innerWidth >= 640, innerHeight < 640) used to
+  // fall through to the `sm:` breakpoint and pick up the desktop layout;
+  // they now stay on the mobile layout, which is the more useful default
+  // because the mobile layout still exposes the per-book panels (this
+  // is the same fix #3759 applied for the tablet-portrait case, just
+  // generalized to all mobile orientations).
+  //
+  // Desktop / web continues to honor the `sm:` (640px) Tailwind breakpoint
+  // because `appService.isMobile` is false there — the layout still
+  // collapses to mobile on a sub-640px desktop window.
+  const forceMobileLayout = !!appService?.isMobile;
 
   const commonProps: FooterBarChildProps = {
     bookKey,


### PR DESCRIPTION
## Problem

The bottom footer bar swaps layouts whenever the user rotates the device:

- portrait → mobile bar (TOC / color / progress / font / TTS panels)
<img width="2240" height="2440" alt="Screenshot_20260613_154011_com bilingify readest" src="https://github.com/user-attachments/assets/681cbe08-c617-46f0-81f3-d9e610fd0de0" />
- landscape → desktop bar (chevron navigation + range slider)
<img width="2440" height="2240" alt="Screenshot_20260613_154332_com bilingify readest" src="https://github.com/user-attachments/assets/ac438a4d-85fa-454c-b655-150cd2c20187" />


- rotate again → flip back


That's an unintentional side-effect of #3759, which made `forceMobileLayout` true only when `innerWidth <= innerHeight`:

```ts
const forceMobileLayout =
  !!appService?.isMobile && window.innerWidth >= 640 && window.innerWidth <= window.innerHeight;
```

The aspect-ratio guard solved the original tablet-in-portrait regression from #3742 / #3746, but it also keys the entire toolbar off the current viewport aspect ratio — so any mobile device (phone, tablet, foldable) re-skins its footer on every rotation. Users expect rotating the device to leave the toolbar alone.

## Fix

Drop the orientation guard. `forceMobileLayout` becomes simply:

```ts
const forceMobileLayout = !!appService?.isMobile;
```

Every iOS / Android instance keeps the mobile footer bar regardless of orientation, which is the more useful default because that bar exposes brightness / font / color / progress panels that the desktop layout omits.

Desktop / web is unaffected — `appService.isMobile` is false there, and the `sm:` (640px) Tailwind breakpoint still collapses a narrow window to the mobile layout the same way it always did.

| Surface | Before | After |
| --- | --- | --- |
| Phone portrait | mobile bar | mobile bar (unchanged) |
| Phone landscape | desktop bar | **mobile bar** (changed) |
| Tablet / foldable portrait | mobile bar (#3759) | mobile bar (unchanged) |
| Tablet / foldable landscape | desktop bar | **mobile bar** (changed) |
| Desktop / web | desktop bar (or mobile under `sm:`) | unchanged |

## Open question for reviewers

#3759 was merged with an explicit contract: `forceMobileLayout` must be false for phones (`innerWidth < 640`) so that all `!forceMobileLayout && 'sm:…'` overrides evaluate to the original class strings and `MobileFooterBar`'s slide-down animation behaves exactly as before #3746. That contract was the reason #3759 did not re-introduce the phone panel animation regression that got #3746 reverted.

This change makes `forceMobileLayout` true on phones too, so it crosses that boundary. In local testing I did not observe a phone-panel-animation regression — by my reading, since #3759 the `MobileFooterBar` subtree no longer wraps children in the extra `<div>` that broke #3746, so the `forceMobileLayout=true` branch is now safe on phones as well. But I have only tested on Android. I'd appreciate confirmation on:

1. iOS phone portrait + landscape — does the bottom panel still slide cleanly behind the navigation bar on dismissal?
2. Is there any other place where the codebase still relies on `forceMobileLayout=false` on phones (CSS, layout, hit-testing) that I missed?

If either turns up an issue, an alternative scope would be `appService.isMobile && innerWidth >= 640` (tablets/foldables in both orientations, phones unchanged) — that keeps the #3759 contract intact while still removing the orientation flip on the larger devices.

## Verification

- `pnpm lint` clean
- Manual: Android phone portrait/landscape, Android tablet portrait/landscape — toolbar stays on the mobile layout across rotation in all four states; desktop window unchanged
