### PR TITLE
docs(readme): point donations to the unified donate.readest.com hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Readest is open-source, and contributions are welcome! Feel free to open issues,
 
 ## Support
 
-If Readest has been useful to you, consider supporting its development. You can [become a sponsor on GitHub](https://github.com/sponsors/readest), [donate via Stripe](https://donate.stripe.com/4gMcN5aZdcE52kW3TFgjC01), or [donate with crypto](https://donate.readest.com). Your contribution helps us squash bugs faster, improve performance, and keep building great features.
+If Readest has been useful to you, consider supporting its development at [donate.readest.com](https://donate.readest.com), where you'll find all available donation methods, including GitHub Sponsors, card payments, and crypto. Your contribution helps us fix bugs faster, improve performance, and keep building great features.
 
 ### Sponsors
 


### PR DESCRIPTION
## Summary

`donate.readest.com` now hosts every donation method, so the README's **Support** section links there directly instead of enumerating GitHub Sponsors, Stripe, and crypto as separate links.

Also rephrased "squash bugs faster" → "fix bugs faster".

### Before
> If Readest has been useful to you, consider supporting its development. You can [become a sponsor on GitHub](...), [donate via Stripe](...), or [donate with crypto](...). Your contribution helps us squash bugs faster, improve performance, and keep building great features.

### After
> If Readest has been useful to you, consider supporting its development at [donate.readest.com](https://donate.readest.com), where you'll find all available donation methods, including GitHub Sponsors, card payments, and crypto. Your contribution helps us fix bugs faster, improve performance, and keep building great features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)