### PR TITLE
docs(readme): make license badge static and modernize release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,8 +341,8 @@ We would also like to thank the [Web Chinese Fonts Plan](https://chinese-font.ne
 
 [badge-website]: https://img.shields.io/badge/website-readest.com-orange
 [badge-web-app]: https://img.shields.io/badge/read%20online-web.readest.com-orange
-[badge-license]: https://img.shields.io/github/license/readest/readest?color=teal
-[badge-release]: https://img.shields.io/github/release/readest/readest?color=green
+[badge-license]: https://img.shields.io/badge/license-AGPL--3.0-teal
+[badge-release]: https://img.shields.io/github/v/release/readest/readest?color=green
 [badge-platforms]: https://img.shields.io/badge/platforms-macOS%2C%20Windows%2C%20Linux%2C%20Android%2C%20iOS%2C%20Web%2C%20PWA-green
 [badge-last-commit]: https://img.shields.io/github/last-commit/readest/readest?color=blue
 [badge-commit-activity]: https://img.shields.io/github/commit-activity/m/readest/readest?color=blue


### PR DESCRIPTION
## Summary

Several README badges intermittently render **"Unable to select next GitHub token from pool"** (see [badges/shields#8907](https://github.com/badges/shields/issues/8907)).

**Cause:** the `license`, `release`, and `last-commit` badges all make shields.io query GitHub's API, authenticated with shields.io's *own* pool of GitHub tokens. When that shared pool is rate-limited/unhealthy, every GitHub-API badge fails. A badge URL is public, so there is no way for us to supply our own token to the hosted `img.shields.io` instance.

This PR removes one GitHub-API dependency outright and modernizes another:

- **License → static badge.** The license is fixed at AGPL-3.0, so `img.shields.io/badge/license-AGPL--3.0-teal` makes no GitHub API call and can never hit the token-pool error.
- **Release → `github/v/release`.** The old `github/release` endpoint is deprecated and 301-redirects; switch to the current path.

`last-commit` / `commit-activity` are genuinely dynamic and stay on shields (a full fix would require generating those badges from the repo's own token in CI — out of scope here).

### Verified
```
img.shields.io/badge/license-AGPL--3.0-teal      -> "license: AGPL-3.0"
img.shields.io/github/v/release/readest/readest  -> "release: v0.11.4"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)