### PR TITLE
docs(readme): remove the Sponsors / TestMu AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,14 +304,6 @@ Readest is open-source, and contributions are welcome! Feel free to open issues,
 
 If Readest has been useful to you, consider supporting its development at [donate.readest.com](https://donate.readest.com), where you'll find all available donation methods, including GitHub Sponsors, card payments, and crypto. Your contribution helps us fix bugs faster, improve performance, and keep building great features.
 
-### Sponsors
-
-<p align="center">
-  <a title="Browser testing via TestMu AI" href="https://www.testmuai.com/?utm_medium=sponsor&utm_source=readest" target="_blank">
-    <img src="https://raw.githubusercontent.com/readest/readest/refs/heads/main/data/sponsors/testmu-ai-logo.png" style="vertical-align: middle;" width="250" />
-  </a>
-</p>
-
 ## License
 
 Readest is free software: you can redistribute it and/or modify it under the terms of the [GNU Affero General Public License](https://www.gnu.org/licenses/agpl-3.0.html) as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary

Removes the `### Sponsors` subsection and its lone TestMu AI logo from the README's Support section. With no current sponsors to list, the empty heading served no purpose, so `## Support` now flows directly into `## License`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)