### PR TITLE
build(web): standalone Docker image + drop Turbopack build cache

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -60,18 +60,6 @@ jobs:
           node-version: 24
           cache: pnpm
 
-      # Turbopack persists its build cache here (turbopackFileSystemCacheForBuild).
-      # The key is deterministic (no commit SHA) so every PR restores the same
-      # entry — in practice the one `main` last saved, which is the only cache
-      # sibling PRs can all see.
-      - name: cache Turbopack build cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: apps/readest-app/.next/cache
-          key: turbo-build-web-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            turbo-build-web-${{ runner.os }}-
-
       - name: install Dependencies
         working-directory: apps/readest-app
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,15 +45,27 @@ COPY --from=dependencies /app/apps/readest-app/public/vendor /app/apps/readest-a
 COPY --from=dependencies /app/packages/foliate-js/node_modules /app/packages/foliate-js/node_modules
 COPY . .
 WORKDIR /app/apps/readest-app
+# Opt into the self-contained `.next/standalone` tree for this image only;
+# next.config.mjs gates `output: 'standalone'` on BUILD_STANDALONE so other
+# web builds keep their default output.
+ENV BUILD_STANDALONE=true
 RUN pnpm build-web
 
+# Production runtime ships only the standalone server, its traced node_modules,
+# and the static/public assets — no pnpm, no source tree, no dev dependencies,
+# no build cache. `output: 'standalone'` (next.config.mjs) emits the self-contained
+# tree under .next/standalone, so the entrypoint is a plain `node server.js`.
 FROM docker.io/library/node:24-slim@sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e AS production-stage
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
-RUN corepack prepare pnpm@11.1.1 --activate
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
 WORKDIR /app
-COPY --from=build /app /app
-WORKDIR /app/apps/readest-app
-ENTRYPOINT ["pnpm", "start-web", "-H", "0.0.0.0"]
+# Monorepo-rooted standalone tree: server.js + hoisted, traced node_modules.
+COPY --from=build --chown=node:node /app/apps/readest-app/.next/standalone ./
+# Static and public assets are not part of the standalone trace; copy them next
+# to the server so their default relative paths resolve.
+COPY --from=build --chown=node:node /app/apps/readest-app/.next/static ./apps/readest-app/.next/static
+COPY --from=build --chown=node:node /app/apps/readest-app/public ./apps/readest-app/public
+USER node
 EXPOSE 3000
+ENTRYPOINT ["node", "apps/readest-app/server.js"]

--- a/apps/readest-app/next.config.mjs
+++ b/apps/readest-app/next.config.mjs
@@ -14,12 +14,23 @@ if (isDev) {
 }
 
 const exportOutput = appPlatform !== 'web' && !isDev;
+// Opt-in standalone output, set only by the Docker production build
+// (Dockerfile). Every other path keeps the original behavior: Tauri `export`,
+// local `build-web` (output undefined), dev, and the Cloudflare/OpenNext
+// deploy — which forces standalone itself via NEXT_PRIVATE_STANDALONE.
+const standaloneOutput = !exportOutput && process.env['BUILD_STANDALONE'] === 'true';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Ensure Next.js uses SSG instead of SSR
   // https://nextjs.org/docs/pages/building-your-application/deploying/static-exports
-  output: exportOutput ? 'export' : undefined,
+  // The Docker production image opts into a self-contained `.next/standalone`
+  // tree (see Dockerfile) so it can ship only the traced runtime; all other
+  // web builds fall back to the default server output.
+  output: exportOutput ? 'export' : standaloneOutput ? 'standalone' : undefined,
+  // Monorepo: trace from the repo root so workspace packages land in the
+  // standalone tree. Only relevant to — and only set for — the Docker build.
+  outputFileTracingRoot: standaloneOutput ? path.join(__dirname, '../../') : undefined,
   pageExtensions: exportOutput ? ['jsx', 'tsx'] : ['js', 'jsx', 'ts', 'tsx'],
   // Note: This feature is required to use the Next.js Image component in SSG mode.
   // See https://nextjs.org/docs/messages/export-image-api for different workarounds.
@@ -28,11 +39,11 @@ const nextConfig = {
   },
   devIndicators: false,
   experimental: {
-    // Persist Turbopack's compilation cache to `.next/` so CI can restore it
-    // between runs. Dev caching is on by default since Next 16.1; build
-    // caching is opt-in (beta).
+    // Dev caching is on by default since Next 16.1. We deliberately do NOT
+    // enable Turbopack's build cache (turbopackFileSystemCacheForBuild, beta):
+    // a build interrupted mid-compile leaves a partial cache that the next
+    // build mishandles, fanning out workers until it exhausts RAM.
     turbopackFileSystemCacheForDev: true,
-    turbopackFileSystemCacheForBuild: true,
   },
   // Configure assetPrefix or else the server won't properly resolve your assets.
   assetPrefix: '',


### PR DESCRIPTION
## Summary

Two related web-build changes, committed together:

### 1. Slim the web Docker production image via Next.js `output: 'standalone'` (opt-in)
- `next.config.mjs`: standalone output is **gated on a `BUILD_STANDALONE` env flag**. Only the Docker production build sets it, so it emits `output: 'standalone'` + `outputFileTracingRoot` (monorepo root, so workspace packages are traced). **Every other path keeps its original output** — Tauri `export`, local `build-web` (`output: undefined`), dev, and the Cloudflare/OpenNext deploy (which forces standalone itself via `NEXT_PRIVATE_STANDALONE`).
- `Dockerfile`: the `build` stage sets `ENV BUILD_STANDALONE=true`; the `production-stage` copies only the traced runtime (`.next/standalone` → `server.js` + hoisted `node_modules`, plus `.next/static` and `public`), runs as the non-root `node` user, and starts with `node apps/readest-app/server.js`. No more shipping pnpm, dev dependencies, or the full source tree.

### 2. Disable the experimental `turbopackFileSystemCacheForBuild`
- A `build-web` interrupted mid-compile leaves a **partial** Turbopack build cache (the flag is beta). The next build mishandles it, fanning out workers until it exhausts host RAM (reproduced locally: 42 workers, 18 GB swap, machine froze).
- Removed the flag from `next.config.mjs` (dev caching, on by default since Next 16.1, is kept).
- Removed the `pull-request.yml` CI step that cached `.next/cache` for it — now dead. Each CI run already starts from a clean container, so this path never affected CI/Docker anyway.

## Verification
- **Gated build, cold cache, watchdog-monitored:** `BUILD_STANDALONE=true pnpm build-web` → exit 0, peak ~5.5 GB RSS, swap flat, and produces `.next/standalone/apps/readest-app/server.js` + traced `node_modules`. Without the flag, output falls back to the original (`undefined`).
- A/B (before vs after the standalone flag) both complete within ~6.5 GB peak with no swap growth.
- Full unit suite green locally: **5685 passed, 8 skipped, 0 failed**.
- `pull-request.yml` re-validated as well-formed YAML.

`docker-image.yml` builds `production-stage` (with `BUILD_STANDALONE=true`) on Linux runners on merge, exercising the image change end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)