### PR TITLE
fix(android): move plugin @Command I/O off the main thread; fix WebView leak & #3297 blank screen

### DIFF
--- a/apps/readest-app/src-tauri/gen/android/app/src/main/java/com/bilingify/readest/MainActivity.kt
+++ b/apps/readest-app/src-tauri/gen/android/app/src/main/java/com/bilingify/readest/MainActivity.kt
@@ -33,9 +33,31 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
     // is an evaluateJavascript round-trip into the WebView.
     private val touchMoveThrottleMs = 100L
     private var lastTouchMoveTime = 0L
+    // #3297: on Android 14+ the window can gain focus before the WebView has
+    // loaded/painted its first frame, leaving a blank screen. Force a single
+    // repaint as soon as both the window has focus and the WebView exists —
+    // whichever happens last — so the compositor draws the initial frame.
+    private var hasWindowFocus = false
+    private var didInitialInvalidate = false
 
     override fun onWebViewCreate(webView: WebView) {
         wv = webView
+        ensureInitialPaint()
+    }
+
+    private fun ensureInitialPaint() {
+        val webView = wv ?: return
+        if (didInitialInvalidate || !hasWindowFocus) return
+        didInitialInvalidate = true
+        webView.post { webView.invalidate() }
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (hasFocus) {
+            hasWindowFocus = true
+            ensureInitialPaint()
+        }
     }
 
     private val keyEventMap = mapOf(

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/ClipUrlController.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/ClipUrlController.kt
@@ -23,6 +23,7 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import app.tauri.annotation.InvokeArg
 import org.json.JSONObject
+import java.lang.ref.WeakReference
 
 /**
  * Args decoded from the JS `invoke('clip_url', { ... })` payload.
@@ -67,10 +68,16 @@ sealed class ClipUrlResult {
  * the page's own hydration can't wipe).
  */
 class ClipUrlController(
-    private val activity: Activity,
+    activity: Activity,
     private val args: ClipUrlArgs,
     private val completion: (ClipUrlResult) -> Unit,
 ) {
+    // Hold the Activity weakly: the controller outlives the synchronous
+    // command call (it waits up to 30 s for the page), and a strong ref
+    // would leak the Activity (and its WebView) if it is destroyed while
+    // a clip is in flight.
+    private val activityRef = WeakReference(activity)
+
     companion object {
         private const val TAG = "ClipUrl"
 
@@ -126,27 +133,32 @@ class ClipUrlController(
             completion(ClipUrlResult.Failure("Invalid URL"))
             return
         }
-        mainHandler.post { presentDialog(urlStr) }
+        val act = activityRef.get()
+        if (act == null || act.isFinishing || act.isDestroyed) {
+            completion(ClipUrlResult.Failure("Activity is no longer available"))
+            return
+        }
+        mainHandler.post { presentDialog(act, urlStr) }
     }
 
-    private fun presentDialog(urlStr: String) {
+    private fun presentDialog(act: Activity, urlStr: String) {
         val bg = parseHexColor(args.background ?: DEFAULT_BACKGROUND) ?: Color.BLACK
         val fg = parseHexColor(args.foreground ?: DEFAULT_FOREGROUND) ?: Color.WHITE
 
         // Full-screen dialog with no chrome — we draw our own overlay
         // on top so the underlying app doesn't peek through during the
         // brief capture window.
-        val dlg = Dialog(activity, android.R.style.Theme_Black_NoTitleBar_Fullscreen)
+        val dlg = Dialog(act, android.R.style.Theme_Black_NoTitleBar_Fullscreen)
         dlg.setCancelable(false)
         dlg.setCanceledOnTouchOutside(false)
         dlg.window?.also { window ->
             window.setBackgroundDrawable(ColorDrawable(bg))
         }
 
-        val root = FrameLayout(activity)
+        val root = FrameLayout(act)
         root.setBackgroundColor(bg)
 
-        val wv = WebView(activity)
+        val wv = WebView(act)
         // Reserve a logical size for layout; the WebView is hidden
         // behind the opaque overlay anyway, but it still needs a
         // non-zero rect for the page to fire its viewport-based
@@ -158,7 +170,7 @@ class ClipUrlController(
         configureWebView(wv)
         root.addView(wv)
 
-        val overlay = buildOverlay(bg, fg)
+        val overlay = buildOverlay(act, bg, fg)
         overlay.layoutParams = FrameLayout.LayoutParams(
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.MATCH_PARENT,
@@ -231,28 +243,28 @@ class ClipUrlController(
         }
     }
 
-    private fun buildOverlay(bg: Int, fg: Int): View {
-        val column = LinearLayout(activity)
+    private fun buildOverlay(act: Activity, bg: Int, fg: Int): View {
+        val column = LinearLayout(act)
         column.orientation = LinearLayout.VERTICAL
         column.gravity = Gravity.CENTER
         column.setBackgroundColor(bg)
-        val pad = dp(24)
+        val pad = dp(act, 24)
         column.setPadding(pad, pad, pad, pad)
 
-        val spinner = ProgressBar(activity)
+        val spinner = ProgressBar(act)
         // Tint with foreground at ~85% — same idea as the iOS overlay.
         val spinTint = Color.argb(
             (0.85f * 255).toInt(),
             Color.red(fg), Color.green(fg), Color.blue(fg),
         )
         spinner.indeterminateDrawable?.setTint(spinTint)
-        val spinSize = dp(36)
+        val spinSize = dp(act, 36)
         val spinParams = LinearLayout.LayoutParams(spinSize, spinSize)
-        spinParams.bottomMargin = dp(14)
+        spinParams.bottomMargin = dp(act, 14)
         spinner.layoutParams = spinParams
         column.addView(spinner)
 
-        val title = TextView(activity)
+        val title = TextView(act)
         title.text = args.overlayTitle ?: DEFAULT_OVERLAY_TITLE
         title.setTextColor(fg)
         title.textSize = 15f
@@ -260,7 +272,7 @@ class ClipUrlController(
         title.setTypeface(title.typeface, android.graphics.Typeface.BOLD)
         column.addView(title)
 
-        val status = TextView(activity)
+        val status = TextView(act)
         status.text = args.loadingStatus ?: DEFAULT_LOADING_STATUS
         // 70% alpha for the secondary line — matches the desktop overlay.
         status.setTextColor(
@@ -277,7 +289,7 @@ class ClipUrlController(
             ViewGroup.LayoutParams.WRAP_CONTENT,
             ViewGroup.LayoutParams.WRAP_CONTENT,
         )
-        statusParams.topMargin = dp(4)
+        statusParams.topMargin = dp(act, 4)
         status.layoutParams = statusParams
         column.addView(status)
         statusLabel = status
@@ -329,8 +341,8 @@ class ClipUrlController(
         completion(result)
     }
 
-    private fun dp(units: Int): Int =
-        (units * activity.resources.displayMetrics.density + 0.5f).toInt()
+    private fun dp(act: Activity, units: Int): Int =
+        (units * act.resources.displayMetrics.density + 0.5f).toInt()
 
     /** Parse `#rrggbb` into an Android ARGB int; null on malformed input. */
     private fun parseHexColor(s: String): Int? {

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -42,6 +42,7 @@ import app.tauri.plugin.Plugin
 import app.tauri.plugin.Invoke
 import org.json.JSONArray
 import java.io.*
+import kotlinx.coroutines.*
 
 @InvokeArg
 class AuthRequestArgs {
@@ -140,6 +141,16 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
     private var redirectHost = "auth-callback"
     private val billingManager by lazy {
         BillingManager(activity)
+    }
+    // Scope for offloading blocking @Command I/O (file copy, package
+    // install, font scan, dictionary lookup) off the plugin command thread.
+    // Cancelled in onDestroy so in-flight work can't resolve into — or leak —
+    // a dead Activity.
+    private val pluginScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    override fun onDestroy() {
+        pluginScope.cancel()
+        instance = null
     }
 
     companion object {
@@ -329,58 +340,68 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
     @Command
     fun copy_uri_to_path(invoke: Invoke) {
         val args = invoke.parseArgs(CopyURIRequestArgs::class.java)
-        val ret = JSObject()
-        try {
-            val uri = Uri.parse(args.uri ?: "")
-            val dst = File(args.dst ?: "")
-            val inputStream = activity.contentResolver.openInputStream(uri)
+        pluginScope.launch {
+            val ret = withContext(Dispatchers.IO) {
+                val r = JSObject()
+                try {
+                    val uri = Uri.parse(args.uri ?: "")
+                    val dst = File(args.dst ?: "")
+                    val inputStream = activity.contentResolver.openInputStream(uri)
 
-            if (inputStream != null) {
-                dst.outputStream().use { output ->
-                    inputStream.use { input ->
-                        input.copyTo(output)
+                    if (inputStream != null) {
+                        dst.outputStream().use { output ->
+                            inputStream.use { input ->
+                                input.copyTo(output)
+                            }
+                        }
+                        r.put("success", true)
+                    } else {
+                        r.put("success", false)
+                        r.put("error", "Failed to open input stream from URI")
                     }
+                } catch (e: Exception) {
+                    r.put("success", false)
+                    r.put("error", e.message)
                 }
-                ret.put("success", true)
-            } else {
-                ret.put("success", false)
-                ret.put("error", "Failed to open input stream from URI")
+                r
             }
-        } catch (e: Exception) {
-            ret.put("success", false)
-            ret.put("error", e.message)
+            if (isActive) invoke.resolve(ret)
         }
-        invoke.resolve(ret)
     }
 
     @Command
     fun install_package(invoke: Invoke) {
         val args = invoke.parseArgs(InstallPackageRequestArgs::class.java)
-        val ret = JSObject()
-        try {
-            val file = File(args.path ?: "")
-            if (file.exists()) {
-                val intent = Intent(Intent.ACTION_VIEW)
-                val apkUri = FileProvider.getUriForFile(activity, "${activity.packageName}.fileprovider", file)
-                intent.setDataAndType(apkUri, "application/vnd.android.package-archive")
-                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
-                val packageManager = activity.packageManager
-                val resolveInfos = packageManager.queryIntentActivities(intent, 0)
-                for (resolveInfo in resolveInfos) {
-                    val packageName = resolveInfo.activityInfo.packageName
-                    activity.grantUriPermission(packageName, apkUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        pluginScope.launch {
+            val ret = withContext(Dispatchers.IO) {
+                val r = JSObject()
+                try {
+                    val file = File(args.path ?: "")
+                    if (file.exists()) {
+                        val intent = Intent(Intent.ACTION_VIEW)
+                        val apkUri = FileProvider.getUriForFile(activity, "${activity.packageName}.fileprovider", file)
+                        intent.setDataAndType(apkUri, "application/vnd.android.package-archive")
+                        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
+                        val packageManager = activity.packageManager
+                        val resolveInfos = packageManager.queryIntentActivities(intent, 0)
+                        for (resolveInfo in resolveInfos) {
+                            val packageName = resolveInfo.activityInfo.packageName
+                            activity.grantUriPermission(packageName, apkUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        }
+                        withContext(Dispatchers.Main) { activity.startActivity(intent) }
+                        r.put("success", true)
+                    } else {
+                        r.put("success", false)
+                        r.put("error", "File does not exist")
+                    }
+                } catch (e: Exception) {
+                    r.put("success", false)
+                    r.put("error", e.message)
                 }
-                activity.startActivity(intent)
-                ret.put("success", true)
-            } else {
-                ret.put("success", false)
-                ret.put("error", "File does not exist")
+                r
             }
-        } catch (e: Exception) {
-            ret.put("success", false)
-            ret.put("error", e.message)
+            if (isActive) invoke.resolve(ret)
         }
-        invoke.resolve(ret)
     }
 
     @Command
@@ -493,46 +514,66 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
 
     @Command
     fun get_sys_fonts_list(invoke: Invoke) {
-        val ret = JSObject()
-        try {
-            val fontList = mutableListOf<String>()
-            val fontFileList = mutableListOf<String>()
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                val systemFonts = SystemFonts.getAvailableFonts()
-                for (font in systemFonts) {
-                    val file = font.getFile()?: continue
-                    if (file.isFile && (file.name.endsWith(".ttf", true) || file.name.endsWith(".otf", true))) {
-                        fontFileList.add(file.name)
+        pluginScope.launch {
+            val ret = withContext(Dispatchers.IO) {
+                val r = JSObject()
+                try {
+                    val fontList = cachedFontList ?: run {
+                        val fonts = scanFonts()
+                        cachedFontList = fonts
+                        fonts
+                    }
+                    val fontDict = JSObject()
+                    for (fontName in fontList) {
+                        fontDict.put(fontName, fontName)
+                    }
+                    r.put("fonts", fontDict)
+                } catch (e: Exception) {
+                    r.put("error", e.message)
+                }
+                r
+            }
+            if (isActive) invoke.resolve(ret)
+        }
+    }
+
+    // Scanning system fonts walks the font directory and is stable for the
+    // process lifetime, so cache it. @Volatile for safe publication across
+    // the IO dispatcher threads.
+    @Volatile
+    private var cachedFontList: List<String>? = null
+
+    private fun scanFonts(): List<String> {
+        val fontList = mutableListOf<String>()
+        val fontFileList = mutableListOf<String>()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val systemFonts = SystemFonts.getAvailableFonts()
+            for (font in systemFonts) {
+                val file = font.getFile() ?: continue
+                if (file.isFile && (file.name.endsWith(".ttf", true) || file.name.endsWith(".otf", true))) {
+                    fontFileList.add(file.name)
+                }
+            }
+        } else {
+            val fontDirs = listOf("/system/fonts", "/system/font", "/data/fonts")
+            for (dirPath in fontDirs) {
+                val dir = File(dirPath)
+                if (dir.exists() && dir.isDirectory) {
+                    dir.listFiles()?.forEach { file ->
+                        if (file.isFile && (file.name.endsWith(".ttf", true) || file.name.endsWith(".otf", true))) {
+                            fontFileList.add(file.name)
+                        }
                     }
                 }
-            } else {
-                val fontDirs = listOf("/system/fonts", "/system/font", "/data/fonts")
-                for (dirPath in fontDirs) {
-                  val dir = File(dirPath)
-                  if (dir.exists() && dir.isDirectory) {
-                      dir.listFiles()?.forEach { file ->
-                          if (file.isFile && (file.name.endsWith(".ttf", true) || file.name.endsWith(".otf", true))) {
-                              fontFileList.add(file.name)
-                          }
-                      }
-                  }
-                }
             }
-            for (fileFileName in fontFileList) {
-                var fontName = fileFileName
-                    .replace(Regex("\\.(ttf|otf)$", RegexOption.IGNORE_CASE), "")
-                    .trim()
-                fontList.add(fontName)
-            }
-            var fontDict = JSObject()
-            for (fontName in fontList) {
-                fontDict.put(fontName, fontName)
-            }
-            ret.put("fonts", fontDict)
-        } catch (e: Exception) {
-            ret.put("error", e.message)
         }
-        invoke.resolve(ret)
+        for (fileFileName in fontFileList) {
+            val fontName = fileFileName
+                .replace(Regex("\\.(ttf|otf)$", RegexOption.IGNORE_CASE), "")
+                .trim()
+            fontList.add(fontName)
+        }
+        return fontList
     }
 
     @Command
@@ -1046,57 +1087,69 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
             return invoke.reject("empty word")
         }
 
-        try {
-            val intent = Intent(Intent.ACTION_PROCESS_TEXT).apply {
-                type = "text/plain"
-                putExtra(Intent.EXTRA_PROCESS_TEXT, word)
-                // Read-only — we don't want third-party apps writing
-                // back into a clipboard or selection slot we don't own.
-                putExtra(Intent.EXTRA_PROCESS_TEXT_READONLY, true)
-            }
+        val intent = Intent(Intent.ACTION_PROCESS_TEXT).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_PROCESS_TEXT, word)
+            // Read-only — we don't want third-party apps writing
+            // back into a clipboard or selection slot we don't own.
+            putExtra(Intent.EXTRA_PROCESS_TEXT_READONLY, true)
+        }
 
-            val pm = activity.packageManager
-            val handlers = pm.queryIntentActivities(intent, 0).map {
-                LookupHandler(it.activityInfo.packageName, it.activityInfo.name)
-            }
-            val browserPackages = queryBrowserPackages(pm)
-            val remembered = readRememberedDictionary()
+        pluginScope.launch {
+            try {
+                // queryIntentActivities/queryBrowserPackages scan installed-app
+                // manifests (50–200ms) and readRememberedDictionary touches
+                // disk; keep them off the plugin command thread so other plugin
+                // IPC isn't queued behind a dictionary lookup. The dispatch
+                // itself (startActivity) hops back to Main below.
+                val (dispatch, remembered) = withContext(Dispatchers.IO) {
+                    val pm = activity.packageManager
+                    val handlers = pm.queryIntentActivities(intent, 0).map {
+                        LookupHandler(it.activityInfo.packageName, it.activityInfo.name)
+                    }
+                    val browserPackages = queryBrowserPackages(pm)
+                    val remembered = readRememberedDictionary()
+                    decideLookupDispatch(handlers, browserPackages, remembered) to remembered
+                }
+                if (!isActive) return@launch
 
-            when (val dispatch = decideLookupDispatch(handlers, browserPackages, remembered)) {
-                is LookupDispatch.Unavailable -> {
-                    val ret = JSObject()
-                    ret.put("success", false)
-                    ret.put("unavailable", true)
-                    return invoke.resolve(ret)
+                when (dispatch) {
+                    is LookupDispatch.Unavailable -> {
+                        val ret = JSObject()
+                        ret.put("success", false)
+                        ret.put("unavailable", true)
+                        invoke.resolve(ret)
+                        return@launch
+                    }
+                    // FLAG_ACTIVITY_NEW_TASK is required because `activity`
+                    // here is the plugin's host activity context — without it
+                    // some OEM ROMs reject the dispatch with "Calling
+                    // startActivity() from outside of an Activity context".
+                    is LookupDispatch.DispatchImplicit -> {
+                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        activity.startActivity(intent)
+                    }
+                    is LookupDispatch.DispatchExplicit -> {
+                        intent.setClassName(dispatch.handler.packageName, dispatch.handler.className)
+                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        activity.startActivity(intent)
+                    }
+                    is LookupDispatch.DispatchChooser -> {
+                        // We only reach here when the remembered app (if any)
+                        // was stale — otherwise it would have been launched
+                        // directly. Drop it so a fresh pick replaces it.
+                        if (remembered != null) clearRememberedDictionary()
+                        startBrowserExcludingChooser(intent, dispatch.exclude)
+                    }
                 }
-                // FLAG_ACTIVITY_NEW_TASK is required because `activity`
-                // here is the plugin's host activity context — without it
-                // some OEM ROMs reject the dispatch with "Calling
-                // startActivity() from outside of an Activity context".
-                is LookupDispatch.DispatchImplicit -> {
-                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    activity.startActivity(intent)
-                }
-                is LookupDispatch.DispatchExplicit -> {
-                    intent.setClassName(dispatch.handler.packageName, dispatch.handler.className)
-                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    activity.startActivity(intent)
-                }
-                is LookupDispatch.DispatchChooser -> {
-                    // We only reach here when the remembered app (if any)
-                    // was stale — otherwise it would have been launched
-                    // directly. Drop it so a fresh pick replaces it.
-                    if (remembered != null) clearRememberedDictionary()
-                    startBrowserExcludingChooser(intent, dispatch.exclude)
-                }
-            }
 
-            val ret = JSObject()
-            ret.put("success", true)
-            invoke.resolve(ret)
-        } catch (e: Exception) {
-            Log.e("NativeBridgePlugin", "show_lookup_popover failed", e)
-            invoke.reject("Failed to look up word: ${e.message}")
+                val ret = JSObject()
+                ret.put("success", true)
+                invoke.resolve(ret)
+            } catch (e: Exception) {
+                Log.e("NativeBridgePlugin", "show_lookup_popover failed", e)
+                if (isActive) invoke.reject("Failed to look up word: ${e.message}")
+            }
         }
     }
 

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-tts/android/src/main/java/MediaPlaybackService.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-tts/android/src/main/java/MediaPlaybackService.kt
@@ -26,12 +26,14 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import app.tauri.plugin.JSObject
+import kotlinx.coroutines.*
 
 class MediaPlaybackService : MediaBrowserServiceCompat() {
     private var mediaSession: MediaSessionCompat? = null
     private lateinit var player: ExoPlayer
     private lateinit var stateBuilder: PlaybackStateCompat.Builder
     private lateinit var audioManager: AudioManager
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     private val afChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
         Log.i("MediaPlaybackService", "Audio focus changed: $focusChange, $player.isPlaying")
@@ -221,24 +223,29 @@ class MediaPlaybackService : MediaBrowserServiceCompat() {
         if (intent?.action == "UPDATE_METADATA") {
             currentTitle = intent.getStringExtra("title") ?: currentTitle
             currentArtist = intent.getStringExtra("artist") ?: currentArtist
-            val newArtwork = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                intent.getParcelableExtra("artwork", Bitmap::class.java)
-            } else {
-                @Suppress("DEPRECATION")
-                intent.getParcelableExtra("artwork")
+            // Unmarshal the artwork Bitmap off the main thread; copying its
+            // pixel buffer out of the Parcel can stall the UI thread and trip
+            // an ANR for large covers.
+            serviceScope.launch {
+                val newArtwork = withContext(Dispatchers.Default) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        intent.getParcelableExtra("artwork", Bitmap::class.java)
+                    } else {
+                        @Suppress("DEPRECATION")
+                        intent.getParcelableExtra("artwork")
+                    }
+                }
+                if (newArtwork != null) {
+                    currentArtwork = newArtwork
+                }
+                if (!isActive) return@launch
+                val metadataBuilder = MediaMetadataCompat.Builder()
+                    .putString(MediaMetadataCompat.METADATA_KEY_TITLE, currentTitle)
+                    .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, currentArtist)
+                    .putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, currentArtwork)
+                mediaSession?.setMetadata(metadataBuilder.build())
+                showNotification(if (player.isPlaying) PlaybackStateCompat.STATE_PLAYING else PlaybackStateCompat.STATE_PAUSED)
             }
-            if (newArtwork != null) {
-                currentArtwork = newArtwork
-            }
-
-            val metadataBuilder = MediaMetadataCompat.Builder()
-                .putString(MediaMetadataCompat.METADATA_KEY_TITLE, currentTitle)
-                .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, currentArtist)
-                .putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, currentArtwork)
-            
-            mediaSession?.setMetadata(metadataBuilder.build())
-
-            showNotification(if (player.isPlaying) PlaybackStateCompat.STATE_PLAYING else PlaybackStateCompat.STATE_PAUSED)
         } else if (intent?.action == "UPDATE_PLAYBACK_STATE") {
             val isPlaying = intent.getBooleanExtra("playing", false)
             val position = intent.getLongExtra("position", 0L) // in milliseconds
@@ -262,6 +269,7 @@ class MediaPlaybackService : MediaBrowserServiceCompat() {
     }
 
     override fun onDestroy() {
+        serviceScope.cancel()
         super.onDestroy()
         player.release()
         mediaSession?.release()


### PR DESCRIPTION
## Summary

Backports the Android ANR / stability fixes from the [`julianshen` fork](https://github.com/julianshen/readest), adapted to upstream. Each fix moves blocking work off the main/UI thread or fixes a lifecycle leak; the #3297 fix addresses a blank-screen-on-launch race on Android 14+.

**Adapted, not copied:** the fork's versions of these files also *dropped* two things this PR deliberately preserves — the cold-start `shared-intent` replay queue (`emitOrQueue` / `registerListener`, the "Open with" cold-start delivery fix) and the #4559 dictionary-dispatch logic (`decideLookupDispatch`). Both are kept intact here.

## Changes

- **`NativeBridgePlugin`** — blocking `@Command` I/O (`copy_uri_to_path`, `install_package`, `get_sys_fonts_list`, and `show_lookup_popover`'s 50–200 ms `queryIntentActivities`) now runs on `Dispatchers.IO` via a Main-dispatched `pluginScope`. `startActivity` hops back to Main; each `invoke.resolve` is `isActive`-guarded; `onDestroy()` cancels the scope and clears the static `instance` (avoids leaking a destroyed Activity); the system-font scan is cached (`@Volatile`).
- **`MediaPlaybackService`** — the notification artwork `Bitmap` is unmarshalled off the main thread (`serviceScope` + `Dispatchers.Default`), `isActive`-guarded; the scope is cancelled in `onDestroy`.
- **`ClipUrlController`** — holds the `Activity` via `WeakReference` and checks `isFinishing`/`isDestroyed` before presenting, so the up-to-30 s clip window can't leak the Activity/WebView.
- **`MainActivity` (#3297)** — on Android 14+ the window can gain focus before the WebView paints its first frame, leaving a blank screen. Forces a single repaint once both the window has focus and the WebView exists (whichever happens last).

## Not backported (on purpose)

The fork's touch-event throttle and intent-handling rewrite are **excluded** — they dropped `touchmove` forwarding (breaking the Android text-selection drag signal) and removed the cold-start intent queue.

## Testing

Kotlin-only; not exercised by the JS (`vitest`) or Rust (`cargo`) test suites, nor by `clippy`/`fmt` (no `.rs` changed). Verified via `ktlint` (parse) + a release `tauri android build` and an on-device smoke test on a Xiaomi (Android). CI's Android build is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
