### PR TITLE
fix(library): restore back button from series/author folders (#4437)

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/group-header.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/group-header.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import GroupHeader from '@/app/library/components/GroupHeader';
+import { LibraryGroupByType } from '@/types/settings';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+vi.mock('@/hooks/useResponsiveSize', () => ({
+  useResponsiveSize: (n: number) => n,
+}));
+
+const routerStub = { push: vi.fn(), replace: vi.fn(), back: vi.fn() };
+let currentSearch = '';
+vi.mock('next/navigation', () => ({
+  useRouter: () => routerStub,
+  useSearchParams: () => new URLSearchParams(currentSearch),
+}));
+
+const navigateToLibraryMock = vi.fn();
+vi.mock('@/utils/nav', () => ({
+  navigateToLibrary: (...args: unknown[]) => navigateToLibraryMock(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+  navigateToLibraryMock.mockReset();
+});
+
+describe('GroupHeader back button', () => {
+  // Regression for #4437: inside a series/author folder after a cold start, the
+  // URL is just `?group=X` (groupBy comes from settings, not the URL). Deleting
+  // `group` would leave an empty query, and `router.replace('/library')` with an
+  // empty search silently no-ops under the Next.js 16.2 static export (same root
+  // cause as #3782, fixed for the breadcrumb "All" button in #3832). The back
+  // button must keep the query non-empty via the `group=` workaround so the
+  // navigation actually commits.
+  it('keeps a non-empty query when group is the only param', () => {
+    currentSearch = 'group=abc123';
+    render(<GroupHeader groupBy={LibraryGroupByType.Series} groupName='My Series' />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to library' }));
+
+    expect(navigateToLibraryMock).toHaveBeenCalledTimes(1);
+    const query = navigateToLibraryMock.mock.calls[0]![1] as string;
+    expect(query).not.toBe('');
+    const params = new URLSearchParams(query);
+    expect(params.has('group')).toBe(true);
+    expect(params.get('group')).toBe('');
+  });
+
+  it('preserves other params while clearing the group', () => {
+    currentSearch = 'groupBy=author&sort=title&group=abc123';
+    render(<GroupHeader groupBy={LibraryGroupByType.Author} groupName='Jane Doe' />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to library' }));
+
+    const query = navigateToLibraryMock.mock.calls[0]![1] as string;
+    const params = new URLSearchParams(query);
+    expect(params.get('groupBy')).toBe('author');
+    expect(params.get('sort')).toBe('title');
+    expect(params.get('group')).toBe('');
+  });
+});

--- a/apps/readest-app/src/app/library/components/GroupHeader.tsx
+++ b/apps/readest-app/src/app/library/components/GroupHeader.tsx
@@ -23,7 +23,16 @@ const GroupHeader: React.FC<GroupHeaderProps> = ({ groupBy, groupName }) => {
 
   const handleBack = () => {
     const params = new URLSearchParams(searchParams?.toString());
-    params.delete('group');
+    // Set `group` to an empty string instead of deleting it. After a cold start
+    // the URL inside a series/author folder is just `?group=X` (groupBy comes
+    // from settings, not the URL), so deleting `group` would leave an empty
+    // search string — and `router.replace('/library')` with an empty search
+    // silently no-ops under the Next.js 16.2 static export, leaving the back
+    // button dead (#4437). This mirrors the workaround in
+    // `handleLibraryNavigation` (see page.tsx, originally #3782/#3832): the
+    // resulting `/library?group=` does commit, and the trailing empty `group=`
+    // is stripped cosmetically by the cleanup effect in page.tsx.
+    params.set('group', '');
     navigateToLibrary(router, params.toString());
   };
 


### PR DESCRIPTION
## Summary

Fixes #4437 — inside a **Series/Author** library folder, the back arrow does nothing; you cannot return to the main list. Reported on Android, iOS, and Windows since v0.10.1.

## Root cause

It's the same **Next.js 16.2 static-export regression** as #3782: `router.replace()` to a same-pathname URL with an **empty query string** silently no-ops (this applies to every non-web `output: 'export'` build; `next dev` is unaffected). #3832 fixed it for the breadcrumb **"All"** button in `handleLibraryNavigation` by setting `group=''` instead of deleting it — but the series/author back button (`GroupHeader.handleBack`) never got the same workaround and still did `params.delete('group')`.

It only reproduces **after a cold start**, when `groupBy` comes from settings (not the URL) and sort/order/view are at defaults — so `group` ends up the *only* query param, and deleting it yields `/library` (empty search → no-op). Within a session the View menu also puts `groupBy=author` in the URL, which keeps the query non-empty, so back works — that's why it couldn't be reproduced in-session.

## Fix

`GroupHeader.handleBack` now sets `group=''` (mirroring `handleLibraryNavigation`). The resulting `/library?group=` commits, and the existing cleanup effect in `page.tsx` strips the trailing empty `group=` cosmetically.

## Testing

- New `src/__tests__/app/library/group-header.test.tsx` — fails on the old behavior (empty query / deleted param), passes with the fix.
- `pnpm test` (full suite) and `pnpm lint` (tsgo + biome) green.
- **Verified on-device** (Xiaomi, Android 16, WebView 148, static-export build): tapping back inside an author folder takes `?group=…` → `/library` and restores the folder list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)