### PR TITLE
fix(security): scope Tauri download_file/upload_file to fs_scope

### DIFF
--- a/apps/readest-app/src-tauri/src/transfer_file.rs
+++ b/apps/readest-app/src-tauri/src/transfer_file.rs
@@ -8,7 +8,8 @@
 
 use futures_util::TryStreamExt;
 use serde::{ser::Serializer, Serialize};
-use tauri::{command, ipc::Channel};
+use tauri::{command, ipc::Channel, AppHandle};
+use tauri_plugin_fs::FsExt;
 use tokio::{
     fs::File,
     io::{AsyncWriteExt, BufWriter},
@@ -82,6 +83,35 @@ pub enum Error {
     ContentLength(String),
     #[error("request failed with status code {0}: {1}")]
     HttpErrorCode(u16, String),
+    #[error("permission denied: path not in filesystem scope: {0}")]
+    Forbidden(String),
+}
+
+/// Reject paths the webview must not be allowed to target: relative paths and
+/// any `..` parent-directory traversal. `fs_scope().is_allowed` is a glob match,
+/// so a `..` segment could otherwise escape an allowed prefix.
+fn has_disallowed_components(file_path: &str) -> bool {
+    let path = std::path::Path::new(file_path);
+    !path.is_absolute()
+        || path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+}
+
+/// Validate a webview-supplied `file_path` before any `File::create`/`File::open`.
+/// Without this, `download_file`/`upload_file` would write/read arbitrary local
+/// paths (e.g. `~/.ssh/id_rsa`, autostart entries) from any JS running in the
+/// privileged Tauri origin — see GHSA-55vr-pvq5-6fmg. We require an absolute,
+/// traversal-free path that is inside the app's filesystem scope (the static
+/// capability globs plus persisted dialog grants for custom/external roots).
+fn ensure_path_allowed(app: &AppHandle, file_path: &str) -> Result<()> {
+    if has_disallowed_components(file_path) {
+        return Err(Error::Forbidden(file_path.to_string()));
+    }
+    if !app.fs_scope().is_allowed(std::path::Path::new(file_path)) {
+        return Err(Error::Forbidden(file_path.to_string()));
+    }
+    Ok(())
 }
 
 impl Serialize for Error {
@@ -102,7 +132,9 @@ pub struct ProgressPayload {
 }
 
 #[command]
+#[allow(clippy::too_many_arguments)] // Tauri command surface mirrors the JS caller's options.
 pub async fn download_file(
+    app: AppHandle,
     url: &str,
     file_path: &str,
     headers: HashMap<String, String>,
@@ -114,6 +146,8 @@ pub async fn download_file(
     use futures::stream::{self, StreamExt};
     use std::cmp::min;
     use tokio::io::AsyncSeekExt;
+
+    ensure_path_allowed(&app, file_path)?;
 
     const PART_SIZE: u64 = 1024 * 1024;
 
@@ -279,12 +313,15 @@ pub async fn download_file(
 
 #[command]
 pub async fn upload_file(
+    app: AppHandle,
     url: &str,
     file_path: &str,
     method: &str,
     headers: HashMap<String, String>,
     on_progress: Channel<ProgressPayload>,
 ) -> Result<String> {
+    ensure_path_allowed(&app, file_path)?;
+
     let file = File::open(file_path).await?;
     let file_len = file.metadata().await.unwrap().len();
 
@@ -329,4 +366,38 @@ fn file_to_body(channel: Channel<ProgressPayload>, file: File, file_len: u64) ->
             });
         }),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_disallowed_components;
+
+    #[test]
+    fn rejects_relative_and_traversal_paths() {
+        // Relative paths can't be reasoned about against an absolute scope.
+        assert!(has_disallowed_components("relative/file.epub"));
+        assert!(has_disallowed_components("file.epub"));
+        // `..` traversal, whether the path is relative or absolute.
+        assert!(has_disallowed_components("foo/../bar"));
+        assert!(has_disallowed_components(
+            "/home/user/Readest/../../.ssh/id_rsa"
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn accepts_plain_absolute_paths() {
+        assert!(!has_disallowed_components(
+            "/Users/x/Library/Caches/app/book.epub"
+        ));
+        assert!(!has_disallowed_components("/Users/x/Readest/Books/h.epub"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn accepts_plain_absolute_paths_windows() {
+        assert!(!has_disallowed_components(
+            "C:\\Users\\x\\AppData\\Roaming\\Readest\\Books\\h.epub"
+        ));
+    }
 }


### PR DESCRIPTION
Native-side fix for the remaining web/desktop security advisory.

## Problem (`GHSA-55vr-pvq5-6fmg`)
The custom Tauri commands `download_file` and `upload_file` in `src-tauri/src/transfer_file.rs` passed a webview-supplied `file_path` straight to `File::create` / `File::open` with no scope or traversal check. Any JavaScript running in the privileged Tauri origin (XSS in the app UI, a compromised renderer, or — depending on the book sandbox — book-embedded script) could therefore write attacker content to any writable path (autostart/RC persistence, overwrite trusted files) or read and exfiltrate any readable file (SSH keys, tokens, the app's own sync secrets). `dir_scanner::read_dir` already gates on `fs_scope`; these two commands did not.

## Fix
Validate `file_path` before any open/create:
- Reject relative paths and any `..` parent-directory traversal.
- Require the path to be inside the app's filesystem scope via `fs_scope().is_allowed()` — the same mechanism `read_dir` uses.

`AppHandle` is injected by Tauri, so the JS `invoke('download_file' | 'upload_file', …)` surface is unchanged.

### Why legitimate flows keep working
Every real caller (cloud sync, WebDAV sync, the self-updater APK, OPDS downloads) resolves its destination through `appService.resolveFilePath`, landing under a path the scope already covers:
- static capability globs — `$APPDATA/Readest/**`, `$APPCACHE/**`, `$TEMP/**`;
- persisted dialog grants — a custom root dir (`setCustomRootDir` via the directory picker → `allow_paths_in_scopes`) and external library folders (re-granted on startup), both made sticky by `tauri_plugin_persisted_scope`.

So a path outside scope indicates a coverage gap to grant explicitly, not a reason to keep an open file API.

## Verification
- `pnpm test:rust` — green (adds `transfer_file::tests` for traversal/relative rejection)
- `pnpm clippy:check` and `pnpm fmt:check` — clean

## Related
Web/server advisories are addressed in #4638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)