### PR TITLE
fix(epub): import books whose OPF has an unescaped ampersand

### DIFF
--- a/apps/readest-app/src/__tests__/foliate-opf-entity-sanitize.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-opf-entity-sanitize.test.ts
@@ -1,0 +1,67 @@
+// Regression test for an import failure on EPUBs whose OPF contains a raw,
+// unescaped ampersand.
+//
+// "Shadow Slave - Vol. 6 - All The Devils Are Here.epub" ships an OPF with a
+// hand-built manifest id that was never XML-escaped:
+//
+//   <item id="Chapter_1213_Search_&_Rescue_153" .../>
+//
+// The bare `&` makes the OPF non-well-formed XML. A strict parser (DOMParser in
+// Chrome/jsdom, and the same parser foliate-js uses on every platform) reads the
+// `&`, then the name `_Rescue_153`, then hits `"` where it expected `;` and
+// reports `EntityRef: expecting ';'`. Import then dies with
+// "Failed to open the book file: XML parsing error: ...".
+//
+// foliate-js already mapped a handful of named HTML entities (`&nbsp;` …) to
+// numeric refs, but it never escaped stray ampersands that aren't part of any
+// entity reference. This test pins the fix: such an OPF must still parse and
+// yield its metadata.
+import { describe, expect, it } from 'vitest';
+
+import { parseEpubMetadataFromXML } from 'foliate-js/epub.js';
+
+const NBSP = String.fromCharCode(160);
+
+const opf = (title: string, manifest: string) => `<?xml version='1.0' encoding='utf-8'?>
+<package xmlns="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" unique-identifier="BookId" version="3.0">
+  <metadata>
+    <dc:title>${title}</dc:title>
+    <dc:creator>Guiltythree</dc:creator>
+    <dc:identifier id="BookId">1</dc:identifier>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    ${manifest}
+  </manifest>
+  <spine>
+    <itemref idref="cover"/>
+  </spine>
+</package>`;
+
+const COVER = `<item id="cover" href="cover.xhtml" media-type="application/xhtml+xml"/>`;
+
+describe('OPF XML entity sanitization', () => {
+  it('imports an OPF with a raw & in a manifest item id (the reported bug)', () => {
+    const title = 'Shadow Slave - Vol. 6 - All The Devils Are Here';
+    const xml = opf(
+      title,
+      `${COVER}
+       <item id="Chapter_1213_Search_&_Rescue_153" href="content/c1.xhtml" media-type="application/xhtml+xml"/>`,
+    );
+    const { metadata } = parseEpubMetadataFromXML(xml);
+    expect(metadata.title).toBe(title);
+  });
+
+  it('escapes a bare & in element text content', () => {
+    const xml = opf('Search & Rescue & More', COVER);
+    const { metadata } = parseEpubMetadataFromXML(xml);
+    expect(metadata.title).toBe('Search & Rescue & More');
+  });
+
+  it('preserves valid entities and numeric/named references (no double-escaping)', () => {
+    // &amp; -> "&", &#160; -> U+00A0, &nbsp; -> U+00A0 (mapped from HTML).
+    const xml = opf('R&amp;D&#160;Press&nbsp;Ltd', COVER);
+    const { metadata } = parseEpubMetadataFromXML(xml);
+    expect(metadata.title).toBe(`R&D${NBSP}Press${NBSP}Ltd`);
+  });
+});


### PR DESCRIPTION
## Problem

Importing some EPUBs fails with:

```
Failed to import book: Shadow Slave - Vol. 6 - All The Devils Are Here.epub
Error: Failed to open the book file: XML parsing error: EPUB/ShadowSlave-Vol.6-AllTheDevilsAreHere.opf
... error on line 172 at column 43: EntityRef: expecting ';'
```

The book's OPF isn't well-formed XML — it has a bare, unescaped `&` in a hand-built manifest id (and the matching spine `idref`):

```xml
<item id="Chapter_1213_Search_&_Rescue_153" .../>
```

A strict XML parser reads `&`, then the name `_Rescue_153`, then hits `"` where it expected `;`. foliate-js already mapped named HTML entities (`&nbsp;` …) but never escaped a stray `&`, so both of its XML entry points threw:

- **Web / desktop / Android reader-open:** `EPUB.init()` → `#loadXML`
- **Android / desktop native import bridge:** `parseEpubMetadataFromXML` (parsed unsanitized)

## Fix

Bumps the `foliate-js` submodule to readest/foliate-js#26, which extracts a shared `sanitizeXMLEntities()` and escapes any `&` that doesn't begin a valid character/entity reference, applied at **both** parse sites. Valid and numeric references (`&amp;`, `&#160;`) are preserved; the manifest `id` and spine `idref` get the same escaping so the reference still resolves.

No Rust change needed — the native parser reads attribute bytes raw (no unescape), so it never choked; only the JS metadata parse did.

## Tests / verification

- New unit test `src/__tests__/foliate-opf-entity-sanitize.test.ts` — fails before the fix (`TypeError` on the parsererror doc), passes after. Covers raw `&` in a manifest id, raw `&` in text, and preservation of valid/numeric/named references.
- Full unit suite green; `pnpm lint` clean.
- **Chrome (web):** real drag-drop import of the book succeeds (count +1, cover renders, no error) where it previously threw.
- **Xiaomi 13 (native):** built + installed the app and opened the book over CDP via the "Open with" intent (the native import path) — renders, OPF title read live — previously failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)