### PR TITLE
fix(metadata): parse FB2 series from title-info sequence (#4646)

### DIFF
--- a/apps/readest-app/src/__tests__/document/series-metadata.test.ts
+++ b/apps/readest-app/src/__tests__/document/series-metadata.test.ts
@@ -77,6 +77,25 @@ describe('Calibre series metadata', () => {
     });
   });
 
+  describe('FB2 (title-info sequence)', () => {
+    let book: BookDoc;
+
+    beforeAll(async () => {
+      book = await loadFixture('sample-metadata.fb2', 'application/x-fictionbook+xml', 'FB2');
+    });
+
+    it('extracts series name and position from the sequence element', () => {
+      const series = getSeries(book);
+      expect(series).toBeTruthy();
+      expect(series!.name).toBe('Metadata Series');
+      expect(series!.position).toBe('3');
+    });
+
+    it('preserves the title', () => {
+      expect(book.metadata.title).toBe('FB2 Metadata');
+    });
+  });
+
   describe('CBZ (ComicInfo.xml + ComicBookInfo)', () => {
     let book: BookDoc;
 

--- a/apps/readest-app/src/__tests__/fixtures/data/sample-metadata.fb2
+++ b/apps/readest-app/src/__tests__/fixtures/data/sample-metadata.fb2
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0" xmlns:l="http://www.w3.org/1999/xlink">
+<description>
+  <title-info>
+    <genre>sf_fantasy</genre>
+    <author>
+      <first-name>Jane</first-name>
+      <last-name>Doe</last-name>
+    </author>
+    <book-title>FB2 Metadata</book-title>
+    <annotation>
+      <p>A short annotation.</p>
+    </annotation>
+    <lang>en</lang>
+    <sequence name="Metadata Series" number="3"/>
+  </title-info>
+  <document-info>
+    <author>
+      <first-name/>
+      <last-name/>
+    </author>
+    <date value="2023-10-18">18 October 2023</date>
+    <id>43AC9A08-92D4-432C-B908-FCE4992205CC</id>
+    <version>1.0</version>
+  </document-info>
+</description>
+<body>
+  <title>
+   <p>FB2 Metadata</p>
+  </title>
+  <section>
+   <title>
+    <p>Chapter 1</p>
+   </title>
+   <p>Hello world.</p>
+  </section>
+</body>
+</FictionBook>


### PR DESCRIPTION
Fixes #4646

## Problem

FB2 series metadata (series name + index) never showed up in the library or book details. FB2 stores it as `<sequence name="…" number="…"/>` inside `<title-info>`, but the foliate-js FB2 parser never read that element, so `book.metadata.belongsTo.series` was always empty. The downstream conversion in `bookService` / `readerStore` (which maps `belongsTo.series → metadata.series / seriesIndex / seriesTotal`) therefore had nothing to convert.

This is why none of the reporter's workarounds helped — import, "Refresh metadata", and export→re-import all share the same `DocumentLoader → makeFB2` path.

## Fix

- Bumps the `packages/foliate-js` submodule to pull in readest/foliate-js#28, which maps `title-info > sequence` into the same `belongsTo.series` shape already produced by the EPUB and comic-book parsers.
- Adds a regression test (`series-metadata.test.ts`, alongside the existing PDF/CBZ cases) plus a minimal `sample-metadata.fb2` fixture.

## Verification

- Verified against the file attached to the issue (`<sequence name="ТБ" number="4"/>`) → `{ name: "ТБ", position: "4" }`.
- `pnpm test` — full suite green (5782 passed). `pnpm lint` (tsgo + Biome) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)