### PR TITLE
fix(settings): tidy Word Lens data pack and level rows on mobile

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -1872,13 +1872,9 @@
   "Data pack": "حزمة البيانات",
   "Open a book to manage its data pack.": "افتح كتابًا لإدارة حزمة بياناته.",
   "No data available for this language pair yet.": "لا تتوفر بيانات لهذا الزوج اللغوي بعد.",
-  "Download {{size}}": "تنزيل {{size}}",
   "Enable Word Lens": "تفعيل Word Lens",
   "Vocabulary level": "مستوى المفردات",
-  "Words above your level get a hint": "تحصل الكلمات الأعلى من مستواك على تلميح",
-  "Hint Language": "لغة التلميح",
   "Data": "البيانات",
-  "Download data packs automatically when needed.": "تنزيل حزم البيانات تلقائيًا عند الحاجة.",
   "Failed to check for updates": "فشل التحقق من التحديثات",
   "Update": "تحديث",
   "Nightly Builds": "إصدارات ليلية",
@@ -1905,5 +1901,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "يتطلب رمز PIN (والبيومترية، إن توفّرت) لفتح Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "البيومترية"
+  "biometrics": "البيومترية",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "أظهر تلميحًا قصيرًا بلغتك الأم فوق الكلمات الصعبة. الكلمات التي تفوق مستواك تحصل على تلميح.",
+  "Level": "المستوى",
+  "CEFR level": "مستوى CEFR"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1740,13 +1740,9 @@
   "Data pack": "ডেটা প্যাক",
   "Open a book to manage its data pack.": "এর ডেটা প্যাক পরিচালনা করতে একটি বই খুলুন।",
   "No data available for this language pair yet.": "এই ভাষা জোড়ার জন্য এখনও কোনো ডেটা উপলব্ধ নেই।",
-  "Download {{size}}": "{{size}} ডাউনলোড করুন",
   "Enable Word Lens": "Word Lens চালু করুন",
   "Vocabulary level": "শব্দভান্ডার স্তর",
-  "Words above your level get a hint": "আপনার স্তরের উপরের শব্দগুলির জন্য একটি ইঙ্গিত দেখানো হয়",
-  "Hint Language": "ইঙ্গিতের ভাষা",
   "Data": "ডেটা",
-  "Download data packs automatically when needed.": "প্রয়োজনে স্বয়ংক্রিয়ভাবে ডেটা প্যাক ডাউনলোড করুন।",
   "Failed to check for updates": "আপডেট পরীক্ষা করতে ব্যর্থ",
   "Update": "আপডেট",
   "Nightly Builds": "নাইটলি বিল্ড",
@@ -1773,5 +1769,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Readest খুলতে PIN (এবং উপলব্ধ হলে বায়োমেট্রিক্স) প্রয়োজন",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "বায়োমেট্রিক্স"
+  "biometrics": "বায়োমেট্রিক্স",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "কঠিন শব্দের উপরে আপনার মাতৃভাষায় একটি সংক্ষিপ্ত ইঙ্গিত দেখান। আপনার স্তরের উপরের শব্দগুলো একটি ইঙ্গিত পায়।",
+  "Level": "স্তর",
+  "CEFR level": "CEFR স্তর"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1707,13 +1707,9 @@
   "Data pack": "གཞི་གྲངས་ཐུམ་སྒྲིལ།",
   "Open a book to manage its data pack.": "དེའི་གཞི་གྲངས་ཐུམ་སྒྲིལ་དོ་དམ་བྱེད་པར་དཔེ་ཆ་ཞིག་ཁ་ཕྱེ།",
   "No data available for this language pair yet.": "སྐད་ཡིག་ཟུང་འདིའི་ཆེད་ད་དུང་གཞི་གྲངས་མེད།",
-  "Download {{size}}": "{{size}} ཕབ་ལེན།",
   "Enable Word Lens": "Word Lens སྤྱོད་རུང་བཟོ།",
   "Vocabulary level": "ཚིག་མཛོད་རིམ་པ།",
-  "Words above your level get a hint": "ཁྱེད་ཀྱི་རིམ་པ་ལས་མཐོ་བའི་ཚིག་ལ་མཚོན་བྱེད་ཐོབ།",
-  "Hint Language": "མཚོན་བྱེད་སྐད་ཡིག",
   "Data": "གཞི་གྲངས།",
-  "Download data packs automatically when needed.": "དགོས་མཁོ་བྱུང་སྐབས་གཞི་གྲངས་ཐུམ་སྒྲིལ་རང་འགུལ་གྱིས་ཕབ་ལེན་བྱེད།",
   "Failed to check for updates": "གསར་སྒྱུར་ཞིབ་བཤེར་མ་ཐུབ།",
   "Update": "གསར་སྒྱུར།",
   "Nightly Builds": "མཚན་མོའི་བཟོ་སྐྲུན།",
@@ -1740,5 +1736,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Readest ཕྱེ་བར་ PIN (དང་གལ་ཏེ་ཡོད་ན་ལུས་རྟགས་ངོ་སྤྲོད།) དགོས།",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "ལུས་རྟགས་ངོ་སྤྲོད།"
+  "biometrics": "ལུས་རྟགས་ངོ་སྤྲོད།",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "ཚིག་དཀའ་མོའི་སྟེང་དུ་རང་གི་སྐད་ཡིག་ཐོག་ནས་བརྡ་སྟོན་ཐུང་ངུ་ཞིག་སྟོན། ཁྱེད་ཀྱི་རིམ་པ་ལས་མཐོ་བའི་ཚིག་ལ་བརྡ་སྟོན་ཐོབ།",
+  "Level": "རིམ་པ།",
+  "CEFR level": "CEFR རིམ་པ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1740,13 +1740,9 @@
   "Data pack": "Datenpaket",
   "Open a book to manage its data pack.": "Öffne ein Buch, um sein Datenpaket zu verwalten.",
   "No data available for this language pair yet.": "Für dieses Sprachpaar sind noch keine Daten verfügbar.",
-  "Download {{size}}": "{{size}} herunterladen",
   "Enable Word Lens": "Word Lens aktivieren",
   "Vocabulary level": "Vokabelniveau",
-  "Words above your level get a hint": "Wörter über deinem Niveau erhalten einen Hinweis",
-  "Hint Language": "Hinweissprache",
   "Data": "Daten",
-  "Download data packs automatically when needed.": "Datenpakete bei Bedarf automatisch herunterladen.",
   "Failed to check for updates": "Suche nach Updates fehlgeschlagen",
   "Update": "Aktualisierung",
   "Nightly Builds": "Nightly-Builds",
@@ -1773,5 +1769,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "PIN (und Biometrie, falls verfügbar) zum Öffnen von Readest erforderlich",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "Biometrie"
+  "biometrics": "Biometrie",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Zeigt einen kurzen Hinweis in deiner Muttersprache über schwierigen Wörtern an. Wörter über deinem Niveau erhalten einen Hinweis.",
+  "Level": "Niveau",
+  "CEFR level": "CEFR-Niveau"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1740,13 +1740,9 @@
   "Data pack": "Πακέτο δεδομένων",
   "Open a book to manage its data pack.": "Ανοίξτε ένα βιβλίο για να διαχειριστείτε το πακέτο δεδομένων του.",
   "No data available for this language pair yet.": "Δεν υπάρχουν ακόμη διαθέσιμα δεδομένα για αυτό το ζεύγος γλωσσών.",
-  "Download {{size}}": "Λήψη {{size}}",
   "Enable Word Lens": "Ενεργοποίηση Word Lens",
   "Vocabulary level": "Επίπεδο λεξιλογίου",
-  "Words above your level get a hint": "Οι λέξεις πάνω από το επίπεδό σας λαμβάνουν υπόδειξη",
-  "Hint Language": "Γλώσσα υπόδειξης",
   "Data": "Δεδομένα",
-  "Download data packs automatically when needed.": "Αυτόματη λήψη πακέτων δεδομένων όταν χρειάζεται.",
   "Failed to check for updates": "Αποτυχία ελέγχου για ενημερώσεις",
   "Update": "Ενημέρωση",
   "Nightly Builds": "Νυχτερινές εκδόσεις",
@@ -1773,5 +1769,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Απαιτείται PIN (και βιομετρικά, εάν διατίθενται) για το άνοιγμα του Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "βιομετρικά"
+  "biometrics": "βιομετρικά",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Εμφανίζει μια σύντομη υπόδειξη στη μητρική σου γλώσσα πάνω από δύσκολες λέξεις. Οι λέξεις πάνω από το επίπεδό σου λαμβάνουν υπόδειξη.",
+  "Level": "Επίπεδο",
+  "CEFR level": "Επίπεδο CEFR"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1773,13 +1773,9 @@
   "Data pack": "Paquete de datos",
   "Open a book to manage its data pack.": "Abre un libro para gestionar su paquete de datos.",
   "No data available for this language pair yet.": "Aún no hay datos disponibles para este par de idiomas.",
-  "Download {{size}}": "Descargar {{size}}",
   "Enable Word Lens": "Activar Word Lens",
   "Vocabulary level": "Nivel de vocabulario",
-  "Words above your level get a hint": "Las palabras por encima de tu nivel reciben una ayuda",
-  "Hint Language": "Idioma de las ayudas",
   "Data": "Datos",
-  "Download data packs automatically when needed.": "Descargar los paquetes de datos automáticamente cuando sea necesario.",
   "Failed to check for updates": "No se pudo buscar actualizaciones",
   "Update": "Actualización",
   "Nightly Builds": "Compilaciones nocturnas",
@@ -1806,5 +1802,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Requiere un PIN (y biometría, si está disponible) para abrir Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biometría"
+  "biometrics": "biometría",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Muestra una breve pista en tu idioma nativo encima de las palabras difíciles. Las palabras por encima de tu nivel reciben una pista.",
+  "Level": "Nivel",
+  "CEFR level": "Nivel CEFR"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1740,13 +1740,9 @@
   "Data pack": "بستهٔ داده",
   "Open a book to manage its data pack.": "برای مدیریت بستهٔ دادهٔ آن، کتابی را باز کنید.",
   "No data available for this language pair yet.": "هنوز داده‌ای برای این جفت‌زبان موجود نیست.",
-  "Download {{size}}": "دانلود {{size}}",
   "Enable Word Lens": "فعال‌سازی Word Lens",
   "Vocabulary level": "سطح واژگان",
-  "Words above your level get a hint": "واژه‌های بالاتر از سطح شما راهنمایی می‌گیرند",
-  "Hint Language": "زبان راهنمایی",
   "Data": "داده",
-  "Download data packs automatically when needed.": "دانلود خودکار بسته‌های داده در صورت نیاز.",
   "Failed to check for updates": "بررسی به‌روزرسانی‌ها ناموفق بود",
   "Update": "به‌روزرسانی",
   "Nightly Builds": "نسخه‌های شبانه",
@@ -1773,5 +1769,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "برای باز کردن Readest به PIN (و در صورت موجود بودن، بیومتریک) نیاز است",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "بیومتریک"
+  "biometrics": "بیومتریک",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "یک راهنمای کوتاه به زبان مادری‌تان بالای واژه‌های دشوار نشان می‌دهد. واژه‌های بالاتر از سطح شما راهنما می‌گیرند.",
+  "Level": "سطح",
+  "CEFR level": "سطح CEFR"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1773,13 +1773,9 @@
   "Data pack": "Pack de données",
   "Open a book to manage its data pack.": "Ouvrez un livre pour gérer son pack de données.",
   "No data available for this language pair yet.": "Aucune donnée disponible pour cette paire de langues pour le moment.",
-  "Download {{size}}": "Télécharger {{size}}",
   "Enable Word Lens": "Activer Word Lens",
   "Vocabulary level": "Niveau de vocabulaire",
-  "Words above your level get a hint": "Les mots au-dessus de votre niveau reçoivent une explication",
-  "Hint Language": "Langue des explications",
   "Data": "Données",
-  "Download data packs automatically when needed.": "Télécharger automatiquement les packs de données si nécessaire.",
   "Failed to check for updates": "Échec de la recherche de mises à jour",
   "Update": "Mise à jour",
   "Nightly Builds": "Versions nocturnes",
@@ -1806,5 +1802,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Exiger un code PIN (et la biométrie, si disponible) pour ouvrir Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biométrie"
+  "biometrics": "biométrie",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Affiche une courte indication dans votre langue maternelle au-dessus des mots difficiles. Les mots au-dessus de votre niveau reçoivent une indication.",
+  "Level": "Niveau",
+  "CEFR level": "Niveau CEFR"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1773,13 +1773,9 @@
   "Data pack": "חבילת נתונים",
   "Open a book to manage its data pack.": "פתח ספר כדי לנהל את חבילת הנתונים שלו.",
   "No data available for this language pair yet.": "אין עדיין נתונים זמינים עבור צמד שפות זה.",
-  "Download {{size}}": "הורדה {{size}}",
   "Enable Word Lens": "הפעלת Word Lens",
   "Vocabulary level": "רמת אוצר מילים",
-  "Words above your level get a hint": "מילים מעל הרמה שלך מקבלות רמז",
-  "Hint Language": "שפת הרמז",
   "Data": "נתונים",
-  "Download data packs automatically when needed.": "הורדת חבילות נתונים אוטומטית בעת הצורך.",
   "Failed to check for updates": "בדיקת העדכונים נכשלה",
   "Update": "עדכון",
   "Nightly Builds": "גרסאות לילה",
@@ -1806,5 +1802,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "דרוש קוד PIN (וביומטריה, אם זמינה) כדי לפתוח את Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "ביומטריה"
+  "biometrics": "ביומטריה",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "מציג רמז קצר בשפת האם שלך מעל מילים קשות. מילים מעל הרמה שלך מקבלות רמז.",
+  "Level": "רמה",
+  "CEFR level": "רמת CEFR"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1740,13 +1740,9 @@
   "Data pack": "डेटा पैक",
   "Open a book to manage its data pack.": "इसके डेटा पैक को प्रबंधित करने के लिए कोई पुस्तक खोलें।",
   "No data available for this language pair yet.": "इस भाषा युग्म के लिए अभी कोई डेटा उपलब्ध नहीं है।",
-  "Download {{size}}": "{{size}} डाउनलोड करें",
   "Enable Word Lens": "Word Lens सक्षम करें",
   "Vocabulary level": "शब्दावली स्तर",
-  "Words above your level get a hint": "आपके स्तर से ऊपर के शब्दों के लिए संकेत मिलता है",
-  "Hint Language": "संकेत भाषा",
   "Data": "डेटा",
-  "Download data packs automatically when needed.": "ज़रूरत पड़ने पर डेटा पैक स्वतः डाउनलोड करें।",
   "Failed to check for updates": "अपडेट की जाँच करने में विफल",
   "Update": "अपडेट",
   "Nightly Builds": "नाइटली बिल्ड",
@@ -1773,5 +1769,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Readest खोलने के लिए PIN (और यदि उपलब्ध हो तो बायोमेट्रिक्स) आवश्यक है",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "बायोमेट्रिक्स"
+  "biometrics": "बायोमेट्रिक्स",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "कठिन शब्दों के ऊपर आपकी मातृभाषा में एक छोटा संकेत दिखाता है। आपके स्तर से ऊपर के शब्दों को संकेत मिलता है।",
+  "Level": "स्तर",
+  "CEFR level": "CEFR स्तर"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1740,13 +1740,9 @@
   "Data pack": "Adatcsomag",
   "Open a book to manage its data pack.": "Nyiss meg egy könyvet az adatcsomagjának kezeléséhez.",
   "No data available for this language pair yet.": "Ehhez a nyelvpárhoz még nincsenek adatok.",
-  "Download {{size}}": "Letöltés ({{size}})",
   "Enable Word Lens": "Word Lens bekapcsolása",
   "Vocabulary level": "Szókincsszint",
-  "Words above your level get a hint": "A szintednél nehezebb szavakhoz tipp jár",
-  "Hint Language": "Tippek nyelve",
   "Data": "Adatok",
-  "Download data packs automatically when needed.": "Adatcsomagok automatikus letöltése, amikor szükséges.",
   "Failed to check for updates": "A frissítések keresése sikertelen",
   "Update": "Frissítés",
   "Nightly Builds": "Éjszakai buildek",
@@ -1773,5 +1769,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "PIN-kód (és biometria, ha elérhető) szükséges a Readest megnyitásához",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biometria"
+  "biometrics": "biometria",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Rövid anyanyelvi tippet jelenít meg a nehéz szavak fölött. A szintednél nehezebb szavak kapnak tippet.",
+  "Level": "Szint",
+  "CEFR level": "CEFR-szint"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1707,13 +1707,9 @@
   "Data pack": "Paket data",
   "Open a book to manage its data pack.": "Buka buku untuk mengelola paket datanya.",
   "No data available for this language pair yet.": "Belum ada data tersedia untuk pasangan bahasa ini.",
-  "Download {{size}}": "Unduh {{size}}",
   "Enable Word Lens": "Aktifkan Word Lens",
   "Vocabulary level": "Tingkat kosakata",
-  "Words above your level get a hint": "Kata di atas tingkat Anda akan diberi petunjuk",
-  "Hint Language": "Bahasa Petunjuk",
   "Data": "Data",
-  "Download data packs automatically when needed.": "Unduh paket data secara otomatis saat diperlukan.",
   "Failed to check for updates": "Gagal memeriksa pembaruan",
   "Update": "Pembaruan",
   "Nightly Builds": "Build Nightly",
@@ -1740,5 +1736,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Memerlukan PIN (dan biometrik, jika tersedia) untuk membuka Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biometrik"
+  "biometrics": "biometrik",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Menampilkan petunjuk singkat dalam bahasa ibu Anda di atas kata-kata sulit. Kata-kata di atas level Anda mendapat petunjuk.",
+  "Level": "Level",
+  "CEFR level": "Level CEFR"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1773,13 +1773,9 @@
   "Data pack": "Pacchetto dati",
   "Open a book to manage its data pack.": "Apri un libro per gestire il suo pacchetto dati.",
   "No data available for this language pair yet.": "Nessun dato ancora disponibile per questa coppia di lingue.",
-  "Download {{size}}": "Scarica {{size}}",
   "Enable Word Lens": "Attiva Word Lens",
   "Vocabulary level": "Livello di vocabolario",
-  "Words above your level get a hint": "Le parole sopra il tuo livello ricevono un suggerimento",
-  "Hint Language": "Lingua dei suggerimenti",
   "Data": "Dati",
-  "Download data packs automatically when needed.": "Scarica automaticamente i pacchetti dati quando necessario.",
   "Failed to check for updates": "Impossibile verificare la presenza di aggiornamenti",
   "Update": "Aggiornamento",
   "Nightly Builds": "Build notturne",
@@ -1806,5 +1802,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Richiede un PIN (e la biometria, se disponibile) per aprire Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biometria"
+  "biometrics": "biometria",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Mostra un breve suggerimento nella tua lingua madre sopra le parole difficili. Le parole sopra il tuo livello ricevono un suggerimento.",
+  "Level": "Livello",
+  "CEFR level": "Livello CEFR"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1707,13 +1707,9 @@
   "Data pack": "データパック",
   "Open a book to manage its data pack.": "データパックを管理するには本を開いてください。",
   "No data available for this language pair yet.": "この言語ペアに対応するデータはまだありません。",
-  "Download {{size}}": "ダウンロード {{size}}",
   "Enable Word Lens": "Word Lens を有効にする",
   "Vocabulary level": "語彙レベル",
-  "Words above your level get a hint": "レベルを超える単語にヒントを表示します",
-  "Hint Language": "ヒント言語",
   "Data": "データ",
-  "Download data packs automatically when needed.": "必要に応じてデータパックを自動的にダウンロードします。",
   "Failed to check for updates": "更新の確認に失敗しました",
   "Update": "アップデート",
   "Nightly Builds": "ナイトリービルド",
@@ -1740,5 +1736,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Readest を開くには PIN（および利用可能な場合は生体認証）が必要です",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "生体認証"
+  "biometrics": "生体認証",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "難しい単語の上に母語の短いヒントを表示します。あなたのレベルを超える単語にヒントが付きます。",
+  "Level": "レベル",
+  "CEFR level": "CEFRレベル"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1707,13 +1707,9 @@
   "Data pack": "데이터 팩",
   "Open a book to manage its data pack.": "데이터 팩을 관리하려면 책을 여세요.",
   "No data available for this language pair yet.": "이 언어 쌍에 사용할 수 있는 데이터가 아직 없습니다.",
-  "Download {{size}}": "다운로드 {{size}}",
   "Enable Word Lens": "Word Lens 사용",
   "Vocabulary level": "어휘 수준",
-  "Words above your level get a hint": "수준을 넘는 단어에 힌트를 표시합니다",
-  "Hint Language": "힌트 언어",
   "Data": "데이터",
-  "Download data packs automatically when needed.": "필요할 때 데이터 팩을 자동으로 다운로드합니다.",
   "Failed to check for updates": "업데이트 확인에 실패했습니다",
   "Update": "업데이트",
   "Nightly Builds": "야간 빌드",
@@ -1740,5 +1736,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Readest를 열려면 PIN(및 사용 가능한 경우 생체 인증)이 필요합니다",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "생체 인증"
+  "biometrics": "생체 인증",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "어려운 단어 위에 모국어로 된 짧은 힌트를 표시합니다. 내 수준보다 높은 단어에 힌트가 표시됩니다.",
+  "Level": "수준",
+  "CEFR level": "CEFR 수준"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1707,13 +1707,9 @@
   "Data pack": "Pakej data",
   "Open a book to manage its data pack.": "Buka buku untuk mengurus pakej datanya.",
   "No data available for this language pair yet.": "Belum ada data tersedia untuk pasangan bahasa ini.",
-  "Download {{size}}": "Muat turun {{size}}",
   "Enable Word Lens": "Dayakan Word Lens",
   "Vocabulary level": "Tahap perbendaharaan kata",
-  "Words above your level get a hint": "Perkataan melebihi tahap anda akan diberi petunjuk",
-  "Hint Language": "Bahasa Petunjuk",
   "Data": "Data",
-  "Download data packs automatically when needed.": "Muat turun pakej data secara automatik apabila diperlukan.",
   "Failed to check for updates": "Gagal menyemak kemas kini",
   "Update": "Kemas kini",
   "Nightly Builds": "Binaan Nightly",
@@ -1740,5 +1736,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Memerlukan PIN (dan biometrik, jika tersedia) untuk membuka Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biometrik"
+  "biometrics": "biometrik",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Menunjukkan petunjuk ringkas dalam bahasa ibunda anda di atas perkataan sukar. Perkataan melebihi tahap anda akan mendapat petunjuk.",
+  "Level": "Tahap",
+  "CEFR level": "Tahap CEFR"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1740,13 +1740,9 @@
   "Data pack": "Gegevenspakket",
   "Open a book to manage its data pack.": "Open een boek om het gegevenspakket te beheren.",
   "No data available for this language pair yet.": "Nog geen gegevens beschikbaar voor deze taalcombinatie.",
-  "Download {{size}}": "Download {{size}}",
   "Enable Word Lens": "Word Lens inschakelen",
   "Vocabulary level": "Woordenschatniveau",
-  "Words above your level get a hint": "Woorden boven je niveau krijgen een hint",
-  "Hint Language": "Hinttaal",
   "Data": "Gegevens",
-  "Download data packs automatically when needed.": "Download gegevenspakketten automatisch wanneer nodig.",
   "Failed to check for updates": "Controleren op updates mislukt",
   "Update": "Update",
   "Nightly Builds": "Nightly-builds",
@@ -1773,5 +1769,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Vereist een pincode (en biometrie, indien beschikbaar) om Readest te openen",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biometrie"
+  "biometrics": "biometrie",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Toont een korte hint in je moedertaal boven moeilijke woorden. Woorden boven jouw niveau krijgen een hint.",
+  "Level": "Niveau",
+  "CEFR level": "CEFR-niveau"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1806,13 +1806,9 @@
   "Data pack": "Pakiet danych",
   "Open a book to manage its data pack.": "Otwórz książkę, aby zarządzać jej pakietem danych.",
   "No data available for this language pair yet.": "Brak danych dla tej pary języków.",
-  "Download {{size}}": "Pobierz {{size}}",
   "Enable Word Lens": "Włącz Word Lens",
   "Vocabulary level": "Poziom słownictwa",
-  "Words above your level get a hint": "Słowa powyżej Twojego poziomu otrzymują podpowiedź",
-  "Hint Language": "Język podpowiedzi",
   "Data": "Dane",
-  "Download data packs automatically when needed.": "Pobieraj pakiety danych automatycznie w razie potrzeby.",
   "Failed to check for updates": "Nie udało się sprawdzić aktualizacji",
   "Update": "Aktualizacja",
   "Nightly Builds": "Kompilacje nocne",
@@ -1839,5 +1835,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Wymaga kodu PIN (i biometrii, jeśli dostępna) do otwarcia Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biometria"
+  "biometrics": "biometria",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Pokazuje krótką wskazówkę w Twoim języku ojczystym nad trudnymi słowami. Słowa powyżej Twojego poziomu otrzymują wskazówkę.",
+  "Level": "Poziom",
+  "CEFR level": "Poziom CEFR"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1773,13 +1773,9 @@
   "Data pack": "Pacote de dados",
   "Open a book to manage its data pack.": "Abra um livro para gerenciar seu pacote de dados.",
   "No data available for this language pair yet.": "Ainda não há dados disponíveis para este par de idiomas.",
-  "Download {{size}}": "Baixar {{size}}",
   "Enable Word Lens": "Ativar o Word Lens",
   "Vocabulary level": "Nível de vocabulário",
-  "Words above your level get a hint": "As palavras acima do seu nível recebem uma dica",
-  "Hint Language": "Idioma das dicas",
   "Data": "Dados",
-  "Download data packs automatically when needed.": "Baixar pacotes de dados automaticamente quando necessário.",
   "Failed to check for updates": "Falha ao verificar atualizações",
   "Update": "Atualização",
   "Nightly Builds": "Compilações noturnas",
@@ -1806,5 +1802,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Requer um PIN (e biometria, se disponível) para abrir o Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biometria"
+  "biometrics": "biometria",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Mostra uma breve dica no seu idioma nativo acima de palavras difíceis. Palavras acima do seu nível recebem uma dica.",
+  "Level": "Nível",
+  "CEFR level": "Nível CEFR"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1773,13 +1773,9 @@
   "Data pack": "Pacote de dados",
   "Open a book to manage its data pack.": "Abra um livro para gerir o respetivo pacote de dados.",
   "No data available for this language pair yet.": "Ainda não há dados disponíveis para este par de idiomas.",
-  "Download {{size}}": "Transferir {{size}}",
   "Enable Word Lens": "Ativar o Word Lens",
   "Vocabulary level": "Nível de vocabulário",
-  "Words above your level get a hint": "As palavras acima do seu nível recebem uma dica",
-  "Hint Language": "Idioma das dicas",
   "Data": "Dados",
-  "Download data packs automatically when needed.": "Transferir pacotes de dados automaticamente quando necessário.",
   "Failed to check for updates": "Falha ao procurar atualizações",
   "Update": "Atualização",
   "Nightly Builds": "Compilações noturnas",
@@ -1806,5 +1802,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Requer um PIN (e biometria, se disponível) para abrir o Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biometria"
+  "biometrics": "biometria",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Mostra uma breve dica na sua língua materna acima de palavras difíceis. Palavras acima do seu nível recebem uma dica.",
+  "Level": "Nível",
+  "CEFR level": "Nível CEFR"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1773,13 +1773,9 @@
   "Data pack": "Pachet de date",
   "Open a book to manage its data pack.": "Deschide o carte pentru a gestiona pachetul ei de date.",
   "No data available for this language pair yet.": "Încă nu există date pentru această pereche de limbi.",
-  "Download {{size}}": "Descarcă {{size}}",
   "Enable Word Lens": "Activează Word Lens",
   "Vocabulary level": "Nivel de vocabular",
-  "Words above your level get a hint": "Cuvintele peste nivelul tău primesc un indiciu",
-  "Hint Language": "Limba indiciilor",
   "Data": "Date",
-  "Download data packs automatically when needed.": "Descarcă automat pachetele de date când este necesar.",
   "Failed to check for updates": "Verificarea actualizărilor a eșuat",
   "Update": "Actualizare",
   "Nightly Builds": "Versiuni nightly",
@@ -1806,5 +1802,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Necesită un PIN (și biometrie, dacă este disponibilă) pentru a deschide Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biometrie"
+  "biometrics": "biometrie",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Afișează un scurt indiciu în limba ta maternă deasupra cuvintelor dificile. Cuvintele peste nivelul tău primesc un indiciu.",
+  "Level": "Nivel",
+  "CEFR level": "Nivel CEFR"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1806,13 +1806,9 @@
   "Data pack": "Пакет данных",
   "Open a book to manage its data pack.": "Откройте книгу, чтобы управлять её пакетом данных.",
   "No data available for this language pair yet.": "Для этой языковой пары пока нет данных.",
-  "Download {{size}}": "Скачать {{size}}",
   "Enable Word Lens": "Включить Word Lens",
   "Vocabulary level": "Уровень словарного запаса",
-  "Words above your level get a hint": "Слова выше вашего уровня получают подсказку",
-  "Hint Language": "Язык подсказок",
   "Data": "Данные",
-  "Download data packs automatically when needed.": "Автоматически загружать пакеты данных при необходимости.",
   "Failed to check for updates": "Не удалось проверить обновления",
   "Update": "Обновление",
   "Nightly Builds": "Ночные сборки",
@@ -1839,5 +1835,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Требуется PIN-код (и биометрия, если доступна) для открытия Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "биометрия"
+  "biometrics": "биометрия",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Показывает короткую подсказку на вашем родном языке над сложными словами. Слова выше вашего уровня получают подсказку.",
+  "Level": "Уровень",
+  "CEFR level": "Уровень CEFR"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1740,13 +1740,9 @@
   "Data pack": "දත්ත පැකේජය",
   "Open a book to manage its data pack.": "එහි දත්ත පැකේජය කළමනාකරණය කිරීමට පොතක් විවෘත කරන්න.",
   "No data available for this language pair yet.": "මෙම භාෂා යුගලය සඳහා තවම දත්ත නොමැත.",
-  "Download {{size}}": "{{size}} බාගන්න",
   "Enable Word Lens": "Word Lens සක්‍රීය කරන්න",
   "Vocabulary level": "වචන මාලා මට්ටම",
-  "Words above your level get a hint": "ඔබේ මට්ටමට වඩා ඉහළ වචන සඳහා ඉඟියක් ලැබේ",
-  "Hint Language": "ඉඟි භාෂාව",
   "Data": "දත්ත",
-  "Download data packs automatically when needed.": "අවශ්‍ය විට දත්ත පැකේජ ස්වයංක්‍රීයව බාගන්න.",
   "Failed to check for updates": "යාවත්කාලීන සඳහා පරීක්ෂා කිරීමට අසමත් විය",
   "Update": "යාවත්කාලීන කිරීම",
   "Nightly Builds": "රාත්‍රී නිකුතු",
@@ -1773,5 +1769,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Readest විවෘත කිරීමට PIN (සහ ජෛව මිතික, ලබා ගත හැකි නම්) අවශ්‍ය වේ",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "ජෛව මිතික"
+  "biometrics": "ජෛව මිතික",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "අසීරු වචන මත ඔබේ මව් භාෂාවෙන් කෙටි ඉඟියක් පෙන්වයි. ඔබේ මට්ටමට වඩා ඉහළ වචනවලට ඉඟියක් ලැබේ.",
+  "Level": "මට්ටම",
+  "CEFR level": "CEFR මට්ටම"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1806,13 +1806,9 @@
   "Data pack": "Paket podatkov",
   "Open a book to manage its data pack.": "Odprite knjigo za upravljanje njenega paketa podatkov.",
   "No data available for this language pair yet.": "Za ta jezikovni par še ni podatkov.",
-  "Download {{size}}": "Prenesi {{size}}",
   "Enable Word Lens": "Omogoči Word Lens",
   "Vocabulary level": "Raven besedišča",
-  "Words above your level get a hint": "Besede nad vašo ravnjo dobijo namig",
-  "Hint Language": "Jezik namigov",
   "Data": "Podatki",
-  "Download data packs automatically when needed.": "Samodejno prenesi pakete podatkov, ko je to potrebno.",
   "Failed to check for updates": "Preverjanje posodobitev ni uspelo",
   "Update": "Posodobitev",
   "Nightly Builds": "Nočne gradnje",
@@ -1839,5 +1835,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Za odpiranje Readest je potrebna PIN-koda (in biometrija, če je na voljo)",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biometrija"
+  "biometrics": "biometrija",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Prikaže kratek namig v tvojem maternem jeziku nad težkimi besedami. Besede nad tvojo ravnjo dobijo namig.",
+  "Level": "Raven",
+  "CEFR level": "Raven CEFR"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1740,13 +1740,9 @@
   "Data pack": "Datapaket",
   "Open a book to manage its data pack.": "Öppna en bok för att hantera dess datapaket.",
   "No data available for this language pair yet.": "Inga data tillgängliga för det här språkparet ännu.",
-  "Download {{size}}": "Ladda ner {{size}}",
   "Enable Word Lens": "Aktivera Word Lens",
   "Vocabulary level": "Ordförrådsnivå",
-  "Words above your level get a hint": "Ord över din nivå får en ledtråd",
-  "Hint Language": "Språk för ledtrådar",
   "Data": "Data",
-  "Download data packs automatically when needed.": "Ladda ner datapaket automatiskt vid behov.",
   "Failed to check for updates": "Det gick inte att söka efter uppdateringar",
   "Update": "Uppdatering",
   "Nightly Builds": "Nattliga versioner",
@@ -1773,5 +1769,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Kräver en PIN-kod (och biometri, om tillgängligt) för att öppna Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biometri"
+  "biometrics": "biometri",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Visar en kort ledtråd på ditt modersmål ovanför svåra ord. Ord över din nivå får en ledtråd.",
+  "Level": "Nivå",
+  "CEFR level": "CEFR-nivå"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1740,13 +1740,9 @@
   "Data pack": "தரவுத் தொகுப்பு",
   "Open a book to manage its data pack.": "அதன் தரவுத் தொகுப்பை நிர்வகிக்க ஒரு புத்தகத்தைத் திற.",
   "No data available for this language pair yet.": "இந்த மொழி இணைக்கு இன்னும் தரவு எதுவும் கிடைக்கவில்லை.",
-  "Download {{size}}": "{{size}} பதிவிறக்கு",
   "Enable Word Lens": "Word Lens-ஐ இயக்கு",
   "Vocabulary level": "சொல்வளம் நிலை",
-  "Words above your level get a hint": "உங்கள் நிலைக்கு மேலான சொற்களுக்கு ஒரு குறிப்பு கிடைக்கும்",
-  "Hint Language": "குறிப்பு மொழி",
   "Data": "தரவு",
-  "Download data packs automatically when needed.": "தேவைப்படும்போது தரவுத் தொகுப்புகளைத் தானாகப் பதிவிறக்கு.",
   "Failed to check for updates": "புதுப்பிப்புகளைச் சரிபார்க்க முடியவில்லை",
   "Update": "புதுப்பிப்பு",
   "Nightly Builds": "இரவு உருவாக்கங்கள்",
@@ -1773,5 +1769,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Readest திறக்க PIN (மற்றும் கிடைத்தால் உயிரியல் அடையாளம்) தேவை",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "உயிரியல் அடையாளம்"
+  "biometrics": "உயிரியல் அடையாளம்",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "கடினமான சொற்களுக்கு மேலே உங்கள் தாய்மொழியில் ஒரு சிறு குறிப்பைக் காட்டும். உங்கள் நிலைக்கு மேலான சொற்களுக்கு குறிப்பு கிடைக்கும்.",
+  "Level": "நிலை",
+  "CEFR level": "CEFR நிலை"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1707,13 +1707,9 @@
   "Data pack": "ชุดข้อมูล",
   "Open a book to manage its data pack.": "เปิดหนังสือเพื่อจัดการชุดข้อมูลของหนังสือ",
   "No data available for this language pair yet.": "ยังไม่มีข้อมูลสำหรับคู่ภาษานี้",
-  "Download {{size}}": "ดาวน์โหลด {{size}}",
   "Enable Word Lens": "เปิดใช้งาน Word Lens",
   "Vocabulary level": "ระดับคำศัพท์",
-  "Words above your level get a hint": "คำที่อยู่เหนือระดับของคุณจะมีคำใบ้",
-  "Hint Language": "ภาษาของคำใบ้",
   "Data": "ข้อมูล",
-  "Download data packs automatically when needed.": "ดาวน์โหลดชุดข้อมูลโดยอัตโนมัติเมื่อจำเป็น",
   "Failed to check for updates": "ตรวจหาอัปเดตไม่สำเร็จ",
   "Update": "อัปเดต",
   "Nightly Builds": "บิลด์รายคืน",
@@ -1740,5 +1736,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "ต้องใช้ PIN (และข้อมูลไบโอเมตริก หากมี) เพื่อเปิด Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "ข้อมูลไบโอเมตริก"
+  "biometrics": "ข้อมูลไบโอเมตริก",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "แสดงคำใบ้สั้น ๆ ในภาษาแม่ของคุณเหนือคำที่ยาก คำที่สูงกว่าระดับของคุณจะมีคำใบ้",
+  "Level": "ระดับ",
+  "CEFR level": "ระดับ CEFR"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1740,13 +1740,9 @@
   "Data pack": "Veri paketi",
   "Open a book to manage its data pack.": "Veri paketini yönetmek için bir kitap açın.",
   "No data available for this language pair yet.": "Bu dil çifti için henüz veri yok.",
-  "Download {{size}}": "İndir {{size}}",
   "Enable Word Lens": "Word Lens'ı etkinleştir",
   "Vocabulary level": "Kelime düzeyi",
-  "Words above your level get a hint": "Düzeyinizin üzerindeki sözcükler bir ipucu alır",
-  "Hint Language": "İpucu Dili",
   "Data": "Veri",
-  "Download data packs automatically when needed.": "Gerektiğinde veri paketlerini otomatik olarak indir.",
   "Failed to check for updates": "Güncellemeler denetlenemedi",
   "Update": "Güncelleme",
   "Nightly Builds": "Gecelik sürümler",
@@ -1773,5 +1769,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Readest'i açmak için PIN (ve varsa biyometri) gereklidir",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biyometri"
+  "biometrics": "biyometri",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Zor kelimelerin üzerinde ana dilinizde kısa bir ipucu gösterir. Seviyenizin üzerindeki kelimeler ipucu alır.",
+  "Level": "Seviye",
+  "CEFR level": "CEFR seviyesi"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1806,13 +1806,9 @@
   "Data pack": "Пакет даних",
   "Open a book to manage its data pack.": "Відкрийте книгу, щоб керувати її пакетом даних.",
   "No data available for this language pair yet.": "Для цієї мовної пари ще немає даних.",
-  "Download {{size}}": "Завантажити {{size}}",
   "Enable Word Lens": "Увімкнути Word Lens",
   "Vocabulary level": "Рівень словникового запасу",
-  "Words above your level get a hint": "Слова, вищі за ваш рівень, отримують підказку",
-  "Hint Language": "Мова підказок",
   "Data": "Дані",
-  "Download data packs automatically when needed.": "Автоматично завантажувати пакети даних за потреби.",
   "Failed to check for updates": "Не вдалося перевірити оновлення",
   "Update": "Оновлення",
   "Nightly Builds": "Нічні збірки",
@@ -1839,5 +1835,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Потрібен PIN-код (і біометрія, якщо доступна) для відкриття Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "біометрія"
+  "biometrics": "біометрія",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Показує коротку підказку вашою рідною мовою над складними словами. Слова, вищі за ваш рівень, отримують підказку.",
+  "Level": "Рівень",
+  "CEFR level": "Рівень CEFR"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1740,13 +1740,9 @@
   "Data pack": "Ma'lumotlar to'plami",
   "Open a book to manage its data pack.": "Ma'lumotlar to'plamini boshqarish uchun kitob oching.",
   "No data available for this language pair yet.": "Bu til juftligi uchun hali ma'lumot yo'q.",
-  "Download {{size}}": "Yuklab olish {{size}}",
   "Enable Word Lens": "Word Lens'ni yoqish",
   "Vocabulary level": "Lug'at darajasi",
-  "Words above your level get a hint": "Darajangizdan yuqori so'zlar uchun maslahat beriladi",
-  "Hint Language": "Maslahat tili",
   "Data": "Ma'lumotlar",
-  "Download data packs automatically when needed.": "Kerak bo'lganda ma'lumotlar to'plamlarini avtomatik yuklab olish.",
   "Failed to check for updates": "Yangilanishlarni tekshirib bo'lmadi",
   "Update": "Yangilanish",
   "Nightly Builds": "Tungi buildlar",
@@ -1773,5 +1769,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Readest-ni ochish uchun PIN (va mavjud bo'lsa, biometrik ma'lumotlar) talab qilinadi",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "biometrik"
+  "biometrics": "biometrik",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Qiyin so‘zlar ustida ona tilingizda qisqa maslahat ko‘rsatadi. Darajangizdan yuqori so‘zlarga maslahat beriladi.",
+  "Level": "Daraja",
+  "CEFR level": "CEFR darajasi"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1707,13 +1707,9 @@
   "Data pack": "Gói dữ liệu",
   "Open a book to manage its data pack.": "Mở một cuốn sách để quản lý gói dữ liệu của nó.",
   "No data available for this language pair yet.": "Chưa có dữ liệu cho cặp ngôn ngữ này.",
-  "Download {{size}}": "Tải xuống {{size}}",
   "Enable Word Lens": "Bật Word Lens",
   "Vocabulary level": "Trình độ từ vựng",
-  "Words above your level get a hint": "Các từ vượt trình độ của bạn sẽ có gợi ý",
-  "Hint Language": "Ngôn ngữ gợi ý",
   "Data": "Dữ liệu",
-  "Download data packs automatically when needed.": "Tự động tải gói dữ liệu khi cần.",
   "Failed to check for updates": "Không kiểm tra được bản cập nhật",
   "Update": "Cập nhật",
   "Nightly Builds": "Bản dựng hằng đêm",
@@ -1740,5 +1736,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "Yêu cầu mã PIN (và sinh trắc học, nếu có) để mở Readest",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "sinh trắc học"
+  "biometrics": "sinh trắc học",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "Hiển thị gợi ý ngắn bằng tiếng mẹ đẻ của bạn phía trên những từ khó. Những từ trên trình độ của bạn sẽ có gợi ý.",
+  "Level": "Cấp độ",
+  "CEFR level": "Cấp độ CEFR"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1707,13 +1707,9 @@
   "Data pack": "数据包",
   "Open a book to manage its data pack.": "打开一本书以管理其数据包。",
   "No data available for this language pair yet.": "暂无适用于此语言对的数据。",
-  "Download {{size}}": "下载 {{size}}",
   "Enable Word Lens": "启用单词透镜",
   "Vocabulary level": "词汇水平",
-  "Words above your level get a hint": "超出你水平的词会显示提示",
-  "Hint Language": "提示语言",
   "Data": "数据",
-  "Download data packs automatically when needed.": "需要时自动下载数据包。",
   "Failed to check for updates": "检查更新失败",
   "Update": "更新",
   "Nightly Builds": "每夜构建版",
@@ -1740,5 +1736,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "打开 Readest 需要 PIN 码（如可用，也支持生物识别）",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "生物识别"
+  "biometrics": "生物识别",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "在生词上方显示一条母语简短提示。高于你水平的单词会显示提示。",
+  "Level": "级别",
+  "CEFR level": "CEFR 级别"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1707,13 +1707,9 @@
   "Data pack": "資料包",
   "Open a book to manage its data pack.": "開啟一本書以管理其資料包。",
   "No data available for this language pair yet.": "尚無適用於此語言配對的資料。",
-  "Download {{size}}": "下載 {{size}}",
   "Enable Word Lens": "啟用單詞透鏡",
   "Vocabulary level": "詞彙程度",
-  "Words above your level get a hint": "超出你程度的字會顯示提示",
-  "Hint Language": "提示語言",
   "Data": "資料",
-  "Download data packs automatically when needed.": "需要時自動下載資料包。",
   "Failed to check for updates": "檢查更新失敗",
   "Update": "更新",
   "Nightly Builds": "每夜建置版",
@@ -1740,5 +1736,8 @@
   "Require a PIN (and biometrics, if available) to open Readest": "開啟 Readest 需要 PIN 碼（如可用，亦支援生物辨識）",
   "Face ID": "Face ID",
   "Touch ID": "Touch ID",
-  "biometrics": "生物辨識"
+  "biometrics": "生物辨識",
+  "Show a short native-language hint above difficult words. Words above your level get a hint.": "在難詞上方顯示一則母語簡短提示。高於你程度的單字會顯示提示。",
+  "Level": "等級",
+  "CEFR level": "CEFR 等級"
 }

--- a/apps/readest-app/src/components/settings/WordLensPanel.tsx
+++ b/apps/readest-app/src/components/settings/WordLensPanel.tsx
@@ -205,11 +205,10 @@ const WordLensPanel: React.FC<WordLensPanelProps> = ({ bookKey, onBack }) => {
   const renderDataPackRow = () => {
     if (!bookSource) {
       return (
-        <SettingsRow label={_('Data pack')}>
-          <span className='text-base-content/60 settings-content text-end'>
-            {_('Open a book to manage its data pack.')}
-          </span>
-        </SettingsRow>
+        <SettingsRow
+          label={_('Data pack')}
+          description={_('Open a book to manage its data pack.')}
+        />
       );
     }
     if (resolving) {
@@ -221,11 +220,10 @@ const WordLensPanel: React.FC<WordLensPanelProps> = ({ bookKey, onBack }) => {
     }
     if (!packStatus) {
       return (
-        <SettingsRow label={_('Data pack')}>
-          <span className='text-base-content/60 settings-content text-end'>
-            {_('No data available for this language pair yet.')}
-          </span>
-        </SettingsRow>
+        <SettingsRow
+          label={_('Data pack')}
+          description={_('No data available for this language pair yet.')}
+        />
       );
     }
     const size = formatBytes(packStatus.pack.bytes);
@@ -243,7 +241,7 @@ const WordLensPanel: React.FC<WordLensPanelProps> = ({ bookKey, onBack }) => {
       );
     }
     return (
-      <SettingsRow label={_('Data pack')}>
+      <SettingsRow label={_('Data pack')} description={size}>
         <div className='flex items-center gap-2'>
           {downloading && progress !== null && progress > 0 && (
             <div
@@ -268,7 +266,7 @@ const WordLensPanel: React.FC<WordLensPanelProps> = ({ bookKey, onBack }) => {
             disabled={downloading}
             className='btn btn-primary btn-contrast btn-sm shrink-0'
           >
-            {_('Download {{size}}', { size })}
+            {_('Download')}
           </button>
         </div>
       </SettingsRow>
@@ -293,7 +291,7 @@ const WordLensPanel: React.FC<WordLensPanelProps> = ({ bookKey, onBack }) => {
           onChange={() => setWordLensEnabled(!wordLensEnabled)}
           data-setting-id='settings.wordlens.enabled'
         />
-        <SettingsRow label={_('Level')} disabled={!wordLensEnabled}>
+        <SettingsRow label={_('Level')} description={_('CEFR level')} disabled={!wordLensEnabled}>
           <div className='flex items-center gap-2'>
             <input
               type='range'


### PR DESCRIPTION
## Summary

Polish the Word Lens settings panel so its rows fit comfortably on mobile.

- **Data pack info rows** — moved the "Open a book to manage its data pack." and "No data available for this language pair yet." hints from the inline trailing slot into the row **description** (a secondary line under the label). Previously they rendered on the right side and stretched the row very wide on narrow screens.
- **Download button** — dropped the size from the button label (`Download {{size}}` → `Download`) and surfaced the size as the row description instead, matching the existing "Downloaded · size" state.
- **Level row** — kept the "Level" label and added a "CEFR level" description line beneath it.
- **i18n** — extracted the three new keys (`Level`, `CEFR level`, and the Word Lens hint description) and translated them across all 33 locales.

## Before / After

The "Data pack" row previously showed its hint as right-aligned trailing text, making the row too lengthy on mobile. It now wraps under the label.

## Testing

- `pnpm lint` (tsgo + Biome) — passes
- i18n verified: 0 remaining `__STRING_NOT_TRANSLATED__`, all locale JSON valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)