### PR TITLE
fix(txt): stop detecting measure-word prose as chapters in TXT import (#4658)

### DIFF
--- a/apps/readest-app/src/__tests__/utils/txt.test.ts
+++ b/apps/readest-app/src/__tests__/utils/txt.test.ts
@@ -148,6 +148,41 @@ describe('createChapterRegexps — Chinese (zh) regex matching', () => {
     });
   });
 
+  // Measure-word phrases such as 第一封信 ("the first letter") and 第四本书
+  // ("the fourth book") are running prose, not chapter headings. The volume
+  // measure words 卷/本/册/部/封 only start a heading when followed by a
+  // separator or the line end — not when a noun follows them directly. See
+  // issue #4658.
+  describe('measure-word false positives (issue #4658)', () => {
+    it.each([
+      '第一封信',
+      '第一封信。',
+      '第七封信',
+      '第四本书记载着锤法',
+      '第四本书记载着锤法，来自孙家，可惜对秦铭用处不大了，他已经彻底掌握。',
+      '第三本书',
+      '第十部手机',
+      '第一册书',
+      '第二卷书卷',
+    ])('should NOT match measure-word prose "%s"', (line) => {
+      const regex = getFirstRegex('zh');
+      expect(regex.test(`\n${line}\n`)).toBe(false);
+    });
+
+    it.each([
+      '第一封',
+      '第一封 致读者',
+      '第一本',
+      '第一本 标题',
+      '第二部 中篇',
+      '第一册 上',
+      '第一卷 起始篇',
+    ])('should still match a real heading "%s"', (line) => {
+      const regex = getFirstRegex('zh');
+      expect(regex.test(`\n${line}\n`)).toBe(true);
+    });
+  });
+
   describe('should not match', () => {
     it('should not match chapter heading embedded mid-line', () => {
       const regex = getFirstRegex('zh');
@@ -385,6 +420,35 @@ describe('extractChaptersFromSegment — Chinese (zh)', () => {
     const chapters = extractChapters('这是前文内容\n第一章 开始\n正文内容', 'zh');
     expect(chapters.length).toBeGreaterThanOrEqual(2);
     expect(chapters[0]!.content).toContain('前文');
+  });
+
+  it('should not extract 第N封信 letter markers as chapters (issue #4658)', () => {
+    const text = [
+      '第一百八十九章 许七安的七封信',
+      '驿卒将信递了过来。',
+      '第一封信',
+      '写这封信的时候我正在云州。',
+      '第二封信',
+      '临安公主亲启。',
+    ].join('\n');
+    const chapters = extractChapters(text, 'zh');
+    const titles = chapters.map((c) => c.title);
+    expect(titles).toEqual(['第一百八十九章 许七安的七封信']);
+    expect(chapters[0]!.content).toContain('第一封信');
+    expect(chapters[0]!.content).toContain('第二封信');
+  });
+
+  it('should not extract 第N本书 + sentence as a chapter (issue #4658)', () => {
+    const text = [
+      '第八十四章 比异人强一点',
+      '他翻阅着那几本秘籍。',
+      '第四本书记载着锤法，来自孙家，可惜对秦铭用处不大了，他已经彻底掌握。',
+      '日子一天天过去。',
+    ].join('\n');
+    const chapters = extractChapters(text, 'zh');
+    const titles = chapters.map((c) => c.title);
+    expect(titles).toEqual(['第八十四章 比异人强一点']);
+    expect(chapters[0]!.content).toContain('第四本书记载着锤法');
   });
 
   it('should extract 番外 chapters mixed with regular chapters (issue #4016)', () => {

--- a/apps/readest-app/src/utils/txt.ts
+++ b/apps/readest-app/src/utils/txt.ts
@@ -719,15 +719,28 @@ export class TxtToEpubConverter {
     const chapterRegexps: RegExp[] = [];
 
     if (language === 'zh') {
+      // 第N + unit, expressed as two explicit tiers that share the 第N prefix and
+      // the trailing boundary. They stay in ONE alternation (and so one split
+      // pass) on purpose: a segment often mixes chapter and volume headings (a
+      // volume wraps chapters), and the regexps array is a fallback chain — the
+      // first regex that splits "well enough" wins — so separate entries would
+      // recognize one tier and silently drop the other.
+      const cjkNumber = '第[ 　零〇一二三四五六七八九十0-9][ 　零〇一二三四五六七八九十百千万0-9]*';
+      // Tier 1 — chapter units. Real headings; a title may attach directly
+      // (第一章天地初开) or after a separator.
+      const chapterUnit = String.raw`[章节回讲篇话](?:[：:、 　\(\)0-9]*[^\n-]{0,36})`;
+      // Tier 2 — volume/measure-word units. These double as 量词 in prose
+      // (第一封信 "the first letter", 第四本书 "the fourth book"), so a title only
+      // counts when introduced by a separator (：:、, space, parens) or the line
+      // ends — never a bare noun directly after the unit. See issue #4658.
+      const volumeUnit = String.raw`[卷本册部封](?:[：:、 　\(\)][：:、 　\(\)0-9]*[^\n-]{0,36})?`;
+      const numberedHeading = String.raw`${cjkNumber}(?:${chapterUnit}|${volumeUnit})(?!\S)`;
+      const prefaceHeading = String.raw`(?:楔子|前言|简介|引言|序言|序章|总论|概论|后记|番外篇|番外|外传)(?:[：: 　][^\n-]{0,36})?(?!\S)`;
+      const englishHeading = String.raw`chapter[\s.]*[0-9]+(?:[：:. 　]+[^\n-]{0,50})?(?!\S)`;
       chapterRegexps.push(
         new RegExp(
-          String.raw`(?:^|\n)\s*` +
-            '(' +
-            [
-              String.raw`第[ 　零〇一二三四五六七八九十0-9][ 　零〇一二三四五六七八九十百千万0-9]*(?:[章卷节回讲篇封本册部话])(?:[：:、 　\(\)0-9]*[^\n-]{0,36})(?!\S)`,
-              String.raw`(?:楔子|前言|简介|引言|序言|序章|总论|概论|后记|番外篇|番外|外传)(?:[：: 　][^\n-]{0,36})?(?!\S)`,
-              String.raw`chapter[\s.]*[0-9]+(?:[：:. 　]+[^\n-]{0,50})?(?!\S)`,
-            ].join('|') +
+          String.raw`(?:^|\n)\s*(` +
+            [numberedHeading, prefaceHeading, englishHeading].join('|') +
             ')',
           'gui',
         ),


### PR DESCRIPTION
## Problem

Closes #4658. When importing Chinese TXT novels, the chapter-detection regex promotes ordinary prose into the TOC. Two reported cases:

1. **`第一封信`–`第七封信`** ("the *Nth letter*" — correspondence the character is reading) became chapters because the measure word `封` was a chapter unit.
2. **`第四本书记载着锤法，来自孙家，可惜对秦铭用处不大了，他已经彻底掌握。`** — a full sentence starting with `第四本书` ("the fourth *book*") became a chapter because `本` was a unit and a title could attach directly after it.

<img width="320" alt="第一封信 entries in TOC" src="https://github.com/user-attachments/assets/618fc76e-2fe3-4c3e-8d27-d93e605234e2" />

## Root cause

`createChapterRegexps('zh')` used a single unit class `[章卷节回讲篇封本册部话]` and allowed a title to attach **directly** after the unit. But `封`/`本`/`部`/`册`/`卷` are also 量词 (measure words) that precede a noun in prose (`封信`, `本书`), so those phrases matched as headings.

## Fix

Split the units into two explicit tiers, kept in **one** alternation (one split pass):

- **Strong chapter units** `[章节回讲篇话]` — real headings; a title may attach directly (`第一章天地初开`). Unchanged.
- **Weak volume/measure-word units** `[卷本册部封]` — a title only counts when introduced by a separator (`：:、`, space, parens) or the line ends — never a bare noun right after the unit.

The trailing `(?!\S)` boundary rejects `第一封信` / `第四本书…` by backtracking when a noun follows with no separator. Real headings still match: `第一卷 起始篇`, `第二部 中篇`, `第一封 致读者`, standalone `第一本`.

The two tiers must stay in one regex: the `chapterRegexps` array is a *fallback chain* (first "good" split wins and `break`s), so separate entries would recognize one tier and silently drop the other in books where a volume wraps chapters.

## Tests

Added regex-level and end-to-end cases for both reported patterns to `src/__tests__/utils/txt.test.ts` (confirmed failing before the fix, passing after). Existing volume/heading tests unchanged.

- `pnpm test` — full suite green (5860 passed)
- `pnpm lint` (tsgo + Biome) — clean
- `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)