### PR TITLE
fix(opds): make saved catalog card hover distinct from dialog background

### DIFF
--- a/apps/readest-app/src/app/opds/components/CatalogManager.tsx
+++ b/apps/readest-app/src/app/opds/components/CatalogManager.tsx
@@ -459,7 +459,7 @@ export function CatalogManager({ inSubPage = false }: CatalogManagerProps = {}) 
                     'focus-visible:ring-base-content/15 focus-visible:outline-none focus-visible:ring-2',
                     catalog.disabled
                       ? 'cursor-not-allowed opacity-60'
-                      : 'hover:bg-base-200/40 cursor-pointer',
+                      : 'hover:bg-base-300 cursor-pointer',
                   )}
                 >
                   <div className='flex flex-1 flex-col gap-2.5 px-4 pb-2 pt-4'>


### PR DESCRIPTION
## Problem

Hovering a saved catalog card in the OPDS Catalogs dialog made the card's background blend into the dialog background, so the hover state effectively "disappeared."

The saved cards used `hover:bg-base-200/40`. Because `base-200` is only ~5% off `base-100`, applying it at 40% alpha shifted the background by roughly 2% — and since the dialog itself sits at `base-200`, the hover collapsed straight into the dialog color.

## Fix

Use `hover:bg-base-300` (~12% off `base-100`) so the hover state is clearly separated from **both** the resting card (`base-100`) and the dialog (`base-200`).

One-line className change in `CatalogManager.tsx`.

## Testing

- `pnpm lint` (tsgo + Biome) passes
- `pnpm test` passes (5877 passed) via the pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)