### PR TITLE
fix(reader): keep cover background-image visible under a texture

### DIFF
--- a/apps/readest-app/src/__tests__/document/paginator-background-segments.test.ts
+++ b/apps/readest-app/src/__tests__/document/paginator-background-segments.test.ts
@@ -133,6 +133,30 @@ describe('textureAwareBackground', () => {
     expect(textureAwareBackground('rgb(255, 255, 255)', true)).toBe('rgb(255, 255, 255)');
   });
 
+  // Regression test for a cover page that paints its image via a body
+  // `background-image` (the EPUB sets `background-color` transparent and lets the
+  // image fill the page). `getComputedStyle(body).background` serializes the
+  // transparent colour FIRST, so the shorthand starts with `rgba(0, 0, 0, 0)`
+  // even though a real image follows. Such a page must NOT be treated as
+  // transparent — a full-page cover image should occlude the texture, not be
+  // dropped so the texture shows through. Verified on a Xiaomi (Android WebView)
+  // where the parchment texture replaced the book's cover on the first page.
+  it('keeps a background that carries an image even when a texture is active', () => {
+    // The real value captured from the cover iframe on-device.
+    expect(
+      textureAwareBackground(
+        'rgba(0, 0, 0, 0) url("blob:http://x/abc") no-repeat fixed 50% 50% / 100% 100% padding-box border-box',
+        true,
+      ),
+    ).toBe(
+      'rgba(0, 0, 0, 0) url("blob:http://x/abc") no-repeat fixed 50% 50% / 100% 100% padding-box border-box',
+    );
+    // A plain relative/absolute url() background (not a blob) is kept too.
+    expect(textureAwareBackground('transparent url(cover.jpg) center / cover', true)).toBe(
+      'transparent url(cover.jpg) center / cover',
+    );
+  });
+
   it('never drops a background when no texture is active (no regression)', () => {
     expect(textureAwareBackground('rgba(0, 0, 0, 0)', false)).toBe('rgba(0, 0, 0, 0)');
     expect(textureAwareBackground('rgb(0, 0, 0)', false)).toBe('rgb(0, 0, 0)');


### PR DESCRIPTION
## Problem

When a background texture (e.g. parchment) is active, opening a book whose cover is painted via a `<body>` CSS `background-image` shows the **texture instead of the cover** on the first page. Reported on a Xiaomi device with `《商梯》` (a Sigil/duokan-style cover):

```html
<body style="background-repeat:no-repeat;background-attachment:fixed;background-size:100% 100%;background-position:center center;background-image:url(../Images/cover.jpg);">
```

Cover **extraction** (library thumbnail) was always correct; this is purely reader rendering. It is texture-dependent, not Android-specific (without a texture the cover renders fine).

## Root cause

foliate captures the body background into `view.docBackground` via `getComputedStyle(body).background` (the shorthand), which always serializes the transparent background-**color** first:

```
rgba(0, 0, 0, 0) url("blob:...") no-repeat fixed 50% 50% / 100% 100% ...
```

`textureAwareBackground()` matched that `rgba(0, 0, 0, 0)` prefix and, under an active texture, returned `''` so no background segment was painted and the host texture (`.foliate-viewer::before`) showed through.

## Fix

In foliate-js (readest/foliate-js#32, merged): treat a background that carries a `url(...)` image as non-transparent so a full-page cover occludes the texture; plain transparent pages still drop their fill so the texture shows through. This PR bumps the submodule to the merged commit and adds a regression test (`paginator-background-segments.test.ts`).

## Verification

- New regression test fails before the fix, passes after.
- `pnpm test` (full suite) and `pnpm lint` (tsgo + Biome) green.
- Verified on a physical Xiaomi 13 (Android 16, WebView 147) via adb + CDP: confirmed parchment texture + dark mode, host `#background` had 0 segments (cover painted nowhere); painted a test segment with the real cover blob and the cover rendered correctly; the fixed `textureAwareBackground` keeps the cover while still dropping imageless transparent pages.

## Related issue

Addresses the 样书B (cover not displaying) symptom of #4643. Note: that issue also reports a 样书A "cannot display fullscreen" symptom, which is a separate code path and is **not** covered by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)