### PR TITLE
fix(sync): stop re-pinning statusless books to the top of the library after every sync

### DIFF
--- a/apps/readest-app/src/__tests__/pages/api/sync-reading-status.test.ts
+++ b/apps/readest-app/src/__tests__/pages/api/sync-reading-status.test.ts
@@ -1,7 +1,31 @@
 import { describe, expect, it } from 'vitest';
-import { resolveReadingStatusMerge } from '@/pages/api/sync';
+import { readingStatusChanged, resolveReadingStatusMerge } from '@/pages/api/sync';
 
 const iso = (ms: number) => new Date(ms).toISOString();
+
+describe('readingStatusChanged', () => {
+  // The bug: a locally-imported book the client never gave a status to sends
+  // `reading_status: undefined`, while the server row stores `null`. Comparing
+  // them with `!==` reports a spurious change, so the server rewrites
+  // `updated_at = now()` on every push and the book floats to the top of the
+  // date-sorted library after every sync.
+  it('treats client undefined and server null as the same (no change)', () => {
+    expect(readingStatusChanged(undefined, null)).toBe(false);
+    expect(readingStatusChanged(null, undefined)).toBe(false);
+    expect(readingStatusChanged(null, null)).toBe(false);
+    expect(readingStatusChanged(undefined, undefined)).toBe(false);
+  });
+
+  it('reports a real status change', () => {
+    expect(readingStatusChanged('finished', null)).toBe(true);
+    expect(readingStatusChanged(undefined, 'reading')).toBe(true);
+    expect(readingStatusChanged('reading', 'finished')).toBe(true);
+  });
+
+  it('reports no change when both sides hold the same status', () => {
+    expect(readingStatusChanged('finished', 'finished')).toBe(false);
+  });
+});
 
 describe('resolveReadingStatusMerge', () => {
   it('keeps the client status when its status timestamp is newer', () => {

--- a/apps/readest-app/src/pages/api/sync.ts
+++ b/apps/readest-app/src/pages/api/sync.ts
@@ -44,6 +44,19 @@ export function pickWinningPages(
  * decided the other way by updated_at (which page-turn progress dominates) —
  * issue #4634.
  */
+/**
+ * `undefined` (the client omitted reading_status entirely — e.g. a locally
+ * imported book that never had a status set) and `null` (the DB default) both
+ * mean "no reading status". Collapse them so a statusless book never registers
+ * as a status change. Without this, the `statusChanged` branch below rewrites
+ * `updated_at = now()` on every push for such books, and since the 1-day
+ * re-sync window re-pushes recently-touched books each cycle, they get a fresh
+ * timestamp every sync and pin themselves to the top of the date-sorted
+ * library.
+ */
+export const readingStatusChanged = (client?: string | null, server?: string | null): boolean =>
+  (client ?? null) !== (server ?? null);
+
 export function resolveReadingStatusMerge(
   client: Pick<DBBook, 'reading_status' | 'reading_status_updated_at'>,
   server: Pick<DBBook, 'reading_status' | 'reading_status_updated_at'>,
@@ -419,7 +432,10 @@ export async function POST(req: NextRequest) {
               // Only rewrite when the resolved status VALUE differs from the
               // server's — a timestamp-only difference on the same value is a
               // no-op, and rewriting it would churn updated_at + re-propagate.
-              const statusChanged = status.reading_status !== serverBook.reading_status;
+              const statusChanged = readingStatusChanged(
+                status.reading_status,
+                serverBook.reading_status,
+              );
               if (statusChanged) {
                 // Server wins the row, but the client's status is newer. Write
                 // server's row with the fresher status and bump updated_at so


### PR DESCRIPTION
## Problem

In a library sorted by **date read** (`updatedAt` desc), a fixed set of books stayed pinned to the top: opening/closing other books moved the just-closed book to the front as expected, but **after every cloud sync** those same books jumped back above it. The issue disappeared after logout, pointing at the sync round-trip.

On-device CDP investigation (Xiaomi 13) found three books sharing an **identical** server `updated_at` to the millisecond — and that value **advanced on every sync** even though the user never opened them, landing them above a book that was *just* read.

## Root cause

The sync `POST` handler (`src/pages/api/sync.ts`) rewrites a book row with a fresh `updated_at = new Date().toISOString()` when the pushed book is **not** newer than the server (`clientIsNewer` false) but its reading status appears changed:

```js
const statusChanged = status.reading_status !== serverBook.reading_status;
```

A book imported locally that was never given a reading status sends `reading_status: undefined` (the field is dropped by `JSON.stringify`), while the server row stores `null`. `undefined !== null` is **true**, so `statusChanged` fires for any statusless book. The rewrite sets the status back to `undefined` (→ stays `null`), so the mismatch never resolves and recurs forever.

Two amplifiers make it visible:
- The **1-day re-sync window** (`useSync.ts`: `lastSyncedAtBooks = stored - ONE_DAY_IN_MS`) re-pushes every recently-touched book on **every** sync, so these books are re-submitted each cycle.
- The rewrite runs inside one batch `upsert` transaction, so all affected books get the **same** `now()` — hence the identical-to-the-millisecond timestamps.

## Verification (on-device, CDP)

The decisive `PUSH_SENT` vs `PUSH_RETURNED` capture during a single read of another book:

| Book | sent `updatedAt` | returned `updated_at` | bumped? |
|------|------|------|------|
| (just-read book) | `02:54:00.858` | `02:54:00.858` | no (client newer) |
| Demian / Lord / Nach | old value | same old value | no (status matches) |
| 商梯 / 亡清 / 100个句子 | `02:42:53.698` (old) | **`02:54:02.125`** (fresh, identical) | **yes** |

All seven books had server `reading_status = null`; only the three statusless (locally-imported, never-pulled) books were bumped. A controlled push of one of them with `reading_status: null` explicitly returned it **unchanged** — confirming `null` vs `undefined` is the discriminator.

## Fix

Normalize nullish `reading_status` before comparing so `undefined` (client omitted) and `null` (DB default) both count as "no status":

```js
export const readingStatusChanged = (client, server) => (client ?? null) !== (server ?? null);
```

A statusless book no longer registers as a status change, so the spurious `updated_at` rewrite stops. Existing inflated timestamps age out naturally as other books are read; no migration needed.

## Tests

Added `readingStatusChanged` cases to `src/__tests__/pages/api/sync-reading-status.test.ts` (undefined/null equivalence + real changes). Full suite green (5884 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)