### PR TITLE
fix(reader): stretch fullscreen cover to fill the page

### DIFF
--- a/apps/readest-app/src/__tests__/document/paginator-duokan-cover.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/paginator-duokan-cover.browser.test.ts
@@ -104,6 +104,25 @@ describe('Paginator Duokan fullscreen cover (#4379)', () => {
     expect(img!.offsetHeight).toBeGreaterThan(0);
   });
 
+  it('stretches the fullscreen cover to fill the page (object-fit: fill)', async () => {
+    paginator = createPaginator();
+    paginator.open(book);
+
+    const stabilized = waitForStabilized(paginator);
+    await paginator.goTo({ index: 0 });
+    await stabilized;
+
+    const img = getCoverImg(paginator);
+    expect(img).toBeTruthy();
+    await waitForImgLoaded(img!);
+    await waitForVisibleHeight(img!);
+
+    // The fullscreen treatment stretches the cover edge-to-edge, ignoring the
+    // image's aspect ratio, to match Duokan's native full-page rendering.
+    const cs = img!.ownerDocument.defaultView!.getComputedStyle(img!);
+    expect(cs.objectFit).toBe('fill');
+  });
+
   it('shows the cover image in scrolled mode', async () => {
     paginator = createPaginator();
     paginator.open(book);


### PR DESCRIPTION
## Summary
Paginated Duokan full-page covers (`data-duokan-page-fullscreen`) were rendered with `object-fit: contain`, which letterboxes the cover when its aspect ratio doesn't match the page. This bumps `foliate-js` so they render with `object-fit: fill` instead — the cover fills the whole page, **distorting to fit** when the aspect ratio differs, matching Duokan's native full-page render.

Scoped strictly to the paginated fullscreen branch of `setImageSize()`:
- Ordinary inline images everywhere keep `object-fit: contain`.
- Scrolled-mode Duokan covers keep `contain` bounded by `max-height` (the #4379 flow is untouched — there's no fixed page height to fill in scrolled mode).

## foliate-js change
Depends on readest/foliate-js#33 (submodule pointer bumped to its branch SHA `d2f7f98`). The pointer will need re-bumping to the squash-merge SHA once that PR lands.

## Test
Adds a browser test (`paginator-duokan-cover.browser.test.ts`) asserting the fullscreen cover computes `object-fit: fill`. Verified test-first: it fails as `contain` without the foliate-js change and passes with it.

- `pnpm test` — 5884 passed
- `pnpm lint` (tsgo + Biome) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)