### PR TITLE
fix(reader): reset scroll to top on paginated fit-width page turn (#4683)

### DIFF
--- a/apps/readest-app/src/__tests__/document/fixed-layout-paginated-scroll.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-paginated-scroll.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { computePaginatedScroll } from 'foliate-js/fixed-layout.js';
+
+describe('fixed-layout paginated page-turn scroll reset', () => {
+  it('resets the vertical scroll to the top of the page on a page turn (#4683)', () => {
+    // A tall fit-width page leaves the host scrolled to the bottom; turning to
+    // the next page must start at the top, not inherit the previous offset.
+    expect(
+      computePaginatedScroll({
+        elementWidth: 800,
+        containerWidth: 800,
+        scrollTop: 1200,
+        pageTurn: true,
+      }),
+    ).toEqual({ scrollLeft: 0, scrollTop: 0 });
+  });
+
+  it('preserves the vertical scroll on a non-navigation re-render (resize/zoom/theme)', () => {
+    expect(
+      computePaginatedScroll({
+        elementWidth: 800,
+        containerWidth: 800,
+        scrollTop: 1200,
+        pageTurn: false,
+      }),
+    ).toEqual({ scrollLeft: 0, scrollTop: 1200 });
+  });
+
+  it('re-centers horizontally when the page is wider than the viewport', () => {
+    expect(
+      computePaginatedScroll({
+        elementWidth: 1200,
+        containerWidth: 800,
+        scrollTop: 0,
+        pageTurn: true,
+      }),
+    ).toEqual({ scrollLeft: 200, scrollTop: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4683. In paginated **fixed-layout** mode (PDF / fixed-layout EPUB) with **fit-width** zoom, a page scaled taller than the viewport makes the renderer host (`overflow:auto`) scroll vertically. The renderer re-centered `scrollLeft` on every render but **never reset `scrollTop`**, so turning the page left the freshly-shown page at the previous page's vertical offset. Because the reader scrolled to the bottom to finish reading — and same-size pages share the same max scroll — the next page opened **scrolled to the end** instead of the top.

## Engine-specific (why it was reported on Linux)

The bug only manifests on **WebKit** — Linux WebKitGTK (the reporter), iOS, and macOS WKWebView — which preserves a scroll container's offset across the page content swap. **Blink** (Android WebView, Chrome, WebView2) resets the offset to zero, so it never shows there.

## Changes

- **foliate-js (readest/foliate-js#34):** add `computePaginatedScroll` and reset `scrollTop` to the top **only on a page turn** (`#showSpread`, `#goLeft`, `#goRight`). Plain re-renders (resize, zoom, theme) preserve the reader's vertical position within a tall page. This PR bumps the submodule to that commit.
- **Test:** `fixed-layout-paginated-scroll.test.ts` for the new helper (the custom element can't be instantiated in jsdom — no `ResizeObserver`, `getBoundingClientRect`=0 — so this follows the repo's existing pure-helper pattern like `captureScrollModeAnchor` / `scrollGapToCss`).

> The submodule points at the merged foliate-js commit `981298c` (readest/foliate-js#34, squash-merged into `main`).

## Verification

- `pnpm test` — 5896 passed, 8 skipped. `pnpm lint` — clean.
- **Real WebKit proof:** a page mirroring the host CSS + `#showSpread` swap, opened in Safari `AppleWebKit/605.1.15` (same WebView version as the reporter): without the reset `scrollTop` after a page turn = 420/440 (bug); with the reset = 0 (fixed).
- **CDP on a Xiaomi 13 (Android/Blink):** confirmed the exact repro scenario is present (fit-width PDF, `isOverflowY`, scrollHeight 1229 vs clientHeight 360) but `view.next()` already yields `scrollTop` 0 on Blink — i.e. Android is unaffected, consistent with the engine analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
