### PR TITLE
feat(reader): add sticky progress bar with chapter ticks

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -464,6 +464,7 @@
   "TTS not supported for this document": "تكنولوجيا تحويل النص إلى كلام غير مدعومة لهذا المستند.",
   "Reset Password": "إعادة تعيين",
   "Show Reading Progress": "إظهار تقدم القراءة",
+  "Show Progress Bar": "إظهار شريط التقدم",
   "Reading Progress Style": "نمط تقدم القراءة",
   "Page Number": "رقم الصفحة",
   "Percentage": "النسبة المئوية",

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -267,6 +267,7 @@
   "Show Remaining Time": "বাকি সময় দেখান",
   "Show Remaining Pages": "বাকি পৃষ্ঠা দেখান",
   "Show Reading Progress": "পড়ার অগ্রগতি দেখান",
+  "Show Progress Bar": "অগ্রগতি বার দেখান",
   "Reading Progress Style": "পড়ার অগ্রগতির স্টাইল",
   "Page Number": "পৃষ্ঠা নম্বর",
   "Percentage": "শতাংশ",

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -443,6 +443,7 @@
   "TTS not supported for this document": "ཡིག་ཆ་འདིར་ TTS རྒྱབ་སྐྱོར་མི་བྱེད།",
   "Reset Password": "གསང་ཨང་བསྐྱར་སྒྲིག",
   "Show Reading Progress": "ཀློག་པའི་ཡར་འཕེལ་མངོན་པ།",
+  "Show Progress Bar": "ཡར་འཕེལ་ཕྲ་རིང་མངོན་པ།",
   "Reading Progress Style": "ཀློག་པའི་ཡར་འཕེལ་གྱི་རྣམ་པ།",
   "Page Number": "ཤོག་ཨང་།",
   "Percentage": "བརྒྱ་ཆ།",

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -448,6 +448,7 @@
   "TTS not supported for this document": "TTS wird für dieses Dokument nicht unterstützt",
   "Reset Password": "Passwort zurücksetzen",
   "Show Reading Progress": "Lesefortschritt anzeigen",
+  "Show Progress Bar": "Fortschrittsleiste anzeigen",
   "Reading Progress Style": "Lesefortschritt-Stil",
   "Page Number": "Seitenzahl",
   "Percentage": "Prozentsatz",

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -448,6 +448,7 @@
   "TTS not supported for this document": "Η τεχνολογία TTS δεν υποστηρίζεται για αυτό το έγγραφο.",
   "Reset Password": "Επαναφορά κωδικού",
   "Show Reading Progress": "Εμφάνιση προόδου ανάγνωσης",
+  "Show Progress Bar": "Εμφάνιση γραμμής προόδου",
   "Reading Progress Style": "Στυλ προόδου ανάγνωσης",
   "Page Number": "Αριθμός σελίδας",
   "Percentage": "Ποσοστό",

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -476,6 +476,7 @@
   "Reading Progress Style": "Estilo de progreso de lectura",
   "Percentage": "Porcentaje",
   "Show Reading Progress": "Mostrar progreso de lectura",
+  "Show Progress Bar": "Mostrar barra de progreso",
   "Page Number": "Número de página",
   "Deleted local copy of the book: {{title}}": "Se eliminó la copia local del libro: {{title}}",
   "Failed to delete cloud backup of the book: {{title}}": "Error al eliminar la copia de seguridad en la nube del libro: {{title}}",

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -448,6 +448,7 @@
   "TTS not supported for this document": "قابلیت تبدیل متن به گفتار برای این سند پشتیبانی نمی‌شود",
   "Reset Password": "بازنشانی رمز عبور",
   "Show Reading Progress": "نمایش وضعیت مطالعه",
+  "Show Progress Bar": "نمایش نوار پیشرفت",
   "Reading Progress Style": "سبک نمایش وضعیت مطالعه",
   "Page Number": "شماره صفحه",
   "Percentage": "درصد",

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -452,6 +452,7 @@
   "TTS not supported for this document": "TTS non pris en charge pour ce document",
   "Reset Password": "Nouveau mot de passe",
   "Show Reading Progress": "Afficher la progression",
+  "Show Progress Bar": "Afficher la barre de progression",
   "Reading Progress Style": "Style de progression",
   "Page Number": "Numéro de page",
   "Percentage": "Pourcentage",

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -950,6 +950,7 @@
   "Show Remaining Time": "הצג זמן נותר",
   "Show Remaining Pages": "הצג דפים נותרים",
   "Show Reading Progress": "הצג התקדמות קריאה",
+  "Show Progress Bar": "הצג סרגל התקדמות",
   "Reading Progress Style": "סגנון התקדמות קריאה",
   "Page Number": "מספר דף",
   "Percentage": "אחוזים",

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -448,6 +448,7 @@
   "TTS not supported for this document": "TTS इस दस्तावेज़ के लिए समर्थित नहीं है",
   "Reset Password": "पासवर्ड रीसेट करें",
   "Show Reading Progress": "पढ़ने की प्रगति दिखाएं",
+  "Show Progress Bar": "प्रगति पट्टी दिखाएं",
   "Reading Progress Style": "पढ़ने की प्रगति शैली",
   "Page Number": "पृष्ठ संख्या",
   "Percentage": "प्रतिशत",

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1027,6 +1027,7 @@
   "Show Remaining Time": "Hátralévő idő megjelenítése",
   "Show Remaining Pages": "Hátralévő oldalak megjelenítése",
   "Show Reading Progress": "Olvasási haladás megjelenítése",
+  "Show Progress Bar": "Folyamatjelző megjelenítése",
   "Reading Progress Style": "Olvasási haladás stílusa",
   "Percentage": "Százalék",
   "Show Current Time": "Aktuális idő megjelenítése",

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -444,6 +444,7 @@
   "TTS not supported for this document": "TTS tidak didukung untuk dokumen ini",
   "Reset Password": "Reset Kata Sandi",
   "Show Reading Progress": "Perlihatkan Progres Membaca",
+  "Show Progress Bar": "Tampilkan Bilah Progres",
   "Reading Progress Style": "Gaya Progres Membaca",
   "Page Number": "Nomor Halaman",
   "Percentage": "Persentase",

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -452,6 +452,7 @@
   "TTS not supported for this document": "TTS non supportato per questo documento",
   "Reset Password": "Reimposta Password",
   "Show Reading Progress": "Mostra Progresso Lettura",
+  "Show Progress Bar": "Mostra barra di avanzamento",
   "Reading Progress Style": "Stile di Progresso Lettura",
   "Page Number": "Numero di Pagina",
   "Percentage": "Percentuale",

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -444,6 +444,7 @@
   "TTS not supported for this document": "TTSはこのドキュメントではサポートされていません",
   "Reset Password": "パスワードをリセット",
   "Show Reading Progress": "読書進捗を表示",
+  "Show Progress Bar": "進捗バーを表示",
   "Reading Progress Style": "読書進捗スタイル",
   "Page Number": "ページ番号",
   "Percentage": "パーセンテージ",

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -444,6 +444,7 @@
   "TTS not supported for this document": "TTS가 이 문서에서 지원되지 않습니다",
   "Reset Password": "비밀번호 재설정",
   "Show Reading Progress": "읽기 진행 상황 표시",
+  "Show Progress Bar": "진행률 표시줄 표시",
   "Reading Progress Style": "읽기 진행 상황 스타일",
   "Page Number": "페이지 번호",
   "Percentage": "백분율",

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -594,6 +594,7 @@
   "Show Remaining Time": "Tunjuk Masa Berbaki",
   "Show Remaining Pages": "Tunjuk Halaman Berbaki",
   "Show Reading Progress": "Tunjuk Kemajuan Membaca",
+  "Show Progress Bar": "Tunjuk Bar Kemajuan",
   "Reading Progress Style": "Gaya Kemajuan Membaca",
   "Page Number": "Nombor Halaman",
   "Percentage": "Peratusan",

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -448,6 +448,7 @@
   "TTS not supported for this document": "TTS niet ondersteund voor dit document",
   "Reset Password": "Wachtwoord resetten",
   "Show Reading Progress": "Leesvoortgang weergeven",
+  "Show Progress Bar": "Voortgangsbalk weergeven",
   "Reading Progress Style": "Stijl van leesvoortgang",
   "Page Number": "Pagina nummer",
   "Percentage": "Percentage",

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -456,6 +456,7 @@
   "TTS not supported for this document": "TTS nie jest obsługiwane dla tego dokumentu",
   "Reset Password": "Zresetuj hasło",
   "Show Reading Progress": "Pokazuj postęp czytania",
+  "Show Progress Bar": "Pokaż pasek postępu",
   "Reading Progress Style": "Styl postępu czytania",
   "Page Number": "Numer strony",
   "Percentage": "Procent",

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1177,6 +1177,7 @@
   "Show Remaining Time": "Mostrar tempo restante",
   "Show Remaining Pages": "Mostrar páginas restantes",
   "Show Reading Progress": "Mostrar progresso de leitura",
+  "Show Progress Bar": "Mostrar barra de progresso",
   "Reading Progress Style": "Estilo do progresso de leitura",
   "Percentage": "Porcentagem",
   "Show Current Time": "Mostrar hora atual",

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -452,6 +452,7 @@
   "TTS not supported for this document": "TTS não suportado para este documento",
   "Reset Password": "Redefinir Senha",
   "Show Reading Progress": "Mostrar Progresso de Leitura",
+  "Show Progress Bar": "Mostrar barra de progresso",
   "Reading Progress Style": "Estilo de Progresso de Leitura",
   "Page Number": "Número da Página",
   "Percentage": "Porcentagem",

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1016,6 +1016,7 @@
   "Show Remaining Time": "Afișează timpul rămas",
   "Show Remaining Pages": "Afișează paginile rămase",
   "Show Reading Progress": "Afișează progresul citirii",
+  "Show Progress Bar": "Afișează bara de progres",
   "Reading Progress Style": "Stilul progresului citirii",
   "Percentage": "Procent",
   "Show Current Time": "Afișează ora curentă",

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -456,6 +456,7 @@
   "TTS not supported for this document": "TTS не поддерживается для этого документа",
   "Reset Password": "Сбросить пароль",
   "Show Reading Progress": "Показать прогресс чтения",
+  "Show Progress Bar": "Показать полосу прогресса",
   "Reading Progress Style": "Стиль прогресса чтения",
   "Page Number": "Номер страницы",
   "Percentage": "Процент",

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -267,6 +267,7 @@
   "Show Remaining Time": "ඉතිරි වේලාව පෙන්වන්න",
   "Show Remaining Pages": "ඉතිරි පිටු පෙන්වන්න",
   "Show Reading Progress": "කියවීමේ ප්‍රගතිය පෙන්වන්න",
+  "Show Progress Bar": "ප්‍රගති තීරුව පෙන්වන්න",
   "Reading Progress Style": "කියවීමේ ප්‍රගති ශෛලිය",
   "Page Number": "පිටු අංකය",
   "Percentage": "ප්‍රතිශතය",

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -991,6 +991,7 @@
   "Show Remaining Time": "Priki preostali čas",
   "Show Remaining Pages": "Prikaži preostale strani",
   "Show Reading Progress": "Prikaži napredek branja",
+  "Show Progress Bar": "Prikaži vrstico napredka",
   "Reading Progress Style": "Slog napredka branja",
   "Percentage": "Odstotek",
   "Tap to Toggle Footer": "Tapnite za preklop noge",

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -509,6 +509,7 @@
   "Show Remaining Time": "Visa återstående tid",
   "Show Remaining Pages": "Visa återstående sidor",
   "Show Reading Progress": "Visa läsframsteg",
+  "Show Progress Bar": "Visa förloppsindikator",
   "Reading Progress Style": "Läsframstegsstil",
   "Page Number": "Sidnummer",
   "Percentage": "Procent",

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -267,6 +267,7 @@
   "Show Remaining Time": "மீதமுள்ள நேரத்தைக் காட்டவும்",
   "Show Remaining Pages": "மீதமுள்ள பக்கங்களைக் காட்டவும்",
   "Show Reading Progress": "வாசிப்பு முன்னேற்றத்தைக் காட்டவும்",
+  "Show Progress Bar": "முன்னேற்றப் பட்டியைக் காட்டவும்",
   "Reading Progress Style": "வாசிப்பு முன்னேற்ற பாணி",
   "Page Number": "பக்க எண்",
   "Percentage": "சதவீதம்",

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -444,6 +444,7 @@
   "TTS not supported for this document": "ไม่รองรับ TTS สำหรับเอกสารนี้",
   "Reset Password": "รีเซ็ตพาสเวิร์ด",
   "Show Reading Progress": "แสดงความคืบหน้าในการอ่าน",
+  "Show Progress Bar": "แสดงแถบความคืบหน้า",
   "Reading Progress Style": "สไตล์ความก้าวหน้าในการอ่าน",
   "Page Number": "หมายเลขหน้า",
   "Percentage": "เปอร์เซ็นต์",

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -448,6 +448,7 @@
   "TTS not supported for this document": "TTS bu belge için desteklenmiyor",
   "Reset Password": "Şifreyi Sıfırla",
   "Show Reading Progress": "Okuma İlerlemesini Göster",
+  "Show Progress Bar": "İlerleme Çubuğunu Göster",
   "Reading Progress Style": "Okuma İlerlemesi Stili",
   "Page Number": "Sayfa Numarası",
   "Percentage": "Yüzde",

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -456,6 +456,7 @@
   "TTS not supported for this document": "TTS не підтримується в цьому документі",
   "Reset Password": "Скинути пароль",
   "Show Reading Progress": "Показати проґрес читання",
+  "Show Progress Bar": "Показати смугу прогресу",
   "Reading Progress Style": "Стиль проґресу читання",
   "Page Number": "Номер сторінки",
   "Percentage": "Відсотки",

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1155,6 +1155,7 @@
   "Show Remaining Time": "Qolgan vaqtni koʻrsatish",
   "Show Remaining Pages": "Qolgan sahifalarni koʻrsatish",
   "Show Reading Progress": "Oʻqish jarayonini koʻrsatish",
+  "Show Progress Bar": "Jarayon panelini koʻrsatish",
   "Reading Progress Style": "Oʻqish jarayoni uslubi",
   "Percentage": "Foiz",
   "Show Current Time": "Joriy vaqtni koʻrsatish",

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -444,6 +444,7 @@
   "TTS not supported for this document": "TTS không được hỗ trợ cho tài liệu này",
   "Reset Password": "Đặt lại mật khẩu",
   "Show Reading Progress": "Hiển thị tiến độ đọc",
+  "Show Progress Bar": "Hiển thị thanh tiến độ",
   "Reading Progress Style": "Phong cách tiến độ đọc",
   "Page Number": "Số trang",
   "Percentage": "Phần trăm",

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -445,6 +445,7 @@
   "TTS not supported for this document": "TTS 不支持此文档",
   "Reset Password": "重置密码",
   "Show Reading Progress": "显示阅读进度",
+  "Show Progress Bar": "显示进度条",
   "Reading Progress Style": "阅读进度样式",
   "Page Number": "页码",
   "Percentage": "百分比",

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -444,6 +444,7 @@
   "TTS not supported for this document": "TTS 不支援此文件",
   "Reset Password": "重設密碼",
   "Show Reading Progress": "顯示閱讀進度",
+  "Show Progress Bar": "顯示進度列",
   "Reading Progress Style": "閱讀進度樣式",
   "Page Number": "頁碼",
   "Percentage": "百分比",

--- a/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import ProgressBar from '@/app/reader/components/ProgressBar';
 import { DEFAULT_VIEW_CONFIG } from '@/services/constants';
 import type { BookProgress, ViewSettings } from '@/types/book';
+import type { TOCItem } from '@/libs/document';
 
 const saveViewSettings = vi.fn();
 
@@ -11,9 +12,11 @@ let currentViewSettings: ViewSettings;
 let currentProgress: BookProgress | null;
 let currentBookData: {
   isFixedLayout: boolean;
-  bookDoc?: { metadata?: Record<string, unknown> };
+  bookDoc?: { metadata?: Record<string, unknown>; toc?: TOCItem[] };
 } | null;
 let currentRenderer: { page: number; pages: number };
+let currentSectionFractions: number[] = [];
+let currentTocHrefIndex: Record<string, number> = {};
 
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => (s: string, values?: Record<string, unknown>) =>
@@ -34,7 +37,12 @@ vi.mock('@/store/readerStore', () => {
   const state = {
     getProgress: () => currentProgress,
     getViewSettings: () => currentViewSettings,
-    getView: () => ({ renderer: currentRenderer }),
+    getView: () => ({
+      renderer: currentRenderer,
+      getSectionFractions: () => currentSectionFractions,
+      resolveNavigation: (href: string) =>
+        href in currentTocHrefIndex ? { index: currentTocHrefIndex[href]! } : null,
+    }),
   };
   return {
     useReaderStore: <R,>(selector?: (s: typeof state) => R) => (selector ? selector(state) : state),
@@ -92,6 +100,8 @@ beforeEach(() => {
   currentProgress = null;
   currentBookData = { isFixedLayout: false };
   currentRenderer = { page: 0, pages: 0 };
+  currentSectionFractions = [];
+  currentTocHrefIndex = {};
 });
 
 const makeProgress = (current: number, total: number): BookProgress =>
@@ -215,5 +225,64 @@ describe('ProgressBar — decorative footer is not focusable', () => {
     const progressInfo = container.querySelector('.progressinfo');
     expect(progressInfo).not.toBeNull();
     expect(progressInfo!.hasAttribute('tabindex')).toBe(false);
+  });
+});
+
+describe('ProgressBar — sticky progress bar', () => {
+  const tocItem = (href: string): TOCItem => ({ id: 0, label: href, href, index: 0 }) as TOCItem;
+
+  const enableStickyBar = (overrides?: Partial<ViewSettings>) => {
+    currentViewSettings = {
+      ...baseSettings,
+      showStickyProgressBar: true,
+      progressInfoMode: 'all',
+      ...overrides,
+    } as ViewSettings;
+    // fraction (0.5) deliberately differs from the page fraction
+    // ((2+1)/5 = 0.6) so the test proves the fill uses progress.fraction.
+    currentProgress = { ...makeProgress(2, 5), fraction: 0.5 } as BookProgress;
+    currentBookData = {
+      isFixedLayout: false,
+      bookDoc: {
+        toc: [
+          tocItem('ch1.xhtml'),
+          tocItem('ch2.xhtml'),
+          tocItem('ch3.xhtml'),
+          tocItem('ch4.xhtml'),
+        ],
+      },
+    };
+    // 5 sections; chapter starts [0.2, 0.4, 0.6, 0.8]; first & last dropped -> 2 ticks.
+    currentSectionFractions = [0, 0.2, 0.4, 0.6, 0.8, 1];
+    currentTocHrefIndex = { 'ch1.xhtml': 1, 'ch2.xhtml': 2, 'ch3.xhtml': 3, 'ch4.xhtml': 4 };
+    currentRenderer = { page: 1, pages: 4 };
+  };
+
+  it('renders the sticky bar with chapter ticks and a fill from progress.fraction', () => {
+    enableStickyBar();
+
+    const { container } = renderProgressBar();
+
+    const bar = container.querySelector('.sticky-progress-bar');
+    expect(bar).not.toBeNull();
+    expect(bar!.querySelectorAll('.sticky-progress-tick').length).toBe(2);
+    const fill = bar!.querySelector('.sticky-progress-fill') as HTMLElement;
+    expect(fill.style.width).toBe('50%');
+  });
+
+  it('does not render the sticky bar when the setting is off', () => {
+    enableStickyBar({ showStickyProgressBar: false });
+
+    const { container } = renderProgressBar();
+
+    expect(container.querySelector('.sticky-progress-bar')).toBeNull();
+  });
+
+  it('does not render the sticky bar in vertical writing mode', () => {
+    enableStickyBar({ vertical: true });
+
+    const { container } = renderProgressBar();
+
+    expect(container.querySelector('.sticky-progress-bar')).toBeNull();
   });
 });

--- a/apps/readest-app/src/__tests__/components/StickyProgressBar.test.tsx
+++ b/apps/readest-app/src/__tests__/components/StickyProgressBar.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import StickyProgressBar from '@/app/reader/components/StickyProgressBar';
+
+afterEach(cleanup);
+
+describe('StickyProgressBar', () => {
+  it('renders the fill width proportional to the reading fraction', () => {
+    const { container } = render(<StickyProgressBar fraction={0.5} tickFractions={[]} />);
+    const fill = container.querySelector('.sticky-progress-fill') as HTMLElement;
+    expect(fill).not.toBeNull();
+    expect(fill.style.width).toBe('50%');
+  });
+
+  it('clamps the fraction to the 0..1 range', () => {
+    const over = render(<StickyProgressBar fraction={1.8} tickFractions={[]} />);
+    expect((over.container.querySelector('.sticky-progress-fill') as HTMLElement).style.width).toBe(
+      '100%',
+    );
+    cleanup();
+    const under = render(<StickyProgressBar fraction={-0.3} tickFractions={[]} />);
+    expect(
+      (under.container.querySelector('.sticky-progress-fill') as HTMLElement).style.width,
+    ).toBe('0%');
+  });
+
+  it('outlines the bar with a thin (1px) rounded border', () => {
+    const { container } = render(<StickyProgressBar fraction={0.5} tickFractions={[]} />);
+    const track = container.querySelector('.sticky-progress-track') as HTMLElement;
+    expect(track).not.toBeNull();
+    expect(track.classList.contains('border')).toBe(true);
+    expect(track.classList.contains('rounded-full')).toBe(true);
+  });
+
+  it('renders the ticks inside the clipping track so the rounded border crops them', () => {
+    const { container } = render(<StickyProgressBar fraction={0} tickFractions={[0.25, 0.75]} />);
+    const track = container.querySelector('.sticky-progress-track') as HTMLElement;
+    expect(track.classList.contains('overflow-hidden')).toBe(true);
+    // Ticks must be descendants of the rounded, clipped track — not siblings —
+    // so ticks near the rounded ends are cropped and never exceed the border.
+    expect(track.querySelectorAll('.sticky-progress-tick').length).toBe(2);
+  });
+
+  it('renders one tick per chapter boundary at its start-edge position (LTR)', () => {
+    const { container } = render(<StickyProgressBar fraction={0} tickFractions={[0.25, 0.75]} />);
+    const ticks = container.querySelectorAll('.sticky-progress-tick');
+    expect(ticks.length).toBe(2);
+    expect((ticks[0] as HTMLElement).style.left).toBe('25%');
+    expect((ticks[1] as HTMLElement).style.left).toBe('75%');
+  });
+
+  it('positions fill and ticks from the right edge in RTL', () => {
+    const { container } = render(<StickyProgressBar fraction={0.5} tickFractions={[0.25]} rtl />);
+    const fill = container.querySelector('.sticky-progress-fill') as HTMLElement;
+    expect(fill.style.right).toBe('0px');
+    expect(fill.style.left).toBe('');
+    const tick = container.querySelector('.sticky-progress-tick') as HTMLElement;
+    expect(tick.style.right).toBe('25%');
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts-auto-advance.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/services/tts-auto-advance.browser.test.tsx
@@ -123,6 +123,7 @@ interface RelocateDetail {
   location: PageInfo;
   time: { section: number; total: number };
   range: Range;
+  fraction: number;
 }
 type BookProgressPageItem = { label?: string; href?: string } | null;
 
@@ -226,6 +227,7 @@ const wireRelocate = (view: FoliateView) => {
       pageInfo,
       detail.time,
       detail.range,
+      detail.fraction,
     );
   });
 };

--- a/apps/readest-app/src/__tests__/utils/progress.test.ts
+++ b/apps/readest-app/src/__tests__/utils/progress.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { getChapterTickFractions } from '@/utils/progress';
+import type { TOCItem } from '@/libs/document';
+
+const toc = (href: string, subitems?: TOCItem[]): TOCItem =>
+  ({ id: 0, label: href, href, index: 0, subitems }) as TOCItem;
+
+// 5 spine sections -> sectionFractions has length 6 ([0, .2, .4, .6, .8, 1]),
+// matching foliate's `getSectionFractions()` (boundaries incl. start and end).
+const sectionFractions = [0, 0.2, 0.4, 0.6, 0.8, 1];
+
+const makeView = (fractions: number[], hrefToIndex: Record<string, number>) => ({
+  getSectionFractions: () => fractions,
+  resolveNavigation: (href: string) => (href in hrefToIndex ? { index: hrefToIndex[href]! } : null),
+});
+
+describe('getChapterTickFractions', () => {
+  it('returns chapter-start fractions sorted, excluding the first and last tick', () => {
+    const view = makeView(sectionFractions, {
+      'ch4.xhtml': 4,
+      'ch1.xhtml': 1,
+      'ch3.xhtml': 3,
+      'ch2.xhtml': 2,
+    });
+
+    const ticks = getChapterTickFractions(view, [
+      toc('ch4.xhtml'),
+      toc('ch1.xhtml'),
+      toc('ch3.xhtml'),
+      toc('ch2.xhtml'),
+    ]);
+
+    // chapter starts = [0.2, 0.4, 0.6, 0.8]; the first (0.2) and last (0.8) are
+    // dropped so ticks never crowd the bar's rounded ends.
+    expect(ticks).toEqual([0.4, 0.6]);
+  });
+
+  it('drops the book-start chapter (section 0) and unresolved hrefs before trimming', () => {
+    const view = makeView(sectionFractions, {
+      'intro.xhtml': 0,
+      'ch1.xhtml': 1,
+      'ch2.xhtml': 2,
+      'ch3.xhtml': 3,
+    });
+
+    const ticks = getChapterTickFractions(view, [
+      toc('intro.xhtml'),
+      toc('ch1.xhtml'),
+      toc('ch2.xhtml'),
+      toc('ch3.xhtml'),
+      toc('missing.xhtml'),
+    ]);
+
+    // interior starts = [0.2, 0.4, 0.6]; first (0.2) and last (0.6) dropped.
+    expect(ticks).toEqual([0.4]);
+  });
+
+  it('collapses TOC entries (including nested subitems) in one section before trimming', () => {
+    const view = makeView(sectionFractions, {
+      'ch1.xhtml': 1,
+      'ch2.xhtml': 2,
+      'ch2.xhtml#sec-a': 2,
+      'ch3.xhtml': 3,
+      'ch4.xhtml': 4,
+    });
+
+    const ticks = getChapterTickFractions(view, [
+      toc('ch1.xhtml'),
+      toc('ch2.xhtml', [toc('ch2.xhtml#sec-a')]),
+      toc('ch3.xhtml'),
+      toc('ch4.xhtml'),
+    ]);
+
+    // unique starts = [0.2, 0.4, 0.6, 0.8]; first and last dropped.
+    expect(ticks).toEqual([0.4, 0.6]);
+  });
+
+  it('returns an empty array when there are too few chapters or data is missing', () => {
+    const view = makeView(sectionFractions, { 'ch1.xhtml': 1, 'ch2.xhtml': 2 });
+    // only 2 interior ticks -> trimming the first and last leaves none
+    expect(getChapterTickFractions(view, [toc('ch1.xhtml'), toc('ch2.xhtml')])).toEqual([]);
+    expect(getChapterTickFractions(null, [toc('ch1.xhtml')])).toEqual([]);
+    expect(getChapterTickFractions(view, [])).toEqual([]);
+    expect(getChapterTickFractions(view, null)).toEqual([]);
+    expect(getChapterTickFractions(makeView([], {}), [toc('ch1.xhtml')])).toEqual([]);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -195,6 +195,7 @@ const FoliateViewer: React.FC<{
       pageInfo,
       detail.time,
       detail.range,
+      detail.fraction,
     );
   }, [bookKey, setProgress]);
 

--- a/apps/readest-app/src/app/reader/components/ProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/ProgressBar.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Trans } from 'react-i18next';
 import type { Insets } from '@/types/misc';
 import { useEnv } from '@/context/EnvContext';
@@ -7,12 +7,18 @@ import { useReaderStore } from '@/store/readerStore';
 import { useBookProgress } from '@/store/readerProgressStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useBookDataStore } from '@/store/bookDataStore';
-import { formatNumber, formatProgress, getReferencePageInfo } from '@/utils/progress';
+import {
+  formatNumber,
+  formatProgress,
+  getChapterTickFractions,
+  getReferencePageInfo,
+} from '@/utils/progress';
 import { saveViewSettings } from '@/helpers/settings';
 import { eventDispatcher } from '@/utils/event';
 import { SIZE_PER_LOC, SIZE_PER_TIME_UNIT } from '@/services/constants';
 import type { ProgressBarMode } from '@/types/book.ts';
 import StatusInfo from './StatusInfo.tsx';
+import StickyProgressBar from './StickyProgressBar.tsx';
 
 interface ProgressBarProps {
   bookKey: string;
@@ -67,6 +73,18 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
   const progressInfo = referenceInfo
     ? `${referenceInfo.current}${isVertical ? ' · ' : ' / '}${referenceInfo.total}`
     : formatProgress(pageInfo?.current, pageInfo?.total, template, localize, lang);
+
+  // Sticky progress bar is horizontal-only; vertical mode keeps its side footer.
+  const stickyBarActive = viewSettings.showStickyProgressBar && !isVertical;
+  const tickFractions = useMemo(
+    () => (stickyBarActive ? getChapterTickFractions(view, bookData?.bookDoc?.toc) : []),
+    [stickyBarActive, view, bookData?.bookDoc?.toc],
+  );
+  // Same size-domain as the chapter ticks; falls back to the page fraction
+  // before the first relocate has populated progress.fraction.
+  const fillFraction =
+    progress?.fraction ??
+    (pageInfo && pageInfo.total > 0 ? (pageInfo.current + 1) / pageInfo.total : 0);
 
   const { page: current = 0, pages: total = 0 } = view?.renderer || {};
   const pagesLeft = bookData?.isFixedLayout
@@ -244,14 +262,30 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
     >
       <div
         aria-hidden='true'
-        className={clsx('flex items-center justify-between', isVertical ? 'h-full' : 'w-full')}
+        className={clsx(
+          'flex items-center',
+          isVertical ? 'h-full' : 'w-full',
+          // Sticky bar grows on the left; the info widgets pack to the right
+          // with even gaps. Without it, keep the 3-zone left/center/right row.
+          stickyBarActive ? 'gap-x-3' : 'justify-between',
+        )}
         style={isVertical ? {} : { height: `${viewSettings.marginBottomPx}px` }}
       >
+        {stickyBarActive && (
+          <StickyProgressBar
+            className='h-3 flex-1'
+            fraction={fillFraction}
+            tickFractions={tickFractions}
+            rtl={viewSettings.rtl}
+            isEink={isEink}
+          />
+        )}
         {(progressBarMode === 'all' || progressBarMode.includes('remaining')) &&
           hasRemainingInfo && (
             <div
               className={clsx(
-                'remaining-info flex-1 whitespace-nowrap text-start',
+                'remaining-info whitespace-nowrap text-start',
+                !stickyBarActive && 'flex-1',
                 showStatusInfo && 'overflow-hidden',
               )}
             >
@@ -308,7 +342,12 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
           />
         )}
 
-        <div className='progress-info flex-1 items-center overflow-hidden whitespace-nowrap text-end tabular-nums'>
+        <div
+          className={clsx(
+            'progress-info items-center overflow-hidden whitespace-nowrap text-end tabular-nums',
+            !stickyBarActive && 'flex-1',
+          )}
+        >
           {(progressBarMode === 'all' || progressBarMode.includes('progress')) && (
             <>
               {viewSettings.showProgressInfo && (

--- a/apps/readest-app/src/app/reader/components/StickyProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/StickyProgressBar.tsx
@@ -1,0 +1,62 @@
+import clsx from 'clsx';
+import React from 'react';
+
+interface StickyProgressBarProps {
+  fraction: number;
+  tickFractions: number[];
+  rtl?: boolean;
+  isEink?: boolean;
+  className?: string;
+}
+
+// Always-visible, display-only reading progress bar with chapter tick marks.
+// Positions are expressed from the reading-start edge so the fill grows and the
+// ticks sit correctly in both LTR and RTL.
+const StickyProgressBar: React.FC<StickyProgressBarProps> = ({
+  fraction,
+  tickFractions,
+  rtl = false,
+  isEink = false,
+  className,
+}) => {
+  const pct = Math.max(0, Math.min(1, fraction)) * 100;
+  const startEdge = rtl ? 'right' : 'left';
+
+  return (
+    <div
+      role='presentation'
+      aria-hidden='true'
+      className={clsx('sticky-progress-bar relative flex items-center', className)}
+    >
+      {/* A thin 1px rounded border outlines the whole bar; the fill sits inside it. */}
+      <div
+        className={clsx(
+          'sticky-progress-track absolute inset-x-0 top-1/2 h-2 -translate-y-1/2 overflow-hidden rounded-full border',
+          isEink ? 'border-base-content' : 'border-base-content/40',
+        )}
+      >
+        <div
+          className={clsx(
+            'sticky-progress-fill absolute inset-y-0 rounded-full',
+            isEink ? 'bg-base-content' : 'bg-base-content/50',
+          )}
+          style={{ width: `${pct}%`, [startEdge]: 0 }}
+        />
+        {/* Ticks live inside the clipped, rounded track so the border crops any
+            that land near the rounded ends — they never exceed the outline. */}
+        {tickFractions.map((tick, index) => (
+          <div
+            key={index}
+            className={clsx(
+              'sticky-progress-tick absolute inset-y-0 w-px',
+              isEink ? 'bg-base-content' : 'bg-base-content/40',
+            )}
+            style={{ [startEdge]: `${tick * 100}%` }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default StickyProgressBar;

--- a/apps/readest-app/src/components/settings/LayoutPanel.tsx
+++ b/apps/readest-app/src/components/settings/LayoutPanel.tsx
@@ -75,6 +75,9 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
   const [showRemainingTime, setShowRemainingTime] = useState(viewSettings.showRemainingTime);
   const [showRemainingPages, setShowRemainingPages] = useState(viewSettings.showRemainingPages);
   const [showProgressInfo, setShowProgressInfo] = useState(viewSettings.showProgressInfo);
+  const [showStickyProgressBar, setShowStickyProgressBar] = useState(
+    viewSettings.showStickyProgressBar,
+  );
   const [showCurrentTime, setShowCurrentTime] = useState(viewSettings.showCurrentTime);
   const [use24HourClock, setUse24HourClock] = useState(viewSettings.use24HourClock);
   const [showCurrentBatteryStatus, setShowCurrentBatteryStatus] = useState(
@@ -120,6 +123,7 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
       showRemainingTime: setShowRemainingTime,
       showRemainingPages: setShowRemainingPages,
       showProgressInfo: setShowProgressInfo,
+      showStickyProgressBar: setShowStickyProgressBar,
       showCurrentTime: setShowCurrentTime,
       use24HourClock: setUse24HourClock,
       showCurrentBatteryStatus: setShowCurrentBatteryStatus,
@@ -351,6 +355,18 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
     saveViewSettings(envConfig, bookKey, 'showProgressInfo', showProgressInfo, false, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showProgressInfo]);
+
+  useEffect(() => {
+    saveViewSettings(
+      envConfig,
+      bookKey,
+      'showStickyProgressBar',
+      showStickyProgressBar,
+      false,
+      false,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showStickyProgressBar]);
 
   useEffect(() => {
     saveViewSettings(envConfig, bookKey, 'showCurrentTime', showCurrentTime, false, false);
@@ -740,6 +756,13 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
             data-setting-id='settings.layout.referencePageCount'
           />
         )}
+        <SettingsSwitchRow
+          label={_('Show Progress Bar')}
+          checked={showStickyProgressBar}
+          disabled={!showFooter}
+          onChange={() => setShowStickyProgressBar(!showStickyProgressBar)}
+          data-setting-id='settings.layout.showStickyProgressBar'
+        />
         <SettingsSwitchRow
           label={_('Show Current Time')}
           checked={showCurrentTime}

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -338,6 +338,7 @@ export const DEFAULT_VIEW_CONFIG: ViewConfig = {
   showRemainingTime: false,
   showRemainingPages: false,
   showProgressInfo: true,
+  showStickyProgressBar: false,
   showCurrentTime: false,
   showCurrentBatteryStatus: false,
   showBatteryPercentage: true,

--- a/apps/readest-app/src/store/readerStore.ts
+++ b/apps/readest-app/src/store/readerStore.ts
@@ -76,6 +76,7 @@ interface ReaderStore {
     pageinfo: PageInfo,
     timeinfo: TimeInfo,
     range: Range,
+    fraction: number,
   ) => void;
   getProgress: (key: string) => BookProgress | null;
   setView: (key: string, view: FoliateView) => void;
@@ -375,6 +376,7 @@ export const useReaderStore = create<ReaderStore>((set, get) => ({
     pageinfo: PageInfo,
     timeinfo: TimeInfo,
     range: Range,
+    fraction: number,
   ) => {
     const id = key.split('-')[0]!;
     const bookData = useBookDataStore.getState().booksData[id];
@@ -436,6 +438,7 @@ export const useReaderStore = create<ReaderStore>((set, get) => ({
       section,
       pageinfo,
       timeinfo,
+      fraction,
       index: section.current,
       range,
       page: pageInfo.current + 1,

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -276,6 +276,7 @@ export interface ViewConfig {
   showRemainingTime: boolean;
   showRemainingPages: boolean;
   showProgressInfo: boolean;
+  showStickyProgressBar: boolean;
   showCurrentTime: boolean;
   use24HourClock: boolean;
   showCurrentBatteryStatus: boolean;
@@ -400,6 +401,9 @@ export interface BookProgress {
   pageinfo: PageInfo;
   pageItem?: { label?: string; href?: string } | null;
   timeinfo: TimeInfo;
+  // Overall reading position in foliate's size-domain (0..1), matching the
+  // domain used by the sticky progress bar's chapter ticks.
+  fraction: number;
   index: number;
   range: Range;
   page: number;

--- a/apps/readest-app/src/types/view.ts
+++ b/apps/readest-app/src/types/view.ts
@@ -70,6 +70,7 @@ export interface FoliateView extends HTMLElement {
   init: (options: { lastLocation: string }) => void;
   goTo: (href: string) => void;
   goToFraction: (fraction: number) => void;
+  getSectionFractions: () => number[];
   prev: (distance?: number) => void;
   next: (distance?: number) => void;
   pan: (dx: number, dy: number) => void;

--- a/apps/readest-app/src/utils/progress.ts
+++ b/apps/readest-app/src/utils/progress.ts
@@ -1,4 +1,45 @@
 import { localizeNumber } from './number';
+import type { TOCItem } from '@/libs/document';
+
+interface ChapterTickSource {
+  getSectionFractions: () => number[];
+  resolveNavigation: (href: string) => { index?: number } | null | undefined;
+}
+
+const flattenTOCHrefs = (items: TOCItem[]): string[] =>
+  items.flatMap((item) => [
+    ...(item.href ? [item.href] : []),
+    ...(item.subitems?.length ? flattenTOCHrefs(item.subitems) : []),
+  ]);
+
+/**
+ * Reading-fraction positions (0..1) of chapter boundaries for the sticky
+ * progress bar's tick marks. Each TOC entry's href is resolved to its spine
+ * section index, then mapped to that section's start fraction (the same
+ * size-domain as the bar fill). Ticks at the book start/end are dropped and
+ * duplicates collapsed, so multiple TOC entries inside one spine file yield a
+ * single tick. The first and last remaining ticks are also dropped so they
+ * never crowd the bar's rounded ends.
+ */
+export function getChapterTickFractions(
+  view: ChapterTickSource | null | undefined,
+  toc: TOCItem[] | null | undefined,
+): number[] {
+  if (!view || !toc?.length) return [];
+  const sectionFractions = view.getSectionFractions();
+  if (!sectionFractions?.length) return [];
+  // sectionFractions = [0, ...interior boundaries..., 1]; section `i` starts at
+  // sectionFractions[i]. Keep interior starts only (1 .. length-2).
+  const lastIndex = sectionFractions.length - 1;
+  const ticks = new Set<number>();
+  for (const href of flattenTOCHrefs(toc)) {
+    const index = view.resolveNavigation(href)?.index;
+    if (typeof index === 'number' && index >= 1 && index < lastIndex) {
+      ticks.add(sectionFractions[index]!);
+    }
+  }
+  return [...ticks].sort((a, b) => a - b).slice(1, -1);
+}
 
 export function formatProgress(
   current: number | undefined,


### PR DESCRIPTION
## Summary

Implements #1616: an always-visible, opt-in **sticky progress bar with chapter ticks** in the persistent reader footer, so reading progress no longer disappears the way the hover footer slider does.

Enable it under **Settings → Layout → Header & Footer → Show Progress Bar** (disabled when the footer is off).

### Behavior
- **Bar**: a 1px rounded-border capsule with a fill and chapter tick marks. Display-only (seeking stays in the hover footer slider), e-ink aware (solid `base-content` + crisp 1px border), and RTL safe.
- **Chapter ticks** come from the TOC, mapped to each chapter's spine-section start fraction (`getChapterTickFractions`). Duplicate entries within one spine file collapse to a single tick, and the first/last ticks are trimmed. Ticks render inside the clipped, rounded track so they can never exceed the border at the rounded ends.
- **Accurate fill**: the fill and the ticks share foliate's size-domain. The overall reading fraction is threaded from the relocate event through `setProgress` into `BookProgress`, so the fill reaches a tick exactly when you enter that chapter.
- **Layout**: when enabled, the footer row puts the bar on the left (grows to fill) with the info widgets grouped to the right with even spacing. When disabled, the original left/center/right layout is untouched.
- **Scope**: horizontal writing mode only; vertical keeps its existing side footer.

### Files
- New `StickyProgressBar` component + `getChapterTickFractions` helper.
- `ProgressBar` layout refactor; `LayoutPanel` toggle; `showStickyProgressBar` setting + default; `BookProgress.fraction` threaded via `FoliateViewer` / `readerStore`; `FoliateView.getSectionFractions` type.
- i18n: `Show Progress Bar` added across all 33 locales.

## Testing
- `pnpm test` — full unit suite green; new tests for `getChapterTickFractions`, `StickyProgressBar`, and the `ProgressBar` layout.
- `pnpm lint` (tsgo + Biome) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
