### PR TITLE
feat(translator): add Urdu as a Translate Text target language (#4721)

### DIFF
--- a/apps/readest-app/src/__tests__/services/constants.test.ts
+++ b/apps/readest-app/src/__tests__/services/constants.test.ts
@@ -1109,6 +1109,10 @@ describe('services/constants', () => {
       expect(TRANSLATOR_LANGS['fi']).toBeDefined();
     });
 
+    it('TRANSLATOR_LANGS includes Urdu', () => {
+      expect(TRANSLATOR_LANGS['ur']).toBe('اردو');
+    });
+
     it('SUPPORTED_LANGS includes zh in addition to TRANSLATED_LANGS entries', () => {
       expect(typeof SUPPORTED_LANGS).toBe('object');
       expect(SUPPORTED_LANGS['zh']).toBeDefined();

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -958,6 +958,7 @@ export const TRANSLATOR_LANGS: Record<string, string> = {
   sl: 'Slovenščina',
   sk: 'Slovenčina',
   fa: 'فارسی',
+  ur: 'اردو',
 };
 
 export const SUPPORTED_LANGS: Record<string, string> = { ...TRANSLATED_LANGS, zh: '中文' };


### PR DESCRIPTION
## What

Adds **Urdu** (`ur: 'اردو'`) to the Translate Text language list, so Urdu-speaking readers can translate selected text to Urdu directly inside Readest instead of copying it into another app.

Closes #4721

## Why this is sufficient

- The language list comes from a single source of truth, `TRANSLATOR_LANGS` in `src/services/constants.ts`, which feeds both the inline `TranslatorPopup` dropdown and the Settings → Translation panel (`getLangOptions(TRANSLATOR_LANGS)`).
- The list is **not** provider-gated — several existing entries (Khmer, Tibetan, Sinhala) aren't DeepL-supported either. Google/Azure/Yandex all translate to Urdu; users who pick Urdu just need a provider that supports it.
- `ur` is already in `MIGHT_BE_RTL_LANGS`, so the translated output renders right-to-left automatically.
- `TRANSLATED_LANGS` (UI interface languages with full app translations) is intentionally left untouched — this only adds a translation **target**.

## Changes

- `src/services/constants.ts` — add `ur: 'اردو'` to `TRANSLATOR_LANGS`.
- `src/__tests__/services/constants.test.ts` — add a test asserting `TRANSLATOR_LANGS['ur'] === 'اردو'` (written test-first: confirmed failing, then passing).

## Verification

- `pnpm test` — full suite passes
- `pnpm lint` — clean (tsgo + Biome)
- `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)