### PR TITLE
fix(reader): smooth single-notch wheel scroll over PDF pages in scrolled mode (#4727)

### DIFF
--- a/apps/readest-app/src/__tests__/document/fixed-layout-scroll-wheel.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-scroll-wheel.browser.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Registers the <foliate-fxl> custom element (the fixed-layout / PDF renderer).
+import 'foliate-js/fixed-layout.js';
+
+// Regression test for readest#4727: in fixed-layout scroll mode, a wheel tick
+// that lands on a page iframe (during the brief idle window where the iframe is
+// interactive) must NOT be scrolled by JS. The browser already chains the wheel
+// to the host scroller natively; if the in-iframe wheel handler also scrolls the
+// host, the page travels twice as far in an instant lurch instead of one smooth
+// notch.
+//
+// This needs a real browser: the bug is the interaction between native wheel
+// scrolling and a programmatic scrollBy, and jsdom has no layout/scroll. We
+// mount the real renderer and assert the JS-side handler does not move the host
+// scroller on its own (the synthetic wheel does not trigger native scrolling,
+// so any movement we observe is purely the JS handler — which must be zero).
+
+const PAGE_HTML = `<!doctype html><html><head><style>
+  html, body { margin: 0; height: 1000px; background: linear-gradient(#fff, #ccc); }
+</style></head><body></body></html>`;
+
+const makeBook = (sectionCount: number) => ({
+  dir: 'ltr',
+  rendition: { viewport: { width: 600, height: 1000 }, spread: 'none' },
+  sections: Array.from({ length: sectionCount }, () => ({
+    // `src` only has to be truthy — when `data` is present the renderer loads it
+    // via srcdoc, which keeps the iframe same-origin so its document (and the
+    // wheel listener attached to it) is reachable.
+    load: async () => ({ src: 'srcdoc', data: PAGE_HTML }),
+    linear: 'yes',
+  })),
+});
+
+const waitFor = async <T>(fn: () => T | null | undefined, timeout = 4000): Promise<T> => {
+  const start = performance.now();
+  for (;;) {
+    const value = fn();
+    if (value) return value;
+    if (performance.now() - start > timeout) throw new Error('waitFor timed out');
+    await new Promise((r) => setTimeout(r, 30));
+  }
+};
+
+let renderer: HTMLElement | null = null;
+
+afterEach(() => {
+  renderer?.remove();
+  renderer = null;
+});
+
+describe('fixed-layout scroll mode wheel handling (readest#4727)', () => {
+  it('does not double-scroll the host when a wheel lands on a page', async () => {
+    renderer = document.createElement('foliate-fxl');
+    renderer.style.width = '600px';
+    renderer.style.height = '400px';
+    renderer.setAttribute('flow', 'scrolled');
+    document.body.append(renderer);
+
+    (renderer as unknown as { open(book: unknown): void }).open(makeBook(3));
+
+    // The first page loads via the IntersectionObserver; wait until its iframe
+    // has rendered (display flipped from 'none') — by then the wheel listener
+    // that #loadScrollPage attaches to the iframe document is in place.
+    const iframe = await waitFor(() => {
+      const f = renderer!.shadowRoot?.querySelector<HTMLIFrameElement>('.scroll-page iframe');
+      return f && f.style.display && f.style.display !== 'none' && f.contentDocument ? f : null;
+    });
+
+    const scroller = renderer as unknown as HTMLElement;
+    scroller.scrollTop = 0;
+
+    // A wheel over the page iframe. With the bug, the iframe handler runs
+    // `host.scrollBy({ top: deltaY })`, moving the host scroller by ~120px on
+    // top of the (here absent) native scroll. With the fix it must stay put.
+    iframe.contentDocument!.dispatchEvent(
+      new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true }),
+    );
+
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(scroller.scrollTop).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #4727

## Problem

In fixed-layout / PDF **scrolled** mode, a single mouse-wheel notch scrolls the page roughly **twice as far**, in an instant lurch, when the pointer is **over a page** — but a single **smooth** scroll when over the **page margin**. Reproduces on both web and the desktop app.

## Root cause

In `packages/foliate-js` (`fixed-layout.js`, `#loadScrollPage`), each scrolled-mode page iframe carried a `{ passive: true }` wheel listener that ran `this.scrollBy({ behavior: 'instant' })`. The page iframe is `scrolling="no"` + `overflow:hidden`, so the browser **already chains** the wheel to the host scroller natively (a single smooth scroll). The manual `scrollBy` **stacked on top** of that native scroll → ~2× distance, with the `behavior:'instant'` jump preceding the native glide.

The iframe is interactive (`pointer-events:auto`) only during the ~150 ms idle window after scrolling settles, so a normally-paced notched wheel lands every notch in that window → every notch doubled. Margin-hover hits the host directly → only the single native scroll → no doubling.

## Fix

Drop the redundant manual `scrollBy`; keep disabling iframe `pointer-events` so the gesture is handed back to the host and scrolled natively, matching the margin. Submodule change: readest/foliate-js#36 (merged) — this PR points the `packages/foliate-js` pointer at the merged commit `e366bdb`.

## Verification

- Reproduced in headless Chromium with a real `mouse.wheel` over a `scrolling="no"` iframe in a scroll container: **240 px over the page vs 120 px over the margin** with the manual scroll; **120 == 120** after removing it.
- New browser-lane regression test `fixed-layout-scroll-wheel.browser.test.ts` mounts the **real** `<foliate-fxl>` renderer in scrolled mode and asserts a wheel over a page does not programmatically move the host scroller. Confirmed it fails (`120`) against the old code and passes (`0`) with the fix.
- `pnpm test` (6020 passed), `pnpm test:browser`, `pnpm lint`, `pnpm format:check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)