### PR TITLE
fix(reader): stop trackpad pinch-zoom flicker on image viewer (#4742)

### DIFF
--- a/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, cleanup, fireEvent } from '@testing-library/react';
+import { render, cleanup, fireEvent, act } from '@testing-library/react';
 
 import ImageViewer from '@/app/reader/components/ImageViewer';
 
@@ -82,5 +82,36 @@ describe('ImageViewer', () => {
 
     fireEvent.mouseUp(window);
     expect(img.style.transition).not.toBe('none');
+  });
+
+  // Trackpad pinch flicker (#4742): on macOS a trackpad pinch-to-zoom arrives
+  // as a rapid stream of ctrl+wheel events. With the 0.05s transition left on,
+  // each event restarts the in-flight transition from its interpolated
+  // mid-point, so the image lags and flickers — the same root cause as the
+  // #4451 pan flicker. The transition must be off while the wheel-zoom gesture
+  // is streaming, then return for discrete zoom once the gesture settles.
+  it('disables the transform transition during ctrl+wheel (trackpad pinch) zoom', () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = render(
+        <ImageViewer src='blob:test-image' onClose={vi.fn()} gridInsets={gridInsets} />,
+      );
+      const img = container.querySelector('img')!;
+
+      expect(img.style.transition).not.toBe('none');
+
+      act(() => {
+        fireEvent.wheel(img, { deltaY: -50, ctrlKey: true, clientX: 100, clientY: 100 });
+      });
+      expect(img.style.transition).toBe('none');
+
+      // After the gesture settles the smoothing returns for discrete zoom.
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(img.style.transition).not.toBe('none');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/readest-app/src/app/reader/components/ImageViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/ImageViewer.tsx
@@ -40,6 +40,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
   const [scale, setScale] = useState(1);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
+  const [isWheelZooming, setIsWheelZooming] = useState(false);
   const [showZoomLabel, setShowZoomLabel] = useState(true);
   const lastTouchDistance = useRef<number>(0);
   const dragStart = useRef({ x: 0, y: 0 });
@@ -47,9 +48,24 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const imageRef = useRef<HTMLImageElement>(null);
   const zoomLabelTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wheelZoomEndTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Escape (desktop) and Android Back key → close the viewer.
   useKeyDownActions({ onCancel: onClose });
+
+  // A macOS trackpad pinch arrives as a rapid stream of ctrl+wheel events.
+  // Flag the gesture as active so the transform transition is suppressed while
+  // it streams (see the transition note below), then clear it shortly after the
+  // last event since wheel has no explicit gesture-end.
+  const markWheelZooming = () => {
+    setIsWheelZooming(true);
+    if (wheelZoomEndTimeoutRef.current) {
+      clearTimeout(wheelZoomEndTimeoutRef.current);
+    }
+    wheelZoomEndTimeoutRef.current = setTimeout(() => {
+      setIsWheelZooming(false);
+    }, 200);
+  };
 
   const hideZoomLabelAfterDelay = () => {
     if (zoomLabelTimeoutRef.current) {
@@ -154,6 +170,9 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
       if (zoomLabelTimeoutRef.current) {
         clearTimeout(zoomLabelTimeoutRef.current);
       }
+      if (wheelZoomEndTimeoutRef.current) {
+        clearTimeout(wheelZoomEndTimeoutRef.current);
+      }
     };
   }, []);
 
@@ -170,6 +189,8 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
 
     const rect = containerRef.current?.getBoundingClientRect();
     if (!rect) return;
+
+    markWheelZooming();
 
     const delta = e.deltaY;
     const newScale = Math.min(
@@ -519,10 +540,12 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
             maxWidth: '100%',
             maxHeight: '100%',
             transform: `scale(${scale}) translate(${position.x / scale}px, ${position.y / scale}px)`,
-            // No transition while dragging: the 0.05s ease made the image lag
-            // behind the cursor, which flickered on desktop (#4451). Keep the
-            // smoothing only for discrete zoom (buttons, double-click, wheel).
-            transition: isDragging ? 'none' : 'transform 0.05s ease-out',
+            // No transition during continuous gestures: the 0.05s ease made the
+            // image lag behind a moving pointer, which flickered on desktop
+            // (#4451). The same lag flickered a trackpad pinch (a rapid
+            // ctrl+wheel stream) on macOS (#4742). Keep the smoothing only for
+            // discrete zoom (buttons, double-click, keyboard).
+            transition: isDragging || isWheelZooming ? 'none' : 'transform 0.05s ease-out',
             // Promote to a GPU layer so transform changes don't repaint the
             // page (the `transform-gpu` class is overridden by this inline
             // transform, so its hint is lost).


### PR DESCRIPTION
## Problem

Closes #4742. Zooming an open image with a MacBook trackpad pinch flickers heavily. Touch pinch on iPhone is smooth, and the earlier mouse-pan flicker (#4451) was already fixed, but the trackpad pinch case was still broken.

## Root cause

On macOS a trackpad pinch-to-zoom is delivered to the WebView as a rapid stream of `wheel` events with `ctrlKey: true` (not touch events), so it flows through `handleWheel`. The zoomed `<img>` kept its `transition: transform 0.05s ease-out` whenever `isDragging` was false. Because pinch wheel events fire faster than 50ms apart, each new transform interrupted the in-flight transition and restarted it from the interpolated mid-point, so the rendered transform constantly lagged and caught up. That is the visible flicker.

This is the same root cause as the #4451 pan flicker, which was fixed by dropping the transition during the gesture for the pan path and (via `isDragging`) the touch-pinch path. The wheel-zoom path was the only continuous-gesture path left with the transition on.

## Fix

Mirror the existing pan/touch fix for the wheel path:

- Add an `isWheelZooming` state, set on each `handleWheel` event and cleared via a 200ms debounce (wheel/pinch has no explicit gesture-end event).
- `transition` is now `isDragging || isWheelZooming ? 'none' : 'transform 0.05s ease-out'`, so discrete zoom (buttons, double-click, keyboard) keeps its smoothing.
- Clear the new timeout on unmount.

## Test

Added a failing-first unit test asserting the transition is `none` during a `ctrl+wheel` event and returns to the eased transition once the gesture settles.

## Verification

- `pnpm test` — 6144 passed / 9 skipped (incl. 4 ImageViewer tests)
- `pnpm lint` (tsgo + Biome) — clean
- `pnpm format:check` — clean

No `src-tauri/` or koplugin changes, so the Rust/Lua gates do not apply.

## Note

The reporter is on macOS 26.5.1 (WebKit 605.1.15) and the maintainer could not reproduce on macOS 15.6.1. I verified the mechanism via the unit test rather than a physical trackpad; the fix removes the interrupted-transition behavior entirely during the gesture and matches the proven #4451 approach, so it should hold across WebKit versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)