### PR TITLE
fix(reader): make annotation toolbar customization apply to all books

### DIFF
--- a/apps/readest-app/src/__tests__/utils/serializer.test.ts
+++ b/apps/readest-app/src/__tests__/utils/serializer.test.ts
@@ -108,6 +108,43 @@ describe('BookConfig serialization', () => {
     expect(tombstone.deletedAt).toBeTruthy();
   });
 
+  it('does not persist an array view setting that equals the global value', () => {
+    // Array/object view settings must be compared by value, not reference —
+    // otherwise annotationToolbarItems (an array) is stored as a per-book override on
+    // every save, shadowing later global changes (the customize-toolbar bug).
+    const global = {
+      ...globalViewSettings,
+      annotationToolbarItems: ['highlight', 'annotate', 'copy'],
+    } as unknown as ViewSettings;
+    const config: BookConfig = {
+      updatedAt: 1,
+      // Same content as global but a distinct array reference, as produced by the
+      // load -> merge -> serialize round-trip.
+      viewSettings: {
+        annotationToolbarItems: ['highlight', 'annotate', 'copy'],
+      } as Partial<ViewSettings>,
+    };
+
+    const parsed = JSON.parse(serializeConfig(config, global, defaultSearchConfig));
+
+    expect(parsed.viewSettings.annotationToolbarItems).toBeUndefined();
+  });
+
+  it('persists an array view setting that differs from the global value', () => {
+    const global = {
+      ...globalViewSettings,
+      annotationToolbarItems: ['highlight', 'annotate', 'copy'],
+    } as unknown as ViewSettings;
+    const config: BookConfig = {
+      updatedAt: 1,
+      viewSettings: { annotationToolbarItems: ['copy'] } as Partial<ViewSettings>,
+    };
+
+    const parsed = JSON.parse(serializeConfig(config, global, defaultSearchConfig));
+
+    expect(parsed.viewSettings.annotationToolbarItems).toEqual(['copy']);
+  });
+
   it('does not migrate annotations when schemaVersion is already 2', () => {
     const config = deserializeConfig(
       JSON.stringify({

--- a/apps/readest-app/src/utils/serializer.ts
+++ b/apps/readest-app/src/utils/serializer.ts
@@ -14,6 +14,15 @@ export const serializeRawConfig = (config: Partial<BookConfig>): string => {
   return JSON.stringify(stampBookConfigSchema(config));
 };
 
+// Compare a per-book view-setting value with the global one by value, not
+// reference. serializeConfig deep-clones the config first, so array/object
+// settings (e.g. annotationToolbarItems) are always fresh references; a reference
+// check would persist them as per-book overrides even when identical to global,
+// which then shadows later global changes on reopen. Primitives short-circuit;
+// the JSON compare covers arrays and plain config objects (all JSON-serializable).
+const isSameViewSettingValue = (a: unknown, b: unknown): boolean =>
+  a === b || JSON.stringify(a) === JSON.stringify(b);
+
 export const serializeConfig = (
   config: BookConfig,
   globalViewSettings: ViewSettings,
@@ -35,7 +44,7 @@ export const serializeConfig = (
   const searchConfig = (config.searchConfig ?? {}) as Partial<BookSearchConfig>;
   config.viewSettings = Object.entries(viewSettings).reduce(
     (acc: Partial<Record<keyof ViewSettings, unknown>>, [key, value]) => {
-      if (globalViewSettings[key as keyof ViewSettings] !== value) {
+      if (!isSameViewSettingValue(globalViewSettings[key as keyof ViewSettings], value)) {
         acc[key as keyof ViewSettings] = value;
       }
       return acc;


### PR DESCRIPTION
## Problem

Removing tools from the annotation toolbar via **Customize Toolbar** only took effect in the book where the change was made, instead of applying to every book. Reproduced on Windows and Android.

## Root cause

`serializeConfig` (`src/utils/serializer.ts`) decides which per-book view settings to persist as overrides using a reference comparison:

```ts
if (globalViewSettings[key] !== value) { acc[key] = value; }
```

It deep-clones the config first (`JSON.parse(JSON.stringify(config))`), so any **array/object** view-setting value (`annotationToolbarItems`, and latently `paragraphMode`, `proofreadRules`, `ttsHighlightOptions`, `noteExportConfig`) is always a fresh reference. The reference check is therefore always true, so the toolbar was stored as a per-book override on **every** save — and config is serialized on every progress autosave.

On reopen, the merge `{ ...globalViewSettings, ...perBookOverrides }` lets that stale per-book override shadow the global value, so a global toolbar change never reached already-opened books. The customization looked per-book.

## Fix

Compare view-setting values by **content**, not reference, so array/object settings equal to the global value are no longer persisted as spurious per-book overrides and a global change propagates to every book. Scoped to the `viewSettings` diff only (the `searchConfig` diff is left as-is since it can hold functions / large result arrays).

`annotationToolbarItems` stays a normal field in `AnnotatorConfig`, so the per-book / global "Global Settings" toggle is honored exactly like other view settings: default (`isGlobal = true`) applies a customization to every book.

### Existing data

The customizer shipped in v0.11.12, so existing books may already carry a per-book `annotationToolbarItems` override written by the buggy build. The value comparison stops new spurious overrides and drops an existing one on the next save when its content matches the global value, but it does not retroactively clear an override whose content differs from the current global. If we want already-customized books to immediately pick up a later global change, a one-time migration that clears persisted per-book toolbar overrides can follow up.

## Tests

- Added two `serializer.test.ts` cases: an array view setting equal to global is **not** persisted per-book (reproduces the bug, fails before the fix); an array that differs **is** persisted.
- `pnpm test` (6166 passed), `pnpm lint`, `pnpm format:check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
