### PR TITLE
fix(reader): stop iOS page-turn animation stutter (#4768)

### DIFF
--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -687,6 +687,14 @@ const FoliateViewer: React.FC<{
       } else {
         view.renderer.removeAttribute('animated');
       }
+      // iOS WebKit composites large/persistent page layers without the Android
+      // high-DPR Blink freeze, so opt this renderer into the GPU-accelerated
+      // page-turn path (persistent compositor layers + no main-thread
+      // rafAnimateScroll fallback) to keep 120Hz ProMotion turns smooth
+      // (readest#4768).
+      if (appService?.isIOSApp) {
+        view.renderer.setAttribute('gpu-composite', '');
+      }
       if (viewSettings.disableSwipe) {
         view.renderer.setAttribute('no-swipe', '');
       } else {


### PR DESCRIPTION
Fixes #4768

## Background

A user on iPhone 17 Pro (iOS 26.5.1) reported that page-turn animation **occasionally stutters** after upgrading from 0.11.2 to 0.11.12 (there is no 0.11.4 on the App Store, so the real bisect window is 0.11.2 -> 0.11.12).

## Root cause

foliate-js commit `c1c7315` *"perf: fallback to raf animate scroll for large sections"* (first shipped in 0.11.4) changed the paginated page-turn in two ways, both aimed at a ~1s Blink freeze on **Android Chromium** when compositing an oversized layer at high DPR:

1. **Removed the persistent GPU-layer hints** (`transform: translateZ(0)` on `#container` and every view). Turns now promote a compositor layer **on demand** via transient `will-change` and tear it down after each turn.
2. **Added a main-thread `rafAnimateScroll` fallback** for sections over 20000px, which drives `container.scrollLeft` + `#replaceBackground()` on the main thread every frame instead of the compositor `cssAnimateScroll` path.

Apple WebKit composites those layers without the freeze, so on iOS the two changes only cost smoothness — most visible on 120Hz ProMotion. The reporter was smooth on 0.11.2 (pre-`c1c7315`), which is direct evidence the old path works well on iOS.

## Fix

foliate-js (companion PR readest/foliate-js#39) adds a `gpu-composite` host attribute that restores persistent compositor layers and skips the `rafAnimateScroll` fallback. This PR opts the **iOS** renderer into it in `FoliateViewer`, restoring the pre-0.11.4 behavior on iOS only. Android/Windows/Linux are unchanged, so the original Android freeze fix stays in force.

- `apps/readest-app/src/app/reader/components/FoliateViewer.tsx` — set `gpu-composite` when `appService?.isIOSApp`
- `packages/foliate-js` — bump submodule to readest/foliate-js#39

## Verification

- `pnpm lint` (tsgo + biome) — clean
- `pnpm test` — 6212 passed
- `pnpm format:check` — clean

Animation jank has no natural unit test (and foliate-js has no paginator test harness), so this still needs **on-device confirmation** on an iOS device with a large-section EPUB.

## Merge order

Depends on readest/foliate-js#39. The submodule is pinned to that PR's branch commit (`cc2d4c2`); after #39 merges, the pin should be updated to the merged main commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)