### PR TITLE
fix(reader): stop a quick-deleted highlight from being re-drawn (#4773)

### DIFF
--- a/apps/readest-app/src/__tests__/utils/annotation-index.test.ts
+++ b/apps/readest-app/src/__tests__/utils/annotation-index.test.ts
@@ -54,6 +54,22 @@ describe('buildAnnotationIndex / selectLocationAnnotations', () => {
     expect(globals).toEqual([]);
   });
 
+  it('skips an annotation deleted in place after the index was built (stale index)', () => {
+    // #4773: the re-apply effect holds a memoized index. A quick delete stamps
+    // `deletedAt` on the SAME object that is still sitting in the bucket (the
+    // memo has not recomputed yet). If the read trusts the build-time filter,
+    // the just-deleted highlight gets re-drawn and its overlay is orphaned —
+    // visible on the page until the book is reopened. The read must re-check.
+    const highlight = note({ style: 'highlight', color: 'yellow', note: 'hi' });
+    const index = buildAnnotationIndex([highlight]);
+    // The user deletes the highlight: `deletedAt` is stamped in place on the
+    // booknote object that the stale index still references.
+    highlight.deletedAt = 123;
+    const { annotations, notes } = selectLocationAnnotations(index, location);
+    expect(annotations).toEqual([]);
+    expect(notes).toEqual([]);
+  });
+
   it('classifies a styled annotation into annotations only', () => {
     const highlight = note({ style: 'highlight', color: 'yellow' });
     const index = buildAnnotationIndex([highlight]);

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -985,6 +985,10 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
       // covered by `onCreateOverlay`. Using the pre-built `globals`
       // array avoids re-walking booknotes per page turn.
       for (const annotation of annotationIndex.globals) {
+        // Same stale-index guard as selectLocationAnnotations: a global deleted
+        // in place after the memoized index was built must not be re-fanned out
+        // across sections, which would orphan its overlays (#4773).
+        if (annotation.deletedAt) continue;
         if (view) expandAllRenderedSections(view, annotation);
       }
     } catch (e) {

--- a/apps/readest-app/src/app/reader/utils/annotationIndex.ts
+++ b/apps/readest-app/src/app/reader/utils/annotationIndex.ts
@@ -70,6 +70,10 @@ export function selectLocationAnnotations(
   const candidates = index.bySection.get(sectionKey) ?? [];
   const matchesLocation = createCfiLocationMatcher(location);
   for (const item of candidates) {
+    // Re-check `deletedAt` at read time: the index is memoized, so a highlight
+    // deleted in place after the index was built still sits in this bucket. Re-
+    // drawing it here would orphan its overlay (visible until reopen) — #4773.
+    if (item.deletedAt) continue;
     if (!matchesLocation(item.cfi)) continue;
     if (item.style) annotations.push(item);
     if (item.note && item.note.trim().length > 0) notes.push(item);


### PR DESCRIPTION
## Summary

Fixes #4773. Deleting a highlight within a very short time left the mark painted on the page; it disappeared only after reopening the book.

## Root cause

`Annotator` re-draws on-page annotations after every relocate from a memoized `annotationIndex`, via `selectLocationAnnotations` then `view.addAnnotation`. `buildAnnotationIndex` filters `deletedAt` when the index is built, but `selectLocationAnnotations` trusted that and never re-checked.

Deleting a highlight (`handleHighlight(false)`) stamps `deletedAt` in place on the booknote object that is still sitting in the index bucket, and removes the overlay. `Annotator` does not re-render on booknote changes (it only subscribes to the stable `getConfig`), so the memo stays stale. If the re-apply effect scheduled from the popup-open render flushes after the delete (the "very short time" window, with passive effects deferred under rapid taps), it reads the deleted object from the pre-deletion snapshot and re-draws the overlay, orphaning it until reopen. Instant Highlight just makes the race easy to hit; the delete plus re-apply path is shared with normal highlights.

## Fix

Re-check `deletedAt` at the read site, not just at index build:

- `selectLocationAnnotations` (annotationIndex.ts): skip `deletedAt` before classifying, covering both highlights and notes.
- The sibling `annotationIndex.globals` re-apply loop in `Annotator` gets the same guard (global highlights have the identical stale-snapshot hazard).

## Testing

- Unit: `annotation-index.test.ts` builds an index, marks the booknote `deletedAt` in place, and asserts `selectLocationAnnotations` returns nothing. Red before the fix, green after.
- `pnpm test` (full suite) and `pnpm lint` pass.
- On a Xiaomi 13 Pro (CDP lane, fixed build): real create then delete then immediate page-turn over 4 iterations left overlay count 6 -> 7 -> 6 each time (no orphan); a stray-overlay probe confirmed the counter is not blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)