### PR TITLE
fix(reader): resolve annotation creation, clipboard copy, and cancellation cleanup

### DIFF
--- a/apps/readest-app/src/__tests__/components/NotebookCancellation.test.tsx
+++ b/apps/readest-app/src/__tests__/components/NotebookCancellation.test.tsx
@@ -1,0 +1,239 @@
+import { render, act, cleanup, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNotebookStore } from '@/store/notebookStore';
+import { BookNote } from '@/types/book';
+
+// ---------- Shared mutable test state ----------
+let mockConfig: { booknotes: BookNote[] };
+// biome-ignore lint/suspicious/noExplicitAny: mock
+let mockView: any;
+// biome-ignore lint/suspicious/noExplicitAny: mock
+let mockViews: any[];
+const mockSaveConfig = vi.fn();
+const mockUpdateBooknotes = vi.fn((_key, notes) => ({ booknotes: notes }));
+
+// ---------- Mocks ----------
+vi.mock('@/utils/supabase', () => ({
+  supabaseClient: {},
+  supabaseAnonKey: 'mock-anon-key',
+  supabaseUrl: 'https://mock-supabase.co',
+}));
+
+vi.mock('@/store/bookDataStore', () => {
+  return {
+    useBookDataStore: () => ({
+      getConfig: () => mockConfig,
+      saveConfig: mockSaveConfig,
+      updateBooknotes: mockUpdateBooknotes,
+      getBookData: () => ({ bookDoc: { metadata: { language: 'en' } } }),
+    }),
+  };
+});
+
+vi.mock('@/store/readerStore', () => {
+  return {
+    useReaderStore: () => ({
+      getView: () => mockView,
+      getProgress: () => ({ page: 1 }),
+      getViewSettings: () => ({}),
+      getViewsById: () => mockViews,
+    }),
+  };
+});
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: Object.assign(
+    () => ({
+      settings: {
+        globalReadSettings: {
+          notebookWidth: '300px',
+          isNotebookPinned: true,
+        },
+      },
+    }),
+    {
+      getState: () => ({
+        settings: {
+          globalReadSettings: {
+            notebookWidth: '300px',
+            isNotebookPinned: true,
+          },
+        },
+      }),
+    },
+  ),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({}),
+  // biome-ignore lint/suspicious/noExplicitAny: mock
+  EnvProvider: ({ children }: any) => children,
+}));
+
+vi.mock('@/app/reader/components/notebook/NoteEditor', () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: mock
+  default: ({ onSave, onCancel }: any) => (
+    <div>
+      <button data-testid='save-btn' onClick={() => onSave({ cfi: 'test-cfi' }, 'Note text')}>
+        Save
+      </button>
+      <button data-testid='cancel-btn' onClick={() => onCancel?.()}>
+        Cancel
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/app/reader/components/notebook/Header', () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: mock
+  default: ({ handleClose }: any) => (
+    <div>
+      <button data-testid='close-btn' onClick={handleClose}>
+        Close
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/app/reader/components/notebook/TabNavigation', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/reader/components/notebook/AIAssistant', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/reader/components/sidebar/BooknoteItem', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/reader/components/EmptyState', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/store/sidebarStore', () => ({
+  useSidebarStore: () => ({
+    setActiveBooknoteType: vi.fn(),
+    setBooknoteResults: vi.fn(),
+    sideBarBookKey: 'book-1',
+  }),
+}));
+
+// Mock useSwipeToDismiss
+vi.mock('@/hooks/useSwipeToDismiss', () => ({
+  useSwipeToDismiss: () => ({
+    panelRef: { current: null },
+    overlayRef: { current: null },
+    panelHeight: { current: 0 },
+    handleVerticalDragStart: vi.fn(),
+  }),
+}));
+
+// Mock useShortcuts
+vi.mock('@/hooks/useShortcuts', () => ({
+  default: vi.fn(),
+}));
+
+import Notebook from '@/app/reader/components/notebook/Notebook';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockView = {
+    getCFI: vi.fn(() => 'test-cfi'),
+    addAnnotation: vi.fn(),
+  };
+  mockViews = [mockView];
+  mockConfig = {
+    booknotes: [
+      {
+        id: '1',
+        type: 'annotation',
+        cfi: 'test-cfi',
+        note: '',
+        text: 'Selected text',
+        createdAt: 1000,
+        updatedAt: 1000,
+      },
+    ],
+  };
+
+  useNotebookStore.setState({
+    notebookWidth: '300px',
+    isNotebookVisible: true,
+    isNotebookPinned: false,
+    notebookActiveTab: 'notes',
+    notebookNewAnnotation: {
+      key: 'sel-1',
+      text: 'Selected text',
+      page: 1,
+      // biome-ignore lint/suspicious/noExplicitAny: mock
+      range: {} as any,
+      index: 0,
+      cfi: 'test-cfi',
+    },
+    notebookEditAnnotation: null,
+    notebookAnnotationDrafts: {},
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Notebook cancellation', () => {
+  it('deletes empty highlight when NoteEditor onCancel is invoked', () => {
+    render(<Notebook />);
+
+    const cancelBtn = screen.getByTestId('cancel-btn');
+    act(() => {
+      cancelBtn.click();
+    });
+
+    // It should mark the highlight as deleted
+    const deletedNote = mockConfig.booknotes.find((a) => a.cfi === 'test-cfi');
+    expect(deletedNote).toBeDefined();
+    expect(deletedNote?.deletedAt).toBeGreaterThan(0);
+    expect(mockUpdateBooknotes).toHaveBeenCalled();
+    expect(mockSaveConfig).toHaveBeenCalled();
+  });
+
+  it('deletes empty highlight when header close button is clicked', () => {
+    render(<Notebook />);
+
+    const closeBtn = screen.getByTestId('close-btn');
+    act(() => {
+      closeBtn.click();
+    });
+
+    const deletedNote = mockConfig.booknotes.find((a) => a.cfi === 'test-cfi');
+    expect(deletedNote?.deletedAt).toBeGreaterThan(0);
+  });
+
+  it('does not delete highlight if it has a non-empty note', () => {
+    mockConfig.booknotes[0]!.note = 'Existing note content';
+    render(<Notebook />);
+
+    const cancelBtn = screen.getByTestId('cancel-btn');
+    act(() => {
+      cancelBtn.click();
+    });
+
+    const deletedNote = mockConfig.booknotes.find((a) => a.cfi === 'test-cfi');
+    expect(deletedNote?.deletedAt).toBeUndefined();
+  });
+
+  it('cleans up empty highlight on unmount', () => {
+    const { unmount } = render(<Notebook />);
+
+    act(() => {
+      unmount();
+    });
+
+    const deletedNote = mockConfig.booknotes.find((a) => a.cfi === 'test-cfi');
+    expect(deletedNote?.deletedAt).toBeGreaterThan(0);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -992,13 +992,11 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     setShowDictionaryPopup(false);
   };
 
-  const handleCopy = (dismissPopup = true) => {
+  const handleCopy = (dismissPopup: boolean = true) => {
     if (!selection || !selection.text) return;
     const textToCopy = selection.text;
-    setTimeout(() => {
-      // Delay to ensure it won't be overridden by system clipboard actions
-      void writeTextToClipboard(textToCopy);
-    }, 100);
+    // Execute immediately to maintain transient user activation context
+    void writeTextToClipboard(textToCopy);
     if (dismissPopup) {
       handleDismissPopupAndSelection();
     }
@@ -1057,7 +1055,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     handleDismissPopupAndSelection();
   };
 
-  const handleHighlight = (update = false, highlightStyle?: HighlightStyle) => {
+  const handleHighlight = (update = false, highlightStyle?: HighlightStyle): string | undefined => {
     if (!selection || !selection.text) return;
     setHighlightOptionsVisible(true);
     const { booknotes: annotations = [] } = config;
@@ -1124,6 +1122,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     if (updatedConfig) {
       saveConfig(envConfig, bookKey, updatedConfig, settings);
     }
+    return cfi;
   };
 
   const handleCreateTTSHighlight = (event: CustomEvent) => {
@@ -1190,10 +1189,12 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     if (!selection || !selection.text) return;
     const { sectionHref: href } = progress;
     selection.href = href;
-    handleHighlight(true);
-    setNotebookVisible(true);
-    setNotebookNewAnnotation(selection);
-    handleDismissPopup();
+    const cfi = handleHighlight(true);
+    if (cfi) {
+      setNotebookVisible(true);
+      setNotebookNewAnnotation({ ...selection, cfi });
+      handleDismissPopup();
+    }
   };
 
   const handleSearch = () => {

--- a/apps/readest-app/src/app/reader/components/notebook/NoteEditor.tsx
+++ b/apps/readest-app/src/app/reader/components/notebook/NoteEditor.tsx
@@ -12,9 +12,10 @@ import TextButton from '@/components/TextButton';
 interface NoteEditorProps {
   onSave: (selection: TextSelection, note: string) => void;
   onEdit: (annotation: BookNote) => void;
+  onCancel?: () => void;
 }
 
-const NoteEditor: React.FC<NoteEditorProps> = ({ onSave, onEdit }) => {
+const NoteEditor: React.FC<NoteEditorProps> = ({ onSave, onEdit, onCancel }) => {
   const _ = useTranslation();
   const {
     notebookNewAnnotation,
@@ -78,6 +79,9 @@ const NoteEditor: React.FC<NoteEditorProps> = ({ onSave, onEdit }) => {
   };
 
   const handleEscape = () => {
+    if (onCancel) {
+      onCancel();
+    }
     if (notebookNewAnnotation) {
       setNotebookNewAnnotation(null);
     }

--- a/apps/readest-app/src/app/reader/components/notebook/Notebook.tsx
+++ b/apps/readest-app/src/app/reader/components/notebook/Notebook.tsx
@@ -23,7 +23,7 @@ import { Overlay } from '@/components/Overlay';
 import { saveSysSettings } from '@/helpers/settings';
 import { NOTE_PREFIX } from '@/types/view';
 import useShortcuts from '@/hooks/useShortcuts';
-import { findAnnotationAtCfi } from '../../utils/annotatorUtil';
+import { findAnnotationAtCfi, removeBookNoteOverlays } from '../../utils/annotatorUtil';
 import BooknoteItem from '../sidebar/BooknoteItem';
 import AIAssistant from './AIAssistant';
 import NotebookHeader from './Header';
@@ -45,7 +45,7 @@ const Notebook: React.FC = ({}) => {
     useNotebookStore();
   const { notebookNewAnnotation, notebookEditAnnotation, setNotebookPin } = useNotebookStore();
   const { getBookData, getConfig, saveConfig, updateBooknotes } = useBookDataStore();
-  const { getView, getProgress, getViewSettings } = useReaderStore();
+  const { getView, getProgress, getViewSettings, getViewsById } = useReaderStore();
   const { getNotebookWidth, setNotebookWidth, setNotebookVisible, toggleNotebookPin } =
     useNotebookStore();
   const { setNotebookNewAnnotation, setNotebookEditAnnotation, setNotebookActiveTab } =
@@ -78,12 +78,51 @@ const Notebook: React.FC = ({}) => {
     }
   };
 
+  const handleCancelNewAnnotation = useCallback(
+    (selection: TextSelection, bookKey: string) => {
+      const view = getView(bookKey);
+      const config = getConfig(bookKey);
+      if (!config) return;
+
+      const cfi = selection.cfi || view?.getCFI(selection.index, selection.range);
+      if (!cfi) return;
+
+      const { booknotes: annotations = [] } = config;
+      const idx = annotations.findIndex(
+        (a) => a.cfi === cfi && a.type === 'annotation' && !a.deletedAt,
+      );
+      if (idx !== -1) {
+        const annotation = annotations[idx]!;
+        if (!annotation.note || annotation.note.trim().length === 0) {
+          annotation.deletedAt = Date.now();
+          const views = getViewsById(bookKey.split('-')[0]!);
+          views.forEach((v) => removeBookNoteOverlays(v, annotation));
+          const updatedConfig = updateBooknotes(bookKey, annotations);
+          if (updatedConfig) {
+            saveConfig(envConfig, bookKey, updatedConfig, settings);
+          }
+        }
+      }
+    },
+    [getView, getConfig, getViewsById, updateBooknotes, saveConfig, envConfig, settings],
+  );
+
+  const handleCancelNote = useCallback(() => {
+    if (notebookNewAnnotation && sideBarBookKey) {
+      handleCancelNewAnnotation(notebookNewAnnotation, sideBarBookKey);
+    }
+  }, [notebookNewAnnotation, sideBarBookKey, handleCancelNewAnnotation]);
+
   const handleHideNotebook = useCallback(() => {
+    if (notebookNewAnnotation && sideBarBookKey) {
+      handleCancelNewAnnotation(notebookNewAnnotation, sideBarBookKey);
+    }
     if (!isNotebookPinned) {
       setNotebookVisible(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isNotebookPinned]);
+    setNotebookNewAnnotation(null);
+    setNotebookEditAnnotation(null);
+  }, [isNotebookPinned, notebookNewAnnotation, sideBarBookKey, handleCancelNewAnnotation]);
 
   useShortcuts({ onEscape: handleHideNotebook }, [handleHideNotebook]);
 
@@ -97,6 +136,16 @@ const Notebook: React.FC = ({}) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isNotebookVisible]);
+
+  useEffect(() => {
+    const currentBookKey = sideBarBookKey;
+    return () => {
+      const state = useNotebookStore.getState();
+      if (state.notebookNewAnnotation && currentBookKey) {
+        handleCancelNewAnnotation(state.notebookNewAnnotation, currentBookKey);
+      }
+    };
+  }, [sideBarBookKey, handleCancelNewAnnotation]);
 
   useEffect(() => {
     setNotebookWidth(settings.globalReadSettings.notebookWidth);
@@ -140,7 +189,19 @@ const Notebook: React.FC = ({}) => {
     saveSysSettings(envConfig, 'globalReadSettings', newGlobalReadSettings);
   };
 
+  const handleClose = () => {
+    if (notebookNewAnnotation && sideBarBookKey) {
+      handleCancelNewAnnotation(notebookNewAnnotation, sideBarBookKey);
+    }
+    setNotebookVisible(false);
+    setNotebookNewAnnotation(null);
+    setNotebookEditAnnotation(null);
+  };
+
   const handleClickOverlay = () => {
+    if (notebookNewAnnotation && sideBarBookKey) {
+      handleCancelNewAnnotation(notebookNewAnnotation, sideBarBookKey);
+    }
     setNotebookVisible(false);
     setNotebookNewAnnotation(null);
     setNotebookEditAnnotation(null);
@@ -151,7 +212,7 @@ const Notebook: React.FC = ({}) => {
     const view = getView(sideBarBookKey);
     const config = getConfig(sideBarBookKey)!;
 
-    const cfi = view?.getCFI(selection.index, selection.range);
+    const cfi = selection.cfi || view?.getCFI(selection.index, selection.range);
     if (!cfi) return;
 
     const { booknotes: annotations = [] } = config;
@@ -355,7 +416,7 @@ const Notebook: React.FC = ({}) => {
           <NotebookHeader
             isPinned={isNotebookPinned}
             isSearchBarVisible={isSearchBarVisible && notebookActiveTab === 'notes'}
-            handleClose={() => setNotebookVisible(false)}
+            handleClose={handleClose}
             handleTogglePin={handleTogglePin}
             handleToggleSearchBar={handleToggleSearchBar}
             showSearchButton={notebookActiveTab === 'notes'}
@@ -463,7 +524,11 @@ const Notebook: React.FC = ({}) => {
               )}
             </div>
             {(notebookNewAnnotation || notebookEditAnnotation) && !isSearchBarVisible && (
-              <NoteEditor onSave={handleSaveNote} onEdit={(item) => handleEditNote(item, false)} />
+              <NoteEditor
+                onSave={handleSaveNote}
+                onEdit={(item) => handleEditNote(item, false)}
+                onCancel={handleCancelNote}
+              />
             )}
             <ul>
               {filteredAnnotationNotes.map((item, index) => (

--- a/apps/readest-app/src/utils/sel.ts
+++ b/apps/readest-app/src/utils/sel.ts
@@ -643,7 +643,11 @@ export const getTextFromRange = (range: Range, rejectTags: string[] = []): strin
     {
       acceptNode: (node) => {
         const parent = node.parentElement;
-        if (rejectTags.includes(parent?.tagName.toLowerCase() || '')) {
+        if (
+          parent &&
+          typeof parent.tagName === 'string' &&
+          rejectTags.includes(parent.tagName.toLowerCase())
+        ) {
           return NodeFilter.FILTER_REJECT;
         }
         return NodeFilter.FILTER_ACCEPT;
@@ -661,7 +665,11 @@ export const getTextFromRange = (range: Range, rejectTags: string[] = []): strin
   while ((node = walker.nextNode())) {
     if (node.nodeType === Node.TEXT_NODE) {
       text += (node as Text).nodeValue ?? '';
-    } else if ((node as Element).tagName === 'BR') {
+    } else if (
+      node.nodeType === Node.ELEMENT_NODE &&
+      typeof (node as Element).tagName === 'string' &&
+      (node as Element).tagName.toUpperCase() === 'BR'
+    ) {
       text += '\n';
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8014,6 +8014,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0


### PR DESCRIPTION
## Background

Selecting text and interacting with highlights/annotations in the reader component had a few edge cases:
- When a user selected text and copied it, a timeout was used which could fail or get blocked by modern browser clipboard protections.
- When starting to create an annotation (which pre-creates a highlight) but cancelling it, the pre-created highlight was not cleaned up, leading to orphaned blank highlights.
- The computed CFI was not propagated to new highlights during creation.
- A missing type check for `tagName` in text range selection could trigger exceptions on non-element nodes.

## Fix

- **Clean up empty highlights on cancel:** Added cancellation handling to clean up empty pre-created highlights when the notebook annotation is cancelled (via cancel button, close button, book switch, or unmounting).
- **CFI propagation:** Correctly propagate the computed CFI to the notebook selection object in `Annotator.tsx`.
- **Immediate clipboard write:** Removed the timeout delay in `writeTextToClipboard` to maintain transient user activation context and avoid browser copy blocks.
- **Type safety:** Added type safety checks for `tagName` in the range utility (`apps/readest-app/src/utils/sel.ts`) to prevent exceptions on non-element nodes.
- **Unit Tests:** Added `NotebookCancellation.test.tsx` containing tests for all cancellation and cleanup flows.

## Verification

- `pnpm lint` (tsgo + biome) — clean
- `pnpm test` — pass (specifically verified `NotebookCancellation.test.tsx` passing 4/4 tests)
- `pnpm --filter @readest/readest-app build` — compiles successfully