### PR TITLE
fix(library): prevent series and description overlap in list view (#4796)

### DIFF
--- a/apps/readest-app/src/app/library/components/BookItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookItem.tsx
@@ -73,7 +73,7 @@ const BookItem: React.FC<BookItemProps> = ({
       className={clsx(
         'book-item flex',
         mode === 'grid' && 'h-full flex-col justify-end',
-        mode === 'list' && 'h-28 flex-row gap-4 overflow-hidden',
+        mode === 'list' && 'min-h-28 flex-row gap-4 overflow-hidden',
         mode === 'list' ? 'library-list-item' : 'library-grid-item',
         appService?.hasContextMenu ? 'cursor-pointer' : '',
       )}


### PR DESCRIPTION
## Summary

Fixes #4796. In the library **list view**, when a book is part of a series the series line and the description preview overlap and get clipped (reported on a Pixel 10 Pro, Android 16).

The list-mode book item used a fixed `h-28` (112px) height. The text column stacks title, authors, series, description, and a progress/actions row. Without a series that fits in 112px, but the optional series line pushes the total past 112px, so under `overflow-hidden` the lines collide and get cut off. A larger **system font scale** (Android's accessibility font size, which the WebView applies to CSS text) inflates line heights and makes the overlap much worse, which is what the reporter saw.

The fix swaps the fixed `h-28` for `min-h-28` so the row grows just enough to fit its content. Non-series rows keep the same 112px height, and the list is virtualized with measured heights, so variable row heights are fine.

## Change

- `src/app/library/components/BookItem.tsx`: list-mode container `h-28` -> `min-h-28` (one class).

## Verification

Reproduced the exact flex layout in a browser before/after, including a ~130% font scale to mirror the reporter's device:

- **Before (`h-28`, 130% font):** series + description overlap and clip (matches the issue screenshot).
- **After (`min-h-28`):** title, authors, series, description, and progress row all stack cleanly at any font scale; non-series rows look identical to today.

Gates: `pnpm lint` (tsgo + Biome) pass, `pnpm test` passes (6324 passed, 9 skipped), `pnpm format:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)