### PR TITLE
feat(reader): add TTS highlight granularity setting (word or sentence)

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -1935,5 +1935,8 @@
   "Sort descending": "ترتيب تنازلي",
   "Filter Annotations": "تصفية التعليقات التوضيحية",
   "Colors": "الألوان",
-  "Styles": "الأنماط"
+  "Styles": "الأنماط",
+  "Word": "كلمة",
+  "Sentence": "جملة",
+  "Granularity": "الدقة"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1803,5 +1803,8 @@
   "Sort descending": "অধঃক্রমে সাজান",
   "Filter Annotations": "টীকা ফিল্টার করুন",
   "Colors": "রঙ",
-  "Styles": "শৈলী"
+  "Styles": "শৈলী",
+  "Word": "শব্দ",
+  "Sentence": "বাক্য",
+  "Granularity": "সূক্ষ্মতা"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1764,5 +1764,8 @@
   "Metadata updated": "གནད་སྨིན་གོ་དོན་གསར་བསྒྱུར་བྱས།",
   "Filter Annotations": "མཆན་འདེམས་སྒྲིག",
   "Colors": "ཁ་དོག",
-  "Styles": "རྣམ་པ"
+  "Styles": "རྣམ་པ",
+  "Word": "ཚིག",
+  "Sentence": "ཚིག་གྲུབ།",
+  "Granularity": "ཞིབ་ཕྲའི་ཚད"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1803,5 +1803,8 @@
   "Sort descending": "Absteigend sortieren",
   "Filter Annotations": "Anmerkungen filtern",
   "Colors": "Farben",
-  "Styles": "Stile"
+  "Styles": "Stile",
+  "Word": "Wort",
+  "Sentence": "Satz",
+  "Granularity": "Granularität"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1803,5 +1803,8 @@
   "Sort descending": "Φθίνουσα ταξινόμηση",
   "Filter Annotations": "Φιλτράρισμα σχολιασμών",
   "Colors": "Χρώματα",
-  "Styles": "Στυλ"
+  "Styles": "Στυλ",
+  "Word": "Λέξη",
+  "Sentence": "Πρόταση",
+  "Granularity": "Διαβάθμιση"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1836,5 +1836,8 @@
   "Sort descending": "Orden descendente",
   "Filter Annotations": "Filtrar anotaciones",
   "Colors": "Colores",
-  "Styles": "Estilos"
+  "Styles": "Estilos",
+  "Word": "Palabra",
+  "Sentence": "Oración",
+  "Granularity": "Granularidad"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1803,5 +1803,8 @@
   "Sort descending": "مرتب‌سازی نزولی",
   "Filter Annotations": "فیلتر یادداشت‌ها",
   "Colors": "رنگ‌ها",
-  "Styles": "سبک‌ها"
+  "Styles": "سبک‌ها",
+  "Word": "کلمه",
+  "Sentence": "جمله",
+  "Granularity": "دانه‌بندی"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1836,5 +1836,8 @@
   "Sort descending": "Tri décroissant",
   "Filter Annotations": "Filtrer les annotations",
   "Colors": "Couleurs",
-  "Styles": "Styles"
+  "Styles": "Styles",
+  "Word": "Mot",
+  "Sentence": "Phrase",
+  "Granularity": "Granularité"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1836,5 +1836,8 @@
   "Sort descending": "מיון יורד",
   "Filter Annotations": "סינון הערות",
   "Colors": "צבעים",
-  "Styles": "סגנונות"
+  "Styles": "סגנונות",
+  "Word": "מילה",
+  "Sentence": "משפט",
+  "Granularity": "רמת פירוט"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1803,5 +1803,8 @@
   "Sort descending": "अवरोही क्रम",
   "Filter Annotations": "टिप्पणियाँ फ़िल्टर करें",
   "Colors": "रंग",
-  "Styles": "शैलियाँ"
+  "Styles": "शैलियाँ",
+  "Word": "शब्द",
+  "Sentence": "वाक्य",
+  "Granularity": "सूक्ष्मता"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1803,5 +1803,8 @@
   "Sort descending": "Csökkenő sorrend",
   "Filter Annotations": "Jegyzetek szűrése",
   "Colors": "Színek",
-  "Styles": "Stílusok"
+  "Styles": "Stílusok",
+  "Word": "Szó",
+  "Sentence": "Mondat",
+  "Granularity": "Részletesség"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1770,5 +1770,8 @@
   "Sort descending": "Urutkan menurun",
   "Filter Annotations": "Filter Anotasi",
   "Colors": "Warna",
-  "Styles": "Gaya"
+  "Styles": "Gaya",
+  "Word": "Kata",
+  "Sentence": "Kalimat",
+  "Granularity": "Granularitas"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1836,5 +1836,8 @@
   "Sort descending": "Ordine decrescente",
   "Filter Annotations": "Filtra annotazioni",
   "Colors": "Colori",
-  "Styles": "Stili"
+  "Styles": "Stili",
+  "Word": "Parola",
+  "Sentence": "Frase",
+  "Granularity": "Granularità"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1770,5 +1770,8 @@
   "Sort descending": "降順で並べ替え",
   "Filter Annotations": "注釈をフィルター",
   "Colors": "色",
-  "Styles": "スタイル"
+  "Styles": "スタイル",
+  "Word": "単語",
+  "Sentence": "文",
+  "Granularity": "粒度"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1770,5 +1770,8 @@
   "Sort descending": "내림차순 정렬",
   "Filter Annotations": "주석 필터링",
   "Colors": "색상",
-  "Styles": "스타일"
+  "Styles": "스타일",
+  "Word": "단어",
+  "Sentence": "문장",
+  "Granularity": "단위"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1770,5 +1770,8 @@
   "Sort descending": "Isih menurun",
   "Filter Annotations": "Tapis Anotasi",
   "Colors": "Warna",
-  "Styles": "Gaya"
+  "Styles": "Gaya",
+  "Word": "Perkataan",
+  "Sentence": "Ayat",
+  "Granularity": "Granulariti"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1803,5 +1803,8 @@
   "Sort descending": "Aflopend sorteren",
   "Filter Annotations": "Aantekeningen filteren",
   "Colors": "Kleuren",
-  "Styles": "Stijlen"
+  "Styles": "Stijlen",
+  "Word": "Woord",
+  "Sentence": "Zin",
+  "Granularity": "Granulariteit"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1869,5 +1869,8 @@
   "Sort descending": "Sortuj malejąco",
   "Filter Annotations": "Filtruj adnotacje",
   "Colors": "Kolory",
-  "Styles": "Style"
+  "Styles": "Style",
+  "Word": "Słowo",
+  "Sentence": "Zdanie",
+  "Granularity": "Ziarnistość"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1836,5 +1836,8 @@
   "Sort descending": "Ordem decrescente",
   "Filter Annotations": "Filtrar anotações",
   "Colors": "Cores",
-  "Styles": "Estilos"
+  "Styles": "Estilos",
+  "Word": "Palavra",
+  "Sentence": "Frase",
+  "Granularity": "Granularidade"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1836,5 +1836,8 @@
   "Sort descending": "Ordem decrescente",
   "Filter Annotations": "Filtrar anotações",
   "Colors": "Cores",
-  "Styles": "Estilos"
+  "Styles": "Estilos",
+  "Word": "Palavra",
+  "Sentence": "Frase",
+  "Granularity": "Granularidade"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1836,5 +1836,8 @@
   "Sort descending": "Sortare descrescătoare",
   "Filter Annotations": "Filtrează adnotările",
   "Colors": "Culori",
-  "Styles": "Stiluri"
+  "Styles": "Stiluri",
+  "Word": "Cuvânt",
+  "Sentence": "Propoziție",
+  "Granularity": "Granularitate"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1869,5 +1869,8 @@
   "Sort descending": "По убыванию",
   "Filter Annotations": "Фильтровать аннотации",
   "Colors": "Цвета",
-  "Styles": "Стили"
+  "Styles": "Стили",
+  "Word": "Слово",
+  "Sentence": "Предложение",
+  "Granularity": "Детализация"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1803,5 +1803,8 @@
   "Sort descending": "අවරෝහණව සකසන්න",
   "Filter Annotations": "සටහන් පෙරහන් කරන්න",
   "Colors": "වර්ණ",
-  "Styles": "මෝස්තර"
+  "Styles": "මෝස්තර",
+  "Word": "වචනය",
+  "Sentence": "වාක්‍යය",
+  "Granularity": "විස්තර මට්ටම"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1869,5 +1869,8 @@
   "Sort descending": "Padajoče razvrščanje",
   "Filter Annotations": "Filtriraj opombe",
   "Colors": "Barve",
-  "Styles": "Slogi"
+  "Styles": "Slogi",
+  "Word": "Beseda",
+  "Sentence": "Stavek",
+  "Granularity": "Granularnost"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1803,5 +1803,8 @@
   "Sort descending": "Fallande sortering",
   "Filter Annotations": "Filtrera anteckningar",
   "Colors": "Färger",
-  "Styles": "Stilar"
+  "Styles": "Stilar",
+  "Word": "Ord",
+  "Sentence": "Mening",
+  "Granularity": "Detaljnivå"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1803,5 +1803,8 @@
   "Sort descending": "இறங்குவரிசை",
   "Filter Annotations": "சிறுகுறிப்புகளை வடிகட்டு",
   "Colors": "நிறங்கள்",
-  "Styles": "பாணிகள்"
+  "Styles": "பாணிகள்",
+  "Word": "சொல்",
+  "Sentence": "வாக்கியம்",
+  "Granularity": "நுண்மை"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1770,5 +1770,8 @@
   "Sort descending": "เรียงจากมากไปน้อย",
   "Filter Annotations": "กรองคำอธิบายประกอบ",
   "Colors": "สี",
-  "Styles": "สไตล์"
+  "Styles": "สไตล์",
+  "Word": "คำ",
+  "Sentence": "ประโยค",
+  "Granularity": "ระดับความละเอียด"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1803,5 +1803,8 @@
   "Sort descending": "Azalan sıralama",
   "Filter Annotations": "Açıklamaları Filtrele",
   "Colors": "Renkler",
-  "Styles": "Stiller"
+  "Styles": "Stiller",
+  "Word": "Kelime",
+  "Sentence": "Cümle",
+  "Granularity": "Ayrıntı düzeyi"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1869,5 +1869,8 @@
   "Sort descending": "За спаданням",
   "Filter Annotations": "Фільтрувати анотації",
   "Colors": "Кольори",
-  "Styles": "Стилі"
+  "Styles": "Стилі",
+  "Word": "Слово",
+  "Sentence": "Речення",
+  "Granularity": "Деталізація"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1803,5 +1803,8 @@
   "Sort descending": "Kamayish boʻyicha",
   "Filter Annotations": "Izohlarni filtrlash",
   "Colors": "Ranglar",
-  "Styles": "Uslublar"
+  "Styles": "Uslublar",
+  "Word": "So‘z",
+  "Sentence": "Gap",
+  "Granularity": "Tafsilot darajasi"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1770,5 +1770,8 @@
   "Sort descending": "Sắp xếp giảm dần",
   "Filter Annotations": "Lọc chú thích",
   "Colors": "Màu sắc",
-  "Styles": "Kiểu"
+  "Styles": "Kiểu",
+  "Word": "Từ",
+  "Sentence": "Câu",
+  "Granularity": "Mức độ chi tiết"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1770,5 +1770,8 @@
   "Sort descending": "降序排列",
   "Filter Annotations": "筛选笔记",
   "Colors": "颜色",
-  "Styles": "样式"
+  "Styles": "样式",
+  "Word": "单词",
+  "Sentence": "句子",
+  "Granularity": "粒度"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1770,5 +1770,8 @@
   "Sort descending": "降序排列",
   "Filter Annotations": "篩選筆記",
   "Colors": "顏色",
-  "Styles": "樣式"
+  "Styles": "樣式",
+  "Word": "單字",
+  "Sentence": "句子",
+  "Granularity": "粒度"
 }

--- a/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
@@ -133,6 +133,7 @@ vi.mock('@/services/tts', () => ({
       ),
       initViewTTS: vi.fn().mockResolvedValue(undefined),
       updateHighlightOptions: vi.fn(),
+      setHighlightGranularity: vi.fn(),
       setLang: vi.fn(),
       setRate: vi.fn(),
       setVoice: vi.fn(),

--- a/apps/readest-app/src/__tests__/services/tts-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller.test.ts
@@ -744,6 +744,29 @@ describe('TTSController', () => {
       controller.prepareSpeakWords([]);
       expect(controller.getCurrentHighlightCfi()).toBeNull();
     });
+
+    test('granularity "sentence" forces sentence highlighting (skips word-by-word)', async () => {
+      controller.setHighlightGranularity('sentence');
+      await armWithSentence(makeSentenceRange());
+      getOverlayer().add.mockClear();
+      // Even when the client reports word boundaries and calls prepareSpeakWords,
+      // the user's "sentence" choice keeps highlighting at the sentence level: the
+      // sentence highlight was already drawn at mark dispatch (not suppressed), so
+      // prepareSpeakWords is a no-op and word mode never engages.
+      controller.prepareSpeakWords(['Hello', 'brave', 'world']);
+      expect(getOverlayer().add).not.toHaveBeenCalled();
+      expect(controller.getCurrentHighlightCfi()).toBeNull();
+    });
+
+    test('granularity "word" (default) still highlights word-by-word', async () => {
+      controller.setHighlightGranularity('word');
+      await armWithSentence(makeSentenceRange());
+      getOverlayer().add.mockClear();
+      controller.prepareSpeakWords(['Hello', 'brave', 'world']);
+      // First word highlighted immediately and word mode engaged.
+      expect(getOverlayer().add).toHaveBeenCalledTimes(1);
+      expect(controller.getCurrentHighlightCfi()).not.toBeNull();
+    });
   });
 
   describe('tts-position event', () => {

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -531,6 +531,12 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewSettings?.ttsHighlightOptions, viewSettings?.isEink, getTTSHighlightOptions]);
 
+  useEffect(() => {
+    if (ttsControllerRef.current && viewSettings?.ttsHighlightGranularity) {
+      ttsControllerRef.current.setHighlightGranularity(viewSettings.ttsHighlightGranularity);
+    }
+  }, [viewSettings?.ttsHighlightGranularity]);
+
   // handleStop (defined before handleTTSSpeak/handleTTSStop which reference it)
   const handleStop = useCallback(
     async (bookKey: string) => {
@@ -659,6 +665,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
         ttsController.updateHighlightOptions(
           getTTSHighlightOptions(viewSettings.ttsHighlightOptions, viewSettings.isEink),
         );
+        ttsController.setHighlightGranularity(viewSettings.ttsHighlightGranularity ?? 'word');
         const ssml =
           oneTime && ttsSpeakRange
             ? genSSMLRaw(ttsSpeakRange.toString().trim())

--- a/apps/readest-app/src/components/settings/TTSPanel.tsx
+++ b/apps/readest-app/src/components/settings/TTSPanel.tsx
@@ -6,7 +6,7 @@ import { useResetViewSettings } from '@/hooks/useResetSettings';
 import { useTranslation } from '@/hooks/useTranslation';
 import { saveViewSettings } from '@/helpers/settings';
 import { SettingsPanelPanelProp } from './SettingsDialog';
-import { TTSMediaMetadataMode } from '@/services/tts/types';
+import { TTSHighlightGranularity, TTSMediaMetadataMode } from '@/services/tts/types';
 import { BoxedList, SettingsRow, SettingsSelect } from './primitives';
 import TTSHighlightStyleEditor, { TTSHighlightStyle } from './color/TTSHighlightStyleEditor';
 
@@ -19,6 +19,9 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
 
   const [ttsMediaMetadata, setTtsMediaMetadata] = useState<TTSMediaMetadataMode>(
     viewSettings.ttsMediaMetadata ?? 'sentence',
+  );
+  const [ttsHighlightGranularity, setTtsHighlightGranularity] = useState<TTSHighlightGranularity>(
+    viewSettings.ttsHighlightGranularity ?? 'word',
   );
   const [ttsHighlightStyle, setTtsHighlightStyle] = useState(
     viewSettings.ttsHighlightOptions.style,
@@ -35,6 +38,9 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
   const handleReset = () => {
     resetToDefaults({
       ttsMediaMetadata: setTtsMediaMetadata as React.Dispatch<React.SetStateAction<string>>,
+      ttsHighlightGranularity: setTtsHighlightGranularity as React.Dispatch<
+        React.SetStateAction<string>
+      >,
     });
   };
 
@@ -48,6 +54,19 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
     saveViewSettings(envConfig, bookKey, 'ttsMediaMetadata', ttsMediaMetadata, false, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ttsMediaMetadata]);
+
+  useEffect(() => {
+    if (ttsHighlightGranularity === viewSettings.ttsHighlightGranularity) return;
+    saveViewSettings(
+      envConfig,
+      bookKey,
+      'ttsHighlightGranularity',
+      ttsHighlightGranularity,
+      false,
+      false,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ttsHighlightGranularity]);
 
   const handleTTSStyleChange = (style: TTSHighlightStyle) => {
     setTtsHighlightStyle(style);
@@ -76,12 +95,18 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
     setTtsMediaMetadata(event.target.value as TTSMediaMetadataMode);
   };
 
+  const handleTTSGranularityChange = (granularity: TTSHighlightGranularity) => {
+    setTtsHighlightGranularity(granularity);
+  };
+
   return (
     <div className='my-4 w-full space-y-6'>
       <TTSHighlightStyleEditor
+        granularity={ttsHighlightGranularity}
         style={ttsHighlightStyle}
         color={ttsHighlightColor}
         customColors={customTtsHighlightColors}
+        onGranularityChange={handleTTSGranularityChange}
         onStyleChange={handleTTSStyleChange}
         onColorChange={handleTTSColorChange}
         onCustomColorsChange={handleCustomTtsColorsChange}

--- a/apps/readest-app/src/components/settings/color/TTSHighlightStyleEditor.tsx
+++ b/apps/readest-app/src/components/settings/color/TTSHighlightStyleEditor.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { MdClose } from 'react-icons/md';
 import { useTranslation } from '@/hooks/useTranslation';
+import { TTSHighlightGranularity } from '@/services/tts/types';
 import { BoxedList, SettingsRow, SettingsSelect } from '../primitives';
 import ColorInput from './ColorInput';
 
@@ -12,18 +13,22 @@ export type TTSHighlightStyle =
   | 'outline';
 
 interface TTSHighlightStyleEditorProps {
+  granularity: TTSHighlightGranularity;
   style: TTSHighlightStyle;
   color: string;
   customColors: string[];
+  onGranularityChange: (granularity: TTSHighlightGranularity) => void;
   onStyleChange: (style: TTSHighlightStyle) => void;
   onColorChange: (color: string) => void;
   onCustomColorsChange: (colors: string[]) => void;
 }
 
 const TTSHighlightStyleEditor: React.FC<TTSHighlightStyleEditorProps> = ({
+  granularity,
   style,
   color,
   customColors,
+  onGranularityChange,
   onStyleChange,
   onColorChange,
   onCustomColorsChange,
@@ -60,6 +65,18 @@ const TTSHighlightStyleEditor: React.FC<TTSHighlightStyleEditorProps> = ({
 
   return (
     <BoxedList title={_('TTS Highlighting')}>
+      <SettingsRow label={_('Granularity')}>
+        <SettingsSelect
+          value={granularity}
+          onChange={(e) => onGranularityChange(e.target.value as TTSHighlightGranularity)}
+          ariaLabel={_('Granularity')}
+          options={[
+            { value: 'word', label: _('Word') },
+            { value: 'sentence', label: _('Sentence') },
+          ]}
+        />
+      </SettingsRow>
+
       <SettingsRow label={_('Style')}>
         <SettingsSelect
           value={style}

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -372,6 +372,7 @@ export const DEFAULT_TTS_CONFIG: TTSConfig = {
   ttsLocation: '',
   showTTSBar: false,
   ttsHighlightOptions: { style: 'highlight', color: '#808080' },
+  ttsHighlightGranularity: 'word',
   ttsMediaMetadata: 'sentence',
 };
 

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -2,7 +2,13 @@ import { FoliateView } from '@/types/view';
 import { AppService } from '@/types/system';
 import { filterSSMLWithLang, parseSSMLMarks } from '@/utils/ssml';
 import { Overlayer } from 'foliate-js/overlayer.js';
-import { TTSGranularity, TTSHighlightOptions, TTSMark, TTSVoice } from './types';
+import {
+  TTSGranularity,
+  TTSHighlightGranularity,
+  TTSHighlightOptions,
+  TTSMark,
+  TTSVoice,
+} from './types';
 import { createRejectFilter } from '@/utils/node';
 import { WebSpeechClient } from './WebSpeechClient';
 import { NativeTTSClient } from './NativeTTSClient';
@@ -78,6 +84,11 @@ export class TTSController extends EventTarget {
   // re-apply the word instead of redrawing the whole sentence over it.
   #wordHighlightActive = false;
   #lastSpeakWordRange: Range | null = null;
+  // User-chosen highlight granularity. 'word' (default) highlights word-by-word
+  // when the active client reports word boundaries (Edge); 'sentence' keeps the
+  // highlight at the sentence level even then. Sentence highlighting is assumed
+  // supported by every client, so 'word' falls back to it automatically.
+  #highlightGranularity: TTSHighlightGranularity = 'word';
 
   state: TTSState = 'stopped';
   ttsLang: string = '';
@@ -188,6 +199,10 @@ export class TTSController extends EventTarget {
   updateHighlightOptions(options: TTSHighlightOptions) {
     this.options.style = options.style;
     this.options.color = options.color;
+  }
+
+  setHighlightGranularity(granularity: TTSHighlightGranularity) {
+    this.#highlightGranularity = granularity;
   }
 
   async initViewTTS(index?: number) {
@@ -677,8 +692,11 @@ export class TTSController extends EventTarget {
         // When the active client highlights word-by-word, suppress the
         // sentence highlight that setMark would otherwise draw, so the page
         // doesn't flash the whole sentence before the first word. The fallback
-        // (no boundaries) is drawn later in prepareSpeakWords.
-        this.#suppressMarkHighlight = this.ttsClient.supportsWordBoundaries();
+        // (no boundaries) is drawn later in prepareSpeakWords. When the user
+        // forces sentence granularity we keep the sentence highlight, so don't
+        // suppress it.
+        this.#suppressMarkHighlight =
+          this.ttsClient.supportsWordBoundaries() && this.#highlightGranularity === 'word';
         const range = this.view.tts?.setMark(mark.name);
         this.#suppressMarkHighlight = false;
         this.#speakWordsArmed = !!range;
@@ -760,6 +778,10 @@ export class TTSController extends EventTarget {
   // sentence-level semantics.
   prepareSpeakWords(words: string[]) {
     if (!this.#speakWordsArmed) return;
+    // User forced sentence-level highlighting: the sentence highlight was drawn
+    // at mark dispatch (not suppressed), so there's nothing to do here — leave
+    // word mode off even though the client reported word boundaries.
+    if (this.#highlightGranularity === 'sentence') return;
     const range = this.view.tts?.getLastRange();
     if (!range) return;
     this.#speakWordBaseRange = range;

--- a/apps/readest-app/src/services/tts/types.ts
+++ b/apps/readest-app/src/services/tts/types.ts
@@ -1,5 +1,7 @@
 export type TTSGranularity = 'sentence' | 'word';
 
+export type TTSHighlightGranularity = 'word' | 'sentence';
+
 export type TTSMediaMetadataMode = 'sentence' | 'paragraph' | 'chapter';
 
 export type TTSHighlightOptions = {

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -1,5 +1,6 @@
 import { BookMetadata } from '@/libs/document';
 import { TTSHighlightOptions } from '@/services/tts/types';
+import { TTSHighlightGranularity } from '@/services/tts/types';
 import { TTSMediaMetadataMode } from '@/services/tts/types';
 import type { AnnotationLinkType } from '@/utils/deeplink';
 import { AnnotationToolType } from './annotator';
@@ -314,6 +315,7 @@ export interface TTSConfig {
   ttsLocation: string;
   showTTSBar: boolean;
   ttsHighlightOptions: TTSHighlightOptions;
+  ttsHighlightGranularity: TTSHighlightGranularity;
   ttsMediaMetadata: TTSMediaMetadataMode;
 }
 


### PR DESCRIPTION
## Summary

Adds a **Granularity** option to Settings > TTS > "TTS Highlighting" that controls whether read-aloud highlighting follows the spoken **word** or the whole **sentence**. Defaults to **Word**, which preserves current behavior.

- Word-level highlighting only happens on engines that report word boundaries (Edge TTS today). Web Speech / native TTS, and the Sentence option, always highlight per sentence.
- Every engine is assumed to support sentence highlighting, so choosing **Word** on an engine without word boundaries automatically falls back to sentence. No broken state.

## Implementation

- New `TTSHighlightGranularity` type and `ttsHighlightGranularity` field on `TTSConfig` (default `'word'`).
- `TTSController` learns the choice via `setHighlightGranularity()` and gates two points:
  - it no longer suppresses the sentence highlight at mark dispatch when the user picks **Sentence**;
  - `prepareSpeakWords` returns early in **Sentence** mode so word-by-word highlighting never engages.
  - Note: the `prepareSpeakWords` gate keys off the setting only, not the client capability, because only Edge calls it in production while the unit tests drive it with the web client.
- Wired through `useTTSControl` at controller creation plus a `useEffect` watching the setting.
- UI added as the first row of the existing "TTS Highlighting" boxed list in `TTSHighlightStyleEditor`.
- i18n: `Word` / `Sentence` / `Granularity` added across all locales.

## Test plan

- New unit tests in `tts-controller.test.ts`: Sentence granularity skips word-by-word highlighting; Word (default) still highlights word-by-word.
- `pnpm test` (6351 passed), `pnpm lint`, and `pnpm format:check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
