### PR TITLE
fix(reader): eliminate PDF scrolled-mode rendering lag on mobile (#4795)

### DIFF
--- a/apps/readest-app/src/__tests__/document/fixed-layout-scroll-scheduler.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-scroll-scheduler.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import { planScrollModePages } from 'foliate-js/fixed-layout.js';
+
+// Page model the scheduler operates on. `visible` is set by the
+// IntersectionObserver (true when the page is within the widened preload
+// margin); `state` mirrors the load lifecycle.
+const page = (index: number, state: string, visible: boolean) => ({ index, state, visible });
+
+describe('planScrollModePages', () => {
+  it('loads the nearest visible idle pages first, within the concurrency budget', () => {
+    const pages = [
+      page(8, 'idle', true),
+      page(9, 'idle', true),
+      page(10, 'loaded', true),
+      page(11, 'idle', true),
+      page(12, 'idle', true),
+    ];
+
+    const { load } = planScrollModePages({
+      pages,
+      currentIndex: 10,
+      maxLoaded: 8,
+      maxConcurrent: 2,
+      loadingCount: 0,
+    });
+
+    // Nearest to index 10 are 9 and 11; both idle+visible; budget is 2.
+    expect(load).toEqual([9, 11]);
+  });
+
+  it('subtracts in-flight loads from the concurrency budget', () => {
+    const pages = [page(9, 'idle', true), page(11, 'idle', true), page(12, 'idle', true)];
+
+    const { load } = planScrollModePages({
+      pages,
+      currentIndex: 10,
+      maxLoaded: 8,
+      maxConcurrent: 3,
+      loadingCount: 2,
+    });
+
+    // 3 concurrent allowed, 2 already loading -> budget of 1 -> nearest only.
+    expect(load).toEqual([9]);
+  });
+
+  it('never starts a load when the budget is already spent', () => {
+    const pages = [page(9, 'idle', true), page(11, 'idle', true)];
+
+    const { load } = planScrollModePages({
+      pages,
+      currentIndex: 10,
+      maxLoaded: 8,
+      maxConcurrent: 2,
+      loadingCount: 2,
+    });
+
+    expect(load).toEqual([]);
+  });
+
+  it('ignores idle pages outside the visible preload band', () => {
+    const pages = [page(9, 'idle', false), page(11, 'idle', true)];
+
+    const { load } = planScrollModePages({
+      pages,
+      currentIndex: 10,
+      maxLoaded: 8,
+      maxConcurrent: 4,
+      loadingCount: 0,
+    });
+
+    // Page 9 is not visible, so only the visible page 11 loads.
+    expect(load).toEqual([11]);
+  });
+
+  it('does not re-load pages that are already loading or loaded', () => {
+    const pages = [page(9, 'loading', true), page(10, 'loaded', true), page(11, 'idle', true)];
+
+    const { load } = planScrollModePages({
+      pages,
+      currentIndex: 10,
+      maxLoaded: 8,
+      maxConcurrent: 4,
+      loadingCount: 1,
+    });
+
+    expect(load).toEqual([11]);
+  });
+
+  it('never re-loads a page in the terminal error state', () => {
+    // A page whose load failed is parked in 'error' so the post-completion
+    // reschedule cannot retry it forever in a tight async loop.
+    const pages = [page(10, 'error', true), page(11, 'idle', true)];
+
+    const { load } = planScrollModePages({
+      pages,
+      currentIndex: 10,
+      maxLoaded: 8,
+      maxConcurrent: 4,
+      loadingCount: 0,
+    });
+
+    expect(load).toEqual([11]);
+  });
+
+  it('evicts the farthest non-visible loaded pages once over the in-memory cap', () => {
+    const pages = [
+      page(2, 'loaded', false),
+      page(20, 'loaded', false),
+      page(9, 'loaded', true),
+      page(10, 'loaded', true),
+      page(11, 'loaded', true),
+    ];
+
+    const { evict } = planScrollModePages({
+      pages,
+      currentIndex: 10,
+      maxLoaded: 3,
+      maxConcurrent: 2,
+      loadingCount: 0,
+    });
+
+    // 5 loaded, cap 3 -> evict the 2 farthest from index 10: pages 20 and 2.
+    expect(evict.sort((a: number, b: number) => a - b)).toEqual([2, 20]);
+  });
+
+  it('never evicts a visible page even when over the cap', () => {
+    const pages = [page(9, 'loaded', true), page(10, 'loaded', true), page(11, 'loaded', true)];
+
+    const { evict } = planScrollModePages({
+      pages,
+      currentIndex: 10,
+      maxLoaded: 1,
+      maxConcurrent: 2,
+      loadingCount: 0,
+    });
+
+    // All three are on screen; none may be torn out from under the reader.
+    expect(evict).toEqual([]);
+  });
+
+  it('does not evict when loaded pages are within the cap', () => {
+    const pages = [page(9, 'loaded', true), page(10, 'loaded', true)];
+
+    const { evict } = planScrollModePages({
+      pages,
+      currentIndex: 10,
+      maxLoaded: 8,
+      maxConcurrent: 2,
+      loadingCount: 0,
+    });
+
+    expect(evict).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #4795 (resurfaces #4031).

## Problem

In **scrolled mode**, PDF pages render blank while scrolling on Android, "rendered on the fly" with noticeable lag even when scrolling one or two pages. Profiled on a Xiaomi 13 via CDP: each PDF page takes **~415 ms** to render uncached (canvas raster + text + annotation layers), but the scrolled-mode `IntersectionObserver` used `rootMargin: '50% 0px'` (~half a page of lead) and started a load for **every** intersecting page with **no concurrency bound and no viewport priority**. The render never finished before the page scrolled into view, and a fast fling spawned many competing full-resolution renders.

## Fix

Bumps the foliate-js submodule to current `main` (`6f1a190`), which lands the scroll-lag fix **readest/foliate-js#40**:

- Widen the scrolled-mode preload margin to `200%` (~2 viewports of lead, enough for the ~415 ms render to finish before arrival).
- Route loading through a new pure, unit-tested `planScrollModePages` scheduler: load the visible idle pages **nearest the reader first**, bounded by a concurrency cap; evict the **farthest off-screen** loaded pages over the in-memory cap, **never evicting a visible page**. A finished load pulls in the next nearest page; a failed load is parked in a terminal `error` state (no retry loop).
- Live-canvas cap 8 -> 12, concurrency cap 3, pdf.js page cache 8 -> 16. Per-page canvas is ~7 MB at dpr 3, so ~12 live canvases stay within budget; orthogonal to the #3470 byte-range parsing throttle.

This PR adds the unit coverage (`fixed-layout-scroll-scheduler.test.ts`, 9 cases) and the submodule bump.

> As the first readest submodule bump past `982f168`, this also carries foliate-js#39 (gpu-composite page-turn opt-in) and foliate-js#41 (page-turn background paint context reuse), which are already on foliate-js `main`.

## Verification (CDP + screen recording on Xiaomi 13)

Identical reading-pace scroll, fresh region, same devtools build:

| | Before (0.11.12) | After |
|---|---|---|
| Frames during scroll | mostly **blank** | **all fully rendered** |
| Settled forward lead | +2 pages (span [-9, +2]) | +4 pages (span [-7, +4]) |
| 240-page fling | blank + thrash | settles to rendered, **no crash** |

`pnpm test` (6358 pass) and `pnpm lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)