### PR TITLE
fix(reader): smooth pinch-zoom, pan for scrolled PDF

### DIFF
--- a/apps/readest-app/src/__tests__/document/fixed-layout-pinch-zoom.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-pinch-zoom.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeScrollPinchTransform } from 'foliate-js/fixed-layout.js';
+
+describe('computeScrollPinchTransform', () => {
+  it('scales by the pinch ratio anchored at the viewport centre in both axes', () => {
+    // Anchoring the live preview at the viewport centre (in container
+    // coordinates) matches the post-pinch re-render, which restores the same
+    // centre point via the center anchor, so the zoom does not jump on release.
+    expect(
+      computeScrollPinchTransform({
+        ratio: 1.5,
+        scrollLeft: 0,
+        scrollTop: 2000,
+        viewportWidth: 360,
+        viewportHeight: 640,
+      }),
+    ).toEqual({
+      transform: 'scale(1.5)',
+      transformOrigin: '180px 2320px',
+    });
+  });
+
+  it('offsets the origin by the current scroll position', () => {
+    expect(
+      computeScrollPinchTransform({
+        ratio: 0.8,
+        scrollLeft: 90,
+        scrollTop: 0,
+        viewportWidth: 360,
+        viewportHeight: 640,
+      }),
+    ).toEqual({
+      transform: 'scale(0.8)',
+      transformOrigin: '270px 320px',
+    });
+  });
+});


### PR DESCRIPTION
Minimal reader-side change for scrolled-mode PDF pinch-zoom: bumps `foliate-js` to readest/foliate-js#43, where the actual fix lives.

In scrolled-mode PDF the page now:
- **zooms live under a pinch** and commits **without a layout shift** (the inter-page gap scales with the zoom so the committed layout matches the transform-scaled preview, and the centre page is restored to its pre-commit on-screen rect),
- is **pannable horizontally** when zoomed wider than the viewport,
- keeps **native text selection** working, because the page iframes stay interactive when idle.

readest already drives the renderer's `pinchZoom` on a two-finger gesture, so the only reader-side change is the submodule bump plus a unit test for the new scroll pinch transform (`fixed-layout-pinch-zoom.test.ts`).

Cross-page pinch (two fingers on two different page iframes) is intentionally not supported: Android serializes touches across iframe documents, so owning the gesture host-side would require making the iframes inert, which breaks native selection. Keeping the iframes interactive is the trade-off.

`pnpm test` + `pnpm lint` green. Verified on Xiaomi 13 (CDP): live pinch with preview->commit scale match and centre-page jump <= 2px (zoom in/out), one-finger vertical scroll + horizontal pan, centre-tap toolbar toggle, iframes interactive when idle.
