### PR TITLE
fix(node): ensure correct cross-platform path resolution in NodeAppService

### DIFF
--- a/apps/readest-app/src/services/nodeAppService.ts
+++ b/apps/readest-app/src/services/nodeAppService.ts
@@ -109,7 +109,7 @@ const getPathResolver = ({ customRootDir }: { customRootDir?: string } = {}) => 
           'Dictionaries',
         ];
         const leafDir = dataDirs.includes(base) ? '' : base;
-        return leafDir ? `${customRootDir}/${leafDir}` : customRootDir!;
+        return leafDir ? nodePath.join(customRootDir!, leafDir) : customRootDir!;
       }
     : undefined;
 
@@ -120,7 +120,7 @@ const getPathResolver = ({ customRootDir }: { customRootDir?: string } = {}) => 
         return {
           baseDir: 0,
           basePrefix: async () => custom ?? getAppConfigDir(),
-          fp: custom ? `${custom}${fp ? `/${fp}` : ''}` : fp,
+          fp: custom ? nodePath.join(custom, fp) : fp,
           base,
         };
       case 'Cache':
@@ -134,16 +134,14 @@ const getPathResolver = ({ customRootDir }: { customRootDir?: string } = {}) => 
         return {
           baseDir: 0,
           basePrefix: async () => custom ?? getAppLogDir(),
-          fp: custom ? `${custom}${fp ? `/${fp}` : ''}` : fp,
+          fp: custom ? nodePath.join(custom, fp) : fp,
           base,
         };
       case 'Data':
         return {
           baseDir: 0,
           basePrefix: async () => custom ?? getAppDataDir(),
-          fp: custom
-            ? `${custom}/${DATA_SUBDIR}${fp ? `/${fp}` : ''}`
-            : `${DATA_SUBDIR}${fp ? `/${fp}` : ''}`,
+          fp: custom ? nodePath.join(custom, DATA_SUBDIR, fp) : nodePath.join(DATA_SUBDIR, fp),
           base,
         };
       case 'Books':
@@ -151,8 +149,8 @@ const getPathResolver = ({ customRootDir }: { customRootDir?: string } = {}) => 
           baseDir: 0,
           basePrefix: async () => custom ?? getAppDataDir(),
           fp: custom
-            ? `${custom}/${LOCAL_BOOKS_SUBDIR}${fp ? `/${fp}` : ''}`
-            : `${LOCAL_BOOKS_SUBDIR}${fp ? `/${fp}` : ''}`,
+            ? nodePath.join(custom, LOCAL_BOOKS_SUBDIR, fp)
+            : nodePath.join(LOCAL_BOOKS_SUBDIR, fp),
           base,
         };
       case 'Fonts':
@@ -160,8 +158,8 @@ const getPathResolver = ({ customRootDir }: { customRootDir?: string } = {}) => 
           baseDir: 0,
           basePrefix: async () => custom ?? getAppDataDir(),
           fp: custom
-            ? `${custom}/${LOCAL_FONTS_SUBDIR}${fp ? `/${fp}` : ''}`
-            : `${LOCAL_FONTS_SUBDIR}${fp ? `/${fp}` : ''}`,
+            ? nodePath.join(custom, LOCAL_FONTS_SUBDIR, fp)
+            : nodePath.join(LOCAL_FONTS_SUBDIR, fp),
           base,
         };
       case 'Images':
@@ -169,8 +167,8 @@ const getPathResolver = ({ customRootDir }: { customRootDir?: string } = {}) => 
           baseDir: 0,
           basePrefix: async () => custom ?? getAppDataDir(),
           fp: custom
-            ? `${custom}/${LOCAL_IMAGES_SUBDIR}${fp ? `/${fp}` : ''}`
-            : `${LOCAL_IMAGES_SUBDIR}${fp ? `/${fp}` : ''}`,
+            ? nodePath.join(custom, LOCAL_IMAGES_SUBDIR, fp)
+            : nodePath.join(LOCAL_IMAGES_SUBDIR, fp),
           base,
         };
       case 'Dictionaries':
@@ -178,8 +176,8 @@ const getPathResolver = ({ customRootDir }: { customRootDir?: string } = {}) => 
           baseDir: 0,
           basePrefix: async () => custom ?? getAppDataDir(),
           fp: custom
-            ? `${custom}/${LOCAL_DICTIONARIES_SUBDIR}${fp ? `/${fp}` : ''}`
-            : `${LOCAL_DICTIONARIES_SUBDIR}${fp ? `/${fp}` : ''}`,
+            ? nodePath.join(custom, LOCAL_DICTIONARIES_SUBDIR, fp)
+            : nodePath.join(LOCAL_DICTIONARIES_SUBDIR, fp),
           base,
         };
       case 'None':

--- a/apps/readest-app/src/services/nodeAppService.ts
+++ b/apps/readest-app/src/services/nodeAppService.ts
@@ -365,6 +365,12 @@ export class NodeAppService extends BaseAppService {
     return this.fs.resolvePath(fp, base);
   }
 
+  override async resolveFilePath(path: string, base: BaseDir): Promise<string> {
+    const prefix = await this.fs.getPrefix(base);
+    if (!path) return prefix;
+    return prefix ? nodePath.join(prefix, path) : path;
+  }
+
   async init(): Promise<void> {
     await this.prepareBooksDir();
   }


### PR DESCRIPTION
Fixes #4815 

## Summary
On Windows, `NodeAppService` produced mixed path separators when resolving paths under custom root directories. This caused several test failures in `node-app-service.test.ts` because expected paths used `path.join()` (platform native separators), while implementation concatenated strings using `/`.

## Solution
- Replaced manual string concatenation with `path.join()` in `NodeAppService` path resolution
- Ensured `resolveFilePath` returns platform-native paths on Windows
- Prevented mixed-separator paths when using custom root directories

## Testing
- Added/validated test ensuring resolved paths match platform-native separators on Windows
- All tests in `node-app-service.test.ts` pass on Windows
- Entire test suite passes on Windows (see note below)

## Note
- One unrelated test (`src/__tests__/helpers/updater.test.ts`) fails locally due to an existing syntax error in the repository.
- This issue is unrelated to the changes in this PR and does not affect `NodeAppService` behavior.

## Environment 
Operating System: Windows 11 25H2