### PR TITLE
fix(reader): keep scrolled content above footer toolbar

### DIFF
--- a/apps/readest-app/src/__tests__/utils/insets.test.ts
+++ b/apps/readest-app/src/__tests__/utils/insets.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { getPanelTopInset } from '@/utils/insets';
+import { getPanelTopInset, getScrolledContentMargins } from '@/utils/insets';
+import type { ViewSettings } from '@/types/book';
 
-const insets = (top: number) => ({ top, right: 0, bottom: 0, left: 0 });
+const insets = (top: number, bottom = 0) => ({ top, right: 0, bottom, left: 0 });
+
+const scrolledSettings = (overrides: Partial<ViewSettings> = {}) =>
+  ({
+    showHeader: true,
+    showFooter: true,
+    vertical: false,
+    marginTopPx: 44,
+    marginBottomPx: 44,
+    showTTSBar: true,
+    ...overrides,
+  }) as ViewSettings;
 
 describe('getPanelTopInset', () => {
   it('respects the status bar on non-mobile panels when system UI is visible', () => {
@@ -76,5 +88,55 @@ describe('getPanelTopInset', () => {
         safeAreaInsets: null,
       }),
     ).toBe(0);
+  });
+});
+
+describe('getScrolledContentMargins', () => {
+  it('reserves the full mobile footer height in scrolled mode', () => {
+    expect(
+      getScrolledContentMargins({
+        gridInsets: insets(12, 30),
+        viewSettings: scrolledSettings({ marginBottomPx: 44 }),
+        ttsEnabled: false,
+        hasSafeAreaInset: true,
+        useMobileFooterLayout: true,
+      }),
+    ).toEqual({ top: 56, bottom: 64 + 30 * 0.33 });
+  });
+
+  it('reserves the desktop footer height when it exceeds the content margin', () => {
+    expect(
+      getScrolledContentMargins({
+        gridInsets: insets(0),
+        viewSettings: scrolledSettings({ marginBottomPx: 44 }),
+        ttsEnabled: false,
+        hasSafeAreaInset: false,
+        useMobileFooterLayout: false,
+      }).bottom,
+    ).toBe(52);
+  });
+
+  it('keeps larger user footer margins and TTS clearance', () => {
+    expect(
+      getScrolledContentMargins({
+        gridInsets: insets(0, 30),
+        viewSettings: scrolledSettings({ marginBottomPx: 88 }),
+        ttsEnabled: true,
+        hasSafeAreaInset: true,
+        useMobileFooterLayout: true,
+      }).bottom,
+    ).toBe(88 + 30 * 0.33);
+  });
+
+  it('does not reserve footer space for vertical writing footer chrome', () => {
+    expect(
+      getScrolledContentMargins({
+        gridInsets: insets(12, 30),
+        viewSettings: scrolledSettings({ vertical: true }),
+        ttsEnabled: false,
+        hasSafeAreaInset: true,
+        useMobileFooterLayout: true,
+      }),
+    ).toEqual({ top: 0, bottom: 0 });
   });
 });

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -67,7 +67,7 @@ import { useTextTranslation } from '../hooks/useTextTranslation';
 import { useBookCoverAutoSave } from '../hooks/useAutoSaveBookCover';
 import { useDiscordPresence } from '@/hooks/useDiscordPresence';
 import { manageSyntaxHighlighting } from '@/utils/highlightjs';
-import { getViewInsets } from '@/utils/insets';
+import { getScrolledContentMargins, getViewInsets } from '@/utils/insets';
 import { handleA11yNavigation } from '@/utils/a11y';
 import { isCJKLang } from '@/utils/lang';
 import { getLocale } from '@/utils/misc';
@@ -781,13 +781,19 @@ const FoliateViewer: React.FC<{
     viewRef.current?.renderer.setAttribute('margin-left', `${leftMargin}px`);
 
     if (viewSettings.scrolled) {
-      const headerVisible = showTopHeader;
-      const footerVisible = showBottomFooter;
-      const safeBottomPadding = appService?.hasSafeAreaInset ? gridInsets.bottom * 0.33 : 0;
-      const footerBarHeight = safeBottomPadding + viewSettings.marginBottomPx;
-      const scrollTop = headerVisible ? gridInsets.top + viewSettings.marginTopPx : 0;
-      const scrollBottom = footerVisible ? Math.max(footerBarHeight, ttsBarHeight) : ttsBarHeight;
-      setScrollMargins({ top: scrollTop, bottom: scrollBottom });
+      const useMobileFooterLayout =
+        !!appService?.isMobile &&
+        window.innerWidth >= 640 &&
+        window.innerWidth <= window.innerHeight;
+      setScrollMargins(
+        getScrolledContentMargins({
+          gridInsets,
+          viewSettings,
+          ttsEnabled: !!viewState?.ttsEnabled,
+          hasSafeAreaInset: !!appService?.hasSafeAreaInset,
+          useMobileFooterLayout: useMobileFooterLayout || window.innerWidth < 640,
+        }),
+      );
     } else {
       setScrollMargins({ top: 0, bottom: 0 });
     }

--- a/apps/readest-app/src/utils/insets.ts
+++ b/apps/readest-app/src/utils/insets.ts
@@ -1,6 +1,10 @@
 import { Insets } from '@/types/misc';
 import { ViewSettings } from '@/types/book';
 
+const SAFE_BOTTOM_FOOTER_INSET_RATIO = 0.33;
+const DESKTOP_FOOTER_BAR_HEIGHT = 52;
+const MOBILE_FOOTER_BAR_HEIGHT = 64;
+
 export const getViewInsets = (viewSettings: ViewSettings) => {
   const showHeader = viewSettings.showHeader!;
   const showFooter = viewSettings.showFooter!;
@@ -47,4 +51,43 @@ export const getPanelTopInset = ({
   if (isMobile && !isFullHeightInMobile) return 0;
   const top = safeAreaInsets?.top || 0;
   return systemUIVisible ? Math.max(top, statusBarHeight) : top;
+};
+
+/**
+ * Extra padding around the foliate scrolled-mode host so fixed/absolute reader
+ * chrome does not cover the first or last line. The renderer's own margins are
+ * user-configurable content margins, but the visible footer chrome has a fixed
+ * minimum height (52px desktop, 64px mobile). Reserve at least that much bottom
+ * space; otherwise iPad users can scroll the last lines underneath the toolbar.
+ */
+export const getScrolledContentMargins = ({
+  gridInsets,
+  viewSettings,
+  ttsEnabled,
+  hasSafeAreaInset,
+  useMobileFooterLayout,
+}: {
+  gridInsets: Insets;
+  viewSettings: ViewSettings;
+  ttsEnabled: boolean;
+  hasSafeAreaInset: boolean;
+  useMobileFooterLayout: boolean;
+}): { top: number; bottom: number } => {
+  const showTopHeader = viewSettings.showHeader && !viewSettings.vertical;
+  const showBottomFooter = viewSettings.showFooter && !viewSettings.vertical;
+  const safeBottomPadding = hasSafeAreaInset
+    ? gridInsets.bottom * SAFE_BOTTOM_FOOTER_INSET_RATIO
+    : 0;
+  const ttsBarHeight =
+    ttsEnabled && viewSettings.showTTSBar ? DESKTOP_FOOTER_BAR_HEIGHT + safeBottomPadding : 0;
+  const footerChromeHeight = useMobileFooterLayout
+    ? MOBILE_FOOTER_BAR_HEIGHT
+    : DESKTOP_FOOTER_BAR_HEIGHT;
+  const footerHeight =
+    safeBottomPadding + Math.max(viewSettings.marginBottomPx, footerChromeHeight);
+
+  return {
+    top: showTopHeader ? gridInsets.top + viewSettings.marginTopPx : 0,
+    bottom: showBottomFooter ? Math.max(footerHeight, ttsBarHeight) : ttsBarHeight,
+  };
 };


### PR DESCRIPTION
## Summary
- reserve the actual footer toolbar height for scrolled-mode reader content
- include bottom safe-area padding in that reserved space
- add unit coverage for mobile, desktop, TTS, and vertical-writing cases

## Verification
- pnpm --filter @readest/readest-app exec vitest run src/__tests__/utils/insets.test.ts
- pnpm exec biome check apps/readest-app/src/utils/insets.ts apps/readest-app/src/app/reader/components/FoliateViewer.tsx apps/readest-app/src/__tests__/utils/insets.test.ts
- pnpm --filter @readest/readest-app exec tsgo --noEmit
- pre-push hook: pnpm -w format:check, tsgo --noEmit && biome lint ., dotenv -e .env -e .env.test.local -- vitest (439 passed, 3 skipped)