### PR TITLE
fix(reader): render code operators literally instead of as ligatures (#4830)

### DIFF
--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -140,6 +140,7 @@ const getFontStyles = (
     }
     pre, code, kbd {
       font-family: var(--monospace);
+      font-variant-ligatures: none;
     }
     body *:not(pre, code, kbd, .code):not(pre *, code *, kbd *, .code *) {
       ${overrideFont ? 'font-family: revert !important;' : ''}


### PR DESCRIPTION
## Problem

On Android, code operators render as math glyphs: `<=` shows as `≤` and `=>` shows as an arrow (`⇒`). Selecting and copying yields the correct `<=` / `=>`, so only the on-screen glyphs are wrong. This misrepresents code in books such as VHDL (`<=` is signal assignment) and would equally affect math/physics texts.

Fixed #4830.

## Root cause

It is the **font**, not the WebView. Readest bundles **Fira Code** as a monospace fallback (`src/styles/fonts.ts`), and Fira Code ships programming ligatures (`<=`→`≤`, `=>`→`⇒`, `>=`→`≥`, `!=`→`≠`) implemented via OpenType contextual alternates (`calt`), which Blink enables by default.

The default monospace setting is `Consolas`, so the resolved chain is `"Consolas", "Fira Code", ...`. On Windows, Consolas exists and wins, so no ligatures appear. On **Android** (and any OS without Consolas installed), the cascade falls through to the bundled Fira Code webfont and the ligatures fire. The underlying text is never altered, which is why copy already worked.

## Verification (Chrome / Blink)

Rendering the identical source text `<= => >=` three ways:

- **Fira Code** -> `≤ ⇒ ≥` (the bug)
- **Courier New / Consolas** -> literal `<= => >=`
- **Fira Code + `font-variant-ligatures: none`** -> literal `<= => >=` (the fix)

A canvas width probe also confirmed Consolas is not actually installed on macOS, so the same bug reproduces outside Android wherever the chosen mono font is absent.

## Fix

Add `font-variant-ligatures: none` to the `pre, code, kbd` rule in `getFontStyles` (`src/utils/style.ts`). This disables `calt`/`liga` so operators render literally regardless of which fallback font wins. Trade-off: a user who deliberately selects Fira Code also loses its ligatures, which is the desired behavior for a reading app where `<=` rendering as `≤` is a correctness bug.

## Testing

- `pnpm test` — full suite green (6500 passed)
- `pnpm lint` — clean (tsgo + Biome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
