### PR TITLE
fix(eink): render Customize Toolbar preview as bordered surface, not black bar (#4839)

### DIFF
--- a/apps/readest-app/src/__tests__/components/settings/AnnotationToolbarCustomizerEink.test.tsx
+++ b/apps/readest-app/src/__tests__/components/settings/AnnotationToolbarCustomizerEink.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+/**
+ * Regression guard for issue #4839 (display error under e-ink mode).
+ *
+ * The Customize Toolbar sub-page renders a content-width *preview* of the live
+ * selection popup. The preview surface uses `bg-gray-600 text-white` to mirror
+ * the real popup — but unlike the real popup (which earns its e-ink treatment
+ * from `.popup-container` in globals.css), the preview Zone is a plain div. With
+ * no e-ink override, the dark fill survives under `[data-eink='true']` and the
+ * whole row paints as an unreadable solid black bar.
+ *
+ * Invariant: the toolbar preview must carry `eink-bordered`, so e-ink swaps the
+ * dark fill for a `base-100` surface with a 1px `base-content` border — matching
+ * how the annotation toolbar renders in the reader.
+ */
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: {} }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({ getViewSettings: () => undefined }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({
+    settings: { globalViewSettings: { annotationToolbarItems: undefined } },
+  }),
+}));
+
+vi.mock('@/helpers/settings', () => ({
+  saveViewSettings: vi.fn(),
+}));
+
+vi.mock('@/utils/share', () => ({
+  canShareText: () => true,
+}));
+
+import AnnotationToolbarCustomizer from '@/components/settings/AnnotationToolbarCustomizer';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AnnotationToolbarCustomizer e-ink toolbar preview', () => {
+  it('marks the toolbar preview eink-bordered so e-ink swaps the dark fill for a bordered base-100 surface', () => {
+    const { container } = render(<AnnotationToolbarCustomizer bookKey='test' onBack={() => {}} />);
+    const toolbarPreview = container.querySelector('.selection-popup') as HTMLElement;
+    expect(toolbarPreview).not.toBeNull();
+    expect(toolbarPreview.classList.contains('eink-bordered')).toBe(true);
+  });
+});

--- a/apps/readest-app/src/components/settings/AnnotationToolbarCustomizer.tsx
+++ b/apps/readest-app/src/components/settings/AnnotationToolbarCustomizer.tsx
@@ -113,14 +113,23 @@ const Zone: React.FC<{
           'flex min-h-12 flex-wrap items-center gap-2 rounded-lg p-2',
           isToolbar
             ? // A faithful, content-width preview of the real popup, start-aligned
-              // with the Available row below it.
-              'selection-popup bg-gray-600 text-white w-fit max-w-full'
+              // with the Available row below it. Off e-ink it mirrors the popup's
+              // dark fill; in e-ink the dark fill is dropped entirely and
+              // `eink-bordered` renders it as the popup's e-ink chrome instead
+              // (.popup-container): a base-100 surface with a 1px base-content
+              // border, so it doesn't paint as a solid black bar (#4839).
+              'selection-popup eink-bordered w-fit max-w-full not-eink:bg-gray-600 not-eink:text-white'
             : 'bg-base-200/60',
         )}
       >
         {items.length === 0 ? (
           <span
-            className={clsx('px-1 text-sm', isToolbar ? 'text-white/70' : 'text-base-content/50')}
+            className={clsx(
+              'px-1 text-sm',
+              // In e-ink the toolbar surface turns base-100, so the white hint would
+              // vanish; fall back to base-content there (#4839).
+              isToolbar ? 'not-eink:text-white/70 eink:text-base-content' : 'text-base-content/50',
+            )}
           >
             {emptyHint}
           </span>


### PR DESCRIPTION
## Problem

Fixes #4839. On e-ink devices the **Customize Toolbar** sub-page (Behavior > Customize Toolbar) renders the toolbar preview row as an unreadable solid black bar.

| Before (e-ink) | Target (reader's annotation toolbar in e-ink) |
| --- | --- |
| <img width="360" alt="black bar" src="https://github.com/user-attachments/assets/5a4516ab-0cca-4c89-ad44-dfbde04efc4d" /> | white box, 1px border, dark icons |

## Root cause

The preview Zone in `AnnotationToolbarCustomizer.tsx` is a content-width preview of the live selection popup, so it copies the popup's `bg-gray-600 text-white`. But the **real** reader popup earns its e-ink chrome from `.popup-container` (`globals.css`: `[data-eink] .popup-container` → `base-100` background + 1px `base-content` border). The preview Zone is a plain `<div>` with no `popup-container`, so under `[data-eink='true']` the dark `bg-gray-600` survived, and the chip icons (inverted to `base-content`/black by the global `[data-eink] button` rule) sat black-on-black.

## Fix

- Scope the dark fill to non-e-ink (`not-eink:bg-gray-600 not-eink:text-white`) so e-ink drops the gray entirely, and let **`eink-bordered`** (the project's documented e-ink primitive) render the preview as the popup's e-ink chrome: a `base-100` surface with a 1px `base-content` border. Icons need no change — they already invert via `[data-eink] button`.
- Fall the empty-state hint ("No tools, drag one here") back to `base-content` in e-ink so it stays legible once the surface turns `base-100`.

No behavior change off e-ink.

## Testing

- New regression test `AnnotationToolbarCustomizerEink.test.tsx` asserts the `.selection-popup` preview carries `eink-bordered`.
- Verified the rendered result via `getComputedStyle` under `[data-eink]` in a real browser: background `oklch(1 0 0)` (white), `1px` `oklch(0.2 0 0)` border, dark icon color — matching the reader's annotation toolbar.
- `pnpm test` — full suite green (6503 passed).
- `pnpm lint` — clean (tsgo + Biome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)