### PR TITLE
ci(release): add GitHub artifact attestation to release and nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,6 +40,12 @@ jobs:
 
   build:
     needs: compute-version
+    permissions:
+      contents: read
+      # Required by actions/attest-build-provenance: id-token mints the Sigstore
+      # OIDC identity, attestations writes the provenance to the repo's store.
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -380,6 +386,18 @@ jobs:
               echo "::error::unknown release leg: $release"; exit 1
               ;;
           esac
+
+      # Attest the distributable binaries staged in nightly-out (apks, AppImage,
+      # app.tar.gz, setup/portable exe). gh attestation verify is digest-based,
+      # so it verifies these against readest/readest even though they ship via
+      # download.readest.com rather than a GitHub release. The .sig updater
+      # signatures are excluded — they are not binaries users run.
+      - name: attest nightly binaries
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            nightly-out/Readest*
+            !nightly-out/*.sig
 
       - name: upload artifacts + fragment to R2
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,10 @@ jobs:
     needs: get-release
     permissions:
       contents: write
+      # Required by actions/attest-build-provenance: id-token mints the Sigstore
+      # OIDC identity, attestations writes the provenance to the repo's store.
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -267,6 +271,14 @@ jobs:
           gh release upload ${{ needs.get-release.outputs.release_tag }} $universial_apk.sig --clobber
           gh release upload ${{ needs.get-release.outputs.release_tag }} $arm64_apk.sig --clobber
 
+      - name: attest Android apks
+        if: matrix.config.release == 'android'
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            apps/readest-app/Readest_${{ needs.get-release.outputs.release_version }}_universal.apk
+            apps/readest-app/Readest_${{ needs.get-release.outputs.release_version }}_arm64.apk
+
       - name: download and update latest.json for Android release
         if: matrix.config.release == 'android'
         env:
@@ -309,6 +321,7 @@ jobs:
         run: cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --force
 
       - uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
+        id: tauri
         if: matrix.config.release != 'android'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -331,6 +344,16 @@ jobs:
           releaseId: ${{ needs.get-release.outputs.release_id }}
           releaseBody: ${{ needs.get-release.outputs.release_note }}
           args: ${{ matrix.config.args || '' }}
+
+      # Attest the freshly built desktop bundles (installers, AppImage, dmg,
+      # updater archives + their .sig). tauri-action reports their on-disk paths
+      # as a JSON array; fromJSON('"\n"') yields a real newline to join them into
+      # the newline-delimited list subject-path expects.
+      - name: attest desktop bundles
+        if: matrix.config.release != 'android' && steps.tauri.outputs.artifactPaths != ''
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: ${{ join(fromJSON(steps.tauri.outputs.artifactPaths), fromJSON('"\n"')) }}
 
       - name: upload release notes to GitHub release
         env:
@@ -383,6 +406,15 @@ jobs:
           popd
           echo "Uploading signature to GitHub release"
           gh release upload ${{ needs.get-release.outputs.release_tag }} $bin_file.sig --clobber
+
+      # The portable rebuild above is not produced by tauri-action, so it is not
+      # covered by the "attest desktop bundles" step; attest it here. Exactly one
+      # portable exe is staged at the workspace root per Windows leg.
+      - name: attest Windows portable binary
+        if: matrix.config.os == 'windows-latest'
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: Readest_*-portable.exe
 
       - name: download and update latest.json for Windows portable release
         if: matrix.config.os == 'windows-latest'


### PR DESCRIPTION
## Summary

Closes #4848. Adds [GitHub artifact attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) to the release and nightly build workflows so anyone can verify a downloaded binary was built from source by this repo's CI:

```bash
gh attestation verify Readest_<version>_x64-setup.exe --repo readest/readest
```

## Approach

Attestation is generated **in the same job that builds each artifact** (via `actions/attest-build-provenance`, SHA-pinned to v4.1.1). That is the only point where provenance is meaningful: it proves the artifact was produced by this workflow run rather than built locally and uploaded by hand. Attesting re-downloaded release assets in a separate job would instead attest "whatever is on the release," which is exactly the threat the issue describes.

### `release.yml` (`build-tauri` job)
- Adds `id-token: write` + `attestations: write` permissions.
- **Desktop bundles** (NSIS installers, AppImage, dmg, updater archives): attested via `tauri-action`'s `artifactPaths` output (`id: tauri`).
- **Android apks**: universal + arm64.
- **Windows portable exe**: the portable rebuild is not produced by `tauri-action`, so it gets its own step.

### `nightly.yml` (`build` job)
- Same permissions, plus one step attesting the staged `nightly-out/` binaries (excluding `.sig`). Nightlies ship via download.readest.com, but `gh attestation verify` is digest-based, so it verifies them against this repo all the same.

## Verification
- `actionlint` clean on both workflows (including the `join(fromJSON(...), fromJSON('"\n"'))` expression and the new `permissions` keys); both parse as valid YAML.
- No application code changed (GitHub Actions YAML only), so `pnpm test` / `lint` / Rust gates are not applicable.

## Notes
- The `build-koreader-plugin` zip is left un-attested (bundled Lua source, not a built binary); easy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
