### PR TITLE
fix(reader): remember last read position for markdown files

### DIFF
--- a/apps/readest-app/src/__tests__/utils/md.test.ts
+++ b/apps/readest-app/src/__tests__/utils/md.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { makeMarkdownBook } from '@/utils/md';
 import type { BookDoc } from '@/libs/document';
+import { CFI } from '@/libs/document';
+import { getIndexFromCfi } from '@/utils/cfi';
 
 // makeMarkdownBook returns a foliate book with a few methods (resolveHref,
 // isExternal, destroy) and a per-section load() that the BookDoc type does not
@@ -78,6 +80,20 @@ describe('makeMarkdownBook', () => {
       expect(typeof sid).toBe('string');
       expect(sectionMap.get(sid as string)).toBeDefined();
     }
+  });
+
+  it('gives each section a CFI base that round-trips to its index (resume position)', async () => {
+    // foliate-js view.getCFI does `section.cfi ?? CFI.fake.fromIndex(index)`,
+    // so an empty-string cfi defeats the fallback and the generated location
+    // CFI loses its spine step. Reopening then resolves to no section and the
+    // reader falls back to the start. Verify each section carries a base CFI
+    // that survives the getCFI -> resolveCFI round-trip.
+    const book = await make('# One\n\na\n\n# Two\n\nb\n\n# Three\n\nc\n');
+    book.sections.forEach((section, index) => {
+      const baseCFI = section.cfi ?? CFI.fake.fromIndex(index);
+      const locationCFI = CFI.joinIndir(baseCFI, '/4/2:3');
+      expect(getIndexFromCfi(locationCFI)).toBe(index);
+    });
   });
 
   it('produces XHTML that parses without errors despite void tags', async () => {

--- a/apps/readest-app/src/utils/md.ts
+++ b/apps/readest-app/src/utils/md.ts
@@ -1,6 +1,7 @@
 import { marked } from 'marked';
 
 import type { BookDoc, SectionItem } from '@/libs/document';
+import { CFI } from '@/libs/document';
 import { sanitizeHtml } from './sanitize';
 
 // Render a standalone Markdown (.md) file into an in-memory foliate-js book at
@@ -158,7 +159,12 @@ export async function makeMarkdownBook(file: File): Promise<BookDoc> {
   const urls: (string | undefined)[] = new Array(xhtml.length).fill(undefined);
   const sections: MarkdownSection[] = xhtml.map((str, index) => ({
     id: String(index),
-    cfi: '',
+    // A per-section spine CFI base. foliate-js builds location CFIs as
+    // `section.cfi ?? CFI.fake.fromIndex(index)`; an empty string defeats that
+    // `??` fallback, so every saved position would collapse to a section-less
+    // CFI and reopening would resume from the start. Set the same fake spine
+    // CFI foliate would synthesize so positions round-trip across reopens.
+    cfi: CFI.fake.fromIndex(index),
     size: new TextEncoder().encode(str).length,
     linear: 'yes',
     load: () => {


### PR DESCRIPTION
## Problem

Fixes #4862. Reopening an imported `.md` book always resumed from the beginning instead of the last read location, even though the library card showed the correct read percentage. Importing the same file as plain text worked, because `.txt` is converted to a real EPUB with proper spine CFIs.

## Root cause

`makeMarkdownBook` in `src/utils/md.ts` created every section with `cfi: ''`. foliate-js builds a location CFI as:

```js
const baseCFI = this.book.sections[index].cfi ?? CFI.fake.fromIndex(index)
```

Nullish coalescing (`??`) only falls back for `null`/`undefined`, **not** for an empty string. So `baseCFI` stayed `''` and every saved position became a section-less CFI like `epubcfi(!/4/2:3)` (identical for all sections). On reopen it resolves to no section, so the reader falls back to fraction 0. The single-file `fb2.js` format that `md.ts` mimics simply omits `cfi` and relies on the `??` fallback; the empty string was the trap.

## Fix

Set each section's `cfi` to `CFI.fake.fromIndex(index)` — the same fake spine CFI foliate would synthesize — so generated positions carry a spine step and round-trip across reopens (`epubcfi(/6/2!/4/2:3)` resolves back to section 0, etc.).

Existing broken saved positions harmlessly fall back to the start once, then re-save correctly on the next reading action, so no migration is needed.

## Testing

- Added a unit test in `md.test.ts` asserting each section's CFI base survives the foliate `getCFI` -> `resolveCFI` round-trip (fails on `null` before the fix).
- `pnpm test` (6549 passed) and `pnpm lint` (tsgo + Biome) clean.
- Verified end-to-end in the web app (Chrome): imported a 6-chapter markdown, navigated to a middle chapter, did a full reload (relaunch from persisted storage), and confirmed it resumed at the saved chapter with no CFI-resolution errors in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)