### PR TITLE
fix(reader): fix fixed-layout spread spine seam and zoomed-out blank page (#4857)

### DIFF
--- a/apps/readest-app/src/__tests__/document/fixed-layout-spine-seam.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-spine-seam.test.ts
@@ -1,0 +1,55 @@
+// Regression test for readest/readest issue #4857.
+//
+// In a fixed-layout (EPUB or PDF) two-page spread at a fractional device pixel
+// ratio (Windows display scale 150% -> devicePixelRatio 1.5), a one-pixel white
+// seam appeared down the middle of the spread at the spine.
+//
+// Root cause: the two page iframes are independent compositor layers, each
+// scaled by a (usually non-integer) factor. At a fractional devicePixelRatio the
+// spine between them lands on a fractional device pixel, so each layer's edge
+// there is anti-aliased against transparency and the reader background bleeds
+// through as a thin white seam. (Filling the page canvas to its box, #4587, does
+// not help: the soft edge comes from scaling the layer, not from the content
+// stopping short of its box.)
+//
+// The fix overlaps the (top-most) right page onto the left by exactly one device
+// pixel, so each soft edge sits over the neighbour's opaque content instead of
+// the background. The shift is visual-only (translateX), leaving the centred
+// spread layout untouched. `computeSpreadSpineOverlap` returns that translateX
+// (in CSS px) for the right page, or 0 for layouts with no touching spine.
+
+import { describe, expect, it } from 'vitest';
+
+import { computeSpreadSpineOverlap } from 'foliate-js/fixed-layout.js';
+
+describe('computeSpreadSpineOverlap (#4857)', () => {
+  it('overlaps the right page by exactly one device pixel on a real two-page spread', () => {
+    // Windows 150% scale: one device pixel is 1 / 1.5 CSS px.
+    expect(computeSpreadSpineOverlap({ devicePixelRatio: 1.5 })).toBeCloseTo(-1 / 1.5, 10);
+    // Retina / mobile: one device pixel is 0.5 CSS px.
+    expect(computeSpreadSpineOverlap({ devicePixelRatio: 2 })).toBeCloseTo(-0.5, 10);
+    // No scaling: one device pixel is one CSS px.
+    expect(computeSpreadSpineOverlap({ devicePixelRatio: 1 })).toBeCloseTo(-1, 10);
+  });
+
+  it('defaults a missing/zero devicePixelRatio to 1 device pixel', () => {
+    expect(computeSpreadSpineOverlap({})).toBeCloseTo(-1, 10);
+    expect(computeSpreadSpineOverlap({ devicePixelRatio: 0 })).toBeCloseTo(-1, 10);
+  });
+
+  it('does not overlap layouts that have no touching spine', () => {
+    // A single centred page (cover / odd page).
+    expect(computeSpreadSpineOverlap({ center: true, devicePixelRatio: 1.5 })).toBe(0);
+    // Portrait device: only one page of the spread is shown.
+    expect(computeSpreadSpineOverlap({ portrait: true, devicePixelRatio: 1.5 })).toBe(0);
+    // A spread slot padded with a blank page shows a single real page.
+    expect(computeSpreadSpineOverlap({ leftBlank: true, devicePixelRatio: 1.5 })).toBe(0);
+    expect(computeSpreadSpineOverlap({ rightBlank: true, devicePixelRatio: 1.5 })).toBe(0);
+  });
+
+  it('still overlaps a two-page spread when zoomed below 100%', () => {
+    // Zoom is intentionally not an input: the pages stay adjacent at every zoom,
+    // so a sub-100% spread gets the same overlap as a 100% one.
+    expect(computeSpreadSpineOverlap({ devicePixelRatio: 2 })).toBeCloseTo(-0.5, 10);
+  });
+});


### PR DESCRIPTION
Fixes #4857. Bumps `packages/foliate-js` (readest/foliate-js#44) with two fixed-layout (EPUB and PDF) two-page spread fixes, and adds a unit test.

## 1. 1px white spine seam

At a fractional `devicePixelRatio` (e.g. Windows 150% display scale, dpr 1.5) a 1px white seam appears down the middle at the spine, for both EPUB and PDF. It comes and goes as the zoom changes (100% shows it, 110% hides it) which is the signature of a sub-pixel rasterization issue.

<img width="600" alt="spine seam at 100%" src="https://github.com/user-attachments/assets/7f38b670-332e-4d1f-9516-f87b52c022b8" />

**Cause:** the two page iframes are independent compositor layers, each scaled by a (usually non-integer) factor. At a fractional dpr the spine between them lands on a fractional *device* pixel, so each layer's edge there is anti-aliased against transparency and the reader background bleeds through. This is a different mechanism from the earlier canvas-truncation seam (#4587): filling the page canvas to its box does not help, which is why the seam still showed on PDF after #4587.

**Fix:** overlap the top-most (right) page onto the left by exactly one device pixel, so each soft edge sits over the neighbour's opaque content instead of over the background. Visual-only `translateX(-1/dpr px)`; skipped for single/centred/portrait/blank spreads.

## 2. Zoomed-out non-PDF pages render blank

While testing #1 it turned out that below 100% zoom, non-PDF fixed-layout pages render blank (a pre-existing bug: the PDF-only zoom-out centering switches the page box to flex and centers the iframe, but a non-PDF iframe keeps its native size and is shrunk with `transform: scale`, so flex-centering pushes the un-scaled iframe out of view).

**Fix:** gate the centering on the PDF path and keep non-PDF pages in block flow at every zoom. Because they now stay adjacent at every zoom, the spine overlap applies at sub-100% zoom too.

## Verification

- Reproduced the seam at dpr 1.5 with Playwright: spine pixel goes from `(191,223,255)` (blended toward white) to solid page color with the overlap.
- Verified in Chrome on the reported book: EPUB fixed-layout renders correctly and seam-free at 50/80/100/130% zoom, no console errors; PDF (`onZoom`) path unchanged.
- `pnpm test` (full suite), `pnpm lint`, and `pnpm format:check` all pass.

Depends on readest/foliate-js#44.
