### PR TITLE
fix(nix): get nix devshell working

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ Basically you need to install or update the following development tools:
 - **Rust** and **Cargo** for Tauri development
 
 ```bash
-nvm install v22
-nvm use v22
+nvm install v24
+nvm use v24
 npm install -g pnpm
 rustup update
 ```

--- a/biome.json
+++ b/biome.json
@@ -40,7 +40,8 @@
       "!**/*.mjs",
       "!**/*.cjs",
       "!**/*.mts",
-      "!pnpm-lock.yaml"
+      "!pnpm-lock.yaml",
+      "!**/nix/store/**"
     ]
   },
   "assist": { "enabled": false },

--- a/ops/flake.lock
+++ b/ops/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1737231446,
-        "narHash": "sha256-5lwp4VeKe0/rZzz7tew6egj1f80cY6xQtqf929iscyU=",
+        "lastModified": 1782941279,
+        "narHash": "sha256-ayqk9KFIFa1TacPfQxLFpbFWiqEhL811Jx/+/gjHKVA=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "11344fbb813770ff8f8b8de5e4d512c0c4910a78",
+        "rev": "9d13340524e2df1448d3b3599ee6b9159a0f8f87",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735644329,
-        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1735644329,
-        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1765003156,
-        "narHash": "sha256-k4YrPUhRj7Ciq385vREU57RHiDFycY5RaJwdCOmsLhU=",
+        "lastModified": 1782900513,
+        "narHash": "sha256-GHrsl1+ysDFgmDQtQSqWS7TiYD2Q58VlwLvnf1+crJM=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e8361cc010853d17740a63aae00385061ac9de51",
+        "rev": "16810aa8f4ad89ca480b1513774e8b6f485fe368",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737062831,
-        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1722073938,
-        "narHash": "sha256-OpX0StkL8vpXyWOGUD6G+MA26wAXK6SpT94kLJXo6B4=",
+        "lastModified": 1762156382,
+        "narHash": "sha256-Yg7Ag7ov5+36jEFC1DaZh/12SEXo6OO3/8rqADRxiqs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e36e9f57337d0ff0cf77aceb58af4c805472bfae",
+        "rev": "7241bcbb4f099a66aafca120d37c65e8dda32717",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1737062831,
-        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1764925941,
-        "narHash": "sha256-zldc1SrUIhGMdQp+0woSqvBS51Mi8PW6JukONBQXZBY=",
+        "lastModified": 1782864348,
+        "narHash": "sha256-NVYhLbaefeIUftPlo3kS6qr0xd8eFJRodEiaHrvFKR4=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "2cbf3587d36dfc7b701ebb744d3dd5064355d04f",
+        "rev": "0d381ca097a8e0375a19387874d952c0a230ac4f",
         "type": "github"
       },
       "original": {

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -17,7 +17,7 @@
   outputs = { self, nixpkgs, flake-utils, android, devshell, fenix }:
     {
       overlay = final: prev: {
-        inherit (self.packages.${final.stdenv.hostPlatform.system}) android-sdk android-studio;
+        inherit (self.packages.${final.stdenv.hostPlatform.system}) android-sdk;
       };
     }
     //
@@ -36,8 +36,6 @@
             self.overlay
           ];
         };
-        # android-studio is not available in aarch64-darwin
-        androidConditionalPackages = if pkgs.stdenv.hostPlatform.system != "aarch64-darwin" then [ pkgs.android-studio ] else [ ];
 
         commonPackages = with pkgs; [
           pnpm
@@ -183,9 +181,6 @@
             system-images-android-34-google-apis-x86-64
             system-images-android-34-google-apis-playstore-x86-64
           ]);
-        } // lib.optionalAttrs (system == "x86_64-linux") {
-          # Android Studio in nixpkgs is currently packaged for x86_64-linux only.
-          android-studio = pkgs.androidStudioPackages.stable;
         };
 
         devShells = {
@@ -224,7 +219,7 @@
               pkgs.android-sdk
               pkgs.gradle
               pkgs.jdk
-            ] ++ androidConditionalPackages;
+            ];
             extraEnv = [
               {
                 name = "ANDROID_HOME";

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -38,18 +38,12 @@
         };
         # android-studio is not available in aarch64-darwin
         androidConditionalPackages = if pkgs.system != "aarch64-darwin" then [ pkgs.android-studio ] else [ ];
+
         commonPackages = with pkgs; [
           pnpm
           nodejs_24
           clang
           pkg-config
-          (pkgs.fenix.complete.withComponents [
-            "cargo"
-            "clippy"
-            "rust-src"
-            "rustc"
-            "rustfmt"
-          ])
           pkgs.rust-analyzer-nightly
           xdg-utils
           self.formatter.${system}
@@ -97,7 +91,9 @@
 
         mkCommonShell =
           { name
+          , postInit ? ""
           , extraPackages ? [ ]
+          , extraTargets ? [ ]
           , extraEnv ? [
               {
                 name = "PKG_CONFIG_PATH";
@@ -140,23 +136,42 @@
           }:
           pkgs.devshell.mkShell {
             inherit name;
-            packages = commonPackages ++ extraPackages;
+            packages =
+              commonPackages
+              ++ extraPackages
+              ++ [
+                (
+                  with pkgs.fenix;
+                  pkgs.fenix.combine [
+                    complete.cargo
+                    complete.clippy
+                    complete.rust-src
+                    complete.rustc
+                    complete.rustfmt
+                    extraTargets
+                  ]
+                )
+              ];
             env = extraEnv;
             devshell.startup.init_project.text = ''
               git submodule update --init --recursive
               pnpm install
               pnpm --filter @readest/readest-app setup-vendors
-            '';
+            '' + postInit;
           };
       in
       {
         packages = {
           android-sdk = android.sdk.${system} (sdkPkgs: with sdkPkgs; [
             # Useful packages for building and testing.
+            build-tools-36-0-0
+            build-tools-35-0-0
             build-tools-34-0-0
             cmdline-tools-latest
             emulator
             platform-tools
+            platforms-android-36
+            platforms-android-35
             platforms-android-34
             ndk-26-1-10909125
           ]
@@ -183,8 +198,28 @@
             extraPackages = [ pkgs.cocoapods ];
           };
 
-          android = mkCommonShell {
+          android = mkCommonShell rec {
             name = "readest-android";
+            postInit = ''
+              rm -rf apps/readest-app/src-tauri/gen/android
+              pnpm tauri android init
+              git checkout apps/readest-app/src-tauri/gen/android
+              pnpm tauri icon ../../data/icons/readest-book.png
+
+              if [ ! -d "$ANDROID_AVD_HOME/${name}.avd" ]; then
+                  avdmanager create avd \
+                    -n ${name} \
+                    -k "system-images;android-34;google_apis;x86_64" \
+                    -d "pixel" \
+                    --force
+                fi
+            '';
+            extraTargets = with pkgs.fenix.targets; [
+              aarch64-linux-android.latest.rust-std
+              armv7-linux-androideabi.latest.rust-std
+              i686-linux-android.latest.rust-std
+              x86_64-linux-android.latest.rust-std
+            ];
             extraPackages = [
               pkgs.android-sdk
               pkgs.gradle
@@ -206,6 +241,10 @@
               {
                 name = "JAVA_HOME";
                 value = pkgs.jdk.home;
+              }
+              {
+                  name = "ANDROID_AVD_HOME";
+                  eval = "$XDG_CONFIG_HOME/.android/avd";
               }
             ];
           };

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -86,6 +86,13 @@
           (lib.makeSearchPath "share/pkgconfig" (map getDev systemDeps))
         ];
 
+        xdgPath = "${
+          lib.makeSearchPath "share/gsettings-schemas" [
+            pkgs.gsettings-desktop-schemas
+            pkgs.gtk3
+          ]
+        }:$XDG_DATA_DIRS";
+
         libPath = lib.makeLibraryPath (map getLib systemDeps);
 
         mkCommonShell =
@@ -104,7 +111,12 @@
                 name = "LIBRARY_PATH";
                 value = libPath;
               }
-            ] ++ (optionals isDarwin [
+              {
+                name = "XDG_DATA_DIRS";
+                eval = xdgPath;
+              }
+            ]
+            ++ (optionals isDarwin [
               {
                 name = "RUSTFLAGS";
                 eval = "\"-L framework=$DEVSHELL_DIR/Library/Frameworks\"";

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -79,7 +79,12 @@
         getDev = pkg: if pkg ? dev then pkg.dev else pkg;
         getLib = pkg: if pkg ? lib then pkg.lib else pkg;
 
-        pkgConfigPath = lib.makeSearchPath "lib/pkgconfig" (map getDev systemDeps);
+        # zlib stores zlib.pc in share/pkgconfig while everything else is stored in lib/pkgconfig
+        pkgConfigPath = lib.concatStringsSep ":" [
+          (lib.makeSearchPath "lib/pkgconfig" (map getDev systemDeps))
+          (lib.makeSearchPath "share/pkgconfig" (map getDev systemDeps))
+        ];
+
         libPath = lib.makeLibraryPath (map getLib systemDeps);
 
         mkCommonShell =

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -17,7 +17,7 @@
   outputs = { self, nixpkgs, flake-utils, android, devshell, fenix }:
     {
       overlay = final: prev: {
-        inherit (self.packages.${final.system}) android-sdk android-studio;
+        inherit (self.packages.${final.stdenv.hostPlatform.system}) android-sdk android-studio;
       };
     }
     //
@@ -37,7 +37,7 @@
           ];
         };
         # android-studio is not available in aarch64-darwin
-        androidConditionalPackages = if pkgs.system != "aarch64-darwin" then [ pkgs.android-studio ] else [ ];
+        androidConditionalPackages = if pkgs.stdenv.hostPlatform.system != "aarch64-darwin" then [ pkgs.android-studio ] else [ ];
 
         commonPackages = with pkgs; [
           pnpm
@@ -46,7 +46,7 @@
           pkg-config
           pkgs.rust-analyzer-nightly
           xdg-utils
-          self.formatter.${system}
+          self.formatter.${pkgs.stdenv.hostPlatform.system}
         ];
 
         systemDeps = with pkgs; [
@@ -162,7 +162,7 @@
       in
       {
         packages = {
-          android-sdk = android.sdk.${system} (sdkPkgs: with sdkPkgs; [
+          android-sdk = android.sdk.${pkgs.stdenv.hostPlatform.system} (sdkPkgs: with sdkPkgs; [
             # Useful packages for building and testing.
             build-tools-36-0-0
             build-tools-35-0-0
@@ -249,7 +249,7 @@
             ];
           };
 
-          default = self.devShells.${system}.web;
+          default = self.devShells.${pkgs.stdenv.hostPlatform.system}.web;
         };
         
         formatter = pkgs.nixfmt;

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -40,7 +40,7 @@
         androidConditionalPackages = if pkgs.system != "aarch64-darwin" then [ pkgs.android-studio ] else [ ];
         commonPackages = with pkgs; [
           pnpm
-          nodejs_22
+          nodejs_24
           clang
           pkg-config
           (pkgs.fenix.complete.withComponents [

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -52,6 +52,7 @@
           ])
           pkgs.rust-analyzer-nightly
           xdg-utils
+          self.formatter.${system}
         ];
 
         systemDeps = with pkgs; [
@@ -194,5 +195,7 @@
 
           default = self.devShells.${system}.web;
         };
+        
+        formatter = pkgs.nixfmt;
       });
 }

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -130,6 +130,11 @@
             inherit name;
             packages = commonPackages ++ extraPackages;
             env = extraEnv;
+            devshell.startup.init_project.text = ''
+              git submodule update --init --recursive
+              pnpm install
+              pnpm --filter @readest/readest-app setup-vendors
+            '';
           };
       in
       {


### PR DESCRIPTION
I've run into some issues while trying to build readest using the nix flake.

Firstly, when running `pnpm tauri dev`, this is what the app looks like:

 <img width="1867" height="998" alt="image" src="https://github.com/user-attachments/assets/21f16496-76f1-4ec5-be93-0c63e862c3eb" />

Secondly, the pre-push git hook is broken, as it tries to modify files in the immutable nix store:

```plaintext
 pnpm -C apps/readest-app format:check

$ pnpm -w format:check
$ biome format .
/nix/store/1c15krms4dvjsasbdsxc3inrb0iv8hqy-source/editors/code/package.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ Formatter would have printed the following content:
  
       1    1 │   {
       2      │ - ····"name":·"rust-analyzer",
       3      │ - ····"displayName":·"rust-analyzer",
       4      │ - ····"description":·"Rust·language·support·for·Visual·Studio·Code",
       5      │ - ····"private":·true,
       6      │ - ····"icon":·"icon.png",
...
```

Lastly, the devshell does not run `pnpm install`, `pnpm --filter @readest/readest-app setup-vendors`, or `git submodule update --init --recursive` upon entering. The flake also does not set a formatter.  I'd like to add these two things, but have no idea whether the changes would be welcome.