### PR TITLE
fix(macos): minimize instead of hide on macOS 26 to avoid black window (#4875)

### DIFF
--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -574,7 +574,17 @@ pub fn run() {
                 window.on_window_event(move |event| {
                     if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                         api.prevent_close();
-                        let _ = window_for_close.hide();
+                        // macOS 26 (Tahoe) regressed `NSWindow` ordering: `orderOut:`
+                        // (what `hide()` maps to) can leave a focused black phantom
+                        // window on screen instead of hiding it (#4875). Minimize
+                        // instead on Tahoe — a different AppKit path that still keeps
+                        // the app in the dock and preserves the open book. The Reopen
+                        // handler below already unminimizes on dock reopen.
+                        if macos::os_version::is_macos_tahoe_or_later() {
+                            let _ = window_for_close.minimize();
+                        } else {
+                            let _ = window_for_close.hide();
+                        }
                     }
                 });
             }

--- a/apps/readest-app/src-tauri/src/macos/mod.rs
+++ b/apps/readest-app/src-tauri/src/macos/mod.rs
@@ -1,5 +1,6 @@
 pub mod apple_auth;
 pub mod menu;
+pub mod os_version;
 pub mod safari_auth;
 pub mod system_dictionary;
 pub mod traffic_light;

--- a/apps/readest-app/src-tauri/src/macos/os_version.rs
+++ b/apps/readest-app/src-tauri/src/macos/os_version.rs
@@ -1,0 +1,53 @@
+//! macOS OS-version detection for the Tahoe close-to-hide workaround.
+//!
+//! macOS 26 (Tahoe) regressed `NSWindow` ordering so that `orderOut:` —
+//! which Tauri's `WebviewWindow::hide()` maps to — can leave a focused
+//! black phantom window on screen instead of hiding it. See issue #4875.
+//! On Tahoe we minimize the window instead, a different AppKit path that
+//! still keeps the app in the dock and preserves the open book.
+
+use objc::{class, msg_send, sel, sel_impl};
+
+/// Returns true when `major` is macOS Tahoe (26) or later.
+pub(crate) fn is_tahoe_or_later(major: i64) -> bool {
+    major >= 26
+}
+
+/// Reads the running macOS major version via `NSProcessInfo`.
+fn macos_major_version() -> i64 {
+    #[repr(C)]
+    struct NSOperatingSystemVersion {
+        major: i64,
+        minor: i64,
+        patch: i64,
+    }
+
+    unsafe {
+        let process_info: *mut objc::runtime::Object =
+            msg_send![class!(NSProcessInfo), processInfo];
+        let version: NSOperatingSystemVersion = msg_send![process_info, operatingSystemVersion];
+        version.major
+    }
+}
+
+/// True when running on macOS Tahoe (26) or later.
+pub fn is_macos_tahoe_or_later() -> bool {
+    is_tahoe_or_later(macos_major_version())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_tahoe_or_later;
+
+    #[test]
+    fn detects_tahoe_and_later() {
+        assert!(is_tahoe_or_later(26)); // Tahoe
+        assert!(is_tahoe_or_later(27));
+    }
+
+    #[test]
+    fn rejects_pre_tahoe() {
+        assert!(!is_tahoe_or_later(25)); // Sequoia
+        assert!(!is_tahoe_or_later(15)); // older numbering
+    }
+}


### PR DESCRIPTION
## Summary

On macOS 26 (Tahoe), closing the main window with `Cmd+W` or the red traffic-light button left a **focused black phantom window** on screen instead of hiding it, and the only recovery was to quit and relaunch (#4875).

Root cause is an **OS-level regression in macOS 26**, not a Readest bug. Apple changed `NSWindow` ordering so that `orderOut:` (what Tauri's `hide()` maps to, via a bare `orderOut(None)` in tao 0.34.8) no longer removes the window from the screen. The close-to-hide handler added in #3928 calls `window.hide()`, so on Tahoe the window lingers as a black rectangle that keeps focus.

This is confirmed OS-level because it also hits **native, non-webview apps**: kitty (a Cocoa/OpenGL terminal) has the identical "window fails to fully close, phantom window remains" bug on Tahoe ([kovidgoyal/kitty#8952](https://github.com/kovidgoyal/kitty/issues/8952)) and its maintainer concluded it is an Apple regression. tao/tauri have a broader Tahoe window/webview regression cluster (tauri#15517, tao#1171, wry#1705/#1730). There is currently no upstream tao issue tracking the `orderOut`/hide variant.

## Fix

On macOS 26 or later, `minimize()` the main window instead of `hide()`:

- `miniaturize:` is a different AppKit path from the buggy `orderOut:`, so it dodges the Tahoe phantom-window bug.
- It keeps the app in the Dock and preserves the open book (no reload).
- The existing `RunEvent::Reopen` handler already calls `unminimize()`, so dock-icon reopen works with no extra restore logic.
- Older macOS keeps the previous `hide()` behavior.

Version detection is a new small helper (`src-tauri/src/macos/os_version.rs`) that reads `NSProcessInfo.operatingSystemVersion.majorVersion`. JS side (`tauriHandleOnCloseWindow`) is unchanged — it just `preventDefault`s and hands off to Rust.

## Test plan

- [x] `pnpm test:rust` — 56 passed (incl. 2 new `os_version` unit tests, written test-first)
- [x] `pnpm clippy:check` — clean (exit 0)
- [x] `pnpm fmt:check` — clean
- [x] `pnpm test` — 6567 passed (pre-push hook; no JS changed, regression check)
- [ ] **Manual verification on real macOS 26 (Tahoe) hardware pending** — the dev machine is Sequoia (15.6), where the bug does not reproduce. The version gate and build are verified; the actual Tahoe minimize behavior should be confirmed on 26.x before release.

Closes #4875