### PR TITLE
fix(ios): keep App Group entitlement on widget/share extensions in App Store builds

### DIFF
--- a/apps/readest-app/scripts/release-ios-appstore.sh
+++ b/apps/readest-app/scripts/release-ios-appstore.sh
@@ -3,6 +3,10 @@ pnpm tauri ios build --export-method app-store-connect
 BUNDLE_DIR=src-tauri/gen/apple/build/arm64
 IPA_BUNDLE=$BUNDLE_DIR/Readest.ipa
 
+# Guard: the App Store export re-sign must not strip the App Group entitlement
+# from the widget / share extensions, or the reading widget ships dead.
+bash scripts/verify-ios-appstore-entitlements.sh "$IPA_BUNDLE"
+
 xcrun altool --upload-app --type ios --file $IPA_BUNDLE --apiKey $APPLE_API_KEY --apiIssuer $APPLE_API_ISSUER
 
 echo "iOS build uploaded to App Store Connect."

--- a/apps/readest-app/scripts/verify-ios-appstore-entitlements.sh
+++ b/apps/readest-app/scripts/verify-ios-appstore-entitlements.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Verify the App Store IPA's app extensions carry the App Group entitlement.
+#
+# group.com.bilingify.readest is how the main app hands the reading-widget
+# snapshot (and the share extension its shared state) to its extensions via the
+# shared App Group container. Automatic App Store signing re-signs embedded
+# extensions during `xcodebuild -exportArchive`; if a target sets
+# CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION=YES, that re-sign silently strips
+# com.apple.security.application-groups from the extension binary even though
+# the provisioning profile and source .entitlements both grant it. The widget
+# then reads an empty snapshot and shows only a placeholder book icon, with no
+# build error. This guard fails the release before upload so it can't ship
+# broken again.
+set -euo pipefail
+
+IPA="${1:-src-tauri/gen/apple/build/arm64/Readest.ipa}"
+GROUP="group.com.bilingify.readest"
+EXTS=(ReadestWidget ShareExtension)
+
+if [ ! -f "$IPA" ]; then
+  echo "verify-ios-appstore-entitlements: IPA not found at $IPA" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+unzip -q "$IPA" -d "$WORK"
+APP="$WORK/Payload/Readest.app"
+
+fail=0
+for ext in "${EXTS[@]}"; do
+  appex="$APP/PlugIns/$ext.appex"
+  if codesign -d --entitlements :- "$appex" 2>/dev/null | grep -q "$GROUP"; then
+    echo "OK   $ext.appex carries $GROUP"
+  else
+    echo "FAIL $ext.appex is MISSING $GROUP (App Group access broken)"
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "" >&2
+  echo "App Group entitlement missing from an extension binary. Do NOT set" >&2
+  echo "CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION on extension targets in" >&2
+  echo "src-tauri/gen/apple/project.yml." >&2
+  exit 1
+fi
+
+echo "All app extensions carry the App Group entitlement."

--- a/apps/readest-app/src-tauri/gen/apple/project.yml
+++ b/apps/readest-app/src-tauri/gen/apple/project.yml
@@ -153,16 +153,16 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.bilingify.readest.ShareExtension
         DEVELOPMENT_TEAM: J5W48D69VR
         CODE_SIGN_ENTITLEMENTS: ShareExtension/ShareExtension.entitlements
-        # Permit Xcode's productPackagingUtility to write the auto-derived
-        # signing entitlements (application-identifier, team-identifier,
-        # get-task-allow) back to the source entitlements file at build
-        # time. Without this, Xcode 16+ refuses the modification it
-        # itself just performed and the build fails with:
-        #   "Entitlements file ... was modified during the build"
-        # Safe for this target because the entitlements file is empty —
-        # the only modifications Xcode performs are the team / app-id
-        # auto-population every iOS extension target needs anyway.
-        CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: YES
+        # Do NOT set CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION here. This
+        # entitlements file declares com.apple.security.application-groups
+        # (group.com.bilingify.readest). With automatic App Store signing,
+        # that flag lets `xcodebuild -exportArchive` overwrite the extension
+        # entitlements with a minimal auto-derived set that DROPS the app
+        # group — silently breaking App Group access in App Store builds
+        # (dev builds are unaffected). The main app ships the group
+        # correctly without this flag. If Xcode ever reports "Entitlements
+        # file was modified during the build", fix it by adding the
+        # auto-derived keys to the source file, not by re-enabling this flag.
         SWIFT_VERSION: "5.0"
         IPHONEOS_DEPLOYMENT_TARGET: 15.0
         ARCHS: [arm64]
@@ -192,7 +192,10 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.bilingify.readest.ReadestWidget
         DEVELOPMENT_TEAM: J5W48D69VR
         CODE_SIGN_ENTITLEMENTS: ReadestWidget/ReadestWidget.entitlements
-        CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: YES
+        # CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION is intentionally omitted
+        # (see ShareExtension): with it, the App Store export re-sign strips
+        # com.apple.security.application-groups, so the widget reads an empty
+        # snapshot from the App Group and shows only the placeholder book icon.
         SWIFT_VERSION: "5.0"
         IPHONEOS_DEPLOYMENT_TARGET: 15.0
         ARCHS: [arm64]


### PR DESCRIPTION
## Problem

The iOS reading widget works on locally-built dev IPAs but shows **only the placeholder book icon** when installed from the App Store. The ShareExtension has the same latent problem (its App Group list is populated in dev builds, empty in App Store builds — it just went unnoticed because its primary path is the `readest://share?url=` deep link, not the shared container).

## Root cause (proven from the shipped IPA)

The App-Store-signed extension binaries are **missing `com.apple.security.application-groups`**, so `UserDefaults(suiteName:)` and `containerURL(forSecurityApplicationGroupIdentifier:)` return nil, the widget reads an empty snapshot, and it falls back to `EmptyReadingView` (`books.vertical`).

Evidence via `codesign -d --entitlements` on the App Store `Readest.ipa`:

| Component | Source `.entitlements` | Provisioning profile | Signed binary |
|---|---|---|---|
| Main app | has group | grants group | **has group** |
| ShareExtension | has group | grants group | **stripped** |
| ReadestWidget | has group | grants group | **stripped** |

The provisioning profiles and source entitlements both grant the group, so this is **not** a portal / App ID capability problem — the entitlement is dropped at signing time.

**Mechanism:** the App Store export is `xcodebuild -exportArchive` with `signingStyle: automatic`. During that re-sign, both extension targets set `CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: YES`, which lets Xcode overwrite their entitlements with a minimal auto-derived set that omits the app group. The main app, which has no such flag, keeps its full entitlements. The correlation is exact: the two targets with the flag are the two that lose the group. Dev builds use development signing that does not re-derive/strip, so the widget works there.

The flag was originally added (per an outdated comment) to silence "Entitlements file was modified during the build" back when the ShareExtension entitlements file was empty; both files now declare the app group.

## Fix

- Remove `CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: YES` from the `ShareExtension` and `ReadestWidget` targets in `project.yml` so signing uses the exact `CODE_SIGN_ENTITLEMENTS` content. This is strictly safer: it turns a silent stripped entitlement (ships a dead widget) into a loud build error. The main app already ships the group correctly without the flag.
- Add `scripts/verify-ios-appstore-entitlements.sh` and run it from `release-ios-appstore.sh` before `altool` upload, so a stripped App Group fails the release instead of shipping.

## Verification

After `xcodegen generate` and a rebuild, no App Store round-trip is needed — inspect the exported IPA:

```
codesign -d --entitlements :- Payload/Readest.app/PlugIns/ReadestWidget.appex | grep group.com.bilingify.readest
```

The new guard asserts this for both extensions and currently fails against the pre-fix IPA (reproduces the bug), passing once the entitlement survives.

If the archive ever reports "Entitlements file was modified during the build", the correct fallback is to add the auto-derived keys to the source `.entitlements` (via `$(AppIdentifierPrefix)`/`$(TeamIdentifierPrefix)`), not to re-enable the flag.

> Note: the regenerated `Readest.xcodeproj/project.pbxproj` is `skip-worktree` in this repo (regenerated locally from `project.yml`), so it is intentionally not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)