### PR TITLE
fix(window): enter fullscreen from maximized windows (#4034)

### DIFF
--- a/apps/readest-app/src/__tests__/utils/window.test.ts
+++ b/apps/readest-app/src/__tests__/utils/window.test.ts
@@ -24,7 +24,7 @@ vi.mock('@/utils/event', () => ({
 
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { type as osType } from '@tauri-apps/plugin-os';
-import { tauriHandleOnCloseWindow } from '@/utils/window';
+import { tauriHandleOnCloseWindow, tauriHandleToggleFullScreen } from '@/utils/window';
 
 type CloseHandler = (event: { preventDefault: () => void }) => Promise<void> | void;
 
@@ -111,5 +111,64 @@ describe('tauriHandleOnCloseWindow', () => {
     expect(win.destroy).not.toHaveBeenCalled();
     vi.advanceTimersByTime(300);
     expect(win.destroy).toHaveBeenCalled();
+  });
+});
+
+function makeFullscreenWindow({
+  isFullscreen,
+  isMaximized,
+}: {
+  isFullscreen: boolean;
+  isMaximized: boolean;
+}) {
+  return {
+    isFullscreen: vi.fn().mockResolvedValue(isFullscreen),
+    isMaximized: vi.fn().mockResolvedValue(isMaximized),
+    setFullscreen: vi.fn().mockResolvedValue(undefined),
+    unmaximize: vi.fn().mockResolvedValue(undefined),
+    toggleMaximize: vi.fn().mockResolvedValue(undefined),
+    innerSize: vi.fn().mockResolvedValue({ width: 800, height: 600 }),
+    setSize: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('tauriHandleToggleFullScreen', () => {
+  test('enters fullscreen when the window is maximized (Phosh / Windows-maximized case)', async () => {
+    // On Phosh the window is always maximized, and on Windows users often run
+    // maximized. The fullscreen button must still enter fullscreen instead of
+    // just unmaximizing the window (issue #4034).
+    vi.mocked(osType).mockReturnValue('linux');
+    const win = makeFullscreenWindow({ isFullscreen: false, isMaximized: true });
+    vi.mocked(getCurrentWindow).mockReturnValue(
+      win as unknown as ReturnType<typeof getCurrentWindow>,
+    );
+
+    await tauriHandleToggleFullScreen();
+
+    expect(win.setFullscreen).toHaveBeenCalledWith(true);
+  });
+
+  test('exits fullscreen when already fullscreen', async () => {
+    vi.mocked(osType).mockReturnValue('windows');
+    const win = makeFullscreenWindow({ isFullscreen: true, isMaximized: false });
+    vi.mocked(getCurrentWindow).mockReturnValue(
+      win as unknown as ReturnType<typeof getCurrentWindow>,
+    );
+
+    await tauriHandleToggleFullScreen();
+
+    expect(win.setFullscreen).toHaveBeenCalledWith(false);
+  });
+
+  test('enters fullscreen when neither maximized nor fullscreen', async () => {
+    vi.mocked(osType).mockReturnValue('macos');
+    const win = makeFullscreenWindow({ isFullscreen: false, isMaximized: false });
+    vi.mocked(getCurrentWindow).mockReturnValue(
+      win as unknown as ReturnType<typeof getCurrentWindow>,
+    );
+
+    await tauriHandleToggleFullScreen();
+
+    expect(win.setFullscreen).toHaveBeenCalledWith(true);
   });
 });

--- a/apps/readest-app/src/utils/window.ts
+++ b/apps/readest-app/src/utils/window.ts
@@ -71,12 +71,11 @@ export const tauriHandleOnCloseWindow = async (callback: () => void) => {
 export const tauriHandleToggleFullScreen = async () => {
   const currentWindow = getCurrentWindow();
   const isFullscreen = await currentWindow.isFullscreen();
-  const isMaximized = await currentWindow.isMaximized();
-  if (isMaximized) {
-    await currentWindow.unmaximize();
-  } else {
-    await currentWindow.setFullscreen(!isFullscreen);
-  }
+  // Toggle fullscreen regardless of the maximized state. Previously a maximized
+  // window was only unmaximized here, so the fullscreen button did nothing when
+  // the window was maximized, which is always the case on mobile shells like
+  // Phosh and common on Windows (issue #4034).
+  await currentWindow.setFullscreen(!isFullscreen);
   if ((await osType()) === 'linux') {
     linuxWindowRestoreTransparentBg();
   }


### PR DESCRIPTION
## Problem

Fixes #4034. The Fullscreen button did nothing on **Phosh** (Wayland mobile shell), and on **Windows** it only worked when the window was *not* maximized (per the issue comment).

## Root cause

`tauriHandleToggleFullScreen` in `src/utils/window.ts` had an `isMaximized` branch (introduced by #872) that called `unmaximize()` and **never** `setFullscreen()` when the window was maximized:

```js
if (isMaximized) {
  await currentWindow.unmaximize();   // never enters fullscreen
} else {
  await currentWindow.setFullscreen(!isFullscreen);
}
```

Phosh windows are always maximized (it's a mobile shell), so the button always hit the `unmaximize()` branch and appeared to do nothing. On Windows, a maximized window was likewise only unmaximized instead of going fullscreen.

## Fix

Toggle fullscreen unconditionally:

```js
const isFullscreen = await currentWindow.isFullscreen();
await currentWindow.setFullscreen(!isFullscreen);
```

The maximize-button handler (`tauriHandleToggleMaximize`) already exits fullscreen first when in fullscreen, so the two window controls stay consistent without the fullscreen handler special-casing maximize. The Linux transparent-background workaround is untouched, and `isMaximized` is still used elsewhere (`themeStore` rounded-window), so no capability changes are needed.

## Testing

- Added a `tauriHandleToggleFullScreen` block to `src/__tests__/utils/window.test.ts` covering the maximized (Phosh/Windows), already-fullscreen, and plain cases. The maximized-window test fails against the old code and passes with the fix.
- `pnpm test` (window suite) and `pnpm lint` (tsgo + biome) pass.

Note: I don't have Phosh hardware to reproduce directly, so this is validated by unit tests and reasoning about the tao/winit fullscreen path. The reporter confirmed the compositor supports fullscreen (libadwaita apps and Firefox work), so entering it via `setFullscreen(true)` should now take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)