### PR TITLE
ci(nightly): fix nightly update detection broken by AppImage bundling hang

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,7 +78,9 @@ jobs:
             args: '--target aarch64-pc-windows-msvc --bundles nsis'
 
     runs-on: ${{ matrix.config.os }}
-    timeout-minutes: 60
+    # Backstop only — must stay ABOVE setup time + the per-step timeouts below,
+    # because a job-level timeout reports `cancelled` and skips assemble-manifest.
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -173,6 +175,7 @@ jobs:
       - name: build and sign Android apks
         if: matrix.config.release == 'android'
         shell: bash
+        timeout-minutes: 55
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358
@@ -213,9 +216,30 @@ jobs:
         if: matrix.config.release == 'linux'
         run: cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --force
 
+      # The truly-portable AppImage bundler downloads quick-sharun.sh from
+      # Anylinux-AppImages@main ONLY when it is not already in the tauri tools
+      # cache. An upstream strace-mode change (2026-06-29) made bundling launch
+      # the app under Xvfb and hang forever, timing out the Linux legs (#4906).
+      # Seed the cache with the last known-good revision so the bundler never
+      # fetches the moving main-branch script.
+      - name: pin quick-sharun.sh for AppImage bundling (Linux)
+        if: matrix.config.release == 'linux'
+        run: |
+          set -euo pipefail
+          cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
+          mkdir -p "$cache_dir"
+          curl -fsSL --retry 3 -o "$cache_dir/quick-sharun.sh" \
+            "https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/b3a9e985cdedf7efa81d172f182cd13983743147/useful-tools/quick-sharun.sh"
+          chmod +x "$cache_dir/quick-sharun.sh"
+
       - name: build desktop bundles
         if: matrix.config.release != 'android'
         shell: bash
+        # A hung build must fail the STEP (step timeout -> job failure), not hit
+        # the job-level timeout: job timeouts report `cancelled`, which the
+        # assemble-manifest guard treats as run cancellation and skips promoting
+        # latest.json for ALL platforms (#4906).
+        timeout-minutes: 45
         env:
           TAURI_BUNDLER_NEW_APPIMAGE_FORMAT: 'true'
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -244,6 +268,7 @@ jobs:
       - name: build and sign portable binaries (Windows only)
         if: matrix.config.os == 'windows-latest'
         shell: bash
+        timeout-minutes: 30
         env:
           TAURI_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,22 @@ jobs:
         if: matrix.config.release == 'linux'
         run: cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --force
 
+      # The truly-portable AppImage bundler downloads quick-sharun.sh from
+      # Anylinux-AppImages@main ONLY when it is not already in the tauri tools
+      # cache. An upstream strace-mode change (2026-06-29) made bundling launch
+      # the app under Xvfb and hang forever (#4906). Seed the cache with the
+      # last known-good revision so the bundler never fetches the moving
+      # main-branch script. Keep in sync with nightly.yml.
+      - name: pin quick-sharun.sh for AppImage bundling (Linux)
+        if: matrix.config.release == 'linux'
+        run: |
+          set -euo pipefail
+          cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
+          mkdir -p "$cache_dir"
+          curl -fsSL --retry 3 -o "$cache_dir/quick-sharun.sh" \
+            "https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/b3a9e985cdedf7efa81d172f182cd13983743147/useful-tools/quick-sharun.sh"
+          chmod +x "$cache_dir/quick-sharun.sh"
+
       - uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
         id: tauri
         if: matrix.config.release != 'android'


### PR DESCRIPTION
## Summary

Closes #4906. Nightly update detection has been dead on **all** platforms since 2026-06-29: every nightly run from June 29 to July 2 ended `cancelled`, so `nightly/latest.json` was never promoted and clients kept seeing the June 28 manifest.

Note: PR #4851 (artifact attestation) is exonerated — it merged 2026-06-29 02:14 UTC, but the actual break landed upstream at 05:59 UTC the same day, and the attest step never even ran in the hung legs.

## Root cause

1. The truly-portable AppImage bundler (tauri fork `feat/truly-portable-appimage`) downloads `quick-sharun.sh` from the **unpinned `main` branch** of `pkgforge-dev/Anylinux-AppImages` — but only when `~/.cache/tauri/quick-sharun.sh` does not already exist.
2. Upstream "fix strace mode" commits on 2026-06-29 (`acb1d719`, `867c0b15`) made the script launch the staged launcher scripts and deployed WebKitGTK binaries under Xvfb (`LD_DEBUG=libs`) to trace dlopened libraries. The spawned WebKit processes survive the script's process-group kill, so bundling hangs forever. Orphans at job kill in [run 28625293417](https://github.com/readest/readest/actions/runs/28625293417): `quick-sharun.sh`, `xvfb-run`, `Xvfb`, `MiniBrowser`.
3. Both Linux legs hit the job-level `timeout-minutes: 60`, which GitHub reports as **`cancelled`** (not `failure`).
4. `assemble-manifest` is guarded by `needs.build.result != 'cancelled'` (meant for real run cancellations), so it skipped, and the manifest was never promoted — blanking nightly updates for every platform, not just Linux.

## Fixes

- **Pin `quick-sharun.sh`** (`nightly.yml` + `release.yml`, Linux legs): pre-seed the tauri tools cache with revision `b3a9e985` — byte-identical (sha256-verified) to the script used by the green June 27/28 nightlies — so the bundler never fetches the moving main-branch script. This also covers the next stable release, which would hit the same hang.
- **Step-level timeouts** (`nightly.yml`): `45` on desktop bundles, `55` on Android, `30` on Windows portable, with the job timeout raised to a `75`-minute backstop. Step timeouts report `failure`, so a future hang fails only its own leg and `assemble-manifest` still promotes fragments from the healthy legs — the workflow's stated "a single failing leg never clobbers the manifest" design.

## Verification

- `actionlint` clean on both workflows; both parse as valid YAML.
- Pinned URL download verified byte-identical to the last known-good script; its `_lib4bin_collect_strace` still has the pre-June-29 `_is_elf || continue` gating (does not execute wrapper scripts).
- Workflow-only change, so `pnpm test` / `lint` / Rust gates are not applicable.
- After merge: the next scheduled nightly (or a manual `workflow_dispatch`) should go green on the Linux legs and promote a fresh `nightly/latest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)