### PR TITLE
fix(reader): keep running header/footer readable over light PDFs in dark mode (#4901)

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/components/SectionInfo.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/SectionInfo.test.tsx
@@ -68,3 +68,27 @@ describe('SectionInfo notch mask', () => {
     expect(notch.classList.contains('bg-base-100')).toBe(false);
   });
 });
+
+describe('SectionInfo contrast against the page (#4901)', () => {
+  // A light-mode PDF shown under a dark theme keeps its white page, but the
+  // running header text was themed for the dark UI (neutral-content, light)
+  // and became unreadable on the white page. mix-blend-mode: difference makes
+  // the text invert against whatever is actually behind it (the page or the
+  // themed margin), so it stays legible over any background.
+  it('blends the section title against the background in non-eink mode', () => {
+    const { container } = render(<SectionInfo {...baseProps} isEink={false} />);
+    const info = container.querySelector('.sectioninfo') as HTMLElement;
+
+    expect(info.classList.contains('mix-blend-difference')).toBe(true);
+    expect(info.classList.contains('text-white/75')).toBe(true);
+    // The theme-fixed neutral color is what made it unreadable on a white page.
+    expect(info.classList.contains('text-neutral-content')).toBe(false);
+  });
+
+  it('does not blend in eink mode (base-content text on the e-ink page)', () => {
+    const { container } = render(<SectionInfo {...baseProps} isEink={true} />);
+    const info = container.querySelector('.sectioninfo') as HTMLElement;
+
+    expect(info.classList.contains('mix-blend-difference')).toBe(false);
+  });
+});

--- a/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
@@ -286,3 +286,51 @@ describe('ProgressBar — sticky progress bar', () => {
     expect(container.querySelector('.sticky-progress-bar')).toBeNull();
   });
 });
+
+describe('ProgressBar — contrast against the page (#4901)', () => {
+  // A light-mode PDF under a dark theme keeps its white page while the footer
+  // progress text stayed themed for the dark UI (neutral-content, light) and
+  // became unreadable over the white page. Blending the text spans against the
+  // real backdrop keeps the page number and remaining-pages text legible on
+  // any background. StatusInfo (clock/battery) is intentionally left alone — it
+  // manages its own blend against the battery glyph.
+  it('blends the progress and remaining text against the background in non-eink mode', () => {
+    currentViewSettings = {
+      ...baseSettings,
+      isEink: false,
+      showRemainingPages: true,
+      showRemainingTime: false,
+      progressInfoMode: 'all',
+    } as ViewSettings;
+    currentProgress = makeProgress(2, 5);
+    currentBookData = { isFixedLayout: false };
+    currentRenderer = { page: 1, pages: 4 };
+
+    const { container } = renderProgressBar();
+
+    const progress = container.querySelector('.progress-info') as HTMLElement;
+    const remaining = container.querySelector('.remaining-info') as HTMLElement;
+    expect(progress.classList.contains('mix-blend-difference')).toBe(true);
+    expect(progress.classList.contains('text-white/75')).toBe(true);
+    expect(remaining.classList.contains('mix-blend-difference')).toBe(true);
+    expect(remaining.classList.contains('text-white/75')).toBe(true);
+  });
+
+  it('does not blend in eink mode', () => {
+    currentViewSettings = {
+      ...baseSettings,
+      isEink: true,
+      showRemainingPages: true,
+      showRemainingTime: false,
+      progressInfoMode: 'all',
+    } as ViewSettings;
+    currentProgress = makeProgress(2, 5);
+    currentBookData = { isFixedLayout: false };
+    currentRenderer = { page: 1, pages: 4 };
+
+    const { container } = renderProgressBar();
+
+    const progress = container.querySelector('.progress-info') as HTMLElement;
+    expect(progress.classList.contains('mix-blend-difference')).toBe(false);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/ProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/ProgressBar.tsx
@@ -287,6 +287,9 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
                 'remaining-info whitespace-nowrap text-start',
                 !stickyBarActive && 'flex-1',
                 showStatusInfo && 'overflow-hidden',
+                // Keep the text legible on any backdrop (e.g. a light PDF page
+                // under a dark theme, #4901); blend it against what's behind.
+                !isEink && 'text-white/75 mix-blend-difference',
               )}
             >
               {viewSettings.showRemainingTime ? (
@@ -346,6 +349,9 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
           className={clsx(
             'progress-info items-center overflow-hidden whitespace-nowrap text-end tabular-nums',
             !stickyBarActive && 'flex-1',
+            // Keep the page number legible on any backdrop (e.g. a light PDF
+            // page under a dark theme, #4901); blend it against what's behind.
+            !isEink && 'text-white/75 mix-blend-difference',
           )}
         >
           {(progressBarMode === 'all' || progressBarMode.includes('progress')) && (

--- a/apps/readest-app/src/app/reader/components/SectionInfo.tsx
+++ b/apps/readest-app/src/app/reader/components/SectionInfo.tsx
@@ -75,7 +75,13 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
       <div
         className={clsx(
           'sectioninfo absolute flex items-center overflow-hidden font-sans',
-          isEink ? 'text-sm font-normal' : 'text-neutral-content text-xs font-light',
+          // A light-mode PDF stays white under a dark theme, so the themed
+          // neutral-content title was unreadable on the page (#4901). Blend the
+          // text against whatever is actually behind it (page or margin) so it
+          // stays legible on any background. text-white/75 matches the previous
+          // neutral-content brightness over the dark theme, so nothing changes
+          // for reflowable books. E-ink keeps its plain base-content text.
+          isEink ? 'text-sm font-normal' : 'text-white/75 mix-blend-difference text-xs font-light',
           isVertical ? 'writing-vertical-rl max-h-[85%]' : 'top-0',
         )}
         role='none'


### PR DESCRIPTION
## Problem

When a **light-mode PDF is read in dark mode**, the running header (chapter title, top-left) and the footer page number (bottom-right) overlap the white page and become unreadable.

The overlays use `text-neutral-content`, which is a *light* color in dark mode. PDFs are not inverted by default (`invertImgColorInDark: false`), so the page stays white and the light text sits on a white background.

Reported in #4901.

## Fix

Blend the header/footer **text** against whatever is actually behind it (the page or the themed margin) with `mix-blend-mode: difference` and a fixed `white/75` anchor:

- `SectionInfo.tsx` (running header) and the `.remaining-info` / `.progress-info` spans in `ProgressBar.tsx` (running footer) now use `text-white/75 mix-blend-difference` instead of `text-neutral-content`.
- Under `difference` the color acts as a blend anchor, not a literal color. A fixed light anchor inverts to dark on a light page and stays light on a dark margin, so it is legible on any background. `text-neutral-content` could not be reused because it flips to a *dark* color in light themes, which would blend to light-on-light and break light mode.
- `white/75` was tuned to match the previous `neutral-content` brightness over the dark theme (`≈#adad`), so reflowable books look unchanged.
- Scoped to the text only. E-ink keeps its plain `base-content` text, and `StatusInfo` (clock/battery, which already manages its own blend) and `StickyProgressBar` are left untouched.

There is precedent for this technique in the same area: `StatusInfo.tsx` already uses `mix-blend-difference` / `mix-blend-luminosity`.

## Testing

- Added tests to `SectionInfo.test.tsx` and `ProgressBar.test.tsx` (written failing first) asserting the blend classes apply in non-e-ink and are absent in e-ink.
- Verified in headless Playwright (**WebKit and Chromium**) that the blend crosses foliate's same-origin (`allow-same-origin`) iframe, covering WKWebView/WebKitGTK and WebView2/Android WebView, and produces dark text over a white page / light text over a dark margin.
- `pnpm test` (6642 passed), `pnpm lint`, and `pnpm format:check` all clean. No Rust/koplugin changes.

Fixes #4901

🤖 Generated with [Claude Code](https://claude.com/claude-code)