### PR TITLE
fix: change formatter to nixpkgs-fmt

### DIFF
--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -238,15 +238,15 @@
                 value = pkgs.jdk.home;
               }
               {
-                  name = "ANDROID_AVD_HOME";
-                  eval = "$XDG_CONFIG_HOME/.android/avd";
+                name = "ANDROID_AVD_HOME";
+                eval = "$XDG_CONFIG_HOME/.android/avd";
               }
             ];
           };
 
           default = self.devShells.${pkgs.stdenv.hostPlatform.system}.web;
         };
-        
-        formatter = pkgs.nixfmt;
+
+        formatter = pkgs.nixpkgs-fmt;
       });
 }


### PR DESCRIPTION
While I intially used `nixfmt` in #4883, the formatter that was used before was `nixpkgs-fmt`. To keep formatting consistent, this PR switches the formatter back to `nixpkgs-fmt` and runs `nix fmt flake.nix` to format the file.