### PR TITLE
fix(reader): open books without a View Transition to avoid timeout (READEST-9)

### DIFF
--- a/apps/readest-app/src/app/library/hooks/useOpenBook.ts
+++ b/apps/readest-app/src/app/library/hooks/useOpenBook.ts
@@ -3,8 +3,8 @@ import { Book } from '@/types/book';
 import { useEnv } from '@/context/EnvContext';
 import { useLibraryStore } from '@/store/libraryStore';
 import { useSettingsStore } from '@/store/settingsStore';
+import { useRouter } from 'next/navigation';
 import { useTranslation } from '@/hooks/useTranslation';
-import { useAppRouter } from '@/hooks/useAppRouter';
 import { eventDispatcher } from '@/utils/event';
 import { navigateToReader, showReaderWindow } from '@/utils/nav';
 
@@ -25,7 +25,11 @@ interface UseOpenBookOptions {
  */
 export const useOpenBook = ({ setLoading, handleBookDownload }: UseOpenBookOptions) => {
   const _ = useTranslation();
-  const router = useAppRouter();
+  // Open the reader with the plain router, NOT the View Transition router:
+  // the reader's initial render is heavy enough to blow the transition's ~4s
+  // DOM-update budget, which aborts with a TimeoutError (Sentry READEST-9).
+  // This matches how every other into-reader path already navigates.
+  const router = useRouter();
   const { envConfig, appService } = useEnv();
   const { settings } = useSettingsStore();
   const { updateBook } = useLibraryStore();

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import * as React from 'react';
 import { MdChevronRight } from 'react-icons/md';
 import { useState, useRef, useEffect, Suspense, useCallback } from 'react';
-import { ReadonlyURLSearchParams, useSearchParams } from 'next/navigation';
+import { ReadonlyURLSearchParams, useRouter, useSearchParams } from 'next/navigation';
 
 import { Book } from '@/types/book';
 import { AppService, DeleteAction } from '@/types/system';
@@ -155,6 +155,10 @@ const LibraryPageWithSearchParams = () => {
 
 const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchParams | null }) => {
   const router = useAppRouter();
+  // Opening the reader is a heavy render that overruns the View Transition
+  // DOM-update budget (TimeoutError, Sentry READEST-9), so navigate to it with
+  // the plain router; `router` above keeps transitions for lighter navigation.
+  const readerRouter = useRouter();
   const { envConfig, appService } = useEnv();
   const { token, user } = useAuth();
   const {
@@ -568,10 +572,10 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
       const bookIds = pendingNavigationBookIds;
       setPendingNavigationBookIds(null);
       if (bookIds.length > 0) {
-        navigateToReader(router, bookIds);
+        navigateToReader(readerRouter, bookIds);
       }
     }
-  }, [pendingNavigationBookIds, appService, router]);
+  }, [pendingNavigationBookIds, appService, readerRouter]);
 
   useEffect(() => {
     if (isInitiating.current) return;


### PR DESCRIPTION
Follow-up to #4943, which stopped *filtering* READEST-9 so it stayed visible as signal. This fixes the underlying cause.

## Root cause

`useAppRouter` wraps **every** navigation in a View Transition (except the existing Linux carve-out). Opening a book is a heavy render — the reader route mounts and loads the book — that can overrun the transition's ~4s DOM-update budget and abort with `TimeoutError: Transition was aborted because of timeout in DOM update` (READEST-9), attributed to `/library`.

Notably, **8 of the 10** into-reader navigation paths already use the plain `useRouter` (e.g. `useOpenBookLink`, `Bookshelf`, OPDS, share/open-with). Only two were outliers using the transition router:

- `useOpenBook` — the primary tap-to-open flow
- `library/page.tsx` — the post-import queued open (`pendingNavigationBookIds`)

## Fix

Both now navigate to the reader with the plain router, matching the rest of the app. `library/page.tsx` keeps `useAppRouter` for its lighter navigations (`/auth`, `replace`) and uses a dedicated plain router only for the reader open.

## Verification
Full JS suite green (6657 passed), `tsgo` + Biome clean. No Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)