### PR TITLE
fix(widget): round iOS cover thumbnail size to whole pixels

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/ReadingWidgetWriter.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/ReadingWidgetWriter.swift
@@ -41,7 +41,13 @@ enum ReadingWidgetWriter {
     }
     let longEdge = max(image.size.width, image.size.height)
     let scale = longEdge > thumbMaxPixels ? thumbMaxPixels / longEdge : 1
-    let target = CGSize(width: image.size.width * scale, height: image.size.height * scale)
+    // Round to whole pixels: the renderer allocates a whole-pixel buffer, so a
+    // fractional target would leave the trailing pixel column/row only partially
+    // covered (semi-transparent). Flattened into JPEG that shows up as a bright
+    // hairline along the right/bottom edge. Whole-pixel target == full coverage.
+    let target = CGSize(
+      width: (image.size.width * scale).rounded(),
+      height: (image.size.height * scale).rounded())
     let format = UIGraphicsImageRendererFormat()
     format.scale = 1.0
     let renderer = UIGraphicsImageRenderer(size: target, format: format)


### PR DESCRIPTION
## Problem

The iOS reading widget book cover sometimes shows a **bright hairline along the right edge** (see the "Digital SAT Prep" cover below). The Android widget never has this.

## Root cause

`ReadingWidgetWriter.writeThumbnail` downsampled covers to a **fractional** target size:

```swift
let target = CGSize(width: image.size.width * scale, height: image.size.height * scale)
```

For portrait covers, `scale = 240 / longEdge` lands the height on a whole pixel but leaves the **width fractional**. `UIGraphicsImageRenderer` allocates a whole-pixel buffer (rounds the size up), while `image.draw(in:)` fills only the exact fractional rect. When the fractional width rounds up, the rightmost pixel column is left only partially covered (semi-transparent). JPEG has no alpha, so that column flattens into a visible bright line at the right edge.

This matches the observed symptoms: intermittent (only when the fraction rounds up) and portrait-specific (width is the fractional axis).

## Fix

Round both target dimensions to whole pixels so the draw rect matches the pixel buffer and every edge pixel is fully covered.

Android is unaffected because `ReadingWidgetStore.kt` scales to a fixed integer 240x360 and center-crops.

## Verification

Reproduced the pixel-grid mechanism with a faithful CoreGraphics test (same rasterization UIKit uses): a `453x680` cover gave a right-edge pixel alpha of `225` (partial coverage, the visible line) before the change and `255` (full coverage, no line) after. All tested sizes return `255` after the fix.

A UIKit unit test is not runnable in CI (the plugin `Package.swift` has no wired test target and the code is UIKit-only), so the CoreGraphics reproduction stood in for the failing/passing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)