### PR TITLE
test(reader): harden fixed-layout wheel double-scroll test against CI flake

### DIFF
--- a/apps/readest-app/src/__tests__/document/fixed-layout-scroll-wheel.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-scroll-wheel.browser.test.ts
@@ -68,17 +68,26 @@ describe('fixed-layout scroll mode wheel handling (readest#4727)', () => {
     });
 
     const scroller = renderer as unknown as HTMLElement;
-    scroller.scrollTop = 0;
 
     // A wheel over the page iframe. With the bug, the iframe handler runs
-    // `host.scrollBy({ top: deltaY })`, moving the host scroller by ~120px on
-    // top of the (here absent) native scroll. With the fix it must stay put.
+    // `host.scrollBy({ top: deltaY, behavior: 'instant' })`, an *instant*
+    // (synchronous) scroll that lands by ~120px before dispatchEvent() returns.
+    // With the fix the handler only drops pointer-events and never scrolls.
+    //
+    // Measure the scroll position synchronously around dispatchEvent() — with no
+    // await in between — so we capture only the wheel handler's own effect. Do
+    // NOT await/settle here: as sibling pages finish loading, the renderer runs
+    // #restoreScrollModeAnchor asynchronously, which snaps scrollTop to a page's
+    // offsetTop (the 4px --scroll-page-gap). A post-dispatch delay races that
+    // re-anchoring and observed scrollTop === 4 instead of 0 on slow CI runners
+    // (readest CI flake). The buggy scrollBy is synchronous, so a synchronous
+    // before/after comparison still catches it while being immune to the race.
+    const before = scroller.scrollTop;
     iframe.contentDocument!.dispatchEvent(
       new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true }),
     );
+    const after = scroller.scrollTop;
 
-    await new Promise((r) => setTimeout(r, 60));
-
-    expect(scroller.scrollTop).toBe(0);
+    expect(after).toBe(before);
   });
 });


### PR DESCRIPTION
## Summary

Hardens the readest#4727 regression test (`fixed-layout-scroll-wheel.browser.test.ts`), which occasionally fails `test_web_app` in CI with:

```
AssertionError: expected 4 to be +0 // Object.is equality
```

## Root cause

The test set `scrollTop = 0`, dispatched a synthetic wheel over the page iframe, waited 60ms, then asserted `scrollTop === 0`.

During that 60ms window, sibling scroll pages are still loading asynchronously. Each `#loadScrollPage` completion runs `#restoreScrollModeAnchor`, which — at `scrollTop = 0` / page-index 0 (fraction 0) — snaps `scrollTop` to page 0's `offsetTop`, i.e. the **4px `--scroll-page-gap`** margin. On slow CI runners that async re-anchor landed inside the wait window, so the assertion observed `4`. That `4` has nothing to do with the wheel bug being guarded (which is a 120px jump).

## Fix

The buggy handler was `scrollBy({ top: deltaY, behavior: 'instant' })` — an *instant, synchronous* scroll that completes before `dispatchEvent()` returns. So the test now reads `scrollTop` **synchronously immediately before and after** the dispatch, with no `await` in between, and asserts they are equal. This isolates the wheel handler's own synchronous effect and is completely immune to the async re-anchoring race.

## Verification

- Reintroduced the buggy `scrollBy` in the renderer -> test goes red (`before=4, after=124`, a clean 120px delta — still catches the real bug).
- Reverted -> passes reliably across repeated runs.
- `pnpm lint` (tsgo + Biome) passes.

No production code changes; test-only.