### PR TITLE
fix(reader): gate captured slide/curl turn on scrollLocked like push

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useCapturedTurn-scrollLock.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useCapturedTurn-scrollLock.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, renderHook } from '@testing-library/react';
+import type { FoliateView } from '@/types/view';
+import type { ViewSettings } from '@/types/book';
+import type { TouchDetail } from '@/app/reader/hooks/useTouchInterceptor';
+
+// The captured page-turn (slide/curl) swipe is handled by an app-side touch
+// interceptor because `no-swipe` disables the paginator's own swipe. Push mode
+// stays on the paginator's native swipe, which bows out while `scrollLocked`
+// is set (instant highlight engaged). This test pins the captured turn to the
+// same gate so a hold-then-swipe extends the highlight instead of paginating.
+const h = vi.hoisted(() => ({
+  controller: {
+    turn: vi.fn(async () => {}),
+    beginDrag: vi.fn(async () => true),
+    moveDrag: vi.fn(),
+    endDrag: vi.fn(async () => {}),
+    dispose: vi.fn(),
+  },
+  renderer: {
+    scrollLocked: false,
+    atEnd: false,
+    atStart: false,
+    hasAttribute: () => false,
+    setAttribute: () => {},
+    removeAttribute: () => {},
+  },
+  viewSettings: {
+    pageTurnStyle: 'curl',
+    animated: true,
+    scrolled: false,
+    disableSwipe: false,
+    isEink: false,
+    rtl: false,
+  } as ViewSettings,
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({ getViewSettings: () => h.viewSettings }),
+}));
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({ getBookData: () => ({ isFixedLayout: false }) }),
+}));
+vi.mock('@/utils/bridge', () => ({ captureWebviewRegion: vi.fn() }));
+vi.mock('@/utils/viewTransition', () => ({ detectViewTransitionGroup: () => false }));
+vi.mock('@/app/reader/utils/capturedTurn', () => ({
+  CapturedPageTurn: class {
+    constructor() {
+      Object.assign(this, h.controller);
+    }
+  },
+}));
+
+import { useCapturedTurn } from '@/app/reader/hooks/useCapturedTurn';
+import { dispatchTouchInterceptors } from '@/app/reader/hooks/useTouchInterceptor';
+
+const makeView = () =>
+  ({ renderer: h.renderer, prev: vi.fn(), next: vi.fn() }) as unknown as FoliateView;
+
+const detail = (phase: TouchDetail['phase'], deltaX = 0, deltaY = 0): TouchDetail => ({
+  phase,
+  touch: { screenX: 0, screenY: 0 },
+  touchStart: { screenX: 0, screenY: 0 },
+  deltaX,
+  deltaY,
+  deltaT: 16,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'tauri');
+  h.renderer.scrollLocked = false;
+  h.renderer.atEnd = false;
+  h.renderer.atStart = false;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  cleanup();
+});
+
+describe('useCapturedTurn scroll-lock gate', () => {
+  test('a horizontal swipe starts the captured turn when scroll is not locked', () => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start'));
+    const consumed = dispatchTouchInterceptors('book-1', detail('move', -60, 3));
+
+    expect(consumed).toBe(true);
+    expect(h.controller.beginDrag).toHaveBeenCalled();
+  });
+
+  test('scroll lock (instant highlight engaged) leaves the swipe to the highlight', () => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    // Instant highlight has engaged after the still-hold: it locks scrolling.
+    h.renderer.scrollLocked = true;
+    dispatchTouchInterceptors('book-1', detail('start'));
+    const consumed = dispatchTouchInterceptors('book-1', detail('move', -60, 3));
+
+    expect(consumed).toBe(false);
+    expect(h.controller.beginDrag).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
+++ b/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
@@ -179,6 +179,11 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
       if (detail.phase === 'move') {
         let state = dragRef.current;
         if (!state) {
+          // Instant highlight engaged (still-hold on text) locks scrolling so
+          // the finger extends the highlight, not turns the page. The push
+          // paginator honors the same lock in its native swipe (paginator's
+          // #scrollLocked); mirror it here so slide/curl behaves identically.
+          if (currentView.renderer.scrollLocked) return false;
           if (!viewSettings || viewSettings.disableSwipe) return false;
           const style = getCapturedTurnStyle(viewSettings, isFixedLayout());
           if (!style) return false;


### PR DESCRIPTION
## Problem

With the **Instant Highlight** quick action enabled, a highlight engages only after a 300ms still-hold on text; after that, a swipe should *extend the highlight*, not turn the page. This worked in **push** mode but not in **slide** or **page curl** mode, where a hold-then-swipe paginated with the slide/curl effect instead of extending the highlight.

## Root cause

There are two independent swipe paths:

- **Push** and the **View-Transition slide** ride foliate's native swipe, which already bows out while `renderer.scrollLocked` is set (`startInstantAnnotating` sets it when the hold engages). ✅
- **Captured curl** (always) and **captured slide** (Tauri without full View-Transitions support) set the `no-swipe` attribute, so the native swipe is disabled and the app's own captured-turn touch interceptor (`useCapturedTurn.ts`) drives the turn. That interceptor started a page turn on any horizontal swipe **without** checking `scrollLocked`, so it turned the page during an instant-highlight drag. ❌

## Fix

Gate the captured-turn interceptor on `renderer.scrollLocked` before it begins a drag, mirroring the native swipe. Because a captured drag needs >15px of travel while the still-hold is cancelled at >10px, a drag can never already be in flight when the highlight engages, so gating at drag-start is sufficient.

`renderer.scrollLocked` was write-only in foliate, so this bumps the submodule to expose a getter (readest/foliate-js#51).

## Changes

- `packages/foliate-js` → readest/foliate-js#51 (`get scrollLocked()`).
- `useCapturedTurn.ts`: bow out of the captured turn when `renderer.scrollLocked` is set.
- `useCapturedTurn-scrollLock.test.ts`: regression test (a swipe starts the captured turn when unlocked; scroll-lock leaves the swipe to the highlight).

## Testing

- `pnpm test` — full suite green (7069 passed).
- `pnpm lint` — clean.
- Runtime verification of the touch gesture (native mobile Tauri curl/captured-slide) is covered by the unit test of the interceptor logic; the foliate getter is a trivial accessor already declared readable in `src/types/view.ts`.

> Depends on readest/foliate-js#51. The submodule pointer here targets that PR's branch commit; it should be re-pointed to the squashed/merged SHA once foliate#51 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)