### PR TITLE
fix: Sentry high-priority crash batch (autoscroll, TTS, MOBI, book-open, PDF links)

### DIFF
--- a/apps/readest-app/src-tauri/src/mobi_parser.rs
+++ b/apps/readest-app/src-tauri/src/mobi_parser.rs
@@ -120,9 +120,28 @@ fn extract_mobi_cover_full_sync(file_path: &str) -> Result<RawCoverImage, String
 ///      MOBI generators almost always place the cover first, and a
 ///      "wrong but plausible" thumbnail is better than no thumbnail.
 ///
-/// Returns `None` only when the file has no image records at all (rare
-/// for real Kindle content).
+/// Returns `None` when the file has no image records at all (rare for real
+/// Kindle content), or when parsing the (untrusted) file panics.
+///
+/// `mobi::Mobi::image_records()` slices raw record bytes and panics on a
+/// truncated / corrupt file whose PDB record offsets are inverted ("slice index
+/// starts at N but ends at M", READEST-1Q / READEST-10). Left unguarded, that
+/// panic unwinds out of the `spawn_blocking` task and fails the whole import, so
+/// contain it here: a bad cover yields no thumbnail instead of a failed import.
 fn extract_cover(mobi: &Mobi) -> Option<RawCoverImage> {
+    catch_cover_panic(|| extract_cover_inner(mobi))
+}
+
+/// Run cover extraction, converting a panic into `None`. Split out so the panic
+/// isolation is unit-testable without a malformed-MOBI fixture.
+fn catch_cover_panic<F>(f: F) -> Option<RawCoverImage>
+where
+    F: FnOnce() -> Option<RawCoverImage>,
+{
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).unwrap_or(None)
+}
+
+fn extract_cover_inner(mobi: &Mobi) -> Option<RawCoverImage> {
     let images = mobi.image_records();
     if images.is_empty() {
         return None;
@@ -202,6 +221,29 @@ fn sniff_image_mime(bytes: &[u8]) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn catch_cover_panic_swallows_a_slice_index_panic() {
+        // The exact shape the `mobi` crate raises on a corrupt file
+        // (READEST-1Q / READEST-10). Silence the backtrace for a clean test log.
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let cover =
+            catch_cover_panic(|| panic!("slice index starts at 3301038 but ends at 3300924"));
+        std::panic::set_hook(prev);
+        assert!(cover.is_none());
+    }
+
+    #[test]
+    fn catch_cover_panic_passes_through_a_cover() {
+        let cover = catch_cover_panic(|| {
+            Some(RawCoverImage {
+                bytes: vec![0xFF, 0xD8, 0xFF],
+                mime: "image/jpeg".to_string(),
+            })
+        });
+        assert_eq!(cover.map(|c| c.mime), Some("image/jpeg".to_string()));
+    }
 
     #[test]
     fn sniff_image_mime_jpeg() {

--- a/apps/readest-app/src/__tests__/document/fixed-layout-container-position.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-container-position.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+// Importing the module registers the <foliate-fxl> custom element.
+import 'foliate-js/fixed-layout.js';
+
+describe('fixed-layout containerPosition (READEST-11)', () => {
+  const FixedLayout = customElements.get('foliate-fxl');
+
+  it('registers the custom element', () => {
+    expect(FixedLayout).toBeTruthy();
+  });
+
+  it('exposes a writable containerPosition for scrolled fixed-layout autoscroll', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(FixedLayout!.prototype, 'containerPosition');
+    expect(typeof descriptor?.get).toBe('function');
+    // Auto Scroll / middle-click autoscroll do `renderer.containerPosition += delta`
+    // in scrolled mode. A getter-only property crashed on the write for PDF / CBZ /
+    // fixed-EPUB books in scrolled mode (READEST-11); the setter must exist.
+    expect(typeof descriptor?.set).toBe('function');
+  });
+});

--- a/apps/readest-app/src/__tests__/hooks/useBooksManager.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useBooksManager.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { eventDispatcher } from '@/utils/event';
+
+// initViewState rejects with "Book not found" when a library reload drops the
+// in-memory entry (readerStore). appendBook / openBookInReader call it
+// fire-and-forget, so the rejection surfaced as an unhandled rejection
+// (READEST-1V). The hook must catch it and surface a toast instead.
+const h = vi.hoisted(() => ({
+  initViewStateMock: vi.fn(() => Promise.resolve()),
+  setBookKeysMock: vi.fn(),
+  setSideBarBookKeyMock: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => ({ toString: () => '' }),
+}));
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {} }),
+}));
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: Object.assign(
+    () => ({ bookKeys: [], setBookKeys: h.setBookKeysMock, initViewState: h.initViewStateMock }),
+    { getState: () => ({ getView: () => null, setPreviewMode: vi.fn() }) },
+  ),
+}));
+vi.mock('@/store/sidebarStore', () => ({
+  useSidebarStore: () => ({ sideBarBookKey: null, setSideBarBookKey: h.setSideBarBookKeyMock }),
+}));
+vi.mock('@/store/parallelViewStore', () => ({
+  useParallelViewStore: () => ({ setParallel: vi.fn() }),
+}));
+vi.mock('@/utils/nav', () => ({ navigateToReader: vi.fn() }));
+
+import useBooksManager from '@/app/reader/hooks/useBooksManager';
+
+describe('useBooksManager open-failure handling', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('toasts instead of leaking an unhandled rejection when the book is missing (READEST-1V)', async () => {
+    h.initViewStateMock.mockReturnValueOnce(Promise.reject(new Error('Book not found')));
+    const dispatchSpy = vi.spyOn(eventDispatcher, 'dispatch');
+
+    const { result } = renderHook(() => useBooksManager());
+
+    await act(async () => {
+      result.current.appendBook('missing-hash', true, false);
+      // Flush the rejected initViewState microtask chain.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledWith('toast', expect.objectContaining({ type: 'error' }));
+    dispatchSpy.mockRestore();
+  });
+});

--- a/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
@@ -441,6 +441,10 @@ describe('useTTSControl handleHighlightMark cross-section navigation', () => {
     mockView.renderer.goTo.mockClear();
     mockView.goTo.mockClear();
     mockView.resolveCFI.mockReset();
+    // Reset renderer state a test may override (a throwing assertion can skip
+    // an inline restore, leaking into later tests).
+    mockView.renderer.getContents = () => [{ index: 0, doc: document as unknown as Document }];
+    mockView.renderer.scrolled = false;
     mockViewSettings.ttsLocation = null;
   });
 
@@ -497,6 +501,42 @@ describe('useTTSControl handleHighlightMark cross-section navigation', () => {
 
     expect(mockView.renderer.scrollToAnchor).toHaveBeenCalledTimes(1);
     expect(mockView.goTo).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when the renderer has no loaded contents (READEST-19)', async () => {
+    const handler = await setupAndCaptureHighlightHandler();
+    // getContents() can be empty mid-relocate (section still loading / view
+    // torn down); the mark handler must not destructure `doc` off undefined.
+    mockView.renderer.getContents = () => [];
+    mockView.resolveCFI.mockReturnValue({ index: 0, anchor: () => new Range() });
+
+    expect(() => {
+      handler(new CustomEvent('tts-highlight-mark', { detail: { cfi: 'epubcfi(/6/4!/4/2)' } }));
+    }).not.toThrow();
+  });
+
+  it('bails without scrolling when the cfi resolves to a null range (READEST-21)', async () => {
+    const handler = await setupAndCaptureHighlightHandler();
+    // In-section (index 0 == primaryIndex 0) so the follow-scroll path runs,
+    // but the anchor cannot resolve to a range in the doc.
+    mockView.resolveCFI.mockReturnValue({ index: 0, anchor: () => null });
+
+    expect(() => {
+      handler(new CustomEvent('tts-highlight-mark', { detail: { cfi: 'epubcfi(/6/4!/4/2)' } }));
+    }).not.toThrow();
+    // A null range must never reach scrollToAnchor (foliate reads
+    // range.startContainer inside it -> the READEST-21 crash).
+    expect(mockView.renderer.scrollToAnchor).not.toHaveBeenCalled();
+  });
+
+  it('does not throw in scrolled mode when the range is null (READEST-21)', async () => {
+    const handler = await setupAndCaptureHighlightHandler();
+    mockView.renderer.scrolled = true;
+    mockView.resolveCFI.mockReturnValue({ index: 0, anchor: () => null });
+
+    expect(() => {
+      handler(new CustomEvent('tts-highlight-mark', { detail: { cfi: 'epubcfi(/6/4!/4/2)' } }));
+    }).not.toThrow();
   });
 });
 

--- a/apps/readest-app/src/app/reader/hooks/useBooksManager.ts
+++ b/apps/readest-app/src/app/reader/hooks/useBooksManager.ts
@@ -7,10 +7,12 @@ import { uniqueId } from '@/utils/misc';
 import { useParallelViewStore } from '@/store/parallelViewStore';
 import { navigateToReader } from '@/utils/nav';
 import { eventDispatcher } from '@/utils/event';
+import { useTranslation } from '@/hooks/useTranslation';
 
 const useBooksManager = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const _ = useTranslation();
   const { envConfig } = useEnv();
   const { bookKeys } = useReaderStore();
   const { setBookKeys, initViewState } = useReaderStore();
@@ -29,10 +31,20 @@ const useBooksManager = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bookKeys, shouldUpdateSearchParams]);
 
+  // initViewState is called fire-and-forget here; it rejects when the book is
+  // missing (e.g. "Book not found" after a library reload dropped the in-memory
+  // entry). It already records the failure on the view state, so just keep the
+  // rejection from becoming an unhandled rejection (READEST-1V) and let the user
+  // know the open failed.
+  const handleOpenError = (error: unknown) => {
+    console.warn('Failed to open book in reader', error);
+    eventDispatcher.dispatch('toast', { message: _('Unable to open book'), type: 'error' });
+  };
+
   // Append a new book and sync with bookKeys and URL
   const appendBook = (id: string, isPrimary: boolean, isParallel: boolean) => {
     const newKey = `${id}-${uniqueId()}`;
-    initViewState(envConfig, id, newKey, isPrimary);
+    initViewState(envConfig, id, newKey, isPrimary).catch(handleOpenError);
     if (!bookKeys.includes(newKey)) {
       const updatedKeys = [...bookKeys, newKey];
       setBookKeys(updatedKeys);
@@ -84,7 +96,7 @@ const useBooksManager = () => {
       return;
     }
     const newKey = `${bookHash}-${uniqueId()}`;
-    initViewState(envConfig, bookHash, newKey, true);
+    initViewState(envConfig, bookHash, newKey, true).catch(handleOpenError);
     setBookKeys([newKey]);
     setSideBarBookKey(newKey);
     setShouldUpdateSearchParams(true);

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -327,8 +327,12 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
 
       const hlContents = view.renderer.getContents();
       const hlPrimaryIdx = view.renderer.primaryIndex;
-      const { doc, index: viewSectionIndex } = (hlContents.find((x) => x.index === hlPrimaryIdx) ??
-        hlContents[0]) as {
+      // getContents() is empty when the mark fires mid-relocate (the section is
+      // still loading, or the view was torn down). Bail instead of destructuring
+      // `doc` off undefined (READEST-19).
+      const hlContent = hlContents.find((x) => x.index === hlPrimaryIdx) ?? hlContents[0];
+      if (!hlContent) return;
+      const { doc, index: viewSectionIndex } = hlContent as {
         doc: Document;
         index?: number;
       };
@@ -360,6 +364,10 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
       }
 
       const range = anchor(doc);
+      // The cfi may not resolve to a range in this doc (stale/cross-realm doc,
+      // detached node). A null range would crash scrollToAnchor (foliate reads
+      // range.startContainer) or getBoundingClientRect below (READEST-21).
+      if (!range) return;
       if (!view.renderer.scrolled) {
         view.renderer.scrollToAnchor?.(range);
       } else {


### PR DESCRIPTION
Works through the high-priority Sentry backlog. Five 0.11.18 production crashes fixed, one commit per issue. All were live on the current release.

Depends on readest/foliate-js#52 (submodule bump for READEST-11 and READEST-2M).

## Fixes

### `fix(tts)`: guard highlight-follow against empty contents and null range (READEST-19, READEST-21)
`handleHighlightMark` runs as a synchronous `tts-highlight-mark` listener, so its throws escape `dispatchSpeakMark`'s try/catch to `window.onerror`. Two unguarded dereferences: an empty `getContents()` mid-relocate made `find(...) ?? [0]` undefined so destructuring `doc` threw (READEST-19), and `resolveCFI`'s `anchor(doc)` can return null, which then crashed foliate's `scrollToAnchor` (reads `range.startContainer`) or `getBoundingClientRect` in scrolled mode (READEST-21). Bail out early in both cases. READEST-21 was the highest-volume issue in the backlog (107 events).

### `fix(reader)`: handle book-open failures instead of leaking a rejection (READEST-1V)
`useBooksManager.appendBook` / `openBookInReader` call `initViewState` fire-and-forget. When the book is missing (`initViewState` rejects with "Book not found" after a library reload dropped the in-memory entry) the rejection had no handler. `ReaderContent` already catches its own call; mirror that here with a toast.

### `fix(reader)`: make autoscroll work on scrolled fixed-layout books (READEST-11)
Auto Scroll (#4999) and middle-click autoscroll (#4951) do `renderer.containerPosition += delta`, which crashed on `FixedLayout`'s getter-only `containerPosition` for PDF / CBZ / fixed-EPUB books read in scrolled mode. Bumps foliate-js so the setter exists (readest/foliate-js#52). Adds a regression test on the custom element.

### `fix(pdf)`: render PDF link annotations without crashing (READEST-2M)
PDFs with named-action / GoTo link annotations made pdf.js call `linkService.getAnchorUrl`, which the foliate stub did not implement. Bumps foliate-js to add it (readest/foliate-js#52).

### `fix(mobi)`: contain panics from the mobi crate when reading a cover (READEST-1Q, READEST-10)
`mobi::Mobi::image_records()` slices raw record bytes and panics on a truncated / corrupt file ("slice index starts at N but ends at M"). `extract_cover` ran it inside a `spawn_blocking` task, so the panic failed the whole import. Wrap in `catch_unwind` so a bad cover yields no thumbnail instead of a failed import. Note: Sentry's panic hook still captures the caught panic, so these issues may keep receiving (now benign) events until a targeted `before_send` drop is added.

## Not included
- **READEST-18** ("Window API not available on mobile"): deferred. No stack trace, and every reader-reachable `@tauri-apps/api/window` caller is already mobile-gated, so pinning the exact trigger needs source maps or Seer.

## Test plan
- `pnpm test` (7092 passed), `pnpm lint`, `pnpm fmt:check`, `pnpm clippy:check`, `pnpm test:rust` (77 passed) all green.
- New regression tests: TTS empty-contents / null-range guards, book-open failure toast, FixedLayout `containerPosition` setter, MOBI cover panic isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)