### PR TITLE
fix(transfer): stop the progress render storm (READEST-2, max update depth)

### DIFF
--- a/apps/readest-app/src/__tests__/store/transfer-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/transfer-store.test.ts
@@ -86,6 +86,17 @@ describe('transferStore', () => {
       useTransferStore.getState().updateTransferProgress(id, 50, 500, 1000, 100);
       expect(useTransferStore.getState().transfers).toBe(before);
     });
+
+    test('a speed-only change is a no-op (transferSpeed is time-derived) (READEST-2)', () => {
+      const id = useTransferStore.getState().addTransfer('h', 'B', 'upload');
+      useTransferStore.getState().updateTransferProgress(id, 50, 500, 1000, 100);
+      const before = useTransferStore.getState().transfers;
+      // transferSpeed is recomputed from wall-clock time on every emission, so it
+      // almost always differs; a speed-only delta (same progress + bytes) must
+      // not allocate a new state, or the no-op guard never fires.
+      useTransferStore.getState().updateTransferProgress(id, 50, 500, 1000, 173);
+      expect(useTransferStore.getState().transfers).toBe(before);
+    });
   });
 
   // ── setTransferStatus ────────────────────────────────────────────

--- a/apps/readest-app/src/__tests__/utils/transfer.test.ts
+++ b/apps/readest-app/src/__tests__/utils/transfer.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { webDownload, type ProgressPayload } from '@/utils/transfer';
+import { createProgressThrottle, webDownload, type ProgressPayload } from '@/utils/transfer';
 
 const buildResponse = (
   body: Uint8Array,
@@ -90,5 +90,63 @@ describe('webDownload', () => {
     globalThis.fetch = vi.fn(async () => buildResponse(bytes, null)) as unknown as typeof fetch;
     const result = await webDownload('https://example.test/file');
     expect(await result.blob.arrayBuffer()).toEqual(bytes.buffer);
+  });
+});
+
+describe('createProgressThrottle', () => {
+  const p = (progress: number, transferSpeed = progress): ProgressPayload => ({
+    progress,
+    total: 100,
+    transferSpeed,
+  });
+
+  test('coalesces a burst to a leading and a single trailing emission (READEST-2)', () => {
+    vi.useFakeTimers();
+    const emit = vi.fn();
+    const throttle = createProgressThrottle(emit, 100);
+
+    // A dense synchronous burst (as buffered stream chunks produce).
+    for (let i = 1; i <= 50; i++) throttle.push(p(i));
+
+    // Leading edge fires once with the first payload; the other 49 coalesce.
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenLastCalledWith(p(1));
+
+    // Trailing edge fires after the interval with the latest payload only.
+    vi.advanceTimersByTime(100);
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(emit).toHaveBeenLastCalledWith(p(50));
+
+    vi.useRealTimers();
+  });
+
+  test('flush emits the pending payload immediately', () => {
+    vi.useFakeTimers();
+    const emit = vi.fn();
+    const throttle = createProgressThrottle(emit, 100);
+    throttle.push(p(1)); // leading fires
+    throttle.push(p(2)); // throttled -> pending
+    emit.mockClear();
+
+    throttle.flush();
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenLastCalledWith(p(2));
+    vi.useRealTimers();
+  });
+
+  test('cancel drops the pending payload and its trailing timer', () => {
+    vi.useFakeTimers();
+    const emit = vi.fn();
+    const throttle = createProgressThrottle(emit, 100);
+    throttle.push(p(1)); // leading fires
+    throttle.push(p(2)); // throttled -> pending
+    emit.mockClear();
+
+    throttle.cancel();
+    vi.advanceTimersByTime(500);
+
+    expect(emit).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });

--- a/apps/readest-app/src/services/transferManager.ts
+++ b/apps/readest-app/src/services/transferManager.ts
@@ -4,12 +4,18 @@ import { useTransferStore, TransferItem, ReplicaTransferFile } from '@/store/tra
 import { useSettingsStore } from '@/store/settingsStore';
 import { isReadestCloudStorageActive } from '@/services/sync/cloudSyncProvider';
 import { TranslationFunc } from '@/hooks/useTranslation';
-import { ProgressHandler, ProgressPayload } from '@/utils/transfer';
+import { createProgressThrottle, ProgressHandler, ProgressPayload } from '@/utils/transfer';
 import { eventDispatcher } from '@/utils/event';
 import { getTransferMessages } from './transferMessages';
 
 const TRANSFER_QUEUE_KEY = 'readest_transfer_queue';
 const RETRY_DELAY_BASE_MS = 2000;
+// Coalesce per-chunk progress emissions to at most ~10/sec per transfer so the
+// transfer-store fan-out cannot sustain a synchronous React update storm (a
+// buffered download emits progress once per chunk in a microtask burst, and
+// transferSpeed changes every call so the store's no-op guard cannot help)
+// (Sentry READEST-2).
+const PROGRESS_THROTTLE_MS = 100;
 // Quota failures in a batch import arrive one per book as transfers drain;
 // collapse them into one summary toast per burst instead of N identical toasts.
 const QUOTA_TOAST_FLUSH_MS = 1500;
@@ -407,11 +413,8 @@ class TransferManager {
     store.setTransferStatus(transfer.id, 'in_progress');
     store.setActiveCount(store.getActiveTransfers().length + 1);
 
-    const progressHandler = (progress: ProgressPayload) => {
-      if (abortController.signal.aborted) return;
-
+    const progressThrottle = createProgressThrottle((progress) => {
       const percentage = progress.total > 0 ? (progress.progress / progress.total) * 100 : 0;
-
       useTransferStore
         .getState()
         .updateTransferProgress(
@@ -421,6 +424,11 @@ class TransferManager {
           progress.total,
           progress.transferSpeed,
         );
+    }, PROGRESS_THROTTLE_MS);
+
+    const progressHandler = (progress: ProgressPayload) => {
+      if (abortController.signal.aborted) return;
+      progressThrottle.push(progress);
     };
 
     try {
@@ -430,6 +438,8 @@ class TransferManager {
         await this.executeBookTransfer(transfer, progressHandler, abortController);
       }
 
+      // Land the final progress value that the throttle may still be holding.
+      progressThrottle.flush();
       useTransferStore.getState().setTransferStatus(transfer.id, 'completed');
 
       const messages = getTransferMessages(transfer, _);
@@ -492,6 +502,9 @@ class TransferManager {
         useTransferStore.getState().setTransferStatus(transfer.id, 'failed', errorMessage);
       }
     } finally {
+      // Drop any pending throttled progress + its trailing timer (a
+      // failed/aborted transfer's stale progress must not fire after teardown).
+      progressThrottle.cancel();
       this.abortControllers.delete(transfer.id);
 
       const currentStore = useTransferStore.getState();

--- a/apps/readest-app/src/store/transferStore.ts
+++ b/apps/readest-app/src/store/transferStore.ts
@@ -223,14 +223,18 @@ export const useTransferStore = create<TransferState>((set, get) => ({
       const transfer = state.transfers[transferId];
       if (!transfer) return state;
 
-      // No-op when nothing changed: re-applying identical progress would
-      // otherwise allocate a new state on every call and re-render every
-      // subscriber, which can sustain a render/update loop (Sentry READEST-2).
+      // No-op when nothing meaningful changed: re-applying identical progress
+      // would otherwise allocate a new state on every call and re-render every
+      // subscriber, sustaining a render/update loop (Sentry READEST-2).
+      // transferSpeed is deliberately excluded: it is recomputed from wall-clock
+      // time on every emission (utils/transfer.ts), so it is almost always
+      // different and would defeat the guard. A speed-only delta is not worth a
+      // re-render. The primary defense against high-frequency churn is the
+      // per-transfer coalescing in transferManager.
       if (
         transfer.progress === progress &&
         transfer.transferredBytes === transferred &&
-        transfer.totalBytes === total &&
-        transfer.transferSpeed === speed
+        transfer.totalBytes === total
       ) {
         return state;
       }

--- a/apps/readest-app/src/utils/transfer.ts
+++ b/apps/readest-app/src/utils/transfer.ts
@@ -15,6 +15,69 @@ export interface ProgressPayload {
 
 export type ProgressHandler = (progress: ProgressPayload) => void;
 
+export interface ProgressThrottle {
+  /** Record a progress payload, emitting at most once per interval. */
+  push: (progress: ProgressPayload) => void;
+  /** Emit any pending payload immediately (e.g. when the transfer finishes). */
+  flush: () => void;
+  /** Drop any pending payload and clear the trailing timer. */
+  cancel: () => void;
+}
+
+/**
+ * Coalesce high-frequency progress emissions to at most one per `intervalMs`
+ * (leading + trailing edges). Web and native download streams call onProgress
+ * once per chunk, often as a dense microtask burst for already-buffered sources
+ * (`while (true) { await reader.read(); onProgress(...) }`), and `transferSpeed`
+ * is recomputed from wall-clock time on every call. Emitting each one churns the
+ * transfer store per chunk and sustains a synchronous React update storm past
+ * the nested-update limit (Sentry READEST-2). Throttling caps store writes and
+ * defers the trailing emit to a macrotask, so the render fan-out cannot loop.
+ */
+export const createProgressThrottle = (
+  emit: (progress: ProgressPayload) => void,
+  intervalMs: number,
+): ProgressThrottle => {
+  let lastEmit = Number.NEGATIVE_INFINITY;
+  let pending: ProgressPayload | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const fire = () => {
+    timer = null;
+    if (!pending) return;
+    const payload = pending;
+    pending = null;
+    lastEmit = Date.now();
+    emit(payload);
+  };
+
+  return {
+    push: (progress) => {
+      pending = progress;
+      const elapsed = Date.now() - lastEmit;
+      if (elapsed >= intervalMs) {
+        fire();
+      } else if (timer === null) {
+        timer = setTimeout(fire, intervalMs - elapsed);
+      }
+    },
+    flush: () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      fire();
+    },
+    cancel: () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      pending = null;
+    },
+  };
+};
+
 export const webUpload = (file: File, uploadUrl: string, onProgress?: ProgressHandler) => {
   return new Promise<void>((resolve, reject) => {
     const startTime = Date.now();


### PR DESCRIPTION
READEST-2 ("Maximum update depth exceeded", 71 users) was still firing on 0.11.18 even though `updateTransferProgress` already had a no-op guard. Root cause: the guard compared `transferSpeed`, which `webDownload`/`webUpload` recompute from wall-clock time on every chunk, so it essentially never matched. Indeterminate downloads (R2/S3 signed URLs with no `Content-Length` -> `total=0`, new in 0.11.18) churn per chunk too. `webDownload` drains the body with `while (true) { await reader.read(); onProgress(...) }`, so a buffered source fires the whole burst in one macrotask; the transfer-store fan-out (the reader subscribes via `useTransferQueue`) then blows past React's nested-update limit.

## Fix
- **Coalesce progress at the single choke point.** New `createProgressThrottle` (leading + trailing, trailing edge on a macrotask) wraps every transfer's progress in `executeTransfer`, capping store writes at ~10/sec per transfer. Flush the final value on completion; cancel on teardown. This breaks the synchronous burst regardless of chunk rate or determinacy.
- **Fix the defeated guard.** Drop `transferSpeed` from the store's no-op equality (it is time-derived) so the guard can actually fire on duplicate/stalled progress.

## Test plan
- `pnpm test` (all pass) and `pnpm lint` green.
- New tests: throttle burst-coalescing / flush / cancel (fake timers); speed-only no-op in the store.
- No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)