### PR TITLE
fix: media-session teardown race + page_stat view migration idempotency

### DIFF
--- a/apps/readest-app/src/__tests__/services/tts-media-bridge.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-media-bridge.test.ts
@@ -5,6 +5,8 @@ vi.mock('@/utils/image', () => ({
 }));
 
 import { TTSMediaBridge } from '@/services/tts/ttsMediaBridge';
+import { fetchImageAsBase64 } from '@/utils/image';
+import { TauriMediaSession } from '@/libs/mediaSession';
 import type { TTSController } from '@/services/tts/TTSController';
 
 // A controller stand-in: EventTarget + the surface the bridge consumes.
@@ -163,5 +165,32 @@ describe('TTSMediaBridge', () => {
     // Metadata still reflects the last known chapter, no crash, no blanking.
     expect(first).toBeTruthy();
     expect(bridge.isBound).toBe(true);
+  });
+});
+
+describe('TTSMediaBridge bind teardown race (READEST-1A)', () => {
+  test('does not crash when unbound while the cover loads', async () => {
+    // A real TauriMediaSession instance so bind() takes the Tauri branch; its
+    // native methods are stubbed so nothing hits `invoke`.
+    const tauriSession = new TauriMediaSession();
+    tauriSession.setActive = vi.fn().mockResolvedValue(undefined);
+    tauriSession.updateMetadata = vi.fn().mockResolvedValue(undefined);
+    tauriSession.setActionHandler = vi.fn();
+
+    const bridge = new TTSMediaBridge(() => tauriSession);
+    const controller = new FakeController();
+
+    // Tear the session down mid-flight, exactly like a stop during startup:
+    // #mediaSession becomes null before the awaited setActive/updateMetadata.
+    vi.mocked(fetchImageAsBase64).mockImplementationOnce(async () => {
+      bridge.unbind();
+      return 'data:image/png;base64,x';
+    });
+
+    await expect(
+      bridge.bind(controller as unknown as TTSController, meta({ coverImageUrl: 'cover.png' })),
+    ).resolves.toBeUndefined();
+    // The bind aborted after teardown; no handlers were wired on a dead session.
+    expect(bridge.isBound).toBe(false);
   });
 });

--- a/apps/readest-app/src/__tests__/statistics/statisticsDb.test.ts
+++ b/apps/readest-app/src/__tests__/statistics/statisticsDb.test.ts
@@ -32,6 +32,22 @@ describe('statistics migration', () => {
     expect(names).toContain('readest_stat_sync_state');
   });
 
+  it('is idempotent when the page_stat view already exists (READEST-13)', async () => {
+    // A DB imported from KOReader (or left by a partially-applied migration)
+    // already has a page_stat view but no migration record. turso ignores
+    // IF NOT EXISTS on CREATE VIEW, so a non-idempotent migration throws
+    // "View page_stat already exists" here.
+    const imported = await NodeDatabaseService.open(':memory:');
+    await imported.execute('CREATE VIEW page_stat AS SELECT 1 AS x');
+
+    await expect(migrate(imported, getMigrations('statistics'))).resolves.toBeUndefined();
+
+    const views = await imported.select<{ name: string }>(
+      `SELECT name FROM sqlite_master WHERE type = 'view'`,
+    );
+    expect(views.map((v) => v.name)).toContain('page_stat');
+  });
+
   it('seeds the numbers helper table 1..1000', async () => {
     const rows = await db.select<{ c: number }>(`SELECT COUNT(*) AS c FROM numbers`);
     expect(rows[0]!.c).toBe(1000);

--- a/apps/readest-app/src/services/database/migrations/index.ts
+++ b/apps/readest-app/src/services/database/migrations/index.ts
@@ -83,7 +83,13 @@ const migrations: Record<SchemaType, MigrationEntry[]> = {
                (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) t,
                (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) h;
 
-        CREATE VIEW IF NOT EXISTS page_stat AS
+        -- turso ignores IF NOT EXISTS on CREATE VIEW (READEST-13), so a plain
+        -- CREATE VIEW IF NOT EXISTS still throws "already exists" when the view
+        -- is present (KOReader-imported stats DB, or a partially-applied run).
+        -- DROP first (turso honors DROP VIEW IF EXISTS) to stay idempotent.
+        DROP VIEW IF EXISTS page_stat;
+
+        CREATE VIEW page_stat AS
           SELECT id_book, first_page + idx - 1 AS page, start_time, duration / (last_page - first_page + 1) AS duration
           FROM (
             SELECT id_book, page, total_pages, pages, start_time, duration,

--- a/apps/readest-app/src/services/tts/ttsMediaBridge.ts
+++ b/apps/readest-app/src/services/tts/ttsMediaBridge.ts
@@ -107,8 +107,13 @@ export class TTSMediaBridge {
     this.#meta = meta;
     this.#mediaSession = this.#resolveMediaSession();
     if (!this.#mediaSession) return;
+    // bind() awaits below (cover fetch, setActive), during which a concurrent
+    // unbind() (e.g. a stop during startup) nulls #mediaSession. Use the
+    // captured session for the awaited calls so they can't deref null, then
+    // bail before wiring handlers onto a torn-down session (READEST-1A).
+    const mediaSession = this.#mediaSession;
 
-    if (this.#mediaSession instanceof TauriMediaSession) {
+    if (mediaSession instanceof TauriMediaSession) {
       let artwork = '/icon.png';
       try {
         artwork = await fetchImageAsBase64(meta.coverImageUrl || '/icon.png');
@@ -119,14 +124,16 @@ export class TTSMediaBridge {
           artwork = '';
         }
       }
-      await this.#mediaSession.setActive({ active: true });
-      await this.#mediaSession.updateMetadata({
+      await mediaSession.setActive({ active: true });
+      await mediaSession.updateMetadata({
         title: meta.title,
         artist: meta.author,
         album: meta.title,
         artwork,
       });
     }
+
+    if (this.#mediaSession !== mediaSession) return;
 
     this.#registerActionHandlers();
 


### PR DESCRIPTION
Two more high-priority Sentry crashes, both live on 0.11.18.

## `fix(tts)`: media session teardown race (READEST-1A, 6 users)
`TTSMediaBridge.bind()` resolves `#mediaSession`, then `await`s the cover fetch and `setActive`. A concurrent `unbind()` (a stop during startup) nulls `#mediaSession` mid-flight, so `this.#mediaSession.setActive` / `.updateMetadata` threw `Cannot read properties of null`. Capture the session in a local for the awaited calls, and bail before wiring action handlers if it was torn down. Regression test forces the Tauri branch with a mid-fetch `unbind()`.

## `fix(stats)`: page_stat view migration idempotency (READEST-13, 9 users)
`Parse error: View page_stat already exists`. The migration already uses `CREATE VIEW IF NOT EXISTS`, but the `@readest/turso` fork **discards the `if_not_exists` flag for views** (`core/schema.rs`), so it still throws when the view is present — a KOReader-imported statistics DB, or a partially-applied migration re-running. `DROP VIEW IF EXISTS` first (turso *does* honor that) so the migration is idempotent. Editing the existing migration only affects DBs that haven't applied it (version-tracked DBs fast-path skip). Regression test reproduces the exact error against the real libsql node backend.

## Test plan
- `pnpm test` (7099 passed) and `pnpm lint` green.
- New tests: media-bridge teardown race; real-turso page_stat idempotency.
- No Rust touched. (A proper turso fix for `CREATE VIEW IF NOT EXISTS` is a separate fork change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)