### PR TITLE
fix(reader): guard foliate paginator null-document crashes (READEST-1H, 2X)

### DIFF
--- a/apps/readest-app/src/__tests__/document/foliate-paginator-null-guards.test.ts
+++ b/apps/readest-app/src/__tests__/document/foliate-paginator-null-guards.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getDirection } from 'foliate-js/paginator.js';
+
+// A view's iframe document is blank/detached while a section loads or the view
+// is torn down: body is null, and getComputedStyle(null) throws
+// "parameter 1 is not of type 'Element'" (READEST-2X).
+describe('getDirection null-document guard (READEST-2X)', () => {
+  it('falls back to horizontal-ltr instead of calling getComputedStyle(null)', () => {
+    const getComputedStyle = vi.fn((el: Element | null) => {
+      if (!el) {
+        throw new TypeError(
+          "Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.",
+        );
+      }
+      return { writingMode: 'horizontal-tb', direction: 'ltr' } as CSSStyleDeclaration;
+    });
+    const doc = {
+      defaultView: { getComputedStyle },
+      body: null,
+      documentElement: { dir: '' },
+    } as unknown as Document;
+
+    expect(() => getDirection(doc)).not.toThrow();
+    expect(getDirection(doc)).toEqual({ vertical: false, rtl: false });
+    expect(getComputedStyle).not.toHaveBeenCalled();
+  });
+
+  it('still reads the writing mode from a present body', () => {
+    const getComputedStyle = vi.fn(() => ({ writingMode: 'vertical-rl', direction: 'ltr' }));
+    const doc = {
+      defaultView: { getComputedStyle },
+      body: { dir: '', querySelector: () => null },
+      documentElement: { dir: '' },
+    } as unknown as Document;
+
+    expect(getDirection(doc)).toEqual({ vertical: true, rtl: true });
+  });
+});


### PR DESCRIPTION
Two foliate paginator render/load crashes, both live on 0.11.18. Depends on readest/foliate-js#53 (submodule bump).

## READEST-1H (11 users, escalating) — `Cannot destructure property 'style' of null`
`columnize` calls `setStyles`/`setStylesImportant(doc.documentElement, ...)`, but the view's document is blank/detached mid-render/teardown, so `documentElement` is null and destructuring `{ style }` throws. Guarded to no-op on a null element.

## READEST-2X (4 users, escalating) — `getComputedStyle: parameter 1 is not of type 'Element'`
`getDirection`/`getBackground` call `getComputedStyle(doc.body)` on iframe load, but `body` is null on a blank/detached document. Fall back to horizontal-ltr / empty background. `getDirection` is exported, so a jsdom regression test covers it.

## Test plan
- `pnpm test` (7101 passed), `pnpm lint` green.
- New test: `getDirection` returns horizontal-ltr and never calls `getComputedStyle(null)` when the document has no body (verified to fail without the guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)