### PR TITLE
fix(reader): guard applyMarginAndGap against a torn-down view (READEST-2V)

### DIFF
--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -779,7 +779,12 @@ const FoliateViewer: React.FC<{
   }, []);
 
   const applyMarginAndGap = () => {
-    const viewSettings = getViewSettings(bookKey)!;
+    // Invoked from effects/observers that can fire after the book is torn down,
+    // when getViewSettings(bookKey) returns null. The `!` assertion hid that, so
+    // the reads below (getViewInsets, viewSettings.showHeader) crashed on null
+    // (READEST-2V). Bail: there is no view left to lay out.
+    const viewSettings = getViewSettings(bookKey);
+    if (!viewSettings) return;
     const viewState = getViewState(bookKey);
     const bookData = getBookData(bookKey);
     const viewInsets = getViewInsets(viewSettings);


### PR DESCRIPTION
`applyMarginAndGap` re-fetches `getViewSettings(bookKey)` with a non-null assertion (`!`), but it runs from effects/observers that can fire after the book is torn down, when `getViewSettings` returns null. The `!` hid that, so `getViewInsets` / `viewSettings.showHeader` threw `Cannot read properties of null (reading 'showHeader')` (READEST-2V, 3 users). Bail when there's no view left to lay out.

## Test plan
- `pnpm test` (7099 passed) and `pnpm lint` (tsgo + biome) green.
- No bespoke test: `applyMarginAndGap` is an internal function of a large component and isn't exported; the change is a defensive removal of a non-null assertion Sentry proves wrong. Covered against regression by the full suite + type check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)