### PR TITLE
chore: add zed-editor support

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,103 @@
+{
+  "languages": {
+    "Rust": {
+      "language_servers": ["rust-analyzer"]
+    },
+    "JavaScript": {
+      "language_servers": ["biome", "...", "!eslint"],
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    },
+    "TypeScript": {
+      "language_servers": ["biome", "...", "!eslint"],
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    },
+    "TSX": {
+      "language_servers": ["biome", "...", "!eslint"],
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      },
+      "code_actions_on_format": {
+        "source.fixAll.biome": true,
+        "source.organizeImports.biome": true
+      }
+    },
+    "CSS": {
+      "language_servers": ["biome", "...", "!eslint"],
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      }
+    },
+    "JSON": {
+      "language_servers": ["biome", "..."],
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      }
+    },
+    "JSONC": {
+      "language_servers": ["biome", "..."],
+      "formatter": {
+        "language_server": {
+          "name": "biome"
+        }
+      }
+    }
+  },
+  "lsp": {
+    "rust-analyzer": {
+      "settings": {
+        "linkedProjects": ["packages/tauri/Cargo.toml", "apps/readest-app/src-tauri/Cargo.toml"]
+      }
+    },
+    "biome": {
+      "binary": {
+        "path": "node_modules/.bin/biome",
+        "arguments": ["lsp-proxy"]
+      }
+    },
+    "vtsls": {
+      "settings": {
+        "typescript": {
+          "inlayHints": {
+            "parameterNames": {
+              "enabled": "all"
+            },
+            "variableTypes": {
+              "enabled": true
+            },
+            "propertyDeclarationTypes": {
+              "enabled": true
+            },
+            "functionLikeReturnTypes": {
+              "enabled": true
+            },
+            "enumMemberValues": {
+              "enabled": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,12 +137,20 @@ This project is a monorepo. The code for the `readest-app` is in the `apps/reade
 | `pnpm dev-web`   | Starts the development server for the web app only |
 | `pnpm build-web` | Builds the web app                                 |
 
-Recommended Visual Studio Code plugins for development:
+### Editor-specific setup
 
-- JavaScript and TypeScript Nightly (ms-vscode.vscode-typescript-next)
-- VS Code ESLint extension (dbaeumer.vscode-eslint)
-- Biome - Code formatter and linter (biomejs.biome)
-- rust-analyzer (rust-lang.rust-analyzer) (for Tauri development only)
+#### VS Code
+
+Upon opening the project, you will be prompted to install the following recommended extensions:
+
+- JavaScript and TypeScript Nightly (`ms-vscode.vscode-typescript-next`)
+- VS Code ESLint extension (`dbaeumer.vscode-eslint`)
+- Biome - Code formatter and linter (`biomejs.biome`)
+- rust-analyzer (`rust-lang.rust-analyzer`) (for Tauri development only)
+
+#### Zed
+
+The only extension needed is [biome-zed](https://github.com/biomejs/biome-zed), for code formatting and linting.
 
 ### When you're done
 


### PR DESCRIPTION
Add instructions for setting up zed with this project, along with an (almost) one-to-one mapping of `.vscode/settings.json` to `.zed/settings.json`. 