### PR TITLE
fix(android): remove Android Auto opt-in from manifest to unblock Play review

### DIFF
--- a/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -23,12 +23,6 @@
         android:hardwareAccelerated="true"
         android:usesCleartextTraffic="${usesCleartextTraffic}">
 
-        <!-- Android Auto: advertise the media capability so the Readest icon
-             shows up in the car launcher and projects the TTS media session. -->
-        <meta-data
-            android:name="com.google.android.gms.car.application"
-            android:resource="@xml/automotive_app_desc" />
-
         <!-- Sentry auto-init (ContentProvider). Empty DSN => disabled. Release
              is auto-detected from versionName; performance and PII stay at
              their safe off/false defaults. -->

--- a/apps/readest-app/src/__tests__/android/android-auto-declarations.test.ts
+++ b/apps/readest-app/src/__tests__/android/android-auto-declarations.test.ts
@@ -9,6 +9,14 @@ import { resolve } from 'path';
  * automotive descriptor that declares the `media` capability. Android Auto
  * then connects to the exported MediaBrowserService
  * (com.readest.native_tts.MediaPlaybackService) to drive TTS playback.
+ *
+ * TEMPORARILY WITHDRAWN: Google Play rejected the release in Android Auto
+ * review because the Auto TTS flow still has a bug. The car meta-data is the
+ * sole signal Play uses to detect Auto support, so it is removed from the
+ * manifest until the bug is fixed. The automotive descriptor and the
+ * MediaBrowserService stay: the descriptor makes re-enabling a one-line
+ * revert, and the service powers the phone lock-screen and background TTS
+ * media session.
  */
 
 const manifest = readFileSync(
@@ -17,12 +25,12 @@ const manifest = readFileSync(
 );
 
 describe('Android Auto declarations (#3919)', () => {
-  it('declares the car application meta-data pointing at the automotive descriptor', () => {
-    expect(manifest).toContain('com.google.android.gms.car.application');
-    expect(manifest).toContain('@xml/automotive_app_desc');
+  it('withholds the car application meta-data until the Auto TTS bug is fixed', () => {
+    expect(manifest).not.toContain('com.google.android.gms.car.application');
+    expect(manifest).not.toContain('@xml/automotive_app_desc');
   });
 
-  it('ships an automotive descriptor with the media capability', () => {
+  it('keeps the automotive descriptor with the media capability for re-enabling', () => {
     const desc = readFileSync(
       resolve(process.cwd(), 'src-tauri/gen/android/app/src/main/res/xml/automotive_app_desc.xml'),
       'utf-8',


### PR DESCRIPTION
## Summary

Google Play rejected the latest Android release in Android Auto review because the Auto TTS integration (#3919, added in #4907) still has a bug. The bug is being fixed separately; this PR withdraws the Android Auto opt-in so the release can be resubmitted through normal review now.

- Remove the `com.google.android.gms.car.application` meta-data from `AndroidManifest.xml`. This meta-data is the sole signal Play uses to detect Android Auto support, so removing it takes the app out of the Auto review track and out of the car launcher.
- Keep the `MediaBrowserService` intent-filter on `com.readest.native_tts.MediaPlaybackService` and the `MediaButtonReceiver`: they power the phone lock-screen and background TTS media session and do not trigger Auto detection by themselves.
- Keep `res/xml/automotive_app_desc.xml` (now unreferenced but harmless) so re-enabling the feature after the bug fix is a one-line revert of the meta-data.
- Update `android-auto-declarations.test.ts` to assert the car meta-data is withheld while still checking the descriptor and MediaBrowserService remain in place.

## Test plan

- [x] `pnpm test` passes (7105 tests), including the updated Android Auto declarations test
- [x] Manifest validated as well-formed XML with no remaining car/automotive references
- [x] Rebuild the Play release bundle and confirm the Play Console no longer lists Android Auto as a supported feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)