### PR TITLE
feat(sync): sync S3 config + credentials cross-device, fix backup leak of device-local fields

### DIFF
--- a/apps/readest-app/src/__tests__/services/sync/adapters/settings.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/adapters/settings.test.ts
@@ -125,7 +125,43 @@ describe('settingsAdapter', () => {
     expect(out.patch.globalReadSettings?.userHighlightColors).toEqual(userColors);
   });
 
-  test('declares encryptedFields covering kosync / readwise / hardcover / webdav credentials only (not serverUrl)', () => {
+  test('pack ∘ unpack round-trips S3 connection fields, dropping per-device state', () => {
+    const record: SettingsRemoteRecord = {
+      name: 'singleton',
+      patch: {
+        s3: {
+          enabled: true,
+          endpoint: 'https://acc.r2.cloudflarestorage.com',
+          region: 'auto',
+          bucket: 'readest',
+          accessKeyId: 'AKIA',
+          secretAccessKey: 'shh',
+          deviceId: 'this-device',
+          lastSyncedAt: 123,
+          providerSelectedAt: 456,
+        },
+      } as unknown as Partial<SystemSettings>,
+    };
+    const fields = settingsAdapter.pack(record);
+    expect(fields['s3.endpoint']).toBe('https://acc.r2.cloudflarestorage.com');
+    expect(fields['s3.region']).toBe('auto');
+    expect(fields['s3.bucket']).toBe('readest');
+    expect(fields['s3.accessKeyId']).toBe('AKIA');
+    expect(fields['s3.secretAccessKey']).toBe('shh');
+    // Per-device bookkeeping must not ship.
+    expect(fields['s3.enabled']).toBeUndefined();
+    expect(fields['s3.deviceId']).toBeUndefined();
+    expect(fields['s3.lastSyncedAt']).toBeUndefined();
+    expect(fields['s3.providerSelectedAt']).toBeUndefined();
+
+    const out = settingsAdapter.unpack(fields);
+    expect(out.patch.s3?.endpoint).toBe('https://acc.r2.cloudflarestorage.com');
+    expect(out.patch.s3?.accessKeyId).toBe('AKIA');
+    expect(out.patch.s3?.secretAccessKey).toBe('shh');
+    expect(out.patch.s3?.enabled).toBeUndefined();
+  });
+
+  test('declares encryptedFields covering kosync / readwise / hardcover / webdav / s3 credentials only (not serverUrl / endpoint)', () => {
     expect(settingsAdapter.encryptedFields).toEqual([
       'kosync.username',
       'kosync.userkey',
@@ -134,6 +170,8 @@ describe('settingsAdapter', () => {
       'hardcover.accessToken',
       'webdav.username',
       'webdav.password',
+      's3.accessKeyId',
+      's3.secretAccessKey',
     ]);
   });
 
@@ -144,6 +182,12 @@ describe('settingsAdapter', () => {
   test('webdav.serverUrl and webdav.rootPath are plaintext (not in encryptedFields)', () => {
     expect(settingsAdapter.encryptedFields).not.toContain('webdav.serverUrl');
     expect(settingsAdapter.encryptedFields).not.toContain('webdav.rootPath');
+  });
+
+  test('s3.endpoint / region / bucket are plaintext (not in encryptedFields)', () => {
+    expect(settingsAdapter.encryptedFields).not.toContain('s3.endpoint');
+    expect(settingsAdapter.encryptedFields).not.toContain('s3.region');
+    expect(settingsAdapter.encryptedFields).not.toContain('s3.bucket');
   });
 
   test('unpackRow reconstructs the patch from CRDT envelopes', () => {
@@ -183,6 +227,17 @@ describe('SETTINGS_WHITELIST', () => {
     expect(SETTINGS_WHITELIST).toContain('dictionarySettings.webSearches');
     // Dictionary popup font size (#4443) follows the user across devices.
     expect(SETTINGS_WHITELIST).toContain('dictionarySettings.fontScale');
+  });
+
+  test('includes the S3 connection fields but not its per-device bookkeeping', () => {
+    expect(SETTINGS_WHITELIST).toContain('s3.endpoint');
+    expect(SETTINGS_WHITELIST).toContain('s3.region');
+    expect(SETTINGS_WHITELIST).toContain('s3.bucket');
+    expect(SETTINGS_WHITELIST).toContain('s3.accessKeyId');
+    expect(SETTINGS_WHITELIST).toContain('s3.secretAccessKey');
+    expect(SETTINGS_WHITELIST).not.toContain('s3.enabled');
+    expect(SETTINGS_WHITELIST).not.toContain('s3.deviceId');
+    expect(SETTINGS_WHITELIST).not.toContain('s3.providerSelectedAt');
   });
 
   test('does NOT sync dictionarySettings.defaultProviderId (per-device last-used tab)', () => {

--- a/apps/readest-app/src/__tests__/services/sync/replicaSettingsSync.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/replicaSettingsSync.test.ts
@@ -362,6 +362,52 @@ describe('publishSettingsIfChanged', () => {
       expect(patch.webdav?.rootPath).toBe('/Books');
     });
 
+    test('omits S3 credentials but keeps endpoint/region/bucket when credentials sync is OFF', async () => {
+      await setCredentials(undefined); // default OFF
+      isUnlocked = false;
+      await publishSettingsIfChanged(
+        makeSettings({
+          s3: {
+            endpoint: 'https://acc.r2.cloudflarestorage.com',
+            region: 'auto',
+            bucket: 'readest',
+            accessKeyId: 'AKIA',
+            secretAccessKey: 'shh',
+          } as SystemSettings['s3'],
+        }),
+      );
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      const patch = publishMock.mock.calls[0]![1].patch as Partial<SystemSettings>;
+      // Plaintext connection metadata still ships.
+      expect(patch.s3?.endpoint).toBe('https://acc.r2.cloudflarestorage.com');
+      expect(patch.s3?.region).toBe('auto');
+      expect(patch.s3?.bucket).toBe('readest');
+      // Access keys are gated off.
+      expect(patch.s3?.accessKeyId).toBeUndefined();
+      expect(patch.s3?.secretAccessKey).toBeUndefined();
+    });
+
+    test('publishes S3 credentials when credentials sync is ON', async () => {
+      await setCredentials(true);
+      isUnlocked = true;
+      await publishSettingsIfChanged(
+        makeSettings({
+          s3: {
+            endpoint: 'https://acc.r2.cloudflarestorage.com',
+            region: 'auto',
+            bucket: 'readest',
+            accessKeyId: 'AKIA',
+            secretAccessKey: 'shh',
+          } as SystemSettings['s3'],
+        }),
+      );
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      const patch = publishMock.mock.calls[0]![1].patch as Partial<SystemSettings>;
+      expect(patch.s3?.endpoint).toBe('https://acc.r2.cloudflarestorage.com');
+      expect(patch.s3?.accessKeyId).toBe('AKIA');
+      expect(patch.s3?.secretAccessKey).toBe('shh');
+    });
+
     test('skipping all of the only-credential changes is a clean no-op (no empty publish)', async () => {
       await setCredentials(undefined);
       isUnlocked = false;
@@ -611,6 +657,51 @@ describe('applyRemoteSettings', () => {
     expect(merged.enabled).toBe(true);
     expect(merged.deviceId).toBe('this-device');
     expect(merged.lastSyncedAt).toBe(999);
+    expect(merged.syncBooks).toBe(true);
+  });
+
+  test('deep-merges S3 credentials without clobbering local per-device fields', () => {
+    const env = makeEnvConfig();
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      settings: makeSettings({
+        s3: {
+          enabled: true,
+          endpoint: 'https://old.r2.cloudflarestorage.com',
+          region: 'auto',
+          bucket: 'old-bucket',
+          accessKeyId: 'OLD',
+          secretAccessKey: 'old-secret',
+          deviceId: 'this-device',
+          lastSyncedAt: 999,
+          providerSelectedAt: 111,
+          syncBooks: true,
+        } as unknown as SystemSettings['s3'],
+      }),
+    });
+    applyRemoteSettings(env, {
+      name: 'singleton',
+      patch: {
+        s3: {
+          endpoint: 'https://acc.r2.cloudflarestorage.com',
+          region: 'auto',
+          bucket: 'readest',
+          accessKeyId: 'AKIA',
+          secretAccessKey: 'shh',
+        },
+      } as unknown as Partial<SystemSettings>,
+    });
+    const merged = useSettingsStore.getState().settings.s3;
+    // Synced connection fields are applied.
+    expect(merged.endpoint).toBe('https://acc.r2.cloudflarestorage.com');
+    expect(merged.bucket).toBe('readest');
+    expect(merged.accessKeyId).toBe('AKIA');
+    expect(merged.secretAccessKey).toBe('shh');
+    // Per-device fields the remote patch omits must survive the merge.
+    expect(merged.enabled).toBe(true);
+    expect(merged.deviceId).toBe('this-device');
+    expect(merged.lastSyncedAt).toBe(999);
+    expect(merged.providerSelectedAt).toBe(111);
     expect(merged.syncBooks).toBe(true);
   });
 

--- a/apps/readest-app/src/services/backupService.ts
+++ b/apps/readest-app/src/services/backupService.ts
@@ -58,6 +58,9 @@ export const BACKUP_SETTINGS_BLACKLIST = [
   'onedrive.deviceId',
   'onedrive.lastSyncedAt',
   'onedrive.providerSelectedAt',
+  's3.deviceId',
+  's3.lastSyncedAt',
+  's3.providerSelectedAt',
   // Transient runtime state — book keys may not exist post-restore; screen
   // brightness is live device state.
   'lastOpenBooks',
@@ -79,6 +82,10 @@ export const BACKUP_SETTINGS_CREDENTIAL_FIELDS = [
   'kosync.password',
   'readwise.accessToken',
   'hardcover.accessToken',
+  // S3 access keys are strong, long-lived cloud credentials — strip them from
+  // unencrypted backup zips unless the user opts into including credentials.
+  's3.accessKeyId',
+  's3.secretAccessKey',
   'aiSettings.aiGatewayApiKey',
   'aiSettings.openrouterApiKey',
 ] as const;

--- a/apps/readest-app/src/services/sync/adapters/settings.ts
+++ b/apps/readest-app/src/services/sync/adapters/settings.ts
@@ -69,6 +69,16 @@ export const SETTINGS_WHITELIST = [
   'webdav.username',
   'webdav.password',
   'webdav.rootPath',
+  // S3-compatible object store. endpoint / region / bucket sync as plaintext so
+  // a fresh device pre-fills the connect form; accessKeyId / secretAccessKey are
+  // listed in `encryptedFields` below. Per-device bookkeeping (enabled,
+  // deviceId, lastSyncedAt, providerSelectedAt, sync sub-toggles) is
+  // deliberately excluded — mirrors WebDAV.
+  's3.endpoint',
+  's3.region',
+  's3.bucket',
+  's3.accessKeyId',
+  's3.secretAccessKey',
 ] as const;
 
 /**
@@ -92,6 +102,8 @@ export const SETTINGS_ENCRYPTED_FIELDS = [
   'hardcover.accessToken',
   'webdav.username',
   'webdav.password',
+  's3.accessKeyId',
+  's3.secretAccessKey',
 ] as const;
 
 export type SettingsWhitelistKey = (typeof SETTINGS_WHITELIST)[number];

--- a/apps/readest-app/src/services/sync/replicaSettingsSync.ts
+++ b/apps/readest-app/src/services/sync/replicaSettingsSync.ts
@@ -379,6 +379,14 @@ const mergeSettings = (current: SystemSettings, patch: Partial<SystemSettings>):
     // preserves them when the remote updates the synced connection fields.
     out.webdav = { ...current.webdav, ...patch.webdav };
   }
+  if (patch.s3) {
+    // Only endpoint / region / bucket / accessKeyId / secretAccessKey are
+    // whitelisted, so the remote patch never carries the per-device fields
+    // (enabled, deviceId, lastSyncedAt, providerSelectedAt, sub-toggles).
+    // Spread-with-current preserves them when the remote updates the synced
+    // connection fields.
+    out.s3 = { ...current.s3, ...patch.s3 };
+  }
   if (patch.dictionarySettings) {
     // `defaultProviderId` (last-used tab) is per-device — not in the
     // whitelist, so the remote patch never sends it. Spread-with-current


### PR DESCRIPTION
Wires the S3-compatible object store into cross-device settings sync, and stops its device-local fields from leaking through backups. Follow-up to the OneDrive review (#5048).

Until now, S3 config + credentials never synced across devices: S3 was absent from every cross-device sync list, so a user had to re-enter their endpoint/bucket/keys on each device.

## What changed

**Cross-device credential sync (mirrors WebDAV, #4810)** in `src/services/sync/adapters/settings.ts`:
- Whitelist `s3.endpoint/region/bucket/accessKeyId/secretAccessKey` in the settings replica.
- Encrypt `s3.accessKeyId/secretAccessKey` (they ride the same opt-in `credentials` sync toggle + `CryptoSession` as `webdav.password`; endpoint/region/bucket stay plaintext so a fresh device pre-fills the connect form).
- Per-device bookkeeping (`enabled`, `deviceId`, `lastSyncedAt`, `providerSelectedAt`, sub-toggles) is deliberately excluded, so it stays device-local exactly like WebDAV.

**Clobber guard** in `src/services/sync/replicaSettingsSync.ts`: added the `if (patch.s3)` deep-merge in `mergeSettings`. Without it, the top-level shallow merge would replace the whole `s3` object with only the synced subfields on every pull, wiping the device's `enabled`/`deviceId`/sub-toggles (the #4810 trap). Guarded by a regression test.

**Backup handling** in `src/services/backupService.ts`:
- Add `s3.deviceId/lastSyncedAt/providerSelectedAt` to `BACKUP_SETTINGS_BLACKLIST` (the follow-up flagged in the OneDrive review; these device-local fields were leaking into cross-device backup restore).
- Add `s3.accessKeyId/secretAccessKey` to `BACKUP_SETTINGS_CREDENTIAL_FIELDS` so strong long-lived cloud keys are stripped from unencrypted backup zips unless the user opts into including credentials.

## Testing
- New/updated tests: S3 pack round-trip (drops per-device state), encrypted-fields declaration, plaintext config fields, credentials-toggle gate ON/OFF, and the deep-merge clobber guard.
- Full sync suite green (655 tests), Biome + tsgo clean.

## Notes / follow-ups
- The `credentials` sync-category description (`SyncCategoriesSection.tsx`) still enumerates "...WebDAV" without S3. Updating that copy triggers a 33-locale i18n key migration, so I left it out of this PR (the toggle covers S3 functionally regardless); worth a tiny copy + i18n follow-up.
- Parity note: `webdav.username/password` are NOT in `BACKUP_SETTINGS_CREDENTIAL_FIELDS`, so WebDAV creds still land in unencrypted backup zips. This PR treats S3 keys more strictly (they are higher-value); bringing WebDAV in line is a separate, deliberate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
