### PR TITLE
feat(tts): make inter-sentence and inter-paragraph gaps configurable

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2038,5 +2038,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "زامن مكتبتك وتقدم القراءة والتمييزات مع Microsoft OneDrive الخاص بك.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "عند اختيار {{provider}}، تتم مزامنة الكتب والتقدم والتعليقات التوضيحية إلى OneDrive الخاص بك فقط.",
   "Readest only accesses the files it creates in your OneDrive.": "لا يصل Readest إلا إلى الملفات التي ينشئها في OneDrive الخاص بك.",
-  ". Make OneDrive the active cloud provider.": ". اجعل OneDrive مزود السحابة النشط."
+  ". Make OneDrive the active cloud provider.": ". اجعل OneDrive مزود السحابة النشط.",
+  "Sentence Pause": "وقفة بين الجمل"
 }

--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2039,5 +2039,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "عند اختيار {{provider}}، تتم مزامنة الكتب والتقدم والتعليقات التوضيحية إلى OneDrive الخاص بك فقط.",
   "Readest only accesses the files it creates in your OneDrive.": "لا يصل Readest إلا إلى الملفات التي ينشئها في OneDrive الخاص بك.",
   ". Make OneDrive the active cloud provider.": ". اجعل OneDrive مزود السحابة النشط.",
-  "Sentence Pause": "وقفة بين الجمل"
+  "Sentence Pause": "وقفة بين الجمل",
+  "Paragraph Gap": "وقفة بين الفقرات"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1898,5 +1898,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "আপনার লাইব্রেরি, পড়ার অগ্রগতি এবং হাইলাইটগুলি আপনার Microsoft OneDrive-এর সাথে সিঙ্ক করুন।",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} নির্বাচিত থাকাকালীন বই, অগ্রগতি ও টীকা শুধুমাত্র আপনার OneDrive-এ সিঙ্ক হয়।",
   "Readest only accesses the files it creates in your OneDrive.": "Readest শুধুমাত্র আপনার OneDrive-এ নিজে তৈরি করা ফাইলগুলিতেই প্রবেশ করে।",
-  ". Make OneDrive the active cloud provider.": "। OneDrive-কে সক্রিয় ক্লাউড প্রদানকারী করুন।"
+  ". Make OneDrive the active cloud provider.": "। OneDrive-কে সক্রিয় ক্লাউড প্রদানকারী করুন।",
+  "Sentence Pause": "বাক্যের মধ্যে বিরতি"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1899,5 +1899,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} নির্বাচিত থাকাকালীন বই, অগ্রগতি ও টীকা শুধুমাত্র আপনার OneDrive-এ সিঙ্ক হয়।",
   "Readest only accesses the files it creates in your OneDrive.": "Readest শুধুমাত্র আপনার OneDrive-এ নিজে তৈরি করা ফাইলগুলিতেই প্রবেশ করে।",
   ". Make OneDrive the active cloud provider.": "। OneDrive-কে সক্রিয় ক্লাউড প্রদানকারী করুন।",
-  "Sentence Pause": "বাক্যের মধ্যে বিরতি"
+  "Sentence Pause": "বাক্যের মধ্যে বিরতি",
+  "Paragraph Gap": "অনুচ্ছেদের মধ্যে বিরতি"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1864,5 +1864,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} བདམས་ཡོད་སྐབས། དཔེ་ཆ་དང་བགྲོད་རིམ། མཆན་འགྲེལ་བཅས་ཁྱེད་ཀྱི་ OneDrive ནང་ཁོ་ནར་མཉམ་བསྒྲིག་བྱེད།",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ཀྱིས་ཁྱེད་ཀྱི་ OneDrive ནང་རང་ཉིད་ཀྱིས་བཟོས་པའི་ཡིག་ཆ་ཁོ་ནར་ལྟ་སྤྱོད་བྱེད།",
   ". Make OneDrive the active cloud provider.": "། OneDrive དེ་སྤྱོད་བཞིན་པའི་སྤྲིན་ཞབས་ཞུ་མཁོ་སྤྲོད་པར་སྒྲིག་པ།",
-  "Sentence Pause": "ཚིག་གྲུབ་བར་གསེང་"
+  "Sentence Pause": "ཚིག་གྲུབ་བར་གསེང་",
+  "Paragraph Gap": "དོན་ཚན་བར་གསེང་"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1863,5 +1863,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "ཁྱེད་ཀྱི་དཔེ་མཛོད་དང་། ཀློག་པའི་ཡར་འཕེལ། གཙོ་གནད་བཅས་ཁྱེད་ཀྱི་ Microsoft OneDrive དང་མཉམ་སྒྲིག་བྱེད།",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} བདམས་ཡོད་སྐབས། དཔེ་ཆ་དང་བགྲོད་རིམ། མཆན་འགྲེལ་བཅས་ཁྱེད་ཀྱི་ OneDrive ནང་ཁོ་ནར་མཉམ་བསྒྲིག་བྱེད།",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ཀྱིས་ཁྱེད་ཀྱི་ OneDrive ནང་རང་ཉིད་ཀྱིས་བཟོས་པའི་ཡིག་ཆ་ཁོ་ནར་ལྟ་སྤྱོད་བྱེད།",
-  ". Make OneDrive the active cloud provider.": "། OneDrive དེ་སྤྱོད་བཞིན་པའི་སྤྲིན་ཞབས་ཞུ་མཁོ་སྤྲོད་པར་སྒྲིག་པ།"
+  ". Make OneDrive the active cloud provider.": "། OneDrive དེ་སྤྱོད་བཞིན་པའི་སྤྲིན་ཞབས་ཞུ་མཁོ་སྤྲོད་པར་སྒྲིག་པ།",
+  "Sentence Pause": "ཚིག་གྲུབ་བར་གསེང་"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1899,5 +1899,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Solange {{provider}} ausgewählt ist, werden Bücher, Fortschritt und Anmerkungen nur mit Ihrem OneDrive synchronisiert.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest greift nur auf die Dateien zu, die es in Ihrem OneDrive erstellt.",
   ". Make OneDrive the active cloud provider.": ". OneDrive als aktiven Cloud-Anbieter festlegen.",
-  "Sentence Pause": "Satzpause"
+  "Sentence Pause": "Satzpause",
+  "Paragraph Gap": "Absatzpause"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1898,5 +1898,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synchronisieren Sie Ihre Bibliothek, Ihren Lesefortschritt und Ihre Markierungen mit Ihrem Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Solange {{provider}} ausgewählt ist, werden Bücher, Fortschritt und Anmerkungen nur mit Ihrem OneDrive synchronisiert.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest greift nur auf die Dateien zu, die es in Ihrem OneDrive erstellt.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive als aktiven Cloud-Anbieter festlegen."
+  ". Make OneDrive the active cloud provider.": ". OneDrive als aktiven Cloud-Anbieter festlegen.",
+  "Sentence Pause": "Satzpause"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1899,5 +1899,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Όσο είναι επιλεγμένο το {{provider}}, τα βιβλία, η πρόοδος και οι σημειώσεις συγχρονίζονται μόνο με το OneDrive σας.",
   "Readest only accesses the files it creates in your OneDrive.": "Το Readest έχει πρόσβαση μόνο στα αρχεία που δημιουργεί στο OneDrive σας.",
   ". Make OneDrive the active cloud provider.": ". Ορίστε το OneDrive ως ενεργό πάροχο cloud.",
-  "Sentence Pause": "Παύση μεταξύ προτάσεων"
+  "Sentence Pause": "Παύση μεταξύ προτάσεων",
+  "Paragraph Gap": "Παύση παραγράφου"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1898,5 +1898,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Συγχρονίστε τη βιβλιοθήκη, την πρόοδο ανάγνωσης και τις επισημάνσεις σας με το Microsoft OneDrive σας.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Όσο είναι επιλεγμένο το {{provider}}, τα βιβλία, η πρόοδος και οι σημειώσεις συγχρονίζονται μόνο με το OneDrive σας.",
   "Readest only accesses the files it creates in your OneDrive.": "Το Readest έχει πρόσβαση μόνο στα αρχεία που δημιουργεί στο OneDrive σας.",
-  ". Make OneDrive the active cloud provider.": ". Ορίστε το OneDrive ως ενεργό πάροχο cloud."
+  ". Make OneDrive the active cloud provider.": ". Ορίστε το OneDrive ως ενεργό πάροχο cloud.",
+  "Sentence Pause": "Παύση μεταξύ προτάσεων"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1933,5 +1933,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincroniza tu biblioteca, progreso de lectura y resaltados con tu Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Mientras {{provider}} esté seleccionado, los libros, el progreso y las anotaciones se sincronizan solo con tu OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest solo accede a los archivos que crea en tu OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Haz que OneDrive sea el proveedor de nube activo."
+  ". Make OneDrive the active cloud provider.": ". Haz que OneDrive sea el proveedor de nube activo.",
+  "Sentence Pause": "Pausa entre frases"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1934,5 +1934,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Mientras {{provider}} esté seleccionado, los libros, el progreso y las anotaciones se sincronizan solo con tu OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest solo accede a los archivos que crea en tu OneDrive.",
   ". Make OneDrive the active cloud provider.": ". Haz que OneDrive sea el proveedor de nube activo.",
-  "Sentence Pause": "Pausa entre frases"
+  "Sentence Pause": "Pausa entre frases",
+  "Paragraph Gap": "Pausa entre párrafos"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1898,5 +1898,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "کتابخانه، وضعیت مطالعه و هایلایت‌های خود را با Microsoft OneDrive خود همگام‌سازی کنید.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "تا زمانی که {{provider}} انتخاب شده باشد، کتاب‌ها، پیشرفت و یادداشت‌ها فقط با OneDrive شما همگام‌سازی می‌شوند.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest فقط به فایل‌هایی دسترسی دارد که خودش در OneDrive شما ایجاد می‌کند.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive را ارائه‌دهنده فعال ابری قرار دهید."
+  ". Make OneDrive the active cloud provider.": ". OneDrive را ارائه‌دهنده فعال ابری قرار دهید.",
+  "Sentence Pause": "مکث بین جملات"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1899,5 +1899,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "تا زمانی که {{provider}} انتخاب شده باشد، کتاب‌ها، پیشرفت و یادداشت‌ها فقط با OneDrive شما همگام‌سازی می‌شوند.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest فقط به فایل‌هایی دسترسی دارد که خودش در OneDrive شما ایجاد می‌کند.",
   ". Make OneDrive the active cloud provider.": ". OneDrive را ارائه‌دهنده فعال ابری قرار دهید.",
-  "Sentence Pause": "مکث بین جملات"
+  "Sentence Pause": "مکث بین جملات",
+  "Paragraph Gap": "وقفه بین پاراگراف‌ها"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1933,5 +1933,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synchronisez votre bibliothèque, votre progression de lecture et vos surlignages avec votre Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Tant que {{provider}} est sélectionné, les livres, la progression et les annotations ne se synchronisent qu'avec votre OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest accède uniquement aux fichiers qu'il crée dans votre OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Faites de OneDrive le fournisseur cloud actif."
+  ". Make OneDrive the active cloud provider.": ". Faites de OneDrive le fournisseur cloud actif.",
+  "Sentence Pause": "Pause entre les phrases"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1934,5 +1934,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Tant que {{provider}} est sélectionné, les livres, la progression et les annotations ne se synchronisent qu'avec votre OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest accède uniquement aux fichiers qu'il crée dans votre OneDrive.",
   ". Make OneDrive the active cloud provider.": ". Faites de OneDrive le fournisseur cloud actif.",
-  "Sentence Pause": "Pause entre les phrases"
+  "Sentence Pause": "Pause entre les phrases",
+  "Paragraph Gap": "Pause entre les paragraphes"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1934,5 +1934,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "כאשר {{provider}} נבחר, ספרים, התקדמות והערות מסתנכרנים רק עם ה-OneDrive שלך.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ניגש רק לקבצים שהוא יוצר ב-OneDrive שלך.",
   ". Make OneDrive the active cloud provider.": ". הפוך את OneDrive לספק הענן הפעיל.",
-  "Sentence Pause": "השהיה בין משפטים"
+  "Sentence Pause": "השהיה בין משפטים",
+  "Paragraph Gap": "הפסקה בין פסקאות"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1933,5 +1933,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "סנכרן את הספרייה, התקדמות הקריאה וההדגשות שלך עם Microsoft OneDrive שלך.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "כאשר {{provider}} נבחר, ספרים, התקדמות והערות מסתנכרנים רק עם ה-OneDrive שלך.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ניגש רק לקבצים שהוא יוצר ב-OneDrive שלך.",
-  ". Make OneDrive the active cloud provider.": ". הפוך את OneDrive לספק הענן הפעיל."
+  ". Make OneDrive the active cloud provider.": ". הפוך את OneDrive לספק הענן הפעיל.",
+  "Sentence Pause": "השהיה בין משפטים"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1899,5 +1899,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "जब {{provider}} चुना गया हो, तो किताबें, प्रगति और एनोटेशन केवल आपके OneDrive से सिंक होते हैं।",
   "Readest only accesses the files it creates in your OneDrive.": "Readest केवल उन्हीं फ़ाइलों तक पहुँचता है जिन्हें वह आपकी OneDrive में बनाता है।",
   ". Make OneDrive the active cloud provider.": "। OneDrive को सक्रिय क्लाउड प्रदाता बनाएं।",
-  "Sentence Pause": "वाक्यों के बीच विराम"
+  "Sentence Pause": "वाक्यों के बीच विराम",
+  "Paragraph Gap": "अनुच्छेदों के बीच विराम"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1898,5 +1898,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "अपनी लाइब्रेरी, पढ़ने की प्रगति और हाइलाइट्स को अपनी Microsoft OneDrive से सिंक करें।",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "जब {{provider}} चुना गया हो, तो किताबें, प्रगति और एनोटेशन केवल आपके OneDrive से सिंक होते हैं।",
   "Readest only accesses the files it creates in your OneDrive.": "Readest केवल उन्हीं फ़ाइलों तक पहुँचता है जिन्हें वह आपकी OneDrive में बनाता है।",
-  ". Make OneDrive the active cloud provider.": "। OneDrive को सक्रिय क्लाउड प्रदाता बनाएं।"
+  ". Make OneDrive the active cloud provider.": "। OneDrive को सक्रिय क्लाउड प्रदाता बनाएं।",
+  "Sentence Pause": "वाक्यों के बीच विराम"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1899,5 +1899,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Amíg a(z) {{provider}} van kiválasztva, a könyvek, az előrehaladás és a jegyzetek csak a OneDrive-odba szinkronizálódnak.",
   "Readest only accesses the files it creates in your OneDrive.": "A Readest csak azokhoz a fájlokhoz fér hozzá, amelyeket ő hozott létre a OneDrive-jában.",
   ". Make OneDrive the active cloud provider.": ". Tegye a OneDrive-ot az aktív felhőszolgáltatóvá.",
-  "Sentence Pause": "Mondatszünet"
+  "Sentence Pause": "Mondatszünet",
+  "Paragraph Gap": "Bekezdésszünet"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1898,5 +1898,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Szinkronizálja könyvtárát, olvasási haladását és kiemeléseit a Microsoft OneDrive-jával.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Amíg a(z) {{provider}} van kiválasztva, a könyvek, az előrehaladás és a jegyzetek csak a OneDrive-odba szinkronizálódnak.",
   "Readest only accesses the files it creates in your OneDrive.": "A Readest csak azokhoz a fájlokhoz fér hozzá, amelyeket ő hozott létre a OneDrive-jában.",
-  ". Make OneDrive the active cloud provider.": ". Tegye a OneDrive-ot az aktív felhőszolgáltatóvá."
+  ". Make OneDrive the active cloud provider.": ". Tegye a OneDrive-ot az aktív felhőszolgáltatóvá.",
+  "Sentence Pause": "Mondatszünet"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1863,5 +1863,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sinkronkan perpustakaan, progres membaca, dan sorotan Anda dengan Microsoft OneDrive Anda.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Saat {{provider}} dipilih, buku, progres, dan anotasi hanya disinkronkan ke OneDrive Anda.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest hanya mengakses file yang dibuatnya di OneDrive Anda.",
-  ". Make OneDrive the active cloud provider.": ". Jadikan OneDrive penyedia cloud yang aktif."
+  ". Make OneDrive the active cloud provider.": ". Jadikan OneDrive penyedia cloud yang aktif.",
+  "Sentence Pause": "Jeda Antar Kalimat"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1864,5 +1864,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Saat {{provider}} dipilih, buku, progres, dan anotasi hanya disinkronkan ke OneDrive Anda.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest hanya mengakses file yang dibuatnya di OneDrive Anda.",
   ". Make OneDrive the active cloud provider.": ". Jadikan OneDrive penyedia cloud yang aktif.",
-  "Sentence Pause": "Jeda Antar Kalimat"
+  "Sentence Pause": "Jeda Antar Kalimat",
+  "Paragraph Gap": "Jeda antarparagraf"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1933,5 +1933,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincronizza la tua biblioteca, il progresso di lettura e le evidenziazioni con il tuo Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Finché {{provider}} è selezionato, libri, progressi e annotazioni si sincronizzano solo con il tuo OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest accede solo ai file che crea nel tuo OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Imposta OneDrive come provider cloud attivo."
+  ". Make OneDrive the active cloud provider.": ". Imposta OneDrive come provider cloud attivo.",
+  "Sentence Pause": "Pausa tra le frasi"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1934,5 +1934,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Finché {{provider}} è selezionato, libri, progressi e annotazioni si sincronizzano solo con il tuo OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest accede solo ai file che crea nel tuo OneDrive.",
   ". Make OneDrive the active cloud provider.": ". Imposta OneDrive come provider cloud attivo.",
-  "Sentence Pause": "Pausa tra le frasi"
+  "Sentence Pause": "Pausa tra le frasi",
+  "Paragraph Gap": "Pausa tra i paragrafi"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1864,5 +1864,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} を選択している間、書籍・進捗・注釈は OneDrive にのみ同期されます。",
   "Readest only accesses the files it creates in your OneDrive.": "Readest がアクセスするのは、OneDrive 内に自身が作成したファイルのみです。",
   ". Make OneDrive the active cloud provider.": "。OneDrive を使用するクラウドプロバイダーに設定します。",
-  "Sentence Pause": "文間のポーズ"
+  "Sentence Pause": "文間のポーズ",
+  "Paragraph Gap": "段落間のポーズ"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1863,5 +1863,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "ライブラリ、読書進捗、ハイライトを Microsoft OneDrive と同期します。",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} を選択している間、書籍・進捗・注釈は OneDrive にのみ同期されます。",
   "Readest only accesses the files it creates in your OneDrive.": "Readest がアクセスするのは、OneDrive 内に自身が作成したファイルのみです。",
-  ". Make OneDrive the active cloud provider.": "。OneDrive を使用するクラウドプロバイダーに設定します。"
+  ". Make OneDrive the active cloud provider.": "。OneDrive を使用するクラウドプロバイダーに設定します。",
+  "Sentence Pause": "文間のポーズ"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1864,5 +1864,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}}를 선택하면 책, 진행률, 주석이 OneDrive에만 동기화됩니다.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest는 OneDrive에서 직접 만든 파일에만 접근합니다.",
   ". Make OneDrive the active cloud provider.": ". OneDrive를 사용할 클라우드 제공업체로 설정합니다.",
-  "Sentence Pause": "문장 사이 일시정지"
+  "Sentence Pause": "문장 사이 일시정지",
+  "Paragraph Gap": "문단 간 정지"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1863,5 +1863,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "라이브러리, 읽기 진행 상황, 하이라이트를 Microsoft OneDrive와 동기화합니다.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}}를 선택하면 책, 진행률, 주석이 OneDrive에만 동기화됩니다.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest는 OneDrive에서 직접 만든 파일에만 접근합니다.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive를 사용할 클라우드 제공업체로 설정합니다."
+  ". Make OneDrive the active cloud provider.": ". OneDrive를 사용할 클라우드 제공업체로 설정합니다.",
+  "Sentence Pause": "문장 사이 일시정지"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1863,5 +1863,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Segerakkan perpustakaan, kemajuan bacaan dan penonjolan anda dengan Microsoft OneDrive anda.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Semasa {{provider}} dipilih, buku, kemajuan dan anotasi hanya disegerakkan ke OneDrive anda.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest hanya mengakses fail yang diciptanya dalam OneDrive anda.",
-  ". Make OneDrive the active cloud provider.": ". Jadikan OneDrive sebagai penyedia awan yang aktif."
+  ". Make OneDrive the active cloud provider.": ". Jadikan OneDrive sebagai penyedia awan yang aktif.",
+  "Sentence Pause": "Jeda Antara Ayat"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1864,5 +1864,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Semasa {{provider}} dipilih, buku, kemajuan dan anotasi hanya disegerakkan ke OneDrive anda.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest hanya mengakses fail yang diciptanya dalam OneDrive anda.",
   ". Make OneDrive the active cloud provider.": ". Jadikan OneDrive sebagai penyedia awan yang aktif.",
-  "Sentence Pause": "Jeda Antara Ayat"
+  "Sentence Pause": "Jeda Antara Ayat",
+  "Paragraph Gap": "Jeda antara perenggan"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1899,5 +1899,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Zolang {{provider}} is geselecteerd, worden boeken, voortgang en annotaties alleen met uw OneDrive gesynchroniseerd.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest heeft alleen toegang tot de bestanden die het zelf in je OneDrive aanmaakt.",
   ". Make OneDrive the active cloud provider.": ". Maak OneDrive de actieve cloudprovider.",
-  "Sentence Pause": "Zinspauze"
+  "Sentence Pause": "Zinspauze",
+  "Paragraph Gap": "Alineapauze"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1898,5 +1898,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synchroniseer je bibliotheek, leesvoortgang en markeringen met je Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Zolang {{provider}} is geselecteerd, worden boeken, voortgang en annotaties alleen met uw OneDrive gesynchroniseerd.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest heeft alleen toegang tot de bestanden die het zelf in je OneDrive aanmaakt.",
-  ". Make OneDrive the active cloud provider.": ". Maak OneDrive de actieve cloudprovider."
+  ". Make OneDrive the active cloud provider.": ". Maak OneDrive de actieve cloudprovider.",
+  "Sentence Pause": "Zinspauze"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1968,5 +1968,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synchronizuj bibliotekę, postęp czytania i zaznaczenia ze swoim Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Gdy wybrany jest {{provider}}, książki, postęp i adnotacje synchronizują się tylko z Twoim OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ma dostęp tylko do plików, które sam tworzy na Twoim OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Ustaw OneDrive jako aktywnego dostawcę chmury."
+  ". Make OneDrive the active cloud provider.": ". Ustaw OneDrive jako aktywnego dostawcę chmury.",
+  "Sentence Pause": "Pauza między zdaniami"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1969,5 +1969,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Gdy wybrany jest {{provider}}, książki, postęp i adnotacje synchronizują się tylko z Twoim OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ma dostęp tylko do plików, które sam tworzy na Twoim OneDrive.",
   ". Make OneDrive the active cloud provider.": ". Ustaw OneDrive jako aktywnego dostawcę chmury.",
-  "Sentence Pause": "Pauza między zdaniami"
+  "Sentence Pause": "Pauza między zdaniami",
+  "Paragraph Gap": "Przerwa między akapitami"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1934,5 +1934,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Enquanto o {{provider}} estiver selecionado, livros, progresso e anotações são sincronizados apenas com seu OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "O Readest só acessa os arquivos que cria no seu OneDrive.",
   ". Make OneDrive the active cloud provider.": ". Torne o OneDrive o provedor de nuvem ativo.",
-  "Sentence Pause": "Pausa entre frases"
+  "Sentence Pause": "Pausa entre frases",
+  "Paragraph Gap": "Pausa entre parágrafos"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1933,5 +1933,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincronize sua biblioteca, progresso de leitura e destaques com o seu Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Enquanto o {{provider}} estiver selecionado, livros, progresso e anotações são sincronizados apenas com seu OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "O Readest só acessa os arquivos que cria no seu OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Torne o OneDrive o provedor de nuvem ativo."
+  ". Make OneDrive the active cloud provider.": ". Torne o OneDrive o provedor de nuvem ativo.",
+  "Sentence Pause": "Pausa entre frases"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1933,5 +1933,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincronize a sua biblioteca, o progresso de leitura e os destaques com o seu Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Enquanto o {{provider}} estiver selecionado, os livros, o progresso e as anotações são sincronizados apenas com o seu OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "O Readest só acede aos ficheiros que cria no seu OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Torne o OneDrive o fornecedor de nuvem ativo."
+  ". Make OneDrive the active cloud provider.": ". Torne o OneDrive o fornecedor de nuvem ativo.",
+  "Sentence Pause": "Pausa entre frases"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1934,5 +1934,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Enquanto o {{provider}} estiver selecionado, os livros, o progresso e as anotações são sincronizados apenas com o seu OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "O Readest só acede aos ficheiros que cria no seu OneDrive.",
   ". Make OneDrive the active cloud provider.": ". Torne o OneDrive o fornecedor de nuvem ativo.",
-  "Sentence Pause": "Pausa entre frases"
+  "Sentence Pause": "Pausa entre frases",
+  "Paragraph Gap": "Pausa entre parágrafos"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1934,5 +1934,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Cât timp {{provider}} este selectat, cărțile, progresul și adnotările se sincronizează doar cu OneDrive-ul tău.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest accesează doar fișierele pe care le creează în OneDrive-ul tău.",
   ". Make OneDrive the active cloud provider.": ". Setează OneDrive ca furnizor de cloud activ.",
-  "Sentence Pause": "Pauză între propoziții"
+  "Sentence Pause": "Pauză între propoziții",
+  "Paragraph Gap": "Pauză între paragrafe"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1933,5 +1933,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincronizează-ți biblioteca, progresul citirii și evidențierile cu Microsoft OneDrive-ul tău.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Cât timp {{provider}} este selectat, cărțile, progresul și adnotările se sincronizează doar cu OneDrive-ul tău.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest accesează doar fișierele pe care le creează în OneDrive-ul tău.",
-  ". Make OneDrive the active cloud provider.": ". Setează OneDrive ca furnizor de cloud activ."
+  ". Make OneDrive the active cloud provider.": ". Setează OneDrive ca furnizor de cloud activ.",
+  "Sentence Pause": "Pauză între propoziții"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1969,5 +1969,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Пока выбран {{provider}}, книги, прогресс и аннотации синхронизируются только с вашим OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest получает доступ только к тем файлам, которые сам создаёт на вашем OneDrive.",
   ". Make OneDrive the active cloud provider.": ". Сделать OneDrive активным облачным провайдером.",
-  "Sentence Pause": "Пауза между предложениями"
+  "Sentence Pause": "Пауза между предложениями",
+  "Paragraph Gap": "Пауза между абзацами"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1968,5 +1968,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Синхронизируйте свою библиотеку, прогресс чтения и выделения с вашим Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Пока выбран {{provider}}, книги, прогресс и аннотации синхронизируются только с вашим OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest получает доступ только к тем файлам, которые сам создаёт на вашем OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Сделать OneDrive активным облачным провайдером."
+  ". Make OneDrive the active cloud provider.": ". Сделать OneDrive активным облачным провайдером.",
+  "Sentence Pause": "Пауза между предложениями"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1899,5 +1899,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} තෝරා ඇති විට, පොත්, ප්‍රගතිය සහ සටහන් ඔබේ OneDrive වෙත පමණක් සමමුහුර්ත වේ.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ප්‍රවේශ වන්නේ ඔබේ OneDrive හි එය සාදන ගොනුවලට පමණි.",
   ". Make OneDrive the active cloud provider.": ". OneDrive සක්‍රිය cloud සපයන්නා ලෙස සකසන්න.",
-  "Sentence Pause": "වාක්‍ය අතර විරාමය"
+  "Sentence Pause": "වාක්‍ය අතර විරාමය",
+  "Paragraph Gap": "ඡේද අතර විරාමය"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1898,5 +1898,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "ඔබේ පුස්තකාලය, කියවීමේ ප්‍රගතිය සහ ඉස්මතු කිරීම් ඔබේ Microsoft OneDrive සමඟ සමමුහුර්ත කරන්න.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} තෝරා ඇති විට, පොත්, ප්‍රගතිය සහ සටහන් ඔබේ OneDrive වෙත පමණක් සමමුහුර්ත වේ.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ප්‍රවේශ වන්නේ ඔබේ OneDrive හි එය සාදන ගොනුවලට පමණි.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive සක්‍රිය cloud සපයන්නා ලෙස සකසන්න."
+  ". Make OneDrive the active cloud provider.": ". OneDrive සක්‍රිය cloud සපයන්නා ලෙස සකසන්න.",
+  "Sentence Pause": "වාක්‍ය අතර විරාමය"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1969,5 +1969,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Dokler je izbran {{provider}}, se knjige, napredek in opombe sinhronizirajo samo z vašim OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest dostopa le do datotek, ki jih sam ustvari v vašem OneDrive.",
   ". Make OneDrive the active cloud provider.": ". Nastavite OneDrive kot aktivnega ponudnika oblaka.",
-  "Sentence Pause": "Premor med stavki"
+  "Sentence Pause": "Premor med stavki",
+  "Paragraph Gap": "Premor med odstavki"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1968,5 +1968,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sinhronizirajte knjižnico, napredek branja in označbe s svojim Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Dokler je izbran {{provider}}, se knjige, napredek in opombe sinhronizirajo samo z vašim OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest dostopa le do datotek, ki jih sam ustvari v vašem OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Nastavite OneDrive kot aktivnega ponudnika oblaka."
+  ". Make OneDrive the active cloud provider.": ". Nastavite OneDrive kot aktivnega ponudnika oblaka.",
+  "Sentence Pause": "Premor med stavki"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1899,5 +1899,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "När {{provider}} är valt synkroniseras böcker, framsteg och anteckningar endast med din OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest kommer bara åt de filer som appen skapar i din OneDrive.",
   ". Make OneDrive the active cloud provider.": ". Gör OneDrive till aktiv molnleverantör.",
-  "Sentence Pause": "Meningspaus"
+  "Sentence Pause": "Meningspaus",
+  "Paragraph Gap": "Styckepaus"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1898,5 +1898,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synka ditt bibliotek, dina läsframsteg och markeringar med din Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "När {{provider}} är valt synkroniseras böcker, framsteg och anteckningar endast med din OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest kommer bara åt de filer som appen skapar i din OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Gör OneDrive till aktiv molnleverantör."
+  ". Make OneDrive the active cloud provider.": ". Gör OneDrive till aktiv molnleverantör.",
+  "Sentence Pause": "Meningspaus"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1898,5 +1898,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "உங்கள் நூலகம், வாசிப்பு முன்னேற்றம் மற்றும் சிறப்பம்சங்களை உங்கள் Microsoft OneDrive உடன் ஒத்திசைக்கவும்.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} தேர்ந்தெடுக்கப்பட்டிருக்கும் போது, புத்தகங்கள், முன்னேற்றம் மற்றும் குறிப்புகள் உங்கள் OneDrive உடன் மட்டுமே ஒத்திசைக்கப்படும்.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest உங்கள் OneDrive இல் தானே உருவாக்கும் கோப்புகளை மட்டுமே அணுகும்.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive ஐ செயலில் உள்ள cloud வழங்குநராக அமைக்கவும்."
+  ". Make OneDrive the active cloud provider.": ". OneDrive ஐ செயலில் உள்ள cloud வழங்குநராக அமைக்கவும்.",
+  "Sentence Pause": "வாக்கிய இடைவேளை"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1899,5 +1899,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} தேர்ந்தெடுக்கப்பட்டிருக்கும் போது, புத்தகங்கள், முன்னேற்றம் மற்றும் குறிப்புகள் உங்கள் OneDrive உடன் மட்டுமே ஒத்திசைக்கப்படும்.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest உங்கள் OneDrive இல் தானே உருவாக்கும் கோப்புகளை மட்டுமே அணுகும்.",
   ". Make OneDrive the active cloud provider.": ". OneDrive ஐ செயலில் உள்ள cloud வழங்குநராக அமைக்கவும்.",
-  "Sentence Pause": "வாக்கிய இடைவேளை"
+  "Sentence Pause": "வாக்கிய இடைவேளை",
+  "Paragraph Gap": "பத்தி இடைவேளை"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1864,5 +1864,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "เมื่อเลือก {{provider}} หนังสือ ความคืบหน้า และคำอธิบายประกอบจะซิงค์ไปยัง OneDrive ของคุณเท่านั้น",
   "Readest only accesses the files it creates in your OneDrive.": "Readest จะเข้าถึงเฉพาะไฟล์ที่สร้างขึ้นเองใน OneDrive ของคุณเท่านั้น",
   ". Make OneDrive the active cloud provider.": ". ตั้งให้ OneDrive เป็นผู้ให้บริการคลาวด์ที่ใช้งานอยู่",
-  "Sentence Pause": "หยุดระหว่างประโยค"
+  "Sentence Pause": "หยุดระหว่างประโยค",
+  "Paragraph Gap": "หยุดชั่วคราวระหว่างย่อหน้า"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1863,5 +1863,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "ซิงค์คลังหนังสือ ความคืบหน้าการอ่าน และไฮไลต์ของคุณกับ Microsoft OneDrive ของคุณ",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "เมื่อเลือก {{provider}} หนังสือ ความคืบหน้า และคำอธิบายประกอบจะซิงค์ไปยัง OneDrive ของคุณเท่านั้น",
   "Readest only accesses the files it creates in your OneDrive.": "Readest จะเข้าถึงเฉพาะไฟล์ที่สร้างขึ้นเองใน OneDrive ของคุณเท่านั้น",
-  ". Make OneDrive the active cloud provider.": ". ตั้งให้ OneDrive เป็นผู้ให้บริการคลาวด์ที่ใช้งานอยู่"
+  ". Make OneDrive the active cloud provider.": ". ตั้งให้ OneDrive เป็นผู้ให้บริการคลาวด์ที่ใช้งานอยู่",
+  "Sentence Pause": "หยุดระหว่างประโยค"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1898,5 +1898,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Kütüphanenizi, okuma ilerlemenizi ve vurgularınızı Microsoft OneDrive'ınızla senkronize edin.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} seçili olduğunda kitaplar, ilerleme ve açıklamalar yalnızca OneDrive'ınızla senkronize edilir.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest yalnızca OneDrive'ınızda kendi oluşturduğu dosyalara erişir.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive'ı etkin bulut sağlayıcısı yapın."
+  ". Make OneDrive the active cloud provider.": ". OneDrive'ı etkin bulut sağlayıcısı yapın.",
+  "Sentence Pause": "Cümle Arası Duraklama"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1899,5 +1899,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} seçili olduğunda kitaplar, ilerleme ve açıklamalar yalnızca OneDrive'ınızla senkronize edilir.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest yalnızca OneDrive'ınızda kendi oluşturduğu dosyalara erişir.",
   ". Make OneDrive the active cloud provider.": ". OneDrive'ı etkin bulut sağlayıcısı yapın.",
-  "Sentence Pause": "Cümle Arası Duraklama"
+  "Sentence Pause": "Cümle Arası Duraklama",
+  "Paragraph Gap": "Paragraf arası duraklama"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1968,5 +1968,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Синхронізуйте свою бібліотеку, проґрес читання та виділення з вашим Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Поки вибрано {{provider}}, книги, прогрес і анотації синхронізуються лише з вашим OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest має доступ лише до файлів, які сам створює у вашому OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Зробити OneDrive активним хмарним провайдером."
+  ". Make OneDrive the active cloud provider.": ". Зробити OneDrive активним хмарним провайдером.",
+  "Sentence Pause": "Пауза між реченнями"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1969,5 +1969,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Поки вибрано {{provider}}, книги, прогрес і анотації синхронізуються лише з вашим OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest має доступ лише до файлів, які сам створює у вашому OneDrive.",
   ". Make OneDrive the active cloud provider.": ". Зробити OneDrive активним хмарним провайдером.",
-  "Sentence Pause": "Пауза між реченнями"
+  "Sentence Pause": "Пауза між реченнями",
+  "Paragraph Gap": "Пауза між абзацами"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1898,5 +1898,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Kutubxonangiz, oʻqish jarayoni va belgilashlaringizni Microsoft OneDrive bilan sinxronlang.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} tanlangan paytda kitoblar, jarayon va izohlar faqat OneDrive'ingizga sinxronlanadi.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest OneDrive-ingizda faqat oʻzi yaratgan fayllarga kiradi.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive-ni faol bulut provayderi qiling."
+  ". Make OneDrive the active cloud provider.": ". OneDrive-ni faol bulut provayderi qiling.",
+  "Sentence Pause": "Gaplar orasidagi pauza"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1899,5 +1899,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} tanlangan paytda kitoblar, jarayon va izohlar faqat OneDrive'ingizga sinxronlanadi.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest OneDrive-ingizda faqat oʻzi yaratgan fayllarga kiradi.",
   ". Make OneDrive the active cloud provider.": ". OneDrive-ni faol bulut provayderi qiling.",
-  "Sentence Pause": "Gaplar orasidagi pauza"
+  "Sentence Pause": "Gaplar orasidagi pauza",
+  "Paragraph Gap": "Paragraflar orasidagi tanaffus"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1863,5 +1863,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Đồng bộ thư viện, tiến trình đọc và điểm nổi bật của bạn với Microsoft OneDrive của bạn.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Khi {{provider}} được chọn, sách, tiến độ và chú thích chỉ đồng bộ với OneDrive của bạn.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest chỉ truy cập các tệp do chính nó tạo trong OneDrive của bạn.",
-  ". Make OneDrive the active cloud provider.": ". Đặt OneDrive làm nhà cung cấp đám mây đang hoạt động."
+  ". Make OneDrive the active cloud provider.": ". Đặt OneDrive làm nhà cung cấp đám mây đang hoạt động.",
+  "Sentence Pause": "Khoảng dừng giữa các câu"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1864,5 +1864,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Khi {{provider}} được chọn, sách, tiến độ và chú thích chỉ đồng bộ với OneDrive của bạn.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest chỉ truy cập các tệp do chính nó tạo trong OneDrive của bạn.",
   ". Make OneDrive the active cloud provider.": ". Đặt OneDrive làm nhà cung cấp đám mây đang hoạt động.",
-  "Sentence Pause": "Khoảng dừng giữa các câu"
+  "Sentence Pause": "Khoảng dừng giữa các câu",
+  "Paragraph Gap": "Khoảng dừng giữa đoạn văn"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1863,5 +1863,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "将您的书库、阅读进度和高亮与您的 Microsoft OneDrive 同步。",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "选择 {{provider}} 后，书籍、进度和标注仅同步到您的 OneDrive。",
   "Readest only accesses the files it creates in your OneDrive.": "Readest 只会访问它在您的 OneDrive 中创建的文件。",
-  ". Make OneDrive the active cloud provider.": "。将 OneDrive 设为当前使用的云服务提供商。"
+  ". Make OneDrive the active cloud provider.": "。将 OneDrive 设为当前使用的云服务提供商。",
+  "Sentence Pause": "句间停顿"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1864,5 +1864,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "选择 {{provider}} 后，书籍、进度和标注仅同步到您的 OneDrive。",
   "Readest only accesses the files it creates in your OneDrive.": "Readest 只会访问它在您的 OneDrive 中创建的文件。",
   ". Make OneDrive the active cloud provider.": "。将 OneDrive 设为当前使用的云服务提供商。",
-  "Sentence Pause": "句间停顿"
+  "Sentence Pause": "句间停顿",
+  "Paragraph Gap": "段落间隔"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1864,5 +1864,6 @@
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "選擇 {{provider}} 後，書籍、進度和標註僅同步到您的 OneDrive。",
   "Readest only accesses the files it creates in your OneDrive.": "Readest 只會存取它在您的 OneDrive 中建立的檔案。",
   ". Make OneDrive the active cloud provider.": "。將 OneDrive 設為目前使用的雲端服務供應商。",
-  "Sentence Pause": "句間停頓"
+  "Sentence Pause": "句間停頓",
+  "Paragraph Gap": "段落間隔"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1863,5 +1863,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "將您的書庫、閱讀進度和高亮與您的 Microsoft OneDrive 同步。",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "選擇 {{provider}} 後，書籍、進度和標註僅同步到您的 OneDrive。",
   "Readest only accesses the files it creates in your OneDrive.": "Readest 只會存取它在您的 OneDrive 中建立的檔案。",
-  ". Make OneDrive the active cloud provider.": "。將 OneDrive 設為目前使用的雲端服務供應商。"
+  ". Make OneDrive the active cloud provider.": "。將 OneDrive 設為目前使用的雲端服務供應商。",
+  "Sentence Pause": "句間停頓"
 }

--- a/apps/readest-app/src/__tests__/components/tts/GapChips.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/GapChips.test.tsx
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+import GapChips from '@/app/reader/components/tts/GapChips';
+
+describe('GapChips', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('renders the presets and marks the active gap', () => {
+    render(<GapChips gap={0.15} onSelect={vi.fn()} />);
+    const active = screen.getByRole('radio', { checked: true });
+    expect(active.textContent).toBe('0.15s');
+    expect(screen.getAllByRole('radio').length).toBe(6);
+  });
+
+  test('an off-preset persisted gap appears as an extra active chip in order', () => {
+    render(<GapChips gap={0.2} onSelect={vi.fn()} />);
+    const chips = screen.getAllByRole('radio');
+    expect(chips.length).toBe(7);
+    const labels = chips.map((c) => c.textContent);
+    expect(labels.indexOf('0.2s')).toBe(labels.indexOf('0.15s') + 1);
+    expect(screen.getByRole('radio', { checked: true }).textContent).toBe('0.2s');
+  });
+
+  test('selecting a chip reports the numeric gap', () => {
+    const onSelect = vi.fn();
+    render(<GapChips gap={0.15} onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('radio', { name: '0.4s' }));
+    expect(onSelect).toHaveBeenCalledWith(0.4);
+  });
+});

--- a/apps/readest-app/src/__tests__/components/tts/TTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSControl.test.tsx
@@ -61,7 +61,9 @@ describe('TTSControl', () => {
       handleBackToCurrentTTSLocation: vi.fn(),
       handleSeekTo: vi.fn(),
       handleGetPlaybackInfo: vi.fn().mockReturnValue(null),
+      handleSetSentenceGap: vi.fn(),
       handleSupportsPlaybackInfo: vi.fn().mockReturnValue(true),
+      handleSupportsGapControl: vi.fn().mockReturnValue(false),
       refreshTtsLang: vi.fn(),
     });
   });

--- a/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
@@ -89,6 +89,7 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
   onForward: vi.fn(),
   onSetRate: vi.fn(),
   onSetSentenceGap: vi.fn(),
+  onSetParagraphGap: vi.fn(),
   onGetVoices: vi.fn().mockResolvedValue(voiceGroups),
   onSetVoice: vi.fn(),
   onGetVoiceId: vi.fn().mockReturnValue('ava'),

--- a/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
@@ -172,7 +172,7 @@ describe('TTSPlayerSheet', () => {
     const props = makeProps({ hasGapControl: false });
     render(<TTSPlayerSheet {...props} />);
     fireEvent.click(screen.getByLabelText('Speed'));
-    expect(screen.queryByText('Sentence Pause')).toBeNull();
+    expect(screen.queryByText(/Sentence Pause/)).toBeNull();
     expect(screen.queryByRole('radiogroup', { name: 'Sentence Pause' })).toBeNull();
   });
 

--- a/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
@@ -44,7 +44,7 @@ vi.mock('@/store/readerStore', () => ({
   }),
 }));
 
-const settings = { globalViewSettings: { ttsRate: 1.0 } };
+const settings = { globalViewSettings: { ttsRate: 1.0, ttsSentenceGap: 0.15 } };
 const saveSettings = vi.fn();
 const settingsState = { settings, setSettings: vi.fn(), saveSettings };
 vi.mock('@/store/settingsStore', () => ({
@@ -79,6 +79,7 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
   ttsLang: 'en',
   isPlaying: true,
   hasTimeline: true,
+  hasGapControl: false,
   timeoutOption: 0,
   timeoutTimestamp: 0,
   chapterRemainingSec: null as number | null,
@@ -87,6 +88,7 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
   onBackward: vi.fn(),
   onForward: vi.fn(),
   onSetRate: vi.fn(),
+  onSetSentenceGap: vi.fn(),
   onGetVoices: vi.fn().mockResolvedValue(voiceGroups),
   onSetVoice: vi.fn(),
   onGetVoiceId: vi.fn().mockReturnValue('ava'),
@@ -101,6 +103,7 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
 describe('TTSPlayerSheet', () => {
   beforeEach(() => {
     viewSettings['ttsRate'] = 1.0;
+    viewSettings['ttsSentenceGap'] = 0.15;
     viewSettings['isEink'] = false;
     getBookData.mockReturnValue({
       book: { title: 'Alice in Wonderland', coverImageUrl: null },
@@ -162,6 +165,26 @@ describe('TTSPlayerSheet', () => {
     expect(props.onSetRate).toHaveBeenCalledWith(1.5);
     expect(viewSettings['ttsRate']).toBe(1.5);
     expect(settings.globalViewSettings.ttsRate).toBe(1.5);
+    expect(saveSettings).toHaveBeenCalled();
+  });
+
+  test('gap control is absent for a non-Edge client (hasGapControl false)', () => {
+    const props = makeProps({ hasGapControl: false });
+    render(<TTSPlayerSheet {...props} />);
+    fireEvent.click(screen.getByLabelText('Speed'));
+    expect(screen.queryByText('Sentence Pause')).toBeNull();
+    expect(screen.queryByRole('radiogroup', { name: 'Sentence Pause' })).toBeNull();
+  });
+
+  test('gap chips show for an Edge client and selecting persists the gap', () => {
+    const props = makeProps({ hasGapControl: true });
+    render(<TTSPlayerSheet {...props} />);
+    fireEvent.click(screen.getByLabelText('Speed'));
+    expect(screen.getByText(/Sentence Pause/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('radio', { name: '0.4s' }));
+    expect(props.onSetSentenceGap).toHaveBeenCalledWith(0.4);
+    expect(viewSettings['ttsSentenceGap']).toBe(0.4);
+    expect(settings.globalViewSettings.ttsSentenceGap).toBe(0.4);
     expect(saveSettings).toHaveBeenCalled();
   });
 

--- a/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
@@ -136,11 +136,14 @@ vi.mock('@/services/tts', () => ({
       setHighlightGranularity: vi.fn(),
       setLang: vi.fn(),
       setRate: vi.fn(),
+      setSentenceGap: vi.fn(),
+      supportsGapControl: vi.fn().mockReturnValue(false),
       setVoice: vi.fn(),
       setTargetLang: vi.fn(),
       speak: vi.fn(),
       pause: vi.fn().mockResolvedValue(undefined),
       resume: vi.fn().mockResolvedValue(undefined),
+      start: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(undefined),
       shutdown: vi.fn().mockResolvedValue(undefined),
       forward: vi.fn().mockResolvedValue(undefined),
@@ -687,5 +690,72 @@ describe('useTTSControl background session lifecycle', () => {
       mockView,
       expect.objectContaining({ bookKey: 'book-1' }),
     );
+  });
+});
+
+describe('useTTSControl gap control (handleSetSentenceGap / handleSupportsGapControl)', () => {
+  let hookResult: ReturnType<typeof useTTSControl> | null = null;
+
+  const CaptureHarness = () => {
+    hookResult = useTTSControl({ bookKey: 'book-1' });
+    return null;
+  };
+
+  beforeEach(() => {
+    ttsControllerInstances.length = 0;
+    pendingInitResolvers.length = 0;
+    hookResult = null;
+    mockSessionManager.claim.mockClear();
+    mockSessionManager.getSessionByHash.mockReturnValue(null);
+    mockSessionManager.getActiveSession.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  const startSession = async () => {
+    render(<CaptureHarness />);
+    await act(async () => {
+      const p = eventDispatcher.dispatch('tts-speak', { bookKey: 'book-1' });
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      while (pendingInitResolvers.length > 0) pendingInitResolvers.shift()!();
+      await p;
+    });
+    return ttsControllerInstances[0] as {
+      setSentenceGap: ReturnType<typeof vi.fn>;
+      supportsGapControl: ReturnType<typeof vi.fn>;
+      stop: ReturnType<typeof vi.fn>;
+      start: ReturnType<typeof vi.fn>;
+      state: string;
+    };
+  };
+
+  it('handleSetSentenceGap calls controller.setSentenceGap directly, without stop/start', async () => {
+    const controller = await startSession();
+    controller.state = 'playing';
+
+    act(() => {
+      hookResult!.handleSetSentenceGap(0.5);
+    });
+
+    expect(controller.setSentenceGap).toHaveBeenCalledWith(0.5);
+    expect(controller.stop).not.toHaveBeenCalled();
+    expect(controller.start).not.toHaveBeenCalled();
+  });
+
+  it('handleSupportsGapControl reflects controller.supportsGapControl()', async () => {
+    const controller = await startSession();
+
+    controller.supportsGapControl.mockReturnValue(false);
+    expect(hookResult!.handleSupportsGapControl()).toBe(false);
+
+    controller.supportsGapControl.mockReturnValue(true);
+    expect(hookResult!.handleSupportsGapControl()).toBe(true);
+  });
+
+  it('handleSupportsGapControl returns false when no controller exists yet', () => {
+    render(<CaptureHarness />);
+    expect(hookResult!.handleSupportsGapControl()).toBe(false);
   });
 });

--- a/apps/readest-app/src/__tests__/services/constants.test.ts
+++ b/apps/readest-app/src/__tests__/services/constants.test.ts
@@ -648,6 +648,8 @@ describe('services/constants', () => {
       expect(typeof DEFAULT_TTS_CONFIG).toBe('object');
       expect(typeof DEFAULT_TTS_CONFIG.ttsRate).toBe('number');
       expect(DEFAULT_TTS_CONFIG.ttsRate).toBeGreaterThan(0);
+      expect(typeof DEFAULT_TTS_CONFIG.ttsSentenceGap).toBe('number');
+      expect(DEFAULT_TTS_CONFIG.ttsSentenceGap).toBeGreaterThan(0);
       expect(typeof DEFAULT_TTS_CONFIG.ttsVoice).toBe('string');
       expect(typeof DEFAULT_TTS_CONFIG.ttsLocation).toBe('string');
       expect(typeof DEFAULT_TTS_CONFIG.ttsMediaMetadata).toBe('string');

--- a/apps/readest-app/src/__tests__/services/edge-tts-client-playback.test.ts
+++ b/apps/readest-app/src/__tests__/services/edge-tts-client-playback.test.ts
@@ -207,8 +207,8 @@ describe('EdgeTTSClient Web Audio playback', () => {
     sources = ctx().sources;
     expect(sources.length).toBeGreaterThanOrEqual(4);
 
-    // Chunk 3 is the first chunk scheduled after setSentenceGap,
-    // so it should use the new gap (from chunk 2's timing)
+    // Chunk 2 is the first chunk scheduled after setSentenceGap, so the gap
+    // preceding chunk 3 (chunk 2's schedule-time gap) reflects the new value.
     const [, , thirdChunk, fourthChunk] = sources;
     expect(fourthChunk!.startedAt! - thirdChunk!.endTime).toBeCloseTo(0.3, 5);
 

--- a/apps/readest-app/src/__tests__/services/edge-tts-client-playback.test.ts
+++ b/apps/readest-app/src/__tests__/services/edge-tts-client-playback.test.ts
@@ -176,6 +176,7 @@ describe('EdgeTTSClient Web Audio playback', () => {
       { name: '0', text: 'First sentence.', language: 'en' },
       { name: '1', text: 'Second sentence.', language: 'en' },
       { name: '2', text: 'Third sentence.', language: 'en' },
+      { name: '3', text: 'Fourth sentence.', language: 'en' },
     ];
     const client = await startClient();
     await client.setRate(1);
@@ -190,16 +191,26 @@ describe('EdgeTTSClient Web Audio playback', () => {
     // Change gap mid-session
     client.setSentenceGap(0.3);
 
-    // Advance playback to trigger more scheduling
-    await ctx().advanceTo(0.5);
+    // Advance playback to trigger chunk 0's onended and free scheduling capacity
+    // for chunk 2 to be scheduled. Then advance more to free chunk 1 so chunk 3 is scheduled.
+    await ctx().advanceTo(1.1);
+    await flush();
+
+    // Chunk 2 should now be scheduled with the old gap (from chunk 1's timing)
+    sources = ctx().sources;
+    expect(sources.length).toBeGreaterThanOrEqual(3);
+
+    // Advance further to free chunk 2, allowing chunk 3 to be scheduled with the new gap
+    await ctx().advanceTo(3.4);
     await flush();
 
     sources = ctx().sources;
-    // If a third chunk has been scheduled, it should use the new gap
-    if (sources.length >= 3) {
-      const [, second, third] = sources;
-      expect(third!.startedAt! - second!.endTime).toBeCloseTo(0.3, 5);
-    }
+    expect(sources.length).toBeGreaterThanOrEqual(4);
+
+    // Chunk 3 is the first chunk scheduled after setSentenceGap,
+    // so it should use the new gap (from chunk 2's timing)
+    const [, , thirdChunk, fourthChunk] = sources;
+    expect(fourthChunk!.startedAt! - thirdChunk!.endTime).toBeCloseTo(0.3, 5);
 
     await ctx().advanceTo(5);
     await done;

--- a/apps/readest-app/src/__tests__/services/edge-tts-client-playback.test.ts
+++ b/apps/readest-app/src/__tests__/services/edge-tts-client-playback.test.ts
@@ -158,6 +158,53 @@ describe('EdgeTTSClient Web Audio playback', () => {
     await done;
   });
 
+  test('setSentenceGap before speaking changes the observed gap', async () => {
+    const client = await startClient();
+    await client.setRate(1);
+    client.setSentenceGap(0.4); // gap = 0.4 / 1
+    const { done } = collectSpeak(client, new AbortController().signal);
+    await flush();
+    await flush();
+    const [first, second] = ctx().sources;
+    expect(second!.startedAt! - first!.endTime).toBeCloseTo(0.4, 5);
+    await ctx().advanceTo(5);
+    await done;
+  });
+
+  test('setSentenceGap mid-session affects the next scheduled gap', async () => {
+    parsedMarks = [
+      { name: '0', text: 'First sentence.', language: 'en' },
+      { name: '1', text: 'Second sentence.', language: 'en' },
+      { name: '2', text: 'Third sentence.', language: 'en' },
+    ];
+    const client = await startClient();
+    await client.setRate(1);
+    const { done } = collectSpeak(client, new AbortController().signal);
+    // Initial scheduling of chunks
+    await flush();
+    await flush();
+    let sources = ctx().sources;
+    const [first, second] = sources;
+    expect(second!.startedAt! - first!.endTime).toBeCloseTo(0.15, 5);
+
+    // Change gap mid-session
+    client.setSentenceGap(0.3);
+
+    // Advance playback to trigger more scheduling
+    await ctx().advanceTo(0.5);
+    await flush();
+
+    sources = ctx().sources;
+    // If a third chunk has been scheduled, it should use the new gap
+    if (sources.length >= 3) {
+      const [, second, third] = sources;
+      expect(third!.startedAt! - second!.endTime).toBeCloseTo(0.3, 5);
+    }
+
+    await ctx().advanceTo(5);
+    await done;
+  });
+
   test('word tracking follows the audio clock and survives pause/resume', async () => {
     createAudioDataBehavior = async () => ({
       data: new ArrayBuffer(48000), // 2s

--- a/apps/readest-app/src/__tests__/services/tts-auto-advance.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/services/tts-auto-advance.browser.test.tsx
@@ -78,8 +78,14 @@ vi.mock('@/services/tts/WebSpeechClient', () => ({
   }),
 }));
 vi.mock('@/services/tts/EdgeTTSClient', () => ({
+  // useTTSControl also imports this named const from the same module; the
+  // mock factory replaces the whole module, so it must re-export it too.
+  DEFAULT_SENTENCE_GAP_SEC: 0.15,
   EdgeTTSClient: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
-    Object.assign(this, makeMockTTSClient('edge'));
+    // TTSController.setSentenceGap always forwards to the real ttsEdgeClient
+    // instance regardless of the active engine, so this mock needs the method
+    // even though the other two client mocks don't.
+    Object.assign(this, makeMockTTSClient('edge'), { setSentenceGap: () => {} });
   }),
 }));
 vi.mock('@/services/tts/NativeTTSClient', () => ({

--- a/apps/readest-app/src/__tests__/services/tts-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/services/tts/WebSpeechClient', () => ({
 
 vi.mock('@/services/tts/EdgeTTSClient', () => ({
   EdgeTTSClient: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
-    Object.assign(this, createMockTTSClient('edge'));
+    Object.assign(this, createMockTTSClient('edge'), { setSentenceGap: vi.fn() });
   }),
 }));
 
@@ -293,6 +293,25 @@ describe('TTSController', () => {
     test('delegates to ttsClient.setRate', async () => {
       await controller.setRate(2.0);
       expect(controller.ttsClient.setRate).toHaveBeenCalledWith(2.0);
+    });
+  });
+
+  describe('supportsGapControl', () => {
+    test('returns true when ttsClient is the edge client', () => {
+      controller.ttsClient = controller.ttsEdgeClient;
+      expect(controller.supportsGapControl()).toBe(true);
+    });
+
+    test('returns false when ttsClient is not the edge client', () => {
+      controller.ttsClient = controller.ttsWebClient;
+      expect(controller.supportsGapControl()).toBe(false);
+    });
+  });
+
+  describe('setSentenceGap', () => {
+    test('delegates to ttsEdgeClient.setSentenceGap with the given value', () => {
+      controller.setSentenceGap(0.5);
+      expect(controller.ttsEdgeClient.setSentenceGap).toHaveBeenCalledWith(0.5);
     });
   });
 

--- a/apps/readest-app/src/app/reader/components/tts/GapChips.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/GapChips.tsx
@@ -1,0 +1,51 @@
+import clsx from 'clsx';
+import { useTranslation } from '@/hooks/useTranslation';
+
+export const GAP_PRESETS = [0, 0.1, 0.15, 0.25, 0.4, 0.6];
+
+export const formatGap = (sec: number) => `${parseFloat(sec.toFixed(2))}s`;
+
+type GapChipsProps = {
+  gap: number;
+  onSelect: (gap: number) => void;
+};
+
+// Inter-sentence pause presets as a wrapping chip grid (lives in the sheet's
+// Sentence Pause sub-view). A persisted off-preset gap (e.g. from a future
+// non-chip input or an older config) merges in as a selectable chip in
+// sorted position so the grid always shows the truth.
+const GapChips = ({ gap, onSelect }: GapChipsProps) => {
+  const _ = useTranslation();
+  const values = GAP_PRESETS.includes(gap)
+    ? GAP_PRESETS
+    : [...GAP_PRESETS, gap].sort((a, b) => a - b);
+
+  return (
+    <div
+      role='radiogroup'
+      aria-label={_('Sentence Pause')}
+      className='flex w-full flex-wrap justify-center gap-2 px-1 py-1'
+    >
+      {values.map((value) => {
+        const active = value === gap;
+        return (
+          <button
+            key={value}
+            type='button'
+            role='radio'
+            aria-checked={active}
+            onClick={() => onSelect(value)}
+            className={clsx(
+              'btn btn-sm h-8 min-h-8 shrink-0 rounded-full border-none px-3 font-normal shadow-none',
+              active ? 'btn-primary' : 'bg-base-100 eink-bordered',
+            )}
+          >
+            {formatGap(value)}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default GapChips;

--- a/apps/readest-app/src/app/reader/components/tts/ParagraphGapChips.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/ParagraphGapChips.tsx
@@ -1,0 +1,49 @@
+import clsx from 'clsx';
+import { useTranslation } from '@/hooks/useTranslation';
+import { formatGap } from './GapChips';
+
+export const PARAGRAPH_GAP_PRESETS = [0, 0.15, 0.3, 0.5, 0.75, 1, 1.5, 2];
+
+type ParagraphGapChipsProps = {
+  gap: number;
+  onSelect: (gap: number) => void;
+};
+
+// Paragraph-pause presets as a wrapping chip grid (lives in the sheet's
+// Paragraph Gap sub-view). A persisted off-preset gap merges in as a
+// selectable chip in sorted position so the grid always shows the truth.
+const ParagraphGapChips = ({ gap, onSelect }: ParagraphGapChipsProps) => {
+  const _ = useTranslation();
+  const values = PARAGRAPH_GAP_PRESETS.includes(gap)
+    ? PARAGRAPH_GAP_PRESETS
+    : [...PARAGRAPH_GAP_PRESETS, gap].sort((a, b) => a - b);
+
+  return (
+    <div
+      role='radiogroup'
+      aria-label={_('Paragraph Gap')}
+      className='flex w-full flex-wrap justify-center gap-2 px-1 py-1'
+    >
+      {values.map((value) => {
+        const active = value === gap;
+        return (
+          <button
+            key={value}
+            type='button'
+            role='radio'
+            aria-checked={active}
+            onClick={() => onSelect(value)}
+            className={clsx(
+              'btn btn-sm h-8 min-h-8 shrink-0 rounded-full border-none px-3 font-normal shadow-none',
+              active ? 'btn-primary' : 'bg-base-100 eink-bordered',
+            )}
+          >
+            {formatGap(value)}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ParagraphGapChips;

--- a/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
@@ -31,6 +31,7 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
 
   const isEink = getViewSettings(bookKey)?.isEink ?? false;
   const hasTimeline = tts.ttsClientsInited && tts.handleSupportsPlaybackInfo();
+  const hasGapControl = tts.ttsClientsInited && tts.handleSupportsGapControl();
 
   useEffect(() => {
     if (tts.showBackToCurrentTTSLocation) {
@@ -110,6 +111,7 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
           ttsLang={tts.ttsLang}
           isPlaying={tts.isPlaying}
           hasTimeline={hasTimeline}
+          hasGapControl={hasGapControl}
           timeoutOption={tts.timeoutOption}
           timeoutTimestamp={tts.timeoutTimestamp}
           chapterRemainingSec={tts.chapterRemainingSec}
@@ -118,6 +120,7 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
           onBackward={tts.handleBackward}
           onForward={tts.handleForward}
           onSetRate={tts.handleSetRate}
+          onSetSentenceGap={tts.handleSetSentenceGap}
           onGetVoices={tts.handleGetVoices}
           onSetVoice={tts.handleSetVoice}
           onGetVoiceId={tts.handleGetVoiceId}

--- a/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
@@ -121,6 +121,7 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
           onForward={tts.handleForward}
           onSetRate={tts.handleSetRate}
           onSetSentenceGap={tts.handleSetSentenceGap}
+          onSetParagraphGap={tts.handleSetParagraphGap}
           onGetVoices={tts.handleGetVoices}
           onSetVoice={tts.handleSetVoice}
           onGetVoiceId={tts.handleGetVoiceId}

--- a/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
@@ -8,12 +8,14 @@ import {
   MdFastRewind,
   MdOutlinePause,
   MdPlayArrow,
+  MdSegment,
   MdSkipNext,
   MdSkipPrevious,
 } from 'react-icons/md';
 import { RiVoiceAiFill } from 'react-icons/ri';
 import { TTSVoicesGroup } from '@/services/tts';
 import { DEFAULT_SENTENCE_GAP_SEC } from '@/services/tts/EdgeTTSClient';
+import { DEFAULT_PARAGRAPH_GAP_SEC } from '@/services/tts/TTSController';
 import { useEnv } from '@/context/EnvContext';
 import { useReaderStore } from '@/store/readerStore';
 import { useBookProgress } from '@/store/readerProgressStore';
@@ -29,8 +31,9 @@ import { useCountdownLabel } from './useCountdownLabel';
 import TTSScrubber from './TTSScrubber';
 import SpeedChips, { formatRate } from './SpeedChips';
 import GapChips, { formatGap } from './GapChips';
+import ParagraphGapChips from './ParagraphGapChips';
 
-type SheetView = 'main' | 'speed' | 'voice' | 'timer';
+type SheetView = 'main' | 'speed' | 'voice' | 'timer' | 'paragraphGap';
 
 const getTTSTimeoutOptions = (_: TranslationFunc) => {
   return [
@@ -67,6 +70,7 @@ type TTSPlayerSheetProps = {
   onForward: (byMark: boolean) => void;
   onSetRate: (rate: number) => void;
   onSetSentenceGap: (sec: number) => void;
+  onSetParagraphGap: (sec: number) => void;
   onGetVoices: (lang: string) => Promise<TTSVoicesGroup[]>;
   onSetVoice: (voice: string, lang: string) => void;
   onGetVoiceId: () => string;
@@ -94,6 +98,7 @@ const TTSPlayerSheet = ({
   onForward,
   onSetRate,
   onSetSentenceGap,
+  onSetParagraphGap,
   onGetVoices,
   onSetVoice,
   onGetVoiceId,
@@ -112,6 +117,9 @@ const TTSPlayerSheet = ({
   const [voiceGroups, setVoiceGroups] = useState<TTSVoicesGroup[]>([]);
   const [rate, setRate] = useState(viewSettings?.ttsRate ?? 1.0);
   const [gap, setGap] = useState(viewSettings?.ttsSentenceGap ?? DEFAULT_SENTENCE_GAP_SEC);
+  const [paragraphGap, setParagraphGap] = useState(
+    viewSettings?.ttsParagraphGap ?? DEFAULT_PARAGRAPH_GAP_SEC,
+  );
   const [selectedVoice, setSelectedVoice] = useState('');
   const timerLabel = useCountdownLabel(timeoutTimestamp);
   const iconSize18 = useResponsiveSize(18);
@@ -128,6 +136,7 @@ const TTSPlayerSheet = ({
     setView('main');
     setRate(getViewSettings(bookKey)?.ttsRate ?? 1.0);
     setGap(getViewSettings(bookKey)?.ttsSentenceGap ?? DEFAULT_SENTENCE_GAP_SEC);
+    setParagraphGap(getViewSettings(bookKey)?.ttsParagraphGap ?? DEFAULT_PARAGRAPH_GAP_SEC);
     setSelectedVoice(onGetVoiceId());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
@@ -181,6 +190,20 @@ const TTSPlayerSheet = ({
     saveSettings(envConfig, settings);
   };
 
+  const handleSelectParagraphGap = (value: number) => {
+    setParagraphGap(value);
+    onSetParagraphGap(value);
+    const vs = getViewSettings(bookKey)!;
+    vs.ttsParagraphGap = value;
+    setViewSettings(bookKey, vs);
+    // Read the store fresh at call time: a `settings` captured at render goes
+    // stale if anything else persisted settings since this sheet mounted.
+    const { settings, setSettings, saveSettings } = useSettingsStore.getState();
+    settings.globalViewSettings.ttsParagraphGap = value;
+    setSettings(settings);
+    saveSettings(envConfig, settings);
+  };
+
   const handleSelectVoice = (voice: string, lang: string) => {
     onSetVoice(voice, lang);
     setSelectedVoice(voice);
@@ -224,7 +247,9 @@ const TTSPlayerSheet = ({
               ? _('Speed')
               : view === 'voice'
                 ? _('Select Voice')
-                : _('Set Timeout')}
+                : view === 'paragraphGap'
+                  ? _('Paragraph Gap')
+                  : _('Set Timeout')}
           </span>
         </div>
       </div>
@@ -349,6 +374,17 @@ const TTSPlayerSheet = ({
                 {timerCaption}
               </span>
             </button>
+            <button
+              type='button'
+              aria-label={_('Paragraph Gap')}
+              onClick={() => setView('paragraphGap')}
+              className='not-eink:bg-base-200 eink-bordered flex h-14 min-w-0 flex-1 flex-col items-center justify-center gap-0.5 rounded-xl'
+            >
+              <MdSegment size={iconSize18} />
+              <span className='text-base-content/60 max-w-full truncate px-1 text-xs tabular-nums'>
+                {formatGap(paragraphGap)}
+              </span>
+            </button>
           </div>
         </div>
       )}
@@ -363,6 +399,11 @@ const TTSPlayerSheet = ({
               <GapChips gap={gap} onSelect={handleSelectGap} />
             </>
           )}
+        </div>
+      )}
+      {view === 'paragraphGap' && (
+        <div className='flex w-full flex-col items-center pb-4 pt-2'>
+          <ParagraphGapChips gap={paragraphGap} onSelect={handleSelectParagraphGap} />
         </div>
       )}
       {view === 'voice' && (

--- a/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-icons/md';
 import { RiVoiceAiFill } from 'react-icons/ri';
 import { TTSVoicesGroup } from '@/services/tts';
+import { DEFAULT_SENTENCE_GAP_SEC } from '@/services/tts/EdgeTTSClient';
 import { useEnv } from '@/context/EnvContext';
 import { useReaderStore } from '@/store/readerStore';
 import { useBookProgress } from '@/store/readerProgressStore';
@@ -27,6 +28,7 @@ import { TTSPlaybackInfo } from './usePlaybackInfo';
 import { useCountdownLabel } from './useCountdownLabel';
 import TTSScrubber from './TTSScrubber';
 import SpeedChips, { formatRate } from './SpeedChips';
+import GapChips, { formatGap } from './GapChips';
 
 type SheetView = 'main' | 'speed' | 'voice' | 'timer';
 
@@ -55,6 +57,7 @@ type TTSPlayerSheetProps = {
   ttsLang: string;
   isPlaying: boolean;
   hasTimeline: boolean;
+  hasGapControl: boolean;
   timeoutOption: number;
   timeoutTimestamp: number;
   chapterRemainingSec: number | null;
@@ -63,6 +66,7 @@ type TTSPlayerSheetProps = {
   onBackward: (byMark: boolean) => void;
   onForward: (byMark: boolean) => void;
   onSetRate: (rate: number) => void;
+  onSetSentenceGap: (sec: number) => void;
   onGetVoices: (lang: string) => Promise<TTSVoicesGroup[]>;
   onSetVoice: (voice: string, lang: string) => void;
   onGetVoiceId: () => string;
@@ -80,6 +84,7 @@ const TTSPlayerSheet = ({
   ttsLang,
   isPlaying,
   hasTimeline,
+  hasGapControl,
   timeoutOption,
   timeoutTimestamp,
   chapterRemainingSec,
@@ -88,6 +93,7 @@ const TTSPlayerSheet = ({
   onBackward,
   onForward,
   onSetRate,
+  onSetSentenceGap,
   onGetVoices,
   onSetVoice,
   onGetVoiceId,
@@ -105,6 +111,7 @@ const TTSPlayerSheet = ({
   const [view, setView] = useState<SheetView>('main');
   const [voiceGroups, setVoiceGroups] = useState<TTSVoicesGroup[]>([]);
   const [rate, setRate] = useState(viewSettings?.ttsRate ?? 1.0);
+  const [gap, setGap] = useState(viewSettings?.ttsSentenceGap ?? DEFAULT_SENTENCE_GAP_SEC);
   const [selectedVoice, setSelectedVoice] = useState('');
   const timerLabel = useCountdownLabel(timeoutTimestamp);
   const iconSize18 = useResponsiveSize(18);
@@ -120,6 +127,7 @@ const TTSPlayerSheet = ({
     if (!isOpen) return;
     setView('main');
     setRate(getViewSettings(bookKey)?.ttsRate ?? 1.0);
+    setGap(getViewSettings(bookKey)?.ttsSentenceGap ?? DEFAULT_SENTENCE_GAP_SEC);
     setSelectedVoice(onGetVoiceId());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
@@ -155,6 +163,20 @@ const TTSPlayerSheet = ({
     // stale if anything else persisted settings since this sheet mounted.
     const { settings, setSettings, saveSettings } = useSettingsStore.getState();
     settings.globalViewSettings.ttsRate = value;
+    setSettings(settings);
+    saveSettings(envConfig, settings);
+  };
+
+  const handleSelectGap = (value: number) => {
+    setGap(value);
+    onSetSentenceGap(value);
+    const vs = getViewSettings(bookKey)!;
+    vs.ttsSentenceGap = value;
+    setViewSettings(bookKey, vs);
+    // Read the store fresh at call time: a `settings` captured at render goes
+    // stale if anything else persisted settings since this sheet mounted.
+    const { settings, setSettings, saveSettings } = useSettingsStore.getState();
+    settings.globalViewSettings.ttsSentenceGap = value;
     setSettings(settings);
     saveSettings(envConfig, settings);
   };
@@ -333,6 +355,14 @@ const TTSPlayerSheet = ({
       {view === 'speed' && (
         <div className='flex w-full flex-col items-center pb-4 pt-2'>
           <SpeedChips rate={rate} onSelect={handleSelectRate} />
+          {hasGapControl && (
+            <>
+              <div className='text-base-content/60 w-full px-2 py-1 text-sm sm:text-xs'>
+                {_('Sentence Pause')} · {formatGap(gap)}
+              </div>
+              <GapChips gap={gap} onSelect={handleSelectGap} />
+            </>
+          )}
         </div>
       )}
       {view === 'voice' && (

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -16,6 +16,7 @@ import {
   TTSVoicesGroup,
 } from '@/services/tts';
 import { DEFAULT_SENTENCE_GAP_SEC } from '@/services/tts/EdgeTTSClient';
+import { DEFAULT_PARAGRAPH_GAP_SEC } from '@/services/tts/TTSController';
 import { eventDispatcher } from '@/utils/event';
 import { genSSMLRaw, parseSSMLLang } from '@/utils/ssml';
 import { throttle } from '@/utils/throttle';
@@ -792,6 +793,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
           ttsController.setLang(lang);
           ttsController.setRate(viewSettings.ttsRate);
           ttsController.setSentenceGap(viewSettings.ttsSentenceGap ?? DEFAULT_SENTENCE_GAP_SEC);
+          ttsController.setParagraphGap(viewSettings.ttsParagraphGap ?? DEFAULT_PARAGRAPH_GAP_SEC);
           ttsController.speak(ssml, oneTime, () => handleStop(bookKey));
           ttsController.setTargetLang(getTTSTargetLang() || '');
         }
@@ -930,6 +932,12 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     ttsControllerRef.current?.setSentenceGap(sec);
   }, []);
 
+  // Paragraph gap: applies to every TTS client (not Edge-only), read live by
+  // the controller when auto-advancing, so no stop/restart here either.
+  const handleSetParagraphGap = useCallback((sec: number) => {
+    ttsControllerRef.current?.setParagraphGap(sec);
+  }, []);
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleSetVoice = useCallback(
     throttle(async (voice: string, lang: string) => {
@@ -998,6 +1006,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     handlePause,
     handleSetRate,
     handleSetSentenceGap,
+    handleSetParagraphGap,
     handleSetVoice,
     handleGetVoices,
     handleGetVoiceId,

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -15,6 +15,7 @@ import {
   TTSHighlightOptions,
   TTSVoicesGroup,
 } from '@/services/tts';
+import { DEFAULT_SENTENCE_GAP_SEC } from '@/services/tts/EdgeTTSClient';
 import { eventDispatcher } from '@/utils/event';
 import { genSSMLRaw, parseSSMLLang } from '@/utils/ssml';
 import { throttle } from '@/utils/throttle';
@@ -790,6 +791,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
 
           ttsController.setLang(lang);
           ttsController.setRate(viewSettings.ttsRate);
+          ttsController.setSentenceGap(viewSettings.ttsSentenceGap ?? DEFAULT_SENTENCE_GAP_SEC);
           ttsController.speak(ssml, oneTime, () => handleStop(bookKey));
           ttsController.setTargetLang(getTTSTargetLang() || '');
         }
@@ -848,6 +850,10 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
 
   const handleSupportsPlaybackInfo = useCallback(() => {
     return ttsControllerRef.current?.supportsPlaybackInfo() ?? false;
+  }, []);
+
+  const handleSupportsGapControl = useCallback(() => {
+    return ttsControllerRef.current?.supportsGapControl() ?? false;
   }, []);
 
   // Playback callbacks
@@ -918,6 +924,12 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     [],
   );
 
+  // Inter-sentence gap: read live at schedule time by the controller, so
+  // changing it must not stop/restart playback like handleSetRate does.
+  const handleSetSentenceGap = useCallback((sec: number) => {
+    ttsControllerRef.current?.setSentenceGap(sec);
+  }, []);
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleSetVoice = useCallback(
     throttle(async (voice: string, lang: string) => {
@@ -985,6 +997,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     handleForward,
     handlePause,
     handleSetRate,
+    handleSetSentenceGap,
     handleSetVoice,
     handleGetVoices,
     handleGetVoiceId,
@@ -993,6 +1006,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     handleSeekTo,
     handleGetPlaybackInfo,
     handleSupportsPlaybackInfo,
+    handleSupportsGapControl,
     refreshTtsLang,
   };
 };

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -36,6 +36,7 @@ import { stubTranslation as _ } from '@/utils/misc';
 import { DEFAULT_AI_SETTINGS } from './ai/constants';
 import { DEFAULT_ANNOTATION_TOOLBAR_ITEMS } from '@/utils/annotationToolbar';
 import { DEFAULT_SENTENCE_GAP_SEC } from './tts/EdgeTTSClient';
+import { DEFAULT_PARAGRAPH_GAP_SEC } from './tts/TTSController';
 
 export const DATA_SUBDIR = 'Readest';
 export const LOCAL_BOOKS_SUBDIR = `${DATA_SUBDIR}/Books`;
@@ -418,6 +419,7 @@ export const DEFAULT_VIEW_CONFIG: ViewConfig = {
 export const DEFAULT_TTS_CONFIG: TTSConfig = {
   ttsRate: 1.3,
   ttsSentenceGap: DEFAULT_SENTENCE_GAP_SEC,
+  ttsParagraphGap: DEFAULT_PARAGRAPH_GAP_SEC,
   ttsVoice: '',
   ttsLocation: '',
   ttsHighlightOptions: { style: 'highlight', color: '#808080' },

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -35,6 +35,7 @@ import { getDefaultMaxBlockSize, getDefaultMaxInlineSize } from '@/utils/config'
 import { stubTranslation as _ } from '@/utils/misc';
 import { DEFAULT_AI_SETTINGS } from './ai/constants';
 import { DEFAULT_ANNOTATION_TOOLBAR_ITEMS } from '@/utils/annotationToolbar';
+import { DEFAULT_SENTENCE_GAP_SEC } from './tts/EdgeTTSClient';
 
 export const DATA_SUBDIR = 'Readest';
 export const LOCAL_BOOKS_SUBDIR = `${DATA_SUBDIR}/Books`;
@@ -416,6 +417,7 @@ export const DEFAULT_VIEW_CONFIG: ViewConfig = {
 
 export const DEFAULT_TTS_CONFIG: TTSConfig = {
   ttsRate: 1.3,
+  ttsSentenceGap: DEFAULT_SENTENCE_GAP_SEC,
   ttsVoice: '',
   ttsLocation: '',
   ttsHighlightOptions: { style: 'highlight', color: '#808080' },

--- a/apps/readest-app/src/services/tts/EdgeTTSClient.ts
+++ b/apps/readest-app/src/services/tts/EdgeTTSClient.ts
@@ -27,7 +27,7 @@ import { TTSAudioBuffer, WebAudioPlayer, WebAudioPlayerEvent } from './WebAudioP
 // Natural pause between sentences, replacing Edge's baked-in ~300ms trailing
 // silence. Divided by the playback rate so pauses shrink with speed (#2033's
 // "gaps don't scale" complaint).
-const INTER_SENTENCE_GAP_SEC = 0.15;
+export const DEFAULT_SENTENCE_GAP_SEC = 0.15;
 const TICKS_PER_SECOND = 10_000_000;
 
 interface ChunkMeta {
@@ -72,6 +72,7 @@ export class EdgeTTSClient implements TTSClient {
   #currentVoiceId = '';
   #rate = 1.0;
   #pitch = 1.0;
+  #sentenceGapSec = DEFAULT_SENTENCE_GAP_SEC;
 
   #edgeTTS: EdgeSpeechTTS | null = null;
   #player = new WebAudioPlayer();
@@ -363,7 +364,7 @@ export class EdgeTTSClient implements TTSClient {
         this.#player.scheduleChunk(generation, prepared.buffer, {
           trimStartSec: prepared.trimStartSec,
           mediaScale: prepared.trimmedDurationSec / prepared.buffer.duration,
-          gapSec: INTER_SENTENCE_GAP_SEC / rate,
+          gapSec: this.#sentenceGapSec / rate,
         });
       }
       if (!signal.aborted && this.#activeGeneration === generation) {
@@ -500,6 +501,10 @@ export class EdgeTTSClient implements TTSClient {
     if (selectedVoice) {
       this.#currentVoiceId = selectedVoice.id;
     }
+  }
+
+  setSentenceGap(sec: number): void {
+    this.#sentenceGapSec = sec;
   }
 
   async getAllVoices(): Promise<TTSVoice[]> {

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -150,7 +150,7 @@ export class TTSController extends EventTarget {
   ttsRate: number = 1.0;
   ttsClient: TTSClient;
   ttsWebClient: TTSClient;
-  ttsEdgeClient: TTSClient;
+  ttsEdgeClient: EdgeTTSClient;
   ttsNativeClient: TTSClient | null = null;
   ttsWebVoices: TTSVoice[] = [];
   ttsEdgeVoices: TTSVoice[] = [];
@@ -503,6 +503,18 @@ export class TTSController extends EventTarget {
   // null, and hides entirely while false.
   supportsPlaybackInfo(): boolean {
     return this.ttsClient === this.ttsEdgeClient;
+  }
+
+  // Whether the active client supports the inter-sentence gap control (Edge only).
+  supportsGapControl(): boolean {
+    return this.ttsClient === this.ttsEdgeClient;
+  }
+
+  // Passthrough to the Edge client's inter-sentence gap. ttsEdgeClient is
+  // always a constructed instance, whether or not it's the currently active
+  // client (same as supportsPlaybackInfo/supportsGapControl's comparison).
+  setSentenceGap(sec: number): void {
+    this.ttsEdgeClient.setSentenceGap(sec);
   }
 
   // Position/duration of the current section playback at the current rate.

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -90,12 +90,21 @@ const createTTSNodeFilter = () =>
     contents: [{ tag: 'a', content: /^[\[\(]?[\*\d]+[\)\]]?$/ }],
   });
 
+// Silence inserted between paragraphs when auto-advancing during continuous
+// playback. Unlike the Edge-only inter-sentence gap, this applies to every
+// TTS client: the paragraph-to-paragraph transition (stop -> next -> speak)
+// is engine-agnostic, handled entirely in #speak()/forward() below. There is
+// no natural pause here otherwise -- the transition is as fast as the async
+// stop/init overhead allows, which reads as no pause at all.
+export const DEFAULT_PARAGRAPH_GAP_SEC = 0.3;
+
 export class TTSController extends EventTarget {
   appService: AppService | null = null;
   view: FoliateView;
   isAuthenticated: boolean = false;
   preprocessCallback?: (ssml: string) => Promise<string>;
   onSectionChange?: (sectionIndex: number) => Promise<void>;
+  #paragraphGapSec: number = DEFAULT_PARAGRAPH_GAP_SEC;
   #nossmlCnt: number = 0;
   // Consecutive native-TTS utterances that ended in a terminal 'error' without
   // a successful 'end' in between. Reset on success; caps skip-on-error so a
@@ -517,6 +526,32 @@ export class TTSController extends EventTarget {
     this.ttsEdgeClient.setSentenceGap(sec);
   }
 
+  // Universal (not Edge-only) paragraph-to-paragraph gap. See
+  // DEFAULT_PARAGRAPH_GAP_SEC and #delayParagraphGap for where it's applied.
+  setParagraphGap(sec: number): void {
+    this.#paragraphGapSec = sec;
+  }
+
+  // Abortable delay inserted before auto-advancing to the next paragraph.
+  // Scales with rate like the sentence gap so pauses shrink with speed.
+  // Races against `signal` so a stop()/pause() during the gap resolves
+  // immediately instead of leaving a stray forward() to fire afterward.
+  async #delayParagraphGap(signal: AbortSignal): Promise<void> {
+    const ms = (this.#paragraphGapSec / this.ttsRate) * 1000;
+    if (ms <= 0 || signal.aborted) return;
+    await new Promise<void>((resolve) => {
+      const onAbort = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        signal.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+      signal.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
   // Position/duration of the current section playback at the current rate.
   // Null while no timeline exists (non-Edge client, timeline not yet built,
   // or nothing located yet) — the UI reserves a disabled slot for that state.
@@ -724,6 +759,8 @@ export class TTSController extends EventTarget {
         if (lastCode === 'end' && this.state === 'playing' && !oneTime) {
           this.#consecutiveSpeakErrors = 0;
           resolve();
+          await this.#delayParagraphGap(signal);
+          if (signal.aborted) return;
           await this.forward();
         } else if (
           lastCode === 'error' &&

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -315,6 +315,7 @@ export interface ViewConfig {
 export interface TTSConfig {
   ttsRate: number;
   ttsSentenceGap: number;
+  ttsParagraphGap: number;
   ttsVoice: string;
   ttsLocation: string;
   ttsHighlightOptions: TTSHighlightOptions;

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -314,6 +314,7 @@ export interface ViewConfig {
 
 export interface TTSConfig {
   ttsRate: number;
+  ttsSentenceGap: number;
   ttsVoice: string;
   ttsLocation: string;
   ttsHighlightOptions: TTSHighlightOptions;


### PR DESCRIPTION
## Summary
- Exposes the Edge TTS inter-sentence pause (previously a hardcoded 0.15s constant) as a user setting, gated to appear only when an Edge TTS voice is active. Default behavior (0.15s, scaling with playback rate) is unchanged for anyone who doesn't touch the new control.
- Adds a new, separate paragraph-gap setting that applies to **all** TTS engines (Edge, native, Web Speech) — the paragraph-to-paragraph transition previously had no deliberate pause at all, just whatever async stop/restart overhead happened to take, which read as no gap. Default is 0.3s.
- Both settings live in the TTS player sheet as their own menu tiles (Speed sub-view for sentence pause since it's closely related to rate; its own "Paragraph Gap" tile/sub-view for the paragraph setting), persisted per-book/view the same way `ttsRate` already is, and survive app restart.
- Changing either value takes effect on the next scheduled sentence/paragraph without requiring a stop/restart of playback.
- i18n: new translation keys added and translated across all supported locales.

Fixes #5037

## Test plan
- [x] `pnpm test` — all TTS/config/component unit tests pass (281 tests across the touched suites)
- [x] `pnpm exec biome lint .` — clean
- [x] `pnpm exec tsgo --noEmit` — clean (no new errors)
- [x] Manually built a Linux release binary (`tauri build --no-bundle`) and ran it: confirmed the Sentence Pause control only appears for an Edge voice, the new Paragraph Gap tile appears regardless of engine, and both persist across a sheet close/reopen.
- [x] Manually built android version, ran it trying different settings on Edge TTS. Works as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Pictures:
paragraph gap
<img width="636" height="299" alt="image" src="https://github.com/user-attachments/assets/e374e001-ae89-4885-ac1e-47198ee002f3" />

sentence pause:
<img width="638" height="321" alt="image" src="https://github.com/user-attachments/assets/4100a301-1e0c-4e2f-95b5-88b272dd7fc3" />
