### PR TITLE
fix(opds): fix logic for temporary destination filename (#5024)

### DIFF
--- a/apps/readest-app/src/app/opds/page.tsx
+++ b/apps/readest-app/src/app/opds/page.tsx
@@ -57,6 +57,7 @@ import { normalizeOPDSCustomHeaders } from './utils/customHeaders';
 import { closeOPDSBrowser, stashOPDSReturnTarget } from './utils/opdsClose';
 import { findExistingBookForPublication } from './utils/findExistingBook';
 import Dialog from '@/components/Dialog';
+import { uniqueId } from '@/utils/misc';
 
 type ViewMode = 'feed' | 'publication' | 'search' | 'loading' | 'error';
 
@@ -588,7 +589,7 @@ export default function BrowserPage() {
 
           const pathname = decodeURIComponent(new URL(url).pathname);
           const ext = getFileExtFromMimeType(parsed?.mediaType) || getFileExtFromPath(pathname);
-          const basename = pathname.replaceAll('/', '_');
+          const basename = uniqueId();
           const filename = ext ? `${basename}.${ext}` : basename;
           let dstFilePath = await appService?.resolveFilePath(filename, 'Cache');
           console.log('Downloading to:', url, dstFilePath);

--- a/apps/readest-app/src/services/opds/autoDownload.ts
+++ b/apps/readest-app/src/services/opds/autoDownload.ts
@@ -17,6 +17,7 @@ import { upsertOPDSSourceMapping } from './sourceMap';
 import { isRetryEligible, DOWNLOAD_CONCURRENCY, MAX_RETRY_ATTEMPTS } from './types';
 import type { PendingItem, SyncResult, OPDSSubscriptionState, FailedEntry } from './types';
 import { runWithConcurrency } from '@/utils/concurrency';
+import { uniqueId } from '@/utils/misc';
 
 /**
  * Download a single item and import it into the library.
@@ -62,9 +63,7 @@ async function downloadAndImport(
   // Use the last non-empty path segment as the base; falling back to the
   // entry id avoids producing 200+ char filenames from deep URLs and keeps
   // us comfortably under the ~255-byte filesystem limit.
-  const lastSegment = pathname.split('/').filter(Boolean).pop() ?? '';
-  const sanitized = (lastSegment || item.entryId).replaceAll(/[/\\:*?"<>|]/g, '_').slice(0, 200);
-  const basename = sanitized || 'opds-download';
+  const basename = uniqueId();
   const filename = ext ? `${basename}.${ext}` : basename;
   let dstFilePath = await appService.resolveFilePath(filename, 'Cache');
 


### PR DESCRIPTION
Previously, the destination filename for OPDS downloads was derived from the request URL. In applications such as Calibre Web Automated, download URLs have the form `/opds/download/364/pdf/`, causing temporary files to be named all `pdf.pdf` or `epub.epub`, leading to race conditions.

This patch uses a random UUID for temporary filenames instead of relying on the URL, ensuring unique filenames regardless of the download endpoint.

Fixes #5024.