### PR TITLE
fix: only open last book if book is not marked as finished

### DIFF
--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -554,7 +554,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     if (lastBookIds.length === 0) return false;
     const bookIds: string[] = [];
     for (const bookId of lastBookIds) {
-      const book = libraryBooks.find((b) => b.hash === bookId);
+      const book = libraryBooks.find((b) => b.hash === bookId && b.readingStatus !== 'finished');
       if (book && (await appService.isBookAvailable(book))) {
         bookIds.push(book.hash);
       }


### PR DESCRIPTION
Closes #5064.

Basically implements a more rudimentary version of Apple Books' 'Open Last Book' feature where the last book is only opened if its status is marked as finished. Of course, Apple Books' version seems to be a lot more complex and complete, something which likely can be implemented later down the line.

I can't actually test these changes because I haven't fixed #5005 yet (been banging my head against a wall for a week with absolutely no progress), but I assume this should work. I hope.