### PR TITLE
fix(dictionary): let a web search entry lead the popup when it is first in the configured order

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/annotator/DictionarySheet.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/annotator/DictionarySheet.test.tsx
@@ -495,6 +495,39 @@ describe('DictionarySheet — web search row', () => {
   });
 });
 
+describe('DictionarySheet — section order', () => {
+  // The registry hands the sheet its providers already sorted by
+  // `settings.providerOrder`, so the first entry of `providersForNextRender`
+  // is whatever the user dragged to the top in settings.
+  const buildWebEntry = (): DictionaryProvider => ({
+    id: BUILTIN_WEB_SEARCH_IDS.google,
+    kind: 'web',
+    label: 'Google',
+    async lookup() {
+      return { ok: true };
+    },
+  });
+
+  const sectionHeadings = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('section > h3')).map((h) => h.textContent);
+
+  it('puts the web-search section first when a web entry is top of the configured order (#5083)', async () => {
+    providersForNextRender.push(buildWebEntry(), buildRealStarDictProvider());
+    const { container } = renderSheet({ word: 'hello' });
+
+    await screen.findByText('CMU American English spelling');
+    expect(sectionHeadings(container)).toEqual(['Search the web', 'Dictionaries']);
+  });
+
+  it('keeps the dictionaries section first when a dictionary is top of the configured order', async () => {
+    providersForNextRender.push(buildRealStarDictProvider(), buildWebEntry());
+    const { container } = renderSheet({ word: 'hello' });
+
+    await screen.findByText('CMU American English spelling');
+    expect(sectionHeadings(container)).toEqual(['Dictionaries', 'Search the web']);
+  });
+});
+
 describe('DictionarySheet — empty state', () => {
   it('renders "No dictionaries enabled" + manage gear when zero providers are configured', async () => {
     // providersForNextRender stays empty.

--- a/apps/readest-app/src/app/reader/components/annotator/DictionaryResultsView.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/DictionaryResultsView.tsx
@@ -43,6 +43,8 @@ export interface DictionaryResultsState {
   goBack: () => void;
   visibleDefinitionProviders: DictionaryProvider[];
   webSearchProviders: DictionaryProvider[];
+  /** Whether the web-search section renders above the dictionaries one (#5083). */
+  webSearchFirst: boolean;
   cards: Record<string, CardState>;
   setContainerRef: (id: string) => (el: HTMLDivElement | null) => void;
   handleContainerClick: (e: React.MouseEvent) => void;
@@ -91,6 +93,11 @@ export function useDictionaryResults({
 
   const definitionProviders = useMemo(() => providers.filter((p) => p.kind !== 'web'), [providers]);
   const webSearchProviders = useMemo(() => providers.filter((p) => p.kind === 'web'), [providers]);
+  // Web entries live in their own section, so `providerOrder` alone can't lift
+  // one above the dictionary cards (#5083). Let the top-most enabled provider
+  // decide which section leads. Derived from the full enabled list rather than
+  // the visible one so the sections don't reshuffle as lookups settle.
+  const webSearchFirst = providers[0]?.kind === 'web';
 
   const [historyStack, setHistoryStack] = useState<string[]>([word.trim()]);
   const currentWord = historyStack[historyStack.length - 1] ?? word.trim();
@@ -336,6 +343,7 @@ export function useDictionaryResults({
     goBack,
     visibleDefinitionProviders,
     webSearchProviders,
+    webSearchFirst,
     cards,
     setContainerRef,
     handleContainerClick,
@@ -429,6 +437,7 @@ interface DictionaryResultsBodyProps extends DictionaryResultsState {}
 export const DictionaryResultsBody: React.FC<DictionaryResultsBodyProps> = ({
   visibleDefinitionProviders,
   webSearchProviders,
+  webSearchFirst,
   cards,
   setContainerRef,
   handleContainerClick,
@@ -439,6 +448,112 @@ export const DictionaryResultsBody: React.FC<DictionaryResultsBodyProps> = ({
   fontScale,
 }) => {
   const _ = useTranslation();
+
+  // `first:pt-2` keeps the leading section's tighter top padding whichever of
+  // the two comes first.
+  const sectionClassName = 'px-4 pt-4 first:pt-2';
+
+  const definitionsSection = visibleDefinitionProviders.length > 0 && (
+    <section className={sectionClassName}>
+      <h3 className='not-eink:opacity-60 mb-2 text-xs font-medium uppercase tracking-wide'>
+        {_('Dictionaries')}
+      </h3>
+      <ul className='flex flex-col gap-3'>
+        {visibleDefinitionProviders.map((p) => {
+          const card = cards[p.id];
+          const isLoading = !card || card.state === 'loading';
+          const expanded = card?.expanded ?? false;
+          const sourceLabel =
+            card?.outcome?.ok && card.outcome.sourceLabel ? card.outcome.sourceLabel : _(p.label);
+          return (
+            <li key={p.id}>
+              <div
+                data-testid='dict-card'
+                role='button'
+                tabIndex={0}
+                aria-expanded={expanded}
+                onClick={(e) => {
+                  const path = e.nativeEvent.composedPath();
+                  for (const node of path) {
+                    if (node === e.currentTarget) break;
+                    if (node instanceof Element) {
+                      const tag = node.tagName;
+                      if (tag === 'A' || tag === 'BUTTON' || tag === 'IMG') return;
+                    }
+                  }
+                  toggleExpanded(p.id);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleExpanded(p.id);
+                  }
+                }}
+                className={clsx('cursor-pointer rounded-lg')}
+              >
+                {isLoading && (
+                  <div
+                    data-testid='dict-card-skeleton'
+                    className='bg-base-200/50 h-12 animate-pulse rounded'
+                  />
+                )}
+                <div
+                  ref={setContainerRef(p.id)}
+                  onClick={handleContainerClick}
+                  // `data-dict-content` + `--dict-font-scale` drive the
+                  // popup font-size rules in globals.css (#4443): the
+                  // light-DOM `font-size` cascade and the MDict shadow
+                  // `::part(dict-content)` rule both read this scope.
+                  data-dict-content=''
+                  style={{ '--dict-font-scale': fontScale } as React.CSSProperties}
+                  className={clsx(
+                    'font-sans',
+                    isLoading && 'hidden',
+                    !isLoading &&
+                      !expanded &&
+                      'line-clamp-4 max-h-40 overflow-hidden [-webkit-box-orient:vertical] [display:-webkit-box]',
+                  )}
+                />
+                {!isLoading && (
+                  <div className='border-base-content/10 -me-4 mt-2 border-b pb-2'>
+                    <span className='not-eink:opacity-60 text-xs'>{sourceLabel}</span>
+                  </div>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+
+  const webSearchSection = webSearchProviders.length > 0 && (
+    <section className={sectionClassName}>
+      <h3 className='not-eink:opacity-60 mb-2 text-xs font-medium uppercase tracking-wide'>
+        {_('Search the web')}
+      </h3>
+      <ul className='flex flex-col'>
+        {webSearchProviders.map((p) => {
+          const url = resolveWebSearchUrl(p.id);
+          return (
+            <li key={p.id}>
+              <a
+                href={url ?? '#'}
+                target={isTauri ? undefined : '_blank'}
+                rel='noopener noreferrer'
+                onClick={(e) => onWebSearchClickTauri(e, p.id)}
+                className='hover:bg-base-200/40 flex w-full items-center justify-between rounded-md px-2 py-3 text-left text-sm no-underline'
+              >
+                <span>{_(p.label)}</span>
+                <MdChevronRight className='not-eink:opacity-60' size={18} />
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+
   return (
     <div className='flex h-full flex-col'>
       <div className='flex-1 overflow-y-auto'>
@@ -449,110 +564,15 @@ export const DictionaryResultsBody: React.FC<DictionaryResultsBodyProps> = ({
               {_('Enable a dictionary in Settings → Language → Dictionaries.')}
             </p>
           </div>
+        ) : webSearchFirst ? (
+          <>
+            {webSearchSection}
+            {definitionsSection}
+          </>
         ) : (
           <>
-            {visibleDefinitionProviders.length > 0 && (
-              <section className='px-4 pt-2'>
-                <h3 className='not-eink:opacity-60 mb-2 text-xs font-medium uppercase tracking-wide'>
-                  {_('Dictionaries')}
-                </h3>
-                <ul className='flex flex-col gap-3'>
-                  {visibleDefinitionProviders.map((p) => {
-                    const card = cards[p.id];
-                    const isLoading = !card || card.state === 'loading';
-                    const expanded = card?.expanded ?? false;
-                    const sourceLabel =
-                      card?.outcome?.ok && card.outcome.sourceLabel
-                        ? card.outcome.sourceLabel
-                        : _(p.label);
-                    return (
-                      <li key={p.id}>
-                        <div
-                          data-testid='dict-card'
-                          role='button'
-                          tabIndex={0}
-                          aria-expanded={expanded}
-                          onClick={(e) => {
-                            const path = e.nativeEvent.composedPath();
-                            for (const node of path) {
-                              if (node === e.currentTarget) break;
-                              if (node instanceof Element) {
-                                const tag = node.tagName;
-                                if (tag === 'A' || tag === 'BUTTON' || tag === 'IMG') return;
-                              }
-                            }
-                            toggleExpanded(p.id);
-                          }}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                              e.preventDefault();
-                              toggleExpanded(p.id);
-                            }
-                          }}
-                          className={clsx('cursor-pointer rounded-lg')}
-                        >
-                          {isLoading && (
-                            <div
-                              data-testid='dict-card-skeleton'
-                              className='bg-base-200/50 h-12 animate-pulse rounded'
-                            />
-                          )}
-                          <div
-                            ref={setContainerRef(p.id)}
-                            onClick={handleContainerClick}
-                            // `data-dict-content` + `--dict-font-scale` drive the
-                            // popup font-size rules in globals.css (#4443): the
-                            // light-DOM `font-size` cascade and the MDict shadow
-                            // `::part(dict-content)` rule both read this scope.
-                            data-dict-content=''
-                            style={{ '--dict-font-scale': fontScale } as React.CSSProperties}
-                            className={clsx(
-                              'font-sans',
-                              isLoading && 'hidden',
-                              !isLoading &&
-                                !expanded &&
-                                'line-clamp-4 max-h-40 overflow-hidden [-webkit-box-orient:vertical] [display:-webkit-box]',
-                            )}
-                          />
-                          {!isLoading && (
-                            <div className='border-base-content/10 -me-4 mt-2 border-b pb-2'>
-                              <span className='not-eink:opacity-60 text-xs'>{sourceLabel}</span>
-                            </div>
-                          )}
-                        </div>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </section>
-            )}
-
-            {webSearchProviders.length > 0 && (
-              <section className='px-4 pt-4'>
-                <h3 className='not-eink:opacity-60 mb-2 text-xs font-medium uppercase tracking-wide'>
-                  {_('Search the web')}
-                </h3>
-                <ul className='flex flex-col'>
-                  {webSearchProviders.map((p) => {
-                    const url = resolveWebSearchUrl(p.id);
-                    return (
-                      <li key={p.id}>
-                        <a
-                          href={url ?? '#'}
-                          target={isTauri ? undefined : '_blank'}
-                          rel='noopener noreferrer'
-                          onClick={(e) => onWebSearchClickTauri(e, p.id)}
-                          className='hover:bg-base-200/40 flex w-full items-center justify-between rounded-md px-2 py-3 text-left text-sm no-underline'
-                        >
-                          <span>{_(p.label)}</span>
-                          <MdChevronRight className='not-eink:opacity-60' size={18} />
-                        </a>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </section>
-            )}
+            {definitionsSection}
+            {webSearchSection}
           </>
         )}
       </div>


### PR DESCRIPTION
Closes #5083

## Problem

Settings > Language > Dictionaries presents one unified, drag-reorderable list of every provider (built-in, imported, and web search). The popup, however, renders that list through two hard-coded sections: **Dictionaries** first, **Search the web** second.

So `providerOrder` only ever ordered entries *within* each section. A user who dragged Oxford and Cambridge (web) above Wiktionary (built-in) still got Wiktionary's card at the top of the popup, with their preferred web entries pushed below the fold, exactly as reported in #5083.

## Fix

The top-most enabled provider now decides which section leads: if the first entry in the configured order is a web search, the **Search the web** section renders above the dictionary cards.

The decision is derived from the full enabled provider list rather than the visible one, so the sections do not reshuffle as lookups settle (empty/error cards drop out of the dictionary section as results arrive). `first:pt-2` keeps the leading section's tighter top padding whichever one comes first.

This keeps the two labelled sections intact (web entries are external links, not inline definition cards) while making the setting behave as configured.

## Tests

Two cases added to `DictionarySheet.test.tsx`, which drives the shared `DictionaryResultsView` used by both the desktop popup and the mobile sheet:

- a web entry first in the configured order puts **Search the web** above **Dictionaries** (fails before this change)
- a dictionary first keeps **Dictionaries** above **Search the web** (regression guard)

`pnpm test` (544 files), `pnpm lint`, and `pnpm format:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)