### PR TITLE
fix(sync): keep the cloud copy when deleting a book from the device only (#5084)

### DIFF
--- a/apps/readest-app/src/__tests__/services/sync/file/appLocalStore.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/appLocalStore.test.ts
@@ -102,4 +102,26 @@ describe('createAppLocalStore — library hydration (data-loss guard)', () => {
     // The deleted book drops off the visible shelf.
     expect(useLibraryStore.getState().visibleLibrary.map((b) => b.hash)).toEqual(['b']);
   });
+
+  test('markBooksUploaded stamps the live rows, not the engine snapshot (#5084)', async () => {
+    // The engine captured `a` at the start of a long run; meanwhile the user
+    // read it and saved progress. The stamp must not roll that back.
+    useLibraryStore.getState().setLibrary([makeBook('a', { progress: [42, 100] }), makeBook('b')]);
+
+    await makeStore().markBooksUploaded(['a'], 900);
+
+    const stamped = savedLibrary!.find((b) => b.hash === 'a')!;
+    expect(stamped.uploadedAt).toBe(900);
+    expect(stamped.progress).toEqual([42, 100]);
+    // Books the engine didn't confirm keep their (absent) cloud state.
+    expect(savedLibrary!.find((b) => b.hash === 'b')!.uploadedAt).toBeFalsy();
+  });
+
+  test('markBooksUploaded hydrates from disk when the store is unloaded', async () => {
+    await makeStore().markBooksUploaded(['a'], 900);
+
+    expect(appService.loadLibraryBooks).toHaveBeenCalled();
+    expect(savedLibrary!.map((b) => b.hash).sort()).toEqual(['a', 'b']);
+    expect(savedLibrary!.find((b) => b.hash === 'a')!.uploadedAt).toBe(900);
+  });
 });

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-auth-abort.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-auth-abort.test.ts
@@ -39,6 +39,7 @@ const makeStore = (overrides: Partial<LocalStore> = {}): LocalStore => ({
   addBookToLibrary: async () => {},
   updateBookMetadata: async () => {},
   deleteBookLocally: async () => {},
+  markBooksUploaded: async () => {},
   ...overrides,
 });
 

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-cloud-copy-tracking.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-cloud-copy-tracking.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import type { Book } from '@/types/book';
+import { FileSyncEngine } from '@/services/sync/file/engine';
+import type { FileSyncProvider } from '@/services/sync/file/provider';
+import type { LocalStore } from '@/services/sync/file/localStore';
+import type { RemoteLibraryIndex } from '@/services/sync/file/wire';
+
+const makeBook = (hash: string, overrides: Partial<Book> = {}): Book => ({
+  hash,
+  format: 'EPUB',
+  title: `Book ${hash}`,
+  sourceTitle: `Book ${hash}`,
+  author: 'A',
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides,
+});
+
+type Captured = { writes: { path: string; body: string }[]; deletedDirs: string[] };
+
+const fakeProvider = (
+  opts: Partial<FileSyncProvider> & { captured?: Captured } = {},
+): FileSyncProvider => ({
+  rootPath: '/',
+  readText: opts.readText ?? (async () => null),
+  readBinary: opts.readBinary ?? (async () => null),
+  head: opts.head ?? (async () => null),
+  list: opts.list ?? (async () => []),
+  writeText:
+    opts.writeText ??
+    (async (path: string, body: string) => {
+      opts.captured?.writes.push({ path, body });
+    }),
+  writeBinary: opts.writeBinary ?? (async () => {}),
+  ensureDir: opts.ensureDir ?? (async () => {}),
+  deleteDir:
+    opts.deleteDir ??
+    (async (path: string) => {
+      opts.captured?.deletedDirs.push(path);
+    }),
+  uploadStream: opts.uploadStream,
+  downloadStream: opts.downloadStream,
+});
+
+const fakeStore = (opts: Partial<LocalStore> = {}): LocalStore => ({
+  loadConfig: opts.loadConfig ?? (async () => null),
+  saveBookConfig: opts.saveBookConfig ?? (async () => {}),
+  loadBookFile: opts.loadBookFile ?? (async () => null),
+  resolveLocalBookPath: opts.resolveLocalBookPath ?? (async () => null),
+  saveBookFile: opts.saveBookFile ?? (async () => {}),
+  prepareLocalBookPath: opts.prepareLocalBookPath ?? (async () => '/local/dst'),
+  loadBookCover: opts.loadBookCover ?? (async () => null),
+  saveBookCover: opts.saveBookCover ?? (async () => {}),
+  addBookToLibrary: opts.addBookToLibrary ?? (async () => {}),
+  updateBookMetadata: opts.updateBookMetadata ?? (async () => {}),
+  deleteBookLocally: opts.deleteBookLocally ?? (async () => {}),
+  markBooksUploaded: opts.markBooksUploaded ?? (async () => {}),
+});
+
+const makeIndex = (books: Book[]): RemoteLibraryIndex => ({
+  schemaVersion: 1,
+  updatedAt: 1,
+  books,
+});
+
+const libraryWrite = (captured: Captured) =>
+  captured.writes.find((w) => w.path.endsWith('library.json'));
+
+const indexedBooks = (captured: Captured): Book[] =>
+  (JSON.parse(libraryWrite(captured)!.body) as RemoteLibraryIndex).books;
+
+/**
+ * #5084: "Remove from Device Only" must leave the book on the remote.
+ *
+ * The device-local `filePath` (an absolute path from an in-place / transient
+ * import) is meaningless on any other device. Leaking it through library.json
+ * makes peers adopt a path that cannot exist for them, and the app reads
+ * `book.filePath` as "this is a purely-local book" — so a peer whose file is
+ * absent treats the row as a stale local record and offers to delete it, which
+ * runs the cloud-and-device delete and GCs the book off Google Drive.
+ * `useBooksSync.getNewBooks` already strips it for the native channel.
+ */
+describe('FileSyncEngine — device-local fields must not cross devices (#5084)', () => {
+  test('the pushed library.json index does not carry filePath', async () => {
+    const captured: Captured = { writes: [], deletedDirs: [] };
+    const provider = fakeProvider({ captured });
+    const local = makeBook('h1', {
+      updatedAt: 200,
+      downloadedAt: 100,
+      filePath: 'C:\\Users\\reader\\Books\\Book h1.epub',
+    });
+
+    await new FileSyncEngine(provider, fakeStore()).syncLibrary([local], {
+      strategy: 'silent',
+      syncBooks: false,
+      deviceId: 'dev-1',
+    });
+
+    const pushed = indexedBooks(captured).find((b) => b.hash === 'h1')!;
+    expect(pushed.filePath).toBeUndefined();
+  });
+
+  test('a peer never adopts a remote row filePath when adding the book locally', async () => {
+    const captured: Captured = { writes: [], deletedDirs: [] };
+    // The remote index was pushed by a device that imported the book in place.
+    const provider = fakeProvider({
+      readText: async (p) =>
+        p.endsWith('library.json')
+          ? JSON.stringify(
+              makeIndex([
+                makeBook('h1', {
+                  updatedAt: 100,
+                  filePath: 'C:\\Users\\reader\\Books\\Book h1.epub',
+                }),
+              ]),
+            )
+          : null,
+      readBinary: async () => new ArrayBuffer(8),
+      list: async (p: string) => {
+        if (p.endsWith('/books')) return [{ name: 'h1', path: '/books/h1', isDirectory: true }];
+        if (p.endsWith('/books/h1'))
+          return [{ name: 'Book h1.epub', path: '/books/h1/Book h1.epub', isDirectory: false }];
+        return [];
+      },
+      captured,
+    });
+    const addBookToLibrary = vi.fn<(b: Book) => Promise<void>>(async () => {});
+    const store = fakeStore({ addBookToLibrary });
+
+    await new FileSyncEngine(provider, store).syncLibrary([], {
+      strategy: 'silent',
+      syncBooks: true,
+      deviceId: 'dev-2',
+    });
+
+    expect(addBookToLibrary).toHaveBeenCalledTimes(1);
+    expect(addBookToLibrary.mock.calls[0]![0]!.filePath).toBeUndefined();
+  });
+});
+
+/**
+ * #5084: `book.uploadedAt` is the only signal the app has for "this book's file
+ * is in the cloud". The engine never set it, so a provider-synced book was read
+ * everywhere as purely-local — it could not be re-downloaded after a local
+ * delete, and the stale-record cleanup offered to delete it, which GC'd the file
+ * off the remote. Stamp it whenever the file is confirmed on the remote.
+ */
+describe('FileSyncEngine — stamps uploadedAt for provider-synced books (#5084)', () => {
+  test('stamps a book whose file this run uploaded', async () => {
+    const captured: Captured = { writes: [], deletedDirs: [] };
+    const provider = fakeProvider({ captured });
+    const markBooksUploaded = vi.fn<(h: string[], at: number) => Promise<void>>(async () => {});
+    const store = fakeStore({
+      markBooksUploaded,
+      loadBookFile: async () => ({ bytes: new ArrayBuffer(4), size: 4 }),
+    });
+    const local = makeBook('h1', { updatedAt: 200, downloadedAt: 100 });
+
+    await new FileSyncEngine(provider, store).syncLibrary([local], {
+      strategy: 'silent',
+      syncBooks: true,
+      deviceId: 'dev-1',
+    });
+
+    expect(markBooksUploaded).toHaveBeenCalledTimes(1);
+    expect(markBooksUploaded.mock.calls[0]![0]).toEqual(['h1']);
+    expect(indexedBooks(captured).find((b) => b.hash === 'h1')!.uploadedAt).toBeTruthy();
+  });
+
+  test('stamps a book the index already records as on the remote', async () => {
+    const captured: Captured = { writes: [], deletedDirs: [] };
+    // Another device uploaded the file; this device only holds the row.
+    const provider = fakeProvider({
+      readText: async (p) =>
+        p.endsWith('library.json')
+          ? JSON.stringify({
+              ...makeIndex([makeBook('h1', { updatedAt: 100 })]),
+              uploadedHashes: ['h1'],
+            })
+          : null,
+      captured,
+    });
+    const markBooksUploaded = vi.fn<(h: string[], at: number) => Promise<void>>(async () => {});
+    const store = fakeStore({ markBooksUploaded });
+    const local = makeBook('h1', { updatedAt: 100, downloadedAt: 50 });
+
+    await new FileSyncEngine(provider, store).syncLibrary([local], {
+      strategy: 'silent',
+      // Even with book-file upload off: the file is already there.
+      syncBooks: false,
+      deviceId: 'dev-1',
+    });
+
+    expect(markBooksUploaded).toHaveBeenCalledTimes(1);
+    expect(markBooksUploaded.mock.calls[0]![0]).toEqual(['h1']);
+  });
+
+  test('does not stamp a book whose file is on no remote', async () => {
+    const captured: Captured = { writes: [], deletedDirs: [] };
+    const provider = fakeProvider({ captured });
+    const markBooksUploaded = vi.fn<(h: string[], at: number) => Promise<void>>(async () => {});
+    // loadBookFile/resolveLocalBookPath both return null => 'no-source'.
+    const store = fakeStore({ markBooksUploaded });
+    const local = makeBook('h1', { updatedAt: 200, downloadedAt: 100 });
+
+    await new FileSyncEngine(provider, store).syncLibrary([local], {
+      strategy: 'silent',
+      syncBooks: true,
+      deviceId: 'dev-1',
+    });
+
+    expect(markBooksUploaded).not.toHaveBeenCalled();
+    expect(indexedBooks(captured).find((b) => b.hash === 'h1')!.uploadedAt).toBeFalsy();
+  });
+
+  test('a device-only delete leaves the book on the remote and keeps it re-downloadable', async () => {
+    const captured: Captured = { writes: [], deletedDirs: [] };
+    const provider = fakeProvider({
+      readText: async (p) =>
+        p.endsWith('library.json')
+          ? JSON.stringify({
+              ...makeIndex([makeBook('h1', { updatedAt: 100 })]),
+              uploadedHashes: ['h1'],
+            })
+          : null,
+      list: async (p: string) => {
+        if (p.endsWith('/books')) return [{ name: 'h1', path: '/books/h1', isDirectory: true }];
+        if (p.endsWith('/books/h1'))
+          return [{ name: 'Book h1.epub', path: '/books/h1/Book h1.epub', isDirectory: false }];
+        return [];
+      },
+      captured,
+    });
+    const markBooksUploaded = vi.fn<(h: string[], at: number) => Promise<void>>(async () => {});
+    const store = fakeStore({ markBooksUploaded });
+    // The row right after "Remove from Device Only": no local file, no tombstone.
+    const local = makeBook('h1', { updatedAt: 200, downloadedAt: null });
+
+    await new FileSyncEngine(provider, store).syncLibrary([local], {
+      strategy: 'silent',
+      syncBooks: true,
+      deviceId: 'dev-1',
+    });
+
+    // The remote copy survives...
+    expect(captured.deletedDirs).toEqual([]);
+    // ...and the row is marked cloud-backed, so the app offers Download instead
+    // of reading it as a local book whose file vanished.
+    expect(markBooksUploaded.mock.calls[0]![0]).toEqual(['h1']);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-deletion-sync.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-deletion-sync.test.ts
@@ -63,6 +63,7 @@ const fakeStore = (opts: Partial<LocalStore> = {}): LocalStore => ({
   addBookToLibrary: opts.addBookToLibrary ?? (async () => {}),
   updateBookMetadata: opts.updateBookMetadata ?? (async () => {}),
   deleteBookLocally: opts.deleteBookLocally ?? (async () => {}),
+  markBooksUploaded: opts.markBooksUploaded ?? (async () => {}),
 });
 
 const makeIndex = (books: Book[]): RemoteLibraryIndex => ({

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-metadata-sync.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-metadata-sync.test.ts
@@ -93,6 +93,7 @@ const makeStore = (overrides: Partial<LocalStore> = {}): LocalStore => ({
   addBookToLibrary: async () => {},
   updateBookMetadata: async () => {},
   deleteBookLocally: async () => {},
+  markBooksUploaded: async () => {},
   ...overrides,
 });
 

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-sync-paths.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-sync-paths.test.ts
@@ -59,6 +59,7 @@ const fakeStore = (opts: Partial<LocalStore> = {}): LocalStore => ({
   addBookToLibrary: opts.addBookToLibrary ?? (async () => {}),
   updateBookMetadata: opts.updateBookMetadata ?? (async () => {}),
   deleteBookLocally: opts.deleteBookLocally ?? (async () => {}),
+  markBooksUploaded: opts.markBooksUploaded ?? (async () => {}),
 });
 
 describe('FileSyncEngine.pushBookFile — streaming upload', () => {

--- a/apps/readest-app/src/app/library/components/ShareBookDialog.tsx
+++ b/apps/readest-app/src/app/library/components/ShareBookDialog.tsx
@@ -16,6 +16,8 @@ import { Book } from '@/types/book';
 import { SHARE_DEFAULT_EXPIRATION_DAYS, SHARE_EXPIRATION_DAYS } from '@/services/constants';
 import { ShareApiError, createShare, revokeShare } from '@/libs/share';
 import { formatBytes } from '@/utils/book';
+import { useSettingsStore } from '@/store/settingsStore';
+import { isReadestCloudStorageActive } from '@/services/sync/cloudSyncProvider';
 
 interface ShareBookDialogProps {
   isOpen: boolean;
@@ -36,6 +38,7 @@ interface CreatedShare {
 const ShareBookDialog: React.FC<ShareBookDialogProps> = ({ isOpen, book, cfi, onClose }) => {
   const _ = useTranslation();
   const { appService } = useEnv();
+  const settings = useSettingsStore((state) => state.settings);
 
   const [expirationDays, setExpirationDays] = useState<number>(SHARE_DEFAULT_EXPIRATION_DAYS);
   // Off by default — sharing the current page reveals where the user is in
@@ -96,8 +99,12 @@ const ShareBookDialog: React.FC<ShareBookDialogProps> = ({ isOpen, book, cfi, on
     setGenerating(true);
     setErrorMessage(null);
     try {
-      // Upload first if the book lives only locally.
-      if (!book.uploadedAt && appService) {
+      // Upload first if the book isn't in Readest storage, which is what a share
+      // link is served from. `uploadedAt` alone doesn't prove that: the file-sync
+      // engine also stamps it for a book whose only cloud copy is on the selected
+      // third-party provider (WebDAV / Google Drive / …).
+      const inReadestStorage = !!book.uploadedAt && isReadestCloudStorageActive(settings);
+      if (!inReadestStorage && appService) {
         try {
           await appService.uploadBook(book, (progress) => {
             setUploadProgress((progress.progress / progress.total) * 100);

--- a/apps/readest-app/src/app/library/components/TransferQueuePanel.tsx
+++ b/apps/readest-app/src/app/library/components/TransferQueuePanel.tsx
@@ -186,16 +186,18 @@ const TransferQueuePanel: React.FC = () => {
   const onClose = () => setIsOpen(false);
   const divRef = useKeyDownActions({ onCancel: onClose, onConfirm: onClose });
 
-  // Uploads target Readest Cloud storage; while a third-party provider is
-  // selected the queue refuses book uploads, so hide the affordance
-  // (downloads and replica transfers keep flowing regardless).
+  // Both bulk actions target Readest Cloud storage; while a third-party provider
+  // is selected the queue refuses book uploads and a queued download would ask
+  // Readest storage for a file that only exists on the provider, so hide both
+  // affordances (per-book Upload / Download in the shelf are provider-routed, and
+  // replica transfers keep flowing regardless).
   const settings = useSettingsStore((s) => s.settings);
   const readestStorageActive = isReadestCloudStorageActive(settings);
 
   const booksToUpload = getVisibleLibrary().filter((book) => book.downloadedAt && !book.uploadedAt);
-  const booksToDownload = getVisibleLibrary().filter(
-    (book) => book.uploadedAt && !book.downloadedAt,
-  );
+  const booksToDownload = readestStorageActive
+    ? getVisibleLibrary().filter((book) => book.uploadedAt && !book.downloadedAt)
+    : [];
 
   const handleUploadAll = () => {
     booksToUpload.forEach((book) => queueUpload(book));

--- a/apps/readest-app/src/app/library/hooks/useOpenBook.ts
+++ b/apps/readest-app/src/app/library/hooks/useOpenBook.ts
@@ -32,27 +32,31 @@ export const useOpenBook = ({ setLoading, handleBookDownload }: UseOpenBookOptio
 
   const makeBookAvailable = useCallback(
     async (book: Book) => {
-      if (book.uploadedAt && !book.downloadedAt) {
-        if (await appService?.isBookAvailable(book)) {
-          if (!book.downloadedAt || !book.coverDownloadedAt) {
-            book.downloadedAt = Date.now();
-            book.coverDownloadedAt = Date.now();
-            await updateBook(envConfig, book);
-          }
-          return true;
-        }
-        let available = false;
-        const loadingTimeout = setTimeout(() => setLoading(true), 200);
-        try {
-          available = await handleBookDownload(book, { queued: false });
+      // A book with no cloud copy has nothing to fetch; `openBook` below already
+      // handles the case where such a book's local file is gone.
+      if (!book.uploadedAt) return true;
+      // The row's `downloadedAt` is not proof that the file is still here: a
+      // "Remove from Device Only" evicts the file, and an in-place original can
+      // be moved or deleted behind our back. Probe, and re-fetch from the cloud
+      // when it's really gone, instead of opening a reader that cannot load.
+      if (await appService?.isBookAvailable(book)) {
+        if (!book.downloadedAt || !book.coverDownloadedAt) {
+          book.downloadedAt = Date.now();
+          book.coverDownloadedAt = Date.now();
           await updateBook(envConfig, book);
-        } finally {
-          if (loadingTimeout) clearTimeout(loadingTimeout);
-          setLoading(false);
         }
-        return available;
+        return true;
       }
-      return true;
+      let available = false;
+      const loadingTimeout = setTimeout(() => setLoading(true), 200);
+      try {
+        available = await handleBookDownload(book, { queued: false });
+        await updateBook(envConfig, book);
+      } finally {
+        if (loadingTimeout) clearTimeout(loadingTimeout);
+        setLoading(false);
+      }
+      return available;
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [appService, envConfig, handleBookDownload, setLoading],

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -1118,11 +1118,22 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
           if (syncBooks) pushLibrary();
         }
 
-        // Queue cloud deletion
+        // Cloud deletion. The transfer queue only speaks to Readest storage, so a
+        // book whose cloud copy lives on the selected third-party provider must
+        // not be routed through it — it would delete nothing. 'both' / 'purge'
+        // tombstoned the book above, and the file sync GCs a tombstoned book's
+        // remote directory on its next run, so the removal is already covered.
+        // ("Remove from Cloud Only" is not offered for those providers — see
+        // BookDetailModal.)
         if (deleteAction === 'cloud' || deleteAction === 'both' || deleteAction === 'purge') {
-          const transferId = transferManager.queueDelete(book, 1, true);
-          if (!transferId) {
-            throw new Error('Failed to queue cloud deletion');
+          if (isReadestCloudStorageActive(useSettingsStore.getState().settings)) {
+            const transferId = transferManager.queueDelete(book, 1, true);
+            if (!transferId) {
+              throw new Error('Failed to queue cloud deletion');
+            }
+          } else {
+            book.uploadedAt = null;
+            await updateBook(envConfig, book);
           }
         }
 
@@ -1761,7 +1772,12 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
           handleBookUpload={handleBookUpload}
           handleBookDownload={handleBookDownload}
           handleBookDelete={handleBookDelete('both')}
-          handleBookDeleteCloudBackup={handleBookDelete('cloud')}
+          // Readest storage only. A third-party provider mirrors the library, so
+          // removing just its cloud copy is not expressible: the next sync would
+          // upload the still-local book straight back (#5084).
+          handleBookDeleteCloudBackup={
+            isReadestCloudStorageActive(settings) ? handleBookDelete('cloud') : undefined
+          }
           handleBookDeleteLocalCopy={handleBookDelete('local')}
           handleBookPurge={handleBookDelete('purge')}
           handleBookMetadataUpdate={handleUpdateMetadata}

--- a/apps/readest-app/src/components/metadata/BookDetailView.tsx
+++ b/apps/readest-app/src/components/metadata/BookDetailView.tsx
@@ -138,13 +138,18 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({
                     label={_('Remove from Cloud & Device')}
                     onClick={onDelete}
                   />
-                  <MenuItem
-                    noIcon
-                    transient
-                    label={_('Remove from Cloud Only')}
-                    onClick={onDeleteCloudBackup}
-                    disabled={!book.uploadedAt}
-                  />
+                  {/* Offered only where a cloud-only removal means something: a
+                      third-party provider mirrors the library, so it would just
+                      re-upload the still-local book on its next sync (#5084). */}
+                  {onDeleteCloudBackup && (
+                    <MenuItem
+                      noIcon
+                      transient
+                      label={_('Remove from Cloud Only')}
+                      onClick={onDeleteCloudBackup}
+                      disabled={!book.uploadedAt}
+                    />
+                  )}
                   <MenuItem
                     noIcon
                     transient

--- a/apps/readest-app/src/services/sync/file/appLocalStore.ts
+++ b/apps/readest-app/src/services/sync/file/appLocalStore.ts
@@ -131,6 +131,22 @@ export const createAppLocalStore = ({
     await useLibraryStore.getState().updateBook(envConfig, book);
   },
 
+  markBooksUploaded: async (hashes, uploadedAt) => {
+    if (!hashes.length) return;
+    if (!useLibraryStore.getState().libraryLoaded) {
+      useLibraryStore.getState().setLibrary(await appService.loadLibraryBooks());
+    }
+    // Stamp the LIVE rows (see the LocalStore contract): a book the user read
+    // while the sync was running must keep the progress it saved meanwhile.
+    const wanted = new Set(hashes);
+    const rows = useLibraryStore
+      .getState()
+      .library.filter((book) => wanted.has(book.hash) && !book.uploadedAt && !book.deletedAt)
+      .map((book) => ({ ...book, uploadedAt }));
+    if (!rows.length) return;
+    await useLibraryStore.getState().updateBooks(envConfig, rows);
+  },
+
   deleteBookLocally: async (book) => {
     // Remove this device's managed copy of the book file (cloudService.deleteBook
     // with 'local' only ever touches app-managed Books/<hash>/ sources; an

--- a/apps/readest-app/src/services/sync/file/engine.ts
+++ b/apps/readest-app/src/services/sync/file/engine.ts
@@ -17,6 +17,7 @@ import {
   buildRemotePayload,
   parseRemotePayload,
   parseRemoteLibraryIndex,
+  stripDeviceLocalFields,
   RemoteLibraryIndex,
 } from './wire';
 import { mergeBookConfig, mergeBookMetadata, shouldApplyRemoteBookMetadata } from './merge';
@@ -628,6 +629,33 @@ export class FileSyncEngine {
           hasLocalFile(book) &&
           knownNoSource.get(book.hash) !== (book.updatedAt ?? 0)));
 
+    // A book whose FILE is on the remote is cloud-backed, exactly like a book in
+    // Readest Cloud storage — and `book.uploadedAt` is the only thing the rest of
+    // the app reads to know that. Leaving it null for a provider-synced book made
+    // the whole library misread it as purely-local: it could never be re-downloaded
+    // (`makeBookAvailable` gates on `uploadedAt`), the shelf offered Upload instead
+    // of Download, and — the data loss in #5084 — once "Remove from Device Only"
+    // cleared `downloadedAt`, the stale-record cleanup treated it as a local book
+    // whose file had vanished and offered a delete that GC'd it off the remote.
+    // Stamps are collected and persisted in one batch at the end of the run.
+    const stampedAt = Date.now();
+    const cloudCopyStamps = new Map<string, Book>();
+    const stampCloudCopy = (hash: string): void => {
+      const current = allBooksMap.get(hash);
+      if (!current || current.uploadedAt || current.deletedAt) return;
+      // A fresh object, never an in-place mutation: the caller's rows are the
+      // ones React renders, and a mutated row is invisible to the memo.
+      const stamped: Book = { ...current, uploadedAt: stampedAt };
+      allBooksMap.set(hash, stamped);
+      cloudCopyStamps.set(hash, stamped);
+    };
+    // The index's uploaded-file record already proves the file is on the remote,
+    // so a book another device (or an earlier run) pushed gets stamped without
+    // any request of its own.
+    for (const book of books) {
+      if (uploadedHashes.has(book.hash)) stampCloudCopy(book.hash);
+    }
+
     const remoteBooksToDownload: Book[] = [];
     // The remote source of truth for a book's on-disk filename is the per-hash
     // directory listing — NOT the book's title (which may be stale). We always
@@ -755,8 +783,11 @@ export class FileSyncEngine {
           if (!allBooksMap.has(rb.hash) && !rb.deletedAt) {
             candidateHashes.add(rb.hash);
             // Provisionally register the indexed book — fields refreshed below
-            // once we've inspected the actual hash dir.
-            allBooksMap.set(rb.hash, rb);
+            // once we've inspected the actual hash dir. Strip the pushing
+            // device's local fields: an index written by an older client still
+            // carries its `filePath`, and adopting it would make this device
+            // read the book as a purely-local record (#5084).
+            allBooksMap.set(rb.hash, stripDeviceLocalFields(rb));
           }
         }
       }
@@ -894,11 +925,13 @@ export class FileSyncEngine {
               } catch (e) {
                 console.warn('file sync: config download failed', rb.hash, e);
               }
+              // We just pulled its bytes, so the file is on the remote: the row is
+              // cloud-backed (#5084) and addBookToLibrary persists the stamp.
+              rb.uploadedAt = Date.now();
               await this.store.addBookToLibrary(rb);
               result.booksDownloaded += 1;
               syncedHashes.add(rb.hash);
-              // We just pulled its bytes, so the file is on the remote — record it
-              // so a later push-side sync doesn't HEAD-probe it back.
+              // Record it so a later push-side sync doesn't HEAD-probe it back.
               uploadedHashes.add(rb.hash);
             } else {
               // No bytes returned (typically a 404 we couldn't resolve).
@@ -1010,9 +1043,11 @@ export class FileSyncEngine {
                 result.filesUploaded += 1;
                 syncedHashes.add(book.hash);
                 uploadedHashes.add(book.hash);
+                stampCloudCopy(book.hash);
               } else if (fileResult.reason === 'remote-matches') {
                 result.filesAlreadyInSync += 1;
                 uploadedHashes.add(book.hash);
+                stampCloudCopy(book.hash);
               } else if (fileResult.reason === 'no-source') {
                 // The file isn't on this device; remember the verdict for this
                 // exact row so the next run doesn't re-pay the fs probes. It
@@ -1111,7 +1146,7 @@ export class FileSyncEngine {
         try {
           const newIndex: RemoteLibraryIndex = {
             schemaVersion: 1,
-            books: Array.from(indexByHash.values()),
+            books: Array.from(indexByHash.values()).map(stripDeviceLocalFields),
             updatedAt: Date.now(),
             uploadedHashes: nextUploadedHashes,
             emptyDirs: nextEmptyDirs,
@@ -1123,6 +1158,17 @@ export class FileSyncEngine {
         } catch (e) {
           console.warn('file sync: failed to push index', e);
         }
+      }
+    }
+
+    // Persist the cloud-copy stamps in one library write. They must survive a
+    // restart: a row that boots without `uploadedAt` is read as purely-local
+    // again, which is what made "Remove from Device Only" destructive (#5084).
+    if (cloudCopyStamps.size > 0) {
+      try {
+        await this.store.markBooksUploaded(Array.from(cloudCopyStamps.keys()), stampedAt);
+      } catch (e) {
+        console.warn('file sync: failed to persist cloud-copy stamps', e);
       }
     }
 

--- a/apps/readest-app/src/services/sync/file/localStore.ts
+++ b/apps/readest-app/src/services/sync/file/localStore.ts
@@ -51,6 +51,16 @@ export interface LocalStore {
   /** Persist refreshed metadata for a book already in the local library. */
   updateBookMetadata(book: Book): Promise<void>;
   /**
+   * Record that these books' files are present on the remote (`uploadedAt`), in
+   * one library write — the engine can confirm many books in a single run.
+   *
+   * Field-scoped by contract: the stamp is applied to the LIVE library rows, not
+   * to the snapshots the engine captured when the run started. A sync can take
+   * minutes, and writing whole snapshots back would roll back any progress or
+   * metadata the user saved while it was running.
+   */
+  markBooksUploaded(hashes: string[], uploadedAt: number): Promise<void>;
+  /**
    * Apply a peer's deletion locally: remove this device's managed copy of the
    * book file and persist the tombstone (`book.deletedAt`) so the book drops
    * off the shelf and stops being re-uploaded. External / in-place sources are

--- a/apps/readest-app/src/services/sync/file/wire.ts
+++ b/apps/readest-app/src/services/sync/file/wire.ts
@@ -129,3 +129,33 @@ export const parseRemoteLibraryIndex = (raw: string | null): RemoteLibraryIndex 
   }
   return null;
 };
+
+/**
+ * Fields that describe THIS device's copy of a book rather than the book
+ * itself: an absolute path from an in-place / transient import, the blob URL of
+ * the rendered cover, and the two "this device holds the bytes" stamps.
+ *
+ * They must never cross devices. A peer that adopts a foreign `filePath` reads
+ * the row as a purely-local book (that is what `book.filePath` means to the
+ * rest of the app), so as soon as its managed copy is absent — exactly the
+ * state "Remove from Device Only" creates — the stale-record cleanup in
+ * `useOpenBook` offers to delete the "missing" book, which runs the cloud-and-
+ * device delete and GCs the book off the shared remote (#5084).
+ * `useBooksSync.getNewBooks` strips `filePath` from the native channel for the
+ * same reason; the shared index needs the same discipline.
+ */
+const DEVICE_LOCAL_BOOK_FIELDS = [
+  'filePath',
+  'coverImageUrl',
+  'downloadedAt',
+  'coverDownloadedAt',
+] as const satisfies readonly (keyof Book)[];
+
+/** A copy of `book` safe to publish to — or adopt from — the shared index. */
+export const stripDeviceLocalFields = (book: Book): Book => {
+  const copy = { ...book };
+  for (const field of DEVICE_LOCAL_BOOK_FIELDS) {
+    delete copy[field];
+  }
+  return copy;
+};


### PR DESCRIPTION
Fixes #5084.

## The report

On Web and Windows with Google Drive sync enabled, **"Remove from Device Only"** also deleted the book from Google Drive.

## Root cause

The local delete never touched the remote. `cloudService.deleteBook('local')` doesn't set `deletedAt`, and the engine only GCs a book's remote directory for tombstoned books. The tombstone arrived one step later, from two defects that only bite together:

1. **`filePath` leaked through the shared `library.json`.** The engine published `Book` rows verbatim, so the device-local absolute path of an in-place / transient import (`C:\Users\…\book.epub`) crossed to every peer, which adopted a path that cannot exist for it. `book.filePath` is what the rest of the app reads as *"this is a purely-local book"*. `useBooksSync.getNewBooks` already strips the field from the native cloud channel for exactly this reason — the file-sync engine never got the same discipline.

2. **The engine never stamped `book.uploadedAt`**, the only signal the app has for *"this book's file is in the cloud"*. Every WebDAV / Drive / OneDrive / S3 book was therefore read everywhere as purely-local.

Chained: "Remove from Device Only" clears `downloadedAt`, leaving a row that looks exactly like a local book whose file has vanished. The next tap hits the stale-record cleanup in `useOpenBook`, which toasts *"Book file no longer exists. Confirm deletion to remove it from the library"* — but dispatches the **cloud-and-device** delete. That tombstones the book, and the next sync GCs its directory off Drive. The same trap fired on a book that had never been downloaded on that device at all.

## The fix

- **Strip device-local fields** (`filePath`, `coverImageUrl`, `downloadedAt`, `coverDownloadedAt`) both when publishing to the index and when adopting a row from it. The adopt-side strip also heals indexes an older client already poisoned.
- **Stamp `uploadedAt`** whenever the engine confirms a file is on the remote (uploaded this run, already mirrored, just downloaded, or recorded in the index's `uploadedHashes`). Persisted through a new field-scoped `LocalStore.markBooksUploaded(hashes, at)`, which stamps the **live** library rows rather than the snapshots the run started with — a long sync must not roll back progress saved while it was running. The `!book.uploadedAt` guard in `useOpenBook` is then correct by construction, and the book stays re-downloadable.
- `makeBookAvailable` **probes the file** instead of trusting `downloadedAt`, so a book evicted by a device-only delete is re-fetched from the cloud on open instead of opening a reader that cannot load.
- Cloud deletes for third-party providers no longer go through the Readest Cloud transfer queue, which would delete nothing.

### "Remove from Cloud Only" is hidden for third-party providers

Routing that action to `deleteRemoteBookDir` is self-undoing: the sync **mirrors** the library, so with "Upload Book Files" on the next run re-uploads the still-local book. There is no per-book "don't mirror this" flag to express the intent, so the item is now offered only for Readest Cloud rather than shipping a button that quietly reverses itself.

### Ripples of `uploadedAt` no longer meaning "in Readest storage"

- `ShareBookDialog` still uploads to Readest storage before creating a link (that is where share links are served from).
- `TransferQueuePanel` hides its bulk **Download All** for third-party providers — `queueDownload` is not provider-routed, while the per-book Download button in the shelf is.

## Tests

New `engine-cloud-copy-tracking.test.ts` (6 tests) covers both halves: the index carries no `filePath` in either direction, `uploadedAt` is stamped on upload / already-mirrored / index-recorded and *not* stamped when the file is on no remote, and a device-only delete leaves the remote dir intact while keeping the row re-downloadable. Two new `appLocalStore` tests pin the live-row stamping contract. All 6 fail without the fix.

`pnpm test` (7296 passed, 3 skipped), `pnpm lint`, and `pnpm format:check` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)