### PR TITLE
Fix blank screen issue on Linux with Nvidia drivers

### DIFF
--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -319,6 +319,15 @@ pub fn run() {
     // handler for native crashes; on mobile, native crashes belong to the
     // sentry-android / sentry-cocoa SDKs. The guard must outlive the app, so it
     // is held until `run()` returns (after the blocking `.run(...)` call).
+
+    // Set the WEBKIT_DISABLE_DMABUF_RENDERER environment var on Linux to prevent issues with Nvidia
+    // drivers
+    #[cfg(target_os = "linux")]
+    {
+        if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
+    }
     let sentry_guard = sentry_config::sentry_dsn().map(|dsn| {
         sentry::init((
             dsn,


### PR DESCRIPTION
A [known issue with webkit](https://gitlab.archlinux.org/archlinux/packaging/packages/webkit2gtk/-/work_items/1) on Linux with Nvidia causes a blank screen to show instead of the desired app. A simple fix is to set the WEBKIT_DISABLE_DMABUF_RENDERER environment variable to 1, which is done here automatically via the std::env methods.