### PR TITLE
fix(android): stop 32-bit ARM builds aborting at launch (#5070)

### DIFF
--- a/apps/readest-app/src-tauri/Cargo.toml
+++ b/apps/readest-app/src-tauri/Cargo.toml
@@ -104,6 +104,12 @@ mobi = "0.8"
 # re-exports sentry-rust-minidump for desktop native crashes. `rustls` avoids
 # the native-tls/OpenSSL system dependency so the transport builds for
 # Android/iOS. Native mobile crashes are handled by sentry-android/-cocoa.
+#
+# The plugin's default `minidump` feature pulls in crash-handler, which
+# interposes `pthread_create` and panics on 32-bit ARM when it cannot resolve
+# the real symbol. That panic crosses a `nounwind` libc boundary, so every
+# armeabi-v7a device aborted at launch (#5070). Minidumps are desktop-only, so
+# the feature is enabled per-target below instead of by default.
 sentry = { version = "0.42", default-features = false, features = [
   "backtrace",
   "contexts",
@@ -111,7 +117,7 @@ sentry = { version = "0.42", default-features = false, features = [
   "reqwest",
   "rustls",
 ] }
-tauri-plugin-sentry = "0.5"
+tauri-plugin-sentry = { version = "0.5", default-features = false }
 
 [target."cfg(target_os = \"macos\")".dependencies]
 rand = "0.8"
@@ -130,6 +136,9 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-window-state = "2"
 discord-rich-presence = "1.0.0"
+# Out-of-process minidump handler for native desktop crashes; `minidump::init`
+# is only called on these targets.
+tauri-plugin-sentry = { version = "0.5", features = ["minidump"] }
 
 [target.'cfg(windows)'.dependencies]
 # Resolve the user's default browser from the registry for the cold-browser

--- a/apps/readest-app/src-tauri/src/sentry_config.rs
+++ b/apps/readest-app/src-tauri/src/sentry_config.rs
@@ -178,6 +178,35 @@ mod tests {
         is_ignored_browser_error, is_mobi_cover_panic_frame, parse_webview_info, release_name,
     };
 
+    /// `tauri-plugin-sentry`'s default `minidump` feature pulls in
+    /// sentry-rust-minidump -> minidumper-child -> crash-handler, whose
+    /// `pthread_create` interposer panics on 32-bit ARM ("We could not obtain the
+    /// real pthread_create()"). The panic unwinds out of a `nounwind` libc
+    /// function, so every armeabi-v7a device aborted with SIGABRT at launch
+    /// (#5070). Minidumps are desktop-only anyway (`minidump::init` is
+    /// `cfg`-gated off for mobile), so the feature must be enabled per-target
+    /// rather than by default, keeping crash-handler out of Android/iOS builds.
+    #[test]
+    fn minidump_feature_is_not_enabled_by_default() {
+        let manifest = include_str!("../Cargo.toml");
+        let base_dep = manifest
+            .lines()
+            .map(str::trim)
+            .find(|line| line.starts_with("tauri-plugin-sentry"))
+            .expect("tauri-plugin-sentry must be declared in Cargo.toml");
+
+        assert!(
+            base_dep.contains("default-features = false"),
+            "tauri-plugin-sentry must set default-features = false so mobile builds \
+             don't link crash-handler (#5070); found: {base_dep}"
+        );
+        assert!(
+            !base_dep.contains("minidump"),
+            "the minidump feature must be enabled only for desktop targets (#5070); \
+             found: {base_dep}"
+        );
+    }
+
     #[test]
     fn dsn_is_none_when_unset_or_blank() {
         assert_eq!(dsn_from_env(None), None);


### PR DESCRIPTION
## Problem

Since 0.11.18, the app SIGABRTs at launch on **every armeabi-v7a (32-bit ARM) device**, before any UI is drawn. Reinstalling doesn't help.

The issue title says "Android 9", but the OS version is a red herring — the real discriminator is the **ABI**. The reporter's Galaxy J4+ and the SM-T595 seen in Sentry are both armeabi-v7a; arm64 devices are unaffected. Sentry shows 185 users hit by `SIGABRT: Abort` (READEST-D) plus the matching Rust-side panics (READEST-B).

## Root cause

`tauri-plugin-sentry` (new in 0.11.18) enables its `minidump` feature **by default**, which pulls in `sentry-rust-minidump` -> `minidumper-child` -> `crash-handler`.

`crash-handler` interposes `pthread_create` and resolves the real symbol via `dlsym`. On 32-bit ARM that lookup fails and it panics:

```
panicked at crash-handler-0.6.3/src/unix/pthread_interpose.rs:92:
We could not obtain the real pthread_create(). Calling the symbol we got
would make us enter an infinte loop so stop here instead.
-> panic in a function that cannot unwind
-> SIGABRT
```

`pthread_create` is a `nounwind` C function, so the panic aborts the process instead of unwinding. It fires on the first thread spawn inside tao's `create()`, i.e. during Activity startup.

Minidumps are desktop-only anyway — `minidump::init` is already `cfg`-gated off for mobile — so `crash-handler` was being linked into mobile builds for nothing.

## Fix

Turn off the plugin's default features and enable `minidump` only for the desktop targets, keeping `crash-handler` out of Android/iOS builds entirely.

- `cargo tree -i crash-handler --target armv7-linux-androideabi` -> empty (also for `aarch64-linux-android`)
- `cargo tree -i crash-handler --target aarch64-apple-darwin` -> still resolves, so desktop minidump reporting is unchanged
- `Cargo.lock` is unchanged (desktop still needs those crates)

Native mobile crash reporting is unaffected: it runs through sentry-android / sentry-cocoa, and `libsentry-android.so` is still bundled.

## Verification

Built armeabi-v7a APKs and ran them on a physical 32-bit-capable device:

| Build | Result |
| --- | --- |
| v0.11.17 (armv7) | launches fine |
| v0.11.18 as released (armv7) | `Fatal signal 6 (SIGABRT)` at launch |
| v0.11.18 + this fix (armv7) | launches, renders the library, Sentry still auto-inits |

The exact panic was captured by temporarily vendoring tao and installing a panic hook that logs to logcat — tao installs its stdout/stderr -> logcat pipe *after* the panic point, so by default the abort shows no message at all.

Guarded by a new `minidump_feature_is_not_enabled_by_default` test in `sentry_config.rs` so the default feature can't creep back in.

Gates: `pnpm test` (7086 passing), `pnpm lint`, `pnpm test:rust` (81 passing), `pnpm fmt:check`, `pnpm clippy:check`.

## Note

Sentry's READEST-C (`assertion failed: previous.is_none()` in `ndk_context::initialize_android_context`, on **aarch64**) is a **separate** bug — tao's `create()` running twice in one process. It is not addressed here and needs its own investigation.

Fixes #5070

🤖 Generated with [Claude Code](https://claude.com/claude-code)