### PR TITLE
fix(kosync): accept pulled progress from servers that omit document

### DIFF
--- a/apps/readest-app/src/__tests__/services/sync/KOSyncClient.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/KOSyncClient.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { KOSyncClient } from '@/services/sync/KOSyncClient';
+import { Book } from '@/types/book';
 import { KOSyncSettings } from '@/types/settings';
 
 // The LAN-server branch of KOSyncClient.request uses window.fetch (mocked
@@ -43,6 +44,80 @@ const jsonResponse = (status: number, body: unknown) => ({
   ok: status >= 200 && status < 300,
   status,
   json: async () => body,
+});
+
+const makeBook = (): Book =>
+  ({
+    hash: 'f248ce0f15105ff390e5292085e0622b',
+    title: 'A Book',
+  }) as Book;
+
+describe('KOSyncClient.getProgress – server response shapes', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('accepts a progress payload that omits `document`', async () => {
+    // Not every KOSync-compatible server echoes the document hash back on GET.
+    // koreader-sync only selects progress/percentage/device/device_id/timestamp,
+    // so requiring `document` silently discarded a perfectly good remote
+    // position and the reader then pushed its stale one over it. (#5063, #5065)
+    setFetch(() =>
+      jsonResponse(200, {
+        progress: '/body/DocFragment[3]/body/div/p[12].0',
+        percentage: 0.0174,
+        device: 'KindlePaperWhite5',
+        device_id: '8F6F541940B74D32B606503DB6B43E0F',
+        timestamp: 1783773009,
+      }),
+    );
+
+    const client = new KOSyncClient(makeConfig({ userkey: 'key' }));
+    const progress = await client.getProgress(makeBook());
+
+    expect(progress).not.toBeNull();
+    expect(progress!.progress).toBe('/body/DocFragment[3]/body/div/p[12].0');
+    expect(progress!.percentage).toBe(0.0174);
+    // The requested hash stands in for the document the server left out.
+    expect(progress!.document).toBe('f248ce0f15105ff390e5292085e0622b');
+  });
+
+  it('accepts a progress payload that includes `document`', async () => {
+    setFetch(() =>
+      jsonResponse(200, {
+        document: 'f248ce0f15105ff390e5292085e0622b',
+        progress: '/body/DocFragment[3]/body/div/p[12].0',
+        percentage: 0.0174,
+        timestamp: 1783773009,
+      }),
+    );
+
+    const client = new KOSyncClient(makeConfig({ userkey: 'key' }));
+    const progress = await client.getProgress(makeBook());
+
+    expect(progress!.document).toBe('f248ce0f15105ff390e5292085e0622b');
+  });
+
+  it('returns null when a 200 body carries no usable position', async () => {
+    // Some servers answer "no progress stored" with 200 and a status body
+    // instead of a 404; that must not be mistaken for a remote position.
+    setFetch(() => jsonResponse(200, { status: 'not found' }));
+
+    const client = new KOSyncClient(makeConfig({ userkey: 'key' }));
+
+    expect(await client.getProgress(makeBook())).toBeNull();
+  });
+
+  it('returns null when the server answers 404', async () => {
+    setFetch(() => jsonResponse(404, { status: 'not found' }));
+
+    const client = new KOSyncClient(makeConfig({ userkey: 'key' }));
+
+    expect(await client.getProgress(makeBook())).toBeNull();
+  });
 });
 
 describe('KOSyncClient.connect – server validation', () => {

--- a/apps/readest-app/src/services/sync/KOSyncClient.ts
+++ b/apps/readest-app/src/services/sync/KOSyncClient.ts
@@ -192,8 +192,18 @@ export class KOSyncClient {
         return null;
       }
 
-      const data = await response.json();
-      return data.document ? data : null;
+      const data: KoSyncProgress = await response.json();
+      if (!data || typeof data !== 'object') return null;
+      // Key validity on an actual position, not on `document`: KOSync-compatible
+      // servers don't all echo the document hash back on GET (koreader-sync only
+      // returns progress/percentage/device/device_id/timestamp), and dropping
+      // those replies left the reader on its stale local position — which it
+      // then pushed back over the newer remote one.
+      const hasPosition =
+        (typeof data.progress === 'string' && data.progress.length > 0) ||
+        (typeof data.percentage === 'number' && Number.isFinite(data.percentage));
+      if (!hasPosition) return null;
+      return { ...data, document: data.document || documentHash };
     } catch (e) {
       console.error('KOSync getProgress failed', e);
       return null;


### PR DESCRIPTION
Fixes #5063
Fixes #5065

## The bug

Both issues report the same thing from iOS against a self-hosted KOReader sync server: Readest performs the `GET /syncs/progress/:document`, the server answers `200` with the newer position from the other device, and Readest never applies it — no jump, no prompt, whatever the sync strategy. Moments later Readest PUTs its own *older* position back, wiping the remote progress.

## Root cause

Both reporters run [`nperez0111/koreader-sync`](https://github.com/nperez0111/koreader-sync). Its GET handler runs:

```sql
SELECT progress, percentage, device, device_id, timestamp FROM progress ...
```

It never returns a `document` field. But `KOSyncClient.getProgress()` threw the whole response away unless one was present:

```ts
const data = await response.json();
return data.document ? data : null;
```

So the valid `200` became `null`. In `useKOSync.pullProgress`, `null` falls into the `setSyncState('synced')` early return, which is why **no strategy applied the position** — `silent` ("Always use latest") and `prompt` ("Ask on conflict") both dead-end at the same line, making the setting look inert. And `'synced'` is precisely the state that arms the auto-push effect, so ~5s later the reader pushed its stale local position over the newer remote one.

A silent pull failure that also arms an overwrite is data loss, not a no-op.

## The fix

Validate the response on an actual *position* — a non-empty `progress` string or a finite `percentage` — rather than on `document`, and backfill `document` from the hash we just requested. A `200` body carrying no position (e.g. `{"status":"not found"}`) is still rejected, so servers that answer that way instead of `404` don't regress.

## Tests

Added four cases to `KOSyncClient.test.ts`, driven by the exact payload shapes from the issue logs. The `document`-less case reproduced the bug before the fix (`expected null not to be null`):

- accepts a progress payload that omits `document`
- accepts a progress payload that includes `document`
- returns null when a 200 body carries no usable position
- returns null when the server answers 404

`pnpm test` (7342 passed) and `pnpm lint` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)