### PR TITLE
fix(macos): skip the minidump handler in sandboxed App Store builds

### DIFF
--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -387,9 +387,13 @@ pub fn run() {
         ))
     });
 
+    // The minidump handler starts its crash-reporter server by re-exec'ing our own
+    // binary, which the sandboxed Mac App Store build cannot do — the child aborts
+    // in dyld before `main()`. Skip it there; see `sentry_config::is_app_sandboxed`.
     #[cfg(not(any(target_os = "ios", target_os = "android")))]
     let _minidump_guard = sentry_guard
         .as_ref()
+        .filter(|_| !sentry_config::is_app_sandboxed())
         .map(|guard| tauri_plugin_sentry::minidump::init(guard));
 
     let builder = tauri::Builder::default()

--- a/apps/readest-app/src-tauri/src/sentry_config.rs
+++ b/apps/readest-app/src-tauri/src/sentry_config.rs
@@ -114,6 +114,38 @@ pub fn is_mobi_cover_panic_frame(function: &str) -> bool {
     function.contains("mobi_parser::extract_cover")
 }
 
+/// Whether a process on `target_os` with this `APP_SANDBOX_CONTAINER_ID` value
+/// runs inside the macOS App Sandbox. The variable is macOS-only, so every other
+/// target is reported unsandboxed regardless of what the environment holds.
+pub fn app_sandboxed(target_os: &str, sandbox_container_id: Option<&str>) -> bool {
+    target_os == "macos" && sandbox_container_id.is_some()
+}
+
+/// True when this process runs inside the macOS App Sandbox, i.e. it is the Mac
+/// App Store build (the DMG and direct-download builds are not sandboxed).
+///
+/// This gates the out-of-process minidump handler. `sentry-rust-minidump` starts
+/// its crash-reporter server by re-exec'ing our own main executable (its
+/// `minidumper-child` spawns `current_exe()` with `--crash-reporter-server=<socket>`),
+/// and that child is the same signed binary — so it carries the app's
+/// `com.apple.security.app-sandbox` entitlement. `libsystem_secinit` then aborts
+/// in dyld's initializers, before `main()` runs, because it cannot apply the
+/// sandbox profile to a process that already inherited one: SIGILL with a
+/// `SYSCALL_SET_PROFILE` signature (#5053). A sandboxed app may only spawn a
+/// *separate* helper binary entitled with `com.apple.security.inherit`, which a
+/// re-exec of the main binary can never be, so the App Store build goes without
+/// native minidumps. Rust panic and WebView error reporting are unaffected.
+///
+/// `libsystem_secinit` exports `APP_SANDBOX_CONTAINER_ID` into every sandboxed
+/// process's environment during startup, so reading it detects the sandbox
+/// without linking the private `sandbox_check` SPI.
+pub fn is_app_sandboxed() -> bool {
+    app_sandboxed(
+        std::env::consts::OS,
+        std::env::var("APP_SANDBOX_CONTAINER_ID").ok().as_deref(),
+    )
+}
+
 /// The WebView (engine, major-version), set once at startup when the app reports
 /// its User-Agent. Stored globally so `before_send` can tag every event — the
 /// browser context integration doesn't run for events forwarded from the webview.
@@ -174,9 +206,29 @@ pub extern "C" fn readest_sentry_dsn() -> *const std::os::raw::c_char {
 #[cfg(test)]
 mod tests {
     use super::{
-        android_version_from_uname, corrected_os_name, dsn_from_env, environment_for_version,
-        is_ignored_browser_error, is_mobi_cover_panic_frame, parse_webview_info, release_name,
+        android_version_from_uname, app_sandboxed, corrected_os_name, dsn_from_env,
+        environment_for_version, is_ignored_browser_error, is_mobi_cover_panic_frame,
+        parse_webview_info, release_name,
     };
+
+    #[test]
+    fn mac_app_store_build_is_detected_as_sandboxed() {
+        // The Mac App Store build runs under the App Sandbox, so libsystem_secinit
+        // exports the container id. The minidump handler must not re-exec our own
+        // binary there (#5053).
+        assert!(app_sandboxed("macos", Some("com.bilingify.readest")));
+    }
+
+    #[test]
+    fn direct_download_and_other_desktops_are_not_sandboxed() {
+        // DMG / direct-download macOS builds are not sandboxed and keep minidumps.
+        assert!(!app_sandboxed("macos", None));
+        // APP_SANDBOX_CONTAINER_ID is a macOS-only variable: never let a stray
+        // value in the environment disable minidumps on the other desktops.
+        assert!(!app_sandboxed("windows", None));
+        assert!(!app_sandboxed("linux", None));
+        assert!(!app_sandboxed("linux", Some("com.bilingify.readest")));
+    }
 
     /// `tauri-plugin-sentry`'s default `minidump` feature pulls in
     /// sentry-rust-minidump -> minidumper-child -> crash-handler, whose


### PR DESCRIPTION
Fixes #5053.

## Root cause

A sandboxed macOS app can never re-exec its own main binary, and 0.11.18 started doing exactly that.

0.11.18 added `tauri_plugin_sentry::minidump::init(...)`. Underneath, `minidumper-child` starts its crash-reporter server by re-exec'ing our own main executable (`current_exe()` + `--crash-reporter-server=<socket>`). That is what the crash report in #5053 shows: the crashing process is `readest [7310]`, whose `Parent Process` is `readest [7308]`.

In the Mac App Store build the app is sandboxed, so that child is the same signed binary and therefore carries `com.apple.security.app-sandbox`. `libsystem_secinit` then aborts inside dyld's initializers, before `main()` runs, because it cannot apply the sandbox profile to a process that already inherited one:

```
Exception Type:  EXC_BAD_INSTRUCTION (SIGILL)
Application Specific Signatures: SYSCALL_SET_PROFILE

0  libsystem_secinit.dylib  _libsecinit_appsandbox.cold.7 + 79
1  libsystem_secinit.dylib  _libsecinit_appsandbox + 1945
3  libsystem_secinit.dylib  _libsecinit_initializer + 67
4  libSystem.B.dylib        libSystem_initializer + 286
5  dyld                     ...findAndRunAllInitializers...
```

A sandboxed app may only spawn a *separate* helper binary entitled with `com.apple.security.inherit` (this is why Chromium/Electron ship a `Helper.app`). A re-exec of the main binary can never qualify, so there is no way to run this crash-reporter server inside the App Store build.

### This is not macOS 13 specific

I reproduced it on Sequoia as well, with a matching stack. It is *sandbox*-specific, not OS-specific, which is why only App Store users hit it while the DMG / direct-download build is fine. The arch changes only the trap instruction (SIGILL/`ud2` on x86_64 vs SIGTRAP/`brk` on arm64), and newer macOS reports `SYSCALL_SET_USERLAND_PROFILE` rather than `SYSCALL_SET_PROFILE`.

## Fix

Gate `minidump::init` off when the process is sandboxed, via `sentry_config::is_app_sandboxed()`. Detection reads `APP_SANDBOX_CONTAINER_ID`, which `libsystem_secinit` exports into every sandboxed process's environment, so it needs no private `sandbox_check` SPI.

The App Store build loses only *native* minidumps. Rust panic reporting and WebView error reporting are unaffected, and unsandboxed builds keep full native crash reports.

## Verification

- New unit tests for the sandbox decision; full `cargo test -p Readest --lib` suite passes (83 tests).
- `pnpm fmt:check` and `pnpm clippy:check` clean.
- Reproduced and confirmed the fix out-of-band with a signed test bundle that re-execs itself the way `minidumper-child` does:
  - signed **with** `com.apple.security.app-sandbox` -> child dies at dyld init with the `_libsecinit_appsandbox.cold.N` stack above;
  - same binary signed **without** it -> child spawns and exits 0;
  - with the gate applied, the sandboxed build no longer spawns the child and does not crash.
- Confirmed `APP_SANDBOX_CONTAINER_ID` is set even when the app is launched from Finder/launchd, not just from a shell.

## Note for the reporter

Strictly speaking the child's death should not by itself kill the app: the parent's connect loop times out after 3s and `init` returns an `Err` that `lib.rs` ignores. So the likely user-visible symptom was the "readest quit unexpectedly" dialog for the helper process (indistinguishable from the app crashing) plus a 3-second startup stall. This change removes both. If the app still fails to open after a build with this fix, we will need the crash report for the *main* process (the one whose parent is `launchd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)