### PR TITLE
feat(markdown): render footnotes in .md books (#5074)

### DIFF
--- a/apps/readest-app/package.json
+++ b/apps/readest-app/package.json
@@ -181,6 +181,7 @@
     "lunr": "^2.3.9",
     "mammoth": "^1.12.0",
     "marked": "^15.0.12",
+    "marked-footnote": "^1.4.0",
     "nanoid": "^5.1.6",
     "next": "16.2.6",
     "next-view-transitions": "^0.3.5",

--- a/apps/readest-app/src/__tests__/utils/md-footnotes.test.ts
+++ b/apps/readest-app/src/__tests__/utils/md-footnotes.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import { makeMarkdownBook } from '@/utils/md';
+import { expandInlineFootnotes } from '@/utils/mdFootnotes';
+import type { BookDoc } from '@/libs/document';
+
+type MdBook = BookDoc & {
+  toc: NonNullable<BookDoc['toc']>;
+  resolveHref: (
+    href: string,
+  ) => { index: number; anchor: (doc: Document) => Element | null } | null;
+};
+
+const make = async (content: string) =>
+  (await makeMarkdownBook(
+    new File([content], 'note.md', { type: 'text/markdown' }),
+  )) as unknown as MdBook;
+
+const docOf = (book: MdBook, index = 0) => book.sections[index]!.createDocument();
+
+const refs = (doc: Document) =>
+  Array.from(doc.querySelectorAll('a[role="doc-noteref"]')) as HTMLAnchorElement[];
+
+const notes = (doc: Document) =>
+  Array.from(doc.querySelectorAll('li[role="doc-endnote"]')) as HTMLLIElement[];
+
+describe('expandInlineFootnotes', () => {
+  it('rewrites an inline note into a reference plus a definition', () => {
+    const out = expandInlineFootnotes('Text.^[The note.]\n');
+    expect(out).toContain('Text.[^inline-1]');
+    expect(out).toContain('[^inline-1]: The note.');
+  });
+
+  it('leaves source without inline notes untouched', () => {
+    const src = 'Plain text[^1].\n\n[^1]: A labelled note.\n';
+    expect(expandInlineFootnotes(src)).toBe(src);
+  });
+
+  it('does not convert ^[...] inside an inline code span', () => {
+    const out = expandInlineFootnotes('Use `^[not a note]` here.\n');
+    expect(out).toContain('`^[not a note]`');
+    expect(out).not.toContain('[^inline-1]');
+  });
+
+  it('does not convert ^[...] inside a fenced code block', () => {
+    const out = expandInlineFootnotes('```\nliteral ^[not a note]\n```\n');
+    expect(out).toContain('literal ^[not a note]');
+    expect(out).not.toContain('[^inline-1]');
+  });
+
+  it('does not convert ^[...] inside a tilde fence', () => {
+    const out = expandInlineFootnotes('~~~\nliteral ^[not a note]\n~~~\n');
+    expect(out).toContain('literal ^[not a note]');
+    expect(out).not.toContain('[^inline-1]');
+  });
+
+  it('captures the whole note when it contains balanced brackets', () => {
+    const out = expandInlineFootnotes('Text.^[see [Foo](http://bar) now] end.\n');
+    expect(out).toContain('[^inline-1]: see [Foo](http://bar) now');
+    expect(out).toContain('Text.[^inline-1] end.');
+  });
+
+  it('collapses a note that wraps across lines', () => {
+    const out = expandInlineFootnotes('Text.^[a note\nwrapped over lines]\n');
+    expect(out).toContain('[^inline-1]: a note wrapped over lines');
+  });
+
+  it('leaves an unterminated ^[ alone', () => {
+    const src = 'Text.^[never closed\n';
+    expect(expandInlineFootnotes(src)).toBe(src);
+  });
+
+  it('respects a backslash-escaped caret', () => {
+    const src = 'Text.\\^[not a note]\n';
+    expect(expandInlineFootnotes(src)).toBe(src);
+  });
+
+  it('picks a label prefix that cannot collide with an author label', () => {
+    const out = expandInlineFootnotes('A[^inline-1] B.^[mine]\n\n[^inline-1]: theirs.\n');
+    // The author already owns `inline-1`, so ours must not reuse it.
+    expect(out).toContain('[^inline-1]: theirs.');
+    expect(out).toMatch(/B\.\[\^inlinex-1\]/);
+    expect(out).toContain('[^inlinex-1]: mine');
+  });
+});
+
+describe('markdown footnotes', () => {
+  it('renders the issue repro as a footnote instead of literal text', async () => {
+    // https://github.com/readest/readest/issues/5074
+    const book = await make('text[^1]\n\n[^1]: footnote\n');
+    const doc = await docOf(book);
+
+    expect(doc.body.textContent).not.toContain('[^1]');
+
+    const [ref] = refs(doc);
+    expect(ref).toBeTruthy();
+    expect(ref!.textContent).toBe('1');
+    expect(ref!.parentElement?.tagName.toLowerCase()).toBe('sup');
+
+    const [note] = notes(doc);
+    expect(note!.textContent).toContain('footnote');
+    expect(ref!.getAttribute('href')).toBe(`#${note!.id}`);
+  });
+
+  it('numbers by first reference, not by label', async () => {
+    const book = await make('a[^zebra] b[^1]\n\n[^1]: one\n[^zebra]: zed\n');
+    const doc = await docOf(book);
+    const [first, second] = refs(doc);
+    expect(first!.textContent).toBe('1');
+    expect(second!.textContent).toBe('2');
+    expect(notes(doc)[0]!.textContent).toContain('zed');
+    expect(notes(doc)[1]!.textContent).toContain('one');
+  });
+
+  it('renders inline notes sharing one sequence with labelled notes', async () => {
+    const book = await make('a.^[inline one] b[^x] c.^[inline two]\n\n[^x]: labelled\n');
+    const doc = await docOf(book);
+    expect(refs(doc).map((r) => r.textContent)).toEqual(['1', '2', '3']);
+    expect(notes(doc).map((n) => n.textContent?.trim())).toEqual([
+      expect.stringContaining('inline one'),
+      expect.stringContaining('labelled'),
+      expect.stringContaining('inline two'),
+    ]);
+  });
+
+  it('keeps a multi-paragraph definition intact', async () => {
+    const book = await make('t[^a]\n\n[^a]: First para.\n\n    Second para.\n');
+    const doc = await docOf(book);
+    const note = notes(doc)[0]!;
+    expect(note.querySelectorAll('p').length).toBe(2);
+    expect(note.textContent).toContain('First para.');
+    expect(note.textContent).toContain('Second para.');
+  });
+
+  it('gives a reused reference one note, unique ids and a backlink per reference', async () => {
+    const book = await make('a[^a] b[^a]\n\n[^a]: once\n');
+    const doc = await docOf(book);
+
+    expect(notes(doc).length).toBe(1);
+    const [r1, r2] = refs(doc);
+    expect(r1!.textContent).toBe('1');
+    expect(r2!.textContent).toBe('1');
+    expect(r1!.id).not.toBe(r2!.id);
+    expect(r1!.getAttribute('href')).toBe(r2!.getAttribute('href'));
+
+    const backlinks = Array.from(
+      notes(doc)[0]!.querySelectorAll('a[role="doc-backlink"]'),
+    ) as HTMLAnchorElement[];
+    expect(backlinks.map((b) => b.getAttribute('href'))).toEqual([`#${r1!.id}`, `#${r2!.id}`]);
+  });
+
+  it('puts each note in the chapter that references it and restarts numbering', async () => {
+    const book = await make(
+      '# One\n\na[^a] b[^b]\n\n# Two\n\nc[^c]\n\n[^a]: note a\n[^b]: note b\n[^c]: note c\n',
+    );
+    const one = await docOf(book, 0);
+    const two = await docOf(book, 1);
+
+    expect(refs(one).map((r) => r.textContent)).toEqual(['1', '2']);
+    expect(notes(one).map((n) => n.textContent)).toEqual([
+      expect.stringContaining('note a'),
+      expect.stringContaining('note b'),
+    ]);
+
+    expect(refs(two).map((r) => r.textContent)).toEqual(['1']);
+    expect(notes(two).length).toBe(1);
+    expect(notes(two)[0]!.textContent).toContain('note c');
+  });
+
+  it('clones a note into every chapter that references it', async () => {
+    const book = await make('# One\n\na[^s]\n\n# Two\n\nb[^s]\n\n[^s]: shared\n');
+    const one = await docOf(book, 0);
+    const two = await docOf(book, 1);
+
+    expect(notes(one)[0]!.textContent).toContain('shared');
+    expect(notes(two)[0]!.textContent).toContain('shared');
+    expect(refs(two)[0]!.textContent).toBe('1');
+    // Each chapter's reference points into its own list, not across sections.
+    expect(refs(one)[0]!.getAttribute('href')).toBe(`#${notes(one)[0]!.id}`);
+    expect(refs(two)[0]!.getAttribute('href')).toBe(`#${notes(two)[0]!.id}`);
+    expect(notes(one)[0]!.id).not.toBe(notes(two)[0]!.id);
+  });
+
+  it('resolves a footnote href to the section that holds it', async () => {
+    const book = await make('# One\n\na[^a]\n\n# Two\n\nb[^b]\n\n[^a]: note a\n[^b]: note b\n');
+    const two = await docOf(book, 1);
+    const href = refs(two)[0]!.getAttribute('href')!;
+    expect(book.resolveHref(href)).toMatchObject({ index: 1 });
+  });
+
+  it('marks backlinks so they do not open a popup on themselves', async () => {
+    const book = await make('t[^a]\n\n[^a]: note\n');
+    const doc = await docOf(book);
+    const backlink = notes(doc)[0]!.querySelector('a[role="doc-backlink"]');
+    expect(backlink).toBeTruthy();
+    expect(backlink!.getAttribute('role')).toBe('doc-backlink');
+  });
+
+  it('keeps the footnotes list out of the TOC', async () => {
+    const book = await make('# One\n\na[^a]\n\n[^a]: note a\n');
+    const labels = book.toc.map((i) => i.label.toLowerCase());
+    expect(labels).toEqual(['one']);
+  });
+
+  it('drops an unreferenced definition and leaves a dangling reference as text', async () => {
+    const book = await make('t[^a]\n\n[^a]: used\n[^b]: never used\n');
+    const doc = await docOf(book);
+    expect(notes(doc).length).toBe(1);
+    expect(doc.body.textContent).not.toContain('never used');
+
+    const dangling = await make('t[^missing]\n');
+    const danglingDoc = await docOf(dangling);
+    expect(refs(danglingDoc).length).toBe(0);
+    expect(danglingDoc.body.textContent).toContain('[^missing]');
+  });
+
+  it('produces XHTML that parses without errors', async () => {
+    const book = await make('# H\n\nt[^a] and inline.^[note b]\n\n[^a]: note a\n');
+    const doc = await docOf(book);
+    expect(doc.querySelector('parsererror')).toBeNull();
+    expect(doc.querySelector('section.md-footnotes')).toBeTruthy();
+  });
+});

--- a/apps/readest-app/src/utils/md.ts
+++ b/apps/readest-app/src/utils/md.ts
@@ -1,7 +1,14 @@
-import { marked } from 'marked';
+import { Marked } from 'marked';
+import markedFootnote from 'marked-footnote';
 
 import type { BookDoc, SectionItem } from '@/libs/document';
 import { CFI } from '@/libs/document';
+import {
+  FOOTNOTE_PREFIX_ID,
+  buildChapterFootnotes,
+  expandInlineFootnotes,
+  extractFootnoteDefs,
+} from './mdFootnotes';
 import { sanitizeHtml } from './sanitize';
 
 // Render a standalone Markdown (.md) file into an in-memory foliate-js book at
@@ -13,6 +20,13 @@ import { sanitizeHtml } from './sanitize';
 
 const XHTML_NS = 'http://www.w3.org/1999/xhtml';
 
+// A scoped parser: `marked` itself is a shared singleton also imported by the
+// annotation note renderer and the export dialog, and must not gain footnote
+// parsing as a side effect.
+const markdown = new Marked({ gfm: true }).use(markedFootnote({ prefixId: FOOTNOTE_PREFIX_ID }), {
+  hooks: { preprocess: expandInlineFootnotes },
+});
+
 // Minimal defaults so code blocks wrap inside the paginated column (long lines
 // would otherwise overflow and break pagination) and tables/images stay legible
 // under every theme. `currentColor` keeps borders readable in dark / e-ink.
@@ -23,6 +37,10 @@ pre, code { font-family: monospace; }
 table { border-collapse: collapse; }
 th, td { border: 1px solid currentColor; padding: 0.2em 0.5em; }
 blockquote { margin-inline: 1em; }
+.md-footnotes { margin-block-start: 2em; font-size: 0.9em; }
+.md-footnotes hr { width: 30%; margin-inline-start: 0; border: 0; border-top: 1px solid currentColor; opacity: 0.4; }
+sup a, .footnote-backref { text-decoration: none; }
+.footnote-backref { margin-inline-start: 0.4em; }
 `;
 
 const wrapXhtml = (inner: string): string =>
@@ -73,9 +91,14 @@ type MarkdownSection = SectionItem & { load: () => string };
 export async function makeMarkdownBook(file: File): Promise<BookDoc> {
   const text = await file.text();
   const { body, meta } = stripFrontmatter(text);
-  const rawHtml = await marked.parse(body, { gfm: true });
+  const rawHtml = await markdown.parse(body);
   const safeHtml = sanitizeHtml(rawHtml);
   const docBody = new DOMParser().parseFromString(safeHtml, 'text/html').body;
+
+  // Lift the collected footnote definitions out before anything else looks at
+  // the document: they are re-emitted per chapter below, and taking them out
+  // here also keeps the generated "Footnotes" heading out of the TOC.
+  const footnoteDefs = extractFootnoteDefs(docBody);
 
   // Ensure every id is unique (including author-provided ids on raw HTML /
   // footnotes), then give each heading a stable slug id for TOC anchors and
@@ -117,6 +140,14 @@ export async function makeMarkdownBook(file: File): Promise<BookDoc> {
   }
   if (hasContent(current)) groups.push(current);
   if (groups.length === 0) groups.push([]);
+
+  // Give each chapter its own endnote list, numbered from 1, so a reference in
+  // chapter 2 resolves within chapter 2 instead of jumping to the end of the
+  // book. Must run before the ids below are mapped to sections.
+  groups.forEach((nodes, index) => {
+    const notes = buildChapterFootnotes(nodes, index, footnoteDefs, uniqueId);
+    if (notes) nodes.push(notes);
+  });
 
   // Serialize each section to well-formed XHTML. Marked emits HTML5 void tags
   // (<br>, <hr>, <img>) that are parse errors under application/xhtml+xml, so

--- a/apps/readest-app/src/utils/mdFootnotes.ts
+++ b/apps/readest-app/src/utils/mdFootnotes.ts
@@ -1,0 +1,228 @@
+// Markdown footnotes for standalone .md books (see utils/md.ts).
+//
+// Two syntaxes are supported. `[^label]` + `[^label]: note` is the de-facto
+// standard (PHP Markdown Extra, adopted verbatim by GitHub, Pandoc, Obsidian,
+// Typora, goldmark and others) and is parsed by the `marked-footnote` plugin.
+// Pandoc's inline `^[note]` is not, so `expandInlineFootnotes` rewrites it into
+// the standard form before the plugin runs; both then share one numbering
+// sequence.
+//
+// The plugin collects every definition into one trailing section, which would
+// strand the whole book's notes inside the last <h1> section once md.ts splits
+// at chapter boundaries. Instead `extractFootnoteDefs` lifts them out and
+// `buildChapterFootnotes` re-emits them as per-chapter endnotes, numbered from
+// 1 in each chapter, with the DPUB roles foliate's footnote popup keys on.
+
+// `prefixId` passed to marked-footnote. Definitions are `<PREFIX><label>` and
+// references `<PREFIX>ref-<label>`; distinctive enough not to collide with ids
+// an author wrote by hand.
+export const FOOTNOTE_PREFIX_ID = 'md-fn-';
+const DEF_PREFIX = FOOTNOTE_PREFIX_ID;
+const REF_PREFIX = `${FOOTNOTE_PREFIX_ID}ref-`;
+
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+
+// Rewrite Pandoc/Obsidian inline notes `^[text]` into a reference plus a
+// definition appended to the source, so marked-footnote sees one uniform
+// document and numbers inline and labelled notes in a single sequence.
+//
+// Code spans and fenced blocks are copied through untouched. Indented (4-space)
+// code blocks are not detected: telling them apart from list continuations needs
+// a full block parser, and a `^[` inside one is vanishingly rare.
+export const expandInlineFootnotes = (src: string): string => {
+  if (!src.includes('^[')) return src;
+
+  // Never reuse a label the author already owns.
+  let prefix = 'inline';
+  while (src.includes(`[^${prefix}-`)) prefix += 'x';
+
+  const defs: string[] = [];
+  let out = '';
+  let i = 0;
+
+  while (i < src.length) {
+    if (i === 0 || src[i - 1] === '\n') {
+      const eol = src.indexOf('\n', i);
+      const line = src.slice(i, eol === -1 ? src.length : eol);
+      const fence = FENCE_RE.exec(line);
+      if (fence) {
+        const marker = fence[1]!;
+        const closing = new RegExp(`^ {0,3}\\${marker[0]}{${marker.length},}[ \t]*$`);
+        let j = eol === -1 ? src.length : eol + 1;
+        while (j < src.length) {
+          const end = src.indexOf('\n', j);
+          const next = src.slice(j, end === -1 ? src.length : end);
+          j = end === -1 ? src.length : end + 1;
+          if (closing.test(next)) break;
+        }
+        out += src.slice(i, j);
+        i = j;
+        continue;
+      }
+    }
+
+    const ch = src[i]!;
+
+    if (ch === '`') {
+      const run = /^`+/.exec(src.slice(i))![0];
+      const close = src.indexOf(run, i + run.length);
+      const stop = close === -1 ? i + run.length : close + run.length;
+      out += src.slice(i, stop);
+      i = stop;
+      continue;
+    }
+
+    if (ch === '\\' && src[i + 1] === '^') {
+      out += src.slice(i, i + 2);
+      i += 2;
+      continue;
+    }
+
+    if (ch === '^' && src[i + 1] === '[') {
+      let depth = 1;
+      let j = i + 2;
+      while (j < src.length && depth > 0) {
+        const c = src[j];
+        if (c === '\\') {
+          j += 2;
+          continue;
+        }
+        if (c === '[') depth++;
+        else if (c === ']') depth--;
+        if (depth === 0) break;
+        j++;
+      }
+      const text =
+        depth === 0
+          ? src
+              .slice(i + 2, j)
+              .replace(/\s*\n\s*/g, ' ')
+              .trim()
+          : '';
+      if (text) {
+        const label = `${prefix}-${defs.length + 1}`;
+        defs.push(`[^${label}]: ${text}`);
+        out += `[^${label}]`;
+        i = j + 1;
+        continue;
+      }
+    }
+
+    out += ch;
+    i++;
+  }
+
+  return defs.length ? `${out.replace(/\s+$/, '')}\n\n${defs.join('\n\n')}\n` : src;
+};
+
+// Lift the plugin's trailing footnotes section out of the document, keyed by
+// label. Removing it here (before md.ts scans headings) also keeps the plugin's
+// "Footnotes" <h2> out of the TOC.
+export const extractFootnoteDefs = (docBody: HTMLElement): Map<string, HTMLLIElement> => {
+  const defs = new Map<string, HTMLLIElement>();
+  const section = docBody.querySelector('section.footnotes');
+  if (!section) return defs;
+  for (const li of Array.from(section.querySelectorAll('li'))) {
+    if (li.id.startsWith(DEF_PREFIX)) defs.set(li.id.slice(DEF_PREFIX.length), li as HTMLLIElement);
+  }
+  section.remove();
+  return defs;
+};
+
+// Rewrite every footnote reference in one chapter's nodes to a chapter-local
+// number, and return the endnote list to append to that chapter. A note cited
+// from two chapters is cloned into both, so each chapter's list is complete and
+// its numbers match its own references.
+export const buildChapterFootnotes = (
+  nodes: ChildNode[],
+  sectionIndex: number,
+  defs: Map<string, HTMLLIElement>,
+  uniqueId: (base: string) => string,
+): HTMLElement | null => {
+  if (!defs.size) return null;
+
+  const doc = nodes[0]?.ownerDocument;
+  if (!doc) return null;
+
+  interface Placed {
+    li: HTMLLIElement;
+    id: string;
+    ordinal: number;
+    refIds: string[];
+  }
+  const placed = new Map<string, Placed>();
+  const list = doc.createElement('ol');
+
+  // A note may itself cite a note, so newly cloned definitions are scanned too.
+  const queue: HTMLAnchorElement[] = [];
+  for (const node of nodes) {
+    if (node.nodeType !== Node.ELEMENT_NODE) continue;
+    queue.push(
+      ...Array.from(
+        (node as Element).querySelectorAll<HTMLAnchorElement>(`a[id^="${REF_PREFIX}"]`),
+      ),
+    );
+  }
+
+  for (let i = 0; i < queue.length; i++) {
+    const ref = queue[i]!;
+    const label = (ref.getAttribute('href') ?? '').slice(`#${DEF_PREFIX}`.length);
+    const def = defs.get(label);
+    if (!def) continue;
+
+    let entry = placed.get(label);
+    if (!entry) {
+      const li = def.cloneNode(true) as HTMLLIElement;
+      // The plugin's backlinks point at document-wide reference ids; ours are
+      // chapter-local, so drop them and regenerate below.
+      for (const back of Array.from(li.querySelectorAll(`a[href^="#${REF_PREFIX}"]`))) {
+        back.remove();
+      }
+      const id = uniqueId(`fn-${sectionIndex}-${placed.size + 1}`);
+      li.id = id;
+      li.setAttribute('role', 'doc-endnote');
+      entry = { li, id, ordinal: placed.size + 1, refIds: [] };
+      placed.set(label, entry);
+      list.appendChild(li);
+      queue.push(...Array.from(li.querySelectorAll<HTMLAnchorElement>(`a[id^="${REF_PREFIX}"]`)));
+    }
+
+    const refId = uniqueId(`fnref-${sectionIndex}-${entry.ordinal}`);
+    ref.id = refId;
+    ref.setAttribute('href', `#${entry.id}`);
+    // foliate's FootnoteHandler treats doc-noteref as a definite footnote
+    // reference, so the popup does not depend on the superscript heuristic.
+    ref.setAttribute('role', 'doc-noteref');
+    ref.textContent = String(entry.ordinal);
+    entry.refIds.push(refId);
+  }
+
+  if (!placed.size) return null;
+
+  for (const entry of placed.values()) {
+    const target = entry.li.querySelector('p:last-of-type') ?? entry.li;
+    entry.refIds.forEach((refId, index) => {
+      const back = doc.createElement('a');
+      back.setAttribute('href', `#${refId}`);
+      // Excluded by foliate's footnote heuristic, so tapping it navigates back
+      // instead of opening a popup on itself.
+      back.setAttribute('role', 'doc-backlink');
+      back.setAttribute('class', 'footnote-backref');
+      back.textContent = '↩';
+      if (entry.refIds.length > 1) {
+        const sup = doc.createElement('sup');
+        sup.textContent = String(index + 1);
+        back.appendChild(sup);
+      }
+      target.appendChild(doc.createTextNode(' '));
+      target.appendChild(back);
+    });
+  }
+
+  const section = doc.createElement('section');
+  section.setAttribute('class', 'md-footnotes');
+  section.setAttribute('role', 'doc-endnotes');
+  section.appendChild(doc.createElement('hr'));
+  section.appendChild(list);
+  return section;
+};

--- a/apps/readest-app/src/utils/sanitize.ts
+++ b/apps/readest-app/src/utils/sanitize.ts
@@ -56,6 +56,9 @@ export function sanitizeHtml(html: string): string {
       'img',
       'figure',
       'figcaption',
+      // Markdown footnote definitions arrive wrapped in <section class="footnotes">
+      // (see utils/mdFootnotes.ts), which must survive to be found and re-emitted.
+      'section',
     ],
     // `id` is allowed so heading anchors survive — the EPUB's nested
     // navMap uses `chapter1.xhtml#heading-id` to link the TOC sidebar to

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
       marked:
         specifier: ^15.0.12
         version: 15.0.12
+      marked-footnote:
+        specifier: ^1.4.0
+        version: 1.4.0(marked@15.0.12)
       nanoid:
         specifier: ^5.1.6
         version: 5.1.11
@@ -6325,6 +6328,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked-footnote@1.4.0:
+    resolution: {integrity: sha512-fZTxAhI1TcLEs5UOjCfYfTHpyKGaWQevbxaGTEA68B51l7i87SctPFtHETYqPkEN0ka5opvy4Dy1l/yXVC+hmg==}
+    peerDependencies:
+      marked: '>=7.0.0'
 
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
@@ -15130,6 +15138,10 @@ snapshots:
       xmlbuilder: 10.1.1
 
   markdown-table@3.0.4: {}
+
+  marked-footnote@1.4.0(marked@15.0.12):
+    dependencies:
+      marked: 15.0.12
 
   marked@15.0.12: {}
 


### PR DESCRIPTION
Closes #5074

## Problem

Markdown footnotes render as literal text. `marked` has no footnote support, with or without the `gfm` flag, and its maintainers have [said they will not add it](https://github.com/markedjs/marked/issues/714).

```
Input:   text[^1]
         [^1]: footnote

Before:  <p>text[^1]</p>
         <p>[^1]: footnote</p>
```

## Which syntax

Footnotes are in no spec -- not CommonMark, not the GFM spec (which covers only tables, task lists, strikethrough, autolinks and raw-HTML filtering). GitHub's support is a `cmark-gfm` extension.

Despite that, one syntax is universal. PHP Markdown Extra's reference-plus-definition form was adopted verbatim by GitHub, Pandoc, Obsidian, Typora, Python-Markdown, markdown-it, remark-gfm, goldmark/Hugo, Quarto and MkDocs:

```markdown
Some text[^1] and a named one[^note].

[^1]: The first footnote.
[^note]: A named footnote.

    A continuation paragraph, indented four spaces.
```

The one meaningful secondary syntax is Pandoc's inline footnote, supported by Pandoc, Quarto, markdown-it and Obsidian's reading view:

```markdown
Some text.^[The note is written right here.]
```

This PR supports both.

## Approach

`marked-footnote` parses the reference form -- it already gets the hard parts right (four-space continuation paragraphs, label normalization, references reused across the document, renumbering by first reference). The plugin does not support inline notes, so `expandInlineFootnotes` rewrites `^[note]` into a synthetic reference plus definition in a `preprocess` hook. The plugin then sees one uniform document, so inline and labelled notes share a single numbering sequence. Code spans and fenced blocks are copied through untouched.

The parser is a scoped `new Marked(...)` instance: the `marked` singleton is also imported by the annotation note renderer and the export dialog, and must not gain footnote parsing as a side effect.

## Per-chapter endnotes

`md.ts` splits a `.md` book into one foliate section per `<h1>`, but every markdown tool collects footnote definitions at the very end of the document. Left alone, that would strand every note in the book inside the final `<h1>` section, so a reference in chapter 2 would jump the reader to the end of the book.

Instead the definitions are lifted out and re-emitted as per-chapter endnote lists, with numbering restarting at 1 in each chapter (ids stay globally unique; only the displayed number restarts). A note cited from two chapters is cloned into both, so each chapter's list is complete and its numbers match its own references.

## Why DPUB roles

The emitted markup uses `role="doc-noteref"` / `doc-endnote` / `doc-backlink` rather than GitHub's `data-footnote-*` shape. That is load-bearing against `foliate-js/footnotes.js`:

- `doc-noteref` puts `isFootnoteReference` on its **yes** branch, so the popup fires deterministically instead of relying on the "is it superscripted?" heuristic in `footnoteHeuristics.ts`.
- `doc-endnote` on the `<li>` makes `getReferencedType` return `endnote`, and `footnotes.js` already special-cases `el.matches('li')` to select the list item's contents as the popup body.
- `doc-backlink` is explicitly excluded by foliate's `maybe()`, so tapping the back arrow navigates instead of opening a popup on itself.

Net effect: markdown footnotes get the same tap-to-popup experience as EPUB footnotes, **with no reader-side changes**.

## Changes

| File | |
| --- | --- |
| `src/utils/mdFootnotes.ts` | new: inline-note expansion, definition extraction, per-chapter endnote building |
| `src/utils/md.ts` | scoped `Marked` instance with the plugin; extract and redistribute definitions; footnote styles |
| `src/utils/sanitize.ts` | allow `section`, so the plugin's footnotes wrapper survives to be found |
| `package.json` | `marked-footnote@^1.4.0` |

## Known limitation

`^[...]` inside a **four-space indented** code block is still converted. Telling those apart from list continuations needs a full block parser, and a `^[` inside one is vanishingly rare. Fenced blocks and inline code spans are handled.

## Testing

22 new tests (`src/__tests__/utils/md-footnotes.test.ts`), starting from the issue's exact repro: numbering by first reference, inline notes sharing the sequence with labelled ones, code-span and fence protection, balanced brackets, multi-paragraph definitions, reused references, per-chapter split and renumbering, cross-chapter cloning, TOC cleanliness, and `resolveHref` round-trips.

Verified manually in the browser: rendering, per-chapter numbering, tap-to-popup in both chapters, and both code forms staying literal.

`pnpm test` (7322 passed), `pnpm lint` and `pnpm format:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)