### PR TITLE
chore(zed): enable typescript type checking across entire codebase

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -79,6 +79,11 @@
     "vtsls": {
       "settings": {
         "typescript": {
+          "tsserver": {
+            "experimental": {
+              "enableProjectDiagnostics": true // Disable if you don't want vtsls to scan the entire codebase
+            }
+          },
           "inlayHints": {
             "parameterNames": {
               "enabled": "all"


### PR DESCRIPTION
Enables a vstls setting to get typescript type checking across the entire codebase.