### PR TITLE
fix(epub): load chapters whose zip entry name needs percent-encoding

### DIFF
--- a/apps/readest-app/src/__tests__/foliate-epub-encoded-href.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-epub-encoded-href.test.ts
@@ -1,0 +1,178 @@
+// Regression test for #5097: chapters whose filename inside the EPUB zip needs
+// percent-encoding in the manifest (e.g. `&`) render as blank pages.
+//
+// Zip entry names are raw bytes: `OEBPS/a&b.html`. The OPF, being a URI, must
+// percent-encode that as `href="a%26b.html"`. foliate-js resolved hrefs with
+// `decodeURI()`, which per spec refuses to decode the reserved set
+// (`; / ? : @ & = + $ , #`), so the href resolved to the *string*
+// `OEBPS/a%26b.html` and never matched the zip entry. The zip loader returns
+// `null` for an unknown entry, so the section silently loaded as empty rather
+// than erroring -- the blank/zero-length page in the report.
+import { describe, expect, it } from 'vitest';
+
+import { EPUB } from 'foliate-js/epub.js';
+
+const CONTAINER = `<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`;
+
+const opf = (items: { id: string; href: string }[]) => `<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="BookID" version="2.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Ampersand Bug Minimal Test</dc:title>
+    <dc:language>en</dc:language>
+    <dc:identifier id="BookID">urn:uuid:12345</dc:identifier>
+  </metadata>
+  <manifest>
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>
+    ${items.map(({ id, href }) => `<item id="${id}" href="${href}" media-type="application/xhtml+xml"/>`).join('\n    ')}
+  </manifest>
+  <spine toc="ncx">
+    ${items.map(({ id }) => `<itemref idref="${id}"/>`).join('\n    ')}
+  </spine>
+</package>`;
+
+// The NCX `src` is percent-encoded exactly like the manifest href.
+const ncx = (points: { label: string; src: string }[]) => `<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <head><meta name="dtb:uid" content="urn:uuid:12345"/></head>
+  <docTitle><text>Ampersand Bug Minimal Test</text></docTitle>
+  <navMap>
+    ${points
+      .map(
+        ({ label, src }, i) => `<navPoint id="navPoint-${i + 1}" playOrder="${i + 1}">
+      <navLabel><text>${label}</text></navLabel>
+      <content src="${src}"/>
+    </navPoint>`,
+      )
+      .join('\n    ')}
+  </navMap>
+</ncx>`;
+
+const chapter = (body: string) =>
+  `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body><p>${body}</p></body></html>`;
+
+type Section = {
+  id: string;
+  loadText: () => Promise<string | null>;
+  resolveHref: (href: string) => string;
+};
+
+// Mirrors foliate-js's real zip loader (view.js): a name that isn't an entry
+// yields `null` rather than throwing.
+const openEpub = async (files: Record<string, string>) => {
+  const epub = new EPUB({
+    entries: Object.keys(files).map((filename) => ({ filename })),
+    loadText: async (name: string) => files[name] ?? null,
+    loadBlob: async (name: string) =>
+      files[name] == null ? null : new Blob([files[name]!], { type: 'application/xhtml+xml' }),
+    getSize: (name: string) => files[name]?.length ?? 0,
+    // only used to deobfuscate fonts, which these fixtures don't have
+    sha1: undefined,
+  });
+  await epub.init();
+  const sections = (epub.sections ?? []) as Section[];
+  const toc = (epub.toc ?? []) as { label: string; href: string }[];
+  return { epub, sections, toc };
+};
+
+describe('EPUB hrefs that percent-encode reserved characters (#5097)', () => {
+  it('loads a chapter whose zip entry name contains "&" (the reported bug)', async () => {
+    const { sections } = await openEpub({
+      'META-INF/container.xml': CONTAINER,
+      'OEBPS/content.opf': opf([
+        { id: 'chapter1', href: 'normal.html' },
+        { id: 'chapter2', href: 'a%26b.html' },
+      ]),
+      'OEBPS/normal.html': chapter('Chapter 1: Normal'),
+      'OEBPS/a&b.html': chapter('Chapter 2: A&amp;B (The Bug)'),
+    });
+
+    // The section must point at the real zip entry, not the still-encoded name.
+    expect(sections[1]!.id).toBe('OEBPS/a&b.html');
+
+    const text = await sections[1]!.loadText();
+    expect(text).toContain('Chapter 2: A&amp;B (The Bug)');
+  });
+
+  it('navigates to that chapter from the table of contents', async () => {
+    const { epub, toc } = await openEpub({
+      'META-INF/container.xml': CONTAINER,
+      'OEBPS/content.opf': opf([
+        { id: 'chapter1', href: 'normal.html' },
+        { id: 'chapter2', href: 'a%26b.html' },
+      ]),
+      'OEBPS/toc.ncx': ncx([
+        { label: 'Chapter 1: Normal', src: 'normal.html' },
+        { label: 'Chapter 2: A&amp;B (The Bug)', src: 'a%26b.html' },
+      ]),
+      'OEBPS/normal.html': chapter('Chapter 1: Normal'),
+      'OEBPS/a&b.html': chapter('Chapter 2: A&amp;B (The Bug)'),
+    });
+
+    // Tapping the TOC row hands its href to `resolveHref`; it must land on the
+    // chapter's spine index instead of resolving to nothing.
+    expect(epub.resolveHref(toc[1]!.href)?.index).toBe(1);
+  });
+
+  // Issue #346, "Pictures in book (ePub) can not be displayed": a book with a
+  // raw, unencoded ":" in a chapter path. That path becomes the base its own
+  // images resolve against, and the base was tested for a URL scheme with
+  // `relativeTo.includes(':')`, so `new URL()` threw and no image resolved. It
+  // was patched by exempting bases that start with "OEBPS", which left books
+  // under any other root still broken. A real scheme test fixes both roots.
+  it.each([
+    'OEBPS',
+    'Text',
+  ])('resolves images inside a ":" chapter under %s/ (#346)', async (root) => {
+    const { sections } = await openEpub({
+      'META-INF/container.xml': CONTAINER.replace('OEBPS/content.opf', `${root}/content.opf`),
+      [`${root}/content.opf`]: opf([{ id: 'chapter1', href: 'Text/ch:1.html' }]),
+      [`${root}/toc.ncx`]: ncx([{ label: 'Chapter 1', src: 'Text/ch:1.html' }]),
+      [`${root}/Text/ch:1.html`]: chapter('Chapter 1'),
+    });
+
+    expect(sections[0]!.id).toBe(`${root}/Text/ch:1.html`);
+    // the image hrefs that went missing in #346
+    expect(sections[0]!.resolveHref('../Images/pic.jpg')).toBe(`${root}/Images/pic.jpg`);
+    expect(sections[0]!.resolveHref('pic.jpg')).toBe(`${root}/Text/pic.jpg`);
+  });
+
+  it('loads chapters for the other reserved characters decodeURI leaves encoded', async () => {
+    // `,` and `:` were previously hand-patched one at a time; the rest of the
+    // set failed the same way.
+    const names = {
+      amp: 'a&b.html',
+      comma: 'a,b.html',
+      colon: 'a:b.html',
+      plus: 'a+b.html',
+      equals: 'a=b.html',
+      at: 'a@b.html',
+      dollar: 'a$b.html',
+      semi: 'a;b.html',
+      question: 'a?b.html',
+    };
+    const files: Record<string, string> = {
+      'META-INF/container.xml': CONTAINER,
+      'OEBPS/content.opf': opf(
+        Object.entries(names).map(([id, name]) => ({
+          id,
+          href: encodeURIComponent(name),
+        })),
+      ),
+    };
+    for (const name of Object.values(names)) {
+      files[`OEBPS/${name}`] = chapter(`body of ${name}`);
+    }
+    const { sections } = await openEpub(files);
+
+    const loaded = await Promise.all(sections.map((section) => section.loadText()));
+    for (const [i, name] of Object.values(names).entries()) {
+      expect(loaded[i], `section for ${name}`).toContain(`body of ${name}`);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #5097

## Problem

A chapter stored in the zip as `a&b.html` must be referenced from the OPF manifest, which is a URI, as `href="a%26b.html"`. foliate-js resolved that href with `decodeURI()`, which **by spec leaves the reserved set** (`; / ? : @ & = + $ , #`) encoded - it only undoes what `encodeURI()` would have escaped. So the href stayed the literal string `OEBPS/a%26b.html` and never matched the zip entry `OEBPS/a&b.html`.

The failure is silent: foliate's zip loader returns `null` for an unknown entry name, and `loadReplaced()` turns null text into a null section. The chapter renders as a **blank, zero-length page** with nothing in the console, which is what the issue reports.

Worth noting for anyone triaging a similar report: the TOC still navigates to the right chapter, because the TOC `src` is resolved through the same code path. Manifest and TOC agree with each other while both disagree with the zip, so navigation looks fine and only the content is empty.

`%2c` and `%3a` had each been hand-patched before with a pre-decode workaround. `%26` is the third character from that same set to surface.

## Fix

Submodule bump for readest/foliate-js#54, which decodes hrefs as a component (keeping only `/` and `#` encoded, since those would become a path or fragment separator) and drops the per-character workarounds.

## Verification

Driving the reproduction EPUB attached to the issue through the real `EPUB` class:

| | Section [1] |
| --- | --- |
| before | `id="OEBPS/a%26b.html"`, **0 bytes**, no heading |
| after | `id="OEBPS/a&b.html"`, **18990 bytes**, `"Chapter 2: A&B"` |

New regression test (written failing first) covers the reported `&` chapter, its TOC entry, a `:` in the book root, and the remaining reserved characters that failed the same way.

- `pnpm test`: 7337 passed, 0 failed
- `pnpm lint`, `pnpm format:check`: clean
- no Rust or Lua files touched

## Merge order

readest/foliate-js#54 is **merged**. The submodule now points at `90764e1`, the squashed commit on foliate-js `main`, and the tests and lint were re-run against it. This PR is self-contained and ready to merge.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Regression check against the earlier workarounds

The foliate-js change removes two long-standing lines, so I traced where each came from:

| removed line | came from | ticket |
| --- | --- | --- |
| `!relativeTo.startsWith('OEBPS')` guard | #349 | #346, "Pictures in book (ePub) can not be displayed" |
| `url.replace(/%2c/, ',')` | #796, "hack to decode incorrectly encoded url in href" | none (empty body, no linked issue) |
| `%3a` + the `/gi` flags | #1379, "css: handle inline image height" | none (drive-by in an unrelated bump) |

**#346** is the only one with a real ticket. It was a book with a raw, unencoded `:` in a chapter path; that path becomes the base its images resolve against, and `relativeTo.includes(':')` mistook it for a URL scheme, so `new URL()` threw and no image in the chapter loaded. `isExternal()` is the real scheme test and covers it properly.

The test file pins this: a book with `href="Text/ch:1.html"` whose images are resolved from that chapter, under both an `OEBPS/` root and a `Text/` root.

- against the **pre-fix** foliate-js: the `OEBPS/` case passes (the #349 guard) and the `Text/` case fails
- against the **fixed** foliate-js: both pass

So #346 stays fixed, and books not rooted at `OEBPS/` now work too. `%2c` behavior is preserved byte-for-byte (verified by diffing the old and new resolver across comma cases); `%3a` only changes where the old code was already broken.


### Verified against the real #346 book

The reproduction book for readest#346 (`大奉打更人.epub`, 971 zip entries, 935 spine sections) turns out to name every file with raw, unencoded `:` and `*` characters, exactly the shape reconstructed above:

```
OEBPS/Text/::*****:**:******::******::*:::::***:::*::*:::*:*:*:.xhtml
OEBPS/Images/:***::::**:::*:****:*****:*:::*:::::::*::*:**::**::.jpg
```

with the OPF referencing them unencoded: `href="Text/::::*:::*::**:*:...xhtml"`. So a chapter path carries a `:`, and it is that path which every image inside the chapter resolves against.

Resolving every `<img src>` in the book's image-bearing chapters and checking each result against the actual zip entry list:

| `resolveURL` version | images resolving to a real zip entry |
| --- | --- |
| pre-#349 upstream (the original bug) | **0 / 8** - reproduces "Pictures in book can not be displayed" |
| current `main` (OEBPS guard + `%2c`/`%3a` hack) | **8 / 8** |
| this PR | **8 / 8** |

The first row confirms the check actually detects the #346 failure, so the third row is meaningful: this PR resolves every image exactly as `main` does, and reads the same 935 spine sections. #346 does not regress.

