### PR TITLE
fix(i18n): merge the split cloud provider tip into one key

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -1939,8 +1939,6 @@
   "Full Sync": "مزامنة كاملة",
   "Waiting for sign-in…": "في انتظار تسجيل الدخول…",
   "Reconnect": "إعادة الاتصال",
-  "Connected as {{account}}": "متصل باسم {{account}}",
-  ". Make Google Drive the active cloud provider.": ". اجعل Google Drive مزود السحابة النشط.",
   "Use Google Drive": "استخدام Google Drive",
   "Sign-in opens in your browser.": "يتم فتح تسجيل الدخول في متصفحك.",
   "Readest only accesses the files it creates in your Drive.": "لا يصل Readest إلا إلى الملفات التي ينشئها في Drive الخاص بك.",
@@ -2038,11 +2036,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "زامن مكتبتك وتقدم القراءة والتمييزات مع Microsoft OneDrive الخاص بك.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "عند اختيار {{provider}}، تتم مزامنة الكتب والتقدم والتعليقات التوضيحية إلى OneDrive الخاص بك فقط.",
   "Readest only accesses the files it creates in your OneDrive.": "لا يصل Readest إلا إلى الملفات التي ينشئها في OneDrive الخاص بك.",
-  ". Make OneDrive the active cloud provider.": ". اجعل OneDrive مزود السحابة النشط.",
   "Sentence Pause": "وقفة بين الجمل",
   "Paragraph Gap": "وقفة بين الفقرات",
   "{{minutes}}m left": "بقيت {{minutes}} دقيقة",
   "{{hours}}h left": "بقيت {{hours}} ساعة",
   "Time Remaining": "الوقت المتبقي",
-  "Theme": "السمة"
+  "Theme": "السمة",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "متصل باسم {{account}}. اجعل {{provider}} مزود السحابة النشط."
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1803,8 +1803,6 @@
   "Full Sync": "সম্পূর্ণ সিঙ্ক",
   "Waiting for sign-in…": "সাইন ইনের জন্য অপেক্ষা করা হচ্ছে…",
   "Reconnect": "পুনরায় সংযোগ করুন",
-  "Connected as {{account}}": "{{account}} হিসেবে সংযুক্ত",
-  ". Make Google Drive the active cloud provider.": "। Google Drive-কে সক্রিয় ক্লাউড প্রদানকারী করুন।",
   "Use Google Drive": "Google Drive ব্যবহার করুন",
   "Sign-in opens in your browser.": "সাইন ইন আপনার ব্রাউজারে খুলবে।",
   "Readest only accesses the files it creates in your Drive.": "Readest শুধুমাত্র আপনার Drive-এ নিজে তৈরি করা ফাইলগুলিতেই প্রবেশ করে।",
@@ -1898,11 +1896,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "আপনার লাইব্রেরি, পড়ার অগ্রগতি এবং হাইলাইটগুলি আপনার Microsoft OneDrive-এর সাথে সিঙ্ক করুন।",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} নির্বাচিত থাকাকালীন বই, অগ্রগতি ও টীকা শুধুমাত্র আপনার OneDrive-এ সিঙ্ক হয়।",
   "Readest only accesses the files it creates in your OneDrive.": "Readest শুধুমাত্র আপনার OneDrive-এ নিজে তৈরি করা ফাইলগুলিতেই প্রবেশ করে।",
-  ". Make OneDrive the active cloud provider.": "। OneDrive-কে সক্রিয় ক্লাউড প্রদানকারী করুন।",
   "Sentence Pause": "বাক্যের মধ্যে বিরতি",
   "Paragraph Gap": "অনুচ্ছেদের মধ্যে বিরতি",
   "{{minutes}}m left": "{{minutes}} মিনিট বাকি",
   "{{hours}}h left": "{{hours}} ঘণ্টা বাকি",
   "Time Remaining": "অবশিষ্ট সময়",
-  "Theme": "থিম"
+  "Theme": "থিম",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} হিসেবে সংযুক্ত। {{provider}}-কে সক্রিয় ক্লাউড প্রদানকারী করুন।"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1763,8 +1763,6 @@
   "Full Sync": "ཡོངས་རྫོགས་མཉམ་སྒྲིག",
   "Waiting for sign-in…": "ནང་བསྐྱོད་ལ་སྒུག་བཞིན་པ།…",
   "Reconnect": "ཡང་བསྐྱར་འབྲེལ་མཐུད།",
-  "Connected as {{account}}": "{{account}} ཐོག་ནས་འབྲེལ་མཐུད་ཟིན།",
-  ". Make Google Drive the active cloud provider.": "། Google Drive དེ་སྤྱོད་བཞིན་པའི་སྤྲིན་ཞབས་ཞུ་མཁོ་སྤྲོད་པར་སྒྲིག་པ།",
   "Use Google Drive": "Google Drive བེད་སྤྱོད།",
   "Sign-in opens in your browser.": "ནང་བསྐྱོད་ཁྱེད་ཀྱི་བརྡར་ཞིབ་ཆས་ནང་ཁ་ཕྱེ་ངེས།",
   "Readest only accesses the files it creates in your Drive.": "Readest ཀྱིས་ཁྱེད་ཀྱི་ Drive ནང་རང་ཉིད་ཀྱིས་བཟོས་པའི་ཡིག་ཆ་ཁོ་ནར་ལྟ་སྤྱོད་བྱེད།",
@@ -1863,11 +1861,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "ཁྱེད་ཀྱི་དཔེ་མཛོད་དང་། ཀློག་པའི་ཡར་འཕེལ། གཙོ་གནད་བཅས་ཁྱེད་ཀྱི་ Microsoft OneDrive དང་མཉམ་སྒྲིག་བྱེད།",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} བདམས་ཡོད་སྐབས། དཔེ་ཆ་དང་བགྲོད་རིམ། མཆན་འགྲེལ་བཅས་ཁྱེད་ཀྱི་ OneDrive ནང་ཁོ་ནར་མཉམ་བསྒྲིག་བྱེད།",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ཀྱིས་ཁྱེད་ཀྱི་ OneDrive ནང་རང་ཉིད་ཀྱིས་བཟོས་པའི་ཡིག་ཆ་ཁོ་ནར་ལྟ་སྤྱོད་བྱེད།",
-  ". Make OneDrive the active cloud provider.": "། OneDrive དེ་སྤྱོད་བཞིན་པའི་སྤྲིན་ཞབས་ཞུ་མཁོ་སྤྲོད་པར་སྒྲིག་པ།",
   "Sentence Pause": "ཚིག་གྲུབ་བར་གསེང་",
   "Paragraph Gap": "དོན་ཚན་བར་གསེང་",
   "{{minutes}}m left": "ད་དུང་ {{minutes}} སྐར་མ་ལྷག་ཡོད།",
   "{{hours}}h left": "ད་དུང་ {{hours}} ཆུ་ཚོད་ལྷག་ཡོད།",
   "Time Remaining": "ལྷག་ཡོད་པའི་དུས་ཚོད།",
-  "Theme": "བརྗོད་བྱ།"
+  "Theme": "བརྗོད་བྱ།",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} ཐོག་ནས་འབྲེལ་མཐུད་ཟིན། {{provider}} དེ་སྤྱོད་བཞིན་པའི་སྤྲིན་ཞབས་ཞུ་མཁོ་སྤྲོད་པར་སྒྲིག་པ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1803,8 +1803,6 @@
   "Full Sync": "Vollständige Synchronisierung",
   "Waiting for sign-in…": "Warten auf Anmeldung…",
   "Reconnect": "Erneut verbinden",
-  "Connected as {{account}}": "Verbunden als {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Google Drive als aktiven Cloud-Anbieter festlegen.",
   "Use Google Drive": "Google Drive verwenden",
   "Sign-in opens in your browser.": "Die Anmeldung wird in Ihrem Browser geöffnet.",
   "Readest only accesses the files it creates in your Drive.": "Readest greift nur auf die Dateien zu, die es in Ihrem Drive erstellt.",
@@ -1898,11 +1896,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synchronisieren Sie Ihre Bibliothek, Ihren Lesefortschritt und Ihre Markierungen mit Ihrem Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Solange {{provider}} ausgewählt ist, werden Bücher, Fortschritt und Anmerkungen nur mit Ihrem OneDrive synchronisiert.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest greift nur auf die Dateien zu, die es in Ihrem OneDrive erstellt.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive als aktiven Cloud-Anbieter festlegen.",
   "Sentence Pause": "Satzpause",
   "Paragraph Gap": "Absatzpause",
   "{{minutes}}m left": "{{minutes}} min verbleibend",
   "{{hours}}h left": "{{hours}} Std. verbleibend",
   "Time Remaining": "Verbleibende Zeit",
-  "Theme": "Thema"
+  "Theme": "Thema",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Verbunden als {{account}}. {{provider}} als aktiven Cloud-Anbieter festlegen."
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1803,8 +1803,6 @@
   "Full Sync": "Πλήρης συγχρονισμός",
   "Waiting for sign-in…": "Αναμονή για σύνδεση…",
   "Reconnect": "Επανασύνδεση",
-  "Connected as {{account}}": "Έχετε συνδεθεί ως {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Ορίστε το Google Drive ως ενεργό πάροχο cloud.",
   "Use Google Drive": "Χρήση Google Drive",
   "Sign-in opens in your browser.": "Η σύνδεση ανοίγει στο πρόγραμμα περιήγησής σας.",
   "Readest only accesses the files it creates in your Drive.": "Το Readest έχει πρόσβαση μόνο στα αρχεία που δημιουργεί στο Drive σας.",
@@ -1898,11 +1896,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Συγχρονίστε τη βιβλιοθήκη, την πρόοδο ανάγνωσης και τις επισημάνσεις σας με το Microsoft OneDrive σας.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Όσο είναι επιλεγμένο το {{provider}}, τα βιβλία, η πρόοδος και οι σημειώσεις συγχρονίζονται μόνο με το OneDrive σας.",
   "Readest only accesses the files it creates in your OneDrive.": "Το Readest έχει πρόσβαση μόνο στα αρχεία που δημιουργεί στο OneDrive σας.",
-  ". Make OneDrive the active cloud provider.": ". Ορίστε το OneDrive ως ενεργό πάροχο cloud.",
   "Sentence Pause": "Παύση μεταξύ προτάσεων",
   "Paragraph Gap": "Παύση παραγράφου",
   "{{minutes}}m left": "απομένουν {{minutes}} λεπτά",
   "{{hours}}h left": "απομένουν {{hours}} ώρες",
   "Time Remaining": "Υπολειπόμενος χρόνος",
-  "Theme": "Θέμα"
+  "Theme": "Θέμα",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Έχετε συνδεθεί ως {{account}}. Ορίστε το {{provider}} ως ενεργό πάροχο cloud."
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1837,8 +1837,6 @@
   "Full Sync": "Sincronización total",
   "Waiting for sign-in…": "Esperando el inicio de sesión…",
   "Reconnect": "Volver a conectar",
-  "Connected as {{account}}": "Conectado como {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Haz que Google Drive sea el proveedor de nube activo.",
   "Use Google Drive": "Usar Google Drive",
   "Sign-in opens in your browser.": "El inicio de sesión se abre en tu navegador.",
   "Readest only accesses the files it creates in your Drive.": "Readest solo accede a los archivos que crea en tu Drive.",
@@ -1933,11 +1931,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincroniza tu biblioteca, progreso de lectura y resaltados con tu Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Mientras {{provider}} esté seleccionado, los libros, el progreso y las anotaciones se sincronizan solo con tu OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest solo accede a los archivos que crea en tu OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Haz que OneDrive sea el proveedor de nube activo.",
   "Sentence Pause": "Pausa entre frases",
   "Paragraph Gap": "Pausa entre párrafos",
   "Time Remaining": "Tiempo restante",
   "{{minutes}}m left": "{{minutes}} min restantes",
   "{{hours}}h left": "{{hours}} h restantes",
-  "Theme": "Tema"
+  "Theme": "Tema",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Conectado como {{account}}. Haz que {{provider}} sea el proveedor de nube activo."
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1803,8 +1803,6 @@
   "Full Sync": "همگام‌سازی کامل",
   "Waiting for sign-in…": "در انتظار ورود…",
   "Reconnect": "اتصال دوباره",
-  "Connected as {{account}}": "متصل به‌عنوان {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Google Drive را ارائه‌دهنده فعال ابری قرار دهید.",
   "Use Google Drive": "استفاده از Google Drive",
   "Sign-in opens in your browser.": "ورود در مرورگر شما باز می‌شود.",
   "Readest only accesses the files it creates in your Drive.": "Readest فقط به فایل‌هایی دسترسی دارد که خودش در Drive شما ایجاد می‌کند.",
@@ -1898,11 +1896,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "کتابخانه، وضعیت مطالعه و هایلایت‌های خود را با Microsoft OneDrive خود همگام‌سازی کنید.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "تا زمانی که {{provider}} انتخاب شده باشد، کتاب‌ها، پیشرفت و یادداشت‌ها فقط با OneDrive شما همگام‌سازی می‌شوند.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest فقط به فایل‌هایی دسترسی دارد که خودش در OneDrive شما ایجاد می‌کند.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive را ارائه‌دهنده فعال ابری قرار دهید.",
   "Sentence Pause": "مکث بین جملات",
   "Paragraph Gap": "وقفه بین پاراگراف‌ها",
   "{{minutes}}m left": "{{minutes}} دقیقه باقی‌مانده",
   "{{hours}}h left": "{{hours}} ساعت باقی‌مانده",
   "Time Remaining": "زمان باقی‌مانده",
-  "Theme": "تم"
+  "Theme": "تم",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "متصل به‌عنوان {{account}}. {{provider}} را ارائه‌دهنده فعال ابری قرار دهید."
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1837,8 +1837,6 @@
   "Full Sync": "Synchronisation complète",
   "Waiting for sign-in…": "En attente de connexion…",
   "Reconnect": "Se reconnecter",
-  "Connected as {{account}}": "Connecté en tant que {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Faites de Google Drive le fournisseur cloud actif.",
   "Use Google Drive": "Utiliser Google Drive",
   "Sign-in opens in your browser.": "La connexion s'ouvre dans votre navigateur.",
   "Readest only accesses the files it creates in your Drive.": "Readest accède uniquement aux fichiers qu'il crée dans votre Drive.",
@@ -1933,11 +1931,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synchronisez votre bibliothèque, votre progression de lecture et vos surlignages avec votre Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Tant que {{provider}} est sélectionné, les livres, la progression et les annotations ne se synchronisent qu'avec votre OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest accède uniquement aux fichiers qu'il crée dans votre OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Faites de OneDrive le fournisseur cloud actif.",
   "Sentence Pause": "Pause entre les phrases",
   "Paragraph Gap": "Pause entre les paragraphes",
   "{{minutes}}m left": "{{minutes}} min restant",
   "{{hours}}h left": "{{hours}} h restant",
   "Time Remaining": "Temps restant",
-  "Theme": "Thème"
+  "Theme": "Thème",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Connecté en tant que {{account}}. Faites de {{provider}} le fournisseur cloud actif."
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1837,8 +1837,6 @@
   "Full Sync": "סנכרון מלא",
   "Waiting for sign-in…": "ממתין להתחברות…",
   "Reconnect": "התחבר מחדש",
-  "Connected as {{account}}": "מחובר כ-{{account}}",
-  ". Make Google Drive the active cloud provider.": ". הפוך את Google Drive לספק הענן הפעיל.",
   "Use Google Drive": "השתמש ב-Google Drive",
   "Sign-in opens in your browser.": "ההתחברות נפתחת בדפדפן שלך.",
   "Readest only accesses the files it creates in your Drive.": "Readest ניגש רק לקבצים שהוא יוצר ב-Drive שלך.",
@@ -1933,11 +1931,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "סנכרן את הספרייה, התקדמות הקריאה וההדגשות שלך עם Microsoft OneDrive שלך.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "כאשר {{provider}} נבחר, ספרים, התקדמות והערות מסתנכרנים רק עם ה-OneDrive שלך.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ניגש רק לקבצים שהוא יוצר ב-OneDrive שלך.",
-  ". Make OneDrive the active cloud provider.": ". הפוך את OneDrive לספק הענן הפעיל.",
   "Sentence Pause": "השהיה בין משפטים",
   "Paragraph Gap": "הפסקה בין פסקאות",
   "{{minutes}}m left": "נותרו {{minutes}} דקות",
   "{{hours}}h left": "נותרו {{hours}} שעות",
   "Time Remaining": "זמן שנותר",
-  "Theme": "ערכת נושא"
+  "Theme": "ערכת נושא",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "מחובר כ-{{account}}. הפוך את {{provider}} לספק הענן הפעיל."
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1803,8 +1803,6 @@
   "Full Sync": "पूर्ण सिंक",
   "Waiting for sign-in…": "साइन-इन की प्रतीक्षा में…",
   "Reconnect": "फिर से कनेक्ट करें",
-  "Connected as {{account}}": "{{account}} के रूप में कनेक्टेड",
-  ". Make Google Drive the active cloud provider.": "। Google Drive को सक्रिय क्लाउड प्रदाता बनाएं।",
   "Use Google Drive": "Google Drive का उपयोग करें",
   "Sign-in opens in your browser.": "साइन-इन आपके ब्राउज़र में खुलता है।",
   "Readest only accesses the files it creates in your Drive.": "Readest केवल उन्हीं फ़ाइलों तक पहुँचता है जिन्हें वह आपकी Drive में बनाता है।",
@@ -1898,11 +1896,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "अपनी लाइब्रेरी, पढ़ने की प्रगति और हाइलाइट्स को अपनी Microsoft OneDrive से सिंक करें।",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "जब {{provider}} चुना गया हो, तो किताबें, प्रगति और एनोटेशन केवल आपके OneDrive से सिंक होते हैं।",
   "Readest only accesses the files it creates in your OneDrive.": "Readest केवल उन्हीं फ़ाइलों तक पहुँचता है जिन्हें वह आपकी OneDrive में बनाता है।",
-  ". Make OneDrive the active cloud provider.": "। OneDrive को सक्रिय क्लाउड प्रदाता बनाएं।",
   "Sentence Pause": "वाक्यों के बीच विराम",
   "Paragraph Gap": "अनुच्छेदों के बीच विराम",
   "{{minutes}}m left": "{{minutes}} मिनट शेष",
   "{{hours}}h left": "{{hours}} घंटे शेष",
   "Time Remaining": "शेष समय",
-  "Theme": "थीम"
+  "Theme": "थीम",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} के रूप में कनेक्टेड। {{provider}} को सक्रिय क्लाउड प्रदाता बनाएं।"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1803,8 +1803,6 @@
   "Full Sync": "Teljes szinkronizálás",
   "Waiting for sign-in…": "Várakozás a bejelentkezésre…",
   "Reconnect": "Újracsatlakozás",
-  "Connected as {{account}}": "Csatlakozva mint {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Tegye a Google Drive-ot az aktív felhőszolgáltatóvá.",
   "Use Google Drive": "Google Drive használata",
   "Sign-in opens in your browser.": "A bejelentkezés a böngészőben nyílik meg.",
   "Readest only accesses the files it creates in your Drive.": "A Readest csak azokhoz a fájlokhoz fér hozzá, amelyeket ő hozott létre a Drive-jában.",
@@ -1898,11 +1896,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Szinkronizálja könyvtárát, olvasási haladását és kiemeléseit a Microsoft OneDrive-jával.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Amíg a(z) {{provider}} van kiválasztva, a könyvek, az előrehaladás és a jegyzetek csak a OneDrive-odba szinkronizálódnak.",
   "Readest only accesses the files it creates in your OneDrive.": "A Readest csak azokhoz a fájlokhoz fér hozzá, amelyeket ő hozott létre a OneDrive-jában.",
-  ". Make OneDrive the active cloud provider.": ". Tegye a OneDrive-ot az aktív felhőszolgáltatóvá.",
   "Sentence Pause": "Mondatszünet",
   "Paragraph Gap": "Bekezdésszünet",
   "{{minutes}}m left": "{{minutes}} perc van hátra",
   "{{hours}}h left": "{{hours}} óra van hátra",
   "Time Remaining": "Hátralévő idő",
-  "Theme": "Téma"
+  "Theme": "Téma",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Csatlakozva mint {{account}}. Tegye a {{provider}}-ot az aktív felhőszolgáltatóvá."
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1769,8 +1769,6 @@
   "Full Sync": "Sinkronisasi Penuh",
   "Waiting for sign-in…": "Menunggu proses masuk…",
   "Reconnect": "Hubungkan Ulang",
-  "Connected as {{account}}": "Terhubung sebagai {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Jadikan Google Drive penyedia cloud yang aktif.",
   "Use Google Drive": "Gunakan Google Drive",
   "Sign-in opens in your browser.": "Proses masuk akan terbuka di browser Anda.",
   "Readest only accesses the files it creates in your Drive.": "Readest hanya mengakses file yang dibuatnya di Drive Anda.",
@@ -1863,11 +1861,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sinkronkan perpustakaan, progres membaca, dan sorotan Anda dengan Microsoft OneDrive Anda.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Saat {{provider}} dipilih, buku, progres, dan anotasi hanya disinkronkan ke OneDrive Anda.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest hanya mengakses file yang dibuatnya di OneDrive Anda.",
-  ". Make OneDrive the active cloud provider.": ". Jadikan OneDrive penyedia cloud yang aktif.",
   "Sentence Pause": "Jeda Antar Kalimat",
   "Paragraph Gap": "Jeda antarparagraf",
   "{{minutes}}m left": "{{minutes}} mnt tersisa",
   "{{hours}}h left": "{{hours}} jam tersisa",
   "Time Remaining": "Sisa waktu",
-  "Theme": "Tema"
+  "Theme": "Tema",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Terhubung sebagai {{account}}. Jadikan {{provider}} penyedia cloud yang aktif."
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1837,8 +1837,6 @@
   "Full Sync": "Sincronizzazione completa",
   "Waiting for sign-in…": "In attesa dell'accesso…",
   "Reconnect": "Riconnetti",
-  "Connected as {{account}}": "Collegato come {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Imposta Google Drive come provider cloud attivo.",
   "Use Google Drive": "Usa Google Drive",
   "Sign-in opens in your browser.": "L'accesso si apre nel browser.",
   "Readest only accesses the files it creates in your Drive.": "Readest accede solo ai file che crea nel tuo Drive.",
@@ -1933,11 +1931,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincronizza la tua biblioteca, il progresso di lettura e le evidenziazioni con il tuo Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Finché {{provider}} è selezionato, libri, progressi e annotazioni si sincronizzano solo con il tuo OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest accede solo ai file che crea nel tuo OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Imposta OneDrive come provider cloud attivo.",
   "Sentence Pause": "Pausa tra le frasi",
   "Paragraph Gap": "Pausa tra i paragrafi",
   "{{minutes}}m left": "{{minutes}} min rimasti",
   "{{hours}}h left": "{{hours}} h rimaste",
   "Time Remaining": "Tempo rimanente",
-  "Theme": "Tema"
+  "Theme": "Tema",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Collegato come {{account}}. Imposta {{provider}} come provider cloud attivo."
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1769,8 +1769,6 @@
   "Full Sync": "完全同期",
   "Waiting for sign-in…": "サインインを待っています…",
   "Reconnect": "再接続",
-  "Connected as {{account}}": "{{account}} として接続済み",
-  ". Make Google Drive the active cloud provider.": "。Google Drive を使用するクラウドプロバイダーに設定します。",
   "Use Google Drive": "Google Drive を使用",
   "Sign-in opens in your browser.": "サインインはブラウザで開きます。",
   "Readest only accesses the files it creates in your Drive.": "Readest がアクセスするのは、Drive 内に自身が作成したファイルのみです。",
@@ -1863,11 +1861,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "ライブラリ、読書進捗、ハイライトを Microsoft OneDrive と同期します。",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} を選択している間、書籍・進捗・注釈は OneDrive にのみ同期されます。",
   "Readest only accesses the files it creates in your OneDrive.": "Readest がアクセスするのは、OneDrive 内に自身が作成したファイルのみです。",
-  ". Make OneDrive the active cloud provider.": "。OneDrive を使用するクラウドプロバイダーに設定します。",
   "Sentence Pause": "文間のポーズ",
   "Paragraph Gap": "段落間のポーズ",
   "{{minutes}}m left": "残り{{minutes}}分",
   "{{hours}}h left": "残り{{hours}}時間",
   "Time Remaining": "残り時間",
-  "Theme": "テーマ"
+  "Theme": "テーマ",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} として接続済み。{{provider}} を使用するクラウドプロバイダーに設定します。"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1769,8 +1769,6 @@
   "Full Sync": "전체 동기화",
   "Waiting for sign-in…": "로그인을 기다리는 중…",
   "Reconnect": "다시 연결",
-  "Connected as {{account}}": "{{account}}(으)로 연결됨",
-  ". Make Google Drive the active cloud provider.": ". Google Drive를 사용할 클라우드 제공업체로 설정합니다.",
   "Use Google Drive": "Google Drive 사용",
   "Sign-in opens in your browser.": "로그인은 브라우저에서 열립니다.",
   "Readest only accesses the files it creates in your Drive.": "Readest는 Drive에서 직접 만든 파일에만 접근합니다.",
@@ -1863,11 +1861,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "라이브러리, 읽기 진행 상황, 하이라이트를 Microsoft OneDrive와 동기화합니다.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}}를 선택하면 책, 진행률, 주석이 OneDrive에만 동기화됩니다.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest는 OneDrive에서 직접 만든 파일에만 접근합니다.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive를 사용할 클라우드 제공업체로 설정합니다.",
   "Sentence Pause": "문장 사이 일시정지",
   "Paragraph Gap": "문단 간 정지",
   "{{minutes}}m left": "{{minutes}}분 남음",
   "{{hours}}h left": "{{hours}}시간 남음",
   "Time Remaining": "남은 시간",
-  "Theme": "테마"
+  "Theme": "테마",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}}(으)로 연결됨. {{provider}}를 사용할 클라우드 제공업체로 설정합니다."
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1769,8 +1769,6 @@
   "Full Sync": "Segerak Penuh",
   "Waiting for sign-in…": "Menunggu log masuk…",
   "Reconnect": "Sambung Semula",
-  "Connected as {{account}}": "Disambungkan sebagai {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Jadikan Google Drive sebagai penyedia awan yang aktif.",
   "Use Google Drive": "Guna Google Drive",
   "Sign-in opens in your browser.": "Log masuk akan dibuka dalam pelayar anda.",
   "Readest only accesses the files it creates in your Drive.": "Readest hanya mengakses fail yang diciptanya dalam Drive anda.",
@@ -1863,11 +1861,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Segerakkan perpustakaan, kemajuan bacaan dan penonjolan anda dengan Microsoft OneDrive anda.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Semasa {{provider}} dipilih, buku, kemajuan dan anotasi hanya disegerakkan ke OneDrive anda.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest hanya mengakses fail yang diciptanya dalam OneDrive anda.",
-  ". Make OneDrive the active cloud provider.": ". Jadikan OneDrive sebagai penyedia awan yang aktif.",
   "Sentence Pause": "Jeda Antara Ayat",
   "Paragraph Gap": "Jeda antara perenggan",
   "{{minutes}}m left": "{{minutes}} min lagi",
   "{{hours}}h left": "{{hours}} jam lagi",
   "Time Remaining": "Masa berbaki",
-  "Theme": "Tema"
+  "Theme": "Tema",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Disambungkan sebagai {{account}}. Jadikan {{provider}} sebagai penyedia awan yang aktif."
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1803,8 +1803,6 @@
   "Full Sync": "Volledige synchronisatie",
   "Waiting for sign-in…": "Wachten op inloggen…",
   "Reconnect": "Opnieuw verbinden",
-  "Connected as {{account}}": "Verbonden als {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Maak Google Drive de actieve cloudprovider.",
   "Use Google Drive": "Google Drive gebruiken",
   "Sign-in opens in your browser.": "Inloggen opent in je browser.",
   "Readest only accesses the files it creates in your Drive.": "Readest heeft alleen toegang tot de bestanden die het zelf in je Drive aanmaakt.",
@@ -1898,11 +1896,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synchroniseer je bibliotheek, leesvoortgang en markeringen met je Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Zolang {{provider}} is geselecteerd, worden boeken, voortgang en annotaties alleen met uw OneDrive gesynchroniseerd.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest heeft alleen toegang tot de bestanden die het zelf in je OneDrive aanmaakt.",
-  ". Make OneDrive the active cloud provider.": ". Maak OneDrive de actieve cloudprovider.",
   "Sentence Pause": "Zinspauze",
   "Paragraph Gap": "Alineapauze",
   "{{minutes}}m left": "Nog {{minutes}} min",
   "{{hours}}h left": "Nog {{hours}} u",
   "Time Remaining": "Resterende tijd",
-  "Theme": "Thema"
+  "Theme": "Thema",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Verbonden als {{account}}. Maak {{provider}} de actieve cloudprovider."
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1871,8 +1871,6 @@
   "Full Sync": "Pełna synchronizacja",
   "Waiting for sign-in…": "Oczekiwanie na zalogowanie…",
   "Reconnect": "Połącz ponownie",
-  "Connected as {{account}}": "Połączono jako {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Ustaw Google Drive jako aktywnego dostawcę chmury.",
   "Use Google Drive": "Użyj Google Drive",
   "Sign-in opens in your browser.": "Logowanie otworzy się w przeglądarce.",
   "Readest only accesses the files it creates in your Drive.": "Readest ma dostęp tylko do plików, które sam tworzy na Twoim Dysku Google.",
@@ -1968,11 +1966,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synchronizuj bibliotekę, postęp czytania i zaznaczenia ze swoim Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Gdy wybrany jest {{provider}}, książki, postęp i adnotacje synchronizują się tylko z Twoim OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ma dostęp tylko do plików, które sam tworzy na Twoim OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Ustaw OneDrive jako aktywnego dostawcę chmury.",
   "Sentence Pause": "Pauza między zdaniami",
   "Paragraph Gap": "Przerwa między akapitami",
   "{{minutes}}m left": "Pozostało {{minutes}} min",
   "{{hours}}h left": "Pozostało {{hours}} godz.",
   "Time Remaining": "Pozostały czas",
-  "Theme": "Motyw"
+  "Theme": "Motyw",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Połączono jako {{account}}. Ustaw {{provider}} jako aktywnego dostawcę chmury."
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1837,8 +1837,6 @@
   "Full Sync": "Sincronização completa",
   "Waiting for sign-in…": "Aguardando login…",
   "Reconnect": "Reconectar",
-  "Connected as {{account}}": "Conectado como {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Torne o Google Drive o provedor de nuvem ativo.",
   "Use Google Drive": "Usar o Google Drive",
   "Sign-in opens in your browser.": "O login abre no seu navegador.",
   "Readest only accesses the files it creates in your Drive.": "O Readest só acessa os arquivos que cria no seu Drive.",
@@ -1933,11 +1931,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincronize sua biblioteca, progresso de leitura e destaques com o seu Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Enquanto o {{provider}} estiver selecionado, livros, progresso e anotações são sincronizados apenas com seu OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "O Readest só acessa os arquivos que cria no seu OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Torne o OneDrive o provedor de nuvem ativo.",
   "Sentence Pause": "Pausa entre frases",
   "Paragraph Gap": "Pausa entre parágrafos",
   "{{minutes}}m left": "{{minutes}} min restantes",
   "{{hours}}h left": "{{hours}} h restantes",
   "Time Remaining": "Tempo restante",
-  "Theme": "Tema"
+  "Theme": "Tema",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Conectado como {{account}}. Torne o {{provider}} o provedor de nuvem ativo."
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1837,8 +1837,6 @@
   "Full Sync": "Sincronização Completa",
   "Waiting for sign-in…": "A aguardar o início de sessão…",
   "Reconnect": "Ligar novamente",
-  "Connected as {{account}}": "Ligado como {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Torne o Google Drive o fornecedor de nuvem ativo.",
   "Use Google Drive": "Usar o Google Drive",
   "Sign-in opens in your browser.": "O início de sessão abre no seu navegador.",
   "Readest only accesses the files it creates in your Drive.": "O Readest só acede aos ficheiros que cria no seu Drive.",
@@ -1933,11 +1931,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincronize a sua biblioteca, o progresso de leitura e os destaques com o seu Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Enquanto o {{provider}} estiver selecionado, os livros, o progresso e as anotações são sincronizados apenas com o seu OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "O Readest só acede aos ficheiros que cria no seu OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Torne o OneDrive o fornecedor de nuvem ativo.",
   "Sentence Pause": "Pausa entre frases",
   "Paragraph Gap": "Pausa entre parágrafos",
   "{{minutes}}m left": "{{minutes}} min restantes",
   "{{hours}}h left": "{{hours}} h restantes",
   "Time Remaining": "Tempo restante",
-  "Theme": "Tema"
+  "Theme": "Tema",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Ligado como {{account}}. Torne o {{provider}} o fornecedor de nuvem ativo."
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1837,8 +1837,6 @@
   "Full Sync": "Sincronizare integrală",
   "Waiting for sign-in…": "Se așteaptă conectarea…",
   "Reconnect": "Reconectare",
-  "Connected as {{account}}": "Conectat ca {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Setează Google Drive ca furnizor de cloud activ.",
   "Use Google Drive": "Folosește Google Drive",
   "Sign-in opens in your browser.": "Conectarea se deschide în browser.",
   "Readest only accesses the files it creates in your Drive.": "Readest accesează doar fișierele pe care le creează în Drive-ul tău.",
@@ -1933,11 +1931,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincronizează-ți biblioteca, progresul citirii și evidențierile cu Microsoft OneDrive-ul tău.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Cât timp {{provider}} este selectat, cărțile, progresul și adnotările se sincronizează doar cu OneDrive-ul tău.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest accesează doar fișierele pe care le creează în OneDrive-ul tău.",
-  ". Make OneDrive the active cloud provider.": ". Setează OneDrive ca furnizor de cloud activ.",
   "Sentence Pause": "Pauză între propoziții",
   "Paragraph Gap": "Pauză între paragrafe",
   "{{minutes}}m left": "Au rămas {{minutes}} min",
   "{{hours}}h left": "Au rămas {{hours}} h",
   "Time Remaining": "Timp rămas",
-  "Theme": "Temă"
+  "Theme": "Temă",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Conectat ca {{account}}. Setează {{provider}} ca furnizor de cloud activ."
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1871,8 +1871,6 @@
   "Full Sync": "Полная синхронизация",
   "Waiting for sign-in…": "Ожидание входа…",
   "Reconnect": "Переподключиться",
-  "Connected as {{account}}": "Подключено как {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Сделать Google Drive активным облачным провайдером.",
   "Use Google Drive": "Использовать Google Drive",
   "Sign-in opens in your browser.": "Вход откроется в вашем браузере.",
   "Readest only accesses the files it creates in your Drive.": "Readest получает доступ только к тем файлам, которые сам создаёт на вашем Google Drive.",
@@ -1968,11 +1966,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Синхронизируйте свою библиотеку, прогресс чтения и выделения с вашим Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Пока выбран {{provider}}, книги, прогресс и аннотации синхронизируются только с вашим OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest получает доступ только к тем файлам, которые сам создаёт на вашем OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Сделать OneDrive активным облачным провайдером.",
   "Sentence Pause": "Пауза между предложениями",
   "Paragraph Gap": "Пауза между абзацами",
   "{{minutes}}m left": "Осталось {{minutes}} мин",
   "{{hours}}h left": "Осталось {{hours}} ч",
   "Time Remaining": "Оставшееся время",
-  "Theme": "Тема"
+  "Theme": "Тема",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Подключено как {{account}}. Сделать {{provider}} активным облачным провайдером."
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1803,8 +1803,6 @@
   "Full Sync": "සම්පූර්ණ සමමුහුර්තය",
   "Waiting for sign-in…": "ඇතුල් වීම සඳහා රැඳී සිටිමින්…",
   "Reconnect": "නැවත සම්බන්ධ වන්න",
-  "Connected as {{account}}": "{{account}} ලෙස සම්බන්ධ වී ඇත",
-  ". Make Google Drive the active cloud provider.": ". Google Drive සක්‍රිය cloud සපයන්නා ලෙස සකසන්න.",
   "Use Google Drive": "Google Drive භාවිතා කරන්න",
   "Sign-in opens in your browser.": "ඇතුල් වීම ඔබේ බ්‍රව්සරයේ විවෘත වේ.",
   "Readest only accesses the files it creates in your Drive.": "Readest ප්‍රවේශ වන්නේ ඔබේ Drive හි එය සාදන ගොනුවලට පමණි.",
@@ -1898,11 +1896,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "ඔබේ පුස්තකාලය, කියවීමේ ප්‍රගතිය සහ ඉස්මතු කිරීම් ඔබේ Microsoft OneDrive සමඟ සමමුහුර්ත කරන්න.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} තෝරා ඇති විට, පොත්, ප්‍රගතිය සහ සටහන් ඔබේ OneDrive වෙත පමණක් සමමුහුර්ත වේ.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ප්‍රවේශ වන්නේ ඔබේ OneDrive හි එය සාදන ගොනුවලට පමණි.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive සක්‍රිය cloud සපයන්නා ලෙස සකසන්න.",
   "Sentence Pause": "වාක්‍ය අතර විරාමය",
   "Paragraph Gap": "ඡේද අතර විරාමය",
   "{{minutes}}m left": "මිනිත්තු {{minutes}} ක් ඉතිරි",
   "{{hours}}h left": "පැය {{hours}} ක් ඉතිරි",
   "Time Remaining": "ඉතිරි කාලය",
-  "Theme": "තේමාව"
+  "Theme": "තේමාව",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} ලෙස සම්බන්ධ වී ඇත. {{provider}} සක්‍රිය cloud සපයන්නා ලෙස සකසන්න."
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1871,8 +1871,6 @@
   "Full Sync": "Polna sinhronizacija",
   "Waiting for sign-in…": "Čakanje na prijavo…",
   "Reconnect": "Znova poveži",
-  "Connected as {{account}}": "Povezano kot {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Nastavite Google Drive kot aktivnega ponudnika oblaka.",
   "Use Google Drive": "Uporabi Google Drive",
   "Sign-in opens in your browser.": "Prijava se odpre v vašem brskalniku.",
   "Readest only accesses the files it creates in your Drive.": "Readest dostopa le do datotek, ki jih sam ustvari v vašem Google Drive.",
@@ -1968,11 +1966,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sinhronizirajte knjižnico, napredek branja in označbe s svojim Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Dokler je izbran {{provider}}, se knjige, napredek in opombe sinhronizirajo samo z vašim OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest dostopa le do datotek, ki jih sam ustvari v vašem OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Nastavite OneDrive kot aktivnega ponudnika oblaka.",
   "Sentence Pause": "Premor med stavki",
   "Paragraph Gap": "Premor med odstavki",
   "{{minutes}}m left": "Še {{minutes}} min",
   "{{hours}}h left": "Še {{hours}} h",
   "Time Remaining": "Preostali čas",
-  "Theme": "Tema"
+  "Theme": "Tema",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Povezano kot {{account}}. Nastavite {{provider}} kot aktivnega ponudnika oblaka."
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1803,8 +1803,6 @@
   "Full Sync": "Fullständig synk",
   "Waiting for sign-in…": "Väntar på inloggning…",
   "Reconnect": "Anslut igen",
-  "Connected as {{account}}": "Ansluten som {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Gör Google Drive till aktiv molnleverantör.",
   "Use Google Drive": "Använd Google Drive",
   "Sign-in opens in your browser.": "Inloggningen öppnas i din webbläsare.",
   "Readest only accesses the files it creates in your Drive.": "Readest kommer bara åt de filer som appen skapar i din Drive.",
@@ -1898,11 +1896,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synka ditt bibliotek, dina läsframsteg och markeringar med din Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "När {{provider}} är valt synkroniseras böcker, framsteg och anteckningar endast med din OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest kommer bara åt de filer som appen skapar i din OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Gör OneDrive till aktiv molnleverantör.",
   "Sentence Pause": "Meningspaus",
   "Paragraph Gap": "Styckepaus",
   "{{minutes}}m left": "{{minutes}} min kvar",
   "{{hours}}h left": "{{hours}} h kvar",
   "Time Remaining": "Återstående tid",
-  "Theme": "Tema"
+  "Theme": "Tema",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Ansluten som {{account}}. Gör {{provider}} till aktiv molnleverantör."
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1803,8 +1803,6 @@
   "Full Sync": "முழு ஒத்திசைவு",
   "Waiting for sign-in…": "உள்நுழைவுக்காகக் காத்திருக்கிறது…",
   "Reconnect": "மீண்டும் இணைக்கவும்",
-  "Connected as {{account}}": "{{account}} ஆக இணைக்கப்பட்டுள்ளது",
-  ". Make Google Drive the active cloud provider.": ". Google Drive ஐ செயலில் உள்ள cloud வழங்குநராக அமைக்கவும்.",
   "Use Google Drive": "Google Drive ஐப் பயன்படுத்தவும்",
   "Sign-in opens in your browser.": "உள்நுழைவு உங்கள் உலாவியில் திறக்கும்.",
   "Readest only accesses the files it creates in your Drive.": "Readest உங்கள் Drive இல் தானே உருவாக்கும் கோப்புகளை மட்டுமே அணுகும்.",
@@ -1898,11 +1896,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "உங்கள் நூலகம், வாசிப்பு முன்னேற்றம் மற்றும் சிறப்பம்சங்களை உங்கள் Microsoft OneDrive உடன் ஒத்திசைக்கவும்.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} தேர்ந்தெடுக்கப்பட்டிருக்கும் போது, புத்தகங்கள், முன்னேற்றம் மற்றும் குறிப்புகள் உங்கள் OneDrive உடன் மட்டுமே ஒத்திசைக்கப்படும்.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest உங்கள் OneDrive இல் தானே உருவாக்கும் கோப்புகளை மட்டுமே அணுகும்.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive ஐ செயலில் உள்ள cloud வழங்குநராக அமைக்கவும்.",
   "Sentence Pause": "வாக்கிய இடைவேளை",
   "Paragraph Gap": "பத்தி இடைவேளை",
   "{{minutes}}m left": "{{minutes}} நிமிடங்கள் மீதம்",
   "{{hours}}h left": "{{hours}} மணி நேரம் மீதம்",
   "Time Remaining": "மீதமுள்ள நேரம்",
-  "Theme": "தீம்"
+  "Theme": "தீம்",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} ஆக இணைக்கப்பட்டுள்ளது. {{provider}} ஐ செயலில் உள்ள cloud வழங்குநராக அமைக்கவும்."
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1769,8 +1769,6 @@
   "Full Sync": "ซิงค์แบบเต็ม",
   "Waiting for sign-in…": "กำลังรอการเข้าสู่ระบบ…",
   "Reconnect": "เชื่อมต่อใหม่",
-  "Connected as {{account}}": "เชื่อมต่อในชื่อ {{account}}",
-  ". Make Google Drive the active cloud provider.": ". ตั้งให้ Google Drive เป็นผู้ให้บริการคลาวด์ที่ใช้งานอยู่",
   "Use Google Drive": "ใช้ Google Drive",
   "Sign-in opens in your browser.": "การเข้าสู่ระบบจะเปิดในเบราว์เซอร์ของคุณ",
   "Readest only accesses the files it creates in your Drive.": "Readest จะเข้าถึงเฉพาะไฟล์ที่สร้างขึ้นเองใน Drive ของคุณเท่านั้น",
@@ -1863,11 +1861,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "ซิงค์คลังหนังสือ ความคืบหน้าการอ่าน และไฮไลต์ของคุณกับ Microsoft OneDrive ของคุณ",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "เมื่อเลือก {{provider}} หนังสือ ความคืบหน้า และคำอธิบายประกอบจะซิงค์ไปยัง OneDrive ของคุณเท่านั้น",
   "Readest only accesses the files it creates in your OneDrive.": "Readest จะเข้าถึงเฉพาะไฟล์ที่สร้างขึ้นเองใน OneDrive ของคุณเท่านั้น",
-  ". Make OneDrive the active cloud provider.": ". ตั้งให้ OneDrive เป็นผู้ให้บริการคลาวด์ที่ใช้งานอยู่",
   "Sentence Pause": "หยุดระหว่างประโยค",
   "Paragraph Gap": "หยุดชั่วคราวระหว่างย่อหน้า",
   "{{minutes}}m left": "เหลือ {{minutes}} นาที",
   "{{hours}}h left": "เหลือ {{hours}} ชม.",
   "Time Remaining": "เวลาที่เหลือ",
-  "Theme": "ธีม"
+  "Theme": "ธีม",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "เชื่อมต่อในชื่อ {{account}} ตั้งให้ {{provider}} เป็นผู้ให้บริการคลาวด์ที่ใช้งานอยู่"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1803,8 +1803,6 @@
   "Full Sync": "Tam Senkronizasyon",
   "Waiting for sign-in…": "Giriş bekleniyor…",
   "Reconnect": "Yeniden Bağlan",
-  "Connected as {{account}}": "{{account}} olarak bağlanıldı",
-  ". Make Google Drive the active cloud provider.": ". Google Drive'ı etkin bulut sağlayıcısı yapın.",
   "Use Google Drive": "Google Drive Kullan",
   "Sign-in opens in your browser.": "Giriş tarayıcınızda açılır.",
   "Readest only accesses the files it creates in your Drive.": "Readest yalnızca Drive'ınızda kendi oluşturduğu dosyalara erişir.",
@@ -1898,11 +1896,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Kütüphanenizi, okuma ilerlemenizi ve vurgularınızı Microsoft OneDrive'ınızla senkronize edin.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} seçili olduğunda kitaplar, ilerleme ve açıklamalar yalnızca OneDrive'ınızla senkronize edilir.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest yalnızca OneDrive'ınızda kendi oluşturduğu dosyalara erişir.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive'ı etkin bulut sağlayıcısı yapın.",
   "Sentence Pause": "Cümle Arası Duraklama",
   "Paragraph Gap": "Paragraf arası duraklama",
   "{{minutes}}m left": "{{minutes}} dk kaldı",
   "{{hours}}h left": "{{hours}} sa kaldı",
   "Time Remaining": "Kalan süre",
-  "Theme": "Tema"
+  "Theme": "Tema",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} olarak bağlanıldı. {{provider}}'ı etkin bulut sağlayıcısı yapın."
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1871,8 +1871,6 @@
   "Full Sync": "Повна синхронізація",
   "Waiting for sign-in…": "Очікування входу…",
   "Reconnect": "Під'єднатися повторно",
-  "Connected as {{account}}": "Під'єднано як {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Зробити Google Drive активним хмарним провайдером.",
   "Use Google Drive": "Використовувати Google Drive",
   "Sign-in opens in your browser.": "Вхід відкриється у вашому браузері.",
   "Readest only accesses the files it creates in your Drive.": "Readest має доступ лише до файлів, які сам створює у вашому Google Drive.",
@@ -1968,11 +1966,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Синхронізуйте свою бібліотеку, проґрес читання та виділення з вашим Microsoft OneDrive.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Поки вибрано {{provider}}, книги, прогрес і анотації синхронізуються лише з вашим OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest має доступ лише до файлів, які сам створює у вашому OneDrive.",
-  ". Make OneDrive the active cloud provider.": ". Зробити OneDrive активним хмарним провайдером.",
   "Sentence Pause": "Пауза між реченнями",
   "Paragraph Gap": "Пауза між абзацами",
   "{{minutes}}m left": "Залишилось {{minutes}} хв",
   "{{hours}}h left": "Залишилось {{hours}} год",
   "Time Remaining": "Час, що залишився",
-  "Theme": "Тема"
+  "Theme": "Тема",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Під'єднано як {{account}}. Зробити {{provider}} активним хмарним провайдером."
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1803,8 +1803,6 @@
   "Full Sync": "Toʻliq sinxronlash",
   "Waiting for sign-in…": "Kirish kutilmoqda…",
   "Reconnect": "Qayta ulanish",
-  "Connected as {{account}}": "{{account}} sifatida ulangan",
-  ". Make Google Drive the active cloud provider.": ". Google Drive-ni faol bulut provayderi qiling.",
   "Use Google Drive": "Google Drive-dan foydalanish",
   "Sign-in opens in your browser.": "Kirish brauzeringizda ochiladi.",
   "Readest only accesses the files it creates in your Drive.": "Readest Drive-ingizda faqat oʻzi yaratgan fayllarga kiradi.",
@@ -1898,11 +1896,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Kutubxonangiz, oʻqish jarayoni va belgilashlaringizni Microsoft OneDrive bilan sinxronlang.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "{{provider}} tanlangan paytda kitoblar, jarayon va izohlar faqat OneDrive'ingizga sinxronlanadi.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest OneDrive-ingizda faqat oʻzi yaratgan fayllarga kiradi.",
-  ". Make OneDrive the active cloud provider.": ". OneDrive-ni faol bulut provayderi qiling.",
   "Sentence Pause": "Gaplar orasidagi pauza",
   "Paragraph Gap": "Paragraflar orasidagi tanaffus",
   "{{minutes}}m left": "{{minutes}} daqiqa qoldi",
   "{{hours}}h left": "{{hours}} soat qoldi",
   "Time Remaining": "Qolgan vaqt",
-  "Theme": "Mavzu"
+  "Theme": "Mavzu",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} sifatida ulangan. {{provider}}-ni faol bulut provayderi qiling."
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1769,8 +1769,6 @@
   "Full Sync": "Đồng bộ đầy đủ",
   "Waiting for sign-in…": "Đang chờ đăng nhập…",
   "Reconnect": "Kết nối lại",
-  "Connected as {{account}}": "Đã kết nối với tư cách {{account}}",
-  ". Make Google Drive the active cloud provider.": ". Đặt Google Drive làm nhà cung cấp đám mây đang hoạt động.",
   "Use Google Drive": "Dùng Google Drive",
   "Sign-in opens in your browser.": "Đăng nhập sẽ mở trong trình duyệt của bạn.",
   "Readest only accesses the files it creates in your Drive.": "Readest chỉ truy cập các tệp do chính nó tạo trong Drive của bạn.",
@@ -1863,11 +1861,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Đồng bộ thư viện, tiến trình đọc và điểm nổi bật của bạn với Microsoft OneDrive của bạn.",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "Khi {{provider}} được chọn, sách, tiến độ và chú thích chỉ đồng bộ với OneDrive của bạn.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest chỉ truy cập các tệp do chính nó tạo trong OneDrive của bạn.",
-  ". Make OneDrive the active cloud provider.": ". Đặt OneDrive làm nhà cung cấp đám mây đang hoạt động.",
   "Sentence Pause": "Khoảng dừng giữa các câu",
   "Paragraph Gap": "Khoảng dừng giữa đoạn văn",
   "{{minutes}}m left": "Còn {{minutes}} phút",
   "{{hours}}h left": "Còn {{hours}} giờ",
   "Time Remaining": "Thời gian còn lại",
-  "Theme": "Chủ đề"
+  "Theme": "Chủ đề",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Đã kết nối với tư cách {{account}}. Đặt {{provider}} làm nhà cung cấp đám mây đang hoạt động."
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1769,8 +1769,6 @@
   "Full Sync": "完全同步",
   "Waiting for sign-in…": "等待登录…",
   "Reconnect": "重新连接",
-  "Connected as {{account}}": "已以 {{account}} 身份连接",
-  ". Make Google Drive the active cloud provider.": "。将 Google Drive 设为当前使用的云服务提供商。",
   "Use Google Drive": "使用 Google Drive",
   "Sign-in opens in your browser.": "登录将在浏览器中打开。",
   "Readest only accesses the files it creates in your Drive.": "Readest 只会访问它在您的 Drive 中创建的文件。",
@@ -1863,11 +1861,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "将您的书库、阅读进度和高亮与您的 Microsoft OneDrive 同步。",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "选择 {{provider}} 后，书籍、进度和标注仅同步到您的 OneDrive。",
   "Readest only accesses the files it creates in your OneDrive.": "Readest 只会访问它在您的 OneDrive 中创建的文件。",
-  ". Make OneDrive the active cloud provider.": "。将 OneDrive 设为当前使用的云服务提供商。",
   "Sentence Pause": "句间停顿",
   "Paragraph Gap": "段落间隔",
   "{{minutes}}m left": "{{minutes}}分钟",
   "{{hours}}h left": "{{hours}}小时",
   "Time Remaining": "剩余时间",
-  "Theme": "主题"
+  "Theme": "主题",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "已以 {{account}} 身份连接。将 {{provider}} 设为当前使用的云服务提供商。"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1769,8 +1769,6 @@
   "Full Sync": "完全同步",
   "Waiting for sign-in…": "等待登入…",
   "Reconnect": "重新連線",
-  "Connected as {{account}}": "已以 {{account}} 身分連線",
-  ". Make Google Drive the active cloud provider.": "。將 Google Drive 設為目前使用的雲端服務供應商。",
   "Use Google Drive": "使用 Google Drive",
   "Sign-in opens in your browser.": "登入將在瀏覽器中開啟。",
   "Readest only accesses the files it creates in your Drive.": "Readest 只會存取它在您的 Drive 中建立的檔案。",
@@ -1863,11 +1861,11 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "將您的書庫、閱讀進度和高亮與您的 Microsoft OneDrive 同步。",
   "While {{provider}} is selected, books, progress, and annotations sync only to your OneDrive.": "選擇 {{provider}} 後，書籍、進度和標註僅同步到您的 OneDrive。",
   "Readest only accesses the files it creates in your OneDrive.": "Readest 只會存取它在您的 OneDrive 中建立的檔案。",
-  ". Make OneDrive the active cloud provider.": "。將 OneDrive 設為目前使用的雲端服務供應商。",
   "Sentence Pause": "句間停頓",
   "Paragraph Gap": "段落間隔",
   "{{minutes}}m left": "{{minutes}}分鐘",
   "{{hours}}h left": "{{hours}}小時",
   "Time Remaining": "剩餘時間",
-  "Theme": "主題"
+  "Theme": "主題",
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "已以 {{account}} 身分連線。將 {{provider}} 設為目前使用的雲端服務供應商。"
 }

--- a/apps/readest-app/src/components/settings/integrations/GoogleDriveForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/GoogleDriveForm.tsx
@@ -153,8 +153,10 @@ const GoogleDriveForm: React.FC = () => {
         </div>
         <Tips>
           <li>
-            {_('Connected as {{account}}', { account: stored.accountLabel })}
-            {_('. Make Google Drive the active cloud provider.')}
+            {_('Connected as {{account}}. Make {{provider}} the active cloud provider.', {
+              account: stored.accountLabel,
+              provider: 'Google Drive',
+            })}
           </li>
         </Tips>
       </div>

--- a/apps/readest-app/src/components/settings/integrations/OneDriveForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/OneDriveForm.tsx
@@ -154,8 +154,10 @@ const OneDriveForm: React.FC = () => {
         </div>
         <Tips>
           <li>
-            {_('Connected as {{account}}', { account: stored.accountLabel })}
-            {_('. Make OneDrive the active cloud provider.')}
+            {_('Connected as {{account}}. Make {{provider}} the active cloud provider.', {
+              account: stored.accountLabel,
+              provider: 'OneDrive',
+            })}
           </li>
         </Tips>
       </div>


### PR DESCRIPTION
## Problem

The Google Drive and OneDrive settings forms built a single sentence out of two separate translation calls, relying on JSX adjacent expressions to join them with no whitespace:

```tsx
{_('Connected as {{account}}', { account: stored.accountLabel })}
{_('. Make OneDrive the active cloud provider.')}
```

This leaves the terminating period of the *first* sentence stranded at the front of the *second* key. Under the key-as-content model, `". Make OneDrive the active cloud provider."` is not valid English content, it is half a sentence with orphaned punctuation.

The consequences:

- **Translators get no context.** They see only the fragment, and have to infer that it continues a preceding clause and reconstruct the joint themselves. You can see them all guessing in the dark: `ja`/`zh` prepended a full-width `。`, `hi`/`bn` used `।`, `bo` used `།`, `th` kept a Latin `.`.
- **Two locales guessed wrong**, and were rendering broken punctuation in production:
  - **`bo`** double-punctuated. `Connected as {{account}}` already ends in a shad (`...ཟིན།`) and the fragment *also* began with one, so the tip rendered `ཟིན།། OneDrive ...`.
  - **`th`** carried a stray Latin full stop. Thai does not punctuate between sentences.
- **The join is fragile.** The period lives in key B but belongs to key A. If anyone ever adds a period to `Connected as {{account}}`, all 33 locales silently double-punctuate and nothing catches it.
- Translators cannot reorder or rephrase across the fragment boundary, the standard sentence-splitting anti-pattern.

## Fix

Collapse both into a single key that takes the provider name as a variable:

```tsx
{_('Connected as {{account}}. Make {{provider}} the active cloud provider.', {
  account: stored.accountLabel,
  provider: 'OneDrive',
})}
```

Three keys (`Connected as {{account}}`, `. Make Google Drive ...`, `. Make OneDrive ...`) become one.

The per-locale strings are **derived from the existing translations** rather than re-translated, so the established translator wording is preserved. The derivation asserts that the template reproduces both provider sentences byte-for-byte, so the rendered text is unchanged everywhere, with two deliberate exceptions:

| Locale | Before | After |
| --- | --- | --- |
| `bo` | `...ཟིན།། OneDrive ...` (double shad) | `...ཟིན། OneDrive ...` |
| `th` | `เชื่อมต่อในชื่อ x. ตั้งให้ ...` (stray period) | `เชื่อมต่อในชื่อ x ตั้งให้ ...` |

Everything else (CJK `。`, Devanagari/Bengali `।`, Latin `. `) carries over unchanged.

## Note for whoever adds the next cloud provider

Some locales glue a case suffix directly onto the provider name, and with a single template that suffix is necessarily baked in:

```
tr: "{{account}} olarak bağlanıldı. {{provider}}'ı etkin bulut sağlayıcısı yapın."
hu: "Csatlakozva mint {{account}}. Tegye a {{provider}}-ot az aktív felhőszolgáltatóvá."
```

These are correct for **Google Drive** and **OneDrive** because both names end in "Drive". They are not correct in general: Turkish picks the accusative suffix by vowel harmony on the name as pronounced (`Dropbox'u`, `S3'ü`, not `...'ı`), and the Hungarian `a`/`az` article depends on the initial sound (`az S3`, not `a S3`).

So a new provider does **not** get its translations for free. `tr`, `hu`, `uz` and `bn` should be revisited when one is added.

## Verification

- `pnpm lint` clean
- `pnpm test` 7333 passed / 9 skipped
- `pnpm format:check` clean
- Re-running `pnpm i18n:extract` is a no-op, and zero `__STRING_NOT_TRANSLATED__` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)