### PR TITLE
fix(sentry): stop the crash reporter booting a second copy of the app (#5052)

### DIFF
--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -396,6 +396,19 @@ pub fn run() {
         .filter(|_| !sentry_config::is_app_sandboxed())
         .map(|guard| tauri_plugin_sentry::minidump::init(guard));
 
+    // In the re-exec'd crash-reporter process, `minidump::init` runs the server
+    // loop and exits the process from inside, so reaching this line there means
+    // the server failed to start and `init` returned an error. Without this guard
+    // the process keeps going and boots a whole second copy of the app next to the
+    // user's real one — a duplicate window, dock icon and webview (#5052). Exit
+    // instead: the app that spawned us gives up after its connect timeout and runs
+    // on without native minidumps.
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    if sentry_config::is_crash_reporter_process() {
+        eprintln!("crash-reporter server failed to start; exiting the reporter process");
+        std::process::exit(1);
+    }
+
     let builder = tauri::Builder::default()
         .plugin(
             tauri_plugin_log::Builder::new()

--- a/apps/readest-app/src-tauri/src/sentry_config.rs
+++ b/apps/readest-app/src-tauri/src/sentry_config.rs
@@ -146,6 +146,29 @@ pub fn is_app_sandboxed() -> bool {
     )
 }
 
+/// The argument `minidumper-child` passes to the copy of our binary it re-execs
+/// to host the crash-reporter server (its default `server_arg`, matched there by
+/// prefix because the socket path is appended as `=<socket>`).
+const CRASH_REPORTER_SERVER_ARG: &str = "--crash-reporter-server";
+
+/// Whether `args` belong to the crash-reporter server process.
+pub fn is_crash_reporter_args<I: IntoIterator<Item = S>, S: AsRef<str>>(args: I) -> bool {
+    args.into_iter()
+        .any(|arg| arg.as_ref().starts_with(CRASH_REPORTER_SERVER_ARG))
+}
+
+/// True when this process is the crash-reporter server that the minidump handler
+/// started by re-exec'ing our own binary, not the app the user launched.
+///
+/// The server process must never boot the UI. `minidump::init` normally runs the
+/// server loop and exits the process from inside, but when the server fails to
+/// start it returns an error instead, and the process would otherwise fall
+/// through into a full second copy of the app — a duplicate window on top of the
+/// user's real one (#5052).
+pub fn is_crash_reporter_process() -> bool {
+    is_crash_reporter_args(std::env::args())
+}
+
 /// The WebView (engine, major-version), set once at startup when the app reports
 /// its User-Agent. Stored globally so `before_send` can tag every event — the
 /// browser context integration doesn't run for events forwarded from the webview.
@@ -207,9 +230,33 @@ pub extern "C" fn readest_sentry_dsn() -> *const std::os::raw::c_char {
 mod tests {
     use super::{
         android_version_from_uname, app_sandboxed, corrected_os_name, dsn_from_env,
-        environment_for_version, is_ignored_browser_error, is_mobi_cover_panic_frame,
-        parse_webview_info, release_name,
+        environment_for_version, is_crash_reporter_args, is_ignored_browser_error,
+        is_mobi_cover_panic_frame, parse_webview_info, release_name,
     };
+
+    #[test]
+    fn crash_reporter_process_is_detected_from_its_server_arg() {
+        // `minidumper-child` re-execs our binary with the socket appended.
+        assert!(is_crash_reporter_args([
+            "/Applications/Readest.app/Contents/MacOS/readest",
+            "--crash-reporter-server=/var/folders/dz/T/temp-socket-6e72b890",
+        ]));
+        // Its own detection matches by prefix, so a bare flag counts too.
+        assert!(is_crash_reporter_args([
+            "readest",
+            "--crash-reporter-server"
+        ]));
+    }
+
+    #[test]
+    fn the_app_the_user_launched_is_not_the_crash_reporter() {
+        assert!(!is_crash_reporter_args(["readest"]));
+        // Open-with passes book paths, never the reporter flag.
+        assert!(!is_crash_reporter_args([
+            "readest",
+            "/Users/me/Books/crash-reporter-server.epub",
+        ]));
+    }
 
     #[test]
     fn mac_app_store_build_is_detected_as_sandboxed() {


### PR DESCRIPTION
## Problem

On macOS, Readest 0.11.18 opens **two windows**: one blank, one that works (#5052). The reporter's video shows two dock icons — two separate app processes.

## Root cause

The minidump handler starts its crash-reporter server by **re-exec'ing our own binary** with `--crash-reporter-server=<socket>` (`tauri-plugin-sentry` -> `sentry-rust-minidump` -> `minidumper-child`). In that re-exec'd process, `minidump::init` normally runs the server loop and exits the process from inside, so it never reaches the app.

When the server *fails to start*, `init` returns `Err` instead — and `run()` threw that `Result` away and carried straight on into `tauri::Builder`. The crash-reporter process then booted a whole second copy of the app: its own window, webview, dock icon, single-instance registration and database handles, next to the user's real one.

Evidence the fall-through is real and widespread:

- **Sentry READEST-Y**: 1890 events / **1106 users** on 0.11.18 — a *webview* unhandled rejection (`http://tauri.localhost/`) whose argv carries `--crash-reporter-server` and whose scope is tagged `event.process: "crash-reporter"`. Only a process that booted the app can emit that. It hits Windows as well, so this is not a macOS 26 quirk.
- **Repro against the shipped 0.11.18 binary**: `readest --crash-reporter-server=/nonexistent/sock` boots the entire app instead of exiting.
- **End-to-end repro**: launching the shipped app with `TMPDIR` pointing at a directory the server cannot bind in makes the real server fail; the crash-reporter child boots the app. On macOS 15 it wins the single-instance handshake, so the instance the user launched exits and the ghost instance takes over — the same root cause, a different race outcome than the reporter's macOS 26.

## Fix

A process launched with `--crash-reporter-server` must never boot the UI. Reaching the line after `minidump::init` in that process means the server failed, so exit there instead of continuing into `tauri::Builder`. The app that spawned it gives up after its connect timeout and runs on without native minidumps — already the reality whenever that server cannot start.

## Verification

Built this branch and ran the real binary:

- Under the production failure condition (unbindable `TMPDIR`): **one process, one window**, reporter process exits with a message. Before the fix, the same condition produced a duplicate instance.
- Healthy launch: unchanged — the reporter child spawns and blocks in its server loop, one window.
- `cargo test -p Readest --lib` (85 passed, incl. 2 new), `pnpm test` (7338 passed), `pnpm lint`, `cargo fmt --check`, `cargo clippy` all pass.

## Follow-ups (not in this PR)

- **Why the server fails is still unknown.** This makes the failure harmless, but those users silently lose native crash reporting, and it is a large group. Worth reporting the underlying `Err` so the actual cause is visible.
- Affected users also eat a ~3s startup stall (the parent's client-connect timeout) on every launch.

Fixes #5052

🤖 Generated with [Claude Code](https://claude.com/claude-code)