### PR TITLE
fix(reader): remove long-press to zoom images and tables

### DIFF
--- a/apps/readest-app/src/__tests__/reader/utils/iframeEventHandlers.test.ts
+++ b/apps/readest-app/src/__tests__/reader/utils/iframeEventHandlers.test.ts
@@ -210,3 +210,16 @@ describe('single-tap opens image gallery / table zoom in reflowable books (#4584
     expect(types).not.toContain('iframe-open-media');
   });
 });
+
+describe('long-press does not open the image gallery / table zoom (#5069)', () => {
+  // A hold over an image/table used to arm a 500ms timer, cancelled only once the
+  // pointer travelled 10px. A slow scroll covers less than that in half a second, so
+  // the timer fired mid-scroll and the viewer opened under the reader's finger. Tap
+  // (#4584) already reaches the same viewer, so nothing registers a long-press
+  // anymore: the iframe handlers must expose no way to attach one.
+  test('the iframe handlers expose no long-press attachment', async () => {
+    const handlers = await importHandlers();
+
+    expect(handlers).not.toHaveProperty('addLongPressListeners');
+  });
+});

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -58,7 +58,6 @@ import {
   handleTouchStart,
   handleTouchMove,
   handleTouchEnd,
-  addLongPressListeners,
 } from '../utils/iframeEventHandlers';
 import { getMaxInlineSize } from '@/utils/config';
 import { getDirFromUILanguage } from '@/utils/rtl';
@@ -426,7 +425,6 @@ const FoliateViewer: React.FC<{
         detail.doc.addEventListener('touchstart', handleTouchStart.bind(null, bookKey));
         detail.doc.addEventListener('touchmove', handleTouchMove.bind(null, bookKey));
         detail.doc.addEventListener('touchend', handleTouchEnd.bind(null, bookKey));
-        addLongPressListeners(bookKey, detail.doc);
         registerBrightnessListeners(detail.doc);
       }
     }

--- a/apps/readest-app/src/app/reader/hooks/useIframeEvents.ts
+++ b/apps/readest-app/src/app/reader/hooks/useIframeEvents.ts
@@ -78,9 +78,8 @@ export const useMouseEvent = (
 };
 
 // Opens the image gallery / table zoom viewer when the iframe reports that the
-// user activated an image or table — via either a long-press (any book) or a
-// single tap (reflowable books). See the `iframe-open-media` producers in
-// iframeEventHandlers.ts.
+// user tapped an image or table (reflowable books only). See the
+// `iframe-open-media` producer in iframeEventHandlers.ts.
 export const useOpenMediaEvent = (
   bookKey: string,
   handleImagePress: (src: string) => void,

--- a/apps/readest-app/src/app/reader/utils/iframeEventHandlers.ts
+++ b/apps/readest-app/src/app/reader/utils/iframeEventHandlers.ts
@@ -218,9 +218,8 @@ export const handleWheel = (bookKey: string, event: WheelEvent) => {
   );
 };
 
-// A tappable/long-pressable media element under the pointer, resolved to the
-// payload the image gallery / table zoom viewers consume. Shared by the
-// long-press path and the single-tap path so the two can't drift.
+// A tappable media element under the pointer, resolved to the payload the image
+// gallery / table zoom viewers consume.
 type MediaTarget = { elementType: 'image'; src: string } | { elementType: 'table'; html: string };
 
 const detectMediaTarget = (target: HTMLElement | null): MediaTarget | null => {
@@ -280,9 +279,9 @@ export const handleClick = (
     const footnote = element?.closest(footnoteSelector);
     // In reflowable books a single tap on an image/table opens the media
     // viewer. A media element wrapped in a plain link (e.g. a figure linking to
-    // its full-resolution image) should still zoom rather than follow the link,
-    // matching long-press (#4757). Footnotes are excluded so footnote links keep
-    // their popup/navigation behavior.
+    // its full-resolution image) should still zoom rather than follow the link
+    // (#4757). Footnotes are excluded so footnote links keep their
+    // popup/navigation behavior.
     const media = !isFixedLayout && !footnote ? detectMediaTarget(element) : null;
     if (
       !media &&
@@ -327,10 +326,11 @@ export const handleClick = (
       return;
     }
 
-    // In reflowable books a single tap on an image/table opens the same viewer
-    // a long-press does, so the image gallery / table zoom is reachable by both
-    // gestures (#4584). Fixed-layout books (PDF/comics/manga) keep tap-to-turn,
-    // since there the tap is the page-turn gesture (media is null there).
+    // In reflowable books a single tap on an image/table opens the image gallery
+    // / table zoom (#4584) — it is the only gesture that does, since long-press
+    // fired mid-scroll and was removed (#5069). Fixed-layout books
+    // (PDF/comics/manga) keep tap-to-turn, since there the tap is the page-turn
+    // gesture (media is null there).
     if (media) {
       window.postMessage({ type: 'iframe-open-media', bookKey, ...media }, '*');
       return;
@@ -401,157 +401,4 @@ export const handleTouchMove = (bookKey: string, event: TouchEvent) => {
 
 export const handleTouchEnd = (bookKey: string, event: TouchEvent) => {
   handleTouchEv(bookKey, event, 'iframe-touchend');
-};
-
-export const addLongPressListeners = (bookKey: string, doc: Document) => {
-  const longPressDuration = 500;
-  const moveThreshold = 10; // pixels - movement threshold to detect dragging/selection
-  const pressTimers = new Map<Element, ReturnType<typeof setTimeout>>();
-  const pressStartPositions = new Map<Element, { x: number; y: number }>();
-
-  const handleLongPress = (event: Event, target: HTMLElement) => {
-    event.preventDefault?.();
-
-    // Check if there's an active text selection - if so, don't trigger long-press
-    const selection = doc.getSelection();
-    if (selection && selection.toString().length > 0) {
-      return;
-    }
-
-    const media = detectMediaTarget(target);
-    if (media) {
-      window.postMessage({ type: 'iframe-open-media', bookKey, ...media }, '*');
-    }
-  };
-
-  const startPress = (event: Event) => {
-    const target = event.target as HTMLElement;
-    const isImage = target.localName === 'img';
-    const isSvgImage = !isImage && !!target.closest('svg')?.querySelector('image');
-    const isTableOrInTable = target.localName === 'table' || target.closest('table');
-
-    if (!isImage && !isSvgImage && !isTableOrInTable) return;
-
-    const elementToTrack = isImage
-      ? target
-      : isSvgImage
-        ? (target.closest('svg') as unknown as HTMLElement)
-        : ((target.localName === 'table' ? target : target.closest('table')) as HTMLElement);
-
-    // Store initial position for movement detection
-    if ('clientX' in event && 'clientY' in event) {
-      const mouseEvent = event as MouseEvent;
-      pressStartPositions.set(elementToTrack, { x: mouseEvent.clientX, y: mouseEvent.clientY });
-    } else if ('touches' in event) {
-      const touchEvent = event as TouchEvent;
-      const touch = touchEvent.touches[0];
-      if (touch) {
-        pressStartPositions.set(elementToTrack, { x: touch.clientX, y: touch.clientY });
-      }
-    }
-
-    clearTimeout(pressTimers.get(elementToTrack));
-    const timer = setTimeout(() => handleLongPress(event, elementToTrack), longPressDuration);
-    pressTimers.set(elementToTrack, timer);
-  };
-
-  const handleMove = (event: Event) => {
-    const target = event.target as HTMLElement;
-    const isImage = target.localName === 'img';
-    const isSvgImage = !isImage && !!target.closest('svg')?.querySelector('image');
-    const isTableOrInTable = target.localName === 'table' || target.closest('table');
-
-    if (!isImage && !isSvgImage && !isTableOrInTable) return;
-
-    const elementToTrack = isImage
-      ? target
-      : isSvgImage
-        ? (target.closest('svg') as unknown as HTMLElement)
-        : ((target.localName === 'table' ? target : target.closest('table')) as HTMLElement);
-
-    // Check if mouse/touch moved beyond threshold - if so, user is probably selecting text or dragging
-    const startPos = pressStartPositions.get(elementToTrack);
-    if (startPos) {
-      let currentX = 0;
-      let currentY = 0;
-
-      if ('clientX' in event && 'clientY' in event) {
-        const mouseEvent = event as MouseEvent;
-        currentX = mouseEvent.clientX;
-        currentY = mouseEvent.clientY;
-      } else if ('touches' in event) {
-        const touchEvent = event as TouchEvent;
-        const touch = touchEvent.touches[0];
-        if (touch) {
-          currentX = touch.clientX;
-          currentY = touch.clientY;
-        }
-      }
-
-      const distance = Math.sqrt(
-        Math.pow(currentX - startPos.x, 2) + Math.pow(currentY - startPos.y, 2),
-      );
-
-      // If moved beyond threshold, cancel the long-press
-      if (distance > moveThreshold) {
-        clearTimeout(pressTimers.get(elementToTrack));
-        pressTimers.delete(elementToTrack);
-        pressStartPositions.delete(elementToTrack);
-      }
-    }
-  };
-
-  const cancelPress = (event: Event) => {
-    const target = event.target as HTMLElement;
-    const isImage = target.localName === 'img';
-    const isSvgImage = !isImage && !!target.closest('svg')?.querySelector('image');
-    const isTableOrInTable = target.localName === 'table' || target.closest('table');
-
-    if (!isImage && !isSvgImage && !isTableOrInTable) return;
-
-    const elementToTrack = isImage
-      ? target
-      : isSvgImage
-        ? (target.closest('svg') as unknown as HTMLElement)
-        : ((target.localName === 'table' ? target : target.closest('table')) as HTMLElement);
-
-    clearTimeout(pressTimers.get(elementToTrack));
-    pressTimers.delete(elementToTrack);
-    pressStartPositions.delete(elementToTrack);
-  };
-
-  const processElements = () => {
-    const addLongPressListeners = (el: Element) => {
-      if (el.hasAttribute('data-long-press-added')) return;
-      el.setAttribute('data-long-press-added', 'true');
-      el.addEventListener('mousedown', startPress);
-      el.addEventListener('mousemove', handleMove);
-      el.addEventListener('mouseup', cancelPress);
-      el.addEventListener('mouseleave', cancelPress);
-      el.addEventListener('touchstart', startPress, { passive: true });
-      el.addEventListener('touchmove', handleMove, { passive: true });
-      el.addEventListener('touchend', cancelPress);
-    };
-
-    doc.querySelectorAll('img, table').forEach(addLongPressListeners);
-    doc.querySelectorAll('svg').forEach((svg) => {
-      if (svg.querySelector('image')) addLongPressListeners(svg);
-    });
-  };
-
-  processElements();
-
-  const observer = new MutationObserver((mutations) => {
-    const hasNewElements = mutations.some((m) => m.type === 'childList' && m.addedNodes.length > 0);
-    if (hasNewElements) {
-      processElements();
-    }
-  });
-
-  observer.observe(doc.body, { childList: true, subtree: true });
-
-  return () => {
-    observer.disconnect();
-    pressTimers.forEach((timer) => clearTimeout(timer));
-  };
 };

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -373,6 +373,13 @@ const getPageLayoutStyles = (
     padding: unset;
     margin: unset;
   }
+  /* -webkit-touch-callout on html/body does not reach descendant images in
+     Android WebView, and the native image callout collides with the reader's
+     touch handlers and can freeze the app */
+  img {
+    -webkit-touch-callout: none;
+    -webkit-user-drag: none;
+  }
   svg:where(:not([width])), img:where(:not([width])) {
     width: auto;
   }


### PR DESCRIPTION
Closes #5069.

## The bug

`addLongPressListeners` armed a 500ms timer on `touchstart` over an `<img>` / `<table>` / `<svg>`, and cancelled it only once the pointer travelled more than 10px. A slow scroll covers less than that in half a second, so in scrolled mode the timer fired mid-gesture and the table or image viewer opened under the reader's finger — without the finger ever lifting, exactly as in the reporter's video.

There was no `touchcancel` listener either: once the WebView claimed the gesture for panning and stopped delivering `touchmove` into the iframe, nothing could cancel the timer at all.

## The fix

Remove long-press-to-zoom entirely rather than harden the timer.

Since #4600 a single tap already opens the same gallery / table viewer in reflowable books, and a mouse click goes through that same path, so long-press was redundant. It was also actively harmful: it raced the OS long-press that starts a text selection, which made selecting text inside a table a coin flip, and it is the gesture behind the recurring Android image-callout freeze. Dropping it removes the detector, its timers, and a per-document `MutationObserver`.

- **Reflowable** — tap (or click) an image/table opens the viewer, unchanged. Long-press now does what the OS does, so text selection inside tables works.
- **Fixed-layout** (comics/manga/PDF) — tap still turns the page and pinch still zooms; the gallery is no longer reachable from the page image. Deliberate: tap is the page-turn gesture there.

With our handler gone, a long-press on a reader image would fall through to the WebView's native image callout, so `-webkit-touch-callout: none` is applied to `img` directly in `getLayoutStyles()` — the rule on `html, body` does not reach descendant images in Android WebView.

## Tests

The existing single-tap tests (#4584) are the guard that the remaining trigger still works and pass unchanged; a new test asserts the module no longer exposes a long-press attachment, so it can't be reintroduced silently.

`pnpm test` (7339 passed) and `pnpm lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)