### PR TITLE
fix(android): give each gallery image its own name and report insert failures

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -470,8 +470,10 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
 
                     val itemUri = resolver.insert(collection, values)
                     if (itemUri == null) {
+                        val error = "MediaStore rejected $displayName ($mimeType) in $album"
+                        Log.e("NativeBridge", error)
                         r.put("success", false)
-                        r.put("error", "Failed to create MediaStore entry")
+                        r.put("error", error)
                         return@withContext r
                     }
 
@@ -492,8 +494,12 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
                     r.put("success", true)
                     r.put("uri", itemUri.toString())
                 } catch (e: Exception) {
+                    // OEM MediaStore implementations diverge on what they accept, so
+                    // the exception is the only thing that identifies a device-specific
+                    // failure from a bug report.
+                    Log.e("NativeBridge", "Failed to save image to gallery", e)
                     r.put("success", false)
-                    r.put("error", e.message)
+                    r.put("error", "${e.javaClass.simpleName}: ${e.message}")
                 }
                 r
             }

--- a/apps/readest-app/src/__tests__/services/native-app-service-gallery.test.ts
+++ b/apps/readest-app/src/__tests__/services/native-app-service-gallery.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Saving an image to the Android gallery goes: ImageViewer -> NativeAppService ->
+// the native-bridge plugin -> MediaStore.insert(). MediaStore is the part that
+// differs between OEMs, so what we hand it has to stand on its own rather than
+// lean on a particular provider's leniency (#5069 follow-up: Samsung One UI
+// reported "Failed to save the image" where AOSP-ish providers were fine).
+
+const osTypeMock = vi.fn().mockReturnValue('android');
+
+const saveImageToGalleryMock = vi.fn().mockResolvedValue({ success: true, uri: 'content://1' });
+
+vi.mock('@tauri-apps/plugin-os', () => ({
+  type: () => osTypeMock(),
+}));
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  exists: vi.fn().mockResolvedValue(false),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  readTextFile: vi.fn().mockResolvedValue(''),
+  readFile: vi.fn().mockResolvedValue(new Uint8Array()),
+  writeTextFile: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  readDir: vi.fn().mockResolvedValue([]),
+  remove: vi.fn().mockResolvedValue(undefined),
+  copyFile: vi.fn().mockResolvedValue(undefined),
+  stat: vi.fn().mockResolvedValue({ size: 0 }),
+  BaseDirectory: {},
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+  convertFileSrc: (p: string) => `asset://${p}`,
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: vi.fn().mockResolvedValue(null),
+  save: vi.fn().mockResolvedValue(null),
+  ask: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@tauri-apps/api/path', () => ({
+  join: (...parts: string[]) => Promise.resolve(parts.join('/')),
+  basename: (p: string) => Promise.resolve(p.split('/').pop() ?? p),
+  appDataDir: () => Promise.resolve('/tmp/app-data'),
+  appConfigDir: () => Promise.resolve('/tmp/app-config'),
+  appCacheDir: () => Promise.resolve('/tmp/app-cache'),
+  appLogDir: () => Promise.resolve('/tmp/app-log'),
+  tempDir: () => Promise.resolve('/tmp'),
+}));
+
+vi.mock('@choochmeque/tauri-plugin-sharekit-api', () => ({
+  shareFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/utils/bridge', () => ({
+  copyURIToPath: vi.fn().mockResolvedValue({ path: '' }),
+  getStorefrontRegionCode: vi.fn().mockResolvedValue({ regionCode: null }),
+  saveImageToGallery: (...args: unknown[]) => saveImageToGalleryMock(...args),
+}));
+
+vi.mock('@/utils/file', () => ({
+  NativeFile: class {},
+  RemoteFile: class {},
+}));
+
+vi.mock('@/utils/files', () => ({
+  copyFiles: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/services/settingsService', () => ({
+  getDefaultViewSettings: vi.fn().mockReturnValue({}),
+  loadSettings: vi.fn().mockResolvedValue({ migrationVersion: 99999999 }),
+  saveSettings: vi.fn().mockResolvedValue(undefined),
+}));
+
+async function initAndroidService() {
+  osTypeMock.mockReturnValue('android');
+  vi.resetModules();
+  const mod = await import('@/services/nativeAppService');
+  const service = new mod.NativeAppService();
+  await service.init();
+  return service;
+}
+
+const pngBytes = () => new Uint8Array([0, 1, 2]).buffer as ArrayBuffer;
+
+type GalleryRequest = { srcPath: string; fileName: string; mimeType: string; albumName?: string };
+
+const requestOf = (call: number): GalleryRequest =>
+  saveImageToGalleryMock.mock.calls[call]![0] as GalleryRequest;
+
+describe('NativeAppService.saveImageToGallery', () => {
+  beforeEach(() => {
+    saveImageToGalleryMock.mockClear();
+    saveImageToGalleryMock.mockResolvedValue({ success: true, uri: 'content://1' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('gives every saved image its own MediaStore display name', async () => {
+    const service = await initAndroidService();
+
+    await service.saveImageToGallery('image.png', pngBytes(), 'image/png');
+    await service.saveImageToGallery('image.png', pngBytes(), 'image/png');
+
+    const first = requestOf(0);
+    const second = requestOf(1);
+
+    // A constant display name makes the insert depend on the provider quietly
+    // de-duplicating it (AOSP renames to "image (1).png"; stricter OEM providers
+    // reject the row instead). Name the file ourselves so it never collides.
+    expect(first.fileName).not.toBe('image.png');
+    expect(first.fileName).not.toBe(second.fileName);
+    expect(first.fileName.endsWith('.png')).toBe(true);
+    expect(second.fileName.endsWith('.png')).toBe(true);
+    // The staged file the plugin reads must be the one we named.
+    expect(first.srcPath.endsWith(first.fileName)).toBe(true);
+    expect(second.srcPath.endsWith(second.fileName)).toBe(true);
+  });
+
+  test('logs the native error when the MediaStore insert fails', async () => {
+    const service = await initAndroidService();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    saveImageToGalleryMock.mockResolvedValue({
+      success: false,
+      error: 'Failed to build unique file: /storage/emulated/0/Pictures/Readest image.png',
+    });
+
+    const saved = await service.saveImageToGallery('image.png', pngBytes(), 'image/png');
+
+    expect(saved).toBe(false);
+    // Without this the toast is all anyone gets, and an OEM-specific failure is
+    // undiagnosable from a bug report.
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to save image to gallery'),
+      'Failed to build unique file: /storage/emulated/0/Pictures/Readest image.png',
+    );
+  });
+});

--- a/apps/readest-app/src/services/nativeAppService.ts
+++ b/apps/readest-app/src/services/nativeAppService.ts
@@ -39,6 +39,7 @@ import { getOSPlatform, isContentURI, isFileURI, isValidURL } from '@/utils/misc
 import { getDirPath, getFilename } from '@/utils/path';
 import { NativeFile, RemoteFile } from '@/utils/file';
 import { copyURIToPath, getStorefrontRegionCode, saveImageToGallery } from '@/utils/bridge';
+import { galleryFileName } from '@/utils/image';
 import { copyFiles } from '@/utils/files';
 import { detectViewTransitionGroup, detectViewTransitionsAPI } from '@/utils/viewTransition';
 
@@ -845,19 +846,27 @@ export class NativeAppService extends BaseAppService {
   ): Promise<boolean> {
     // MediaStore is Android-only; other platforms keep the saveFile/share path.
     if (!this.isAndroidApp) return false;
+    // Every image reaching here is called `image.<ext>`, which left the insert at
+    // the mercy of the OEM's duplicate handling. Name each save uniquely instead.
+    const galleryName = galleryFileName(filename);
     // Write the bytes to a Temp subdirectory (not the Temp root, mirroring the
     // share path), then hand the path to the native MediaStore insert.
     const shareDir = await this.resolveFilePath('shared', 'Temp');
     await mkdir(shareDir, { recursive: true });
-    const srcPath = await this.resolveFilePath(`shared/${filename}`, 'Temp');
+    const srcPath = await this.resolveFilePath(`shared/${galleryName}`, 'Temp');
     try {
       await writeFile(srcPath, new Uint8Array(content));
       const res = await saveImageToGallery({
         srcPath,
-        fileName: filename,
+        fileName: galleryName,
         mimeType,
         albumName: 'Readest',
       });
+      if (!res.success) {
+        // The plugin returns the MediaStore exception here. Dropping it left an
+        // OEM-specific insert failure showing up as nothing but a toast.
+        console.error('Failed to save image to gallery:', res.error);
+      }
       return res.success;
     } catch (error) {
       console.error('Failed to save image to gallery:', error);

--- a/apps/readest-app/src/utils/image.ts
+++ b/apps/readest-app/src/utils/image.ts
@@ -35,6 +35,28 @@ export function imageExtensionFromMime(mimeType: string): string {
   return base === 'jpeg' ? 'jpg' : base;
 }
 
+// Strictly increasing so two saves in the same millisecond still get distinct
+// names.
+let lastGalleryStamp = 0;
+
+const pad = (value: number, width: number) => String(value).padStart(width, '0');
+
+/**
+ * A collision-free name for an image handed to the gallery. Android's MediaStore
+ * neither overwrites an existing display name nor de-duplicates it consistently:
+ * AOSP renames to `image (1).png`, while stricter OEM providers reject the row
+ * outright. Naming each save ourselves keeps the insert independent of that.
+ */
+export function galleryFileName(filename: string, now = Date.now()): string {
+  const dot = filename.lastIndexOf('.');
+  const ext = dot > 0 ? filename.slice(dot) : '';
+  lastGalleryStamp = Math.max(now, lastGalleryStamp + 1);
+  const d = new Date(lastGalleryStamp);
+  const date = `${d.getFullYear()}${pad(d.getMonth() + 1, 2)}${pad(d.getDate(), 2)}`;
+  const time = `${pad(d.getHours(), 2)}${pad(d.getMinutes(), 2)}${pad(d.getSeconds(), 2)}`;
+  return `readest-${date}-${time}-${pad(d.getMilliseconds(), 3)}${ext}`;
+}
+
 /**
  * Process book cover for Discord Rich Presence:
  * - Fit to 512x512 with transparent background


### PR DESCRIPTION
Saving an image from the gallery viewer fails with "Failed to save the image" on Samsung One UI 8.5 (S23 Ultra) while the same build works on Xiaomi (Android 16).

## What I could establish

We hand MediaStore four values: `DISPLAY_NAME`, `MIME_TYPE`, `RELATIVE_PATH=Pictures/Readest` and `IS_PENDING=1`. Three are textbook and identical on both devices. The only one that varies over time is the display name — and it never changes: `ImageViewer` names **every** saved image `image.<ext>`.

So the insert has always depended on the OEM's MediaProvider quietly de-duplicating a colliding display name. AOSP (and Xiaomi's fork) rename the row to `image (1).png`; a stricter provider rejects it instead. That is the leading hypothesis for the OEM divergence, and a defect regardless of Samsung: a gallery full of `image`, `image (1)`, `image (2)` is not what we want either.

I could not *prove* it, because the code discards the only evidence that would identify the cause — see below. Without a Samsung device in hand, this PR fixes the defect I can prove by reading, and makes the next report diagnosable if the cause is something else.

## Changes

- **Unique display name.** Each save is named `readest-<date>-<time>-<ms>.<ext>` (`galleryFileName` in `utils/image.ts`, strictly increasing so two saves in the same millisecond still differ), and the staged temp file uses the same name. The insert no longer relies on provider leniency.
- **Report the failure.** The plugin already returned the MediaStore exception in `error`, but `saveImageToGallery` read only `success` and dropped it, so an OEM-specific insert failure surfaced as nothing but a toast — indistinguishable from a failed temp-file write. The JS side now logs the native error, and the Kotlin side `Log.e`s the exception with its class name. A future report will carry the actual `IllegalStateException: …` rather than a shrug.

## Tests

New `native-app-service-gallery.test.ts` covers both: consecutive saves get distinct MediaStore display names matching their staged paths, and a failed insert logs the native error and returns false.

`pnpm test` (7340 passed) and `pnpm lint` are clean. No Rust changed (Kotlin only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)