### PR TITLE
fix(library): keep demo books out of the cloud book channel (#5049)

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/demo-books-sync.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/demo-books-sync.test.tsx
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import type { Book } from '@/types/book';
+
+/**
+ * Issue #5049 — "web.readest.com after signing in retains the example books".
+ *
+ * The demo books are the sample shelf an anonymous web visitor gets. They are
+ * imported as ordinary url-backed Book rows, so once the user signs in they are
+ * indistinguishable from the user's own books:
+ *
+ *   1. they get pushed to the user's cloud library, and
+ *   2. deleting them does not stick — the cloud row never learned about the
+ *      tombstone (a delete does not bump `updatedAt`, so the row loses LWW on
+ *      the server), and the next pull merges it back over the local row,
+ *      clearing `deletedAt`. The resurrected books come back coverless because
+ *      the delete cleared `coverDownloadedAt` and there is no cloud cover to
+ *      refetch.
+ *
+ * Demo books are never the user's content: they must stay out of the push, and
+ * a cloud row must never write back over one.
+ */
+
+const DEMO_URL = 'https://cdn.readest.com/books/the-great-gatsby.epub';
+
+const appService = vi.hoisted(() => ({
+  saveLibraryBooks: vi.fn(async () => {}),
+  generateCoverImageUrl: vi.fn(async () => 'blob:cover'),
+  downloadBookCovers: vi.fn(async () => {}),
+}));
+
+const syncState = vi.hoisted(() => ({
+  useSyncInited: true,
+  syncedBooks: null as Book[] | null,
+  syncBooks: vi.fn(async (_books?: Book[], _op?: string, _since?: number) => 0),
+  lastSyncedAtBooks: 1000,
+}));
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService }),
+}));
+
+vi.mock('@/context/SyncContext', () => ({
+  useSyncContext: () => ({ syncClient: {} }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (text: string) => text,
+}));
+
+vi.mock('@/hooks/useSync', () => ({
+  useSync: () => syncState,
+}));
+
+vi.mock('@/services/sync/cloudSyncProvider', () => ({
+  getCloudSyncProvider: () => 'readest',
+}));
+
+vi.mock('@/services/sync/file/runLibrarySync', () => ({
+  runActiveFileLibrarySync: vi.fn(async () => ({ booksSynced: 0 })),
+}));
+
+vi.mock('@/services/sync/fleetDetection', () => ({
+  checkMixedFleetOnce: vi.fn(),
+}));
+
+const { useBooksSync } = await import('@/app/library/hooks/useBooksSync');
+const { useLibraryStore } = await import('@/store/libraryStore');
+
+const makeBook = (over: Partial<Book> & Pick<Book, 'hash'>): Book => ({
+  format: 'EPUB',
+  title: 'Title',
+  author: 'Author',
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  syncState.syncedBooks = null;
+  useLibraryStore.setState({ library: [], libraryLoaded: false, isSyncing: false });
+});
+
+describe('demo books and the cloud book channel (issue #5049)', () => {
+  it('never pushes a demo book to the cloud', async () => {
+    useLibraryStore
+      .getState()
+      .setLibrary([
+        makeBook({ hash: 'demo-1', url: DEMO_URL, title: 'The Great Gatsby' }),
+        makeBook({ hash: 'mine-1', title: 'My Own Book' }),
+      ]);
+
+    const { result } = renderHook(() => useBooksSync());
+    await result.current.pushLibrary();
+
+    // Both the explicit push and the auto-sync effect push, so assert on the
+    // set of hashes that ever reached the cloud channel, not the call count.
+    const pushed = new Set(
+      syncState.syncBooks.mock.calls
+        .flatMap((call) => (call[0] ?? []) as Book[])
+        .map((book) => book.hash),
+    );
+
+    expect([...pushed]).toEqual(['mine-1']);
+  });
+
+  it('keeps a deleted demo book deleted when a stale cloud row is pulled back', async () => {
+    // Local: the user deleted the demo book. Cloud: the row this device pushed
+    // before the delete — same updatedAt, no tombstone. The user's own book
+    // rides along in the same pull, so the merge really runs.
+    useLibraryStore.getState().setLibrary([
+      makeBook({
+        hash: 'demo-1',
+        url: DEMO_URL,
+        title: 'The Great Gatsby',
+        deletedAt: 2000,
+        downloadedAt: null,
+        coverDownloadedAt: null,
+      }),
+      makeBook({ hash: 'mine-1', title: 'My Own Book', uploadedAt: 1000 }),
+    ]);
+    syncState.syncedBooks = [
+      makeBook({
+        hash: 'demo-1',
+        title: 'The Great Gatsby',
+        deletedAt: null,
+        uploadedAt: null,
+        coverHash: 'cover-hash',
+        coverUpdatedAt: 1000,
+      }),
+      makeBook({ hash: 'mine-1', title: 'My Own Book', uploadedAt: 1000, updatedAt: 3000 }),
+    ];
+
+    renderHook(() => useBooksSync());
+
+    await waitFor(() => expect(appService.saveLibraryBooks).toHaveBeenCalled());
+
+    const library = useLibraryStore.getState().library;
+    expect(library.find((book) => book.hash === 'demo-1')?.deletedAt).toBe(2000);
+    // The demo book's cover was never uploaded: refetching it would only wipe
+    // the local one, which is what left the resurrected books coverless.
+    const coverRefreshed = appService.downloadBookCovers.mock.calls.flatMap(
+      (call) => (call as unknown as [Book[]])[0],
+    );
+    expect(coverRefreshed.map((book) => book.hash)).not.toContain('demo-1');
+    // The user's own book still merges as before.
+    expect(library.find((book) => book.hash === 'mine-1')?.updatedAt).toBe(3000);
+  });
+});

--- a/apps/readest-app/src/app/library/hooks/useBooksSync.ts
+++ b/apps/readest-app/src/app/library/hooks/useBooksSync.ts
@@ -11,6 +11,7 @@ import { debounce } from '@/utils/debounce';
 import { eventDispatcher } from '@/utils/event';
 import { useSettingsStore } from '@/store/settingsStore';
 import { getCloudSyncProvider } from '@/services/sync/cloudSyncProvider';
+import { isDemoBook } from '@/services/demoBooks';
 import { runActiveFileLibrarySync } from '@/services/sync/file/runLibrarySync';
 import { checkMixedFleetOnce } from '@/services/sync/fleetDetection';
 import { useSyncContext } from '@/context/SyncContext';
@@ -34,6 +35,9 @@ export const useBooksSync = () => {
     if (!user) return {};
     const library = useLibraryStore.getState().library;
     const newBooks = library
+      // Demo books are the sample shelf we hand anonymous web visitors, not the
+      // user's content — they never go to the cloud (issue #5049).
+      .filter((book) => !isDemoBook(book))
       .filter(
         (book) =>
           !book.syncedAt ||
@@ -157,10 +161,24 @@ export const useBooksSync = () => {
   const updateLibrary = useCallback(async () => {
     if (!syncedBooks?.length) return;
 
+    // A cloud row for a demo book can only be a stale one pushed before #5049.
+    // Merging it back would write over the local demo row — and, because a
+    // delete doesn't bump `updatedAt`, the not-deleted cloud row wins the LWW
+    // tie and clears `deletedAt`, resurrecting a book the user just deleted
+    // (coverless, since its cover was never uploaded either).
+    const demoHashes = new Set(
+      useLibraryStore
+        .getState()
+        .library.filter(isDemoBook)
+        .map((book) => book.hash),
+    );
+    const cloudBooks = syncedBooks.filter((book) => !demoHashes.has(book.hash));
+    if (!cloudBooks.length) return;
+
     // Process old books first so that when we update the library the order is preserved
-    syncedBooks.sort((a, b) => a.updatedAt - b.updatedAt);
-    const bookHashesInSynced = new Set(syncedBooks.map((book) => book.hash));
-    const syncedByHash = new Map(syncedBooks.map((book) => [book.hash, book]));
+    cloudBooks.sort((a, b) => a.updatedAt - b.updatedAt);
+    const bookHashesInSynced = new Set(cloudBooks.map((book) => book.hash));
+    const syncedByHash = new Map(cloudBooks.map((book) => [book.hash, book]));
     const liveLibrary = useLibraryStore.getState().library;
     const oldBooks = liveLibrary.filter((book) => bookHashesInSynced.has(book.hash));
     // Books whose cover must be (re)fetched: never-downloaded, or a newer cover
@@ -209,7 +227,7 @@ export const useBooksSync = () => {
     appService?.saveLibraryBooks(updatedLibrary);
 
     const bookHashesInLibrary = new Set(updatedLibrary.map((book) => book.hash));
-    const newBooks = syncedBooks.filter(
+    const newBooks = cloudBooks.filter(
       (newBook) =>
         !bookHashesInLibrary.has(newBook.hash) && newBook.uploadedAt && !newBook.deletedAt,
     );

--- a/apps/readest-app/src/app/library/hooks/useDemoBooks.ts
+++ b/apps/readest-app/src/app/library/hooks/useDemoBooks.ts
@@ -4,14 +4,7 @@ import { useEnv } from '@/context/EnvContext';
 import { Book } from '@/types/book';
 import { getUserLang } from '@/utils/misc';
 import { isWebAppPlatform } from '@/services/environment';
-
-import libraryEn from '@/data/demo/library.en.json';
-import libraryZh from '@/data/demo/library.zh.json';
-
-const libraries = {
-  en: libraryEn,
-  zh: libraryZh,
-};
+import { demoLibraries as libraries } from '@/services/demoBooks';
 
 interface DemoBooks {
   library: string[];

--- a/apps/readest-app/src/services/demoBooks.ts
+++ b/apps/readest-app/src/services/demoBooks.ts
@@ -1,0 +1,20 @@
+import { Book } from '@/types/book';
+
+import libraryEn from '@/data/demo/library.en.json';
+import libraryZh from '@/data/demo/library.zh.json';
+
+export const demoLibraries = {
+  en: libraryEn,
+  zh: libraryZh,
+};
+
+const demoBookUrls = new Set([...libraryEn.library, ...libraryZh.library]);
+
+/**
+ * Demo books are the sample shelf an anonymous web visitor gets (issue #5049).
+ * They are imported as ordinary url-backed rows so the library isn't empty, but
+ * they are not the user's content: they must never be pushed to the cloud, and
+ * a cloud row must never be merged back over one. Identifying them by url also
+ * covers rows imported before this rule existed.
+ */
+export const isDemoBook = (book: Book): boolean => !!book.url && demoBookUrls.has(book.url);


### PR DESCRIPTION
Fixes #5049.

## The bug

The demo shelf (`the-great-gatsby.epub` and friends, fetched from `cdn.readest.com`) is imported into `library.json` as **ordinary url-backed `Book` rows**. Nothing marks them as demo content, so the moment a web visitor signs in they are indistinguishable from the user's own books. Two things follow:

1. **They get pushed to the user's cloud library.** `getNewBooks()` pushes every row without a `syncedAt`, so the demo books land in the user's cloud on the first sync after sign-in.

2. **Deleting them doesn't stick.** A delete sets `deletedAt` but never bumps `updatedAt`, so the tombstone loses the last-writer-wins tie against the pre-delete cloud row. The next pull merges that row back over the local one (`matchingBook.updatedAt >= oldBook.updatedAt ? { ...oldBook, ...matchingBook }`), clearing `deletedAt`. The book returns **without a cover**, because the delete cleared `coverDownloadedAt` and there is no cloud cover to refetch — exactly the coverless zombies in the issue's second screenshot.

## The fix

Demo books are the sample shelf we hand anonymous visitors, not the user's content — so they stay on the shelf, but they never enter the cloud book channel:

- `services/demoBooks.ts`: `isDemoBook(book)`, matching on the demo `cdn.readest.com` urls. Matching on the url rather than a new `Book` field means rows already in existing libraries are recognized, with no migration.
- `useBooksSync.getNewBooks()`: demo books are filtered out of the push.
- `useBooksSync.updateLibrary()`: cloud rows for books that are demo books locally are dropped before the merge. Such a row can only be a stale pre-fix push, and merging it is what resurrects a deleted demo book — this is what makes deletion stick for users who are already affected.

## Tests

`src/__tests__/app/library/demo-books-sync.test.tsx` drives the real `useBooksSync` hook:

- a demo book never reaches the cloud push, while the user's own book still does;
- a deleted demo book stays deleted when a stale cloud row is pulled back (this test fails on `main` — the merge clears `deletedAt`), its cover is not refetched, and the user's own book still merges as before.

`pnpm test`, `pnpm lint`, and `pnpm format:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)