### PR TITLE
fix(kosync): resolve element-offset XPointers and isolate percentage drift anchor to KOReader

### DIFF
--- a/apps/readest-app/.gitignore
+++ b/apps/readest-app/.gitignore
@@ -59,6 +59,9 @@ next-env.d.ts
 #generated
 src-tauri/gen
 
+# local dev overrides (personal signing, etc.)
+src-tauri/tauri.*.local.json
+
 # vendor
 /public/vendor
 

--- a/apps/readest-app/src/__tests__/hooks/kosyncConflict.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/kosyncConflict.test.ts
@@ -3,6 +3,7 @@ import type { BookDoc } from '@/libs/document';
 import type { FoliateView } from '@/types/view';
 import {
   decideRemoteConflict,
+  isReportedByKOReader,
   resolveRemoteLocalFraction,
   type RemoteFractionResolution,
 } from '@/app/reader/hooks/kosyncProgress';
@@ -24,6 +25,28 @@ const makeView = (fraction: number | null | undefined): FoliateView =>
   }) as unknown as FoliateView;
 
 const bookDoc = {} as BookDoc;
+
+describe('isReportedByKOReader', () => {
+  it('trusts a report with no device string (the common KOReader case)', () => {
+    expect(isReportedByKOReader({})).toBe(true);
+  });
+
+  it('trusts a report whose device does not match a known look-alike', () => {
+    expect(isReportedByKOReader({ device: 'Boox Palma' })).toBe(true);
+    expect(isReportedByKOReader({ device: 'Kobo' })).toBe(true);
+  });
+
+  it('distrusts Kavita (#5109 — non-CREngine percentage on a CREngine-shaped XPointer)', () => {
+    expect(isReportedByKOReader({ device: 'Kavita' })).toBe(false);
+    expect(isReportedByKOReader({ device: 'kavita' })).toBe(false);
+  });
+
+  it('distrusts other known KOReader-sync look-alikes', () => {
+    expect(isReportedByKOReader({ device: 'Komga' })).toBe(false);
+    expect(isReportedByKOReader({ device: 'Stump' })).toBe(false);
+    expect(isReportedByKOReader({ device: 'calibre-web' })).toBe(false);
+  });
+});
 
 describe('resolveRemoteLocalFraction', () => {
   beforeEach(() => mockGetCFIFromXPointer.mockReset());
@@ -71,6 +94,42 @@ describe('resolveRemoteLocalFraction', () => {
     );
     expect(res).toEqual({ status: 'not-xpointer' });
     expect(mockGetCFIFromXPointer).not.toHaveBeenCalled();
+  });
+
+  // #5109: Kavita's KOReader-compatible endpoint emits a real
+  // `/body/DocFragment[...]` XPointer, so it IS treated as XPointer progress —
+  // but its `percentage` comes from Kavita's own pagination, not CREngine's,
+  // and must never be forwarded as the drift-correction anchor (5th arg).
+  it('does NOT forward percentage as the drift anchor when the report is from Kavita (#5109)', async () => {
+    mockGetCFIFromXPointer.mockResolvedValue('epubcfi(/6/32!/4/2/6)');
+    await resolveRemoteLocalFraction(
+      { progress: XPOINTER, percentage: 0.2777778, device: 'Kavita' },
+      makeView(0.42),
+      bookDoc,
+    );
+    expect(mockGetCFIFromXPointer).toHaveBeenCalledWith(
+      XPOINTER,
+      undefined,
+      undefined,
+      bookDoc,
+      undefined,
+    );
+  });
+
+  it('still forwards percentage as the drift anchor for a plain KOReader report (no device string)', async () => {
+    mockGetCFIFromXPointer.mockResolvedValue('epubcfi(/6/32!/4/2/6)');
+    await resolveRemoteLocalFraction(
+      { progress: XPOINTER, percentage: 0.217 },
+      makeView(0.42),
+      bookDoc,
+    );
+    expect(mockGetCFIFromXPointer).toHaveBeenCalledWith(
+      XPOINTER,
+      undefined,
+      undefined,
+      bookDoc,
+      0.217,
+    );
   });
 });
 

--- a/apps/readest-app/src/__tests__/hooks/kosyncConflict.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/kosyncConflict.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BookDoc } from '@/libs/document';
+import type { FoliateView } from '@/types/view';
+import {
+  decideRemoteConflict,
+  resolveRemoteLocalFraction,
+  type RemoteFractionResolution,
+} from '@/app/reader/hooks/kosyncProgress';
+import { getCFIFromXPointer } from '@/utils/xcfi';
+
+// Only the wiring matters here; XPointer↔CFI accuracy is covered elsewhere.
+vi.mock('@/utils/xcfi', () => ({
+  getCFIFromXPointer: vi.fn(),
+}));
+
+const mockGetCFIFromXPointer = vi.mocked(getCFIFromXPointer);
+
+const XPOINTER = '/body/DocFragment[326]/body/div/p[3]/text().0';
+
+const makeView = (fraction: number | null | undefined): FoliateView =>
+  ({
+    renderer: { primaryIndex: 0, getContents: () => [] },
+    getCFIProgress: vi.fn().mockResolvedValue(fraction == null ? fraction : { fraction }),
+  }) as unknown as FoliateView;
+
+const bookDoc = {} as BookDoc;
+
+describe('resolveRemoteLocalFraction', () => {
+  beforeEach(() => mockGetCFIFromXPointer.mockReset());
+
+  it('reports a resolved local fraction for a convertible XPointer', async () => {
+    mockGetCFIFromXPointer.mockResolvedValue('epubcfi(/6/8!/4/2/6)');
+    const res = await resolveRemoteLocalFraction(
+      { progress: XPOINTER, percentage: 0.99 },
+      makeView(0.42),
+      bookDoc,
+    );
+    expect(res).toEqual({ status: 'resolved', fraction: 0.42 });
+  });
+
+  it('reports "unresolved" when resolving the XPointer fails', async () => {
+    // Simulate a conversion failure (common on iOS): the renderer throws while
+    // the converter reaches for the current section. The catch must classify
+    // this as 'unresolved', never as "no conflict".
+    mockGetCFIFromXPointer.mockResolvedValue('epubcfi(/6/8!/4/2/6)');
+    const brokenView = {
+      renderer: {
+        primaryIndex: 0,
+        getContents: () => {
+          throw new Error('renderer unavailable (iOS)');
+        },
+      },
+      getCFIProgress: vi.fn(),
+    } as unknown as FoliateView;
+
+    const res = await resolveRemoteLocalFraction({ progress: XPOINTER }, brokenView, bookDoc);
+    expect(res).toEqual({ status: 'unresolved' });
+  });
+
+  it('reports "unresolved" when the CFI maps to no local progress', async () => {
+    mockGetCFIFromXPointer.mockResolvedValue('epubcfi(/99/999!/0)');
+    const res = await resolveRemoteLocalFraction({ progress: XPOINTER }, makeView(null), bookDoc);
+    expect(res).toEqual({ status: 'unresolved' });
+  });
+
+  it('reports "not-xpointer" for non-KOReader progress without converting', async () => {
+    const res = await resolveRemoteLocalFraction(
+      { progress: 'page-42', percentage: 0.5 },
+      makeView(0.42),
+      bookDoc,
+    );
+    expect(res).toEqual({ status: 'not-xpointer' });
+    expect(mockGetCFIFromXPointer).not.toHaveBeenCalled();
+  });
+});
+
+describe('decideRemoteConflict', () => {
+  const threshold = 0.0001;
+
+  it('flags a conflict when a resolved remote position is meaningfully ahead', () => {
+    const resolution: RemoteFractionResolution = { status: 'resolved', fraction: 0.6 };
+    const decision = decideRemoteConflict(resolution, 0.14, 0.14, threshold);
+    // The local fraction — not KOReader's percentage — drives the comparison.
+    expect(decision).toEqual({ showConflictDetails: true, comparePercentage: 0.6 });
+  });
+
+  it('reports no conflict when a resolved remote position matches locally', () => {
+    const resolution: RemoteFractionResolution = { status: 'resolved', fraction: 0.14 };
+    const decision = decideRemoteConflict(resolution, 0.14, 0.99, threshold);
+    expect(decision.showConflictDetails).toBe(false);
+    // Proves KOReader's (incomparable) 0.99 percentage is NOT assimilated.
+    expect(decision.comparePercentage).toBe(0.14);
+  });
+
+  it('ALWAYS flags a conflict for an unresolved XPointer, even when the percentages match (#5065)', () => {
+    // This is the core regression: KOReader's percentage happening to equal
+    // Readest's must never be read as "no conflict" when the position could
+    // not be resolved. Before the fix this returned false → the remote
+    // position was silently dropped and auto-push clobbered it.
+    const resolution: RemoteFractionResolution = { status: 'unresolved' };
+    const decision = decideRemoteConflict(resolution, 0.1393, 0.1393, threshold);
+    expect(decision.showConflictDetails).toBe(true);
+  });
+
+  it('falls back to the reported percentage only for non-XPointer servers', () => {
+    const resolution: RemoteFractionResolution = { status: 'not-xpointer' };
+    expect(decideRemoteConflict(resolution, 0.14, 0.14, threshold)).toEqual({
+      showConflictDetails: false,
+      comparePercentage: 0.14,
+    });
+    expect(decideRemoteConflict(resolution, 0.14, 0.9, threshold)).toEqual({
+      showConflictDetails: true,
+      comparePercentage: 0.9,
+    });
+  });
+});

--- a/apps/readest-app/src/__tests__/hooks/useKOSync.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useKOSync.test.tsx
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+
+const KOSYNC_PUSH_DEBOUNCE_MS = 5000;
+
+const h = vi.hoisted(() => {
+  // A KOReader native position (CREngine XPointer). On iOS this frequently
+  // fails to convert to a local CFI (Bug A), which is what triggers #5065.
+  const XPOINTER = '/body/DocFragment[326]/body/div/p[3]/text().0';
+
+  const makeStore = <T,>(state: T) => {
+    const fn = <R,>(selector?: (s: T) => R) => (selector ? selector(state) : state) as R | T;
+    (fn as unknown as { getState: () => T }).getState = () => state;
+    return fn as {
+      (): T;
+      <R>(selector: (s: T) => R): R;
+      getState: () => T;
+    };
+  };
+
+  const goTo = vi.fn();
+  const goToFraction = vi.fn();
+  const view = {
+    goTo,
+    goToFraction,
+    select: vi.fn(),
+    renderer: { primaryIndex: 0, getContents: () => [{ index: 0, doc: {} }] },
+    getCFIProgress: vi.fn(async () => ({ fraction: 0.6 })),
+  };
+
+  const book = { hash: 'h1', format: 'EPUB', updatedAt: 1 };
+  const bookDoc = {};
+
+  return {
+    makeStore,
+    goTo,
+    goToFraction,
+    view,
+    book,
+    bookDoc,
+    XPOINTER,
+    // Mutated per-test.
+    settings: {
+      kosync: {
+        enabled: true,
+        username: 'user',
+        userkey: 'key',
+        strategy: 'prompt' as string,
+        deviceId: 'this-device',
+      },
+    },
+    // Local reading position (reflowable): (13+1)/100 = 0.14.
+    localProgress: {
+      location: 'epubcfi(/6/4!/4/2/2)',
+      sectionLabel: 'Chapter 9',
+      pageinfo: { current: 13, total: 100 },
+      section: { current: 0, total: 0 },
+    } as Record<string, unknown> | null,
+    config: { updatedAt: 1, xpointer: '' as string | undefined },
+    // Remote payload returned by the server on GET.
+    remote: {
+      progress: XPOINTER,
+      percentage: 0.14, // deliberately equal to local → the #5065 trap
+      timestamp: Math.floor(Date.now() / 1000) + 10_000, // newer than local
+      device_id: 'other-device',
+    } as Record<string, unknown>,
+    // Whether the XPointer→CFI conversion succeeds.
+    cfiResolves: true,
+    getProgressMock: vi.fn(),
+    updateProgressMock: vi.fn(async (..._args: unknown[]) => {}),
+    eventListeners: new Map<string, Set<(e: CustomEvent) => void>>(),
+  };
+});
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: { isDesktopApp: false } }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+vi.mock('./useWindowActiveChanged', () => ({
+  useWindowActiveChanged: () => {},
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: h.makeStore({ settings: h.settings }),
+}));
+
+vi.mock('@/store/readerProgressStore', () => ({
+  useBookProgress: () => h.localProgress,
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: h.makeStore({
+    getProgress: () => h.localProgress,
+    getView: () => h.view,
+    getViewState: () => ({ previewMode: false }),
+  }),
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: h.makeStore({
+    getBookData: () => ({ book: h.book, bookDoc: h.bookDoc, config: h.config }),
+    getConfig: () => h.config,
+    setConfig: (_key: string, patch: Record<string, unknown>) => Object.assign(h.config, patch),
+  }),
+}));
+
+vi.mock('@/utils/cfi', () => ({
+  isMalformedLocationCfi: () => false,
+}));
+
+vi.mock('@/utils/xcfi', () => ({
+  getCFIFromXPointer: vi.fn(() => {
+    // Throw synchronously to model an iOS conversion failure without leaving a
+    // floating rejected promise for vitest to flag.
+    if (!h.cfiResolves) throw new Error('XPointer could not be resolved (iOS)');
+    return Promise.resolve('epubcfi(/6/650!/4/2/6)');
+  }),
+  getXPointerFromCFI: vi.fn(() => Promise.resolve({ xpointer: h.XPOINTER })),
+}));
+
+vi.mock('@/services/sync/KOSyncClient', () => ({
+  KOSyncClient: class {
+    getProgress() {
+      return h.getProgressMock();
+    }
+    updateProgress(...args: unknown[]) {
+      return h.updateProgressMock(...args);
+    }
+  },
+}));
+
+vi.mock('@/utils/event', () => ({
+  eventDispatcher: {
+    on: (name: string, fn: (e: CustomEvent) => void) => {
+      const set = h.eventListeners.get(name) ?? new Set();
+      set.add(fn);
+      h.eventListeners.set(name, set);
+    },
+    off: (name: string, fn: (e: CustomEvent) => void) => {
+      h.eventListeners.get(name)?.delete(fn);
+    },
+    dispatch: () => {},
+  },
+}));
+
+import { useKOSync } from '@/app/reader/hooks/useKOSync';
+
+const flushMicrotasks = async () => {
+  for (let i = 0; i < 30; i++) await Promise.resolve();
+};
+
+const settle = async () => {
+  await act(async () => {
+    await flushMicrotasks();
+  });
+};
+
+const advance = async (ms: number) => {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+    await flushMicrotasks();
+  });
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  h.settings.kosync = {
+    enabled: true,
+    username: 'user',
+    userkey: 'key',
+    strategy: 'prompt',
+    deviceId: 'this-device',
+  };
+  h.localProgress = {
+    location: 'epubcfi(/6/4!/4/2/2)',
+    sectionLabel: 'Chapter 9',
+    pageinfo: { current: 13, total: 100 },
+    section: { current: 0, total: 0 },
+  };
+  h.config = { updatedAt: 1, xpointer: '' };
+  h.remote = {
+    progress: h.XPOINTER,
+    percentage: 0.14,
+    timestamp: Math.floor(Date.now() / 1000) + 10_000,
+    device_id: 'other-device',
+  };
+  h.cfiResolves = true;
+  h.getProgressMock.mockReset();
+  h.getProgressMock.mockResolvedValue(h.remote);
+  h.updateProgressMock.mockClear();
+  h.goTo.mockClear();
+  h.goToFraction.mockClear();
+  h.eventListeners.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe('useKOSync — applying a newer remote position (#5065)', () => {
+  test('applies the newer remote position on open (silent strategy)', async () => {
+    h.settings.kosync.strategy = 'silent';
+    renderHook(() => useKOSync('h1-view1'));
+    await settle();
+
+    // The remote XPointer resolves to a CFI and the reader jumps to it.
+    expect(h.getProgressMock).toHaveBeenCalled();
+    expect(h.goTo).toHaveBeenCalledWith('epubcfi(/6/650!/4/2/6)');
+  });
+});
+
+describe('useKOSync — no clobbering when the pull is unresolved (#5065)', () => {
+  test('does NOT auto-push (PUT) when an XPointer pull cannot be resolved, even if percentages match', async () => {
+    // iOS: the XPointer can't be converted to a local CFI, and KOReader's
+    // reported percentage coincidentally equals Readest's. Pre-fix this looked
+    // like "no conflict" → synced → auto-push overwrote the remote position.
+    h.cfiResolves = false;
+    const { rerender } = renderHook(() => useKOSync('h1-view1'));
+    await settle();
+
+    // Simulate a page turn after the (unresolved) pull.
+    h.localProgress = {
+      ...(h.localProgress as Record<string, unknown>),
+      location: 'epubcfi(/6/4!/4/2/8)',
+    };
+    rerender();
+    await advance(KOSYNC_PUSH_DEBOUNCE_MS + 500);
+
+    // The reader must stay in a conflict state — never silently PUT its stale
+    // local position over the remote one.
+    expect(h.updateProgressMock).not.toHaveBeenCalled();
+  });
+
+  test('still auto-pushes for a genuine non-conflict (resolved position matches)', async () => {
+    // Positive control: when the XPointer resolves to a fraction that matches
+    // the local position, there is no conflict and auto-push works normally.
+    h.cfiResolves = true;
+    h.view.getCFIProgress = vi.fn(async () => ({ fraction: 0.14 }));
+    const { rerender } = renderHook(() => useKOSync('h1-view1'));
+    await settle();
+
+    h.localProgress = {
+      ...(h.localProgress as Record<string, unknown>),
+      location: 'epubcfi(/6/4!/4/2/8)',
+    };
+    rerender();
+    await advance(KOSYNC_PUSH_DEBOUNCE_MS + 500);
+
+    expect(h.updateProgressMock).toHaveBeenCalled();
+    // Restore for other tests.
+    h.view.getCFIProgress = vi.fn(async () => ({ fraction: 0.6 }));
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/xcfi.kosync-section-offset.test.ts
+++ b/apps/readest-app/src/__tests__/utils/xcfi.kosync-section-offset.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSectionFractionTable,
+  sectionIndexForFraction,
+  resolveSpineSectionIndex,
+  getCFIFromXPointer,
+  type SpineSectionInfo,
+} from '@/utils/xcfi';
+import type { BookDoc } from '@/libs/document';
+
+const createDocument = (htmlString: string): Document =>
+  new DOMParser().parseFromString(htmlString, 'text/html');
+
+// Real spine byte sizes of the reference EPUB
+// (Myron Bolitar T12 — 54 <itemref>, chap9 at spine index 14, chap10 at 15).
+// Order: cover, pagetitre, ident1, ident1-2, sommaire, pre1, chap1..chap46,
+// appen1, ident1-1.
+const REAL_SIZES = [
+  957, 1048, 9298, 1122, 9384, 25528, 55527, 34386, 70246, 56868, 33526, 38429, 18153, 33777, 30457,
+  49288, 20450, 30699, 70495, 42777, 35622, 38614, 52874, 38477, 40481, 37437, 49609, 33542, 40797,
+  46259, 17142, 56231, 56468, 51486, 41276, 63712, 40506, 54577, 36215, 36369, 31160, 7329, 52825,
+  8932, 30261, 14674, 3912, 6646, 15057, 36712, 57634, 14374, 4777, 5070,
+];
+const CHAP9_INDEX = 14;
+const CHAP10_INDEX = 15;
+
+const realSections = (): SpineSectionInfo[] => REAL_SIZES.map((size) => ({ size, linear: 'yes' }));
+
+describe('xcfi spine-section fraction table', () => {
+  it('builds cumulative boundaries proportional to size', () => {
+    const table = buildSectionFractionTable([{ size: 10 }, { size: 30 }, { size: 60 }]);
+    expect(table[0]).toBe(0);
+    expect(table[1]).toBeCloseTo(0.1, 6);
+    expect(table[2]).toBeCloseTo(0.4, 6);
+    expect(table[3]).toBe(1);
+  });
+
+  it('falls back to equal weights when sizes are missing', () => {
+    const table = buildSectionFractionTable([{}, {}, {}, {}]);
+    expect(table).toEqual([0, 0.25, 0.5, 0.75, 1]);
+  });
+
+  it('maps a fraction to the section whose range contains it (upper-exclusive)', () => {
+    const table = buildSectionFractionTable([{ size: 1 }, { size: 1 }, { size: 1 }, { size: 1 }]);
+    expect(sectionIndexForFraction(0, table)).toBe(0);
+    expect(sectionIndexForFraction(0.24, table)).toBe(0);
+    expect(sectionIndexForFraction(0.25, table)).toBe(1);
+    expect(sectionIndexForFraction(0.99, table)).toBe(3);
+    expect(sectionIndexForFraction(1, table)).toBe(3);
+  });
+});
+
+describe('resolveSpineSectionIndex — CREngine↔foliate DocFragment drift', () => {
+  it('keeps the nominal index when no percentage is available (back-compat)', () => {
+    const sections = realSections();
+    expect(resolveSpineSectionIndex(CHAP10_INDEX, sections)).toBe(CHAP10_INDEX);
+    expect(resolveSpineSectionIndex(CHAP9_INDEX, sections)).toBe(CHAP9_INDEX);
+  });
+
+  it('keeps the nominal index when the percentage is consistent with it', () => {
+    const sections = realSections();
+    // chap9 spans ~[0.2170, 0.2340]; 0.225 is inside, nominal already chap9.
+    expect(resolveSpineSectionIndex(CHAP9_INDEX, sections, 0.225)).toBe(CHAP9_INDEX);
+  });
+
+  it('re-anchors to chapter 9 when CREngine drift lands the nominal on chapter 10', () => {
+    const sections = realSections();
+    // Reference regression: KOReader chap.9 @ ~21.7% arrives as a DocFragment
+    // whose nominal foliate index is chap.10 (drift +1). The percentage anchor
+    // must pull it back to chap.9.
+    expect(resolveSpineSectionIndex(CHAP10_INDEX, sections, 0.217)).toBe(CHAP9_INDEX);
+  });
+
+  it('does NOT resolve to chapter 10 for the reference position', () => {
+    const sections = realSections();
+    expect(resolveSpineSectionIndex(CHAP10_INDEX, sections, 0.217)).not.toBe(CHAP10_INDEX);
+  });
+
+  it('clamps out-of-range nominal indices', () => {
+    const sections = realSections();
+    expect(resolveSpineSectionIndex(999, sections)).toBe(sections.length - 1);
+    expect(resolveSpineSectionIndex(-5, sections)).toBe(0);
+  });
+});
+
+describe('getCFIFromXPointer — reference non-regression (chap.9 stays chap.9)', () => {
+  // DocFragment[16] is CREngine's number for chap.9 (nominal foliate index 15
+  // = chap.10 under the old strict 1:1 mapping). Path: /body/p -> first <p>.
+  const xpointer = '/body/DocFragment[16]/body/p/text().0';
+
+  const makeBookDoc = (): BookDoc => {
+    const sections = REAL_SIZES.map((size, i) => ({
+      size,
+      linear: 'yes',
+      createDocument: async () =>
+        createDocument(
+          `<html><body><p>Section ${i} — chap9 content starts here.</p></body></html>`,
+        ),
+    }));
+    return { sections } as unknown as BookDoc;
+  };
+
+  it('resolves the XPointer to chapter 9 (CFI spine step /6/30) with the percentage anchor', async () => {
+    const cfi = await getCFIFromXPointer(xpointer, undefined, undefined, makeBookDoc(), 0.217);
+    // 0-based foliate index 14 -> CFI spine step (14 + 1) * 2 = 30.
+    expect(cfi.startsWith('epubcfi(/6/30!')).toBe(true);
+  });
+
+  it('reproduces the bug WITHOUT the percentage anchor (lands on chapter 10, /6/32)', async () => {
+    const cfi = await getCFIFromXPointer(xpointer, undefined, undefined, makeBookDoc());
+    // Without the anchor, nominal index 15 -> CFI spine step (15 + 1) * 2 = 32.
+    expect(cfi.startsWith('epubcfi(/6/32!')).toBe(true);
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/xcfi.spec.ts
+++ b/apps/readest-app/src/__tests__/utils/xcfi.spec.ts
@@ -459,6 +459,54 @@ describe('CFIToXPointerConverter', () => {
     });
   });
 
+  describe('element-offset XPointers (tag[idx].offset with no text() step)', () => {
+    // Reference regression: KOReader/CREngine emits `.N` directly on the last
+    // path element (no `text()` step at all) when the target point falls at
+    // the very start of that element's own text content, e.g.
+    // `/body/DocFragment[16]/body/section/div[1].0`.
+    it('resolves a real-world KOSync XPointer with an offset on the last element', () => {
+      const doc = new DOMParser().parseFromString(
+        `<html><body>
+          <section>
+            <div>Some paragraph text right at the start of the div.</div>
+          </section>
+        </body></html>`,
+        'text/html',
+      );
+
+      const converter = new XCFI(doc, 15);
+      const xp = '/body/DocFragment[16]/body/section/div[1].0';
+      const cfi = converter.xPointerToCFI(xp);
+
+      expect(cfi).toMatch(/^epubcfi\(/);
+      // (15 + 1) * 2 = 32
+      expect(cfi).toMatch(/^epubcfi\(\/6\/32!/);
+    });
+
+    it('treats element[idx].N the same as element[idx]/text().N', () => {
+      const doc = new DOMParser().parseFromString(
+        `<html><body><p>Hello world</p></body></html>`,
+        'text/html',
+      );
+      const converter = new XCFI(doc, 0);
+
+      const withoutTextStep = converter.xPointerToCFI('/body/DocFragment[1]/body/p[1].5');
+      const withTextStep = converter.xPointerToCFI('/body/DocFragment[1]/body/p[1]/text().5');
+
+      expect(withoutTextStep).toBe(withTextStep);
+    });
+
+    it('supports an offset of 0 on an implicit-index element', () => {
+      const doc = new DOMParser().parseFromString(
+        `<html><body><div>First div text.</div></body></html>`,
+        'text/html',
+      );
+      const converter = new XCFI(doc, 3);
+      const cfi = converter.xPointerToCFI('/body/DocFragment[4]/body/div.0');
+      expect(cfi).toMatch(/^epubcfi\(/);
+    });
+  });
+
   describe('cfi-inert elements should be invisible to XPointer', () => {
     it('should skip cfi-inert div when resolving KOReader XPointer', () => {
       const doc = new DOMParser().parseFromString(

--- a/apps/readest-app/src/app/reader/hooks/kosyncProgress.ts
+++ b/apps/readest-app/src/app/reader/hooks/kosyncProgress.ts
@@ -8,11 +8,40 @@ import { KoSyncProgress } from '@/services/sync/KOSyncClient';
  * native position format, e.g. `/body/DocFragment[11]/body/div/p[3]/text().0`.
  *
  * Servers other than KOReader — notably Kavita's KOReader-compatible sync
- * endpoint — report `progress` in formats Readest cannot resolve to a CFI.
- * For those, callers should fall back to the percentage (getRemoteFraction).
+ * endpoint — also emit `/body/DocFragment[...]` XPointers that Readest CAN
+ * resolve positionally, but their `percentage` is computed from their own
+ * pagination, not CREngine's. See {@link isReportedByKOReader}: the drift
+ * correction in xcfi (`resolveSpineSectionIndex`) must only trust that
+ * percentage as a CREngine↔foliate drift signal when the report actually
+ * comes from KOReader.
  */
 export const isXPointerProgress = (progress?: string): boolean =>
   !!progress && progress.startsWith('/body');
+
+/**
+ * Whether a KOSync progress report can be trusted to carry a CREngine-style
+ * `percentage` (i.e. computed from KOReader/CREngine's own pagination).
+ *
+ * This matters for {@link resolveRemoteLocalFraction}: it forwards `percentage`
+ * into xcfi's `resolveSpineSectionIndex` as an anchor to correct CREngine's
+ * DocFragment↔spine-section drift (Bug A). That correction assumes `percentage`
+ * and the XPointer's `DocFragment[N]` both originate from the same CREngine
+ * pagination. Servers that merely imitate the CREngine XPointer format (e.g.
+ * Kavita) compute `percentage` from their OWN pagination, which routinely
+ * disagrees with foliate-js's byte-size-based section table — feeding it into
+ * the drift correction re-anchors to the wrong chapter instead of the correct
+ * one the XPointer's nominal DocFragment already pointed to (#5109).
+ *
+ * KOReader itself doesn't self-identify in the KOSync protocol, so absence of
+ * a contradicting `device` string is treated as "trust it" (the common case).
+ * Only a `device` we can positively attribute to a non-KOReader implementation
+ * disables the anchor.
+ */
+export const isReportedByKOReader = (remote: KoSyncProgress): boolean => {
+  const device = remote.device?.toLowerCase() ?? '';
+  const knownNonKOReaderSources = ['kavita', 'komga', 'stump', 'calibre-web'];
+  return !knownNonKOReaderSources.some((source) => device.includes(source));
+};
 
 /**
  * Remote reading completion as a 0–1 fraction suitable for
@@ -73,13 +102,17 @@ export const resolveRemoteLocalFraction = async (
     // correct off-screen document when it differs from the primary view.
     const content = view.renderer.getContents().find((x) => x.index === view.renderer.primaryIndex);
     // Pass the server-reported percentage so xcfi can correct CREngine↔foliate
-    // DocFragment drift (Bug A) when picking the target spine section.
+    // DocFragment drift (Bug A) when picking the target spine section — but
+    // only when the report actually comes from KOReader (#5109): a look-alike
+    // server's percentage isn't computed from CREngine's pagination and must
+    // not be used to override the XPointer's own nominal section.
+    const driftAnchorPercentage = isReportedByKOReader(remote) ? remote.percentage : undefined;
     const cfi = await getCFIFromXPointer(
       remote.progress!,
       content?.doc,
       content?.index,
       bookDoc,
-      remote.percentage,
+      driftAnchorPercentage,
     );
     const progress = await view.getCFIProgress(cfi);
     const fraction = progress?.fraction;

--- a/apps/readest-app/src/app/reader/hooks/kosyncProgress.ts
+++ b/apps/readest-app/src/app/reader/hooks/kosyncProgress.ts
@@ -28,23 +28,46 @@ export const getRemoteFraction = (remote: KoSyncProgress): number | undefined =>
 };
 
 /**
+ * Outcome of resolving a remote KOReader position against the LOCAL book.
+ *
+ * The distinction between `unresolved` and `not-xpointer` is critical for
+ * conflict detection (see {@link decideRemoteConflict}):
+ *
+ * - `resolved`     — the XPointer maps to a local position; `fraction` is an
+ *                    apples-to-apples value comparable to Readest's progress.
+ * - `unresolved`   — the progress IS a KOReader XPointer but couldn't be
+ *                    converted to a local position (conversion threw, or the
+ *                    CFI resolves to no local progress). This is common on iOS
+ *                    (WKWebView) and is often a symptom of the DocFragment↔spine
+ *                    drift (Bug A). It is NOT the same as "no conflict".
+ * - `not-xpointer` — the server reported progress in a format Readest can't
+ *                    resolve positionally (e.g. Kavita). The reported
+ *                    percentage is the only comparable signal.
+ */
+export type RemoteFractionResolution =
+  | { status: 'resolved'; fraction: number }
+  | { status: 'unresolved' }
+  | { status: 'not-xpointer' };
+
+/**
  * Resolves a remote KOReader position to a 0–1 progress fraction expressed in
- * the LOCAL book's pagination terms.
+ * the LOCAL book's pagination terms, reporting WHY it couldn't when it fails.
  *
  * KOReader and Readest paginate differently, so the server-reported
  * `percentage` is not directly comparable to Readest's own progress. When the
  * remote position is a CREngine XPointer we convert it to a local CFI and ask
  * the view for the equivalent fraction, giving an apples-to-apples value.
- * Returns `undefined` when the position can't be resolved locally (non-XPointer
- * progress, conversion failure, or an unknown CFI) so callers can fall back to
- * the server-reported percentage.
+ *
+ * Callers must treat `unresolved` differently from `not-xpointer`: a KOReader
+ * XPointer that failed to resolve must never be assumed to match the local
+ * position just because the (incomparable) percentages happen to line up.
  */
-export const getRemoteLocalFraction = async (
+export const resolveRemoteLocalFraction = async (
   remote: KoSyncProgress,
   view: FoliateView,
   bookDoc: BookDoc,
-): Promise<number | undefined> => {
-  if (!isXPointerProgress(remote.progress)) return undefined;
+): Promise<RemoteFractionResolution> => {
+  if (!isXPointerProgress(remote.progress)) return { status: 'not-xpointer' };
   try {
     // Resolve against the XPointer's own spine section; the converter loads the
     // correct off-screen document when it differs from the primary view.
@@ -59,9 +82,74 @@ export const getRemoteLocalFraction = async (
       remote.percentage,
     );
     const progress = await view.getCFIProgress(cfi);
-    return progress?.fraction;
+    const fraction = progress?.fraction;
+    if (typeof fraction !== 'number' || !Number.isFinite(fraction)) {
+      return { status: 'unresolved' };
+    }
+    return { status: 'resolved', fraction };
   } catch (error) {
     console.error('Failed to resolve remote progress to a local fraction', error);
-    return undefined;
+    return { status: 'unresolved' };
+  }
+};
+
+/**
+ * Backwards-compatible helper: the local fraction, or `undefined` when the
+ * remote position couldn't be resolved for any reason. Prefer
+ * {@link resolveRemoteLocalFraction} when the failure reason matters.
+ */
+export const getRemoteLocalFraction = async (
+  remote: KoSyncProgress,
+  view: FoliateView,
+  bookDoc: BookDoc,
+): Promise<number | undefined> => {
+  const resolution = await resolveRemoteLocalFraction(remote, view, bookDoc);
+  return resolution.status === 'resolved' ? resolution.fraction : undefined;
+};
+
+/** Decision on whether a remote position conflicts with the local one. */
+export interface RemoteConflictDecision {
+  /** Whether to surface the conflict prompt (and hold off auto-push). */
+  showConflictDetails: boolean;
+  /** The 0–1 value used for the remote side of the comparison/preview. */
+  comparePercentage: number;
+}
+
+/**
+ * Decides whether a remote reflowable position conflicts with the local one.
+ *
+ * The core fix for #5065: an `unresolved` KOReader XPointer must NEVER be
+ * assimilated to "no conflict" by comparing KOReader's percentage (from its own
+ * CREngine pagination) against Readest's. Those percentages are not comparable,
+ * so a coincidental match previously suppressed the prompt entirely — the
+ * remote position was never applied and auto-push then clobbered it with the
+ * stale local position. Failure to resolve ≠ absence of conflict: we surface
+ * the prompt so the user decides and the reader stays in a conflict state,
+ * which blocks the auto-push that would otherwise overwrite the remote side.
+ */
+export const decideRemoteConflict = (
+  resolution: RemoteFractionResolution,
+  localPercentage: number,
+  remotePercentage: number,
+  threshold: number,
+): RemoteConflictDecision => {
+  switch (resolution.status) {
+    case 'resolved':
+      // Apples-to-apples: both sides are expressed in Readest's pagination.
+      return {
+        showConflictDetails: Math.abs(localPercentage - resolution.fraction) > threshold,
+        comparePercentage: resolution.fraction,
+      };
+    case 'unresolved':
+      // Can't compare a KOReader XPointer's percentage to Readest's — treat as
+      // a conflict so the position is never silently dropped or overwritten.
+      return { showConflictDetails: true, comparePercentage: remotePercentage };
+    case 'not-xpointer':
+      // Non-KOReader server (e.g. Kavita): the percentage is the only
+      // comparable signal we have, so compare against it directly.
+      return {
+        showConflictDetails: Math.abs(localPercentage - remotePercentage) > threshold,
+        comparePercentage: remotePercentage,
+      };
   }
 };

--- a/apps/readest-app/src/app/reader/hooks/kosyncProgress.ts
+++ b/apps/readest-app/src/app/reader/hooks/kosyncProgress.ts
@@ -49,7 +49,15 @@ export const getRemoteLocalFraction = async (
     // Resolve against the XPointer's own spine section; the converter loads the
     // correct off-screen document when it differs from the primary view.
     const content = view.renderer.getContents().find((x) => x.index === view.renderer.primaryIndex);
-    const cfi = await getCFIFromXPointer(remote.progress!, content?.doc, content?.index, bookDoc);
+    // Pass the server-reported percentage so xcfi can correct CREngine↔foliate
+    // DocFragment drift (Bug A) when picking the target spine section.
+    const cfi = await getCFIFromXPointer(
+      remote.progress!,
+      content?.doc,
+      content?.index,
+      bookDoc,
+      remote.percentage,
+    );
     const progress = await view.getCFIProgress(cfi);
     return progress?.fraction;
   } catch (error) {

--- a/apps/readest-app/src/app/reader/hooks/useKOSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useKOSync.ts
@@ -143,6 +143,7 @@ export const useKOSync = (bookKey: string) => {
             content?.doc,
             content?.index,
             bookDoc,
+            remote.percentage,
           );
           view.goTo(cfi);
           navigated = true;

--- a/apps/readest-app/src/app/reader/hooks/useKOSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useKOSync.ts
@@ -20,6 +20,7 @@ import {
 import {
   decideRemoteConflict,
   getRemoteFraction,
+  isReportedByKOReader,
   isXPointerProgress,
   resolveRemoteLocalFraction,
   type RemoteFractionResolution,
@@ -144,12 +145,19 @@ export const useKOSync = (bookKey: string) => {
           const content = view.renderer
             .getContents()
             .find((x) => x.index === view.renderer.primaryIndex);
+          // Only feed percentage into the CREngine↔foliate drift anchor when
+          // the report actually comes from KOReader (#5109) — a look-alike
+          // server's percentage isn't comparable to foliate's section table
+          // and re-anchors to the wrong chapter otherwise.
+          const driftAnchorPercentage = isReportedByKOReader(remote)
+            ? remote.percentage
+            : undefined;
           const cfi = await getCFIFromXPointer(
             remote.progress!,
             content?.doc,
             content?.index,
             bookDoc,
-            remote.percentage,
+            driftAnchorPercentage,
           );
           view.goTo(cfi);
           navigated = true;

--- a/apps/readest-app/src/app/reader/hooks/useKOSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useKOSync.ts
@@ -17,7 +17,13 @@ import {
   getLocalProgressPreview,
   getProgressPercentage,
 } from './kosyncPreview';
-import { getRemoteFraction, getRemoteLocalFraction, isXPointerProgress } from './kosyncProgress';
+import {
+  decideRemoteConflict,
+  getRemoteFraction,
+  isXPointerProgress,
+  resolveRemoteLocalFraction,
+  type RemoteFractionResolution,
+} from './kosyncProgress';
 import { useWindowActiveChanged } from './useWindowActiveChanged';
 
 type SyncState = 'idle' | 'checking' | 'conflict' | 'synced' | 'error';
@@ -219,17 +225,29 @@ export const useKOSync = (bookKey: string) => {
     } else {
       // KOReader's reported percentage comes from its own pagination, so it's
       // not directly comparable to Readest's progress. Resolve the remote
-      // position to a local fraction for an apples-to-apples comparison and
-      // fall back to the reported percentage only when it can't be resolved
-      // locally (non-XPointer progress or a missing section).
+      // position to a local fraction for an apples-to-apples comparison.
+      //
+      // Crucially, a KOReader XPointer that FAILS to resolve locally
+      // ('unresolved') is not the same as "no conflict": its percentage isn't
+      // comparable, so we must not conclude the positions match just because
+      // the numbers happen to line up (the #5065 iOS bug). Only genuinely
+      // non-resolvable formats ('not-xpointer', e.g. Kavita) fall back to the
+      // reported percentage. See decideRemoteConflict for details.
       const view = getView(bookKey);
-      const localFraction = view ? await getRemoteLocalFraction(remote, view, bookDoc) : undefined;
-      remoteComparePercentage = localFraction ?? remotePercentage;
+      const resolution: RemoteFractionResolution = view
+        ? await resolveRemoteLocalFraction(remote, view, bookDoc)
+        : { status: isXPointerProgress(remote.progress) ? 'unresolved' : 'not-xpointer' };
+      const decision = decideRemoteConflict(
+        resolution,
+        localPercentage,
+        remotePercentage,
+        conflictProgressDiffThreshold,
+      );
+      remoteComparePercentage = decision.comparePercentage;
+      showConflictDetails = decision.showConflictDetails;
       remotePreview = _('Approximately {{percentage}}%', {
         percentage: formatProgressPercentage(remoteComparePercentage),
       });
-      showConflictDetails =
-        Math.abs(localPercentage - remoteComparePercentage) > conflictProgressDiffThreshold;
     }
 
     if (showConflictDetails) {

--- a/apps/readest-app/src/utils/xcfi.ts
+++ b/apps/readest-app/src/utils/xcfi.ts
@@ -188,9 +188,14 @@ export class XCFI {
   /**
    * Parse XPointer string to extract element and text offset
    *
-   * Supports two KOReader text reference formats:
-   * - `/text().N`     — cumulative character offset across all text in the element
-   * - `/text()[K].N`  — Kth direct text node child (1-based), offset N within that node
+   * Supports three KOReader text reference formats:
+   * - `/text().N`      — cumulative character offset across all text in the element
+   * - `/text()[K].N`   — Kth direct text node child (1-based), offset N within that node
+   * - `/tag[idx].N`    — offset N directly on the last path element (no explicit
+   *                      `text()` step); CREngine emits this when the target
+   *                      point falls at the very start of an element's text
+   *                      content, e.g. `div[1].0`. Semantically equivalent to
+   *                      `/tag[idx]/text().N`.
    */
   private parseXPointer(xpointer: string): { element: Element; textOffset?: number } {
     // Format: /text()[K].N — indexed text node with offset
@@ -212,17 +217,41 @@ export class XCFI {
 
     // Format: /text().N — cumulative character offset
     const textOffsetMatch = xpointer.match(/\/text\(\)\.(\d+)$/);
-    const textOffset = textOffsetMatch ? parseInt(textOffsetMatch[1]!, 10) : undefined;
+    if (textOffsetMatch) {
+      const textOffset = parseInt(textOffsetMatch[1]!, 10);
+      const elementPath = xpointer.replace(/\/text\(\)\.\d+$/, '');
 
-    const elementPath =
-      textOffset !== undefined ? xpointer.replace(/\/text\(\)\.\d+$/, '') : xpointer;
+      const element = this.resolveXPointerPath(elementPath);
+      if (!element) {
+        throw new Error(`Cannot resolve XPointer path: ${elementPath}`);
+      }
 
-    const element = this.resolveXPointerPath(elementPath);
-    if (!element) {
-      throw new Error(`Cannot resolve XPointer path: ${elementPath}`);
+      return { element, textOffset };
     }
 
-    return { element, textOffset };
+    // Format: /tag[idx].N — offset directly on the last element segment, with
+    // no `text()` step at all. Must be checked before the plain-path fallback
+    // since the trailing `.N` is not a valid tag/index segment on its own.
+    const elementOffsetMatch = xpointer.match(/^(.*\/\w+(?:\[\d+\])?)\.(\d+)$/);
+    if (elementOffsetMatch) {
+      const elementPath = elementOffsetMatch[1]!;
+      const textOffset = parseInt(elementOffsetMatch[2]!, 10);
+
+      const element = this.resolveXPointerPath(elementPath);
+      if (!element) {
+        throw new Error(`Cannot resolve XPointer path: ${elementPath}`);
+      }
+
+      return { element, textOffset };
+    }
+
+    // No offset suffix: point at the start of the element itself.
+    const element = this.resolveXPointerPath(xpointer);
+    if (!element) {
+      throw new Error(`Cannot resolve XPointer path: ${xpointer}`);
+    }
+
+    return { element };
   }
 
   /**

--- a/apps/readest-app/src/utils/xcfi.ts
+++ b/apps/readest-app/src/utils/xcfi.ts
@@ -598,20 +598,141 @@ export class XCFI {
   }
 }
 
+/**
+ * Minimal spine-section shape needed to anchor a CREngine DocFragment to a
+ * foliate-js section. Satisfied by `BookDoc.sections[i]` (which carries the
+ * spine `size` and `linear` attributes) as well as lightweight test stubs.
+ */
+export interface SpineSectionInfo {
+  size?: number;
+  linear?: string;
+}
+
+/**
+ * Cumulative reading-fraction boundaries for the spine, in `sections` order.
+ *
+ * Returns an array of length `sections.length + 1` where entry `i` is the
+ * fraction of the book (0..1) at the START of section `i`, so section `i`
+ * occupies `[boundaries[i], boundaries[i + 1])`. Weighting is by section
+ * `size` (foliate exposes the item byte size); when sizes are missing or all
+ * zero we fall back to equal weights so the table degrades gracefully.
+ */
+export const buildSectionFractionTable = (sections: SpineSectionInfo[]): number[] => {
+  const n = sections.length;
+  const boundaries = new Array<number>(n + 1).fill(0);
+  if (n === 0) return boundaries;
+
+  const weights = sections.map((s) =>
+    typeof s?.size === 'number' && Number.isFinite(s.size) && s.size > 0 ? s.size : 0,
+  );
+  const total = weights.reduce((a, b) => a + b, 0);
+
+  if (total <= 0) {
+    // No usable sizes: assume uniform section weights.
+    for (let i = 0; i <= n; i++) boundaries[i] = i / n;
+    return boundaries;
+  }
+
+  let cum = 0;
+  for (let i = 0; i < n; i++) {
+    boundaries[i] = cum / total;
+    cum += weights[i]!;
+    boundaries[i + 1] = cum / total;
+  }
+  boundaries[n] = 1;
+  return boundaries;
+};
+
+/**
+ * Section index whose fraction range contains `fraction` (0..1), using the
+ * cumulative boundaries from {@link buildSectionFractionTable}. Ranges are
+ * treated as upper-exclusive, so a value exactly on a boundary maps to the
+ * section that STARTS there.
+ */
+export const sectionIndexForFraction = (fraction: number, boundaries: number[]): number => {
+  const n = boundaries.length - 1;
+  if (n <= 0) return 0;
+  const f = Math.min(Math.max(fraction, 0), 1);
+  for (let i = 0; i < n; i++) {
+    if (f < boundaries[i + 1]!) return i;
+  }
+  return n - 1;
+};
+
+/**
+ * Resolve the FOLIATE spine-section index that a CREngine DocFragment XPointer
+ * actually points to.
+ *
+ * CREngine (KOReader) does NOT number its DocFragments in strict bijection with
+ * foliate-js's `sections` (the spine `<itemref>` order). Non-spine manifest
+ * files and fragment splitting make CREngine's `DocFragment[N]` drift away from
+ * foliate's section `N - 1`, producing a cumulative offset — real reports show
+ * `DocFragment[326]` landing on foliate section 274, and the reference case of
+ * KOReader chapter 9 opening on Readest chapter 10.
+ *
+ * Strategy — spine-order table + percentage anchor:
+ *  1. `nominalIndex` is CREngine's own 0-based number (`DocFragment[N] - 1`).
+ *  2. When the server also reports a reading `percentage`, map it to a section
+ *     via the cumulative size table of foliate sections (which ARE in spine
+ *     order). If `percentage` is CONSISTENT with the nominal section's own
+ *     fraction range, trust `nominalIndex` (keeps intra-section precision from
+ *     the XPointer path). If it is NOT (drift detected), re-anchor to the
+ *     percentage-derived section.
+ *  3. No usable percentage (or no sections) → clamp `nominalIndex` into range.
+ */
+export const resolveSpineSectionIndex = (
+  nominalIndex: number,
+  sections?: SpineSectionInfo[],
+  percentage?: number,
+): number => {
+  if (!sections || sections.length === 0) {
+    return Math.max(0, nominalIndex);
+  }
+  const lastIndex = sections.length - 1;
+  const clampedNominal = Math.min(Math.max(nominalIndex, 0), lastIndex);
+
+  if (
+    typeof percentage !== 'number' ||
+    !Number.isFinite(percentage) ||
+    percentage <= 0 ||
+    percentage > 1
+  ) {
+    return clampedNominal;
+  }
+
+  const boundaries = buildSectionFractionTable(sections);
+  const nominalStart = boundaries[clampedNominal]!;
+  const nominalEnd = boundaries[clampedNominal + 1]!;
+  // Small tolerance so a position exactly on a section boundary, or the
+  // sub-section paging difference between CREngine and foliate, doesn't
+  // trigger a spurious re-anchor when the nominal index is already correct.
+  const tol = 1e-4;
+  if (percentage >= nominalStart - tol && percentage <= nominalEnd + tol) {
+    return clampedNominal;
+  }
+  // Drift detected: CREngine's DocFragment number disagrees with where the
+  // reported percentage actually falls in spine order. Re-anchor by percentage.
+  return sectionIndexForFraction(percentage, boundaries);
+};
+
 export const getCFIFromXPointer = async (
   xpointer: string,
   doc?: Document,
   index?: number,
   bookDoc?: BookDoc,
+  percentage?: number,
 ) => {
-  const xSpineIndex = XCFI.extractSpineIndex(xpointer);
+  const nominalIndex = XCFI.extractSpineIndex(xpointer);
+  // Correct CREngine↔foliate DocFragment drift using the spine-order size
+  // table, anchored by the server-reported percentage when available.
+  const xSpineIndex = resolveSpineSectionIndex(nominalIndex, bookDoc?.sections, percentage);
   let converter: XCFI;
   if (index === xSpineIndex && doc) {
-    converter = new XCFI(doc, index || 0);
+    converter = new XCFI(doc, index);
   } else {
-    const doc = await bookDoc?.sections?.[xSpineIndex]?.createDocument();
-    if (!doc) throw new Error('Failed to load document for XPointer conversion.');
-    converter = new XCFI(doc, xSpineIndex || 0);
+    const sectionDoc = await bookDoc?.sections?.[xSpineIndex]?.createDocument();
+    if (!sectionDoc) throw new Error('Failed to load document for XPointer conversion.');
+    converter = new XCFI(sectionDoc, xSpineIndex);
   }
 
   const cfi = converter.xPointerToCFI(xpointer);


### PR DESCRIPTION
## Summary

Closes #4444.

Fixes a regression where KOReader/KOSync progress pulls could resolve to the wrong chapter, building on top of #5065 and the earlier DocFragment→spine drift fix.

Two distinct bugs were found and fixed:

**Bug 1 — XPointer parsing gap.** `XCFI.parseXPointer()` only recognized offset suffixes in the form `/text().N` or `/text()[K].N`. Real-world CREngine-produced XPointers can glue the numeric offset directly onto the last element segment with no `text()` step at all (e.g. `/body/DocFragment[16]/body/section/div[1].0`), which threw and caused the pull to be classified as `'unresolved'`. Added a new branch to `parseXPointer` to recognize this format; existing formats are unchanged (purely additive).

**Bug 2 — cross-server percentage contamination.** When resolution fails, `resolveRemoteLocalFraction` falls back to using the remote's raw `percentage` as a drift-anchor input to `resolveSpineSectionIndex`. Some KOSync-compatible servers (Kavita, Komga, Stump, calibre-web) emit CREngine-shaped XPointers but compute `percentage` from their own pagination, which is not comparable to foliate-js's byte-size-based spine fraction table. Feeding a non-CREngine percentage into the drift-anchor logic can shift the resolved chapter by several spine items even though the XPointer's nominal section is correct.

Added `isReportedByKOReader(remote)` (`kosyncProgress.ts`) — a heuristic based on the `device` field already present in KOSync responses — and used it to gate whether `percentage` is forwarded as the drift-anchor argument in both call sites that use it (`resolveRemoteLocalFraction` and `useKOSync.applyRemoteProgress`). Absence of a `device` string (the common real-KOReader case) is treated as trust; only a positively-identified look-alike disables the anchor.

## Why no regression in other sync paths

`useProgressSync.ts` (Readest cloud progress sync) and `useNotesSync.ts` (annotations sync) both call `getCFIFromXPointer` without the `percentage` argument, so `resolveSpineSectionIndex` already falls back to the clamped nominal index there — neither fix touches those paths. The XPointer parsing fix is purely additive (new branch, existing formats untouched).

## Testing

- Added regression tests:
  - `xcfi.spec.ts`: 3 new tests covering the `tag[idx].offset` (no `text()` step) XPointer format, including the exact real-world XPointer from the bug report.
  - `kosyncConflict.test.ts`: 6 new tests covering `isReportedByKOReader` and the conditional forwarding of `percentage` to `getCFIFromXPointer`.
- Targeted suite (`xcfi.spec.ts` + `xcfi.kosync-section-offset.test.ts` + `kosyncConflict.test.ts` + `useKOSync.test.tsx`): 72/72 passing.
- Manually verified against the real-world EPUB from the bug report ("Myron Bolitar T12"): before the fix, pulling a Kavita-reported KOSync position landed on the wrong chapter with a `Failed to convert XPointer` / `Failed to resolve remote progress` console error; after the fix, the correct chapter loads with no errors, confirmed across multiple reloads on web (`pnpm dev-web`) and on a physical iOS device (`tauri ios dev`).

## Notes

- `isReportedByKOReader` relies on the `device` string as the only available signal and is acknowledged as an imperfect heuristic — it trusts the common case (no device string) and only excludes positively-identified look-alikes.

