### PR TITLE
fix(settings): keep the screen awake only while reading (#5104)

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2042,5 +2042,6 @@
   "{{hours}}h left": "بقيت {{hours}} ساعة",
   "Time Remaining": "الوقت المتبقي",
   "Theme": "السمة",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "متصل باسم {{account}}. اجعل {{provider}} مزود السحابة النشط."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "متصل باسم {{account}}. اجعل {{provider}} مزود السحابة النشط.",
+  "Only while reading": "أثناء القراءة فقط"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1902,5 +1902,6 @@
   "{{hours}}h left": "{{hours}} ঘণ্টা বাকি",
   "Time Remaining": "অবশিষ্ট সময়",
   "Theme": "থিম",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} হিসেবে সংযুক্ত। {{provider}}-কে সক্রিয় ক্লাউড প্রদানকারী করুন।"
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} হিসেবে সংযুক্ত। {{provider}}-কে সক্রিয় ক্লাউড প্রদানকারী করুন।",
+  "Only while reading": "শুধু পড়ার সময়"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1867,5 +1867,6 @@
   "{{hours}}h left": "ད་དུང་ {{hours}} ཆུ་ཚོད་ལྷག་ཡོད།",
   "Time Remaining": "ལྷག་ཡོད་པའི་དུས་ཚོད།",
   "Theme": "བརྗོད་བྱ།",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} ཐོག་ནས་འབྲེལ་མཐུད་ཟིན། {{provider}} དེ་སྤྱོད་བཞིན་པའི་སྤྲིན་ཞབས་ཞུ་མཁོ་སྤྲོད་པར་སྒྲིག་པ།"
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} ཐོག་ནས་འབྲེལ་མཐུད་ཟིན། {{provider}} དེ་སྤྱོད་བཞིན་པའི་སྤྲིན་ཞབས་ཞུ་མཁོ་སྤྲོད་པར་སྒྲིག་པ།",
+  "Only while reading": "ཀློག་པའི་སྐབས་སུ་ཁོ་ན།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1902,5 +1902,6 @@
   "{{hours}}h left": "{{hours}} Std. verbleibend",
   "Time Remaining": "Verbleibende Zeit",
   "Theme": "Thema",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Verbunden als {{account}}. {{provider}} als aktiven Cloud-Anbieter festlegen."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Verbunden als {{account}}. {{provider}} als aktiven Cloud-Anbieter festlegen.",
+  "Only while reading": "Nur während des Lesens"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1902,5 +1902,6 @@
   "{{hours}}h left": "απομένουν {{hours}} ώρες",
   "Time Remaining": "Υπολειπόμενος χρόνος",
   "Theme": "Θέμα",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Έχετε συνδεθεί ως {{account}}. Ορίστε το {{provider}} ως ενεργό πάροχο cloud."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Έχετε συνδεθεί ως {{account}}. Ορίστε το {{provider}} ως ενεργό πάροχο cloud.",
+  "Only while reading": "Μόνο κατά την ανάγνωση"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1937,5 +1937,6 @@
   "{{minutes}}m left": "{{minutes}} min restantes",
   "{{hours}}h left": "{{hours}} h restantes",
   "Theme": "Tema",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Conectado como {{account}}. Haz que {{provider}} sea el proveedor de nube activo."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Conectado como {{account}}. Haz que {{provider}} sea el proveedor de nube activo.",
+  "Only while reading": "Solo durante la lectura"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1902,5 +1902,6 @@
   "{{hours}}h left": "{{hours}} ساعت باقی‌مانده",
   "Time Remaining": "زمان باقی‌مانده",
   "Theme": "تم",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "متصل به‌عنوان {{account}}. {{provider}} را ارائه‌دهنده فعال ابری قرار دهید."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "متصل به‌عنوان {{account}}. {{provider}} را ارائه‌دهنده فعال ابری قرار دهید.",
+  "Only while reading": "فقط هنگام مطالعه"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1937,5 +1937,6 @@
   "{{hours}}h left": "{{hours}} h restant",
   "Time Remaining": "Temps restant",
   "Theme": "Thème",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Connecté en tant que {{account}}. Faites de {{provider}} le fournisseur cloud actif."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Connecté en tant que {{account}}. Faites de {{provider}} le fournisseur cloud actif.",
+  "Only while reading": "Uniquement pendant la lecture"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1937,5 +1937,6 @@
   "{{hours}}h left": "נותרו {{hours}} שעות",
   "Time Remaining": "זמן שנותר",
   "Theme": "ערכת נושא",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "מחובר כ-{{account}}. הפוך את {{provider}} לספק הענן הפעיל."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "מחובר כ-{{account}}. הפוך את {{provider}} לספק הענן הפעיל.",
+  "Only while reading": "רק בזמן הקריאה"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1902,5 +1902,6 @@
   "{{hours}}h left": "{{hours}} घंटे शेष",
   "Time Remaining": "शेष समय",
   "Theme": "थीम",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} के रूप में कनेक्टेड। {{provider}} को सक्रिय क्लाउड प्रदाता बनाएं।"
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} के रूप में कनेक्टेड। {{provider}} को सक्रिय क्लाउड प्रदाता बनाएं।",
+  "Only while reading": "केवल पढ़ते समय"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1902,5 +1902,6 @@
   "{{hours}}h left": "{{hours}} óra van hátra",
   "Time Remaining": "Hátralévő idő",
   "Theme": "Téma",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Csatlakozva mint {{account}}. Tegye a {{provider}}-ot az aktív felhőszolgáltatóvá."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Csatlakozva mint {{account}}. Tegye a {{provider}}-ot az aktív felhőszolgáltatóvá.",
+  "Only while reading": "Csak olvasás közben"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1867,5 +1867,6 @@
   "{{hours}}h left": "{{hours}} jam tersisa",
   "Time Remaining": "Sisa waktu",
   "Theme": "Tema",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Terhubung sebagai {{account}}. Jadikan {{provider}} penyedia cloud yang aktif."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Terhubung sebagai {{account}}. Jadikan {{provider}} penyedia cloud yang aktif.",
+  "Only while reading": "Hanya saat membaca"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1937,5 +1937,6 @@
   "{{hours}}h left": "{{hours}} h rimaste",
   "Time Remaining": "Tempo rimanente",
   "Theme": "Tema",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Collegato come {{account}}. Imposta {{provider}} come provider cloud attivo."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Collegato come {{account}}. Imposta {{provider}} come provider cloud attivo.",
+  "Only while reading": "Solo durante la lettura"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1867,5 +1867,6 @@
   "{{hours}}h left": "残り{{hours}}時間",
   "Time Remaining": "残り時間",
   "Theme": "テーマ",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} として接続済み。{{provider}} を使用するクラウドプロバイダーに設定します。"
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} として接続済み。{{provider}} を使用するクラウドプロバイダーに設定します。",
+  "Only while reading": "読書中のみ"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1867,5 +1867,6 @@
   "{{hours}}h left": "{{hours}}시간 남음",
   "Time Remaining": "남은 시간",
   "Theme": "테마",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}}(으)로 연결됨. {{provider}}를 사용할 클라우드 제공업체로 설정합니다."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}}(으)로 연결됨. {{provider}}를 사용할 클라우드 제공업체로 설정합니다.",
+  "Only while reading": "독서 중에만"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1867,5 +1867,6 @@
   "{{hours}}h left": "{{hours}} jam lagi",
   "Time Remaining": "Masa berbaki",
   "Theme": "Tema",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Disambungkan sebagai {{account}}. Jadikan {{provider}} sebagai penyedia awan yang aktif."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Disambungkan sebagai {{account}}. Jadikan {{provider}} sebagai penyedia awan yang aktif.",
+  "Only while reading": "Hanya semasa membaca"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1902,5 +1902,6 @@
   "{{hours}}h left": "Nog {{hours}} u",
   "Time Remaining": "Resterende tijd",
   "Theme": "Thema",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Verbonden als {{account}}. Maak {{provider}} de actieve cloudprovider."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Verbonden als {{account}}. Maak {{provider}} de actieve cloudprovider.",
+  "Only while reading": "Alleen tijdens het lezen"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1972,5 +1972,6 @@
   "{{hours}}h left": "Pozostało {{hours}} godz.",
   "Time Remaining": "Pozostały czas",
   "Theme": "Motyw",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Połączono jako {{account}}. Ustaw {{provider}} jako aktywnego dostawcę chmury."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Połączono jako {{account}}. Ustaw {{provider}} jako aktywnego dostawcę chmury.",
+  "Only while reading": "Tylko podczas czytania"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1937,5 +1937,6 @@
   "{{hours}}h left": "{{hours}} h restantes",
   "Time Remaining": "Tempo restante",
   "Theme": "Tema",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Conectado como {{account}}. Torne o {{provider}} o provedor de nuvem ativo."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Conectado como {{account}}. Torne o {{provider}} o provedor de nuvem ativo.",
+  "Only while reading": "Apenas durante a leitura"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1937,5 +1937,6 @@
   "{{hours}}h left": "{{hours}} h restantes",
   "Time Remaining": "Tempo restante",
   "Theme": "Tema",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Ligado como {{account}}. Torne o {{provider}} o fornecedor de nuvem ativo."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Ligado como {{account}}. Torne o {{provider}} o fornecedor de nuvem ativo.",
+  "Only while reading": "Apenas durante a leitura"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1937,5 +1937,6 @@
   "{{hours}}h left": "Au rămas {{hours}} h",
   "Time Remaining": "Timp rămas",
   "Theme": "Temă",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Conectat ca {{account}}. Setează {{provider}} ca furnizor de cloud activ."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Conectat ca {{account}}. Setează {{provider}} ca furnizor de cloud activ.",
+  "Only while reading": "Doar în timpul citirii"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1972,5 +1972,6 @@
   "{{hours}}h left": "Осталось {{hours}} ч",
   "Time Remaining": "Оставшееся время",
   "Theme": "Тема",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Подключено как {{account}}. Сделать {{provider}} активным облачным провайдером."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Подключено как {{account}}. Сделать {{provider}} активным облачным провайдером.",
+  "Only while reading": "Только во время чтения"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1902,5 +1902,6 @@
   "{{hours}}h left": "පැය {{hours}} ක් ඉතිරි",
   "Time Remaining": "ඉතිරි කාලය",
   "Theme": "තේමාව",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} ලෙස සම්බන්ධ වී ඇත. {{provider}} සක්‍රිය cloud සපයන්නා ලෙස සකසන්න."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} ලෙස සම්බන්ධ වී ඇත. {{provider}} සක්‍රිය cloud සපයන්නා ලෙස සකසන්න.",
+  "Only while reading": "කියවීමේදී පමණි"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1972,5 +1972,6 @@
   "{{hours}}h left": "Še {{hours}} h",
   "Time Remaining": "Preostali čas",
   "Theme": "Tema",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Povezano kot {{account}}. Nastavite {{provider}} kot aktivnega ponudnika oblaka."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Povezano kot {{account}}. Nastavite {{provider}} kot aktivnega ponudnika oblaka.",
+  "Only while reading": "Samo med branjem"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1902,5 +1902,6 @@
   "{{hours}}h left": "{{hours}} h kvar",
   "Time Remaining": "Återstående tid",
   "Theme": "Tema",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Ansluten som {{account}}. Gör {{provider}} till aktiv molnleverantör."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Ansluten som {{account}}. Gör {{provider}} till aktiv molnleverantör.",
+  "Only while reading": "Endast under läsning"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1902,5 +1902,6 @@
   "{{hours}}h left": "{{hours}} மணி நேரம் மீதம்",
   "Time Remaining": "மீதமுள்ள நேரம்",
   "Theme": "தீம்",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} ஆக இணைக்கப்பட்டுள்ளது. {{provider}} ஐ செயலில் உள்ள cloud வழங்குநராக அமைக்கவும்."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} ஆக இணைக்கப்பட்டுள்ளது. {{provider}} ஐ செயலில் உள்ள cloud வழங்குநராக அமைக்கவும்.",
+  "Only while reading": "வாசிக்கும் போது மட்டும்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1867,5 +1867,6 @@
   "{{hours}}h left": "เหลือ {{hours}} ชม.",
   "Time Remaining": "เวลาที่เหลือ",
   "Theme": "ธีม",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "เชื่อมต่อในชื่อ {{account}} ตั้งให้ {{provider}} เป็นผู้ให้บริการคลาวด์ที่ใช้งานอยู่"
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "เชื่อมต่อในชื่อ {{account}} ตั้งให้ {{provider}} เป็นผู้ให้บริการคลาวด์ที่ใช้งานอยู่",
+  "Only while reading": "เฉพาะขณะอ่าน"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1902,5 +1902,6 @@
   "{{hours}}h left": "{{hours}} sa kaldı",
   "Time Remaining": "Kalan süre",
   "Theme": "Tema",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} olarak bağlanıldı. {{provider}}'ı etkin bulut sağlayıcısı yapın."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} olarak bağlanıldı. {{provider}}'ı etkin bulut sağlayıcısı yapın.",
+  "Only while reading": "Yalnızca okurken"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1972,5 +1972,6 @@
   "{{hours}}h left": "Залишилось {{hours}} год",
   "Time Remaining": "Час, що залишився",
   "Theme": "Тема",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Під'єднано як {{account}}. Зробити {{provider}} активним хмарним провайдером."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Під'єднано як {{account}}. Зробити {{provider}} активним хмарним провайдером.",
+  "Only while reading": "Лише під час читання"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1902,5 +1902,6 @@
   "{{hours}}h left": "{{hours}} soat qoldi",
   "Time Remaining": "Qolgan vaqt",
   "Theme": "Mavzu",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} sifatida ulangan. {{provider}}-ni faol bulut provayderi qiling."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} sifatida ulangan. {{provider}}-ni faol bulut provayderi qiling.",
+  "Only while reading": "Faqat oʻqish paytida"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1867,5 +1867,6 @@
   "{{hours}}h left": "Còn {{hours}} giờ",
   "Time Remaining": "Thời gian còn lại",
   "Theme": "Chủ đề",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Đã kết nối với tư cách {{account}}. Đặt {{provider}} làm nhà cung cấp đám mây đang hoạt động."
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Đã kết nối với tư cách {{account}}. Đặt {{provider}} làm nhà cung cấp đám mây đang hoạt động.",
+  "Only while reading": "Chỉ khi đang đọc"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1867,5 +1867,6 @@
   "{{hours}}h left": "{{hours}}小时",
   "Time Remaining": "剩余时间",
   "Theme": "主题",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "已以 {{account}} 身份连接。将 {{provider}} 设为当前使用的云服务提供商。"
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "已以 {{account}} 身份连接。将 {{provider}} 设为当前使用的云服务提供商。",
+  "Only while reading": "仅在阅读时"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1867,5 +1867,6 @@
   "{{hours}}h left": "{{hours}}小時",
   "Time Remaining": "剩餘時間",
   "Theme": "主題",
-  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "已以 {{account}} 身分連線。將 {{provider}} 設為目前使用的雲端服務供應商。"
+  "Connected as {{account}}. Make {{provider}} the active cloud provider.": "已以 {{account}} 身分連線。將 {{provider}} 設為目前使用的雲端服務供應商。",
+  "Only while reading": "僅在閱讀時"
 }

--- a/apps/readest-app/src/__tests__/hooks/useScreenWakeLock-scope.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useScreenWakeLock-scope.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { relative, resolve } from 'path';
+
+/**
+ * Regression guard for issue #5104 ("Keep Screen Awake" outside the reader).
+ *
+ * The setting is meant to hold the screen awake while reading. The library page
+ * used to acquire the wake lock too, so a device parked on the home screen — or
+ * on any library menu — never slept.
+ *
+ * Invariant: the reader is the only place that acquires the wake lock. Any new
+ * call site outside `src/app/reader/` re-opens the bug.
+ */
+const SRC = resolve(process.cwd(), 'src');
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(dir, entry.name);
+    if (entry.isDirectory()) return entry.name === '__tests__' ? [] : walk(path);
+    return /\.tsx?$/.test(entry.name) ? [path] : [];
+  });
+
+describe('screen wake lock scope', () => {
+  const callSites = walk(SRC)
+    .filter((path) => !path.endsWith('hooks/useScreenWakeLock.ts'))
+    .filter((path) => /useScreenWakeLock\(/.test(readFileSync(path, 'utf8')))
+    .map((path) => relative(SRC, path));
+
+  it('is acquired while reading', () => {
+    expect(callSites).toContain('app/reader/components/Reader.tsx');
+  });
+
+  it('is not acquired outside the reader', () => {
+    expect(callSites.filter((path) => !path.startsWith('app/reader/'))).toEqual([]);
+  });
+});

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -56,7 +56,6 @@ import { useInboxDrainer } from '@/hooks/useInboxDrainer';
 import { useOPDSSubscriptions } from '@/hooks/useOPDSSubscriptions';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useTransferStore } from '@/store/transferStore';
-import { useScreenWakeLock } from '@/hooks/useScreenWakeLock';
 import { useBackgroundTexture } from '@/hooks/useBackgroundTexture';
 import { getLibraryViewSettings } from '@/helpers/settings';
 import { useAppUrlIngress } from '@/hooks/useAppUrlIngress';
@@ -332,8 +331,6 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
       checkOPDSSubscriptions(true);
     },
   );
-  useScreenWakeLock(settings.screenWakeLock);
-
   useShortcuts({
     onToggleFullscreen: async () => {
       if (isTauriAppPlatform()) {

--- a/apps/readest-app/src/components/settings/ControlPanel.tsx
+++ b/apps/readest-app/src/components/settings/ControlPanel.tsx
@@ -506,6 +506,7 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
         )}
         <SettingsSwitchRow
           label={_('Keep Screen Awake')}
+          description={_('Only while reading')}
           checked={screenWakeLock}
           onChange={() => setScreenWakeLock(!screenWakeLock)}
           data-setting-id='settings.control.screenWakeLock'


### PR DESCRIPTION
Closes #5104.

## Problem

`useScreenWakeLock(settings.screenWakeLock)` was called from two places: the reader (`src/app/reader/components/Reader.tsx`) and the library home page (`src/app/library/page.tsx`). With "Keep Screen Awake" enabled, the library copy held the wake lock while the app sat on the home screen or in any library menu, so a device left there never slept. The original feature (#403) was scoped to reading.

## Changes

- Drop the wake lock from the library page, so it is acquired only by the reader. Both reader entry points (app router and the web pages router at `pages/reader/[ids].tsx`) mount `Reader.tsx`, and the hook's cleanup releases the lock when the reader unmounts on navigation back to the library.
- Add an "Only while reading" description under the toggle in `ControlPanel.tsx`. The setting lives in a global settings panel reachable from the library, so the scope should be visible where it is toggled. Translations added to all 33 locales.
- Add `src/__tests__/hooks/useScreenWakeLock-scope.test.ts`, a static guard asserting the reader is the only call site, so a new one outside `src/app/reader/` cannot silently re-open the bug.

Note this also stops the wake lock in the desktop library window, matching the issue title and the original feature intent.

## Verification

- `pnpm test`: 7345 passed, 9 skipped. The new test was confirmed failing (naming `app/library/page.tsx`) before the fix.
- `pnpm lint` (tsgo + Biome) and `pnpm format:check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)