### PR TITLE
fix(sync): verify the sync passphrase and make a wrong one recoverable

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -1474,7 +1474,6 @@
   "Credentials": "بيانات الاعتماد",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "الرموز وأسماء المستخدمين وكلمات المرور لـ OPDS و KOReader و Hardcover و Readwise و WebDAV. عند التعطيل، تبقى بيانات الاعتماد على هذا الجهاز فقط ولا تُرفع أبدًا.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "تُشفَّر الحقول الحساسة المتزامنة قبل الرفع. عيّن عبارة مرور الآن أو لاحقًا عند الحاجة إلى التشفير.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "محفوظة في هذا الحساب. سيُطلب منك إدخالها عند فك تشفير بيانات الاعتماد.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "يختلف تقدم القراءة على هذا الجهاز عن «{{deviceName}}».",
   "This device": "هذا الجهاز",
   "Red": "أحمر",
@@ -1682,7 +1681,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "تم نسيان عبارة المرور للمزامنة. تم مسح جميع الحقول المشفرة.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "هل تريد حذف {{n}} كتاب/كتب من خادم WebDAV؟\n\nهذا يحذف الملفات البعيدة فقط؛ مكتبتك المحلية لن تتأثر. لا يمكن التراجع عن الحذف. البيانات على الخادم ستزول للأبد.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "عبارة مرور المزامنة غير صحيحة. تعذر فك تشفير بيانات الاعتماد المتزامنة.",
   "Email books straight to your library": "أرسل الكتب مباشرة إلى مكتبتك عبر البريد الإلكتروني",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "أعد توجيه المرفقات والمقالات إلى عنوان Readest الخاص بك. متوفر في خطط Plus وPro وLifetime.",
   "View plans": "عرض الخطط",
@@ -2043,5 +2041,11 @@
   "Time Remaining": "الوقت المتبقي",
   "Theme": "السمة",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "متصل باسم {{account}}. اجعل {{provider}} مزود السحابة النشط.",
-  "Only while reading": "أثناء القراءة فقط"
+  "Only while reading": "أثناء القراءة فقط",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "تم فتح القفل على هذا الجهاز. يجري فك تشفير بيانات الاعتماد المتزامنة.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "تم تعيينها لهذا الحساب. أدخلها على هذا الجهاز لفك تشفير بيانات الاعتماد المتزامنة.",
+  "Re-enter passphrase": "إعادة إدخال عبارة المرور",
+  "Enter passphrase": "إدخال عبارة المرور",
+  "Incorrect passphrase. Please try again.": "عبارة مرور غير صحيحة. يرجى المحاولة مرة أخرى.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "عبارة مرور المزامنة غير صحيحة. أعد إدخالها في الإعدادات لفتح بيانات الاعتماد."
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1374,7 +1374,6 @@
   "Credentials": "ক্রেডেনশিয়াল",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "OPDS, KOReader, Hardcover, Readwise এবং WebDAV-এর জন্য টোকেন, ব্যবহারকারীর নাম এবং পাসওয়ার্ড। নিষ্ক্রিয় থাকলে ক্রেডেনশিয়ালগুলি কেবল এই ডিভাইসেই থাকে এবং কখনই আপলোড হয় না।",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "সংবেদনশীল সিঙ্ক করা ক্ষেত্রগুলি আপলোডের আগে এনক্রিপ্ট করা হয়। এনক্রিপশনের প্রয়োজন হলে এখনই অথবা পরে একটি পাসফ্রেজ সেট করুন।",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "এই অ্যাকাউন্টে সংরক্ষিত। ক্রেডেনশিয়াল ডিক্রিপ্ট করার সময় আপনাকে এটি দিতে বলা হবে।",
   "Reading progress on this device differs from \"{{deviceName}}\".": "এই ডিভাইসে পড়ার অগ্রগতি \"{{deviceName}}\" থেকে আলাদা।",
   "This device": "এই ডিভাইস",
   "Red": "লাল",
@@ -1562,7 +1561,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "সিঙ্ক পাসফ্রেজ ভুলে যাওয়া হয়েছে। সমস্ত এনক্রিপ্ট করা ফিল্ড পরিষ্কার করা হয়েছে।",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "WebDAV সার্ভার থেকে {{n}}টি বই মুছে ফেলবেন?\n\nএটি শুধু রিমোট ফাইল মুছে; আপনার স্থানীয় লাইব্রেরি অপরিবর্তিত থাকে। মুছে ফেলা পূর্বাবস্থায় ফেরানো যাবে না। সার্ভারের ডেটা স্থায়ীভাবে চলে যাবে।",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "ভুল সিঙ্ক পাসফ্রেজ। সিঙ্ক করা ক্রেডেনশিয়াল ডিক্রিপ্ট করা যায়নি।",
   "Email books straight to your library": "ইমেইলের মাধ্যমে সরাসরি বই আপনার লাইব্রেরিতে পাঠান",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "অ্যাটাচমেন্ট এবং নিবন্ধগুলি আপনার ব্যক্তিগত Readest ঠিকানায় ফরওয়ার্ড করুন। Plus, Pro এবং Lifetime প্ল্যানে উপলব্ধ।",
   "View plans": "প্ল্যান দেখুন",
@@ -1903,5 +1901,11 @@
   "Time Remaining": "অবশিষ্ট সময়",
   "Theme": "থিম",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} হিসেবে সংযুক্ত। {{provider}}-কে সক্রিয় ক্লাউড প্রদানকারী করুন।",
-  "Only while reading": "শুধু পড়ার সময়"
+  "Only while reading": "শুধু পড়ার সময়",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "এই ডিভাইসে আনলক করা হয়েছে। আপনার সিঙ্ক করা শংসাপত্রগুলি ডিক্রিপ্ট করা হচ্ছে।",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "এই অ্যাকাউন্টে সেট করা আছে। সিঙ্ক করা শংসাপত্র ডিক্রিপ্ট করতে এই ডিভাইসে এটি লিখুন।",
+  "Re-enter passphrase": "পাসফ্রেজ আবার লিখুন",
+  "Enter passphrase": "পাসফ্রেজ লিখুন",
+  "Incorrect passphrase. Please try again.": "ভুল পাসফ্রেজ। অনুগ্রহ করে আবার চেষ্টা করুন।",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "সিঙ্ক পাসফ্রেজ ভুল। শংসাপত্র আনলক করতে সেটিংসে এটি আবার লিখুন।"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1349,7 +1349,6 @@
   "Credentials": "ངོས་སྦྱོར་ཆ་འཕྲིན།",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "OPDS, KOReader, Hardcover, Readwise, དང་ WebDAV བཅས་ཀྱི་ཐོ་ཀེན་དང་སྤྱོད་མི་མིང་དང་གསང་གྲངས། སྤོ་འཛུགས་མེད་པའི་སྐབས། ངོས་སྦྱོར་ཆ་འཕྲིན་ཡིག་ཆས་འདི་ཁོ་ནར་གནས་པ་དང་ནམ་ཡང་སྤོ་གཏོང་མི་བྱེད།",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "གཙོ་གནད་ཆགས་པའི་མཉམ་སྡེབ་ཐོ་ཁོངས་ཡིག་ཆ་སྤོ་གཏོང་མ་བྱས་སྔོན་ལ་གསང་སྦས་སུ་འགྱུར་བར་བཟོ། གསང་སྦས་དགོས་སྐབས་ད་ལྟ་འམ་ཕྱིས་སུ་གསང་ཚིག་ཕྲེང་གཅིག་སྒྲིག་འཛུགས་གནང་རོགས།",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "རྩིས་ཐོ་འདིར་ཉར་ཚགས་བྱས་ཡོད། ངོས་སྦྱོར་ཆ་འཕྲིན་ལ་གསང་སྦས་འགྲོལ་སྐབས་ཁྱེད་ལ་འདྲི་སློང་གནང་འགྱུར།",
   "Reading progress on this device differs from \"{{deviceName}}\".": "སྒྲིག་ཆས་འདིའི་ཀློག་འགྲོས་ནི་\"{{deviceName}}\"དང་མི་འདྲ།",
   "This device": "སྒྲིག་ཆས་འདི།",
   "Red": "དམར་པོ།",
@@ -1532,7 +1531,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "མཉམ་སྦྲེལ་གསང་ཨང་བརྗེད་སོང་། གསང་སྦས་བྱས་པའི་ཁོངས་གཙང་འཕྱག་བྱས་ཟིན།",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "WebDAV རིམ་པ་ཟུང་འབྲེལ་ནས་དཔེ་ཆ་{{n}}་སུབ་དགོས་སམ?\n\nའདིས་རྒྱང་རིང་གི་ཡིག་ཆ་ཁོ་ན་སུབ་པ་ཡིན། ཁྱེད་ཀྱི་ས་གནས་དཔེ་མཛོད་ལ་གནོད་མི་འགྱུར། སུབ་པ་འདི་ཕྱིར་ལོག་མི་ཐུབ། རིམ་པ་ཟུང་འབྲེལ་གྱི་ཟིན་བྲིས་གཏན་ནས་མེད་པར་འགྱུར།",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "མཉམ་སྦྲེལ་གསང་ཨང་ནོར་འདུག། མཉམ་སྦྲེལ་བྱས་པའི་ངོ་སྤྲོད་ཀྱི་གསང་སྒྲིག་འགྲོལ་མ་ཐུབ།",
   "Email books straight to your library": "གློག་འཕྲིན་གྱིས་དཔེ་ཆ་ཁྱེད་ཀྱི་དཔེ་མཛོད་དུ་ཐད་ཀར་སྐུར།",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "མཉམ་སྦྱར་དང་ཡིག་རྩོམ་ཁྱེད་ཀྱི་སྒེར་གྱི་ Readest ས་གནས་སུ་གཏོང་། Plus, Pro, Lifetime འཆར་གཞི་ལ་ཐོབ་པ།",
   "View plans": "འཆར་གཞི་ལ་ལྟ།",
@@ -1868,5 +1866,11 @@
   "Time Remaining": "ལྷག་ཡོད་པའི་དུས་ཚོད།",
   "Theme": "བརྗོད་བྱ།",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} ཐོག་ནས་འབྲེལ་མཐུད་ཟིན། {{provider}} དེ་སྤྱོད་བཞིན་པའི་སྤྲིན་ཞབས་ཞུ་མཁོ་སྤྲོད་པར་སྒྲིག་པ།",
-  "Only while reading": "ཀློག་པའི་སྐབས་སུ་ཁོ་ན།"
+  "Only while reading": "ཀློག་པའི་སྐབས་སུ་ཁོ་ན།",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "སྒྲིག་ཆས་འདིར་སྒོ་ཕྱེས་ཟིན། ཁྱེད་ཀྱི་མཉམ་སྦྱོར་དཔང་ཡིག་གསང་སྒྲོལ་བྱེད་བཞིན་ཡོད།",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "རྩིས་ཐོ་འདིར་བཙུགས་ཟིན། མཉམ་སྦྱོར་དཔང་ཡིག་གསང་སྒྲོལ་བྱེད་པར་སྒྲིག་ཆས་འདིར་འཇུག་རོགས།",
+  "Re-enter passphrase": "གསང་ཚིག་ཡང་བསྐྱར་འཇུག་པ།",
+  "Enter passphrase": "གསང་ཚིག་འཇུག་པ།",
+  "Incorrect passphrase. Please try again.": "གསང་ཚིག་ནོར་འདུག ཡང་བསྐྱར་ཚོད་ལྟ་བྱོས།",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "མཉམ་སྦྱོར་གསང་ཚིག་ནོར་འདུག སྒྲིག་སྟངས་ནང་ཡང་བསྐྱར་འཇུག་ནས་དཔང་ཡིག་སྒོ་ཕྱེ་རོགས།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1374,7 +1374,6 @@
   "Credentials": "Anmeldedaten",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Tokens, Benutzernamen und Passwörter für OPDS, KOReader, Hardcover, Readwise und WebDAV. Wenn deaktiviert, bleiben die Anmeldedaten nur auf diesem Gerät und werden nie hochgeladen.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Sensible synchronisierte Felder werden vor dem Hochladen verschlüsselt. Lege jetzt oder später eine Passphrase fest, wenn die Verschlüsselung benötigt wird.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "In diesem Konto gespeichert. Du wirst beim Entschlüsseln von Anmeldedaten danach gefragt.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Der Lesefortschritt auf diesem Gerät weicht von „{{deviceName}}“ ab.",
   "This device": "Dieses Gerät",
   "Red": "Rot",
@@ -1562,7 +1561,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Sync-Passphrase vergessen. Alle verschlüsselten Felder gelöscht.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "{{n}} Buch/Bücher vom WebDAV-Server löschen?\n\nDamit werden nur die Remote-Dateien entfernt; Ihre lokale Bibliothek bleibt unverändert. Das Löschen kann nicht rückgängig gemacht werden. Die Bytes auf dem Server sind dauerhaft verloren.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Falsche Sync-Passphrase. Synchronisierte Anmeldedaten konnten nicht entschlüsselt werden.",
   "Email books straight to your library": "Bücher direkt per E-Mail in Ihre Bibliothek senden",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Leiten Sie Anhänge und Artikel an Ihre private Readest-Adresse weiter. Verfügbar in den Plus-, Pro- und Lifetime-Tarifen.",
   "View plans": "Tarife anzeigen",
@@ -1903,5 +1901,11 @@
   "Time Remaining": "Verbleibende Zeit",
   "Theme": "Thema",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Verbunden als {{account}}. {{provider}} als aktiven Cloud-Anbieter festlegen.",
-  "Only while reading": "Nur während des Lesens"
+  "Only while reading": "Nur während des Lesens",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Auf diesem Gerät entsperrt. Ihre synchronisierten Zugangsdaten werden entschlüsselt.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Für dieses Konto festgelegt. Geben Sie sie auf diesem Gerät ein, um Ihre synchronisierten Zugangsdaten zu entschlüsseln.",
+  "Re-enter passphrase": "Passphrase erneut eingeben",
+  "Enter passphrase": "Passphrase eingeben",
+  "Incorrect passphrase. Please try again.": "Falsche Passphrase. Bitte versuchen Sie es erneut.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Falsche Sync-Passphrase. Geben Sie sie in den Einstellungen erneut ein, um Ihre Zugangsdaten zu entsperren."
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1374,7 +1374,6 @@
   "Credentials": "Διαπιστευτήρια",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Διακριτικά, ονόματα χρήστη και κωδικοί πρόσβασης για OPDS, KOReader, Hardcover, Readwise και WebDAV. Όταν είναι απενεργοποιημένο, τα διαπιστευτήρια παραμένουν μόνο σε αυτή τη συσκευή και δεν αποστέλλονται ποτέ.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Τα ευαίσθητα συγχρονισμένα πεδία κρυπτογραφούνται πριν τη μεταφόρτωση. Ορίστε μια φράση πρόσβασης τώρα ή αργότερα, όταν χρειαστεί η κρυπτογράφηση.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Αποθηκεύτηκε σε αυτόν τον λογαριασμό. Θα σας ζητηθεί όταν χρειαστεί να αποκρυπτογραφηθούν διαπιστευτήρια.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Η πρόοδος ανάγνωσης σε αυτή τη συσκευή διαφέρει από το «{{deviceName}}».",
   "This device": "Αυτή η συσκευή",
   "Red": "Κόκκινο",
@@ -1562,7 +1561,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Η συνθηματική φράση συγχρονισμού λησμονήθηκε. Όλα τα κρυπτογραφημένα πεδία διαγράφηκαν.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Διαγραφή {{n}} βιβλίων από τον διακομιστή WebDAV;\n\nΑυτό αφαιρεί μόνο τα απομακρυσμένα αρχεία· η τοπική σας βιβλιοθήκη παραμένει ανέπαφη. Η διαγραφή είναι μη αναστρέψιμη. Τα δεδομένα στον διακομιστή θα χαθούν οριστικά.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Λανθασμένη συνθηματική φράση συγχρονισμού. Δεν ήταν δυνατή η αποκρυπτογράφηση των συγχρονισμένων διαπιστευτηρίων.",
   "Email books straight to your library": "Στείλτε βιβλία απευθείας στη βιβλιοθήκη σας μέσω email",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Προωθήστε συνημμένα και άρθρα στην ιδιωτική σας διεύθυνση Readest. Διαθέσιμο στα πλάνα Plus, Pro και Lifetime.",
   "View plans": "Προβολή πλάνων",
@@ -1903,5 +1901,11 @@
   "Time Remaining": "Υπολειπόμενος χρόνος",
   "Theme": "Θέμα",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Έχετε συνδεθεί ως {{account}}. Ορίστε το {{provider}} ως ενεργό πάροχο cloud.",
-  "Only while reading": "Μόνο κατά την ανάγνωση"
+  "Only while reading": "Μόνο κατά την ανάγνωση",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Ξεκλειδώθηκε σε αυτήν τη συσκευή. Τα συγχρονισμένα διαπιστευτήριά σας αποκρυπτογραφούνται.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Έχει οριστεί σε αυτόν τον λογαριασμό. Εισαγάγετέ την σε αυτήν τη συσκευή για να αποκρυπτογραφήσετε τα συγχρονισμένα διαπιστευτήριά σας.",
+  "Re-enter passphrase": "Εισαγωγή φράσης πρόσβασης ξανά",
+  "Enter passphrase": "Εισαγωγή φράσης πρόσβασης",
+  "Incorrect passphrase. Please try again.": "Λανθασμένη φράση πρόσβασης. Δοκιμάστε ξανά.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Λανθασμένη φράση πρόσβασης συγχρονισμού. Εισαγάγετέ την ξανά στις Ρυθμίσεις για να ξεκλειδώσετε τα διαπιστευτήριά σας."
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1399,7 +1399,6 @@
   "Credentials": "Credenciales",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Tokens, nombres de usuario y contraseñas de OPDS, KOReader, Hardcover, Readwise y WebDAV. Si está desactivado, las credenciales permanecen solo en este dispositivo y nunca se cargan.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Los campos sincronizados sensibles se cifran antes de subirlos. Establece una frase de contraseña ahora o más tarde, cuando se necesite el cifrado.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Guardada en esta cuenta. Se te pedirá cuando se necesite descifrar credenciales.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "El progreso de lectura en este dispositivo difiere del de «{{deviceName}}».",
   "This device": "Este dispositivo",
   "Red": "Rojo",
@@ -1592,7 +1591,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Frase de paso de sincronización olvidada. Se borraron todos los campos cifrados.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "¿Eliminar {{n}} libro(s) del servidor WebDAV?\n\nEsto solo elimina los archivos remotos; tu biblioteca local no se verá afectada. La eliminación no se puede deshacer. Los bytes en el servidor desaparecerán permanentemente.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Frase de paso de sincronización incorrecta. No se pudieron descifrar las credenciales sincronizadas.",
   "Email books straight to your library": "Envía libros por correo directamente a tu biblioteca",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Reenvía archivos adjuntos y artículos a tu dirección privada de Readest. Disponible en los planes Plus, Pro y Lifetime.",
   "View plans": "Ver planes",
@@ -1938,5 +1936,11 @@
   "{{hours}}h left": "{{hours}} h restantes",
   "Theme": "Tema",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Conectado como {{account}}. Haz que {{provider}} sea el proveedor de nube activo.",
-  "Only while reading": "Solo durante la lectura"
+  "Only while reading": "Solo durante la lectura",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Desbloqueada en este dispositivo. Tus credenciales sincronizadas se están descifrando.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Establecida en esta cuenta. Introdúcela en este dispositivo para descifrar tus credenciales sincronizadas.",
+  "Re-enter passphrase": "Volver a introducir la frase de contraseña",
+  "Enter passphrase": "Introducir frase de contraseña",
+  "Incorrect passphrase. Please try again.": "Frase de contraseña incorrecta. Inténtalo de nuevo.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Frase de contraseña de sincronización incorrecta. Vuelve a introducirla en Configuraciones para desbloquear tus credenciales."
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1374,7 +1374,6 @@
   "Credentials": "اعتبارنامه‌ها",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "توکن‌ها، نام‌های کاربری و رمزهای عبور OPDS، KOReader، Hardcover، Readwise و WebDAV. هنگام غیرفعال بودن، اعتبارنامه‌ها فقط روی این دستگاه باقی می‌مانند و هرگز بارگذاری نمی‌شوند.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "فیلدهای حساسِ همگام‌سازی‌شده پیش از بارگذاری رمزگذاری می‌شوند. اکنون یا بعداً، هنگامی که به رمزگذاری نیاز شد، یک عبارت عبور تنظیم کنید.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "در این حساب ذخیره شد. هنگام رمزگشایی اعتبارنامه‌ها از شما خواسته می‌شود.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "پیشرفت مطالعه در این دستگاه با «{{deviceName}}» تفاوت دارد.",
   "This device": "این دستگاه",
   "Red": "قرمز",
@@ -1562,7 +1561,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "عبارت عبور همگام‌سازی فراموش شد. تمام فیلدهای رمزگذاری‌شده پاک شدند.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "{{n}} کتاب از سرور WebDAV حذف شود؟\n\nاین فقط فایل‌های راه‌دور را حذف می‌کند؛ کتابخانه محلی شما دست‌نخورده می‌ماند. حذف غیرقابل بازگشت است. داده‌های روی سرور برای همیشه از بین می‌رود.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "عبارت عبور همگام‌سازی نادرست است. اعتبارنامه‌های همگام‌شده قابل رمزگشایی نبودند.",
   "Email books straight to your library": "کتاب‌ها را مستقیماً به کتابخانه‌تان ایمیل کنید",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "پیوست‌ها و مقالات را به آدرس خصوصی Readest خود ارسال کنید. در پلن‌های Plus، Pro و Lifetime در دسترس است.",
   "View plans": "مشاهده پلن‌ها",
@@ -1903,5 +1901,11 @@
   "Time Remaining": "زمان باقی‌مانده",
   "Theme": "تم",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "متصل به‌عنوان {{account}}. {{provider}} را ارائه‌دهنده فعال ابری قرار دهید.",
-  "Only while reading": "فقط هنگام مطالعه"
+  "Only while reading": "فقط هنگام مطالعه",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "روی این دستگاه باز شد. اطلاعات ورود همگام‌سازی‌شده شما در حال رمزگشایی است.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "برای این حساب تنظیم شده است. برای رمزگشایی اطلاعات ورود همگام‌سازی‌شده، آن را در این دستگاه وارد کنید.",
+  "Re-enter passphrase": "وارد کردن دوباره عبارت عبور",
+  "Enter passphrase": "وارد کردن عبارت عبور",
+  "Incorrect passphrase. Please try again.": "عبارت عبور نادرست است. لطفاً دوباره تلاش کنید.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "عبارت عبور همگام‌سازی نادرست است. برای باز کردن اطلاعات ورود، آن را در تنظیمات دوباره وارد کنید."
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1399,7 +1399,6 @@
   "Credentials": "Identifiants",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Jetons, noms d'utilisateur et mots de passe pour OPDS, KOReader, Hardcover, Readwise et WebDAV. Lorsqu'ils sont désactivés, les identifiants restent uniquement sur cet appareil et ne sont jamais téléversés.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Les champs sensibles synchronisés sont chiffrés avant l'envoi. Définissez une phrase de passe maintenant ou plus tard, lorsque le chiffrement sera nécessaire.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Enregistrée sur ce compte. Elle vous sera demandée lors du déchiffrement des identifiants.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "La progression de lecture sur cet appareil diffère de « {{deviceName}} ».",
   "This device": "Cet appareil",
   "Red": "Rouge",
@@ -1592,7 +1591,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Phrase secrète de synchronisation oubliée. Tous les champs chiffrés ont été effacés.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Supprimer {{n}} livre(s) du serveur WebDAV ?\n\nCela ne supprime que les fichiers distants ; votre bibliothèque locale n'est pas affectée. La suppression est irréversible. Les octets sur le serveur seront définitivement perdus.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Phrase secrète de synchronisation incorrecte. Les identifiants synchronisés n'ont pas pu être déchiffrés.",
   "Email books straight to your library": "Envoyez des livres par e-mail directement dans votre bibliothèque",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Transférez les pièces jointes et les articles vers votre adresse Readest privée. Disponible avec les forfaits Plus, Pro et Lifetime.",
   "View plans": "Voir les forfaits",
@@ -1938,5 +1936,11 @@
   "Time Remaining": "Temps restant",
   "Theme": "Thème",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Connecté en tant que {{account}}. Faites de {{provider}} le fournisseur cloud actif.",
-  "Only while reading": "Uniquement pendant la lecture"
+  "Only while reading": "Uniquement pendant la lecture",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Déverrouillée sur cet appareil. Vos identifiants synchronisés sont en cours de déchiffrement.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Définie pour ce compte. Saisissez-la sur cet appareil pour déchiffrer vos identifiants synchronisés.",
+  "Re-enter passphrase": "Saisir à nouveau la phrase secrète",
+  "Enter passphrase": "Saisir la phrase secrète",
+  "Incorrect passphrase. Please try again.": "Phrase secrète incorrecte. Veuillez réessayer.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Phrase secrète de synchronisation incorrecte. Saisissez-la à nouveau dans les Paramètres pour déverrouiller vos identifiants."
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1399,7 +1399,6 @@
   "Credentials": "אישורים",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "אסימונים, שמות משתמש וסיסמאות עבור OPDS, KOReader, Hardcover, Readwise ו-WebDAV. כאשר מבוטל, האישורים נשמרים רק במכשיר זה ולעולם אינם מועלים.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "שדות מסונכרנים רגישים מוצפנים לפני העלאה. הגדר ביטוי סיסמה עכשיו או מאוחר יותר, כאשר תידרש הצפנה.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "נשמר בחשבון זה. תתבקש להזינו בעת פענוח אישורים.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "התקדמות הקריאה במכשיר זה שונה מ-\"{{deviceName}}\".",
   "This device": "מכשיר זה",
   "Red": "אדום",
@@ -1592,7 +1591,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "משפט הסיסמה לסנכרון נשכח. כל השדות המוצפנים נמחקו.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "למחוק {{n}} ספרים משרת ה-WebDAV?\n\nפעולה זו מסירה רק את הקבצים המרוחקים; הספרייה המקומית שלך אינה מושפעת. לא ניתן לבטל את המחיקה. הבייטים בשרת ייעלמו לתמיד.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "משפט סיסמה לסנכרון שגוי. לא ניתן היה לפענח את פרטי הכניסה המסונכרנים.",
   "Email books straight to your library": "שלח ספרים ישירות לספרייה שלך באמצעות אימייל",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "העבר קבצים מצורפים ומאמרים לכתובת Readest הפרטית שלך. זמין בתוכניות Plus, Pro ו-Lifetime.",
   "View plans": "הצג תוכניות",
@@ -1938,5 +1936,11 @@
   "Time Remaining": "זמן שנותר",
   "Theme": "ערכת נושא",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "מחובר כ-{{account}}. הפוך את {{provider}} לספק הענן הפעיל.",
-  "Only while reading": "רק בזמן הקריאה"
+  "Only while reading": "רק בזמן הקריאה",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "נפתח במכשיר הזה. פרטי הכניסה המסונכרנים שלך מפוענחים.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "הוגדר בחשבון הזה. הזן אותו במכשיר הזה כדי לפענח את פרטי הכניסה המסונכרנים.",
+  "Re-enter passphrase": "הזן שוב ביטוי סיסמה",
+  "Enter passphrase": "הזן ביטוי סיסמה",
+  "Incorrect passphrase. Please try again.": "ביטוי סיסמה שגוי. נסה שוב.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "ביטוי סיסמה לסנכרון שגוי. הזן אותו שוב בהגדרות כדי לפתוח את פרטי הכניסה."
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1374,7 +1374,6 @@
   "Credentials": "क्रेडेंशियल",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "OPDS, KOReader, Hardcover, Readwise और WebDAV के लिए टोकन, उपयोगकर्ता नाम और पासवर्ड। अक्षम होने पर, क्रेडेंशियल केवल इसी डिवाइस पर रहते हैं और कभी अपलोड नहीं किए जाते।",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "संवेदनशील सिंक किए गए फ़ील्ड अपलोड से पहले एन्क्रिप्ट किए जाते हैं। अभी पासफ़्रेज़ सेट करें या बाद में जब एन्क्रिप्शन की आवश्यकता हो।",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "इस खाते में सहेजा गया। क्रेडेंशियल डिक्रिप्ट करते समय आपसे पूछा जाएगा।",
   "Reading progress on this device differs from \"{{deviceName}}\".": "इस डिवाइस पर पढ़ने की प्रगति \"{{deviceName}}\" से भिन्न है।",
   "This device": "यह डिवाइस",
   "Red": "लाल",
@@ -1562,7 +1561,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "सिंक पासफ़्रेज़ भुलाया गया। सभी एन्क्रिप्ट किए गए फ़ील्ड साफ़ कर दिए गए।",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "WebDAV सर्वर से {{n}} किताब(ें) हटाएं?\n\nयह केवल रिमोट फ़ाइलें हटाता है; आपकी स्थानीय लाइब्रेरी अप्रभावित रहती है। हटाना पूर्ववत नहीं किया जा सकता। सर्वर पर डेटा हमेशा के लिए चला जाएगा।",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "गलत सिंक पासफ़्रेज़। सिंक की गई क्रेडेंशियल्स को डिक्रिप्ट नहीं किया जा सका।",
   "Email books straight to your library": "अपनी लाइब्रेरी में सीधे ईमेल से किताबें भेजें",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "अनुलग्नक और लेख अपने निजी Readest पते पर अग्रेषित करें। Plus, Pro और Lifetime प्लान में उपलब्ध।",
   "View plans": "योजनाएँ देखें",
@@ -1903,5 +1901,11 @@
   "Time Remaining": "शेष समय",
   "Theme": "थीम",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} के रूप में कनेक्टेड। {{provider}} को सक्रिय क्लाउड प्रदाता बनाएं।",
-  "Only while reading": "केवल पढ़ते समय"
+  "Only while reading": "केवल पढ़ते समय",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "इस डिवाइस पर अनलॉक है। आपके सिंक किए गए क्रेडेंशियल डिक्रिप्ट किए जा रहे हैं।",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "इस खाते पर सेट है। सिंक किए गए क्रेडेंशियल डिक्रिप्ट करने के लिए इसे इस डिवाइस पर दर्ज करें।",
+  "Re-enter passphrase": "पासफ़्रेज़ फिर से दर्ज करें",
+  "Enter passphrase": "पासफ़्रेज़ दर्ज करें",
+  "Incorrect passphrase. Please try again.": "गलत पासफ़्रेज़। कृपया फिर से प्रयास करें।",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "सिंक पासफ़्रेज़ गलत है। अपने क्रेडेंशियल अनलॉक करने के लिए इसे सेटिंग्स में फिर से दर्ज करें।"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1374,7 +1374,6 @@
   "Credentials": "Hitelesítő adatok",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Tokenek, felhasználónevek és jelszavak az OPDS, KOReader, Hardcover, Readwise és WebDAV szolgáltatásokhoz. Ha le van tiltva, a hitelesítő adatok csak ezen az eszközön maradnak, és soha nem töltődnek fel.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Az érzékeny szinkronizált mezők feltöltés előtt titkosítva vannak. Állíts be egy jelmondatot most, vagy később, amikor titkosításra lesz szükség.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Mentve ehhez a fiókhoz. Akkor kérjük majd, amikor hitelesítő adatokat kell visszafejteni.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Az olvasási előrehaladás ezen az eszközön eltér a következőtől: „{{deviceName}}”.",
   "This device": "Ez az eszköz",
   "Red": "Piros",
@@ -1562,7 +1561,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "A szinkronizálási jelmondat törölve. Minden titkosított mező törölve.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Törli a(z) {{n}} könyvet a WebDAV kiszolgálóról?\n\nEz csak a távoli fájlokat törli; a helyi könyvtárát nem érinti. A törlés nem vonható vissza. A kiszolgálón lévő adatok véglegesen eltűnnek.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Hibás szinkronizálási jelmondat. A szinkronizált hitelesítő adatokat nem sikerült visszafejteni.",
   "Email books straight to your library": "Küldjön könyveket közvetlenül e-mailben a könyvtárába",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Továbbítsa a mellékleteket és cikkeket a privát Readest-címére. Elérhető a Plus, Pro és Lifetime csomagokban.",
   "View plans": "Csomagok megtekintése",
@@ -1903,5 +1901,11 @@
   "Time Remaining": "Hátralévő idő",
   "Theme": "Téma",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Csatlakozva mint {{account}}. Tegye a {{provider}}-ot az aktív felhőszolgáltatóvá.",
-  "Only while reading": "Csak olvasás közben"
+  "Only while reading": "Csak olvasás közben",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Feloldva ezen az eszközön. A szinkronizált hitelesítő adatok visszafejtése folyamatban van.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Beállítva ehhez a fiókhoz. Adja meg ezen az eszközön a szinkronizált hitelesítő adatok visszafejtéséhez.",
+  "Re-enter passphrase": "Jelmondat ismételt megadása",
+  "Enter passphrase": "Jelmondat megadása",
+  "Incorrect passphrase. Please try again.": "Hibás jelmondat. Kérjük, próbálja újra.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Hibás szinkronizálási jelmondat. Adja meg újra a Beállításokban a hitelesítő adatok feloldásához."
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1349,7 +1349,6 @@
   "Credentials": "Kredensial",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Token, nama pengguna, dan kata sandi untuk OPDS, KOReader, Hardcover, Readwise, dan WebDAV. Saat dinonaktifkan, kredensial hanya tetap di perangkat ini dan tidak pernah diunggah.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Bidang sinkron yang sensitif dienkripsi sebelum diunggah. Atur frasa sandi sekarang atau nanti saat enkripsi diperlukan.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Disimpan di akun ini. Anda akan diminta memasukkannya saat mendekripsi kredensial.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Progres membaca di perangkat ini berbeda dari \"{{deviceName}}\".",
   "This device": "Perangkat ini",
   "Red": "Merah",
@@ -1532,7 +1531,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Frasa sandi sinkronisasi dilupakan. Semua bidang terenkripsi dihapus.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Hapus {{n}} buku dari server WebDAV?\n\nIni hanya menghapus file jarak jauh; perpustakaan lokal Anda tidak terpengaruh. Penghapusan tidak dapat dibatalkan. Data di server akan hilang permanen.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Frasa sandi sinkronisasi salah. Kredensial yang disinkronkan tidak dapat didekripsi.",
   "Email books straight to your library": "Kirim buku langsung ke perpustakaan Anda melalui email",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Teruskan lampiran dan artikel ke alamat Readest pribadi Anda. Tersedia di paket Plus, Pro, dan Lifetime.",
   "View plans": "Lihat paket",
@@ -1868,5 +1866,11 @@
   "Time Remaining": "Sisa waktu",
   "Theme": "Tema",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Terhubung sebagai {{account}}. Jadikan {{provider}} penyedia cloud yang aktif.",
-  "Only while reading": "Hanya saat membaca"
+  "Only while reading": "Hanya saat membaca",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Terbuka di perangkat ini. Kredensial tersinkronisasi Anda sedang didekripsi.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Disetel pada akun ini. Masukkan di perangkat ini untuk mendekripsi kredensial tersinkronisasi Anda.",
+  "Re-enter passphrase": "Masukkan ulang frasa sandi",
+  "Enter passphrase": "Masukkan frasa sandi",
+  "Incorrect passphrase. Please try again.": "Frasa sandi salah. Silakan coba lagi.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Frasa sandi sinkronisasi salah. Masukkan lagi di Pengaturan untuk membuka kredensial Anda."
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1399,7 +1399,6 @@
   "Credentials": "Credenziali",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Token, nomi utente e password per OPDS, KOReader, Hardcover, Readwise e WebDAV. Quando disattivato, le credenziali restano solo su questo dispositivo e non vengono mai caricate.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "I campi sincronizzati sensibili vengono cifrati prima del caricamento. Imposta una passphrase ora o più tardi, quando servirà la cifratura.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Salvata in questo account. Ti verrà richiesta quando occorrerà decifrare le credenziali.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "L'avanzamento di lettura su questo dispositivo è diverso da «{{deviceName}}».",
   "This device": "Questo dispositivo",
   "Red": "Rosso",
@@ -1592,7 +1591,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Passphrase di sincronizzazione dimenticata. Tutti i campi cifrati sono stati cancellati.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Eliminare {{n}} libro/i dal server WebDAV?\n\nQuesto rimuove solo i file remoti; la tua libreria locale non è interessata. L'eliminazione non può essere annullata. I byte sul server saranno persi per sempre.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Passphrase di sincronizzazione errata. Impossibile decifrare le credenziali sincronizzate.",
   "Email books straight to your library": "Invia i libri direttamente alla tua libreria via email",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Inoltra allegati e articoli al tuo indirizzo Readest privato. Disponibile nei piani Plus, Pro e Lifetime.",
   "View plans": "Vedi piani",
@@ -1938,5 +1936,11 @@
   "Time Remaining": "Tempo rimanente",
   "Theme": "Tema",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Collegato come {{account}}. Imposta {{provider}} come provider cloud attivo.",
-  "Only while reading": "Solo durante la lettura"
+  "Only while reading": "Solo durante la lettura",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Sbloccata su questo dispositivo. Le credenziali sincronizzate vengono decifrate.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Impostata su questo account. Inseriscila su questo dispositivo per decifrare le credenziali sincronizzate.",
+  "Re-enter passphrase": "Reinserisci la passphrase",
+  "Enter passphrase": "Inserisci la passphrase",
+  "Incorrect passphrase. Please try again.": "Passphrase errata. Riprova.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Passphrase di sincronizzazione errata. Reinseriscila nelle Impostazioni per sbloccare le tue credenziali."
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1349,7 +1349,6 @@
   "Credentials": "認証情報",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "OPDS、KOReader、Hardcover、Readwise、WebDAV のトークン、ユーザー名、パスワード。無効にすると、認証情報はこのデバイスにのみ残り、アップロードされません。",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "機密性の高い同期フィールドはアップロード前に暗号化されます。パスフレーズは今すぐ設定するか、暗号化が必要なときに後で設定できます。",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "このアカウントに保存されました。認証情報を復号する際に入力を求められます。",
   "Reading progress on this device differs from \"{{deviceName}}\".": "このデバイスの読書進捗は「{{deviceName}}」と異なります。",
   "This device": "このデバイス",
   "Red": "赤",
@@ -1532,7 +1531,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "同期パスフレーズを忘却しました。すべての暗号化フィールドがクリアされました。",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "WebDAV サーバーから {{n}} 冊を削除しますか?\n\nこの操作はリモートファイルのみを削除します。ローカルライブラリには影響しません。削除は元に戻せません。サーバー上のデータは完全に失われます。",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "同期パスフレーズが正しくありません。同期された認証情報を復号できませんでした。",
   "Email books straight to your library": "本をメールで直接ライブラリに送信",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "添付ファイルや記事をあなた専用の Readest アドレスに転送できます。Plus、Pro、Lifetime プランで利用可能。",
   "View plans": "プランを見る",
@@ -1868,5 +1866,11 @@
   "Time Remaining": "残り時間",
   "Theme": "テーマ",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} として接続済み。{{provider}} を使用するクラウドプロバイダーに設定します。",
-  "Only while reading": "読書中のみ"
+  "Only while reading": "読書中のみ",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "このデバイスでロック解除済みです。同期された認証情報を復号しています。",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "このアカウントに設定されています。同期された認証情報を復号するには、このデバイスで入力してください。",
+  "Re-enter passphrase": "パスフレーズを再入力",
+  "Enter passphrase": "パスフレーズを入力",
+  "Incorrect passphrase. Please try again.": "パスフレーズが正しくありません。もう一度お試しください。",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "同期パスフレーズが正しくありません。設定で再入力して認証情報のロックを解除してください。"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1349,7 +1349,6 @@
   "Credentials": "자격 증명",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "OPDS, KOReader, Hardcover, Readwise, WebDAV의 토큰, 사용자 이름, 비밀번호입니다. 비활성화되면 자격 증명이 이 기기에만 남아 있고 절대 업로드되지 않습니다.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "민감한 동기화 필드는 업로드 전에 암호화됩니다. 지금 또는 암호화가 필요할 때 나중에 암호 문구를 설정하세요.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "이 계정에 저장되었습니다. 자격 증명을 복호화할 때 입력하라는 메시지가 표시됩니다.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "이 기기의 읽기 진행 상황이 \"{{deviceName}}\"와(과) 다릅니다.",
   "This device": "이 기기",
   "Red": "빨강",
@@ -1532,7 +1531,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "동기화 암호구를 잊었습니다. 모든 암호화된 필드가 지워졌습니다.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "WebDAV 서버에서 {{n}}권을 삭제하시겠습니까?\n\n이 작업은 원격 파일만 제거합니다; 로컬 라이브러리에는 영향을 주지 않습니다. 삭제는 취소할 수 없습니다. 서버의 데이터는 영구히 사라집니다.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "동기화 암호구가 잘못되었습니다. 동기화된 자격 증명을 복호화할 수 없습니다.",
   "Email books straight to your library": "이메일로 책을 라이브러리에 바로 전송",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "첨부 파일과 기사를 개인 Readest 주소로 전달하세요. Plus, Pro, Lifetime 요금제에서 사용할 수 있습니다.",
   "View plans": "요금제 보기",
@@ -1868,5 +1866,11 @@
   "Time Remaining": "남은 시간",
   "Theme": "테마",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}}(으)로 연결됨. {{provider}}를 사용할 클라우드 제공업체로 설정합니다.",
-  "Only while reading": "독서 중에만"
+  "Only while reading": "독서 중에만",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "이 기기에서 잠금 해제됨. 동기화된 자격 증명을 복호화하고 있습니다.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "이 계정에 설정되어 있습니다. 동기화된 자격 증명을 복호화하려면 이 기기에서 입력하세요.",
+  "Re-enter passphrase": "암호 문구 다시 입력",
+  "Enter passphrase": "암호 문구 입력",
+  "Incorrect passphrase. Please try again.": "암호 문구가 올바르지 않습니다. 다시 시도해 주세요.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "동기화 암호 문구가 올바르지 않습니다. 설정에서 다시 입력하여 자격 증명을 잠금 해제하세요."
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1349,7 +1349,6 @@
   "Credentials": "Kelayakan",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Token, nama pengguna dan kata laluan untuk OPDS, KOReader, Hardcover, Readwise dan WebDAV. Apabila dilumpuhkan, kelayakan hanya kekal pada peranti ini dan tidak pernah dimuat naik.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Medan disegerakkan yang sensitif disulitkan sebelum dimuat naik. Tetapkan frasa laluan sekarang atau kemudian apabila penyulitan diperlukan.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Disimpan dalam akaun ini. Anda akan diminta memasukkannya apabila kelayakan perlu dinyahsulit.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Kemajuan membaca pada peranti ini berbeza daripada \"{{deviceName}}\".",
   "This device": "Peranti ini",
   "Red": "Merah",
@@ -1532,7 +1531,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Frasa kata laluan penyegerakan dilupakan. Semua medan yang disulitkan dibersihkan.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Padam {{n}} buah buku dari pelayan WebDAV?\n\nIni hanya membuang fail jauh; perpustakaan tempatan anda tidak terjejas. Pemadaman tidak boleh dibatalkan. Bait di pelayan akan hilang selamanya.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Frasa kata laluan penyegerakan salah. Bukti kelayakan yang disegerakkan tidak dapat dinyahsulit.",
   "Email books straight to your library": "E-mel buku terus ke perpustakaan anda",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Majukan lampiran dan artikel ke alamat Readest peribadi anda. Tersedia pada pelan Plus, Pro dan Lifetime.",
   "View plans": "Lihat pelan",
@@ -1868,5 +1866,11 @@
   "Time Remaining": "Masa berbaki",
   "Theme": "Tema",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Disambungkan sebagai {{account}}. Jadikan {{provider}} sebagai penyedia awan yang aktif.",
-  "Only while reading": "Hanya semasa membaca"
+  "Only while reading": "Hanya semasa membaca",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Dibuka pada peranti ini. Kelayakan tersegerak anda sedang dinyahsulit.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Ditetapkan pada akaun ini. Masukkannya pada peranti ini untuk menyahsulit kelayakan tersegerak anda.",
+  "Re-enter passphrase": "Masukkan semula frasa laluan",
+  "Enter passphrase": "Masukkan frasa laluan",
+  "Incorrect passphrase. Please try again.": "Frasa laluan salah. Sila cuba lagi.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Frasa laluan penyegerakan salah. Masukkannya semula dalam Tetapan untuk membuka kelayakan anda."
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1374,7 +1374,6 @@
   "Credentials": "Inloggegevens",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Tokens, gebruikersnamen en wachtwoorden voor OPDS, KOReader, Hardcover, Readwise en WebDAV. Wanneer uitgeschakeld blijven inloggegevens alleen op dit apparaat en worden ze nooit geüpload.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Gevoelige gesynchroniseerde velden worden vóór het uploaden versleuteld. Stel nu of later een wachtwoordzin in wanneer versleuteling nodig is.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Opgeslagen op dit account. Er wordt om gevraagd wanneer inloggegevens ontsleuteld moeten worden.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "De leesvoortgang op dit apparaat verschilt van \"{{deviceName}}\".",
   "This device": "Dit apparaat",
   "Red": "Rood",
@@ -1562,7 +1561,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Sync-wachtwoordzin vergeten. Alle versleutelde velden gewist.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "{{n}} boek(en) van WebDAV-server verwijderen?\n\nDit verwijdert alleen de externe bestanden; je lokale bibliotheek wordt niet beïnvloed. Verwijderen kan niet ongedaan worden gemaakt. De bytes op de server zijn permanent verloren.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Verkeerde sync-wachtwoordzin. Gesynchroniseerde inloggegevens konden niet worden ontsleuteld.",
   "Email books straight to your library": "Mail boeken rechtstreeks naar je bibliotheek",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Stuur bijlagen en artikelen door naar je privé Readest-adres. Beschikbaar in de Plus-, Pro- en Lifetime-abonnementen.",
   "View plans": "Abonnementen bekijken",
@@ -1903,5 +1901,11 @@
   "Time Remaining": "Resterende tijd",
   "Theme": "Thema",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Verbonden als {{account}}. Maak {{provider}} de actieve cloudprovider.",
-  "Only while reading": "Alleen tijdens het lezen"
+  "Only while reading": "Alleen tijdens het lezen",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Ontgrendeld op dit apparaat. Je gesynchroniseerde inloggegevens worden ontsleuteld.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Ingesteld voor dit account. Voer deze op dit apparaat in om je gesynchroniseerde inloggegevens te ontsleutelen.",
+  "Re-enter passphrase": "Wachtwoordzin opnieuw invoeren",
+  "Enter passphrase": "Wachtwoordzin invoeren",
+  "Incorrect passphrase. Please try again.": "Onjuiste wachtwoordzin. Probeer het opnieuw.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Onjuiste sync-wachtwoordzin. Voer deze opnieuw in bij Instellingen om je inloggegevens te ontgrendelen."
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1424,7 +1424,6 @@
   "Credentials": "Poświadczenia",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Tokeny, nazwy użytkowników i hasła do OPDS, KOReader, Hardcover, Readwise i WebDAV. Gdy wyłączone, poświadczenia pozostają tylko na tym urządzeniu i nigdy nie są przesyłane.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Wrażliwe zsynchronizowane pola są szyfrowane przed wysłaniem. Ustaw hasło teraz lub później, gdy szyfrowanie będzie potrzebne.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Zapisane w tym koncie. Zostaniesz o nie poproszony przy odszyfrowywaniu poświadczeń.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Postęp czytania na tym urządzeniu różni się od „{{deviceName}}”.",
   "This device": "To urządzenie",
   "Red": "Czerwony",
@@ -1622,7 +1621,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Zapomniano hasło synchronizacji. Wszystkie zaszyfrowane pola wyczyszczone.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Usunąć {{n}} książek z serwera WebDAV?\n\nUsuwa to tylko zdalne pliki; lokalna biblioteka pozostaje nienaruszona. Usunięcia nie można cofnąć. Bajty na serwerze zostaną trwale utracone.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Nieprawidłowe hasło synchronizacji. Nie udało się odszyfrować zsynchronizowanych poświadczeń.",
   "Email books straight to your library": "Wysyłaj książki e-mailem prosto do biblioteki",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Przekazuj załączniki i artykuły na swój prywatny adres Readest. Dostępne w planach Plus, Pro i Lifetime.",
   "View plans": "Zobacz plany",
@@ -1973,5 +1971,11 @@
   "Time Remaining": "Pozostały czas",
   "Theme": "Motyw",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Połączono jako {{account}}. Ustaw {{provider}} jako aktywnego dostawcę chmury.",
-  "Only while reading": "Tylko podczas czytania"
+  "Only while reading": "Tylko podczas czytania",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Odblokowane na tym urządzeniu. Zsynchronizowane dane logowania są odszyfrowywane.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Ustawione na tym koncie. Wprowadź je na tym urządzeniu, aby odszyfrować zsynchronizowane dane logowania.",
+  "Re-enter passphrase": "Wprowadź hasło ponownie",
+  "Enter passphrase": "Wprowadź hasło",
+  "Incorrect passphrase. Please try again.": "Nieprawidłowe hasło. Spróbuj ponownie.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Nieprawidłowe hasło synchronizacji. Wprowadź je ponownie w Ustawieniach, aby odblokować dane logowania."
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1399,7 +1399,6 @@
   "Credentials": "Credenciais",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Tokens, nomes de usuário e senhas para OPDS, KOReader, Hardcover, Readwise e WebDAV. Quando desativado, as credenciais permanecem apenas neste dispositivo e nunca são enviadas.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Os campos sincronizados sensíveis são criptografados antes do envio. Defina uma senha agora ou mais tarde, quando a criptografia for necessária.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Salva nesta conta. Você será solicitado a informá-la quando precisar descriptografar credenciais.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "O progresso de leitura neste dispositivo difere do de \"{{deviceName}}\".",
   "This device": "Este dispositivo",
   "Red": "Vermelho",
@@ -1592,7 +1591,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Frase-senha de sincronização esquecida. Todos os campos criptografados foram limpos.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Excluir {{n}} livro(s) do servidor WebDAV?\n\nIsso apenas remove os arquivos remotos; sua biblioteca local não é afetada. A exclusão não pode ser desfeita. Os bytes no servidor desaparecerão permanentemente.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Frase-senha de sincronização incorreta. Não foi possível descriptografar as credenciais sincronizadas.",
   "Email books straight to your library": "Envie livros por e-mail direto para sua biblioteca",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Encaminhe anexos e artigos para seu endereço Readest privado. Disponível nos planos Plus, Pro e Lifetime.",
   "View plans": "Ver planos",
@@ -1938,5 +1936,11 @@
   "Time Remaining": "Tempo restante",
   "Theme": "Tema",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Conectado como {{account}}. Torne o {{provider}} o provedor de nuvem ativo.",
-  "Only while reading": "Apenas durante a leitura"
+  "Only while reading": "Apenas durante a leitura",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Desbloqueada neste dispositivo. Suas credenciais sincronizadas estão sendo descriptografadas.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Definida nesta conta. Digite-a neste dispositivo para descriptografar suas credenciais sincronizadas.",
+  "Re-enter passphrase": "Digitar a frase secreta novamente",
+  "Enter passphrase": "Digitar frase secreta",
+  "Incorrect passphrase. Please try again.": "Frase secreta incorreta. Tente novamente.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Frase secreta de sincronização incorreta. Digite-a novamente nas Configurações para desbloquear suas credenciais."
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1399,7 +1399,6 @@
   "Credentials": "Credenciais",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Tokens, nomes de utilizador e palavras-passe para OPDS, KOReader, Hardcover, Readwise e WebDAV. Quando desativado, as credenciais permanecem apenas neste dispositivo e nunca são enviadas.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Os campos sincronizados sensíveis são cifrados antes do envio. Defina uma frase-senha agora ou mais tarde, quando a cifragem for necessária.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Guardada nesta conta. Ser-lhe-á pedida quando precisar de decifrar credenciais.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "O progresso de leitura neste dispositivo difere do «{{deviceName}}».",
   "This device": "Este dispositivo",
   "Red": "Vermelho",
@@ -1592,7 +1591,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Frase-passe de sincronização esquecida. Todos os campos encriptados foram limpos.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Eliminar {{n}} livro(s) do servidor WebDAV?\n\nIsto apenas remove os ficheiros remotos; a sua biblioteca local não é afetada. A eliminação não pode ser anulada. Os bytes no servidor desaparecerão permanentemente.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Frase-passe de sincronização incorreta. Não foi possível desencriptar as credenciais sincronizadas.",
   "Email books straight to your library": "Envie livros por e-mail diretamente para a sua biblioteca",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Encaminhe anexos e artigos para o seu endereço Readest privado. Disponível nos planos Plus, Pro e Lifetime.",
   "View plans": "Ver planos",
@@ -1938,5 +1936,11 @@
   "Time Remaining": "Tempo restante",
   "Theme": "Tema",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Ligado como {{account}}. Torne o {{provider}} o fornecedor de nuvem ativo.",
-  "Only while reading": "Apenas durante a leitura"
+  "Only while reading": "Apenas durante a leitura",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Desbloqueada neste dispositivo. As suas credenciais sincronizadas estão a ser desencriptadas.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Definida nesta conta. Introduza-a neste dispositivo para desencriptar as suas credenciais sincronizadas.",
+  "Re-enter passphrase": "Introduzir novamente a frase-passe",
+  "Enter passphrase": "Introduzir frase-passe",
+  "Incorrect passphrase. Please try again.": "Frase-passe incorreta. Tente novamente.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Frase-passe de sincronização incorreta. Introduza-a novamente nas Configurações para desbloquear as suas credenciais."
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1399,7 +1399,6 @@
   "Credentials": "Acreditări",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Token-uri, nume de utilizator și parole pentru OPDS, KOReader, Hardcover, Readwise și WebDAV. Când sunt dezactivate, acreditările rămân doar pe acest dispozitiv și nu sunt niciodată încărcate.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Câmpurile sincronizate sensibile sunt criptate înainte de încărcare. Setați o frază de acces acum sau mai târziu, când criptarea va fi necesară.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Salvată în acest cont. Vi se va cere când va trebui să se decripteze acreditările.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Progresul de citire pe acest dispozitiv diferă de „{{deviceName}}”.",
   "This device": "Acest dispozitiv",
   "Red": "Roșu",
@@ -1592,7 +1591,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Parola de sincronizare uitată. Toate câmpurile criptate au fost șterse.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Ștergi {{n}} carte/cărți de pe serverul WebDAV?\n\nAceasta elimină doar fișierele de la distanță; biblioteca locală nu este afectată. Ștergerea nu poate fi anulată. Datele de pe server vor dispărea definitiv.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Parolă de sincronizare incorectă. Acreditările sincronizate nu au putut fi decriptate.",
   "Email books straight to your library": "Trimite cărți prin e-mail direct în biblioteca ta",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Redirecționează atașamente și articole către adresa ta Readest privată. Disponibil în planurile Plus, Pro și Lifetime.",
   "View plans": "Vezi planurile",
@@ -1938,5 +1936,11 @@
   "Time Remaining": "Timp rămas",
   "Theme": "Temă",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Conectat ca {{account}}. Setează {{provider}} ca furnizor de cloud activ.",
-  "Only while reading": "Doar în timpul citirii"
+  "Only while reading": "Doar în timpul citirii",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Deblocată pe acest dispozitiv. Datele de autentificare sincronizate sunt decriptate.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Setată pe acest cont. Introdu-o pe acest dispozitiv pentru a decripta datele de autentificare sincronizate.",
+  "Re-enter passphrase": "Introdu din nou fraza de acces",
+  "Enter passphrase": "Introdu fraza de acces",
+  "Incorrect passphrase. Please try again.": "Frază de acces incorectă. Încearcă din nou.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Frază de acces pentru sincronizare incorectă. Introdu-o din nou în Setări pentru a debloca datele de autentificare."
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1424,7 +1424,6 @@
   "Credentials": "Учётные данные",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Токены, имена пользователей и пароли для OPDS, KOReader, Hardcover, Readwise и WebDAV. Если отключено, учётные данные остаются только на этом устройстве и никогда не отправляются.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Конфиденциальные синхронизируемые поля шифруются перед загрузкой. Задайте парольную фразу сейчас или позже, когда понадобится шифрование.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Сохранено в этой учётной записи. Вы получите запрос при расшифровке учётных данных.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Прогресс чтения на этом устройстве отличается от «{{deviceName}}».",
   "This device": "Это устройство",
   "Red": "Красный",
@@ -1622,7 +1621,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Парольная фраза синхронизации забыта. Все зашифрованные поля очищены.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Удалить {{n}} книг с сервера WebDAV?\n\nЭто удалит только удалённые файлы; ваша локальная библиотека не пострадает. Удаление невозможно отменить. Данные на сервере исчезнут навсегда.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Неверная парольная фраза синхронизации. Не удалось расшифровать синхронизированные данные.",
   "Email books straight to your library": "Отправляйте книги по электронной почте прямо в библиотеку",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Пересылайте вложения и статьи на ваш личный адрес Readest. Доступно в тарифах Plus, Pro и Lifetime.",
   "View plans": "Посмотреть тарифы",
@@ -1973,5 +1971,11 @@
   "Time Remaining": "Оставшееся время",
   "Theme": "Тема",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Подключено как {{account}}. Сделать {{provider}} активным облачным провайдером.",
-  "Only while reading": "Только во время чтения"
+  "Only while reading": "Только во время чтения",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Разблокировано на этом устройстве. Синхронизированные учётные данные расшифровываются.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Задана для этого аккаунта. Введите её на этом устройстве, чтобы расшифровать синхронизированные учётные данные.",
+  "Re-enter passphrase": "Ввести секретную фразу заново",
+  "Enter passphrase": "Ввести секретную фразу",
+  "Incorrect passphrase. Please try again.": "Неверная секретная фраза. Попробуйте ещё раз.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Неверная секретная фраза синхронизации. Введите её заново в Настройках, чтобы разблокировать учётные данные."
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1374,7 +1374,6 @@
   "Credentials": "අක්තපත්‍ර",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "OPDS, KOReader, Hardcover, Readwise, සහ WebDAV සඳහා ටෝකන, පරිශීලක නාම සහ මුරපද. අක්‍රිය කළ විට, අක්තපත්‍ර මෙම උපාංගයේ පමණක් රැඳී පවතින අතර කිසිදා උඩුගත නොකෙරේ.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "සංවේදී සමමුහූර්ත ක්ෂේත්‍ර උඩුගත කිරීමට පෙර සංකේතනය වේ. සංකේතනය අවශ්‍ය වූ විට දැන් හෝ පසුව මුර වැකියක් සකසන්න.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "මෙම ගිණුමට සුරකින ලදී. අක්තපත්‍ර විකේතනය කිරීමේදී ඔබෙන් එය ඉල්ලනු ලැබේ.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "මෙම උපාංගයේ කියවීමේ ප්‍රගතිය \"{{deviceName}}\" වලින් වෙනස් වේ.",
   "This device": "මෙම උපාංගය",
   "Red": "රතු",
@@ -1562,7 +1561,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "සමමුහුර්ත මුරපදය අමතක කරන ලදී. සියලුම සංකේතාංකන ක්ෂේත්‍ර හිස් කරන ලදී.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "WebDAV සේවාදායකයෙන් පොත් {{n}}ක් මකන්න ද?\n\nමෙය දුරස්ථ ගොනු පමණක් ඉවත් කරයි; ඔබේ දේශීය පුස්තකාලය බලපාන්නේ නැත. මැකීම අහෝසි කළ නොහැක. සේවාදායකයේ දත්ත සදහටම නැති වේ.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "වැරදි සමමුහුර්ත මුරපදය. සමමුහුර්ත අක්තපත්‍ර විකේතනය කළ නොහැකි විය.",
   "Email books straight to your library": "ඊමේල් මගින් ඔබේ පුස්තකාලයට කෙලින්ම පොත් යවන්න",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "ඇමුණුම් සහ ලිපි ඔබේ පෞද්ගලික Readest ලිපිනය වෙත ඉදිරියට යවන්න. Plus, Pro සහ Lifetime සැලසුම් වල ලබා ගත හැක.",
   "View plans": "සැලසුම් බලන්න",
@@ -1903,5 +1901,11 @@
   "Time Remaining": "ඉතිරි කාලය",
   "Theme": "තේමාව",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} ලෙස සම්බන්ධ වී ඇත. {{provider}} සක්‍රිය cloud සපයන්නා ලෙස සකසන්න.",
-  "Only while reading": "කියවීමේදී පමණි"
+  "Only while reading": "කියවීමේදී පමණි",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "මෙම උපාංගයේ අගුළු හැර ඇත. ඔබේ සමමුහුර්ත අක්තපත්‍ර විකේතනය වෙමින් පවතී.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "මෙම ගිණුමට සකසා ඇත. සමමුහුර්ත අක්තපත්‍ර විකේතනය කිරීමට එය මෙම උපාංගයේ ඇතුළත් කරන්න.",
+  "Re-enter passphrase": "මුරපදය නැවත ඇතුළත් කරන්න",
+  "Enter passphrase": "මුරපදය ඇතුළත් කරන්න",
+  "Incorrect passphrase. Please try again.": "මුරපදය වැරදියි. නැවත උත්සාහ කරන්න.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "සමමුහුර්ත මුරපදය වැරදියි. ඔබේ අක්තපත්‍ර අගුළු ඇරීමට එය සැකසුම් තුළ නැවත ඇතුළත් කරන්න."
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1424,7 +1424,6 @@
   "Credentials": "Poverilnice",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Žetoni, uporabniška imena in gesla za OPDS, KOReader, Hardcover, Readwise in WebDAV. Ko je onemogočeno, poverilnice ostanejo le na tej napravi in se nikoli ne naložijo.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Občutljiva sinhronizirana polja so pred nalaganjem šifrirana. Nastavite geselsko frazo zdaj ali pozneje, ko bo šifriranje potrebno.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Shranjeno v tem računu. Pozvani boste, ko bo treba dešifrirati poverilnice.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Napredek branja na tej napravi se razlikuje od »{{deviceName}}«.",
   "This device": "Ta naprava",
   "Red": "Rdeča",
@@ -1622,7 +1621,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Sinhronizacijska gesla pozabljena. Vsa šifrirana polja so počiščena.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Izbrišem {{n}} knjig s strežnika WebDAV?\n\nTo odstrani samo oddaljene datoteke; vaša lokalna knjižnica ostane nedotaknjena. Izbrisa ni mogoče razveljaviti. Biti na strežniku bodo trajno izgubljeni.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Napačno geslo sinhronizacije. Sinhroniziranih poverilnic ni bilo mogoče dešifrirati.",
   "Email books straight to your library": "Knjige po e-pošti pošljite naravnost v knjižnico",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Posredujte priponke in članke na svoj zasebni Readest naslov. Na voljo v paketih Plus, Pro in Lifetime.",
   "View plans": "Oglej si pakete",
@@ -1973,5 +1971,11 @@
   "Time Remaining": "Preostali čas",
   "Theme": "Tema",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Povezano kot {{account}}. Nastavite {{provider}} kot aktivnega ponudnika oblaka.",
-  "Only while reading": "Samo med branjem"
+  "Only while reading": "Samo med branjem",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Odklenjeno v tej napravi. Vaše sinhronizirane poverilnice se dešifrirajo.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Nastavljeno za ta račun. Vnesite ga v tej napravi, da dešifrirate sinhronizirane poverilnice.",
+  "Re-enter passphrase": "Znova vnesite geslo",
+  "Enter passphrase": "Vnesite geslo",
+  "Incorrect passphrase. Please try again.": "Napačno geslo. Poskusite znova.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Napačno sinhronizacijsko geslo. Znova ga vnesite v Nastavitvah, da odklenete poverilnice."
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1374,7 +1374,6 @@
   "Credentials": "Inloggningsuppgifter",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Tokens, användarnamn och lösenord för OPDS, KOReader, Hardcover, Readwise och WebDAV. När inaktiverat förblir inloggningsuppgifterna endast på denna enhet och laddas aldrig upp.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Känsliga synkroniserade fält krypteras före uppladdning. Ange en lösenfras nu eller senare när kryptering behövs.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Sparad på det här kontot. Du blir tillfrågad när inloggningsuppgifter ska dekrypteras.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Läsförloppet på den här enheten skiljer sig från \"{{deviceName}}\".",
   "This device": "Den här enheten",
   "Red": "Röd",
@@ -1562,7 +1561,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Synklösenfras glömd. Alla krypterade fält rensade.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Ta bort {{n}} bok/böcker från WebDAV-servern?\n\nDetta tar bara bort fjärrfiler; ditt lokala bibliotek påverkas inte. Borttagningen kan inte ångras. Data på servern försvinner permanent.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Fel synklösenfras. Synkroniserade autentiseringsuppgifter kunde inte dekrypteras.",
   "Email books straight to your library": "E-posta böcker direkt till ditt bibliotek",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Vidarebefordra bilagor och artiklar till din privata Readest-adress. Tillgänglig i Plus-, Pro- och Lifetime-abonnemangen.",
   "View plans": "Visa abonnemang",
@@ -1903,5 +1901,11 @@
   "Time Remaining": "Återstående tid",
   "Theme": "Tema",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Ansluten som {{account}}. Gör {{provider}} till aktiv molnleverantör.",
-  "Only while reading": "Endast under läsning"
+  "Only while reading": "Endast under läsning",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Upplåst på den här enheten. Dina synkroniserade inloggningsuppgifter dekrypteras.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Angiven för det här kontot. Skriv in den på den här enheten för att dekryptera dina synkroniserade inloggningsuppgifter.",
+  "Re-enter passphrase": "Skriv in lösenfrasen igen",
+  "Enter passphrase": "Skriv in lösenfras",
+  "Incorrect passphrase. Please try again.": "Fel lösenfras. Försök igen.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Fel synkroniseringslösenfras. Skriv in den igen i Inställningar för att låsa upp dina inloggningsuppgifter."
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1374,7 +1374,6 @@
   "Credentials": "அங்கீகாரத் தரவுகள்",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "OPDS, KOReader, Hardcover, Readwise மற்றும் WebDAV-க்கான டோக்கன்கள், பயனர் பெயர்கள் மற்றும் கடவுச்சொற்கள். முடக்கப்பட்டிருக்கும் போது, அங்கீகாரத் தரவுகள் இந்த சாதனத்தில் மட்டுமே இருக்கும், ஒருபோதும் பதிவேற்றப்படாது.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "முக்கியமான ஒத்திசைக்கப்பட்ட புலங்கள் பதிவேற்றத்திற்கு முன் குறியாக்கம் செய்யப்படுகின்றன. குறியாக்கம் தேவைப்படும் போது இப்போது அல்லது பின்னர் கடவுச்சொற்றொடரை அமைக்கவும்.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "இந்த கணக்கில் சேமிக்கப்பட்டது. அங்கீகாரத் தரவுகளை மறைகுறியாக்கும்போது உங்களிடம் கேட்கப்படும்.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "இந்தச் சாதனத்தில் படிப்பு முன்னேற்றம் \"{{deviceName}}\" என்பதிலிருந்து வேறுபடுகிறது.",
   "This device": "இந்தச் சாதனம்",
   "Red": "சிவப்பு",
@@ -1562,7 +1561,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "ஒத்திசைவு கடவுச்சொற்றொடர் மறக்கப்பட்டது. அனைத்து குறியாக்கப்பட்ட புலங்களும் அழிக்கப்பட்டன.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "WebDAV சேவையகத்திலிருந்து {{n}} புத்தகம்(ங்கள்) நீக்க வேண்டுமா?\n\nஇது தொலைதூர கோப்புகளை மட்டுமே நீக்கும்; உங்கள் உள்ளூர் நூலகம் பாதிக்கப்படாது. நீக்கலை மீட்க முடியாது. சேவையகத்தில் உள்ள தரவு நிரந்தரமாக மறையும்.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "தவறான ஒத்திசைவு கடவுச்சொற்றொடர். ஒத்திசைக்கப்பட்ட சான்றுகளை மறைகுறியாக்க முடியவில்லை.",
   "Email books straight to your library": "புத்தகங்களை மின்னஞ்சல் வழியாக நேரடியாக உங்கள் நூலகத்திற்கு அனுப்பவும்",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "இணைப்புகள் மற்றும் கட்டுரைகளை உங்கள் தனிப்பட்ட Readest முகவரிக்கு முன்னனுப்பவும். Plus, Pro மற்றும் Lifetime திட்டங்களில் கிடைக்கும்.",
   "View plans": "திட்டங்களைப் பார்",
@@ -1903,5 +1901,11 @@
   "Time Remaining": "மீதமுள்ள நேரம்",
   "Theme": "தீம்",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} ஆக இணைக்கப்பட்டுள்ளது. {{provider}} ஐ செயலில் உள்ள cloud வழங்குநராக அமைக்கவும்.",
-  "Only while reading": "வாசிக்கும் போது மட்டும்"
+  "Only while reading": "வாசிக்கும் போது மட்டும்",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "இந்தச் சாதனத்தில் திறக்கப்பட்டுள்ளது. ஒத்திசைக்கப்பட்ட உங்கள் சான்றுகள் மறைநீக்கம் செய்யப்படுகின்றன.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "இந்தக் கணக்கில் அமைக்கப்பட்டுள்ளது. ஒத்திசைக்கப்பட்ட சான்றுகளை மறைநீக்க இந்தச் சாதனத்தில் அதை உள்ளிடவும்.",
+  "Re-enter passphrase": "கடவுச்சொற்றொடரை மீண்டும் உள்ளிடவும்",
+  "Enter passphrase": "கடவுச்சொற்றொடரை உள்ளிடவும்",
+  "Incorrect passphrase. Please try again.": "தவறான கடவுச்சொற்றொடர். மீண்டும் முயற்சிக்கவும்.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "ஒத்திசைவு கடவுச்சொற்றொடர் தவறானது. உங்கள் சான்றுகளைத் திறக்க அமைப்புகளில் மீண்டும் உள்ளிடவும்."
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1349,7 +1349,6 @@
   "Credentials": "ข้อมูลรับรอง",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "โทเคน ชื่อผู้ใช้ และรหัสผ่านสำหรับ OPDS, KOReader, Hardcover, Readwise และ WebDAV เมื่อปิดใช้งาน ข้อมูลรับรองจะยังคงอยู่ในอุปกรณ์นี้เท่านั้นและจะไม่ถูกอัปโหลด",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "ฟิลด์ที่ซิงค์ที่มีความละเอียดอ่อนจะถูกเข้ารหัสก่อนอัปโหลด ตั้งวลีรหัสผ่านตอนนี้หรือภายหลังเมื่อจำเป็นต้องเข้ารหัส",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "บันทึกในบัญชีนี้แล้ว คุณจะได้รับแจ้งเมื่อจำเป็นต้องถอดรหัสข้อมูลรับรอง",
   "Reading progress on this device differs from \"{{deviceName}}\".": "ความคืบหน้าการอ่านบนอุปกรณ์นี้แตกต่างจาก \"{{deviceName}}\"",
   "This device": "อุปกรณ์นี้",
   "Red": "แดง",
@@ -1532,7 +1531,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "ลืมรหัสผ่านการซิงค์แล้ว ฟิลด์ที่เข้ารหัสทั้งหมดถูกล้าง",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "ลบหนังสือ {{n}} เล่มจากเซิร์ฟเวอร์ WebDAV?\n\nสิ่งนี้จะลบเฉพาะไฟล์ระยะไกล; คลังข้อมูลในเครื่องของคุณจะไม่ได้รับผลกระทบ การลบไม่สามารถย้อนกลับได้ ข้อมูลบนเซิร์ฟเวอร์จะหายไปอย่างถาวร",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "รหัสผ่านการซิงค์ไม่ถูกต้อง ไม่สามารถถอดรหัสข้อมูลรับรองที่ซิงค์ได้",
   "Email books straight to your library": "ส่งหนังสือทางอีเมลไปยังคลังของคุณโดยตรง",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "ส่งต่อไฟล์แนบและบทความไปยังที่อยู่ Readest ส่วนตัวของคุณ ใช้งานได้ในแผน Plus, Pro และ Lifetime",
   "View plans": "ดูแผน",
@@ -1868,5 +1866,11 @@
   "Time Remaining": "เวลาที่เหลือ",
   "Theme": "ธีม",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "เชื่อมต่อในชื่อ {{account}} ตั้งให้ {{provider}} เป็นผู้ให้บริการคลาวด์ที่ใช้งานอยู่",
-  "Only while reading": "เฉพาะขณะอ่าน"
+  "Only while reading": "เฉพาะขณะอ่าน",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "ปลดล็อกบนอุปกรณ์นี้แล้ว กำลังถอดรหัสข้อมูลรับรองที่ซิงค์ไว้ของคุณ",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "ตั้งค่าไว้กับบัญชีนี้แล้ว ป้อนบนอุปกรณ์นี้เพื่อถอดรหัสข้อมูลรับรองที่ซิงค์ไว้",
+  "Re-enter passphrase": "ป้อนวลีรหัสผ่านอีกครั้ง",
+  "Enter passphrase": "ป้อนวลีรหัสผ่าน",
+  "Incorrect passphrase. Please try again.": "วลีรหัสผ่านไม่ถูกต้อง โปรดลองอีกครั้ง",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "วลีรหัสผ่านสำหรับซิงค์ไม่ถูกต้อง ป้อนอีกครั้งในการตั้งค่าเพื่อปลดล็อกข้อมูลรับรองของคุณ"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1374,7 +1374,6 @@
   "Credentials": "Kimlik Bilgileri",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "OPDS, KOReader, Hardcover, Readwise ve WebDAV için belirteçler, kullanıcı adları ve parolalar. Devre dışı bırakıldığında kimlik bilgileri yalnızca bu cihazda kalır ve hiçbir zaman karşıya yüklenmez.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Hassas senkronize alanlar yüklemeden önce şifrelenir. Şifreleme gerektiğinde şimdi ya da daha sonra bir parola tümcesi belirleyin.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Bu hesaba kaydedildi. Kimlik bilgileri şifresi çözülürken sizden istenecektir.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Bu cihazdaki okuma ilerlemesi \"{{deviceName}}\" cihazından farklı.",
   "This device": "Bu cihaz",
   "Red": "Kırmızı",
@@ -1562,7 +1561,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Eşitleme parola tümcesi unutuldu. Tüm şifreli alanlar temizlendi.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "WebDAV sunucusundan {{n}} kitap silinsin mi?\n\nBu yalnızca uzak dosyaları kaldırır; yerel kitaplığınız etkilenmez. Silme geri alınamaz. Sunucudaki veriler kalıcı olarak yok olur.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Yanlış eşitleme parola tümcesi. Eşitlenmiş kimlik bilgileri çözülemedi.",
   "Email books straight to your library": "Kitapları e-postayla doğrudan kitaplığınıza gönderin",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Ekleri ve makaleleri özel Readest adresinize iletin. Plus, Pro ve Lifetime planlarında kullanılabilir.",
   "View plans": "Planları görüntüle",
@@ -1903,5 +1901,11 @@
   "Time Remaining": "Kalan süre",
   "Theme": "Tema",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} olarak bağlanıldı. {{provider}}'ı etkin bulut sağlayıcısı yapın.",
-  "Only while reading": "Yalnızca okurken"
+  "Only while reading": "Yalnızca okurken",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Bu cihazda kilidi açıldı. Eşitlenen kimlik bilgilerinizin şifresi çözülüyor.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Bu hesapta ayarlandı. Eşitlenen kimlik bilgilerinizin şifresini çözmek için bu cihazda girin.",
+  "Re-enter passphrase": "Parolayı yeniden girin",
+  "Enter passphrase": "Parolayı girin",
+  "Incorrect passphrase. Please try again.": "Parola yanlış. Lütfen tekrar deneyin.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Eşitleme parolası yanlış. Kimlik bilgilerinizin kilidini açmak için Ayarlar'da yeniden girin."
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1424,7 +1424,6 @@
   "Credentials": "Облікові дані",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Токени, імена користувачів і паролі для OPDS, KOReader, Hardcover, Readwise та WebDAV. Якщо вимкнено, облікові дані залишаються лише на цьому пристрої і ніколи не вивантажуються.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Конфіденційні синхронізовані поля шифруються перед вивантаженням. Установіть парольну фразу зараз або пізніше, коли знадобиться шифрування.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Збережено в цьому обліковому записі. Вас запитають про неї під час розшифровування облікових даних.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Прогрес читання на цьому пристрої відрізняється від «{{deviceName}}».",
   "This device": "Цей пристрій",
   "Red": "Червоний",
@@ -1622,7 +1621,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Парольну фразу синхронізації забуто. Усі зашифровані поля очищено.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Видалити {{n}} книг із сервера WebDAV?\n\nЦе видалить лише віддалені файли; ваша локальна бібліотека не зміниться. Видалення неможливо скасувати. Дані на сервері зникнуть назавжди.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Неправильна парольна фраза синхронізації. Не вдалося розшифрувати синхронізовані облікові дані.",
   "Email books straight to your library": "Надсилайте книги електронною поштою прямо в бібліотеку",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Пересилайте вкладення та статті на свою приватну адресу Readest. Доступно в планах Plus, Pro і Lifetime.",
   "View plans": "Переглянути плани",
@@ -1973,5 +1971,11 @@
   "Time Remaining": "Час, що залишився",
   "Theme": "Тема",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Під'єднано як {{account}}. Зробити {{provider}} активним хмарним провайдером.",
-  "Only while reading": "Лише під час читання"
+  "Only while reading": "Лише під час читання",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Розблоковано на цьому пристрої. Синхронізовані облікові дані розшифровуються.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Установлено для цього облікового запису. Уведіть її на цьому пристрої, щоб розшифрувати синхронізовані облікові дані.",
+  "Re-enter passphrase": "Увести парольну фразу знову",
+  "Enter passphrase": "Увести парольну фразу",
+  "Incorrect passphrase. Please try again.": "Неправильна парольна фраза. Спробуйте ще раз.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Неправильна парольна фраза синхронізації. Уведіть її знову в Налаштуваннях, щоб розблокувати облікові дані."
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1374,7 +1374,6 @@
   "Credentials": "Hisob ma'lumotlari",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "OPDS, KOReader, Hardcover, Readwise va WebDAV uchun tokenlar, foydalanuvchi nomlari va parollar. O'chirilganda, hisob ma'lumotlari faqat shu qurilmada qoladi va hech qachon yuklanmaydi.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Maxfiy sinxronlashtirilgan maydonlar yuklashdan oldin shifrlanadi. Hozir yoki keyinroq, shifrlash kerak bo'lganda parol iborasini o'rnating.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Ushbu hisobga saqlangan. Hisob ma'lumotlarini deshifrlashda sizdan so'raladi.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Bu qurilmadagi o'qish jarayoni \"{{deviceName}}\" qurilmasidan farq qiladi.",
   "This device": "Ushbu qurilma",
   "Red": "Qizil",
@@ -1562,7 +1561,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Sinxronlash parol iborasi unutildi. Barcha shifrlangan maydonlar tozalandi.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "WebDAV serveridan {{n}} ta kitob o'chirilsinmi?\n\nBu faqat masofaviy fayllarni o'chiradi; mahalliy kutubxonangiz ta'sirlanmaydi. O'chirishni bekor qilib bo'lmaydi. Serverdagi ma'lumotlar mangulikka yo'qoladi.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Noto'g'ri sinxronlash parol iborasi. Sinxronlangan hisob ma'lumotlarini parolini ochib bo'lmadi.",
   "Email books straight to your library": "Kitoblarni elektron pochta orqali to'g'ridan-to'g'ri kutubxonangizga yuboring",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Ilovalar va maqolalarni shaxsiy Readest manzilingizga yuboring. Plus, Pro va Lifetime tariflarida mavjud.",
   "View plans": "Tariflarni ko'rish",
@@ -1903,5 +1901,11 @@
   "Time Remaining": "Qolgan vaqt",
   "Theme": "Mavzu",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "{{account}} sifatida ulangan. {{provider}}-ni faol bulut provayderi qiling.",
-  "Only while reading": "Faqat oʻqish paytida"
+  "Only while reading": "Faqat oʻqish paytida",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Bu qurilmada qulfi ochilgan. Sinxronlangan hisob ma’lumotlaringiz shifrdan chiqarilmoqda.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Bu hisob uchun o‘rnatilgan. Sinxronlangan hisob ma’lumotlarini shifrdan chiqarish uchun uni bu qurilmada kiriting.",
+  "Re-enter passphrase": "Parol iborasini qayta kiriting",
+  "Enter passphrase": "Parol iborasini kiriting",
+  "Incorrect passphrase. Please try again.": "Parol iborasi noto‘g‘ri. Qayta urinib ko‘ring.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Sinxronlash parol iborasi noto‘g‘ri. Hisob ma’lumotlaringiz qulfini ochish uchun uni Sozlamalarda qayta kiriting."
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1349,7 +1349,6 @@
   "Credentials": "Thông tin xác thực",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "Mã thông báo, tên người dùng và mật khẩu cho OPDS, KOReader, Hardcover, Readwise và WebDAV. Khi bị tắt, thông tin xác thực chỉ ở trên thiết bị này và không bao giờ được tải lên.",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "Các trường đồng bộ nhạy cảm được mã hóa trước khi tải lên. Đặt cụm mật khẩu ngay bây giờ hoặc sau khi cần mã hóa.",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "Đã lưu vào tài khoản này. Bạn sẽ được nhắc nhập khi cần giải mã thông tin xác thực.",
   "Reading progress on this device differs from \"{{deviceName}}\".": "Tiến trình đọc trên thiết bị này khác với \"{{deviceName}}\".",
   "This device": "Thiết bị này",
   "Red": "Đỏ",
@@ -1532,7 +1531,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "Đã quên cụm mật khẩu đồng bộ. Tất cả các trường được mã hóa đã bị xóa.",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "Xóa {{n}} sách khỏi máy chủ WebDAV?\n\nThao tác này chỉ xóa các tệp từ xa; thư viện cục bộ của bạn không bị ảnh hưởng. Không thể hoàn tác. Dữ liệu trên máy chủ sẽ mất vĩnh viễn.",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "Cụm mật khẩu đồng bộ không đúng. Không thể giải mã thông tin xác thực đã đồng bộ.",
   "Email books straight to your library": "Gửi sách qua email thẳng đến thư viện của bạn",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "Chuyển tiếp tệp đính kèm và bài viết đến địa chỉ Readest riêng của bạn. Có sẵn trong các gói Plus, Pro và Lifetime.",
   "View plans": "Xem các gói",
@@ -1868,5 +1866,11 @@
   "Time Remaining": "Thời gian còn lại",
   "Theme": "Chủ đề",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "Đã kết nối với tư cách {{account}}. Đặt {{provider}} làm nhà cung cấp đám mây đang hoạt động.",
-  "Only while reading": "Chỉ khi đang đọc"
+  "Only while reading": "Chỉ khi đang đọc",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "Đã mở khóa trên thiết bị này. Thông tin đăng nhập đã đồng bộ của bạn đang được giải mã.",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "Đã đặt cho tài khoản này. Nhập trên thiết bị này để giải mã thông tin đăng nhập đã đồng bộ.",
+  "Re-enter passphrase": "Nhập lại cụm mật khẩu",
+  "Enter passphrase": "Nhập cụm mật khẩu",
+  "Incorrect passphrase. Please try again.": "Cụm mật khẩu không đúng. Vui lòng thử lại.",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "Cụm mật khẩu đồng bộ không đúng. Nhập lại trong Cài đặt để mở khóa thông tin đăng nhập của bạn."
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1349,7 +1349,6 @@
   "Credentials": "凭据",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "OPDS、KOReader、Hardcover、Readwise 和 WebDAV 的令牌、用户名和密码。关闭时，凭据仅保留在此设备上，永远不会上传。",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "敏感的同步字段在上传前会被加密。立即设置密码短语，或稍后在需要加密时再设置。",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "已保存到此账户。需要解密凭据时会提示您输入。",
   "Reading progress on this device differs from \"{{deviceName}}\".": "此设备上的阅读进度与“{{deviceName}}”不同。",
   "This device": "此设备",
   "Red": "红色",
@@ -1532,7 +1531,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "已忘记同步密码短语。所有加密字段已清空。",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "从 WebDAV 服务器删除 {{n}} 本书？\n\n这只会移除远程文件；您的本地书库不受影响。删除无法撤销。服务器上的数据将永久消失。",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "同步密码短语错误。无法解密已同步的凭据。",
   "Email books straight to your library": "通过电子邮件直接将书籍发送到您的书库",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "将附件和文章转发到您的专属 Readest 地址。Plus、Pro 和 Lifetime 套餐可用。",
   "View plans": "查看套餐",
@@ -1868,5 +1866,11 @@
   "Time Remaining": "剩余时间",
   "Theme": "主题",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "已以 {{account}} 身份连接。将 {{provider}} 设为当前使用的云服务提供商。",
-  "Only while reading": "仅在阅读时"
+  "Only while reading": "仅在阅读时",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "已在此设备解锁。正在解密您已同步的凭据。",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "已在此账户设置。在此设备输入密语即可解密已同步的凭据。",
+  "Re-enter passphrase": "重新输入密语",
+  "Enter passphrase": "输入密语",
+  "Incorrect passphrase. Please try again.": "密语不正确，请重试。",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "同步密语错误。请在“设置”中重新输入以解锁您的凭据。"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1349,7 +1349,6 @@
   "Credentials": "憑證",
   "Tokens, usernames, and passwords for OPDS, KOReader, Hardcover, Readwise, and WebDAV. When disabled, credentials remain on this device only and are never uploaded.": "OPDS、KOReader、Hardcover、Readwise 與 WebDAV 的權杖、使用者名稱與密碼。停用時，憑證僅留在此裝置上，永不上傳。",
   "Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.": "敏感的同步欄位會在上傳前加密。立即設定密碼短語，或稍後在需要加密時再設定。",
-  "Saved to this account. You will be prompted for it when decrypting credentials.": "已儲存到此帳號。需要解密憑證時會提示您輸入。",
   "Reading progress on this device differs from \"{{deviceName}}\".": "此裝置上的閱讀進度與「{{deviceName}}」不同。",
   "This device": "此裝置",
   "Red": "紅色",
@@ -1532,7 +1531,6 @@
   "Sync passphrase forgotten. All encrypted fields cleared.": "已忘記同步密碼短語。所有加密欄位已清空。",
   "Delete {{n}} book(s) from the WebDAV server?\n\nThis only removes the remote files; your local library is unaffected. The deletion cannot be undone. The bytes on the server will be permanently gone.": "從 WebDAV 伺服器刪除 {{n}} 本書？\n\n這只會移除遠端檔案；您的本機書庫不受影響。刪除無法復原。伺服器上的資料將永久消失。",
   "{{action}} {{n}} / {{total}}": "{{action}} {{n}} / {{total}}",
-  "Wrong sync passphrase. Synced credentials could not be decrypted.": "同步密碼短語錯誤。無法解密已同步的憑證。",
   "Email books straight to your library": "透過電子郵件直接將書籍傳送到您的書庫",
   "Forward attachments and articles to your private Readest address. Available on the Plus, Pro, and Lifetime plans.": "將附件和文章轉寄到您的專屬 Readest 地址。Plus、Pro 和 Lifetime 方案可用。",
   "View plans": "查看方案",
@@ -1868,5 +1866,11 @@
   "Time Remaining": "剩餘時間",
   "Theme": "主題",
   "Connected as {{account}}. Make {{provider}} the active cloud provider.": "已以 {{account}} 身分連線。將 {{provider}} 設為目前使用的雲端服務供應商。",
-  "Only while reading": "僅在閱讀時"
+  "Only while reading": "僅在閱讀時",
+  "Unlocked on this device. Your synced credentials are being decrypted.": "已在此裝置解鎖。正在解密您已同步的憑證。",
+  "Set on this account. Enter it on this device to decrypt your synced credentials.": "已在此帳戶設定。在此裝置輸入密語即可解密已同步的憑證。",
+  "Re-enter passphrase": "重新輸入密語",
+  "Enter passphrase": "輸入密語",
+  "Incorrect passphrase. Please try again.": "密語不正確，請再試一次。",
+  "Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.": "同步密語錯誤。請在「設定」中重新輸入以解鎖您的憑證。"
 }

--- a/apps/readest-app/src/__tests__/components/passphrase-prompt.test.tsx
+++ b/apps/readest-app/src/__tests__/components/passphrase-prompt.test.tsx
@@ -1,0 +1,131 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import PassphrasePrompt from '@/components/PassphrasePrompt';
+import { CryptoSession } from '@/libs/crypto/session';
+import {
+  ensurePassphraseUnlocked,
+  __resetPassphraseGateForTests,
+} from '@/services/sync/passphraseGate';
+import type { CipherEnvelope } from '@/types/replica';
+import type { ReplicaKeyRow } from '@/libs/replicaSyncClient';
+
+// Stand-in for a non-English UI: only the retry error has a translation. The
+// gate can only `stubTranslation` that string (it is a non-React module), so
+// the component has to run it through `_()` — if it renders the raw key
+// instead, the assertion below catches it.
+const WRONG_PASSPHRASE_KEY = 'Incorrect passphrase. Please try again.';
+const WRONG_PASSPHRASE_TRANSLATED = '密语不正确，请重试。';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) =>
+    key === WRONG_PASSPHRASE_KEY ? WRONG_PASSPHRASE_TRANSLATED : key,
+}));
+
+const ITER = 1000;
+const PBKDF2_ALG = 'pbkdf2-600k-sha256';
+
+const bytesToBase64 = (bytes: Uint8Array): string => {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
+  return btoa(s);
+};
+
+class FakeClient {
+  rows: ReplicaKeyRow[] = [];
+  async listReplicaKeys(): Promise<ReplicaKeyRow[]> {
+    return [...this.rows];
+  }
+  async createReplicaKey(): Promise<ReplicaKeyRow> {
+    const bytes = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) bytes[i] = i;
+    const row = {
+      saltId: 'salt-1',
+      alg: PBKDF2_ALG,
+      salt: bytesToBase64(bytes),
+      createdAt: '2026-01-01T00:00:00Z',
+    };
+    this.rows.push(row);
+    return row;
+  }
+  async forgetReplicaKeys(): Promise<void> {
+    this.rows = [];
+  }
+}
+
+const submit = async (passphrase: string) => {
+  const input = screen.getByPlaceholderText('Sync passphrase');
+  fireEvent.change(input, { target: { value: passphrase } });
+  await act(async () => {
+    fireEvent.submit(input.closest('form')!);
+  });
+};
+
+describe('PassphrasePrompt', () => {
+  let client: FakeClient;
+  let session: CryptoSession;
+  let cipher: CipherEnvelope;
+
+  beforeEach(async () => {
+    client = new FakeClient();
+    const writer = new CryptoSession({ client, iterations: ITER });
+    await writer.setup('correct-passphrase');
+    cipher = await writer.encryptField('hunter2');
+    session = new CryptoSession({ client, iterations: ITER });
+  });
+
+  afterEach(() => {
+    cleanup();
+    __resetPassphraseGateForTests();
+  });
+
+  test('a wrong passphrase re-prompts in place, then the right one unlocks and closes', async () => {
+    render(<PassphrasePrompt />);
+    // Nothing on screen until a caller asks for the passphrase.
+    expect(screen.queryByText('Enter sync passphrase')).toBeNull();
+
+    let unlocked = false;
+    await act(async () => {
+      void ensurePassphraseUnlocked({ session, client, verifyWith: cipher }).then(() => {
+        unlocked = true;
+      });
+    });
+    expect(screen.getByText('Enter sync passphrase')).toBeTruthy();
+
+    await submit('wrong-passphrase');
+
+    // The dialog stays up and says why — translated, not the raw key — instead
+    // of closing on a passphrase that was never checked (the bug behind issue
+    // #5068). The trial decrypt is real WebCrypto, so wait for the re-prompt
+    // rather than a microtask.
+    await screen.findByText(WRONG_PASSPHRASE_TRANSLATED);
+    expect(screen.queryByText(WRONG_PASSPHRASE_KEY)).toBeNull();
+    expect(screen.getByText('Enter sync passphrase')).toBeTruthy();
+    expect(session.isUnlocked()).toBe(false);
+    expect(unlocked).toBe(false);
+
+    await submit('correct-passphrase');
+    await waitFor(() => expect(screen.queryByText('Enter sync passphrase')).toBeNull());
+
+    expect(session.isUnlocked()).toBe(true);
+    expect(unlocked).toBe(true);
+  });
+
+  test('cancelling closes the dialog and leaves the session locked', async () => {
+    render(<PassphrasePrompt />);
+    let rejected = false;
+    await act(async () => {
+      void ensurePassphraseUnlocked({ session, client, verifyWith: cipher }).catch(() => {
+        rejected = true;
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Cancel'));
+    });
+
+    expect(rejected).toBe(true);
+    expect(session.isUnlocked()).toBe(false);
+    expect(screen.queryByText('Enter sync passphrase')).toBeNull();
+  });
+});

--- a/apps/readest-app/src/__tests__/libs/crypto/session.test.ts
+++ b/apps/readest-app/src/__tests__/libs/crypto/session.test.ts
@@ -3,6 +3,8 @@ import { CryptoSession } from '@/libs/crypto/session';
 import { CURRENT_ALG, encryptToEnvelope } from '@/libs/crypto/envelope';
 import { derivePbkdf2Key } from '@/libs/crypto/derive';
 import { isSyncError, SyncError } from '@/libs/errors';
+import type { PassphraseStore } from '@/libs/crypto/passphrase';
+import type { CipherEnvelope } from '@/types/replica';
 import type { ReplicaKeyRow } from '@/libs/replicaSyncClient';
 
 const ITER = 1000;
@@ -47,6 +49,22 @@ class FakeClient {
   async forgetReplicaKeys(): Promise<void> {
     this.forgetCalls += 1;
     this.rows = [];
+  }
+}
+
+class FakePassphraseStore implements PassphraseStore {
+  value: string | null = null;
+  async set(passphrase: string): Promise<void> {
+    this.value = passphrase;
+  }
+  async get(): Promise<string | null> {
+    return this.value;
+  }
+  async clear(): Promise<void> {
+    this.value = null;
+  }
+  isAvailable(): boolean {
+    return true;
   }
 }
 
@@ -190,5 +208,76 @@ describe('CryptoSession', () => {
     const direct = await encryptToEnvelope('a', directKey, salt.saltId);
     const recovered = await session.decryptField(direct);
     expect(recovered).toBe('a');
+  });
+});
+
+describe('CryptoSession passphrase verification', () => {
+  let client: FakeClient;
+  let store: FakePassphraseStore;
+
+  const seedCipher = async (passphrase: string): Promise<CipherEnvelope> => {
+    const writer = new CryptoSession({ client, iterations: ITER });
+    await writer.setup(passphrase);
+    return writer.encryptField('secret');
+  };
+
+  beforeEach(() => {
+    client = new FakeClient();
+    store = new FakePassphraseStore();
+  });
+
+  test('unlock() rejects a passphrase that cannot decrypt the verification sample', async () => {
+    const cipher = await seedCipher('correct');
+    const session = new CryptoSession({ client, iterations: ITER, store });
+
+    await expect(session.unlock('wrong', { verifyWith: cipher })).rejects.toMatchObject({
+      name: 'SyncError',
+      code: 'DECRYPT',
+    });
+    // A rejected passphrase must leave no trace: the session stays locked so
+    // the gate re-prompts, and nothing lands in the keychain for
+    // tryRestoreFromStore to silently resurrect on the next launch.
+    expect(session.isUnlocked()).toBe(false);
+    expect(store.value).toBeNull();
+  });
+
+  test('unlock() accepts and persists a passphrase that decrypts the sample', async () => {
+    const cipher = await seedCipher('correct');
+    const session = new CryptoSession({ client, iterations: ITER, store });
+
+    await session.unlock('correct', { verifyWith: cipher });
+    expect(session.isUnlocked()).toBe(true);
+    expect(store.value).toBe('correct');
+    expect(await session.decryptField(cipher)).toBe('secret');
+  });
+
+  test('unlock() accepts the passphrase when the sample is unverifiable (orphan salt)', async () => {
+    const cipher = await seedCipher('correct');
+    const orphan: CipherEnvelope = { ...cipher, s: 'no-such-salt' };
+    const session = new CryptoSession({ client, iterations: ITER, store });
+
+    // SALT_NOT_FOUND means "we can't tell", not "wrong passphrase" — refusing
+    // here would lock the user out of an account whose ciphers were orphaned
+    // by an out-of-band replica_keys reset.
+    await session.unlock('correct', { verifyWith: orphan });
+    expect(session.isUnlocked()).toBe(true);
+  });
+
+  test('unlock() without a sample stays permissive (no cipher to check against)', async () => {
+    await seedCipher('correct');
+    const session = new CryptoSession({ client, iterations: ITER, store });
+
+    await session.unlock('wrong');
+    expect(session.isUnlocked()).toBe(true);
+  });
+
+  test('invalidatePassphrase() locks the session and clears the stored copy', async () => {
+    const session = new CryptoSession({ client, iterations: ITER, store });
+    await session.setup('pw');
+    expect(store.value).toBe('pw');
+
+    await session.invalidatePassphrase();
+    expect(session.isUnlocked()).toBe(false);
+    expect(store.value).toBeNull();
   });
 });

--- a/apps/readest-app/src/__tests__/libs/replicaSyncClient.test.ts
+++ b/apps/readest-app/src/__tests__/libs/replicaSyncClient.test.ts
@@ -212,7 +212,7 @@ describe('ReplicaSyncClient.listReplicaKeys (cache + dedupe)', () => {
     expect(second).toEqual([sampleKey]);
   });
 
-  test('createReplicaKey appends the new salt to the cache (no extra fetch)', async () => {
+  test('createReplicaKey puts the new salt first in the cache (no extra fetch)', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ rows: [sampleKey] }), { status: 200 }),
     );
@@ -222,7 +222,10 @@ describe('ReplicaSyncClient.listReplicaKeys (cache + dedupe)', () => {
     mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ row: fresh }), { status: 201 }));
     await client.createReplicaKey('pbkdf2-600k-sha256');
     const cached = await client.listReplicaKeys();
-    expect(cached).toEqual([sampleKey, fresh]);
+    // Newest first, matching the server's ORDER BY created_at DESC — the
+    // CryptoSession takes rows[0] as the active salt, so an appended row
+    // would hand it the *oldest* salt after a rotation.
+    expect(cached).toEqual([fresh, sampleKey]);
     expect(mockFetch).toHaveBeenCalledTimes(2); // initial list + create; no re-list
   });
 

--- a/apps/readest-app/src/__tests__/services/sync/passphraseGate.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/passphraseGate.test.ts
@@ -6,6 +6,7 @@ import {
   __resetPassphraseGateForTests,
 } from '@/services/sync/passphraseGate';
 import { isSyncError } from '@/libs/errors';
+import type { CipherEnvelope } from '@/types/replica';
 import type { ReplicaKeyRow } from '@/libs/replicaSyncClient';
 
 const ITER = 1000;
@@ -59,14 +60,17 @@ describe('ensurePassphraseUnlocked', () => {
     expect(prompter).not.toHaveBeenCalled();
   });
 
-  test('throws NO_PASSPHRASE when no prompter is registered', async () => {
-    let caught: unknown = null;
+  test('throws NO_PASSPHRASE when no prompter ever registers', async () => {
+    vi.useFakeTimers();
     try {
-      await ensurePassphraseUnlocked({ session, client });
-    } catch (e) {
-      caught = e;
+      const pending = ensurePassphraseUnlocked({ session, client });
+      const caught = pending.catch((e: unknown) => e);
+      await vi.advanceTimersByTimeAsync(30_000);
+      const err = await caught;
+      expect(isSyncError(err) && err.code).toBe('NO_PASSPHRASE');
+    } finally {
+      vi.useRealTimers();
     }
-    expect(isSyncError(caught) && caught.code).toBe('NO_PASSPHRASE');
   });
 
   test('prompts with kind=setup when account has no salt', async () => {
@@ -116,6 +120,144 @@ describe('ensurePassphraseUnlocked', () => {
       ensurePassphraseUnlocked({ session, client }),
     ]);
     expect(calls).toBe(1);
+    expect(session.isUnlocked()).toBe(true);
+  });
+
+  test('waits for a prompter that registers after the request', async () => {
+    const pending = ensurePassphraseUnlocked({ session, client });
+    await Promise.resolve();
+    setPassphrasePrompter(async () => 'pw');
+    await pending;
+    expect(session.isUnlocked()).toBe(true);
+  });
+});
+
+describe('ensurePassphraseUnlocked — wrong passphrase recovery', () => {
+  let client: FakeClient;
+  let session: CryptoSession;
+  let cipher: CipherEnvelope;
+
+  beforeEach(async () => {
+    client = new FakeClient();
+    const writer = new CryptoSession({ client, iterations: ITER });
+    await writer.setup('correct');
+    cipher = await writer.encryptField('secret');
+    session = new CryptoSession({ client, iterations: ITER });
+  });
+
+  afterEach(() => {
+    __resetPassphraseGateForTests();
+  });
+
+  test('re-prompts with an error until the passphrase verifies', async () => {
+    const seen: (string | undefined)[] = [];
+    const answers = ['wrong', 'still-wrong', 'correct'];
+    setPassphrasePrompter(async ({ error }) => {
+      seen.push(error);
+      return answers.shift()!;
+    });
+
+    await ensurePassphraseUnlocked({ session, client, verifyWith: cipher });
+
+    expect(session.isUnlocked()).toBe(true);
+    expect(await session.decryptField(cipher)).toBe('secret');
+    // First prompt is clean; every retry carries the "that was wrong" copy.
+    expect(seen[0]).toBeUndefined();
+    expect(seen[1]).toBeTruthy();
+    expect(seen[2]).toBeTruthy();
+  });
+
+  test('cancelling a retry rejects with NO_PASSPHRASE and leaves the session locked', async () => {
+    const answers: (string | null)[] = ['wrong', null];
+    setPassphrasePrompter(async () => answers.shift()!);
+
+    await expect(
+      ensurePassphraseUnlocked({ session, client, verifyWith: cipher }),
+    ).rejects.toMatchObject({ code: 'NO_PASSPHRASE' });
+    expect(session.isUnlocked()).toBe(false);
+  });
+
+  test('invalidate drops a known-bad unlocked session and prompts again', async () => {
+    // The Android dead-end: a wrong passphrase was accepted before verification
+    // existed, so the session reports unlocked while every decrypt fails.
+    await session.unlock('wrong');
+    expect(session.isUnlocked()).toBe(true);
+
+    setPassphrasePrompter(async () => 'correct');
+    await ensurePassphraseUnlocked({ session, client, verifyWith: cipher, invalidate: true });
+
+    expect(await session.decryptField(cipher)).toBe('secret');
+  });
+
+  test('automatic recovery runs once per run, then stays out of the way', async () => {
+    await session.unlock('wrong');
+    // Answers a wrong passphrase, then cancels the retry — the first recovery
+    // ends in failure.
+    let call = 0;
+    const prompter = vi.fn(async (): Promise<string | null> => (call++ === 0 ? 'nope' : null));
+    setPassphrasePrompter(prompter);
+
+    await expect(
+      ensurePassphraseUnlocked({
+        session,
+        client,
+        verifyWith: cipher,
+        invalidate: true,
+        auto: true,
+      }),
+    ).rejects.toMatchObject({ code: 'NO_PASSPHRASE' });
+
+    // An account whose rows carry ciphers under two different passphrases can
+    // never satisfy them all — the next pull must not reopen the modal and
+    // wipe the session again.
+    prompter.mockClear();
+    await expect(
+      ensurePassphraseUnlocked({
+        session,
+        client,
+        verifyWith: cipher,
+        invalidate: true,
+        auto: true,
+      }),
+    ).rejects.toMatchObject({ code: 'NO_PASSPHRASE' });
+    expect(prompter).not.toHaveBeenCalled();
+  });
+
+  test('concurrent recovery requests share one prompt', async () => {
+    await session.unlock('wrong');
+    const prompter = vi.fn(async (): Promise<string | null> => 'correct');
+    setPassphrasePrompter(prompter);
+
+    await Promise.all([
+      ensurePassphraseUnlocked({ session, client, verifyWith: cipher, invalidate: true }),
+      ensurePassphraseUnlocked({ session, client, verifyWith: cipher, invalidate: true }),
+    ]);
+
+    // The second request must not invalidate the session the first one just
+    // unlocked — it waits for that same prompt instead.
+    expect(prompter).toHaveBeenCalledTimes(1);
+    expect(session.isUnlocked()).toBe(true);
+    expect(await session.decryptField(cipher)).toBe('secret');
+  });
+
+  test('auto requests stay quiet after the user cancels, user-initiated ones do not', async () => {
+    const prompter = vi.fn(async (): Promise<string | null> => null);
+    setPassphrasePrompter(prompter);
+
+    await expect(
+      ensurePassphraseUnlocked({ session, client, verifyWith: cipher, auto: true }),
+    ).rejects.toMatchObject({ code: 'NO_PASSPHRASE' });
+    // A declined user must not be re-prompted by every focus / periodic pull.
+    await expect(
+      ensurePassphraseUnlocked({ session, client, verifyWith: cipher, auto: true }),
+    ).rejects.toMatchObject({ code: 'NO_PASSPHRASE' });
+    expect(prompter).toHaveBeenCalledTimes(1);
+
+    // ...but an explicit user action (Settings → Enter passphrase, saving a
+    // new credential) always gets its prompt back.
+    prompter.mockImplementation(async () => 'correct');
+    await ensurePassphraseUnlocked({ session, client, verifyWith: cipher });
+    expect(prompter).toHaveBeenCalledTimes(2);
     expect(session.isUnlocked()).toBe(true);
   });
 });

--- a/apps/readest-app/src/__tests__/services/sync/replicaCryptoMiddleware.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/replicaCryptoMiddleware.test.ts
@@ -131,7 +131,7 @@ describe('replicaCryptoMiddleware', () => {
         password: wrapField(cipher),
         username: wrapField(await writer.encryptField('alice')),
       };
-      await decryptRowFields(fields, ['username', 'password'], reader, onLocked);
+      await decryptRowFields(fields, ['username', 'password'], reader, { onLocked });
       // Callback fired exactly once even though there are two cipher
       // fields — once unlocked, the second field decrypts directly.
       expect(onLocked).toHaveBeenCalledTimes(1);
@@ -149,7 +149,7 @@ describe('replicaCryptoMiddleware', () => {
         throw new Error('user cancelled');
       });
       const fields: FieldsObject = { password: wrapField(cipher) };
-      await decryptRowFields(fields, ['password'], reader, onLocked);
+      await decryptRowFields(fields, ['password'], reader, { onLocked });
       expect(onLocked).toHaveBeenCalledTimes(1);
       expect(fields['password']).toBeUndefined();
     });
@@ -164,6 +164,54 @@ describe('replicaCryptoMiddleware', () => {
       const fields: FieldsObject = { password: wrapField(cipher) };
       await decryptRowFields(fields, ['password'], reader);
       expect(fields['password']).toBeUndefined();
+    });
+
+    test('wrong-passphrase decrypt asks for a new passphrase and retries the field', async () => {
+      const writer = new CryptoSession({ client, iterations: ITER });
+      await writer.setup('correct');
+      const cipher = await writer.encryptField('secret');
+      const userCipher = await writer.encryptField('alice');
+
+      // Reader is unlocked with a stale/wrong passphrase — the state a device
+      // lands in when a mistyped passphrase was accepted and keychained.
+      const reader = new CryptoSession({ client, iterations: ITER });
+      await reader.unlock('wrong');
+      const onWrongPassphrase = vi.fn(async () => {
+        reader.lock();
+        await reader.unlock('correct');
+      });
+      const fields: FieldsObject = {
+        password: wrapField(cipher),
+        username: wrapField(userCipher),
+      };
+      await decryptRowFields(fields, ['password', 'username'], reader, { onWrongPassphrase });
+
+      // One recovery attempt, both fields recovered — no data dropped.
+      expect(onWrongPassphrase).toHaveBeenCalledTimes(1);
+      expect((fields['password'] as { v: unknown }).v).toBe('secret');
+      expect((fields['username'] as { v: unknown }).v).toBe('alice');
+    });
+
+    test('onWrongPassphrase runs at most once and the field drops if it fails', async () => {
+      const writer = new CryptoSession({ client, iterations: ITER });
+      await writer.setup('correct');
+      const cipher = await writer.encryptField('secret');
+      const userCipher = await writer.encryptField('alice');
+
+      const reader = new CryptoSession({ client, iterations: ITER });
+      await reader.unlock('wrong');
+      const onWrongPassphrase = vi.fn(async () => {
+        throw new Error('user cancelled');
+      });
+      const fields: FieldsObject = {
+        password: wrapField(cipher),
+        username: wrapField(userCipher),
+      };
+      await decryptRowFields(fields, ['password', 'username'], reader, { onWrongPassphrase });
+
+      expect(onWrongPassphrase).toHaveBeenCalledTimes(1);
+      expect(fields['password']).toBeUndefined();
+      expect(fields['username']).toBeUndefined();
     });
 
     test('leaves plaintext envelopes untouched (no cipher detected)', async () => {

--- a/apps/readest-app/src/__tests__/services/sync/replicaPullAndApply.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/replicaPullAndApply.test.ts
@@ -14,16 +14,19 @@ vi.mock('@/libs/crypto/session', () => ({
 }));
 
 const passphraseMocks = vi.hoisted(() => ({
-  ensure: vi.fn(async () => {}),
+  ensure: vi.fn(async (_deps?: Record<string, unknown>) => {}),
+  remember: vi.fn((_envelope: unknown) => {}),
 }));
 vi.mock('@/services/sync/passphraseGate', () => ({
-  ensurePassphraseUnlocked: () => passphraseMocks.ensure(),
+  ensurePassphraseUnlocked: (deps?: Record<string, unknown>) => passphraseMocks.ensure(deps),
+  rememberVerificationSample: (envelope: unknown) => passphraseMocks.remember(envelope),
 }));
 
 import { replicaPullAndApply, type PullAndApplyDeps } from '@/services/sync/replicaPullAndApply';
 import { dictionaryAdapter } from '@/services/sync/adapters/dictionary';
 import { opdsCatalogAdapter } from '@/services/sync/adapters/opdsCatalog';
 import { hlcPack } from '@/libs/crdt';
+import { SyncError } from '@/libs/errors';
 import type { CipherEnvelope, Hlc, Manifest, ReplicaRow } from '@/types/replica';
 import type { ImportedDictionary } from '@/services/dictionaries/types';
 import type { OPDSCatalog } from '@/types/opds';
@@ -471,6 +474,7 @@ describe('replicaPullAndApply credentials category gate (opds adapter)', () => {
     cryptoMocks.decryptField.mockReset();
     passphraseMocks.ensure.mockReset();
     passphraseMocks.ensure.mockResolvedValue(undefined);
+    passphraseMocks.remember.mockReset();
   });
 
   afterEach(() => {
@@ -536,5 +540,34 @@ describe('replicaPullAndApply credentials category gate (opds adapter)', () => {
     // Gate prompted (cipher present + locked + cipher fingerprint not seen).
     expect(passphraseMocks.ensure).toHaveBeenCalledTimes(1);
     expect(cryptoMocks.decryptField).toHaveBeenCalledTimes(2);
+  });
+
+  test('re-prompts and recovers when the session holds the wrong passphrase', async () => {
+    setCredentialsCategory(true);
+    // The stranded-device state (issue #5068): the session reports unlocked
+    // because a wrong passphrase was accepted and keychained, so the locked-
+    // path prompt never fires — every decrypt just fails.
+    cryptoMocks.isUnlocked.mockReturnValue(true);
+    let rightKey = false;
+    cryptoMocks.decryptField.mockImplementation(async () => {
+      if (!rightKey) throw new SyncError('DECRYPT', 'AES-GCM decryption failed');
+      return 'plain';
+    });
+    passphraseMocks.ensure.mockImplementation(async () => {
+      rightKey = true;
+    });
+
+    const deps = makeOpdsDeps();
+    (deps.pull as ReturnType<typeof vi.fn>).mockResolvedValue([opdsRow()]);
+
+    await replicaPullAndApply(deps);
+
+    // The bad passphrase is thrown away (keychain included) and re-asked for,
+    // once — then both fields decrypt on the retry.
+    expect(passphraseMocks.ensure).toHaveBeenCalledTimes(1);
+    expect(passphraseMocks.ensure.mock.calls[0]![0]).toMatchObject({ invalidate: true });
+    const applied = (deps.applyRemote as ReturnType<typeof vi.fn>).mock.calls[0]![0] as OPDSCatalog;
+    expect(applied.username).toBe('plain');
+    expect(applied.password).toBe('plain');
   });
 });

--- a/apps/readest-app/src/app/user/components/SyncPassphraseSection.tsx
+++ b/apps/readest-app/src/app/user/components/SyncPassphraseSection.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from '@/hooks/useTranslation';
 import { cryptoSession } from '@/libs/crypto/session';
-import { ensurePassphraseUnlocked } from '@/services/sync/passphraseGate';
+import { clearVerificationSample, ensurePassphraseUnlocked } from '@/services/sync/passphraseGate';
 import { replicaSyncClient } from '@/libs/replicaSyncClient';
 import { isSyncError } from '@/libs/errors';
 import { useSettingsStore } from '@/store/settingsStore';
@@ -23,10 +23,12 @@ export function SyncPassphraseSection() {
     (state) => state.settings?.syncCategories?.credentials === true,
   );
   const [status, setStatus] = useState<SyncPassphraseStatus>('loading');
+  const [unlocked, setUnlocked] = useState(false);
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
   const refreshStatus = async () => {
+    setUnlocked(cryptoSession.isUnlocked());
     try {
       const rows = await replicaSyncClient.listReplicaKeys();
       setStatus(rows.length === 0 ? 'unset' : 'set');
@@ -46,25 +48,28 @@ export function SyncPassphraseSection() {
     void refreshStatus();
   }, [credentialsSync]);
 
-  // Credentials sync off → no passphrase UI at all (set / forget /
+  // Credentials sync off → no passphrase UI at all (set / enter / forget /
   // status indicator are all hidden).
   if (!credentialsSync) return null;
   if (status === 'loading') return null;
 
-  // First-time setup: when the user has no replica_keys row yet, the
-  // gate's `kind === 'setup'` branch creates a fresh salt + key. Once
-  // a passphrase exists the unlock prompt fires automatically on the
-  // first encrypted-field push or pull, so there's no manual unlock
-  // affordance — the only button left is "Forgot passphrase".
-  const handleSetOrUnlock = async () => {
+  /**
+   * The manual way in. Without it, a device that holds the wrong passphrase
+   * has no recovery: the pull sees an "unlocked" session, never prompts, and
+   * just fails to decrypt. `invalidate` throws away whatever this device is
+   * holding (including the copy in the OS keychain) so the prompt asks again
+   * from scratch and verifies the answer before accepting it.
+   */
+  const handleSetOrEnter = async () => {
     setBusy(true);
     setMessage(null);
     try {
-      await ensurePassphraseUnlocked();
+      await ensurePassphraseUnlocked({ invalidate: unlocked });
       await refreshStatus();
       setMessage(_('Sync passphrase ready'));
     } catch (err) {
       setMessage(err instanceof Error ? err.message : String(err));
+      setUnlocked(cryptoSession.isUnlocked());
     } finally {
       setBusy(false);
     }
@@ -84,6 +89,7 @@ export function SyncPassphraseSection() {
     setMessage(null);
     try {
       await cryptoSession.forget();
+      clearVerificationSample();
       await refreshStatus();
       setMessage(_('Sync passphrase forgotten. All encrypted fields cleared.'));
     } catch (err) {
@@ -101,15 +107,20 @@ export function SyncPassphraseSection() {
           ? _(
               'Sensitive synced fields are encrypted before upload. Set a passphrase now or later when encryption is needed.',
             )
-          : _('Saved to this account. You will be prompted for it when decrypting credentials.')}
+          : unlocked
+            ? _('Unlocked on this device. Your synced credentials are being decrypted.')
+            : _('Set on this account. Enter it on this device to decrypt your synced credentials.')}
       </p>
       {message && <p className='text-base-content/60 mb-3 text-xs'>{message}</p>}
       <div className='flex flex-wrap gap-2'>
-        {status === 'unset' ? (
-          <button className='btn btn-primary btn-sm' disabled={busy} onClick={handleSetOrUnlock}>
-            {_('Set passphrase')}
-          </button>
-        ) : (
+        <button className='btn btn-contrast btn-sm' disabled={busy} onClick={handleSetOrEnter}>
+          {status === 'unset'
+            ? _('Set passphrase')
+            : unlocked
+              ? _('Re-enter passphrase')
+              : _('Enter passphrase')}
+        </button>
+        {status !== 'unset' && (
           <button
             className='btn btn-error btn-outline btn-sm'
             disabled={busy}

--- a/apps/readest-app/src/components/PassphrasePrompt.tsx
+++ b/apps/readest-app/src/components/PassphrasePrompt.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import ModalPortal from '@/components/ModalPortal';
 import { useTranslation } from '@/hooks/useTranslation';
-import { setPassphrasePrompter } from '@/services/sync/passphraseGate';
+import { setPassphraseDismisser, setPassphrasePrompter } from '@/services/sync/passphraseGate';
 import type { PassphrasePromptKind } from '@/services/sync/passphraseGate';
 
 interface PendingPrompt {
@@ -17,6 +17,11 @@ interface PendingPrompt {
  * any caller that invokes `ensurePassphraseUnlocked` causes this
  * modal to render and resolve with the entered passphrase (or null
  * on cancel).
+ *
+ * Submitting doesn't close the dialog — the gate verifies the passphrase
+ * against the account's ciphertext first (a PBKDF2 derive, seconds on a
+ * phone), and either dismisses us or prompts again with an error. So the
+ * modal shows a checking state in between rather than blinking out.
  */
 export default function PassphrasePrompt() {
   const _ = useTranslation();
@@ -24,19 +29,37 @@ export default function PassphrasePrompt() {
   const [value, setValue] = useState('');
   const [confirm, setConfirm] = useState('');
   const [error, setError] = useState('');
+  const [checking, setChecking] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    setPassphrasePrompter(({ kind }) => {
+    // `promptError` arrives on a re-prompt: the gate trial-decrypted the
+    // previous answer against this account's ciphertext and it didn't verify.
+    // It reaches us as the untranslated key (the gate is a non-React module and
+    // can only `stubTranslation` it), so the real `_()` has to run here.
+    setPassphrasePrompter(({ kind, error: promptError }) => {
       return new Promise<string | null>((resolve) => {
         setValue('');
         setConfirm('');
-        setError('');
+        setError(promptError ? _(promptError) : '');
+        setChecking(false);
         setPending({ kind, resolve });
       });
     });
-    return () => setPassphrasePrompter(null);
-  }, []);
+    setPassphraseDismisser(() => {
+      setPending(null);
+      setValue('');
+      setConfirm('');
+      setError('');
+      setChecking(false);
+    });
+    return () => {
+      setPassphrasePrompter(null);
+      setPassphraseDismisser(null);
+    };
+    // Re-register when the translator changes (UI language switch) so the
+    // retry error isn't rendered by a stale `_`.
+  }, [_]);
 
   useEffect(() => {
     if (pending) {
@@ -50,16 +73,9 @@ export default function PassphrasePrompt() {
 
   const isSetup = pending.kind === 'setup';
 
-  const close = (passphrase: string | null) => {
-    pending.resolve(passphrase);
-    setPending(null);
-    setValue('');
-    setConfirm('');
-    setError('');
-  };
-
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (checking) return;
     if (value.length < 8) {
       setError(_('Passphrase must be at least 8 characters'));
       return;
@@ -68,14 +84,19 @@ export default function PassphrasePrompt() {
       setError(_('Passphrases do not match'));
       return;
     }
-    close(value);
+    // Hand the answer to the gate and wait: it dismisses us on success, or
+    // calls the prompter again with an error if the passphrase was wrong.
+    setChecking(true);
+    setError('');
+    pending.resolve(value);
   };
 
   // Input pill — modern style for color themes; eink-bordered swaps to
   // 1px border + base-100 bg under [data-eink='true'].
   const inputClass =
     'eink-bordered w-full rounded-xl bg-base-300/60 px-4 py-3 text-sm placeholder:text-base-content/40 ' +
-    'border border-transparent transition-colors focus:border-base-content/20 focus:bg-base-300';
+    'border border-transparent transition-colors focus:border-base-content/20 focus:bg-base-300 ' +
+    'disabled:opacity-60';
 
   return (
     <ModalPortal>
@@ -105,6 +126,7 @@ export default function PassphrasePrompt() {
               placeholder={_('Sync passphrase')}
               className={inputClass}
               autoComplete='new-password'
+              disabled={checking}
               required
             />
             {isSetup && (
@@ -118,6 +140,7 @@ export default function PassphrasePrompt() {
                 placeholder={_('Confirm passphrase')}
                 className={inputClass}
                 autoComplete='new-password'
+                disabled={checking}
                 required
               />
             )}
@@ -125,23 +148,25 @@ export default function PassphrasePrompt() {
             <div className='flex justify-end gap-2 pt-4'>
               {/*
                * Cancel: ghost in color themes, eink-bordered (white bg
-               * + base-content border) under eink. Submit: bg-primary
-               * in color themes, picks up the existing
-               * `[data-eink] .btn-primary` rule (inverted to
-               * base-content bg + base-100 text) under eink — so the
-               * two buttons stay visually distinct on e-paper.
+               * + base-content border) under eink. Submit: btn-contrast —
+               * base-content bg + base-100 label, theme-neutral and already
+               * e-ink-correct, so the two stay distinct on e-paper without a
+               * themed accent colour.
                */}
               <button
                 type='button'
-                onClick={() => close(null)}
-                className='eink-bordered hover:bg-base-300/70 rounded-lg px-4 py-2 text-sm font-medium transition-colors'
+                onClick={() => pending.resolve(null)}
+                disabled={checking}
+                className='eink-bordered hover:bg-base-300/70 rounded-lg px-4 py-2 text-sm font-medium transition-colors disabled:opacity-60'
               >
                 {_('Cancel')}
               </button>
               <button
                 type='submit'
-                className='btn btn-primary text-primary-content hover:bg-primary/90 active:bg-primary/80 rounded-lg border-0 px-4 py-2 text-sm font-medium transition-colors'
+                disabled={checking}
+                className='btn btn-contrast rounded-lg px-4 py-2 text-sm font-medium transition-colors'
               >
+                {checking && <span className='loading loading-spinner loading-xs' />}
                 {isSetup ? _('Set passphrase') : _('Unlock')}
               </button>
             </div>

--- a/apps/readest-app/src/libs/crypto/session.ts
+++ b/apps/readest-app/src/libs/crypto/session.ts
@@ -1,4 +1,4 @@
-import { SyncError } from '@/libs/errors';
+import { isWrongPassphraseError, SyncError } from '@/libs/errors';
 import type { CipherEnvelope } from '@/types/replica';
 import { replicaSyncClient } from '@/libs/replicaSyncClient';
 import type { ReplicaKeyRow, ReplicaSyncClient } from '@/libs/replicaSyncClient';
@@ -32,6 +32,16 @@ export interface CryptoSessionDeps {
    * upgrades to OS keychain on Tauri). Tests pass a mock.
    */
   store?: PassphraseStore;
+}
+
+export interface UnlockOptions {
+  /**
+   * A cipher envelope belonging to this account, trial-decrypted to prove
+   * the candidate passphrase is the right one before it is accepted and
+   * persisted. Omit only when the account holds no ciphertext to check
+   * against.
+   */
+  verifyWith?: CipherEnvelope;
 }
 
 export class CryptoSession {
@@ -79,8 +89,17 @@ export class CryptoSession {
    * the account has no salt yet — callers must call setup() instead.
    * On success, persists the passphrase to the configured store so the
    * next launch can silently restore (Tauri keychain) or re-prompt (web).
+   *
+   * PBKDF2 derivation succeeds for *any* string, so without
+   * `opts.verifyWith` this call cannot tell a right passphrase from a
+   * wrong one. Pass a cipher envelope the account is known to hold and
+   * the candidate is trial-decrypted first: a wrong passphrase throws,
+   * the session stays locked, and nothing is persisted. Callers that
+   * skip verification (no cipher exists yet) can still land a wrong
+   * passphrase — the pull path catches that later and calls
+   * `invalidatePassphrase`.
    */
-  async unlock(passphrase: string): Promise<void> {
+  async unlock(passphrase: string, opts: UnlockOptions = {}): Promise<void> {
     const rows = await this.client.listReplicaKeys();
     if (rows.length === 0) {
       throw new SyncError(
@@ -91,8 +110,48 @@ export class CryptoSession {
     this.ingestRows(rows);
     this.passphrase = passphrase;
     this.activeSaltId = rows[0]!.saltId;
-    await this.deriveKeyFor(this.activeSaltId);
+    try {
+      await this.deriveKeyFor(this.activeSaltId);
+      if (opts.verifyWith) await this.verifyAgainst(opts.verifyWith);
+    } catch (err) {
+      // Leave nothing half-derived behind: a rejected candidate must not
+      // sit in this.keys / this.passphrase where isUnlocked() would
+      // report a working session.
+      this.lock();
+      throw err;
+    }
     await this.persistPassphrase(passphrase);
+  }
+
+  /**
+   * Trial-decrypt the sample. Only a wrong-passphrase signature is fatal —
+   * SALT_NOT_FOUND (cipher orphaned by an out-of-band replica_keys reset) or
+   * a crypto-unavailable environment means "can't tell", and refusing there
+   * would lock the user out of an account whose passphrase is actually right.
+   */
+  private async verifyAgainst(sample: CipherEnvelope): Promise<void> {
+    try {
+      await this.decryptField(sample);
+    } catch (err) {
+      if (isWrongPassphraseError(err)) throw err;
+      console.warn('[cryptoSession] passphrase sample could not be verified', err);
+    }
+  }
+
+  /**
+   * The passphrase this session holds is wrong (a decrypt failed with an
+   * auth-tag mismatch). Drop it from memory AND from the store, so the
+   * keychain doesn't silently restore the same bad passphrase on the next
+   * launch — that loop is what stranded devices with an undismissable
+   * "wrong sync passphrase" toast and no way to re-enter it.
+   */
+  async invalidatePassphrase(): Promise<void> {
+    this.lock();
+    try {
+      await this.store().clear();
+    } catch (err) {
+      console.warn('[cryptoSession] failed to clear passphrase store', err);
+    }
   }
 
   /**

--- a/apps/readest-app/src/libs/errors.ts
+++ b/apps/readest-app/src/libs/errors.ts
@@ -43,6 +43,15 @@ export class SyncError extends Error {
 export const isSyncError = (e: unknown): e is SyncError =>
   e instanceof SyncError || (e instanceof Error && e.name === 'SyncError');
 
+/**
+ * The signature of "this key can't read this ciphertext": AES-GCM auth-tag
+ * failure or SHA-256 sidecar mismatch. In practice both mean the passphrase
+ * behind the derived key is wrong. Distinct from SALT_NOT_FOUND /
+ * CRYPTO_UNAVAILABLE, which say nothing about the passphrase.
+ */
+export const isWrongPassphraseError = (e: unknown): boolean =>
+  isSyncError(e) && (e.code === 'DECRYPT' || e.code === 'INTEGRITY');
+
 export const assertNever = (x: never): never => {
   throw new SyncError('VALIDATION', `Unexpected value: ${JSON.stringify(x)}`);
 };

--- a/apps/readest-app/src/libs/replicaSyncClient.ts
+++ b/apps/readest-app/src/libs/replicaSyncClient.ts
@@ -265,10 +265,12 @@ export class ReplicaSyncClient {
       throw new SyncError('SERVER', 'replica-keys create returned no row');
     }
     // Splice the new salt into the cache so the next listReplicaKeys
-    // call sees it without another round trip. Rotation appends — old
-    // salts stay accessible for decrypting envelopes still under them.
+    // call sees it without another round trip. Newest first, matching the
+    // server's ORDER BY created_at DESC — CryptoSession reads rows[0] as the
+    // active salt, so appending here would hand it the oldest one. Old salts
+    // stay in the list: envelopes still under them must remain decryptable.
     if (this.replicaKeysCache !== null) {
-      this.replicaKeysCache = [...this.replicaKeysCache, data.row];
+      this.replicaKeysCache = [data.row, ...this.replicaKeysCache];
     }
     return data.row;
   }

--- a/apps/readest-app/src/services/sync/passphraseGate.ts
+++ b/apps/readest-app/src/services/sync/passphraseGate.ts
@@ -10,19 +10,27 @@
  *   - If the server has no salt yet (first encrypted op for the
  *     account), the prompter is called with `{ kind: 'setup' }` and
  *     the entered passphrase mints a fresh salt + key.
+ * - The entered passphrase is verified against a cipher envelope the
+ *   account is known to hold (`verifyWith`, or the sample the pull path
+ *   last saw). A wrong one is never accepted: the prompt re-opens with an
+ *   error until it verifies or the user cancels.
  * - When the user cancels the modal, ensurePassphraseUnlocked rejects
  *   with `NO_PASSPHRASE`. Callers handle by aborting the sync action
  *   (e.g., refusing to save credentials, falling back to plaintext-only).
+ *   A cancel also silences `auto: true` (pull-triggered) requests for the
+ *   rest of the run so a declined user isn't re-prompted on every pull;
+ *   any user-initiated request clears that.
  *
  * The gate is platform-agnostic — same path on web (ephemeral session)
- * and native (also ephemeral until PR 4d wires the keychain). Once 4d
- * lands, the only change is that `cryptoSession.unlock` reads the
- * passphrase from the keychain on subsequent launches without
- * re-prompting.
+ * and native (OS keychain). On native, `cryptoSession.tryRestoreFromStore`
+ * unlocks from the keychain at boot without re-prompting.
  */
-import { SyncError } from '@/libs/errors';
+import { isWrongPassphraseError, SyncError } from '@/libs/errors';
 import { cryptoSession as defaultCryptoSession } from '@/libs/crypto/session';
 import { replicaSyncClient } from '@/libs/replicaSyncClient';
+import { isCipherEnvelope } from '@/types/replica';
+import { stubTranslation as _ } from '@/utils/misc';
+import type { CipherEnvelope } from '@/types/replica';
 import type { CryptoSession } from '@/libs/crypto/session';
 import type { ReplicaSyncClient } from '@/libs/replicaSyncClient';
 
@@ -30,61 +38,224 @@ export type PassphrasePromptKind = 'unlock' | 'setup';
 
 export interface PassphrasePromptRequest {
   kind: PassphrasePromptKind;
+  /** Set on a re-prompt after the previous attempt failed to verify. */
+  error?: string;
 }
 
 export type PassphrasePrompter = (req: PassphrasePromptRequest) => Promise<string | null>;
 
+/** How long a caller waits for the prompt UI to mount before giving up. */
+const PROMPTER_WAIT_MS = 10_000;
+
 let prompter: PassphrasePrompter | null = null;
+let dismisser: (() => void) | null = null;
+let prompterWaiters: Array<(p: PassphrasePrompter) => void> = [];
 let inflight: Promise<void> | null = null;
+let declined = false;
+let recoveryFailed = false;
+/**
+ * The most recent cipher envelope the pull path saw for this account. Lets
+ * a caller with no envelope of its own still verify a candidate passphrase
+ * — notably the Settings → Enter passphrase action, which runs long after
+ * the row that carried the ciphertext was applied.
+ */
+let verificationSample: CipherEnvelope | null = null;
 
 export const setPassphrasePrompter = (p: PassphrasePrompter | null): void => {
   prompter = p;
+  if (!p) return;
+  const waiters = prompterWaiters;
+  prompterWaiters = [];
+  for (const resolve of waiters) resolve(p);
 };
 
-interface EnsureUnlockedDeps {
+/**
+ * Register the UI's "close the modal" callback. The prompter's promise
+ * resolves the moment the user submits, but the modal stays up while we
+ * derive the key and trial-decrypt — a wrong passphrase then re-prompts in
+ * place instead of the dialog blinking out and back. The gate calls this
+ * once the whole unlock cycle is done, however it ended.
+ */
+export const setPassphraseDismisser = (d: (() => void) | null): void => {
+  dismisser = d;
+};
+
+const SAMPLE_KEY = 'readest_passphrase_verify_sample_v1';
+
+const safeLocalStorage = (): Storage | null => {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Remember a cipher envelope this account holds, for later verification.
+ *
+ * Persisted, because the pull that carries the ciphertext only runs on the
+ * library / reader routes — without this, the Settings action (a separate
+ * route, and a fresh page load on web) would have nothing to check an
+ * entered passphrase against. Only ciphertext is written; the plaintext it
+ * protects already lives in local settings on this device.
+ */
+export const rememberVerificationSample = (envelope: CipherEnvelope): void => {
+  verificationSample = envelope;
+  try {
+    safeLocalStorage()?.setItem(SAMPLE_KEY, JSON.stringify(envelope));
+  } catch {
+    /* ignore quota / private mode */
+  }
+};
+
+/** Drop the sample — its ciphertext is gone server-side (forgot passphrase). */
+export const clearVerificationSample = (): void => {
+  verificationSample = null;
+  try {
+    safeLocalStorage()?.removeItem(SAMPLE_KEY);
+  } catch {
+    /* ignore */
+  }
+};
+
+const getVerificationSample = (): CipherEnvelope | undefined => {
+  if (verificationSample) return verificationSample;
+  try {
+    const raw = safeLocalStorage()?.getItem(SAMPLE_KEY);
+    if (!raw) return undefined;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isCipherEnvelope(parsed)) return undefined;
+    verificationSample = parsed;
+    return parsed;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Resolve the registered prompter, waiting briefly if the UI hasn't mounted
+ * yet. Without the wait, a pull that lands before `PassphrasePrompt`'s
+ * registration effect runs throws NO_PASSPHRASE and silently skips the
+ * prompt — the "sometimes the popup shows, sometimes it doesn't, so I keep
+ * refreshing" symptom.
+ */
+const waitForPrompter = async (): Promise<PassphrasePrompter> => {
+  if (prompter) return prompter;
+  return new Promise<PassphrasePrompter>((resolve, reject) => {
+    const onReady = (p: PassphrasePrompter) => {
+      clearTimeout(timer);
+      resolve(p);
+    };
+    const timer = setTimeout(() => {
+      prompterWaiters = prompterWaiters.filter((w) => w !== onReady);
+      reject(new SyncError('NO_PASSPHRASE', 'No passphrase prompter registered'));
+    }, PROMPTER_WAIT_MS);
+    prompterWaiters.push(onReady);
+  });
+};
+
+export interface EnsureUnlockedDeps {
   session?: CryptoSession;
   client?: Pick<ReplicaSyncClient, 'listReplicaKeys'>;
+  /**
+   * Cipher envelope used to check the entered passphrase. Defaults to the
+   * sample the pull path last recorded.
+   */
+  verifyWith?: CipherEnvelope;
+  /**
+   * The session's current passphrase is known-bad (a decrypt failed with an
+   * auth-tag mismatch). Drop it — and the copy in the OS keychain — before
+   * prompting, instead of returning early on `isUnlocked()`.
+   */
+  invalidate?: boolean;
+  /**
+   * Automatic, pull-triggered request. Suppressed for the rest of the run
+   * once the user has cancelled a prompt. User-initiated requests (saving a
+   * credential, Settings → Enter passphrase) leave this off, and clear the
+   * suppression.
+   */
+  auto?: boolean;
 }
 
 /**
- * Resolves once the CryptoSession is unlocked. If unlocked already,
+ * Resolves once the CryptoSession is unlocked with a passphrase that
+ * actually decrypts this account's ciphertext. If unlocked already,
  * resolves immediately. If a prompt is already in flight, awaits the
  * existing one (so concurrent calls don't open multiple modals).
  *
- * Throws `NO_PASSPHRASE` when the user cancels or no prompter has
- * been registered. Throws other SyncError codes for crypto failures
- * (CRYPTO_UNAVAILABLE, AUTH, SERVER, ...).
+ * Throws `NO_PASSPHRASE` when the user cancels, when a declined `auto`
+ * request is suppressed, or when no prompter shows up. Throws other
+ * SyncError codes for crypto failures (CRYPTO_UNAVAILABLE, AUTH, ...).
  */
 export const ensurePassphraseUnlocked = async (deps: EnsureUnlockedDeps = {}): Promise<void> => {
   const session = deps.session ?? defaultCryptoSession;
   const client = deps.client ?? replicaSyncClient;
-  if (session.isUnlocked()) return;
+  if (deps.auto && declined) {
+    throw new SyncError('NO_PASSPHRASE', 'User declined the passphrase prompt this run');
+  }
+  if (deps.auto && deps.invalidate && recoveryFailed) {
+    // One *failed* automatic recovery per run. An account whose rows were
+    // encrypted under two different passphrases (two devices raced the first
+    // setup) can never satisfy every row at once — without this bound, each
+    // pull would throw away the session the previous one just unlocked and
+    // prompt again, forever. The Settings action stays available either way.
+    throw new SyncError('NO_PASSPHRASE', 'Passphrase recovery already failed this run');
+  }
+  if (!deps.auto) {
+    declined = false;
+    recoveryFailed = false;
+  }
+  if (!deps.invalidate && session.isUnlocked()) return;
+  // Checked before invalidating: a prompt that's already up will produce a
+  // verified passphrase that serves this caller too, and throwing away the
+  // session it is about to unlock would strand it.
   if (inflight) return inflight;
 
   inflight = (async () => {
     try {
-      if (!prompter) {
-        throw new SyncError('NO_PASSPHRASE', 'No passphrase prompter registered');
-      }
+      // Inside the IIFE so `inflight` is assigned synchronously above — an
+      // await before the assignment would let a second caller slip past the
+      // check and open a second modal.
+      if (deps.invalidate) await session.invalidatePassphrase();
+      const prompt = await waitForPrompter();
       // Decide setup vs unlock by checking whether the server has any
       // salt rows for this user. The gate doesn't try to silently
       // unlock — it always prompts; the kind argument lets the modal
       // render the right copy.
       const rows = await client.listReplicaKeys();
       const kind: PassphrasePromptKind = rows.length === 0 ? 'setup' : 'unlock';
+      const verifyWith = deps.verifyWith ?? getVerificationSample();
 
-      const passphrase = await prompter({ kind });
-      if (passphrase === null || passphrase === '') {
-        throw new SyncError('NO_PASSPHRASE', 'User cancelled the passphrase prompt');
+      let error: string | undefined;
+      for (;;) {
+        const passphrase = await prompt(error ? { kind, error } : { kind });
+        if (passphrase === null || passphrase === '') {
+          declined = true;
+          throw new SyncError('NO_PASSPHRASE', 'User cancelled the passphrase prompt');
+        }
+        if (kind === 'setup') {
+          await session.setup(passphrase);
+          return;
+        }
+        try {
+          await session.unlock(passphrase, verifyWith ? { verifyWith } : {});
+          return;
+        } catch (err) {
+          // A wrong passphrase is the one failure worth retrying — network,
+          // auth or missing-WebCrypto errors won't resolve on a second try.
+          if (!isWrongPassphraseError(err)) throw err;
+          error = _('Incorrect passphrase. Please try again.');
+        }
       }
-
-      if (kind === 'setup') {
-        await session.setup(passphrase);
-      } else {
-        await session.unlock(passphrase);
-      }
+    } catch (err) {
+      // Burn the once-per-run recovery budget only on a recovery that
+      // actually failed — a successful one, or one that simply joined the
+      // prompt another caller had already opened, leaves it intact.
+      if (deps.auto && deps.invalidate) recoveryFailed = true;
+      throw err;
     } finally {
       inflight = null;
+      dismisser?.();
     }
   })();
 
@@ -94,5 +265,10 @@ export const ensurePassphraseUnlocked = async (deps: EnsureUnlockedDeps = {}): P
 /** Test seam — clear in-flight + prompter between specs. */
 export const __resetPassphraseGateForTests = (): void => {
   prompter = null;
+  dismisser = null;
+  prompterWaiters = [];
   inflight = null;
+  declined = false;
+  recoveryFailed = false;
+  clearVerificationSample();
 };

--- a/apps/readest-app/src/services/sync/replicaCryptoMiddleware.ts
+++ b/apps/readest-app/src/services/sync/replicaCryptoMiddleware.ts
@@ -14,7 +14,7 @@
  * Local plaintext copies are preserved by the store's applyRemote
  * merge — see customOPDSStore.applyRemoteCatalog.
  */
-import { isSyncError, SyncError } from '@/libs/errors';
+import { isSyncError, isWrongPassphraseError, SyncError } from '@/libs/errors';
 import { isCipherEnvelope } from '@/types/replica';
 import type { CipherEnvelope, FieldsObject } from '@/types/replica';
 import type { CryptoSession } from '@/libs/crypto/session';
@@ -134,6 +134,25 @@ export const collectDecryptSuccess = (
 };
 
 /**
+ * Return the first cipher envelope among the named fields, or null. The
+ * orchestrator uses it as the verification sample the passphrase gate
+ * trial-decrypts before accepting an entered passphrase.
+ */
+export const firstCipherEnvelope = (
+  fields: FieldsObject,
+  encryptedFields: readonly string[] | undefined,
+): CipherEnvelope | null => {
+  if (!encryptedFields) return null;
+  for (const fieldName of encryptedFields) {
+    const envelope = fields[fieldName];
+    if (!envelope || typeof envelope !== 'object' || !('v' in envelope)) continue;
+    const v = (envelope as { v: unknown }).v;
+    if (isCipherEnvelope(v)) return v as CipherEnvelope;
+  }
+  return null;
+};
+
+/**
  * Decrypt the named fields of a row's fields_jsonb in place. Each named
  * field's CRDT envelope value (the `v` slot) is replaced with the
  * decrypted plaintext so the adapter's unpackRow sees a plain value.
@@ -141,12 +160,26 @@ export const collectDecryptSuccess = (
  * publishing device hadn't unlocked yet, or this is a metadata-only
  * legacy row) are left untouched. Decrypt failures delete the field
  * from fields_jsonb entirely.
- *
- * `onLocked` is invoked at most once per call when the session is
- * locked AND a cipher field is encountered. The orchestrator wires
- * this to the passphrase gate so a sync fresh device prompts the user
- * before silently dropping the encrypted creds.
  */
+export interface DecryptRowHooks {
+  /**
+   * Invoked at most once per call, when the session is locked AND a cipher
+   * field is encountered. The orchestrator wires this to the passphrase
+   * gate so a fresh device prompts the user before silently dropping the
+   * encrypted creds.
+   */
+  onLocked?: (sample: CipherEnvelope) => Promise<void>;
+  /**
+   * Invoked at most once per call, when a decrypt fails with a wrong-
+   * passphrase signature. The session holds a passphrase that doesn't match
+   * this account's ciphertext — on native it was restored from the keychain
+   * without ever being checked. The orchestrator wires this to the gate's
+   * `invalidate` path: drop the bad passphrase, prompt for the right one,
+   * and this call retries the field afterwards.
+   */
+  onWrongPassphrase?: (sample: CipherEnvelope) => Promise<void>;
+}
+
 export interface DecryptRowResult {
   /**
    * Field paths whose decrypt failed because the cipher envelope's
@@ -164,11 +197,12 @@ export const decryptRowFields = async (
   fields: FieldsObject,
   encryptedFields: readonly string[] | undefined,
   session: CryptoSession = defaultCryptoSession,
-  onLocked?: () => Promise<void>,
+  hooks: DecryptRowHooks = {},
 ): Promise<DecryptRowResult> => {
   if (!encryptedFields || encryptedFields.length === 0) return { saltNotFound: [] };
   const saltNotFound: string[] = [];
   let promptAttempted = false;
+  let repromptAttempted = false;
   let lastFailureCode: string | null = null;
   let failedFieldCount = 0;
   for (const fieldName of encryptedFields) {
@@ -176,14 +210,15 @@ export const decryptRowFields = async (
     if (!envelope || typeof envelope !== 'object' || !('v' in envelope)) continue;
     const v = (envelope as { v: unknown }).v;
     if (!isCipherEnvelope(v)) continue;
+    const cipher = v as CipherEnvelope;
     // Locked session + cipher field: ask the gate to unlock once per
     // decryptRowFields call. If the unlock succeeds, fall through to
     // decrypt; if it fails (user cancelled, gate has no prompter),
     // drop the field and preserve the local plaintext copy.
-    if (!session.isUnlocked() && onLocked && !promptAttempted) {
+    if (!session.isUnlocked() && hooks.onLocked && !promptAttempted) {
       promptAttempted = true;
       try {
-        await onLocked();
+        await hooks.onLocked(cipher);
       } catch {
         // Ignore — the next isUnlocked() check below decides what to do.
       }
@@ -193,9 +228,23 @@ export const decryptRowFields = async (
       continue;
     }
     try {
-      const plaintext = await session.decryptField(v as CipherEnvelope);
-      (envelope as { v: unknown }).v = plaintext;
+      (envelope as { v: unknown }).v = await session.decryptField(cipher);
     } catch (err) {
+      // The session is unlocked but its key can't read this ciphertext —
+      // the passphrase is wrong. Ask for the right one (once per call) and
+      // retry the field; a successful recovery decrypts the remaining
+      // fields directly, since the session is now correctly unlocked.
+      if (isWrongPassphraseError(err) && hooks.onWrongPassphrase && !repromptAttempted) {
+        repromptAttempted = true;
+        try {
+          await hooks.onWrongPassphrase(cipher);
+          (envelope as { v: unknown }).v = await session.decryptField(cipher);
+          continue;
+        } catch {
+          // Fall through to the failure bookkeeping below with the retry's
+          // own error folded in — the field is unreadable either way.
+        }
+      }
       const code = isSyncError(err) ? (err as SyncError).code : 'unknown';
       // Loud + uniformly prefixed so it's easy to grep in production
       // console output. AES-GCM failures (wrong passphrase) surface
@@ -212,9 +261,11 @@ export const decryptRowFields = async (
   }
 
   // One toast per call, surfaced after the loop so the user notices
-  // even if they don't watch the console.
-  //   * DECRYPT / INTEGRITY: AES-GCM or sidecar verification failed —
-  //     almost always "wrong sync passphrase entered on this device".
+  // even if they don't watch the console. Only fields we couldn't recover
+  // get here — a passphrase re-entry that worked leaves the count at zero.
+  //   * DECRYPT / INTEGRITY: AES-GCM or sidecar verification failed and the
+  //     user didn't (or couldn't) enter a working passphrase. Point them at
+  //     the manual re-entry action rather than leaving a dead-end error.
   //     Local plaintext copy is preserved.
   //   * SALT_NOT_FOUND: the row's cipher envelope references a salt
   //     that no longer exists in `replica_keys` server-side. This
@@ -228,7 +279,7 @@ export const decryptRowFields = async (
   if (failedFieldCount > 0 && lastFailureCode !== null) {
     let message: string;
     if (lastFailureCode === 'DECRYPT' || lastFailureCode === 'INTEGRITY') {
-      message = _('Wrong sync passphrase. Synced credentials could not be decrypted.');
+      message = _('Wrong sync passphrase. Re-enter it in Settings to unlock your credentials.');
     } else if (lastFailureCode === 'SALT_NOT_FOUND') {
       message = _(
         'Sync passphrase data on the server was reset. Re-encrypting your credentials under the new passphrase…',

--- a/apps/readest-app/src/services/sync/replicaPullAndApply.ts
+++ b/apps/readest-app/src/services/sync/replicaPullAndApply.ts
@@ -8,8 +8,10 @@ import {
   cipherTextsChanged,
   collectDecryptSuccess,
   decryptRowFields,
+  firstCipherEnvelope,
+  type DecryptRowHooks,
 } from './replicaCryptoMiddleware';
-import { ensurePassphraseUnlocked } from './passphraseGate';
+import { ensurePassphraseUnlocked, rememberVerificationSample } from './passphraseGate';
 import { isCredentialsSyncEnabled } from './syncCategories';
 import { cryptoSession } from '@/libs/crypto/session';
 
@@ -163,18 +165,30 @@ const applyRow = async <T extends ReplicaLocalRecord>(
   const beforeDecrypt = captureCipherTexts(row.fields_jsonb, encryptedFields);
   const localLastSeen = local?.lastSeenCipher;
 
+  // Hand the gate a cipher envelope from this row so an entered passphrase
+  // can be verified before it's accepted — and so the Settings → Enter
+  // passphrase action has something to verify against later.
+  const sample = firstCipherEnvelope(row.fields_jsonb, encryptedFields);
+  if (sample) rememberVerificationSample(sample);
+
   const needsPrompt =
     !deps.silentDecrypt &&
     !cryptoSession.isUnlocked() &&
     Object.keys(beforeDecrypt).length > 0 &&
     cipherTextsChanged(beforeDecrypt, localLastSeen);
-  const onLocked = needsPrompt ? () => ensurePassphraseUnlocked() : undefined;
-  const decryptResult = await decryptRowFields(
-    row.fields_jsonb,
-    encryptedFields,
-    undefined,
-    onLocked,
-  );
+  const hooks: DecryptRowHooks = {};
+  if (needsPrompt) {
+    hooks.onLocked = (verifyWith) => ensurePassphraseUnlocked({ verifyWith, auto: true });
+  }
+  if (!deps.silentDecrypt) {
+    // A wrong passphrase must always be recoverable, fingerprint heuristic or
+    // not: the session it came from claims to be unlocked, so the locked-path
+    // prompt above never fires and the user would otherwise be stuck with an
+    // undismissable "wrong passphrase" toast and nowhere to re-enter it.
+    hooks.onWrongPassphrase = (verifyWith) =>
+      ensurePassphraseUnlocked({ verifyWith, invalidate: true, auto: true });
+  }
+  const decryptResult = await decryptRowFields(row.fields_jsonb, encryptedFields, undefined, hooks);
   if (decryptResult.saltNotFound.length > 0 && deps.onSaltNotFound) {
     deps.onSaltNotFound(decryptResult.saltNotFound);
   }


### PR DESCRIPTION
Fixes #5068.

## The bug

`CryptoSession.unlock()` never verified the passphrase. PBKDF2 derivation succeeds for *any* string, so a mistyped passphrase was accepted, the session flipped to `isUnlocked()`, and the passphrase was written to the OS keychain. From then on the device was stranded:

- every launch, `tryRestoreFromStore()` silently restored the wrong passphrase, so `isUnlocked()` was `true`, so `needsPrompt` in `applyRow` was `false` — **the prompt could never fire again**, and each pull just failed to decrypt and showed an undismissable "Wrong sync passphrase" toast (the screenshot in the issue);
- there was no manual escape: once a salt exists, `SyncPassphraseSection` only offered the destructive **Forgot passphrase**, which wipes every encrypted field server-side;
- on web the prompt was purely opportunistic — it fires from inside a pull, only when the row's ciphertext differs from the persisted fingerprint, and only if `PassphrasePrompt` had already registered its prompter (otherwise the gate threw `NO_PASSPHRASE` silently). Hence "sometimes it shows, sometimes it doesn't, so I keep refreshing".

## The fix

A passphrase is now proven before it is trusted.

- **`unlock()` trial-decrypts a cipher envelope the account holds** before accepting a candidate. A wrong one leaves the session locked with nothing in the keychain, and the modal re-opens in place with an "Incorrect passphrase" error rather than closing on an answer it never checked. Only `DECRYPT`/`INTEGRITY` are fatal — `SALT_NOT_FOUND` means "can't tell", so a user whose ciphers were orphaned by an out-of-band `replica_keys` reset is not locked out.
- **Already-stranded devices self-heal.** A decrypt failure on a supposedly-unlocked session invalidates the passphrase (memory *and* keychain), re-prompts with verification, and retries the row. Bounded to one *failed* automatic recovery per run, so an account whose rows were encrypted under two different passphrases can't loop.
- **Account → Sync passphrase gains Enter / Re-enter passphrase**, so a stranded device always has a way in. Both CTAs use `btn-contrast`.
- **The gate waits for the prompt UI to mount** instead of throwing `NO_PASSPHRASE` at it.
- Drive-by: `createReplicaKey` cached a new salt *last* while the server lists newest-first, so `rows[0]` — which the session takes as the active salt — was stale after a rotation.

## Verification

`pnpm test` (7362 passed), `pnpm lint`, `pnpm format:check` all green.

Driven end-to-end in Chrome against a real signed-in account and the live backend:

- the pull fired the prompt; a wrong passphrase was **rejected against production ciphertext** (dialog stayed open, nothing persisted), and the correct one decrypted four credential fields off the server (`kosync.username`, `kosync.userkey`, `kosync.password`, `hardcover.accessToken`);
- the stranded state (wrong passphrase already in the keychain, session claiming to be unlocked) recovers in a single pull instead of dead-ending on the toast;
- the retry error renders translated (the gate can only `stubTranslation` it, so the modal runs it through `useTranslation` — covered by a test that fails if the raw key leaks through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)