### PR TITLE
fix(tts): use more intuitive icons in tts player

### DIFF
--- a/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
@@ -1,11 +1,5 @@
 import clsx from 'clsx';
-import {
-  MdClose,
-  MdPauseCircleFilled,
-  MdPlayCircleFilled,
-  MdSkipNext,
-  MdSkipPrevious,
-} from 'react-icons/md';
+import { MdClose, MdPauseCircleFilled, MdPlayCircleFilled } from 'react-icons/md';
 import { Insets } from '@/types/misc';
 import { useEnv } from '@/context/EnvContext';
 import { useReaderStore } from '@/store/readerStore';
@@ -16,6 +10,7 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { formatPlaybackTime } from '@/utils/time';
 import { TTSPlaybackInfo, usePlaybackInfo } from './usePlaybackInfo';
 import { useCountdownLabel } from './useCountdownLabel';
+import { BsFastForwardFill, BsRewindFill } from 'react-icons/bs';
 
 // Reader text reserves this much bottom clearance while a session is active
 // (card height + bottom gap); FoliateViewer consumes it via applyMarginAndGap.
@@ -63,7 +58,6 @@ const TTSMiniPlayer = ({
   const playback = usePlaybackInfo({ bookKey, isEink, onGetPlaybackInfo });
   const timerLabel = useCountdownLabel(timeoutTimestamp);
   const iconSize20 = useResponsiveSize(20);
-  const iconSize28 = useResponsiveSize(28);
   const iconSize40 = useResponsiveSize(40);
 
   const isVisible = hoveredBookKey !== bookKey;
@@ -158,7 +152,7 @@ const TTSMiniPlayer = ({
               aria-label={_('Previous Sentence')}
               onClick={() => onBackward(true)}
             >
-              <MdSkipPrevious size={iconSize28} />
+              <BsRewindFill size={iconSize20} />
             </button>
             <button
               type='button'
@@ -178,7 +172,7 @@ const TTSMiniPlayer = ({
               aria-label={_('Next Sentence')}
               onClick={() => onForward(true)}
             >
-              <MdSkipNext size={iconSize28} />
+              <BsFastForwardFill size={iconSize20} />
             </button>
             <button
               type='button'

--- a/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
@@ -4,13 +4,13 @@ import {
   MdAlarm,
   MdArrowBackIosNew,
   MdCheck,
-  MdFastForward,
-  MdFastRewind,
+  MdKeyboardArrowLeft,
+  MdKeyboardArrowRight,
+  MdKeyboardDoubleArrowLeft,
+  MdKeyboardDoubleArrowRight,
   MdOutlinePause,
   MdPlayArrow,
   MdSegment,
-  MdSkipNext,
-  MdSkipPrevious,
 } from 'react-icons/md';
 import { RiVoiceAiFill } from 'react-icons/ri';
 import { TTSVoicesGroup } from '@/services/tts';
@@ -124,6 +124,7 @@ const TTSPlayerSheet = ({
   const timerLabel = useCountdownLabel(timeoutTimestamp);
   const iconSize18 = useResponsiveSize(18);
   const iconSize24 = useResponsiveSize(24);
+  const iconSize28 = useResponsiveSize(28);
   const iconSize32 = useResponsiveSize(32);
 
   const book = getBookData(bookKey)?.book;
@@ -304,7 +305,7 @@ const TTSPlayerSheet = ({
               aria-label={_('Previous Paragraph')}
               onClick={() => onBackward(false)}
             >
-              <MdFastRewind size={iconSize24} />
+              <MdKeyboardDoubleArrowLeft size={iconSize24} />
             </button>
             <button
               type='button'
@@ -313,7 +314,7 @@ const TTSPlayerSheet = ({
               aria-label={_('Previous Sentence')}
               onClick={() => onBackward(true)}
             >
-              <MdSkipPrevious size={iconSize32} />
+              <MdKeyboardArrowLeft size={iconSize28} />
             </button>
             <button
               type='button'
@@ -330,7 +331,7 @@ const TTSPlayerSheet = ({
               aria-label={_('Next Sentence')}
               onClick={() => onForward(true)}
             >
-              <MdSkipNext size={iconSize32} />
+              <MdKeyboardArrowRight size={iconSize28} />
             </button>
             <button
               type='button'
@@ -339,7 +340,7 @@ const TTSPlayerSheet = ({
               aria-label={_('Next Paragraph')}
               onClick={() => onForward(false)}
             >
-              <MdFastForward size={iconSize24} />
+              <MdKeyboardDoubleArrowRight size={iconSize24} />
             </button>
           </div>
           <div className='flex w-full gap-2'>


### PR DESCRIPTION
The previous TTS rewind and fast-forward icons felt very unintuitive to me. When I was first using the TTS controls, I interpreted the skip buttons as navigating to the next/previous chapter instead of the next/previous sentence. 

This PR changes these icons to be more intuitive to a new user. For the miniplayer, I decided to use fast-forward and rewind icons instead of skip icons, and for the player sheet I chose to use arrows, since it effectively communicates the idea of going to the next/previous sentence/paragraph.

# Screenshots

## Before

<img width="537" height="67" alt="image" src="https://github.com/user-attachments/assets/a2c655b6-bc4c-4ec5-8e78-b97992148aac" />

<img width="504" height="454" alt="image" src="https://github.com/user-attachments/assets/2243f9cf-1cf9-4ecb-8353-8090cde52869" />

## After

<img width="537" height="67" alt="image" src="https://github.com/user-attachments/assets/c8d04720-22c4-4491-a61b-649a739a19b3" />

<img width="504" height="454" alt="image" src="https://github.com/user-attachments/assets/23b7c577-2625-4b86-8094-d2f094a8881a" />
