### PR TITLE
fix(opds): normalize XML MIME types

### DIFF
--- a/apps/readest-app/src/__tests__/app/opds/opds-utils.test.ts
+++ b/apps/readest-app/src/__tests__/app/opds/opds-utils.test.ts
@@ -51,6 +51,7 @@ import {
   expandOPDSSearchTemplate,
   resolveURL,
   getFileExtFromPath,
+  getSafeDOMParserMimeType,
   looksLikeXMLContent,
   parseOPDSXML,
   MIME,
@@ -448,6 +449,19 @@ describe('opdsUtils', () => {
 
     it('returns false for an empty string', () => {
       expect(looksLikeXMLContent('')).toBe(false);
+    });
+  });
+
+  describe('getSafeDOMParserMimeType', () => {
+    it('maps XML-like MIME types to application/xml', () => {
+      expect(getSafeDOMParserMimeType('application/atom+xml')).toBe('application/xml');
+      expect(getSafeDOMParserMimeType('application/atom+xml;profile=opds-catalog')).toBe(
+        'application/xml',
+      );
+    });
+
+    it('leaves HTML MIME types unchanged', () => {
+      expect(getSafeDOMParserMimeType('text/html')).toBe('text/html');
     });
   });
 

--- a/apps/readest-app/src/app/opds/page.tsx
+++ b/apps/readest-app/src/app/opds/page.tsx
@@ -29,6 +29,7 @@ import { OPDSFeed, OPDSPublication, OPDSSearch, REL } from '@/types/opds';
 import {
   expandOPDSSearchTemplate,
   getFileExtFromPath,
+  getSafeDOMParserMimeType,
   isSearchLink,
   looksLikeXMLContent,
   MIME,
@@ -307,7 +308,7 @@ export default function BrowserPage() {
           } else {
             const contentType = res.headers.get('Content-Type') ?? MIME.HTML;
             const type = parseMediaType(contentType)?.mediaType ?? MIME.HTML;
-            const htmlDoc = new DOMParser().parseFromString(text, type as DOMParserSupportedType);
+            const htmlDoc = new DOMParser().parseFromString(text, getSafeDOMParserMimeType(type));
 
             if (!htmlDoc.head) {
               stashOPDSReturnTarget(searchParams);

--- a/apps/readest-app/src/app/opds/utils/opdsUtils.ts
+++ b/apps/readest-app/src/app/opds/utils/opdsUtils.ts
@@ -30,6 +30,11 @@ export const MIME = {
   OPDS2: 'application/opds+json',
 };
 
+export const getSafeDOMParserMimeType = (mimeType: string): DOMParserSupportedType =>
+  mimeType.toLowerCase().includes('xml')
+    ? (MIME.XML as DOMParserSupportedType)
+    : (mimeType as DOMParserSupportedType);
+
 export const enum VALIDATION_ERROR {
   INVALID_URL = 'Invalid URL format',
   LOAD_FAILED = 'Failed to load OPDS feed',
@@ -110,7 +115,7 @@ const hasXMLParseError = (doc: Document): boolean =>
  * callers fall through to their existing HTML/non-OPDS handling.
  */
 export const parseOPDSXML = (text: string): Document => {
-  const doc = new DOMParser().parseFromString(text, MIME.XML as DOMParserSupportedType);
+  const doc = new DOMParser().parseFromString(text, getSafeDOMParserMimeType(MIME.XML));
   if (!hasXMLParseError(doc)) return doc;
 
   const rootMatch = text.match(/<([A-Za-z_][\w.:-]*)/);
@@ -121,7 +126,7 @@ export const parseOPDSXML = (text: string): Document => {
     const closeIdx = text.lastIndexOf(closeTag);
     if (closeIdx > startIdx) {
       const sliced = text.slice(startIdx, closeIdx + closeTag.length);
-      const retry = new DOMParser().parseFromString(sliced, MIME.XML as DOMParserSupportedType);
+      const retry = new DOMParser().parseFromString(sliced, getSafeDOMParserMimeType(MIME.XML));
       if (!hasXMLParseError(retry)) return retry;
     }
   }
@@ -250,7 +255,7 @@ export const validateOPDSURL = async (
         // Check for HTML with OPDS link
         const contentType = res.headers.get('Content-Type') ?? MIME.HTML;
         const type = parseMediaType(contentType)?.mediaType ?? MIME.HTML;
-        const htmlDoc = new DOMParser().parseFromString(text, type as DOMParserSupportedType);
+        const htmlDoc = new DOMParser().parseFromString(text, getSafeDOMParserMimeType(type));
 
         if (!htmlDoc.head) {
           return {


### PR DESCRIPTION
## Summary

Normalize XML-like MIME types before passing them to `DOMParser` so OPDS XML parsing works in both client-side and SSR contexts.

## Changed

- Added `getSafeDOMParserMimeType` to map XML-like media types to `application/xml`
- Updated OPDS parsing code paths in `opdsUtils.ts` and `page.tsx`
- Added unit coverage for MIME normalization

## Why

Some upstream OPDS responses use MIME types like `application/atom+xml`, which can trigger `DOMParser.parseFromString()` `SupportedType` errors in some environments. Normalizing them avoids those crashes.

## Tests

- `opds-utils.test.ts`