### PR TITLE
fix(opds): escape malformed XML in proxy

### DIFF
--- a/apps/readest-app/src/__tests__/app/api/opds-proxy-ssrf.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/opds-proxy-ssrf.test.ts
@@ -117,8 +117,21 @@ describe('OPDS proxy SSRF guard', () => {
 
     const res = await GET(proxyReq('https://feeds.example.com/catalog.atom'));
     expect(res.status).toBe(200);
-    expect(Buffer.from(await res.arrayBuffer()).toString('latin1')).toContain(
-      'José &amp; María',
+    expect(Buffer.from(await res.arrayBuffer()).toString('latin1')).toContain('José &amp; María');
+  });
+
+  it('leaves ampersands inside CDATA unchanged', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response('<feed><content><![CDATA[Tom & Jerry]]></content></feed>', {
+        status: 200,
+        headers: { 'Content-Type': 'application/xml' },
+      }),
     );
+
+    const res = await GET(proxyReq('https://feeds.example.com/catalog.atom'));
+    const body = await res.text();
+    expect(res.status).toBe(200);
+    expect(body).toContain('<![CDATA[Tom & Jerry]]>');
+    expect(body).not.toContain('<![CDATA[Tom &amp; Jerry]]>');
   });
 });

--- a/apps/readest-app/src/__tests__/app/api/opds-proxy-ssrf.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/opds-proxy-ssrf.test.ts
@@ -93,4 +93,16 @@ describe('OPDS proxy SSRF guard', () => {
     const body = await res.text();
     expect(body).toContain('<feed');
   });
+
+  it('escapes stray ampersands in XML responses', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response('<feed><link href="BOOKS.zip&file=1"/></feed>', {
+        status: 200,
+        headers: { 'Content-Type': 'application/xml' },
+      }),
+    );
+    const res = await GET(proxyReq('https://feeds.example.com/catalog.atom'));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('BOOKS.zip&amp;file=1');
+  });
 });

--- a/apps/readest-app/src/__tests__/app/api/opds-proxy-ssrf.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/opds-proxy-ssrf.test.ts
@@ -105,4 +105,20 @@ describe('OPDS proxy SSRF guard', () => {
     expect(res.status).toBe(200);
     expect(await res.text()).toContain('BOOKS.zip&amp;file=1');
   });
+
+  it('preserves non-utf8 XML bytes while escaping stray ampersands', async () => {
+    const latin1 = Buffer.from('<feed><title>José & María</title></feed>', 'latin1');
+    fetchSpy.mockResolvedValueOnce(
+      new Response(latin1, {
+        status: 200,
+        headers: { 'Content-Type': 'application/xml; charset=iso-8859-1' },
+      }),
+    );
+
+    const res = await GET(proxyReq('https://feeds.example.com/catalog.atom'));
+    expect(res.status).toBe(200);
+    expect(Buffer.from(await res.arrayBuffer()).toString('latin1')).toContain(
+      'José &amp; María',
+    );
+  });
 });

--- a/apps/readest-app/src/app/api/opds/proxy/route.ts
+++ b/apps/readest-app/src/app/api/opds/proxy/route.ts
@@ -20,6 +20,18 @@ const isPrivateHostAllowed = () => process.env.NODE_ENV === 'development';
  */
 class SsrfBlockedError extends Error {}
 
+const sanitizeXmlBuffer = (buf: ArrayBuffer): ArrayBuffer => {
+  let text = '';
+  const bytes = new Uint8Array(buf);
+  for (const byte of bytes) text += String.fromCharCode(byte);
+
+  text = text.replace(/&(?!([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+);)/g, '&amp;');
+
+  const out = new Uint8Array(text.length);
+  for (let i = 0; i < text.length; i++) out[i] = text.charCodeAt(i) & 0xff;
+  return out.buffer;
+};
+
 async function fetchFollowingRedirects(
   startUrl: string,
   init: { method: 'GET' | 'HEAD'; headers: Headers; signal: AbortSignal },
@@ -240,10 +252,7 @@ async function handleRequest(request: NextRequest, method: 'GET' | 'HEAD') {
     } else {
       let buf = await response.arrayBuffer();
       if (contentType.toLowerCase().includes('xml')) {
-        const xmlText = new TextDecoder('utf-8')
-          .decode(buf)
-          .replace(/&(?!([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+);)/g, '&amp;');
-        buf = new TextEncoder().encode(xmlText).buffer;
+        buf = sanitizeXmlBuffer(buf);
       }
       const length = buf.byteLength;
       console.log(`[OPDS Proxy] Buffered Success: ${url} (${length} bytes)`);

--- a/apps/readest-app/src/app/api/opds/proxy/route.ts
+++ b/apps/readest-app/src/app/api/opds/proxy/route.ts
@@ -238,7 +238,13 @@ async function handleRequest(request: NextRequest, method: 'GET' | 'HEAD') {
       });
       return new NextResponse(response.body, { status: 200, headers });
     } else {
-      const buf = await response.arrayBuffer();
+      let buf = await response.arrayBuffer();
+      if (contentType.toLowerCase().includes('xml')) {
+        const xmlText = new TextDecoder('utf-8')
+          .decode(buf)
+          .replace(/&(?!([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+);)/g, '&amp;');
+        buf = new TextEncoder().encode(xmlText).buffer;
+      }
       const length = buf.byteLength;
       console.log(`[OPDS Proxy] Buffered Success: ${url} (${length} bytes)`);
       return new NextResponse(buf, {

--- a/apps/readest-app/src/app/api/opds/proxy/route.ts
+++ b/apps/readest-app/src/app/api/opds/proxy/route.ts
@@ -25,11 +25,35 @@ const sanitizeXmlBuffer = (buf: ArrayBuffer): ArrayBuffer => {
   const bytes = new Uint8Array(buf);
   for (const byte of bytes) text += String.fromCharCode(byte);
 
-  text = text.replace(/&(?!([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+);)/g, '&amp;');
+  let out = '';
+  let inCdata = false;
+  for (let i = 0; i < text.length; i++) {
+    if (!inCdata && text.startsWith('<![CDATA[', i)) {
+      inCdata = true;
+      out += '<![CDATA[';
+      i += '<![CDATA['.length - 1;
+      continue;
+    }
+    if (inCdata && text.startsWith(']]>', i)) {
+      inCdata = false;
+      out += ']]>';
+      i += ']]>'.length - 1;
+      continue;
+    }
+    if (
+      !inCdata &&
+      text[i] === '&' &&
+      !text.slice(i).match(/^&(amp|lt|gt|quot|apos|#[0-9]+|#x[0-9a-fA-F]+);/)
+    ) {
+      out += '&amp;';
+      continue;
+    }
+    out += text[i];
+  }
 
-  const out = new Uint8Array(text.length);
-  for (let i = 0; i < text.length; i++) out[i] = text.charCodeAt(i) & 0xff;
-  return out.buffer;
+  const outBytes = new Uint8Array(out.length);
+  for (let i = 0; i < out.length; i++) outBytes[i] = out.charCodeAt(i) & 0xff;
+  return outBytes.buffer;
 };
 
 async function fetchFollowingRedirects(


### PR DESCRIPTION
## Summary

Escape unescaped ampersands in buffered XML responses from the OPDS proxy before returning them to the browser.

## Changed

- Added XML sanitization in `/api/opds/proxy`
- Replaced raw `&` with `&amp;` in buffered XML payloads
- Added regression coverage for malformed upstream XML

## Why

Some upstream OPDS servers return XML with unescaped ampersands in metadata URLs. That makes the XML not well-formed and causes browser-side parsing failures. Sanitizing the proxy response avoids the crash.

## Tests

- `opds-proxy-ssrf.test.ts`