### PR TITLE
feat(tts): persistent per-book audio cache with offline downloads

### DIFF
--- a/apps/readest-app/src/__tests__/components/tts/TTSChaptersView.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSChaptersView.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string, opts?: Record<string, unknown>) =>
+    opts ? Object.entries(opts).reduce((s, [k, v]) => s.replace(`{{${k}}}`, String(v)), key) : key,
+}));
+
+vi.mock('@/hooks/useResponsiveSize', () => ({
+  useResponsiveSize: (size: number) => size,
+}));
+
+vi.mock('@/utils/book', () => ({
+  formatBytes: (n: number) => `${n} B`,
+}));
+
+import TTSChaptersView from '@/app/reader/components/tts/TTSChaptersView';
+import type { UseTTSDownloadsResult } from '@/app/reader/hooks/useTTSDownloads';
+import type { DownloadChapter } from '@/services/tts/downloadChapters';
+
+const chapters: DownloadChapter[] = [
+  { key: 'a', label: 'Chapter One', depth: 0, startSection: 0, endSection: 1 },
+  { key: 'b', label: 'Chapter Two', depth: 0, startSection: 1, endSection: 2 },
+  { key: 'c', label: 'Chapter Three', depth: 1, startSection: 2, endSection: 3 },
+];
+
+const makeDownloads = (overrides: Partial<UseTTSDownloadsResult> = {}): UseTTSDownloadsResult => ({
+  supported: true,
+  chapters,
+  statuses: new Map(),
+  cacheBytes: 0,
+  download: { activeChapterKey: null, done: 0, total: 0 },
+  downloadChapter: vi.fn().mockResolvedValue(undefined),
+  downloadAll: vi.fn().mockResolvedValue(undefined),
+  cancel: vi.fn(),
+  statusOf: vi.fn().mockReturnValue('none'),
+  refresh: vi.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+describe('TTSChaptersView', () => {
+  afterEach(() => cleanup());
+
+  test('lists every chapter with a download control', () => {
+    render(
+      <TTSChaptersView downloads={makeDownloads()} activeSectionIndex={null} isEink={false} />,
+    );
+    expect(screen.getByText('Chapter One')).toBeTruthy();
+    expect(screen.getByText('Chapter Three')).toBeTruthy();
+    expect(screen.getAllByLabelText('Download chapter')).toHaveLength(3);
+  });
+
+  test('tapping a chapter badge downloads that chapter', () => {
+    const downloads = makeDownloads();
+    render(<TTSChaptersView downloads={downloads} activeSectionIndex={null} isEink={false} />);
+    fireEvent.click(screen.getAllByLabelText('Download chapter')[1]!);
+    expect(downloads.downloadChapter).toHaveBeenCalledWith(chapters[1]);
+  });
+
+  test('a complete chapter shows the downloaded state and disables its badge', () => {
+    const downloads = makeDownloads({
+      statusOf: vi
+        .fn()
+        .mockImplementation((c: DownloadChapter) => (c.key === 'a' ? 'complete' : 'none')),
+    });
+    render(<TTSChaptersView downloads={downloads} activeSectionIndex={null} isEink={false} />);
+    const downloaded = screen.getByLabelText('Downloaded') as HTMLButtonElement;
+    expect(downloaded.disabled).toBe(true);
+  });
+
+  test('the active chapter shows live progress and a stop control', () => {
+    const downloads = makeDownloads({
+      download: { activeChapterKey: 'b', done: 3, total: 10 },
+    });
+    render(<TTSChaptersView downloads={downloads} activeSectionIndex={null} isEink={false} />);
+    expect(screen.getByText('Downloading 3/10')).toBeTruthy();
+    fireEvent.click(screen.getByLabelText('Stop downloading'));
+    expect(downloads.cancel).toHaveBeenCalled();
+  });
+
+  test('download all skips when every chapter is complete', () => {
+    const downloads = makeDownloads({ statusOf: vi.fn().mockReturnValue('complete') });
+    render(<TTSChaptersView downloads={downloads} activeSectionIndex={null} isEink={false} />);
+    const button = screen.getByText('Download all') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  test('marks the currently playing chapter', () => {
+    render(<TTSChaptersView downloads={makeDownloads()} activeSectionIndex={1} isEink={false} />);
+    expect(screen.getByLabelText('Now playing')).toBeTruthy();
+  });
+});

--- a/apps/readest-app/src/__tests__/components/tts/TTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSControl.test.tsx
@@ -21,6 +21,25 @@ vi.mock('@/app/reader/hooks/useTTSControl', () => ({
   useTTSControl: () => ttsState,
 }));
 
+vi.mock('@/app/reader/hooks/useTTSDownloads', () => ({
+  useTTSDownloads: () => ({
+    supported: false,
+    chapters: [],
+    statuses: new Map(),
+    cacheBytes: 0,
+    download: { activeChapterKey: null, done: 0, total: 0 },
+    downloadChapter: vi.fn(),
+    downloadAll: vi.fn(),
+    cancel: vi.fn(),
+    statusOf: () => 'none',
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('@/store/readerProgressStore', () => ({
+  useBookProgress: () => ({ index: 0 }),
+}));
+
 vi.mock('@/app/reader/components/tts/TTSMiniPlayer', () => ({
   __esModule: true,
   TTS_MINI_PLAYER_CLEARANCE: 64,
@@ -47,6 +66,7 @@ describe('TTSControl', () => {
       ttsClientsInited: true,
       showIndicator: true,
       showBackToCurrentTTSLocation: false,
+      getController: () => null,
       timeoutOption: 0,
       timeoutTimestamp: 0,
       chapterRemainingSec: null,

--- a/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
@@ -60,6 +60,27 @@ vi.mock('@/store/readerProgressStore', () => ({
   useBookProgress: () => ({ sectionLabel: 'Chapter 5' }),
 }));
 
+// Premium gating for the offline-audio row. Defaults to a signed-in premium
+// user so the existing tests (which don't render the row) are unaffected;
+// the gating tests below flip these.
+const { routerPush, mockAuth, mockQuota } = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  mockAuth: { user: { id: 'u' } as { id: string } | null },
+  mockQuota: {
+    userProfilePlan: 'pro' as 'free' | 'plus' | 'pro' | 'purchase' | undefined,
+  },
+}));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: routerPush }) }));
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: mockAuth.user, token: 'tok' }),
+}));
+vi.mock('@/hooks/useQuotaStats', () => ({
+  useQuotaStats: () => ({ userProfilePlan: mockQuota.userProfilePlan }),
+}));
+vi.mock('@/app/reader/components/tts/TTSChaptersView', () => ({
+  default: () => <div>chapters-view</div>,
+}));
+
 import TTSPlayerSheet from '@/app/reader/components/tts/TTSPlayerSheet';
 
 const voiceGroups = [
@@ -98,6 +119,19 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
   onGetPlaybackInfo: vi
     .fn()
     .mockReturnValue({ position: 10, duration: 100, measuredFraction: 0.4 }),
+  downloads: {
+    supported: false,
+    chapters: [],
+    statuses: new Map(),
+    cacheBytes: 0,
+    download: { activeChapterKey: null, done: 0, total: 0 },
+    downloadChapter: vi.fn().mockResolvedValue(undefined),
+    downloadAll: vi.fn().mockResolvedValue(undefined),
+    cancel: vi.fn(),
+    statusOf: vi.fn().mockReturnValue('none'),
+    refresh: vi.fn().mockResolvedValue(undefined),
+  },
+  activeSectionIndex: null as number | null,
   ...overrides,
 });
 
@@ -109,6 +143,9 @@ describe('TTSPlayerSheet', () => {
     getBookData.mockReturnValue({
       book: { title: 'Alice in Wonderland', coverImageUrl: null },
     });
+    // Default: signed-in premium user (the row-less tests never hit the gate).
+    mockAuth.user = { id: 'u' };
+    mockQuota.userProfilePlan = 'pro';
   });
 
   afterEach(() => {
@@ -205,6 +242,56 @@ describe('TTSPlayerSheet', () => {
     // The translation mock interpolates, so options render as real labels.
     fireEvent.click(await screen.findByText('30 minutes'));
     expect(props.onSelectTimeout).toHaveBeenCalledWith('b1', 1800);
+  });
+
+  const makeDownloads = (over: Record<string, unknown> = {}) => ({
+    supported: true,
+    chapters: [{ key: 'c1', label: 'One', depth: 0, startSection: 0, endSection: 1 }],
+    statuses: new Map(),
+    cacheBytes: 0,
+    download: { activeChapterKey: null, done: 0, total: 0 },
+    downloadChapter: vi.fn().mockResolvedValue(undefined),
+    downloadAll: vi.fn().mockResolvedValue(undefined),
+    cancel: vi.fn(),
+    statusOf: vi.fn().mockReturnValue('complete'),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    ...over,
+  });
+
+  test('offline audio row: a premium user has no badge and opens the chapters view', () => {
+    mockQuota.userProfilePlan = 'pro';
+    const props = makeProps({ downloads: makeDownloads() });
+    render(<TTSPlayerSheet {...props} />);
+    const row = screen.getByLabelText('Offline Audio');
+    expect(screen.queryByText('Premium')).toBeNull();
+    expect(screen.getByText('1 of 1 downloaded')).toBeTruthy();
+    fireEvent.click(row);
+    expect(screen.getByText('chapters-view')).toBeTruthy();
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
+  test('offline audio row: a free user sees a Premium badge and is routed to upgrade', () => {
+    mockQuota.userProfilePlan = 'free';
+    const props = makeProps({ downloads: makeDownloads() });
+    render(<TTSPlayerSheet {...props} />);
+    expect(screen.getByText('Premium')).toBeTruthy();
+    expect(screen.getByText('Download chapters for offline playback')).toBeTruthy();
+    fireEvent.click(screen.getByLabelText('Offline Audio'));
+    expect(routerPush).toHaveBeenCalledWith('/user');
+    expect(props.onClose).toHaveBeenCalled();
+    // The premium chapters view must not open for a free user.
+    expect(screen.queryByText('chapters-view')).toBeNull();
+  });
+
+  test('offline audio row: a signed-out user is routed to sign-in', () => {
+    mockAuth.user = null;
+    mockQuota.userProfilePlan = undefined;
+    const props = makeProps({ downloads: makeDownloads() });
+    render(<TTSPlayerSheet {...props} />);
+    expect(screen.getByText('Premium')).toBeTruthy();
+    fireEvent.click(screen.getByLabelText('Offline Audio'));
+    expect(routerPush).toHaveBeenCalledWith(expect.stringContaining('/auth?redirect='));
+    expect(screen.queryByText('chapters-view')).toBeNull();
   });
 
   test('reopening the sheet returns to the main view', async () => {

--- a/apps/readest-app/src/__tests__/services/cloud-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/cloud-service.test.ts
@@ -190,6 +190,15 @@ describe('cloudService', () => {
         expect(mockFs.removeDir).toHaveBeenCalledWith(book.hash, 'Books', true);
       });
 
+      test('removes the per-book TTS audio cache (#tts-cache)', async () => {
+        // The cache lives under Cache (backup- and sync-excluded), so the
+        // Books/<hash>/ wipe cannot cover it; purge erases every trace.
+        const book = createMockBook();
+        await deleteBook(mockFs, book, 'purge');
+
+        expect(mockFs.removeDir).toHaveBeenCalledWith(`tts-cache/${book.hash}`, 'Cache', true);
+      });
+
       test('does not remove the managed book file individually (the dir wipe covers it)', async () => {
         const book = createMockBook();
         await deleteBook(mockFs, book, 'purge');

--- a/apps/readest-app/src/__tests__/services/edge-tts-client-playback.test.ts
+++ b/apps/readest-app/src/__tests__/services/edge-tts-client-playback.test.ts
@@ -334,7 +334,18 @@ describe('EdgeTTSClient Web Audio playback', () => {
     expect(codes).not.toContain('boundary');
   });
 
-  test('a hard fetch error yields error and terminates', async () => {
+  test('a sustained run of hard fetch errors terminates the session (bounded skip)', async () => {
+    // A non-permanent (network) error skips the sentence so cached neighbours
+    // can still play — a cached chapter whose heading is uncached must not stop
+    // on the heading. But a RUN of consecutive unreachable sentences, with no
+    // cached hit to reset the budget, stops instead of skipping to the end of
+    // the book. Enough failing marks to exceed the budget, so the session ends
+    // with 'error' rather than wedging in 'playing'.
+    parsedMarks = Array.from({ length: 6 }, (_, i) => ({
+      name: String(i),
+      text: `Sentence ${i}.`,
+      language: 'en',
+    }));
     createAudioDataBehavior = async () => {
       throw new Error('network exploded');
     };

--- a/apps/readest-app/src/__tests__/services/edge-tts-client.test.ts
+++ b/apps/readest-app/src/__tests__/services/edge-tts-client.test.ts
@@ -239,7 +239,7 @@ describe('EdgeTTSClient', () => {
 
   describe('supportsWordBoundaries', () => {
     test('returns true (Edge reports word-boundary timings)', () => {
-      expect(client.supportsWordBoundaries()).toBe(true);
+      expect(client.getCapabilities().wordBoundaries).toBe(true);
     });
   });
 

--- a/apps/readest-app/src/__tests__/services/tts-auto-advance.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/services/tts-auto-advance.browser.test.tsx
@@ -66,7 +66,12 @@ function makeMockTTSClient(name: string): TTSClient {
     getAllVoices: () => Promise.resolve([]),
     getVoices: () => Promise.resolve([]),
     getGranularities: () => ['sentence'],
-    supportsWordBoundaries: () => false,
+    getCapabilities: () => ({
+      wordBoundaries: false,
+      mediaClock: false,
+      gapControl: false,
+      liveRateChange: false,
+    }),
     getVoiceId: () => 'mock-voice',
     getSpeakingLang: () => 'en',
   };

--- a/apps/readest-app/src/__tests__/services/tts-book-cache-store.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-book-cache-store.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { NodeDatabaseService } from '@/services/database/nodeDatabaseService';
+import {
+  BookTTSCacheStore,
+  getTTSCacheConfig,
+  setTTSCacheConfig,
+} from '@/services/tts/providers/bookCacheStore';
+import type { AppService } from '@/types/system';
+
+const BOUNDARIES = [{ offset: 0, duration: 1_000_000, text: 'word' }];
+const entry = () => ({
+  audio: new Uint8Array(16).fill(3).buffer as ArrayBuffer,
+  boundaries: BOUNDARIES,
+});
+
+describe('BookTTSCacheStore', () => {
+  let db: NodeDatabaseService;
+  let appService: AppService;
+  let createDir: ReturnType<typeof vi.fn>;
+  let openDatabase: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    db = await NodeDatabaseService.open(':memory:');
+    createDir = vi.fn().mockResolvedValue(undefined);
+    openDatabase = vi.fn().mockResolvedValue(db);
+    appService = { createDir, openDatabase } as unknown as AppService;
+  });
+
+  test('does nothing until the book hash resolves', async () => {
+    const store = new BookTTSCacheStore(appService, () => null, 1024 * 1024);
+    await store.put('k', entry());
+    expect(await store.get('k')).toBeNull();
+    expect(openDatabase).not.toHaveBeenCalled();
+  });
+
+  test('opens the per-book database lazily and round-trips entries', async () => {
+    const store = new BookTTSCacheStore(appService, () => 'hash123', 1024 * 1024);
+    await store.put('k', entry(), { provider: 'edge-tts', voice: 'v1' });
+    const got = await store.get('k');
+    expect(got).not.toBeNull();
+    expect(got!.boundaries).toEqual(BOUNDARIES);
+    expect(createDir).toHaveBeenCalledWith('tts-cache/hash123', 'Cache', true);
+    expect(openDatabase).toHaveBeenCalledTimes(1);
+    expect(openDatabase).toHaveBeenCalledWith('tts-cache', 'tts-cache/hash123/cache.db', 'Cache');
+  });
+
+  test('an open failure degrades to a no-op cache', async () => {
+    openDatabase.mockRejectedValue(new Error('locked'));
+    const store = new BookTTSCacheStore(appService, () => 'hash123', 1024 * 1024);
+    await expect(store.put('k', entry())).resolves.toBeUndefined();
+    await expect(store.get('k')).resolves.toBeNull();
+  });
+
+  test('manifest registration flows through and close compacts once', async () => {
+    const store = new BookTTSCacheStore(appService, () => 'hash123', 1024 * 1024);
+    await store.registerSectionMarks(7, ['0:a', '0:b']);
+    await store.put('k1', entry());
+    await store.recordMarkKey(7, 0, 'k1');
+    await store.put('k2', entry());
+    await store.recordMarkKey(7, 1, 'k2');
+    // Close triggers the session-end compaction; without a pack fs in this
+    // fake (web-like) appService the compaction is a safe no-op, but the
+    // manifest rows must exist for it to consider.
+    await expect(store.close()).resolves.toBeUndefined();
+  });
+
+  test('close flushes and releases the database', async () => {
+    const closeSpy = vi.spyOn(db, 'close').mockResolvedValue(undefined);
+    const store = new BookTTSCacheStore(appService, () => 'hash123', 1024 * 1024);
+    await store.put('k', entry());
+    await store.close();
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    // A closed store is inert, not broken.
+    expect(openDatabase).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getTTSCacheConfig', () => {
+  test('defaults to enabled, 200 MB budget, sync off', () => {
+    localStorage.removeItem('readest-tts-cache');
+    expect(getTTSCacheConfig()).toEqual({ enabled: true, budgetMB: 200, syncEnabled: false });
+  });
+
+  test('reads overrides from localStorage', () => {
+    localStorage.setItem(
+      'readest-tts-cache',
+      JSON.stringify({ enabled: false, budgetMB: 50, syncEnabled: true }),
+    );
+    expect(getTTSCacheConfig()).toEqual({ enabled: false, budgetMB: 50, syncEnabled: true });
+    localStorage.removeItem('readest-tts-cache');
+  });
+
+  test('setTTSCacheConfig round-trips through getTTSCacheConfig', () => {
+    setTTSCacheConfig({ enabled: false, budgetMB: 500, syncEnabled: false });
+    expect(getTTSCacheConfig()).toEqual({ enabled: false, budgetMB: 500, syncEnabled: false });
+    localStorage.removeItem('readest-tts-cache');
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts-cache-sweep.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-cache-sweep.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { sweepTTSCaches, touchTTSCacheMeta } from '@/services/tts/providers/cacheSweep';
+import type { AppService } from '@/types/system';
+
+const NOW = 1_000_000_000;
+const HOUR = 3_600_000;
+
+describe('sweepTTSCaches', () => {
+  let files: { path: string; size: number }[];
+  let metas: Record<string, number>;
+  let deleteDir: ReturnType<typeof vi.fn>;
+  let appService: AppService;
+
+  const bookCache = (hash: string, sizeBytes: number, lastUsedAt: number | null) => {
+    files.push({ path: `${hash}/cache.db`, size: sizeBytes });
+    if (lastUsedAt !== null) {
+      files.push({ path: `${hash}/meta.json`, size: 32 });
+      metas[hash] = lastUsedAt;
+    }
+  };
+
+  beforeEach(() => {
+    files = [];
+    metas = {};
+    deleteDir = vi.fn().mockResolvedValue(undefined);
+    appService = {
+      readDirectory: vi.fn().mockImplementation(async () => files),
+      readFile: vi.fn().mockImplementation(async (path: string) => {
+        const hash = path.split('/')[1]!;
+        if (!(hash in metas)) throw new Error('ENOENT');
+        return JSON.stringify({ lastUsedAt: metas[hash] });
+      }),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+      deleteDir,
+      createDir: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AppService;
+  });
+
+  test('does nothing while the total is under budget', async () => {
+    bookCache('aaa', 40, NOW - 5 * HOUR);
+    bookCache('bbb', 40, NOW - 9 * HOUR);
+    // 40 + 40 audio plus two 32-byte meta stamps = 144.
+    await sweepTTSCaches(appService, 'aaa', 200, () => NOW);
+    expect(deleteDir).not.toHaveBeenCalled();
+  });
+
+  test('deletes least recently used book caches until under budget', async () => {
+    bookCache('aaa', 60, NOW - 1 * HOUR); // active
+    bookCache('bbb', 60, NOW - 9 * HOUR); // oldest
+    bookCache('ccc', 60, NOW - 5 * HOUR);
+    // Total 276 (three books plus stamps); removing bbb (92) reaches 184.
+    await sweepTTSCaches(appService, 'aaa', 200, () => NOW);
+    expect(deleteDir).toHaveBeenCalledTimes(1);
+    expect(deleteDir).toHaveBeenCalledWith('tts-cache/bbb', 'Cache', true);
+  });
+
+  test('never deletes the active book, even when it is the oldest', async () => {
+    bookCache('aaa', 80, NOW - 9 * HOUR); // active and oldest
+    bookCache('bbb', 80, NOW - 5 * HOUR);
+    await sweepTTSCaches(appService, 'aaa', 100, () => NOW);
+    expect(deleteDir).toHaveBeenCalledTimes(1);
+    expect(deleteDir).toHaveBeenCalledWith('tts-cache/bbb', 'Cache', true);
+  });
+
+  test('spares caches used within the grace window (another live session)', async () => {
+    bookCache('aaa', 80, NOW - 1 * HOUR);
+    bookCache('bbb', 80, NOW - 60_000); // one minute ago: likely open elsewhere
+    await sweepTTSCaches(appService, 'aaa', 100, () => NOW);
+    expect(deleteDir).not.toHaveBeenCalled();
+  });
+
+  test('treats a cache without meta as the oldest candidate', async () => {
+    bookCache('aaa', 80, NOW - 1 * HOUR);
+    bookCache('bbb', 80, NOW - 9 * HOUR);
+    bookCache('ccc', 80, null); // no meta.json
+    // Total 304; removing ccc (80) reaches 224.
+    await sweepTTSCaches(appService, 'aaa', 250, () => NOW);
+    expect(deleteDir).toHaveBeenCalledTimes(1);
+    expect(deleteDir).toHaveBeenCalledWith('tts-cache/ccc', 'Cache', true);
+  });
+
+  test('handles windows path separators in listings', async () => {
+    files.push({ path: 'bbb\\cache.db', size: 200 });
+    metas['bbb'] = NOW - 9 * HOUR;
+    files.push({ path: 'bbb\\meta.json', size: 32 });
+    bookCache('aaa', 80, NOW - 1 * HOUR);
+    await sweepTTSCaches(appService, 'aaa', 100, () => NOW);
+    expect(deleteDir).toHaveBeenCalledWith('tts-cache/bbb', 'Cache', true);
+  });
+
+  test('a listing failure is swallowed', async () => {
+    vi.mocked(appService.readDirectory).mockRejectedValue(new Error('no such dir'));
+    await expect(sweepTTSCaches(appService, 'aaa', 100, () => NOW)).resolves.toBeUndefined();
+  });
+});
+
+describe('touchTTSCacheMeta', () => {
+  test('writes the last-used stamp and never throws', async () => {
+    const writeFile = vi.fn().mockRejectedValue(new Error('disk full'));
+    const appService = { writeFile } as unknown as AppService;
+    await expect(touchTTSCacheMeta(appService, 'aaa')).resolves.toBeUndefined();
+    expect(writeFile).toHaveBeenCalledWith(
+      'tts-cache/aaa/meta.json',
+      'Cache',
+      expect.stringContaining('lastUsedAt'),
+    );
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts-caching-provider.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-caching-provider.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { CachingProvider, TTSCacheStore } from '@/services/tts/providers/cache';
+import {
+  SpeechProvider,
+  SpeechSynthesisPermanentError,
+  SpeechSynthesisResult,
+} from '@/services/tts/providers/types';
+
+const BOUNDARIES = [{ offset: 0, duration: 1_000_000, text: 'hello' }];
+
+const makeInner = (overrides: Partial<SpeechProvider> = {}): SpeechProvider => ({
+  id: 'fake',
+  label: 'Fake',
+  cacheable: true,
+  init: vi.fn().mockResolvedValue(true),
+  getAllVoices: vi.fn().mockResolvedValue([]),
+  synthesize: vi.fn().mockImplementation(
+    async (): Promise<SpeechSynthesisResult> => ({
+      audio: new ArrayBuffer(8),
+      boundaries: BOUNDARIES,
+    }),
+  ),
+  ...overrides,
+});
+
+class MemoryStore implements TTSCacheStore {
+  map = new Map<string, { audio: ArrayBuffer; boundaries: typeof BOUNDARIES }>();
+  get = vi.fn().mockImplementation(async (key: string) => this.map.get(key) ?? null);
+  put = vi.fn().mockImplementation(async (key: string, entry: never) => {
+    this.map.set(key, entry);
+  });
+}
+
+const req = (text = 'hello') => ({ lang: 'en', text, voice: 'v1', pitch: 1.0 });
+const signal = () => new AbortController().signal;
+
+describe('CachingProvider', () => {
+  let inner: SpeechProvider;
+  let store: MemoryStore;
+  let provider: CachingProvider;
+
+  beforeEach(() => {
+    inner = makeInner();
+    store = new MemoryStore();
+    provider = new CachingProvider(inner, store);
+  });
+
+  test('mirrors the inner provider identity', () => {
+    expect(provider.id).toBe('fake');
+    expect(provider.label).toBe('Fake');
+  });
+
+  test('cache miss synthesizes once and stores the result', async () => {
+    const result = await provider.synthesize(req(), signal());
+    expect(result.boundaries).toEqual(BOUNDARIES);
+    expect(inner.synthesize).toHaveBeenCalledTimes(1);
+    expect(store.put).toHaveBeenCalledTimes(1);
+  });
+
+  test('cache hit never reaches the inner provider', async () => {
+    await provider.synthesize(req(), signal());
+    const result = await provider.synthesize(req(), signal());
+    expect(result.audio.byteLength).toBe(8);
+    expect(result.boundaries).toEqual(BOUNDARIES);
+    expect(inner.synthesize).toHaveBeenCalledTimes(1);
+  });
+
+  test('hits hand out an independent buffer per call', async () => {
+    // decodeAudioData detaches its input; a shared cached buffer would break
+    // the second playback of the same sentence.
+    await provider.synthesize(req(), signal());
+    const a = await provider.synthesize(req(), signal());
+    const b = await provider.synthesize(req(), signal());
+    expect(a.audio).not.toBe(b.audio);
+    new Uint8Array(a.audio); // touching one must not affect the other
+    expect(b.audio.byteLength).toBe(8);
+  });
+
+  test('the key covers voice, pitch, and text but never rate', async () => {
+    await provider.synthesize(req('one'), signal());
+    await provider.synthesize(req('two'), signal());
+    await provider.synthesize({ lang: 'en', text: 'one', voice: 'v2', pitch: 1.0 }, signal());
+    await provider.synthesize({ lang: 'en', text: 'one', voice: 'v1', pitch: 1.2 }, signal());
+    expect(inner.synthesize).toHaveBeenCalledTimes(4);
+    await provider.synthesize(req('one'), signal());
+    expect(inner.synthesize).toHaveBeenCalledTimes(4);
+  });
+
+  test('concurrent requests for the same key synthesize once', async () => {
+    let release!: (r: SpeechSynthesisResult) => void;
+    inner = makeInner({
+      synthesize: vi
+        .fn()
+        .mockImplementation(() => new Promise<SpeechSynthesisResult>((r) => (release = r))),
+    });
+    provider = new CachingProvider(inner, store);
+    const p1 = provider.synthesize(req(), signal());
+    const p2 = provider.synthesize(req(), signal());
+    // Let the store-miss resolve so the inner synthesize (and its
+    // release handle) exists before firing it.
+    await new Promise((r) => setTimeout(r, 0));
+    release({ audio: new ArrayBuffer(8), boundaries: BOUNDARIES });
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(inner.synthesize).toHaveBeenCalledTimes(1);
+    expect(r1.boundaries).toEqual(r2.boundaries);
+  });
+
+  test('a non-cacheable inner provider bypasses the store entirely', async () => {
+    inner = makeInner({ cacheable: false });
+    provider = new CachingProvider(inner, store);
+    await provider.synthesize(req(), signal());
+    expect(store.get).not.toHaveBeenCalled();
+    expect(store.put).not.toHaveBeenCalled();
+    expect(inner.synthesize).toHaveBeenCalledTimes(1);
+  });
+
+  test('synthesis failures propagate and are never cached', async () => {
+    inner = makeInner({
+      synthesize: vi.fn().mockRejectedValue(new SpeechSynthesisPermanentError('no audio')),
+    });
+    provider = new CachingProvider(inner, store);
+    await expect(provider.synthesize(req(), signal())).rejects.toBeInstanceOf(
+      SpeechSynthesisPermanentError,
+    );
+    expect(store.put).not.toHaveBeenCalled();
+    // The failed in-flight slot must not poison retries.
+    await expect(provider.synthesize(req(), signal())).rejects.toBeInstanceOf(
+      SpeechSynthesisPermanentError,
+    );
+    expect(inner.synthesize).toHaveBeenCalledTimes(2);
+  });
+
+  test('store failures degrade to synthesis instead of breaking playback', async () => {
+    store.get.mockRejectedValue(new Error('disk gone'));
+    store.put.mockRejectedValue(new Error('disk full'));
+    const result = await provider.synthesize(req(), signal());
+    expect(result.boundaries).toEqual(BOUNDARIES);
+    expect(inner.synthesize).toHaveBeenCalledTimes(1);
+  });
+
+  test('shutdown closes the store and chains the inner provider', async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const innerShutdown = vi.fn().mockResolvedValue(undefined);
+    inner = makeInner({ shutdown: innerShutdown });
+    const closableStore = Object.assign(new MemoryStore(), { close });
+    provider = new CachingProvider(inner, closableStore);
+    await provider.shutdown();
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(innerShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  test('delegates init, voices, and default-voice policy to the inner provider', async () => {
+    inner = makeInner({
+      pickDefaultVoice: () => 'v-picked',
+      fallbackVoiceId: 'v-fallback',
+    });
+    provider = new CachingProvider(inner, store);
+    await expect(provider.init()).resolves.toBe(true);
+    expect(provider.pickDefaultVoice?.([])).toBe('v-picked');
+    expect(provider.fallbackVoiceId).toBe('v-fallback');
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts-controller-detach.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller-detach.test.ts
@@ -24,7 +24,12 @@ const makeMockClient = (name: string): TTSClient => ({
   getAllVoices: vi.fn().mockResolvedValue([]),
   getVoices: vi.fn().mockResolvedValue([]),
   getGranularities: vi.fn().mockReturnValue(['sentence']),
-  supportsWordBoundaries: vi.fn().mockReturnValue(false),
+  getCapabilities: vi.fn().mockReturnValue({
+    wordBoundaries: false,
+    mediaClock: false,
+    gapControl: false,
+    liveRateChange: false,
+  }),
   getVoiceId: vi.fn().mockReturnValue('detach-voice'),
   getSpeakingLang: vi.fn().mockReturnValue('en'),
 });

--- a/apps/readest-app/src/__tests__/services/tts-controller-lifecycle.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller-lifecycle.test.ts
@@ -25,7 +25,12 @@ const makeMockClient = (name: string): TTSClient => ({
   getAllVoices: vi.fn().mockResolvedValue([]),
   getVoices: vi.fn().mockResolvedValue([]),
   getGranularities: vi.fn().mockReturnValue(['sentence']),
-  supportsWordBoundaries: vi.fn().mockReturnValue(false),
+  getCapabilities: vi.fn().mockReturnValue({
+    wordBoundaries: false,
+    mediaClock: false,
+    gapControl: false,
+    liveRateChange: false,
+  }),
   getVoiceId: vi.fn().mockReturnValue('lifecycle-voice'),
   getSpeakingLang: vi.fn().mockReturnValue('en'),
 });

--- a/apps/readest-app/src/__tests__/services/tts-controller-timeline.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller-timeline.test.ts
@@ -26,7 +26,12 @@ const makeMockClient = (name: string): TTSClient => ({
   getAllVoices: vi.fn().mockResolvedValue([]),
   getVoices: vi.fn().mockResolvedValue([]),
   getGranularities: vi.fn().mockReturnValue(['sentence']),
-  supportsWordBoundaries: vi.fn().mockReturnValue(true),
+  getCapabilities: vi.fn().mockReturnValue({
+    wordBoundaries: true,
+    mediaClock: true,
+    gapControl: true,
+    liveRateChange: false,
+  }),
   getVoiceId: vi.fn().mockReturnValue('timeline-ctrl-voice'),
   getSpeakingLang: vi.fn().mockReturnValue('en'),
   getChunkPosition: vi.fn().mockReturnValue(0.5),

--- a/apps/readest-app/src/__tests__/services/tts-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller.test.ts
@@ -98,7 +98,12 @@ function createMockTTSClient(name: string): TTSClient {
     getAllVoices: vi.fn().mockResolvedValue([]),
     getVoices: vi.fn().mockResolvedValue([]),
     getGranularities: vi.fn().mockReturnValue(['word', 'sentence'] as TTSGranularity[]),
-    supportsWordBoundaries: vi.fn().mockReturnValue(name === 'edge'),
+    getCapabilities: vi.fn().mockImplementation(() => ({
+      wordBoundaries: name === 'edge',
+      mediaClock: name === 'edge',
+      gapControl: name === 'edge',
+      liveRateChange: false,
+    })),
     getVoiceId: vi.fn().mockReturnValue('voice-1'),
     getSpeakingLang: vi.fn().mockReturnValue('en'),
   };
@@ -1380,9 +1385,12 @@ describe('TTSController', () => {
 
     test('reapplyCurrentHighlight never draws the sentence in word mode while playing', async () => {
       await controller.initViewTTS(0);
-      controller.ttsClient.supportsWordBoundaries = vi
-        .fn()
-        .mockReturnValue(true) as unknown as () => boolean;
+      controller.ttsClient.getCapabilities = vi.fn().mockReturnValue({
+        wordBoundaries: true,
+        mediaClock: false,
+        gapControl: false,
+        liveRateChange: false,
+      }) as unknown as typeof controller.ttsClient.getCapabilities;
       controller.setHighlightGranularity('word');
       controller.state = 'playing';
       const content = (

--- a/apps/readest-app/src/__tests__/services/tts-download-chapters.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-download-chapters.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'vitest';
+
+import { chapterDownloadStatus, deriveDownloadChapters } from '@/services/tts/downloadChapters';
+import type { TOCItem } from '@/libs/document';
+
+const toc = (label: string, href: string, subitems?: TOCItem[]): TOCItem => ({
+  id: 0,
+  label,
+  href,
+  index: 0,
+  subitems,
+});
+
+// href -> section index resolver, like view.resolveNavigation.
+const resolver = (map: Record<string, number>) => (href: string) =>
+  href in map ? map[href]! : null;
+
+describe('deriveDownloadChapters', () => {
+  test('one chapter per TOC entry, spanning to the next chapter section', () => {
+    const chapters = deriveDownloadChapters(
+      [toc('One', 'a'), toc('Two', 'b'), toc('Three', 'c')],
+      resolver({ a: 0, b: 2, c: 4 }),
+      6,
+    );
+    expect(chapters).toEqual([
+      { key: 'a', label: 'One', depth: 0, startSection: 0, endSection: 2 },
+      { key: 'b', label: 'Two', depth: 0, startSection: 2, endSection: 4 },
+      { key: 'c', label: 'Three', depth: 0, startSection: 4, endSection: 6 },
+    ]);
+  });
+
+  test('flattens nested subitems in reading order', () => {
+    const chapters = deriveDownloadChapters(
+      [toc('Part I', 'p1', [toc('Ch 1', 'c1'), toc('Ch 2', 'c2')]), toc('Part II', 'p2')],
+      resolver({ p1: 0, c1: 1, c2: 2, p2: 3 }),
+      4,
+    );
+    expect(chapters.map((c) => [c.label, c.startSection, c.depth])).toEqual([
+      ['Part I', 0, 0],
+      ['Ch 1', 1, 1],
+      ['Ch 2', 2, 1],
+      ['Part II', 3, 0],
+    ]);
+  });
+
+  test('collapses consecutive entries that resolve to the same section', () => {
+    const chapters = deriveDownloadChapters(
+      [toc('Heading', 'h'), toc('Subheading', 'h#frag'), toc('Next', 'n')],
+      resolver({ h: 1, 'h#frag': 1, n: 3 }),
+      5,
+    );
+    expect(chapters.map((c) => [c.label, c.startSection, c.endSection])).toEqual([
+      ['Heading', 1, 3],
+      ['Next', 3, 5],
+    ]);
+  });
+
+  test('a chapter that spans several TOC-less sections covers all of them', () => {
+    const chapters = deriveDownloadChapters(
+      [toc('One', 'a'), toc('Two', 'b')],
+      resolver({ a: 0, b: 5 }),
+      8,
+    );
+    expect(chapters[0]).toMatchObject({ startSection: 0, endSection: 5 });
+    expect(chapters[1]).toMatchObject({ startSection: 5, endSection: 8 });
+  });
+
+  test('falls back to one row per section when there is no usable TOC', () => {
+    const chapters = deriveDownloadChapters([], resolver({}), 3);
+    expect(chapters).toEqual([
+      { key: 'section-0', label: 'Section 1', depth: 0, startSection: 0, endSection: 1 },
+      { key: 'section-1', label: 'Section 2', depth: 0, startSection: 1, endSection: 2 },
+      { key: 'section-2', label: 'Section 3', depth: 0, startSection: 2, endSection: 3 },
+    ]);
+  });
+
+  test('drops entries whose href does not resolve', () => {
+    const chapters = deriveDownloadChapters(
+      [toc('Good', 'a'), toc('Broken', 'x'), toc('Also good', 'c')],
+      resolver({ a: 0, c: 2 }),
+      4,
+    );
+    expect(chapters.map((c) => c.label)).toEqual(['Good', 'Also good']);
+  });
+});
+
+describe('chapterDownloadStatus', () => {
+  const chapter = { key: 'a', label: 'A', depth: 0, startSection: 1, endSection: 4 };
+
+  test('complete only when every span section is packed', () => {
+    const statuses = new Map([
+      [1, { total: 3, recorded: 3, packed: true }],
+      [2, { total: 2, recorded: 2, packed: true }],
+      [3, { total: 4, recorded: 4, packed: true }],
+    ]);
+    expect(chapterDownloadStatus(chapter, statuses)).toBe('complete');
+  });
+
+  test('partial when some section has recorded audio but not all are packed', () => {
+    const statuses = new Map([
+      [1, { total: 3, recorded: 3, packed: true }],
+      [2, { total: 2, recorded: 1, packed: false }],
+    ]);
+    expect(chapterDownloadStatus(chapter, statuses)).toBe('partial');
+  });
+
+  test('none when no span section has any recorded audio', () => {
+    expect(chapterDownloadStatus(chapter, new Map())).toBe('none');
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts-downloader.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-downloader.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  CacheWarmer,
+  DownloadableSentence,
+  SectionEnumerator,
+  TTSDownloader,
+} from '@/services/tts/TTSDownloader';
+
+const sentence = (ordinal: number, text: string): DownloadableSentence => ({
+  ordinal,
+  label: `0:s${ordinal}`,
+  lang: 'en',
+  text,
+});
+
+describe('TTSDownloader', () => {
+  let enumerated: Record<number, DownloadableSentence[] | null>;
+  let warmer: CacheWarmer & {
+    manifests: { section: number; labels: string[] }[];
+    warmed: { section: number; ordinal: number; text: string }[];
+    compacts: number;
+  };
+  let enumerator: SectionEnumerator;
+  let warmFails: Set<string>;
+
+  beforeEach(() => {
+    enumerated = {};
+    warmFails = new Set();
+    warmer = {
+      manifests: [],
+      warmed: [],
+      compacts: 0,
+      registerSectionManifest(section, labels) {
+        this.manifests.push({ section, labels });
+      },
+      warmSentence: vi.fn().mockImplementation(async (section, ordinal, _lang, text) => {
+        warmer.warmed.push({ section, ordinal, text });
+        return !warmFails.has(text);
+      }),
+      compactCache: vi.fn().mockImplementation(async () => {
+        warmer.compacts++;
+      }),
+    };
+    enumerator = {
+      enumerateSection: vi.fn().mockImplementation(async (i: number) => enumerated[i] ?? null),
+    };
+  });
+
+  test('synthesizes every sentence of a section in order and compacts once', async () => {
+    enumerated[2] = [sentence(0, 'a'), sentence(1, 'b'), sentence(2, 'c')];
+    const downloader = new TTSDownloader(enumerator, warmer);
+    const progress: string[] = [];
+    const result = await downloader.download([2], (p) => progress.push(`${p.done}/${p.total}`));
+
+    expect(warmer.manifests).toEqual([{ section: 2, labels: ['0:s0', '0:s1', '0:s2'] }]);
+    expect(warmer.warmed.map((w) => w.text)).toEqual(['a', 'b', 'c']);
+    expect(warmer.compacts).toBe(1);
+    expect(progress).toEqual(['1/3', '2/3', '3/3']);
+    expect(result.completed).toEqual([2]);
+  });
+
+  test('processes multiple sections and reports per-section totals', async () => {
+    enumerated[0] = [sentence(0, 'a')];
+    enumerated[1] = [sentence(0, 'x'), sentence(1, 'y')];
+    const downloader = new TTSDownloader(enumerator, warmer);
+    const seen: { section: number; total: number }[] = [];
+    await downloader.download([0, 1], (p) =>
+      seen.push({ section: p.sectionIndex, total: p.total }),
+    );
+    expect(warmer.compacts).toBe(2);
+    expect(seen).toContainEqual({ section: 0, total: 1 });
+    expect(seen).toContainEqual({ section: 1, total: 2 });
+  });
+
+  test('a section that cannot enumerate is skipped, not fatal', async () => {
+    enumerated[0] = null;
+    enumerated[1] = [sentence(0, 'x')];
+    const downloader = new TTSDownloader(enumerator, warmer);
+    const result = await downloader.download([0, 1]);
+    expect(result.completed).toEqual([1]);
+    expect(result.skipped).toEqual([0]);
+  });
+
+  test('records only the sentences that synthesized (a failed one is not recorded)', async () => {
+    enumerated[0] = [sentence(0, 'a'), sentence(1, 'bad'), sentence(2, 'c')];
+    warmFails.add('bad');
+    const downloader = new TTSDownloader(enumerator, warmer);
+    const result = await downloader.download([0]);
+    // All three were attempted; two succeeded.
+    expect(warmer.warmed).toHaveLength(3);
+    expect(result.synthesized).toBe(2);
+    // A section with a failed sentence is still compacted (the pack simply
+    // won't form until the gap fills), so a later retry can complete it.
+    expect(warmer.compacts).toBe(1);
+  });
+
+  test('an empty section registers an empty manifest and still compacts', async () => {
+    enumerated[0] = [];
+    const downloader = new TTSDownloader(enumerator, warmer);
+    await downloader.download([0]);
+    expect(warmer.manifests).toEqual([{ section: 0, labels: [] }]);
+    expect(warmer.warmed).toHaveLength(0);
+  });
+
+  test('abort stops before the next section and does not compact it', async () => {
+    enumerated[0] = [sentence(0, 'a')];
+    enumerated[1] = [sentence(0, 'b')];
+    const controller = new AbortController();
+    warmer.warmSentence = vi.fn().mockImplementation(async (section, ordinal, _l, text) => {
+      warmer.warmed.push({ section, ordinal, text });
+      controller.abort(); // abort mid-first-section
+      return true;
+    });
+    const downloader = new TTSDownloader(enumerator, warmer);
+    const result = await downloader.download([0, 1], undefined, controller.signal);
+    expect(warmer.warmed.map((w) => w.section)).toEqual([0]);
+    expect(result.completed).not.toContain(1);
+    expect(enumerator.enumerateSection).not.toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts-offline-init.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-offline-init.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Offline: every Edge transport probe rejects.
+let createRejects = true;
+
+vi.mock('@/libs/edgeTTS', () => ({
+  EdgeSpeechTTS: class MockEdgeSpeechTTS {
+    static voices = [{ id: 'en-US-AriaNeural', name: 'Aria', lang: 'en-US' }];
+    create = vi
+      .fn()
+      .mockImplementation(() =>
+        createRejects ? Promise.reject(new Error('offline')) : Promise.resolve(undefined),
+      );
+    createAudioData = vi.fn().mockRejectedValue(new Error('offline'));
+  },
+  EDGE_TTS_PROTOCOL: 'wss',
+}));
+
+vi.mock('@/utils/misc', () => ({
+  getUserLocale: vi.fn((lang: string) => (lang === 'en' ? 'en-US' : lang)),
+  getOSPlatform: vi.fn(() => 'macos'),
+  stubTranslation: (key: string) => key,
+}));
+
+vi.mock('@/services/environment', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/environment')>()),
+  isTauriAppPlatform: () => false,
+}));
+
+// Cache config is toggled per test; the store itself is a no-op so no real
+// database is opened.
+let cacheEnabled = true;
+const noopStore = {
+  get: vi.fn().mockResolvedValue(null),
+  put: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
+};
+vi.mock('@/services/tts/providers/bookCacheStore', () => ({
+  getTTSCacheConfig: vi.fn(() => ({ enabled: cacheEnabled, budgetMB: 200, syncEnabled: false })),
+  BookTTSCacheStore: class {
+    get = noopStore.get;
+    put = noopStore.put;
+    close = noopStore.close;
+  },
+}));
+
+import { EdgeTTSClient } from '@/services/tts/EdgeTTSClient';
+import { EdgeSpeechProvider } from '@/services/tts/providers/edge';
+import { SpeechSynthesisPermanentError } from '@/services/tts/providers/types';
+import type { TTSController } from '@/services/tts/TTSController';
+import type { AppService } from '@/types/system';
+
+const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+void consoleSpy;
+
+const fakeController = (authed: boolean) => {
+  const events: string[] = [];
+  return {
+    controller: {
+      isAuthenticated: authed,
+      bookKey: 'hash1-xyz',
+      dispatchEvent: (e: Event) => {
+        events.push(e.type);
+        return true;
+      },
+    } as unknown as TTSController,
+    events,
+  };
+};
+
+const fakeAppService = {} as AppService;
+
+describe('EdgeTTSClient offline cache-only init', () => {
+  beforeEach(() => {
+    createRejects = true;
+    cacheEnabled = true;
+    vi.clearAllMocks();
+  });
+
+  test('initializes cache-only when the probe fails but a cache exists', async () => {
+    const { controller, events } = fakeController(false);
+    const client = new EdgeTTSClient(controller, fakeAppService);
+    await expect(client.init()).resolves.toBe(true);
+    expect(client.initialized).toBe(true);
+    // A signed-out user with a warm cache must NOT be nagged to sign in.
+    expect(events).not.toContain('tts-need-auth');
+  });
+
+  test('without a cache, an offline unauthenticated init fails and asks for auth', async () => {
+    cacheEnabled = false;
+    const { controller, events } = fakeController(false);
+    const client = new EdgeTTSClient(controller, fakeAppService);
+    await expect(client.init()).resolves.toBe(false);
+    expect(client.initialized).toBe(false);
+    expect(events).toContain('tts-need-auth');
+  });
+
+  test('a successful probe still initializes normally with a cache present', async () => {
+    createRejects = false;
+    const { controller } = fakeController(true);
+    const client = new EdgeTTSClient(controller, fakeAppService);
+    await expect(client.init()).resolves.toBe(true);
+    expect(client.initialized).toBe(true);
+  });
+});
+
+describe('EdgeSpeechProvider offline behavior', () => {
+  test('a cache miss still attempts the fetch and propagates a NON-permanent error offline', async () => {
+    // A permanent error would make the buffered client skip the sentence and
+    // race to the end of the book. Offline, the fetch fails with a plain
+    // (transient) error, which — after the client's retries — stops playback.
+    createRejects = true;
+    const provider = new EdgeSpeechProvider();
+    await provider.init(); // transport probe fails
+    const err = await provider
+      .synthesize(
+        { lang: 'en', text: 'hi', voice: 'en-US-AriaNeural', pitch: 1 },
+        new AbortController().signal,
+      )
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(SpeechSynthesisPermanentError);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts-opfs-pack-fs.browser.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-opfs-pack-fs.browser.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { createOpfsPackFs } from '@/services/tts/providers/opfsPackFs';
+
+const DIR = 'tts-cache/test-book/packs';
+
+const bytes = (...values: number[]) => new Uint8Array(values);
+
+describe('createOpfsPackFs (real OPFS)', () => {
+  beforeEach(async () => {
+    // Isolate runs: drop the test book's cache dir if a previous test left it.
+    const root = await navigator.storage.getDirectory();
+    try {
+      const parent = await root.getDirectoryHandle('tts-cache');
+      await parent.removeEntry('test-book', { recursive: true });
+    } catch {
+      // First run: nothing to clean.
+    }
+  });
+
+  test('write, rename, list, and range reads round-trip', async () => {
+    const fs = await createOpfsPackFs(DIR);
+    expect(fs).toBeDefined();
+
+    await fs!.write('tmp-1.mp3', bytes(1, 2, 3, 4, 5, 6));
+    await fs!.rename('tmp-1.mp3', '1-abcd.mp3');
+
+    const names = await fs!.list();
+    expect(names).toEqual(['1-abcd.mp3']);
+
+    const range = await fs!.readRange('1-abcd.mp3', 2, 3);
+    expect([...new Uint8Array(range)]).toEqual([3, 4, 5]);
+  });
+
+  test('remove deletes files and readRange on missing files throws', async () => {
+    const fs = await createOpfsPackFs(DIR);
+    await fs!.write('x.mp3', bytes(9, 9));
+    await fs!.remove('x.mp3');
+    expect(await fs!.list()).toEqual([]);
+    await expect(fs!.readRange('x.mp3', 0, 1)).rejects.toThrow();
+  });
+
+  test('a short file fails the range read instead of returning truncated audio', async () => {
+    const fs = await createOpfsPackFs(DIR);
+    await fs!.write('short.mp3', bytes(1, 2));
+    await expect(fs!.readRange('short.mp3', 0, 10)).rejects.toThrow(/short pack read/);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
@@ -1,0 +1,325 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { md5 } from 'js-md5';
+import { NodeDatabaseService } from '@/services/database/nodeDatabaseService';
+import {
+  SqliteTTSCacheStore,
+  TTSPackFs,
+  TTSPackSidecar,
+  packSidecarName,
+} from '@/services/tts/providers/sqliteCacheStore';
+
+const BOUNDARIES = [{ offset: 0, duration: 1_000_000, text: 'w' }];
+
+// In-memory pack filesystem: name -> bytes.
+class FakePackFs implements TTSPackFs {
+  files = new Map<string, Uint8Array>();
+  async write(name: string, data: Uint8Array): Promise<void> {
+    this.files.set(name, data);
+  }
+  async rename(from: string, to: string): Promise<void> {
+    const data = this.files.get(from);
+    if (!data) throw new Error(`ENOENT: ${from}`);
+    this.files.set(to, data);
+    this.files.delete(from);
+  }
+  async readRange(name: string, offset: number, length: number): Promise<ArrayBuffer> {
+    const data = this.files.get(name);
+    if (!data) throw new Error(`ENOENT: ${name}`);
+    return data.slice(offset, offset + length).buffer as ArrayBuffer;
+  }
+  async remove(name: string): Promise<void> {
+    this.files.delete(name);
+  }
+  async list(): Promise<string[]> {
+    return [...this.files.keys()];
+  }
+}
+
+const sentence = (byte: number, size = 40) => ({
+  audio: new Uint8Array(size).fill(byte).buffer as ArrayBuffer,
+  boundaries: BOUNDARIES,
+});
+
+describe('SqliteTTSCacheStore pack compaction', () => {
+  let db: NodeDatabaseService;
+  let packFs: FakePackFs;
+  let store: SqliteTTSCacheStore;
+  let clock: { t: number };
+
+  beforeEach(async () => {
+    db = await NodeDatabaseService.open(':memory:');
+    packFs = new FakePackFs();
+    clock = { t: 1_000 };
+    store = new SqliteTTSCacheStore(db, {
+      budgetBytes: 1024 * 1024,
+      now: () => clock.t++,
+      packFs,
+    });
+  });
+
+  const cacheSection = async (section: number, marks: string[], keys: string[]) => {
+    await store.registerSectionMarks(section, marks);
+    for (let i = 0; i < keys.length; i++) {
+      await store.put(keys[i]!, sentence(i + 1));
+      await store.recordMarkKey(section, i, keys[i]!);
+    }
+  };
+
+  test('compacts a fully cached section into one pack file, in mark order', async () => {
+    await cacheSection(3, ['m1', 'm2', 'm3'], ['k1', 'k2', 'k3']);
+    const compacted = await store.compact();
+    expect(compacted).toBe(1);
+
+    // One pack file (plus its sidecar) holding the three sentences back to
+    // back in reading order, named by the hash of its ordered keys.
+    const packNames = (await packFs.list()).filter((n) => n.endsWith('.mp3'));
+    expect(packNames).toHaveLength(1);
+    expect(packNames[0]).toBe(`3-${md5(JSON.stringify(['k1', 'k2', 'k3'])).slice(0, 8)}.mp3`);
+    const bytes = packFs.files.get(packNames[0]!)!;
+    expect(bytes.length).toBe(120);
+    expect(bytes[0]).toBe(1);
+    expect(bytes[40]).toBe(2);
+    expect(bytes[80]).toBe(3);
+  });
+
+  test('packed entries read back through range reads, byte for byte', async () => {
+    await cacheSection(3, ['m1', 'm2'], ['k1', 'k2']);
+    await store.compact();
+    const got = await store.get('k2');
+    expect(got).not.toBeNull();
+    expect(got!.audio.byteLength).toBe(40);
+    expect(new Uint8Array(got!.audio)[0]).toBe(2);
+    expect(got!.boundaries).toEqual(BOUNDARIES);
+  });
+
+  test('concurrent identical registrations do not collide on (section, ordinal)', async () => {
+    // Two callers registering the same section at once (live enumeration + a
+    // download) previously raced their DELETE-then-INSERT and hit the primary
+    // key. UPSERT makes it idempotent.
+    await Promise.all([
+      store.registerSectionMarks(9, ['m1', 'm2', 'm3']),
+      store.registerSectionMarks(9, ['m1', 'm2', 'm3']),
+    ]);
+    const statuses = await store.getSectionStatuses();
+    expect(statuses.get(9)).toEqual({ total: 3, recorded: 0, packed: false });
+  });
+
+  test('re-registering identical marks preserves an already recorded key', async () => {
+    await store.registerSectionMarks(9, ['m1', 'm2']);
+    await store.put('k1', sentence(1));
+    await store.recordMarkKey(9, 0, 'k1');
+    // A later identical registration (fingerprint unchanged) is a no-op, but
+    // even a forced re-run must not wipe the recorded key.
+    await store.registerSectionMarks(9, ['m1', 'm2']);
+    const statuses = await store.getSectionStatuses();
+    expect(statuses.get(9)).toEqual({ total: 2, recorded: 1, packed: false });
+  });
+
+  test('a shorter re-registration trims trailing ordinals', async () => {
+    await store.registerSectionMarks(9, ['m1', 'm2', 'm3', 'm4']);
+    await store.registerSectionMarks(9, ['a', 'b']);
+    const statuses = await store.getSectionStatuses();
+    expect(statuses.get(9)?.total).toBe(2);
+  });
+
+  test('an incomplete section never packs', async () => {
+    await store.registerSectionMarks(5, ['m1', 'm2']);
+    await store.put('k1', sentence(1));
+    await store.recordMarkKey(5, 0, 'k1');
+    // m2 never recorded.
+    expect(await store.compact()).toBe(0);
+    expect(await packFs.list()).toHaveLength(0);
+  });
+
+  test('an already compacted section does not pack twice', async () => {
+    await cacheSection(3, ['m1'], ['k1']);
+    expect(await store.compact()).toBe(1);
+    expect(await store.compact()).toBe(0);
+    expect((await packFs.list()).filter((n) => n.endsWith('.mp3'))).toHaveLength(1);
+  });
+
+  test('re-registering identical marks keeps recorded keys', async () => {
+    await cacheSection(4, ['m1', 'm2'], ['k1', 'k2']);
+    await store.registerSectionMarks(4, ['m1', 'm2']);
+    expect(await store.compact()).toBe(1);
+  });
+
+  test('re-registering different marks resets the manifest', async () => {
+    await cacheSection(4, ['m1', 'm2'], ['k1', 'k2']);
+    await store.registerSectionMarks(4, ['m1', 'm2', 'm3']);
+    expect(await store.compact()).toBe(0);
+  });
+
+  test('a lost pack file self-heals to a miss instead of failing', async () => {
+    await cacheSection(3, ['m1'], ['k1']);
+    await store.compact();
+    packFs.files.clear();
+    expect(await store.get('k1')).toBeNull();
+    // The dead row is gone: a later put can re-cache the sentence.
+    await store.put('k1', sentence(9));
+    expect(await store.get('k1')).not.toBeNull();
+  });
+
+  test('evicting under pressure removes the oldest pack with its entries and file', async () => {
+    const tight = new SqliteTTSCacheStore(db, {
+      budgetBytes: 150,
+      now: () => clock.t++,
+      packFs,
+    });
+    await tight.registerSectionMarks(1, ['m1', 'm2']);
+    await tight.put('k1', sentence(1));
+    await tight.recordMarkKey(1, 0, 'k1');
+    await tight.put('k2', sentence(2));
+    await tight.recordMarkKey(1, 1, 'k2');
+    await tight.compact();
+    expect((await packFs.list()).filter((n) => n.endsWith('.mp3'))).toHaveLength(1);
+
+    // 80 packed + 2*40 incoming loose > 150: the pack must be evicted.
+    await tight.put('k3', sentence(3));
+    await tight.put('k4', sentence(4));
+    expect(await packFs.list()).toHaveLength(0);
+    expect(await tight.get('k1')).toBeNull();
+    expect(await tight.get('k3')).not.toBeNull();
+    expect(await tight.get('k4')).not.toBeNull();
+  });
+
+  test('gc removes pack files unknown to the database', async () => {
+    await cacheSection(3, ['m1'], ['k1']);
+    await store.compact();
+    packFs.files.set('tmp-crashed', new Uint8Array(10));
+    packFs.files.set('stray.mp3', new Uint8Array(10));
+    await store.gcPackFiles();
+    // The known pack and its sidecar survive; the strays are gone.
+    const names = (await packFs.list()).sort();
+    expect(names).toHaveLength(2);
+    expect(names.some((n) => n === 'tmp-crashed' || n === 'stray.mp3')).toBe(false);
+    // The legitimate pack still reads.
+    expect(await store.get('k1')).not.toBeNull();
+  });
+
+  test('without a pack filesystem, compaction is a no-op and loose reads keep working', async () => {
+    const webStore = new SqliteTTSCacheStore(db, { budgetBytes: 1024, now: () => clock.t++ });
+    await webStore.registerSectionMarks(1, ['m1']);
+    await webStore.put('k1', sentence(1));
+    await webStore.recordMarkKey(1, 0, 'k1');
+    expect(await webStore.compact()).toBe(0);
+    expect(await webStore.get('k1')).not.toBeNull();
+  });
+});
+
+describe('SqliteTTSCacheStore pack portability', () => {
+  let db: NodeDatabaseService;
+  let packFs: FakePackFs;
+  let store: SqliteTTSCacheStore;
+  let clock: { t: number };
+
+  beforeEach(async () => {
+    db = await NodeDatabaseService.open(':memory:');
+    packFs = new FakePackFs();
+    clock = { t: 1_000 };
+    store = new SqliteTTSCacheStore(db, {
+      budgetBytes: 1024 * 1024,
+      now: () => clock.t++,
+      packFs,
+    });
+    await store.registerSectionMarks(3, ['m1', 'm2']);
+    await store.put('k1', sentence(1));
+    await store.recordMarkKey(3, 0, 'k1');
+    await store.put('k2', sentence(2));
+    await store.recordMarkKey(3, 1, 'k2');
+    await store.compact();
+  });
+
+  const packName = async () => (await packFs.list()).find((n) => n.endsWith('.mp3'))!;
+  const readSidecar = async (): Promise<TTSPackSidecar> =>
+    JSON.parse(new TextDecoder().decode(packFs.files.get(packSidecarName(await packName()))!));
+
+  test('compaction writes a sidecar that fully describes the pack', async () => {
+    const sidecar = await readSidecar();
+    expect(sidecar.version).toBe(1);
+    expect(sidecar.section).toBe(3);
+    expect(sidecar.totalSize).toBe(80);
+    expect(sidecar.entries.map((e) => [e.key, e.offset, e.length])).toEqual([
+      ['k1', 0, 40],
+      ['k2', 40, 40],
+    ]);
+    expect(sidecar.entries[0]!.boundaries).toEqual(BOUNDARIES);
+  });
+
+  test('importPack makes the section readable on a fresh device', async () => {
+    const sidecar = await readSidecar();
+    const bytes = packFs.files.get(await packName())!;
+
+    const otherDb = await NodeDatabaseService.open(':memory:');
+    const otherFs = new FakePackFs();
+    const other = new SqliteTTSCacheStore(otherDb, {
+      budgetBytes: 1024 * 1024,
+      now: () => clock.t++,
+      packFs: otherFs,
+    });
+    expect(await other.importPack(bytes.slice().buffer as ArrayBuffer, sidecar)).toBe(true);
+
+    const got = await other.get('k2');
+    expect(got).not.toBeNull();
+    expect(new Uint8Array(got!.audio)[0]).toBe(2);
+    expect(got!.boundaries).toEqual(BOUNDARIES);
+    // Re-import is a no-op.
+    expect(await other.importPack(bytes.slice().buffer as ArrayBuffer, sidecar)).toBe(false);
+  });
+
+  test('importPack rejects a sidecar that does not match the bytes', async () => {
+    const sidecar = await readSidecar();
+    const bytes = packFs.files.get(await packName())!;
+
+    const otherDb = await NodeDatabaseService.open(':memory:');
+    const otherFs = new FakePackFs();
+    const other = new SqliteTTSCacheStore(otherDb, {
+      budgetBytes: 1024 * 1024,
+      now: () => clock.t++,
+      packFs: otherFs,
+    });
+    const corrupt = { ...sidecar, totalSize: sidecar.totalSize + 1 };
+    expect(await other.importPack(bytes.slice().buffer as ArrayBuffer, corrupt)).toBe(false);
+    expect(await otherFs.list()).toHaveLength(0);
+    expect(await other.get('k1')).toBeNull();
+  });
+
+  test('getSectionStatuses reports total, recorded, and packed', async () => {
+    // Section 3 is fully packed (from beforeEach). Add section 5 partial.
+    await store.registerSectionMarks(5, ['m1', 'm2', 'm3']);
+    await store.put('p1', sentence(1));
+    await store.recordMarkKey(5, 0, 'p1');
+
+    const statuses = await store.getSectionStatuses();
+    expect(statuses.get(3)).toEqual({ total: 2, recorded: 2, packed: true });
+    expect(statuses.get(5)).toEqual({ total: 3, recorded: 1, packed: false });
+    expect(await store.totalCacheBytes()).toBeGreaterThan(0);
+  });
+
+  test('the sync source surface reflects the database', async () => {
+    const name = await packName();
+    expect(await store.listPacks()).toEqual([{ name, size: 80 }]);
+    expect(await store.hasPack(name)).toBe(true);
+    expect(await store.hasPack('nope.mp3')).toBe(false);
+
+    const bytes = await store.readPackBytes(name);
+    expect(bytes?.byteLength).toBe(80);
+
+    // The sidecar rebuilt from rows matches the one written at compaction.
+    const rebuilt = await store.buildPackSidecar(name);
+    expect(rebuilt).toEqual(await readSidecar());
+    expect(await store.buildPackSidecar('nope.mp3')).toBeNull();
+  });
+
+  test('evicting a pack removes its sidecar too', async () => {
+    // Shrink the budget with a new store over the same db and force eviction.
+    const tight = new SqliteTTSCacheStore(db, {
+      budgetBytes: 100,
+      now: () => clock.t++,
+      packFs,
+    });
+    await tight.put('k3', sentence(3, 60));
+    expect(await packFs.list()).toHaveLength(0);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts-pack-sync.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-pack-sync.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { FileEntry, FileSyncProvider } from '@/services/sync/file/provider';
+import {
+  pullTTSPacks,
+  pushTTSPacks,
+  TTSPackDestination,
+  TTSPackSource,
+} from '@/services/sync/file/ttsPackSync';
+import type { TTSPackSidecar } from '@/services/tts/providers/sqliteCacheStore';
+
+const HASH = 'bookhash1';
+const TTS_DIR = '/Readest/books/bookhash1/tts';
+
+const sidecarOf = (name: string): TTSPackSidecar => ({
+  version: 1,
+  section: 3,
+  keysFingerprint: name.replace(/\.mp3$/, ''),
+  totalSize: 4,
+  entries: [{ key: `k-${name}`, offset: 0, length: 4, boundaries: [] }],
+});
+
+// In-memory provider: path -> bytes/text, with an operation log so tests can
+// assert ordering (mp3 must land before its sidecar).
+class FakeProvider implements FileSyncProvider {
+  rootPath = '/';
+  files = new Map<string, ArrayBuffer | string>();
+  ops: string[] = [];
+  listError: Error | null = null;
+
+  async readText(path: string): Promise<string | null> {
+    const value = this.files.get(path);
+    return typeof value === 'string' ? value : null;
+  }
+  async readBinary(path: string): Promise<ArrayBuffer | null> {
+    const value = this.files.get(path);
+    return value instanceof ArrayBuffer ? value : null;
+  }
+  async head() {
+    return null;
+  }
+  async list(path: string): Promise<FileEntry[]> {
+    if (this.listError) throw this.listError;
+    const prefix = `${path}/`;
+    const out: FileEntry[] = [];
+    for (const key of this.files.keys()) {
+      if (key.startsWith(prefix) && !key.slice(prefix.length).includes('/')) {
+        out.push({ name: key.slice(prefix.length), path: key, isDirectory: false });
+      }
+    }
+    if (!out.length) throw new Error('404: no such directory');
+    return out;
+  }
+  async writeText(path: string, body: string): Promise<void> {
+    this.ops.push(`writeText:${path}`);
+    this.files.set(path, body);
+  }
+  async writeBinary(path: string, body: ArrayBuffer): Promise<void> {
+    this.ops.push(`writeBinary:${path}`);
+    this.files.set(path, body);
+  }
+  async ensureDir(paths: string[]): Promise<void> {
+    this.ops.push(`ensureDir:${paths.join(',')}`);
+  }
+  async deleteDir(): Promise<void> {}
+}
+
+const makeSource = (packs: Record<string, ArrayBuffer | null>): TTSPackSource => ({
+  listPacks: vi.fn().mockResolvedValue(Object.keys(packs).map((name) => ({ name, size: 4 }))),
+  readPackBytes: vi.fn().mockImplementation(async (name: string) => packs[name] ?? null),
+  buildPackSidecar: vi
+    .fn()
+    .mockImplementation(async (name: string) => (packs[name] ? sidecarOf(name) : null)),
+});
+
+const makeDest = (
+  existing: string[] = [],
+): TTSPackDestination & {
+  imported: TTSPackSidecar[];
+} => {
+  const imported: TTSPackSidecar[] = [];
+  return {
+    imported,
+    hasPack: vi.fn().mockImplementation(async (name: string) => existing.includes(name)),
+    importPack: vi.fn().mockImplementation(async (_data: ArrayBuffer, s: TTSPackSidecar) => {
+      imported.push(s);
+      return true;
+    }),
+  };
+};
+
+describe('pushTTSPacks', () => {
+  let provider: FakeProvider;
+
+  beforeEach(() => {
+    provider = new FakeProvider();
+  });
+
+  test('uploads missing packs, mp3 before sidecar', async () => {
+    const source = makeSource({ 'a.mp3': new ArrayBuffer(4) });
+    const pushed = await pushTTSPacks(provider, HASH, source);
+    expect(pushed).toBe(1);
+    expect(provider.files.has(`${TTS_DIR}/a.mp3`)).toBe(true);
+    expect(provider.files.has(`${TTS_DIR}/a.json`)).toBe(true);
+    const mp3Index = provider.ops.findIndex((op) => op.endsWith('a.mp3'));
+    const jsonIndex = provider.ops.findIndex((op) => op.endsWith('a.json'));
+    expect(mp3Index).toBeGreaterThanOrEqual(0);
+    expect(mp3Index).toBeLessThan(jsonIndex);
+  });
+
+  test('skips packs the remote already has', async () => {
+    provider.files.set(`${TTS_DIR}/a.mp3`, new ArrayBuffer(4));
+    provider.files.set(`${TTS_DIR}/a.json`, JSON.stringify(sidecarOf('a.mp3')));
+    const source = makeSource({ 'a.mp3': new ArrayBuffer(4) });
+    const pushed = await pushTTSPacks(provider, HASH, source);
+    expect(pushed).toBe(0);
+    expect(provider.ops.filter((op) => op.startsWith('write'))).toHaveLength(0);
+  });
+
+  test('heals a remote pack whose sidecar is missing', async () => {
+    provider.files.set(`${TTS_DIR}/a.mp3`, new ArrayBuffer(4));
+    const source = makeSource({ 'a.mp3': new ArrayBuffer(4) });
+    const pushed = await pushTTSPacks(provider, HASH, source);
+    expect(pushed).toBe(1);
+    expect(provider.files.has(`${TTS_DIR}/a.json`)).toBe(true);
+    // The mp3 itself was not re-uploaded.
+    expect(provider.ops.some((op) => op === `writeBinary:${TTS_DIR}/a.mp3`)).toBe(false);
+  });
+
+  test('a pack whose bytes cannot be read locally is skipped, not fatal', async () => {
+    const source = makeSource({ 'a.mp3': null, 'b.mp3': new ArrayBuffer(4) });
+    const pushed = await pushTTSPacks(provider, HASH, source);
+    expect(pushed).toBe(1);
+    expect(provider.files.has(`${TTS_DIR}/b.mp3`)).toBe(true);
+    expect(provider.files.has(`${TTS_DIR}/a.mp3`)).toBe(false);
+  });
+
+  test('nothing local means no remote traffic at all', async () => {
+    const source = makeSource({});
+    expect(await pushTTSPacks(provider, HASH, source)).toBe(0);
+    expect(provider.ops).toHaveLength(0);
+  });
+});
+
+describe('pullTTSPacks', () => {
+  let provider: FakeProvider;
+
+  beforeEach(() => {
+    provider = new FakeProvider();
+  });
+
+  const remotePack = (name: string) => {
+    provider.files.set(`${TTS_DIR}/${name}`, new ArrayBuffer(4));
+    provider.files.set(
+      `${TTS_DIR}/${name.replace(/\.mp3$/, '.json')}`,
+      JSON.stringify(sidecarOf(name)),
+    );
+  };
+
+  test('imports packs the device does not have', async () => {
+    remotePack('a.mp3');
+    remotePack('b.mp3');
+    const dest = makeDest(['a.mp3']);
+    const imported = await pullTTSPacks(provider, HASH, dest);
+    expect(imported).toBe(1);
+    expect(dest.imported.map((s) => s.keysFingerprint)).toEqual(['b']);
+  });
+
+  test('ignores a sidecar without its pack (incomplete upload)', async () => {
+    provider.files.set(`${TTS_DIR}/a.json`, JSON.stringify(sidecarOf('a.mp3')));
+    const dest = makeDest();
+    expect(await pullTTSPacks(provider, HASH, dest)).toBe(0);
+    expect(dest.importPack).not.toHaveBeenCalled();
+  });
+
+  test('ignores malformed sidecars', async () => {
+    provider.files.set(`${TTS_DIR}/a.mp3`, new ArrayBuffer(4));
+    provider.files.set(`${TTS_DIR}/a.json`, '{not json');
+    const dest = makeDest();
+    expect(await pullTTSPacks(provider, HASH, dest)).toBe(0);
+  });
+
+  test('a missing remote directory is silence, not an error', async () => {
+    const dest = makeDest();
+    await expect(pullTTSPacks(provider, HASH, dest)).resolves.toBe(0);
+  });
+
+  test('a listing failure is swallowed', async () => {
+    provider.listError = new Error('503');
+    const dest = makeDest();
+    await expect(pullTTSPacks(provider, HASH, dest)).resolves.toBe(0);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts-speech-provider.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-speech-provider.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// The provider delegates to EdgeSpeechTTS; mock at the lib boundary exactly
+// like the edge-tts-client suites so the contract is tested in isolation.
+const h = vi.hoisted(() => ({
+  createAudioData: vi.fn(),
+  create: vi.fn(),
+  lastConstructedProtocol: '' as string,
+}));
+
+vi.mock('@/libs/edgeTTS', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/libs/edgeTTS')>();
+  return {
+    ...original,
+    EdgeSpeechTTS: class MockEdgeSpeechTTS {
+      static voices = [
+        { id: 'en-US-AriaNeural', name: 'Aria', lang: 'en-US' },
+        { id: 'fr-FR-DeniseNeural', name: 'Denise', lang: 'fr-FR' },
+      ];
+      constructor(protocol: string) {
+        h.lastConstructedProtocol = protocol;
+      }
+      create = h.create;
+      createAudioData = h.createAudioData;
+    },
+  };
+});
+
+import { EdgeSpeechProvider } from '@/services/tts/providers/edge';
+import { SpeechSynthesisPermanentError } from '@/services/tts/providers/types';
+
+describe('EdgeSpeechProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.createAudioData.mockResolvedValue({
+      data: new ArrayBuffer(4),
+      boundaries: [{ offset: 0, duration: 1_000_000, text: 'hello' }],
+    });
+    h.create.mockResolvedValue(new Response());
+  });
+
+  const initializedProvider = async () => {
+    const provider = new EdgeSpeechProvider();
+    await provider.init();
+    return provider;
+  };
+
+  test('identifies as edge-tts with a label', async () => {
+    const provider = new EdgeSpeechProvider();
+    expect(provider.id).toBe('edge-tts');
+    expect(provider.label).toBe('Edge TTS');
+  });
+
+  test('init probes the transport and reports availability', async () => {
+    const provider = new EdgeSpeechProvider();
+    await expect(provider.init()).resolves.toBe(true);
+    expect(h.lastConstructedProtocol).toBe('wss');
+
+    h.create.mockRejectedValueOnce(new Error('boom'));
+    const failing = new EdgeSpeechProvider();
+    await expect(failing.init()).resolves.toBe(false);
+  });
+
+  test('init accepts an explicit protocol', async () => {
+    const provider = new EdgeSpeechProvider();
+    await provider.init('https');
+    expect(h.lastConstructedProtocol).toBe('https');
+  });
+
+  test('synthesize always pins rate to 1.0 in the payload', async () => {
+    // The invariant that keeps cached audio rate-independent: the playback
+    // rate is a playout concern (WSOLA / AVPlayer), never the provider's.
+    const provider = await initializedProvider();
+    await provider.synthesize(
+      { lang: 'en', text: 'hello world', voice: 'en-US-AriaNeural', pitch: 1.2 },
+      new AbortController().signal,
+    );
+    expect(h.createAudioData).toHaveBeenCalledWith(
+      expect.objectContaining({ rate: 1.0, pitch: 1.2, text: 'hello world' }),
+    );
+  });
+
+  test('synthesize returns audio bytes and boundaries', async () => {
+    const provider = await initializedProvider();
+    const result = await provider.synthesize(
+      { lang: 'en', text: 'hello', voice: 'en-US-AriaNeural', pitch: 1.0 },
+      new AbortController().signal,
+    );
+    expect(result.audio.byteLength).toBe(4);
+    expect(result.boundaries).toEqual([{ offset: 0, duration: 1_000_000, text: 'hello' }]);
+  });
+
+  test('maps the no-audio failure to SpeechSynthesisPermanentError', async () => {
+    // "No audio data received." is permanent for a given sentence; the
+    // buffered client must skip it instead of retrying.
+    const provider = await initializedProvider();
+    h.createAudioData.mockRejectedValue(new Error('No audio data received.'));
+    await expect(
+      provider.synthesize(
+        { lang: 'en', text: 'hello', voice: 'en-US-AriaNeural', pitch: 1.0 },
+        new AbortController().signal,
+      ),
+    ).rejects.toBeInstanceOf(SpeechSynthesisPermanentError);
+  });
+
+  test('propagates transient errors unchanged for the client retry path', async () => {
+    const provider = await initializedProvider();
+    h.createAudioData.mockRejectedValue(new Error('network error'));
+    await expect(
+      provider.synthesize(
+        { lang: 'en', text: 'hello', voice: 'en-US-AriaNeural', pitch: 1.0 },
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow('network error');
+  });
+
+  test('exposes the static Edge voice list', async () => {
+    const provider = await initializedProvider();
+    const voices = await provider.getAllVoices();
+    expect(voices.map((v) => v.id)).toEqual(['en-US-AriaNeural', 'fr-FR-DeniseNeural']);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts-sqlite-cache-store.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-sqlite-cache-store.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { NodeDatabaseService } from '@/services/database/nodeDatabaseService';
+import { SqliteTTSCacheStore } from '@/services/tts/providers/sqliteCacheStore';
+
+const BOUNDARIES = [{ offset: 0, duration: 1_000_000, text: 'word' }];
+
+const entry = (size: number, fill = 1) => ({
+  audio: new Uint8Array(size).fill(fill).buffer as ArrayBuffer,
+  boundaries: BOUNDARIES,
+  durationMs: 1234,
+});
+
+describe('SqliteTTSCacheStore', () => {
+  let db: NodeDatabaseService;
+
+  beforeEach(async () => {
+    db = await NodeDatabaseService.open(':memory:');
+  });
+
+  const makeStore = (budgetBytes: number, startAt = 1_000) => {
+    let now = startAt;
+    return new SqliteTTSCacheStore(db, { budgetBytes, now: () => now++ });
+  };
+
+  test('round-trips audio, boundaries, and duration', async () => {
+    const store = makeStore(1024 * 1024);
+    await store.put('key1', entry(64, 7), { provider: 'edge-tts', voice: 'v1' });
+    const got = await store.get('key1');
+    expect(got).not.toBeNull();
+    expect(got!.audio.byteLength).toBe(64);
+    expect(new Uint8Array(got!.audio)[0]).toBe(7);
+    expect(got!.boundaries).toEqual(BOUNDARIES);
+    expect(got!.durationMs).toBe(1234);
+  });
+
+  test('misses return null', async () => {
+    const store = makeStore(1024);
+    await expect(store.get('nope')).resolves.toBeNull();
+  });
+
+  test('hits hand back an independent buffer per call', async () => {
+    const store = makeStore(1024 * 1024);
+    await store.put('key1', entry(16));
+    const a = await store.get('key1');
+    const b = await store.get('key1');
+    expect(a!.audio).not.toBe(b!.audio);
+  });
+
+  test('evicts the least recently used entries once over budget', async () => {
+    const store = makeStore(300);
+    await store.put('a', entry(120));
+    await store.put('b', entry(120));
+    // Touch `a` so `b` becomes the oldest.
+    await store.get('a');
+    // 120*3 > 300: someone must go, and it must be `b`.
+    await store.put('c', entry(120));
+    expect(await store.get('b')).toBeNull();
+    expect(await store.get('a')).not.toBeNull();
+    expect(await store.get('c')).not.toBeNull();
+  });
+
+  test('an entry larger than the whole budget is not cached', async () => {
+    const store = makeStore(100);
+    await store.put('huge', entry(500));
+    expect(await store.get('huge')).toBeNull();
+  });
+
+  test('replacing an entry under the same key does not double-count its size', async () => {
+    const store = makeStore(300);
+    await store.put('a', entry(200));
+    await store.put('a', entry(200));
+    await store.put('b', entry(90));
+    // 200 + 90 fits: replacing `a` must not have evicted anything.
+    expect(await store.get('a')).not.toBeNull();
+    expect(await store.get('b')).not.toBeNull();
+  });
+
+  test('a second store over the same database sees persisted entries', async () => {
+    const store = makeStore(1024 * 1024);
+    await store.put('key1', entry(32));
+    await store.flush();
+    const reopened = makeStore(1024 * 1024, 9_000);
+    const got = await reopened.get('key1');
+    expect(got).not.toBeNull();
+    expect(got!.boundaries).toEqual(BOUNDARIES);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/web-speech-client.test.ts
+++ b/apps/readest-app/src/__tests__/services/web-speech-client.test.ts
@@ -66,6 +66,6 @@ describe('WebSpeechClient getVoices', () => {
   });
 
   test('does not support word boundaries (sentence highlight only)', () => {
-    expect(client.supportsWordBoundaries()).toBe(false);
+    expect(client.getCapabilities().wordBoundaries).toBe(false);
   });
 });

--- a/apps/readest-app/src/__tests__/utils/tts-cache-plan-gate.test.ts
+++ b/apps/readest-app/src/__tests__/utils/tts-cache-plan-gate.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+
+import { TTS_CACHE_REQUIRES_PREMIUM, isTTSCacheAllowed, isTTSCacheInPlan } from '@/utils/access';
+
+describe('isTTSCacheInPlan', () => {
+  test('any paid plan can use the offline TTS audio cache', () => {
+    expect(isTTSCacheInPlan('plus')).toBe(true);
+    expect(isTTSCacheInPlan('pro')).toBe(true);
+    expect(isTTSCacheInPlan('purchase')).toBe(true); // lifetime
+  });
+
+  test('free plan cannot', () => {
+    expect(isTTSCacheInPlan('free')).toBe(false);
+  });
+});
+
+describe('isTTSCacheAllowed (premium paywall)', () => {
+  test('downloading TTS audio for offline playback requires a paid plan', () => {
+    expect(TTS_CACHE_REQUIRES_PREMIUM).toBe(true);
+    expect(isTTSCacheAllowed('free')).toBe(false);
+    expect(isTTSCacheAllowed('plus')).toBe(true);
+    expect(isTTSCacheAllowed('pro')).toBe(true);
+    expect(isTTSCacheAllowed('purchase')).toBe(true);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/tts/DownloadBadge.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/DownloadBadge.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { MdDownloadForOffline, MdOfflinePin, MdOutlineFileDownload, MdStop } from 'react-icons/md';
+import clsx from 'clsx';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useResponsiveSize } from '@/hooks/useResponsiveSize';
+import type { ChapterDownloadStatus } from '@/services/tts/downloadChapters';
+
+interface DownloadBadgeProps {
+  status: ChapterDownloadStatus;
+  active: boolean;
+  // 0..1 while active; drives the ring. Ignored otherwise.
+  progress: number;
+  isEink: boolean;
+  onDownload: () => void;
+  onCancel: () => void;
+}
+
+// The one expressive control of the podcast sheet: a circular badge that
+// changes shape with state so it reads without relying on color (needed on
+// e-ink). Download tray -> stop-in-a-progress-ring while active -> resume
+// arc for a partial chapter -> filled offline pin when complete.
+const DownloadBadge: React.FC<DownloadBadgeProps> = ({
+  status,
+  active,
+  progress,
+  isEink,
+  onDownload,
+  onCancel,
+}) => {
+  const _ = useTranslation();
+  const size = useResponsiveSize(26);
+
+  if (active) {
+    // A determinate ring around a stop square. On e-ink the ring updates only
+    // as progress events land (no continuous animation), so it stays crisp.
+    const r = size / 2 - 2;
+    const circumference = 2 * Math.PI * r;
+    return (
+      <button
+        type='button'
+        aria-label={_('Stop downloading')}
+        onClick={onCancel}
+        className='relative flex shrink-0 items-center justify-center'
+        style={{ width: size, height: size }}
+      >
+        <svg width={size} height={size} className='rotate-[-90deg]'>
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={r}
+            fill='none'
+            strokeWidth={2}
+            className='stroke-base-300'
+          />
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={r}
+            fill='none'
+            strokeWidth={2}
+            strokeLinecap='round'
+            className={isEink ? 'stroke-base-content' : 'stroke-primary'}
+            strokeDasharray={circumference}
+            strokeDashoffset={circumference * (1 - Math.max(0, Math.min(1, progress)))}
+          />
+        </svg>
+        <MdStop className='absolute' size={size * 0.42} />
+      </button>
+    );
+  }
+
+  const [Icon, label, tone] =
+    status === 'complete'
+      ? [MdOfflinePin, _('Downloaded'), isEink ? 'text-base-content' : 'text-primary']
+      : status === 'partial'
+        ? [MdDownloadForOffline, _('Resume download'), 'text-base-content/70']
+        : [MdOutlineFileDownload, _('Download chapter'), 'text-base-content/70'];
+
+  return (
+    <button
+      type='button'
+      aria-label={label}
+      disabled={status === 'complete'}
+      onClick={onDownload}
+      className={clsx(
+        'flex shrink-0 items-center justify-center rounded-full',
+        status !== 'complete' && 'not-eink:hover:bg-base-200',
+      )}
+      style={{ width: size, height: size }}
+    >
+      <Icon size={size} className={tone} />
+    </button>
+  );
+};
+
+export default DownloadBadge;

--- a/apps/readest-app/src/app/reader/components/tts/TTSChaptersView.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSChaptersView.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import clsx from 'clsx';
+import { MdGraphicEq } from 'react-icons/md';
+import { useTranslation } from '@/hooks/useTranslation';
+import { formatBytes } from '@/utils/book';
+import DownloadBadge from './DownloadBadge';
+import type { UseTTSDownloadsResult } from '@/app/reader/hooks/useTTSDownloads';
+
+interface TTSChaptersViewProps {
+  downloads: UseTTSDownloadsResult;
+  activeSectionIndex: number | null;
+  isEink: boolean;
+}
+
+// Podcast-style episode list: every chapter is a row with a download badge.
+// Downloading a chapter caches its audio for offline playback; the badge
+// reflects what is already on the device.
+const TTSChaptersView: React.FC<TTSChaptersViewProps> = ({
+  downloads,
+  activeSectionIndex,
+  isEink,
+}) => {
+  const _ = useTranslation();
+  const { chapters, statusOf, download, downloadChapter, downloadAll, cancel, cacheBytes } =
+    downloads;
+
+  const completeCount = chapters.filter((c) => statusOf(c) === 'complete').length;
+  const anyIncomplete = completeCount < chapters.length;
+  const busy = download.activeChapterKey !== null;
+
+  return (
+    <div className='flex w-full flex-col pb-4'>
+      <div className='flex items-center justify-between gap-2 px-2 py-1'>
+        <span className='text-base-content/60 text-sm sm:text-xs'>
+          {_('{{done}} of {{total}} chapters offline', {
+            done: completeCount,
+            total: chapters.length,
+          })}
+          {cacheBytes > 0 ? ` · ${formatBytes(cacheBytes)}` : ''}
+        </span>
+        <button
+          type='button'
+          className='text-primary shrink-0 text-sm font-medium disabled:opacity-40 sm:text-xs'
+          disabled={busy || !anyIncomplete}
+          onClick={() => void downloadAll()}
+        >
+          {_('Download all')}
+        </button>
+      </div>
+
+      <div className='flex w-full flex-col'>
+        {chapters.map((chapter) => {
+          const status = statusOf(chapter);
+          const isActive = download.activeChapterKey === chapter.key;
+          const isPlaying =
+            activeSectionIndex !== null &&
+            activeSectionIndex >= chapter.startSection &&
+            activeSectionIndex < chapter.endSection;
+          const subtitle = isActive
+            ? _('Downloading {{done}}/{{total}}', { done: download.done, total: download.total })
+            : status === 'complete'
+              ? _('Downloaded')
+              : status === 'partial'
+                ? _('Partly downloaded')
+                : null;
+
+          return (
+            <div
+              key={chapter.key}
+              className='flex w-full items-center gap-3 rounded-lg px-2 py-2'
+              style={{ paddingInlineStart: `${8 + chapter.depth * 14}px` }}
+            >
+              <div className='flex min-w-0 flex-1 flex-col'>
+                <div className='flex items-center gap-1.5'>
+                  {isPlaying && (
+                    <MdGraphicEq
+                      className={isEink ? 'text-base-content' : 'text-primary'}
+                      aria-label={_('Now playing')}
+                    />
+                  )}
+                  <span
+                    className={clsx(
+                      'line-clamp-1 text-base sm:text-sm',
+                      isPlaying && 'font-semibold',
+                    )}
+                  >
+                    {chapter.label}
+                  </span>
+                </div>
+                {subtitle && (
+                  <span className='text-base-content/60 line-clamp-1 text-xs tabular-nums'>
+                    {subtitle}
+                  </span>
+                )}
+              </div>
+              <DownloadBadge
+                status={status}
+                active={isActive}
+                progress={download.total > 0 ? download.done / download.total : 0}
+                isEink={isEink}
+                onDownload={() => void downloadChapter(chapter)}
+                onCancel={cancel}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default TTSChaptersView;

--- a/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
@@ -4,6 +4,8 @@ import { useThemeStore } from '@/store/themeStore';
 import { useReaderStore } from '@/store/readerStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useTTSControl } from '@/app/reader/hooks/useTTSControl';
+import { useTTSDownloads } from '@/app/reader/hooks/useTTSDownloads';
+import { useBookProgress } from '@/store/readerProgressStore';
 import { Insets } from '@/types/misc';
 import { eventDispatcher } from '@/utils/event';
 import TTSMiniPlayer from './TTSMiniPlayer';
@@ -28,6 +30,9 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
     bookKey,
     onRequestHidePanel: () => setShowPlayerSheet(false),
   });
+
+  const downloads = useTTSDownloads(bookKey, tts.getController, showPlayerSheet);
+  const activeSectionIndex = useBookProgress(bookKey)?.index ?? null;
 
   const isEink = getViewSettings(bookKey)?.isEink ?? false;
   const hasTimeline = tts.ttsClientsInited && tts.handleSupportsPlaybackInfo();
@@ -128,6 +133,8 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
           onSelectTimeout={tts.handleSelectTimeout}
           onSeek={tts.handleSeekTo}
           onGetPlaybackInfo={tts.handleGetPlaybackInfo}
+          downloads={downloads}
+          activeSectionIndex={activeSectionIndex}
         />
       )}
     </>

--- a/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
@@ -11,18 +11,25 @@ import {
   MdOutlinePause,
   MdPlayArrow,
   MdSegment,
+  MdOutlineFileDownload,
+  MdChevronRight,
 } from 'react-icons/md';
 import { RiVoiceAiFill } from 'react-icons/ri';
+import { useRouter } from 'next/navigation';
 import { TTSVoicesGroup } from '@/services/tts';
 import { DEFAULT_SENTENCE_GAP_SEC } from '@/services/tts/EdgeTTSClient';
 import { DEFAULT_PARAGRAPH_GAP_SEC } from '@/services/tts/TTSController';
 import { useEnv } from '@/context/EnvContext';
+import { useAuth } from '@/context/AuthContext';
 import { useReaderStore } from '@/store/readerStore';
 import { useBookProgress } from '@/store/readerProgressStore';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { TranslationFunc, useTranslation } from '@/hooks/useTranslation';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
+import { useQuotaStats } from '@/hooks/useQuotaStats';
+import { isTTSCacheAllowed } from '@/utils/access';
+import { navigateToLogin, navigateToProfile } from '@/utils/nav';
 import { getLanguageName } from '@/utils/lang';
 import { formatPlaybackTime } from '@/utils/time';
 import Dialog from '@/components/Dialog';
@@ -32,8 +39,10 @@ import TTSScrubber from './TTSScrubber';
 import SpeedChips, { formatRate } from './SpeedChips';
 import GapChips, { formatGap } from './GapChips';
 import ParagraphGapChips from './ParagraphGapChips';
+import TTSChaptersView from './TTSChaptersView';
+import type { UseTTSDownloadsResult } from '@/app/reader/hooks/useTTSDownloads';
 
-type SheetView = 'main' | 'speed' | 'voice' | 'timer' | 'paragraphGap';
+type SheetView = 'main' | 'speed' | 'voice' | 'timer' | 'paragraphGap' | 'chapters';
 
 const getTTSTimeoutOptions = (_: TranslationFunc) => {
   return [
@@ -77,6 +86,8 @@ type TTSPlayerSheetProps = {
   onSelectTimeout: (bookKey: string, value: number) => void;
   onSeek: (seconds: number) => Promise<void>;
   onGetPlaybackInfo: () => TTSPlaybackInfo | null;
+  downloads: UseTTSDownloadsResult;
+  activeSectionIndex: number | null;
 };
 
 // Full player sheet: cover, chapter, scrubber, transport, and one compact
@@ -105,13 +116,29 @@ const TTSPlayerSheet = ({
   onSelectTimeout,
   onSeek,
   onGetPlaybackInfo,
+  downloads,
+  activeSectionIndex,
 }: TTSPlayerSheetProps) => {
   const _ = useTranslation();
+  const router = useRouter();
   const { envConfig } = useEnv();
+  const { user } = useAuth();
   const { getViewSettings, setViewSettings } = useReaderStore();
   const { getBookData } = useBookDataStore();
   const progress = useBookProgress(bookKey);
   const viewSettings = getViewSettings(bookKey);
+
+  // Offline audio (pre-downloading Read Aloud audio per chapter) is a premium
+  // feature: any paid plan can use it; free / signed-out users see the row with
+  // a Premium badge that routes to the upgrade page instead of the per-chapter
+  // download controls. Mirrors the cloud-sync paywall in IntegrationsPanel.
+  const { userProfilePlan } = useQuotaStats();
+  const isDownloadPremium = isTTSCacheAllowed(userProfilePlan ?? 'free');
+  // Only badge users who can't use it yet: signed out (known at once), or a
+  // resolved plan without the feature. Suppress it while a signed-in user's
+  // plan is still loading so it never flashes at an entitled user.
+  const premiumBadge =
+    !user || (userProfilePlan !== undefined && !isDownloadPremium) ? _('Premium') : undefined;
 
   const [view, setView] = useState<SheetView>('main');
   const [voiceGroups, setVoiceGroups] = useState<TTSVoicesGroup[]>([]);
@@ -219,6 +246,21 @@ const TTSPlayerSheet = ({
     setView('main');
   };
 
+  // Entitled users drill into the per-chapter download view; everyone else is
+  // routed to the upgrade page (or sign-in), the sheet closing first so the
+  // navigation isn't hidden behind it.
+  const handleOpenDownloads = () => {
+    if (isDownloadPremium) {
+      setView('chapters');
+    } else if (user) {
+      onClose();
+      navigateToProfile(router);
+    } else {
+      onClose();
+      navigateToLogin(router);
+    }
+  };
+
   const timeoutOptions = getTTSTimeoutOptions(_);
   const currentVoiceName = voiceGroups
     .flatMap((group) => group.voices)
@@ -250,7 +292,9 @@ const TTSPlayerSheet = ({
                 ? _('Select Voice')
                 : view === 'paragraphGap'
                   ? _('Paragraph Gap')
-                  : _('Set Timeout')}
+                  : view === 'chapters'
+                    ? _('Offline Audio')
+                    : _('Set Timeout')}
           </span>
         </div>
       </div>
@@ -387,7 +431,40 @@ const TTSPlayerSheet = ({
               </span>
             </button>
           </div>
+          {downloads.supported && downloads.chapters.length > 0 && (
+            <button
+              type='button'
+              aria-label={_('Offline Audio')}
+              onClick={handleOpenDownloads}
+              className='not-eink:bg-base-200 eink-bordered flex w-full items-center gap-3 rounded-xl px-3 py-2.5'
+            >
+              <MdOutlineFileDownload size={iconSize24} className='shrink-0' />
+              <div className='flex min-w-0 flex-1 flex-col items-start'>
+                <span className='text-sm font-semibold'>{_('Offline Audio')}</span>
+                <span className='text-base-content/60 line-clamp-1 text-start text-xs'>
+                  {premiumBadge
+                    ? _('Download chapters for offline playback')
+                    : _('{{done}} of {{total}} downloaded', {
+                        done: downloads.chapters.filter((c) => downloads.statusOf(c) === 'complete')
+                          .length,
+                        total: downloads.chapters.length,
+                      })}
+                </span>
+              </div>
+              {premiumBadge && (
+                <span className='badge badge-sm badge-ghost shrink-0'>{premiumBadge}</span>
+              )}
+              <MdChevronRight size={iconSize24} className='shrink-0 rtl:rotate-180' />
+            </button>
+          )}
         </div>
+      )}
+      {view === 'chapters' && (
+        <TTSChaptersView
+          downloads={downloads}
+          activeSectionIndex={activeSectionIndex}
+          isEink={isEink}
+        />
       )}
       {view === 'speed' && (
         <div className='flex w-full flex-col items-center pb-4 pt-2'>

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -758,6 +758,10 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
           preprocessSSMLForTTS,
           handleSectionChange,
         );
+        // The constructor takes the view directly (attachView, which also binds
+        // this, only runs on the background-session reattach path), so set the
+        // book key here or the per-book audio cache never gets a hash to open.
+        ttsController.bookKey = bookKey;
         ttsControllerRef.current = ttsController;
         setTtsController(ttsController);
         ttsSessionManager.claim(bookKey, ttsController, {
@@ -854,6 +858,13 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
   const handleSupportsGapControl = useCallback(() => {
     return ttsControllerRef.current?.supportsGapControl() ?? false;
   }, []);
+
+  // Stable handle for the download/chapters surface (reads the cache and
+  // drives headless pre-synthesis off the playback path). MUST be memoized:
+  // an inline arrow here changes identity every render, which would cascade
+  // through useTTSDownloads' refresh callback into its effect and spin an
+  // infinite render loop the moment the sheet opens.
+  const getController = useCallback(() => ttsControllerRef.current, []);
 
   // Playback callbacks
   const handleTogglePlay = useCallback(async () => {
@@ -1014,5 +1025,6 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     handleSupportsPlaybackInfo,
     handleSupportsGapControl,
     refreshTtsLang,
+    getController,
   };
 };

--- a/apps/readest-app/src/app/reader/hooks/useTTSDownloads.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSDownloads.ts
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useBookDataStore } from '@/store/bookDataStore';
+import { useTranslation } from '@/hooks/useTranslation';
+import type { TTSController } from '@/services/tts/TTSController';
+import {
+  chapterDownloadStatus,
+  chapterSections,
+  deriveDownloadChapters,
+  DownloadChapter,
+  SectionCacheStatus,
+} from '@/services/tts/downloadChapters';
+
+export interface ChapterDownloadState {
+  // The chapter currently synthesizing, plus its live progress.
+  activeChapterKey: string | null;
+  done: number;
+  total: number;
+}
+
+export interface UseTTSDownloadsResult {
+  supported: boolean;
+  chapters: DownloadChapter[];
+  statuses: Map<number, SectionCacheStatus>;
+  cacheBytes: number;
+  download: ChapterDownloadState;
+  downloadChapter: (chapter: DownloadChapter) => Promise<void>;
+  downloadAll: () => Promise<void>;
+  cancel: () => void;
+  statusOf: (chapter: DownloadChapter) => 'none' | 'partial' | 'complete';
+  refresh: () => Promise<void>;
+}
+
+// Orchestrates the podcast download surface: derives chapters from the TOC,
+// reads per-section cache status, and runs the headless synthesizer with live
+// progress. Everything is off the playback path; a download can run while the
+// user listens.
+export const useTTSDownloads = (
+  bookKey: string,
+  getController: () => TTSController | null,
+  isOpen: boolean,
+): UseTTSDownloadsResult => {
+  const _ = useTranslation();
+  const { getBookData } = useBookDataStore();
+  const [statuses, setStatuses] = useState<Map<number, SectionCacheStatus>>(new Map());
+  const [cacheBytes, setCacheBytes] = useState(0);
+  const [download, setDownload] = useState<ChapterDownloadState>({
+    activeChapterKey: null,
+    done: 0,
+    total: 0,
+  });
+  const abortRef = useRef<AbortController | null>(null);
+
+  const controller = getController();
+  const supported = !!controller?.canDownload();
+
+  const chapters = useMemo(() => {
+    if (!controller) return [];
+    const toc = getBookData(bookKey)?.bookDoc?.toc ?? [];
+    const view = controller.view;
+    const sectionCount = view?.book?.sections?.length ?? 0;
+    if (!sectionCount) return [];
+    return deriveDownloadChapters(
+      toc,
+      (href) => {
+        try {
+          return view.resolveNavigation(href)?.index ?? null;
+        } catch {
+          return null;
+        }
+      },
+      sectionCount,
+      (n) => _('Section {{index}}', { index: n }),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bookKey, controller, isOpen]);
+
+  const refresh = useCallback(async () => {
+    const ctrl = getController();
+    if (!ctrl) return;
+    const [nextStatuses, bytes] = await Promise.all([
+      ctrl.getSectionCacheStatuses(),
+      ctrl.getCacheBytes(),
+    ]);
+    setStatuses(nextStatuses);
+    setCacheBytes(bytes);
+  }, [getController]);
+
+  // Refresh on open so badges reflect what playback has already cached.
+  useEffect(() => {
+    if (isOpen) void refresh();
+  }, [isOpen, refresh]);
+
+  const runDownload = useCallback(
+    async (targets: DownloadChapter[]) => {
+      const downloader = getController()?.getTTSDownloader();
+      if (!downloader || !targets.length) return;
+      abortRef.current?.abort();
+      const abort = new AbortController();
+      abortRef.current = abort;
+      try {
+        for (const chapter of targets) {
+          if (abort.signal.aborted) break;
+          const sections = chapterSections(chapter).filter(
+            (section) => !statuses.get(section)?.packed,
+          );
+          if (!sections.length) continue;
+          setDownload({ activeChapterKey: chapter.key, done: 0, total: 0 });
+          await downloader.download(
+            sections,
+            (progress) => {
+              setDownload((prev) =>
+                prev.activeChapterKey === chapter.key
+                  ? { ...prev, done: progress.done, total: progress.total }
+                  : prev,
+              );
+            },
+            abort.signal,
+          );
+          await refresh();
+        }
+      } finally {
+        if (abortRef.current === abort) abortRef.current = null;
+        setDownload({ activeChapterKey: null, done: 0, total: 0 });
+      }
+    },
+    [getController, refresh, statuses],
+  );
+
+  const downloadChapter = useCallback(
+    (chapter: DownloadChapter) => runDownload([chapter]),
+    [runDownload],
+  );
+
+  const downloadAll = useCallback(
+    () => runDownload(chapters.filter((c) => chapterDownloadStatus(c, statuses) !== 'complete')),
+    [runDownload, chapters, statuses],
+  );
+
+  const cancel = useCallback(() => abortRef.current?.abort(), []);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const statusOf = useCallback(
+    (chapter: DownloadChapter) => chapterDownloadStatus(chapter, statuses),
+    [statuses],
+  );
+
+  return {
+    supported,
+    chapters,
+    statuses,
+    cacheBytes,
+    download,
+    downloadChapter,
+    downloadAll,
+    cancel,
+    statusOf,
+    refresh,
+  };
+};

--- a/apps/readest-app/src/components/settings/TTSPanel.tsx
+++ b/apps/readest-app/src/components/settings/TTSPanel.tsx
@@ -7,7 +7,8 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { saveViewSettings } from '@/helpers/settings';
 import { SettingsPanelPanelProp } from './SettingsDialog';
 import { TTSHighlightGranularity, TTSMediaMetadataMode } from '@/services/tts/types';
-import { BoxedList, SettingsRow, SettingsSelect } from './primitives';
+import { getTTSCacheConfig, setTTSCacheConfig } from '@/services/tts/providers/bookCacheStore';
+import { BoxedList, SettingsRow, SettingsSelect, SettingsSwitchRow } from './primitives';
 import TTSHighlightStyleEditor, { TTSHighlightStyle } from './color/TTSHighlightStyleEditor';
 
 const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }) => {
@@ -32,6 +33,13 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
   const [customTtsHighlightColors, setCustomTtsHighlightColors] = useState(
     settings.globalReadSettings.customTtsHighlightColors || [],
   );
+
+  const [ttsCacheConfig, setTtsCacheConfigState] = useState(getTTSCacheConfig());
+
+  const updateTTSCacheConfig = (config: typeof ttsCacheConfig) => {
+    setTtsCacheConfigState(config);
+    setTTSCacheConfig(config);
+  };
 
   const resetToDefaults = useResetViewSettings();
 
@@ -123,6 +131,48 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
               { value: 'sentence', label: _('Every Sentence') },
               { value: 'paragraph', label: _('Every Paragraph') },
               { value: 'chapter', label: _('Every Chapter') },
+            ]}
+          />
+        </SettingsRow>
+      </BoxedList>
+
+      <BoxedList title={_('Audio Cache')} data-setting-id='settings.tts.audioCache'>
+        <SettingsSwitchRow
+          label={_('Cache Synthesized Audio')}
+          description={_('Reuse generated speech across sessions without refetching')}
+          checked={ttsCacheConfig.enabled}
+          onChange={() =>
+            updateTTSCacheConfig({ ...ttsCacheConfig, enabled: !ttsCacheConfig.enabled })
+          }
+          data-setting-id='settings.tts.audioCacheEnabled'
+        />
+        <SettingsSwitchRow
+          label={_('Sync Audio Cache')}
+          description={_('Share section audio between your devices through your file sync service')}
+          checked={ttsCacheConfig.syncEnabled}
+          disabled={!ttsCacheConfig.enabled}
+          onChange={() =>
+            updateTTSCacheConfig({ ...ttsCacheConfig, syncEnabled: !ttsCacheConfig.syncEnabled })
+          }
+          data-setting-id='settings.tts.audioCacheSync'
+        />
+        <SettingsRow label={_('Storage Limit')}>
+          <SettingsSelect
+            value={String(ttsCacheConfig.budgetMB)}
+            onChange={(event) =>
+              updateTTSCacheConfig({
+                ...ttsCacheConfig,
+                budgetMB: Number(event.target.value),
+              })
+            }
+            ariaLabel={_('Storage Limit')}
+            disabled={!ttsCacheConfig.enabled}
+            options={[
+              { value: '50', label: '50 MB' },
+              { value: '100', label: '100 MB' },
+              { value: '200', label: '200 MB' },
+              { value: '500', label: '500 MB' },
+              { value: '1024', label: '1 GB' },
             ]}
           />
         </SettingsRow>

--- a/apps/readest-app/src/services/cloudService.ts
+++ b/apps/readest-app/src/services/cloudService.ts
@@ -49,6 +49,14 @@ export async function deleteBook(
       if (await fs.exists(dir, 'Books')) {
         await fs.removeDir(dir, 'Books', true);
       }
+      // The per-book TTS audio cache lives under Cache (kept out of Books/
+      // so backups and sync never pick it up); purge erases every trace of
+      // the book, so drop it too. Non-purge deletes leave it: like
+      // config.json, a re-downloaded book resumes with a warm audio cache.
+      const ttsCacheDir = `tts-cache/${book.hash}`;
+      if (await fs.exists(ttsCacheDir, 'Cache')) {
+        await fs.removeDir(ttsCacheDir, 'Cache', true);
+      }
     }
 
     if (deleteAction === 'both' && (await fs.exists(getCoverFilename(book), 'Books'))) {

--- a/apps/readest-app/src/services/sync/file/layout.ts
+++ b/apps/readest-app/src/services/sync/file/layout.ts
@@ -32,6 +32,10 @@ export const SYNC_BOOKS_DIR = 'books';
 export const SYNC_LIBRARY_FILE = 'library.json';
 export const SYNC_BOOK_CONFIG_FILE = 'config.json';
 export const SYNC_BOOK_COVER_FILE = 'cover.png';
+// TTS section packs (<section>-<keysfp>.mp3 + .json sidecars) live in a
+// per-book subdirectory. Additive to the frozen layout above: older clients
+// simply never look inside it.
+export const SYNC_BOOK_TTS_DIR = 'tts';
 
 /**
  * Normalise the user-entered rootPath so the rest of the code can rely on
@@ -58,6 +62,14 @@ export const buildBasePath = (rootPath: string): string =>
 /** Absolute path of the per-book directory keyed by hash. */
 export const buildBookDirPath = (rootPath: string, bookHash: string): string =>
   join(buildBasePath(rootPath), SYNC_BOOKS_DIR, bookHash);
+
+/** Absolute path of the per-book TTS pack directory. */
+export const buildBookTTSDirPath = (rootPath: string, bookHash: string): string =>
+  join(buildBookDirPath(rootPath, bookHash), SYNC_BOOK_TTS_DIR);
+
+/** Absolute path of one TTS pack file (or sidecar) inside the tts dir. */
+export const buildBookTTSFilePath = (rootPath: string, bookHash: string, name: string): string =>
+  join(buildBookTTSDirPath(rootPath, bookHash), name);
 
 /** Absolute path of a book's config.json (progress + booknotes). */
 export const buildBookConfigPath = (rootPath: string, bookHash: string): string =>

--- a/apps/readest-app/src/services/sync/file/ttsPackSync.ts
+++ b/apps/readest-app/src/services/sync/file/ttsPackSync.ts
@@ -1,0 +1,155 @@
+// Cross-device sync of TTS section packs (phase B of the pack sync design in
+// .agents/plans/2026-07-13-tts-cache-sqlite-packs.md section 9). Packs are
+// immutable and named by the hash of their ordered entry keys, so the whole
+// protocol is an existence check: a remote file with the right name already
+// has the right bytes. Deletions never propagate — local eviction is a local
+// budget decision and the remote acts as a shared pack library on the user's
+// own storage.
+//
+// Sidecars are uploaded AFTER their mp3 so a sidecar's presence always
+// implies a complete pack; the pull side only trusts mp3+json pairs and the
+// importer re-validates the sidecar against the bytes anyway.
+//
+// Everything here is fire-and-forget housekeeping: failures are swallowed
+// (returning 0) and must never affect playback or the main sync pipeline.
+
+import { useSettingsStore } from '@/store/settingsStore';
+import { resolveCloudSyncGate } from '@/services/sync/cloudSyncProvider';
+import type { TTSPackSidecar } from '@/services/tts/providers/sqliteCacheStore';
+import { ancestorsOf, buildBookTTSDirPath, buildBookTTSFilePath } from './layout';
+import type { FileSyncProvider } from './provider';
+import { createFileSyncProvider } from './providerRegistry';
+
+export interface TTSPackSource {
+  listPacks(): Promise<{ name: string; size: number }[]>;
+  readPackBytes(name: string): Promise<ArrayBuffer | null>;
+  buildPackSidecar(name: string): Promise<TTSPackSidecar | null>;
+}
+
+export interface TTSPackDestination {
+  hasPack(name: string): Promise<boolean>;
+  importPack(data: ArrayBuffer, sidecar: TTSPackSidecar): Promise<boolean>;
+}
+
+const sidecarNameOf = (packName: string): string => packName.replace(/\.mp3$/, '.json');
+
+const listRemoteNames = async (provider: FileSyncProvider, dir: string): Promise<Set<string>> => {
+  try {
+    const entries = await provider.list(dir);
+    return new Set(entries.filter((entry) => !entry.isDirectory).map((entry) => entry.name));
+  } catch {
+    // Missing directory (nothing synced yet) or a transient backend error;
+    // both read as "remote has nothing".
+    return new Set();
+  }
+};
+
+// Upload local packs the remote does not have. Returns how many packs were
+// pushed (a healed missing sidecar counts as a push).
+export const pushTTSPacks = async (
+  provider: FileSyncProvider,
+  bookHash: string,
+  source: TTSPackSource,
+): Promise<number> => {
+  try {
+    const local = await source.listPacks();
+    if (!local.length) return 0;
+    const dir = buildBookTTSDirPath(provider.rootPath, bookHash);
+    const remote = await listRemoteNames(provider, dir);
+    const missing = local.filter(
+      (pack) => !remote.has(pack.name) || !remote.has(sidecarNameOf(pack.name)),
+    );
+    if (!missing.length) return 0;
+
+    await provider.ensureDir(ancestorsOf(buildBookTTSFilePath(provider.rootPath, bookHash, 'x')));
+    let pushed = 0;
+    for (const pack of missing) {
+      try {
+        const sidecar = await source.buildPackSidecar(pack.name);
+        if (!sidecar) continue;
+        if (!remote.has(pack.name)) {
+          const bytes = await source.readPackBytes(pack.name);
+          if (!bytes) continue;
+          await provider.writeBinary(
+            buildBookTTSFilePath(provider.rootPath, bookHash, pack.name),
+            bytes,
+            'audio/mpeg',
+          );
+        }
+        await provider.writeText(
+          buildBookTTSFilePath(provider.rootPath, bookHash, sidecarNameOf(pack.name)),
+          JSON.stringify(sidecar),
+          'application/json',
+        );
+        pushed++;
+      } catch (err) {
+        console.warn('TTS pack push failed for', pack.name, err);
+      }
+    }
+    return pushed;
+  } catch (err) {
+    console.warn('TTS pack push failed', err);
+    return 0;
+  }
+};
+
+// Import remote packs the device does not have. Returns how many landed.
+export const pullTTSPacks = async (
+  provider: FileSyncProvider,
+  bookHash: string,
+  dest: TTSPackDestination,
+): Promise<number> => {
+  try {
+    const dir = buildBookTTSDirPath(provider.rootPath, bookHash);
+    const remote = await listRemoteNames(provider, dir);
+    let imported = 0;
+    for (const name of remote) {
+      if (!name.endsWith('.json')) continue;
+      const packName = name.replace(/\.json$/, '.mp3');
+      try {
+        // A sidecar without its mp3 is an incomplete upload: skip.
+        if (!remote.has(packName)) continue;
+        if (await dest.hasPack(packName)) continue;
+        const text = await provider.readText(
+          buildBookTTSFilePath(provider.rootPath, bookHash, name),
+        );
+        if (!text) continue;
+        let sidecar: TTSPackSidecar;
+        try {
+          sidecar = JSON.parse(text) as TTSPackSidecar;
+        } catch {
+          continue;
+        }
+        const bytes = await provider.readBinary(
+          buildBookTTSFilePath(provider.rootPath, bookHash, packName),
+        );
+        if (!bytes) continue;
+        if (await dest.importPack(bytes, sidecar)) imported++;
+      } catch (err) {
+        console.warn('TTS pack pull failed for', packName, err);
+      }
+    }
+    return imported;
+  } catch (err) {
+    console.warn('TTS pack pull failed', err);
+    return 0;
+  }
+};
+
+// The provider pack sync rides: the user's SELECTED third-party file-sync
+// backend, honoring the pause gate (#4959). Readest Cloud is deliberately
+// excluded — packs live on the user's own storage only.
+export const getActiveTTSPackSyncProvider = async (): Promise<FileSyncProvider | null> => {
+  try {
+    const settings = useSettingsStore.getState().settings;
+    const gate = resolveCloudSyncGate(settings);
+    // Third-party backends only (Readest Cloud is excluded from packs) and
+    // never while the plan has them paused (#4959). Use the highest-priority
+    // enabled backend, matching the fixed webdav/gdrive/s3/onedrive order.
+    const backend = gate.paused ? undefined : gate.backends[0];
+    if (!backend) return null;
+    return await createFileSyncProvider(backend, settings);
+  } catch {
+    return null;
+  }
+};

--- a/apps/readest-app/src/services/tts/BufferedTTSClient.ts
+++ b/apps/readest-app/src/services/tts/BufferedTTSClient.ts
@@ -1,0 +1,714 @@
+import { getOSPlatform, getUserLocale } from '@/utils/misc';
+import { isTauriAppPlatform } from '@/services/environment';
+import { isSameLang } from '@/utils/lang';
+import { NativeAudioPlayer } from './NativeAudioPlayer';
+import { TTSClient, TTSCapabilities, TTSMessageEvent } from './TTSClient';
+import { TTSWordBoundary } from '@/libs/edgeTTS';
+import { TTSGranularity, TTSMark, TTSVoice, TTSVoicesGroup } from './types';
+import { AppService } from '@/types/system';
+import { parseSSMLMarks } from '@/utils/ssml';
+import { TTSController } from './TTSController';
+import { TTSUtils } from './TTSUtils';
+import { findBoundaryIndexAtTime } from './wordHighlight';
+import { applyEdgeFade, findSpeechBounds } from './pcm';
+import { timeStretch } from './timeStretch';
+import {
+  calibrateVoiceRate,
+  recordMeasuredDuration,
+  recordProvisionalDuration,
+} from './ttsDuration';
+import { CachingProvider } from './providers/cache';
+import {
+  SpeechProvider,
+  SpeechSynthesisPermanentError,
+  SpeechSynthesisRequest,
+} from './providers/types';
+import { TTSAudioBuffer, WebAudioPlayer, WebAudioPlayerEvent } from './WebAudioPlayer';
+
+// The generic buffered TTS client: one SpeechProvider synthesizes compressed
+// audio + word boundaries, and everything engine-independent lives here —
+// the scheduler with backpressure, decode/trim/WSOLA (web path), native raw
+// playout (iOS), word tracking against the player's media clock, preload,
+// and duration bookkeeping. A new engine is just a new SpeechProvider.
+//
+// Playback pipeline: synthesize MP3 (cached at rate 1.0) -> decode -> trim
+// silence -> WSOLA time-stretch to the playback rate -> schedule gaplessly on
+// the shared AudioContext. Marks are dispatched when a chunk becomes AUDIBLE
+// (player chunk-start events ride source onended, which keeps working with
+// the screen off), not when it is fetched — schedule-ahead would otherwise
+// run foliate's mark cursor ahead of the voice and break prev/next/resume.
+
+// Natural pause between sentences, replacing Edge's baked-in ~300ms trailing
+// silence. Divided by the playback rate so pauses shrink with speed (#2033's
+// "gaps don't scale" complaint).
+export const DEFAULT_SENTENCE_GAP_SEC = 0.15;
+const TICKS_PER_SECOND = 10_000_000;
+
+// How many consecutive unreachable sentences (offline with nothing cached, or
+// a persistent service failure) to skip before stopping. A cached chapter
+// whose heading is uncached still plays: the heading skips, the cached body
+// resets the count. A wholly-uncached run stops instead of racing to the end.
+const MAX_CONSECUTIVE_SKIPS = 3;
+
+interface ChunkMeta {
+  mark: TTSMark;
+  boundaries: TTSWordBoundary[];
+  trimStartSec: number;
+  trimmedDurationSec: number;
+  // The exact synthesis request, for manifest key recording at chunk-start.
+  req?: SpeechSynthesisRequest;
+}
+
+type SpeakQueueEvent =
+  | { kind: 'chunk-start'; index: number }
+  | { kind: 'chunk-skip'; markName: string }
+  | { kind: 'session-end' }
+  | { kind: 'error'; message: string };
+
+class AsyncQueue<T> {
+  #items: T[] = [];
+  #resolvers: Array<(item: T) => void> = [];
+
+  push(item: T): void {
+    const resolve = this.#resolvers.shift();
+    if (resolve) resolve(item);
+    else this.#items.push(item);
+  }
+
+  next(): Promise<T> {
+    const item = this.#items.shift();
+    if (item !== undefined) return Promise.resolve(item);
+    return new Promise((resolve) => this.#resolvers.push(resolve));
+  }
+}
+
+export class BufferedTTSClient implements TTSClient {
+  name: string;
+  initialized = false;
+  controller?: TTSController;
+  appService?: AppService | null;
+
+  protected readonly provider: SpeechProvider;
+  protected voices: TTSVoice[] = [];
+  #primaryLang = 'en';
+  #speakingLang = '';
+  #currentVoiceId = '';
+  #rate = 1.0;
+  #pitch = 1.0;
+  #sentenceGapSec = DEFAULT_SENTENCE_GAP_SEC;
+
+  // iOS plays natively (app-process AVPlayer): audio in the app's own audio
+  // session makes Now Playing, pause-slot retention, AirPods routing, and the
+  // mute switch behave like a music app — the WebAudio path renders in
+  // WebKit's GPU process under a session the app cannot own. Everywhere else
+  // the gapless WSOLA WebAudio pipeline stays.
+  #player: WebAudioPlayer | NativeAudioPlayer =
+    getOSPlatform() === 'ios' && isTauriAppPlatform()
+      ? new NativeAudioPlayer()
+      : new WebAudioPlayer();
+  #activeGeneration: number | null = null;
+  #activeQueue: AsyncQueue<SpeakQueueEvent> | null = null;
+  #chunkMeta: ChunkMeta[] = [];
+  #isPlaying = false;
+  #wordTrackingRafId: number | null = null;
+  // Run of consecutive unreachable sentences (offline misses / persistent
+  // failures) in the current session. Reset by any successful chunk; persists
+  // across auto-advanced sections so a wholly-uncached run stops instead of
+  // skipping to the end. A user-initiated restart builds a fresh client, so it
+  // starts at 0 there too.
+  #consecutiveSkips = 0;
+
+  constructor(
+    provider: SpeechProvider,
+    controller?: TTSController,
+    appService?: AppService | null,
+  ) {
+    this.provider = provider;
+    this.name = provider.id;
+    this.controller = controller;
+    this.appService = appService;
+  }
+
+  async init(): Promise<boolean> {
+    this.voices = await this.provider.getAllVoices();
+    this.initialized = await this.provider.init();
+    return this.initialized;
+  }
+
+  // Synthesis requests fail intermittently (network transports); retry a few
+  // times before giving up so a single transient failure doesn't stall
+  // playback. SpeechSynthesisPermanentError is permanent for a given
+  // sentence, so it rethrows immediately for the caller's skip path.
+  #synthesizeWithRetry = async (
+    lang: string,
+    text: string,
+    voiceId: string,
+    signal: AbortSignal,
+    maxAttempts = 3,
+  ): Promise<{ data: ArrayBuffer; boundaries: TTSWordBoundary[] } | undefined> => {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      if (signal.aborted) return undefined;
+      try {
+        // Rate is deliberately absent from the request: the provider
+        // synthesizes at rate 1.0 and playout applies the playback rate.
+        const { audio, boundaries } = await this.provider.synthesize(
+          { lang, text, voice: voiceId, pitch: this.#pitch },
+          signal,
+        );
+        return { data: audio, boundaries };
+      } catch (err) {
+        if (err instanceof SpeechSynthesisPermanentError) throw err;
+        lastError = err;
+        console.warn(`TTS synthesis attempt ${attempt}/${maxAttempts} failed`, err);
+        if (attempt < maxAttempts && !signal.aborted) {
+          await new Promise((resolve) => setTimeout(resolve, 200 * attempt));
+        }
+      }
+    }
+    throw lastError;
+  };
+
+  #recordDurations = (
+    voiceId: string,
+    text: string,
+    boundaries: TTSWordBoundary[],
+    trimmedDurationSec?: number,
+  ) => {
+    if (trimmedDurationSec !== undefined) {
+      // Canonical: decode-time trimmed duration; also feeds the per-voice
+      // speaking-rate calibration used by timeline estimates.
+      recordMeasuredDuration(voiceId, text, trimmedDurationSec);
+      calibrateVoiceRate(voiceId, text, trimmedDurationSec);
+      return;
+    }
+    const last = boundaries[boundaries.length - 1];
+    if (last) {
+      recordProvisionalDuration(voiceId, text, (last.offset + last.duration) / TICKS_PER_SECOND);
+    }
+  };
+
+  getVoiceIdFromLang = async (lang: string) => {
+    const preferredVoiceId = TTSUtils.getPreferredVoice(this.name, lang);
+    const preferredVoice = this.voices.find((v) => v.id === preferredVoiceId);
+    if (preferredVoice) return preferredVoice.id;
+
+    const availableVoices = (await this.getVoices(lang))[0]?.voices || [];
+    const picked = this.provider.pickDefaultVoice?.(availableVoices);
+    return (
+      picked ||
+      availableVoices[0]?.id ||
+      this.#currentVoiceId ||
+      this.provider.fallbackVoiceId ||
+      ''
+    );
+  };
+
+  async *speak(ssml: string, signal: AbortSignal, preload = false) {
+    const { marks } = parseSSMLMarks(ssml, this.#primaryLang);
+
+    if (preload) {
+      yield* this.#preload(marks, signal);
+      return;
+    }
+
+    await this.stopInternal();
+
+    const queue = new AsyncQueue<SpeakQueueEvent>();
+    const chunkMeta: ChunkMeta[] = [];
+    this.#activeQueue = queue;
+    this.#chunkMeta = chunkMeta;
+
+    // startSession before ensureContext: starting a session declares playback
+    // intent, clearing any lingering user-pause so the context may resume.
+    const generation = this.#player.startSession((event: WebAudioPlayerEvent) => {
+      if (event.type === 'chunk-start') {
+        queue.push({ kind: 'chunk-start', index: event.chunkIndex });
+      } else if (event.type === 'session-end') {
+        queue.push({ kind: 'session-end' });
+      } else {
+        queue.push({ kind: 'error', message: event.message });
+      }
+    });
+    this.#activeGeneration = generation;
+    await this.#player.ensureContext();
+    this.#isPlaying = true;
+
+    this.#runScheduler(marks, signal, generation, queue, chunkMeta);
+
+    let abortHandler: (() => void) | null = null;
+    try {
+      if (signal.aborted) {
+        yield { code: 'error', message: 'Aborted' } as TTSMessageEvent;
+        return;
+      }
+      abortHandler = () => queue.push({ kind: 'error', message: 'Aborted' });
+      signal.addEventListener('abort', abortHandler);
+
+      for (;;) {
+        const event = await queue.next();
+        if (event.kind === 'chunk-start') {
+          const meta = chunkMeta[event.index];
+          if (!meta) continue;
+          const located = this.controller?.dispatchSpeakMark(meta.mark);
+          if (located && meta.req && this.provider instanceof CachingProvider) {
+            // The sentence audibly played: record its cache key against the
+            // section manifest so a fully covered section can compact.
+            this.provider.recordMark(located.sectionIndex, located.sentenceIndex, meta.req);
+          }
+          this.#startWordTracking(generation, event.index, meta);
+          yield {
+            code: 'boundary',
+            message: `Start chunk: ${meta.mark.name}`,
+            mark: meta.mark.name,
+          } as TTSMessageEvent;
+        } else if (event.kind === 'chunk-skip') {
+          yield {
+            code: 'end',
+            message: `Chunk skipped: ${event.markName}`,
+          } as TTSMessageEvent;
+        } else if (event.kind === 'session-end') {
+          yield { code: 'end', message: 'Speak finished' } as TTSMessageEvent;
+          return;
+        } else {
+          yield { code: 'error', message: event.message } as TTSMessageEvent;
+          return;
+        }
+      }
+    } finally {
+      // The controller aborts the signal after every successful paragraph; a
+      // lingering listener would push a stale 'Aborted' into a dead queue.
+      if (abortHandler) signal.removeEventListener('abort', abortHandler);
+      this.#stopWordTracking();
+      this.#isPlaying = false;
+      if (this.#activeGeneration === generation) {
+        this.#activeGeneration = null;
+        this.#activeQueue = null;
+        this.#player.abortSession();
+      }
+    }
+  }
+
+  async *#preload(marks: TTSMark[], signal: AbortSignal) {
+    // Fetch the first couple of marks immediately and the rest in the
+    // background; the provider's in-flight dedup keeps this from racing
+    // duplicate requests against the playback scheduler.
+    const maxImmediate = 2;
+    for (let i = 0; i < Math.min(maxImmediate, marks.length); i++) {
+      if (signal.aborted) break;
+      const mark = marks[i]!;
+      const voiceId = await this.getVoiceIdFromLang(mark.language);
+      this.#currentVoiceId = voiceId;
+      try {
+        const audio = await this.#synthesizeWithRetry(mark.language, mark.text, voiceId, signal);
+        if (audio) this.#recordDurations(voiceId, mark.text, audio.boundaries);
+      } catch (err) {
+        console.warn('Error preloading mark', i, err);
+      }
+    }
+    if (marks.length > maxImmediate) {
+      (async () => {
+        for (let i = maxImmediate; i < marks.length; i++) {
+          const mark = marks[i]!;
+          try {
+            if (signal.aborted) break;
+            const voiceId = await this.getVoiceIdFromLang(mark.language);
+            const audio = await this.#synthesizeWithRetry(
+              mark.language,
+              mark.text,
+              voiceId,
+              signal,
+            );
+            if (audio) this.#recordDurations(voiceId, mark.text, audio.boundaries);
+          } catch (err) {
+            console.warn('Error preloading mark (bg)', i, err);
+          }
+        }
+      })();
+    }
+
+    yield {
+      code: 'end',
+      message: 'Preload finished',
+    } as TTSMessageEvent;
+  }
+
+  // Detached scheduler: fetches, prepares, and schedules chunks ahead of the
+  // playhead under the player's backpressure. Never throws; failures surface
+  // through the event queue.
+  async #runScheduler(
+    marks: TTSMark[],
+    signal: AbortSignal,
+    generation: number,
+    queue: AsyncQueue<SpeakQueueEvent>,
+    chunkMeta: ChunkMeta[],
+  ): Promise<void> {
+    const rate = this.#rate;
+    try {
+      for (const mark of marks) {
+        if (signal.aborted || this.#activeGeneration !== generation) return;
+        // Voices resolve per mark: mixed-language sections speak (and record
+        // durations under) the voice actually used for each sentence.
+        const voiceId = await this.getVoiceIdFromLang(mark.language);
+        this.#speakingLang = mark.language;
+        this.#currentVoiceId = voiceId;
+
+        const req: SpeechSynthesisRequest = {
+          lang: mark.language,
+          text: mark.text,
+          voice: voiceId,
+          pitch: this.#pitch,
+        };
+        let audio: { data: ArrayBuffer; boundaries: TTSWordBoundary[] } | undefined;
+        try {
+          audio = await this.#synthesizeWithRetry(mark.language, mark.text, voiceId, signal);
+        } catch (error) {
+          if (error instanceof SpeechSynthesisPermanentError) {
+            // Genuinely unsynthesizable sentence (server returned no audio):
+            // skip it and keep going — a few bad sentences must not stop a
+            // chapter. These don't count toward the offline stop budget.
+            console.warn('No audio data received for:', mark.text);
+            queue.push({ kind: 'chunk-skip', markName: mark.name });
+            continue;
+          }
+          // A synthesis error that survived the retries: offline with this
+          // sentence uncached, or a persistent service failure. Skip it so
+          // cached neighbours still play (a cached section whose heading is
+          // uncached must not stop on the heading), but stop after a RUN of
+          // unreachable sentences rather than silently skipping to the end of
+          // the book. A later cached hit resets the budget below.
+          const message = error instanceof Error ? error.message : String(error);
+          this.#consecutiveSkips += 1;
+          if (this.#consecutiveSkips > MAX_CONSECUTIVE_SKIPS) {
+            console.warn('TTS stopping after consecutive unreachable sentences:', message);
+            queue.push({ kind: 'error', message });
+            return;
+          }
+          console.warn('TTS skipping unreachable sentence:', mark.text, message);
+          queue.push({ kind: 'chunk-skip', markName: mark.name });
+          continue;
+        }
+        if (!audio || signal.aborted || this.#activeGeneration !== generation) return;
+        this.#consecutiveSkips = 0;
+        this.#recordDurations(voiceId, mark.text, audio.boundaries);
+
+        if (this.#player instanceof NativeAudioPlayer) {
+          // Native playout: no decode/trim/WSOLA — the raw MP3 goes to the
+          // AVPlayer, which time-stretches at the pitch-preserving native
+          // rate. Word boundaries stay in original media time, matching the
+          // player's media clock, so trimStartSec is 0 by construction.
+          const ready = await this.#player.waitUntilReady(generation);
+          if (!ready || signal.aborted) return;
+          const index = chunkMeta.length;
+          const meta: ChunkMeta = {
+            mark,
+            boundaries: audio.boundaries,
+            trimStartSec: 0,
+            trimmedDurationSec: 0,
+            req,
+          };
+          // Push before enqueue: the chunk-start event can arrive as soon as
+          // the native side starts the item.
+          chunkMeta.push(meta);
+          try {
+            const durationSec = await this.#player.scheduleRawChunk(generation, index, audio.data, {
+              gapSec: this.#sentenceGapSec / rate,
+            });
+            meta.trimmedDurationSec = durationSec;
+            this.#recordDurations(voiceId, mark.text, audio.boundaries, durationSec);
+          } catch (error) {
+            console.warn('Failed to enqueue TTS audio for:', mark.text, error);
+            queue.push({ kind: 'chunk-skip', markName: mark.name });
+          }
+          continue;
+        }
+
+        const webPlayer = this.#player;
+        let prepared: {
+          buffer: TTSAudioBuffer;
+          trimStartSec: number;
+          trimmedDurationSec: number;
+        };
+        try {
+          prepared = await this.#prepareChunkBuffer(webPlayer, audio.data, rate);
+        } catch (error) {
+          // Malformed MP3 must not dead-end the session: same UX as no-audio.
+          console.warn('Failed to decode TTS audio for:', mark.text, error);
+          queue.push({ kind: 'chunk-skip', markName: mark.name });
+          continue;
+        }
+        this.#recordDurations(voiceId, mark.text, audio.boundaries, prepared.trimmedDurationSec);
+
+        const ready = await this.#player.waitUntilReady(generation);
+        if (!ready || signal.aborted) return;
+        chunkMeta.push({
+          mark,
+          boundaries: audio.boundaries,
+          trimStartSec: prepared.trimStartSec,
+          trimmedDurationSec: prepared.trimmedDurationSec,
+          req,
+        });
+        this.#player.scheduleChunk(generation, prepared.buffer, {
+          trimStartSec: prepared.trimStartSec,
+          mediaScale: prepared.trimmedDurationSec / prepared.buffer.duration,
+          gapSec: this.#sentenceGapSec / rate,
+        });
+      }
+      if (!signal.aborted && this.#activeGeneration === generation) {
+        // Fires session-end synchronously when every mark was skipped or the
+        // last chunk already ended, so the session always terminates.
+        this.#player.endSession(generation);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      queue.push({ kind: 'error', message });
+    }
+  }
+
+  async #prepareChunkBuffer(
+    player: WebAudioPlayer,
+    data: ArrayBuffer,
+    rate: number,
+  ): Promise<{ buffer: TTSAudioBuffer; trimStartSec: number; trimmedDurationSec: number }> {
+    // decodeAudioData resamples to the context rate (44.1/48kHz on real
+    // devices, not the stream's 24kHz) — all math below must use the decoded
+    // buffer's sampleRate.
+    const decoded = await player.decode(data);
+    const sampleRate = decoded.sampleRate;
+    const channel = decoded.getChannelData(0);
+    const bounds = findSpeechBounds(channel, sampleRate);
+    const startSample = Math.floor(bounds.startSec * sampleRate);
+    const endSample = Math.min(channel.length, Math.ceil(bounds.endSec * sampleRate));
+    // A subarray is a view; timeStretch never writes its input and
+    // createMonoBuffer copies, so no mutation can reach the decoded buffer.
+    const trimmed = channel.subarray(startSample, endSample);
+    const trimmedDurationSec = trimmed.length / sampleRate;
+    const samples = rate !== 1 ? timeStretch(trimmed, sampleRate, rate) : trimmed;
+    const buffer = await player.createMonoBuffer(samples, sampleRate);
+    // Silence-trimmed edges sit on non-zero samples; fade the buffer's own copy
+    // so chunk starts/ends don't click against the inter-sentence gap.
+    applyEdgeFade(buffer.getChannelData(0), sampleRate);
+    return { buffer, trimStartSec: startSample / sampleRate, trimmedDurationSec };
+  }
+
+  // Poll the audio clock (visual concern only, so rAF throttling with the
+  // screen off is fine) and tell the controller which word is being spoken.
+  // The player reports original (rate-1.0) media time, so the boundary
+  // ticks need no rescaling for trim or rate.
+  #startWordTracking(generation: number, chunkIndex: number, meta: ChunkMeta): void {
+    this.#stopWordTracking();
+    const controller = this.controller;
+    if (!controller) return;
+    // Always hand the words to the controller — with boundaries it highlights
+    // word-by-word; with none it draws the sentence highlight that was
+    // suppressed at mark dispatch (see TTSController.prepareSpeakWords).
+    controller.prepareSpeakWords(meta.boundaries.map((boundary) => boundary.text));
+    if (!meta.boundaries.length) return;
+    let lastIndex = -1;
+    const tick = () => {
+      const pos = this.#player.getPlaybackPosition(generation);
+      // Guard the one-frame window around a transition where this tick still
+      // holds the previous chunk's boundaries.
+      if (pos && pos.chunkIndex === chunkIndex) {
+        const index = findBoundaryIndexAtTime(meta.boundaries, pos.mediaTimeSec);
+        if (index !== lastIndex && index >= 0) {
+          lastIndex = index;
+          controller.dispatchSpeakWord(index);
+        }
+      }
+      this.#wordTrackingRafId = requestAnimationFrame(tick);
+    };
+    this.#wordTrackingRafId = requestAnimationFrame(tick);
+  }
+
+  #stopWordTracking(): void {
+    if (this.#wordTrackingRafId !== null) {
+      cancelAnimationFrame(this.#wordTrackingRafId);
+      this.#wordTrackingRafId = null;
+    }
+  }
+
+  async pause() {
+    if (!this.#isPlaying) return true;
+    await this.#player.pauseContext();
+    return true;
+  }
+
+  async resume() {
+    // Throws when the context refuses to run again (iOS post-interruption);
+    // the controller's catch stops playback visibly instead of showing
+    // "playing" over silence.
+    await this.#player.resumeContext();
+    return true;
+  }
+
+  async stop() {
+    await this.stopInternal();
+  }
+
+  protected async stopInternal() {
+    this.#stopWordTracking();
+    this.#isPlaying = false;
+    if (this.#activeGeneration !== null) {
+      this.#activeGeneration = null;
+      // Unblock a generator awaiting the queue; without this a stop() outside
+      // the abort path would leave the consumer parked forever.
+      this.#activeQueue?.push({ kind: 'error', message: 'Aborted' });
+      this.#activeQueue = null;
+      this.#player.abortSession();
+    }
+  }
+
+  getChunkPosition(): number | null {
+    const generation = this.#activeGeneration;
+    if (generation === null) return null;
+    const pos = this.#player.getPlaybackPosition(generation);
+    if (!pos) return null;
+    const meta = this.#chunkMeta[pos.chunkIndex];
+    if (!meta) return null;
+    // Trim-relative and clamped: the section timeline sums TRIMMED durations,
+    // while the player reports untrimmed media time (kept that way for word
+    // boundaries).
+    return Math.min(Math.max(pos.mediaTimeSec - meta.trimStartSec, 0), meta.trimmedDurationSec);
+  }
+
+  async setRate(rate: number) {
+    // Web path: applied client-side via WSOLA time-stretch at schedule time;
+    // takes effect on the next speak() session (the controller restarts
+    // playback on rate changes). Native path: applied live by the AVPlayer.
+    this.#rate = rate;
+    if (this.#player instanceof NativeAudioPlayer) {
+      await this.#player.setRate(rate);
+    }
+  }
+
+  async setPitch(pitch: number) {
+    // Passed through to the provider per synthesis request (Edge accepts
+    // pitch in [0.5 .. 1.5]).
+    this.#pitch = pitch;
+  }
+
+  async setVoice(voice: string) {
+    const selectedVoice = this.voices.find((v) => v.id === voice);
+    if (selectedVoice) {
+      this.#currentVoiceId = selectedVoice.id;
+    }
+  }
+
+  setSentenceGap(sec: number): void {
+    this.#sentenceGapSec = sec;
+  }
+
+  registerSectionManifest(section: number, marks: string[]): void {
+    if (this.provider instanceof CachingProvider) {
+      this.provider.registerSectionManifest(section, marks);
+    }
+  }
+
+  // ── Headless pre-synthesis (TTSDownloader CacheWarmer) ─────────────────
+
+  // Whether this client has a persistent cache to download into.
+  canDownload(): boolean {
+    return this.provider instanceof CachingProvider;
+  }
+
+  // Synthesize one sentence into the cache (a hit is a no-op) and record its
+  // key against the section manifest. Resolves the voice exactly as live
+  // playback does, so the computed key matches. Returns whether audio is now
+  // cached for it.
+  async warmSentence(
+    section: number,
+    ordinal: number,
+    lang: string,
+    text: string,
+  ): Promise<boolean> {
+    if (!(this.provider instanceof CachingProvider)) return false;
+    const voiceId = await this.getVoiceIdFromLang(lang);
+    const req = { lang, text, voice: voiceId, pitch: this.#pitch };
+    try {
+      await this.provider.synthesize(req, new AbortController().signal);
+    } catch {
+      // Offline / permanent failure: leave the ordinal unrecorded so the
+      // section stays incomplete and can be retried later.
+      return false;
+    }
+    this.provider.recordMark(section, ordinal, req);
+    return true;
+  }
+
+  async compactCache(): Promise<void> {
+    if (this.provider instanceof CachingProvider) await this.provider.compact();
+  }
+
+  async getSectionCacheStatuses(): Promise<
+    Map<number, { total: number; recorded: number; packed: boolean }>
+  > {
+    if (!(this.provider instanceof CachingProvider)) return new Map();
+    return this.provider.getSectionStatuses();
+  }
+
+  async getCacheBytes(): Promise<number> {
+    if (!(this.provider instanceof CachingProvider)) return 0;
+    return this.provider.totalCacheBytes();
+  }
+
+  async getAllVoices(): Promise<TTSVoice[]> {
+    this.voices.forEach((voice) => {
+      voice.disabled = !this.initialized;
+    });
+    return this.voices;
+  }
+
+  async getVoices(lang: string) {
+    const locale = lang === 'en' ? getUserLocale(lang) || lang : lang;
+    const voices = await this.getAllVoices();
+    // Match by primary language so the voice set stays the same across a book
+    // whose sections mix region variants (e.g. en-US front matter and en-GB
+    // body text); the requested locale's voices sort first. See #4033.
+    const filteredVoices = voices.filter((v) => isSameLang(v.lang, lang));
+
+    const voicesGroup: TTSVoicesGroup = {
+      id: this.name,
+      name: this.provider.label,
+      voices: filteredVoices.sort(TTSUtils.sortVoicesPreferLocaleFunc(locale)),
+      disabled: !this.initialized || filteredVoices.length === 0,
+    };
+
+    return [voicesGroup];
+  }
+
+  setPrimaryLang(lang: string) {
+    this.#primaryLang = lang;
+  }
+
+  getCapabilities(): TTSCapabilities {
+    return {
+      wordBoundaries: true,
+      mediaClock: true,
+      gapControl: true,
+      // The native player time-stretches live; the web path bakes the rate
+      // into the scheduled buffers, so it needs a session restart.
+      liveRateChange: this.#player instanceof NativeAudioPlayer,
+    };
+  }
+
+  getGranularities(): TTSGranularity[] {
+    return ['sentence'];
+  }
+
+  getVoiceId(): string {
+    return this.#currentVoiceId;
+  }
+
+  getSpeakingLang(): string {
+    return this.#speakingLang;
+  }
+
+  async shutdown(): Promise<void> {
+    await this.stopInternal();
+    await this.#player.shutdown();
+    await this.provider.shutdown?.();
+    this.initialized = false;
+    this.voices = [];
+  }
+}

--- a/apps/readest-app/src/services/tts/EdgeTTSClient.ts
+++ b/apps/readest-app/src/services/tts/EdgeTTSClient.ts
@@ -1,606 +1,68 @@
-import { getOSPlatform, getUserLocale } from '@/utils/misc';
-import { isTauriAppPlatform } from '@/services/environment';
-import { isSameLang } from '@/utils/lang';
-import { NativeAudioPlayer } from './NativeAudioPlayer';
-import { TTSClient, TTSMessageEvent } from './TTSClient';
-import { EdgeSpeechTTS, EdgeTTSPayload, EDGE_TTS_PROTOCOL, TTSWordBoundary } from '@/libs/edgeTTS';
-import { TTSGranularity, TTSMark, TTSVoice, TTSVoicesGroup } from './types';
+import { EDGE_TTS_PROTOCOL } from '@/libs/edgeTTS';
 import { AppService } from '@/types/system';
-import { parseSSMLMarks } from '@/utils/ssml';
+import { BufferedTTSClient } from './BufferedTTSClient';
+import { BookTTSCacheStore, getTTSCacheConfig } from './providers/bookCacheStore';
+import { CachingProvider } from './providers/cache';
+import { EdgeSpeechProvider } from './providers/edge';
+import { SpeechProvider } from './providers/types';
 import { TTSController } from './TTSController';
-import { TTSUtils } from './TTSUtils';
-import { findBoundaryIndexAtTime } from './wordHighlight';
-import { applyEdgeFade, findSpeechBounds } from './pcm';
-import { timeStretch } from './timeStretch';
-import {
-  calibrateVoiceRate,
-  recordMeasuredDuration,
-  recordProvisionalDuration,
-} from './ttsDuration';
-import { TTSAudioBuffer, WebAudioPlayer, WebAudioPlayerEvent } from './WebAudioPlayer';
 
-// Playback pipeline: fetch MP3 (cached at rate 1.0) -> decode -> trim silence
-// -> WSOLA time-stretch to the playback rate -> schedule gaplessly on the
-// shared AudioContext. Marks are dispatched when a chunk becomes AUDIBLE
-// (player chunk-start events ride source onended, which keeps working with
-// the screen off), not when it is fetched — schedule-ahead would otherwise
-// run foliate's mark cursor ahead of the voice and break prev/next/resume.
+// Everything engine-independent (scheduler, playout, word tracking, preload)
+// lives in BufferedTTSClient; the Edge specifics live in EdgeSpeechProvider.
+// This subclass keeps the persisted 'edge-tts' client name and owns the one
+// policy that needs app context: the wss -> https transport fallback, which
+// depends on the user's auth state.
+export { DEFAULT_SENTENCE_GAP_SEC } from './BufferedTTSClient';
 
-// Natural pause between sentences, replacing Edge's baked-in ~300ms trailing
-// silence. Divided by the playback rate so pauses shrink with speed (#2033's
-// "gaps don't scale" complaint).
-export const DEFAULT_SENTENCE_GAP_SEC = 0.15;
-const TICKS_PER_SECOND = 10_000_000;
-
-interface ChunkMeta {
-  mark: TTSMark;
-  boundaries: TTSWordBoundary[];
-  trimStartSec: number;
-  trimmedDurationSec: number;
-}
-
-type SpeakQueueEvent =
-  | { kind: 'chunk-start'; index: number }
-  | { kind: 'chunk-skip'; markName: string }
-  | { kind: 'session-end' }
-  | { kind: 'error'; message: string };
-
-class AsyncQueue<T> {
-  #items: T[] = [];
-  #resolvers: Array<(item: T) => void> = [];
-
-  push(item: T): void {
-    const resolve = this.#resolvers.shift();
-    if (resolve) resolve(item);
-    else this.#items.push(item);
-  }
-
-  next(): Promise<T> {
-    const item = this.#items.shift();
-    if (item !== undefined) return Promise.resolve(item);
-    return new Promise((resolve) => this.#resolvers.push(resolve));
-  }
-}
-
-export class EdgeTTSClient implements TTSClient {
-  name = 'edge-tts';
-  initialized = false;
-  controller?: TTSController;
-  appService?: AppService | null;
-
-  #voices: TTSVoice[] = [];
-  #primaryLang = 'en';
-  #speakingLang = '';
-  #currentVoiceId = '';
-  #rate = 1.0;
-  #pitch = 1.0;
-  #sentenceGapSec = DEFAULT_SENTENCE_GAP_SEC;
-
-  #edgeTTS: EdgeSpeechTTS | null = null;
-  // iOS plays natively (app-process AVPlayer): audio in the app's own audio
-  // session makes Now Playing, pause-slot retention, AirPods routing, and the
-  // mute switch behave like a music app — the WebAudio path renders in
-  // WebKit's GPU process under a session the app cannot own. Everywhere else
-  // the gapless WSOLA WebAudio pipeline stays.
-  #player: WebAudioPlayer | NativeAudioPlayer =
-    getOSPlatform() === 'ios' && isTauriAppPlatform()
-      ? new NativeAudioPlayer()
-      : new WebAudioPlayer();
-  #activeGeneration: number | null = null;
-  #activeQueue: AsyncQueue<SpeakQueueEvent> | null = null;
-  #chunkMeta: ChunkMeta[] = [];
-  #isPlaying = false;
-  #wordTrackingRafId: number | null = null;
+export class EdgeTTSClient extends BufferedTTSClient {
+  #edgeProvider: EdgeSpeechProvider;
 
   constructor(controller?: TTSController, appService?: AppService | null) {
-    this.controller = controller;
-    this.appService = appService;
+    const edgeProvider = new EdgeSpeechProvider();
+    let provider: SpeechProvider = edgeProvider;
+    const cacheConfig = getTTSCacheConfig();
+    if (appService && cacheConfig.enabled) {
+      // Per-book persistent cache on every platform: appService.openDatabase
+      // rides tauri-plugin-turso natively and turso WASM over OPFS on the
+      // web. The book key lands on the controller in init(), after this
+      // constructor, hence the lazy resolver — the hash is the part of the
+      // key before the first dash (see TTSSessionManager.getBookHashFromKey;
+      // inlined to avoid a module cycle through the session manager).
+      const store = new BookTTSCacheStore(
+        appService,
+        () => controller?.bookKey?.split('-')[0] || null,
+        cacheConfig.budgetMB * 1024 * 1024,
+      );
+      provider = new CachingProvider(edgeProvider, store);
+    }
+    super(provider, controller, appService);
+    this.#edgeProvider = edgeProvider;
   }
 
-  async init(protocol: EDGE_TTS_PROTOCOL = 'wss') {
-    this.#edgeTTS = new EdgeSpeechTTS(protocol);
-    this.#voices = EdgeSpeechTTS.voices;
-    try {
-      await this.#edgeTTS.create({
-        lang: 'en',
-        text: 'test',
-        voice: 'en-US-AriaNeural',
-        rate: 1.0,
-        pitch: 1.0,
-      });
+  override async init(_protocol: EDGE_TTS_PROTOCOL = 'wss'): Promise<boolean> {
+    this.voices = await this.#edgeProvider.getAllVoices();
+    // The free wss transport is intermittently blocked; authenticated users
+    // fall back to the https proxy route.
+    if (await this.#edgeProvider.init('wss')) {
       this.initialized = true;
-    } catch {
-      if (protocol === 'wss') {
-        if (this.controller?.isAuthenticated) {
-          await this.init('https');
-        } else {
-          this.controller?.dispatchEvent(new CustomEvent('tts-need-auth'));
-        }
-      } else {
-        this.initialized = false;
-      }
+      return true;
     }
-    return this.initialized;
-  }
-
-  getPayload = (lang: string, text: string, voiceId: string) => {
-    // Rate stays 1.0 so the MP3 cache is rate-independent; the playback rate
-    // is applied client-side via time-stretch.
-    return { lang, text, voice: voiceId, rate: 1.0, pitch: this.#pitch } as EdgeTTSPayload;
-  };
-
-  // Edge TTS websocket requests fail intermittently; retry a few times before
-  // giving up so a single transient failure doesn't stall playback. The
-  // "No audio data received." failure is permanent for a given sentence, so it
-  // rethrows immediately for the caller's skip path.
-  #createAudioDataWithRetry = async (
-    payload: EdgeTTSPayload,
-    signal: AbortSignal,
-    maxAttempts = 3,
-  ): Promise<{ data: ArrayBuffer; boundaries: TTSWordBoundary[] } | undefined> => {
-    let lastError: unknown;
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      if (signal.aborted) return undefined;
-      try {
-        return await this.#edgeTTS?.createAudioData(payload);
-      } catch (err) {
-        if (err instanceof Error && err.message === 'No audio data received.') throw err;
-        lastError = err;
-        console.warn(`Edge TTS fetch attempt ${attempt}/${maxAttempts} failed`, err);
-        if (attempt < maxAttempts && !signal.aborted) {
-          await new Promise((resolve) => setTimeout(resolve, 200 * attempt));
-        }
-      }
+    if (this.controller?.isAuthenticated && (await this.#edgeProvider.init('https'))) {
+      this.initialized = true;
+      return true;
     }
-    throw lastError;
-  };
-
-  #recordDurations = (
-    voiceId: string,
-    text: string,
-    boundaries: TTSWordBoundary[],
-    trimmedDurationSec?: number,
-  ) => {
-    if (trimmedDurationSec !== undefined) {
-      // Canonical: decode-time trimmed duration; also feeds the per-voice
-      // speaking-rate calibration used by timeline estimates.
-      recordMeasuredDuration(voiceId, text, trimmedDurationSec);
-      calibrateVoiceRate(voiceId, text, trimmedDurationSec);
-      return;
+    // Every probe failed: blocked, or offline. With a persistent cache a
+    // pre-downloaded book still plays (hits play, misses skip via the
+    // provider's permanent error), so init as cache-only rather than fail —
+    // and do NOT nag a signed-out user with a warm cache to sign in.
+    if (this.provider instanceof CachingProvider) {
+      this.initialized = true;
+      return true;
     }
-    const last = boundaries[boundaries.length - 1];
-    if (last) {
-      recordProvisionalDuration(voiceId, text, (last.offset + last.duration) / TICKS_PER_SECOND);
+    if (!this.controller?.isAuthenticated) {
+      this.controller?.dispatchEvent(new CustomEvent('tts-need-auth'));
     }
-  };
-
-  getVoiceIdFromLang = async (lang: string) => {
-    const preferredVoiceId = TTSUtils.getPreferredVoice(this.name, lang);
-    const preferredVoice = this.#voices.find((v) => v.id === preferredVoiceId);
-    if (preferredVoice) return preferredVoice.id;
-
-    const availableVoices = (await this.getVoices(lang))[0]?.voices || [];
-    const defaultVoice: TTSVoice | null = availableVoices[0] || null;
-    if (defaultVoice?.id === 'en-US-AnaNeural') return 'en-US-AriaNeural'; // avoid using AnaNeural as default
-    return defaultVoice?.id || this.#currentVoiceId || 'en-US-AriaNeural';
-  };
-
-  async *speak(ssml: string, signal: AbortSignal, preload = false) {
-    const { marks } = parseSSMLMarks(ssml, this.#primaryLang);
-
-    if (preload) {
-      yield* this.#preload(marks, signal);
-      return;
-    }
-
-    await this.stopInternal();
-
-    const queue = new AsyncQueue<SpeakQueueEvent>();
-    const chunkMeta: ChunkMeta[] = [];
-    this.#activeQueue = queue;
-    this.#chunkMeta = chunkMeta;
-
-    // startSession before ensureContext: starting a session declares playback
-    // intent, clearing any lingering user-pause so the context may resume.
-    const generation = this.#player.startSession((event: WebAudioPlayerEvent) => {
-      if (event.type === 'chunk-start') {
-        queue.push({ kind: 'chunk-start', index: event.chunkIndex });
-      } else if (event.type === 'session-end') {
-        queue.push({ kind: 'session-end' });
-      } else {
-        queue.push({ kind: 'error', message: event.message });
-      }
-    });
-    this.#activeGeneration = generation;
-    await this.#player.ensureContext();
-    this.#isPlaying = true;
-
-    this.#runScheduler(marks, signal, generation, queue, chunkMeta);
-
-    let abortHandler: (() => void) | null = null;
-    try {
-      if (signal.aborted) {
-        yield { code: 'error', message: 'Aborted' } as TTSMessageEvent;
-        return;
-      }
-      abortHandler = () => queue.push({ kind: 'error', message: 'Aborted' });
-      signal.addEventListener('abort', abortHandler);
-
-      for (;;) {
-        const event = await queue.next();
-        if (event.kind === 'chunk-start') {
-          const meta = chunkMeta[event.index];
-          if (!meta) continue;
-          this.controller?.dispatchSpeakMark(meta.mark);
-          this.#startWordTracking(generation, event.index, meta);
-          yield {
-            code: 'boundary',
-            message: `Start chunk: ${meta.mark.name}`,
-            mark: meta.mark.name,
-          } as TTSMessageEvent;
-        } else if (event.kind === 'chunk-skip') {
-          yield {
-            code: 'end',
-            message: `Chunk skipped: ${event.markName}`,
-          } as TTSMessageEvent;
-        } else if (event.kind === 'session-end') {
-          yield { code: 'end', message: 'Speak finished' } as TTSMessageEvent;
-          return;
-        } else {
-          yield { code: 'error', message: event.message } as TTSMessageEvent;
-          return;
-        }
-      }
-    } finally {
-      // The controller aborts the signal after every successful paragraph; a
-      // lingering listener would push a stale 'Aborted' into a dead queue.
-      if (abortHandler) signal.removeEventListener('abort', abortHandler);
-      this.#stopWordTracking();
-      this.#isPlaying = false;
-      if (this.#activeGeneration === generation) {
-        this.#activeGeneration = null;
-        this.#activeQueue = null;
-        this.#player.abortSession();
-      }
-    }
-  }
-
-  async *#preload(marks: TTSMark[], signal: AbortSignal) {
-    // Fetch the first couple of marks immediately and the rest in the
-    // background; the in-flight dedup in EdgeSpeechTTS keeps this from racing
-    // duplicate requests against the playback scheduler.
-    const maxImmediate = 2;
-    for (let i = 0; i < Math.min(maxImmediate, marks.length); i++) {
-      if (signal.aborted) break;
-      const mark = marks[i]!;
-      const voiceId = await this.getVoiceIdFromLang(mark.language);
-      this.#currentVoiceId = voiceId;
-      try {
-        const audio = await this.#createAudioDataWithRetry(
-          this.getPayload(mark.language, mark.text, voiceId),
-          signal,
-        );
-        if (audio) this.#recordDurations(voiceId, mark.text, audio.boundaries);
-      } catch (err) {
-        console.warn('Error preloading mark', i, err);
-      }
-    }
-    if (marks.length > maxImmediate) {
-      (async () => {
-        for (let i = maxImmediate; i < marks.length; i++) {
-          const mark = marks[i]!;
-          try {
-            if (signal.aborted) break;
-            const voiceId = await this.getVoiceIdFromLang(mark.language);
-            const audio = await this.#createAudioDataWithRetry(
-              this.getPayload(mark.language, mark.text, voiceId),
-              signal,
-            );
-            if (audio) this.#recordDurations(voiceId, mark.text, audio.boundaries);
-          } catch (err) {
-            console.warn('Error preloading mark (bg)', i, err);
-          }
-        }
-      })();
-    }
-
-    yield {
-      code: 'end',
-      message: 'Preload finished',
-    } as TTSMessageEvent;
-  }
-
-  // Detached scheduler: fetches, prepares, and schedules chunks ahead of the
-  // playhead under the player's backpressure. Never throws; failures surface
-  // through the event queue.
-  async #runScheduler(
-    marks: TTSMark[],
-    signal: AbortSignal,
-    generation: number,
-    queue: AsyncQueue<SpeakQueueEvent>,
-    chunkMeta: ChunkMeta[],
-  ): Promise<void> {
-    const rate = this.#rate;
-    try {
-      for (const mark of marks) {
-        if (signal.aborted || this.#activeGeneration !== generation) return;
-        // Voices resolve per mark: mixed-language sections speak (and record
-        // durations under) the voice actually used for each sentence.
-        const voiceId = await this.getVoiceIdFromLang(mark.language);
-        this.#speakingLang = mark.language;
-        this.#currentVoiceId = voiceId;
-        const payload = this.getPayload(mark.language, mark.text, voiceId);
-
-        let audio: { data: ArrayBuffer; boundaries: TTSWordBoundary[] } | undefined;
-        try {
-          audio = await this.#createAudioDataWithRetry(payload, signal);
-        } catch (error) {
-          if (error instanceof Error && error.message === 'No audio data received.') {
-            console.warn('No audio data received for:', mark.text);
-            queue.push({ kind: 'chunk-skip', markName: mark.name });
-            continue;
-          }
-          const message = error instanceof Error ? error.message : String(error);
-          console.warn('TTS error for mark:', mark.text, message);
-          queue.push({ kind: 'error', message });
-          return;
-        }
-        if (!audio || signal.aborted || this.#activeGeneration !== generation) return;
-        this.#recordDurations(voiceId, mark.text, audio.boundaries);
-
-        if (this.#player instanceof NativeAudioPlayer) {
-          // Native playout: no decode/trim/WSOLA — the raw MP3 goes to the
-          // AVPlayer, which time-stretches at the pitch-preserving native
-          // rate. Word boundaries stay in original media time, matching the
-          // player's media clock, so trimStartSec is 0 by construction.
-          const ready = await this.#player.waitUntilReady(generation);
-          if (!ready || signal.aborted) return;
-          const index = chunkMeta.length;
-          const meta: ChunkMeta = {
-            mark,
-            boundaries: audio.boundaries,
-            trimStartSec: 0,
-            trimmedDurationSec: 0,
-          };
-          // Push before enqueue: the chunk-start event can arrive as soon as
-          // the native side starts the item.
-          chunkMeta.push(meta);
-          try {
-            const durationSec = await this.#player.scheduleRawChunk(generation, index, audio.data, {
-              gapSec: this.#sentenceGapSec / rate,
-            });
-            meta.trimmedDurationSec = durationSec;
-            this.#recordDurations(voiceId, mark.text, audio.boundaries, durationSec);
-          } catch (error) {
-            console.warn('Failed to enqueue TTS audio for:', mark.text, error);
-            queue.push({ kind: 'chunk-skip', markName: mark.name });
-          }
-          continue;
-        }
-
-        const webPlayer = this.#player;
-        let prepared: {
-          buffer: TTSAudioBuffer;
-          trimStartSec: number;
-          trimmedDurationSec: number;
-        };
-        try {
-          prepared = await this.#prepareChunkBuffer(webPlayer, audio.data, rate);
-        } catch (error) {
-          // Malformed MP3 must not dead-end the session: same UX as no-audio.
-          console.warn('Failed to decode TTS audio for:', mark.text, error);
-          queue.push({ kind: 'chunk-skip', markName: mark.name });
-          continue;
-        }
-        this.#recordDurations(voiceId, mark.text, audio.boundaries, prepared.trimmedDurationSec);
-
-        const ready = await this.#player.waitUntilReady(generation);
-        if (!ready || signal.aborted) return;
-        chunkMeta.push({
-          mark,
-          boundaries: audio.boundaries,
-          trimStartSec: prepared.trimStartSec,
-          trimmedDurationSec: prepared.trimmedDurationSec,
-        });
-        this.#player.scheduleChunk(generation, prepared.buffer, {
-          trimStartSec: prepared.trimStartSec,
-          mediaScale: prepared.trimmedDurationSec / prepared.buffer.duration,
-          gapSec: this.#sentenceGapSec / rate,
-        });
-      }
-      if (!signal.aborted && this.#activeGeneration === generation) {
-        // Fires session-end synchronously when every mark was skipped or the
-        // last chunk already ended, so the session always terminates.
-        this.#player.endSession(generation);
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      queue.push({ kind: 'error', message });
-    }
-  }
-
-  async #prepareChunkBuffer(
-    player: WebAudioPlayer,
-    data: ArrayBuffer,
-    rate: number,
-  ): Promise<{ buffer: TTSAudioBuffer; trimStartSec: number; trimmedDurationSec: number }> {
-    // decodeAudioData resamples to the context rate (44.1/48kHz on real
-    // devices, not the stream's 24kHz) — all math below must use the decoded
-    // buffer's sampleRate.
-    const decoded = await player.decode(data);
-    const sampleRate = decoded.sampleRate;
-    const channel = decoded.getChannelData(0);
-    const bounds = findSpeechBounds(channel, sampleRate);
-    const startSample = Math.floor(bounds.startSec * sampleRate);
-    const endSample = Math.min(channel.length, Math.ceil(bounds.endSec * sampleRate));
-    // A subarray is a view; timeStretch never writes its input and
-    // createMonoBuffer copies, so no mutation can reach the decoded buffer.
-    const trimmed = channel.subarray(startSample, endSample);
-    const trimmedDurationSec = trimmed.length / sampleRate;
-    const samples = rate !== 1 ? timeStretch(trimmed, sampleRate, rate) : trimmed;
-    const buffer = await player.createMonoBuffer(samples, sampleRate);
-    // Silence-trimmed edges sit on non-zero samples; fade the buffer's own copy
-    // so chunk starts/ends don't click against the inter-sentence gap.
-    applyEdgeFade(buffer.getChannelData(0), sampleRate);
-    return { buffer, trimStartSec: startSample / sampleRate, trimmedDurationSec };
-  }
-
-  // Poll the audio clock (visual concern only, so rAF throttling with the
-  // screen off is fine) and tell the controller which word is being spoken.
-  // The player reports original (rate-1.0) media time, so Edge's boundary
-  // ticks need no rescaling for trim or rate.
-  #startWordTracking(generation: number, chunkIndex: number, meta: ChunkMeta): void {
-    this.#stopWordTracking();
-    const controller = this.controller;
-    if (!controller) return;
-    // Always hand the words to the controller — with boundaries it highlights
-    // word-by-word; with none it draws the sentence highlight that was
-    // suppressed at mark dispatch (see TTSController.prepareSpeakWords).
-    controller.prepareSpeakWords(meta.boundaries.map((boundary) => boundary.text));
-    if (!meta.boundaries.length) return;
-    let lastIndex = -1;
-    const tick = () => {
-      const pos = this.#player.getPlaybackPosition(generation);
-      // Guard the one-frame window around a transition where this tick still
-      // holds the previous chunk's boundaries.
-      if (pos && pos.chunkIndex === chunkIndex) {
-        const index = findBoundaryIndexAtTime(meta.boundaries, pos.mediaTimeSec);
-        if (index !== lastIndex && index >= 0) {
-          lastIndex = index;
-          controller.dispatchSpeakWord(index);
-        }
-      }
-      this.#wordTrackingRafId = requestAnimationFrame(tick);
-    };
-    this.#wordTrackingRafId = requestAnimationFrame(tick);
-  }
-
-  #stopWordTracking(): void {
-    if (this.#wordTrackingRafId !== null) {
-      cancelAnimationFrame(this.#wordTrackingRafId);
-      this.#wordTrackingRafId = null;
-    }
-  }
-
-  async pause() {
-    if (!this.#isPlaying) return true;
-    await this.#player.pauseContext();
-    return true;
-  }
-
-  async resume() {
-    // Throws when the context refuses to run again (iOS post-interruption);
-    // the controller's catch stops playback visibly instead of showing
-    // "playing" over silence.
-    await this.#player.resumeContext();
-    return true;
-  }
-
-  async stop() {
-    await this.stopInternal();
-  }
-
-  private async stopInternal() {
-    this.#stopWordTracking();
-    this.#isPlaying = false;
-    if (this.#activeGeneration !== null) {
-      this.#activeGeneration = null;
-      // Unblock a generator awaiting the queue; without this a stop() outside
-      // the abort path would leave the consumer parked forever.
-      this.#activeQueue?.push({ kind: 'error', message: 'Aborted' });
-      this.#activeQueue = null;
-      this.#player.abortSession();
-    }
-  }
-
-  getChunkPosition(): number | null {
-    const generation = this.#activeGeneration;
-    if (generation === null) return null;
-    const pos = this.#player.getPlaybackPosition(generation);
-    if (!pos) return null;
-    const meta = this.#chunkMeta[pos.chunkIndex];
-    if (!meta) return null;
-    // Trim-relative and clamped: the section timeline sums TRIMMED durations,
-    // while the player reports untrimmed media time (kept that way for word
-    // boundaries).
-    return Math.min(Math.max(pos.mediaTimeSec - meta.trimStartSec, 0), meta.trimmedDurationSec);
-  }
-
-  async setRate(rate: number) {
-    // Web path: applied client-side via WSOLA time-stretch at schedule time;
-    // takes effect on the next speak() session (the controller restarts
-    // playback on rate changes). Native path: applied live by the AVPlayer.
-    this.#rate = rate;
-    if (this.#player instanceof NativeAudioPlayer) {
-      await this.#player.setRate(rate);
-    }
-  }
-
-  async setPitch(pitch: number) {
-    // The Edge TTS API uses pitch in [0.5 .. 1.5].
-    this.#pitch = pitch;
-  }
-
-  async setVoice(voice: string) {
-    const selectedVoice = this.#voices.find((v) => v.id === voice);
-    if (selectedVoice) {
-      this.#currentVoiceId = selectedVoice.id;
-    }
-  }
-
-  setSentenceGap(sec: number): void {
-    this.#sentenceGapSec = sec;
-  }
-
-  async getAllVoices(): Promise<TTSVoice[]> {
-    this.#voices.forEach((voice) => {
-      voice.disabled = !this.initialized;
-    });
-    return this.#voices;
-  }
-
-  async getVoices(lang: string) {
-    const locale = lang === 'en' ? getUserLocale(lang) || lang : lang;
-    const voices = await this.getAllVoices();
-    // Match by primary language so the voice set stays the same across a book
-    // whose sections mix region variants (e.g. en-US front matter and en-GB
-    // body text); the requested locale's voices sort first. See #4033.
-    const filteredVoices = voices.filter((v) => isSameLang(v.lang, lang));
-
-    const voicesGroup: TTSVoicesGroup = {
-      id: 'edge-tts',
-      name: 'Edge TTS',
-      voices: filteredVoices.sort(TTSUtils.sortVoicesPreferLocaleFunc(locale)),
-      disabled: !this.initialized || filteredVoices.length === 0,
-    };
-
-    return [voicesGroup];
-  }
-
-  setPrimaryLang(lang: string) {
-    this.#primaryLang = lang;
-  }
-
-  supportsWordBoundaries(): boolean {
-    return true;
-  }
-
-  getGranularities(): TTSGranularity[] {
-    return ['sentence'];
-  }
-
-  getVoiceId(): string {
-    return this.#currentVoiceId;
-  }
-
-  getSpeakingLang(): string {
-    return this.#speakingLang;
-  }
-
-  async shutdown(): Promise<void> {
-    await this.stopInternal();
-    await this.#player.shutdown();
     this.initialized = false;
-    this.#voices = [];
+    return false;
   }
 }

--- a/apps/readest-app/src/services/tts/NativeAudioPlayer.ts
+++ b/apps/readest-app/src/services/tts/NativeAudioPlayer.ts
@@ -14,6 +14,7 @@
 // AVPlayer.currentTime reports item time, not wall time.
 
 import { addPluginListener, invoke, PluginListener } from '@tauri-apps/api/core';
+import type { TTSAudioPlayer } from './TTSAudioPlayer';
 import type { WebAudioPlayerEvent } from './WebAudioPlayer';
 
 interface PlayoutPosition {
@@ -55,7 +56,7 @@ const toBase64 = (data: ArrayBuffer): string => {
   return btoa(binary);
 };
 
-export class NativeAudioPlayer {
+export class NativeAudioPlayer implements TTSAudioPlayer {
   #generation = 0;
   #session: NativePlayerSession | null = null;
   #listener: PluginListener | null = null;

--- a/apps/readest-app/src/services/tts/NativeTTSClient.ts
+++ b/apps/readest-app/src/services/tts/NativeTTSClient.ts
@@ -4,7 +4,7 @@ import { getUserLocale } from '@/utils/misc';
 import { isSameLang } from '@/utils/lang';
 import { parseSSMLMarks } from '@/utils/ssml';
 import { stubTranslation as _ } from '@/utils/misc';
-import { TTSClient, TTSMessageEvent } from './TTSClient';
+import { TTSCapabilities, TTSClient, TTSMessageEvent } from './TTSClient';
 import { TTSGranularity, TTSMark, TTSVoice, TTSVoicesGroup } from './types';
 import { TTSUtils } from './TTSUtils';
 import { TTSController } from './TTSController';
@@ -306,8 +306,10 @@ export class NativeTTSClient implements TTSClient {
     this.#primaryLang = lang;
   }
 
-  supportsWordBoundaries(): boolean {
-    return false;
+  getCapabilities(): TTSCapabilities {
+    // Direct-speak engine: the OS renders the audio, so there is no media
+    // clock, no word boundaries, and no gap or live-rate control.
+    return { wordBoundaries: false, mediaClock: false, gapControl: false, liveRateChange: false };
   }
 
   getGranularities(): TTSGranularity[] {

--- a/apps/readest-app/src/services/tts/TTSAudioPlayer.ts
+++ b/apps/readest-app/src/services/tts/TTSAudioPlayer.ts
@@ -1,0 +1,50 @@
+// The playout seam of the TTS architecture: BufferedTTSClient schedules
+// synthesized audio through this interface and reads the media clock back
+// for word highlighting and the section timeline. The driver is chosen per
+// platform by OS constraints, not preference:
+// - WebAudioPlayer (web/desktop/Android): gapless sample-accurate scheduling
+//   of decoded PCM, WSOLA rate applied at prepare time.
+// - NativeAudioPlayer (iOS Tauri): in-process AVPlayer playing the raw
+//   compressed chunks, because WKWebView renders WebAudio in the GPU process
+//   under an audio session the app cannot own (Now Playing, pause retention,
+//   AirPods, mute switch all key off session ownership).
+//
+// The two schedule methods are deliberately distinct rather than unified:
+// the web path must decode to PCM to time-stretch, the native path must NOT
+// decode (AVPlayer streams the compressed file and time-stretches natively).
+// A driver implements exactly one of them.
+
+import type { ChunkTiming, TTSAudioBuffer, WebAudioPlayerEvent } from './WebAudioPlayer';
+
+export interface TTSAudioPlayer {
+  // The web driver resolves with its AudioContext; callers only await.
+  ensureContext(): Promise<unknown>;
+  // Returns a generation token; events for older generations must be ignored
+  // by the caller. The onEvent callback delivers chunk-start (audible),
+  // session-end, and error events.
+  startSession(onEvent: (event: WebAudioPlayerEvent) => void): number;
+  // PCM path (web): schedule a prepared buffer gaplessly.
+  scheduleChunk?(generation: number, buffer: TTSAudioBuffer, timing: ChunkTiming): void;
+  // Raw path (native): enqueue the compressed chunk; resolves with its
+  // duration in seconds.
+  scheduleRawChunk?(
+    generation: number,
+    index: number,
+    data: ArrayBuffer,
+    opts: { gapSec: number },
+  ): Promise<number>;
+  // Backpressure: resolves when the player can accept another chunk, false
+  // when the session died first.
+  waitUntilReady(generation: number): Promise<boolean>;
+  endSession(generation: number): void;
+  abortSession(): void;
+  pauseContext(): Promise<void>;
+  resumeContext(): Promise<void>;
+  isUserPaused(): boolean;
+  // Live rate change; only drivers that time-stretch at playout implement it.
+  setRate?(rate: number): Promise<void>;
+  // Media clock: original (rate-1.0) media time of the audible chunk, the
+  // reference frame word boundaries are expressed in.
+  getPlaybackPosition(generation: number): { chunkIndex: number; mediaTimeSec: number } | null;
+  shutdown(): Promise<void>;
+}

--- a/apps/readest-app/src/services/tts/TTSClient.ts
+++ b/apps/readest-app/src/services/tts/TTSClient.ts
@@ -8,6 +8,21 @@ export interface TTSMessageEvent {
   mark?: string;
 }
 
+// What the active engine can actually do, so the controller and UI degrade
+// uniformly instead of probing per-feature or comparing client identities.
+export interface TTSCapabilities {
+  // Reports word-boundary timings during playback: the controller highlights
+  // word-by-word and suppresses the sentence highlight.
+  wordBoundaries: boolean;
+  // Has a real audio clock: getChunkPosition() returns positions, enabling
+  // the scrubber/seek via the section timeline.
+  mediaClock: boolean;
+  // The inter-sentence gap setting applies.
+  gapControl: boolean;
+  // Rate changes apply to in-flight audio without restarting the session.
+  liveRateChange: boolean;
+}
+
 export interface TTSClient {
   name: string;
   initialized: boolean;
@@ -24,14 +39,15 @@ export interface TTSClient {
   getAllVoices(): Promise<TTSVoice[]>;
   getVoices(lang: string): Promise<TTSVoicesGroup[]>;
   getGranularities(): TTSGranularity[];
-  // Whether this client reports word-boundary timings during playback so the
-  // controller can highlight word-by-word (and suppress the sentence highlight).
-  supportsWordBoundaries(): boolean;
+  getCapabilities(): TTSCapabilities;
+  // Ordered sentence labels for a section (timeline enumeration), consumed
+  // by clients with a persistent cache to drive section-pack compaction.
+  registerSectionManifest?(section: number, marks: string[]): void;
   getVoiceId(): string;
   getSpeakingLang(): string;
   // Playback position within the currently audible sentence, in trimmed media
-  // seconds at rate 1.0, clamped to [0, sentenceDuration]. Optional: only
-  // clients with a real audio clock (Edge via Web Audio) implement it; the
-  // section timeline treats absence as sentence-granularity positions.
+  // seconds at rate 1.0, clamped to [0, sentenceDuration]. Only meaningful
+  // when capabilities.mediaClock is true; the section timeline treats absence
+  // as sentence-granularity positions.
   getChunkPosition?(): number | null;
 }

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -14,6 +14,7 @@ import { WebSpeechClient } from './WebSpeechClient';
 import { NativeTTSClient } from './NativeTTSClient';
 import { EdgeTTSClient } from './EdgeTTSClient';
 import { SectionTimeline, TimelineSentence } from './SectionTimeline';
+import { DownloadableSentence, SectionEnumerator, TTSDownloader } from './TTSDownloader';
 import { TTSUtils } from './TTSUtils';
 import { TTSClient } from './TTSClient';
 import { isValidLang } from '@/utils/lang';
@@ -101,6 +102,9 @@ export const DEFAULT_PARAGRAPH_GAP_SEC = 0.3;
 export class TTSController extends EventTarget {
   appService: AppService | null = null;
   view: FoliateView;
+  // The owning reader's book key, bound (and re-bound) by attachView; the
+  // per-book TTS cache derives its book hash from it.
+  bookKey?: string;
   isAuthenticated: boolean = false;
   preprocessCallback?: (ssml: string) => Promise<string>;
   onSectionChange?: (sectionIndex: number) => Promise<void>;
@@ -285,6 +289,7 @@ export class TTSController extends EventTarget {
 
     // Synchronous swap.
     this.view = view;
+    this.bookKey = bindings.bookKey;
     this.preprocessCallback = bindings.preprocessCallback;
     this.onSectionChange = bindings.onSectionChange;
     this.#attached = true;
@@ -367,6 +372,10 @@ export class TTSController extends EventTarget {
       try {
         const cfi = this.view.getCFI(index, range);
         const visibleRange = this.view.resolveCFI(cfi).anchor(doc);
+        // A stale range (re-applied after a relocate that changed the section
+        // content) resolves to nothing in the current doc; overlayer.add would
+        // then dereference a null range. Skip instead.
+        if (!visibleRange) return;
         const { style, color } = this.options;
         overlayer?.remove(HIGHLIGHT_KEY);
         overlayer?.add(HIGHLIGHT_KEY, visibleRange, Overlayer[style], { color });
@@ -504,7 +513,106 @@ export class TTSController extends EventTarget {
     timeline.setRate(this.ttsRate);
     this.#sectionTimeline = timeline;
     this.#timelineSectionIndex = this.#ttsSectionIndex;
+    // Tell the cache which sentences make up this section (ordinal-keyed);
+    // once every ordinal has a recorded synthesis key, the section can be
+    // compacted into one pack file.
+    this.ttsClient.registerSectionManifest?.(
+      this.#ttsSectionIndex,
+      sentences.map((s) => `${s.blockIndex}:${s.markName}`),
+    );
     return timeline;
+  }
+
+  // Build a downloader for headless pre-synthesis, or null when the Edge
+  // client has no cache to download into. The enumerator replays the exact
+  // live pipeline (per-block SSML -> preprocess -> parseSSMLMarks) on a FRESH
+  // document + TTS instance per section, so it never disturbs live playback,
+  // and labels sentences identically to ensureTimeline so packs written here
+  // and by playback share one manifest.
+  canDownload(): boolean {
+    return this.ttsEdgeClient.canDownload();
+  }
+
+  getTTSDownloader(): TTSDownloader | null {
+    const edge = this.ttsEdgeClient;
+    if (!edge.canDownload()) return null;
+    const enumerator: SectionEnumerator = {
+      enumerateSection: async (sectionIndex: number) => {
+        const sections = this.view.book.sections;
+        const section = sections?.[sectionIndex];
+        if (!section?.createDocument) return null;
+        try {
+          const doc = await section.createDocument();
+          const html = doc.querySelector('html');
+          const lang = html?.getAttribute('lang') || html?.getAttribute('xml:lang') || '';
+          if (html && !isValidLang(lang) && this.ttsLang) {
+            html.setAttribute('lang', this.ttsLang);
+            html.setAttribute('xml:lang', this.ttsLang);
+          }
+          const { TTS, getSentences } = await import('foliate-js/tts.js');
+          const { textWalker } = await import('foliate-js/text-walker.js');
+          const nodeFilter = createTTSNodeFilter();
+          let granularity: TTSGranularity = this.view.language.isCJK ? 'sentence' : 'word';
+          const supported = edge.getGranularities();
+          if (!supported.includes(granularity)) granularity = supported[0]!;
+
+          // getSentences enumerates EVERY segment; parseSSMLMarks drops the
+          // ones that carry no speech (punctuation- or symbol-only lines like
+          // "* * *", empty separators). The manifest must count only the
+          // recordable sentences, or a section with any such separator can
+          // never complete. Filter getSentences by the same rule so the
+          // meaningful segments line up 1:1 with the marks.
+          const isSpeakable = (text: string) => {
+            const trimmed = text.trim();
+            return trimmed.length > 0 && !/^[\p{P}\p{S}]+$/u.test(trimmed);
+          };
+          const speakableSegs: { blockIndex: number; markName: string }[] = [];
+          for (const entry of getSentences(doc, textWalker, nodeFilter, granularity)) {
+            if (isSpeakable(entry.range.toString())) {
+              speakableSegs.push({ blockIndex: entry.blockIndex, markName: entry.markName });
+            }
+          }
+          // Per-sentence language + preprocessed text: identical to what
+          // playback synthesizes, so the computed cache keys match. A no-op
+          // highlighter: this throwaway instance only generates SSML and must
+          // never draw on the live view.
+          const tts = new TTS(doc, textWalker, nodeFilter, () => {}, granularity);
+          const marks: { language: string; text: string }[] = [];
+          let raw = tts.start();
+          while (raw) {
+            const ssml = await this.#preprocessSSML(raw);
+            if (ssml) marks.push(...parseSSMLMarks(ssml, this.ttsLang || 'en').marks);
+            raw = tts.next();
+          }
+          // Pair speakable segments with marks in reading order; contiguous
+          // ordinals so the manifest is exactly what gets recorded.
+          const n = Math.min(speakableSegs.length, marks.length);
+          const out: DownloadableSentence[] = [];
+          for (let i = 0; i < n; i++) {
+            out.push({
+              ordinal: i,
+              label: `${speakableSegs[i]!.blockIndex}:${speakableSegs[i]!.markName}`,
+              lang: marks[i]!.language,
+              text: marks[i]!.text,
+            });
+          }
+          return out;
+        } catch (err) {
+          console.warn('TTS download enumeration failed for section', sectionIndex, err);
+          return null;
+        }
+      },
+    };
+    return new TTSDownloader(enumerator, edge);
+  }
+
+  // Per-section download status keyed by section index, for the podcast UI.
+  async getSectionCacheStatuses() {
+    return this.ttsEdgeClient.getSectionCacheStatuses();
+  }
+
+  async getCacheBytes() {
+    return this.ttsEdgeClient.getCacheBytes();
   }
 
   // Whether the active client can ever produce a timeline (Edge only). The
@@ -514,9 +622,9 @@ export class TTSController extends EventTarget {
     return this.ttsClient === this.ttsEdgeClient;
   }
 
-  // Whether the active client supports the inter-sentence gap control (Edge only).
+  // Whether the active client supports the inter-sentence gap control.
   supportsGapControl(): boolean {
-    return this.ttsClient === this.ttsEdgeClient;
+    return this.ttsClient.getCapabilities().gapControl;
   }
 
   // Passthrough to the Edge client's inter-sentence gap. ttsEdgeClient is
@@ -787,6 +895,21 @@ export class TTSController extends EventTarget {
             this.#terminate('error');
             await this.stop();
           }
+        } else if (
+          lastCode === 'error' &&
+          !canSkipOnError &&
+          !signal.aborted &&
+          this.state === 'playing' &&
+          !oneTime
+        ) {
+          // A buffered client (Edge/Web) reported a synthesis error that
+          // survived its retries: offline with this sentence uncached, or a
+          // persistent service failure, with no online fallback available.
+          // Stop cleanly rather than skip to the end of the book or leave the
+          // controls wedged in 'playing'.
+          resolve();
+          this.#terminate('error');
+          await this.stop();
         }
         resolve();
       } catch (e) {
@@ -1003,7 +1126,11 @@ export class TTSController extends EventTarget {
     );
   }
 
-  dispatchSpeakMark(mark?: TTSMark) {
+  // Returns where the mark landed on the section timeline (section index +
+  // sentence ordinal) when a timeline exists, so the buffered client can
+  // record the sentence's cache key against the section manifest.
+  dispatchSpeakMark(mark?: TTSMark): { sectionIndex: number; sentenceIndex: number } | null {
+    let located: { sectionIndex: number; sentenceIndex: number } | null = null;
     this.#resetSpeakWords();
     this.dispatchEvent(new CustomEvent('tts-speak-mark', { detail: mark || { text: '' } }));
     if (mark && mark.name !== '-1') {
@@ -1015,7 +1142,7 @@ export class TTSController extends EventTarget {
         // forces sentence granularity we keep the sentence highlight, so don't
         // suppress it.
         this.#suppressMarkHighlight =
-          this.ttsClient.supportsWordBoundaries() && this.#highlightGranularity === 'word';
+          this.ttsClient.getCapabilities().wordBoundaries && this.#highlightGranularity === 'word';
         const range = this.#getTts()?.setMark(mark.name);
         this.#suppressMarkHighlight = false;
         this.#speakWordsArmed = !!range;
@@ -1024,6 +1151,12 @@ export class TTSController extends EventTarget {
           // audible sentence for position reporting.
           this.#sectionTimeline.refresh();
           this.#currentSentenceIndex = this.#sectionTimeline.indexOfRange(range);
+          if (this.#currentSentenceIndex >= 0) {
+            located = {
+              sectionIndex: this.#ttsSectionIndex,
+              sentenceIndex: this.#currentSentenceIndex,
+            };
+          }
         }
         const cfi = this.view.getCFI(this.#ttsSectionIndex, range);
         this.dispatchEvent(new CustomEvent('tts-highlight-mark', { detail: { cfi } }));
@@ -1032,6 +1165,7 @@ export class TTSController extends EventTarget {
         this.#suppressMarkHighlight = false;
       }
     }
+    return located;
   }
 
   #resetSpeakWords() {
@@ -1059,7 +1193,7 @@ export class TTSController extends EventTarget {
     // Paused/stopped states keep the sentence re-draw (navigation UX).
     if (
       this.state === 'playing' &&
-      this.ttsClient.supportsWordBoundaries() &&
+      this.ttsClient.getCapabilities().wordBoundaries &&
       this.#highlightGranularity === 'word'
     ) {
       return;
@@ -1127,21 +1261,6 @@ export class TTSController extends EventTarget {
     const matchText = rangeTextExcludingInert(range);
     this.#speakWordOffsets = computeWordOffsets(matchText, words);
     this.#speakWordRanges = [];
-    if (process.env.NODE_ENV !== 'production') {
-      // Dev-only trace of the Edge word-sync: each spoken (boundary) word vs the
-      // text it actually highlights. A drifted or "(unmatched)" mapping — or an
-      // empty word list — pinpoints word-highlight bugs without instrumenting
-      // the overlayer by hand. `process.env.NODE_ENV` is statically inlined, so
-      // this whole block is dropped from production builds.
-      const mapping = words.map((word, i) => {
-        const offset = this.#speakWordOffsets[i];
-        const highlighted = offset
-          ? getTextSubRange(range, offset.start, offset.end)?.toString()
-          : '';
-        return { spoken: word, highlighted: highlighted || '(unmatched)' };
-      });
-      console.log('[TTS] word-sync', { sentence: matchText, words: mapping });
-    }
     if (words.length === 0) {
       // No word boundaries for this chunk: the sentence highlight was
       // suppressed at mark dispatch, so draw it now as the fallback.

--- a/apps/readest-app/src/services/tts/TTSDownloader.ts
+++ b/apps/readest-app/src/services/tts/TTSDownloader.ts
@@ -1,0 +1,118 @@
+// Headless pre-synthesis of TTS audio for offline use (design section 10 in
+// .agents/plans/2026-07-13-tts-cache-sqlite-packs.md). Given a set of
+// sections, it walks each section's sentences through the SAME synthesis
+// pipeline as live playback — minus the audio — populating the per-book
+// cache and recording the section manifest so the sections compact into
+// downloadable packs.
+//
+// The foliate/document coupling is isolated behind SectionEnumerator (the
+// live pipeline: per-block SSML -> proofread preprocess -> parseSSMLMarks ->
+// per-mark language/text, ordered and labelled identically to what playback
+// produces). CacheWarmer is the client. This module owns only the ordering,
+// progress, and cancellation, so it is fully unit-testable with fakes.
+
+export interface DownloadableSentence {
+  // Position in the section, 1:1 with the live timeline enumeration.
+  ordinal: number;
+  // `${blockIndex}:${markName}` — the manifest identity, must match the label
+  // ensureTimeline registers during live playback so the fingerprints agree.
+  label: string;
+  lang: string;
+  // The preprocessed sentence text: exactly what live playback synthesizes,
+  // so the computed cache key is identical.
+  text: string;
+}
+
+export interface SectionEnumerator {
+  // Enumerate one section's sentences in reading order, or null when the
+  // section is unavailable (no document, wrong client). Never throws.
+  enumerateSection(sectionIndex: number): Promise<DownloadableSentence[] | null>;
+}
+
+export interface CacheWarmer {
+  registerSectionManifest(section: number, labels: string[]): void;
+  // Synthesize this sentence into the cache (a hit is a no-op) and record its
+  // key against the section manifest at the ordinal. Returns whether audio is
+  // now cached for it (false = offline miss / permanent failure).
+  warmSentence(section: number, ordinal: number, lang: string, text: string): Promise<boolean>;
+  // Force any newly-completed sections to compact into packs now (and push,
+  // if pack sync is on) rather than waiting for the debounced timer.
+  compactCache(): Promise<void>;
+}
+
+export interface SectionDownloadProgress {
+  sectionIndex: number;
+  total: number;
+  // Sentences processed so far in this section (attempted, cached or skipped).
+  done: number;
+  // Sentences actually synthesized so far (cache misses that succeeded).
+  synthesized: number;
+}
+
+export interface DownloadResult {
+  completed: number[];
+  skipped: number[];
+  synthesized: number;
+}
+
+export class TTSDownloader {
+  #enumerator: SectionEnumerator;
+  #warmer: CacheWarmer;
+
+  constructor(enumerator: SectionEnumerator, warmer: CacheWarmer) {
+    this.#enumerator = enumerator;
+    this.#warmer = warmer;
+  }
+
+  async download(
+    sectionIndexes: number[],
+    onProgress?: (progress: SectionDownloadProgress) => void,
+    signal?: AbortSignal,
+  ): Promise<DownloadResult> {
+    const completed: number[] = [];
+    const skipped: number[] = [];
+    let synthesizedTotal = 0;
+
+    for (const sectionIndex of sectionIndexes) {
+      if (signal?.aborted) break;
+      const sentences = await this.#enumerator.enumerateSection(sectionIndex);
+      if (!sentences) {
+        skipped.push(sectionIndex);
+        continue;
+      }
+
+      this.#warmer.registerSectionManifest(
+        sectionIndex,
+        sentences.map((s) => s.label),
+      );
+
+      let synthesized = 0;
+      let aborted = false;
+      for (let done = 0; done < sentences.length; done++) {
+        if (signal?.aborted) {
+          aborted = true;
+          break;
+        }
+        const s = sentences[done]!;
+        const ok = await this.#warmer.warmSentence(sectionIndex, s.ordinal, s.lang, s.text);
+        if (ok) synthesized++;
+        onProgress?.({
+          sectionIndex,
+          total: sentences.length,
+          done: done + 1,
+          synthesized,
+        });
+      }
+
+      // Compact whatever completed. A section left partial by an abort or an
+      // offline miss simply will not form a pack until the gap fills on a
+      // later run; compacting is still safe and cheap.
+      await this.#warmer.compactCache();
+      synthesizedTotal += synthesized;
+      if (aborted) break;
+      completed.push(sectionIndex);
+    }
+
+    return { completed, skipped, synthesized: synthesizedTotal };
+  }
+}

--- a/apps/readest-app/src/services/tts/WebAudioPlayer.ts
+++ b/apps/readest-app/src/services/tts/WebAudioPlayer.ts
@@ -26,6 +26,8 @@
 // drives MPNowPlayingInfoCenter/MPRemoteCommandCenter natively via the
 // native-tts plugin (getMediaSession -> TauriMediaSession).
 
+import type { TTSAudioPlayer } from './TTSAudioPlayer';
+
 export interface TTSAudioBuffer {
   readonly sampleRate: number;
   readonly length: number;
@@ -123,7 +125,7 @@ export const ensureSharedAudioContext = async (): Promise<void> => {
   }
 };
 
-export class WebAudioPlayer {
+export class WebAudioPlayer implements TTSAudioPlayer {
   #createContext: () => TTSAudioContext;
   #usesSharedContext: boolean;
   #ctx: TTSAudioContext | null = null;

--- a/apps/readest-app/src/services/tts/WebSpeechClient.ts
+++ b/apps/readest-app/src/services/tts/WebSpeechClient.ts
@@ -1,6 +1,6 @@
 import { getUserLocale } from '@/utils/misc';
 import { isSameLang } from '@/utils/lang';
-import { TTSClient, TTSMessageEvent } from './TTSClient';
+import { TTSCapabilities, TTSClient, TTSMessageEvent } from './TTSClient';
 import { parseSSMLMarks } from '@/utils/ssml';
 import { TTSGranularity, TTSMark, TTSVoice, TTSVoicesGroup } from './types';
 import { WEB_SPEECH_BLACKLISTED_VOICES } from './TTSData';
@@ -266,8 +266,10 @@ export class WebSpeechClient implements TTSClient {
     return [voicesGroup];
   }
 
-  supportsWordBoundaries(): boolean {
-    return false;
+  getCapabilities(): TTSCapabilities {
+    // Direct-speak engine: the OS renders the audio, so there is no media
+    // clock, no word boundaries, and no gap or live-rate control.
+    return { wordBoundaries: false, mediaClock: false, gapControl: false, liveRateChange: false };
   }
 
   getGranularities(): TTSGranularity[] {

--- a/apps/readest-app/src/services/tts/downloadChapters.ts
+++ b/apps/readest-app/src/services/tts/downloadChapters.ts
@@ -1,0 +1,106 @@
+// Map a book's table of contents onto downloadable chapters for the podcast
+// player sheet. Downloads work per section index; the TOC is href-based and
+// often nested, so this derives, in reading order, one chapter per distinct
+// section a TOC entry points at, each spanning to the next chapter's section
+// (so TOC-less continuation sections fold into the preceding chapter). Books
+// without a usable TOC fall back to one row per section.
+
+import type { TOCItem } from '@/libs/document';
+
+export interface DownloadChapter {
+  key: string;
+  label: string;
+  depth: number;
+  startSection: number;
+  // Exclusive: the sections this chapter downloads are [startSection, endSection).
+  endSection: number;
+}
+
+export type ChapterDownloadStatus = 'none' | 'partial' | 'complete';
+
+export interface SectionCacheStatus {
+  total: number;
+  recorded: number;
+  packed: boolean;
+}
+
+const flatten = (
+  items: TOCItem[],
+  depth: number,
+  out: { label: string; href: string; depth: number }[],
+): void => {
+  for (const item of items) {
+    out.push({ label: item.label, href: item.href, depth });
+    if (item.subitems?.length) flatten(item.subitems, depth + 1, out);
+  }
+};
+
+export const deriveDownloadChapters = (
+  toc: TOCItem[],
+  resolveSection: (href: string) => number | null,
+  sectionCount: number,
+  // User-facing label for TOC-less sections; the component injects i18n.
+  sectionLabel: (oneBasedIndex: number) => string = (n) => `Section ${n}`,
+): DownloadChapter[] => {
+  const flat: { label: string; href: string; depth: number }[] = [];
+  flatten(toc ?? [], 0, flat);
+
+  // Resolve each entry to a section, keeping the first label seen for each
+  // distinct section in reading order.
+  const seen = new Set<number>();
+  const anchors: { key: string; label: string; depth: number; startSection: number }[] = [];
+  for (const entry of flat) {
+    const section = resolveSection(entry.href);
+    if (section === null || section < 0 || section >= sectionCount) continue;
+    if (seen.has(section)) continue;
+    seen.add(section);
+    anchors.push({
+      key: entry.href,
+      label: entry.label,
+      depth: entry.depth,
+      startSection: section,
+    });
+  }
+
+  if (!anchors.length) {
+    return Array.from({ length: sectionCount }, (_, i) => ({
+      key: `section-${i}`,
+      label: sectionLabel(i + 1),
+      depth: 0,
+      startSection: i,
+      endSection: i + 1,
+    }));
+  }
+
+  // Anchors are in reading order but keep them sorted defensively, then span
+  // each to the next anchor's section (last spans to the end of the book).
+  anchors.sort((a, b) => a.startSection - b.startSection);
+  return anchors.map((anchor, i) => ({
+    key: anchor.key,
+    label: anchor.label,
+    depth: anchor.depth,
+    startSection: anchor.startSection,
+    endSection: i + 1 < anchors.length ? anchors[i + 1]!.startSection : sectionCount,
+  }));
+};
+
+export const chapterDownloadStatus = (
+  chapter: DownloadChapter,
+  statuses: Map<number, SectionCacheStatus>,
+): ChapterDownloadStatus => {
+  let allPacked = true;
+  let anyRecorded = false;
+  for (let section = chapter.startSection; section < chapter.endSection; section++) {
+    const status = statuses.get(section);
+    if (!status?.packed) allPacked = false;
+    if (status && (status.packed || status.recorded > 0)) anyRecorded = true;
+  }
+  if (allPacked) return 'complete';
+  return anyRecorded ? 'partial' : 'none';
+};
+
+export const chapterSections = (chapter: DownloadChapter): number[] =>
+  Array.from(
+    { length: chapter.endSection - chapter.startSection },
+    (_, i) => chapter.startSection + i,
+  );

--- a/apps/readest-app/src/services/tts/providers/bookCacheStore.ts
+++ b/apps/readest-app/src/services/tts/providers/bookCacheStore.ts
@@ -1,0 +1,278 @@
+// Per-book persistent TTS cache binding (see the design doc
+// .agents/plans/2026-07-13-tts-cache-sqlite-packs.md): each book gets its
+// own database under Cache/tts-cache/<book_hash>/, opened lazily on the
+// first synthesize of a TTS session and closed when the client shuts down.
+// Every failure path degrades to "no cache": playback must never depend on
+// the cache working.
+//
+// The store also gets a pack filesystem so fully cached sections compact
+// into one MP3 pack file each: plugin-fs under AppCache on Tauri platforms,
+// OPFS in the browser (where supported). Compaction runs debounced after
+// manifest updates and once more at session close.
+
+import { isTauriAppPlatform } from '@/services/environment';
+import type { DatabaseService } from '@/types/database';
+import type { AppService } from '@/types/system';
+import type { TTSCacheEntry, TTSCacheStore } from './cache';
+import { sweepTTSCaches, touchTTSCacheMeta } from './cacheSweep';
+import { createOpfsPackFs } from './opfsPackFs';
+import { SqliteTTSCacheStore, TTSPackFs } from './sqliteCacheStore';
+
+const CONFIG_KEY = 'readest-tts-cache';
+const DEFAULT_BUDGET_MB = 200;
+const COMPACT_DEBOUNCE_MS = 30_000;
+
+export interface TTSCacheConfig {
+  enabled: boolean;
+  budgetMB: number;
+  // Share section packs through the user's third-party file-sync provider.
+  syncEnabled: boolean;
+}
+
+// localStorage-backed like the other TTS preferences (TTSUtils); a settings
+// UI can edit the same key later.
+export const getTTSCacheConfig = (): TTSCacheConfig => {
+  try {
+    const raw = localStorage.getItem(CONFIG_KEY);
+    const parsed = raw ? (JSON.parse(raw) as Partial<TTSCacheConfig>) : {};
+    return {
+      enabled: parsed.enabled !== false,
+      budgetMB: typeof parsed.budgetMB === 'number' ? parsed.budgetMB : DEFAULT_BUDGET_MB,
+      syncEnabled: parsed.syncEnabled === true,
+    };
+  } catch {
+    return { enabled: true, budgetMB: DEFAULT_BUDGET_MB, syncEnabled: false };
+  }
+};
+
+// Applies to TTS sessions started after the change (the client reads the
+// config when it is constructed).
+export const setTTSCacheConfig = (config: TTSCacheConfig): void => {
+  try {
+    localStorage.setItem(CONFIG_KEY, JSON.stringify(config));
+  } catch {
+    // Storage full or unavailable; the default config keeps applying.
+  }
+};
+
+// Pack file IO under AppCache via plugin-fs (native platforms only). The
+// plugin modules load lazily so the web bundle never pulls them in.
+const createNativePackFs = (dir: string): TTSPackFs => ({
+  async write(name, data) {
+    const { writeFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+    await writeFile(`${dir}/${name}`, data, { baseDir: BaseDirectory.AppCache });
+  },
+  async rename(from, to) {
+    const { rename, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+    await rename(`${dir}/${from}`, `${dir}/${to}`, {
+      oldPathBaseDir: BaseDirectory.AppCache,
+      newPathBaseDir: BaseDirectory.AppCache,
+    });
+  },
+  async readRange(name, offset, length) {
+    const { open, BaseDirectory, SeekMode } = await import('@tauri-apps/plugin-fs');
+    const file = await open(`${dir}/${name}`, { read: true, baseDir: BaseDirectory.AppCache });
+    try {
+      await file.seek(offset, SeekMode.Start);
+      const buffer = new Uint8Array(length);
+      let read = 0;
+      while (read < length) {
+        const n = await file.read(buffer.subarray(read));
+        if (!n) break;
+        read += n;
+      }
+      if (read !== length) throw new Error(`short pack read: ${read}/${length}`);
+      return buffer.buffer as ArrayBuffer;
+    } finally {
+      await file.close();
+    }
+  },
+  async remove(name) {
+    const { remove, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+    await remove(`${dir}/${name}`, { baseDir: BaseDirectory.AppCache });
+  },
+  async list() {
+    const { readDir, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+    const entries = await readDir(dir, { baseDir: BaseDirectory.AppCache });
+    return entries.filter((entry) => entry.isFile).map((entry) => entry.name);
+  },
+});
+
+export class BookTTSCacheStore implements TTSCacheStore {
+  #appService: AppService;
+  // The book key lands on the controller after construction (init()), so the
+  // hash resolves lazily at first use.
+  #getBookHash: () => string | null;
+  #budgetBytes: number;
+  #opening: Promise<{ db: DatabaseService; store: SqliteTTSCacheStore } | null> | null = null;
+  #compactTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(appService: AppService, getBookHash: () => string | null, budgetBytes: number) {
+    this.#appService = appService;
+    this.#getBookHash = getBookHash;
+    this.#budgetBytes = budgetBytes;
+  }
+
+  #open() {
+    if (this.#opening) return this.#opening;
+    const bookHash = this.#getBookHash();
+    if (!bookHash) {
+      // No book hash yet (the key binds to the controller on view attach):
+      // the cache cannot open, so every op silently no-ops. Surfacing this
+      // makes "downloads never persist" diagnosable instead of invisible.
+      console.warn('TTS cache not opened: no book hash available yet');
+      return Promise.resolve(null);
+    }
+    this.#opening = (async () => {
+      try {
+        const dir = `tts-cache/${bookHash}`;
+        await this.#appService.createDir(dir, 'Cache', true);
+        let packFs: TTSPackFs | undefined;
+        if (isTauriAppPlatform()) {
+          const packsDir = `${dir}/packs`;
+          await this.#appService.createDir(packsDir, 'Cache', true);
+          packFs = createNativePackFs(packsDir);
+        } else {
+          packFs = await createOpfsPackFs(`${dir}/packs`);
+        }
+        // 'tts-cache' has no registered migrations; the store owns its DDL.
+        const db = await this.#appService.openDatabase('tts-cache', `${dir}/cache.db`, 'Cache');
+        const store = new SqliteTTSCacheStore(db, { budgetBytes: this.#budgetBytes, packFs });
+        // Sweep tmp files from crashed compactions and packs whose rows were
+        // evicted before the file delete landed. Concurrent-safe: only files
+        // unknown to the database are touched.
+        void store.gcPackFiles().catch(() => {});
+        // Stamp this book as in use, then enforce the cross-book budget by
+        // deleting whole least-recently-used book caches (this book exempt).
+        void touchTTSCacheMeta(this.#appService, bookHash).then(() =>
+          sweepTTSCaches(this.#appService, bookHash, this.#budgetBytes),
+        );
+        // Adopt packs other devices produced (existence-checked, validated
+        // on import); fire-and-forget like all cache housekeeping.
+        this.#syncPacks(bookHash, store, 'pull');
+        return { db, store };
+      } catch (err) {
+        console.warn('TTS cache unavailable for this session', err);
+        return null;
+      }
+    })();
+    return this.#opening;
+  }
+
+  async get(key: string): Promise<TTSCacheEntry | null> {
+    const opened = await this.#open();
+    return opened ? opened.store.get(key) : null;
+  }
+
+  async put(
+    key: string,
+    entry: TTSCacheEntry,
+    meta?: { provider?: string; voice?: string },
+  ): Promise<void> {
+    const opened = await this.#open();
+    await opened?.store.put(key, entry, meta);
+  }
+
+  async registerSectionMarks(section: number, marks: string[]): Promise<void> {
+    const opened = await this.#open();
+    if (!opened) return;
+    await opened.store.registerSectionMarks(section, marks);
+    this.#scheduleCompact();
+  }
+
+  async recordMarkKey(section: number, ordinal: number, key: string): Promise<void> {
+    const opened = await this.#open();
+    await opened?.store.recordMarkKey(section, ordinal, key);
+  }
+
+  // Immediate compaction for downloads (bypasses the debounced timer), then a
+  // push if any packs were created and sync is on.
+  async compact(): Promise<void> {
+    const opened = await this.#open();
+    if (!opened) return;
+    const created = await opened.store.compact();
+    const bookHash = this.#getBookHash();
+    if (created > 0 && bookHash) this.#syncPacks(bookHash, opened.store, 'push');
+  }
+
+  async getSectionStatuses(): Promise<
+    Map<number, { total: number; recorded: number; packed: boolean }>
+  > {
+    const opened = await this.#open();
+    return opened ? opened.store.getSectionStatuses() : new Map();
+  }
+
+  async totalCacheBytes(): Promise<number> {
+    const opened = await this.#open();
+    return opened ? opened.store.totalCacheBytes() : 0;
+  }
+
+  // Compaction is idle work: debounce it behind manifest updates so it never
+  // competes with the synthesis burst at section start.
+  #scheduleCompact(): void {
+    if (this.#compactTimer) clearTimeout(this.#compactTimer);
+    this.#compactTimer = setTimeout(() => {
+      this.#compactTimer = null;
+      void this.#compactNow();
+    }, COMPACT_DEBOUNCE_MS);
+  }
+
+  async #compactNow(): Promise<void> {
+    try {
+      const opened = await this.#opening;
+      if (!opened) return;
+      const created = await opened.store.compact();
+      const bookHash = this.#getBookHash();
+      if (created > 0 && bookHash) this.#syncPacks(bookHash, opened.store, 'push');
+    } catch (err) {
+      console.warn('TTS cache compaction failed', err);
+    }
+  }
+
+  // Push/pull section packs through the selected file-sync provider. The
+  // sync module is imported lazily: it must stay out of the TTS module
+  // graph (settingsStore -> constants -> EdgeTTSClient would cycle) and out
+  // of sessions that never enable sync.
+  #syncPacks(bookHash: string, store: SqliteTTSCacheStore, direction: 'push' | 'pull'): void {
+    if (!getTTSCacheConfig().syncEnabled) return;
+    void (async () => {
+      const { getActiveTTSPackSyncProvider, pullTTSPacks, pushTTSPacks } = await import(
+        '@/services/sync/file/ttsPackSync'
+      );
+      const provider = await getActiveTTSPackSyncProvider();
+      if (!provider) return;
+      if (direction === 'pull') {
+        await pullTTSPacks(provider, bookHash, store);
+      } else {
+        await pushTTSPacks(provider, bookHash, store);
+      }
+    })().catch((err) => {
+      console.warn('TTS pack sync failed', err);
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.#compactTimer) {
+      clearTimeout(this.#compactTimer);
+      this.#compactTimer = null;
+    }
+    const opening = this.#opening;
+    this.#opening = null;
+    const opened = await opening;
+    if (!opened) return;
+    try {
+      // Session end is the natural compaction point: sections finished
+      // during this session merge into packs before the database closes.
+      const created = await opened.store.compact();
+      const bookHash = this.#getBookHash();
+      if (created > 0 && bookHash) this.#syncPacks(bookHash, opened.store, 'push');
+      await opened.store.flush();
+    } catch (err) {
+      console.warn('TTS cache close housekeeping failed', err);
+    } finally {
+      await opened.db.close();
+      const bookHash = this.#getBookHash();
+      if (bookHash) await touchTTSCacheMeta(this.#appService, bookHash);
+    }
+  }
+}

--- a/apps/readest-app/src/services/tts/providers/cache.ts
+++ b/apps/readest-app/src/services/tts/providers/cache.ts
@@ -1,0 +1,170 @@
+// Persistent-cache decorator for any SpeechProvider. Content-addressed:
+// key = hash(version, provider id, lang, voice, pitch, text) — the playback
+// RATE is excluded by construction because providers never see it, which is
+// what makes cached audio replayable at any speed.
+//
+// The store is pluggable (see the design doc: per-book SQLite database with
+// section packs). Every store failure degrades to plain synthesis — the
+// cache must never be able to break playback.
+
+import { md5 } from 'js-md5';
+import type { TTSWordBoundary } from '@/libs/edgeTTS';
+import type { TTSVoice } from '../types';
+import type { SpeechProvider, SpeechSynthesisRequest, SpeechSynthesisResult } from './types';
+
+export interface TTSCacheEntry {
+  audio: ArrayBuffer;
+  boundaries: TTSWordBoundary[];
+  durationMs?: number;
+}
+
+export interface TTSCacheStore {
+  get(key: string): Promise<TTSCacheEntry | null>;
+  put(
+    key: string,
+    entry: TTSCacheEntry,
+    meta?: { provider?: string; voice?: string },
+  ): Promise<void>;
+  // Section manifest hooks (see the pack-compaction design): ordered mark
+  // labels per section, and the observed synthesis key per sentence ordinal.
+  registerSectionMarks?(section: number, marks: string[]): Promise<void>;
+  recordMarkKey?(section: number, ordinal: number, key: string): Promise<void>;
+  // Force completed sections to compact into packs now (and push if sync is
+  // on), rather than waiting for the debounced timer. Used by downloads.
+  // Returns the pack count (SqliteTTSCacheStore) or void (BookTTSCacheStore).
+  compact?(): Promise<number | void>;
+  // Per-section download status + total size, for the podcast UI.
+  getSectionStatuses?(): Promise<Map<number, { total: number; recorded: number; packed: boolean }>>;
+  totalCacheBytes?(): Promise<number>;
+  // Flush and release backing resources (the per-book database handle).
+  close?(): Promise<void>;
+}
+
+export const computeTTSCacheKey = (providerId: string, req: SpeechSynthesisRequest): string =>
+  md5(JSON.stringify(['tts-v1', providerId, req.lang, req.voice, req.pitch, req.text]));
+
+export class CachingProvider implements SpeechProvider {
+  readonly #inner: SpeechProvider;
+  readonly #store: TTSCacheStore;
+  // Dedups whole get-or-synthesize flows: the playback scheduler and the
+  // preloader routinely race the same sentence.
+  readonly #inflight = new Map<string, Promise<SpeechSynthesisResult>>();
+
+  constructor(inner: SpeechProvider, store: TTSCacheStore) {
+    this.#inner = inner;
+    this.#store = store;
+  }
+
+  get id(): string {
+    return this.#inner.id;
+  }
+
+  get label(): string {
+    return this.#inner.label;
+  }
+
+  get fallbackVoiceId(): string | undefined {
+    return this.#inner.fallbackVoiceId;
+  }
+
+  init(): Promise<boolean> {
+    return this.#inner.init();
+  }
+
+  getAllVoices(): Promise<TTSVoice[]> {
+    return this.#inner.getAllVoices();
+  }
+
+  pickDefaultVoice(voices: TTSVoice[]): string | undefined {
+    return this.#inner.pickDefaultVoice?.(voices);
+  }
+
+  async synthesize(
+    req: SpeechSynthesisRequest,
+    signal: AbortSignal,
+  ): Promise<SpeechSynthesisResult> {
+    if (this.#inner.cacheable === false) {
+      return this.#inner.synthesize(req, signal);
+    }
+    const key = computeTTSCacheKey(this.#inner.id, req);
+    const pending = this.#inflight.get(key);
+    if (pending) {
+      // Joiners get their own buffer: decodeAudioData detaches its input.
+      return pending.then((result) => ({ ...result, audio: result.audio.slice(0) }));
+    }
+    const promise = this.#getOrSynthesize(key, req, signal);
+    this.#inflight.set(key, promise);
+    try {
+      return await promise;
+    } finally {
+      // Always cleared — a failed slot must not poison the retry path.
+      this.#inflight.delete(key);
+    }
+  }
+
+  async #getOrSynthesize(
+    key: string,
+    req: SpeechSynthesisRequest,
+    signal: AbortSignal,
+  ): Promise<SpeechSynthesisResult> {
+    try {
+      const cached = await this.#store.get(key);
+      if (cached) {
+        return { audio: cached.audio.slice(0), boundaries: cached.boundaries };
+      }
+    } catch (err) {
+      console.warn('TTS cache read failed; synthesizing instead', err);
+    }
+    const result = await this.#inner.synthesize(req, signal);
+    try {
+      await this.#store.put(
+        key,
+        { audio: result.audio, boundaries: result.boundaries },
+        { provider: this.#inner.id, voice: req.voice },
+      );
+    } catch (err) {
+      console.warn('TTS cache write failed; continuing uncached', err);
+    }
+    return result;
+  }
+
+  // Ordered sentence labels for a section, from the timeline enumeration.
+  registerSectionManifest(section: number, marks: string[]): void {
+    void this.#store.registerSectionMarks?.(section, marks).catch((err) => {
+      console.warn('TTS cache manifest registration failed', err);
+    });
+  }
+
+  // The sentence at this ordinal audibly played from this synthesis request;
+  // record its cache key so the section can compact once fully covered.
+  recordMark(section: number, ordinal: number, req: SpeechSynthesisRequest): void {
+    if (this.#inner.cacheable === false) return;
+    const key = computeTTSCacheKey(this.#inner.id, req);
+    void this.#store.recordMarkKey?.(section, ordinal, key).catch((err) => {
+      console.warn('TTS cache mark recording failed', err);
+    });
+  }
+
+  async compact(): Promise<void> {
+    await this.#store.compact?.();
+  }
+
+  async getSectionStatuses(): Promise<
+    Map<number, { total: number; recorded: number; packed: boolean }>
+  > {
+    return (await this.#store.getSectionStatuses?.()) ?? new Map();
+  }
+
+  async totalCacheBytes(): Promise<number> {
+    return (await this.#store.totalCacheBytes?.()) ?? 0;
+  }
+
+  async shutdown(): Promise<void> {
+    await this.#inner.shutdown?.();
+    try {
+      await this.#store.close?.();
+    } catch (err) {
+      console.warn('TTS cache close failed', err);
+    }
+  }
+}

--- a/apps/readest-app/src/services/tts/providers/cacheSweep.ts
+++ b/apps/readest-app/src/services/tts/providers/cacheSweep.ts
@@ -1,0 +1,86 @@
+// Cross-book budget enforcement for the per-book TTS caches: the intra-book
+// eviction inside SqliteTTSCacheStore keeps each book under the budget, and
+// this sweep keeps the SUM across books under the same budget by deleting
+// whole least-recently-used book cache directories. Runs fire-and-forget
+// when a book's cache opens; every failure is swallowed — housekeeping must
+// never affect playback.
+
+import type { AppService } from '@/types/system';
+
+const TTS_CACHE_ROOT = 'tts-cache';
+const META_FILE = 'meta.json';
+// Never sweep a cache stamped within this window: a recent stamp usually
+// means another window's live session (its database may be open right now).
+const RECENT_USE_GRACE_MS = 10 * 60 * 1000;
+
+// Stamp a book cache as in use; written when the per-book store opens and
+// closes so the sweep can order books by real usage.
+export const touchTTSCacheMeta = async (
+  appService: AppService,
+  bookHash: string,
+): Promise<void> => {
+  try {
+    await appService.writeFile(
+      `${TTS_CACHE_ROOT}/${bookHash}/${META_FILE}`,
+      'Cache',
+      JSON.stringify({ lastUsedAt: Date.now() }),
+    );
+  } catch {
+    // Missing dir or full disk: the sweep just treats the book as unstamped.
+  }
+};
+
+export const sweepTTSCaches = async (
+  appService: AppService,
+  activeBookHash: string,
+  budgetBytes: number,
+  now: () => number = Date.now,
+): Promise<void> => {
+  try {
+    // Recursive listing with sizes; paths are host-separator relative paths
+    // like `<hash>/packs/3-abcd1234.mp3` (backslashes on Windows).
+    const files = await appService.readDirectory(TTS_CACHE_ROOT, 'Cache');
+    const books = new Map<string, { size: number }>();
+    for (const file of files) {
+      const hash = file.path.split(/[/\\]/)[0];
+      if (!hash) continue;
+      const book = books.get(hash) ?? { size: 0 };
+      book.size += file.size;
+      books.set(hash, book);
+    }
+    let total = [...books.values()].reduce((sum, book) => sum + book.size, 0);
+    if (total <= budgetBytes) return;
+
+    const candidates: { hash: string; size: number; lastUsedAt: number }[] = [];
+    for (const [hash, book] of books) {
+      if (hash === activeBookHash) continue;
+      let lastUsedAt = 0;
+      try {
+        const raw = (await appService.readFile(
+          `${TTS_CACHE_ROOT}/${hash}/${META_FILE}`,
+          'Cache',
+          'text',
+        )) as string;
+        const parsed = JSON.parse(raw) as { lastUsedAt?: number };
+        if (typeof parsed.lastUsedAt === 'number') lastUsedAt = parsed.lastUsedAt;
+      } catch {
+        // No stamp: oldest possible candidate.
+      }
+      if (now() - lastUsedAt < RECENT_USE_GRACE_MS) continue;
+      candidates.push({ hash, size: book.size, lastUsedAt });
+    }
+    candidates.sort((a, b) => a.lastUsedAt - b.lastUsedAt);
+
+    for (const candidate of candidates) {
+      if (total <= budgetBytes) break;
+      try {
+        await appService.deleteDir(`${TTS_CACHE_ROOT}/${candidate.hash}`, 'Cache', true);
+        total -= candidate.size;
+      } catch (err) {
+        console.warn('TTS cache sweep failed to delete', candidate.hash, err);
+      }
+    }
+  } catch {
+    // Root dir missing (fresh install, web OPFS) or listing unsupported.
+  }
+};

--- a/apps/readest-app/src/services/tts/providers/edge.ts
+++ b/apps/readest-app/src/services/tts/providers/edge.ts
@@ -1,0 +1,79 @@
+// Edge (Microsoft) speech as a SpeechProvider. Pure re-homing: the WS/HTTP
+// transport, LRU + inflight caches, and voice list all stay in
+// EdgeSpeechTTS (@/libs/edgeTTS); this adapter owns the contract-level
+// concerns — the rate-1.0 invariant and permanent-error classification.
+
+import { EDGE_TTS_PROTOCOL, EdgeSpeechTTS } from '@/libs/edgeTTS';
+import type { TTSVoice } from '../types';
+import {
+  SpeechProvider,
+  SpeechSynthesisPermanentError,
+  SpeechSynthesisRequest,
+  SpeechSynthesisResult,
+} from './types';
+
+export class EdgeSpeechProvider implements SpeechProvider {
+  readonly id = 'edge-tts';
+  readonly label = 'Edge TTS';
+  readonly fallbackVoiceId = 'en-US-AriaNeural';
+  readonly cacheable = true;
+
+  #tts: EdgeSpeechTTS | null = null;
+
+  // The wss transport is free but intermittently blocked; the https fallback
+  // goes through the authenticated proxy route. The Edge client owns the
+  // fallback policy (auth state lives there); the provider just takes the
+  // protocol to probe with.
+  async init(protocol: EDGE_TTS_PROTOCOL = 'wss'): Promise<boolean> {
+    this.#tts = new EdgeSpeechTTS(protocol);
+    try {
+      await this.#tts.create({
+        lang: 'en',
+        text: 'test',
+        voice: 'en-US-AriaNeural',
+        rate: 1.0,
+        pitch: 1.0,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getAllVoices(): Promise<TTSVoice[]> {
+    return EdgeSpeechTTS.voices;
+  }
+
+  async synthesize(
+    req: SpeechSynthesisRequest,
+    _signal: AbortSignal,
+  ): Promise<SpeechSynthesisResult> {
+    const tts = this.#tts;
+    if (!tts) throw new Error('EdgeSpeechProvider not initialized');
+    try {
+      // Rate pinned to 1.0: keeps the audio cache rate-independent; the
+      // playback rate is applied at playout.
+      const { data, boundaries } = await tts.createAudioData({
+        lang: req.lang,
+        text: req.text,
+        voice: req.voice,
+        rate: 1.0,
+        pitch: req.pitch,
+      });
+      return { audio: data, boundaries };
+    } catch (err) {
+      // Permanent for this sentence: Edge answered without audio frames.
+      if (err instanceof Error && err.message === 'No audio data received.') {
+        throw new SpeechSynthesisPermanentError(err.message, { cause: err });
+      }
+      throw err;
+    }
+  }
+
+  pickDefaultVoice(voices: TTSVoice[]): string | undefined {
+    // Avoid AnaNeural (a child voice) as an accidental English default.
+    const first = voices[0];
+    if (first?.id === 'en-US-AnaNeural') return 'en-US-AriaNeural';
+    return first?.id;
+  }
+}

--- a/apps/readest-app/src/services/tts/providers/opfsPackFs.ts
+++ b/apps/readest-app/src/services/tts/providers/opfsPackFs.ts
@@ -1,0 +1,79 @@
+// OPFS-backed pack file IO for the web: the same TTSPackFs contract the
+// native plugin-fs backend implements, so section-pack compaction works in
+// the browser too. Returns undefined where OPFS is unavailable (older
+// browsers, non-secure contexts); the store then keeps loose rows only.
+//
+// OPFS has no rename, so rename() is copy + delete. That still preserves the
+// compactor's crash-safety: a partially copied final file is only adopted by
+// the database in the transaction AFTER rename resolves, and unknown files
+// are collected by the startup sweep.
+
+import type { TTSPackFs } from './sqliteCacheStore';
+
+export const createOpfsPackFs = async (dir: string): Promise<TTSPackFs | undefined> => {
+  try {
+    if (!navigator.storage?.getDirectory) return undefined;
+    const root = await navigator.storage.getDirectory();
+    let handle = root;
+    for (const segment of dir.split('/').filter(Boolean)) {
+      handle = await handle.getDirectoryHandle(segment, { create: true });
+    }
+    const packsDir = handle;
+
+    const readBytes = async (name: string): Promise<File> => {
+      const fileHandle = await packsDir.getFileHandle(name);
+      return fileHandle.getFile();
+    };
+
+    return {
+      async write(name, data) {
+        const fileHandle = await packsDir.getFileHandle(name, { create: true });
+        const writable = await fileHandle.createWritable();
+        try {
+          // Copy out of the view: the lib typings require a plain ArrayBuffer.
+          await writable.write(
+            data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer,
+          );
+        } finally {
+          await writable.close();
+        }
+      },
+      async rename(from, to) {
+        const source = await readBytes(from);
+        const target = await packsDir.getFileHandle(to, { create: true });
+        const writable = await target.createWritable();
+        try {
+          await writable.write(await source.arrayBuffer());
+        } finally {
+          await writable.close();
+        }
+        await packsDir.removeEntry(from);
+      },
+      async readRange(name, offset, length) {
+        const file = await readBytes(name);
+        const slice = await file.slice(offset, offset + length).arrayBuffer();
+        if (slice.byteLength !== length) {
+          throw new Error(`short pack read: ${slice.byteLength}/${length}`);
+        }
+        return slice;
+      },
+      async remove(name) {
+        await packsDir.removeEntry(name);
+      },
+      async list() {
+        // The async-iteration members are missing from the DOM lib typings.
+        const iterable = packsDir as unknown as {
+          entries(): AsyncIterableIterator<[string, { kind: string }]>;
+        };
+        const names: string[] = [];
+        for await (const [name, entry] of iterable.entries()) {
+          if (entry.kind === 'file') names.push(name);
+        }
+        return names;
+      },
+    };
+  } catch (err) {
+    console.warn('OPFS pack storage unavailable', err);
+    return undefined;
+  }
+};

--- a/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
+++ b/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
@@ -1,0 +1,710 @@
+// SQLite-backed TTSCacheStore: the per-book audio cache of the design in
+// .agents/plans/2026-07-13-tts-cache-sqlite-packs.md. One database per book
+// (Cache/tts-cache/<book_hash>/cache.db) so deleting a book's audio cache is
+// a directory delete and cache traffic never contends with another database
+// behind the turso per-db mutex.
+//
+// Two tiers:
+// - loose rows: one BLOB per sentence, content-addressed, written by
+//   CachingProvider as sentences are synthesized;
+// - section packs: once a section's manifest is fully cached, its sentence
+//   MP3s are concatenated into one pack file in reading order. Each Edge
+//   sentence is a self-contained MP3 stream, so bytes[offset..offset+length]
+//   of a pack is exactly the original sentence (range reads decode
+//   independently) while the pack as a whole stays a playable MP3.
+//
+// Manifests carry ordered MARK NAMES from the section timeline enumeration;
+// the client records the ACTUAL synthesis key per mark as it speaks. That
+// keeps the cache purely content-addressed with zero text/lang re-derivation:
+// if enumeration and synthesis ever disagree, the section simply never packs
+// (a missed optimization, never wrong audio).
+//
+// The store does not own the DatabaseService lifecycle: the caller opens the
+// per-book database and closes it when the TTS session shuts down.
+
+import { md5 } from 'js-md5';
+import type { DatabaseService, DatabaseRow } from '@/types/database';
+import type { TTSWordBoundary } from '@/libs/edgeTTS';
+import type { TTSCacheEntry, TTSCacheStore } from './cache';
+
+// Pack file IO, rooted at the book's packs directory. Injected because the
+// backends differ (tauri plugin-fs natively, OPFS on the web later) and so
+// tests can run against an in-memory map. When absent (web today),
+// compaction is disabled and packed rows read as misses.
+export interface TTSPackFs {
+  write(name: string, data: Uint8Array): Promise<void>;
+  rename(from: string, to: string): Promise<void>;
+  readRange(name: string, offset: number, length: number): Promise<ArrayBuffer>;
+  remove(name: string): Promise<void>;
+  list(): Promise<string[]>;
+}
+
+// Portable description of a pack file: everything a fresh device needs to
+// adopt the pack into its own database (sync) or to label an export. Written
+// beside the pack as <name>.json AFTER the mp3 exists, so a sidecar's
+// presence always implies a complete pack.
+export interface TTSPackSidecarEntry {
+  key: string;
+  offset: number;
+  length: number;
+  boundaries: TTSWordBoundary[];
+  durationMs?: number;
+}
+
+export interface TTSPackSidecar {
+  version: 1;
+  section: number;
+  keysFingerprint: string;
+  totalSize: number;
+  entries: TTSPackSidecarEntry[];
+}
+
+export const packSidecarName = (packName: string): string => packName.replace(/\.mp3$/, '.json');
+
+export interface SqliteTTSCacheStoreOptions {
+  // Intra-book budget for loose rows + packs; the cross-book budget is
+  // enforced by the global sweep at book granularity.
+  budgetBytes: number;
+  // Injectable clock for deterministic eviction tests; values must be
+  // monotonic per store instance.
+  now?: () => number;
+  packFs?: TTSPackFs;
+}
+
+interface EntryRow extends DatabaseRow {
+  audio: unknown;
+  boundaries: string;
+  duration_ms: number | null;
+  pack_id: number | null;
+  pack_offset: number | null;
+  pack_length: number | null;
+}
+
+// Blob round-trip shapes differ per backend (node Buffer, wasm Uint8Array,
+// tauri IPC number[]); normalize to a fresh ArrayBuffer the caller owns.
+// instanceof is useless here — node Buffers fail cross-realm Uint8Array
+// checks under vitest — so use realm-safe ArrayBuffer.isView plus a
+// duck-type fallback. Slice by byteOffset/byteLength: Buffers share pooled
+// ArrayBuffers, so copying the whole .buffer would leak neighbors.
+const toArrayBuffer = (value: unknown): ArrayBuffer | null => {
+  if (!value) return null;
+  if (ArrayBuffer.isView(value)) {
+    return value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength) as ArrayBuffer;
+  }
+  if (value instanceof ArrayBuffer) {
+    return value.slice(0);
+  }
+  if (Array.isArray(value)) {
+    return new Uint8Array(value).buffer as ArrayBuffer;
+  }
+  const duck = value as { buffer?: ArrayBufferLike; byteOffset?: number; byteLength?: number };
+  if (duck.buffer && typeof duck.byteOffset === 'number' && typeof duck.byteLength === 'number') {
+    return new Uint8Array(duck.buffer, duck.byteOffset, duck.byteLength).slice()
+      .buffer as ArrayBuffer;
+  }
+  return null;
+};
+
+const SCHEMA = [
+  `CREATE TABLE IF NOT EXISTS entries (
+    key         TEXT PRIMARY KEY,
+    provider    TEXT NOT NULL DEFAULT '',
+    voice       TEXT NOT NULL DEFAULT '',
+    audio       BLOB,
+    pack_id     INTEGER,
+    pack_offset INTEGER,
+    pack_length INTEGER,
+    boundaries  TEXT NOT NULL,
+    duration_ms INTEGER,
+    size        INTEGER NOT NULL,
+    created_at  INTEGER NOT NULL,
+    accessed_at INTEGER NOT NULL
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_entries_accessed ON entries(accessed_at)`,
+  `CREATE INDEX IF NOT EXISTS idx_entries_pack ON entries(pack_id)`,
+  `CREATE TABLE IF NOT EXISTS manifests (
+    section     INTEGER PRIMARY KEY,
+    fingerprint TEXT NOT NULL,
+    updated_at  INTEGER NOT NULL
+  )`,
+  `CREATE TABLE IF NOT EXISTS manifest_marks (
+    section INTEGER NOT NULL,
+    ordinal INTEGER NOT NULL,
+    mark    TEXT NOT NULL,
+    key     TEXT,
+    PRIMARY KEY (section, ordinal)
+  )`,
+  `CREATE TABLE IF NOT EXISTS packs (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    section          INTEGER NOT NULL,
+    fingerprint      TEXT NOT NULL,
+    keys_fingerprint TEXT,
+    path             TEXT NOT NULL,
+    size             INTEGER NOT NULL,
+    created_at       INTEGER NOT NULL,
+    accessed_at      INTEGER NOT NULL
+  )`,
+];
+
+// Batch accessed_at updates: reads must not each cost a synchronous write.
+const TOUCH_FLUSH_LIMIT = 64;
+
+export class SqliteTTSCacheStore implements TTSCacheStore {
+  #db: DatabaseService;
+  #budgetBytes: number;
+  #now: () => number;
+  #packFs: TTSPackFs | null;
+  #ready: Promise<void> | null = null;
+  #pendingTouches = new Map<string, number>();
+  #pendingPackTouches = new Map<number, number>();
+
+  constructor(db: DatabaseService, options: SqliteTTSCacheStoreOptions) {
+    this.#db = db;
+    this.#budgetBytes = options.budgetBytes;
+    this.#now = options.now ?? Date.now;
+    this.#packFs = options.packFs ?? null;
+  }
+
+  #ensureSchema(): Promise<void> {
+    if (!this.#ready) {
+      this.#ready = (async () => {
+        for (const statement of SCHEMA) {
+          await this.#db.execute(statement);
+        }
+        // Additive migration for databases created before pack portability.
+        await this.#db
+          .execute('ALTER TABLE packs ADD COLUMN keys_fingerprint TEXT')
+          .catch(() => {});
+      })();
+    }
+    return this.#ready;
+  }
+
+  async get(key: string): Promise<TTSCacheEntry | null> {
+    await this.#ensureSchema();
+    const rows = await this.#db.select<EntryRow>(
+      `SELECT audio, boundaries, duration_ms, pack_id, pack_offset, pack_length
+         FROM entries WHERE key = ?`,
+      [key],
+    );
+    const row = rows[0];
+    if (!row) return null;
+    const audio = toArrayBuffer(row.audio) ?? (await this.#readPackedAudio(key, row));
+    if (!audio) return null;
+    this.#pendingTouches.set(key, this.#now());
+    if (row.pack_id != null) this.#pendingPackTouches.set(row.pack_id, this.#now());
+    if (this.#pendingTouches.size + this.#pendingPackTouches.size >= TOUCH_FLUSH_LIMIT) {
+      await this.#flushTouches();
+    }
+    return {
+      audio,
+      boundaries: JSON.parse(row.boundaries) as TTSWordBoundary[],
+      durationMs: row.duration_ms ?? undefined,
+    };
+  }
+
+  async #readPackedAudio(key: string, row: EntryRow): Promise<ArrayBuffer | null> {
+    if (
+      !this.#packFs ||
+      row.pack_id == null ||
+      row.pack_offset == null ||
+      row.pack_length == null
+    ) {
+      return null;
+    }
+    const packs = await this.#db.select<DatabaseRow & { path: string }>(
+      'SELECT path FROM packs WHERE id = ?',
+      [row.pack_id],
+    );
+    const path = packs[0]?.path;
+    if (!path) return null;
+    try {
+      return await this.#packFs.readRange(path, row.pack_offset, row.pack_length);
+    } catch (err) {
+      // Self-heal: the pack file is gone or truncated. Drop the dead row so
+      // the sentence is treated as a miss and resynthesized into a loose row.
+      console.warn('TTS pack range read failed; healing entry to a miss', err);
+      await this.#db.execute('DELETE FROM entries WHERE key = ?', [key]);
+      return null;
+    }
+  }
+
+  async put(
+    key: string,
+    entry: TTSCacheEntry,
+    meta?: { provider?: string; voice?: string },
+  ): Promise<void> {
+    await this.#ensureSchema();
+    const size = entry.audio.byteLength;
+    if (size > this.#budgetBytes) return;
+    await this.#evictUntilFits(size, key);
+    const timestamp = this.#now();
+    await this.#db.execute(
+      `INSERT OR REPLACE INTO entries
+         (key, provider, voice, audio, boundaries, duration_ms, size, created_at, accessed_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        key,
+        meta?.provider ?? '',
+        meta?.voice ?? '',
+        new Uint8Array(entry.audio),
+        JSON.stringify(entry.boundaries),
+        entry.durationMs ?? null,
+        size,
+        timestamp,
+        timestamp,
+      ],
+    );
+  }
+
+  // Ordered mark names for a section, from the timeline enumeration. An
+  // identical re-registration keeps the recorded keys; a changed list (voice
+  // or text changes reshape marks rarely; section edits do) resets them.
+  async registerSectionMarks(section: number, marks: string[]): Promise<void> {
+    await this.#ensureSchema();
+    const fingerprint = md5(JSON.stringify(marks));
+    const existing = await this.#db.select<DatabaseRow & { fingerprint: string }>(
+      'SELECT fingerprint FROM manifests WHERE section = ?',
+      [section],
+    );
+    if (existing[0]?.fingerprint === fingerprint) return;
+    await this.#db.execute('INSERT OR REPLACE INTO manifests VALUES (?, ?, ?)', [
+      section,
+      fingerprint,
+      this.#now(),
+    ]);
+    // Idempotent per row instead of DELETE-then-INSERT: two concurrent
+    // registrations of the same section (live enumeration + a download, or a
+    // re-run) would otherwise both delete and then collide on the
+    // (section, ordinal) primary key. UPSERT keeps each ordinal unique and
+    // preserves a key already recorded for an unchanged mark; a trailing
+    // DELETE trims ordinals left over from a shorter new manifest.
+    for (let i = 0; i < marks.length; i++) {
+      await this.#db.execute(
+        `INSERT INTO manifest_marks (section, ordinal, mark, key) VALUES (?, ?, ?, NULL)
+         ON CONFLICT(section, ordinal) DO UPDATE SET mark = excluded.mark`,
+        [section, i, marks[i]!],
+      );
+    }
+    await this.#db.execute('DELETE FROM manifest_marks WHERE section = ? AND ordinal >= ?', [
+      section,
+      marks.length,
+    ]);
+  }
+
+  // The client observed the sentence at this ordinal actually synthesizing
+  // under this cache key. Ordinal-keyed: mark names restart per block, but
+  // the timeline enumeration ordinal is unique within the section.
+  async recordMarkKey(section: number, ordinal: number, key: string): Promise<void> {
+    await this.#ensureSchema();
+    await this.#db.execute('UPDATE manifest_marks SET key = ? WHERE section = ? AND ordinal = ?', [
+      key,
+      section,
+      ordinal,
+    ]);
+  }
+
+  // Merge every fully cached section into one pack file. Returns the number
+  // of packs created. Idle-time work: callers debounce it.
+  async compact(): Promise<number> {
+    if (!this.#packFs) return 0;
+    await this.#ensureSchema();
+    const completable = await this.#db.select<
+      DatabaseRow & { section: number; fingerprint: string }
+    >(
+      `SELECT m.section, m.fingerprint FROM manifests m
+        WHERE NOT EXISTS (
+          SELECT 1 FROM packs p
+           WHERE p.section = m.section AND p.fingerprint = m.fingerprint)
+          AND NOT EXISTS (
+          SELECT 1 FROM manifest_marks mm WHERE mm.section = m.section AND mm.key IS NULL)
+          AND NOT EXISTS (
+          SELECT 1 FROM manifest_marks mm
+            LEFT JOIN entries e ON e.key = mm.key
+           WHERE mm.section = m.section AND (e.key IS NULL OR e.audio IS NULL))`,
+    );
+    let created = 0;
+    for (const manifest of completable) {
+      if (await this.#packSection(manifest.section, manifest.fingerprint)) created++;
+    }
+    return created;
+  }
+
+  async #packSection(section: number, fingerprint: string): Promise<boolean> {
+    const rows = await this.#db.select<
+      DatabaseRow & { key: string; audio: unknown; boundaries: string; duration_ms: number | null }
+    >(
+      `SELECT mm.key, e.audio, e.boundaries, e.duration_ms FROM manifest_marks mm
+         JOIN entries e ON e.key = mm.key
+        WHERE mm.section = ? ORDER BY mm.ordinal ASC`,
+      [section],
+    );
+    // Concatenate in reading order; a repeated sentence appears at each of
+    // its positions (the pack doubles as a playable section MP3), while the
+    // entry row points at the first occurrence.
+    const parts: {
+      key: string;
+      bytes: Uint8Array;
+      boundaries: string;
+      durationMs: number | null;
+    }[] = [];
+    for (const row of rows) {
+      const audio = toArrayBuffer(row.audio);
+      if (!audio) return false;
+      parts.push({
+        key: row.key,
+        bytes: new Uint8Array(audio),
+        boundaries: row.boundaries,
+        durationMs: row.duration_ms,
+      });
+    }
+    const totalSize = parts.reduce((sum, p) => sum + p.bytes.length, 0);
+    const merged = new Uint8Array(totalSize);
+    const sidecarEntries: TTSPackSidecarEntry[] = [];
+    const seen = new Set<string>();
+    let offset = 0;
+    for (const part of parts) {
+      merged.set(part.bytes, offset);
+      if (!seen.has(part.key)) {
+        seen.add(part.key);
+        sidecarEntries.push({
+          key: part.key,
+          offset,
+          length: part.bytes.length,
+          boundaries: JSON.parse(part.boundaries) as TTSWordBoundary[],
+          durationMs: part.durationMs ?? undefined,
+        });
+      }
+      offset += part.bytes.length;
+    }
+
+    // Pack identity is the hash of the ordered KEYS, not the mark names:
+    // keys encode provider/voice/pitch/text, so two devices reading the same
+    // section with different voices produce different pack names. That is
+    // what makes packs safe to sync: same name always means same bytes.
+    const keysFingerprint = md5(JSON.stringify(parts.map((p) => p.key)));
+    const sidecar: TTSPackSidecar = {
+      version: 1,
+      section,
+      keysFingerprint,
+      totalSize,
+      entries: sidecarEntries,
+    };
+    return this.#adoptPack(merged, sidecar, fingerprint);
+  }
+
+  // Write the pack + sidecar files and flip/insert the entry rows in one
+  // transaction. Shared by compaction (flips existing loose rows) and
+  // importPack (inserts packed rows a fresh device never had).
+  async #adoptPack(
+    merged: Uint8Array,
+    sidecar: TTSPackSidecar,
+    manifestFingerprint: string,
+  ): Promise<boolean> {
+    const packFs = this.#packFs!;
+    const finalName = `${sidecar.section}-${sidecar.keysFingerprint.slice(0, 8)}.mp3`;
+    const existing = await this.#db.select<DatabaseRow & { id: number }>(
+      'SELECT id FROM packs WHERE path = ?',
+      [finalName],
+    );
+    if (existing.length) return false;
+
+    const tmpName = `tmp-${finalName}`;
+    await packFs.write(tmpName, merged);
+    await packFs.rename(tmpName, finalName);
+    await packFs.write(
+      packSidecarName(finalName),
+      new TextEncoder().encode(JSON.stringify(sidecar)),
+    );
+
+    const timestamp = this.#now();
+    try {
+      await this.#db.execute('BEGIN');
+      await this.#db.execute(
+        `INSERT INTO packs
+           (section, fingerprint, keys_fingerprint, path, size, created_at, accessed_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          sidecar.section,
+          manifestFingerprint,
+          sidecar.keysFingerprint,
+          finalName,
+          sidecar.totalSize,
+          timestamp,
+          timestamp,
+        ],
+      );
+      const packIds = await this.#db.select<DatabaseRow & { id: number }>(
+        'SELECT id FROM packs WHERE path = ?',
+        [finalName],
+      );
+      const packId = packIds[0]!.id;
+      for (const entry of sidecar.entries) {
+        await this.#db.execute(
+          `INSERT INTO entries
+             (key, provider, voice, audio, pack_id, pack_offset, pack_length,
+              boundaries, duration_ms, size, created_at, accessed_at)
+           VALUES (?, '', '', NULL, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(key) DO UPDATE SET
+             audio = NULL, pack_id = excluded.pack_id,
+             pack_offset = excluded.pack_offset, pack_length = excluded.pack_length`,
+          [
+            entry.key,
+            packId,
+            entry.offset,
+            entry.length,
+            JSON.stringify(entry.boundaries),
+            entry.durationMs ?? null,
+            entry.length,
+            timestamp,
+            timestamp,
+          ],
+        );
+      }
+      await this.#db.execute('COMMIT');
+      return true;
+    } catch (err) {
+      console.warn('TTS pack transaction failed; keeping loose rows', err);
+      try {
+        await this.#db.execute('ROLLBACK');
+      } catch {
+        // No open transaction to roll back.
+      }
+      await packFs.remove(finalName).catch(() => {});
+      await packFs.remove(packSidecarName(finalName)).catch(() => {});
+      return false;
+    }
+  }
+
+  // Adopt a pack produced elsewhere (another device via sync). Validates the
+  // sidecar against the bytes; rejects rather than trusts. Returns false on
+  // any mismatch, unsupported version, or when the pack already exists.
+  async importPack(data: ArrayBuffer, sidecar: TTSPackSidecar): Promise<boolean> {
+    if (!this.#packFs) return false;
+    await this.#ensureSchema();
+    if (sidecar.version !== 1) return false;
+    if (sidecar.totalSize !== data.byteLength || !sidecar.entries.length) return false;
+    const keys = new Set<string>();
+    for (const entry of sidecar.entries) {
+      if (keys.has(entry.key)) return false;
+      keys.add(entry.key);
+      if (
+        entry.offset < 0 ||
+        entry.length <= 0 ||
+        entry.offset + entry.length > sidecar.totalSize
+      ) {
+        return false;
+      }
+    }
+    const existing = await this.#db.select<DatabaseRow & { id: number }>(
+      'SELECT id FROM packs WHERE keys_fingerprint = ?',
+      [sidecar.keysFingerprint],
+    );
+    if (existing.length) return false;
+    if (sidecar.totalSize > this.#budgetBytes) return false;
+    await this.#evictUntilFits(sidecar.totalSize, '');
+    return this.#adoptPack(new Uint8Array(data), sidecar, `imported-${sidecar.keysFingerprint}`);
+  }
+
+  // Per-section download status for the podcast UI. `recorded` is the count
+  // of manifest sentences that have a cached key; `total` is the manifest
+  // size; `packed` means the whole section compacted into a pack file.
+  async getSectionStatuses(): Promise<
+    Map<number, { total: number; recorded: number; packed: boolean }>
+  > {
+    await this.#ensureSchema();
+    const out = new Map<number, { total: number; recorded: number; packed: boolean }>();
+    const totals = await this.#db.select<DatabaseRow & { section: number; total: number }>(
+      'SELECT section, COUNT(*) AS total FROM manifest_marks GROUP BY section',
+    );
+    for (const row of totals)
+      out.set(row.section, { total: row.total, recorded: 0, packed: false });
+    const recorded = await this.#db.select<DatabaseRow & { section: number; recorded: number }>(
+      `SELECT mm.section, COUNT(*) AS recorded FROM manifest_marks mm
+         JOIN entries e ON e.key = mm.key
+        GROUP BY mm.section`,
+    );
+    for (const row of recorded) {
+      const entry = out.get(row.section);
+      if (entry) entry.recorded = row.recorded;
+    }
+    const packed = await this.#db.select<DatabaseRow & { section: number }>(
+      'SELECT DISTINCT section FROM packs',
+    );
+    for (const row of packed) {
+      const entry = out.get(row.section);
+      if (entry) entry.packed = true;
+    }
+    return out;
+  }
+
+  async totalCacheBytes(): Promise<number> {
+    await this.#ensureSchema();
+    const rows = await this.#db.select<DatabaseRow & { total: number | null }>(
+      `SELECT (SELECT COALESCE(SUM(size), 0) FROM entries WHERE pack_id IS NULL)
+            + (SELECT COALESCE(SUM(size), 0) FROM packs) AS total`,
+    );
+    return rows[0]?.total ?? 0;
+  }
+
+  // ── Pack sync surface (services/sync/file/ttsPackSync) ────────────────
+  // The database is the source of truth for what packs exist; the sidecar
+  // is REBUILT from rows rather than read from disk, so a stale or missing
+  // sidecar file can never poison a push.
+
+  async listPacks(): Promise<{ name: string; size: number }[]> {
+    await this.#ensureSchema();
+    const rows = await this.#db.select<DatabaseRow & { path: string; size: number }>(
+      'SELECT path, size FROM packs',
+    );
+    return rows.map((row) => ({ name: row.path, size: row.size }));
+  }
+
+  async hasPack(name: string): Promise<boolean> {
+    await this.#ensureSchema();
+    const rows = await this.#db.select<DatabaseRow & { id: number }>(
+      'SELECT id FROM packs WHERE path = ?',
+      [name],
+    );
+    return rows.length > 0;
+  }
+
+  async readPackBytes(name: string): Promise<ArrayBuffer | null> {
+    if (!this.#packFs) return null;
+    await this.#ensureSchema();
+    const rows = await this.#db.select<DatabaseRow & { size: number }>(
+      'SELECT size FROM packs WHERE path = ?',
+      [name],
+    );
+    const size = rows[0]?.size;
+    if (!size) return null;
+    try {
+      return await this.#packFs.readRange(name, 0, size);
+    } catch {
+      return null;
+    }
+  }
+
+  async buildPackSidecar(name: string): Promise<TTSPackSidecar | null> {
+    await this.#ensureSchema();
+    const packs = await this.#db.select<
+      DatabaseRow & { id: number; section: number; keys_fingerprint: string | null; size: number }
+    >('SELECT id, section, keys_fingerprint, size FROM packs WHERE path = ?', [name]);
+    const pack = packs[0];
+    // Packs from before keys-based identity have no fingerprint: not portable.
+    if (!pack?.keys_fingerprint) return null;
+    const entries = await this.#db.select<
+      DatabaseRow & {
+        key: string;
+        pack_offset: number;
+        pack_length: number;
+        boundaries: string;
+        duration_ms: number | null;
+      }
+    >(
+      `SELECT key, pack_offset, pack_length, boundaries, duration_ms
+         FROM entries WHERE pack_id = ? ORDER BY pack_offset ASC`,
+      [pack.id],
+    );
+    if (!entries.length) return null;
+    return {
+      version: 1,
+      section: pack.section,
+      keysFingerprint: pack.keys_fingerprint,
+      totalSize: pack.size,
+      entries: entries.map((entry) => ({
+        key: entry.key,
+        offset: entry.pack_offset,
+        length: entry.pack_length,
+        boundaries: JSON.parse(entry.boundaries) as TTSWordBoundary[],
+        durationMs: entry.duration_ms ?? undefined,
+      })),
+    };
+  }
+
+  // Remove pack files the database does not know: tmp files from a crashed
+  // compaction and packs whose rows were evicted before the file delete
+  // landed. Called once when the per-book store opens.
+  async gcPackFiles(): Promise<void> {
+    if (!this.#packFs) return;
+    await this.#ensureSchema();
+    const known = new Set<string>();
+    for (const row of await this.#db.select<DatabaseRow & { path: string }>(
+      'SELECT path FROM packs',
+    )) {
+      known.add(row.path);
+      known.add(packSidecarName(row.path));
+    }
+    for (const name of await this.#packFs.list()) {
+      if (!known.has(name)) {
+        await this.#packFs.remove(name).catch(() => {});
+      }
+    }
+  }
+
+  async #evictUntilFits(incomingSize: number, replacingKey: string): Promise<void> {
+    // Pending touches must land first so eviction sees true recency.
+    await this.#flushTouches();
+    const totals = await this.#db.select<DatabaseRow & { total: number | null }>(
+      `SELECT (SELECT COALESCE(SUM(size), 0) FROM entries
+                WHERE pack_id IS NULL AND key != ?)
+            + (SELECT COALESCE(SUM(size), 0) FROM packs) AS total`,
+      [replacingKey],
+    );
+    let total = totals[0]?.total ?? 0;
+    while (total + incomingSize > this.#budgetBytes) {
+      const oldestLoose = (
+        await this.#db.select<DatabaseRow & { key: string; size: number; accessed_at: number }>(
+          `SELECT key, size, accessed_at FROM entries
+            WHERE pack_id IS NULL AND key != ?
+            ORDER BY accessed_at ASC LIMIT 1`,
+          [replacingKey],
+        )
+      )[0];
+      const oldestPack = (
+        await this.#db.select<
+          DatabaseRow & { id: number; path: string; size: number; accessed_at: number }
+        >('SELECT id, path, size, accessed_at FROM packs ORDER BY accessed_at ASC LIMIT 1')
+      )[0];
+      if (!oldestLoose && !oldestPack) return;
+      const evictPack =
+        oldestPack && (!oldestLoose || oldestPack.accessed_at <= oldestLoose.accessed_at);
+      if (evictPack) {
+        await this.#db.execute('DELETE FROM entries WHERE pack_id = ?', [oldestPack!.id]);
+        await this.#db.execute('DELETE FROM packs WHERE id = ?', [oldestPack!.id]);
+        await this.#packFs?.remove(oldestPack!.path).catch(() => {});
+        await this.#packFs?.remove(packSidecarName(oldestPack!.path)).catch(() => {});
+        total -= oldestPack!.size;
+      } else {
+        await this.#db.execute('DELETE FROM entries WHERE key = ?', [oldestLoose!.key]);
+        total -= oldestLoose!.size;
+      }
+    }
+  }
+
+  async #flushTouches(): Promise<void> {
+    if (this.#pendingTouches.size) {
+      const touches = [...this.#pendingTouches];
+      this.#pendingTouches.clear();
+      for (const [key, timestamp] of touches) {
+        await this.#db.execute('UPDATE entries SET accessed_at = ? WHERE key = ?', [
+          timestamp,
+          key,
+        ]);
+      }
+    }
+    if (this.#pendingPackTouches.size) {
+      const touches = [...this.#pendingPackTouches];
+      this.#pendingPackTouches.clear();
+      for (const [id, timestamp] of touches) {
+        await this.#db.execute('UPDATE packs SET accessed_at = ? WHERE id = ?', [timestamp, id]);
+      }
+    }
+  }
+
+  // Persist pending access times; call before the owner closes the database.
+  async flush(): Promise<void> {
+    await this.#ensureSchema();
+    await this.#flushTouches();
+  }
+}

--- a/apps/readest-app/src/services/tts/providers/types.ts
+++ b/apps/readest-app/src/services/tts/providers/types.ts
@@ -1,0 +1,66 @@
+// The synthesis-side seam of the TTS architecture: a SpeechProvider turns
+// text into compressed audio plus word-boundary timings, and nothing else.
+// Scheduling, decoding, time-stretch, playout, word tracking, and media
+// sessions all live above this seam (BufferedTTSClient and the players), so
+// a new engine — another HTTP service, a local model, a system voice
+// synthesizing to buffers — is one adapter implementing this contract.
+//
+// Invariants every provider must uphold:
+// - The playback RATE is never sent to the provider. Rate is a playout
+//   concern (WSOLA on the web path, AVPlayer timeDomain on iOS), which keeps
+//   synthesized audio rate-independent and therefore cacheable.
+// - `boundaries` use the Edge wire shape (100ns ticks from stream start,
+//   verbatim text spans); providers convert at their edge. Absent boundaries
+//   simply degrade word highlighting to sentence highlighting.
+
+import type { TTSWordBoundary } from '@/libs/edgeTTS';
+import type { TTSVoice } from '../types';
+
+export interface SpeechSynthesisRequest {
+  lang: string;
+  text: string;
+  voice: string;
+  pitch: number;
+}
+
+export interface SpeechSynthesisResult {
+  // Compressed audio exactly as delivered by the engine. Callers own the
+  // buffer (providers must hand out a fresh copy per call: WebKit's
+  // decodeAudioData detaches its input).
+  audio: ArrayBuffer;
+  boundaries: TTSWordBoundary[];
+}
+
+// A failure that is permanent for the given sentence (retrying the same
+// request cannot succeed). The buffered client skips the sentence instead of
+// retrying; anything else thrown from synthesize() is treated as transient.
+export class SpeechSynthesisPermanentError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'SpeechSynthesisPermanentError';
+  }
+}
+
+export interface SpeechProvider {
+  // Stable identifier: persisted voice/client preferences and cache
+  // namespaces key off it, so renaming one is a migration.
+  readonly id: string;
+  // Human-readable engine name for voice-group headers.
+  readonly label: string;
+  // Probe/initialize the transport; false means the engine is unavailable
+  // (its voices render disabled in the picker).
+  init(): Promise<boolean>;
+  getAllVoices(): Promise<TTSVoice[]>;
+  synthesize(req: SpeechSynthesisRequest, signal: AbortSignal): Promise<SpeechSynthesisResult>;
+  // Engine-specific default-voice policy for a language's candidate list
+  // (already filtered and sorted); return undefined to accept the first.
+  pickDefaultVoice?(voices: TTSVoice[]): string | undefined;
+  // Last-resort voice when nothing matched and no voice was ever selected.
+  readonly fallbackVoiceId?: string;
+  // Whether synthesized audio may be persisted. Some services forbid
+  // storing their output; CachingProvider bypasses the store when false.
+  readonly cacheable?: boolean;
+  // Release provider resources (network handles, cache databases) when the
+  // owning client shuts down.
+  shutdown?(): Promise<void>;
+}

--- a/apps/readest-app/src/utils/access.ts
+++ b/apps/readest-app/src/utils/access.ts
@@ -75,6 +75,29 @@ export const CLOUD_SYNC_REQUIRES_PREMIUM = true;
 export const isCloudSyncAllowed = (plan: UserPlan): boolean =>
   !CLOUD_SYNC_REQUIRES_PREMIUM || isCloudSyncInPlan(plan);
 
+/**
+ * Plans that include the offline TTS audio cache — pre-downloading a book's
+ * Read Aloud audio per chapter so it plays without a network: any paid plan
+ * (Plus, Pro, and Lifetime `purchase`). Free users see the download row with a
+ * Premium badge and an upgrade route instead of the per-chapter controls.
+ */
+export const TTS_CACHE_PLANS: readonly UserPlan[] = ['plus', 'pro', 'purchase'];
+
+export const isTTSCacheInPlan = (plan: UserPlan): boolean =>
+  (TTS_CACHE_PLANS as readonly UserPlan[]).includes(plan);
+
+/**
+ * Master switch for the offline-audio premium paywall, mirroring
+ * {@link CLOUD_SYNC_REQUIRES_PREMIUM}. ON: pre-downloading TTS audio requires a
+ * {@link TTS_CACHE_PLANS} plan. Flipping it off ungates every plan. The
+ * automatic playback cache (audio kept as the user listens) is unaffected —
+ * only the explicit download UI is gated.
+ */
+export const TTS_CACHE_REQUIRES_PREMIUM = true;
+
+export const isTTSCacheAllowed = (plan: UserPlan): boolean =>
+  !TTS_CACHE_REQUIRES_PREMIUM || isTTSCacheInPlan(plan);
+
 export const STORAGE_QUOTA_GRACE_BYTES = 10 * 1024 * 1024; // 10 MB grace
 
 export const getStoragePlanData = (token: string) => {


### PR DESCRIPTION
## What

Adds a persistent, per-book TTS audio cache and a podcast-style offline download experience, built on a refactor that separates synthesis from playout. Offline audio is gated as a premium feature.

## Architecture

- **SpeechProvider seam.** Synthesis and playout are now separate planes. `BufferedTTSClient` owns the scheduler, playout, word tracking and preload; `EdgeSpeechProvider` owns Edge synthesis. `EdgeTTSClient` keeps its persisted name and the wss to https transport fallback.
- **Per-book SQLite cache** (one database per book, under `Cache/tts-cache/<book_hash>/`) via the cross-platform `DatabaseService`: `tauri-plugin-turso` natively and turso WASM over OPFS on the web. Entries are content-addressed by `provider, lang, voice, pitch, text`, so rate is excluded by construction and cached audio replays at any speed. Every cache failure degrades to plain synthesis, so playback never depends on the cache working.
- **Section packs.** Once a section is fully cached, its sentence MP3s compact into a single pack file. Each Edge sentence is a self-contained MP3, so a byte range of the pack decodes independently while the whole pack stays a playable MP3. A portable JSON sidecar lets packs sync across devices through the file-sync provider (pack identity is the hash of the ordered keys, so same name always means same bytes).

## Offline downloads

- Podcast-style per-chapter download controls live in the Read Aloud player sheet. A headless pre-synthesizer (`TTSDownloader`) warms sections off the playback path, with per-chapter progress.
- **Resilient offline playback:** cache hits play with no network; an uncached sentence is skipped so cached neighbours still play (a cached chapter whose heading is uncached no longer stops on the heading); playback stops only after a run of consecutive unreachable sentences, instead of skipping to the end of the book.

## Premium gating

Pre-downloading offline audio is a premium feature (Plus, Pro, Lifetime), mirroring the cloud-sync paywall. Free and signed-out users see the row with a **Premium** badge and an upgrade route instead of the per-chapter download controls; the automatic playback cache (audio kept as you listen) is unaffected.

## Testing

- `pnpm test`: full suite green (7556 passed).
- `pnpm lint` (tsgo + Biome): clean.
- New coverage for the cache store, packs/compaction, pack sync, the downloader and chapter derivation, offline init/skip behaviour, and the premium gate (unit + player-sheet component tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
