### PR TITLE
perf(sync): drop redundant deleted_at OR from stats pull cursor

### DIFF
--- a/apps/readest-app/src/__tests__/pages/api/sync-stats-updated-at-cursor.test.ts
+++ b/apps/readest-app/src/__tests__/pages/api/sync-stats-updated-at-cursor.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+// The `type=stats` pull was the #1 query by total DB time (~43%). It filtered
+// `(updated_at > since OR deleted_at > since)`, and that OR defeats the
+// `(user_id, updated_at)` index: Postgres can no longer use `updated_at > since`
+// as a range bound, so it walks the user's whole stat_pages history (one row per
+// page-turn event) in updated_at order and filters. The OR is redundant, though:
+// every stat push stamps `updated_at = now()` server-side (sync.ts), including
+// deletes, so a delete always lands with updated_at greater than any peer's
+// max(updated_at) pull cursor. `updated_at > since` alone therefore returns every
+// change, and the query collapses to a clean forward index range scan.
+
+type Call = { table: string; method: string; args: unknown[] };
+const calls: Call[] = [];
+
+const makeBuilder = (table: string) => {
+  const builder: Record<string, unknown> = {};
+  const rec =
+    (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ table, method, args });
+      return builder;
+    };
+  for (const m of ['select', 'eq', 'or', 'gt', 'lt', 'in', 'is', 'order', 'range']) {
+    builder[m] = rec(m);
+  }
+  // Every chain terminal is awaited and destructured as { data, error }; the
+  // real PostgREST builder is itself thenable, so the mock must be too.
+  // biome-ignore lint/suspicious/noThenProperty: mock PostgREST builder is intentionally thenable
+  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve({ data: [], error: null });
+  return builder;
+};
+
+const fromMock = vi.fn((table: string) => makeBuilder(table));
+
+vi.mock('@/utils/supabase', () => ({
+  createSupabaseClient: () => ({ from: fromMock }),
+}));
+vi.mock('@/utils/access', () => ({
+  validateUserAndToken: async () => ({ user: { id: 'u1' }, token: 'tok' }),
+}));
+
+import { GET } from '@/pages/api/sync';
+
+const req = (qs: string) =>
+  new Request(`https://web.readest.com/api/sync?${qs}`, {
+    headers: { authorization: 'Bearer tok' },
+  }) as unknown as NextRequest;
+
+beforeEach(() => {
+  calls.length = 0;
+  fromMock.mockClear();
+});
+
+describe('GET /api/sync?type=stats pull cursor', () => {
+  it('filters stat_pages/stat_books on updated_at only, without the redundant deleted_at OR', async () => {
+    await GET(req('type=stats&since=1000&limit=100'));
+
+    const statCalls = calls.filter((c) => c.table === 'stat_pages' || c.table === 'stat_books');
+    expect(statCalls.length).toBeGreaterThan(0);
+
+    const orDeleted = statCalls.filter(
+      (c) => c.method === 'or' && String(c.args[0]).includes('deleted_at'),
+    );
+    expect(orDeleted).toHaveLength(0);
+
+    const gtUpdated = statCalls.filter((c) => c.method === 'gt' && c.args[0] === 'updated_at');
+    expect(gtUpdated.length).toBeGreaterThan(0);
+  });
+
+  it('also drops the deleted_at OR for the koplugin full-delta pull (no limit)', async () => {
+    await GET(req('type=stats&since=1000'));
+
+    const statPagesCalls = calls.filter((c) => c.table === 'stat_pages');
+    expect(statPagesCalls.length).toBeGreaterThan(0);
+    expect(
+      statPagesCalls.filter((c) => c.method === 'or' && String(c.args[0]).includes('deleted_at')),
+    ).toHaveLength(0);
+    expect(
+      statPagesCalls.filter((c) => c.method === 'gt' && c.args[0] === 'updated_at'),
+    ).not.toHaveLength(0);
+  });
+});

--- a/apps/readest-app/src/pages/api/sync.ts
+++ b/apps/readest-app/src/pages/api/sync.ts
@@ -267,6 +267,15 @@ export async function GET(req: NextRequest) {
       // event, so page through both tables (ordered by updated_at ascending for a
       // stable cursor) and accumulate every row — otherwise a device pulling >1000
       // events only gets the first page and then advances its cursor past the rest.
+      //
+      // Cursor is `updated_at > since` ONLY (no `OR deleted_at > since`). Every
+      // stat push server-stamps `updated_at = now()` including deletes (see the
+      // upserts below), so a delete always lands with updated_at greater than any
+      // peer's max(updated_at) pull cursor — `updated_at > since` already returns
+      // it. The redundant OR was the #1 query by total DB time: it defeats the
+      // (user_id, updated_at) index range scan and forces a walk of the user's
+      // entire page-event history on every incremental sync. Same rationale as the
+      // books `synced_at` cursor (#4678); here updated_at is itself server-stamped.
       const PAGE = 1000;
       const fetchAll = async (table: 'stat_books' | 'stat_pages', filterBook: boolean) => {
         const all: Record<string, unknown>[] = [];
@@ -276,7 +285,7 @@ export async function GET(req: NextRequest) {
             .from(table)
             .select('*')
             .eq('user_id', user.id)
-            .or(`updated_at.gt.${sinceIso},deleted_at.gt.${sinceIso}`)
+            .gt('updated_at', sinceIso)
             .order('updated_at', { ascending: true })
             .range(offset, offset + PAGE - 1);
           if (filterBook && bookParam) q = q.eq('book_hash', bookParam);
@@ -297,7 +306,7 @@ export async function GET(req: NextRequest) {
           .from('stat_pages')
           .select('*')
           .eq('user_id', user.id)
-          .or(`updated_at.gt.${sinceIso},deleted_at.gt.${sinceIso}`)
+          .gt('updated_at', sinceIso)
           .order('updated_at', { ascending: true })
           .range(0, statsLimit - 1);
         if (bookParam) q = q.eq('book_hash', bookParam);


### PR DESCRIPTION
## Problem

The `type=stats` pull (`stat_pages` / `stat_books`) is the **#1 query by total DB time (~43%)** in production, with a mean of ~190ms and a notably low **67% buffer cache hit rate** (disk-heavy).

Its cursor filtered `(updated_at > since OR deleted_at > since)`. That `OR` prevents Postgres from using the `idx_stat_pages_user_updated (user_id, updated_at)` index as a range scan: it can no longer treat `updated_at > since` as an index bound, so it walks the user's **entire** `stat_pages` history (which grows one row per page-turn event) in `updated_at` order and applies the `OR` as a filter. A heavy reader re-scans tens of thousands of rows on every incremental sync.

## Why the `deleted_at` disjunct is redundant here

Every stat push server-stamps `updated_at = new Date()` on **every** write, including deletes (`sync.ts` upserts for `stat_books`/`stat_pages`). The client pull cursor is `max(updated_at_ms)`, advancing forward only. So a deletion always lands with `updated_at` greater than any peer's cursor, and `updated_at > since` alone already returns it. The `OR deleted_at > since` matched nothing that `updated_at > since` didn't.

Removing it turns the query into a clean forward index range-scan (seek to the cursor, scan `LIMIT` rows). No new index or migration needed, and it's more reliable than adding an index (avoids the classic `ORDER BY ... LIMIT` planner trap that can keep the bad plan even when a better index exists).

## Why this is NOT applied to `book_notes` / `book_configs`

Those keep the client's `updated_at` on update, and a note deletion bumps **only** `deletedAt`, not `updatedAt` (`Notebook.tsx`, `Annotator.tsx` toggle-off + clear-all, `annotatorUtil.ts`). There, `deleted_at > since` is load-bearing: dropping it would make peers miss deletions and resurrect deleted highlights. They're also per-book scoped, so far cheaper. Left untouched.

## Testing

- New regression test `sync-stats-updated-at-cursor.test.ts` (written failing first) asserting the stats pull filters on `updated_at` only, with no `deleted_at` OR, for both the app paged pull and the koplugin full-delta pull.
- `pnpm test` full suite green; `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)