### PR TITLE
chore: replace outdated `react-color` package with `react-colorful`

### DIFF
--- a/apps/readest-app/package.json
+++ b/apps/readest-app/package.json
@@ -192,7 +192,7 @@
     "overlayscrollbars-react": "^0.5.6",
     "posthog-js": "^1.246.0",
     "react": "19.2.5",
-    "react-color": "^2.19.3",
+    "react-colorful": "^5.8.0",
     "react-dom": "19.2.5",
     "react-i18next": "^15.2.0",
     "react-icons": "^5.4.0",

--- a/apps/readest-app/src/__tests__/components/HighlightColorsEditor.test.tsx
+++ b/apps/readest-app/src/__tests__/components/HighlightColorsEditor.test.tsx
@@ -40,6 +40,7 @@ vi.mock('react-colorful', () => ({
       />
     );
   },
+  HexColorInput: () => <input data-testid='mock-hex-input' />,
 }));
 
 afterEach(() => {

--- a/apps/readest-app/src/__tests__/components/HighlightColorsEditor.test.tsx
+++ b/apps/readest-app/src/__tests__/components/HighlightColorsEditor.test.tsx
@@ -10,21 +10,15 @@ vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => (s: string) => s,
 }));
 
-// Mocked SketchPicker that tracks mount/unmount via a shared module-level
+// Mocked HexColorPicker that tracks mount/unmount via a shared module-level
 // registry, so we can detect whether the picker was remounted across a hex
 // change. Each mount gets a unique id; a mount is "alive" while its cleanup
 // hasn't run.
 const mountLog: Array<{ id: number; alive: boolean }> = [];
 let nextMountId = 0;
 
-vi.mock('react-color', () => ({
-  SketchPicker: ({
-    color,
-    onChange,
-  }: {
-    color: string;
-    onChange: (c: { hex: string }) => void;
-  }) => {
+vi.mock('react-colorful', () => ({
+  HexColorPicker: ({ color, onChange }: { color: string; onChange: (c: string) => void }) => {
     const [mountId] = useState(() => {
       const id = nextMountId++;
       mountLog.push({ id, alive: true });
@@ -42,11 +36,10 @@ vi.mock('react-color', () => ({
         data-mount-id={mountId}
         data-color={color}
         // Expose a way to trigger onChange as if from a drag.
-        onClick={() => onChange({ hex: '#112233' })}
+        onClick={() => onChange('#112233')}
       />
     );
   },
-  ColorResult: undefined,
 }));
 
 afterEach(() => {
@@ -75,8 +68,8 @@ const Harness: React.FC<{ initialUserColors: UserHighlightColor[] }> = ({ initia
   );
 };
 
-describe('HighlightColorsEditor — user color SketchPicker stability', () => {
-  it('keeps the SketchPicker mounted when the user-color hex updates (so drag is not interrupted)', () => {
+describe('HighlightColorsEditor — user color HexColorPicker stability', () => {
+  it('keeps the HexColorPicker mounted when the user-color hex updates (so drag is not interrupted)', () => {
     render(<Harness initialUserColors={[{ hex: '#aabbcc' }]} />);
 
     // ColorInput swatchOnly renders a circular button per color, all with
@@ -88,14 +81,14 @@ describe('HighlightColorsEditor — user color SketchPicker stability', () => {
     const userSwatch = editColorButtons[editColorButtons.length - 1]! as HTMLButtonElement;
     expect(userSwatch.style.backgroundColor).toBe('rgb(170, 187, 204)');
 
-    // Open the SketchPicker for this user color.
+    // Open the HexColorPicker for this user color.
     fireEvent.click(userSwatch);
 
     const picker = screen.getByTestId('mock-sketch-picker');
     const initialMountId = picker.getAttribute('data-mount-id');
     expect(initialMountId).not.toBeNull();
 
-    // Simulate an onChange coming from the SketchPicker during drag.
+    // Simulate an onChange coming from the HexColorPicker during drag.
     // (In the real picker this fires continuously as the user drags.)
     fireEvent.click(picker);
 
@@ -104,8 +97,8 @@ describe('HighlightColorsEditor — user color SketchPicker stability', () => {
     // mount would be gone and React would have mounted a fresh one — the
     // drag's window-level mouse listeners would be torn down with it.
     const sameMount = mountLog.find((m) => String(m.id) === initialMountId);
-    expect(sameMount, 'SketchPicker mount with initial id should still exist').toBeDefined();
-    expect(sameMount!.alive, 'SketchPicker should not be unmounted on hex change').toBe(true);
+    expect(sameMount, 'HexColorPicker mount with initial id should still exist').toBeDefined();
+    expect(sameMount!.alive, 'HexColorPicker should not be unmounted on hex change').toBe(true);
 
     // And a picker for the new color should still be visible in the DOM.
     const pickerAfter = screen.queryByTestId('mock-sketch-picker');

--- a/apps/readest-app/src/components/settings/color/ColorInput.tsx
+++ b/apps/readest-app/src/components/settings/color/ColorInput.tsx
@@ -96,14 +96,18 @@ const ColorInput: React.FC<ColorInputProps> = ({
         {isOpen && (
           <div
             ref={pickerRef}
-            className={`absolute top-full z-50 mt-2 flex flex-col gap-2 rounded-lg border border-base-300/50 bg-base-100 p-3 shadow-xl items-center ${getPickerPositionClass()} `}
+            className={`absolute top-full z-50 mt-2 flex flex-col gap-2 rounded-lg border not-eink:border-base-300/50 bg-base-100 p-3 shadow-xl items-center ${getPickerPositionClass()}`}
           >
-            <HexColorPicker color={value} onChange={handlePickerChange} />
+            <HexColorPicker
+              color={value}
+              onChange={handlePickerChange}
+              className='eink-bordered rounded-lg'
+            />
             <HexColorInput
               color={value}
               onChange={handlePickerChange}
               prefixed
-              className='rounded-md px-2 py-1 bg-base-300 text-base-content w-[200px] font-mono'
+              className='rounded-md px-2 py-1 bg-base-300 text-base-content w-[200px] font-mono eink-bordered'
             />
           </div>
         )}

--- a/apps/readest-app/src/components/settings/color/ColorInput.tsx
+++ b/apps/readest-app/src/components/settings/color/ColorInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { HexColorPicker } from 'react-colorful';
+import { HexColorInput, HexColorPicker } from 'react-colorful';
 import { CgColorPicker } from 'react-icons/cg';
 
 type ColorInputProps = {
@@ -98,9 +98,14 @@ const ColorInput: React.FC<ColorInputProps> = ({
         {isOpen && (
           <div
             ref={pickerRef}
-            className={`absolute top-full z-50 py-1 ${getPickerPositionClass()}`}
+            className={`absolute top-full z-50 mt-2 flex flex-col gap-2 rounded-lg border border-base-300/50 bg-base-100 p-3 shadow-xl items-center ${getPickerPositionClass()} `}
           >
             <HexColorPicker color={value} onChange={handlePickerChange} />
+            <HexColorInput
+              color={value}
+              onChange={handlePickerChange}
+              className='rounded-md px-2 py-1 bg-base-300 text-base-content w-[200px] font-mono'
+            />
           </div>
         )}
       </div>

--- a/apps/readest-app/src/components/settings/color/ColorInput.tsx
+++ b/apps/readest-app/src/components/settings/color/ColorInput.tsx
@@ -102,6 +102,7 @@ const ColorInput: React.FC<ColorInputProps> = ({
             <HexColorInput
               color={value}
               onChange={handlePickerChange}
+              prefixed
               className='rounded-md px-2 py-1 bg-base-300 text-base-content w-[200px] font-mono'
             />
           </div>

--- a/apps/readest-app/src/components/settings/color/ColorInput.tsx
+++ b/apps/readest-app/src/components/settings/color/ColorInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { SketchPicker, ColorResult } from 'react-color';
+import { HexColorPicker } from 'react-colorful';
 import { CgColorPicker } from 'react-icons/cg';
 
 type ColorInputProps = {
@@ -60,8 +60,8 @@ const ColorInput: React.FC<ColorInputProps> = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [isOpen, onCommit]);
 
-  const handlePickerChange = (colorResult: ColorResult) => {
-    onChange(colorResult.hex);
+  const handlePickerChange = (colorResultHex: string) => {
+    onChange(colorResultHex);
   };
 
   const getPickerPositionClass = () => {
@@ -100,12 +100,7 @@ const ColorInput: React.FC<ColorInputProps> = ({
             ref={pickerRef}
             className={`absolute top-full z-50 py-1 ${getPickerPositionClass()}`}
           >
-            <SketchPicker
-              width='200px'
-              color={value}
-              onChange={handlePickerChange}
-              disableAlpha={true}
-            />
+            <HexColorPicker color={value} onChange={handlePickerChange} />
           </div>
         )}
       </div>
@@ -130,12 +125,7 @@ const ColorInput: React.FC<ColorInputProps> = ({
             ref={pickerRef}
             className={`absolute top-full z-50 py-1 ${getPickerPositionClass()}`}
           >
-            <SketchPicker
-              width='200px'
-              color={value}
-              onChange={handlePickerChange}
-              disableAlpha={true}
-            />
+            <HexColorPicker color={value} onChange={handlePickerChange} />
           </div>
         )}
       </div>
@@ -165,12 +155,7 @@ const ColorInput: React.FC<ColorInputProps> = ({
       {isOpen && (
         <div ref={pickerRef} className='relative z-50 mt-2'>
           <div className='absolute'>
-            <SketchPicker
-              width='100%'
-              color={value}
-              onChange={handlePickerChange}
-              disableAlpha={true}
-            />
+            <HexColorPicker color={value} onChange={handlePickerChange} className='w-full' />
           </div>
         </div>
       )}

--- a/apps/readest-app/src/components/settings/color/ColorInput.tsx
+++ b/apps/readest-app/src/components/settings/color/ColorInput.tsx
@@ -96,7 +96,7 @@ const ColorInput: React.FC<ColorInputProps> = ({
         {isOpen && (
           <div
             ref={pickerRef}
-            className={`absolute top-full z-50 mt-2 flex flex-col gap-2 rounded-lg border not-eink:border-base-300/50 bg-base-100 p-3 shadow-xl items-center ${getPickerPositionClass()}`}
+            className={`absolute top-full z-50 mt-2 flex flex-col gap-2 rounded-lg border not-eink:border-base-300/50 bg-base-100 p-3 not-eink:shadow-xl items-center ${getPickerPositionClass()}`}
           >
             <HexColorPicker
               color={value}

--- a/apps/readest-app/src/components/settings/color/ColorInput.tsx
+++ b/apps/readest-app/src/components/settings/color/ColorInput.tsx
@@ -101,7 +101,7 @@ const ColorInput: React.FC<ColorInputProps> = ({
             <HexColorPicker
               color={value}
               onChange={handlePickerChange}
-              className='eink-bordered rounded-lg'
+              className='eink-bordered rounded-lg m-2'
             />
             <HexColorInput
               color={value}

--- a/apps/readest-app/src/components/settings/color/ColorInput.tsx
+++ b/apps/readest-app/src/components/settings/color/ColorInput.tsx
@@ -13,7 +13,6 @@ type ColorInputProps = {
    * settles, not on every onChange tick.
    */
   onCommit?: () => void;
-  compact?: boolean;
   /**
    * Render only the color swatch as a circular button — no hex input. Click
    * the swatch to open the picker. Cleaner UX for casual users who don't
@@ -35,7 +34,6 @@ const ColorInput: React.FC<ColorInputProps> = ({
   value,
   onChange,
   onCommit,
-  compact = false,
   swatchOnly = false,
   showPickerIcon = false,
   pickerPosition = 'left',
@@ -106,31 +104,6 @@ const ColorInput: React.FC<ColorInputProps> = ({
               onChange={handlePickerChange}
               className='rounded-md px-2 py-1 bg-base-300 text-base-content w-[200px] font-mono'
             />
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  if (compact) {
-    return (
-      <div className='relative'>
-        <input
-          type='text'
-          value={value}
-          spellCheck={false}
-          onChange={(e) => onChange(e.target.value)}
-          onBlur={() => onCommit?.()}
-          onClick={() => setIsOpen(!isOpen)}
-          className='bg-base-100 text-base-content border-base-200/75 w-16 cursor-pointer rounded border px-1 py-0.5 text-center font-mono text-xs'
-        />
-
-        {isOpen && (
-          <div
-            ref={pickerRef}
-            className={`absolute top-full z-50 py-1 ${getPickerPositionClass()}`}
-          >
-            <HexColorPicker color={value} onChange={handlePickerChange} />
           </div>
         )}
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,9 +354,9 @@ importers:
       react:
         specifier: 19.2.5
         version: 19.2.5
-      react-color:
-        specifier: ^2.19.3
-        version: 2.19.3(react@19.2.5)
+      react-colorful:
+        specifier: ^5.8.0
+        version: 5.8.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react-dom:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
@@ -1619,11 +1619,6 @@ packages:
 
   '@iconify/utils@3.1.3':
     resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
-
-  '@icons/material@0.2.4':
-    resolution: {integrity: sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==}
-    peerDependencies:
-      react: '*'
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -6347,9 +6342,6 @@ packages:
   matchmediaquery@0.4.2:
     resolution: {integrity: sha512-wrZpoT50ehYOudhDjt/YvUJc6eUzcdFPdmbizfgvswCKNHD1/OBOHYJpHie+HXpu6bSkEGieFMYk6VuutaiRfA==}
 
-  material-colors@1.2.6:
-    resolution: {integrity: sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==}
-
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -7170,10 +7162,11 @@ packages:
     peerDependencies:
       webpack: ^4.0.0 || ^5.0.0
 
-  react-color@2.19.3:
-    resolution: {integrity: sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==}
+  react-colorful@5.8.0:
+    resolution: {integrity: sha512-Wy9OzPfjSN9bF12OB8N7UQvlsZ0I+7wHxpN+bV5BjNQGxOj6IiwkRjevJK9yOBjJWGQvAaf1OXtn8rUeEatAng==}
     peerDependencies:
-      react: '*'
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -7298,11 +7291,6 @@ packages:
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
-
-  reactcss@1.2.3:
-    resolution: {integrity: sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==}
-    peerDependencies:
-      react: '*'
 
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
@@ -10139,10 +10127,6 @@ snapshots:
       '@antfu/install-pkg': 1.1.0
       '@iconify/types': 2.0.0
       import-meta-resolve: 4.2.0
-
-  '@icons/material@0.2.4(react@19.2.5)':
-    dependencies:
-      react: 19.2.5
 
   '@img/colour@1.1.0': {}
 
@@ -15150,8 +15134,6 @@ snapshots:
     dependencies:
       css-mediaquery: 0.1.2
 
-  material-colors@1.2.6: {}
-
   math-intrinsics@1.1.0: {}
 
   mdast-util-find-and-replace@3.0.2:
@@ -16220,16 +16202,10 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.106.2(postcss@8.5.14)
 
-  react-color@2.19.3(react@19.2.5):
+  react-colorful@5.8.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@icons/material': 0.2.4(react@19.2.5)
-      lodash: 4.18.1
-      lodash-es: 4.18.1
-      material-colors: 1.2.6
-      prop-types: 15.8.1
       react: 19.2.5
-      reactcss: 1.2.3(react@19.2.5)
-      tinycolor2: 1.6.0
+      react-dom: 19.2.5(react@19.2.5)
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -16354,11 +16330,6 @@ snapshots:
       loose-envify: 1.4.0
 
   react@19.2.5: {}
-
-  reactcss@1.2.3(react@19.2.5):
-    dependencies:
-      lodash: 4.18.1
-      react: 19.2.5
 
   read-cache@1.0.0:
     dependencies:


### PR DESCRIPTION
The old color picker was completely unstyled:

<img width="720" height="596" alt="image" src="https://github.com/user-attachments/assets/70a8e122-c40b-409f-b1c1-b48db0ff44d0" />

So I replaced it with `react-colorful`'s `HexColorPicker`, which is smaller, and doesn't look outdated:

https://github.com/user-attachments/assets/6630d1c7-147d-43c4-b1ce-40deafe5053e