### PR TITLE
chore: migrate away from numtide devshell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,13 @@ nix develop ./ops#ios # enter a dev shell for the ios app
 nix develop ./ops#android # enter a dev shell for the android app
 ```
 
+Then, simply run:
+
+```bash
+# copy vendors dist libs to public directory
+pnpm --filter @readest/readest-app setup-vendors
+```
+
 ### 4. Build for Development
 
 ```bash

--- a/ops/flake.lock
+++ b/ops/flake.lock
@@ -42,24 +42,6 @@
         "type": "github"
       }
     },
-    "devshell_2": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1768818222,
-        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
     "fenix": {
       "inputs": {
         "nixpkgs": [
@@ -135,22 +117,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1762156382,
-        "narHash": "sha256-Yg7Ag7ov5+36jEFC1DaZh/12SEXo6OO3/8rqADRxiqs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7241bcbb4f099a66aafca120d37c65e8dda32717",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
         "lastModified": 1782723713,
         "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
@@ -168,10 +134,9 @@
     "root": {
       "inputs": {
         "android": "android",
-        "devshell": "devshell_2",
         "fenix": "fenix",
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "rust-analyzer-src": {

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -24,7 +24,6 @@
       let
         inherit (nixpkgs) lib;
         inherit (pkgs.lib) optionals;
-        inherit (pkgs.lib) optionalAttrs;
         inherit (pkgs.stdenv) isDarwin;
 
         pkgs = import nixpkgs {
@@ -36,95 +35,61 @@
           ];
         };
 
-        commonPackages = with pkgs; [
+        toolchain = with pkgs.fenix.complete; [
+          cargo
+          clippy
+          rust-src
+          rustc
+          rustfmt
+        ];
+
+        commonNativeBuildInupts = with pkgs; [
           pnpm
           nodejs_24
           clang
-          pkg-config
           pkgs.rust-analyzer-nightly
+          pkg-config
           xdg-utils
           self.formatter.${pkgs.stdenv.hostPlatform.system}
         ];
 
-        systemDeps = with pkgs; [
-          at-spi2-atk
-          atkmm
-          cairo
-          fontconfig
-          fontconfig.out
-          freetype
-          gdk-pixbuf
-          glib
+        commonBuildInputs = with pkgs; [
           gtk3
-          gtk4
-          harfbuzz
           librsvg
-          libsoup_3
           openssl
-          pango
           zlib
+          fontconfig
         ] ++ (optionals (!isDarwin) [
           webkitgtk_4_1
         ]) ++ (optionals isDarwin [
           darwin.libiconv
         ]);
-        getDev = pkg: if pkg ? dev then pkg.dev else pkg;
-        getLib = pkg: if pkg ? lib then pkg.lib else pkg;
-
-        # zlib stores zlib.pc in share/pkgconfig while everything else is stored in lib/pkgconfig
-        pkgConfigPath = lib.concatStringsSep ":" [
-          (lib.makeSearchPath "lib/pkgconfig" (map getDev systemDeps))
-          (lib.makeSearchPath "share/pkgconfig" (map getDev systemDeps))
-        ];
-
-        xdgPath = "${
-          lib.makeSearchPath "share/gsettings-schemas" [
-            pkgs.gsettings-desktop-schemas
-            pkgs.gtk3
-          ]
-        }:$XDG_DATA_DIRS";
-
-        libPath = lib.makeLibraryPath (map getLib systemDeps);
 
         mkCommonShell =
           { name
           , postInit ? ""
-          , extraPackages ? [ ]
+          , extraNativeBuildInputs ? [ ]
           , extraTargets ? [ ]
           , extraEnv ? { }
           }:
           pkgs.mkShell {
             inherit name;
-            packages =
-              commonPackages
-              ++ extraPackages
-              ++ [
-                (
-                  with pkgs.fenix;
-                  pkgs.fenix.combine [
-                    complete.cargo
-                    complete.clippy
-                    complete.rust-src
-                    complete.rustc
-                    complete.rustfmt
-                    extraTargets
-                  ]
-                )
-              ];
+
+            nativeBuildInputs = commonNativeBuildInupts ++ extraNativeBuildInputs;
+            buildInputs = commonBuildInputs ++ [
+              (
+                with pkgs.fenix;
+                combine [
+                  toolchain
+                  extraTargets
+                ]
+              )
+            ];
+
             env = {
-              PKG_CONFIG_PATH = pkgConfigPath;
-              RUSTFLAGS = "-C link-arg=-Wl,-rpath,${libPath}";
-              LIBRARY_PATH = libPath;
-              XDG_DATA_DIRS = xdgPath;
               GDK_BACKEND = "x11";
-            } // (optionalAttrs isDarwin {
-              RUSTFLAGS = ''"-L framework=$DEVSHELL_DIR/Library/Frameworks"'';
-              RUSTDOCFLAGS = ''"-L framework=$DEVSHELL_DIR/Library/Frameworks"'';
-              PATH = "${lib.makeBinPath [
-                  pkgs.xcbuild
-                  "${pkgs.xcbuild}/Toolchains/XcodeDefault.xctoolchain"
-                ]}:$PATH";
-            }) // extraEnv;
+            } // extraEnv;
+
             shellHook = ''
               git submodule update --init --recursive
               pnpm install
@@ -166,7 +131,7 @@
 
           ios = mkCommonShell {
             name = "readest-ios";
-            extraPackages = [ pkgs.cocoapods ];
+            extraNativeBuildInputs = [ pkgs.cocoapods ];
           };
 
           android = mkCommonShell rec {
@@ -191,7 +156,7 @@
               i686-linux-android.latest.rust-std
               x86_64-linux-android.latest.rust-std
             ];
-            extraPackages = [
+            extraNativeBuildInputs = [
               pkgs.android-sdk
               pkgs.gradle
               pkgs.jdk

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -70,7 +70,7 @@
           openssl
           pango
           zlib
-        
+
           gst_all_1.gstreamer
           gst_all_1.gst-plugins-base
           gst_all_1.gst-plugins-good
@@ -110,7 +110,6 @@
             shellHook = ''
               git submodule update --init --recursive
               pnpm install
-              # pnpm --filter @readest/readest-app setup-vendors
 
               ${postInit}
             '';

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -72,7 +72,7 @@
           , extraTargets ? [ ]
           , extraEnv ? { }
           }:
-          pkgs.mkShell {
+          pkgs.mkShell rec {
             inherit name;
 
             nativeBuildInputs = commonNativeBuildInupts ++ extraNativeBuildInputs;
@@ -88,6 +88,7 @@
 
             env = {
               GDK_BACKEND = "x11";
+              LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
             } // extraEnv;
 
             shellHook = ''

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -47,7 +47,7 @@
           pnpm
           nodejs_24
           clang
-          pkgs.rust-analyzer-nightly
+          rust-analyzer-nightly
           pkg-config
           xdg-utils
           self.formatter.${pkgs.stdenv.hostPlatform.system}

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -50,15 +50,31 @@
           rust-analyzer-nightly
           pkg-config
           xdg-utils
+          patchelf
+          wrapGAppsHook4
           self.formatter.${pkgs.stdenv.hostPlatform.system}
         ];
 
         commonBuildInputs = with pkgs; [
-          gtk3
-          librsvg
-          openssl
-          zlib
+          at-spi2-atk
+          atkmm
+          cairo
           fontconfig
+          freetype
+          gdk-pixbuf
+          glib
+          gtk3
+          harfbuzz
+          librsvg
+          libsoup_3
+          openssl
+          pango
+          zlib
+        
+          gst_all_1.gstreamer
+          gst_all_1.gst-plugins-base
+          gst_all_1.gst-plugins-good
+          gst_all_1.gst-plugins-bad
         ] ++ (optionals (!isDarwin) [
           webkitgtk_4_1
         ]) ++ (optionals isDarwin [
@@ -94,7 +110,7 @@
             shellHook = ''
               git submodule update --init --recursive
               pnpm install
-              pnpm --filter @readest/readest-app setup-vendors
+              # pnpm --filter @readest/readest-app setup-vendors
 
               ${postInit}
             '';

--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -4,7 +4,6 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    devshell.url = "github:numtide/devshell";
     android = {
       url = "github:tadfisher/android-nixpkgs/stable";
     };
@@ -14,7 +13,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, android, devshell, fenix }:
+  outputs = { self, nixpkgs, flake-utils, android, fenix }:
     {
       overlay = final: prev: {
         inherit (self.packages.${final.stdenv.hostPlatform.system}) android-sdk;
@@ -25,13 +24,13 @@
       let
         inherit (nixpkgs) lib;
         inherit (pkgs.lib) optionals;
+        inherit (pkgs.lib) optionalAttrs;
         inherit (pkgs.stdenv) isDarwin;
 
         pkgs = import nixpkgs {
           inherit system;
           config.allowUnfree = true;
           overlays = [
-            devshell.overlays.default
             fenix.overlays.default
             self.overlay
           ];
@@ -92,51 +91,9 @@
           , postInit ? ""
           , extraPackages ? [ ]
           , extraTargets ? [ ]
-          , extraEnv ? [
-              {
-                name = "PKG_CONFIG_PATH";
-                value = pkgConfigPath;
-              }
-              {
-                name = "GDK_BACKEND";
-                value = "x11";
-              }
-              {
-                name = "RUSTFLAGS";
-                value = "-C link-arg=-Wl,-rpath,${libPath}";
-              }
-              {
-                name = "LIBRARY_PATH";
-                value = libPath;
-              }
-              {
-                name = "XDG_DATA_DIRS";
-                eval = xdgPath;
-              }
-            ]
-            ++ (optionals isDarwin [
-              {
-                name = "RUSTFLAGS";
-                eval = "\"-L framework=$DEVSHELL_DIR/Library/Frameworks\"";
-              }
-              {
-                name = "RUSTDOCFLAGS";
-                eval = "\"-L framework=$DEVSHELL_DIR/Library/Frameworks\"";
-              }
-              {
-                name = "PATH";
-                prefix =
-                  let
-                    inherit (pkgs) xcbuild;
-                  in
-                  lib.makeBinPath [
-                    xcbuild
-                    "${xcbuild}/Toolchains/XcodeDefault.xctoolchain"
-                  ];
-              }
-            ])
+          , extraEnv ? { }
           }:
-          pkgs.devshell.mkShell {
+          pkgs.mkShell {
             inherit name;
             packages =
               commonPackages
@@ -154,12 +111,27 @@
                   ]
                 )
               ];
-            env = extraEnv;
-            devshell.startup.init_project.text = ''
+            env = {
+              PKG_CONFIG_PATH = pkgConfigPath;
+              RUSTFLAGS = "-C link-arg=-Wl,-rpath,${libPath}";
+              LIBRARY_PATH = libPath;
+              XDG_DATA_DIRS = xdgPath;
+              GDK_BACKEND = "x11";
+            } // (optionalAttrs isDarwin {
+              RUSTFLAGS = ''"-L framework=$DEVSHELL_DIR/Library/Frameworks"'';
+              RUSTDOCFLAGS = ''"-L framework=$DEVSHELL_DIR/Library/Frameworks"'';
+              PATH = "${lib.makeBinPath [
+                  pkgs.xcbuild
+                  "${pkgs.xcbuild}/Toolchains/XcodeDefault.xctoolchain"
+                ]}:$PATH";
+            }) // extraEnv;
+            shellHook = ''
               git submodule update --init --recursive
               pnpm install
               pnpm --filter @readest/readest-app setup-vendors
-            '' + postInit;
+
+              ${postInit}
+            '';
           };
       in
       {
@@ -224,28 +196,13 @@
               pkgs.gradle
               pkgs.jdk
             ];
-            extraEnv = [
-              {
-                name = "ANDROID_HOME";
-                value = "${pkgs.android-sdk}/share/android-sdk";
-              }
-              {
-                name = "ANDROID_SDK_ROOT";
-                value = "${pkgs.android-sdk}/share/android-sdk";
-              }
-              {
-                name = "NDK_HOME";
-                value = "${pkgs.android-sdk}/share/android-sdk/ndk/26.1.10909125";
-              }
-              {
-                name = "JAVA_HOME";
-                value = pkgs.jdk.home;
-              }
-              {
-                name = "ANDROID_AVD_HOME";
-                eval = "$XDG_CONFIG_HOME/.android/avd";
-              }
-            ];
+            extraEnv = {
+              ANDROID_HOME = "${pkgs.android-sdk}/share/android-sdk";
+              ANDROID_SDK_ROOT = "${pkgs.android-sdk}/share/android-sdk";
+              NDK_HOME = "${pkgs.android-sdk}/share/android-sdk/ndk/26.1.10909125";
+              JAVA_HOME = pkgs.jdk.home;
+              ANDROID_AVD_HOME = "$XDG_CONFIG_HOME/.android/avd";
+            };
           };
 
           default = self.devShells.${pkgs.stdenv.hostPlatform.system}.web;


### PR DESCRIPTION
Migrates away from numtide devshell, which hasn't received a commit in the last 6 months.

In general, using nix abstractions like these are usually a bad idea, since a) they're not typically supported for very long and b) result in tons of workarounds that could be mitigated by just using regular nix.

I've tried to structure these commits to show what is gained by using the regular `pkgs.mkShell` rather than relying on a nix abstraction.