### PR TITLE
fix: change dictionary icon

### DIFF
--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationTools.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationTools.tsx
@@ -2,7 +2,8 @@ import { IconType } from 'react-icons';
 import { FiSearch } from 'react-icons/fi';
 import { FiCopy } from 'react-icons/fi';
 import { FiShare } from 'react-icons/fi';
-import { PiTextAa, PiHighlighterFill } from 'react-icons/pi';
+import { PiHighlighterFill } from 'react-icons/pi';
+import { LuBookA } from 'react-icons/lu';
 import { BsPencilSquare } from 'react-icons/bs';
 import { BsTranslate } from 'react-icons/bs';
 import { FaHeadphones } from 'react-icons/fa6';
@@ -66,7 +67,7 @@ export const annotationToolButtons = createAnnotationToolButtons([
     type: 'dictionary',
     label: _('Dictionary'),
     tooltip: _('Look up text in dictionary after selection'),
-    Icon: PiTextAa,
+    Icon: LuBookA,
     quickAction: true,
   },
   {

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationTools.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationTools.tsx
@@ -2,10 +2,10 @@ import { IconType } from 'react-icons';
 import { FiSearch } from 'react-icons/fi';
 import { FiCopy } from 'react-icons/fi';
 import { FiShare } from 'react-icons/fi';
-import { PiHighlighterFill } from 'react-icons/pi';
+import { PiBookOpenText, PiHighlighterFill } from 'react-icons/pi';
 import { BsPencilSquare } from 'react-icons/bs';
 import { BsTranslate } from 'react-icons/bs';
-import { FaHeadphones, FaBook } from 'react-icons/fa6';
+import { FaHeadphones } from 'react-icons/fa6';
 import { IoIosBuild } from 'react-icons/io';
 import { AnnotationToolType } from '@/types/annotator';
 import { stubTranslation as _ } from '@/utils/misc';
@@ -66,7 +66,7 @@ export const annotationToolButtons = createAnnotationToolButtons([
     type: 'dictionary',
     label: _('Dictionary'),
     tooltip: _('Look up text in dictionary after selection'),
-    Icon: FaBook,
+    Icon: PiBookOpenText,
     quickAction: true,
   },
   {

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationTools.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationTools.tsx
@@ -5,8 +5,7 @@ import { FiShare } from 'react-icons/fi';
 import { PiHighlighterFill } from 'react-icons/pi';
 import { BsPencilSquare } from 'react-icons/bs';
 import { BsTranslate } from 'react-icons/bs';
-import { TbHexagonLetterD } from 'react-icons/tb';
-import { FaHeadphones } from 'react-icons/fa6';
+import { FaHeadphones, FaBook } from 'react-icons/fa6';
 import { IoIosBuild } from 'react-icons/io';
 import { AnnotationToolType } from '@/types/annotator';
 import { stubTranslation as _ } from '@/utils/misc';
@@ -67,7 +66,7 @@ export const annotationToolButtons = createAnnotationToolButtons([
     type: 'dictionary',
     label: _('Dictionary'),
     tooltip: _('Look up text in dictionary after selection'),
-    Icon: TbHexagonLetterD,
+    Icon: FaBook,
     quickAction: true,
   },
   {

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationTools.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationTools.tsx
@@ -2,7 +2,7 @@ import { IconType } from 'react-icons';
 import { FiSearch } from 'react-icons/fi';
 import { FiCopy } from 'react-icons/fi';
 import { FiShare } from 'react-icons/fi';
-import { PiBookOpenText, PiHighlighterFill } from 'react-icons/pi';
+import { PiTextAa, PiHighlighterFill } from 'react-icons/pi';
 import { BsPencilSquare } from 'react-icons/bs';
 import { BsTranslate } from 'react-icons/bs';
 import { FaHeadphones } from 'react-icons/fa6';
@@ -66,7 +66,7 @@ export const annotationToolButtons = createAnnotationToolButtons([
     type: 'dictionary',
     label: _('Dictionary'),
     tooltip: _('Look up text in dictionary after selection'),
-    Icon: PiBookOpenText,
+    Icon: PiTextAa,
     quickAction: true,
   },
   {


### PR DESCRIPTION
The old dictionary icon was too ambiguous, and I constantly mistook the find icon for the dictionary icon because of it. This changes the dictionary icon to a book:

<img width="360" height="52" alt="image" src="https://github.com/user-attachments/assets/99c0b9bf-3f27-422f-a542-c504fd27c34d" />
