### PR TITLE
fix(tts): show mini player immediately and keep it above bottom bar and footer

### DIFF
--- a/apps/readest-app/src/__tests__/components/tts-mini-player-position.test.ts
+++ b/apps/readest-app/src/__tests__/components/tts-mini-player-position.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTTSMiniPlayerBottomOffset } from '@/app/reader/utils/ttsMiniPlayerPosition';
+import { DEFAULT_BOOK_LAYOUT, DEFAULT_VIEW_CONFIG } from '@/services/constants';
+import type { ViewSettings } from '@/types/book';
+
+// The TTS mini player stays visible for the whole session and stacks above
+// whatever occupies the bottom edge (offsets exclude the safe-area inset,
+// which the component applies separately as margin-bottom):
+//   - bottom bar shown (hoveredBookKey === bookKey): above the bar
+//     (64px mobile nav bar / 52px desktop bar, + 8px gap)
+//   - bottom bar dismissed: above the footer info band (marginBottomPx)
+//   - no footer info at the bottom: 16px above the bottom edge
+const settings = (overrides: Partial<ViewSettings>): ViewSettings =>
+  ({ ...DEFAULT_VIEW_CONFIG, ...DEFAULT_BOOK_LAYOUT, ...overrides }) as ViewSettings;
+
+describe('getTTSMiniPlayerBottomOffset', () => {
+  it('sits above the mobile bottom bar while it is shown', () => {
+    expect(
+      getTTSMiniPlayerBottomOffset(settings({}), { barVisible: true, usesMobileBar: true }),
+    ).toBe(72);
+  });
+
+  it('sits above the desktop footer bar while it is shown', () => {
+    expect(
+      getTTSMiniPlayerBottomOffset(settings({}), { barVisible: true, usesMobileBar: false }),
+    ).toBe(60);
+  });
+
+  it('sits above the footer band once the bar is dismissed (default settings)', () => {
+    expect(getTTSMiniPlayerBottomOffset(settings({}), { barVisible: false })).toBe(
+      DEFAULT_BOOK_LAYOUT.marginBottomPx,
+    );
+  });
+
+  it('sits above the floating footer pills in scrolled mode', () => {
+    expect(getTTSMiniPlayerBottomOffset(settings({ scrolled: true }), { barVisible: false })).toBe(
+      DEFAULT_BOOK_LAYOUT.marginBottomPx,
+    );
+  });
+
+  it('falls back to 16px when Show Footer is off', () => {
+    expect(
+      getTTSMiniPlayerBottomOffset(settings({ showFooter: false }), { barVisible: false }),
+    ).toBe(16);
+  });
+
+  it('falls back to 16px when no footer widget renders at the bottom', () => {
+    expect(
+      getTTSMiniPlayerBottomOffset(
+        settings({
+          showRemainingTime: false,
+          showRemainingPages: false,
+          showProgressInfo: false,
+          showCurrentTime: false,
+          showCurrentBatteryStatus: false,
+        }),
+        { barVisible: false },
+      ),
+    ).toBe(16);
+  });
+
+  it('keeps the footer offset for the sticky progress bar even without widgets', () => {
+    expect(
+      getTTSMiniPlayerBottomOffset(
+        settings({
+          showStickyProgressBar: true,
+          showRemainingTime: false,
+          showRemainingPages: false,
+          showProgressInfo: false,
+          showCurrentTime: false,
+          showCurrentBatteryStatus: false,
+        }),
+        { barVisible: false },
+      ),
+    ).toBe(DEFAULT_BOOK_LAYOUT.marginBottomPx);
+  });
+
+  it('falls back to 16px in vertical writing mode (footer is a side column)', () => {
+    expect(getTTSMiniPlayerBottomOffset(settings({ vertical: true }), { barVisible: false })).toBe(
+      16,
+    );
+  });
+
+  it('never drops below 16px even with a tiny bottom margin', () => {
+    expect(
+      getTTSMiniPlayerBottomOffset(settings({ marginBottomPx: 8 }), { barVisible: false }),
+    ).toBe(16);
+  });
+});

--- a/apps/readest-app/src/__tests__/components/tts-mini-player-position.test.ts
+++ b/apps/readest-app/src/__tests__/components/tts-mini-player-position.test.ts
@@ -27,6 +27,32 @@ describe('getTTSMiniPlayerBottomOffset', () => {
     ).toBe(60);
   });
 
+  it('rides above an expanded action panel with an 8px gap', () => {
+    expect(
+      getTTSMiniPlayerBottomOffset(settings({}), {
+        barVisible: true,
+        usesMobileBar: true,
+        panelTopOffset: 200,
+      }),
+    ).toBe(208);
+  });
+
+  it('never drops below the bar offset for a tiny panel measurement', () => {
+    expect(
+      getTTSMiniPlayerBottomOffset(settings({}), {
+        barVisible: true,
+        usesMobileBar: true,
+        panelTopOffset: 20,
+      }),
+    ).toBe(72);
+  });
+
+  it('ignores the panel offset once the bar is dismissed', () => {
+    expect(
+      getTTSMiniPlayerBottomOffset(settings({}), { barVisible: false, panelTopOffset: 200 }),
+    ).toBe(DEFAULT_BOOK_LAYOUT.marginBottomPx);
+  });
+
   it('sits above the footer band once the bar is dismissed (default settings)', () => {
     expect(getTTSMiniPlayerBottomOffset(settings({}), { barVisible: false })).toBe(
       DEFAULT_BOOK_LAYOUT.marginBottomPx,

--- a/apps/readest-app/src/__tests__/components/tts/TTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSControl.test.tsx
@@ -42,7 +42,6 @@ vi.mock('@/store/readerProgressStore', () => ({
 
 vi.mock('@/app/reader/components/tts/TTSMiniPlayer', () => ({
   __esModule: true,
-  TTS_MINI_PLAYER_CLEARANCE: 64,
   default: ({ onExpand }: { onExpand: () => void }) => (
     <div data-testid='mini-player' onClick={onExpand} />
   ),
@@ -99,11 +98,21 @@ describe('TTSControl', () => {
     expect(screen.queryByTestId('player-sheet')).toBeNull();
   });
 
-  test('renders nothing before the clients are initialized', () => {
+  test('renders nothing while no session is active', () => {
     Object.assign(ttsState, { showIndicator: false, ttsClientsInited: false });
     render(<TTSControl bookKey='b1' gridInsets={gridInsets} />);
     expect(screen.queryByTestId('mini-player')).toBeNull();
     expect(screen.queryByTestId('player-sheet')).toBeNull();
+  });
+
+  test('mounts the mini player immediately, before the clients are initialized', () => {
+    Object.assign(ttsState, { showIndicator: true, ttsClientsInited: false });
+    render(<TTSControl bookKey='b1' gridInsets={gridInsets} />);
+    expect(screen.getByTestId('mini-player')).toBeTruthy();
+    // Expanding needs initialized clients; taps are ignored until then.
+    fireEvent.click(screen.getByTestId('mini-player'));
+    expect(screen.queryByTestId('player-sheet')).toBeNull();
+    expect(screen.getByTestId('mini-player')).toBeTruthy();
   });
 
   test('expanding the mini player opens the sheet and hides the mini player', () => {

--- a/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@/context/EnvContext', () => ({
 
 const readerState = {
   hoveredBookKey: '',
+  bottomBarTab: '',
   setHoveredBookKey: vi.fn(),
   getViewSettings: () => ({ ...DEFAULT_VIEW_CONFIG, ...DEFAULT_BOOK_LAYOUT }),
 };
@@ -61,6 +62,7 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
 describe('TTSMiniPlayer', () => {
   beforeEach(() => {
     readerState.hoveredBookKey = '';
+    readerState.bottomBarTab = '';
     getBookData.mockReturnValue({ book: { title: 'Alice in Wonderland', coverImageUrl: null } });
   });
 
@@ -111,6 +113,27 @@ describe('TTSMiniPlayer', () => {
     // Desktop footer bar (52px) + 8px gap; the card stays interactive.
     expect(card.style.bottom).toBe('60px');
     expect(card.className).not.toContain('pointer-events-none');
+  });
+
+  test('rides above an expanded action panel while one is open', () => {
+    readerState.hoveredBookKey = 'b1';
+    readerState.bottomBarTab = 'font';
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-b1';
+    const panel = document.createElement('div');
+    panel.className = 'footerbar-font-mobile';
+    cell.appendChild(panel);
+    document.body.appendChild(cell);
+    cell.getBoundingClientRect = () => ({ bottom: 800, top: 0, height: 800 }) as DOMRect;
+    // Panel settled at 600..736 above the nav bar; no transform in jsdom.
+    panel.getBoundingClientRect = () => ({ top: 600, bottom: 736, height: 136 }) as DOMRect;
+    try {
+      render(<TTSMiniPlayer {...makeProps()} />);
+      // 800 - 600 + 8px gap; beats the plain above-the-bar offset.
+      expect(screen.getByRole('status').style.bottom).toBe('208px');
+    } finally {
+      cell.remove();
+    }
   });
 
   test('rests above the footer info band once the bar is dismissed', () => {

--- a/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
@@ -16,7 +16,11 @@ vi.mock('@/context/EnvContext', () => ({
   }),
 }));
 
-const readerState = { hoveredBookKey: '', setHoveredBookKey: vi.fn() };
+const readerState = {
+  hoveredBookKey: '',
+  setHoveredBookKey: vi.fn(),
+  getViewSettings: () => ({ ...DEFAULT_VIEW_CONFIG, ...DEFAULT_BOOK_LAYOUT }),
+};
 vi.mock('@/store/readerStore', () => ({
   useReaderStore: () => readerState,
 }));
@@ -31,6 +35,7 @@ vi.mock('@/store/bookDataStore', () => ({
 }));
 
 import TTSMiniPlayer from '@/app/reader/components/tts/TTSMiniPlayer';
+import { DEFAULT_BOOK_LAYOUT, DEFAULT_VIEW_CONFIG } from '@/services/constants';
 
 const gridInsets = { top: 0, right: 0, bottom: 0, left: 0 };
 
@@ -99,10 +104,18 @@ describe('TTSMiniPlayer', () => {
     expect(props.onExpand).toHaveBeenCalled();
   });
 
-  test('fades out while the footer bar is up for this book', () => {
+  test('rides above the bottom bar while it is up for this book', () => {
     readerState.hoveredBookKey = 'b1';
     render(<TTSMiniPlayer {...makeProps()} />);
-    expect(screen.getByRole('status').className).toContain('pointer-events-none');
+    const card = screen.getByRole('status');
+    // Desktop footer bar (52px) + 8px gap; the card stays interactive.
+    expect(card.style.bottom).toBe('60px');
+    expect(card.className).not.toContain('pointer-events-none');
+  });
+
+  test('rests above the footer info band once the bar is dismissed', () => {
+    render(<TTSMiniPlayer {...makeProps()} />);
+    expect(screen.getByRole('status').style.bottom).toBe(`${DEFAULT_BOOK_LAYOUT.marginBottomPx}px`);
   });
 
   test('without a timeline shows the estimated chapter remaining instead', () => {

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -87,7 +87,10 @@ import Spinner from '@/components/Spinner';
 import KOSyncConflictResolver from './KOSyncResolver';
 import ImageViewer from './ImageViewer';
 import TableViewer from './TableViewer';
-import { TTS_MINI_PLAYER_CLEARANCE } from './tts/TTSMiniPlayer';
+import {
+  getTTSMiniPlayerBottomOffset,
+  TTS_MINI_PLAYER_HEIGHT,
+} from '../utils/ttsMiniPlayerPosition';
 
 declare global {
   interface Window {
@@ -822,8 +825,13 @@ const FoliateViewer: React.FC<{
     // full-width blank bar that steals space from the book text.
     const showBottomFooter = footerReservesBand(viewSettings) && !viewSettings.vertical;
     const moreTopInset = showTopHeader ? Math.max(0, 16 - insets.top) : 0;
+    // Resting position (bottom bar dismissed): the card stacks above the
+    // footer band, so the reserved clearance is its bottom offset plus the
+    // card height.
     const miniPlayerClearance = viewState?.ttsEnabled
-      ? TTS_MINI_PLAYER_CLEARANCE + gridInsets.bottom * 0.33
+      ? getTTSMiniPlayerBottomOffset(viewSettings) +
+        TTS_MINI_PLAYER_HEIGHT +
+        gridInsets.bottom * 0.33
       : 0;
     const moreBottomInset = showBottomFooter
       ? Math.max(0, Math.max(miniPlayerClearance, 16) - insets.bottom)

--- a/apps/readest-app/src/app/reader/components/footerbar/ColorPanel.tsx
+++ b/apps/readest-app/src/app/reader/components/footerbar/ColorPanel.tsx
@@ -80,9 +80,13 @@ export const ColorPanel: React.FC<ColorPanelProps> = ({
     'footerbar-color-mobile not-eink:bg-base-200 eink:bg-base-100 absolute flex w-full flex-col items-center gap-y-8 px-4 transition-all',
     'eink:border-base-content eink:border-t',
     !forceMobileLayout && 'sm:hidden',
+    // Paddings stay constant in both states (the slide is transform-only) so
+    // offsetHeight always reports the panel's settled height; the TTS mini
+    // player measures it to stack above the expanded panel.
+    'pb-4 pt-8',
     actionTab === 'color'
-      ? 'pointer-events-auto translate-y-0 pb-4 pt-8 ease-out'
-      : 'pointer-events-none invisible translate-y-full overflow-hidden pb-0 pt-0 ease-in',
+      ? 'pointer-events-auto translate-y-0 ease-out'
+      : 'pointer-events-none invisible translate-y-full overflow-hidden ease-in',
   );
 
   return (

--- a/apps/readest-app/src/app/reader/components/footerbar/FontLayoutPanel.tsx
+++ b/apps/readest-app/src/app/reader/components/footerbar/FontLayoutPanel.tsx
@@ -96,9 +96,13 @@ export const FontLayoutPanel: React.FC<FontLayoutPanelProps> = ({
     'footerbar-font-mobile not-eink:bg-base-200 eink:bg-base-100 absolute flex w-full flex-col items-center gap-y-8 px-4 transition-all',
     'eink:border-base-content eink:border-t',
     !forceMobileLayout && 'sm:hidden',
+    // Paddings stay constant in both states (the slide is transform-only) so
+    // offsetHeight always reports the panel's settled height; the TTS mini
+    // player measures it to stack above the expanded panel.
+    'pb-4 pt-8',
     actionTab === 'font'
-      ? 'pointer-events-auto translate-y-0 pb-4 pt-8 ease-out'
-      : 'pointer-events-none invisible translate-y-full overflow-hidden pb-0 pt-0 ease-in',
+      ? 'pointer-events-auto translate-y-0 ease-out'
+      : 'pointer-events-none invisible translate-y-full overflow-hidden ease-in',
   );
 
   return (

--- a/apps/readest-app/src/app/reader/components/footerbar/FooterBar.tsx
+++ b/apps/readest-app/src/app/reader/components/footerbar/FooterBar.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import React, { useCallback, useMemo, useEffect, useRef } from 'react';
 import { useEnv } from '@/context/EnvContext';
 import { useSpatialNavigation } from '@/app/reader/hooks/useSpatialNavigation';
 import { useReaderStore } from '@/store/readerStore';
@@ -28,7 +28,7 @@ const FooterBar: React.FC<FooterBarProps> = ({
   const _ = useTranslation();
   const { appService } = useEnv();
   const { getConfig, setConfig, getBookData } = useBookDataStore();
-  const { hoveredBookKey, setHoveredBookKey } = useReaderStore();
+  const { hoveredBookKey, setHoveredBookKey, bottomBarTab, setBottomBarTab } = useReaderStore();
   const { getView, getViewState, getProgress, getViewSettings } = useReaderStore();
   const { isSideBarVisible, isSideBarPinned, setSideBarVisible } = useSidebarStore();
   const { acquireBackKeyInterception, releaseBackKeyInterception } = useDeviceControlStore();
@@ -40,8 +40,7 @@ const FooterBar: React.FC<FooterBarProps> = ({
   const progress = getProgress(bookKey);
   const viewSettings = getViewSettings(bookKey);
 
-  const [userSelectedTab, setUserSelectedTab] = useState('');
-  const actionTab = hoveredBookKey === bookKey ? userSelectedTab : '';
+  const actionTab = hoveredBookKey === bookKey ? bottomBarTab : '';
   const isVisible = hoveredBookKey === bookKey;
 
   const docs = view?.renderer.getContents() ?? [];
@@ -101,7 +100,7 @@ const FooterBar: React.FC<FooterBarProps> = ({
 
   const handleSetActionTab = useCallback(
     (tab: string) => {
-      setUserSelectedTab((prevTab) => (prevTab === tab ? '' : tab));
+      setBottomBarTab(bottomBarTab === tab ? '' : tab);
 
       if (tab === 'tts') {
         if (viewState?.ttsEnabled) {
@@ -127,8 +126,10 @@ const FooterBar: React.FC<FooterBarProps> = ({
     [
       config,
       bookKey,
+      bottomBarTab,
       viewState?.ttsEnabled,
       setConfig,
+      setBottomBarTab,
       setSideBarVisible,
       setHoveredBookKey,
       handleSpeakText,

--- a/apps/readest-app/src/app/reader/components/footerbar/NavigationPanel.tsx
+++ b/apps/readest-app/src/app/reader/components/footerbar/NavigationPanel.tsx
@@ -61,9 +61,13 @@ export const NavigationPanel: React.FC<NavigationPanelProps> = ({
     'footerbar-progress-mobile not-eink:bg-base-200 eink:bg-base-100 absolute flex w-full flex-col items-center gap-y-8 px-4 transition-all',
     'eink:border-base-content eink:border-t',
     !forceMobileLayout && 'sm:hidden',
+    // Paddings stay constant in both states (the slide is transform-only) so
+    // offsetHeight always reports the panel's settled height; the TTS mini
+    // player measures it to stack above the expanded panel.
+    'pb-4 pt-8',
     actionTab === 'progress'
-      ? 'pointer-events-auto translate-y-0 pb-4 pt-8 ease-out'
-      : 'pointer-events-none invisible translate-y-full overflow-hidden pb-0 pt-0 ease-in',
+      ? 'pointer-events-auto translate-y-0 ease-out'
+      : 'pointer-events-none invisible translate-y-full overflow-hidden ease-in',
   );
 
   return (

--- a/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
@@ -58,6 +58,9 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
   }, [tts.showBackToCurrentTTSLocation]);
 
   const handleExpand = () => {
+    // The mini player mounts as soon as the session starts; the full sheet
+    // needs initialized clients (voices, timeline), so ignore taps until then.
+    if (!tts.ttsClientsInited) return;
     tts.refreshTtsLang();
     setShowPlayerSheet(true);
   };
@@ -91,8 +94,10 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
           </button>
         </div>
       )}
-      {/* One surface at a time: the sheet replaces the mini player while open. */}
-      {tts.showIndicator && tts.ttsClientsInited && !showPlayerSheet && (
+      {/* One surface at a time: the sheet replaces the mini player while open.
+          Mounts on showIndicator alone so the card appears the moment the
+          session starts, before the TTS clients finish initializing. */}
+      {tts.showIndicator && !showPlayerSheet && (
         <TTSMiniPlayer
           bookKey={bookKey}
           isPlaying={tts.isPlaying}

--- a/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { useLayoutEffect, useState } from 'react';
 import { MdClose, MdPauseCircleFilled, MdPlayCircleFilled } from 'react-icons/md';
 import { Insets } from '@/types/misc';
 import { useEnv } from '@/context/EnvContext';
@@ -49,7 +50,7 @@ const TTSMiniPlayer = ({
 }: TTSMiniPlayerProps) => {
   const _ = useTranslation();
   const { appService } = useEnv();
-  const { hoveredBookKey, setHoveredBookKey, getViewSettings } = useReaderStore();
+  const { hoveredBookKey, setHoveredBookKey, getViewSettings, bottomBarTab } = useReaderStore();
   const { getBookData } = useBookDataStore();
   const progress = useBookProgress(bookKey);
   const playback = usePlaybackInfo({ bookKey, isEink, onGetPlaybackInfo });
@@ -60,19 +61,43 @@ const TTSMiniPlayer = ({
   const book = getBookData(bookKey)?.book;
   const sectionLabel = progress?.sectionLabel;
 
-  // Stack above whatever occupies the bottom edge: the bottom bar while it is
-  // shown, the footer info band once it is dismissed, or a 16px resting
-  // offset. Mirrors FooterBar's mobile/desktop layout split (see
-  // forceMobileLayout there) to pick the right bar height.
+  // Stack above whatever occupies the bottom edge: the bottom bar (or its
+  // expanded action panel) while it is shown, the footer info band once it is
+  // dismissed, or a 16px resting offset. Mirrors FooterBar's mobile/desktop
+  // layout split (see forceMobileLayout there) to pick the right bar height.
   const viewSettings = getViewSettings(bookKey);
+  const barVisible = hoveredBookKey === bookKey;
+  const safeAreaMargin = appService?.hasSafeAreaInset ? gridInsets.bottom * 0.33 : 0;
   const forceMobileLayout =
     !!appService?.isMobile && window.innerWidth >= 640 && window.innerWidth <= window.innerHeight;
   const usesMobileBar = forceMobileLayout || window.innerWidth < 640 || window.innerHeight < 640;
+
+  // Distance from the bottom edge (safe-area margin excluded) to the top of
+  // the expanded action panel, so the card rides above it. Measured from the
+  // DOM because panel heights are content-driven and their anchor differs per
+  // platform. The panels' paddings are constant and the slide is
+  // transform-only, so subtracting the in-flight translate yields the settled
+  // top edge even mid-animation.
+  const [panelTopOffset, setPanelTopOffset] = useState(0);
+  useLayoutEffect(() => {
+    const cell = document.getElementById(`gridcell-${bookKey}`);
+    const panel =
+      barVisible && bottomBarTab ? cell?.querySelector(`.footerbar-${bottomBarTab}-mobile`) : null;
+    const rect = panel?.getBoundingClientRect();
+    if (!cell || !panel || !rect || rect.height === 0) {
+      setPanelTopOffset(0);
+      return;
+    }
+    const transform = getComputedStyle(panel).transform;
+    const translateY = transform && transform !== 'none' ? new DOMMatrixReadOnly(transform).m42 : 0;
+    const settledTop = rect.top - translateY;
+    setPanelTopOffset(
+      Math.max(0, Math.round(cell.getBoundingClientRect().bottom - settledTop - safeAreaMargin)),
+    );
+  }, [barVisible, bottomBarTab, bookKey, safeAreaMargin]);
+
   const bottomOffset = viewSettings
-    ? getTTSMiniPlayerBottomOffset(viewSettings, {
-        barVisible: hoveredBookKey === bookKey,
-        usesMobileBar,
-      })
+    ? getTTSMiniPlayerBottomOffset(viewSettings, { barVisible, usesMobileBar, panelTopOffset })
     : 16;
 
   const { ready, position, total, measuredFraction } = playback;
@@ -94,12 +119,12 @@ const TTSMiniPlayer = ({
       role='status'
       aria-label={`${_('Reading aloud')}: ${book?.title ?? ''}`}
       className={clsx(
-        'absolute z-40 inset-x-2 sm:inset-x-0 sm:mx-auto sm:w-full sm:max-w-md',
+        'absolute z-40 inset-x-4 sm:inset-x-0 sm:mx-auto sm:w-full sm:max-w-md',
         'pointer-events-auto transition-[bottom] duration-300',
       )}
       style={{
         bottom: `${bottomOffset}px`,
-        marginBottom: appService?.hasSafeAreaInset ? `${gridInsets.bottom * 0.33}px` : 0,
+        marginBottom: `${safeAreaMargin}px`,
       }}
       onMouseEnter={() => !appService?.isMobile && setHoveredBookKey('')}
       onTouchStart={() => !appService?.isMobile && setHoveredBookKey('')}

--- a/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
@@ -11,10 +11,7 @@ import { formatPlaybackTime } from '@/utils/time';
 import { TTSPlaybackInfo, usePlaybackInfo } from './usePlaybackInfo';
 import { useCountdownLabel } from './useCountdownLabel';
 import { BsFastForwardFill, BsRewindFill } from 'react-icons/bs';
-
-// Reader text reserves this much bottom clearance while a session is active
-// (card height + bottom gap); FoliateViewer consumes it via applyMarginAndGap.
-export const TTS_MINI_PLAYER_CLEARANCE = 64;
+import { getTTSMiniPlayerBottomOffset } from '../../utils/ttsMiniPlayerPosition';
 
 type TTSMiniPlayerProps = {
   bookKey: string;
@@ -52,7 +49,7 @@ const TTSMiniPlayer = ({
 }: TTSMiniPlayerProps) => {
   const _ = useTranslation();
   const { appService } = useEnv();
-  const { hoveredBookKey, setHoveredBookKey } = useReaderStore();
+  const { hoveredBookKey, setHoveredBookKey, getViewSettings } = useReaderStore();
   const { getBookData } = useBookDataStore();
   const progress = useBookProgress(bookKey);
   const playback = usePlaybackInfo({ bookKey, isEink, onGetPlaybackInfo });
@@ -60,9 +57,23 @@ const TTSMiniPlayer = ({
   const iconSize20 = useResponsiveSize(20);
   const iconSize40 = useResponsiveSize(40);
 
-  const isVisible = hoveredBookKey !== bookKey;
   const book = getBookData(bookKey)?.book;
   const sectionLabel = progress?.sectionLabel;
+
+  // Stack above whatever occupies the bottom edge: the bottom bar while it is
+  // shown, the footer info band once it is dismissed, or a 16px resting
+  // offset. Mirrors FooterBar's mobile/desktop layout split (see
+  // forceMobileLayout there) to pick the right bar height.
+  const viewSettings = getViewSettings(bookKey);
+  const forceMobileLayout =
+    !!appService?.isMobile && window.innerWidth >= 640 && window.innerWidth <= window.innerHeight;
+  const usesMobileBar = forceMobileLayout || window.innerWidth < 640 || window.innerHeight < 640;
+  const bottomOffset = viewSettings
+    ? getTTSMiniPlayerBottomOffset(viewSettings, {
+        barVisible: hoveredBookKey === bookKey,
+        usesMobileBar,
+      })
+    : 16;
 
   const { ready, position, total, measuredFraction } = playback;
   const forceHours = total >= 3600;
@@ -83,11 +94,11 @@ const TTSMiniPlayer = ({
       role='status'
       aria-label={`${_('Reading aloud')}: ${book?.title ?? ''}`}
       className={clsx(
-        'absolute bottom-2 z-40 inset-x-2 sm:inset-x-0 sm:mx-auto sm:w-full sm:max-w-md',
-        'transition-opacity duration-300',
-        isVisible ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0',
+        'absolute z-40 inset-x-2 sm:inset-x-0 sm:mx-auto sm:w-full sm:max-w-md',
+        'pointer-events-auto transition-[bottom] duration-300',
       )}
       style={{
+        bottom: `${bottomOffset}px`,
         marginBottom: appService?.hasSafeAreaInset ? `${gridInsets.bottom * 0.33}px` : 0,
       }}
       onMouseEnter={() => !appService?.isMobile && setHoveredBookKey('')}

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -750,7 +750,11 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
         // disqualifies the app from Now Playing and fought the claim.
         setTtsClientsInitialized(false);
 
+        // Show the mini player immediately, in the "playing" state: client
+        // init below can take a while and the session is conceptually already
+        // starting. The catch handler rolls both back if the start fails.
         setShowIndicator(true);
+        setIsPlaying(true);
         const ttsController = new TTSController(
           appService,
           view,
@@ -797,10 +801,15 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
           ttsController.setParagraphGap(viewSettings.ttsParagraphGap ?? DEFAULT_PARAGRAPH_GAP_SEC);
           ttsController.speak(ssml, oneTime, () => handleStop(bookKey));
           ttsController.setTargetLang(getTTSTargetLang() || '');
+        } else {
+          // Nothing to speak: roll back the optimistic playing state.
+          setIsPlaying(false);
         }
         setTtsClientsInitialized(true);
         setTTSEnabled(bookKey, true);
       } catch (error) {
+        setShowIndicator(false);
+        setIsPlaying(false);
         eventDispatcher.dispatch('toast', {
           message: _('TTS not supported for this document'),
           type: 'error',

--- a/apps/readest-app/src/app/reader/utils/ttsMiniPlayerPosition.ts
+++ b/apps/readest-app/src/app/reader/utils/ttsMiniPlayerPosition.ts
@@ -1,0 +1,32 @@
+import type { ViewSettings } from '@/types/book';
+import { footerInfoVisible } from './footerBand';
+
+// Card height of the TTS mini player (h-14). Reader text reserves this plus
+// the bottom offset below as clearance while a session is active;
+// FoliateViewer consumes it via applyMarginAndGap.
+export const TTS_MINI_PLAYER_HEIGHT = 56;
+
+// 64px mobile nav bar / 52px desktop footer bar, plus an 8px gap.
+const ABOVE_MOBILE_BAR = 72;
+const ABOVE_DESKTOP_BAR = 60;
+const BASE_OFFSET = 16;
+
+/**
+ * Bottom offset (px) of the TTS mini player, excluding the safe-area inset
+ * (applied separately as margin-bottom). The card stays visible for the whole
+ * session and stacks above whatever occupies the bottom edge:
+ *   - the bottom bar while it is shown (hoveredBookKey === bookKey)
+ *   - the footer info band / floating pills once the bar is dismissed
+ *   - otherwise a 16px resting offset above the bottom edge
+ */
+export const getTTSMiniPlayerBottomOffset = (
+  viewSettings: ViewSettings,
+  { barVisible = false, usesMobileBar = false } = {},
+): number => {
+  if (barVisible) return usesMobileBar ? ABOVE_MOBILE_BAR : ABOVE_DESKTOP_BAR;
+  const footerAtBottom =
+    viewSettings.showFooter &&
+    !viewSettings.vertical &&
+    (footerInfoVisible(viewSettings) || viewSettings.showStickyProgressBar);
+  return footerAtBottom ? Math.max(viewSettings.marginBottomPx, BASE_OFFSET) : BASE_OFFSET;
+};

--- a/apps/readest-app/src/app/reader/utils/ttsMiniPlayerPosition.ts
+++ b/apps/readest-app/src/app/reader/utils/ttsMiniPlayerPosition.ts
@@ -9,21 +9,27 @@ export const TTS_MINI_PLAYER_HEIGHT = 56;
 // 64px mobile nav bar / 52px desktop footer bar, plus an 8px gap.
 const ABOVE_MOBILE_BAR = 72;
 const ABOVE_DESKTOP_BAR = 60;
+const PANEL_GAP = 8;
 const BASE_OFFSET = 16;
 
 /**
  * Bottom offset (px) of the TTS mini player, excluding the safe-area inset
  * (applied separately as margin-bottom). The card stays visible for the whole
  * session and stacks above whatever occupies the bottom edge:
- *   - the bottom bar while it is shown (hoveredBookKey === bookKey)
+ *   - the bottom bar while it is shown (hoveredBookKey === bookKey), or the
+ *     expanded action panel above it (panelTopOffset: measured distance from
+ *     the bottom edge to the open panel's top, safe-area margin excluded)
  *   - the footer info band / floating pills once the bar is dismissed
  *   - otherwise a 16px resting offset above the bottom edge
  */
 export const getTTSMiniPlayerBottomOffset = (
   viewSettings: ViewSettings,
-  { barVisible = false, usesMobileBar = false } = {},
+  { barVisible = false, usesMobileBar = false, panelTopOffset = 0 } = {},
 ): number => {
-  if (barVisible) return usesMobileBar ? ABOVE_MOBILE_BAR : ABOVE_DESKTOP_BAR;
+  if (barVisible) {
+    const aboveBar = usesMobileBar ? ABOVE_MOBILE_BAR : ABOVE_DESKTOP_BAR;
+    return Math.max(aboveBar, panelTopOffset + PANEL_GAP);
+  }
   const footerAtBottom =
     viewSettings.showFooter &&
     !viewSettings.vertical &&

--- a/apps/readest-app/src/store/readerStore.ts
+++ b/apps/readest-app/src/store/readerStore.ts
@@ -67,8 +67,13 @@ interface ReaderStore {
   viewStates: { [key: string]: ViewState };
   bookKeys: string[];
   hoveredBookKey: string | null;
+  /* The action tab selected in the mobile bottom bar (font/color/progress);
+     lives here rather than in FooterBar state so the TTS mini player can
+     stack above the expanded panel. Persists across bar hide/show. */
+  bottomBarTab: string;
   setBookKeys: (keys: string[]) => void;
   setHoveredBookKey: (key: string | null) => void;
+  setBottomBarTab: (tab: string) => void;
   setBookmarkRibbonVisibility: (key: string, visible: boolean) => void;
   setTTSEnabled: (key: string, enabled: boolean) => void;
   setAutoScrollEnabled: (key: string, enabled: boolean) => void;
@@ -113,8 +118,10 @@ export const useReaderStore = create<ReaderStore>((set, get) => ({
   viewStates: {},
   bookKeys: [],
   hoveredBookKey: null,
+  bottomBarTab: '',
   setBookKeys: (keys: string[]) => set({ bookKeys: keys }),
   setHoveredBookKey: (key: string | null) => set({ hoveredBookKey: key }),
+  setBottomBarTab: (tab: string) => set({ bottomBarTab: tab }),
   getView: (key: string | null) => (key && get().viewStates[key]?.view) || null,
   setView: (key: string, view) =>
     set((state) => ({


### PR DESCRIPTION
Fixes #5032

The TTS mini player covered the footer info line (pages left in chapter / reading progress) at the bottom of the reader, and it only appeared once the TTS clients finished initializing, which can take noticeably long on a cold start.

### Changes

- **Immediate mount**: the mini player now mounts the moment the session starts (gated on `showIndicator` alone), with an optimistic playing state. A failed start or an empty section rolls the indicator and playing state back, so no zombie card is left behind. Expanding to the full player sheet still waits for initialized clients since it needs voices and the timeline.
- **Stacks above the bottom bar**: while the bottom bar is shown (`hoveredBookKey` set), the card stays visible and rides above the bar (64px mobile nav bar / 52px desktop bar, plus an 8px gap) instead of fading out. The position animates with the same 300ms timing as the bar.
- **Stacks above expanded panels**: when a mobile action panel (font, color, progress) is expanded from the nav bar, the card floats 8px above the panel's top edge. The selected tab moved from FooterBar local state into the reader store so the card can react; the panel's settled top is measured from the DOM (panel paddings are now constant in both states, making the slide transform-only and the measurement stable mid-animation).
- **Rests on the footer band**: once the bottom bar is dismissed, the card sits exactly on top of the footer info band (`max(marginBottomPx, 16)`, including the floating pills in scrolled mode), keeping the pages-left line readable, which is what #5032 asked for.
- **16px fallback**: with Show Footer off (or vertical writing mode, where the footer is a side column), the card rests 16px above the bottom edge. Safe-area insets are still applied separately as margin.
- **Wider insets**: the card's horizontal insets grew from 8px to 16px on small screens.
- **Text clearance follows**: `FoliateViewer` now reserves `bottom offset + card height (56px)` of clearance while a session is active, replacing the flat `TTS_MINI_PLAYER_CLEARANCE = 64` constant, since the card stacks above the band instead of overlaying it.

The offset logic lives in a new pure helper, `src/app/reader/utils/ttsMiniPlayerPosition.ts`, shared by `TTSMiniPlayer` and `FoliateViewer`.

### Testing

- New unit tests for the offset helper (13 cases) plus updated `TTSMiniPlayer`/`TTSControl` tests covering the pre-init mount, panel stacking, and positioning; full suite passes (7574 tests), `pnpm lint` and `pnpm format:check` clean.
- Verified live in Chrome (desktop layout): the card mounted 74ms after tapping Speak (well before client init), measured `bottom: 60px` with the bar open, `bottom: 44px` flush with the footer band top (0px gap) with the bar dismissed, and `bottom: 16px` with Show Footer disabled.
- Verified on a Pixel 9 Pro emulator (release APK with devtools, driven over CDP with real taps): card mounted immediately on Speak, `bottom: 72px` with an exact 8px gap above the nav bar, jumped to `bottom: 240px` with an exact 8px gap above the expanded Font & Layout panel, rested flush on the footer band (0px gap, pages-left line readable) after dismissing the bars, and kept 16px horizontal insets throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)