### PR TITLE
fix: fix param name typo

### DIFF
--- a/apps/readest-app/src/components/settings/ThemePanel.tsx
+++ b/apps/readest-app/src/components/settings/ThemePanel.tsx
@@ -244,7 +244,7 @@ const ThemePanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset
           light: generateLightPalette(customTheme.colors.light),
           dark: generateDarkPalette(customTheme.colors.dark),
         },
-        isCustomizale: true,
+        isCustomizable: true,
       })),
     );
   }, [settings]);

--- a/apps/readest-app/src/components/settings/color/ThemeColorSelector.tsx
+++ b/apps/readest-app/src/components/settings/color/ThemeColorSelector.tsx
@@ -32,7 +32,7 @@ const ThemeColorSelector: React.FC<ThemeColorSelectorProps> = ({
     <div>
       <SectionTitle className='mb-2'>{_('Theme Color')}</SectionTitle>
       <div className='grid grid-cols-3 gap-4'>
-        {themes.map(({ name, label, colors, isCustomizale }) => (
+        {themes.map(({ name, label, colors, isCustomizable }) => (
           <button
             key={name}
             tabIndex={0}
@@ -71,7 +71,7 @@ const ThemeColorSelector: React.FC<ThemeColorSelectorProps> = ({
               <MdRadioButtonUnchecked size={iconSize24} />
             )}
             <span className='max-w-full truncate'>{_(label)}</span>
-            {isCustomizale && themeColor === name && (
+            {isCustomizable && themeColor === name && (
               <button onClick={() => onEditTheme(name)}>
                 <CgColorPicker size={iconSize16} className='absolute right-2 top-2' />
               </button>

--- a/apps/readest-app/src/styles/themes.ts
+++ b/apps/readest-app/src/styles/themes.ts
@@ -27,7 +27,7 @@ export type Theme = {
     light: Palette;
     dark: Palette;
   };
-  isCustomizale?: boolean;
+  isCustomizable?: boolean;
 };
 
 export type CustomTheme = {


### PR DESCRIPTION
A very necessary and urgent fix that changes `isCustomizale` to `isCustomizable`.

Also getting these failing tests that have nothing to do w my changes:

```plaintext
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/__tests__/document/pdf-canvas-memory-cap.test.ts > PDF canvas memory cap (#5118) > does not scale the DOM (no transform / zoom on the page)
AssertionError: expected 'scale(0.3333333333333333)' to be '' // Object.is equality

- Expected
+ Received

+ scale(0.3333333333333333)

 ❯ src/__tests__/document/pdf-canvas-memory-cap.test.ts:121:35
    119|     const { canvas } = await renderPageCanvas(3, 0.64);
    120|     const docEl = canvas.ownerDocument.documentElement;
    121|     expect(docEl.style.transform).toBe('');
       |                                   ^
    122|     expect(docEl.style.zoom).toBe('');
    123|   });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/5]⎯

 FAIL  src/__tests__/document/pdf-canvas-memory-cap.test.ts > PDF canvas memory cap (#5118) > clamps the bitmap to MAX_RENDER_DPR on a high-dpr phone, CSS box stays display size
AssertionError: expected 0.9999659586056645 to be close to 2, received difference is 1.0000340413943354, but expected 0.005
 ❯ src/__tests__/document/pdf-canvas-memory-cap.test.ts:133:23
    131|
    132|     // Bitmap is over-sampled at the clamped dpr, not the full device dpr.
    133|     expect(renderDpr).toBeCloseTo(MAX_RENDER_DPR, 2);
       |                       ^
    134|     expect(renderDpr).toBeLessThan(dpr);
    135|     expect(canvas.width).toBeCloseTo(PAGE_W * zoom * MAX_RENDER_DPR, 0);

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/5]⎯

 FAIL  src/__tests__/document/pdf-canvas-memory-cap.test.ts > PDF canvas memory cap (#5118) > clamps the bitmap area to MAX_CANVAS_PIXELS on a large page
AssertionError: expected 4961572 to be less than or equal to 3153920
 ❯ src/__tests__/document/pdf-canvas-memory-cap.test.ts:153:42
    151|     // Even at dpr 2 this page is over budget, so the render dpr drops below 2.
    152|     expect(renderDpr).toBeLessThan(MAX_RENDER_DPR);
    153|     expect(canvas.width * canvas.height).toBeLessThanOrEqual(MAX_CANVAS_PIXELS + 8192);
       |                                          ^
    154|     // Aspect ratio and display box are preserved.
    155|     expect(canvas.width / canvas.height).toBeCloseTo(PAGE_W / PAGE_H, 2);

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/5]⎯

 FAIL  src/__tests__/document/pdf-canvas-memory-cap.test.ts > PDF canvas memory cap (#5118) > over-samples at exactly the device dpr when already within budget (desktop dpr 2)
AssertionError: expected 1 to be close to 2, received difference is 1, but expected 0.005
 ❯ src/__tests__/document/pdf-canvas-memory-cap.test.ts:166:23
    164|     expect(canvas).toBeTruthy();
    165|
    166|     expect(renderDpr).toBeCloseTo(dpr, 2);
       |                       ^
    167|     expect(canvas.width).toBeCloseTo(PAGE_W * zoom * dpr, 0);
    168|     expect(canvas.height).toBeCloseTo(PAGE_H * zoom * dpr, 0);

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/5]⎯

 FAIL  src/__tests__/document/pdf-spread-seam.test.ts > PDF spread canvas seam (#4587) > sizes the page canvas to fill its box exactly at fractional devicePixelRatio
AssertionError: expected 782.4114 to be close to 521.6075999999999, received difference is 260.8038, but expected 0.0005
 ❯ src/__tests__/document/pdf-spread-seam.test.ts:133:44
    131|     // no white seam. The browser scales the over-sampled bitmap to fill the box.
    132|     expect(canvas.style.width).not.toBe('');
    133|     expect(parseFloat(canvas.style.width)).toBeCloseTo(pageBoxWidth, 3);
       |                                            ^
    134|   });
    135| });
```

...I'm sure that's nothing to worry about, right?