### PR TITLE
fix(tts): keep Android system TTS reading with the screen locked (#4408)

### DIFF
--- a/apps/readest-app/src/__tests__/services/tts-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller.test.ts
@@ -26,6 +26,16 @@ vi.mock('@/services/tts/NativeTTSClient', () => ({
   }),
 }));
 
+// Track the inaudible background keep-alive (WebAudio) toggled for direct-speak
+// engines. Arrow closures so the vi.mock hoist never hits a TDZ on these consts.
+const startKeepAlive = vi.fn();
+const stopKeepAlive = vi.fn();
+vi.mock('@/services/tts/WebAudioPlayer', async (importActual) => ({
+  ...(await importActual<typeof import('@/services/tts/WebAudioPlayer')>()),
+  startAudioKeepAlive: () => startKeepAlive(),
+  stopAudioKeepAlive: () => stopKeepAlive(),
+}));
+
 vi.mock('@/services/tts/TTSUtils', () => ({
   TTSUtils: {
     getPreferredClient: vi.fn().mockReturnValue(null),
@@ -1247,6 +1257,73 @@ describe('TTSController', () => {
       await new Promise((r) => setTimeout(r, 150));
       expect(c.state).not.toBe('playing');
       expect(state.attempts).toBeLessThanOrEqual(10);
+    });
+  });
+
+  describe('native TTS background keep-alive (#4408)', () => {
+    // Android controller whose ACTIVE client is the direct-speak native engine
+    // (mediaClock === false): its audio renders in the OS, not the WebView.
+    const makeAndroidNativeController = async () => {
+      const c = new TTSController(createMockAppService(true), mockView);
+      await c.init();
+      c.ttsClient = c.ttsNativeClient!;
+      await c.initViewTTS(0);
+      return c;
+    };
+
+    test('starts an inaudible keep-alive when native TTS begins playing on Android', async () => {
+      const c = await makeAndroidNativeController();
+      vi.spyOn(c, 'forward').mockResolvedValue();
+
+      c.speak('<speak>hello</speak>');
+
+      await vi.waitFor(() => expect(startKeepAlive).toHaveBeenCalled(), { timeout: 5000 });
+      expect(c.state).toBe('playing');
+      expect(stopKeepAlive).not.toHaveBeenCalled();
+    });
+
+    test('does not keep the WebView awake for a buffered (Edge) engine — it emits its own audio', async () => {
+      const c = await makeAndroidNativeController();
+      c.ttsClient = c.ttsEdgeClient; // mediaClock === true
+      vi.spyOn(c, 'forward').mockResolvedValue();
+
+      c.speak('<speak>hello</speak>');
+
+      await vi.waitFor(() => expect(c.state).toBe('playing'), { timeout: 5000 });
+      expect(startKeepAlive).not.toHaveBeenCalled();
+    });
+
+    test('does not start the keep-alive off Android', async () => {
+      // Default controller: appService.isAndroidApp === false, web engine.
+      await controller.initViewTTS(0);
+      vi.spyOn(controller, 'forward').mockResolvedValue();
+
+      controller.speak('<speak>hello</speak>');
+
+      await vi.waitFor(() => expect(controller.state).toBe('playing'), { timeout: 5000 });
+      expect(startKeepAlive).not.toHaveBeenCalled();
+    });
+
+    test('stops the keep-alive when playback is paused', async () => {
+      const c = await makeAndroidNativeController();
+      vi.spyOn(c, 'forward').mockResolvedValue();
+      c.speak('<speak>hello</speak>');
+      await vi.waitFor(() => expect(startKeepAlive).toHaveBeenCalled(), { timeout: 5000 });
+
+      await c.pause();
+
+      expect(stopKeepAlive).toHaveBeenCalled();
+    });
+
+    test('stops the keep-alive on shutdown', async () => {
+      const c = await makeAndroidNativeController();
+      vi.spyOn(c, 'forward').mockResolvedValue();
+      c.speak('<speak>hello</speak>');
+      await vi.waitFor(() => expect(startKeepAlive).toHaveBeenCalled(), { timeout: 5000 });
+
+      await c.shutdown();
+
+      expect(stopKeepAlive).toHaveBeenCalled();
     });
   });
 

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -17,6 +17,7 @@ import { SectionTimeline, TimelineSentence } from './SectionTimeline';
 import { DownloadableSentence, SectionEnumerator, TTSDownloader } from './TTSDownloader';
 import { TTSUtils } from './TTSUtils';
 import { TTSClient } from './TTSClient';
+import { startAudioKeepAlive, stopAudioKeepAlive } from './WebAudioPlayer';
 import { isValidLang } from '@/utils/lang';
 import {
   computeWordOffsets,
@@ -228,9 +229,28 @@ export class TTSController extends EventTarget {
   #terminate(reason: 'ended' | 'error') {
     if (this.#terminated) return;
     this.#terminated = true;
+    stopAudioKeepAlive();
     queueMicrotask(() => {
       this.dispatchEvent(new CustomEvent('tts-session-ended', { detail: { reason } }));
     });
+  }
+
+  // A direct-speak engine (Android system TTS) renders its audio in the OS, not
+  // the WebView, and advances sentence-to-sentence from JS timers here. With the
+  // screen locked the hidden WebView would be throttled/frozen and that loop
+  // stalls — so keep an inaudible tone playing to hold the page "audible" and
+  // its timers alive, exactly the exemption Edge/WebAudio playback earns for
+  // free. Android-only (iOS drives playout through its own native audio
+  // session); a no-op for buffered engines that already emit audible output.
+  // See #4408.
+  #syncNativeAudioKeepAlive() {
+    const needsKeepAlive =
+      !!this.appService?.isAndroidApp && this.ttsClient.getCapabilities().mediaClock === false;
+    if (needsKeepAlive) {
+      startAudioKeepAlive();
+    } else {
+      stopAudioKeepAlive();
+    }
   }
 
   get isViewAttached(): boolean {
@@ -816,6 +836,7 @@ export class TTSController extends EventTarget {
       try {
         console.log('[TTS] speak');
         this.state = 'playing';
+        this.#syncNativeAudioKeepAlive();
 
         signal.addEventListener('abort', () => {
           resolve();
@@ -969,6 +990,7 @@ export class TTSController extends EventTarget {
 
   async pause() {
     this.state = 'paused';
+    stopAudioKeepAlive();
     if (!(await this.ttsClient.pause().catch((e) => this.error(e)))) {
       await this.stop();
       this.state = 'stop-paused';
@@ -1316,6 +1338,7 @@ export class TTSController extends EventTarget {
   }
 
   async shutdown() {
+    stopAudioKeepAlive();
     await this.stop();
     this.#clearAllHighlights();
     this.#ttsSectionIndex = -1;

--- a/apps/readest-app/src/services/tts/WebAudioPlayer.ts
+++ b/apps/readest-app/src/services/tts/WebAudioPlayer.ts
@@ -125,6 +125,59 @@ export const ensureSharedAudioContext = async (): Promise<void> => {
   }
 };
 
+// Inaudible background keep-alive for direct-speak engines (Android system TTS).
+//
+// When the screen locks the WebView page becomes hidden, and Chromium throttles
+// (and eventually freezes) a hidden page's timers and task queues — which stalls
+// the JS-driven per-sentence auto-advance loop that direct-speak engines rely on
+// (their audio renders in the external TTS engine, not the WebView). A page that
+// is emitting audio is exempt from that throttling: that is precisely why Edge
+// TTS keeps reading with the screen off (its speech is audible WebAudio output)
+// while system TTS stops after a page. Merely having a running-but-idle context
+// does NOT earn the exemption — Chromium keys off actual, non-silent output — so
+// we play a continuous 40 Hz tone at ~-62 dBFS: below the reach of phone
+// speakers and masked to inaudibility by the speech, but non-silent enough to
+// keep the page "audible" and its timers alive. See #4408.
+const KEEP_ALIVE_FREQ_HZ = 40;
+const KEEP_ALIVE_GAIN = 0.0008;
+let keepAliveOsc: OscillatorNode | null = null;
+let keepAliveGain: GainNode | null = null;
+
+export const startAudioKeepAlive = (): void => {
+  if (typeof AudioContext === 'undefined') return;
+  if (keepAliveOsc) return;
+  try {
+    const ctx = getSharedContext() as unknown as AudioContext;
+    // The gesture handler already resumed the shared context; nudge it best-
+    // effort in case autoplay policy left it suspended.
+    if (ctx.state !== 'running') void ctx.resume();
+    const osc = ctx.createOscillator();
+    osc.frequency.value = KEEP_ALIVE_FREQ_HZ;
+    const gain = ctx.createGain();
+    gain.gain.value = KEEP_ALIVE_GAIN;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    keepAliveOsc = osc;
+    keepAliveGain = gain;
+  } catch (err) {
+    console.warn('[TTS] audio keep-alive start failed', err);
+  }
+};
+
+export const stopAudioKeepAlive = (): void => {
+  if (!keepAliveOsc && !keepAliveGain) return;
+  try {
+    keepAliveOsc?.stop();
+    keepAliveOsc?.disconnect();
+    keepAliveGain?.disconnect();
+  } catch (err) {
+    console.warn('[TTS] audio keep-alive stop failed', err);
+  }
+  keepAliveOsc = null;
+  keepAliveGain = null;
+};
+
 export class WebAudioPlayer implements TTSAudioPlayer {
   #createContext: () => TTSAudioContext;
   #usesSharedContext: boolean;

--- a/apps/readest-app/src/services/tts/index.ts
+++ b/apps/readest-app/src/services/tts/index.ts
@@ -5,7 +5,11 @@ export * from './EdgeTTSClient';
 export * from './NativeTTSClient';
 export * from './TTSController';
 export * from './TTSData';
-export { ensureSharedAudioContext } from './WebAudioPlayer';
+export {
+  ensureSharedAudioContext,
+  startAudioKeepAlive,
+  stopAudioKeepAlive,
+} from './WebAudioPlayer';
 export * from './TTSSessionManager';
 export { ttsMediaBridge, unblockAudio, releaseUnblockAudio } from './ttsMediaBridge';
 export { SectionTimeline } from './SectionTimeline';


### PR DESCRIPTION
## Problem

Fixes #4408. The screen-ON dead-end was fixed in #4716; this addresses the reporter's follow-up: with the **screen locked**, Android system TTS reads about a page and then stops, while Edge TTS keeps reading fine.

## Root cause

System TTS renders its audio in the external Android TextToSpeech engine (a separate process), so the WebView emits no audio of its own — it only orchestrates, advancing sentence to sentence from JS timers in the WebView. When the screen locks, the page becomes `hidden` and Chromium throttles its timers (and freezes the task queues entirely on stricter builds such as GrapheneOS/Vanadium), stalling that loop after roughly a page.

Edge TTS is unaffected because its speech *is* audible WebAudio output, and Chromium exempts any page that is emitting audio from background throttling/freezing. The foreground media service and silent ExoPlayer keep-alive keep the process and audio focus alive but do not make the WebView page "audible" — that is a per-page property Chromium derives from the page's own non-silent output.

## Fix

While a direct-speak engine (`mediaClock === false`) reads on Android, play a continuous **inaudible** 40 Hz tone (about -62 dBFS) on the shared audio context so the page stays audible to Chromium and its timers keep running with the screen off — the same exemption Edge gets for free.

- `WebAudioPlayer.ts`: `startAudioKeepAlive` / `stopAudioKeepAlive` (module-singleton oscillator, guarded for jsdom).
- `TTSController`: starts the tone when a native engine begins playing, stops it on pause, session end, and shutdown. No-op for Edge/WebAudio and on iOS (which drives playout through its own native audio session).

## Verification

Android emulator (Pixel 9, Android 16):
- Isolated mechanism: with the real TTS foreground service active but no WebView audio, a locked page's `setInterval` throttled to ~1s; adding an audible WebAudio output held it at 200 ms across the whole lock.
- End-to-end with this build driving real System TTS (Google offline embedded voice): TTS read continuously through a 75 s screen lock (22 synthesis requests, 6 paragraph advances, no stall); the page stayed largely un-throttled (476 timer ticks vs ~83 in the throttled baseline).

Unit tests added (`tts-controller.test.ts`, written test-first). Full suite green, lint clean.

Note: the emulator only exhibits the mild ~1s throttle in a short window, not the multi-minute freeze the reporter's device does, but it proves the throttle exists and that the keep-alive removes it — the same mechanism that becomes a full freeze on stricter devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)