### PR TITLE
fix(sync): sync WebDAV server URL for configured-but-disabled providers (#5141)

### DIFF
--- a/apps/readest-app/src/__tests__/services/sync/replicaSettingsSync.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/replicaSettingsSync.test.ts
@@ -445,35 +445,37 @@ describe('publishSettingsIfChanged', () => {
     expect(patch.hardcover?.accessToken).toBeUndefined();
   });
 
-  test('initSettingsSync(initialSettings) primes the snapshot so the first setSettings(disk_default) does not push', async () => {
+  test('initSettingsSync(initialSettings) primes the snapshot so structural disk defaults do not re-push', async () => {
     // Real-world bug: a fresh-install Device B's library boot calls
     // setSettings(disk_default) which fires publishSettingsIfChanged
-    // with an empty lastPublishedFields snapshot. Every whitelisted
-    // field looks "changed from undefined" and gets pushed to the
-    // server with a fresh HLC, overwriting the cross-device
+    // with an empty lastPublishedFields snapshot. Every structural
+    // whitelisted field looks "changed from undefined" and gets pushed
+    // to the server with a fresh HLC, overwriting the cross-device
     // authoritative values another device set. Disk-priming via
     // initSettingsSync(initialSettings) seeds the snapshot from the
-    // just-loaded disk so the same-value first publish is a no-op.
+    // just-loaded disk so the same-value first publish skips them.
+    //
+    // Credential connection metadata (webdav.rootPath, kosync.serverUrl, ...)
+    // is push-hash tracked, NOT disk-seeded, so it is intentionally exempt
+    // from this priming — that exemption is what lets a configured-but-never-
+    // published URL reach the other devices (#5141).
     const diskSettings = makeSettings({
       dictionarySettings: {
         providerOrder: ['builtin:wiktionary', 'builtin:wikipedia'],
         providerEnabled: { 'builtin:wiktionary': true, 'builtin:wikipedia': true },
         webSearches: [],
       },
-      kosync: {
-        serverUrl: 'https://sync.koreader.rocks/',
-        username: '',
-        userkey: '',
-        password: '',
-      } as SystemSettings['kosync'],
     } as Partial<SystemSettings>);
     initSettingsSync(diskSettings);
 
-    // The same disk_default replayed (typical library page initLibrary
-    // flow) — should produce no publish because every whitelisted
-    // field already matches the primed snapshot.
+    // The same disk_default replayed (typical library page initLibrary flow).
     await publishSettingsIfChanged(diskSettings);
-    expect(publishMock).not.toHaveBeenCalled();
+
+    // Structural fields primed from disk stay out of the diff — only the
+    // hash-tracked connection metadata (if any) may publish.
+    const patch = publishMock.mock.calls[0]?.[1].patch as Partial<SystemSettings> | undefined;
+    expect(patch?.dictionarySettings?.providerEnabled).toBeUndefined();
+    expect(patch?.globalReadSettings).toBeUndefined();
   });
 
   test('initSettingsSync priming does not block legitimate user changes against the seeded baseline', async () => {
@@ -501,6 +503,34 @@ describe('publishSettingsIfChanged', () => {
     expect(publishMock).toHaveBeenCalledTimes(1);
     const patch = publishMock.mock.calls[0]![1].patch as Partial<SystemSettings>;
     expect(patch.kosync?.serverUrl).toBe('https://kosync.example');
+  });
+
+  test('re-publishes a disk-configured connection URL that was never synced, so it rejoins its credentials (issue #5141)', async () => {
+    enableCredentialsSync();
+    isUnlocked = true;
+    // A device that configured WebDAV before serverUrl entered the sync
+    // whitelist (#4810): the URL + credentials are on disk at boot, but were
+    // never actually published to the server.
+    const disk = makeSettings({
+      webdav: {
+        serverUrl: 'https://dav.example.com',
+        username: 'alice',
+        password: 'hunter2',
+        rootPath: '/Books',
+      } as SystemSettings['webdav'],
+    });
+    initSettingsSync(disk);
+
+    // Any settings save re-runs the publisher. The credentials (no stored
+    // push-hash) publish; the server URL and root path MUST ride along
+    // rather than stay stranded on this device.
+    await publishSettingsIfChanged(disk);
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    const patch = publishMock.mock.calls[0]![1].patch as Partial<SystemSettings>;
+    expect(patch.webdav?.username).toBe('alice');
+    expect(patch.webdav?.password).toBe('hunter2');
+    expect(patch.webdav?.serverUrl).toBe('https://dav.example.com');
+    expect(patch.webdav?.rootPath).toBe('/Books');
   });
 
   test('does NOT trigger the gate when only plaintext settings change', async () => {

--- a/apps/readest-app/src/services/sync/replicaSettingsSync.ts
+++ b/apps/readest-app/src/services/sync/replicaSettingsSync.ts
@@ -6,12 +6,20 @@
  * Push side: `publishSettingsIfChanged(settings)` runs after every
  * settingsStore save. It walks the whitelist, diffs against the
  * snapshot, and emits a single replica upsert with only the changed
- * fields. Encrypted paths use a SHA-256 hash of the value as the
- * snapshot (persisted in localStorage so refresh-after-credential-set
- * doesn't re-fire the prompt). When the diff includes a new
- * non-empty encrypted value AND the CryptoSession is locked, we
- * proactively trigger the passphrase gate — that's the moment the
- * user is opting into encrypted-credential sync.
+ * fields. There are three tracking flavors:
+ *   * Plain settings diff against an in-memory `lastPublishedFields`
+ *     snapshot, seeded from disk at boot (see `initSettingsSync`).
+ *   * Encrypted paths use a SHA-256 hash of the value as the snapshot
+ *     (persisted in localStorage so refresh-after-credential-set doesn't
+ *     re-fire the prompt). When the diff includes a new non-empty
+ *     encrypted value AND the CryptoSession is locked, we proactively
+ *     trigger the passphrase gate — the moment the user opts into
+ *     encrypted-credential sync.
+ *   * Credential connection metadata (`CONNECTION_PATHS`: serverUrl,
+ *     endpoint, rootPath, ...) is plaintext but push-hash tracked like
+ *     the encrypted fields rather than disk-seeded, so a URL configured
+ *     before it was ever published still reaches the other devices
+ *     alongside its credentials (#5141).
  *
  * Pull side: `applyRemoteSettings(record)` merges a remote partial
  * into useSettingsStore, persists, and updates both snapshots so the
@@ -42,6 +50,32 @@ import { isCredentialsSyncEnabled } from '@/services/sync/syncCategories';
 import { useCustomDictionaryStore } from '@/store/customDictionaryStore';
 
 const ENCRYPTED_PATHS: ReadonlySet<string> = new Set(SETTINGS_ENCRYPTED_FIELDS);
+
+/**
+ * Plaintext connection metadata that belongs to a credential-bearing group
+ * (webdav.serverUrl / rootPath, s3.endpoint / region / bucket,
+ * kosync.serverUrl, readwise.baseUrl). Derived as: whitelisted, not itself
+ * encrypted, but sharing a top-level group with an encrypted field.
+ *
+ * These use the same persisted push-hash tracking as the encrypted fields
+ * (see below) rather than the disk-seeded `lastPublishedFields` snapshot. The
+ * snapshot marks any value already on disk at boot as "already published", so
+ * a URL that was configured before it entered the sync whitelist (#4810) — or
+ * before localStorage recorded a push — would be stranded on one device while
+ * its credentials (which have no stored hash, so they DO publish) sync to the
+ * others: the peer receives username/password but not the server URL (#5141).
+ * Hash tracking lets a never-published URL publish on the next save so it
+ * reunites with its credentials. Empty values stay local, mirroring the
+ * encrypted-field rule.
+ */
+const CREDENTIAL_GROUPS: ReadonlySet<string> = new Set(
+  SETTINGS_ENCRYPTED_FIELDS.map((path) => path.split('.')[0]!),
+);
+const CONNECTION_PATHS: ReadonlySet<string> = new Set(
+  SETTINGS_WHITELIST.filter(
+    (path) => !ENCRYPTED_PATHS.has(path) && CREDENTIAL_GROUPS.has(path.split('.')[0]!),
+  ),
+);
 
 const HASH_KEY_PREFIX = 'readest_settings_pushed_hash_v1:';
 const CIPHER_KEY = 'readest_settings_last_seen_cipher_v1';
@@ -199,10 +233,12 @@ const setStoredLastSeenCipher = (val: Record<string, string>): void => {
 
 export const publishSettingsIfChanged = async (settings: SystemSettings): Promise<void> => {
   // Pass 1: figure out what's changed. Plaintext paths use the
-  // in-memory snapshot; encrypted paths compare against the
-  // persisted SHA-256 hash so refresh-after-credential-set doesn't
-  // mistake a re-load for a fresh change.
+  // in-memory snapshot; encrypted paths AND credential connection
+  // metadata compare against the persisted SHA-256 hash so
+  // refresh-after-credential-set doesn't mistake a re-load for a fresh
+  // change (and a never-published URL isn't stranded — see #5141).
   const plainChanged: Record<string, unknown> = {};
+  const connectionChanged: Array<{ path: string; value: unknown; hash: string }> = [];
   const encryptedChanged: Array<{ path: string; value: unknown; hash: string }> = [];
   let hasNewEncryptedContent = false;
 
@@ -229,6 +265,15 @@ export const publishSettingsIfChanged = async (settings: SystemSettings): Promis
       if (currentHash === getStoredEncryptedHash(path)) continue;
       encryptedChanged.push({ path, value: current, hash: currentHash });
       hasNewEncryptedContent = true;
+    } else if (CONNECTION_PATHS.has(path)) {
+      // Credential connection metadata: tracked by a persisted push-hash like
+      // the encrypted fields (NOT the disk-seeded snapshot) so a URL that was
+      // configured before it was ever published still reaches the other
+      // devices alongside its credentials (#5141). Empty values stay local.
+      if (!isMeaningful(current)) continue;
+      const currentHash = await sha256Hex(current);
+      if (currentHash === getStoredEncryptedHash(path)) continue;
+      connectionChanged.push({ path, value: current, hash: currentHash });
     } else {
       // Auto-mutation gate: paths in PATHS_REQUIRING_EXPLICIT_PUBLISH
       // (currently dictionarySettings.providerOrder) only ship when a
@@ -256,7 +301,13 @@ export const publishSettingsIfChanged = async (settings: SystemSettings): Promis
     explicitPublishPending.delete(path);
   }
 
-  if (Object.keys(plainChanged).length === 0 && encryptedChanged.length === 0) return;
+  if (
+    Object.keys(plainChanged).length === 0 &&
+    connectionChanged.length === 0 &&
+    encryptedChanged.length === 0
+  ) {
+    return;
+  }
 
   // Proactive prompt: only fire when the user has actually entered a
   // meaningful encrypted value (not just blanked out) AND we don't
@@ -280,6 +331,9 @@ export const publishSettingsIfChanged = async (settings: SystemSettings): Promis
   for (const [path, value] of Object.entries(plainChanged)) {
     writePath(patch, path, value);
   }
+  for (const { path, value } of connectionChanged) {
+    writePath(patch, path, value);
+  }
   for (const { path, value } of encryptedChanged) {
     writePath(patch, path, value);
   }
@@ -288,6 +342,12 @@ export const publishSettingsIfChanged = async (settings: SystemSettings): Promis
     patch: patch as Partial<SystemSettings>,
   };
   void publishReplicaUpsert(SETTINGS_KIND, record, SETTINGS_REPLICA_ID);
+
+  // Connection metadata is plaintext — its publish always ships, so record
+  // its push-hash unconditionally.
+  for (const { path, hash } of connectionChanged) {
+    setStoredEncryptedHash(path, hash);
+  }
 
   // Persist hashes for encrypted paths only when the session is
   // unlocked (the publish actually ships their values). Otherwise
@@ -328,8 +388,9 @@ export const applyRemoteSettings = (
   for (const path of SETTINGS_WHITELIST) {
     const v = readPath(record.patch, path);
     if (v === undefined) continue;
-    if (ENCRYPTED_PATHS.has(path)) {
-      // Stored hash mirrors the just-applied plaintext.
+    if (ENCRYPTED_PATHS.has(path) || CONNECTION_PATHS.has(path)) {
+      // Both are push-hash tracked; the stored hash mirrors the just-applied
+      // plaintext so the post-save publish hook sees no diff.
       void sha256Hex(v).then((h) => setStoredEncryptedHash(path, h));
     } else {
       lastPublishedFields.set(path, v);
@@ -428,10 +489,12 @@ export const initSettingsSync = (initialSettings?: SystemSettings): void => {
     for (const path of SETTINGS_WHITELIST) {
       const v = readPath(initialSettings, path);
       if (v === undefined) continue;
-      // Encrypted paths use the persisted-hash mechanism that already
-      // survives reloads; plaintext paths are the ones that need
-      // in-memory priming.
-      if (!ENCRYPTED_PATHS.has(path)) {
+      // Encrypted paths and credential connection metadata both use the
+      // persisted-hash mechanism that already survives reloads; only the
+      // remaining plaintext paths need in-memory priming. (Seeding the
+      // connection fields here is what stranded a configured-but-unpublished
+      // URL — see CONNECTION_PATHS and #5141.)
+      if (!ENCRYPTED_PATHS.has(path) && !CONNECTION_PATHS.has(path)) {
         lastPublishedFields.set(path, v);
       }
     }

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -674,6 +674,17 @@ input[type='range'].slider-input {
   --tglbg: theme('colors.base-100') !important;
 }
 
+/* DaisyUI checkboxes on e-ink: the default unchecked border is a ~20%-opacity
+ * theme color that barely registers on a grayscale panel, so a configured-but-
+ * disabled control (e.g. a cloud sync provider's enable box, #5141) reads as
+ * empty space. Give the box a crisp 1px base-content outline so it stays
+ * visible when unchecked. Scoped to `.checkbox` so the `.toggle` switch keeps
+ * its own treatment. */
+[data-eink='true'] input[type='checkbox'].checkbox {
+  border-width: 1px !important;
+  border-color: theme('colors.base-content') !important;
+}
+
 /* Dictionary popup font size (#4443).
  *
  * `--dict-font-scale` is set per content card by DictionaryResultsView; `1`


### PR DESCRIPTION
Fixes #5141.

## Problem

Two issues from the report:

1. **Server URL not synced.** When a WebDAV server was configured but not enabled, the username and password synced to other devices but the server address did not, so the peer received half a config and could not reconnect.
2. **E-ink checkbox invisible.** On e-ink the enable checkbox for a configured-but-disabled cloud sync provider was not prominent enough.

## Root cause (sync)

In `replicaSettingsSync.ts`, plaintext and encrypted whitelisted settings used two different "was this already published?" trackers, and they diverge:

- Plaintext `webdav.serverUrl` / `rootPath` diff against an in-memory snapshot that `initSettingsSync` **seeds from disk at boot**, so any value already on disk is treated as already-published and never sent again unless it changes.
- Encrypted `webdav.username` / `password` use a persisted push-hash, so a value with **no stored hash** is treated as never-published and *is* sent on the next save.

When WebDAV was configured before `webdav.*` entered the sync whitelist (#4810) — or before localStorage recorded a push — the boot seeding stranded `serverUrl` / `rootPath` while the credentials synced normally. The peer received username/password but not the server address, exactly as reported. A fresh Connect always worked because there the URL goes from empty to set while the app runs, so it diffs.

## Fix

- Track credential **connection metadata** (`webdav.serverUrl` / `rootPath` plus the kosync/readwise/s3 equivalents, derived as "whitelisted, not encrypted, sharing a top-level group with an encrypted field") with the same persisted push-hash as the encrypted fields instead of the disk-seeded snapshot. A never-published URL now publishes on the next save and rejoins its credentials. Empty values stay local, mirroring the encrypted-field rule. Structural settings keep their disk-seeded clobber protection.
- Give DaisyUI `.checkbox` a crisp 1px `base-content` border in e-ink mode so a configured-but-disabled provider's enable box stays visible on grayscale panels. Scoped to `.checkbox` so the `.toggle` switch keeps its own treatment (`eink-bordered` is wrong here — its forced `base-100` background would wipe the checked fill).

## Tests

- Added a failing test first that reproduced the stranded URL (credentials publish, `serverUrl` does not), now passing.
- Rewrote one existing test whose fixture had encoded the buggy behavior (it used a disk-configured `kosync.serverUrl` to assert no-push) to instead assert that only structural fields stay out of the diff and that connection metadata is exempt from disk-seed priming.

## Verification

- `pnpm test` — 7565 passed / 9 skipped
- `pnpm lint` (tsgo + Biome) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)