### PR TITLE
fix(sync): create Google Drive files atomically to stop stranding "Untitled" files in the Drive root

### DIFF
--- a/apps/readest-app/src/__tests__/services/sync/providers/gdrive/GoogleDriveProvider.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/providers/gdrive/GoogleDriveProvider.test.ts
@@ -69,22 +69,19 @@ describe('GoogleDriveProvider — Drive transport', () => {
     expect(h.fetchMock).toHaveBeenCalledTimes(4);
   });
 
-  test('writeText uploads via create-then-name and auto-creates the parent folder', async () => {
+  test('writeText uploads via a multipart create and auto-creates the parent folder', async () => {
     const h = makeDrive();
     h.fetchMock
       .mockResolvedValueOnce(json({ files: [] })) // findChild('Readest') — missing
       .mockResolvedValueOnce(json({ id: 'RID' })) // createFolder('Readest')
       .mockResolvedValueOnce(json({ files: [folder('RID')] })) // re-query winner
       .mockResolvedValueOnce(json({ files: [] })) // findChild('new.json') — not exists
-      .mockResolvedValueOnce(json({ id: 'NID' })) // POST upload
-      .mockResolvedValueOnce(json({ id: 'NID' })); // PATCH name + reparent
+      .mockResolvedValueOnce(json({ id: 'NID' })); // multipart create
     await h.provider.writeText('/Readest/new.json', '{"a":1}');
-    expect(h.fetchMock).toHaveBeenCalledTimes(6);
+    expect(h.fetchMock).toHaveBeenCalledTimes(5);
     expect(h.method(1)).toBe('POST'); // create folder
-    expect(h.url(4)).toContain('uploadType=media');
-    expect(h.method(4)).toBe('POST'); // create file bytes
-    expect(h.url(5)).toContain('addParents=RID');
-    expect(h.method(5)).toBe('PATCH'); // name + reparent
+    expect(h.url(4)).toContain('uploadType=multipart');
+    expect(h.method(4)).toBe('POST'); // create file (metadata + bytes together)
   });
 
   test('list drains every nextPageToken page', async () => {
@@ -239,6 +236,70 @@ describe('GoogleDriveProvider — Drive transport', () => {
     expect(h.method(3)).toBe('PATCH');
   });
 
+  // #5147: the old create path POSTed the bytes unnamed (Drive materialises
+  // that as a file literally called "Untitled" in the user's Drive ROOT) and
+  // only a second PATCH named + reparented it. Any failure between the two —
+  // rate limit, network drop, app suspension — stranded the "Untitled" file
+  // where the user can see it. Metadata and bytes must travel in ONE request.
+  test('creating a new file sends name+parent and bytes in one multipart request (#5147)', async () => {
+    const h = makeDrive();
+    h.fetchMock
+      .mockResolvedValueOnce(json({ files: [folder('RID')] })) // findChild('Readest')
+      .mockResolvedValueOnce(json({ files: [] })) // findChild('new.json') — not exists
+      .mockResolvedValueOnce(json({ id: 'NID' })); // multipart create
+    await h.provider.writeText('/Readest/new.json', '{"a":1}');
+    expect(h.fetchMock).toHaveBeenCalledTimes(3);
+    expect(h.url(2)).toContain('uploadType=multipart');
+    expect(h.method(2)).toBe('POST');
+    const init = h.fetchMock.mock.calls[2]![1] as RequestInit;
+    const bodyText = new TextDecoder().decode(init.body as ArrayBuffer);
+    expect(bodyText).toContain('"name":"new.json"');
+    expect(bodyText).toContain('"parents":["RID"]');
+    expect(bodyText).toContain('{"a":1}');
+
+    // The created id is cached: a follow-up read is a single media GET.
+    h.fetchMock.mockResolvedValueOnce(text('AFTER'));
+    expect(await h.provider.readText('/Readest/new.json')).toBe('AFTER');
+    expect(h.url(3)).toContain('/NID?alt=media');
+  });
+
+  test('a failed create leaves nothing unnamed in the Drive root (#5147)', async () => {
+    const h = makeDrive();
+    h.fetchMock
+      .mockResolvedValueOnce(json({ files: [folder('RID')] })) // findChild('Readest')
+      .mockResolvedValueOnce(json({ files: [] })) // findChild('new.json') — not exists
+      .mockResolvedValue(json({ error: { errors: [{ reason: 'userRateLimitExceeded' }] } }, 403));
+    await expect(h.provider.writeText('/Readest/new.json', 'X')).rejects.toMatchObject({
+      code: 'NETWORK',
+    });
+    // Every upload attempt carried the name and target parent inline, so a
+    // failure creates no file at all — never an orphaned "Untitled" at root.
+    for (const call of h.fetchMock.mock.calls.slice(2)) {
+      expect(call[0] as string).toContain('uploadType=multipart');
+      const bodyText = new TextDecoder().decode((call[1] as RequestInit).body as ArrayBuffer);
+      expect(bodyText).toContain('"name":"new.json"');
+      expect(bodyText).toContain('"parents":["RID"]');
+    }
+  });
+
+  test('a large buffered create carries its metadata in a resumable session (#5147)', async () => {
+    const h = makeDrive();
+    const big = new Uint8Array(5 * 1024 * 1024 + 1);
+    h.fetchMock
+      .mockResolvedValueOnce(json({ files: [folder('RID')] })) // findChild('Readest')
+      .mockResolvedValueOnce(json({ files: [] })) // findChild('big.bin') — not exists
+      .mockResolvedValueOnce(
+        new Response(null, { status: 200, headers: { Location: 'https://upload.test/session' } }),
+      ) // resumable initiation (metadata rides here)
+      .mockResolvedValueOnce(json({ id: 'NID' })); // PUT bytes to the session URI
+    await h.provider.writeBinary('/Readest/big.bin', big.buffer);
+    expect(h.url(2)).toContain('uploadType=resumable');
+    const initBody = (h.fetchMock.mock.calls[2]![1] as RequestInit).body as string;
+    expect(JSON.parse(initBody)).toEqual({ name: 'big.bin', parents: ['RID'] });
+    expect(h.url(3)).toBe('https://upload.test/session');
+    expect(h.method(3)).toBe('PUT');
+  });
+
   test('a stale cached id on write evicts and falls back to the full resolve', async () => {
     const h = makeDrive();
     h.fetchMock
@@ -248,19 +309,18 @@ describe('GoogleDriveProvider — Drive transport', () => {
     await h.provider.readText('/Readest/x.json');
 
     // Cached XID was deleted remotely: the fast-path PATCH 404s, the provider
-    // evicts and re-resolves, finds no existing file, and create-then-names.
+    // evicts and re-resolves, finds no existing file, and multipart-creates.
     h.fetchMock
       .mockResolvedValueOnce(json({}, 404)) // PATCH on stale XID
       .mockResolvedValueOnce(json({ files: [folder('RID')] })) // re-resolve Readest
       .mockResolvedValueOnce(json({ files: [] })) // findChild('x.json') — gone
-      .mockResolvedValueOnce(json({ id: 'NID' })) // POST upload
-      .mockResolvedValueOnce(json({ id: 'NID' })); // PATCH name + reparent
+      .mockResolvedValueOnce(json({ id: 'NID' })); // multipart create
     await h.provider.writeText('/Readest/x.json', 'BODY');
-    expect(h.fetchMock).toHaveBeenCalledTimes(8);
+    expect(h.fetchMock).toHaveBeenCalledTimes(7);
 
     // The recreated file's id is cached: a follow-up read is one media GET.
     h.fetchMock.mockResolvedValueOnce(text('AFTER'));
     expect(await h.provider.readText('/Readest/x.json')).toBe('AFTER');
-    expect(h.url(8)).toContain('/NID?alt=media');
+    expect(h.url(7)).toContain('/NID?alt=media');
   });
 });

--- a/apps/readest-app/src/__tests__/services/sync/providers/gdrive/driveRest.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/providers/gdrive/driveRest.test.ts
@@ -10,10 +10,9 @@ import {
   mediaDownloadUrl,
   mediaUpdateUrl,
   metadataUrl,
-  reparentUrl,
+  multipartUploadUrl,
   resumableCreateUrl,
   resumableUpdateUrl,
-  simpleUploadUrl,
 } from '@/services/sync/providers/gdrive/driveRest';
 
 describe('driveRest', () => {
@@ -45,9 +44,11 @@ describe('driveRest', () => {
     expect(mediaDownloadUrl('FID')).toBe(`${FILES_ENDPOINT}/FID?alt=media`);
   });
 
-  test('upload URLs use uploadType=media and request id/md5/size', () => {
-    expect(simpleUploadUrl()).toContain('uploadType=media');
-    expect(simpleUploadUrl()).toContain('fields=id,md5Checksum,size');
+  test('upload URLs carry the right uploadType and request id/md5/size', () => {
+    // Creates are multipart so the name + parent ride WITH the bytes — an
+    // unnamed create would materialise as "Untitled" in the Drive root (#5147).
+    expect(multipartUploadUrl()).toContain('uploadType=multipart');
+    expect(multipartUploadUrl()).toContain('fields=id,md5Checksum,size');
     expect(mediaUpdateUrl('FID')).toContain('/FID?uploadType=media');
   });
 
@@ -65,13 +66,6 @@ describe('driveRest', () => {
       `${FILES_ENDPOINT}/FID?fields=id,name,mimeType,size,modifiedTime,md5Checksum`,
     );
     expect(deleteUrl('FID')).toBe(`${FILES_ENDPOINT}/FID`);
-  });
-
-  test('reparentUrl moves a file from one parent to another via query params', () => {
-    const url = new URL(reparentUrl('FID', 'NEWPARENT', 'root'));
-    expect(url.pathname.endsWith('/FID')).toBe(true);
-    expect(url.searchParams.get('addParents')).toBe('NEWPARENT');
-    expect(url.searchParams.get('removeParents')).toBe('root');
   });
 
   test('aboutUrl requests only the user identity fields', () => {

--- a/apps/readest-app/src/services/sync/providers/gdrive/GoogleDriveProvider.ts
+++ b/apps/readest-app/src/services/sync/providers/gdrive/GoogleDriveProvider.ts
@@ -52,10 +52,9 @@ import {
   mediaDownloadUrl,
   mediaUpdateUrl,
   metadataUrl,
-  reparentUrl,
+  multipartUploadUrl,
   resumableCreateUrl,
   resumableUpdateUrl,
-  simpleUploadUrl,
 } from './driveRest';
 
 /** Token source for Drive requests, supplied by the OAuth/token layer. */
@@ -82,6 +81,7 @@ const DRIVE_ROOT_ID = 'root';
 
 const HTTP_GET = 'GET';
 const HTTP_POST = 'POST';
+const HTTP_PUT = 'PUT';
 const HTTP_PATCH = 'PATCH';
 const HTTP_DELETE = 'DELETE';
 
@@ -100,6 +100,11 @@ const UPLOAD_CONTENT_TYPE_HEADER = 'X-Upload-Content-Type';
 const JSON_CONTENT_TYPE = 'application/json';
 const DEFAULT_TEXT_CONTENT_TYPE = 'application/json';
 const DEFAULT_BINARY_CONTENT_TYPE = 'application/octet-stream';
+
+/** Part separator for multipart creates; unusual enough to never appear in a payload. */
+const MULTIPART_BOUNDARY = 'readest-gdrive-multipart-3f9a2c17';
+/** Drive caps `uploadType=multipart` at 5 MB; larger creates go resumable. */
+const MULTIPART_UPLOAD_MAX_BYTES = 5 * 1024 * 1024;
 
 /** Backoff: up to this many retries on a transient (429/5xx) response. */
 const MAX_BACKOFF_RETRIES = 4;
@@ -280,7 +285,6 @@ const describeDriveRequest = (url: string, method: string): string => {
     const id = /\/files\/([^/?]+)/.exec(u.pathname)?.[1];
     if (u.searchParams.get('alt') === 'media') return `download ${id}`;
     if (u.pathname.includes('/upload/')) return id ? `upload(overwrite) ${id}` : 'upload(create)';
-    if (u.searchParams.has('addParents')) return `name+reparent ${id}`;
     if (method === HTTP_DELETE) return `delete ${id}`;
     if (id) return `stat ${id}`;
     if (method === HTTP_POST) return 'create folder';
@@ -392,7 +396,7 @@ class DriveProviderImpl {
     const cachedId = this.idCache.get(path);
     if (cachedId !== undefined) {
       try {
-        await this.uploadMedia(mediaUpdateUrl(cachedId), HTTP_PATCH, body, contentType, path);
+        await this.uploadMedia(mediaUpdateUrl(cachedId), body, contentType, path);
         return;
       } catch (e) {
         if (!(e instanceof DriveHttpError) || e.status !== HTTP_NOT_FOUND) throw e;
@@ -415,13 +419,17 @@ class DriveProviderImpl {
     if (existingId !== null) {
       // Overwrite in place, preserving the file id (and any links) rather than
       // orphaning it and creating a duplicate name.
-      await this.uploadMedia(mediaUpdateUrl(existingId), HTTP_PATCH, body, contentType, path);
+      await this.uploadMedia(mediaUpdateUrl(existingId), body, contentType, path);
       this.idCache.set(path, existingId);
     } else {
-      // `uploadType=media` carries no metadata, so create-then-name: POST the
-      // bytes to root, then PATCH name + reparent under the resolved folder.
-      const created = await this.uploadMedia(simpleUploadUrl(), HTTP_POST, body, contentType, path);
-      await this.nameAndReparent(created.id, name, folderId, path);
+      // Metadata (name + parent) and bytes MUST travel in one atomic request.
+      // The old create-then-name pair (an unnamed POST that Drive materialises
+      // as "Untitled" in the Drive ROOT, then a rename/reparent PATCH) stranded
+      // that root file every time the second request failed (#5147).
+      const created =
+        body.byteLength <= MULTIPART_UPLOAD_MAX_BYTES
+          ? await this.createViaMultipart(name, folderId, body, contentType, path)
+          : await this.createViaResumable(name, folderId, body, contentType, path);
       this.idCache.set(path, created.id);
     }
   }
@@ -605,29 +613,78 @@ class DriveProviderImpl {
     return file.id;
   }
 
-  /** Set a freshly-uploaded file's name and move it under its target folder. */
-  private async nameAndReparent(
-    fileId: string,
+  /**
+   * Create a new file with its metadata and bytes in a single
+   * `uploadType=multipart` POST: a `multipart/related` body whose first part is
+   * the `{name, parents}` JSON and whose second part is the raw bytes. Because
+   * the name and target folder ride with the bytes, a failed create leaves
+   * nothing behind — there is no window in which an unnamed file sits in the
+   * user's Drive root (#5147).
+   */
+  private async createViaMultipart(
     name: string,
     folderId: string,
-    path: string,
-  ): Promise<void> {
-    const res = await this.authedFetch(reparentUrl(fileId, folderId, DRIVE_ROOT_ID), HTTP_PATCH, {
-      headers: { [CONTENT_TYPE_HEADER]: JSON_CONTENT_TYPE },
-      body: JSON.stringify({ name }),
-    });
-    await this.ensureOk(res, 'set metadata', path);
-  }
-
-  /** Send a simple media upload (create POST or overwrite PATCH) and parse the result. */
-  private async uploadMedia(
-    url: string,
-    method: typeof HTTP_POST | typeof HTTP_PATCH,
     body: ArrayBuffer,
     contentType: string,
     path: string,
   ): Promise<DriveFile> {
-    const res = await this.authedFetch(url, method, {
+    const metadata = JSON.stringify({ name, parents: [folderId] });
+    const encoder = new TextEncoder();
+    const head = encoder.encode(
+      `--${MULTIPART_BOUNDARY}\r\n` +
+        `${CONTENT_TYPE_HEADER}: ${JSON_CONTENT_TYPE}; charset=UTF-8\r\n\r\n` +
+        `${metadata}\r\n` +
+        `--${MULTIPART_BOUNDARY}\r\n` +
+        `${CONTENT_TYPE_HEADER}: ${contentType}\r\n\r\n`,
+    );
+    const tail = encoder.encode(`\r\n--${MULTIPART_BOUNDARY}--`);
+    const payload = new Uint8Array(head.byteLength + body.byteLength + tail.byteLength);
+    payload.set(head, 0);
+    payload.set(new Uint8Array(body), head.byteLength);
+    payload.set(tail, head.byteLength + body.byteLength);
+    const res = await this.authedFetch(multipartUploadUrl(), HTTP_POST, {
+      headers: {
+        [CONTENT_TYPE_HEADER]: `multipart/related; boundary=${MULTIPART_BOUNDARY}`,
+      },
+      body: payload.buffer as ArrayBuffer,
+    });
+    await this.ensureOk(res, 'upload', path);
+    return (await res.json()) as DriveFile;
+  }
+
+  /**
+   * Create a file too large for a multipart upload (Drive caps it at 5 MB —
+   * a buffered web book upload can exceed that) through a resumable session:
+   * the metadata rides in the initiation, and the file only materialises when
+   * the byte PUT completes, so an interrupted create strands nothing (#5147).
+   * The PUT is single-shot, like {@link uploadStream}'s: on failure the engine
+   * simply re-runs the write, which opens a fresh session.
+   */
+  private async createViaResumable(
+    name: string,
+    folderId: string,
+    body: ArrayBuffer,
+    contentType: string,
+    path: string,
+  ): Promise<DriveFile> {
+    const sessionUri = await this.openResumableSession(name, folderId, null, contentType, path);
+    const res = await this.fetchFn(sessionUri, {
+      method: HTTP_PUT,
+      headers: { [CONTENT_TYPE_HEADER]: contentType },
+      body,
+    });
+    await this.ensureOk(res, 'upload', path);
+    return (await res.json()) as DriveFile;
+  }
+
+  /** Overwrite an existing file's bytes via a media PATCH and parse the result. */
+  private async uploadMedia(
+    url: string,
+    body: ArrayBuffer,
+    contentType: string,
+    path: string,
+  ): Promise<DriveFile> {
+    const res = await this.authedFetch(url, HTTP_PATCH, {
       headers: { [CONTENT_TYPE_HEADER]: contentType },
       body,
     });
@@ -647,8 +704,8 @@ class DriveProviderImpl {
    * Two-step handshake: (1) POST/PATCH the metadata to open a session — Drive
    * replies with a one-time, already-authenticated session URI in `Location`;
    * (2) the native upload plugin PUTs the file body to that URI off the disk.
-   * The metadata (name + parent) rides in the initiation, so unlike the buffered
-   * create-then-name path there is no follow-up reparent PATCH.
+   * The metadata (name + parent) rides in the initiation, so the file can never
+   * appear unnamed in the Drive root, mirroring the buffered create paths.
    *
    * Returns `true` on success, `false` on a swallowed failure (matching the
    * provider contract: the engine re-ensures dirs and retries once, then throws).
@@ -767,8 +824,8 @@ class DriveProviderImpl {
   /**
    * Retry `fn` on a 429 / 5xx response — OR a thrown transport error — with
    * `Retry-After`-aware exponential backoff. A first full-sync of a large library
-   * at concurrency 4 multiplies Drive calls (per-segment resolution + 2-write
-   * create-then-name), so a 429 is expected, not exceptional.
+   * at concurrency 4 multiplies Drive calls (per-segment resolution + per-file
+   * creates), so a 429 is expected, not exceptional.
    *
    * Thrown fetches are retried too: on mobile (observed on Android) a long
    * multi-request sync hits transient transport failures — reqwest's

--- a/apps/readest-app/src/services/sync/providers/gdrive/driveRest.ts
+++ b/apps/readest-app/src/services/sync/providers/gdrive/driveRest.ts
@@ -74,29 +74,31 @@ export const childrenQuery = (parentId: string): string =>
 export const mediaDownloadUrl = (fileId: string): string => `${FILES_ENDPOINT}/${fileId}?alt=media`;
 
 /**
- * URL for a simple (single-request) media upload that creates a new file.
- * `uploadType=media` means the request body *is* the file bytes (no multipart
- * metadata envelope). `fields` narrows the JSON response to the new `id` plus
- * the `md5Checksum`/`size`.
+ * URL for a multipart upload that creates a new file with its metadata (name +
+ * parent) and its bytes in ONE request. Atomicity is the point: the previous
+ * two-request create (an unnamed `uploadType=media` POST, which Drive
+ * materialises as a file literally called "Untitled" in the user's Drive root,
+ * followed by a rename/reparent PATCH) stranded that "Untitled" file whenever
+ * the second request failed (#5147).
  */
-export const simpleUploadUrl = (): string =>
-  `${UPLOAD_ENDPOINT}?uploadType=media&fields=id,md5Checksum,size`;
+export const multipartUploadUrl = (): string =>
+  `${UPLOAD_ENDPOINT}?uploadType=multipart&fields=id,md5Checksum,size`;
 
 /**
- * URL to overwrite an *existing* file's bytes via a media PATCH. Same simple
- * media transfer as {@link simpleUploadUrl}, targeted at a known file id.
+ * URL to overwrite an *existing* file's bytes via a media PATCH. The request
+ * body is the raw file bytes (`uploadType=media`), targeted at a known file id.
  */
 export const mediaUpdateUrl = (fileId: string): string =>
   `${UPLOAD_ENDPOINT}/${fileId}?uploadType=media&fields=id,md5Checksum,size`;
 
 /**
- * URL to open a *resumable* upload session that creates a new file. Unlike the
- * simple media upload, the resumable initiation request carries the file
- * metadata (name + parent) in its body, so no follow-up reparent PATCH is
- * needed. The POST replies with the one-time session URI in its `Location`
- * header; the bytes are then streamed to that URI from disk (constant heap,
- * the whole point for large books on mobile). `fields=id` narrows the
- * completion response to the new file id.
+ * URL to open a *resumable* upload session that creates a new file. Like the
+ * multipart create, the initiation request carries the file metadata (name +
+ * parent) in its body, so the file can never appear unnamed in the Drive root.
+ * The POST replies with the one-time session URI in its `Location` header; the
+ * bytes are then PUT to that URI — streamed from disk on Tauri (constant heap,
+ * the whole point for large books on mobile), or buffered for a large web
+ * upload. `fields=id` narrows the completion response to the new file id.
  */
 export const resumableCreateUrl = (): string => `${UPLOAD_ENDPOINT}?uploadType=resumable&fields=id`;
 
@@ -118,23 +120,6 @@ export const metadataUrl = (fileId: string): string =>
 
 /** URL to delete a file by id. */
 export const deleteUrl = (fileId: string): string => `${FILES_ENDPOINT}/${fileId}`;
-
-/**
- * URL for the metadata PATCH that renames a freshly-uploaded file and moves it
- * from the upload's default root location into its target folder. `addParents`
- * attaches the file to the destination folder and `removeParents` detaches it
- * from `root`. Both are query parameters; only the new `name` rides in the body.
- */
-export const reparentUrl = (
-  fileId: string,
-  addParentId: string,
-  removeParentId: string,
-): string => {
-  const url = new URL(`${FILES_ENDPOINT}/${fileId}`);
-  url.searchParams.set('addParents', addParentId);
-  url.searchParams.set('removeParents', removeParentId);
-  return url.toString();
-};
 
 /**
  * URL for the `about.get` call that returns the signed-in user's identity. The


### PR DESCRIPTION
Fixes the "Untitled files created in GoogleDrive root" half of #5147.

## Problem

Creating a new file on Google Drive used a two-request pair:

1. An unnamed `uploadType=media` POST, which Drive materialises as a file literally named **"Untitled" in the user's Drive ROOT**.
2. A follow-up PATCH that renames it and moves it under `/Readest/...`.

Any failure between the two strands the "Untitled" file where the user can see it: a 403 rate limit (the backoff only retries 429/5xx), an exhausted retry budget, a network drop, or the app getting suspended mid-sync on mobile. The engine then retries the whole write on the next run and creates another one. The reporter of #5147 accumulated 176 such files (mostly config.json-sized) during one sync storm.

## Fix

Metadata and bytes now always travel in ONE atomic request, so a failed create leaves nothing behind:

- Creates up to Drive's 5 MB multipart cap use `uploadType=multipart` with a `multipart/related` body carrying `{name, parents}` plus the bytes.
- Larger buffered creates (web book uploads have no streaming path) open a resumable session whose initiation carries the metadata; the file only materialises when the byte PUT completes.
- Overwrites keep the existing in-place media PATCH, which was already safe.
- The rename/reparent step and the `simpleUploadUrl`/`reparentUrl` builders are removed. The Tauri streaming upload path already carried metadata in its session initiation and is unchanged.

This also drops one request per file creation.

## Note on the deletion half of #5147

The mass deletion the reporter saw (Drive files GC'd, libraries shrinking on every device) is the #5084 defect family in v0.11.18: index rows carried device-local `filePath`, `uploadedAt` was never stamped, so provider-synced books were misread as purely-local books with missing files, and the resulting "confirm deletion" flow tombstoned them fleet-wide. That was already fixed by #5087 (merged after 0.11.18) and ships in the next release; upgraded clients also heal indexes an older client poisoned.

## Tests

- New: create sends name+parent and bytes in one multipart request; a failed create leaves nothing unnamed at root; a large (>5 MB) buffered create carries metadata in the resumable initiation.
- Updated: the create-then-name wire assertions and `driveRest` URL builder tests.
- `pnpm test` (7581 passed), `pnpm lint`, `pnpm format:check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)