### PR TITLE
test(tts): stop detached speak loops so no state dispatch escapes teardown

### DIFF
--- a/apps/readest-app/src/__tests__/services/tts-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller.test.ts
@@ -172,6 +172,15 @@ describe('TTSController', () => {
   let mockView: FoliateView;
   let mockAppService: AppService;
 
+  // Controllers that kick off a detached `#speak` loop (the native-TTS tests
+  // start speak() un-awaited and only assert on an early side-effect). They
+  // must be stopped after the test, or the loop keeps running past teardown
+  // and its deferred `set state` dispatch — queueMicrotask(() =>
+  // dispatchEvent(new CustomEvent(...))) — fires once the jsdom env is gone,
+  // where `CustomEvent` is Node's global rather than jsdom's and jsdom's
+  // EventTarget rejects it as "parameter 1 is not of type 'Event'" (#5149).
+  const speakingControllers: TTSController[] = [];
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockView = createMockView();
@@ -188,6 +197,19 @@ describe('TTSController', () => {
     } catch {
       // ignore
     }
+    // Abort any detached speak loop started on a locally-created controller so
+    // no trailing state change escapes into env teardown (see speakingControllers).
+    for (const c of speakingControllers) {
+      try {
+        await c.stop();
+      } catch {
+        // ignore
+      }
+    }
+    speakingControllers.length = 0;
+    // Flush the deferred set-state dispatch microtasks while the jsdom realm
+    // is still alive.
+    await new Promise((resolve) => setTimeout(resolve, 0));
     vi.restoreAllMocks();
   });
 
@@ -1193,6 +1215,7 @@ describe('TTSController', () => {
       await c.init();
       c.ttsClient = c.ttsNativeClient!;
       await c.initViewTTS(0);
+      speakingControllers.push(c);
       return c;
     };
 
@@ -1268,6 +1291,7 @@ describe('TTSController', () => {
       await c.init();
       c.ttsClient = c.ttsNativeClient!;
       await c.initViewTTS(0);
+      speakingControllers.push(c);
       return c;
     };
 


### PR DESCRIPTION
## Problem

`test_web_app (2)` (the sharded web unit tests) intermittently fails with an **unhandled error**, even though every test passes:

```
TypeError: Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'.
 ❯ TTSController.dispatchEvent .../jsdom/lib/generated/idl/EventTarget.js:236:24
 ❯ src/services/tts/TTSController.ts:212:12
This error originated in "src/__tests__/services/tts-controller.test.ts"
```

Seen on PR #5149's run; re-running the failed job made it pass, confirming it is a flaky teardown race rather than a real regression.

## Root cause

`TTSController`'s `set state` defers its event dispatch to a microtask to avoid re-entrancy:

```ts
set state(value) {
  ...
  queueMicrotask(() => {
    this.dispatchEvent(new CustomEvent('tts-state-change', { detail: { state: value } }));
  });
}
```

The native-TTS tests call `speak()` **un-awaited** and only assert on an early side-effect via `vi.waitFor`, leaving the `#speak` loop running on a locally-created controller that `afterEach` never stopped. Past the test the loop keeps mutating state, and its deferred dispatch fires after the file's jsdom environment is torn down. At that point `CustomEvent` resolves to Node's global (Node 20+) rather than jsdom's, so jsdom's `EventTarget.dispatchEvent` rejects it. Sharding changes file order enough to expose it.

## Fix

Test-only. Track controllers that start a detached speak loop and stop them in `afterEach` (`stop()` aborts the loop's `AbortSignal` and awaits it), then flush pending microtasks while the jsdom realm is still alive. No production change: a browser realm never tears down mid-microtask, so the deferred dispatch remains a legitimate re-entrancy guard.

## Verification

- `pnpm test:pr:web:unit --shard=2/2` (the exact failing CI command) — ran 3x, all green, no unhandled errors.
- `pnpm lint` (tsgo + Biome) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)