### PR TITLE
fix(layout): items overlap in footer on Android phone (#5004)

### DIFF
--- a/apps/readest-app/src/app/reader/components/ProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/ProgressBar.tsx
@@ -194,7 +194,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
           isVertical ? 'h-full' : 'w-full',
           // Sticky bar grows on the left; the info widgets pack to the right
           // with even gaps. Without it, keep the 3-zone left/center/right row.
-          stickyBarActive ? 'gap-x-3' : 'justify-between',
+          stickyBarActive ? 'gap-x-3' : 'justify-between gap-x-2',
         )}
         style={isVertical ? {} : { height: `${viewSettings.marginBottomPx}px` }}
       >
@@ -210,9 +210,8 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
         {hasRemainingInfo && (
           <div
             className={clsx(
-              'remaining-info whitespace-nowrap text-start',
-              !stickyBarActive && 'flex-1',
-              showStatusInfo && 'overflow-hidden',
+              'remaining-info text-start truncate',
+              !stickyBarActive && 'flex-1 min-w-0',
             )}
           >
             {viewSettings.showRemainingTime ? (
@@ -267,8 +266,8 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
 
         <div
           className={clsx(
-            'progress-info items-center overflow-hidden whitespace-nowrap text-end tabular-nums',
-            !stickyBarActive && 'flex-1',
+            'progress-info items-center text-end tabular-nums truncate',
+            !stickyBarActive && 'flex-1 min-w-0',
           )}
         >
           {viewSettings.showProgressInfo && (


### PR DESCRIPTION
### Summary
This PR fixes issue #5004 by resolving the layout overlap in the reader's footer on narrow viewports/mobile devices.

### Changes
- Added gap-x-2 to the parent flex container to ensure a minimum spacing is maintained between footer elements.
- Added min-w-0 to the left (\emaining-info\) and right (\progress-info\) flex containers so they can shrink below their content size.
- Added \	runcate\ to both containers to ensure that any text overflow is gracefully truncated with an ellipsis (\...\) instead of pushing adjacent elements or overlapping with the center clock/battery status.

### Verification
- Ran all \@readest/readest-app\ unit tests.