### PR TITLE
fix(reader): return the turn promise from the captured view.next/prev wrappers

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useCapturedTurn-scrollLock.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useCapturedTurn-scrollLock.test.ts
@@ -102,3 +102,39 @@ describe('useCapturedTurn scroll-lock gate', () => {
     expect(h.controller.beginDrag).not.toHaveBeenCalled();
   });
 });
+
+describe('useCapturedTurn view.next replacement', () => {
+  // The corner auto-turn awaits view.next() to keep its isAutoTurning guard up
+  // (and the #873 selection scroll-pin suspended) until the turn settles. The
+  // replaced view.next must return the turn's promise — discarding it resolves
+  // awaiters while the page is still animating, and the pin snaps the turn back.
+  test('the replaced view.next resolves only when the underlying turn settles', async () => {
+    const savedStyle = h.viewSettings.pageTurnStyle;
+    // push is never captured, so the wrapper takes the originals fallback path.
+    h.viewSettings.pageTurnStyle = 'push';
+    let resolveTurn!: () => void;
+    const originalNext = vi.fn(
+      () =>
+        new Promise<void>((r) => {
+          resolveTurn = r;
+        }),
+    );
+    const view = {
+      renderer: h.renderer,
+      prev: vi.fn(),
+      next: originalNext,
+    } as unknown as FoliateView;
+    renderHook(() => useCapturedTurn('book-1', { current: view }));
+
+    const settled = vi.fn();
+    Promise.resolve(view.next() as unknown as Promise<void>).then(settled);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(originalNext).toHaveBeenCalled();
+    expect(settled).not.toHaveBeenCalled();
+
+    resolveTurn();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(settled).toHaveBeenCalled();
+    h.viewSettings.pageTurnStyle = savedStyle;
+  });
+});

--- a/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
+++ b/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
@@ -150,8 +150,13 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
         return forward ? originals.next() : originals.prev();
       }
     };
-    view.prev = (distance?: number) => void capturedTurn(false, distance);
-    view.next = (distance?: number) => void capturedTurn(true, distance);
+    // Return the turn's promise (the foliate originals do too, despite the
+    // published void type): the corner auto-turn awaits it to hold its
+    // isAutoTurning guard up until the turn settles — discarding it resolves
+    // awaiters ~300ms early, and the #873 selection scroll-pin then snaps the
+    // still-animating page straight back (nightly Android e2e regression).
+    view.prev = (distance?: number) => capturedTurn(false, distance);
+    view.next = (distance?: number) => capturedTurn(true, distance);
 
     return () => {
       view.prev = originals.prev;


### PR DESCRIPTION
## Problem

The nightly [Android E2E (CDP)](https://github.com/readest/readest/actions/workflows/android-e2e.yml) lane has failed on every run for the past month, always on the same test: `selection.android.test.ts > keeps the previous page selected across a corner-dwell auto page turn` ("timed out waiting for auto page turn"). On devices this shows up as: dragging a selection handle into the bottom-right corner turns the page and then immediately snaps back, and occasionally a selection dragged upward spuriously turns backward a page.

## Root cause

The captured page-turn (#4940) replaces `view.next`/`view.prev` with wrappers that discard the turn's promise:

```ts
view.next = (distance?: number) => void capturedTurn(true, distance);
```

Every caller that awaits `view.next()` therefore resolves ~300ms before the page actually moves (the animated turn is transform-based; the container scroll only changes at animation cleanup). The corner-dwell auto page-turn (`useAutoPageTurn.armDwell`) awaits `view.next()` to (a) hold its `isAutoTurning` guard up and (b) re-anchor the Android selection scroll-pin (#873) to the new page afterward. With the promise discarded:

1. `isAutoTurning` dropped instantly, while the turn animation was still running;
2. the pin re-anchored to the stale pre-turn position;
3. the first scroll event after the animation hit the un-guarded `handleScroll` pin, which snapped the page straight back — a net-zero turn.

Diagnosed with millisecond event tracing on an emulator over CDP; the broken ordering was `turnSettled(pos=0)` at +3ms with `cssAnim:cleanup(427)` at +330ms followed by `PIN 427->0`. With the fix the trace reads `cssAnim:cleanup(427)` then `turnSettled(pos=427)`, re-anchor to 427, pin harmless.

## Fix

Return the promise from the wrappers (foliate's own `next`/`prev` return the turn promise despite the published `void` type, and TypeScript permits a `Promise<void>` return on a `void`-typed signature).

## Verification

- New unit test (`useCapturedTurn-scrollLock.test.ts`) pins the behavior: the replaced `view.next()` must resolve only when the underlying turn settles. Fails against the old wrapper, passes with the fix.
- The failing e2e lane now passes on an API 36 arm64 emulator over CDP: `selection.android.test.ts` 6/6, including the corner-dwell test.
- Verified on a physical Android device (Xiaomi, Android 16, WebView 148), both manually and via scripted CDP/adb gestures: the corner-dwell forward turn completes and keeps the cross-page selection, and the spurious backward turns are gone.
- A suspected follow-up regression (system selection ActionMode popping over the reader) was investigated on the same device: it occurred once, could not be reproduced by the reporter nor by scripted gesture patterns (long-press, tap-on-selection, handle drag, corner dwell with and without a completed turn, double-tap), and the existing `contextmenu` suppression was confirmed still effective on WebView 148 — concluded a false positive / one-off; the investigation notes and a ready fix design are recorded in the project agent memory in case it recurs.
- `pnpm test` (7565 passed) and `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)