### PR TITLE
fix(reader): do not toggle bars on vertical pan swipes over fixed-layout pages

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useTouchEvent.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTouchEvent.test.tsx
@@ -113,3 +113,80 @@ describe('useTouchEvent pinch vs two-finger scroll', () => {
     expect(mocks.dispatch).not.toHaveBeenCalledWith('pinch-zoom', expect.anything());
   });
 });
+
+// Swipe-up toggles the header/footer bars — but never when the swipe is a
+// vertical pan of an overflowing fixed-layout page (#5142: fit-width in
+// landscape overflows vertically even at 100% zoom).
+describe('useTouchEvent swipe-up bar toggle on fixed-layout', () => {
+  const swipeUp = (h: { current: Handlers }) => {
+    h.current.onTouchStart(touchEvent([touch(100, 500)], 0));
+    h.current.onTouchMove(touchEvent([touch(100, 300)], 50));
+    h.current.onTouchEnd(touchEvent([], 100));
+  };
+
+  const fxlView = (isOverflowY: boolean) => ({
+    book: { rendition: { layout: 'pre-paginated' } },
+    isOverflowY: () => isOverflowY,
+    renderer: {},
+  });
+
+  beforeEach(() => {
+    mocks.hoveredBookKey = null;
+    mocks.getBookData.mockReturnValue({ isFixedLayout: true });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      zoomMode: 'fit-width',
+      scrolled: false,
+      vertical: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('swipe up on a vertically overflowing page (fit-width landscape) pans, not toggles', () => {
+    mocks.getView.mockReturnValue(fxlView(true));
+    const h = renderTouchHook();
+    swipeUp(h);
+
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+  });
+
+  test('swipe up still toggles the bars when the page fits vertically', () => {
+    mocks.getView.mockReturnValue(fxlView(false));
+    const h = renderTouchHook();
+    swipeUp(h);
+
+    expect(mocks.setHoveredBookKey).toHaveBeenCalledWith('book-1');
+  });
+
+  test('swipe up on a zoomed page with vertical overflow pans, not toggles', () => {
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 150,
+      zoomMode: 'fit-page',
+      scrolled: false,
+      vertical: false,
+    });
+    mocks.getView.mockReturnValue(fxlView(true));
+    const h = renderTouchHook();
+    swipeUp(h);
+
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+  });
+
+  test('swipe up toggles on a zoomed page that still fits vertically', () => {
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 150,
+      zoomMode: 'fit-page',
+      scrolled: false,
+      vertical: false,
+    });
+    mocks.getView.mockReturnValue(fxlView(false));
+    const h = renderTouchHook();
+    swipeUp(h);
+
+    expect(mocks.setHoveredBookKey).toHaveBeenCalledWith('book-1');
+  });
+});

--- a/apps/readest-app/src/app/reader/hooks/useIframeEvents.ts
+++ b/apps/readest-app/src/app/reader/hooks/useIframeEvents.ts
@@ -5,6 +5,7 @@ import { eventDispatcher } from '@/utils/event';
 import { MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL } from '@/services/constants';
 import { createWheelGestureDetector } from '@/app/reader/utils/wheelGesture';
 import { dispatchTouchInterceptors, TouchDetail } from './useTouchInterceptor';
+import { hasVerticalPanning } from './usePagination';
 
 export const useMouseEvent = (
   bookKey: string,
@@ -341,10 +342,13 @@ export const useTouchEvent = (bookKey: string) => {
       ) {
         const viewSettings = getViewSettings(bookKey)!;
         const bookData = getBookData(bookKey)!;
+        // On a fixed-layout page that can pan vertically (e.g. fit-width in
+        // landscape overflows vertically even at 100% zoom) an upward swipe
+        // is a pan, not a toggle-the-bars gesture (#5142).
         if (
           !viewSettings!.scrolled &&
           !viewSettings!.vertical &&
-          (!bookData.isFixedLayout || viewSettings.zoomLevel <= 100)
+          (!bookData.isFixedLayout || !hasVerticalPanning(getView(bookKey), viewSettings))
         ) {
           setHoveredBookKey(hoveredBookKey ? null : bookKey);
         }

--- a/apps/readest-app/src/app/reader/hooks/usePagination.ts
+++ b/apps/readest-app/src/app/reader/hooks/usePagination.ts
@@ -42,7 +42,7 @@ const hasHorizontalPanning = (
   return isPanningView(view, viewSettings) && view.isOverflowX();
 };
 
-const hasVerticalPanning = (
+export const hasVerticalPanning = (
   view: FoliateView | null,
   viewSettings: ViewSettings | null | undefined,
 ) => {


### PR DESCRIPTION
Fixes #5142

### Root cause

On paginated fixed-layout books, the swipe-up gesture that toggles the header and footer bars was gated by `zoomLevel <= 100` in `useIframeEvents.ts`. Zoom level is a poor proxy for whether a vertical swipe pans the page: `isPanningView` treats `zoomMode !== 'fit-page'` as pannable, and fit-width at 100% zoom in landscape overflows vertically. Every vertical pan swipe therefore also popped up the control menu.

### Fix

Gate the toggle on actual vertical pannability instead: `hasVerticalPanning` (now exported from `usePagination.ts`) combines `isPanningView` with the renderer's real `view.isOverflowY()`. A vertical swipe toggles the bars only when it cannot pan the page. This also means a page zoomed beyond 100% that still fits vertically allows the swipe-up toggle again, since a vertical swipe pans nothing there.

### Tests

- New unit tests in `useTouchEvent.test.tsx` covering all four combinations (fit-width with and without vertical overflow, zoomed with and without vertical overflow); the overflowing fit-width case failed before the fix.
- Full suite, lint, and format checks pass.

### Device verification (Xiaomi 13, adb + CDP)

Installed a dev build with the fix and drove the real app: opened a multi-page PDF via VIEW intent, rotated to landscape, set Fit Width through the UI. Swipe-up at the left side, right side, and center left the bars hidden while the page panned; a center tap still toggles the bars both ways; with Fit Page (no vertical overflow) swipe-up still toggles the bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)