### PR TITLE
fix(payment): stop Google Play RTDN fallback from downgrading paying subscribers

### DIFF
--- a/apps/readest-app/src/__tests__/libs/payment/google-notifications.test.ts
+++ b/apps/readest-app/src/__tests__/libs/payment/google-notifications.test.ts
@@ -24,6 +24,7 @@ import { handleGoogleNotification } from '@/libs/payment/iap/google/notification
 
 type Captures = {
   googleSubUpserts: Array<Record<string, unknown>>;
+  googleSubUpsertOptions: Array<Record<string, unknown> | undefined>;
   planUpdates: Array<Record<string, unknown>>;
   paymentUpdates: Array<Record<string, unknown>>;
 };
@@ -33,7 +34,12 @@ function createSupabaseMock(state: {
   paymentRow?: unknown;
   completedPayments?: Array<{ storage_gb: number }>;
 }) {
-  const captures: Captures = { googleSubUpserts: [], planUpdates: [], paymentUpdates: [] };
+  const captures: Captures = {
+    googleSubUpserts: [],
+    googleSubUpsertOptions: [],
+    planUpdates: [],
+    paymentUpdates: [],
+  };
   const client = {
     from(table: string) {
       switch (table) {
@@ -42,8 +48,9 @@ function createSupabaseMock(state: {
             select: () => ({
               eq: () => ({ single: () => Promise.resolve({ data: state.googleSubRow ?? null }) }),
             }),
-            upsert: (obj: Record<string, unknown>) => {
+            upsert: (obj: Record<string, unknown>, options?: Record<string, unknown>) => {
               captures.googleSubUpserts.push(obj);
+              captures.googleSubUpsertOptions.push(options);
               return Promise.resolve({ data: obj, error: null });
             },
           };
@@ -185,6 +192,45 @@ describe('handleGoogleNotification — subscriptions', () => {
 
     expect(res).toMatchObject({ handled: true, status: 'expired' });
     expect(sb.captures.planUpdates.at(-1)).toEqual({ plan: 'free', status: 'expired' });
+  });
+
+  it('does not downgrade when re-verification fails on a renewal', async () => {
+    // A failed Play API call on a non-terminal event (renewal/recovery/purchase)
+    // is transient; the handler must surface an error so Pub/Sub retries instead
+    // of downgrading a paying user to free.
+    googleMocks.verifyPurchase.mockResolvedValue({ success: false, error: 'api unavailable' });
+    const sb = createSupabaseMock({ googleSubRow: subRow });
+    h.supabase = sb;
+
+    await expect(handleGoogleNotification(subscriptionMessage(2))).rejects.toThrow(
+      /re-verification failed/,
+    );
+    expect(sb.captures.googleSubUpserts).toHaveLength(0);
+    expect(sb.captures.planUpdates).toHaveLength(0);
+  });
+
+  it('records a renewal under the stable purchase-token key', async () => {
+    // After a renewal the Play API returns the order id with a `..N` suffix.
+    // The upsert must conflict on (user_id, purchase_token) — the token never
+    // changes across renewals — so the existing row is updated instead of an
+    // insert that collides with the unique_user_purchase constraint.
+    googleMocks.verifyPurchase.mockResolvedValue({
+      ...activeVerification(),
+      purchaseData: { ...activeVerification().purchaseData, orderId: 'order-1..3' },
+    });
+    const sb = createSupabaseMock({ googleSubRow: subRow });
+    h.supabase = sb;
+
+    const res = await handleGoogleNotification(subscriptionMessage(2)); // SUBSCRIPTION_RENEWED
+
+    expect(res).toMatchObject({ handled: true, status: 'active' });
+    expect(sb.captures.googleSubUpsertOptions.at(-1)).toMatchObject({
+      onConflict: 'user_id,purchase_token',
+    });
+    const upsert = sb.captures.googleSubUpserts.at(-1)!;
+    expect(upsert).toMatchObject({ order_id: 'order-1..3', purchase_token: TOKEN });
+    // created_at has a DB default and must not be rewritten on every upsert.
+    expect(upsert).not.toHaveProperty('created_at');
   });
 
   it('ignores notifications for an unknown purchase token', async () => {

--- a/apps/readest-app/src/__tests__/libs/payment/google-verifier.test.ts
+++ b/apps/readest-app/src/__tests__/libs/payment/google-verifier.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// The Play Developer API client can fail for reasons that have nothing to do
+// with the purchase itself (auth, network, runtime). The verifier must log the
+// underlying error instead of silently mapping every failure to "not found" —
+// a swallowed runtime error on the RTDN path once downgraded paying users.
+
+const apiMocks = vi.hoisted(() => ({
+  subscriptionsGet: vi.fn(),
+  productsGet: vi.fn(),
+}));
+
+vi.mock('@googleapis/androidpublisher', () => ({
+  androidpublisher: () => ({
+    purchases: {
+      subscriptions: { get: apiMocks.subscriptionsGet },
+      products: { get: apiMocks.productsGet },
+    },
+  }),
+}));
+
+vi.mock('google-auth-library', () => ({
+  GoogleAuth: class {},
+}));
+
+import { GoogleIAPVerifier } from '@/libs/payment/iap/google/verifier';
+
+const params = {
+  orderId: 'order-1',
+  purchaseToken: 'token-1',
+  productId: 'com.bilingify.readest.plus.monthly',
+  packageName: 'com.bilingify.readest',
+};
+
+describe('GoogleIAPVerifier.verifyPurchase', () => {
+  beforeEach(() => {
+    vi.stubEnv('GOOGLE_IAP_SERVICE_ACCOUNT_KEY', '{"client_email":"t@t","private_key":"k"}');
+    apiMocks.subscriptionsGet.mockReset();
+    apiMocks.productsGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('logs the underlying API error when verification fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const subError = new Error('workerd exploded');
+    const prodError = new Error('also failed');
+    apiMocks.subscriptionsGet.mockRejectedValue(subError);
+    apiMocks.productsGet.mockRejectedValue(prodError);
+
+    const result = await new GoogleIAPVerifier().verifyPurchase(params);
+
+    expect(result.success).toBe(false);
+    const logged = errorSpy.mock.calls.flat();
+    expect(logged).toContain(subError);
+    expect(logged).toContain(prodError);
+  });
+
+  it('still verifies an active subscription', async () => {
+    apiMocks.subscriptionsGet.mockResolvedValue({
+      data: {
+        startTimeMillis: '1700000000000',
+        expiryTimeMillis: String(Date.now() + 86_400_000),
+        paymentState: 1,
+        autoRenewing: true,
+        orderId: 'order-1..2',
+      },
+    });
+
+    const result = await new GoogleIAPVerifier().verifyPurchase(params);
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe('active');
+  });
+});

--- a/apps/readest-app/src/libs/payment/iap/google/notifications.ts
+++ b/apps/readest-app/src/libs/payment/iap/google/notifications.ts
@@ -142,7 +142,22 @@ async function handleSubscriptionNotification(
   }
 
   // Re-verification failed (e.g. a revoked purchase is no longer queryable).
-  // For terminal events we still downgrade the user using the stored row.
+  // Only terminal/grace events may downgrade the user from the stored row; for
+  // anything else (renewal, recovery, purchase) a failed verification is a
+  // transient or environmental error, so surface it for a Pub/Sub retry
+  // instead of downgrading a paying user to free.
+  const isDowngradeEvent = [
+    SubscriptionNotificationType.REVOKED,
+    SubscriptionNotificationType.EXPIRED,
+    SubscriptionNotificationType.ON_HOLD,
+    SubscriptionNotificationType.PAUSED,
+    SubscriptionNotificationType.IN_GRACE_PERIOD,
+  ].includes(notificationType);
+  if (!isDowngradeEvent) {
+    throw new Error(
+      `Google re-verification failed for notification type ${notificationType}: ${verificationResult.error}`,
+    );
+  }
   const status = overrideStatus('expired', notificationType);
   await createOrUpdateSubscription(
     subRow.user_id,

--- a/apps/readest-app/src/libs/payment/iap/google/server.ts
+++ b/apps/readest-app/src/libs/payment/iap/google/server.ts
@@ -75,11 +75,14 @@ export async function createOrUpdateSubscription(userId: string, purchase: Verif
         obfuscated_external_profile_id: purchase.obfuscatedExternalProfileId,
         cancel_reason: purchase.cancelReason,
         user_cancellation_time_millis: purchase.userCancellationTimeMillis,
-        created_at: new Date(),
         updated_at: new Date(),
       },
       {
-        onConflict: 'user_id,order_id',
+        // The purchase token is the stable key across a subscription's life;
+        // the Play API order id gains a `..N` suffix on every renewal, so
+        // conflicting on order_id would insert instead of update and collide
+        // with the unique (user_id, purchase_token) constraint.
+        onConflict: 'user_id,purchase_token',
       },
     );
 

--- a/apps/readest-app/src/libs/payment/iap/google/verifier.ts
+++ b/apps/readest-app/src/libs/payment/iap/google/verifier.ts
@@ -155,7 +155,8 @@ export class GoogleIAPVerifier {
         purchaseData: purchase,
         purchaseType: 'subscription',
       };
-    } catch {
+    } catch (error) {
+      console.error('Google Play subscription verification failed:', error);
       return {
         success: false,
         error: 'Not a subscription purchase',
@@ -189,7 +190,8 @@ export class GoogleIAPVerifier {
         purchaseData: purchase,
         purchaseType: 'product',
       };
-    } catch {
+    } catch (error) {
+      console.error('Google Play product verification failed:', error);
       return {
         success: false,
         error: 'Purchase not found',


### PR DESCRIPTION
## Problem

Since the Google Play RTDN webhook shipped (#4701), every notification re-verified against the Play Developer API has failed in production: the webhook is served by the Cloudflare Worker, where the googleapis client cannot run (the same reason `iap-verify` is routed to the Node deployment via `getNodeAPIBaseUrl`). The verifier's bare `catch` swallowed the real error, and the failure fallback wrote `status=expired` with a null expiry for every notification type, then set the user's plan to `free`.

Result: healthy monthly renewals downgraded paying subscribers to the free plan. 30 of 30 RTDN events since Jun 24 took the fallback path; 22 of them were subscriptions that Google reports as ACTIVE (verified per token against the Play API). At least two affected users purchased a second subscription to recover.

Restore purchases could not repair an affected account either: after a renewal the Play API returns the order id with a `..N` suffix, so the upsert keyed on `(user_id, order_id)` attempted an INSERT and collided with the `unique_user_purchase (user_id, purchase_token)` constraint, failing the verify request with a 500 ("Payment failed. We couldn't process your subscription."). Zero suffixed order ids exist across all 103 rows: no renewal was ever successfully recorded.

## Changes

- **notifications**: on re-verification failure, only terminal/grace events (REVOKED, EXPIRED, ON_HOLD, PAUSED, IN_GRACE_PERIOD) may downgrade from the stored row. Other events (renewal, recovery, purchase) now throw so the route returns 500 and Pub/Sub retries, instead of downgrading a paying user.
- **server**: upsert subscriptions on the stable `(user_id, purchase_token)` key so renewals update the existing row and record the latest order id; stop rewriting `created_at` on every upsert (column has a DB default).
- **verifier**: log the underlying Play API error instead of silently mapping every failure to a not-found result.

## Tests

- New: renewal + verification failure must not write a downgrade (throws for Pub/Sub retry); renewal success upserts on `user_id,purchase_token` with the suffixed order id and without `created_at`; verifier logs the underlying API errors.
- Existing terminal-event fallback behavior (EXPIRED/REVOKED/grace) unchanged and still covered.
- Full suite: 7591 passed. Lint clean.

## Deployment notes

- The Pub/Sub push subscription must be repointed from the CF Worker to the Node deployment (`https://node.readest.com/api/google/notifications?token=...`), with `GOOGLE_RTDN_VERIFICATION_TOKEN` and `GOOGLE_IAP_SERVICE_ACCOUNT_KEY` present in that environment. Until then, downgrades continue at roughly one per day.
- Affected rows/plans are being restored with a one-off re-verify script (dry-run reviewed: 23 subscription rows, 20 plans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)