### PR TITLE
feat(tts): add mini player Player Style (full/minimal); keep Tauri off the edge proxy

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2027,7 +2027,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "زامن مكتبتك وتقدم القراءة والتمييزات مع Microsoft OneDrive الخاص بك.",
   "Readest only accesses the files it creates in your OneDrive.": "لا يصل Readest إلا إلى الملفات التي ينشئها في OneDrive الخاص بك.",
   "Sentence Pause": "وقفة بين الجمل",
-  "Paragraph Gap": "وقفة بين الفقرات",
   "{{minutes}}m left": "بقيت {{minutes}} دقيقة",
   "{{hours}}h left": "بقيت {{hours}} ساعة",
   "Time Remaining": "الوقت المتبقي",
@@ -2072,5 +2071,11 @@
   "Reuse generated speech across sessions without refetching": "إعادة استخدام الصوت المُولَّد عبر الجلسات دون إعادة جلبه",
   "Sync Audio Cache": "مزامنة ذاكرة التخزين المؤقت للصوت",
   "Share section audio between your devices through your file sync service": "مشاركة صوت المقاطع بين أجهزتك عبر خدمة مزامنة الملفات",
-  "Storage Limit": "حد التخزين"
+  "Storage Limit": "حد التخزين",
+  "Playback settings": "إعدادات التشغيل",
+  "Paragraph Pause": "وقفة بين الفقرات",
+  "Player Style": "نمط المشغل",
+  "Full": "كامل",
+  "Minimal": "مبسط",
+  "TTS Player Style": "نمط مشغل TTS"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1887,7 +1887,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "আপনার লাইব্রেরি, পড়ার অগ্রগতি এবং হাইলাইটগুলি আপনার Microsoft OneDrive-এর সাথে সিঙ্ক করুন।",
   "Readest only accesses the files it creates in your OneDrive.": "Readest শুধুমাত্র আপনার OneDrive-এ নিজে তৈরি করা ফাইলগুলিতেই প্রবেশ করে।",
   "Sentence Pause": "বাক্যের মধ্যে বিরতি",
-  "Paragraph Gap": "অনুচ্ছেদের মধ্যে বিরতি",
   "{{minutes}}m left": "{{minutes}} মিনিট বাকি",
   "{{hours}}h left": "{{hours}} ঘণ্টা বাকি",
   "Time Remaining": "অবশিষ্ট সময়",
@@ -1928,5 +1927,11 @@
   "Reuse generated speech across sessions without refetching": "তৈরি করা কণ্ঠস্বর পুনরায় না এনে সেশনজুড়ে ব্যবহার করুন",
   "Sync Audio Cache": "অডিও ক্যাশ সিঙ্ক করুন",
   "Share section audio between your devices through your file sync service": "আপনার ফাইল সিঙ্ক পরিষেবার মাধ্যমে ডিভাইসগুলির মধ্যে অংশের অডিও ভাগ করুন",
-  "Storage Limit": "স্টোরেজ সীমা"
+  "Storage Limit": "স্টোরেজ সীমা",
+  "Playback settings": "প্লেব্যাক সেটিংস",
+  "Paragraph Pause": "অনুচ্ছেদের মধ্যে বিরতি",
+  "Player Style": "প্লেয়ার শৈলী",
+  "Full": "পূর্ণ",
+  "Minimal": "ন্যূনতম",
+  "TTS Player Style": "TTS প্লেয়ার শৈলী"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1852,7 +1852,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "ཁྱེད་ཀྱི་དཔེ་མཛོད་དང་། ཀློག་པའི་ཡར་འཕེལ། གཙོ་གནད་བཅས་ཁྱེད་ཀྱི་ Microsoft OneDrive དང་མཉམ་སྒྲིག་བྱེད།",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ཀྱིས་ཁྱེད་ཀྱི་ OneDrive ནང་རང་ཉིད་ཀྱིས་བཟོས་པའི་ཡིག་ཆ་ཁོ་ནར་ལྟ་སྤྱོད་བྱེད།",
   "Sentence Pause": "ཚིག་གྲུབ་བར་གསེང་",
-  "Paragraph Gap": "དོན་ཚན་བར་གསེང་",
   "{{minutes}}m left": "ད་དུང་ {{minutes}} སྐར་མ་ལྷག་ཡོད།",
   "{{hours}}h left": "ད་དུང་ {{hours}} ཆུ་ཚོད་ལྷག་ཡོད།",
   "Time Remaining": "ལྷག་ཡོད་པའི་དུས་ཚོད།",
@@ -1892,5 +1891,11 @@
   "Reuse generated speech across sessions without refetching": "བཟོས་ཟིན་པའི་སྐད་སྒྲ་བསྐྱར་དུ་ལེན་མི་དགོས་པར་བསྐྱར་སྤྱོད་བྱེད།",
   "Sync Audio Cache": "སྒྲའི་གསོག་མཛོད་མཉམ་འགྲིག",
   "Share section audio between your devices through your file sync service": "ཡིག་ཆ་མཉམ་འགྲིག་ཞབས་ཞུ་བརྒྱུད་སྒྲིག་ཆས་བར་ས་བཅད་ཀྱི་སྒྲ་མཉམ་སྤྱོད།",
-  "Storage Limit": "གསོག་ཉར་ཚད་བཀག"
+  "Storage Limit": "གསོག་ཉར་ཚད་བཀག",
+  "Playback settings": "གཏོང་བའི་སྒྲིག་སྟངས།",
+  "Paragraph Pause": "དོན་ཚན་བར་གསེང་",
+  "Player Style": "གཏོང་ཆས་ཀྱི་བཟོ་དབྱིབས།",
+  "Full": "ཆ་ཚང་།",
+  "Minimal": "སྟབས་བདེ།",
+  "TTS Player Style": "TTS གཏོང་ཆས་ཀྱི་བཟོ་དབྱིབས།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1887,7 +1887,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synchronisieren Sie Ihre Bibliothek, Ihren Lesefortschritt und Ihre Markierungen mit Ihrem Microsoft OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest greift nur auf die Dateien zu, die es in Ihrem OneDrive erstellt.",
   "Sentence Pause": "Satzpause",
-  "Paragraph Gap": "Absatzpause",
   "{{minutes}}m left": "{{minutes}} min verbleibend",
   "{{hours}}h left": "{{hours}} Std. verbleibend",
   "Time Remaining": "Verbleibende Zeit",
@@ -1928,5 +1927,11 @@
   "Reuse generated speech across sessions without refetching": "Generierte Sprache sitzungsübergreifend wiederverwenden, ohne sie erneut abzurufen",
   "Sync Audio Cache": "Audio-Cache synchronisieren",
   "Share section audio between your devices through your file sync service": "Abschnitts-Audio über Ihren Dateisynchronisierungsdienst zwischen Geräten teilen",
-  "Storage Limit": "Speicherlimit"
+  "Storage Limit": "Speicherlimit",
+  "Playback settings": "Wiedergabeeinstellungen",
+  "Paragraph Pause": "Absatzpause",
+  "Player Style": "Player-Stil",
+  "Full": "Vollständig",
+  "Minimal": "Minimal",
+  "TTS Player Style": "TTS-Player-Stil"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1887,7 +1887,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Συγχρονίστε τη βιβλιοθήκη, την πρόοδο ανάγνωσης και τις επισημάνσεις σας με το Microsoft OneDrive σας.",
   "Readest only accesses the files it creates in your OneDrive.": "Το Readest έχει πρόσβαση μόνο στα αρχεία που δημιουργεί στο OneDrive σας.",
   "Sentence Pause": "Παύση μεταξύ προτάσεων",
-  "Paragraph Gap": "Παύση παραγράφου",
   "{{minutes}}m left": "απομένουν {{minutes}} λεπτά",
   "{{hours}}h left": "απομένουν {{hours}} ώρες",
   "Time Remaining": "Υπολειπόμενος χρόνος",
@@ -1928,5 +1927,11 @@
   "Reuse generated speech across sessions without refetching": "Επαναχρησιμοποίηση της παραγόμενης ομιλίας μεταξύ συνεδριών χωρίς εκ νέου λήψη",
   "Sync Audio Cache": "Συγχρονισμός προσωρινής μνήμης ήχου",
   "Share section audio between your devices through your file sync service": "Κοινή χρήση του ήχου ενοτήτων μεταξύ των συσκευών σας μέσω της υπηρεσίας συγχρονισμού αρχείων",
-  "Storage Limit": "Όριο αποθήκευσης"
+  "Storage Limit": "Όριο αποθήκευσης",
+  "Playback settings": "Ρυθμίσεις αναπαραγωγής",
+  "Paragraph Pause": "Παύση παραγράφου",
+  "Player Style": "Στυλ αναπαραγωγής",
+  "Full": "Πλήρες",
+  "Minimal": "Μινιμαλιστικό",
+  "TTS Player Style": "Στυλ αναπαραγωγής TTS"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1922,7 +1922,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincroniza tu biblioteca, progreso de lectura y resaltados con tu Microsoft OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest solo accede a los archivos que crea en tu OneDrive.",
   "Sentence Pause": "Pausa entre frases",
-  "Paragraph Gap": "Pausa entre párrafos",
   "Time Remaining": "Tiempo restante",
   "{{minutes}}m left": "{{minutes}} min restantes",
   "{{hours}}h left": "{{hours}} h restantes",
@@ -1964,5 +1963,11 @@
   "Reuse generated speech across sessions without refetching": "Reutilizar la voz generada entre sesiones sin volver a obtenerla",
   "Sync Audio Cache": "Sincronizar caché de audio",
   "Share section audio between your devices through your file sync service": "Compartir el audio de las secciones entre sus dispositivos mediante su servicio de sincronización de archivos",
-  "Storage Limit": "Límite de almacenamiento"
+  "Storage Limit": "Límite de almacenamiento",
+  "Playback settings": "Configuración de reproducción",
+  "Paragraph Pause": "Pausa entre párrafos",
+  "Player Style": "Estilo del reproductor",
+  "Full": "Completo",
+  "Minimal": "Minimalista",
+  "TTS Player Style": "Estilo del reproductor TTS"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1887,7 +1887,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "کتابخانه، وضعیت مطالعه و هایلایت‌های خود را با Microsoft OneDrive خود همگام‌سازی کنید.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest فقط به فایل‌هایی دسترسی دارد که خودش در OneDrive شما ایجاد می‌کند.",
   "Sentence Pause": "مکث بین جملات",
-  "Paragraph Gap": "وقفه بین پاراگراف‌ها",
   "{{minutes}}m left": "{{minutes}} دقیقه باقی‌مانده",
   "{{hours}}h left": "{{hours}} ساعت باقی‌مانده",
   "Time Remaining": "زمان باقی‌مانده",
@@ -1928,5 +1927,11 @@
   "Reuse generated speech across sessions without refetching": "استفاده دوباره از گفتار تولیدشده بین نشست‌ها بدون دریافت مجدد",
   "Sync Audio Cache": "همگام‌سازی حافظه پنهان صدا",
   "Share section audio between your devices through your file sync service": "اشتراک‌گذاری صدای بخش‌ها بین دستگاه‌های شما از طریق سرویس همگام‌سازی فایل",
-  "Storage Limit": "محدودیت فضای ذخیره‌سازی"
+  "Storage Limit": "محدودیت فضای ذخیره‌سازی",
+  "Playback settings": "تنظیمات پخش",
+  "Paragraph Pause": "وقفه بین پاراگراف‌ها",
+  "Player Style": "سبک پخش‌کننده",
+  "Full": "کامل",
+  "Minimal": "ساده",
+  "TTS Player Style": "سبک پخش‌کننده TTS"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1922,7 +1922,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synchronisez votre bibliothèque, votre progression de lecture et vos surlignages avec votre Microsoft OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest accède uniquement aux fichiers qu'il crée dans votre OneDrive.",
   "Sentence Pause": "Pause entre les phrases",
-  "Paragraph Gap": "Pause entre les paragraphes",
   "{{minutes}}m left": "{{minutes}} min restant",
   "{{hours}}h left": "{{hours}} h restant",
   "Time Remaining": "Temps restant",
@@ -1964,5 +1963,11 @@
   "Reuse generated speech across sessions without refetching": "Réutiliser la voix générée entre les sessions sans la retélécharger",
   "Sync Audio Cache": "Synchroniser le cache audio",
   "Share section audio between your devices through your file sync service": "Partager l'audio des sections entre vos appareils via votre service de synchronisation de fichiers",
-  "Storage Limit": "Limite de stockage"
+  "Storage Limit": "Limite de stockage",
+  "Playback settings": "Paramètres de lecture",
+  "Paragraph Pause": "Pause entre les paragraphes",
+  "Player Style": "Style du lecteur",
+  "Full": "Complet",
+  "Minimal": "Minimal",
+  "TTS Player Style": "Style du lecteur TTS"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1922,7 +1922,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "סנכרן את הספרייה, התקדמות הקריאה וההדגשות שלך עם Microsoft OneDrive שלך.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ניגש רק לקבצים שהוא יוצר ב-OneDrive שלך.",
   "Sentence Pause": "השהיה בין משפטים",
-  "Paragraph Gap": "הפסקה בין פסקאות",
   "{{minutes}}m left": "נותרו {{minutes}} דקות",
   "{{hours}}h left": "נותרו {{hours}} שעות",
   "Time Remaining": "זמן שנותר",
@@ -1964,5 +1963,11 @@
   "Reuse generated speech across sessions without refetching": "שימוש חוזר בדיבור שנוצר בין הפעלות ללא הורדה מחדש",
   "Sync Audio Cache": "סנכרן מטמון שמע",
   "Share section audio between your devices through your file sync service": "שתף שמע של קטעים בין המכשירים שלך דרך שירות סנכרון הקבצים",
-  "Storage Limit": "מגבלת אחסון"
+  "Storage Limit": "מגבלת אחסון",
+  "Playback settings": "הגדרות השמעה",
+  "Paragraph Pause": "הפסקה בין פסקאות",
+  "Player Style": "סגנון הנגן",
+  "Full": "מלא",
+  "Minimal": "מינימלי",
+  "TTS Player Style": "סגנון נגן TTS"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1887,7 +1887,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "अपनी लाइब्रेरी, पढ़ने की प्रगति और हाइलाइट्स को अपनी Microsoft OneDrive से सिंक करें।",
   "Readest only accesses the files it creates in your OneDrive.": "Readest केवल उन्हीं फ़ाइलों तक पहुँचता है जिन्हें वह आपकी OneDrive में बनाता है।",
   "Sentence Pause": "वाक्यों के बीच विराम",
-  "Paragraph Gap": "अनुच्छेदों के बीच विराम",
   "{{minutes}}m left": "{{minutes}} मिनट शेष",
   "{{hours}}h left": "{{hours}} घंटे शेष",
   "Time Remaining": "शेष समय",
@@ -1928,5 +1927,11 @@
   "Reuse generated speech across sessions without refetching": "जनरेट की गई आवाज़ को दोबारा प्राप्त किए बिना सत्रों में फिर से उपयोग करें",
   "Sync Audio Cache": "ऑडियो कैश सिंक करें",
   "Share section audio between your devices through your file sync service": "अपनी फ़ाइल सिंक सेवा के ज़रिये अपने डिवाइसों के बीच खंड ऑडियो साझा करें",
-  "Storage Limit": "संग्रहण सीमा"
+  "Storage Limit": "संग्रहण सीमा",
+  "Playback settings": "प्लेबैक सेटिंग्स",
+  "Paragraph Pause": "अनुच्छेदों के बीच विराम",
+  "Player Style": "प्लेयर शैली",
+  "Full": "पूर्ण",
+  "Minimal": "न्यूनतम",
+  "TTS Player Style": "TTS प्लेयर शैली"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1887,7 +1887,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Szinkronizálja könyvtárát, olvasási haladását és kiemeléseit a Microsoft OneDrive-jával.",
   "Readest only accesses the files it creates in your OneDrive.": "A Readest csak azokhoz a fájlokhoz fér hozzá, amelyeket ő hozott létre a OneDrive-jában.",
   "Sentence Pause": "Mondatszünet",
-  "Paragraph Gap": "Bekezdésszünet",
   "{{minutes}}m left": "{{minutes}} perc van hátra",
   "{{hours}}h left": "{{hours}} óra van hátra",
   "Time Remaining": "Hátralévő idő",
@@ -1928,5 +1927,11 @@
   "Reuse generated speech across sessions without refetching": "A generált beszéd újrafelhasználása a munkamenetek között újbóli letöltés nélkül",
   "Sync Audio Cache": "Hang-gyorsítótár szinkronizálása",
   "Share section audio between your devices through your file sync service": "Szakaszok hangjának megosztása eszközei között a fájlszinkronizálási szolgáltatással",
-  "Storage Limit": "Tárhelykorlát"
+  "Storage Limit": "Tárhelykorlát",
+  "Playback settings": "Lejátszási beállítások",
+  "Paragraph Pause": "Bekezdésszünet",
+  "Player Style": "Lejátszó stílusa",
+  "Full": "Teljes",
+  "Minimal": "Minimális",
+  "TTS Player Style": "TTS lejátszó stílusa"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1852,7 +1852,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sinkronkan perpustakaan, progres membaca, dan sorotan Anda dengan Microsoft OneDrive Anda.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest hanya mengakses file yang dibuatnya di OneDrive Anda.",
   "Sentence Pause": "Jeda Antar Kalimat",
-  "Paragraph Gap": "Jeda antarparagraf",
   "{{minutes}}m left": "{{minutes}} mnt tersisa",
   "{{hours}}h left": "{{hours}} jam tersisa",
   "Time Remaining": "Sisa waktu",
@@ -1892,5 +1891,11 @@
   "Reuse generated speech across sessions without refetching": "Gunakan kembali suara yang dihasilkan antar sesi tanpa mengambil ulang",
   "Sync Audio Cache": "Sinkronkan cache audio",
   "Share section audio between your devices through your file sync service": "Bagikan audio bagian antar perangkat melalui layanan sinkronisasi file Anda",
-  "Storage Limit": "Batas penyimpanan"
+  "Storage Limit": "Batas penyimpanan",
+  "Playback settings": "Pengaturan pemutaran",
+  "Paragraph Pause": "Jeda antarparagraf",
+  "Player Style": "Gaya Pemutar",
+  "Full": "Lengkap",
+  "Minimal": "Minimal",
+  "TTS Player Style": "Gaya Pemutar TTS"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1922,7 +1922,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincronizza la tua biblioteca, il progresso di lettura e le evidenziazioni con il tuo Microsoft OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest accede solo ai file che crea nel tuo OneDrive.",
   "Sentence Pause": "Pausa tra le frasi",
-  "Paragraph Gap": "Pausa tra i paragrafi",
   "{{minutes}}m left": "{{minutes}} min rimasti",
   "{{hours}}h left": "{{hours}} h rimaste",
   "Time Remaining": "Tempo rimanente",
@@ -1964,5 +1963,11 @@
   "Reuse generated speech across sessions without refetching": "Riutilizza la voce generata tra le sessioni senza doverla riscaricare",
   "Sync Audio Cache": "Sincronizza cache audio",
   "Share section audio between your devices through your file sync service": "Condividi l'audio delle sezioni tra i tuoi dispositivi tramite il servizio di sincronizzazione dei file",
-  "Storage Limit": "Limite di archiviazione"
+  "Storage Limit": "Limite di archiviazione",
+  "Playback settings": "Impostazioni di riproduzione",
+  "Paragraph Pause": "Pausa tra i paragrafi",
+  "Player Style": "Stile del lettore",
+  "Full": "Completo",
+  "Minimal": "Minimale",
+  "TTS Player Style": "Stile del lettore TTS"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1852,7 +1852,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "ライブラリ、読書進捗、ハイライトを Microsoft OneDrive と同期します。",
   "Readest only accesses the files it creates in your OneDrive.": "Readest がアクセスするのは、OneDrive 内に自身が作成したファイルのみです。",
   "Sentence Pause": "文間のポーズ",
-  "Paragraph Gap": "段落間のポーズ",
   "{{minutes}}m left": "残り{{minutes}}分",
   "{{hours}}h left": "残り{{hours}}時間",
   "Time Remaining": "残り時間",
@@ -1892,5 +1891,11 @@
   "Reuse generated speech across sessions without refetching": "生成した音声をセッションをまたいで再利用し、再取得を不要にします",
   "Sync Audio Cache": "音声キャッシュを同期",
   "Share section audio between your devices through your file sync service": "ファイル同期サービスを通じてセクションの音声をデバイス間で共有",
-  "Storage Limit": "ストレージ上限"
+  "Storage Limit": "ストレージ上限",
+  "Playback settings": "再生設定",
+  "Paragraph Pause": "段落間のポーズ",
+  "Player Style": "プレーヤーのスタイル",
+  "Full": "フル",
+  "Minimal": "ミニマル",
+  "TTS Player Style": "TTSプレーヤーのスタイル"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1852,7 +1852,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "라이브러리, 읽기 진행 상황, 하이라이트를 Microsoft OneDrive와 동기화합니다.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest는 OneDrive에서 직접 만든 파일에만 접근합니다.",
   "Sentence Pause": "문장 사이 일시정지",
-  "Paragraph Gap": "문단 간 정지",
   "{{minutes}}m left": "{{minutes}}분 남음",
   "{{hours}}h left": "{{hours}}시간 남음",
   "Time Remaining": "남은 시간",
@@ -1892,5 +1891,11 @@
   "Reuse generated speech across sessions without refetching": "생성된 음성을 다시 가져오지 않고 세션 간에 재사용합니다",
   "Sync Audio Cache": "오디오 캐시 동기화",
   "Share section audio between your devices through your file sync service": "파일 동기화 서비스를 통해 기기 간에 섹션 오디오 공유",
-  "Storage Limit": "저장 용량 제한"
+  "Storage Limit": "저장 용량 제한",
+  "Playback settings": "재생 설정",
+  "Paragraph Pause": "문단 간 정지",
+  "Player Style": "플레이어 스타일",
+  "Full": "전체",
+  "Minimal": "미니멀",
+  "TTS Player Style": "TTS 플레이어 스타일"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1852,7 +1852,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Segerakkan perpustakaan, kemajuan bacaan dan penonjolan anda dengan Microsoft OneDrive anda.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest hanya mengakses fail yang diciptanya dalam OneDrive anda.",
   "Sentence Pause": "Jeda Antara Ayat",
-  "Paragraph Gap": "Jeda antara perenggan",
   "{{minutes}}m left": "{{minutes}} min lagi",
   "{{hours}}h left": "{{hours}} jam lagi",
   "Time Remaining": "Masa berbaki",
@@ -1892,5 +1891,11 @@
   "Reuse generated speech across sessions without refetching": "Guna semula suara yang dijana antara sesi tanpa mendapatkannya semula",
   "Sync Audio Cache": "Segerakkan cache audio",
   "Share section audio between your devices through your file sync service": "Kongsi audio bahagian antara peranti anda melalui perkhidmatan penyegerakan fail",
-  "Storage Limit": "Had storan"
+  "Storage Limit": "Had storan",
+  "Playback settings": "Tetapan main balik",
+  "Paragraph Pause": "Jeda antara perenggan",
+  "Player Style": "Gaya Pemain",
+  "Full": "Penuh",
+  "Minimal": "Minimal",
+  "TTS Player Style": "Gaya Pemain TTS"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1887,7 +1887,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synchroniseer je bibliotheek, leesvoortgang en markeringen met je Microsoft OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest heeft alleen toegang tot de bestanden die het zelf in je OneDrive aanmaakt.",
   "Sentence Pause": "Zinspauze",
-  "Paragraph Gap": "Alineapauze",
   "{{minutes}}m left": "Nog {{minutes}} min",
   "{{hours}}h left": "Nog {{hours}} u",
   "Time Remaining": "Resterende tijd",
@@ -1928,5 +1927,11 @@
   "Reuse generated speech across sessions without refetching": "Gegenereerde spraak hergebruiken tussen sessies zonder opnieuw op te halen",
   "Sync Audio Cache": "Audiocache synchroniseren",
   "Share section audio between your devices through your file sync service": "Sectie-audio delen tussen je apparaten via je bestandssynchronisatiedienst",
-  "Storage Limit": "Opslaglimiet"
+  "Storage Limit": "Opslaglimiet",
+  "Playback settings": "Afspeelinstellingen",
+  "Paragraph Pause": "Alineapauze",
+  "Player Style": "Spelerstijl",
+  "Full": "Volledig",
+  "Minimal": "Minimaal",
+  "TTS Player Style": "TTS-spelerstijl"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1957,7 +1957,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synchronizuj bibliotekę, postęp czytania i zaznaczenia ze swoim Microsoft OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ma dostęp tylko do plików, które sam tworzy na Twoim OneDrive.",
   "Sentence Pause": "Pauza między zdaniami",
-  "Paragraph Gap": "Przerwa między akapitami",
   "{{minutes}}m left": "Pozostało {{minutes}} min",
   "{{hours}}h left": "Pozostało {{hours}} godz.",
   "Time Remaining": "Pozostały czas",
@@ -2000,5 +1999,11 @@
   "Reuse generated speech across sessions without refetching": "Używaj ponownie wygenerowanej mowy między sesjami bez ponownego pobierania",
   "Sync Audio Cache": "Synchronizuj pamięć podręczną audio",
   "Share section audio between your devices through your file sync service": "Udostępniaj dźwięk sekcji między urządzeniami za pomocą usługi synchronizacji plików",
-  "Storage Limit": "Limit pamięci"
+  "Storage Limit": "Limit pamięci",
+  "Playback settings": "Ustawienia odtwarzania",
+  "Paragraph Pause": "Przerwa między akapitami",
+  "Player Style": "Styl odtwarzacza",
+  "Full": "Pełny",
+  "Minimal": "Minimalny",
+  "TTS Player Style": "Styl odtwarzacza TTS"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1922,7 +1922,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincronize sua biblioteca, progresso de leitura e destaques com o seu Microsoft OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "O Readest só acessa os arquivos que cria no seu OneDrive.",
   "Sentence Pause": "Pausa entre frases",
-  "Paragraph Gap": "Pausa entre parágrafos",
   "{{minutes}}m left": "{{minutes}} min restantes",
   "{{hours}}h left": "{{hours}} h restantes",
   "Time Remaining": "Tempo restante",
@@ -1964,5 +1963,11 @@
   "Reuse generated speech across sessions without refetching": "Reutilizar a voz gerada entre sessões sem baixá-la novamente",
   "Sync Audio Cache": "Sincronizar cache de áudio",
   "Share section audio between your devices through your file sync service": "Compartilhar o áudio das seções entre seus dispositivos pelo seu serviço de sincronização de arquivos",
-  "Storage Limit": "Limite de armazenamento"
+  "Storage Limit": "Limite de armazenamento",
+  "Playback settings": "Configurações de reprodução",
+  "Paragraph Pause": "Pausa entre parágrafos",
+  "Player Style": "Estilo do reprodutor",
+  "Full": "Completo",
+  "Minimal": "Minimalista",
+  "TTS Player Style": "Estilo do reprodutor TTS"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1922,7 +1922,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincronize a sua biblioteca, o progresso de leitura e os destaques com o seu Microsoft OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "O Readest só acede aos ficheiros que cria no seu OneDrive.",
   "Sentence Pause": "Pausa entre frases",
-  "Paragraph Gap": "Pausa entre parágrafos",
   "{{minutes}}m left": "{{minutes}} min restantes",
   "{{hours}}h left": "{{hours}} h restantes",
   "Time Remaining": "Tempo restante",
@@ -1964,5 +1963,11 @@
   "Reuse generated speech across sessions without refetching": "Reutilizar a voz gerada entre sessões sem a obter novamente",
   "Sync Audio Cache": "Sincronizar cache de áudio",
   "Share section audio between your devices through your file sync service": "Partilhar o áudio das secções entre os seus dispositivos através do seu serviço de sincronização de ficheiros",
-  "Storage Limit": "Limite de armazenamento"
+  "Storage Limit": "Limite de armazenamento",
+  "Playback settings": "Definições de reprodução",
+  "Paragraph Pause": "Pausa entre parágrafos",
+  "Player Style": "Estilo do leitor",
+  "Full": "Completo",
+  "Minimal": "Minimalista",
+  "TTS Player Style": "Estilo do leitor TTS"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1922,7 +1922,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sincronizează-ți biblioteca, progresul citirii și evidențierile cu Microsoft OneDrive-ul tău.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest accesează doar fișierele pe care le creează în OneDrive-ul tău.",
   "Sentence Pause": "Pauză între propoziții",
-  "Paragraph Gap": "Pauză între paragrafe",
   "{{minutes}}m left": "Au rămas {{minutes}} min",
   "{{hours}}h left": "Au rămas {{hours}} h",
   "Time Remaining": "Timp rămas",
@@ -1964,5 +1963,11 @@
   "Reuse generated speech across sessions without refetching": "Reutilizați vocea generată între sesiuni fără a o prelua din nou",
   "Sync Audio Cache": "Sincronizează cache-ul audio",
   "Share section audio between your devices through your file sync service": "Partajați audio-ul secțiunilor între dispozitive prin serviciul de sincronizare a fișierelor",
-  "Storage Limit": "Limită de stocare"
+  "Storage Limit": "Limită de stocare",
+  "Playback settings": "Setări de redare",
+  "Paragraph Pause": "Pauză între paragrafe",
+  "Player Style": "Stilul playerului",
+  "Full": "Complet",
+  "Minimal": "Minimal",
+  "TTS Player Style": "Stilul playerului TTS"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1957,7 +1957,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Синхронизируйте свою библиотеку, прогресс чтения и выделения с вашим Microsoft OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest получает доступ только к тем файлам, которые сам создаёт на вашем OneDrive.",
   "Sentence Pause": "Пауза между предложениями",
-  "Paragraph Gap": "Пауза между абзацами",
   "{{minutes}}m left": "Осталось {{minutes}} мин",
   "{{hours}}h left": "Осталось {{hours}} ч",
   "Time Remaining": "Оставшееся время",
@@ -2000,5 +1999,11 @@
   "Reuse generated speech across sessions without refetching": "Повторно использовать созданную речь между сеансами без повторной загрузки",
   "Sync Audio Cache": "Синхронизировать аудиокэш",
   "Share section audio between your devices through your file sync service": "Делитесь аудио разделов между устройствами через сервис синхронизации файлов",
-  "Storage Limit": "Лимит хранилища"
+  "Storage Limit": "Лимит хранилища",
+  "Playback settings": "Настройки воспроизведения",
+  "Paragraph Pause": "Пауза между абзацами",
+  "Player Style": "Стиль плеера",
+  "Full": "Полный",
+  "Minimal": "Минимальный",
+  "TTS Player Style": "Стиль TTS-плеера"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1887,7 +1887,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "ඔබේ පුස්තකාලය, කියවීමේ ප්‍රගතිය සහ ඉස්මතු කිරීම් ඔබේ Microsoft OneDrive සමඟ සමමුහුර්ත කරන්න.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest ප්‍රවේශ වන්නේ ඔබේ OneDrive හි එය සාදන ගොනුවලට පමණි.",
   "Sentence Pause": "වාක්‍ය අතර විරාමය",
-  "Paragraph Gap": "ඡේද අතර විරාමය",
   "{{minutes}}m left": "මිනිත්තු {{minutes}} ක් ඉතිරි",
   "{{hours}}h left": "පැය {{hours}} ක් ඉතිරි",
   "Time Remaining": "ඉතිරි කාලය",
@@ -1928,5 +1927,11 @@
   "Reuse generated speech across sessions without refetching": "ජනනය කළ කථනය නැවත ලබා නොගෙන සැසි අතර නැවත භාවිත කරන්න",
   "Sync Audio Cache": "ශ්‍රව්‍ය කෑෂය සමමුහුර්ත කරන්න",
   "Share section audio between your devices through your file sync service": "ඔබගේ ගොනු සමමුහුර්ත සේවාව හරහා උපාංග අතර කොටස් ශ්‍රව්‍ය බෙදාගන්න",
-  "Storage Limit": "ගබඩා සීමාව"
+  "Storage Limit": "ගබඩා සීමාව",
+  "Playback settings": "වාදන සැකසුම්",
+  "Paragraph Pause": "ඡේද අතර විරාමය",
+  "Player Style": "වාදක විලාසය",
+  "Full": "සම්පූර්ණ",
+  "Minimal": "අවම",
+  "TTS Player Style": "TTS වාදක විලාසය"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1957,7 +1957,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Sinhronizirajte knjižnico, napredek branja in označbe s svojim Microsoft OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest dostopa le do datotek, ki jih sam ustvari v vašem OneDrive.",
   "Sentence Pause": "Premor med stavki",
-  "Paragraph Gap": "Premor med odstavki",
   "{{minutes}}m left": "Še {{minutes}} min",
   "{{hours}}h left": "Še {{hours}} h",
   "Time Remaining": "Preostali čas",
@@ -2000,5 +1999,11 @@
   "Reuse generated speech across sessions without refetching": "Ponovno uporabi ustvarjeni govor med sejami brez ponovnega prenosa",
   "Sync Audio Cache": "Sinhroniziraj zvočni predpomnilnik",
   "Share section audio between your devices through your file sync service": "Delite zvok razdelkov med napravami prek storitve za sinhronizacijo datotek",
-  "Storage Limit": "Omejitev shrambe"
+  "Storage Limit": "Omejitev shrambe",
+  "Playback settings": "Nastavitve predvajanja",
+  "Paragraph Pause": "Premor med odstavki",
+  "Player Style": "Slog predvajalnika",
+  "Full": "Polni",
+  "Minimal": "Minimalni",
+  "TTS Player Style": "Slog predvajalnika TTS"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1887,7 +1887,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Synka ditt bibliotek, dina läsframsteg och markeringar med din Microsoft OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest kommer bara åt de filer som appen skapar i din OneDrive.",
   "Sentence Pause": "Meningspaus",
-  "Paragraph Gap": "Styckepaus",
   "{{minutes}}m left": "{{minutes}} min kvar",
   "{{hours}}h left": "{{hours}} h kvar",
   "Time Remaining": "Återstående tid",
@@ -1928,5 +1927,11 @@
   "Reuse generated speech across sessions without refetching": "Återanvänd genererat tal mellan sessioner utan att hämta det igen",
   "Sync Audio Cache": "Synkronisera ljudcache",
   "Share section audio between your devices through your file sync service": "Dela avsnittsljud mellan dina enheter via din filsynkroniseringstjänst",
-  "Storage Limit": "Lagringsgräns"
+  "Storage Limit": "Lagringsgräns",
+  "Playback settings": "Uppspelningsinställningar",
+  "Paragraph Pause": "Styckepaus",
+  "Player Style": "Spelarstil",
+  "Full": "Fullständig",
+  "Minimal": "Minimal",
+  "TTS Player Style": "TTS-spelarstil"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1887,7 +1887,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "உங்கள் நூலகம், வாசிப்பு முன்னேற்றம் மற்றும் சிறப்பம்சங்களை உங்கள் Microsoft OneDrive உடன் ஒத்திசைக்கவும்.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest உங்கள் OneDrive இல் தானே உருவாக்கும் கோப்புகளை மட்டுமே அணுகும்.",
   "Sentence Pause": "வாக்கிய இடைவேளை",
-  "Paragraph Gap": "பத்தி இடைவேளை",
   "{{minutes}}m left": "{{minutes}} நிமிடங்கள் மீதம்",
   "{{hours}}h left": "{{hours}} மணி நேரம் மீதம்",
   "Time Remaining": "மீதமுள்ள நேரம்",
@@ -1928,5 +1927,11 @@
   "Reuse generated speech across sessions without refetching": "உருவாக்கிய பேச்சை மீண்டும் பெறாமல் அமர்வுகளுக்கு இடையில் மீண்டும் பயன்படுத்தவும்",
   "Sync Audio Cache": "ஆடியோ கேச்சை ஒத்திசை",
   "Share section audio between your devices through your file sync service": "உங்கள் கோப்பு ஒத்திசைவு சேவையின் மூலம் சாதனங்களுக்கு இடையில் பகுதி ஆடியோவைப் பகிரவும்",
-  "Storage Limit": "சேமிப்பு வரம்பு"
+  "Storage Limit": "சேமிப்பு வரம்பு",
+  "Playback settings": "இயக்க அமைப்புகள்",
+  "Paragraph Pause": "பத்தி இடைவேளை",
+  "Player Style": "இயக்கி பாணி",
+  "Full": "முழு",
+  "Minimal": "எளிய",
+  "TTS Player Style": "TTS இயக்கி பாணி"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1852,7 +1852,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "ซิงค์คลังหนังสือ ความคืบหน้าการอ่าน และไฮไลต์ของคุณกับ Microsoft OneDrive ของคุณ",
   "Readest only accesses the files it creates in your OneDrive.": "Readest จะเข้าถึงเฉพาะไฟล์ที่สร้างขึ้นเองใน OneDrive ของคุณเท่านั้น",
   "Sentence Pause": "หยุดระหว่างประโยค",
-  "Paragraph Gap": "หยุดชั่วคราวระหว่างย่อหน้า",
   "{{minutes}}m left": "เหลือ {{minutes}} นาที",
   "{{hours}}h left": "เหลือ {{hours}} ชม.",
   "Time Remaining": "เวลาที่เหลือ",
@@ -1892,5 +1891,11 @@
   "Reuse generated speech across sessions without refetching": "ใช้เสียงที่สร้างไว้ซ้ำระหว่างเซสชันโดยไม่ต้องดึงใหม่",
   "Sync Audio Cache": "ซิงค์แคชเสียง",
   "Share section audio between your devices through your file sync service": "แชร์เสียงของแต่ละส่วนระหว่างอุปกรณ์ผ่านบริการซิงค์ไฟล์ของคุณ",
-  "Storage Limit": "ขีดจำกัดพื้นที่จัดเก็บ"
+  "Storage Limit": "ขีดจำกัดพื้นที่จัดเก็บ",
+  "Playback settings": "การตั้งค่าการเล่น",
+  "Paragraph Pause": "หยุดชั่วคราวระหว่างย่อหน้า",
+  "Player Style": "รูปแบบตัวเล่น",
+  "Full": "เต็มรูปแบบ",
+  "Minimal": "มินิมอล",
+  "TTS Player Style": "รูปแบบตัวเล่น TTS"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1887,7 +1887,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Kütüphanenizi, okuma ilerlemenizi ve vurgularınızı Microsoft OneDrive'ınızla senkronize edin.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest yalnızca OneDrive'ınızda kendi oluşturduğu dosyalara erişir.",
   "Sentence Pause": "Cümle Arası Duraklama",
-  "Paragraph Gap": "Paragraf arası duraklama",
   "{{minutes}}m left": "{{minutes}} dk kaldı",
   "{{hours}}h left": "{{hours}} sa kaldı",
   "Time Remaining": "Kalan süre",
@@ -1928,5 +1927,11 @@
   "Reuse generated speech across sessions without refetching": "Oluşturulan konuşmayı yeniden almadan oturumlar arasında yeniden kullanın",
   "Sync Audio Cache": "Ses önbelleğini eşitle",
   "Share section audio between your devices through your file sync service": "Kısım seslerini dosya eşitleme hizmetiniz üzerinden cihazlarınız arasında paylaşın",
-  "Storage Limit": "Depolama sınırı"
+  "Storage Limit": "Depolama sınırı",
+  "Playback settings": "Oynatma Ayarları",
+  "Paragraph Pause": "Paragraf arası duraklama",
+  "Player Style": "Oynatıcı Stili",
+  "Full": "Tam",
+  "Minimal": "Minimal",
+  "TTS Player Style": "TTS Oynatıcı Stili"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1957,7 +1957,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Синхронізуйте свою бібліотеку, проґрес читання та виділення з вашим Microsoft OneDrive.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest має доступ лише до файлів, які сам створює у вашому OneDrive.",
   "Sentence Pause": "Пауза між реченнями",
-  "Paragraph Gap": "Пауза між абзацами",
   "{{minutes}}m left": "Залишилось {{minutes}} хв",
   "{{hours}}h left": "Залишилось {{hours}} год",
   "Time Remaining": "Час, що залишився",
@@ -2000,5 +1999,11 @@
   "Reuse generated speech across sessions without refetching": "Повторно використовувати згенероване мовлення між сеансами без повторного отримання",
   "Sync Audio Cache": "Синхронізувати аудіокеш",
   "Share section audio between your devices through your file sync service": "Діліться аудіо секцій між пристроями через сервіс синхронізації файлів",
-  "Storage Limit": "Ліміт сховища"
+  "Storage Limit": "Ліміт сховища",
+  "Playback settings": "Налаштування відтворення",
+  "Paragraph Pause": "Пауза між абзацами",
+  "Player Style": "Стиль плеєра",
+  "Full": "Повний",
+  "Minimal": "Мінімальний",
+  "TTS Player Style": "Стиль TTS-плеєра"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1887,7 +1887,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Kutubxonangiz, oʻqish jarayoni va belgilashlaringizni Microsoft OneDrive bilan sinxronlang.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest OneDrive-ingizda faqat oʻzi yaratgan fayllarga kiradi.",
   "Sentence Pause": "Gaplar orasidagi pauza",
-  "Paragraph Gap": "Paragraflar orasidagi tanaffus",
   "{{minutes}}m left": "{{minutes}} daqiqa qoldi",
   "{{hours}}h left": "{{hours}} soat qoldi",
   "Time Remaining": "Qolgan vaqt",
@@ -1928,5 +1927,11 @@
   "Reuse generated speech across sessions without refetching": "Yaratilgan nutqni qayta yuklab olmasdan seanslar orasida qayta ishlatish",
   "Sync Audio Cache": "Audio keshni sinxronlash",
   "Share section audio between your devices through your file sync service": "Boʻlim audiosini fayl sinxronlash xizmati orqali qurilmalaringiz oʻrtasida ulashing",
-  "Storage Limit": "Saqlash chegarasi"
+  "Storage Limit": "Saqlash chegarasi",
+  "Playback settings": "Ijro sozlamalari",
+  "Paragraph Pause": "Paragraflar orasidagi tanaffus",
+  "Player Style": "Pleyer uslubi",
+  "Full": "Toʻliq",
+  "Minimal": "Minimal",
+  "TTS Player Style": "TTS pleyer uslubi"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1852,7 +1852,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "Đồng bộ thư viện, tiến trình đọc và điểm nổi bật của bạn với Microsoft OneDrive của bạn.",
   "Readest only accesses the files it creates in your OneDrive.": "Readest chỉ truy cập các tệp do chính nó tạo trong OneDrive của bạn.",
   "Sentence Pause": "Khoảng dừng giữa các câu",
-  "Paragraph Gap": "Khoảng dừng giữa đoạn văn",
   "{{minutes}}m left": "Còn {{minutes}} phút",
   "{{hours}}h left": "Còn {{hours}} giờ",
   "Time Remaining": "Thời gian còn lại",
@@ -1892,5 +1891,11 @@
   "Reuse generated speech across sessions without refetching": "Dùng lại giọng nói đã tạo giữa các phiên mà không cần tải lại",
   "Sync Audio Cache": "Đồng bộ bộ nhớ đệm âm thanh",
   "Share section audio between your devices through your file sync service": "Chia sẻ âm thanh của các phần giữa các thiết bị qua dịch vụ đồng bộ tệp của bạn",
-  "Storage Limit": "Giới hạn lưu trữ"
+  "Storage Limit": "Giới hạn lưu trữ",
+  "Playback settings": "Cài đặt phát",
+  "Paragraph Pause": "Khoảng dừng giữa đoạn văn",
+  "Player Style": "Kiểu trình phát",
+  "Full": "Đầy đủ",
+  "Minimal": "Tối giản",
+  "TTS Player Style": "Kiểu trình phát TTS"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1852,7 +1852,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "将您的书库、阅读进度和高亮与您的 Microsoft OneDrive 同步。",
   "Readest only accesses the files it creates in your OneDrive.": "Readest 只会访问它在您的 OneDrive 中创建的文件。",
   "Sentence Pause": "句间停顿",
-  "Paragraph Gap": "段落间隔",
   "{{minutes}}m left": "{{minutes}}分钟",
   "{{hours}}h left": "{{hours}}小时",
   "Time Remaining": "剩余时间",
@@ -1892,5 +1891,11 @@
   "Reuse generated speech across sessions without refetching": "跨会话复用已生成的语音，无需重新获取",
   "Sync Audio Cache": "同步音频缓存",
   "Share section audio between your devices through your file sync service": "通过您的文件同步服务在设备间共享章节音频",
-  "Storage Limit": "存储上限"
+  "Storage Limit": "存储上限",
+  "Playback settings": "播放设置",
+  "Paragraph Pause": "段落间隔",
+  "Player Style": "播放器样式",
+  "Full": "完整",
+  "Minimal": "简约",
+  "TTS Player Style": "TTS 播放器样式"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1852,7 +1852,6 @@
   "Sync your library, reading progress, and highlights with your Microsoft OneDrive.": "將您的書庫、閱讀進度和高亮與您的 Microsoft OneDrive 同步。",
   "Readest only accesses the files it creates in your OneDrive.": "Readest 只會存取它在您的 OneDrive 中建立的檔案。",
   "Sentence Pause": "句間停頓",
-  "Paragraph Gap": "段落間隔",
   "{{minutes}}m left": "{{minutes}}分鐘",
   "{{hours}}h left": "{{hours}}小時",
   "Time Remaining": "剩餘時間",
@@ -1892,5 +1891,11 @@
   "Reuse generated speech across sessions without refetching": "跨工作階段重複使用已產生的語音，無需重新取得",
   "Sync Audio Cache": "同步音訊快取",
   "Share section audio between your devices through your file sync service": "透過您的檔案同步服務在裝置間共享章節音訊",
-  "Storage Limit": "儲存空間上限"
+  "Storage Limit": "儲存空間上限",
+  "Playback settings": "播放設定",
+  "Paragraph Pause": "段落間隔",
+  "Player Style": "播放器樣式",
+  "Full": "完整",
+  "Minimal": "簡約",
+  "TTS Player Style": "TTS 播放器樣式"
 }

--- a/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/context/EnvContext', () => ({
   }),
 }));
 
+let viewSettingsOverride: Record<string, unknown> = {};
 const readerState = {
   hoveredBookKey: '',
   bottomBarTab: '',
@@ -24,6 +25,7 @@ const readerState = {
     ...DEFAULT_VIEW_CONFIG,
     ...DEFAULT_BOOK_LAYOUT,
     ...DEFAULT_TTS_CONFIG,
+    ...viewSettingsOverride,
   }),
 };
 vi.mock('@/store/readerStore', () => ({
@@ -66,6 +68,7 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
 
 describe('TTSMiniPlayer', () => {
   beforeEach(() => {
+    viewSettingsOverride = {};
     readerState.hoveredBookKey = '';
     readerState.bottomBarTab = '';
     progressState.sectionLabel = 'Chapter 5';
@@ -77,25 +80,46 @@ describe('TTSMiniPlayer', () => {
     vi.clearAllMocks();
   });
 
-  test('leads with the chapter, keeps time below, and drops title and cover', () => {
+  test('minimal style shows only the time info, dropping chapter, title and cover', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
     getBookData.mockReturnValue({
       book: { title: 'Alice in Wonderland', coverImageUrl: 'blob:cover' },
     });
     const { container } = render(<TTSMiniPlayer {...makeProps()} />);
-    expect(screen.getByText('Chapter 5')).toBeTruthy();
+    expect(screen.queryByText('Chapter 5')).toBeNull();
     expect(screen.queryByText('Alice in Wonderland')).toBeNull();
     expect(container.querySelector('img')).toBeNull();
     expect(screen.getByText(/0:10/)).toBeTruthy();
     expect(screen.getByText(/-1:30/)).toBeTruthy();
   });
 
-  test('falls back to the book title when no section label exists', () => {
-    progressState.sectionLabel = undefined;
+  test('minimal style stacks the sleep timer on a second line below the time', () => {
+    vi.useFakeTimers();
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
+    render(<TTSMiniPlayer {...makeProps({ timeoutTimestamp: Date.now() + 90_000 })} />);
+    const body = screen.getByLabelText('Open Read Aloud player');
+    expect(body.className).toContain('flex-col');
+    // Time row and timer chip are separate stacked children, so the timer
+    // cannot squeeze the elapsed time into truncation.
+    const timer = screen.getByText(/^1:(2\d|30)$/);
+    const elapsed = screen.getByText('0:10');
+    expect(timer.parentElement).toBe(body);
+    expect(elapsed.parentElement?.parentElement).toBe(body);
+    vi.useRealTimers();
+  });
+
+  test('minimal style centers the time and emphasizes elapsed over remaining', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
     render(<TTSMiniPlayer {...makeProps()} />);
-    expect(screen.getByText('Alice in Wonderland')).toBeTruthy();
+    const body = screen.getByLabelText('Open Read Aloud player');
+    expect(body.className).toContain('justify-center');
+    const elapsed = screen.getByText('0:10');
+    expect(elapsed.className).toContain('font-medium');
+    expect(screen.getByText(/-1:30/).className).toContain('text-base-content/60');
   });
 
   test('sentence and paragraph skips and play/pause drive the transport callbacks', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
     const props = makeProps();
     render(<TTSMiniPlayer {...props} />);
     fireEvent.click(screen.getByLabelText('Previous Sentence'));
@@ -113,6 +137,7 @@ describe('TTSMiniPlayer', () => {
   });
 
   test('play and pause glyphs share a size so toggling does not shift the row', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
     const { rerender } = render(<TTSMiniPlayer {...makeProps({ isPlaying: true })} />);
     const pauseWidth = screen.getByLabelText('Pause').querySelector('svg')?.getAttribute('width');
     rerender(<TTSMiniPlayer {...makeProps({ isPlaying: false })} />);
@@ -130,13 +155,15 @@ describe('TTSMiniPlayer', () => {
   });
 
   test('tapping the body expands the player sheet', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
     const props = makeProps();
     render(<TTSMiniPlayer {...props} />);
-    fireEvent.click(screen.getByText('Chapter 5'));
+    fireEvent.click(screen.getByLabelText('Open Read Aloud player'));
     expect(props.onExpand).toHaveBeenCalled();
   });
 
   test('the settings affordance shows the speed and opens the full player', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
     const props = makeProps();
     render(<TTSMiniPlayer {...props} />);
     const btn = screen.getByLabelText('Playback settings');
@@ -199,5 +226,39 @@ describe('TTSMiniPlayer', () => {
     render(<TTSMiniPlayer {...makeProps({ timeoutTimestamp: Date.now() + 90_000 })} />);
     expect(screen.getByText(/^1:(2\d|30)$/)).toBeTruthy();
     vi.useRealTimers();
+  });
+
+  // Player Style 'full': the pre-#5162 card (0.11.18) with book cover, book
+  // title, chapter + timestamps line, and the sentence-only transport.
+  test('full style is the default and shows cover, book title, chapter and timestamps', () => {
+    getBookData.mockReturnValue({
+      book: { title: 'Alice in Wonderland', coverImageUrl: 'blob:cover' },
+    });
+    const { container } = render(<TTSMiniPlayer {...makeProps()} />);
+    expect(screen.getByText('Alice in Wonderland')).toBeTruthy();
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('blob:cover');
+    expect(screen.getByText('Chapter 5 · 0:10 · -1:30')).toBeTruthy();
+  });
+
+  test('full style keeps the sentence-only transport without minimal chrome', () => {
+    const props = makeProps();
+    render(<TTSMiniPlayer {...props} />);
+    fireEvent.click(screen.getByLabelText('Previous Sentence'));
+    expect(props.onBackward).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByLabelText('Next Sentence'));
+    expect(props.onForward).toHaveBeenCalledWith(true);
+    expect(screen.queryByLabelText('Previous Paragraph')).toBeNull();
+    expect(screen.queryByLabelText('Next Paragraph')).toBeNull();
+    expect(screen.queryByLabelText('Playback settings')).toBeNull();
+  });
+
+  test('full style expands the sheet from the book info area', () => {
+    getBookData.mockReturnValue({
+      book: { title: 'Alice in Wonderland', coverImageUrl: 'blob:cover' },
+    });
+    const props = makeProps();
+    render(<TTSMiniPlayer {...props} />);
+    fireEvent.click(screen.getByLabelText('Open Read Aloud player'));
+    expect(props.onExpand).toHaveBeenCalled();
   });
 });

--- a/apps/readest-app/src/__tests__/services/edge-tts-client.test.ts
+++ b/apps/readest-app/src/__tests__/services/edge-tts-client.test.ts
@@ -43,9 +43,10 @@ vi.mock('@/utils/misc', () => ({
   stubTranslation: (key: string) => key,
 }));
 
+let tauriPlatform = false;
 vi.mock('@/services/environment', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/services/environment')>()),
-  isTauriAppPlatform: () => false,
+  isTauriAppPlatform: () => tauriPlatform,
 }));
 
 vi.mock('@/services/tts/TTSUtils', async (importOriginal) => {
@@ -75,6 +76,7 @@ describe('EdgeTTSClient', () => {
   let client: EdgeTTSClient;
 
   beforeEach(() => {
+    tauriPlatform = false;
     createBehavior = () => Promise.resolve(undefined);
     createAudioDataBehavior = vi.fn<() => Promise<MockAudioData>>(() =>
       Promise.resolve({ data: new ArrayBuffer(8), boundaries: [] }),
@@ -144,6 +146,27 @@ describe('EdgeTTSClient', () => {
       expect(c.initialized).toBe(true);
       // Two calls: initial wss attempt + https fallback
       expect(callCount).toBe(2);
+    });
+
+    test('wss failure does not fall back to https on Tauri even when authenticated', async () => {
+      tauriPlatform = true;
+      const mockController = {
+        isAuthenticated: true,
+        dispatchEvent: vi.fn(),
+      } as unknown as TTSController;
+      const c = new EdgeTTSClient(mockController);
+
+      let callCount = 0;
+      createBehavior = () => {
+        callCount++;
+        return Promise.reject(new Error('offline'));
+      };
+
+      const result = await c.init();
+      expect(result).toBe(false);
+      // Only the wss probe ran: the /api/tts/edge proxy must not be requested
+      // from the Tauri app (its native wss transport is the only Edge path).
+      expect(callCount).toBe(1);
     });
 
     test('wss failure dispatches tts-need-auth when not authenticated', async () => {

--- a/apps/readest-app/src/__tests__/services/tts/wordPronouncer.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/wordPronouncer.test.ts
@@ -49,6 +49,12 @@ const h = vi.hoisted(() => {
   };
 });
 
+let tauriPlatform = false;
+vi.mock('@/services/environment', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/environment')>()),
+  isTauriAppPlatform: () => tauriPlatform,
+}));
+
 vi.mock('@/libs/edgeTTS', () => {
   class EdgeSpeechTTS {
     static voices = [
@@ -90,6 +96,7 @@ import { pronounceWord, pickEdgeVoiceId, cancelWordPronounce } from '@/services/
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 beforeEach(() => {
+  tauriPlatform = false;
   vi.clearAllMocks();
   (globalThis as unknown as { AudioContext: unknown }).AudioContext = vi.fn();
   h.createAudioData.mockReset();
@@ -166,6 +173,29 @@ describe('pronounceWord — fallback path', () => {
 
     expect(h.nativeSpeak).toHaveBeenCalledTimes(1);
     expect(h.webSpeak).not.toHaveBeenCalled();
+  });
+
+  it('retries via the authenticated https proxy on the web when wss fails', async () => {
+    h.createAudioData.mockRejectedValue(new Error('wss blocked'));
+
+    await pronounceWord('hello', 'en', {}, vi.fn());
+    await flush();
+
+    // wss attempt + https proxy retry
+    expect(h.createAudioData).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry via the https proxy on Tauri when wss fails', async () => {
+    tauriPlatform = true;
+    h.createAudioData.mockRejectedValue(new Error('offline'));
+
+    await pronounceWord('hello', 'en', { appService: { isMobile: true } as never }, vi.fn());
+    await flush();
+
+    // Only the native wss attempt: the /api/tts/edge proxy must not be
+    // requested from the Tauri app; the word drops to the platform speech.
+    expect(h.createAudioData).toHaveBeenCalledTimes(1);
+    expect(h.nativeSpeak).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
@@ -8,7 +8,11 @@ import {
   MdKeyboardDoubleArrowLeft,
   MdKeyboardDoubleArrowRight,
   MdOutlinePause,
+  MdPauseCircleFilled,
   MdPlayArrow,
+  MdPlayCircleFilled,
+  MdSkipNext,
+  MdSkipPrevious,
 } from 'react-icons/md';
 import { Insets } from '@/types/misc';
 import { useEnv } from '@/context/EnvContext';
@@ -43,10 +47,10 @@ const SpeedSettingsIcon = ({ size, label }: { size: number; label: string }) => 
           into edge 2 (only its trailing third draws), runs through edges
           3-6, and stops at edge 1's midpoint (only its leading half draws).
           The opening between the two partial edges carries the speed label. */}
-      <path d='M19.33 10.66 L20.8 13.2 L16.4 20.82 L7.6 20.82 L3.2 13.2 L7.6 5.58 L12 5.58' />
-      <circle cx='12' cy='13.2' r='3.2' />
+      <path d='M19.33 9.46 L20.8 12 L16.4 19.62 L7.6 19.62 L3.2 12 L7.6 4.38 L12 4.38' />
+      <circle cx='12' cy='12' r='3.2' />
     </svg>
-    <span className='absolute start-[56%] top-[6%] text-[9px] font-semibold leading-none tabular-nums'>
+    <span className='absolute start-[56%] top-[5%] text-[9px] font-semibold leading-none tabular-nums'>
       {label}
     </span>
   </span>
@@ -69,11 +73,13 @@ type TTSMiniPlayerProps = {
 };
 
 // Persistent mini-player shown while a TTS session is active: passive
-// progress line with buffer-ahead fill on the card's bottom edge, chapter +
-// time info (tap to expand the full player sheet), and the same
-// paragraph/sentence transport vocabulary as the full player (#5101 — the
-// paragraph skips matter to eyes-off listeners). Deliberately chrome-free:
-// no cover, no book title, plain glyph buttons.
+// progress line with buffer-ahead fill on the card's bottom edge and, per the
+// ttsPlayerStyle setting, one of two card layouts. 'full' (the default) is
+// the 0.11.18 card: book cover, book title, chapter + timestamps line, and a
+// sentence-only transport with a filled play blob. 'minimal' is chrome-free —
+// no cover, no titles, plain glyphs — with only the time info and the same
+// paragraph/sentence transport vocabulary as the full player sheet (#5101 —
+// the paragraph skips matter to eyes-off listeners).
 const TTSMiniPlayer = ({
   bookKey,
   isPlaying,
@@ -98,8 +104,9 @@ const TTSMiniPlayer = ({
   const timerLabel = useCountdownLabel(timeoutTimestamp);
   const iconSize14 = useResponsiveSize(14);
   const iconSize20 = useResponsiveSize(20);
-  const iconSize22 = useResponsiveSize(22);
+  const iconSize26 = useResponsiveSize(26);
   const iconSize28 = useResponsiveSize(28);
+  const iconSize40 = useResponsiveSize(40);
 
   const book = getBookData(bookKey)?.book;
   const sectionLabel = progress?.sectionLabel;
@@ -142,20 +149,22 @@ const TTSMiniPlayer = ({
   const bottomOffset = viewSettings
     ? getTTSMiniPlayerBottomOffset(viewSettings, { barVisible, usesMobileBar, panelTopOffset })
     : 16;
+  const playerStyle = viewSettings?.ttsPlayerStyle ?? 'full';
 
   const { ready, position, total, measuredFraction } = playback;
   const forceHours = total >= 3600;
   const playedPct = ready && total > 0 ? Math.min((position / total) * 100, 100) : 0;
   const bufferedPct = ready ? Math.max(playedPct, Math.min(measuredFraction, 1) * 100) : 0;
-  const timeLabel =
-    hasTimeline && ready
-      ? `${formatPlaybackTime(position, forceHours)} · -${formatPlaybackTime(
-          Math.max(total - position, 0),
-          forceHours,
-        )}`
-      : chapterRemainingSec !== null
-        ? _('{{time}} left in chapter', { time: formatPlaybackTime(chapterRemainingSec) })
-        : '';
+  // The minimal style weights the two halves differently, so keep them split;
+  // the full style joins them into the 0.11.18 "elapsed · -remaining" string.
+  const elapsedLabel = hasTimeline && ready ? formatPlaybackTime(position, forceHours) : '';
+  const remainingLabel =
+    hasTimeline && ready ? `-${formatPlaybackTime(Math.max(total - position, 0), forceHours)}` : '';
+  const timeLabel = elapsedLabel
+    ? `${elapsedLabel} · ${remainingLabel}`
+    : chapterRemainingSec !== null
+      ? _('{{time}} left in chapter', { time: formatPlaybackTime(chapterRemainingSec) })
+      : '';
 
   return (
     <div
@@ -193,96 +202,184 @@ const TTSMiniPlayer = ({
             />
           </div>
         )}
-        <div className='text-base-content flex h-14 items-center gap-2 pe-1 ps-1.5'>
-          {/* Visible route into the full player: a settings glyph carrying
-              the live speed as a superscript (the sheet is where speed and
-              voice live). The chapter text expands too, but text alone
-              reads as a label, not an affordance. */}
-          <button
-            type='button'
-            aria-label={_('Playback settings')}
-            onClick={onExpand}
-            className='text-base-content/70 flex shrink-0 rounded-full p-1 pe-4'
-          >
-            <SpeedSettingsIcon size={iconSize22} label={formatRate(viewSettings?.ttsRate ?? 1.0)} />
-          </button>
-          <div
-            role='button'
-            tabIndex={0}
-            onClick={onExpand}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') onExpand();
-            }}
-            aria-label={_('Open Read Aloud player')}
-            className='flex min-w-0 flex-1 cursor-pointer flex-col justify-center gap-0.5'
-          >
-            <span className='truncate text-sm font-medium'>
-              {sectionLabel || book?.title || ''}
-            </span>
-            {(timeLabel || timerLabel) && (
-              <span className='text-base-content/60 flex items-center gap-1.5 text-xs tabular-nums'>
-                {timeLabel && <span className='truncate'>{timeLabel}</span>}
-                {timerLabel && (
-                  <span className='flex shrink-0 items-center gap-0.5'>
-                    <MdAlarm size={iconSize14} aria-hidden='true' />
-                    {timerLabel}
+        {playerStyle === 'full' ? (
+          <div className='text-base-content flex h-14 items-center gap-1 px-2'>
+            <div
+              role='button'
+              tabIndex={0}
+              onClick={onExpand}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') onExpand();
+              }}
+              aria-label={_('Open Read Aloud player')}
+              className='flex min-w-0 flex-1 cursor-pointer items-center gap-2'
+            >
+              {book?.coverImageUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={book.coverImageUrl}
+                  alt=''
+                  className='h-10 w-10 shrink-0 rounded-lg object-cover'
+                />
+              ) : null}
+              <div className='flex min-w-0 flex-col'>
+                <span className='truncate text-sm'>{book?.title ?? ''}</span>
+                {(sectionLabel || timeLabel) && (
+                  <span className='text-base-content/70 truncate text-xs tabular-nums'>
+                    {[sectionLabel, timeLabel].filter(Boolean).join(' · ')}
                   </span>
                 )}
-              </span>
+              </div>
+            </div>
+            {timerLabel && (
+              <span className='shrink-0 text-xs tabular-nums opacity-70'>{timerLabel}</span>
             )}
+            <div dir='ltr' className='flex shrink-0 items-center gap-1'>
+              <button
+                type='button'
+                className='shrink-0 rounded-full p-1'
+                aria-label={_('Previous Sentence')}
+                onClick={() => onBackward(true)}
+              >
+                <MdSkipPrevious size={iconSize28} />
+              </button>
+              <button
+                type='button'
+                className='shrink-0 rounded-full p-0.5'
+                aria-label={isPlaying ? _('Pause') : _('Play')}
+                onClick={onTogglePlay}
+              >
+                {isPlaying ? (
+                  <MdPauseCircleFilled size={iconSize40} />
+                ) : (
+                  <MdPlayCircleFilled size={iconSize40} />
+                )}
+              </button>
+              <button
+                type='button'
+                className='shrink-0 rounded-full p-1'
+                aria-label={_('Next Sentence')}
+                onClick={() => onForward(true)}
+              >
+                <MdSkipNext size={iconSize28} />
+              </button>
+              <button
+                type='button'
+                className='shrink-0 rounded-full p-1'
+                aria-label={_('Stop reading aloud')}
+                onClick={onStop}
+              >
+                <MdClose size={iconSize20} />
+              </button>
+            </div>
           </div>
-          <div dir='ltr' className='flex shrink-0 items-center'>
+        ) : (
+          <div className='text-base-content flex h-14 items-center gap-2 pe-1 ps-1.5'>
+            {/* Visible route into the full player: a settings glyph carrying
+              the live speed as a superscript (the sheet is where speed and
+              voice live). The time text expands too, but text alone reads
+              as a label, not an affordance. */}
             <button
               type='button'
-              className='shrink-0 rounded-full p-1'
-              aria-label={_('Previous Paragraph')}
-              onClick={() => onBackward(false)}
+              aria-label={_('Playback settings')}
+              onClick={onExpand}
+              className='text-base-content/70 flex shrink-0 rounded-full p-1 pe-4'
             >
-              <MdKeyboardDoubleArrowLeft size={iconSize20} />
+              <SpeedSettingsIcon
+                size={iconSize26}
+                label={formatRate(viewSettings?.ttsRate ?? 1.0)}
+              />
             </button>
-            <button
-              type='button'
-              className='shrink-0 rounded-full p-1'
-              aria-label={_('Previous Sentence')}
-              onClick={() => onBackward(true)}
+            <div
+              role='button'
+              tabIndex={0}
+              onClick={onExpand}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') onExpand();
+              }}
+              aria-label={_('Open Read Aloud player')}
+              className='flex min-w-0 flex-1 cursor-pointer flex-col items-center justify-center gap-0.5'
             >
-              <MdKeyboardArrowLeft size={iconSize22} />
-            </button>
-            <button
-              type='button'
-              className='shrink-0 rounded-full p-1'
-              aria-label={isPlaying ? _('Pause') : _('Play')}
-              onClick={onTogglePlay}
-            >
-              {/* Same canvas size for both glyphs, or the row shifts on toggle. */}
-              {isPlaying ? <MdOutlinePause size={iconSize28} /> : <MdPlayArrow size={iconSize28} />}
-            </button>
-            <button
-              type='button'
-              className='shrink-0 rounded-full p-1'
-              aria-label={_('Next Sentence')}
-              onClick={() => onForward(true)}
-            >
-              <MdKeyboardArrowRight size={iconSize22} />
-            </button>
-            <button
-              type='button'
-              className='shrink-0 rounded-full p-1'
-              aria-label={_('Next Paragraph')}
-              onClick={() => onForward(false)}
-            >
-              <MdKeyboardDoubleArrowRight size={iconSize20} />
-            </button>
-            <button
-              type='button'
-              className='text-base-content/70 ms-0.5 shrink-0 rounded-full p-1'
-              aria-label={_('Stop reading aloud')}
-              onClick={onStop}
-            >
-              <MdClose size={iconSize20} />
-            </button>
+              {/* Centered in the flexible middle; elapsed carries the weight,
+                  the remaining half stays dim. An armed sleep timer stacks on
+                  its own line so it can never squeeze the time into
+                  truncation. */}
+              {elapsedLabel ? (
+                <span className='flex min-w-0 items-baseline gap-1 text-sm tabular-nums'>
+                  <span className='text-base-content truncate font-medium'>{elapsedLabel}</span>
+                  <span className='text-base-content/60 shrink-0'>· {remainingLabel}</span>
+                </span>
+              ) : (
+                timeLabel && (
+                  <span className='text-base-content/60 truncate text-xs tabular-nums'>
+                    {timeLabel}
+                  </span>
+                )
+              )}
+              {timerLabel && (
+                <span className='text-base-content/60 flex shrink-0 items-center gap-0.5 text-xs tabular-nums'>
+                  <MdAlarm size={iconSize14} aria-hidden='true' />
+                  {timerLabel}
+                </span>
+              )}
+            </div>
+            <div dir='ltr' className='flex shrink-0 items-center'>
+              <button
+                type='button'
+                className='shrink-0 rounded-full p-1'
+                aria-label={_('Previous Paragraph')}
+                onClick={() => onBackward(false)}
+              >
+                <MdKeyboardDoubleArrowLeft size={iconSize26} />
+              </button>
+              <button
+                type='button'
+                className='shrink-0 rounded-full p-1'
+                aria-label={_('Previous Sentence')}
+                onClick={() => onBackward(true)}
+              >
+                <MdKeyboardArrowLeft size={iconSize26} />
+              </button>
+              <button
+                type='button'
+                className='shrink-0 rounded-full p-1'
+                aria-label={isPlaying ? _('Pause') : _('Play')}
+                onClick={onTogglePlay}
+              >
+                {/* Same canvas size for both glyphs, or the row shifts on toggle. */}
+                {isPlaying ? (
+                  <MdOutlinePause size={iconSize26} />
+                ) : (
+                  <MdPlayArrow size={iconSize26} />
+                )}
+              </button>
+              <button
+                type='button'
+                className='shrink-0 rounded-full p-1'
+                aria-label={_('Next Sentence')}
+                onClick={() => onForward(true)}
+              >
+                <MdKeyboardArrowRight size={iconSize26} />
+              </button>
+              <button
+                type='button'
+                className='shrink-0 rounded-full p-1'
+                aria-label={_('Next Paragraph')}
+                onClick={() => onForward(false)}
+              >
+                <MdKeyboardDoubleArrowRight size={iconSize26} />
+              </button>
+              <button
+                type='button'
+                className='text-base-content/70 ms-0.5 shrink-0 rounded-full p-1'
+                aria-label={_('Stop reading aloud')}
+                onClick={onStop}
+              >
+                <MdClose size={iconSize20} />
+              </button>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/apps/readest-app/src/components/settings/TTSPanel.tsx
+++ b/apps/readest-app/src/components/settings/TTSPanel.tsx
@@ -6,7 +6,11 @@ import { useResetViewSettings } from '@/hooks/useResetSettings';
 import { useTranslation } from '@/hooks/useTranslation';
 import { saveViewSettings } from '@/helpers/settings';
 import { SettingsPanelPanelProp } from './SettingsDialog';
-import { TTSHighlightGranularity, TTSMediaMetadataMode } from '@/services/tts/types';
+import {
+  TTSHighlightGranularity,
+  TTSMediaMetadataMode,
+  TTSPlayerStyle,
+} from '@/services/tts/types';
 import { getTTSCacheConfig, setTTSCacheConfig } from '@/services/tts/providers/bookCacheStore';
 import { BoxedList, SettingsRow, SettingsSelect, SettingsSwitchRow } from './primitives';
 import TTSHighlightStyleEditor, { TTSHighlightStyle } from './color/TTSHighlightStyleEditor';
@@ -20,6 +24,9 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
 
   const [ttsMediaMetadata, setTtsMediaMetadata] = useState<TTSMediaMetadataMode>(
     viewSettings.ttsMediaMetadata ?? 'sentence',
+  );
+  const [ttsPlayerStyle, setTtsPlayerStyle] = useState<TTSPlayerStyle>(
+    viewSettings.ttsPlayerStyle ?? 'full',
   );
   const [ttsHighlightGranularity, setTtsHighlightGranularity] = useState<TTSHighlightGranularity>(
     viewSettings.ttsHighlightGranularity ?? 'word',
@@ -46,6 +53,7 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
   const handleReset = () => {
     resetToDefaults({
       ttsMediaMetadata: setTtsMediaMetadata as React.Dispatch<React.SetStateAction<string>>,
+      ttsPlayerStyle: setTtsPlayerStyle as React.Dispatch<React.SetStateAction<string>>,
       ttsHighlightGranularity: setTtsHighlightGranularity as React.Dispatch<
         React.SetStateAction<string>
       >,
@@ -62,6 +70,12 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
     saveViewSettings(envConfig, bookKey, 'ttsMediaMetadata', ttsMediaMetadata, false, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ttsMediaMetadata]);
+
+  useEffect(() => {
+    if (ttsPlayerStyle === viewSettings.ttsPlayerStyle) return;
+    saveViewSettings(envConfig, bookKey, 'ttsPlayerStyle', ttsPlayerStyle, false, false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ttsPlayerStyle]);
 
   useEffect(() => {
     if (ttsHighlightGranularity === viewSettings.ttsHighlightGranularity) return;
@@ -103,6 +117,10 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
     setTtsMediaMetadata(event.target.value as TTSMediaMetadataMode);
   };
 
+  const handlePlayerStyleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setTtsPlayerStyle(event.target.value as TTSPlayerStyle);
+  };
+
   const handleTTSGranularityChange = (granularity: TTSHighlightGranularity) => {
     setTtsHighlightGranularity(granularity);
   };
@@ -122,6 +140,17 @@ const TTSPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }
       />
 
       <BoxedList title={_('Media Info')} data-setting-id='settings.tts.mediaMetadata'>
+        <SettingsRow label={_('Player Style')} data-setting-id='settings.tts.playerStyle'>
+          <SettingsSelect
+            value={ttsPlayerStyle}
+            onChange={handlePlayerStyleChange}
+            ariaLabel={_('Player Style')}
+            options={[
+              { value: 'full', label: _('Full') },
+              { value: 'minimal', label: _('Minimal') },
+            ]}
+          />
+        </SettingsRow>
         <SettingsRow label={_('Update Frequency')}>
           <SettingsSelect
             value={ttsMediaMetadata}

--- a/apps/readest-app/src/services/commandRegistry.ts
+++ b/apps/readest-app/src/services/commandRegistry.ts
@@ -385,6 +385,12 @@ const colorPanelItems = [
     section: 'TTS',
   },
   {
+    id: 'settings.tts.playerStyle',
+    labelKey: _('TTS Player Style'),
+    keywords: ['tts', 'player', 'mini', 'style', 'cover', 'full', 'minimal'],
+    section: 'TTS',
+  },
+  {
     id: 'settings.color.readingRuler',
     labelKey: _('Reading Ruler'),
     keywords: ['reading', 'ruler', 'line', 'guide', 'focus'],

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -425,6 +425,7 @@ export const DEFAULT_TTS_CONFIG: TTSConfig = {
   ttsHighlightOptions: { style: 'highlight', color: '#808080' },
   ttsHighlightGranularity: 'word',
   ttsMediaMetadata: 'sentence',
+  ttsPlayerStyle: 'full',
 };
 
 export const DEFAULT_TRANSLATOR_CONFIG: TranslatorConfig = {

--- a/apps/readest-app/src/services/tts/EdgeTTSClient.ts
+++ b/apps/readest-app/src/services/tts/EdgeTTSClient.ts
@@ -1,4 +1,5 @@
 import { EDGE_TTS_PROTOCOL } from '@/libs/edgeTTS';
+import { isTauriAppPlatform } from '@/services/environment';
 import { AppService } from '@/types/system';
 import { BufferedTTSClient } from './BufferedTTSClient';
 import { BookTTSCacheStore, getTTSCacheConfig } from './providers/bookCacheStore';
@@ -41,13 +42,20 @@ export class EdgeTTSClient extends BufferedTTSClient {
 
   override async init(_protocol: EDGE_TTS_PROTOCOL = 'wss'): Promise<boolean> {
     this.voices = await this.#edgeProvider.getAllVoices();
-    // The free wss transport is intermittently blocked; authenticated users
-    // fall back to the https proxy route.
+    // The free wss transport is intermittently blocked in browsers;
+    // authenticated users fall back to the https proxy route. On Tauri the
+    // native WebSocket (with full headers) is the only Edge transport — a
+    // failure there means offline or Edge itself is down, so never fall back
+    // to the proxy, which would fire cross-origin /api/tts/edge requests.
     if (await this.#edgeProvider.init('wss')) {
       this.initialized = true;
       return true;
     }
-    if (this.controller?.isAuthenticated && (await this.#edgeProvider.init('https'))) {
+    if (
+      !isTauriAppPlatform() &&
+      this.controller?.isAuthenticated &&
+      (await this.#edgeProvider.init('https'))
+    ) {
       this.initialized = true;
       return true;
     }

--- a/apps/readest-app/src/services/tts/types.ts
+++ b/apps/readest-app/src/services/tts/types.ts
@@ -4,6 +4,10 @@ export type TTSHighlightGranularity = 'word' | 'sentence';
 
 export type TTSMediaMetadataMode = 'sentence' | 'paragraph' | 'chapter';
 
+// Mini player card style: 'full' is the pre-#5162 (0.11.18) card with book
+// cover, book title, chapter + timestamps; 'minimal' is the chrome-free card.
+export type TTSPlayerStyle = 'full' | 'minimal';
+
 export type TTSHighlightOptions = {
   style: 'highlight' | 'underline' | 'strikethrough' | 'squiggly' | 'outline';
   color: string;

--- a/apps/readest-app/src/services/tts/wordPronouncer.ts
+++ b/apps/readest-app/src/services/tts/wordPronouncer.ts
@@ -1,5 +1,6 @@
 import { AppService } from '@/types/system';
 import { EdgeSpeechTTS, EdgeTTSPayload } from '@/libs/edgeTTS';
+import { isTauriAppPlatform } from '@/services/environment';
 import { isSameLang } from '@/utils/lang';
 import { genSSMLRaw } from '@/utils/ssml';
 import { TTSClient } from './TTSClient';
@@ -84,12 +85,15 @@ export const cancelWordPronounce = (): void => {
 };
 
 // Edge audio bytes: direct wss first; on failure the authenticated https proxy
-// (the reader's own fallback for networks that block Bing). The proxy throws
+// (the reader's own fallback for browsers that block Bing). The proxy throws
 // "Not authenticated" when logged out, which propagates to the speech fallback.
+// On Tauri the native wss transport is the only Edge path — never retry via
+// the proxy (a cross-origin /api/tts/edge request, e.g. fired when offline).
 const fetchEdgeAudio = async (payload: EdgeTTSPayload): Promise<ArrayBuffer> => {
   try {
     return (await edgeWss.createAudioData(payload)).data;
-  } catch {
+  } catch (err) {
+    if (isTauriAppPlatform()) throw err;
     return (await edgeHttps.createAudioData(payload)).data;
   }
 };

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -2,6 +2,7 @@ import { BookMetadata } from '@/libs/document';
 import { TTSHighlightOptions } from '@/services/tts/types';
 import { TTSHighlightGranularity } from '@/services/tts/types';
 import { TTSMediaMetadataMode } from '@/services/tts/types';
+import { TTSPlayerStyle } from '@/services/tts/types';
 import type { AnnotationLinkType } from '@/utils/deeplink';
 import { AnnotationToolType } from './annotator';
 
@@ -321,6 +322,7 @@ export interface TTSConfig {
   ttsHighlightOptions: TTSHighlightOptions;
   ttsHighlightGranularity: TTSHighlightGranularity;
   ttsMediaMetadata: TTSMediaMetadataMode;
+  ttsPlayerStyle: TTSPlayerStyle;
 }
 
 export interface TranslatorConfig {


### PR DESCRIPTION
Two independent TTS changes bundled into one PR.

## 1. Mini player Player Style (full / minimal)

The #5162 redesign dropped the book cover and title that the 0.11.18 mini player showed. This adds a per-book **Player Style** option under **Settings > TTS > Media Info**, defaulting to **full** so existing users get the 0.11.18 card back.

- **Full** (default) restores the pre-#5162 card: book cover, book title, a `chapter . elapsed . -remaining` line, and the sentence-only transport with the filled play/pause circle.
- **Minimal** is the #5162 chrome-free card (no cover, no titles, plain glyphs) with the paragraph + sentence transport. Its time line is now **centered** in the flexible middle, with the elapsed time emphasized and the `-remaining` half dimmed; an armed **sleep timer stacks on its own second line** so it can never squeeze the time into truncation.

Both styles share the card chassis, buffered progress track, and the #5144 positioning/stacking logic, so neither reintroduces the covered-by-bottom-bar bugs. The player sheet is untouched.

Ran `pnpm i18n:extract`, which also filled the `Playback settings` and `Paragraph Pause` keys that #5162 shipped untranslated, and pruned the dead `Paragraph Gap` key. New keys (`Player Style`, `Full`, `Minimal`, `TTS Player Style`) translated across all 33 locales.

## 2. Keep Tauri off the /api/tts/edge proxy

The `/api/tts/edge` HTTPS proxy exists only because browser WebSockets cannot send the headers Edge's wss endpoint requires. On Tauri, wss goes through `tauri-plugin-websocket` with full headers, so a wss failure means offline or Edge is down, not a blocked transport. Two call sites still probed the proxy after a wss failure and fired a cross-origin fetch to `web.readest.com/api/tts/edge`, which WKWebView reports as an access-control error (reproduced on **iOS in airplane mode**):

- `EdgeTTSClient.init()` for the reader session
- `fetchEdgeAudio` in the word pronouncer

Both are now gated behind `!isTauriAppPlatform()`, so Tauri flows to cache-only init or the native speech fallback instead.

## Testing

- `pnpm test` (full suite green), `pnpm lint`, `pnpm format:check` all pass.
- New/updated unit tests pin: the Tauri-no-proxy contract in `edge-tts-client.test.ts` and `wordPronouncer.test.ts`; and the full vs. minimal mini-player layouts (cover/title/transport, centered weighted time, stacked sleep timer) in `TTSMiniPlayer.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)