### PR TITLE
feat(annotator): copy a highlight or note with its deep link

### DIFF
--- a/apps/readest-app/src/__tests__/utils/note.test.ts
+++ b/apps/readest-app/src/__tests__/utils/note.test.ts
@@ -3,6 +3,7 @@ import {
   renderNoteTemplate,
   validateNoteTemplate,
   formatBlockQuote,
+  buildAnnotationCopyMarkdown,
   NoteTemplateData,
 } from '../../utils/note';
 
@@ -650,5 +651,77 @@ describe('formatBlockQuote', () => {
 
   it('should preserve empty lines within the quote', () => {
     expect(formatBlockQuote('First\n\nThird')).toBe('> First\n> \n> Third');
+  });
+});
+
+describe('buildAnnotationCopyMarkdown', () => {
+  const url = 'readest://book/abc/annotation/n1?cfi=/6/4';
+
+  it('should build a highlight (text only) with a link line', () => {
+    const result = buildAnnotationCopyMarkdown({
+      text: 'In my younger and more vulnerable years',
+      noteLabel: 'Note',
+      url,
+      linkLabel: 'Page: 12',
+    });
+    expect(result).toBe(
+      '> In my younger and more vulnerable years\n\n*[Page: 12](readest://book/abc/annotation/n1?cfi=/6/4)*',
+    );
+  });
+
+  it('should include the note block between the quote and the link', () => {
+    const result = buildAnnotationCopyMarkdown({
+      text: 'quote',
+      note: 'my thought',
+      noteLabel: 'Note',
+      url,
+      linkLabel: 'Page: 12',
+    });
+    expect(result).toBe(
+      '> quote\n\n**Note**: my thought\n\n*[Page: 12](readest://book/abc/annotation/n1?cfi=/6/4)*',
+    );
+  });
+
+  it('should blockquote every line of a multi-line highlight', () => {
+    const result = buildAnnotationCopyMarkdown({
+      text: 'line one\nline two',
+      noteLabel: 'Note',
+      url,
+      linkLabel: 'Open in Readest',
+    });
+    expect(result).toBe(
+      '> line one\n> line two\n\n*[Open in Readest](readest://book/abc/annotation/n1?cfi=/6/4)*',
+    );
+  });
+
+  it('should emit only the link line when there is no text or note', () => {
+    const result = buildAnnotationCopyMarkdown({
+      noteLabel: 'Note',
+      url,
+      linkLabel: 'Open in Readest',
+    });
+    expect(result).toBe('*[Open in Readest](readest://book/abc/annotation/n1?cfi=/6/4)*');
+  });
+
+  it('should translate the note label', () => {
+    const result = buildAnnotationCopyMarkdown({
+      text: 'quote',
+      note: 'ma pensee',
+      noteLabel: 'Note',
+      url,
+      linkLabel: 'Page: 3',
+    });
+    expect(result).toContain('**Note**: ma pensee');
+  });
+
+  it('should pass the web link form through unchanged', () => {
+    const webUrl = 'https://web.readest.com/o/book/abc/annotation/n1';
+    const result = buildAnnotationCopyMarkdown({
+      text: 'quote',
+      noteLabel: 'Note',
+      url: webUrl,
+      linkLabel: 'Page: 1',
+    });
+    expect(result).toBe(`> quote\n\n*[Page: 1](${webUrl})*`);
   });
 });

--- a/apps/readest-app/src/app/reader/components/sidebar/BooknoteItem.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/BooknoteItem.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import dayjs from 'dayjs';
 import React, { useMemo, useRef, useState } from 'react';
-import { MdEdit, MdDelete } from 'react-icons/md';
+import { MdEdit, MdDelete, MdContentCopy } from 'react-icons/md';
 
 import { marked } from 'marked';
 import { useEnv } from '@/context/EnvContext';
@@ -14,6 +14,10 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
 import { eventDispatcher } from '@/utils/event';
 import { isCfiInLocation } from '@/utils/cfi';
+import { buildAnnotationUrl } from '@/utils/deeplink';
+import { buildAnnotationCopyMarkdown } from '@/utils/note';
+import { writeTextToClipboard } from '@/utils/clipboard';
+import { DEFAULT_NOTE_EXPORT_CONFIG } from '@/services/constants';
 import { removeBookNoteOverlays } from '../../utils/annotatorUtil';
 import TextButton from '@/components/TextButton';
 import TextEditor, { TextEditorRef } from '@/components/TextEditor';
@@ -30,7 +34,7 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({ bookKey, item, isNearest, o
   const { envConfig } = useEnv();
   const { settings } = useSettingsStore();
   const { getConfig, saveConfig, updateBooknotes } = useBookDataStore();
-  const { getProgress, getView, getViewsById } = useReaderStore();
+  const { getProgress, getView, getViewsById, getViewSettings } = useReaderStore();
   const { setNotebookEditAnnotation, setNotebookVisible } = useNotebookStore();
 
   const globalReadSettings = settings.globalReadSettings;
@@ -93,6 +97,30 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({ bookKey, item, isNearest, o
   const editNote = (note: BookNote) => {
     setNotebookVisible(true);
     setNotebookEditAnnotation(note);
+  };
+
+  const handleCopyLink = () => {
+    const bookHash = item.bookHash || bookKey.split('-')[0]!;
+    const linkType =
+      getViewSettings(bookKey)?.noteExportConfig?.linkType ?? DEFAULT_NOTE_EXPORT_CONFIG.linkType;
+    const url = buildAnnotationUrl({ bookHash, noteId: item.id, cfi: item.cfi }, linkType);
+    const linkLabel = item.page
+      ? _('Page: {{number}}', { number: item.page })
+      : _('Open in Readest');
+    const markdown = buildAnnotationCopyMarkdown({
+      text: item.text,
+      note: item.note,
+      noteLabel: _('Note'),
+      url,
+      linkLabel,
+    });
+    void writeTextToClipboard(markdown);
+    eventDispatcher.dispatch('toast', {
+      type: 'info',
+      message: _('Copied to clipboard'),
+      className: 'whitespace-nowrap',
+      timeout: 2000,
+    });
   };
 
   const editBookmark = () => {
@@ -259,6 +287,14 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({ bookKey, item, isNearest, o
             className={clsx('flex items-center justify-end gap-4', isEditable && 'w-full')}
             dir='ltr'
           >
+            <button
+              onClick={handleCopyLink}
+              className='btn btn-ghost btn-xs text-base-content p-0 opacity-0 transition duration-300 ease-in-out hover:bg-transparent group-focus-within:opacity-100 group-hover:opacity-100'
+              aria-label={_('Copy')}
+            >
+              <MdContentCopy size={size18} />
+            </button>
+
             <button
               onClick={deleteNote.bind(null, item)}
               className='btn btn-ghost btn-xs p-0 text-red-500 opacity-0 transition duration-300 ease-in-out hover:bg-transparent group-focus-within:opacity-100 group-hover:opacity-100'

--- a/apps/readest-app/src/utils/note.ts
+++ b/apps/readest-app/src/utils/note.ts
@@ -236,6 +236,34 @@ env.addFilter('blockquote', (value: string) => {
 });
 
 /**
+ * Builds the markdown for copying a single annotation (highlight/note) together
+ * with a deep link back to its position, ready to paste into note apps like
+ * Obsidian. Mirrors the default markdown-export layout: a block-quoted highlight,
+ * an optional bold note line, and an italic link line. Empty blocks are omitted;
+ * the link line is always present. Label strings are passed in already translated
+ * to keep this helper i18n-agnostic.
+ */
+export function buildAnnotationCopyMarkdown({
+  text,
+  note,
+  noteLabel,
+  url,
+  linkLabel,
+}: {
+  text?: string;
+  note?: string;
+  noteLabel: string;
+  url: string;
+  linkLabel: string;
+}): string {
+  const blocks: string[] = [];
+  if (text) blocks.push(formatBlockQuote(text));
+  if (note) blocks.push(`**${noteLabel}**: ${note}`);
+  blocks.push(`*[${linkLabel}](${url})*`);
+  return blocks.join('\n\n');
+}
+
+/**
  * Renders a Jinja2/Nunjucks template with the given data
  * @param template The template string in Jinja2/Nunjucks syntax
  * @param data The data to render the template with


### PR DESCRIPTION
## Summary

Adds the ability to copy a single highlight or note together with a deep link back to its exact position, so it can be pasted straight into note apps like Obsidian. This addresses a user request: capture a highlight/note plus its link, paste into a new file, and start writing, then reconcile with a full markdown export later.

A **Copy** button now sits alongside Edit and Delete on each annotation row in the notebook and the sidebar (`BooknoteItem`). Since that row is shared, the action appears in both surfaces and works for highlights, notes, excerpts, and bookmarks. A plain highlight (which previously showed only Delete) now gets a copy affordance too.

## What gets copied

For a highlight with a note on page 12:

```
> In my younger and more vulnerable years

**Note**: Opening line

*[Page: 12](readest://book/{hash}/annotation/{id}?cfi=...)*
```

- The link uses the existing markdown-export `linkType` preference: the `readest://` **app link** on desktop/mobile, the `https://web.readest.com` universal link on web.
- When the annotation has no page number, the link is labeled "Open in Readest".
- The layout mirrors the default markdown-export output, so single-item copies match bulk exports.

## Implementation

- New pure helper `buildAnnotationCopyMarkdown` in `utils/note.ts` (next to `formatBlockQuote`) assembles the markdown; the component only gathers translated labels, builds the URL via the existing `buildAnnotationUrl`, copies with `writeTextToClipboard`, and shows a toast.
- No new i18n keys: every label reuses strings already translated across all locales, so no locale files were touched.

## Testing

- `pnpm test` full suite: 7614 passed, 0 failed (includes 6 new unit tests for the helper, written test-first).
- `pnpm lint` (tsgo + Biome): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)