### PR TITLE
fix(transfer): stop bulk cloud uploads from freezing the library (#5047)

### DIFF
--- a/apps/readest-app/src/__tests__/app/library-transfer-rerender.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library-transfer-rerender.test.tsx
@@ -1,0 +1,76 @@
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { useTransferStore, type TransferItem } from '@/store/transferStore';
+
+// Regression guard for issue #5047 ("Entire app freezes when uploading large
+// files to Readest Cloud"). The library page reads a single boolean
+// (`isTransferQueueOpen`) from the transfer store. During a bulk upload the
+// store churns ~10 progress writes/sec per active transfer, so if the page
+// subscribes to the WHOLE store (`const { isTransferQueueOpen } =
+// useTransferStore()`) it re-renders the entire library tree on every tick and
+// the app becomes unresponsive. A field selector must isolate the page from
+// that churn: it may only re-render when `isTransferQueueOpen` itself flips.
+
+const initialState = {
+  transfers: {} as Record<string, TransferItem>,
+  isQueuePaused: false,
+  isTransferQueueOpen: false,
+  maxConcurrent: 2,
+  activeCount: 0,
+};
+
+beforeEach(() => {
+  useTransferStore.setState(initialState);
+});
+
+afterEach(cleanup);
+
+// Mirrors the page's subscription: a boolean field selector.
+const renderCounter = { count: 0 };
+function QueueOpenConsumer() {
+  renderCounter.count += 1;
+  const isTransferQueueOpen = useTransferStore((state) => state.isTransferQueueOpen);
+  return <div data-testid='open'>{String(isTransferQueueOpen)}</div>;
+}
+
+describe('library transfer-store subscription (issue #5047)', () => {
+  it('does not re-render on transfer progress churn', () => {
+    renderCounter.count = 0;
+    render(<QueueOpenConsumer />);
+    expect(renderCounter.count).toBe(1);
+
+    const id = useTransferStore.getState().addTransfer('hash1', 'Book One', 'upload');
+    act(() => {
+      useTransferStore.getState().setTransferStatus(id, 'in_progress');
+    });
+
+    // Simulate a burst of upload progress updates (the >10/sec churn that
+    // would freeze the app if the page subscribed to the whole store).
+    act(() => {
+      for (let i = 1; i <= 50; i += 1) {
+        useTransferStore.getState().updateTransferProgress(id, i * 2, i * 2, 100, 1000 + i);
+      }
+    });
+
+    // The queue-open boolean never changed, so the consumer must not re-render.
+    expect(renderCounter.count).toBe(1);
+  });
+
+  it('re-renders only when isTransferQueueOpen flips', () => {
+    renderCounter.count = 0;
+    render(<QueueOpenConsumer />);
+    expect(renderCounter.count).toBe(1);
+
+    act(() => {
+      useTransferStore.getState().setIsTransferQueueOpen(true);
+    });
+    expect(renderCounter.count).toBe(2);
+
+    // A no-op set to the same value must not re-render.
+    act(() => {
+      useTransferStore.getState().setIsTransferQueueOpen(true);
+    });
+    expect(renderCounter.count).toBe(2);
+  });
+});

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -183,7 +183,11 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
   const { clearBookData } = useBookDataStore();
   const { settings, setSettings, saveSettings } = useSettingsStore();
   const { isSettingsDialogOpen, setSettingsDialogOpen } = useSettingsStore();
-  const { isTransferQueueOpen } = useTransferStore();
+  // Field selector, not `const { isTransferQueueOpen } = useTransferStore()`:
+  // a whole-store subscription re-renders the entire library tree on every
+  // transfer progress tick (~10/sec per active upload), freezing the app
+  // during a bulk cloud upload (issue #5047).
+  const isTransferQueueOpen = useTransferStore((state) => state.isTransferQueueOpen);
 
   // Library page pulls user replicas (dictionaries, custom fonts,
   // background textures, OPDS catalogs, bundled settings). Deferred


### PR DESCRIPTION
Fixes #5047

## Problem
Bulk-uploading many books to Readest Cloud froze the entire app until a force quit.

## Root cause
The library page subscribed to the *whole* transfer store with no selector:

```ts
const { isTransferQueueOpen } = useTransferStore();
```

A no-argument Zustand hook re-renders on **any** store change. During a bulk upload the store emits ~10 progress writes/sec per active transfer (×2 concurrent ≈ 20/sec), so this single line re-rendered the entire library tree ~20 times/sec and locked up the UI. It's platform-agnostic — on desktop the bytes stream through Rust, so the render storm, not the transfer itself, is what froze the app. This complements #5015 (which throttled the write *rate* but couldn't help while the page still subscribed to every write).

## Fix
Use a field selector so the page only re-renders when `isTransferQueueOpen` actually flips. It was the only non-selector transfer-store subscription in the codebase.

## Test
Adds a regression test that fires a 50-update progress burst: the old whole-store pattern re-renders 51 times, the selector renders once (verified failing→passing).

- `pnpm test` — 7603 passing
- `pnpm lint` (Biome + tsgo) — clean
- Verified in `pnpm dev-web` against a 704-book library: full grid renders, menus work, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)