### PR TITLE
refactor: create primitive `Toggle` component

### DIFF
--- a/apps/readest-app/src/app/reader/components/annotator/ExportMarkdownDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/ExportMarkdownDialog.tsx
@@ -21,6 +21,7 @@ import {
   buildAnnotationWebUrl,
 } from '@/utils/deeplink';
 import Dialog from '@/components/Dialog';
+import { Toggle } from '@/components/primitives/toggle';
 
 interface ExportMarkdownDialogProps {
   bookKey: string;
@@ -811,11 +812,9 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
         <div className='mt-4 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center'>
           <div className='flex items-center gap-3'>
             <label className='flex cursor-pointer items-center gap-2'>
-              <input
-                type='checkbox'
+              <Toggle
                 checked={exportConfig.exportAsPlainText}
                 onChange={() => handleToggle('exportAsPlainText')}
-                className='toggle'
               />
               <span className='line-clamp-2 text-xs'>
                 {exportConfig.exportAsPlainText

--- a/apps/readest-app/src/app/reader/components/rsvp/RSVPOverlay.tsx
+++ b/apps/readest-app/src/app/reader/components/rsvp/RSVPOverlay.tsx
@@ -31,6 +31,7 @@ import { Overlay } from '@/components/Overlay';
 import DictionarySheet from '@/app/reader/components/annotator/DictionarySheet';
 import DictionaryPopup from '@/app/reader/components/annotator/DictionaryPopup';
 import TTSFollowIndicator, { TtsSyncStatus } from '@/app/reader/components/tts/TTSFollowIndicator';
+import { Toggle } from '@/components/primitives/toggle';
 
 interface FlatChapter {
   label: string;
@@ -1264,9 +1265,7 @@ const RSVPOverlay: React.FC<RSVPOverlayProps> = ({
             {/* Split hyphenated words */}
             <div className='config-item gap-2'>
               <span className='opacity-50'>{_('Split Hyphens')}</span>
-              <input
-                type='checkbox'
-                className='toggle'
+              <Toggle
                 checked={state.splitHyphens}
                 onChange={(e) => controller.setSplitHyphens(e.target.checked)}
               />
@@ -1276,10 +1275,8 @@ const RSVPOverlay: React.FC<RSVPOverlayProps> = ({
             {state.hasCJK && (
               <div className='config-item gap-2'>
                 <span className='opacity-50'>{_('Character Mode')}</span>
-                <input
-                  type='checkbox'
+                <Toggle
                   data-testid='rsvp-char-mode-toggle'
-                  className='toggle'
                   checked={state.cjkCharMode}
                   onChange={(e) => controller.setCjkCharMode(e.target.checked)}
                 />
@@ -1290,10 +1287,8 @@ const RSVPOverlay: React.FC<RSVPOverlayProps> = ({
             {state.hasCJK && (
               <div className='config-item gap-2'>
                 <span className='opacity-50'>{_('Highlight Word')}</span>
-                <input
-                  type='checkbox'
+                <Toggle
                   data-testid='rsvp-highlight-word-toggle'
-                  className='toggle'
                   checked={highlightWholeWord}
                   onChange={(e) => updateHighlightWholeWord(e.target.checked)}
                 />

--- a/apps/readest-app/src/components/primitives/toggle.tsx
+++ b/apps/readest-app/src/components/primitives/toggle.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+const Toggle = React.forwardRef<
+  React.ComponentRef<'input'>,
+  React.ComponentPropsWithoutRef<'input'>
+>(({ className, ...props }, ref) => (
+  <input ref={ref} type='checkbox' className='toggle' {...props} />
+));
+
+export { Toggle };

--- a/apps/readest-app/src/components/settings/FontPanel.tsx
+++ b/apps/readest-app/src/components/settings/FontPanel.tsx
@@ -32,6 +32,7 @@ import { BoxedList, NavigationRow, SettingLabel, SettingsRow } from './primitive
 import NumberInput from './NumberInput';
 import FontDropdown from './FontDropDown';
 import CustomFonts from './CustomFonts';
+import { Toggle } from '../primitives/toggle';
 
 const genCJKFontsList = (sysFonts: string[]) => {
   return Array.from(new Set([...sysFonts, ...CJK_SERIF_FONTS, ...CJK_SANS_SERIF_FONTS]))
@@ -306,12 +307,7 @@ const FontPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset 
         className='flex cursor-pointer items-center justify-between px-4'
       >
         <SettingLabel>{_('Override Book Font')}</SettingLabel>
-        <input
-          type='checkbox'
-          className='toggle'
-          checked={overrideFont}
-          onChange={() => setOverrideFont(!overrideFont)}
-        />
+        <Toggle checked={overrideFont} onChange={() => setOverrideFont(!overrideFont)} />
       </label>
 
       <BoxedList title={_('Font Size')}>

--- a/apps/readest-app/src/components/settings/LayoutPanel.tsx
+++ b/apps/readest-app/src/components/settings/LayoutPanel.tsx
@@ -26,6 +26,7 @@ import {
   SettingsSwitchRow,
 } from './primitives';
 import NumberInput from './NumberInput';
+import { Toggle } from '../primitives/toggle';
 
 const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }) => {
   const _ = useTranslation();
@@ -455,12 +456,7 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
         className='flex items-center justify-between px-4'
       >
         <SettingLabel>{_('Override Book Layout')}</SettingLabel>
-        <input
-          type='checkbox'
-          className='toggle'
-          checked={overrideLayout}
-          onChange={() => setOverrideLayout(!overrideLayout)}
-        />
+        <Toggle checked={overrideLayout} onChange={() => setOverrideLayout(!overrideLayout)} />
       </div>
       {mightBeRTLBook && (
         <div

--- a/apps/readest-app/src/components/settings/ThemePanel.tsx
+++ b/apps/readest-app/src/components/settings/ThemePanel.tsx
@@ -32,6 +32,7 @@ import BackgroundTextureSelector from './color/BackgroundTextureSelector';
 import HighlightColorsEditor from './color/HighlightColorsEditor';
 import CodeHighlightingSettings from './color/CodeHighlightingSettings';
 import ReadingRulerSettings from './color/ReadingRulerSettings';
+import { Toggle } from '../primitives/toggle';
 
 const ThemePanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }) => {
   const _ = useTranslation();
@@ -356,9 +357,7 @@ const ThemePanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset
             )}
           >
             <SettingLabel>{_('Invert Image In Dark Mode')}</SettingLabel>
-            <input
-              type='checkbox'
-              className='toggle'
+            <Toggle
               checked={invertImgColorInDark}
               disabled={!isDarkMode}
               onChange={() => setInvertImgColorInDark(!invertImgColorInDark)}
@@ -370,12 +369,7 @@ const ThemePanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset
             className='flex cursor-pointer items-center justify-between px-4'
           >
             <SettingLabel>{_('Override Book Color')}</SettingLabel>
-            <input
-              type='checkbox'
-              className='toggle'
-              checked={overrideColor}
-              onChange={() => setOverrideColor(!overrideColor)}
-            />
+            <Toggle checked={overrideColor} onChange={() => setOverrideColor(!overrideColor)} />
           </label>
 
           <ThemeColorSelector

--- a/apps/readest-app/src/components/settings/integrations/HardcoverForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/HardcoverForm.tsx
@@ -7,6 +7,7 @@ import { eventDispatcher } from '@/utils/event';
 import { HardcoverClient, HardcoverSyncMapStore } from '@/services/hardcover';
 import SubPageHeader from '../SubPageHeader';
 import { SectionTitle, SettingLabel } from '../primitives';
+import { Toggle } from '@/components/primitives/toggle';
 
 interface HardcoverFormProps {
   onBack: () => void;
@@ -110,18 +111,14 @@ const HardcoverForm: React.FC<HardcoverFormProps> = ({ onBack }) => {
             <div className='divide-base-200 divide-y'>
               <label className='flex min-h-14 items-center justify-between px-4'>
                 <SettingLabel>{_('Sync Enabled')}</SettingLabel>
-                <input
-                  type='checkbox'
-                  className='toggle'
+                <Toggle
                   checked={settings.hardcover?.enabled ?? false}
                   onChange={handleToggleEnabled}
                 />
               </label>
               <label className='flex min-h-14 items-center justify-between px-4'>
                 <SettingLabel>{_('Auto Sync')}</SettingLabel>
-                <input
-                  type='checkbox'
-                  className='toggle'
+                <Toggle
                   checked={settings.hardcover?.autoSync === true}
                   onChange={handleToggleAutoSync}
                 />

--- a/apps/readest-app/src/components/settings/integrations/KOSyncForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/KOSyncForm.tsx
@@ -12,6 +12,7 @@ import { debounce } from '@/utils/debounce';
 import { getOSPlatform } from '@/utils/misc';
 import SubPageHeader from '../SubPageHeader';
 import { SectionTitle, SettingLabel, SettingsSelect } from '../primitives';
+import { Toggle } from '@/components/primitives/toggle';
 
 interface KOSyncFormProps {
   onBack: () => void;
@@ -162,12 +163,7 @@ const KOSyncForm: React.FC<KOSyncFormProps> = ({ onBack }) => {
                   to match modern preferences-panel convention. */}
               <label className='flex min-h-14 items-center justify-between px-4'>
                 <SettingLabel>{_('Sync Server Connected')}</SettingLabel>
-                <input
-                  type='checkbox'
-                  className='toggle'
-                  checked={settings.kosync.enabled}
-                  onChange={handleToggleEnabled}
-                />
+                <Toggle checked={settings.kosync.enabled} onChange={handleToggleEnabled} />
               </label>
               {/* SettingsSelect handles the chromeless treatment, the
                   custom MdArrowDropDown icon at the trailing edge (so the

--- a/apps/readest-app/src/components/settings/integrations/ReadwiseForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/ReadwiseForm.tsx
@@ -9,6 +9,7 @@ import { ReadwiseClient } from '@/services/readwise';
 import { READWISE_API_BASE_URL } from '@/services/constants';
 import SubPageHeader from '../SubPageHeader';
 import { SectionTitle, SettingLabel, Tips } from '../primitives';
+import { Toggle } from '@/components/primitives/toggle';
 
 interface ReadwiseFormProps {
   onBack: () => void;
@@ -128,9 +129,7 @@ const ReadwiseForm: React.FC<ReadwiseFormProps> = ({ onBack }) => {
             <div className='divide-base-200 divide-y'>
               <label className='flex min-h-14 items-center justify-between px-4'>
                 <SettingLabel>{_('Sync Enabled')}</SettingLabel>
-                <input
-                  type='checkbox'
-                  className='toggle'
+                <Toggle
                   checked={settings.readwise?.enabled ?? false}
                   onChange={handleToggleEnabled}
                 />

--- a/apps/readest-app/src/components/settings/primitives/SettingsSwitchRow.tsx
+++ b/apps/readest-app/src/components/settings/primitives/SettingsSwitchRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import SettingsRow from './SettingsRow';
+import { Toggle } from '@/components/primitives/toggle';
 
 interface SettingsSwitchRowProps {
   label: React.ReactNode;
@@ -37,13 +38,7 @@ const SettingsSwitchRow: React.FC<SettingsSwitchRowProps> = ({
       disabled={disabled}
       data-setting-id={dataSettingId}
     >
-      <input
-        type='checkbox'
-        className='toggle'
-        checked={checked}
-        disabled={disabled}
-        onChange={onChange}
-      />
+      <Toggle checked={checked} disabled={disabled} onChange={onChange} />
     </SettingsRow>
   );
 };


### PR DESCRIPTION
Replace all toggles with a `Toggle` primitive component. Allows for easier changes in the future, should this component be changed.
