### PR TITLE
fix(reader): synchronize toolbar with layered page turns

### DIFF
--- a/apps/readest-app/src/__tests__/document/paginator-turn-styles.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/paginator-turn-styles.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
 import { DocumentLoader } from '@/libs/document';
 import type { BookDoc } from '@/libs/document';
 import type { Renderer } from '@/types/view';
@@ -190,6 +190,39 @@ describe('Page turn styles (browser)', () => {
     expect(paginator.containerPosition).toBe(before + size);
   });
 
+  it('finishes a vertical programmatic turn when a touch starts mid-transition', async () => {
+    await setup(verticalBook, 'slide', 0);
+    const size = paginator.size;
+    const before = paginator.containerPosition;
+
+    const turn = paginator.next();
+    fireTouch('touchstart', 500, 300);
+    fireTouch('touchmove', 580, 300);
+    fireTouch('touchend', 580, 300);
+    await turn;
+
+    expect(paginator.containerPosition).toBe(before + size);
+    expect(document.documentElement.className).not.toContain('foliate-vt');
+
+    await paginator.prev();
+    expect(paginator.containerPosition).toBe(before);
+  });
+
+  it('cleans up an active programmatic transition when destroyed', async () => {
+    await setup(ltrBook, 'slide');
+
+    const turn = paginator.next();
+    await vi.waitFor(() => {
+      expect(document.documentElement.className).toContain('foliate-vt');
+      expect(paginator.style.viewTransitionName).toBe('foliate-turn');
+    });
+    paginator.destroy();
+    await turn;
+
+    expect(document.documentElement.className).not.toContain('foliate-vt');
+    expect(paginator.style.viewTransitionName).toBe('');
+  });
+
   const makeTouch = (x: number, y: number) =>
     new Touch({ identifier: 1, target: paginator, screenX: x, screenY: y, clientX: x, clientY: y });
 
@@ -198,7 +231,7 @@ describe('Page turn styles (browser)', () => {
       new TouchEvent(type, {
         bubbles: true,
         cancelable: true,
-        touches: type === 'touchend' ? [] : [makeTouch(x, y)],
+        touches: type === 'touchend' || type === 'touchcancel' ? [] : [makeTouch(x, y)],
         changedTouches: [makeTouch(x, y)],
       }),
     );
@@ -214,6 +247,10 @@ describe('Page turn styles (browser)', () => {
   it('tracks the finger: the paused snapshot follows the drag and commits on release', async () => {
     await setup(ltrBook, 'slide');
     const page = paginator.page;
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
 
     // ltr: finger moves LEFT to go forward.
     let x = 700;
@@ -238,14 +275,24 @@ describe('Page turn styles (browser)', () => {
 
     fireTouch('touchend', x, 300);
     const t0 = performance.now();
-    while (paginator.page !== page + 1 && performance.now() - t0 < 2000) await wait(50);
+    while (
+      (paginator.page !== page + 1 || !phases.includes('finished')) &&
+      performance.now() - t0 < 2000
+    ) {
+      await wait(50);
+    }
     expect(paginator.page).toBe(page + 1);
+    expect(phases).toEqual(['before-capture', 'covered', 'ready', 'finished']);
   });
 
   it('tracks the finger: a mostly-returned drag reverses without turning', async () => {
     await setup(ltrBook, 'slide');
     const page = paginator.page;
     const before = paginator.containerPosition;
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
 
     let x = 700;
     fireTouch('touchstart', x, 300);
@@ -267,6 +314,123 @@ describe('Page turn styles (browser)', () => {
     expect(paginator.page).toBe(page);
     expect(paginator.containerPosition).toBe(before);
     expect(scrubbedAnimations().length).toBe(0);
+    expect(phases).toEqual(['before-capture', 'covered', 'ready', 'cancelled', 'finished']);
+  });
+
+  it('cancels a layered drag on touchcancel and cleans up its lifecycle', async () => {
+    await setup(ltrBook, 'slide');
+    const page = paginator.page;
+    const before = paginator.containerPosition;
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    fireTouch('touchstart', 700, 300);
+    fireTouch('touchmove', 620, 300);
+    await vi.waitFor(() => {
+      expect(scrubbedAnimations().length).toBeGreaterThan(0);
+      expect(phases).toContain('ready');
+    });
+    fireTouch('touchcancel', 620, 300);
+    await vi.waitFor(
+      () => {
+        expect(phases).toContain('finished');
+      },
+      { timeout: 2000 },
+    );
+
+    expect(paginator.page).toBe(page);
+    expect(paginator.containerPosition).toBe(before);
+    expect(scrubbedAnimations()).toHaveLength(0);
+    expect(phases).toEqual(['before-capture', 'covered', 'ready', 'cancelled', 'finished']);
+    expect(document.documentElement.className).not.toContain('foliate-vt');
+    expect(paginator.style.viewTransitionName).toBe('');
+  });
+
+  it('orders lifecycle events when touchcancel arrives before capture is ready', async () => {
+    await setup(ltrBook, 'slide');
+    const before = paginator.containerPosition;
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    fireTouch('touchstart', 700, 300);
+    fireTouch('touchmove', 620, 300);
+    fireTouch('touchcancel', 620, 300);
+    await vi.waitFor(
+      () => {
+        expect(phases).toContain('finished');
+      },
+      { timeout: 2000 },
+    );
+
+    expect(paginator.containerPosition).toBe(before);
+    expect(phases[0]).toBe('before-capture');
+    expect(phases.indexOf('covered')).toBeGreaterThan(0);
+    expect(phases.indexOf('cancelled')).toBeGreaterThan(phases.indexOf('covered'));
+    expect(phases.at(-1)).toBe('finished');
+    expect(document.documentElement.className).not.toContain('foliate-vt');
+    expect(paginator.style.viewTransitionName).toBe('');
+  });
+
+  it('finishes a vertical layered cancellation when another tap starts immediately', async () => {
+    await setup(verticalBook, 'slide', 0);
+    const before = paginator.containerPosition;
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    // vertical-rl uses RTL page progression: a rightward finger advances.
+    fireTouch('touchstart', 100, 300);
+    fireTouch('touchmove', 180, 300);
+    await vi.waitFor(() => expect(phases).toContain('ready'));
+    fireTouch('touchcancel', 180, 300);
+    // This second touch used to bump the shared slide generation and make the
+    // first turn return before cleanup/finished.
+    fireTouch('touchstart', 500, 300);
+    fireTouch('touchend', 500, 300);
+
+    await vi.waitFor(
+      () => {
+        expect(phases).toContain('finished');
+      },
+      { timeout: 2000 },
+    );
+    expect(paginator.containerPosition).toBe(before);
+    expect(phases).toEqual(['before-capture', 'covered', 'ready', 'cancelled', 'finished']);
+    expect(document.documentElement.className).not.toContain('foliate-vt');
+  });
+
+  it('finishes cancellation before accepting another programmatic turn', async () => {
+    await setup(ltrBook, 'slide');
+    const page = paginator.page;
+    const before = paginator.containerPosition;
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    fireTouch('touchstart', 700, 300);
+    fireTouch('touchmove', 620, 300);
+    await vi.waitFor(() => expect(phases).toContain('ready'));
+    fireTouch('touchcancel', 620, 300);
+    // Programmatic navigation shares the same document-level pseudo tree and
+    // must not supersede cancellation before its terminal event.
+    await paginator.next();
+    await vi.waitFor(
+      () => {
+        expect(phases).toContain('finished');
+      },
+      { timeout: 2000 },
+    );
+
+    expect(paginator.page).toBe(page);
+    expect(paginator.containerPosition).toBe(before);
+    expect(phases).toEqual(['before-capture', 'covered', 'ready', 'cancelled', 'finished']);
+    expect(document.documentElement.className).not.toContain('foliate-vt');
   });
 
   // Xiaomi report (Android 16, WebView 148): with the layered slide style, a

--- a/apps/readest-app/src/__tests__/hooks/useCapturedTurn-scrollLock.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useCapturedTurn-scrollLock.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { cleanup, renderHook } from '@testing-library/react';
+import { act, cleanup, renderHook } from '@testing-library/react';
 import type { FoliateView } from '@/types/view';
 import type { ViewSettings } from '@/types/book';
 import type { TouchDetail } from '@/app/reader/hooks/useTouchInterceptor';
@@ -10,6 +10,13 @@ import type { TouchDetail } from '@/app/reader/hooks/useTouchInterceptor';
 // is set (instant highlight engaged). This test pins the captured turn to the
 // same gate so a hold-then-swipe extends the highlight instead of paginating.
 const h = vi.hoisted(() => ({
+  controllerHost: null as null | {
+    onBeforeCapture?: (style: 'curl' | 'slide') => Promise<void> | void;
+    onCovered?: (style: 'curl' | 'slide') => Promise<void> | void;
+    onCancelled?: (style: 'curl' | 'slide') => Promise<void> | void;
+  },
+  hoveredBookKey: 'book-1' as string | null,
+  setHoveredBookKey: vi.fn(),
   controller: {
     turn: vi.fn(async () => {}),
     beginDrag: vi.fn(async () => true),
@@ -19,6 +26,7 @@ const h = vi.hoisted(() => ({
   },
   selection: null as { rangeCount: number; isCollapsed: boolean } | null,
   renderer: {
+    listeners: new Map<string, Set<EventListener>>(),
     scrollLocked: false,
     atEnd: false,
     atStart: false,
@@ -29,6 +37,17 @@ const h = vi.hoisted(() => ({
     hasAttribute: () => false,
     setAttribute: () => {},
     removeAttribute: () => {},
+    addEventListener(type: string, listener: EventListener) {
+      const listeners = this.listeners.get(type) ?? new Set<EventListener>();
+      listeners.add(listener);
+      this.listeners.set(type, listeners);
+    },
+    removeEventListener(type: string, listener: EventListener) {
+      this.listeners.get(type)?.delete(listener);
+    },
+    dispatchEvent(event: Event) {
+      for (const listener of this.listeners.get(event.type) ?? []) listener(event);
+    },
   },
   viewSettings: {
     pageTurnStyle: 'curl',
@@ -40,9 +59,14 @@ const h = vi.hoisted(() => ({
   } as ViewSettings,
 }));
 
-vi.mock('@/store/readerStore', () => ({
-  useReaderStore: () => ({ getViewSettings: () => h.viewSettings }),
-}));
+vi.mock('@/store/readerStore', () => {
+  const useReaderStore = () => ({
+    getViewSettings: () => h.viewSettings,
+    setHoveredBookKey: h.setHoveredBookKey,
+  });
+  useReaderStore.getState = () => ({ hoveredBookKey: h.hoveredBookKey });
+  return { useReaderStore };
+});
 vi.mock('@/store/bookDataStore', () => ({
   useBookDataStore: () => ({ getBookData: () => ({ isFixedLayout: false }) }),
 }));
@@ -50,7 +74,8 @@ vi.mock('@/utils/bridge', () => ({ captureWebviewRegion: vi.fn() }));
 vi.mock('@/utils/viewTransition', () => ({ detectViewTransitionGroup: () => false }));
 vi.mock('@/app/reader/utils/capturedTurn', () => ({
   CapturedPageTurn: class {
-    constructor() {
+    constructor(host: NonNullable<typeof h.controllerHost>) {
+      h.controllerHost = host;
       Object.assign(this, h.controller);
     }
   },
@@ -73,15 +98,21 @@ const detail = (phase: TouchDetail['phase'], deltaX = 0, deltaY = 0): TouchDetai
 
 beforeEach(() => {
   vi.clearAllMocks();
+  h.controller.beginDrag.mockResolvedValue(true);
+  h.setHoveredBookKey.mockReset();
   vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'tauri');
   h.renderer.scrollLocked = false;
   h.renderer.atEnd = false;
   h.renderer.atStart = false;
   h.selection = null;
+  h.renderer.listeners.clear();
+  h.controllerHost = null;
+  h.hoveredBookKey = 'book-1';
 });
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  document.getElementById('gridcell-book-1')?.remove();
   cleanup();
 });
 
@@ -94,6 +125,17 @@ describe('useCapturedTurn scroll-lock gate', () => {
 
     expect(consumed).toBe(true);
     expect(h.controller.beginDrag).toHaveBeenCalled();
+  });
+
+  test('touch cancellation always reverses an active captured drag', () => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start'));
+    dispatchTouchInterceptors('book-1', detail('move', -60, 3));
+    const consumed = dispatchTouchInterceptors('book-1', detail('cancel', -60, 3));
+
+    expect(consumed).toBe(true);
+    expect(h.controller.endDrag).toHaveBeenCalledWith(false);
   });
 
   test('scroll lock (instant highlight engaged) leaves the swipe to the highlight', () => {
@@ -205,6 +247,185 @@ describe('useCapturedTurn scroll-lock gate', () => {
 
     expect(consumed).toBe(true);
     expect(h.controller.beginDrag).toHaveBeenCalled();
+  });
+
+  test.each([
+    'curl',
+    'slide',
+  ] as const)('hides live toolbar without transitions once the %s snapshot covers it', async (style) => {
+    const gridCell = document.createElement('div');
+    gridCell.id = 'gridcell-book-1';
+    document.body.appendChild(gridCell);
+    h.setHoveredBookKey.mockImplementationOnce(() => {
+      expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(true);
+    });
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    await act(async () => {
+      await h.controllerHost?.onBeforeCapture?.(style);
+      await h.controllerHost?.onCovered?.(style);
+    });
+
+    expect(h.setHoveredBookKey).toHaveBeenCalledWith(null);
+    expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(false);
+  });
+
+  test.each([
+    'curl',
+    'slide',
+  ] as const)('restores a previously visible toolbar when a %s turn is cancelled', async (style) => {
+    const gridCell = document.createElement('div');
+    gridCell.id = 'gridcell-book-1';
+    document.body.appendChild(gridCell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    await act(async () => {
+      await h.controllerHost?.onBeforeCapture?.(style);
+      await h.controllerHost?.onCovered?.(style);
+      await h.controllerHost?.onCancelled?.(style);
+    });
+
+    expect(h.setHoveredBookKey.mock.calls).toEqual([[null], ['book-1']]);
+  });
+
+  test('does not show the toolbar after cancellation when it started hidden', async () => {
+    h.hoveredBookKey = null;
+    const gridCell = document.createElement('div');
+    gridCell.id = 'gridcell-book-1';
+    document.body.appendChild(gridCell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    await act(async () => {
+      await h.controllerHost?.onBeforeCapture?.('curl');
+      await h.controllerHost?.onCovered?.('curl');
+      await h.controllerHost?.onCancelled?.('curl');
+    });
+
+    expect(h.setHoveredBookKey).not.toHaveBeenCalled();
+  });
+
+  test('restores the toolbar state captured before the snapshot starts', async () => {
+    const gridCell = document.createElement('div');
+    gridCell.id = 'gridcell-book-1';
+    document.body.appendChild(gridCell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    await act(async () => {
+      await h.controllerHost?.onBeforeCapture?.('curl');
+      // A later event must not overwrite the gesture's original UI state.
+      h.hoveredBookKey = null;
+      await h.controllerHost?.onCovered?.('curl');
+      await h.controllerHost?.onCancelled?.('curl');
+    });
+
+    expect(h.setHoveredBookKey.mock.calls).toEqual([[null], ['book-1']]);
+  });
+
+  test('paints the snapshot before hiding chrome and keeps transitions disabled for a painted frame', async () => {
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const gridCell = document.createElement('div');
+    gridCell.id = 'gridcell-book-1';
+    document.body.appendChild(gridCell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    try {
+      await h.controllerHost?.onBeforeCapture?.('curl');
+      const covered = Promise.resolve(h.controllerHost?.onCovered?.('curl'));
+
+      // The live toolbar must remain untouched until the flat snapshot has
+      // survived a rendering opportunity.
+      expect(h.setHoveredBookKey).not.toHaveBeenCalled();
+      frames.shift()?.(16);
+      await Promise.resolve();
+      expect(h.setHoveredBookKey).not.toHaveBeenCalled();
+      frames.shift()?.(32);
+      await Promise.resolve();
+
+      expect(h.setHoveredBookKey).toHaveBeenCalledWith(null);
+      expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(true);
+
+      // Keep transition:none through another painted frame before restoring
+      // the normal CSS transition declaration.
+      frames.shift()?.(48);
+      await Promise.resolve();
+      expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(true);
+      frames.shift()?.(64);
+      await covered;
+      expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(false);
+    } finally {
+      raf.mockRestore();
+    }
+  });
+
+  test('synchronizes toolbar state with a native layered slide lifecycle', async () => {
+    const gridCell = document.createElement('div');
+    gridCell.id = 'gridcell-book-1';
+    document.body.appendChild(gridCell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    const dispatch = (phase: string) =>
+      h.renderer.dispatchEvent(
+        new CustomEvent('layered-turn-state', {
+          detail: { phase, style: 'slide', forward: true },
+        }),
+      );
+
+    act(() => {
+      dispatch('before-capture');
+      dispatch('covered');
+    });
+    expect(h.setHoveredBookKey).toHaveBeenLastCalledWith(null);
+    expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(true);
+
+    act(() => dispatch('ready'));
+    expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(false);
+
+    act(() => dispatch('cancelled'));
+    expect(h.setHoveredBookKey).toHaveBeenLastCalledWith('book-1');
+    expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(true);
+
+    act(() => dispatch('finished'));
+    expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(false);
+  });
+
+  test.each([
+    'curl',
+    'slide',
+  ] as const)('synchronizes toolbar state with a web layered %s lifecycle', (style) => {
+    vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'web');
+    const gridCell = document.createElement('div');
+    gridCell.id = 'gridcell-book-1';
+    document.body.appendChild(gridCell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    const dispatch = (phase: string) =>
+      h.renderer.dispatchEvent(
+        new CustomEvent('layered-turn-state', {
+          detail: { phase, style, forward: true },
+        }),
+      );
+
+    act(() => {
+      dispatch('before-capture');
+      dispatch('covered');
+    });
+    expect(h.controllerHost).toBeNull();
+    expect(h.setHoveredBookKey).toHaveBeenLastCalledWith(null);
+    expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(true);
+
+    act(() => dispatch('ready'));
+    expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(false);
+
+    act(() => dispatch('cancelled'));
+    expect(h.setHoveredBookKey).toHaveBeenLastCalledWith('book-1');
+    expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(true);
+
+    act(() => dispatch('finished'));
+    expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(false);
   });
 });
 

--- a/apps/readest-app/src/__tests__/hooks/useTouchEvent.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTouchEvent.test.tsx
@@ -32,6 +32,11 @@ vi.mock('@/utils/event', () => ({
 }));
 
 import { useTouchEvent } from '@/app/reader/hooks/useIframeEvents';
+import {
+  registerTouchInterceptor,
+  setLayeredTurnGestureActive,
+  type TouchDetail,
+} from '@/app/reader/hooks/useTouchInterceptor';
 
 type Touch = { clientX: number; clientY: number; screenX: number; screenY: number };
 const touch = (screenX: number, screenY: number): Touch => ({
@@ -40,7 +45,11 @@ const touch = (screenX: number, screenY: number): Touch => ({
   screenX,
   screenY,
 });
-const touchEvent = (touches: Touch[], timeStamp = 0) => ({ timeStamp, targetTouches: touches });
+const touchEvent = (touches: Touch[], timeStamp = 0, changedTouches: Touch[] = touches) => ({
+  timeStamp,
+  targetTouches: touches,
+  changedTouches,
+});
 
 type Handlers = ReturnType<typeof useTouchEvent>;
 
@@ -59,6 +68,7 @@ describe('useTouchEvent pinch vs two-finger scroll', () => {
   let pinchEnd: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    setLayeredTurnGestureActive('book-1', false);
     pinchZoom = vi.fn();
     pinchEnd = vi.fn();
     mocks.hoveredBookKey = null;
@@ -68,6 +78,7 @@ describe('useTouchEvent pinch vs two-finger scroll', () => {
   });
 
   afterEach(() => {
+    setLayeredTurnGestureActive('book-1', false);
     cleanup();
     vi.clearAllMocks();
   });
@@ -111,6 +122,269 @@ describe('useTouchEvent pinch vs two-finger scroll', () => {
 
     expect(pinchZoom).not.toHaveBeenCalled();
     expect(mocks.dispatch).not.toHaveBeenCalledWith('pinch-zoom', expect.anything());
+  });
+
+  test.each([
+    'curl',
+    'slide',
+  ] as const)('does not start hiding the toolbar before a captured %s turn claims the swipe', (pageTurnStyle) => {
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle,
+    });
+    const unregister = registerTouchInterceptor(
+      'captured-turn-threshold-test',
+      (_bookKey, detail) =>
+        detail.phase === 'move' &&
+        Math.abs(detail.deltaX) >= 15 &&
+        Math.abs(detail.deltaX) > Math.abs(detail.deltaY),
+      5,
+    );
+
+    try {
+      const h = renderTouchHook();
+      h.current.onTouchStart(touchEvent([touch(100, 300)], 100));
+      h.current.onTouchMove(touchEvent([touch(88, 300)], 116));
+
+      expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+    } finally {
+      unregister();
+    }
+  });
+
+  test('does not pre-toggle a push turn until movement leaves the shared tap slop', () => {
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle: 'push',
+    });
+    const h = renderTouchHook();
+
+    h.current.onTouchStart(touchEvent([touch(100, 300)], 100));
+    h.current.onTouchMove(touchEvent([touch(88, 300)], 116));
+
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+
+    h.current.onTouchMove(touchEvent([touch(84, 300)], 132));
+
+    expect(mocks.setHoveredBookKey).toHaveBeenCalledWith(null);
+  });
+
+  test('does not hide a toolbar for tap-sized jitter in scrolled mode', () => {
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: true,
+      vertical: false,
+      pageTurnStyle: 'push',
+    });
+    const h = renderTouchHook();
+
+    h.current.onTouchStart(touchEvent([touch(100, 300)], 100));
+    h.current.onTouchMove(touchEvent([touch(106, 306)], 116));
+    h.current.onTouchEnd(touchEvent([], 132, [touch(106, 306)]));
+
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    'curl',
+    'slide',
+  ] as const)('leaves web %s toolbar hiding to the layered transition lifecycle', (pageTurnStyle) => {
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle,
+      animated: true,
+      isEink: false,
+      disableSwipe: false,
+    });
+    mocks.getView.mockReturnValue({
+      renderer: {
+        getAttribute: (name: string) => (name === 'turn-style' ? pageTurnStyle : null),
+      },
+    });
+    setLayeredTurnGestureActive('book-1', true);
+    const h = renderTouchHook();
+
+    h.current.onTouchStart(touchEvent([touch(200, 300)], 100));
+    h.current.onTouchMove(touchEvent([touch(120, 300)], 180));
+    // The lifecycle may finish before the iframe's queued touchend message is
+    // delivered. Ownership must remain sticky for this gesture.
+    setLayeredTurnGestureActive('book-1', false);
+    h.current.onTouchEnd(touchEvent([], 220, [touch(120, 450)]));
+
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    'curl',
+    'slide',
+  ] as const)('does not fade the web %s toolbar before a fast flick snapshot settles', (pageTurnStyle) => {
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle,
+      animated: true,
+      isEink: false,
+      disableSwipe: false,
+    });
+    mocks.getView.mockReturnValue({
+      renderer: {
+        getAttribute: (name: string) => (name === 'turn-style' ? pageTurnStyle : null),
+      },
+    });
+    setLayeredTurnGestureActive('book-1', true);
+    const h = renderTouchHook();
+
+    h.current.onTouchStart(touchEvent([touch(200, 300)], 100));
+    h.current.onTouchEnd(touchEvent([], 160, [touch(120, 300)]));
+
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+  });
+
+  test('leaves native layered slide toolbar changes to the transition lifecycle', () => {
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle: 'slide',
+      animated: true,
+      isEink: false,
+      disableSwipe: false,
+    });
+    mocks.getView.mockReturnValue({
+      renderer: { getAttribute: (name: string) => (name === 'turn-style' ? 'slide' : null) },
+    });
+    setLayeredTurnGestureActive('book-1', true);
+    const h = renderTouchHook();
+
+    h.current.onTouchStart(touchEvent([touch(200, 300)], 100));
+    h.current.onTouchMove(touchEvent([touch(120, 300)], 180));
+    h.current.onTouchEnd(touchEvent([], 260, [touch(120, 300)]));
+
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['scrolled', { scrolled: true }],
+    ['animations disabled', { animated: false }],
+    ['E-ink', { isEink: true }],
+    ['swipe disabled', { disableSwipe: true }],
+  ] as const)('uses generic toolbar hiding when a layered style is not active: %s', (_label, override) => {
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle: 'slide',
+      animated: true,
+      isEink: false,
+      disableSwipe: false,
+      ...override,
+    });
+    mocks.getView.mockReturnValue({
+      renderer: { getAttribute: (name: string) => (name === 'turn-style' ? 'slide' : null) },
+    });
+    const h = renderTouchHook();
+
+    h.current.onTouchStart(touchEvent([touch(200, 300)], 100));
+    h.current.onTouchMove(touchEvent([touch(120, 300)], 180));
+
+    expect(mocks.setHoveredBookKey).toHaveBeenCalledWith(null);
+  });
+
+  test('leaves a clean tap to the synthesized click toolbar handler', () => {
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle: 'slide',
+    });
+    const h = renderTouchHook();
+
+    h.current.onTouchStart(touchEvent([touch(200, 300)], 100));
+    h.current.onTouchEnd(touchEvent([], 160, [touch(203, 302)]));
+
+    // usePagination owns iframe-single-click and performs the one toggle.
+    // touchend must not pre-toggle the same gesture.
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+  });
+
+  test('uses the released finger position and time for the final gesture sample', () => {
+    const details: TouchDetail[] = [];
+    const unregister = registerTouchInterceptor('touch-end-sample-test', (_bookKey, detail) => {
+      details.push(detail);
+      return detail.phase === 'move';
+    });
+
+    try {
+      const h = renderTouchHook();
+      h.current.onTouchStart(touchEvent([touch(100, 300)], 100));
+      h.current.onTouchMove(touchEvent([touch(60, 300)], 150));
+      h.current.onTouchEnd(touchEvent([], 300, [touch(20, 300)]));
+
+      expect(details.at(-1)).toMatchObject({
+        phase: 'end',
+        deltaX: -80,
+        deltaY: 0,
+        deltaT: 200,
+      });
+    } finally {
+      unregister();
+    }
+  });
+
+  test('forwards touch cancellation without toggling the toolbar', () => {
+    const details: TouchDetail[] = [];
+    const unregister = registerTouchInterceptor('touch-cancel-test', (_bookKey, detail) => {
+      details.push(detail);
+      return detail.phase === 'move' || detail.phase === 'cancel';
+    });
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle: 'push',
+    });
+
+    try {
+      const h = renderTouchHook();
+      h.current.onTouchStart(touchEvent([touch(100, 300)], 100));
+      h.current.onTouchMove(touchEvent([touch(60, 300)], 150));
+      h.current.onTouchCancel(touchEvent([], 220, [touch(40, 300)]));
+
+      expect(details.at(-1)).toMatchObject({
+        phase: 'cancel',
+        deltaX: -60,
+        deltaY: 0,
+        deltaT: 120,
+      });
+      expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+    } finally {
+      unregister();
+    }
   });
 });
 

--- a/apps/readest-app/src/__tests__/reader/utils/iframeEventHandlers.test.ts
+++ b/apps/readest-app/src/__tests__/reader/utils/iframeEventHandlers.test.ts
@@ -22,6 +22,17 @@ function mouseEvent(overrides: Partial<MouseEvent> = {}): MouseEvent {
   } as unknown as MouseEvent;
 }
 
+function touchPoint(screenX: number, screenY: number): Touch {
+  return { clientX: screenX, clientY: screenY, screenX, screenY } as Touch;
+}
+
+function touchEvent(touches: Touch[], changedTouches: Touch[] = touches): TouchEvent {
+  return {
+    touches: touches as unknown as TouchList,
+    changedTouches: changedTouches as unknown as TouchList,
+  } as TouchEvent;
+}
+
 function postedTypes(spy: ReturnType<typeof vi.spyOn>): string[] {
   return spy.mock.calls.map((call: unknown[]) => (call[0] as { type: string }).type);
 }
@@ -221,5 +232,181 @@ describe('long-press does not open the image gallery / table zoom (#5069)', () =
     const handlers = await importHandlers();
 
     expect(handlers).not.toHaveProperty('addLongPressListeners');
+  });
+});
+
+describe('iframeEventHandlers touch forwarding', () => {
+  let postSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    postSpy = vi.spyOn(window, 'postMessage').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test('touchend forwards the released finger through changedTouches', async () => {
+    const { handleTouchEnd } = await importHandlers();
+    const released = {
+      clientX: 20,
+      clientY: 30,
+      screenX: 120,
+      screenY: 230,
+    } as Touch;
+    handleTouchEnd('book-1', {
+      touches: [] as unknown as TouchList,
+      changedTouches: [released] as unknown as TouchList,
+    } as TouchEvent);
+
+    expect(postSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'iframe-touchend',
+        bookKey: 'book-1',
+        targetTouches: [],
+        changedTouches: [
+          {
+            clientX: 20,
+            clientY: 30,
+            screenX: 120,
+            screenY: 230,
+          },
+        ],
+      }),
+      '*',
+    );
+  });
+
+  test('touchcancel forwards the released finger and clears the gesture', async () => {
+    const {
+      handleClick,
+      handleMousedown,
+      handleMouseup,
+      handleTouchStart,
+      handleTouchEnd,
+      handleTouchCancel,
+    } = await importHandlers();
+    const start = touchPoint(200, 300);
+    const released = touchPoint(160, 300);
+
+    handleTouchStart('book-1', touchEvent([start]));
+    handleTouchCancel('book-1', touchEvent([], [released]));
+
+    expect(postSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: 'iframe-touchcancel',
+        bookKey: 'book-1',
+        targetTouches: [],
+        changedTouches: [
+          {
+            clientX: 160,
+            clientY: 300,
+            screenX: 160,
+            screenY: 300,
+          },
+        ],
+      }),
+      '*',
+    );
+
+    // A cancelled touch cannot synthesize a click, so it must not suppress a
+    // subsequent deliberate tap at the same release position.
+    handleTouchStart('book-1', touchEvent([released]));
+    handleTouchEnd('book-1', touchEvent([], [released]));
+    handleMousedown('book-1', mouseEvent({ screenX: 160, screenY: 300 }));
+    handleMouseup('book-1', mouseEvent({ screenX: 160, screenY: 300 }));
+    handleClick('book-1', { current: true }, false, mouseEvent({ screenX: 160, screenY: 300 }));
+
+    const singleClicks = postSpy.mock.calls
+      .map((call: unknown[]) => call[0] as { type: string; screenX?: number })
+      .filter((message: { type: string }) => message.type === 'iframe-single-click');
+    expect(singleClicks).toEqual([expect.objectContaining({ screenX: 160 })]);
+  });
+
+  test('a swipe suppresses its synthesized click', async () => {
+    vi.useFakeTimers();
+    const {
+      handleClick,
+      handleMousedown,
+      handleMouseup,
+      handleTouchStart,
+      handleTouchMove,
+      handleTouchEnd,
+    } = await importHandlers();
+    const start = touchPoint(200, 300);
+    const end = touchPoint(120, 300);
+
+    handleTouchStart('book-1', touchEvent([start]));
+    handleTouchMove('book-1', touchEvent([end]));
+    handleTouchEnd('book-1', touchEvent([], [end]));
+    handleMousedown('book-1', mouseEvent({ screenX: 120, screenY: 300 }));
+    handleMouseup('book-1', mouseEvent({ screenX: 120, screenY: 300 }));
+    handleClick('book-1', { current: false }, false, mouseEvent({ screenX: 120, screenY: 300 }));
+    vi.advanceTimersByTime(300);
+
+    expect(postedTypes(postSpy)).not.toContain('iframe-single-click');
+  });
+
+  test('a fast swipe without a touchmove still suppresses its synthesized click', async () => {
+    vi.useFakeTimers();
+    const { handleClick, handleMousedown, handleMouseup, handleTouchStart, handleTouchEnd } =
+      await importHandlers();
+    const start = touchPoint(200, 300);
+    const end = touchPoint(120, 300);
+
+    handleTouchStart('book-1', touchEvent([start]));
+    handleTouchEnd('book-1', touchEvent([], [end]));
+    handleMousedown('book-1', mouseEvent({ screenX: 120, screenY: 300 }));
+    handleMouseup('book-1', mouseEvent({ screenX: 120, screenY: 300 }));
+    handleClick('book-1', { current: false }, false, mouseEvent({ screenX: 120, screenY: 300 }));
+    vi.advanceTimersByTime(300);
+
+    expect(postedTypes(postSpy)).not.toContain('iframe-single-click');
+  });
+
+  test('a tap still forwards its synthesized click', async () => {
+    vi.useFakeTimers();
+    const { handleClick, handleMousedown, handleMouseup, handleTouchStart, handleTouchEnd } =
+      await importHandlers();
+    const point = touchPoint(200, 300);
+
+    handleTouchStart('book-1', touchEvent([point]));
+    handleTouchEnd('book-1', touchEvent([], [point]));
+    handleMousedown('book-1', mouseEvent({ screenX: 200, screenY: 300 }));
+    handleMouseup('book-1', mouseEvent({ screenX: 200, screenY: 300 }));
+    handleClick('book-1', { current: false }, false, mouseEvent({ screenX: 200, screenY: 300 }));
+    vi.advanceTimersByTime(300);
+
+    expect(postedTypes(postSpy)).toContain('iframe-single-click');
+  });
+
+  test('allows a new tap while still suppressing the preceding swipe click', async () => {
+    vi.useFakeTimers();
+    const { handleClick, handleMousedown, handleMouseup, handleTouchStart, handleTouchEnd } =
+      await importHandlers();
+    const swipeStart = touchPoint(200, 300);
+    const swipeEnd = touchPoint(120, 300);
+    const tapPoint = touchPoint(210, 300);
+
+    handleTouchStart('book-1', touchEvent([swipeStart]));
+    handleTouchEnd('book-1', touchEvent([], [swipeEnd]));
+    // This WebView delays the swipe's synthesized click until after the next
+    // deliberate tap. The new click must pass without releasing the old one.
+    handleTouchStart('book-1', touchEvent([tapPoint]));
+    handleTouchEnd('book-1', touchEvent([], [tapPoint]));
+    handleMousedown('book-1', mouseEvent({ screenX: 210, screenY: 300 }));
+    handleMouseup('book-1', mouseEvent({ screenX: 210, screenY: 300 }));
+    handleClick('book-1', { current: true }, false, mouseEvent({ screenX: 210, screenY: 300 }));
+
+    handleMousedown('book-1', mouseEvent({ screenX: 120, screenY: 300 }));
+    handleMouseup('book-1', mouseEvent({ screenX: 120, screenY: 300 }));
+    handleClick('book-1', { current: true }, false, mouseEvent({ screenX: 120, screenY: 300 }));
+
+    const singleClicks = postSpy.mock.calls
+      .map((call: unknown[]) => call[0] as { type: string; screenX?: number })
+      .filter((message: { type: string }) => message.type === 'iframe-single-click');
+    expect(singleClicks).toEqual([expect.objectContaining({ screenX: 210 })]);
   });
 });

--- a/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { CapturedPageTurn, CapturedTurnHost } from '@/app/reader/utils/capturedTurn';
+import {
+  CapturedPageTurn,
+  CapturedTurnHost,
+  type CapturedTurnStyle,
+} from '@/app/reader/utils/capturedTurn';
 
 // Choreography tests for the captured page-turn controller (readest#555):
 // capture the page → overlay the captured bitmap → instantly navigate the
@@ -66,6 +70,48 @@ describe('CapturedPageTurn (browser)', () => {
     expect(host.querySelector('canvas')).toBeNull();
   });
 
+  it('notifies the host after the covering frame is mounted and before navigation', async () => {
+    const onCovered = vi.fn<NonNullable<CapturedTurnHost['onCovered']>>(async (style) => {
+      expect(style).toBe('curl');
+      expect(host.querySelector('canvas')).not.toBeNull();
+      expect(navigate).not.toHaveBeenCalled();
+    });
+    const covered = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      capture,
+      onCovered,
+      navigate,
+    });
+
+    expect(await covered.beginDrag(true, false)).toBe(true);
+    expect(onCovered).toHaveBeenCalledOnce();
+    expect(navigate).toHaveBeenCalledOnce();
+    covered.dispose();
+  });
+
+  it('records host state before starting the native snapshot', async () => {
+    const order: string[] = [];
+    const onBeforeCapture = vi.fn(() => {
+      order.push('before');
+    });
+    const orderedCapture = vi.fn<CapturedTurnHost['capture']>(async (rect) => {
+      order.push('capture');
+      return capture(rect);
+    });
+    const prepared = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      capture: orderedCapture,
+      onBeforeCapture,
+      navigate,
+    });
+
+    expect(await prepared.beginDrag(true, false)).toBe(true);
+    expect(order).toEqual(['before', 'capture']);
+    prepared.dispose();
+  });
+
   it('mounts the overlay canvas over the content box while animating', async () => {
     // Slow animation so the overlay is reliably observable mid-turn.
     const slow = new CapturedPageTurn(
@@ -83,6 +129,22 @@ describe('CapturedPageTurn (browser)', () => {
     slow.dispose();
     await turned;
     expect(host.querySelector('canvas')).toBeNull();
+  });
+
+  it('uses the official WebGL mesh renderer for curl turns', async () => {
+    const slow = new CapturedPageTurn(
+      { getHostElement: () => host, getContentRect: contentRect, capture, navigate },
+      { duration: 5000 },
+    );
+    const turned = slow.turn(true, false);
+    await vi.waitFor(() => {
+      const canvas = host.querySelector('canvas');
+      expect(canvas).not.toBeNull();
+      expect(canvas?.dataset['pageCurlBackend']).toBeUndefined();
+      expect(canvas?.getContext('webgl')).not.toBeNull();
+    });
+    slow.dispose();
+    await turned;
   });
 
   it('slides the captured page toward the spine on a forward LTR turn', async () => {
@@ -131,6 +193,53 @@ describe('CapturedPageTurn (browser)', () => {
     expect(host.querySelector('canvas')).toBeNull();
   });
 
+  it('restores host state and removes the overlay when instant navigation fails', async () => {
+    const onCancelled = vi.fn<NonNullable<CapturedTurnHost['onCancelled']>>();
+    navigate.mockRejectedValueOnce(new Error('navigation failed'));
+    const failing = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      capture,
+      onCancelled,
+      navigate,
+    });
+
+    await expect(failing.turn(true, false)).rejects.toThrow('navigation failed');
+
+    expect(onCancelled).toHaveBeenCalledWith('curl');
+    expect(host.querySelector('canvas')).toBeNull();
+    failing.dispose();
+  });
+
+  it('restores host state and removes the overlay when reverse navigation fails', async () => {
+    const onCancelled = vi.fn<NonNullable<CapturedTurnHost['onCancelled']>>();
+    navigate
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('reverse navigation failed'));
+    const failing = new CapturedPageTurn(
+      {
+        getHostElement: () => host,
+        getContentRect: contentRect,
+        capture,
+        onCancelled,
+        navigate,
+      },
+      { duration: 1 },
+    );
+
+    expect(await failing.beginDrag(true, false)).toBe(true);
+    failing.moveDrag(0.2, 0.5);
+    await expect(failing.endDrag(false)).rejects.toThrow('reverse navigation failed');
+
+    expect(onCancelled).toHaveBeenCalledWith('curl');
+    expect(failing.active).toBe(false);
+    expect(host.querySelector('canvas')).toBeNull();
+
+    // A rejected cancellation must not poison the serialized turn queue.
+    await expect(failing.turn(true, false)).resolves.toBe(true);
+    failing.dispose();
+  });
+
   it('interrupts an in-flight turn when a new one starts', async () => {
     const first = controller.turn(true, false);
     await vi.waitFor(() => expect(navigate).toHaveBeenCalledTimes(1));
@@ -151,6 +260,32 @@ describe('CapturedPageTurn (browser)', () => {
     // Cancel: back to flat, then instantly turn back under the overlay.
     expect(navigate).toHaveBeenNthCalledWith(2, false);
     expect(host.querySelector('canvas')).toBeNull();
+  });
+
+  it.each([
+    'curl',
+    'slide',
+  ] as CapturedTurnStyle[])('notifies the host under the flat overlay when a %s drag is cancelled', async (style) => {
+    const onCancelled = vi.fn(async (cancelledStyle: CapturedTurnStyle) => {
+      expect(cancelledStyle).toBe(style);
+      expect(navigate).toHaveBeenNthCalledWith(2, false);
+      expect(host.querySelector('canvas')).not.toBeNull();
+    });
+    const cancellable = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      capture,
+      onCancelled,
+      navigate,
+    });
+
+    expect(await cancellable.beginDrag(true, false, style)).toBe(true);
+    cancellable.moveDrag(0.3, 0.5);
+    await cancellable.endDrag(false);
+
+    expect(onCancelled).toHaveBeenCalledOnce();
+    expect(host.querySelector('canvas')).toBeNull();
+    cancellable.dispose();
   });
 
   it('scrubs a slide drag and cleans up on commit', async () => {
@@ -221,5 +356,96 @@ describe('CapturedPageTurn (browser)', () => {
     expect(navigate).toHaveBeenCalledTimes(1);
     expect(host.querySelector('canvas')).toBeNull();
     expect(controller.active).toBe(false);
+  });
+
+  it('finishes a fast swipe released before its snapshot is ready', async () => {
+    let resolveCapture!: (image: ArrayBuffer) => void;
+    const deferredCapture = new Promise<ArrayBuffer>((resolve) => {
+      resolveCapture = resolve;
+    });
+    const rapid = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      capture: () => deferredCapture,
+      navigate,
+    });
+
+    const beginning = rapid.beginDrag(true, false);
+    const ending = rapid.endDrag(true);
+    resolveCapture(await makePngBuffer());
+    await Promise.all([beginning, ending]);
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(host.querySelector('canvas')).toBeNull();
+    rapid.dispose();
+  });
+
+  it('does not mount or navigate when disposed during capture', async () => {
+    let resolveCapture!: (image: ArrayBuffer) => void;
+    const deferredCapture = new Promise<ArrayBuffer>((resolve) => {
+      resolveCapture = resolve;
+    });
+    const onCovered = vi.fn<NonNullable<CapturedTurnHost['onCovered']>>();
+    const pending = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      capture: () => deferredCapture,
+      onCovered,
+      navigate,
+    });
+
+    const beginning = pending.beginDrag(true, false);
+    await Promise.resolve();
+    pending.dispose();
+    resolveCapture(await makePngBuffer());
+
+    await expect(beginning).resolves.toBe(false);
+    expect(onCovered).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+    expect(host.querySelector('canvas')).toBeNull();
+  });
+
+  it('restores host state without navigating when disposed while covered', async () => {
+    let releaseCovered!: () => void;
+    const coveredGate = new Promise<void>((resolve) => {
+      releaseCovered = resolve;
+    });
+    const onCovered = vi.fn<NonNullable<CapturedTurnHost['onCovered']>>(() => coveredGate);
+    const onCancelled = vi.fn<NonNullable<CapturedTurnHost['onCancelled']>>();
+    const pending = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      capture,
+      onCovered,
+      onCancelled,
+      navigate,
+    });
+
+    const beginning = pending.beginDrag(true, false);
+    await vi.waitFor(() => expect(onCovered).toHaveBeenCalledOnce());
+    pending.dispose();
+    releaseCovered();
+
+    await expect(beginning).resolves.toBe(false);
+    expect(onCancelled).toHaveBeenCalledWith('curl');
+    expect(navigate).not.toHaveBeenCalled();
+    expect(host.querySelector('canvas')).toBeNull();
+  });
+
+  it('still removes the overlay when disposal restoration throws synchronously', async () => {
+    const pending = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      capture,
+      onCancelled: () => {
+        throw new Error('restore failed');
+      },
+      navigate,
+    });
+
+    expect(await pending.beginDrag(true, false)).toBe(true);
+    expect(() => pending.dispose()).not.toThrow();
+    expect(pending.active).toBe(false);
+    expect(host.querySelector('canvas')).toBeNull();
   });
 });

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -58,6 +58,7 @@ import {
   handleTouchStart,
   handleTouchMove,
   handleTouchEnd,
+  handleTouchCancel,
 } from '../utils/iframeEventHandlers';
 import { getMaxInlineSize } from '@/utils/config';
 import { getDirFromUILanguage } from '@/utils/rtl';
@@ -428,6 +429,7 @@ const FoliateViewer: React.FC<{
         detail.doc.addEventListener('touchstart', handleTouchStart.bind(null, bookKey));
         detail.doc.addEventListener('touchmove', handleTouchMove.bind(null, bookKey));
         detail.doc.addEventListener('touchend', handleTouchEnd.bind(null, bookKey));
+        detail.doc.addEventListener('touchcancel', handleTouchCancel.bind(null, bookKey));
         registerBrightnessListeners(detail.doc);
       }
     }

--- a/apps/readest-app/src/app/reader/components/ReadingRuler.tsx
+++ b/apps/readest-app/src/app/reader/components/ReadingRuler.tsx
@@ -716,11 +716,11 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
         return true;
       }
 
-      if (detail.phase === 'end') {
+      if (detail.phase === 'end' || detail.phase === 'cancel') {
         const wasConsumed = isTouchDraggingRef.current;
         if (wasConsumed) {
           isDragging.current = false;
-          throttledSave(currentPositionRef.current);
+          if (detail.phase === 'end') throttledSave(currentPositionRef.current);
         }
         touchInRulerRef.current = false;
         isTouchDraggingRef.current = false;

--- a/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
+++ b/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { flushSync } from 'react-dom';
 import { FoliateView } from '@/types/view';
 import { ViewSettings } from '@/types/book';
 import { useBookDataStore } from '@/store/bookDataStore';
@@ -7,7 +8,11 @@ import { captureWebviewRegion } from '@/utils/bridge';
 import { isTauriAppPlatform } from '@/services/environment';
 import { detectViewTransitionGroup } from '@/utils/viewTransition';
 import { CapturedPageTurn, CapturedTurnStyle } from '../utils/capturedTurn';
-import { useTouchInterceptor } from './useTouchInterceptor';
+import {
+  setLayeredTurnGestureActive,
+  TOUCH_SWIPE_THRESHOLD_PX,
+  useTouchInterceptor,
+} from './useTouchInterceptor';
 
 // Once the native snapshot fails (older webview, capture bug), stop trying
 // for the rest of the session: the renderer's own `turn-style` animations
@@ -88,7 +93,7 @@ const hasActiveSelection = (view: FoliateView) => {
  * paginator's own animations when the native capture is unavailable.
  */
 export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<FoliateView | null>) => {
-  const { getViewSettings } = useReaderStore();
+  const { getViewSettings, setHoveredBookKey } = useReaderStore();
   const { getBookData } = useBookDataStore();
   const controllerRef = useRef<CapturedPageTurn | null>(null);
   const dragRef = useRef<DragState | null>(null);
@@ -101,6 +106,7 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
   //   at release runs before the gesture's queued trailing touchmoves are
   //   delivered, and their full-stroke deltas would read as a swipe).
   const gestureClaimed = useRef(false);
+  const restoreToolbarOnCancelRef = useRef(false);
   const view = viewRef.current;
 
   const isFixedLayout = () => !!getBookData(bookKey)?.isFixedLayout;
@@ -117,7 +123,67 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
   };
 
   useEffect(() => {
-    if (!view || !isTauriAppPlatform()) return;
+    if (!view) return;
+
+    const waitForPaint = () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      });
+    const setToolbarVisibilityNow = (visible: boolean) => {
+      const gridCell = document.getElementById(`gridcell-${bookKey}`);
+      if (!gridCell) return null;
+
+      gridCell.classList.add('captured-turn-sync-chrome');
+      flushSync(() => setHoveredBookKey(visible ? bookKey : null));
+      return gridCell;
+    };
+    const syncToolbarVisibility = async (visible: boolean) => {
+      // The page snapshot covers this state change. Suppress the normal
+      // 300ms toolbar transition, commit the matching live state underneath,
+      // and keep the override through one painted frame before removing it.
+      const gridCell = setToolbarVisibilityNow(visible);
+      if (!gridCell) return;
+      try {
+        await waitForPaint();
+      } finally {
+        gridCell.classList.remove('captured-turn-sync-chrome');
+      }
+    };
+    const handleLayeredTurnState = (event: Event) => {
+      const detail = (event as CustomEvent<{ phase?: string }>).detail;
+      if (detail.phase === 'before-capture') {
+        setLayeredTurnGestureActive(bookKey, true);
+        restoreToolbarOnCancelRef.current = useReaderStore.getState().hoveredBookKey === bookKey;
+      } else if (detail.phase === 'covered') {
+        if (restoreToolbarOnCancelRef.current) setToolbarVisibilityNow(false);
+      } else if (detail.phase === 'ready') {
+        document
+          .getElementById(`gridcell-${bookKey}`)
+          ?.classList.remove('captured-turn-sync-chrome');
+      } else if (detail.phase === 'cancelled') {
+        const shouldRestore = restoreToolbarOnCancelRef.current;
+        restoreToolbarOnCancelRef.current = false;
+        if (shouldRestore) void syncToolbarVisibility(true);
+      } else if (detail.phase === 'finished') {
+        setLayeredTurnGestureActive(bookKey, false);
+        restoreToolbarOnCancelRef.current = false;
+        document
+          .getElementById(`gridcell-${bookKey}`)
+          ?.classList.remove('captured-turn-sync-chrome');
+      }
+    };
+    const cleanupLayeredTurn = () => {
+      view.renderer.removeEventListener('layered-turn-state', handleLayeredTurnState);
+      setLayeredTurnGestureActive(bookKey, false);
+      restoreToolbarOnCancelRef.current = false;
+      document.getElementById(`gridcell-${bookKey}`)?.classList.remove('captured-turn-sync-chrome');
+    };
+    view.renderer.addEventListener('layered-turn-state', handleLayeredTurnState);
+
+    // Browser View Transitions emit the same lifecycle as Tauri layered
+    // turns, so toolbar/snapshot synchronization is shared. Only the native
+    // platform needs the captured-canvas controller and prev/next wrappers.
+    if (!isTauriAppPlatform()) return cleanupLayeredTurn;
 
     // The foliate implementation returns the turn's promise even though the
     // published type is void; navigate() awaits it so the overlay only starts
@@ -135,7 +201,22 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
       // text content box.
       getContentRect: () =>
         document.getElementById(`gridcell-${bookKey}`)?.getBoundingClientRect() ?? null,
+      onBeforeCapture: () => {
+        restoreToolbarOnCancelRef.current = useReaderStore.getState().hoveredBookKey === bookKey;
+      },
       capture: captureWebviewRegion,
+      onCovered: async () => {
+        // Let the flat canvas reach the compositor before touching the live
+        // chrome; otherwise the toolbar can flash out before its captured copy
+        // is actually visible on Android/iOS WebViews.
+        await waitForPaint();
+        if (restoreToolbarOnCancelRef.current) await syncToolbarVisibility(false);
+      },
+      onCancelled: async () => {
+        const shouldRestore = restoreToolbarOnCancelRef.current;
+        restoreToolbarOnCancelRef.current = false;
+        if (shouldRestore) await syncToolbarVisibility(true);
+      },
       navigate: async (forward: boolean) => {
         // The paginator's animated paths (push slide and the layered VT
         // turns) all gate on the `animated` attribute; dropping it makes
@@ -181,6 +262,7 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
       view.prev = originals.prev;
       view.next = originals.next;
       controller.dispose();
+      cleanupLayeredTurn();
       controllerRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -202,7 +284,7 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
 
       const viewSettings = getViewSettings(bookKey);
       if (detail.phase === 'move') {
-        let state = dragRef.current;
+        const state = dragRef.current;
         if (!state) {
           // Instant highlight engaged (still-hold on text) locks scrolling so
           // the finger extends the highlight, not turns the page. The push
@@ -226,23 +308,27 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
           if (!style) return false;
           // Horizontal intent only; leave vertical swipes and taps alone.
           const { deltaX, deltaY } = detail;
-          if (Math.abs(deltaX) < 15 || Math.abs(deltaX) <= Math.abs(deltaY)) return false;
+          if (Math.abs(deltaX) < TOUCH_SWIPE_THRESHOLD_PX || Math.abs(deltaX) <= Math.abs(deltaY)) {
+            return false;
+          }
           const forward = viewSettings.rtl ? deltaX > 0 : deltaX < 0;
           if (forward ? currentView.renderer.atEnd : currentView.renderer.atStart) return false;
           const rect = document.getElementById(`gridcell-${bookKey}`)?.getBoundingClientRect();
-          state = {
+          const startedState: DragState = {
             forward,
             width: rect?.width || window.innerWidth,
             height: rect?.height || window.innerHeight,
           };
-          dragRef.current = state;
+          dragRef.current = startedState;
           controller
             .beginDrag(forward, viewSettings.rtl, style)
             .then((ok) => {
-              if (!ok) dragRef.current = null;
+              if (!ok) {
+                if (dragRef.current === startedState) dragRef.current = null;
+              }
             })
             .catch((error) => {
-              dragRef.current = null;
+              if (dragRef.current === startedState) dragRef.current = null;
               markCaptureBroken(error);
             });
           return true;
@@ -256,16 +342,23 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
         return true;
       }
 
-      // phase === 'end'
+      // phase === 'end' | 'cancel'
       const state = dragRef.current;
       if (!state) return false;
       dragRef.current = null;
+      if (detail.phase === 'cancel') {
+        controller.endDrag(false).catch(() => {});
+        return true;
+      }
       const progress = dragProgress(state, detail.deltaX, viewSettings?.rtl ?? false);
       const signed = progress * state.width;
       const velocity = signed / (detail.deltaT || 1);
       // Same carousel rule as the paginator: a flick along the turn commits
       // regardless of distance; otherwise commit past halfway.
       const commit = velocity > 0.3 ? true : progress > 0.5;
+      // CapturedPageTurn serializes endDrag behind an in-flight beginDrag, so
+      // queue release immediately. This also keeps a following gesture behind
+      // the complete begin/end pair instead of letting it supersede the turn.
       controller.endDrag(commit).catch(() => {});
       return true;
     },

--- a/apps/readest-app/src/app/reader/hooks/useIframeEvents.ts
+++ b/apps/readest-app/src/app/reader/hooks/useIframeEvents.ts
@@ -4,7 +4,13 @@ import { useBookDataStore } from '@/store/bookDataStore';
 import { eventDispatcher } from '@/utils/event';
 import { MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL } from '@/services/constants';
 import { createWheelGestureDetector } from '@/app/reader/utils/wheelGesture';
-import { dispatchTouchInterceptors, TouchDetail } from './useTouchInterceptor';
+import {
+  dispatchTouchInterceptors,
+  isLayeredTurnGestureActive,
+  TOUCH_TAP_SLOP_PX,
+  TOUCH_SWIPE_THRESHOLD_PX,
+  TouchDetail,
+} from './useTouchInterceptor';
 import { hasVerticalPanning } from './usePagination';
 
 export const useMouseEvent = (
@@ -115,6 +121,7 @@ interface IframeTouch {
 interface IframeTouchEvent {
   timeStamp: number;
   targetTouches: IframeTouch[];
+  changedTouches?: IframeTouch[];
 }
 
 // A two-finger gesture only becomes a pinch once the fingers' separation
@@ -136,10 +143,13 @@ export const useTouchEvent = (bookKey: string) => {
   const touchStartTimeRef = useRef<number | null>(null);
   const touchEndTimeRef = useRef<number | null>(null);
   const touchConsumedRef = useRef(false);
+  const layeredTurnOwnedRef = useRef(false);
   // Two fingers on a fixed-layout book start in a "pending" state: we wait to
   // see whether they spread/converge (pinch) or slide together (scroll) before
   // committing. isPinchingRef only flips true once a pinch is confirmed.
   const pinchPendingRef = useRef(false);
+
+  const isLifecycleManagedLayeredTurn = () => isLayeredTurnGestureActive(bookKey);
   const isPinchingRef = useRef(false);
   const initialTouch0Ref = useRef<IframeTouch | null>(null);
   const initialTouch1Ref = useRef<IframeTouch | null>(null);
@@ -157,7 +167,7 @@ export const useTouchEvent = (bookKey: string) => {
   };
 
   const buildTouchDetail = (
-    phase: 'start' | 'move' | 'end',
+    phase: TouchDetail['phase'],
     touch: IframeTouch,
     touchStart: IframeTouch,
     startTime: number | null,
@@ -172,6 +182,7 @@ export const useTouchEvent = (bookKey: string) => {
   });
 
   const onTouchStart = (e: IframeTouchEvent | React.TouchEvent<HTMLDivElement>) => {
+    layeredTurnOwnedRef.current = false;
     const t0 = e.targetTouches[0] as IframeTouch | undefined;
     const t1 = e.targetTouches[1] as IframeTouch | undefined;
     if (t0 && t1) {
@@ -261,14 +272,20 @@ export const useTouchEvent = (bookKey: string) => {
       }
     }
     if (touchConsumedRef.current) return;
+    // Layered turns own toolbar synchronization through their
+    // snapshot lifecycle. A second store update here would start the normal
+    // fade while the View Transition snapshot is being composed.
+    if (isLifecycleManagedLayeredTurn()) layeredTurnOwnedRef.current = true;
+    if (layeredTurnOwnedRef.current) return;
     const { current: touchStart } = touchStartRef;
     const { current: touchEnd } = touchEndRef;
     if (hoveredBookKey && touchEnd) {
       const viewSettings = getViewSettings(bookKey)!;
       const deltaY = touchEnd.screenY - touchStart.screenY;
       const deltaX = touchEnd.screenX - touchStart.screenX;
+      if (Math.hypot(deltaX, deltaY) < TOUCH_TAP_SLOP_PX) return;
       if (!viewSettings!.scrolled && !viewSettings!.vertical) {
-        if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > 10) {
+        if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) >= TOUCH_SWIPE_THRESHOLD_PX) {
           setHoveredBookKey(null);
         }
       } else {
@@ -298,15 +315,22 @@ export const useTouchEvent = (bookKey: string) => {
       }
       touchStartRef.current = null;
       touchEndRef.current = null;
+      layeredTurnOwnedRef.current = false;
       return;
     }
-    if (!touchStartRef.current) return;
+    if (!touchStartRef.current) {
+      layeredTurnOwnedRef.current = false;
+      return;
+    }
 
-    const touch = e.targetTouches[0];
+    // A single-finger touchend has no active targetTouches. changedTouches
+    // carries the actual release point; using the last move instead made fast
+    // and slow curls commit differently and under-reported the gesture time.
+    const touch = e.changedTouches?.[0] ?? e.targetTouches[0];
     if (touch) {
       touchEndRef.current = touch;
-      touchEndTimeRef.current = 'timeStamp' in e ? e.timeStamp : Date.now();
     }
+    touchEndTimeRef.current = 'timeStamp' in e ? e.timeStamp : Date.now();
 
     const { current: touchStart } = touchStartRef;
     const { current: touchEnd } = touchEndRef;
@@ -327,7 +351,41 @@ export const useTouchEvent = (bookKey: string) => {
       touchConsumedRef.current = false;
       touchStartRef.current = null;
       touchEndRef.current = null;
+      layeredTurnOwnedRef.current = false;
       return;
+    }
+
+    if (layeredTurnOwnedRef.current) {
+      touchStartRef.current = null;
+      touchEndRef.current = null;
+      layeredTurnOwnedRef.current = false;
+      return;
+    }
+
+    if (touchEnd && touchStart && isLifecycleManagedLayeredTurn()) {
+      const deltaX = touchEnd.screenX - touchStart.screenX;
+      const deltaY = touchEnd.screenY - touchStart.screenY;
+      if (Math.abs(deltaX) >= TOUCH_SWIPE_THRESHOLD_PX && Math.abs(deltaX) > Math.abs(deltaY)) {
+        touchStartRef.current = null;
+        touchEndRef.current = null;
+        layeredTurnOwnedRef.current = false;
+        return;
+      }
+    }
+
+    if (touchEnd && touchStart) {
+      const deltaX = touchEnd.screenX - touchStart.screenX;
+      const deltaY = touchEnd.screenY - touchStart.screenY;
+      if (Math.hypot(deltaX, deltaY) < TOUCH_TAP_SLOP_PX) {
+        // A clean tap is handled once by iframe-single-click. Mutating the
+        // toolbar here as well makes the touchend hide it and the following
+        // synthesized click immediately show it again (or vice versa).
+        touchConsumedRef.current = false;
+        touchStartRef.current = null;
+        touchEndRef.current = null;
+        layeredTurnOwnedRef.current = false;
+        return;
+      }
     }
 
     // Gesture was not consumed — handle hover bar toggle
@@ -362,6 +420,38 @@ export const useTouchEvent = (bookKey: string) => {
     touchConsumedRef.current = false;
     touchStartRef.current = null;
     touchEndRef.current = null;
+    layeredTurnOwnedRef.current = false;
+  };
+
+  const onTouchCancel = (e: IframeTouchEvent | React.TouchEvent<HTMLDivElement>) => {
+    if (isPinchingRef.current || pinchPendingRef.current) {
+      getView(bookKey)?.renderer.pinchEnd?.();
+      isPinchingRef.current = false;
+      pinchPendingRef.current = false;
+      initialTouch0Ref.current = null;
+      initialTouch1Ref.current = null;
+    }
+
+    const touchStart = touchStartRef.current;
+    const touch =
+      (e.changedTouches?.[0] as IframeTouch | undefined) ??
+      (e.targetTouches[0] as IframeTouch | undefined) ??
+      touchEndRef.current ??
+      touchStart;
+    const endTime = 'timeStamp' in e ? e.timeStamp : Date.now();
+    if (touchStart && touch) {
+      dispatchTouchInterceptors(
+        bookKey,
+        buildTouchDetail('cancel', touch, touchStart, touchStartTimeRef.current, endTime),
+      );
+    }
+
+    touchConsumedRef.current = false;
+    touchStartRef.current = null;
+    touchEndRef.current = null;
+    touchStartTimeRef.current = null;
+    touchEndTimeRef.current = null;
+    layeredTurnOwnedRef.current = false;
   };
 
   const handleTouch = (msg: MessageEvent) => {
@@ -372,6 +462,8 @@ export const useTouchEvent = (bookKey: string) => {
         onTouchMove(msg.data);
       } else if (msg.data.type === 'iframe-touchend') {
         onTouchEnd(msg.data);
+      } else if (msg.data.type === 'iframe-touchcancel') {
+        onTouchCancel(msg.data);
       }
     }
   };
@@ -388,5 +480,6 @@ export const useTouchEvent = (bookKey: string) => {
     onTouchStart,
     onTouchMove,
     onTouchEnd,
+    onTouchCancel,
   };
 };

--- a/apps/readest-app/src/app/reader/hooks/useTouchInterceptor.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTouchInterceptor.ts
@@ -1,7 +1,31 @@
 import { useEffect, useRef } from 'react';
 
+// A horizontal page-turn gesture becomes intentional at this distance. Keep
+// the generic toolbar handling and captured turn interceptor on the same
+// boundary so neither can act in the gap before the other claims the swipe.
+export const TOUCH_SWIPE_THRESHOLD_PX = 15;
+
+// Movement below this distance is still a tap. Touchend must leave these
+// gestures alone because the browser's synthesized click is the single owner
+// of center-tap toolbar toggling.
+export const TOUCH_TAP_SLOP_PX = TOUCH_SWIPE_THRESHOLD_PX;
+
+// The paginator announces layered turns only after it has actually claimed a
+// horizontal gesture. Generic toolbar handling yields to that active gesture,
+// not merely to a configured turn style (which may be inactive in scroll,
+// E-ink, no-animation, selection, or boundary cases).
+const activeLayeredTurnGestures = new Set<string>();
+
+export const setLayeredTurnGestureActive = (bookKey: string, active: boolean) => {
+  if (active) activeLayeredTurnGestures.add(bookKey);
+  else activeLayeredTurnGestures.delete(bookKey);
+};
+
+export const isLayeredTurnGestureActive = (bookKey: string) =>
+  activeLayeredTurnGestures.has(bookKey);
+
 export interface TouchDetail {
-  phase: 'start' | 'move' | 'end';
+  phase: 'start' | 'move' | 'end' | 'cancel';
   touch: { screenX: number; screenY: number };
   touchStart: { screenX: number; screenY: number };
   deltaX: number;

--- a/apps/readest-app/src/app/reader/utils/capturedTurn.ts
+++ b/apps/readest-app/src/app/reader/utils/capturedTurn.ts
@@ -37,6 +37,12 @@ export interface CapturedTurnHost {
   getContentRect: () => DOMRect | null;
   /** Native webview snapshot of `rect`, as PNG bytes. */
   capture: (rect: { x: number; y: number; width: number; height: number }) => Promise<ArrayBuffer>;
+  /** Records live UI state before the native snapshot starts. */
+  onBeforeCapture?: (style: CapturedTurnStyle) => void | Promise<void>;
+  /** Called once the flat captured frame covers the live reader. */
+  onCovered?: (style: CapturedTurnStyle) => void | Promise<void>;
+  /** Called under the restored flat frame before a cancelled turn is removed. */
+  onCancelled?: (style: CapturedTurnStyle) => void | Promise<void>;
   /** Instant (animation-less) page turn of the live view. */
   navigate: (forward: boolean) => Promise<void>;
 }
@@ -54,6 +60,7 @@ interface TurnRenderer {
 interface ActiveTurn {
   overlay: HTMLElement;
   renderer: TurnRenderer;
+  style: CapturedTurnStyle;
   forward: boolean;
   /** Renderer-space mirror flag (spine side of the turn), not book direction. */
   rendererRtl: boolean;
@@ -70,6 +77,7 @@ export class CapturedPageTurn {
   #host: CapturedTurnHost;
   #duration: number;
   #active: ActiveTurn | null = null;
+  #disposed = false;
   /** Serializes turns: a new turn interrupts and awaits the previous one. */
   #pending: Promise<unknown> = Promise.resolve();
 
@@ -90,12 +98,16 @@ export class CapturedPageTurn {
    */
   async turn(forward: boolean, rtl: boolean, style: CapturedTurnStyle = 'curl'): Promise<boolean> {
     const run = this.#pending.then(async () => {
+      if (this.#disposed) return false;
       this.#finishActive();
       const active = await this.#setUp(forward, rtl, style);
       if (!active) return false;
-      await this.#playTo(active, 1);
-      this.#disposeActive();
-      return true;
+      try {
+        await this.#playTo(active, 1);
+        return true;
+      } finally {
+        if (this.#active === active) this.#disposeActive();
+      }
     });
     // Keep the chain alive after failures so later turns still run.
     this.#pending = run.catch(() => {});
@@ -113,6 +125,7 @@ export class CapturedPageTurn {
     style: CapturedTurnStyle = 'curl',
   ): Promise<boolean> {
     const run = this.#pending.then(async () => {
+      if (this.#disposed) return false;
       this.#finishActive();
       const active = await this.#setUp(forward, rtl, style);
       if (!active) return false;
@@ -147,21 +160,51 @@ export class CapturedPageTurn {
    */
   async endDrag(commit: boolean) {
     const run = this.#pending.then(async () => {
+      if (this.#disposed) return;
       const active = this.#active;
       if (!active) return;
-      if (commit) {
-        await this.#playTo(active, 1);
-      } else {
-        await this.#playTo(active, 0);
-        if (this.#active === active) await this.#host.navigate(!active.forward);
+      try {
+        if (commit) {
+          await this.#playTo(active, 1);
+        } else {
+          await this.#playTo(active, 0);
+          if (this.#active === active) {
+            let navigationError: unknown;
+            try {
+              await this.#host.navigate(!active.forward);
+            } catch (error) {
+              navigationError = error;
+            }
+            try {
+              await this.#host.onCancelled?.(active.style);
+            } catch (error) {
+              if (navigationError === undefined) throw error;
+            }
+            if (navigationError !== undefined) throw navigationError;
+          }
+        }
+      } finally {
+        if (this.#active === active) this.#disposeActive();
       }
-      this.#disposeActive();
     });
     this.#pending = run.catch(() => {});
     return run;
   }
 
   dispose() {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    const active = this.#active;
+    if (active) {
+      // Start restoration before invalidating the active frame. Async host
+      // callbacks run synchronously through their first await, which lets the
+      // hook recover toolbar state before its own cleanup clears that state.
+      try {
+        Promise.resolve(this.#host.onCancelled?.(active.style)).catch(() => {});
+      } catch {
+        // Disposal must still release the GPU renderer and overlay.
+      }
+    }
     this.#finishActive();
   }
 
@@ -170,20 +213,28 @@ export class CapturedPageTurn {
     rtl: boolean,
     style: CapturedTurnStyle,
   ): Promise<ActiveTurn | null> {
+    if (this.#disposed) return null;
     const hostElement = this.#host.getHostElement();
     const rect = this.#host.getContentRect();
     if (!hostElement || !rect || rect.width <= 0 || rect.height <= 0) return null;
 
+    await this.#host.onBeforeCapture?.(style);
+    if (this.#disposed) return null;
     const image = await this.#host.capture({
       x: rect.x,
       y: rect.y,
       width: rect.width,
       height: rect.height,
     });
+    if (this.#disposed) return null;
     // No mime: the platforms return different formats (PNG on iOS/macOS,
     // JPEG on Android where PNG encoding took ~1.5s per turn) and the
     // decoder sniffs the actual format from the bytes.
     const bitmap = await createImageBitmap(new Blob([image]));
+    if (this.#disposed) {
+      bitmap.close();
+      return null;
+    }
 
     // Position the overlay at the content box within the host element.
     const hostRect = hostElement.getBoundingClientRect();
@@ -215,6 +266,7 @@ export class CapturedPageTurn {
     const active: ActiveTurn = {
       overlay,
       renderer,
+      style,
       forward,
       // Forward: the page moves out from its outer edge toward the spine
       // (left for LTR books). Backward: the mirror image — it recedes over
@@ -229,9 +281,28 @@ export class CapturedPageTurn {
 
     // First frame draws the captured page exactly covering the content box,
     // hiding the instant page swap happening underneath.
-    renderer.render(0, this.#grab(active), active.rendererRtl);
-    await this.#host.navigate(forward);
-    return active;
+    try {
+      renderer.render(0, this.#grab(active), active.rendererRtl);
+      await this.#host.onCovered?.(style);
+      if (this.#disposed || this.#active !== active) return null;
+      await this.#host.navigate(forward);
+      if (this.#disposed || this.#active !== active) return null;
+      return active;
+    } catch (error) {
+      if (this.#disposed) return null;
+      // Once the covering frame is mounted, any later failure must restore
+      // the pre-turn chrome and remove the overlay. Otherwise a failed instant
+      // navigation can leave both the toolbar and the captured canvas stuck.
+      if (this.#active === active) {
+        try {
+          await this.#host.onCancelled?.(style);
+        } catch {
+          // Preserve the setup/navigation failure as the caller-facing error.
+        }
+        this.#disposeActive();
+      }
+      throw error;
+    }
   }
 
   #grab(active: ActiveTurn) {

--- a/apps/readest-app/src/app/reader/utils/iframeEventHandlers.ts
+++ b/apps/readest-app/src/app/reader/utils/iframeEventHandlers.ts
@@ -5,6 +5,11 @@ import { findGlossWord } from '@/app/reader/utils/wordlensRuby';
 let lastClickTime = 0;
 let longHoldTimeout: ReturnType<typeof setTimeout> | null = null;
 let isMouseDown = false;
+const touchGestures = new Map<string, { startX: number; startY: number; moved: boolean }>();
+const suppressedSwipeClicks = new Map<string, { until: number; endX: number; endY: number }>();
+const SYNTHESIZED_CLICK_SWIPE_DISTANCE_PX = 15;
+const SYNTHESIZED_CLICK_SUPPRESSION_MS = 750;
+const SYNTHESIZED_CLICK_POSITION_SLOP_PX = 15;
 
 // Middle-click autoscroll (#4951). Books where the feature is armed (desktop
 // app, scrolled mode, setting on) get the middle button's defaults suppressed,
@@ -246,6 +251,20 @@ export const handleClick = (
   event: MouseEvent,
 ) => {
   const now = Date.now();
+  const suppressedSwipe = suppressedSwipeClicks.get(bookKey);
+  if (suppressedSwipe) {
+    if (now > suppressedSwipe.until) {
+      suppressedSwipeClicks.delete(bookKey);
+    } else {
+      const nearEnd =
+        Math.hypot(event.screenX - suppressedSwipe.endX, event.screenY - suppressedSwipe.endY) <=
+        SYNTHESIZED_CLICK_POSITION_SLOP_PX;
+      if (nearEnd) {
+        suppressedSwipeClicks.delete(bookKey);
+        return;
+      }
+    }
+  }
 
   if (!doubleClickDisabled.current && now - lastClickTime < DOUBLE_CLICK_INTERVAL_THRESHOLD_MS) {
     lastClickTime = now;
@@ -366,25 +385,65 @@ const handleTouchEv = (bookKey: string, event: TouchEvent, type: string) => {
   // Use event.touches (all active touches) instead of event.targetTouches
   // so that multi-finger gestures work even when fingers land on different
   // elements within the iframe (e.g. canvas vs textLayer spans in PDF)
-  const touchList = type === 'iframe-touchend' ? event.targetTouches : event.touches;
-  const touches = [];
-  for (let i = 0; i < touchList.length; i++) {
-    const touch = touchList[i];
+  const serializeTouches = (touchList: TouchList) => {
+    const touches = [];
+    for (let i = 0; i < touchList.length; i++) {
+      const touch = touchList[i];
+      if (touch) {
+        touches.push({
+          clientX: touch.clientX,
+          clientY: touch.clientY,
+          screenX: touch.screenX,
+          screenY: touch.screenY,
+        });
+      }
+    }
+    return touches;
+  };
+  const targetTouches = serializeTouches(event.touches);
+  const changedTouches = serializeTouches(event.changedTouches);
+  if (type === 'iframe-touchstart') {
+    const touch = targetTouches[0];
     if (touch) {
-      touches.push({
-        clientX: touch.clientX,
-        clientY: touch.clientY,
-        screenX: touch.screenX,
-        screenY: touch.screenY,
+      touchGestures.set(bookKey, { startX: touch.screenX, startY: touch.screenY, moved: false });
+    }
+  } else if (type === 'iframe-touchmove') {
+    const gesture = touchGestures.get(bookKey);
+    const touch = targetTouches[0];
+    if (gesture && touch) {
+      const distance = Math.hypot(touch.screenX - gesture.startX, touch.screenY - gesture.startY);
+      if (distance >= SYNTHESIZED_CLICK_SWIPE_DISTANCE_PX) gesture.moved = true;
+    }
+  } else if (type === 'iframe-touchend' || type === 'iframe-touchcancel') {
+    const gesture = touchGestures.get(bookKey);
+    // Very fast flicks can go from touchstart straight to touchend without a
+    // touchmove event. Include the released finger when deciding whether the
+    // browser-generated click belongs to a swipe.
+    const releasedTouch = changedTouches[0];
+    const moved =
+      gesture?.moved ||
+      (gesture &&
+        releasedTouch &&
+        Math.hypot(
+          releasedTouch.screenX - gesture.startX,
+          releasedTouch.screenY - gesture.startY,
+        ) >= SYNTHESIZED_CLICK_SWIPE_DISTANCE_PX);
+    if (type === 'iframe-touchend' && moved && gesture) {
+      suppressedSwipeClicks.set(bookKey, {
+        until: Date.now() + SYNTHESIZED_CLICK_SUPPRESSION_MS,
+        endX: releasedTouch?.screenX ?? gesture.startX,
+        endY: releasedTouch?.screenY ?? gesture.startY,
       });
     }
+    touchGestures.delete(bookKey);
   }
   window.postMessage(
     {
       type: type,
       bookKey,
       timeStamp: Date.now(),
-      targetTouches: touches,
+      targetTouches,
+      changedTouches,
       ...getKeyStatus(event),
     },
     '*',
@@ -401,4 +460,8 @@ export const handleTouchMove = (bookKey: string, event: TouchEvent) => {
 
 export const handleTouchEnd = (bookKey: string, event: TouchEvent) => {
   handleTouchEv(bookKey, event, 'iframe-touchend');
+};
+
+export const handleTouchCancel = (bookKey: string, event: TouchEvent) => {
+  handleTouchEv(bookKey, event, 'iframe-touchcancel');
 };

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -986,6 +986,14 @@ textarea:focus-within,
   box-shadow: none !important;
 }
 
+/* A captured or View Transition curl/slide snapshot already contains the
+   visible reader chrome. Sync its live copy underneath without playing the
+   regular toolbar transition alongside the page turn or cancellation. */
+.captured-turn-sync-chrome .header-bar,
+.captured-turn-sync-chrome .footer-bar {
+  transition: none !important;
+}
+
 /* TTS player scrubber: the track is painted by an inline three-stop gradient
    (played / buffered / rest), so the native appearance must be blanked and
    the element itself becomes the 4px track. Thumb inherits currentColor. */


### PR DESCRIPTION
Closes #5169

## Summary

- Synchronize the real reader toolbar with captured Slide/Curl snapshots.
- Hide the real toolbar immediately after the snapshot covers the page, without
  showing its normal fade transition underneath the snapshot.
- Restore the toolbar underneath the snapshot when a turn is cancelled.
- Preserve the toolbar's original hidden state across cancelled turns.
- Preserve normal center-tap toolbar toggling.
- Suppress synthetic clicks generated after swipes without blocking deliberate
  taps at a different position.
- Handle `touchcancel`, interrupted capture, failed navigation, and overlapping
  turn requests without leaving stale overlays or transition state.

## Root cause

Layered Slide/Curl turns and the generic iframe touch handler could both
interpret the same gesture.

This allowed the real toolbar to fade or toggle while the captured page already
contained another copy of it. Fast releases, cancelled transitions, and
browser-generated clicks after swipes could also leave the toolbar or overlay
in an inconsistent state.

The fix gives a claimed layered gesture exclusive ownership and coordinates the
toolbar with the capture and View Transition lifecycle.

## Companion change

Depends on readest/foliate-js#56.

## Behavior

- A visible toolbar is included in the captured snapshot.
- Once covered, the real toolbar is hidden immediately without fading.
- A committed turn leaves the toolbar hidden.
- A cancelled turn restores the toolbar before removing the snapshot.
- An initially hidden toolbar remains hidden after cancellation.
- Center taps continue to toggle the toolbar normally.

## Validation

- `pnpm format:check` passed.
- `pnpm lint` passed.
- Focused page-turn unit tests: 66 passed.
- Focused page-turn browser tests: 31 passed.
- Full local unit suite: 7,645 passed, 9 skipped, and 4 unrelated
  document-loader tests failed:
  - 3 existing TXT-to-EPUB failures
  - 1 existing nested ComicInfo archive failure
- Manual regression of center-tap toggling, committed turns, cancelled turns,
  and fast flicks.

## Recordings

### before fix:
See https://github.com/readest/readest/issues/5169#issuecomment-5006166447

### after fix:
Toolbar behavior stabilized during Slide/Curl animation

https://github.com/user-attachments/assets/a48d957c-6691-4bd7-9655-3219da4932a2


https://github.com/user-attachments/assets/b370f091-0c8e-4866-83f4-82863e7388e2


