### PR TITLE
fix(library): anchor the native context menu popup at the pointer position

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/book-context-menu-cache.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/book-context-menu-cache.test.tsx
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import type { Book } from '@/types/book';
+
+/**
+ * Issue #5181 — the native context menu takes several hundred ms to appear
+ * because every right-click rebuilds the full menu over the Tauri IPC
+ * boundary (Menu.new with a dozen items) before popup() can run.
+ *
+ * The menu must be built once and cached: repeated openings reuse the cached
+ * menu, hovering the item prewarms it so the first right-click pops
+ * instantly, and any state baked into the items (selection label, book
+ * status) invalidates the cache so the next opening rebuilds.
+ */
+
+const popupSpy = vi.hoisted(() => vi.fn(async () => {}));
+const closeSpy = vi.hoisted(() => vi.fn(async () => {}));
+const menuNew = vi.hoisted(() => vi.fn(async () => ({ popup: popupSpy, close: closeSpy })));
+
+vi.mock('@tauri-apps/api/menu', () => ({
+  Menu: { new: menuNew },
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    innerSize: async () => ({ width: 2048, height: 1536 }),
+    scaleFactor: async () => 2,
+  }),
+}));
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  revealItemInDir: vi.fn(),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({
+    envConfig: {},
+    appService: { hasContextMenu: true, isAndroidApp: false, isMobileApp: false },
+  }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: { localBooksDir: '/books' } }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (text: string) => text,
+}));
+
+vi.mock('@/app/library/hooks/useOpenBook', () => ({
+  useOpenBook: () => ({ openBook: vi.fn() }),
+}));
+
+vi.mock('@/app/library/components/BookItem', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/library/components/GroupItem', () => ({
+  default: () => null,
+}));
+
+const BookshelfItem = (await import('@/app/library/components/BookshelfItem')).default;
+
+const book: Book = {
+  hash: 'hash-1',
+  format: 'EPUB',
+  title: 'Test Book',
+  author: 'Test Author',
+  createdAt: 0,
+  updatedAt: 0,
+  downloadedAt: 1,
+};
+
+const renderItem = (overrides: { itemSelected?: boolean } = {}) => {
+  const props = {
+    mode: 'grid' as const,
+    item: book,
+    coverFit: 'crop' as const,
+    isSelectMode: false,
+    itemSelected: false,
+    transferProgress: null,
+    setLoading: vi.fn(),
+    toggleSelection: vi.fn(),
+    handleGroupBooks: vi.fn(),
+    handleBookDownload: vi.fn(async () => true),
+    handleBookUpload: vi.fn(async () => true),
+    handleBookDelete: vi.fn(async () => true),
+    handleSetSelectMode: vi.fn(),
+    handleShowDetailsBook: vi.fn(),
+    handleLibraryNavigation: vi.fn(),
+    handleUpdateReadingStatus: vi.fn(),
+    showTimeRemaining: false,
+    ...overrides,
+  };
+  const utils = render(<BookshelfItem {...props} />);
+  const rerenderItem = (nextOverrides: { itemSelected?: boolean }) =>
+    utils.rerender(<BookshelfItem {...props} {...nextOverrides} />);
+  return { ...utils, rerenderItem };
+};
+
+const openContextMenu = () =>
+  fireEvent.contextMenu(screen.getByRole('button', { name: 'Test Book' }), {
+    clientX: 10,
+    clientY: 20,
+  });
+
+describe('library context menu caching (issue #5181)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('builds the menu once and reuses it across repeated openings', async () => {
+    renderItem();
+
+    openContextMenu();
+    await waitFor(() => expect(popupSpy).toHaveBeenCalledTimes(1));
+
+    openContextMenu();
+    await waitFor(() => expect(popupSpy).toHaveBeenCalledTimes(2));
+
+    expect(menuNew).toHaveBeenCalledTimes(1);
+  });
+
+  it('prewarms the menu on pointer enter so the first popup is instant', async () => {
+    renderItem();
+
+    // React synthesizes onPointerEnter from pointerover transitions, so
+    // dispatch pointerOver (pointerEnter does not bubble and jsdom delivers
+    // it past React's delegated listeners).
+    fireEvent.pointerOver(screen.getByRole('button', { name: 'Test Book' }));
+
+    await waitFor(() => expect(menuNew).toHaveBeenCalledTimes(1));
+    expect(popupSpy).not.toHaveBeenCalled();
+
+    openContextMenu();
+    await waitFor(() => expect(popupSpy).toHaveBeenCalledTimes(1));
+    expect(menuNew).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes and rebuilds the cached menu when the selection state changes', async () => {
+    const { rerenderItem } = renderItem();
+
+    openContextMenu();
+    await waitFor(() => expect(popupSpy).toHaveBeenCalledTimes(1));
+    expect(menuNew).toHaveBeenCalledTimes(1);
+
+    rerenderItem({ itemSelected: true });
+    await waitFor(() => expect(closeSpy).toHaveBeenCalledTimes(1));
+
+    openContextMenu();
+    await waitFor(() => expect(popupSpy).toHaveBeenCalledTimes(2));
+    expect(menuNew).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/readest-app/src/__tests__/app/library/book-context-menu-popup-position.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/book-context-menu-popup-position.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import type { Book } from '@/types/book';
 
@@ -18,13 +18,33 @@ import type { Book } from '@/types/book';
  * Passing an explicit position makes muda anchor to the app window's own
  * GdkWindow instead, which always has a parent. So the popup call must carry
  * the pointer position from the triggering contextmenu event.
+ *
+ * CSS pixels are not window-logical pixels when the webview carries a page
+ * zoom. WebKitGTK folds the desktop text-scaling factor into such a zoom
+ * without reflecting it in devicePixelRatio (e.g. GDK scale 2 × 0.8 text
+ * scale: CSS→physical is 1.6 while dPR reports 2), so both raw client
+ * coordinates and clientX×dPR land the menu offset from the click by a
+ * factor that grows with distance. The zoom-proof conversion is the click's
+ * *fraction* of the CSS viewport mapped onto the window's logical size:
+ * any uniform zoom cancels out of the ratio.
  */
 
-const popupSpy = vi.hoisted(() => vi.fn(async () => {}));
-const menuNew = vi.hoisted(() => vi.fn(async () => ({ popup: popupSpy })));
+const popupSpy = vi.hoisted(() => vi.fn(async (_pos?: unknown) => {}));
+const menuNew = vi.hoisted(() => vi.fn(async () => ({ popup: popupSpy, close: vi.fn() })));
+const windowState = vi.hoisted(() => ({
+  innerSize: { width: 2560, height: 1600 },
+  scaleFactor: 2,
+}));
 
 vi.mock('@tauri-apps/api/menu', () => ({
   Menu: { new: menuNew },
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    innerSize: async () => windowState.innerSize,
+    scaleFactor: async () => windowState.scaleFactor,
+  }),
 }));
 
 vi.mock('@tauri-apps/plugin-opener', () => ({
@@ -98,7 +118,19 @@ describe('library context menu popup position (issue #5181)', () => {
     vi.clearAllMocks();
   });
 
-  it('passes the contextmenu pointer position to menu.popup', async () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const setViewport = (width: number, height: number) => {
+    Object.defineProperty(window, 'innerWidth', { value: width, configurable: true });
+    Object.defineProperty(window, 'innerHeight', { value: height, configurable: true });
+  };
+
+  it('passes the contextmenu position to menu.popup in window-logical pixels', async () => {
+    // CSS viewport matches the window logical size (1280×800): no zoom, so
+    // the popup position equals the client coordinates.
+    setViewport(1280, 800);
     renderItem();
 
     fireEvent.contextMenu(screen.getByRole('button', { name: 'Test Book' }), {
@@ -107,6 +139,28 @@ describe('library context menu popup position (issue #5181)', () => {
     });
 
     await waitFor(() => expect(popupSpy).toHaveBeenCalled());
-    expect(popupSpy).toHaveBeenCalledWith(expect.objectContaining({ x: 123, y: 456 }));
+    const pos = popupSpy.mock.calls[0]![0] as unknown as { type: string; x: number; y: number };
+    expect(pos.type).toBe('Logical');
+    expect(pos.x).toBeCloseTo(123);
+    expect(pos.y).toBeCloseTo(456);
+  });
+
+  it('compensates a webview page zoom when mapping the click to window coordinates', async () => {
+    // A 0.8 page zoom inflates the CSS viewport to 1600×1000 while the
+    // window is still 1280×800 logical: client coordinates must shrink by
+    // the same ratio or the menu lands past the click (issue #5181).
+    setViewport(1600, 1000);
+    renderItem();
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'Test Book' }), {
+      clientX: 500,
+      clientY: 250,
+    });
+
+    await waitFor(() => expect(popupSpy).toHaveBeenCalled());
+    const pos = popupSpy.mock.calls[0]![0] as unknown as { type: string; x: number; y: number };
+    expect(pos.type).toBe('Logical');
+    expect(pos.x).toBeCloseTo(400);
+    expect(pos.y).toBeCloseTo(200);
   });
 });

--- a/apps/readest-app/src/__tests__/app/library/book-context-menu-popup-position.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/book-context-menu-popup-position.test.tsx
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import type { Book } from '@/types/book';
+
+/**
+ * Issue #5181 — the library context menu flashes and disappears on Wayland
+ * when opened with a touchpad two-finger tap.
+ *
+ * `menu.popup()` without a position makes muda anchor the GTK popup to the
+ * screen's root window (muda gtk show_context_menu). X11 has a real root
+ * window so that works; Wayland has none, so the popup gets no parent and the
+ * compositor refuses to map it:
+ *
+ *   Gdk-WARNING **: Couldn't map as window 0x… as popup because it doesn't
+ *   have a parent
+ *
+ * Passing an explicit position makes muda anchor to the app window's own
+ * GdkWindow instead, which always has a parent. So the popup call must carry
+ * the pointer position from the triggering contextmenu event.
+ */
+
+const popupSpy = vi.hoisted(() => vi.fn(async () => {}));
+const menuNew = vi.hoisted(() => vi.fn(async () => ({ popup: popupSpy })));
+
+vi.mock('@tauri-apps/api/menu', () => ({
+  Menu: { new: menuNew },
+}));
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  revealItemInDir: vi.fn(),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({
+    envConfig: {},
+    appService: { hasContextMenu: true, isAndroidApp: false, isMobileApp: false },
+  }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: { localBooksDir: '/books' } }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (text: string) => text,
+}));
+
+vi.mock('@/app/library/hooks/useOpenBook', () => ({
+  useOpenBook: () => ({ openBook: vi.fn() }),
+}));
+
+vi.mock('@/app/library/components/BookItem', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/library/components/GroupItem', () => ({
+  default: () => null,
+}));
+
+const BookshelfItem = (await import('@/app/library/components/BookshelfItem')).default;
+
+const book: Book = {
+  hash: 'hash-1',
+  format: 'EPUB',
+  title: 'Test Book',
+  author: 'Test Author',
+  createdAt: 0,
+  updatedAt: 0,
+  downloadedAt: 1,
+};
+
+const renderItem = () =>
+  render(
+    <BookshelfItem
+      mode='grid'
+      item={book}
+      coverFit='crop'
+      isSelectMode={false}
+      itemSelected={false}
+      transferProgress={null}
+      setLoading={vi.fn()}
+      toggleSelection={vi.fn()}
+      handleGroupBooks={vi.fn()}
+      handleBookDownload={vi.fn(async () => true)}
+      handleBookUpload={vi.fn(async () => true)}
+      handleBookDelete={vi.fn(async () => true)}
+      handleSetSelectMode={vi.fn()}
+      handleShowDetailsBook={vi.fn()}
+      handleLibraryNavigation={vi.fn()}
+      handleUpdateReadingStatus={vi.fn()}
+      showTimeRemaining={false}
+    />,
+  );
+
+describe('library context menu popup position (issue #5181)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes the contextmenu pointer position to menu.popup', async () => {
+    renderItem();
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'Test Book' }), {
+      clientX: 123,
+      clientY: 456,
+    });
+
+    await waitFor(() => expect(popupSpy).toHaveBeenCalled());
+    expect(popupSpy).toHaveBeenCalledWith(expect.objectContaining({ x: 123, y: 456 }));
+  });
+});

--- a/apps/readest-app/src/app/library/components/BookshelfItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookshelfItem.tsx
@@ -5,6 +5,7 @@ import { useSettingsStore } from '@/store/settingsStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useLongPress } from '@/hooks/useLongPress';
 import { Menu, type MenuItemOptions } from '@tauri-apps/api/menu';
+import { LogicalPosition } from '@tauri-apps/api/dpi';
 import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import { eventDispatcher } from '@/utils/event';
 import { openExternalUrl } from '@/utils/open';
@@ -159,7 +160,7 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
     [isSelectMode, handleLibraryNavigation],
   );
 
-  const bookContextMenuHandler = async (book: Book) => {
+  const bookContextMenuHandler = async (book: Book, position: { x: number; y: number }) => {
     if (!appService?.hasContextMenu) return;
     const osPlatform = getOSPlatform();
     const fileRevealLabel =
@@ -258,10 +259,13 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
     };
     const items = getBookContextMenuItemIds(book).map((id) => itemOptions[id]);
     const menu = await Menu.new({ items });
-    await menu.popup();
+    // Pop up at an explicit window position: a positionless popup is anchored
+    // to the X11 root window, which doesn't exist on Wayland, so the menu
+    // fails to map and disappears immediately (issue #5181).
+    await menu.popup(new LogicalPosition(position.x, position.y));
   };
 
-  const groupContextMenuHandler = async (group: BooksGroup) => {
+  const groupContextMenuHandler = async (group: BooksGroup, position: { x: number; y: number }) => {
     if (!appService?.hasContextMenu) return;
     // Single Menu.new({ items }) call keeps the order deterministic — see the
     // note in bookContextMenuHandler about the Menu.append() IPC race (#4389).
@@ -296,7 +300,9 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
       },
     ];
     const menu = await Menu.new({ items });
-    await menu.popup();
+    // See the note in bookContextMenuHandler: the Wayland popup needs an
+    // explicit position to get a parent window (issue #5181).
+    await menu.popup(new LogicalPosition(position.x, position.y));
   };
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -332,11 +338,11 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleContextMenu = useCallback(
-    throttle(() => {
+    throttle((position: { x: number; y: number }) => {
       if ('format' in item) {
-        bookContextMenuHandler(item as Book);
+        bookContextMenuHandler(item as Book, position);
       } else {
-        groupContextMenuHandler(item as BooksGroup);
+        groupContextMenuHandler(item as BooksGroup, position);
       }
     }, 100),
     [itemSelected, settings.localBooksDir],
@@ -350,9 +356,9 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
       onTap: () => {
         handleOpenItem();
       },
-      onContextMenu: () => {
+      onContextMenu: (e) => {
         if (appService?.hasContextMenu) {
-          handleContextMenu();
+          handleContextMenu({ x: e.clientX, y: e.clientY });
         } else if (appService?.isAndroidApp) {
           handleSelectItem();
         }
@@ -368,7 +374,8 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
     }
     if (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) {
       e.preventDefault();
-      handleContextMenu();
+      const rect = e.currentTarget.getBoundingClientRect();
+      handleContextMenu({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
     }
   };
 

--- a/apps/readest-app/src/app/library/components/BookshelfItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookshelfItem.tsx
@@ -1,11 +1,12 @@
 import clsx from 'clsx';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useEnv } from '@/context/EnvContext';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useLongPress } from '@/hooks/useLongPress';
 import { Menu, type MenuItemOptions } from '@tauri-apps/api/menu';
 import { LogicalPosition } from '@tauri-apps/api/dpi';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import { eventDispatcher } from '@/utils/event';
 import { openExternalUrl } from '@/utils/open';
@@ -160,8 +161,7 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
     [isSelectMode, handleLibraryNavigation],
   );
 
-  const bookContextMenuHandler = async (book: Book, position: { x: number; y: number }) => {
-    if (!appService?.hasContextMenu) return;
+  const buildBookMenu = async (book: Book) => {
     const osPlatform = getOSPlatform();
     const fileRevealLabel =
       FILE_REVEAL_LABELS[osPlatform as FILE_REVEAL_PLATFORMS] || FILE_REVEAL_LABELS.default;
@@ -258,15 +258,10 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
       },
     };
     const items = getBookContextMenuItemIds(book).map((id) => itemOptions[id]);
-    const menu = await Menu.new({ items });
-    // Pop up at an explicit window position: a positionless popup is anchored
-    // to the X11 root window, which doesn't exist on Wayland, so the menu
-    // fails to map and disappears immediately (issue #5181).
-    await menu.popup(new LogicalPosition(position.x, position.y));
+    return Menu.new({ items });
   };
 
-  const groupContextMenuHandler = async (group: BooksGroup, position: { x: number; y: number }) => {
-    if (!appService?.hasContextMenu) return;
+  const buildGroupMenu = async (group: BooksGroup) => {
     // Single Menu.new({ items }) call keeps the order deterministic — see the
     // note in bookContextMenuHandler about the Menu.append() IPC race (#4389).
     const items: MenuItemOptions[] = [
@@ -299,11 +294,38 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
         },
       },
     ];
-    const menu = await Menu.new({ items });
-    // See the note in bookContextMenuHandler: the Wayland popup needs an
-    // explicit position to get a parent window (issue #5181).
-    await menu.popup(new LogicalPosition(position.x, position.y));
+    return Menu.new({ items });
   };
+
+  // Building the menu crosses the Tauri IPC boundary and takes long enough
+  // that the popup visibly lags the right-click (issue #5181). Cache the
+  // built menu so popup() fires immediately; hovering the item prewarms the
+  // cache so even the first opening is instant.
+  const cachedMenuRef = useRef<Promise<Menu> | null>(null);
+
+  const ensureMenu = () => {
+    if (!cachedMenuRef.current) {
+      const building =
+        'format' in item ? buildBookMenu(item as Book) : buildGroupMenu(item as BooksGroup);
+      building.catch(() => {
+        // A failed build must not poison the cache with a rejected promise.
+        if (cachedMenuRef.current === building) cachedMenuRef.current = null;
+      });
+      cachedMenuRef.current = building;
+    }
+    return cachedMenuRef.current;
+  };
+
+  // Drop the cache whenever state baked into the items changes (selection
+  // label, book status, reveal path, language); the cleanup also runs on
+  // unmount so the native menu resource is released.
+  useEffect(() => {
+    return () => {
+      const cached = cachedMenuRef.current;
+      cachedMenuRef.current = null;
+      cached?.then((menu) => menu.close()).catch(() => {});
+    };
+  }, [item, itemSelected, isSelectMode, settings.localBooksDir, _]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleSelectItem = useCallback(
@@ -338,14 +360,27 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleContextMenu = useCallback(
-    throttle((position: { x: number; y: number }) => {
-      if ('format' in item) {
-        bookContextMenuHandler(item as Book, position);
-      } else {
-        groupContextMenuHandler(item as BooksGroup, position);
-      }
+    throttle(async (position: { x: number; y: number }) => {
+      if (!appService?.hasContextMenu) return;
+      const menu = await ensureMenu();
+      // Pop up at an explicit window position: a positionless popup is
+      // anchored to the X11 root window, which doesn't exist on Wayland, so
+      // the menu fails to map and disappears immediately (issue #5181).
+      // CSS px are not window-logical px when the webview carries a page
+      // zoom (WebKitGTK folds the desktop text-scaling factor into one
+      // without reflecting it in devicePixelRatio), so map the click's
+      // fraction of the CSS viewport onto the window's logical size — any
+      // uniform zoom cancels out of the ratio.
+      const win = getCurrentWindow();
+      const [innerSize, scale] = await Promise.all([win.innerSize(), win.scaleFactor()]);
+      await menu.popup(
+        new LogicalPosition(
+          (position.x / window.innerWidth) * (innerSize.width / scale),
+          (position.y / window.innerHeight) * (innerSize.height / scale),
+        ),
+      );
     }, 100),
-    [itemSelected, settings.localBooksDir],
+    [item, itemSelected, isSelectMode, settings.localBooksDir],
   );
 
   const { pressing, handlers } = useLongPress(
@@ -405,6 +440,9 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
           transition: 'transform 0.2s',
         }}
         onKeyDown={handleKeyDown}
+        onPointerEnter={() => {
+          if (appService?.hasContextMenu) void ensureMenu();
+        }}
         {...itemDataAttrs}
         {...handlers}
       >

--- a/apps/readest-app/src/hooks/useLongPress.ts
+++ b/apps/readest-app/src/hooks/useLongPress.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 interface UseLongPressOptions {
   onTap?: () => void;
   onLongPress?: () => void;
-  onContextMenu?: () => void;
+  onContextMenu?: (e: React.MouseEvent) => void;
   onCancel?: () => void;
   threshold?: number;
   moveThreshold?: number;
@@ -149,7 +149,7 @@ export const useLongPress = (
         e.preventDefault();
         e.stopPropagation();
         setTimeout(() => {
-          onContextMenu();
+          onContextMenu(e);
         }, 100);
       }
       reset();


### PR DESCRIPTION
## What

Two commits:

1. **Anchor the native library context menu at an explicit position** instead of calling `menu.popup()` with no arguments, so the popup gets a parent surface on Wayland.
2. **Map the click to window-logical coordinates** via its fraction of the CSS viewport, and cache/prewarm the built native menu per item.

## Why

Fixes #5181, fixes #5041 — on Linux/Wayland the library context menu flashed and disappeared immediately when opened with a touchpad two-finger tap.

The reporter's terminal capture showed the root cause:

```
Gdk-WARNING **: Couldn't map window 0x… as popup because it doesn't have a parent
```

In muda's GTK backend, a positionless popup is anchored to the screen's **root window**. On X11 the root window is real, so this works; on Wayland there is no root window — the popup gets no parent and the compositor refuses to map it. With an explicit position, muda anchors the popup to the app window's own `GdkWindow`, which always maps.

**Coordinate mapping.** CSS pixels are not window-logical pixels when the webview carries a page zoom: WebKitGTK folds the desktop text-scaling factor into one *without reflecting it in `devicePixelRatio`* (measured on X11 with GDK scale 2 and a 0.8 text scale: CSS renders at 1.6× physical while dPR reports 2). Both `LogicalPosition(clientX)` and `PhysicalPosition(clientX × dPR)` therefore land the menu offset from the click by a factor that grows with distance (right-click book 3, menu on book 4). The zoom-proof conversion maps the click's *fraction* of the CSS viewport onto the window's logical size:

```
logicalX = clientX / window.innerWidth × (innerSize.width / scaleFactor)
```

Any uniform zoom cancels out of the ratio, and on macOS/Windows (where CSS px = logical px) the formula degenerates to the plain client coordinates.

**Latency.** Building a dozen-item native menu over the IPC boundary on every right-click made the popup visibly lag. The menu is now built once per item, cached, invalidated when item state baked into it changes, and prewarmed on pointer enter so the first right-click pops instantly.

## Verification

- Verified on X11 GNOME with 1.6× effective scaling by synthesizing right-clicks (XTEST) against the built release binary and measuring the popup window position: the menu now opens exactly at the click point; before the fix it landed at 1.25× the click's distance from the window origin.
- `book-context-menu-popup-position.test.tsx` pins the viewport-fraction conversion (no-zoom and 0.8-zoom cases); `book-context-menu-cache.test.tsx` pins the cache/prewarm/invalidation behavior.
- `pnpm test` (7606 passed) and `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
