### PR TITLE
fix(koplugin): fix auto-sync push crash and UI-thread block on book open/close (#5006)

### DIFF
--- a/apps/readest.koplugin/library/syncbooks.lua
+++ b/apps/readest.koplugin/library/syncbooks.lua
@@ -125,6 +125,24 @@ function M.resolve_collision(candidate, exists)
     return candidate
 end
 
+-- sanitize_json_nulls(v) — recursively replace function-valued JSON null
+-- sentinels with dkjson's null. KOReader's require("json") is LuaJSON, whose
+-- decoder represents a JSON null as a *function* (json.util.null). The /sync
+-- push payload is re-encoded by Spore's Format.JSON middleware with dkjson,
+-- which raises "type 'function' is not supported by JSON" on any function and
+-- fails the entire pushChanges (issue #5006). Converting the sentinel to
+-- dkjson.null re-encodes it as a JSON null — byte-faithful to what the
+-- metadata carried on the wire, with no metadata churn across devices.
+local function sanitize_json_nulls(v)
+    if type(v) == "function" then
+        return require("dkjson").null
+    elseif type(v) == "table" then
+        for k, val in pairs(v) do v[k] = sanitize_json_nulls(val) end
+    end
+    return v
+end
+M._sanitize_json_nulls = sanitize_json_nulls  -- exported for tests
+
 -- ---------------------------------------------------------------------------
 -- row_to_wire(row) — convert our internal snake_case row to the
 -- camelCase Book shape Readest's server expects on POST /sync (mirrors
@@ -159,14 +177,14 @@ local function row_to_wire(row)
     if row.metadata_json and row.metadata_json ~= "" then
         local json = require("json")
         local ok, parsed = pcall(json.decode, row.metadata_json)
-        if ok and type(parsed) == "table" then out.metadata = parsed end
+        if ok and type(parsed) == "table" then out.metadata = sanitize_json_nulls(parsed) end
     end
     -- progress: stored locally as JSON tuple [cur, total] in progress_lib;
     -- the wire format expects the actual array.
     if row.progress_lib and row.progress_lib ~= "" then
         local json = require("json")
         local ok, parsed = pcall(json.decode, row.progress_lib)
-        if ok and type(parsed) == "table" then out.progress = parsed end
+        if ok and type(parsed) == "table" then out.progress = sanitize_json_nulls(parsed) end
     end
     return out
 end

--- a/apps/readest.koplugin/main.lua
+++ b/apps/readest.koplugin/main.lua
@@ -22,6 +22,10 @@ local ReadestSync = WidgetContainer:new{
 }
 
 local API_CALL_DEBOUNCE_DELAY = 30
+-- Delay before the on-open pull runs, so the reader paints and becomes
+-- interactive first and rapid book switching coalesces to a single pull for
+-- the book you settle on, instead of stacking blocking round-trips (#5006).
+local READER_READY_PULL_DELAY = 1
 local SUPABAE_ANON_KEY_BASE64 = "ZXlKaGJHY2lPaUpJVXpJMU5pSXNJblI1Y0NJNklrcFhWQ0o5LmV5SnBjM01pT2lKemRYQmhZbUZ6WlNJc0luSmxaaUk2SW5aaWMzbDRablZ6YW1weFpIaHJhbkZzZVhOaklpd2ljbTlzWlNJNkltRnViMjRpTENKcFlYUWlPakUzTXpReE1qTTJOekVzSW1WNGNDSTZNakEwT1RZNU9UWTNNWDAuM1U1VXFhb3VfMVNnclZlMWVvOXJBcGMwdUtqcWhwUWRVWGh2d1VIbVVmZw=="
 
 ReadestSync.default_settings = {
@@ -93,11 +97,19 @@ end
 
 function ReadestSync:onReaderReady()
     if self.settings.auto_sync and self.settings.access_token then
-        UIManager:nextTick(function()
+        -- Defer the per-book pull so the reader is interactive first, and keep a
+        -- handle so a rapid book switch cancels it (onCloseWidget) instead of
+        -- stacking blocking round-trips on the UI thread (issue #5006).
+        if self.reader_ready_pull_task then
+            UIManager:unschedule(self.reader_ready_pull_task)
+        end
+        self.reader_ready_pull_task = function()
+            self.reader_ready_pull_task = nil
             self:pullBookConfig(false)
             self:pullBookNotes(false)
             self:pullBookStats(false)
-        end)
+        end
+        UIManager:scheduleIn(READER_READY_PULL_DELAY, self.reader_ready_pull_task)
     end
     self:onDispatcherRegisterReaderActions()
 end
@@ -924,13 +936,43 @@ function ReadestSync:syncBooksLibrary(mode, interactive)
     end)
 end
 
+-- pushOpenBook(interactive) — push ONLY the currently-open book's library
+-- row. Closing a book has to persist this book's reading progress and
+-- timestamps, but it does NOT need other devices' rows, so we skip the full
+-- library pull whose ~3s blocking round-trip froze the UI on every close
+-- (issue #5006). The cross-device library pull still runs when the Library
+-- widget opens. touchOpenBook returns the row with the cloud-side uploaded_at
+-- / metadata / group_id still in place (from the last pull), so this
+-- single-book push preserves them — no explicit-null wipe (issue #4138), same
+-- as the existing interactive "push" path.
+function ReadestSync:pushOpenBook(interactive)
+    if not (self.settings.access_token and self.settings.user_id) then return end
+    local touched = self:touchOpenBook()
+    if not touched then return end
+    local syncbooks = require("library.syncbooks")
+    syncbooks.pushBook(touched, {
+        sync_auth = SyncAuth,
+        sync_path = self.path,
+        settings  = self.settings,
+    }, function(success, _msg, status)
+        logger.info("ReadestSync pushOpenBook done: success=" .. tostring(success)
+            .. " status=" .. tostring(status))
+        if interactive then
+            UIManager:show(InfoMessage:new{
+                text = success and _("Books synced") or _("Books sync failed"),
+                timeout = 2,
+            })
+        end
+    end)
+end
+
 function ReadestSync:onCloseDocument()
     if self.settings.auto_sync and self.settings.access_token then
         NetworkMgr:goOnlineToRun(function()
             self:pushBookConfig(false)
             self:pushBookNotes(false)
             self:pushBookStats(false)
-            self:syncBooksLibrary("both", false)
+            self:pushOpenBook(false)
         end)
     end
 end
@@ -1006,6 +1048,10 @@ function ReadestSync:onCloseWidget()
     if self.resume_pull_task then
         UIManager:unschedule(self.resume_pull_task)
         self.resume_pull_task = nil
+    end
+    if self.reader_ready_pull_task then
+        UIManager:unschedule(self.reader_ready_pull_task)
+        self.reader_ready_pull_task = nil
     end
 end
 

--- a/apps/readest.koplugin/spec/library/syncbooks_spec.lua
+++ b/apps/readest.koplugin/spec/library/syncbooks_spec.lua
@@ -214,6 +214,39 @@ describe("library.syncbooks", function()
             assert.is_nil(syncbooks._row_to_wire(nil))
         end)
 
+        -- Regression (#5006): KOReader's require("json") is LuaJSON, whose
+        -- decoder represents a JSON null as a *function* sentinel
+        -- (json.util.null). The push payload is re-encoded by Spore with
+        -- dkjson, which raises "type 'function' is not supported by JSON" and
+        -- fails the whole pushChanges. row_to_wire must neutralise those
+        -- sentinels so the payload always re-encodes. The test harness swaps
+        -- in dkjson (which drops nulls) so we stub the LuaJSON behaviour here.
+        it("re-encodes cleanly when decoded metadata holds a JSON null (LuaJSON sentinel)", function()
+            local null_fn  -- LuaJSON: JSON null -> function sentinel
+            null_fn = function() return null_fn end
+            local prev_json = package.loaded["json"]
+            package.loaded["json"] = {
+                decode = function(_)
+                    return { series = "Foundation", published = null_fn }
+                end,
+            }
+            finally(function() package.loaded["json"] = prev_json end)
+
+            local out = syncbooks._row_to_wire({
+                hash = "h1", title = "T",
+                metadata_json = '{"series":"Foundation","published":null}',
+            })
+
+            -- The wire payload is serialized by Spore/dkjson; must not raise.
+            local dkjson = require("dkjson")
+            local ok, err = pcall(dkjson.encode, { books = { out }, notes = {}, configs = {} })
+            assert.is_true(ok, "payload must be dkjson-encodable: " .. tostring(err))
+            -- Null preserved as JSON null (byte-faithful to the wire), not a function.
+            assert.are_not.equal("function", type(out.metadata.published))
+            assert.are.equal(dkjson.null, out.metadata.published)
+            assert.are.equal("Foundation", out.metadata.series)
+        end)
+
         it("emits readingStatusUpdatedAt in the wire payload", function()
             local wire = syncbooks._row_to_wire({ hash = "h1", title = "T",
                 reading_status = "finished", reading_status_updated_at = 1750000000000 })

--- a/apps/readest.koplugin/spec/main_close_spec.lua
+++ b/apps/readest.koplugin/spec/main_close_spec.lua
@@ -1,0 +1,129 @@
+-- main_close_spec.lua
+-- Tests for ReadestSync:onCloseDocument + pushOpenBook (issue #5006).
+-- Closing a book must persist THIS book's progress/notes/stats and push only
+-- the open book's library row. It must NOT trigger a full library pull, whose
+-- ~3s blocking round-trip froze the UI on every book close.
+
+require("spec_helper")
+local stubs = require("spec.koreader_stubs")
+
+local ReadestSync = require("main")
+
+-- Stand in for library.syncbooks. main.lua require()s it lazily inside the
+-- push path, so seeding package.loaded is enough to intercept.
+local function fakeSyncbooks(pushes, result)
+    return {
+        pushBook = function(row, opts, cb)
+            table.insert(pushes, { row = row, opts = opts })
+            if cb then cb(result.success, result.msg, result.status) end
+        end,
+    }
+end
+
+describe("ReadestSync:onCloseDocument", function()
+    before_each(function() stubs.reset() end)
+
+    -- Bare instance: records which sync methods the close path dispatches.
+    local function makePlugin(opts)
+        local plugin = setmetatable({
+            settings = {
+                auto_sync = opts.auto_sync,
+                access_token = opts.access_token,
+                user_id = "u1",
+            },
+            calls = {},
+        }, { __index = ReadestSync })
+        for _, method in ipairs({ "pushBookConfig", "pushBookNotes",
+                "pushBookStats", "pushOpenBook", "syncBooksLibrary" }) do
+            plugin[method] = function(self, arg1)
+                table.insert(self.calls, { method = method, arg1 = arg1 })
+            end
+        end
+        return plugin
+    end
+
+    local function called(plugin)
+        local by = {}
+        for _, c in ipairs(plugin.calls) do by[c.method] = c end
+        return by
+    end
+
+    it("pushes config, notes, stats and the open book row (no library pull)", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok" })
+        plugin:onCloseDocument()
+
+        local by = called(plugin)
+        assert.truthy(by.pushBookConfig)
+        assert.truthy(by.pushBookNotes)
+        assert.truthy(by.pushBookStats)
+        assert.truthy(by.pushOpenBook)
+        assert.is_false(by.pushOpenBook.arg1)  -- non-interactive
+        -- The heavy full-library pull ("both") must be gone from the close path.
+        assert.is_nil(by.syncBooksLibrary)
+    end)
+
+    it("does nothing when auto sync is disabled", function()
+        local plugin = makePlugin({ auto_sync = false, access_token = "tok" })
+        plugin:onCloseDocument()
+        assert.are.equal(0, #plugin.calls)
+    end)
+
+    it("does nothing when signed out", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = nil })
+        plugin:onCloseDocument()
+        assert.are.equal(0, #plugin.calls)
+    end)
+end)
+
+describe("ReadestSync:pushOpenBook", function()
+    before_each(function() stubs.reset() end)
+
+    local function makePlugin(opts)
+        return setmetatable({
+            path = "/plugins/readest.koplugin",
+            settings = {
+                access_token = opts.access_token,
+                user_id = opts.user_id == nil and "u1" or opts.user_id,
+            },
+        }, { __index = ReadestSync })
+    end
+
+    it("pushes only the open book's row via the targeted pushBook (no pull)", function()
+        local pushes = {}
+        package.loaded["library.syncbooks"] = fakeSyncbooks(pushes, { success = true })
+        finally(function() package.loaded["library.syncbooks"] = nil end)
+
+        local plugin = makePlugin({ access_token = "tok" })
+        local row = { hash = "h1", title = "T", uploaded_at = 123, updated_at = 456 }
+        plugin.touchOpenBook = function() return row end
+
+        plugin:pushOpenBook(false)
+
+        assert.are.equal(1, #pushes)
+        assert.are.equal(row, pushes[1].row)
+    end)
+
+    it("does nothing when the open book has no library row", function()
+        local pushes = {}
+        package.loaded["library.syncbooks"] = fakeSyncbooks(pushes, { success = true })
+        finally(function() package.loaded["library.syncbooks"] = nil end)
+
+        local plugin = makePlugin({ access_token = "tok" })
+        plugin.touchOpenBook = function() return nil end
+
+        plugin:pushOpenBook(false)
+        assert.are.equal(0, #pushes)
+    end)
+
+    it("does nothing when signed out", function()
+        local pushes = {}
+        package.loaded["library.syncbooks"] = fakeSyncbooks(pushes, { success = true })
+        finally(function() package.loaded["library.syncbooks"] = nil end)
+
+        local plugin = makePlugin({ access_token = nil })
+        plugin.touchOpenBook = function() error("should not be reached") end
+
+        plugin:pushOpenBook(false)
+        assert.are.equal(0, #pushes)
+    end)
+end)

--- a/apps/readest.koplugin/spec/main_open_spec.lua
+++ b/apps/readest.koplugin/spec/main_open_spec.lua
@@ -1,0 +1,85 @@
+-- main_open_spec.lua
+-- Tests for ReadestSync:onReaderReady (open path, issue #5006). Opening a book
+-- pulls its config/notes/stats, but that pull must be DEFERRED and CANCELLABLE:
+-- the reader has to paint and become interactive first, and rapidly switching
+-- between books must not stack blocking round-trips on the UI thread — a
+-- pending open pull is dropped when the book closes before it fires.
+
+require("spec_helper")
+local stubs = require("spec.koreader_stubs")
+
+local UIManagerStub = stubs.UIManager
+local ReadestSync = require("main")
+
+local function makePlugin(opts)
+    local plugin = setmetatable({
+        settings = {
+            auto_sync = opts.auto_sync,
+            access_token = opts.access_token,
+        },
+        pull_calls = {},
+    }, { __index = ReadestSync })
+    for _, method in ipairs({ "pullBookConfig", "pullBookNotes", "pullBookStats" }) do
+        plugin[method] = function(self, interactive)
+            table.insert(self.pull_calls, { method = method, interactive = interactive })
+        end
+    end
+    return plugin
+end
+
+describe("ReadestSync:onReaderReady", function()
+    before_each(function() stubs.reset() end)
+
+    it("defers the open pull (reader paints first) then pulls config/notes/stats", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok" })
+
+        plugin:onReaderReady()
+
+        assert.are.equal(1, #UIManagerStub._scheduled)
+        -- Deferred, not immediate: the reader must be interactive before the
+        -- blocking pull runs.
+        assert.is_true(UIManagerStub._scheduled[1].delay > 0)
+        assert.are.equal(0, #plugin.pull_calls)
+
+        UIManagerStub._scheduled[1].fn()
+        assert.are.equal(3, #plugin.pull_calls)
+        local pulled = {}
+        for _, c in ipairs(plugin.pull_calls) do
+            pulled[c.method] = true
+            assert.is_false(c.interactive)
+        end
+        assert.is_true(pulled.pullBookConfig)
+        assert.is_true(pulled.pullBookNotes)
+        assert.is_true(pulled.pullBookStats)
+    end)
+
+    it("cancels a pending open pull when the book closes (rapid switching)", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok" })
+
+        plugin:onReaderReady()
+        assert.are.equal(1, #UIManagerStub._scheduled)
+
+        plugin:onCloseWidget()
+        assert.are.equal(0, #UIManagerStub._scheduled)
+    end)
+
+    it("does not stack duplicate pulls when onReaderReady fires twice", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok" })
+
+        plugin:onReaderReady()
+        plugin:onReaderReady()
+        assert.are.equal(1, #UIManagerStub._scheduled)
+    end)
+
+    it("does nothing when auto sync is disabled", function()
+        local plugin = makePlugin({ auto_sync = false, access_token = "tok" })
+        plugin:onReaderReady()
+        assert.are.equal(0, #UIManagerStub._scheduled)
+    end)
+
+    it("does nothing when signed out", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = nil })
+        plugin:onReaderReady()
+        assert.are.equal(0, #UIManagerStub._scheduled)
+    end)
+end)


### PR DESCRIPTION
Fixes #5006. Two independent problems made auto-sync slow/broken around opening and closing books. Both are addressed here (disjoint code paths).

## 1. Push crash: `type 'function' is not supported by JSON`

KOReader's `require("json")` is LuaJSON, whose decoder represents a JSON `null` as a **function** sentinel (`json.util.null`). `row_to_wire` decodes the server `metadata_json` into the `/sync` push payload, which Spore re-encodes with **dkjson**. dkjson rejects functions, so the whole `pushChanges` failed for any changed book whose metadata had a `null` field:

```
ReadestSyncClient:pushChanges failure: common/Spore/Middleware/Format/JSON.lua:26: type 'function' is not supported by JSON.
```

**Fix:** `sanitize_json_nulls` converts the function-valued null sentinels to `dkjson.null`, so the payload re-encodes as a real JSON `null`, byte-faithful to the wire with no metadata churn. Applied to the decoded `metadata` and `progress` in `row_to_wire`.

## 2. UI-thread block on book open/close

With auto-sync on, opening or closing a book froze the reader for seconds, and rapid switching triggered ANRs. The sync HTTP runs synchronously on the UI thread: the Turbo async path is dead on shipping builds (`DUSE_TURBO_LIB` defaults to `false`, so `UIManager.looper` is nil and Spore falls back to blocking socket HTTP; KOReader's own `KOSyncClient` has the same vestigial code). The block was amplified by doing far more on the critical path than KOSync:

- **Close** ran three per-book pushes + `syncBooksLibrary("both")`, and `"both"` did a **full library pull of every row (~3s) then a push**, inline via `goOnlineToRun`.
- **Open** fired three blocking per-book pulls on `nextTick`, and every rapid switch stacked another three.

**Fix** (mirrors KOSync's idiom: tiny payload on the hot path, defer the rest):

- **Close, push-only + targeted** (`pushOpenBook`): push only the open book's row instead of the full library pull+push. `touchOpenBook` returns the row with the cloud-side `uploaded_at` / `metadata` / `group_id` still in place, so the single-book push preserves them with no explicit-null wipe (#4138). Cross-device library reconciliation still runs when the Library widget opens (it already did `"both"` there).
- **Open, deferred + cancellable pull**: the per-book pull is scheduled (reader paints first) and stored so a rapid switch cancels it in `onCloseWidget` instead of stacking blocking round-trips.

Net: per-book progress/notes/stats still sync on open and close; only the heavy library-wide reconciliation moves off the reading hot path.

## Tests

- `syncbooks_spec.lua`: regression for the null-sentinel crash (stubs LuaJSON's function-null since the harness uses dkjson; asserts the payload is `dkjson.encode`-able and null is preserved). Fails with the exact production error before the fix.
- `spec/main_close_spec.lua`: close path dispatches push-only + `pushOpenBook`, no library pull.
- `spec/main_open_spec.lua`: open pull is deferred, cancelled on close (rapid switching), no duplicate stacking.
- `pnpm lint:lua` clean, `pnpm test:lua` green (267/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)