### PR TITLE
fix(koplugin): keep auto-sync off the book open/close UI thread (#5006)

### DIFF
--- a/apps/readest.koplugin/main.lua
+++ b/apps/readest.koplugin/main.lua
@@ -22,6 +22,10 @@ local ReadestSync = WidgetContainer:new{
 }
 
 local API_CALL_DEBOUNCE_DELAY = 30
+-- Delay before the on-open pull runs, so the reader paints and becomes
+-- interactive first and rapid book switching coalesces to a single pull for
+-- the book you settle on, instead of stacking blocking round-trips (#5006).
+local READER_READY_PULL_DELAY = 1
 local SUPABAE_ANON_KEY_BASE64 = "ZXlKaGJHY2lPaUpJVXpJMU5pSXNJblI1Y0NJNklrcFhWQ0o5LmV5SnBjM01pT2lKemRYQmhZbUZ6WlNJc0luSmxaaUk2SW5aaWMzbDRablZ6YW1weFpIaHJhbkZzZVhOaklpd2ljbTlzWlNJNkltRnViMjRpTENKcFlYUWlPakUzTXpReE1qTTJOekVzSW1WNGNDSTZNakEwT1RZNU9UWTNNWDAuM1U1VXFhb3VfMVNnclZlMWVvOXJBcGMwdUtqcWhwUWRVWGh2d1VIbVVmZw=="
 
 ReadestSync.default_settings = {
@@ -93,11 +97,19 @@ end
 
 function ReadestSync:onReaderReady()
     if self.settings.auto_sync and self.settings.access_token then
-        UIManager:nextTick(function()
+        -- Defer the per-book pull so the reader is interactive first, and keep a
+        -- handle so a rapid book switch cancels it (onCloseWidget) instead of
+        -- stacking blocking round-trips on the UI thread (issue #5006).
+        if self.reader_ready_pull_task then
+            UIManager:unschedule(self.reader_ready_pull_task)
+        end
+        self.reader_ready_pull_task = function()
+            self.reader_ready_pull_task = nil
             self:pullBookConfig(false)
             self:pullBookNotes(false)
             self:pullBookStats(false)
-        end)
+        end
+        UIManager:scheduleIn(READER_READY_PULL_DELAY, self.reader_ready_pull_task)
     end
     self:onDispatcherRegisterReaderActions()
 end
@@ -924,13 +936,43 @@ function ReadestSync:syncBooksLibrary(mode, interactive)
     end)
 end
 
+-- pushOpenBook(interactive) — push ONLY the currently-open book's library
+-- row. Closing a book has to persist this book's reading progress and
+-- timestamps, but it does NOT need other devices' rows, so we skip the full
+-- library pull whose ~3s blocking round-trip froze the UI on every close
+-- (issue #5006). The cross-device library pull still runs when the Library
+-- widget opens. touchOpenBook returns the row with the cloud-side uploaded_at
+-- / metadata / group_id still in place (from the last pull), so this
+-- single-book push preserves them — no explicit-null wipe (issue #4138), same
+-- as the existing interactive "push" path.
+function ReadestSync:pushOpenBook(interactive)
+    if not (self.settings.access_token and self.settings.user_id) then return end
+    local touched = self:touchOpenBook()
+    if not touched then return end
+    local syncbooks = require("library.syncbooks")
+    syncbooks.pushBook(touched, {
+        sync_auth = SyncAuth,
+        sync_path = self.path,
+        settings  = self.settings,
+    }, function(success, _msg, status)
+        logger.info("ReadestSync pushOpenBook done: success=" .. tostring(success)
+            .. " status=" .. tostring(status))
+        if interactive then
+            UIManager:show(InfoMessage:new{
+                text = success and _("Books synced") or _("Books sync failed"),
+                timeout = 2,
+            })
+        end
+    end)
+end
+
 function ReadestSync:onCloseDocument()
     if self.settings.auto_sync and self.settings.access_token then
         NetworkMgr:goOnlineToRun(function()
             self:pushBookConfig(false)
             self:pushBookNotes(false)
             self:pushBookStats(false)
-            self:syncBooksLibrary("both", false)
+            self:pushOpenBook(false)
         end)
     end
 end
@@ -1006,6 +1048,10 @@ function ReadestSync:onCloseWidget()
     if self.resume_pull_task then
         UIManager:unschedule(self.resume_pull_task)
         self.resume_pull_task = nil
+    end
+    if self.reader_ready_pull_task then
+        UIManager:unschedule(self.reader_ready_pull_task)
+        self.reader_ready_pull_task = nil
     end
 end
 

--- a/apps/readest.koplugin/spec/main_close_spec.lua
+++ b/apps/readest.koplugin/spec/main_close_spec.lua
@@ -1,0 +1,129 @@
+-- main_close_spec.lua
+-- Tests for ReadestSync:onCloseDocument + pushOpenBook (issue #5006).
+-- Closing a book must persist THIS book's progress/notes/stats and push only
+-- the open book's library row. It must NOT trigger a full library pull, whose
+-- ~3s blocking round-trip froze the UI on every book close.
+
+require("spec_helper")
+local stubs = require("spec.koreader_stubs")
+
+local ReadestSync = require("main")
+
+-- Stand in for library.syncbooks. main.lua require()s it lazily inside the
+-- push path, so seeding package.loaded is enough to intercept.
+local function fakeSyncbooks(pushes, result)
+    return {
+        pushBook = function(row, opts, cb)
+            table.insert(pushes, { row = row, opts = opts })
+            if cb then cb(result.success, result.msg, result.status) end
+        end,
+    }
+end
+
+describe("ReadestSync:onCloseDocument", function()
+    before_each(function() stubs.reset() end)
+
+    -- Bare instance: records which sync methods the close path dispatches.
+    local function makePlugin(opts)
+        local plugin = setmetatable({
+            settings = {
+                auto_sync = opts.auto_sync,
+                access_token = opts.access_token,
+                user_id = "u1",
+            },
+            calls = {},
+        }, { __index = ReadestSync })
+        for _, method in ipairs({ "pushBookConfig", "pushBookNotes",
+                "pushBookStats", "pushOpenBook", "syncBooksLibrary" }) do
+            plugin[method] = function(self, arg1)
+                table.insert(self.calls, { method = method, arg1 = arg1 })
+            end
+        end
+        return plugin
+    end
+
+    local function called(plugin)
+        local by = {}
+        for _, c in ipairs(plugin.calls) do by[c.method] = c end
+        return by
+    end
+
+    it("pushes config, notes, stats and the open book row (no library pull)", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok" })
+        plugin:onCloseDocument()
+
+        local by = called(plugin)
+        assert.truthy(by.pushBookConfig)
+        assert.truthy(by.pushBookNotes)
+        assert.truthy(by.pushBookStats)
+        assert.truthy(by.pushOpenBook)
+        assert.is_false(by.pushOpenBook.arg1)  -- non-interactive
+        -- The heavy full-library pull ("both") must be gone from the close path.
+        assert.is_nil(by.syncBooksLibrary)
+    end)
+
+    it("does nothing when auto sync is disabled", function()
+        local plugin = makePlugin({ auto_sync = false, access_token = "tok" })
+        plugin:onCloseDocument()
+        assert.are.equal(0, #plugin.calls)
+    end)
+
+    it("does nothing when signed out", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = nil })
+        plugin:onCloseDocument()
+        assert.are.equal(0, #plugin.calls)
+    end)
+end)
+
+describe("ReadestSync:pushOpenBook", function()
+    before_each(function() stubs.reset() end)
+
+    local function makePlugin(opts)
+        return setmetatable({
+            path = "/plugins/readest.koplugin",
+            settings = {
+                access_token = opts.access_token,
+                user_id = opts.user_id == nil and "u1" or opts.user_id,
+            },
+        }, { __index = ReadestSync })
+    end
+
+    it("pushes only the open book's row via the targeted pushBook (no pull)", function()
+        local pushes = {}
+        package.loaded["library.syncbooks"] = fakeSyncbooks(pushes, { success = true })
+        finally(function() package.loaded["library.syncbooks"] = nil end)
+
+        local plugin = makePlugin({ access_token = "tok" })
+        local row = { hash = "h1", title = "T", uploaded_at = 123, updated_at = 456 }
+        plugin.touchOpenBook = function() return row end
+
+        plugin:pushOpenBook(false)
+
+        assert.are.equal(1, #pushes)
+        assert.are.equal(row, pushes[1].row)
+    end)
+
+    it("does nothing when the open book has no library row", function()
+        local pushes = {}
+        package.loaded["library.syncbooks"] = fakeSyncbooks(pushes, { success = true })
+        finally(function() package.loaded["library.syncbooks"] = nil end)
+
+        local plugin = makePlugin({ access_token = "tok" })
+        plugin.touchOpenBook = function() return nil end
+
+        plugin:pushOpenBook(false)
+        assert.are.equal(0, #pushes)
+    end)
+
+    it("does nothing when signed out", function()
+        local pushes = {}
+        package.loaded["library.syncbooks"] = fakeSyncbooks(pushes, { success = true })
+        finally(function() package.loaded["library.syncbooks"] = nil end)
+
+        local plugin = makePlugin({ access_token = nil })
+        plugin.touchOpenBook = function() error("should not be reached") end
+
+        plugin:pushOpenBook(false)
+        assert.are.equal(0, #pushes)
+    end)
+end)

--- a/apps/readest.koplugin/spec/main_open_spec.lua
+++ b/apps/readest.koplugin/spec/main_open_spec.lua
@@ -1,0 +1,85 @@
+-- main_open_spec.lua
+-- Tests for ReadestSync:onReaderReady (open path, issue #5006). Opening a book
+-- pulls its config/notes/stats, but that pull must be DEFERRED and CANCELLABLE:
+-- the reader has to paint and become interactive first, and rapidly switching
+-- between books must not stack blocking round-trips on the UI thread — a
+-- pending open pull is dropped when the book closes before it fires.
+
+require("spec_helper")
+local stubs = require("spec.koreader_stubs")
+
+local UIManagerStub = stubs.UIManager
+local ReadestSync = require("main")
+
+local function makePlugin(opts)
+    local plugin = setmetatable({
+        settings = {
+            auto_sync = opts.auto_sync,
+            access_token = opts.access_token,
+        },
+        pull_calls = {},
+    }, { __index = ReadestSync })
+    for _, method in ipairs({ "pullBookConfig", "pullBookNotes", "pullBookStats" }) do
+        plugin[method] = function(self, interactive)
+            table.insert(self.pull_calls, { method = method, interactive = interactive })
+        end
+    end
+    return plugin
+end
+
+describe("ReadestSync:onReaderReady", function()
+    before_each(function() stubs.reset() end)
+
+    it("defers the open pull (reader paints first) then pulls config/notes/stats", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok" })
+
+        plugin:onReaderReady()
+
+        assert.are.equal(1, #UIManagerStub._scheduled)
+        -- Deferred, not immediate: the reader must be interactive before the
+        -- blocking pull runs.
+        assert.is_true(UIManagerStub._scheduled[1].delay > 0)
+        assert.are.equal(0, #plugin.pull_calls)
+
+        UIManagerStub._scheduled[1].fn()
+        assert.are.equal(3, #plugin.pull_calls)
+        local pulled = {}
+        for _, c in ipairs(plugin.pull_calls) do
+            pulled[c.method] = true
+            assert.is_false(c.interactive)
+        end
+        assert.is_true(pulled.pullBookConfig)
+        assert.is_true(pulled.pullBookNotes)
+        assert.is_true(pulled.pullBookStats)
+    end)
+
+    it("cancels a pending open pull when the book closes (rapid switching)", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok" })
+
+        plugin:onReaderReady()
+        assert.are.equal(1, #UIManagerStub._scheduled)
+
+        plugin:onCloseWidget()
+        assert.are.equal(0, #UIManagerStub._scheduled)
+    end)
+
+    it("does not stack duplicate pulls when onReaderReady fires twice", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok" })
+
+        plugin:onReaderReady()
+        plugin:onReaderReady()
+        assert.are.equal(1, #UIManagerStub._scheduled)
+    end)
+
+    it("does nothing when auto sync is disabled", function()
+        local plugin = makePlugin({ auto_sync = false, access_token = "tok" })
+        plugin:onReaderReady()
+        assert.are.equal(0, #UIManagerStub._scheduled)
+    end)
+
+    it("does nothing when signed out", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = nil })
+        plugin:onReaderReady()
+        assert.are.equal(0, #UIManagerStub._scheduled)
+    end)
+end)


### PR DESCRIPTION
## Problem

With auto-sync on, opening or closing a book froze the KOReader UI for seconds, and rapid book switching triggered "Application Not Responding" (#5006).

Root cause: the sync HTTP runs synchronously on the UI thread. The Turbo async path is dead on shipping builds (`DUSE_TURBO_LIB` defaults to `false`, so `UIManager.looper` is nil and Spore's `AsyncHTTP` middleware falls back to blocking socket HTTP; KOReader's own `KOSyncClient` has the same vestigial code). The block was amplified by doing far more work on the critical path than KOSync does:

- **Close** (`onCloseDocument`) ran `pushBookConfig` + `pushBookNotes` + `pushBookStats` + `syncBooksLibrary("both")`, and `"both"` did a **full library pull of every row (~3s) then a push**, inline via `goOnlineToRun`.
- **Open** (`onReaderReady`) fired three blocking per-book pulls on `nextTick`, and every rapid switch stacked another three.

## Fix

Keep the heavy work off the open/close critical path (the approach KOReader's own KOSync uses: tiny payload on the hot path, defer the rest).

**Close path, push-only + targeted** (`pushOpenBook`): push only the open book's library row instead of the full library pull+push. Closing a book only needs to persist this book's changes. `touchOpenBook` returns the row with the cloud-side `uploaded_at` / `metadata` / `group_id` still in place from the last pull, so the single-book push preserves them with no explicit-null wipe (#4138), same as the existing interactive "push" path. Cross-device library reconciliation still runs when the Library widget opens (it already did `"both"` there).

**Open path, deferred + cancellable pull**: the per-book pull is scheduled (reader paints and becomes interactive first) and stored so a rapid book switch cancels it in `onCloseWidget` instead of stacking blocking round-trips.

Net: per-book progress/notes/stats still sync on open and close; only the heavy library-wide reconciliation moves off the reading hot path.

## Tests

- `spec/main_close_spec.lua`: close path dispatches push-only + `pushOpenBook` with no library pull; `pushOpenBook` pushes only the open book's row.
- `spec/main_open_spec.lua`: open pull is deferred, cancelled on close (rapid switching), and does not stack duplicates.
- `pnpm lint:lua` clean, `pnpm test:lua` green.

Note: depends on the JSON-null push crash fix in #5186 (the other half of #5006); the two touch disjoint files and can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)