### PR TITLE
fix(ios): keep the App Group on the widget and share extensions in App Store builds

### DIFF
--- a/apps/readest-app/scripts/release-ios-appstore.sh
+++ b/apps/readest-app/scripts/release-ios-appstore.sh
@@ -1,10 +1,28 @@
+#!/usr/bin/env bash
+# Fail-fast so a failing guard (below) aborts the release instead of letting a
+# broken IPA reach altool. Without this, verify-ios-appstore-entitlements.sh
+# could report a stripped App Group and the upload would still proceed (this is
+# how 0.11.18 shipped with a dead widget despite the guard existing).
+set -euo pipefail
+
 pnpm tauri ios build --export-method app-store-connect
 
 BUNDLE_DIR=src-tauri/gen/apple/build/arm64
 IPA_BUNDLE=$BUNDLE_DIR/Readest.ipa
 
 # Guard: the App Store export re-sign must not strip the App Group entitlement
-# from the widget / share extensions, or the reading widget ships dead.
+# from the widget / share extensions, or the reading widget ships dead. With
+# `set -e` above, a failure here aborts the release before upload.
+#
+# NOTE: the build uses the committed src-tauri/gen/apple/Readest.xcodeproj as-is
+# (Tauri does not re-run xcodegen). If you change project.yml (e.g. #4891
+# removing CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION from the app extensions),
+# regenerate the project and commit it:
+#   (cd src-tauri/gen/apple && env -u FORCE_COLOR xcodegen generate)
+# Run it WITHOUT FORCE_COLOR in the env: xcodegen expands ${VAR} from the
+# generating shell, and pnpm/CI set FORCE_COLOR, which would bake a literal
+# value into the "Build Rust Code" script phase and break the build. This guard
+# still catches a stale pbxproj that strips the App Group and aborts the release.
 bash scripts/verify-ios-appstore-entitlements.sh "$IPA_BUNDLE"
 
 xcrun altool --upload-app --type ios --file $IPA_BUNDLE --apiKey $APPLE_API_KEY --apiIssuer $APPLE_API_ISSUER

--- a/apps/readest-app/src-tauri/gen/apple/Readest.xcodeproj/project.pbxproj
+++ b/apps/readest-app/src-tauri/gen/apple/Readest.xcodeproj/project.pbxproj
@@ -7,19 +7,31 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		09CC5CA1145D579F4A35BA86 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF6CC501CA70CA9BBEA6F3D9 /* WidgetKit.framework */; };
 		1792D73C771B1E81C35E6437 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 13DB566659AC0A0F741EBBBF /* Security.framework */; };
+		18653C7427FA61B643FB5927 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE7112678AB90D73F62180F /* CarPlaySceneDelegate.swift */; };
 		1F65F6BB7F9A5D5B84F5AC1E /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB09AA381EE87AED8151864C /* WebKit.framework */; };
 		283677BE23AD394BECB28EBE /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D765B7634BFC9B2D619B82E /* MetalKit.framework */; };
+		2F73290CC16EF2B1EF671B9B /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF6CC501CA70CA9BBEA6F3D9 /* WidgetKit.framework */; };
+		44677EC36EA80A8D960F4EAA /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = BA7D35F7E90C824A389B15DD /* Sentry */; };
 		4F33997845572B54DBBE431F /* libapp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 576303E7E1596790E0DEF8DC /* libapp.a */; };
 		6C2F2F58E6E25C554C47E527 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F0000D58F392BC2F808417D /* Assets.xcassets */; };
 		6CD28C6C81C7C367F51FCB70 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A77628B94260724841CB0C1F /* QuartzCore.framework */; };
+		77DEFFF81AE57C6577265ADF /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 806FEDFF1D14FC258DA1A7A0 /* MediaPlayer.framework */; };
 		7B3153C771891CB24D874FB8 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C29EFE86C85351F81C99F2A /* Metal.framework */; };
+		89B51D8F5E3BC00590E1DA6E /* ReadestWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = BAD20961DC66C6D576E1F60B /* ReadestWidget.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9E79568218100A2569F00CEA /* SentryBootstrap.m in Sources */ = {isa = PBXBuildFile; fileRef = 683FEABC98A68296CA480126 /* SentryBootstrap.m */; };
 		A3B9B497F2EC434EEEBA2235 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CF94262BF7499D2AD8B627D /* main.mm */; };
 		A870FB123FF2CAFB98EDCD36 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57535F4C21FEA405C0A45945 /* CoreGraphics.framework */; };
+		AAF9140CE4DCCB761DD7E52C /* CarPlay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7F1EE1A41EFDFC53AA8AC46 /* CarPlay.framework */; };
+		AD210F1B265493B680566A63 /* WidgetSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A89C3EE1081B36DD033E747 /* WidgetSnapshot.swift */; };
 		BA0A7C5B168460D96FA21D6B /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB595336F6275E2B879AF397 /* ShareViewController.swift */; };
+		D4A0A4E1CB92879877D7319E /* ReadestWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60661C103F0FF9B56906D570 /* ReadestWidgetBundle.swift */; };
+		D59272888A2BFE858490838D /* ReadingWidgetViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CB7597C040DC2E2BBAAD58 /* ReadingWidgetViews.swift */; };
 		D608DE39BD2F9FA892508F37 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B62E5ED5797D06981F30B6F /* UIKit.framework */; };
 		E6D9510F89AD18B18D0FCBC9 /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = E5F4A6E57CB4895FFFBC2DE8 /* ShareExtension.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E853ADD6F720091D24E184FD /* AppGroupBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1EACF94D1026C7A51CD0A63 /* AppGroupBridge.swift */; };
+		EF4B1B9640A3E70CE3F329E9 /* ReadingWidgetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CB13FE16F5D99107B056A7 /* ReadingWidgetProvider.swift */; };
 		F6003A5A70DA4C33BDBD838B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 30D8E7F6023C1DF41F8BD47C /* LaunchScreen.storyboard */; };
 		FB2C2290EAFB8BA38C973E4B /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 40409827389F82307433878B /* assets */; };
 /* End PBXBuildFile section */
@@ -32,6 +44,13 @@
 			remoteGlobalIDString = 44B76E0EA5B592540156EFE5;
 			remoteInfo = ShareExtension;
 		};
+		A5ADF63C73D87F80C946A345 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4DC84354F14AFCCC05EC3197 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C2B0475E36F5AAE3634B6C0F;
+			remoteInfo = ReadestWidget;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -42,6 +61,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				E6D9510F89AD18B18D0FCBC9 /* ShareExtension.appex in Embed Foundation Extensions */,
+				89B51D8F5E3BC00590E1DA6E /* ReadestWidget.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -56,32 +76,56 @@
 		1A5492F8B4749D670A93DE66 /* clip_url.rs */ = {isa = PBXFileReference; path = clip_url.rs; sourceTree = "<group>"; };
 		1C29EFE86C85351F81C99F2A /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		1CF94262BF7499D2AD8B627D /* main.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
+		1F45B5B458F63D98B6113A19 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		25CB7597C040DC2E2BBAAD58 /* ReadingWidgetViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingWidgetViews.swift; sourceTree = "<group>"; };
 		27B7FEAE989ABFF6C8FF0F77 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		282EE616A1F2B81C6121C9B6 /* transfer_file.rs */ = {isa = PBXFileReference; path = transfer_file.rs; sourceTree = "<group>"; };
+		2D116E0618AF542C1A1D9593 /* nightly_update.rs */ = {isa = PBXFileReference; path = nightly_update.rs; sourceTree = "<group>"; };
 		2E226C87AD0606FFF9DDEE11 /* dir_scanner.rs */ = {isa = PBXFileReference; path = dir_scanner.rs; sourceTree = "<group>"; };
 		2F0000D58F392BC2F808417D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		30D8E7F6023C1DF41F8BD47C /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		32229C1C4618F3DE22D7DA83 /* bindings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bindings.h; sourceTree = "<group>"; };
+		3A705F128DD67152CCD839D8 /* os_version.rs */ = {isa = PBXFileReference; path = os_version.rs; sourceTree = "<group>"; };
+		3A89C3EE1081B36DD033E747 /* WidgetSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSnapshot.swift; sourceTree = "<group>"; };
+		3C76FEE05802FC0886EA9BFA /* window_state.rs */ = {isa = PBXFileReference; path = window_state.rs; sourceTree = "<group>"; };
 		40409827389F82307433878B /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; path = assets; sourceTree = SOURCE_ROOT; };
+		46E88042CAF3013F6107F17A /* parser_common.rs */ = {isa = PBXFileReference; path = parser_common.rs; sourceTree = "<group>"; };
 		4924DDD171577C52C0C5809E /* ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShareExtension.entitlements; sourceTree = "<group>"; };
 		4B62E5ED5797D06981F30B6F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		4C4A7AE08BDD49657A0C749E /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
 		57535F4C21FEA405C0A45945 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		576303E7E1596790E0DEF8DC /* libapp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libapp.a; sourceTree = "<group>"; };
 		5D765B7634BFC9B2D619B82E /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
+		60661C103F0FF9B56906D570 /* ReadestWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadestWidgetBundle.swift; sourceTree = "<group>"; };
 		661E6D88481643D5928A8853 /* discord_rpc.rs */ = {isa = PBXFileReference; path = discord_rpc.rs; sourceTree = "<group>"; };
+		683FEABC98A68296CA480126 /* SentryBootstrap.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryBootstrap.m; sourceTree = "<group>"; };
 		7DADD61846736B0E638BF012 /* Readest_iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Readest_iOS.entitlements; sourceTree = "<group>"; };
+		806FEDFF1D14FC258DA1A7A0 /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
+		93460D5281B9FD6211B45C72 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		983AD7B7F8D8B9BF527EF05D /* traffic_light.rs */ = {isa = PBXFileReference; path = traffic_light.rs; sourceTree = "<group>"; };
+		9AFF95DFCB4CA01100B8C075 /* libapp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libapp.a; sourceTree = "<group>"; };
+		9B00698C6D8D59E6093819A0 /* range_file.rs */ = {isa = PBXFileReference; path = range_file.rs; sourceTree = "<group>"; };
 		9B22460180952B7C3F11DE9D /* main.rs */ = {isa = PBXFileReference; path = main.rs; sourceTree = "<group>"; };
+		9CE7112678AB90D73F62180F /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
 		A02C074BB1C537B8020DB593 /* system_dictionary.rs */ = {isa = PBXFileReference; path = system_dictionary.rs; sourceTree = "<group>"; };
+		A37E99A73D229E08C8B46AEB /* epub_parser.rs */ = {isa = PBXFileReference; path = epub_parser.rs; sourceTree = "<group>"; };
 		A7318D4877A991A1DAB79861 /* lib.rs */ = {isa = PBXFileReference; path = lib.rs; sourceTree = "<group>"; };
 		A77628B94260724841CB0C1F /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		AA9882F143239C0055D58746 /* spawn_fresh_browser.rs */ = {isa = PBXFileReference; path = spawn_fresh_browser.rs; sourceTree = "<group>"; };
+		AF314D0DE71EED6A946E0616 /* mobi_parser.rs */ = {isa = PBXFileReference; path = mobi_parser.rs; sourceTree = "<group>"; };
 		B16A12C78C47C4990EB4A028 /* apple_auth.rs */ = {isa = PBXFileReference; path = apple_auth.rs; sourceTree = "<group>"; };
+		B54784C0F9E4197FF454E3C0 /* libapp.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libapp.a; sourceTree = "<group>"; };
+		BAD20961DC66C6D576E1F60B /* ReadestWidget.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = ReadestWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		BF6CBF86E39770276E8FAFB4 /* sentry_config.rs */ = {isa = PBXFileReference; path = sentry_config.rs; sourceTree = "<group>"; };
 		C1EACF94D1026C7A51CD0A63 /* AppGroupBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupBridge.swift; sourceTree = "<group>"; };
+		C5052368822445B8F6FC0638 /* ReadestWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ReadestWidget.entitlements; sourceTree = "<group>"; };
 		CB595336F6275E2B879AF397 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		D3F4A4DF56E899C9DB0B7D60 /* eink.rs */ = {isa = PBXFileReference; path = eink.rs; sourceTree = "<group>"; };
 		DAC68A4107C30410409E5506 /* Readest_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Readest_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E4CB13FE16F5D99107B056A7 /* ReadingWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingWidgetProvider.swift; sourceTree = "<group>"; };
 		E5F4A6E57CB4895FFFBC2DE8 /* ShareExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		EF6CC501CA70CA9BBEA6F3D9 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		F7F1EE1A41EFDFC53AA8AC46 /* CarPlay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CarPlay.framework; path = System/Library/Frameworks/CarPlay.framework; sourceTree = SDKROOT; };
 		FB09AA381EE87AED8151864C /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		FF84C225AF4E94849713D59C /* mod.rs */ = {isa = PBXFileReference; path = mod.rs; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -91,6 +135,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				44677EC36EA80A8D960F4EAA /* Sentry in Frameworks */,
 				4F33997845572B54DBBE431F /* libapp.a in Frameworks */,
 				A870FB123FF2CAFB98EDCD36 /* CoreGraphics.framework in Frameworks */,
 				7B3153C771891CB24D874FB8 /* Metal.framework in Frameworks */,
@@ -99,12 +144,36 @@
 				1792D73C771B1E81C35E6437 /* Security.framework in Frameworks */,
 				D608DE39BD2F9FA892508F37 /* UIKit.framework in Frameworks */,
 				1F65F6BB7F9A5D5B84F5AC1E /* WebKit.framework in Frameworks */,
+				09CC5CA1145D579F4A35BA86 /* WidgetKit.framework in Frameworks */,
+				AAF9140CE4DCCB761DD7E52C /* CarPlay.framework in Frameworks */,
+				77DEFFF81AE57C6577265ADF /* MediaPlayer.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		16A0AAF2487FC0F200E77AA7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2F73290CC16EF2B1EF671B9B /* WidgetKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0DF97B3F0BF7031C35A6C773 /* ReadestWidget */ = {
+			isa = PBXGroup;
+			children = (
+				93460D5281B9FD6211B45C72 /* Info.plist */,
+				C5052368822445B8F6FC0638 /* ReadestWidget.entitlements */,
+				60661C103F0FF9B56906D570 /* ReadestWidgetBundle.swift */,
+				E4CB13FE16F5D99107B056A7 /* ReadingWidgetProvider.swift */,
+				25CB7597C040DC2E2BBAAD58 /* ReadingWidgetViews.swift */,
+				3A89C3EE1081B36DD033E747 /* WidgetSnapshot.swift */,
+			);
+			path = ReadestWidget;
+			sourceTree = "<group>";
+		};
 		14DF549AD83CD73CFFB27C6D /* Readest */ = {
 			isa = PBXGroup;
 			children = (
@@ -122,10 +191,19 @@
 			path = Sources;
 			sourceTree = "<group>";
 		};
+		245AF1EF44095ADF8D1AE58A /* debug */ = {
+			isa = PBXGroup;
+			children = (
+				9AFF95DFCB4CA01100B8C075 /* libapp.a */,
+			);
+			path = debug;
+			sourceTree = "<group>";
+		};
 		2D6F041DFA6B062224902B98 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				DAC68A4107C30410409E5506 /* Readest_iOS.app */,
+				BAD20961DC66C6D576E1F60B /* ReadestWidget.appex */,
 				E5F4A6E57CB4895FFFBC2DE8 /* ShareExtension.appex */,
 			);
 			name = Products;
@@ -140,12 +218,22 @@
 			path = android;
 			sourceTree = "<group>";
 		};
+		2FB21E2BD03D75C169D20A5E /* arm64 */ = {
+			isa = PBXGroup;
+			children = (
+				245AF1EF44095ADF8D1AE58A /* debug */,
+				3E60E9E90FC306D4F0F35FDF /* release */,
+			);
+			path = arm64;
+			sourceTree = "<group>";
+		};
 		3ABE44D21683D1A3A9053FF4 /* macos */ = {
 			isa = PBXGroup;
 			children = (
 				B16A12C78C47C4990EB4A028 /* apple_auth.rs */,
 				0EB90B3B3C88D7C6ABEDF11E /* menu.rs */,
 				4C4A7AE08BDD49657A0C749E /* mod.rs */,
+				3A705F128DD67152CCD839D8 /* os_version.rs */,
 				0F0D4492F8DDE94F4DC4854F /* safari_auth.rs */,
 				A02C074BB1C537B8020DB593 /* system_dictionary.rs */,
 				983AD7B7F8D8B9BF527EF05D /* traffic_light.rs */,
@@ -153,11 +241,28 @@
 			path = macos;
 			sourceTree = "<group>";
 		};
+		3E60E9E90FC306D4F0F35FDF /* release */ = {
+			isa = PBXGroup;
+			children = (
+				B54784C0F9E4197FF454E3C0 /* libapp.a */,
+			);
+			path = release;
+			sourceTree = "<group>";
+		};
 		60924896DC53876DC5E00FC4 /* Externals */ = {
 			isa = PBXGroup;
 			children = (
+				2FB21E2BD03D75C169D20A5E /* arm64 */,
 			);
 			path = Externals;
+			sourceTree = "<group>";
+		};
+		78A80B1A0F19E69A0DDE1F53 /* SentrySupport */ = {
+			isa = PBXGroup;
+			children = (
+				683FEABC98A68296CA480126 /* SentryBootstrap.m */,
+			);
+			path = SentrySupport;
 			sourceTree = "<group>";
 		};
 		9C2B108362B7772D6E89122F /* bindings */ = {
@@ -176,6 +281,8 @@
 				30D8E7F6023C1DF41F8BD47C /* LaunchScreen.storyboard */,
 				60924896DC53876DC5E00FC4 /* Externals */,
 				ADF310BD2F14DA462EF79E53 /* Readest_iOS */,
+				0DF97B3F0BF7031C35A6C773 /* ReadestWidget */,
+				78A80B1A0F19E69A0DDE1F53 /* SentrySupport */,
 				A350AB745ED478D99A088984 /* ShareExtension */,
 				241834D53E673450176D63E0 /* Sources */,
 				C86DD901A804E29C9D5A85A0 /* src */,
@@ -198,6 +305,8 @@
 		ADF310BD2F14DA462EF79E53 /* Readest_iOS */ = {
 			isa = PBXGroup;
 			children = (
+				9CE7112678AB90D73F62180F /* CarPlaySceneDelegate.swift */,
+				1F45B5B458F63D98B6113A19 /* Info.plist */,
 				7DADD61846736B0E638BF012 /* Readest_iOS.entitlements */,
 			);
 			path = Readest_iOS;
@@ -214,14 +323,17 @@
 		C5040CC68EE16BB47F46BFEB /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F7F1EE1A41EFDFC53AA8AC46 /* CarPlay.framework */,
 				57535F4C21FEA405C0A45945 /* CoreGraphics.framework */,
 				576303E7E1596790E0DEF8DC /* libapp.a */,
+				806FEDFF1D14FC258DA1A7A0 /* MediaPlayer.framework */,
 				1C29EFE86C85351F81C99F2A /* Metal.framework */,
 				5D765B7634BFC9B2D619B82E /* MetalKit.framework */,
 				A77628B94260724841CB0C1F /* QuartzCore.framework */,
 				13DB566659AC0A0F741EBBBF /* Security.framework */,
 				4B62E5ED5797D06981F30B6F /* UIKit.framework */,
 				FB09AA381EE87AED8151864C /* WebKit.framework */,
+				EF6CC501CA70CA9BBEA6F3D9 /* WidgetKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -232,9 +344,17 @@
 				1A5492F8B4749D670A93DE66 /* clip_url.rs */,
 				2E226C87AD0606FFF9DDEE11 /* dir_scanner.rs */,
 				661E6D88481643D5928A8853 /* discord_rpc.rs */,
+				A37E99A73D229E08C8B46AEB /* epub_parser.rs */,
 				A7318D4877A991A1DAB79861 /* lib.rs */,
 				9B22460180952B7C3F11DE9D /* main.rs */,
+				AF314D0DE71EED6A946E0616 /* mobi_parser.rs */,
+				2D116E0618AF542C1A1D9593 /* nightly_update.rs */,
+				46E88042CAF3013F6107F17A /* parser_common.rs */,
+				9B00698C6D8D59E6093819A0 /* range_file.rs */,
+				BF6CBF86E39770276E8FAFB4 /* sentry_config.rs */,
+				AA9882F143239C0055D58746 /* spawn_fresh_browser.rs */,
 				282EE616A1F2B81C6121C9B6 /* transfer_file.rs */,
+				3C76FEE05802FC0886EA9BFA /* window_state.rs */,
 				2D86805A2877EA3ADDDC28F8 /* android */,
 				3ABE44D21683D1A3A9053FF4 /* macos */,
 				C41C744CD45746D97A7E1DC3 /* windows */,
@@ -243,14 +363,7 @@
 			path = ../../src;
 			sourceTree = "<group>";
 		};
-		"TEMP_4DCF4303-D43B-49A2-841D-FA7AC0DF4CA6" /* arm64 */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = arm64;
-			sourceTree = "<group>";
-		};
-		"TEMP_E02BFCED-1A1D-42A7-9629-AB8D373B6ACC" /* x86_64 */ = {
+		"TEMP_BB4E7AFC-598A-43D1-8D21-5BD7069AC357" /* x86_64 */ = {
 			isa = PBXGroup;
 			children = (
 			);
@@ -274,9 +387,11 @@
 			);
 			dependencies = (
 				36709209B4F223291AF5B857 /* PBXTargetDependency */,
+				D0D65668018F8B1C3AED5E22 /* PBXTargetDependency */,
 			);
 			name = Readest_iOS;
 			packageProductDependencies = (
+				BA7D35F7E90C824A389B15DD /* Sentry */,
 			);
 			productName = Readest_iOS;
 			productReference = DAC68A4107C30410409E5506 /* Readest_iOS.app */;
@@ -299,6 +414,24 @@
 			productReference = E5F4A6E57CB4895FFFBC2DE8 /* ShareExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		C2B0475E36F5AAE3634B6C0F /* ReadestWidget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 43DFFD15B0475835BBD103B6 /* Build configuration list for PBXNativeTarget "ReadestWidget" */;
+			buildPhases = (
+				7E4819FD58AA62747EA451B7 /* Sources */,
+				16A0AAF2487FC0F200E77AA7 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ReadestWidget;
+			packageProductDependencies = (
+			);
+			productName = ReadestWidget;
+			productReference = BAD20961DC66C6D576E1F60B /* ReadestWidget.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -314,6 +447,9 @@
 					44B76E0EA5B592540156EFE5 = {
 						DevelopmentTeam = J5W48D69VR;
 					};
+					C2B0475E36F5AAE3634B6C0F = {
+						DevelopmentTeam = J5W48D69VR;
+					};
 				};
 			};
 			buildConfigurationList = B1D240E8E88B6626B5836EE7 /* Build configuration list for PBXProject "Readest" */;
@@ -325,11 +461,15 @@
 			);
 			mainGroup = 9D615C0A1CC543EF4AE91D05;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				C89A16DFD48933F6F6EDCCFE /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 2D6F041DFA6B062224902B98 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				C2B0475E36F5AAE3634B6C0F /* ReadestWidget */,
 				004FF73D61EDB0623C953EBF /* Readest_iOS */,
 				44B76E0EA5B592540156EFE5 /* ShareExtension */,
 			);
@@ -378,6 +518,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				18653C7427FA61B643FB5927 /* CarPlaySceneDelegate.swift in Sources */,
+				9E79568218100A2569F00CEA /* SentryBootstrap.m in Sources */,
 				A3B9B497F2EC434EEEBA2235 /* main.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -391,6 +533,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7E4819FD58AA62747EA451B7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D4A0A4E1CB92879877D7319E /* ReadestWidgetBundle.swift in Sources */,
+				EF4B1B9640A3E70CE3F329E9 /* ReadingWidgetProvider.swift in Sources */,
+				D59272888A2BFE858490838D /* ReadingWidgetViews.swift in Sources */,
+				AD210F1B265493B680566A63 /* WidgetSnapshot.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -398,6 +551,11 @@
 			isa = PBXTargetDependency;
 			target = 44B76E0EA5B592540156EFE5 /* ShareExtension */;
 			targetProxy = 03BA6A76BE384252922805BF /* PBXContainerItemProxy */;
+		};
+		D0D65668018F8B1C3AED5E22 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C2B0475E36F5AAE3634B6C0F /* ReadestWidget */;
+			targetProxy = A5ADF63C73D87F80C946A345 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -409,7 +567,6 @@
 				ARCHS = (
 					arm64,
 				);
-				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
 				DEVELOPMENT_TEAM = J5W48D69VR;
 				ENABLE_BITCODE = NO;
@@ -441,7 +598,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Readest_iOS/Readest_iOS.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = J5W48D69VR;
+				DEVELOPMENT_TEAM = "J5W48D69VR";
 				EMBEDDED_CONTENT_CONTAINS_SWIFT_CODE = YES;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
@@ -457,8 +614,9 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bilingify.readest;
-				PRODUCT_NAME = Readest;
+				PRODUCT_NAME = "Readest";
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;
 			};
@@ -537,7 +695,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Readest_iOS/Readest_iOS.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = J5W48D69VR;
+				DEVELOPMENT_TEAM = "J5W48D69VR";
 				EMBEDDED_CONTENT_CONTAINS_SWIFT_CODE = YES;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
@@ -553,8 +711,9 @@
 				"LIBRARY_SEARCH_PATHS[arch=arm64]" = "$(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				"LIBRARY_SEARCH_PATHS[arch=x86_64]" = "$(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bilingify.readest;
-				PRODUCT_NAME = Readest;
+				PRODUCT_NAME = "Readest";
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = arm64;
 			};
@@ -616,6 +775,34 @@
 			};
 			name = release;
 		};
+		A580FD3C122F6E59AD769DEA /* release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				ARCHS = (
+					arm64,
+				);
+				CODE_SIGN_ENTITLEMENTS = ReadestWidget/ReadestWidget.entitlements;
+				DEVELOPMENT_TEAM = J5W48D69VR;
+				ENABLE_BITCODE = NO;
+				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
+				INFOPLIST_FILE = ReadestWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bilingify.readest.ReadestWidget;
+				PRODUCT_NAME = ReadestWidget;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALID_ARCHS = arm64;
+			};
+			name = release;
+		};
 		C8133B6719701AA0FCBFB505 /* release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -623,7 +810,6 @@
 				ARCHS = (
 					arm64,
 				);
-				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
 				DEVELOPMENT_TEAM = J5W48D69VR;
 				ENABLE_BITCODE = NO;
@@ -645,6 +831,34 @@
 			};
 			name = release;
 		};
+		D9546DBD8A8E4E0CBFA34986 /* debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				ARCHS = (
+					arm64,
+				);
+				CODE_SIGN_ENTITLEMENTS = ReadestWidget/ReadestWidget.entitlements;
+				DEVELOPMENT_TEAM = J5W48D69VR;
+				ENABLE_BITCODE = NO;
+				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
+				INFOPLIST_FILE = ReadestWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bilingify.readest.ReadestWidget;
+				PRODUCT_NAME = ReadestWidget;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALID_ARCHS = arm64;
+			};
+			name = debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -653,6 +867,15 @@
 			buildConfigurations = (
 				04ED2C8C8903E9E56E98A711 /* debug */,
 				C8133B6719701AA0FCBFB505 /* release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = debug;
+		};
+		43DFFD15B0475835BBD103B6 /* Build configuration list for PBXNativeTarget "ReadestWidget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D9546DBD8A8E4E0CBFA34986 /* debug */,
+				A580FD3C122F6E59AD769DEA /* release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = debug;
@@ -676,6 +899,25 @@
 			defaultConfigurationName = debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		C89A16DFD48933F6F6EDCCFE /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		BA7D35F7E90C824A389B15DD /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C89A16DFD48933F6F6EDCCFE /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 4DC84354F14AFCCC05EC3197 /* Project object */;
 }


### PR DESCRIPTION
## Problem

The iOS reading widget shows only a placeholder book icon (no recent books) and the share extension can only see a single default group instead of the real library groups. Both work under `pnpm dev-ios` on device but are broken in TestFlight and the App Store (confirmed on the live 0.11.18 release).

## Root cause

Both extensions read the shared App Group container `group.com.bilingify.readest` that the main app writes. In App Store distribution builds the App Group entitlement was stripped from both `.appex` binaries during the `xcodebuild` archive/export re-sign, because the generated `Readest.xcodeproj` still set `CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES` on the extension targets. Dev builds do not run that minimize step, which is why it only reproduced in distribution.

#4891 removed the flag from `project.yml`, but:

- Tauri's iOS build does not re-run `xcodegen`, so `project.yml` and the generated `project.pbxproj` drift apart.
- `project.pbxproj` is marked `skip-worktree`, so the corrected file was never committed and the committed project stayed stale (it predates the widget target entirely).

So the flag reached the shipped build even though the source fix was merged.

## Fix

- Regenerate the committed `Readest.xcodeproj` from `project.yml`: the flag is gone from both extension targets, and the widget + CarPlay targets that the committed project was missing are now present.
- `release-ios-appstore.sh` now runs with `set -euo pipefail`. Previously it had no `set -e`, so `verify-ios-appstore-entitlements.sh` could report a stripped App Group and the script would still continue to `altool --upload-app`. The guard is now blocking, so a missing App Group aborts the release instead of shipping (this is how 0.11.18 shipped broken despite the guard existing).

## Verification

- Re-exported the current archive with an App Store `ExportOptions` (`signingStyle: automatic`, `-allowProvisioningUpdates`, same as the release path): `group.com.bilingify.readest` is present in the main app, `ShareExtension.appex`, and `ReadestWidget.appex` (distribution signing: `get-task-allow=0`, `beta-reports-active=1`).
- `bash -n` passes on the release script.
- Confirmed the regenerated project is generated from the same `project.yml` as `main` and references only source files present on `main`.

## Note

`project.pbxproj` stays `skip-worktree` and Tauri regenerates it locally, so it can drift again. If `project.yml` changes, regenerate with `(cd src-tauri/gen/apple && env -u FORCE_COLOR xcodegen generate)` and commit. `FORCE_COLOR` must be unset because `xcodegen` expands `${VAR}` from the generating shell and pnpm/CI set it, which would bake a literal value into the "Build Rust Code" script phase and break the build. The blocking guard is the durable backstop regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
