### PR TITLE
fix(opds): restore Calibre pipe-escaped commas in author names and join authors with &

### DIFF
--- a/apps/readest-app/src/__tests__/app/opds/feed-view.test.tsx
+++ b/apps/readest-app/src/__tests__/app/opds/feed-view.test.tsx
@@ -15,22 +15,22 @@ vi.mock('@/components/CachedImage', () => ({
 // synchronously via itemContent, matching the TOCView/BooknoteView test mocks.
 vi.mock('react-virtuoso', async () => {
   const React = await import('react');
+  const renderAll = (
+    {
+      totalCount,
+      itemContent,
+    }: { totalCount: number; itemContent: (index: number) => React.ReactNode },
+    _ref: React.Ref<unknown>,
+  ) => (
+    <div>
+      {Array.from({ length: totalCount }, (_, index) => (
+        <div key={index}>{itemContent(index)}</div>
+      ))}
+    </div>
+  );
   return {
-    Virtuoso: React.forwardRef(
-      (
-        {
-          totalCount,
-          itemContent,
-        }: { totalCount: number; itemContent: (index: number) => React.ReactNode },
-        _ref: React.Ref<unknown>,
-      ) => (
-        <div>
-          {Array.from({ length: totalCount }, (_, index) => (
-            <div key={index}>{itemContent(index)}</div>
-          ))}
-        </div>
-      ),
-    ),
+    Virtuoso: React.forwardRef(renderAll),
+    VirtuosoGrid: React.forwardRef(renderAll),
   };
 });
 
@@ -84,6 +84,29 @@ describe('FeedView groups', () => {
     expect(screen.queryByTestId('group-carousel')).toBeNull();
     // Publications still render in the (grid) layout.
     expect(screen.getByText('Only Group A')).toBeTruthy();
+  });
+
+  it('shows card authors with Calibre pipes restored to commas, joined by & (issue #5183)', () => {
+    const feed: OPDSFeed = {
+      metadata: { title: 'Catalog' },
+      links: [],
+      publications: [
+        {
+          metadata: {
+            title: 'Two Authors',
+            author: [
+              { name: 'Doe| John Walter', links: [] },
+              { name: 'Smith| James Richard', links: [] },
+            ],
+          },
+          links: [],
+          images: [],
+        },
+      ],
+    };
+    renderFeed(feed);
+
+    expect(screen.getByText('Doe, John Walter & Smith, James Richard')).toBeTruthy();
   });
 
   it('selects the right publication when a carousel item is clicked', () => {

--- a/apps/readest-app/src/__tests__/app/opds/opds-utils.test.ts
+++ b/apps/readest-app/src/__tests__/app/opds/opds-utils.test.ts
@@ -58,6 +58,7 @@ import {
   validateOPDSURL,
   getOPDSNavLink,
   getUnaddedPopularCatalogs,
+  formatContributorName,
 } from '@/app/opds/utils/opdsUtils';
 import type { OPDSBaseLink, OPDSCatalog } from '@/types/opds';
 import { fetchWithAuth } from '@/app/opds/utils/opdsReq';
@@ -67,6 +68,18 @@ const mockFetchWithAuth = vi.mocked(fetchWithAuth);
 describe('opdsUtils', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe('formatContributorName', () => {
+    // Calibre stores commas in author names as `|` (e.g. `Doe| John`), and
+    // Calibre-Web OPDS feeds serve that raw form (readest issue #5183).
+    it('restores commas that Calibre escaped as pipes', () => {
+      expect(formatContributorName('Doe| John Walter')).toBe('Doe, John Walter');
+    });
+
+    it('leaves names without pipes unchanged', () => {
+      expect(formatContributorName('John Walter Doe')).toBe('John Walter Doe');
+    });
   });
 
   describe('groupByArray', () => {

--- a/apps/readest-app/src/__tests__/app/opds/publication-view.test.tsx
+++ b/apps/readest-app/src/__tests__/app/opds/publication-view.test.tsx
@@ -240,6 +240,40 @@ describe('PublicationView', () => {
     expect(screen.getByText('Washington: Government printing office, 1904.')).toBeTruthy();
   });
 
+  it('restores Calibre pipe-escaped commas and joins authors with & (issue #5183)', () => {
+    const calibrePublication: OPDSPublication = {
+      metadata: {
+        title: 'Two Authors',
+        author: [
+          {
+            name: 'Doe| John Walter',
+            links: [{ href: '/opds/search?author_id=1', type: 'application/opds+json' }],
+          },
+          { name: 'Smith| James Richard', links: [] },
+        ],
+      },
+      links: [],
+      images: [],
+    };
+
+    const { container } = render(
+      <DropdownProvider>
+        <PublicationView
+          publication={calibrePublication}
+          baseURL='https://calibre.example.com/opds'
+          resolveURL={(href, base) => new URL(href, base).toString()}
+          onDownload={vi.fn(async () => null)}
+          onNavigate={vi.fn()}
+          onGenerateCachedImageUrl={vi.fn(async (url: string) => url)}
+        />
+      </DropdownProvider>,
+    );
+
+    expect(container.textContent).toContain('Doe, John Walter & Smith, James Richard');
+    // Linked authors stay clickable with the normalized name.
+    expect(screen.getByRole('button', { name: 'Doe, John Walter' })).toBeTruthy();
+  });
+
   it('renders a tag without an OPDS link as plain, non-clickable text', () => {
     render(
       <DropdownProvider>

--- a/apps/readest-app/src/app/opds/components/PublicationCard.tsx
+++ b/apps/readest-app/src/app/opds/components/PublicationCard.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react';
 import { CachedImage } from '@/components/CachedImage';
 import { OPDSPublication, REL } from '@/types/opds';
+import { formatContributorName } from '../utils/opdsUtils';
 
 interface PublicationCardProps {
   publication: OPDSPublication;
@@ -42,7 +43,10 @@ export function PublicationCard({
 
     const authorList = Array.isArray(author) ? author : [author];
 
-    return authorList.map((a) => (typeof a === 'string' ? a : a?.name)).filter(Boolean);
+    return authorList
+      .map((a) => (typeof a === 'string' ? a : a?.name))
+      .filter((name): name is string => Boolean(name))
+      .map(formatContributorName);
   }, [publication.metadata?.author]);
 
   return (
@@ -62,7 +66,7 @@ export function PublicationCard({
           {publication.metadata?.title || 'Untitled'}
         </h3>
         {authors && authors.length > 0 && (
-          <p className='text-base-content/70 line-clamp-1 text-xs'>{authors.join(', ')}</p>
+          <p className='text-base-content/70 line-clamp-1 text-xs'>{authors.join(' & ')}</p>
         )}
       </div>
     </div>

--- a/apps/readest-app/src/app/opds/components/PublicationView.tsx
+++ b/apps/readest-app/src/app/opds/components/PublicationView.tsx
@@ -13,7 +13,7 @@ import { getImportErrorMessage, ImportError } from '@/services/errors';
 import { eventDispatcher } from '@/utils/event';
 import { navigateToReader } from '@/utils/nav';
 import { CachedImage } from '@/components/CachedImage';
-import { groupByArray, getOPDSNavLink } from '../utils/opdsUtils';
+import { groupByArray, getOPDSNavLink, formatContributorName } from '../utils/opdsUtils';
 import { getOPDSDescriptionHtml } from '../utils/opdsContent';
 import Dropdown from '@/components/Dropdown';
 import MenuItem from '@/components/MenuItem';
@@ -104,7 +104,8 @@ export function PublicationView({
           ? { name: a, href: undefined as string | undefined }
           : { name: a?.name, href: getOPDSNavLink(a?.links) },
       )
-      .filter((a): a is { name: string; href: string | undefined } => Boolean(a.name));
+      .filter((a): a is { name: string; href: string | undefined } => Boolean(a.name))
+      .map((a) => ({ ...a, name: formatContributorName(a.name) }));
   }, [publication.metadata?.author]);
 
   const authorNames = useMemo(() => authors.map((a) => a.name), [authors]);
@@ -212,7 +213,7 @@ export function PublicationView({
               <p className='text-base-content/70 text-sm'>
                 {authors.map((author, index) => (
                   <span key={index}>
-                    {index > 0 && ', '}
+                    {index > 0 && ' & '}
                     {author.href ? (
                       <button
                         type='button'
@@ -326,7 +327,7 @@ export function PublicationView({
                           link.href!,
                           count,
                           publication.metadata?.title || '',
-                          authorNames.join(', '),
+                          authorNames.join(' & '),
                         )
                       }
                       disabled={downloading || !!downloadedBook}

--- a/apps/readest-app/src/app/opds/utils/opdsUtils.ts
+++ b/apps/readest-app/src/app/opds/utils/opdsUtils.ts
@@ -144,6 +144,13 @@ export const getOPDSNavLink = (
   links?: Array<{ href?: string; type?: string }>,
 ): string | undefined => links?.find((link) => link.href && isOPDSCatalog(link.type ?? ''))?.href;
 
+/**
+ * Calibre stores commas in contributor names escaped as pipes (`Doe, John` →
+ * `Doe| John`), and Calibre-Web serves that raw form in its OPDS feeds
+ * (readest issue #5183). Restore the commas for display.
+ */
+export const formatContributorName = (name: string): string => name.replace(/\|/g, ',');
+
 export const isSearchLink = (link: OPDSBaseLink): boolean => {
   const rels = Array.isArray(link.rel) ? link.rel : [link.rel || ''];
   if (!rels.includes('search')) return false;


### PR DESCRIPTION
### What

Fixes #5183

OPDS catalogs backed by Calibre libraries (Calibre-Web, Calibre-Web-NextGen) showed author names like `Doe| John Walter, Smith| James Richard`, which is hard to parse when several authors each carry a family-name/given-names split.

### Why

The `|` comes from the server side: Calibre stores commas in author names escaped as pipes (`Doe, John` is stored as `Doe| John` in `authors.name`), and Calibre-Web's OPDS template emits `{{author.name}}` raw without the `replace('|', ',')` filter its HTML templates apply. Readest displayed the escaped form verbatim and joined multiple authors with `, `, compounding the ambiguity.

### How

- New `formatContributorName()` in `opdsUtils.ts` restores the escaped commas (`|` to `,`).
- `PublicationCard` (catalog view) and `PublicationView` (book view) normalize each author name and join multiple authors with `&`, following the Calibre convention suggested in the issue: `Doe, John Walter & Smith, James Richard`.
- Author links and the streamed-book author string pick up the normalized names as well.

### Tests

- Unit tests for `formatContributorName`.
- `PublicationView` test: normalized names, `&` separator, linked author stays clickable.
- `FeedView` card test: normalized names with `&` join (the react-virtuoso mock now also provides `VirtuosoGrid`, which the publications grid uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)