### PR TITLE
perf(test): reduce unit test runtime

### DIFF
--- a/apps/readest-app/extensions/send-to-readest/src/popup/popup.test.ts
+++ b/apps/readest-app/extensions/send-to-readest/src/popup/popup.test.ts
@@ -116,62 +116,42 @@ describe('popup — initial render', () => {
 });
 
 describe('popup — render(progress)', () => {
-  test('"capturing" disables Send and shows the reading label', async () => {
+  test('renders each progress phase', async () => {
     await loadPopup();
+
     pushProgress({ phase: 'capturing' });
     expect(document.getElementById('progress-label')?.textContent).toBe('Reading page…');
     expect((document.getElementById('send') as HTMLButtonElement).disabled).toBe(true);
     expect(document.getElementById('progress')?.classList.contains('show')).toBe(true);
-  });
 
-  test('"converting" shows the EPUB-build label', async () => {
-    await loadPopup();
     pushProgress({ phase: 'converting' });
     expect(document.getElementById('progress-label')?.textContent).toBe('Building EPUB…');
-  });
 
-  test('"uploading" shows the send-to-Readest label', async () => {
-    await loadPopup();
     pushProgress({ phase: 'uploading' });
     expect(document.getElementById('progress-label')?.textContent).toBe('Sending to Readest…');
-  });
 
-  test('"done" hides progress, re-enables Send, shows success status', async () => {
-    await loadPopup();
     pushProgress({ phase: 'done' });
     expect(document.getElementById('progress')?.classList.contains('show')).toBe(false);
     expect((document.getElementById('send') as HTMLButtonElement).disabled).toBe(false);
     const status = document.getElementById('status')!;
     expect(status.classList.contains('ok')).toBe(true);
     expect(status.textContent).toContain('Saved to your library');
-  });
 
-  test('"done" with missingAssets surfaces the image-fetch failure count', async () => {
-    await loadPopup();
     pushProgress({ phase: 'done', missingAssets: 3 });
     expect(document.getElementById('status')?.textContent).toContain(
       '3 images could not be fetched',
     );
-  });
 
-  test('"done" with a single missing asset uses singular grammar', async () => {
-    await loadPopup();
     pushProgress({ phase: 'done', missingAssets: 1 });
     expect(document.getElementById('status')?.textContent).toContain(
       '1 image could not be fetched',
     );
-  });
 
-  test('"error" surfaces the message and re-enables Send', async () => {
-    await loadPopup();
     pushProgress({ phase: 'error', code: 'server-error', message: 'Server returned 500' });
     expect((document.getElementById('send') as HTMLButtonElement).disabled).toBe(false);
     expect(document.getElementById('status')?.classList.contains('err')).toBe(true);
     expect(document.getElementById('status')?.textContent).toBe('Server returned 500');
-  });
 
-  test('"error" with session-expired flips to the signed-out view', async () => {
-    await loadPopup();
     pushProgress({ phase: 'error', code: 'session-expired', message: 'Session expired' });
     expect(document.getElementById('signed-in-view')?.classList.contains('hidden')).toBe(true);
     expect(document.getElementById('signed-out-view')?.classList.contains('hidden')).toBe(false);

--- a/apps/readest-app/src/__tests__/app/reader/annotator/DictionarySheet.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/annotator/DictionarySheet.test.tsx
@@ -9,7 +9,14 @@
  * abort assertions).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup, fireEvent, waitFor, act } from '@testing-library/react';
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor as waitForWithOptions,
+  act,
+} from '@testing-library/react';
 import type { ReactNode } from 'react';
 
 import type { DictionaryProvider, DictionaryLookupOutcome } from '@/services/dictionaries/types';
@@ -19,6 +26,9 @@ import type { BaseDir } from '@/types/system';
 import { createStarDictProvider } from '@/services/dictionaries/providers/starDictProvider';
 import { createDictProvider } from '@/services/dictionaries/providers/dictProvider';
 import { useCustomDictionaryStore } from '@/store/customDictionaryStore';
+
+const waitFor = <T,>(callback: () => T | Promise<T>) =>
+  waitForWithOptions(callback, { interval: 1 });
 
 import {
   IFO_FIXTURE_NAME,
@@ -274,7 +284,7 @@ describe('DictionarySheet — header', () => {
     providersForNextRender.push(buildRealStarDictProvider());
     renderSheet({ word: 'hello', onManage: vi.fn() });
 
-    expect((await screen.findByTestId('dict-title')).textContent).toBe('hello');
+    expect((await waitFor(() => screen.getByTestId('dict-title'))).textContent).toBe('hello');
     expect(screen.getByLabelText('Manage Dictionaries')).toBeTruthy();
     expect(screen.queryByLabelText('Back')).toBeNull();
   });
@@ -285,7 +295,7 @@ describe('DictionarySheet — speak button', () => {
     providersForNextRender.push(buildRealStarDictProvider());
     renderSheet({ word: 'hello', lang: 'en' });
 
-    const speak = await screen.findByLabelText('Speak');
+    const speak = await waitFor(() => screen.getByLabelText('Speak'));
     fireEvent.click(speak);
 
     expect(warmWordAudio).toHaveBeenCalledTimes(1);
@@ -318,7 +328,7 @@ describe('DictionarySheet — concurrent lookup', () => {
     providersForNextRender.push(buildRealStarDictProvider());
     renderSheet({ word: 'hello' });
 
-    await screen.findByText('CMU American English spelling');
+    await waitFor(() => screen.getByText('CMU American English spelling'));
   });
 
   it('hides cards from providers that return empty', async () => {
@@ -330,7 +340,7 @@ describe('DictionarySheet — concurrent lookup', () => {
     renderSheet({ word: 'hello' });
 
     // The cmudict card eventually appears.
-    await screen.findByText('CMU American English spelling');
+    await waitFor(() => screen.getByText('CMU American English spelling'));
     // The two empty providers never render a card.
     expect(screen.queryByText('Empty One')).toBeNull();
     expect(screen.queryByText('Empty Two')).toBeNull();
@@ -344,7 +354,7 @@ describe('DictionarySheet — query normalization', () => {
     providersForNextRender.push(exact);
     renderSheet({ word: 'Hello' });
 
-    await screen.findByText('Exact Match');
+    await waitFor(() => screen.getByText('Exact Match'));
     // First probe is the selection as-is; the lowercase fallback hits.
     expect(spy).toHaveBeenCalledWith('Hello', expect.any(Object));
     expect(spy).toHaveBeenCalledWith('hello', expect.any(Object));
@@ -354,14 +364,14 @@ describe('DictionarySheet — query normalization', () => {
     providersForNextRender.push(buildExactProvider('world'));
     renderSheet({ word: 'world ' });
 
-    await screen.findByText('Exact Match');
+    await waitFor(() => screen.getByText('Exact Match'));
   });
 
   it('trims trailing whitespace from the displayed title', async () => {
     providersForNextRender.push(buildExactProvider('world'));
     renderSheet({ word: 'world ' });
 
-    expect((await screen.findByTestId('dict-title')).textContent).toBe('world');
+    expect((await waitFor(() => screen.getByTestId('dict-title'))).textContent).toBe('world');
   });
 
   it('stops at the first matching variant without probing the rest', async () => {
@@ -370,7 +380,7 @@ describe('DictionarySheet — query normalization', () => {
     providersForNextRender.push(exact);
     renderSheet({ word: 'hello' });
 
-    await screen.findByText('Exact Match');
+    await waitFor(() => screen.getByText('Exact Match'));
     // 'hello' hits immediately — no title-case / upper-case probes follow.
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -382,7 +392,7 @@ describe('DictionarySheet — expand / collapse', () => {
     renderSheet({ word: 'hello' });
 
     // Wait for the lookup to finish (source label visible).
-    await screen.findByText('CMU American English spelling');
+    await waitFor(() => screen.getByText('CMU American English spelling'));
     const card = screen.getByTestId('dict-card');
     // With ≤ 3 results the sheet defaults to expanded.
     await waitFor(() => expect(card.getAttribute('aria-expanded')).toBe('true'));
@@ -411,7 +421,7 @@ describe('DictionarySheet — expand / collapse', () => {
     providersForNextRender.push(...providers);
     renderSheet({ word: 'hello' });
 
-    await screen.findByText('Pseudo 0');
+    await waitFor(() => screen.getByText('Pseudo 0'));
     const cards = screen.getAllByTestId('dict-card');
     expect(cards).toHaveLength(4);
     for (const card of cards) {
@@ -425,10 +435,10 @@ describe('DictionarySheet — in-content navigation', () => {
     providersForNextRender.push(buildNavProvider('world'));
     renderSheet({ word: 'hello' });
 
-    expect((await screen.findByTestId('dict-title')).textContent).toBe('hello');
+    expect((await waitFor(() => screen.getByTestId('dict-title'))).textContent).toBe('hello');
     expect(screen.queryByLabelText('Back')).toBeNull();
 
-    const navLink = await screen.findByTestId('nav-link');
+    const navLink = await waitFor(() => screen.getByTestId('nav-link'));
     await act(async () => {
       fireEvent.click(navLink);
     });
@@ -443,7 +453,7 @@ describe('DictionarySheet — in-content navigation', () => {
     providersForNextRender.push(buildNavProvider('world'));
     renderSheet({ word: 'hello' });
 
-    const navLink = await screen.findByTestId('nav-link');
+    const navLink = await waitFor(() => screen.getByTestId('nav-link'));
     await act(async () => {
       fireEvent.click(navLink);
     });
@@ -483,7 +493,9 @@ describe('DictionarySheet — web search row', () => {
     // The test setup mocks `isTauriAppPlatform: () => false`, so we
     // exercise the web-build path: anchor with href + target="_blank",
     // openUrl untouched.
-    const link = (await screen.findByRole('link', { name: /Google/i })) as HTMLAnchorElement;
+    const link = (await waitFor(() =>
+      screen.getByRole('link', { name: /Google/i }),
+    )) as HTMLAnchorElement;
     expect(link.getAttribute('target')).toBe('_blank');
     expect(link.getAttribute('rel')).toContain('noopener');
     const url = link.getAttribute('href') ?? '';
@@ -515,7 +527,7 @@ describe('DictionarySheet — section order', () => {
     providersForNextRender.push(buildWebEntry(), buildRealStarDictProvider());
     const { container } = renderSheet({ word: 'hello' });
 
-    await screen.findByText('CMU American English spelling');
+    await waitFor(() => screen.getByText('CMU American English spelling'));
     expect(sectionHeadings(container)).toEqual(['Search the web', 'Dictionaries']);
   });
 
@@ -523,7 +535,7 @@ describe('DictionarySheet — section order', () => {
     providersForNextRender.push(buildRealStarDictProvider(), buildWebEntry());
     const { container } = renderSheet({ word: 'hello' });
 
-    await screen.findByText('CMU American English spelling');
+    await waitFor(() => screen.getByText('CMU American English spelling'));
     expect(sectionHeadings(container)).toEqual(['Dictionaries', 'Search the web']);
   });
 });
@@ -534,7 +546,7 @@ describe('DictionarySheet — empty state', () => {
     const onManage = vi.fn();
     renderSheet({ word: 'hello', onManage });
 
-    expect(await screen.findByText('No dictionaries enabled')).toBeTruthy();
+    expect(await waitFor(() => screen.getByText('No dictionaries enabled'))).toBeTruthy();
     const gear = screen.getByLabelText('Manage Dictionaries');
     fireEvent.click(gear);
     expect(onManage).toHaveBeenCalledTimes(1);

--- a/apps/readest-app/src/__tests__/components/ProofreadRules.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ProofreadRules.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, within, act } from '@testing-library/react';
 import React from 'react';
 import { vi } from 'vitest';
 
@@ -153,7 +153,7 @@ describe('ProofreadRulesManager', () => {
     // wait a tick so the component's effect attaches the event listener
     await Promise.resolve();
     // open via helper which dispatches the custom event
-    setProofreadRulesVisibility(true);
+    await act(async () => setProofreadRulesVisibility(true));
 
     // Assert
     const dialog = await screen.findByRole('dialog');
@@ -232,7 +232,7 @@ describe('ProofreadRulesManager', () => {
     // Act: render and open dialog
     renderWithProviders(<ProofreadRulesManager />);
     await Promise.resolve();
-    setProofreadRulesVisibility(true);
+    await act(async () => setProofreadRulesVisibility(true));
 
     // Assert
     const dialog = await screen.findByRole('dialog');
@@ -298,7 +298,7 @@ describe('ProofreadRulesManager', () => {
 
     renderWithProviders(<ProofreadRulesManager />);
     await Promise.resolve();
-    setProofreadRulesVisibility(true);
+    await act(async () => setProofreadRulesVisibility(true));
 
     await screen.findByRole('dialog');
     expect(screen.getByText('visible-pattern')).toBeTruthy();
@@ -341,7 +341,7 @@ describe('ProofreadRulesManager', () => {
 
     renderWithProviders(<ProofreadRulesManager />);
     await Promise.resolve();
-    setProofreadRulesVisibility(true);
+    await act(async () => setProofreadRulesVisibility(true));
 
     await screen.findByRole('dialog');
     expect(screen.getByText('disabled-pattern')).toBeTruthy();
@@ -390,7 +390,7 @@ describe('ProofreadRulesManager', () => {
 
     renderWithProviders(<ProofreadRulesManager />);
     await Promise.resolve();
-    setProofreadRulesVisibility(true);
+    await act(async () => setProofreadRulesVisibility(true));
     await screen.findByRole('dialog');
 
     const row = screen.getByText('toggle-me').closest('li');
@@ -444,7 +444,7 @@ describe('ProofreadRulesManager', () => {
 
     renderWithProviders(<ProofreadRulesManager />);
     await Promise.resolve();
-    setProofreadRulesVisibility(true);
+    await act(async () => setProofreadRulesVisibility(true));
     await screen.findByRole('dialog');
 
     const row = screen.getByText('old-find').closest('li');
@@ -503,7 +503,7 @@ describe('ProofreadRulesManager', () => {
 
     renderWithProviders(<ProofreadRulesManager />);
     await Promise.resolve();
-    setProofreadRulesVisibility(true);
+    await act(async () => setProofreadRulesVisibility(true));
     await screen.findByRole('dialog');
 
     const row = screen.getByText('sel-text').closest('li');
@@ -554,7 +554,7 @@ describe('ProofreadRulesManager', () => {
 
     renderWithProviders(<ProofreadRulesManager />);
     await Promise.resolve();
-    setProofreadRulesVisibility(true);
+    await act(async () => setProofreadRulesVisibility(true));
     await screen.findByRole('dialog');
 
     const row = screen.getByText('valid').closest('li');
@@ -618,7 +618,7 @@ describe('ProofreadRulesManager', () => {
 
     renderWithProviders(<ProofreadRulesManager />);
     await Promise.resolve();
-    setProofreadRulesVisibility(true);
+    await act(async () => setProofreadRulesVisibility(true));
     await screen.findByRole('dialog');
 
     const handles = screen.getAllByLabelText('Drag to reorder');
@@ -704,7 +704,7 @@ describe('ProofreadRulesManager', () => {
 
     renderWithProviders(<ProofreadRulesManager />);
     await Promise.resolve();
-    setProofreadRulesVisibility(true);
+    await act(async () => setProofreadRulesVisibility(true));
 
     const dialog = await screen.findByRole('dialog');
     expect(dialog).toBeTruthy();
@@ -782,7 +782,7 @@ describe('ProofreadRulesManager', () => {
 
     renderWithProviders(<ProofreadRulesManager />);
     await Promise.resolve();
-    setProofreadRulesVisibility(true);
+    await act(async () => setProofreadRulesVisibility(true));
 
     const dialog = await screen.findByRole('dialog');
     expect(dialog).toBeTruthy();
@@ -854,7 +854,7 @@ describe('ProofreadRulesManager', () => {
 
     renderWithProviders(<ProofreadRulesManager />);
     await Promise.resolve();
-    setProofreadRulesVisibility(true);
+    await act(async () => setProofreadRulesVisibility(true));
 
     const dialog = await screen.findByRole('dialog');
     expect(dialog).toBeTruthy();
@@ -886,7 +886,7 @@ describe('ProofreadRulesManager', () => {
 
       renderWithProviders(<ProofreadRulesManager />);
       await Promise.resolve();
-      setProofreadRulesVisibility(true);
+      await act(async () => setProofreadRulesVisibility(true));
       await screen.findByRole('dialog');
 
       return { addRuleSpy, recreateSpy };
@@ -1039,7 +1039,7 @@ describe('ProofreadRulesManager', () => {
 
     renderWithProviders(<ProofreadRulesManager />);
     await Promise.resolve();
-    setProofreadRulesVisibility(true);
+    await act(async () => setProofreadRulesVisibility(true));
 
     const dialog = await screen.findByRole('dialog');
     expect(dialog).toBeTruthy();

--- a/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor as waitForWithOptions,
+} from '@testing-library/react';
 
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => (key: string, opts?: Record<string, unknown>) =>
@@ -83,6 +89,9 @@ vi.mock('@/app/reader/components/tts/TTSChaptersView', () => ({
 
 import TTSPlayerSheet from '@/app/reader/components/tts/TTSPlayerSheet';
 
+const waitFor = <T,>(callback: () => T | Promise<T>) =>
+  waitForWithOptions(callback, { interval: 1 });
+
 const voiceGroups = [
   {
     id: 'edge',
@@ -164,7 +173,7 @@ describe('TTSPlayerSheet', () => {
     // Compact one-row controls: speed / voice / sleep timer buttons.
     expect(screen.getByLabelText('Speed')).toBeTruthy();
     expect(screen.getByLabelText('Sleep Timer')).toBeTruthy();
-    expect(await screen.findByText('Ava')).toBeTruthy(); // voice button caption
+    expect(await waitFor(() => screen.getByText('Ava'))).toBeTruthy(); // voice button caption
     // The main view carries no header label (vertical space).
     expect(screen.queryByText('Read Aloud')).toBeNull();
   });
@@ -282,7 +291,7 @@ describe('TTSPlayerSheet', () => {
     const props = makeProps();
     render(<TTSPlayerSheet {...props} />);
     fireEvent.click(screen.getByLabelText('Voice'));
-    fireEvent.click(await screen.findByText('Guy'));
+    fireEvent.click(await waitFor(() => screen.getByText('Guy')));
     expect(props.onSetVoice).toHaveBeenCalledWith('guy', 'en-US');
     expect(viewSettings['ttsVoice']).toBe('guy');
   });
@@ -292,7 +301,7 @@ describe('TTSPlayerSheet', () => {
     render(<TTSPlayerSheet {...props} />);
     fireEvent.click(screen.getByLabelText('Sleep Timer'));
     // The translation mock interpolates, so options render as real labels.
-    fireEvent.click(await screen.findByText('30 minutes'));
+    fireEvent.click(screen.getByText('30 minutes'));
     expect(props.onSelectTimeout).toHaveBeenCalledWith('b1', 1800);
   });
 
@@ -350,7 +359,7 @@ describe('TTSPlayerSheet', () => {
     const props = makeProps();
     const { rerender } = render(<TTSPlayerSheet {...props} />);
     fireEvent.click(screen.getByLabelText('Voice'));
-    expect(await screen.findByText('Guy')).toBeTruthy();
+    expect(await waitFor(() => screen.getByText('Guy'))).toBeTruthy();
     rerender(<TTSPlayerSheet {...props} isOpen={false} />);
     rerender(<TTSPlayerSheet {...props} isOpen={true} />);
     expect(screen.getByLabelText('Previous Paragraph')).toBeTruthy();

--- a/apps/readest-app/src/__tests__/hooks/useFileSync.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useFileSync.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { act, cleanup, renderHook, waitFor as waitForWithOptions } from '@testing-library/react';
 import type { Book, BookConfig, BookNote } from '@/types/book';
 import type { SystemSettings } from '@/types/settings';
 import type { FileSyncBackendKind } from '@/services/sync/file/providerRegistry';
 import { FileSyncError } from '@/services/sync/file/provider';
 import { eventDispatcher } from '@/utils/event';
+
+const waitFor = <T>(callback: () => T | Promise<T>) =>
+  waitForWithOptions(callback, { interval: 1 });
 
 /**
  * Issue #5062 — cloud sync providers are independently selectable, so a book

--- a/apps/readest-app/src/__tests__/hooks/useSpatialNavigation.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useSpatialNavigation.test.tsx
@@ -58,14 +58,18 @@ function simulateKeyboardActivation() {
 }
 
 async function waitForAutoFocus() {
-  await act(() => new Promise((r) => setTimeout(r, 150)));
+  await act(() => vi.advanceTimersByTimeAsync(150));
 }
 
 describe('useToolbarKeyNavigation', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     _resetLastKeyboardTime();
   });
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
 
   describe('auto-focus', () => {
     it('focuses first enabled button when keyboard-activated', async () => {

--- a/apps/readest-app/src/__tests__/paragraph-mode.test.tsx
+++ b/apps/readest-app/src/__tests__/paragraph-mode.test.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor as waitForWithOptions,
+} from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ParagraphOverlay from '@/app/reader/components/paragraph/ParagraphOverlay';
@@ -22,6 +28,20 @@ const currentViewSettings = {
 const mockGetViewSettings = vi.fn(() => currentViewSettings);
 const mockSetViewSettings = vi.fn();
 const mockGetProgress = vi.fn(() => null);
+const realSetTimeout = globalThis.setTimeout;
+const waitFor = <T,>(callback: () => T | Promise<T>) =>
+  waitForWithOptions(callback, { interval: 1 });
+
+beforeEach(() => {
+  // Preserve Testing Library's 1s failure timeout while collapsing app animation/debounce waits.
+  vi.spyOn(globalThis, 'setTimeout').mockImplementation((handler, timeout) =>
+    realSetTimeout(handler, typeof timeout === 'number' && timeout < 500 ? 0 : timeout),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 let mockIsFixedLayout = false;
 
@@ -343,6 +363,8 @@ describe('paragraph mode', () => {
       y: 0,
       toJSON: () => ({}),
     } as DOMRect);
+    let clickTime = 1_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => clickTime);
 
     fireEvent.click(contentArea, { clientX: 150, clientY: 20 });
     await waitFor(() => {
@@ -363,9 +385,7 @@ describe('paragraph mode', () => {
     });
     dispatchSpy.mockClear();
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 320));
-    });
+    clickTime += 320;
 
     fireEvent.click(contentArea, { clientX: 40, clientY: 150 });
     await waitFor(() => {

--- a/apps/readest-app/src/__tests__/reedy/ReedyDb.test.ts
+++ b/apps/readest-app/src/__tests__/reedy/ReedyDb.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { NodeDatabaseService } from '@/services/database/nodeDatabaseService';
 import { DatabaseService } from '@/types/database';
 import { migrate } from '@/services/database/migrate';
@@ -31,13 +31,19 @@ describe('ReedyDb', () => {
   let svc: DatabaseService;
   let reedy: ReedyDb;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     svc = await NodeDatabaseService.open(':memory:', { experimental: ['index_method'] });
     await migrate(svc, getMigrations('reedy'));
     reedy = new ReedyDb(svc);
   });
 
-  afterEach(async () => {
+  beforeEach(async () => {
+    await svc.execute('DROP TABLE IF EXISTS reedy_book_chunk_embeddings');
+    await svc.execute('DELETE FROM reedy_book_chunks');
+    await svc.execute('DELETE FROM reedy_book_meta');
+  });
+
+  afterAll(async () => {
     await svc.close();
   });
 

--- a/apps/readest-app/src/__tests__/services/edge-tts-client-playback.test.ts
+++ b/apps/readest-app/src/__tests__/services/edge-tts-client-playback.test.ts
@@ -110,6 +110,7 @@ describe('EdgeTTSClient Web Audio playback', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -350,7 +351,9 @@ describe('EdgeTTSClient Web Audio playback', () => {
       throw new Error('network exploded');
     };
     const client = await startClient();
+    vi.useFakeTimers();
     const { events, done } = collectSpeak(client, new AbortController().signal);
+    await vi.runAllTimersAsync();
     await done;
     expect(events.at(-1)).toMatchObject({ code: 'error', message: 'network exploded' });
   }, 10000);

--- a/apps/readest-app/src/__tests__/services/edge-tts-client.test.ts
+++ b/apps/readest-app/src/__tests__/services/edge-tts-client.test.ts
@@ -86,6 +86,7 @@ describe('EdgeTTSClient', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -464,7 +465,10 @@ describe('EdgeTTSClient', () => {
       parsedMarks = [{ name: 'mark-0', text: 'hello', language: 'en' }];
       createAudioDataBehavior = vi.fn(() => Promise.reject(new Error('network error')));
 
-      await consumePreload(client, new AbortController().signal);
+      vi.useFakeTimers();
+      const preload = consumePreload(client, new AbortController().signal);
+      await vi.runAllTimersAsync();
+      await preload;
 
       expect(createAudioDataBehavior).toHaveBeenCalledTimes(3);
     });
@@ -489,7 +493,10 @@ describe('EdgeTTSClient', () => {
           : Promise.resolve({ data: new ArrayBuffer(8), boundaries: [] });
       });
 
-      await consumePreload(client, new AbortController().signal);
+      vi.useFakeTimers();
+      const preload = consumePreload(client, new AbortController().signal);
+      await vi.runAllTimersAsync();
+      await preload;
 
       expect(createAudioDataBehavior).toHaveBeenCalledTimes(2);
     });

--- a/apps/readest-app/src/__tests__/services/hardcover/HardcoverClient.test.ts
+++ b/apps/readest-app/src/__tests__/services/hardcover/HardcoverClient.test.ts
@@ -26,6 +26,7 @@ type TestBookContext = {
 
 type HardcoverClientTestApi = {
   token: string;
+  minRequestIntervalMs: number;
   extractISBN: (book: Book) => string | null;
   request: <TVariables, TData>(query: string, variables: TVariables) => Promise<TData>;
   fetchBookContext: (book: Book) => Promise<TestBookContext | null>;
@@ -70,6 +71,8 @@ describe('HardcoverClient', () => {
 
     client = new HardcoverClient(mockSettings, mockMapStore);
     clientApi = client as unknown as HardcoverClientTestApi;
+    // Mocked API responses do not need the production request-rate throttle.
+    clientApi.minRequestIntervalMs = 0;
   });
 
   test('should normalize accessToken correctly', () => {

--- a/apps/readest-app/src/__tests__/services/tts-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller.test.ts
@@ -1275,9 +1275,8 @@ describe('TTSController', () => {
       // transiently re-enters 'stopped' between chunks.)
       await vi.waitFor(() => expect(state.attempts).toBeGreaterThanOrEqual(5), { timeout: 8000 });
 
-      // Let the cap-stop settle, then confirm it terminated (bounded, not
-      // racing to the end of the book) and is no longer playing.
-      await new Promise((r) => setTimeout(r, 150));
+      // Confirm the cap-stop settled (bounded, not racing to the end of the book).
+      await vi.waitFor(() => expect(c.state).not.toBe('playing'));
       expect(c.state).not.toBe('playing');
       expect(state.attempts).toBeLessThanOrEqual(10);
     });


### PR DESCRIPTION
## Summary

- replace real timer waits and retry backoffs with deterministic fake timers or state-based polling
- skip the mocked Hardcover API throttle and reuse the migrated in-memory Reedy database
- reduce Testing Library polling intervals and repeated popup module initialization

## Benchmark

- aggregate test execution: 53.77s -> 40.27s (25.1% faster)
- original hotspot subset: 13.99s -> 6.49s (53.6% faster)
- second targeted group: 8.18s -> 3.29s (59.8% faster)

Wall-clock totals varied with other test runs on the same machine, so the comparisons above use matched focused runs and Vitest's aggregate test durations.

## Verification

- `pnpm -w format:check`
- `pnpm lint`
- `pnpm test`: 580 passed, 3 skipped test files; 7,633 passed, 9 skipped tests
