### PR TITLE
fix(opds): keep re-added catalogs from vanishing after app restart

### DIFF
--- a/apps/readest-app/src/__tests__/store/custom-opds-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/custom-opds-store.test.ts
@@ -76,6 +76,45 @@ describe('customOPDSStore', () => {
       expect(revived.reincarnation).toBeTruthy();
       expect(publishReplicaUpsert).toHaveBeenCalledTimes(1);
     });
+
+    test('re-adding after a restart (local tombstone stripped) still revives the server row', async () => {
+      // Reporter scenario (#5180): the catalog carries a server-side
+      // tombstone (from a prior delete on this or another device). After
+      // an app restart the local tombstone is gone — saveCustomOPDSCatalogs
+      // strips deletedAt entries from persisted settings — so addCatalog
+      // sees no in-memory entry and, before this fix, never minted a
+      // reincarnation token. Under CRDT remove-wins the re-added catalog
+      // then loses to the tombstone and vanishes on the next pull. The
+      // re-add must reincarnate even though no local tombstone survives.
+      const env = makeEnvConfig();
+      const first = useCustomOPDSStore.getState().addCatalog({
+        id: 'l1',
+        name: 'L1',
+        url: 'https://example.com/opds',
+      });
+      useCustomOPDSStore.getState().removeCatalog(first.id);
+      await useCustomOPDSStore.getState().saveCustomOPDSCatalogs(env);
+      // The tombstone did not survive persistence...
+      expect(useSettingsStore.getState().settings.opdsCatalogs).toHaveLength(0);
+
+      // ...so a restart hydrates an empty store.
+      useCustomOPDSStore.setState({ catalogs: [], loading: false });
+      await useCustomOPDSStore.getState().loadCustomOPDSCatalogs(env);
+      expect(useCustomOPDSStore.getState().catalogs).toHaveLength(0);
+
+      vi.clearAllMocks();
+      const revived = useCustomOPDSStore.getState().addCatalog({
+        id: 'l2',
+        name: 'L1 again',
+        url: 'https://example.com/opds',
+      });
+      expect(revived.deletedAt).toBeUndefined();
+      expect(revived.reincarnation).toBeTruthy();
+      // The published upsert must carry the reincarnation token so the
+      // server-side tombstone is revived rather than winning again.
+      const call = (publishReplicaUpsert as unknown as ReturnType<typeof vi.fn>).mock.calls[0]!;
+      expect(call[3]).toBeTruthy();
+    });
   });
 
   describe('updateCatalog', () => {

--- a/apps/readest-app/src/store/customOPDSStore.ts
+++ b/apps/readest-app/src/store/customOPDSStore.ts
@@ -59,8 +59,9 @@ interface OPDSStoreState {
 
   /**
    * Add (or revive) a catalog. Computes `contentId` from URL if absent.
-   * Re-import of a previously soft-deleted entry mints a reincarnation
-   * token so the server-side tombstone is replaced with a fresh row.
+   * Always attaches a reincarnation token (minted when absent, existing
+   * one preserved) so the upsert replaces any server-side tombstone with
+   * a fresh row instead of losing to it under remove-wins.
    */
   addCatalog(catalog: Omit<OPDSCatalog, 'contentId'> & { contentId?: string }): OPDSCatalog;
   /**
@@ -108,13 +109,19 @@ export const useCustomOPDSStore = create<OPDSStoreState>((set, get) => ({
 
   addCatalog: (input) => {
     const contentId = input.contentId ?? computeOpdsCatalogContentId(input.url);
-    // Revive tombstoned entry under a reincarnation token so the
-    // server-side tombstone gets replaced rather than stuck.
     const existing = get().catalogs.find((c) => c.contentId === contentId);
+    // Under CRDT remove-wins a plain upsert can't revive a server-side
+    // tombstone, so a re-added catalog silently vanishes on the next
+    // pull (issue #5180, same class as fonts/textures #4410). We can't
+    // see the server's tombstone from here, and — unlike fonts/textures —
+    // saveCustomOPDSCatalogs strips local tombstones at persistence, so
+    // after an app restart `existing` is usually absent even when the
+    // server row is dead. Always carry a reincarnation token on add so
+    // the upsert beats any server tombstone; the token is inert when the
+    // row is alive. Preserve an existing token to avoid churning a new
+    // one on every add.
     const reincarnation =
-      existing?.deletedAt && !input.reincarnation
-        ? Math.random().toString(36).slice(2)
-        : input.reincarnation;
+      input.reincarnation ?? existing?.reincarnation ?? Math.random().toString(36).slice(2);
     const catalog: OPDSCatalog = {
       ...input,
       contentId,


### PR DESCRIPTION
## Problem

Fixes #5180. OPDS catalogs "keep getting deleted" after closing the app: a user adds an OPDS server, closes the app, and on the next launch the catalog is gone. Reproduces on both iOS and macOS (both signed into cloud sync) and recurs on every launch. Contributors couldn't reproduce it because it only happens once a server-side tombstone exists for the catalog's row.

## Root cause

The OPDS catalog list syncs as `opds_catalog` **replica rows** under a **CRDT remove-wins** policy. Once a row is tombstoned server-side (a delete on any device, a cross-device delete, or the forget-passphrase credential wipe), every app launch's boot pull mirrors that tombstone locally (`replicaPullAndApply` -> `softDeleteByContentId`) and the catalog disappears.

Re-adding the catalog should revive it via a `reincarnation` token, but `customOPDSStore.addCatalog` only minted one when it found a still-in-memory soft-deleted entry (`existing?.deletedAt`). And `saveCustomOPDSCatalogs` strips tombstones at persistence (`filter(c => !c.deletedAt)`) - unlike fonts/textures, which keep them. So after an app restart there is no local tombstone, `addCatalog` sees no `existing`, mints no token, the upsert loses to the server tombstone under remove-wins, and the next pull deletes the catalog again -> it keeps disappearing on every launch.

This is the same class of bug as the custom fonts/textures reincarnation fix (#4410); OPDS had the remaining hole because of its tombstone-stripping persistence.

## Fix

Always carry a reincarnation token in `addCatalog` (mint when absent, preserve an existing one):

```ts
const reincarnation =
  input.reincarnation ?? existing?.reincarnation ?? Math.random().toString(36).slice(2);
```

The token is inert when the row is alive, so first-ever adds are unaffected; an existing token is preserved to avoid churn. This revives any hidden server tombstone on the very next add, so an affected user only has to re-add their catalog once.

I deliberately left the persistence strip alone (avoids accumulating dead rows in settings; the always-mint makes the strip irrelevant to correctness).

## Testing

- Added `custom-opds-store.test.ts` -> "re-adding after a restart (local tombstone stripped) still revives the server row", which fails without the fix (`reincarnation` is `undefined`) and passes with it.
- `pnpm test` full suite green (the flaky, unrelated `paginator-stabilization` font-timeout and `DictionarySheet` concurrent-lookup tests pass in isolation).
- `pnpm lint` (tsgo + biome) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
