### PR TITLE
test: remove redundant cases and silence passing logs

### DIFF
--- a/apps/readest-app/src/__tests__/services/app-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/app-service.test.ts
@@ -418,10 +418,6 @@ describe('BaseAppService', () => {
       const result = await service.loadLibraryBooks();
       expect(result).toEqual([{ title: 'Book1' }]);
     });
-
-    test('saveLibraryBooks delegates', async () => {
-      await service.saveLibraryBooks([]);
-    });
   });
 
   describe('runMigrations', () => {

--- a/apps/readest-app/src/__tests__/services/edge-tts-client.test.ts
+++ b/apps/readest-app/src/__tests__/services/edge-tts-client.test.ts
@@ -203,30 +203,6 @@ describe('EdgeTTSClient', () => {
     });
   });
 
-  describe('setRate', () => {
-    test('stores rate value', async () => {
-      await client.setRate(1.5);
-      // Rate is private, so we verify indirectly - no error thrown
-      await expect(client.setRate(0.5)).resolves.toBeUndefined();
-    });
-
-    test('accepts boundary values', async () => {
-      await expect(client.setRate(0.5)).resolves.toBeUndefined();
-      await expect(client.setRate(2.0)).resolves.toBeUndefined();
-    });
-  });
-
-  describe('setPitch', () => {
-    test('stores pitch value', async () => {
-      await expect(client.setPitch(1.2)).resolves.toBeUndefined();
-    });
-
-    test('accepts boundary values', async () => {
-      await expect(client.setPitch(0.5)).resolves.toBeUndefined();
-      await expect(client.setPitch(1.5)).resolves.toBeUndefined();
-    });
-  });
-
   describe('setVoice', () => {
     test('sets voice when voice id exists in voice list', async () => {
       await client.init();
@@ -239,25 +215,6 @@ describe('EdgeTTSClient', () => {
       await client.setVoice('en-US-AriaNeural');
       await client.setVoice('nonexistent-voice');
       expect(client.getVoiceId()).toBe('en-US-AriaNeural');
-    });
-
-    test('voice id remains empty when no voice has been set', () => {
-      expect(client.getVoiceId()).toBe('');
-    });
-  });
-
-  describe('setPrimaryLang', () => {
-    test('sets primary language', () => {
-      client.setPrimaryLang('fr');
-      // No public getter for primaryLang, but we verify no error
-      // The effect is observed when speak() uses it
-    });
-
-    test('accepts any language string', () => {
-      client.setPrimaryLang('zh-CN');
-      client.setPrimaryLang('ja');
-      client.setPrimaryLang('en');
-      // No error thrown
     });
   });
 

--- a/apps/readest-app/src/__tests__/services/sync/replicaPublish.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/replicaPublish.test.ts
@@ -82,6 +82,7 @@ describe('publishReplicaUpsert (dictionary adapter)', () => {
     (getReplicaSync as ReturnType<typeof vi.fn>).mockReturnValue(null);
     (getUserID as ReturnType<typeof vi.fn>).mockResolvedValue('user-1');
     await upsertDict(baseDict());
+    expect(getUserID).not.toHaveBeenCalled();
   });
 
   test('no-ops when no adapter registered for the kind', async () => {
@@ -167,6 +168,7 @@ describe('publishReplicaDelete', () => {
     (getReplicaSync as ReturnType<typeof vi.fn>).mockReturnValue(null);
     (getUserID as ReturnType<typeof vi.fn>).mockResolvedValue('user-1');
     await publishReplicaDelete('dictionary', 'content-hash-abc');
+    expect(getUserID).not.toHaveBeenCalled();
   });
 
   test('no-ops when user not authenticated', async () => {
@@ -204,6 +206,7 @@ describe('publishReplicaManifest', () => {
     (getReplicaSync as ReturnType<typeof vi.fn>).mockReturnValue(null);
     (getUserID as ReturnType<typeof vi.fn>).mockResolvedValue('user-1');
     await publishReplicaManifest('dictionary', 'content-hash-abc', []);
+    expect(getUserID).not.toHaveBeenCalled();
   });
 
   test('no-ops when user not authenticated', async () => {

--- a/apps/readest-app/src/__tests__/services/tts-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller.test.ts
@@ -526,12 +526,6 @@ describe('TTSController', () => {
       expect(controller.ttsClient.resume).toHaveBeenCalled();
     });
 
-    test('stop sets state to stopped', async () => {
-      controller.state = 'playing';
-      await controller.stop();
-      expect(controller.state).toBe('stopped');
-    });
-
     test('error sets state to stopped', () => {
       controller.state = 'playing';
       controller.error(new Error('test'));
@@ -1416,27 +1410,7 @@ describe('TTSController', () => {
     });
   });
 
-  describe('initViewTTS', () => {
-    test('does nothing when already initialised (section index != -1)', async () => {
-      // Manually set section index via a reflect access workaround
-      // Since #ttsSectionIndex is private, we test indirectly through initViewTTS
-      // being called multiple times - first call will init, second should skip
-      mockView.tts = {
-        doc: {},
-        start: vi.fn(),
-      } as unknown as FoliateView['tts'];
-
-      // Call once to set the section index
-      await controller.initViewTTS(0);
-      // Now we can verify it doesn't re-init by checking the section was already created
-    });
-  });
-
   describe('extends EventTarget', () => {
-    test('is an instance of EventTarget', () => {
-      expect(controller instanceof EventTarget).toBe(true);
-    });
-
     test('can add and dispatch custom events', () => {
       const handler = vi.fn();
       controller.addEventListener('test-event', handler);

--- a/apps/readest-app/src/__tests__/services/web-app-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/web-app-service.test.ts
@@ -192,8 +192,7 @@ describe('WebAppService', () => {
 
   describe('setCustomRootDir', () => {
     test('is a no-op', async () => {
-      // Should not throw
-      await service.setCustomRootDir();
+      await expect(service.setCustomRootDir()).resolves.toBeUndefined();
     });
   });
 

--- a/apps/readest-app/src/__tests__/utils/ssml.test.ts
+++ b/apps/readest-app/src/__tests__/utils/ssml.test.ts
@@ -45,11 +45,6 @@ describe('parseSSMLLang', () => {
     expect(parseSSMLLang(ssml, 'fr')).toBe('de');
   });
 
-  it('should default to en when no xml:lang and no primaryLang', () => {
-    const ssml = ssmlNoLang('<mark name="0"/>Hello');
-    expect(parseSSMLLang(ssml)).toBe('en');
-  });
-
   it('should infer CJK lang from script when lang is en', () => {
     const ssml = ssmlNoLang('<mark name="0"/>こんにちは');
     expect(parseSSMLLang(ssml)).toBe('ja');

--- a/apps/readest-app/src/__tests__/utils/walk.test.ts
+++ b/apps/readest-app/src/__tests__/utils/walk.test.ts
@@ -196,29 +196,4 @@ describe('walkTextNodes', () => {
     expect(result).toHaveLength(1);
     expect(result[0]!.textContent).toBe('Text');
   });
-
-  test.skip('walks into shadow DOM (requires real shadow DOM support)', () => {
-    // jsdom has limited shadow DOM support; skipping for now
-    const host = document.createElement('div');
-    const shadow = host.attachShadow({ mode: 'open' });
-    shadow.appendChild(el('p', 'Shadow text'));
-    const root = el('div', host);
-    const result = walkTextNodes(root);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.textContent).toBe('Shadow text');
-  });
-
-  test.skip('walks into iframe contentDocument (not supported in jsdom)', () => {
-    // jsdom iframes do not have usable contentDocument; skipping
-    const iframe = document.createElement('iframe');
-    document.body.appendChild(iframe);
-    const iframeDoc = iframe.contentDocument;
-    if (iframeDoc) {
-      iframeDoc.body.appendChild(el('p', 'Iframe text'));
-    }
-    const root = el('div', iframe);
-    const result = walkTextNodes(root);
-    expect(result).toHaveLength(1);
-    document.body.removeChild(iframe);
-  });
 });

--- a/apps/readest-app/tailwind.config.ts
+++ b/apps/readest-app/tailwind.config.ts
@@ -37,6 +37,7 @@ const config: Config = {
     }),
   ],
   daisyui: {
+    logs: false,
     themes: themes.reduce(
       (acc, { name, colors }) => {
         acc.push({

--- a/apps/readest-app/vitest.config.mts
+++ b/apps/readest-app/vitest.config.mts
@@ -22,6 +22,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    silent: 'passed-only',
     setupFiles: ['./vitest.setup.ts'],
     exclude: [
       '**/node_modules/**',

--- a/apps/readest-app/vitest.setup.ts
+++ b/apps/readest-app/vitest.setup.ts
@@ -53,3 +53,11 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
       dispatchEvent: () => false,
     }) as MediaQueryList;
 }
+
+// jsdom reports these unimplemented methods to its virtual console even when
+// the calling test passes. Tests that need media behavior replace them locally.
+if (typeof HTMLMediaElement !== 'undefined') {
+  HTMLMediaElement.prototype.play = () => Promise.resolve();
+  HTMLMediaElement.prototype.pause = () => {};
+  HTMLMediaElement.prototype.load = () => {};
+}


### PR DESCRIPTION
## Summary

- audit 7,532 explicit test declarations across 614 test files for assertion-free, duplicated, skipped, and weak-assertion cases
- remove 12 vacuous or redundant passing cases and 2 permanently skipped jsdom placeholders
- strengthen four retained no-op tests with explicit early-return assertions
- suppress console output from passing tests while preserving failure logs and the Vitest result summary
- disable the DaisyUI startup banner and stub jsdom's unimplemented media methods in test setup

## Removed cases

- setter tests that only asserted that a call returned
- one exact duplicate SSML assertion
- duplicate TTS stop-state and EventTarget type assertions already covered behaviorally
- an assertion-free `initViewTTS` placeholder and library-save delegation case
- two permanently skipped jsdom-only shadow DOM/iframe placeholders

## Verification

- `pnpm -w format:check`
- `pnpm lint`
- `pnpm test`: 580 passed, 3 skipped test files; 7,625 passed, 7 skipped tests
- successful test runs print no test stdout, DaisyUI banner, or jsdom media warnings
