### PR TITLE
feat: improve accuracy of time remaining calculation

### DIFF
--- a/apps/readest-app/src/__tests__/statistics/statisticsDb.test.ts
+++ b/apps/readest-app/src/__tests__/statistics/statisticsDb.test.ts
@@ -151,4 +151,49 @@ describe('StatisticsDb', () => {
     const rows = await stats.getEventsForPush(-1); // no events; just exercise no crash
     void rows;
   });
+
+  it('returns null until enough page data exists for a median', async () => {
+    const id = await stats.upsertBook({ bookMd5: 'm-few', title: 'T', authors: 'A' });
+    for (let i = 0; i < 4; i++) {
+      await stats.insertPageEvent(id, {
+        page: i,
+        startTime: 100 + i,
+        duration: 10,
+        totalPages: 50,
+      });
+    }
+    expect(await stats.getMedianPageDurationSecs(id)).toBeNull();
+  });
+
+  it('takes the median by duration value, not by recency (odd count)', async () => {
+    const id = await stats.upsertBook({ bookMd5: 'm-odd', title: 'T', authors: 'A' });
+    // Inserted in ascending start_time; durations are NOT sorted by value, so the
+    // median must sort by value before picking the middle (recency-middle is 50).
+    const byTime = [30, 10, 50, 20, 40];
+    for (let i = 0; i < byTime.length; i++) {
+      await stats.insertPageEvent(id, {
+        page: i,
+        startTime: 100 + i,
+        duration: byTime[i]!,
+        totalPages: 50,
+      });
+    }
+    // Sorted: [10, 20, 30, 40, 50] -> median 30.
+    expect(await stats.getMedianPageDurationSecs(id)).toBe(30);
+  });
+
+  it('averages the two middle durations (even count)', async () => {
+    const id = await stats.upsertBook({ bookMd5: 'm-even', title: 'T', authors: 'A' });
+    const byTime = [60, 10, 50, 20, 40, 30];
+    for (let i = 0; i < byTime.length; i++) {
+      await stats.insertPageEvent(id, {
+        page: i,
+        startTime: 100 + i,
+        duration: byTime[i]!,
+        totalPages: 50,
+      });
+    }
+    // Sorted: [10, 20, 30, 40, 50, 60] -> (30 + 40) / 2 = 35.
+    expect(await stats.getMedianPageDurationSecs(id)).toBe(35);
+  });
 });

--- a/apps/readest-app/src/app/library/components/ReadingProgress.tsx
+++ b/apps/readest-app/src/app/library/components/ReadingProgress.tsx
@@ -4,7 +4,8 @@ import type { Book } from '@/types/book';
 import { useTranslation } from '@/hooks/useTranslation';
 import { SHOW_UNREAD_STATUS_BADGE } from '@/services/constants';
 import StatusBadge from './StatusBadge';
-import { getDisplayedTimeRemaining, useMedianPageDurationSecs } from '../utils/libraryUtils';
+import { getDisplayedTimeRemaining } from '../utils/libraryUtils';
+import { useMedianPageDurationSecs } from '@/hooks/useMedianPageDurationSecs';
 
 interface ReadingProgressProps {
   book: Book;

--- a/apps/readest-app/src/app/library/components/ReadingProgress.tsx
+++ b/apps/readest-app/src/app/library/components/ReadingProgress.tsx
@@ -4,7 +4,7 @@ import type { Book } from '@/types/book';
 import { useTranslation } from '@/hooks/useTranslation';
 import { SHOW_UNREAD_STATUS_BADGE } from '@/services/constants';
 import StatusBadge from './StatusBadge';
-import { getDisplayedTimeRemaining } from '../utils/libraryUtils';
+import { getDisplayedTimeRemaining, useMedianPageDurationSecs } from '../utils/libraryUtils';
 
 interface ReadingProgressProps {
   book: Book;
@@ -26,8 +26,8 @@ const ReadingProgress: React.FC<ReadingProgressProps> = memo(
   ({ book, showTimeRemaining }) => {
     const _ = useTranslation();
     const progressPercentage = useMemo(() => getProgressPercentage(book), [book]);
-
-    const minutes = getDisplayedTimeRemaining(book);
+    const medianPageDurationSecs = useMedianPageDurationSecs(book.hash) ?? undefined;
+    const minutes = getDisplayedTimeRemaining(book, medianPageDurationSecs);
     const formatTimeLeft = (total: number) => {
       if (total < 60) return _('{{minutes}}m left', { minutes: total });
       const hours = total / 60;

--- a/apps/readest-app/src/app/library/utils/libraryUtils.ts
+++ b/apps/readest-app/src/app/library/utils/libraryUtils.ts
@@ -237,9 +237,11 @@ export const convertPagesToTimeRemainingMinutes = (
   pagesLeft: number,
   medianPageDurationSecs?: number,
 ): number => {
-  return medianPageDurationSecs
+  const minutes = medianPageDurationSecs
     ? Math.round((pagesLeft * medianPageDurationSecs) / 60)
     : Math.round((pagesLeft * SIZE_PER_LOC) / SIZE_PER_TIME_UNIT); // Fall back to less precise calculation
+
+  return Math.max(1, minutes);
 };
 
 /**

--- a/apps/readest-app/src/app/library/utils/libraryUtils.ts
+++ b/apps/readest-app/src/app/library/utils/libraryUtils.ts
@@ -212,11 +212,11 @@ export const convertPagesToTimeRemainingMinutes = (
   pagesLeft: number,
   medianPageDurationSecs?: number,
 ): number => {
-  const minutes = medianPageDurationSecs
-    ? Math.round((pagesLeft * medianPageDurationSecs) / 60)
-    : Math.round((pagesLeft * SIZE_PER_LOC) / SIZE_PER_TIME_UNIT); // Fall back to less precise calculation
-
-  return Math.max(1, minutes);
+  // Prefer the reader's own pace; fall back to the coarse global estimate.
+  const minutesPerPage = medianPageDurationSecs
+    ? medianPageDurationSecs / 60
+    : SIZE_PER_LOC / SIZE_PER_TIME_UNIT;
+  return Math.max(1, Math.round(pagesLeft * minutesPerPage));
 };
 
 /**
@@ -240,11 +240,8 @@ export const getDisplayedTimeRemaining = (
  * Remaining minutes for a shelf item, or `undefined` when its tile can show no
  * time at all — that includes every group, since a group tile renders no progress.
  */
-const getShelfItemTimeRemaining = (
-  item: Book | BooksGroup,
-  medianPageDurationSecs?: number,
-): number | undefined =>
-  'books' in item ? undefined : getDisplayedTimeRemaining(item, medianPageDurationSecs);
+const getShelfItemTimeRemaining = (item: Book | BooksGroup): number | undefined =>
+  'books' in item ? undefined : getDisplayedTimeRemaining(item);
 
 /**
  * Wrap a comparator that has *already* had the sort direction applied, so items
@@ -253,28 +250,18 @@ const getShelfItemTimeRemaining = (
  * sort-order multiplier, otherwise descending would float those items to the top.
  */
 export const withTimeRemainingLast =
-  <T extends Book | BooksGroup>(
-    sortBy: LibrarySortByType,
-    compare: (a: T, b: T) => number,
-    medianPageDurationSecs?: number,
-  ) =>
+  <T extends Book | BooksGroup>(sortBy: LibrarySortByType, compare: (a: T, b: T) => number) =>
   (a: T, b: T): number => {
     if (sortBy !== LibrarySortByType.TimeRemaining) return compare(a, b);
-    const aTime = getShelfItemTimeRemaining(a, medianPageDurationSecs);
-    const bTime = getShelfItemTimeRemaining(b, medianPageDurationSecs);
+    const aTime = getShelfItemTimeRemaining(a);
+    const bTime = getShelfItemTimeRemaining(b);
     if (aTime === undefined && bTime === undefined) return 0;
     if (aTime === undefined) return 1;
     if (bTime === undefined) return -1;
     return compare(a, b);
   };
 
-const compareBookByKey = (
-  a: Book,
-  b: Book,
-  sortBy: string,
-  uiLanguage: string,
-  medianPageDurationSecs?: number,
-): number => {
+const compareBookByKey = (a: Book, b: Book, sortBy: string, uiLanguage: string): number => {
   switch (sortBy) {
     case LibrarySortByType.Title: {
       const aTitle = formatTitle(a.title);
@@ -327,8 +314,8 @@ const compareBookByKey = (
       return aDate - bDate;
     }
     case LibrarySortByType.TimeRemaining: {
-      const aTime = getDisplayedTimeRemaining(a, medianPageDurationSecs);
-      const bTime = getDisplayedTimeRemaining(b, medianPageDurationSecs);
+      const aTime = getDisplayedTimeRemaining(a);
+      const bTime = getDisplayedTimeRemaining(b);
       // Never subtract two Infinities here: NaN makes the comparator inconsistent
       // and Array.sort then scatters the no-time books through the shelf.
       if (aTime === undefined && bTime === undefined) return 0;

--- a/apps/readest-app/src/app/library/utils/libraryUtils.ts
+++ b/apps/readest-app/src/app/library/utils/libraryUtils.ts
@@ -1,4 +1,3 @@
-import { useEnv } from '@/context/EnvContext';
 import { Book, BooksGroup, ReadingStatus } from '@/types/book';
 import {
   LibraryGroupByType,
@@ -8,8 +7,6 @@ import {
 import { formatAuthors, formatTitle } from '@/utils/book';
 import { md5Fingerprint } from '@/utils/md5';
 import { SIZE_PER_LOC, SIZE_PER_TIME_UNIT } from '@/services/constants';
-import { useEffect, useState } from 'react';
-import { StatisticsDb } from '@/services/statistics/statisticsDb';
 
 /** Valid sort types for the library */
 const VALID_SORT_TYPES: LibrarySortByType[] = Object.values(LibrarySortByType);
@@ -200,28 +197,6 @@ const getBookReadRatio = (book: Book): number => {
   const [current, total] = book.progress ?? [];
   if (!current || !total || total <= 0) return 0;
   return current / total;
-};
-
-export const useMedianPageDurationSecs = (bookMd5?: string): number | null => {
-  const { appService } = useEnv();
-  const [medianPageDurationSecs, setMedianPageDurationSecs] = useState<number | null>(null);
-
-  useEffect(() => {
-    if (!appService || !bookMd5) return;
-
-    const load = async () => {
-      const db = await StatisticsDb.open(appService);
-      const book = await db.getBookByMd5(bookMd5);
-      if (!book) return;
-      const id = book.id;
-      const medianPageDurationSecs = await db.getMedianPageDurationSecs(id);
-      setMedianPageDurationSecs(medianPageDurationSecs);
-    };
-
-    void load();
-  });
-
-  return medianPageDurationSecs;
 };
 
 export const getTimeRemainingMinutes = (

--- a/apps/readest-app/src/app/library/utils/libraryUtils.ts
+++ b/apps/readest-app/src/app/library/utils/libraryUtils.ts
@@ -199,6 +199,28 @@ const getBookReadRatio = (book: Book): number => {
   return current / total;
 };
 
+export const useMedianPageDurationSecs = (bookMd5: string): number | null => {
+  const { appService } = useEnv();
+  const [medianPageDurationSecs, setMedianPageDurationSecs] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!appService) return;
+
+    const load = async () => {
+      const db = await StatisticsDb.open(appService);
+      const book = await db.getBookByMd5(bookMd5);
+      if (!book) return;
+      const id = book.id;
+      const medianPageDurationSecs = await db.getMedianPageDurationSecs(id);
+      setMedianPageDurationSecs(medianPageDurationSecs);
+    };
+
+    void load();
+  });
+
+  return medianPageDurationSecs;
+};
+
 export const getTimeRemainingMinutes = (book: Book): number | undefined => {
   const pagesLeft = book.progress ? book.progress[1] - book.progress[0] : undefined;
   return pagesLeft ? Math.round((pagesLeft * SIZE_PER_LOC) / SIZE_PER_TIME_UNIT) : undefined;

--- a/apps/readest-app/src/app/library/utils/libraryUtils.ts
+++ b/apps/readest-app/src/app/library/utils/libraryUtils.ts
@@ -1,3 +1,4 @@
+import { useEnv } from '@/context/EnvContext';
 import { Book, BooksGroup, ReadingStatus } from '@/types/book';
 import {
   LibraryGroupByType,
@@ -7,6 +8,8 @@ import {
 import { formatAuthors, formatTitle } from '@/utils/book';
 import { md5Fingerprint } from '@/utils/md5';
 import { SIZE_PER_LOC, SIZE_PER_TIME_UNIT } from '@/services/constants';
+import { useEffect, useState } from 'react';
+import { StatisticsDb } from '@/services/statistics/statisticsDb';
 
 /** Valid sort types for the library */
 const VALID_SORT_TYPES: LibrarySortByType[] = Object.values(LibrarySortByType);
@@ -221,9 +224,15 @@ export const useMedianPageDurationSecs = (bookMd5: string): number | null => {
   return medianPageDurationSecs;
 };
 
-export const getTimeRemainingMinutes = (book: Book): number | undefined => {
+export const getTimeRemainingMinutes = (
+  book: Book,
+  medianPageDurationSecs?: number,
+): number | undefined => {
   const pagesLeft = book.progress ? book.progress[1] - book.progress[0] : undefined;
-  return pagesLeft ? Math.round((pagesLeft * SIZE_PER_LOC) / SIZE_PER_TIME_UNIT) : undefined;
+  if (!pagesLeft) return undefined;
+  return medianPageDurationSecs
+    ? Math.round((pagesLeft * medianPageDurationSecs) / 60)
+    : Math.round((pagesLeft * SIZE_PER_LOC) / SIZE_PER_TIME_UNIT); // Fall back to less precise calculation
 };
 
 /**
@@ -232,20 +241,26 @@ export const getTimeRemainingMinutes = (book: Book): number | undefined => {
  * `ReadingProgress`), even when they still have pages left — so they have no time
  * to sort by. Sorting and the label must agree on this, hence the shared helper.
  */
-export const getDisplayedTimeRemaining = (book: Book): number | undefined => {
+export const getDisplayedTimeRemaining = (
+  book: Book,
+  medianPageDurationSecs?: number,
+): number | undefined => {
   const { readingStatus } = book;
   if (readingStatus === 'finished' || readingStatus === 'abandoned' || readingStatus === 'unread') {
     return undefined;
   }
-  return getTimeRemainingMinutes(book);
+  return getTimeRemainingMinutes(book, medianPageDurationSecs);
 };
 
 /**
  * Remaining minutes for a shelf item, or `undefined` when its tile can show no
  * time at all — that includes every group, since a group tile renders no progress.
  */
-const getShelfItemTimeRemaining = (item: Book | BooksGroup): number | undefined =>
-  'books' in item ? undefined : getDisplayedTimeRemaining(item);
+const getShelfItemTimeRemaining = (
+  item: Book | BooksGroup,
+  medianPageDurationSecs?: number,
+): number | undefined =>
+  'books' in item ? undefined : getDisplayedTimeRemaining(item, medianPageDurationSecs);
 
 /**
  * Wrap a comparator that has *already* had the sort direction applied, so items
@@ -254,18 +269,28 @@ const getShelfItemTimeRemaining = (item: Book | BooksGroup): number | undefined 
  * sort-order multiplier, otherwise descending would float those items to the top.
  */
 export const withTimeRemainingLast =
-  <T extends Book | BooksGroup>(sortBy: LibrarySortByType, compare: (a: T, b: T) => number) =>
+  <T extends Book | BooksGroup>(
+    sortBy: LibrarySortByType,
+    compare: (a: T, b: T) => number,
+    medianPageDurationSecs?: number,
+  ) =>
   (a: T, b: T): number => {
     if (sortBy !== LibrarySortByType.TimeRemaining) return compare(a, b);
-    const aTime = getShelfItemTimeRemaining(a);
-    const bTime = getShelfItemTimeRemaining(b);
+    const aTime = getShelfItemTimeRemaining(a, medianPageDurationSecs);
+    const bTime = getShelfItemTimeRemaining(b, medianPageDurationSecs);
     if (aTime === undefined && bTime === undefined) return 0;
     if (aTime === undefined) return 1;
     if (bTime === undefined) return -1;
     return compare(a, b);
   };
 
-const compareBookByKey = (a: Book, b: Book, sortBy: string, uiLanguage: string): number => {
+const compareBookByKey = (
+  a: Book,
+  b: Book,
+  sortBy: string,
+  uiLanguage: string,
+  medianPageDurationSecs?: number,
+): number => {
   switch (sortBy) {
     case LibrarySortByType.Title: {
       const aTitle = formatTitle(a.title);
@@ -318,8 +343,8 @@ const compareBookByKey = (a: Book, b: Book, sortBy: string, uiLanguage: string):
       return aDate - bDate;
     }
     case LibrarySortByType.TimeRemaining: {
-      const aTime = getDisplayedTimeRemaining(a);
-      const bTime = getDisplayedTimeRemaining(b);
+      const aTime = getDisplayedTimeRemaining(a, medianPageDurationSecs);
+      const bTime = getDisplayedTimeRemaining(b, medianPageDurationSecs);
       // Never subtract two Infinities here: NaN makes the comparator inconsistent
       // and Array.sort then scatters the no-time books through the shelf.
       if (aTime === undefined && bTime === undefined) return 0;

--- a/apps/readest-app/src/app/library/utils/libraryUtils.ts
+++ b/apps/readest-app/src/app/library/utils/libraryUtils.ts
@@ -202,12 +202,12 @@ const getBookReadRatio = (book: Book): number => {
   return current / total;
 };
 
-export const useMedianPageDurationSecs = (bookMd5: string): number | null => {
+export const useMedianPageDurationSecs = (bookMd5?: string): number | null => {
   const { appService } = useEnv();
   const [medianPageDurationSecs, setMedianPageDurationSecs] = useState<number | null>(null);
 
   useEffect(() => {
-    if (!appService) return;
+    if (!appService || !bookMd5) return;
 
     const load = async () => {
       const db = await StatisticsDb.open(appService);
@@ -230,6 +230,13 @@ export const getTimeRemainingMinutes = (
 ): number | undefined => {
   const pagesLeft = book.progress ? book.progress[1] - book.progress[0] : undefined;
   if (!pagesLeft) return undefined;
+  return convertPagesToTimeRemainingMinutes(pagesLeft, medianPageDurationSecs);
+};
+
+export const convertPagesToTimeRemainingMinutes = (
+  pagesLeft: number,
+  medianPageDurationSecs?: number,
+): number => {
   return medianPageDurationSecs
     ? Math.round((pagesLeft * medianPageDurationSecs) / 60)
     : Math.round((pagesLeft * SIZE_PER_LOC) / SIZE_PER_TIME_UNIT); // Fall back to less precise calculation

--- a/apps/readest-app/src/app/reader/components/ProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/ProgressBar.tsx
@@ -15,10 +15,8 @@ import {
 } from '@/utils/progress';
 import StatusInfo from './StatusInfo.tsx';
 import StickyProgressBar from './StickyProgressBar.tsx';
-import {
-  convertPagesToTimeRemainingMinutes,
-  useMedianPageDurationSecs,
-} from '@/app/library/utils/libraryUtils.ts';
+import { convertPagesToTimeRemainingMinutes } from '@/app/library/utils/libraryUtils.ts';
+import { useMedianPageDurationSecs } from '@/hooks/useMedianPageDurationSecs';
 
 interface ProgressBarProps {
   bookKey: string;

--- a/apps/readest-app/src/app/reader/components/ProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/ProgressBar.tsx
@@ -13,9 +13,12 @@ import {
   getChapterTickFractions,
   getReferencePageInfo,
 } from '@/utils/progress';
-import { SIZE_PER_LOC, SIZE_PER_TIME_UNIT } from '@/services/constants';
 import StatusInfo from './StatusInfo.tsx';
 import StickyProgressBar from './StickyProgressBar.tsx';
+import {
+  convertPagesToTimeRemainingMinutes,
+  useMedianPageDurationSecs,
+} from '@/app/library/utils/libraryUtils.ts';
 
 interface ProgressBarProps {
   bookKey: string;
@@ -90,6 +93,8 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
       : 0
     : Math.min(Math.max(total - current, 1), pageInfo ? pageInfo.total - pageInfo.current : total);
   const showPagesLeft = pagesLeft > 0 && (total > 0 || !!bookData?.isFixedLayout);
+  const md5 = bookData?.book?.hash;
+  const medianPageDurationSecs = useMedianPageDurationSecs(md5) ?? undefined;
   // Fixed-layout formats (CBZ, PDF) have no chapter structure — every page is
   // its own section — so the remaining count is the whole book, not a chapter.
   const remainingInBook = !!bookData?.isFixedLayout;
@@ -97,14 +102,14 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
     ? remainingInBook
       ? _('{{time}} min left in book', {
           time: formatNumber(
-            Math.round((pagesLeft * SIZE_PER_LOC) / SIZE_PER_TIME_UNIT),
+            convertPagesToTimeRemainingMinutes(pagesLeft, medianPageDurationSecs),
             localize,
             lang,
           ),
         })
       : _('{{time}} min left in chapter', {
           time: formatNumber(
-            Math.round((pagesLeft * SIZE_PER_LOC) / SIZE_PER_TIME_UNIT),
+            convertPagesToTimeRemainingMinutes(pagesLeft, medianPageDurationSecs),
             localize,
             lang,
           ),

--- a/apps/readest-app/src/hooks/useMedianPageDurationSecs.ts
+++ b/apps/readest-app/src/hooks/useMedianPageDurationSecs.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { useEnv } from '@/context/EnvContext';
+import { StatisticsDb } from '@/services/statistics/statisticsDb';
+
+/**
+ * Median seconds-per-page for a book, read from its reading statistics, or
+ * `null` until enough data exists. Used to make time-remaining estimates match
+ * the reader's own pace.
+ */
+export const useMedianPageDurationSecs = (bookMd5?: string): number | null => {
+  const { appService } = useEnv();
+  const [medianPageDurationSecs, setMedianPageDurationSecs] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!appService || !bookMd5) return;
+
+    const load = async () => {
+      const db = await StatisticsDb.open(appService);
+      const book = await db.getBookByMd5(bookMd5);
+      if (!book) return;
+      const median = await db.getMedianPageDurationSecs(book.id);
+      setMedianPageDurationSecs(median);
+    };
+
+    void load();
+  }, [appService, bookMd5]);
+
+  return medianPageDurationSecs;
+};

--- a/apps/readest-app/src/services/statistics/statisticsDb.ts
+++ b/apps/readest-app/src/services/statistics/statisticsDb.ts
@@ -153,8 +153,8 @@ export class StatisticsDb {
          LIMIT 50`,
       [idBook],
     );
+    if (rows.length < PAGE_THRESHOLD) return null;
     const pageDurations = rows.map((d) => d['duration']);
-    if (pageDurations.length <= PAGE_THRESHOLD) return null;
     const mid = Math.floor(pageDurations.length / 2);
     return pageDurations.length % 2 !== 0
       ? (pageDurations[mid] ?? 0)

--- a/apps/readest-app/src/services/statistics/statisticsDb.ts
+++ b/apps/readest-app/src/services/statistics/statisticsDb.ts
@@ -149,7 +149,8 @@ export class StatisticsDb {
       `SELECT duration
          FROM page_stat_data
          WHERE id_book = ?
-         ORDER BY start_time DESC`,
+         ORDER BY start_time DESC
+         LIMIT 50`,
       [idBook],
     );
     const pageDurations = rows.map((d) => d['duration']);

--- a/apps/readest-app/src/services/statistics/statisticsDb.ts
+++ b/apps/readest-app/src/services/statistics/statisticsDb.ts
@@ -154,11 +154,12 @@ export class StatisticsDb {
       [idBook],
     );
     if (rows.length < PAGE_THRESHOLD) return null;
-    const pageDurations = rows.map((d) => d['duration']);
+    // The query orders by recency; sort by value so the middle is the true median.
+    const pageDurations = rows.map((d) => d['duration']).sort((a, b) => a - b);
     const mid = Math.floor(pageDurations.length / 2);
     return pageDurations.length % 2 !== 0
       ? (pageDurations[mid] ?? 0)
-      : (pageDurations[mid - 1] ?? 0 + (pageDurations[mid] ?? 0)) / 2;
+      : ((pageDurations[mid - 1] ?? 0) + (pageDurations[mid] ?? 0)) / 2;
   }
 
   async getBookByMd5(md5: string): Promise<BookRow | null> {

--- a/apps/readest-app/src/services/statistics/statisticsDb.ts
+++ b/apps/readest-app/src/services/statistics/statisticsDb.ts
@@ -136,6 +136,30 @@ export class StatisticsDb {
     );
   }
 
+  /**
+   * Returns the median duration of time spent on each page in seconds. Returns
+   * `null` if sufficient data is not available.
+   *
+   * Use the median since reading times are skewed; thus the median must be
+   * used to get the middle value.
+   */
+  async getMedianPageDurationSecs(idBook: number): Promise<number | null> {
+    const PAGE_THRESHOLD = 5;
+    const rows = await this.db.select<{ duration: number }>(
+      `SELECT duration
+         FROM page_stat_data
+         WHERE id_book = ?`,
+      [idBook],
+    );
+    const pageTimes = rows.map((d) => d['duration']);
+    if (pageTimes.length <= PAGE_THRESHOLD) return null;
+    const mid = Math.floor(pageTimes.length / 2),
+      sorted = [...pageTimes].sort((a, b) => a - b);
+    return pageTimes.length % 2 !== 0
+      ? (sorted[mid] ?? 0)
+      : (sorted[mid - 1] ?? 0 + (sorted[mid] ?? 0)) / 2;
+  }
+
   async getBookByMd5(md5: string): Promise<BookRow | null> {
     const rows = await this.db.select<BookRow>(`SELECT * FROM book WHERE md5 = ? LIMIT 1`, [md5]);
     return rows[0] ?? null;

--- a/apps/readest-app/src/services/statistics/statisticsDb.ts
+++ b/apps/readest-app/src/services/statistics/statisticsDb.ts
@@ -148,16 +148,16 @@ export class StatisticsDb {
     const rows = await this.db.select<{ duration: number }>(
       `SELECT duration
          FROM page_stat_data
-         WHERE id_book = ?`,
+         WHERE id_book = ?
+         ORDER BY start_time DESC`,
       [idBook],
     );
-    const pageTimes = rows.map((d) => d['duration']);
-    if (pageTimes.length <= PAGE_THRESHOLD) return null;
-    const mid = Math.floor(pageTimes.length / 2),
-      sorted = [...pageTimes].sort((a, b) => a - b);
-    return pageTimes.length % 2 !== 0
-      ? (sorted[mid] ?? 0)
-      : (sorted[mid - 1] ?? 0 + (sorted[mid] ?? 0)) / 2;
+    const pageDurations = rows.map((d) => d['duration']);
+    if (pageDurations.length <= PAGE_THRESHOLD) return null;
+    const mid = Math.floor(pageDurations.length / 2);
+    return pageDurations.length % 2 !== 0
+      ? (pageDurations[mid] ?? 0)
+      : (pageDurations[mid - 1] ?? 0 + (pageDurations[mid] ?? 0)) / 2;
   }
 
   async getBookByMd5(md5: string): Promise<BookRow | null> {


### PR DESCRIPTION
Closes #5116.

Previously, time left calculations did not take into account the user's natural reading speed. This PR fixes that by using the user's seconds-per-page rate.

However, it would probably be better to use words per minute instead. This is just a hacked together version for now.