### PR TITLE
fix(reader): keep the side panel resize handle from sticking over PDF pages

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useDrag.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useDrag.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
+
+import { useDrag } from '@/hooks/useDrag';
+
+type Api = ReturnType<typeof useDrag>;
+
+const setup = (onMove = vi.fn(), onEnd = vi.fn()) => {
+  let api: Api = null as unknown as Api;
+  function Wrapper() {
+    api = useDrag(onMove, vi.fn(), onEnd);
+    return null;
+  }
+  render(<Wrapper />);
+  return { getApi: () => api, onMove, onEnd };
+};
+
+const startMouseDrag = (api: Api, clientX = 100) => {
+  act(() => {
+    api.handleDragStart({ clientX, clientY: 0 } as unknown as ReactMouseEvent);
+  });
+};
+
+const fireWindowMouse = (type: string, clientX: number, clientY = 0) => {
+  act(() => {
+    window.dispatchEvent(new MouseEvent(type, { clientX, clientY, bubbles: true }));
+  });
+};
+
+const getShield = () => document.querySelector<HTMLElement>('.drag-shield');
+
+describe('useDrag', () => {
+  afterEach(() => {
+    cleanup();
+    document.body.style.cssText = '';
+    document.documentElement.style.cssText = '';
+  });
+
+  it('keeps a top-most pointer-capturing shield above the content while dragging so a release over a PDF iframe still ends the drag (readest#5043)', () => {
+    const { getApi } = setup();
+    expect(getShield()).toBeNull();
+
+    startMouseDrag(getApi());
+
+    const shield = getShield();
+    expect(shield).not.toBeNull();
+    // Must sit above the book iframes (sidebar is z-[45]) and stay interactive
+    // even though PDF pages set inline pointer-events:auto on their iframes.
+    expect(shield!.style.position).toBe('fixed');
+    expect(shield!.style.pointerEvents).toBe('auto');
+    expect(Number(shield!.style.zIndex)).toBeGreaterThan(45);
+  });
+
+  it('removes the shield and stops resizing once the pointer is released', () => {
+    const { getApi, onMove, onEnd } = setup();
+    startMouseDrag(getApi());
+
+    fireWindowMouse('mousemove', 150);
+    expect(onMove).toHaveBeenCalledTimes(1);
+
+    fireWindowMouse('mouseup', 150);
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(getShield()).toBeNull();
+
+    // No further resizing after release.
+    fireWindowMouse('mousemove', 200);
+    expect(onMove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/readest-app/src/hooks/useDrag.ts
+++ b/apps/readest-app/src/hooks/useDrag.ts
@@ -35,9 +35,31 @@ export const useDrag = (
       }
       startTime.current = performance.now();
 
-      document.body.style.pointerEvents = 'none';
       document.body.style.userSelect = 'none';
       document.documentElement.style.cursor = cursor;
+
+      // Cover the viewport with a transparent, top-most shield for the duration
+      // of the drag. Book content is rendered in iframes, and fixed-layout/PDF
+      // pages set inline `pointer-events: auto` on their iframe (foliate-js
+      // fixed-layout.js) which defeats a plain `body { pointer-events: none }`.
+      // Without the shield a `mouseup` released over a PDF page is delivered
+      // into the iframe's own document and never reaches these window
+      // listeners, so the drag never ends and the panel "sticks" to the cursor
+      // (readest#5043). The shield sits above every iframe, so all pointer
+      // events land on it and bubble to window, ending the drag reliably.
+      const shield = document.createElement('div');
+      shield.className = 'drag-shield';
+      Object.assign(shield.style, {
+        position: 'fixed',
+        top: '0',
+        left: '0',
+        right: '0',
+        bottom: '0',
+        zIndex: '2147483647',
+        cursor,
+        pointerEvents: 'auto',
+      });
+      document.body.appendChild(shield);
 
       const handleMove = (event: MouseEvent | TouchEvent) => {
         if (isDragging.current) {
@@ -67,7 +89,7 @@ export const useDrag = (
       const handleEnd = (event: MouseEvent | TouchEvent) => {
         isDragging.current = false;
 
-        document.body.style.pointerEvents = '';
+        shield.remove();
         document.body.style.userSelect = '';
         document.documentElement.style.cursor = '';
 


### PR DESCRIPTION
## Summary

Fixes #5043. Dragging the reader side panel's resize handle would "stick" to the cursor and only resize toward one side until the book was closed. It reproduced with fixed-layout **PDF** pages (auto spread and scrolled mode) but not with reflowable EPUB.

## Root cause

`useDrag` attaches `mousemove`/`mouseup` to `window` and, for the duration of a drag, set `document.body.style.pointerEvents = 'none'` so the terminating `mouseup` released over the book iframe would pass through to the window listener.

foliate-js's fixed-layout renderer (`packages/foliate-js/fixed-layout.js`) sets **inline** `pointer-events: auto` on the visible PDF page frames. Inline `auto` overrides the inherited `none`, so a `mouseup` released over a PDF page is delivered into the iframe's own document and never reaches the window listener. `handleEnd` never runs, `isDragging` stays `true`, and the listeners are never removed, so the panel keeps following the cursor. Reflowable EPUB iframes have no inline override, so they inherit `none` and work.

## Fix

Replace the body `pointer-events` trick with a transparent, top-most **shield overlay** that covers the viewport for the duration of the drag. The shield sits above every iframe, so all pointer events land on it and bubble to `window`, ending the drag reliably regardless of iframe `pointer-events`.

## Verification

Confirmed live in Chrome against a real PDF in auto spread:

- Hit-test over a PDF page: the old `body { pointer-events: none }` still resolves to the page `iframe` (trick fails); with the shield it resolves to the shield, and a `mouseup` on it reaches `window`.
- Buggy build behavioral repro: `mouseup` over the PDF never reached `window`, `body.pointerEvents` stayed stuck at `none`, and a no-button hover then still resized the panel.
- Fixed build: `mouseup` over the PDF reached `window`, the shield was removed, and a post-release hover did not resize.

Added `src/__tests__/hooks/useDrag.test.tsx` (red before the fix, green after). `pnpm test` (7616 passed) and `pnpm lint` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
