### PR TITLE
fix(library): keep the select-mode action bar from hiding the last book

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/select-mode-actions.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/select-mode-actions.test.tsx
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+// The keydown hook pulls in EnvContext + device store; the measurement path we
+// exercise here is independent of it, so stub it to a no-op ref.
+vi.mock('@/hooks/useKeyDownActions', () => ({
+  useKeyDownActions: () => ({ current: null }),
+}));
+
+import SelectModeActions from '@/app/library/components/SelectModeActions';
+
+// jsdom has no layout engine, so drive the ResizeObserver callback manually and
+// fake the measured height via getBoundingClientRect.
+let resizeCallback: ResizeObserverCallback | null = null;
+beforeEach(() => {
+  resizeCallback = null;
+  global.ResizeObserver = class {
+    constructor(cb: ResizeObserverCallback) {
+      resizeCallback = cb;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const noop = () => {};
+const baseProps = {
+  selectedBooks: ['0123456789abcdef0123456789abcdef'],
+  safeAreaBottom: 24,
+  onOpen: noop,
+  onGroup: noop,
+  onDetails: noop,
+  onStatus: noop,
+  onSend: noop,
+  onDelete: noop,
+  onCancel: noop,
+};
+
+describe('SelectModeActions height reporting', () => {
+  // Regression for #5175: the fixed bottom popup overlaps the last book in list
+  // mode. The list reserves trailing space equal to the popup height, so the
+  // popup must report how tall it actually is.
+  it('reports its measured height so the shelf can reserve matching bottom space', () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      height: 118,
+    } as DOMRect);
+
+    const onHeightChange = vi.fn();
+    render(<SelectModeActions {...baseProps} onHeightChange={onHeightChange} />);
+
+    expect(onHeightChange).toHaveBeenCalledWith(118);
+  });
+
+  it('resets the reserved space to 0 when the popup unmounts', () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      height: 118,
+    } as DOMRect);
+
+    const onHeightChange = vi.fn();
+    const { unmount } = render(
+      <SelectModeActions {...baseProps} onHeightChange={onHeightChange} />,
+    );
+    onHeightChange.mockClear();
+
+    unmount();
+
+    expect(onHeightChange).toHaveBeenCalledWith(0);
+  });
+
+  it('re-reports when the popup is resized (e.g. wraps to two rows)', () => {
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue({ height: 118 } as DOMRect);
+
+    const onHeightChange = vi.fn();
+    render(<SelectModeActions {...baseProps} onHeightChange={onHeightChange} />);
+    onHeightChange.mockClear();
+
+    rectSpy.mockReturnValue({ height: 176 } as DOMRect);
+    resizeCallback?.([], {} as ResizeObserver);
+
+    expect(onHeightChange).toHaveBeenCalledWith(176);
+  });
+});

--- a/apps/readest-app/src/app/library/components/Bookshelf.tsx
+++ b/apps/readest-app/src/app/library/components/Bookshelf.tsx
@@ -101,7 +101,19 @@ type BookshelfListContext = {
    * identity stable and does not reset its scroller on every Bookshelf render.
    */
   recentShelfHeader: React.ReactNode;
+  /**
+   * Height (px) of the trailing Footer spacer. Defaults to the baseline
+   * breathing room, but grows to clear the fixed select-mode action bar so the
+   * last book can scroll above it instead of hiding behind it (#5175).
+   */
+  footerHeight: number;
 };
+
+const DEFAULT_FOOTER_HEIGHT = 34;
+
+const BookshelfFooter = ({ context }: { context?: BookshelfListContext }) => (
+  <div style={{ height: context?.footerHeight ?? DEFAULT_FOOTER_HEIGHT }} />
+);
 
 const BOOKSHELF_GRID_CLASSES =
   'bookshelf-items transform-wrapper grid gap-x-4 px-4 sm:gap-x-0 sm:px-2 ' +
@@ -147,12 +159,12 @@ const BookshelfHeader = ({ context }: { context?: BookshelfListContext }) => (
 const GRID_VIRTUOSO_COMPONENTS: GridComponents<BookshelfListContext> = {
   List: BookshelfGridList,
   Header: BookshelfHeader,
-  Footer: () => <div style={{ height: 34 }} />,
+  Footer: BookshelfFooter,
 };
 const LIST_VIRTUOSO_COMPONENTS: Components<unknown, BookshelfListContext> = {
   List: BookshelfLinearList,
   Header: BookshelfHeader,
-  Footer: () => <div style={{ height: 34 }} />,
+  Footer: BookshelfFooter,
 };
 
 const Bookshelf: React.FC<BookshelfProps> = ({
@@ -198,6 +210,7 @@ const Bookshelf: React.FC<BookshelfProps> = ({
 
   const [loading, setLoading] = useState(false);
   const [showSelectModeActions, setShowSelectModeActions] = useState(false);
+  const [selectModeActionsHeight, setSelectModeActionsHeight] = useState(0);
   const [bookIdsToDelete, setBookIdsToDelete] = useState<string[]>([]);
   const [showDeleteAlert, setShowDeleteAlert] = useState(false);
   const [showStatusAlert, setShowStatusAlert] = useState(false);
@@ -741,14 +754,30 @@ const Bookshelf: React.FC<BookshelfProps> = ({
     ],
   );
 
+  // Reserve enough trailing space for the fixed select-mode action bar so the
+  // last book scrolls clear of it (#5175). `selectModeActionsHeight` already
+  // includes the bar's safe-area padding and is 0 whenever the bar is hidden,
+  // so the baseline breathing room applies at all other times.
+  const footerHeight =
+    selectModeActionsHeight > 0
+      ? selectModeActionsHeight + DEFAULT_FOOTER_HEIGHT
+      : DEFAULT_FOOTER_HEIGHT;
+
   const listContext = useMemo<BookshelfListContext>(
     () => ({
       autoColumns: settings.libraryAutoColumns,
       fixedColumns: settings.libraryColumns,
       recentShelfHeader,
       showTimeRemaining,
+      footerHeight,
     }),
-    [settings.libraryAutoColumns, settings.libraryColumns, recentShelfHeader, showTimeRemaining],
+    [
+      settings.libraryAutoColumns,
+      settings.libraryColumns,
+      recentShelfHeader,
+      showTimeRemaining,
+      footerHeight,
+    ],
   );
 
   const renderBookshelfItem = useCallback(
@@ -883,6 +912,7 @@ const Bookshelf: React.FC<BookshelfProps> = ({
         <SelectModeActions
           selectedBooks={selectedBooks}
           safeAreaBottom={safeAreaInsets?.bottom || 0}
+          onHeightChange={setSelectModeActionsHeight}
           // Native send targets: iOS, Android, macOS — route through
           // tauri-plugin-sharekit (UIActivityViewController /
           // Intent.ACTION_SEND / NSSharingServicePicker). Linux has no

--- a/apps/readest-app/src/app/library/components/SelectModeActions.tsx
+++ b/apps/readest-app/src/app/library/components/SelectModeActions.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { useEffect, useRef } from 'react';
 import {
   MdDelete,
   MdOpenInNew,
@@ -32,6 +33,10 @@ interface SelectModeActionsProps {
   onSend: () => void;
   onDelete: () => void;
   onCancel: () => void;
+  // Reports the popup's rendered height (including its safe-area padding) so the
+  // shelf can reserve matching trailing space and keep the last book from being
+  // hidden behind this fixed bar (#5175). Reports 0 on unmount.
+  onHeightChange?: (height: number) => void;
 }
 
 const SelectModeActions: React.FC<SelectModeActionsProps> = ({
@@ -45,17 +50,36 @@ const SelectModeActions: React.FC<SelectModeActionsProps> = ({
   onSend,
   onDelete,
   onCancel,
+  onHeightChange,
 }) => {
   const _ = useTranslation();
 
   const hasSelection = selectedBooks.length > 0;
   const hasValidBooks = selectedBooks.every((id) => isMd5(id));
   const hasSingleSelection = selectedBooks.length === 1;
-  const divRef = useKeyDownActions({ onCancel });
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  useKeyDownActions({ onCancel, elementRef: rootRef });
+
+  useEffect(() => {
+    if (!onHeightChange) return;
+    const el = rootRef.current;
+    if (!el) return;
+    const report = () => onHeightChange(el.getBoundingClientRect().height);
+    report();
+    let observer: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== 'undefined') {
+      observer = new ResizeObserver(report);
+      observer.observe(el);
+    }
+    return () => {
+      observer?.disconnect();
+      onHeightChange(0);
+    };
+  }, [onHeightChange]);
 
   return (
     <div
-      ref={divRef}
+      ref={rootRef}
       className='fixed bottom-0 left-0 right-0 z-40'
       style={{
         paddingBottom: `${safeAreaBottom + 16}px`,


### PR DESCRIPTION
## Problem

Fixes #5175. In the library **list view**, once a book is selected the fixed
bottom action bar (`SelectModeActions`) appears. When the shelf is scrolled to
the very end, that bar overlaps and hides the **last book**, so it can't be
tapped/selected.

## Root cause

The Virtuoso list reserved only a hardcoded `34px` of trailing space via its
`Footer`, while the action bar is ~88px tall (taller still when it wraps to two
rows on narrow/mobile widths, plus the bottom safe-area inset). So the last row
ended up behind the bar.

## Fix

- `SelectModeActions` now measures its own rendered height (including safe-area
  padding) via `getBoundingClientRect` + a `ResizeObserver`, reports it through a
  new `onHeightChange` callback, and reports `0` on unmount.
- `Bookshelf` stores that height and reserves `height + baseline` in the Virtuoso
  footer spacer, threaded through the existing `BookshelfListContext`
  (`BookshelfFooter` reads `context.footerHeight`). The Virtuoso component maps
  stay module-level constants so component identity is preserved. Applies to both
  list and grid modes.

Measuring live (rather than hardcoding a taller value) keeps the reserved space
correct when the bar wraps to two rows on narrow screens or when the safe-area
inset changes on rotation.

## Verification

- New unit test `select-mode-actions.test.tsx` (report-on-mount, reset-on-unmount,
  re-report-on-resize) - fails before the fix, passes after.
- Chrome: in select mode the footer spacer measures exactly popup height + 34, and
  the last book scrolls fully clear of the bar on both wide and narrow viewports.
- Full suite green: `pnpm test` (7618 passed), Biome clean, `tsgo` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
