### PR TITLE
fix(library): show only currently-reading books on recent shelf and widget

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/recent-shelf.test.ts
+++ b/apps/readest-app/src/__tests__/app/library/recent-shelf.test.ts
@@ -56,6 +56,25 @@ describe('selectRecentShelfBooks', () => {
     expect(selectRecentShelfBooks([opened], 10).map((book) => book.hash)).toEqual(['opened']);
   });
 
+  it('excludes finished, abandoned and unread books even when they have progress', () => {
+    const reading = createMockBook({ hash: 'reading', updatedAt: 1000 });
+    const finished = createMockBook({
+      hash: 'finished',
+      updatedAt: 4000,
+      readingStatus: 'finished',
+    });
+    const abandoned = createMockBook({
+      hash: 'abandoned',
+      updatedAt: 3000,
+      readingStatus: 'abandoned',
+    });
+    const unread = createMockBook({ hash: 'unread', updatedAt: 2000, readingStatus: 'unread' });
+
+    const result = selectRecentShelfBooks([reading, finished, abandoned, unread], 10);
+
+    expect(result.map((book) => book.hash)).toEqual(['reading']);
+  });
+
   it('slices to the requested count, keeping the most recent', () => {
     const books = [
       createMockBook({ hash: 'a', updatedAt: 1000 }),

--- a/apps/readest-app/src/__tests__/services/readingWidget.test.ts
+++ b/apps/readest-app/src/__tests__/services/readingWidget.test.ts
@@ -51,18 +51,20 @@ describe('computeReadingPercent', () => {
 });
 
 describe('selectReadingWidgetBooks', () => {
-  it('keeps non-deleted, non-finished, non-abandoned and sorts by updatedAt desc', () => {
+  it('keeps only currently-reading books and sorts by updatedAt desc', () => {
     const books = [
-      mk({ hash: 'a', updatedAt: 10, readingStatus: 'reading' }),
-      mk({ hash: 'b', updatedAt: 30, readingStatus: 'unread' }),
-      mk({ hash: 'c', updatedAt: 20, readingStatus: 'finished' }),
-      mk({ hash: 'd', updatedAt: 40, readingStatus: 'abandoned' }),
-      mk({ hash: 'e', updatedAt: 50, deletedAt: 123 }),
+      mk({ hash: 'a', updatedAt: 10, progress: [1, 2] }), // reading (no explicit status)
+      mk({ hash: 'r', updatedAt: 35, progress: [1, 2], readingStatus: 'reading' }),
+      mk({ hash: 'b', updatedAt: 30, progress: [1, 2], readingStatus: 'unread' }), // parked
+      mk({ hash: 'c', updatedAt: 20, progress: [1, 2], readingStatus: 'finished' }),
+      mk({ hash: 'd', updatedAt: 40, progress: [1, 2], readingStatus: 'abandoned' }),
+      mk({ hash: 'e', updatedAt: 50, progress: [1, 2], deletedAt: 123 }), // deleted
+      mk({ hash: 'n', updatedAt: 60, progress: undefined }), // newly imported, never opened
     ];
-    expect(selectReadingWidgetBooks(books).map((b) => b.hash)).toEqual(['b', 'a']);
+    expect(selectReadingWidgetBooks(books).map((b) => b.hash)).toEqual(['r', 'a']);
   });
   it('caps at the limit', () => {
-    const books = [1, 2, 3, 4].map((n) => mk({ hash: String(n), updatedAt: n }));
+    const books = [1, 2, 3, 4].map((n) => mk({ hash: String(n), updatedAt: n, progress: [1, 2] }));
     expect(selectReadingWidgetBooks(books, 3)).toHaveLength(3);
   });
 });

--- a/apps/readest-app/src/app/library/utils/libraryUtils.ts
+++ b/apps/readest-app/src/app/library/utils/libraryUtils.ts
@@ -4,7 +4,7 @@ import {
   LibrarySecondarySortByType,
   LibrarySortByType,
 } from '@/types/settings';
-import { formatAuthors, formatTitle } from '@/utils/book';
+import { formatAuthors, formatTitle, isCurrentlyReadingBook } from '@/utils/book';
 import { md5Fingerprint } from '@/utils/md5';
 import { SIZE_PER_LOC, SIZE_PER_TIME_UNIT } from '@/services/constants';
 
@@ -342,23 +342,18 @@ export const createBookSorter =
   };
 
 /**
- * A book counts as "read" once it has reading progress. Importing a book sets
- * timestamps but never `progress`; only opening it does. Gating on this keeps
- * freshly-added-but-unopened books off the shelf.
- */
-const hasBeenRead = (book: Book): boolean => book.progress != null;
-
-/**
  * Pick the books for the recently-read shelf: most-recently-read first, capped
- * at `count`. Recency uses `updatedAt` (the library's "Updated" sort key) so the
- * row matches the app's existing sort convention. NB: `updatedAt` is last-modified
- * (also bumped by status/metadata edits and sync), not strictly last-read.
- * Independent of the main shelf's sort/grouping — always a flat, recency slice.
+ * at `count`. Only currently-reading books qualify (see `isCurrentlyReadingBook`):
+ * finished, abandoned and freshly-imported books are left off. Recency uses
+ * `updatedAt` (the library's "Updated" sort key) so the row matches the app's
+ * existing sort convention. NB: `updatedAt` is last-modified (also bumped by
+ * status/metadata edits and sync), not strictly last-read. Independent of the
+ * main shelf's sort/grouping — always a flat, recency slice.
  */
 export const selectRecentShelfBooks = (books: Book[], count: number): Book[] => {
   const byRecency = createBookSorter(LibrarySortByType.Updated, '');
   return books
-    .filter((book) => !book.deletedAt && hasBeenRead(book))
+    .filter(isCurrentlyReadingBook)
     .sort((a, b) => -byRecency(a, b))
     .slice(0, count);
 };

--- a/apps/readest-app/src/services/widget/readingWidget.ts
+++ b/apps/readest-app/src/services/widget/readingWidget.ts
@@ -1,7 +1,7 @@
 import type { Book } from '@/types/book';
 import type { AppService } from '@/types/system';
 import { useLibraryStore } from '@/store/libraryStore';
-import { getCoverFilename } from '@/utils/book';
+import { getCoverFilename, isCurrentlyReadingBook } from '@/utils/book';
 import { updateReadingWidget } from '@/utils/bridge';
 import type { ReadingWidgetTts } from '@/utils/bridge';
 
@@ -20,8 +20,6 @@ export interface ReadingWidgetPayload {
   tts?: ReadingWidgetTts;
 }
 
-const EXCLUDED_STATUSES = new Set(['finished', 'abandoned']);
-
 export const computeReadingPercent = (book: Book): number => {
   const progress = book.progress;
   if (!progress) return 0;
@@ -32,7 +30,7 @@ export const computeReadingPercent = (book: Book): number => {
 
 export const selectReadingWidgetBooks = (library: Book[], limit = 3): Book[] =>
   library
-    .filter((b) => !b.deletedAt && !EXCLUDED_STATUSES.has(b.readingStatus ?? 'unread'))
+    .filter(isCurrentlyReadingBook)
     .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
     .slice(0, limit);
 

--- a/apps/readest-app/src/utils/book.ts
+++ b/apps/readest-app/src/utils/book.ts
@@ -281,6 +281,23 @@ export const getCurrentPage = (book: Book, progress: BookProgress) => {
       : 0;
 };
 
+/**
+ * A book is "currently reading" iff it has real reading progress and has not
+ * been parked. Importing a book sets timestamps but never `progress` (only
+ * opening it does), so the progress gate drops freshly-added-but-unopened
+ * books; the status gate drops finished, abandoned (on hold) and
+ * manually-marked-unread books. A book actively being read has `readingStatus`
+ * either `undefined` (cleared from 'unread' on first open) or `'reading'`, both
+ * of which pass. Shared by the library's recently-read shelf and the
+ * home-screen reading widget so the two surfaces stay in sync.
+ */
+export const isCurrentlyReadingBook = (book: Book): boolean =>
+  !book.deletedAt &&
+  book.progress != null &&
+  book.readingStatus !== 'finished' &&
+  book.readingStatus !== 'abandoned' &&
+  book.readingStatus !== 'unread';
+
 export const getBookDirFromWritingMode = (writingMode: WritingMode) => {
   switch (writingMode) {
     case 'horizontal-tb':


### PR DESCRIPTION
## Summary

Both the library's **Recently read** strip and the **home-screen reading widget** are meant to surface the books you're actively reading, but each filtered differently:

| | Recent shelf | Reading widget |
|---|---|---|
| Excludes deleted | ✅ | ✅ |
| Excludes newly-imported (no progress) | ✅ | ❌ |
| Excludes finished / abandoned | ❌ | ✅ |

So the shelf kept finished/abandoned books, and the widget kept freshly-imported books that had never been opened. Neither showed *just* the currently-reading books.

## Change

- Add a shared `isCurrentlyReadingBook` predicate in `utils/book.ts`: a book qualifies only when it has real reading progress **and** is not `finished`, `abandoned`, or manually marked `unread`. Actively-reading books (`readingStatus` `undefined` or `'reading'`, with progress) pass.
- Use it in both `selectReadingWidgetBooks` and `selectRecentShelfBooks`, replacing the two divergent local filters (`EXCLUDED_STATUSES` / `hasBeenRead`) so the surfaces can't drift again.

Sort order (`updatedAt` desc) and counts (12 shelf / 3 widget) are unchanged — this only tightens *which* books qualify.

## Testing

- `pnpm test` — 7635 passed, 0 failed
- `pnpm lint` — clean
- Added failing-first unit cases: recent shelf now excludes finished/abandoned/unread-with-progress; widget now excludes no-progress and unread, keeping undefined-status-with-progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)