### PR TITLE
fix(reader): preserve paragraph breaks when copying text

### DIFF
--- a/apps/readest-app/src/__tests__/utils/sel.test.ts
+++ b/apps/readest-app/src/__tests__/utils/sel.test.ts
@@ -392,6 +392,21 @@ describe('sel utilities', () => {
       document.body.removeChild(container);
     });
 
+    it('should separate selected paragraphs with newlines', async () => {
+      const { getTextFromRange } = await import('@/utils/sel');
+      const container = document.createElement('div');
+      container.innerHTML = '<p>First paragraph</p><p>Second paragraph</p><p>Third paragraph</p>';
+      document.body.appendChild(container);
+
+      const range = document.createRange();
+      range.setStart(container.children[0]!.firstChild!, 6);
+      range.setEnd(container.children[2]!.firstChild!, 5);
+
+      expect(getTextFromRange(range)).toBe('paragraph\nSecond paragraph\nThird');
+
+      document.body.removeChild(container);
+    });
+
     it('should insert a newline for <br> between adjacent text spans (PDF line wrap)', async () => {
       const { getTextFromRange } = await import('@/utils/sel');
       // Mirrors how pdf.js renders the text layer: each text run is its

--- a/apps/readest-app/src/utils/sel.ts
+++ b/apps/readest-app/src/utils/sel.ts
@@ -789,18 +789,20 @@ export const getTextFromRange = (range: Range, rejectTags: string[] = []): strin
     },
   );
 
-  // pdf.js inserts <br role="presentation"> between text spans at line endings
-  // (see TextLayer#appendText in pdfjs). Without this, multi-line PDF
-  // selections collapse adjacent line-final and line-initial words into a
-  // single token (e.g. "lastfirst"). Treat <br> as a newline, matching how
-  // Selection.toString() handles line breaks in the browser.
+  // Preserve explicit line and paragraph boundaries. Without this, adjacent
+  // PDF lines or HTML paragraphs collapse into a single token.
   let text = '';
   let node: Node | null;
   while ((node = walker.nextNode())) {
     if (node.nodeType === Node.TEXT_NODE) {
       text += (node as Text).nodeValue ?? '';
-    } else if ((node as Element).tagName === 'BR') {
-      text += '\n';
+    } else {
+      const tagName = (node as Element).tagName.toLowerCase();
+      if (tagName === 'p' && text && !text.endsWith('\n')) {
+        text += '\n';
+      } else if (tagName === 'br') {
+        text += '\n';
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- preserve `<p>` boundaries when serializing a selected DOM range
- insert one newline between adjacent selected paragraphs without adding a trailing newline
- retain the existing `<br>` handling used by HTML and PDF text layers

## Regression test

Adds a partial selection that starts in the first paragraph, crosses a complete second paragraph, and ends in the third paragraph. The copied text must retain both paragraph breaks.

## Verification

- `pnpm exec dotenv -e .env -e .env.test.local -- vitest run src/__tests__/utils/sel.test.ts`: 49 passed
- `pnpm lint`
- `pnpm test`: 582 passed, 3 skipped test files; 7,636 passed, 7 skipped tests
- isolated retry of the unrelated updater timeout: 4 passed
