### PR TITLE
feat(updater): show original text for auto-translated release notes

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2077,5 +2077,7 @@
   "Player Style": "نمط المشغل",
   "Full": "كامل",
   "Minimal": "مبسط",
-  "TTS Player Style": "نمط مشغل TTS"
+  "TTS Player Style": "نمط مشغل TTS",
+  "Show translation": "إظهار الترجمة",
+  "Show original": "إظهار الأصل"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1933,5 +1933,7 @@
   "Player Style": "প্লেয়ার শৈলী",
   "Full": "পূর্ণ",
   "Minimal": "ন্যূনতম",
-  "TTS Player Style": "TTS প্লেয়ার শৈলী"
+  "TTS Player Style": "TTS প্লেয়ার শৈলী",
+  "Show translation": "অনুবাদ দেখান",
+  "Show original": "মূল দেখান"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1897,5 +1897,7 @@
   "Player Style": "གཏོང་ཆས་ཀྱི་བཟོ་དབྱིབས།",
   "Full": "ཆ་ཚང་།",
   "Minimal": "སྟབས་བདེ།",
-  "TTS Player Style": "TTS གཏོང་ཆས་ཀྱི་བཟོ་དབྱིབས།"
+  "TTS Player Style": "TTS གཏོང་ཆས་ཀྱི་བཟོ་དབྱིབས།",
+  "Show translation": "འགྱུར་ཡིག་སྟོན་པ།",
+  "Show original": "མ་ཡིག་སྟོན་པ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1933,5 +1933,7 @@
   "Player Style": "Player-Stil",
   "Full": "Vollständig",
   "Minimal": "Minimal",
-  "TTS Player Style": "TTS-Player-Stil"
+  "TTS Player Style": "TTS-Player-Stil",
+  "Show translation": "Übersetzung anzeigen",
+  "Show original": "Original anzeigen"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1933,5 +1933,7 @@
   "Player Style": "Στυλ αναπαραγωγής",
   "Full": "Πλήρες",
   "Minimal": "Μινιμαλιστικό",
-  "TTS Player Style": "Στυλ αναπαραγωγής TTS"
+  "TTS Player Style": "Στυλ αναπαραγωγής TTS",
+  "Show translation": "Εμφάνιση μετάφρασης",
+  "Show original": "Εμφάνιση πρωτοτύπου"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1969,5 +1969,7 @@
   "Player Style": "Estilo del reproductor",
   "Full": "Completo",
   "Minimal": "Minimalista",
-  "TTS Player Style": "Estilo del reproductor TTS"
+  "TTS Player Style": "Estilo del reproductor TTS",
+  "Show translation": "Mostrar traducción",
+  "Show original": "Mostrar original"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1933,5 +1933,7 @@
   "Player Style": "سبک پخش‌کننده",
   "Full": "کامل",
   "Minimal": "ساده",
-  "TTS Player Style": "سبک پخش‌کننده TTS"
+  "TTS Player Style": "سبک پخش‌کننده TTS",
+  "Show translation": "نمایش ترجمه",
+  "Show original": "نمایش متن اصلی"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1969,5 +1969,7 @@
   "Player Style": "Style du lecteur",
   "Full": "Complet",
   "Minimal": "Minimal",
-  "TTS Player Style": "Style du lecteur TTS"
+  "TTS Player Style": "Style du lecteur TTS",
+  "Show translation": "Afficher la traduction",
+  "Show original": "Afficher l'original"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1969,5 +1969,7 @@
   "Player Style": "סגנון הנגן",
   "Full": "מלא",
   "Minimal": "מינימלי",
-  "TTS Player Style": "סגנון נגן TTS"
+  "TTS Player Style": "סגנון נגן TTS",
+  "Show translation": "הצג תרגום",
+  "Show original": "הצג מקור"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1933,5 +1933,7 @@
   "Player Style": "प्लेयर शैली",
   "Full": "पूर्ण",
   "Minimal": "न्यूनतम",
-  "TTS Player Style": "TTS प्लेयर शैली"
+  "TTS Player Style": "TTS प्लेयर शैली",
+  "Show translation": "अनुवाद दिखाएं",
+  "Show original": "मूल दिखाएं"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1933,5 +1933,7 @@
   "Player Style": "Lejátszó stílusa",
   "Full": "Teljes",
   "Minimal": "Minimális",
-  "TTS Player Style": "TTS lejátszó stílusa"
+  "TTS Player Style": "TTS lejátszó stílusa",
+  "Show translation": "Fordítás megjelenítése",
+  "Show original": "Eredeti megjelenítése"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1897,5 +1897,7 @@
   "Player Style": "Gaya Pemutar",
   "Full": "Lengkap",
   "Minimal": "Minimal",
-  "TTS Player Style": "Gaya Pemutar TTS"
+  "TTS Player Style": "Gaya Pemutar TTS",
+  "Show translation": "Tampilkan terjemahan",
+  "Show original": "Tampilkan asli"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1969,5 +1969,7 @@
   "Player Style": "Stile del lettore",
   "Full": "Completo",
   "Minimal": "Minimale",
-  "TTS Player Style": "Stile del lettore TTS"
+  "TTS Player Style": "Stile del lettore TTS",
+  "Show translation": "Mostra traduzione",
+  "Show original": "Mostra originale"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1897,5 +1897,7 @@
   "Player Style": "プレーヤーのスタイル",
   "Full": "フル",
   "Minimal": "ミニマル",
-  "TTS Player Style": "TTSプレーヤーのスタイル"
+  "TTS Player Style": "TTSプレーヤーのスタイル",
+  "Show translation": "翻訳を表示",
+  "Show original": "原文を表示"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1897,5 +1897,7 @@
   "Player Style": "플레이어 스타일",
   "Full": "전체",
   "Minimal": "미니멀",
-  "TTS Player Style": "TTS 플레이어 스타일"
+  "TTS Player Style": "TTS 플레이어 스타일",
+  "Show translation": "번역 표시",
+  "Show original": "원문 표시"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1897,5 +1897,7 @@
   "Player Style": "Gaya Pemain",
   "Full": "Penuh",
   "Minimal": "Minimal",
-  "TTS Player Style": "Gaya Pemain TTS"
+  "TTS Player Style": "Gaya Pemain TTS",
+  "Show translation": "Tunjukkan terjemahan",
+  "Show original": "Tunjukkan asal"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1933,5 +1933,7 @@
   "Player Style": "Spelerstijl",
   "Full": "Volledig",
   "Minimal": "Minimaal",
-  "TTS Player Style": "TTS-spelerstijl"
+  "TTS Player Style": "TTS-spelerstijl",
+  "Show translation": "Vertaling tonen",
+  "Show original": "Origineel tonen"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2005,5 +2005,7 @@
   "Player Style": "Styl odtwarzacza",
   "Full": "Pełny",
   "Minimal": "Minimalny",
-  "TTS Player Style": "Styl odtwarzacza TTS"
+  "TTS Player Style": "Styl odtwarzacza TTS",
+  "Show translation": "Pokaż tłumaczenie",
+  "Show original": "Pokaż oryginał"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1969,5 +1969,7 @@
   "Player Style": "Estilo do reprodutor",
   "Full": "Completo",
   "Minimal": "Minimalista",
-  "TTS Player Style": "Estilo do reprodutor TTS"
+  "TTS Player Style": "Estilo do reprodutor TTS",
+  "Show translation": "Mostrar tradução",
+  "Show original": "Mostrar original"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1969,5 +1969,7 @@
   "Player Style": "Estilo do leitor",
   "Full": "Completo",
   "Minimal": "Minimalista",
-  "TTS Player Style": "Estilo do leitor TTS"
+  "TTS Player Style": "Estilo do leitor TTS",
+  "Show translation": "Mostrar tradução",
+  "Show original": "Mostrar original"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1969,5 +1969,7 @@
   "Player Style": "Stilul playerului",
   "Full": "Complet",
   "Minimal": "Minimal",
-  "TTS Player Style": "Stilul playerului TTS"
+  "TTS Player Style": "Stilul playerului TTS",
+  "Show translation": "Afișează traducerea",
+  "Show original": "Afișează originalul"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2005,5 +2005,7 @@
   "Player Style": "Стиль плеера",
   "Full": "Полный",
   "Minimal": "Минимальный",
-  "TTS Player Style": "Стиль TTS-плеера"
+  "TTS Player Style": "Стиль TTS-плеера",
+  "Show translation": "Показать перевод",
+  "Show original": "Показать оригинал"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1933,5 +1933,7 @@
   "Player Style": "වාදක විලාසය",
   "Full": "සම්පූර්ණ",
   "Minimal": "අවම",
-  "TTS Player Style": "TTS වාදක විලාසය"
+  "TTS Player Style": "TTS වාදක විලාසය",
+  "Show translation": "පරිවර්තනය පෙන්වන්න",
+  "Show original": "මුල් පිටපත පෙන්වන්න"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2005,5 +2005,7 @@
   "Player Style": "Slog predvajalnika",
   "Full": "Polni",
   "Minimal": "Minimalni",
-  "TTS Player Style": "Slog predvajalnika TTS"
+  "TTS Player Style": "Slog predvajalnika TTS",
+  "Show translation": "Pokaži prevod",
+  "Show original": "Pokaži izvirnik"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1933,5 +1933,7 @@
   "Player Style": "Spelarstil",
   "Full": "Fullständig",
   "Minimal": "Minimal",
-  "TTS Player Style": "TTS-spelarstil"
+  "TTS Player Style": "TTS-spelarstil",
+  "Show translation": "Visa översättning",
+  "Show original": "Visa original"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1933,5 +1933,7 @@
   "Player Style": "இயக்கி பாணி",
   "Full": "முழு",
   "Minimal": "எளிய",
-  "TTS Player Style": "TTS இயக்கி பாணி"
+  "TTS Player Style": "TTS இயக்கி பாணி",
+  "Show translation": "மொழிபெயர்ப்பைக் காட்டு",
+  "Show original": "மூலத்தைக் காட்டு"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1897,5 +1897,7 @@
   "Player Style": "รูปแบบตัวเล่น",
   "Full": "เต็มรูปแบบ",
   "Minimal": "มินิมอล",
-  "TTS Player Style": "รูปแบบตัวเล่น TTS"
+  "TTS Player Style": "รูปแบบตัวเล่น TTS",
+  "Show translation": "แสดงคำแปล",
+  "Show original": "แสดงต้นฉบับ"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1933,5 +1933,7 @@
   "Player Style": "Oynatıcı Stili",
   "Full": "Tam",
   "Minimal": "Minimal",
-  "TTS Player Style": "TTS Oynatıcı Stili"
+  "TTS Player Style": "TTS Oynatıcı Stili",
+  "Show translation": "Çeviriyi göster",
+  "Show original": "Orijinali göster"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2005,5 +2005,7 @@
   "Player Style": "Стиль плеєра",
   "Full": "Повний",
   "Minimal": "Мінімальний",
-  "TTS Player Style": "Стиль TTS-плеєра"
+  "TTS Player Style": "Стиль TTS-плеєра",
+  "Show translation": "Показати переклад",
+  "Show original": "Показати оригінал"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1933,5 +1933,7 @@
   "Player Style": "Pleyer uslubi",
   "Full": "Toʻliq",
   "Minimal": "Minimal",
-  "TTS Player Style": "TTS pleyer uslubi"
+  "TTS Player Style": "TTS pleyer uslubi",
+  "Show translation": "Tarjimani ko'rsatish",
+  "Show original": "Aslini ko'rsatish"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1897,5 +1897,7 @@
   "Player Style": "Kiểu trình phát",
   "Full": "Đầy đủ",
   "Minimal": "Tối giản",
-  "TTS Player Style": "Kiểu trình phát TTS"
+  "TTS Player Style": "Kiểu trình phát TTS",
+  "Show translation": "Hiển thị bản dịch",
+  "Show original": "Hiển thị bản gốc"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1897,5 +1897,7 @@
   "Player Style": "播放器样式",
   "Full": "完整",
   "Minimal": "简约",
-  "TTS Player Style": "TTS 播放器样式"
+  "TTS Player Style": "TTS 播放器样式",
+  "Show translation": "显示译文",
+  "Show original": "显示原文"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1897,5 +1897,7 @@
   "Player Style": "播放器樣式",
   "Full": "完整",
   "Minimal": "簡約",
-  "TTS Player Style": "TTS 播放器樣式"
+  "TTS Player Style": "TTS 播放器樣式",
+  "Show translation": "顯示譯文",
+  "Show original": "顯示原文"
 }

--- a/apps/readest-app/src/__tests__/components/UpdaterWindow.test.tsx
+++ b/apps/readest-app/src/__tests__/components/UpdaterWindow.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * UpdaterContent — the "What's New in Readest" changelog.
+ *
+ * When the UI locale is non-English, the release notes are auto-translated in
+ * place. These tests cover the "Show original" toggle that lets the reader flip
+ * the auto-translated changelog back to the source English text (and back).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+// ── Locale + translation controls ────────────────────────────────
+let mockLocale = 'en';
+const mockTranslate = vi.fn(async (input: string[]) => input.map((s) => `[zh] ${s}`));
+
+vi.mock('@/utils/misc', () => ({
+  getLocale: () => mockLocale,
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+vi.mock('@/hooks/useTranslator', () => ({
+  useTranslator: () => ({
+    translate: mockTranslate,
+    translator: null,
+    translators: [],
+    loading: false,
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({
+    appService: {
+      hasUpdater: false,
+      isIOSApp: false,
+      isMacOSApp: false,
+      isAndroidApp: false,
+    },
+  }),
+}));
+
+vi.mock('@/services/environment', () => ({
+  isTauriAppPlatform: () => false,
+}));
+
+const mockAppVersion = '0.11.0';
+vi.mock('@/utils/version', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/version')>('@/utils/version');
+  return { ...actual, getAppVersion: () => mockAppVersion };
+});
+
+vi.mock('@/helpers/updater', () => ({
+  setLastShownReleaseNotesVersion: vi.fn(),
+}));
+
+vi.mock('@/services/constants', () => ({
+  READEST_UPDATER_FILE: 'https://example.com/latest.json',
+  READEST_CHANGELOG_FILE: 'https://example.com/release-notes.json',
+  READEST_UPDATER_PUBKEY: 'pk',
+}));
+
+// ── Tauri / heavy modules pulled in by UpdaterWindow's top-level imports ──
+vi.mock('@tauri-apps/plugin-os', () => ({ type: () => 'macos', arch: () => 'aarch64' }));
+vi.mock('@tauri-apps/plugin-updater', () => ({ check: vi.fn(), Update: class {} }));
+vi.mock('@tauri-apps/plugin-process', () => ({ relaunch: vi.fn(), exit: vi.fn() }));
+vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }));
+vi.mock('@tauri-apps/plugin-shell', () => ({ Command: { create: vi.fn() } }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/path', () => ({ desktopDir: vi.fn(), join: vi.fn() }));
+vi.mock('@/utils/transfer', () => ({ tauriDownload: vi.fn() }));
+vi.mock('@/utils/bridge', () => ({
+  installPackage: vi.fn(),
+  verifyUpdateSignature: vi.fn(),
+  installNightlyUpdate: vi.fn(),
+}));
+vi.mock('next/image', () => ({ default: () => null }));
+vi.mock('@/components/Dialog', () => ({
+  default: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock('@/components/Link', () => ({ default: () => null }));
+
+import { UpdaterContent } from '@/components/UpdaterWindow';
+
+const RELEASE_NOTES = {
+  releases: {
+    '0.11.18': { date: '2026-07-08', notes: ['First feature', 'Second feature'] },
+  },
+};
+
+beforeEach(() => {
+  mockLocale = 'en';
+  mockTranslate.mockClear();
+  window.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => RELEASE_NOTES,
+  })) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('UpdaterContent — auto-translated changelog', () => {
+  it('shows a "Show original" toggle that swaps the translation for the source English', async () => {
+    mockLocale = 'zh-CN';
+    render(<UpdaterContent checkUpdate={false} latestVersion='0.11.18' lastVersion='0.11.0' />);
+
+    // The translated notes render by default (current behavior preserved).
+    await waitFor(() => expect(screen.getByText('[zh] First feature')).toBeTruthy());
+    expect(mockTranslate).toHaveBeenCalled();
+    // The original English is hidden until the reader asks for it.
+    expect(screen.queryByText('First feature')).toBeNull();
+
+    const toggle = screen.getByRole('button', { name: 'Show original' });
+    fireEvent.click(toggle);
+
+    // Now the source English is shown, the translation is hidden, label flips.
+    await waitFor(() => expect(screen.getByText('First feature')).toBeTruthy());
+    expect(screen.queryByText('[zh] First feature')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Show translation' })).toBeTruthy();
+  });
+
+  it('renders no toggle when the locale is English (nothing was translated)', async () => {
+    mockLocale = 'en';
+    render(<UpdaterContent checkUpdate={false} latestVersion='0.11.18' lastVersion='0.11.0' />);
+
+    await waitFor(() => expect(screen.getByText('First feature')).toBeTruthy());
+    expect(mockTranslate).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Show original' })).toBeNull();
+  });
+});

--- a/apps/readest-app/src/components/UpdaterWindow.tsx
+++ b/apps/readest-app/src/components/UpdaterWindow.tsx
@@ -43,6 +43,9 @@ interface Changelog {
   version: string;
   date: string;
   notes: string[];
+  // Auto-translated notes, kept alongside the original English `notes` so the
+  // reader can flip back to the source text. Only set when translation ran.
+  translatedNotes?: string[];
 }
 
 type DownloadEvent =
@@ -106,6 +109,7 @@ export const UpdaterContent = ({
   );
   const [update, setUpdate] = useState<GenericUpdate | Update | null>(null);
   const [changelogs, setChangelogs] = useState<Changelog[]>([]);
+  const [showOriginal, setShowOriginal] = useState(false);
   const [progress, setProgress] = useState<number | null>(null);
   const [contentLength, setContentLength] = useState<number | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
@@ -449,7 +453,9 @@ export const UpdaterContent = ({
       if (!targetLang.toLowerCase().startsWith('en')) {
         for (const entry of changelogs) {
           try {
-            entry.notes = await translate(entry.notes, { useCache: true });
+            // Preserve the original English `notes`; store the translation
+            // separately so the "Show original" toggle can flip between them.
+            entry.translatedNotes = await translate(entry.notes, { useCache: true });
           } catch (error) {
             console.log('Failed to translate changelog:', error);
           }
@@ -622,7 +628,17 @@ export const UpdaterContent = ({
           )}
         </div>
         <div className='text-base-content text-sm'>
-          <h3 className='mb-2 font-bold'>{_('Changelog')}</h3>
+          <div className='mb-2 flex items-center justify-between gap-2'>
+            <h3 className='font-bold'>{_('Changelog')}</h3>
+            {changelogs.some((entry) => entry.translatedNotes?.length) && (
+              <button
+                className='btn btn-ghost btn-xs eink-bordered font-normal'
+                onClick={() => setShowOriginal((prev) => !prev)}
+              >
+                {showOriginal ? _('Show translation') : _('Show original')}
+              </button>
+            )}
+          </div>
           <div className='not-eink:bg-base-200 not-eink:px-4 mb-4 rounded-lg pb-2 pt-4'>
             {changelogs.length > 0 ? (
               changelogs.map((entry: Changelog) => (
@@ -631,9 +647,11 @@ export const UpdaterContent = ({
                     {entry.version} ({entry.date})
                   </h4>
                   <ul className='list-disc space-y-1 ps-6 text-sm'>
-                    {entry.notes.map((note: string, i: number) => (
-                      <li key={i}>{note}</li>
-                    ))}
+                    {(showOriginal ? entry.notes : (entry.translatedNotes ?? entry.notes)).map(
+                      (note: string, i: number) => (
+                        <li key={i}>{note}</li>
+                      ),
+                    )}
                   </ul>
                 </div>
               ))


### PR DESCRIPTION
## What

When the UI locale is not English, the **What's New in Readest** changelog is auto-translated in place. Until now the translation *replaced* the source English notes, so there was no way to read the original text and no indication the notes were machine-translated.

This adds a **Show original** toggle to the Changelog heading. It keeps the original English notes alongside the translation and lets the reader flip between them.

## How

- `Changelog` now carries an optional `translatedNotes` field; the translation loop writes there instead of overwriting `notes`, so the source English is preserved.
- A `showOriginal` state drives which set of notes renders. The toggle button (`Show original` / `Show translation`) appears only when a translation actually ran (`translatedNotes` present), so English locales and translation failures are byte-for-byte unchanged.
- Added `Show original` / `Show translation` to all 33 non-English locale files.

## Behavior

- Non-English locale: default shows the translated notes with a **Show original** button; clicking swaps every entry to the original English and the label becomes **Show translation**.
- English locale (or all translations failed): no toggle, identical to before.

## Testing

- New component test `src/__tests__/components/UpdaterWindow.test.tsx`: asserts the toggle swaps translated <-> original and that no toggle renders for an English locale (written test-first).
- `pnpm test` (components + updater suites): 419 passed.
- `pnpm lint` (tsgo + Biome): clean.
- `pnpm check:translations`: all strings translated.
- Verified live in Chrome (web build) with the locale set to Chinese: default renders the translated changelog with a **Show original** toggle; toggling flips to the original English and back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)