### PR TITLE
fix(reader): support offline dictionary pronunciation

### DIFF
--- a/apps/readest-app/src/__tests__/services/tts/wordPronouncer.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/wordPronouncer.test.ts
@@ -5,8 +5,8 @@
  * synthesizes via EdgeSpeechTTS directly (no throwaway init synth), plays on a
  * dedicated Web Audio context, and drops to the platform speech client
  * (Web Speech on desktop/web, native on the mobile app) when Edge is
- * unavailable. These tests pin that Edge-first / fallback-on-failure contract
- * and the language -> Edge voice selection.
+ * unavailable. These tests pin online Edge playback, direct offline platform
+ * speech, fallback-on-failure, and the language -> Edge voice selection.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -99,6 +99,7 @@ beforeEach(() => {
   tauriPlatform = false;
   vi.clearAllMocks();
   (globalThis as unknown as { AudioContext: unknown }).AudioContext = vi.fn();
+  Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
   h.createAudioData.mockReset();
 });
 
@@ -149,7 +150,19 @@ describe('pronounceWord — Edge path', () => {
   });
 });
 
-describe('pronounceWord — fallback path', () => {
+describe('pronounceWord — platform speech path', () => {
+  it('uses Web Speech without contacting Edge when the device is offline', async () => {
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+    const onStatus = vi.fn();
+
+    await pronounceWord('hello', 'en', {}, onStatus);
+    await flush();
+
+    expect(h.createAudioData).not.toHaveBeenCalled();
+    expect(h.webSpeak).toHaveBeenCalledTimes(1);
+    expect(onStatus).toHaveBeenLastCalledWith('ended');
+  });
+
   it('drops to Web Speech on desktop/web when Edge fails', async () => {
     h.createAudioData.mockRejectedValue(new Error('wss blocked'));
     const onStatus = vi.fn();

--- a/apps/readest-app/src/services/tts/wordPronouncer.ts
+++ b/apps/readest-app/src/services/tts/wordPronouncer.ts
@@ -15,8 +15,8 @@ import type { TTSAudioContext } from './WebAudioPlayer';
 // trip synthesizing "test") and never spins up a full speaking session — it
 // calls EdgeSpeechTTS directly (whose static MP3 cache makes repeat words
 // instant) and schedules one chunk on a dedicated Web Audio context. Edge is
-// tried first (wss, then the authenticated https proxy); any failure drops to
-// the platform speech client so a word still speaks offline. See issue #4876.
+// tried first while online (wss, then the authenticated https proxy); offline
+// requests and Edge failures use the platform speech client. See issue #4876.
 
 const EDGE_TTS_NAME = 'edge-tts';
 const DEFAULT_EDGE_VOICE = 'en-US-AriaNeural';
@@ -160,7 +160,8 @@ export const pronounceWord = async (
   stopFallback();
 
   const player = getPlayer();
-  if (player) {
+  const isOffline = typeof navigator !== 'undefined' && navigator.onLine === false;
+  if (player && !isOffline) {
     try {
       const voice = pickEdgeVoiceId(voiceLang);
       const data = await fetchEdgeAudio({


### PR DESCRIPTION
## Summary
- skip Edge network synthesis when the device reports that it is offline
- use native TTS on mobile or Web Speech on desktop/web for offline dictionary pronunciation
- preserve the existing Edge-first behavior while online and platform fallback when Edge fails

## Testing
- `pnpm test` (7,672 passed, 7 skipped)
- `pnpm lint`
- `pnpm -w format:check`
- `vitest run src/__tests__/services/tts/wordPronouncer.test.ts`

## Review
- Pre-landing review: no issues found