### PR TITLE
feat(reader): add right-edge swipe to adjust auto scroll speed

### DIFF
--- a/apps/readest-app/src/__tests__/app/autoScrollSpeedGesture.test.ts
+++ b/apps/readest-app/src/__tests__/app/autoScrollSpeedGesture.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_AUTO_SCROLL_SPEED,
+  MIN_AUTO_SCROLL_SPEED,
+  AUTO_SCROLL_SPEED_STEP,
+} from '@/services/constants';
+import {
+  AUTO_SCROLL_GESTURE_ACTIVATION_PX,
+  AUTO_SCROLL_GESTURE_EDGE_RATIO,
+  isInRightEdge,
+  shouldActivate,
+  speedToPosition,
+  computeSpeed,
+} from '@/app/reader/utils/autoScrollSpeedGesture';
+
+describe('autoScrollSpeedGesture pure helpers', () => {
+  describe('isInRightEdge', () => {
+    it('is true on and above the right 10% boundary, false below', () => {
+      const w = 1000;
+      const boundary = w * (1 - AUTO_SCROLL_GESTURE_EDGE_RATIO); // 900
+      expect(isInRightEdge(w, w)).toBe(true);
+      expect(isInRightEdge(boundary, w)).toBe(true); // exactly 900
+      expect(isInRightEdge(boundary - 1, w)).toBe(false);
+    });
+
+    it('is false for a non-positive view width', () => {
+      expect(isInRightEdge(0, 0)).toBe(false);
+      expect(isInRightEdge(5, -10)).toBe(false);
+    });
+  });
+
+  describe('shouldActivate', () => {
+    it('activates only when vertical-dominant past the threshold', () => {
+      const t = AUTO_SCROLL_GESTURE_ACTIVATION_PX;
+      expect(shouldActivate(0, t)).toBe(true); // exactly at threshold, dominant
+      expect(shouldActivate(0, t - 1)).toBe(false); // below threshold
+      expect(shouldActivate(0, -t)).toBe(true); // upward, magnitude counts
+      expect(shouldActivate(10, 20)).toBe(true); // vertical-dominant
+    });
+
+    it('does not activate on horizontal-dominant or tie moves', () => {
+      expect(shouldActivate(30, 20)).toBe(false); // horizontal-dominant
+      expect(shouldActivate(20, 20)).toBe(false); // tie is not "> "
+    });
+  });
+
+  describe('speedToPosition', () => {
+    it('maps the speed range linearly onto [0,1]', () => {
+      expect(speedToPosition(MIN_AUTO_SCROLL_SPEED)).toBeCloseTo(0, 10);
+      expect(speedToPosition(MAX_AUTO_SCROLL_SPEED)).toBeCloseTo(1, 10);
+      const mid = MIN_AUTO_SCROLL_SPEED + (MAX_AUTO_SCROLL_SPEED - MIN_AUTO_SCROLL_SPEED) / 2;
+      expect(speedToPosition(mid)).toBeCloseTo(0.5, 10);
+    });
+
+    it('clamps out-of-range speeds', () => {
+      expect(speedToPosition(0)).toBe(0);
+      expect(speedToPosition(MAX_AUTO_SCROLL_SPEED + 100)).toBe(1);
+    });
+  });
+
+  describe('computeSpeed', () => {
+    it('swiping up (negative deltaY) increases speed; down decreases', () => {
+      const start = 100;
+      expect(computeSpeed(start, -100, 1000)).toBeGreaterThan(start);
+      expect(computeSpeed(start, 100, 1000)).toBeLessThan(start);
+    });
+
+    it('a full view-height upward drag from min reaches max', () => {
+      expect(computeSpeed(MIN_AUTO_SCROLL_SPEED, -1000, 1000)).toBe(MAX_AUTO_SCROLL_SPEED);
+    });
+
+    it('a full view-height downward drag from max reaches min', () => {
+      expect(computeSpeed(MAX_AUTO_SCROLL_SPEED, 1000, 1000)).toBe(MIN_AUTO_SCROLL_SPEED);
+    });
+
+    it('snaps the result to the speed step', () => {
+      expect(computeSpeed(100, -13, 1000) % AUTO_SCROLL_SPEED_STEP).toBe(0);
+      expect(computeSpeed(137, -47, 1000) % AUTO_SCROLL_SPEED_STEP).toBe(0);
+    });
+
+    it('clamps to [min,max]', () => {
+      expect(computeSpeed(MAX_AUTO_SCROLL_SPEED, -500, 1000)).toBe(MAX_AUTO_SCROLL_SPEED);
+      expect(computeSpeed(MIN_AUTO_SCROLL_SPEED, 500, 1000)).toBe(MIN_AUTO_SCROLL_SPEED);
+    });
+
+    it('returns the clamped start when viewHeight is non-positive', () => {
+      expect(computeSpeed(150, -50, 0)).toBe(150);
+      expect(computeSpeed(1000, -50, 0)).toBe(MAX_AUTO_SCROLL_SPEED);
+      expect(computeSpeed(10, -50, 0)).toBe(MIN_AUTO_SCROLL_SPEED);
+    });
+  });
+});

--- a/apps/readest-app/src/app/reader/components/AutoScrollSpeedOverlay.tsx
+++ b/apps/readest-app/src/app/reader/components/AutoScrollSpeedOverlay.tsx
@@ -1,0 +1,59 @@
+import clsx from 'clsx';
+import React from 'react';
+import { MdSpeed } from 'react-icons/md';
+import { speedToPosition } from '@/app/reader/utils/autoScrollSpeedGesture';
+
+interface AutoScrollSpeedOverlayProps {
+  visible: boolean;
+  /** Auto scroll speed as a percentage (25-500). */
+  speed: number;
+}
+
+const isEink = () =>
+  typeof document !== 'undefined' && document.documentElement.getAttribute('data-eink') === 'true';
+
+/**
+ * Transient speed indicator shown at the right edge while the swipe gesture
+ * adjusts the Auto Scroll speed. Mirrors `BrightnessOverlay` on the opposite
+ * edge: its own capsule surface keeps it legible over any book background; on
+ * e-ink it snaps (no continuous animation) and quantizes the fill.
+ */
+const AutoScrollSpeedOverlay: React.FC<AutoScrollSpeedOverlayProps> = ({ visible, speed }) => {
+  const eink = isEink();
+  // Fill height tracks the slider's position; the label shows the percentage.
+  let fillPercent = speedToPosition(speed) * 100;
+  if (eink) {
+    fillPercent = Math.round(fillPercent / 10) * 10;
+  }
+
+  return (
+    <div
+      aria-hidden
+      dir='ltr'
+      className={clsx(
+        'pointer-events-none absolute right-0 top-1/2 z-[15] -translate-y-1/2',
+        'not-eink:transition-opacity not-eink:duration-200 motion-reduce:transition-none',
+        visible ? 'opacity-100' : 'opacity-0',
+      )}
+      style={{ marginInlineEnd: 'calc(env(safe-area-inset-right) + 12px)' }}
+    >
+      <div
+        className={clsx(
+          'eink-bordered flex flex-col items-center gap-2 rounded-full px-2 py-3',
+          'bg-base-100/90 not-eink:shadow-md',
+        )}
+      >
+        <MdSpeed className='text-base-content h-4 w-4' />
+        <div className='bg-base-content/20 relative h-40 w-1.5 overflow-hidden rounded-full'>
+          <div
+            className='bg-base-content absolute bottom-0 left-0 w-full rounded-full'
+            style={{ height: `${fillPercent}%` }}
+          />
+        </div>
+        <span className='text-base-content text-xs tabular-nums'>{speed}%</span>
+      </div>
+    </div>
+  );
+};
+
+export default AutoScrollSpeedOverlay;

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -81,9 +81,11 @@ import { isFontType } from '@/utils/font';
 import { getScrollGapAttr } from '@/utils/webtoon';
 import { useMiddleClickAutoscroll } from '../hooks/useMiddleClickAutoscroll';
 import { useAutoScroll } from '../hooks/useAutoScroll';
+import { useAutoScrollSpeedGesture } from '../hooks/useAutoScrollSpeedGesture';
 import { ParagraphControl } from './paragraph';
 import AutoscrollIndicator from './AutoscrollIndicator';
 import AutoScrollControl from './AutoScrollControl';
+import AutoScrollSpeedOverlay from './AutoScrollSpeedOverlay';
 import Spinner from '@/components/Spinner';
 import KOSyncConflictResolver from './KOSyncResolver';
 import ImageViewer from './ImageViewer';
@@ -143,6 +145,10 @@ const FoliateViewer: React.FC<{
   const navSpinnerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [scrollMargins, setScrollMargins] = useState({ top: 0, bottom: 0 });
   const docLoaded = useRef(false);
+
+  const autoScroll = useAutoScroll(bookKey, viewRef);
+  const { registerSpeedListeners, overlayVisible: speedOverlayVisible } =
+    useAutoScrollSpeedGesture(autoScroll);
 
   // A pending anti-flash timer must not fire setNavigating on an unmounted component.
   useEffect(() => {
@@ -431,6 +437,7 @@ const FoliateViewer: React.FC<{
         detail.doc.addEventListener('touchend', handleTouchEnd.bind(null, bookKey));
         detail.doc.addEventListener('touchcancel', handleTouchCancel.bind(null, bookKey));
         registerBrightnessListeners(detail.doc);
+        registerSpeedListeners(detail.doc);
       }
     }
   };
@@ -546,7 +553,6 @@ const FoliateViewer: React.FC<{
   const mouseHandlers = useMouseEvent(bookKey, handlePageFlip);
   const touchHandlers = useTouchEvent(bookKey);
   const autoscrollAnchor = useMiddleClickAutoscroll(bookKey, viewRef, containerRef);
-  const autoScroll = useAutoScroll(bookKey, viewRef);
 
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [selectedTableHtml, setSelectedTableHtml] = useState<string | null>(null);
@@ -1053,6 +1059,9 @@ const FoliateViewer: React.FC<{
         />
       )}
       <BrightnessOverlay visible={overlayVisible} level={overlayLevel} />
+      {autoScroll.active && (
+        <AutoScrollSpeedOverlay visible={speedOverlayVisible} speed={autoScroll.speed} />
+      )}
       <ParagraphControl bookKey={bookKey} viewRef={viewRef} gridInsets={gridInsets} />
       {((!docLoaded.current && loading) || navigating || viewState?.loading) && (
         <div className='absolute left-0 top-0 z-10 flex h-full w-full items-center justify-center'>

--- a/apps/readest-app/src/app/reader/hooks/useAutoScroll.ts
+++ b/apps/readest-app/src/app/reader/hooks/useAutoScroll.ts
@@ -24,6 +24,7 @@ export interface AutoScrollState {
   speed: number;
   togglePause: () => void;
   adjustSpeed: (dir: 1 | -1) => void;
+  setSpeed: (value: number, persist?: boolean) => void;
   stop: () => void;
 }
 
@@ -43,7 +44,7 @@ export const useAutoScroll = (
   const viewSettings = getViewSettings(bookKey);
   const [active, setActive] = useState(false);
   const [paused, setPaused] = useState(false);
-  const [speed, setSpeed] = useState(viewSettings?.autoScrollSpeed ?? 100);
+  const [speed, setSpeedState] = useState(viewSettings?.autoScrollSpeed ?? 100);
 
   // Undoes the per-session window listeners; set on start.
   const sessionCleanupRef = useRef<(() => void) | null>(null);
@@ -100,15 +101,21 @@ export const useAutoScroll = (
     setPaused(scroller.paused);
   };
 
-  const adjustSpeed = (dir: 1 | -1) => {
-    const current = getViewSettings(bookKey)?.autoScrollSpeed ?? speed;
+  // Commit a speed (percent). `persist` off skips the settings write, for the
+  // per-frame updates of a continuous drag; the release persists once.
+  const setSpeed = (value: number, persist = true) => {
     const next = Math.min(
       MAX_AUTO_SCROLL_SPEED,
-      Math.max(MIN_AUTO_SCROLL_SPEED, current + dir * AUTO_SCROLL_SPEED_STEP),
+      Math.max(MIN_AUTO_SCROLL_SPEED, Math.round(value)),
     );
-    setSpeed(next);
+    setSpeedState(next);
     scrollerRef.current!.setVelocity((AUTO_SCROLL_BASE_PX_PER_SEC * next) / 100);
-    saveViewSettings(envConfig, bookKey, 'autoScrollSpeed', next, false, false);
+    if (persist) saveViewSettings(envConfig, bookKey, 'autoScrollSpeed', next, false, false);
+  };
+
+  const adjustSpeed = (dir: 1 | -1) => {
+    const current = getViewSettings(bookKey)?.autoScrollSpeed ?? speed;
+    setSpeed(current + dir * AUTO_SCROLL_SPEED_STEP);
   };
 
   const startSession = () => {
@@ -116,7 +123,7 @@ export const useAutoScroll = (
     const renderer = viewRef.current?.renderer;
     if (!renderer?.scrolled) return;
     const speedNow = getViewSettings(bookKey)?.autoScrollSpeed ?? 100;
-    setSpeed(speedNow);
+    setSpeedState(speedNow);
     stallStartRef.current = null;
     scroller.start((AUTO_SCROLL_BASE_PX_PER_SEC * speedNow) / 100);
     setActive(true);
@@ -177,6 +184,7 @@ export const useAutoScroll = (
     speed,
     togglePause,
     adjustSpeed,
+    setSpeed,
     stop: () => scrollerRef.current?.stop(),
   };
 };

--- a/apps/readest-app/src/app/reader/hooks/useAutoScrollSpeedGesture.ts
+++ b/apps/readest-app/src/app/reader/hooks/useAutoScrollSpeedGesture.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  computeSpeed,
+  isInRightEdge,
+  shouldActivate,
+} from '@/app/reader/utils/autoScrollSpeedGesture';
+import { AutoScrollState } from './useAutoScroll';
+
+const OVERLAY_HIDE_DELAY_MS = 600;
+
+/**
+ * Right-edge swipe-to-adjust-auto-scroll-speed gesture (touch).
+ *
+ * Mirrors `useBrightnessGesture` on the opposite edge, but is armed only while
+ * an Auto Scroll session is active. Attaches capture-phase, non-passive touch
+ * listeners to the foliate iframe document once; capture phase is required so
+ * an active gesture's `stopImmediatePropagation` can suppress foliate-js's own
+ * bubble-phase paginator listeners. Everything runtime-variable is read through
+ * `latestRef` (updated each render).
+ *
+ * The transient capsule shows the live speed (`autoScroll.speed`); this hook
+ * only owns its visibility.
+ */
+export const useAutoScrollSpeedGesture = (autoScroll: AutoScrollState) => {
+  const [overlayVisible, setOverlayVisible] = useState(false);
+
+  // The once-attached listener reads the latest session state and setter here.
+  const latestRef = useRef(autoScroll);
+  latestRef.current = autoScroll;
+
+  // Per-gesture state.
+  const armedRef = useRef(false);
+  const activeRef = useRef(false);
+  const startXRef = useRef(0);
+  const startYRef = useRef(0);
+  const viewHeightRef = useRef(0);
+  const startSpeedRef = useRef(0);
+  const lastSpeedRef = useRef(0);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const resetGesture = useCallback(() => {
+    armedRef.current = false;
+    activeRef.current = false;
+  }, []);
+
+  const registerSpeedListeners = useCallback(
+    (doc: Document) => {
+      const opts = { capture: true, passive: false } as const;
+
+      const onTouchStart = (e: TouchEvent) => {
+        resetGesture();
+        if (!latestRef.current.active) return;
+        const selection = doc.getSelection?.();
+        if (selection && !selection.isCollapsed) return; // don't hijack selection
+        const t = e.touches[0];
+        if (!t) return;
+        // Use screenX/screenY, not clientX/clientY: in scrolled mode the iframe
+        // document is many screens tall, and this listener runs in the parent
+        // realm, so screen coordinates match the app viewport.
+        const viewWidth = window.innerWidth;
+        viewHeightRef.current = window.innerHeight;
+        startXRef.current = t.screenX;
+        startYRef.current = t.screenY;
+        armedRef.current = isInRightEdge(t.screenX, viewWidth);
+        startSpeedRef.current = latestRef.current.speed;
+      };
+
+      const onTouchMove = (e: TouchEvent) => {
+        if (!armedRef.current) return;
+        const t = e.touches[0];
+        if (!t) return;
+        const dx = t.screenX - startXRef.current;
+        const dy = t.screenY - startYRef.current;
+        // Reserve the strip: stop the native (paced) scroll from the first move,
+        // so there is no scroll-then-freeze jump once speed control activates.
+        e.preventDefault();
+        if (!activeRef.current && shouldActivate(dx, dy)) {
+          activeRef.current = true;
+        }
+        if (!activeRef.current) return;
+        e.stopImmediatePropagation();
+        const value = computeSpeed(startSpeedRef.current, dy, viewHeightRef.current);
+        lastSpeedRef.current = value;
+        latestRef.current.setSpeed(value, false);
+        setOverlayVisible(true);
+      };
+
+      const onTouchEnd = (e: TouchEvent) => {
+        if (!activeRef.current) {
+          resetGesture();
+          return;
+        }
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        latestRef.current.setSpeed(lastSpeedRef.current, true);
+        if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = setTimeout(() => setOverlayVisible(false), OVERLAY_HIDE_DELAY_MS);
+        resetGesture();
+      };
+
+      doc.addEventListener('touchstart', onTouchStart, opts);
+      doc.addEventListener('touchmove', onTouchMove, opts);
+      doc.addEventListener('touchend', onTouchEnd, opts);
+      doc.addEventListener('touchcancel', onTouchEnd, opts);
+    },
+    [resetGesture],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    };
+  }, []);
+
+  return { registerSpeedListeners, overlayVisible };
+};

--- a/apps/readest-app/src/app/reader/utils/autoScrollSpeedGesture.ts
+++ b/apps/readest-app/src/app/reader/utils/autoScrollSpeedGesture.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure helpers for the right-edge swipe-to-adjust-auto-scroll-speed gesture.
+ *
+ * Mirrors the left-edge brightness gesture (`brightnessGesture.ts`) but on the
+ * opposite edge and only while an Auto Scroll session is active. The gesture
+ * reserves the right `AUTO_SCROLL_GESTURE_EDGE_RATIO` of the rendered
+ * iframe-document width; once a touch that starts there becomes
+ * vertical-dominant past `AUTO_SCROLL_GESTURE_ACTIVATION_PX`, finger travel maps
+ * linearly onto the speed range and snaps to `AUTO_SCROLL_SPEED_STEP` so the
+ * gesture and the −/+ pill land on the same values.
+ */
+
+import {
+  AUTO_SCROLL_SPEED_STEP,
+  MAX_AUTO_SCROLL_SPEED,
+  MIN_AUTO_SCROLL_SPEED,
+} from '@/services/constants';
+
+export const AUTO_SCROLL_GESTURE_EDGE_RATIO = 0.1;
+export const AUTO_SCROLL_GESTURE_ACTIVATION_PX = 18;
+
+const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
+
+const clampSpeed = (speed: number): number =>
+  Math.max(MIN_AUTO_SCROLL_SPEED, Math.min(MAX_AUTO_SCROLL_SPEED, speed));
+
+/** True when `clientX` falls within the right edge strip of the view. */
+export const isInRightEdge = (
+  clientX: number,
+  viewWidth: number,
+  edgeRatio = AUTO_SCROLL_GESTURE_EDGE_RATIO,
+): boolean => viewWidth > 0 && clientX >= viewWidth * (1 - edgeRatio);
+
+/** True when movement is vertical-dominant and past the activation threshold. */
+export const shouldActivate = (
+  deltaX: number,
+  deltaY: number,
+  threshold = AUTO_SCROLL_GESTURE_ACTIVATION_PX,
+): boolean => Math.abs(deltaY) >= threshold && Math.abs(deltaY) > Math.abs(deltaX);
+
+/** Perceptual position (0-1) for a speed, linear across [min, max]. */
+export const speedToPosition = (speed: number): number =>
+  clamp01(
+    (clampSpeed(speed) - MIN_AUTO_SCROLL_SPEED) / (MAX_AUTO_SCROLL_SPEED - MIN_AUTO_SCROLL_SPEED),
+  );
+
+/**
+ * New speed after dragging `deltaY` px from `startSpeed`.
+ *
+ * Up (negative `deltaY`) speeds up. A full view-height drag spans the whole
+ * range. Travel is linear in position, then converted back to a speed and
+ * snapped to the step so it matches the pill's increments.
+ */
+export const computeSpeed = (startSpeed: number, deltaY: number, viewHeight: number): number => {
+  if (viewHeight <= 0) return clampSpeed(startSpeed);
+  const startPos = speedToPosition(startSpeed);
+  const nextPos = clamp01(startPos - deltaY / viewHeight);
+  const raw = MIN_AUTO_SCROLL_SPEED + nextPos * (MAX_AUTO_SCROLL_SPEED - MIN_AUTO_SCROLL_SPEED);
+  return clampSpeed(Math.round(raw / AUTO_SCROLL_SPEED_STEP) * AUTO_SCROLL_SPEED_STEP);
+};


### PR DESCRIPTION
## Summary

Adds a right-edge swipe gesture to adjust the Auto Scroll speed, mirroring the existing left-edge brightness gesture. It is available only while an Auto Scroll session is active.

- Swipe up/down in the right edge strip to change speed; a transient capsule (speedometer icon + vertical fill + percentage) appears while dragging and fades shortly after release.
- Travel maps linearly across the 25-500% range and snaps to the existing 25% step, so the gesture and the -/+ speed pill land on the same values.
- Speed applies live during the drag and persists on release.
- Touch only by nature (desktop keeps the pill). The left strip stays brightness, the right strip is speed, so they never overlap. During normal reading (no active session) the right strip is not reserved.

## Implementation

- `autoScrollSpeedGesture.ts` - pure helpers (right-edge detection, vertical-dominance activation, linear speed mapping), unit tested.
- `useAutoScrollSpeedGesture.ts` - capture-phase touch listeners on the foliate iframe document, mirroring `useBrightnessGesture`; armed only when the session is active, reserves the strip in scrolled mode.
- `AutoScrollSpeedOverlay.tsx` - the right-edge transient capsule, mirror of `BrightnessOverlay` (safe-area and e-ink aware).
- `useAutoScroll.ts` - new public `setSpeed(value, persist?)`; `adjustSpeed` (the pill) now routes through it so gesture and buttons share one commit path.

## Test plan

- `pnpm test` full suite green (7684 passed)
- `pnpm lint` (tsgo + Biome) and `pnpm format:check` clean (enforced by the pre-push hook)
- New unit tests: `src/__tests__/app/autoScrollSpeedGesture.test.ts` (12 cases)
- Note: not yet exercised on a physical touch device; the gesture mirrors the already-shipped brightness gesture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)