### PR TITLE
fix(applock): hide PIN entry while the biometric sheet is on screen

### DIFF
--- a/apps/readest-app/src/__tests__/components/AppLockScreen.test.tsx
+++ b/apps/readest-app/src/__tests__/components/AppLockScreen.test.tsx
@@ -76,4 +76,45 @@ describe('AppLockScreen biometric gate', () => {
     expect(authenticateWithBiometricsMock).not.toHaveBeenCalled();
     expect(screen.queryByRole('button', { name: /Use/ })).toBeNull();
   });
+
+  it('hides the PIN entry on mount while the biometric check is pending', () => {
+    // getBiometricStatus resolves on a later microtask, so on the first
+    // render the biometric attempt is still pending and the PIN entry must
+    // not show behind the incoming system sheet.
+    render(<AppLockScreen />);
+    expect(screen.queryByText('Enter your PIN')).toBeNull();
+    expect(screen.queryByLabelText('PIN code')).toBeNull();
+  });
+
+  it('keeps the PIN entry hidden while the biometric prompt is in flight', async () => {
+    let resolveAuth: (v: boolean) => void = () => {};
+    authenticateWithBiometricsMock.mockReturnValue(
+      new Promise<boolean>((res) => {
+        resolveAuth = res;
+      }),
+    );
+    render(<AppLockScreen />);
+    await waitFor(() => expect(authenticateWithBiometricsMock).toHaveBeenCalledTimes(1));
+    // System Face ID sheet is up — the PIN entry must stay hidden behind it.
+    expect(screen.queryByText('Enter your PIN')).toBeNull();
+    expect(screen.queryByLabelText('PIN code')).toBeNull();
+    // Dismiss/fail the sheet — now the PIN fallback is revealed.
+    resolveAuth(false);
+    await waitFor(() => expect(screen.getByLabelText('PIN code')).toBeTruthy());
+    expect(screen.getByText('Enter your PIN')).toBeTruthy();
+  });
+
+  it('shows the PIN entry immediately when biometric is unsupported', () => {
+    isSupported = false;
+    render(<AppLockScreen />);
+    expect(screen.getByLabelText('PIN code')).toBeTruthy();
+    expect(screen.getByText('Enter your PIN')).toBeTruthy();
+  });
+
+  it('shows the PIN entry immediately when biometric unlock is disabled', () => {
+    biometricUnlockEnabled = false;
+    render(<AppLockScreen />);
+    expect(screen.getByLabelText('PIN code')).toBeTruthy();
+    expect(screen.getByText('Enter your PIN')).toBeTruthy();
+  });
 });

--- a/apps/readest-app/src/components/AppLockScreen.tsx
+++ b/apps/readest-app/src/components/AppLockScreen.tsx
@@ -25,6 +25,14 @@ export default function AppLockScreen() {
   const [error, setError] = useState('');
   const [shaking, setShaking] = useState(false);
   const [kbInset, setKbInset] = useState(0);
+  // Keep the PIN entry hidden while a biometric attempt is pending or its
+  // native sheet is on screen, so the user only ever sees one unlock method
+  // at a time (the system Face ID / Touch ID sheet, then the PIN fallback).
+  // Seeded from the synchronous platform check so the PIN never flashes
+  // before the sheet on a biometric-enabled launch.
+  const [biometricBusy, setBiometricBusy] = useState(
+    () => isBiometricSupported(appService) && !!biometricUnlockEnabled,
+  );
   const biometricAttemptedRef = useRef(false);
   const biometricInFlightRef = useRef(false);
   const autoFocusEnabled = !appService?.isMobile;
@@ -32,16 +40,21 @@ export default function AppLockScreen() {
   const runBiometric = async () => {
     if (biometricInFlightRef.current) return;
     biometricInFlightRef.current = true;
+    setBiometricBusy(true);
     try {
       const ok = await authenticateWithBiometrics(_('Unlock Readest'));
       if (ok) unlock();
     } finally {
       biometricInFlightRef.current = false;
+      setBiometricBusy(false);
     }
   };
 
   useEffect(() => {
-    if (!isBiometricSupported(appService)) return;
+    if (!isBiometricSupported(appService)) {
+      setBiometricBusy(false);
+      return;
+    }
     let cancelled = false;
     void (async () => {
       const { available, biometryType } = await getBiometricStatus();
@@ -53,9 +66,13 @@ export default function AppLockScreen() {
           available,
         })
       ) {
+        setBiometricBusy(false);
         return;
       }
       setBiometryLabel(_(getBiometryLabelKey(biometryType)));
+      // Already attempted (the effect can re-run): leave `biometricBusy`
+      // to `runBiometric`'s own finally so a re-run can't reveal the PIN
+      // while the first attempt's native sheet is still in flight.
       if (biometricAttemptedRef.current) return;
       biometricAttemptedRef.current = true;
       await runBiometric();
@@ -122,52 +139,54 @@ export default function AppLockScreen() {
       aria-modal='true'
       aria-label={_('App locked')}
     >
-      <div className='flex max-w-sm flex-col items-center text-center'>
-        <h1 className='text-base-content mb-2 text-xl font-semibold tracking-tight'>
-          {_('Enter your PIN')}
-        </h1>
-        <p className='text-base-content/60 mb-8 text-sm leading-relaxed'>
-          {_('Readest is locked. Enter your 4-digit PIN to continue.')}
-        </p>
+      {!biometricBusy && (
+        <div className='flex max-w-sm flex-col items-center text-center'>
+          <h1 className='text-base-content mb-2 text-xl font-semibold tracking-tight'>
+            {_('Enter your PIN')}
+          </h1>
+          <p className='text-base-content/60 mb-8 text-sm leading-relaxed'>
+            {_('Readest is locked. Enter your 4-digit PIN to continue.')}
+          </p>
 
-        <PinInput
-          value={pin}
-          onChange={handleChange}
-          ariaLabel={_('PIN code')}
-          stickyFocus={autoFocusEnabled}
-          shake={shaking}
-        />
+          <PinInput
+            value={pin}
+            onChange={handleChange}
+            ariaLabel={_('PIN code')}
+            stickyFocus={autoFocusEnabled}
+            shake={shaking}
+          />
 
-        <p
-          className={clsx(
-            'text-error mt-4 h-5 text-sm transition-opacity',
-            error ? 'opacity-100' : 'opacity-0',
-          )}
-          aria-live='polite'
-        >
-          {error || ' '}
-        </p>
-
-        {biometryLabel && (
-          <button
-            type='button'
-            onClick={runBiometric}
+          <p
             className={clsx(
-              'eink-bordered',
-              'mt-2 h-10 rounded-lg px-4 text-sm font-medium',
-              'text-base-content hover:bg-base-200 transition-colors duration-150',
+              'text-error mt-4 h-5 text-sm transition-opacity',
+              error ? 'opacity-100' : 'opacity-0',
             )}
+            aria-live='polite'
           >
-            {_('Use {{biometry}}', { biometry: biometryLabel })}
-          </button>
-        )}
+            {error || ' '}
+          </p>
 
-        <p className='text-base-content/40 mt-10 text-xs leading-relaxed'>
-          {_(
-            "Forgetting your PIN locks you out of this device. You'll need to clear the app's data to reset it.",
+          {biometryLabel && (
+            <button
+              type='button'
+              onClick={runBiometric}
+              className={clsx(
+                'eink-bordered',
+                'mt-2 h-10 rounded-lg px-4 text-sm font-medium',
+                'text-base-content hover:bg-base-200 transition-colors duration-150',
+              )}
+            >
+              {_('Use {{biometry}}', { biometry: biometryLabel })}
+            </button>
           )}
-        </p>
-      </div>
+
+          <p className='text-base-content/40 mt-10 text-xs leading-relaxed'>
+            {_(
+              "Forgetting your PIN locks you out of this device. You'll need to clear the app's data to reset it.",
+            )}
+          </p>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Problem

On iOS/Android launch with biometric unlock enabled, the native Face ID / Touch ID system sheet is presented **on top of** the app's "Enter your PIN" screen, so both unlock methods are visible at once:

<img src="https://github.com/user-attachments/assets/placeholder" alt="Face ID sheet over the PIN screen" width="240" />

Only one unlock method should be shown at a time.

## Fix

Gate the PIN entry on a new `biometricBusy` state in `AppLockScreen`:

- Stays `true` while a biometric attempt is pending or its native sheet is in flight, and clears once biometrics succeeds, fails, cancels, or will not run.
- Seeded from the synchronous `isBiometricSupported(appService) && biometricUnlockEnabled` check so the PIN never flashes before the sheet on a biometric-enabled launch.
- `runBiometric`'s `finally` is the single owner of clearing the flag after an attempt, so a re-run of the `[appService]` effect cannot reveal the PIN while the first sheet is still up.

Result: **Face ID/Touch ID sheet up -> PIN hidden. Sheet fails/cancels -> PIN revealed.** One method, never both.

Desktop and web are unchanged: without biometric support the flag starts `false` and the PIN entry shows immediately.

## Tests

Added to `AppLockScreen.test.tsx` (written test-first, confirmed failing before the fix):

- PIN entry hidden on mount while the biometric check is pending
- PIN entry hidden while the native sheet is in flight, then revealed after it fails
- PIN entry shown immediately when biometrics is unsupported
- PIN entry shown immediately when biometric unlock is disabled

## Verification

- `pnpm test` full suite green (7655 passed)
- `pnpm lint` (Biome + tsgo) clean

Note: the native biometric plugin is mobile-only, so the launch flow needs a final check on a real iOS/Android device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)