### PR TITLE
fix(reader): draw the theme background on the curl back face

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -1587,7 +1587,7 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
                             pluginScope.launch {
                                 val data = withContext(Dispatchers.IO) {
                                     val out = ByteArrayOutputStream()
-                                    bitmap.compress(Bitmap.CompressFormat.JPEG, 85, out)
+                                    bitmap.compress(Bitmap.CompressFormat.JPEG, 90, out)
                                     Base64.encodeToString(out.toByteArray(), Base64.NO_WRAP)
                                 }
                                 invoke.resolve(JSObject().put("data", data))

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
@@ -1655,7 +1655,7 @@ class NativeBridgePlugin: Plugin {
         // Encode and base64 off the main thread; the completion arrives on
         // main and a full-screen encode is fast but not free.
         DispatchQueue.global(qos: .userInteractive).async {
-          guard let data = image.jpegData(compressionQuality: 0.85) else {
+          guard let data = image.jpegData(compressionQuality: 0.9) else {
             return invoke.reject("JPEG encoding failed")
           }
           invoke.resolve(["data": data.base64EncodedString()])

--- a/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
@@ -131,6 +131,43 @@ describe('CapturedPageTurn (browser)', () => {
     expect(host.querySelector('canvas')).toBeNull();
   });
 
+  it('draws the host backdrop on the back of the curling page', async () => {
+    const paper = document.createElement('canvas');
+    paper.width = W;
+    paper.height = H;
+    const ctx = paper.getContext('2d')!;
+    ctx.fillStyle = 'rgb(20, 20, 20)';
+    ctx.fillRect(0, 0, W, H);
+    const getBackdrop = vi.fn(() => paper);
+    const withBackdrop = new CapturedPageTurn(
+      { getHostElement: () => host, getContentRect: contentRect, capture, navigate, getBackdrop },
+      { duration: 5000 },
+    );
+
+    expect(await withBackdrop.beginDrag(true, false)).toBe(true);
+    expect(getBackdrop).toHaveBeenCalledOnce();
+    withBackdrop.moveDrag(0.45, 0.5);
+
+    // The wrapped-over back face shows the red page mixed toward the dark
+    // theme paper — the hardcoded whitened back would read near-white here.
+    const canvas = host.querySelector('canvas')!;
+    const gl = canvas.getContext('webgl')!;
+    const dpr = window.devicePixelRatio;
+    const px = new Uint8Array(4);
+    gl.readPixels(
+      Math.round(100 * dpr),
+      canvas.height - 1 - Math.round(60 * dpr),
+      1,
+      1,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      px,
+    );
+    expect(px[3]).toBe(255);
+    expect(px[0]).toBeLessThan(100);
+    withBackdrop.dispose();
+  });
+
   it('uses the official WebGL mesh renderer for curl turns', async () => {
     const slow = new CapturedPageTurn(
       { getHostElement: () => host, getContentRect: contentRect, capture, navigate },

--- a/apps/readest-app/src/__tests__/utils/page-curl.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/page-curl.browser.test.ts
@@ -96,6 +96,30 @@ describe('PageCurlRenderer (browser)', () => {
     expect(front[0]).toBeLessThan(120);
   });
 
+  it('tints the folded back with the backdrop paper instead of white', () => {
+    const paper = document.createElement('canvas');
+    paper.width = W;
+    paper.height = H;
+    const ctx = paper.getContext('2d')!;
+    ctx.fillStyle = 'rgb(20, 20, 20)';
+    ctx.fillRect(0, 0, W, H);
+    renderer.setBackdrop(paper);
+    renderer.render(0.45, { x: 1, y: 0.5 });
+
+    // Same wrapped-over sample point as the whitened-back test: with a dark
+    // theme backdrop the mirrored blue content mixes toward the dark paper,
+    // not toward white.
+    const back = renderer.readPixel(100, 75);
+    expect(back[3]).toBe(255);
+    expect(back[0]).toBeLessThan(60);
+    expect(back[2]).toBeGreaterThan(35); // faint blue remainder
+    expect(back[2]).toBeLessThan(90);
+
+    // The flat front is not tinted by the backdrop.
+    const front = renderer.readPixel(12, 75);
+    expect(front[1]).toBeGreaterThan(100);
+  });
+
   it('fully clears the page at progress 1', () => {
     renderer.render(1, { x: 1, y: 0.5 });
     for (const x of [20, W / 2, W - 20]) {

--- a/apps/readest-app/src/__tests__/utils/turn-backdrop.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/turn-backdrop.browser.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderTurnBackdrop } from '@/app/reader/utils/turnBackdrop';
+
+// Tests for the captured-turn backdrop painter: the "paper" shown on the
+// back of the WebGL page curl. It must reproduce the theme background —
+// the solid theme color plus the active background texture composited the
+// way the viewer's ::before layer draws it (blend mode, opacity).
+
+const readPixel = (canvas: HTMLCanvasElement, x: number, y: number) =>
+  Array.from(canvas.getContext('2d')!.getImageData(x, y, 1, 1).data);
+
+const solidPngUrl = (r: number, g: number, b: number) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 4;
+  canvas.height = 4;
+  const ctx = canvas.getContext('2d')!;
+  ctx.fillStyle = `rgb(${r}, ${g}, ${b})`;
+  ctx.fillRect(0, 0, 4, 4);
+  return canvas.toDataURL('image/png');
+};
+
+describe('renderTurnBackdrop (browser)', () => {
+  const mounted: Element[] = [];
+  const mount = <T extends Element>(el: T): T => {
+    document.body.appendChild(el);
+    mounted.push(el);
+    return el;
+  };
+
+  afterEach(() => {
+    for (const el of mounted.splice(0)) el.remove();
+  });
+
+  it('paints the plain theme color when no texture is active', async () => {
+    const viewer = mount(document.createElement('div'));
+    const canvas = await renderTurnBackdrop(viewer, 'rgb(30, 40, 50)', 60, 40);
+    expect(canvas).not.toBeNull();
+    expect(readPixel(canvas!, 30, 20)).toEqual([30, 40, 50, 255]);
+  });
+
+  it('composites the ::before texture with its blend mode and opacity', async () => {
+    const style = mount(document.createElement('style'));
+    style.textContent = `
+      .backdrop-tex::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background-image: url("${solidPngUrl(100, 100, 100)}");
+        background-size: cover;
+        mix-blend-mode: lighten;
+        opacity: 0.5;
+      }
+    `;
+    const viewer = mount(document.createElement('div'));
+    viewer.className = 'backdrop-tex';
+
+    const canvas = await renderTurnBackdrop(viewer, 'rgb(40, 40, 40)', 64, 48);
+    expect(canvas).not.toBeNull();
+    // lighten(40, 100) = 100, layered at 0.5 over the base 40 -> 70.
+    const [r, g, b, a] = readPixel(canvas!, 32, 24);
+    expect(a).toBe(255);
+    for (const channel of [r, g, b]) {
+      expect(channel).toBeGreaterThan(66);
+      expect(channel).toBeLessThan(74);
+    }
+  });
+
+  it('falls back to the plain color when the texture image cannot load', async () => {
+    const style = mount(document.createElement('style'));
+    style.textContent = `
+      .backdrop-broken::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background-image: url("data:image/png;base64,broken");
+      }
+    `;
+    const viewer = mount(document.createElement('div'));
+    viewer.className = 'backdrop-broken';
+
+    const canvas = await renderTurnBackdrop(viewer, 'rgb(10, 20, 30)', 20, 20);
+    expect(canvas).not.toBeNull();
+    expect(readPixel(canvas!, 10, 10)).toEqual([10, 20, 30, 255]);
+  });
+});

--- a/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
+++ b/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
@@ -4,10 +4,12 @@ import { FoliateView } from '@/types/view';
 import { ViewSettings } from '@/types/book';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useReaderStore } from '@/store/readerStore';
+import { useThemeStore } from '@/store/themeStore';
 import { captureWebviewRegion } from '@/utils/bridge';
 import { isTauriAppPlatform } from '@/services/environment';
 import { detectViewTransitionGroup } from '@/utils/viewTransition';
 import { CapturedPageTurn, CapturedTurnStyle } from '../utils/capturedTurn';
+import { renderTurnBackdrop } from '../utils/turnBackdrop';
 import {
   setLayeredTurnGestureActive,
   TOUCH_SWIPE_THRESHOLD_PX,
@@ -205,6 +207,19 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
         restoreToolbarOnCancelRef.current = useReaderStore.getState().hoveredBookKey === bookKey;
       },
       capture: captureWebviewRegion,
+      getBackdrop: () => {
+        const cell = document.getElementById(`gridcell-${bookKey}`);
+        const rect = cell?.getBoundingClientRect();
+        if (!cell || !rect) return null;
+        // The back of the curl shows the theme paper: the background color
+        // plus the texture layer painted on the viewer's ::before.
+        return renderTurnBackdrop(
+          cell.querySelector('.foliate-viewer'),
+          useThemeStore.getState().themeCode.bg,
+          rect.width,
+          rect.height,
+        );
+      },
       onCovered: async () => {
         // Let the flat canvas reach the compositor before touching the live
         // chrome; otherwise the toolbar can flash out before its captured copy

--- a/apps/readest-app/src/app/reader/utils/capturedTurn.ts
+++ b/apps/readest-app/src/app/reader/utils/capturedTurn.ts
@@ -37,6 +37,12 @@ export interface CapturedTurnHost {
   getContentRect: () => DOMRect | null;
   /** Native webview snapshot of `rect`, as PNG bytes. */
   capture: (rect: { x: number; y: number; width: number; height: number }) => Promise<ArrayBuffer>;
+  /**
+   * Theme paper (background color + texture) drawn on the back of the
+   * curling page. Fetched concurrently with the capture; a missing or
+   * failing backdrop falls back to the renderer's plain white back.
+   */
+  getBackdrop?: () => Promise<TexImageSource | null> | TexImageSource | null;
   /** Records live UI state before the native snapshot starts. */
   onBeforeCapture?: (style: CapturedTurnStyle) => void | Promise<void>;
   /** Called once the flat captured frame covers the live reader. */
@@ -53,6 +59,7 @@ export type CapturedTurnStyle = 'curl' | 'slide';
 interface TurnRenderer {
   attach(container: HTMLElement, width: number, height: number): void;
   setTexture(source: ImageBitmap): void;
+  setBackdrop?(source: TexImageSource): void;
   render(progress: number, grab: CurlGrab, rtl: boolean): void;
   dispose(): void;
 }
@@ -220,6 +227,14 @@ export class CapturedPageTurn {
 
     await this.#host.onBeforeCapture?.(style);
     if (this.#disposed) return null;
+    // Only the curl shows the back of the page; fetch its paper while the
+    // native capture is in flight so it never delays the turn.
+    const backdropPromise =
+      style === 'curl' && this.#host.getBackdrop
+        ? Promise.resolve()
+            .then(() => this.#host.getBackdrop!())
+            .catch(() => null)
+        : null;
     const image = await this.#host.capture({
       x: rect.x,
       y: rect.y,
@@ -231,6 +246,7 @@ export class CapturedPageTurn {
     // JPEG on Android where PNG encoding took ~1.5s per turn) and the
     // decoder sniffs the actual format from the bytes.
     const bitmap = await createImageBitmap(new Blob([image]));
+    const backdrop = backdropPromise ? await backdropPromise : null;
     if (this.#disposed) {
       bitmap.close();
       return null;
@@ -255,6 +271,7 @@ export class CapturedPageTurn {
     try {
       renderer.attach(overlay, rect.width, rect.height);
       renderer.setTexture(bitmap);
+      if (backdrop) renderer.setBackdrop?.(backdrop);
     } catch (error) {
       renderer.dispose();
       overlay.remove();

--- a/apps/readest-app/src/app/reader/utils/turnBackdrop.ts
+++ b/apps/readest-app/src/app/reader/utils/turnBackdrop.ts
@@ -1,0 +1,54 @@
+/**
+ * Paints the theme "paper" shown on the back of the WebGL page curl
+ * (readest#555): the solid theme background color plus the active
+ * background texture, composited the way the viewer's ::before layer draws
+ * it (background-size, mix-blend-mode, opacity). The texture styles are
+ * read from the live ::before pseudo-element so custom textures, blob URLs,
+ * and the user's opacity/size settings all flow through unchanged.
+ */
+export const renderTurnBackdrop = async (
+  viewer: Element | null,
+  bg: string,
+  width: number,
+  height: number,
+): Promise<HTMLCanvasElement | null> => {
+  const w = Math.max(1, Math.round(width));
+  const h = Math.max(1, Math.round(height));
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, w, h);
+
+  const style = viewer ? getComputedStyle(viewer, '::before') : null;
+  const url = style?.backgroundImage.match(/url\("?(.*?)"?\)/)?.[1];
+  if (!style || !url) return canvas;
+  try {
+    const img = new Image();
+    img.src = url;
+    await img.decode();
+    ctx.globalAlpha = parseFloat(style.opacity) || 1;
+    // The multiply/lighten keywords the texture layer uses exist as canvas
+    // composite operations too; anything unsupported leaves source-over.
+    ctx.globalCompositeOperation = style.mixBlendMode as GlobalCompositeOperation;
+    const size = style.backgroundSize;
+    const scale =
+      size === 'cover'
+        ? Math.max(w / img.width, h / img.height)
+        : size === 'contain'
+          ? Math.min(w / img.width, h / img.height)
+          : 1;
+    const tileW = Math.max(1, img.width * scale);
+    const tileH = Math.max(1, img.height * scale);
+    for (let y = 0; y < h; y += tileH) {
+      for (let x = 0; x < w; x += tileW) {
+        ctx.drawImage(img, x, y, tileW, tileH);
+      }
+    }
+  } catch {
+    // Texture failed to load: the plain theme color is still the right paper.
+  }
+  return canvas;
+};

--- a/apps/readest-app/src/utils/pageCurl.ts
+++ b/apps/readest-app/src/utils/pageCurl.ts
@@ -4,8 +4,9 @@
  * Draws a captured page bitmap as a grid mesh deformed around a cylinder —
  * the classic page curl: content before the fold stays flat, content past the
  * fold wraps over the cylinder and comes out mirrored on top, showing the
- * whitened back of the page. The canvas is transparent wherever the page has
- * curled away, so the live (already turned) page shows through underneath.
+ * back of the page: the content bleeding through the theme paper (see
+ * setBackdrop). The canvas is transparent wherever the page has curled
+ * away, so the live (already turned) page shows through underneath.
  *
  * The renderer knows nothing about capture or gestures: callers provide an
  * ImageBitmap of the outgoing page and drive `render(progress, grab)`.
@@ -52,6 +53,7 @@ void main() {
 const FRAGMENT_SHADER = `
 precision mediump float;
 uniform sampler2D uTex;
+uniform sampler2D uBack;
 varying vec2 vUv;
 varying float vLift;
 
@@ -61,8 +63,10 @@ void main() {
     // Slight contact shading as the page lifts.
     c.rgb *= 1.0 - 0.18 * vLift;
   } else {
-    // The back of the page: the mirrored content bleeding through paper.
-    c.rgb = mix(c.rgb, vec3(1.0), 0.72);
+    // The back of the page: the mirrored content bleeding through the
+    // paper — the theme background supplied via setBackdrop.
+    vec3 paper = texture2D(uBack, vUv).rgb;
+    c.rgb = mix(c.rgb, paper, 0.72);
     c.rgb *= 1.0 - 0.08 * vLift;
   }
   gl_FragColor = vec4(c.rgb, c.a);
@@ -80,6 +84,7 @@ export interface CurlGrab {
 export class PageCurlRenderer {
   private canvas: HTMLCanvasElement | null = null;
   private gl: WebGLRenderingContext | null = null;
+  private backTex: WebGLTexture | null = null;
   private indexCount = 0;
   private width = 0;
   private height = 0;
@@ -164,10 +169,33 @@ export class PageCurlRenderer {
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), gl.STATIC_DRAW);
 
-    for (const name of ['uPage', 'uFold', 'uDir', 'uRadius', 'uTex']) {
+    for (const name of ['uPage', 'uFold', 'uDir', 'uRadius', 'uTex', 'uBack']) {
       this.uniforms[name] = gl.getUniformLocation(program, name);
     }
     gl.uniform2f(this.uniforms['uPage']!, width, height);
+
+    // Back-face paper on unit 1: plain white until setBackdrop supplies the
+    // theme background.
+    this.backTex = gl.createTexture();
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, this.backTex);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA,
+      1,
+      1,
+      0,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      new Uint8Array([255, 255, 255, 255]),
+    );
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.uniform1i(this.uniforms['uBack']!, 1);
+    gl.activeTexture(gl.TEXTURE0);
 
     gl.viewport(0, 0, canvas.width, canvas.height);
     gl.enable(gl.DEPTH_TEST);
@@ -197,6 +225,17 @@ export class PageCurlRenderer {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     gl.uniform1i(this.uniforms['uTex']!, 0);
+  }
+
+  /** Paper drawn on the back of the page (theme background color + texture). */
+  setBackdrop(source: TexImageSource) {
+    const gl = this.gl;
+    if (!gl || !this.backTex) return;
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, this.backTex);
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, source);
+    gl.activeTexture(gl.TEXTURE0);
   }
 
   /**


### PR DESCRIPTION
## Problem

The WebGL page curl (readest#555 mesh curl on Tauri platforms) rendered the back of the turning page by mixing the mirrored content toward hardcoded white. On dark themes the curling sheet showed up as a light gray card, and textured themes lost their paper look entirely.


## Fix

- `PageCurlRenderer` back face now samples a paper texture (`uBack`, defaulting to the previous white) supplied via a new `setBackdrop()` method.
- New `renderTurnBackdrop()` paints that paper: the theme background color plus the active background texture, composited the way the viewer's `::before` layer draws it. It reads background-image, size, blend mode, and opacity off the live pseudo element, so custom textures, blob URLs, and user opacity/size settings all carry over.
- `CapturedPageTurn` gains an optional `getBackdrop` host callback, fetched concurrently with the native capture (no added turn latency) and only for curl turns; a missing or failing backdrop falls back to the white back. The View Transitions turns and the captured slide have no visible back face and are untouched.
- `useCapturedTurn` supplies the backdrop from `themeCode.bg` and the `.foliate-viewer` element.

## Tests

Written test first; all three failed before the fix:

- Renderer: a dark backdrop makes the folded-back pixel dark with a faint content remainder while the flat front stays untinted (`page-curl.browser.test.ts`).
- Backdrop painter: plain color, lighten blend with 0.5 opacity compositing, and broken-image fallback (`turn-backdrop.browser.test.ts`).
- Pipeline: a real `CapturedPageTurn` drag reads the overlay WebGL pixels and finds the dark-mixed back where the old code rendered near white (`captured-turn.browser.test.ts`).

Full unit suite (7655), full browser suite (244), and lint all pass.




## Also included

The captured turn textures (slide and curl) are now encoded at JPEG quality 90 instead of 85 on Android and iOS, trading a slightly larger transfer for fewer visible compression artifacts on the moving page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
