### PR TITLE
fix(reader): gate concurrent programmatic captured page turns

### DIFF
--- a/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
@@ -277,11 +277,24 @@ describe('CapturedPageTurn (browser)', () => {
     failing.dispose();
   });
 
-  it('interrupts an in-flight turn when a new one starts', async () => {
+  it('drops a concurrent programmatic turn instead of queuing it', async () => {
+    // A programmatic turn (key/tap/page-turner) arriving while one is still
+    // running is dropped, like the paginator's #locked push turn — it does not
+    // queue behind the animation. This is what keeps a spurious opposite key
+    // (e.g. the echo an iOS volume press emits when the session volume resets)
+    // from turning the page straight back the moment the first turn lands.
     const first = controller.turn(true, false);
-    await vi.waitFor(() => expect(navigate).toHaveBeenCalledTimes(1));
-    const second = controller.turn(true, false);
-    await Promise.all([first, second]);
+    const second = controller.turn(false, false);
+    await expect(second).resolves.toBe(false);
+    await first;
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith(true);
+    expect(host.querySelector('canvas')).toBeNull();
+  });
+
+  it('runs sequential programmatic turns once the previous one settles', async () => {
+    expect(await controller.turn(true, false)).toBe(true);
+    expect(await controller.turn(true, false)).toBe(true);
     expect(navigate).toHaveBeenCalledTimes(2);
     expect(host.querySelector('canvas')).toBeNull();
   });

--- a/apps/readest-app/src/app/reader/utils/capturedTurn.ts
+++ b/apps/readest-app/src/app/reader/utils/capturedTurn.ts
@@ -87,6 +87,8 @@ export class CapturedPageTurn {
   #disposed = false;
   /** Serializes turns: a new turn interrupts and awaits the previous one. */
   #pending: Promise<unknown> = Promise.resolve();
+  /** True while a programmatic `turn()` is running, gating concurrent ones. */
+  #running = false;
 
   constructor(host: CapturedTurnHost, options: { duration?: number } = {}) {
     this.#host = host;
@@ -104,16 +106,32 @@ export class CapturedPageTurn {
    * book's page progression direction.
    */
   async turn(forward: boolean, rtl: boolean, style: CapturedTurnStyle = 'curl'): Promise<boolean> {
+    // Programmatic turns (keys, taps, wheel, hardware page-turner) mirror the
+    // paginator's #locked push turn: while one is still running, drop the next
+    // instead of queuing it. A finger drag carries its own gesture and uses the
+    // begin/move/end path; a keyed turn has none, so without this gate a rapid
+    // or spurious opposite key — e.g. the echo an iOS volume press emits when
+    // the session volume is reset — queues behind the animation and turns the
+    // page straight back the moment the first turn lands.
+    if (this.#running) return false;
+    this.#running = true;
     const run = this.#pending.then(async () => {
-      if (this.#disposed) return false;
-      this.#finishActive();
-      const active = await this.#setUp(forward, rtl, style);
-      if (!active) return false;
       try {
-        await this.#playTo(active, 1);
-        return true;
+        if (this.#disposed) return false;
+        this.#finishActive();
+        const active = await this.#setUp(forward, rtl, style);
+        if (!active) return false;
+        try {
+          await this.#playTo(active, 1);
+          return true;
+        } finally {
+          if (this.#active === active) this.#disposeActive();
+        }
       } finally {
-        if (this.#active === active) this.#disposeActive();
+        // Release the gate as the turn settles, before the caller's awaiter
+        // resumes, so a genuine sequential turn is never mistaken for a
+        // concurrent one.
+        this.#running = false;
       }
     });
     // Keep the chain alive after failures so later turns still run.


### PR DESCRIPTION
## Problem

On iOS, a single volume-key press in **slide** or **curl** mode sometimes turned the page forward and then immediately reverted. It never happened with the push animation.

## Root cause

Two things combine:

1. **iOS emits a phantom opposite key.** `VolumeKeyHandler` (`NativeBridgePlugin.swift`) detects a press via an `AVAudioSession.outputVolume` KVO observer, then resets the session volume back to a reference level. That reset changes `outputVolume` again, which re-fires the observer in the **opposite** direction, so one press dispatches its key followed by the reverse key. It is intermittent because iOS sometimes coalesces the two rapid volume changes into a single KVO callback.

2. **The captured pipeline queued the phantom; push drops it.** Both turns arrive about 1ms apart.
   - **Push:** the paginator holds `#locked` for the whole ~300ms scroll animation, so the second turn hits `if (this.#locked) return` and is dropped.
   - **Captured slide/curl:** the instant navigation releases `#locked` after ~100ms and the ~450ms overlay animation runs unlocked, so the second turn was serialized onto `CapturedPageTurn`'s pending chain and played out in full, turning the page back. On iOS both slide and curl use the captured pipeline (WebKit lacks nested `view-transition-group`).

So push accidentally masks a phantom event that the captured pipeline dutifully replays. `no-swipe` in `paginator.js` only gates touch handlers, so programmatic turns never got the re-entrancy protection that push turns get from `#locked`.

## Fix

Gate programmatic turns in `CapturedPageTurn.turn` the same way push does: while one turn is running, drop the next instead of queuing it. The gate:

- is set synchronously at the start of `turn()` and released in the run body's `finally`, *before* the caller's awaiter resumes, so genuine **sequential** turns still run;
- leaves the finger-drag path (`beginDrag`/`moveDrag`/`endDrag`) and its own serialization untouched;
- also guards against any rapid opposite programmatic turn, e.g. a hardware page-turner double press or a media-key echo, not just the iOS volume quirk.

## Tests

- `captured-turn.browser.test.ts`: replaced the old "interrupts an in-flight turn" test (which asserted the now-removed queue-both behavior) with "drops a concurrent programmatic turn instead of queuing it", and added "runs sequential programmatic turns once the previous one settles". Confirmed the new test fails before the fix.
- Full unit suite (7688) passes, `pnpm lint` clean, captured-turn browser suite (24) passes.

On-device iOS confirmation is still pending (hardware volume buttons cannot be driven from CI), but the automated tests lock in the exact behavior change that removes the revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
