### PR TITLE
fix(reader): make the custom theme editor readable on mobile

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -185,7 +185,6 @@
   "No supported files found. Supported formats: {{formats}}": "لم يتم العثور على ملفات مدعومة. الصيغ المدعومة: {{formats}}",
   "Drop to Import Books": "قم بالسحب والإسقاط لاستيراد الكتب",
   "Custom": "مخصص",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "العالم مسرح،\nوالناس فيه ممثلون؛\nلهم مخارج ومداخل،\nوالإنسان في حياته يلعب دورًا كثيرًا،\nوأفعاله تمر بسبع مراحل.\n\n— ويليام شكسبير",
   "Custom Theme": "سمة مخصصة",
   "Theme Name": "اسم السمة",
   "Text Color": "لون النص",
@@ -247,7 +246,6 @@
   "No description available": "لا يوجد وصف متاح",
   "List": "قائمة",
   "Grid": "شبكة",
-  "(from 'As You Like It', Act II)": "(من 'كما تحب'، الفصل الثاني)",
   "Link Color": "لون الرابط",
   "Screen": "الشاشة",
   "Orientation": "الاتجاه",
@@ -2079,5 +2077,7 @@
   "Minimal": "مبسط",
   "TTS Player Style": "نمط مشغل TTS",
   "Show translation": "إظهار الترجمة",
-  "Show original": "إظهار الأصل"
+  "Show original": "إظهار الأصل",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "العالم كله مسرح، وكل الرجال والنساء مجرد ممثلين؛ لهم مخارجهم ومداخلهم، والمرء الواحد في زمنه يؤدي أدوارًا كثيرة.",
+  "— William Shakespeare, As You Like It": "— ويليام شكسبير، كما تشاء"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -285,8 +285,6 @@
   "Color": "রঙ",
   "Behavior": "আচরণ",
   "Reset {{settings}}": "{{settings}} রিসেট",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "সারা বিশ্বটাই একটা মঞ্চ,\nআর সব নর-নারী কেবল অভিনেতা;\nতাদের আছে প্রস্থান ও প্রবেশ,\nআর একজন মানুষ তার জীবনে অনেক চরিত্র পালন করে,\nতার অভিনয় সাত যুগের।\n\n— উইলিয়াম শেক্সপিয়র",
-  "(from 'As You Like It', Act II)": "('অ্যাজ ইউ লাইক ইট', দ্বিতীয় অঙ্ক থেকে)",
   "Custom Theme": "কাস্টম থিম",
   "Theme Name": "থিমের নাম",
   "Text Color": "টেক্সট রঙ",
@@ -1935,5 +1933,7 @@
   "Minimal": "ন্যূনতম",
   "TTS Player Style": "TTS প্লেয়ার শৈলী",
   "Show translation": "অনুবাদ দেখান",
-  "Show original": "মূল দেখান"
+  "Show original": "মূল দেখান",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "সমগ্র বিশ্বই একটি রঙ্গমঞ্চ, আর সব নারী-পুরুষ কেবল অভিনেতা; তাদের আছে প্রস্থান আর প্রবেশ, আর একজন মানুষ তার জীবনে বহু ভূমিকায় অভিনয় করে।",
+  "— William Shakespeare, As You Like It": "— উইলিয়াম শেক্সপিয়ার, অ্যাজ ইউ লাইক ইট"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -247,7 +247,6 @@
   "No description available": "ད་རེས་ངོ་སྤྲོད་བསྡུས་དོན་མེད།",
   "List": "ཐོ་རེའུ།",
   "Grid": "དྲྭ་རྡལ།",
-  "(from 'As You Like It', Act II)": "《ཐམས་ཅད་དགའ་བ》ནས་དྲངས་པ། ལེའུ་གཉིས་པ།",
   "Link Color": "སྦྲེལ་ཐག་གི་ཚོན་མདོག",
   "Screen": "བརྡ་ཁྱབ་ངོས།",
   "Orientation": "བརྡ་ཁྱབ་ངོས་ཀྱི་ཁ་ཕྱོགས།",
@@ -473,7 +472,6 @@
   "KOReader Sync": "KOReader སྤྲི་དོན་འདེམས་པ།",
   "Sync Conflict": "སྤྲི་དོན་འབྱུང་ཁུངས།",
   "another device": "གཞན་ཡིག་སྣེ།",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "འབྱུང་ཁུངས་འདེམས་པ་བྱས་ནས་བརྗེ་བ།",
   "Page {{page}} of {{total}} ({{percentage}}%)": "ཤོག་ {{page}} དང་ {{total}} ({{percentage}}%)",
   "Current position": "ད་ལྟའི་གནས་ས།",
   "Approximately page {{page}} of {{total}} ({{percentage}}%)": "ཕྲན་བུ་ཤོག་ངོས་ {{page}} / {{total}} ({{percentage}}%)",
@@ -1899,5 +1897,7 @@
   "Minimal": "སྟབས་བདེ།",
   "TTS Player Style": "TTS གཏོང་ཆས་ཀྱི་བཟོ་དབྱིབས།",
   "Show translation": "འགྱུར་ཡིག་སྟོན་པ།",
-  "Show original": "མ་ཡིག་སྟོན་པ།"
+  "Show original": "མ་ཡིག་སྟོན་པ།",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "འཇིག་རྟེན་ཧྲིལ་པོ་ནི་འཁྲབ་སྟེགས་ཤིག་ཡིན། སྐྱེས་པ་དང་བུད་མེད་ཐམས་ཅད་ནི་འཁྲབ་མཁན་ཙམ་ཡིན། ཁོ་ཚོ་ལ་ཐོན་པ་དང་འཛུལ་བ་ཡོད་ཅིང། མི་གཅིག་གིས་རང་གི་མི་ཚེའི་ནང་དུ་འཁྲབ་གཞུང་མང་པོ་འཁྲབ།",
+  "— William Shakespeare, As You Like It": "— ཝི་ལི་ཡམ་ཤེགས་སི་པིར།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -185,7 +185,6 @@
   "No supported files found. Supported formats: {{formats}}": "Keine unterstützten Dateien gefunden. Unterstützte Formate: {{formats}}",
   "Drop to Import Books": "Zum Importieren von Büchern ablegen",
   "Custom": "Eigen",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Die ganze Welt ist eine Bühne,\nUnd alle Männer und Frauen sind bloß Spieler;\nSie haben ihre Abgänge und ihre Auftritte,\nUnd ein Mann spielt in seinem Leben viele Rollen,\nSeine Taten sind sieben Zeitalter.\n\n— William Shakespeare",
   "Custom Theme": "Benutzerdefiniertes Thema",
   "Theme Name": "Themenname",
   "Text Color": "Textfarbe",
@@ -247,7 +246,6 @@
   "No description available": "Keine Beschreibung verfügbar",
   "List": "Liste",
   "Grid": "Raster",
-  "(from 'As You Like It', Act II)": "(aus 'Wie es euch gefällt', Akt II)",
   "Link Color": "Linkfarbe",
   "Screen": "Bildschirm",
   "Orientation": "Orientierung",
@@ -1935,5 +1933,7 @@
   "Minimal": "Minimal",
   "TTS Player Style": "TTS-Player-Stil",
   "Show translation": "Übersetzung anzeigen",
-  "Show original": "Original anzeigen"
+  "Show original": "Original anzeigen",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Die ganze Welt ist eine Bühne, und alle Männer und Frauen sind bloß Spieler; sie haben ihre Abgänge und ihre Auftritte, und ein Mann spielt in seinem Leben viele Rollen.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Wie es euch gefällt"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -186,7 +186,6 @@
   "No supported files found. Supported formats: {{formats}}": "Δεν βρέθηκαν υποστηριζόμενα αρχεία. Υποστηριζόμενες μορφές: {{formats}}",
   "Drop to Import Books": "Ρίξτε για εισαγωγή βιβλίων",
   "Custom": "Προσαρμοσμένο",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Όλος ο κόσμος είναι σκηνή,\nΚαι όλοι οι άνδρες και οι γυναίκες απλώς ηθοποιοί·\nΈχουν τις εξόδους και τις εισόδους τους,\nΚαι ένας άνθρωπος στον χρόνο του παίζει πολλούς ρόλους,\nΟι πράξεις του υπάρχουν σε επτά ηλικίες.\n\n— William Shakespeare",
   "Custom Theme": "Προσαρμοσμένο θέμα",
   "Theme Name": "Όνομα θέματος",
   "Text Color": "Χρώμα κειμένου",
@@ -248,7 +247,6 @@
   "No description available": "Δεν είναι διαθέσιμη καμία περιγραφή",
   "List": "Λίστα",
   "Grid": "Πλέγμα",
-  "(from 'As You Like It', Act II)": "('Όπως σας αρέσει', Πράξη II)",
   "Link Color": "Χρώμα συνδέσμου",
   "Screen": "Οθόνη",
   "Orientation": "Προσανατολισμός",
@@ -1935,5 +1933,7 @@
   "Minimal": "Μινιμαλιστικό",
   "TTS Player Style": "Στυλ αναπαραγωγής TTS",
   "Show translation": "Εμφάνιση μετάφρασης",
-  "Show original": "Εμφάνιση πρωτοτύπου"
+  "Show original": "Εμφάνιση πρωτοτύπου",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Όλος ο κόσμος είναι μια σκηνή, και όλοι οι άντρες κι οι γυναίκες απλοί ηθοποιοί· έχουν τις εξόδους και τις εισόδους τους, κι ένας άνθρωπος στη ζωή του παίζει πολλούς ρόλους.",
+  "— William Shakespeare, As You Like It": "— Ουίλιαμ Σαίξπηρ, Όπως Αγαπάτε"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -209,7 +209,6 @@
   "No supported files found. Supported formats: {{formats}}": "No se encontraron archivos compatibles. Formatos compatibles: {{formats}}",
   "Drop to Import Books": "Soltar para importar libros",
   "Custom": "Personalizado",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Todo el mundo es un escenario,\nY todos los hombres y mujeres son meros actores;\nTienen sus salidas y sus entradas,\nY un hombre en su tiempo interpreta muchos papeles,\nSus actos son siete edades.\n\n— William Shakespeare",
   "Custom Theme": "Tema personalizado",
   "Theme Name": "Nombre del tema",
   "Text Color": "Color del texto",
@@ -271,7 +270,6 @@
   "No description available": "No hay descripción disponible",
   "List": "Lista",
   "Grid": "Cuadrícula",
-  "(from 'As You Like It', Act II)": "(de 'Como gustéis', Acto II)",
   "Link Color": "Color del enlace",
   "Screen": "Pantalla",
   "Orientation": "Orientación",
@@ -1971,5 +1969,7 @@
   "Minimal": "Minimalista",
   "TTS Player Style": "Estilo del reproductor TTS",
   "Show translation": "Mostrar traducción",
-  "Show original": "Mostrar original"
+  "Show original": "Mostrar original",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "El mundo entero es un escenario, y todos los hombres y mujeres, meros actores; tienen sus entradas y sus salidas, y un hombre en su vida representa muchos papeles.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Como gustéis"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -185,7 +185,6 @@
   "No supported files found. Supported formats: {{formats}}": "فایل پشتیبانی‌شده‌ای یافت نشد. فرمت‌های قابل پشتیبانی: {{formats}}",
   "Drop to Import Books": "برای وارد کردن کتاب‌ها، فایل را رها کنید",
   "Custom": "سفارشی",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "تمام دنیا صحنه‌ای است،\nو همه‌ی مردان و زنان تنها بازیگرانی بیش نیستند؛\nآن‌ها ورود و خروج خود را دارند،\nو هر آدمی در طول زمان نقش‌های بسیاری ایفا می‌کند،\nاعمال او هفت دوره‌اند.\n\n— ویلیام شکسپیر",
   "Custom Theme": "تم سفارشی",
   "Theme Name": "نام تم",
   "Text Color": "رنگ متن",
@@ -247,7 +246,6 @@
   "No description available": "هیچ توضیحی موجود نیست",
   "List": "لیست",
   "Grid": "جدول",
-  "(from 'As You Like It', Act II)": "(از «همان‌طور که دوست دارید»، پرده‌ی دوم)",
   "Link Color": "رنگ لینک",
   "Screen": "صفحه",
   "Orientation": "جهت",
@@ -1935,5 +1933,7 @@
   "Minimal": "ساده",
   "TTS Player Style": "سبک پخش‌کننده TTS",
   "Show translation": "نمایش ترجمه",
-  "Show original": "نمایش متن اصلی"
+  "Show original": "نمایش متن اصلی",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "تمام دنیا یک صحنه است و همه‌ی مردان و زنان تنها بازیگرند؛ آن‌ها را خروج‌ها و ورودهایی است، و هر کس در طول عمر خود نقش‌های بسیاری بازی می‌کند.",
+  "— William Shakespeare, As You Like It": "— ویلیام شکسپیر، هرطور که دوست دارید"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -185,7 +185,6 @@
   "No supported files found. Supported formats: {{formats}}": "Aucun fichier pris en charge trouvé. Formats pris en charge : {{formats}}",
   "Drop to Import Books": "Déposez pour importer des livres",
   "Custom": "Personnalisé",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Le monde entier est un théâtre,\nEt tous les hommes et les femmes ne sont que des acteurs ;\nIls ont leurs sorties et leurs entrées,\nEt un homme, dans sa vie, joue de nombreux rôles,\nSes actes étant sept âges.\n\n— William Shakespeare",
   "Custom Theme": "Thème personnalisé",
   "Theme Name": "Nom du thème",
   "Text Color": "Couleur du texte",
@@ -247,7 +246,6 @@
   "No description available": "Aucune description disponible",
   "List": "Liste",
   "Grid": "Grille",
-  "(from 'As You Like It', Act II)": "(de 'Comme il vous plaira', Acte II)",
   "Link Color": "Couleur du lien",
   "Screen": "Écran",
   "Orientation": "Orientation",
@@ -1971,5 +1969,7 @@
   "Minimal": "Minimal",
   "TTS Player Style": "Style du lecteur TTS",
   "Show translation": "Afficher la traduction",
-  "Show original": "Afficher l'original"
+  "Show original": "Afficher l'original",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Le monde entier est un théâtre, et tous, hommes et femmes, ne sont que des acteurs; ils ont leurs entrées et leurs sorties, et un homme, dans le cours de sa vie, joue bien des rôles.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Comme il vous plaira"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -822,8 +822,6 @@
   "Ruler Color": "צבע סרגל",
   "Theme Color": "צבע ערכת נושא",
   "Custom": "מותאם אישית",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "כל העולם במה,\nוכל הגברים והנשים רק שחקנים הם;\nיש להם את היציאות והכניסות שלהם,\nואדם אחד בזמנו משחק תפקידים רבים,\nמעשיו הם שבעה גילאים.\n\n— ויליאם שייקספיר",
-  "(from 'As You Like It', Act II)": "(מתוך 'כטוב בעיניכם', מערכה שנייה)",
   "Custom Theme": "ערכת נושא מותאמת אישית",
   "Theme Name": "שם ערכת הנושא",
   "Text Color": "צבע טקסט",
@@ -1971,5 +1969,7 @@
   "Minimal": "מינימלי",
   "TTS Player Style": "סגנון נגן TTS",
   "Show translation": "הצג תרגום",
-  "Show original": "הצג מקור"
+  "Show original": "הצג מקור",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "כל העולם במה, וכל הגברים והנשים אינם אלא שחקנים; יש להם יציאות ויש להם כניסות, ואדם אחד משחק בימי חייו תפקידים רבים.",
+  "— William Shakespeare, As You Like It": "— ויליאם שייקספיר, כטוב בעיניכם"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -186,7 +186,6 @@
   "No supported files found. Supported formats: {{formats}}": "कोई समर्थित फ़ाइलें नहीं मिलीं। समर्थित प्रारूप: {{formats}}",
   "Drop to Import Books": "पुस्तकें आयात करने के लिए छोड़ें",
   "Custom": "कस्टम",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "पूरी दुनिया एक स्टेज है,\nऔर सभी आदमी और महिलाएँ केवल अभिनेता हैं;\nउनके निकास और प्रवेश होते हैं,\nऔर एक आदमी अपने समय में कई भूमिकाएँ निभाता है,\nउसके कार्य सात युग होते हैं।\n\n— विलियम शेक्सपियर",
   "Custom Theme": "कस्टम थीम",
   "Theme Name": "थीम का नाम",
   "Text Color": "टेक्स्ट रंग",
@@ -248,7 +247,6 @@
   "No description available": "कोई विवरण उपलब्ध नहीं है",
   "List": "सूची",
   "Grid": "ग्रिड",
-  "(from 'As You Like It', Act II)": "('जैसा आप इसे पसंद करते हैं', अधिनियम II)",
   "Link Color": "लिंक रंग",
   "Screen": "स्क्रीन",
   "Orientation": "अवयव",
@@ -1935,5 +1933,7 @@
   "Minimal": "न्यूनतम",
   "TTS Player Style": "TTS प्लेयर शैली",
   "Show translation": "अनुवाद दिखाएं",
-  "Show original": "मूल दिखाएं"
+  "Show original": "मूल दिखाएं",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "सारा संसार एक रंगमंच है, और सभी स्त्री-पुरुष केवल अभिनेता हैं; उनके अपने प्रस्थान और प्रवेश होते हैं, और एक मनुष्य अपने जीवनकाल में अनेक भूमिकाएँ निभाता है।",
+  "— William Shakespeare, As You Like It": "— विलियम शेक्सपियर, एज़ यू लाइक इट"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -897,8 +897,6 @@
   "Ruler Color": "Vonalzó színe",
   "Theme Color": "Téma színe",
   "Custom": "Egyéni",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Színház az egész világ,\nÉs színész benne minden férfi és nő;\nMegvan a föllépése, lelépése,\nS mindenki több szerepben is megjelenik,\nHét felvonásra oszlik egy-egy élet.\n\n— William Shakespeare",
-  "(from 'As You Like It', Act II)": "(az 'Ahogy tetszik' c. műből, II. felvonás)",
   "Custom Theme": "Egyéni téma",
   "Theme Name": "Téma neve",
   "Text Color": "Szöveg színe",
@@ -1935,5 +1933,7 @@
   "Minimal": "Minimális",
   "TTS Player Style": "TTS lejátszó stílusa",
   "Show translation": "Fordítás megjelenítése",
-  "Show original": "Eredeti megjelenítése"
+  "Show original": "Eredeti megjelenítése",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Színház az egész világ, és színész benne minden férfi és nő; megvannak a maguk kilépői és belépői, és egy ember életében sok szerepet játszik el.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Ahogy tetszik"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -186,7 +186,6 @@
   "No supported files found. Supported formats: {{formats}}": "Tidak ada file yang didukung ditemukan. Format yang didukung: {{formats}}",
   "Drop to Import Books": "Jatuhkan untuk Mengimpor Buku",
   "Custom": "Kustom",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Seluruh dunia adalah panggung,\nDan semua pria dan wanita hanyalah pemain;\nMereka memiliki keluar dan masuk mereka,\nDan seorang pria dalam hidupnya memainkan banyak peran,\nTindakannya ada tujuh zaman.\n\n— William Shakespeare",
   "Custom Theme": "Tema Kustom",
   "Theme Name": "Nama Tema",
   "Text Color": "Warna Teks",
@@ -248,7 +247,6 @@
   "No description available": "Tidak ada deskripsi yang tersedia",
   "List": "Daftar",
   "Grid": "Jala",
-  "(from 'As You Like It', Act II)": "(dari 'Seperti yang Anda Inginkan', Bab II)",
   "Link Color": "Warna Tautan",
   "Screen": "Screen",
   "Orientation": "Orientasi",
@@ -1899,5 +1897,7 @@
   "Minimal": "Minimal",
   "TTS Player Style": "Gaya Pemutar TTS",
   "Show translation": "Tampilkan terjemahan",
-  "Show original": "Tampilkan asli"
+  "Show original": "Tampilkan asli",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Seluruh dunia adalah panggung, dan semua pria dan wanita hanyalah pemain; mereka punya saat keluar dan saat masuk, dan seseorang dalam hidupnya memainkan banyak peran.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, As You Like It"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -186,7 +186,6 @@
   "No supported files found. Supported formats: {{formats}}": "Nessun file supportato trovato. Formati supportati: {{formats}}",
   "Drop to Import Books": "Rilascia per importare libri",
   "Custom": "Personalizzato",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Tutto il mondo è un palcoscenico,\nE tutti gli uomini e le donne sono solo attori;\nHanno le loro uscite e le loro entrate,\nE un uomo nella sua vita interpreta molte parti,\nI suoi atti sono sette età.\n\n— William Shakespeare",
   "Custom Theme": "Tema personalizzato",
   "Theme Name": "Nome tema",
   "Text Color": "Colore testo",
@@ -248,7 +247,6 @@
   "No description available": "Nessuna descrizione disponibile",
   "List": "Elenco",
   "Grid": "Griglia",
-  "(from 'As You Like It', Act II)": "(da 'Come vi piace', Atto II)",
   "Link Color": "Colore link",
   "Screen": "Schermo",
   "Orientation": "Orientamento",
@@ -1971,5 +1969,7 @@
   "Minimal": "Minimale",
   "TTS Player Style": "Stile del lettore TTS",
   "Show translation": "Mostra traduzione",
-  "Show original": "Mostra originale"
+  "Show original": "Mostra originale",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Tutto il mondo è un palcoscenico, e tutti gli uomini e le donne non sono che attori; hanno le loro uscite e le loro entrate, e uno stesso uomo nella sua vita recita molte parti.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Come vi piace"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -186,7 +186,6 @@
   "No supported files found. Supported formats: {{formats}}": "サポートされているファイルが見つかりません。サポートされている形式：{{formats}}",
   "Drop to Import Books": "書籍をインポートするにはドロップ",
   "Custom": "カスタム",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "全世界は舞台であり、\nそしてすべての男性と女性は単なる役者です。\n彼らは出入り口を持っており、\nそして一人の男性は時に多くの役を演じます。\n彼の行為は七つの時代です。\n\n— ウィリアム・シェイクスピア",
   "Custom Theme": "カスタムテーマ",
   "Theme Name": "テーマ名",
   "Text Color": "テキストカラー",
@@ -248,7 +247,6 @@
   "No description available": "説明はありません",
   "List": "リスト",
   "Grid": "グリッド",
-  "(from 'As You Like It', Act II)": "(「お気に召すまま」第2幕)",
   "Link Color": "リンクカラー",
   "Screen": "画面",
   "Orientation": "向き",
@@ -1899,5 +1897,7 @@
   "Minimal": "ミニマル",
   "TTS Player Style": "TTSプレーヤーのスタイル",
   "Show translation": "翻訳を表示",
-  "Show original": "原文を表示"
+  "Show original": "原文を表示",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "この世はすべて舞台、男も女もみな役者にすぎない。彼らには退場があり登場があり、一人の人間はその一生でいくつもの役を演じる。",
+  "— William Shakespeare, As You Like It": "— ウィリアム・シェイクスピア『お気に召すまま』"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -186,7 +186,6 @@
   "No supported files found. Supported formats: {{formats}}": "지원되는 파일이 없습니다. 지원되는 형식: {{formats}}",
   "Drop to Import Books": "책 가져오기 위해 드롭",
   "Custom": "사용자 정의",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "세상은 무대이며,\n그리고 모든 남자와 여자는 단지 배우일 뿐입니다;\n그들은 나가는 곳과 들어오는 곳이 있으며,\n그리고 한 남자는 그의 시간에 많은 역할을 합니다,\n그의 행동은 일곱 시대입니다.\n\n— 윌리엄 셰익스피어",
   "Custom Theme": "사용자 정의 테마",
   "Theme Name": "테마 이름",
   "Text Color": "텍스트 색상",
@@ -248,7 +247,6 @@
   "No description available": "설명 없음",
   "List": "목록",
   "Grid": "격자",
-  "(from 'As You Like It', Act II)": "(당신이 좋아하는 대로, 2막)",
   "Link Color": "링크 색상",
   "Screen": "화면",
   "Orientation": "방향",
@@ -1899,5 +1897,7 @@
   "Minimal": "미니멀",
   "TTS Player Style": "TTS 플레이어 스타일",
   "Show translation": "번역 표시",
-  "Show original": "원문 표시"
+  "Show original": "원문 표시",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "온 세상은 무대이고, 모든 남자와 여자는 한낱 배우일 뿐이다. 그들에게는 퇴장이 있고 등장이 있으며, 한 사람은 살아가는 동안 여러 역을 연기한다.",
+  "— William Shakespeare, As You Like It": "— 윌리엄 셰익스피어, 「뜻대로 하세요」"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -473,8 +473,6 @@
   "Highlight Colors": "Warna Penonjolan",
   "Theme Color": "Warna Tema",
   "Custom": "Tersuai",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Seluruh dunia adalah pentas,\nDan semua lelaki dan wanita hanyalah pelakon;\nMereka ada pintu keluar dan pintu masuk mereka,\nDan seseorang dalam masanya memainkan banyak peranan,\nTindakannya adalah tujuh zaman.\n\n— William Shakespeare",
-  "(from 'As You Like It', Act II)": "(daripada 'As You Like It', Babak II)",
   "Custom Theme": "Tema Tersuai",
   "Theme Name": "Nama Tema",
   "Text Color": "Warna Teks",
@@ -1899,5 +1897,7 @@
   "Minimal": "Minimal",
   "TTS Player Style": "Gaya Pemain TTS",
   "Show translation": "Tunjukkan terjemahan",
-  "Show original": "Tunjukkan asal"
+  "Show original": "Tunjukkan asal",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Seluruh dunia ini pentas, dan semua lelaki dan wanita hanyalah pelakon; mereka ada masa keluar dan masa masuk, dan seseorang dalam hidupnya memainkan pelbagai peranan.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, As You Like It"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -183,7 +183,6 @@
   "Font": "Lettertype",
   "Layout": "Opmaak",
   "Color": "Kleur",
-  "(from 'As You Like It', Act II)": "(uit 'As You Like It', Akte II)",
   "Custom Theme": "Aangepast thema",
   "Theme Name": "Themanaam",
   "Text Color": "Tekstkleur",
@@ -259,7 +258,6 @@
   "Reveal in File Explorer": "Tonen in Verkenner",
   "Reveal in Folder": "Tonen in map",
   "Don't have an account? Sign up": "Nog geen account? Registreer u",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "De hele wereld is een toneel,\nEn alle mannen en vrouwen slechts spelers;\nZij hebben hun uitgangen en hun entrees,\nEn één man speelt in zijn tijd vele rollen,\nZijn daden zijnde zeven leeftijden.\n\n— William Shakespeare",
   "Next Section": "Volgende sectie",
   "Previous Section": "Vorige sectie",
   "Next Page": "Volgende pagina",
@@ -1935,5 +1933,7 @@
   "Minimal": "Minimaal",
   "TTS Player Style": "TTS-spelerstijl",
   "Show translation": "Vertaling tonen",
-  "Show original": "Origineel tonen"
+  "Show original": "Origineel tonen",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "De hele wereld is een toneel, en alle mannen en vrouwen slechts spelers; zij hebben hun aftredens en hun optredens, en één mens speelt in zijn leven vele rollen.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Zoals u het wilt"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -186,7 +186,6 @@
   "No supported files found. Supported formats: {{formats}}": "Nie znaleziono obsługiwanych plików. Obsługiwane formaty: {{formats}}",
   "Drop to Import Books": "Upuść, aby zaimportować książki",
   "Custom": "Niestandardowy",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Cały świat jest sceną,\nA wszyscy mężczyźni i kobiety są tylko aktorami;\nMają swoje wyjścia i wejścia,\nI jeden człowiek w swoim czasie gra wiele ról,\nJego czyny to siedem wieków.\n\n— William Shakespeare",
   "Custom Theme": "Niestandardowy motyw",
   "Theme Name": "Nazwa motywu",
   "Text Color": "Kolor tekstu",
@@ -248,7 +247,6 @@
   "No description available": "Brak opisu",
   "List": "Lista",
   "Grid": "Siatka",
-  "(from 'As You Like It', Act II)": "(z „Jak wam się podoba”, Akt II)",
   "Link Color": "Kolor linku",
   "Screen": "Ekran",
   "Orientation": "Orientacja",
@@ -2007,5 +2005,7 @@
   "Minimal": "Minimalny",
   "TTS Player Style": "Styl odtwarzacza TTS",
   "Show translation": "Pokaż tłumaczenie",
-  "Show original": "Pokaż oryginał"
+  "Show original": "Pokaż oryginał",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Cały świat to scena, a wszyscy ludzie, mężczyźni i kobiety, to tylko aktorzy; mają swoje wejścia i wyjścia, a jeden człowiek w swoim życiu gra wiele ról.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Jak wam się podoba"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1014,8 +1014,6 @@
   "Ruler Color": "Cor da régua",
   "Theme Color": "Cor do tema",
   "Custom": "Personalizado",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Todo o mundo é um palco,\nE todos os homens e mulheres são meros atores;\nEles têm suas saídas e suas entradas,\nE um homem em seu tempo desempenha muitos papéis,\nSeus atos sendo sete idades.\n\n— William Shakespeare",
-  "(from 'As You Like It', Act II)": "(de 'Como Quiserdes', Ato II)",
   "Custom Theme": "Tema personalizado",
   "Theme Name": "Nome do tema",
   "Text Color": "Cor do texto",
@@ -1971,5 +1969,7 @@
   "Minimal": "Minimalista",
   "TTS Player Style": "Estilo do reprodutor TTS",
   "Show translation": "Mostrar tradução",
-  "Show original": "Mostrar original"
+  "Show original": "Mostrar original",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "O mundo inteiro é um palco, e todos os homens e mulheres não passam de atores; eles têm suas saídas e suas entradas, e um homem, em seu tempo, representa muitos papéis.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Como Gostais"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -186,7 +186,6 @@
   "No supported files found. Supported formats: {{formats}}": "Nenhum arquivo suportado encontrado. Formatos suportados: {{formats}}",
   "Drop to Import Books": "Arraste para Importar Livros",
   "Custom": "Personalizado",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Todo o mundo é um palco,\nE todos os homens e mulheres são meros atores;\nEles têm suas saídas e suas entradas,\nE um homem em seu tempo desempenha muitos papéis,\nSeus atos sendo sete idades.\n\n— William Shakespeare",
   "Custom Theme": "Tema Personalizado",
   "Theme Name": "Nome do Tema",
   "Text Color": "Cor do Texto",
@@ -248,7 +247,6 @@
   "No description available": "Nenhuma descrição disponível",
   "List": "Lista",
   "Grid": "Grade",
-  "(from 'As You Like It', Act II)": "(de 'Como Gostais', Ato II)",
   "Link Color": "Cor do Link",
   "Screen": "Tela",
   "Orientation": "Orientação",
@@ -1971,5 +1969,7 @@
   "Minimal": "Minimalista",
   "TTS Player Style": "Estilo do leitor TTS",
   "Show translation": "Mostrar tradução",
-  "Show original": "Mostrar original"
+  "Show original": "Mostrar original",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "O mundo inteiro é um palco, e todos os homens e mulheres não passam de atores; têm as suas saídas e as suas entradas, e um homem, no seu tempo, representa muitos papéis.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Como Gostais"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -886,8 +886,6 @@
   "Ruler Color": "Culoarea riglei",
   "Theme Color": "Culoarea temei",
   "Custom": "Personalizat",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Lumea întreagă e o scenă,\nȘi toți oamenii-s doar actori;\nAu intrările și ieșirile lor,\nȘi fiecare, în timpul lui, joacă mai multe roluri,\nActele sale fiind cele șapte vârste.\n\n— William Shakespeare",
-  "(from 'As You Like It', Act II)": "(din „Cum vă place”, Actul II)",
   "Custom Theme": "Temă personalizată",
   "Theme Name": "Numele temei",
   "Text Color": "Culoare text",
@@ -1971,5 +1969,7 @@
   "Minimal": "Minimal",
   "TTS Player Style": "Stilul playerului TTS",
   "Show translation": "Afișează traducerea",
-  "Show original": "Afișează originalul"
+  "Show original": "Afișează originalul",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Lumea întreagă e o scenă, iar toți bărbații și femeile doar actori; ei au ieșirile și intrările lor, iar un om joacă în viața lui multe roluri.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Cum vă place"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -186,7 +186,6 @@
   "No supported files found. Supported formats: {{formats}}": "Поддерживаемые файлы не найдены. Поддерживаемые форматы: {{formats}}",
   "Drop to Import Books": "Перетащите сюда книги для импорта",
   "Custom": "Пользовательский",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Весь мир — театр,\nИ все мужчины и женщины — просто актёры;\nУ них есть свои выходы и входы,\nИ один человек в своё время играет много ролей,\nЕго поступки — это семь веков.\n\n— Уильям Шекспир",
   "Custom Theme": "Пользовательская тема",
   "Theme Name": "Название темы",
   "Text Color": "Цвет текста",
@@ -248,7 +247,6 @@
   "No description available": "Нет доступного описания",
   "List": "Список",
   "Grid": "Сетка",
-  "(from 'As You Like It', Act II)": "(из 'Как вам это понравится', Акт II)",
   "Link Color": "Цвет ссылки",
   "Screen": "Экран",
   "Orientation": "Ориентация",
@@ -2007,5 +2005,7 @@
   "Minimal": "Минимальный",
   "TTS Player Style": "Стиль TTS-плеера",
   "Show translation": "Показать перевод",
-  "Show original": "Показать оригинал"
+  "Show original": "Показать оригинал",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Весь мир — театр, а люди в нём — актёры; у них есть свои уходы и выходы, и каждый за свою жизнь играет множество ролей.",
+  "— William Shakespeare, As You Like It": "— Уильям Шекспир, «Как вам это понравится»"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -285,8 +285,6 @@
   "Color": "වර්ණය",
   "Behavior": "හැසිරීම",
   "Reset {{settings}}": "{{settings}} නැවත සකස් කරන්න",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "සියලු ලෝකය වේදිකාවක්,\nසහ සියලු පුරුෂයන් සහ ගැහැණියන් හුදු රංගන ශිල්පීන්;\nඔවුන්ට පිටවීම් සහ ඇතුල්වීම් ඇත,\nසහ එක් මනුෂ්‍යයෙක් ඔහුගේ කාලයේ බොහෝ භාගයන් ඉටු කරයි,\nඔහුගේ ක්‍රියා වයස් හතකි.\n\n— විලියම් ශේක්ස්පියර්",
-  "(from 'As You Like It', Act II)": "('ඔබට අවශ්‍ය ලෙස', දෙවන අංකයෙන්)",
   "Custom Theme": "අභිරුචි තේමාව",
   "Theme Name": "තේමා නාමය",
   "Text Color": "පෙළ වර්ණය",
@@ -1935,5 +1933,7 @@
   "Minimal": "අවම",
   "TTS Player Style": "TTS වාදක විලාසය",
   "Show translation": "පරිවර්තනය පෙන්වන්න",
-  "Show original": "මුල් පිටපත පෙන්වන්න"
+  "Show original": "මුල් පිටපත පෙන්වන්න",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "මුළු ලෝකයම වේදිකාවකි; සියලු පිරිමින් හා ගැහැනුන් හුදෙක් නළු නිළියෝ පමණි; ඔවුනට පිටවීම් හා පිවිසීම් ඇත, එක් මිනිසෙක් තම ජීවිත කාලයේදී භූමිකා රැසක් රඟ දක්වයි.",
+  "— William Shakespeare, As You Like It": "— විලියම් ෂේක්ස්පියර්, As You Like It"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -862,8 +862,6 @@
   "Ruler Color": "Barva ravnila",
   "Theme Color": "Barva teme",
   "Custom": "Po meri",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Ves svet je oder,\nin vsi moški in ženske le igralci;\nimajo svoje izhode in svoje vhode,\nin vsak v svojem času igra mnogo vlog,\nnjegova dejanja pa so sedem obdobij.\n\n— William Shakespeare",
-  "(from 'As You Like It', Act II)": "(iz 'Kakor vam drago', 2. dejanje)",
   "Custom Theme": "Tema po meri",
   "Theme Name": "Ime teme",
   "Text Color": "Barva besedila",
@@ -2007,5 +2005,7 @@
   "Minimal": "Minimalni",
   "TTS Player Style": "Slog predvajalnika TTS",
   "Show translation": "Pokaži prevod",
-  "Show original": "Pokaži izvirnik"
+  "Show original": "Pokaži izvirnik",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Ves svet je oder, in vsi ljudje, moški in ženske, so le igralci; imajo svoje odhode in prihode, in en sam človek v svojem življenju igra mnogo vlog.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Kakor vam drago"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -524,8 +524,6 @@
   "Behavior": "Beteende",
   "Settings Panels": "Inställningspaneler",
   "Reset {{settings}}": "Återställ {{settings}}",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Hela världen är en scen,\nOch alla män och kvinnor bara spelare;\nDe har sina utgångar och entréer,\nOch en man spelar i sin tid många roller,\nHans akter är sju åldrar.\n\n— William Shakespeare",
-  "(from 'As You Like It', Act II)": "(från 'Som ni behagar', Akt II)",
   "Custom Theme": "Anpassat tema",
   "Theme Name": "Temanamn",
   "Text Color": "Textfärg",
@@ -1935,5 +1933,7 @@
   "Minimal": "Minimal",
   "TTS Player Style": "TTS-spelarstil",
   "Show translation": "Visa översättning",
-  "Show original": "Visa original"
+  "Show original": "Visa original",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Hela världen är en scen, och alla människor, män som kvinnor, blott skådespelare; de har sina sortier och sina entréer, och en människa spelar under sin tid många roller.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Som ni behagar"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -285,8 +285,6 @@
   "Color": "நிறம்",
   "Behavior": "நடத்தை",
   "Reset {{settings}}": "{{settings}} மீட்டமைக்கவும்",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "உலகம் முழுவதும் ஒரு மேடை,\nஅதில் ஆண்களும் பெண்களும் வெறும் நடிகர்கள்;\nஅவர்களுக்கு வெளியேறுதலும் நுழைவும் உண்டு,\nஒரு மனிதன் தன் காலத்தில் பல பாத்திரங்களை வகிக்கிறான்,\nஅவனுடைய செயல்கள் ஏழு வயதுகளாக இருக்கின்றன.\n\n— வில்லியம் ஷேக்ஸ்பியர்",
-  "(from 'As You Like It', Act II)": "('ஆஸ் யூ லைக் இட்', இரண்டாவது அங்கத்திலிருந்து)",
   "Custom Theme": "தனிப்பயன் தீம்",
   "Theme Name": "தீம் பெயர்",
   "Text Color": "உரை நிறம்",
@@ -1935,5 +1933,7 @@
   "Minimal": "எளிய",
   "TTS Player Style": "TTS இயக்கி பாணி",
   "Show translation": "மொழிபெயர்ப்பைக் காட்டு",
-  "Show original": "மூலத்தைக் காட்டு"
+  "Show original": "மூலத்தைக் காட்டு",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "உலகம் முழுவதும் ஒரு நாடக அரங்கம், ஆண்களும் பெண்களும் அனைவரும் நடிகர்களே; அவர்களுக்கு வெளியேற்றங்களும் நுழைவுகளும் உண்டு, ஒரு மனிதன் தன் வாழ்நாளில் பல பாத்திரங்களை ஏற்று நடிக்கிறான்.",
+  "— William Shakespeare, As You Like It": "— வில்லியம் ஷேக்ஸ்பியர், As You Like It"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -242,7 +242,6 @@
   "Color": "สี",
   "Behavior": "พฤติกรรม",
   "Reset {{settings}}": "รีเซ็ต {{settings}}",
-  "(from 'As You Like It', Act II)": "(จาก 'As You Like It', องก์ที่ 2)",
   "Custom Theme": "ธีมกำหนดเอง",
   "Theme Name": "ชื่อธีม",
   "Text Color": "สีข้อความ",
@@ -389,7 +388,6 @@
   "Reveal in File Explorer": "แสดงใน File Explorer",
   "Reveal in Folder": "แสดงในโฟลเดอร์",
   "Don't have an account? Sign up": "ยังไม่มีบัญชี? สมัครสมาชิก",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "โลกทั้งใบเป็นเวที\nและชายหญิงทั้งปวงเป็นนักแสดง\nมีทางเข้าและทางออก\nแต่ละคนในชีวิตเล่นหลายบท\nการกระทำของเขาแบ่งเป็นเจ็ดวัย\n\n— วิลเลียม เชกสเปียร์",
   "What's New in Readest": "มีอะไรใหม่ใน Readest",
   "Enter book title": "ป้อนชื่อหนังสือ",
   "Subtitle": "หัวข้อรอง",
@@ -1899,5 +1897,7 @@
   "Minimal": "มินิมอล",
   "TTS Player Style": "รูปแบบตัวเล่น TTS",
   "Show translation": "แสดงคำแปล",
-  "Show original": "แสดงต้นฉบับ"
+  "Show original": "แสดงต้นฉบับ",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "โลกทั้งใบคือเวที และชายหญิงทั้งปวงล้วนเป็นเพียงนักแสดง พวกเขาต่างมีวาระเข้าและออก และคนหนึ่งในชั่วชีวิตของเขาย่อมสวมบทบาทมากมาย",
+  "— William Shakespeare, As You Like It": "— วิลเลียม เชกสเปียร์, As You Like It"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -186,7 +186,6 @@
   "No supported files found. Supported formats: {{formats}}": "Desteklenen dosya bulunamadı. Desteklenen formatlar: {{formats}}",
   "Drop to Import Books": "Kitapları İçe Aktarmak İçin Bırak",
   "Custom": "Özel",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Tüm dünya bir sahnedir,\nVe tüm erkekler ve kadınlar sadece oyunculardır;\nOnların çıkışları ve girişleri vardır,\nVe bir adam zamanında birçok rol oynar,\nOnun eylemleri yedi yaşındadır.\n\n— William Shakespeare",
   "Custom Theme": "Özel Tema",
   "Theme Name": "Tema Adı",
   "Text Color": "Metin Rengi",
@@ -248,7 +247,6 @@
   "No description available": "Tanım mevcut değil",
   "List": "Liste",
   "Grid": "Izgara",
-  "(from 'As You Like It', Act II)": "(As You Like It, 2. Perde)",
   "Link Color": "Bağlantı Rengi",
   "Screen": "Ekran",
   "Orientation": "Yönlendirme",
@@ -1935,5 +1933,7 @@
   "Minimal": "Minimal",
   "TTS Player Style": "TTS Oynatıcı Stili",
   "Show translation": "Çeviriyi göster",
-  "Show original": "Orijinali göster"
+  "Show original": "Orijinali göster",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Bütün dünya bir sahne, ve bütün kadınlar, erkekler sadece birer oyuncu; girişleri ve çıkışları var, ve bir insan ömrü boyunca birçok rol oynuyor.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Nasıl Hoşunuza Giderse"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -186,7 +186,6 @@
   "No supported files found. Supported formats: {{formats}}": "Не знайдено підтримуваних файлів. Підтримувані формати: {{formats}}",
   "Drop to Import Books": "Перетягніть для імпорту книг",
   "Custom": "Користувацький",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Так, світ — театр,\nДе всі чоловіки й жінки — актори.\nТут кожному приписаний свій вихід,\nне одну з них кожне грає роль.\nСім дій в тій п’єсі...\nВільям Шекспір\n(переклад Олександра Мокровольського)",
   "Custom Theme": "Користувацька тема",
   "Theme Name": "Назва теми",
   "Text Color": "Колір тексту",
@@ -248,7 +247,6 @@
   "No description available": "Опис недоступний",
   "List": "Список",
   "Grid": "Сітка",
-  "(from 'As You Like It', Act II)": "(із 'Як вам це подобається', Дія II)",
   "Link Color": "Колір посилання",
   "Screen": "Екран",
   "Orientation": "Орієнтація",
@@ -2007,5 +2005,7 @@
   "Minimal": "Мінімальний",
   "TTS Player Style": "Стиль TTS-плеєра",
   "Show translation": "Показати переклад",
-  "Show original": "Показати оригінал"
+  "Show original": "Показати оригінал",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Увесь світ — театр, і всі чоловіки й жінки в ньому — лише актори; вони мають свої виходи й входи, і кожна людина за своє життя грає багато ролей.",
+  "— William Shakespeare, As You Like It": "— Вільям Шекспір, «Як вам це сподобається»"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -993,8 +993,6 @@
   "Ruler Color": "Chizgʻich rangi",
   "Theme Color": "Mavzu rangi",
   "Custom": "Maxsus",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Butun dunyo — sahna,\nVa barcha erkaklar va ayollar oddiy aktyorlardir;\nUlarning oʻz chiqishlari va kirishlari bor,\nVa bir kishi oʻz davrida koʻp rollar oʻynaydi,\nUning amallari yetti yoshda boʻladi.\n\n— Uilyam Shekspir",
-  "(from 'As You Like It', Act II)": "('Sizga maʼqulidir' asaridan, II parda)",
   "Custom Theme": "Maxsus mavzu",
   "Theme Name": "Mavzu nomi",
   "Text Color": "Matn rangi",
@@ -1935,5 +1933,7 @@
   "Minimal": "Minimal",
   "TTS Player Style": "TTS pleyer uslubi",
   "Show translation": "Tarjimani ko'rsatish",
-  "Show original": "Aslini ko'rsatish"
+  "Show original": "Aslini ko'rsatish",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Butun dunyo — sahna, va barcha erkagu ayol faqat aktyorlardir; ularning o‘z chiqishlari va kirishlari bor, va inson umri davomida ko‘p rollarni o‘ynaydi.",
+  "— William Shakespeare, As You Like It": "— Uilyam Shekspir, Xohishingizga ko‘ra"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -186,7 +186,6 @@
   "No supported files found. Supported formats: {{formats}}": "Không tìm thấy tệp được hỗ trợ. Định dạng được hỗ trợ: {{formats}}",
   "Drop to Import Books": "Kéo và thả để nhập sách",
   "Custom": "Tùy chỉnh",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "Cả thế giới này là một sân khấu,\nVà tất cả đàn ông và phụ nữ chỉ là những diễn viên;\nHọ có cửa ra và cửa vào của mình,\nVà một người trong cuộc đời mình đóng nhiều vai,\nHành động của mình là bảy tuổi.\n\n— William Shakespeare",
   "Custom Theme": "Chủ đề tùy chỉnh",
   "Theme Name": "Tên chủ đề",
   "Text Color": "Màu văn bản",
@@ -248,7 +247,6 @@
   "No description available": "Không có mô tả nào",
   "List": "Danh sách",
   "Grid": "Lưới",
-  "(from 'As You Like It', Act II)": "(từ 'Như bạn thích', Hành động II)",
   "Link Color": "Màu liên kết",
   "Screen": "Màn hình",
   "Orientation": "Định hướng",
@@ -1899,5 +1897,7 @@
   "Minimal": "Tối giản",
   "TTS Player Style": "Kiểu trình phát TTS",
   "Show translation": "Hiển thị bản dịch",
-  "Show original": "Hiển thị bản gốc"
+  "Show original": "Hiển thị bản gốc",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Cả thế giới là một sân khấu, và tất cả đàn ông đàn bà chỉ là những diễn viên; họ có lúc ra và lúc vào, và một người trong đời mình đóng nhiều vai.",
+  "— William Shakespeare, As You Like It": "— William Shakespeare, Theo Ý Thích"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -187,7 +187,6 @@
   "No supported files found. Supported formats: {{formats}}": "未找到支持的文件。支持的格式：{{formats}}",
   "Drop to Import Books": "拖放导入书籍",
   "Custom": "自定义",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "世界是座舞台， \n所有男女都只是演员； \n各有其出场和入场； \n每个人皆扮演许多角色， \n而演出共分为七个阶段。\n\n——威廉·莎士比亚",
   "Custom Theme": "自定义主题",
   "Theme Name": "主题名称",
   "Text Color": "文本颜色",
@@ -249,7 +248,6 @@
   "No description available": "暂无简介",
   "List": "列表",
   "Grid": "网格",
-  "(from 'As You Like It', Act II)": "出自《皆大欢喜》，第二幕",
   "Link Color": "链接颜色",
   "Screen": "屏幕",
   "Orientation": "屏幕方向",
@@ -1899,5 +1897,7 @@
   "Minimal": "简约",
   "TTS Player Style": "TTS 播放器样式",
   "Show translation": "显示译文",
-  "Show original": "显示原文"
+  "Show original": "显示原文",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "整个世界是一座舞台，所有的男男女女不过是演员；他们各有登场和退场，一个人一生中要扮演许多角色。",
+  "— William Shakespeare, As You Like It": "— 威廉·莎士比亚，《皆大欢喜》"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -186,7 +186,6 @@
   "No supported files found. Supported formats: {{formats}}": "未找到支援的檔案。支援的格式：{{formats}}",
   "Drop to Import Books": "拖放導入書籍",
   "Custom": "自定義",
-  "All the world's a stage,\nAnd all the men and women merely players;\nThey have their exits and their entrances,\nAnd one man in his time plays many parts,\nHis acts being seven ages.\n\n— William Shakespeare": "世界是一個舞台，\n所有的男人和女人都只是演員：\n他們有出口，也有入口；\n一個人在他的時代扮演許多角​​色。 \n\n——威廉·莎士比亞",
   "Custom Theme": "自定義主題",
   "Theme Name": "主題名稱",
   "Text Color": "文字顏色",
@@ -248,7 +247,6 @@
   "No description available": "暫無簡介",
   "List": "列表",
   "Grid": "網格",
-  "(from 'As You Like It', Act II)": "（出自《皆大歡喜》，第二幕）",
   "Link Color": "連結顏色",
   "Screen": "螢幕",
   "Orientation": "螢幕方向",
@@ -1899,5 +1897,7 @@
   "Minimal": "簡約",
   "TTS Player Style": "TTS 播放器樣式",
   "Show translation": "顯示譯文",
-  "Show original": "顯示原文"
+  "Show original": "顯示原文",
+  "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "整個世界是一座舞臺，所有的男男女女不過是演員；他們各有登場和退場，一個人一生中要扮演許多角色。",
+  "— William Shakespeare, As You Like It": "— 威廉·莎士比亞，《皆大歡喜》"
 }

--- a/apps/readest-app/src/components/settings/ThemePanel.tsx
+++ b/apps/readest-app/src/components/settings/ThemePanel.tsx
@@ -332,7 +332,12 @@ const ThemePanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset
   };
 
   return (
-    <div className='my-4 w-full space-y-6'>
+    // In editor mode the ThemeEditor owns its own top spacing (mt-6) and pins a
+    // sticky Save/Cancel footer to the scroll bottom. Dropping the wrapper's
+    // bottom margin here removes the gap between the editor's bottom edge and
+    // the scroll viewport, so the footer sits flush with no bottom gap and no
+    // upward jump when scrolled to the end.
+    <div className={clsx('w-full', showCustomThemeEditor ? '' : 'my-4 space-y-6')}>
       {showCustomThemeEditor ? (
         <ThemeEditor
           customTheme={editTheme}

--- a/apps/readest-app/src/components/settings/color/ThemeEditor.tsx
+++ b/apps/readest-app/src/components/settings/color/ThemeEditor.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from '@/hooks/useTranslation';
 import { CustomTheme } from '@/styles/themes';
 import { md5Fingerprint } from '@/utils/md5';
@@ -32,7 +33,9 @@ const ThemePreview: React.FC<{
         }}
       >
         <p className='mb-2 whitespace-pre-line break-words text-xs'>
-          {_('All that glisters is not gold.')}
+          {_(
+            'All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.',
+          )}
           {'\n\n'}
           <span
             className='mt-4 cursor-pointer italic'
@@ -40,7 +43,7 @@ const ThemePreview: React.FC<{
               color: primaryColor,
             }}
           >
-            {_('— William Shakespeare, Merchant of Venice')}
+            {_('— William Shakespeare, As You Like It')}
           </span>
         </p>
       </div>
@@ -116,8 +119,46 @@ const ThemeEditor: React.FC<ThemeEditorProps> = ({ customTheme, onSave, onDelete
     };
   };
 
+  // Render the Save/Cancel bar outside the dialog's scroll viewport (pinned to
+  // the modal box) instead of as a sticky footer inside it. A sticky footer
+  // overlaps the scrolling preview cards, which leaks a hairline of card pixels
+  // at its clipped bottom edge on fractional-DPR screens and jumps a pixel when
+  // the scroll bottoms out. Portaling it out of the scroller sidesteps both.
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [footerContainer, setFooterContainer] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setFooterContainer(rootRef.current?.closest<HTMLElement>('.modal-box') ?? null);
+  }, []);
+
+  const footer = (
+    <div
+      className={clsx(
+        'flex shrink-0 bg-base-200 px-6 py-2 sm:px-[10%]',
+        existingTheme ? 'justify-between' : 'justify-end',
+      )}
+    >
+      {existingTheme && (
+        <button className='btn btn-error btn-sm px-2' onClick={() => onDelete(getCustomTheme())}>
+          {_('Delete')}
+        </button>
+      )}
+
+      <div className='flex gap-2'>
+        <button className='btn btn-ghost btn-sm px-2' onClick={onCancel}>
+          {_('Cancel')}
+        </button>
+        <button
+          className='btn btn-contrast btn-sm text-base-content px-2'
+          onClick={() => onSave(getCustomTheme())}
+        >
+          {_('Save')}
+        </button>
+      </div>
+    </div>
+  );
+
   return (
-    <div className='flex flex-col gap-2 mt-6 rounded-lg'>
+    <div ref={rootRef} className='flex flex-col gap-2 mt-6 rounded-lg'>
       <div className='flex items-center gap-4'>
         <label className='font-medium whitespace-nowrap'>{_('Theme Name')}</label>
         <input
@@ -129,7 +170,7 @@ const ThemeEditor: React.FC<ThemeEditorProps> = ({ customTheme, onSave, onDelete
         />
       </div>
 
-      <div className='grid grid-cols-2 gap-6 mt-4'>
+      <div className='grid grid-cols-1 gap-4 mt-4 sm:grid-cols-2 sm:gap-6'>
         <div className='bg-base-100 rounded-lg p-3'>
           <h3 className='mb-3 truncate text-center font-medium' title={_('Light Mode')}>
             {_('Light Mode')}
@@ -195,30 +236,7 @@ const ThemeEditor: React.FC<ThemeEditorProps> = ({ customTheme, onSave, onDelete
           />
         </div>
       </div>
-      <div
-        className={clsx(
-          'flex sticky bottom-0 bg-base-200 py-2',
-          existingTheme ? 'justify-between' : 'justify-end',
-        )}
-      >
-        {existingTheme && (
-          <button className='btn btn-error btn-sm px-2' onClick={() => onDelete(getCustomTheme())}>
-            {_('Delete')}
-          </button>
-        )}
-
-        <div className='flex gap-2'>
-          <button className='btn btn-ghost btn-sm px-2' onClick={onCancel}>
-            {_('Cancel')}
-          </button>
-          <button
-            className='btn btn-contrast btn-sm text-base-content px-2'
-            onClick={() => onSave(getCustomTheme())}
-          >
-            {_('Save')}
-          </button>
-        </div>
-      </div>
+      {footerContainer ? createPortal(footer, footerContainer) : footer}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

The custom theme editor's preview now uses the well-known "All the world's a stage" passage from *As You Like It*. That longer passage exposed two layout problems in the editor, which this PR also fixes.

## Changes

- **Responsive preview cards** — the Light/Dark preview cards stack into a single full-width column below the `sm` breakpoint. They were previously locked to two columns, so on a phone the longer passage wrapped into two cramped ~150px columns.
- **Action bar pinned outside the scroller** — the Save/Cancel bar is portaled into the modal box instead of being a sticky footer inside the dialog's scroll viewport. As a sticky footer it overlapped the scrolling preview cards, leaked a 1px sliver of a card at its clipped bottom edge on fractional-DPR (retina) screens, and jumped ~1px when the content scrolled to the bottom. Moving it out of the scroller removes all three by construction.
- **i18n** — the new preview strings are translated across all 33 locales; the retired Merchant of Venice strings and a stale duplicate passage were pruned by `i18n:extract`.

## Testing

- `pnpm lint` (Biome + tsgo) — clean
- `pnpm test` — 7688 passed, 7 skipped
- Verified live in the browser: DOM confirms the action bar is a direct child of `.modal-box`, entirely below the scroll clip (no leak, no shift); single column on mobile, two columns on desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)