### PR TITLE
fix(reader): keep captured turns aligned with the finger

### DIFF
--- a/apps/readest-app/src/__tests__/document/paginator-turn-styles.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/paginator-turn-styles.browser.test.ts
@@ -41,6 +41,7 @@ const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 describe('Page turn styles (browser)', () => {
   let paginator: Renderer;
+  let transitionRoot: HTMLDivElement | null = null;
 
   beforeAll(async () => {
     ltrBook = await loadEPUB(LTR_EPUB_URL, 'sample-alice.epub');
@@ -48,7 +49,7 @@ describe('Page turn styles (browser)', () => {
     await import('foliate-js/paginator.js');
   }, 30000);
 
-  const createPaginator = () => {
+  const createPaginator = (rootWidth?: number) => {
     const el = document.createElement('foliate-paginator') as Renderer;
     Object.assign(el.style, {
       width: '800px',
@@ -57,12 +58,26 @@ describe('Page turn styles (browser)', () => {
       left: '0',
       top: '0',
     });
-    document.body.appendChild(el);
+    if (rootWidth) {
+      transitionRoot = document.createElement('div');
+      transitionRoot.setAttribute('data-view-transition-root', '');
+      Object.assign(transitionRoot.style, {
+        width: `${rootWidth}px`,
+        height: '600px',
+        position: 'absolute',
+        left: '0',
+        top: '0',
+      });
+      transitionRoot.appendChild(el);
+      document.body.appendChild(transitionRoot);
+    } else {
+      document.body.appendChild(el);
+    }
     return el;
   };
 
-  const setup = async (book: BookDoc, style: string, index = 3) => {
-    paginator = createPaginator();
+  const setup = async (book: BookDoc, style: string, index = 3, rootWidth?: number) => {
+    paginator = createPaginator(rootWidth);
     paginator.setAttribute('animated', '');
     paginator.setAttribute('turn-style', style);
     paginator.open(book);
@@ -81,6 +96,8 @@ describe('Page turn styles (browser)', () => {
       }
       paginator.remove();
     }
+    transitionRoot?.remove();
+    transitionRoot = null;
     // A transition may still be running; let it finish before the next test.
     await wait(600);
   });
@@ -244,6 +261,11 @@ describe('Page turn styles (browser)', () => {
         (a.effect as KeyframeEffect | null)?.pseudoElement?.includes('(foliate-turn)'),
       );
 
+  const scrubProgress = (animation: Animation) => {
+    const duration = Number((animation.effect as KeyframeEffect).getTiming().duration);
+    return Number(animation.currentTime) / (duration * 0.999);
+  };
+
   it('tracks the finger: the paused snapshot follows the drag and commits on release', async () => {
     await setup(ltrBook, 'slide');
     const page = paginator.page;
@@ -261,10 +283,13 @@ describe('Page turn styles (browser)', () => {
       await wait(16);
     }
     // Mid-drag: the transition exists, is paused, and its progress tracks the
-    // finger (~180px of an 800px-wide page).
+    // finger (~180px of total travel on an 800px-wide page).
     const anims = scrubbedAnimations();
     expect(anims.length).toBeGreaterThan(0);
     expect(anims.every((a) => a.playState === 'paused')).toBe(true);
+    expect(anims.every((a) => (a.effect as KeyframeEffect).getTiming().easing === 'linear')).toBe(
+      true,
+    );
     const timeA = Number(anims[0]!.currentTime);
     expect(timeA).toBeGreaterThan(0);
     x -= 60;
@@ -283,6 +308,46 @@ describe('Page turn styles (browser)', () => {
     }
     expect(paginator.page).toBe(page + 1);
     expect(phases).toEqual(['before-capture', 'covered', 'ready', 'finished']);
+  });
+
+  it('uses the named transition root width while preserving total drag distance', async () => {
+    await setup(ltrBook, 'slide', 3, 1000);
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    expect(paginator.getBoundingClientRect().width).toBe(800);
+    expect(transitionRoot?.getBoundingClientRect().width).toBe(1000);
+
+    // This first move exceeds 24px but remains too diagonal to claim. The
+    // second becomes horizontal enough only after 80px of travel. Recognition
+    // catches the snapshot up to that cumulative displacement.
+    fireTouch('touchstart', 700, 300);
+    fireTouch('touchmove', 640, 345);
+    expect(scrubbedAnimations()).toHaveLength(0);
+    fireTouch('touchmove', 620, 330);
+    const t0 = performance.now();
+    while (
+      (scrubbedAnimations().length === 0 ||
+        scrubbedAnimations().some((animation) => animation.playState !== 'paused')) &&
+      performance.now() - t0 < 1000
+    ) {
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    }
+    const animations = scrubbedAnimations();
+    expect(animations.length).toBeGreaterThan(0);
+    expect(scrubProgress(animations[0]!)).toBeCloseTo(80 / 1000, 2);
+
+    // Further movement remains one-to-one against the actual 1000px snapshot.
+    fireTouch('touchmove', 540, 330);
+    await vi.waitFor(() => expect(scrubProgress(animations[0]!)).toBeCloseTo(160 / 1000, 2));
+
+    // Return to the origin and cancel so no transition leaks into cleanup.
+    fireTouch('touchmove', 700, 300);
+    fireTouch('touchend', 700, 300);
+    await vi.waitFor(() => expect(phases.at(-1)).toBe('finished'), { timeout: 2000 });
+    expect(scrubbedAnimations()).toHaveLength(0);
   });
 
   it('tracks the finger: a mostly-returned drag reverses without turning', async () => {

--- a/apps/readest-app/src/__tests__/hooks/useCapturedTurn-scrollLock.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useCapturedTurn-scrollLock.test.ts
@@ -127,6 +127,94 @@ describe('useCapturedTurn scroll-lock gate', () => {
     expect(h.controller.beginDrag).toHaveBeenCalled();
   });
 
+  test('catches the captured drag up to the activation-threshold distance', async () => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start'));
+    dispatchTouchInterceptors('book-1', detail('move', -15, 0));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(h.controller.moveDrag).toHaveBeenLastCalledWith(15 / window.innerWidth, 0.5);
+  });
+
+  test('preserves total travel when horizontal intent is recognized later', async () => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start'));
+    dispatchTouchInterceptors('book-1', detail('move', -60, 80));
+    expect(h.controller.beginDrag).not.toHaveBeenCalled();
+
+    dispatchTouchInterceptors('book-1', detail('move', -100, 80));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(h.controller.moveDrag).toHaveBeenLastCalledWith(
+      100 / window.innerWidth,
+      expect.any(Number),
+    );
+  });
+
+  test('forwards the latest sample before queueing release while capture is pending', async () => {
+    let finishCapture!: (ok: boolean) => void;
+    h.controller.beginDrag.mockImplementationOnce(
+      () => new Promise<boolean>((resolve) => (finishCapture = resolve)),
+    );
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start'));
+    dispatchTouchInterceptors('book-1', detail('move', -15, 0));
+    dispatchTouchInterceptors('book-1', detail('move', -240, 10));
+    const released = dispatchTouchInterceptors('book-1', detail('end', -240, 10));
+
+    expect(released).toBe(true);
+    expect(h.controller.endDrag).toHaveBeenCalledWith(true);
+    const lastSample = h.controller.moveDrag.mock.calls.at(-1)!;
+    // 240px of total travel across the 300px captured reader cell.
+    expect(lastSample[0]).toBeCloseTo(0.8);
+    expect(lastSample[1]).toBeCloseTo(0.52);
+    expect(h.controller.moveDrag.mock.invocationCallOrder.at(-1)!).toBeLessThan(
+      h.controller.endDrag.mock.invocationCallOrder[0]!,
+    );
+
+    await act(async () => {
+      finishCapture(true);
+      await Promise.resolve();
+    });
+  });
+
+  test('commits a short fast flick before halfway', () => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start'));
+    dispatchTouchInterceptors('book-1', detail('move', -20, 0));
+    dispatchTouchInterceptors('book-1', { ...detail('end', -20, 0), deltaT: 50 });
+
+    // 20px / 50ms = 0.4px/ms, above the 0.3 flick threshold.
+    expect(h.controller.endDrag).toHaveBeenCalledWith(true);
+  });
+
+  test('cancels an unfinished drag before accepting a replacement touch sequence', () => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start'));
+    dispatchTouchInterceptors('book-1', detail('move', -60, 0));
+    dispatchTouchInterceptors('book-1', detail('start'));
+    dispatchTouchInterceptors('book-1', detail('move', -60, 0));
+
+    expect(h.controller.beginDrag).toHaveBeenCalledTimes(2);
+    expect(h.controller.endDrag).toHaveBeenCalledWith(false);
+    expect(h.controller.endDrag.mock.invocationCallOrder[0]!).toBeLessThan(
+      h.controller.beginDrag.mock.invocationCallOrder[1]!,
+    );
+  });
+
   test('touch cancellation always reverses an active captured drag', () => {
     renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
 

--- a/apps/readest-app/src/__tests__/hooks/useTouchEvent.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTouchEvent.test.tsx
@@ -231,6 +231,105 @@ describe('useTouchEvent pinch vs two-finger scroll', () => {
   test.each([
     'curl',
     'slide',
+  ] as const)('keeps the toolbar visible when a web %s turn claims after the pre-claim gap', (pageTurnStyle) => {
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle,
+      animated: true,
+      isEink: false,
+      disableSwipe: false,
+    });
+    mocks.getView.mockReturnValue({
+      renderer: {
+        getAttribute: (name: string) => (name === 'turn-style' ? pageTurnStyle : null),
+      },
+    });
+    const h = renderTouchHook();
+
+    h.current.onTouchStart(touchEvent([touch(200, 300)], 100));
+    // Readest's 15px native threshold has been crossed, but the paginator's
+    // stricter browser-layered gate has not claimed the gesture yet.
+    h.current.onTouchMove(touchEvent([touch(184, 300)], 116));
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+
+    // The paginator synchronously claims on a later raw touchmove before its
+    // forwarded iframe message arrives. Ownership stays sticky through the
+    // cancellation lifecycle, even if `finished` precedes touchend delivery.
+    setLayeredTurnGestureActive('book-1', true);
+    h.current.onTouchMove(touchEvent([touch(175, 300)], 132));
+    h.current.onTouchMove(touchEvent([touch(190, 300)], 148));
+    setLayeredTurnGestureActive('book-1', false);
+    h.current.onTouchEnd(touchEvent([], 164, [touch(190, 300)]));
+
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    'curl',
+    'slide',
+  ] as const)('does not hide the toolbar when an unclaimed web %s turn is cancelled', (pageTurnStyle) => {
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle,
+      animated: true,
+      isEink: false,
+      disableSwipe: false,
+    });
+    mocks.getView.mockReturnValue({
+      renderer: {
+        getAttribute: (name: string) => (name === 'turn-style' ? pageTurnStyle : null),
+      },
+    });
+    const h = renderTouchHook();
+
+    h.current.onTouchStart(touchEvent([touch(200, 300)], 100));
+    h.current.onTouchMove(touchEvent([touch(184, 300)], 116));
+    h.current.onTouchCancel(touchEvent([], 132, [touch(184, 300)]));
+
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    'curl',
+    'slide',
+  ] as const)('defers an unclaimed web %s toolbar update until touchend', (pageTurnStyle) => {
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle,
+      animated: true,
+      isEink: false,
+      disableSwipe: false,
+    });
+    mocks.getView.mockReturnValue({
+      renderer: {
+        getAttribute: (name: string) => (name === 'turn-style' ? pageTurnStyle : null),
+      },
+    });
+    const h = renderTouchHook();
+
+    h.current.onTouchStart(touchEvent([touch(200, 300)], 100));
+    h.current.onTouchMove(touchEvent([touch(184, 300)], 116));
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+
+    h.current.onTouchEnd(touchEvent([], 132, [touch(184, 300)]));
+    expect(mocks.setHoveredBookKey).toHaveBeenCalledWith(null);
+  });
+
+  test.each([
+    'curl',
+    'slide',
   ] as const)('does not fade the web %s toolbar before a fast flick snapshot settles', (pageTurnStyle) => {
     mocks.hoveredBookKey = 'book-1';
     mocks.getBookData.mockReturnValue({ isFixedLayout: false });

--- a/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
@@ -430,6 +430,79 @@ describe('CapturedPageTurn (browser)', () => {
     rapid.dispose();
   });
 
+  it('settles a pending capture from its latest buffered drag sample', async () => {
+    let resolveCapture!: (image: ArrayBuffer) => void;
+    const deferredCapture = new Promise<ArrayBuffer>((resolve) => {
+      resolveCapture = resolve;
+    });
+    const rapid = new CapturedPageTurn(
+      {
+        getHostElement: () => host,
+        getContentRect: contentRect,
+        capture: () => deferredCapture,
+        navigate,
+      },
+      { duration: 5000 },
+    );
+
+    const beginning = rapid.beginDrag(true, false, 'slide');
+    rapid.moveDrag(0.75, 0.52);
+    const ending = rapid.endDrag(true);
+    resolveCapture(await makePngBuffer());
+
+    await beginning;
+    const canvas = host.querySelector('canvas')!;
+    expect(new DOMMatrixReadOnly(getComputedStyle(canvas).transform).e).toBeCloseTo(-W * 0.75, 0);
+
+    // Stop the deliberately slow settle and let its promise drain.
+    rapid.dispose();
+    await ending;
+  });
+
+  it('cancels an unreleased drag before starting its replacement', async () => {
+    expect(await controller.beginDrag(true, false, 'slide')).toBe(true);
+    controller.moveDrag(0.3, 0.5);
+
+    // No endDrag for the first gesture: beginDrag must synthesize its cancel
+    // before it captures and navigates the replacement page.
+    expect(await controller.beginDrag(true, false, 'slide')).toBe(true);
+    expect(navigate).toHaveBeenNthCalledWith(1, true);
+    expect(navigate).toHaveBeenNthCalledWith(2, false);
+    expect(navigate).toHaveBeenNthCalledWith(3, true);
+
+    await controller.endDrag(false);
+    expect(navigate).toHaveBeenNthCalledWith(4, false);
+    expect(host.querySelector('canvas')).toBeNull();
+  });
+
+  it('cancels an unreleased drag before a programmatic turn', async () => {
+    expect(await controller.beginDrag(true, false, 'slide')).toBe(true);
+    controller.moveDrag(0.3, 0.5);
+
+    expect(await controller.turn(true, false, 'slide')).toBe(true);
+    expect(navigate).toHaveBeenNthCalledWith(1, true);
+    expect(navigate).toHaveBeenNthCalledWith(2, false);
+    expect(navigate).toHaveBeenNthCalledWith(3, true);
+    expect(host.querySelector('canvas')).toBeNull();
+  });
+
+  it('ignores drag samples delivered after release', async () => {
+    const slow = new CapturedPageTurn(
+      { getHostElement: () => host, getContentRect: contentRect, capture, navigate },
+      { duration: 5000 },
+    );
+    expect(await slow.beginDrag(true, false, 'slide')).toBe(true);
+    const canvas = host.querySelector('canvas')!;
+    slow.moveDrag(0.25, 0.5);
+    const ending = slow.endDrag(true);
+
+    slow.moveDrag(0.9, 0.5);
+    expect(new DOMMatrixReadOnly(getComputedStyle(canvas).transform).e).toBeCloseTo(-W * 0.25, 0);
+
+    slow.dispose();
+    await ending;
+  });
+
   it('does not mount or navigate when disposed during capture', async () => {
     let resolveCapture!: (image: ArrayBuffer) => void;
     const deferredCapture = new Promise<ArrayBuffer>((resolve) => {

--- a/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
+++ b/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
@@ -13,6 +13,7 @@ import { renderTurnBackdrop } from '../utils/turnBackdrop';
 import {
   setLayeredTurnGestureActive,
   TOUCH_SWIPE_THRESHOLD_PX,
+  type TouchDetail,
   useTouchInterceptor,
 } from './useTouchInterceptor';
 
@@ -75,6 +76,8 @@ interface DragState {
   forward: boolean;
   width: number;
   height: number;
+  progress: number;
+  grabY: number;
 }
 
 // Whether the visible section's document holds a non-collapsed selection —
@@ -292,6 +295,11 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
       if (!currentView || !controller) return false;
 
       if (detail.phase === 'start') {
+        // Some webviews can start a replacement touch sequence without
+        // delivering the previous touchend. Cancel the old drag before its
+        // state is replaced so it cannot remain over, or settle onto, the
+        // following page.
+        if (dragRef.current) controller.endDrag(false).catch(() => {});
         dragRef.current = null;
         gestureClaimed.current = hasActiveSelection(currentView);
         return false;
@@ -333,10 +341,16 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
             forward,
             width: rect?.width || window.innerWidth,
             height: rect?.height || window.innerHeight,
+            progress: 0,
+            grabY: 0.5,
           };
+          updateDragSample(startedState, detail, viewSettings.rtl);
           dragRef.current = startedState;
-          controller
-            .beginDrag(forward, viewSettings.rtl, style)
+          const beginning = controller.beginDrag(forward, viewSettings.rtl, style);
+          // moveDrag buffers this initial sample even while native capture is
+          // pending, then applies it before a queued release can settle.
+          controller.moveDrag(startedState.progress, startedState.grabY);
+          beginning
             .then((ok) => {
               if (!ok) {
                 if (dragRef.current === startedState) dragRef.current = null;
@@ -348,12 +362,8 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
             });
           return true;
         }
-        controller.moveDrag(
-          dragProgress(state, detail.deltaX, viewSettings?.rtl ?? false),
-          // The fold tilts as the finger strays vertically, curling corners
-          // like a real page pinch.
-          Math.max(0.05, Math.min(0.95, 0.5 + detail.deltaY / state.height)),
-        );
+        updateDragSample(state, detail, viewSettings?.rtl ?? false);
+        controller.moveDrag(state.progress, state.grabY);
         return true;
       }
 
@@ -361,16 +371,19 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
       const state = dragRef.current;
       if (!state) return false;
       dragRef.current = null;
+      updateDragSample(state, detail, viewSettings?.rtl ?? false);
+      // Store the release position before endDrag joins the controller's
+      // serialized queue. This ordering also covers touchcancel.
+      controller.moveDrag(state.progress, state.grabY);
       if (detail.phase === 'cancel') {
         controller.endDrag(false).catch(() => {});
         return true;
       }
-      const progress = dragProgress(state, detail.deltaX, viewSettings?.rtl ?? false);
-      const signed = progress * state.width;
+      const signed = dragDistance(state, detail.deltaX, viewSettings?.rtl ?? false);
       const velocity = signed / (detail.deltaT || 1);
       // Same carousel rule as the paginator: a flick along the turn commits
       // regardless of distance; otherwise commit past halfway.
-      const commit = velocity > 0.3 ? true : progress > 0.5;
+      const commit = velocity > 0.3 ? true : state.progress > 0.5;
       // CapturedPageTurn serializes endDrag behind an in-flight beginDrag, so
       // queue release immediately. This also keeps a following gesture behind
       // the complete begin/end pair instead of letting it supersede the turn.
@@ -383,7 +396,21 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
 };
 
 const dragProgress = (state: DragState, deltaX: number, rtl: boolean) => {
-  const along = rtl ? -deltaX : deltaX;
-  const signed = state.forward ? -along : along;
+  const signed = dragDistance(state, deltaX, rtl);
+  // Preserve the full displacement from touchstart: recognition catches the
+  // animation up to the gesture, and later progress remains based on the same
+  // cumulative travel.
   return Math.max(0, Math.min(1, signed / state.width));
+};
+
+const dragDistance = (state: DragState, deltaX: number, rtl: boolean) => {
+  const along = rtl ? -deltaX : deltaX;
+  return state.forward ? -along : along;
+};
+
+const updateDragSample = (state: DragState, detail: TouchDetail, rtl: boolean) => {
+  state.progress = dragProgress(state, detail.deltaX, rtl);
+  // The fold tilts as the finger strays vertically, curling corners like a
+  // real page pinch.
+  state.grabY = Math.max(0.05, Math.min(0.95, 0.5 + detail.deltaY / state.height));
 };

--- a/apps/readest-app/src/app/reader/hooks/useIframeEvents.ts
+++ b/apps/readest-app/src/app/reader/hooks/useIframeEvents.ts
@@ -144,12 +144,25 @@ export const useTouchEvent = (bookKey: string) => {
   const touchEndTimeRef = useRef<number | null>(null);
   const touchConsumedRef = useRef(false);
   const layeredTurnOwnedRef = useRef(false);
+  const layeredTurnCandidateRef = useRef(false);
   // Two fingers on a fixed-layout book start in a "pending" state: we wait to
   // see whether they spread/converge (pinch) or slide together (scroll) before
   // committing. isPinchingRef only flips true once a pinch is confirmed.
   const pinchPendingRef = useRef(false);
 
   const isLifecycleManagedLayeredTurn = () => isLayeredTurnGestureActive(bookKey);
+  const isLayeredTurnCandidate = () => {
+    const viewSettings = getViewSettings(bookKey);
+    if (!viewSettings || getBookData(bookKey)?.isFixedLayout) return false;
+    const turnStyle = getView(bookKey)?.renderer.getAttribute?.('turn-style');
+    return (
+      (turnStyle === 'slide' || turnStyle === 'curl') &&
+      viewSettings.animated &&
+      !viewSettings.scrolled &&
+      !viewSettings.isEink &&
+      !viewSettings.disableSwipe
+    );
+  };
   const isPinchingRef = useRef(false);
   const initialTouch0Ref = useRef<IframeTouch | null>(null);
   const initialTouch1Ref = useRef<IframeTouch | null>(null);
@@ -183,6 +196,7 @@ export const useTouchEvent = (bookKey: string) => {
 
   const onTouchStart = (e: IframeTouchEvent | React.TouchEvent<HTMLDivElement>) => {
     layeredTurnOwnedRef.current = false;
+    layeredTurnCandidateRef.current = false;
     const t0 = e.targetTouches[0] as IframeTouch | undefined;
     const t1 = e.targetTouches[1] as IframeTouch | undefined;
     if (t0 && t1) {
@@ -201,6 +215,7 @@ export const useTouchEvent = (bookKey: string) => {
       }
     }
     if (!t0) return;
+    layeredTurnCandidateRef.current = isLayeredTurnCandidate();
     touchStartRef.current = t0;
     touchStartTimeRef.current = 'timeStamp' in e ? e.timeStamp : Date.now();
     touchConsumedRef.current = false;
@@ -279,6 +294,15 @@ export const useTouchEvent = (bookKey: string) => {
     if (layeredTurnOwnedRef.current) return;
     const { current: touchStart } = touchStartRef;
     const { current: touchEnd } = touchEndRef;
+    if (layeredTurnCandidateRef.current && touchEnd) {
+      const deltaX = touchEnd.screenX - touchStart.screenX;
+      const deltaY = touchEnd.screenY - touchStart.screenY;
+      // Browser layered turns use a stricter, direction-aware paginator gate
+      // than native captured turns. Do not hide the toolbar in the gap before
+      // `before-capture`: if the paginator claims later, its snapshot lifecycle
+      // takes over; if it never claims, touchend runs the generic behavior.
+      if (Math.abs(deltaX) > Math.abs(deltaY)) return;
+    }
     if (hoveredBookKey && touchEnd) {
       const viewSettings = getViewSettings(bookKey)!;
       const deltaY = touchEnd.screenY - touchStart.screenY;
@@ -295,6 +319,7 @@ export const useTouchEvent = (bookKey: string) => {
   };
 
   const onTouchEnd = (e: IframeTouchEvent | React.TouchEvent<HTMLDivElement>) => {
+    layeredTurnCandidateRef.current = false;
     if (isPinchingRef.current || pinchPendingRef.current) {
       const t0 = e.targetTouches[0] as IframeTouch | undefined;
       const t1 = e.targetTouches[1] as IframeTouch | undefined;
@@ -424,6 +449,7 @@ export const useTouchEvent = (bookKey: string) => {
   };
 
   const onTouchCancel = (e: IframeTouchEvent | React.TouchEvent<HTMLDivElement>) => {
+    layeredTurnCandidateRef.current = false;
     if (isPinchingRef.current || pinchPendingRef.current) {
       getView(bookKey)?.renderer.pinchEnd?.();
       isPinchingRef.current = false;

--- a/apps/readest-app/src/app/reader/hooks/useTouchInterceptor.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTouchInterceptor.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react';
 
-// A horizontal page-turn gesture becomes intentional at this distance. Keep
-// the generic toolbar handling and captured turn interceptor on the same
-// boundary so neither can act in the gap before the other claims the swipe.
+// Native captured turns become intentional at this distance. Browser layered
+// turns keep the paginator's stricter claim gate; generic toolbar handling
+// defers its move-time update while that path can still claim the gesture.
 export const TOUCH_SWIPE_THRESHOLD_PX = 15;
 
 // Movement below this distance is still a tap. Touchend must leave these
@@ -11,9 +11,9 @@ export const TOUCH_SWIPE_THRESHOLD_PX = 15;
 export const TOUCH_TAP_SLOP_PX = TOUCH_SWIPE_THRESHOLD_PX;
 
 // The paginator announces layered turns only after it has actually claimed a
-// horizontal gesture. Generic toolbar handling yields to that active gesture,
-// not merely to a configured turn style (which may be inactive in scroll,
-// E-ink, no-animation, selection, or boundary cases).
+// horizontal gesture. This remains the authoritative lifecycle ownership once
+// active; candidate detection only delays generic move-time toolbar changes
+// until the paginator either claims the gesture or it ends normally.
 const activeLayeredTurnGestures = new Set<string>();
 
 export const setLayeredTurnGestureActive = (bookKey: string, active: boolean) => {

--- a/apps/readest-app/src/app/reader/utils/capturedTurn.ts
+++ b/apps/readest-app/src/app/reader/utils/capturedTurn.ts
@@ -64,6 +64,11 @@ interface TurnRenderer {
   dispose(): void;
 }
 
+interface DragSession {
+  progress: number;
+  grabY: number;
+}
+
 interface ActiveTurn {
   overlay: HTMLElement;
   renderer: TurnRenderer;
@@ -73,6 +78,8 @@ interface ActiveTurn {
   rendererRtl: boolean;
   progress: number;
   grabY: number;
+  /** Buffered input and identity token, absent for programmatic turns. */
+  dragSession: DragSession | null;
   raf: number;
   /** Resolves when the play-out animation finishes or is interrupted. */
   finish: (() => void) | null;
@@ -84,8 +91,10 @@ export class CapturedPageTurn {
   #host: CapturedTurnHost;
   #duration: number;
   #active: ActiveTurn | null = null;
+  /** Latest sample and identity for the currently open finger drag. */
+  #dragSession: DragSession | null = null;
   #disposed = false;
-  /** Serializes turns: a new turn interrupts and awaits the previous one. */
+  /** Serializes drag setup/settle and accepted programmatic turns. */
   #pending: Promise<unknown> = Promise.resolve();
   /** True while a programmatic `turn()` is running, gating concurrent ones. */
   #running = false;
@@ -115,6 +124,9 @@ export class CapturedPageTurn {
     // page straight back the moment the first turn lands.
     if (this.#running) return false;
     this.#running = true;
+    // An accepted keyboard/tap turn can also race a touch sequence whose end
+    // event was dropped. Restore that drag before capturing the new turn.
+    this.#cancelOpenDrag();
     const run = this.#pending.then(async () => {
       try {
         if (this.#disposed) return false;
@@ -141,21 +153,42 @@ export class CapturedPageTurn {
 
   /**
    * Finger-tracked turn: captures, navigates instantly under the overlay,
-   * and leaves the turn at progress 0 for `moveDrag` to scrub. Resolves
-   * false when the turn could not start (no host element/rect).
+   * then applies the latest `moveDrag` sample (including samples buffered
+   * during capture). Resolves false when the turn could not start (no host
+   * element/rect).
    */
   async beginDrag(
     forward: boolean,
     rtl: boolean,
     style: CapturedTurnStyle = 'curl',
   ): Promise<boolean> {
+    // A replacement drag can arrive when a platform drops the previous
+    // touchend. Cancel that specific request before queueing the new one;
+    // token matching keeps the synthesized cancellation on its own overlay.
+    this.#cancelOpenDrag();
+    const session: DragSession = { progress: 0, grabY: 0.5 };
+    this.#dragSession = session;
     const run = this.#pending.then(async () => {
-      if (this.#disposed) return false;
+      if (this.#disposed) {
+        if (this.#dragSession === session) this.#dragSession = null;
+        return false;
+      }
       this.#finishActive();
-      const active = await this.#setUp(forward, rtl, style);
-      if (!active) return false;
-      active.renderer.render(active.progress, this.#grab(active), active.rendererRtl);
-      return true;
+      try {
+        const active = await this.#setUp(forward, rtl, style, session);
+        if (!active) {
+          if (this.#dragSession === session) this.#dragSession = null;
+          return false;
+        }
+        // A sample may have arrived before native capture produced an active
+        // overlay. Apply it before beginDrag resolves, so a queued endDrag
+        // always settles from the latest finger position rather than zero.
+        this.#applyDragSession(active, session);
+        return true;
+      } catch (error) {
+        if (this.#dragSession === session) this.#dragSession = null;
+        throw error;
+      }
     });
     this.#pending = run.catch(() => {});
     return run;
@@ -163,11 +196,15 @@ export class CapturedPageTurn {
 
   /** Scrub the turn from the finger. Safe to call while beginDrag is pending. */
   moveDrag(progress: number, grabY: number) {
+    const session = this.#dragSession;
+    if (!session) return;
+    session.progress = Math.min(1, Math.max(0, progress));
+    session.grabY = grabY;
     const active = this.#active;
-    if (!active) return;
-    active.progress = Math.min(1, Math.max(0, progress));
-    active.grabY = grabY;
-    active.renderer.render(active.progress, this.#grab(active), active.rendererRtl);
+    // A following drag can be queued while the previous overlay is settling.
+    // Never paint the new gesture's sample onto that older page.
+    if (!active || active.dragSession !== session) return;
+    this.#applyDragSession(active, session);
   }
 
   /**
@@ -184,11 +221,22 @@ export class CapturedPageTurn {
    * live view, making every following turn off by one page.
    */
   async endDrag(commit: boolean) {
+    const session = this.#dragSession;
+    if (!session) return;
+    // Seal the released sample immediately. Late touchmoves cannot mutate a
+    // page that has already started committing or returning, while a new
+    // beginDrag can safely install its own independent input buffer.
+    this.#dragSession = null;
+    return this.#endDrag(session, commit);
+  }
+
+  #endDrag(session: DragSession, commit: boolean) {
     const run = this.#pending.then(async () => {
       if (this.#disposed) return;
       const active = this.#active;
-      if (!active) return;
+      if (!active || active.dragSession !== session) return;
       try {
+        this.#applyDragSession(active, session);
         if (commit) {
           await this.#playTo(active, 1);
         } else {
@@ -216,6 +264,13 @@ export class CapturedPageTurn {
     return run;
   }
 
+  #cancelOpenDrag() {
+    const session = this.#dragSession;
+    if (!session) return;
+    this.#dragSession = null;
+    this.#endDrag(session, false).catch(() => {});
+  }
+
   dispose() {
     if (this.#disposed) return;
     this.#disposed = true;
@@ -231,12 +286,14 @@ export class CapturedPageTurn {
       }
     }
     this.#finishActive();
+    this.#dragSession = null;
   }
 
   async #setUp(
     forward: boolean,
     rtl: boolean,
     style: CapturedTurnStyle,
+    dragSession: DragSession | null = null,
   ): Promise<ActiveTurn | null> {
     if (this.#disposed) return null;
     const hostElement = this.#host.getHostElement();
@@ -309,6 +366,7 @@ export class CapturedPageTurn {
       rendererRtl: forward ? rtl : !rtl,
       progress: 0,
       grabY: 0.5,
+      dragSession,
       raf: 0,
       finish: null,
     };
@@ -344,6 +402,12 @@ export class CapturedPageTurn {
     return { x: active.rendererRtl ? 0 : 1, y: active.grabY };
   }
 
+  #applyDragSession(active: ActiveTurn, session: DragSession) {
+    active.progress = session.progress;
+    active.grabY = session.grabY;
+    active.renderer.render(active.progress, this.#grab(active), active.rendererRtl);
+  }
+
   /** Animate the active turn from its current progress to `target`. */
   #playTo(active: ActiveTurn, target: number): Promise<void> {
     return new Promise((resolve) => {
@@ -374,6 +438,9 @@ export class CapturedPageTurn {
     const active = this.#active;
     if (!active) return;
     this.#active = null;
+    if (active.dragSession && this.#dragSession === active.dragSession) {
+      this.#dragSession = null;
+    }
     cancelAnimationFrame(active.raf);
     active.finish?.();
     active.renderer.dispose();


### PR DESCRIPTION
Closes #5215.

Depends on readest/foliate-js#58 (merged).

## Summary

- Preserve touchstart-relative cumulative progress when a captured turn is claimed.
- Buffer drag samples while native capture is pending.
- Apply the latest release sample before settling the captured page.
- Prevent late drag samples or a dropped `touchend` from leaking into a later turn.
- Preserve toolbar state while a browser layered turn is waiting to claim the gesture.
- Add regression coverage for native captured turns and browser View Transition turns.

## Root cause

Browser View Transition turns measured progress against the paginator's inner container instead of the actual named snapshot root. When those widths differed, the page gradually drifted relative to the finger. Some Android WebViews could also retain eased timing because they reject JavaScript timing updates for View Transition pseudo-animations.

The existing touchstart-relative mapping is intentional: when a gesture is recognized, the animation catches up to the distance consumed during recognition instead of remaining behind the finger by the claim threshold.

On the native path, capture can finish after additional drag samples or even after release. Those samples were previously discarded while no active overlay existed, so the settle animation could begin from an older position.

There was also a toolbar ownership gap: Readest's generic handler reacted after 15px, while the browser layered paginator did not claim until at least 24px. A slow drag could therefore hide the toolbar before the snapshot lifecycle recorded its initial state.

## Behavior

- When the gesture is claimed, the turn catches up to the cumulative horizontal displacement since `touchstart`.
- Subsequent progress remains linear against the actual captured reader or named snapshot-root width.
- Capture delay does not discard newer drag samples.
- Quick releases settle from the latest release position.
- Late samples cannot mutate a released turn.
- Replacement gestures and accepted programmatic turns safely cancel stale open drags.
- Claimed Slide/Curl cancellations restore a toolbar that was initially visible.
- Unclaimed gestures retain the existing generic `touchend` behavior.
- Push, selection, scroll-lock, and existing commit/cancel rules remain intact.

## Companion change

readest/foliate-js#58 handles the browser layered-turn changes:

- use the actual named snapshot-root width for cumulative drag progress;
- preserve the existing touchstart-relative gesture mapping;
- enforce linear View Transition scrubbing through CSS, with the JavaScript timing update retained as a best-effort fallback.

The submodule now points to `dd71f2b`, the merged commit of readest/foliate-js#58 on `main`.

## Validation

- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] Focused captured-turn unit tests
- [x] Focused paginator browser tests
- [x] Web build
- [x] Manual slow-drag regression — Slide and Curl
- [x] Manual quick-release regression — Slide and Curl
- [x] Manual claimed-turn cancellation with the toolbar initially visible
