### PR TITLE
fix(reader): keep TTS media session and volume control with volume-key paging

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
@@ -936,10 +936,19 @@ class NativeBridgePlugin: Plugin {
         if volumeKeys {
           self.activateVolumeKeyInterception()
         } else {
+          // Stop intercepting but KEEP the handler alive — do NOT nil it. Its
+          // ReadestTTSAudioSessionClaimed/Released observers must survive the
+          // play/pause cycle. usePagination releases interception the instant TTS
+          // starts playing (the `ttsPlaying` gate) — which is exactly when
+          // tauri-plugin-native-tts posts "Claimed" — and re-acquires it on
+          // pause. If the handler is destroyed here, that fire-once "Claimed" is
+          // lost, and the fresh handler built on the next pause has
+          // ttsOwnsAudioSession=false, so it reconfigures the TTS-owned session
+          // to .mixWithOthers. A mixable session is ineligible for Now Playing,
+          // so iOS vacates the slot and AirPods / lock-screen play resumes
+          // whatever app played before us. A single long-lived handler catches
+          // the claim and leaves the TTS session untouched.
           self.volumeKeyHandler?.stopInterception()
-          DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            self?.volumeKeyHandler = nil
-          }
         }
       }
 

--- a/apps/readest-app/src/__tests__/app/reader/hooks/usePagination-volumeKeys.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/usePagination-volumeKeys.test.ts
@@ -48,6 +48,7 @@ import { interceptKeys } from '@/utils/bridge';
 import { eventDispatcher } from '@/utils/event';
 import { useDeviceControlStore } from '@/store/deviceStore';
 import { usePagination } from '@/app/reader/hooks/usePagination';
+import type { FoliateView } from '@/types/view';
 
 const BOOK_KEY = 'book-1';
 
@@ -55,6 +56,25 @@ const setup = () => {
   const viewRef = { current: null };
   const containerRef = { current: null };
   return renderHook(() => usePagination(BOOK_KEY, viewRef, containerRef));
+};
+
+const makeView = () => ({
+  renderer: { scrolled: false },
+  book: { dir: 'ltr' as const },
+  next: vi.fn(),
+  prev: vi.fn(),
+});
+
+const setupWithView = (view: ReturnType<typeof makeView>) => {
+  const viewRef = { current: view as unknown as FoliateView };
+  const containerRef = { current: null };
+  return renderHook(() => usePagination(BOOK_KEY, viewRef, containerRef));
+};
+
+const pressVolumeKey = async (keyName: 'VolumeUp' | 'VolumeDown') => {
+  await act(async () => {
+    await eventDispatcher.dispatch('native-key-down', { keyName });
+  });
 };
 
 const emitPlayback = async (state: string, bookKey = BOOK_KEY) => {
@@ -134,5 +154,41 @@ describe('usePagination volume-key interception with TTS (#4691)', () => {
     setup();
     expect(interceptKeys).not.toHaveBeenCalledWith({ volumeKeys: true });
     expect(useDeviceControlStore.getState().volumeKeysIntercepted).toBe(false);
+  });
+
+  // The native side still forwards volume keys to the web layer while TTS plays
+  // (iOS via a lingering KVO, Android calls onNativeKeyDown unconditionally), so
+  // handlePageFlip must itself refuse to page-flip while TTS is playing — the
+  // key should fall through to controlling the volume instead.
+  test('does not page-flip on volume keys while TTS is playing', async () => {
+    const view = makeView();
+    setupWithView(view);
+    await emitPlayback('playing');
+
+    await pressVolumeKey('VolumeUp');
+    await pressVolumeKey('VolumeDown');
+
+    expect(view.prev).not.toHaveBeenCalled();
+    expect(view.next).not.toHaveBeenCalled();
+  });
+
+  test('page-flips on volume keys when TTS is paused', async () => {
+    const view = makeView();
+    setupWithView(view);
+    await emitPlayback('playing');
+    await emitPlayback('paused');
+
+    await pressVolumeKey('VolumeDown');
+
+    expect(view.next).toHaveBeenCalled();
+  });
+
+  test('page-flips on volume keys when TTS is idle', async () => {
+    const view = makeView();
+    setupWithView(view);
+
+    await pressVolumeKey('VolumeUp');
+
+    expect(view.prev).toHaveBeenCalled();
   });
 });

--- a/apps/readest-app/src/app/reader/hooks/usePagination.ts
+++ b/apps/readest-app/src/app/reader/hooks/usePagination.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useEnv } from '@/context/EnvContext';
 import { FoliateView } from '@/types/view';
 import { ViewSettings } from '@/types/book';
@@ -204,6 +204,10 @@ export const usePagination = (
   // native interception never reconfigures the audio session while native TTS
   // owns it (a .mixWithOthers flip there would vacate the Now Playing slot).
   const [ttsPlaying, setTtsPlaying] = useState(false);
+  // handlePageFlip is registered once (see the effect below), so it can't read
+  // the ttsPlaying state directly without going stale. This ref mirrors it for
+  // the volume-key page-flip guard.
+  const ttsPlayingRef = useRef(false);
 
   const handlePageFlip = async (
     msg: MessageEvent | CustomEvent | React.MouseEvent<HTMLDivElement, MouseEvent>,
@@ -308,7 +312,14 @@ export const usePagination = (
       }
     } else if (msg instanceof CustomEvent) {
       const viewSettings = getViewSettings(bookKey);
-      if (msg.type === 'native-key-down' && viewSettings?.volumeKeysToFlip) {
+      // While TTS is playing, volume keys control the volume, not pagination.
+      // The native layer still forwards the key here (iOS via a lingering KVO,
+      // Android calls onNativeKeyDown unconditionally), so guard it here too.
+      if (
+        msg.type === 'native-key-down' &&
+        viewSettings?.volumeKeysToFlip &&
+        !ttsPlayingRef.current
+      ) {
         const { keyName } = msg.detail;
         setHoveredBookKey('');
         if (keyName === 'VolumeUp') {
@@ -436,7 +447,9 @@ export const usePagination = (
     const handlePlaybackState = (event: Event) => {
       const detail = (event as CustomEvent).detail as { bookKey?: string; state?: string };
       if (detail?.bookKey !== bookKey) return;
-      setTtsPlaying(detail.state === 'playing');
+      const playing = detail.state === 'playing';
+      ttsPlayingRef.current = playing;
+      setTtsPlaying(playing);
     };
     eventDispatcher.on('tts-playback-state', handlePlaybackState);
     return () => {


### PR DESCRIPTION
## Summary

Two fixes for the mobile volume-key page-turner interfering with TTS media behavior. Both surfaced while debugging "pause then play with AirPods resumes another app instead of Readest TTS".

### 1. iOS: the volume-key page-turner stripped the TTS Now Playing session on pause

The `VolumeKeyHandler` was destroyed every time TTS started playing (`usePagination` releases interception on the `ttsPlaying` gate) and rebuilt on the next pause. A freshly-built handler has `ttsOwnsAudioSession = false` and had missed the fire-once `ReadestTTSAudioSessionClaimed` notification, so on pause it reconfigured the TTS-owned session to `.mixWithOthers`. A mixable session is ineligible for Now Playing, so iOS vacated the slot and AirPods / lock-screen play resumed whatever app played before.

Fix: keep a single long-lived handler (do not null it on release) so its `Claimed`/`Released` observers persist across the play/pause cycle and it leaves the TTS-owned session untouched on pause.

### 2. iOS + Android: volume keys paginated while TTS was playing

`handlePageFlip` turned pages on volume keys whenever `volumeKeysToFlip` was on, without checking whether TTS was playing. The native layer still forwards the key while playing (iOS via the volume KVO, Android's `onKeyDown` calls `window.onNativeKeyDown` unconditionally), so volume keys flipped pages instead of controlling volume.

Fix: gate the volume-key page flip on the TTS playing state (via a ref, since `handlePageFlip` is registered once). Volume keys now control volume while TTS is playing and page-turn only when paused or stopped.

## Testing

- Unit: `usePagination-volumeKeys.test.ts` adds cases for playing (no flip) and paused/idle (flip). `pnpm test` + `pnpm lint` green.
- Device: fix #1 confirmed on device (AirPods / lock-screen pause then play resumes Readest). Fix #2 is covered by unit tests; on-device confirmation pending (volume controls volume while playing, page-turn while paused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
