### PR TITLE
fix(android): drop the Sentry NDK integration that destabilizes the WebView (#5227)

### DIFF
--- a/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
              their safe off/false defaults. -->
         <meta-data android:name="io.sentry.dsn" android:value="${sentryDsn}" />
         <meta-data android:name="io.sentry.environment" android:value="production" />
+        <meta-data android:name="io.sentry.ndk.enable" android:value="false" />
 
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"


### PR DESCRIPTION
## Summary

Removes the Sentry NDK (native) crash handler on Android via the documented `io.sentry.ndk.enable=false` manifest flag. Sentry still reports the app's own JS (`@sentry/browser`), Rust panics, and JVM errors.

## Why

Issue #5227 reports a black screen / frozen app on 32-bit Android since 0.11.18. Investigating the reporter's bugreport (0.11.18, `armeabi-v7a`) together with Sentry shows the crashes are all in Sentry's native crash-reporting machinery, which was added in 0.11.18:

- The reporter's dominant crash (an 11x SIGABRT loop at launch) is the Rust crash-handler `pthread_create` panic on armv7 (#5070), already fixed in 0.11.20.
- The residual crash (`READEST-P`, 152 users, live on 0.11.20 across architectures including arm64) is the WebView renderer dying and taking the whole app down with "Render process crash wasn't handled by all associated webviews". These are captured by sentry-android's NDK integration and are unsymbolicated Chromium-internal frames.

sentry-android's NDK handler is the same crash-prone native-handler class already removed for the Rust minidump feature (#5052/#5053/#5070). On a WebView-only Tauri app it provides little value (unsymbolicated non-app crashes) while installing a native signal handler at startup that is implicated in destabilizing the WebView's own renderer-death handling.

## Change

One manifest meta-data flag.

## Verification

Declarative Android manifest flag; no Rust or TS changed, full vitest suite green. The real confirmation is post-release: watch `READEST-P`'s event rate on the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
