### PR TITLE
fix(android): withdraw Android Auto opt-in to pass Play review

### DIFF
--- a/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -23,13 +23,17 @@
         android:hardwareAccelerated="true"
         android:usesCleartextTraffic="${usesCleartextTraffic}">
 
-        <!-- Android Auto: advertise the media capability so Readest shows up in
-             the car launcher and projects the TTS media session. Withdrawn in
-             #5038 after a Play Auto rejection (broken forward/back feedback);
-             re-enabled once the skip controls give instant, coherent state. -->
-        <meta-data
-            android:name="com.google.android.gms.car.application"
-            android:resource="@xml/automotive_app_desc" />
+        <!-- Android Auto media capability intentionally NOT declared here. The
+             car-application meta-data (gms car application) is withdrawn for
+             this release to pass Play's Auto review, which rejected version
+             code 11020 for inconsistent TTS playback in the car. Previously
+             withdrawn in #5038 for the same reason and re-enabled in #5066; it
+             is withdrawn again until the car audio bug is fixed. The
+             automotive_app_desc.xml resource and the exported
+             MediaBrowserService (needed for the phone lock-screen/background
+             TTS media session) stay in place; re-add the car-application
+             meta-data pointing at @xml/automotive_app_desc to re-enable
+             Android Auto. -->
 
         <!-- Sentry auto-init (ContentProvider). Empty DSN => disabled. Release
              is auto-detected from versionName; performance and PII stay at

--- a/apps/readest-app/src/__tests__/android/android-auto-declarations.test.ts
+++ b/apps/readest-app/src/__tests__/android/android-auto-declarations.test.ts
@@ -4,19 +4,21 @@ import { resolve } from 'path';
 
 /**
  * Android Auto support (#3919): for Readest to appear in the Android Auto
- * launcher as a media app, the manifest must opt in to car projection via the
+ * launcher as a media app, the manifest opts in to car projection via the
  * `com.google.android.gms.car.application` meta-data pointing at an
  * automotive descriptor that declares the `media` capability. Android Auto
  * then connects to the exported MediaBrowserService
  * (com.readest.native_tts.MediaPlaybackService) to drive TTS playback.
  *
- * Withdrawn in #5038 after a Play Auto rejection: the forward/back controls
- * gave no immediate coherent feedback (the silent player seeked to 0 and the
- * metadata lagged a ~1s WebView round trip, so the car saw a pause flicker
- * with no track change). Re-enabled once the skip path was fixed to assert
- * playing at once and hold state through the round trip (ttsMediaBridge
- * #skipping + MediaPlaybackService no longer seeks the silent player on
- * skip), so the car meta-data is present again.
+ * The car meta-data is currently WITHDRAWN. It was first withdrawn in #5038
+ * after a Play Auto rejection, re-enabled in #5066, then withdrawn again after
+ * Play rejected version code 11020 for inconsistent TTS playback in the car.
+ * Until the car audio bug is fixed the opt-in stays out, so this test asserts
+ * the meta-data is ABSENT; flip it back to `toContain` when re-enabling.
+ *
+ * The automotive descriptor and the exported MediaBrowserService stay in
+ * place (the service also backs the phone lock-screen/background TTS media
+ * session), so those declarations are still asserted below.
  */
 
 const manifest = readFileSync(
@@ -25,9 +27,8 @@ const manifest = readFileSync(
 );
 
 describe('Android Auto declarations (#3919)', () => {
-  it('opts in to car projection via the car application meta-data', () => {
-    expect(manifest).toContain('com.google.android.gms.car.application');
-    expect(manifest).toContain('@xml/automotive_app_desc');
+  it('does not opt in to car projection while Android Auto is withdrawn', () => {
+    expect(manifest).not.toContain('com.google.android.gms.car.application');
   });
 
   it('keeps the automotive descriptor with the media capability for re-enabling', () => {


### PR DESCRIPTION
## Summary

Google Play rejected version code **11020 (0.11.20)** under the Auto App Quality Guidelines ("App doesn't perform as expected" / "Audio inconsistently plays on the Android Auto environment"), so the previous version stays live and the release is blocked.

This withdraws the Android Auto opt-in for this release so the build passes review, deferring the audio fix. The `com.google.android.gms.car.application` meta-data is removed from the Android manifest, so Readest no longer advertises itself as an Android Auto media app.

What stays in place, so re-enabling later only needs the meta-data added back:
- `res/xml/automotive_app_desc.xml` (the automotive descriptor with the `media` capability)
- the exported `MediaBrowserService` (`com.readest.native_tts.MediaPlaybackService`), which also backs the phone lock-screen and background TTS media session and does not by itself trigger Play's Auto review

## History

Android Auto was first withdrawn in #5038 for the same reason (a prior Play Auto rejection) and re-enabled in #5066. Play rejected it again on 11020, so it is withdrawn again until the car audio bug is fixed.

## Verification

Reproduced the rejection locally first: installed the 11020 release APK on a Pixel emulator and connected the Android Auto Desktop Head Unit (DHU). Readest's Now Playing surface rendered, but the media session state and the car UI were out of sync (car showed a play/pause state and scrubber position that did not match the actual `MediaSession` `PlaybackState`), consistent with the "audio inconsistently plays" report.

- `pnpm test` — 7716 passed, 7 skipped
- `pnpm lint` — clean (tsgo + biome)
- Guard test `android-auto-declarations.test.ts` updated to assert the opt-in is absent; the descriptor and MediaBrowserService assertions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)