### PR TITLE
Fix high-priority reader runtime errors

### DIFF
--- a/apps/readest-app/src/__tests__/components/Link.test.tsx
+++ b/apps/readest-app/src/__tests__/components/Link.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mockOpenUrl } = vi.hoisted(() => ({
+  mockOpenUrl: vi.fn(),
+}));
+
+vi.mock('@/services/environment', () => ({
+  isTauriAppPlatform: () => true,
+}));
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: mockOpenUrl,
+}));
+
+import Link from '@/components/Link';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  mockOpenUrl.mockReset();
+});
+
+describe('Link', () => {
+  it('contains native opener failures', async () => {
+    const error = new Error('native opener unavailable');
+    const consoleInfo = vi.spyOn(console, 'info').mockImplementation(() => {});
+    mockOpenUrl.mockRejectedValueOnce(error);
+
+    render(<Link href='https://example.com'>Open</Link>);
+    fireEvent.click(screen.getByRole('link', { name: 'Open' }));
+
+    await waitFor(() => {
+      expect(consoleInfo).toHaveBeenCalledWith('Failed to open external link:', error);
+    });
+  });
+});

--- a/apps/readest-app/src/__tests__/document/paginator-paginated.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/paginator-paginated.browser.test.ts
@@ -491,6 +491,67 @@ describe('Paginator multi-view architecture (browser)', () => {
       // If no non-linear sections, the test passes trivially
       expect(true).toBe(true);
     });
+
+    it('ignores a page turn when the section list is invalidated before navigation resumes', async () => {
+      paginator = createPaginator();
+      paginator.setAttribute('no-preload', '');
+      const sections = [...book.sections!];
+      paginator.open({ ...book, sections } as BookDoc);
+      const index = sections.findIndex(
+        (section, i) =>
+          section.linear !== 'no' && sections.slice(i + 1).some((next) => next.linear !== 'no'),
+      );
+      const stabilized = waitForStabilized(paginator);
+      await paginator.goTo({ index, anchor: 1 });
+      await stabilized;
+
+      const turn = paginator.next();
+      (paginator as Renderer & { sections: BookDoc['sections'] }).sections = [];
+
+      await expect(turn).resolves.toBeUndefined();
+    });
+
+    it('ignores a section load when the iframe document is unavailable', async () => {
+      let resolveSection!: (src: string) => void;
+      const sectionLoaded = new Promise<string>((resolve) => {
+        resolveSection = resolve;
+      });
+      const sections = [
+        {
+          linear: 'yes',
+          load: () => sectionLoaded,
+        },
+      ];
+      paginator = createPaginator();
+      paginator.open({ sections } as unknown as BookDoc);
+
+      const descriptor = Object.getOwnPropertyDescriptor(
+        HTMLIFrameElement.prototype,
+        'contentDocument',
+      );
+      if (!descriptor) throw new Error('HTMLIFrameElement.contentDocument is unavailable');
+
+      Object.defineProperty(HTMLIFrameElement.prototype, 'contentDocument', {
+        configurable: true,
+        get: () => null,
+      });
+
+      try {
+        const navigation = paginator.goTo({ index: 0 });
+        resolveSection('about:blank');
+
+        await expect(
+          Promise.race([
+            navigation,
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error('navigation timeout')), 1000),
+            ),
+          ]),
+        ).resolves.toBeUndefined();
+      } finally {
+        Object.defineProperty(HTMLIFrameElement.prototype, 'contentDocument', descriptor);
+      }
+    });
   });
 });
 

--- a/apps/readest-app/src/components/Link.tsx
+++ b/apps/readest-app/src/components/Link.tsx
@@ -12,7 +12,11 @@ const Link: React.FC<LinkProps> = ({ href, children, ...props }) => {
   const handleClick = async (e: React.MouseEvent<HTMLAnchorElement>) => {
     if (isTauri) {
       e.preventDefault();
-      await openUrl(href);
+      try {
+        await openUrl(href);
+      } catch (error) {
+        console.info('Failed to open external link:', error);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

- contain native external-link opener failures instead of leaving rejected promises unhandled
- pin readest/foliate-js#59 to ignore navigation after the section list is invalidated
- discard failed iframe loads before null documents reach reader event handlers
- add behavior-level regression coverage for all three failure modes

## Dependency

- readest/foliate-js#59

## Sentry

Fixes READEST-G4
Fixes READEST-97
Fixes READEST-A7
Fixes READEST-V
Fixes READEST-1F
Fixes READEST-2Y
Fixes READEST-72

## Verification

- pnpm test: 7717 passed, 7 skipped
- pnpm test:browser: 255 passed, 1 skipped
- pnpm lint
- pnpm format:check
- pnpm build
- git diff --check