### PR TITLE
Contain updater and native auth rejections

### DIFF
--- a/apps/readest-app/src/__tests__/app/auth-page.test.tsx
+++ b/apps/readest-app/src/__tests__/app/auth-page.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@supabase/auth-ui-react', () => ({ Auth: () => null }));
+vi.mock('@supabase/auth-ui-shared', () => ({ ThemeSupa: {} }));
+
+import { ProviderLogin } from '@/app/auth/page';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ProviderLogin', () => {
+  it('contains a rejected native sign-in request', async () => {
+    const error = new Error('The operation could not be completed. Authentication error 1.');
+    const handleSignIn = vi.fn().mockRejectedValue(error);
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(
+      <ProviderLogin
+        provider='apple'
+        handleSignIn={handleSignIn}
+        Icon={() => null}
+        label='Sign in with Apple'
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in with Apple' }));
+
+    await waitFor(() => {
+      expect(consoleWarn).toHaveBeenCalledWith('Failed to sign in with apple:', error);
+    });
+  });
+});

--- a/apps/readest-app/src/__tests__/components/UpdaterWindow.test.tsx
+++ b/apps/readest-app/src/__tests__/components/UpdaterWindow.test.tsx
@@ -9,6 +9,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 
+const { mockInstallNightlyUpdate } = vi.hoisted(() => ({
+  mockInstallNightlyUpdate: vi.fn(),
+}));
+
 // ── Locale + translation controls ────────────────────────────────
 let mockLocale = 'en';
 const mockTranslate = vi.fn(async (input: string[]) => input.map((s) => `[zh] ${s}`));
@@ -37,7 +41,7 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/context/EnvContext', () => ({
   useEnv: () => ({
     appService: {
-      hasUpdater: false,
+      hasUpdater: true,
       isIOSApp: false,
       isMacOSApp: false,
       isAndroidApp: false,
@@ -77,7 +81,7 @@ vi.mock('@/utils/transfer', () => ({ tauriDownload: vi.fn() }));
 vi.mock('@/utils/bridge', () => ({
   installPackage: vi.fn(),
   verifyUpdateSignature: vi.fn(),
-  installNightlyUpdate: vi.fn(),
+  installNightlyUpdate: mockInstallNightlyUpdate,
 }));
 vi.mock('next/image', () => ({ default: () => null }));
 vi.mock('@/components/Dialog', () => ({
@@ -96,6 +100,7 @@ const RELEASE_NOTES = {
 beforeEach(() => {
   mockLocale = 'en';
   mockTranslate.mockClear();
+  mockInstallNightlyUpdate.mockReset();
   window.fetch = vi.fn(async () => ({
     ok: true,
     json: async () => RELEASE_NOTES,
@@ -107,6 +112,32 @@ afterEach(() => {
 });
 
 describe('UpdaterContent — auto-translated changelog', () => {
+  it('contains download failures and shows an updater error', async () => {
+    const failure = 'Download request failed with status: 403 Forbidden';
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockInstallNightlyUpdate.mockRejectedValueOnce(failure);
+
+    render(
+      <UpdaterContent
+        latestVersion='0.11.20'
+        nightlyUpdate={{
+          endpoint: 'https://example.com/nightly.json',
+          version: '0.11.20',
+          platformKey: 'windows-x86_64',
+          url: 'https://example.com/readest.exe',
+          signature: 'signature',
+        }}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'DOWNLOAD & INSTALL' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to download and install update')).toBeTruthy();
+    });
+    expect(consoleError).toHaveBeenCalledWith('Failed to download and install update:', failure);
+  });
+
   it('shows a "Show original" toggle that swaps the translation for the source English', async () => {
     mockLocale = 'zh-CN';
     render(<UpdaterContent checkUpdate={false} latestVersion='0.11.18' lastVersion='0.11.0' />);

--- a/apps/readest-app/src/app/auth/page.tsx
+++ b/apps/readest-app/src/app/auth/page.tsx
@@ -37,7 +37,7 @@ interface SingleInstancePayload {
 
 interface ProviderLoginProp {
   provider: OAuthProvider;
-  handleSignIn: (provider: OAuthProvider) => void;
+  handleSignIn: (provider: OAuthProvider) => Promise<void>;
   Icon: React.ElementType;
   label: string;
 }
@@ -46,10 +46,19 @@ const WEB_AUTH_CALLBACK = `${getBaseUrl()}/auth/callback`;
 const DEEPLINK_CALLBACK = 'readest://auth-callback';
 const USE_APPLE_SIGN_IN = process.env['NEXT_PUBLIC_USE_APPLE_SIGN_IN'] === 'true';
 
-const ProviderLogin: React.FC<ProviderLoginProp> = ({ provider, handleSignIn, Icon, label }) => {
+export const ProviderLogin: React.FC<ProviderLoginProp> = ({
+  provider,
+  handleSignIn,
+  Icon,
+  label,
+}) => {
   return (
     <button
-      onClick={() => handleSignIn(provider)}
+      onClick={() => {
+        void handleSignIn(provider).catch((error) => {
+          console.warn(`Failed to sign in with ${provider}:`, error);
+        });
+      }}
       className={clsx(
         'mb-2 flex w-64 items-center justify-center rounded border p-2.5',
         'bg-base-100 border-base-300 hover:bg-base-200 shadow-sm transition',

--- a/apps/readest-app/src/components/UpdaterWindow.tsx
+++ b/apps/readest-app/src/components/UpdaterWindow.tsx
@@ -484,33 +484,40 @@ export const UpdaterContent = ({
     let lastLogged = 0;
     setProgress(0);
     setIsDownloading(true);
-    await update.downloadAndInstall?.((event) => {
-      switch (event.event) {
-        case 'Started':
-          contentLength = event.data.contentLength!;
-          setContentLength(contentLength);
-          break;
-        case 'Progress':
-          downloaded += event.data.chunkLength;
-          setDownloaded(downloaded);
-          // Guard against a 0 total (server omitted Content-Length): keep the
-          // bar at an indeterminate 0% instead of NaN/Infinity.
-          const percent = contentLength > 0 ? Math.floor((downloaded / contentLength) * 100) : 0;
-          setProgress(percent);
-          if (downloaded - lastLogged >= 1 * 1024 * 1024) {
-            console.log(`downloaded ${downloaded} bytes from ${contentLength}`);
-            lastLogged = downloaded;
-          }
-          break;
-        case 'Finished':
-          console.log('download finished');
-          setProgress(100);
-          break;
+    try {
+      await update.downloadAndInstall?.((event) => {
+        switch (event.event) {
+          case 'Started':
+            contentLength = event.data.contentLength!;
+            setContentLength(contentLength);
+            break;
+          case 'Progress':
+            downloaded += event.data.chunkLength;
+            setDownloaded(downloaded);
+            // Guard against a 0 total (server omitted Content-Length): keep the
+            // bar at an indeterminate 0% instead of NaN/Infinity.
+            const percent = contentLength > 0 ? Math.floor((downloaded / contentLength) * 100) : 0;
+            setProgress(percent);
+            if (downloaded - lastLogged >= 1 * 1024 * 1024) {
+              console.log(`downloaded ${downloaded} bytes from ${contentLength}`);
+              lastLogged = downloaded;
+            }
+            break;
+          case 'Finished':
+            console.log('download finished');
+            setProgress(100);
+            break;
+        }
+      });
+      console.log('package installed');
+      if (!appService?.isAndroidApp && process.env.NODE_ENV === 'production') {
+        await relaunch();
       }
-    });
-    console.log('package installed');
-    if (!appService?.isAndroidApp && process.env.NODE_ENV === 'production') {
-      await relaunch();
+    } catch (error) {
+      console.error('Failed to download and install update:', error);
+      setError(_('Failed to download and install update'));
+    } finally {
+      setIsDownloading(false);
     }
   };
 


### PR DESCRIPTION
## Summary

- catch updater download/install failures, release the downloading state, and show the existing updater error UI
- attach a rejection handler to native provider login buttons so Apple/Safari cancellations do not become global unhandled rejections
- add click-level behavior coverage for both failure paths

## Sentry

Fixes READEST-16E
Fixes READEST-3
Fixes READEST-17
Fixes READEST-8G
Fixes READEST-16

## Verification

- pnpm test: 7718 passed, 7 skipped
- pnpm lint
- pnpm format:check
- pnpm build
- targeted updater and auth interaction tests