### PR TITLE
Show import options when clicking the bookshelf add button

### DIFF
--- a/apps/readest-app/e2e/pages/LibraryPage.ts
+++ b/apps/readest-app/e2e/pages/LibraryPage.ts
@@ -11,6 +11,9 @@ export class LibraryPage extends BasePage {
   readonly searchInput: Locator;
   readonly clearSearchButton: Locator;
   readonly emptyState: Locator;
+  readonly emptyStateImportButton: Locator;
+  readonly importMenu: Locator;
+  readonly localFileImportItem: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -20,6 +23,11 @@ export class LibraryPage extends BasePage {
     this.searchInput = page.locator('.search-input');
     this.clearSearchButton = page.locator('[aria-label="Clear Search"]');
     this.emptyState = page.getByRole('heading', { name: 'Start your library' });
+    this.emptyStateImportButton = page.locator('.hero').getByRole('button', {
+      name: 'Import Books',
+    });
+    this.importMenu = page.locator('.menu-container');
+    this.localFileImportItem = this.importMenu.getByRole('menuitem', { name: 'From Local File' });
   }
 
   async goto(): Promise<void> {
@@ -37,16 +45,19 @@ export class LibraryPage extends BasePage {
   }
 
   /**
-   * Import a book file via the empty-state "Import Books" button.
+   * Import a book file via the empty-state "Import Books" button, which opens
+   * the same import menu as the library header "+" button.
    *
    * The file `<input>` is created off-DOM (see `useFileSelector.selectFileWeb`),
    * so a `filechooser` event must be awaited rather than locating an
    * `<input type="file">`.
    */
   async importBook(filePath: string): Promise<void> {
-    const importButton = this.page.locator('.hero').getByRole('button', { name: 'Import Books' });
+    await this.emptyStateImportButton.click();
+    await this.localFileImportItem.waitFor({ state: 'visible' });
+
     const chooserPromise = this.page.waitForEvent('filechooser');
-    await importButton.click();
+    await this.localFileImportItem.click();
     const chooser = await chooserPromise;
     await chooser.setFiles(filePath);
   }

--- a/apps/readest-app/e2e/tests/library.spec.ts
+++ b/apps/readest-app/e2e/tests/library.spec.ts
@@ -11,6 +11,16 @@ test.describe('Library page', () => {
     await expect(library.emptyState).toBeVisible();
   });
 
+  test('opens the import menu from the empty-library state', async ({ page }) => {
+    const library = new LibraryPage(page);
+    await library.goto();
+
+    await library.emptyStateImportButton.click();
+
+    await expect(library.importMenu).toBeVisible();
+    await expect(library.localFileImportItem).toBeVisible();
+  });
+
   test('search input accepts text and exposes a clear control', async ({ page }) => {
     const library = new LibraryPage(page);
     await library.goto();

--- a/apps/readest-app/src/__tests__/app/library/import-menu-popup.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/import-menu-popup.test.tsx
@@ -1,0 +1,133 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ImportMenuPopup, { getMenuPosition } from '@/app/library/components/ImportMenuPopup';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+const useEnvMock = vi.fn();
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => useEnvMock(),
+}));
+
+const renderPopup = (props: Partial<React.ComponentProps<typeof ImportMenuPopup>> = {}) => {
+  const anchor = document.createElement('button');
+  document.body.appendChild(anchor);
+  const onClose = vi.fn();
+  const utils = render(
+    <ImportMenuPopup
+      anchor={anchor}
+      onClose={onClose}
+      onImportBooksFromFiles={vi.fn()}
+      onOpenCatalogManager={vi.fn()}
+      onOpenFeeds={vi.fn()}
+      {...props}
+    />,
+  );
+  return { ...utils, anchor, onClose };
+};
+
+beforeEach(() => {
+  useEnvMock.mockReturnValue({ appService: { isOnlineCatalogsAccessible: true } });
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+  useEnvMock.mockReset();
+});
+
+describe('ImportMenuPopup', () => {
+  it('shows the same always-available options as the library header menu', () => {
+    renderPopup();
+
+    expect(screen.getByRole('menuitem', { name: 'From Local File' })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: 'From Feed URL' })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: 'Online Library' })).toBeTruthy();
+    expect(screen.queryByRole('menuitem', { name: 'From Directory' })).toBeNull();
+    expect(screen.queryByRole('menuitem', { name: 'From Web URL' })).toBeNull();
+  });
+
+  it('adds the platform-dependent options when their callbacks are available', () => {
+    const onImportBooksFromDirectory = vi.fn();
+    const onImportBookFromUrl = vi.fn();
+    const { onClose } = renderPopup({ onImportBooksFromDirectory, onImportBookFromUrl });
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'From Directory' }));
+    expect(onImportBooksFromDirectory).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'From Web URL' }));
+    expect(onImportBookFromUrl).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the OPDS label when curated online catalogs are unavailable', () => {
+    useEnvMock.mockReturnValue({ appService: { isOnlineCatalogsAccessible: false } });
+    renderPopup();
+
+    expect(screen.getByRole('menuitem', { name: 'OPDS Catalogs' })).toBeTruthy();
+  });
+
+  it('runs the selected action and dismisses the popup', () => {
+    const onImportBooksFromFiles = vi.fn();
+    const { onClose } = renderPopup({ onImportBooksFromFiles });
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'From Local File' }));
+
+    expect(onImportBooksFromFiles).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses the popup when the backdrop is clicked', () => {
+    const { container, onClose } = renderPopup();
+
+    fireEvent.click(container.querySelector('.overlay')!);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getMenuPosition', () => {
+  const bounds = { left: 8, top: 8, right: 992, bottom: 792 };
+  const menu = { width: 200, height: 240 };
+  const anchorRect = (left: number, top: number, width = 100, height = 140) =>
+    ({
+      left,
+      top,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+    }) as DOMRect;
+
+  it('centers the menu under the anchor', () => {
+    expect(getMenuPosition(anchorRect(400, 200), menu, bounds)).toEqual({
+      left: 400 + 50 - 100,
+      top: 340 + 8,
+    });
+  });
+
+  it('flips above the anchor when there is no room below', () => {
+    expect(getMenuPosition(anchorRect(400, 600), menu, bounds)).toEqual({
+      left: 350,
+      top: 600 - 8 - 240,
+    });
+  });
+
+  it('keeps the menu inside the bounds near the edges', () => {
+    expect(getMenuPosition(anchorRect(0, 200), menu, bounds).left).toBe(8);
+    expect(getMenuPosition(anchorRect(960, 200, 40), menu, bounds).left).toBe(792);
+    // Menu taller than the room on either side of a short viewport.
+    expect(
+      getMenuPosition(anchorRect(400, 40), menu, { left: 8, top: 8, right: 992, bottom: 292 }).top,
+    ).toBe(8);
+  });
+
+  it('respects safe area insets when clamping', () => {
+    const insetBounds = { left: 52, top: 8, right: 992, bottom: 792 };
+
+    expect(getMenuPosition(anchorRect(0, 200), menu, insetBounds).left).toBe(52);
+  });
+});

--- a/apps/readest-app/src/app/library/components/Bookshelf.tsx
+++ b/apps/readest-app/src/app/library/components/Bookshelf.tsx
@@ -71,7 +71,7 @@ interface BookshelfProps {
   isSelectAll: boolean;
   isSelectNone: boolean;
   onScrollerRef: (el: HTMLDivElement | null) => void;
-  handleImportBooks: () => void;
+  handleImportBooks: (anchor: HTMLElement) => void;
   handleBookDownload: (
     book: Book,
     options?: { redownload?: boolean; queued?: boolean },
@@ -794,12 +794,13 @@ const Bookshelf: React.FC<BookshelfProps> = ({
           >
             <button
               aria-label={_('Import Books')}
+              aria-haspopup='menu'
               className={clsx(
                 'bookitem-main bg-base-100 hover:bg-base-300/50',
                 'flex items-center justify-center',
                 'aspect-[28/41] w-full',
               )}
-              onClick={handleImportBooks}
+              onClick={(event) => handleImportBooks(event.currentTarget)}
             >
               <div className='flex items-center justify-center'>
                 <PiPlus className='size-10' color='gray' />

--- a/apps/readest-app/src/app/library/components/ImportMenu.tsx
+++ b/apps/readest-app/src/app/library/components/ImportMenu.tsx
@@ -7,7 +7,8 @@ import { useTranslation } from '@/hooks/useTranslation';
 import MenuItem from '@/components/MenuItem';
 import Menu from '@/components/Menu';
 
-interface ImportMenuProps {
+export interface ImportMenuProps {
+  menuClassName?: string;
   setIsDropdownOpen?: (open: boolean) => void;
   onImportBooksFromFiles: () => void;
   onImportBooksFromDirectory?: () => void;
@@ -17,6 +18,7 @@ interface ImportMenuProps {
 }
 
 const ImportMenu: React.FC<ImportMenuProps> = ({
+  menuClassName,
   setIsDropdownOpen,
   onImportBooksFromFiles,
   onImportBooksFromDirectory,
@@ -54,7 +56,10 @@ const ImportMenu: React.FC<ImportMenuProps> = ({
 
   return (
     <Menu
-      className={clsx('dropdown-content bg-base-100 rounded-box !relative z-[1] mt-3 p-2 shadow')}
+      className={clsx(
+        'dropdown-content bg-base-100 rounded-box !relative z-[1] mt-3 p-2 shadow',
+        menuClassName,
+      )}
       onCancel={() => setIsDropdownOpen?.(false)}
     >
       <MenuItem

--- a/apps/readest-app/src/app/library/components/ImportMenuPopup.tsx
+++ b/apps/readest-app/src/app/library/components/ImportMenuPopup.tsx
@@ -1,0 +1,85 @@
+import clsx from 'clsx';
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import { useThemeStore } from '@/store/themeStore';
+import { Overlay } from '@/components/Overlay';
+import ImportMenu, { ImportMenuProps } from './ImportMenu';
+
+const VIEWPORT_PADDING = 8;
+const ANCHOR_GAP = 8;
+
+interface Size {
+  width: number;
+  height: number;
+}
+
+interface Bounds {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/**
+ * Anchor the menu below the button that opened it, flipping above when it would
+ * run off the bottom and clamping to `bounds` near the edges. The bookshelf "+"
+ * tile lives inside the virtualized scroller, so the menu is positioned as a
+ * fixed overlay instead of a `dropdown-content` that the scroller would clip.
+ */
+export const getMenuPosition = (anchor: DOMRect, menu: Size, bounds: Bounds) => {
+  const left = Math.max(
+    bounds.left,
+    Math.min(anchor.left + anchor.width / 2 - menu.width / 2, bounds.right - menu.width),
+  );
+  const below = anchor.bottom + ANCHOR_GAP;
+  const fitsBelow = below + menu.height <= bounds.bottom;
+  const top = fitsBelow ? below : Math.max(bounds.top, anchor.top - ANCHOR_GAP - menu.height);
+  return { left, top };
+};
+
+interface ImportMenuPopupProps
+  extends Omit<ImportMenuProps, 'menuClassName' | 'setIsDropdownOpen'> {
+  anchor: HTMLElement;
+  onClose: () => void;
+}
+
+const ImportMenuPopup: React.FC<ImportMenuPopupProps> = ({ anchor, onClose, ...menuProps }) => {
+  const { safeAreaInsets: insets } = useThemeStore();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<{ left: number; top: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!menuRef.current) return;
+    const { width, height } = menuRef.current.getBoundingClientRect();
+    setPosition(
+      getMenuPosition(
+        anchor.getBoundingClientRect(),
+        { width, height },
+        {
+          left: VIEWPORT_PADDING + (insets?.left ?? 0),
+          top: VIEWPORT_PADDING + (insets?.top ?? 0),
+          right: window.innerWidth - VIEWPORT_PADDING - (insets?.right ?? 0),
+          bottom: window.innerHeight - VIEWPORT_PADDING - (insets?.bottom ?? 0),
+        },
+      ),
+    );
+  }, [anchor, insets]);
+
+  return (
+    <>
+      <Overlay onDismiss={onClose} className='z-50' />
+      <div
+        ref={menuRef}
+        className={clsx('fixed z-50 w-max', !position && 'invisible')}
+        style={{ left: position?.left ?? 0, top: position?.top ?? 0 }}
+      >
+        <ImportMenu
+          menuClassName='no-triangle !mt-0'
+          setIsDropdownOpen={(open) => !open && onClose()}
+          {...menuProps}
+        />
+      </div>
+    </>
+  );
+};
+
+export default ImportMenuPopup;

--- a/apps/readest-app/src/app/library/components/LibraryEmptyState.tsx
+++ b/apps/readest-app/src/app/library/components/LibraryEmptyState.tsx
@@ -9,7 +9,7 @@ import { useAppRouter } from '@/hooks/useAppRouter';
 import { navigateToLogin } from '@/utils/nav';
 
 interface LibraryEmptyStateProps {
-  onImport: () => void;
+  onImport: (anchor: HTMLElement) => void;
 }
 
 const LibraryEmptyState: React.FC<LibraryEmptyStateProps> = ({ onImport }) => {
@@ -34,8 +34,9 @@ const LibraryEmptyState: React.FC<LibraryEmptyStateProps> = ({ onImport }) => {
         <div className='flex w-full max-w-xs flex-col gap-3'>
           <button
             type='button'
+            aria-haspopup='menu'
             className='btn btn-primary h-11 min-h-11 rounded-lg'
-            onClick={onImport}
+            onClick={(event) => onImport(event.currentTarget)}
           >
             {_('Import Books')}
           </button>

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -98,6 +98,7 @@ import Spinner from '@/components/Spinner';
 import LibraryHeader from './components/LibraryHeader';
 import Bookshelf from './components/Bookshelf';
 import LibraryEmptyState from './components/LibraryEmptyState';
+import ImportMenuPopup from './components/ImportMenuPopup';
 import GroupHeader from './components/GroupHeader';
 import FailedImportsDialog, { FailedImport } from './components/FailedImportsDialog';
 import ImportFromFolderDialog, {
@@ -207,6 +208,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
   const [showFeeds, setShowFeeds] = useState(false);
   const [showAddFeed, setShowAddFeed] = useState(false);
   const [showImportFromUrl, setShowImportFromUrl] = useState(false);
+  const [importMenuAnchor, setImportMenuAnchor] = useState<HTMLElement | null>(null);
   const [loading, setLoading] = useState(false);
   // Seed from the library store: if we already have books in memory (the
   // common reader → library return path), treat the page as loaded
@@ -1630,7 +1632,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
                 isSelectAll={isSelectAll}
                 isSelectNone={isSelectNone}
                 onScrollerRef={handleScrollerRef}
-                handleImportBooks={handleImportBooksFromFiles}
+                handleImportBooks={setImportMenuAnchor}
                 handleBookUpload={handleBookUpload}
                 handleBookDownload={handleBookDownload}
                 handleBookDelete={handleBookDelete('both')}
@@ -1646,9 +1648,22 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
         ) : (
           <div className='hero drop-zone h-screen items-center justify-center'>
             <DropIndicator />
-            <LibraryEmptyState onImport={handleImportBooksFromFiles} />
+            <LibraryEmptyState onImport={setImportMenuAnchor} />
           </div>
         ))}
+      {importMenuAnchor && (
+        <ImportMenuPopup
+          anchor={importMenuAnchor}
+          onClose={() => setImportMenuAnchor(null)}
+          onImportBooksFromFiles={handleImportBooksFromFiles}
+          onImportBooksFromDirectory={
+            appService?.canReadExternalDir ? handleImportBooksFromDirectory : undefined
+          }
+          onImportBookFromUrl={isTauriAppPlatform() ? () => setShowImportFromUrl(true) : undefined}
+          onOpenCatalogManager={handleShowOPDSDialog}
+          onOpenFeeds={handleShowFeeds}
+        />
+      )}
       <NowPlayingBar isSelectMode={isSelectMode} />
       {showDetailsBook && (
         <BookDetailModal


### PR DESCRIPTION
## Summary

The Bookshelf "+" tile and the empty-library "Import Books" button opened the local file picker directly, so the Online Library, feeds and the other platform-specific import methods were only discoverable from the Library header. Both entry points now open the same `ImportMenu` that the header "+" button uses.

This addresses #5222.

## Changes

### Reuse the header import menu as an anchored popup

- Added `ImportMenuPopup`, which renders the existing `ImportMenu` as a fixed overlay anchored to the button that opened it.
- The "+" tile lives inside the virtualized bookshelf scroller, whose `overflow-y: scroll` would clip an absolutely positioned `dropdown-content`, so the menu is positioned from the anchor's bounding rect instead.
- The menu is centered below the anchor, flips above it when there is no room below, and is clamped to the viewport minus safe-area insets.
- `getMenuPosition` is a pure function so the placement rules are unit tested.
- Dismisses on backdrop click and on Escape, like the header dropdown.

### Keep a single source of import options

- `ImportMenu` is unchanged apart from an optional `menuClassName`, which follows the existing `Dropdown` convention and lets the popup drop the header-specific triangle and top margin.
- The header dropdown and both bookshelf entry points now render the same component, so the available options and their platform gates cannot drift apart.

### Update the Bookshelf import entry points

- The Bookshelf "+" tile and the empty-library "Import Books" button report the clicked element as the popup anchor.
- `page.tsx` holds the anchor state and renders one popup, reusing the file, directory, URL, feed and catalog handlers with the same platform gates the Library header already uses.

### Tests

- Added `import-menu-popup.test.tsx`: the always-available options, the platform-dependent Directory and Web URL options, the Online Library / OPDS label, action + dismiss, backdrop dismiss, and the placement math including safe-area insets.
- Updated the Playwright `LibraryPage.importBook()` helper, since the empty-state button now opens the menu instead of the file picker directly.
- Added a web e2e test that the empty-library button opens the import menu.

## Testing

- [x] `pnpm test` - 7815 passed, 7 skipped
- [x] `pnpm lint` (tsgo + Biome) and `pnpm format:check`
- [x] `pnpm test:e2e:web` - 15 passed
- [x] Manual web check: the menu opens under the "+" tile, flips above and clamps to the edge when the tile sits at the bottom of the scroller without being clipped, the backdrop dismisses it, and "Online Library" opens the catalog dialog.
