### PR TITLE
fix: apply percentage-only KOSync progress

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/kosyncProgress.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/kosyncProgress.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { isXPointerProgress, getRemoteFraction } from '@/app/reader/hooks/kosyncProgress';
+import {
+  getRemoteFraction,
+  hasUsableRemoteProgress,
+  isXPointerProgress,
+} from '@/app/reader/hooks/kosyncProgress';
 
 describe('isXPointerProgress', () => {
   it('accepts CREngine XPointers', () => {
@@ -37,5 +41,19 @@ describe('getRemoteFraction', () => {
     const remote = { progress: 'page-42', percentage: 0.5 };
     expect(isXPointerProgress(remote.progress)).toBe(false);
     expect(getRemoteFraction(remote)).toBe(0.5);
+  });
+});
+
+describe('hasUsableRemoteProgress', () => {
+  it('accepts either a position string or a usable percentage', () => {
+    expect(hasUsableRemoteProgress({ progress: '/body/DocFragment[3]/body/p' })).toBe(true);
+    expect(hasUsableRemoteProgress({ percentage: 0.42 })).toBe(true);
+  });
+
+  it('rejects empty responses and unusable percentages', () => {
+    expect(hasUsableRemoteProgress(null)).toBe(false);
+    expect(hasUsableRemoteProgress({})).toBe(false);
+    expect(hasUsableRemoteProgress({ progress: '', percentage: 0 })).toBe(false);
+    expect(hasUsableRemoteProgress({ percentage: Number.NaN })).toBe(false);
   });
 });

--- a/apps/readest-app/src/__tests__/hooks/useKOSync.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useKOSync.test.tsx
@@ -212,6 +212,25 @@ describe('useKOSync — applying a newer remote position (#5065)', () => {
     expect(h.getProgressMock).toHaveBeenCalled();
     expect(h.goTo).toHaveBeenCalledWith('epubcfi(/6/650!/4/2/6)');
   });
+
+  test('applies a newer percentage-only response from a compatible server', async () => {
+    h.settings.kosync.strategy = 'receive';
+    h.remote = {
+      progress: null,
+      percentage: 0.42,
+      timestamp: Math.floor(Date.now() / 1000) + 10_000,
+      device: 'BookLore',
+      device_id: 'BookLore',
+    };
+    h.getProgressMock.mockResolvedValue(h.remote);
+
+    renderHook(() => useKOSync('h1-view1'));
+    await settle();
+
+    expect(h.getProgressMock).toHaveBeenCalled();
+    expect(h.goToFraction).toHaveBeenCalledWith(0.42);
+    expect(h.goTo).not.toHaveBeenCalled();
+  });
 });
 
 describe('useKOSync — no clobbering when the pull is unresolved (#5065)', () => {

--- a/apps/readest-app/src/app/reader/hooks/kosyncProgress.ts
+++ b/apps/readest-app/src/app/reader/hooks/kosyncProgress.ts
@@ -57,6 +57,16 @@ export const getRemoteFraction = (remote: KoSyncProgress): number | undefined =>
 };
 
 /**
+ * Whether a KOSync response contains enough information to move the reader.
+ * Some compatible servers can report only a percentage when they cannot
+ * translate their native locator into a KOReader XPointer.
+ */
+export const hasUsableRemoteProgress = (
+  remote: KoSyncProgress | null | undefined,
+): remote is KoSyncProgress =>
+  !!remote && (!!remote.progress || getRemoteFraction(remote) !== undefined);
+
+/**
  * Outcome of resolving a remote KOReader position against the LOCAL book.
  *
  * The distinction between `unresolved` and `not-xpointer` is critical for

--- a/apps/readest-app/src/app/reader/hooks/useKOSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useKOSync.ts
@@ -20,6 +20,7 @@ import {
 import {
   decideRemoteConflict,
   getRemoteFraction,
+  hasUsableRemoteProgress,
   isReportedByKOReader,
   isXPointerProgress,
   resolveRemoteLocalFraction,
@@ -307,7 +308,7 @@ export const useKOSync = (bookKey: string) => {
 
       setSyncState('checking');
       const remoteProgress = await kosyncClient.getProgress(book);
-      if (!remoteProgress || !remoteProgress.progress) {
+      if (!hasUsableRemoteProgress(remoteProgress)) {
         setSyncState('synced');
         return;
       }


### PR DESCRIPTION
## Summary

- accept remote KOSync progress when it contains either a non-empty position string or a usable percentage
- let percentage-only responses reach the existing `goToFraction` fallback
- preserve precise XPointer navigation whenever a position string is available
- add helper-level and rendered-hook regression coverage

## Root cause

Some KOSync-compatible servers cannot translate a source reader locator into a KOReader XPointer and return a valid percentage with a null progress string. Grimmory is one such KOSync-compatible server. `KOSyncClient` already accepted this response shape, and `applyRemoteProgress` already had a `goToFraction` fallback, but `pullProgress` returned early whenever the progress string was absent, so that fallback was unreachable.

The implementation remains server-agnostic: it checks only whether the response has a usable position or fraction. Existing upload behavior, timestamp comparison, conflict strategies, and XPointer conversion are unchanged.

## User impact

Readers can now apply newer percentage-only remote progress instead of silently remaining at the current position. Invalid fractions such as zero, negative values, `NaN`, and infinity remain unusable.

## Validation

- Full unit suite: `pnpm exec dotenv -e .env -e .env.test.local -- vitest run` — 589 files passed, 3 skipped; 7,722 tests passed, 7 skipped.
- Focused KOSync suite: direct one-shot Vitest run over `kosyncProgress`, `kosyncConflict`, `kosyncRemoteFraction`, `useKOSync`, and `KOSyncClient` — 5 files passed, 37 tests passed.
- `pnpm exec biome lint` on the four touched files — passed.
- `pnpm exec tsgo --noEmit` — passed.
- `git diff --check origin/main...HEAD` — passed.
