### PR TITLE
fix(translate): restore Yandex Translate provider

### DIFF
--- a/apps/readest-app/src/__tests__/app/api/yandex-translate.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/yandex-translate.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/yandex-translate/route';
+
+const makeReq = (
+  query = 'endpoint=session',
+  init: { body?: string; origin?: string | null; contentLength?: string | null } = {},
+) => {
+  const body = init.body ?? 'options=0&text=Hello';
+  const headers: Record<string, string> = {};
+  if (init.origin !== null) headers['origin'] = init.origin ?? 'https://web.readest.com';
+  if (init.contentLength !== null) {
+    headers['content-length'] = init.contentLength ?? String(new TextEncoder().encode(body).length);
+  }
+  return new NextRequest(`https://web.readest.com/api/yandex-translate?${query}`, {
+    method: 'POST',
+    body,
+    headers,
+  });
+};
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchSpy = vi.fn().mockResolvedValue(
+    new Response('{"code":200,"text":["Bonjour"]}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('yandex-translate proxy route', () => {
+  it('returns 400 for an unknown endpoint without fetching', async () => {
+    const res = await POST(makeReq('endpoint=nope'));
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('forwards session requests to the yandex session endpoint with required headers', async () => {
+    const res = await POST(makeReq('endpoint=session&srv=tr-text&yu=123'));
+    expect(res.status).toBe(200);
+
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toContain('https://translate.yandex.ru/props/api/v1.0/sessions');
+    expect(String(url)).toContain('srv=tr-text');
+    expect(String(url)).toContain('yu=123');
+    expect(String(url)).not.toContain('endpoint=');
+    expect(init.headers['Referer']).toBe('https://translate.yandex.ru/');
+    expect(init.headers['Origin']).toBe('https://translate.yandex.ru');
+    expect(init.headers['User-Agent']).toContain('YaBrowser');
+    expect(await res.json()).toEqual({ code: 200, text: ['Bonjour'] });
+  });
+
+  it('forwards translate requests to the tr.json endpoint and relays the body', async () => {
+    await POST(
+      makeReq('endpoint=translate&source_lang=en&target_lang=ru', {
+        body: 'options=0&text=Hello',
+      }),
+    );
+
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toContain('https://translate.yandex.net/api/v1/tr.json/translate');
+    expect(String(url)).toContain('source_lang=en');
+    expect(String(url)).toContain('target_lang=ru');
+    expect(init.body).toBe('options=0&text=Hello');
+  });
+
+  it('rejects cross-origin requests without fetching', async () => {
+    const res = await POST(makeReq('endpoint=session', { origin: 'https://evil.example.com' }));
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('allows same-origin requests', async () => {
+    const res = await POST(makeReq('endpoint=session', { origin: 'https://web.readest.com' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects requests without an Origin header', async () => {
+    const res = await POST(makeReq('endpoint=session', { origin: null }));
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('allows an empty session request without Content-Length', async () => {
+    const res = await POST(makeReq('endpoint=session', { body: '', contentLength: null }));
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it('accepts a non-empty chunked request without Content-Length', async () => {
+    const res = await POST(makeReq('endpoint=translate', { contentLength: null }));
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it('rejects oversized bodies without fetching', async () => {
+    const res = await POST(makeReq('endpoint=translate', { body: 'x'.repeat(100_001) }));
+    expect(res.status).toBe(413);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects concurrent requests before reading their bodies', async () => {
+    const releaseFetches: Array<() => void> = [];
+    fetchSpy.mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          releaseFetches.push(() => resolve(new Response('{"code":200}', { status: 200 })));
+        }),
+    );
+
+    const pending = [1, 2, 3].map((index) =>
+      POST(
+        makeReq('endpoint=session', {
+          origin: 'https://web.readest.com',
+          contentLength: '0',
+          body: '',
+        }),
+      ),
+    );
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(3));
+
+    const rejectedRequest = makeReq('endpoint=session', {
+      origin: 'https://web.readest.com',
+      contentLength: '0',
+      body: '',
+    });
+    const textSpy = vi.spyOn(rejectedRequest, 'text');
+    const rejected = await POST(rejectedRequest);
+
+    expect(rejected.status).toBe(429);
+    expect(textSpy).not.toHaveBeenCalled();
+
+    releaseFetches.forEach((release) => release());
+    await Promise.all(pending);
+  });
+
+  it('returns 502 when reading the upstream body fails', async () => {
+    fetchSpy.mockResolvedValue({
+      status: 200,
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      text: vi.fn().mockRejectedValue(new Error('connection reset')),
+    });
+    const res = await POST(makeReq('endpoint=session'));
+    expect(res.status).toBe(502);
+  });
+
+  it('returns 502 when the upstream is unreachable', async () => {
+    fetchSpy.mockRejectedValue(new Error('network down'));
+    const res = await POST(makeReq('endpoint=session'));
+    expect(res.status).toBe(502);
+  });
+
+  it('passes through the upstream status code and body', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response('{"code":413,"message":"The text size exceeds the maximum"}', {
+        status: 413,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const res = await POST(makeReq('endpoint=translate'));
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ code: 413, message: 'The text size exceeds the maximum' });
+  });
+
+  it('sets an upstream timeout', async () => {
+    await POST(makeReq('endpoint=session'));
+    const [, init] = fetchSpy.mock.calls[0]!;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('aborts the upstream request after the timeout elapses', async () => {
+    vi.stubEnv('YANDEX_UPSTREAM_TIMEOUT_MS', '50');
+    fetchSpy.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () =>
+            reject(new DOMException('The operation timed out', 'TimeoutError')),
+          );
+        }),
+    );
+
+    const res = await POST(makeReq('endpoint=session'));
+    expect(res.status).toBe(502);
+    expect(fetchSpy.mock.calls[0]![1].signal.aborted).toBe(true);
+  });
+
+  it.each([
+    '-100',
+    'abc',
+    'Infinity',
+  ])('ignores invalid timeout env value %s instead of breaking requests', async (envValue) => {
+    vi.stubEnv('YANDEX_UPSTREAM_TIMEOUT_MS', envValue);
+    fetchSpy.mockImplementation((_url: string, init: RequestInit) => {
+      if (init.signal?.aborted) {
+        return Promise.reject(new DOMException('The operation was aborted', 'AbortError'));
+      }
+      return Promise.resolve(
+        new Response('{"code":200}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    const res = await POST(makeReq('endpoint=session'));
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/readest-app/src/__tests__/app/api/yandex-translate.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/yandex-translate.test.ts
@@ -117,7 +117,7 @@ describe('yandex-translate proxy route', () => {
         }),
     );
 
-    const pending = [1, 2, 3].map((index) =>
+    const pending = [1, 2, 3].map(() =>
       POST(
         makeReq('endpoint=session', {
           origin: 'https://web.readest.com',

--- a/apps/readest-app/src/__tests__/app/api/yandex-translate.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/yandex-translate.test.ts
@@ -1,13 +1,26 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NextRequest } from 'next/server';
+
+const validateUserAndTokenMock = vi.hoisted(() => vi.fn());
+vi.mock('@/utils/access', () => ({
+  validateUserAndToken: (...args: unknown[]) => validateUserAndTokenMock(...args),
+}));
+
 import { POST } from '@/app/api/yandex-translate/route';
 
 const makeReq = (
   query = 'endpoint=session',
-  init: { body?: string; origin?: string | null; contentLength?: string | null } = {},
+  init: {
+    body?: string;
+    origin?: string | null;
+    contentLength?: string | null;
+    authorization?: string;
+  } = {},
 ) => {
   const body = init.body ?? 'options=0&text=Hello';
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = {
+    authorization: init.authorization ?? 'Bearer test-token',
+  };
   if (init.origin !== null) headers['origin'] = init.origin ?? 'https://web.readest.com';
   if (init.contentLength !== null) {
     headers['content-length'] = init.contentLength ?? String(new TextEncoder().encode(body).length);
@@ -22,6 +35,10 @@ const makeReq = (
 let fetchSpy: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
+  validateUserAndTokenMock.mockReset().mockImplementation(async (authorization: string | null) => ({
+    user: authorization ? { id: authorization } : null,
+    token: authorization,
+  }));
   fetchSpy = vi.fn().mockResolvedValue(
     new Response('{"code":200,"text":["Bonjour"]}', {
       status: 200,
@@ -38,6 +55,19 @@ afterEach(() => {
 });
 
 describe('yandex-translate proxy route', () => {
+  it('returns 403 before reading the body or fetching when unauthenticated', async () => {
+    validateUserAndTokenMock.mockResolvedValue({ user: null, token: null });
+    const request = makeReq();
+    const textSpy = vi.spyOn(request, 'text');
+
+    const res = await POST(request);
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Not authenticated' });
+    expect(textSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it('returns 400 for an unknown endpoint without fetching', async () => {
     const res = await POST(makeReq('endpoint=nope'));
     expect(res.status).toBe(400);
@@ -123,6 +153,7 @@ describe('yandex-translate proxy route', () => {
           origin: 'https://web.readest.com',
           contentLength: '0',
           body: '',
+          authorization: 'Bearer user-a',
         }),
       ),
     );
@@ -132,6 +163,7 @@ describe('yandex-translate proxy route', () => {
       origin: 'https://web.readest.com',
       contentLength: '0',
       body: '',
+      authorization: 'Bearer user-a',
     });
     const textSpy = vi.spyOn(rejectedRequest, 'text');
     const rejected = await POST(rejectedRequest);
@@ -139,7 +171,17 @@ describe('yandex-translate proxy route', () => {
     expect(rejected.status).toBe(429);
     expect(textSpy).not.toHaveBeenCalled();
 
+    const otherUser = POST(
+      makeReq('endpoint=session', {
+        contentLength: '0',
+        body: '',
+        authorization: 'Bearer user-b',
+      }),
+    );
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(4));
+
     releaseFetches.forEach((release) => release());
+    await expect(otherUser).resolves.toMatchObject({ status: 200 });
     await Promise.all(pending);
   });
 

--- a/apps/readest-app/src/__tests__/services/translators/providers.test.ts
+++ b/apps/readest-app/src/__tests__/services/translators/providers.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
+import { isTauriAppPlatform } from '@/services/environment';
 
 // Mock environment module
 vi.mock('@/services/environment', () => ({
@@ -134,8 +136,46 @@ describe('googleProvider', () => {
 // Yandex Translate Provider
 // ---------------------------------------------------------------------------
 describe('yandexProvider', () => {
+  const mockTauriFetch = vi.mocked(tauriFetch);
+
+  const sessionResponse = () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      session: {
+        id: 'test-session-id',
+        creationTimestamp: Math.floor(Date.now() / 1000),
+        maxAge: 604800,
+      },
+    }),
+  });
+
+  const translateCalls = () =>
+    mockTauriFetch.mock.calls.filter(([url]) => String(url).includes('/tr.json/translate'));
+  const sessionCalls = () =>
+    mockTauriFetch.mock.calls.filter(([url]) => String(url).includes('/sessions'));
+
+  /** Routes session and translate requests to the given mock responses. */
+  function mockYandexFlow(translateJson: (text: string) => unknown) {
+    mockTauriFetch.mockImplementation(async (url, init) => {
+      if (String(url).includes('/sessions')) return sessionResponse() as unknown as Response;
+      const text = new URLSearchParams((init?.body as string) ?? '').get('text') ?? '';
+      return {
+        ok: true,
+        status: 200,
+        json: async () => translateJson(text),
+      } as unknown as Response;
+    });
+  }
+
   beforeEach(() => {
+    mockTauriFetch.mockReset();
     mockFetch.mockReset();
+    // The provider calls Yandex directly on Tauri and via the same-origin
+    // proxy on web — default to the Tauri path in these tests
+    vi.mocked(isTauriAppPlatform).mockReturnValue(true);
+    // Reset the module-level session cache between tests by re-importing
+    vi.resetModules();
   });
 
   afterEach(() => {
@@ -146,67 +186,205 @@ describe('yandexProvider', () => {
     const { yandexProvider } = await import('@/services/translators/providers/yandex');
     const result = await yandexProvider.translate([], 'en', 'fr');
     expect(result).toEqual([]);
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockTauriFetch).not.toHaveBeenCalled();
   });
 
-  it('translates text using yandexgpt service', async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        translations: ['Bonjour'],
-      }),
-    });
+  it('translates text via the direct yandex API', async () => {
+    mockYandexFlow(() => ({ code: 200, lang: 'en-fr', text: ['Bonjour'] }));
 
     const { yandexProvider } = await import('@/services/translators/providers/yandex');
     const result = await yandexProvider.translate(['Hello'], 'en', 'fr');
     expect(result).toEqual(['Bonjour']);
 
-    // Verify request format
-    const [url, opts] = mockFetch.mock.calls[0]!;
-    expect(url).toBe('https://translate.toil.cc/v2/translate/');
-    expect(opts.method).toBe('POST');
-    const body = JSON.parse(opts.body);
-    expect(body.service).toBe('yandexgpt');
-    expect(body.lang).toBe('en-fr');
+    // Verify session + translate request format
+    expect(sessionCalls()).toHaveLength(1);
+    expect(String(sessionCalls()[0]![0])).toContain('https://translate.yandex.ru/');
+
+    expect(translateCalls()).toHaveLength(1);
+    const [url, opts] = translateCalls()[0]!;
+    expect(String(url)).toContain('https://translate.yandex.net/api/v1/tr.json/translate');
+    const query = new URLSearchParams(String(url).split('?')[1]);
+    expect(query.get('source_lang')).toBe('en');
+    expect(query.get('target_lang')).toBe('fr');
+    expect(query.get('sid')).toBe('test-session-id-5-0');
+    expect(opts?.method).toBe('POST');
+    const body = new URLSearchParams(opts?.body as string);
+    expect(body.get('text')).toBe('Hello');
+    expect(opts?.signal).toBeInstanceOf(AbortSignal);
   });
 
-  it('uses "en" when source language is AUTO', async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        translations: ['Bonjour'],
-      }),
-    });
-
-    const { yandexProvider } = await import('@/services/translators/providers/yandex');
-    await yandexProvider.translate(['Hello'], 'AUTO', 'fr');
-
-    const body = JSON.parse(mockFetch.mock.calls[0]![1].body);
-    expect(body.lang).toBe('en-fr');
-  });
-
-  it('throws on non-OK response', async () => {
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 429,
-      json: async () => ({ error: 'rate limited' }),
-    });
-
-    const { yandexProvider } = await import('@/services/translators/providers/yandex');
-    await expect(yandexProvider.translate(['Hello'], 'en', 'fr')).rejects.toThrow(
-      'yandexgpt failed with status 429',
-    );
-  });
-
-  it('falls back to original text when translations array is missing', async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({}),
+  it('routes requests through the same-origin proxy in web builds', async () => {
+    vi.mocked(isTauriAppPlatform).mockReturnValue(false);
+    mockFetch.mockImplementation(async (url: string, init?: { body?: string }) => {
+      if (String(url).includes('endpoint=session')) {
+        return sessionResponse();
+      }
+      const text = new URLSearchParams(init?.body ?? '').get('text') ?? '';
+      return { ok: true, json: async () => ({ code: 200, lang: 'en-fr', text: [`<${text}>`] }) };
     });
 
     const { yandexProvider } = await import('@/services/translators/providers/yandex');
     const result = await yandexProvider.translate(['Hello'], 'en', 'fr');
-    expect(result).toEqual(['Hello']);
+    expect(result).toEqual(['<Hello>']);
+
+    const urls = mockFetch.mock.calls.map(([url]) => String(url));
+    expect(urls[0]).toContain('/api/yandex-translate?endpoint=session');
+    expect(urls[1]).toContain('/api/yandex-translate?endpoint=translate');
+    expect(urls[1]).toContain('source_lang=en');
+    expect(urls[1]).toContain('target_lang=fr');
+    // the browser must not try to set the Referer — the proxy attaches it
+    expect(mockTauriFetch).not.toHaveBeenCalled();
+  });
+
+  it('uses automatic detection when source language is AUTO', async () => {
+    mockYandexFlow(() => ({ code: 200, lang: 'en-fr', text: ['Bonjour'] }));
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await yandexProvider.translate(['Hello'], 'AUTO', 'fr');
+
+    const query = new URLSearchParams(String(translateCalls()[0]![0]).split('?')[1]);
+    expect(query.get('source_lang')).toBe('auto');
+  });
+
+  it.each(['zh-Hans', 'zh-Hant'])('normalizes Chinese locale %s to zh', async (targetLang) => {
+    mockYandexFlow(() => ({ code: 200, text: ['你好'] }));
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await yandexProvider.translate(['Hello'], 'en', targetLang);
+
+    const query = new URLSearchParams(String(translateCalls()[0]![0]).split('?')[1]);
+    expect(query.get('target_lang')).toBe('zh');
+  });
+
+  it('reuses the yandex session across calls', async () => {
+    mockYandexFlow(() => ({ code: 200, lang: 'en-fr', text: ['Bonjour'] }));
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await yandexProvider.translate(['Hello'], 'en', 'fr');
+    await yandexProvider.translate(['World'], 'en', 'fr');
+
+    expect(sessionCalls()).toHaveLength(1);
+    expect(translateCalls()).toHaveLength(2);
+  });
+
+  it('throws when the session request fails', async () => {
+    mockTauriFetch.mockResolvedValue({ ok: false, status: 403 } as unknown as Response);
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await expect(yandexProvider.translate(['Hello'], 'en', 'fr')).rejects.toThrow(
+      'yandex session request failed with status 403',
+    );
+  });
+
+  it('retries once with a fresh session after a session-specific error', async () => {
+    let sessionNumber = 0;
+    mockTauriFetch.mockImplementation(async (url) => {
+      if (String(url).includes('/sessions')) {
+        sessionNumber++;
+        const response = sessionResponse();
+        return {
+          ...response,
+          json: async () => ({
+            session: {
+              id: `test-session-${sessionNumber}`,
+              creationTimestamp: Math.floor(Date.now() / 1000),
+              maxAge: 604800,
+            },
+          }),
+        } as unknown as Response;
+      }
+      if (translateCalls().length === 1) {
+        return {
+          ok: false,
+          status: 403,
+          json: async () => ({ code: 403, message: 'Invalid session' }),
+        } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ code: 200, text: ['Bonjour'] }),
+      } as unknown as Response;
+    });
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await expect(yandexProvider.translate(['Hello'], 'en', 'fr')).resolves.toEqual(['Bonjour']);
+    expect(sessionCalls()).toHaveLength(2);
+    expect(translateCalls()).toHaveLength(2);
+  });
+
+  it('does not retry a proxy 403 without a Yandex session error code', async () => {
+    vi.mocked(isTauriAppPlatform).mockReturnValue(false);
+    mockFetch.mockImplementation(async (url: string) => {
+      if (String(url).includes('endpoint=session')) return sessionResponse();
+      return {
+        ok: false,
+        status: 403,
+        json: async () => ({ error: 'Forbidden' }),
+      };
+    });
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await expect(yandexProvider.translate(['Hello'], 'en', 'fr')).rejects.toThrow(
+      'yandex translate failed with status 403: Forbidden',
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws on non-session translate errors without dropping the session', async () => {
+    mockTauriFetch.mockImplementation(async (url) => {
+      if (String(url).includes('/sessions')) return sessionResponse() as unknown as Response;
+      return { ok: false, status: 500, json: async () => ({}) } as unknown as Response;
+    });
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await expect(yandexProvider.translate(['Hello'], 'en', 'fr')).rejects.toThrow(
+      'yandex translate failed with status 500',
+    );
+
+    mockYandexFlow(() => ({ code: 200, lang: 'en-fr', text: ['Bonjour'] }));
+    const result = await yandexProvider.translate(['Hello'], 'en', 'fr');
+    expect(result).toEqual(['Bonjour']);
+    expect(sessionCalls()).toHaveLength(1);
+  });
+
+  it('throws when the translate response shape is unexpected', async () => {
+    mockYandexFlow(() => ({ code: 200, text: 'Bonjour' }));
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await expect(yandexProvider.translate(['Hello'], 'en', 'fr')).rejects.toThrow(
+      'yandex translate failed: malformed response',
+    );
+  });
+
+  it('throws a malformed-response error for a 200 non-JSON response', async () => {
+    mockTauriFetch.mockImplementation(async (url) => {
+      if (String(url).includes('/sessions')) return sessionResponse() as unknown as Response;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError('Unexpected token');
+        },
+      } as unknown as Response;
+    });
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await expect(yandexProvider.translate(['Hello'], 'en', 'fr')).rejects.toThrow(
+      'yandex translate failed: malformed response',
+    );
+  });
+
+  it('rejects a session response with an invalid lifetime', async () => {
+    mockTauriFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ session: { id: 'test-session-id' } }),
+    } as unknown as Response);
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await expect(yandexProvider.translate(['Hello'], 'en', 'fr')).rejects.toThrow(
+      'yandex session request failed: malformed response',
+    );
   });
 
   it('has correct provider metadata', async () => {
@@ -217,17 +395,136 @@ describe('yandexProvider', () => {
   });
 
   it('translates multiple texts in parallel', async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        translations: ['Translated'],
-      }),
-    });
+    mockYandexFlow(() => ({ code: 200, lang: 'en-fr', text: ['Translated'] }));
 
     const { yandexProvider } = await import('@/services/translators/providers/yandex');
     const result = await yandexProvider.translate(['Hello', 'World'], 'en', 'fr');
     expect(result).toEqual(['Translated', 'Translated']);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(translateCalls()).toHaveLength(2);
+    expect(sessionCalls()).toHaveLength(1);
+  });
+
+  it('shares a single in-flight session creation across concurrent calls', async () => {
+    mockYandexFlow(() => ({ code: 200, lang: 'en-fr', text: ['Translated'] }));
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    // two concurrent calls on a cold session cache: without sharing the
+    // in-flight creation, each would open its own session
+    const [hello, world] = await Promise.all([
+      yandexProvider.translate(['Hello'], 'en', 'fr'),
+      yandexProvider.translate(['World'], 'en', 'fr'),
+    ]);
+    expect(hello).toEqual(['Translated']);
+    expect(world).toEqual(['Translated']);
+    expect(sessionCalls()).toHaveLength(1);
+  });
+
+  it('sends a text under the request limit in a single request', async () => {
+    mockYandexFlow(() => ({ code: 200, lang: 'en-fr', text: ['Translated'] }));
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    const result = await yandexProvider.translate(['a'.repeat(599)], 'en', 'fr');
+    expect(result).toEqual(['Translated']);
+    expect(translateCalls()).toHaveLength(1);
+  });
+
+  it('splits an oversized text into chunks within the request limit', async () => {
+    mockYandexFlow((text) => ({ code: 200, lang: 'en-fr', text: [`<${text.length}>`] }));
+
+    // ~3k chars of sentence-like content, no sentence boundary at the exact cut
+    const sentence = 'This is a fairly long sentence used for chunking tests. ';
+    const text = sentence.repeat(60);
+    expect(text.length).toBeGreaterThan(600);
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    const result = await yandexProvider.translate([text], 'en', 'fr');
+
+    expect(result).toHaveLength(1);
+    expect(translateCalls().length).toBeGreaterThan(1);
+    const sentTexts = translateCalls().map(
+      (call) => new URLSearchParams(call[1]?.body as string).get('text') ?? '',
+    );
+    for (const sent of sentTexts) {
+      expect(sent.length).toBeLessThanOrEqual(600);
+    }
+    // chunks are reassembled into a single output in request order
+    expect(sentTexts.join('')).toBe(text);
+    expect(result[0]).toBe(sentTexts.map((sent) => `<${sent.length}>`).join(''));
+  });
+
+  it('does not exceed the chunk limit at an exact whitespace boundary', async () => {
+    mockYandexFlow((text) => ({ code: 200, text: [text] }));
+    const text = `${'x'.repeat(600)} ${'y'.repeat(10)}`;
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await yandexProvider.translate([text], 'en', 'fr');
+
+    const sentTexts = translateCalls().map(
+      (call) => new URLSearchParams(call[1]?.body as string).get('text') ?? '',
+    );
+    expect(Math.max(...sentTexts.map((sent) => sent.length))).toBe(600);
+    expect(sentTexts.join('')).toBe(text);
+  });
+
+  it('does not split a Unicode grapheme cluster at the chunk boundary', async () => {
+    mockYandexFlow((text) => ({ code: 200, text: [text] }));
+    const grapheme = '👩‍👩‍👧‍👦';
+    const text = `${'x'.repeat(595)}${grapheme}tail`;
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await yandexProvider.translate([text], 'en', 'fr');
+
+    const sentTexts = translateCalls().map(
+      (call) => new URLSearchParams(call[1]?.body as string).get('text') ?? '',
+    );
+    expect(sentTexts[0]).toHaveLength(595);
+    expect(sentTexts[1]!.startsWith(grapheme)).toBe(true);
+    expect(sentTexts.join('')).toBe(text);
+  });
+
+  it('rejects input that would exceed the proxy request budget before fetching', async () => {
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+
+    await expect(yandexProvider.translate(['x'.repeat(600 * 60)], 'en', 'fr')).rejects.toThrow(
+      'maximum is 29',
+    );
+    expect(mockTauriFetch).not.toHaveBeenCalled();
+  });
+
+  it('limits concurrent chunk requests', async () => {
+    let active = 0;
+    let peak = 0;
+    mockTauriFetch.mockImplementation(async (url, init) => {
+      if (String(url).includes('/sessions')) return sessionResponse() as unknown as Response;
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      active--;
+      const text = new URLSearchParams((init?.body as string) ?? '').get('text') ?? '';
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ code: 200, text: [text] }),
+      } as unknown as Response;
+    });
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await yandexProvider.translate(['x'.repeat(6000)], 'en', 'fr');
+
+    expect(peak).toBe(3);
+  });
+
+  it('splits on sentence boundaries rather than mid-sentence when possible', async () => {
+    mockYandexFlow(() => ({ code: 200, lang: 'en-fr', text: ['Translated'] }));
+
+    const text = `${'x'.repeat(500)}. ${'y'.repeat(200)}`;
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await yandexProvider.translate([text], 'en', 'fr');
+
+    expect(translateCalls()).toHaveLength(2);
+    const firstBody = new URLSearchParams(translateCalls()[0]![1]?.body as string);
+    expect(firstBody.get('text')!.endsWith('.')).toBe(true);
   });
 });
 
@@ -237,6 +534,9 @@ describe('yandexProvider', () => {
 describe('azureProvider', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    // The yandex suite above flips the platform mock to Tauri; azure uses
+    // window.fetch off Tauri, so restore the default for these tests
+    vi.mocked(isTauriAppPlatform).mockReturnValue(false);
     // Suppress expected error noise from token fetch failure tests.
     vi.spyOn(console, 'error').mockImplementation(() => {});
     // Reset the module-level token cache between tests by re-importing
@@ -330,9 +630,9 @@ describe('azureProvider', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Provider registry — disabled providers stay visible but unselectable
+// Provider registry — availability rules
 // ---------------------------------------------------------------------------
-describe('provider registry disabled handling', () => {
+describe('provider registry availability handling', () => {
   // No `vi.resetModules()` here — these tests only inspect static provider
   // metadata, so resolving the registry once is enough. Resetting between
   // each test would re-evaluate the full import chain and churn module
@@ -344,20 +644,21 @@ describe('provider registry disabled handling', () => {
     expect(names).toContain('yandex');
   });
 
-  it('exposes yandex as disabled so callers can grey it out', async () => {
-    const { getTranslator } = await import('@/services/translators/providers');
-    const yandex = getTranslator('yandex');
-    expect(yandex).toBeDefined();
-    expect(yandex!.disabled).toBe(true);
-  });
-
-  it('isTranslatorAvailable returns false for disabled providers', async () => {
+  it('exposes yandex as available', async () => {
     const { getTranslator, isTranslatorAvailable } = await import(
       '@/services/translators/providers'
     );
-    const yandex = getTranslator('yandex')!;
-    expect(isTranslatorAvailable(yandex, true)).toBe(false);
-    expect(isTranslatorAvailable(yandex, false)).toBe(false);
+    const yandex = getTranslator('yandex');
+    expect(yandex).toBeDefined();
+    expect(yandex!.disabled).toBeFalsy();
+    expect(isTranslatorAvailable(yandex!, false)).toBe(true);
+  });
+
+  it('isTranslatorAvailable returns false for disabled providers', async () => {
+    const { isTranslatorAvailable } = await import('@/services/translators/providers');
+    const disabled = { name: 'x', label: 'X', disabled: true, translate: async () => [] };
+    expect(isTranslatorAvailable(disabled, true)).toBe(false);
+    expect(isTranslatorAvailable(disabled, false)).toBe(false);
   });
 
   it('isTranslatorAvailable returns false for authRequired without token', async () => {

--- a/apps/readest-app/src/__tests__/services/translators/providers.test.ts
+++ b/apps/readest-app/src/__tests__/services/translators/providers.test.ts
@@ -189,7 +189,7 @@ describe('yandexProvider', () => {
     expect(mockTauriFetch).not.toHaveBeenCalled();
   });
 
-  it('translates text via the direct yandex API', async () => {
+  it('translates without a Readest token via the direct yandex API', async () => {
     mockYandexFlow(() => ({ code: 200, lang: 'en-fr', text: ['Bonjour'] }));
 
     const { yandexProvider } = await import('@/services/translators/providers/yandex');
@@ -208,6 +208,7 @@ describe('yandexProvider', () => {
     expect(query.get('target_lang')).toBe('fr');
     expect(query.get('sid')).toBe('test-session-id-5-0');
     expect(opts?.method).toBe('POST');
+    expect((opts?.headers as Record<string, string>)['Authorization']).toBeUndefined();
     const body = new URLSearchParams(opts?.body as string);
     expect(body.get('text')).toBe('Hello');
     expect(opts?.signal).toBeInstanceOf(AbortSignal);
@@ -224,15 +225,29 @@ describe('yandexProvider', () => {
     });
 
     const { yandexProvider } = await import('@/services/translators/providers/yandex');
-    const result = await yandexProvider.translate(['Hello'], 'en', 'fr');
+    const result = await yandexProvider.translate(['Hello'], 'en', 'fr', 'readest-access-token');
     expect(result).toEqual(['<Hello>']);
 
+    for (const [, init] of mockFetch.mock.calls) {
+      expect(init.headers['Authorization']).toBe('Bearer readest-access-token');
+    }
     const urls = mockFetch.mock.calls.map(([url]) => String(url));
     expect(urls[0]).toContain('/api/yandex-translate?endpoint=session');
     expect(urls[1]).toContain('/api/yandex-translate?endpoint=translate');
     expect(urls[1]).toContain('source_lang=en');
     expect(urls[1]).toContain('target_lang=fr');
     // the browser must not try to set the Referer — the proxy attaches it
+    expect(mockTauriFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects web requests without a Readest token before fetching', async () => {
+    vi.mocked(isTauriAppPlatform).mockReturnValue(false);
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    await expect(yandexProvider.translate(['Hello'], 'en', 'fr')).rejects.toThrow(
+      'yandex translate requires authentication in web builds',
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
     expect(mockTauriFetch).not.toHaveBeenCalled();
   });
 
@@ -325,9 +340,9 @@ describe('yandexProvider', () => {
     });
 
     const { yandexProvider } = await import('@/services/translators/providers/yandex');
-    await expect(yandexProvider.translate(['Hello'], 'en', 'fr')).rejects.toThrow(
-      'yandex translate failed with status 403: Forbidden',
-    );
+    await expect(
+      yandexProvider.translate(['Hello'], 'en', 'fr', 'readest-access-token'),
+    ).rejects.toThrow('yandex translate failed with status 403: Forbidden');
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
@@ -644,14 +659,18 @@ describe('provider registry availability handling', () => {
     expect(names).toContain('yandex');
   });
 
-  it('exposes yandex as available', async () => {
+  it('requires authentication for yandex only in web builds', async () => {
     const { getTranslator, isTranslatorAvailable } = await import(
       '@/services/translators/providers'
     );
-    const yandex = getTranslator('yandex');
-    expect(yandex).toBeDefined();
-    expect(yandex!.disabled).toBeFalsy();
-    expect(isTranslatorAvailable(yandex!, false)).toBe(true);
+    const yandex = getTranslator('yandex')!;
+
+    vi.mocked(isTauriAppPlatform).mockReturnValue(false);
+    expect(isTranslatorAvailable(yandex, false)).toBe(false);
+    expect(isTranslatorAvailable(yandex, true)).toBe(true);
+
+    vi.mocked(isTauriAppPlatform).mockReturnValue(true);
+    expect(isTranslatorAvailable(yandex, false)).toBe(true);
   });
 
   it('isTranslatorAvailable returns false for disabled providers', async () => {

--- a/apps/readest-app/src/app/api/yandex-translate/route.ts
+++ b/apps/readest-app/src/app/api/yandex-translate/route.ts
@@ -1,0 +1,129 @@
+﻿import { NextRequest, NextResponse } from 'next/server';
+import {
+  YANDEX_ORIGIN,
+  YANDEX_SESSION_URL,
+  YANDEX_TRANSLATE_URL,
+  YANDEX_USER_AGENT,
+} from '@/services/translators/providers/yandexShared';
+
+/**
+ * Same-origin proxy for the Yandex Translate web API, used by the `yandex`
+ * translation provider in web builds. The Yandex session endpoint requires a
+ * translate.yandex.ru Referer, which a browser cannot send cross-origin, so
+ * the client calls this route and the headers are attached server-side.
+ * Only two fixed upstream endpoints are exposed — no arbitrary URL is ever
+ * fetched, so there is no SSRF surface.
+ */
+const ENDPOINTS: Record<string, string> = {
+  session: YANDEX_SESSION_URL,
+  translate: YANDEX_TRANSLATE_URL,
+};
+
+// The provider chunks texts at 600 chars; anything much larger is abuse.
+const MAX_BODY_CHARS = 100_000;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_REQUESTS = 60;
+const MAX_CONCURRENT_REQUESTS = 3;
+const UPSTREAM_TIMEOUT_MS = 15_000;
+
+const requestBudgets = new Map<string, { count: number; resetAt: number; active: number }>();
+// Read lazily so tests and deployments can override it via the env var.
+// Invalid values (non-positive, NaN, Infinity) fall back to the default —
+// AbortSignal.timeout() would abort immediately or throw otherwise.
+const upstreamTimeoutMs = () => {
+  const value = Number(process.env['YANDEX_UPSTREAM_TIMEOUT_MS']);
+  return Number.isFinite(value) && value > 0 ? value : UPSTREAM_TIMEOUT_MS;
+};
+// Response constructor throws when these statuses carry a body.
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+
+const getClientId = (request: NextRequest) =>
+  request.headers.get('cf-connecting-ip') ??
+  request.headers.get('x-real-ip') ??
+  request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+  'unknown';
+
+export async function POST(request: NextRequest) {
+  const origin = request.headers.get('origin');
+  let originHost: string | null = null;
+  try {
+    originHost = origin ? new URL(origin).host : null;
+  } catch {
+    // leave originHost null — treated as a mismatch below
+  }
+  if (originHost !== request.nextUrl.host) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const endpoint = request.nextUrl.searchParams.get('endpoint');
+  const upstream = endpoint ? ENDPOINTS[endpoint] : undefined;
+  if (!upstream) {
+    return NextResponse.json({ error: 'Unknown endpoint' }, { status: 400 });
+  }
+
+  const now = Date.now();
+  const clientId = getClientId(request);
+  let budget = requestBudgets.get(clientId);
+  if (!budget || budget.resetAt <= now) {
+    budget = {
+      count: 0,
+      resetAt: now + RATE_LIMIT_WINDOW_MS,
+      active: budget?.active ?? 0,
+    };
+    requestBudgets.set(clientId, budget);
+  }
+  if (budget.count >= RATE_LIMIT_REQUESTS || budget.active >= MAX_CONCURRENT_REQUESTS) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      { status: 429, headers: { 'Retry-After': String(Math.ceil((budget.resetAt - now) / 1000)) } },
+    );
+  }
+  budget.count++;
+  budget.active++;
+
+  try {
+    const contentLength = request.headers.get('content-length');
+    if (contentLength !== null) {
+      const declaredLength = Number(contentLength);
+      if (
+        !Number.isSafeInteger(declaredLength) ||
+        declaredLength < 0 ||
+        declaredLength > MAX_BODY_CHARS * 3
+      ) {
+        return NextResponse.json({ error: 'Invalid request body size' }, { status: 413 });
+      }
+    }
+    const body = await request.text();
+    if (body.length > MAX_BODY_CHARS) {
+      return NextResponse.json({ error: 'Request body too large' }, { status: 413 });
+    }
+
+    const url = new URL(upstream);
+    request.nextUrl.searchParams.forEach((value, key) => {
+      if (key !== 'endpoint') url.searchParams.append(key, value);
+    });
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'User-Agent': YANDEX_USER_AGENT,
+          Origin: YANDEX_ORIGIN,
+          Referer: `${YANDEX_ORIGIN}/`,
+        },
+        body,
+        signal: AbortSignal.any([request.signal, AbortSignal.timeout(upstreamTimeoutMs())]),
+      });
+      const responseBody = NULL_BODY_STATUSES.has(response.status) ? null : await response.text();
+      return new NextResponse(responseBody, {
+        status: response.status,
+        headers: { 'Content-Type': response.headers.get('Content-Type') ?? 'application/json' },
+      });
+    } catch {
+      return NextResponse.json({ error: 'Upstream request failed' }, { status: 502 });
+    }
+  } finally {
+    budget.active--;
+  }
+}

--- a/apps/readest-app/src/app/api/yandex-translate/route.ts
+++ b/apps/readest-app/src/app/api/yandex-translate/route.ts
@@ -5,6 +5,7 @@ import {
   YANDEX_TRANSLATE_URL,
   YANDEX_USER_AGENT,
 } from '@/services/translators/providers/yandexShared';
+import { validateUserAndToken } from '@/utils/access';
 
 /**
  * Same-origin proxy for the Yandex Translate web API, used by the `yandex`
@@ -37,13 +38,12 @@ const upstreamTimeoutMs = () => {
 // Response constructor throws when these statuses carry a body.
 const NULL_BODY_STATUSES = new Set([204, 205, 304]);
 
-const getClientId = (request: NextRequest) =>
-  request.headers.get('cf-connecting-ip') ??
-  request.headers.get('x-real-ip') ??
-  request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-  'unknown';
-
 export async function POST(request: NextRequest) {
+  const { user, token } = await validateUserAndToken(request.headers.get('authorization'));
+  if (!user || !token) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 403 });
+  }
+
   const origin = request.headers.get('origin');
   let originHost: string | null = null;
   try {
@@ -62,15 +62,14 @@ export async function POST(request: NextRequest) {
   }
 
   const now = Date.now();
-  const clientId = getClientId(request);
-  let budget = requestBudgets.get(clientId);
+  let budget = requestBudgets.get(user.id);
   if (!budget || budget.resetAt <= now) {
     budget = {
       count: 0,
       resetAt: now + RATE_LIMIT_WINDOW_MS,
       active: budget?.active ?? 0,
     };
-    requestBudgets.set(clientId, budget);
+    requestBudgets.set(user.id, budget);
   }
   if (budget.count >= RATE_LIMIT_REQUESTS || budget.active >= MAX_CONCURRENT_REQUESTS) {
     return NextResponse.json(

--- a/apps/readest-app/src/services/translators/providers/yandex.ts
+++ b/apps/readest-app/src/services/translators/providers/yandex.ts
@@ -3,81 +3,337 @@ import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import { isTauriAppPlatform } from '@/services/environment';
 import { normalizeToShortLang } from '@/utils/lang';
 import { TranslationProvider } from '../types';
+import { YANDEX_REQUEST_HEADERS, YANDEX_SESSION_URL, YANDEX_TRANSLATE_URL } from './yandexShared';
 
 /**
- * Based on https://translate.toil.cc/v2/docs API specification
+ * Direct client for the Yandex Translate web API — the same endpoints the
+ * translate.yandex.ru frontend uses (protocol reverse-engineered by the
+ * FOSWLY/translate project). No relay server or API key required.
+ *
+ * Constraints:
+ * - the API rejects texts longer than ~650 chars with 413 "The text size
+ *   exceeds the maximum" (verified empirically — the FOSWLY docs claiming
+ *   10k are outdated), so longer texts are split into chunks;
+ * - the session endpoint validates the Referer header. In the Tauri app we
+ *   send it directly; in web builds the browser cannot spoof it cross-origin,
+ *   so requests go through the same-origin proxy at /api/yandex-translate,
+ *   which attaches the headers server-side.
  */
-async function translateSingleTextForService(
-  text: string,
-  lang: string,
-  service: string,
-): Promise<string[]> {
-  const fetchImpl = isTauriAppPlatform() ? tauriFetch : window.fetch;
-  const url = 'https://translate.toil.cc/v2/translate/';
+const MAX_CHARS_PER_REQUEST = 600;
+const MAX_CONCURRENT_REQUESTS = 3;
+// Reserve two requests for initial and refreshed sessions, and account for
+// every translate chunk potentially retrying once with the refreshed SID.
+const MAX_TRANSLATE_REQUESTS_PER_CALL = 29;
+const TRANSPORT_TIMEOUT_MS = 15_000;
+const PROXY_URL = '/api/yandex-translate';
 
-  const request = {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      lang: lang,
-      service: service,
-      text: text,
-    }),
+interface YandexSession {
+  id: string;
+  expiresAt: number;
+}
+
+interface RequestWaiter {
+  start: () => void;
+  abort: () => void;
+}
+
+let cachedSession: YandexSession | null = null;
+// Concurrent translate() calls must not race to create several sessions,
+// so the in-flight creation is shared between callers.
+let sessionPromise: Promise<string> | null = null;
+let activeRequests = 0;
+const requestQueue: RequestWaiter[] = [];
+
+function releaseRequestSlot() {
+  const waiter = requestQueue.shift();
+  if (waiter) {
+    // Transfer the occupied slot directly. Keeping activeRequests unchanged
+    // makes the handoff atomic with respect to fresh callers.
+    waiter.start();
+  } else {
+    activeRequests--;
+  }
+}
+
+async function withRequestLimit<T>(task: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+  signal?.throwIfAborted();
+  if (activeRequests < MAX_CONCURRENT_REQUESTS) {
+    activeRequests++;
+  } else {
+    await new Promise<void>((resolve, reject) => {
+      const waiter: RequestWaiter = {
+        start: () => {
+          signal?.removeEventListener('abort', waiter.abort);
+          resolve();
+        },
+        abort: () => {
+          const index = requestQueue.indexOf(waiter);
+          if (index >= 0) requestQueue.splice(index, 1);
+          reject(signal?.reason);
+        },
+      };
+      requestQueue.push(waiter);
+      signal?.addEventListener('abort', waiter.abort, { once: true });
+    });
+  }
+
+  try {
+    signal?.throwIfAborted();
+    return await task();
+  } finally {
+    releaseRequestSlot();
+  }
+}
+
+const getRequestTarget = (endpoint: 'session' | 'translate') => {
+  if (isTauriAppPlatform()) {
+    return {
+      fetchImpl: tauriFetch,
+      url: endpoint === 'session' ? YANDEX_SESSION_URL : YANDEX_TRANSLATE_URL,
+      headers: YANDEX_REQUEST_HEADERS,
+      direct: true,
+    };
+  }
+  return {
+    fetchImpl: window.fetch.bind(window),
+    url: `${PROXY_URL}?endpoint=${endpoint}`,
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    direct: false,
   };
+};
 
-  const response = await fetchImpl(url, request);
+const withParams = (base: string, params: URLSearchParams) =>
+  `${base}${base.includes('?') ? '&' : '?'}${params}`;
 
+const requestSignal = (direct: boolean, signal?: AbortSignal) => {
+  if (!direct) return signal;
+  const timeout = AbortSignal.timeout(TRANSPORT_TIMEOUT_MS);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+};
+
+// yu — random Yandex UID, yum — Metrika timestamp in microseconds
+const genYandexUID = () => BigInt(Math.floor(Math.random() * 1e19)).toString();
+const genYandexMetrikaUID = () => (Date.now() * 1e6).toString();
+
+const baseParams = () => ({
+  srv: 'tr-text',
+  yu: genYandexUID(),
+  yum: genYandexMetrikaUID(),
+});
+
+async function createSession(): Promise<string> {
+  const { fetchImpl, url, headers, direct } = getRequestTarget('session');
+  const params = new URLSearchParams(baseParams());
+  const signal = requestSignal(direct);
+  const response = await withRequestLimit(
+    () =>
+      fetchImpl(withParams(url, params), {
+        method: 'POST',
+        headers,
+        signal,
+      }),
+    signal,
+  );
   if (!response.ok) {
-    const response_json = JSON.stringify(await response.json());
+    throw new Error(`yandex session request failed with status ${response.status}`);
+  }
+  const data = await response.json();
+  const session = data?.session;
+  if (
+    typeof session?.id !== 'string' ||
+    !session.id ||
+    !Number.isFinite(session.creationTimestamp) ||
+    session.creationTimestamp <= 0 ||
+    !Number.isFinite(session.maxAge) ||
+    session.maxAge <= 0
+  ) {
+    throw new Error('yandex session request failed: malformed response');
+  }
+  cachedSession = {
+    id: session.id,
+    expiresAt: (session.creationTimestamp + session.maxAge) * 1000,
+  };
+  return session.id;
+}
+
+async function getSession(signal?: AbortSignal): Promise<string> {
+  signal?.throwIfAborted();
+  if (cachedSession && cachedSession.expiresAt > Date.now()) {
+    return cachedSession.id;
+  }
+  sessionPromise ??= createSession().finally(() => {
+    sessionPromise = null;
+  });
+  if (!signal) return sessionPromise;
+
+  return new Promise<string>((resolve, reject) => {
+    const abort = () => reject(signal.reason);
+    signal.addEventListener('abort', abort, { once: true });
+    sessionPromise!.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', abort);
+    });
+  });
+}
+
+/**
+ * Splits a long text into chunks of at most `maxLength` UTF-16 code units,
+ * breaking on sentence ends, newlines or spaces whenever possible without
+ * splitting a Unicode grapheme cluster.
+ */
+function splitTextIntoChunks(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) return [text];
+
+  const boundaries = Array.from(
+    new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(text),
+    ({ index }) => index,
+  );
+  boundaries.push(text.length);
+
+  const chunks: string[] = [];
+  let start = 0;
+  while (start < text.length) {
+    let end = start;
+    for (const boundary of boundaries) {
+      if (boundary <= start) continue;
+      if (boundary - start > maxLength) break;
+      end = boundary;
+    }
+    if (end === start) {
+      throw new Error('yandex translate cannot fit a grapheme cluster within the request limit');
+    }
+
+    const window = text.slice(start, end);
+    let cut = end;
+    const sentenceEnd = Math.max(
+      window.lastIndexOf('. '),
+      window.lastIndexOf('! '),
+      window.lastIndexOf('? '),
+      window.lastIndexOf('\n'),
+    );
+    if (sentenceEnd > maxLength / 2) {
+      cut = start + sentenceEnd + 1;
+    } else {
+      const space = window.lastIndexOf(' ');
+      if (space > maxLength / 2) cut = start + space + 1;
+    }
+    chunks.push(text.slice(start, cut));
+    start = cut;
+  }
+  return chunks;
+}
+
+async function translateChunk(
+  text: string,
+  sourceLang: string,
+  targetLang: string,
+  signal?: AbortSignal,
+  retrySession = true,
+): Promise<string> {
+  signal?.throwIfAborted();
+  const sid = await getSession(signal);
+  const params = new URLSearchParams({
+    ...baseParams(),
+    sid: `${sid}-5-0`,
+    source_lang: sourceLang,
+    target_lang: targetLang,
+    reason: 'paste',
+    format: 'text',
+    strategy: '0',
+    disable_cache: 'false',
+    ajax: '1',
+  });
+  const body = new URLSearchParams([
+    ['options', '0'],
+    ['text', text],
+  ]);
+
+  const { fetchImpl, url, headers, direct } = getRequestTarget('translate');
+  const transportSignal = requestSignal(direct, signal);
+  const response = await withRequestLimit(
+    () =>
+      fetchImpl(withParams(url, params), {
+        method: 'POST',
+        headers,
+        body: body.toString(),
+        signal: transportSignal,
+      }),
+    transportSignal,
+  );
+  const data = await response.json().catch(() => null);
+  if (response.ok && !data) {
+    throw new Error('yandex translate failed: malformed response');
+  }
+  const errorCode = typeof data?.code === 'number' ? data.code : null;
+  if (!response.ok || errorCode !== 200 || data?.message) {
+    // Proxy transport errors use { error } without a Yandex `code`; they must
+    // not invalidate a healthy SID or trigger a futile retry.
+    const sessionInvalid = errorCode === 401 || errorCode === 403;
+    if (sessionInvalid && cachedSession?.id === sid) cachedSession = null;
+    if (sessionInvalid && retrySession) {
+      return translateChunk(text, sourceLang, targetLang, signal, false);
+    }
     throw new Error(
-      `${service} failed with status ${response.status}\n${text.length}\n${JSON.stringify(request)}\n${response_json}`,
+      `yandex translate failed with status ${response.status}: ${data?.message ?? data?.error ?? 'unknown error'}`,
     );
   }
-
-  const data = await response.json();
-  if (data && Array.isArray(data.translations)) {
-    return data.translations;
-  } else {
-    // fallback: return original texts if translation failed
-    return [text];
+  if (!Array.isArray(data.text) || !data.text.every((item: unknown) => typeof item === 'string')) {
+    throw new Error('yandex translate failed: malformed response');
   }
+  return data.text.join('');
 }
 
 export const yandexProvider: TranslationProvider = {
   name: 'yandex',
   label: _('Yandex Translate'),
   authRequired: false,
-  // The upstream translate.toil.cc relay is currently down. Keep the
-  // implementation in tree so we can re-enable it simply by flipping this
-  // flag to `false` (or deleting the line) once the service is healthy.
-  disabled: true,
-  translate: async (texts: string[], sourceLang: string, targetLang: string): Promise<string[]> => {
+  translate: async (
+    texts: string[],
+    sourceLang: string,
+    targetLang: string,
+    _token?: string | null,
+    _useCache?: boolean,
+    signal?: AbortSignal,
+  ): Promise<string[]> => {
     if (!texts.length) return [];
 
-    /**
-      Possible options:
-      - yandexcloud: often returns 500: {"error":"The text couldn't be translated, because Forbidden"}
-      - yandexgpt: often better than others
-      - yandextranslate
-      - yandexbrowser
-    */
-    const service = 'yandexgpt';
+    const normalizeLang = (lang: string) => {
+      const normalized = normalizeToShortLang(lang).toLowerCase();
+      return normalized === 'zh' || normalized.startsWith('zh-') ? 'zh' : normalized;
+    };
+    const source_lang = sourceLang === 'AUTO' ? 'auto' : normalizeLang(sourceLang);
+    const target_lang = normalizeLang(targetLang);
+    const chunkedTexts = texts.map((text) => splitTextIntoChunks(text, MAX_CHARS_PER_REQUEST));
+    const chunkCount = chunkedTexts.reduce((total, chunks) => total + chunks.length, 0);
+    if (chunkCount > MAX_TRANSLATE_REQUESTS_PER_CALL) {
+      throw new Error(
+        `yandex translate request requires ${chunkCount} chunks; maximum is ${MAX_TRANSLATE_REQUESTS_PER_CALL}`,
+      );
+    }
 
-    // Yandex does not accept "auto" language
-    const source_lang =
-      sourceLang == 'AUTO' ? 'en' : normalizeToShortLang(sourceLang).toLowerCase();
-    const target_lang = normalizeToShortLang(targetLang).toLowerCase();
-    const lang = `${source_lang}-${target_lang}`;
-
-    const responses = await Promise.all(
-      texts.map(async (text) => {
-        return await translateSingleTextForService(text, lang, service);
-      }),
+    const results = new Array<string>(texts.length);
+    const jobs = chunkedTexts.flatMap((chunks, textIndex) =>
+      chunks.map((chunk, chunkIndex) => ({ chunk, chunkIndex, textIndex })),
     );
-
-    const translatedTexts = responses.flat();
-    return translatedTexts;
+    const translatedChunks = chunkedTexts.map((chunks) => new Array<string>(chunks.length));
+    let nextJob = 0;
+    const worker = async () => {
+      while (nextJob < jobs.length) {
+        signal?.throwIfAborted();
+        const job = jobs[nextJob++]!;
+        translatedChunks[job.textIndex]![job.chunkIndex] = await translateChunk(
+          job.chunk,
+          source_lang,
+          target_lang,
+          signal,
+        );
+      }
+    };
+    await Promise.all(
+      Array.from({ length: Math.min(MAX_CONCURRENT_REQUESTS, jobs.length) }, () => worker()),
+    );
+    translatedChunks.forEach((chunks, index) => {
+      results[index] = chunks.join('');
+    });
+    return results;
   },
 };

--- a/apps/readest-app/src/services/translators/providers/yandex.ts
+++ b/apps/readest-app/src/services/translators/providers/yandex.ts
@@ -85,7 +85,7 @@ async function withRequestLimit<T>(task: () => Promise<T>, signal?: AbortSignal)
   }
 }
 
-const getRequestTarget = (endpoint: 'session' | 'translate') => {
+const getRequestTarget = (endpoint: 'session' | 'translate', token?: string | null) => {
   if (isTauriAppPlatform()) {
     return {
       fetchImpl: tauriFetch,
@@ -94,10 +94,16 @@ const getRequestTarget = (endpoint: 'session' | 'translate') => {
       direct: true,
     };
   }
+  if (!token) {
+    throw new Error('yandex translate requires authentication in web builds');
+  }
   return {
     fetchImpl: window.fetch.bind(window),
     url: `${PROXY_URL}?endpoint=${endpoint}`,
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Bearer ${token}`,
+    },
     direct: false,
   };
 };
@@ -121,8 +127,8 @@ const baseParams = () => ({
   yum: genYandexMetrikaUID(),
 });
 
-async function createSession(): Promise<string> {
-  const { fetchImpl, url, headers, direct } = getRequestTarget('session');
+async function createSession(token?: string | null): Promise<string> {
+  const { fetchImpl, url, headers, direct } = getRequestTarget('session', token);
   const params = new URLSearchParams(baseParams());
   const signal = requestSignal(direct);
   const response = await withRequestLimit(
@@ -156,12 +162,12 @@ async function createSession(): Promise<string> {
   return session.id;
 }
 
-async function getSession(signal?: AbortSignal): Promise<string> {
+async function getSession(token?: string | null, signal?: AbortSignal): Promise<string> {
   signal?.throwIfAborted();
   if (cachedSession && cachedSession.expiresAt > Date.now()) {
     return cachedSession.id;
   }
-  sessionPromise ??= createSession().finally(() => {
+  sessionPromise ??= createSession(token).finally(() => {
     sessionPromise = null;
   });
   if (!signal) return sessionPromise;
@@ -226,11 +232,12 @@ async function translateChunk(
   text: string,
   sourceLang: string,
   targetLang: string,
+  token?: string | null,
   signal?: AbortSignal,
   retrySession = true,
 ): Promise<string> {
   signal?.throwIfAborted();
-  const sid = await getSession(signal);
+  const sid = await getSession(token, signal);
   const params = new URLSearchParams({
     ...baseParams(),
     sid: `${sid}-5-0`,
@@ -247,7 +254,7 @@ async function translateChunk(
     ['text', text],
   ]);
 
-  const { fetchImpl, url, headers, direct } = getRequestTarget('translate');
+  const { fetchImpl, url, headers, direct } = getRequestTarget('translate', token);
   const transportSignal = requestSignal(direct, signal);
   const response = await withRequestLimit(
     () =>
@@ -270,7 +277,7 @@ async function translateChunk(
     const sessionInvalid = errorCode === 401 || errorCode === 403;
     if (sessionInvalid && cachedSession?.id === sid) cachedSession = null;
     if (sessionInvalid && retrySession) {
-      return translateChunk(text, sourceLang, targetLang, signal, false);
+      return translateChunk(text, sourceLang, targetLang, token, signal, false);
     }
     throw new Error(
       `yandex translate failed with status ${response.status}: ${data?.message ?? data?.error ?? 'unknown error'}`,
@@ -285,12 +292,14 @@ async function translateChunk(
 export const yandexProvider: TranslationProvider = {
   name: 'yandex',
   label: _('Yandex Translate'),
-  authRequired: false,
+  get authRequired() {
+    return !isTauriAppPlatform();
+  },
   translate: async (
     texts: string[],
     sourceLang: string,
     targetLang: string,
-    _token?: string | null,
+    token?: string | null,
     _useCache?: boolean,
     signal?: AbortSignal,
   ): Promise<string[]> => {
@@ -324,6 +333,7 @@ export const yandexProvider: TranslationProvider = {
           job.chunk,
           source_lang,
           target_lang,
+          token,
           signal,
         );
       }

--- a/apps/readest-app/src/services/translators/providers/yandexShared.ts
+++ b/apps/readest-app/src/services/translators/providers/yandexShared.ts
@@ -1,0 +1,18 @@
+﻿/**
+ * Shared constants for the Yandex Translate web API: used both by the client
+ * provider ('./yandex', which calls Yandex directly on Tauri) and by the
+ * same-origin web proxy ('@/app/api/yandex-translate/route'). Keep this module
+ * free of platform-specific imports so it loads in both bundles.
+ */
+export const YANDEX_ORIGIN = 'https://translate.yandex.ru';
+export const YANDEX_SESSION_URL = `${YANDEX_ORIGIN}/props/api/v1.0/sessions`;
+export const YANDEX_TRANSLATE_URL = 'https://translate.yandex.net/api/v1/tr.json/translate';
+export const YANDEX_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+  'Chrome/148.0.0.0 YaBrowser/26.6.0.0 Safari/537.36';
+export const YANDEX_REQUEST_HEADERS = {
+  'Content-Type': 'application/x-www-form-urlencoded',
+  'User-Agent': YANDEX_USER_AGENT,
+  Origin: YANDEX_ORIGIN,
+  Referer: `${YANDEX_ORIGIN}/`,
+};

--- a/apps/readest-app/src/services/translators/types.ts
+++ b/apps/readest-app/src/services/translators/types.ts
@@ -19,6 +19,7 @@ export interface TranslationProvider {
     targetLang: string,
     token?: string | null,
     useCache?: boolean,
+    signal?: AbortSignal,
   ) => Promise<string[]>;
 }
 


### PR DESCRIPTION
## Summary

I originally added the Yandex Translate provider to Readest. The relay service it depended on is no longer available, so this PR repairs my original integration and brings the provider back without relying on that relay.

Yandex Translate is especially useful for Slavic languages, where in my experience it often produces better translations than the other available providers. I would like to restore it as an option for Readest users.

## What changed

- Replaced the unavailable `translate.toil.cc` relay with Yandex's translation endpoints.
- Added session creation and reuse, including one retry when Yandex reports an invalid session.
- Added a same-origin Next.js proxy for web builds because browsers cannot set the `Referer` header required by Yandex. Tauri builds call Yandex directly.
- Split long text into requests below Yandex's actual size limit while preserving sentence, whitespace, and grapheme boundaries where possible.
- Kept automatic source-language detection and normalized Chinese locale variants to the language code accepted by the endpoint.
- Added request concurrency limits, timeouts, cancellation support, response validation, and basic abuse protection for the web proxy.
- Re-enabled Yandex in the provider registry.

## Testing

- Yandex provider and translator registry tests: 43 passed.
- Yandex web proxy tests: 18 passed.