### PR TITLE
Hide upload/download buttons when signed out

### DIFF
--- a/apps/readest-app/src/app/library/components/BookItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookItem.tsx
@@ -10,12 +10,10 @@ import {
 import { Book } from '@/types/book';
 import { useEnv } from '@/context/EnvContext';
 import { useAuth } from '@/context/AuthContext';
-import { useRouter } from 'next/navigation';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
 import { LibraryCoverFitType, LibraryViewModeType } from '@/types/settings';
-import { navigateToLogin } from '@/utils/nav';
 import { isReadestCloudStorageActive } from '@/services/sync/cloudSyncProvider';
 import { formatAuthors, formatDescription, formatSeries } from '@/utils/book';
 import ReadingProgress from './ReadingProgress';
@@ -47,7 +45,6 @@ const BookItem: React.FC<BookItemProps> = ({
   showTimeRemaining,
 }) => {
   const _ = useTranslation();
-  const router = useRouter();
   const { user } = useAuth();
   const { appService } = useEnv();
   const { settings } = useSettingsStore();
@@ -187,16 +184,13 @@ const BookItem: React.FC<BookItemProps> = ({
                 ></div>
               )
             ) : (
+              user &&
               (!book.uploadedAt || (book.uploadedAt && !book.downloadedAt)) && (
                 <button
                   aria-label={!book.uploadedAt ? _('Upload Book') : _('Download Book')}
                   className='show-cloud-button -m-2 p-2'
                   onPointerDown={(e) => e.stopPropagation()}
                   onClick={() => {
-                    if (!user) {
-                      navigateToLogin(router);
-                      return;
-                    }
                     if (!book.uploadedAt) {
                       handleBookUpload(book);
                     } else if (!book.downloadedAt) {


### PR DESCRIPTION
Simplify the library view for signed-out users by hiding the upload and download cloud icons displayed in the bottom-right corner of each book.

These actions are unavailable without signing in, and currently only redirect users to the sign-in page. Since sign-in is already accessible via the swipe-down gesture and the Settings menu, the extra buttons add unnecessary clutter.