### PR TITLE
feat(reader): add collapsible chapter sections to search results

### DIFF
--- a/apps/readest-app/src/__tests__/components/SearchBar.test.tsx
+++ b/apps/readest-app/src/__tests__/components/SearchBar.test.tsx
@@ -1,0 +1,97 @@
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SearchBar from '@/app/reader/components/sidebar/SearchBar';
+
+const mocks = vi.hoisted(() => ({
+  // getProgress returns null until the book emits its first relocate event.
+  progress: null as { section: { current: number } } | null,
+  search: vi.fn(),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: null }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: {} }),
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({
+    getBookData: () => ({ book: { primaryLanguage: 'en' } }),
+    getConfig: () => ({ searchConfig: { scope: 'section', mode: 'text' } }),
+    setConfig: vi.fn(),
+    saveConfig: vi.fn(),
+  }),
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    getView: () => ({ search: mocks.search, clearSearch: vi.fn() }),
+    getProgress: () => mocks.progress,
+    getViewSettings: () => ({}),
+  }),
+}));
+
+vi.mock('@/store/sidebarStore', () => ({
+  useSidebarStore: () => ({
+    setSearchTerm: vi.fn(),
+    setSearchResults: vi.fn(),
+    setSearchProgress: vi.fn(),
+    setSearchError: vi.fn(),
+    setSearchStatus: vi.fn(),
+    getSearchStatus: () => 'searching',
+    getSearchNavState: () => ({ searchTerm: 'alice', searchError: null }),
+  }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+vi.mock('@/hooks/useResponsiveSize', () => ({
+  useResponsiveSize: (size: number) => size,
+}));
+
+describe('SearchBar', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.search.mockReset();
+    mocks.search.mockImplementation(async function* () {
+      yield 'done';
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  const renderBar = async () => {
+    render(<SearchBar isVisible bookKey='book-1' onHideSearchBar={vi.fn()} />);
+    // The search term change is debounced by 500ms before handleSearch runs.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+  };
+
+  // A section-scoped search fired before the first relocate event used to
+  // destructure `section` off a null progress and throw, so the search never
+  // reached the view.
+  it('searches the whole book when progress is not available yet', async () => {
+    mocks.progress = null;
+    await renderBar();
+
+    expect(mocks.search).toHaveBeenCalledTimes(1);
+    expect(mocks.search.mock.calls[0]![0]).toMatchObject({ query: 'alice', index: undefined });
+  });
+
+  it('scopes the search to the current section once progress is available', async () => {
+    mocks.progress = { section: { current: 4 } };
+    await renderBar();
+
+    expect(mocks.search).toHaveBeenCalledTimes(1);
+    expect(mocks.search.mock.calls[0]![0]).toMatchObject({ query: 'alice', index: 4 });
+  });
+});

--- a/apps/readest-app/src/__tests__/components/SearchResults.test.tsx
+++ b/apps/readest-app/src/__tests__/components/SearchResults.test.tsx
@@ -1,0 +1,95 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import SearchResults from '@/app/reader/components/sidebar/SearchResults';
+import { BookSearchResult } from '@/types/book';
+
+const navState = vi.hoisted(() => ({ searchProgress: 1 }));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({ getProgress: () => ({ location: '' }) }),
+}));
+
+vi.mock('@/store/sidebarStore', () => ({
+  useSidebarStore: () => ({
+    getSearchNavState: () => ({
+      searchProgress: navState.searchProgress,
+      searchError: null,
+    }),
+  }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+vi.mock('@/utils/cfi', () => ({
+  findNearestCfi: () => null,
+  isCfiInLocation: () => false,
+}));
+
+const makeResults = (): BookSearchResult[] =>
+  ['Chapter One', 'Chapter Two'].map((label, chapter) => ({
+    label,
+    subitems: [0, 1].map((match) => ({
+      cfi: `epubcfi(/6/${chapter + 2}!/4/${match + 1})`,
+      excerpt: { pre: 'pre ', match: 'hit', post: ' post' },
+    })),
+  }));
+
+const renderResults = (results = makeResults()) =>
+  render(<SearchResults bookKey='book-1' results={results} onSelectResult={vi.fn()} />);
+
+const resultItems = () => screen.getAllByRole('button').filter((el) => el.tagName === 'LI');
+
+describe('SearchResults chapter sections', () => {
+  afterEach(() => {
+    cleanup();
+    navState.searchProgress = 1;
+  });
+
+  it('collapses and expands a chapter section when its header is toggled', () => {
+    renderResults();
+    expect(resultItems()).toHaveLength(4);
+
+    const header = screen.getByRole('button', { name: /Chapter One/ });
+    fireEvent.click(header);
+    expect(resultItems()).toHaveLength(2);
+    expect(header.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(header);
+    expect(resultItems()).toHaveLength(4);
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  // A new search resets searchProgress to 0 but leaves the previous results
+  // mounted until the first hit arrives. Sections are keyed by index+label, so
+  // without an explicit reset the reused key kept the section collapsed for
+  // results the reader had never seen.
+  it('expands every section again when a new search starts', () => {
+    const { rerender } = renderResults();
+    fireEvent.click(screen.getByRole('button', { name: /Chapter One/ }));
+    expect(resultItems()).toHaveLength(2);
+
+    navState.searchProgress = 0;
+    rerender(<SearchResults bookKey='book-1' results={makeResults()} onSelectResult={vi.fn()} />);
+
+    expect(resultItems()).toHaveLength(4);
+    const header = screen.getByRole('button', { name: /Chapter One/ });
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('styles the chapter header for RTL and e-ink', () => {
+    renderResults();
+    const header = screen.getByRole('button', { name: /Chapter One/ });
+
+    // DESIGN.md 2.8: logical properties only, the sidebar flips direction for RTL books.
+    expect(header.innerHTML).not.toMatch(/\bml-2\b/);
+    expect(header.innerHTML).toMatch(/\bms-2\b/);
+    // The sidebar itself is bg-base-100 under e-ink, so a bare bg-base-200 header
+    // would render as a grey band there.
+    const sticky = header.closest('h3')!;
+    expect(sticky.className).toContain('eink:bg-base-100');
+    expect(sticky.className).toContain('not-eink:bg-base-200');
+  });
+});

--- a/apps/readest-app/src/app/reader/components/sidebar/SearchBar.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/SearchBar.tsx
@@ -157,7 +157,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ isVisible, bookKey, onHideSearchB
   const view = getView(bookKey)!;
   const config = getConfig(bookKey)!;
   const bookData = getBookData(bookKey)!;
-  const progress = getProgress(bookKey)!;
+  const progress = getProgress(bookKey);
   const primaryLang = bookData.book?.primaryLanguage || 'en';
   const searchMode = (config.searchConfig as BookSearchConfig).mode;
 
@@ -249,8 +249,10 @@ const SearchBar: React.FC<SearchBarProps> = ({ isVisible, bookKey, onHideSearchB
       setSearchStatus(bookKey, 'searching');
       setSearchError(bookKey, null);
 
-      const { section } = progress;
-      const index = searchConfig.scope === 'section' ? section.current : undefined;
+      // progress is null until the book emits its first relocate event, so a
+      // search fired right after opening has no current section to scope to.
+      // Fall back to searching the whole book rather than throwing.
+      const index = searchConfig.scope === 'section' ? progress?.section.current : undefined;
       const generator = await view.search({
         ...searchConfig,
         index,

--- a/apps/readest-app/src/app/reader/components/sidebar/SearchResults.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/SearchResults.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { BookSearchMatch, BookSearchResult, SearchExcerpt } from '@/types/book';
 import { useReaderStore } from '@/store/readerStore';
 import { useSidebarStore } from '@/store/sidebarStore';
@@ -79,6 +79,115 @@ const SearchResultItem: React.FC<SearchResultItemProps> = ({
     </li>
   );
 };
+interface ChapterSectionProps {
+  bookKey: string;
+  label: string;
+  subitems: BookSearchMatch[];
+  nearestCfi: string | null;
+  onSelectResult: (cfi: string) => void;
+}
+
+const ChapterSection: React.FC<ChapterSectionProps> = ({
+  bookKey,
+  label,
+  subitems,
+  nearestCfi,
+  onSelectResult,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const matchCount = subitems.length;
+  const headerRef = useRef<HTMLHeadingElement>(null);
+  const wasStuckRef = useRef<boolean>(false);
+
+  const handleToggle = useCallback(() => {
+    if (isExpanded && headerRef.current) {
+      const header = headerRef.current;
+      const container = header.closest('.overflow-y-auto') as HTMLElement | null;
+      if (container) {
+        // Detect if the header is currently stuck at the top of the scroll container.
+        // Compare visual positions (getBoundingClientRect) rather than offsetTop,
+        // because sticky stacking can offset the header from the container's top.
+        const headerRect = header.getBoundingClientRect();
+        const containerRect = container.getBoundingClientRect();
+        wasStuckRef.current = headerRect.top <= containerRect.top + 1;
+      }
+    }
+    setIsExpanded((prev) => !prev);
+  }, [isExpanded]);
+
+  // useLayoutEffect runs synchronously after DOM mutations but before paint,
+  // avoiding a visible flash when we adjust scroll position.
+  useLayoutEffect(() => {
+    if (isExpanded) return;
+    if (!wasStuckRef.current) return;
+    const header = headerRef.current;
+    if (!header) return;
+    const container = header.closest('.overflow-y-auto') as HTMLElement | null;
+    if (!container) return;
+    // Recalculate the header's position after the collapse (DOM has already
+    // updated) and scroll so the collapsed header sits at the top of the viewport.
+    const headerRect = header.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    const headerOffset = headerRect.top - containerRect.top + container.scrollTop;
+    container.scrollTop = headerOffset;
+  }, [isExpanded]);
+
+  return (
+    <ul>
+      <h3
+        ref={headerRef}
+        className='sticky top-0 z-10 bg-base-200 line-clamp-1 cursor-pointer select-none font-normal hover:bg-base-300 rounded px-1 py-1 flex items-center justify-between'
+        onClick={handleToggle}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleToggle();
+          }
+        }}
+        tabIndex={0}
+        role='button'
+        aria-expanded={isExpanded}
+      >
+        <span className='flex items-center gap-1.5 min-w-0'>
+          <svg
+            viewBox='0 0 8 10'
+            width='8'
+            height='10'
+            className={clsx(
+              'shrink-0 text-base-content transition-transform duration-200',
+              isExpanded ? 'rotate-90' : 'rotate-0',
+            )}
+            style={{ transformOrigin: 'center' }}
+            fill='currentColor'
+            aria-hidden='true'
+            focusable='false'
+          >
+            <polygon points='0 0, 8 5, 0 10' />
+          </svg>
+          <span className='truncate'>{label}</span>
+        </span>
+        <span className='text-xs text-base-content/60 whitespace-nowrap ml-2 shrink-0'>
+          {matchCount}
+        </span>
+      </h3>
+      {isExpanded && (
+        <ul>
+          {subitems.map((item, index) => (
+            <SearchResultItem
+              key={`${index}-${item.cfi}`}
+              bookKey={bookKey}
+              cfi={item.cfi}
+              excerpt={item.excerpt}
+              isNearest={item.cfi === nearestCfi}
+              onSelectResult={onSelectResult}
+            />
+          ))}
+        </ul>
+      )}
+    </ul>
+  );
+};
+
 interface SearchResultsProps {
   bookKey: string;
   results: BookSearchResult[] | BookSearchMatch[];
@@ -122,26 +231,19 @@ const SearchResults: React.FC<SearchResultsProps> = ({ bookKey, results, onSelec
   }
 
   return (
-    <div className='search-results overflow-y-auto p-2 font-sans text-sm font-light'>
+    <div className='search-results overflow-y-auto font-sans text-sm font-light'>
       <ul className='px-2'>
         {results.map((result, index) => {
           if ('subitems' in result) {
             return (
-              <ul key={`${index}-${result.label}`}>
-                <h3 className='line-clamp-1 font-normal'>{result.label}</h3>
-                <ul>
-                  {result.subitems.map((item, index) => (
-                    <SearchResultItem
-                      key={`${index}-${item.cfi}`}
-                      bookKey={bookKey}
-                      cfi={item.cfi}
-                      excerpt={item.excerpt}
-                      isNearest={item.cfi === nearestCfi}
-                      onSelectResult={onSelectResult}
-                    />
-                  ))}
-                </ul>
-              </ul>
+              <ChapterSection
+                key={`${index}-${result.label}`}
+                bookKey={bookKey}
+                label={result.label}
+                subitems={result.subitems}
+                nearestCfi={nearestCfi}
+                onSelectResult={onSelectResult}
+              />
             );
           } else {
             return (

--- a/apps/readest-app/src/app/reader/components/sidebar/SearchResults.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/SearchResults.tsx
@@ -231,7 +231,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({ bookKey, results, onSelec
   }
 
   return (
-    <div className='search-results overflow-y-auto font-sans text-sm font-light'>
+    <div className='search-results overflow-y-auto px-2 font-sans text-sm font-light'>
       <ul className='px-2'>
         {results.map((result, index) => {
           if ('subitems' in result) {

--- a/apps/readest-app/src/app/reader/components/sidebar/SearchResults.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/SearchResults.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { BookSearchMatch, BookSearchResult, SearchExcerpt } from '@/types/book';
 import { useReaderStore } from '@/store/readerStore';
 import { useSidebarStore } from '@/store/sidebarStore';
@@ -79,11 +79,14 @@ const SearchResultItem: React.FC<SearchResultItemProps> = ({
     </li>
   );
 };
+
 interface ChapterSectionProps {
   bookKey: string;
   label: string;
   subitems: BookSearchMatch[];
   nearestCfi: string | null;
+  isExpanded: boolean;
+  onToggle: () => void;
   onSelectResult: (cfi: string) => void;
 }
 
@@ -92,9 +95,10 @@ const ChapterSection: React.FC<ChapterSectionProps> = ({
   label,
   subitems,
   nearestCfi,
+  isExpanded,
+  onToggle,
   onSelectResult,
 }) => {
-  const [isExpanded, setIsExpanded] = useState(true);
   const matchCount = subitems.length;
   const headerRef = useRef<HTMLHeadingElement>(null);
   const wasStuckRef = useRef<boolean>(false);
@@ -102,7 +106,7 @@ const ChapterSection: React.FC<ChapterSectionProps> = ({
   const handleToggle = useCallback(() => {
     if (isExpanded && headerRef.current) {
       const header = headerRef.current;
-      const container = header.closest('.overflow-y-auto') as HTMLElement | null;
+      const container = header.closest('.search-results') as HTMLElement | null;
       if (container) {
         // Detect if the header is currently stuck at the top of the scroll container.
         // Compare visual positions (getBoundingClientRect) rather than offsetTop,
@@ -112,8 +116,8 @@ const ChapterSection: React.FC<ChapterSectionProps> = ({
         wasStuckRef.current = headerRect.top <= containerRect.top + 1;
       }
     }
-    setIsExpanded((prev) => !prev);
-  }, [isExpanded]);
+    onToggle();
+  }, [isExpanded, onToggle]);
 
   // useLayoutEffect runs synchronously after DOM mutations but before paint,
   // avoiding a visible flash when we adjust scroll position.
@@ -122,7 +126,7 @@ const ChapterSection: React.FC<ChapterSectionProps> = ({
     if (!wasStuckRef.current) return;
     const header = headerRef.current;
     if (!header) return;
-    const container = header.closest('.overflow-y-auto') as HTMLElement | null;
+    const container = header.closest('.search-results') as HTMLElement | null;
     if (!container) return;
     // Recalculate the header's position after the collapse (DOM has already
     // updated) and scroll so the collapsed header sits at the top of the viewport.
@@ -134,41 +138,40 @@ const ChapterSection: React.FC<ChapterSectionProps> = ({
 
   return (
     <ul>
+      {/* The sticky band carries the surface color so results scrolling underneath
+          stay occluded; the button inside owns the hover and focus affordances. */}
       <h3
         ref={headerRef}
-        className='sticky top-0 z-10 bg-base-200 line-clamp-1 cursor-pointer select-none font-normal hover:bg-base-300 rounded px-1 py-1 flex items-center justify-between'
-        onClick={handleToggle}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            handleToggle();
-          }
-        }}
-        tabIndex={0}
-        role='button'
-        aria-expanded={isExpanded}
+        className='not-eink:bg-base-200 eink:bg-base-100 sticky top-0 z-10 font-normal'
       >
-        <span className='flex items-center gap-1.5 min-w-0'>
-          <svg
-            viewBox='0 0 8 10'
-            width='8'
-            height='10'
-            className={clsx(
-              'shrink-0 text-base-content transition-transform duration-200',
-              isExpanded ? 'rotate-90' : 'rotate-0',
-            )}
-            style={{ transformOrigin: 'center' }}
-            fill='currentColor'
-            aria-hidden='true'
-            focusable='false'
-          >
-            <polygon points='0 0, 8 5, 0 10' />
-          </svg>
-          <span className='truncate'>{label}</span>
-        </span>
-        <span className='text-xs text-base-content/60 whitespace-nowrap ml-2 shrink-0'>
-          {matchCount}
-        </span>
+        <button
+          type='button'
+          className='not-eink:hover:bg-base-300 focus-visible:ring-base-content/15 flex w-full select-none items-center justify-between rounded px-1 py-1 text-start focus-visible:outline-none focus-visible:ring-2'
+          onClick={handleToggle}
+          aria-expanded={isExpanded}
+        >
+          <span className='flex min-w-0 items-center gap-1.5'>
+            <svg
+              viewBox='0 0 8 10'
+              width='8'
+              height='10'
+              className={clsx(
+                'text-base-content not-eink:transition-transform shrink-0',
+                isExpanded ? 'rotate-90' : 'rotate-0',
+              )}
+              style={{ transformOrigin: 'center' }}
+              fill='currentColor'
+              aria-hidden='true'
+              focusable='false'
+            >
+              <polygon points='0 0, 8 5, 0 10' />
+            </svg>
+            <span className='truncate'>{label}</span>
+          </span>
+          <span className='text-base-content/60 ms-2 shrink-0 whitespace-nowrap text-xs'>
+            {matchCount}
+          </span>
+        </button>
       </h3>
       {isExpanded && (
         <ul>
@@ -200,6 +203,23 @@ const SearchResults: React.FC<SearchResultsProps> = ({ bookKey, results, onSelec
   const { getSearchNavState } = useSidebarStore();
   const progress = getProgress(bookKey);
   const { searchProgress, searchError } = getSearchNavState(bookKey);
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(() => new Set());
+
+  // Starting a search resets progress to 0 while the previous results stay
+  // mounted until the first new hit arrives. Sections are keyed by index+label,
+  // so a reused key would otherwise come back collapsed for results the reader
+  // has never seen.
+  useEffect(() => {
+    if (searchProgress === 0) setCollapsedSections(new Set());
+  }, [searchProgress]);
+
+  const toggleSection = useCallback((sectionKey: string) => {
+    setCollapsedSections((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(sectionKey)) next.add(sectionKey);
+      return next;
+    });
+  }, []);
 
   const nearestCfi = useMemo(() => {
     const allCfis: string[] = [];
@@ -235,13 +255,16 @@ const SearchResults: React.FC<SearchResultsProps> = ({ bookKey, results, onSelec
       <ul className='px-2'>
         {results.map((result, index) => {
           if ('subitems' in result) {
+            const sectionKey = `${index}-${result.label}`;
             return (
               <ChapterSection
-                key={`${index}-${result.label}`}
+                key={sectionKey}
                 bookKey={bookKey}
                 label={result.label}
                 subitems={result.subitems}
                 nearestCfi={nearestCfi}
+                isExpanded={!collapsedSections.has(sectionKey)}
+                onToggle={() => toggleSection(sectionKey)}
                 onSelectResult={onSelectResult}
               />
             );


### PR DESCRIPTION
## Summary

Add collapsible chapter sections to the search results sidebar, making it easier to navigate through long search result lists. Each chapter group now has a sticky header with a toggle, so readers can collapse irrelevant chapters and focus on the ones they care about.

## Changes

### Collapsible chapter sections

Extracted a `ChapterSection` component from the previously flat inline JSX. Each section header:

- Shows the **chapter label** and **match count** badge
- Uses a **sticky header** (`position: sticky; top: 0`) so it remains visible while scrolling through results
- Uses the same **SVG triangle expander icon** as the table of contents (TOC) chapter list for visual consistency

<img width="295" height="619" alt="demo" src="https://github.com/user-attachments/assets/0eb1289d-8078-4923-99ad-063231a5f207" />


