### PR TITLE
Load OPDS catalogs when opening the Integrations panel

### DIFF
--- a/apps/readest-app/src/components/settings/IntegrationsPanel.tsx
+++ b/apps/readest-app/src/components/settings/IntegrationsPanel.tsx
@@ -87,6 +87,7 @@ const IntegrationsPanel: React.FC = () => {
   const { envConfig, appService } = useEnv();
   const { user } = useAuth();
   const { settings, requestedSubPage, setRequestedSubPage } = useSettingsStore();
+  useCustomOPDSStore.getState().loadCustomOPDSCatalogs(envConfig);
   const opdsCatalogs = useCustomOPDSStore((s) => s.catalogs);
   const opdsCount = opdsCatalogs.filter((c) => !c.deletedAt).length;
   // Surface a library-wide WebDAV sync that's mid-flight in the row's

--- a/apps/readest-app/src/components/settings/IntegrationsPanel.tsx
+++ b/apps/readest-app/src/components/settings/IntegrationsPanel.tsx
@@ -87,7 +87,6 @@ const IntegrationsPanel: React.FC = () => {
   const { envConfig, appService } = useEnv();
   const { user } = useAuth();
   const { settings, requestedSubPage, setRequestedSubPage } = useSettingsStore();
-  useCustomOPDSStore.getState().loadCustomOPDSCatalogs(envConfig);
   const opdsCatalogs = useCustomOPDSStore((s) => s.catalogs);
   const opdsCount = opdsCatalogs.filter((c) => !c.deletedAt).length;
   // Surface a library-wide WebDAV sync that's mid-flight in the row's
@@ -116,6 +115,15 @@ const IntegrationsPanel: React.FC = () => {
     !user || (userProfilePlan !== undefined && !isCloudSyncPremium) ? _('Premium') : undefined;
 
   const [subPage, setSubPage] = useState<SubPage>(null);
+
+  // Hydrate the OPDS store from settings so the row's catalog count is
+  // accurate on first open. Without this the store starts empty and the
+  // count reads zero until the user drills into the OPDS sub-page (where
+  // CatalogManager loads it). Loading happens once per mount; the store
+  // handles backfilling contentId for legacy entries.
+  useEffect(() => {
+    void useCustomOPDSStore.getState().loadCustomOPDSCatalogs(envConfig);
+  }, [envConfig]);
 
   // Android Back / Esc: when any integrations sub-page (KOSync, WebDAV,
   // Readwise, Hardcover, OPDS, Send-to-Readest) is open, intercept and


### PR DESCRIPTION
Opening the Integrations panel for the first time always reports 0 OPDS catalogs, even when catalogs are already configured, because the catalog list has not yet been loaded.

This change makes sure we load the catalog list before computing the count so the displayed value reflects the actual number of registered OPDS catalogs, and not zero.