### PR TITLE
perf(reader): improve Slide/Curl gesture responsiveness

### DIFF
--- a/apps/readest-app/src/__tests__/components/Overlay.test.tsx
+++ b/apps/readest-app/src/__tests__/components/Overlay.test.tsx
@@ -1,0 +1,17 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Overlay } from '@/components/Overlay';
+
+describe('Overlay capture state', () => {
+  afterEach(cleanup);
+
+  it('blocks capture by default and supports a closed-parent opt-out', () => {
+    const { container, rerender } = render(<Overlay onDismiss={vi.fn()} />);
+    const overlay = container.firstElementChild!;
+
+    expect(overlay.getAttribute('data-capture-blocking-overlay')).toBe('true');
+
+    rerender(<Overlay onDismiss={vi.fn()} captureBlocking={false} />);
+    expect(overlay.hasAttribute('data-capture-blocking-overlay')).toBe(false);
+  });
+});

--- a/apps/readest-app/src/__tests__/components/Popup.test.tsx
+++ b/apps/readest-app/src/__tests__/components/Popup.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/hooks/useResponsiveSize', () => ({
+  useResponsiveSize: (value: number) => value,
+}));
+vi.mock('@/hooks/useKeyDownActions', () => ({
+  useKeyDownActions: vi.fn(),
+}));
+
+import Popup from '@/components/Popup';
+
+describe('Popup capture state', () => {
+  beforeAll(() => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+  });
+
+  afterEach(cleanup);
+  afterAll(() => vi.unstubAllGlobals());
+
+  it('marks only an open popup as capture-blocking', () => {
+    const { container, rerender } = render(
+      <Popup isOpen={false} width={240}>
+        Footnote
+      </Popup>,
+    );
+    const popup = container.querySelector<HTMLElement>('.popup-container')!;
+
+    expect(popup.getAttribute('aria-hidden')).toBe('true');
+    expect(popup.hasAttribute('data-capture-blocking-overlay')).toBe(false);
+
+    rerender(
+      <Popup isOpen width={240}>
+        Footnote
+      </Popup>,
+    );
+
+    expect(popup.getAttribute('aria-hidden')).toBe('false');
+    expect(popup.getAttribute('data-capture-blocking-overlay')).toBe('true');
+  });
+});

--- a/apps/readest-app/src/__tests__/components/rsvp-overlay-context.test.tsx
+++ b/apps/readest-app/src/__tests__/components/rsvp-overlay-context.test.tsx
@@ -119,6 +119,20 @@ const renderOverlay = (state: RsvpState, fontFamily?: string) => {
   return { ...result, controller };
 };
 
+describe('RSVPOverlay — capture lifecycle', () => {
+  afterEach(() => cleanup());
+
+  test('marks its mounted full-screen surface as capture-blocking', () => {
+    const state = buildState({
+      words: [{ text: 'hello', orpIndex: 1, pauseMultiplier: 1 }],
+    });
+
+    const { getByTestId } = renderOverlay(state);
+
+    expect(getByTestId('rsvp-overlay').getAttribute('data-capture-blocking-overlay')).toBe('true');
+  });
+});
+
 describe('RSVPOverlay — context panel performance', () => {
   afterEach(() => cleanup());
 

--- a/apps/readest-app/src/__tests__/document/paginator-turn-styles.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/paginator-turn-styles.browser.test.ts
@@ -243,15 +243,16 @@ describe('Page turn styles (browser)', () => {
   const makeTouch = (x: number, y: number) =>
     new Touch({ identifier: 1, target: paginator, screenX: x, screenY: y, clientX: x, clientY: y });
 
-  const fireTouch = (type: string, x: number, y: number) =>
-    paginator.dispatchEvent(
-      new TouchEvent(type, {
-        bubbles: true,
-        cancelable: true,
-        touches: type === 'touchend' || type === 'touchcancel' ? [] : [makeTouch(x, y)],
-        changedTouches: [makeTouch(x, y)],
-      }),
-    );
+  const fireTouch = (type: string, x: number, y: number, timeStamp?: number) => {
+    const event = new TouchEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      touches: type === 'touchend' || type === 'touchcancel' ? [] : [makeTouch(x, y)],
+      changedTouches: [makeTouch(x, y)],
+    });
+    if (timeStamp !== undefined) Object.defineProperty(event, 'timeStamp', { value: timeStamp });
+    return paginator.dispatchEvent(event);
+  };
 
   /** The scrubbed turn's paused animations, keyed for inspection. */
   const scrubbedAnimations = () =>
@@ -310,7 +311,216 @@ describe('Page turn styles (browser)', () => {
     expect(phases).toEqual(['before-capture', 'covered', 'ready', 'finished']);
   });
 
-  it('uses the named transition root width while preserving total drag distance', async () => {
+  it('claims an edge-originated turn on the first clear inward move', async () => {
+    await setup(ltrBook, 'slide');
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    // The rightmost 18% is a page-turn fast path. Two pixels toward the page
+    // interior are enough to claim without waiting for the fallback slop.
+    fireTouch('touchstart', 790, 300);
+    fireTouch('touchmove', 788, 300);
+    expect(phases[0]).toBe('before-capture');
+    await vi.waitFor(() => expect(phases).toContain('ready'));
+
+    fireTouch('touchcancel', 788, 300);
+    await vi.waitFor(() => expect(phases.at(-1)).toBe('finished'), { timeout: 2000 });
+    expect(phases).toEqual(['before-capture', 'covered', 'ready', 'cancelled', 'finished']);
+  });
+
+  it('claims an early edge gesture at a book boundary without starting a snapshot', async () => {
+    await setup(ltrBook, 'slide', 0);
+    const claims: CustomEvent[] = [];
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-gesture-claimed', ((event: CustomEvent) => {
+      claims.push(event);
+    }) as EventListener);
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    // At the first page, an inward drag from the left edge expresses a
+    // previous-page gesture. There is no page to snapshot, but the host still
+    // needs the ownership signal so the drag cannot become a synthesized tap.
+    fireTouch('touchstart', 100, 300);
+    fireTouch('touchmove', 102, 300);
+    fireTouch('touchend', 102, 300);
+    await wait(50);
+
+    expect(claims).toHaveLength(1);
+    expect(claims[0]!.detail).toMatchObject({ style: 'slide', forward: false });
+    expect(phases).toHaveLength(0);
+  });
+
+  it('reserves the outermost left strip for the vertical brightness gesture', async () => {
+    await setup(ltrBook, 'slide');
+    paginator.setAttribute('turn-gesture-left-inset', '0.1');
+    const claims: CustomEvent[] = [];
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-gesture-claimed', ((event: CustomEvent) => {
+      claims.push(event);
+    }) as EventListener);
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    fireTouch('touchstart', 40, 300);
+    fireTouch('touchmove', 42, 300);
+    fireTouch('touchmove', 46, 300);
+    fireTouch('touchmove', 46, 290);
+    fireTouch('touchmove', 20, 290);
+    fireTouch('touchend', 20, 290);
+    await wait(50);
+
+    expect(claims).toHaveLength(0);
+    expect(phases).toHaveLength(0);
+  });
+
+  it('claims a central turn after two consistent horizontal samples below 15px', async () => {
+    await setup(ltrBook, 'slide');
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    fireTouch('touchstart', 400, 300);
+    fireTouch('touchmove', 397, 300);
+    expect(phases).toHaveLength(0);
+    fireTouch('touchmove', 394, 300);
+    expect(phases[0]).toBe('before-capture');
+    await vi.waitFor(() => expect(phases).toContain('ready'));
+
+    fireTouch('touchcancel', 394, 300);
+    await vi.waitFor(() => expect(phases.at(-1)).toBe('finished'), { timeout: 2000 });
+    expect(phases).toEqual(['before-capture', 'covered', 'ready', 'cancelled', 'finished']);
+  });
+
+  it('does not combine stale central samples into an early claim', async () => {
+    await setup(ltrBook, 'slide');
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    fireTouch('touchstart', 400, 300, 1000);
+    fireTouch('touchmove', 397, 300, 1010);
+    fireTouch('touchmove', 394, 300, 1100);
+    expect(phases).toHaveLength(0);
+    fireTouch('touchmove', 391, 300, 1120);
+    expect(phases[0]).toBe('before-capture');
+
+    fireTouch('touchcancel', 391, 300, 1130);
+    await vi.waitFor(() => expect(phases.at(-1)).toBe('finished'), { timeout: 2000 });
+  });
+
+  it('permanently yields a pending gesture when scroll lock takes ownership', async () => {
+    await setup(ltrBook, 'slide');
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    paginator.scrollLocked = true;
+    fireTouch('touchstart', 400, 300);
+    fireTouch('touchmove', 397, 300);
+    paginator.scrollLocked = false;
+    fireTouch('touchmove', 360, 300);
+    fireTouch('touchend', 360, 300);
+    await wait(50);
+
+    expect(phases).toHaveLength(0);
+  });
+
+  it('cleans up lifecycle state when layered capture throws synchronously', async () => {
+    await setup(ltrBook, 'slide');
+    const before = paginator.containerPosition;
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+    const original = document.startViewTransition;
+    document.startViewTransition = (() => {
+      throw new Error('synchronous capture failure');
+    }) as typeof document.startViewTransition;
+
+    try {
+      fireTouch('touchstart', 400, 300);
+      fireTouch('touchmove', 397, 300);
+      fireTouch('touchmove', 394, 300);
+      fireTouch('touchend', 394, 300);
+      await wait(50);
+
+      expect(phases).toEqual(['before-capture', 'finished']);
+      expect(paginator.containerPosition).toBe(before);
+      expect(document.documentElement.className).not.toContain('foliate-vt');
+      expect(paginator.style.viewTransitionName).toBe('');
+    } finally {
+      document.startViewTransition = original;
+    }
+  });
+
+  it('cancels an active layered drag before accepting a replacement touch', async () => {
+    await setup(ltrBook, 'slide');
+    const page = paginator.page;
+    const before = paginator.containerPosition;
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    fireTouch('touchstart', 400, 300);
+    fireTouch('touchmove', 397, 300);
+    fireTouch('touchmove', 394, 300);
+    await vi.waitFor(() => expect(phases).toContain('ready'));
+    fireTouch('touchstart', 500, 300);
+    fireTouch('touchmove', 300, 300);
+    fireTouch('touchend', 300, 300);
+
+    await vi.waitFor(() => expect(phases.at(-1)).toBe('finished'), { timeout: 2000 });
+    expect(phases).toEqual(['before-capture', 'covered', 'ready', 'cancelled', 'finished']);
+    expect(paginator.page).toBe(page);
+    expect(paginator.containerPosition).toBe(before);
+  });
+
+  it('permanently rejects a vertical gesture after a one-frame 16px landing wobble', async () => {
+    await setup(ltrBook, 'slide');
+    const page = paginator.page;
+    const position = paginator.containerPosition;
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+    const original = document.startViewTransition.bind(document);
+    let transitionCalls = 0;
+    document.startViewTransition = ((callback: () => Promise<void> | void) => {
+      transitionCalls++;
+      return original(callback);
+    }) as typeof document.startViewTransition;
+
+    try {
+      fireTouch('touchstart', 400, 500);
+      // A single horizontal-looking sample is insufficient in the center.
+      fireTouch('touchmove', 416, 496);
+      expect(phases).toHaveLength(0);
+      // Cumulative vertical travel then wins and locks this gesture. Even a
+      // later horizontal hook cannot re-enter the page-turn arena.
+      fireTouch('touchmove', 416, 480);
+      fireTouch('touchmove', 300, 480);
+      fireTouch('touchend', 300, 480);
+      await wait(50);
+
+      expect(transitionCalls).toBe(0);
+      expect(phases).toHaveLength(0);
+      expect(paginator.page).toBe(page);
+      expect(paginator.containerPosition).toBe(position);
+    } finally {
+      document.startViewTransition = original;
+    }
+  });
+
+  it('starts Slide flat at claim and uses the named transition root width afterward', async () => {
     await setup(ltrBook, 'slide', 3, 1000);
     const phases: string[] = [];
     paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
@@ -321,8 +531,8 @@ describe('Page turn styles (browser)', () => {
     expect(transitionRoot?.getBoundingClientRect().width).toBe(1000);
 
     // This first move exceeds 24px but remains too diagonal to claim. The
-    // second becomes horizontal enough only after 80px of travel. Recognition
-    // catches the snapshot up to that cumulative displacement.
+    // second becomes horizontal enough only after 80px of travel. The
+    // recognition distance owns the gesture but is not shown as a jump.
     fireTouch('touchstart', 700, 300);
     fireTouch('touchmove', 640, 345);
     expect(scrubbedAnimations()).toHaveLength(0);
@@ -337,17 +547,185 @@ describe('Page turn styles (browser)', () => {
     }
     const animations = scrubbedAnimations();
     expect(animations.length).toBeGreaterThan(0);
-    expect(scrubProgress(animations[0]!)).toBeCloseTo(80 / 1000, 2);
+    expect(scrubProgress(animations[0]!)).toBeCloseTo(0, 5);
 
-    // Further movement remains one-to-one against the actual 1000px snapshot.
+    // Further movement is one-to-one against the actual 1000px snapshot,
+    // measured from the claim point rather than the original touch point.
     fireTouch('touchmove', 540, 330);
-    await vi.waitFor(() => expect(scrubProgress(animations[0]!)).toBeCloseTo(160 / 1000, 2));
+    await vi.waitFor(() => expect(scrubProgress(animations[0]!)).toBeCloseTo(80 / 1000, 2));
 
     // Return to the origin and cancel so no transition leaks into cleanup.
     fireTouch('touchmove', 700, 300);
     fireTouch('touchend', 700, 300);
     await vi.waitFor(() => expect(phases.at(-1)).toBe('finished'), { timeout: 2000 });
     expect(scrubbedAnimations()).toHaveLength(0);
+  });
+
+  it.each([
+    { style: 'slide', speed: 0.9, expectedRate: 1.875 },
+    { style: 'slide', speed: 1.5, expectedRate: 2 },
+    { style: 'curl', speed: 1.5, expectedRate: 1.5 },
+  ])('settles a $style release at $expectedRate× for a $speed px/ms flick', async ({
+    style,
+    speed,
+    expectedRate,
+  }) => {
+    await setup(ltrBook, style);
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    const startX = 700;
+    const startTime = 100;
+    const sampleDuration = 240;
+    const releaseX = startX - speed * sampleDuration;
+    fireTouch('touchstart', startX, 300, startTime);
+    fireTouch('touchmove', releaseX, 300, startTime + sampleDuration);
+    await vi.waitFor(() => expect(phases).toContain('ready'));
+    const animations = scrubbedAnimations();
+    expect(animations.length).toBeGreaterThan(0);
+
+    fireTouch('touchend', releaseX, 300, startTime + sampleDuration);
+    await vi.waitFor(() => {
+      for (const animation of animations) {
+        expect(Math.abs(animation.playbackRate)).toBeCloseTo(expectedRate, 5);
+      }
+    });
+    await vi.waitFor(() => expect(phases.at(-1)).toBe('finished'), { timeout: 2000 });
+    expect(phases).not.toContain('cancelled');
+  });
+
+  it('combines sub-flick speed with distance to commit a Slide', async () => {
+    await setup(ltrBook, 'slide');
+    const page = paginator.page;
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    fireTouch('touchstart', 700, 300, 100);
+    fireTouch('touchmove', 358, 300, 410);
+    await vi.waitFor(() => expect(phases).toContain('ready'));
+    fireTouch('touchmove', 358, 300, 510);
+    fireTouch('touchend', 340, 300, 600);
+    await vi.waitFor(() => expect(phases.at(-1)).toBe('finished'), { timeout: 2000 });
+
+    // 45% distance + (0.2px/ms * 240ms / 800px) = 51%.
+    expect(paginator.page).toBe(page + 1);
+    expect(phases).not.toContain('cancelled');
+  });
+
+  it('lets a sub-flick reverse release cancel a Slide beyond halfway', async () => {
+    await setup(ltrBook, 'slide');
+    const page = paginator.page;
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    fireTouch('touchstart', 700, 300, 100);
+    fireTouch('touchmove', 242, 300, 410);
+    await vi.waitFor(() => expect(phases).toContain('ready'));
+    fireTouch('touchmove', 242, 300, 510);
+    fireTouch('touchend', 260, 300, 600);
+    await vi.waitFor(() => expect(phases.at(-1)).toBe('finished'), { timeout: 2000 });
+
+    // 55% distance + (-0.2px/ms * 240ms / 800px) = 49%.
+    expect(paginator.page).toBe(page);
+    expect(phases).toContain('cancelled');
+  });
+
+  it('does not boost a release after the finger has rested', async () => {
+    await setup(ltrBook, 'slide');
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    fireTouch('touchstart', 700, 300, 100);
+    fireTouch('touchmove', 640, 300, 140);
+    await vi.waitFor(() => expect(phases).toContain('ready'));
+    const animations = scrubbedAnimations();
+    expect(animations.length).toBeGreaterThan(0);
+
+    // More than 80ms without a sample clears the otherwise-fast last velocity.
+    fireTouch('touchend', 640, 300, 241);
+    await vi.waitFor(() => expect(phases.at(-1)).toBe('finished'), { timeout: 2000 });
+    for (const animation of animations) {
+      expect(Math.abs(animation.playbackRate)).toBe(1);
+    }
+  });
+
+  it('boosts a fast reverse release toward the cancellation target', async () => {
+    await setup(ltrBook, 'slide');
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    fireTouch('touchstart', 700, 300, 100);
+    fireTouch('touchmove', 580, 300, 140);
+    await vi.waitFor(() => expect(phases).toContain('ready'));
+    const animations = scrubbedAnimations();
+
+    fireTouch('touchmove', 580, 300, 200);
+    fireTouch('touchmove', 620, 300, 220);
+    // The final 40px of the reversal arrives only in changedTouches.
+    fireTouch('touchend', 660, 300, 240);
+
+    const releaseVelocity = 80 / 90;
+    const expectedRate = 1 + ((releaseVelocity - 0.2) / (1 - 0.2)) * (2 - 1);
+    await vi.waitFor(() => {
+      for (const animation of animations) {
+        expect(animation.playbackRate).toBeLessThan(-1);
+        expect(Math.abs(animation.playbackRate)).toBeCloseTo(expectedRate, 5);
+      }
+    });
+    await vi.waitFor(() => expect(phases.at(-1)).toBe('finished'), { timeout: 2000 });
+    expect(phases).toContain('cancelled');
+  });
+
+  it('does not boost velocity moving away from the selected settle target', async () => {
+    await setup(ltrBook, 'slide');
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    fireTouch('touchstart', 700, 500, 100);
+    fireTouch('touchmove', 620, 496, 140);
+    await vi.waitFor(() => expect(phases).toContain('ready'));
+    const animations = scrubbedAnimations();
+
+    // The whole gesture becomes vertical, so it must cancel. Its final fast
+    // horizontal sample still points toward commit, away from that target.
+    fireTouch('touchmove', 580, 300, 180);
+    fireTouch('touchend', 580, 300, 181);
+    await vi.waitFor(() => expect(phases.at(-1)).toBe('finished'), { timeout: 2000 });
+    expect(phases).toContain('cancelled');
+    expect(animations.every((animation) => Math.abs(animation.playbackRate) === 1)).toBe(true);
+  });
+
+  it('cancels when the final changedTouches sample makes the whole gesture vertical', async () => {
+    await setup(ltrBook, 'slide');
+    const page = paginator.page;
+    const phases: string[] = [];
+    paginator.addEventListener('layered-turn-state', ((event: CustomEvent) => {
+      phases.push(event.detail.phase);
+    }) as EventListener);
+
+    fireTouch('touchstart', 700, 300, 100);
+    fireTouch('touchmove', 660, 300, 140);
+    await vi.waitFor(() => expect(phases).toContain('ready'));
+
+    // The final point has enough horizontal speed and projected progress to
+    // commit on its own, but the complete gesture is predominantly vertical.
+    fireTouch('touchend', 500, 600, 180);
+    await vi.waitFor(() => expect(phases.at(-1)).toBe('finished'), { timeout: 2000 });
+
+    expect(paginator.page).toBe(page);
+    expect(phases).toContain('cancelled');
   });
 
   it('tracks the finger: a mostly-returned drag reverses without turning', async () => {
@@ -397,6 +775,7 @@ describe('Page turn styles (browser)', () => {
       expect(scrubbedAnimations().length).toBeGreaterThan(0);
       expect(phases).toContain('ready');
     });
+    const animations = scrubbedAnimations();
     fireTouch('touchcancel', 620, 300);
     await vi.waitFor(
       () => {
@@ -407,6 +786,7 @@ describe('Page turn styles (browser)', () => {
 
     expect(paginator.page).toBe(page);
     expect(paginator.containerPosition).toBe(before);
+    expect(animations.every((animation) => Math.abs(animation.playbackRate) === 1)).toBe(true);
     expect(scrubbedAnimations()).toHaveLength(0);
     expect(phases).toEqual(['before-capture', 'covered', 'ready', 'cancelled', 'finished']);
     expect(document.documentElement.className).not.toContain('foliate-vt');
@@ -496,6 +876,38 @@ describe('Page turn styles (browser)', () => {
     expect(paginator.containerPosition).toBe(before);
     expect(phases).toEqual(['before-capture', 'covered', 'ready', 'cancelled', 'finished']);
     expect(document.documentElement.className).not.toContain('foliate-vt');
+  });
+
+  it('a programmatic turn permanently rejects an already-pending touch', async () => {
+    await setup(ltrBook, 'slide');
+    const page = paginator.page;
+    const claims: CustomEvent[] = [];
+    paginator.addEventListener('layered-turn-gesture-claimed', ((event: CustomEvent) => {
+      claims.push(event);
+    }) as EventListener);
+    const original = document.startViewTransition.bind(document);
+    let transitionCalls = 0;
+    document.startViewTransition = ((callback: () => Promise<void> | void) => {
+      transitionCalls++;
+      return original(callback);
+    }) as typeof document.startViewTransition;
+
+    try {
+      fireTouch('touchstart', 400, 300);
+      await paginator.next();
+      // Without the rejection, these two central samples would reuse the
+      // pre-turn origin and start a second layered transition.
+      fireTouch('touchmove', 397, 300);
+      fireTouch('touchmove', 394, 300);
+      fireTouch('touchend', 394, 300);
+      await wait(50);
+
+      expect(transitionCalls).toBe(1);
+      expect(claims).toHaveLength(0);
+      expect(paginator.page).toBe(page + 1);
+    } finally {
+      document.startViewTransition = original;
+    }
   });
 
   // Xiaomi report (Android 16, WebView 148): with the layered slide style, a

--- a/apps/readest-app/src/__tests__/hooks/useBrightnessGesture.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useBrightnessGesture.test.tsx
@@ -9,6 +9,10 @@ const h = vi.hoisted(() => ({
   setScreenBrightness: vi.fn(),
   getScreenBrightness: vi.fn(),
   saveSysSettings: vi.fn(),
+  renderer: {
+    setAttribute: vi.fn(),
+    removeAttribute: vi.fn(),
+  },
 }));
 
 vi.mock('@/context/EnvContext', () => ({
@@ -23,7 +27,10 @@ vi.mock('@/store/settingsStore', () => ({
   }),
 }));
 vi.mock('@/store/readerStore', () => ({
-  useReaderStore: () => ({ getViewSettings: () => ({ scrolled: h.scrolled }) }),
+  useReaderStore: () => ({
+    getView: () => ({ renderer: h.renderer }),
+    getViewSettings: () => ({ scrolled: h.scrolled }),
+  }),
 }));
 vi.mock('@/store/deviceStore', () => ({
   useDeviceControlStore: () => ({
@@ -52,17 +59,34 @@ const makeDoc = () => {
   return d;
 };
 
-const fireTouch = (target: EventTarget, type: string, x: number, y: number) => {
+const dispatchTouch = (
+  target: EventTarget,
+  type: string,
+  touches: TouchLike[],
+  changedTouches = touches,
+) => {
   const ev = new Event(type, { bubbles: true, cancelable: true }) as FakeTouchEvent;
-  const touch = { clientX: x, clientY: y, screenX: x, screenY: y };
-  ev.touches = [touch];
-  ev.changedTouches = [touch];
+  ev.touches = touches;
+  ev.changedTouches = changedTouches;
   const preventDefault = vi.spyOn(ev, 'preventDefault');
   const stopImmediatePropagation = vi.spyOn(ev, 'stopImmediatePropagation');
   act(() => {
     target.dispatchEvent(ev);
   });
   return { preventDefault, stopImmediatePropagation };
+};
+
+const point = (x: number, y: number): TouchLike => ({
+  clientX: x,
+  clientY: y,
+  screenX: x,
+  screenY: y,
+});
+
+const fireTouch = (target: EventTarget, type: string, x: number, y: number) => {
+  const touch = point(x, y);
+  const activeTouches = type === 'touchend' || type === 'touchcancel' ? [] : [touch];
+  return dispatchTouch(target, type, activeTouches, [touch]);
 };
 
 const setup = () => {
@@ -91,9 +115,24 @@ describe('useBrightnessGesture (listener-level)', () => {
     h.screenBrightness = -1;
     h.setScreenBrightness.mockReset();
     h.saveSysSettings.mockReset();
+    h.renderer.setAttribute.mockReset();
+    h.renderer.removeAttribute.mockReset();
     h.getScreenBrightness.mockReset().mockResolvedValue(0.5);
   });
   afterEach(() => cleanup());
+
+  it('publishes the reserved left inset to the page-turn arena while enabled', () => {
+    setup();
+
+    expect(h.renderer.setAttribute).toHaveBeenCalledWith('turn-gesture-left-inset', '0.1');
+  });
+
+  it('removes the reserved left inset when the gesture is disabled', () => {
+    h.swipeSetting = false;
+    setup();
+
+    expect(h.renderer.removeAttribute).toHaveBeenCalledWith('turn-gesture-left-inset');
+  });
 
   it('activates on a left-edge upward flick and suppresses the paginator (capture phase)', () => {
     const { target, paginator } = setup();
@@ -110,6 +149,31 @@ describe('useBrightnessGesture (listener-level)', () => {
     const { stopImmediatePropagation } = fireTouch(target, 'touchmove', 60, 510); // dx=50, dy=10
     expect(stopImmediatePropagation).not.toHaveBeenCalled();
     expect(paginator).toHaveBeenCalled();
+  });
+
+  it('cannot take ownership after a horizontal page-turn trajectory wins', () => {
+    const { target, paginator } = setup();
+    fireTouch(target, 'touchstart', 10, 500);
+    fireTouch(target, 'touchmove', 40, 500); // horizontal > 18px permanently disarms
+    const { stopImmediatePropagation } = fireTouch(target, 'touchmove', 40, 450);
+
+    expect(stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(paginator).toHaveBeenCalledTimes(2);
+    expect(h.setScreenBrightness).not.toHaveBeenCalled();
+  });
+
+  it('permanently yields when a second finger joins in the brightness strip', () => {
+    const { target, paginator } = setup();
+    fireTouch(target, 'touchstart', 10, 500);
+    dispatchTouch(target, 'touchstart', [point(10, 500), point(30, 500)], [point(30, 500)]);
+    const { stopImmediatePropagation } = dispatchTouch(target, 'touchmove', [
+      point(10, 450),
+      point(30, 450),
+    ]);
+
+    expect(stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(paginator).toHaveBeenCalled();
+    expect(h.setScreenBrightness).not.toHaveBeenCalled();
   });
 
   it('does not arm outside the left strip', () => {

--- a/apps/readest-app/src/__tests__/hooks/useCapturedTurn-scrollLock.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useCapturedTurn-scrollLock.test.ts
@@ -12,18 +12,29 @@ import type { TouchDetail } from '@/app/reader/hooks/useTouchInterceptor';
 const h = vi.hoisted(() => ({
   controllerHost: null as null | {
     onBeforeCapture?: (style: 'curl' | 'slide') => Promise<void> | void;
-    onCovered?: (style: 'curl' | 'slide') => Promise<void> | void;
+    onCovered?: (style: 'curl' | 'slide', surfaceAlreadyPainted?: boolean) => Promise<void> | void;
     onCancelled?: (style: 'curl' | 'slide') => Promise<void> | void;
+    preparePixelCapture?: () =>
+      | void
+      | (() => void | Promise<void>)
+      | Promise<void | (() => void | Promise<void>)>;
   },
   hoveredBookKey: 'book-1' as string | null,
   setHoveredBookKey: vi.fn(),
+  settingsDialogOpen: false,
+  settingsListeners: new Set<
+    (state: { isSettingsDialogOpen: boolean }, previous: { isSettingsDialogOpen: boolean }) => void
+  >(),
   controller: {
     turn: vi.fn(async () => {}),
     beginDrag: vi.fn(async () => true),
     moveDrag: vi.fn(),
     endDrag: vi.fn(async () => {}),
     prepareCapture: vi.fn(async () => true),
+    retainPreparedCapture: vi.fn(),
+    releasePreparedCapture: vi.fn(),
     invalidatePreparedCapture: vi.fn(),
+    invalidatePendingPreparedCapture: vi.fn(),
     dispose: vi.fn(),
   },
   viewListeners: new Map<string, Set<EventListener>>(),
@@ -79,8 +90,29 @@ vi.mock('@/store/readerStore', () => {
 vi.mock('@/store/bookDataStore', () => ({
   useBookDataStore: () => ({ getBookData: () => ({ isFixedLayout: false }) }),
 }));
+vi.mock('@/store/settingsStore', () => {
+  const useSettingsStore = () => ({ isSettingsDialogOpen: h.settingsDialogOpen });
+  useSettingsStore.getState = () => ({ isSettingsDialogOpen: h.settingsDialogOpen });
+  useSettingsStore.subscribe = (
+    listener: (
+      state: { isSettingsDialogOpen: boolean },
+      previous: { isSettingsDialogOpen: boolean },
+    ) => void,
+  ) => {
+    h.settingsListeners.add(listener);
+    return () => h.settingsListeners.delete(listener);
+  };
+  return { useSettingsStore };
+});
 vi.mock('@/utils/bridge', () => ({ captureWebviewRegion: vi.fn() }));
 vi.mock('@/utils/viewTransition', () => ({ detectViewTransitionGroup: () => false }));
+vi.mock('@/services/environment', () => ({
+  isTauriAppPlatform: () => process.env['NEXT_PUBLIC_APP_PLATFORM'] === 'tauri',
+  getInitializedAppService: () => ({
+    isMobileApp: process.env['NEXT_PUBLIC_APP_PLATFORM'] === 'tauri',
+    isMacOSApp: false,
+  }),
+}));
 vi.mock('@/app/reader/utils/capturedTurn', () => ({
   CapturedPageTurn: class {
     constructor(host: NonNullable<typeof h.controllerHost>) {
@@ -123,6 +155,13 @@ const detail = (
   deltaT,
 });
 
+const setSettingsDialogOpen = (open: boolean) => {
+  const previous = { isSettingsDialogOpen: h.settingsDialogOpen };
+  h.settingsDialogOpen = open;
+  const state = { isSettingsDialogOpen: open };
+  for (const listener of h.settingsListeners) listener(state, previous);
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   h.controller.beginDrag.mockResolvedValue(true);
@@ -137,16 +176,290 @@ beforeEach(() => {
   h.renderer.listeners.clear();
   h.controllerHost = null;
   h.hoveredBookKey = 'book-1';
+  h.settingsDialogOpen = false;
+  h.settingsListeners.clear();
   h.viewSettings.pageTurnStyle = 'curl';
 });
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  vi.useRealTimers();
+  document.documentElement.classList.remove('captured-turn-filter-transient-overlays');
   document.getElementById('gridcell-book-1')?.remove();
+  document.querySelectorAll('[data-capture-blocking-test]').forEach((element) => element.remove());
   cleanup();
 });
 
 describe('useCapturedTurn scroll-lock gate', () => {
+  test('starts an eligible snapshot warm-up immediately on touchstart', () => {
+    h.viewSettings.pageTurnStyle = 'slide';
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+
+    expect(h.controller.retainPreparedCapture).toHaveBeenCalledOnce();
+    expect(h.controller.prepareCapture).toHaveBeenCalledOnce();
+    expect(h.controller.prepareCapture).toHaveBeenCalledWith('slide');
+    expect(h.controller.beginDrag).not.toHaveBeenCalled();
+    expect(h.controller.releasePreparedCapture.mock.invocationCallOrder[0]).toBeLessThan(
+      h.controller.retainPreparedCapture.mock.invocationCallOrder[0]!,
+    );
+    expect(h.controller.retainPreparedCapture.mock.invocationCallOrder[0]).toBeLessThan(
+      h.controller.prepareCapture.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  test('invalidates around Settings and never prepares a modal-covered snapshot', () => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    setSettingsDialogOpen(true);
+    expect(h.controller.invalidatePreparedCapture).toHaveBeenCalledOnce();
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    expect(h.controller.retainPreparedCapture).not.toHaveBeenCalled();
+    expect(h.controller.prepareCapture).not.toHaveBeenCalled();
+
+    setSettingsDialogOpen(false);
+    // Opening invalidates immediately and the blocked touch defensively clears
+    // any surface that raced the overlay observer. Closing keeps the empty
+    // slot and schedules a post-paint replacement without another epoch bump.
+    expect(h.controller.invalidatePreparedCapture).toHaveBeenCalledTimes(2);
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    expect(h.controller.retainPreparedCapture).toHaveBeenCalledOnce();
+    expect(h.controller.prepareCapture).toHaveBeenCalledOnce();
+  });
+
+  test('pauses idle preparation until Settings has closed and repainted', async () => {
+    vi.useFakeTimers();
+    h.settingsDialogOpen = true;
+    const { unmount } = renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+    try {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(h.controller.prepareCapture).not.toHaveBeenCalled();
+
+      act(() => setSettingsDialogOpen(false));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(h.controller.prepareCapture).toHaveBeenCalledOnce();
+      expect(h.controller.prepareCapture).toHaveBeenCalledWith('curl');
+    } finally {
+      unmount();
+      vi.useRealTimers();
+    }
+  });
+
+  test('invalidates and pauses preparation for a semantic modal outside Settings', async () => {
+    vi.useFakeTimers();
+    const { unmount } = renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+    const dialog = document.createElement('div');
+    dialog.setAttribute('data-capture-blocking-test', '');
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    try {
+      await act(async () => {
+        document.body.appendChild(dialog);
+        await Promise.resolve();
+      });
+      expect(h.controller.invalidatePreparedCapture).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(h.controller.prepareCapture).not.toHaveBeenCalled();
+
+      await act(async () => {
+        dialog.remove();
+        await Promise.resolve();
+      });
+      expect(h.controller.invalidatePreparedCapture).toHaveBeenCalledOnce();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(h.controller.prepareCapture).toHaveBeenCalledOnce();
+      expect(h.controller.prepareCapture).toHaveBeenCalledWith('curl');
+    } finally {
+      dialog.remove();
+      unmount();
+      vi.useRealTimers();
+    }
+  });
+
+  test('does not warm a surface while a host popup is expanded', async () => {
+    const popupTrigger = document.createElement('button');
+    popupTrigger.setAttribute('data-capture-blocking-test', '');
+    popupTrigger.setAttribute('aria-haspopup', 'menu');
+    popupTrigger.setAttribute('aria-expanded', 'true');
+    document.body.appendChild(popupTrigger);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    expect(h.controller.retainPreparedCapture).not.toHaveBeenCalled();
+    expect(h.controller.prepareCapture).not.toHaveBeenCalled();
+    expect(dispatchTouchInterceptors('book-1', detail('move', -30, 0, 16, 150))).toBe(false);
+    expect(h.controller.beginDrag).not.toHaveBeenCalled();
+
+    await act(async () => {
+      popupTrigger.setAttribute('aria-expanded', 'false');
+      await Promise.resolve();
+    });
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    expect(h.controller.retainPreparedCapture).toHaveBeenCalledOnce();
+    expect(h.controller.prepareCapture).toHaveBeenCalledOnce();
+  });
+
+  test('does not treat a closed offscreen popup container as a blocking overlay', () => {
+    const closedPopup = document.createElement('div');
+    closedPopup.setAttribute('data-capture-blocking-test', '');
+    closedPopup.className = 'popup-container';
+    closedPopup.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(closedPopup);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+
+    expect(h.controller.retainPreparedCapture).toHaveBeenCalledOnce();
+    expect(h.controller.prepareCapture).toHaveBeenCalledOnce();
+  });
+
+  test('blocks explicit capture overlays until their visible marker is removed', async () => {
+    const viewer = document.createElement('div');
+    viewer.setAttribute('data-capture-blocking-test', '');
+    viewer.setAttribute('data-capture-blocking-overlay', 'true');
+    document.body.appendChild(viewer);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    expect(h.controller.prepareCapture).not.toHaveBeenCalled();
+
+    await act(async () => {
+      viewer.removeAttribute('data-capture-blocking-overlay');
+      await Promise.resolve();
+    });
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+
+    expect(h.controller.retainPreparedCapture).toHaveBeenCalledOnce();
+    expect(h.controller.prepareCapture).toHaveBeenCalledOnce();
+  });
+
+  test('invalidates for a transient toast without swallowing the page-turn gesture', () => {
+    const toast = document.createElement('div');
+    toast.setAttribute('data-capture-blocking-test', '');
+    toast.setAttribute('data-capture-invalidating-overlay', 'true');
+    document.body.appendChild(toast);
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    expect(h.controller.invalidatePendingPreparedCapture).toHaveBeenCalledOnce();
+    expect(h.controller.invalidatePreparedCapture).not.toHaveBeenCalled();
+    expect(h.controller.retainPreparedCapture).not.toHaveBeenCalled();
+    expect(h.controller.prepareCapture).not.toHaveBeenCalled();
+
+    expect(dispatchTouchInterceptors('book-1', detail('move', -30, 0, 16, 150))).toBe(true);
+    expect(h.controller.beginDrag).toHaveBeenCalledWith(true, false, 'curl');
+  });
+
+  test('reference-counts overlapping native pixel filters', async () => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    const releaseA = await h.controllerHost!.preparePixelCapture!();
+    const releaseB = await h.controllerHost!.preparePixelCapture!();
+    expect(
+      document.documentElement.classList.contains('captured-turn-filter-transient-overlays'),
+    ).toBe(true);
+
+    await releaseA?.();
+    expect(
+      document.documentElement.classList.contains('captured-turn-filter-transient-overlays'),
+    ).toBe(true);
+
+    await releaseB?.();
+    expect(
+      document.documentElement.classList.contains('captured-turn-filter-transient-overlays'),
+    ).toBe(false);
+  });
+
+  test('removes a stalled native pixel filter after its safety timeout', async () => {
+    vi.useFakeTimers();
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    await h.controllerHost!.preparePixelCapture!();
+    expect(
+      document.documentElement.classList.contains('captured-turn-filter-transient-overlays'),
+    ).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(
+      document.documentElement.classList.contains('captured-turn-filter-transient-overlays'),
+    ).toBe(false);
+  });
+
+  test('falls back without a captured surface for a programmatic turn under an overlay', async () => {
+    const dialog = document.createElement('dialog');
+    dialog.setAttribute('data-capture-blocking-test', '');
+    dialog.setAttribute('open', '');
+    document.body.appendChild(dialog);
+    const view = makeView();
+    const originalNext = view.next as ReturnType<typeof vi.fn>;
+    renderHook(() => useCapturedTurn('book-1', { current: view }));
+
+    await view.next();
+
+    expect(originalNext).toHaveBeenCalledOnce();
+    expect(h.controller.turn).not.toHaveBeenCalled();
+  });
+
+  test.each(['end', 'cancel'] as const)('releases an unclaimed touch lease on %s', (phase) => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    dispatchTouchInterceptors('book-1', detail(phase, 2, 0, 16, 150));
+
+    // Once before acquiring the new lease, once when the unclaimed touch
+    // ends. No drag controller lifecycle was started.
+    expect(h.controller.releasePreparedCapture).toHaveBeenCalledTimes(2);
+    expect(h.controller.beginDrag).not.toHaveBeenCalled();
+    expect(h.controller.endDrag).not.toHaveBeenCalled();
+  });
+
+  test('a replacement touch releases the previous lease before retaining the next one', () => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+
+    expect(h.controller.releasePreparedCapture).toHaveBeenCalledTimes(2);
+    expect(h.controller.retainPreparedCapture).toHaveBeenCalledTimes(2);
+    expect(h.controller.releasePreparedCapture.mock.invocationCallOrder[1]).toBeLessThan(
+      h.controller.retainPreparedCapture.mock.invocationCallOrder[1]!,
+    );
+  });
+
+  test('does not speculatively capture a touch reserved for the brightness strip', () => {
+    h.renderer.getAttribute.mockReturnValue('0.1');
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 10));
+
+    expect(h.controller.retainPreparedCapture).not.toHaveBeenCalled();
+    expect(h.controller.prepareCapture).not.toHaveBeenCalled();
+    expect(h.controller.invalidatePreparedCapture).toHaveBeenCalledOnce();
+  });
+
   test('claims the first inward sample from the right edge', () => {
     const cell = document.createElement('div');
     cell.id = 'gridcell-book-1';
@@ -174,6 +487,7 @@ describe('useCapturedTurn scroll-lock gate', () => {
     expect(dispatchTouchInterceptors('book-1', detail('move', 30, 0, 32, 285))).toBe(false);
 
     expect(h.controller.beginDrag).not.toHaveBeenCalled();
+    expect(h.controller.releasePreparedCapture).toHaveBeenCalledTimes(2);
   });
 
   test('claims a central drag after two coherent samples at 6px', () => {
@@ -207,6 +521,24 @@ describe('useCapturedTurn scroll-lock gate', () => {
 
     dispatchTouchInterceptors('book-1', detail('move', -36, 0, 48, 150));
     expect(h.controller.moveDrag).toHaveBeenLastCalledWith(30 / 300, 0.5);
+  });
+
+  test('keeps a short Slide flick visually flat at claim but uses its full release intent', () => {
+    h.viewSettings.pageTurnStyle = 'slide';
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    expect(dispatchTouchInterceptors('book-1', detail('move', -30, 0, 16, 150))).toBe(true);
+
+    expect(h.controller.beginDrag).toHaveBeenCalledWith(true, false, 'slide');
+    expect(h.controller.moveDrag).toHaveBeenLastCalledWith(0, 0.5);
+
+    expect(dispatchTouchInterceptors('book-1', detail('end', -30, 0, 16, 150))).toBe(true);
+    expect(h.controller.endDrag).toHaveBeenCalledWith(true, expect.any(Number));
   });
 
   test('does not use the central fast path for an outward edge drag', () => {
@@ -528,6 +860,7 @@ describe('useCapturedTurn scroll-lock gate', () => {
 
     expect(consumed).toBe(false);
     expect(h.controller.beginDrag).not.toHaveBeenCalled();
+    expect(h.controller.invalidatePreparedCapture).toHaveBeenCalledOnce();
   });
 
   // Non-instant selection: a long-press selection (or a drag of its handles)
@@ -545,6 +878,7 @@ describe('useCapturedTurn scroll-lock gate', () => {
 
     expect(consumed).toBe(false);
     expect(h.controller.beginDrag).not.toHaveBeenCalled();
+    expect(h.controller.invalidatePreparedCapture).toHaveBeenCalledOnce();
   });
 
   test('a collapsed selection does not block the captured turn', () => {
@@ -647,6 +981,13 @@ describe('useCapturedTurn scroll-lock gate', () => {
     });
 
     expect(h.setHoveredBookKey).toHaveBeenCalledWith(null);
+    expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(true);
+    await act(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        }),
+    );
     expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(false);
   });
 
@@ -735,6 +1076,37 @@ describe('useCapturedTurn scroll-lock gate', () => {
       expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(true);
       frames.shift()?.(64);
       await covered;
+      expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(false);
+    } finally {
+      raf.mockRestore();
+    }
+  });
+
+  test('a pre-painted surface hides live chrome without another cover wait', async () => {
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const gridCell = document.createElement('div');
+    gridCell.id = 'gridcell-book-1';
+    document.body.appendChild(gridCell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    try {
+      await h.controllerHost?.onBeforeCapture?.('slide');
+      await h.controllerHost?.onCovered?.('slide', true);
+
+      expect(h.setHoveredBookKey).toHaveBeenCalledWith(null);
+      expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(true);
+      // Only the non-blocking transition-class cleanup is queued; there was
+      // no leading pair of cover RAFs.
+      expect(frames).toHaveLength(1);
+
+      frames.shift()?.(16);
+      await Promise.resolve();
+      frames.shift()?.(32);
+      await Promise.resolve();
       expect(gridCell.classList.contains('captured-turn-sync-chrome')).toBe(false);
     } finally {
       raf.mockRestore();

--- a/apps/readest-app/src/__tests__/hooks/useCapturedTurn-scrollLock.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useCapturedTurn-scrollLock.test.ts
@@ -22,8 +22,11 @@ const h = vi.hoisted(() => ({
     beginDrag: vi.fn(async () => true),
     moveDrag: vi.fn(),
     endDrag: vi.fn(async () => {}),
+    prepareCapture: vi.fn(async () => true),
+    invalidatePreparedCapture: vi.fn(),
     dispose: vi.fn(),
   },
+  viewListeners: new Map<string, Set<EventListener>>(),
   selection: null as { rangeCount: number; isCollapsed: boolean } | null,
   renderer: {
     listeners: new Map<string, Set<EventListener>>(),
@@ -34,6 +37,7 @@ const h = vi.hoisted(() => ({
     getContents() {
       return [{ index: 0, doc: { getSelection: () => h.selection } }];
     },
+    getAttribute: vi.fn(() => null as string | null),
     hasAttribute: () => false,
     setAttribute: () => {},
     removeAttribute: () => {},
@@ -64,7 +68,12 @@ vi.mock('@/store/readerStore', () => {
     getViewSettings: () => h.viewSettings,
     setHoveredBookKey: h.setHoveredBookKey,
   });
-  useReaderStore.getState = () => ({ hoveredBookKey: h.hoveredBookKey });
+  useReaderStore.getState = () => ({
+    hoveredBookKey: h.hoveredBookKey,
+    bottomBarTab: '',
+    viewStates: { 'book-1': { inited: true, ttsEnabled: false } },
+  });
+  useReaderStore.subscribe = () => () => {};
   return { useReaderStore };
 });
 vi.mock('@/store/bookDataStore', () => ({
@@ -85,15 +94,33 @@ import { useCapturedTurn } from '@/app/reader/hooks/useCapturedTurn';
 import { dispatchTouchInterceptors } from '@/app/reader/hooks/useTouchInterceptor';
 
 const makeView = () =>
-  ({ renderer: h.renderer, prev: vi.fn(), next: vi.fn() }) as unknown as FoliateView;
+  ({
+    renderer: h.renderer,
+    prev: vi.fn(),
+    next: vi.fn(),
+    addEventListener(type: string, listener: EventListener) {
+      const listeners = h.viewListeners.get(type) ?? new Set<EventListener>();
+      listeners.add(listener);
+      h.viewListeners.set(type, listeners);
+    },
+    removeEventListener(type: string, listener: EventListener) {
+      h.viewListeners.get(type)?.delete(listener);
+    },
+  }) as unknown as FoliateView;
 
-const detail = (phase: TouchDetail['phase'], deltaX = 0, deltaY = 0): TouchDetail => ({
+const detail = (
+  phase: TouchDetail['phase'],
+  deltaX = 0,
+  deltaY = 0,
+  deltaT = 16,
+  startX = 0,
+): TouchDetail => ({
   phase,
-  touch: { screenX: 0, screenY: 0 },
-  touchStart: { screenX: 0, screenY: 0 },
+  touch: { screenX: startX + deltaX, screenY: deltaY },
+  touchStart: { screenX: startX, screenY: 0 },
   deltaX,
   deltaY,
-  deltaT: 16,
+  deltaT,
 });
 
 beforeEach(() => {
@@ -104,10 +131,13 @@ beforeEach(() => {
   h.renderer.scrollLocked = false;
   h.renderer.atEnd = false;
   h.renderer.atStart = false;
+  h.renderer.getAttribute.mockReset().mockReturnValue(null);
   h.selection = null;
+  h.viewListeners.clear();
   h.renderer.listeners.clear();
   h.controllerHost = null;
   h.hoveredBookKey = 'book-1';
+  h.viewSettings.pageTurnStyle = 'curl';
 });
 
 afterEach(() => {
@@ -117,6 +147,144 @@ afterEach(() => {
 });
 
 describe('useCapturedTurn scroll-lock gate', () => {
+  test('claims the first inward sample from the right edge', () => {
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 285));
+    const consumed = dispatchTouchInterceptors('book-1', detail('move', -1, 0, 16, 285));
+
+    expect(consumed).toBe(true);
+    expect(h.controller.beginDrag).toHaveBeenCalledWith(true, false, 'curl');
+  });
+
+  test('an edge claim at a boundary cannot reverse into a second turn', () => {
+    h.renderer.atEnd = true;
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 285));
+    expect(dispatchTouchInterceptors('book-1', detail('move', -1, 0, 16, 285))).toBe(true);
+    expect(dispatchTouchInterceptors('book-1', detail('move', 30, 0, 32, 285))).toBe(false);
+
+    expect(h.controller.beginDrag).not.toHaveBeenCalled();
+  });
+
+  test('claims a central drag after two coherent samples at 6px', () => {
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    expect(dispatchTouchInterceptors('book-1', detail('move', -3, 0, 16, 150))).toBe(false);
+    expect(dispatchTouchInterceptors('book-1', detail('move', -6, 0, 32, 150))).toBe(true);
+
+    expect(h.controller.beginDrag).toHaveBeenCalledWith(true, false, 'curl');
+  });
+
+  test('starts a claimed Slide flat and follows only post-claim finger travel', () => {
+    h.viewSettings.pageTurnStyle = 'slide';
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    dispatchTouchInterceptors('book-1', detail('move', -3, 0, 16, 150));
+    dispatchTouchInterceptors('book-1', detail('move', -6, 0, 32, 150));
+
+    expect(h.controller.beginDrag).toHaveBeenCalledWith(true, false, 'slide');
+    expect(h.controller.moveDrag).toHaveBeenLastCalledWith(0, 0.5);
+
+    dispatchTouchInterceptors('book-1', detail('move', -36, 0, 48, 150));
+    expect(h.controller.moveDrag).toHaveBeenLastCalledWith(30 / 300, 0.5);
+  });
+
+  test('does not use the central fast path for an outward edge drag', () => {
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 45));
+    expect(dispatchTouchInterceptors('book-1', detail('move', -3, 0, 16, 45))).toBe(false);
+    expect(dispatchTouchInterceptors('book-1', detail('move', -6, 0, 32, 45))).toBe(false);
+    expect(dispatchTouchInterceptors('book-1', detail('move', -15, 0, 48, 45))).toBe(true);
+
+    expect(h.controller.beginDrag).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not combine coherent samples separated by more than 80ms', () => {
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    expect(dispatchTouchInterceptors('book-1', detail('move', -3, 0, 16, 150))).toBe(false);
+    expect(dispatchTouchInterceptors('book-1', detail('move', -6, 0, 120, 150))).toBe(false);
+    expect(dispatchTouchInterceptors('book-1', detail('move', -9, 0, 136, 150))).toBe(true);
+
+    expect(h.controller.beginDrag).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not early-claim inside the left brightness strip', () => {
+    h.renderer.getAttribute.mockReturnValue('0.1');
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 10));
+    expect(dispatchTouchInterceptors('book-1', detail('move', 3, 0, 16, 10))).toBe(false);
+    expect(dispatchTouchInterceptors('book-1', detail('move', 6, 0, 32, 10))).toBe(false);
+
+    expect(h.controller.beginDrag).not.toHaveBeenCalled();
+  });
+
+  test('uses the 24px fallback inside the left brightness strip', () => {
+    h.renderer.getAttribute.mockReturnValue('0.1');
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 10));
+    expect(dispatchTouchInterceptors('book-1', detail('move', 15, 0, 16, 10))).toBe(false);
+    expect(dispatchTouchInterceptors('book-1', detail('move', 23, 0, 32, 10))).toBe(false);
+    expect(dispatchTouchInterceptors('book-1', detail('move', 24, 0, 48, 10))).toBe(true);
+
+    expect(h.controller.beginDrag).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not claim after a central gesture locks vertically', () => {
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    expect(dispatchTouchInterceptors('book-1', detail('move', -4, 0, 16, 150))).toBe(false);
+    expect(dispatchTouchInterceptors('book-1', detail('move', -4, -10, 32, 150))).toBe(false);
+    expect(dispatchTouchInterceptors('book-1', detail('move', -30, -10, 48, 150))).toBe(false);
+
+    expect(h.controller.beginDrag).not.toHaveBeenCalled();
+  });
+
   test('a horizontal swipe starts the captured turn when scroll is not locked', () => {
     renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
 
@@ -130,8 +298,8 @@ describe('useCapturedTurn scroll-lock gate', () => {
   test('catches the captured drag up to the activation-threshold distance', async () => {
     renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
 
-    dispatchTouchInterceptors('book-1', detail('start'));
-    dispatchTouchInterceptors('book-1', detail('move', -15, 0));
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    dispatchTouchInterceptors('book-1', detail('move', -15, 0, 16, 150));
     await act(async () => {
       await Promise.resolve();
     });
@@ -142,11 +310,11 @@ describe('useCapturedTurn scroll-lock gate', () => {
   test('preserves total travel when horizontal intent is recognized later', async () => {
     renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
 
-    dispatchTouchInterceptors('book-1', detail('start'));
-    dispatchTouchInterceptors('book-1', detail('move', -60, 80));
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    dispatchTouchInterceptors('book-1', detail('move', -4, 6, 16, 150));
     expect(h.controller.beginDrag).not.toHaveBeenCalled();
 
-    dispatchTouchInterceptors('book-1', detail('move', -100, 80));
+    dispatchTouchInterceptors('book-1', detail('move', -100, 80, 32, 150));
     await act(async () => {
       await Promise.resolve();
     });
@@ -169,12 +337,12 @@ describe('useCapturedTurn scroll-lock gate', () => {
     renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
 
     dispatchTouchInterceptors('book-1', detail('start'));
-    dispatchTouchInterceptors('book-1', detail('move', -15, 0));
-    dispatchTouchInterceptors('book-1', detail('move', -240, 10));
-    const released = dispatchTouchInterceptors('book-1', detail('end', -240, 10));
+    dispatchTouchInterceptors('book-1', detail('move', -15, 0, 16));
+    dispatchTouchInterceptors('book-1', detail('move', -240, 10, 32));
+    const released = dispatchTouchInterceptors('book-1', detail('end', -240, 10, 48));
 
     expect(released).toBe(true);
-    expect(h.controller.endDrag).toHaveBeenCalledWith(true);
+    expect(h.controller.endDrag).toHaveBeenCalledWith(true, 5);
     const lastSample = h.controller.moveDrag.mock.calls.at(-1)!;
     // 240px of total travel across the 300px captured reader cell.
     expect(lastSample[0]).toBeCloseTo(0.8);
@@ -192,12 +360,97 @@ describe('useCapturedTurn scroll-lock gate', () => {
   test('commits a short fast flick before halfway', () => {
     renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
 
-    dispatchTouchInterceptors('book-1', detail('start'));
-    dispatchTouchInterceptors('book-1', detail('move', -20, 0));
-    dispatchTouchInterceptors('book-1', { ...detail('end', -20, 0), deltaT: 50 });
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    dispatchTouchInterceptors('book-1', detail('move', -20, 0, 16, 150));
+    dispatchTouchInterceptors('book-1', detail('end', -20, 0, 50, 150));
 
     // 20px / 50ms = 0.4px/ms, above the 0.3 flick threshold.
-    expect(h.controller.endDrag).toHaveBeenCalledWith(true);
+    expect(h.controller.endDrag).toHaveBeenCalledWith(true, 0.4);
+  });
+
+  test('lets distance and sub-flick release speed combine to commit a Slide', () => {
+    h.viewSettings.pageTurnStyle = 'slide';
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start'));
+    dispatchTouchInterceptors('book-1', detail('move', -102, 0, 310));
+    dispatchTouchInterceptors('book-1', detail('move', -102, 0, 410));
+    dispatchTouchInterceptors('book-1', detail('end', -120, 0, 500));
+
+    // Neither 40% distance nor 0.2px/ms speed passes the old independent
+    // threshold. Together they project to 56%, so the Slide commits.
+    expect(h.controller.endDrag).toHaveBeenCalledWith(true, 0.2);
+  });
+
+  test('cancels a rested Slide below halfway', () => {
+    h.viewSettings.pageTurnStyle = 'slide';
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start'));
+    dispatchTouchInterceptors('book-1', detail('move', -108, 0, 500));
+    dispatchTouchInterceptors('book-1', detail('end', -108, 0, 600));
+
+    expect(h.controller.endDrag).toHaveBeenCalledWith(false, 0);
+  });
+
+  test('lets a sub-flick reverse release pull projected Slide progress back', () => {
+    h.viewSettings.pageTurnStyle = 'slide';
+    const cell = document.createElement('div');
+    cell.id = 'gridcell-book-1';
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 300, 500));
+    document.body.appendChild(cell);
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start'));
+    dispatchTouchInterceptors('book-1', detail('move', -174, 0, 410));
+    dispatchTouchInterceptors('book-1', detail('move', -174, 0, 510));
+    dispatchTouchInterceptors('book-1', detail('end', -165, 0, 600));
+
+    // Distance alone is 55%, but projecting the -0.1px/ms release returns it
+    // to 47%, so the Slide cancels.
+    expect(h.controller.endDrag).toHaveBeenCalledWith(false, -0.1);
+  });
+
+  test("uses recent release velocity without changing Curl's full-gesture commit rule", () => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start'));
+    dispatchTouchInterceptors('book-1', detail('move', -40, 0, 200));
+    dispatchTouchInterceptors('book-1', detail('move', -40, 0, 300));
+    dispatchTouchInterceptors('book-1', detail('end', -120, 0, 340));
+
+    // Commit still uses 120px / 340ms; settle momentum uses the latest
+    // 80px of movement inside the interpolated 90ms release window.
+    expect(h.controller.endDrag).toHaveBeenCalledWith(true, 80 / 90);
+  });
+
+  test('drops release momentum after the finger pauses for more than 80ms', () => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start'));
+    dispatchTouchInterceptors('book-1', detail('move', -120, 0, 40));
+    dispatchTouchInterceptors('book-1', detail('end', -120, 0, 130));
+
+    expect(h.controller.endDrag).toHaveBeenCalledWith(true, 0);
+  });
+
+  test('passes a reverse release velocity to a cancelling settle', () => {
+    renderHook(() => useCapturedTurn('book-1', { current: makeView() }));
+
+    dispatchTouchInterceptors('book-1', detail('start'));
+    dispatchTouchInterceptors('book-1', detail('move', -120, 0, 40));
+    dispatchTouchInterceptors('book-1', detail('move', -120, 0, 100));
+    dispatchTouchInterceptors('book-1', detail('end', -40, 0, 140));
+
+    expect(h.controller.endDrag).toHaveBeenCalledWith(false, -80 / 90);
   });
 
   test('cancels an unfinished drag before accepting a replacement touch sequence', () => {
@@ -213,6 +466,45 @@ describe('useCapturedTurn scroll-lock gate', () => {
     expect(h.controller.endDrag.mock.invocationCallOrder[0]!).toBeLessThan(
       h.controller.beginDrag.mock.invocationCallOrder[1]!,
     );
+  });
+
+  test('an accepted programmatic turn permanently rejects a pending touch sequence', () => {
+    const view = makeView();
+    renderHook(() => useCapturedTurn('book-1', { current: view }));
+
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    void view.next();
+    const consumed = dispatchTouchInterceptors('book-1', detail('move', -60, 0, 16, 150));
+
+    expect(h.controller.turn).toHaveBeenCalledWith(true, false, 'curl');
+    expect(consumed).toBe(false);
+    expect(h.controller.beginDrag).not.toHaveBeenCalled();
+  });
+
+  test('a touch that starts during a programmatic turn stays rejected until its release', async () => {
+    let resolveTurn!: () => void;
+    h.controller.turn.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveTurn = resolve;
+        }),
+    );
+    const view = makeView();
+    renderHook(() => useCapturedTurn('book-1', { current: view }));
+
+    const turning = view.next() as unknown as Promise<void>;
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    expect(dispatchTouchInterceptors('book-1', detail('move', -60, 0, 16, 150))).toBe(false);
+
+    resolveTurn();
+    await act(async () => turning);
+    expect(dispatchTouchInterceptors('book-1', detail('move', -90, 0, 32, 150))).toBe(false);
+    expect(h.controller.beginDrag).not.toHaveBeenCalled();
+
+    dispatchTouchInterceptors('book-1', detail('end', -90, 0, 48, 150));
+    dispatchTouchInterceptors('book-1', detail('start', 0, 0, 0, 150));
+    expect(dispatchTouchInterceptors('book-1', detail('move', -60, 0, 16, 150))).toBe(true);
+    expect(h.controller.beginDrag).toHaveBeenCalledOnce();
   });
 
   test('touch cancellation always reverses an active captured drag', () => {
@@ -533,11 +825,8 @@ describe('useCapturedTurn view.next replacement', () => {
           resolveTurn = r;
         }),
     );
-    const view = {
-      renderer: h.renderer,
-      prev: vi.fn(),
-      next: originalNext,
-    } as unknown as FoliateView;
+    const view = makeView();
+    view.next = originalNext;
     renderHook(() => useCapturedTurn('book-1', { current: view }));
 
     const settled = vi.fn();

--- a/apps/readest-app/src/__tests__/hooks/useCapturedTurn.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useCapturedTurn.test.ts
@@ -50,13 +50,19 @@ describe('getCapturedTurnStyle', () => {
   it('captures the slide on Tauri when the engine cannot layer View Transitions', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'tauri');
     stubEngine({ startViewTransition: true, nestedGroups: false });
-    expect(getCapturedTurnStyle(settings('slide'), false)).toBe('slide');
+    expect(getCapturedTurnStyle(settings('slide'), false, false)).toBe('slide');
   });
 
-  it('leaves the slide to View Transitions on fully supporting engines', () => {
+  it('leaves the slide to View Transitions on fully supporting desktop Tauri engines', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'tauri');
     stubEngine({ startViewTransition: true, nestedGroups: true });
-    expect(getCapturedTurnStyle(settings('slide'), false)).toBeNull();
+    expect(getCapturedTurnStyle(settings('slide'), false, false)).toBeNull();
+  });
+
+  it('keeps the slide on the pre-warmed capture path on mobile Tauri engines', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'tauri');
+    stubEngine({ startViewTransition: true, nestedGroups: true });
+    expect(getCapturedTurnStyle(settings('slide'), false, true)).toBe('slide');
   });
 
   it('never captures outside Tauri platforms', () => {
@@ -72,7 +78,7 @@ describe('applyPageTurnAttributes', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'web');
     stubEngine({ startViewTransition: true, nestedGroups: true });
     const { view, renderer } = makeView();
-    applyPageTurnAttributes(view, settings('slide'), false);
+    applyPageTurnAttributes(view, settings('slide'), false, false);
     expect(renderer.getAttribute('turn-style')).toBe('slide');
   });
 
@@ -81,18 +87,54 @@ describe('applyPageTurnAttributes', () => {
     stubEngine({ startViewTransition: true, nestedGroups: false });
     const { view, renderer } = makeView();
     renderer.setAttribute('turn-style', 'slide');
-    applyPageTurnAttributes(view, settings('slide'), false);
+    renderer.setAttribute('captured-turn-style', 'slide');
+    applyPageTurnAttributes(view, settings('slide'), false, false);
     expect(renderer.hasAttribute('turn-style')).toBe(false);
+    expect(renderer.hasAttribute('captured-turn-style')).toBe(false);
   });
 
   it('hands the slide to the capture pipeline on Tauri without full support', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'tauri');
     stubEngine({ startViewTransition: true, nestedGroups: false });
     const { view, renderer } = makeView();
-    applyPageTurnAttributes(view, settings('slide'), false);
+    applyPageTurnAttributes(view, settings('slide'), false, false);
     // The app slides the captured page itself: the paginator must not run
     // its own View Transition nor its swipe tracking.
     expect(renderer.hasAttribute('turn-style')).toBe(false);
     expect(renderer.hasAttribute('no-swipe')).toBe(true);
+    expect(renderer.getAttribute('captured-turn-style')).toBe('slide');
+  });
+
+  it('keeps the View Transition slide on fully supporting desktop Tauri engines', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'tauri');
+    stubEngine({ startViewTransition: true, nestedGroups: true });
+    const { view, renderer } = makeView();
+    applyPageTurnAttributes(view, settings('slide'), false, false);
+    expect(renderer.getAttribute('turn-style')).toBe('slide');
+    expect(renderer.hasAttribute('no-swipe')).toBe(false);
+    expect(renderer.hasAttribute('captured-turn-style')).toBe(false);
+  });
+
+  it('hands the slide to the capture pipeline on fully supporting mobile Tauri engines', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'tauri');
+    stubEngine({ startViewTransition: true, nestedGroups: true });
+    const { view, renderer } = makeView();
+    applyPageTurnAttributes(view, settings('slide'), false, true);
+    expect(renderer.hasAttribute('turn-style')).toBe(false);
+    expect(renderer.hasAttribute('no-swipe')).toBe(true);
+    expect(renderer.getAttribute('captured-turn-style')).toBe('slide');
+  });
+
+  it('does not publish the native touch arena when swipe navigation is disabled', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'tauri');
+    stubEngine({ startViewTransition: true, nestedGroups: false });
+    const { view, renderer } = makeView();
+    const disabled = settings('slide');
+    disabled.disableSwipe = true;
+
+    applyPageTurnAttributes(view, disabled, false, false);
+
+    expect(renderer.hasAttribute('no-swipe')).toBe(true);
+    expect(renderer.hasAttribute('captured-turn-style')).toBe(false);
   });
 });

--- a/apps/readest-app/src/__tests__/hooks/useTouchEvent.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTouchEvent.test.tsx
@@ -33,6 +33,14 @@ vi.mock('@/utils/event', () => ({
 
 import { useTouchEvent } from '@/app/reader/hooks/useIframeEvents';
 import {
+  beginLayeredTurnTouch,
+  cancelLayeredTurnTouch,
+  endLayeredTurnTouch,
+  handleClickCapture,
+  isLayeredTurnTouchActive,
+  setLayeredTurnTouchClaimed,
+} from '@/app/reader/utils/iframeEventHandlers';
+import {
   registerTouchInterceptor,
   setLayeredTurnGestureActive,
   type TouchDetail,
@@ -49,6 +57,10 @@ const touchEvent = (touches: Touch[], timeStamp = 0, changedTouches: Touch[] = t
   timeStamp,
   targetTouches: touches,
   changedTouches,
+});
+const directTouchEvent = (touches: Touch[], timeStamp = 0, changedTouches: Touch[] = touches) => ({
+  ...touchEvent(touches, timeStamp, changedTouches),
+  preventDefault: vi.fn(),
 });
 
 type Handlers = ReturnType<typeof useTouchEvent>;
@@ -69,6 +81,7 @@ describe('useTouchEvent pinch vs two-finger scroll', () => {
 
   beforeEach(() => {
     setLayeredTurnGestureActive('book-1', false);
+    cancelLayeredTurnTouch('book-1');
     pinchZoom = vi.fn();
     pinchEnd = vi.fn();
     mocks.hoveredBookKey = null;
@@ -79,6 +92,7 @@ describe('useTouchEvent pinch vs two-finger scroll', () => {
 
   afterEach(() => {
     setLayeredTurnGestureActive('book-1', false);
+    cancelLayeredTurnTouch('book-1');
     cleanup();
     vi.clearAllMocks();
   });
@@ -122,6 +136,47 @@ describe('useTouchEvent pinch vs two-finger scroll', () => {
 
     expect(pinchZoom).not.toHaveBeenCalled();
     expect(mocks.dispatch).not.toHaveBeenCalledWith('pinch-zoom', expect.anything());
+  });
+
+  test('cancels a claimed reflowable drag once when a second finger appears', () => {
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({ zoomLevel: 100, scrolled: false, vertical: false });
+    const details: TouchDetail[] = [];
+    const unregister = registerTouchInterceptor(
+      'reflowable-multitouch-test',
+      (_bookKey, detail) => {
+        details.push(detail);
+        return detail.phase === 'move' || detail.phase === 'cancel';
+      },
+    );
+
+    try {
+      const h = renderTouchHook();
+      h.current.onTouchStart(touchEvent([touch(200, 300)], 100));
+      h.current.onTouchMove(touchEvent([touch(180, 300)], 116));
+
+      // The second finger cancels the captured single-finger drag, then the
+      // remaining finger stays latched out until both fingers are up.
+      h.current.onTouchStart(touchEvent([touch(180, 300), touch(260, 300)], 132));
+      expect(details.map(({ phase }) => phase)).toEqual(['start', 'move', 'cancel']);
+
+      h.current.onTouchEnd(touchEvent([touch(260, 300)], 148, [touch(180, 300)]));
+      h.current.onTouchMove(touchEvent([touch(230, 300)], 164));
+      expect(details.map(({ phase }) => phase)).toEqual(['start', 'move', 'cancel']);
+
+      h.current.onTouchEnd(touchEvent([], 180, [touch(230, 300)]));
+      h.current.onTouchStart(touchEvent([touch(200, 300)], 196));
+      h.current.onTouchMove(touchEvent([touch(180, 300)], 212));
+      expect(details.map(({ phase }) => phase)).toEqual([
+        'start',
+        'move',
+        'cancel',
+        'start',
+        'move',
+      ]);
+    } finally {
+      unregister();
+    }
   });
 
   test.each([
@@ -295,6 +350,125 @@ describe('useTouchEvent pinch vs two-finger scroll', () => {
     h.current.onTouchCancel(touchEvent([], 132, [touch(184, 300)]));
 
     expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+  });
+
+  test('defers native captured-turn toolbar changes across the 15–24px claim gap', () => {
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle: 'slide',
+      animated: true,
+      isEink: false,
+      disableSwipe: false,
+    });
+    mocks.getView.mockReturnValue({
+      renderer: {
+        getAttribute: (name: string) => (name === 'captured-turn-style' ? 'slide' : null),
+      },
+    });
+    const h = renderTouchHook();
+
+    h.current.onTouchStart(touchEvent([touch(10, 300)], 100));
+    h.current.onTouchMove(touchEvent([touch(26, 300)], 116));
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+
+    h.current.onTouchMove(touchEvent([touch(35, 300)], 132));
+    h.current.onTouchCancel(touchEvent([], 148, [touch(35, 300)]));
+    expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    'end',
+    'cancel',
+  ] as const)('seals a directly claimed parent-surface touch on %s and suppresses compatibility clicks', (phase) => {
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle: 'slide',
+    });
+    const unregister = registerTouchInterceptor(
+      'direct-parent-layered-turn-test',
+      (_bookKey, detail) => {
+        if (detail.phase === 'move') setLayeredTurnTouchClaimed('book-1', true);
+        return detail.phase !== 'start';
+      },
+      5,
+    );
+
+    try {
+      const h = renderTouchHook();
+      const start = directTouchEvent([touch(200, 300)], 100);
+      const move = directTouchEvent([touch(180, 300)], 116);
+      h.current.onTouchStart(start);
+      h.current.onTouchMove(move);
+
+      expect(isLayeredTurnTouchActive('book-1')).toBe(true);
+      expect(move.preventDefault).toHaveBeenCalledOnce();
+
+      const terminal = directTouchEvent([], 132, [touch(180, 300)]);
+      if (phase === 'end') h.current.onTouchEnd(terminal);
+      else h.current.onTouchCancel(terminal);
+
+      expect(isLayeredTurnTouchActive('book-1')).toBe(false);
+      expect(terminal.preventDefault).toHaveBeenCalledOnce();
+    } finally {
+      unregister();
+    }
+  });
+
+  test('does not let a forwarded iframe start erase an earlier raw claim', () => {
+    mocks.getBookData.mockReturnValue({ isFixedLayout: false });
+    mocks.getViewSettings.mockReturnValue({
+      zoomLevel: 100,
+      scrolled: false,
+      vertical: false,
+      pageTurnStyle: 'slide',
+    });
+    const h = renderTouchHook();
+
+    beginLayeredTurnTouch('book-1');
+    setLayeredTurnTouchClaimed('book-1', true);
+    h.current.onTouchStart(touchEvent([touch(200, 300)], 100));
+    endLayeredTurnTouch('book-1');
+
+    const click = {
+      preventDefault: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+      screenX: 200,
+      screenY: 300,
+    } as unknown as MouseEvent;
+    handleClickCapture('book-1', click);
+
+    expect(click.preventDefault).toHaveBeenCalledOnce();
+    expect(click.stopImmediatePropagation).toHaveBeenCalledOnce();
+  });
+
+  test('honors an interceptor that claims only the direct touchend', () => {
+    mocks.hoveredBookKey = 'book-1';
+    mocks.getBookData.mockReturnValue({ isFixedLayout: true });
+    mocks.getViewSettings.mockReturnValue({ zoomLevel: 100, scrolled: false, vertical: false });
+    const unregister = registerTouchInterceptor(
+      'direct-end-only-test',
+      (_bookKey, detail) => detail.phase === 'end',
+      5,
+    );
+
+    try {
+      const h = renderTouchHook();
+      h.current.onTouchStart(directTouchEvent([touch(200, 300)], 100));
+      const terminal = directTouchEvent([], 132, [touch(120, 300)]);
+      h.current.onTouchEnd(terminal);
+
+      expect(terminal.preventDefault).toHaveBeenCalledOnce();
+      expect(mocks.setHoveredBookKey).not.toHaveBeenCalled();
+    } finally {
+      unregister();
+    }
   });
 
   test.each([

--- a/apps/readest-app/src/__tests__/reader/utils/iframeEventHandlers.test.ts
+++ b/apps/readest-app/src/__tests__/reader/utils/iframeEventHandlers.test.ts
@@ -18,6 +18,8 @@ function mouseEvent(overrides: Partial<MouseEvent> = {}): MouseEvent {
     altKey: false,
     metaKey: false,
     target: null,
+    preventDefault: vi.fn(),
+    stopImmediatePropagation: vi.fn(),
     ...overrides,
   } as unknown as MouseEvent;
 }
@@ -30,7 +32,9 @@ function touchEvent(touches: Touch[], changedTouches: Touch[] = touches): TouchE
   return {
     touches: touches as unknown as TouchList,
     changedTouches: changedTouches as unknown as TouchList,
-  } as TouchEvent;
+    timeStamp: 0,
+    preventDefault: vi.fn(),
+  } as unknown as TouchEvent;
 }
 
 function postedTypes(spy: ReturnType<typeof vi.spyOn>): string[] {
@@ -240,6 +244,7 @@ describe('iframeEventHandlers touch forwarding', () => {
 
   beforeEach(() => {
     vi.resetModules();
+    vi.useFakeTimers();
     postSpy = vi.spyOn(window, 'postMessage').mockImplementation(() => {});
   });
 
@@ -318,11 +323,23 @@ describe('iframeEventHandlers touch forwarding', () => {
     handleMousedown('book-1', mouseEvent({ screenX: 160, screenY: 300 }));
     handleMouseup('book-1', mouseEvent({ screenX: 160, screenY: 300 }));
     handleClick('book-1', { current: true }, false, mouseEvent({ screenX: 160, screenY: 300 }));
+    vi.advanceTimersByTime(0);
 
     const singleClicks = postSpy.mock.calls
       .map((call: unknown[]) => call[0] as { type: string; screenX?: number })
       .filter((message: { type: string }) => message.type === 'iframe-single-click');
     expect(singleClicks).toEqual([expect.objectContaining({ screenX: 160 })]);
+  });
+
+  test('tracks the raw touch lifetime independently of app interceptor ownership', async () => {
+    const { handleTouchStart, handleTouchEnd, isLayeredTurnTouchActive } = await importHandlers();
+    const point = touchPoint(200, 300);
+
+    expect(isLayeredTurnTouchActive('book-1')).toBe(false);
+    handleTouchStart('book-1', touchEvent([point]));
+    expect(isLayeredTurnTouchActive('book-1')).toBe(true);
+    handleTouchEnd('book-1', touchEvent([], [point]));
+    expect(isLayeredTurnTouchActive('book-1')).toBe(false);
   });
 
   test('a swipe suppresses its synthesized click', async () => {
@@ -345,6 +362,63 @@ describe('iframeEventHandlers touch forwarding', () => {
     handleMouseup('book-1', mouseEvent({ screenX: 120, screenY: 300 }));
     handleClick('book-1', { current: false }, false, mouseEvent({ screenX: 120, screenY: 300 }));
     vi.advanceTimersByTime(300);
+
+    expect(postedTypes(postSpy)).not.toContain('iframe-single-click');
+  });
+
+  test('a layered turn claimed below 15px suppresses its synthesized click', async () => {
+    vi.useFakeTimers();
+    const {
+      handleClick,
+      handleMousedown,
+      handleMouseup,
+      handleTouchStart,
+      handleTouchMove,
+      handleTouchEnd,
+      setLayeredTurnTouchClaimed,
+    } = await importHandlers();
+    const start = touchPoint(200, 300);
+    const end = touchPoint(194, 300);
+
+    handleTouchStart('book-1', touchEvent([start]));
+    handleTouchMove('book-1', touchEvent([end]));
+    setLayeredTurnTouchClaimed('book-1', true);
+    const touchEnd = touchEvent([], [end]);
+    handleTouchEnd('book-1', touchEnd);
+    handleMousedown('book-1', mouseEvent({ screenX: 194, screenY: 300 }));
+    handleMouseup('book-1', mouseEvent({ screenX: 194, screenY: 300 }));
+    const click = mouseEvent({ screenX: 194, screenY: 300 });
+    handleClick('book-1', { current: false }, false, click);
+    vi.advanceTimersByTime(300);
+
+    expect(postedTypes(postSpy)).not.toContain('iframe-single-click');
+    expect(touchEnd.preventDefault).toHaveBeenCalled();
+    expect(click.preventDefault).toHaveBeenCalled();
+    expect(click.stopImmediatePropagation).toHaveBeenCalled();
+  });
+
+  test('a native layered claim arriving after touchend still suppresses its click', async () => {
+    vi.useFakeTimers();
+    const {
+      handleClick,
+      handleMousedown,
+      handleMouseup,
+      handleTouchStart,
+      handleTouchMove,
+      handleTouchEnd,
+      setLayeredTurnTouchClaimed,
+    } = await importHandlers();
+    const start = touchPoint(200, 300);
+    const end = touchPoint(194, 300);
+
+    handleTouchStart('book-1', touchEvent([start]));
+    handleTouchMove('book-1', touchEvent([end]));
+    handleTouchEnd('book-1', touchEvent([], [end]));
+    handleMousedown('book-1', mouseEvent({ screenX: 194, screenY: 300 }));
+    handleMouseup('book-1', mouseEvent({ screenX: 194, screenY: 300 }));
+    handleClick('book-1', { current: true }, false, mouseEvent({ screenX: 194, screenY: 300 }));
+    setLayeredTurnTouchClaimed('book-1', true);
+    vi.advanceTimersByTime(0);
 
     expect(postedTypes(postSpy)).not.toContain('iframe-single-click');
   });
@@ -399,10 +473,12 @@ describe('iframeEventHandlers touch forwarding', () => {
     handleMousedown('book-1', mouseEvent({ screenX: 210, screenY: 300 }));
     handleMouseup('book-1', mouseEvent({ screenX: 210, screenY: 300 }));
     handleClick('book-1', { current: true }, false, mouseEvent({ screenX: 210, screenY: 300 }));
+    vi.advanceTimersByTime(0);
 
     handleMousedown('book-1', mouseEvent({ screenX: 120, screenY: 300 }));
     handleMouseup('book-1', mouseEvent({ screenX: 120, screenY: 300 }));
     handleClick('book-1', { current: true }, false, mouseEvent({ screenX: 120, screenY: 300 }));
+    vi.advanceTimersByTime(0);
 
     const singleClicks = postSpy.mock.calls
       .map((call: unknown[]) => call[0] as { type: string; screenX?: number })

--- a/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
@@ -33,6 +33,10 @@ describe('CapturedPageTurn (browser)', () => {
 
   const contentRect = () => new DOMRect(10, 20, W, H);
   const slideSheet = () => host.querySelector<HTMLElement>('[data-page-slide-sheet]')!;
+  const waitForPaint = () =>
+    new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
 
   beforeEach(async () => {
     host = document.createElement('div');
@@ -113,20 +117,306 @@ describe('CapturedPageTurn (browser)', () => {
     prepared.dispose();
   });
 
-  it('uses a prepared decoded snapshot without recapturing at turn time', async () => {
+  it('pre-mounts a renderer-ready snapshot without recapturing at turn time', async () => {
     expect(await controller.prepareCapture('slide')).toBe(true);
     expect(capture).toHaveBeenCalledTimes(1);
+    const overlay = host.querySelector<HTMLElement>('[data-captured-turn-prepared="true"]');
+    expect(overlay).not.toBeNull();
+    expect(overlay?.parentElement).toBe(host);
+    expect(overlay?.getAttribute('aria-hidden')).toBe('true');
+    expect(overlay?.style.pointerEvents).toBe('none');
+    expect(Number(overlay?.style.opacity)).toBeGreaterThan(0);
+    expect(Number(overlay?.style.opacity)).toBeLessThan(1);
 
     expect(await controller.turn(true, false, 'slide')).toBe(true);
     expect(capture).toHaveBeenCalledTimes(1);
   });
 
+  it('reuses the same painted surface identity when a drag claims it', async () => {
+    const onCovered = vi.fn<NonNullable<CapturedTurnHost['onCovered']>>();
+    const prepared = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      capture,
+      onCovered,
+      navigate,
+    });
+    expect(await prepared.prepareCapture('slide')).toBe(true);
+    const overlay = host.querySelector<HTMLElement>('[data-captured-turn-prepared="true"]')!;
+    const canvas = overlay.querySelector('canvas');
+    await waitForPaint();
+
+    expect(await prepared.beginDrag(true, false, 'slide')).toBe(true);
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(host.querySelector<HTMLElement>('[data-captured-turn-prepared="false"]')).toBe(overlay);
+    expect(overlay.querySelector('canvas')).toBe(canvas);
+    expect(onCovered).toHaveBeenCalledWith('slide', true);
+
+    await prepared.endDrag(false);
+    prepared.dispose();
+  });
+
+  it('prepares and reuses one non-preserved WebGL surface for Curl', async () => {
+    expect(await controller.prepareCapture('curl')).toBe(true);
+    const overlay = host.querySelector<HTMLElement>('[data-captured-turn-prepared="true"]')!;
+    const canvas = overlay.querySelector('canvas')!;
+    const gl = canvas.getContext('webgl')!;
+    expect(gl.getContextAttributes()?.preserveDrawingBuffer).toBe(false);
+    await waitForPaint();
+
+    expect(await controller.beginDrag(true, false, 'curl')).toBe(true);
+    expect(capture).toHaveBeenCalledOnce();
+    expect(overlay.querySelector('canvas')).toBe(canvas);
+    expect(canvas.getContext('webgl')).toBe(gl);
+
+    await controller.endDrag(false);
+  });
+
+  it('recaptures Curl when an idle prepared WebGL context is no longer usable', async () => {
+    expect(await controller.prepareCapture('curl')).toBe(true);
+    const preparedCanvas = host.querySelector<HTMLCanvasElement>(
+      '[data-captured-turn-prepared="true"] canvas',
+    )!;
+    const gl = preparedCanvas.getContext('webgl')!;
+    const contextLost = vi.spyOn(gl, 'isContextLost').mockReturnValue(true);
+
+    try {
+      expect(await controller.beginDrag(true, false, 'curl')).toBe(true);
+      expect(capture).toHaveBeenCalledTimes(2);
+      const activeCanvas = host.querySelector<HTMLCanvasElement>(
+        '[data-captured-turn-prepared="false"] canvas',
+      );
+      expect(activeCanvas).not.toBe(preparedCanvas);
+      await controller.endDrag(false);
+    } finally {
+      contextLost.mockRestore();
+    }
+  });
+
+  it('recaptures Slide when an idle prepared 2D context was lost', async () => {
+    expect(await controller.prepareCapture('slide')).toBe(true);
+    const preparedCanvas = host.querySelector<HTMLCanvasElement>(
+      '[data-captured-turn-prepared="true"] canvas',
+    )!;
+    preparedCanvas.dispatchEvent(new Event('contextlost', { cancelable: true }));
+
+    expect(await controller.beginDrag(true, false, 'slide')).toBe(true);
+    expect(capture).toHaveBeenCalledTimes(2);
+    const activeCanvas = host.querySelector<HTMLCanvasElement>(
+      '[data-captured-turn-prepared="false"] canvas',
+    );
+    expect(activeCanvas).not.toBe(preparedCanvas);
+
+    await controller.endDrag(false);
+  });
+
+  it('aborts before navigation when a prepared Curl context is lost after claim', async () => {
+    const onCancelled = vi.fn<NonNullable<CapturedTurnHost['onCancelled']>>();
+    const guarded = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      capture,
+      onCancelled,
+      navigate,
+    });
+    expect(await guarded.prepareCapture('curl')).toBe(true);
+    const preparedCanvas = host.querySelector<HTMLCanvasElement>(
+      '[data-captured-turn-prepared="true"] canvas',
+    )!;
+    const gl = preparedCanvas.getContext('webgl')!;
+    const contextLost = vi
+      .spyOn(gl, 'isContextLost')
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true);
+
+    try {
+      await expect(guarded.beginDrag(true, false, 'curl')).rejects.toThrow(
+        'renderer became unavailable',
+      );
+      expect(onCancelled).toHaveBeenCalledWith('curl');
+      expect(navigate).not.toHaveBeenCalled();
+      expect(host.querySelector('[data-captured-turn-prepared]')).toBeNull();
+    } finally {
+      contextLost.mockRestore();
+      guarded.dispose();
+    }
+  });
+
+  it('does not report a prepared surface as painted before its two RAFs complete', async () => {
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const onCovered = vi.fn<NonNullable<CapturedTurnHost['onCovered']>>();
+    const prepared = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      capture,
+      onCovered,
+      navigate,
+    });
+    try {
+      expect(await prepared.prepareCapture('slide')).toBe(true);
+      expect(frames).toHaveLength(1);
+
+      expect(await prepared.beginDrag(true, false, 'slide')).toBe(true);
+      expect(onCovered).toHaveBeenCalledWith('slide', false);
+    } finally {
+      prepared.dispose();
+      raf.mockRestore();
+    }
+  });
+
   it('falls back to a live capture after the prepared snapshot is invalidated', async () => {
     expect(await controller.prepareCapture('slide')).toBe(true);
+    const oldOverlay = host.querySelector<HTMLElement>('[data-captured-turn-prepared="true"]')!;
     controller.invalidatePreparedCapture();
+    expect(oldOverlay.isConnected).toBe(false);
+    expect(host.querySelector('[data-captured-turn-prepared]')).toBeNull();
 
     expect(await controller.turn(true, false, 'slide')).toBe(true);
     expect(capture).toHaveBeenCalledTimes(2);
+  });
+
+  it('never mounts a prepared surface that was invalidated while capture was in flight', async () => {
+    const png = await makePngBuffer();
+    let resolveCapture!: (image: ArrayBuffer) => void;
+    capture.mockImplementationOnce(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveCapture = resolve;
+        }),
+    );
+
+    const warming = controller.prepareCapture('slide');
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledOnce());
+    controller.invalidatePreparedCapture();
+    resolveCapture(png);
+
+    expect(await warming).toBe(false);
+    expect(host.querySelector('[data-captured-turn-prepared]')).toBeNull();
+  });
+
+  it('cancels only an in-flight warm-up without dropping a completed clean surface', async () => {
+    expect(await controller.prepareCapture('slide')).toBe(true);
+    const cleanOverlay = host.querySelector<HTMLElement>('[data-captured-turn-prepared="true"]')!;
+
+    controller.invalidatePendingPreparedCapture();
+
+    expect(cleanOverlay.isConnected).toBe(true);
+    expect(await controller.beginDrag(true, false, 'slide')).toBe(true);
+    expect(capture).toHaveBeenCalledOnce();
+    await controller.endDrag(false);
+  });
+
+  it('discards an in-flight warm-up after a transient overlay invalidation', async () => {
+    const png = await makePngBuffer();
+    let resolveCapture!: (image: ArrayBuffer) => void;
+    capture.mockImplementationOnce(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveCapture = resolve;
+        }),
+    );
+
+    const warming = controller.prepareCapture('slide');
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledOnce());
+    controller.invalidatePendingPreparedCapture();
+    resolveCapture(png);
+
+    expect(await warming).toBe(false);
+    expect(host.querySelector('[data-captured-turn-prepared]')).toBeNull();
+  });
+
+  it('does not abort a cold turn when only warm-up generation changes', async () => {
+    const png = await makePngBuffer();
+    let resolveCapture!: (image: ArrayBuffer) => void;
+    capture.mockImplementationOnce(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveCapture = resolve;
+        }),
+    );
+
+    const beginning = controller.beginDrag(true, false, 'slide');
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledOnce());
+    controller.invalidatePendingPreparedCapture();
+    resolveCapture(png);
+
+    expect(await beginning).toBe(true);
+    expect(navigate).toHaveBeenCalledOnce();
+    await controller.endDrag(false);
+  });
+
+  it('restores transient host chrome before revealing or navigating', async () => {
+    const order: string[] = [];
+    const filteredCapture = vi.fn<CapturedTurnHost['capture']>(async (rect) => {
+      order.push('capture');
+      return capture(rect);
+    });
+    const filteredNavigate = vi.fn<CapturedTurnHost['navigate']>(async () => {
+      order.push('navigate');
+    });
+    const filtered = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      preparePixelCapture: () => {
+        order.push('filter');
+        return () => {
+          order.push('restore');
+        };
+      },
+      capture: filteredCapture,
+      navigate: filteredNavigate,
+    });
+
+    expect(await filtered.beginDrag(true, false, 'slide')).toBe(true);
+    expect(order).toEqual(['filter', 'capture', 'restore', 'navigate']);
+    await filtered.endDrag(false);
+    filtered.dispose();
+  });
+
+  it('does not mount or navigate when a blocking overlay opens during a cold capture', async () => {
+    const png = await makePngBuffer();
+    let captureAllowed = true;
+    let resolveCapture!: (image: ArrayBuffer) => void;
+    const deferredCapture = vi.fn<CapturedTurnHost['capture']>(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveCapture = resolve;
+        }),
+    );
+    const guarded = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      capture: deferredCapture,
+      isCaptureAllowed: () => captureAllowed,
+      navigate,
+    });
+
+    const beginning = guarded.beginDrag(true, false, 'slide');
+    await vi.waitFor(() => expect(deferredCapture).toHaveBeenCalledOnce());
+    captureAllowed = false;
+    guarded.invalidatePreparedCapture();
+    resolveCapture(png);
+
+    expect(await beginning).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
+    expect(host.querySelector('[data-captured-turn-prepared]')).toBeNull();
+    guarded.dispose();
+  });
+
+  it('does not reuse a prepared renderer for a different turn style', async () => {
+    expect(await controller.prepareCapture('slide')).toBe(true);
+    const slideOverlay = host.querySelector<HTMLElement>('[data-captured-turn-prepared="true"]')!;
+
+    expect(await controller.beginDrag(true, false, 'curl')).toBe(true);
+    expect(slideOverlay.isConnected).toBe(false);
+    expect(capture).toHaveBeenCalledTimes(2);
+    expect(host.querySelector('canvas')?.getContext('webgl')).not.toBeNull();
+
+    await controller.endDrag(false);
   });
 
   it('lets a turn reuse a matching warm-up already in flight', async () => {
@@ -147,6 +437,509 @@ describe('CapturedPageTurn (browser)', () => {
     expect(await warming).toBe(true);
     expect(await turning).toBe(true);
     expect(capture).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a late mismatched warm-up replace the active turn surface', async () => {
+    const png = await makePngBuffer();
+    let resolveWarmCapture!: (image: ArrayBuffer) => void;
+    capture.mockImplementationOnce(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveWarmCapture = resolve;
+        }),
+    );
+
+    const warming = controller.prepareCapture('slide');
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledOnce());
+
+    const beginning = controller.beginDrag(true, false, 'curl');
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledTimes(2));
+    expect(await beginning).toBe(true);
+    expect(host.querySelectorAll('[data-captured-turn-prepared]')).toHaveLength(1);
+    expect(host.querySelector('[data-captured-turn-prepared="true"]')).toBeNull();
+    expect(host.querySelector('canvas')?.getContext('webgl')).not.toBeNull();
+
+    resolveWarmCapture(png);
+    expect(await warming).toBe(false);
+    expect(host.querySelectorAll('[data-captured-turn-prepared]')).toHaveLength(1);
+    expect(host.querySelector('[data-captured-turn-prepared="true"]')).toBeNull();
+
+    await controller.endDrag(false);
+  });
+
+  it('recaptures once when the reader geometry changes during a cold capture', async () => {
+    const png = await makePngBuffer();
+    let rect = new DOMRect(10, 20, W, H);
+    let resolveFirstCapture!: (image: ArrayBuffer) => void;
+    capture.mockImplementationOnce(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveFirstCapture = resolve;
+        }),
+    );
+    const resizing = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: () => rect,
+      capture,
+      navigate,
+    });
+
+    const beginning = resizing.beginDrag(true, false, 'slide');
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledOnce());
+    rect = new DOMRect(30, 40, 280, 200);
+    // The real ResizeObserver invalidates the in-flight generation together
+    // with updating the target rect. The retry must use the new generation.
+    resizing.invalidatePreparedCapture();
+    resolveFirstCapture(png);
+
+    expect(await beginning).toBe(true);
+    expect(capture).toHaveBeenNthCalledWith(2, { x: 30, y: 40, width: 280, height: 200 });
+    const overlay = host.querySelector<HTMLElement>('[data-captured-turn-prepared="false"]')!;
+    expect(overlay.style.left).toBe('30px');
+    expect(overlay.style.top).toBe('40px');
+    expect(overlay.style.width).toBe('280px');
+    expect(overlay.style.height).toBe('200px');
+
+    await resizing.endDrag(false);
+    resizing.dispose();
+  });
+
+  it('does not store an idle surface after its host provider is replaced', async () => {
+    const png = await makePngBuffer();
+    let currentHost: HTMLElement | null = host;
+    let resolveCapture!: (image: ArrayBuffer) => void;
+    const deferredCapture = vi.fn<CapturedTurnHost['capture']>(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveCapture = resolve;
+        }),
+    );
+    const replacing = new CapturedPageTurn({
+      getHostElement: () => currentHost,
+      getContentRect: contentRect,
+      capture: deferredCapture,
+      navigate,
+    });
+
+    const warming = replacing.prepareCapture('slide');
+    await vi.waitFor(() => expect(deferredCapture).toHaveBeenCalledOnce());
+    // The stale host remains connected while React has already stopped
+    // returning it for this reader cell.
+    currentHost = null;
+    resolveCapture(png);
+
+    expect(await warming).toBe(false);
+    expect(host.querySelector('[data-captured-turn-prepared]')).toBeNull();
+    replacing.dispose();
+  });
+
+  it('aborts safely when geometry changes again during the one cold-capture retry', async () => {
+    const png = await makePngBuffer();
+    let rect = new DOMRect(10, 20, W, H);
+    const captureResolvers: ((image: ArrayBuffer) => void)[] = [];
+    capture.mockImplementation(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          captureResolvers.push(resolve);
+        }),
+    );
+    const resizing = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: () => rect,
+      capture,
+      navigate,
+    });
+
+    const beginning = resizing.beginDrag(true, false, 'slide');
+    await vi.waitFor(() => expect(captureResolvers).toHaveLength(1));
+    rect = new DOMRect(20, 30, 300, 220);
+    captureResolvers[0]!(png);
+    await vi.waitFor(() => expect(captureResolvers).toHaveLength(2));
+    rect = new DOMRect(30, 40, 280, 200);
+    captureResolvers[1]!(png);
+
+    expect(await beginning).toBe(false);
+    expect(capture).toHaveBeenCalledTimes(2);
+    expect(navigate).not.toHaveBeenCalled();
+    expect(host.querySelector('[data-captured-turn-prepared]')).toBeNull();
+    resizing.dispose();
+  });
+
+  it('disposes a cold surface without navigating when its capture target disappears', async () => {
+    const png = await makePngBuffer();
+    let currentHost: HTMLElement | null = host;
+    let resolveCapture!: (image: ArrayBuffer) => void;
+    const disappearingCapture = vi.fn<CapturedTurnHost['capture']>(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveCapture = resolve;
+        }),
+    );
+    const disappearing = new CapturedPageTurn({
+      getHostElement: () => currentHost,
+      getContentRect: contentRect,
+      capture: disappearingCapture,
+      navigate,
+    });
+
+    const beginning = disappearing.beginDrag(true, false, 'slide');
+    await vi.waitFor(() => expect(disappearingCapture).toHaveBeenCalledOnce());
+    // The old element can remain connected briefly after the BookCell stops
+    // owning it, so isConnected alone is not a sufficient lifecycle check.
+    currentHost = null;
+    resolveCapture(png);
+
+    expect(await beginning).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
+    expect(host.querySelector('[data-captured-turn-prepared]')).toBeNull();
+    disappearing.dispose();
+  });
+
+  it('serializes speculative idle preparation across reader cells', async () => {
+    const png = await makePngBuffer();
+    let resolveCapture!: (image: ArrayBuffer) => void;
+    capture.mockImplementationOnce(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveCapture = resolve;
+        }),
+    );
+    const warming = controller.prepareCapture('slide');
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledOnce());
+
+    const otherHost = document.createElement('div');
+    document.body.appendChild(otherHost);
+    const otherCapture = vi
+      .fn<CapturedTurnHost['capture']>()
+      .mockResolvedValue(await makePngBuffer());
+    const other = new CapturedPageTurn({
+      getHostElement: () => otherHost,
+      getContentRect: contentRect,
+      capture: otherCapture,
+      navigate,
+    });
+    try {
+      expect(await other.prepareCapture('slide')).toBe(false);
+      expect(otherCapture).not.toHaveBeenCalled();
+
+      resolveCapture(png);
+      expect(await warming).toBe(true);
+    } finally {
+      other.dispose();
+      otherHost.remove();
+    }
+  });
+
+  it('coalesces same-controller replacements queued behind a mismatched warm-up', async () => {
+    const png = await makePngBuffer();
+    const resolvers: Array<(image: ArrayBuffer) => void> = [];
+    capture.mockImplementation(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+
+    const original = controller.prepareCapture('slide');
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledOnce());
+
+    const replacementA = controller.prepareCapture('curl');
+    const replacementB = controller.prepareCapture('curl');
+    resolvers[0]!(png);
+
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledTimes(2));
+    // Both waiters must join the one Curl replacement. The old implementation
+    // let each waiter allocate and race its own full-screen renderer.
+    await Promise.resolve();
+    expect(capture).toHaveBeenCalledTimes(2);
+
+    resolvers[1]!(png);
+    await expect(original).resolves.toBe(true);
+    await expect(replacementA).resolves.toBe(true);
+    await expect(replacementB).resolves.toBe(true);
+    expect(host.querySelectorAll('[data-captured-turn-prepared="true"]')).toHaveLength(1);
+  });
+
+  it('releases global preparation ownership immediately when disposed', async () => {
+    let resolveCapture!: (image: ArrayBuffer) => void;
+    capture.mockImplementationOnce(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveCapture = resolve;
+        }),
+    );
+    const warming = controller.prepareCapture('slide');
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledOnce());
+    controller.dispose();
+
+    const otherHost = document.createElement('div');
+    document.body.appendChild(otherHost);
+    const otherCapture = vi
+      .fn<CapturedTurnHost['capture']>()
+      .mockResolvedValue(await makePngBuffer());
+    const other = new CapturedPageTurn({
+      getHostElement: () => otherHost,
+      getContentRect: contentRect,
+      capture: otherCapture,
+      navigate,
+    });
+    try {
+      expect(await other.prepareCapture('slide')).toBe(true);
+      expect(otherCapture).toHaveBeenCalledOnce();
+
+      resolveCapture(await makePngBuffer());
+      expect(await warming).toBe(false);
+    } finally {
+      other.dispose();
+      otherHost.remove();
+    }
+  });
+
+  it('blocks another cell from idle-preparing while a turn surface is active', async () => {
+    expect(await controller.beginDrag(true, false, 'slide')).toBe(true);
+
+    const otherHost = document.createElement('div');
+    document.body.appendChild(otherHost);
+    const otherCapture = vi
+      .fn<CapturedTurnHost['capture']>()
+      .mockResolvedValue(await makePngBuffer());
+    const other = new CapturedPageTurn({
+      getHostElement: () => otherHost,
+      getContentRect: contentRect,
+      capture: otherCapture,
+      navigate,
+    });
+    try {
+      expect(await other.prepareCapture('slide')).toBe(false);
+      expect(otherCapture).not.toHaveBeenCalled();
+
+      await controller.endDrag(false);
+      expect(await other.prepareCapture('slide')).toBe(true);
+      expect(otherCapture).toHaveBeenCalledOnce();
+    } finally {
+      other.dispose();
+      otherHost.remove();
+    }
+  });
+
+  it('discards a speculative surface that finishes after another turn becomes active', async () => {
+    const png = await makePngBuffer();
+    let resolveOtherCapture!: (image: ArrayBuffer) => void;
+    const otherHost = document.createElement('div');
+    document.body.appendChild(otherHost);
+    const otherCapture = vi.fn<CapturedTurnHost['capture']>(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveOtherCapture = resolve;
+        }),
+    );
+    const other = new CapturedPageTurn({
+      getHostElement: () => otherHost,
+      getContentRect: contentRect,
+      capture: otherCapture,
+      navigate,
+    });
+    try {
+      const warming = other.prepareCapture('slide');
+      await vi.waitFor(() => expect(otherCapture).toHaveBeenCalledOnce());
+
+      expect(await controller.beginDrag(true, false, 'slide')).toBe(true);
+      resolveOtherCapture(png);
+
+      expect(await warming).toBe(false);
+      expect(otherHost.querySelector('[data-captured-turn-prepared]')).toBeNull();
+      await controller.endDrag(false);
+    } finally {
+      other.dispose();
+      otherHost.remove();
+    }
+  });
+
+  it('discards a released touch warm-up that finishes after another turn becomes active', async () => {
+    const png = await makePngBuffer();
+    let resolveOtherCapture!: (image: ArrayBuffer) => void;
+    const otherHost = document.createElement('div');
+    document.body.appendChild(otherHost);
+    const otherCapture = vi.fn<CapturedTurnHost['capture']>(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveOtherCapture = resolve;
+        }),
+    );
+    const other = new CapturedPageTurn({
+      getHostElement: () => otherHost,
+      getContentRect: contentRect,
+      capture: otherCapture,
+      navigate,
+    });
+    try {
+      other.retainPreparedCapture();
+      const warming = other.prepareCapture('slide');
+      await vi.waitFor(() => expect(otherCapture).toHaveBeenCalledOnce());
+      other.releasePreparedCapture();
+
+      expect(await controller.beginDrag(true, false, 'slide')).toBe(true);
+      resolveOtherCapture(png);
+
+      expect(await warming).toBe(false);
+      expect(otherHost.querySelector('[data-captured-turn-prepared]')).toBeNull();
+      await controller.endDrag(false);
+    } finally {
+      other.dispose();
+      otherHost.remove();
+    }
+  });
+
+  it('evicts another cell idle surface before a programmatic cold turn', async () => {
+    const otherHost = document.createElement('div');
+    document.body.appendChild(otherHost);
+    const otherCapture = vi
+      .fn<CapturedTurnHost['capture']>()
+      .mockResolvedValue(await makePngBuffer());
+    const other = new CapturedPageTurn({
+      getHostElement: () => otherHost,
+      getContentRect: contentRect,
+      capture: otherCapture,
+      navigate,
+    });
+    try {
+      expect(await other.prepareCapture('slide')).toBe(true);
+      const idleOverlay = otherHost.querySelector<HTMLElement>(
+        '[data-captured-turn-prepared="true"]',
+      )!;
+
+      expect(await controller.turn(true, false, 'slide')).toBe(true);
+
+      expect(idleOverlay.isConnected).toBe(false);
+      expect(capture).toHaveBeenCalledOnce();
+    } finally {
+      other.dispose();
+      otherHost.remove();
+    }
+  });
+
+  it('does not allocate a second active surface in another reader cell', async () => {
+    expect(await controller.beginDrag(true, false, 'slide')).toBe(true);
+    const otherHost = document.createElement('div');
+    document.body.appendChild(otherHost);
+    const otherCapture = vi
+      .fn<CapturedTurnHost['capture']>()
+      .mockResolvedValue(await makePngBuffer());
+    const otherNavigate = vi.fn<CapturedTurnHost['navigate']>().mockResolvedValue(undefined);
+    const other = new CapturedPageTurn({
+      getHostElement: () => otherHost,
+      getContentRect: contentRect,
+      capture: otherCapture,
+      navigate: otherNavigate,
+    });
+    try {
+      expect(await other.turn(true, false, 'slide')).toBe(false);
+      expect(otherCapture).not.toHaveBeenCalled();
+      expect(otherNavigate).not.toHaveBeenCalled();
+      expect(otherHost.querySelector('[data-captured-turn-prepared]')).toBeNull();
+    } finally {
+      await controller.endDrag(false);
+      other.dispose();
+      otherHost.remove();
+    }
+  });
+
+  it('retains a touched surface against the one-surface global eviction budget', async () => {
+    expect(await controller.prepareCapture('slide')).toBe(true);
+    const retainedOverlay = host.querySelector<HTMLElement>(
+      '[data-captured-turn-prepared="true"]',
+    )!;
+    controller.retainPreparedCapture();
+
+    const otherHost = document.createElement('div');
+    document.body.appendChild(otherHost);
+    const otherCapture = vi
+      .fn<CapturedTurnHost['capture']>()
+      .mockResolvedValue(await makePngBuffer());
+    const other = new CapturedPageTurn({
+      getHostElement: () => otherHost,
+      getContentRect: contentRect,
+      capture: otherCapture,
+      navigate,
+    });
+    try {
+      expect(await other.prepareCapture('slide')).toBe(false);
+      expect(otherCapture).not.toHaveBeenCalled();
+      expect(retainedOverlay.isConnected).toBe(true);
+
+      controller.releasePreparedCapture();
+      // A real touch on the other cell may take over the idle budget; another
+      // speculative timer stays serialized behind the existing warm surface.
+      other.retainPreparedCapture();
+      expect(await other.prepareCapture('slide')).toBe(true);
+      expect(otherCapture).toHaveBeenCalledOnce();
+      expect(retainedOverlay.isConnected).toBe(false);
+      other.releasePreparedCapture();
+    } finally {
+      other.dispose();
+      otherHost.remove();
+    }
+  });
+
+  it('keeps a touch lease while replacing a mismatched prepared surface', async () => {
+    expect(await controller.prepareCapture('slide')).toBe(true);
+    controller.retainPreparedCapture();
+
+    const png = await makePngBuffer();
+    let resolveReplacement!: (image: ArrayBuffer) => void;
+    capture.mockImplementationOnce(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveReplacement = resolve;
+        }),
+    );
+    const replacement = controller.prepareCapture('curl');
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledTimes(2));
+
+    const otherHost = document.createElement('div');
+    document.body.appendChild(otherHost);
+    const otherCapture = vi
+      .fn<CapturedTurnHost['capture']>()
+      .mockResolvedValue(await makePngBuffer());
+    const other = new CapturedPageTurn({
+      getHostElement: () => otherHost,
+      getContentRect: contentRect,
+      capture: otherCapture,
+      navigate,
+    });
+    try {
+      expect(await other.prepareCapture('slide')).toBe(false);
+      expect(otherCapture).not.toHaveBeenCalled();
+
+      resolveReplacement(png);
+      expect(await replacement).toBe(true);
+    } finally {
+      controller.releasePreparedCapture();
+      other.dispose();
+      otherHost.remove();
+    }
+  });
+
+  it('falls back cleanly after a speculative warm-up failure', async () => {
+    capture.mockRejectedValueOnce(new Error('warm-up failed'));
+
+    expect(await controller.prepareCapture('slide')).toBe(false);
+    expect(host.querySelector('[data-captured-turn-prepared]')).toBeNull();
+
+    expect(await controller.beginDrag(true, false, 'slide')).toBe(true);
+    expect(capture).toHaveBeenCalledTimes(2);
+    await controller.endDrag(false);
+  });
+
+  it('disposes a completed prepared surface synchronously', async () => {
+    expect(await controller.prepareCapture('slide')).toBe(true);
+    const overlay = host.querySelector<HTMLElement>('[data-captured-turn-prepared="true"]')!;
+
+    controller.dispose();
+
+    expect(overlay.isConnected).toBe(false);
+    await expect(controller.prepareCapture('slide')).resolves.toBe(false);
+    await expect(controller.beginDrag(true, false, 'slide')).resolves.toBe(false);
   });
 
   it('mounts the overlay canvas over the content box while animating', async () => {
@@ -270,6 +1063,22 @@ describe('CapturedPageTurn (browser)', () => {
     await expect(controller.turn(true, false)).rejects.toThrow('no capture');
     expect(navigate).not.toHaveBeenCalled();
     expect(host.querySelector('canvas')).toBeNull();
+  });
+
+  it('restores filtered host pixels when native capture rejects', async () => {
+    const restorePixels = vi.fn();
+    const failing = new CapturedPageTurn({
+      getHostElement: () => host,
+      getContentRect: contentRect,
+      capture: vi.fn().mockRejectedValue(new Error('no capture')),
+      preparePixelCapture: () => restorePixels,
+      navigate,
+    });
+
+    await expect(failing.turn(true, false, 'slide')).rejects.toThrow('no capture');
+    expect(restorePixels).toHaveBeenCalledOnce();
+    expect(navigate).not.toHaveBeenCalled();
+    failing.dispose();
   });
 
   it('restores host state and removes the overlay when instant navigation fails', async () => {

--- a/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/captured-turn.browser.test.ts
@@ -32,6 +32,7 @@ describe('CapturedPageTurn (browser)', () => {
   let controller: CapturedPageTurn;
 
   const contentRect = () => new DOMRect(10, 20, W, H);
+  const slideSheet = () => host.querySelector<HTMLElement>('[data-page-slide-sheet]')!;
 
   beforeEach(async () => {
     host = document.createElement('div');
@@ -112,6 +113,42 @@ describe('CapturedPageTurn (browser)', () => {
     prepared.dispose();
   });
 
+  it('uses a prepared decoded snapshot without recapturing at turn time', async () => {
+    expect(await controller.prepareCapture('slide')).toBe(true);
+    expect(capture).toHaveBeenCalledTimes(1);
+
+    expect(await controller.turn(true, false, 'slide')).toBe(true);
+    expect(capture).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a live capture after the prepared snapshot is invalidated', async () => {
+    expect(await controller.prepareCapture('slide')).toBe(true);
+    controller.invalidatePreparedCapture();
+
+    expect(await controller.turn(true, false, 'slide')).toBe(true);
+    expect(capture).toHaveBeenCalledTimes(2);
+  });
+
+  it('lets a turn reuse a matching warm-up already in flight', async () => {
+    const png = await makePngBuffer();
+    let resolveCapture!: (image: ArrayBuffer) => void;
+    capture.mockImplementationOnce(
+      () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveCapture = resolve;
+        }),
+    );
+
+    const warming = controller.prepareCapture('slide');
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledOnce());
+    const turning = controller.turn(true, false, 'slide');
+    resolveCapture(png);
+
+    expect(await warming).toBe(true);
+    expect(await turning).toBe(true);
+    expect(capture).toHaveBeenCalledTimes(1);
+  });
+
   it('mounts the overlay canvas over the content box while animating', async () => {
     // Slow animation so the overlay is reliably observable mid-turn.
     const slow = new CapturedPageTurn(
@@ -152,7 +189,7 @@ describe('CapturedPageTurn (browser)', () => {
     // theme paper — the hardcoded whitened back would read near-white here.
     const canvas = host.querySelector('canvas')!;
     const gl = canvas.getContext('webgl')!;
-    const dpr = window.devicePixelRatio;
+    const dpr = canvas.width / W;
     const px = new Uint8Array(4);
     gl.readPixels(
       Math.round(100 * dpr),
@@ -194,10 +231,14 @@ describe('CapturedPageTurn (browser)', () => {
       expect(host.querySelector('canvas')).not.toBeNull();
     });
     const canvas = host.querySelector('canvas')!;
+    const sheet = slideSheet();
     // The overlay clips the exiting page to the content box like the VT slide.
-    expect(canvas.parentElement!.style.overflow).toBe('hidden');
+    expect(sheet.parentElement!.style.overflow).toBe('hidden');
+    expect(sheet.style.willChange).toBe('transform');
+    expect(canvas.style.boxShadow).toBe('');
+    expect(host.querySelector<HTMLElement>('[data-page-slide-shadow]')?.style.left).toBe('100%');
     await vi.waitFor(() => {
-      const shift = new DOMMatrixReadOnly(getComputedStyle(canvas).transform).e;
+      const shift = new DOMMatrixReadOnly(getComputedStyle(sheet).transform).e;
       expect(shift).toBeLessThan(0);
     });
     slow.dispose();
@@ -214,9 +255,10 @@ describe('CapturedPageTurn (browser)', () => {
     await vi.waitFor(() => {
       expect(host.querySelector('canvas')).not.toBeNull();
     });
-    const canvas = host.querySelector('canvas')!;
+    const sheet = slideSheet();
+    expect(host.querySelector<HTMLElement>('[data-page-slide-shadow]')?.style.left).toBe('-28px');
     await vi.waitFor(() => {
-      const shift = new DOMMatrixReadOnly(getComputedStyle(canvas).transform).e;
+      const shift = new DOMMatrixReadOnly(getComputedStyle(sheet).transform).e;
       expect(shift).toBeGreaterThan(0);
     });
     slow.dispose();
@@ -292,6 +334,17 @@ describe('CapturedPageTurn (browser)', () => {
     expect(host.querySelector('canvas')).toBeNull();
   });
 
+  it('does not queue a finger drag behind a running programmatic turn', async () => {
+    const turning = controller.turn(true, false);
+
+    await expect(controller.beginDrag(true, false)).resolves.toBe(false);
+    await turning;
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith(true);
+    expect(host.querySelector('canvas')).toBeNull();
+  });
+
   it('runs sequential programmatic turns once the previous one settles', async () => {
     expect(await controller.turn(true, false)).toBe(true);
     expect(await controller.turn(true, false)).toBe(true);
@@ -320,6 +373,9 @@ describe('CapturedPageTurn (browser)', () => {
       expect(cancelledStyle).toBe(style);
       expect(navigate).toHaveBeenNthCalledWith(2, false);
       expect(host.querySelector('canvas')).not.toBeNull();
+      if (cancelledStyle === 'slide') {
+        expect(new DOMMatrixReadOnly(getComputedStyle(slideSheet()).transform).e).toBeCloseTo(0, 5);
+      }
     });
     const cancellable = new CapturedPageTurn({
       getHostElement: () => host,
@@ -341,12 +397,134 @@ describe('CapturedPageTurn (browser)', () => {
   it('scrubs a slide drag and cleans up on commit', async () => {
     const began = await controller.beginDrag(true, false, 'slide');
     expect(began).toBe(true);
-    const canvas = host.querySelector('canvas')!;
+    const sheet = slideSheet();
     controller.moveDrag(0.5, 0.5);
-    expect(new DOMMatrixReadOnly(getComputedStyle(canvas).transform).e).toBeCloseTo(-W / 2, 0);
+    expect(new DOMMatrixReadOnly(getComputedStyle(sheet).transform).e).toBeCloseTo(-W / 2, 0);
     await controller.endDrag(true);
     expect(navigate).toHaveBeenCalledTimes(1);
     expect(host.querySelector('canvas')).toBeNull();
+  });
+
+  it('keeps Curl settle on the requestAnimationFrame path', async () => {
+    const paced = new CapturedPageTurn(
+      { getHostElement: () => host, getContentRect: contentRect, capture, navigate },
+      { duration: 1000 },
+    );
+    expect(await paced.beginDrag(true, false, 'curl')).toBe(true);
+    paced.moveDrag(0.5, 0.5);
+
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const now = vi.spyOn(performance, 'now').mockReturnValue(0);
+    try {
+      const ending = paced.endDrag(true, 1.5);
+      await vi.waitFor(() => expect(frames).toHaveLength(1));
+
+      const expectedDuration = 500 / 1.5;
+      frames.shift()!(expectedDuration - 1);
+      expect(paced.active).toBe(true);
+      expect(frames).toHaveLength(1);
+
+      frames.shift()!(expectedDuration);
+      await ending;
+      expect(paced.active).toBe(false);
+    } finally {
+      paced.dispose();
+      raf.mockRestore();
+      now.mockRestore();
+    }
+  });
+
+  it.each([
+    { progress: 0.5, velocity: 1.5, commit: true, expectedDuration: 250 },
+    { progress: 0.5, velocity: 0.6, commit: true, expectedDuration: 500 / 1.5 },
+    { progress: 0.8, velocity: 1.5, commit: true, expectedDuration: 100 },
+    {
+      progress: 0.95,
+      velocity: 1.5,
+      commit: true,
+      expectedDuration: 1000 * Math.abs(1 - 0.95),
+    },
+    { progress: 0.5, velocity: -1.5, commit: true, expectedDuration: 500 },
+    { progress: 0.5, velocity: -1.5, commit: false, expectedDuration: 250 },
+  ] as const)('settles Slide from $progress toward commit=$commit on WAAPI at the bounded momentum duration', async ({
+    progress,
+    velocity,
+    commit,
+    expectedDuration,
+  }) => {
+    const paced = new CapturedPageTurn(
+      { getHostElement: () => host, getContentRect: contentRect, capture, navigate },
+      { duration: 1000 },
+    );
+    expect(await paced.beginDrag(true, false, 'slide')).toBe(true);
+    paced.moveDrag(progress, 0.5);
+    const sheet = slideSheet();
+    const nativeAnimate = sheet.animate.bind(sheet);
+    const animate = vi.spyOn(sheet, 'animate').mockImplementation((keyframes, options) => {
+      const animation = nativeAnimate(keyframes, options);
+      animation.pause();
+      return animation;
+    });
+    const raf = vi.spyOn(window, 'requestAnimationFrame');
+    try {
+      const ending = paced.endDrag(commit, velocity);
+      await vi.waitFor(() => expect(animate).toHaveBeenCalledOnce());
+      const animation = animate.mock.results[0]!.value;
+      const effect = animation.effect as KeyframeEffect;
+
+      expect(Number(effect.getTiming().duration)).toBeCloseTo(expectedDuration, 5);
+      expect(effect.getTiming().easing).toBe('linear');
+      const keyframes = effect.getKeyframes();
+      expect(keyframes).toHaveLength(33);
+      expect(keyframes[0]!.offset).toBe(0);
+      expect(keyframes.at(-1)!.offset).toBe(1);
+      expect(raf).not.toHaveBeenCalled();
+
+      animation.finish();
+      await ending;
+      expect(paced.active).toBe(false);
+      if (!commit) expect(navigate).toHaveBeenLastCalledWith(false);
+    } finally {
+      paced.dispose();
+      animate.mockRestore();
+      raf.mockRestore();
+    }
+  });
+
+  it('falls back to requestAnimationFrame when Slide WAAPI is unavailable', async () => {
+    const paced = new CapturedPageTurn(
+      { getHostElement: () => host, getContentRect: contentRect, capture, navigate },
+      { duration: 1000 },
+    );
+    expect(await paced.beginDrag(true, false, 'slide')).toBe(true);
+    paced.moveDrag(0.5, 0.5);
+    const sheet = slideSheet();
+    Object.defineProperty(sheet, 'animate', { value: undefined, configurable: true });
+
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    const now = vi.spyOn(performance, 'now').mockReturnValue(0);
+    try {
+      const ending = paced.endDrag(true);
+      await vi.waitFor(() => expect(frames).toHaveLength(1));
+      frames.shift()!(499);
+      expect(paced.active).toBe(true);
+      frames.shift()!(500);
+      await ending;
+      expect(paced.active).toBe(false);
+    } finally {
+      Reflect.deleteProperty(sheet, 'animate');
+      paced.dispose();
+      raf.mockRestore();
+      now.mockRestore();
+    }
   });
 
   it('commits a drag without a second navigation', async () => {
@@ -451,8 +629,10 @@ describe('CapturedPageTurn (browser)', () => {
     resolveCapture(await makePngBuffer());
 
     await beginning;
-    const canvas = host.querySelector('canvas')!;
-    expect(new DOMMatrixReadOnly(getComputedStyle(canvas).transform).e).toBeCloseTo(-W * 0.75, 0);
+    expect(new DOMMatrixReadOnly(getComputedStyle(slideSheet()).transform).e).toBeCloseTo(
+      -W * 0.75,
+      0,
+    );
 
     // Stop the deliberately slow settle and let its promise drain.
     rapid.dispose();
@@ -492,12 +672,12 @@ describe('CapturedPageTurn (browser)', () => {
       { duration: 5000 },
     );
     expect(await slow.beginDrag(true, false, 'slide')).toBe(true);
-    const canvas = host.querySelector('canvas')!;
+    const sheet = slideSheet();
     slow.moveDrag(0.25, 0.5);
     const ending = slow.endDrag(true);
 
     slow.moveDrag(0.9, 0.5);
-    expect(new DOMMatrixReadOnly(getComputedStyle(canvas).transform).e).toBeCloseTo(-W * 0.25, 0);
+    expect(new DOMMatrixReadOnly(getComputedStyle(sheet).transform).e).toBeCloseTo(-W * 0.25, 0);
 
     slow.dispose();
     await ending;

--- a/apps/readest-app/src/__tests__/utils/page-curl.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/page-curl.browser.test.ts
@@ -71,6 +71,16 @@ describe('PageCurlRenderer (browser)', () => {
     expect(bottomLeft[1]).toBeLessThan(100);
   });
 
+  it('uses the full device DPR for its backing store', () => {
+    renderer.dispose();
+    renderer = new PageCurlRenderer();
+    renderer.attach(host, W, H, 3);
+
+    const canvas = host.querySelector('canvas')!;
+    expect(canvas.width).toBe(W * 3);
+    expect(canvas.height).toBe(H * 3);
+  });
+
   it('curls the outer half away, folding its whitened back over the spine side', () => {
     renderer.render(0.45, { x: 1, y: 0.5 });
 

--- a/apps/readest-app/src/__tests__/utils/page-slide.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/page-slide.browser.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { PageSlideRenderer } from '@/utils/pageSlide';
+
+describe('PageSlideRenderer (browser)', () => {
+  let host: HTMLDivElement;
+  let renderer: PageSlideRenderer;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    renderer = new PageSlideRenderer();
+    renderer.attach(host, 320, 240, 3);
+  });
+
+  afterEach(() => {
+    renderer.dispose();
+    host.remove();
+  });
+
+  it('uses the device DPR and promotes one moving sheet', () => {
+    const canvas = host.querySelector('canvas')!;
+    const sheet = host.querySelector<HTMLElement>('[data-page-slide-sheet]')!;
+    const shadow = host.querySelector<HTMLElement>('[data-page-slide-shadow]')!;
+
+    expect(canvas.width).toBe(960);
+    expect(canvas.height).toBe(720);
+    expect(canvas.style.width).toBe('320px');
+    expect(canvas.style.height).toBe('240px');
+    expect(canvas.style.boxShadow).toBe('');
+    expect(sheet.style.willChange).toBe('transform');
+    expect(sheet.style.transform).toBe('translate3d(0px, 0px, 0px)');
+    expect(shadow.style.width).toBe('28px');
+  });
+
+  it('moves the sheet and places the narrow shadow on its trailing edge', () => {
+    const sheet = host.querySelector<HTMLElement>('[data-page-slide-sheet]')!;
+    const shadow = host.querySelector<HTMLElement>('[data-page-slide-shadow]')!;
+
+    renderer.render(0.25, undefined, false);
+    expect(sheet.style.transform).toBe('translate3d(-80px, 0px, 0px)');
+    expect(shadow.style.left).toBe('100%');
+    expect(shadow.style.background).toContain('rgba(0, 0, 0, 0.35), transparent');
+
+    renderer.render(0.25, undefined, true);
+    expect(sheet.style.transform).toBe('translate3d(80px, 0px, 0px)');
+    expect(shadow.style.left).toBe('-28px');
+    expect(shadow.style.background).toContain('transparent, rgba(0, 0, 0, 0.35)');
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/page-slide.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/page-slide.browser.test.ts
@@ -46,4 +46,17 @@ describe('PageSlideRenderer (browser)', () => {
     expect(shadow.style.left).toBe('-28px');
     expect(shadow.style.background).toContain('transparent, rgba(0, 0, 0, 0.35)');
   });
+
+  it('becomes permanently unusable after its 2D backing store is lost', () => {
+    const canvas = host.querySelector('canvas')!;
+    const contextLost = new Event('contextlost', { cancelable: true });
+
+    expect(renderer.isUsable()).toBe(true);
+    canvas.dispatchEvent(contextLost);
+
+    expect(contextLost.defaultPrevented).toBe(true);
+    expect(renderer.isUsable()).toBe(false);
+    canvas.dispatchEvent(new Event('contextrestored'));
+    expect(renderer.isUsable()).toBe(false);
+  });
 });

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -54,6 +54,7 @@ import {
   handleMousemove,
   handleAuxclick,
   handleClick,
+  handleClickCapture,
   handleWheel,
   handleTouchStart,
   handleTouchMove,
@@ -427,14 +428,21 @@ const FoliateViewer: React.FC<{
         detail.doc.addEventListener('mouseup', handleMouseup.bind(null, bookKey));
         detail.doc.addEventListener('mousemove', handleMousemove.bind(null, bookKey));
         detail.doc.addEventListener('auxclick', handleAuxclick.bind(null, bookKey));
+        detail.doc.addEventListener('click', handleClickCapture.bind(null, bookKey), {
+          capture: true,
+        });
         detail.doc.addEventListener(
           'click',
           handleClick.bind(null, bookKey, doubleClickDisabled, !!bookData?.isFixedLayout),
         );
         detail.doc.addEventListener('wheel', handleWheel.bind(null, bookKey));
         detail.doc.addEventListener('touchstart', handleTouchStart.bind(null, bookKey));
-        detail.doc.addEventListener('touchmove', handleTouchMove.bind(null, bookKey));
-        detail.doc.addEventListener('touchend', handleTouchEnd.bind(null, bookKey));
+        detail.doc.addEventListener('touchmove', handleTouchMove.bind(null, bookKey), {
+          passive: false,
+        });
+        detail.doc.addEventListener('touchend', handleTouchEnd.bind(null, bookKey), {
+          passive: false,
+        });
         detail.doc.addEventListener('touchcancel', handleTouchCancel.bind(null, bookKey));
         registerBrightnessListeners(detail.doc);
         registerSpeedListeners(detail.doc);

--- a/apps/readest-app/src/app/reader/components/ImageViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/ImageViewer.tsx
@@ -458,6 +458,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
     // collides with the pinch/pan handlers below and freezes the app.
     <div
       ref={containerRef}
+      data-capture-blocking-overlay='true'
       tabIndex={-1}
       role='button'
       aria-label={_('Image viewer')}

--- a/apps/readest-app/src/app/reader/components/TableViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/TableViewer.tsx
@@ -173,6 +173,7 @@ const TableViewer: React.FC<TableViewerProps> = ({ gridInsets, html, isDarkMode,
   return (
     <div
       ref={containerRef}
+      data-capture-blocking-overlay='true'
       tabIndex={-1}
       role='button'
       aria-label={_('Table viewer')}

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -1852,7 +1852,10 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
         </ModalPortal>
       )}
       {importingMrexpt && (
-        <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/30'>
+        <div
+          data-capture-blocking-overlay='true'
+          className='fixed inset-0 z-50 flex items-center justify-center bg-black/30'
+        >
           <div className='modal-box bg-base-100 flex flex-col items-center gap-3 px-8 py-6 shadow-2xl'>
             <svg className='text-primary h-8 w-8 animate-spin' viewBox='0 0 24 24' fill='none'>
               <circle

--- a/apps/readest-app/src/app/reader/components/rsvp/RSVPOverlay.tsx
+++ b/apps/readest-app/src/app/reader/components/rsvp/RSVPOverlay.tsx
@@ -685,6 +685,7 @@ const RSVPOverlay: React.FC<RSVPOverlayProps> = ({
   return (
     <div
       data-testid='rsvp-overlay'
+      data-capture-blocking-overlay='true'
       aria-label={_('Speed Reading')}
       className='fixed inset-0 z-[100] flex select-none flex-col'
       style={{

--- a/apps/readest-app/src/app/reader/hooks/useBrightnessGesture.ts
+++ b/apps/readest-app/src/app/reader/hooks/useBrightnessGesture.ts
@@ -4,10 +4,14 @@ import { useReaderStore } from '@/store/readerStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useDeviceControlStore } from '@/store/deviceStore';
 import { saveSysSettings } from '@/helpers/settings';
+import { setLayeredTurnTouchClaimed } from '@/app/reader/utils/iframeEventHandlers';
 import {
+  BRIGHTNESS_GESTURE_ACTIVATION_PX,
+  BRIGHTNESS_GESTURE_EDGE_RATIO,
   computeBrightness,
   isInLeftEdge,
   shouldActivate,
+  TURN_GESTURE_LEFT_INSET_ATTRIBUTE,
 } from '@/app/reader/utils/brightnessGesture';
 
 const OVERLAY_HIDE_DELAY_MS = 600;
@@ -32,11 +36,13 @@ interface LatestState {
 export const useBrightnessGesture = (bookKey: string) => {
   const { appService, envConfig } = useEnv();
   const { settings } = useSettingsStore();
-  const { getViewSettings } = useReaderStore();
+  const { getView, getViewSettings } = useReaderStore();
   const { getScreenBrightness, setScreenBrightness } = useDeviceControlStore();
 
   const hasScreenBrightness = !!appService?.hasScreenBrightness;
   const viewSettings = getViewSettings(bookKey);
+  const renderer = getView(bookKey)?.renderer;
+  const brightnessGestureEnabled = hasScreenBrightness && settings.swipeBrightnessGesture;
 
   const [overlayVisible, setOverlayVisible] = useState(false);
   const [overlayLevel, setOverlayLevel] = useState(0);
@@ -44,9 +50,22 @@ export const useBrightnessGesture = (bookKey: string) => {
   // Everything the once-attached listener must read at the latest value.
   const latestRef = useRef<LatestState>({ enabled: false, scrolled: false });
   latestRef.current = {
-    enabled: hasScreenBrightness && settings.swipeBrightnessGesture,
+    enabled: brightnessGestureEnabled,
     scrolled: !!viewSettings?.scrolled,
   };
+
+  useEffect(() => {
+    if (!renderer) return;
+    if (brightnessGestureEnabled) {
+      renderer.setAttribute(
+        TURN_GESTURE_LEFT_INSET_ATTRIBUTE,
+        String(BRIGHTNESS_GESTURE_EDGE_RATIO),
+      );
+    } else {
+      renderer.removeAttribute(TURN_GESTURE_LEFT_INSET_ATTRIBUTE);
+    }
+    return () => renderer.removeAttribute(TURN_GESTURE_LEFT_INSET_ATTRIBUTE);
+  }, [renderer, brightnessGestureEnabled]);
 
   // Per-gesture state.
   const armedRef = useRef(false);
@@ -114,13 +133,27 @@ export const useBrightnessGesture = (bookKey: string) => {
     activeRef.current = false;
   }, []);
 
+  const abortGesture = useCallback(() => {
+    cancelRaf();
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+    resetGesture();
+    setOverlayVisible(false);
+  }, [cancelRaf, resetGesture]);
+
   const registerBrightnessListeners = useCallback(
     (doc: Document) => {
       const opts = { capture: true, passive: false } as const;
 
       const onTouchStart = (e: TouchEvent) => {
-        resetGesture();
+        abortGesture();
         if (!latestRef.current.enabled) return;
+        // A second finger permanently yields this sequence to pinch/zoom. In
+        // particular, do not let the first finger keep brightness armed and
+        // steal later moves from the paginator in capture phase.
+        if (e.touches.length !== 1) return;
         const selection = doc.getSelection?.();
         if (selection && !selection.isCollapsed) return; // don't hijack selection
         const t = e.touches[0];
@@ -140,10 +173,25 @@ export const useBrightnessGesture = (bookKey: string) => {
 
       const onTouchMove = (e: TouchEvent) => {
         if (!armedRef.current) return;
+        if (e.touches.length !== 1) {
+          abortGesture();
+          return;
+        }
         const t = e.touches[0];
         if (!t) return;
         const dx = t.screenX - startXRef.current;
         const dy = t.screenY - startYRef.current;
+        // Gesture ownership is one-way. Once the same activation distance is
+        // clearly horizontal, brightness may not claim the sequence later if
+        // the trajectory bends vertically; Slide/Curl can safely own it.
+        if (
+          !activeRef.current &&
+          Math.abs(dx) >= BRIGHTNESS_GESTURE_ACTIVATION_PX &&
+          Math.abs(dx) > Math.abs(dy)
+        ) {
+          resetGesture();
+          return;
+        }
         // Reserve the strip in scrolled mode: stop native scroll from the first
         // move, so there is no scroll-then-freeze jump once brightness activates.
         if (latestRef.current.scrolled) e.preventDefault();
@@ -161,12 +209,19 @@ export const useBrightnessGesture = (bookKey: string) => {
       };
 
       const onTouchEnd = (e: TouchEvent) => {
+        if (e.touches.length > 0) {
+          abortGesture();
+          return;
+        }
         if (!activeRef.current) {
           resetGesture();
           return;
         }
         e.preventDefault();
         e.stopImmediatePropagation();
+        // This capture-phase owner prevents the normal iframe touchend
+        // forwarder from seeing the release, so clear its per-touch state here.
+        setLayeredTurnTouchClaimed(bookKey, false);
         cancelRaf();
         const value = levelRef.current;
         setScreenBrightness(value);
@@ -174,7 +229,10 @@ export const useBrightnessGesture = (bookKey: string) => {
         saveSysSettings(envConfig, 'screenBrightness', Math.round(value * 100));
         saveSysSettings(envConfig, 'autoScreenBrightness', false);
         if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
-        hideTimerRef.current = setTimeout(() => setOverlayVisible(false), OVERLAY_HIDE_DELAY_MS);
+        hideTimerRef.current = setTimeout(() => {
+          hideTimerRef.current = null;
+          setOverlayVisible(false);
+        }, OVERLAY_HIDE_DELAY_MS);
         resetGesture();
       };
 
@@ -183,7 +241,7 @@ export const useBrightnessGesture = (bookKey: string) => {
       doc.addEventListener('touchend', onTouchEnd, opts);
       doc.addEventListener('touchcancel', onTouchEnd, opts);
     },
-    [resetGesture, scheduleBrightness, cancelRaf, setScreenBrightness, envConfig],
+    [abortGesture, resetGesture, scheduleBrightness, cancelRaf, setScreenBrightness, envConfig],
   );
 
   useEffect(() => {

--- a/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
+++ b/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
@@ -6,10 +6,20 @@ import { useBookDataStore } from '@/store/bookDataStore';
 import { useReaderStore } from '@/store/readerStore';
 import { useThemeStore } from '@/store/themeStore';
 import { captureWebviewRegion } from '@/utils/bridge';
-import { isTauriAppPlatform } from '@/services/environment';
+import { getInitializedAppService, isTauriAppPlatform } from '@/services/environment';
 import { detectViewTransitionGroup } from '@/utils/viewTransition';
+import { TURN_GESTURE_LEFT_INSET_ATTRIBUTE } from '../utils/brightnessGesture';
+import { isLayeredTurnTouchActive, setLayeredTurnTouchClaimed } from '../utils/iframeEventHandlers';
 import { CapturedPageTurn, CapturedTurnStyle } from '../utils/capturedTurn';
 import { renderTurnBackdrop } from '../utils/turnBackdrop';
+import {
+  createTurnGestureIntent as createArenaIntent,
+  NATIVE_CAPTURED_TURN_ATTRIBUTE,
+  NATIVE_PROGRAMMATIC_TURN_ATTRIBUTE,
+  shouldClaimTurnGesture as shouldClaimArenaGesture,
+  TURN_EDGE_ZONE_RATIO,
+  type TurnGestureIntent,
+} from '../utils/turnGestureArena';
 import {
   setLayeredTurnGestureActive,
   TOUCH_SWIPE_THRESHOLD_PX,
@@ -27,20 +37,27 @@ let captureBroken = false;
  * null when the paginator's own turns apply. The pipeline needs a native
  * webview snapshot (Tauri only) and only makes sense for animated,
  * paginated, reflowable books. The curl always turns from a capture (a
- * flat snapshot cannot mesh-bend); the slide prefers the View Transitions
- * version and falls back to the captured slide on engines without full
- * support.
+ * flat snapshot cannot mesh-bend). Mobile Tauri also keeps slide on this path
+ * so a decoded snapshot can be prepared while the page is idle; desktop and
+ * web builds retain the browser View Transition implementation when it is
+ * available.
  */
 export const getCapturedTurnStyle = (
   viewSettings: ViewSettings,
   isFixedLayout: boolean,
+  prepareNativeSlide = getInitializedAppService()?.isMobileApp === true,
 ): CapturedTurnStyle | null => {
   if (!isTauriAppPlatform() || captureBroken) return null;
   if (!viewSettings.animated || viewSettings.scrolled || viewSettings.isEink || isFixedLayout) {
     return null;
   }
   if (viewSettings.pageTurnStyle === 'curl') return 'curl';
-  if (viewSettings.pageTurnStyle === 'slide' && !detectViewTransitionGroup()) return 'slide';
+  if (
+    viewSettings.pageTurnStyle === 'slide' &&
+    (prepareNativeSlide || !detectViewTransitionGroup())
+  ) {
+    return 'slide';
+  }
   return null;
 };
 
@@ -49,16 +66,17 @@ export const getCapturedTurnStyle = (
  * captured turn is active the paginator must stay out of the way: no
  * `turn-style` (the app animates the captured page itself) and `no-swipe`
  * (the touch interceptor scrubs the turn instead of the paginator's
- * finger-tracked View Transition). The layered `turn-style` values are
- * withheld from engines without full View Transitions support — iOS 18
- * WebKit crashes on them — leaving those on push.
+ * finger-tracked View Transition). Outside the captured mobile path, layered
+ * `turn-style` values are withheld from engines without full View Transitions
+ * support — iOS 18 WebKit crashes on them — leaving those on push.
  */
 export const applyPageTurnAttributes = (
   view: FoliateView,
   viewSettings: ViewSettings,
   isFixedLayout: boolean,
+  prepareNativeSlide = getInitializedAppService()?.isMobileApp === true,
 ) => {
-  const captured = getCapturedTurnStyle(viewSettings, isFixedLayout);
+  const captured = getCapturedTurnStyle(viewSettings, isFixedLayout, prepareNativeSlide);
   const style = viewSettings.pageTurnStyle;
   if (style && style !== 'push' && !captured && detectViewTransitionGroup()) {
     view.renderer.setAttribute('turn-style', style);
@@ -70,15 +88,31 @@ export const applyPageTurnAttributes = (
   } else {
     view.renderer.removeAttribute('no-swipe');
   }
+  if (captured && !viewSettings.disableSwipe) {
+    view.renderer.setAttribute(NATIVE_CAPTURED_TURN_ATTRIBUTE, captured);
+  } else {
+    view.renderer.removeAttribute(NATIVE_CAPTURED_TURN_ATTRIBUTE);
+  }
 };
 
 interface DragState {
+  style: CapturedTurnStyle;
   forward: boolean;
   width: number;
   height: number;
+  /** Finger distance already consumed when a Slide gesture was claimed. */
+  visualOriginDistance: number;
   progress: number;
   grabY: number;
+  releaseSamples: { distance: number; time: number }[];
+  lastMovementTime: number;
 }
+
+const RELEASE_VELOCITY_WINDOW_MS = 90;
+const RELEASE_PAUSE_THRESHOLD_MS = 80;
+const SLIDE_RELEASE_PROJECTION_MS = 240;
+const PREPARED_CAPTURE_DELAY_MS = 160;
+const PREPARED_CAPTURE_CHROME_DELAY_MS = 360;
 
 // Whether the visible section's document holds a non-collapsed selection —
 // the same condition the paginator's native swipe bows out on (#onTouchMove
@@ -102,6 +136,10 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
   const { getBookData } = useBookDataStore();
   const controllerRef = useRef<CapturedPageTurn | null>(null);
   const dragRef = useRef<DragState | null>(null);
+  const gestureIntentRef = useRef<TurnGestureIntent | null>(null);
+  const programmaticTurnsInFlightRef = useRef(new Set<symbol>());
+  const schedulePreparedCaptureRef = useRef<(() => void) | null>(null);
+  const cancelPreparedCaptureScheduleRef = useRef<(() => void) | null>(null);
   // Whether the current touch gesture is claimed by another interaction and
   // must never morph into a page turn, even after the claim is released:
   // - it began with an active selection (a handle drag stays a selection
@@ -109,7 +147,9 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
   //   dismisses on selectionchange and iOS re-confirms right after);
   // - it was ever blocked by the instant-highlight scroll lock (the unlock
   //   at release runs before the gesture's queued trailing touchmoves are
-  //   delivered, and their full-stroke deltas would read as a swipe).
+  //   delivered, and their full-stroke deltas would read as a swipe);
+  // - a layered turn already recognized it (including at a book boundary),
+  //   or a programmatic turn took ownership while the finger was still down.
   const gestureClaimed = useRef(false);
   const restoreToolbarOnCancelRef = useRef(false);
   const view = viewRef.current;
@@ -171,19 +211,32 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
         if (shouldRestore) void syncToolbarVisibility(true);
       } else if (detail.phase === 'finished') {
         setLayeredTurnGestureActive(bookKey, false);
+        // Keep per-touch ownership latched until iframe touchend/cancel clears
+        // it. A synchronous View Transition failure can finish while the
+        // finger is still down; clearing here would let its release become a
+        // synthesized toolbar click.
         restoreToolbarOnCancelRef.current = false;
         document
           .getElementById(`gridcell-${bookKey}`)
           ?.classList.remove('captured-turn-sync-chrome');
       }
     };
+    const handleLayeredTurnGestureClaimed = () => {
+      setLayeredTurnTouchClaimed(bookKey, true);
+    };
     const cleanupLayeredTurn = () => {
       view.renderer.removeEventListener('layered-turn-state', handleLayeredTurnState);
+      view.renderer.removeEventListener(
+        'layered-turn-gesture-claimed',
+        handleLayeredTurnGestureClaimed,
+      );
       setLayeredTurnGestureActive(bookKey, false);
+      setLayeredTurnTouchClaimed(bookKey, false);
       restoreToolbarOnCancelRef.current = false;
       document.getElementById(`gridcell-${bookKey}`)?.classList.remove('captured-turn-sync-chrome');
     };
     view.renderer.addEventListener('layered-turn-state', handleLayeredTurnState);
+    view.renderer.addEventListener('layered-turn-gesture-claimed', handleLayeredTurnGestureClaimed);
 
     // Browser View Transitions emit the same lifecycle as Tauri layered
     // turns, so toolbar/snapshot synchronization is shared. Only the native
@@ -251,6 +304,132 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
     });
     controllerRef.current = controller;
 
+    let prepareTimer: ReturnType<typeof setTimeout> | null = null;
+    let prepareRaf = 0;
+    let preparePaintRaf = 0;
+    let prepareNotBefore = 0;
+    let cleanedUp = false;
+    const cancelPreparedCaptureSchedule = () => {
+      if (prepareTimer !== null) clearTimeout(prepareTimer);
+      if (prepareRaf) cancelAnimationFrame(prepareRaf);
+      if (preparePaintRaf) cancelAnimationFrame(preparePaintRaf);
+      prepareTimer = null;
+      prepareRaf = 0;
+      preparePaintRaf = 0;
+    };
+    function runPreparedCapture() {
+      if (cleanedUp) return;
+      const remaining = prepareNotBefore - performance.now();
+      if (remaining > 0) {
+        prepareTimer = setTimeout(runPreparedCapture, remaining);
+        return;
+      }
+      prepareTimer = null;
+      prepareNotBefore = 0;
+      prepareRaf = requestAnimationFrame(() => {
+        prepareRaf = 0;
+        preparePaintRaf = requestAnimationFrame(() => {
+          preparePaintRaf = 0;
+          if (cleanedUp || document.hidden) return;
+          const currentViewState = useReaderStore.getState().viewStates[bookKey];
+          if (!currentViewState?.inited || currentViewState.ttsEnabled) return;
+          if (hasActiveSelection(view!)) {
+            schedulePreparedCapture(PREPARED_CAPTURE_CHROME_DELAY_MS);
+            return;
+          }
+          // Do not ask the native webview to capture while a tap, selection,
+          // brightness drag, or still-unclaimed turn gesture is in flight.
+          if (isLayeredTurnTouchActive(bookKey)) {
+            schedulePreparedCapture();
+            return;
+          }
+          const appService = getInitializedAppService();
+          if (!appService?.isMobileApp && !appService?.isMacOSApp) return;
+          const currentSettings = getViewSettings(bookKey);
+          const style = currentSettings
+            ? getCapturedTurnStyle(currentSettings, isFixedLayout())
+            : null;
+          if (style) void controller.prepareCapture(style);
+        });
+      });
+    }
+    function schedulePreparedCapture(delay = PREPARED_CAPTURE_DELAY_MS) {
+      if (cleanedUp) return;
+      prepareNotBefore = Math.max(prepareNotBefore, performance.now() + delay);
+      cancelPreparedCaptureSchedule();
+      prepareTimer = setTimeout(
+        runPreparedCapture,
+        Math.max(0, prepareNotBefore - performance.now()),
+      );
+    }
+    const invalidateAndSchedulePreparedCapture = (delay = PREPARED_CAPTURE_DELAY_MS) => {
+      controller.invalidatePreparedCapture();
+      schedulePreparedCapture(delay);
+    };
+    schedulePreparedCaptureRef.current = schedulePreparedCapture;
+    cancelPreparedCaptureScheduleRef.current = cancelPreparedCaptureSchedule;
+
+    // A warm bitmap represents the pixels of one settled reader-cell state.
+    // Coalesce the renderer's noisy lifecycle into one post-paint capture and
+    // discard any result whose generation changed while native work ran.
+    const handleCapturedSurfaceChange = () => invalidateAndSchedulePreparedCapture();
+    view.addEventListener('relocate', handleCapturedSurfaceChange);
+    view.addEventListener('draw-annotation', handleCapturedSurfaceChange);
+    view.addEventListener('show-annotation', handleCapturedSurfaceChange);
+    view.renderer.addEventListener('stabilized', handleCapturedSurfaceChange);
+
+    const gridCell = document.getElementById(`gridcell-${bookKey}`);
+    const resizeObserver =
+      gridCell && typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(() => invalidateAndSchedulePreparedCapture())
+        : null;
+    if (gridCell) resizeObserver?.observe(gridCell);
+
+    const unsubscribeReader = useReaderStore.subscribe((state, previous) => {
+      const currentViewState = state.viewStates[bookKey];
+      const previousViewState = previous.viewStates[bookKey];
+      const toolbarChanged =
+        (state.hoveredBookKey === bookKey) !== (previous.hoveredBookKey === bookKey);
+      const toolbarContentChanged =
+        state.bottomBarTab !== previous.bottomBarTab &&
+        (state.hoveredBookKey === bookKey || previous.hoveredBookKey === bookKey);
+      const readerPixelsChanged =
+        toolbarChanged || toolbarContentChanged || currentViewState !== previousViewState;
+      if (readerPixelsChanged) {
+        invalidateAndSchedulePreparedCapture(
+          toolbarChanged || toolbarContentChanged
+            ? PREPARED_CAPTURE_CHROME_DELAY_MS
+            : PREPARED_CAPTURE_DELAY_MS,
+        );
+      }
+    });
+    const unsubscribeTheme = useThemeStore.subscribe((state, previous) => {
+      const systemChromeChanged = state.systemUIVisible !== previous.systemUIVisible;
+      const themePixelsChanged =
+        state.themeCode !== previous.themeCode ||
+        state.isDarkMode !== previous.isDarkMode ||
+        systemChromeChanged ||
+        state.statusBarHeight !== previous.statusBarHeight ||
+        state.safeAreaInsets !== previous.safeAreaInsets ||
+        state.isRoundedWindow !== previous.isRoundedWindow;
+      if (themePixelsChanged) {
+        invalidateAndSchedulePreparedCapture(
+          systemChromeChanged ? PREPARED_CAPTURE_CHROME_DELAY_MS : PREPARED_CAPTURE_DELAY_MS,
+        );
+      }
+    });
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        cancelPreparedCaptureSchedule();
+        prepareNotBefore = 0;
+        controller.invalidatePreparedCapture();
+      } else {
+        schedulePreparedCapture();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    schedulePreparedCapture();
+
     const capturedTurn = async (forward: boolean, distance?: number) => {
       const viewSettings = getViewSettings(bookKey);
       const boundary = forward ? view.renderer.atEnd : view.renderer.atStart;
@@ -261,11 +440,31 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
       if (!viewSettings || !style) {
         return forward ? originals.next(distance) : originals.prev(distance);
       }
+      const programmaticTurn = Symbol('captured-turn');
+      programmaticTurnsInFlightRef.current.add(programmaticTurn);
+      view.renderer.setAttribute(NATIVE_PROGRAMMATIC_TURN_ATTRIBUTE, '');
+      // If another input starts a programmatic turn while a finger is still
+      // pending, that navigation owns the rest of the touch sequence. Do not
+      // let later samples reuse the old origin and launch a second turn after
+      // the programmatic animation; the controller cancels any open drag.
+      const rawTouchActive = isLayeredTurnTouchActive(bookKey);
+      if (rawTouchActive || gestureIntentRef.current || dragRef.current) {
+        dragRef.current = null;
+        gestureIntentRef.current = null;
+        gestureClaimed.current = true;
+        if (rawTouchActive) setLayeredTurnTouchClaimed(bookKey, true);
+      }
       try {
         await controller.turn(forward, viewSettings.rtl, style);
       } catch (error) {
         markCaptureBroken(error);
         return forward ? originals.next() : originals.prev();
+      } finally {
+        programmaticTurnsInFlightRef.current.delete(programmaticTurn);
+        if (programmaticTurnsInFlightRef.current.size === 0) {
+          view.renderer.removeAttribute(NATIVE_PROGRAMMATIC_TURN_ATTRIBUTE);
+        }
+        schedulePreparedCapture();
       }
     };
     // Return the turn's promise (the foliate originals do too, despite the
@@ -277,10 +476,32 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
     view.next = (distance?: number) => capturedTurn(true, distance);
 
     return () => {
+      cleanedUp = true;
+      cancelPreparedCaptureSchedule();
+      prepareNotBefore = 0;
+      if (schedulePreparedCaptureRef.current === schedulePreparedCapture) {
+        schedulePreparedCaptureRef.current = null;
+      }
+      if (cancelPreparedCaptureScheduleRef.current === cancelPreparedCaptureSchedule) {
+        cancelPreparedCaptureScheduleRef.current = null;
+      }
+      unsubscribeReader();
+      unsubscribeTheme();
+      resizeObserver?.disconnect();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      view.removeEventListener('relocate', handleCapturedSurfaceChange);
+      view.removeEventListener('draw-annotation', handleCapturedSurfaceChange);
+      view.removeEventListener('show-annotation', handleCapturedSurfaceChange);
+      view.renderer.removeEventListener('stabilized', handleCapturedSurfaceChange);
       view.prev = originals.prev;
       view.next = originals.next;
       controller.dispose();
       cleanupLayeredTurn();
+      programmaticTurnsInFlightRef.current.clear();
+      view.renderer.removeAttribute(NATIVE_PROGRAMMATIC_TURN_ATTRIBUTE);
+      dragRef.current = null;
+      gestureIntentRef.current = null;
+      gestureClaimed.current = false;
       controllerRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -295,13 +516,21 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
       if (!currentView || !controller) return false;
 
       if (detail.phase === 'start') {
+        cancelPreparedCaptureScheduleRef.current?.();
         // Some webviews can start a replacement touch sequence without
         // delivering the previous touchend. Cancel the old drag before its
         // state is replaced so it cannot remain over, or settle onto, the
         // following page.
-        if (dragRef.current) controller.endDrag(false).catch(() => {});
+        if (dragRef.current) {
+          controller
+            .endDrag(false)
+            .finally(() => schedulePreparedCaptureRef.current?.())
+            .catch(() => {});
+        }
         dragRef.current = null;
-        gestureClaimed.current = hasActiveSelection(currentView);
+        gestureIntentRef.current = createTurnGestureIntent(bookKey, currentView, detail);
+        gestureClaimed.current =
+          programmaticTurnsInFlightRef.current.size > 0 || hasActiveSelection(currentView);
         return false;
       }
 
@@ -316,6 +545,7 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
           // and claim the whole gesture, so the trailing moves delivered
           // after the release's unlock cannot start a stray drag.
           if (currentView.renderer.scrollLocked) {
+            gestureIntentRef.current = null;
             gestureClaimed.current = true;
             return false;
           }
@@ -325,25 +555,57 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
           // selection gate), so the captured turn must as well. The claim
           // latch keeps a handle drag from morphing into a turn during a
           // transient mid-drag deselect.
-          if (gestureClaimed.current || hasActiveSelection(currentView)) return false;
-          if (!viewSettings || viewSettings.disableSwipe) return false;
-          const style = getCapturedTurnStyle(viewSettings, isFixedLayout());
-          if (!style) return false;
-          // Horizontal intent only; leave vertical swipes and taps alone.
-          const { deltaX, deltaY } = detail;
-          if (Math.abs(deltaX) < TOUCH_SWIPE_THRESHOLD_PX || Math.abs(deltaX) <= Math.abs(deltaY)) {
+          if (gestureClaimed.current || hasActiveSelection(currentView)) {
+            gestureIntentRef.current = null;
             return false;
           }
+          if (!viewSettings || viewSettings.disableSwipe) {
+            gestureIntentRef.current = null;
+            return false;
+          }
+          const style = getCapturedTurnStyle(viewSettings, isFixedLayout());
+          if (!style) {
+            gestureIntentRef.current = null;
+            return false;
+          }
+          const intent =
+            gestureIntentRef.current ?? createTurnGestureIntent(bookKey, currentView, detail);
+          gestureIntentRef.current = intent;
+          // Edge drags can engage on their first clear inward sample. Central
+          // drags use two timely, coherent samples for a 6px fast path, while
+          // ambiguous trajectories retain the established 15px fallback.
+          // The brightness strip keeps the paginator-compatible 24px fallback
+          // so it can reach its own 18px activation point first.
+          if (!shouldClaimTurnGesture(intent, detail)) {
+            return false;
+          }
+          gestureIntentRef.current = null;
+          const { deltaX } = detail;
           const forward = viewSettings.rtl ? deltaX > 0 : deltaX < 0;
-          if (forward ? currentView.renderer.atEnd : currentView.renderer.atStart) return false;
+          // Recognition owns the touch even at a book boundary, where no
+          // captured animation can start. Otherwise a 1–6px early claim can
+          // be replayed as a synthesized toolbar click on release.
+          setLayeredTurnTouchClaimed(bookKey, true);
+          gestureClaimed.current = true;
+          if (forward ? currentView.renderer.atEnd : currentView.renderer.atStart) return true;
           const rect = document.getElementById(`gridcell-${bookKey}`)?.getBoundingClientRect();
           const startedState: DragState = {
+            style,
             forward,
             width: rect?.width || window.innerWidth,
             height: rect?.height || window.innerHeight,
+            visualOriginDistance: 0,
             progress: 0,
             grabY: 0.5,
+            releaseSamples: [{ distance: 0, time: 0 }],
+            lastMovementTime: 0,
           };
+          if (style === 'slide') {
+            startedState.visualOriginDistance = Math.max(
+              0,
+              dragDistance(startedState, detail.deltaX, viewSettings.rtl),
+            );
+          }
           updateDragSample(startedState, detail, viewSettings.rtl);
           dragRef.current = startedState;
           const beginning = controller.beginDrag(forward, viewSettings.rtl, style);
@@ -369,25 +631,46 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
 
       // phase === 'end' | 'cancel'
       const state = dragRef.current;
-      if (!state) return false;
+      gestureIntentRef.current = null;
+      if (!state) {
+        schedulePreparedCaptureRef.current?.();
+        return false;
+      }
       dragRef.current = null;
       updateDragSample(state, detail, viewSettings?.rtl ?? false);
       // Store the release position before endDrag joins the controller's
       // serialized queue. This ordering also covers touchcancel.
       controller.moveDrag(state.progress, state.grabY);
       if (detail.phase === 'cancel') {
-        controller.endDrag(false).catch(() => {});
+        controller
+          .endDrag(false)
+          .finally(() => schedulePreparedCaptureRef.current?.())
+          .catch(() => {});
         return true;
       }
       const signed = dragDistance(state, detail.deltaX, viewSettings?.rtl ?? false);
-      const velocity = signed / (detail.deltaT || 1);
-      // Same carousel rule as the paginator: a flick along the turn commits
-      // regardless of distance; otherwise commit past halfway.
-      const commit = velocity > 0.3 ? true : state.progress > 0.5;
+      const fullGestureVelocity = signed / (detail.deltaT || 1);
+      const releaseVelocity = getReleaseVelocity(state);
+      // Slide projects the release velocity forward over a short horizon:
+      // distance and speed contribute continuously instead of crossing two
+      // independent hard thresholds. Curl preserves the existing whole-
+      // gesture 0.3px/ms-or-halfway rule.
+      const releaseProgress = Math.max(0, Math.min(1, signed / state.width));
+      const projectedProgress =
+        releaseProgress + (releaseVelocity * SLIDE_RELEASE_PROJECTION_MS) / state.width;
+      const commit =
+        state.style === 'slide'
+          ? projectedProgress > 0.5
+          : fullGestureVelocity > 0.3
+            ? true
+            : state.progress > 0.5;
       // CapturedPageTurn serializes endDrag behind an in-flight beginDrag, so
       // queue release immediately. This also keeps a following gesture behind
       // the complete begin/end pair instead of letting it supersede the turn.
-      controller.endDrag(commit).catch(() => {});
+      controller
+        .endDrag(commit, releaseVelocity)
+        .finally(() => schedulePreparedCaptureRef.current?.())
+        .catch(() => {});
       return true;
     },
     // Above the fixed-layout swipe-flip (0), below the reading ruler (10).
@@ -397,11 +680,46 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
 
 const dragProgress = (state: DragState, deltaX: number, rtl: boolean) => {
   const signed = dragDistance(state, deltaX, rtl);
-  // Preserve the full displacement from touchstart: recognition catches the
-  // animation up to the gesture, and later progress remains based on the same
-  // cumulative travel.
-  return Math.max(0, Math.min(1, signed / state.width));
+  // Slide starts visually flat at the claim point, avoiding a first-frame
+  // jump by the distance consumed during gesture recognition. Curl keeps its
+  // established touchstart-relative fold. Release decisions still use the
+  // full signed distance above, so this changes presentation only.
+  const visualDistance = state.style === 'slide' ? signed - state.visualOriginDistance : signed;
+  return Math.max(0, Math.min(1, visualDistance / state.width));
 };
+
+const createTurnGestureIntent = (
+  bookKey: string,
+  view: FoliateView,
+  detail: TouchDetail,
+): TurnGestureIntent => {
+  const rect = document.getElementById(`gridcell-${bookKey}`)?.getBoundingClientRect();
+  let edgeDirection: TurnGestureIntent['edgeDirection'] = 0;
+  const inset = Number(view.renderer.getAttribute?.(TURN_GESTURE_LEFT_INSET_ATTRIBUTE));
+  const reservedLeftRatio = Number.isFinite(inset) ? Math.max(0, Math.min(0.5, inset)) : 0;
+  let earlyClaimBlocked = detail.touchStart.screenX <= window.innerWidth * reservedLeftRatio;
+  if (rect && rect.width > 0) {
+    const windowScreenX = Number.isFinite(window.screenX) ? window.screenX : 0;
+    const localStartX = detail.touchStart.screenX - windowScreenX - rect.left;
+    earlyClaimBlocked = localStartX <= rect.width * reservedLeftRatio;
+    if (
+      !earlyClaimBlocked &&
+      localStartX >= 0 &&
+      localStartX <= rect.width * TURN_EDGE_ZONE_RATIO
+    ) {
+      edgeDirection = 1;
+    } else if (
+      localStartX <= rect.width &&
+      localStartX >= rect.width * (1 - TURN_EDGE_ZONE_RATIO)
+    ) {
+      edgeDirection = -1;
+    }
+  }
+  return createArenaIntent(edgeDirection, earlyClaimBlocked, detail.deltaT);
+};
+
+const shouldClaimTurnGesture = (intent: TurnGestureIntent, detail: TouchDetail) =>
+  shouldClaimArenaGesture(intent, detail, TOUCH_SWIPE_THRESHOLD_PX);
 
 const dragDistance = (state: DragState, deltaX: number, rtl: boolean) => {
   const along = rtl ? -deltaX : deltaX;
@@ -409,8 +727,43 @@ const dragDistance = (state: DragState, deltaX: number, rtl: boolean) => {
 };
 
 const updateDragSample = (state: DragState, detail: TouchDetail, rtl: boolean) => {
+  const distance = dragDistance(state, detail.deltaX, rtl);
   state.progress = dragProgress(state, detail.deltaX, rtl);
   // The fold tilts as the finger strays vertically, curling corners like a
   // real page pinch.
   state.grabY = Math.max(0.05, Math.min(0.95, 0.5 + detail.deltaY / state.height));
+
+  const time = Math.max(0, detail.deltaT);
+  const previous = state.releaseSamples.at(-1);
+  if (!previous || distance !== previous.distance) state.lastMovementTime = time;
+  if (previous?.time === time) {
+    previous.distance = distance;
+  } else {
+    state.releaseSamples.push({ distance, time });
+  }
+
+  const cutoff = time - RELEASE_VELOCITY_WINDOW_MS;
+  while (state.releaseSamples.length > 2 && state.releaseSamples[1]!.time < cutoff) {
+    state.releaseSamples.shift();
+  }
+};
+
+const getReleaseVelocity = (state: DragState) => {
+  const latest = state.releaseSamples.at(-1);
+  if (!latest || latest.time - state.lastMovementTime > RELEASE_PAUSE_THRESHOLD_MS) return 0;
+
+  const cutoff = latest.time - RELEASE_VELOCITY_WINDOW_MS;
+  const before = state.releaseSamples[0];
+  const after = state.releaseSamples.find((sample) => sample.time >= cutoff);
+  if (!before || !after) return 0;
+
+  const startTime = Math.max(cutoff, before.time);
+  if (latest.time <= startTime) return 0;
+  const interval = after.time - before.time;
+  const startDistance =
+    interval > 0 && startTime > before.time
+      ? before.distance +
+        ((after.distance - before.distance) * (startTime - before.time)) / interval
+      : after.distance;
+  return (latest.distance - startDistance) / (latest.time - startTime);
 };

--- a/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
+++ b/apps/readest-app/src/app/reader/hooks/useCapturedTurn.ts
@@ -4,6 +4,7 @@ import { FoliateView } from '@/types/view';
 import { ViewSettings } from '@/types/book';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useReaderStore } from '@/store/readerStore';
+import { useSettingsStore } from '@/store/settingsStore';
 import { useThemeStore } from '@/store/themeStore';
 import { captureWebviewRegion } from '@/utils/bridge';
 import { getInitializedAppService, isTauriAppPlatform } from '@/services/environment';
@@ -38,8 +39,8 @@ let captureBroken = false;
  * webview snapshot (Tauri only) and only makes sense for animated,
  * paginated, reflowable books. The curl always turns from a capture (a
  * flat snapshot cannot mesh-bend). Mobile Tauri also keeps slide on this path
- * so a decoded snapshot can be prepared while the page is idle; desktop and
- * web builds retain the browser View Transition implementation when it is
+ * so a renderer-ready surface can be prepared while the page is idle. Desktop
+ * and web builds retain the browser View Transition implementation when it is
  * available.
  */
 export const getCapturedTurnStyle = (
@@ -114,6 +115,101 @@ const SLIDE_RELEASE_PROJECTION_MS = 240;
 const PREPARED_CAPTURE_DELAY_MS = 160;
 const PREPARED_CAPTURE_CHROME_DELAY_MS = 360;
 
+// Native webview capture sees composited pixels, not just the reader cell.
+// Keep renderer-ready surfaces out of any host UI that visually covers the
+// page. These selectors intentionally follow shared HTML/ARIA state instead
+// of subscribing to every dialog or popup store independently.
+const CAPTURE_BLOCKING_OVERLAY_SELECTOR = [
+  'dialog[open]',
+  'dialog.modal-open',
+  '[role="dialog"][aria-modal="true"]:not([aria-hidden="true"])',
+  '[role="dialog"].modal-open',
+  '[role="alertdialog"]:not([aria-hidden="true"])',
+  '[aria-haspopup][aria-expanded="true"]',
+  '[role="menu"][data-state="open"]',
+  '[role="listbox"][data-state="open"]',
+  '[data-capture-blocking-overlay="true"]',
+  '.fixed.inset-0 [role="alert"]:not([aria-hidden="true"])',
+].join(',');
+const CAPTURE_INVALIDATING_OVERLAY_SELECTOR = '[data-capture-invalidating-overlay="true"]';
+const PIXEL_CAPTURE_FILTER_CLASS = 'captured-turn-filter-transient-overlays';
+let pixelCaptureFilterDepth = 0;
+
+const isCapturedSurfaceBlockedByOverlay = () =>
+  useSettingsStore.getState().isSettingsDialogOpen ||
+  (typeof document !== 'undefined' &&
+    document.querySelector(CAPTURE_BLOCKING_OVERLAY_SELECTOR) !== null);
+
+// Transient, non-interactive chrome (for example Toast) must invalidate idle
+// work but must not disable a Slide/Curl gesture while paginator no-swipe is
+// active. Native capture temporarily filters it from the page texture, leaving
+// the live transient above the turn without a moving duplicate.
+const isPreparedSurfaceBlockedByOverlay = () =>
+  isCapturedSurfaceBlockedByOverlay() ||
+  (typeof document !== 'undefined' &&
+    document.querySelector(CAPTURE_INVALIDATING_OVERLAY_SELECTOR) !== null);
+
+const acquirePixelCaptureFilter = () => {
+  pixelCaptureFilterDepth++;
+  document.documentElement.classList.add(PIXEL_CAPTURE_FILTER_CLASS);
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    pixelCaptureFilterDepth = Math.max(0, pixelCaptureFilterDepth - 1);
+    if (pixelCaptureFilterDepth === 0) {
+      document.documentElement.classList.remove(PIXEL_CAPTURE_FILTER_CLASS);
+    }
+  };
+  // Do not leave all toasts hidden forever if a platform capture bridge stalls.
+  const safetyTimer = setTimeout(release, 2000);
+  return () => {
+    clearTimeout(safetyTimer);
+    release();
+  };
+};
+
+const captureBlockingOverlayListeners = new Set<() => void>();
+let captureBlockingOverlayObserver: MutationObserver | null = null;
+
+/** Share one document observer across every mounted reader cell. */
+const subscribeCaptureBlockingOverlay = (listener: () => void) => {
+  captureBlockingOverlayListeners.add(listener);
+  if (
+    !captureBlockingOverlayObserver &&
+    typeof MutationObserver !== 'undefined' &&
+    typeof document !== 'undefined' &&
+    document.body
+  ) {
+    captureBlockingOverlayObserver = new MutationObserver(() => {
+      for (const notify of captureBlockingOverlayListeners) notify();
+    });
+    captureBlockingOverlayObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      // Static role/class semantics are observed through mount/unmount. Watch
+      // only state attributes here so ordinary React class updates do not make
+      // every mounted reader cell rescan the full document for overlays.
+      attributeFilter: [
+        'open',
+        'aria-expanded',
+        'aria-hidden',
+        'data-state',
+        'data-capture-blocking-overlay',
+        'data-capture-invalidating-overlay',
+      ],
+    });
+  }
+  return () => {
+    captureBlockingOverlayListeners.delete(listener);
+    if (captureBlockingOverlayListeners.size === 0) {
+      captureBlockingOverlayObserver?.disconnect();
+      captureBlockingOverlayObserver = null;
+    }
+  };
+};
+
 // Whether the visible section's document holds a non-collapsed selection —
 // the same condition the paginator's native swipe bows out on (#onTouchMove
 // selection gate), mirrored for the captured-turn interceptor.
@@ -170,28 +266,37 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
   useEffect(() => {
     if (!view) return;
 
+    let toolbarSyncEpoch = 0;
     const waitForPaint = () =>
       new Promise<void>((resolve) => {
         requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
       });
     const setToolbarVisibilityNow = (visible: boolean) => {
+      const epoch = ++toolbarSyncEpoch;
       const gridCell = document.getElementById(`gridcell-${bookKey}`);
       if (!gridCell) return null;
 
       gridCell.classList.add('captured-turn-sync-chrome');
       flushSync(() => setHoveredBookKey(visible ? bookKey : null));
-      return gridCell;
+      return { gridCell, epoch };
+    };
+    const clearToolbarSyncClass = (sync?: { gridCell: HTMLElement; epoch: number } | null) => {
+      if (sync && sync.epoch !== toolbarSyncEpoch) return;
+      toolbarSyncEpoch++;
+      (sync?.gridCell ?? document.getElementById(`gridcell-${bookKey}`))?.classList.remove(
+        'captured-turn-sync-chrome',
+      );
     };
     const syncToolbarVisibility = async (visible: boolean) => {
       // The page snapshot covers this state change. Suppress the normal
       // 300ms toolbar transition, commit the matching live state underneath,
       // and keep the override through one painted frame before removing it.
-      const gridCell = setToolbarVisibilityNow(visible);
-      if (!gridCell) return;
+      const sync = setToolbarVisibilityNow(visible);
+      if (!sync) return;
       try {
         await waitForPaint();
       } finally {
-        gridCell.classList.remove('captured-turn-sync-chrome');
+        clearToolbarSyncClass(sync);
       }
     };
     const handleLayeredTurnState = (event: Event) => {
@@ -202,9 +307,7 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
       } else if (detail.phase === 'covered') {
         if (restoreToolbarOnCancelRef.current) setToolbarVisibilityNow(false);
       } else if (detail.phase === 'ready') {
-        document
-          .getElementById(`gridcell-${bookKey}`)
-          ?.classList.remove('captured-turn-sync-chrome');
+        clearToolbarSyncClass();
       } else if (detail.phase === 'cancelled') {
         const shouldRestore = restoreToolbarOnCancelRef.current;
         restoreToolbarOnCancelRef.current = false;
@@ -216,9 +319,7 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
         // finger is still down; clearing here would let its release become a
         // synthesized toolbar click.
         restoreToolbarOnCancelRef.current = false;
-        document
-          .getElementById(`gridcell-${bookKey}`)
-          ?.classList.remove('captured-turn-sync-chrome');
+        clearToolbarSyncClass();
       }
     };
     const handleLayeredTurnGestureClaimed = () => {
@@ -233,7 +334,7 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
       setLayeredTurnGestureActive(bookKey, false);
       setLayeredTurnTouchClaimed(bookKey, false);
       restoreToolbarOnCancelRef.current = false;
-      document.getElementById(`gridcell-${bookKey}`)?.classList.remove('captured-turn-sync-chrome');
+      clearToolbarSyncClass();
     };
     view.renderer.addEventListener('layered-turn-state', handleLayeredTurnState);
     view.renderer.addEventListener('layered-turn-gesture-claimed', handleLayeredTurnGestureClaimed);
@@ -263,6 +364,20 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
         restoreToolbarOnCancelRef.current = useReaderStore.getState().hoveredBookKey === bookKey;
       },
       capture: captureWebviewRegion,
+      preparePixelCapture: async () => {
+        const transientVisible =
+          document.querySelector(CAPTURE_INVALIDATING_OVERLAY_SELECTOR) !== null;
+        const release = acquirePixelCaptureFilter();
+        // Adding the class is free when no transient exists. If one is already
+        // painted, wait until its hidden state reaches the compositor before
+        // asking the native webview for pixels.
+        if (transientVisible) await waitForPaint();
+        return release;
+      },
+      // A modal can open while the native snapshot promise is in flight. The
+      // controller rechecks this gate before mounting or navigating so those
+      // pixels can never be replayed by a later turn.
+      isCaptureAllowed: () => !isCapturedSurfaceBlockedByOverlay(),
       getBackdrop: () => {
         const cell = document.getElementById(`gridcell-${bookKey}`);
         const rect = cell?.getBoundingClientRect();
@@ -276,12 +391,18 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
           rect.height,
         );
       },
-      onCovered: async () => {
-        // Let the flat canvas reach the compositor before touching the live
-        // chrome; otherwise the toolbar can flash out before its captured copy
-        // is actually visible on Android/iOS WebViews.
-        await waitForPaint();
-        if (restoreToolbarOnCancelRef.current) await syncToolbarVisibility(false);
+      onCovered: async (_style, surfaceAlreadyPainted) => {
+        // A warm low-alpha surface has already survived a compositor paint.
+        // Cold surfaces retain the conservative wait before touching live UI.
+        if (!surfaceAlreadyPainted) await waitForPaint();
+        if (restoreToolbarOnCancelRef.current) {
+          // Keep transition:none until the hidden live chrome has painted, but
+          // do not hold navigation and the first finger-driven frame behind
+          // another pair of RAFs. The epoch prevents a rapid cancellation's
+          // restoration sync from being cleared by this older background job.
+          const sync = setToolbarVisibilityNow(false);
+          if (sync) void waitForPaint().finally(() => clearToolbarSyncClass(sync));
+        }
       },
       onCancelled: async () => {
         const shouldRestore = restoreToolbarOnCancelRef.current;
@@ -333,6 +454,9 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
           if (cleanedUp || document.hidden) return;
           const currentViewState = useReaderStore.getState().viewStates[bookKey];
           if (!currentViewState?.inited || currentViewState.ttsEnabled) return;
+          // The observer below schedules a fresh post-paint surface after the
+          // last covering dialog or popup has left the composited page.
+          if (isPreparedSurfaceBlockedByOverlay()) return;
           if (hasActiveSelection(view!)) {
             schedulePreparedCapture(PREPARED_CAPTURE_CHROME_DELAY_MS);
             return;
@@ -369,7 +493,7 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
     schedulePreparedCaptureRef.current = schedulePreparedCapture;
     cancelPreparedCaptureScheduleRef.current = cancelPreparedCaptureSchedule;
 
-    // A warm bitmap represents the pixels of one settled reader-cell state.
+    // A warm surface represents the pixels of one settled reader-cell state.
     // Coalesce the renderer's noisy lifecycle into one post-paint capture and
     // discard any result whose generation changed while native work ran.
     const handleCapturedSurfaceChange = () => invalidateAndSchedulePreparedCapture();
@@ -418,6 +542,44 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
         );
       }
     });
+    let captureBlockedByOverlay = isPreparedSurfaceBlockedByOverlay();
+    let captureInteractivelyBlocked = isCapturedSurfaceBlockedByOverlay();
+    const syncCaptureBlockingOverlay = () => {
+      const blocked = isPreparedSurfaceBlockedByOverlay();
+      const interactivelyBlocked = isCapturedSurfaceBlockedByOverlay();
+      const wasBlocked = captureBlockedByOverlay;
+      const wasInteractivelyBlocked = captureInteractivelyBlocked;
+      if (blocked === wasBlocked && interactivelyBlocked === wasInteractivelyBlocked) return;
+      captureBlockedByOverlay = blocked;
+      captureInteractivelyBlocked = interactivelyBlocked;
+      if (interactivelyBlocked && !wasInteractivelyBlocked) {
+        // Discard the clean-page surface as soon as the first covering layer
+        // opens, and invalidate any native work that was already in flight.
+        cancelPreparedCaptureSchedule();
+        prepareNotBefore = 0;
+        controller.invalidatePreparedCapture();
+      } else if (blocked && !wasBlocked) {
+        // Toast-like chrome is non-interactive. Keep a completed clean surface
+        // available for the next gesture, but cancel any native warm-up whose
+        // pixels may overlap the newly mounted transient.
+        cancelPreparedCaptureSchedule();
+        prepareNotBefore = 0;
+        controller.invalidatePendingPreparedCapture();
+      }
+      if (!blocked && wasBlocked) {
+        // Wait for close animations plus reader updates triggered from the
+        // overlay to paint before filling a missing prepared slot.
+        schedulePreparedCapture(PREPARED_CAPTURE_CHROME_DELAY_MS);
+      }
+    };
+    const unsubscribeSettings = useSettingsStore.subscribe((state, previous) => {
+      if (state.isSettingsDialogOpen === previous.isSettingsDialogOpen) return;
+      // The store fires before React commits Settings, giving its open path an
+      // immediate invalidation. On close the still-mounted <dialog> keeps the
+      // shared gate closed until the mutation observer sees it leave the DOM.
+      syncCaptureBlockingOverlay();
+    });
+    const unsubscribeBlockingOverlay = subscribeCaptureBlockingOverlay(syncCaptureBlockingOverlay);
     const handleVisibilityChange = () => {
       if (document.hidden) {
         cancelPreparedCaptureSchedule();
@@ -437,7 +599,7 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
         viewSettings && distance === undefined && !boundary
           ? getCapturedTurnStyle(viewSettings, isFixedLayout())
           : null;
-      if (!viewSettings || !style) {
+      if (!viewSettings || !style || isCapturedSurfaceBlockedByOverlay()) {
         return forward ? originals.next(distance) : originals.prev(distance);
       }
       const programmaticTurn = Symbol('captured-turn');
@@ -487,6 +649,8 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
       }
       unsubscribeReader();
       unsubscribeTheme();
+      unsubscribeSettings();
+      unsubscribeBlockingOverlay();
       resizeObserver?.disconnect();
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       view.removeEventListener('relocate', handleCapturedSurfaceChange);
@@ -517,6 +681,9 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
 
       if (detail.phase === 'start') {
         cancelPreparedCaptureScheduleRef.current?.();
+        // A replacement touch also releases a lease left behind by a WebView
+        // that omitted the previous touchend.
+        controller.releasePreparedCapture();
         // Some webviews can start a replacement touch sequence without
         // delivering the previous touchend. Cancel the old drag before its
         // state is replaced so it cannot remain over, or settle onto, the
@@ -528,9 +695,64 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
             .catch(() => {});
         }
         dragRef.current = null;
-        gestureIntentRef.current = createTurnGestureIntent(bookKey, currentView, detail);
+        const intent = createTurnGestureIntent(bookKey, currentView, detail);
+        gestureIntentRef.current = intent;
+        const selectionActive = hasActiveSelection(currentView);
+        const overlayBlocksCapture = isCapturedSurfaceBlockedByOverlay();
+        const preparedPixelsBlocked = isPreparedSurfaceBlockedByOverlay();
         gestureClaimed.current =
-          programmaticTurnsInFlightRef.current.size > 0 || hasActiveSelection(currentView);
+          programmaticTurnsInFlightRef.current.size > 0 || selectionActive || overlayBlocksCapture;
+
+        // These interactions can change the live pixels while the finger is
+        // down. Remove a low-alpha idle surface immediately rather than leave
+        // a stale selection/brightness frame resident above the DOM.
+        if (
+          preparedPixelsBlocked ||
+          selectionActive ||
+          currentView.renderer.scrollLocked ||
+          intent.earlyClaimBlocked
+        ) {
+          if (
+            overlayBlocksCapture ||
+            selectionActive ||
+            currentView.renderer.scrollLocked ||
+            intent.earlyClaimBlocked
+          ) {
+            controller.invalidatePreparedCapture();
+          } else {
+            controller.invalidatePendingPreparedCapture();
+          }
+        }
+        if (
+          overlayBlocksCapture ||
+          selectionActive ||
+          currentView.renderer.scrollLocked ||
+          programmaticTurnsInFlightRef.current.size > 0
+        ) {
+          gestureIntentRef.current = null;
+        }
+
+        // The idle warm-up normally leaves a mounted, texture-uploaded surface
+        // ready before the next gesture. If it has not run yet (for example,
+        // during rapid consecutive turns), start the same invisible work as
+        // soon as the finger lands. A later beginDrag joins that promise.
+        // Keep the brightness strip out of this speculative path because its
+        // touch is reserved for changing the live page appearance.
+        const viewSettings = getViewSettings(bookKey);
+        if (
+          !gestureClaimed.current &&
+          !preparedPixelsBlocked &&
+          !currentView.renderer.scrollLocked &&
+          !intent.earlyClaimBlocked &&
+          viewSettings &&
+          !viewSettings.disableSwipe
+        ) {
+          const style = getCapturedTurnStyle(viewSettings, isFixedLayout());
+          if (style) {
+            controller.retainPreparedCapture();
+            void controller.prepareCapture(style);
+          }
+        }
         return false;
       }
 
@@ -545,8 +767,10 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
           // and claim the whole gesture, so the trailing moves delivered
           // after the release's unlock cannot start a stray drag.
           if (currentView.renderer.scrollLocked) {
+            const shouldInvalidate = gestureIntentRef.current !== null;
             gestureIntentRef.current = null;
             gestureClaimed.current = true;
+            if (shouldInvalidate) controller.invalidatePreparedCapture();
             return false;
           }
           // A non-collapsed selection means the finger is creating or
@@ -555,17 +779,22 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
           // selection gate), so the captured turn must as well. The claim
           // latch keeps a handle drag from morphing into a turn during a
           // transient mid-drag deselect.
-          if (gestureClaimed.current || hasActiveSelection(currentView)) {
+          const selectionActive = hasActiveSelection(currentView);
+          if (gestureClaimed.current || selectionActive) {
+            const shouldInvalidate = selectionActive && gestureIntentRef.current !== null;
             gestureIntentRef.current = null;
+            if (shouldInvalidate) controller.invalidatePreparedCapture();
             return false;
           }
           if (!viewSettings || viewSettings.disableSwipe) {
             gestureIntentRef.current = null;
+            controller.releasePreparedCapture();
             return false;
           }
           const style = getCapturedTurnStyle(viewSettings, isFixedLayout());
           if (!style) {
             gestureIntentRef.current = null;
+            controller.releasePreparedCapture();
             return false;
           }
           const intent =
@@ -587,7 +816,10 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
           // be replayed as a synthesized toolbar click on release.
           setLayeredTurnTouchClaimed(bookKey, true);
           gestureClaimed.current = true;
-          if (forward ? currentView.renderer.atEnd : currentView.renderer.atStart) return true;
+          if (forward ? currentView.renderer.atEnd : currentView.renderer.atStart) {
+            controller.releasePreparedCapture();
+            return true;
+          }
           const rect = document.getElementById(`gridcell-${bookKey}`)?.getBoundingClientRect();
           const startedState: DragState = {
             style,
@@ -633,6 +865,7 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
       const state = dragRef.current;
       gestureIntentRef.current = null;
       if (!state) {
+        controller.releasePreparedCapture();
         schedulePreparedCaptureRef.current?.();
         return false;
       }
@@ -681,9 +914,8 @@ export const useCapturedTurn = (bookKey: string, viewRef: React.RefObject<Foliat
 const dragProgress = (state: DragState, deltaX: number, rtl: boolean) => {
   const signed = dragDistance(state, deltaX, rtl);
   // Slide starts visually flat at the claim point, avoiding a first-frame
-  // jump by the distance consumed during gesture recognition. Curl keeps its
-  // established touchstart-relative fold. Release decisions still use the
-  // full signed distance above, so this changes presentation only.
+  // jump by the distance consumed during gesture recognition. Release intent
+  // is calculated separately from the full touchstart-relative distance.
   const visualDistance = state.style === 'slide' ? signed - state.visualOriginDistance : signed;
   return Math.max(0, Math.min(1, visualDistance / state.width));
 };

--- a/apps/readest-app/src/app/reader/hooks/useIframeEvents.ts
+++ b/apps/readest-app/src/app/reader/hooks/useIframeEvents.ts
@@ -5,6 +5,12 @@ import { eventDispatcher } from '@/utils/event';
 import { MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL } from '@/services/constants';
 import { createWheelGestureDetector } from '@/app/reader/utils/wheelGesture';
 import {
+  beginLayeredTurnTouch,
+  cancelLayeredTurnTouch,
+  endLayeredTurnTouch,
+} from '@/app/reader/utils/iframeEventHandlers';
+import { NATIVE_CAPTURED_TURN_ATTRIBUTE } from '@/app/reader/utils/turnGestureArena';
+import {
   dispatchTouchInterceptors,
   isLayeredTurnGestureActive,
   TOUCH_TAP_SLOP_PX,
@@ -149,12 +155,19 @@ export const useTouchEvent = (bookKey: string) => {
   // see whether they spread/converge (pinch) or slide together (scroll) before
   // committing. isPinchingRef only flips true once a pinch is confirmed.
   const pinchPendingRef = useRef(false);
+  // Reflowable books do not pinch-zoom, but a second finger must still end the
+  // single-finger arena. Keep the whole multi-touch sequence latched out until
+  // every finger is up so the remaining finger cannot inherit the old start.
+  const reflowableMultiTouchRef = useRef(false);
 
   const isLifecycleManagedLayeredTurn = () => isLayeredTurnGestureActive(bookKey);
   const isLayeredTurnCandidate = () => {
     const viewSettings = getViewSettings(bookKey);
     if (!viewSettings || getBookData(bookKey)?.isFixedLayout) return false;
-    const turnStyle = getView(bookKey)?.renderer.getAttribute?.('turn-style');
+    const renderer = getView(bookKey)?.renderer;
+    const turnStyle =
+      renderer?.getAttribute?.('turn-style') ??
+      renderer?.getAttribute?.(NATIVE_CAPTURED_TURN_ATTRIBUTE);
     return (
       (turnStyle === 'slide' || turnStyle === 'curl') &&
       viewSettings.animated &&
@@ -191,17 +204,69 @@ export const useTouchEvent = (bookKey: string) => {
     touchStart: { screenX: touchStart.screenX, screenY: touchStart.screenY },
     deltaX: touch.screenX - touchStart.screenX,
     deltaY: touch.screenY - touchStart.screenY,
-    deltaT: endTime && startTime ? endTime - startTime : 0,
+    deltaT: endTime !== null && startTime !== null ? endTime - startTime : 0,
   });
+
+  const clearSingleTouchState = () => {
+    touchStartRef.current = null;
+    touchEndRef.current = null;
+    touchStartTimeRef.current = null;
+    touchEndTimeRef.current = null;
+    touchConsumedRef.current = false;
+    layeredTurnOwnedRef.current = false;
+    layeredTurnCandidateRef.current = false;
+  };
+
+  const preventDirectTouchDefault = (e: IframeTouchEvent | React.TouchEvent<HTMLDivElement>) => {
+    // Forwarded iframe messages are plain data. React events originate on the
+    // paginator's parent surface (header/footer/margins) and must explicitly
+    // suppress the compatibility click once a layered turn owns the touch.
+    if ('preventDefault' in e) e.preventDefault();
+  };
+
+  const latchReflowableMultiTouch = (
+    e: IframeTouchEvent | React.TouchEvent<HTMLDivElement>,
+    t0: IframeTouch | undefined,
+    t1: IframeTouch | undefined,
+  ) => {
+    if (!t0 || !t1 || getBookData(bookKey)?.isFixedLayout) return false;
+    cancelLayeredTurnTouch(bookKey);
+    if (!reflowableMultiTouchRef.current) {
+      reflowableMultiTouchRef.current = true;
+      const touchStart = touchStartRef.current;
+      // A native captured turn has already claimed only when its move was
+      // consumed. Cancel it exactly once before discarding the single-finger
+      // baseline; unclaimed starts need no synthetic lifecycle event.
+      if (touchConsumedRef.current && touchStart) {
+        const touch = touchEndRef.current ?? t0;
+        const endTime = 'timeStamp' in e ? e.timeStamp : Date.now();
+        dispatchTouchInterceptors(
+          bookKey,
+          buildTouchDetail('cancel', touch, touchStart, touchStartTimeRef.current, endTime),
+        );
+      }
+    }
+    clearSingleTouchState();
+    return true;
+  };
 
   const onTouchStart = (e: IframeTouchEvent | React.TouchEvent<HTMLDivElement>) => {
     layeredTurnOwnedRef.current = false;
     layeredTurnCandidateRef.current = false;
     const t0 = e.targetTouches[0] as IframeTouch | undefined;
     const t1 = e.targetTouches[1] as IframeTouch | undefined;
+    if (reflowableMultiTouchRef.current) {
+      cancelLayeredTurnTouch(bookKey);
+      return;
+    }
+    // iframeEventHandlers owns the lifecycle for forwarded iframe messages.
+    // Starting it again after postMessage delivery could erase a claim made by
+    // a raw move that arrived while the start message was still queued.
+    if ('preventDefault' in e) beginLayeredTurnTouch(bookKey);
     if (t0 && t1) {
       const bookData = getBookData(bookKey);
       if (bookData?.isFixedLayout) {
+        cancelLayeredTurnTouch(bookKey);
         pinchPendingRef.current = true;
         isPinchingRef.current = false;
         initialTouch0Ref.current = t0;
@@ -213,8 +278,13 @@ export const useTouchEvent = (bookKey: string) => {
         touchEndRef.current = null;
         return;
       }
+      latchReflowableMultiTouch(e, t0, t1);
+      return;
     }
-    if (!t0) return;
+    if (!t0) {
+      cancelLayeredTurnTouch(bookKey);
+      return;
+    }
     layeredTurnCandidateRef.current = isLayeredTurnCandidate();
     touchStartRef.current = t0;
     touchStartTimeRef.current = 'timeStamp' in e ? e.timeStamp : Date.now();
@@ -232,6 +302,7 @@ export const useTouchEvent = (bookKey: string) => {
   const onTouchMove = (e: IframeTouchEvent | React.TouchEvent<HTMLDivElement>) => {
     const t0 = e.targetTouches[0] as IframeTouch | undefined;
     const t1 = e.targetTouches[1] as IframeTouch | undefined;
+    if (reflowableMultiTouchRef.current || latchReflowableMultiTouch(e, t0, t1)) return;
     if ((pinchPendingRef.current || isPinchingRef.current) && t0 && t1) {
       if (pinchPendingRef.current) {
         const init0 = initialTouch0Ref.current;
@@ -283,6 +354,7 @@ export const useTouchEvent = (bookKey: string) => {
       );
       if (dispatchTouchInterceptors(bookKey, detail)) {
         touchConsumedRef.current = true;
+        preventDirectTouchDefault(e);
         return;
       }
     }
@@ -297,10 +369,10 @@ export const useTouchEvent = (bookKey: string) => {
     if (layeredTurnCandidateRef.current && touchEnd) {
       const deltaX = touchEnd.screenX - touchStart.screenX;
       const deltaY = touchEnd.screenY - touchStart.screenY;
-      // Browser layered turns use a stricter, direction-aware paginator gate
-      // than native captured turns. Do not hide the toolbar in the gap before
-      // `before-capture`: if the paginator claims later, its snapshot lifecycle
-      // takes over; if it never claims, touchend runs the generic behavior.
+      // The paginator's direction-aware arena may still claim this gesture.
+      // Do not hide the toolbar while ownership is pending: if it claims later,
+      // its snapshot lifecycle takes over; otherwise touchend runs the generic
+      // behavior.
       if (Math.abs(deltaX) > Math.abs(deltaY)) return;
     }
     if (hoveredBookKey && touchEnd) {
@@ -320,6 +392,14 @@ export const useTouchEvent = (bookKey: string) => {
 
   const onTouchEnd = (e: IframeTouchEvent | React.TouchEvent<HTMLDivElement>) => {
     layeredTurnCandidateRef.current = false;
+    if (reflowableMultiTouchRef.current) {
+      if (e.targetTouches.length === 0) {
+        reflowableMultiTouchRef.current = false;
+        cancelLayeredTurnTouch(bookKey);
+        clearSingleTouchState();
+      }
+      return;
+    }
     if (isPinchingRef.current || pinchPendingRef.current) {
       const t0 = e.targetTouches[0] as IframeTouch | undefined;
       const t1 = e.targetTouches[1] as IframeTouch | undefined;
@@ -341,8 +421,10 @@ export const useTouchEvent = (bookKey: string) => {
       touchStartRef.current = null;
       touchEndRef.current = null;
       layeredTurnOwnedRef.current = false;
+      cancelLayeredTurnTouch(bookKey);
       return;
     }
+    if (e.targetTouches.length === 0) endLayeredTurnTouch(bookKey);
     if (!touchStartRef.current) {
       layeredTurnOwnedRef.current = false;
       return;
@@ -361,6 +443,7 @@ export const useTouchEvent = (bookKey: string) => {
     const { current: touchEnd } = touchEndRef;
 
     // Dispatch end to interceptors, then check if the gesture was consumed
+    let endConsumed = false;
     if (touchEnd && touchStart) {
       const detail = buildTouchDetail(
         'end',
@@ -369,10 +452,11 @@ export const useTouchEvent = (bookKey: string) => {
         touchStartTimeRef.current,
         touchEndTimeRef.current,
       );
-      dispatchTouchInterceptors(bookKey, detail);
+      endConsumed = dispatchTouchInterceptors(bookKey, detail);
     }
 
-    if (touchConsumedRef.current) {
+    if (touchConsumedRef.current || endConsumed) {
+      preventDirectTouchDefault(e);
       touchConsumedRef.current = false;
       touchStartRef.current = null;
       touchEndRef.current = null;
@@ -381,6 +465,7 @@ export const useTouchEvent = (bookKey: string) => {
     }
 
     if (layeredTurnOwnedRef.current) {
+      preventDirectTouchDefault(e);
       touchStartRef.current = null;
       touchEndRef.current = null;
       layeredTurnOwnedRef.current = false;
@@ -450,6 +535,14 @@ export const useTouchEvent = (bookKey: string) => {
 
   const onTouchCancel = (e: IframeTouchEvent | React.TouchEvent<HTMLDivElement>) => {
     layeredTurnCandidateRef.current = false;
+    const preventCompatibilityClick = touchConsumedRef.current || layeredTurnOwnedRef.current;
+    cancelLayeredTurnTouch(bookKey);
+    if (preventCompatibilityClick) preventDirectTouchDefault(e);
+    if (reflowableMultiTouchRef.current) {
+      if (e.targetTouches.length === 0) reflowableMultiTouchRef.current = false;
+      clearSingleTouchState();
+      return;
+    }
     if (isPinchingRef.current || pinchPendingRef.current) {
       getView(bookKey)?.renderer.pinchEnd?.();
       isPinchingRef.current = false;

--- a/apps/readest-app/src/app/reader/hooks/useTouchInterceptor.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTouchInterceptor.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react';
 
-// Native captured turns become intentional at this distance. Browser layered
-// turns keep the paginator's stricter claim gate; generic toolbar handling
-// defers its move-time update while that path can still claim the gesture.
+// Generic swipe/tap fallback shared by toolbar and click handling. Layered
+// turns may claim earlier through their edge/trajectory arena, while ambiguous
+// gestures retain this established distance before generic behavior applies.
 export const TOUCH_SWIPE_THRESHOLD_PX = 15;
 
 // Movement below this distance is still a tap. Touchend must leave these

--- a/apps/readest-app/src/app/reader/utils/brightnessGesture.ts
+++ b/apps/readest-app/src/app/reader/utils/brightnessGesture.ts
@@ -12,6 +12,7 @@
 
 export const BRIGHTNESS_GESTURE_EDGE_RATIO = 0.1;
 export const BRIGHTNESS_GESTURE_ACTIVATION_PX = 18;
+export const TURN_GESTURE_LEFT_INSET_ATTRIBUTE = 'turn-gesture-left-inset';
 
 const clamp01 = (v: number): number => Math.max(0, Math.min(1, v));
 

--- a/apps/readest-app/src/app/reader/utils/capturedTurn.ts
+++ b/apps/readest-app/src/app/reader/utils/capturedTurn.ts
@@ -1,5 +1,5 @@
 import { CurlGrab, PageCurlRenderer } from '@/utils/pageCurl';
-import { PageSlideRenderer } from '@/utils/pageSlide';
+import { PageSlideRenderer, type PageSlideSettleOptions } from '@/utils/pageSlide';
 
 /**
  * Captured page-turn orchestration (readest#555, Tauri platforms).
@@ -14,8 +14,9 @@ import { PageSlideRenderer } from '@/utils/pageSlide';
  *   navigate instantly under it → animate/scrub the turn → dispose.
  *
  * Two overlay renderers share the pipeline: the WebGL mesh curl, and the
- * flat slide for engines where the View Transitions slide is unavailable
- * (iOS 18 WebKit crashes on it; older engines lack the API).
+ * flat slide. Mobile Tauri keeps both here so the decoded outgoing page can
+ * be prepared before a gesture; web and desktop builds can use browser View
+ * Transitions for the slide.
  *
  * Backward turns run the same pipeline mirrored: the current page curls or
  * slides away from the spine edge, revealing the previous page underneath —
@@ -35,7 +36,7 @@ export interface CapturedTurnHost {
    * like a physical sheet, matching Apple Books.
    */
   getContentRect: () => DOMRect | null;
-  /** Native webview snapshot of `rect`, as PNG bytes. */
+  /** Native webview snapshot of `rect`, as compressed image bytes. */
   capture: (rect: { x: number; y: number; width: number; height: number }) => Promise<ArrayBuffer>;
   /**
    * Theme paper (background color + texture) drawn on the back of the
@@ -61,12 +62,37 @@ interface TurnRenderer {
   setTexture(source: ImageBitmap): void;
   setBackdrop?(source: TexImageSource): void;
   render(progress: number, grab: CurlGrab, rtl: boolean): void;
+  animateSettle?(options: PageSlideSettleOptions): Animation | null;
   dispose(): void;
 }
 
 interface DragSession {
   progress: number;
   grabY: number;
+}
+
+interface CaptureRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface PreparedCapture {
+  bitmap: ImageBitmap;
+  rect: CaptureRect;
+  hostElement: HTMLElement;
+  dpr: number;
+  /** `undefined` means the warm-up did not request curl paper. */
+  backdrop: TexImageSource | null | undefined;
+}
+
+interface PreparingCapture {
+  epoch: number;
+  rect: CaptureRect;
+  hostElement: HTMLElement;
+  dpr: number;
+  promise: Promise<PreparedCapture | null>;
 }
 
 interface ActiveTurn {
@@ -81,11 +107,40 @@ interface ActiveTurn {
   /** Buffered input and identity token, absent for programmatic turns. */
   dragSession: DragSession | null;
   raf: number;
+  animation: Animation | null;
   /** Resolves when the play-out animation finishes or is interrupted. */
   finish: (() => void) | null;
 }
 
 const easeInOutQuad = (t: number) => (t < 0.5 ? 2 * t * t : 1 - (1 - t) * (1 - t) * 2);
+const easeOutCubic = (t: number) => 1 - (1 - t) ** 3;
+const RELEASE_SETTLE_CONFIG = {
+  slide: { minSpeed: 0.2, maxSpeed: 1, maxPlaybackRate: 2 },
+  curl: { minSpeed: 0.3, maxSpeed: 1.5, maxPlaybackRate: 1.5 },
+} as const satisfies Record<
+  CapturedTurnStyle,
+  { minSpeed: number; maxSpeed: number; maxPlaybackRate: number }
+>;
+const MIN_BOOSTED_SETTLE_MS = 90;
+// easeOutCubic starts with a normalized slope of 3. Limit its blend so a
+// maximum flick starts near the settle's average speed instead of shooting
+// forward at three times that already-boosted rate.
+const MAX_RELEASE_EASE_OUT_BLEND = 1 / 3;
+
+const captureRectFrom = (rect: DOMRect): CaptureRect => ({
+  x: rect.x,
+  y: rect.y,
+  width: rect.width,
+  height: rect.height,
+});
+
+const sameCaptureRect = (a: CaptureRect, b: CaptureRect) =>
+  Math.abs(a.x - b.x) < 0.5 &&
+  Math.abs(a.y - b.y) < 0.5 &&
+  Math.abs(a.width - b.width) < 0.5 &&
+  Math.abs(a.height - b.height) < 0.5;
+
+const currentDpr = () => globalThis.devicePixelRatio || 1;
 
 export class CapturedPageTurn {
   #host: CapturedTurnHost;
@@ -93,11 +148,19 @@ export class CapturedPageTurn {
   #active: ActiveTurn | null = null;
   /** Latest sample and identity for the currently open finger drag. */
   #dragSession: DragSession | null = null;
+  /** Drag lifetimes, including capture/settle after touchend cleared #dragSession. */
+  #busyDragSessions = new Set<DragSession>();
   #disposed = false;
   /** Serializes drag setup/settle and accepted programmatic turns. */
   #pending: Promise<unknown> = Promise.resolve();
   /** True while a programmatic `turn()` is running, gating concurrent ones. */
   #running = false;
+  /** One decoded, idle-time snapshot of the currently visible reader cell. */
+  #preparedCapture: PreparedCapture | null = null;
+  /** Native capture already in flight; a turn can reuse it instead of restarting. */
+  #preparingCapture: PreparingCapture | null = null;
+  /** Invalidates both completed and in-flight prepared captures. */
+  #captureEpoch = 0;
 
   constructor(host: CapturedTurnHost, options: { duration?: number } = {}) {
     this.#host = host;
@@ -106,6 +169,39 @@ export class CapturedPageTurn {
 
   get active(): boolean {
     return this.#active !== null;
+  }
+
+  /**
+   * Decode the current reader cell ahead of the next turn. This intentionally
+   * stops at an ImageBitmap: keeping a full WebGL renderer resident for every
+   * open book costs considerably more GPU memory and risks context eviction.
+   *
+   * Warm-up failures are non-fatal. A later turn simply runs the established
+   * capture path and reports a real platform failure through that path.
+   */
+  async prepareCapture(style: CapturedTurnStyle = 'curl'): Promise<boolean> {
+    if (this.#disposed || this.#active || this.#running || this.#busyDragSessions.size) {
+      return false;
+    }
+    const hostElement = this.#host.getHostElement();
+    const rect = this.#host.getContentRect();
+    if (!hostElement || !rect || rect.width <= 0 || rect.height <= 0) return false;
+    try {
+      return !!(await this.#ensurePreparedCapture(
+        hostElement,
+        captureRectFrom(rect),
+        currentDpr(),
+        style,
+      ));
+    } catch {
+      return false;
+    }
+  }
+
+  /** Drop a stale idle snapshot; an in-flight result is discarded on arrival. */
+  invalidatePreparedCapture() {
+    this.#captureEpoch++;
+    this.#closePreparedCapture();
   }
 
   /**
@@ -162,15 +258,21 @@ export class CapturedPageTurn {
     rtl: boolean,
     style: CapturedTurnStyle = 'curl',
   ): Promise<boolean> {
+    // A finger that lands while a programmatic capture is running belongs to
+    // that navigation epoch. Do not queue a fresh captured turn behind it;
+    // the hook latches the touch until the next touchstart as well.
+    if (this.#running) return false;
     // A replacement drag can arrive when a platform drops the previous
     // touchend. Cancel that specific request before queueing the new one;
     // token matching keeps the synthesized cancellation on its own overlay.
     this.#cancelOpenDrag();
     const session: DragSession = { progress: 0, grabY: 0.5 };
     this.#dragSession = session;
+    this.#busyDragSessions.add(session);
     const run = this.#pending.then(async () => {
       if (this.#disposed) {
         if (this.#dragSession === session) this.#dragSession = null;
+        this.#busyDragSessions.delete(session);
         return false;
       }
       this.#finishActive();
@@ -178,6 +280,7 @@ export class CapturedPageTurn {
         const active = await this.#setUp(forward, rtl, style, session);
         if (!active) {
           if (this.#dragSession === session) this.#dragSession = null;
+          this.#busyDragSessions.delete(session);
           return false;
         }
         // A sample may have arrived before native capture produced an active
@@ -187,6 +290,7 @@ export class CapturedPageTurn {
         return true;
       } catch (error) {
         if (this.#dragSession === session) this.#dragSession = null;
+        this.#busyDragSessions.delete(session);
         throw error;
       }
     });
@@ -211,7 +315,8 @@ export class CapturedPageTurn {
    * Release the drag: play out to the end (commit) or animate back flat and
    * instantly turn the live view back (cancel) — the overlay shows the old
    * page flat while the view underneath returns, so no wrong page ever
-   * flashes.
+   * flashes. `releaseVelocity` is the recent signed finger velocity in
+   * CSS px/ms; it only accelerates a settle when it points toward the target.
    *
    * Serialized on the same chain as beginDrag: the release can arrive while
    * the drag's async capture is still in flight (after an instant-highlight
@@ -220,27 +325,33 @@ export class CapturedPageTurn {
    * that drag stranded — overlay frozen at progress 0 over an already-turned
    * live view, making every following turn off by one page.
    */
-  async endDrag(commit: boolean) {
+  async endDrag(commit: boolean, releaseVelocity = 0) {
     const session = this.#dragSession;
     if (!session) return;
     // Seal the released sample immediately. Late touchmoves cannot mutate a
     // page that has already started committing or returning, while a new
     // beginDrag can safely install its own independent input buffer.
     this.#dragSession = null;
-    return this.#endDrag(session, commit);
+    return this.#endDrag(session, commit, releaseVelocity);
   }
 
-  #endDrag(session: DragSession, commit: boolean) {
+  #endDrag(session: DragSession, commit: boolean, releaseVelocity = 0) {
     const run = this.#pending.then(async () => {
-      if (this.#disposed) return;
+      if (this.#disposed) {
+        this.#busyDragSessions.delete(session);
+        return;
+      }
       const active = this.#active;
-      if (!active || active.dragSession !== session) return;
+      if (!active || active.dragSession !== session) {
+        this.#busyDragSessions.delete(session);
+        return;
+      }
       try {
         this.#applyDragSession(active, session);
         if (commit) {
-          await this.#playTo(active, 1);
+          await this.#playTo(active, 1, releaseVelocity);
         } else {
-          await this.#playTo(active, 0);
+          await this.#playTo(active, 0, releaseVelocity);
           if (this.#active === active) {
             let navigationError: unknown;
             try {
@@ -258,6 +369,7 @@ export class CapturedPageTurn {
         }
       } finally {
         if (this.#active === active) this.#disposeActive();
+        this.#busyDragSessions.delete(session);
       }
     });
     this.#pending = run.catch(() => {});
@@ -287,6 +399,8 @@ export class CapturedPageTurn {
     }
     this.#finishActive();
     this.#dragSession = null;
+    this.#busyDragSessions.clear();
+    this.invalidatePreparedCapture();
   }
 
   async #setUp(
@@ -296,32 +410,82 @@ export class CapturedPageTurn {
     dragSession: DragSession | null = null,
   ): Promise<ActiveTurn | null> {
     if (this.#disposed) return null;
-    const hostElement = this.#host.getHostElement();
-    const rect = this.#host.getContentRect();
+    let hostElement = this.#host.getHostElement();
+    let rect = this.#host.getContentRect();
     if (!hostElement || !rect || rect.width <= 0 || rect.height <= 0) return null;
 
     await this.#host.onBeforeCapture?.(style);
     if (this.#disposed) return null;
-    // Only the curl shows the back of the page; fetch its paper while the
-    // native capture is in flight so it never delays the turn.
-    const backdropPromise =
-      style === 'curl' && this.#host.getBackdrop
-        ? Promise.resolve()
-            .then(() => this.#host.getBackdrop!())
-            .catch(() => null)
+    hostElement = this.#host.getHostElement();
+    rect = this.#host.getContentRect();
+    if (!hostElement || !rect || rect.width <= 0 || rect.height <= 0) return null;
+    let captureRect = captureRectFrom(rect);
+    let dpr = currentDpr();
+    let prepared = this.#takePreparedCapture(hostElement, captureRect, dpr);
+    if (
+      !prepared &&
+      this.#preparingCapture?.epoch === this.#captureEpoch &&
+      this.#preparingCapture.hostElement === hostElement &&
+      this.#preparingCapture.dpr === dpr &&
+      sameCaptureRect(this.#preparingCapture.rect, captureRect)
+    ) {
+      try {
+        await this.#preparingCapture.promise;
+      } catch {
+        // A speculative warm-up must never prevent the normal capture path.
+      }
+      if (this.#disposed) return null;
+      const currentHostElement = this.#host.getHostElement();
+      const currentRect = this.#host.getContentRect();
+      const currentCaptureRect = currentRect ? captureRectFrom(currentRect) : null;
+      const currentCaptureDpr = currentDpr();
+      if (
+        !currentHostElement ||
+        !currentRect ||
+        !currentCaptureRect ||
+        currentRect.width <= 0 ||
+        currentRect.height <= 0
+      ) {
+        return null;
+      }
+      if (
+        currentHostElement !== hostElement ||
+        currentCaptureDpr !== dpr ||
+        !sameCaptureRect(currentCaptureRect, captureRect)
+      ) {
+        // The prepared frame finished after a rotation or layout change. It
+        // is no longer safe to position over the live reader; recapture the
+        // current target instead of using either the old bitmap or old rect.
+        this.invalidatePreparedCapture();
+        hostElement = currentHostElement;
+        rect = currentRect;
+        captureRect = currentCaptureRect;
+        dpr = currentCaptureDpr;
+      } else {
+        prepared = this.#takePreparedCapture(hostElement, captureRect, dpr);
+      }
+    }
+    if (!prepared) {
+      prepared = await this.#capturePrepared(
+        hostElement,
+        captureRect,
+        dpr,
+        style,
+        this.#captureEpoch,
+        false,
+      );
+    }
+    if (!prepared || this.#disposed) {
+      prepared?.bitmap.close();
+      return null;
+    }
+    const bitmap = prepared.bitmap;
+    const backdrop =
+      style === 'curl'
+        ? prepared.backdrop !== undefined
+          ? prepared.backdrop
+          : await this.#getBackdrop()
         : null;
-    const image = await this.#host.capture({
-      x: rect.x,
-      y: rect.y,
-      width: rect.width,
-      height: rect.height,
-    });
-    if (this.#disposed) return null;
-    // No mime: the platforms return different formats (PNG on iOS/macOS,
-    // JPEG on Android where PNG encoding took ~1.5s per turn) and the
-    // decoder sniffs the actual format from the bytes.
-    const bitmap = await createImageBitmap(new Blob([image]));
-    const backdrop = backdropPromise ? await backdropPromise : null;
     if (this.#disposed) {
       bitmap.close();
       return null;
@@ -368,6 +532,7 @@ export class CapturedPageTurn {
       grabY: 0.5,
       dragSession,
       raf: 0,
+      animation: null,
       finish: null,
     };
     this.#active = active;
@@ -408,28 +573,216 @@ export class CapturedPageTurn {
     active.renderer.render(active.progress, this.#grab(active), active.rendererRtl);
   }
 
+  async #ensurePreparedCapture(
+    hostElement: HTMLElement,
+    rect: CaptureRect,
+    dpr: number,
+    style: CapturedTurnStyle,
+  ): Promise<PreparedCapture | null> {
+    const cached = this.#preparedCapture;
+    if (
+      cached &&
+      cached.hostElement === hostElement &&
+      cached.dpr === dpr &&
+      sameCaptureRect(cached.rect, rect)
+    ) {
+      if (style !== 'curl' || cached.backdrop !== undefined) return cached;
+      cached.backdrop = await this.#getBackdrop();
+      return this.#preparedCapture === cached ? cached : null;
+    }
+    if (cached) this.#closePreparedCapture();
+
+    const epoch = this.#captureEpoch;
+    const pending = this.#preparingCapture;
+    if (pending) {
+      if (
+        pending.epoch === epoch &&
+        pending.hostElement === hostElement &&
+        pending.dpr === dpr &&
+        sameCaptureRect(pending.rect, rect)
+      ) {
+        const result = await pending.promise;
+        if (result && style === 'curl' && result.backdrop === undefined) {
+          result.backdrop = await this.#getBackdrop();
+        }
+        return this.#preparedCapture === result ? result : null;
+      }
+      try {
+        await pending.promise;
+      } catch {
+        // Its epoch or geometry is stale; create the requested frame below.
+      }
+      if (this.#disposed || epoch !== this.#captureEpoch) return null;
+    }
+
+    const promise = this.#capturePrepared(hostElement, rect, dpr, style, epoch).then((result) => {
+      if (!result) return null;
+      if (this.#disposed || epoch !== this.#captureEpoch) {
+        result.bitmap.close();
+        return null;
+      }
+      this.#closePreparedCapture();
+      this.#preparedCapture = result;
+      return result;
+    });
+    const preparing: PreparingCapture = { epoch, rect, hostElement, dpr, promise };
+    this.#preparingCapture = preparing;
+    try {
+      return await promise;
+    } finally {
+      if (this.#preparingCapture === preparing) this.#preparingCapture = null;
+    }
+  }
+
+  async #capturePrepared(
+    hostElement: HTMLElement,
+    rect: CaptureRect,
+    dpr: number,
+    style: CapturedTurnStyle,
+    epoch: number,
+    discardWhenStale = true,
+  ): Promise<PreparedCapture | null> {
+    const backdropPromise = style === 'curl' ? this.#getBackdrop() : Promise.resolve(undefined);
+    const image = await this.#host.capture(rect);
+    if (this.#disposed || (discardWhenStale && epoch !== this.#captureEpoch)) return null;
+    // No mime: the platforms return different formats (PNG on macOS,
+    // JPEG on iOS/Android) and the decoder sniffs the bytes.
+    const bitmap = await createImageBitmap(new Blob([image]));
+    const backdrop = await backdropPromise;
+    if (this.#disposed || (discardWhenStale && epoch !== this.#captureEpoch)) {
+      bitmap.close();
+      return null;
+    }
+    return { bitmap, rect, hostElement, dpr, backdrop };
+  }
+
+  #getBackdrop(): Promise<TexImageSource | null> {
+    if (!this.#host.getBackdrop) return Promise.resolve(null);
+    return Promise.resolve()
+      .then(() => this.#host.getBackdrop!())
+      .catch(() => null);
+  }
+
+  #takePreparedCapture(
+    hostElement: HTMLElement,
+    rect: CaptureRect,
+    dpr: number,
+  ): PreparedCapture | null {
+    const prepared = this.#preparedCapture;
+    if (!prepared) return null;
+    if (
+      prepared.hostElement !== hostElement ||
+      prepared.dpr !== dpr ||
+      !sameCaptureRect(prepared.rect, rect)
+    ) {
+      this.#closePreparedCapture();
+      return null;
+    }
+    this.#preparedCapture = null;
+    return prepared;
+  }
+
+  #closePreparedCapture() {
+    this.#preparedCapture?.bitmap.close();
+    this.#preparedCapture = null;
+  }
+
   /** Animate the active turn from its current progress to `target`. */
-  #playTo(active: ActiveTurn, target: number): Promise<void> {
+  #playTo(active: ActiveTurn, target: number, releaseVelocity = 0): Promise<void> {
     return new Promise((resolve) => {
       const from = active.progress;
       const span = target - from;
       if (span === 0) return resolve();
-      const duration = Math.max(1, this.#duration * Math.abs(span));
-      const start = performance.now();
+      const towardTarget = releaseVelocity * span > 0;
+      const { minSpeed, maxSpeed, maxPlaybackRate } = RELEASE_SETTLE_CONFIG[active.style];
+      const speedRange = maxSpeed - minSpeed;
+      const releaseBoost = towardTarget
+        ? Math.max(0, Math.min(1, (Math.abs(releaseVelocity) - minSpeed) / speedRange))
+        : 0;
+      const playbackRate = 1 + (maxPlaybackRate - 1) * releaseBoost;
+      const baseDuration = Math.max(1, this.#duration * Math.abs(span));
+      const duration =
+        releaseBoost > 0
+          ? Math.max(Math.min(MIN_BOOSTED_SETTLE_MS, baseDuration), baseDuration / playbackRate)
+          : baseDuration;
+      const easeOutBlend = releaseBoost * MAX_RELEASE_EASE_OUT_BLEND;
+      const easing = (t: number) =>
+        easeInOutQuad(t) * (1 - easeOutBlend) + easeOutCubic(t) * easeOutBlend;
       active.finish = resolve;
-      const step = (now: number) => {
-        if (this.#active !== active) return resolve();
-        const t = Math.min(1, (now - start) / duration);
-        active.progress = from + span * easeInOutQuad(t);
-        active.renderer.render(active.progress, this.#grab(active), active.rendererRtl);
-        if (t < 1) {
-          active.raf = requestAnimationFrame(step);
-        } else {
-          active.finish = null;
-          resolve();
-        }
+
+      const runRafFallback = () => {
+        const start = performance.now();
+        const step = (now: number) => {
+          if (this.#active !== active) return resolve();
+          const t = Math.min(1, (now - start) / duration);
+          active.progress = from + span * easing(t);
+          active.renderer.render(active.progress, this.#grab(active), active.rendererRtl);
+          if (t < 1) {
+            active.raf = requestAnimationFrame(step);
+          } else {
+            active.finish = null;
+            resolve();
+          }
+        };
+        active.raf = requestAnimationFrame(step);
       };
-      active.raf = requestAnimationFrame(step);
+
+      let animation: Animation | null = null;
+      try {
+        animation =
+          active.renderer.animateSettle?.({
+            from,
+            target,
+            rtl: active.rendererRtl,
+            duration,
+            easing,
+          }) ?? null;
+      } catch {
+        // A partial/buggy WAAPI implementation falls back to the established
+        // requestAnimationFrame path instead of breaking the turn.
+      }
+      if (!animation) return runRafFallback();
+
+      const settleAnimation = animation;
+      active.animation = settleAnimation;
+      let settled = false;
+      const clearHandlers = () => {
+        settleAnimation.onfinish = null;
+        settleAnimation.oncancel = null;
+      };
+      const finishSettle = () => {
+        if (settled) return;
+        settled = true;
+        if (this.#active !== active || active.animation !== settleAnimation) return resolve();
+        // Persist the terminal transform before removing the fill effect. This
+        // is essential on cancellation: the old page must remain flat while
+        // the live paginator and toolbar are restored underneath it.
+        active.progress = target;
+        active.renderer.render(target, this.#grab(active), active.rendererRtl);
+        active.animation = null;
+        active.finish = null;
+        clearHandlers();
+        settleAnimation.cancel();
+        resolve();
+      };
+      const cancelSettle = () => {
+        if (settled) return;
+        settled = true;
+        if (this.#active !== active || active.animation !== settleAnimation) return resolve();
+        active.animation = null;
+        clearHandlers();
+        runRafFallback();
+      };
+      settleAnimation.onfinish = finishSettle;
+      settleAnimation.oncancel = cancelSettle;
+      // Some older WebViews have dropped finish events while still resolving
+      // Animation.finished. Listen to both channels through the same idempotent
+      // handlers; partial implementations can keep using the event callbacks.
+      try {
+        void settleAnimation.finished.then(finishSettle, cancelSettle);
+      } catch {
+        // `finished` is not essential when onfinish/oncancel are available.
+      }
     });
   }
 
@@ -441,8 +794,16 @@ export class CapturedPageTurn {
     if (active.dragSession && this.#dragSession === active.dragSession) {
       this.#dragSession = null;
     }
+    const finish = active.finish;
+    active.finish = null;
+    if (active.animation) {
+      active.animation.onfinish = null;
+      active.animation.oncancel = null;
+      active.animation.cancel();
+      active.animation = null;
+    }
     cancelAnimationFrame(active.raf);
-    active.finish?.();
+    finish?.();
     active.renderer.dispose();
     active.overlay.remove();
   }

--- a/apps/readest-app/src/app/reader/utils/capturedTurn.ts
+++ b/apps/readest-app/src/app/reader/utils/capturedTurn.ts
@@ -39,6 +39,16 @@ export interface CapturedTurnHost {
   /** Native webview snapshot of `rect`, as compressed image bytes. */
   capture: (rect: { x: number; y: number; width: number; height: number }) => Promise<ArrayBuffer>;
   /**
+   * Temporarily remove non-interactive chrome from a native pixel capture.
+   * Returns a cleanup that restores it after the platform snapshot resolves.
+   */
+  preparePixelCapture?: () =>
+    | void
+    | (() => void | Promise<void>)
+    | Promise<void | (() => void | Promise<void>)>;
+  /** Whether a freshly captured frame is still safe to reveal and navigate. */
+  isCaptureAllowed?: () => boolean;
+  /**
    * Theme paper (background color + texture) drawn on the back of the
    * curling page. Fetched concurrently with the capture; a missing or
    * failing backdrop falls back to the renderer's plain white back.
@@ -46,8 +56,13 @@ export interface CapturedTurnHost {
   getBackdrop?: () => Promise<TexImageSource | null> | TexImageSource | null;
   /** Records live UI state before the native snapshot starts. */
   onBeforeCapture?: (style: CapturedTurnStyle) => void | Promise<void>;
-  /** Called once the flat captured frame covers the live reader. */
-  onCovered?: (style: CapturedTurnStyle) => void | Promise<void>;
+  /**
+   * Called once the flat captured frame covers the live reader. A prepared
+   * surface has already spent a painted frame in the real host, so its reveal
+   * can be synchronized with the live chrome without another conservative
+   * compositor wait.
+   */
+  onCovered?: (style: CapturedTurnStyle, surfaceAlreadyPainted: boolean) => void | Promise<void>;
   /** Called under the restored flat frame before a cancelled turn is removed. */
   onCancelled?: (style: CapturedTurnStyle) => void | Promise<void>;
   /** Instant (animation-less) page turn of the live view. */
@@ -58,9 +73,11 @@ export type CapturedTurnStyle = 'curl' | 'slide';
 
 /** What the overlay draws each frame; PageCurlRenderer and PageSlideRenderer. */
 interface TurnRenderer {
-  attach(container: HTMLElement, width: number, height: number): void;
+  attach(container: HTMLElement, width: number, height: number, dpr?: number): void;
   setTexture(source: ImageBitmap): void;
   setBackdrop?(source: TexImageSource): void;
+  /** Whether an idle GPU surface survived context eviction. */
+  isUsable?(): boolean;
   render(progress: number, grab: CurlGrab, rtl: boolean): void;
   animateSettle?(options: PageSlideSettleOptions): Animation | null;
   dispose(): void;
@@ -78,21 +95,35 @@ interface CaptureRect {
   height: number;
 }
 
-interface PreparedCapture {
-  bitmap: ImageBitmap;
-  rect: CaptureRect;
+interface CaptureTarget {
   hostElement: HTMLElement;
+  rect: CaptureRect;
   dpr: number;
-  /** `undefined` means the warm-up did not request curl paper. */
-  backdrop: TexImageSource | null | undefined;
 }
 
-interface PreparingCapture {
-  epoch: number;
+interface PreparedSurface {
+  /** Renderer initialized, texture-uploaded, and mounted in the real host. */
+  renderer: TurnRenderer;
+  /** Low-alpha layer kept in the compositor tree until a turn consumes it. */
+  overlay: HTMLDivElement;
+  style: CapturedTurnStyle;
   rect: CaptureRect;
   hostElement: HTMLElement;
   dpr: number;
-  promise: Promise<PreparedCapture | null>;
+  /** True after the low-alpha layer has survived a complete paint. */
+  surfaceAlreadyPainted: boolean;
+  /** Nested paint-tracking RAF, cancelled when the surface is consumed. */
+  paintRaf: number;
+}
+
+interface PreparingSurface {
+  captureEpoch: number;
+  preparedEpoch: number;
+  rect: CaptureRect;
+  hostElement: HTMLElement;
+  dpr: number;
+  style: CapturedTurnStyle;
+  promise: Promise<PreparedSurface | null>;
 }
 
 interface ActiveTurn {
@@ -115,6 +146,8 @@ interface ActiveTurn {
 const easeInOutQuad = (t: number) => (t < 0.5 ? 2 * t * t : 1 - (1 - t) * (1 - t) * 2);
 const easeOutCubic = (t: number) => 1 - (1 - t) ** 3;
 const RELEASE_SETTLE_CONFIG = {
+  // Keep a visible momentum lift without compressing a half-page tail into
+  // the ~90ms range, which looks choppy even when every display frame lands.
   slide: { minSpeed: 0.2, maxSpeed: 1, maxPlaybackRate: 2 },
   curl: { minSpeed: 0.3, maxSpeed: 1.5, maxPlaybackRate: 1.5 },
 } as const satisfies Record<
@@ -142,6 +175,24 @@ const sameCaptureRect = (a: CaptureRect, b: CaptureRect) =>
 
 const currentDpr = () => globalThis.devicePixelRatio || 1;
 
+// A strictly zero-opacity layer can be skipped by mobile compositors. Keep the
+// prepared surface imperceptibly present so its canvas/WebGL backing store and
+// texture upload are promoted before the gesture reveals it.
+const PREPARED_SURFACE_WARM_OPACITY = '0.004';
+
+// A full-screen high-DPR canvas or WebGL surface can occupy tens of megabytes.
+// Several reader cells may stay mounted, so keep one speculative idle surface
+// process-wide and stop creating more while any full-screen turn is active.
+let preparedSurfaceOwner: CapturedPageTurn | null = null;
+/** One speculative idle warm-up may allocate at a time across reader cells. */
+let idlePreparingOwner: CapturedPageTurn | null = null;
+/** All controllers with prepared native capture work currently in flight. */
+const preparingSurfaceOwners = new Set<CapturedPageTurn>();
+/** A touch lease protects completed and replacement surfaces until claim/end. */
+let preparedSurfaceLeaseOwner: CapturedPageTurn | null = null;
+/** Active surfaces also consume the process-wide full-screen surface budget. */
+const activeSurfaceOwners = new Set<CapturedPageTurn>();
+
 export class CapturedPageTurn {
   #host: CapturedTurnHost;
   #duration: number;
@@ -155,12 +206,16 @@ export class CapturedPageTurn {
   #pending: Promise<unknown> = Promise.resolve();
   /** True while a programmatic `turn()` is running, gating concurrent ones. */
   #running = false;
-  /** One decoded, idle-time snapshot of the currently visible reader cell. */
-  #preparedCapture: PreparedCapture | null = null;
-  /** Native capture already in flight; a turn can reuse it instead of restarting. */
-  #preparingCapture: PreparingCapture | null = null;
-  /** Invalidates both completed and in-flight prepared captures. */
+  /** One renderer-ready, idle-time surface of the visible reader cell. */
+  #preparedSurface: PreparedSurface | null = null;
+  /** Prevents another reader cell from evicting this touch's warm surface. */
+  #preparedSurfaceRetained = false;
+  /** Native capture/surface construction already in flight. */
+  #preparingSurface: PreparingSurface | null = null;
+  /** Invalidates both completed and in-flight prepared surfaces. */
   #captureEpoch = 0;
+  /** Invalidates only speculative/touch warm-up work, never an active cold turn. */
+  #preparedEpoch = 0;
 
   constructor(host: CapturedTurnHost, options: { duration?: number } = {}) {
     this.#host = host;
@@ -172,9 +227,10 @@ export class CapturedPageTurn {
   }
 
   /**
-   * Decode the current reader cell ahead of the next turn. This intentionally
-   * stops at an ImageBitmap: keeping a full WebGL renderer resident for every
-   * open book costs considerably more GPU memory and risks context eviction.
+   * Build the current reader cell into a renderer-ready surface ahead of the
+   * next turn. Capture, decode, canvas/WebGL creation, texture upload, mounting,
+   * and the first flat draw all happen outside the gesture's critical path.
+   * A module-level one-surface budget bounds idle GPU memory across open books.
    *
    * Warm-up failures are non-fatal. A later turn simply runs the established
    * capture path and reports a real platform failure through that path.
@@ -183,25 +239,81 @@ export class CapturedPageTurn {
     if (this.#disposed || this.#active || this.#running || this.#busyDragSessions.size) {
       return false;
     }
-    const hostElement = this.#host.getHostElement();
-    const rect = this.#host.getContentRect();
-    if (!hostElement || !rect || rect.width <= 0 || rect.height <= 0) return false;
+    if (preparedSurfaceLeaseOwner && preparedSurfaceLeaseOwner !== this) {
+      return false;
+    }
+    if ([...activeSurfaceOwners].some((owner) => owner !== this)) return false;
+    const target = this.#readCaptureTarget();
+    if (!target) return false;
+    const idlePreparation = !this.#preparedSurfaceRetained;
+    if (idlePreparation) {
+      // All mounted BookCells schedule the same idle work. Serializing the
+      // speculative path prevents a burst of native snapshots and full-screen
+      // GPU uploads; a real touch lease is latency-sensitive and may bypass it.
+      if (
+        activeSurfaceOwners.size > 0 ||
+        (preparedSurfaceOwner && preparedSurfaceOwner !== this) ||
+        (idlePreparingOwner && idlePreparingOwner !== this) ||
+        [...preparingSurfaceOwners].some((owner) => owner !== this)
+      ) {
+        return false;
+      }
+      idlePreparingOwner = this;
+    } else {
+      // A real touch takes the idle budget before it allocates another
+      // full-screen surface. Late results from the previous owner stop before
+      // decode/upload, and its completed low-alpha layer is removed now.
+      for (const owner of preparingSurfaceOwners) {
+        if (owner !== this) owner.invalidatePendingPreparedCapture();
+      }
+      if (idlePreparingOwner && idlePreparingOwner !== this) {
+        idlePreparingOwner.invalidatePendingPreparedCapture();
+      }
+      if (preparedSurfaceOwner && preparedSurfaceOwner !== this) {
+        preparedSurfaceOwner.#closePreparedSurface();
+      }
+    }
     try {
-      return !!(await this.#ensurePreparedCapture(
-        hostElement,
-        captureRectFrom(rect),
-        currentDpr(),
+      return !!(await this.#ensurePreparedSurface(
+        target.hostElement,
+        target.rect,
+        target.dpr,
         style,
       ));
     } catch {
       return false;
+    } finally {
+      if (idlePreparation && idlePreparingOwner === this) idlePreparingOwner = null;
     }
+  }
+
+  /** Hold this controller's current or in-flight surface until claim/release. */
+  retainPreparedCapture() {
+    if (this.#disposed) return;
+    if (preparedSurfaceLeaseOwner && preparedSurfaceLeaseOwner !== this) {
+      preparedSurfaceLeaseOwner.#preparedSurfaceRetained = false;
+    }
+    preparedSurfaceLeaseOwner = this;
+    this.#preparedSurfaceRetained = true;
+  }
+
+  /** Release a touch that ended without consuming the prepared surface. */
+  releasePreparedCapture() {
+    this.#preparedSurfaceRetained = false;
+    if (preparedSurfaceLeaseOwner === this) preparedSurfaceLeaseOwner = null;
   }
 
   /** Drop a stale idle snapshot; an in-flight result is discarded on arrival. */
   invalidatePreparedCapture() {
+    this.releasePreparedCapture();
     this.#captureEpoch++;
-    this.#closePreparedCapture();
+    this.#preparedEpoch++;
+    this.#closePreparedSurface(false);
+  }
+
+  /** Cancel only warm-up work while preserving a clean completed surface. */
+  invalidatePendingPreparedCapture() {
+    this.#preparedEpoch++;
   }
 
   /**
@@ -227,8 +339,18 @@ export class CapturedPageTurn {
       try {
         if (this.#disposed) return false;
         this.#finishActive();
-        const active = await this.#setUp(forward, rtl, style);
-        if (!active) return false;
+        if (!this.#reserveActiveSurface()) return false;
+        let active: ActiveTurn | null;
+        try {
+          active = await this.#setUp(forward, rtl, style);
+        } catch (error) {
+          activeSurfaceOwners.delete(this);
+          throw error;
+        }
+        if (!active) {
+          activeSurfaceOwners.delete(this);
+          return false;
+        }
         try {
           await this.#playTo(active, 1);
           return true;
@@ -276,9 +398,15 @@ export class CapturedPageTurn {
         return false;
       }
       this.#finishActive();
+      if (!this.#reserveActiveSurface()) {
+        if (this.#dragSession === session) this.#dragSession = null;
+        this.#busyDragSessions.delete(session);
+        return false;
+      }
       try {
         const active = await this.#setUp(forward, rtl, style, session);
         if (!active) {
+          activeSurfaceOwners.delete(this);
           if (this.#dragSession === session) this.#dragSession = null;
           this.#busyDragSessions.delete(session);
           return false;
@@ -289,6 +417,7 @@ export class CapturedPageTurn {
         this.#applyDragSession(active, session);
         return true;
       } catch (error) {
+        activeSurfaceOwners.delete(this);
         if (this.#dragSession === session) this.#dragSession = null;
         this.#busyDragSessions.delete(session);
         throw error;
@@ -398,9 +527,18 @@ export class CapturedPageTurn {
       }
     }
     this.#finishActive();
+    preparingSurfaceOwners.delete(this);
+    if (idlePreparingOwner === this) idlePreparingOwner = null;
     this.#dragSession = null;
     this.#busyDragSessions.clear();
     this.invalidatePreparedCapture();
+  }
+
+  #readCaptureTarget(): CaptureTarget | null {
+    const hostElement = this.#host.getHostElement();
+    const rect = this.#host.getContentRect();
+    if (!hostElement?.isConnected || !rect || rect.width <= 0 || rect.height <= 0) return null;
+    return { hostElement, rect: captureRectFrom(rect), dpr: currentDpr() };
   }
 
   async #setUp(
@@ -410,114 +548,137 @@ export class CapturedPageTurn {
     dragSession: DragSession | null = null,
   ): Promise<ActiveTurn | null> {
     if (this.#disposed) return null;
-    let hostElement = this.#host.getHostElement();
-    let rect = this.#host.getContentRect();
-    if (!hostElement || !rect || rect.width <= 0 || rect.height <= 0) return null;
+    let target = this.#readCaptureTarget();
+    if (!target) {
+      this.releasePreparedCapture();
+      return null;
+    }
 
     await this.#host.onBeforeCapture?.(style);
-    if (this.#disposed) return null;
-    hostElement = this.#host.getHostElement();
-    rect = this.#host.getContentRect();
-    if (!hostElement || !rect || rect.width <= 0 || rect.height <= 0) return null;
-    let captureRect = captureRectFrom(rect);
-    let dpr = currentDpr();
-    let prepared = this.#takePreparedCapture(hostElement, captureRect, dpr);
-    if (
-      !prepared &&
-      this.#preparingCapture?.epoch === this.#captureEpoch &&
-      this.#preparingCapture.hostElement === hostElement &&
-      this.#preparingCapture.dpr === dpr &&
-      sameCaptureRect(this.#preparingCapture.rect, captureRect)
-    ) {
+    if (this.#disposed) {
+      this.releasePreparedCapture();
+      return null;
+    }
+    target = this.#readCaptureTarget();
+    if (!target) {
+      this.releasePreparedCapture();
+      return null;
+    }
+    let { hostElement, rect: captureRect, dpr } = target;
+    let surface = this.#takePreparedSurface(hostElement, captureRect, dpr, style);
+    let surfaceAlreadyPainted = surface?.surfaceAlreadyPainted ?? false;
+    const preparing = this.#preparingSurface;
+    const preparingMatches =
+      !!preparing &&
+      preparing.captureEpoch === this.#captureEpoch &&
+      preparing.preparedEpoch === this.#preparedEpoch &&
+      preparing.hostElement === hostElement &&
+      preparing.dpr === dpr &&
+      preparing.style === style &&
+      sameCaptureRect(preparing.rect, captureRect);
+    if (!surface && preparing && !preparingMatches) {
+      // Never let an old style/geometry warm-up finish after this turn and
+      // cache the outgoing page as the next page's prepared surface.
+      this.invalidatePreparedCapture();
+    }
+    if (!surface && preparing && preparingMatches) {
       try {
-        await this.#preparingCapture.promise;
+        await preparing.promise;
       } catch {
         // A speculative warm-up must never prevent the normal capture path.
       }
       if (this.#disposed) return null;
-      const currentHostElement = this.#host.getHostElement();
-      const currentRect = this.#host.getContentRect();
-      const currentCaptureRect = currentRect ? captureRectFrom(currentRect) : null;
-      const currentCaptureDpr = currentDpr();
-      if (
-        !currentHostElement ||
-        !currentRect ||
-        !currentCaptureRect ||
-        currentRect.width <= 0 ||
-        currentRect.height <= 0
-      ) {
+      const currentTarget = this.#readCaptureTarget();
+      if (!currentTarget) {
+        this.invalidatePreparedCapture();
         return null;
       }
       if (
-        currentHostElement !== hostElement ||
-        currentCaptureDpr !== dpr ||
-        !sameCaptureRect(currentCaptureRect, captureRect)
+        currentTarget.hostElement !== hostElement ||
+        currentTarget.dpr !== dpr ||
+        !sameCaptureRect(currentTarget.rect, captureRect)
       ) {
         // The prepared frame finished after a rotation or layout change. It
         // is no longer safe to position over the live reader; recapture the
-        // current target instead of using either the old bitmap or old rect.
+        // current target instead of using either the old surface or old rect.
         this.invalidatePreparedCapture();
-        hostElement = currentHostElement;
-        rect = currentRect;
-        captureRect = currentCaptureRect;
-        dpr = currentCaptureDpr;
+        hostElement = currentTarget.hostElement;
+        captureRect = currentTarget.rect;
+        dpr = currentTarget.dpr;
       } else {
-        prepared = this.#takePreparedCapture(hostElement, captureRect, dpr);
+        surface = this.#takePreparedSurface(hostElement, captureRect, dpr, style);
+        surfaceAlreadyPainted = surface?.surfaceAlreadyPainted ?? false;
       }
     }
-    if (!prepared) {
-      prepared = await this.#capturePrepared(
+    if (!surface) {
+      // No prepared surface remains to protect. A cold live capture does not
+      // participate in the global idle-surface budget.
+      this.releasePreparedCapture();
+      const coldCaptureEpoch = this.#captureEpoch;
+      surface = await this.#captureSurface(
         hostElement,
         captureRect,
         dpr,
         style,
-        this.#captureEpoch,
+        coldCaptureEpoch,
+        true,
         false,
       );
+      if (this.#disposed) {
+        if (surface) this.#disposeSurface(surface);
+        return null;
+      }
+
+      // Native capture can span a rotation, resize, or grid-cell replacement.
+      // Never mount the old pixels at new geometry: retry the current target
+      // once, then abort if layout is still moving.
+      let currentTarget = this.#readCaptureTarget();
+      if (!currentTarget) {
+        if (surface) this.#disposeSurface(surface);
+        return null;
+      }
+      if (
+        currentTarget.hostElement !== hostElement ||
+        currentTarget.dpr !== dpr ||
+        !sameCaptureRect(currentTarget.rect, captureRect)
+      ) {
+        if (surface) this.#disposeSurface(surface);
+        hostElement = currentTarget.hostElement;
+        captureRect = currentTarget.rect;
+        dpr = currentTarget.dpr;
+        surface = await this.#captureSurface(
+          hostElement,
+          captureRect,
+          dpr,
+          style,
+          this.#captureEpoch,
+          true,
+          false,
+        );
+        currentTarget = this.#readCaptureTarget();
+        if (
+          !currentTarget ||
+          currentTarget.hostElement !== hostElement ||
+          currentTarget.dpr !== dpr ||
+          !sameCaptureRect(currentTarget.rect, captureRect)
+        ) {
+          if (surface) this.#disposeSurface(surface);
+          return null;
+        }
+      }
     }
-    if (!prepared || this.#disposed) {
-      prepared?.bitmap.close();
+    if (!surface || this.#disposed) {
+      if (surface) this.#disposeSurface(surface);
       return null;
     }
-    const bitmap = prepared.bitmap;
-    const backdrop =
-      style === 'curl'
-        ? prepared.backdrop !== undefined
-          ? prepared.backdrop
-          : await this.#getBackdrop()
-        : null;
-    if (this.#disposed) {
-      bitmap.close();
+    if (this.#host.isCaptureAllowed?.() === false) {
+      this.#disposeSurface(surface);
       return null;
     }
-
-    // Position the overlay at the content box within the host element.
-    const hostRect = hostElement.getBoundingClientRect();
-    const overlay = document.createElement('div');
-    Object.assign(overlay.style, {
-      position: 'absolute',
-      left: `${rect.left - hostRect.left}px`,
-      top: `${rect.top - hostRect.top}px`,
-      width: `${rect.width}px`,
-      height: `${rect.height}px`,
-      pointerEvents: 'none',
-      zIndex: '50',
-    });
-    hostElement.appendChild(overlay);
-
-    const renderer: TurnRenderer =
-      style === 'slide' ? new PageSlideRenderer() : new PageCurlRenderer();
-    try {
-      renderer.attach(overlay, rect.width, rect.height);
-      renderer.setTexture(bitmap);
-      if (backdrop) renderer.setBackdrop?.(backdrop);
-    } catch (error) {
-      renderer.dispose();
-      overlay.remove();
-      throw error;
-    } finally {
-      bitmap.close();
-    }
+    const { overlay, renderer } = surface;
+    this.#positionOverlay(overlay, hostElement, captureRect);
+    overlay.dataset['capturedTurnPrepared'] = 'false';
+    overlay.style.opacity = '1';
 
     const active: ActiveTurn = {
       overlay,
@@ -541,8 +702,37 @@ export class CapturedPageTurn {
     // hiding the instant page swap happening underneath.
     try {
       renderer.render(0, this.#grab(active), active.rendererRtl);
-      await this.#host.onCovered?.(style);
+      if (renderer.isUsable?.() === false) {
+        throw new Error('Captured page-turn renderer became unavailable before navigation');
+      }
+      await this.#host.onCovered?.(style, surfaceAlreadyPainted);
       if (this.#disposed || this.#active !== active) return null;
+      if (this.#host.isCaptureAllowed?.() === false) {
+        try {
+          await this.#host.onCancelled?.(style);
+        } finally {
+          if (this.#active === active) this.#disposeActive();
+        }
+        return null;
+      }
+      if (renderer.isUsable?.() === false) {
+        throw new Error('Captured page-turn renderer became unavailable before navigation');
+      }
+      const currentTarget = this.#readCaptureTarget();
+      if (
+        !currentTarget ||
+        currentTarget.hostElement !== hostElement ||
+        currentTarget.dpr !== dpr ||
+        !sameCaptureRect(currentTarget.rect, captureRect)
+      ) {
+        try {
+          await this.#host.onCancelled?.(style);
+        } catch {
+          // Target loss still has to remove the stale full-screen surface.
+        }
+        if (this.#active === active) this.#disposeActive();
+        return null;
+      }
       await this.#host.navigate(forward);
       if (this.#disposed || this.#active !== active) return null;
       return active;
@@ -573,87 +763,209 @@ export class CapturedPageTurn {
     active.renderer.render(active.progress, this.#grab(active), active.rendererRtl);
   }
 
-  async #ensurePreparedCapture(
+  async #ensurePreparedSurface(
     hostElement: HTMLElement,
     rect: CaptureRect,
     dpr: number,
     style: CapturedTurnStyle,
-  ): Promise<PreparedCapture | null> {
-    const cached = this.#preparedCapture;
+  ): Promise<PreparedSurface | null> {
+    const cached = this.#preparedSurface;
     if (
       cached &&
       cached.hostElement === hostElement &&
+      cached.overlay.parentElement === hostElement &&
+      hostElement.isConnected &&
       cached.dpr === dpr &&
+      cached.style === style &&
+      cached.renderer.isUsable?.() !== false &&
       sameCaptureRect(cached.rect, rect)
     ) {
-      if (style !== 'curl' || cached.backdrop !== undefined) return cached;
-      cached.backdrop = await this.#getBackdrop();
-      return this.#preparedCapture === cached ? cached : null;
+      return cached;
     }
-    if (cached) this.#closePreparedCapture();
+    // Internal replacement must not drop the touchstart lease while the new
+    // style/geometry/context is still being prepared.
+    if (cached) this.#closePreparedSurface(false);
 
-    const epoch = this.#captureEpoch;
-    const pending = this.#preparingCapture;
+    const captureEpoch = this.#captureEpoch;
+    const preparedEpoch = this.#preparedEpoch;
+    const pending = this.#preparingSurface;
     if (pending) {
       if (
-        pending.epoch === epoch &&
+        pending.captureEpoch === captureEpoch &&
+        pending.preparedEpoch === preparedEpoch &&
         pending.hostElement === hostElement &&
         pending.dpr === dpr &&
+        pending.style === style &&
         sameCaptureRect(pending.rect, rect)
       ) {
         const result = await pending.promise;
-        if (result && style === 'curl' && result.backdrop === undefined) {
-          result.backdrop = await this.#getBackdrop();
-        }
-        return this.#preparedCapture === result ? result : null;
+        return this.#preparedSurface === result ? result : null;
       }
       try {
         await pending.promise;
       } catch {
         // Its epoch or geometry is stale; create the requested frame below.
       }
-      if (this.#disposed || epoch !== this.#captureEpoch) return null;
-    }
-
-    const promise = this.#capturePrepared(hostElement, rect, dpr, style, epoch).then((result) => {
-      if (!result) return null;
-      if (this.#disposed || epoch !== this.#captureEpoch) {
-        result.bitmap.close();
+      if (
+        this.#disposed ||
+        captureEpoch !== this.#captureEpoch ||
+        preparedEpoch !== this.#preparedEpoch
+      ) {
         return null;
       }
-      this.#closePreparedCapture();
-      this.#preparedCapture = result;
-      return result;
+      // Re-read both the cached surface and in-flight request after waiting.
+      // Multiple callers can be queued behind the same mismatched warm-up;
+      // recursion lets the first caller install the replacement and every
+      // later caller join it instead of allocating duplicate GPU surfaces.
+      return this.#ensurePreparedSurface(hostElement, rect, dpr, style);
+    }
+
+    preparingSurfaceOwners.add(this);
+    const promise = this.#captureSurface(
+      hostElement,
+      rect,
+      dpr,
+      style,
+      captureEpoch,
+      true,
+      true,
+      () => preparedEpoch === this.#preparedEpoch,
+    ).then((result) => {
+      if (!result) return null;
+      if (
+        this.#disposed ||
+        captureEpoch !== this.#captureEpoch ||
+        preparedEpoch !== this.#preparedEpoch
+      ) {
+        this.#disposeSurface(result);
+        return null;
+      }
+      return this.#storePreparedSurface(result) ? result : null;
     });
-    const preparing: PreparingCapture = { epoch, rect, hostElement, dpr, promise };
-    this.#preparingCapture = preparing;
+    const preparing: PreparingSurface = {
+      captureEpoch,
+      preparedEpoch,
+      rect,
+      hostElement,
+      dpr,
+      style,
+      promise,
+    };
+    this.#preparingSurface = preparing;
     try {
       return await promise;
     } finally {
-      if (this.#preparingCapture === preparing) this.#preparingCapture = null;
+      if (this.#preparingSurface === preparing) this.#preparingSurface = null;
+      if (!this.#preparingSurface) preparingSurfaceOwners.delete(this);
     }
   }
 
-  async #capturePrepared(
+  async #captureSurface(
     hostElement: HTMLElement,
     rect: CaptureRect,
     dpr: number,
     style: CapturedTurnStyle,
     epoch: number,
     discardWhenStale = true,
-  ): Promise<PreparedCapture | null> {
-    const backdropPromise = style === 'curl' ? this.#getBackdrop() : Promise.resolve(undefined);
-    const image = await this.#host.capture(rect);
-    if (this.#disposed || (discardWhenStale && epoch !== this.#captureEpoch)) return null;
+    preMount = true,
+    isStillValid: () => boolean = () => true,
+  ): Promise<PreparedSurface | null> {
+    const backdropPromise = style === 'curl' ? this.#getBackdrop() : Promise.resolve(null);
+    const restorePixels = await this.#host.preparePixelCapture?.();
+    if (
+      this.#disposed ||
+      this.#host.isCaptureAllowed?.() === false ||
+      !isStillValid() ||
+      (discardWhenStale && epoch !== this.#captureEpoch)
+    ) {
+      await restorePixels?.();
+      return null;
+    }
+    let image: ArrayBuffer;
+    try {
+      image = await this.#host.capture(rect);
+    } finally {
+      await restorePixels?.();
+    }
+    if (
+      this.#disposed ||
+      this.#host.isCaptureAllowed?.() === false ||
+      !isStillValid() ||
+      (discardWhenStale && epoch !== this.#captureEpoch)
+    ) {
+      return null;
+    }
     // No mime: the platforms return different formats (PNG on macOS,
     // JPEG on iOS/Android) and the decoder sniffs the bytes.
     const bitmap = await createImageBitmap(new Blob([image]));
     const backdrop = await backdropPromise;
-    if (this.#disposed || (discardWhenStale && epoch !== this.#captureEpoch)) {
+    if (
+      this.#disposed ||
+      this.#host.isCaptureAllowed?.() === false ||
+      !isStillValid() ||
+      (discardWhenStale && epoch !== this.#captureEpoch)
+    ) {
       bitmap.close();
       return null;
     }
-    return { bitmap, rect, hostElement, dpr, backdrop };
+    if (!hostElement.isConnected) {
+      bitmap.close();
+      return null;
+    }
+    const overlay = document.createElement('div');
+    const renderer: TurnRenderer =
+      style === 'slide'
+        ? new PageSlideRenderer()
+        : new PageCurlRenderer({ preserveDrawingBuffer: false });
+    overlay.setAttribute('aria-hidden', 'true');
+    overlay.dataset['capturedTurnPrepared'] = String(preMount);
+    Object.assign(overlay.style, {
+      position: 'absolute',
+      pointerEvents: 'none',
+      zIndex: '50',
+      opacity: preMount ? PREPARED_SURFACE_WARM_OPACITY : '1',
+      overflow: 'hidden',
+      transform: 'translateZ(0)',
+      willChange: 'opacity',
+    });
+    this.#positionOverlay(overlay, hostElement, rect);
+    hostElement.appendChild(overlay);
+    try {
+      renderer.attach(overlay, rect.width, rect.height, dpr);
+      renderer.setTexture(bitmap);
+      if (backdrop) renderer.setBackdrop?.(backdrop);
+      // At progress zero both directions are the same flat page. Claim redraws
+      // once with the actual spine direction without reallocating or uploading.
+      renderer.render(0, { x: 1, y: 0.5 }, false);
+    } catch (error) {
+      renderer.dispose();
+      overlay.remove();
+      throw error;
+    } finally {
+      bitmap.close();
+    }
+    if (
+      this.#disposed ||
+      this.#host.isCaptureAllowed?.() === false ||
+      !isStillValid() ||
+      (discardWhenStale && epoch !== this.#captureEpoch)
+    ) {
+      renderer.dispose();
+      overlay.remove();
+      return null;
+    }
+    const surface: PreparedSurface = {
+      renderer,
+      overlay,
+      style,
+      rect,
+      hostElement,
+      dpr,
+      surfaceAlreadyPainted: false,
+      paintRaf: 0,
+    };
+    if (preMount) this.#trackPreparedSurfacePaint(surface);
+    return surface;
   }
 
   #getBackdrop(): Promise<TexImageSource | null> {
@@ -663,28 +975,136 @@ export class CapturedPageTurn {
       .catch(() => null);
   }
 
-  #takePreparedCapture(
+  #takePreparedSurface(
     hostElement: HTMLElement,
     rect: CaptureRect,
     dpr: number,
-  ): PreparedCapture | null {
-    const prepared = this.#preparedCapture;
+    style: CapturedTurnStyle,
+  ): PreparedSurface | null {
+    const prepared = this.#preparedSurface;
     if (!prepared) return null;
     if (
       prepared.hostElement !== hostElement ||
+      prepared.overlay.parentElement !== hostElement ||
+      !hostElement.isConnected ||
       prepared.dpr !== dpr ||
+      prepared.style !== style ||
+      prepared.renderer.isUsable?.() === false ||
       !sameCaptureRect(prepared.rect, rect)
     ) {
-      this.#closePreparedCapture();
+      this.#closePreparedSurface();
       return null;
     }
-    this.#preparedCapture = null;
+    this.#preparedSurface = null;
+    if (preparedSurfaceOwner === this) preparedSurfaceOwner = null;
+    this.releasePreparedCapture();
+    this.#stopPreparedSurfacePaint(prepared);
     return prepared;
   }
 
-  #closePreparedCapture() {
-    this.#preparedCapture?.bitmap.close();
-    this.#preparedCapture = null;
+  #storePreparedSurface(surface: PreparedSurface) {
+    // Decide against current ownership, not the request's start state: a touch
+    // can release while native capture is pending, or another cell can claim
+    // the global surface budget before this result arrives.
+    if (
+      surface.renderer.isUsable?.() === false ||
+      this.#active ||
+      [...activeSurfaceOwners].some((owner) => owner !== this)
+    ) {
+      this.#disposeSurface(surface);
+      return false;
+    }
+    const currentTarget = this.#readCaptureTarget();
+    if (
+      !currentTarget ||
+      currentTarget.hostElement !== surface.hostElement ||
+      currentTarget.dpr !== surface.dpr ||
+      !sameCaptureRect(currentTarget.rect, surface.rect)
+    ) {
+      this.#disposeSurface(surface);
+      return false;
+    }
+    if (preparedSurfaceOwner && preparedSurfaceOwner !== this) {
+      if (preparedSurfaceOwner.#preparedSurfaceRetained) {
+        this.#disposeSurface(surface);
+        return false;
+      }
+      preparedSurfaceOwner.#closePreparedSurface();
+    }
+    this.#closePreparedSurface(false);
+    if (this.#disposed) {
+      this.#disposeSurface(surface);
+      return false;
+    }
+    this.#preparedSurface = surface;
+    preparedSurfaceOwner = this;
+    return true;
+  }
+
+  /** Reserve the one-full-screen-surface budget for setup and active playback. */
+  #reserveActiveSurface() {
+    if ([...activeSurfaceOwners].some((owner) => owner !== this)) return false;
+    for (const owner of preparingSurfaceOwners) {
+      if (owner !== this) owner.invalidatePreparedCapture();
+    }
+    if (idlePreparingOwner && idlePreparingOwner !== this) {
+      idlePreparingOwner.invalidatePreparedCapture();
+    }
+    if (preparedSurfaceOwner && preparedSurfaceOwner !== this) {
+      // An accepted turn takes priority over another cell's idle frame. Any
+      // in-flight frame from that cell is rejected by #storePreparedSurface.
+      preparedSurfaceOwner.#closePreparedSurface();
+    }
+    activeSurfaceOwners.add(this);
+    return true;
+  }
+
+  #trackPreparedSurfacePaint(surface: PreparedSurface) {
+    this.#stopPreparedSurfacePaint(surface);
+    surface.surfaceAlreadyPainted = false;
+    surface.paintRaf = requestAnimationFrame(() => {
+      surface.paintRaf = requestAnimationFrame(() => {
+        surface.paintRaf = 0;
+        if (
+          !this.#disposed &&
+          this.#preparedSurface === surface &&
+          surface.overlay.parentElement === surface.hostElement &&
+          surface.overlay.isConnected
+        ) {
+          surface.surfaceAlreadyPainted = true;
+        }
+      });
+    });
+  }
+
+  #stopPreparedSurfacePaint(surface: PreparedSurface) {
+    if (!surface.paintRaf) return;
+    cancelAnimationFrame(surface.paintRaf);
+    surface.paintRaf = 0;
+  }
+
+  #positionOverlay(overlay: HTMLElement, hostElement: HTMLElement, rect: CaptureRect) {
+    const hostRect = hostElement.getBoundingClientRect();
+    Object.assign(overlay.style, {
+      left: `${rect.x - hostRect.left}px`,
+      top: `${rect.y - hostRect.top}px`,
+      width: `${rect.width}px`,
+      height: `${rect.height}px`,
+    });
+  }
+
+  #disposeSurface(surface: PreparedSurface) {
+    this.#stopPreparedSurfacePaint(surface);
+    surface.renderer.dispose();
+    surface.overlay.remove();
+  }
+
+  #closePreparedSurface(releaseRetention = true) {
+    const surface = this.#preparedSurface;
+    this.#preparedSurface = null;
+    if (releaseRetention) this.releasePreparedCapture();
+    if (preparedSurfaceOwner === this) preparedSurfaceOwner = null;
+    if (surface) this.#disposeSurface(surface);
   }
 
   /** Animate the active turn from its current progress to `target`. */
@@ -789,8 +1209,12 @@ export class CapturedPageTurn {
   /** Tear down the current overlay, resolving any in-flight animation. */
   #finishActive() {
     const active = this.#active;
-    if (!active) return;
+    if (!active) {
+      activeSurfaceOwners.delete(this);
+      return;
+    }
     this.#active = null;
+    activeSurfaceOwners.delete(this);
     if (active.dragSession && this.#dragSession === active.dragSession) {
       this.#dragSession = null;
     }

--- a/apps/readest-app/src/app/reader/utils/iframeEventHandlers.ts
+++ b/apps/readest-app/src/app/reader/utils/iframeEventHandlers.ts
@@ -1,15 +1,86 @@
 import { DOUBLE_CLICK_INTERVAL_THRESHOLD_MS, LONG_HOLD_THRESHOLD } from '@/services/constants';
 import { eventDispatcher } from '@/utils/event';
 import { findGlossWord } from '@/app/reader/utils/wordlensRuby';
+import { TURN_GESTURE_LEFT_INSET_ATTRIBUTE } from './brightnessGesture';
+import {
+  createTurnGestureIntent,
+  NATIVE_CAPTURED_TURN_ATTRIBUTE,
+  NATIVE_PROGRAMMATIC_TURN_ATTRIBUTE,
+  shouldClaimTurnGesture,
+  TURN_EDGE_ZONE_RATIO,
+  type TurnGestureIntent,
+} from './turnGestureArena';
 
 let lastClickTime = 0;
 let longHoldTimeout: ReturnType<typeof setTimeout> | null = null;
 let isMouseDown = false;
-const touchGestures = new Map<string, { startX: number; startY: number; moved: boolean }>();
+interface NativeTurnHost extends HTMLElement {
+  scrollLocked?: boolean;
+}
+interface TouchGesture {
+  startX: number;
+  startY: number;
+  startTime: number;
+  moved: boolean;
+  turnHost?: NativeTurnHost;
+  turnIntent?: TurnGestureIntent;
+}
+const touchGestures = new Map<string, TouchGesture>();
 const suppressedSwipeClicks = new Map<string, { until: number; endX: number; endY: number }>();
+interface LayeredTurnTouchClaim {
+  claimed: boolean;
+  ended: boolean;
+  cleanupTimer?: ReturnType<typeof setTimeout>;
+}
+const layeredTurnTouchClaims = new Map<string, LayeredTurnTouchClaim>();
 const SYNTHESIZED_CLICK_SWIPE_DISTANCE_PX = 15;
 const SYNTHESIZED_CLICK_SUPPRESSION_MS = 750;
 const SYNTHESIZED_CLICK_POSITION_SLOP_PX = 15;
+
+const getNativeTurnHost = (event: TouchEvent): NativeTurnHost | null => {
+  const currentTarget = event.currentTarget as Document | null;
+  if (currentTarget?.nodeType !== 9) return null;
+  const frame = currentTarget.defaultView?.frameElement;
+  const root = frame?.getRootNode();
+  const host = root && 'host' in root ? (root.host as NativeTurnHost) : null;
+  if (
+    host?.localName !== 'foliate-paginator' ||
+    !host.hasAttribute(NATIVE_CAPTURED_TURN_ATTRIBUTE) ||
+    host.hasAttribute(NATIVE_PROGRAMMATIC_TURN_ATTRIBUTE)
+  ) {
+    return null;
+  }
+  return host;
+};
+
+const createNativeTurnIntent = (
+  event: TouchEvent,
+  touch: { screenX: number },
+): { host: NativeTurnHost; intent: TurnGestureIntent } | null => {
+  const host = getNativeTurnHost(event);
+  if (!host?.getBoundingClientRect) return null;
+  const currentTarget = event.currentTarget as Document;
+  const selection = currentTarget.getSelection?.();
+  if (selection && !selection.isCollapsed) return null;
+
+  const rect = host.getBoundingClientRect();
+  if (rect.width <= 0) return null;
+  const windowScreenX = Number.isFinite(window.screenX) ? window.screenX : 0;
+  const localStartX = touch.screenX - windowScreenX - rect.left;
+  const inset = Number(host.getAttribute(TURN_GESTURE_LEFT_INSET_ATTRIBUTE));
+  const reservedLeftRatio = Number.isFinite(inset) ? Math.max(0, Math.min(0.5, inset)) : 0;
+  const earlyClaimBlocked = localStartX <= rect.width * reservedLeftRatio;
+  let edgeDirection: -1 | 0 | 1 = 0;
+  if (!earlyClaimBlocked && localStartX >= 0 && localStartX <= rect.width * TURN_EDGE_ZONE_RATIO) {
+    edgeDirection = 1;
+  } else if (localStartX <= rect.width && localStartX >= rect.width * (1 - TURN_EDGE_ZONE_RATIO)) {
+    edgeDirection = -1;
+  }
+  return {
+    host,
+    intent: createTurnGestureIntent(edgeDirection, earlyClaimBlocked, 0),
+  };
+};
 
 // Middle-click autoscroll (#4951). Books where the feature is armed (desktop
 // app, scrolled mode, setting on) get the middle button's defaults suppressed,
@@ -28,6 +99,101 @@ export const setAutoscrollArmed = (bookKey: string, armed: boolean) => {
 
 export const setAutoscrollTracking = (tracking: boolean) => {
   autoscrollTracking = tracking;
+};
+
+// A layered turn can now claim below the generic 15px swipe threshold. Keep
+// synthesized-click suppression tied to the authoritative gesture claim so a
+// valid early turn cannot be replayed as a toolbar click after touchend.
+export const setLayeredTurnTouchClaimed = (bookKey: string, claimed: boolean) => {
+  if (!claimed) {
+    const previous = layeredTurnTouchClaims.get(bookKey);
+    if (previous?.cleanupTimer) clearTimeout(previous.cleanupTimer);
+    layeredTurnTouchClaims.delete(bookKey);
+    return;
+  }
+  const state = layeredTurnTouchClaims.get(bookKey) ?? { claimed: false, ended: false };
+  state.claimed = true;
+  layeredTurnTouchClaims.set(bookKey, state);
+};
+
+/** Start a fresh raw/direct touch lifetime for layered-turn ownership. */
+export const beginLayeredTurnTouch = (bookKey: string) => {
+  const previous = layeredTurnTouchClaims.get(bookKey);
+  if (previous?.cleanupTimer) clearTimeout(previous.cleanupTimer);
+  layeredTurnTouchClaims.set(bookKey, { claimed: false, ended: false });
+};
+
+/**
+ * Seal a completed touch while retaining a claimed gesture briefly enough to
+ * suppress the browser's delayed compatibility click. This is idempotent
+ * because iframe events and the parent React surface can observe the same
+ * physical release.
+ */
+export const endLayeredTurnTouch = (bookKey: string) => {
+  const state = layeredTurnTouchClaims.get(bookKey);
+  if (!state || state.ended) return;
+  state.ended = true;
+  state.cleanupTimer = setTimeout(() => {
+    if (layeredTurnTouchClaims.get(bookKey) === state) {
+      layeredTurnTouchClaims.delete(bookKey);
+    }
+  }, SYNTHESIZED_CLICK_SUPPRESSION_MS);
+};
+
+/** Cancel a touch without retaining synthesized-click suppression state. */
+export const cancelLayeredTurnTouch = (bookKey: string) => {
+  setLayeredTurnTouchClaimed(bookKey, false);
+};
+
+// The forwarded iframe lifecycle is independent of app-interceptor priority,
+// so it is more reliable than any one interceptor's local start/end state for
+// ordinary page-turn candidates. A capture-phase owner may still suppress a
+// later forwarded event; the next touchstart always replaces stale state.
+export const isLayeredTurnTouchActive = (bookKey: string) => {
+  const state = layeredTurnTouchClaims.get(bookKey);
+  return !!state && !state.ended;
+};
+
+const clearLayeredTurnTouchClaim = (bookKey: string) => {
+  cancelLayeredTurnTouch(bookKey);
+};
+
+const suppressDomClick = (event: MouseEvent) => {
+  event.preventDefault();
+  event.stopImmediatePropagation();
+};
+
+const consumeSuppressedDomClick = (bookKey: string, event: MouseEvent, now: number) => {
+  const suppressedSwipe = suppressedSwipeClicks.get(bookKey);
+  if (suppressedSwipe) {
+    if (now > suppressedSwipe.until) {
+      suppressedSwipeClicks.delete(bookKey);
+    } else {
+      const nearEnd =
+        Math.hypot(event.screenX - suppressedSwipe.endX, event.screenY - suppressedSwipe.endY) <=
+        SYNTHESIZED_CLICK_POSITION_SLOP_PX;
+      if (nearEnd) {
+        suppressedSwipeClicks.delete(bookKey);
+        clearLayeredTurnTouchClaim(bookKey);
+        suppressDomClick(event);
+        return true;
+      }
+    }
+  }
+  const layeredClaim = layeredTurnTouchClaims.get(bookKey);
+  if (layeredClaim?.claimed && layeredClaim.ended) {
+    clearLayeredTurnTouchClaim(bookKey);
+    suppressDomClick(event);
+    return true;
+  }
+  return false;
+};
+
+// Runs before Foliate's bubble-phase link handler. Only recognized swipes are
+// intercepted here; ordinary clicks retain their existing listener order and
+// link/media/footnote behavior.
+export const handleClickCapture = (bookKey: string, event: MouseEvent) => {
+  consumeSuppressedDomClick(bookKey, event, Date.now());
 };
 
 // The event's position in main-window viewport coordinates: iframe client
@@ -251,20 +417,7 @@ export const handleClick = (
   event: MouseEvent,
 ) => {
   const now = Date.now();
-  const suppressedSwipe = suppressedSwipeClicks.get(bookKey);
-  if (suppressedSwipe) {
-    if (now > suppressedSwipe.until) {
-      suppressedSwipeClicks.delete(bookKey);
-    } else {
-      const nearEnd =
-        Math.hypot(event.screenX - suppressedSwipe.endX, event.screenY - suppressedSwipe.endY) <=
-        SYNTHESIZED_CLICK_POSITION_SLOP_PX;
-      if (nearEnd) {
-        suppressedSwipeClicks.delete(bookKey);
-        return;
-      }
-    }
-  }
+  if (consumeSuppressedDomClick(bookKey, event, now)) return;
 
   if (!doubleClickDisabled.current && now - lastClickTime < DOUBLE_CLICK_INTERVAL_THRESHOLD_MS) {
     lastClickTime = now;
@@ -288,6 +441,15 @@ export const handleClick = (
   lastClickTime = now;
 
   const postSingleClick = () => {
+    // Native captured-turn recognition is delivered through postMessage and
+    // can land one task after the iframe touchend/click. Re-check ownership at
+    // dispatch time so an early 1–6px claim cannot slip through that gap.
+    const lateLayeredClaim = layeredTurnTouchClaims.get(bookKey);
+    if (lateLayeredClaim?.claimed && lateLayeredClaim.ended) {
+      clearLayeredTurnTouchClaim(bookKey);
+      if (lastClickTime === now) lastClickTime = 0;
+      return;
+    }
     const element = event.target as HTMLElement | null;
     const footnoteSelector = [
       '.js_readerFooterNote',
@@ -377,7 +539,10 @@ export const handleClick = (
       }
     }, DOUBLE_CLICK_INTERVAL_THRESHOLD_MS);
   } else {
-    postSingleClick();
+    // Mouse clicks remain synchronous. A touch-synthesized click waits one
+    // task so the parent realm can publish a native captured-turn claim.
+    if (layeredTurnTouchClaims.get(bookKey)?.ended) setTimeout(postSingleClick, 0);
+    else postSingleClick();
   }
 };
 
@@ -403,9 +568,18 @@ const handleTouchEv = (bookKey: string, event: TouchEvent, type: string) => {
   const targetTouches = serializeTouches(event.touches);
   const changedTouches = serializeTouches(event.changedTouches);
   if (type === 'iframe-touchstart') {
+    beginLayeredTurnTouch(bookKey);
     const touch = targetTouches[0];
     if (touch) {
-      touchGestures.set(bookKey, { startX: touch.screenX, startY: touch.screenY, moved: false });
+      const nativeTurn = event.touches.length === 1 ? createNativeTurnIntent(event, touch) : null;
+      touchGestures.set(bookKey, {
+        startX: touch.screenX,
+        startY: touch.screenY,
+        startTime: event.timeStamp,
+        moved: false,
+        turnHost: nativeTurn?.host,
+        turnIntent: nativeTurn?.intent,
+      });
     }
   } else if (type === 'iframe-touchmove') {
     const gesture = touchGestures.get(bookKey);
@@ -413,6 +587,39 @@ const handleTouchEv = (bookKey: string, event: TouchEvent, type: string) => {
     if (gesture && touch) {
       const distance = Math.hypot(touch.screenX - gesture.startX, touch.screenY - gesture.startY);
       if (distance >= SYNTHESIZED_CLICK_SWIPE_DISTANCE_PX) gesture.moved = true;
+      const { turnHost, turnIntent } = gesture;
+      if (turnHost && turnIntent) {
+        const currentTarget = event.currentTarget as Document | null;
+        const selection = currentTarget?.getSelection?.();
+        const invalid =
+          event.touches.length !== 1 ||
+          !turnHost.hasAttribute(NATIVE_CAPTURED_TURN_ATTRIBUTE) ||
+          turnHost.hasAttribute(NATIVE_PROGRAMMATIC_TURN_ATTRIBUTE) ||
+          !!turnHost.scrollLocked ||
+          !!(selection && !selection.isCollapsed);
+        if (invalid) {
+          gesture.turnHost = undefined;
+          gesture.turnIntent = undefined;
+        } else if (
+          shouldClaimTurnGesture(
+            turnIntent,
+            {
+              deltaX: touch.screenX - gesture.startX,
+              deltaY: touch.screenY - gesture.startY,
+              deltaT: event.timeStamp - gesture.startTime,
+            },
+            SYNTHESIZED_CLICK_SWIPE_DISTANCE_PX,
+          )
+        ) {
+          gesture.turnIntent = undefined;
+          setLayeredTurnTouchClaimed(bookKey, true);
+          // Native capture recognition reaches the React interceptor through
+          // postMessage. Claim the browser gesture synchronously here as well,
+          // so a 1–6px page turn cannot generate a compatibility/link click in
+          // the gap before that message is handled.
+          event.preventDefault();
+        }
+      }
     }
   } else if (type === 'iframe-touchend' || type === 'iframe-touchcancel') {
     const gesture = touchGestures.get(bookKey);
@@ -420,7 +627,10 @@ const handleTouchEv = (bookKey: string, event: TouchEvent, type: string) => {
     // touchmove event. Include the released finger when deciding whether the
     // browser-generated click belongs to a swipe.
     const releasedTouch = changedTouches[0];
+    const layeredClaim = layeredTurnTouchClaims.get(bookKey);
+    if (type === 'iframe-touchend' && layeredClaim?.claimed) event.preventDefault();
     const moved =
+      layeredClaim?.claimed ||
       gesture?.moved ||
       (gesture &&
         releasedTouch &&
@@ -436,6 +646,11 @@ const handleTouchEv = (bookKey: string, event: TouchEvent, type: string) => {
       });
     }
     touchGestures.delete(bookKey);
+    if (type === 'iframe-touchcancel') {
+      cancelLayeredTurnTouch(bookKey);
+    } else {
+      endLayeredTurnTouch(bookKey);
+    }
   }
   window.postMessage(
     {

--- a/apps/readest-app/src/app/reader/utils/turnGestureArena.ts
+++ b/apps/readest-app/src/app/reader/utils/turnGestureArena.ts
@@ -1,0 +1,101 @@
+export type TurnGestureDirection = -1 | 0 | 1;
+
+export interface TurnGestureIntent {
+  edgeDirection: TurnGestureDirection;
+  earlyClaimBlocked: boolean;
+  lastDeltaX: number;
+  lastDeltaY: number;
+  lastSampleTime: number;
+  horizontalSign: TurnGestureDirection;
+  horizontalStreak: number;
+  verticalLocked: boolean;
+}
+
+export interface TurnGestureSample {
+  deltaX: number;
+  deltaY: number;
+  deltaT: number;
+}
+
+export const NATIVE_CAPTURED_TURN_ATTRIBUTE = 'captured-turn-style';
+export const NATIVE_PROGRAMMATIC_TURN_ATTRIBUTE = 'captured-turn-programmatic';
+export const TURN_EDGE_ZONE_RATIO = 0.18;
+export const TURN_FAST_CLAIM_DISTANCE_PX = 6;
+export const TURN_FAST_CLAIM_MAX_SAMPLE_GAP_MS = 80;
+export const TURN_RESERVED_INSET_FALLBACK_PX = 24;
+export const TURN_VERTICAL_LOCK_DISTANCE_PX = 8;
+export const TURN_DIRECTION_DOMINANCE = 1.5;
+
+export const createTurnGestureIntent = (
+  edgeDirection: TurnGestureDirection,
+  earlyClaimBlocked: boolean,
+  startTime: number,
+): TurnGestureIntent => ({
+  edgeDirection,
+  earlyClaimBlocked,
+  lastDeltaX: 0,
+  lastDeltaY: 0,
+  lastSampleTime: startTime,
+  horizontalSign: 0,
+  horizontalStreak: 0,
+  verticalLocked: false,
+});
+
+/**
+ * Advances the native captured-turn arena and returns true exactly once its
+ * horizontal intent is strong enough to own the current touch sequence.
+ */
+export const shouldClaimTurnGesture = (
+  intent: TurnGestureIntent,
+  sample: TurnGestureSample,
+  fallbackDistance: number,
+) => {
+  if (intent.verticalLocked) return false;
+
+  const { deltaX, deltaY, deltaT } = sample;
+  const stepX = deltaX - intent.lastDeltaX;
+  const stepY = deltaY - intent.lastDeltaY;
+  const sampleGap = deltaT - intent.lastSampleTime;
+  intent.lastDeltaX = deltaX;
+  intent.lastDeltaY = deltaY;
+  intent.lastSampleTime = deltaT;
+
+  const absX = Math.abs(deltaX);
+  const absY = Math.abs(deltaY);
+  if (absY >= TURN_VERTICAL_LOCK_DISTANCE_PX && absY > absX) {
+    intent.verticalLocked = true;
+    intent.horizontalStreak = 0;
+    intent.horizontalSign = 0;
+    return false;
+  }
+
+  const stepSign = Math.sign(stepX) as TurnGestureDirection;
+  const timelySample = sampleGap >= 0 && sampleGap <= TURN_FAST_CLAIM_MAX_SAMPLE_GAP_MS;
+  const horizontalSample =
+    Math.abs(stepX) >= 1 && Math.abs(stepX) > Math.abs(stepY) * TURN_DIRECTION_DOMINANCE;
+  if (horizontalSample) {
+    intent.horizontalStreak =
+      timelySample && stepSign === intent.horizontalSign ? intent.horizontalStreak + 1 : 1;
+    intent.horizontalSign = stepSign;
+  } else {
+    intent.horizontalStreak = 0;
+    intent.horizontalSign = 0;
+  }
+
+  const edgeFastPath =
+    !intent.earlyClaimBlocked &&
+    intent.edgeDirection !== 0 &&
+    Math.sign(deltaX) === intent.edgeDirection &&
+    absX > absY * TURN_DIRECTION_DOMINANCE;
+  const coherentFastPath =
+    !intent.earlyClaimBlocked &&
+    intent.edgeDirection === 0 &&
+    absX >= TURN_FAST_CLAIM_DISTANCE_PX &&
+    intent.horizontalStreak >= 2 &&
+    absX > absY * TURN_DIRECTION_DOMINANCE;
+  const requiredFallbackDistance = intent.earlyClaimBlocked
+    ? TURN_RESERVED_INSET_FALLBACK_PX
+    : fallbackDistance;
+  const fallback = absX >= requiredFallbackDistance && absX > absY;
+  return edgeFastPath || coherentFastPath || fallback;
+};

--- a/apps/readest-app/src/components/Dialog.tsx
+++ b/apps/readest-app/src/components/Dialog.tsx
@@ -205,6 +205,7 @@ const Dialog: React.FC<DialogProps> = ({
       dir={isRtl ? 'rtl' : undefined}
     >
       <Overlay
+        captureBlocking={isOpen}
         className={clsx(
           'dialog-overlay z-10 bg-black/50 sm:bg-black/50',
           appService?.hasRoundedWindow && 'rounded-window',

--- a/apps/readest-app/src/components/ModalPortal.tsx
+++ b/apps/readest-app/src/components/ModalPortal.tsx
@@ -17,6 +17,7 @@ interface ModalPortalProps {
 const ModalPortal: React.FC<ModalPortalProps> = ({ children, showOverlay = true }) => {
   return ReactDOM.createPortal(
     <div
+      data-capture-blocking-overlay='true'
       className={clsx(
         'fixed inset-0 isolate z-[120] flex items-center justify-center',
         showOverlay && 'bg-black bg-opacity-50',

--- a/apps/readest-app/src/components/Overlay.tsx
+++ b/apps/readest-app/src/components/Overlay.tsx
@@ -5,9 +5,15 @@ interface OverlayProps {
   onDismiss: () => void;
   dismissLabel?: string;
   className?: string;
+  /** Whether this mounted layer covers reader pixels and blocks native capture. */
+  captureBlocking?: boolean;
 }
 
-export const Overlay: React.FC<OverlayProps> = ({ onDismiss, className }) => {
+export const Overlay: React.FC<OverlayProps> = ({
+  onDismiss,
+  className,
+  captureBlocking = true,
+}) => {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape' || e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
@@ -17,6 +23,7 @@ export const Overlay: React.FC<OverlayProps> = ({ onDismiss, className }) => {
 
   return (
     <div
+      data-capture-blocking-overlay={captureBlocking ? 'true' : undefined}
       className={clsx('overlay fixed inset-0 cursor-default', className)}
       role='none'
       tabIndex={-1}

--- a/apps/readest-app/src/components/Popup.tsx
+++ b/apps/readest-app/src/components/Popup.tsx
@@ -149,6 +149,8 @@ const Popup = ({
       <div
         id='popup-container'
         ref={containerRef}
+        aria-hidden={!isOpen}
+        data-capture-blocking-overlay={isOpen ? 'true' : undefined}
         className={clsx(
           'popup-container bg-base-300 absolute z-50 rounded-lg font-sans',
           'eink:border eink:border-base-content',

--- a/apps/readest-app/src/components/Toast.tsx
+++ b/apps/readest-app/src/components/Toast.tsx
@@ -117,6 +117,7 @@ export const Toast = () => {
   return (
     toastMessage && (
       <div
+        data-capture-invalidating-overlay='true'
         className={clsx(
           'toast z-[130] w-auto max-w-screen-sm transition-all duration-300',
           toastClassMap[toastType],

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -994,6 +994,12 @@ textarea:focus-within,
   transition: none !important;
 }
 
+/* Native snapshots must not bake transient host chrome (for example Toast)
+   into the page texture. The live element remains above the turn after capture. */
+.captured-turn-filter-transient-overlays [data-capture-invalidating-overlay='true'] {
+  visibility: hidden !important;
+}
+
 /* TTS player scrubber: the track is painted by an inline three-stop gradient
    (played / buffered / rest), so the native appearance must be blanked and
    the element itself becomes the 4px track. Thumb inherits currentColor. */

--- a/apps/readest-app/src/utils/pageCurl.ts
+++ b/apps/readest-app/src/utils/pageCurl.ts
@@ -89,6 +89,14 @@ export class PageCurlRenderer {
   private width = 0;
   private height = 0;
   private uniforms: Record<string, WebGLUniformLocation | null> = {};
+  private preserveDrawingBuffer: boolean;
+
+  constructor(options: { preserveDrawingBuffer?: boolean } = {}) {
+    // Standalone pixel/readback users retain the historical default. The
+    // captured-turn pipeline opts out because its idle surface can stay alive
+    // much longer and redraws before reveal.
+    this.preserveDrawingBuffer = options.preserveDrawingBuffer ?? true;
+  }
 
   /** Mount the overlay canvas covering `rect` (CSS px) inside `container`. */
   attach(container: HTMLElement, width: number, height: number, dpr = window.devicePixelRatio) {
@@ -108,13 +116,13 @@ export class PageCurlRenderer {
     container.appendChild(canvas);
     this.canvas = canvas;
 
-    // preserveDrawingBuffer keeps readPixels valid after the browser
-    // composites (readbacks otherwise silently return zeros past an await);
-    // one short-lived overlay per turn, so the extra buffer copy is cheap.
+    // preserveDrawingBuffer is only needed by readback callers. Long-lived
+    // prepared turn surfaces disable it to avoid retaining another full-size
+    // color buffer while idle.
     const gl = canvas.getContext('webgl', {
       alpha: true,
       premultipliedAlpha: true,
-      preserveDrawingBuffer: true,
+      preserveDrawingBuffer: this.preserveDrawingBuffer,
     });
     if (!gl) {
       this.dispose();
@@ -287,6 +295,11 @@ export class PageCurlRenderer {
     const data = new Uint8Array(4);
     gl.readPixels(x, canvas.height - 1 - y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, data);
     return [data[0]!, data[1]!, data[2]!, data[3]!];
+  }
+
+  /** An idle prepared surface may lose its WebGL context under memory pressure. */
+  isUsable() {
+    return !!this.gl && !this.gl.isContextLost();
   }
 
   dispose() {

--- a/apps/readest-app/src/utils/pageSlide.ts
+++ b/apps/readest-app/src/utils/pageSlide.ts
@@ -1,18 +1,33 @@
 import { CurlGrab } from '@/utils/pageCurl';
 
+const EDGE_SHADOW_WIDTH_PX = 28;
+const SETTLE_KEYFRAME_STEPS = 32;
+
+export interface PageSlideSettleOptions {
+  from: number;
+  target: number;
+  rtl: boolean;
+  duration: number;
+  easing: (progress: number) => number;
+}
+
 /**
  * Slide renderer for the captured page-turn pipeline (readest#555). Draws
  * the captured outgoing page on a plain 2D canvas and translates it
- * horizontally out of the content box — the flat sibling of the WebGL
- * `PageCurlRenderer`, used where the View Transitions slide is unavailable
- * (iOS 18 WebKit crashes on it; older engines lack the API).
+ * horizontally out of the reader cell — the flat sibling of the WebGL
+ * `PageCurlRenderer`, used by mobile Tauri so the outgoing page can be
+ * captured and decoded ahead of the gesture (and as the fallback where View
+ * Transitions are unavailable).
  *
  * Mirrors the paginator's VT slide choreography: the moving page exits
- * toward the spine side on forward turns with a soft edge shadow, clipped
- * to the content box so the margins stay still.
+ * toward the spine side on forward turns with a soft edge shadow, while the
+ * overlay clips the moving sheet to its original reader cell.
  */
 export class PageSlideRenderer {
   private canvas: HTMLCanvasElement | null = null;
+  private sheet: HTMLDivElement | null = null;
+  private edgeShadow: HTMLDivElement | null = null;
+  private shadowRtl: boolean | null = null;
   private width = 0;
 
   /** Mount the overlay canvas covering `rect` (CSS px) inside `container`. */
@@ -21,6 +36,23 @@ export class PageSlideRenderer {
     // The page slides past the container edge; clip it like the VT version
     // clips its transition group to the content box.
     container.style.overflow = 'hidden';
+
+    // Move one compositor-friendly sheet containing both the page and its
+    // trailing edge. A narrow static gradient replaces the full-canvas blur,
+    // avoiding an oversized shadow raster around all four sides.
+    const sheet = document.createElement('div');
+    sheet.dataset['pageSlideSheet'] = '';
+    Object.assign(sheet.style, {
+      position: 'absolute',
+      inset: '0',
+      width: `${width}px`,
+      height: `${height}px`,
+      pointerEvents: 'none',
+      willChange: 'transform',
+      backfaceVisibility: 'hidden',
+      transform: 'translate3d(0px, 0, 0)',
+    });
+
     const canvas = document.createElement('canvas');
     canvas.width = Math.round(width * dpr);
     canvas.height = Math.round(height * dpr);
@@ -30,10 +62,24 @@ export class PageSlideRenderer {
       width: `${width}px`,
       height: `${height}px`,
       pointerEvents: 'none',
-      boxShadow: '0 0 24px rgba(0, 0, 0, 0.35)',
     });
-    container.appendChild(canvas);
+
+    const edgeShadow = document.createElement('div');
+    edgeShadow.dataset['pageSlideShadow'] = '';
+    Object.assign(edgeShadow.style, {
+      position: 'absolute',
+      top: '0',
+      bottom: '0',
+      width: `${EDGE_SHADOW_WIDTH_PX}px`,
+      pointerEvents: 'none',
+    });
+
+    sheet.append(canvas, edgeShadow);
+    container.appendChild(sheet);
     this.canvas = canvas;
+    this.sheet = sheet;
+    this.edgeShadow = edgeShadow;
+    this.updateShadowDirection(false);
   }
 
   /** Draw the captured page (at progress 0 it exactly covers). */
@@ -50,13 +96,60 @@ export class PageSlideRenderer {
    * spine side of a forward LTR turn), true exits right.
    */
   render(progress: number, _grab: CurlGrab = { x: 1, y: 0.5 }, rtl = false) {
-    if (!this.canvas) return;
+    if (!this.sheet) return;
+    this.updateShadowDirection(rtl);
+    this.sheet.style.transform = this.transformAt(progress, rtl);
+  }
+
+  /**
+   * Settle the flat page with compositor-owned transform keyframes. The
+   * controller supplies its existing easing function, sampled here so old
+   * WebViews do not need CSS linear() support.
+   */
+  animateSettle(options: PageSlideSettleOptions): Animation | null {
+    const sheet = this.sheet;
+    if (!sheet || typeof sheet.animate !== 'function') return null;
+    this.updateShadowDirection(options.rtl);
+    const span = options.target - options.from;
+    const keyframes = Array.from({ length: SETTLE_KEYFRAME_STEPS + 1 }, (_, index) => {
+      const offset = index / SETTLE_KEYFRAME_STEPS;
+      const progress = options.from + span * options.easing(offset);
+      return { offset, transform: this.transformAt(progress, options.rtl) };
+    });
+    try {
+      return sheet.animate(keyframes, {
+        duration: options.duration,
+        easing: 'linear',
+        fill: 'both',
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  private transformAt(progress: number, rtl: boolean) {
     const shift = (rtl ? 1 : -1) * progress * this.width;
-    this.canvas.style.transform = `translateX(${shift}px)`;
+    return `translate3d(${shift}px, 0, 0)`;
+  }
+
+  private updateShadowDirection(rtl: boolean) {
+    const shadow = this.edgeShadow;
+    if (!shadow || this.shadowRtl === rtl) return;
+    this.shadowRtl = rtl;
+    if (rtl) {
+      shadow.style.left = `${-EDGE_SHADOW_WIDTH_PX}px`;
+      shadow.style.background = 'linear-gradient(to right, transparent, rgba(0, 0, 0, 0.35))';
+    } else {
+      shadow.style.left = '100%';
+      shadow.style.background = 'linear-gradient(to right, rgba(0, 0, 0, 0.35), transparent)';
+    }
   }
 
   dispose() {
-    this.canvas?.remove();
+    this.sheet?.remove();
     this.canvas = null;
+    this.sheet = null;
+    this.edgeShadow = null;
+    this.shadowRtl = null;
   }
 }

--- a/apps/readest-app/src/utils/pageSlide.ts
+++ b/apps/readest-app/src/utils/pageSlide.ts
@@ -29,10 +29,19 @@ export class PageSlideRenderer {
   private edgeShadow: HTMLDivElement | null = null;
   private shadowRtl: boolean | null = null;
   private width = 0;
+  // A prepared canvas no longer has its source bitmap. Once the browser loses
+  // its 2D backing store, even a later context restoration cannot reconstruct
+  // the outgoing page, so force the controller to recapture it.
+  private usable = true;
+  private readonly handleContextLost = (event: Event) => {
+    event.preventDefault();
+    this.usable = false;
+  };
 
   /** Mount the overlay canvas covering `rect` (CSS px) inside `container`. */
   attach(container: HTMLElement, width: number, height: number, dpr = window.devicePixelRatio) {
     this.width = width;
+    this.usable = true;
     // The page slides past the container edge; clip it like the VT version
     // clips its transition group to the content box.
     container.style.overflow = 'hidden';
@@ -54,6 +63,7 @@ export class PageSlideRenderer {
     });
 
     const canvas = document.createElement('canvas');
+    canvas.addEventListener('contextlost', this.handleContextLost);
     canvas.width = Math.round(width * dpr);
     canvas.height = Math.round(height * dpr);
     Object.assign(canvas.style, {
@@ -86,7 +96,10 @@ export class PageSlideRenderer {
   setTexture(source: CanvasImageSource) {
     const canvas = this.canvas;
     const ctx = canvas?.getContext('2d');
-    if (!canvas || !ctx) return;
+    if (!canvas || !ctx) {
+      this.usable = false;
+      return;
+    }
     ctx.drawImage(source, 0, 0, canvas.width, canvas.height);
   }
 
@@ -99,6 +112,10 @@ export class PageSlideRenderer {
     if (!this.sheet) return;
     this.updateShadowDirection(rtl);
     this.sheet.style.transform = this.transformAt(progress, rtl);
+  }
+
+  isUsable() {
+    return this.usable && !!this.canvas && !!this.sheet;
   }
 
   /**
@@ -146,10 +163,12 @@ export class PageSlideRenderer {
   }
 
   dispose() {
+    this.canvas?.removeEventListener('contextlost', this.handleContextLost);
     this.sheet?.remove();
     this.canvas = null;
     this.sheet = null;
     this.edgeShadow = null;
     this.shadowRtl = null;
+    this.usable = false;
   }
 }


### PR DESCRIPTION
Closes #5288.

Depends on readest/foliate-js#60.

This PR remains a draft until the foliate-js change is merged and the submodule is updated to the official upstream commit.

## Summary

- Recognize clear native Slide/Curl gestures with lower apparent slop while preserving conservative fallbacks.
- Buffer drag and release samples while native capture is pending.
- Use distance plus recent release velocity for Slide commit and settle behavior.
- Prebuild renderer-ready native surfaces outside the gesture-critical path.
- Keep at most one speculative full-page surface across mounted reader cells.
- Invalidate stale surfaces after reader, geometry, theme, toolbar, annotation, or overlay changes.
- Prevent Settings, dialogs, popups, RSVP, viewers, and Toast UI from reappearing inside captured pages.
- Use compositor-owned transform animation for Slide settle.
- Add regression coverage for gesture ownership, capture races, renderer loss, surface lifetime, and toolbar synchronization.

## Root cause

The native captured-turn path previously performed all expensive setup after the gesture was claimed:

1. capture the WebView;
2. decode the image;
3. create the Canvas or WebGL renderer;
4. upload the texture;
5. draw and mount the first covering frame.

Additional movement, or even release, can arrive while that work is pending. Buffering the samples preserves the correct position, but building the surface on the gesture-critical path can still produce a visible hesitation.

Gesture recognition and release intent also need different inputs:

- visual Slide progress should begin at the claim point;
- release intent should include the full touchstart-relative distance;
- recent velocity should influence both Slide commit probability and the remaining settle speed.

## Gesture and release behavior

- Clear edge gestures can claim on their first inward horizontal sample.
- Central gestures can use a two-sample low-slop path.
- Ambiguous trajectories retain the established swipe fallback.
- The left brightness strip is excluded from early claim.
- Vertical intent, selection, instant-highlight scroll lock, multi-touch, and programmatic turns retain priority.
- Drag samples are buffered while native capture is pending.
- The actual `touchend.changedTouches` position is applied before settling.
- Late samples cannot modify a released turn.
- Replacement gestures safely cancel unfinished previous drags.
- Slide uses full distance plus recent velocity to decide commit.
- Curl preserves its existing commit behavior.
- Velocity directed toward the selected target can accelerate the remaining animation.

## Renderer-ready surface preparation

After the reader becomes stable, eligible native Slide/Curl views prepare:

- the native WebView snapshot;
- image decoding;
- Canvas or WebGL renderer creation;
- texture upload;
- Curl backdrop preparation;
- the first flat render;
- mounting into the real reader host.

When the gesture is claimed, the prepared renderer and texture are revealed and reused instead of being rebuilt.

If idle preparation has not completed, `touchstart` starts the same preparation immediately and the captured turn can join the in-flight work.

## Resource and lifecycle safeguards

- At most one speculative full-page surface is retained process-wide.
- Active turns take priority over idle preparation.
- Touch retention protects a surface between `touchstart` and claim.
- Concurrent replacement requests are coalesced.
- Late asynchronous results are discarded after invalidation or disposal.
- Host identity, geometry, DPR, renderer usability, and active ownership are revalidated before use.
- Captures spanning a resize or rotation are retried once.
- Full device DPR is preserved.
- Lost Canvas or WebGL contexts force recapture.
- Prepared Curl surfaces avoid unnecessary `preserveDrawingBuffer` storage.

## Snapshot validity

Prepared surfaces are invalidated after changes to:

- pagination and reader location;
- annotations;
- reader and toolbar state;
- theme, safe areas, and system UI;
- reader-cell geometry;
- document visibility;
- Settings, dialogs, popups, menus, Sidebar, Notebook, RSVP, Image Viewer, Table Viewer, and import overlays.

Transient Toast UI does not claim the page-turn gesture or discard an already prepared clean surface.

During native capture, transient UI is filtered from the captured pixels and restored immediately afterward. The filter is reference-counted and includes a safety timeout.

## Toolbar behavior

The existing toolbar lifecycle remains unchanged:

- a visible toolbar is included in the outgoing snapshot;
- the live toolbar hides immediately underneath without fading;
- a committed turn leaves it hidden;
- a cancelled turn restores it underneath the snapshot;
- an initially hidden toolbar remains hidden;
- center taps continue to toggle the toolbar normally.

## Platform scope

The prepared native path applies to eligible paginated, reflowable Tauri views.

Web and supported desktop Slide/Curl turns continue through the foliate-js View Transition path.

The following remain unchanged:

- Push turns
- fixed-layout books
- scrolled reading
- E-Ink mode
- disabled animation
- disabled swipe

## Companion change

readest/foliate-js#60 provides the browser layered-turn gesture arena, release projection, settle pacing, and touch-lifecycle hardening.

The submodule temporarily points to `32c6f44`. It will be updated to the official merged commit before this PR is marked ready.

## Recordings:

https://github.com/user-attachments/assets/7027b3b4-ef8e-4e19-9fc1-f2e587d67596


https://github.com/user-attachments/assets/9a8a1e4d-3051-416b-8716-5154caf16c48



## Validation

- [x] `pnpm format:check`
- [x] `pnpm --filter @readest/readest-app lint`
- [x] Focused unit tests: 167 passed
- [x] Focused browser tests: 116 passed
- [x] Full browser suite: 321 passed, 1 skipped
- [x] Web production build
- [x] Full unit suite executed:
  - 7,769 passed
  - 7 skipped
  - 4 existing unrelated document-loader failures:
    - 3 TXT-to-EPUB failures
    - 1 nested ComicInfo archive failure
- [x] Android manual regression — slow Slide drag
- [x] Android manual regression — short Slide flick
- [x] Android manual regression — Page Curl
- [x] Cancel with the toolbar initially visible
- [x] Settings/Popup/Toast snapshot regression
- [x] Browser View Transition Slide/Curl regression
- [x] iOS native regression