### PR TITLE
fix(reader): keep system brightness on after swipe

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -2,7 +2,9 @@ package com.readest.native_bridge
 
 import android.Manifest
 import android.app.Activity
+import android.app.Application
 import android.app.PendingIntent
+import android.os.Bundle
 import android.content.ComponentName
 import android.content.ContentValues
 import android.content.Context
@@ -203,12 +205,16 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
 
     override fun onDestroy() {
         pluginScope.cancel()
+        activity.application.unregisterActivityLifecycleCallbacks(lifecycleCallbacks)
         instance = null
     }
+
+    private var systemBrightnessAtOverride: Int? = null
 
     companion object {
         private const val REQUEST_MANAGE_STORAGE = 1001
         private const val FOLDER_PICKER_REQUEST_CODE = 1002
+        private const val BRIGHTNESS_DRIFT_TOLERANCE = 26 // of 0-255
         var pendingInvoke: Invoke? = null
         var pendingFolderPickerInvoke: Invoke? = null
         private var instance: NativeBridgePlugin? = null
@@ -219,11 +225,43 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
         instance = this
         webViewRef = webView
         super.load(webView)
+        activity.application.registerActivityLifecycleCallbacks(lifecycleCallbacks)
         handleIntent(activity.intent)
     }
 
     override fun onNewIntent(intent: Intent) {
         handleIntent(intent)
+    }
+
+    // Tauri declares Plugin.onResume but never registers the observer that calls it.
+    private val lifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
+        override fun onActivityResumed(resumed: Activity) {
+            if (resumed === activity) dropBrightnessOverrideIfSystemMoved()
+        }
+
+        override fun onActivityCreated(a: Activity, b: Bundle?) {}
+        override fun onActivityStarted(a: Activity) {}
+        override fun onActivityPaused(a: Activity) {}
+        override fun onActivityStopped(a: Activity) {}
+        override fun onActivitySaveInstanceState(a: Activity, b: Bundle) {}
+        override fun onActivityDestroyed(a: Activity) {}
+    }
+
+    private fun dropBrightnessOverrideIfSystemMoved() {
+        val baseline = systemBrightnessAtOverride ?: return
+        val current = readSystemBrightness() ?: return
+        if (kotlin.math.abs(current - baseline) > BRIGHTNESS_DRIFT_TOLERANCE) {
+            val layoutParams = activity.window.attributes
+            layoutParams.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
+            activity.window.attributes = layoutParams
+            systemBrightnessAtOverride = null
+        }
+    }
+
+    private fun readSystemBrightness(): Int? = try {
+        Settings.System.getInt(activity.contentResolver, Settings.System.SCREEN_BRIGHTNESS)
+    } catch (e: Exception) {
+        null
     }
 
     private fun handleIntent(intent: Intent?) {
@@ -811,10 +849,14 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
 
             if (brightness == null || brightness < 0.0) {
                 layoutParams.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
+                systemBrightnessAtOverride = null
             } else {
                 if (brightness > 1.0) {
                     invoke.reject("Brightness must be between 0.0 and 1.0, or null to use system brightness")
                     return
+                }
+                if (systemBrightnessAtOverride == null) {
+                    systemBrightnessAtOverride = readSystemBrightness()
                 }
                 layoutParams.screenBrightness = brightness
             }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -209,8 +209,6 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
         instance = null
     }
 
-    private var systemBrightnessAtOverride: Int? = null
-
     companion object {
         private const val REQUEST_MANAGE_STORAGE = 1001
         private const val FOLDER_PICKER_REQUEST_CODE = 1002
@@ -235,7 +233,7 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
     // Tauri declares Plugin.onResume but never registers the observer that calls it.
     private val lifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
         override fun onActivityResumed(resumed: Activity) {
-            if (resumed === activity) dropBrightnessOverrideIfSystemMoved()
+            if (resumed === activity) releaseBrightnessOverride()
         }
 
         override fun onActivityCreated(a: Activity, b: Bundle?) {}
@@ -246,21 +244,12 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
         override fun onActivityDestroyed(a: Activity) {}
     }
 
-    private fun dropBrightnessOverrideIfSystemMoved() {
-        val baseline = systemBrightnessAtOverride ?: return
-        val current = readSystemBrightness() ?: return
-        if (current != baseline) {
-            val layoutParams = activity.window.attributes
-            layoutParams.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
-            activity.window.attributes = layoutParams
-            systemBrightnessAtOverride = null
-        }
-    }
-
-    private fun readSystemBrightness(): Int? = try {
-        Settings.System.getInt(activity.contentResolver, Settings.System.SCREEN_BRIGHTNESS)
-    } catch (e: Exception) {
-        null
+    // The system owns brightness across a background trip: drop our window
+    // override on resume and keep whatever brightness the system shows now.
+    private fun releaseBrightnessOverride() {
+        val layoutParams = activity.window.attributes
+        layoutParams.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
+        activity.window.attributes = layoutParams
     }
 
     private fun handleIntent(intent: Intent?) {
@@ -848,14 +837,10 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
 
             if (brightness == null || brightness < 0.0) {
                 layoutParams.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
-                systemBrightnessAtOverride = null
             } else {
                 if (brightness > 1.0) {
                     invoke.reject("Brightness must be between 0.0 and 1.0, or null to use system brightness")
                     return
-                }
-                if (systemBrightnessAtOverride == null) {
-                    systemBrightnessAtOverride = readSystemBrightness()
                 }
                 layoutParams.screenBrightness = brightness
             }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -214,7 +214,6 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
     companion object {
         private const val REQUEST_MANAGE_STORAGE = 1001
         private const val FOLDER_PICKER_REQUEST_CODE = 1002
-        private const val BRIGHTNESS_DRIFT_TOLERANCE = 26 // of 0-255
         var pendingInvoke: Invoke? = null
         var pendingFolderPickerInvoke: Invoke? = null
         private var instance: NativeBridgePlugin? = null
@@ -250,7 +249,7 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
     private fun dropBrightnessOverrideIfSystemMoved() {
         val baseline = systemBrightnessAtOverride ?: return
         val current = readSystemBrightness() ?: return
-        if (kotlin.math.abs(current - baseline) > BRIGHTNESS_DRIFT_TOLERANCE) {
+        if (current != baseline) {
             val layoutParams = activity.window.attributes
             layoutParams.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
             activity.window.attributes = layoutParams

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
@@ -528,6 +528,7 @@ class NativeBridgePlugin: Plugin {
   // foreground, and re-assert the app's value when it returns.
   private var appDesiredBrightness: CGFloat?
   private var systemBrightnessBeforeOverride: CGFloat?
+  private static let brightnessDriftTolerance: CGFloat = 0.1
 
   @objc public override func load(webview: WKWebView) {
     self.webView = webview
@@ -573,6 +574,13 @@ class NativeBridgePlugin: Plugin {
 
     NotificationCenter.default.addObserver(
       self,
+      selector: #selector(appWillResignActive),
+      name: UIApplication.willResignActiveNotification,
+      object: nil
+    )
+
+    NotificationCenter.default.addObserver(
+      self,
       selector: #selector(appWillEnterForeground),
       name: UIApplication.willEnterForegroundNotification,
       object: nil
@@ -595,14 +603,11 @@ class NativeBridgePlugin: Plugin {
 
   @objc func appWillEnterForeground() {
     logger.log("NativeBridgePlugin: App will enter foreground")
-    // Re-assert the app's brightness that was released on background (#4885).
-    if let desired = appDesiredBrightness {
-      UIScreen.main.brightness = desired
-    }
     webViewLifecycleManager?.handleAppWillEnterForeground()
   }
 
   @objc func appDidBecomeActive() {
+    reapplyBrightnessUnlessSystemMoved()
     if volumeKeyHandler != nil {
       activateVolumeKeyInterception()
     }
@@ -612,6 +617,18 @@ class NativeBridgePlugin: Plugin {
     // dark mode from Control Center.
     notifyColorSchemeChange()
     syncShareExtensionState()
+  }
+
+  private func reapplyBrightnessUnlessSystemMoved() {
+    guard let desired = appDesiredBrightness, let handedBack = systemBrightnessBeforeOverride else {
+      return
+    }
+    if abs(UIScreen.main.brightness - handedBack) <= Self.brightnessDriftTolerance {
+      UIScreen.main.brightness = desired
+    } else {
+      appDesiredBrightness = nil
+      systemBrightnessBeforeOverride = nil
+    }
   }
 
   /// JS-initiated entry point. The share-extension JS hook calls
@@ -720,15 +737,17 @@ class NativeBridgePlugin: Plugin {
     }
   }
 
+  // iOS ignores brightness writes once the app has resigned the foreground.
+  @objc func appWillResignActive() {
+    if appDesiredBrightness != nil, let original = systemBrightnessBeforeOverride {
+      UIScreen.main.brightness = original
+    }
+  }
+
   @objc func appDidEnterBackground() {
     logger.log("NativeBridgePlugin: App did enter background")
     if let handler = volumeKeyHandler, handler.isIntercepting {
       handler.stopInterception()
-    }
-    // Hand screen brightness back to iOS so ambient auto-brightness resumes
-    // while backgrounded; the override is re-applied on foreground (#4885).
-    if appDesiredBrightness != nil, let original = systemBrightnessBeforeOverride {
-      UIScreen.main.brightness = original
     }
     webViewLifecycleManager?.handleAppDidEnterBackground()
   }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
@@ -525,7 +525,7 @@ class NativeBridgePlugin: Plugin {
   // leaving the system stuck at the app's level until the user nudges it
   // manually (issue #4885). We remember the value that was there before the
   // first override so we can hand it back whenever the app leaves the
-  // foreground, and re-assert the app's value when it returns.
+  // foreground; on return the system value stands and the override is dropped.
   private var appDesiredBrightness: CGFloat?
   private var systemBrightnessBeforeOverride: CGFloat?
 
@@ -606,7 +606,10 @@ class NativeBridgePlugin: Plugin {
   }
 
   @objc func appDidBecomeActive() {
-    reapplyBrightnessUnlessSystemMoved()
+    // The system owns brightness across a background trip: drop our override and
+    // keep whatever brightness the system shows now.
+    appDesiredBrightness = nil
+    systemBrightnessBeforeOverride = nil
     if volumeKeyHandler != nil {
       activateVolumeKeyInterception()
     }
@@ -616,18 +619,6 @@ class NativeBridgePlugin: Plugin {
     // dark mode from Control Center.
     notifyColorSchemeChange()
     syncShareExtensionState()
-  }
-
-  private func reapplyBrightnessUnlessSystemMoved() {
-    guard let desired = appDesiredBrightness, let handedBack = systemBrightnessBeforeOverride else {
-      return
-    }
-    if UIScreen.main.brightness == handedBack {
-      UIScreen.main.brightness = desired
-    } else {
-      appDesiredBrightness = nil
-      systemBrightnessBeforeOverride = nil
-    }
   }
 
   /// JS-initiated entry point. The share-extension JS hook calls

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
@@ -528,7 +528,6 @@ class NativeBridgePlugin: Plugin {
   // foreground, and re-assert the app's value when it returns.
   private var appDesiredBrightness: CGFloat?
   private var systemBrightnessBeforeOverride: CGFloat?
-  private static let brightnessDriftTolerance: CGFloat = 0.1
 
   @objc public override func load(webview: WKWebView) {
     self.webView = webview
@@ -623,7 +622,7 @@ class NativeBridgePlugin: Plugin {
     guard let desired = appDesiredBrightness, let handedBack = systemBrightnessBeforeOverride else {
       return
     }
-    if abs(UIScreen.main.brightness - handedBack) <= Self.brightnessDriftTolerance {
+    if UIScreen.main.brightness == handedBack {
       UIScreen.main.brightness = desired
     } else {
       appDesiredBrightness = nil

--- a/apps/readest-app/src/__tests__/hooks/useBrightnessGesture.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useBrightnessGesture.test.tsx
@@ -6,6 +6,8 @@ const h = vi.hoisted(() => ({
   swipeSetting: true,
   scrolled: false,
   screenBrightness: -1,
+  autoScreenBrightness: false,
+  lastScreenBrightness: null as number | null,
   setScreenBrightness: vi.fn(),
   getScreenBrightness: vi.fn(),
   saveSysSettings: vi.fn(),
@@ -19,18 +21,24 @@ vi.mock('@/context/EnvContext', () => ({
 }));
 vi.mock('@/store/settingsStore', () => ({
   useSettingsStore: () => ({
-    settings: { swipeBrightnessGesture: h.swipeSetting, screenBrightness: h.screenBrightness },
+    settings: {
+      swipeBrightnessGesture: h.swipeSetting,
+      screenBrightness: h.screenBrightness,
+      autoScreenBrightness: h.autoScreenBrightness,
+    },
   }),
 }));
 vi.mock('@/store/readerStore', () => ({
   useReaderStore: () => ({ getViewSettings: () => ({ scrolled: h.scrolled }) }),
 }));
-vi.mock('@/store/deviceStore', () => ({
-  useDeviceControlStore: () => ({
+vi.mock('@/store/deviceStore', () => {
+  const useDeviceControlStore = () => ({
     getScreenBrightness: h.getScreenBrightness,
     setScreenBrightness: h.setScreenBrightness,
-  }),
-}));
+  });
+  useDeviceControlStore.getState = () => ({ lastScreenBrightness: h.lastScreenBrightness });
+  return { useDeviceControlStore };
+});
 vi.mock('@/helpers/settings', () => ({ saveSysSettings: h.saveSysSettings }));
 
 import { useBrightnessGesture } from '@/app/reader/hooks/useBrightnessGesture';
@@ -89,6 +97,8 @@ describe('useBrightnessGesture (listener-level)', () => {
     h.swipeSetting = true;
     h.scrolled = false;
     h.screenBrightness = -1;
+    h.autoScreenBrightness = false;
+    h.lastScreenBrightness = null;
     h.setScreenBrightness.mockReset();
     h.saveSysSettings.mockReset();
     h.getScreenBrightness.mockReset().mockResolvedValue(0.5);
@@ -138,7 +148,7 @@ describe('useBrightnessGesture (listener-level)', () => {
     expect(stopImmediatePropagation).not.toHaveBeenCalled(); // not yet active
   });
 
-  it('persists brightness and disables auto-brightness on release', () => {
+  it('persists brightness on release in manual mode', () => {
     const { target } = setup();
     fireTouch(target, 'touchstart', 10, 800);
     fireTouch(target, 'touchmove', 10, 300); // big upward drag → brighter
@@ -147,7 +157,40 @@ describe('useBrightnessGesture (listener-level)', () => {
     const last = h.setScreenBrightness.mock.calls.at(-1)![0];
     expect(last).toBeGreaterThan(0.5);
     expect(h.saveSysSettings).toHaveBeenCalledWith({}, 'screenBrightness', expect.any(Number));
-    expect(h.saveSysSettings).toHaveBeenCalledWith({}, 'autoScreenBrightness', false);
+  });
+
+  it('keeps system brightness on: applies the swipe without persisting it', () => {
+    h.autoScreenBrightness = true;
+    const { target } = setup();
+    fireTouch(target, 'touchstart', 10, 800);
+    fireTouch(target, 'touchmove', 10, 300);
+    fireTouch(target, 'touchend', 10, 300);
+    expect(h.setScreenBrightness.mock.calls.at(-1)![0]).toBeGreaterThan(0.5);
+    expect(h.saveSysSettings).not.toHaveBeenCalled();
+  });
+
+  it('seeds from the device when system brightness is on, ignoring the stale saved value', async () => {
+    h.autoScreenBrightness = true;
+    h.screenBrightness = 100;
+    h.getScreenBrightness.mockResolvedValue(0.2);
+    const { target } = setup();
+    await act(async () => {});
+    fireTouch(target, 'touchstart', 10, 500);
+    fireTouch(target, 'touchmove', 10, 400);
+    fireTouch(target, 'touchend', 10, 400);
+    expect(h.setScreenBrightness.mock.calls.at(-1)![0]).toBeLessThan(0.5);
+  });
+
+  it('starts from the brightness the slider last applied, not the mount-time seed', async () => {
+    h.autoScreenBrightness = true;
+    h.getScreenBrightness.mockResolvedValue(0.9);
+    const { target } = setup();
+    await act(async () => {});
+    h.lastScreenBrightness = 0.1; // slider dragged down, nothing persisted
+    fireTouch(target, 'touchstart', 10, 500);
+    fireTouch(target, 'touchmove', 10, 400);
+    fireTouch(target, 'touchend', 10, 400);
+    expect(h.setScreenBrightness.mock.calls.at(-1)![0]).toBeLessThan(0.5);
   });
 
   it('is inert when the setting is disabled', () => {

--- a/apps/readest-app/src/__tests__/hooks/useScreenBrightness.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useScreenBrightness.test.tsx
@@ -6,6 +6,7 @@ const h = vi.hoisted(() => ({
   autoScreenBrightness: false,
   screenBrightness: -1,
   setScreenBrightness: vi.fn(),
+  syncScreenBrightness: vi.fn(),
 }));
 
 vi.mock('@/context/EnvContext', () => ({
@@ -20,7 +21,10 @@ vi.mock('@/store/settingsStore', () => ({
   }),
 }));
 vi.mock('@/store/deviceStore', () => ({
-  useDeviceControlStore: () => ({ setScreenBrightness: h.setScreenBrightness }),
+  useDeviceControlStore: () => ({
+    setScreenBrightness: h.setScreenBrightness,
+    syncScreenBrightness: h.syncScreenBrightness,
+  }),
 }));
 
 import { useScreenBrightness } from '@/app/reader/hooks/useScreenBrightness';
@@ -38,8 +42,28 @@ describe('useScreenBrightness', () => {
     h.autoScreenBrightness = false;
     h.screenBrightness = -1;
     h.setScreenBrightness.mockReset();
+    h.syncScreenBrightness.mockReset();
   });
   afterEach(() => cleanup());
+
+  const becomeVisible = (state: 'visible' | 'hidden') => {
+    Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  };
+
+  it('re-reads the device brightness when the app returns to the foreground', () => {
+    h.autoScreenBrightness = true;
+    setup();
+    becomeVisible('visible');
+    expect(h.syncScreenBrightness).toHaveBeenCalled();
+  });
+
+  it('does not re-read while the app is going into the background', () => {
+    h.autoScreenBrightness = true;
+    setup();
+    becomeVisible('hidden');
+    expect(h.syncScreenBrightness).not.toHaveBeenCalled();
+  });
 
   it('applies the saved manual brightness when auto is off', () => {
     h.autoScreenBrightness = false;

--- a/apps/readest-app/src/__tests__/hooks/useScreenBrightness.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useScreenBrightness.test.tsx
@@ -65,6 +65,24 @@ describe('useScreenBrightness', () => {
     expect(h.syncScreenBrightness).not.toHaveBeenCalled();
   });
 
+  it('re-applies the manual brightness on foreground', () => {
+    h.autoScreenBrightness = false;
+    h.screenBrightness = 40;
+    setup();
+    h.setScreenBrightness.mockClear();
+    becomeVisible('visible');
+    expect(h.setScreenBrightness).toHaveBeenCalledWith(0.4);
+  });
+
+  it('leaves the system value alone on foreground in system-brightness mode', () => {
+    h.autoScreenBrightness = true;
+    h.screenBrightness = 40;
+    setup();
+    h.setScreenBrightness.mockClear();
+    becomeVisible('visible');
+    expect(h.setScreenBrightness).not.toHaveBeenCalled();
+  });
+
   it('applies the saved manual brightness when auto is off', () => {
     h.autoScreenBrightness = false;
     h.screenBrightness = 40;

--- a/apps/readest-app/src/__tests__/store/device-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/device-store.test.ts
@@ -190,6 +190,26 @@ describe('deviceStore', () => {
     });
   });
 
+  describe('syncScreenBrightness', () => {
+    test('records what the device currently reports', async () => {
+      const { getScreenBrightness } = await import('@/utils/bridge');
+      vi.mocked(getScreenBrightness).mockResolvedValue({ brightness: 0.3 });
+
+      useDeviceControlStore.setState({ lastScreenBrightness: 0.9 });
+      await useDeviceControlStore.getState().syncScreenBrightness();
+      expect(useDeviceControlStore.getState().lastScreenBrightness).toBe(0.3);
+    });
+
+    test('records null when the device reports no app override', async () => {
+      const { getScreenBrightness } = await import('@/utils/bridge');
+      vi.mocked(getScreenBrightness).mockResolvedValue({ brightness: -1 });
+
+      useDeviceControlStore.setState({ lastScreenBrightness: 0.9 });
+      await useDeviceControlStore.getState().syncScreenBrightness();
+      expect(useDeviceControlStore.getState().lastScreenBrightness).toBeNull();
+    });
+  });
+
   // ── Native touch events ────────────────────────────────────────
   describe('listenToNativeTouchEvents', () => {
     test('sets window.onNativeTouch handler', () => {

--- a/apps/readest-app/src/app/reader/components/footerbar/ColorPanel.tsx
+++ b/apps/readest-app/src/app/reader/components/footerbar/ColorPanel.tsx
@@ -54,11 +54,12 @@ export const ColorPanel: React.FC<ColorPanelProps> = ({
   const debouncedSetScreenBrightness = useMemo(
     () =>
       debounce(async (value: number) => {
-        saveSysSettings(envConfig, 'screenBrightness', value);
-        saveSysSettings(envConfig, 'autoScreenBrightness', false);
+        if (!settings.autoScreenBrightness) {
+          saveSysSettings(envConfig, 'screenBrightness', value);
+        }
         await setScreenBrightness(value / 100);
       }, 100),
-    [envConfig, setScreenBrightness],
+    [envConfig, setScreenBrightness, settings.autoScreenBrightness],
   );
 
   const handleScreenBrightnessChange = useCallback(

--- a/apps/readest-app/src/app/reader/hooks/useBrightnessGesture.ts
+++ b/apps/readest-app/src/app/reader/hooks/useBrightnessGesture.ts
@@ -16,6 +16,7 @@ const DEFAULT_BRIGHTNESS = 0.5;
 interface LatestState {
   enabled: boolean;
   scrolled: boolean;
+  autoBrightness: boolean;
 }
 
 /**
@@ -42,10 +43,11 @@ export const useBrightnessGesture = (bookKey: string) => {
   const [overlayLevel, setOverlayLevel] = useState(0);
 
   // Everything the once-attached listener must read at the latest value.
-  const latestRef = useRef<LatestState>({ enabled: false, scrolled: false });
+  const latestRef = useRef<LatestState>({ enabled: false, scrolled: false, autoBrightness: false });
   latestRef.current = {
     enabled: hasScreenBrightness && settings.swipeBrightnessGesture,
     scrolled: !!viewSettings?.scrolled,
+    autoBrightness: settings.autoScreenBrightness,
   };
 
   // Per-gesture state.
@@ -67,7 +69,7 @@ export const useBrightnessGesture = (bookKey: string) => {
 
   useEffect(() => {
     if (!hasScreenBrightness) return;
-    if (settings.screenBrightness >= 0) {
+    if (!settings.autoScreenBrightness && settings.screenBrightness >= 0) {
       seedRef.current = Math.max(0, Math.min(1, settings.screenBrightness / 100));
       seededRef.current = true;
       return;
@@ -81,7 +83,12 @@ export const useBrightnessGesture = (bookKey: string) => {
     return () => {
       cancelled = true;
     };
-  }, [hasScreenBrightness, settings.screenBrightness, getScreenBrightness]);
+  }, [
+    hasScreenBrightness,
+    settings.screenBrightness,
+    settings.autoScreenBrightness,
+    getScreenBrightness,
+  ]);
 
   const flushBrightness = useCallback(() => {
     rafIdRef.current = null;
@@ -135,7 +142,8 @@ export const useBrightnessGesture = (bookKey: string) => {
         startXRef.current = t.screenX;
         startYRef.current = t.screenY;
         armedRef.current = isInLeftEdge(t.screenX, viewWidth);
-        startValueRef.current = seedRef.current;
+        const applied = useDeviceControlStore.getState().lastScreenBrightness;
+        startValueRef.current = applied ?? seedRef.current;
       };
 
       const onTouchMove = (e: TouchEvent) => {
@@ -171,8 +179,9 @@ export const useBrightnessGesture = (bookKey: string) => {
         const value = levelRef.current;
         setScreenBrightness(value);
         seedRef.current = value;
-        saveSysSettings(envConfig, 'screenBrightness', Math.round(value * 100));
-        saveSysSettings(envConfig, 'autoScreenBrightness', false);
+        if (!latestRef.current.autoBrightness) {
+          saveSysSettings(envConfig, 'screenBrightness', Math.round(value * 100));
+        }
         if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
         hideTimerRef.current = setTimeout(() => setOverlayVisible(false), OVERLAY_HIDE_DELAY_MS);
         resetGesture();

--- a/apps/readest-app/src/app/reader/hooks/useScreenBrightness.ts
+++ b/apps/readest-app/src/app/reader/hooks/useScreenBrightness.ts
@@ -21,7 +21,7 @@ const RELEASE_BRIGHTNESS = -1;
 export const useScreenBrightness = () => {
   const { appService } = useEnv();
   const { settings } = useSettingsStore();
-  const { setScreenBrightness } = useDeviceControlStore();
+  const { setScreenBrightness, syncScreenBrightness } = useDeviceControlStore();
 
   const hasScreenBrightness = !!appService?.hasScreenBrightness;
   const { screenBrightness, autoScreenBrightness } = settings;
@@ -42,4 +42,13 @@ export const useScreenBrightness = () => {
     // and when the auto/manual mode flips.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasScreenBrightness, autoScreenBrightness, setScreenBrightness]);
+
+  useEffect(() => {
+    if (!hasScreenBrightness) return;
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') syncScreenBrightness();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange);
+  }, [hasScreenBrightness, syncScreenBrightness]);
 };

--- a/apps/readest-app/src/app/reader/hooks/useScreenBrightness.ts
+++ b/apps/readest-app/src/app/reader/hooks/useScreenBrightness.ts
@@ -13,10 +13,11 @@ const RELEASE_BRIGHTNESS = -1;
  * releases control back to the system when the reader closes or the user
  * switches "System Screen Brightness" back on.
  *
- * The native iOS bridge additionally restores the system brightness whenever
- * the app backgrounds (and re-applies on foreground), so ambient auto-brightness
- * never stays locked after leaving the app — the reader component does not
- * unmount when the app is merely sent to the home screen.
+ * The native bridge hands brightness back to the system on background and drops
+ * the override on foreground, so the system value always wins across a
+ * background trip; this hook re-applies the manual brightness on foreground
+ * (the reader component does not unmount when the app is sent to the home
+ * screen), while system mode is left at whatever the system now shows.
  */
 export const useScreenBrightness = () => {
   const { appService } = useEnv();
@@ -46,9 +47,21 @@ export const useScreenBrightness = () => {
   useEffect(() => {
     if (!hasScreenBrightness) return;
     const onVisibilityChange = () => {
-      if (document.visibilityState === 'visible') syncScreenBrightness();
+      if (document.visibilityState !== 'visible') return;
+      // The native bridge drops the override on foreground, so re-apply the
+      // manual brightness here; in system mode we leave it at the system value.
+      if (!autoScreenBrightness && screenBrightness >= 0) {
+        setScreenBrightness(screenBrightness / 100);
+      }
+      syncScreenBrightness();
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
     return () => document.removeEventListener('visibilitychange', onVisibilityChange);
-  }, [hasScreenBrightness, syncScreenBrightness]);
+  }, [
+    hasScreenBrightness,
+    autoScreenBrightness,
+    screenBrightness,
+    setScreenBrightness,
+    syncScreenBrightness,
+  ]);
 };

--- a/apps/readest-app/src/store/deviceStore.ts
+++ b/apps/readest-app/src/store/deviceStore.ts
@@ -27,6 +27,8 @@ type DeviceControlState = {
   backKeyInterceptionCount: number;
   getScreenBrightness: () => Promise<number>; // 0.0 to 1.0
   setScreenBrightness: (brightness: number) => Promise<void>; // brightness: 0.0 to 1.0
+  lastScreenBrightness: number | null; // 0.0 to 1.0, null once released
+  syncScreenBrightness: () => Promise<void>;
   acquireVolumeKeyInterception: () => void;
   releaseVolumeKeyInterception: () => void;
   acquireBackKeyInterception: () => void;
@@ -40,6 +42,7 @@ type DeviceControlState = {
 };
 
 export const useDeviceControlStore = create<DeviceControlState>((set, get) => ({
+  lastScreenBrightness: null,
   volumeKeysIntercepted: false,
   backKeyIntercepted: false,
   volumeKeysInterceptionCount: 0,
@@ -126,6 +129,12 @@ export const useDeviceControlStore = create<DeviceControlState>((set, get) => ({
   },
 
   setScreenBrightness: async (brightness: number) => {
+    set({ lastScreenBrightness: brightness >= 0 ? brightness : null });
     await setScreenBrightness({ brightness });
+  },
+
+  syncScreenBrightness: async () => {
+    const { brightness } = await getScreenBrightness();
+    set({ lastScreenBrightness: brightness >= 0 && brightness <= 1 ? brightness : null });
   },
 }));


### PR DESCRIPTION
> Disclaimer: the code is fully agent-written. The PR description is fully human-written (`→`s courtesy of [Ilya Birman's typography layout](https://ilyabirman.net/typography-layout/)).

I had the same problem as described in #3183:

- turn on "follow system brightness"
- adjust brightness in readest during the day, system brightness toggle silently turns off
- pick up a phone to read at night → unpleasantly surprised by bright screen

Workaround as proposed in #3183:

- keep "follow system brightness" off, only modify brightness via system controls

That works, but is not very convenient. This PR makes it so swipe-to-adjust-brightness still works, but if you close the app and open it again, you get current system brightness.

# Review

Agent self-reviewed via mattpocock's `code-review` skill. I then read the whole PR myself, changed several things. In its current state it looks reasonable to me. (But I don't know neither Swift nor Kotlin, so take that with a grain of salt.)

# Testing

My agent tested in Simulator via `axe` CLI and in android emulator. Then I booted dev app on my physical iPhone and confirmed the flow:

1. Set system brightness low, open Readest → brightness is low.
2. Swipe brightness up to medium, close Readest → brightness is back to system low.
3. Reopen Readest → back at system low.

I didn't test on a physical Android.

Also, this PR doesn't break any tests (apparently there are some pre-existing broken tests).
