### PR TITLE
fix(reader): invalidate stale nav cache for encoded TOC hrefs (#5308)

### DIFF
--- a/apps/readest-app/src/__tests__/foliate-epub-encoded-href.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-epub-encoded-href.test.ts
@@ -116,7 +116,16 @@ describe('EPUB hrefs that percent-encode reserved characters (#5097)', () => {
 
     // Tapping the TOC row hands its href to `resolveHref`; it must land on the
     // chapter's spine index instead of resolving to nothing.
+    expect(toc[1]!.href).toBe('OEBPS/a&b.html');
     expect(epub.resolveHref(toc[1]!.href)?.index).toBe(1);
+
+    // The decoded href resolves; the still-encoded form a pre-#5097 nav cache
+    // would hold does not. `resolveHref` decodes with `decodeURI`, which leaves
+    // the reserved set encoded, so `OEBPS/a%26b.html` never matches the decoded
+    // manifest entry -> `goTo` silently no-ops. A stale cache carrying that
+    // encoded href is exactly the #5308 TOC-nav failure, which is why
+    // BOOK_NAV_VERSION is bumped (see book-nav-cache.test.ts) to invalidate it.
+    expect(epub.resolveHref('OEBPS/a%26b.html')).toBeNull();
   });
 
   // Issue #346, "Pictures in book (ePub) can not be displayed": a book with a

--- a/apps/readest-app/src/__tests__/utils/book-nav-cache.test.ts
+++ b/apps/readest-app/src/__tests__/utils/book-nav-cache.test.ts
@@ -6,6 +6,7 @@ import type { BookDoc, TOCItem, SectionItem } from '@/libs/document';
 import {
   computeBookNav,
   hydrateBookNav,
+  isBookNavCacheCurrent,
   updateToc,
   findTocItemBS,
   BOOK_NAV_VERSION,
@@ -289,4 +290,37 @@ describe('hierarchical fragments under a single section', () => {
       expect(foundNested).toBe(true);
     }
   }, 30000);
+});
+
+describe('isBookNavCacheCurrent — nav cache invalidation (#5308)', () => {
+  // A nav.json persisted by a pre-#5097 build stored the ampersand chapter's
+  // TOC href percent-encoded (`OEBPS/a%26b.html`). foliate's resolveHref decodes
+  // with decodeURI(), which leaves the reserved set encoded, so that href no
+  // longer matches the now-decoded manifest entry and TOC navigation silently
+  // no-ops. readerStore reuses a cache only when `isBookNavCacheCurrent` holds,
+  // so the BOOK_NAV_VERSION bump makes those stale caches recompute instead.
+  const PRE_5097_NAV_VERSION = 3;
+
+  const makeCache = (version: number): BookNav => ({
+    version,
+    toc: [
+      { label: 'Chapter 1', href: 'OEBPS/normal.html' },
+      // The still-encoded href a pre-#5097 build would have cached.
+      { label: 'Chapter 2: A&B', href: 'OEBPS/a%26b.html' },
+    ] as TOCItem[],
+    sections: {},
+  });
+
+  it('rejects a pre-#5097 (v3) cache so the reader recomputes a decoded TOC', () => {
+    expect(isBookNavCacheCurrent(makeCache(PRE_5097_NAV_VERSION))).toBe(false);
+  });
+
+  it('accepts a cache written by the current algorithm version', () => {
+    expect(isBookNavCacheCurrent(makeCache(BOOK_NAV_VERSION))).toBe(true);
+  });
+
+  it('treats a missing cache as not current', () => {
+    expect(isBookNavCacheCurrent(null)).toBe(false);
+    expect(isBookNavCacheCurrent(undefined)).toBe(false);
+  });
 });

--- a/apps/readest-app/src/services/nav/index.ts
+++ b/apps/readest-app/src/services/nav/index.ts
@@ -61,9 +61,15 @@ export type { SectionFragment };
 //     of inherited from the TOC item (ported from foliate-js 317051e).
 // v3: nav-enrichment fallback — when toc.ncx is sparse, scan section HTMLs for
 //     embedded <nav> elements and merge their links as top-level TOC items.
+// v4: invalidate caches written before the #5097 reserved-char href fix. Those
+//     builds stored the ampersand chapter's TOC href percent-encoded
+//     (`OEBPS/a%26b.html`); foliate's resolveHref decodes with decodeURI(),
+//     which leaves the reserved set encoded, so the stale href no longer matches
+//     the now-decoded manifest entry and TOC navigation silently no-ops (#5308).
+//     Bumping forces a one-time recompute that re-derives the decoded TOC.
 // -----------------------------------------------------------------------------
 
-export const BOOK_NAV_VERSION = 3;
+export const BOOK_NAV_VERSION = 4;
 
 export interface BookNavSection {
   id: string;
@@ -75,6 +81,18 @@ export interface BookNav {
   toc: TOCItem[];
   sections: Record<string, BookNavSection>;
 }
+
+/**
+ * Whether a persisted nav cache may be reused as-is. A cache is only current
+ * when it was produced by the running BOOK_NAV_VERSION; anything older is
+ * recomputed. This is what protects readers from stale caches whose output
+ * semantics have since changed — e.g. pre-#5097 caches that stored reserved-
+ * char TOC hrefs percent-encoded, which no longer resolve against the decoded
+ * manifest (see the BOOK_NAV_VERSION docblock, #5308).
+ */
+export const isBookNavCacheCurrent = (
+  cachedNav: BookNav | null | undefined,
+): cachedNav is BookNav => cachedNav?.version === BOOK_NAV_VERSION;
 
 const convertTocLabels = (items: TOCItem[], convertChineseVariant: ConvertChineseVariant) => {
   items.forEach((item) => {

--- a/apps/readest-app/src/store/readerStore.ts
+++ b/apps/readest-app/src/store/readerStore.ts
@@ -21,7 +21,7 @@ import {
 import type { FileSystem } from '@/types/system';
 import { isFeedBookUrl, parseFeedBookUrl } from '@/services/rss/feedBookUrl';
 import { openFeedBookDoc } from '@/services/rss/feedReader';
-import { BOOK_NAV_VERSION, computeBookNav, hydrateBookNav, updateToc } from '@/services/nav';
+import { computeBookNav, hydrateBookNav, isBookNavCacheCurrent, updateToc } from '@/services/nav';
 import { formatTitle, getMetadataHash, getPrimaryLanguage } from '@/utils/book';
 import { getBaseFilename } from '@/utils/path';
 import { SUPPORTED_LANGNAMES } from '@/services/constants';
@@ -245,7 +245,7 @@ export const useReaderStore = create<ReaderStore>((set, get) => ({
       // Load cached book navigation (TOC + section fragments) or compute and persist.
       if (book.format === 'EPUB' && bookDoc.rendition?.layout !== 'pre-paginated') {
         const cachedNav = await appService.loadBookNav(book);
-        if (cachedNav?.version === BOOK_NAV_VERSION && process.env.NODE_ENV === 'production') {
+        if (isBookNavCacheCurrent(cachedNav) && process.env.NODE_ENV === 'production') {
           hydrateBookNav(bookDoc, cachedNav);
         } else {
           const freshNav = await computeBookNav(bookDoc);


### PR DESCRIPTION
## Summary

Fixes #5308: chapters whose filename contains a reserved character (e.g. `&`) could not be reached from the Table of Contents.

This is **not** a live-parse regression, it is a **stale nav cache**. Root cause, verified live in Chrome and reproduced in tests:

- The reader caches each EPUB's TOC in `Books/{hash}/nav.json`, gated by `BOOK_NAV_VERSION`.
- A `nav.json` written by a **pre-#5097** build stored the ampersand chapter's TOC href percent-encoded (`OEBPS/a%26b.html`). The #5097 fix (foliate `decodeURIPath`) corrected the *fresh* parse but **did not bump `BOOK_NAV_VERSION`**, so `readerStore` reused the stale cache via `hydrateBookNav` instead of recomputing.
- foliate's `resolveHref` decodes with `decodeURI`, which per spec leaves the reserved set (`; / ? : @ & = + $ , #`) encoded, so the stale `OEBPS/a%26b.html` never matched the now-decoded manifest entry `OEBPS/a&b.html`. `resolveHref` returns `null`, `view.goTo` silently no-ops, and the chapter is unreachable from the TOC.

Verified live in the running reader: `resolveHref('OEBPS/a%26b.html')` -> `null`, `resolveHref('OEBPS/a&b.html')` -> index 1.

### Why it was hard to reproduce
A fresh import always recomputes a correct decoded nav, and the cache path is additionally gated on `process.env.NODE_ENV === 'production'`, so dev builds never read the cache. A stale cache can only bite a release build that first opened the book before the #5097 fix.

## Fix

- Bump `BOOK_NAV_VERSION` 3 -> 4 to invalidate pre-#5097 caches, forcing a one-time recompute that re-derives the decoded TOC.
- Extract the version gate into a `isBookNavCacheCurrent(cachedNav): cachedNav is BookNav` type guard (used by `readerStore`) so the invalidation decision is unit tested rather than inlined.

## Tests

- `book-nav-cache.test.ts`: `isBookNavCacheCurrent` rejects a pre-#5097 (v3) cache, accepts a current-version cache, treats a missing cache as not current. Confirmed the v3-rejection test fails if the version bump is reverted (not tautological).
- `foliate-epub-encoded-href.test.ts`: added an assertion that the still-encoded href (`OEBPS/a%26b.html`) does not resolve, documenting why a stale cache breaks TOC navigation.

Full suite: 7730 passed / 7 skipped. `pnpm lint` (tsgo + biome) clean.

## Note on latent fragility (not addressed here)
foliate's `resolveHref` still uses `decodeURI`, so any still-encoded href reaching `goTo` no-ops. Optional defense-in-depth (decoding reserved chars in `resolveHref`) was left out since the version bump resolves the reported issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)