### PR TITLE
fix(rss): sync feed subscriptions across devices (#5307)

### DIFF
--- a/apps/readest-app/.claude/memory/MEMORY.md
+++ b/apps/readest-app/.claude/memory/MEMORY.md
@@ -34,6 +34,7 @@
 - [#5068 sync passphrase unverified](sync-passphrase-unverified-5068.md) trial-decrypt before persist
 - [Empty-start CFI sync](empty-start-cfi-sync.md) · [Custom fonts vanish #4410](custom-fonts-reincarnation-4410.md) CRDT remove-wins
 - [#5180 OPDS catalog reincarnates](opds-catalog-reincarnate-restart-5180.md) MERGED #5191; remove-wins class; addCatalog always carries a token
+- [#5307 RSS feeds don't sync](rss-feed-books-not-syncing-5307.md) feed books are fileless; peer gate needs uploadedAt; `isFeedBook` predicate
 - koplugin: [note deletion](koplugin-note-deletion-sync.md); [#4666 stats](koplugin-stats-sync.md); [#4751 bulk download](koplugin-bulk-download-4751.md); [#4861 dup rows](koplugin-stats-duplicate-book-rows-4861.md)
 - [Statusless re-pin #4677](sync-statusless-book-rebump-4677.md) · [pull cursor synced_at #4678](sync-synced-at-cursor-4678.md)
 - [deleted_at OR cursor invariant](sync-deleted-at-cursor-invariant.md) notes/configs OR load-bearing

--- a/apps/readest-app/.claude/memory/rss-feed-books-not-syncing-5307.md
+++ b/apps/readest-app/.claude/memory/rss-feed-books-not-syncing-5307.md
@@ -1,0 +1,47 @@
+---
+name: rss-feed-books-not-syncing-5307
+description: "#5307 RSS feed subscriptions never reach other devices because feed books are fileless and the peer sync gate requires uploadedAt"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 5d6b056c-0530-4374-9334-20e607a216cb
+  modified: 2026-07-25T01:46:50.819Z
+---
+
+# #5307 — RSS feeds only show in the browser where they were added
+
+Reported on web.readest.com 0.11.20, two laptops, same account. Two symptoms, one cause:
+manual "upload to cloud" fails immediately, and the feed never appears on the other browser.
+
+**A feed subscription is a fileless Book row.** `createFeedBook` (`src/services/rss/feedBook.ts`)
+makes a virtual EPUB with `url = feed://<encoded {feedUrl}>`, `metadata.feedUrl`, `uploadedAt: null`,
+`downloadedAt: now`. There is no blob anywhere — `readerStore` rebuilds the book from the feed URL,
+and `transformBookFromDB` rehydrates `book.url` from `metadata.feedUrl` on peers.
+
+**Root cause.** `resolveBookContentSource` returns `{kind:'feed'}`, which `isBookFileContentSource`
+rejects, so `cloudService.uploadBook` throws `Book file not uploaded` → the queued transfer fails
+(that is the visible "sync is failing"). `uploadedAt` therefore stays null forever. The row's
+METADATA does reach the cloud (verified: `getNewBooks` pushes it, the server pull has no
+`uploaded_at` filter) — but `useBooksSync.updateLibrary`'s new-book filter required
+`newBook.uploadedAt`, a guard that exists so a peer never shelves a book whose file it cannot
+fetch. A feed book needs no file, so it was silently dropped on every device but the origin.
+
+**Fix.** New predicate `isFeedBook(book)` in `services/rss/feedBookUrl.ts`, applied at the places
+that reason about a book's FILE:
+- `useBooksSync.updateLibrary` — `(newBook.uploadedAt || isFeedBook(newBook))` (the actual sync fix)
+- `getBookContextMenuItemIds` — no download/upload/share
+- `BookItem` shelf cloud badge, `TransferQueuePanel` "Upload All", `BookDetailView` upload button
+- `processNewBook` regenerates the cover locally via new `ensureFeedBookCover` (extracted from
+  `handleAddFeedSubmit`) — the cover is derived from feedUrl+title, and there is no cloud copy to
+  download because `uploadBook` never ran.
+
+**Rejected alternatives:** stamping `uploadedAt` at creation (peers would then offer Download and
+fetch a nonexistent file); setting `downloadedAt: null` instead (implicit, and does not fix feed
+books already in users' libraries).
+
+**Notes for future work:** feed books degrade gracefully on file-sync backends (WebDAV/Drive/S3) —
+`pushBookFile` resolves `no-source` and skips. `ShareBookDialog` was already safe: `shareEnabled`
+gates on `fileSize !== null`. `FeedsView` + `feedStore` (`Settings/feeds.json`) appear to be dead
+code — `handleShowFeeds` opens `AddFeedModal`, nothing sets `showFeeds`; per-item read state is
+therefore not synced at all. Related: [[opds-catalog-reincarnate-restart-5180]],
+[[demo-books-cloud-sync-5049]].

--- a/apps/readest-app/src/__tests__/app/library/book-context-menu.test.ts
+++ b/apps/readest-app/src/__tests__/app/library/book-context-menu.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { getBookContextMenuItemIds } from '@/app/library/utils/libraryUtils';
+import { buildFeedBookUrl } from '@/services/rss/feedBookUrl';
 import { Book } from '@/types/book';
 
 const createBook = (overrides: Partial<Book> = {}): Book => ({
@@ -98,6 +99,26 @@ describe('getBookContextMenuItemIds', () => {
 
   it('omits download/upload/share for a book that is neither downloaded nor uploaded', () => {
     const book = createBook({ filePath: '/some/external/file.epub' });
+    expect(getBookContextMenuItemIds(book)).toEqual([
+      'select',
+      'group',
+      'markFinished',
+      'markAbandoned',
+      'showDetails',
+      'showInFinder',
+      'searchGoodreads',
+      'delete',
+    ]);
+  });
+
+  // Issue #5307 — a feed subscription has no file anywhere: the cloud has
+  // nothing to upload it to and nothing to hand a share link. Offering those
+  // actions only produces a failed transfer.
+  it('omits download/upload/share for a feed book (issue #5307)', () => {
+    const book = createBook({
+      downloadedAt: 1,
+      url: buildFeedBookUrl('https://www.saastr.com/feed/'),
+    });
     expect(getBookContextMenuItemIds(book)).toEqual([
       'select',
       'group',

--- a/apps/readest-app/src/__tests__/app/library/feed-books-sync.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/feed-books-sync.test.tsx
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import type { Book } from '@/types/book';
+
+/**
+ * Issue #5307 — "RSS feeds are only showing in the original web browser where
+ * they were added".
+ *
+ * A feed subscription is a fileless Book row: `url` is a `feed://` descriptor
+ * and the content is rebuilt from `metadata.feedUrl` on whatever device opens
+ * it. There is no blob to put in cloud storage, so `uploadedAt` stays null
+ * forever. The row's metadata does reach the cloud, but the peer's
+ * `updateLibrary` only adopts a cloud row once it is `uploadedAt` — a guard
+ * that exists so peers never shelve a book whose file they cannot fetch.
+ * A feed book needs no file, so that guard must not apply to it.
+ */
+
+const appService = vi.hoisted(() => ({
+  saveLibraryBooks: vi.fn(async () => {}),
+  generateCoverImageUrl: vi.fn(async () => 'blob:cover'),
+  downloadBookCovers: vi.fn(async () => {}),
+}));
+
+// Rasterizing the generated SVG needs a real canvas, so the cover writer itself
+// is covered by its own unit test; here we only assert the routing.
+const ensureFeedBookCover = vi.hoisted(() =>
+  vi.fn(async (_appService: unknown, _book: Book) => 'blob:feed-cover'),
+);
+
+const syncState = vi.hoisted(() => ({
+  useSyncInited: true,
+  syncedBooks: null as Book[] | null,
+  syncBooks: vi.fn(async (_books?: Book[], _op?: string, _since?: number) => 0),
+  lastSyncedAtBooks: 1000,
+}));
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService }),
+}));
+
+vi.mock('@/context/SyncContext', () => ({
+  useSyncContext: () => ({ syncClient: {} }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (text: string) => text,
+}));
+
+vi.mock('@/hooks/useSync', () => ({
+  useSync: () => syncState,
+}));
+
+vi.mock('@/services/sync/cloudSyncProvider', () => ({
+  isReadestCloudEnabled: () => true,
+  getActiveFileSyncBackends: () => [],
+}));
+
+vi.mock('@/services/sync/file/runLibrarySync', () => ({
+  runFileLibrarySyncPass: vi.fn(async () => ({ booksSynced: 0 })),
+}));
+
+vi.mock('@/services/sync/fleetDetection', () => ({
+  checkMixedFleetOnce: vi.fn(),
+}));
+
+vi.mock('@/services/rss/feedBook', () => ({ ensureFeedBookCover }));
+
+const { useBooksSync } = await import('@/app/library/hooks/useBooksSync');
+const { useLibraryStore } = await import('@/store/libraryStore');
+const { buildFeedBookUrl } = await import('@/services/rss/feedBookUrl');
+
+const FEED_URL = 'https://www.saastr.com/feed/';
+
+const makeBook = (over: Partial<Book> & Pick<Book, 'hash'>): Book => ({
+  format: 'EPUB',
+  title: 'Title',
+  author: 'Author',
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...over,
+});
+
+const makeFeedBook = (over: Partial<Book> = {}): Book =>
+  makeBook({
+    hash: 'feed-1',
+    title: 'SaaStr',
+    url: buildFeedBookUrl(FEED_URL),
+    metadata: { title: 'SaaStr', author: '', language: '', feedUrl: FEED_URL },
+    uploadedAt: null,
+    ...over,
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  syncState.syncedBooks = null;
+  useLibraryStore.setState({ library: [], libraryLoaded: false, isSyncing: false });
+});
+
+describe('feed books and the cloud book channel (issue #5307)', () => {
+  it('shelves a synced feed book even though it has no uploadedAt', async () => {
+    useLibraryStore.getState().setLibrary([]);
+    useLibraryStore.setState({ libraryLoaded: true });
+    syncState.syncedBooks = [makeFeedBook()];
+
+    renderHook(() => useBooksSync());
+
+    await waitFor(() => {
+      const hashes = useLibraryStore.getState().library.map((book) => book.hash);
+      expect(hashes).toContain('feed-1');
+    });
+  });
+
+  it('regenerates the feed cover locally instead of expecting one in the cloud', async () => {
+    // The origin device's cover.png was never uploaded — a feed book has no
+    // cloud files at all — so the peer rebuilds it from the feed descriptor.
+    useLibraryStore.getState().setLibrary([]);
+    useLibraryStore.setState({ libraryLoaded: true });
+    syncState.syncedBooks = [makeFeedBook()];
+
+    renderHook(() => useBooksSync());
+
+    await waitFor(() => expect(ensureFeedBookCover).toHaveBeenCalled());
+    expect(ensureFeedBookCover.mock.calls[0]?.[1]?.hash).toBe('feed-1');
+    expect(useLibraryStore.getState().library[0]?.coverImageUrl).toBe('blob:feed-cover');
+  });
+
+  it('leaves ordinary books on the cloud cover path', async () => {
+    useLibraryStore.getState().setLibrary([]);
+    useLibraryStore.setState({ libraryLoaded: true });
+    syncState.syncedBooks = [makeBook({ hash: 'plain-1', uploadedAt: 2000 })];
+
+    renderHook(() => useBooksSync());
+
+    await waitFor(() => expect(appService.generateCoverImageUrl).toHaveBeenCalled());
+    expect(ensureFeedBookCover).not.toHaveBeenCalled();
+  });
+
+  it('still skips an ordinary cloud row whose file was never uploaded', async () => {
+    useLibraryStore.getState().setLibrary([]);
+    useLibraryStore.setState({ libraryLoaded: true });
+    syncState.syncedBooks = [makeBook({ hash: 'plain-1', uploadedAt: null })];
+
+    renderHook(() => useBooksSync());
+
+    await waitFor(() => expect(appService.saveLibraryBooks).toHaveBeenCalled());
+    expect(useLibraryStore.getState().library.map((book) => book.hash)).toEqual([]);
+  });
+
+  it('pushes the feed book to the cloud so peers can see it at all', async () => {
+    useLibraryStore.getState().setLibrary([makeFeedBook()]);
+    useLibraryStore.setState({ libraryLoaded: true });
+
+    const { result } = renderHook(() => useBooksSync());
+    await result.current.pushLibrary();
+
+    const pushed = new Set(
+      syncState.syncBooks.mock.calls
+        .flatMap((call) => (call[0] ?? []) as Book[])
+        .map((book) => book.hash),
+    );
+    expect(pushed.has('feed-1')).toBe(true);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/rss/feedBook.test.ts
+++ b/apps/readest-app/src/__tests__/services/rss/feedBook.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest';
-import { createFeedBook, feedBookHash, generateFeedCoverSvg } from '@/services/rss/feedBook';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createFeedBook,
+  ensureFeedBookCover,
+  feedBookHash,
+  generateFeedCoverSvg,
+} from '@/services/rss/feedBook';
 import { parseFeedBookUrl } from '@/services/rss/feedBookUrl';
 
 describe('generateFeedCoverSvg', () => {
@@ -25,5 +30,33 @@ describe('createFeedBook', () => {
     expect(parseFeedBookUrl(book.url!)).toEqual({ feedUrl });
     expect(book.metadata?.feedUrl).toBe(feedUrl);
     expect(book.filePath).toBeUndefined();
+  });
+});
+
+// Issue #5307 — a feed book has no files in cloud storage, so every device that
+// receives the subscription writes the cover itself.
+describe('ensureFeedBookCover', () => {
+  const book = createFeedBook('https://www.saastr.com/feed/', { title: 'SaaStr', items: [] });
+
+  const makeAppService = (coverExists: boolean) => ({
+    exists: vi.fn(async () => coverExists),
+    createDir: vi.fn(async () => {}),
+    writeFile: vi.fn(async () => {}),
+    generateCoverImageUrl: vi.fn(async () => 'blob:cover'),
+  });
+
+  it('reuses the cover already on disk', async () => {
+    const appService = makeAppService(true);
+    const url = await ensureFeedBookCover(appService, book);
+    expect(url).toBe('blob:cover');
+    expect(appService.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('falls back to no cover url when the cover cannot be written', async () => {
+    const appService = makeAppService(false);
+    // Worst case is the shelf's title-only fallback cover, never a rejection
+    // that would abort the sync pass this runs inside.
+    appService.exists.mockRejectedValue(new Error('fs unavailable'));
+    await expect(ensureFeedBookCover(appService, book)).resolves.toBeUndefined();
   });
 });

--- a/apps/readest-app/src/app/library/components/BookItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookItem.tsx
@@ -17,6 +17,7 @@ import { useResponsiveSize } from '@/hooks/useResponsiveSize';
 import { LibraryCoverFitType, LibraryViewModeType } from '@/types/settings';
 import { navigateToLogin } from '@/utils/nav';
 import { isReadestCloudStorageActive } from '@/services/sync/cloudSyncProvider';
+import { isFeedBook } from '@/services/rss/feedBookUrl';
 import { formatAuthors, formatDescription, formatSeries } from '@/utils/book';
 import ReadingProgress from './ReadingProgress';
 import BookCover from '@/components/BookCover';
@@ -190,6 +191,9 @@ const BookItem: React.FC<BookItemProps> = ({
                 ></div>
               )
             ) : (
+              // A feed book has no file to move either way, so it never gets a
+              // cloud badge — it would only queue a transfer that fails (#5307).
+              !isFeedBook(book) &&
               (!book.uploadedAt || (book.uploadedAt && !book.downloadedAt)) && (
                 <button
                   aria-label={!book.uploadedAt ? _('Upload Book') : _('Download Book')}

--- a/apps/readest-app/src/app/library/components/TransferQueuePanel.tsx
+++ b/apps/readest-app/src/app/library/components/TransferQueuePanel.tsx
@@ -19,6 +19,7 @@ import { useKeyDownActions } from '@/hooks/useKeyDownActions';
 import { useLibraryStore } from '@/store/libraryStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { isReadestCloudStorageActive } from '@/services/sync/cloudSyncProvider';
+import { isFeedBook } from '@/services/rss/feedBookUrl';
 import {
   TransferItem,
   TransferStatus,
@@ -194,7 +195,11 @@ const TransferQueuePanel: React.FC = () => {
   const settings = useSettingsStore((s) => s.settings);
   const readestStorageActive = isReadestCloudStorageActive(settings);
 
-  const booksToUpload = getVisibleLibrary().filter((book) => book.downloadedAt && !book.uploadedAt);
+  // Feed books are fileless (#5307): sweeping them into "Upload All" only fills
+  // the queue with transfers that can never resolve a source.
+  const booksToUpload = getVisibleLibrary().filter(
+    (book) => book.downloadedAt && !book.uploadedAt && !isFeedBook(book),
+  );
   const booksToDownload = readestStorageActive
     ? getVisibleLibrary().filter((book) => book.uploadedAt && !book.downloadedAt)
     : [];

--- a/apps/readest-app/src/app/library/hooks/useBooksSync.ts
+++ b/apps/readest-app/src/app/library/hooks/useBooksSync.ts
@@ -15,6 +15,8 @@ import {
   getActiveFileSyncBackends,
 } from '@/services/sync/cloudSyncProvider';
 import { isDemoBook } from '@/services/demoBooks';
+import { isFeedBook } from '@/services/rss/feedBookUrl';
+import { ensureFeedBookCover } from '@/services/rss/feedBook';
 import { runFileLibrarySyncPass } from '@/services/sync/file/runLibrarySync';
 import { checkMixedFleetOnce } from '@/services/sync/fleetDetection';
 import { useSyncContext } from '@/context/SyncContext';
@@ -242,13 +244,24 @@ export const useBooksSync = () => {
     appService?.saveLibraryBooks(updatedLibrary);
 
     const bookHashesInLibrary = new Set(updatedLibrary.map((book) => book.hash));
+    // `uploadedAt` gates adoption so a peer never shelves a book whose file it
+    // cannot fetch. A feed book has no file to fetch — it is rebuilt from
+    // `metadata.feedUrl` — so it would never pass that gate and the
+    // subscription stayed stuck on the device that added it (issue #5307).
     const newBooks = cloudBooks.filter(
       (newBook) =>
-        !bookHashesInLibrary.has(newBook.hash) && newBook.uploadedAt && !newBook.deletedAt,
+        !bookHashesInLibrary.has(newBook.hash) &&
+        (newBook.uploadedAt || isFeedBook(newBook)) &&
+        !newBook.deletedAt,
     );
 
     const processNewBook = async (newBook: Book) => {
-      newBook.coverImageUrl = await appService?.generateCoverImageUrl(newBook);
+      // A feed book has no cover in cloud storage; its cover is derived from the
+      // feed descriptor, so this device regenerates the same image locally.
+      newBook.coverImageUrl =
+        appService && isFeedBook(newBook)
+          ? await ensureFeedBookCover(appService, newBook)
+          : await appService?.generateCoverImageUrl(newBook);
       newBook.syncedAt = Date.now();
       updatedLibrary.push(newBook);
     };

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -15,7 +15,7 @@ import {
   selectNewImportableFiles,
 } from '@/services/bookService';
 import { navigateToLibrary, navigateToLogin, navigateToReader } from '@/utils/nav';
-import { getCoverFilename, getBookWithUpdatedMetadata, listFormater } from '@/utils/book';
+import { getBookWithUpdatedMetadata, listFormater } from '@/utils/book';
 import { getImportErrorMessage } from '@/services/errors';
 import { ingestFile } from '@/services/ingestService';
 import { eventDispatcher } from '@/utils/event';
@@ -80,7 +80,7 @@ import { CatalogDialog } from './components/OPDSDialog';
 import { FeedsView } from './components/feeds/FeedsView';
 import AddFeedModal from './components/feeds/AddFeedModal';
 import { fetchAndParseFeed } from '@/services/rss/feedClient';
-import { createFeedBook, generateFeedCoverSvg, rasterizeCoverSvg } from '@/services/rss/feedBook';
+import { createFeedBook, ensureFeedBookCover } from '@/services/rss/feedBook';
 import { MigrateDataWindow } from './components/MigrateDataWindow';
 import { BackupWindow } from './components/BackupWindow';
 import { CacheManagerWindow } from './components/CacheManagerWindow';
@@ -569,15 +569,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     const parsed = await fetchAndParseFeed(url);
     const book = createFeedBook(url, parsed);
     if (appService) {
-      try {
-        const cover = generateFeedCoverSvg(url, book.title);
-        const pngBytes = await rasterizeCoverSvg(cover);
-        await appService.createDir(book.hash, 'Books', true);
-        await appService.writeFile(getCoverFilename(book), 'Books', pngBytes);
-        book.coverImageUrl = await appService.generateCoverImageUrl(book);
-      } catch (e) {
-        console.warn('Failed to generate feed book cover:', e);
-      }
+      book.coverImageUrl = await ensureFeedBookCover(appService, book);
     }
     await useLibraryStore.getState().updateBooks(envConfig, [book]);
     eventDispatcher.dispatch('toast', {

--- a/apps/readest-app/src/app/library/utils/libraryUtils.ts
+++ b/apps/readest-app/src/app/library/utils/libraryUtils.ts
@@ -7,6 +7,7 @@ import {
 import { formatAuthors, formatTitle, isCurrentlyReadingBook } from '@/utils/book';
 import { md5Fingerprint } from '@/utils/md5';
 import { SIZE_PER_LOC, SIZE_PER_TIME_UNIT } from '@/services/constants';
+import { isFeedBook } from '@/services/rss/feedBookUrl';
 
 /** Valid sort types for the library */
 const VALID_SORT_TYPES: LibrarySortByType[] = Object.values(LibrarySortByType);
@@ -827,11 +828,15 @@ export const getBookContextMenuItemIds = (book: Book): BookContextMenuItemId[] =
     ids.push('clearStatus');
   }
   ids.push('showDetails', 'showInFinder', 'searchGoodreads');
-  if (book.uploadedAt && !book.downloadedAt) ids.push('download');
-  if (!book.uploadedAt && book.downloadedAt) ids.push('upload');
-  // Share is offered for any local-or-uploaded book; the dialog uploads first
-  // if the book hasn't been pushed yet.
-  if (book.downloadedAt || book.uploadedAt) ids.push('share');
+  // A feed book has no file to move: every transfer action would fail, and the
+  // share dialog uploads before it can hand out a link (issue #5307).
+  if (!isFeedBook(book)) {
+    if (book.uploadedAt && !book.downloadedAt) ids.push('download');
+    if (!book.uploadedAt && book.downloadedAt) ids.push('upload');
+    // Share is offered for any local-or-uploaded book; the dialog uploads first
+    // if the book hasn't been pushed yet.
+    if (book.downloadedAt || book.uploadedAt) ids.push('share');
+  }
   ids.push('delete');
   return ids;
 };

--- a/apps/readest-app/src/components/metadata/BookDetailView.tsx
+++ b/apps/readest-app/src/components/metadata/BookDetailView.tsx
@@ -26,6 +26,7 @@ import {
   formatPublisher,
   formatTitle,
 } from '@/utils/book';
+import { isFeedBook } from '@/services/rss/feedBookUrl';
 import { saveSysSettings } from '@/helpers/settings';
 import BookCover from '@/components/BookCover';
 import Dropdown from '../Dropdown';
@@ -114,7 +115,8 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({
                 <MdOutlineCloudDownload className='fill-base-content' />
               </button>
             )}
-            {book.downloadedAt && onUpload && (
+            {/* A feed book is fileless — there is nothing to push (#5307). */}
+            {book.downloadedAt && !isFeedBook(book) && onUpload && (
               <button onClick={onUpload} title={_('Upload to Cloud')}>
                 <MdOutlineCloudUpload className='fill-base-content' />
               </button>

--- a/apps/readest-app/src/services/rss/feedBook.ts
+++ b/apps/readest-app/src/services/rss/feedBook.ts
@@ -1,8 +1,10 @@
 import { md5 } from '@/utils/md5';
-import { buildFeedBookUrl } from './feedBookUrl';
+import { buildFeedBookUrl, parseFeedBookUrl } from './feedBookUrl';
 import { generateCoverSvg } from '@/services/send/conversion/coverGenerator';
+import { getCoverFilename } from '@/utils/book';
 import type { ParsedFeed } from '@/types/rss';
 import type { Book } from '@/types/book';
+import type { AppService } from '@/types/system';
 import type { EpubImage } from '@/services/send/conversion/types';
 
 // The classic feed icon (Wikimedia Commons "Generic Feed-icon.svg" geometry):
@@ -62,6 +64,37 @@ export async function rasterizeCoverSvg(svg: EpubImage, scale = 2): Promise<Arra
     return await pngBlob.arrayBuffer();
   } finally {
     URL.revokeObjectURL(url);
+  }
+}
+
+type FeedCoverWriter = Pick<
+  AppService,
+  'exists' | 'createDir' | 'writeFile' | 'generateCoverImageUrl'
+>;
+
+/**
+ * Make sure Books/<hash>/cover.png holds the generated RSS cover and return its
+ * display URL. The image is derived purely from the feed URL and title, so a
+ * peer that receives the subscription over sync regenerates the identical cover
+ * locally — a feed book has no files in cloud storage to download (#5307).
+ * Best-effort: a failure leaves the shelf's title-only fallback cover.
+ */
+export async function ensureFeedBookCover(
+  appService: FeedCoverWriter,
+  book: Book,
+): Promise<string | undefined> {
+  try {
+    const feedUrl = book.metadata?.feedUrl ?? (book.url ? parseFeedBookUrl(book.url).feedUrl : '');
+    const coverFilename = getCoverFilename(book);
+    if (!(await appService.exists(coverFilename, 'Books'))) {
+      const pngBytes = await rasterizeCoverSvg(generateFeedCoverSvg(feedUrl, book.title));
+      await appService.createDir(book.hash, 'Books', true);
+      await appService.writeFile(coverFilename, 'Books', pngBytes);
+    }
+    return await appService.generateCoverImageUrl(book);
+  } catch (e) {
+    console.warn('Failed to generate feed book cover:', e);
+    return undefined;
   }
 }
 

--- a/apps/readest-app/src/services/rss/feedBookUrl.ts
+++ b/apps/readest-app/src/services/rss/feedBookUrl.ts
@@ -7,3 +7,14 @@ export const buildFeedBookUrl = (feedUrl: string): string =>
 
 export const parseFeedBookUrl = (url: string): { feedUrl: string } =>
   JSON.parse(decodeURIComponent(url.replace(FEED_SCHEME, '')));
+
+/**
+ * A feed subscription is a fileless book: there is no blob on disk or in cloud
+ * storage, only a `feed://` descriptor whose content every device rebuilds from
+ * `metadata.feedUrl`. Everything that reasons about a book's FILE — upload,
+ * download, share, and the peer-side "is this row fetchable?" sync guard — has
+ * to special-case it, or it offers transfers that can only fail and drops the
+ * subscription on every device but the one that added it (issue #5307).
+ */
+export const isFeedBook = (book: { url?: string }): boolean =>
+  !!book.url && isFeedBookUrl(book.url);


### PR DESCRIPTION
Fixes #5307

## Problem

A feed subscription added on one browser never appears on any other device, and clicking Upload on it fails immediately.

A feed subscription is a **fileless book**: `createFeedBook` makes a virtual EPUB row whose `url` is a `feed://` descriptor, and every device rebuilds the content from `metadata.feedUrl`. There is no blob anywhere. So:

1. `resolveBookContentSource` returns `{kind: 'feed'}`, which `isBookFileContentSource` rejects, and `cloudService.uploadBook` throws `Book file not uploaded`. That is the failing transfer the reporter saw.
2. Because the upload can never succeed, `uploadedAt` stays `null` forever. The row's *metadata* does reach the cloud (the push includes it, and the server pull has no `uploaded_at` filter), but `useBooksSync.updateLibrary` only adopts a cloud row when `uploadedAt` is set. That guard exists so a peer never shelves a book whose file it cannot fetch, and it silently dropped every feed book.

## Fix

A new `isFeedBook(book)` predicate in `services/rss/feedBookUrl.ts`, applied where the code reasons about a book's *file*:

- `useBooksSync.updateLibrary` accepts `(uploadedAt || isFeedBook)` for new cloud rows. This is the actual sync fix.
- `getBookContextMenuItemIds` drops download/upload/share for feed books.
- The shelf cloud badge (`BookItem`), Upload All (`TransferQueuePanel`), and the detail-view upload button no longer offer a transfer that can only fail.
- `processNewBook` regenerates the cover locally via a new `ensureFeedBookCover`, extracted from `handleAddFeedSubmit` so both paths share it. The cover is derived from feed URL and title, and there is no cloud copy to download, so a synced feed book would otherwise show the blank title-only fallback.

Stamping `uploadedAt` at creation was considered and rejected: peers would then offer Download and chase a file that does not exist.

## Verification

- `pnpm test`: 7730 passed, 7 skipped, 0 failures
- `pnpm lint` and `pnpm format:check`: clean
- No `src-tauri/` or Lua changes, so those gates do not apply

New tests in `src/__tests__/app/library/feed-books-sync.test.tsx` (both key cases fail before the fix), plus feed cases in `book-context-menu.test.ts` and `services/rss/feedBook.test.ts`. An ordinary un-uploaded book is still correctly skipped by the peer gate.

## Notes

Two things found while investigating, left out of scope: per-item read state is not synced at all (`FeedsView` and `feedStore` back onto a local `Settings/feeds.json`, and `FeedsView` appears unreachable since nothing sets `showFeeds`), and the issue's request for RSS documentation on readest.com/docs is a separate task.

Feed books already degrade gracefully on file-sync backends: `pushBookFile` resolves `no-source` and skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)