### PR TITLE
feat(settings): rename "Column Gap" to "Additional Margin"

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -325,7 +325,6 @@
   "Bottom Margin (px)": "الهامش السفلي (بكسل)",
   "Right Margin (px)": "الهامش الأيمن (بكسل)",
   "Left Margin (px)": "الهامش الأيسر (بكسل)",
-  "Column Gap (%)": "تباعد الأعمدة (%)",
   "Always Show Status Bar": "دائمًا إظهار شريط الحالة",
   "Custom Content CSS": "CSS مخصص للمحتوى",
   "Enter CSS for book content styling...": "أدخل CSS لتنسيق محتوى الكتاب...",
@@ -2079,5 +2078,6 @@
   "Show original": "إظهار الأصل",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "العالم كله مسرح، وكل الرجال والنساء مجرد ممثلين؛ لهم مخارجهم ومداخلهم، والمرء الواحد في زمنه يؤدي أدوارًا كثيرة.",
   "— William Shakespeare, As You Like It": "— ويليام شكسبير، كما تشاء",
-  "Failed to download and install update": "فشل تنزيل التحديث وتثبيته"
+  "Failed to download and install update": "فشل تنزيل التحديث وتثبيته",
+  "Additional Margin (%)": "هامش إضافي (%)"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -257,7 +257,6 @@
   "Bottom Margin (px)": "নিচের মার্জিন (px)",
   "Left Margin (px)": "বাম মার্জিন (px)",
   "Right Margin (px)": "ডান মার্জিন (px)",
-  "Column Gap (%)": "কলাম গ্যাপ (%)",
   "Maximum Number of Columns": "সর্বোচ্চ কলাম সংখ্যা",
   "Maximum Column Height": "সর্বোচ্চ কলাম উচ্চতা",
   "Maximum Column Width": "সর্বোচ্চ কলাম প্রস্থ",
@@ -1935,5 +1934,6 @@
   "Show original": "মূল দেখান",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "সমগ্র বিশ্বই একটি রঙ্গমঞ্চ, আর সব নারী-পুরুষ কেবল অভিনেতা; তাদের আছে প্রস্থান আর প্রবেশ, আর একজন মানুষ তার জীবনে বহু ভূমিকায় অভিনয় করে।",
   "— William Shakespeare, As You Like It": "— উইলিয়াম শেক্সপিয়ার, অ্যাজ ইউ লাইক ইট",
-  "Failed to download and install update": "আপডেট ডাউনলোড এবং ইনস্টল করতে ব্যর্থ হয়েছে"
+  "Failed to download and install update": "আপডেট ডাউনলোড এবং ইনস্টল করতে ব্যর্থ হয়েছে",
+  "Additional Margin (%)": "অতিরিক্ত মার্জিন (%)"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -311,7 +311,6 @@
   "Bottom Margin (px)": "འོག་ངོས་ཀྱི་བར་ཐག",
   "Right Margin (px)": "གཡས་ངོས་ཀྱི་བར་ཐག",
   "Left Margin (px)": "གཡོན་ངོས་ཀྱི་བར་ཐག",
-  "Column Gap (%)": "གྲལ་ཐིག་བར་གྱི་བར་ཐག",
   "Always Show Status Bar": "རྟག་ཏུ་གནས་ཚུལ་གྱི་གྲལ་ཐིག་མངོན་པ།",
   "Custom Content CSS": "རང་འགུལ་གྱི་ནང་དོན་ CSS",
   "Enter CSS for book content styling...": "དཔེ་དེབ་ཀྱི་ནང་དོན་གྱི་རྣམ་པའི་ CSS ནང་འཇུག་བྱོས།...",
@@ -1899,5 +1898,6 @@
   "Show original": "མ་ཡིག་སྟོན་པ།",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "འཇིག་རྟེན་ཧྲིལ་པོ་ནི་འཁྲབ་སྟེགས་ཤིག་ཡིན། སྐྱེས་པ་དང་བུད་མེད་ཐམས་ཅད་ནི་འཁྲབ་མཁན་ཙམ་ཡིན། ཁོ་ཚོ་ལ་ཐོན་པ་དང་འཛུལ་བ་ཡོད་ཅིང། མི་གཅིག་གིས་རང་གི་མི་ཚེའི་ནང་དུ་འཁྲབ་གཞུང་མང་པོ་འཁྲབ།",
   "— William Shakespeare, As You Like It": "— ཝི་ལི་ཡམ་ཤེགས་སི་པིར།",
-  "Failed to download and install update": "གསར་སྒྱུར་ཕབ་ལེན་དང་སྒྲིག་འཇུག་བྱེད་མ་ཐུབ།"
+  "Failed to download and install update": "གསར་སྒྱུར་ཕབ་ལེན་དང་སྒྲིག་འཇུག་བྱེད་མ་ཐུབ།",
+  "Additional Margin (%)": "ཁ་སྣོན་མཐའ་འགྲམ"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -313,7 +313,6 @@
   "Bottom Margin (px)": "Unterer Rand (px)",
   "Right Margin (px)": "Rechter Rand (px)",
   "Left Margin (px)": "Linker Rand (px)",
-  "Column Gap (%)": "Spaltenabstand (%)",
   "Always Show Status Bar": "Statusleiste immer anzeigen",
   "Custom Content CSS": "Benutzerdefiniertes Inhalts-CSS",
   "Enter CSS for book content styling...": "CSS für die Buchinhaltsgestaltung eingeben...",
@@ -1935,5 +1934,6 @@
   "Show original": "Original anzeigen",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Die ganze Welt ist eine Bühne, und alle Männer und Frauen sind bloß Spieler; sie haben ihre Abgänge und ihre Auftritte, und ein Mann spielt in seinem Leben viele Rollen.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Wie es euch gefällt",
-  "Failed to download and install update": "Fehler beim Herunterladen und Installieren des Updates"
+  "Failed to download and install update": "Fehler beim Herunterladen und Installieren des Updates",
+  "Additional Margin (%)": "Zusätzlicher Rand (%)"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -314,7 +314,6 @@
   "Bottom Margin (px)": "Κάτω περιθώριο (px)",
   "Right Margin (px)": "Δεξί περιθώριο (px)",
   "Left Margin (px)": "Αριστερό περιθώριο (px)",
-  "Column Gap (%)": "Απόσταση στηλών (%)",
   "Always Show Status Bar": "Πάντα εμφάνιση γραμμής κατάστασης",
   "Custom Content CSS": "Προσαρμοσμένο CSS περιεχομένου",
   "Enter CSS for book content styling...": "Εισαγάγετε CSS για στυλ περιεχομένου βιβλίου...",
@@ -1935,5 +1934,6 @@
   "Show original": "Εμφάνιση πρωτοτύπου",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Όλος ο κόσμος είναι μια σκηνή, και όλοι οι άντρες κι οι γυναίκες απλοί ηθοποιοί· έχουν τις εξόδους και τις εισόδους τους, κι ένας άνθρωπος στη ζωή του παίζει πολλούς ρόλους.",
   "— William Shakespeare, As You Like It": "— Ουίλιαμ Σαίξπηρ, Όπως Αγαπάτε",
-  "Failed to download and install update": "Αποτυχία λήψης και εγκατάστασης της ενημέρωσης"
+  "Failed to download and install update": "Αποτυχία λήψης και εγκατάστασης της ενημέρωσης",
+  "Additional Margin (%)": "Πρόσθετο περιθώριο (%)"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -340,7 +340,6 @@
   "Bottom Margin (px)": "Margen inferior (px)",
   "Right Margin (px)": "Margen derecho (px)",
   "Left Margin (px)": "Margen izquierdo (px)",
-  "Column Gap (%)": "Espacio entre columnas (%)",
   "Always Show Status Bar": "Mostrar siempre la barra de estado",
   "Custom Content CSS": "CSS del contenido",
   "Enter CSS for book content styling...": "Introduce CSS para el contenido del libro...",
@@ -1971,5 +1970,6 @@
   "Show original": "Mostrar original",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "El mundo entero es un escenario, y todos los hombres y mujeres, meros actores; tienen sus entradas y sus salidas, y un hombre en su vida representa muchos papeles.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Como gustéis",
-  "Failed to download and install update": "Error al descargar e instalar la actualización"
+  "Failed to download and install update": "Error al descargar e instalar la actualización",
+  "Additional Margin (%)": "Margen adicional (%)"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -313,7 +313,6 @@
   "Bottom Margin (px)": "حاشیه‌ی پایین (px)",
   "Right Margin (px)": "حاشیه‌ی راست (px)",
   "Left Margin (px)": "حاشیه‌ی چپ (px)",
-  "Column Gap (%)": "فاصله‌ی ستون (%)",
   "Always Show Status Bar": "نمایش همیشگی نوار وضعیت",
   "Custom Content CSS": "CSS محتوای سفارشی",
   "Enter CSS for book content styling...": "CSS برای استایل محتوای کتاب وارد کنید...",
@@ -1935,5 +1934,6 @@
   "Show original": "نمایش متن اصلی",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "تمام دنیا یک صحنه است و همه‌ی مردان و زنان تنها بازیگرند؛ آن‌ها را خروج‌ها و ورودهایی است، و هر کس در طول عمر خود نقش‌های بسیاری بازی می‌کند.",
   "— William Shakespeare, As You Like It": "— ویلیام شکسپیر، هرطور که دوست دارید",
-  "Failed to download and install update": "دانلود و نصب به‌روزرسانی ناموفق بود"
+  "Failed to download and install update": "دانلود و نصب به‌روزرسانی ناموفق بود",
+  "Additional Margin (%)": "حاشیه‌ی اضافی (%)"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -316,7 +316,6 @@
   "Bottom Margin (px)": "Marge inférieure (px)",
   "Right Margin (px)": "Marge droite (px)",
   "Left Margin (px)": "Marge gauche (px)",
-  "Column Gap (%)": "Espacement des colonnes (%)",
   "Always Show Status Bar": "Afficher toujours la barre d'état",
   "Custom Content CSS": "CSS du contenu",
   "Enter CSS for book content styling...": "Saisissez le CSS pour le contenu du livre...",
@@ -1971,5 +1970,6 @@
   "Show original": "Afficher l'original",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Le monde entier est un théâtre, et tous, hommes et femmes, ne sont que des acteurs; ils ont leurs entrées et leurs sorties, et un homme, dans le cours de sa vie, joue bien des rôles.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Comme il vous plaira",
-  "Failed to download and install update": "Échec du téléchargement et de l'installation de la mise à jour"
+  "Failed to download and install update": "Échec du téléchargement et de l'installation de la mise à jour",
+  "Additional Margin (%)": "Marge supplémentaire (%)"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -931,7 +931,6 @@
   "Bottom Margin (px)": "שוליים תחתונים (פיקסלים)",
   "Left Margin (px)": "שוליים שמאליים (פיקסלים)",
   "Right Margin (px)": "שוליים ימניים (פיקסלים)",
-  "Column Gap (%)": "רווח בין עמודות (%)",
   "Maximum Number of Columns": "מספר עמודות מקסימלי",
   "Maximum Column Height": "גובה עמודה מקסימלי",
   "Maximum Column Width": "רוחב עמודה מקסימלי",
@@ -1971,5 +1970,6 @@
   "Show original": "הצג מקור",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "כל העולם במה, וכל הגברים והנשים אינם אלא שחקנים; יש להם יציאות ויש להם כניסות, ואדם אחד משחק בימי חייו תפקידים רבים.",
   "— William Shakespeare, As You Like It": "— ויליאם שייקספיר, כטוב בעיניכם",
-  "Failed to download and install update": "הורדת העדכון והתקנתו נכשלו"
+  "Failed to download and install update": "הורדת העדכון והתקנתו נכשלו",
+  "Additional Margin (%)": "שוליים נוספים (%)"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -314,7 +314,6 @@
   "Bottom Margin (px)": "निचला हाशिया (px)",
   "Right Margin (px)": "दायां हाशिया (px)",
   "Left Margin (px)": "बायां हाशिया (px)",
-  "Column Gap (%)": "स्तंभों के बीच की दूरी (%)",
   "Always Show Status Bar": "स्थिति पट्टी हमेशा दिखाएं",
   "Custom Content CSS": "सामग्री का CSS",
   "Enter CSS for book content styling...": "पुस्तक सामग्री के लिए CSS दर्ज करें...",
@@ -1935,5 +1934,6 @@
   "Show original": "मूल दिखाएं",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "सारा संसार एक रंगमंच है, और सभी स्त्री-पुरुष केवल अभिनेता हैं; उनके अपने प्रस्थान और प्रवेश होते हैं, और एक मनुष्य अपने जीवनकाल में अनेक भूमिकाएँ निभाता है।",
   "— William Shakespeare, As You Like It": "— विलियम शेक्सपियर, एज़ यू लाइक इट",
-  "Failed to download and install update": "अपडेट डाउनलोड और इंस्टॉल करने में विफल"
+  "Failed to download and install update": "अपडेट डाउनलोड और इंस्टॉल करने में विफल",
+  "Additional Margin (%)": "अतिरिक्त हाशिया (%)"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1008,7 +1008,6 @@
   "Bottom Margin (px)": "Alsó margó (px)",
   "Left Margin (px)": "Bal margó (px)",
   "Right Margin (px)": "Jobb margó (px)",
-  "Column Gap (%)": "Oszlopköz (%)",
   "Maximum Number of Columns": "Oszlopok maximális száma",
   "Maximum Column Height": "Maximális oszlopmagasság",
   "Maximum Column Width": "Maximális oszlopszélesség",
@@ -1935,5 +1934,6 @@
   "Show original": "Eredeti megjelenítése",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Színház az egész világ, és színész benne minden férfi és nő; megvannak a maguk kilépői és belépői, és egy ember életében sok szerepet játszik el.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Ahogy tetszik",
-  "Failed to download and install update": "A frissítés letöltése és telepítése sikertelen"
+  "Failed to download and install update": "A frissítés letöltése és telepítése sikertelen",
+  "Additional Margin (%)": "További margó (%)"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -311,7 +311,6 @@
   "Bottom Margin (px)": "Margin Bawah (px)",
   "Right Margin (px)": "Margin Kanan (px)",
   "Left Margin (px)": "Margin Kiri (px)",
-  "Column Gap (%)": "Jarak Antar Kolom (%)",
   "Always Show Status Bar": "Selalu Tampilkan Bilah Status",
   "Custom Content CSS": "CSS konten",
   "Enter CSS for book content styling...": "Masukkan CSS untuk gaya konten buku...",
@@ -1899,5 +1898,6 @@
   "Show original": "Tampilkan asli",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Seluruh dunia adalah panggung, dan semua pria dan wanita hanyalah pemain; mereka punya saat keluar dan saat masuk, dan seseorang dalam hidupnya memainkan banyak peran.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, As You Like It",
-  "Failed to download and install update": "Gagal mengunduh dan memasang pembaruan"
+  "Failed to download and install update": "Gagal mengunduh dan memasang pembaruan",
+  "Additional Margin (%)": "Margin Tambahan (%)"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -317,7 +317,6 @@
   "Bottom Margin (px)": "Margine Inferiore (px)",
   "Right Margin (px)": "Margine Destro (px)",
   "Left Margin (px)": "Margine Sinistro (px)",
-  "Column Gap (%)": "Spazio tra Colonne (%)",
   "Always Show Status Bar": "Mostra sempre la barra di stato",
   "Custom Content CSS": "CSS contenuto",
   "Enter CSS for book content styling...": "Inserisci il CSS per il contenuto del libro...",
@@ -1971,5 +1970,6 @@
   "Show original": "Mostra originale",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Tutto il mondo è un palcoscenico, e tutti gli uomini e le donne non sono che attori; hanno le loro uscite e le loro entrate, e uno stesso uomo nella sua vita recita molte parti.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Come vi piace",
-  "Failed to download and install update": "Impossibile scaricare e installare l'aggiornamento"
+  "Failed to download and install update": "Impossibile scaricare e installare l'aggiornamento",
+  "Additional Margin (%)": "Margine aggiuntivo (%)"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -311,7 +311,6 @@
   "Bottom Margin (px)": "下マージン (px)",
   "Right Margin (px)": "右マージン (px)",
   "Left Margin (px)": "左マージン (px)",
-  "Column Gap (%)": "列間の間隔 (%)",
   "Always Show Status Bar": "ステータスバーを常に表示",
   "Custom Content CSS": "コンテンツCSS",
   "Enter CSS for book content styling...": "本のコンテンツ用CSSを入力...",
@@ -1899,5 +1898,6 @@
   "Show original": "原文を表示",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "この世はすべて舞台、男も女もみな役者にすぎない。彼らには退場があり登場があり、一人の人間はその一生でいくつもの役を演じる。",
   "— William Shakespeare, As You Like It": "— ウィリアム・シェイクスピア『お気に召すまま』",
-  "Failed to download and install update": "アップデートのダウンロードとインストールに失敗しました"
+  "Failed to download and install update": "アップデートのダウンロードとインストールに失敗しました",
+  "Additional Margin (%)": "追加の余白 (%)"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -311,7 +311,6 @@
   "Bottom Margin (px)": "아래쪽 여백 (px)",
   "Right Margin (px)": "오른쪽 여백 (px)",
   "Left Margin (px)": "왼쪽 여백 (px)",
-  "Column Gap (%)": "열 간격 (%)",
   "Always Show Status Bar": "상태 표시줄 항상 표시",
   "Custom Content CSS": "콘텐츠 CSS",
   "Enter CSS for book content styling...": "도서 콘텐츠 스타일을 위한 CSS 입력...",
@@ -1899,5 +1898,6 @@
   "Show original": "원문 표시",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "온 세상은 무대이고, 모든 남자와 여자는 한낱 배우일 뿐이다. 그들에게는 퇴장이 있고 등장이 있으며, 한 사람은 살아가는 동안 여러 역을 연기한다.",
   "— William Shakespeare, As You Like It": "— 윌리엄 셰익스피어, 「뜻대로 하세요」",
-  "Failed to download and install update": "업데이트 다운로드 및 설치에 실패했습니다"
+  "Failed to download and install update": "업데이트 다운로드 및 설치에 실패했습니다",
+  "Additional Margin (%)": "추가 여백 (%)"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -576,7 +576,6 @@
   "Bottom Margin (px)": "Margin Bawah (px)",
   "Left Margin (px)": "Margin Kiri (px)",
   "Right Margin (px)": "Margin Kanan (px)",
-  "Column Gap (%)": "Jurang Lajur (%)",
   "Maximum Number of Columns": "Bilangan Maksimum Lajur",
   "Maximum Column Height": "Tinggi Maksimum Lajur",
   "Maximum Column Width": "Lebar Maksimum Lajur",
@@ -1899,5 +1898,6 @@
   "Show original": "Tunjukkan asal",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Seluruh dunia ini pentas, dan semua lelaki dan wanita hanyalah pelakon; mereka ada masa keluar dan masa masuk, dan seseorang dalam hidupnya memainkan pelbagai peranan.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, As You Like It",
-  "Failed to download and install update": "Gagal memuat turun dan memasang kemas kini"
+  "Failed to download and install update": "Gagal memuat turun dan memasang kemas kini",
+  "Additional Margin (%)": "Margin Tambahan (%)"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -314,7 +314,6 @@
   "Bottom Margin (px)": "Ondermarge (px)",
   "Right Margin (px)": "Rechter marge (px)",
   "Left Margin (px)": "Linker marge (px)",
-  "Column Gap (%)": "Kolomafstand (%)",
   "Always Show Status Bar": "Statusbalk altijd weergeven",
   "Custom Content CSS": "Aangepaste inhoud-CSS",
   "Enter CSS for book content styling...": "Voer CSS in voor de opmaak van de boekinhoud...",
@@ -1935,5 +1934,6 @@
   "Show original": "Origineel tonen",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "De hele wereld is een toneel, en alle mannen en vrouwen slechts spelers; zij hebben hun aftredens en hun optredens, en één mens speelt in zijn leven vele rollen.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Zoals u het wilt",
-  "Failed to download and install update": "Kan de update niet downloaden en installeren"
+  "Failed to download and install update": "Kan de update niet downloaden en installeren",
+  "Additional Margin (%)": "Extra marge (%)"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -320,7 +320,6 @@
   "Bottom Margin (px)": "Dolny margines (px)",
   "Right Margin (px)": "Prawy margines (px)",
   "Left Margin (px)": "Lewy margines (px)",
-  "Column Gap (%)": "Odstęp między kolumnami (%)",
   "Always Show Status Bar": "Zawsze pokazuj pasek stanu",
   "Custom Content CSS": "CSS treści",
   "Enter CSS for book content styling...": "Wprowadź CSS dla stylu treści książki...",
@@ -2007,5 +2006,6 @@
   "Show original": "Pokaż oryginał",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Cały świat to scena, a wszyscy ludzie, mężczyźni i kobiety, to tylko aktorzy; mają swoje wejścia i wyjścia, a jeden człowiek w swoim życiu gra wiele ról.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Jak wam się podoba",
-  "Failed to download and install update": "Nie udało się pobrać i zainstalować aktualizacji"
+  "Failed to download and install update": "Nie udało się pobrać i zainstalować aktualizacji",
+  "Additional Margin (%)": "Dodatkowy margines (%)"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1158,7 +1158,6 @@
   "Bottom Margin (px)": "Margem inferior (px)",
   "Left Margin (px)": "Margem esquerda (px)",
   "Right Margin (px)": "Margem direita (px)",
-  "Column Gap (%)": "Espaço entre colunas (%)",
   "Maximum Number of Columns": "Número máximo de colunas",
   "Maximum Column Height": "Altura máxima da coluna",
   "Maximum Column Width": "Largura máxima da coluna",
@@ -1971,5 +1970,6 @@
   "Show original": "Mostrar original",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "O mundo inteiro é um palco, e todos os homens e mulheres não passam de atores; eles têm suas saídas e suas entradas, e um homem, em seu tempo, representa muitos papéis.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Como Gostais",
-  "Failed to download and install update": "Falha ao baixar e instalar a atualização"
+  "Failed to download and install update": "Falha ao baixar e instalar a atualização",
+  "Additional Margin (%)": "Margem adicional (%)"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -317,7 +317,6 @@
   "Bottom Margin (px)": "Margem inferior (px)",
   "Right Margin (px)": "Margem direita (px)",
   "Left Margin (px)": "Margem esquerda (px)",
-  "Column Gap (%)": "Espaço entre colunas (%)",
   "Always Show Status Bar": "Exibir sempre a barra de status",
   "Custom Content CSS": "CSS do conteúdo",
   "Enter CSS for book content styling...": "Insira o CSS para o estilo do conteúdo do livro...",
@@ -1971,5 +1970,6 @@
   "Show original": "Mostrar original",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "O mundo inteiro é um palco, e todos os homens e mulheres não passam de atores; têm as suas saídas e as suas entradas, e um homem, no seu tempo, representa muitos papéis.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Como Gostais",
-  "Failed to download and install update": "Falha ao transferir e instalar a atualização"
+  "Failed to download and install update": "Falha ao transferir e instalar a atualização",
+  "Additional Margin (%)": "Margem adicional (%)"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -997,7 +997,6 @@
   "Bottom Margin (px)": "Margine inferioară (px)",
   "Left Margin (px)": "Margine stângă (px)",
   "Right Margin (px)": "Margine dreaptă (px)",
-  "Column Gap (%)": "Distanță între coloane (%)",
   "Maximum Number of Columns": "Număr maxim de coloane",
   "Maximum Column Height": "Înălțimea maximă a coloanei",
   "Maximum Column Width": "Lățimea maximă a coloanei",
@@ -1971,5 +1970,6 @@
   "Show original": "Afișează originalul",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Lumea întreagă e o scenă, iar toți bărbații și femeile doar actori; ei au ieșirile și intrările lor, iar un om joacă în viața lui multe roluri.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Cum vă place",
-  "Failed to download and install update": "Descărcarea și instalarea actualizării au eșuat"
+  "Failed to download and install update": "Descărcarea și instalarea actualizării au eșuat",
+  "Additional Margin (%)": "Margine suplimentară (%)"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -320,7 +320,6 @@
   "Bottom Margin (px)": "Нижний отступ (пикс)",
   "Right Margin (px)": "Правый отступ (пикс)",
   "Left Margin (px)": "Левый отступ (пикс)",
-  "Column Gap (%)": "Промежуток между колонками (%)",
   "Always Show Status Bar": "Всегда показывать панель состояния",
   "Custom Content CSS": "CSS содержимого",
   "Enter CSS for book content styling...": "Введите CSS для оформления содержимого книги...",
@@ -2007,5 +2006,6 @@
   "Show original": "Показать оригинал",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Весь мир — театр, а люди в нём — актёры; у них есть свои уходы и выходы, и каждый за свою жизнь играет множество ролей.",
   "— William Shakespeare, As You Like It": "— Уильям Шекспир, «Как вам это понравится»",
-  "Failed to download and install update": "Не удалось загрузить и установить обновление"
+  "Failed to download and install update": "Не удалось загрузить и установить обновление",
+  "Additional Margin (%)": "Дополнительное поле (%)"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -257,7 +257,6 @@
   "Bottom Margin (px)": "පහළ මායිම (px)",
   "Left Margin (px)": "වම් මායිම (px)",
   "Right Margin (px)": "දකුණු මායිම (px)",
-  "Column Gap (%)": "තීරු පරතරය (%)",
   "Maximum Number of Columns": "අවරෝධ තීරු ගණන",
   "Maximum Column Height": "අවරෝධ තීරු උස",
   "Maximum Column Width": "අවරෝධ තීරු පළල",
@@ -1935,5 +1934,6 @@
   "Show original": "මුල් පිටපත පෙන්වන්න",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "මුළු ලෝකයම වේදිකාවකි; සියලු පිරිමින් හා ගැහැනුන් හුදෙක් නළු නිළියෝ පමණි; ඔවුනට පිටවීම් හා පිවිසීම් ඇත, එක් මිනිසෙක් තම ජීවිත කාලයේදී භූමිකා රැසක් රඟ දක්වයි.",
   "— William Shakespeare, As You Like It": "— විලියම් ෂේක්ස්පියර්, As You Like It",
-  "Failed to download and install update": "යාවත්කාලීනය බාගත කර ස්ථාපනය කිරීමට අසමත් විය"
+  "Failed to download and install update": "යාවත්කාලීනය බාගත කර ස්ථාපනය කිරීමට අසමත් විය",
+  "Additional Margin (%)": "අමතර මායිම (%)"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -972,7 +972,6 @@
   "Bottom Margin (px)": "Spodnji rob (px)",
   "Left Margin (px)": "Levi rob (px)",
   "Right Margin (px)": "Desni rob (px)",
-  "Column Gap (%)": "Razmik med stolpci (%)",
   "Maximum Number of Columns": "Največje število stolpcev",
   "Maximum Column Height": "Največja višina stolpca",
   "Maximum Column Width": "Največja širina stolpca",
@@ -2007,5 +2006,6 @@
   "Show original": "Pokaži izvirnik",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Ves svet je oder, in vsi ljudje, moški in ženske, so le igralci; imajo svoje odhode in prihode, in en sam človek v svojem življenju igra mnogo vlog.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Kakor vam drago",
-  "Failed to download and install update": "Prenos in namestitev posodobitve ni uspela"
+  "Failed to download and install update": "Prenos in namestitev posodobitve ni uspela",
+  "Additional Margin (%)": "Dodatni rob (%)"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -493,7 +493,6 @@
   "Bottom Margin (px)": "Nedre marginal (px)",
   "Left Margin (px)": "Vänster marginal (px)",
   "Right Margin (px)": "Höger marginal (px)",
-  "Column Gap (%)": "Kolumnavstånd (%)",
   "Maximum Number of Columns": "Max antal kolumner",
   "Maximum Column Height": "Max kolumnhöjd",
   "Maximum Column Width": "Max kolumnbredd",
@@ -1935,5 +1934,6 @@
   "Show original": "Visa original",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Hela världen är en scen, och alla människor, män som kvinnor, blott skådespelare; de har sina sortier och sina entréer, och en människa spelar under sin tid många roller.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Som ni behagar",
-  "Failed to download and install update": "Det gick inte att ladda ner och installera uppdateringen"
+  "Failed to download and install update": "Det gick inte att ladda ner och installera uppdateringen",
+  "Additional Margin (%)": "Extra marginal (%)"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -257,7 +257,6 @@
   "Bottom Margin (px)": "கீழ் விளிம்பு (px)",
   "Left Margin (px)": "இடது விளிம்பு (px)",
   "Right Margin (px)": "வலது விளிம்பு (px)",
-  "Column Gap (%)": "நெடுவரிசை இடைவெளி (%)",
   "Maximum Number of Columns": "அதிகபட்ச நெடுவரிசை எண்ணிக்கை",
   "Maximum Column Height": "அதிகபட்ச நெடுவரிசை உயரம்",
   "Maximum Column Width": "அதிகபட்ச நெடுவரிசை அகலம்",
@@ -1935,5 +1934,6 @@
   "Show original": "மூலத்தைக் காட்டு",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "உலகம் முழுவதும் ஒரு நாடக அரங்கம், ஆண்களும் பெண்களும் அனைவரும் நடிகர்களே; அவர்களுக்கு வெளியேற்றங்களும் நுழைவுகளும் உண்டு, ஒரு மனிதன் தன் வாழ்நாளில் பல பாத்திரங்களை ஏற்று நடிக்கிறான்.",
   "— William Shakespeare, As You Like It": "— வில்லியம் ஷேக்ஸ்பியர், As You Like It",
-  "Failed to download and install update": "புதுப்பிப்பைப் பதிவிறக்கி நிறுவ முடியவில்லை"
+  "Failed to download and install update": "புதுப்பிப்பைப் பதிவிறக்கி நிறுவ முடியவில்லை",
+  "Additional Margin (%)": "கூடுதல் விளிம்பு (%)"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -218,7 +218,6 @@
   "Bottom Margin (px)": "ขอบล่าง (px)",
   "Left Margin (px)": "ขอบซ้าย (px)",
   "Right Margin (px)": "ขอบขวา (px)",
-  "Column Gap (%)": "ช่องว่างคอลัมน์ (%)",
   "Maximum Number of Columns": "จำนวนคอลัมน์สูงสุด",
   "Maximum Column Height": "ความสูงคอลัมน์สูงสุด",
   "Maximum Column Width": "ความกว้างคอลัมน์สูงสุด",
@@ -1899,5 +1898,6 @@
   "Show original": "แสดงต้นฉบับ",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "โลกทั้งใบคือเวที และชายหญิงทั้งปวงล้วนเป็นเพียงนักแสดง พวกเขาต่างมีวาระเข้าและออก และคนหนึ่งในชั่วชีวิตของเขาย่อมสวมบทบาทมากมาย",
   "— William Shakespeare, As You Like It": "— วิลเลียม เชกสเปียร์, As You Like It",
-  "Failed to download and install update": "ดาวน์โหลดและติดตั้งการอัปเดตไม่สำเร็จ"
+  "Failed to download and install update": "ดาวน์โหลดและติดตั้งการอัปเดตไม่สำเร็จ",
+  "Additional Margin (%)": "ระยะขอบเพิ่มเติม (%)"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -314,7 +314,6 @@
   "Bottom Margin (px)": "Alt Kenar Boşluğu (px)",
   "Right Margin (px)": "Sağ Kenar Boşluğu (px)",
   "Left Margin (px)": "Sol Kenar Boşluğu (px)",
-  "Column Gap (%)": "Sütun Aralığı (%)",
   "Always Show Status Bar": "Durum Çubuğunu Her Zaman Göster",
   "Custom Content CSS": "Özel İçerik CSS'si",
   "Enter CSS for book content styling...": "Kitap içeriği stili için CSS girin...",
@@ -1935,5 +1934,6 @@
   "Show original": "Orijinali göster",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Bütün dünya bir sahne, ve bütün kadınlar, erkekler sadece birer oyuncu; girişleri ve çıkışları var, ve bir insan ömrü boyunca birçok rol oynuyor.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Nasıl Hoşunuza Giderse",
-  "Failed to download and install update": "Güncelleme indirilip yüklenemedi"
+  "Failed to download and install update": "Güncelleme indirilip yüklenemedi",
+  "Additional Margin (%)": "Ek Kenar Boşluğu (%)"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -320,7 +320,6 @@
   "Bottom Margin (px)": "Нижній відступ (px)",
   "Right Margin (px)": "Правий відступ (px)",
   "Left Margin (px)": "Лівий відступ (px)",
-  "Column Gap (%)": "Проміжок між стовпцями (%)",
   "Always Show Status Bar": "Завжди показувати панель стану",
   "Custom Content CSS": "Користуацький CSS вмісту",
   "Enter CSS for book content styling...": "Введіть CSS для стилізації вмісту книги...",
@@ -2007,5 +2006,6 @@
   "Show original": "Показати оригінал",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Увесь світ — театр, і всі чоловіки й жінки в ньому — лише актори; вони мають свої виходи й входи, і кожна людина за своє життя грає багато ролей.",
   "— William Shakespeare, As You Like It": "— Вільям Шекспір, «Як вам це сподобається»",
-  "Failed to download and install update": "Не вдалося завантажити та встановити оновлення"
+  "Failed to download and install update": "Не вдалося завантажити та встановити оновлення",
+  "Additional Margin (%)": "Додаткове поле (%)"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1136,7 +1136,6 @@
   "Bottom Margin (px)": "Pastki chet (px)",
   "Left Margin (px)": "Chap chet (px)",
   "Right Margin (px)": "Oʻng chet (px)",
-  "Column Gap (%)": "Ustunlar oraligʻi (%)",
   "Maximum Number of Columns": "Maksimal ustunlar soni",
   "Maximum Column Height": "Maksimal ustun balandligi",
   "Maximum Column Width": "Maksimal ustun kengligi",
@@ -1935,5 +1934,6 @@
   "Show original": "Aslini ko'rsatish",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Butun dunyo — sahna, va barcha erkagu ayol faqat aktyorlardir; ularning o‘z chiqishlari va kirishlari bor, va inson umri davomida ko‘p rollarni o‘ynaydi.",
   "— William Shakespeare, As You Like It": "— Uilyam Shekspir, Xohishingizga ko‘ra",
-  "Failed to download and install update": "Yangilanishni yuklab olish va o'rnatishda xatolik yuz berdi"
+  "Failed to download and install update": "Yangilanishni yuklab olish va o'rnatishda xatolik yuz berdi",
+  "Additional Margin (%)": "Qoʻshimcha chet (%)"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -311,7 +311,6 @@
   "Bottom Margin (px)": "Lề dưới (px)",
   "Right Margin (px)": "Lề phải (px)",
   "Left Margin (px)": "Lề trái (px)",
-  "Column Gap (%)": "Khoảng cách cột (%)",
   "Always Show Status Bar": "Luôn hiển thị thanh trạng thái",
   "Custom Content CSS": "CSS nội dung",
   "Enter CSS for book content styling...": "Nhập CSS cho phần nội dung sách...",
@@ -1899,5 +1898,6 @@
   "Show original": "Hiển thị bản gốc",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "Cả thế giới là một sân khấu, và tất cả đàn ông đàn bà chỉ là những diễn viên; họ có lúc ra và lúc vào, và một người trong đời mình đóng nhiều vai.",
   "— William Shakespeare, As You Like It": "— William Shakespeare, Theo Ý Thích",
-  "Failed to download and install update": "Không thể tải xuống và cài đặt bản cập nhật"
+  "Failed to download and install update": "Không thể tải xuống và cài đặt bản cập nhật",
+  "Additional Margin (%)": "Lề bổ sung (%)"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -312,7 +312,6 @@
   "Bottom Margin (px)": "下边距",
   "Right Margin (px)": "右边距",
   "Left Margin (px)": "左边距",
-  "Column Gap (%)": "列间距",
   "Always Show Status Bar": "始终显示状态栏",
   "Custom Content CSS": "自定义内容 CSS",
   "Enter CSS for book content styling...": "输入书籍内容样式的CSS…",
@@ -1899,5 +1898,6 @@
   "Show original": "显示原文",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "整个世界是一座舞台，所有的男男女女不过是演员；他们各有登场和退场，一个人一生中要扮演许多角色。",
   "— William Shakespeare, As You Like It": "— 威廉·莎士比亚，《皆大欢喜》",
-  "Failed to download and install update": "下载并安装更新失败"
+  "Failed to download and install update": "下载并安装更新失败",
+  "Additional Margin (%)": "额外边距"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -311,7 +311,6 @@
   "Bottom Margin (px)": "下邊距",
   "Right Margin (px)": "右邊距",
   "Left Margin (px)": "左邊距",
-  "Column Gap (%)": "欄間距",
   "Always Show Status Bar": "始終顯示狀態欄",
   "Custom Content CSS": "自訂內容 CSS",
   "Enter CSS for book content styling...": "輸入書籍內容樣式的CSS…",
@@ -1899,5 +1898,6 @@
   "Show original": "顯示原文",
   "All the world’s a stage, and all the men and women merely players; they have their exits and their entrances, and one man in his time plays many parts.": "整個世界是一座舞臺，所有的男男女女不過是演員；他們各有登場和退場，一個人一生中要扮演許多角色。",
   "— William Shakespeare, As You Like It": "— 威廉·莎士比亞，《皆大歡喜》",
-  "Failed to download and install update": "下載並安裝更新失敗"
+  "Failed to download and install update": "下載並安裝更新失敗",
+  "Additional Margin (%)": "額外邊距"
 }

--- a/apps/readest-app/src/components/settings/LayoutPanel.tsx
+++ b/apps/readest-app/src/components/settings/LayoutPanel.tsx
@@ -639,7 +639,7 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
           step={4}
         />
         <NumberInput
-          label={_('Column Gap (%)')}
+          label={_('Additional Margin (%)')}
           value={gapPercent}
           onChange={setGapPercent}
           min={0}

--- a/apps/readest-app/src/services/commandRegistry.ts
+++ b/apps/readest-app/src/services/commandRegistry.ts
@@ -292,8 +292,8 @@ const layoutPanelItems = [
   },
   {
     id: 'settings.layout.pageGap',
-    labelKey: _('Column Gap (%)'),
-    keywords: ['page', 'gap', 'spacing', 'gutter'],
+    labelKey: _('Additional Margin (%)'),
+    keywords: ['page', 'margin', 'additional', 'gap', 'spacing', 'gutter', 'column'],
     section: 'Page',
   },
   {


### PR DESCRIPTION
## What

Renames the layout setting **"Column Gap (%)"** to **"Additional Margin (%)"**.

## Why

Closes #5301.

"Column Gap" names a CSS/pagination implementation detail that is invisible to users. Because the paginated view is always at least one CSS column, the gap is what actually widens the left/right page margins, but nothing about the label made that discoverable — users hit the 144px margin cap and had no idea the column gap was the knob to turn.

The gap is intentionally tied to the left/right margin values to keep pages symmetrical (you can't adjust the gutter independently), so it isn't really a "gutter" either. In practice it behaves as an extra page margin, and "Additional Margin" reflects that behavior in user-facing terms. See also #3909.

## Changes

- `src/components/settings/LayoutPanel.tsx` — the `NumberInput` label.
- `src/services/commandRegistry.ts` — command-palette `labelKey`; broadened the search `keywords` (`margin`, `additional`, `column` added) so the setting is still found by the old terms.
- `public/locales/*/translation.json` (33 locales) — re-ran `pnpm i18n:extract` and translated the new key.

The underlying setting id (`settings.layout.pageGap`) and state (`viewSettings.gapPercent`) are unchanged — this is a label-only rename.

## Verification

- `pnpm lint` (tsgo + Biome) — pass
- `pnpm test` — 7722 passed, 7 skipped
- `pnpm format:check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)