### PR TITLE
fix(library): disable skeuomorphic book covers by default

### DIFF
--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -177,7 +177,7 @@ export const DEFAULT_SYSTEM_SETTINGS: Partial<SystemSettings> = {
   libraryCoverFit: 'crop',
   libraryAutoColumns: true,
   libraryColumns: 6,
-  librarySkeuomorphicCovers: true, // TODO: Disable by default
+  librarySkeuomorphicCovers: false,
   libraryRecentShelfEnabled: false,
 
   metadataSeriesCollapsed: false,


### PR DESCRIPTION
## Summary

Turns off **Skeuomorphic Book Covers** by default so new users start with flat covers. The setting already had a `// TODO: Disable by default` marker in the default settings.

Users can still enable the effect anytime from **Settings > Library**.

## Changes

- `src/services/constants.ts`: `librarySkeuomorphicCovers` default changed from `true` to `false`.

## Testing

- `pnpm test` — all unit tests pass (ran via pre-push hook).
- `pnpm lint` / `format:check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)