### PR TITLE
fix(opds): keep same-host links on https when the feed is https (#5300)

### DIFF
--- a/apps/readest-app/src/__tests__/app/opds/opds-utils.test.ts
+++ b/apps/readest-app/src/__tests__/app/opds/opds-utils.test.ts
@@ -375,6 +375,36 @@ describe('opdsUtils', () => {
       // The function strips search params for non-scheme relativeTo
       expect(result).not.toContain('page=2');
     });
+
+    // bookserver.mek.oszk.hu (readest issue #5300) serves its catalog over HTTPS
+    // but publishes absolute `http://` links to itself; its plain-HTTP vhost
+    // 301-redirects to an unrelated host that 404s, so every sub-feed failed.
+    it('should keep same-host links on https when the feed was fetched over https', () => {
+      const result = resolveURL(
+        'http://bookserver.mek.oszk.hu/abcrend.atom',
+        'https://bookserver.mek.oszk.hu/',
+      );
+      expect(result).toBe('https://bookserver.mek.oszk.hu/abcrend.atom');
+    });
+
+    it('should upgrade same-host links behind the proxy base too', () => {
+      const proxyBase = '/api/opds/proxy?url=https%3A%2F%2Fexample.com%2Fopds';
+      expect(resolveURL('http://example.com/feed/new', proxyBase)).toBe(
+        'https://example.com/feed/new',
+      );
+    });
+
+    it('should leave cross-host http links untouched', () => {
+      expect(resolveURL('http://other.com/feed', 'https://example.com/opds')).toBe(
+        'http://other.com/feed',
+      );
+    });
+
+    it('should not upgrade when the feed itself was fetched over http', () => {
+      expect(resolveURL('http://example.com/feed', 'http://example.com/opds')).toBe(
+        'http://example.com/feed',
+      );
+    });
   });
 
   describe('getFileExtFromPath', () => {

--- a/apps/readest-app/src/app/opds/utils/opdsUtils.ts
+++ b/apps/readest-app/src/app/opds/utils/opdsUtils.ts
@@ -187,7 +187,25 @@ export const resolveURL = (url: string, relativeTo: string): string => {
     return resolveURL(url, proxiedURL);
   }
   try {
-    if (relativeTo.includes(':')) return new URL(url, relativeTo).toString();
+    if (relativeTo.includes(':')) {
+      const resolved = new URL(url, relativeTo);
+      const base = new URL(relativeTo);
+      // Some catalogs are only reachable over HTTPS yet publish absolute
+      // `http://` links to themselves. bookserver.mek.oszk.hu (readest issue
+      // #5300) 301-redirects every plain-HTTP request to an unrelated host that
+      // 404s, so following those links breaks navigation. When the feed itself
+      // came over HTTPS, keep same-host links on HTTPS -- the upgrade browsers
+      // already apply to mixed content. Cross-host links are left alone so this
+      // can never silently retarget a request.
+      if (
+        base.protocol === 'https:' &&
+        resolved.protocol === 'http:' &&
+        resolved.host === base.host
+      ) {
+        resolved.protocol = 'https:';
+      }
+      return resolved.toString();
+    }
     const root = 'https://invalid.invalid/';
     const obj = new URL(url, root + relativeTo);
     obj.search = '';


### PR DESCRIPTION
Fixes #5300

## Problem

`https://bookserver.mek.oszk.hu/` (Magyar Elektronikus Könyvtár) serves its OPDS catalog fine over HTTPS, but every `<link href>` inside the feed is an absolute **`http://`** URL:

```xml
<link href="http://bookserver.mek.oszk.hu/abcrend.atom" type="application/atom+xml"/>
```

Its plain-HTTP vhost 301-redirects to a *different* host that has none of those paths:

```
http://bookserver.mek.oszk.hu/abcrend.atom
  -> 301 https://balassi.oszk.hu/abcrend.atom -> 404
```

So the catalog root loaded and every sub-feed, cover and acquisition link below it 404'd.

This is not a regression — `v0.11.17` reproduces it too (thanks @chloeroform for checking). An absolute URL wins over the base in `new URL(url, base)`, so `resolveURL` handed the `http://` URL straight to the fetch layer.

## Fix

`resolveURL()` is the single choke point that turns feed hrefs into request URLs — `page.tsx`, `FeedView`, `PublicationView`, `NavigationCard`, `feedChecker` and `autoDownload` all route through it. It now upgrades `http:` to `https:` when the feed itself was fetched over HTTPS **and** the resolved link points at the same host, mirroring the mixed-content upgrade browsers already apply.

Deliberately narrow:

- Cross-host `http://` links are left alone, so this can never silently retarget a request.
- HTTPS is never downgraded, and an HTTP-based feed is left untouched.
- `host` is compared rather than `hostname`, so a port mismatch blocks the upgrade.

Because `baseURL` is the URL actually fetched (`responseURL`), one upgraded link keeps the whole subtree on HTTPS.

## Testing

- 4 new `resolveURL` cases in `src/__tests__/app/opds/opds-utils.test.ts` — two fail without the fix (same-host upgrade, and the same through the `/api/opds/proxy` base), two pin the no-upgrade behaviour for cross-host and HTTP-base links.
- Full suite: 7788 passed. `pnpm lint` clean.
- Manually in the browser against the real catalog: root -> "Cím szerint" (the link that used to 404) -> "CÍM: A" -> publication detail, with covers and download links all resolving. No console errors.

## Not covered

Search on this particular catalog stays broken, and nothing on the client can fix it: its `opensearch.xml` templates `http://mek.oszk.hu/opds/opensearch/?q={searchTerms}`, which 404s over **both** schemes and on both hosts. That is a different host from the catalog, so the same-host rule leaves it alone — and upgrading it would not have helped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)