### PR TITLE
fix(calibre): verify the cloud blob exists before a row-only push

### DIFF
--- a/apps/readest-calibre-plugin/api.py
+++ b/apps/readest-calibre-plugin/api.py
@@ -29,6 +29,7 @@ DEFAULT_ANON_KEY = (
 
 TIMEOUT = 30
 UPLOAD_TIMEOUT = 600
+LIST_PAGE_SIZE = 100  # the storage/list endpoint's maximum
 
 
 class ReadestAPIError(Exception):
@@ -306,6 +307,21 @@ class ReadestClient:
     def list_files(self, book_hash):
         result = self._api('GET', '/storage/list?bookHash=' + urllib.parse.quote(book_hash))
         return (result or {}).get('files') or []
+
+    def list_all_files(self):
+        """Every stored file for the user, following the endpoint's paging.
+
+        Pagination is driven by `totalPages`, not by the batch length: the
+        endpoint pads each page with the other files of any book it touched,
+        so a batch can be larger than `pageSize`.
+        """
+        page, files = 1, []
+        while True:
+            result = self._api('GET', '/storage/list?page=%d&pageSize=%d' % (page, LIST_PAGE_SIZE))
+            files.extend((result or {}).get('files') or [])
+            if page >= ((result or {}).get('totalPages') or 0):
+                return files
+            page += 1
 
     def delete_file(self, file_key):
         return self._api(

--- a/apps/readest-calibre-plugin/tests/test_client.py
+++ b/apps/readest-calibre-plugin/tests/test_client.py
@@ -198,6 +198,31 @@ class StorageTest(unittest.TestCase):
         self.assertEqual(req['url'], f'{API_BASE}/storage/list?bookHash=h')
         self.assertEqual(files, [{'file_key': 'u/Readest/Books/h/h.epub'}])
 
+    def test_list_all_files_paginates(self):
+        transport = FakeTransport()
+        transport.queue(200, {'files': [{'file_key': 'u/a'}], 'totalPages': 2})
+        transport.queue(200, {'files': [{'file_key': 'u/b'}], 'totalPages': 2})
+        client = make_client(transport, tokens=valid_tokens())
+        files = client.list_all_files()
+
+        self.assertEqual(files, [{'file_key': 'u/a'}, {'file_key': 'u/b'}])
+        urls = [req['url'] for req in transport.requests]
+        self.assertEqual(
+            urls,
+            [
+                f'{API_BASE}/storage/list?page=1&pageSize=100',
+                f'{API_BASE}/storage/list?page=2&pageSize=100',
+            ],
+        )
+
+    def test_list_all_files_stops_on_single_page(self):
+        transport = FakeTransport()
+        transport.queue(200, {'files': [], 'totalPages': 0})
+        client = make_client(transport, tokens=valid_tokens())
+
+        self.assertEqual(client.list_all_files(), [])
+        self.assertEqual(len(transport.requests), 1)
+
     def test_delete_file(self):
         transport = FakeTransport()
         transport.queue(200, {'success': True})

--- a/apps/readest-calibre-plugin/tests/test_wire.py
+++ b/apps/readest-calibre-plugin/tests/test_wire.py
@@ -6,11 +6,15 @@ import unittest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from wire import (  # noqa: E402
+    book_file_name,
     build_metadata,
     build_wire_book,
+    cloud_book_hashes,
+    cover_file_name,
     index_rows_by_uuid,
     iso_to_ms,
     merge_for_push,
+    ms_to_iso,
     pick_format,
     pick_server_row,
     plan_push,
@@ -239,6 +243,95 @@ class PlanPushTest(unittest.TestCase):
         row['book_hash'] = 'o' * 32  # raw hash of the OLD file
         plan = plan_push(row, wire_for(), 'c' * 32, SRC)
         self.assertEqual(plan['action'], 'replace')
+
+    def test_missing_blob_is_replaced_even_when_row_claims_upload(self):
+        # "Manage Storage" deletes the object and its files row but leaves
+        # books.uploaded_at set, so the row alone cannot prove the blob exists.
+        wire = wire_for()
+        plan = plan_push(synced_row(wire), wire, 'c' * 32, SRC, blob_present=False)
+        self.assertEqual(plan['action'], 'replace')
+        self.assertTrue(plan['upload_cover'])
+
+    def test_missing_blob_on_tombstoned_row_is_replaced(self):
+        # Deleting a book with the "local" option tombstones the row but keeps
+        # uploaded_at; resurrecting it row-only would leave an undownloadable book.
+        wire = wire_for()
+        row = synced_row(wire)
+        row['deleted_at'] = '2024-06-01T00:00:00.000Z'
+        plan = plan_push(row, wire, 'c' * 32, SRC, blob_present=False)
+        self.assertEqual(plan['action'], 'replace')
+
+    def test_missing_blob_does_not_affect_new_book(self):
+        plan = plan_push(None, wire_for(), 'c' * 32, SRC, blob_present=False)
+        self.assertEqual(plan['action'], 'new')
+
+
+class CloudBookHashesTest(unittest.TestCase):
+    def test_book_file_marks_hash_present(self):
+        files = [{'file_key': 'user-1/Readest/Books/%s/%s.epub' % ('a' * 32, 'a' * 32)}]
+        self.assertEqual(cloud_book_hashes(files), {'a' * 32})
+
+    def test_cover_alone_does_not_mark_hash_present(self):
+        files = [{'file_key': 'user-1/Readest/Books/%s/cover.png' % ('a' * 32)}]
+        self.assertEqual(cloud_book_hashes(files), set())
+
+    def test_app_uploaded_title_filename(self):
+        # The app stores books as {hash}/{title}.{ext}, not {hash}/{hash}.{ext}.
+        files = [{'file_key': 'user-1/Readest/Books/%s/The Test Book.epub' % ('b' * 32)}]
+        self.assertEqual(cloud_book_hashes(files), {'b' * 32})
+
+    def test_ignores_unrelated_and_malformed_keys(self):
+        files = [
+            {'file_key': 'user-1/Readest/Replicas/notes/r1/notes.db'},
+            {'file_key': 'user-1/Readest/Books/%s' % ('c' * 32)},  # no file name
+            {'file_key': ''},
+            {},
+        ]
+        self.assertEqual(cloud_book_hashes(files), set())
+
+    def test_empty_listing(self):
+        self.assertEqual(cloud_book_hashes([]), set())
+        self.assertEqual(cloud_book_hashes(None), set())
+
+    def test_agrees_with_the_keys_we_upload(self):
+        # The producer (book_file_name/cover_file_name) and this consumer must
+        # not drift; the listing returns them under a user-id prefix.
+        book_hash = 'a' * 32
+        files = [
+            {'file_key': 'user-1/' + book_file_name(book_hash, 'EPUB')},
+            {'file_key': 'user-1/' + cover_file_name(book_hash)},
+        ]
+        self.assertEqual(cloud_book_hashes(files), {book_hash})
+
+
+class PlanPushAfterStorageWipeTest(unittest.TestCase):
+    """The reported failure: files deleted, books rows left claiming uploaded_at."""
+
+    def test_wiped_storage_forces_reupload(self):
+        wire = wire_for()
+        row = synced_row(wire)
+        row['book_hash'] = 'a' * 32
+        present = cloud_book_hashes([])  # every file deleted under Manage Storage
+        plan = plan_push(row, wire, 'c' * 32, SRC, row['book_hash'] in present)
+        self.assertEqual(plan['action'], 'replace')
+
+    def test_intact_storage_still_skips(self):
+        wire = wire_for()
+        row = synced_row(wire)
+        row['book_hash'] = 'a' * 32
+        present = cloud_book_hashes(
+            [{'file_key': 'user-1/' + book_file_name(row['book_hash'], 'EPUB')}]
+        )
+        plan = plan_push(row, wire, 'c' * 32, SRC, row['book_hash'] in present)
+        self.assertEqual(plan['action'], 'skip')
+
+
+class MsToIsoTest(unittest.TestCase):
+    def test_round_trips_through_iso_to_ms(self):
+        self.assertEqual(iso_to_ms(ms_to_iso(NOW)), NOW)
+
+    def test_none(self):
+        self.assertIsNone(ms_to_iso(None))
 
 
 class ServerRowLookupTest(unittest.TestCase):

--- a/apps/readest-calibre-plugin/wire.py
+++ b/apps/readest-calibre-plugin/wire.py
@@ -34,6 +34,7 @@ EXTS = {
 }
 
 CLOUD_BOOKS_SUBDIR = 'Readest/Books'
+COVER_FILE_NAME = 'cover.png'
 
 
 def pick_format(available):
@@ -53,7 +54,26 @@ def book_file_name(file_hash, fmt):
 
 
 def cover_file_name(file_hash):
-    return '%s/%s/cover.png' % (CLOUD_BOOKS_SUBDIR, file_hash)
+    return '%s/%s/%s' % (CLOUD_BOOKS_SUBDIR, file_hash, COVER_FILE_NAME)
+
+
+def cloud_book_hashes(files):
+    """Book hashes that still have a book blob (not just a cover) in storage.
+
+    Read from the file key (`{user_id}/Readest/Books/{hash}/{name}`) rather
+    than the row's `book_hash`, which is only set when the uploader passed it.
+    """
+    marker = CLOUD_BOOKS_SUBDIR + '/'
+    hashes = set()
+    for record in files or []:
+        key = record.get('file_key') or ''
+        index = key.find(marker)
+        if index < 0:
+            continue
+        book_hash, _, name = key[index + len(marker) :].partition('/')
+        if book_hash and name and name != COVER_FILE_NAME:
+            hashes.add(book_hash)
+    return hashes
 
 
 def _clean(value):
@@ -144,6 +164,12 @@ def iso_to_ms(iso):
     return int(dt.timestamp() * 1000)
 
 
+def ms_to_iso(ms):
+    if ms is None:
+        return None
+    return datetime.fromtimestamp(ms / 1000, timezone.utc).isoformat()
+
+
 def _parse_row_metadata(row):
     raw = row.get('metadata')
     if isinstance(raw, dict):
@@ -218,7 +244,7 @@ def pick_server_row(hash_row, uuid_row):
     return hash_row if hash_row is not None else uuid_row
 
 
-def plan_push(server_row, wire, local_cover_hash, source_hash):
+def plan_push(server_row, wire, local_cover_hash, source_hash, blob_present=True):
     """Decide what to do for one book.
 
     Returns {'action': 'new' | 'replace' | 'update' | 'skip',
@@ -228,10 +254,20 @@ def plan_push(server_row, wire, local_cover_hash, source_hash):
                fresh embedded blob under its new hash, tombstone the old row
     - update:  file unchanged, but metadata/cover/tombstone differ — row only
     - skip:    file + metadata + cover all unchanged
+
+    `blob_present` says whether the row's book file is actually in cloud
+    storage. `uploaded_at` alone doesn't prove it: deleting files under
+    "Manage Storage" drops the object and its `files` row but never touches
+    `books.uploaded_at`, and a row-only push against a missing blob leaves a
+    book that shows up in the library but 404s on download.
     """
     if server_row is None:
         return {'action': 'new', 'upload_cover': bool(local_cover_hash)}
-    if not server_row.get('uploaded_at') or row_source_hash(server_row) != source_hash:
+    if (
+        not server_row.get('uploaded_at')
+        or not blob_present
+        or row_source_hash(server_row) != source_hash
+    ):
         # A replaced book gets a new hash namespace, so it needs its own cover.
         return {'action': 'replace', 'upload_cover': bool(local_cover_hash)}
     cover_changed = bool(local_cover_hash) and local_cover_hash != server_row.get('cover_hash')

--- a/apps/readest-calibre-plugin/worker.py
+++ b/apps/readest-calibre-plugin/worker.py
@@ -22,9 +22,11 @@ from calibre_plugins.readest.wire import (
     EXTS,
     book_file_name,
     build_wire_book,
+    cloud_book_hashes,
     cover_file_name,
     index_rows_by_uuid,
     merge_for_push,
+    ms_to_iso,
     pick_format,
     pick_server_row,
     plan_push,
@@ -132,6 +134,14 @@ class PushWorker(QThread):
             self.done.emit(False, 'Could not reach Readest: %s' % err)
             return
 
+        try:
+            self.cloud_hashes = cloud_book_hashes(self.client.list_all_files())
+        except Exception:
+            # Without the listing we can only trust uploaded_at, which is what
+            # the plugin did before. Stale rows stay stale, but the push runs.
+            traceback.print_exc()
+            self.cloud_hashes = None
+
         counts = {}
         for index, book_id in enumerate(self.book_ids):
             if self.canceled:
@@ -187,12 +197,14 @@ class PushWorker(QThread):
             'author': record['author'],
             'tags': record.get('tags'),
             'metadata': record['metadata'],
-            'uploaded_at': 'pushed',
+            'uploaded_at': ms_to_iso(record.get('uploadedAt')),
             'cover_hash': record.get('coverHash'),
         }
         self.by_hash[record['hash']] = row
         if uuid:
             self.by_uuid[uuid] = row
+        if self.cloud_hashes is not None:
+            self.cloud_hashes.add(record['hash'])
 
     def _push_one(self, book_id):
         mi = self.db.get_metadata(book_id)
@@ -214,7 +226,10 @@ class PushWorker(QThread):
         server_row = pick_server_row(
             self.by_hash.get(source_hash), self.by_uuid.get(uuid) if uuid else None
         )
-        plan = plan_push(server_row, wire, cover_hash, source_hash)
+        blob_present = self.cloud_hashes is None or (
+            server_row is not None and server_row['book_hash'] in self.cloud_hashes
+        )
+        plan = plan_push(server_row, wire, cover_hash, source_hash, blob_present)
 
         if plan['action'] == 'skip':
             return 'skipped', ''


### PR DESCRIPTION
## Problem

A user pushing 88 EPUBs from the calibre plugin reported that roughly a third of them were marked **Updated** instead of **Replaced**, never uploaded, and then failed to download with `File not found`. They had already deleted every book on every device and deleted all files under **Manage Storage**.

The plugin treated `books.uploaded_at` as proof that a book file is in cloud storage. Nothing keeps that column honest:

- `pages/api/storage/delete.ts` and `purge.ts` delete the object and its `files` row, and never touch the `books` table.
- `services/cloudService.ts` only clears `uploadedAt` for `deleteAction` `cloud`/`both`; the "local" option tombstones the row and leaves it set.
- Signing out before the row change syncs means the server never learns.

With a stale `uploaded_at`, `plan_push` picked `update`, which pushes the row and uploads nothing. For a tombstoned row, `pick_server_row`'s resurrection path plus `merge_for_push` clearing `deletedAt` republished the book against a `book_hash` whose blob was gone, so it showed up in the library and 404'd on download. Re-pushing could not recover it: the calibre file is unchanged, so `calibreSourceHash` keeps matching forever.

## Fix

Verify against storage instead of trusting the column.

- `ReadestClient.list_all_files()` pulls the whole listing once per push. It paginates `/storage/list` by `totalPages`, not batch length, because that endpoint pads every page with the sibling files of any book it touched (`list.ts:88-119`), so a batch can exceed `pageSize`.
- `wire.cloud_book_hashes()` derives the set of hashes that still have a book blob. It reads the hash out of the file key (`{user_id}/Readest/Books/{hash}/{name}`) rather than `files.book_hash`, which is only set when the uploader passes it, and ignores `cover.png` so a wiped book with a surviving cover still re-uploads.
- `plan_push(..., blob_present)` downgrades `update`/`skip` to `replace` when the blob is missing.
- A failed listing sets `cloud_hashes = None`, which restores the previous trust-`uploaded_at` behavior rather than aborting the push.

This self-heals accounts already in the broken state: the next push routes those books to **Replaced**.

Also fixed along the way: `_remember` stored the sentinel `'uploaded_at': 'pushed'`, which `merge_for_push` fed to `iso_to_ms` and raised `ValueError`. It now stores a real ISO timestamp.

## Not covered

A book whose file survives but whose cover was deleted will not get its cover re-uploaded. That is cosmetic and not reachable from a bulk Manage Storage wipe, which removes both.

## Testing

- `make test` in `apps/readest-calibre-plugin`: 83 passed (68 before; 15 new, each written failing first). New cases cover a live row and a tombstoned row that both claim `uploaded_at` after storage was wiped, plus a round-trip test asserting `book_file_name`/`cover_file_name` and `cloud_book_hashes` agree so producer and consumer cannot drift.
- `pnpm test`: 7784 passed, 7 skipped
- `pnpm lint`: clean
- `make zip` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)