### PR TITLE
[WIP] feat: add mangadex integration

### DIFF
--- a/apps/readest-app/src/__tests__/services/mangadex/search.test.ts
+++ b/apps/readest-app/src/__tests__/services/mangadex/search.test.ts
@@ -1,0 +1,115 @@
+import { searchManga } from '@/services/mangadex/search';
+import { describe, it, expect, vi } from 'vitest';
+
+describe('search', () => {
+  const fakeResponse = {
+    result: 'ok',
+    response: 'collection',
+    data: [
+      {
+        id: 'fcb5111f-be88-4f5a-b456-22135f3eda49',
+        type: 'manga',
+        attributes: {
+          title: { en: 'ONE PIECE STRONG WORLD' },
+          altTitles: [{ en: 'One Piece: Strong World' }, { en: 'One PIece Volume 0' }],
+          description: {
+            en: 'One Piece: Strong World is a free volume distributed to the first 1.5 million attendees of the fillm bearing the same name. Icluded is the special prologue chapter. Chapter 0 depicts events 20 years before the current timeline of the manga. The main focus is the relationship between Shiki, the Golden Lion and Roger, the Pirate King. In addition, it shows what other characters were doing 20 years ago.',
+            'pt-br':
+              'One-Shot pr\u00f3logo do filme Strong World que se passa 20 anos antes dos acontecimentos do filme. Focado na rela\u00e7\u00e3o do Shiki, O Le\u00e3o Dourado e Gol D. Roger, O Rei dos Piratas.',
+          },
+          isLocked: false,
+          links: { al: '47152', ap: 'one-piece-strong-world-0', kt: '4194', mal: '17152' },
+          officialLinks: null,
+          originalLanguage: 'ja',
+          lastVolume: '0',
+          lastChapter: '0',
+          publicationDemographic: 'shounen',
+          status: 'completed',
+          year: 2009,
+          contentRating: 'safe',
+          tags: [
+            {
+              id: '391b0423-d847-456f-aff0-8b0cfc03066b',
+              type: 'tag',
+              attributes: { name: { en: 'Action' }, description: {}, group: 'genre', version: 1 },
+              relationships: [],
+            },
+            {
+              id: '4d32cc48-9f00-4cca-9b5a-a839f0764984',
+              type: 'tag',
+              attributes: { name: { en: 'Comedy' }, description: {}, group: 'genre', version: 1 },
+              relationships: [],
+            },
+            {
+              id: '87cc87cd-a395-47af-b27a-93258283bbc6',
+              type: 'tag',
+              attributes: {
+                name: { en: 'Adventure' },
+                description: {},
+                group: 'genre',
+                version: 1,
+              },
+              relationships: [],
+            },
+          ],
+          state: 'published',
+          chapterNumbersResetOnNewVolume: false,
+          createdAt: '2018-06-21T15:11:36+00:00',
+          updatedAt: '2023-08-15T18:06:34+00:00',
+          version: 6,
+          availableTranslatedLanguages: ['vi', 'en', 'ru', 'pl', 'eu', 'ca', 'pt-br'],
+          latestUploadedChapter: 'a97e9b7a-dcab-49f3-9bf7-f8e41fa47f18',
+        },
+        relationships: [
+          { id: 'b6045e2c-28f4-4ce0-b4dd-b14070f2f5ae', type: 'author' },
+          { id: 'b6045e2c-28f4-4ce0-b4dd-b14070f2f5ae', type: 'artist' },
+          { id: '3b441fd3-023d-4f96-9e58-e11312421f45', type: 'cover_art' },
+          { id: 'a1c7c817-4e59-43b7-9365-09675a149a6f', type: 'manga', related: 'adapted_from' },
+          { id: 'a1c7c817-4e59-43b7-9365-09675a149a6f', type: 'manga', related: 'sequel' },
+        ],
+      },
+    ],
+    limit: 10,
+    offset: 0,
+    total: 1,
+  };
+
+  describe('searchManga', () => {
+    it('parses response correctly', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(() =>
+          Promise.resolve({
+            json: () => Promise.resolve(fakeResponse),
+          }),
+        ),
+      );
+
+      const manga = await searchManga('one piece');
+      const firstManga = manga[0]!;
+
+      expect(manga).toHaveLength(1);
+      expect(firstManga).toBeDefined();
+      expect(firstManga.id).toBe('fcb5111f-be88-4f5a-b456-22135f3eda49');
+    });
+
+    it('returns empty array when no manga found', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(() =>
+          Promise.resolve({
+            json: () =>
+              Promise.resolve({
+                ...fakeResponse,
+                data: [],
+              }),
+          }),
+        ),
+      );
+
+      const manga = await searchManga('does not exist');
+
+      expect(manga).toEqual([]);
+    });
+  });
+});

--- a/apps/readest-app/src/app/mangadex/components/Navigation.tsx
+++ b/apps/readest-app/src/app/mangadex/components/Navigation.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import WindowButtons from '@/components/WindowButtons';
+import { useDropdownContext } from '@/context/DropdownContext';
+import { useEnv } from '@/context/EnvContext';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useSettingsStore } from '@/store/settingsStore';
+import { debounce } from '@/utils/debounce';
+import { navigateToLibrary } from '@/utils/nav';
+import clsx from 'clsx';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FaSearch } from 'react-icons/fa';
+import { IoMdCloseCircle } from 'react-icons/io';
+
+interface NavigationProps {
+  searchTerm?: string;
+  onSearch: (queryTerm: string) => void;
+  hasSearch: boolean;
+}
+
+export function Navigation({ searchTerm, onSearch, hasSearch = false }: NavigationProps) {
+  const _ = useTranslation();
+  const router = useRouter();
+  const { appService } = useEnv();
+  const { settings } = useSettingsStore();
+  const viewSettings = settings.globalViewSettings;
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const headerRef = useRef<HTMLElement>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const dropdownContext = useDropdownContext();
+
+  useEffect(() => {
+    setSearchQuery(searchTerm || '');
+  }, [searchTerm]);
+
+  useEffect(() => {
+    if (hasSearch && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [hasSearch]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(min-width: 1024px)');
+
+    const handleMediaChange = (e: MediaQueryListEvent) => e.matches && dropdownContext?.closeAll();
+
+    mediaQuery.addEventListener('change', handleMediaChange);
+    return () => mediaQuery.removeEventListener('change', handleMediaChange);
+  }, [dropdownContext]);
+
+  const handleGoLibrary = useCallback(() => {
+    navigateToLibrary(router);
+  }, [router]);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debouncedUpdateQueryParam = useCallback(
+    debounce((value: string) => {
+      if (value) {
+        onSearch(value);
+      }
+    }, 1000),
+    [onSearch],
+  );
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newQuery = e.target.value;
+    setSearchQuery(newQuery);
+    debouncedUpdateQueryParam(newQuery);
+  };
+
+  return (
+    <header
+      ref={headerRef}
+      className={clsx(
+        'navbar min-h-0 px-2',
+        'flex h-[48px] w-full items-center',
+        appService?.isMobile ? '' : 'bg-base-100',
+      )}
+    >
+      {/*<div className={clsx('justify-start gap-1 sm:gap-3', isTrafficLightVisible && '!pl-16')}>
+        <div className='flex gap-1'>
+          {onBack && (
+            <button
+              className='btn btn-ghost btn-sm px-1 disabled:cursor-not-allowed disabled:bg-transparent disabled:opacity-40'
+              onClick={onBack}
+              disabled={!canGoBack}
+              title={_('Back')}
+            >
+              <IoChevronBack className='h-6 w-6' />
+            </button>
+          )}
+          {onForward && (
+            <button
+              className='btn btn-ghost btn-sm px-1 disabled:cursor-not-allowed disabled:bg-transparent disabled:opacity-40'
+              onClick={onForward}
+              disabled={!canGoForward}
+              title={_('Forward')}
+            >
+              <IoChevronForward className='h-6 w-6' />
+            </button>
+          )}
+        </div>
+        <button className='btn btn-ghost btn-sm px-1' onClick={onGoStart} title={_('Home')}>
+          <IoHome className='h-5 w-5' />
+        </button>
+      </div>*/}
+
+      <div className='flex-grow px-3 sm:px-5'>
+        <div className='relative flex w-full items-center'>
+          <span className='text-base-content/50 absolute left-3'>
+            <FaSearch className='h-4 w-4' />
+          </span>
+          <input
+            type='text'
+            ref={inputRef}
+            value={searchQuery}
+            placeholder={_('Search MangaDex...')}
+            disabled={!hasSearch}
+            onChange={handleSearchChange}
+            spellCheck='false'
+            className={clsx(
+              'input rounded-badge h-9 w-full pl-10 pr-4 sm:h-7',
+              viewSettings?.isEink
+                ? 'border-1 border-base-content focus:border-base-content'
+                : 'bg-base-300/45 border-none',
+              'font-sans text-sm font-light',
+              'placeholder:text-base-content/50 truncate',
+              'focus:outline-none focus:ring-0',
+            )}
+          />
+          <div className='text-base-content/50 absolute right-2 flex items-center space-x-2 sm:space-x-4'>
+            {searchQuery && (
+              <button
+                type='button'
+                onClick={() => {
+                  setSearchQuery('');
+                  onSearch(searchQuery);
+                }}
+                className='text-base-content/40 hover:text-base-content/60 pe-1'
+                aria-label={_('Clear Search')}
+              >
+                <IoMdCloseCircle className='h-4 w-4' />
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className='justify-end gap-2 px-1 flex items-center'>
+        <WindowButtons
+          className='window-buttons flex h-full items-center'
+          onClose={() => {
+            handleGoLibrary();
+          }}
+        />
+      </div>
+    </header>
+  );
+}

--- a/apps/readest-app/src/app/mangadex/page.tsx
+++ b/apps/readest-app/src/app/mangadex/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Toast } from '@/components/Toast';
+import { useEnv } from '@/context/EnvContext';
+import { useThemeStore } from '@/store/themeStore';
+import clsx from 'clsx';
+
+export default function MangaDexPage() {
+  const { safeAreaInsets, isRoundedWindow } = useThemeStore();
+  const { appService } = useEnv();
+
+  return (
+    <div
+      className={clsx(
+        'bg-base-100 flex h-screen select-none flex-col',
+        appService?.hasRoundedWindow && isRoundedWindow && 'window-border rounded-window',
+      )}
+    >
+      <div
+        className='relative top-0 z-40 w-full'
+        style={{
+          paddingTop: `${safeAreaInsets?.top || 0}px`,
+        }}
+      >
+        <Toast />
+      </div>
+      <h1>hello world!!!!!!!</h1>
+    </div>
+  );
+}

--- a/apps/readest-app/src/app/mangadex/page.tsx
+++ b/apps/readest-app/src/app/mangadex/page.tsx
@@ -4,10 +4,26 @@ import { Toast } from '@/components/Toast';
 import { useEnv } from '@/context/EnvContext';
 import { useThemeStore } from '@/store/themeStore';
 import clsx from 'clsx';
+import { Navigation } from './components/Navigation';
+import { useRef, useState } from 'react';
+import { searchManga } from '@/services/mangadex/search';
+import { Manga } from '@/services/mangadex/types';
 
 export default function MangaDexPage() {
   const { safeAreaInsets, isRoundedWindow } = useThemeStore();
   const { appService } = useEnv();
+  const searchTermRef = useRef('');
+  const [results, setResults] = useState<Manga[]>([]);
+
+  const handleSearch = async (queryTerm: string) => {
+    searchTermRef.current = queryTerm;
+
+    try {
+      const manga = await searchManga(queryTerm);
+      setResults(manga);
+    } finally {
+    }
+  };
 
   return (
     <div
@@ -22,9 +38,14 @@ export default function MangaDexPage() {
           paddingTop: `${safeAreaInsets?.top || 0}px`,
         }}
       >
-        <Toast />
+        <Navigation searchTerm={searchTermRef.current} onSearch={handleSearch} hasSearch={true} />
       </div>
-      <h1>hello world!!!!!!!</h1>
+      <main className='flex-1 overflow-auto'>
+        {results.map((manga) => (
+          <div key={manga.id}>{manga.attributes.title['ja-ro']}</div>
+        ))}
+      </main>
+      <Toast />
     </div>
   );
 }

--- a/apps/readest-app/src/components/settings/IntegrationsPanel.tsx
+++ b/apps/readest-app/src/components/settings/IntegrationsPanel.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { MdChevronRight } from 'react-icons/md';
+import { SiMangaupdates } from 'react-icons/si';
 import {
   RiBookOpenLine,
   RiRssLine,
@@ -625,6 +626,12 @@ const IntegrationsPanel: React.FC = () => {
               title={_('OPDS Catalogs')}
               status={opdsStatus}
               onClick={() => setSubPage('opds')}
+            />
+            <IntegrationRow
+              icon={SiMangaupdates}
+              title={_('MangaDex')}
+              status={_('Download manga to your library')}
+              onClick={() => router.push('/mangadex')}
             />
             <IntegrationRow
               icon={RiSendPlaneLine}

--- a/apps/readest-app/src/services/mangadex/apiTypes.ts
+++ b/apps/readest-app/src/services/mangadex/apiTypes.ts
@@ -1,0 +1,10 @@
+import { Manga } from './types';
+
+export interface SearchResponse {
+  result: string;
+  response: string;
+  data: Manga[];
+  limit: number;
+  offset: number;
+  total: number;
+}

--- a/apps/readest-app/src/services/mangadex/search.ts
+++ b/apps/readest-app/src/services/mangadex/search.ts
@@ -1,0 +1,19 @@
+import { SearchResponse } from './apiTypes';
+import { BASE_URL, Manga } from './types';
+
+export async function searchManga(title: string): Promise<Manga[]> {
+  const url = new URL('/manga', BASE_URL);
+  url.searchParams.set('title', title);
+  const resp = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+  return parseSearchResponse(resp);
+}
+
+async function parseSearchResponse(resp: Response): Promise<Manga[]> {
+  const response = (await resp.json()) as SearchResponse;
+  return response.data;
+}

--- a/apps/readest-app/src/services/mangadex/types.ts
+++ b/apps/readest-app/src/services/mangadex/types.ts
@@ -1,0 +1,65 @@
+export const BASE_URL = new URL('https://api.mangadex.org');
+
+export type LocalizedString = Record<string, string>;
+export type MangaRelation =
+  | 'monochrome'
+  | 'colored'
+  | 'adapted_from'
+  | 'based_on'
+  | 'prequel'
+  | 'sequel'
+  | 'main_story'
+  | 'side_story'
+  | 'spin_off'
+  | 'doujinshi'
+  | 'same_franchise'
+  | 'shared_universe'
+  | 'alternate_story'
+  | 'alternate_version';
+export type Relationship =
+  | {
+      id: string;
+      type: 'author' | 'artist' | 'cover_art' | 'chapter' | 'scanlation_group' | 'user' | 'creator';
+      attributes?: Record<string, unknown>;
+    }
+  | {
+      id: string;
+      type: 'manga';
+      related: MangaRelation;
+      attributes?: Record<string, unknown>;
+    };
+
+export interface Tag {
+  id: string;
+  name: Record<string, string>;
+  group: string; // TODO: Convert to union
+}
+
+export interface MangaAttributes {
+  title: Record<string, string>;
+  altTitles: Record<string, string>[];
+  description: Record<string, string>;
+  isLocked: boolean;
+  links?: Record<string, string>;
+  originalLanguage: string;
+  lastVolume: string | null;
+  lastChapter: string | null;
+  publicationDemographic: string | null;
+  status: string;
+  year: number | null;
+  contentRating: string;
+  tags: Tag[];
+  state: string;
+  chapterNumbersResetOnNewVolume: boolean;
+  createdAt: string;
+  updatedAt: string;
+  version: number;
+  availableTranslatedLanguages: string[];
+  latestUploadedChapter: string | null;
+}
+
+export interface Manga {
+  id: string;
+  attributes: MangaAttributes;
+  relationships: Relationship[];
+}


### PR DESCRIPTION
Closes #5221.

The idea here is to add a `/mangadex` route that lets the user download manga to their library in the `.cbz` format via the [MangaDex API](https://api.mangadex.org/docs/).

Here is a list of features I hope to implement:

# Roadmap

## Core features

- [ ] Search MangaDex for manga
- [ ] View manga details and available chapters
- [ ] Download chapters as `.cbz` files
  - [ ] Choose between original and reduced quality (supported natively by the mangadex api)
  - [ ] Download a single chapter
  - [ ] Download multiple chapters in bulk
    - [ ] Save chapters as separate books or a single book
  - [ ] Download chapters by volume when possible

## Possible future improvements

While these features would be nice, whether I actually go through with adding them is another thing. These features would basically turn readest into a mangadex client, which is *way* out of the scope of my abilities. That being said:

- [ ] MangaDex account integration (prerequisite for the next two features)
- [ ] Sync manga reading status with MangaDex
- [ ] Manga updates feed (perhaps with added push notifications as well)
- [ ] Resize manga to user's device screen resolution (would reduce file sizes)
  - [ ] If sync is enabled, the option to choose which device to resize/optimize for

(Personally feel that resizing manga would be nice, just because ~40 chapters can result in a 400mb file in my experience, which, given the 500mb sync limit would be very limiting.)