### PR TITLE
feat(calibre): Check Readest status action, with faster cloud lookups

### DIFF
--- a/apps/readest-app/src/__tests__/pages/api/storage-list-paging.test.ts
+++ b/apps/readest-app/src/__tests__/pages/api/storage-list-paging.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { IN_CHUNK_SIZE, MAX_PAGE_SIZE, chunkIds, resolvePageSize } from '@/pages/api/storage/list';
+
+// The listing costs roughly a second per request almost regardless of how many
+// rows come back, so a client walking the whole account (the calibre plugin)
+// pays per page. Raising the cap collapses ~16 requests into 2.
+describe('resolvePageSize', () => {
+  it('defaults to 50 when absent or unparseable', () => {
+    expect(resolvePageSize(undefined)).toBe(50);
+    expect(resolvePageSize('')).toBe(50);
+    expect(resolvePageSize('abc')).toBe(50);
+  });
+
+  it('honours a requested size up to the cap', () => {
+    expect(resolvePageSize('20')).toBe(20);
+    expect(resolvePageSize(String(MAX_PAGE_SIZE))).toBe(MAX_PAGE_SIZE);
+  });
+
+  it('clamps anything above the cap', () => {
+    expect(resolvePageSize('5000')).toBe(MAX_PAGE_SIZE);
+  });
+
+  it('never returns a range-breaking size', () => {
+    expect(resolvePageSize('0')).toBe(50); // 0 is falsy, so it falls back
+    expect(resolvePageSize('-5')).toBe(1);
+  });
+});
+
+// Supabase renders `.in()` into the request's query string. A full page of
+// book hashes at the raised cap would be tens of kilobytes of URL, which
+// PostgREST rejects, so the group expansion has to go out in batches.
+describe('chunkIds', () => {
+  it('splits into batches no larger than the limit', () => {
+    const ids = Array.from({ length: 250 }, (_, i) => `id-${i}`);
+    const batches = chunkIds(ids);
+    expect(batches.every((batch) => batch.length <= IN_CHUNK_SIZE)).toBe(true);
+    expect(batches).toHaveLength(3);
+  });
+
+  it('keeps every id exactly once and in order', () => {
+    const ids = Array.from({ length: 250 }, (_, i) => `id-${i}`);
+    expect(chunkIds(ids).flat()).toEqual(ids);
+  });
+
+  it('returns nothing for an empty list', () => {
+    expect(chunkIds([])).toEqual([]);
+  });
+
+  it('does not emit a trailing empty batch on an exact multiple', () => {
+    const ids = Array.from({ length: IN_CHUNK_SIZE * 2 }, (_, i) => `id-${i}`);
+    expect(chunkIds(ids)).toHaveLength(2);
+  });
+
+  it('keeps a batch of 32-char hashes well inside a safe URL length', () => {
+    const hashes = Array.from({ length: IN_CHUNK_SIZE }, () => 'a'.repeat(32));
+    // `book_hash=in.("h1","h2",...)` — roughly 36 chars per quoted, encoded id.
+    expect(chunkIds(hashes)[0]!.join(',').length * 1.2).toBeLessThan(8000);
+  });
+});

--- a/apps/readest-app/src/pages/api/storage/list.ts
+++ b/apps/readest-app/src/pages/api/storage/list.ts
@@ -21,6 +21,28 @@ interface ListFilesResponse {
   totalPages: number;
 }
 
+// A listing request costs about a second almost regardless of how many rows it
+// returns, so a client walking the whole account (the calibre plugin) pays per
+// page. 1000 turns ~16 requests into 2. The in-app Storage Manager asks for 20
+// and is unaffected.
+export const MAX_PAGE_SIZE = 1000;
+
+// Supabase renders `.in()` into the request's query string, so a whole page of
+// hashes at MAX_PAGE_SIZE would be tens of kilobytes of URL. Send the group
+// expansion in batches instead.
+export const IN_CHUNK_SIZE = 100;
+
+export const resolvePageSize = (raw: string | undefined) =>
+  Math.max(1, Math.min(parseInt(raw as string) || 50, MAX_PAGE_SIZE));
+
+export const chunkIds = <T>(ids: T[], size = IN_CHUNK_SIZE): T[][] => {
+  const batches: T[][] = [];
+  for (let index = 0; index < ids.length; index += size) {
+    batches.push(ids.slice(index, index + size));
+  }
+  return batches;
+};
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   await runMiddleware(req, res, corsAllMethods);
 
@@ -43,7 +65,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       search?: string;
     };
     const page = parseInt(reqQuery.page as string) || 1;
-    const pageSize = Math.min(parseInt(reqQuery.pageSize as string) || 50, 100);
+    const pageSize = resolvePageSize(reqQuery.pageSize);
     const sortBy = (reqQuery.sortBy as string) || 'created_at';
     const sortOrder = (reqQuery.sortOrder as string) === 'asc' ? 'asc' : 'desc';
     const bookHash = reqQuery.bookHash as string | undefined;
@@ -107,14 +129,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           .is('deleted_at', null);
 
       const fileMap = new Map(allRelatedFiles.map((f) => [f.file_key, f]));
-      if (bookHashes.length > 0) {
-        const { data, error } = await baseQuery().in('book_hash', bookHashes);
-        if (!error && data) data.forEach((f) => fileMap.set(f.file_key, f));
-      }
-      if (replicaIds.length > 0) {
-        const { data, error } = await baseQuery().in('replica_id', replicaIds);
-        if (!error && data) data.forEach((f) => fileMap.set(f.file_key, f));
-      }
+      const absorb = async (column: 'book_hash' | 'replica_id', ids: string[]) => {
+        const results = await Promise.all(
+          chunkIds(ids).map((batch) => baseQuery().in(column, batch)),
+        );
+        results.forEach(({ data, error }) => {
+          if (!error && data) data.forEach((f) => fileMap.set(f.file_key, f));
+        });
+      };
+      if (bookHashes.length > 0) await absorb('book_hash', bookHashes);
+      if (replicaIds.length > 0) await absorb('replica_id', replicaIds);
       allRelatedFiles = Array.from(fileMap.values());
     }
 

--- a/apps/readest-calibre-plugin/Makefile
+++ b/apps/readest-calibre-plugin/Makefile
@@ -1,17 +1,23 @@
 NAME = Readest
-VERSION = $(shell python3 -c "import re; \
-	m = re.search(r'PLUGIN_VERSION = \((\d+), (\d+), (\d+)\)', open('__init__.py').read()); \
-	print('.'.join(m.groups()))")
+# The app's package.json is the single source of truth for the version, the
+# same one release.yml reads. `version` stamps it into __init__.py, which is
+# what calibre shows in Preferences > Plugins.
+VERSION = $(shell python3 -c "from sync_version import app_version; \
+	print('.'.join(str(p) for p in app_version()))")
 ZIP = dist/$(NAME)-$(VERSION).calibre-plugin.zip
 
 FILES = __init__.py api.py config.py dialogs.py oauth.py ui.py wire.py worker.py \
 	plugin-import-name-readest.txt images/icon.png
 
-.PHONY: zip test install clean
+.PHONY: zip version test install clean
 
 zip: $(ZIP)
 
-$(ZIP): $(FILES)
+# Writes only when the version has drifted, so it never forces a rebuild.
+version:
+	@python3 sync_version.py
+
+$(ZIP): $(FILES) | version
 	mkdir -p dist
 	rm -f $(ZIP)
 	zip -q $(ZIP) $(FILES)

--- a/apps/readest-calibre-plugin/__init__.py
+++ b/apps/readest-calibre-plugin/__init__.py
@@ -3,7 +3,7 @@ __copyright__ = '2026, Bilingify LLC'
 
 from calibre.customize import InterfaceActionBase
 
-PLUGIN_VERSION = (0, 1, 0)
+PLUGIN_VERSION = (0, 11, 20)
 
 
 class ReadestPlugin(InterfaceActionBase):

--- a/apps/readest-calibre-plugin/api.py
+++ b/apps/readest-calibre-plugin/api.py
@@ -29,7 +29,10 @@ DEFAULT_ANON_KEY = (
 
 TIMEOUT = 30
 UPLOAD_TIMEOUT = 600
-LIST_PAGE_SIZE = 100  # the storage/list endpoint's maximum
+# Servers cap this (100 at the time of writing) and report the size they
+# actually served, so asking for more is free and pays off if the cap rises:
+# the listing costs about a second per request regardless of rows returned.
+LIST_PAGE_SIZE = 1000
 
 
 class ReadestAPIError(Exception):
@@ -308,6 +311,17 @@ class ReadestClient:
         result = self._api('GET', '/storage/list?bookHash=' + urllib.parse.quote(book_hash))
         return (result or {}).get('files') or []
 
+    def list_files_page(self, page):
+        """(files, total_pages) for one page of the whole-account listing.
+
+        `total_pages` reflects the page size the server actually served, so
+        paging stays correct whether or not it honoured LIST_PAGE_SIZE.
+        """
+        result = (
+            self._api('GET', '/storage/list?page=%d&pageSize=%d' % (page, LIST_PAGE_SIZE)) or {}
+        )
+        return (result.get('files') or []), (result.get('totalPages') or 0)
+
     def list_all_files(self):
         """Every stored file for the user, following the endpoint's paging.
 
@@ -315,13 +329,11 @@ class ReadestClient:
         endpoint pads each page with the other files of any book it touched,
         so a batch can be larger than `pageSize`.
         """
-        page, files = 1, []
-        while True:
-            result = self._api('GET', '/storage/list?page=%d&pageSize=%d' % (page, LIST_PAGE_SIZE))
-            files.extend((result or {}).get('files') or [])
-            if page >= ((result or {}).get('totalPages') or 0):
-                return files
-            page += 1
+        files, total_pages = self.list_files_page(1)
+        for page in range(2, total_pages + 1):
+            more, _ = self.list_files_page(page)
+            files.extend(more)
+        return files
 
     def delete_file(self, file_key):
         return self._api(

--- a/apps/readest-calibre-plugin/dialogs.py
+++ b/apps/readest-calibre-plugin/dialogs.py
@@ -22,7 +22,12 @@ from calibre.gui2 import error_dialog, open_url
 
 from calibre_plugins.readest.api import ReadestAPIError
 from calibre_plugins.readest.oauth import PROVIDERS, OAuthCallbackServer, build_authorize_url
-from calibre_plugins.readest.worker import STATUS_LABELS, PushWorker
+from calibre_plugins.readest.worker import (
+    CHECK_LABELS,
+    STATUS_LABELS,
+    PushWorker,
+    StatusWorker,
+)
 
 OAUTH_WAIT_SECONDS = 300
 
@@ -152,26 +157,27 @@ class LoginDialog(QDialog):
         QDialog.done(self, result)
 
 
-class PushDialog(QDialog):
-    """Per-book status table for a push run, modeled on BookFusion's sync log."""
+class _RunDialog(QDialog):
+    """Per-book status table for one worker run, modeled on BookFusion's sync log."""
+
+    worker_class = None
+    title = ''
+    heading = ''
+    labels = {}
+    failure_title = ''
 
     def __init__(self, parent, db, book_ids, client, include_custom_columns):
         QDialog.__init__(self, parent)
         self.db = db
-        self.worker = PushWorker(self, db, book_ids, client, include_custom_columns)
-        self.worker.progress.connect(self.on_progress)
-        self.worker.book_status.connect(self.on_book_status)
-        self.worker.done.connect(self.on_done)
+        self.marks = {}
 
-        self.setWindowTitle('Push to Readest')
+        self.setWindowTitle(self.title)
         self.setMinimumSize(520, 380)
         layout = QVBoxLayout()
         self.setLayout(layout)
 
         count = len(book_ids)
-        layout.addWidget(
-            QLabel('Pushing %d %s to your Readest library…' % (count, _plural(count)))
-        )
+        layout.addWidget(QLabel(self.heading % (count, _plural(count))))
 
         self.progress_bar = QProgressBar(self)
         self.progress_bar.setRange(0, count)
@@ -192,6 +198,10 @@ class PushDialog(QDialog):
         self.buttons.rejected.connect(self.reject)
         layout.addWidget(self.buttons)
 
+        self.worker = self.worker_class(self, db, book_ids, client, include_custom_columns)
+        self.worker.progress.connect(self.on_progress)
+        self.worker.book_status.connect(self.on_book_status)
+        self.worker.done.connect(self.on_done)
         self.worker.start()
 
     def on_progress(self, done, total):
@@ -202,7 +212,7 @@ class PushDialog(QDialog):
         row = self.table.rowCount()
         self.table.insertRow(row)
         self.table.setItem(row, 0, QTableWidgetItem(title))
-        self.table.setItem(row, 1, QTableWidgetItem(STATUS_LABELS.get(status, status)))
+        self.table.setItem(row, 1, QTableWidgetItem(self.labels.get(status, status)))
         self.table.setItem(row, 2, QTableWidgetItem(detail))
         self.table.scrollToBottom()
 
@@ -210,8 +220,11 @@ class PushDialog(QDialog):
         self.progress_bar.setValue(self.progress_bar.maximum())
         self.summary_label.setText(message)
         self.buttons.setStandardButtons(QDialogButtonBox.StandardButton.Close)
+        # Read on the GUI thread once the worker is finished, so ui.py can
+        # apply them to the library view.
+        self.marks = dict(self.worker.marks)
         if not ok and self.table.rowCount() == 0:
-            error_dialog(self, 'Push to Readest failed', message, show=True)
+            error_dialog(self, self.failure_title, message, show=True)
 
     def reject(self):
         if self.worker.isRunning():
@@ -219,6 +232,22 @@ class PushDialog(QDialog):
             self.summary_label.setText('Canceling…')
             return
         QDialog.reject(self)
+
+
+class PushDialog(_RunDialog):
+    worker_class = PushWorker
+    title = 'Push to Readest'
+    heading = 'Pushing %d %s to your Readest library…'
+    labels = STATUS_LABELS
+    failure_title = 'Push to Readest failed'
+
+
+class StatusDialog(_RunDialog):
+    worker_class = StatusWorker
+    title = 'Readest status'
+    heading = 'Checking %d %s against your Readest library…'
+    labels = CHECK_LABELS
+    failure_title = 'Readest status check failed'
 
 
 def _plural(count):

--- a/apps/readest-calibre-plugin/sync_version.py
+++ b/apps/readest-calibre-plugin/sync_version.py
@@ -1,0 +1,59 @@
+__license__ = 'AGPL v3'
+__copyright__ = '2026, Bilingify LLC'
+
+"""Keep PLUGIN_VERSION in step with apps/readest-app/package.json.
+
+The plugin is installed into calibre as a standalone zip, so its version has
+to be a literal in `__init__.py` rather than something read at runtime. That
+literal drifts the moment the app is bumped, and a drifted value is what
+calibre then shows in Preferences > Plugins. `make zip` runs this first, and
+release.yml stamps releases from the same package.json.
+
+Build-time only: not part of FILES, so it never ships inside the zip.
+"""
+
+import json
+import os
+import re
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PACKAGE_JSON = os.path.join(HERE, os.pardir, 'readest-app', 'package.json')
+INIT_PY = os.path.join(HERE, '__init__.py')
+PATTERN = re.compile(r'^PLUGIN_VERSION = \((\d+), (\d+), (\d+)\)', re.MULTILINE)
+
+
+def app_version(path=PACKAGE_JSON):
+    """(major, minor, patch) from the app's package.json."""
+    with open(path, encoding='utf-8') as handle:
+        raw = json.load(handle)['version']
+    return tuple(int(part) for part in raw.split('.')[:3])
+
+
+def plugin_version(path=INIT_PY):
+    """(major, minor, patch) currently written into `path`, or None."""
+    with open(path, encoding='utf-8') as handle:
+        match = PATTERN.search(handle.read())
+    return tuple(int(group) for group in match.groups()) if match else None
+
+
+def sync(path=INIT_PY, version=None):
+    """Rewrite PLUGIN_VERSION when it has drifted. True if the file changed."""
+    if version is None:
+        version = app_version()
+    with open(path, encoding='utf-8') as handle:
+        source = handle.read()
+    updated = PATTERN.sub('PLUGIN_VERSION = (%d, %d, %d)' % version, source, count=1)
+    if updated == source:
+        return False
+    with open(path, 'w', encoding='utf-8') as handle:
+        handle.write(updated)
+    return True
+
+
+if __name__ == '__main__':
+    target = app_version()
+    changed = sync(version=target)
+    print(
+        'PLUGIN_VERSION %s: %s'
+        % ('updated' if changed else 'already', '.'.join(str(p) for p in target))
+    )

--- a/apps/readest-calibre-plugin/tests/test_client.py
+++ b/apps/readest-calibre-plugin/tests/test_client.py
@@ -8,6 +8,7 @@ import unittest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from api import (  # noqa: E402
+    LIST_PAGE_SIZE,
     AuthRequiredError,
     QuotaExceededError,
     ReadestAPIError,
@@ -210,10 +211,28 @@ class StorageTest(unittest.TestCase):
         self.assertEqual(
             urls,
             [
-                f'{API_BASE}/storage/list?page=1&pageSize=100',
-                f'{API_BASE}/storage/list?page=2&pageSize=100',
+                f'{API_BASE}/storage/list?page=1&pageSize={LIST_PAGE_SIZE}',
+                f'{API_BASE}/storage/list?page=2&pageSize={LIST_PAGE_SIZE}',
             ],
         )
+
+    def test_list_all_files_follows_a_clamping_server(self):
+        # Servers cap pageSize and report totalPages for the size they served,
+        # so asking for more than they allow must not truncate the listing.
+        transport = FakeTransport()
+        for page in range(1, 4):
+            transport.queue(200, {'files': [{'file_key': 'u/%d' % page}], 'totalPages': 3})
+        client = make_client(transport, tokens=valid_tokens())
+
+        self.assertEqual(len(client.list_all_files()), 3)
+        self.assertEqual(len(transport.requests), 3)
+
+    def test_list_files_page_returns_total_pages(self):
+        transport = FakeTransport()
+        transport.queue(200, {'files': [{'file_key': 'u/a'}], 'totalPages': 7})
+        client = make_client(transport, tokens=valid_tokens())
+
+        self.assertEqual(client.list_files_page(1), ([{'file_key': 'u/a'}], 7))
 
     def test_list_all_files_stops_on_single_page(self):
         transport = FakeTransport()

--- a/apps/readest-calibre-plugin/tests/test_version.py
+++ b/apps/readest-calibre-plugin/tests/test_version.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from sync_version import app_version, plugin_version, sync  # noqa: E402
+
+
+class PluginVersionTest(unittest.TestCase):
+    def test_committed_version_matches_the_app(self):
+        # The zip ships PLUGIN_VERSION as a literal, so a stale value means
+        # every local build installs into calibre under the wrong version.
+        # release.yml stamps releases from this same package.json.
+        self.assertEqual(plugin_version(), app_version())
+
+    def test_app_version_is_a_three_part_tuple(self):
+        version = app_version()
+        self.assertEqual(len(version), 3)
+        self.assertTrue(all(isinstance(part, int) for part in version))
+
+
+class SyncTest(unittest.TestCase):
+    def write(self, body):
+        fd, path = tempfile.mkstemp(suffix='.py')
+        os.close(fd)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(body)
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def test_rewrites_a_stale_version(self):
+        path = self.write("NAME = 'x'\nPLUGIN_VERSION = (0, 1, 0)\nOTHER = 1\n")
+        self.assertTrue(sync(path, (0, 11, 20)))
+        self.assertEqual(plugin_version(path), (0, 11, 20))
+
+    def test_is_idempotent(self):
+        path = self.write('PLUGIN_VERSION = (0, 11, 20)\n')
+        self.assertFalse(sync(path, (0, 11, 20)))
+
+    def test_leaves_the_rest_of_the_file_alone(self):
+        path = self.write(
+            "HEAD = 1\nPLUGIN_VERSION = (0, 1, 0)\nTAIL = 'PLUGIN_VERSION = (9, 9, 9)'\n"
+        )
+        sync(path, (1, 2, 3))
+        with open(path, encoding='utf-8') as f:
+            body = f.read()
+        self.assertIn('HEAD = 1', body)
+        self.assertIn("TAIL = 'PLUGIN_VERSION = (9, 9, 9)'", body)
+        self.assertIn('PLUGIN_VERSION = (1, 2, 3)', body)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apps/readest-calibre-plugin/tests/test_wire.py
+++ b/apps/readest-calibre-plugin/tests/test_wire.py
@@ -21,6 +21,7 @@ from wire import (  # noqa: E402
     pick_format,
     pick_server_row,
     plan_push,
+    should_bulk_list,
     tombstone_record,
 )
 
@@ -267,6 +268,75 @@ class PlanPushTest(unittest.TestCase):
     def test_missing_blob_does_not_affect_new_book(self):
         plan = plan_push(None, wire_for(), 'c' * 32, SRC, blob_present=False)
         self.assertEqual(plan['action'], 'new')
+
+
+class BlobLookupTest(unittest.TestCase):
+    """`blob_present` may be a callable, consulted only when it can change the answer.
+
+    A storage lookup costs a request, so plan_push must not make one for a book
+    the cheaper checks have already routed to new/replace.
+    """
+
+    def setUp(self):
+        self.asked = []
+
+    def probe(self, result):
+        def lookup(book_hash):
+            self.asked.append(book_hash)
+            return result
+
+        return lookup
+
+    def test_not_consulted_for_a_new_book(self):
+        plan = plan_push(None, wire_for(), 'c' * 32, SRC, self.probe(True))
+        self.assertEqual(plan['action'], 'new')
+        self.assertEqual(self.asked, [])
+
+    def test_not_consulted_when_the_row_has_no_upload(self):
+        wire = wire_for()
+        row = synced_row(wire)
+        row['uploaded_at'] = None
+        plan = plan_push(row, wire, 'c' * 32, SRC, self.probe(True))
+        self.assertEqual(plan['action'], 'replace')
+        self.assertEqual(self.asked, [])
+
+    def test_not_consulted_when_the_source_file_changed(self):
+        wire = wire_for(dict(BOOK, source_hash='n' * 32))
+        row = synced_row(wire_for())
+        plan = plan_push(row, wire, 'c' * 32, 'n' * 32, self.probe(True))
+        self.assertEqual(plan['action'], 'replace')
+        self.assertEqual(self.asked, [])
+
+    def test_consulted_once_the_cheap_checks_pass(self):
+        wire = wire_for()
+        row = synced_row(wire)
+        row['book_hash'] = 'a' * 32
+        self.assertEqual(plan_push(row, wire, 'c' * 32, SRC, self.probe(True))['action'], 'skip')
+        self.assertEqual(self.asked, ['a' * 32])
+
+    def test_missing_blob_from_the_callable_forces_replace(self):
+        wire = wire_for()
+        row = synced_row(wire)
+        row['book_hash'] = 'a' * 32
+        plan = plan_push(row, wire, 'c' * 32, SRC, self.probe(False))
+        self.assertEqual(plan['action'], 'replace')
+        self.assertEqual(self.asked, ['a' * 32])
+
+
+class ShouldBulkListTest(unittest.TestCase):
+    def test_one_book_against_a_large_library_uses_per_book_lookups(self):
+        self.assertFalse(should_bulk_list(16, 1))
+
+    def test_a_large_selection_pays_for_the_listing(self):
+        self.assertTrue(should_bulk_list(16, 88))
+
+    def test_break_even_prefers_the_listing(self):
+        self.assertTrue(should_bulk_list(16, 16))
+
+    def test_a_single_page_is_always_worth_it(self):
+        # We have to fetch page 1 to learn the count, so it is already paid for.
+        self.assertTrue(should_bulk_list(1, 1))
+        self.assertTrue(should_bulk_list(0, 1))
 
 
 class CloudBookHashesTest(unittest.TestCase):

--- a/apps/readest-calibre-plugin/tests/test_wire.py
+++ b/apps/readest-calibre-plugin/tests/test_wire.py
@@ -6,6 +6,8 @@ import unittest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from wire import (  # noqa: E402
+    MARK_PREFIX,
+    PLAN_MARKS,
     book_file_name,
     build_metadata,
     build_wire_book,
@@ -14,6 +16,7 @@ from wire import (  # noqa: E402
     index_rows_by_uuid,
     iso_to_ms,
     merge_for_push,
+    merge_marks,
     ms_to_iso,
     pick_format,
     pick_server_row,
@@ -324,6 +327,38 @@ class PlanPushAfterStorageWipeTest(unittest.TestCase):
         )
         plan = plan_push(row, wire, 'c' * 32, SRC, row['book_hash'] in present)
         self.assertEqual(plan['action'], 'skip')
+
+
+class MarksTest(unittest.TestCase):
+    def test_every_plan_action_has_a_mark(self):
+        # plan_push's four actions must all map to a label, or a status check
+        # would silently leave books unmarked.
+        self.assertEqual(set(PLAN_MARKS), {'new', 'replace', 'update', 'skip'})
+        for label in PLAN_MARKS.values():
+            self.assertTrue(label.startswith(MARK_PREFIX))
+
+    def test_replaces_our_own_stale_marks(self):
+        existing = {1: 'readest_synced', 2: 'readest_missing'}
+        self.assertEqual(merge_marks(existing, {1: 'readest_missing'}), {1: 'readest_missing'})
+
+    def test_keeps_marks_the_user_set(self):
+        existing = {1: 'true', 2: 'readest_synced', 3: 'todo'}
+        merged = merge_marks(existing, {2: 'readest_missing'})
+        self.assertEqual(merged, {1: 'true', 3: 'todo', 2: 'readest_missing'})
+
+    def test_new_marks_win_over_a_user_mark_on_the_same_book(self):
+        self.assertEqual(merge_marks({1: 'true'}, {1: 'readest_synced'}), {1: 'readest_synced'})
+
+    def test_empty_inputs(self):
+        self.assertEqual(merge_marks(None, None), {})
+        self.assertEqual(merge_marks({1: 'readest_synced'}, {}), {})
+        self.assertEqual(merge_marks({1: 'true'}, {}), {1: 'true'})
+
+    def test_tolerates_non_string_labels(self):
+        # calibre stores whatever the marking code passed; 'true' marks can be
+        # bare booleans in older libraries.
+        merged = merge_marks({1: True}, {2: 'readest_synced'})
+        self.assertEqual(merged, {1: True, 2: 'readest_synced'})
 
 
 class MsToIsoTest(unittest.TestCase):

--- a/apps/readest-calibre-plugin/ui.py
+++ b/apps/readest-calibre-plugin/ui.py
@@ -8,7 +8,8 @@ from calibre.gui2.actions import InterfaceAction
 
 from calibre_plugins.readest.api import ReadestClient
 from calibre_plugins.readest.config import prefs, save_tokens
-from calibre_plugins.readest.dialogs import LoginDialog, PushDialog
+from calibre_plugins.readest.dialogs import LoginDialog, PushDialog, StatusDialog
+from calibre_plugins.readest.wire import merge_marks
 
 
 def make_client():
@@ -36,6 +37,12 @@ class ReadestInterfacePlugin(InterfaceAction):
         )
         self.push_action.triggered.connect(self.push_selected)
 
+        self.check_action = self.create_action(
+            spec=('Check Readest status', None, None, None),
+            attr='Check Readest status of selected books',
+        )
+        self.check_action.triggered.connect(self.check_selected)
+
         self.login_action = self.create_action(
             spec=('Log in to Readest…', None, None, None), attr='Log in to Readest'
         )
@@ -53,6 +60,7 @@ class ReadestInterfacePlugin(InterfaceAction):
 
         self.menu = QMenu(self.gui)
         self.menu.addAction(self.push_action)
+        self.menu.addAction(self.check_action)
         self.menu.addSeparator()
         self.menu.addAction(self.login_action)
         self.menu.addAction(self.logout_action)
@@ -70,26 +78,46 @@ class ReadestInterfacePlugin(InterfaceAction):
         self.logout_action.setVisible(logged_in)
         if logged_in and email:
             self.logout_action.setText('Log out (%s)' % email)
-        self.push_action.setEnabled(len(self.selected_book_ids()) > 0)
+        selected = len(self.selected_book_ids()) > 0
+        self.push_action.setEnabled(selected)
+        self.check_action.setEnabled(selected)
 
     def selected_book_ids(self):
         return self.gui.library_view.get_selected_ids()
 
     def push_selected(self):
+        self.run_on_selection(PushDialog, 'Select the books to push to Readest.')
+
+    def check_selected(self):
+        self.run_on_selection(StatusDialog, 'Select the books to check against Readest.')
+
+    def run_on_selection(self, dialog_class, no_selection_message):
         book_ids = self.selected_book_ids()
         if not book_ids:
             return error_dialog(
-                self.gui, 'No books selected', 'Select the books to push to Readest.', show=True
+                self.gui, 'No books selected', no_selection_message, show=True
             )
         if not prefs['tokens'] and not self.login():
             return
-        PushDialog(
+        dialog = dialog_class(
             self.gui,
             self.gui.current_db.new_api,
             book_ids,
             make_client(),
             bool(prefs['include_custom_columns']),
-        ).exec()
+        )
+        dialog.exec()
+        self.apply_marks(dialog.marks)
+
+    def apply_marks(self, marks):
+        """Show the result in the book list as calibre marks (`marked:readest_*`)."""
+        if not marks:
+            return
+        view = self.gui.current_db.data
+        # Repaint the rows we are marking plus the ones we are unmarking.
+        touched = set(view.marked_ids) | set(marks)
+        view.set_marked_ids(merge_marks(view.marked_ids, marks))
+        self.gui.library_view.model().refresh_ids(sorted(touched))
 
     def login(self):
         dialog = LoginDialog(self.gui, make_client())

--- a/apps/readest-calibre-plugin/wire.py
+++ b/apps/readest-calibre-plugin/wire.py
@@ -36,6 +36,27 @@ EXTS = {
 CLOUD_BOOKS_SUBDIR = 'Readest/Books'
 COVER_FILE_NAME = 'cover.png'
 
+# calibre marks: in-memory labels shown in the book list and searchable as
+# `marked:<label>`. Derived from the cloud on every status check, never stored.
+MARK_PREFIX = 'readest_'
+PLAN_MARKS = {
+    'new': MARK_PREFIX + 'missing',
+    'replace': MARK_PREFIX + 'outdated',
+    'update': MARK_PREFIX + 'metadata',
+    'skip': MARK_PREFIX + 'synced',
+}
+
+
+def merge_marks(existing, new_marks):
+    """Our marks replaced wholesale, everyone else's left alone.
+
+    `existing` is calibre's `View.marked_ids` ({book_id: label}), which also
+    holds marks the user set by hand.
+    """
+    merged = {i: l for i, l in (existing or {}).items() if not str(l).startswith(MARK_PREFIX)}
+    merged.update(new_marks or {})
+    return merged
+
 
 def pick_format(available):
     """Best Readest-supported format among calibre's, or None."""

--- a/apps/readest-calibre-plugin/wire.py
+++ b/apps/readest-calibre-plugin/wire.py
@@ -265,6 +265,21 @@ def pick_server_row(hash_row, uuid_row):
     return hash_row if hash_row is not None else uuid_row
 
 
+def should_bulk_list(total_pages, selected_books):
+    """Whether paging the whole storage listing beats per-book lookups.
+
+    Paging costs one request per page no matter how many books are selected;
+    a per-book lookup costs one request per book that needs checking. Measured
+    against a real account both are around a second, so compare the counts.
+    Page 1 is already paid for by the time we can ask, hence the <=.
+    """
+    return total_pages <= max(1, selected_books)
+
+
+def _resolve_blob_present(blob_present, book_hash):
+    return blob_present(book_hash) if callable(blob_present) else bool(blob_present)
+
+
 def plan_push(server_row, wire, local_cover_hash, source_hash, blob_present=True):
     """Decide what to do for one book.
 
@@ -281,13 +296,17 @@ def plan_push(server_row, wire, local_cover_hash, source_hash, blob_present=True
     "Manage Storage" drops the object and its `files` row but never touches
     `books.uploaded_at`, and a row-only push against a missing blob leaves a
     book that shows up in the library but 404s on download.
+
+    It may be a bool, or a callable(book_hash) -> bool for callers that look
+    storage up one book at a time. It is checked last, so a lookup only costs
+    a request when it can still change the answer.
     """
     if server_row is None:
         return {'action': 'new', 'upload_cover': bool(local_cover_hash)}
     if (
         not server_row.get('uploaded_at')
-        or not blob_present
         or row_source_hash(server_row) != source_hash
+        or not _resolve_blob_present(blob_present, server_row['book_hash'])
     ):
         # A replaced book gets a new hash namespace, so it needs its own cover.
         return {'action': 'replace', 'upload_cover': bool(local_cover_hash)}

--- a/apps/readest-calibre-plugin/worker.py
+++ b/apps/readest-calibre-plugin/worker.py
@@ -32,6 +32,7 @@ from calibre_plugins.readest.wire import (
     pick_format,
     pick_server_row,
     plan_push,
+    should_bulk_list,
     tombstone_record,
 )
 
@@ -150,6 +151,8 @@ class _CloudWorker(QThread):
         self.include_custom_columns = include_custom_columns
         self.canceled = False
         self.marks = {}  # book_id -> calibre mark label
+        self.cloud_hashes = None  # whole-account listing, when it is worth paging
+        self._blob_cache = {}  # book_hash -> in storage? (per-book fallback)
 
     def cancel(self):
         self.canceled = True
@@ -164,15 +167,47 @@ class _CloudWorker(QThread):
             return 'Could not reach Readest: %s' % err
         self.by_hash = {r['book_hash']: r for r in rows}
         self.by_uuid = index_rows_by_uuid(rows)
-
-        try:
-            self.cloud_hashes = cloud_book_hashes(self.client.list_all_files())
-        except Exception:
-            # Without the listing we can only trust uploaded_at, which is what
-            # the plugin did before. Stale rows stay stale, but the run goes on.
-            traceback.print_exc()
-            self.cloud_hashes = None
+        self.cloud_hashes = self._bulk_listing()
         return None
+
+    def _bulk_listing(self):
+        """Every book hash in storage, or None to look them up one at a time.
+
+        Paging the whole listing costs a request per page whatever the
+        selection size, so for a handful of books it is far cheaper to ask
+        about just those. Page 1 tells us how long the listing is, and we need
+        it anyway when we do go on to page the rest.
+        """
+        try:
+            files, total_pages = self.client.list_files_page(1)
+            if not should_bulk_list(total_pages, len(self.book_ids)):
+                return None
+            for page in range(2, total_pages + 1):
+                if self.canceled:
+                    return None
+                more, _ = self.client.list_files_page(page)
+                files.extend(more)
+            return cloud_book_hashes(files)
+        except Exception:
+            # Fall back to per-book lookups, which degrade on their own.
+            traceback.print_exc()
+            return None
+
+    def _blob_present(self, book_hash):
+        """Whether this book's file is really in cloud storage."""
+        if self.cloud_hashes is not None:
+            return book_hash in self.cloud_hashes
+        if book_hash not in self._blob_cache:
+            try:
+                self._blob_cache[book_hash] = book_hash in cloud_book_hashes(
+                    self.client.list_files(book_hash)
+                )
+            except Exception:
+                # Without an answer we can only trust uploaded_at, which is
+                # what the plugin did before. The run goes on.
+                traceback.print_exc()
+                self._blob_cache[book_hash] = True
+        return self._blob_cache[book_hash]
 
     def _plan_for(self, book_id):
         """(_BookPlan, '') for one book, or (None, reason) when it cannot be pushed."""
@@ -195,10 +230,7 @@ class _CloudWorker(QThread):
         server_row = pick_server_row(
             self.by_hash.get(source_hash), self.by_uuid.get(uuid) if uuid else None
         )
-        blob_present = self.cloud_hashes is None or (
-            server_row is not None and server_row['book_hash'] in self.cloud_hashes
-        )
-        plan = plan_push(server_row, wire, cover_hash, source_hash, blob_present)
+        plan = plan_push(server_row, wire, cover_hash, source_hash, self._blob_present)
         return (
             _BookPlan(
                 mi, fmt, path, source_hash, cover_bytes, cover_hash,
@@ -284,6 +316,8 @@ class PushWorker(_CloudWorker):
         self.by_hash[record['hash']] = row
         if uuid:
             self.by_uuid[uuid] = row
+        # We just uploaded it, so don't go asking storage about it again.
+        self._blob_cache[record['hash']] = True
         if self.cloud_hashes is not None:
             self.cloud_hashes.add(record['hash'])
 

--- a/apps/readest-calibre-plugin/worker.py
+++ b/apps/readest-calibre-plugin/worker.py
@@ -9,6 +9,7 @@ import shutil
 import tempfile
 import time
 import traceback
+from collections import namedtuple
 
 from qt.core import QThread, pyqtSignal
 
@@ -20,6 +21,7 @@ from calibre_plugins.readest.api import (
 )
 from calibre_plugins.readest.wire import (
     EXTS,
+    PLAN_MARKS,
     book_file_name,
     build_wire_book,
     cloud_book_hashes,
@@ -40,6 +42,30 @@ STATUS_LABELS = {
     'skipped': 'Up to date',
     'failed': 'Failed',
 }
+PUSH_ORDER = ('uploaded', 'replaced', 'updated', 'skipped', 'failed')
+
+# A status check reports plan_push's actions verbatim, so its keys are the
+# plan names rather than the past-tense push outcomes.
+CHECK_LABELS = {
+    'skip': 'In Readest',
+    'update': 'Metadata differs',
+    'replace': 'Out of date',
+    'new': 'Not in Readest',
+    'failed': 'Failed',
+}
+CHECK_ORDER = ('skip', 'update', 'replace', 'new', 'failed')
+
+# Every push outcome except a failure leaves the book present in the cloud.
+PUSHED_MARK = PLAN_MARKS['skip']
+
+_BookPlan = namedtuple(
+    '_BookPlan',
+    'mi fmt path source_hash cover_bytes cover_hash now_ms wire uuid server_row plan',
+)
+
+
+def _lower_first(text):
+    return text[:1].lower() + text[1:]
 
 
 def _jsonable(value):
@@ -106,7 +132,12 @@ def _embed_metadata_copy(path, mi, fmt):
     return tmp
 
 
-class PushWorker(QThread):
+class _CloudWorker(QThread):
+    """Pulls the cloud state once, then classifies each selected book.
+
+    `PushWorker` acts on the plan; `StatusWorker` only reports it.
+    """
+
     progress = pyqtSignal(int, int)  # done, total
     book_status = pyqtSignal(int, str, str)  # book_id, status key, detail
     done = pyqtSignal(bool, str)  # ok, message
@@ -118,29 +149,77 @@ class PushWorker(QThread):
         self.client = client
         self.include_custom_columns = include_custom_columns
         self.canceled = False
+        self.marks = {}  # book_id -> calibre mark label
 
     def cancel(self):
         self.canceled = True
 
-    def run(self):
+    def _load_cloud_state(self):
+        """Server rows + storage listing. Returns an error message, or None."""
         try:
             rows = [r for r in self.client.pull_books() if r.get('book_hash')]
-            self.by_hash = {r['book_hash']: r for r in rows}
-            self.by_uuid = index_rows_by_uuid(rows)
         except AuthRequiredError as err:
-            self.done.emit(False, 'Please log in to Readest first. (%s)' % err)
-            return
+            return 'Please log in to Readest first. (%s)' % err
         except Exception as err:
-            self.done.emit(False, 'Could not reach Readest: %s' % err)
-            return
+            return 'Could not reach Readest: %s' % err
+        self.by_hash = {r['book_hash']: r for r in rows}
+        self.by_uuid = index_rows_by_uuid(rows)
 
         try:
             self.cloud_hashes = cloud_book_hashes(self.client.list_all_files())
         except Exception:
             # Without the listing we can only trust uploaded_at, which is what
-            # the plugin did before. Stale rows stay stale, but the push runs.
+            # the plugin did before. Stale rows stay stale, but the run goes on.
             traceback.print_exc()
             self.cloud_hashes = None
+        return None
+
+    def _plan_for(self, book_id):
+        """(_BookPlan, '') for one book, or (None, reason) when it cannot be pushed."""
+        mi = self.db.get_metadata(book_id)
+        fmt = pick_format(self.db.formats(book_id))
+        if fmt is None:
+            return None, 'No Readest-supported format (EPUB, PDF, ...)'
+        path = self.db.format_abspath(book_id, fmt)
+        if not path or not os.path.exists(path):
+            return None, 'Book file is missing from the calibre library'
+
+        source_hash = partial_md5(path)
+        cover_bytes = self.db.cover(book_id)
+        cover_hash = partial_md5_bytes(cover_bytes) if cover_bytes else None
+
+        now_ms = int(time.time() * 1000)
+        book = _book_dict(mi, self.include_custom_columns, source_hash)
+        wire = build_wire_book(book, source_hash, fmt, now_ms)
+        uuid = (book.get('uuid') or '').lower()
+        server_row = pick_server_row(
+            self.by_hash.get(source_hash), self.by_uuid.get(uuid) if uuid else None
+        )
+        blob_present = self.cloud_hashes is None or (
+            server_row is not None and server_row['book_hash'] in self.cloud_hashes
+        )
+        plan = plan_push(server_row, wire, cover_hash, source_hash, blob_present)
+        return (
+            _BookPlan(
+                mi, fmt, path, source_hash, cover_bytes, cover_hash,
+                now_ms, wire, uuid, server_row, plan,
+            ),
+            '',
+        )
+
+    def _summary(self, counts, labels, order, empty):
+        parts = ', '.join(
+            '%d %s' % (counts[key], _lower_first(labels[key])) for key in order if key in counts
+        )
+        return parts or empty
+
+
+class PushWorker(_CloudWorker):
+    def run(self):
+        error = self._load_cloud_state()
+        if error:
+            self.done.emit(False, error)
+            return
 
         counts = {}
         for index, book_id in enumerate(self.book_ids):
@@ -161,15 +240,17 @@ class PushWorker(QThread):
                 traceback.print_exc()
                 status, detail = 'failed', str(err)
             counts[status] = counts.get(status, 0) + 1
+            if status != 'failed':
+                # Whatever the outcome, the book is now in the cloud, so keep
+                # any marks a previous status check left from going stale.
+                self.marks[book_id] = PUSHED_MARK
             self.book_status.emit(book_id, status, detail)
             self.progress.emit(index + 1, len(self.book_ids))
 
-        summary = ', '.join(
-            '%d %s' % (counts[key], STATUS_LABELS[key].lower())
-            for key in ('uploaded', 'replaced', 'updated', 'skipped', 'failed')
-            if key in counts
+        self.done.emit(
+            'failed' not in counts,
+            self._summary(counts, STATUS_LABELS, PUSH_ORDER, 'Nothing to push.'),
         )
-        self.done.emit('failed' not in counts, summary or 'Nothing to push.')
 
     def _upload(self, file_name, fileobj, size, book_hash):
         upload = self.client.get_upload_url(file_name, size, book_hash)
@@ -207,29 +288,14 @@ class PushWorker(QThread):
             self.cloud_hashes.add(record['hash'])
 
     def _push_one(self, book_id):
-        mi = self.db.get_metadata(book_id)
-        fmt = pick_format(self.db.formats(book_id))
-        if fmt is None:
-            return 'failed', 'No Readest-supported format (EPUB, PDF, ...)'
-        path = self.db.format_abspath(book_id, fmt)
-        if not path or not os.path.exists(path):
-            return 'failed', 'Book file is missing from the calibre library'
+        ctx, reason = self._plan_for(book_id)
+        if ctx is None:
+            return 'failed', reason
 
-        source_hash = partial_md5(path)
-        cover_bytes = self.db.cover(book_id)
-        cover_hash = partial_md5_bytes(cover_bytes) if cover_bytes else None
-
-        now_ms = int(time.time() * 1000)
-        book = _book_dict(mi, self.include_custom_columns, source_hash)
-        wire = build_wire_book(book, source_hash, fmt, now_ms)
-        uuid = (book.get('uuid') or '').lower()
-        server_row = pick_server_row(
-            self.by_hash.get(source_hash), self.by_uuid.get(uuid) if uuid else None
-        )
-        blob_present = self.cloud_hashes is None or (
-            server_row is not None and server_row['book_hash'] in self.cloud_hashes
-        )
-        plan = plan_push(server_row, wire, cover_hash, source_hash, blob_present)
+        mi, fmt, path = ctx.mi, ctx.fmt, ctx.path
+        cover_bytes, cover_hash = ctx.cover_bytes, ctx.cover_hash
+        now_ms, wire, uuid, server_row = ctx.now_ms, ctx.wire, ctx.uuid, ctx.server_row
+        plan = ctx.plan
 
         if plan['action'] == 'skip':
             return 'skipped', ''
@@ -280,3 +346,35 @@ class PushWorker(QThread):
         self.client.push_books([record])
         self._remember(record, uuid)
         return 'updated', ''
+
+
+class StatusWorker(_CloudWorker):
+    """Plans every selected book without uploading, and marks the results."""
+
+    def run(self):
+        error = self._load_cloud_state()
+        if error:
+            self.done.emit(False, error)
+            return
+
+        counts = {}
+        for index, book_id in enumerate(self.book_ids):
+            if self.canceled:
+                self.done.emit(False, 'Canceled.')
+                return
+            try:
+                ctx, reason = self._plan_for(book_id)
+                status, detail = (ctx.plan['action'], '') if ctx else ('failed', reason)
+            except Exception as err:
+                traceback.print_exc()
+                status, detail = 'failed', str(err)
+            if status in PLAN_MARKS:
+                self.marks[book_id] = PLAN_MARKS[status]
+            counts[status] = counts.get(status, 0) + 1
+            self.book_status.emit(book_id, status, detail)
+            self.progress.emit(index + 1, len(self.book_ids))
+
+        self.done.emit(
+            'failed' not in counts,
+            self._summary(counts, CHECK_LABELS, CHECK_ORDER, 'Nothing to check.'),
+        )


### PR DESCRIPTION
Rebased onto `main` now that #5325 has merged. Builds on the storage verification added there.

Four commits: the feature, then three things that came out of running it against a real account.

---

## 1. `feat(calibre)`: Check Readest status action

A menu action that runs the same planner as a push over the selected books, uploads nothing, and records the answer as calibre marks:

| `plan_push` action | mark | shown as |
|---|---|---|
| `skip` | `readest_synced` | In Readest |
| `update` | `readest_metadata` | Metadata differs |
| `replace` | `readest_outdated` | Out of date |
| `new` | `readest_missing` | Not in Readest |

The marks appear as icons in the book list and are searchable, so `marked:readest_missing` selects exactly the books that still need pushing. That is the point of the feature — the badge is secondary to the selection.

**Why marks and not a custom column.** Marks are in-memory and derived from the cloud on every run, so they cannot silently rot — the same class of bug as the stale `uploaded_at` fixed in #5325. A custom column would be persistent and sortable, but it mutates the user's library schema and would drift with nothing to correct it. Still available as a follow-up if anyone asks.

`merge_marks` replaces only the `readest_` labels, so marks the user set by hand survive a check. A push also marks what it pushed, otherwise a prior check's marks would go stale the moment you upload.

`plan_push` already produced all four states, so `PushWorker` and the new `StatusWorker` now share `_CloudWorker` rather than duplicating the classification.

## 2. `fix(calibre)`: plugin version comes from the app's package.json

`PLUGIN_VERSION` was a committed `(0, 1, 0)` placeholder that only release CI rewrote, so anything built locally installed into calibre as `Readest Sync (0, 1, 0)` — which is what Preferences > Plugins then reports.

`apps/readest-app/package.json` is now the source of truth for local builds too. It already was for releases: `release_version` is `require('./apps/readest-app/package.json').version`, so `make zip` and CI read the same value and cannot disagree. `sync_version.py` writes only on drift, so it is an order-only prerequisite of the zip and never forces a rebuild. A unit test asserts the committed literal matches package.json, so drift fails the suite instead of reaching a user's calibre.

## 3. `perf(calibre)`: per-book blob lookups for small selections

Checking a single book took 25s. Timed against a real account, all of it was setup:

| | time |
|---|---|
| `pull_books` | 3.17s (1362 rows) |
| `list_all_files` | **22.39s** (1580 files, 16 pages) |

A one-book check was paying to page the entire storage listing. The endpoint costs about a second per request almost regardless of rows returned (1 file 0.93s, 100 files 1.23s), and a single-hash lookup costs about the same — so page 1 now decides: if the listing is longer than the selection, ask storage per book instead, cached per run.

`plan_push` takes a callable for that and consults it **last**, after the free checks, so a book already headed for `new`/`replace` never spends a request.

| selection | before | after |
|---|---|---|
| 1 book | 25.6s | **4.84s** |
| 5 books | 25.6s | 6.82s |
| 40 books | 25.6s | 24.2s (takes the listing, by design) |

Per-book lookups key on `files.book_hash`, which is nullable. Checked against a real account: of 1580 files, the 50 with a null hash are all dictionary replicas, never book blobs.

## 4. `perf(storage)`: raise the listing page cap to 1000

Since the cost is per-request rather than per-row, the cap was the real constraint. `list.ts` clamped `pageSize` to 100; 1530 files meant 16 requests.

Bumping the number alone would have broken the endpoint. The group expansion runs `.in('book_hash', hashes)` with one entry per distinct hash on the page, and Supabase renders that into the query string — a full page at the new cap would be tens of kilobytes of URL, which PostgREST rejects. It now goes out in batches of 100, in parallel, merging into the same `fileMap` as before. Worst case ~21 subrequests per listing call, well inside the Workers limit.

`resolvePageSize` also floors the size at 1, so a negative `pageSize` can no longer produce an inverted `.range()` and a 500. Pre-existing, fixed in passing.

**Blast radius:** the in-app Storage Manager asks for `pageSize: 20` and is unaffected. The plugin already asks for 1000 and paginates off the `totalPages` the server reports, so it speeds up as soon as this deploys and stays correct against servers that still clamp.

---

## Testing

- Plugin `make test`: **105 passed** (83 at the base of this branch)
- `pnpm test`: 7802 passed, 7 skipped
- `pnpm lint`: clean

Verified against a real calibre 8 install and library via `calibre-debug`, since calibre's GUI cannot be driven from this environment:

- the plugin loads and exposes the new symbols
- `_plan_for` classifies real books, CJK titles included
- the #5325 fix reproduces on real data: same row, blob present → `skip`; blob deleted → `replace`
- `merge_marks` against a live `View`: a user's `true` mark survives, stale `readest_*` marks are dropped
- `model.refresh_ids(...)` is the correct repaint call and does not raise for ids filtered out of the current view
- `model.marked_text_icon_for(...)` renders an icon for all four custom labels
- `make zip` produces `Readest-0.11.20.calibre-plugin.zip`; `calibre-customize -l` reports `Readest Sync (0, 11, 20)`
- the timings in sections 3 and 4 are measured, not estimated

**Not verified:** the visual result in a running calibre window, and the section 4 speedup in production — that needs the worker deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
