### PR TITLE
fix(macos): restore close-to-hide behavior on Tahoe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "block",
  "cocoa",
  "discord-rich-presence",
+ "dispatch2",
  "futures",
  "futures-util",
  "image",

--- a/apps/readest-app/src-tauri/Cargo.toml
+++ b/apps/readest-app/src-tauri/Cargo.toml
@@ -129,6 +129,7 @@ objc = "0.2.7"
 objc-foundation = "0.1.1"
 objc_id = "0.1.1"
 block = "0.1.6"
+dispatch2 = "0.3"
 objc2 = "0.6"
 objc2-authentication-services = "0.3"
 objc2-foundation = { version = "0.3", features = ["NSError", "NSArray"] }

--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -708,26 +708,29 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             {
                 let window = win_builder.build().unwrap();
-                // On macOS, closing a window (via Cmd+W or the red traffic light) should
-                // not quit the app — only Cmd+Q should. Hide the window instead so the
-                // app keeps running in the dock, and restore it when the user reopens
-                // the app from the dock.
+                // On macOS, closing a window (via Cmd+W or the red traffic light)
+                // should not quit the app — only Cmd+Q should — and normally hides
+                // instead of minimizing (#5240): the app keeps running in the dock
+                // and the window is restored when the user reopens the app from the
+                // dock. On Tahoe the hide is defensive against the `orderOut:`
+                // phantom-window regression (#4875); see
+                // `macos::window::hide_main_window` for the fullscreen-failure
+                // fallback.
                 let window_for_close = window.clone();
-                window.on_window_event(move |event| {
-                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                window.on_window_event(move |event| match event {
+                    tauri::WindowEvent::CloseRequested { api, .. } => {
                         api.prevent_close();
-                        // macOS 26 (Tahoe) regressed `NSWindow` ordering: `orderOut:`
-                        // (what `hide()` maps to) can leave a focused black phantom
-                        // window on screen instead of hiding it (#4875). Minimize
-                        // instead on Tahoe — a different AppKit path that still keeps
-                        // the app in the dock and preserves the open book. The Reopen
-                        // handler below already unminimizes on dock reopen.
-                        if macos::os_version::is_macos_tahoe_or_later() {
-                            let _ = window_for_close.minimize();
-                        } else {
-                            let _ = window_for_close.hide();
-                        }
+                        macos::window::hide_main_window(&window_for_close);
                     }
+                    // Safety net for JS-side `show()` callers (e.g.
+                    // `ensureMainLibraryWindow` in src/utils/nav.ts re-shows a hidden
+                    // main window from a reader window without a dock Reopen): the
+                    // window can only become key after it is back on screen, so any
+                    // pending defensively-zeroed frame must be restored by now.
+                    tauri::WindowEvent::Focused(true) => {
+                        macos::window::restore_main_window_frame(&window_for_close);
+                    }
+                    _ => {}
                 });
             }
 
@@ -766,9 +769,21 @@ pub fn run() {
                         ..
                     } => {
                         if let Some(window) = app_handle.get_webview_window("main") {
+                            // Undo a pending Tahoe defensive hide (zeroed frame) before
+                            // showing so the window reappears at its real position and
+                            // size. No-op when the window was hidden plainly.
+                            macos::window::restore_main_window_frame(&window);
                             let _ = window.show();
                             let _ = window.set_focus();
                             let _ = window.unminimize();
+                        }
+                    }
+                    // A programmatic exit emits ExitRequested before the window-state
+                    // plugin performs its final save. Restore any zeroed frame while
+                    // the window is still hidden so live geometry remains valid.
+                    tauri::RunEvent::ExitRequested { .. } => {
+                        if let Some(window) = app_handle.get_webview_window("main") {
+                            macos::window::restore_main_window_frame(&window);
                         }
                     }
                     _ => {}

--- a/apps/readest-app/src-tauri/src/macos/mod.rs
+++ b/apps/readest-app/src-tauri/src/macos/mod.rs
@@ -4,3 +4,4 @@ pub mod os_version;
 pub mod safari_auth;
 pub mod system_dictionary;
 pub mod traffic_light;
+pub mod window;

--- a/apps/readest-app/src-tauri/src/macos/os_version.rs
+++ b/apps/readest-app/src-tauri/src/macos/os_version.rs
@@ -3,14 +3,15 @@
 //! macOS 26 (Tahoe) regressed `NSWindow` ordering so that `orderOut:` —
 //! which Tauri's `WebviewWindow::hide()` maps to — can leave a focused
 //! black phantom window on screen instead of hiding it. See issue #4875.
-//! On Tahoe we minimize the window instead, a different AppKit path that
-//! still keeps the app in the dock and preserves the open book.
+//! The workaround is intentionally scoped to major version 26. A future
+//! macOS release should use the normal AppKit path unless it is independently
+//! shown to have the same regression.
 
 use objc::{class, msg_send, sel, sel_impl};
 
-/// Returns true when `major` is macOS Tahoe (26) or later.
-pub(crate) fn is_tahoe_or_later(major: i64) -> bool {
-    major >= 26
+/// Returns true when `major` is macOS Tahoe (26).
+pub(crate) fn is_tahoe(major: i64) -> bool {
+    major == 26
 }
 
 /// Reads the running macOS major version via `NSProcessInfo`.
@@ -30,24 +31,23 @@ fn macos_major_version() -> i64 {
     }
 }
 
-/// True when running on macOS Tahoe (26) or later.
-pub fn is_macos_tahoe_or_later() -> bool {
-    is_tahoe_or_later(macos_major_version())
+/// True when running on macOS Tahoe (26).
+pub fn is_macos_tahoe() -> bool {
+    is_tahoe(macos_major_version())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::is_tahoe_or_later;
+    use super::is_tahoe;
 
     #[test]
-    fn detects_tahoe_and_later() {
-        assert!(is_tahoe_or_later(26)); // Tahoe
-        assert!(is_tahoe_or_later(27));
+    fn detects_tahoe() {
+        assert!(is_tahoe(26));
     }
 
     #[test]
-    fn rejects_pre_tahoe() {
-        assert!(!is_tahoe_or_later(25)); // Sequoia
-        assert!(!is_tahoe_or_later(15)); // older numbering
+    fn rejects_other_major_versions() {
+        assert!(!is_tahoe(25));
+        assert!(!is_tahoe(27));
     }
 }

--- a/apps/readest-app/src-tauri/src/macos/traffic_light.rs
+++ b/apps/readest-app/src-tauri/src/macos/traffic_light.rs
@@ -1,3 +1,4 @@
+use dispatch2::DispatchQueue;
 use objc::{msg_send, sel, sel_impl};
 use rand::{distributions::Alphanumeric, Rng};
 use tauri::{
@@ -388,6 +389,22 @@ pub fn setup_traffic_light_positioner<R: Runtime>(window: Window<R>) {
 
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowDidExitFullScreen: notification];
+
+                // Tao restores the normal frame in its delegate callback above
+                // and can enqueue a maximize restoration. Defer the defensive
+                // hide on that same serial GCD queue so its frame mutation is
+                // ordered after Tao's style-mask and maximize work.
+                let mut main_window = None;
+                with_window_state(this, |state: &mut WindowState<R>| {
+                    if state.window.label() == "main" {
+                        main_window = Some(state.window.clone());
+                    }
+                });
+                if let Some(main_window) = main_window {
+                    DispatchQueue::main().exec_async(move || {
+                        super::window::finish_pending_fullscreen_hide(&main_window);
+                    });
+                }
             }
         }
         extern "C" fn on_window_will_exit_full_screen<R: Runtime>(
@@ -416,6 +433,17 @@ pub fn setup_traffic_light_positioner<R: Runtime>(window: Window<R>) {
                 let super_del: id = *this.get_ivar("super_delegate");
                 let _: () = msg_send![super_del, windowDidFailToEnterFullScreen: window];
             }
+        }
+        extern "C" fn on_window_did_fail_to_exit_full_screen<R: Runtime>(
+            this: &Object,
+            _cmd: Sel,
+            _window: id,
+        ) {
+            with_window_state(this, |state: &mut WindowState<R>| {
+                if state.window.label() == "main" {
+                    super::window::finish_failed_fullscreen_hide(&state.window);
+                }
+            });
         }
         extern "C" fn on_effective_appearance_did_change(
             this: &Object,
@@ -479,6 +507,7 @@ pub fn setup_traffic_light_positioner<R: Runtime>(window: Window<R>) {
             (windowDidExitFullScreen:) => on_window_did_exit_full_screen::<R> as extern "C" fn(&Object, Sel, id),
             (windowWillExitFullScreen:) => on_window_will_exit_full_screen::<R> as extern "C" fn(&Object, Sel, id),
             (windowDidFailToEnterFullScreen:) => on_window_did_fail_to_enter_full_screen as extern "C" fn(&Object, Sel, id),
+            (windowDidFailToExitFullScreen:) => on_window_did_fail_to_exit_full_screen::<R> as extern "C" fn(&Object, Sel, id),
             (effectiveAppearanceDidChange:) => on_effective_appearance_did_change as extern "C" fn(&Object, Sel, id),
             (effectiveAppearanceDidChangedOnMainThread:) => on_effective_appearance_did_changed_on_main_thread as extern "C" fn(&Object, Sel, id)
         }))

--- a/apps/readest-app/src-tauri/src/macos/window.rs
+++ b/apps/readest-app/src-tauri/src/macos/window.rs
@@ -1,0 +1,276 @@
+//! Close-to-hide for the macOS main window.
+//!
+//! Closing the main window (red traffic light or Cmd+W) hides it: the
+//! window vanishes, the app stays in the Dock and the open book stays
+//! loaded. On every successful AppKit path it must hide rather than
+//! minimize — mapping close to minimize on Tahoe (PR #4890) made the red
+//! button behave like the yellow one (#5240) — and it must never quit.
+//!
+//! On macOS 26 (Tahoe) a plain `hide()` is not enough: the OS can leave
+//! a focused black phantom window on screen (#4875). The defensive path
+//! adapts kitty's zero-frame workaround to Readest's reusable main
+//! window, restoring its frame before the next show.
+//!
+//! If AppKit itself refuses to leave fullscreen, neither the zero-frame
+//! workaround nor a plain `hide()` is safe. That exceptional path alone
+//! minimizes as a conservative fallback and is undone by the existing
+//! dock-reopen handler.
+//!
+//! Thread-safety: everything here runs on the AppKit main thread —
+//! `on_window_event` closures and the `RunEvent` run-loop closure are
+//! both dispatched from the main event loop — so the raw `msg_send!`
+//! calls are sound. The `Mutex` around the saved frame exists only to
+//! make the `static` safe, mirroring the statics in `traffic_light.rs`.
+
+use cocoa::appkit::NSWindowStyleMask;
+use cocoa::base::{id, nil, NO, YES};
+use cocoa::foundation::NSUInteger;
+use cocoa::foundation::{NSPoint, NSRect, NSSize};
+use objc::{msg_send, sel, sel_impl};
+use std::sync::Mutex;
+
+/// The main window's real frame, captured immediately before the Tahoe
+/// defensive hide zeroes it. `None` while no defensive hide is pending.
+static SAVED_MAIN_FRAME: Mutex<Option<NSRect>> = Mutex::new(None);
+
+/// Fullscreen transitions are asynchronous. Keep the close request pending
+/// until the AppKit delegate reports success or failure.
+static FULLSCREEN_HIDE_STATE: Mutex<FullscreenHideState> =
+    Mutex::new(FullscreenHideState { pending: false });
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MainWindowCloseAction {
+    Hide,
+    DefensiveHide,
+    ExitFullscreenThenDefensiveHide,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FullscreenHideCompletion {
+    DefensiveHide,
+    /// Last-resort fallback when AppKit refuses to leave fullscreen. A plain
+    /// hide would re-enter Tahoe's phantom-window path (#4875).
+    Minimize,
+}
+
+#[derive(Debug, Default)]
+struct FullscreenHideState {
+    pending: bool,
+}
+
+impl FullscreenHideState {
+    fn begin(&mut self) {
+        self.pending = true;
+    }
+
+    fn cancel(&mut self) {
+        self.pending = false;
+    }
+
+    fn finish(&mut self, exit_succeeded: bool) -> Option<FullscreenHideCompletion> {
+        if !std::mem::take(&mut self.pending) {
+            return None;
+        }
+        Some(if exit_succeeded {
+            FullscreenHideCompletion::DefensiveHide
+        } else {
+            FullscreenHideCompletion::Minimize
+        })
+    }
+}
+
+fn main_window_close_action(
+    tahoe_workaround_required: bool,
+    fullscreen: bool,
+) -> MainWindowCloseAction {
+    if tahoe_workaround_required && fullscreen {
+        MainWindowCloseAction::ExitFullscreenThenDefensiveHide
+    } else if tahoe_workaround_required {
+        MainWindowCloseAction::DefensiveHide
+    } else {
+        MainWindowCloseAction::Hide
+    }
+}
+
+/// Hides the main window on close. Called from the `CloseRequested`
+/// handler in `lib.rs` (main thread).
+pub fn hide_main_window(window: &tauri::WebviewWindow) {
+    let fullscreen = is_fullscreen_or_transitioning(window);
+    match main_window_close_action(super::os_version::is_macos_tahoe(), fullscreen) {
+        MainWindowCloseAction::Hide => {
+            let _ = window.hide();
+        }
+        MainWindowCloseAction::DefensiveHide => {
+            FULLSCREEN_HIDE_STATE.lock().unwrap().cancel();
+            defensive_hide(&window.as_ref().window());
+        }
+        MainWindowCloseAction::ExitFullscreenThenDefensiveHide => {
+            FULLSCREEN_HIDE_STATE.lock().unwrap().begin();
+            if let Err(error) = window.set_fullscreen(false) {
+                log::error!("Failed to leave fullscreen before hiding main window: {error}");
+                FULLSCREEN_HIDE_STATE.lock().unwrap().cancel();
+                // A plain hide can produce Tahoe's phantom window while AppKit
+                // still owns the fullscreen frame. This is intentionally the
+                // only path where close degrades to minimize.
+                let _ = window.minimize();
+            }
+        }
+    }
+}
+
+/// Completes a close requested while fullscreen after AppKit has returned the
+/// window to its normal Space. Called directly from the traffic-light
+/// delegate's `windowDidExitFullScreen:` callback.
+pub fn finish_pending_fullscreen_hide<R: tauri::Runtime>(window: &tauri::Window<R>) {
+    if FULLSCREEN_HIDE_STATE.lock().unwrap().finish(true)
+        == Some(FullscreenHideCompletion::DefensiveHide)
+    {
+        defensive_hide(window);
+    }
+}
+
+/// Guarantees that a failed fullscreen transition cannot leave a close request
+/// pending forever. AppKit still owns the fullscreen frame, so changing it to
+/// 0x0 is unsafe here, while a plain hide can reproduce Tahoe's phantom
+/// window. Minimize is therefore the safest last-resort fallback.
+pub fn finish_failed_fullscreen_hide<R: tauri::Runtime>(window: &tauri::Window<R>) {
+    if FULLSCREEN_HIDE_STATE.lock().unwrap().finish(false)
+        == Some(FullscreenHideCompletion::Minimize)
+    {
+        log::warn!("Fullscreen exit failed; minimizing the main window as a safe fallback");
+        let _ = window.minimize();
+    }
+}
+
+fn is_fullscreen_or_transitioning(window: &tauri::WebviewWindow) -> bool {
+    // tao updates its fullscreen state at the start of a transition. The
+    // native style bit covers the opposite half of an exit transition, while
+    // tao's state covers the start of an enter transition.
+    if window.is_fullscreen().unwrap_or(false) {
+        return true;
+    }
+    let Ok(ns_window) = window.ns_window() else {
+        return false;
+    };
+    unsafe {
+        let style_mask: NSUInteger = msg_send![ns_window as id, styleMask];
+        style_mask & NSWindowStyleMask::NSFullScreenWindowMask.bits() != 0
+    }
+}
+
+/// Tahoe defensive hide: zero the frame, then order out, both in the
+/// same runloop turn.
+///
+/// The zero rect keeps the old frame's *top-left* corner: AppKit frames
+/// are bottom-left anchored, so the top edge is `origin.y + height`.
+/// That keeps tao's `outer_position()` (top-left based) unchanged while
+/// hidden. The tao delegate is suspended only for the frame mutation so
+/// its resize/move listeners (including `tauri-plugin-window-state`) never
+/// observe the temporary 0x0 geometry. It is restored before `orderOut:`
+/// so focus-loss events still flow normally.
+fn defensive_hide<R: tauri::Runtime>(window: &tauri::Window<R>) {
+    let Ok(ns_window) = window.ns_window() else {
+        let _ = window.hide();
+        return;
+    };
+    let ns_window = ns_window as id;
+    unsafe {
+        let frame: NSRect = msg_send![ns_window, frame];
+        let mut saved_frame = SAVED_MAIN_FRAME.lock().unwrap();
+        if saved_frame.is_some() {
+            let _: () = msg_send![ns_window, orderOut: nil];
+            return;
+        }
+        *saved_frame = Some(frame);
+        drop(saved_frame);
+
+        let zero = NSRect::new(
+            NSPoint::new(frame.origin.x, frame.origin.y + frame.size.height),
+            NSSize::new(0.0, 0.0),
+        );
+
+        // A 0x0 resize event would overwrite the window-state plugin's cache.
+        // Suppress only this temporary geometry notification; restoring the
+        // delegate before orderOut keeps normal focus and visibility events.
+        let delegate: id = msg_send![ns_window, delegate];
+        let _: () = msg_send![ns_window, setDelegate: nil];
+        let _: () = msg_send![ns_window, setFrame: zero display: NO];
+        let _: () = msg_send![ns_window, setDelegate: delegate];
+        let _: () = msg_send![ns_window, orderOut: nil];
+    }
+}
+
+/// Restores the frame saved by the defensive hide; no-op when none is
+/// pending. Called from the dock `Reopen` handler before `show()`, and
+/// from `Focused(true)` as a safety net for JS-side `show()` callers
+/// (e.g. `ensureMainLibraryWindow` in `src/utils/nav.ts`).
+pub fn restore_main_window_frame(window: &tauri::WebviewWindow) {
+    FULLSCREEN_HIDE_STATE.lock().unwrap().cancel();
+    let Ok(ns_window) = window.ns_window() else {
+        return;
+    };
+    let mut saved_frame = SAVED_MAIN_FRAME.lock().unwrap();
+    let Some(frame) = saved_frame.as_ref().copied() else {
+        return;
+    };
+    unsafe {
+        let _: () = msg_send![ns_window as id, setFrame: frame display: YES];
+    }
+    saved_frame.take();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        main_window_close_action, FullscreenHideCompletion, FullscreenHideState,
+        MainWindowCloseAction,
+    };
+
+    #[test]
+    fn hides_plainly_without_the_tahoe_workaround() {
+        assert_eq!(
+            main_window_close_action(false, false),
+            MainWindowCloseAction::Hide
+        );
+    }
+
+    #[test]
+    fn hides_defensively_on_tahoe() {
+        assert_eq!(
+            main_window_close_action(true, false),
+            MainWindowCloseAction::DefensiveHide
+        );
+    }
+
+    #[test]
+    fn exits_fullscreen_before_the_defensive_hide() {
+        assert_eq!(
+            main_window_close_action(true, true),
+            MainWindowCloseAction::ExitFullscreenThenDefensiveHide
+        );
+    }
+
+    #[test]
+    fn successful_fullscreen_exit_consumes_pending_close_as_defensive_hide() {
+        let mut state = FullscreenHideState::default();
+        state.begin();
+
+        assert_eq!(
+            state.finish(true),
+            Some(FullscreenHideCompletion::DefensiveHide)
+        );
+        assert_eq!(state.finish(true), None);
+    }
+
+    #[test]
+    fn failed_fullscreen_exit_consumes_pending_close_as_safe_minimize() {
+        let mut state = FullscreenHideState::default();
+        state.begin();
+
+        assert_eq!(
+            state.finish(false),
+            Some(FullscreenHideCompletion::Minimize)
+        );
+        assert_eq!(state.finish(false), None);
+    }
+}


### PR DESCRIPTION
## Problem

On macOS 26 (Tahoe), the workaround added in #4890 maps the main window's red close button and `Cmd+W` to `minimize()` in order to avoid the black phantom window from #4875.

That avoids the Tahoe `orderOut:` regression, but it also makes the red close button behave exactly like the yellow minimize button: the window is placed in the Dock instead of being hidden. The intended Readest behavior is to hide the main window, keep the application running, and preserve the open book until the user reopens the app from the Dock.

## Root cause

Simply reverting to `WebviewWindow::hide()` would restore the correct close semantics but could also restore the Tahoe phantom-window regression. Tahoe therefore needs a defensive hide path that removes the native window without turning close into minimize.

## Fix

- Route main-window close handling through a dedicated macOS window module.
- Keep the normal Tauri `hide()` path outside macOS major version 26.
- On Tahoe, save the native frame, temporarily suppress delegate geometry notifications, set a zero-sized frame anchored at the same top-left position, and then call `orderOut:`.
- Restore the saved frame before Dock reopen, JS-side show/focus, or final window-state persistence.
- When closing from fullscreen, leave fullscreen first and complete the defensive hide after Tao's frame/style restoration on the same serial main dispatch queue.
- If AppKit refuses to leave fullscreen, minimize only as a last-resort safety fallback rather than risking a live fullscreen phantom window.
- Scope the workaround to major version 26 instead of assuming future macOS releases need it.

`dispatch2` is a direct macOS-only dependency because the fullscreen completion must be ordered on the same main GCD queue Tao uses for its deferred frame/maximize restoration. The crate was already present transitively through Tao; the lockfile only gains Readest's direct dependency edge.

## User impact

- The red close button and `Cmd+W` hide the main window instead of placing it in the Dock.
- The app remains running and the current book stays loaded.
- The yellow minimize button continues to minimize normally.
- Clicking the app's Dock icon restores the original frame and focuses the window.

## Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm test:pr:web:unit` — 594 files passed, 3 skipped; 7,793 tests passed, 7 skipped
- `pnpm build`
- `cargo fmt --check`
- `cargo clippy -p Readest --no-deps -- -D warnings`
- `cargo test -p Readest --lib` — 86 passed, including 7 macOS version/close-state tests
- Release Tauri application bundle built successfully
- Manually verified on macOS 26.5.2:
  - normal and fullscreen red-button close
  - `Cmd+W`
  - no minimized Dock window after a successful close
  - Dock reopen restores the original frame and focus
  - the open book remains available after reopen

The native workaround applies to macOS 26.0–26.5 by major-version gate. Manual hardware verification was performed on 26.5.2; earlier Tahoe point releases are covered by the same code path and automated state tests but were not individually tested on hardware.

No user documentation is changed because this restores the previously intended macOS behavior and adds no new setting, command, or public API.

Closes #5240
