### PR TITLE
fix(auth): move ProviderLogin out of the auth page module

### DIFF
--- a/apps/readest-app/src/__tests__/app/auth-page.test.tsx
+++ b/apps/readest-app/src/__tests__/app/auth-page.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@supabase/auth-ui-react', () => ({ Auth: () => null }));
 vi.mock('@supabase/auth-ui-shared', () => ({ ThemeSupa: {} }));
 
-import { ProviderLogin } from '@/app/auth/page';
+import { ProviderLogin } from '@/app/auth/components/ProviderLogin';
 
 afterEach(() => {
   cleanup();

--- a/apps/readest-app/src/app/auth/components/ProviderLogin.tsx
+++ b/apps/readest-app/src/app/auth/components/ProviderLogin.tsx
@@ -1,0 +1,34 @@
+import clsx from 'clsx';
+
+export type OAuthProvider = 'google' | 'apple' | 'azure' | 'github' | 'discord';
+
+interface ProviderLoginProp {
+  provider: OAuthProvider;
+  handleSignIn: (provider: OAuthProvider) => Promise<void>;
+  Icon: React.ElementType;
+  label: string;
+}
+
+export const ProviderLogin: React.FC<ProviderLoginProp> = ({
+  provider,
+  handleSignIn,
+  Icon,
+  label,
+}) => {
+  return (
+    <button
+      onClick={() => {
+        void handleSignIn(provider).catch((error) => {
+          console.warn(`Failed to sign in with ${provider}:`, error);
+        });
+      }}
+      className={clsx(
+        'mb-2 flex w-64 items-center justify-center rounded border p-2.5',
+        'bg-base-100 border-base-300 hover:bg-base-200 shadow-sm transition',
+      )}
+    >
+      <Icon />
+      <span className='text-base-content/75 px-2 text-sm'>{label}</span>
+    </button>
+  );
+};

--- a/apps/readest-app/src/app/auth/page.tsx
+++ b/apps/readest-app/src/app/auth/page.tsx
@@ -27,48 +27,16 @@ import { getUserProfilePlan } from '@/utils/access';
 import { getAppleIdAuth, Scope } from './utils/appleIdAuth';
 import { authWithCustomTab, authWithSafari } from './utils/nativeAuth';
 import WindowButtons from '@/components/WindowButtons';
-
-type OAuthProvider = 'google' | 'apple' | 'azure' | 'github' | 'discord';
+import { ProviderLogin, type OAuthProvider } from './components/ProviderLogin';
 
 interface SingleInstancePayload {
   args: string[];
   cwd: string;
 }
 
-interface ProviderLoginProp {
-  provider: OAuthProvider;
-  handleSignIn: (provider: OAuthProvider) => Promise<void>;
-  Icon: React.ElementType;
-  label: string;
-}
-
 const WEB_AUTH_CALLBACK = `${getBaseUrl()}/auth/callback`;
 const DEEPLINK_CALLBACK = 'readest://auth-callback';
 const USE_APPLE_SIGN_IN = process.env['NEXT_PUBLIC_USE_APPLE_SIGN_IN'] === 'true';
-
-export const ProviderLogin: React.FC<ProviderLoginProp> = ({
-  provider,
-  handleSignIn,
-  Icon,
-  label,
-}) => {
-  return (
-    <button
-      onClick={() => {
-        void handleSignIn(provider).catch((error) => {
-          console.warn(`Failed to sign in with ${provider}:`, error);
-        });
-      }}
-      className={clsx(
-        'mb-2 flex w-64 items-center justify-center rounded border p-2.5',
-        'bg-base-100 border-base-300 hover:bg-base-200 shadow-sm transition',
-      )}
-    >
-      <Icon />
-      <span className='text-base-content/75 px-2 text-sm'>{label}</span>
-    </button>
-  );
-};
 
 export default function AuthPage() {
   const _ = useTranslation();


### PR DESCRIPTION
## Problem

The Cloudflare deploy build is currently broken on `main`:

```
  Running TypeScript ...
Failed to type check.

src/app/auth/page.tsx
Type error: Page "src/app/auth/page.tsx" does not match the required types of a Next.js Page.
  "ProviderLogin" is not a valid Page export field.
```

A page file may only export the fields Next.js recognizes (`default`, `metadata`, `generateMetadata`, `revalidate`, `dynamic`, ...). #5237 added `export const ProviderLogin` to `src/app/auth/page.tsx` purely so `src/__tests__/app/auth-page.test.tsx` could import it.

## Why it went unnoticed

Next only runs the page-export type check in the **webpack** build. Turbopack skips it, so `pnpm build`, `pnpm build-web` and CI all pass. The check only fires in `pnpm deploy` / `pnpm preview` / `pnpm upload`, which run `patch-build-webpack` first and therefore build with `next build --webpack`.

## Fix

Move the component to `src/app/auth/components/ProviderLogin.tsx` (co-located non-route files in the app dir are fine) along with the `OAuthProvider` type, and import it from both the page and the test.

## Verification

Reproduced on `33600cf3` with Next 16.2.6: `pnpm patch-build-webpack && pnpm build-web` fails with the error above. With this change the same build type-checks clean and completes static generation. `pnpm lint` and the auth page test pass.

Not related to the dependency bumps in #5335 - `next-types-plugin/index.js` is byte-identical between 16.2.6 and 16.2.11. #5335's OpenNext build verification needed this branch on top.

Debugging note: `.next/types/**/*.ts` is in the tsconfig include, so a stale `.next` left over from a webpack build makes `pnpm lint` fail on the generated validator even after switching branches. `rm -rf .next` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)