### PR TITLE
fix(library): stop re-importing duplicate files from watched folders

### DIFF
--- a/apps/readest-app/src/__tests__/services/auto-import-duplicate-files.test.ts
+++ b/apps/readest-app/src/__tests__/services/auto-import-duplicate-files.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Book } from '@/types/book';
+
+const mockOpen = vi.hoisted(() => vi.fn());
+const mockPartialMD5 = vi.hoisted(() => vi.fn());
+
+vi.mock('@/utils/md5', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/md5')>('@/utils/md5');
+  return { ...actual, partialMD5: mockPartialMD5 };
+});
+
+vi.mock('@/libs/document', async () => {
+  const actual = await vi.importActual<typeof import('@/libs/document')>('@/libs/document');
+  class MockDocumentLoader {
+    open() {
+      return mockOpen();
+    }
+  }
+  return { ...actual, DocumentLoader: MockDocumentLoader };
+});
+
+vi.mock('@/utils/txt', () => ({ TxtToEpubConverter: vi.fn() }));
+vi.mock('@/utils/svg', () => ({ svg2png: vi.fn() }));
+vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }));
+vi.mock('@/libs/storage', () => ({
+  downloadFile: vi.fn(),
+  uploadFile: vi.fn(),
+  deleteFile: vi.fn(),
+  createProgressHandler: vi.fn(),
+  batchGetDownloadUrls: vi.fn(),
+}));
+
+import { BaseAppService } from '@/services/appService';
+import {
+  buildBookLookupIndex,
+  collectKnownSourcePaths,
+  selectNewImportableFiles,
+} from '@/services/bookService';
+
+class TestAppService extends BaseAppService {
+  protected fs = {
+    openFile: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    copyFile: vi.fn(),
+    removeFile: vi.fn(),
+    readDir: vi.fn(),
+    createDir: vi.fn(),
+    removeDir: vi.fn(),
+    exists: vi.fn(),
+    stats: vi.fn(),
+    resolvePath: vi.fn(),
+    getURL: vi.fn(),
+    getBlobURL: vi.fn().mockResolvedValue(''),
+    getImageURL: vi.fn(),
+    getPrefix: vi.fn(),
+  };
+
+  protected resolvePath() {
+    return { baseDir: 0, basePrefix: async () => '', fp: '', base: 'Books' as const };
+  }
+
+  override osPlatform = 'linux' as BaseAppService['osPlatform'];
+
+  async init() {}
+  async setCustomRootDir() {}
+  async selectDirectory() {
+    return '';
+  }
+  async selectFiles() {
+    return [];
+  }
+  async saveFile() {
+    return false;
+  }
+  async saveImageToGallery() {
+    return false;
+  }
+  async ask() {
+    return false;
+  }
+  async openDatabase() {
+    return {} as ReturnType<BaseAppService['openDatabase']>;
+  }
+  async createWindow() {}
+  async getCacheDir() {
+    return '';
+  }
+  async clearWebviewCache() {}
+  async showNotification() {}
+
+  getFs() {
+    return this.fs;
+  }
+}
+
+const TEST_METADATA = {
+  title: 'Duplicated Book',
+  author: 'Author',
+  language: 'en',
+  identifier: 'isbn-dup',
+};
+
+/** One watched folder holding the same book under two different filenames. */
+const ORIGINAL_PATH = '/lib/watched/book.epub';
+const DUPLICATE_PATH = '/lib/watched/book-copy.epub';
+const SCANNED = [
+  { fullPath: ORIGINAL_PATH, size: 1024 },
+  { fullPath: DUPLICATE_PATH, size: 1024 },
+];
+
+describe('auto-import: watched folder with duplicated files', () => {
+  let service: TestAppService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TestAppService();
+    const fs = service.getFs();
+    fs.exists.mockResolvedValue(false);
+    fs.createDir.mockResolvedValue(undefined);
+    fs.writeFile.mockResolvedValue(undefined);
+    fs.removeDir.mockResolvedValue(undefined);
+    fs.readFile.mockResolvedValue('{}');
+    fs.openFile.mockImplementation(async (path: string) => new File(['content'], path));
+    // Same bytes under both names -> identical partial md5.
+    mockPartialMD5.mockResolvedValue('dup-hash');
+    mockOpen.mockResolvedValue({
+      book: { metadata: TEST_METADATA, getCover: vi.fn().mockResolvedValue(null) },
+      format: 'EPUB',
+    });
+  });
+
+  /** One auto-import pass: pick the files that look new, then ingest them. */
+  const runScan = async (library: Book[]) => {
+    const existingPaths = collectKnownSourcePaths(library, 'linux');
+    const fresh = selectNewImportableFiles(SCANNED, {
+      extensions: ['epub'],
+      minSizeBytes: 0,
+      existingPaths,
+      osPlatform: 'linux',
+    });
+    const lookupIndex = buildBookLookupIndex(library, 'linux');
+    for (const entry of fresh) {
+      await service.importBook(entry.fullPath, library, { lookupIndex, inPlace: true });
+    }
+    return fresh.map((f) => f.fullPath);
+  };
+
+  it('does not re-import the duplicate on every later scan', async () => {
+    const library: Book[] = [];
+
+    const first = await runScan(library);
+    expect(first).toEqual([ORIGINAL_PATH, DUPLICATE_PATH]);
+    // Both files are the same book, so the library holds a single entry.
+    expect(library.filter((b) => !b.deletedAt)).toHaveLength(1);
+
+    // Second scan (app returns to the foreground): nothing on disk changed, so
+    // nothing should be imported again.
+    const second = await runScan(library);
+    expect(second).toEqual([]);
+
+    // And it must stay quiet on every later scan, not ping-pong between the
+    // two paths.
+    const third = await runScan(library);
+    expect(third).toEqual([]);
+  });
+
+  it('keeps both names on the single deduped entry', async () => {
+    const library: Book[] = [];
+    await runScan(library);
+
+    const book = library.find((b) => !b.deletedAt)!;
+    // The most recently ingested file owns `filePath` (that is what makes a
+    // rename recoverable); the other name is remembered alongside it.
+    expect(book.filePath).toBe(DUPLICATE_PATH);
+    expect(book.altFilePaths).toEqual([ORIGINAL_PATH]);
+  });
+
+  it('does not accumulate duplicate entries across repeated imports', async () => {
+    const library: Book[] = [];
+    await runScan(library);
+
+    const book = library.find((b) => !b.deletedAt)!;
+    const lookupIndex = buildBookLookupIndex(library, 'linux');
+    // Re-importing the same two files (manual folder import, which ignores the
+    // known-path filter) must not grow the list without bound.
+    await service.importBook(ORIGINAL_PATH, library, { lookupIndex, inPlace: true });
+    await service.importBook(DUPLICATE_PATH, library, { lookupIndex, inPlace: true });
+
+    expect(book.filePath).toBe(DUPLICATE_PATH);
+    expect(book.altFilePaths).toEqual([ORIGINAL_PATH]);
+  });
+
+  it('follows a rename and remembers the vacated path', async () => {
+    const library: Book[] = [];
+    const lookupIndex = buildBookLookupIndex(library, 'linux');
+    await service.importBook(ORIGINAL_PATH, library, { lookupIndex, inPlace: true });
+
+    const book = library[0]!;
+    expect(book.filePath).toBe(ORIGINAL_PATH);
+
+    const renamed = '/lib/watched/renamed.epub';
+    await service.importBook(renamed, library, {
+      lookupIndex: buildBookLookupIndex(library, 'linux'),
+      inPlace: true,
+    });
+
+    // Content is read from `filePath`, so it must point at the name that
+    // actually exists on disk now.
+    expect(book.filePath).toBe(renamed);
+    expect(book.altFilePaths).toEqual([ORIGINAL_PATH]);
+  });
+
+  // The other dedup arm: two different files (different bytes, so different
+  // hashes) that describe the same book and collapse on `metaHash`.
+  it('remembers both paths when two different files share a metaHash', async () => {
+    mockPartialMD5.mockImplementation(async (file: File) =>
+      file.name === ORIGINAL_PATH ? 'hash-a' : 'hash-b',
+    );
+
+    const library: Book[] = [];
+    const first = await runScan(library);
+    expect(first).toEqual([ORIGINAL_PATH, DUPLICATE_PATH]);
+    expect(library.filter((b) => !b.deletedAt)).toHaveLength(1);
+
+    const book = library.find((b) => !b.deletedAt)!;
+    // The metaHash arm re-keys the survivor to the newest file's hash.
+    expect(book.hash).toBe('hash-b');
+    expect(book.altFilePaths).toEqual([ORIGINAL_PATH]);
+    expect(await runScan(library)).toEqual([]);
+  });
+
+  it('leaves alternative paths unset for a copy-mode import', async () => {
+    const library: Book[] = [];
+    const lookupIndex = buildBookLookupIndex(library, 'linux');
+    await service.importBook(ORIGINAL_PATH, library, { lookupIndex });
+    await service.importBook(DUPLICATE_PATH, library, { lookupIndex });
+
+    const book = library.find((b) => !b.deletedAt)!;
+    // Copy-mode books live under Books/<hash>/ and carry no source path at all.
+    expect(book.filePath).toBeUndefined();
+    expect(book.altFilePaths).toBeUndefined();
+  });
+});

--- a/apps/readest-app/src/__tests__/services/collect-known-source-paths.test.ts
+++ b/apps/readest-app/src/__tests__/services/collect-known-source-paths.test.ts
@@ -41,6 +41,30 @@ describe('collectKnownSourcePaths', () => {
     expect(result.size).toBe(0);
   });
 
+  // A watched folder can hold the same book under several names; the importer
+  // dedups them into one entry and parks the folded-away paths on
+  // `altFilePaths`. Auto-import must treat those as known, or it re-imports the
+  // duplicate on every scan.
+  test('includes the alternative source paths of a deduped book', () => {
+    const book = makeBook({
+      filePath: '/Users/me/Books/sample.epub',
+      altFilePaths: ['/Users/me/Books/sample-copy.epub', '/Users/me/Books/sample (1).epub'],
+    });
+    const result = collectKnownSourcePaths([book]);
+    expect(result.has('/Users/me/Books/sample.epub')).toBe(true);
+    expect(result.has('/Users/me/Books/sample-copy.epub')).toBe(true);
+    expect(result.has('/Users/me/Books/sample (1).epub')).toBe(true);
+  });
+
+  test('normalizes alternative source paths on case-insensitive platforms', () => {
+    const book = makeBook({
+      filePath: '/Users/Me/Books/Sample.epub',
+      altFilePaths: ['/Users/Me/Books/Sample-Copy.EPUB'],
+    });
+    const result = collectKnownSourcePaths([book], 'macos');
+    expect(result.has('/users/me/books/sample-copy.epub')).toBe(true);
+  });
+
   test('excludes a book with no filePath', () => {
     const book = makeBook();
     const result = collectKnownSourcePaths([book]);

--- a/apps/readest-app/src/app/library/hooks/useBooksSync.ts
+++ b/apps/readest-app/src/app/library/hooks/useBooksSync.ts
@@ -59,7 +59,9 @@ export const useBooksSync = () => {
       // got its branch order swapped (it currently checks Books/<hash>
       // before falling back to filePath; flipping that order would make
       // peers chase a non-existent path instead of downloading).
-      .map(({ filePath: _filePath, ...rest }): Book => rest);
+      // `altFilePaths` (the other on-disk names that resolve to the same book)
+      // is device-local for exactly the same reason.
+      .map(({ filePath: _filePath, altFilePaths: _altFilePaths, ...rest }): Book => rest);
     return {
       books: newBooks,
       lastSyncedAt: lastSyncedAtBooks,

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -129,19 +129,50 @@ export function selectNewImportableFiles(
  *
  * Unlike `buildBookLookupIndex(...).byFilePath`, this includes soft-deleted
  * books (`deletedAt` set) so that auto-import does not resurrect a book the
- * user intentionally removed from their library.
+ * user intentionally removed from their library. `altFilePaths` is included
+ * alongside `filePath`: several files in a watched folder can dedup into one
+ * book (same bytes under two names, or two files sharing a metaHash), and a
+ * path the importer folded away is just as "known" as the one it kept.
  *
  * URL-backed entries (remote books) are excluded — only on-disk paths matter.
  */
 export function collectKnownSourcePaths(books: Book[], osPlatform?: OsPlatform): Set<string> {
   const paths = new Set<string>();
   for (const book of books) {
-    if (book.filePath && !isValidURL(book.filePath)) {
-      const key = normalizeFilePathForIndex(book.filePath, osPlatform);
+    for (const path of [book.filePath, ...(book.altFilePaths ?? [])]) {
+      if (!path || isValidURL(path)) continue;
+      const key = normalizeFilePathForIndex(path, osPlatform);
       if (key) paths.add(key);
     }
   }
   return paths;
+}
+
+/**
+ * Move `book.filePath` into `book.altFilePaths` because `nextFilePath` is about
+ * to take its place.
+ *
+ * The newest path always wins the `filePath` slot — that is what makes a rename
+ * recoverable (the old name is gone from disk, the new one is where the bytes
+ * are). Without this the displaced path would simply be forgotten, and the
+ * auto-import scan would rediscover it as a "new" file on the next pass,
+ * re-import it, displace the current path in turn, and ping-pong forever.
+ *
+ * Idempotent: entries are deduplicated by normalized key and `nextFilePath` is
+ * never kept as its own alternative.
+ */
+function displaceSourcePath(book: Book, nextFilePath: string, osPlatform?: OsPlatform): void {
+  const nextKey = normalizeFilePathForIndex(nextFilePath, osPlatform);
+  const seen = new Set<string>();
+  const paths: string[] = [];
+  for (const path of [book.filePath, ...(book.altFilePaths ?? [])]) {
+    if (!path || isValidURL(path)) continue;
+    const key = normalizeFilePathForIndex(path, osPlatform);
+    if (!key || key === nextKey || seen.has(key)) continue;
+    seen.add(key);
+    paths.push(path);
+  }
+  book.altFilePaths = paths.length > 0 ? paths : undefined;
 }
 
 export interface CoverContext {
@@ -645,7 +676,16 @@ export async function importBook(
         // inPlace: source file is inside the user's library root and we read it
         // there directly instead of duplicating it under Books/<hash>/.
         book.filePath = file;
-        if (existingBook) existingBook.filePath = file;
+        if (existingBook) {
+          // A second on-disk file just deduped into a book we already have.
+          // Keep the path it is losing so the auto-import scan knows both
+          // files are accounted for (transient previews are never persisted,
+          // so there is nothing to remember for them).
+          if (inPlace && !transient) {
+            displaceSourcePath(existingBook, file, osPlatform);
+          }
+          existingBook.filePath = file;
+        }
       }
     }
     // Now that `filePath` is set, keep the path index in sync so later files

--- a/apps/readest-app/src/services/sync/file/wire.ts
+++ b/apps/readest-app/src/services/sync/file/wire.ts
@@ -146,6 +146,7 @@ export const parseRemoteLibraryIndex = (raw: string | null): RemoteLibraryIndex 
  */
 const DEVICE_LOCAL_BOOK_FIELDS = [
   'filePath',
+  'altFilePaths',
   'coverImageUrl',
   'downloadedAt',
   'coverDownloadedAt',

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -88,6 +88,12 @@ export interface Book {
   url?: string;
   // if Book is a transient local book we can load the book content via filePath
   filePath?: string;
+  // Other on-disk paths that resolved to this same book — a watched folder
+  // holding the same file twice under different names, or a copy left behind
+  // after a rename. Only `filePath` is ever read from; these are remembered so
+  // the auto-import scan doesn't treat a known duplicate as a new file on every
+  // pass. Device-local like `filePath`: never published to peers.
+  altFilePaths?: string[];
   // Partial md5 hash of the book file, used as the unique identifier
   hash: string;
   // Metadata md5 hash, used to aggregate different versions of the same book


### PR DESCRIPTION
## Problem

When a watched folder (Import from Folder -> "Auto-import new books from this folder") contains the same book under two different filenames, Readest re-imports it **every time the app comes back to the foreground**: the "Successfully imported 1 book" toast fires again and again, and it only stops once the duplicate files are removed.

## Root cause

Several files in a watched folder can dedup into a single library book: identical bytes (same `hash`) or different bytes that share a `metaHash`. But a `Book` records exactly one source path:

- `importBook` overwrote `existingBook.filePath` with whichever duplicate was ingested last.
- `collectKnownSourcePaths`, which the scan diffs against via `selectNewImportableFiles`, read only `filePath`.

So the other path was never known. Each foreground scan picked it up as a new file, imported it, displaced the current path in turn, and the two paths ping-ponged forever. Beyond the toast, every pass re-parsed the file and reset `createdAt`/`updatedAt`, so the book jumped to the top of the shelf and queued a sync push on every foreground.

## Fix

Remember every path that resolved to a book instead of only the last one.

- New device-local `Book.altFilePaths?: string[]`: other on-disk paths that resolve to the same book. Only `filePath` is ever read for content.
- `displaceSourcePath()` moves the outgoing `filePath` into `altFilePaths` (deduped by `normalizeFilePathForIndex`) before the newest path takes the slot.
- `collectKnownSourcePaths` unions `filePath` and `altFilePaths`.
- Same device-local discipline as `filePath`: added to `DEVICE_LOCAL_BOOK_FIELDS` in `sync/file/wire.ts` and stripped in `useBooksSync.getNewBooks`. The native cloud row uses an explicit allow-list (`transformBookToDB`), so it needs no change.

Two deliberate calls:

- **The newest path keeps winning the `filePath` slot.** That is what makes a rename recoverable, since the old name no longer exists on disk.
- **Alt paths are not added to `buildBookLookupIndex.byFilePath`.** A stale alt path should only ever make auto-import skip a file, never resolve book content to the wrong entry.

Existing libraries self-heal: an already-ping-ponging library imports once more, records the displaced path, then goes quiet.

## Tests

New `src/__tests__/services/auto-import-duplicate-files.test.ts` drives scan -> ingest -> re-scan through the real `importBook` and covers both dedup arms, the rename case, copy-mode imports, and repeat-import idempotency. It fails on `main` (the second scan re-picks the first file) and passes here. Two cases added to `collect-known-source-paths.test.ts`.

- `pnpm test` 7792 passed, 7 skipped
- `pnpm lint` clean
- `pnpm format:check` clean

No Rust or Lua changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
