### PR TITLE
fix(reader): align paragraph mode chrome with the TTS player (#5275)

### DIFF
--- a/apps/readest-app/src/__tests__/paragraph-bar.test.tsx
+++ b/apps/readest-app/src/__tests__/paragraph-bar.test.tsx
@@ -52,6 +52,47 @@ describe('ParagraphBar', () => {
     expect(root.className).toContain('-translate-x-1/2');
   });
 
+  it('fades in and out only, with no slide, scale, or blur (#5275)', () => {
+    vi.useFakeTimers();
+    const { container } = renderBar();
+    const root = getBarRoot(container);
+
+    expect(root.className).toContain('transition-opacity');
+    expect(root.className).toContain('opacity-100');
+
+    act(() => {
+      vi.advanceTimersByTime(2600);
+    });
+
+    expect(root.className).toContain('opacity-0');
+    // The centering -translate-x-1/2 stays; the motion extras must not.
+    expect(root.className).not.toMatch(/translate-y/);
+    expect(root.className).not.toMatch(/scale-/);
+    expect(root.className).not.toMatch(/blur/);
+  });
+
+  it('wears the TTS mini player card chrome: solid surface, no backdrop blur (#5275)', () => {
+    const { container } = renderBar();
+    const card = getBarRoot(container).firstElementChild as HTMLElement;
+
+    expect(card.className).toContain('not-eink:bg-base-300');
+    expect(card.className).toContain('eink-bordered');
+    expect(card.className).toContain('rounded-2xl');
+    expect(card.className).toContain('shadow-lg');
+    expect(card.className).toContain('h-14');
+    expect(card.className).not.toContain('backdrop-blur');
+    expect(card.className).not.toMatch(/not-eink:border\b/);
+  });
+
+  it('renders the position as plain UI text without the per-digit animation (#5275)', () => {
+    const { container } = renderBar();
+
+    expect(container.textContent).toContain('1 / 10');
+    expect(container.textContent).toContain('10%');
+    expect(container.querySelector('style')).toBeNull();
+    expect(container.innerHTML).not.toContain('subtle-slide-up');
+  });
+
   describe('show-controls event', () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/apps/readest-app/src/__tests__/paragraph-mode.test.tsx
+++ b/apps/readest-app/src/__tests__/paragraph-mode.test.tsx
@@ -322,7 +322,6 @@ describe('paragraph mode', () => {
     const { container } = render(
       <ParagraphOverlay
         bookKey={overlayBookKey}
-        dimOpacity={0.3}
         viewSettings={{ writingMode: 'horizontal-tb', vertical: false, rtl: true } as never}
       />,
     );
@@ -403,7 +402,6 @@ describe('paragraph mode', () => {
     const { container } = render(
       <ParagraphOverlay
         bookKey={overlayBookKey}
-        dimOpacity={0.3}
         viewSettings={{ writingMode: 'horizontal-tb', vertical: false, rtl: false } as never}
         onClose={onClose}
       />,
@@ -487,6 +485,15 @@ describe('paragraph mode', () => {
 
   const getDialog = (container: HTMLElement) =>
     container.querySelector('[role="dialog"]') as HTMLDivElement;
+
+  it('paints a solid backdrop instead of blurring the page behind it (#5275)', async () => {
+    const { container } = await renderVisibleOverlay(vi.fn());
+    const dialog = getDialog(container);
+
+    expect(dialog.className).toContain('bg-base-100');
+    expect(dialog.getAttribute('style') ?? '').not.toContain('blur');
+    expect(dialog.getAttribute('style') ?? '').not.toContain('background');
+  });
 
   it('focuses the dialog when it opens so it receives keys directly (#4717)', async () => {
     const { container } = await renderVisibleOverlay(vi.fn());

--- a/apps/readest-app/src/app/reader/components/paragraph/ParagraphBar.tsx
+++ b/apps/readest-app/src/app/reader/components/paragraph/ParagraphBar.tsx
@@ -39,14 +39,9 @@ interface ParagraphBarProps {
   gridInsets: Insets;
 }
 
-const AnimatedNumber: React.FC<{ value: number | string }> = ({ value }) => (
-  <span
-    key={value}
-    className='inline-block animate-[subtle-slide-up_0.2s_ease-out] text-sm font-medium tabular-nums'
-  >
-    {value}
-  </span>
-);
+// Same glyph button as the TTS mini player's transport, plus the disabled state
+// paragraph navigation needs while a section re-extracts.
+const BAR_BUTTON = 'shrink-0 rounded-full p-1 transition-colors not-eink:hover:bg-base-content/10';
 
 const ParagraphBar: React.FC<ParagraphBarProps> = ({
   bookKey,
@@ -64,7 +59,9 @@ const ParagraphBar: React.FC<ParagraphBarProps> = ({
   const _ = useTranslation();
   const { appService } = useEnv();
   const { hoveredBookKey } = useReaderStore();
-  const iconSize = useResponsiveSize(18);
+  // Mirrors the TTS mini player: 26px transport glyphs, a 20px close.
+  const iconSize20 = useResponsiveSize(20);
+  const iconSize26 = useResponsiveSize(26);
   const buttonDirections = getParagraphButtonDirections(viewSettings);
 
   const [isBarVisible, setIsBarVisible] = useState(true);
@@ -190,157 +187,115 @@ const ParagraphBar: React.FC<ParagraphBarProps> = ({
         : MdChevronRight;
 
   return (
-    <>
-      <style jsx global>{`
-        @keyframes subtle-slide-up {
-          from {
-            opacity: 0;
-            transform: translateY(2px);
-          }
-          to {
-            opacity: 1;
-            transform: translateY(0);
-          }
-        }
-      `}</style>
+    <div
+      className={clsx(
+        // `fixed` (not `absolute`) so the bar centers on the viewport like the
+        // overlay paragraph; `absolute` centered it on the gridcell, which is
+        // pushed off-center when the sidebar is pinned (#4474).
+        'fixed bottom-6 left-1/2 z-50 -translate-x-1/2',
+        // Plain fade, like the reader's other transient chrome — the slide,
+        // scale, and blur it used to animate read as a different app (#5275).
+        'transition-opacity duration-300 ease-out',
+        isVisible ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0',
+      )}
+      style={{
+        paddingBottom: appService?.hasSafeAreaInset ? `${gridInsets.bottom * 0.33}px` : 0,
+      }}
+      onMouseEnter={() => {
+        isInTriggerZoneRef.current = true;
+        showBar(false);
+      }}
+      onMouseLeave={() => {
+        isInTriggerZoneRef.current = false;
+        startHideTimer();
+      }}
+    >
+      {/* Same card as the TTS mini player: solid base-300 surface, 2xl radius,
+          soft shadow, 56px row. No backdrop blur, no hairline border. */}
       <div
         className={clsx(
-          // `fixed` (not `absolute`) so the bar centers on the viewport like the
-          // overlay paragraph; `absolute` centered it on the gridcell, which is
-          // pushed off-center when the sidebar is pinned (#4474).
-          'fixed bottom-6 left-1/2 z-50 -translate-x-1/2',
-          'transition-[opacity,filter,transform] duration-200 ease-out',
-          isVisible
-            ? 'pointer-events-auto translate-y-0 scale-100 opacity-100 blur-0'
-            : 'pointer-events-none translate-y-4 scale-90 opacity-0 blur-sm',
+          'not-eink:bg-base-300 eink-bordered rounded-2xl shadow-lg',
+          'text-base-content flex h-14 items-center gap-1 px-2',
         )}
-        style={{
-          paddingBottom: appService?.hasSafeAreaInset ? `${gridInsets.bottom * 0.33}px` : 0,
-        }}
-        onMouseEnter={() => {
-          isInTriggerZoneRef.current = true;
-          showBar(false);
-        }}
-        onMouseLeave={() => {
-          isInTriggerZoneRef.current = false;
-          startHideTimer();
-        }}
       >
-        <div
-          className={clsx(
-            'text-base-content flex items-center gap-1 rounded-full px-3 py-1.5',
-            'not-eink:bg-base-300 eink-bordered',
-            'not-eink:border-base-content/10 not-eink:border',
-            'shadow-sm backdrop-blur-md',
-            'transition-all duration-200 ease-out',
-          )}
+        <button
+          type='button'
+          onClick={onPrev}
+          disabled={isLoading}
+          className={clsx(BAR_BUTTON, isLoading && 'pointer-events-none opacity-50')}
+          title={_('Previous Paragraph')}
+          aria-label={_('Previous Paragraph')}
         >
-          <button
-            onClick={onPrev}
-            disabled={isLoading}
-            className={clsx(
-              'flex items-center justify-center rounded-full p-1.5',
-              'transition-all duration-200 ease-out',
-              'not-eink:hover:bg-base-200 active:scale-90',
-              isLoading && 'pointer-events-none opacity-50',
-            )}
-            title={_('Previous Paragraph')}
-            aria-label={_('Previous Paragraph')}
-          >
-            <PrevIcon size={iconSize} />
-          </button>
+          <PrevIcon size={iconSize26} />
+        </button>
 
-          <div className='bg-base-content/10 mx-1 h-4 w-px' />
-
-          <div className='flex items-center gap-2 px-1'>
-            {isLoading ? (
-              <div className='flex min-w-[3rem] items-center justify-center gap-2'>
-                <span className='loading loading-dots loading-sm text-base-content/50' />
-                <span className='text-base-content/50 text-sm'>{_('Loading')}</span>
-              </div>
-            ) : (
-              <>
-                <div className='flex min-w-[3rem] items-center justify-center gap-1'>
-                  <AnimatedNumber value={currentIndex + 1} />
-                  <span className='text-base-content/30 text-sm'>/</span>
-                  <span className='text-sm font-medium tabular-nums'>{totalParagraphs}</span>
-                </div>
-
-                <span className='text-base-content/40 text-sm'>•</span>
-
-                <div className='flex min-w-[2.5rem] items-center justify-center gap-0.5'>
-                  <AnimatedNumber value={progress} />
-                  <span className='text-sm font-medium'>%</span>
-                </div>
-              </>
-            )}
-          </div>
-
-          <div className='bg-base-content/10 mx-1 h-4 w-px' />
-
-          <button
-            onClick={onNext}
-            disabled={isLoading}
-            className={clsx(
-              'flex items-center justify-center rounded-full p-1.5',
-              'transition-all duration-200 ease-out',
-              'not-eink:hover:bg-base-200 active:scale-90',
-              isLoading && 'pointer-events-none opacity-50',
-            )}
-            title={_('Next Paragraph')}
-            aria-label={_('Next Paragraph')}
-          >
-            <NextIcon size={iconSize} />
-          </button>
-
-          {onToggleTtsAudio && (
-            <>
-              <div className='bg-base-content/10 mx-1 h-4 w-px' />
-
-              {/* Audio (TTS) toggle — starts read-along from the focused
-                  paragraph, or stops it when engaged (#3235). Active state uses a
-                  filled glyph + eink-bordered surface so it reads in e-ink
-                  without relying on color. */}
-              <button
-                onClick={onToggleTtsAudio}
-                disabled={isLoading}
-                className={clsx(
-                  'flex items-center justify-center rounded-full p-1.5',
-                  'transition-all duration-200 ease-out active:scale-90',
-                  ttsActive
-                    ? 'text-primary eink-bordered not-eink:bg-base-200'
-                    : 'not-eink:hover:bg-base-200',
-                  isLoading && 'pointer-events-none opacity-50',
-                )}
-                title={ttsActive ? _('Pause audio') : _('Play audio')}
-                aria-label={ttsActive ? _('Pause audio') : _('Play audio')}
-              >
-                {ttsActive ? (
-                  <IoVolumeHigh size={iconSize} aria-hidden='true' />
-                ) : (
-                  <IoVolumeMediumOutline size={iconSize} aria-hidden='true' />
-                )}
-              </button>
-            </>
+        <div className='flex min-w-[6rem] items-center justify-center px-1'>
+          {isLoading ? (
+            <div className='flex items-center gap-2'>
+              <span className='loading loading-dots loading-sm text-base-content/60' />
+              <span className='text-base-content/60 text-sm'>{_('Loading')}</span>
+            </div>
+          ) : (
+            <span className='flex items-baseline gap-1 text-sm tabular-nums'>
+              <span>
+                {currentIndex + 1} / {totalParagraphs}
+              </span>
+              <span className='text-base-content/60'>· {progress}%</span>
+            </span>
           )}
+        </div>
 
+        <button
+          type='button'
+          onClick={onNext}
+          disabled={isLoading}
+          className={clsx(BAR_BUTTON, isLoading && 'pointer-events-none opacity-50')}
+          title={_('Next Paragraph')}
+          aria-label={_('Next Paragraph')}
+        >
+          <NextIcon size={iconSize26} />
+        </button>
+
+        {onToggleTtsAudio && (
+          // Audio (TTS) toggle — starts read-along from the focused paragraph,
+          // or stops it when engaged (#3235). Active state uses a filled glyph +
+          // eink-bordered surface so it reads in e-ink without relying on color.
           <button
-            onClick={onClose}
+            type='button'
+            onClick={onToggleTtsAudio}
             disabled={isLoading}
             className={clsx(
-              'flex items-center justify-center rounded-full p-1.5',
-              'transition-all duration-200 ease-out',
-              'not-eink:hover:bg-base-200 active:scale-90',
+              BAR_BUTTON,
+              ttsActive && 'text-primary eink-bordered not-eink:bg-base-200',
               isLoading && 'pointer-events-none opacity-50',
             )}
-            title={_('Exit Paragraph Mode')}
-            aria-label={_('Exit Paragraph Mode')}
+            title={ttsActive ? _('Pause audio') : _('Play audio')}
+            aria-label={ttsActive ? _('Pause audio') : _('Play audio')}
           >
-            <MdClose size={iconSize} />
+            {ttsActive ? (
+              <IoVolumeHigh size={iconSize26} aria-hidden='true' />
+            ) : (
+              <IoVolumeMediumOutline size={iconSize26} aria-hidden='true' />
+            )}
           </button>
-        </div>
+        )}
+
+        <button
+          type='button'
+          onClick={onClose}
+          disabled={isLoading}
+          className={clsx(
+            BAR_BUTTON,
+            'text-base-content/70 ms-0.5',
+            isLoading && 'pointer-events-none opacity-50',
+          )}
+          title={_('Exit Paragraph Mode')}
+          aria-label={_('Exit Paragraph Mode')}
+        >
+          <MdClose size={iconSize20} />
+        </button>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/apps/readest-app/src/app/reader/components/paragraph/ParagraphControl.tsx
+++ b/apps/readest-app/src/app/reader/components/paragraph/ParagraphControl.tsx
@@ -10,8 +10,6 @@ import { useParagraphMode } from '../../hooks/useParagraphMode';
 import ParagraphBar from './ParagraphBar';
 import ParagraphOverlay from './ParagraphOverlay';
 
-const DIM_OPACITY = 0.3;
-
 interface ParagraphControlProps {
   bookKey: string;
   viewRef: React.RefObject<FoliateView | null>;
@@ -61,7 +59,6 @@ const ParagraphControl: React.FC<ParagraphControlProps> = ({ bookKey, viewRef, g
     <>
       <ParagraphOverlay
         bookKey={bookKey}
-        dimOpacity={DIM_OPACITY}
         viewSettings={viewSettings ?? undefined}
         gridInsets={gridInsets}
         ttsSyncStatus={ttsSyncStatus}

--- a/apps/readest-app/src/app/reader/components/paragraph/ParagraphOverlay.tsx
+++ b/apps/readest-app/src/app/reader/components/paragraph/ParagraphOverlay.tsx
@@ -24,7 +24,6 @@ const TTS_HIGHLIGHT_NAME = 'readest-tts-paragraph';
 
 interface ParagraphOverlayProps {
   bookKey: string;
-  dimOpacity: number;
   viewSettings?: ViewSettings;
   gridInsets?: Insets;
   /** Derived TTS-sync status driving the "following audio" indicator (#3235). */
@@ -129,7 +128,6 @@ const SectionTransitionIndicator: React.FC<{
 
 const ParagraphOverlay: React.FC<ParagraphOverlayProps> = ({
   bookKey,
-  dimOpacity,
   viewSettings,
   gridInsets = { top: 0, right: 0, bottom: 0, left: 0 },
   ttsSyncStatus = 'idle',
@@ -212,13 +210,6 @@ const ParagraphOverlay: React.FC<ParagraphOverlayProps> = ({
       marginInline: 'auto',
     } as React.CSSProperties;
   }, [appService?.hasSafeAreaInset, gridInsets.bottom, gridInsets.top, layoutContext.vertical]);
-  const surfaceStyle = useMemo(
-    () =>
-      ({
-        backgroundColor: 'oklch(var(--b1) / 0.14)',
-      }) as React.CSSProperties,
-    [],
-  );
   // `::highlight()` declaration matching the user's TTS highlight color/style so
   // the in-paragraph word/sentence highlight looks like normal mode (#3235).
   const ttsHighlightCss = useMemo(
@@ -548,6 +539,10 @@ const ParagraphOverlay: React.FC<ParagraphOverlayProps> = ({
       className={clsx(
         'fixed inset-0 z-40',
         'flex flex-col items-center justify-center',
+        // Solid page color, not a translucent blur of the book behind it — the
+        // blurred backdrop read as foreign chrome next to the rest of the app
+        // (#5275), and without the blur any translucency leaks ghost text.
+        'bg-base-100',
         // The dialog is focused programmatically (so it receives keys); it is not
         // a tab stop, so suppress the focus ring that would otherwise outline the
         // whole viewport.
@@ -556,9 +551,6 @@ const ParagraphOverlay: React.FC<ParagraphOverlayProps> = ({
         isOverlayMounted ? 'opacity-100' : 'opacity-0',
       )}
       style={{
-        backgroundColor: `oklch(var(--b1) / ${Math.min(dimOpacity + 0.4, 0.92)})`,
-        backdropFilter: 'blur(20px)',
-        WebkitBackdropFilter: 'blur(20px)',
         paddingTop: appService?.hasSafeAreaInset ? `${gridInsets.top}px` : undefined,
         paddingBottom: appService?.hasSafeAreaInset ? `${gridInsets.bottom * 0.33}px` : undefined,
       }}
@@ -616,12 +608,14 @@ const ParagraphOverlay: React.FC<ParagraphOverlayProps> = ({
         {activeParagraph ? (
           <div
             className={clsx(
-              'relative rounded-[2rem]',
+              // No surface of its own: the paragraph sits on the page color, so
+              // there is nothing left to round off (#5275).
+              'relative',
               layoutContext.vertical
                 ? 'inline-flex items-center justify-center self-center overflow-visible'
                 : 'w-full overflow-auto',
             )}
-            style={{ ...frameStyle, ...surfaceStyle }}
+            style={frameStyle}
           >
             <AnimatedParagraph
               key={activeParagraph.id}


### PR DESCRIPTION
Fixes #5275.

Paragraph mode's chrome looked like it came from a different app than the rest of the reader. The bottom bar was a blur-backed pill with hairline dividers, per-digit slide animations, and spacing wide enough to read as a mono font, and it slid + scaled + blurred on show/hide. Behind it, the overlay blurred the page instead of using a plain surface.

Everything here now borrows the TTS mini player's vocabulary, since that is the reader's other bottom-anchored transport surface.

### Changes

- **Bar surface** — the mini player's card: solid `bg-base-300`, `rounded-2xl`, `shadow-lg`, 56px row, `eink-bordered`. Dropped `backdrop-blur-md`, the `base-content/10` hairline border, and the dividers between controls.
- **Typography** — the position is one text run in the UI font (`36 / 94 · 61%`, percent dimmed), mirroring the player's `8:12 · -15:11` time label. Removed the `AnimatedNumber` per-digit keyframes and the `<style jsx global>` block they needed.
- **Buttons** — the player's plain glyph buttons (`shrink-0 rounded-full p-1`, 26px transport / 20px close, close dimmed with `ms-0.5`). Dropped `active:scale-90`; kept a hover tint, since prev/next get clicked repeatedly.
- **Show/hide** — plain `transition-opacity duration-300`, like the reader's other transient chrome. No slide, scale, or blur.
- **Overlay backdrop** — solid `bg-base-100` in place of `oklch(var(--b1) / 0.92)` + `backdrop-filter: blur(20px)`. Removing only the blur would leave book text ghosting through the 8% gap, so the backdrop is fully opaque. That also made the paragraph frame's `oklch(var(--b1) / 0.14)` tint, its `rounded-[2rem]`, and the `dimOpacity` prop dead code, so they are gone.

Auto-hide timing, trigger zones, direction-aware prev/next glyphs, the TTS read-along toggle, and e-ink behavior are unchanged. `eink-bordered` plus the global `[data-eink]` rules keep the card flat with a 1px border and no shadow on e-ink, exactly as the mini player does.

### Verification

- 4 new tests in `paragraph-bar.test.tsx` / `paragraph-mode.test.tsx`, written first and confirmed failing against the old chrome: opacity-only fade, mini-player card classes with no backdrop blur, plain-text position with no animation, solid overlay backdrop.
- `pnpm test` (paragraph suites: 33 pass), `pnpm lint`, `pnpm format:check` all clean.
- Checked in the running app: entered paragraph mode on an EPUB, confirmed the solid backdrop shows no ghost text and the bar renders as the 56px card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
