### PR TITLE
fix(epub): fall back to cover-named zip entries

### DIFF
--- a/apps/readest-app/src-tauri/src/epub_parser.rs
+++ b/apps/readest-app/src-tauri/src/epub_parser.rs
@@ -118,7 +118,8 @@ fn parse_epub_metadata_sync(file_path: &str) -> Result<ParsedEpubMetadata, Strin
         parse_opf_cover_inputs(&opf_bytes).map_err(|e| format!("parse opf cover inputs: {e}"))?;
 
     let cover_zip_path =
-        resolve_cover_path(&cover_inputs.manifest, &cover_inputs.cover_id, &opf_path);
+        resolve_cover_path(&cover_inputs.manifest, &cover_inputs.cover_id, &opf_path)
+            .or_else(|| find_undeclared_cover_entry(&zip));
 
     // Inline resize on the import hot path: at our target size (long edge
     // <= 512px, Triangle filter, JPEG q85) a release build keeps per-book
@@ -173,6 +174,7 @@ fn extract_epub_cover_full_sync(file_path: &str) -> Result<RawCoverImage, String
         parse_opf_cover_inputs(&opf_bytes).map_err(|e| format!("parse opf cover inputs: {e}"))?;
     let cover_zip_path =
         resolve_cover_path(&cover_inputs.manifest, &cover_inputs.cover_id, &opf_path)
+            .or_else(|| find_undeclared_cover_entry(&zip))
             .ok_or_else(|| "no cover image in epub".to_string())?;
     let bytes = read_zip_entry(&mut zip, &cover_zip_path)
         .map_err(|e| format!("read cover {cover_zip_path}: {e}"))?;
@@ -733,6 +735,34 @@ fn resolve_cover_path(
     chosen.map(|item| resolve_relative(opf_path, &item.href))
 }
 
+/// Whether a container entry name ends in `cover`/`couv` (the French
+/// spelling) plus an image extension, e.g. `cover.jpg`, `Images/Cover.PNG`,
+/// `couv.jpeg`. Mirrors `UNDECLARED_COVER_RE` in foliate-js's `epub.js` so
+/// both parsers surface the same image.
+fn is_undeclared_cover_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    let Some((stem, ext)) = lower.rsplit_once('.') else {
+        return false;
+    };
+    if !matches!(ext, "jpg" | "jpeg" | "png" | "gif" | "webp" | "svg") {
+        return false;
+    }
+    stem.ends_with("cover") || stem.ends_with("couv")
+}
+
+/// Last-ditch cover lookup for EPUBs where `resolve_cover_path` came up
+/// empty: scan the container's own entry names. Some EPUBs ship the cover
+/// image without ever declaring it (no `cover-image` property, no
+/// `<meta name="cover">` target, no manifest item), which leaves every
+/// manifest-driven lookup empty even though the image is in the zip.
+/// Entries are walked in central-directory order, so the first match wins.
+fn find_undeclared_cover_entry<R: Read + Seek>(zip: &ZipArchive<R>) -> Option<String> {
+    (0..zip.len())
+        .filter_map(|i| zip.name_for_index(i))
+        .find(|name| is_undeclared_cover_name(name))
+        .map(str::to_string)
+}
+
 fn resolve_relative(opf_path: &str, href: &str) -> String {
     // Strip query/fragment that occasionally appear in manifest hrefs.
     let href = href.split(['?', '#']).next().unwrap_or(href);
@@ -1025,6 +1055,50 @@ mod tests {
         );
         let p = resolve_cover_path(&manifest, &None, "OEBPS/content.opf").unwrap();
         assert_eq!(p, "OEBPS/images/other.jpg");
+    }
+
+    #[test]
+    fn undeclared_cover_matches_cover_named_entries() {
+        // Names the JS-side `UNDECLARED_COVER_RE` matches too.
+        assert!(is_undeclared_cover_name("cover.jpg"));
+        assert!(is_undeclared_cover_name("OEBPS/images/Cover.PNG"));
+        assert!(is_undeclared_cover_name("couv.jpeg"));
+        assert!(is_undeclared_cover_name("book-cover.webp"));
+        assert!(is_undeclared_cover_name("cover.svg"));
+        // ...and names it doesn't: unrelated images, non-images, and stems
+        // that merely start with "cover".
+        assert!(!is_undeclared_cover_name("images/rat.jpg"));
+        assert!(!is_undeclared_cover_name("cover.xhtml"));
+        assert!(!is_undeclared_cover_name("covers.jpg"));
+        assert!(!is_undeclared_cover_name("cover"));
+    }
+
+    #[test]
+    fn undeclared_cover_picks_first_matching_zip_entry() {
+        use std::io::Write;
+        let build = |names: &[&str]| {
+            let mut buf = Vec::<u8>::new();
+            {
+                let mut w = zip::ZipWriter::new(Cursor::new(&mut buf));
+                let opts = zip::write::SimpleFileOptions::default()
+                    .compression_method(zip::CompressionMethod::Stored);
+                for name in names {
+                    w.start_file(*name, opts).unwrap();
+                    w.write_all(b"x").unwrap();
+                }
+                w.finish().unwrap();
+            }
+            ZipArchive::new(Cursor::new(buf)).unwrap()
+        };
+
+        let zip = build(&["mimetype", "start.xhtml", "cover.jpg", "back-cover.jpg"]);
+        assert_eq!(
+            find_undeclared_cover_entry(&zip),
+            Some("cover.jpg".to_string())
+        );
+
+        let zip = build(&["mimetype", "images/rat.jpg"]);
+        assert_eq!(find_undeclared_cover_entry(&zip), None);
     }
 
     #[test]

--- a/apps/readest-app/src/__tests__/document/document-loader-epub-undeclared-cover.test.ts
+++ b/apps/readest-app/src/__tests__/document/document-loader-epub-undeclared-cover.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import { DocumentLoader } from '@/libs/document';
+
+// Minimal JPEG SOI marker + filler. Nothing decodes these bytes on the JS
+// side, we only assert that they made it out of the zip untouched.
+const COVER_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x01, 0x02, 0x03, 0x04]);
+
+/**
+ * Build an EPUB whose manifest declares nothing but the single spine
+ * document -- no `properties="cover-image"` item, no
+ * `<meta name="cover">` target, no image item at all -- while the zip
+ * still carries `imageEntry`. Calibre produces exactly this shape when a
+ * cover image is added to the container but the manifest entry is lost
+ * (issue #5273).
+ */
+const createUndeclaredCoverEpub = async (imageEntry: string | null) => {
+  const { ZipWriter, BlobWriter, TextReader, Uint8ArrayReader } = await import('@zip.js/zip.js');
+  const writer = new ZipWriter(new BlobWriter('application/epub+zip'));
+
+  await writer.add('mimetype', new TextReader('application/epub+zip'), { level: 0 });
+  await writer.add(
+    'META-INF/container.xml',
+    new TextReader(`<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="metadata.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`),
+  );
+  await writer.add(
+    'metadata.opf',
+    new TextReader(`<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="uuid_id" version="2.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:identifier id="uuid_id">undeclared-cover</dc:identifier>
+    <dc:title>test</dc:title>
+    <dc:language>eng</dc:language>
+    <meta name="cover" content="cover"/>
+  </metadata>
+  <manifest>
+    <item href="start.xhtml" id="start" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="start"/>
+  </spine>
+</package>`),
+  );
+  await writer.add(
+    'start.xhtml',
+    new TextReader(`<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>test</title></head>
+  <body><p>Hello.</p></body>
+</html>`),
+  );
+  if (imageEntry) {
+    await writer.add(imageEntry, new Uint8ArrayReader(COVER_BYTES));
+  }
+
+  const blob = await writer.close();
+  const arrayBuffer = await blob.arrayBuffer();
+  return new File([arrayBuffer], 'undeclared-cover.epub', { type: 'application/epub+zip' });
+};
+
+const openCover = async (imageEntry: string | null) => {
+  const file = await createUndeclaredCoverEpub(imageEntry);
+  const { book } = await new DocumentLoader(file).open();
+  return book.getCover();
+};
+
+describe('EPUB cover fallback for undeclared zip entries', () => {
+  it('falls back to a cover-named zip entry missing from the manifest', async () => {
+    const cover = await openCover('cover.jpg');
+
+    expect(cover).not.toBeNull();
+    expect(cover!.type).toBe('image/jpeg');
+    expect(new Uint8Array(await cover!.arrayBuffer())).toEqual(COVER_BYTES);
+  });
+
+  it('matches cover-named entries in nested directories and other formats', async () => {
+    const cover = await openCover('OEBPS/images/Cover.PNG');
+
+    expect(cover).not.toBeNull();
+    expect(cover!.type).toBe('image/png');
+  });
+
+  it('matches the French "couv" spelling', async () => {
+    const cover = await openCover('couv.jpeg');
+
+    expect(cover).not.toBeNull();
+    expect(cover!.type).toBe('image/jpeg');
+  });
+
+  it('does not invent a cover from unrelated images', async () => {
+    expect(await openCover('images/rat.jpg')).toBeNull();
+  });
+
+  it('returns null when the container has no image at all', async () => {
+    expect(await openCover(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #5273.

## Problem

The request reads like a missing heuristic, but both EPUB parsers already match manifest hrefs containing `cover` and even fall back to the first image in the manifest. The reporter's sample shows the real cause: Calibre wrote `<meta name="cover" content="cover"/>` into the OPF and left `cover.jpg` in the container, but the manifest never got the matching item.

```xml
<meta name="cover" content="cover"/>
...
<manifest>
  <item href="start.xhtml" id="start" media-type="application/xhtml+xml"/>
  <item href="toc.ncx" id="ncx" media-type="application/x-dtbncx+xml"/>
</manifest>
```

Every existing lookup is manifest-driven, so all of them come up empty and the book lands in the library with no cover — while `gnome-epub-thumbnailer` and other readers show it fine.

## Change

Once manifest resolution yields nothing, scan the container's own entry names for one ending in `cover`/`couv` (the French spelling) plus an image extension — the same fallback `gnome-epub-thumbnailer` uses, extended with `webp`. Entries are walked in central-directory order, so the first match wins.

Cover resolution is duplicated across two parsers, so both needed the rule or native and web imports would disagree:

- **foliate-js** — `EPUB.getCover()`, used by web imports and the reader. Landed in readest/foliate-js#61; this PR bumps the submodule to that merge commit.
- **`src-tauri/src/epub_parser.rs`** — `resolve_cover_path`, reached from `parse_epub_metadata` (every Tauri import) and `extract_epub_cover_full`. Rust owns the cover on native platforms, so a JS-only fix would leave desktop and mobile broken.

Both run strictly after the existing manifest paths, so EPUBs that declare a cover are unaffected. `epub-parser-parity.tauri.test.ts` asserts cover-presence parity between the two implementations, which is why the matching rules are kept identical.

## Tests

- `src/__tests__/document/document-loader-epub-undeclared-cover.test.ts` — five cases over synthesized EPUBs: root `cover.jpg`, nested `OEBPS/images/Cover.PNG`, `couv.jpeg`, plus negatives for an unrelated `images/rat.jpg` and a container with no image at all. Fails on `main`, passes here.
- Two Rust unit tests: name matching (including the non-matches `covers.jpg`, `cover.xhtml`, `images/rat.jpg`) and first-match-wins over a real in-memory zip.
- Verified end to end against both files attached to #5273 — each now yields the full 18971-byte cover through the Rust importer and through foliate-js.

`pnpm test`, `pnpm lint`, `pnpm format:check`, `pnpm fmt:check`, `pnpm clippy:check`, and `pnpm test:rust` all pass.