### PR TITLE
feat(markdown): parse YAML frontmatter into book metadata

### DIFF
--- a/apps/readest-app/src/__tests__/utils/md-frontmatter.test.ts
+++ b/apps/readest-app/src/__tests__/utils/md-frontmatter.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import { frontmatterToMetadata, parseFrontmatter } from '@/utils/mdFrontmatter';
+
+// A 1x1 transparent GIF, small enough to keep inline.
+const GIF_B64 = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+const GIF_URI = `data:image/gif;base64,${GIF_B64}`;
+
+const fm = (block: string, body = '# Body\n') => parseFrontmatter(`---\n${block}\n---\n${body}`);
+
+describe('parseFrontmatter', () => {
+  it('returns the text untouched when there is no frontmatter block', () => {
+    const { body, fields } = parseFrontmatter('# Title\n\ntext\n');
+    expect(body).toBe('# Title\n\ntext\n');
+    expect(fields).toEqual({});
+  });
+
+  it('strips the block from the body and reads scalar keys', () => {
+    const { body, fields } = fm('title: Moby Dick\nauthor: Herman Melville');
+    expect(body).toBe('# Body\n');
+    expect(fields).toEqual({ title: 'Moby Dick', author: 'Herman Melville' });
+  });
+
+  it('tolerates a BOM, CRLF line endings and padded delimiters', () => {
+    const { body, fields } = parseFrontmatter('﻿---  \r\ntitle: A\r\n--- \r\n# Body\r\n');
+    expect(fields).toEqual({ title: 'A' });
+    expect(body).toBe('# Body\r\n');
+  });
+
+  it('normalizes keys by case and by dropping dashes and underscores', () => {
+    const { fields } = fm('ISBN: 1\nCover-Image: 2\nseries_index: 3');
+    expect(fields).toEqual({ isbn: '1', coverimage: '2', seriesindex: '3' });
+  });
+
+  it('reads block lists', () => {
+    const { fields } = fm('tags:\n  - fiction\n  - classics\nauthor: Melville');
+    expect(fields['tags']).toEqual(['fiction', 'classics']);
+    expect(fields['author']).toBe('Melville');
+  });
+
+  it('reads flow lists, including an empty one', () => {
+    const { fields } = fm('tags: [fiction, "sea stories"]\nkeywords: []');
+    expect(fields['tags']).toEqual(['fiction', 'sea stories']);
+    expect(fields['keywords']).toEqual([]);
+  });
+
+  it('skips full-line comments and blank lines', () => {
+    const { fields } = fm('# a comment\n\ntitle: A\n   # indented comment\nauthor: B');
+    expect(fields).toEqual({ title: 'A', author: 'B' });
+  });
+
+  it('strips a trailing comment only when whitespace precedes the hash', () => {
+    const { fields } = fm('title: A  # the title\ncover: http://h/i.jpg#frag');
+    expect(fields['title']).toBe('A');
+    expect(fields['cover']).toBe('http://h/i.jpg#frag');
+  });
+
+  it('strips only matched surrounding quotes', () => {
+    const { fields } = fm(`title: "A Book"\nauthor: 'Jane'\nseries: don't\npublisher: "half`);
+    expect(fields['title']).toBe('A Book');
+    expect(fields['author']).toBe('Jane');
+    expect(fields['series']).toBe("don't");
+    expect(fields['publisher']).toBe('"half');
+  });
+
+  it('keeps a quoted value intact, comment marker and all', () => {
+    const { fields } = fm('title: "A # B"');
+    expect(fields['title']).toBe('A # B');
+  });
+
+  it('keeps a long unwrapped data URI intact', () => {
+    const { fields } = fm(`cover: ${GIF_URI}`);
+    expect(fields['cover']).toBe(GIF_URI);
+  });
+
+  it('ignores unsupported constructs instead of throwing', () => {
+    const { body, fields } = fm('description: |\n  line one\n  line two\ntitle: A');
+    expect(fields['title']).toBe('A');
+    expect(body).toBe('# Body\n');
+  });
+
+  it('drops keys with no value and no list items', () => {
+    const { fields } = fm('title: A\npublisher:\nauthor: B');
+    expect(fields).toEqual({ title: 'A', author: 'B' });
+  });
+
+  it('does not treat a horizontal rule mid-document as frontmatter', () => {
+    const { body, fields } = parseFrontmatter('# Title\n\n---\n\ntext\n');
+    expect(fields).toEqual({});
+    expect(body).toBe('# Title\n\n---\n\ntext\n');
+  });
+
+  it('leaves an unterminated block alone', () => {
+    const { body, fields } = parseFrontmatter('---\ntitle: A\n\n# Body\n');
+    expect(fields).toEqual({});
+    expect(body).toBe('---\ntitle: A\n\n# Body\n');
+  });
+});
+
+describe('frontmatterToMetadata', () => {
+  const map = (block: string) => frontmatterToMetadata(fm(block).fields);
+
+  it('returns nothing for an empty frontmatter', () => {
+    const { metadata, coverBlob } = frontmatterToMetadata({});
+    expect(metadata).toEqual({});
+    expect(coverBlob).toBeNull();
+  });
+
+  it('maps every supported field', () => {
+    const { metadata } = map(
+      [
+        'title: Moby Dick',
+        'subtitle: The Whale',
+        'author: Herman Melville',
+        'isbn: 979-8985322538',
+        'identifier: urn:uuid:1234',
+        'language: fr',
+        'publisher: Harper',
+        'published: 1851-10-18',
+        'description: A whale of a book',
+        'tags: [fiction, classics]',
+        'series: Sea Tales',
+        'series_index: 2',
+      ].join('\n'),
+    );
+    expect(metadata).toEqual({
+      title: 'Moby Dick',
+      subtitle: 'The Whale',
+      author: 'Herman Melville',
+      isbn: '979-8985322538',
+      identifier: 'urn:uuid:1234',
+      language: 'fr',
+      publisher: 'Harper',
+      published: '1851-10-18',
+      description: 'A whale of a book',
+      subject: ['fiction', 'classics'],
+      series: 'Sea Tales',
+      seriesIndex: 2,
+    });
+  });
+
+  it('accepts each documented key alias', () => {
+    expect(map('authors: A').metadata.author).toBe('A');
+    expect(map('lang: de').metadata.language).toBe('de');
+    expect(map('date: 2020').metadata.published).toBe('2020');
+    expect(map('pubdate: 2021').metadata.published).toBe('2021');
+    expect(map('summary: s').metadata.description).toBe('s');
+    expect(map('subject: [a]').metadata.subject).toEqual(['a']);
+    expect(map('keywords: [a]').metadata.subject).toEqual(['a']);
+  });
+
+  it('keeps multiple authors as an array', () => {
+    const { metadata } = map('author:\n  - Jane Doe\n  - John Roe');
+    expect(metadata.author).toEqual(['Jane Doe', 'John Roe']);
+  });
+
+  it('drops a series index that is not a finite number', () => {
+    expect(map('series_index: 1.5').metadata.seriesIndex).toBe(1.5);
+    expect(map('series_index: two').metadata.seriesIndex).toBeUndefined();
+  });
+
+  it('collapses a single-item list back to a scalar for scalar-only fields', () => {
+    expect(map('title:\n  - Only').metadata.title).toBe('Only');
+  });
+
+  it('wraps a scalar into an array for list-valued fields', () => {
+    expect(map('tags: fiction').metadata.subject).toEqual(['fiction']);
+  });
+
+  it('ignores blank values', () => {
+    expect(map('title: ""\nauthor: "  "').metadata).toEqual({});
+  });
+
+  it('decodes a base64 data URI cover into a blob of the declared type', async () => {
+    const { metadata, coverBlob } = map(`cover: ${GIF_URI}`);
+    expect(metadata.coverImageUrl).toBeUndefined();
+    expect(coverBlob).toBeInstanceOf(Blob);
+    expect(coverBlob!.type).toBe('image/gif');
+    const bytes = new Uint8Array(await coverBlob!.arrayBuffer());
+    expect(bytes.length).toBe(42);
+    expect(Array.from(bytes.slice(0, 3))).toEqual([0x47, 0x49, 0x46]); // GIF
+  });
+
+  it('decodes a percent-encoded data URI cover', async () => {
+    const { coverBlob } = map('cover: "data:image/svg+xml,%3Csvg%2F%3E"');
+    expect(coverBlob!.type).toBe('image/svg+xml');
+    expect(await coverBlob!.text()).toBe('<svg/>');
+  });
+
+  it('defaults a data URI with no media type to text/plain, per RFC 2397', async () => {
+    const { coverBlob } = map('cover: data:,hi');
+    expect(coverBlob!.type).toBe('text/plain');
+    expect(await coverBlob!.text()).toBe('hi');
+  });
+
+  it('keeps an http(s) cover as a URL instead of downloading it', () => {
+    const url = 'https://m.media-amazon.com/images/I/71JB5kFNJ5L._SL1500_.jpg';
+    const { metadata, coverBlob } = map(`cover: ${url}`);
+    expect(metadata.coverImageUrl).toBe(url);
+    expect(coverBlob).toBeNull();
+  });
+
+  it('accepts the cover_image and image aliases', () => {
+    expect(map('cover_image: https://h/a.jpg').metadata.coverImageUrl).toBe('https://h/a.jpg');
+    expect(map('image: http://h/b.jpg').metadata.coverImageUrl).toBe('http://h/b.jpg');
+  });
+
+  it('prefers cover over its aliases when several are present', () => {
+    const { metadata } = map('image: https://h/b.jpg\ncover: https://h/a.jpg');
+    expect(metadata.coverImageUrl).toBe('https://h/a.jpg');
+  });
+
+  it('ignores a relative cover path, which a standalone file cannot resolve', () => {
+    const { metadata, coverBlob } = map('cover: ./images/cover.png');
+    expect(metadata.coverImageUrl).toBeUndefined();
+    expect(coverBlob).toBeNull();
+  });
+
+  it('ignores a malformed data URI instead of throwing', () => {
+    expect(map('cover: data:image/png;base64,!!!not base64!!!').coverBlob).toBeNull();
+    expect(map('cover: data:image/png;base64').coverBlob).toBeNull();
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/md.test.ts
+++ b/apps/readest-app/src/__tests__/utils/md.test.ts
@@ -136,6 +136,75 @@ describe('makeMarkdownBook', () => {
     expect(fn.metadata.title).toBe('My Notes');
   });
 
+  // Issue #5279: the two frontmatter shapes the reporter attached, each pairing
+  // a cover with an ISBN. The library reads both off BookDoc.metadata, and the
+  // importer writes whatever getCover() returns as the book's cover file.
+  it('carries a base64 cover and an ISBN from frontmatter into the book', async () => {
+    const gif = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+    const book = await make(`---\ncover: ${gif}\nISBN: 979-8985322538\n---\n\n# YAML MD Test\n`);
+    expect(book.metadata.isbn).toBe('979-8985322538');
+    // With no explicit identifier, the ISBN becomes one, so the same book
+    // imported from another copy of the file lands on the same metaHash.
+    expect(book.metadata.identifier).toBe('979-8985322538');
+    expect(book.metadata.coverImageUrl).toBeUndefined();
+    const cover = await book.getCover();
+    expect(cover).toBeInstanceOf(Blob);
+    expect(cover!.type).toBe('image/gif');
+    expect(cover!.size).toBe(42);
+  });
+
+  it('carries an http cover URL from frontmatter without fetching it', async () => {
+    const url = 'https://m.media-amazon.com/images/I/71JB5kFNJ5L._SL1500_.jpg';
+    const book = await make(`---\ncover: ${url}\nISBN: 979-8985322538\n---\n\n# YAML MD Test\n`);
+    expect(book.metadata.coverImageUrl).toBe(url);
+    expect(await book.getCover()).toBeNull();
+  });
+
+  it('lifts the remaining book details out of frontmatter', async () => {
+    const book = await make(
+      [
+        '---',
+        'title: Moby Dick',
+        'subtitle: The Whale',
+        'author:',
+        '  - Herman Melville',
+        '  - Someone Else',
+        'language: fr',
+        'publisher: Harper',
+        'published: 1851-10-18',
+        'description: A whale of a book',
+        'tags: [fiction, classics]',
+        'series: Sea Tales',
+        'series_index: 2',
+        'identifier: urn:uuid:abcd',
+        '---',
+        '',
+        '# Chapter One',
+      ].join('\n'),
+    );
+    expect(book.metadata).toMatchObject({
+      title: 'Moby Dick',
+      subtitle: 'The Whale',
+      author: ['Herman Melville', 'Someone Else'],
+      language: 'fr',
+      publisher: 'Harper',
+      published: '1851-10-18',
+      description: 'A whale of a book',
+      subject: ['fiction', 'classics'],
+      series: 'Sea Tales',
+      seriesIndex: 2,
+      identifier: 'urn:uuid:abcd',
+    });
+  });
+
+  it('keeps the pre-frontmatter defaults when there is none, so hashes are stable', async () => {
+    const book = await make('# The Heading\n\nbody\n', 'My Notes.md');
+    expect(book.metadata.identifier).toBe('My Notes.md');
+    expect(book.metadata.language).toBe('en');
+    expect(book.metadata.author).toBe('');
+    expect(await book.getCover()).toBeNull();
+  });
+
   it('creates object URLs lazily and revokes every one on destroy', async () => {
     const url = URL as unknown as {
       createObjectURL: (b: Blob) => string;

--- a/apps/readest-app/src/utils/md.ts
+++ b/apps/readest-app/src/utils/md.ts
@@ -9,6 +9,7 @@ import {
   expandInlineFootnotes,
   extractFootnoteDefs,
 } from './mdFootnotes';
+import { frontmatterToMetadata, parseFrontmatter } from './mdFrontmatter';
 import { sanitizeHtml } from './sanitize';
 
 // Render a standalone Markdown (.md) file into an in-memory foliate-js book at
@@ -48,28 +49,6 @@ const wrapXhtml = (inner: string): string =>
   `<html xmlns="${XHTML_NS}"><head><meta charset="utf-8"/>` +
   `<style>${MD_STYLE}</style></head><body>${inner}</body></html>`;
 
-interface Frontmatter {
-  title?: string;
-  author?: string;
-}
-
-// Strip a leading YAML frontmatter block so it does not render as a stray
-// `<hr>` + text, and lift `title` / `author` from it.
-const stripFrontmatter = (text: string): { body: string; meta: Frontmatter } => {
-  const match = text.match(/^﻿?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?/);
-  if (!match) return { body: text, meta: {} };
-  const meta: Frontmatter = {};
-  for (const line of match[1]!.split(/\r?\n/)) {
-    const kv = line.match(/^([A-Za-z][\w-]*)\s*:\s*(.*)$/);
-    if (!kv) continue;
-    const key = kv[1]!.toLowerCase();
-    const value = kv[2]!.trim().replace(/^['"]|['"]$/g, '');
-    if (key === 'title') meta.title = value;
-    else if (key === 'author') meta.author = value;
-  }
-  return { body: text.slice(match[0]!.length), meta };
-};
-
 const slugify = (text: string): string =>
   text
     .toLowerCase()
@@ -90,7 +69,10 @@ type MarkdownSection = SectionItem & { load: () => string };
 
 export async function makeMarkdownBook(file: File): Promise<BookDoc> {
   const text = await file.text();
-  const { body, meta } = stripFrontmatter(text);
+  // The frontmatter block is stripped before rendering so it does not show up
+  // as a stray `<hr>` + text; its keys become the book's metadata (issue #5279).
+  const { body, fields } = parseFrontmatter(text);
+  const { metadata: frontmatter, coverBlob } = frontmatterToMetadata(fields);
   const rawHtml = await markdown.parse(body);
   const safeHtml = sanitizeHtml(rawHtml);
   const docBody = new DOMParser().parseFromString(safeHtml, 'text/html').body;
@@ -209,16 +191,21 @@ export async function makeMarkdownBook(file: File): Promise<BookDoc> {
   }));
 
   const title =
-    meta.title?.trim() ||
+    frontmatter.title ||
     (headingEls.find((h) => h.tagName === 'H1')?.textContent ?? '').trim() ||
     file.name.replace(/\.(?:md|markdown)$/i, '');
 
   const book = {
     metadata: {
-      title,
-      author: meta.author?.trim() ?? '',
+      author: '',
       language: 'en',
-      identifier: file.name,
+      ...frontmatter,
+      title,
+      // A frontmatter identifier — an explicit one, else the ISBN — makes the
+      // same book import to the same `metaHash` from any copy of the file. With
+      // neither, the filename stays the identifier, so books already in the
+      // library keep the hash they were imported under.
+      identifier: frontmatter.identifier || frontmatter.isbn || file.name,
     },
     rendition: { layout: 'reflowable' as const },
     dir: 'ltr',
@@ -239,7 +226,7 @@ export async function makeMarkdownBook(file: File): Promise<BookDoc> {
       return { index, anchor: (doc: Document) => doc.getElementById(b) };
     },
     isExternal: (uri: string): boolean => isExternalUri(uri),
-    getCover: async (): Promise<Blob | null> => null,
+    getCover: async (): Promise<Blob | null> => coverBlob,
     destroy: () => {
       for (const url of urls) if (url) URL.revokeObjectURL(url);
     },

--- a/apps/readest-app/src/utils/mdFrontmatter.ts
+++ b/apps/readest-app/src/utils/mdFrontmatter.ts
@@ -1,0 +1,188 @@
+// YAML frontmatter for standalone .md books (see utils/md.ts).
+//
+// Markdown has no metadata container of its own, so Obsidian, Jekyll, Hugo,
+// Pandoc and friends all settled on a leading `---` block of YAML. Issue #5279
+// asks for that block to reach the library: a `cover:` image and an `isbn:`
+// (which is what unlocks metadata auto-retrieve), plus the usual book details.
+//
+// Parsing is deliberately hand-rolled rather than pulling in a YAML engine.
+// Frontmatter in the wild is a flat map of scalars and short lists, and that is
+// exactly what this covers: `key: value`, block lists, flow lists, comments and
+// quoting. Block scalars (`|`, `>`), nested maps, anchors and multi-document
+// streams are skipped, never thrown on — a frontmatter mistake must cost the
+// reader a metadata field, not the whole book.
+
+import type { BookMetadata } from '@/libs/document';
+
+export type FrontmatterFields = Record<string, string | string[]>;
+
+// `author` widens the `BookMetadata` field: a frontmatter list of names stays a
+// list, which `formatAuthors` / `getAuthorsList` in utils/book.ts already
+// accept, and which keeps the names separable for sorting and search.
+export type MarkdownMetadata = Omit<Partial<BookMetadata>, 'author'> & {
+  author?: string | string[];
+};
+
+const BLOCK_RE = /^﻿?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/;
+const KEY_RE = /^([A-Za-z][\w-]*)[ \t]*:[ \t]*(.*)$/;
+const ITEM_RE = /^[ \t]*-[ \t]*(.+)$/;
+const COMMENT_RE = /^[ \t]*#/;
+// `|`, `>`, and their chomping / explicit-indent variants: the start of a block
+// scalar, whose continuation lines this parser cannot reassemble.
+const BLOCK_SCALAR_RE = /^[|>][-+]?\d*$/;
+
+// A scalar as written in the block. A value wrapped in matching quotes is taken
+// verbatim (a `#` inside it is content, not a comment); anything else has a
+// trailing comment stripped. YAML only starts a comment after whitespace, so
+// `https://host/img.jpg#anchor` keeps its fragment.
+const unquote = (raw: string): string => {
+  const value = raw.trim();
+  const quoted = value.match(/^(['"])([\s\S]*)\1$/);
+  if (quoted) return quoted[2]!;
+  return value.replace(/\s+#.*$/, '').trim();
+};
+
+// `[a, b]`. Values containing commas would need a real tokenizer; frontmatter
+// lists are tags and author names, so a split is enough.
+const parseFlowList = (raw: string): string[] =>
+  raw.slice(1, -1).split(',').map(unquote).filter(Boolean);
+
+/**
+ * Split a leading `---` frontmatter block off `text`.
+ *
+ * Keys are normalized to lowercase with `-` and `_` removed, so `ISBN`,
+ * `Cover-Image` and `series_index` each collapse onto one lookup key.
+ * Returns the text unchanged with no fields when there is no complete block.
+ */
+export const parseFrontmatter = (text: string): { body: string; fields: FrontmatterFields } => {
+  const match = text.match(BLOCK_RE);
+  if (!match) return { body: text, fields: {} };
+
+  const fields: FrontmatterFields = {};
+  // The key of a `key:` line still waiting to see whether indented `- item`
+  // lines follow. The list is only recorded once an item actually arrives, so a
+  // key with neither value nor items leaves no empty entry behind.
+  let pendingKey: string | null = null;
+  let pendingList: string[] | null = null;
+
+  for (const line of match[1]!.split(/\r?\n/)) {
+    if (!line.trim() || COMMENT_RE.test(line)) continue;
+
+    const item = pendingKey ? line.match(ITEM_RE) : null;
+    if (item) {
+      if (!pendingList) {
+        pendingList = [];
+        fields[pendingKey!] = pendingList;
+      }
+      const value = unquote(item[1]!);
+      if (value) pendingList.push(value);
+      continue;
+    }
+
+    pendingKey = null;
+    pendingList = null;
+
+    const kv = line.match(KEY_RE);
+    if (!kv) continue;
+    const key = kv[1]!.toLowerCase().replace(/[-_]/g, '');
+    const raw = kv[2]!.trim();
+
+    if (!raw) {
+      pendingKey = key;
+    } else if (raw.startsWith('[') && raw.endsWith(']')) {
+      fields[key] = parseFlowList(raw);
+    } else if (!BLOCK_SCALAR_RE.test(raw)) {
+      fields[key] = unquote(raw);
+    }
+  }
+
+  return { body: text.slice(match[0]!.length), fields };
+};
+
+// The first key that carries a non-empty value, in the order given.
+const pick = (fields: FrontmatterFields, ...keys: string[]): string | string[] | undefined => {
+  for (const key of keys) {
+    const value = fields[key];
+    if (value === undefined) continue;
+    const cleaned = Array.isArray(value)
+      ? value.map((v) => v.trim()).filter(Boolean)
+      : value.trim();
+    if (cleaned.length) return cleaned;
+  }
+  return undefined;
+};
+
+const one = (value: string | string[] | undefined): string | undefined =>
+  Array.isArray(value) ? value[0] : value;
+
+const many = (value: string | string[] | undefined): string[] | undefined =>
+  value === undefined ? undefined : Array.isArray(value) ? value : [value];
+
+const DATA_URI_RE = /^data:([^,]*),([\s\S]*)$/i;
+
+// Decode a `data:` URI into a Blob. Returns null for anything malformed so a
+// broken cover falls back to the generated one instead of failing the import.
+const dataUriToBlob = (uri: string): Blob | null => {
+  const match = uri.match(DATA_URI_RE);
+  if (!match) return null;
+  const header = match[1]!;
+  const isBase64 = /;base64$/i.test(header);
+  // RFC 2397: an omitted media type means text/plain.
+  const type =
+    (isBase64 ? header.slice(0, -';base64'.length) : header).split(';')[0] || 'text/plain';
+  try {
+    if (!isBase64) return new Blob([decodeURIComponent(match[2]!)], { type });
+    const binary = atob(match[2]!);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return new Blob([bytes], { type });
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Map parsed frontmatter fields onto book metadata.
+ *
+ * Only keys the frontmatter actually supplied are set; the fallbacks that need
+ * the document or the filename (title, language, identifier) stay in md.ts.
+ *
+ * A `data:` cover is decoded to a Blob for the importer to write as the book's
+ * cover file. An `http(s)` cover is kept as `coverImageUrl` and not fetched:
+ * `BookCover` renders that URL directly, which shows the cover on every
+ * platform without a cross-origin request the web build would usually lose.
+ * Relative paths are ignored — a standalone .md has no sibling files to read.
+ */
+export const frontmatterToMetadata = (
+  fields: FrontmatterFields,
+): { metadata: MarkdownMetadata; coverBlob: Blob | null } => {
+  const metadata: MarkdownMetadata = {};
+  const set = <K extends keyof MarkdownMetadata>(key: K, value: MarkdownMetadata[K]) => {
+    if (value !== undefined) metadata[key] = value;
+  };
+
+  set('title', one(pick(fields, 'title')));
+  set('subtitle', one(pick(fields, 'subtitle')));
+  set('author', pick(fields, 'author', 'authors'));
+  set('isbn', one(pick(fields, 'isbn')));
+  set('identifier', one(pick(fields, 'identifier')));
+  set('language', one(pick(fields, 'language', 'lang')));
+  set('publisher', one(pick(fields, 'publisher')));
+  set('published', one(pick(fields, 'published', 'date', 'pubdate')));
+  set('description', one(pick(fields, 'description', 'summary')));
+  set('subject', many(pick(fields, 'subject', 'tags', 'keywords')));
+  set('series', one(pick(fields, 'series')));
+
+  const seriesIndex = parseFloat(one(pick(fields, 'seriesindex')) ?? '');
+  if (Number.isFinite(seriesIndex)) metadata.seriesIndex = seriesIndex;
+
+  let coverBlob: Blob | null = null;
+  const cover = one(pick(fields, 'cover', 'coverimage', 'image'));
+  if (cover?.startsWith('data:')) {
+    coverBlob = dataUriToBlob(cover);
+  } else if (cover && /^https?:\/\//i.test(cover)) {
+    metadata.coverImageUrl = cover;
+  }
+
+  return { metadata, coverBlob };
+};


### PR DESCRIPTION
Closes #5279

## Problem

A standalone `.md` book had no way to declare a cover image, and none of its YAML frontmatter reached the library beyond `title` and `author`. The reporter asked for a `cover:` property (URL or base64 data URI) and, more generally, for frontmatter to feed the book's details -- ISBN in particular, since a valid ISBN is what unlocks metadata auto-retrieve.

Before this change `src/utils/md.ts` scanned frontmatter with a single regex and kept only `title` / `author`, and `getCover()` on the synthesized `BookDoc` returned a hardcoded `null`.

## Approach

New `src/utils/mdFrontmatter.ts`, mirroring the existing `mdFootnotes.ts` split, so `md.ts` keeps document structure (sections, TOC, CFI, footnotes) and only consumes the result. The module has no DOM dependency and is unit-tested in isolation.

**`parseFrontmatter`** handles `key: value` scalars, block lists, flow lists (`[a, b]`), full-line and trailing `#` comments, and matched-quote stripping. YAML only starts a comment after whitespace, so `cover: https://host/img.jpg#anchor` keeps its fragment. Keys are normalized to lowercase with `-` and `_` removed, so `ISBN`, `Cover-Image` and `series_index` each collapse onto one lookup key. Block scalars (`|`, `>`), nested maps and anchors are skipped rather than thrown on -- a frontmatter mistake should cost a metadata field, not the whole book. No YAML dependency added.

**`frontmatterToMetadata`** maps onto `title`, `subtitle`, `author`/`authors`, `isbn`, `identifier`, `language`/`lang`, `publisher`, `published`/`date`/`pubdate`, `description`/`summary`, `subject`/`tags`/`keywords`, `series` and `series_index`. A multi-valued `author` stays an array, which `formatAuthors` and `getAuthorsList` already accept.

**Covers.** A `data:` URI is decoded to a Blob and returned from `getCover()`, so the importer writes it as the book's cover file like any other format -- it persists offline and syncs. An `http(s)` cover is kept as `metadata.coverImageUrl` and deliberately **not** fetched: `BookCover` already renders that URL in preference to the local cover file, and a `fetch()` inside `getCover()` would be blocked by CORS for most image hosts on the web build, silently yielding no cover. Relative paths are ignored, since a standalone `.md` has no sibling files to read.

**Identifier.** A frontmatter `isbn` becomes the book `identifier` when no explicit one is given, so the same file imports to the same `metaHash` on every device. With neither key the filename stays the identifier, so books already in a library keep the hash they were imported under and do not re-import as new entries.

## Testing

- `src/__tests__/utils/md-frontmatter.test.ts` (new, 31 cases): parser and mapper directly -- lists, comments, quoting, `#` inside an unquoted URL, key aliases, every mapped field, `seriesIndex` coercion, both cover forms, malformed data URIs.
- `src/__tests__/utils/md.test.ts` (extended): end-to-end `BookDoc` metadata and `getCover()` for the two frontmatter shapes attached to the issue, plus a regression case that a book with no frontmatter keeps its filename identifier and `en` language.
- `pnpm test` 7862 passed / 7 skipped, `pnpm lint` and `pnpm format:check` clean.

Also verified by hand in the web app: a base64 cover decodes and renders in the library grid, and an `http` cover renders straight from `coverImageUrl` with no download. When a cover URL is unreachable the library falls back to the generated cover, as intended.

## Note for reviewers

Because markdown books now participate in `metaHash` dedup like every other format, two different `.md` files declaring the same ISBN are treated as the same book. That is the intent, but it makes an existing dedup race reachable for markdown: importing two same-`metaHash` files concurrently can create duplicate rows, and a subsequent re-import then merges them and soft-deletes both. The same is reachable today with two EPUB files of one book, so it is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)