### PR TITLE
fix(reader): keep book fonts when proofread rules change (#5277)

### DIFF
--- a/apps/readest-app/src/__tests__/store/reader-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/reader-store.test.ts
@@ -70,6 +70,7 @@ vi.mock('@/services/rss/feedReader', () => ({
 
 import { useReaderStore } from '@/store/readerStore';
 import { useBookDataStore } from '@/store/bookDataStore';
+import { uniqueId } from '@/utils/misc';
 
 /**
  * Helper to seed a minimal ViewState in the store for a given key.
@@ -326,6 +327,52 @@ describe('readerStore', () => {
 
       useReaderStore.getState().setViewInited('book-1', false);
       expect(useReaderStore.getState().viewStates['book-1']!.inited).toBe(false);
+    });
+  });
+
+  describe('recreateViewer', () => {
+    // Regression test for #5277: `initViewState` already mints a fresh
+    // viewerKey, so minting a second one here remounted <FoliateViewer> twice.
+    // The abandoned first mount kept opening the same bookDoc and left an extra
+    // `data` transform listener on its shared loader, so every stylesheet was
+    // transformed twice and the book's fonts were replaced by the app's.
+    test('mints a single viewerKey so the viewer mounts only once', async () => {
+      seedViewState('book-1', { viewerKey: 'book-1-uid-0' });
+
+      let counter = 0;
+      const uniqueIdMock = vi.mocked(uniqueId);
+      uniqueIdMock.mockImplementation(() => `uid-${++counter}`);
+
+      // Stand in for the real initViewState, which reloads the book and ends by
+      // assigning a fresh viewerKey of its own.
+      const initViewState = vi.fn(async (_envConfig: unknown, _id: string, key: string) => {
+        useReaderStore.setState((state) => ({
+          viewStates: {
+            ...state.viewStates,
+            [key]: { ...state.viewStates[key]!, viewerKey: `${key}-${uniqueId()}` },
+          },
+        }));
+      });
+      useReaderStore.setState({
+        initViewState: initViewState as unknown as ReturnType<
+          typeof useReaderStore.getState
+        >['initViewState'],
+      });
+
+      const mountedKeys: string[] = [];
+      const unsubscribe = useReaderStore.subscribe((state) => {
+        const viewerKey = state.viewStates['book-1']?.viewerKey;
+        if (viewerKey && mountedKeys.at(-1) !== viewerKey) mountedKeys.push(viewerKey);
+      });
+
+      useReaderStore.getState().recreateViewer({} as never, 'book-1');
+      await vi.waitFor(() => expect(initViewState).toHaveBeenCalled());
+      await Promise.resolve();
+      await Promise.resolve();
+      unsubscribe();
+
+      expect(mountedKeys).toEqual(['book-1-uid-1']);
+      uniqueIdMock.mockImplementation(() => 'mock-uid-123');
     });
   });
 });

--- a/apps/readest-app/src/__tests__/utils/style.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style.test.ts
@@ -181,6 +181,31 @@ describe('transformStylesheet', () => {
       const result = transformStylesheet(css, VW, VH, VERTICAL);
       expect(result).toContain('var(--monospace, monospace)');
     });
+
+    // Regression test for #5277: a stylesheet can be handed to this transform
+    // more than once. Rewriting the generic families again turned them into
+    // `var(--var(--serif, serif), serif)`, which the CSS parser drops - the
+    // book's font-family declarations vanished and the reader's own font
+    // showed through instead.
+    describe('idempotence', () => {
+      const cases = [
+        ['.text { font-family: serif; }', 'var(--serif, serif)'],
+        ['.text { font-family: sans-serif; }', 'var(--sans-serif, sans-serif)'],
+        ['.code { font-family: monospace; }', 'var(--monospace, monospace)'],
+        ['.text { font-family: "FZSongTi", serif; }', 'var(--serif, serif)'],
+        ['.text { font-family: Helvetica, sans-serif; }', 'var(--sans-serif, sans-serif)'],
+      ] as const;
+
+      cases.forEach(([css, expected]) => {
+        it(`keeps ${css} stable across repeated transforms`, () => {
+          const once = transformStylesheet(css, VW, VH, VERTICAL);
+          const twice = transformStylesheet(once, VW, VH, VERTICAL);
+          expect(once).toContain(expected);
+          expect(twice).toBe(once);
+          expect(twice).not.toContain('var(--var(');
+        });
+      });
+    });
   });
 
   describe('color black to var(--theme-fg-color)', () => {

--- a/apps/readest-app/src/store/readerStore.ts
+++ b/apps/readest-app/src/store/readerStore.ts
@@ -560,18 +560,14 @@ export const useReaderStore = create<ReaderStore>((set, get) => ({
 
   recreateViewer: (envConfig: EnvConfigType, key: string) => {
     const id = key.split('-')[0]!;
-    get()
-      .initViewState(envConfig, id, key, true, true)
-      .then(() => {
-        set((state) => ({
-          viewStates: {
-            ...state.viewStates,
-            [key]: {
-              ...state.viewStates[key]!,
-              viewerKey: `${key}-${uniqueId()}`,
-            },
-          },
-        }));
-      });
+    // `initViewState` already mints a fresh `viewerKey` when the reload lands,
+    // which is what remounts <FoliateViewer>. Minting a second one here
+    // remounted it twice: the abandoned first mount kept running its async
+    // `openBook()` and registered another `data` transform listener on the
+    // *same* reloaded bookDoc, so every resource was piped through the
+    // transform chain twice. A twice-transformed stylesheet lost all its
+    // font-family declarations, and the book fell back to the app font
+    // (readest#5277).
+    void get().initViewState(envConfig, id, key, true, true);
   },
 }));

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1101,10 +1101,17 @@ export const transformStylesheet = (css: string, vw: number, vh: number, vertica
     .replace(/([\s;])-ms-user-select\s*:\s*none/gi, '$1-ms-user-select: unset')
     .replace(/([\s;])-o-user-select\s*:\s*none/gi, '$1-o-user-select: unset')
     .replace(/([\s;])user-select\s*:\s*none/gi, '$1user-select: unset')
+    // Park the `var(--x, x)` chunks an earlier pass already produced: their
+    // inner keywords would otherwise be rewritten again into
+    // `var(--var(--serif, serif), serif)`, which is invalid, so the CSS parser
+    // drops the whole declaration and the book loses its fonts (readest#5277).
+    // The placeholders are underscore-wrapped so `\b` never matches inside them.
+    .replace(/var\(\s*--(sans-serif|serif|monospace)\s*,\s*\1\s*\)/gi, 'READEST_GF_$1_PLACEHOLDER')
     .replace(/(font-family\s*:[^;]*?)\bsans-serif\b/gi, '$1READEST_SS_PLACEHOLDER')
     .replace(/(font-family\s*:[^;]*?)\bserif\b(?!-)/gi, '$1var(--serif, serif)')
     .replace(/READEST_SS_PLACEHOLDER/g, 'var(--sans-serif, sans-serif)')
     .replace(/(font-family\s*:[^;]*?)\bmonospace\b/gi, '$1var(--monospace, monospace)')
+    .replace(/READEST_GF_(sans-serif|serif|monospace)_PLACEHOLDER/gi, 'var(--$1, $1)')
     .replace(/([\s;])font-weight\s*:\s*normal/gi, '$1font-weight: var(--font-weight)')
     .replace(/([\s;])color\s*:\s*black/gi, '$1color: var(--theme-fg-color)')
     .replace(/([\s;])color\s*:\s*#000000/gi, '$1color: var(--theme-fg-color)')


### PR DESCRIPTION
Closes #5277.

## Symptom

With **Override Book Font** off, adding, editing or deleting a proofread replacement rule made the book render in the app-configured font. Reopening the book restored the book's own font.

## Root cause

Two defects stacked on top of each other.

**1. `recreateViewer` remounted the viewer twice.** `initViewState` already mints a fresh `viewerKey` at the end of its success path, and `recreateViewer` minted a second one in `.then()`. React commits both, so `<FoliateViewer key={viewerKey}>` mounted twice per rule change (confirmed live: `Opening book …` logged twice). Nothing cancels the abandoned first mount, so its async `openBook()` keeps going, appends its `foliate-view` to a detached container, and registers a second `data` transform listener on the **same** reloaded `bookDoc`. The listeners chain `detail.data`, so every resource ran through the transform chain twice.

**2. `transformStylesheet` was not idempotent for the generic families.** `-` is a word boundary, so the second pass matched the `serif` inside `--serif`:

```
font-family: "FZSongTi", serif
  -> font-family: "FZSongTi", var(--serif, serif)                  (pass 1, correct)
  -> font-family: "FZSongTi", var(--var(--serif, serif), serif)    (pass 2, invalid)
```

An invalid `var()` makes the CSS parser drop the whole declaration, so the book lost **every** `font-family` and inherited the reader's `html { font-family: var(--serif) }` - the app font. A fresh open transforms once, which is why reopening the book fixed it.

## Fix

- `recreateViewer` just calls `initViewState`; the viewer key is minted once.
- `transformStylesheet` parks the `var(--x, x)` chunks an earlier pass produced behind an underscore-wrapped placeholder (so `\b` cannot match inside it) across the generic-family rewrites, and restores them afterwards. No lookbehind, so iOS Safari stays happy.

## Verification

Reproduced and verified in the web dev server by fetching the section's `blob:` stylesheet:

| | before rule change | after rule change |
| --- | --- | --- |
| before fix | `var(--var(` x0 | `var(--var(` x3, `font-family:var(--var(--sans-serif, sans-serif), sans-var(--serif, serif))` |
| after fix | `var(--var(` x0 | `var(--var(` x0, declarations unchanged |

Also confirmed post-fix that `Opening book` logs once per recreate and that replacements still apply to the rendered text.

Regression tests added (both written failing first):
- `src/__tests__/store/reader-store.test.ts` - `recreateViewer` mints a single viewerKey.
- `src/__tests__/utils/style.test.ts` - `transformStylesheet` is idempotent for `serif` / `sans-serif` / `monospace`, including named-font-plus-generic stacks.

`pnpm test` 7833 passed, `pnpm lint` and `pnpm format:check` clean. No Rust or Lua files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)