### PR TITLE
fix(metadata): make "Change cover image" work on iOS

### DIFF
--- a/apps/readest-app/src-tauri/capabilities/default.json
+++ b/apps/readest-app/src-tauri/capabilities/default.json
@@ -70,6 +70,9 @@
           "path": "$TEMP/**/*"
         },
         {
+          "path": "$APPCACHE"
+        },
+        {
           "path": "$APPCACHE/**/*"
         },
         {

--- a/apps/readest-app/src/__tests__/hooks/useFileSelector.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useFileSelector.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { AppService } from '@/types/system';
+
+const basenameMock = vi.fn(async (path: string) => path.split('/').pop() || path);
+
+vi.mock('@tauri-apps/api/path', () => ({
+  basename: (path: string) => basenameMock(path),
+}));
+
+vi.mock('@/services/environment', () => ({
+  isTauriAppPlatform: () => true,
+}));
+
+import { useFileSelector } from '@/hooks/useFileSelector';
+
+const _ = (key: string) => key;
+
+const makeAppService = (
+  platform: 'ios' | 'android',
+  picked: string[],
+): { appService: AppService; selectFiles: ReturnType<typeof vi.fn> } => {
+  const selectFiles = vi.fn(async () => picked);
+  const appService = {
+    isIOSApp: platform === 'ios',
+    isAndroidApp: platform === 'android',
+    selectFiles,
+  } as unknown as AppService;
+  return { appService, selectFiles };
+};
+
+beforeEach(() => {
+  basenameMock.mockClear();
+});
+
+describe('useFileSelector cover selection', () => {
+  test('iOS: asks the native picker for the image extensions so the photo picker opens', async () => {
+    const { appService, selectFiles } = makeAppService('ios', [
+      'file:///private/var/mobile/Containers/Data/Application/ABC/Library/Caches/photo.jpg',
+    ]);
+    const { selectFiles: select } = useFileSelector(appService, _);
+
+    await select({ type: 'covers', multiple: false });
+
+    // The iOS branch currently passes `[]` (unfiltered), which makes the Tauri
+    // dialog plugin fall back to the Files document picker instead of the
+    // Photos (PHPicker) UI.
+    expect(selectFiles).toHaveBeenCalledWith(expect.any(String), ['png', 'jpg', 'jpeg', 'gif']);
+  });
+
+  test('iOS: keeps a picked HEIC photo instead of silently dropping it', async () => {
+    const { appService } = makeAppService('ios', [
+      'file:///private/var/mobile/Containers/Data/Application/ABC/Library/Caches/IMG_0001.heic',
+    ]);
+    const { selectFiles: select } = useFileSelector(appService, _);
+
+    const result = await select({ type: 'covers', multiple: false });
+
+    // A HEIC photo is the iPhone camera default. Dropping it here makes the
+    // "Change cover image" button a silent no-op.
+    expect(result.files).toHaveLength(1);
+  });
+
+  test('Android: leaves the MIME-filtered picker result untouched', async () => {
+    const { appService, selectFiles } = makeAppService('android', [
+      'content://media/external/images/media/42',
+    ]);
+    const { selectFiles: select } = useFileSelector(appService, _);
+
+    const result = await select({ type: 'covers', multiple: false });
+
+    expect(selectFiles).toHaveBeenCalledWith(expect.any(String), ['png', 'jpg', 'jpeg', 'gif']);
+    expect(result.files).toHaveLength(1);
+  });
+});

--- a/apps/readest-app/src/hooks/useFileSelector.ts
+++ b/apps/readest-app/src/hooks/useFileSelector.ts
@@ -82,8 +82,16 @@ const selectFileTauri = async (
   // resulting paths below. We extend the same treatment to 'generic'
   // selections because callers there typically pass arbitrary extensions
   // that SAF likewise cannot match (e.g. mrexpt, txt).
+  //
+  // Image selections are the exception on iOS: image extensions all map to
+  // real UTTypes, so passing them lets the dialog plugin open the Photos
+  // (PHPicker) UI instead of the Files browser — matching Android. Asking for
+  // no filter there also made the client-side whitelist below drop anything
+  // outside png/jpg/jpeg/gif, so picking a HEIC (the iPhone camera default)
+  // silently selected nothing at all.
+  const isImageSelection = options.type === 'covers' || options.type === 'images';
   const noFilter =
-    appService?.isIOSApp ||
+    (appService?.isIOSApp && !isImageSelection) ||
     (appService?.isAndroidApp &&
       (options.type === 'books' || options.type === 'dictionaries' || options.type === 'generic'));
   const exts = noFilter ? [] : options.extensions || [];


### PR DESCRIPTION
Changing a book cover from the book details modal did nothing on iOS. Two independent defects; both are fixed here.

## 1. Wrong picker, and photos silently dropped

`selectFileTauri` asked for an *unfiltered* picker on iOS for **every** selection type:

```ts
const noFilter = appService?.isIOSApp || (appService?.isAndroidApp && (...));
const exts = noFilter ? [] : options.extensions || [];
```

The blanket bypass exists because Android's SAF picker greys out extensions with no registered MIME (`.mrexpt`, `.mdx`). Image extensions all map to real UTTypes, so it was never needed for covers.

With an empty filter list, the dialog plugin's `parseFiltersOption` returns no UTTypes, `filtersIncludeImage` is false, and it falls back to `UIDocumentPickerViewController` instead of `PHPickerViewController`. Users got the **Files browser** (listing every file type, epubs included) rather than their photo library.

The unfiltered path then re-applies the client-side whitelist, which for covers is `png/jpg/jpeg/gif`. A **HEIC**, the iPhone camera default, was discarded, so `selectFiles` returned zero files and `handleSelectLocalImage` returned early with no error and no visible change.

Fix: keep the bypass for `books` / `dictionaries` / `generic`, but let image selections pass their real extensions through. iOS now opens the Photos picker, matching Android, and no longer drops HEIC.

## 2. `mkdir` on the app cache directory was out of scope

`getCachedImageUrl` writes the picked image into the `Cache` base dir, and `ensureDirExists` calls `createDir('', 'Cache')`, which resolves to `$APPCACHE` itself. The fs scope only allowed `$APPCACHE/**/*`, which requires at least one child component and so never matches the bare directory:

```
forbidden path: .../Library/Caches/com.bilingify.readest/, maybe it is not
allowed on the scope for `allow-mkdir` permission in your capability file
```

Because `handleSelectLocalImage` has no `.catch`, this surfaced only as an unhandled promise rejection.

Fix: allow `$APPCACHE` alongside `$APPCACHE/**/*`, mirroring how this file already handles Readest's own directory (`**/Readest` **and** `**/Readest/**/*`).

Real devices were already covered by the `/private/var/mobile/Containers/Data/Application/**/*` entry (Tauri matches with `require_literal_separator: true`, so `**` spans `<UUID>/Library/Caches` and `*` matches the bundle id), so this one was **simulator only**. The gap is real either way.

## Verification

Driven through the real UI, not just unit tests.

**iOS (iPhone 17 Pro simulator, iOS 26.3)**

| Case | Before | After |
| --- | --- | --- |
| Tap "Change cover image" | Files browser, epubs listed | Photos picker, images only |
| Pick a PNG | nothing (mkdir rejection) | cover applies, Save persists |
| Pick a HEIC | nothing, no error | cover applies, Save persists |

**Android (Xiaomi 13, HyperOS, Android 16, v0.11.20)** was already working and is unchanged: photo picker opens, preview updates, Save persists to the details view, recent shelf and library grid, and survives a force-stop relaunch.

`useFileSelector` had no test coverage; this adds one covering the iOS extensions passed to the native picker, the HEIC case, and the Android path as a regression guard. All three fail on `main` for iOS and pass here.

## Checks

- `pnpm test` 7871 passed, 7 skipped
- `pnpm lint` clean
- `pnpm fmt:check` clean
- `pnpm clippy:check` clean

## Note on scope

`$TEMP` has the same bare-directory gap as `$APPCACHE` (`$TEMP/**/*` with no `$TEMP`). I left it alone since nothing was observed hitting it, but it will bite the same way if anything ever writes to the `Temp` base dir root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
