### PR TITLE
fix(reader): keep the PDF footer readable in scrolled mode (#5342)

### DIFF
--- a/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
@@ -349,4 +349,48 @@ describe('ProgressBar — contrast against the page (#4901)', () => {
     const info = container.querySelector('.progressinfo') as HTMLElement;
     expect(info.classList.contains('mix-blend-difference')).toBe(false);
   });
+
+  // #5342: scrolled mode gives every segment its own bg-base-100/85 pill, and
+  // the blend applies to the container as a group -- a white pill differenced
+  // against the white PDF page turns pure black. The pill already guarantees
+  // legibility, so the blend must stand down whenever pills are on.
+  it('drops the blend for a fixed-layout book when the pills provide the backdrop', () => {
+    currentViewSettings = {
+      ...baseSettings,
+      isEink: false,
+      scrolled: true,
+      showRemainingPages: true,
+      showRemainingTime: false,
+    } as ViewSettings;
+    currentProgress = makeProgress(2, 5);
+    currentBookData = { isFixedLayout: true };
+    currentRenderer = { page: 1, pages: 4 };
+
+    const { container } = renderProgressBar();
+
+    const info = container.querySelector('.progressinfo') as HTMLElement;
+    expect(container.querySelector('.progress-pill')).not.toBeNull();
+    expect(info.classList.contains('mix-blend-difference')).toBe(false);
+    expect(info.classList.contains('text-base-content')).toBe(true);
+  });
+
+  it('keeps the blend for a fixed-layout book in scrolled mode when the sticky bar replaces the pills', () => {
+    currentViewSettings = {
+      ...baseSettings,
+      isEink: false,
+      scrolled: true,
+      showStickyProgressBar: true,
+      showRemainingPages: true,
+      showRemainingTime: false,
+    } as ViewSettings;
+    currentProgress = makeProgress(2, 5);
+    currentBookData = { isFixedLayout: true };
+    currentRenderer = { page: 1, pages: 4 };
+
+    const { container } = renderProgressBar();
+
+    const info = container.querySelector('.progressinfo') as HTMLElement;
+    expect(container.querySelector('.progress-pill')).toBeNull();
+    expect(info.classList.contains('mix-blend-difference')).toBe(true);
+  });
 });

--- a/apps/readest-app/src/app/reader/components/ProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/ProgressBar.tsx
@@ -156,7 +156,12 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
       className={clsx(
         'progressinfo pointer-events-none absolute bottom-0 flex items-center justify-between font-sans',
         isEink ? 'text-sm font-normal' : 'text-xs font-extralight',
-        bookData?.isFixedLayout && !isEink
+        // The blend keeps the info legible over an unthemed fixed-layout page,
+        // but it composites the whole container as a group -- with the pills on
+        // it differences a white pill against the white page and paints it pure
+        // black (#5342). The pill backdrop already guarantees legibility, so it
+        // takes over from the blend whenever it is present.
+        bookData?.isFixedLayout && !isEink && !pillClass
           ? 'text-white/75 mix-blend-difference'
           : 'text-base-content',
         isVertical ? 'writing-vertical-rl' : 'w-full',


### PR DESCRIPTION
Fixes #5342

### Problem

In a light theme, a PDF read in **scrolled** mode paints every footer segment (remaining pages, clock/battery, progress) as a solid black pill with near-invisible text.

### Root cause

Two independent legibility mechanisms collided in `ProgressBar.tsx`:

- **#4901** gives fixed-layout books `text-white/75 mix-blend-difference` on the footer container, so the info stays legible over a PDF page the app never themes.
- **#5029** gives scrolled mode a `bg-base-100/85` pill behind each segment, because scrolled mode reserves no bottom band and the info floats over the text.

`mix-blend-mode` composites the **whole element as a group** against the backdrop, so each pill's own background is blended too. In a light theme `base-100` is white, and white differenced against the white PDF page is `#000`.

### Fix

The pill backdrop already guarantees contrast in both light and dark themes, so the blend stands down whenever a pill is present:

```diff
-        bookData?.isFixedLayout && !isEink
+        bookData?.isFixedLayout && !isEink && !pillClass
           ? 'text-white/75 mix-blend-difference'
           : 'text-base-content',
```

Paginated PDFs and the sticky-progress-bar variant have no pills, so they keep the blend unchanged.

### Testing

- New test reproducing the bug (fails before, passes after) plus a companion test pinning the sticky-bar path that must keep blending, in the existing `contrast against the page (#4901)` describe block.
- `pnpm test`: 7875 passed, 7 skipped.
- `pnpm lint`, `pnpm format:check`: clean.
- Verified in the browser on a real PDF in scrolled mode: black pills before, dark-on-light pills after in the light theme, and light-on-dark pills in the dark theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)