### PR TITLE
Allow Tauri app to connect to a custom self-hosted instance

### DIFF
--- a/apps/readest-app/src/__tests__/services/runtimeConfig.test.ts
+++ b/apps/readest-app/src/__tests__/services/runtimeConfig.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
+
+import {
+  getSelfHostedLocalConfig,
+  SELF_HOSTED_STORAGE_KEY,
+  type SelfHostedLocalConfig,
+} from '@/services/runtimeConfig';
+
+const validConfig: SelfHostedLocalConfig = {
+  supabaseUrl: 'http://192.168.1.100:8000',
+  supabaseAnonKey: 'eyJhbGciOiJIUzI1NiJ9.test.sig',
+  apiBaseUrl: 'http://192.168.1.100:3000',
+};
+
+describe('getSelfHostedLocalConfig', () => {
+  beforeEach(() => localStorageMock.clear());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns null when key is absent', () => {
+    expect(getSelfHostedLocalConfig()).toBeNull();
+  });
+
+  it('returns parsed config when valid JSON is stored', () => {
+    localStorageMock.setItem(SELF_HOSTED_STORAGE_KEY, JSON.stringify(validConfig));
+    expect(getSelfHostedLocalConfig()).toEqual(validConfig);
+  });
+
+  it('returns null when stored value is malformed JSON', () => {
+    localStorageMock.setItem(SELF_HOSTED_STORAGE_KEY, '{not valid json');
+    expect(getSelfHostedLocalConfig()).toBeNull();
+  });
+
+  it('returns null when localStorage.getItem throws', () => {
+    vi.spyOn(localStorageMock, 'getItem').mockImplementation(() => {
+      throw new Error('storage unavailable');
+    });
+    expect(getSelfHostedLocalConfig()).toBeNull();
+  });
+
+  it('returns config with empty apiBaseUrl when field is empty string', () => {
+    const cfg = { ...validConfig, apiBaseUrl: '' };
+    localStorageMock.setItem(SELF_HOSTED_STORAGE_KEY, JSON.stringify(cfg));
+    expect(getSelfHostedLocalConfig()?.apiBaseUrl).toBe('');
+  });
+
+  it('reflects removal after key is deleted', () => {
+    localStorageMock.setItem(SELF_HOSTED_STORAGE_KEY, JSON.stringify(validConfig));
+    localStorageMock.removeItem(SELF_HOSTED_STORAGE_KEY);
+    expect(getSelfHostedLocalConfig()).toBeNull();
+  });
+});

--- a/apps/readest-app/src/app/library/components/SettingsMenu.tsx
+++ b/apps/readest-app/src/app/library/components/SettingsMenu.tsx
@@ -364,7 +364,7 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
                     : _('Library sync via {{provider}}', { provider: providerNames })
               }
             />
-            {readestEnabled ? (
+            {readestEnabled && !settings.selfHosted?.supabaseUrl ? (
               <button
                 onClick={handleUserProfile}
                 className='hover:bg-base-300 w-full rounded-md'

--- a/apps/readest-app/src/app/user/page.tsx
+++ b/apps/readest-app/src/app/user/page.tsx
@@ -7,6 +7,7 @@ import { useEnv } from '@/context/EnvContext';
 import { useAuth } from '@/context/AuthContext';
 import { useTheme } from '@/hooks/useTheme';
 import { useThemeStore } from '@/store/themeStore';
+import { useSettingsStore } from '@/store/settingsStore';
 import { useQuotaStats } from '@/hooks/useQuotaStats';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useUserActions } from '@/hooks/useUserActions';
@@ -89,6 +90,9 @@ const ProfilePage = () => {
   }, [mounted, user, token, appService, router]);
 
   useTheme({ systemUIVisible: false });
+
+  const { settings } = useSettingsStore();
+  const isSelfHosted = !!settings.selfHosted?.supabaseUrl;
 
   const { quotas, userProfilePlan = 'free' } = useQuotaStats();
   const { handleLogout, handleResetPassword, handleUpdateEmail, handleConfirmDelete } =
@@ -268,8 +272,11 @@ const ProfilePage = () => {
   const avatarUrl = user?.user_metadata?.['picture'] || user?.user_metadata?.['avatar_url'];
   const userFullName = user?.user_metadata?.['full_name'] || '-';
   const userEmail = user?.email || '';
-  const userPlanDetails =
-    getPlanDetails(userProfilePlan, availablePlans) || getPlanDetails('free', availablePlans);
+  const userPlanDetails = isSelfHosted
+    ? ({ name: _('Self-hosted'), color: 'bg-teal-100 text-teal-800' } as unknown as ReturnType<
+        typeof getPlanDetails
+      >)
+    : getPlanDetails(userProfilePlan, availablePlans) || getPlanDetails('free', availablePlans);
 
   return (
     <div
@@ -311,9 +318,10 @@ const ProfilePage = () => {
                     planDetails={userPlanDetails}
                   />
 
-                  {!showStorageManager && !showSharedLinksManager && !showSyncManager && (
-                    <UsageStats quotas={quotas} />
-                  )}
+                  {!isSelfHosted &&
+                    !showStorageManager &&
+                    !showSharedLinksManager &&
+                    !showSyncManager && <UsageStats quotas={quotas} />}
                 </div>
 
                 {showStorageManager ? (
@@ -331,17 +339,19 @@ const ProfilePage = () => {
                   </div>
                 ) : (
                   <>
-                    <div className='flex flex-col gap-y-8 sm:px-6'>
-                      <PlansComparison
-                        availablePlans={availablePlans}
-                        userPlan={userProfilePlan}
-                        onSubscribe={
-                          appService.hasIAP && iapAvailable
-                            ? handleIAPSubscribe
-                            : handleStripeSubscribe
-                        }
-                      />
-                    </div>
+                    {!isSelfHosted && (
+                      <div className='flex flex-col gap-y-8 sm:px-6'>
+                        <PlansComparison
+                          availablePlans={availablePlans}
+                          userPlan={userProfilePlan}
+                          onSubscribe={
+                            appService.hasIAP && iapAvailable
+                              ? handleIAPSubscribe
+                              : handleStripeSubscribe
+                          }
+                        />
+                      </div>
+                    )}
                     <div className='flex flex-col gap-y-8 px-6'>
                       <AccountActions
                         userPlan={userProfilePlan}
@@ -350,10 +360,10 @@ const ProfilePage = () => {
                         onResetPassword={handleResetPassword}
                         onUpdateEmail={handleUpdateEmail}
                         onConfirmDelete={handleDeleteWithMessage}
-                        onRestorePurchase={handleIAPRestorePurchase}
-                        onManageSubscription={handleManageSubscription}
-                        onManageStorage={handleManageStorage}
-                        onManageSharedLinks={handleManageSharedLinks}
+                        onRestorePurchase={isSelfHosted ? undefined : handleIAPRestorePurchase}
+                        onManageSubscription={isSelfHosted ? undefined : handleManageSubscription}
+                        onManageStorage={isSelfHosted ? undefined : handleManageStorage}
+                        onManageSharedLinks={isSelfHosted ? undefined : handleManageSharedLinks}
                         onManageSync={handleManageSync}
                       />
                     </div>

--- a/apps/readest-app/src/components/settings/IntegrationsPanel.tsx
+++ b/apps/readest-app/src/components/settings/IntegrationsPanel.tsx
@@ -14,6 +14,7 @@ import {
   RiDatabase2Line,
   RiGoogleLine,
   RiMicrosoftLine,
+  RiServerLine,
 } from 'react-icons/ri';
 import { useEnv } from '@/context/EnvContext';
 import { useAuth } from '@/context/AuthContext';
@@ -26,11 +27,12 @@ import { useFileSyncStore } from '@/store/fileSyncStore';
 import { CatalogManager } from '@/app/opds/components/CatalogManager';
 import { saveSysSettings } from '@/helpers/settings';
 import { isCloudSyncAllowed } from '@/utils/access';
-import { isWebAppPlatform } from '@/services/environment';
+import { isWebAppPlatform, isTauriAppPlatform } from '@/services/environment';
 import { getGoogleWebClientId } from '@/services/sync/providers/gdrive/buildGoogleDriveProvider';
 import { getMicrosoftClientId } from '@/services/sync/providers/onedrive/buildOneDriveProvider';
 import { navigateToLogin, navigateToProfile } from '@/utils/nav';
 import KOSyncForm from './integrations/KOSyncForm';
+import SelfHostedForm from './integrations/SelfHostedForm';
 import ReadwiseForm from './integrations/ReadwiseForm';
 import HardcoverForm from './integrations/HardcoverForm';
 import SendToReadestForm from './integrations/SendToReadestForm';
@@ -67,6 +69,7 @@ type SubPage =
   | 'hardcover'
   | 'opds'
   | 'send'
+  | 'selfhosted'
   | null;
 
 /**
@@ -377,6 +380,12 @@ const IntegrationsPanel: React.FC = () => {
         <SendToReadestForm onBack={() => setSubPage(null)} />
       </div>
     );
+  if (subPage === 'selfhosted')
+    return (
+      <div className='my-4 w-full'>
+        <SelfHostedForm onBack={() => setSubPage(null)} />
+      </div>
+    );
 
   const koSyncStatus = settings.kosync?.enabled
     ? settings.kosync.username
@@ -647,6 +656,26 @@ const IntegrationsPanel: React.FC = () => {
                 description={_("Display what I'm reading on Discord")}
                 checked={settings.discordRichPresenceEnabled}
                 onChange={toggleDiscordPresence}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {(isTauriAppPlatform() || !!settings.selfHosted?.supabaseUrl) && (
+        <div className='w-full' data-setting-id='settings.integrations.selfhosted'>
+          <SectionTitle className='mb-2'>{_('Advanced')}</SectionTitle>
+          <div className='card eink-bordered border-base-200 bg-base-100 overflow-hidden border'>
+            <div className='divide-base-200 divide-y'>
+              <IntegrationRow
+                icon={RiServerLine}
+                title={_('Self-hosted Instance')}
+                status={
+                  settings.selfHosted?.supabaseUrl
+                    ? settings.selfHosted.supabaseUrl
+                    : _('Using Readest Cloud')
+                }
+                onClick={() => setSubPage('selfhosted')}
               />
             </div>
           </div>

--- a/apps/readest-app/src/components/settings/integrations/SelfHostedForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/SelfHostedForm.tsx
@@ -1,0 +1,196 @@
+import clsx from 'clsx';
+import React, { useState } from 'react';
+import { useEnv } from '@/context/EnvContext';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useSettingsStore } from '@/store/settingsStore';
+import { eventDispatcher } from '@/utils/event';
+import { SELF_HOSTED_STORAGE_KEY, SelfHostedLocalConfig } from '@/services/runtimeConfig';
+import { SelfHostedConfig } from '@/types/settings';
+import SubPageHeader from '../SubPageHeader';
+import { SectionTitle, Tips } from '../primitives';
+
+interface SelfHostedFormProps {
+  onBack: () => void;
+}
+
+const SelfHostedForm: React.FC<SelfHostedFormProps> = ({ onBack }) => {
+  const _ = useTranslation();
+  const { envConfig } = useEnv();
+  const { settings, setSettings, saveSettings } = useSettingsStore();
+
+  const configured = settings.selfHosted;
+
+  const [supabaseUrl, setSupabaseUrl] = useState(configured?.supabaseUrl ?? '');
+  const [supabaseAnonKey, setSupabaseAnonKey] = useState(configured?.supabaseAnonKey ?? '');
+  const [apiBaseUrl, setApiBaseUrl] = useState(configured?.apiBaseUrl ?? '');
+
+  const isValid = supabaseUrl.trim() !== '' && supabaseAnonKey.trim() !== '';
+
+  const persistConfig = async (cfg: SelfHostedConfig | undefined) => {
+    const newSettings = { ...settings, selfHosted: cfg };
+    setSettings(newSettings);
+    await saveSettings(envConfig, newSettings);
+
+    if (cfg) {
+      const local: SelfHostedLocalConfig = {
+        supabaseUrl: cfg.supabaseUrl,
+        supabaseAnonKey: cfg.supabaseAnonKey,
+        apiBaseUrl: cfg.apiBaseUrl,
+      };
+      localStorage.setItem(SELF_HOSTED_STORAGE_KEY, JSON.stringify(local));
+    } else {
+      localStorage.removeItem(SELF_HOSTED_STORAGE_KEY);
+    }
+  };
+
+  const handleSave = async () => {
+    const cfg: SelfHostedConfig = {
+      supabaseUrl: supabaseUrl.trim().replace(/\/$/, ''),
+      supabaseAnonKey: supabaseAnonKey.trim(),
+      apiBaseUrl: apiBaseUrl.trim().replace(/\/$/, ''),
+    };
+    await persistConfig(cfg);
+    eventDispatcher.dispatch('toast', {
+      message: _('Self-hosted instance saved. Restart the app to connect.'),
+      type: 'info',
+    });
+  };
+
+  const handleClear = async () => {
+    await persistConfig(undefined);
+    setSupabaseUrl('');
+    setSupabaseAnonKey('');
+    setApiBaseUrl('');
+    eventDispatcher.dispatch('toast', {
+      message: _('Self-hosted config cleared. Restart the app to reconnect to Readest Cloud.'),
+      type: 'info',
+    });
+  };
+
+  const description = configured
+    ? _('Connected to {{url}}', { url: configured.supabaseUrl })
+    : _('Point this app at your own Readest instance.');
+
+  return (
+    <div className='w-full'>
+      <SubPageHeader
+        parentLabel={_('Integrations')}
+        currentLabel={_('Self-hosted Instance')}
+        description={description}
+        onBack={onBack}
+      />
+
+      <form
+        className='space-y-4'
+        onSubmit={(e) => {
+          e.preventDefault();
+          void handleSave();
+        }}
+      >
+        <div className='space-y-1.5'>
+          <SectionTitle as='label' htmlFor='sh-supabase-url' className='block'>
+            {_('Supabase URL')}
+          </SectionTitle>
+          <input
+            id='sh-supabase-url'
+            type='url'
+            placeholder='http://192.168.1.100:8000'
+            className='input input-bordered eink-bordered h-11 w-full text-sm focus:outline-none'
+            spellCheck='false'
+            value={supabaseUrl}
+            onChange={(e) => setSupabaseUrl(e.target.value)}
+          />
+          <p className='text-base-content/55 text-xs'>
+            {_('SUPABASE_PUBLIC_URL from your docker/.env (host:KONG_HTTP_PORT)')}
+          </p>
+        </div>
+
+        <div className='space-y-1.5'>
+          <SectionTitle as='label' htmlFor='sh-anon-key' className='block'>
+            {_('Anon Key')}
+          </SectionTitle>
+          <input
+            id='sh-anon-key'
+            type='password'
+            placeholder='eyJ...'
+            className='input input-bordered eink-bordered h-11 w-full text-sm focus:outline-none'
+            spellCheck='false'
+            value={supabaseAnonKey}
+            onChange={(e) => setSupabaseAnonKey(e.target.value)}
+            autoComplete='off'
+          />
+          <p className='text-base-content/55 text-xs'>{_('ANON_KEY from your docker/.env')}</p>
+        </div>
+
+        <div className='space-y-1.5'>
+          <SectionTitle as='label' htmlFor='sh-api-base-url' className='block'>
+            {_('Site URL')}
+            <span className='text-base-content/50 ml-1 text-xs font-normal'>{_('(optional)')}</span>
+          </SectionTitle>
+          <input
+            id='sh-api-base-url'
+            type='url'
+            placeholder='http://192.168.1.100:3000'
+            className='input input-bordered eink-bordered h-11 w-full text-sm focus:outline-none'
+            spellCheck='false'
+            value={apiBaseUrl}
+            onChange={(e) => setApiBaseUrl(e.target.value)}
+          />
+          <p className='text-base-content/55 text-xs'>
+            {_(
+              'SITE_URL from your docker/.env (host:3000). Leave blank to use Readest Cloud APIs.',
+            )}
+          </p>
+        </div>
+
+        <div className='flex justify-end gap-3 pt-1'>
+          {configured && (
+            <button
+              type='button'
+              onClick={() => void handleClear()}
+              className={clsx(
+                'eink-bordered',
+                'h-10 rounded-lg px-4 text-sm font-medium',
+                'text-error hover:bg-error/10',
+                'transition-colors duration-150',
+                'focus-visible:ring-error/40 focus-visible:outline-none focus-visible:ring-2',
+              )}
+            >
+              {_('Clear')}
+            </button>
+          )}
+          <button
+            type='submit'
+            disabled={!isValid}
+            className={clsx(
+              'btn btn-primary',
+              'h-10 min-h-10 rounded-lg border-0 px-5 text-sm font-medium',
+              'focus-visible:ring-primary/40 focus-visible:outline-none focus-visible:ring-2',
+              !isValid && 'opacity-60',
+            )}
+          >
+            {_('Save')}
+          </button>
+        </div>
+      </form>
+
+      <div className='mt-5'>
+        <Tips>
+          <li>
+            {_(
+              'Values come from your docker/.env file. Run docker compose up to start your instance.',
+            )}
+          </li>
+          <li>
+            {_('The app must be restarted after saving for the new instance to take effect.')}
+          </li>
+          {configured && (
+            <li>{_('Clear the config and restart to switch back to Readest Cloud.')}</li>
+          )}
+        </Tips>
+      </div>
+    </div>
+  );
+};
+
+export default SelfHostedForm;

--- a/apps/readest-app/src/services/environment.ts
+++ b/apps/readest-app/src/services/environment.ts
@@ -1,6 +1,6 @@
 import { AppService } from '@/types/system';
 import { READEST_NODE_BASE_URL, READEST_WEB_BASE_URL } from './constants';
-import { getRuntimeConfig } from './runtimeConfig';
+import { getRuntimeConfig, getSelfHostedLocalConfig } from './runtimeConfig';
 
 declare global {
   interface Window {
@@ -16,6 +16,7 @@ export const getBaseUrl = () =>
   getRuntimeConfig()?.apiBaseUrl ??
   process.env['API_BASE_URL'] ??
   process.env['NEXT_PUBLIC_API_BASE_URL'] ??
+  getSelfHostedLocalConfig()?.apiBaseUrl ??
   READEST_WEB_BASE_URL;
 export const getNodeBaseUrl = () =>
   process.env['NEXT_PUBLIC_NODE_BASE_URL'] ?? READEST_NODE_BASE_URL;

--- a/apps/readest-app/src/services/runtimeConfig.ts
+++ b/apps/readest-app/src/services/runtimeConfig.ts
@@ -16,6 +16,24 @@ declare global {
 export const getRuntimeConfig = () =>
   typeof window === 'undefined' ? undefined : window.__READEST_RUNTIME_CONFIG;
 
+export const SELF_HOSTED_STORAGE_KEY = 'readest_selfhosted';
+
+export interface SelfHostedLocalConfig {
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  apiBaseUrl: string;
+}
+
+export const getSelfHostedLocalConfig = (): SelfHostedLocalConfig | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(SELF_HOSTED_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as SelfHostedLocalConfig) : null;
+  } catch {
+    return null;
+  }
+};
+
 export const getServerRuntimeConfig = (): ReadestRuntimeConfig => ({
   // Browser runtime config should prefer a public Supabase URL when provided.
   // SUPABASE_URL remains as a backward-compatible fallback for non-split setups.

--- a/apps/readest-app/src/types/settings.ts
+++ b/apps/readest-app/src/types/settings.ts
@@ -72,6 +72,12 @@ export interface ReadSettings {
   customThemes: CustomTheme[];
 }
 
+export interface SelfHostedConfig {
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  apiBaseUrl: string;
+}
+
 export interface KOSyncSettings {
   enabled: boolean;
   serverUrl: string;
@@ -411,6 +417,12 @@ export interface SystemSettings {
    * so existing PIN users are never silently switched to biometric.
    */
   biometricUnlockEnabled?: boolean;
+
+  /**
+   * Self-hosted Readest instance config. Optional — absent means the official
+   * cloud is used. Device-local (excluded from cloud settings backup).
+   */
+  selfHosted?: SelfHostedConfig;
 
   kosync: KOSyncSettings;
   readwise: ReadwiseSettings;

--- a/apps/readest-app/src/utils/supabase.ts
+++ b/apps/readest-app/src/utils/supabase.ts
@@ -1,13 +1,22 @@
 import { createClient } from '@supabase/supabase-js';
-import { getRuntimeConfig } from '@/services/runtimeConfig';
+import { getRuntimeConfig, getSelfHostedLocalConfig } from '@/services/runtimeConfig';
+
+// getSelfHostedLocalConfig() is read once at module-evaluation time so the
+// client is always initialized with a consistent URL for the lifetime of the
+// page. Tauri builds have no server-side runtime-config injection, so the
+// localStorage value is the only way to configure a self-hosted instance
+// without rebuilding the app. A restart is required when the value changes.
+const selfHostedConfig = getSelfHostedLocalConfig();
 
 const supabaseUrl =
   getRuntimeConfig()?.supabaseUrl ||
+  selfHostedConfig?.supabaseUrl ||
   process.env['SUPABASE_URL'] ||
   process.env['NEXT_PUBLIC_SUPABASE_URL'] ||
   atob(process.env['NEXT_PUBLIC_DEFAULT_SUPABASE_URL_BASE64']!);
 const supabaseAnonKey =
   getRuntimeConfig()?.supabaseAnonKey ||
+  selfHostedConfig?.supabaseAnonKey ||
   process.env['SUPABASE_ANON_KEY'] ||
   process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY'] ||
   atob(process.env['NEXT_PUBLIC_DEFAULT_SUPABASE_KEY_BASE64']!);


### PR DESCRIPTION
   Tauri desktop/mobile users can now point the app at their own Readest
   docker stack without rebuilding. The self-hosted Supabase URL, anon key,
   and site URL are saved to both the settings store and localStorage so
   the supabase client (initialized at module-eval time) picks them up on
   the next app start.

   Key changes:
   - runtimeConfig.ts: add getSelfHostedLocalConfig() + SELF_HOSTED_STORAGE_KEY
     for reading the localStorage bridge at module-eval time
   - supabase.ts: read localStorage self-hosted config as a fallback before
     env-var defaults, enabling runtime URL switching without a rebuild
   - environment.ts: getBaseUrl() falls back to selfHosted.apiBaseUrl so API
     calls route to the custom instance
   - settings.ts: add SelfHostedConfig interface and selfHosted? on SystemSettings
   - SelfHostedForm.tsx: new settings sub-page (Supabase URL, Anon Key, Site URL)
     with Save / Clear actions; Clear removes the localStorage key so the next
     restart reconnects to Readest Cloud
   - IntegrationsPanel.tsx: Advanced section with Self-hosted Instance
     on Tauri or whenever selfHosted is already configured (so it can always be cleared)
   - user/page.tsx: hide UsageStats, PlansComparison, and cloud account actions
     when self-hosted is active; show "Self-hosted" plan badge instead
   - SettingsMenu.tsx: hide the storage/translation quota row when self-hosted
   - library/page.tsx: force redirect to /auth when self-hosted is configured and
     no session exists, using the existing keepLogin path
   - runtimeConfig.test.ts: unit tests for getSelfHostedLocalConfig covering
     happy path, missing key, malformed JSON, and thrown storage errors