### PR TITLE
fix: preserve U+200F/U+200E BiDi marks in Persian/Arabic ebooks (#5216)

### DIFF
--- a/apps/readest-app/src/services/transformers/sanitizer.ts
+++ b/apps/readest-app/src/services/transformers/sanitizer.ts
@@ -13,8 +13,12 @@ export const sanitizerTransformer: Transformer = {
     const allowScript = ctx.viewSettings.allowScript;
     if (allowScript) return ctx.content;
 
-    const result = ctx.content.replaceAll('&nbsp;', '&#160;');
-
+    // Protect BiDi control characters that XMLSerializer encodes as numeric
+    // character references, breaking Persian/Arabic text shaping. Both the
+    // literal character and its numeric-entity form (produced by XMLSerializer)
+    // must be restored to the literal after serialization, just like U+00A0.
+    const result = ctx.content.replaceAll('&nbsp;', '&#160;');    
+    
     const sanitized = DOMPurify.sanitize(result, {
       WHOLE_DOCUMENT: true,
       FORBID_TAGS: ['script', 'iframe', 'object', 'embed'],
@@ -48,7 +52,13 @@ export const sanitizerTransformer: Transformer = {
 
     const serializer = new XMLSerializer();
     let serialized = serializer.serializeToString(sanitized);
-    serialized = serialized.replaceAll('&#160;', '&nbsp;').replaceAll('\u00A0', '&nbsp;');
+    serialized = serialized
+      .replaceAll('&#160;', '&nbsp;')
+      .replaceAll('\u00A0', '&nbsp;')
+      .replaceAll('&#x200e;', '\u200E')
+      .replaceAll('&#8206;', '\u200E')
+      .replaceAll('&#x200f;', '\u200F')
+      .replaceAll('&#8207;', '\u200F');
     serialized = '<?xml version="1.0" encoding="utf-8"?>' + DOCTYPE_XHTML11 + serialized;
     serialized = serialized.replace(/(<head[^>]*>)/i, '\n$1');
     serialized = serialized.replace(/(<\/body>)(<\/html>)/i, '$1\n$2');

--- a/apps/readest-app/src/services/transformers/sanitizer.ts
+++ b/apps/readest-app/src/services/transformers/sanitizer.ts
@@ -17,7 +17,7 @@ export const sanitizerTransformer: Transformer = {
     // character references, breaking Persian/Arabic text shaping. Both the
     // literal character and its numeric-entity form (produced by XMLSerializer)
     // must be restored to the literal after serialization, just like U+00A0.
-    const result = ctx.content.replaceAll('&nbsp;', '&#160;');    
+    const result = ctx.content.replaceAll('&nbsp;', '&#160;');
     
     const sanitized = DOMPurify.sanitize(result, {
       WHOLE_DOCUMENT: true,

--- a/apps/readest-app/src/services/transformers/sanitizer.ts
+++ b/apps/readest-app/src/services/transformers/sanitizer.ts
@@ -18,7 +18,7 @@ export const sanitizerTransformer: Transformer = {
     // literal character and its numeric-entity form (produced by XMLSerializer)
     // must be restored to the literal after serialization, just like U+00A0.
     const result = ctx.content.replaceAll('&nbsp;', '&#160;');
-    
+
     const sanitized = DOMPurify.sanitize(result, {
       WHOLE_DOCUMENT: true,
       FORBID_TAGS: ['script', 'iframe', 'object', 'embed'],

--- a/apps/readest-app/src/utils/paragraph.ts
+++ b/apps/readest-app/src/utils/paragraph.ts
@@ -32,7 +32,7 @@ const blockTags = new Set([
 const MAX_BLOCKS = 5000;
 
 const INVISIBLE_TEXT_PATTERN =
-  /[\s\u00a0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000\u200b-\u200d\u2060\ufeff]/g;
+  /[\s\u00a0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000\u200b-\u200f\u2060\ufeff]/g;
 const MEDIA_SELECTOR = 'img, svg, video, audio, canvas, math, iframe, object, embed, hr';
 
 const hasMeaningfulText = (text?: string | null): boolean =>


### PR DESCRIPTION
XMLSerializer encodes U+200F (RLM) and U+200E (LRM) as numeric character references (&#x200f;, &#x200e;) which breaks text shaping for Persian and Arabic scripts. Restore them to literal characters after serialization, using the same round-trip pattern already in place for &nbsp;/U+00A0.

Also extend INVISIBLE_TEXT_PATTERN in paragraph.ts to include U+200E and U+200F (range was \u200b-\u200d, now \u200b-\u200f) so paragraphs containing only bare BiDi control characters are correctly skipped.

Fixes #5216