### PR TITLE
fix(sync): pull the books delta in bounded pages for large libraries

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useSync-paged-books-pull.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useSync-paged-books-pull.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { pullBooksPaged } from '@/hooks/useSync';
+import type { BookDataRecord } from '@/types/book';
+
+const iso = (ms: number) => new Date(ms).toISOString();
+const row = (hash: string, syncedMs: number) =>
+  ({ book_hash: hash, synced_at: iso(syncedMs) }) as unknown as BookDataRecord;
+
+// The books delta is pulled in bounded pages: a delta grown to a 10k-book
+// library in one response exceeded Cloudflare Worker limits (error 1102) and
+// wedged the device — the pull failed forever and the cursor never advanced.
+// The server orders pages by synced_at ascending with tie-completion; the
+// client advances its cursor to the newest row seen and persists it per page
+// so an interrupted initial sync resumes instead of restarting.
+describe('pullBooksPaged', () => {
+  it('walks pages until a short page, advancing the since cursor', async () => {
+    const calls: Array<{ since: number; limit: number }> = [];
+    const pages = [
+      [row('a', 1000), row('b', 2000)],
+      [row('c', 3000), row('d', 4000)],
+      [row('e', 5000)],
+    ];
+    const records = await pullBooksPaged(
+      async (since, limit) => {
+        calls.push({ since, limit });
+        return pages.shift() ?? [];
+      },
+      0,
+      undefined,
+      2,
+    );
+
+    expect(records.map((r) => r.book_hash)).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(calls).toEqual([
+      { since: 0, limit: 2 },
+      { since: 2000, limit: 2 },
+      { since: 4000, limit: 2 },
+    ]);
+  });
+
+  it('keeps the newest occurrence of a row re-read at the cursor boundary', async () => {
+    const pages = [
+      [row('a', 1000), row('b', 2000)],
+      [{ ...row('b', 2500), title: 'newer' } as unknown as BookDataRecord],
+    ];
+    const records = await pullBooksPaged(async () => pages.shift() ?? [], 0, undefined, 2);
+
+    expect(records).toHaveLength(2);
+    expect((records.find((r) => r.book_hash === 'b') as { title?: string }).title).toBe('newer');
+  });
+
+  it('reports the advancing cursor after each page for persistence', async () => {
+    const cursors: number[] = [];
+    const pages = [[row('a', 1000), row('b', 2000)], [row('c', 3000)]];
+    await pullBooksPaged(
+      async () => pages.shift() ?? [],
+      0,
+      (cursor) => cursors.push(cursor),
+      2,
+    );
+
+    expect(cursors).toEqual([2000, 3000]);
+  });
+
+  it('terminates when a full page cannot advance the cursor (boundary ties)', async () => {
+    let calls = 0;
+    const records = await pullBooksPaged(
+      async () => {
+        calls++;
+        return [row('a', 500), row('b', 500)];
+      },
+      500,
+      undefined,
+      2,
+    );
+
+    expect(calls).toBe(1);
+    expect(records).toHaveLength(2);
+  });
+
+  it('keeps the pages already pulled when a later page fails, matching the persisted cursor', async () => {
+    // The cursor is persisted per page; discarding pulled pages on a later
+    // failure would advance the cursor past rows that were never delivered.
+    const cursors: number[] = [];
+    const pages = [[row('a', 1000), row('b', 2000)]];
+    const records = await pullBooksPaged(
+      async () => {
+        const page = pages.shift();
+        if (!page) throw new Error('network down');
+        return page;
+      },
+      0,
+      (cursor) => cursors.push(cursor),
+      2,
+    );
+
+    expect(records.map((r) => r.book_hash)).toEqual(['a', 'b']);
+    expect(cursors).toEqual([2000]);
+  });
+
+  it('rethrows when the first page fails (nothing accumulated)', async () => {
+    await expect(
+      pullBooksPaged(
+        async () => {
+          throw new Error('Not authenticated');
+        },
+        0,
+        undefined,
+        2,
+      ),
+    ).rejects.toThrow('Not authenticated');
+  });
+
+  it('handles a server that ignores limit and returns the whole delta', async () => {
+    const pages: BookDataRecord[][] = [[row('a', 1000), row('b', 2000), row('c', 3000)], []];
+    const calls: number[] = [];
+    const records = await pullBooksPaged(
+      async (since) => {
+        calls.push(since);
+        return pages.shift() ?? [];
+      },
+      0,
+      undefined,
+      2,
+    );
+
+    expect(records).toHaveLength(3);
+    expect(calls).toEqual([0, 3000]);
+  });
+});

--- a/apps/readest-app/src/__tests__/pages/api/sync-books-paged-pull.test.ts
+++ b/apps/readest-app/src/__tests__/pages/api/sync-books-paged-pull.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+// A 10k-book library made GET /api/sync?type=books collapse: the whole delta
+// was accumulated and serialized in one Worker response, exceeding Cloudflare's
+// resource limits (error 1102) for the calibre plugin's since=0 pull and for
+// devices whose pending delta had grown to the whole library. `limit` turns the
+// books pull into a client-driven page: rows ordered by synced_at ASCENDING,
+// completed to the trailing synced_at (batch upserts stamp one now() per
+// statement, so rows share boundary timestamps) — a strict `> cursor` re-pull
+// never skips rows, and a page shorter than `limit` means the delta is done.
+
+type Call = { method: string; args: unknown[] };
+const queries: Call[][] = [];
+const responses: Array<{ data: unknown[] | null; error: { message: string } | null }> = [];
+
+const makeBuilder = () => {
+  const chain: Call[] = [];
+  queries.push(chain);
+  const builder: Record<string, unknown> = {};
+  const rec =
+    (method: string) =>
+    (...args: unknown[]) => {
+      chain.push({ method, args });
+      return builder;
+    };
+  for (const m of ['select', 'eq', 'or', 'gt', 'lt', 'in', 'is', 'order', 'range']) {
+    builder[m] = rec(m);
+  }
+  // Every chain terminal is awaited and destructured as { data, error }; the
+  // real PostgREST builder is itself thenable, so the mock must be too.
+  // biome-ignore lint/suspicious/noThenProperty: mock PostgREST builder is intentionally thenable
+  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(responses.shift() ?? { data: [], error: null });
+  return builder;
+};
+
+const fromMock = vi.fn(() => makeBuilder());
+
+vi.mock('@/utils/supabase', () => ({
+  createSupabaseClient: () => ({ from: fromMock }),
+}));
+vi.mock('@/utils/access', () => ({
+  validateUserAndToken: async () => ({ user: { id: 'u1' }, token: 'tok' }),
+}));
+
+import { GET } from '@/pages/api/sync';
+
+const req = (qs: string) =>
+  new Request(`https://web.readest.com/api/sync?${qs}`, {
+    headers: { authorization: 'Bearer tok' },
+  }) as unknown as NextRequest;
+
+const iso = (ms: number) => new Date(ms).toISOString();
+const row = (hash: string, syncedMs: number) => ({ book_hash: hash, synced_at: iso(syncedMs) });
+const hashes = (body: { books: { book_hash: string }[] }) => body.books.map((b) => b.book_hash);
+const findCalls = (chain: Call[], method: string) => chain.filter((c) => c.method === method);
+
+beforeEach(() => {
+  queries.length = 0;
+  responses.length = 0;
+  fromMock.mockClear();
+});
+
+describe('GET /api/sync?type=books&limit=N (paged pull)', () => {
+  it('returns one ascending page bounded by limit, tie-completed at the trailing synced_at', async () => {
+    responses.push({ data: [row('a', 2000), row('b', 3000)], error: null });
+    // Tie-completion query: every row sharing the trailing synced_at, page rows included.
+    responses.push({ data: [row('b', 3000), row('c', 3000)], error: null });
+
+    const res = await GET(req('type=books&since=1000&limit=2'));
+    const body = await res.json();
+
+    expect(queries).toHaveLength(2);
+    const [page, ties] = queries;
+    expect(findCalls(page!, 'gt')[0]?.args).toEqual(['synced_at', iso(1000)]);
+    expect(findCalls(page!, 'order')[0]?.args).toEqual(['synced_at', { ascending: true }]);
+    expect(findCalls(page!, 'range')[0]?.args).toEqual([0, 1]);
+    expect(findCalls(ties!, 'eq').map((c) => c.args)).toContainEqual(['synced_at', iso(3000)]);
+
+    expect(hashes(body)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('skips tie-completion and returns a short page as-is (delta exhausted)', async () => {
+    responses.push({ data: [row('a', 2000)], error: null });
+
+    const res = await GET(req('type=books&since=1000&limit=2'));
+    const body = await res.json();
+
+    expect(queries).toHaveLength(1);
+    expect(hashes(body)).toEqual(['a']);
+  });
+
+  it('keeps the initial-race dummy tombstone for an empty since=0 page', async () => {
+    responses.push({ data: [], error: null });
+
+    const res = await GET(req('type=books&since=0&limit=2'));
+    const body = await res.json();
+
+    expect(body.books).toHaveLength(1);
+    expect(body.books[0].book_hash).toBe('00000000000000000000000000000000');
+    expect(body.books[0].deleted_at).toBeTruthy();
+  });
+
+  it('leaves the no-limit pull on the full-delta path for old clients', async () => {
+    responses.push({ data: [row('a', 2000)], error: null });
+
+    const res = await GET(req('type=books&since=1000'));
+    const body = await res.json();
+
+    expect(queries).toHaveLength(1);
+    const [q] = queries;
+    expect(findCalls(q!, 'order')[0]?.args).toEqual(['synced_at', { ascending: false }]);
+    expect(findCalls(q!, 'range')[0]?.args).toEqual([0, 999]);
+    expect(hashes(body)).toEqual(['a']);
+  });
+});

--- a/apps/readest-app/src/hooks/useSync.ts
+++ b/apps/readest-app/src/hooks/useSync.ts
@@ -56,6 +56,56 @@ export const countSyncedRecords = (
   return records.filter((rec) => !rec.deleted_at && (type !== 'books' || !!rec.uploaded_at)).length;
 };
 
+export const BOOKS_PULL_PAGE_SIZE = 1000;
+
+/**
+ * Pull the books delta in bounded pages: a delta grown to a whole 10k-book
+ * library in one response exceeded Cloudflare Worker limits (error 1102) and
+ * wedged the device — the pull failed forever and the cursor never advanced.
+ * The server orders each page by synced_at ascending and completes it to the
+ * trailing timestamp, so advancing the cursor to the newest row seen never
+ * skips rows; the millisecond-truncated cursor can re-return boundary rows,
+ * deduped here with last-wins. A page shorter than the limit — or a cursor
+ * that cannot advance — ends the walk. `onPage` runs after each page so the
+ * caller can persist the cursor and an interrupted initial sync resumes
+ * instead of restarting.
+ */
+export async function pullBooksPaged(
+  pull: (since: number, limit: number) => Promise<BookDataRecord[] | null | undefined>,
+  since: number,
+  onPage?: (cursor: number) => void,
+  pageSize = BOOKS_PULL_PAGE_SIZE,
+): Promise<BookDataRecord[]> {
+  const byHash = new Map<string, BookDataRecord>();
+  let cursor = since;
+  for (;;) {
+    let page: BookDataRecord[];
+    try {
+      page = (await pull(cursor, pageSize)) ?? [];
+    } catch (err) {
+      // A failed FIRST page delivered nothing — let the caller handle it
+      // (auth redirect, error surface). A failed LATER page must not discard
+      // the pages already pulled: the cursor persisted by onPage has advanced
+      // past them, so dropping them here would skip their rows forever. Keep
+      // the partial delta — it matches the cursor — and resume next sync.
+      if (cursor === since) throw err;
+      break;
+    }
+    for (const rec of page) {
+      byHash.set(rec.book_hash ?? rec.id, rec);
+    }
+    const pageMax = computeMaxTimestamp(page);
+    if (pageMax > cursor) {
+      cursor = pageMax;
+      onPage?.(cursor);
+    } else if (page.length > 0) {
+      break;
+    }
+    if (page.length < pageSize) break;
+  }
+  return [...byHash.values()];
+}
+
 const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
 export function useSync(bookKey?: string) {
   const router = useRouter();
@@ -129,13 +179,28 @@ export function useSync(bookKey?: string) {
     setSyncError(null);
 
     try {
-      const result = await syncClient.pullChanges(since, type, bookId, metaHash);
-      const resultAsRecord = result as unknown as Record<
-        string,
-        BookDataRecord[] | null | undefined
-      >;
-      setSyncResult({ ...syncResult, [type]: resultAsRecord[type] });
-      const records = resultAsRecord[type];
+      let records: BookDataRecord[] | null | undefined;
+      if (type === 'books' && !bookId && !metaHash) {
+        records = await pullBooksPaged(
+          async (cursor, limit) => {
+            const result = await syncClient.pullChanges(cursor, type, undefined, undefined, limit);
+            return (result as unknown as Record<string, BookDataRecord[] | null | undefined>)[type];
+          },
+          since,
+          (cursor) => {
+            // Persist the cursor per page so an interrupted initial sync
+            // resumes from the last page instead of restarting from `since`.
+            setLastSyncedAt(cursor);
+            const settings = useSettingsStore.getState().settings;
+            settings.lastSyncedAtBooks = cursor;
+            setSettings(settings);
+          },
+        );
+      } else {
+        const result = await syncClient.pullChanges(since, type, bookId, metaHash);
+        records = (result as unknown as Record<string, BookDataRecord[] | null | undefined>)[type];
+      }
+      setSyncResult({ ...syncResult, [type]: records });
       if (since > 1000 && !records?.length) return 0;
       // For since <= 1000, we set lastSyncedAt to now if no records returned
       const maxTime = records?.length ? computeMaxTimestamp(records) : Date.now();

--- a/apps/readest-app/src/pages/api/sync.ts
+++ b/apps/readest-app/src/pages/api/sync.ts
@@ -141,10 +141,10 @@ export async function GET(req: NextRequest) {
   const typeParam = searchParams.get('type') as SyncType | undefined;
   const bookParam = searchParams.get('book');
   const metaHashParam = searchParams.get('meta_hash');
-  // Optional page size for `type=stats` (client-driven paged pull). Absent for
-  // the koplugin, which keeps the full-delta response.
-  const statsLimitParam = searchParams.get('limit');
-  const statsLimit = statsLimitParam ? Math.max(1, Math.floor(Number(statsLimitParam))) : 0;
+  // Optional page size for `type=stats` and `type=books` (client-driven paged
+  // pull). Absent for old clients, which keep the full-delta response.
+  const limitParam = searchParams.get('limit');
+  const limit = limitParam ? Math.max(1, Math.floor(Number(limitParam))) : 0;
 
   if (!sinceParam) {
     return NextResponse.json({ error: '"since" query parameter is required' }, { status: 400 });
@@ -233,8 +233,59 @@ export async function GET(req: NextRequest) {
       (results as unknown as Record<string, SyncRecord[]>)[DBSyncTypeMap[table]] = records || [];
     };
 
+    // One bounded page of books for the app's and the calibre plugin's
+    // client-driven paged pull: a 10k-book delta accumulated into a single
+    // response exceeds the Worker's resource limits (CF error 1102). Rows come
+    // back ordered by synced_at ASCENDING, completed to the trailing synced_at
+    // millisecond — batch upserts stamp one now() per statement, so rows share
+    // boundary timestamps and a strict `> cursor` re-pull would otherwise skip
+    // the rest of a batch split by the page boundary. A page shorter than
+    // `limit` tells the client the delta is exhausted.
+    const fetchPagedBooks = async () => {
+      const bookFilters = <T extends { or: (f: string) => T; eq: (c: string, v: string) => T }>(
+        q: T,
+      ): T => {
+        if (bookParam && metaHashParam) {
+          return q.or(`book_hash.eq.${bookParam},meta_hash.eq.${metaHashParam}`);
+        } else if (bookParam) {
+          return q.eq('book_hash', bookParam);
+        } else if (metaHashParam) {
+          return q.eq('meta_hash', metaHashParam);
+        }
+        return q;
+      };
+      const { data, error } = await bookFilters(
+        supabase
+          .from('books')
+          .select('*')
+          .eq('user_id', user.id)
+          .gt('synced_at', sinceIso)
+          .order('synced_at', { ascending: true })
+          .range(0, limit - 1),
+      );
+      if (error) throw { table: 'books', error } as DBError;
+      const rows = (data ?? []) as SyncRecord[];
+      if (rows.length === limit) {
+        const lastSynced = (rows[rows.length - 1] as unknown as { synced_at: string }).synced_at;
+        const { data: extra, error: extraError } = await bookFilters(
+          supabase.from('books').select('*').eq('user_id', user.id).eq('synced_at', lastSynced),
+        );
+        if (extraError) throw { table: 'books', error: extraError } as DBError;
+        const seen = new Set(rows.map((r) => r.book_hash));
+        for (const r of (extra ?? []) as SyncRecord[]) {
+          if (!seen.has(r.book_hash)) {
+            seen.add(r.book_hash);
+            rows.push(r);
+          }
+        }
+      }
+      results.books = rows;
+    };
+
     if (!typeParam || typeParam === 'books') {
-      await queryTables('books').catch((err) => (errors['books'] = err));
+      const booksQuery =
+        limit > 0 && typeParam === 'books' ? fetchPagedBooks : () => queryTables('books');
+      await booksQuery().catch((err) => (errors['books'] = err));
       // TODO: Remove this hotfix for the initial race condition for books sync
       if (results.books?.length === 0 && since.getTime() < 1000) {
         const dummyHash = '00000000000000000000000000000000';
@@ -308,12 +359,12 @@ export async function GET(req: NextRequest) {
           .eq('user_id', user.id)
           .gt('updated_at', sinceIso)
           .order('updated_at', { ascending: true })
-          .range(0, statsLimit - 1);
+          .range(0, limit - 1);
         if (bookParam) q = q.eq('book_hash', bookParam);
         const { data, error } = await q;
         if (error) return { error };
         const rows = (data ?? []) as Record<string, unknown>[];
-        if (rows.length === statsLimit) {
+        if (rows.length === limit) {
           const lastUpdated = rows[rows.length - 1]!['updated_at'] as string;
           let eq = supabase
             .from('stat_pages')
@@ -339,7 +390,7 @@ export async function GET(req: NextRequest) {
       // stat_books is always returned in full (one row per book, small); only
       // stat_pages pages when the client asks (the koplugin omits `limit`).
       const sb = await fetchAll('stat_books', false);
-      const sp = statsLimit > 0 ? await fetchPagedPages() : await fetchAll('stat_pages', true);
+      const sp = limit > 0 ? await fetchPagedPages() : await fetchAll('stat_pages', true);
       if (sb.error)
         return NextResponse.json(
           { error: `stat_books: ${sb.error.message || 'Unknown error'}` },

--- a/apps/readest-calibre-plugin/api.py
+++ b/apps/readest-calibre-plugin/api.py
@@ -16,6 +16,7 @@ import unicodedata
 import urllib.error
 import urllib.parse
 import urllib.request
+from datetime import datetime, timezone
 
 DEFAULT_API_BASE = 'https://web.readest.com/api'
 DEFAULT_SUPABASE_URL = 'https://readest.supabase.co'
@@ -33,6 +34,24 @@ UPLOAD_TIMEOUT = 600
 # actually served, so asking for more is free and pays off if the cap rises:
 # the listing costs about a second per request regardless of rows returned.
 LIST_PAGE_SIZE = 1000
+# Page size for the books pull. A 10k-book library cannot come back in one
+# response — serializing it exceeded the server's per-request resource limits
+# (Cloudflare error 1102) — so pull_books walks bounded pages instead.
+PULL_PAGE_SIZE = 1000
+
+
+def _synced_at_ms(row):
+    """Epoch ms of a row's synced_at (fallback updated_at); 0 when absent."""
+    value = row.get('synced_at') or row.get('updated_at')
+    if not isinstance(value, str) or not value:
+        return 0
+    try:
+        dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except ValueError:
+        return 0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
 
 
 class ReadestAPIError(Exception):
@@ -294,8 +313,31 @@ class ReadestClient:
         return parsed
 
     def pull_books(self, since=0):
-        result = self._api('GET', '/sync?type=books&since=%d' % since)
-        return (result or {}).get('books') or []
+        """All book rows changed since `since` (epoch ms), pulled in pages.
+
+        The server returns each page ordered by synced_at ascending and
+        completed to the trailing timestamp, so advancing the cursor to the
+        newest row seen and re-asking never skips rows; the millisecond-
+        truncated cursor can re-return boundary rows, deduped here with
+        last-wins. A page shorter than the limit — or a cursor that cannot
+        advance — means the delta is exhausted. A server that ignores `limit`
+        returns everything at once and the follow-up page comes back empty.
+        """
+        by_key = {}
+        cursor = since
+        while True:
+            result = self._api(
+                'GET', '/sync?type=books&since=%d&limit=%d' % (cursor, PULL_PAGE_SIZE)
+            )
+            rows = (result or {}).get('books') or []
+            max_ms = cursor
+            for row in rows:
+                by_key[row.get('book_hash') or row.get('id')] = row
+                max_ms = max(max_ms, _synced_at_ms(row))
+            if len(rows) < PULL_PAGE_SIZE or max_ms <= cursor:
+                break
+            cursor = max_ms
+        return list(by_key.values())
 
     def push_books(self, records):
         return self._api('POST', '/sync', body={'books': records, 'notes': [], 'configs': []})

--- a/apps/readest-calibre-plugin/tests/test_client.py
+++ b/apps/readest-calibre-plugin/tests/test_client.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 import unittest
+from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
@@ -140,6 +141,17 @@ class TokenRefreshTest(unittest.TestCase):
             client.pull_books()
 
 
+def _iso_ms(ms):
+    return datetime.fromtimestamp(ms / 1000, timezone.utc).isoformat()
+
+
+def _rows(start, count):
+    """`count` book rows h<start>.. with synced_at at ms start+1, start+2, ..."""
+    return [
+        {'book_hash': 'h%d' % i, 'synced_at': _iso_ms(i + 1)} for i in range(start, start + count)
+    ]
+
+
 class SyncTest(unittest.TestCase):
     def test_pull_books(self):
         transport = FakeTransport()
@@ -149,9 +161,70 @@ class SyncTest(unittest.TestCase):
 
         req = transport.requests[0]
         self.assertEqual(req['method'], 'GET')
-        self.assertEqual(req['url'], f'{API_BASE}/sync?type=books&since=0')
+        self.assertEqual(req['url'], f'{API_BASE}/sync?type=books&since=0&limit=1000')
         self.assertEqual(req['headers']['authorization'], 'Bearer at')
         self.assertEqual(books, [{'book_hash': 'h1'}])
+
+    # A 10k-book cloud library cannot come back in one response (the server
+    # exceeded Cloudflare Worker limits serializing it — error 1102), so
+    # pull_books walks synced_at-ascending pages, advancing `since` to the
+    # newest row seen until a page comes back shorter than the limit.
+    def test_pull_books_pages_until_short_page(self):
+        transport = FakeTransport()
+        transport.queue(200, {'books': _rows(0, 1000)})  # ms 1..1000
+        transport.queue(200, {'books': _rows(1000, 500)})  # ms 1001..1500
+        client = make_client(transport, tokens=valid_tokens())
+        books = client.pull_books()
+
+        self.assertEqual(len(books), 1500)
+        self.assertEqual(len(transport.requests), 2)
+        self.assertEqual(
+            transport.requests[0]['url'], f'{API_BASE}/sync?type=books&since=0&limit=1000'
+        )
+        self.assertEqual(
+            transport.requests[1]['url'], f'{API_BASE}/sync?type=books&since=1000&limit=1000'
+        )
+
+    def test_pull_books_dedupes_rows_reread_at_the_cursor_boundary(self):
+        # The millisecond-truncated cursor re-includes rows whose synced_at
+        # shares the boundary timestamp; they must not appear twice.
+        transport = FakeTransport()
+        page1 = _rows(0, 1000)
+        page2 = [dict(page1[-1]), {'book_hash': 'h1000', 'synced_at': _iso_ms(2000)}]
+        transport.queue(200, {'books': page1})
+        transport.queue(200, {'books': page2})
+        client = make_client(transport, tokens=valid_tokens())
+        books = client.pull_books()
+
+        hashes = [b['book_hash'] for b in books]
+        self.assertEqual(len(hashes), len(set(hashes)))
+        self.assertEqual(len(books), 1001)
+
+    def test_pull_books_terminates_when_the_cursor_cannot_advance(self):
+        # A full page whose rows all share the cursor timestamp is already
+        # complete (the server tie-completes pages); asking again with the
+        # same cursor would loop forever.
+        transport = FakeTransport()
+        same_ms = [{'book_hash': 'h%d' % i, 'synced_at': _iso_ms(500)} for i in range(1000)]
+        transport.queue(200, {'books': same_ms})
+        client = make_client(transport, tokens=valid_tokens())
+        books = client.pull_books(since=500)
+
+        self.assertIn('limit=1000', transport.requests[0]['url'])
+        self.assertEqual(len(books), 1000)
+        self.assertEqual(len(transport.requests), 1)
+
+    def test_pull_books_handles_a_server_that_ignores_limit(self):
+        # Old servers return the full delta in one response; the follow-up
+        # request from the advanced cursor comes back empty and ends the walk.
+        transport = FakeTransport()
+        transport.queue(200, {'books': _rows(0, 1200)})
+        transport.queue(200, {'books': []})
+        client = make_client(transport, tokens=valid_tokens())
+        books = client.pull_books()
+
+        self.assertEqual(len(books), 1200)
+        self.assertEqual(len(transport.requests), 2)
 
     def test_push_books(self):
         transport = FakeTransport()


### PR DESCRIPTION
## Problem

A user pushed a ~10k-book calibre library and then hit Cloudflare **error 1102 "Worker exceeded resource limits"** on every subsequent plugin push, while their devices stopped pulling (one stuck near 4k books, another near 800) even though Manage Storage showed the full upload.

`GET /api/sync?type=books` accumulates the entire delta in memory: it pages Supabase at 1000 rows per request but concatenates every row and serializes one giant JSON response, which the pages/api wrapper buffers twice more. At 10k rows (each carrying KBs of metadata) that exceeds the Worker's resource limits.

- The calibre plugin starts every push/status run with a full `since=0` pull (`worker.py::_load_cloud_state`), so the failing request is the very first one; the user's error prefix "Could not reach Readest:" pins it exactly. The recent #5325/#5332 fixes do not touch this path.
- The app pulls `since = lastSyncedAtBooks + 1`, but a bulk import bumps `synced_at` on every row, so the pending delta becomes the whole library; the pull fails, the cursor never advances, and the device retries the same impossible request forever (after 3 idle days it resets to a full `since=0` pull, same outcome).

## Changes

- **Server**: `type=books&limit=N` returns one bounded page ordered by `synced_at` ascending, completed to the trailing timestamp. Tie-completion matters: batch upserts stamp one `now()` per 100-row statement, so rows share boundary timestamps and a strict `> cursor` re-pull would otherwise skip the rest of a batch split by the page boundary (same pattern as the stats paged pull; `statsLimit` is now the shared `limit`). Requests without `limit` keep the full-delta response, so existing clients see no behavior change.
- **Calibre plugin**: `pull_books()` walks pages, advancing `since` to the newest row seen, deduping the boundary rows a millisecond-truncated cursor re-returns (last-wins), and stopping on a short page or a non-advancing cursor. A server that ignores `limit` degrades to the previous single full response plus one empty follow-up request.
- **App**: books pulls go through `pullBooksPaged`, which persists `lastSyncedAtBooks` after each page so an interrupted initial sync resumes instead of restarting; wedged devices catch up incrementally once they update. If a later page fails, the pages already pulled are kept (they match the persisted cursor; discarding them would skip their rows forever); a first-page failure rethrows so auth handling still works.

## Tests

- `sync-books-paged-pull.test.ts`: ascending bounded page, tie-completion, short-page fast path, dummy-tombstone hotfix preserved, no-limit path unchanged
- `useSync-paged-books-pull.test.ts`: page walk + cursor advance, boundary dedupe, per-page persistence, tie-stall termination, limit-ignoring server, partial-failure resilience
- plugin `tests/test_client.py`: paging until short page, boundary dedupe, cursor-stall termination, limit-ignoring server

`pnpm test` (7928 passed), `pnpm lint`, `pnpm format:check`, plugin `make test` (109 passed) all green.

## Notes

- Old clients still issue the full-delta pull and stay wedged above the size limit until they ship with this change; capping the no-limit response was deliberately left out to avoid changing legacy semantics (old plugins would mis-plan unpulled books as new, and the koplugin cursor behavior under a capped response is unverified).
- configs/notes keep the full-delta path for now; a very heavy annotator could eventually hit the same wall there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)