### PR TITLE
fix(reader): report image zoom against the image resolution, closes #5362

### DIFF
--- a/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
@@ -84,6 +84,78 @@ describe('ImageViewer', () => {
     expect(img.style.transition).not.toBe('none');
   });
 
+  // Zoom percentage is relative to the image's own resolution (#5362).
+  //
+  // `scale` is relative to the fit-to-screen size, so on its own it says
+  // nothing about how much of the image's detail is actually on screen: fitting
+  // a 1600px illustration into an 800-device-pixel box paints it at half its
+  // resolution while the badge claimed "100%". Because the fit size and the
+  // device pixel ratio differ per device, the same book showed a different
+  // amount of detail on every device at the same reported zoom, and always less
+  // than the extracted file in an external viewer. 100% now means one image
+  // pixel per device pixel — no interpolation, identical detail everywhere.
+  const measuredViewer = ({
+    naturalWidth,
+    offsetWidth,
+    dpr,
+  }: {
+    naturalWidth: number;
+    offsetWidth: number;
+    dpr: number;
+  }) => {
+    Object.defineProperty(window, 'devicePixelRatio', { value: dpr, configurable: true });
+    const { container } = render(
+      <ImageViewer src='blob:test-image' onClose={vi.fn()} gridInsets={gridInsets} />,
+    );
+    const img = container.querySelector('img')!;
+    Object.defineProperty(img, 'naturalWidth', { value: naturalWidth, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: naturalWidth, configurable: true });
+    // `offsetWidth` is the laid-out (untransformed) width, so it stays the
+    // fit-to-screen size at any zoom level.
+    Object.defineProperty(img, 'offsetWidth', { value: offsetWidth, configurable: true });
+    act(() => {
+      fireEvent.load(img);
+    });
+    return { container, img };
+  };
+
+  const zoomPercent = (container: HTMLElement) =>
+    Number(container.querySelector('[aria-label="Zoom level"]')!.textContent!.replace('%', ''));
+
+  it('reports the fraction of the image resolution actually shown when fit to screen', () => {
+    // 1600 image px painted across 400 CSS px * dpr 2 = 800 device px: half the
+    // image's detail is on screen, so the badge must not claim 100%.
+    const { container } = measuredViewer({ naturalWidth: 1600, offsetWidth: 400, dpr: 2 });
+
+    expect(zoomPercent(container)).toBe(50);
+  });
+
+  it('double-click zooms to exactly 1:1 (100% = one image pixel per device pixel)', () => {
+    // Pixel-perfect needs scale 1200 / (400 * 1) = 3, which the old fixed 2x
+    // double-click could never land on.
+    const { container, img } = measuredViewer({ naturalWidth: 1200, offsetWidth: 400, dpr: 1 });
+
+    act(() => {
+      fireEvent.doubleClick(img);
+    });
+
+    expect(img.style.transform).toContain('scale(3)');
+    expect(zoomPercent(container)).toBe(100);
+  });
+
+  it('keeps 1:1 reachable for images larger than the old zoom ceiling', () => {
+    // 1:1 needs scale 50 here, far past the old MAX_SCALE of 8 — the full
+    // resolution of a large illustration was simply unreachable.
+    const { img } = measuredViewer({ naturalWidth: 20000, offsetWidth: 400, dpr: 1 });
+
+    act(() => {
+      fireEvent.wheel(img, { deltaY: -20000, ctrlKey: true, clientX: 100, clientY: 100 });
+    });
+
+    const reachedScale = Number(/scale\(([\d.]+)\)/.exec(img.style.transform)![1]);
+    expect(reachedScale).toBeGreaterThanOrEqual(50);
+  });
+
   // Trackpad pinch flicker (#4742): on macOS a trackpad pinch-to-zoom arrives
   // as a rapid stream of ctrl+wheel events. With the 0.05s transition left on,
   // each event restarts the in-flight transition from its interpolated

--- a/apps/readest-app/src/app/reader/components/ImageViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/ImageViewer.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { IoChevronBack, IoChevronForward } from 'react-icons/io5';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useKeyDownActions } from '@/hooks/useKeyDownActions';
@@ -22,6 +22,9 @@ const MIN_SCALE = 0.5;
 const MAX_SCALE = 8;
 const ZOOM_STEP = 1.2;
 const WHEEL_SENSITIVITY = 0.001;
+// Double-click magnification used when 1:1 is not a zoom in (see
+// `doubleClickScale`), which is what double-click always did before.
+const FALLBACK_DOUBLE_CLICK_SCALE = 2;
 
 const ImageViewer: React.FC<ImageViewerProps> = ({
   src,
@@ -38,6 +41,13 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
   const saveToGallery = appService?.isAndroidApp ?? false;
   const canShare = !saveToGallery && canShareText(appService);
   const [scale, setScale] = useState(1);
+  // `scale` is relative to the fit-to-screen size, which says nothing about how
+  // much of the image's own resolution is on screen: fitting a 1600px
+  // illustration into an 800-device-pixel box paints it at half its detail.
+  // `pixelPerfectScale` is the `scale` at which one image pixel covers exactly
+  // one device pixel, so the zoom badge can report true resolution instead of a
+  // fit-relative number that meant something different on every device (#5362).
+  const [pixelPerfectScale, setPixelPerfectScale] = useState<number | null>(null);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
   const [isWheelZooming, setIsWheelZooming] = useState(false);
@@ -52,6 +62,36 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
 
   // Escape (desktop) and Android Back key → close the viewer.
   useKeyDownActions({ onCancel: onClose });
+
+  const measurePixelPerfectScale = useCallback(() => {
+    const img = imageRef.current;
+    // `offsetWidth` is the laid-out width, which ignores the zoom transform, so
+    // it stays the fit-to-screen size at any zoom level.
+    if (!img?.naturalWidth || !img.offsetWidth) return;
+    const dpr = window.devicePixelRatio || 1;
+    setPixelPerfectScale(img.naturalWidth / (img.offsetWidth * dpr));
+  }, []);
+
+  // A cached image can already be decoded before the load event would fire, and
+  // rotating the device or resizing the window changes the fit size.
+  useEffect(() => {
+    setPixelPerfectScale(null);
+    measurePixelPerfectScale();
+    window.addEventListener('resize', measurePixelPerfectScale);
+    return () => window.removeEventListener('resize', measurePixelPerfectScale);
+  }, [src, measurePixelPerfectScale]);
+
+  // Percentage of the image's own resolution: 100% means one image pixel per
+  // device pixel, so it reads the same on every device and matches what an
+  // external image viewer shows for the extracted file.
+  const zoomPercent = Math.round((scale / (pixelPerfectScale ?? 1)) * 100);
+  // A large illustration in a small window can need more than MAX_SCALE just to
+  // reach its own resolution; never cap zoom below 1:1.
+  const maxScale = pixelPerfectScale ? Math.max(MAX_SCALE, pixelPerfectScale * 2) : MAX_SCALE;
+  // Jump straight to 1:1, unless the image is small enough that fitting already
+  // oversamples it (`pixelPerfectScale` < 1), where 1:1 would zoom *out*.
+  const doubleClickScale =
+    pixelPerfectScale && pixelPerfectScale > 1 ? pixelPerfectScale : FALLBACK_DOUBLE_CLICK_SCALE;
 
   // A macOS trackpad pinch arrives as a rapid stream of ctrl+wheel events.
   // Flag the gesture as active so the transform transition is suppressed while
@@ -78,7 +118,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
   };
 
   const handleZoomIn = () => {
-    const newScale = Math.min(scale * ZOOM_STEP, MAX_SCALE);
+    const newScale = Math.min(scale * ZOOM_STEP, maxScale);
     setScale(newScale);
     hideZoomLabelAfterDelay();
   };
@@ -195,7 +235,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
     const delta = e.deltaY;
     const newScale = Math.min(
       Math.max(scale * Math.exp(-delta * WHEEL_SENSITIVITY), MIN_SCALE),
-      MAX_SCALE,
+      maxScale,
     );
 
     if (newScale <= 1) {
@@ -310,7 +350,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
       const distanceChange = currentDistance / lastTouchDistance.current;
 
       requestAnimationFrame(() => {
-        const newScale = Math.min(Math.max(scale * distanceChange, MIN_SCALE), MAX_SCALE);
+        const newScale = Math.min(Math.max(scale * distanceChange, MIN_SCALE), maxScale);
 
         if (newScale <= 1) {
           setPosition({ x: 0, y: 0 });
@@ -415,7 +455,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
     if (scale === 1) {
       const mouseX = e.clientX - rect.left - rect.width / 2;
       const mouseY = e.clientY - rect.top - rect.height / 2;
-      const newScale = 2;
+      const newScale = doubleClickScale;
 
       setPosition((prevPos) => {
         return getZoomedOffset(mouseX, mouseY, scale, newScale, prevPos);
@@ -532,6 +572,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
           width={0}
           height={0}
           sizes='100vw'
+          onLoad={measurePixelPerfectScale}
           onClick={handleImageClick}
           onMouseDown={handleImageMouseDown}
           onDoubleClick={onDoubleClick}
@@ -561,7 +602,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
           aria-label={_('Zoom level')}
           className='zoom-level-label eink-bordered not-eink:text-white not-eink:bg-black/50 pointer-events-none absolute left-1/2 top-12 -translate-x-1/2 rounded-full px-3 py-1 text-sm transition-opacity duration-300'
         >
-          {Math.round((scale * 100) / 5) * 5}%
+          {zoomPercent}%
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #5362

## Problem

The image viewer's zoom percentage is relative to the **fit-to-screen** size, so it says nothing about how much of the image's own resolution is on screen. Fitting a 1600px illustration into an 800 device pixel box paints it at half its detail while the badge reads `100%`.

Both the fit size and the device pixel ratio differ per device, so the same illustration at the same reported zoom showed a different amount of detail on every device, and always less than the extracted file in an external viewer. For a 1600x2400 illustration:

| Device | device px per image px at "100%" |
| --- | --- |
| Windows 11, 1080p (DPR 1) | 0.43 |
| iPhone XR (DPR 2) | 0.52 |
| Redmi K70 Ultra (DPR 3) | 0.76 |
| Extracted file, external viewer at 100% | **1.00** |

That ordering is exactly what the reporter observed.

## Not a decoding or rendering bug

Worth recording, since both were plausible:

- `convertBlobUrlToDataUrl` uses `FileReader.readAsDataURL` on the raw blob, so the pixels reaching the viewer are byte-exact. No canvas, no re-encode.
- The `will-change: transform` layer promotion added in #4465 does **not** pin the raster scale. Verified in Chrome: at `scale(6)` a 1px grating resolves identically with and without the hint, so full detail is already recoverable by zooming.

The information was never missing. The viewer was discarding it and mislabelling the result, which is also why super-resolution would be the wrong tool here: at the default view there is no missing detail to reconstruct, and invented detail is a visible defect on line art and text-bearing illustrations.

## Fix

Measure the scale at which one image pixel covers exactly one device pixel, and report zoom against that. `100%` now means no interpolation and reads the same on every device.

- **Honest badge.** Opening a large illustration now reads e.g. `43%`, telling the user they are zoomed out, instead of claiming `100%`.
- **Double-click jumps to 1:1.** Multiplicative 1.2x steps can never land on 100%, so the snap point matters. Falls back to the old fixed 2x when the image is small enough that fitting already oversamples it, where 1:1 would zoom *out*.
- **The ceiling can no longer sit below 1:1.** `MAX_SCALE` is fit-relative, so an illustration more than 8x the fit size previously could not be viewed at its own resolution at all.

The initial view is unchanged: images still open fit to screen, now labelled with the resolution they are actually showing.

`TableViewer` carries the same badge expression but scales HTML, which is resolution-independent, so fit-relative is correct there and it is deliberately untouched.

## Verification

- 3 new tests, written failing first (`100` vs `50`, `scale(2)` vs `scale(3)`, `8` vs `>=50`), then passing.
- `pnpm test` 7920 passed, 7 skipped
- `pnpm lint` clean, `pnpm format:check` clean
- Checked against a real layout engine: `offsetWidth` stays the untransformed fit width under the zoom transform, and at the computed scale the painted device pixels equal `naturalWidth` exactly (1800 = 1800).

🤖 Generated with [Claude Code](https://claude.com/claude-code)