### PR TITLE
fix: disable hardcoded debug flag in AI logger

### DIFF
--- a/apps/readest-app/src/services/ai/logger.ts
+++ b/apps/readest-app/src/services/ai/logger.ts
@@ -1,4 +1,4 @@
-const DEBUG = true;
+const DEBUG = false;
 const PREFIX = '[AI]';
 
 type LogLevel = 'info' | 'warn' | 'error' | 'debug';


### PR DESCRIPTION
## Summary

- Disabled the hardcoded `DEBUG = true` flag in `apps/readest-app/src/services/ai/logger.ts`

## Changes

**`apps/readest-app/src/services/ai/logger.ts`** (line 1)

`const DEBUG = true` → `const DEBUG = false`

The debug flag was left enabled, causing all AI service operations (chunk processing, embedding, vector/BM25 search, chat, RAG indexing) to emit verbose console.log output in production builds. This leaks internal implementation details to end users and adds unnecessary overhead.

## Test plan

- [x] Verified that setting `DEBUG = false` silences all AI debug logging via the early return on line 19
- [x] No functional change — all AI features work identically, just without console output