### PR TITLE
fix(translate): restore Yandex auto-detection and translated TTS

### DIFF
--- a/apps/readest-app/src/__tests__/document/tts.test.ts
+++ b/apps/readest-app/src/__tests__/document/tts.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { textWalker } from 'foliate-js/text-walker.js';
 import { TTS } from 'foliate-js/tts.js';
 import { createRejectFilter } from '@/utils/node';
+import { filterSSMLWithLang, parseSSMLMarks } from '@/utils/ssml';
 
 const createHTMLDoc = (bodyHTML: string, attrs: Record<string, string> = {}): Document => {
   const parser = new DOMParser();
@@ -409,6 +410,41 @@ describe('TTS', () => {
       const text = stripTags(ssml!);
       expect(text.startsWith('Last one')).toBe(true);
       expect(text).not.toContain('immortals');
+    });
+  });
+
+  describe('translations added during playback', () => {
+    it('keeps a mark for the first translated sentence after filtering out source text', () => {
+      const doc = createHTMLDoc(
+        '<p>Source sentence.<font lang="fr">Phrase traduite une. Phrase traduite deux.</font></p>',
+        { lang: 'en' },
+      );
+      const tts = new TTS(doc, textWalker, undefined, highlight, 'sentence');
+
+      const translatedSSML = filterSSMLWithLang(tts.start()!, 'fr');
+      const { plainText, marks } = parseSSMLMarks(translatedSSML);
+
+      expect(plainText).toContain('Phrase traduite une');
+      expect(marks).not.toHaveLength(0);
+      expect(marks[0]?.offset).toBe(0);
+    });
+
+    it('keeps the first sentence when a translated paragraph contains multiple sentences', () => {
+      const doc = createHTMLDoc(
+        '<p>Source sentence.<font lang="ru">О все воинство небесное! О земля! Что дальше?</font></p>',
+        { lang: 'en' },
+      );
+      const tts = new TTS(doc, textWalker, undefined, highlight, 'sentence');
+
+      const translatedSSML = filterSSMLWithLang(tts.start()!, 'ru');
+      const { marks } = parseSSMLMarks(translatedSSML);
+
+      expect(marks.map(({ text }) => text)).toEqual([
+        'О все воинство небесное! ',
+        'О земля! ',
+        'Что дальше?',
+      ]);
+      expect(marks[0]?.offset).toBe(0);
     });
   });
 

--- a/apps/readest-app/src/__tests__/services/translators/providers.test.ts
+++ b/apps/readest-app/src/__tests__/services/translators/providers.test.ts
@@ -251,14 +251,14 @@ describe('yandexProvider', () => {
     expect(mockTauriFetch).not.toHaveBeenCalled();
   });
 
-  it('uses automatic detection when source language is AUTO', async () => {
+  it('omits source_lang for automatic detection when source language is AUTO', async () => {
     mockYandexFlow(() => ({ code: 200, lang: 'en-fr', text: ['Bonjour'] }));
 
     const { yandexProvider } = await import('@/services/translators/providers/yandex');
     await yandexProvider.translate(['Hello'], 'AUTO', 'fr');
 
     const query = new URLSearchParams(String(translateCalls()[0]![0]).split('?')[1]);
-    expect(query.get('source_lang')).toBe('auto');
+    expect(query.has('source_lang')).toBe(false);
   });
 
   it.each(['zh-Hans', 'zh-Hant'])('normalizes Chinese locale %s to zh', async (targetLang) => {

--- a/apps/readest-app/src/services/translators/providers/yandex.ts
+++ b/apps/readest-app/src/services/translators/providers/yandex.ts
@@ -241,7 +241,6 @@ async function translateChunk(
   const params = new URLSearchParams({
     ...baseParams(),
     sid: `${sid}-5-0`,
-    source_lang: sourceLang,
     target_lang: targetLang,
     reason: 'paste',
     format: 'text',
@@ -249,6 +248,7 @@ async function translateChunk(
     disable_cache: 'false',
     ajax: '1',
   });
+  if (sourceLang) params.set('source_lang', sourceLang);
   const body = new URLSearchParams([
     ['options', '0'],
     ['text', text],
@@ -309,7 +309,9 @@ export const yandexProvider: TranslationProvider = {
       const normalized = normalizeToShortLang(lang).toLowerCase();
       return normalized === 'zh' || normalized.startsWith('zh-') ? 'zh' : normalized;
     };
-    const source_lang = sourceLang === 'AUTO' ? 'auto' : normalizeLang(sourceLang);
+    // The classic Yandex endpoint auto-detects only when source_lang is absent;
+    // passing source_lang=auto is rejected as "Invalid parameter: source_lang".
+    const source_lang = sourceLang === 'AUTO' ? '' : normalizeLang(sourceLang);
     const target_lang = normalizeLang(targetLang);
     const chunkedTexts = texts.map((text) => splitTextIntoChunks(text, MAX_CHARS_PER_REQUEST));
     const chunkCount = chunkedTexts.reduce((total, chunks) => total + chunks.length, 0);

--- a/apps/readest-app/src/utils/ssml.ts
+++ b/apps/readest-app/src/utils/ssml.ts
@@ -159,7 +159,7 @@ export const filterSSMLWithLang = (
   }
 
   // Check if target matches any <lang> block
-  const langBlocks: Array<{ match: string; lang: string; content: string }> = [];
+  const langBlocks: Array<{ match: string; lang: string; content: string; index: number }> = [];
   const langBlockRegex = /<lang\s+xml:lang="([^"]+)"[^>]*>(.*?)<\/lang>/gs;
   let match: RegExpExecArray | null;
 
@@ -171,6 +171,7 @@ export const filterSSMLWithLang = (
         match: match[0]!,
         lang: match[1]!,
         content: match[2]!,
+        index: match.index,
       });
     }
   }
@@ -183,7 +184,26 @@ export const filterSSMLWithLang = (
       return ssml;
     }
 
-    const combinedContent = langBlocks.map((block) => block.match).join('');
+    const combinedContent = langBlocks
+      .map((block) => {
+        const firstMarkIndex = block.content.search(/<mark\b[^>]*\/>/i);
+        const textBeforeFirstMark = block.content
+          .slice(0, firstMarkIndex < 0 ? undefined : firstMarkIndex)
+          .replace(/<[^>]+>/g, '')
+          .trim();
+        if (!textBeforeFirstMark) return block.match;
+
+        // Foliate can place the mark for the first translated sentence
+        // immediately before its <lang> block. Keep that existing mark when
+        // source text is filtered out, even when later translated sentences
+        // already have marks of their own.
+        const precedingMarks = ssml.slice(0, block.index).match(/<mark\b[^>]*\/>/gi);
+        const precedingMark = precedingMarks?.at(-1);
+        if (!precedingMark) return block.match;
+
+        return block.match.replace(/(<lang\b[^>]*>)/i, `$1${precedingMark}`);
+      })
+      .join('');
     return `${speakOpenMatch[0]}${combinedContent}${speakCloseMatch[0]}`;
   }
 


### PR DESCRIPTION
﻿## Summary

- fix Yandex Translate auto-detection by omitting `source_lang` instead of sending the unsupported `source_lang=auto`
- preserve the first translated sentence when TTS is configured to read translated text only
- add regression coverage for translated paragraphs with and without later sentence marks

## Problem

### Yandex Translate auto-detection

The classic Yandex `tr.json` endpoint rejects `source_lang=auto` with HTTP 400:

```json
{"code":502,"message":"Invalid parameter: source_lang"}
```

Auto-detection works when `source_lang` is omitted entirely. The provider now leaves the parameter out for `AUTO` while continuing to send normalized explicit source languages.

### Translated-text TTS

Foliate can place the mark for the first translated sentence immediately before the translated `<lang>` block, while marks for later sentences remain inside the block. Filtering SSML to the target language removed the first mark, leaving initial translated text without an active mark. `parseSSMLMarks()` then omitted that first sentence, so playback started from the next one.

`filterSSMLWithLang()` now preserves the nearest preceding Foliate mark whenever pronounceable translated text appears before the first internal mark. Existing mark names are retained so playback highlighting continues to map back to Foliate ranges.

## TTS videos

Both videos use the **Read translated text only** setting.

### Before the fix

When playback moves to the next paragraph, TTS skips some of its sentences. The skipped text is visible on screen and can also be heard missing from the narration.


https://github.com/user-attachments/assets/2710fe71-7a95-4811-837a-578cbf95a6a7



### After the fix

With the same book and TTS settings, playback reads the next paragraph from its first sentence without skipping any translated text.


https://github.com/user-attachments/assets/4f1e37f2-1a8c-477c-9b91-e33a7773cc91



## Testing

- `apps/readest-app/src/__tests__/document/tts.test.ts`: 34 passed
- `apps/readest-app/src/__tests__/services/translators/providers.test.ts`: 44 passed
- reproduced the TTS regression under the IDE debugger before the fix and confirmed all three translated sentence marks after the fix
- verified Yandex AUTO translation against the live web endpoint: requests without `source_lang` returned HTTP 200 and rendered translated text

## Notes

`pnpm format:check` from the pre-push hook could not complete on Windows because Biome reported repository-wide CRLF differences in unrelated files. The changed files passed the staged Biome formatter and `git diff --check`.
