### PR TITLE
fix(sync): stop a local-only delete from wiping the Drive copy (#5265)

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/useOpenBook.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/useOpenBook.test.tsx
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import type { Book } from '@/types/book';
+import type { AppService } from '@/types/system';
+import type { EnvConfigType } from '@/services/environment';
+
+/**
+ * Issue #5265 (the residue of #5084): "Delete locally" must never cost the user
+ * their Google Drive copy.
+ *
+ * The only automatic route into the destructive `handleBookDelete('both')` is
+ * this hook's stale-record cleanup: a book whose local file is missing is
+ * offered for deletion, the confirm tombstones it, and the file sync then GCs
+ * the book's directory off the remote. #5087 fixed the misclassification that
+ * fed it (peers adopting a foreign `filePath`, provider-synced books never
+ * stamped `uploadedAt`) — but a device that synced on an older build still
+ * carries poisoned rows, so the escalation itself has to stop being possible:
+ * a missing LOCAL file is not evidence that the REMOTE copy is unwanted.
+ */
+
+const routing = vi.hoisted(() => ({
+  backends: [] as ('webdav' | 'gdrive' | 's3' | 'onedrive')[],
+}));
+
+const isBookAvailable = vi.hoisted(() => vi.fn(async () => false));
+const navigateToReader = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (text: string) => text,
+}));
+
+vi.mock('@/hooks/useAppRouter', () => ({
+  useAppRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock('@/utils/nav', () => ({
+  navigateToReader,
+  showReaderWindow: vi.fn(),
+}));
+
+vi.mock('@/services/sync/cloudSyncProvider', () => ({
+  getActiveFileSyncBackends: () => routing.backends,
+}));
+
+const appService = {
+  isBookAvailable,
+  hasWindow: false,
+  saveLibraryBooks: vi.fn(async () => {}),
+} as unknown as AppService;
+
+const envConfig = { getAppService: async () => appService } as unknown as EnvConfigType;
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig, appService }),
+}));
+
+const { useOpenBook } = await import('@/app/library/hooks/useOpenBook');
+const { eventDispatcher } = await import('@/utils/event');
+
+const makeBook = (over: Partial<Book> = {}): Book => ({
+  hash: 'h1',
+  format: 'EPUB',
+  title: 'Title',
+  sourceTitle: 'Title',
+  author: 'Author',
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...over,
+});
+
+const setup = (downloadOk = true) => {
+  const handleBookDownload = vi.fn(async () => downloadOk);
+  const { result } = renderHook(() => useOpenBook({ setLoading: vi.fn(), handleBookDownload }));
+  return { result, handleBookDownload };
+};
+
+/** `openBook` hands the reader navigation to a setTimeout(0); let it land. */
+const flushNavigation = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+let deleteIntents: string[][] = [];
+
+eventDispatcher.on('delete-books', (event: CustomEvent) => {
+  deleteIntents.push(event.detail.ids as string[]);
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  routing.backends = [];
+  isBookAvailable.mockResolvedValue(false);
+  deleteIntents = [];
+});
+
+describe('useOpenBook — a missing local file must not delete the cloud copy (#5265)', () => {
+  it('never offers to delete a book whose bytes may still be on the file mirror', async () => {
+    routing.backends = ['gdrive'];
+    // The row right after "Remove from Device Only" on a device whose library
+    // was poisoned by a pre-#5087 client: a peer's absolute `filePath`, and no
+    // `uploadedAt` because the engine kept misreading that path as the source.
+    const book = makeBook({ filePath: 'C:\\Users\\other\\Book.epub', downloadedAt: null });
+
+    const { result, handleBookDownload } = setup();
+    await result.current.openBook(book);
+    await flushNavigation();
+
+    expect(deleteIntents).toEqual([]);
+    // Instead of proposing a deletion, fetch the book back from the mirror.
+    expect(handleBookDownload).toHaveBeenCalledTimes(1);
+    expect(navigateToReader).toHaveBeenCalled();
+  });
+
+  it('still cleans up a stale in-place record when no mirror could hold the book', async () => {
+    routing.backends = [];
+    const book = makeBook({ filePath: '/home/reader/moved-away.epub' });
+
+    const { result } = setup();
+    await result.current.openBook(book);
+    await flushNavigation();
+
+    expect(deleteIntents).toEqual([['h1']]);
+    expect(navigateToReader).not.toHaveBeenCalled();
+  });
+
+  it('reports failure rather than deleting when the mirror does not have it either', async () => {
+    routing.backends = ['gdrive'];
+    const book = makeBook({ filePath: 'C:\\Users\\other\\Book.epub' });
+
+    const { result } = setup(false);
+    await result.current.openBook(book);
+    await flushNavigation();
+
+    expect(deleteIntents).toEqual([]);
+    expect(navigateToReader).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/__tests__/services/sync/file/appLocalStore.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/appLocalStore.test.ts
@@ -125,3 +125,61 @@ describe('createAppLocalStore — library hydration (data-loss guard)', () => {
     expect(savedLibrary!.find((b) => b.hash === 'a')!.uploadedAt).toBe(900);
   });
 });
+
+/**
+ * #5265 — the residue of #5084. Devices that synced on a pre-#5087 build hold
+ * library rows carrying a PEER's absolute `filePath`, adopted from the shared
+ * library.json. The upload source resolvers preferred that path blindly, so a
+ * book whose managed copy `Books/<hash>/…` was sitting right there resolved to
+ * 'no-source': the engine never confirmed the file, never stamped
+ * `uploadedAt`, and the row stayed classified as a purely-local book — which is
+ * what lets "Remove from Device Only" end in a cloud-and-device delete that GCs
+ * the book off Google Drive.
+ *
+ * `resolveBookContentSource` already documents the right precedence ("prefer the
+ * managed copy when it exists; book.filePath is device-local and can outlive a
+ * prior in-place/import mode"); these resolvers must follow it.
+ */
+describe('createAppLocalStore — a stale filePath must not mask the managed copy (#5265)', () => {
+  const STALE = 'C:\\Users\\other-device\\Books\\Book h1.epub';
+
+  beforeEach(() => {
+    appService.exists = vi.fn(async (path: string) => path !== STALE);
+    appService.openFile = vi.fn(async () => new File([new Uint8Array(4)], 'h1.epub'));
+    appService.resolveFilePath = vi.fn(async (path: string) => `/root/Books/${path}`);
+  });
+
+  test('loadBookFile reads the managed copy when filePath points nowhere', async () => {
+    const bytes = await makeStore().loadBookFile(makeBook('h1', { filePath: STALE }));
+
+    expect(bytes).not.toBeNull();
+    expect(bytes!.size).toBe(4);
+    expect(appService.openFile).toHaveBeenCalledWith('h1/Book h1.epub', 'Books');
+  });
+
+  test('resolveLocalBookPath resolves the managed copy when filePath points nowhere', async () => {
+    const src = await makeStore().resolveLocalBookPath(makeBook('h1', { filePath: STALE }));
+
+    expect(src).not.toBeNull();
+    expect(src!.path).toBe('/root/Books/h1/Book h1.epub');
+    expect(appService.resolveFilePath).toHaveBeenCalledWith('h1/Book h1.epub', 'Books');
+  });
+
+  test('an in-place book still uploads from its external source', async () => {
+    const inPlace = '/home/reader/Calibre/Book h1.epub';
+    // No managed copy — only the user's own file at an external location.
+    appService.exists = vi.fn(async (path: string) => path === inPlace);
+
+    const src = await makeStore().resolveLocalBookPath(makeBook('h1', { filePath: inPlace }));
+
+    expect(src!.path).toBe('/root/Books/' + inPlace);
+    expect(appService.resolveFilePath).toHaveBeenCalledWith(inPlace, 'None');
+  });
+
+  test('a book on no device at all is still reported as having no source', async () => {
+    appService.exists = vi.fn(async () => false);
+
+    expect(await makeStore().loadBookFile(makeBook('h1', { filePath: STALE }))).toBeNull();
+    expect(await makeStore().resolveLocalBookPath(makeBook('h1', { filePath: STALE }))).toBeNull();
+  });
+});

--- a/apps/readest-app/src/app/library/hooks/useOpenBook.ts
+++ b/apps/readest-app/src/app/library/hooks/useOpenBook.ts
@@ -7,6 +7,16 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { useAppRouter } from '@/hooks/useAppRouter';
 import { eventDispatcher } from '@/utils/event';
 import { navigateToReader, showReaderWindow } from '@/utils/nav';
+import { getActiveFileSyncBackends } from '@/services/sync/cloudSyncProvider';
+
+/**
+ * Whether a third-party file mirror (WebDAV / Google Drive / S3 / OneDrive) is
+ * switched on. Read straight off the store: the callbacks below are memoized
+ * without `settings` in their dependency list, so a captured copy would go
+ * stale the moment the user toggles a provider.
+ */
+const hasFileSyncMirror = (): boolean =>
+  getActiveFileSyncBackends(useSettingsStore.getState().settings).length > 0;
 
 interface UseOpenBookOptions {
   setLoading: Dispatch<SetStateAction<boolean>>;
@@ -33,8 +43,12 @@ export const useOpenBook = ({ setLoading, handleBookDownload }: UseOpenBookOptio
   const makeBookAvailable = useCallback(
     async (book: Book) => {
       // A book with no cloud copy has nothing to fetch; `openBook` below already
-      // handles the case where such a book's local file is gone.
-      if (!book.uploadedAt) return true;
+      // handles the case where such a book's local file is gone. `uploadedAt` is
+      // not the whole story for a file backend: it is stamped by the sync engine,
+      // so a row it has not reconciled yet (or one poisoned by a pre-#5087
+      // client, #5265) can be sitting on the mirror without carrying the stamp.
+      // Ask the mirror before giving up on it.
+      if (!book.uploadedAt && !hasFileSyncMirror()) return true;
       // The row's `downloadedAt` is not proof that the file is still here: a
       // "Remove from Device Only" evicts the file, and an in-place original can
       // be moved or deleted behind our back. Probe, and re-fetch from the cloud
@@ -70,7 +84,14 @@ export const useOpenBook = ({ setLoading, handleBookDownload }: UseOpenBookOptio
       // instead of opening the reader only to fail and bounce back. Restricted
       // to purely-local in-place books — cloud-synced books (`uploadedAt`) still
       // go through `makeBookAvailable`'s on-demand download path.
-      if (book.filePath && !book.uploadedAt && !book.deletedAt) {
+      //
+      // This dispatch is the only automatic route into `handleBookDelete('both')`,
+      // which tombstones the book and lets the file sync GC its directory off the
+      // remote — so a device with a file mirror must never take it (#5265). A
+      // missing LOCAL file is not evidence that the user wants the REMOTE copy
+      // destroyed, and there the book is very likely still on the mirror;
+      // `makeBookAvailable` below fetches it back instead.
+      if (book.filePath && !book.uploadedAt && !book.deletedAt && !hasFileSyncMirror()) {
         const available = await appService?.isBookAvailable(book);
         if (!available) {
           eventDispatcher.dispatch('toast', {

--- a/apps/readest-app/src/services/sync/file/appLocalStore.ts
+++ b/apps/readest-app/src/services/sync/file/appLocalStore.ts
@@ -1,4 +1,5 @@
-import { AppService } from '@/types/system';
+import { Book } from '@/types/book';
+import { AppService, BaseDir } from '@/types/system';
 import { SystemSettings } from '@/types/settings';
 import { EnvConfigType } from '@/services/environment';
 import { useLibraryStore } from '@/store/libraryStore';
@@ -6,15 +7,36 @@ import { getCoverFilename, getLocalBookFilename } from '@/utils/book';
 import { LocalStore } from './localStore';
 
 /**
+ * Where this device's copy of the book actually is, or null when it holds none
+ * (the engine's `no-source` verdict). In-place imports keep their bytes outside
+ * `Books/<hash>/`, so `book.filePath` is a valid fallback — but only a fallback.
+ * The managed copy wins, exactly as `resolveBookContentSource` puts it:
+ * "book.filePath is device-local and can outlive a prior in-place/import mode".
+ *
+ * Preferring `filePath` blindly is what kept #5084 alive into #5265. A row
+ * poisoned by a pre-#5087 client carries a PEER's absolute path; probing only
+ * that path reports `no-source` for a book whose managed copy is sitting right
+ * there, so the engine never confirms the file on the remote and never stamps
+ * `uploadedAt` — leaving the row classified as a purely-local book, the state
+ * that turns "Remove from Device Only" into a cloud-and-device delete.
+ */
+const resolveLocalSource = async (
+  appService: AppService,
+  book: Book,
+): Promise<{ path: string; base: BaseDir } | null> => {
+  const managed = getLocalBookFilename(book);
+  if (await appService.exists(managed, 'Books')) return { path: managed, base: 'Books' };
+  if (book.filePath && (await appService.exists(book.filePath, 'None'))) {
+    return { path: book.filePath, base: 'None' };
+  }
+  return null;
+};
+
+/**
  * The app-backed {@link LocalStore} used by every file-sync consumer (the
  * reader hook and the library "Sync now" form). Consolidating the buffered +
  * streaming book/cover loaders here is the whole reason the bridge exists:
  * the logic used to be copy-pasted across both consumers.
- *
- * In-place imports keep their bytes outside `Books/<hash>/`, so the book-file
- * helpers resolve to `(book.filePath, 'None')` when `filePath` is set and fall
- * through to the hash-copy `Books`-relative path otherwise — mirroring
- * `cloudService.uploadBook` so sync treats in-place books as first-class.
  */
 export const createAppLocalStore = ({
   appService,
@@ -29,18 +51,17 @@ export const createAppLocalStore = ({
   saveBookConfig: (book, config) => appService.saveBookConfig(book, config, settings),
 
   loadBookFile: async (book) => {
-    const fp = book.filePath ?? getLocalBookFilename(book);
-    const base = book.filePath ? 'None' : 'Books';
-    if (!(await appService.exists(fp, base))) return null;
-    const file = await appService.openFile(fp, base);
+    const source = await resolveLocalSource(appService, book);
+    if (!source) return null;
+    const file = await appService.openFile(source.path, source.base);
     const bytes = await file.arrayBuffer();
     return { bytes, size: bytes.byteLength };
   },
 
   resolveLocalBookPath: async (book) => {
-    const fp = book.filePath ?? getLocalBookFilename(book);
-    const base = book.filePath ? 'None' : 'Books';
-    if (!(await appService.exists(fp, base))) return null;
+    const source = await resolveLocalSource(appService, book);
+    if (!source) return null;
+    const { path: fp, base } = source;
     const file = await appService.openFile(fp, base);
     const size = file.size;
     // Release the FD before streaming so the Tauri side can re-open the path


### PR DESCRIPTION
Fixes #5265.

## Why #5087 was not enough

v0.11.20 does contain the #5084 fix (`git tag --contains 5834bbccf` -> `v0.11.20`), so this is a residue rather than a revert.

`stripDeviceLocalFields` heals rows on **adoption**, which only fires for hashes not already in the local library, and `mergeBookMetadata` deliberately preserves the local `filePath`. A row poisoned before the upgrade (carrying a peer's absolute path adopted from a <=0.11.18 `library.json`) is therefore never healed. From there:

1. `appLocalStore` resolved the upload source as ``book.filePath ?? getLocalBookFilename(book)``, so `filePath` won unconditionally. A poisoned row resolves to a path that cannot exist on this device, and `pushBookFile` returns `no-source` for a book whose managed copy `Books/<hash>/...` is sitting right there. The file is never confirmed on the remote, the hash never enters `uploadedHashes`, `stampCloudCopy` never runs, and `uploadedAt` stays null forever.
2. `uploadedAt` null plus `filePath` set is exactly the "purely-local book" classification. Once "Remove from Device Only" evicts the managed copy, the next tap hits `useOpenBook`'s stale-record cleanup, which offers "Book file no longer exists. Confirm deletion...". The confirm runs `handleBookDelete('both')` -> tombstone -> `dirsToGc` GCs the hash dir off Google Drive.

Corroborating detail: `book.filePath` is assigned in exactly one place (`bookService.ts:678`, in-place / transient imports only), so on a device that only ever imported normally, any `filePath` is by definition foreign.

## Changes

**`services/sync/file/appLocalStore.ts`** - new `resolveLocalSource()`: managed copy first, `filePath` only as a fallback. This is the precedence `resolveBookContentSource` already documents ("book.filePath is device-local and can outlive a prior in-place/import mode"); the sync bridge was the odd one out. In-place books still upload from their external source, and a book present on no device still reports `no-source`.

**`app/library/hooks/useOpenBook.ts`** - that dispatch is the only automatic route into `handleBookDelete('both')`, so it is skipped entirely when a file mirror is active, and `makeBookAvailable` no longer early-returns on `!uploadedAt`, so the book is re-fetched from the mirror instead. With no mirror configured the stale in-place cleanup behaves exactly as before.

The invariant worth keeping: **a missing local file must never escalate to a remote deletion.** Only two call sites can delete a remote book dir, `dirsToGc` in `engine.ts` and `WebDAVBrowsePane`.

## Tests

Written first and confirmed failing against the old code (2 in `appLocalStore.test.ts`, 2 in the new `useOpenBook.test.tsx`). The two guard cases, in-place upload and the no-mirror cleanup, passed throughout.

- `pnpm test` - 7887 passed, 7 skipped (604 files)
- `pnpm lint` - clean
- `pnpm format:check` - clean

No `src-tauri/` or koplugin changes, so the Rust and Lua gates do not apply.

## Note

This could not be reproduced against a real Drive account, so the provenance of the poisoned rows is inferred from the code paths rather than observed in the reporter's data. A useful confirmation from the reporter would be whether the affected book offers "Upload Book" instead of "Download Book" in its context menu, which is the direct symptom of the missing `uploadedAt` stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
