### PR TITLE
fix(android): keep All Files Access on the Play build (#5372) (#2862)

### DIFF
--- a/apps/readest-app/docs/google-play-all-files-access.md
+++ b/apps/readest-app/docs/google-play-all-files-access.md
@@ -1,0 +1,66 @@
+# Google Play: All files access (MANAGE_EXTERNAL_STORAGE)
+
+The Play Store build ships `MANAGE_EXTERNAL_STORAGE`, same as the direct
+download build. Play requires a declaration for it in **Play Console → App
+content → Permissions and APIs → All files access**, and the declaration has to
+be re-confirmed whenever a release that uses the permission is submitted.
+
+Keep the answers below in sync with what the app actually does. If a release
+changes how shared storage is used, update this file first, then the Console.
+
+## Declaration form answers
+
+**Which core feature of your app requires access to All files access?**
+
+> Readest is an ebook reader and library manager. Its core feature is a user
+> owned book library that lives in a folder the user picks on shared storage,
+> not inside the app sandbox. The app has to enumerate, read, write, rename and
+> delete arbitrary document files (EPUB, PDF, MOBI, AZW3, CBZ, FB2, TXT,
+> Markdown) anywhere the user keeps them.
+
+**Why can't your app use a more privacy-protective alternative (SAF, Media
+Store, app-specific directories)?**
+
+> - The library folder is a stable, absolute filesystem path that is shared with
+>   other apps the user runs on the same files: Syncthing, KOReader, Calibre
+>   companion tools and desktop sync clients. SAF hands back opaque per-grant
+>   tree URIs that are not usable as paths, are not stable across a factory
+>   reset or app reinstall, and are not resolvable by the app's native (Rust)
+>   file and database layer.
+> - The library is a directory tree, not a media collection. It contains
+>   documents plus sidecar files the app maintains alongside them (covers,
+>   annotation and reading-progress databases, per-book config). MediaStore does
+>   not index document formats and cannot represent those relationships.
+> - Books must survive uninstall and must be readable by the user with any file
+>   manager. App-specific directories are wiped on uninstall and are hidden from
+>   other apps, which is exactly the failure users report.
+> - The app performs recursive scans of user-selected folders for bulk import
+>   and for watched auto-import folders, over libraries of thousands of files.
+>   Per-file SAF document URIs make this prohibitively slow and require a
+>   separate grant for every folder.
+
+**Features that depend on the permission**
+
+- Change Data Location: move the whole library and its databases to a folder on
+  shared storage or an SD card (issues #5372, #2862).
+- Import books from a folder, including recursive scans and watched folders that
+  are re-scanned on launch.
+- Backup and restore of the library archive to a user-chosen folder.
+- Save the current book cover to a user-chosen folder for lock screen use.
+
+**Video demonstration**
+
+Play asks for a short screen recording showing the feature in context. Record:
+open Settings → Change Data Location, pick a shared folder such as
+`/sdcard/Books`, complete the migration, then show the imported books opening
+from that folder and the same folder visible in a third-party file manager.
+
+## Notes for the release submission
+
+- Do not remove the permission from `AndroidManifest.xml` for the Play build.
+  `scripts/release-google-play.sh` fails the build if it is missing.
+- `REQUEST_INSTALL_PACKAGES` is still stripped for Play: the in-app updater is
+  disabled on that channel.
+- The permission is requested at runtime only when the user picks a shared
+  folder, never on first launch. Denying it leaves the app fully usable with its
+  default in-sandbox library.

--- a/apps/readest-app/scripts/release-google-play.sh
+++ b/apps/readest-app/scripts/release-google-play.sh
@@ -5,7 +5,6 @@ set -e
 VERSION=$(jq -r '.version' package.json)
 MANIFEST="./src-tauri/gen/android/app/src/main/AndroidManifest.xml"
 INSTALL_PERMISSION_LINE='<uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>'
-STORAGE_PERMISSION_LINE='<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>'
 
 ised() {
   if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -28,14 +27,14 @@ if grep -q 'REQUEST_INSTALL_PACKAGES' "$MANIFEST"; then
   fi
 fi
 
-if grep -q 'MANAGE_EXTERNAL_STORAGE' "$MANIFEST"; then
-  echo "🧹 Removing MANAGE_EXTERNAL_STORAGE from AndroidManifest.xml"
-  if ised "/MANAGE_EXTERNAL_STORAGE/d" "$MANIFEST"; then
-    echo "✅ Successfully removed MANAGE_EXTERNAL_STORAGE"
-  else
-    echo "❌ Failed to remove MANAGE_EXTERNAL_STORAGE" >&2
-    exit 1
-  fi
+# MANAGE_EXTERNAL_STORAGE stays in the Play build: Readest is a file manager
+# style ebook reader and needs All Files Access to keep the library in a
+# user-chosen shared folder (issues #5372 and #2862). Play requires a written
+# justification in the permission declaration form for every release that
+# ships it — see docs/google-play-all-files-access.md for the text to paste.
+if ! grep -q 'MANAGE_EXTERNAL_STORAGE' "$MANIFEST"; then
+  echo "❌ MANAGE_EXTERNAL_STORAGE is missing from AndroidManifest.xml" >&2
+  exit 1
 fi
 
 source .env.google-play.local
@@ -50,12 +49,9 @@ if ! grep -q 'REQUEST_INSTALL_PACKAGES' "$MANIFEST"; then
   " "$MANIFEST"
 fi
 
-if ! grep -q 'MANAGE_EXTERNAL_STORAGE' "$MANIFEST"; then
-  echo "♻️  Restoring MANAGE_EXTERNAL_STORAGE in AndroidManifest.xml"
-  ised "/android.permission.WRITE_EXTERNAL_STORAGE/a\\
-    $STORAGE_PERMISSION_LINE
-  " "$MANIFEST"
-fi
+echo "📋 Reminder: this build declares MANAGE_EXTERNAL_STORAGE."
+echo "   Play Console → App content → Permissions → All files access needs the"
+echo "   justification from docs/google-play-all-files-access.md"
 
 if [[ -z "$GOOGLE_PLAY_JSON_KEY_FILE" ]]; then
   echo "❌ GOOGLE_PLAY_JSON_KEY_FILE is not set"

--- a/apps/readest-app/src/app/library/components/MigrateDataWindow.tsx
+++ b/apps/readest-app/src/app/library/components/MigrateDataWindow.tsx
@@ -17,7 +17,7 @@ import { FileItem } from '@/types/system';
 import { getDirPath } from '@/utils/path';
 import { formatBytes } from '@/utils/book';
 import { getOSPlatform } from '@/utils/misc';
-import { getExternalSDCardPath } from '@/utils/bridge';
+import { getExternalSDCardPath, selectDirectory } from '@/utils/bridge';
 import { FILE_REVEAL_LABELS, FILE_REVEAL_PLATFORMS } from '@/utils/os';
 import { requestStoragePermission } from '@/utils/permission';
 import Dialog from '@/components/Dialog';
@@ -119,8 +119,7 @@ export const MigrateDataWindow = () => {
         }
         const localDocumentDir = await documentDir();
         setAndroidNewDirs([
-          // For Google Play version we won't request permission to access root of /sdcard
-          ...(appService?.distChannel === 'playstore' ? [] : sdcardDirs),
+          ...sdcardDirs,
           { path: localDocumentDir, label: '/sdcard/APPDATA/Documents' },
         ]);
       }
@@ -162,6 +161,22 @@ export const MigrateDataWindow = () => {
       await appService?.createDir(newDataDir, 'None', true);
       setNewDataDir(newDataDir);
       setMigrationStatus('idle');
+    } catch (error) {
+      console.error('Error selecting directory:', error);
+      setErrorMessage(_('Failed to select directory'));
+      setMigrationStatus('error');
+    }
+  };
+
+  // The preset shortcuts only cover the well-known shared-storage folders. Open
+  // the system folder picker so any folder can become the data location (#2862);
+  // it hands back an absolute path that All Files Access makes writable.
+  const handleBrowseNewDir = async () => {
+    try {
+      const response = await selectDirectory();
+      if (response.path) {
+        await handleSelectedNewDir(response.path);
+      }
     } catch (error) {
       console.error('Error selecting directory:', error);
       setErrorMessage(_('Failed to select directory'));
@@ -340,6 +355,7 @@ export const MigrateDataWindow = () => {
                       onClick={() => handleSelectedNewDir(dir.path)}
                     />
                   ))}
+                  <MenuItem transient label={_('Choose a folder')} onClick={handleBrowseNewDir} />
                 </div>
               </Dropdown>
             ) : (

--- a/apps/readest-app/src/app/library/components/SettingsMenu.tsx
+++ b/apps/readest-app/src/app/library/components/SettingsMenu.tsx
@@ -237,7 +237,7 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
   };
 
   const handleSetSavedBookCoverForLockScreen = async () => {
-    if (!(await requestStoragePermission()) && appService?.distChannel === 'readest') return;
+    if (!(await requestStoragePermission())) return;
 
     const newValue = settings.savedBookCoverForLockScreen ? '' : 'default';
     if (newValue) {
@@ -462,7 +462,7 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
               onClick={toggleBiometricUnlock}
             />
           )}
-          {appService?.isAndroidApp && appService?.distChannel !== 'playstore' && (
+          {appService?.isAndroidApp && (
             <MenuItem
               label={_('Save Book Cover')}
               tooltip={_('Auto-save last book cover')}

--- a/apps/readest-app/src/services/nativeAppService.ts
+++ b/apps/readest-app/src/services/nativeAppService.ts
@@ -577,7 +577,10 @@ export class NativeAppService extends BaseAppService {
   // CustomizeRootDir has a blocker on macOS App Store builds due to Security Scoped Resource restrictions.
   // See: https://github.com/tauri-apps/tauri/issues/3716
   override canCustomizeRootDir = DIST_CHANNEL !== 'appstore';
-  override canReadExternalDir = DIST_CHANNEL !== 'appstore' && DIST_CHANNEL !== 'playstore';
+  // Android builds — Play Store included — declare MANAGE_EXTERNAL_STORAGE, so
+  // absolute-path reads outside the app sandbox work once the user grants All
+  // Files Access. Apple offers no equivalent, so App Store builds stay gated.
+  override canReadExternalDir = DIST_CHANNEL !== 'appstore';
   override supportsCanvasContext2DFilter =
     OS_TYPE !== 'ios' && OS_TYPE !== 'macos' && OS_TYPE !== 'linux';
   // WebKitGTK on Linux crashes when a View Transition snapshots the window,


### PR DESCRIPTION
Fixes #5372
Fixes #2862

## Problem

The Play release script stripped `MANAGE_EXTERNAL_STORAGE` from the manifest before building, and the app gated every shared-storage path behind `distChannel === 'playstore'` to match. That made the Play build strictly worse than the direct download build:

- **#5372** — "Change Data Location" filtered out every `/sdcard` shortcut, leaving only `/sdcard/APPDATA/Documents`. That resolves to the directory the app is already using, so the current and new locations were identical and the migration could never start.
- **#2862** — no way to put the library in a user-chosen folder (a Syncthing folder, an SD card, a folder shared with KOReader).
- Importing books from a folder was disabled entirely (`canReadExternalDir` was false).
- The "Save Book Cover" toggle was hidden.

## Change

Keep the permission in the Play build and drop the playstore gates:

- `scripts/release-google-play.sh` no longer removes `MANAGE_EXTERNAL_STORAGE`. It now fails the build if the permission is missing, and prints a reminder about the Play Console declaration. `REQUEST_INSTALL_PACKAGES` is still stripped, since the in-app updater stays off on Play.
- `canReadExternalDir` is now `DIST_CHANNEL !== 'appstore'`. iOS App Store builds stay gated: there is no All Files Access equivalent there.
- `MigrateDataWindow` offers the shared-storage shortcuts on every Android channel, plus a new **"Choose a folder"** entry that opens the system folder picker so any folder can become the data location. The picker already existed for book import and returns a real absolute path, which All Files Access makes writable.
- "Save Book Cover" is shown on all Android builds, and its permission check no longer has the `distChannel === 'readest'` escape hatch that only existed because Play builds could never be granted the permission.

## Play Console declaration

Play requires a written justification for All Files Access at every submission that ships it. The text to paste, plus what the demo video should show, is in `apps/readest-app/docs/google-play-all-files-access.md`. In short: Readest is a document-management style reader whose core feature is a user-owned library on shared storage, and SAF tree URIs are not usable as stable absolute paths by the native (Rust) file and database layer, are not shareable with the other apps operating on the same files, and make recursive scans of large libraries prohibitively slow.

If Play rejects the declaration, the fallback should be real SAF support in the Rust fs layer, not re-stripping the permission, which regresses both issues.

## Verification

- `pnpm test` — 7952 passed, 7 skipped
- `pnpm lint` — clean
- `pnpm format:check` — clean

No `src-tauri/` changes, so the Rust checks do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)