### PR TITLE
fix(ios): unbreak the share extension build after the clip capture change

### DIFF
--- a/apps/readest-app/src-tauri/gen/apple/ShareExtension/ShareViewController.swift
+++ b/apps/readest-app/src-tauri/gen/apple/ShareExtension/ShareViewController.swift
@@ -72,7 +72,13 @@ final class ShareViewController: UIViewController {
     // Safari web-page shares deliver the JS-preprocessed DOM; every other
     // source falls through to the plain URL/text extraction.
     let pageContent = await firstPageContent(from: items)
-    let url = pageContent?.url ?? (await firstShareableURL(from: items))
+    // `??` takes a non-async autoclosure, so the fallback can't be inlined.
+    let url: URL?
+    if let pageURL = pageContent?.url {
+      url = pageURL
+    } else {
+      url = await firstShareableURL(from: items)
+    }
     let pageTitle =
       pageContent?.title
       ?? items


### PR DESCRIPTION
## Problem

`pnpm dev-ios` (and any `xcodebuild` for iOS) fails on `main` since #5377:

```
ShareExtension/ShareViewController.swift:75:42: error: 'async' call in an
autoclosure that does not support concurrency
    let url = pageContent?.url ?? (await firstShareableURL(from: items))
                                         ^
** BUILD FAILED **
```

The Safari page-content fallback added in #5377 puts an `await` on the right-hand
side of `??`. That operand is declared as `@autoclosure () throws -> T?`, a
non-async closure, so the call can never be awaited there. The `ShareExtension`
target fails to compile, which takes the whole iOS build down with it.

## Fix

Hoist the fallback out of the autoclosure into a plain `if`/`else`. It stays a
`let` so the `MainActor.run` block below still captures an immutable value
(a `var` would trip concurrency capture checking).

```swift
let url: URL?
if let pageURL = pageContent?.url {
  url = pageURL
} else {
  url = await firstShareableURL(from: items)
}
```

Behavior is unchanged: the Safari-supplied URL still wins, and the
URL/plain-text attachment scan is still only run when there isn't one.

## Verification

```
xcodebuild -project Readest.xcodeproj -target ShareExtension \
  -configuration release -sdk iphoneos build CODE_SIGNING_ALLOWED=NO
** BUILD SUCCEEDED **
```

Swift-only change under `src-tauri/gen/apple/`, so the JS/Rust suites are not
affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
