### PR TITLE
fix(window): cover the taskbar when entering fullscreen while maximized on Windows

### DIFF
--- a/apps/readest-app/src/utils/window.ts
+++ b/apps/readest-app/src/utils/window.ts
@@ -68,6 +68,10 @@ export const tauriHandleOnCloseWindow = async (callback: () => void) => {
   });
 };
 
+// Whether the window was maximized when it last entered fullscreen, so the
+// maximized state survives a fullscreen round-trip on Windows.
+let wasMaximizedBeforeFullscreen = false;
+
 export const tauriHandleToggleFullScreen = async () => {
   const currentWindow = getCurrentWindow();
   const isFullscreen = await currentWindow.isFullscreen();
@@ -75,7 +79,26 @@ export const tauriHandleToggleFullScreen = async () => {
   // window was only unmaximized here, so the fullscreen button did nothing when
   // the window was maximized, which is always the case on mobile shells like
   // Phosh and common on Windows (issue #4034).
-  await currentWindow.setFullscreen(!isFullscreen);
+  if (isFullscreen) {
+    await currentWindow.setFullscreen(false);
+    if (wasMaximizedBeforeFullscreen) {
+      wasMaximizedBeforeFullscreen = false;
+      await currentWindow.maximize();
+    }
+  } else {
+    // On Windows, tao keeps the WS_MAXIMIZE style when a maximized window
+    // enters borderless fullscreen, so Windows clamps the window to the work
+    // area and the taskbar stays visible but unclickable (issue #5295).
+    // Unmaximize first and restore the maximized state on exit. Other
+    // platforms must keep entering fullscreen straight from the maximized
+    // state (Phosh windows are always maximized).
+    wasMaximizedBeforeFullscreen =
+      (await osType()) === 'windows' && (await currentWindow.isMaximized());
+    if (wasMaximizedBeforeFullscreen) {
+      await currentWindow.unmaximize();
+    }
+    await currentWindow.setFullscreen(true);
+  }
   if ((await osType()) === 'linux') {
     linuxWindowRestoreTransparentBg();
   }


### PR DESCRIPTION
Closes #5295

## Problem

On Windows, toggling fullscreen while the reader window is maximized leaves the window constrained to the work area: the taskbar stays visible but ignores clicks. Entering fullscreen from a non-maximized window works fine.

## Root cause

The bug is in tao's Windows backend, which Readest cannot patch directly. When a maximized window enters borderless fullscreen, `set_fullscreen` updates the window flags and `apply_diff` re-issues `ShowWindow(SW_MAXIMIZE)` because the `MAXIMIZED` flag is still set (it triggers on `new.contains(MAXIMIZED)` even with no state change). The style also keeps `WS_MAXIMIZE`, so Windows clamps the window to the work area and tao's follow-up `SetWindowPos` with the full monitor bounds never sticks. tao also marks the window fullscreen to the shell via `ITaskbarList2::MarkFullscreenWindow`, which is why the still-visible taskbar stops responding.

## Fix

In `tauriHandleToggleFullScreen`, on Windows only:

- unmaximize before `setFullscreen(true)`, turning the transition into the non-maximized path that already works;
- remember the prior maximized state and re-maximize after `setFullscreen(false)` so the window state survives the fullscreen round-trip.

Other platforms keep entering fullscreen straight from the maximized state, preserving the behavior added for Phosh in #4034 (Phosh windows are always maximized).

## Verification

- `pnpm test`, `pnpm lint`, and `pnpm format:check` all pass.
- The mechanism is verified against the tao 0.35.3 source; a manual check on real Windows hardware by the reporter would be welcome since I developed this on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)