### PR TITLE
fix(discord): keep the rich presence cover URL stable (#5352)

### DIFF
--- a/apps/readest-app/src/__tests__/api/storage-upload-temp-key.test.ts
+++ b/apps/readest-app/src/__tests__/api/storage-upload-temp-key.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Issue #5352: the temp (public) image key used to embed the wall-clock hour,
+// so the same cover got a brand-new public URL every hour. Discord had to
+// resolve a never-before-seen external asset on each rotation, and any hiccup
+// in that resolution showed the app icon instead of the cover. The key must be
+// content-addressed: same user + same file name -> same URL, forever.
+
+const validateUserAndTokenMock = vi.fn();
+const getUploadSignedUrlMock = vi.fn();
+const getDownloadSignedUrlMock = vi.fn();
+
+vi.mock('@/utils/cors', () => ({
+  corsAllMethods: {},
+  runMiddleware: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/utils/access', () => ({
+  validateUserAndToken: (...a: unknown[]) => validateUserAndTokenMock(...a),
+  getStoragePlanData: vi.fn().mockReturnValue({ usage: 0, quota: 10 ** 12 }),
+  STORAGE_QUOTA_GRACE_BYTES: 0,
+}));
+vi.mock('@/utils/object', async (orig) => {
+  const actual = await orig<typeof import('@/utils/object')>();
+  return {
+    ...actual,
+    getUploadSignedUrl: (...a: unknown[]) => getUploadSignedUrlMock(...a),
+    getDownloadSignedUrl: (...a: unknown[]) => getDownloadSignedUrlMock(...a),
+  };
+});
+vi.mock('@/utils/supabase', () => ({
+  createSupabaseAdminClient: vi.fn(),
+}));
+
+import handler from '@/pages/api/storage/upload';
+
+const uploadTempAt = async (isoTime: string) => {
+  vi.setSystemTime(new Date(isoTime));
+  const req = {
+    method: 'POST',
+    headers: { authorization: 'Bearer tok' },
+    body: { fileName: 'drp_c0ffee.jpg', fileSize: 4096, temp: true },
+  } as unknown as NextApiRequest;
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as NextApiResponse;
+  await handler(req, res);
+  return getUploadSignedUrlMock.mock.calls.at(-1)![0] as string;
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  validateUserAndTokenMock.mockReset().mockResolvedValue({
+    user: { id: 'abcdef12-3456-7890-abcd-ef1234567890' },
+    token: 'tok',
+  });
+  getUploadSignedUrlMock.mockReset().mockResolvedValue('https://r2/upload');
+  getDownloadSignedUrlMock
+    .mockReset()
+    .mockResolvedValue('https://r2.example/bucket/temp/img/abcdef12/drp_c0ffee.jpg?sig=1');
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('POST /api/storage/upload — temp image key', () => {
+  it('gives the same key across hours, days and app restarts', async () => {
+    const first = await uploadTempAt('2026-07-28T12:59:59Z');
+    const second = await uploadTempAt('2026-07-28T13:00:01Z');
+    const later = await uploadTempAt('2026-08-02T04:17:00Z');
+
+    expect(second).toBe(first);
+    expect(later).toBe(first);
+  });
+
+  it('scopes the key to the user without a time segment', async () => {
+    const key = await uploadTempAt('2026-07-28T12:00:00Z');
+
+    expect(key).toBe('temp/img/abcdef12/drp_c0ffee.jpg');
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/discord-cover-cache.test.ts
+++ b/apps/readest-app/src/__tests__/utils/discord-cover-cache.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Book } from '@/types/book';
+import type { AppService } from '@/types/system';
+
+// Issue #5352: a single transient upload failure used to poison the Discord
+// cover for a full hour — the presence kept showing the fallback book icon
+// long after the network recovered, which is why the reporter saw covers
+// "stop working" for books that had rendered fine minutes earlier. Transient
+// failures must be retried quickly (with backoff); only a genuinely missing
+// cover deserves a long negative cache.
+
+const invokeMock = vi.fn();
+const processDiscordCoverMock = vi.fn();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...a: unknown[]) => invokeMock(...a),
+}));
+vi.mock('@/utils/image', () => ({
+  processDiscordCover: (...a: unknown[]) => processDiscordCoverMock(...a),
+}));
+
+const BOOK = {
+  hash: 'bookhash1234',
+  title: 'Lord of the Flies',
+  author: 'William Golding',
+  coverHash: 'coverhashabcd',
+} as Book;
+
+type Svc = AppService & {
+  exists: ReturnType<typeof vi.fn>;
+  uploadFileToCloud: ReturnType<typeof vi.fn>;
+  writeFile: ReturnType<typeof vi.fn>;
+};
+
+const makeAppService = (): Svc =>
+  ({
+    isDesktopApp: true,
+    exists: vi.fn().mockResolvedValue(true),
+    resolveFilePath: vi.fn().mockResolvedValue('/books/cover.png'),
+    getImageURL: vi.fn().mockResolvedValue('asset://cover.png'),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    uploadFileToCloud: vi.fn().mockResolvedValue('https://storage.readest.com/temp/img/u/c.jpg'),
+  }) as unknown as Svc;
+
+const loadDiscord = async () => {
+  vi.resetModules();
+  return import('@/utils/discord');
+};
+
+const lastPresence = () =>
+  invokeMock.mock.calls.filter((c) => c[0] === 'update_book_presence').at(-1)?.[1] as
+    | { presence: { coverUrl: string | null } }
+    | undefined;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-07-28T12:00:00Z'));
+  invokeMock.mockReset().mockResolvedValue(undefined);
+  processDiscordCoverMock.mockReset().mockResolvedValue({
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('Discord cover URL cache', () => {
+  it('names the uploaded file by cover hash so the public URL is content-addressed', async () => {
+    const { updateDiscordPresence } = await loadDiscord();
+    const appService = makeAppService();
+    appService.exists.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await updateDiscordPresence(BOOK, Date.now(), appService);
+
+    expect(appService.uploadFileToCloud).toHaveBeenCalledWith(
+      'drp_coverhashabcd.jpg',
+      'drp_coverhashabcd.jpg',
+      'Cache',
+      expect.any(Function),
+      BOOK.hash,
+      true,
+    );
+  });
+
+  it('falls back to the book hash when the cover hash is unknown', async () => {
+    const { updateDiscordPresence } = await loadDiscord();
+    const appService = makeAppService();
+    appService.exists.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await updateDiscordPresence({ ...BOOK, coverHash: null } as Book, Date.now(), appService);
+
+    expect(appService.uploadFileToCloud).toHaveBeenCalledWith(
+      'drp_bookhash1234.jpg',
+      expect.anything(),
+      'Cache',
+      expect.any(Function),
+      BOOK.hash,
+      true,
+    );
+  });
+
+  it('reuses a successful URL without re-uploading', async () => {
+    const { updateDiscordPresence } = await loadDiscord();
+    const appService = makeAppService();
+
+    await updateDiscordPresence(BOOK, Date.now(), appService);
+    await updateDiscordPresence(BOOK, Date.now(), appService);
+
+    expect(appService.uploadFileToCloud).toHaveBeenCalledTimes(1);
+    expect(lastPresence()?.presence.coverUrl).toBe('https://storage.readest.com/temp/img/u/c.jpg');
+  });
+
+  it('retries soon after a transient upload failure instead of waiting an hour', async () => {
+    const { updateDiscordPresence } = await loadDiscord();
+    const appService = makeAppService();
+    appService.uploadFileToCloud.mockRejectedValueOnce(new Error('network down'));
+
+    await updateDiscordPresence(BOOK, Date.now(), appService);
+    expect(lastPresence()?.presence.coverUrl).toBeNull();
+
+    // The 15s presence tick must not hammer the upload endpoint.
+    vi.setSystemTime(new Date('2026-07-28T12:00:15Z'));
+    await updateDiscordPresence(BOOK, Date.now(), appService);
+    expect(appService.uploadFileToCloud).toHaveBeenCalledTimes(1);
+
+    // ...but the cover comes back well within the old one-hour window.
+    vi.setSystemTime(new Date('2026-07-28T12:01:00Z'));
+    await updateDiscordPresence(BOOK, Date.now(), appService);
+    expect(appService.uploadFileToCloud).toHaveBeenCalledTimes(2);
+    expect(lastPresence()?.presence.coverUrl).toBe('https://storage.readest.com/temp/img/u/c.jpg');
+  });
+
+  it('backs off when transient failures keep repeating', async () => {
+    const { updateDiscordPresence } = await loadDiscord();
+    const appService = makeAppService();
+    appService.uploadFileToCloud.mockRejectedValue(new Error('network down'));
+
+    await updateDiscordPresence(BOOK, Date.now(), appService);
+    vi.setSystemTime(new Date('2026-07-28T12:01:00Z'));
+    await updateDiscordPresence(BOOK, Date.now(), appService);
+    expect(appService.uploadFileToCloud).toHaveBeenCalledTimes(2);
+
+    // Second failure doubles the window, so the next minute is a no-op.
+    vi.setSystemTime(new Date('2026-07-28T12:02:00Z'));
+    await updateDiscordPresence(BOOK, Date.now(), appService);
+    expect(appService.uploadFileToCloud).toHaveBeenCalledTimes(2);
+
+    vi.setSystemTime(new Date('2026-07-28T12:03:00Z'));
+    await updateDiscordPresence(BOOK, Date.now(), appService);
+    expect(appService.uploadFileToCloud).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not re-check a missing cover on every tick', async () => {
+    const { updateDiscordPresence } = await loadDiscord();
+    const appService = makeAppService();
+    appService.exists.mockResolvedValue(false);
+
+    await updateDiscordPresence(BOOK, Date.now(), appService);
+    vi.setSystemTime(new Date('2026-07-28T12:05:00Z'));
+    await updateDiscordPresence(BOOK, Date.now(), appService);
+
+    expect(appService.exists).toHaveBeenCalledTimes(1);
+    expect(lastPresence()?.presence.coverUrl).toBeNull();
+  });
+});

--- a/apps/readest-app/src/pages/api/storage/upload.ts
+++ b/apps/readest-app/src/pages/api/storage/upload.ts
@@ -33,10 +33,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (temp) {
     try {
-      const datetime = new Date();
-      const timeStr = datetime.toISOString().replace(/[-:]/g, '').replace('T', '').slice(0, 10);
+      // The key carries no timestamp: `fileName` is content-addressed by the
+      // caller, so the same image always resolves to the same public URL. It
+      // used to embed the wall-clock hour, which handed Discord Rich Presence
+      // a brand-new external asset to fetch every hour — and every failed
+      // fetch dropped the cover back to the app icon (issue #5352). A stable
+      // URL lets Discord's media proxy reuse what it already resolved.
+      // Re-uploads overwrite in place, so bucket retention still applies.
       const userStr = user.id.slice(0, 8);
-      const fileKey = `temp/img/${timeStr}/${userStr}/${fileName}`;
+      const fileKey = `temp/img/${userStr}/${fileName}`;
       const bucketName = process.env['TEMP_STORAGE_PUBLIC_BUCKET_NAME'] || '';
       const uploadUrl = await getUploadSignedUrl(fileKey, fileSize, 1800, bucketName);
       const downloadUrl = await getDownloadSignedUrl(fileKey, 3 * 86400, bucketName);

--- a/apps/readest-app/src/utils/discord.ts
+++ b/apps/readest-app/src/utils/discord.ts
@@ -6,11 +6,33 @@ import { processDiscordCover } from './image';
 
 type CacheEntry = {
   url: string | null;
-  timestamp: number;
+  expiresAt: number;
+  failures: number;
 };
 
 const coverUrlCache = new Map<string, CacheEntry>();
-const CACHE_DURATION = 60 * 60 * 1000; // 1 hour in milliseconds
+// A resolved URL is content-addressed and therefore stable; we only re-upload
+// often enough to stay ahead of the temp bucket's retention.
+const SUCCESS_TTL = 60 * 60 * 1000;
+// No cover.png on disk is a durable state, but a synced cover can still land
+// later, so keep re-checking on the same slow cadence.
+const MISSING_COVER_TTL = 60 * 60 * 1000;
+// A failed upload is almost always the network. Caching that for an hour is
+// what made covers "stop working" long after connectivity came back (issue
+// #5352), so retry soon — and back off, because the presence tick fires every
+// 15s and must not turn an outage into an upload loop.
+const RETRY_BASE_TTL = 60 * 1000;
+const RETRY_MAX_TTL = 15 * 60 * 1000;
+
+const remember = (bookHash: string, url: string | null, ttl: number) => {
+  coverUrlCache.set(bookHash, { url, expiresAt: Date.now() + ttl, failures: 0 });
+};
+
+const rememberFailure = (bookHash: string) => {
+  const failures = (coverUrlCache.get(bookHash)?.failures ?? 0) + 1;
+  const ttl = Math.min(RETRY_BASE_TTL * 2 ** (failures - 1), RETRY_MAX_TTL);
+  coverUrlCache.set(bookHash, { url: null, expiresAt: Date.now() + ttl, failures });
+};
 
 type BookPresence = {
   bookHash: string;
@@ -22,8 +44,8 @@ type BookPresence = {
 
 /**
  * Get an HTTPS cover URL suitable for Discord Rich Presence
- * - Caches successful uploads for session
- * - Caches failures (undefined) for 1 hour to avoid retries
+ * - Caches successful uploads for an hour
+ * - Caches a missing cover for an hour, but retries upload failures quickly
  * - Processes cover with Readest icon overlay
  */
 const getCoverUrlForDiscord = async (
@@ -31,14 +53,8 @@ const getCoverUrlForDiscord = async (
   appService: AppService,
 ): Promise<string | undefined> => {
   const cached = coverUrlCache.get(book.hash);
-  if (cached) {
-    const isExpired = Date.now() - cached.timestamp > CACHE_DURATION;
-    if (!isExpired) {
-      return cached.url ?? undefined;
-    }
-    if (!cached.url) {
-      coverUrlCache.delete(book.hash);
-    }
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.url ?? undefined;
   }
 
   try {
@@ -46,11 +62,15 @@ const getCoverUrlForDiscord = async (
 
     const exists = await appService.exists(fp, 'Books');
     if (!exists) {
-      coverUrlCache.set(book.hash, { url: null, timestamp: Date.now() });
+      remember(book.hash, null, MISSING_COVER_TTL);
       return undefined;
     }
 
-    const cacheKey = `drp_${book.hash}.jpg`;
+    // Name the upload after the cover's content hash so the public URL is
+    // identical across sessions and devices — Discord then reuses the external
+    // asset it already resolved. Books imported before coverHash existed fall
+    // back to the book hash, which is just as stable per book.
+    const cacheKey = `drp_${book.coverHash || book.hash}.jpg`;
     // Check if processed image exists in cache
     const cachedExists = await appService.exists(cacheKey, 'Cache');
     if (cachedExists) {
@@ -64,7 +84,7 @@ const getCoverUrlForDiscord = async (
       );
 
       if (downloadUrl) {
-        coverUrlCache.set(book.hash, { url: downloadUrl, timestamp: Date.now() });
+        remember(book.hash, downloadUrl, SUCCESS_TTL);
         return downloadUrl;
       }
     }
@@ -87,14 +107,14 @@ const getCoverUrlForDiscord = async (
     );
 
     if (downloadUrl) {
-      coverUrlCache.set(book.hash, { url: downloadUrl, timestamp: Date.now() });
+      remember(book.hash, downloadUrl, SUCCESS_TTL);
       return downloadUrl;
     }
-    coverUrlCache.set(book.hash, { url: null, timestamp: Date.now() });
+    rememberFailure(book.hash);
     return undefined;
   } catch (error) {
     console.warn('Failed to process/upload cover for Discord:', error);
-    coverUrlCache.set(book.hash, { url: null, timestamp: Date.now() });
+    rememberFailure(book.hash);
     return undefined;
   }
 };


### PR DESCRIPTION
Closes #5352.

## The report

Discord Rich Presence showed the open-book icon instead of the cover "for some books". The reporter later noticed the two books that *had* worked stopped working too, and asked whether something was wrong with their system.

## It was never book-specific

I pulled the four EPUBs the reporter shared and ran the real `processDiscordCover` in Chromium against their extracted covers:

| Book | Reported | Processed output |
| --- | --- | --- |
| Ella Minnow Pea | works | `image/jpeg`, 54 KB |
| Lights Out | works | `image/jpeg`, 58 KB |
| Lord of the Flies | **fails** | `image/jpeg`, 66 KB |
| Milk and Honey | **fails** | `image/jpeg`, 32 KB |

All four are ordinary baseline JPEGs and all four process fine, so cover content and extraction are not involved. The working screenshot also shows the cover with a black bar and the baked-in Readest icon, i.e. genuine `processDiscordCover` output, so the whole chain does work for this user. What breaks is a flaky link in it.

## Two causes

**1. The public cover URL was re-minted every clock hour.** `/api/storage/upload` built the temp key as `temp/img/<YYYYMMDDHH>/<user8>/<file>` (`slice(0, 10)` of the ISO string is hour-granular). Combined with the one-hour client cache, every book handed Discord a brand-new, never-before-seen URL at least once an hour, forcing a fresh external-asset resolution each time instead of reusing one Discord already had.

This PR drops the time segment and names the upload after the cover content hash (`book.coverHash`, already maintained for cover sync; legacy books fall back to `book.hash`). The same cover now always resolves to the same public URL. Re-uploads overwrite in place, so bucket retention is unaffected -- R2 lifecycle keys off object age, not the prefix.

**2. Any failure was cached for a full hour with no retry.** `getCoverUrlForDiscord` stored `url: null` on every failure path, so one network blip pinned the fallback icon for an hour, long after connectivity returned. That is what the reporter's later screenshots (0:07 and 4:15 into a session, still showing the icon) were capturing.

The negative cache is now split by kind: a missing `cover.png` still parks for an hour, while an upload failure retries after a minute with exponential backoff capped at 15 minutes. The backoff matters because the presence tick fires every 15 seconds and must not turn an outage into an upload loop.

## Tests

Written first, confirmed failing against the old code:

- `src/__tests__/api/storage-upload-temp-key.test.ts` -- the temp key is identical across hours, days and restarts, and carries no time segment.
- `src/__tests__/utils/discord-cover-cache.test.ts` -- the upload is named by cover hash (with book-hash fallback), a success is reused without re-uploading, a transient failure retries within a minute rather than an hour, repeated failures back off, and a missing cover is not re-checked on every tick.

`pnpm test` 7969 passed, `pnpm lint` and `pnpm format:check` clean. No `src-tauri/` changes.

## Known, left for follow-ups

Found while investigating, deliberately out of scope here: the desktop PUT sends no `Content-Type`, so R2 serves the JPEG as `application/octet-stream`; failures only reach `console.warn` and never the Tauri log, so users cannot report the actual cause; `processDiscordCover` has no timeout, and a never-settling `Image` would wedge presence updates for that book; and the JPEG encode over a transparent canvas is what produces the black bars beside portrait covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
