### PR TITLE
fix(css): keep image invert effective in dark mode with color override

### DIFF
--- a/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
@@ -504,6 +504,52 @@ describe('getColorStyles branches (via getStyles)', () => {
     expect(css).not.toMatch(/^\s*img\s*\{[^}]*mix-blend-mode: multiply/m);
   });
 
+  // #5250: with overrideColor also on, a second filter declaration in the same
+  // img rule silently discarded invert(100%) (last declaration wins), and
+  // mix-blend-mode: multiply erased images against dark page backgrounds
+  // (multiply with black is always black).
+  describe('invert image in dark mode combined with overrideColor (#5250)', () => {
+    // Concatenate every plain `img { ... }` rule in document order: they all
+    // share the same specificity, so this mirrors the cascade the browser
+    // applies (last declaration wins).
+    const getImgBlock = (css: string) => {
+      const blocks = [...css.matchAll(/^\s*img\s*\{([^}]*)\}/gm)].map((m) => m[1]!);
+      expect(blocks.length).toBeGreaterThan(0);
+      return blocks.join('\n');
+    };
+
+    it('keeps invert(100%) as the only filter declaration when overrideColor is on', () => {
+      const vs = makeViewSettings({ invertImgColorInDark: true, overrideColor: true });
+      const theme = makeThemeCode({ isDarkMode: true, bg: '#000000', fg: '#e0e0e0' });
+      const imgBlock = getImgBlock(getStyles(vs, theme));
+      const filters = [...imgBlock.matchAll(/filter:[^;]*;/g)].map((m) => m[0]);
+      expect(filters).toEqual(['filter: invert(100%);']);
+    });
+
+    it('does not multiply-blend inverted images into the dark background', () => {
+      const vs = makeViewSettings({ invertImgColorInDark: true, overrideColor: true });
+      const theme = makeThemeCode({ isDarkMode: true, bg: '#000000', fg: '#e0e0e0' });
+      const imgBlock = getImgBlock(getStyles(vs, theme));
+      expect(imgBlock).not.toContain('mix-blend-mode: multiply');
+    });
+
+    it('keeps the grayscale + multiply treatment when invert is off in dark mode', () => {
+      const vs = makeViewSettings({ invertImgColorInDark: false, overrideColor: true });
+      const theme = makeThemeCode({ isDarkMode: true, bg: '#1a1a1a', fg: '#e0e0e0' });
+      const imgBlock = getImgBlock(getStyles(vs, theme));
+      expect(imgBlock).toContain('filter: grayscale(100%) contrast(1.2) brightness(1.2);');
+      expect(imgBlock).toContain('mix-blend-mode: multiply;');
+    });
+
+    it('keeps multiply in light mode when overrideColor is on regardless of invert', () => {
+      const vs = makeViewSettings({ invertImgColorInDark: true, overrideColor: true });
+      const theme = makeThemeCode({ isDarkMode: false });
+      const imgBlock = getImgBlock(getStyles(vs, theme));
+      expect(imgBlock).toContain('mix-blend-mode: multiply;');
+      expect(imgBlock).not.toContain('filter: invert(100%)');
+    });
+  });
+
   it('sets bg-texture-id CSS variable', () => {
     const vs = makeViewSettings({ backgroundTextureId: 'paper' });
     const theme = makeThemeCode();

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -264,10 +264,13 @@ const getColorStyles = (
     body.pbg {
       ${isDarkMode ? `background-color: ${bg} !important;` : ''}
     }
+    /* When inverting in dark mode, invert(100%) must stay the effective filter
+       (a later filter declaration would discard it), and multiply must not
+       apply: multiply with a dark page background erases the image (#5250). */
     img {
       ${isDarkMode && invertImgColorInDark ? 'filter: invert(100%);' : ''}
-      ${isDarkMode && overrideColor ? 'filter: grayscale(100%) contrast(1.2) brightness(1.2);' : ''}
-      ${overrideColor ? 'mix-blend-mode: multiply;' : ''}
+      ${isDarkMode && !invertImgColorInDark && overrideColor ? 'filter: grayscale(100%) contrast(1.2) brightness(1.2);' : ''}
+      ${overrideColor && !(isDarkMode && invertImgColorInDark) ? 'mix-blend-mode: multiply;' : ''}
     }
     svg, img {
       ${overrideColor ? `background-color: transparent !important;` : ''};


### PR DESCRIPTION
Fixes #5250

## Root cause

#4763 rewrote the reflowable `img` rule in `getColorStyles` so that dark mode with **Override Book Color** emits a second `filter:` declaration in the same rule:

```css
img {
  filter: invert(100%);                                  /* Invert Image In Dark Mode */
  filter: grayscale(100%) contrast(1.2) brightness(1.2); /* dark + override, silently wins */
  mix-blend-mode: multiply;                              /* now applied in dark mode too */
}
```

Two independent breakages when both options are on:

- CSS last-declaration-wins discards `invert(100%)`, so the **Invert Image In Dark Mode** option has no effect.
- `mix-blend-mode: multiply` composites the image against the dark page background; multiply with a black background is always black, so on OLED-black themes images disappear entirely (the second report in the issue).

## Fix

Make the branches mutually exclusive so the rule emits at most one `filter`:

- dark + invert on: `filter: invert(100%)`, no multiply (multiply would erase the inverted image against a dark page)
- dark + invert off + override: the #4763 grayscale + multiply treatment, unchanged
- light + override: multiply, unchanged

## Verification

- New unit tests assert the effective cascade (all same-specificity `img` rules concatenated, exactly one `filter` declaration) instead of string presence, which is why the existing invert test kept passing on the broken code. They fail on the old rule and pass on the fix.
- Verified on a physical Xiaomi 13 with the reporter's EPUB and settings (dark theme, invert + override on): before, the computed style was `grayscale(1) contrast(1.2) brightness(1.2)` + `multiply` and equation images were unreadable; after, block equations compute `invert(1)` + `normal` and inline math `invert(1)` + `screen`, and both render as readable light glyphs. The inline math also loses the glaring white box it had before.
- `pnpm test` (7965 passed), `pnpm lint`, `pnpm format:check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)