### PR TITLE
feat(reader): add font size setting and honor custom fonts in paragraph mode

### DIFF
--- a/apps/readest-app/src/__tests__/paragraph-bar.test.tsx
+++ b/apps/readest-app/src/__tests__/paragraph-bar.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ParagraphBar from '@/app/reader/components/paragraph/ParagraphBar';
@@ -20,7 +20,7 @@ vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => (key: string) => key,
 }));
 
-const renderBar = (bookKey = 'book-1') =>
+const renderBar = (bookKey = 'book-1', props: Record<string, unknown> = {}) =>
   render(
     <ParagraphBar
       bookKey={bookKey}
@@ -31,6 +31,9 @@ const renderBar = (bookKey = 'book-1') =>
       onClose={vi.fn()}
       viewSettings={{ writingMode: 'horizontal-tb', vertical: false, rtl: false } as never}
       gridInsets={{ top: 0, right: 0, bottom: 0, left: 0 }}
+      fontScaleIndex={0}
+      onFontScaleIndexChange={vi.fn()}
+      {...props}
     />,
   );
 
@@ -91,6 +94,40 @@ describe('ParagraphBar', () => {
     expect(container.textContent).toContain('10%');
     expect(container.querySelector('style')).toBeNull();
     expect(container.innerHTML).not.toContain('subtle-slide-up');
+  });
+
+  describe('display settings panel (#5246)', () => {
+    it('opens from the gear and steps the font scale', () => {
+      const onChange = vi.fn();
+      const { container, getByLabelText } = renderBar('book-1', {
+        fontScaleIndex: 1,
+        onFontScaleIndexChange: onChange,
+      });
+
+      // Panel is closed until the gear is pressed.
+      expect(container.textContent).not.toContain('Font Size');
+
+      fireEvent.click(getByLabelText('Settings'));
+      expect(container.textContent).toContain('Font Size');
+      expect(container.textContent).toContain('115%');
+
+      fireEvent.click(getByLabelText('Increase font size'));
+      expect(onChange).toHaveBeenCalledWith(2);
+      fireEvent.click(getByLabelText('Decrease font size'));
+      expect(onChange).toHaveBeenCalledWith(0);
+    });
+
+    it('keeps the bar visible while the panel is open', () => {
+      vi.useFakeTimers();
+      const { container, getByLabelText } = renderBar();
+      fireEvent.click(getByLabelText('Settings'));
+
+      act(() => {
+        vi.advanceTimersByTime(2600);
+      });
+
+      expect(getBarRoot(container).className).toContain('pointer-events-auto');
+    });
   });
 
   describe('show-controls event', () => {

--- a/apps/readest-app/src/__tests__/paragraph-mode.test.tsx
+++ b/apps/readest-app/src/__tests__/paragraph-mode.test.tsx
@@ -543,6 +543,75 @@ describe('paragraph mode', () => {
   });
 });
 
+describe('paragraph mode display settings (#5246)', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const fontViewSettings = {
+    writingMode: 'horizontal-tb',
+    vertical: false,
+    rtl: false,
+    defaultFont: 'Serif',
+    serifFont: 'Bitter',
+    sansSerifFont: 'Roboto',
+    monospaceFont: 'Fira Code',
+    defaultCJKFont: 'LXGW WenKai',
+    defaultFontSize: 20,
+    lineHeight: 1.6,
+    fontWeight: 400,
+  } as never;
+
+  const renderOverlayWithFonts = async (fontScale?: number) => {
+    const overlayBookKey = 'overlay-book';
+    const doc = createDoc('<p>你好，世界</p>');
+    const range = doc.createRange();
+    range.selectNodeContents(doc.querySelector('p')!);
+
+    const { container } = render(
+      <ParagraphOverlay
+        bookKey={overlayBookKey}
+        viewSettings={fontViewSettings}
+        fontScale={fontScale}
+      />,
+    );
+
+    await act(async () => {
+      await eventDispatcher.dispatch('paragraph-focus', {
+        bookKey: overlayBookKey,
+        range,
+        presentation: { dir: 'ltr', writingMode: 'horizontal-tb', vertical: false, rtl: false },
+      });
+    });
+
+    return waitFor(() => {
+      const node = container.querySelector('.paragraph-content') as HTMLDivElement | null;
+      expect(node).not.toBeNull();
+      return node!;
+    });
+  };
+
+  it('applies the reader font chain including the CJK/custom font', async () => {
+    const paragraphContent = await renderOverlayWithFonts();
+
+    // The bare `"Bitter", serif` pair dropped the user's CJK/custom font, so
+    // CJK text fell back to the system font (#5246). The overlay must resolve
+    // the same chain as the RSVP overlay (getBaseFontFamily).
+    expect(paragraphContent.style.fontFamily).toContain('Bitter');
+    expect(paragraphContent.style.fontFamily).toContain('LXGW WenKai');
+  });
+
+  it('scales the paragraph text and its frame by the font scale', async () => {
+    const paragraphContent = await renderOverlayWithFonts(1.5);
+
+    expect(paragraphContent.style.fontSize).toBe('30px');
+    // The frame must carry the scaled font too, so its ch-based width cap
+    // grows with the text instead of squeezing bigger text into the same box.
+    const frame = paragraphContent.parentElement as HTMLDivElement;
+    expect(frame.style.fontSize).toBe('30px');
+  });
+});
+
 describe('paragraph mode TTS sync', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/readest-app/src/__tests__/utils/paragraph-font-scale.test.ts
+++ b/apps/readest-app/src/__tests__/utils/paragraph-font-scale.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  PARAGRAPH_FONT_SCALE_OPTIONS,
+  PARAGRAPH_FONT_SCALE_STORAGE_KEY,
+  loadParagraphFontScaleIndex,
+  saveParagraphFontScaleIndex,
+} from '@/utils/paragraphPresentation';
+
+describe('paragraph mode font scale persistence (#5246)', () => {
+  afterEach(() => {
+    localStorage.removeItem(PARAGRAPH_FONT_SCALE_STORAGE_KEY);
+  });
+
+  it('round-trips a saved index', () => {
+    saveParagraphFontScaleIndex(3);
+    expect(loadParagraphFontScaleIndex()).toBe(3);
+  });
+
+  it('clamps out-of-range saves and rejects corrupt stored values', () => {
+    expect(saveParagraphFontScaleIndex(-2)).toBe(0);
+    expect(saveParagraphFontScaleIndex(999)).toBe(PARAGRAPH_FONT_SCALE_OPTIONS.length - 1);
+
+    localStorage.setItem(PARAGRAPH_FONT_SCALE_STORAGE_KEY, 'garbage');
+    expect(loadParagraphFontScaleIndex()).toBe(0);
+    localStorage.setItem(PARAGRAPH_FONT_SCALE_STORAGE_KEY, '99');
+    expect(loadParagraphFontScaleIndex()).toBe(0);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/paragraph/ParagraphBar.tsx
+++ b/apps/readest-app/src/app/reader/components/paragraph/ParagraphBar.tsx
@@ -9,7 +9,13 @@ import {
   MdKeyboardArrowDown,
   MdKeyboardArrowUp,
 } from 'react-icons/md';
-import { IoVolumeHigh, IoVolumeMediumOutline } from 'react-icons/io5';
+import {
+  IoAdd,
+  IoRemove,
+  IoSettingsSharp,
+  IoVolumeHigh,
+  IoVolumeMediumOutline,
+} from 'react-icons/io5';
 import { ViewSettings } from '@/types/book';
 import { Insets } from '@/types/misc';
 import { useEnv } from '@/context/EnvContext';
@@ -17,7 +23,10 @@ import { useReaderStore } from '@/store/readerStore';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
 import { useTranslation } from '@/hooks/useTranslation';
 import { eventDispatcher } from '@/utils/event';
-import { getParagraphButtonDirections } from '@/utils/paragraphPresentation';
+import {
+  getParagraphButtonDirections,
+  PARAGRAPH_FONT_SCALE_OPTIONS,
+} from '@/utils/paragraphPresentation';
 
 const INITIAL_SHOW_DURATION = 2500;
 const HIDE_DELAY = 2000;
@@ -35,6 +44,9 @@ interface ParagraphBarProps {
   ttsActive?: boolean;
   /** Toggle read-along: start TTS from the focused paragraph, or stop it. */
   onToggleTtsAudio?: () => void;
+  /** Index into PARAGRAPH_FONT_SCALE_OPTIONS for the display settings (#5246). */
+  fontScaleIndex: number;
+  onFontScaleIndexChange: (index: number) => void;
   viewSettings?: ViewSettings;
   gridInsets: Insets;
 }
@@ -53,6 +65,8 @@ const ParagraphBar: React.FC<ParagraphBarProps> = ({
   onClose,
   ttsActive = false,
   onToggleTtsAudio,
+  fontScaleIndex,
+  onFontScaleIndexChange,
   viewSettings,
   gridInsets,
 }) => {
@@ -65,9 +79,13 @@ const ParagraphBar: React.FC<ParagraphBarProps> = ({
   const buttonDirections = getParagraphButtonDirections(viewSettings);
 
   const [isBarVisible, setIsBarVisible] = useState(true);
+  const [showSettings, setShowSettings] = useState(false);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isInTriggerZoneRef = useRef(false);
   const isMountedRef = useRef(true);
+  // Ref mirror so the hide timer sees the live value without re-arming.
+  const showSettingsRef = useRef(showSettings);
+  showSettingsRef.current = showSettings;
 
   const clearHideTimer = useCallback(() => {
     if (hideTimerRef.current) {
@@ -80,7 +98,9 @@ const ParagraphBar: React.FC<ParagraphBarProps> = ({
     (delay: number = HIDE_DELAY) => {
       clearHideTimer();
       hideTimerRef.current = setTimeout(() => {
-        if (isMountedRef.current && !isInTriggerZoneRef.current) {
+        // Never auto-hide while the display settings panel is open — hiding
+        // would take the panel (and its stepper) away mid-interaction (#5246).
+        if (isMountedRef.current && !isInTriggerZoneRef.current && !showSettingsRef.current) {
           setIsBarVisible(false);
         }
       }, delay);
@@ -169,8 +189,21 @@ const ParagraphBar: React.FC<ParagraphBarProps> = ({
     return () => eventDispatcher.off('paragraph-show-controls', handleShowControls);
   }, [bookKey, showBar]);
 
+  const toggleSettings = useCallback(() => {
+    setShowSettings((prev) => {
+      const next = !prev;
+      if (next) {
+        clearHideTimer();
+      } else {
+        startHideTimer();
+      }
+      return next;
+    });
+  }, [clearHideTimer, startHideTimer]);
+
   const isHiddenByHover = hoveredBookKey === bookKey;
   const isVisible = isBarVisible && !isHiddenByHover;
+  const fontScale = PARAGRAPH_FONT_SCALE_OPTIONS[fontScaleIndex] ?? 1;
   const progress =
     totalParagraphs > 0 ? Math.round(((currentIndex + 1) / totalParagraphs) * 100) : 0;
   const PrevIcon =
@@ -210,6 +243,48 @@ const ParagraphBar: React.FC<ParagraphBarProps> = ({
         startHideTimer();
       }}
     >
+      {/* Display settings (#5246) — same chrome as the bar card, floating just
+          above it. Font size here is a scale on the reader's own font size, so
+          the paragraph can be larger than the book text on big screens. */}
+      {showSettings && (
+        <div
+          className={clsx(
+            'absolute bottom-full left-1/2 mb-2 -translate-x-1/2',
+            'not-eink:bg-base-300 eink-bordered rounded-2xl shadow-lg',
+            'text-base-content flex items-center gap-1 whitespace-nowrap px-4 py-2 text-sm',
+          )}
+        >
+          <span className='text-base-content/60 me-1 font-medium'>{_('Font Size')}</span>
+          <button
+            type='button'
+            onClick={() => onFontScaleIndexChange(fontScaleIndex - 1)}
+            disabled={fontScaleIndex <= 0}
+            className={clsx(BAR_BUTTON, fontScaleIndex <= 0 && 'pointer-events-none opacity-50')}
+            title={_('Decrease font size')}
+            aria-label={_('Decrease font size')}
+          >
+            <IoRemove size={iconSize20} />
+          </button>
+          <span className='min-w-12 text-center font-medium tabular-nums'>
+            {Math.round(fontScale * 100)}%
+          </span>
+          <button
+            type='button'
+            onClick={() => onFontScaleIndexChange(fontScaleIndex + 1)}
+            disabled={fontScaleIndex >= PARAGRAPH_FONT_SCALE_OPTIONS.length - 1}
+            className={clsx(
+              BAR_BUTTON,
+              fontScaleIndex >= PARAGRAPH_FONT_SCALE_OPTIONS.length - 1 &&
+                'pointer-events-none opacity-50',
+            )}
+            title={_('Increase font size')}
+            aria-label={_('Increase font size')}
+          >
+            <IoAdd size={iconSize20} />
+          </button>
+        </div>
+      )}
+
       {/* Same card as the TTS mini player: solid base-300 surface, 2xl radius,
           soft shadow, 56px row. No backdrop blur, no hairline border. */}
       <div
@@ -279,6 +354,16 @@ const ParagraphBar: React.FC<ParagraphBarProps> = ({
             )}
           </button>
         )}
+
+        <button
+          type='button'
+          onClick={toggleSettings}
+          className={clsx(BAR_BUTTON, showSettings && 'eink-bordered not-eink:bg-base-200')}
+          title={_('Settings')}
+          aria-label={_('Settings')}
+        >
+          <IoSettingsSharp size={iconSize20} />
+        </button>
 
         <button
           type='button'

--- a/apps/readest-app/src/app/reader/components/paragraph/ParagraphControl.tsx
+++ b/apps/readest-app/src/app/reader/components/paragraph/ParagraphControl.tsx
@@ -1,11 +1,16 @@
 'use client';
 
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { FoliateView } from '@/types/view';
 import { Insets } from '@/types/misc';
 import { useReaderStore } from '@/store/readerStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { eventDispatcher } from '@/utils/event';
+import {
+  loadParagraphFontScaleIndex,
+  PARAGRAPH_FONT_SCALE_OPTIONS,
+  saveParagraphFontScaleIndex,
+} from '@/utils/paragraphPresentation';
 import { useParagraphMode } from '../../hooks/useParagraphMode';
 import ParagraphBar from './ParagraphBar';
 import ParagraphOverlay from './ParagraphOverlay';
@@ -32,6 +37,13 @@ const ParagraphControl: React.FC<ParagraphControlProps> = ({ bookKey, viewRef, g
     toggleTtsAudio,
     reengageTtsFollow,
   } = useParagraphMode({ bookKey, viewRef });
+
+  // Device-level display scale for the paragraph text (#5246), persisted like
+  // the RSVP overlay's display settings.
+  const [fontScaleIndex, setFontScaleIndex] = useState(loadParagraphFontScaleIndex);
+  const handleFontScaleIndexChange = useCallback((index: number) => {
+    setFontScaleIndex(saveParagraphFontScaleIndex(index));
+  }, []);
 
   // One-time-per-session decouple toast: the first time following drops while
   // TTS still plays, tell the user once. Reset when following re-engages so a
@@ -60,6 +72,7 @@ const ParagraphControl: React.FC<ParagraphControlProps> = ({ bookKey, viewRef, g
       <ParagraphOverlay
         bookKey={bookKey}
         viewSettings={viewSettings ?? undefined}
+        fontScale={PARAGRAPH_FONT_SCALE_OPTIONS[fontScaleIndex] ?? 1}
         gridInsets={gridInsets}
         ttsSyncStatus={ttsSyncStatus}
         onResumeTtsFollow={reengageTtsFollow}
@@ -75,6 +88,8 @@ const ParagraphControl: React.FC<ParagraphControlProps> = ({ bookKey, viewRef, g
         onClose={toggleParagraphMode}
         ttsActive={ttsActive}
         onToggleTtsAudio={toggleTtsAudio}
+        fontScaleIndex={fontScaleIndex}
+        onFontScaleIndexChange={handleFontScaleIndexChange}
         viewSettings={viewSettings ?? undefined}
         gridInsets={gridInsets}
       />

--- a/apps/readest-app/src/app/reader/components/paragraph/ParagraphOverlay.tsx
+++ b/apps/readest-app/src/app/reader/components/paragraph/ParagraphOverlay.tsx
@@ -13,6 +13,7 @@ import {
   ParagraphPresentation,
 } from '@/utils/paragraphPresentation';
 import { getTextSubRange } from '@/services/tts/wordHighlight';
+import { getBaseFontFamily } from '@/utils/style';
 import { loadShortcuts } from '@/helpers/shortcuts';
 import { matchesShortcut } from '@/utils/shortcutKeys';
 import TTSFollowIndicator, { TtsSyncStatus } from '../tts/TTSFollowIndicator';
@@ -25,6 +26,8 @@ const TTS_HIGHLIGHT_NAME = 'readest-tts-paragraph';
 interface ParagraphOverlayProps {
   bookKey: string;
   viewSettings?: ViewSettings;
+  /** Display scale on top of the reader's font size (#5246); 1 = book size. */
+  fontScale?: number;
   gridInsets?: Insets;
   /** Derived TTS-sync status driving the "following audio" indicator (#3235). */
   ttsSyncStatus?: TtsSyncStatus;
@@ -129,6 +132,7 @@ const SectionTransitionIndicator: React.FC<{
 const ParagraphOverlay: React.FC<ParagraphOverlayProps> = ({
   bookKey,
   viewSettings,
+  fontScale = 1,
   gridInsets = { top: 0, right: 0, bottom: 0, left: 0 },
   ttsSyncStatus = 'idle',
   onResumeTtsFollow,
@@ -160,13 +164,15 @@ const ParagraphOverlay: React.FC<ParagraphOverlayProps> = ({
 
   const contentStyle = useMemo(() => {
     if (!viewSettings) return {};
-    const defaultFontFamily =
-      viewSettings.defaultFont?.toLowerCase() === 'serif'
-        ? `"${viewSettings.serifFont}", serif`
-        : `"${viewSettings.sansSerifFont}", sans-serif`;
+    // Resolve the same font chain as the RSVP overlay (custom + CJK +
+    // fallbacks); a bare serif/sans pair dropped the user's CJK/custom font,
+    // so CJK text fell back to the system font (#5246).
+    const defaultFontFamily = viewSettings.defaultFont
+      ? getBaseFontFamily(viewSettings)
+      : undefined;
     return {
       fontFamily: defaultFontFamily,
-      fontSize: `${viewSettings.defaultFontSize || 16}px`,
+      fontSize: `${(viewSettings.defaultFontSize || 16) * fontScale}px`,
       lineHeight: viewSettings.lineHeight || 1.6,
       letterSpacing: viewSettings.letterSpacing ? `${viewSettings.letterSpacing}px` : undefined,
       wordSpacing: viewSettings.wordSpacing ? `${viewSettings.wordSpacing}px` : undefined,
@@ -175,7 +181,7 @@ const ParagraphOverlay: React.FC<ParagraphOverlayProps> = ({
       fontKerning: 'normal',
       textRendering: 'optimizeLegibility',
     } as React.CSSProperties;
-  }, [viewSettings]);
+  }, [viewSettings, fontScale]);
 
   const activePresentation = paragraphs[0]?.presentation ?? undefined;
   const activeParagraph = paragraphs[0];
@@ -615,7 +621,14 @@ const ParagraphOverlay: React.FC<ParagraphOverlayProps> = ({
                 ? 'inline-flex items-center justify-center self-center overflow-visible'
                 : 'w-full overflow-auto',
             )}
-            style={frameStyle}
+            // The frame carries the paragraph font too so its ch-based width
+            // cap resolves against the (scaled) text, widening the column as
+            // the text grows instead of squeezing it into the same box (#5246).
+            style={{
+              ...frameStyle,
+              fontFamily: contentStyle.fontFamily,
+              fontSize: contentStyle.fontSize,
+            }}
           >
             <AnimatedParagraph
               key={activeParagraph.id}

--- a/apps/readest-app/src/utils/paragraphPresentation.ts
+++ b/apps/readest-app/src/utils/paragraphPresentation.ts
@@ -117,6 +117,35 @@ export const getParagraphPresentation = (
   };
 };
 
+// Display scale applied on top of the reader's font size in paragraph mode
+// (#5246). Device-level (localStorage), like the RSVP overlay's display
+// settings — 1x keeps the paragraph at the book's own font size.
+export const PARAGRAPH_FONT_SCALE_OPTIONS = [1, 1.15, 1.3, 1.5, 1.75, 2, 2.5, 3, 4, 5];
+export const PARAGRAPH_FONT_SCALE_STORAGE_KEY = 'readest_paragraph_fontsize';
+
+export const loadParagraphFontScaleIndex = (): number => {
+  try {
+    const saved = localStorage.getItem(PARAGRAPH_FONT_SCALE_STORAGE_KEY);
+    if (saved !== null) {
+      const index = parseInt(saved, 10);
+      if (index >= 0 && index < PARAGRAPH_FONT_SCALE_OPTIONS.length) return index;
+    }
+  } catch {
+    /* ignore */
+  }
+  return 0;
+};
+
+export const saveParagraphFontScaleIndex = (index: number): number => {
+  const clamped = Math.max(0, Math.min(PARAGRAPH_FONT_SCALE_OPTIONS.length - 1, index));
+  try {
+    localStorage.setItem(PARAGRAPH_FONT_SCALE_STORAGE_KEY, String(clamped));
+  } catch {
+    /* ignore */
+  }
+  return clamped;
+};
+
 export const getParagraphButtonDirections = (
   source?: ParagraphLayoutSource,
 ): Record<ParagraphNavAction, ParagraphNavDirection> => {


### PR DESCRIPTION
Closes #5246

## Summary

Paragraph mode (Shift+P) rendered the text at the body font size and with a bare `"serifFont", serif` font pair, so on large screens the paragraph stayed small and the user's custom/CJK font never applied (CJK text fell back to the system font).

- Resolve the paragraph overlay font with the same chain as the RSVP overlay (`getBaseFontFamily`), so custom and CJK fonts apply.
- Add a display settings panel behind a settings gear on the paragraph bar (modeled on the RSVP overlay's config panel) with a font size stepper: 100% to 500% of the reader's font size in 10 steps, persisted device-wide in localStorage like the RSVP display settings. The bar does not auto-hide while the panel is open.
- Apply the scaled font on the paragraph frame as well, so its ch-based width cap resolves against the scaled text and the column widens as the text grows instead of squeezing into the same box.

Reuses existing i18n keys (Font Size, Settings, Decrease/Increase font size), so no new translations are needed.

## Test plan

- New unit tests: overlay font chain includes the CJK/custom font; frame and content scale with the font scale; bar gear opens the panel and steps the scale; the bar stays visible while the panel is open; scale index persistence round-trip and clamping.
- Full suite: 8002 passed. `pnpm lint` and `pnpm format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)