### PR TITLE
feat(reader): auto-hide the mouse cursor while reading (#5178)

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2104,5 +2104,7 @@
   "{{count}} chapters_many": "{{count}} فصلًا",
   "{{count}} chapters_other": "{{count}} فصل",
   "Downloading chapters…": "جارٍ تنزيل الفصول…",
-  "This chapter could not be downloaded.": "تعذر تنزيل هذا الفصل."
+  "This chapter could not be downloaded.": "تعذر تنزيل هذا الفصل.",
+  "Auto-hide Cursor": "إخفاء المؤشر تلقائيًا",
+  "After a moment of inactivity": "بعد لحظة من عدم النشاط"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1952,5 +1952,7 @@
   "{{count}} chapters_one": "{{count}}টি অধ্যায়",
   "{{count}} chapters_other": "{{count}}টি অধ্যায়",
   "Downloading chapters…": "অধ্যায় ডাউনলোড হচ্ছে…",
-  "This chapter could not be downloaded.": "এই অধ্যায়টি ডাউনলোড করা যায়নি।"
+  "This chapter could not be downloaded.": "এই অধ্যায়টি ডাউনলোড করা যায়নি।",
+  "Auto-hide Cursor": "কার্সার স্বয়ংক্রিয়ভাবে লুকান",
+  "After a moment of inactivity": "কিছুক্ষণ নিষ্ক্রিয় থাকার পরে"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1914,5 +1914,7 @@
   "Fetch Chapters": "ལེའུ་རྣམས་ལེན་པ།",
   "{{count}} chapters_other": "ལེའུ་ {{count}}",
   "Downloading chapters…": "ལེའུ་རྣམས་ཕབ་ལེན་བྱེད་བཞིན་པ…",
-  "This chapter could not be downloaded.": "ལེའུ་འདི་ཕབ་ལེན་བྱེད་མ་ཐུབ།"
+  "This chapter could not be downloaded.": "ལེའུ་འདི་ཕབ་ལེན་བྱེད་མ་ཐུབ།",
+  "Auto-hide Cursor": "འོད་རྟགས་རང་འགུལ་སྦས་པ།",
+  "After a moment of inactivity": "སྐར་ཆ་འགའ་ལས་ཀ་མེད་རྗེས།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1952,5 +1952,7 @@
   "{{count}} chapters_one": "{{count}} Kapitel",
   "{{count}} chapters_other": "{{count}} Kapitel",
   "Downloading chapters…": "Kapitel werden heruntergeladen…",
-  "This chapter could not be downloaded.": "Dieses Kapitel konnte nicht heruntergeladen werden."
+  "This chapter could not be downloaded.": "Dieses Kapitel konnte nicht heruntergeladen werden.",
+  "Auto-hide Cursor": "Mauszeiger automatisch ausblenden",
+  "After a moment of inactivity": "Nach kurzer Inaktivität"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1952,5 +1952,7 @@
   "{{count}} chapters_one": "{{count}} κεφάλαιο",
   "{{count}} chapters_other": "{{count}} κεφάλαια",
   "Downloading chapters…": "Λήψη κεφαλαίων…",
-  "This chapter could not be downloaded.": "Δεν ήταν δυνατή η λήψη αυτού του κεφαλαίου."
+  "This chapter could not be downloaded.": "Δεν ήταν δυνατή η λήψη αυτού του κεφαλαίου.",
+  "Auto-hide Cursor": "Αυτόματη απόκρυψη δείκτη",
+  "After a moment of inactivity": "Μετά από λίγη αδράνεια"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1990,5 +1990,7 @@
   "{{count}} chapters_many": "{{count}} capítulos",
   "{{count}} chapters_other": "{{count}} capítulos",
   "Downloading chapters…": "Descargando capítulos…",
-  "This chapter could not be downloaded.": "No se pudo descargar este capítulo."
+  "This chapter could not be downloaded.": "No se pudo descargar este capítulo.",
+  "Auto-hide Cursor": "Ocultar el cursor automáticamente",
+  "After a moment of inactivity": "Tras un momento de inactividad"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1952,5 +1952,7 @@
   "{{count}} chapters_one": "{{count}} فصل",
   "{{count}} chapters_other": "{{count}} فصل",
   "Downloading chapters…": "در حال دانلود فصل‌ها…",
-  "This chapter could not be downloaded.": "این فصل دانلود نشد."
+  "This chapter could not be downloaded.": "این فصل دانلود نشد.",
+  "Auto-hide Cursor": "پنهان‌سازی خودکار نشانگر",
+  "After a moment of inactivity": "پس از مدتی بی‌حرکتی"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1990,5 +1990,7 @@
   "{{count}} chapters_many": "{{count}} chapitres",
   "{{count}} chapters_other": "{{count}} chapitres",
   "Downloading chapters…": "Téléchargement des chapitres…",
-  "This chapter could not be downloaded.": "Ce chapitre n’a pas pu être téléchargé."
+  "This chapter could not be downloaded.": "Ce chapitre n’a pas pu être téléchargé.",
+  "Auto-hide Cursor": "Masquer automatiquement le curseur",
+  "After a moment of inactivity": "Après un moment d'inactivité"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1990,5 +1990,7 @@
   "{{count}} chapters_two": "{{count}} פרקים",
   "{{count}} chapters_other": "{{count}} פרקים",
   "Downloading chapters…": "מוריד פרקים…",
-  "This chapter could not be downloaded.": "לא ניתן היה להוריד את הפרק הזה."
+  "This chapter could not be downloaded.": "לא ניתן היה להוריד את הפרק הזה.",
+  "Auto-hide Cursor": "הסתרה אוטומטית של הסמן",
+  "After a moment of inactivity": "לאחר רגע של חוסר פעילות"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1952,5 +1952,7 @@
   "{{count}} chapters_one": "{{count}} अध्याय",
   "{{count}} chapters_other": "{{count}} अध्याय",
   "Downloading chapters…": "अध्याय डाउनलोड हो रहे हैं…",
-  "This chapter could not be downloaded.": "यह अध्याय डाउनलोड नहीं हो सका।"
+  "This chapter could not be downloaded.": "यह अध्याय डाउनलोड नहीं हो सका।",
+  "Auto-hide Cursor": "कर्सर स्वतः छिपाएँ",
+  "After a moment of inactivity": "कुछ देर निष्क्रिय रहने पर"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1952,5 +1952,7 @@
   "{{count}} chapters_one": "{{count}} fejezet",
   "{{count}} chapters_other": "{{count}} fejezet",
   "Downloading chapters…": "Fejezetek letöltése…",
-  "This chapter could not be downloaded.": "Ezt a fejezetet nem sikerült letölteni."
+  "This chapter could not be downloaded.": "Ezt a fejezetet nem sikerült letölteni.",
+  "Auto-hide Cursor": "Kurzor automatikus elrejtése",
+  "After a moment of inactivity": "Rövid tétlenség után"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1914,5 +1914,7 @@
   "Fetch Chapters": "Ambil Bab",
   "{{count}} chapters_other": "{{count}} bab",
   "Downloading chapters…": "Mengunduh bab…",
-  "This chapter could not be downloaded.": "Bab ini tidak dapat diunduh."
+  "This chapter could not be downloaded.": "Bab ini tidak dapat diunduh.",
+  "Auto-hide Cursor": "Sembunyikan kursor otomatis",
+  "After a moment of inactivity": "Setelah beberapa saat tidak aktif"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1990,5 +1990,7 @@
   "{{count}} chapters_many": "{{count}} capitoli",
   "{{count}} chapters_other": "{{count}} capitoli",
   "Downloading chapters…": "Download dei capitoli…",
-  "This chapter could not be downloaded.": "Non è stato possibile scaricare questo capitolo."
+  "This chapter could not be downloaded.": "Non è stato possibile scaricare questo capitolo.",
+  "Auto-hide Cursor": "Nascondi automaticamente il cursore",
+  "After a moment of inactivity": "Dopo un momento di inattività"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1914,5 +1914,7 @@
   "Fetch Chapters": "章を取得",
   "{{count}} chapters_other": "{{count}} 章",
   "Downloading chapters…": "章をダウンロード中…",
-  "This chapter could not be downloaded.": "この章はダウンロードできませんでした。"
+  "This chapter could not be downloaded.": "この章はダウンロードできませんでした。",
+  "Auto-hide Cursor": "カーソルを自動的に隠す",
+  "After a moment of inactivity": "しばらく操作がないとき"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1914,5 +1914,7 @@
   "Fetch Chapters": "챕터 불러오기",
   "{{count}} chapters_other": "{{count}}개 챕터",
   "Downloading chapters…": "챕터 다운로드 중…",
-  "This chapter could not be downloaded.": "이 챕터를 다운로드하지 못했습니다."
+  "This chapter could not be downloaded.": "이 챕터를 다운로드하지 못했습니다.",
+  "Auto-hide Cursor": "커서 자동 숨기기",
+  "After a moment of inactivity": "잠시 동작이 없을 때"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1914,5 +1914,7 @@
   "Fetch Chapters": "Dapatkan Bab",
   "{{count}} chapters_other": "{{count}} bab",
   "Downloading chapters…": "Memuat turun bab…",
-  "This chapter could not be downloaded.": "Bab ini tidak dapat dimuat turun."
+  "This chapter could not be downloaded.": "Bab ini tidak dapat dimuat turun.",
+  "Auto-hide Cursor": "Sembunyikan kursor secara automatik",
+  "After a moment of inactivity": "Selepas seketika tidak aktif"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1952,5 +1952,7 @@
   "{{count}} chapters_one": "{{count}} hoofdstuk",
   "{{count}} chapters_other": "{{count}} hoofdstukken",
   "Downloading chapters…": "Hoofdstukken downloaden…",
-  "This chapter could not be downloaded.": "Dit hoofdstuk kon niet worden gedownload."
+  "This chapter could not be downloaded.": "Dit hoofdstuk kon niet worden gedownload.",
+  "Auto-hide Cursor": "Cursor automatisch verbergen",
+  "After a moment of inactivity": "Na een moment van inactiviteit"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2028,5 +2028,7 @@
   "{{count}} chapters_many": "{{count}} rozdziałów",
   "{{count}} chapters_other": "{{count}} rozdziału",
   "Downloading chapters…": "Pobieranie rozdziałów…",
-  "This chapter could not be downloaded.": "Nie udało się pobrać tego rozdziału."
+  "This chapter could not be downloaded.": "Nie udało się pobrać tego rozdziału.",
+  "Auto-hide Cursor": "Automatycznie ukrywaj kursor",
+  "After a moment of inactivity": "Po chwili bezczynności"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1990,5 +1990,7 @@
   "{{count}} chapters_many": "{{count}} capítulos",
   "{{count}} chapters_other": "{{count}} capítulos",
   "Downloading chapters…": "Baixando capítulos…",
-  "This chapter could not be downloaded.": "Este capítulo não pôde ser baixado."
+  "This chapter could not be downloaded.": "Este capítulo não pôde ser baixado.",
+  "Auto-hide Cursor": "Ocultar o cursor automaticamente",
+  "After a moment of inactivity": "Após um momento de inatividade"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1990,5 +1990,7 @@
   "{{count}} chapters_many": "{{count}} capítulos",
   "{{count}} chapters_other": "{{count}} capítulos",
   "Downloading chapters…": "A transferir capítulos…",
-  "This chapter could not be downloaded.": "Não foi possível transferir este capítulo."
+  "This chapter could not be downloaded.": "Não foi possível transferir este capítulo.",
+  "Auto-hide Cursor": "Ocultar o cursor automaticamente",
+  "After a moment of inactivity": "Após um momento de inatividade"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1990,5 +1990,7 @@
   "{{count}} chapters_few": "{{count}} capitole",
   "{{count}} chapters_other": "{{count}} de capitole",
   "Downloading chapters…": "Se descarcă capitolele…",
-  "This chapter could not be downloaded.": "Acest capitol nu a putut fi descărcat."
+  "This chapter could not be downloaded.": "Acest capitol nu a putut fi descărcat.",
+  "Auto-hide Cursor": "Ascunde automat cursorul",
+  "After a moment of inactivity": "După un moment de inactivitate"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2028,5 +2028,7 @@
   "{{count}} chapters_many": "{{count}} глав",
   "{{count}} chapters_other": "{{count}} главы",
   "Downloading chapters…": "Скачивание глав…",
-  "This chapter could not be downloaded.": "Не удалось скачать эту главу."
+  "This chapter could not be downloaded.": "Не удалось скачать эту главу.",
+  "Auto-hide Cursor": "Автоматически скрывать курсор",
+  "After a moment of inactivity": "После короткого бездействия"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1952,5 +1952,7 @@
   "{{count}} chapters_one": "පරිච්ඡේද {{count}}",
   "{{count}} chapters_other": "පරිච්ඡේද {{count}}",
   "Downloading chapters…": "පරිච්ඡේද බාගනිමින්…",
-  "This chapter could not be downloaded.": "මෙම පරිච්ඡේදය බාගත නොහැකි විය."
+  "This chapter could not be downloaded.": "මෙම පරිච්ඡේදය බාගත නොහැකි විය.",
+  "Auto-hide Cursor": "කර්සරය ස්වයංක්‍රීයව සඟවන්න",
+  "After a moment of inactivity": "මොහොතක් අක්‍රියව සිටි පසු"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2028,5 +2028,7 @@
   "{{count}} chapters_few": "{{count}} poglavja",
   "{{count}} chapters_other": "{{count}} poglavij",
   "Downloading chapters…": "Prenašanje poglavij…",
-  "This chapter could not be downloaded.": "Tega poglavja ni bilo mogoče prenesti."
+  "This chapter could not be downloaded.": "Tega poglavja ni bilo mogoče prenesti.",
+  "Auto-hide Cursor": "Samodejno skrij kazalec",
+  "After a moment of inactivity": "Po trenutku nedejavnosti"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1952,5 +1952,7 @@
   "{{count}} chapters_one": "{{count}} kapitel",
   "{{count}} chapters_other": "{{count}} kapitel",
   "Downloading chapters…": "Laddar ner kapitel…",
-  "This chapter could not be downloaded.": "Det här kapitlet kunde inte laddas ner."
+  "This chapter could not be downloaded.": "Det här kapitlet kunde inte laddas ner.",
+  "Auto-hide Cursor": "Dölj muspekaren automatiskt",
+  "After a moment of inactivity": "Efter en stunds inaktivitet"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1952,5 +1952,7 @@
   "{{count}} chapters_one": "{{count}} அத்தியாயம்",
   "{{count}} chapters_other": "{{count}} அத்தியாயங்கள்",
   "Downloading chapters…": "அத்தியாயங்கள் பதிவிறக்கப்படுகின்றன…",
-  "This chapter could not be downloaded.": "இந்த அத்தியாயத்தைப் பதிவிறக்க முடியவில்லை."
+  "This chapter could not be downloaded.": "இந்த அத்தியாயத்தைப் பதிவிறக்க முடியவில்லை.",
+  "Auto-hide Cursor": "கர்சரைத் தானாக மறை",
+  "After a moment of inactivity": "சிறிது நேரம் செயலற்ற பிறகு"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1914,5 +1914,7 @@
   "Fetch Chapters": "ดึงรายการตอน",
   "{{count}} chapters_other": "{{count}} ตอน",
   "Downloading chapters…": "กำลังดาวน์โหลดตอน…",
-  "This chapter could not be downloaded.": "ไม่สามารถดาวน์โหลดตอนนี้ได้"
+  "This chapter could not be downloaded.": "ไม่สามารถดาวน์โหลดตอนนี้ได้",
+  "Auto-hide Cursor": "ซ่อนเคอร์เซอร์อัตโนมัติ",
+  "After a moment of inactivity": "หลังจากไม่มีการใช้งานครู่หนึ่ง"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1952,5 +1952,7 @@
   "{{count}} chapters_one": "{{count}} bölüm",
   "{{count}} chapters_other": "{{count}} bölüm",
   "Downloading chapters…": "Bölümler indiriliyor…",
-  "This chapter could not be downloaded.": "Bu bölüm indirilemedi."
+  "This chapter could not be downloaded.": "Bu bölüm indirilemedi.",
+  "Auto-hide Cursor": "İmleci otomatik gizle",
+  "After a moment of inactivity": "Kısa bir hareketsizlikten sonra"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2028,5 +2028,7 @@
   "{{count}} chapters_many": "{{count}} розділів",
   "{{count}} chapters_other": "{{count}} розділу",
   "Downloading chapters…": "Завантаження розділів…",
-  "This chapter could not be downloaded.": "Не вдалося завантажити цей розділ."
+  "This chapter could not be downloaded.": "Не вдалося завантажити цей розділ.",
+  "Auto-hide Cursor": "Автоматично ховати курсор",
+  "After a moment of inactivity": "Після короткої бездіяльності"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1952,5 +1952,7 @@
   "{{count}} chapters_one": "{{count}} bob",
   "{{count}} chapters_other": "{{count}} bob",
   "Downloading chapters…": "Boblar yuklab olinmoqda…",
-  "This chapter could not be downloaded.": "Bu bob yuklab olinmadi."
+  "This chapter could not be downloaded.": "Bu bob yuklab olinmadi.",
+  "Auto-hide Cursor": "Kursorni avtomatik yashirish",
+  "After a moment of inactivity": "Bir oz harakatsizlikdan keyin"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1914,5 +1914,7 @@
   "Fetch Chapters": "Lấy danh sách chương",
   "{{count}} chapters_other": "{{count}} chương",
   "Downloading chapters…": "Đang tải các chương…",
-  "This chapter could not be downloaded.": "Không thể tải chương này."
+  "This chapter could not be downloaded.": "Không thể tải chương này.",
+  "Auto-hide Cursor": "Tự động ẩn con trỏ",
+  "After a moment of inactivity": "Sau một lúc không hoạt động"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1914,5 +1914,7 @@
   "Fetch Chapters": "获取章节",
   "{{count}} chapters_other": "{{count}} 章",
   "Downloading chapters…": "正在下载章节…",
-  "This chapter could not be downloaded.": "本章下载失败。"
+  "This chapter could not be downloaded.": "本章下载失败。",
+  "Auto-hide Cursor": "自动隐藏光标",
+  "After a moment of inactivity": "静止片刻后隐藏"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1914,5 +1914,7 @@
   "Fetch Chapters": "取得章節",
   "{{count}} chapters_other": "{{count}} 章",
   "Downloading chapters…": "正在下載章節…",
-  "This chapter could not be downloaded.": "本章下載失敗。"
+  "This chapter could not be downloaded.": "本章下載失敗。",
+  "Auto-hide Cursor": "自動隱藏游標",
+  "After a moment of inactivity": "靜止片刻後隱藏"
 }

--- a/apps/readest-app/src/__tests__/helpers/settings.test.ts
+++ b/apps/readest-app/src/__tests__/helpers/settings.test.ts
@@ -32,7 +32,7 @@ vi.mock('@/utils/style', () => ({
   getStyles: vi.fn(() => ''),
 }));
 
-import { getLibraryViewSettings, saveViewSettings } from '@/helpers/settings';
+import { getLibraryViewSettings, saveReadSettings, saveViewSettings } from '@/helpers/settings';
 import { useSettingsStore } from '@/store/settingsStore';
 import type { EnvConfigType } from '@/services/environment';
 import type { SystemSettings } from '@/types/settings';
@@ -42,6 +42,7 @@ const envConfig = {} as EnvConfigType;
 const makeSettings = (): SystemSettings =>
   ({
     globalViewSettings: { userStylesheet: '', userUIStylesheet: '' },
+    globalReadSettings: { autohideCursor: true },
   }) as unknown as SystemSettings;
 
 beforeEach(() => {
@@ -170,6 +171,55 @@ describe('saveViewSettings', () => {
     // must NOT publish global settings, otherwise per-book overrides would leak
     // into the cross-device globals.
     expect(referenceChanges).toHaveLength(0);
+    expect(useSettingsStore.getState().settings).toBe(initial);
+  });
+});
+
+describe('saveReadSettings', () => {
+  test('write swaps the settings reference so replicaSettingsSync subscribers fire', async () => {
+    const referenceChanges: SystemSettings[] = [];
+    const unsubscribe = useSettingsStore.subscribe((state, prev) => {
+      if (state.settings && state.settings !== prev?.settings) {
+        referenceChanges.push(state.settings);
+      }
+    });
+
+    try {
+      await saveReadSettings(envConfig, 'autohideCursor', false);
+    } finally {
+      unsubscribe();
+    }
+
+    expect(referenceChanges).toHaveLength(1);
+    expect(referenceChanges[0]!.globalReadSettings.autohideCursor).toBe(false);
+  });
+
+  test('persists with the same new reference passed to setSettings', async () => {
+    let savedSettings: SystemSettings | null = null;
+    const saveSettingsMock = vi.fn(async (_env: EnvConfigType, s: SystemSettings) => {
+      savedSettings = s;
+    });
+    useSettingsStore.setState({
+      saveSettings: saveSettingsMock,
+    } as unknown as ReturnType<typeof useSettingsStore.getState>);
+
+    await saveReadSettings(envConfig, 'autohideCursor', false);
+
+    expect(saveSettingsMock).toHaveBeenCalledTimes(1);
+    expect(savedSettings!.globalReadSettings.autohideCursor).toBe(false);
+    expect(savedSettings).toBe(useSettingsStore.getState().settings);
+  });
+
+  test('no-op when the value is unchanged', async () => {
+    const initial = useSettingsStore.getState().settings;
+    const saveSettingsMock = vi.fn(async () => {});
+    useSettingsStore.setState({
+      saveSettings: saveSettingsMock,
+    } as unknown as ReturnType<typeof useSettingsStore.getState>);
+
+    await saveReadSettings(envConfig, 'autohideCursor', true);
+
+    expect(saveSettingsMock).not.toHaveBeenCalled();
     expect(useSettingsStore.getState().settings).toBe(initial);
   });
 });

--- a/apps/readest-app/src/__tests__/helpers/settings.test.ts
+++ b/apps/readest-app/src/__tests__/helpers/settings.test.ts
@@ -32,7 +32,7 @@ vi.mock('@/utils/style', () => ({
   getStyles: vi.fn(() => ''),
 }));
 
-import { getLibraryViewSettings, saveReadSettings, saveViewSettings } from '@/helpers/settings';
+import { getLibraryViewSettings, saveViewSettings } from '@/helpers/settings';
 import { useSettingsStore } from '@/store/settingsStore';
 import type { EnvConfigType } from '@/services/environment';
 import type { SystemSettings } from '@/types/settings';
@@ -42,7 +42,6 @@ const envConfig = {} as EnvConfigType;
 const makeSettings = (): SystemSettings =>
   ({
     globalViewSettings: { userStylesheet: '', userUIStylesheet: '' },
-    globalReadSettings: { autohideCursor: true },
   }) as unknown as SystemSettings;
 
 beforeEach(() => {
@@ -171,55 +170,6 @@ describe('saveViewSettings', () => {
     // must NOT publish global settings, otherwise per-book overrides would leak
     // into the cross-device globals.
     expect(referenceChanges).toHaveLength(0);
-    expect(useSettingsStore.getState().settings).toBe(initial);
-  });
-});
-
-describe('saveReadSettings', () => {
-  test('write swaps the settings reference so replicaSettingsSync subscribers fire', async () => {
-    const referenceChanges: SystemSettings[] = [];
-    const unsubscribe = useSettingsStore.subscribe((state, prev) => {
-      if (state.settings && state.settings !== prev?.settings) {
-        referenceChanges.push(state.settings);
-      }
-    });
-
-    try {
-      await saveReadSettings(envConfig, 'autohideCursor', false);
-    } finally {
-      unsubscribe();
-    }
-
-    expect(referenceChanges).toHaveLength(1);
-    expect(referenceChanges[0]!.globalReadSettings.autohideCursor).toBe(false);
-  });
-
-  test('persists with the same new reference passed to setSettings', async () => {
-    let savedSettings: SystemSettings | null = null;
-    const saveSettingsMock = vi.fn(async (_env: EnvConfigType, s: SystemSettings) => {
-      savedSettings = s;
-    });
-    useSettingsStore.setState({
-      saveSettings: saveSettingsMock,
-    } as unknown as ReturnType<typeof useSettingsStore.getState>);
-
-    await saveReadSettings(envConfig, 'autohideCursor', false);
-
-    expect(saveSettingsMock).toHaveBeenCalledTimes(1);
-    expect(savedSettings!.globalReadSettings.autohideCursor).toBe(false);
-    expect(savedSettings).toBe(useSettingsStore.getState().settings);
-  });
-
-  test('no-op when the value is unchanged', async () => {
-    const initial = useSettingsStore.getState().settings;
-    const saveSettingsMock = vi.fn(async () => {});
-    useSettingsStore.setState({
-      saveSettings: saveSettingsMock,
-    } as unknown as ReturnType<typeof useSettingsStore.getState>);
-
-    await saveReadSettings(envConfig, 'autohideCursor', true);
-
-    expect(saveSettingsMock).not.toHaveBeenCalled();
     expect(useSettingsStore.getState().settings).toBe(initial);
   });
 });

--- a/apps/readest-app/src/__tests__/reader/autohide-cursor.test.ts
+++ b/apps/readest-app/src/__tests__/reader/autohide-cursor.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+
+// Pins the foliate-js CursorAutohider contract the reader wiring relies on
+// (readest#5178): the `autohide-cursor` attribute on <foliate-view> arms a
+// 1s idle timer that hides the cursor; mousemove events with unchanged
+// screen coordinates (the synthetic ones browsers fire when content scrolls
+// or pages turn under a stationary pointer) must not reveal it.
+
+const IDLE_HIDE_MS = 1000;
+
+const createView = (): HTMLElement => document.createElement('foliate-view');
+
+const move = (el: HTMLElement, screenX: number, screenY: number) =>
+  el.dispatchEvent(new MouseEvent('mousemove', { screenX, screenY }));
+
+beforeAll(async () => {
+  await import('foliate-js/view.js');
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('foliate-view autohide-cursor', () => {
+  test('hides the cursor after idle when the attribute is set', () => {
+    const view = createView();
+    view.setAttribute('autohide-cursor', '');
+
+    move(view, 5, 5);
+    expect(view.style.cursor).not.toBe('none');
+
+    vi.advanceTimersByTime(IDLE_HIDE_MS);
+    expect(view.style.cursor).toBe('none');
+  });
+
+  test('stays hidden on mousemove with unchanged coordinates (scroll / page turn)', () => {
+    const view = createView();
+    view.setAttribute('autohide-cursor', '');
+
+    move(view, 5, 5);
+    vi.advanceTimersByTime(IDLE_HIDE_MS);
+    expect(view.style.cursor).toBe('none');
+
+    move(view, 5, 5);
+    expect(view.style.cursor).toBe('none');
+  });
+
+  test('reappears when the pointer actually moves', () => {
+    const view = createView();
+    view.setAttribute('autohide-cursor', '');
+
+    move(view, 5, 5);
+    vi.advanceTimersByTime(IDLE_HIDE_MS);
+    expect(view.style.cursor).toBe('none');
+
+    move(view, 6, 9);
+    expect(view.style.cursor).not.toBe('none');
+  });
+
+  test('never hides without the attribute', () => {
+    const view = createView();
+
+    move(view, 5, 5);
+    vi.advanceTimersByTime(IDLE_HIDE_MS);
+    expect(view.style.cursor).not.toBe('none');
+  });
+
+  test('removing the attribute at runtime disarms hiding', () => {
+    const view = createView();
+    view.setAttribute('autohide-cursor', '');
+
+    move(view, 5, 5);
+    vi.advanceTimersByTime(IDLE_HIDE_MS);
+    expect(view.style.cursor).toBe('none');
+
+    view.removeAttribute('autohide-cursor');
+    move(view, 6, 9);
+    expect(view.style.cursor).not.toBe('none');
+
+    vi.advanceTimersByTime(IDLE_HIDE_MS);
+    expect(view.style.cursor).not.toBe('none');
+  });
+});

--- a/apps/readest-app/src/__tests__/services/constants.test.ts
+++ b/apps/readest-app/src/__tests__/services/constants.test.ts
@@ -231,6 +231,7 @@ describe('services/constants', () => {
       expect(typeof DEFAULT_SYSTEM_SETTINGS.alwaysShowStatusBar).toBe('boolean');
       expect(typeof DEFAULT_SYSTEM_SETTINGS.autoCheckUpdates).toBe('boolean');
       expect(typeof DEFAULT_SYSTEM_SETTINGS.screenWakeLock).toBe('boolean');
+      expect(typeof DEFAULT_SYSTEM_SETTINGS.autohideCursor).toBe('boolean');
       expect(typeof DEFAULT_SYSTEM_SETTINGS.openLastBooks).toBe('boolean');
       expect(typeof DEFAULT_SYSTEM_SETTINGS.autoImportBooksOnOpen).toBe('boolean');
       expect(typeof DEFAULT_SYSTEM_SETTINGS.telemetryEnabled).toBe('boolean');
@@ -369,8 +370,7 @@ describe('services/constants', () => {
       expect(typeof DEFAULT_READSETTINGS.notebookActiveTab).toBe('string');
     });
 
-    it('has cursor and translation settings', () => {
-      expect(typeof DEFAULT_READSETTINGS.autohideCursor).toBe('boolean');
+    it('has translation settings', () => {
       expect(typeof DEFAULT_READSETTINGS.translationProvider).toBe('string');
       expect(typeof DEFAULT_READSETTINGS.translateTargetLang).toBe('string');
     });

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -759,6 +759,14 @@ const FoliateViewer: React.FC<{
       } else {
         view.renderer.removeAttribute('animated');
       }
+      // Arms the foliate CursorAutohider — goes on the view element itself,
+      // not the renderer, and is re-checked on every mousemove so the
+      // ControlPanel toggle takes effect without recreating the view.
+      view.toggleAttribute(
+        'autohide-cursor',
+        !appService?.isMobile &&
+          !!useSettingsStore.getState().settings.globalReadSettings?.autohideCursor,
+      );
       applyPageTurnAttributes(view, viewSettings, bookDoc.rendition?.layout === 'pre-paginated');
       // iOS WebKit composites large/persistent page layers without the Android
       // high-DPR Blink freeze, so opt this renderer into the GPU-accelerated

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -764,8 +764,7 @@ const FoliateViewer: React.FC<{
       // ControlPanel toggle takes effect without recreating the view.
       view.toggleAttribute(
         'autohide-cursor',
-        !appService?.isMobile &&
-          !!useSettingsStore.getState().settings.globalReadSettings?.autohideCursor,
+        !appService?.isMobile && !!useSettingsStore.getState().settings.autohideCursor,
       );
       applyPageTurnAttributes(view, viewSettings, bookDoc.rendition?.layout === 'pre-paginated');
       // iOS WebKit composites large/persistent page layers without the Android

--- a/apps/readest-app/src/components/settings/ControlPanel.tsx
+++ b/apps/readest-app/src/components/settings/ControlPanel.tsx
@@ -8,7 +8,7 @@ import { useResetViewSettings } from '@/hooks/useResetSettings';
 import { useEinkMode } from '@/hooks/useEinkMode';
 import { getStyles } from '@/utils/style';
 import { getMaxInlineSize } from '@/utils/config';
-import { saveSysSettings, saveViewSettings } from '@/helpers/settings';
+import { saveReadSettings, saveSysSettings, saveViewSettings } from '@/helpers/settings';
 import { PageTurnStyle } from '@/types/book';
 import { SettingsPanelPanelProp } from './SettingsDialog';
 import { annotationToolQuickActions } from '@/app/reader/components/annotator/AnnotationTools';
@@ -31,7 +31,7 @@ import { optInTelemetry, optOutTelemetry } from '@/utils/telemetry';
 const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }) => {
   const _ = useTranslation();
   const { envConfig, appService } = useEnv();
-  const { getView, getViewSettings, recreateViewer } = useReaderStore();
+  const { getView, getViews, getViewSettings, recreateViewer } = useReaderStore();
   const { getBookData } = useBookDataStore();
   const { settings } = useSettingsStore();
   const { applyEinkMode } = useEinkMode();
@@ -67,6 +67,7 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
     settings.swipeBrightnessGesture,
   );
   const [screenWakeLock, setScreenWakeLock] = useState(settings.screenWakeLock);
+  const [autohideCursor, setAutohideCursor] = useState(settings.globalReadSettings.autohideCursor);
   const [allowScript, setAllowScript] = useState(viewSettings.allowScript);
   const [isAutoCheckUpdates, setIsAutoCheckUpdates] = useState(settings.autoCheckUpdates);
   const [isNightlyChannel, setIsNightlyChannel] = useState(settings.updateChannel === 'nightly');
@@ -257,6 +258,13 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
     saveSysSettings(envConfig, 'screenWakeLock', screenWakeLock);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [screenWakeLock]);
+
+  useEffect(() => {
+    if (autohideCursor === settings.globalReadSettings.autohideCursor) return;
+    saveReadSettings(envConfig, 'autohideCursor', autohideCursor);
+    getViews().forEach((view) => view?.toggleAttribute('autohide-cursor', autohideCursor));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autohideCursor]);
 
   useEffect(() => {
     if (viewSettings.allowScript === allowScript) return;
@@ -511,6 +519,15 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
           onChange={() => setScreenWakeLock(!screenWakeLock)}
           data-setting-id='settings.control.screenWakeLock'
         />
+        {!appService?.isMobile && (
+          <SettingsSwitchRow
+            label={_('Auto-hide Cursor')}
+            description={_('After a moment of inactivity')}
+            checked={autohideCursor}
+            onChange={() => setAutohideCursor(!autohideCursor)}
+            data-setting-id='settings.control.autohideCursor'
+          />
+        )}
       </BoxedList>
 
       {appService?.hasUpdater && (

--- a/apps/readest-app/src/components/settings/ControlPanel.tsx
+++ b/apps/readest-app/src/components/settings/ControlPanel.tsx
@@ -8,7 +8,7 @@ import { useResetViewSettings } from '@/hooks/useResetSettings';
 import { useEinkMode } from '@/hooks/useEinkMode';
 import { getStyles } from '@/utils/style';
 import { getMaxInlineSize } from '@/utils/config';
-import { saveReadSettings, saveSysSettings, saveViewSettings } from '@/helpers/settings';
+import { saveSysSettings, saveViewSettings } from '@/helpers/settings';
 import { PageTurnStyle } from '@/types/book';
 import { SettingsPanelPanelProp } from './SettingsDialog';
 import { annotationToolQuickActions } from '@/app/reader/components/annotator/AnnotationTools';
@@ -67,7 +67,7 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
     settings.swipeBrightnessGesture,
   );
   const [screenWakeLock, setScreenWakeLock] = useState(settings.screenWakeLock);
-  const [autohideCursor, setAutohideCursor] = useState(settings.globalReadSettings.autohideCursor);
+  const [autohideCursor, setAutohideCursor] = useState(settings.autohideCursor);
   const [allowScript, setAllowScript] = useState(viewSettings.allowScript);
   const [isAutoCheckUpdates, setIsAutoCheckUpdates] = useState(settings.autoCheckUpdates);
   const [isNightlyChannel, setIsNightlyChannel] = useState(settings.updateChannel === 'nightly');
@@ -260,8 +260,8 @@ const ControlPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRes
   }, [screenWakeLock]);
 
   useEffect(() => {
-    if (autohideCursor === settings.globalReadSettings.autohideCursor) return;
-    saveReadSettings(envConfig, 'autohideCursor', autohideCursor);
+    if (autohideCursor === settings.autohideCursor) return;
+    saveSysSettings(envConfig, 'autohideCursor', autohideCursor);
     getViews().forEach((view) => view?.toggleAttribute('autohide-cursor', autohideCursor));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autohideCursor]);

--- a/apps/readest-app/src/helpers/settings.ts
+++ b/apps/readest-app/src/helpers/settings.ts
@@ -1,5 +1,5 @@
 import { ViewSettings } from '@/types/book';
-import { SystemSettings } from '@/types/settings';
+import { ReadSettings, SystemSettings } from '@/types/settings';
 import { EnvConfigType } from '@/services/environment';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useReaderStore } from '@/store/readerStore';
@@ -93,4 +93,21 @@ export const saveSysSettings = async <K extends keyof SystemSettings>(
     setSettings(settings);
     await saveSettings(envConfig, settings);
   }
+};
+
+export const saveReadSettings = async <K extends keyof ReadSettings>(
+  envConfig: EnvConfigType,
+  key: K,
+  value: ReadSettings[K],
+) => {
+  const { settings, setSettings, saveSettings } = useSettingsStore.getState();
+  if (settings.globalReadSettings[key] === value) return;
+  // New references for the same reason as the global write in saveViewSettings:
+  // the replica-push subscriber compares settings identity.
+  const nextSettings: SystemSettings = {
+    ...settings,
+    globalReadSettings: { ...settings.globalReadSettings, [key]: value },
+  };
+  setSettings(nextSettings);
+  await saveSettings(envConfig, nextSettings);
 };

--- a/apps/readest-app/src/helpers/settings.ts
+++ b/apps/readest-app/src/helpers/settings.ts
@@ -1,5 +1,5 @@
 import { ViewSettings } from '@/types/book';
-import { ReadSettings, SystemSettings } from '@/types/settings';
+import { SystemSettings } from '@/types/settings';
 import { EnvConfigType } from '@/services/environment';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useReaderStore } from '@/store/readerStore';
@@ -93,21 +93,4 @@ export const saveSysSettings = async <K extends keyof SystemSettings>(
     setSettings(settings);
     await saveSettings(envConfig, settings);
   }
-};
-
-export const saveReadSettings = async <K extends keyof ReadSettings>(
-  envConfig: EnvConfigType,
-  key: K,
-  value: ReadSettings[K],
-) => {
-  const { settings, setSettings, saveSettings } = useSettingsStore.getState();
-  if (settings.globalReadSettings[key] === value) return;
-  // New references for the same reason as the global write in saveViewSettings:
-  // the replica-push subscriber compares settings identity.
-  const nextSettings: SystemSettings = {
-    ...settings,
-    globalReadSettings: { ...settings.globalReadSettings, [key]: value },
-  };
-  setSettings(nextSettings);
-  await saveSettings(envConfig, nextSettings);
 };

--- a/apps/readest-app/src/services/commandRegistry.ts
+++ b/apps/readest-app/src/services/commandRegistry.ts
@@ -497,6 +497,12 @@ const controlPanelItems = [
     section: 'Device',
   },
   {
+    id: 'settings.control.autohideCursor',
+    labelKey: _('Auto-hide Cursor'),
+    keywords: ['cursor', 'mouse', 'pointer', 'hide', 'autohide', 'idle'],
+    section: 'Device',
+  },
+  {
     id: 'settings.control.allowJavascript',
     labelKey: _('Allow JavaScript'),
     keywords: ['javascript', 'js', 'script', 'security', 'allow'],

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -150,6 +150,7 @@ export const DEFAULT_SYSTEM_SETTINGS: Partial<SystemSettings> = {
   autoCheckUpdates: true,
   updateChannel: 'stable',
   screenWakeLock: false,
+  autohideCursor: true,
   screenBrightness: -1, // -1~100, -1 for system default
   autoScreenBrightness: true,
   swipeBrightnessGesture: true,
@@ -249,7 +250,6 @@ export const DEFAULT_READSETTINGS: ReadSettings = {
   notebookWidth: '25%',
   isNotebookPinned: false,
   notebookActiveTab: 'notes',
-  autohideCursor: true,
   translationProvider: 'deepl',
   translateTargetLang: 'EN',
   wordLensAutoDownload: true,

--- a/apps/readest-app/src/types/settings.ts
+++ b/apps/readest-app/src/types/settings.ts
@@ -53,7 +53,6 @@ export interface ReadSettings {
   notebookWidth: string;
   isNotebookPinned: boolean;
   notebookActiveTab: NotebookTab;
-  autohideCursor: boolean;
   translationProvider: string;
   translateTargetLang: string;
   /**
@@ -338,6 +337,7 @@ export interface SystemSettings {
   autoCheckUpdates: boolean;
   updateChannel: 'stable' | 'nightly';
   screenWakeLock: boolean;
+  autohideCursor: boolean;
   screenBrightness: number;
   autoScreenBrightness: boolean;
   swipeBrightnessGesture: boolean;


### PR DESCRIPTION
Closes #5178

### What

Adds an optional "Auto-hide Cursor" setting (Settings > Behavior > Device, desktop and web only) that hides the mouse cursor after about 1s of pointer inactivity over the reading area.

The mechanism was already ~80% present but dormant: foliate-js ships a complete `CursorAutohider` in `view.js` gated on an `autohide-cursor` attribute that nothing ever set, and `ReadSettings.autohideCursor` has existed (default `true`) with zero consumers. This PR is the wiring:

- `FoliateViewer` sets `autohide-cursor` on the view element at init when the setting is on and the platform is not mobile. Foliate re-checks the attribute on every mousemove, so toggling needs no view recreation.
- `ControlPanel` gets the switch row (gated `!appService?.isMobile`) plus a command palette entry; its persistence effect also pushes the attribute to all open views via `getViews()`.
- The dormant `autohideCursor` field is moved from `ReadSettings` to top-level `SystemSettings` next to `screenWakeLock`, persisted via the existing `saveSysSettings`. It is a per-device preference outside the replica sync whitelist, and the `loadSettings` defaults merge gives existing profiles the default with no migration (a stale `globalReadSettings.autohideCursor` key in stored JSON is simply ignored).
- Both new strings translated across all 33 locales.

### Behavior

- Cursor hides after ~1s without pointer movement over the book content.
- Reappears instantly on real pointer movement.
- Does NOT reappear when scrolling or turning pages: the synthetic mousemove Chrome fires when content moves under a stationary pointer carries unchanged screen coordinates, which foliate's coordinate check filters out.

### Verification

- New contract test pins the foliate `CursorAutohider` behavior against the real `foliate-view` element in jsdom (idle hide, same-coordinate filtering, runtime attribute toggling).
- Full suite: 8004 tests pass; `pnpm lint` and `pnpm format:check` clean.
- Verified live in Chrome against `pnpm dev-web`: attribute wiring, idle hide on the iframe document (both synthetic and trusted pointer events), scroll-synthetic filtering, live toggle on/off from settings, and persistence across reload.

### Note for review

The pre-existing default is `autohideCursor: true`, so desktop users get auto-hide enabled after update (matches foliate's stock reader behavior). If opt-in is preferred it is a one-line change in `constants.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
