### PR TITLE
fix(ios): declare NSPhotoLibraryAddUsageDescription so saving images works (#5397)

### DIFF
--- a/apps/readest-app/src-tauri/Info-ios.plist
+++ b/apps/readest-app/src-tauri/Info-ios.plist
@@ -43,6 +43,13 @@
     </array>
     <key>LSSupportsOpeningDocumentsInPlace</key>
     <true/>
+    <!-- Add-only Photos access. Readest never reads the library, but the
+         WebView's "Add to Photos" image callout and the share sheet's
+         "Save Image" activity both write through PHPhotoLibrary in-process;
+         without this key TCC terminates the app on the first attempt (#5397)
+         and iOS hides "Save Image" from the share sheet entirely. -->
+    <key>NSPhotoLibraryAddUsageDescription</key>
+    <string>Readest needs access to save images from your books to your photo library.</string>
     <key>CFBundleURLTypes</key>
     <array>
       <dict>

--- a/apps/readest-app/src/__tests__/ios/photo-library-add-usage-description.test.ts
+++ b/apps/readest-app/src/__tests__/ios/photo-library-add-usage-description.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression guard: saving an image to Photos killed the app on iOS (#5397).
+ *
+ * Readest writes to the photo library through paths it does not own: WebKit's
+ * native long-press image callout ("Add to Photos") and the `Save Image`
+ * activity of the share sheet the image viewer opens. Both run in-process and
+ * hit `PHPhotoLibrary.performChanges`, so TCC terminates the app with
+ * `__TCC_CRASHING_DUE_TO_PRIVACY_VIOLATION__` unless the bundle declares an
+ * add-only usage description. The same missing key also makes iOS drop
+ * `Save Image` from the share sheet, leaving only the out-of-process entries
+ * ("Add to Shared Album", "Save to Files").
+ *
+ * We assert on the tracked seed `src-tauri/Info-ios.plist` (referenced by
+ * `tauri.conf.json` `bundle.iOS.infoPlist`). The built
+ * `gen/apple/Readest_iOS/Info.plist` is a gitignored artifact Tauri merges this
+ * seed into, so edits there do not survive a regeneration.
+ */
+
+const infoPlist = readFileSync(resolve(process.cwd(), 'src-tauri/Info-ios.plist'), 'utf-8');
+
+const stringValueFor = (key: string): string | undefined =>
+  infoPlist.match(new RegExp(`<key>${key}</key>\\s*<string>([^<]*)</string>`))?.[1];
+
+describe('iOS photo library usage description (#5397)', () => {
+  it('declares NSPhotoLibraryAddUsageDescription', () => {
+    expect(infoPlist).toContain('<key>NSPhotoLibraryAddUsageDescription</key>');
+  });
+
+  it('gives it a non-empty purpose string', () => {
+    expect(stringValueFor('NSPhotoLibraryAddUsageDescription')?.trim()).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #5397

## Problem

Saving an image to Photos on iOS kills the app. The crash log the reporter attached terminates in the TCC namespace:

> This app has crashed because it attempted to access privacy-sensitive data without a usage description. The app's Info.plist must contain an `NSPhotoLibraryAddUsageDescription` key...

and the reporting thread (`com.apple.photos.accessIsolation`) confirms an in-process photo library write:

```
PHPhotoLibrary._performCancellableChanges…
  PHPerformChangesRequest.determineAuthorizationStatusForChanges
    PLPrivacy.checkPhotosAccessAllowedWithScope:
→ __TCC_CRASHING_DUE_TO_PRIVACY_VIOLATION__ → abort_with_payload
```

## Why there is no "Save to Photos" in our code

There isn't one, and that is the confusing part of this report. Readest never *reads* the photo library, but it *writes* to it through two paths it does not own, and both run in-process:

1. WebKit's native long-press image callout in WKWebView (`_WKElementActionTypeSaveImage`, labeled "Add to Photos"). We suppress that callout with `-webkit-touch-callout: none` on `img` in `getPageLayoutStyles`, but that stylesheet only covers the reflowable EPUB iframe.
2. The `Save Image` activity (`UIActivityTypeSaveToCameraRoll`) of the share sheet the image viewer opens via `appService.saveFile(..., { share: true })`.

Without an add-only usage description, path 1 crashes the app and iOS silently drops path 2 from the share sheet, leaving only the out-of-process entries ("Add to Shared Album", "Save to Files") that need no host-app TCC declaration. So the missing key both crashed the WebKit path and hid our own working one.

## Fix

Declare `NSPhotoLibraryAddUsageDescription` in the tracked seed `src-tauri/Info-ios.plist`. Add-only is the correct scope: the image picker (`DialogPlugin.swift` `PHPickerConfiguration`) is out-of-process and needs no read description.

The seed is the only place this survives. Every `tauri ios build` / `tauri ios dev` runs `merge_plist([gen/apple/Readest_iOS/Info.plist, src-tauri/Info.plist, bundle.iOS.infoPlist])` and writes the result back to the generated path (`crates/tauri-cli/src/mobile/ios/{build,dev}.rs`), and the generated plist is a gitignored artifact.

Plus a regression guard following the existing `share-extension-activation-rule.test.ts` convention. It fails on both assertions without the plist change.

## Verification

- `plutil -lint src-tauri/Info-ios.plist` OK
- `pnpm test` 8009 passed, 7 skipped
- `pnpm lint` clean
- `pnpm format:check` clean

Not exercised on hardware. Worth a device run to confirm the permission prompt appears and that `Save Image` now shows up in the image viewer's share sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)