### PR TITLE
fix(layout): keep CSS-anchored dropdown menus within viewport

### DIFF
--- a/apps/readest-app/src/__tests__/components/dropdown-viewport.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/dropdown-viewport.browser.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Layout regression test for issue #5259 (drop-down menu not fully displayed).
+ *
+ * Renders the real Dropdown + Menu + MenuItem with Tailwind loaded and checks,
+ * in a real Chromium layout engine, that the CSS-anchored menus stay inside
+ * the viewport on a narrow phone screen:
+ *
+ * 1. Long translations (Russian): the menu is capped to the viewport width and
+ *    labels wrap to multiple lines so the full text stays readable.
+ * 2. Short labels (CJK): the menu keeps its natural content width and labels
+ *    do NOT wrap — guards the shrink-to-fit collapse where removing `nowrap`
+ *    let menus shrink to their longest word/character.
+ * 3. Every placement (start, center, end) is shifted back into the viewport
+ *    when its anchor sits near a screen edge, without portaling the menu out
+ *    of its DOM position next to the toggle (screen-reader traversal order).
+ * 4. Explicit consumer widths (w-44) and RTL alignment are preserved.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { page } from 'vitest/browser';
+
+import '@/styles/globals.css';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: null }),
+}));
+
+import Dropdown from '@/components/Dropdown';
+import Menu from '@/components/Menu';
+import MenuItem from '@/components/MenuItem';
+import { DropdownProvider } from '@/context/DropdownContext';
+
+const PHONE_WIDTH = 360;
+const VIEWPORT_PADDING = 16;
+const RIGHT_ANCHOR_LEFT = 280;
+const LEFT_ANCHOR_LEFT = 8;
+
+const renderMenu = (
+  labels: string[],
+  {
+    placement = 'dropdown-end',
+    anchorLeft = RIGHT_ANCHOR_LEFT,
+    menuClassName = '',
+    direction = 'ltr',
+  }: {
+    placement?: 'dropdown-bottom' | 'dropdown-center' | 'dropdown-end';
+    anchorLeft?: number;
+    menuClassName?: string;
+    direction?: 'ltr' | 'rtl';
+  } = {},
+) => {
+  document.documentElement.classList.toggle('ui-rtl', direction === 'rtl');
+  const utils = render(
+    <DropdownProvider>
+      <div data-testid='dropdown-anchor' style={{ position: 'fixed', top: 8, left: anchorLeft }}>
+        <Dropdown
+          label='Test Menu'
+          className={`dropdown-bottom ${placement}`}
+          buttonClassName='btn btn-ghost h-8 min-h-8 w-8 p-0'
+          toggleButton={<span>⋯</span>}
+          showTooltip={false}
+        >
+          <Menu className={`dropdown-content no-triangle z-20 mt-2 shadow-2xl ${menuClassName}`}>
+            {labels.map((label) => (
+              <MenuItem key={label} label={label} buttonClass='min-h-8 !py-1' transient />
+            ))}
+          </Menu>
+        </Dropdown>
+      </div>
+    </DropdownProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Test Menu' }));
+  return utils;
+};
+
+const openMenu = () => document.querySelector<HTMLElement>('.dropdown-content')!;
+
+const expectMenuWithinViewport = async () => {
+  await waitFor(() => {
+    const rect = openMenu().getBoundingClientRect();
+    expect(rect.left).toBeGreaterThanOrEqual(VIEWPORT_PADDING);
+    expect(rect.right).toBeLessThanOrEqual(PHONE_WIDTH - VIEWPORT_PADDING);
+  });
+};
+
+beforeAll(async () => {
+  await page.viewport(PHONE_WIDTH, 800);
+});
+
+afterEach(() => {
+  cleanup();
+  document.documentElement.classList.remove('ui-rtl');
+});
+
+describe('Dropdown menu viewport layout', () => {
+  it('keeps the menu adjacent to its toggle in the DOM for assistive tech', () => {
+    renderMenu(['Показать недавно прочитанные']);
+
+    const toggle = screen.getByRole('button', { name: 'Test Menu' });
+    const menu = openMenu();
+    // The menu must live next to the toggle (same anchor subtree), not in a
+    // portal at the end of <body> — TalkBack/VoiceOver traversal order and
+    // keyboard Tab order both follow DOM order (regression guard for the
+    // Floating UI portal approach that broke screen-reader navigation).
+    expect(toggle.closest('.dropdown-container')).toBe(menu.closest('.dropdown-container'));
+  });
+
+  it('caps a long-translation menu to the viewport and wraps its labels', async () => {
+    renderMenu(['Управление Пользовательскими Шрифтами', 'Сбросить Шрифт']);
+
+    await expectMenuWithinViewport();
+
+    const longLabel = screen.getByText('Управление Пользовательскими Шрифтами');
+    expect(longLabel.offsetHeight).toBeGreaterThan(30);
+    // Wrapped lines must stay start-aligned; <button> defaults to center.
+    expect(getComputedStyle(longLabel).textAlign).toBe('start');
+    // The row must grow with the wrapped label instead of letting it
+    // overflow across separators (fixed h-8 would clip it to 32px).
+    const row = longLabel.closest('button')!;
+    expect(row.getBoundingClientRect().bottom).toBeGreaterThanOrEqual(
+      longLabel.getBoundingClientRect().bottom,
+    );
+  });
+
+  it.each([
+    ['end placement near the left edge', 'dropdown-end', LEFT_ANCHOR_LEFT],
+    ['start placement near the right edge', 'dropdown-bottom', RIGHT_ANCHOR_LEFT],
+    ['center placement near the left edge', 'dropdown-center', LEFT_ANCHOR_LEFT],
+    ['center placement near the right edge', 'dropdown-center', RIGHT_ANCHOR_LEFT],
+  ] as const)('keeps %s inside the viewport', async (_name, placement, anchorLeft) => {
+    renderMenu(['Управление Пользовательскими Шрифтами', 'Сбросить Шрифт'], {
+      placement,
+      anchorLeft,
+    });
+
+    await expectMenuWithinViewport();
+  });
+
+  it('preserves an explicit consumer width', async () => {
+    renderMenu(['Revoke share'], { menuClassName: 'w-44' });
+
+    await waitFor(() => {
+      expect(openMenu().getBoundingClientRect().width).toBe(176);
+    });
+  });
+
+  it('keeps natural width for short CJK labels without wrapping', async () => {
+    renderMenu(['自动主题', '设置', '下载 Readest']);
+
+    await expectMenuWithinViewport();
+    const menu = openMenu();
+    // Collapsed-to-longest-character would be ~40px; natural width is wider.
+    expect(menu.getBoundingClientRect().width).toBeGreaterThan(80);
+
+    for (const text of ['自动主题', '设置', '下载 Readest']) {
+      const label = screen.getByText(text);
+      expect(label.offsetHeight).toBeLessThanOrEqual(30);
+      expect(label.closest('button')!.offsetHeight).toBe(32);
+    }
+  });
+
+  it('keeps an RTL end-aligned menu inside the viewport', async () => {
+    renderMenu(['Управление Пользовательскими Шрифтами', 'Сбросить Шрифт'], {
+      anchorLeft: LEFT_ANCHOR_LEFT,
+      direction: 'rtl',
+    });
+
+    await expectMenuWithinViewport();
+  });
+});

--- a/apps/readest-app/src/app/library/components/ViewMenu.tsx
+++ b/apps/readest-app/src/app/library/components/ViewMenu.tsx
@@ -179,7 +179,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({ setIsDropdownOpen }) => {
         <MenuItem
           key={option.value}
           label={option.label}
-          buttonClass='h-8'
+          buttonClass='min-h-8 !py-1'
           toggled={viewMode === option.value}
           onClick={() => handleSetViewMode(option.value as LibraryViewModeType)}
           transient
@@ -188,10 +188,15 @@ const ViewMenu: React.FC<ViewMenuProps> = ({ setIsDropdownOpen }) => {
 
       {/* Columns */}
       <hr aria-hidden='true' className='border-base-200 my-1' />
-      <MenuItem label={_('Columns')} buttonClass='h-8' labelClass='text-sm sm:text-xs' disabled />
+      <MenuItem
+        label={_('Columns')}
+        buttonClass='min-h-8 !py-1'
+        labelClass='text-sm sm:text-xs'
+        disabled
+      />
       <MenuItem
         label={_('Auto')}
-        buttonClass='h-10'
+        buttonClass='min-h-10 !py-2'
         toggled={autoColumns}
         disabled={viewMode === 'list'}
         siblings={
@@ -213,7 +218,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({ setIsDropdownOpen }) => {
       <hr aria-hidden='true' className='border-base-200 my-1' />
       <MenuItem
         label={_('Book Covers')}
-        buttonClass='h-8'
+        buttonClass='min-h-8 !py-1'
         labelClass='text-sm sm:text-xs'
         disabled
       />
@@ -221,7 +226,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({ setIsDropdownOpen }) => {
         <MenuItem
           key={option.value}
           label={option.label}
-          buttonClass='h-8'
+          buttonClass='min-h-8 !py-1'
           toggled={coverFit === option.value}
           onClick={() => handleToggleCropCovers(option.value as LibraryCoverFitType)}
           transient
@@ -232,7 +237,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({ setIsDropdownOpen }) => {
       <hr aria-hidden='true' className='border-base-200 my-1' />
       <MenuItem
         label={_('Show recently read')}
-        buttonClass='h-8'
+        buttonClass='min-h-8 !py-1'
         toggled={settings.libraryRecentShelfEnabled}
         onClick={handleToggleRecentShelf}
         transient
@@ -246,7 +251,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({ setIsDropdownOpen }) => {
             <MenuItem
               key={option.value}
               label={option.label}
-              buttonClass='h-8'
+              buttonClass='min-h-8 !py-1'
               toggled={groupBy === option.value}
               onClick={() => handleSetGroupBy(option.value as LibraryGroupByType)}
               transient
@@ -266,7 +271,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({ setIsDropdownOpen }) => {
               <MenuItem
                 key={option.value}
                 label={isImplicit ? `${option.label} (${_('Auto')})` : option.label}
-                buttonClass='h-8'
+                buttonClass='min-h-8 !py-1'
                 toggled={toggled}
                 onClick={() => handleSetSortBy(option.value as LibrarySortByType)}
                 transient
@@ -278,7 +283,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({ setIsDropdownOpen }) => {
             <MenuItem
               key={option.value.toString()}
               label={option.label}
-              buttonClass='h-8'
+              buttonClass='min-h-8 !py-1'
               toggled={isAscending === option.value}
               onClick={() => handleSetSortAscending(option.value)}
               transient
@@ -298,7 +303,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({ setIsDropdownOpen }) => {
               <MenuItem
                 key={option.value}
                 label={isImplicit ? `${option.label} (${_('Auto')})` : option.label}
-                buttonClass='h-8'
+                buttonClass='min-h-8 !py-1'
                 toggled={isExplicit || isImplicit}
                 onClick={() => handleSetSortBy2(option.value)}
                 transient

--- a/apps/readest-app/src/app/reader/components/ViewMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/ViewMenu.tsx
@@ -239,10 +239,6 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
         'view-menu dropdown-content dropdown-right no-triangle z-20 mt-1.5 border',
         'bgcolor-base-200 shadow-2xl',
       )}
-      style={{
-        maxWidth: `${window.innerWidth - 40}px`,
-        marginRight: window.innerWidth < 640 ? '-36px' : '0px',
-      }}
       onCancel={() => setIsDropdownOpen?.(false)}
     >
       {bookData.bookDoc?.rendition?.layout === 'pre-paginated' && (

--- a/apps/readest-app/src/app/reader/components/annotator/QuickActionMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/QuickActionMenu.tsx
@@ -52,9 +52,6 @@ const QuickActionMenu: React.FC<QuickActionMenuProps> = ({
         'bgcolor-base-200 shadow-2xl',
         menuClassName,
       )}
-      style={{
-        maxWidth: `${window.innerWidth - 40}px`,
-      }}
       onCancel={() => setIsDropdownOpen?.(false)}
     >
       {annotationToolQuickActions.map((button) => (

--- a/apps/readest-app/src/components/Dropdown.tsx
+++ b/apps/readest-app/src/components/Dropdown.tsx
@@ -1,5 +1,13 @@
 import clsx from 'clsx';
-import React, { useState, isValidElement, ReactElement, ReactNode, useRef, useId } from 'react';
+import React, {
+  useState,
+  isValidElement,
+  ReactElement,
+  ReactNode,
+  useLayoutEffect,
+  useRef,
+  useId,
+} from 'react';
 import { useDropdownContext } from '@/context/DropdownContext';
 import { Overlay } from './Overlay';
 import MenuItem from './MenuItem';
@@ -24,6 +32,8 @@ interface DropdownProps {
 type MenuItemProps = {
   setIsDropdownOpen?: (open: boolean) => void;
 };
+
+const MENU_VIEWPORT_PADDING = 16;
 
 const enhanceMenuItems = (
   children: ReactNode,
@@ -75,7 +85,40 @@ const Dropdown: React.FC<DropdownProps> = ({
   const context = useDropdownContext();
   const isOpen = context ? context.openDropdownId === dropdownId : false;
   const containerRef = useRef<HTMLDivElement>(null);
+  const detailsRef = useRef<HTMLDetailsElement>(null);
   const [isFocused, setIsFocused] = useState(false);
+
+  // The menu stays CSS-anchored next to its toggle (screen readers and Tab
+  // traverse it in DOM order), so a menu near a screen edge can stick out of
+  // the viewport (#5259). Measure the open menu and shift it back inside.
+  useLayoutEffect(() => {
+    if (!isOpen) return undefined;
+    const content = detailsRef.current?.querySelector<HTMLElement>(':scope > :not(summary)');
+    if (!content) return undefined;
+    const clamp = () => {
+      content.style.transform = '';
+      const rect = content.getBoundingClientRect();
+      let dx = 0;
+      if (rect.right > window.innerWidth - MENU_VIEWPORT_PADDING) {
+        dx = window.innerWidth - MENU_VIEWPORT_PADDING - rect.right;
+      }
+      if (rect.left + dx < MENU_VIEWPORT_PADDING) {
+        dx = MENU_VIEWPORT_PADDING - rect.left;
+      }
+      if (dx !== 0) {
+        content.style.transform = `translateX(${dx}px)`;
+      }
+    };
+    clamp();
+    window.addEventListener('resize', clamp);
+    const observer = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(clamp) : null;
+    observer?.observe(content);
+    return () => {
+      window.removeEventListener('resize', clamp);
+      observer?.disconnect();
+      content.style.transform = '';
+    };
+  }, [isOpen]);
 
   const setIsDropdownOpen = (open: boolean) => {
     if (disabled) return;
@@ -139,11 +182,12 @@ const Dropdown: React.FC<DropdownProps> = ({
           {toggleButton}
         </button>
         <details
+          ref={detailsRef}
           open={isOpen}
           role='none'
           className={clsx('dropdown flex items-center justify-center', className)}
         >
-          <summary aria-hidden='true' className='list-none' />
+          <summary aria-hidden='true' tabIndex={-1} className='list-none' />
           {isOpen && childrenWithToggle}
         </details>
       </div>

--- a/apps/readest-app/src/components/MenuItem.tsx
+++ b/apps/readest-app/src/components/MenuItem.tsx
@@ -73,7 +73,10 @@ const MenuItem: React.FC<MenuItemProps> = ({
             </span>
           )}
           <span
-            className={clsx('mx-2 flex-1 truncate text-base sm:text-sm', labelClass)}
+            className={clsx(
+              'mx-2 flex-1 break-words text-pretty text-start text-base sm:text-sm',
+              labelClass,
+            )}
             style={{ minWidth: 0 }}
           >
             {label}

--- a/apps/readest-app/src/components/Overlay.tsx
+++ b/apps/readest-app/src/components/Overlay.tsx
@@ -26,6 +26,10 @@ export const Overlay: React.FC<OverlayProps> = ({
       data-capture-blocking-overlay={captureBlocking ? 'true' : undefined}
       className={clsx('overlay fixed inset-0 cursor-default', className)}
       role='none'
+      // Pointer-only dismiss layer: hide it from screen readers so TalkBack /
+      // VoiceOver don't land on an unlabeled full-screen node whose activation
+      // dismisses the popup (Escape and the system back gesture still dismiss).
+      aria-hidden='true'
       tabIndex={-1}
       onClick={onDismiss}
       onContextMenu={onDismiss}

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -168,6 +168,16 @@ foliate-fxl {
   border-radius: 14px;
 }
 
+/* Menu labels wrap (no nowrap), so the anchor-positioned shrink-to-fit box
+   would collapse toward its longest word; keep the natural content width but
+   cap it to the viewport so long translations wrap instead of overflowing the
+   screen (#5259 — Dropdown shifts the box back inside). Zero specificity so
+   explicit utility widths (w-44, max-w-[90vw]) still win. */
+:where(.dropdown-content) {
+  width: max-content;
+  max-width: calc(100vw - 32px);
+}
+
 .dropdown-content::before,
 .dropdown-content::after {
   content: '';


### PR DESCRIPTION
Closes #5259

## Summary

Fixes dropdown menus overflowing the viewport while keeping the original CSS-anchored placement, so the menu stays DOM-adjacent to its toggle and screen readers can navigate it.

An earlier approach (#5392) repositioned menus with Floating UI through a portal at the end of `<body>`. Static checks (ARIA attributes, axe scans, Blink accessibility tree) all passed, but on-device testing with TalkBack enabled showed real screen readers could not navigate the portaled menu:

- Menu entries landed at the very end of the accessibility traversal order, dozens of swipes away from the toggle, instead of right next to it.
- The dismiss overlay was exposed as an unlabeled full-screen clickable node sitting in the traversal path right before the entries, and activating it closed the menu.
- The menu intermittently dismissed itself right after opening when TalkBack's accessibility focus was on background content.

VoiceOver failed the same way for the same DOM-order reason.

## Changes

- Let menu labels wrap (`break-words`) and size library view-menu rows with `min-h` so long translations stay readable instead of truncating (adopted from #5392, credit to @ChuwuYo).
- Give `.dropdown-content` its natural `max-content` width capped to the viewport, with a zero-specificity `:where()` rule so explicit utility widths (`w-44`, `max-w-[90vw]`) still win. Without this, enabling wrapping would let anchor-positioned menus collapse toward their longest word.
- Measure the open menu in `Dropdown` and shift it back inside the viewport with a `translateX` clamp, re-clamped on window resize and content resize. RTL works unchanged since the clamp is rect-based.
- Drop the per-menu inline `maxWidth`/`marginRight` viewport hacks in the reader view menu and quick action menu.
- Hide the pointer-only dismiss `Overlay` from assistive tech (`aria-hidden`), and remove the `aria-hidden` `<summary>` from the Tab order (`tabIndex={-1}`).

## Verification

- New browser test `dropdown-viewport.browser.test.tsx` (real Chromium layout at 360px): long Russian labels wrap and stay within the viewport for start/center/end placements near both screen edges, CJK menus keep natural width without wrapping, explicit consumer widths are preserved, RTL end alignment stays inside the viewport, and the menu stays DOM-adjacent to its toggle as an accessibility regression guard.
- Verified on a Xiaomi 13 (392px viewport, TalkBack enabled): the accessibility tree now lists the first menu entry immediately after the toggle, the unlabeled overlay node is gone, the menu no longer auto-dismisses, and both the library view menu and the reader view menu render fully inside the viewport.
- `pnpm test` (8009 passed), `pnpm test:browser` (330 passed), `pnpm lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)