### PR TITLE
fix(library): do not dedupe distinct PDFs with identical metadata

### DIFF
--- a/apps/readest-app/src/__tests__/services/import-metahash.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-metahash.test.ts
@@ -32,7 +32,7 @@ vi.mock('@/libs/storage', () => ({
 }));
 
 import { BaseAppService } from '@/services/appService';
-import { buildBookLookupIndex } from '@/services/bookService';
+import { buildBookLookupIndex, refreshBookMetadata } from '@/services/bookService';
 
 // Concrete test subclass of BaseAppService with mocked fs
 class TestAppService extends BaseAppService {
@@ -620,6 +620,106 @@ describe('importBook metaHash aggregation', () => {
     expect(writtenConfig.bookHash).toBe('exact-hash');
     // Merged booknotes from both
     expect(writtenConfig.booknotes).toHaveLength(2);
+  });
+});
+
+// PDF metadata is often generic (e.g. every PowerPoint export is titled
+// "PowerPoint Presentation" with the same author), so metaHash alone wrongly
+// collapses distinct PDFs into one book (issue #5411). PDF metaHash is salted
+// with the original filename so only same-named files dedupe.
+describe('importBook PDF filename-aware dedup', () => {
+  let service: TestAppService;
+
+  const PDF_METADATA = {
+    title: 'PowerPoint Presentation',
+    author: 'Alice Author',
+    language: 'en',
+  };
+
+  function setupMockPdfDoc() {
+    const bookDoc = {
+      metadata: { ...PDF_METADATA },
+      getCover: vi.fn().mockResolvedValue(null),
+    };
+    mockOpen.mockResolvedValue({ book: bookDoc, format: 'PDF' });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TestAppService();
+    const fs = service.getFs();
+    fs.exists.mockResolvedValue(false);
+    fs.createDir.mockResolvedValue(undefined);
+    fs.writeFile.mockResolvedValue(undefined);
+    fs.removeDir.mockResolvedValue(undefined);
+    fs.readFile.mockResolvedValue('{}');
+  });
+
+  it('imports PDFs with identical metadata but different filenames as separate books', async () => {
+    const books: Book[] = [];
+
+    mockPartialMD5.mockResolvedValue('pdf-hash-1');
+    setupMockPdfDoc();
+    const book1 = await service.importBook(
+      new File(['slides 1'], 'lecture-01.pdf', { type: 'application/pdf' }),
+      books,
+    );
+
+    mockPartialMD5.mockResolvedValue('pdf-hash-2');
+    setupMockPdfDoc();
+    const book2 = await service.importBook(
+      new File(['slides 2'], 'lecture-02.pdf', { type: 'application/pdf' }),
+      books,
+    );
+
+    expect(book2).not.toBe(book1);
+    expect(books.filter((b) => !b.deletedAt)).toHaveLength(2);
+  });
+
+  it('still dedupes a PDF re-imported with the same filename and metadata', async () => {
+    const books: Book[] = [];
+
+    mockPartialMD5.mockResolvedValue('pdf-hash-1');
+    setupMockPdfDoc();
+    const book1 = await service.importBook(
+      new File(['v1'], 'deck.pdf', { type: 'application/pdf' }),
+      books,
+    );
+
+    mockPartialMD5.mockResolvedValue('pdf-hash-2');
+    setupMockPdfDoc();
+    const book2 = await service.importBook(
+      new File(['v2'], 'deck.pdf', { type: 'application/pdf' }),
+      books,
+    );
+
+    expect(book2).toBe(book1);
+    expect(books.filter((b) => !b.deletedAt)).toHaveLength(1);
+    expect(book1!.hash).toBe('pdf-hash-2');
+  });
+
+  it('refreshBookMetadata preserves the salted metaHash for PDFs', async () => {
+    // The original filename is lost after import (files are stored under the
+    // metadata title), so re-parsing the file cannot reproduce the salt and
+    // must keep the metaHash stamped at import time.
+    const book = makeBook({
+      hash: 'pdf-hash-1',
+      format: 'PDF' as Book['format'],
+      metaHash: 'salted-import-hash',
+    });
+
+    const fs = service.getFs();
+    fs.exists.mockResolvedValue(true);
+    fs.openFile.mockResolvedValue(new File(['pdf'], 'Test Book.pdf'));
+    setupMockPdfDoc();
+
+    const refreshed = await refreshBookMetadata(
+      fs as unknown as Parameters<typeof refreshBookMetadata>[0],
+      book,
+    );
+
+    expect(refreshed).toBe(true);
+    expect(book.metaHash).toBe('salted-import-hash');
   });
 });
 

--- a/apps/readest-app/src/__tests__/utils/metadata-hash-info.test.ts
+++ b/apps/readest-app/src/__tests__/utils/metadata-hash-info.test.ts
@@ -49,4 +49,32 @@ describe('getMetadataHashInfo', () => {
     const info = getMetadataHashInfo(null as unknown as BookMetadata);
     expect(info).toBeUndefined();
   });
+
+  describe('with a filename salt (issue #5411)', () => {
+    const metadata: BookMetadata = {
+      title: 'PowerPoint Presentation',
+      author: 'Alice Author',
+      language: 'en',
+    };
+
+    it('produces different hashes for the same metadata under different filenames', () => {
+      expect(getMetadataHash(metadata, 'lecture-01')).not.toBe(
+        getMetadataHash(metadata, 'lecture-02'),
+      );
+    });
+
+    it('produces the same hash for the same metadata and filename', () => {
+      expect(getMetadataHash(metadata, 'lecture-01')).toBe(getMetadataHash(metadata, 'lecture-01'));
+    });
+
+    it('appends the filename to the hash source', () => {
+      const info = getMetadataHashInfo(metadata, 'lecture-01');
+      expect(info!.hashSource).toBe('PowerPoint Presentation|Alice Author||lecture-01');
+    });
+
+    it('leaves the hash unchanged when no filename is given', () => {
+      const info = getMetadataHashInfo(metadata);
+      expect(info!.hashSource).toBe('PowerPoint Presentation|Alice Author|');
+    });
+  });
 });

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -482,7 +482,14 @@ export async function importBook(
         ? nativeHash!
         : await partialMD5(fileobj!);
 
-    const metaHash = getMetadataHash(loadedBook.metadata);
+    // PDF metadata is often generic boilerplate (e.g. every PowerPoint export
+    // is titled "PowerPoint Presentation" by the same author), so metadata
+    // alone wrongly collapses distinct files into one book (issue #5411).
+    // Salt the hash with the original filename so only same-named PDFs dedupe.
+    const metaHash = getMetadataHash(
+      loadedBook.metadata,
+      format === 'PDF' ? getBaseFilename(filename) : undefined,
+    );
     let existingBook = lookupIndex
       ? lookupIndex.byHash.get(hash)
       : books.find((b) => b.hash === hash);
@@ -862,7 +869,11 @@ export async function refreshBookMetadata(fs: FileSystem, book: Book): Promise<b
   if (!bookDoc) return false;
 
   book.metadata = bookDoc.metadata;
-  book.metaHash = getMetadataHash(bookDoc.metadata);
+  // PDF metaHash is salted with the original import filename (issue #5411),
+  // which is lost after import — keep the value stamped at import time.
+  if (book.format !== 'PDF' || !book.metaHash) {
+    book.metaHash = getMetadataHash(bookDoc.metadata);
+  }
   const primaryLanguage = getPrimaryLanguage(bookDoc.metadata.language);
   if (primaryLanguage) {
     book.primaryLanguage = primaryLanguage;

--- a/apps/readest-app/src/store/readerStore.ts
+++ b/apps/readest-app/src/store/readerStore.ts
@@ -291,7 +291,11 @@ export const useReaderStore = create<ReaderStore>((set, get) => ({
       }
       // TODO: uncomment this when we can ensure metaHash is correctly generated for all books
       // book.metaHash = book.metaHash ?? getMetadataHash(bookDoc.metadata);
-      book.metaHash = getMetadataHash(bookDoc.metadata);
+      // PDF metaHash is salted with the original import filename (issue #5411),
+      // which is lost after import — keep the value stamped at import time.
+      if (book.format !== 'PDF' || !book.metaHash) {
+        book.metaHash = getMetadataHash(bookDoc.metadata);
+      }
 
       const isFixedLayout =
         bookDoc.rendition?.layout === 'pre-paginated' || FIXED_LAYOUT_FORMATS.has(book.format);

--- a/apps/readest-app/src/utils/book.ts
+++ b/apps/readest-app/src/utils/book.ts
@@ -394,13 +394,17 @@ export interface MetadataHashInfo {
   metaHash: string;
 }
 
-export const getMetadataHashInfo = (metadata: BookMetadata): MetadataHashInfo | undefined => {
+export const getMetadataHashInfo = (
+  metadata: BookMetadata,
+  filename?: string,
+): MetadataHashInfo | undefined => {
   if (!metadata) return;
   try {
     const title = getTitleForHash(metadata.title);
     const authors = getAuthorsList(metadata.author);
     const identifiers = getIdentifiersList(metadata.altIdentifier || metadata.identifier);
-    const hashSource = `${title}|${authors.join(',')}|${identifiers.join(',')}`;
+    let hashSource = `${title}|${authors.join(',')}|${identifiers.join(',')}`;
+    if (filename) hashSource += `|${filename}`;
     const metaHash = md5(hashSource.normalize('NFC'));
     return { title, authors, identifiers, hashSource, metaHash };
   } catch (error) {
@@ -409,6 +413,6 @@ export const getMetadataHashInfo = (metadata: BookMetadata): MetadataHashInfo | 
   return;
 };
 
-export const getMetadataHash = (metadata: BookMetadata) => {
-  return getMetadataHashInfo(metadata)?.metaHash;
+export const getMetadataHash = (metadata: BookMetadata, filename?: string) => {
+  return getMetadataHashInfo(metadata, filename)?.metaHash;
 };


### PR DESCRIPTION
Closes #5411

### Problem

Importing several PDFs that share identical embedded metadata (e.g. PowerPoint exports are all titled "PowerPoint Presentation" with the same author and no identifiers) collapsed them into a single library entry. The metaHash dedupe in `importBook` keys on `md5(title|authors|identifiers)` per format, and the merge path replaces the survivor's content hash and deletes the old book directory, so previously imported PDFs silently disappeared from the library.

### Fix

- `getMetadataHashInfo` / `getMetadataHash` accept an optional filename that is appended to the hash source. When omitted the hash is byte-identical to before, so non-PDF hashes are unchanged.
- `importBook` salts the metaHash with the original base filename for PDFs only, so PDFs dedupe only when both metadata and filename match. EPUB dedupe stays filename independent since its identifiers are reliable and cross-source dedupe there is intentional.
- The two re-parse sites (`initViewState` in readerStore and `refreshBookMetadata`) now preserve the metaHash stamped at import for PDFs instead of recomputing it: the original filename is lost after import (files are stored under the metadata title), so the salt cannot be reproduced there.

PDFs with an empty metadata title were never affected, as the title already falls back to the base filename which flows into the hash. Identical re-imports are still deduped by the content hash check. koplugin and the Rust side only read metaHash from sync rows and never compute it.

### Tests

Written first and confirmed failing before the fix:

- Import: PDFs with identical metadata but different filenames import as separate books.
- Import: a PDF re-imported with the same filename and metadata still dedupes in place and re-keys the hash.
- `refreshBookMetadata` preserves the salted metaHash for PDFs.
- Hash util: filename salt changes the hash, is stable for the same filename, and omitting it leaves the hash source unchanged.

`pnpm test` (8016 passed), `pnpm lint`, and `pnpm format:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)