### PR TITLE
fix(reader): exclude trailing whitespace from double-click selection

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-doubleClick.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-doubleClick.test.ts
@@ -73,9 +73,9 @@ const setup = (setSelection: (s: TextSelection | null) => void) => {
 
 // A jsdom document carrying a real text node and a caretRangeFromPoint that
 // resolves to a caret inside "world".
-const makeDoc = (caretOffset: number | null) => {
+const makeDoc = (caretOffset: number | null, text = 'Hello world test') => {
   const container = document.createElement('div');
-  const node = document.createTextNode('Hello world test');
+  const node = document.createTextNode(text);
   container.appendChild(node);
   document.body.appendChild(container);
   Object.assign(document, {
@@ -88,6 +88,23 @@ const makeDoc = (caretOffset: number | null) => {
     },
   });
   return { container, node, doc: document as Document };
+};
+
+const mouseDown = (detail: number, x = 50, y = 50) =>
+  ({ detail, button: 0, clientX: x, clientY: y }) as MouseEvent;
+
+const mousePointer = (x = 50, y = 50) =>
+  ({ pointerType: 'mouse', clientX: x, clientY: y }) as PointerEvent;
+
+const makeRangeVisibleAt = (range: Range, x = 50, y = 50) => {
+  Object.assign(range, {
+    getClientRects: () =>
+      ({
+        0: { left: x - 5, right: x + 5, top: y - 5, bottom: y + 5 },
+        length: 1,
+        item: () => null,
+      }) as unknown as DOMRectList,
+  });
 };
 
 beforeEach(() => {
@@ -152,6 +169,111 @@ describe('useTextSelector double-click word selection', () => {
     // The existing pointerup path owns this; the double-click handler must not
     // double-fire the selection.
     expect(setSelection).not.toHaveBeenCalled();
+    document.body.removeChild(container);
+  });
+
+  test('normalizes a native double-click before publishing the selection', async () => {
+    const setSelection = vi.fn();
+    const { result } = setup(setSelection);
+    const { container, node, doc } = makeDoc(8);
+
+    // Chromium can include the separator after a word in its native selection.
+    const pre = document.createRange();
+    pre.setStart(node, 6);
+    pre.setEnd(node, 12);
+    const sel = document.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(pre);
+    makeRangeVisibleAt(pre);
+    expect(sel.toString()).toBe('world ');
+
+    result.current.handleMouseDown(mouseDown(2));
+    await result.current.handlePointerUp(doc, 0, mousePointer());
+    // The later click-derived double-click message must not publish a second,
+    // competing TextSelection.
+    await result.current.handleDoubleClick(doc, 0, 50, 50);
+
+    // Keep the browser's live selection untouched. Only the Range captured by
+    // Readest is normalized, avoiding native touch-handle rewrites (#1553).
+    expect(sel.toString()).toBe('world ');
+    expect(setSelection).toHaveBeenCalledTimes(1);
+    const arg = setSelection.mock.calls[0]![0] as TextSelection;
+    expect(arg.text).toBe('world');
+    expect(arg.range.toString()).toBe('world');
+    expect(arg.range).not.toBe(sel.getRangeAt(0));
+
+    document.body.removeChild(container);
+  });
+
+  test('keeps only the clicked word when native selection spans Unicode whitespace', async () => {
+    const setSelection = vi.fn();
+    const { result } = setup(setSelection);
+    const { container, node, doc } = makeDoc(2, 'space\u202fbetween');
+    const pre = document.createRange();
+    pre.selectNodeContents(node);
+    const sel = document.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(pre);
+    makeRangeVisibleAt(pre);
+
+    result.current.handleMouseDown(mouseDown(2));
+    await result.current.handlePointerUp(doc, 0, mousePointer());
+
+    expect(sel.toString()).toBe('space\u202fbetween');
+    expect(setSelection).toHaveBeenCalledTimes(1);
+    const arg = setSelection.mock.calls[0]![0] as TextSelection;
+    expect(arg.text).toBe('space');
+    expect(arg.range.toString()).toBe('space');
+    expect(arg.range).not.toBe(sel.getRangeAt(0));
+
+    document.body.removeChild(container);
+  });
+
+  test('preserves a native double-click selection deliberately extended into whitespace', async () => {
+    const setSelection = vi.fn();
+    const { result } = setup(setSelection);
+    const { container, node, doc } = makeDoc(8);
+
+    // A double-click then drag can intentionally select only the separator,
+    // without reaching the next word.
+    const pre = document.createRange();
+    pre.setStart(node, 6);
+    pre.setEnd(node, 12);
+    const sel = document.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(pre);
+    makeRangeVisibleAt(pre, 60, 50);
+
+    result.current.handleMouseDown(mouseDown(2));
+    result.current.handlePointerMove(doc, 0, mousePointer(60, 50));
+    await result.current.handlePointerUp(doc, 0, mousePointer(60, 50));
+    await result.current.handleDoubleClick(doc, 0, 50, 50);
+
+    expect(sel.toString()).toBe('world ');
+    expect(setSelection).toHaveBeenCalledTimes(1);
+    expect((setSelection.mock.calls[0]![0] as TextSelection).text).toBe('world ');
+
+    document.body.removeChild(container);
+  });
+
+  test('does not normalize a stale selection outside the double-click target', async () => {
+    const setSelection = vi.fn();
+    const { result } = setup(setSelection);
+    const { container, node, doc } = makeDoc(8);
+    const pre = document.createRange();
+    pre.setStart(node, 6);
+    pre.setEnd(node, 12);
+    const sel = document.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(pre);
+    makeRangeVisibleAt(pre, 200, 200);
+
+    result.current.handleMouseDown(mouseDown(2));
+    await result.current.handlePointerUp(doc, 0, mousePointer());
+
+    expect(sel.toString()).toBe('world ');
+    expect(setSelection).not.toHaveBeenCalled();
+
     document.body.removeChild(container);
   });
 });

--- a/apps/readest-app/src/__tests__/utils/sel.test.ts
+++ b/apps/readest-app/src/__tests__/utils/sel.test.ts
@@ -637,4 +637,103 @@ describe('sel utilities', () => {
       delete (doc as { caretRangeFromPoint?: unknown }).caretRangeFromPoint;
     });
   });
+
+  describe('trimRangeWhitespaceAroundPoint', () => {
+    it.each([
+      ['world\u00a0', 'world'],
+      ['日本語\u3000', '日本語'],
+      ['שלום\u00a0', 'שלום'],
+    ])('trims Unicode trailing whitespace from %j', async (source, expected) => {
+      const container = document.createElement('div');
+      const node = document.createTextNode(source);
+      container.appendChild(node);
+      document.body.appendChild(container);
+      const range = document.createRange();
+      range.selectNodeContents(node);
+      const { trimRangeWhitespaceAroundPoint } = await import('@/utils/sel');
+
+      expect(trimRangeWhitespaceAroundPoint(range, node, 2)).toBe(true);
+      expect(range.toString()).toBe(expected);
+      expect(range.endContainer).toBe(node);
+      expect(range.endOffset).toBe(expected.length);
+
+      document.body.removeChild(container);
+    });
+
+    it('trims across inline text nodes while preserving the native word range', async () => {
+      const container = document.createElement('div');
+      container.innerHTML = 'Hello wor<em>ld</em><span> \u00a0</span>test';
+      document.body.appendChild(container);
+      const first = container.firstChild!;
+      const emphasized = container.querySelector('em')!.firstChild!;
+      const whitespace = container.querySelector('span')!.firstChild!;
+      const range = document.createRange();
+      range.setStart(first, 6);
+      range.setEnd(whitespace, 2);
+      const { trimRangeWhitespaceAroundPoint } = await import('@/utils/sel');
+
+      expect(range.toString()).toBe('world \u00a0');
+      expect(trimRangeWhitespaceAroundPoint(range, emphasized, 1)).toBe(true);
+      expect(range.toString()).toBe('world');
+      expect(range.endContainer).toBe(emphasized);
+      expect(range.endOffset).toBe(2);
+
+      document.body.removeChild(container);
+    });
+
+    it('preserves a whitespace-only range', async () => {
+      const container = document.createElement('div');
+      const node = document.createTextNode(' \u00a0');
+      container.appendChild(node);
+      document.body.appendChild(container);
+      const range = document.createRange();
+      range.selectNodeContents(node);
+      const { trimRangeWhitespaceAroundPoint } = await import('@/utils/sel');
+
+      expect(trimRangeWhitespaceAroundPoint(range, node, 1)).toBe(false);
+      expect(range.toString()).toBe(' \u00a0');
+
+      document.body.removeChild(container);
+    });
+
+    it.each([
+      ['\u00a0', 'non-breaking space'],
+      ['\u2009', 'thin space'],
+      ['\u202f', 'narrow no-break space'],
+      ['\u3000', 'ideographic space'],
+    ])('selects only the clicked side of a %s separator', async (separator) => {
+      const container = document.createElement('div');
+      const node = document.createTextNode(`space${separator}between`);
+      container.appendChild(node);
+      document.body.appendChild(container);
+      const { trimRangeWhitespaceAroundPoint } = await import('@/utils/sel');
+
+      const left = document.createRange();
+      left.selectNodeContents(node);
+      expect(trimRangeWhitespaceAroundPoint(left, node, 2)).toBe(true);
+      expect(left.toString()).toBe('space');
+
+      const right = document.createRange();
+      right.selectNodeContents(node);
+      expect(trimRangeWhitespaceAroundPoint(right, node, 8)).toBe(true);
+      expect(right.toString()).toBe('between');
+
+      document.body.removeChild(container);
+    });
+
+    it('does not reinterpret a hyphenated native selection', async () => {
+      const container = document.createElement('div');
+      const node = document.createTextNode('mother-in-law');
+      container.appendChild(node);
+      document.body.appendChild(container);
+      const range = document.createRange();
+      range.selectNodeContents(node);
+      const { trimRangeWhitespaceAroundPoint } = await import('@/utils/sel');
+
+      expect(trimRangeWhitespaceAroundPoint(range, node, 8)).toBe(false);
+      expect(range.toString()).toBe('mother-in-law');
+
+      document.body.removeChild(container);
+    });
+  });
 });

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -317,6 +317,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     handleTouchStart,
     handleTouchMove,
     handleTouchEnd,
+    handleMouseDown,
     handlePointerDown,
     handlePointerMove,
     handleNativeTouchMove,
@@ -396,6 +397,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
         opts,
       );
     }
+    detail.doc?.addEventListener('mousedown', handleMouseDown);
     detail.doc?.addEventListener('pointerdown', handlePointerDown.bind(null, doc, index), opts);
     detail.doc?.addEventListener('pointermove', handlePointerMove.bind(null, doc, index), opts);
     detail.doc?.addEventListener('pointercancel', handlePointerCancel.bind(null, doc, index));

--- a/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
@@ -8,6 +8,7 @@ import { getOSPlatform } from '@/utils/misc';
 import { eventDispatcher } from '@/utils/event';
 import {
   focusCaretWindowPos,
+  getCaretPointFromPoint,
   getWordRangeFromPoint,
   isHyphenHandleBugProneRange,
   isPointerInsideSelection,
@@ -15,6 +16,7 @@ import {
   rangeFromAnchorToPoint,
   repairJumpedSelectionRange,
   TextSelection,
+  trimRangeWhitespaceAroundPoint,
 } from '@/utils/sel';
 import { Corner, useAutoPageTurn } from './useAutoPageTurn';
 import { useInstantAnnotation } from './useInstantAnnotation';
@@ -29,6 +31,9 @@ const INSTANT_HOLD_MS = 300;
 // Movement past this many CSS px during the hold means the user is swiping, not
 // settling in to highlight, so the pending engagement is cancelled.
 const INSTANT_HOLD_MOVE_PX = 10;
+// Ignore tiny pointer jitter, but preserve a deliberate double-click-drag even
+// when it only extends the selection into adjacent whitespace.
+const DOUBLE_CLICK_DRAG_MOVE_PX = 3;
 
 export const useTextSelector = (
   bookKey: string,
@@ -94,6 +99,7 @@ export const useTextSelector = (
   // native touchmove): an auto-turn engagement signal alongside the caret, and
   // the finger position the Android hyphen repair rebuilds from.
   const pointerPos = useRef<{ x: number; y: number } | null>(null);
+  const mouseDoubleClickRef = useRef<{ x: number; y: number; moved: boolean } | null>(null);
 
   // Android hyphen selection-bounds bug (#1553): the selection anchor captured
   // at the first selectionchange of a touch gesture, plus whether that initial
@@ -144,13 +150,19 @@ export const useTextSelector = (
     index: number,
     rebuildRange = false,
     handlesSuppressed = false,
+    trimPoint?: { node: Node; offset: number } | null,
   ) => {
     isTextSelected.current = true;
-    const range = sel.getRangeAt(0);
+    const liveRange = sel.getRangeAt(0);
     if (rebuildRange) {
       sel.removeAllRanges();
-      sel.addRange(range);
+      sel.addRange(liveRange);
     }
+    // Selection.getRangeAt() returns the live, associated Range by reference.
+    // Clone only for double-click normalization so native touch paths retain
+    // their established Range behavior and browser handles stay untouched.
+    const range = trimPoint ? liveRange.cloneRange() : liveRange;
+    if (trimPoint) trimRangeWhitespaceAroundPoint(range, trimPoint.node, trimPoint.offset);
     const progress = getProgress(bookKey);
     setSelection({
       key: bookKey,
@@ -268,7 +280,27 @@ export const useTextSelector = (
     }
   };
 
+  // UI Events exposes the current click count on mousedown (`detail`). Record
+  // the second primary-button press before pointerup publishes the native word
+  // selection, so any browser-added separator can be removed exactly once.
+  const handleMouseDown = (ev: MouseEvent) => {
+    const doubleClickEnabled = !getViewSettings(bookKey)?.disableDoubleClick;
+    mouseDoubleClickRef.current =
+      doubleClickEnabled && ev.button === 0 && ev.detail === 2
+        ? { x: ev.clientX, y: ev.clientY, moved: false }
+        : null;
+  };
+
   const handlePointerMove = (doc: Document, index: number, ev: PointerEvent) => {
+    const doubleClick = mouseDoubleClickRef.current;
+    if (
+      doubleClick &&
+      ev.pointerType === 'mouse' &&
+      Math.hypot(ev.clientX - doubleClick.x, ev.clientY - doubleClick.y) >=
+        DOUBLE_CLICK_DRAG_MOVE_PX
+    ) {
+      doubleClick.moved = true;
+    }
     // The listener lives on the book iframe's document, so ev.clientX/Y are in
     // the (very wide, multi-column) iframe viewport. Map to window coordinates
     // via the iframe element's on-screen rect, like the selection caret.
@@ -340,6 +372,7 @@ export const useTextSelector = (
 
   const handlePointerCancel = (_doc: Document, _index: number, _ev: PointerEvent) => {
     isPointerDown.current = false;
+    mouseDoubleClickRef.current = null;
     // A pending still-hold that never engaged: drop it so a swipe-takeover
     // (Android fires pointercancel when the browser starts scrolling) keeps its
     // native page-turn instead of being swallowed.
@@ -436,11 +469,9 @@ export const useTextSelector = (
 
   // A double-click / touch double-tap on a word: select the word (like a
   // long-press selection) and route it through the same selection state that
-  // drives the quick action / annotation toolbar. On desktop the browser already
-  // selects the word natively on a real double-click, and that selection flows
-  // through handlePointerUp; so we only synthesize the selection when nothing is
-  // selected yet — the touch double-tap case (Android has no native word-select
-  // gesture), where the dblclick is detected from two quick taps.
+  // drives the quick action / annotation toolbar. Desktop native selection is
+  // finalized in handlePointerUp; touch double-tap still needs this synthesized
+  // range when the platform has no native word-select gesture.
   const handleDoubleClick = async (doc: Document, index: number, x: number, y: number) => {
     if (isInstantAnnotating.current) return;
     const sel = doc.getSelection();
@@ -462,6 +493,8 @@ export const useTextSelector = (
 
   const handlePointerUp = async (doc: Document, index: number, ev?: PointerEvent) => {
     isPointerDown.current = false;
+    const mouseDoubleClick = mouseDoubleClickRef.current;
+    mouseDoubleClickRef.current = null;
     // A tap (or a long-press shorter than the hold) that never engaged: drop the
     // pending still-hold so the tap falls through to a page turn.
     if (instantHoldTimer.current) cancelInstantHold();
@@ -500,13 +533,22 @@ export const useTextSelector = (
     const sel = doc.getSelection() as Selection;
     if (isValidSelection(sel)) {
       const isPointerInside = ev && isPointerInsideSelection(sel, ev);
+      let trimPoint: { node: Node; offset: number } | null = null;
+      if (
+        isPointerInside &&
+        ev.pointerType === 'mouse' &&
+        mouseDoubleClick &&
+        !mouseDoubleClick.moved
+      ) {
+        trimPoint = getCaretPointFromPoint(doc, mouseDoubleClick.x, mouseDoubleClick.y);
+      }
 
       // iOS no longer needs a special path: the native plugin
       // (ContextMenuSuppressor) suppresses the system selection menu, so
       // iOS selections go through the same path as desktop.
       if (isPointerInside) {
         isUpToPopup.current = true;
-        makeSelection(sel, index, true);
+        makeSelection(sel, index, true, false, trimPoint);
       } else if (appService?.isAndroidApp) {
         isUpToPopup.current = false;
       }
@@ -721,6 +763,7 @@ export const useTextSelector = (
     handleTouchStart,
     handleTouchMove,
     handleTouchEnd,
+    handleMouseDown,
     handlePointerDown,
     handlePointerMove,
     handleNativeTouchMove,

--- a/apps/readest-app/src/utils/sel.ts
+++ b/apps/readest-app/src/utils/sel.ts
@@ -509,7 +509,11 @@ export const getWordRangeAt = (node: Node, offset: number): Range | null => {
 
 // The word range under a point (in `doc` viewport coordinates), like a native
 // double-click. Returns null when the point isn't on word-like text.
-export const getWordRangeFromPoint = (doc: Document, x: number, y: number): Range | null => {
+export const getCaretPointFromPoint = (
+  doc: Document,
+  x: number,
+  y: number,
+): { node: Node; offset: number } | null => {
   let node: Node | null = null;
   let offset = 0;
   if (doc.caretPositionFromPoint) {
@@ -526,7 +530,105 @@ export const getWordRangeFromPoint = (doc: Document, x: number, y: number): Rang
     }
   }
   if (!node) return null;
-  return getWordRangeAt(node, offset);
+  return { node, offset };
+};
+
+export const getWordRangeFromPoint = (doc: Document, x: number, y: number): Range | null => {
+  const point = getCaretPointFromPoint(doc, x, y);
+  return point ? getWordRangeAt(point.node, point.offset) : null;
+};
+
+interface SelectedTextSlice {
+  node: Text;
+  start: number;
+  end: number;
+}
+
+const getSelectedTextSlices = (range: Range): SelectedTextSlice[] => {
+  const root = range.commonAncestorContainer;
+  const textNodes: Text[] = [];
+  if (root.nodeType === Node.TEXT_NODE) {
+    textNodes.push(root as Text);
+  } else {
+    const walker = root.ownerDocument?.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    if (!walker) return [];
+    let node: Node | null;
+    while ((node = walker.nextNode())) {
+      if (range.intersectsNode(node)) textNodes.push(node as Text);
+    }
+  }
+
+  return textNodes
+    .map((node) => ({
+      node,
+      start: node === range.startContainer ? range.startOffset : 0,
+      end: node === range.endContainer ? range.endOffset : node.data.length,
+    }))
+    .filter(({ start, end }) => end > start);
+};
+
+// Restrict a captured Range snapshot to the non-whitespace segment under the
+// click. This corrects engines that treat NBSP-like separators as part of one
+// word while preserving their punctuation, hyphen, and language rules. Do not
+// pass the live Range associated with Selection: changing it rewrites the
+// browser selection and can disturb native touch handles. The selected segment
+// may span inline DOM nodes.
+export const trimRangeWhitespaceAroundPoint = (
+  range: Range,
+  pointNode: Node,
+  pointOffset: number,
+): boolean => {
+  const slices = getSelectedTextSlices(range);
+  const text = slices.map(({ node, start, end }) => node.data.slice(start, end)).join('');
+  if (!text || text !== range.toString() || !/\s/u.test(text)) return false;
+
+  let caretOffset: number | null = null;
+  let consumed = 0;
+  for (const slice of slices) {
+    const length = slice.end - slice.start;
+    if (slice.node === pointNode && pointOffset >= slice.start && pointOffset <= slice.end) {
+      caretOffset = consumed + pointOffset - slice.start;
+      break;
+    }
+    consumed += length;
+  }
+  if (caretOffset === null) return false;
+
+  const isWhitespace = (char: string): boolean => /\s/u.test(char);
+  let pivot: number;
+  if (caretOffset < text.length && !isWhitespace(text[caretOffset]!)) {
+    pivot = caretOffset;
+  } else if (caretOffset > 0 && !isWhitespace(text[caretOffset - 1]!)) {
+    pivot = caretOffset - 1;
+  } else {
+    return false;
+  }
+
+  let segmentStart = pivot;
+  while (segmentStart > 0 && !isWhitespace(text[segmentStart - 1]!)) segmentStart--;
+  let segmentEnd = pivot + 1;
+  while (segmentEnd < text.length && !isWhitespace(text[segmentEnd]!)) segmentEnd++;
+  if (segmentStart === 0 && segmentEnd === text.length) return false;
+
+  const boundaryAt = (target: number, side: 'start' | 'end') => {
+    let offset = 0;
+    for (const slice of slices) {
+      const length = slice.end - slice.start;
+      const nextOffset = offset + length;
+      if (target < nextOffset || (side === 'end' && target === nextOffset)) {
+        return { node: slice.node, offset: slice.start + target - offset };
+      }
+      offset = nextOffset;
+    }
+    return null;
+  };
+
+  const start = boundaryAt(segmentStart, 'start');
+  const end = boundaryAt(segmentEnd, 'end');
+  if (!start || !end) return false;
+  range.setStart(start.node, start.offset);
+  range.setEnd(end.node, end.offset);
+  return true;
 };
 
 // --- Android hyphenation selection-bounds bug (issue #1553) -----------------


### PR DESCRIPTION
Closes #5408

## Summary

Fixes a bug where browser double-click word selection could include trailing or internal whitespace characters in the selection Readest captures.

## Changes

- Normalize native mouse double-click selections before publishing them to the reader selection pipeline.
- `Selection.getRangeAt(0)` returns a live Range by reference; the fix now clones the Range on the desktop double-click path and trims the copy, leaving the browser's live Selection and native touch handles untouched.
- Restrict the captured Range to the word segment under the original click position.
- Preserve native browser selection behavior for punctuation, hyphenated words, RTL text, combining characters, and inline DOM structures.
- Touch and Android selection paths are unchanged.

## Behavior

Handled whitespace characters:

- Regular spaces
- Non-breaking spaces (`U+00A0`)
- Thin spaces (`U+2009`)
- Narrow no-break spaces (`U+202F`)
- Ideographic spaces (`U+3000`)

Expected behavior:

- Whitespace is excluded from the Range captured by Readest without rewriting the browser's live Selection.
- Unicode whitespace acts as a word boundary.
- Real hyphenated words continue following browser-native selection behavior.
- Visual hyphens created by line wrapping do not affect the underlying text selection.

## Scope

Applies to text-based reading content that uses the shared DOM selection pipeline. Image-only documents without selectable text are not affected.