### PR TITLE
fix(ios): declare txt and md in fileAssociations so Files offers Readest again

### DIFF
--- a/apps/readest-app/src-tauri/tauri.conf.json
+++ b/apps/readest-app/src-tauri/tauri.conf.json
@@ -125,6 +125,20 @@
         "description": "PDF file",
         "mimeType": "application/pdf",
         "role": "Viewer"
+      },
+      {
+        "name": "txt",
+        "ext": ["txt"],
+        "description": "TXT file",
+        "mimeType": "text/plain",
+        "role": "Viewer"
+      },
+      {
+        "name": "md",
+        "ext": ["md"],
+        "description": "Markdown file",
+        "mimeType": "text/markdown",
+        "role": "Viewer"
       }
     ],
     "createUpdaterArtifacts": true

--- a/apps/readest-app/src/__tests__/ios/txt-file-association.test.ts
+++ b/apps/readest-app/src/__tests__/ios/txt-file-association.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression guard: iOS Files preview/share sheet lost Readest for `.txt`
+ * in 0.11.20 (worked in 0.11.18), while EPUB/PDF kept working.
+ *
+ * The app's plain-text claim used to come from the hand-tuned
+ * `CFBundleDocumentTypes` in `src-tauri/Info.plist` (`Text File` /
+ * `public.plain-text`), merged into the generated iOS Info.plist at build
+ * time. tauri-cli 2.11.0 (bumped in #5085) added mobile file associations:
+ * it now generates `CFBundleDocumentTypes` from `bundle.fileAssociations`
+ * and inserts the key AFTER the custom-plist merge, replacing the
+ * hand-tuned array. `fileAssociations` listed every supported format
+ * except txt, so the `public.plain-text` claim silently disappeared and
+ * iOS stopped offering Readest as a `.txt` handler.
+ *
+ * The durable fix is declaring txt in `bundle.fileAssociations`:
+ * tauri-utils maps `text/plain`/`txt` to the `public.plain-text` UTI, so
+ * the generated entry restores the claim. The hand-tuned array in
+ * `src-tauri/Info.plist` is dead on iOS as long as the CLI generates this
+ * key, so it must not be relied on for any format.
+ */
+
+interface FileAssociation {
+  name?: string;
+  ext: string[];
+  mimeType?: string;
+}
+
+const tauriConf = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'src-tauri/tauri.conf.json'), 'utf-8'),
+) as { bundle: { fileAssociations: FileAssociation[] } };
+
+const associations = tauriConf.bundle.fileAssociations;
+
+describe('txt file association (iOS share sheet lost Readest for .txt)', () => {
+  it('declares txt in bundle.fileAssociations', () => {
+    const txt = associations.find((a) => a.ext.includes('txt'));
+    expect(txt).toBeDefined();
+    // text/plain is what tauri-utils maps to the public.plain-text UTI on
+    // iOS; without it the entry is extension-only and the claim is weaker.
+    expect(txt?.mimeType).toBe('text/plain');
+  });
+
+  it('declares md in bundle.fileAssociations', () => {
+    // .md resolves to net.daringfireball.markdown, which conforms to
+    // public.plain-text, so markdown rode on the lost plain-text claim too.
+    const md = associations.find((a) => a.ext.includes('md'));
+    expect(md).toBeDefined();
+    expect(md?.mimeType).toBe('text/markdown');
+  });
+
+  it('keeps the formats that were never affected', () => {
+    for (const ext of ['epub', 'mobi', 'azw', 'azw3', 'fb2', 'cbz', 'pdf']) {
+      expect(associations.some((a) => a.ext.includes(ext))).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Regression in 0.11.20 (0.11.18 was fine): on iOS, previewing or sharing a `.txt` file from the Files app no longer offers Readest in the share sheet. EPUB and PDF were unaffected.

## Root cause

The app's plain-text claim used to come from the hand-tuned `CFBundleDocumentTypes` in `src-tauri/Info.plist` (`Text File` / `public.plain-text`), merged into the generated iOS `Info.plist` at build time.

The tauri CLI bump 2.10.1 -> 2.11.4 (#5085) picked up tauri-cli 2.11.0's new mobile file associations feature ([tauri-apps/tauri#14486](https://github.com/tauri-apps/tauri/pull/14486)): the CLI now generates `CFBundleDocumentTypes` from `bundle.fileAssociations` and inserts the key after the custom-plist merge, replacing the hand-tuned array. `fileAssociations` listed every supported format except `txt` and `md`, so 0.11.20 builds silently stopped claiming `public.plain-text` and iOS dropped Readest as a handler for `.txt`. Markdown rode on the same claim (`net.daringfireball.markdown` conforms to `public.plain-text`), so `.md` was lost as well.

## Fix

Declare `txt` and `md` in `bundle.fileAssociations`:

- `txt` with `text/plain`: tauri-utils maps it to the `public.plain-text` UTI and emits `LSItemContentTypes`, restoring exactly the claim that was lost.
- `md` with `text/markdown`: tauri-utils has no UTI mapping for markdown, so it gets an extension-based entry, the same shape that keeps EPUB working on iOS.

Added a regression test asserting both entries (plus the seven pre-existing formats) stay in `fileAssociations`, since the hand-tuned `CFBundleDocumentTypes` in `src-tauri/Info.plist` is dead on iOS for any key the CLI generates.

Note: `fileAssociations` also feeds the Windows installer registry and Linux mime entries, so desktop platforms now list Readest under Open With for `.txt`/`.md` too (macOS already claimed plain text via the hand-tuned plist).

## Verification

- New test fails before the config change, passes after
- Full unit suite (8033 tests), `pnpm lint`, `pnpm format:check` pass
- `pnpm fmt:check`, `pnpm clippy:check`, `pnpm test:rust` pass (Rust compile re-validates the modified config through tauri codegen)
- Device check pending: needs a TestFlight/device build since the regression lives in the generated `Info.plist`

🤖 Generated with [Claude Code](https://claude.com/claude-code)