### PR TITLE
fix(tts): read TTS section documents through the display transform pipeline (#5406)

### DIFF
--- a/apps/readest-app/src/__tests__/services/tts-proofread-doc-sync.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-proofread-doc-sync.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { TTSController } from '@/services/tts/TTSController';
+import { TTSClient, TTSMessageEvent } from '@/services/tts/TTSClient';
+import { transformTTSSectionDocument } from '@/services/tts/transformDoc';
+import { FoliateView } from '@/types/view';
+
+// #5406: TTS must read the same transformed content the display shows.
+// Sections that are not currently rendered used to be read through
+// section.createDocument(), which parses the raw resource and bypasses the
+// loader 'data' event where display transformers (proofread, simplecc, ...)
+// run. Speech then diverged from the displayed text and highlight offsets
+// drifted once a proofread rule added or deleted text.
+
+const makeMockClient = (name: string): TTSClient => ({
+  name,
+  initialized: true,
+  init: vi.fn().mockResolvedValue(true),
+  shutdown: vi.fn().mockResolvedValue(undefined),
+  speak: vi.fn().mockImplementation(async function* (): AsyncIterable<TTSMessageEvent> {
+    yield { code: 'end', message: 'done' };
+  }),
+  pause: vi.fn().mockResolvedValue(true),
+  resume: vi.fn().mockResolvedValue(true),
+  stop: vi.fn().mockResolvedValue(undefined),
+  setPrimaryLang: vi.fn(),
+  setRate: vi.fn().mockResolvedValue(undefined),
+  setPitch: vi.fn().mockResolvedValue(undefined),
+  setVoice: vi.fn().mockResolvedValue(undefined),
+  getAllVoices: vi.fn().mockResolvedValue([]),
+  getVoices: vi.fn().mockResolvedValue([]),
+  getGranularities: vi.fn().mockReturnValue(['sentence']),
+  getCapabilities: vi.fn().mockReturnValue({
+    wordBoundaries: false,
+    mediaClock: false,
+    gapControl: false,
+    liveRateChange: false,
+  }),
+  getVoiceId: vi.fn().mockReturnValue('doc-sync-voice'),
+  getSpeakingLang: vi.fn().mockReturnValue('en'),
+});
+
+vi.mock('@/services/tts/WebSpeechClient', () => ({
+  WebSpeechClient: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    Object.assign(this, makeMockClient('web-speech'));
+  }),
+}));
+vi.mock('@/services/tts/EdgeTTSClient', () => ({
+  EdgeTTSClient: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    Object.assign(this, makeMockClient('edge-tts'));
+  }),
+}));
+vi.mock('@/services/tts/NativeTTSClient', () => ({
+  NativeTTSClient: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    Object.assign(this, makeMockClient('native'));
+  }),
+}));
+vi.mock('@/services/tts/TTSUtils', () => ({
+  TTSUtils: {
+    getPreferredClient: vi.fn().mockReturnValue('edge-tts'),
+    setPreferredClient: vi.fn(),
+    setPreferredVoice: vi.fn(),
+    getPreferredVoice: vi.fn().mockReturnValue(null),
+  },
+}));
+vi.mock('foliate-js/overlayer.js', () => ({ Overlayer: { highlight: 'highlightFn' } }));
+
+// Capture the document each foliate TTS instance is constructed over: that is
+// the document whose text gets spoken.
+const ttsCtorDocs: Document[] = [];
+vi.mock('foliate-js/tts.js', () => ({
+  TTS: vi.fn().mockImplementation(function (this: Record<string, unknown>, doc: Document) {
+    ttsCtorDocs.push(doc);
+    Object.assign(this, {
+      start: vi.fn().mockReturnValue('<speak>hello</speak>'),
+      resume: vi.fn().mockReturnValue('<speak>hello</speak>'),
+      next: vi.fn().mockReturnValue(undefined),
+      prev: vi.fn().mockReturnValue(undefined),
+      from: vi.fn().mockReturnValue('<speak>from</speak>'),
+      setMark: vi.fn().mockReturnValue(undefined),
+      getLastRange: vi.fn().mockReturnValue(undefined),
+      doc,
+    });
+  }),
+  getSentences: vi.fn().mockImplementation(function* () {}),
+}));
+vi.mock('foliate-js/text-walker.js', () => ({ textWalker: vi.fn() }));
+vi.mock('@/utils/ssml', () => ({
+  filterSSMLWithLang: vi.fn((ssml: string) => ssml),
+  parseSSMLMarks: vi.fn(() => ({
+    plainText: 'hello',
+    marks: [{ offset: 0, name: '0', text: 'hello', language: 'en' }],
+  })),
+}));
+vi.mock('@/utils/node', () => ({ createRejectFilter: vi.fn(() => () => 1) }));
+vi.mock('@/utils/lang', () => ({
+  isValidLang: vi.fn(() => true),
+  isCJKLang: vi.fn(() => false),
+}));
+
+const parseXhtml = (body: string) =>
+  new DOMParser().parseFromString(
+    `<html xmlns="http://www.w3.org/1999/xhtml"><head><title>t</title></head><body>${body}</body></html>`,
+    'application/xhtml+xml',
+  );
+
+// Mirrors FoliateViewer's getDocTransformHandler contract: replace detail.data
+// with a promise of the transformed markup, or '' on error.
+const attachDisplayTransform = (target: EventTarget, replace: (content: string) => string) => {
+  const seen: { name?: string; type?: string }[] = [];
+  target.addEventListener('data', (event) => {
+    const detail = (event as CustomEvent).detail;
+    seen.push({ name: detail.name, type: detail.type });
+    detail.data = Promise.resolve(detail.data).then((data: string) => replace(data));
+  });
+  return seen;
+};
+
+describe('transformTTSSectionDocument', () => {
+  test('returns the input document when the book has no transformTarget', async () => {
+    const doc = parseXhtml('<p>proofread me please</p>');
+    const out = await transformTTSSectionDocument({}, 'sec.xhtml', doc);
+    expect(out).toBe(doc);
+  });
+
+  test('applies the display transform pipeline to the section document', async () => {
+    const transformTarget = new EventTarget();
+    const seen = attachDisplayTransform(transformTarget, (content) =>
+      content.replace('proofread me please', 'corrected text'),
+    );
+    const doc = parseXhtml('<p>proofread me please</p>');
+    const out = await transformTTSSectionDocument({ transformTarget }, 'sec.xhtml', doc);
+    expect(out).not.toBe(doc);
+    expect(out.documentElement.textContent).toContain('corrected text');
+    expect(out.documentElement.textContent).not.toContain('proofread me please');
+    expect(seen[0]?.name).toBe('sec.xhtml');
+    expect(seen[0]?.type).toBe('application/xhtml+xml');
+  });
+
+  test('falls back to the input document when the transform yields nothing', async () => {
+    const transformTarget = new EventTarget();
+    // FoliateViewer's handler resolves to '' when a transformer throws.
+    attachDisplayTransform(transformTarget, () => '');
+    const doc = parseXhtml('<p>proofread me please</p>');
+    const out = await transformTTSSectionDocument({ transformTarget }, 'sec.xhtml', doc);
+    expect(out).toBe(doc);
+  });
+
+  test('returns the input document unchanged when no listener modifies the data', async () => {
+    const doc = parseXhtml('<p>proofread me please</p>');
+    const out = await transformTTSSectionDocument(
+      { transformTarget: new EventTarget() },
+      'sec.xhtml',
+      doc,
+    );
+    expect(out).toBe(doc);
+  });
+});
+
+interface RenderedContent {
+  doc: Document;
+  index: number;
+  overlayer: { add: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> };
+}
+
+const makeView = ({ withTransformTarget = true } = {}) => {
+  const liveDoc0 = parseXhtml('<p>rendered section zero</p>');
+  const contents: RenderedContent[] = [
+    { doc: liveDoc0, index: 0, overlayer: { add: vi.fn(), remove: vi.fn() } },
+  ];
+  const transformTarget = new EventTarget();
+  const view = {
+    book: {
+      ...(withTransformTarget ? { transformTarget } : {}),
+      sections: [
+        {
+          id: 'sec0.xhtml',
+          createDocument: vi.fn().mockResolvedValue(parseXhtml('<p>raw zero</p>')),
+        },
+        {
+          id: 'sec1.xhtml',
+          createDocument: vi.fn().mockResolvedValue(parseXhtml('<p>proofread me please</p>')),
+        },
+      ],
+    },
+    renderer: { getContents: () => contents, primaryIndex: 0 },
+    language: { isCJK: false },
+    getCFI: vi.fn().mockReturnValue('epubcfi(/6/2!/4/2)'),
+    resolveCFI: vi.fn().mockReturnValue({ anchor: () => new Range() }),
+    tts: null,
+  } as unknown as FoliateView;
+  return { view, contents, transformTarget };
+};
+
+describe('TTSController proofread document sync', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    ttsCtorDocs.length = 0;
+  });
+
+  test('reads an unrendered section through the display transform pipeline', async () => {
+    const { view, transformTarget } = makeView();
+    attachDisplayTransform(transformTarget, (content) =>
+      content.replace('proofread me please', 'corrected text'),
+    );
+    const controller = new TTSController(null, view);
+    await controller.init();
+    // Section 1 is not rendered (primary content is section 0) and there is
+    // no onSectionChange navigation, so the doc must come from createDocument
+    // plus the display transform.
+    await controller.initViewTTS(1);
+    const doc = ttsCtorDocs.at(-1)!;
+    expect(doc.documentElement.textContent).toContain('corrected text');
+    expect(doc.documentElement.textContent).not.toContain('proofread me please');
+  });
+
+  test('prefers the live rendered document after section navigation', async () => {
+    const { view, contents } = makeView();
+    const liveDoc1 = parseXhtml('<p>live transformed one</p>');
+    const onSectionChange = vi.fn().mockImplementation(async (index: number) => {
+      contents.length = 0;
+      contents.push({ doc: liveDoc1, index, overlayer: { add: vi.fn(), remove: vi.fn() } });
+    });
+    const controller = new TTSController(null, view, false, undefined, onSectionChange);
+    await controller.init();
+    await controller.initViewTTS(1);
+    expect(onSectionChange).toHaveBeenCalledWith(1);
+    // The navigated-to view renders the transformed content; TTS must read
+    // that exact document so highlights anchor into it by identity.
+    expect(ttsCtorDocs.at(-1)).toBe(liveDoc1);
+    expect(view.book.sections[1]!.createDocument).not.toHaveBeenCalled();
+  });
+
+  test('keeps the raw document when the book has no transform pipeline', async () => {
+    const { view } = makeView({ withTransformTarget: false });
+    const controller = new TTSController(null, view);
+    await controller.init();
+    await controller.initViewTTS(1);
+    const doc = ttsCtorDocs.at(-1)!;
+    expect(doc.documentElement.textContent).toContain('proofread me please');
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/md.test.ts
+++ b/apps/readest-app/src/__tests__/utils/md.test.ts
@@ -9,7 +9,13 @@ import { getIndexFromCfi } from '@/utils/cfi';
 // declare. Cast to this richer shape in tests to exercise them.
 type MdBook = BookDoc & {
   toc: NonNullable<BookDoc['toc']>;
-  sections: Array<BookDoc['sections'][number] & { load: () => string }>;
+  sections: Array<
+    BookDoc['sections'][number] & {
+      load: () => string;
+      loadContent?: () => Promise<string>;
+      unload?: () => void;
+    }
+  >;
   resolveHref: (
     href: string,
   ) => { index: number; anchor: (doc: Document) => Element | null } | null;
@@ -264,6 +270,74 @@ describe('makeMarkdownBook', () => {
       url.createObjectURL = origCreate;
       url.revokeObjectURL = origRevoke;
     }
+  });
+});
+
+// #5406 follow-up: MD books get the same transformTarget 'data' pipeline as
+// EPUB/MOBI, so display transformers (proofread, simplecc, punctuation, ...)
+// apply to Markdown books too. The paginator renders `loadContent()` via
+// srcdoc when it is defined, so the transformed content is what gets shown.
+describe('makeMarkdownBook display transforms', () => {
+  // Mirrors FoliateViewer's getDocTransformHandler contract: replace
+  // detail.data with a promise of the transformed markup, or '' on error.
+  const attachDisplayTransform = (target: EventTarget, replace: (content: string) => string) => {
+    const seen: { name?: string; type?: string }[] = [];
+    const listener = vi.fn((event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      seen.push({ name: detail.name, type: detail.type });
+      detail.data = Promise.resolve(detail.data).then((data: string) => replace(data));
+    });
+    target.addEventListener('data', listener);
+    return { seen, listener };
+  };
+
+  it('exposes a transformTarget on the book', async () => {
+    const book = await make('# A\n\nteh text\n');
+    expect(book.transformTarget).toBeInstanceOf(EventTarget);
+  });
+
+  it('routes section loadContent through data listeners with the section index as name', async () => {
+    const book = await make('# A\n\nteh text\n\n# B\n\nteh other\n');
+    const { seen } = attachDisplayTransform(book.transformTarget!, (content) =>
+      content.replace(/teh/g, 'the'),
+    );
+    const content = await book.sections[1]!.loadContent!();
+    expect(content).toContain('the other');
+    expect(content).not.toContain('teh');
+    // Selection-scoped proofread rules compare rule.sectionHref (a TOC href
+    // like "1#b") against detail.name via split('#')[0], so the name must be
+    // the bare section index.
+    expect(seen[0]?.name).toBe('1');
+    expect(seen[0]?.type).toBe('application/xhtml+xml');
+  });
+
+  it('caches the transformed content until unload invalidates it', async () => {
+    const book = await make('# A\n\nteh text\n');
+    const { listener } = attachDisplayTransform(book.transformTarget!, (content) =>
+      content.replace(/teh/g, 'the'),
+    );
+    await book.sections[0]!.loadContent!();
+    await book.sections[0]!.loadContent!();
+    expect(listener).toHaveBeenCalledTimes(1);
+    // Viewer recreation (e.g. after a proofread rule change) destroys the
+    // views, which unloads the sections; the next load must re-transform.
+    book.sections[0]!.unload!();
+    await book.sections[0]!.loadContent!();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps createDocument raw so the TTS transform path does not double-apply', async () => {
+    const book = await make('# A\n\nteh text\n');
+    attachDisplayTransform(book.transformTarget!, (content) => content.replace(/teh/g, 'the'));
+    const doc = await book.sections[0]!.createDocument();
+    expect(doc.documentElement.textContent).toContain('teh text');
+  });
+
+  it('falls back to the raw content when the transform yields nothing', async () => {
+    const book = await make('# A\n\nteh text\n');
+    attachDisplayTransform(book.transformTarget!, () => '');
+    const content = await book.sections[0]!.loadContent!();
+    expect(content).toContain('teh text');
   });
 });
 

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -1,5 +1,7 @@
 import { FoliateView } from '@/types/view';
 import { AppService } from '@/types/system';
+import { SectionItem } from '@/libs/document';
+import { transformTTSSectionDocument } from './transformDoc';
 import { filterSSMLWithLang, parseSSMLMarks } from '@/utils/ssml';
 import { Overlayer } from 'foliate-js/overlayer.js';
 import {
@@ -299,7 +301,9 @@ export class TTSController extends EventTarget {
     let doc = primary && (primary.index ?? 0) === sectionIndex ? primary.doc : undefined;
     if (!doc) {
       const section = view.book.sections?.[sectionIndex];
-      doc = section?.createDocument ? await section.createDocument() : undefined;
+      doc = section?.createDocument
+        ? await transformTTSSectionDocument(view.book, section.id, await section.createDocument())
+        : undefined;
     }
     if (!doc) {
       console.warn('[TTS] attachView: no document for section', sectionIndex);
@@ -387,6 +391,28 @@ export class TTSController extends EventTarget {
       | undefined;
   }
 
+  // The rendered document for a section from ANY live view (the multiview
+  // paginator keeps preloaded adjacent sections alive), not just the primary.
+  #getLiveSectionDoc(sectionIndex: number): Document | undefined {
+    if (!this.#attached) return undefined;
+    const contents = this.view.renderer.getContents() as { doc?: Document; index?: number }[];
+    return contents.find((x) => x.index === sectionIndex && x.doc)?.doc;
+  }
+
+  // A fresh section document replayed through the display transform pipeline
+  // (see transformTTSSectionDocument), with the lang fixup TTS voices need.
+  async #createSectionDoc(section: SectionItem): Promise<Document> {
+    const raw = await section.createDocument();
+    const doc = await transformTTSSectionDocument(this.view.book, section.id, raw);
+    const html = doc.querySelector('html');
+    const lang = html?.getAttribute('lang') || html?.getAttribute('xml:lang') || '';
+    if (html && !isValidLang(lang) && this.ttsLang) {
+      html.setAttribute('lang', this.ttsLang);
+      html.setAttribute('xml:lang', this.ttsLang);
+    }
+    return doc;
+  }
+
   #getHighlighter() {
     return (range: Range) => {
       // Suppress the sentence highlight that foliate's setMark draws when the
@@ -467,18 +493,13 @@ export class TTSController extends EventTarget {
       await this.onSectionChange?.(sectionIndex);
     }
 
-    let doc: Document;
-    if (currentSection?.index === sectionIndex && currentSection?.doc) {
-      doc = currentSection.doc;
-    } else {
-      doc = await section.createDocument();
-      const html = doc.querySelector('html');
-      const lang = html?.getAttribute('lang') || html?.getAttribute('xml:lang') || '';
-      if (html && !isValidLang(lang) && this.ttsLang) {
-        html.setAttribute('lang', this.ttsLang);
-        html.setAttribute('xml:lang', this.ttsLang);
-      }
-    }
+    // Prefer a live rendered document for the section, re-queried AFTER the
+    // navigation above (auto-advance lands here with the pre-navigation
+    // primary captured, so checking only `currentSection` always missed it):
+    // it carries the display transforms and highlights anchor into it by
+    // identity. Otherwise replay a fresh document through the same transform
+    // pipeline so speech and highlight offsets match the displayed text.
+    const doc = this.#getLiveSectionDoc(sectionIndex) ?? (await this.#createSectionDoc(section));
 
     // The section changed (or is initializing): any previous timeline maps a
     // dead document.
@@ -601,13 +622,9 @@ export class TTSController extends EventTarget {
         const section = sections?.[sectionIndex];
         if (!section?.createDocument) return null;
         try {
-          const doc = await section.createDocument();
-          const html = doc.querySelector('html');
-          const lang = html?.getAttribute('lang') || html?.getAttribute('xml:lang') || '';
-          if (html && !isValidLang(lang) && this.ttsLang) {
-            html.setAttribute('lang', this.ttsLang);
-            html.setAttribute('xml:lang', this.ttsLang);
-          }
+          // Same transformed document as live playback, or the synthesized
+          // text (and its cache keys) would diverge from what gets spoken.
+          const doc = await this.#createSectionDoc(section);
           const { TTS, getSentences } = await import('foliate-js/tts.js');
           const { textWalker } = await import('foliate-js/text-walker.js');
           const nodeFilter = createTTSNodeFilter();

--- a/apps/readest-app/src/services/tts/transformDoc.ts
+++ b/apps/readest-app/src/services/tts/transformDoc.ts
@@ -1,0 +1,38 @@
+// TTS reads sections that are not currently rendered through
+// section.createDocument(), which parses the raw resource and bypasses the
+// book loader's 'data' event where the display transformers (proofread,
+// simplecc, punctuation, ...) run. Speech then diverges from the displayed
+// text, and highlight CFIs computed on the raw document anchor at wrong
+// offsets in the transformed live document once a proofread rule adds or
+// deletes text (#5406). This helper replays the exact same 'data' pipeline
+// over a raw section document so TTS documents are content-identical to what
+// the reader displays. Books without a transformTarget (whose display is not
+// transformed either) pass through unchanged.
+export const transformTTSSectionDocument = async (
+  book: { transformTarget?: EventTarget },
+  sectionId: string | undefined,
+  doc: Document,
+): Promise<Document> => {
+  const target = book.transformTarget;
+  if (!target) return doc;
+  try {
+    const type = doc.contentType || 'application/xhtml+xml';
+    const data = new XMLSerializer().serializeToString(doc);
+    const detail: { data: string | Promise<string>; type: string } = { data, type };
+    // Readonly, mirroring foliate's Loader.createURL dispatch; the reader's
+    // transform handler keys selection-scoped proofread rules off this name.
+    Object.defineProperty(detail, 'name', {
+      value: typeof sectionId === 'string' ? sectionId : '',
+    });
+    target.dispatchEvent(new CustomEvent('data', { detail }));
+    const transformed = await detail.data;
+    // '' is the transform handler's error fallback; identical output means no
+    // transformer touched the content, so the reparse can be skipped.
+    if (typeof transformed !== 'string' || !transformed || transformed === data) return doc;
+    const newDoc = new DOMParser().parseFromString(transformed, type as DOMParserSupportedType);
+    if (!newDoc.documentElement || newDoc.querySelector('parsererror')) return doc;
+    return newDoc;
+  } catch {
+    return doc;
+  }
+};

--- a/apps/readest-app/src/utils/md.ts
+++ b/apps/readest-app/src/utils/md.ts
@@ -65,7 +65,11 @@ interface TocNode {
   subitems?: TocNode[];
 }
 
-type MarkdownSection = SectionItem & { load: () => string };
+type MarkdownSection = SectionItem & {
+  load: () => string;
+  loadContent: () => Promise<string>;
+  unload: () => void;
+};
 
 export async function makeMarkdownBook(file: File): Promise<BookDoc> {
   const text = await file.text();
@@ -171,6 +175,42 @@ export async function makeMarkdownBook(file: File): Promise<BookDoc> {
     }));
   const toc = prune(root);
 
+  // The same transform pipeline EPUB/MOBI content goes through: the reader
+  // attaches its content transformers (proofread, simplecc, punctuation, ...)
+  // to `book.transformTarget`, and the paginator renders `loadContent()` via
+  // srcdoc when it is defined. Transformed content is cached per section and
+  // invalidated by unload() (the paginator unloads a section whenever its view
+  // is destroyed, e.g. on the viewer recreation a proofread rule change
+  // triggers), so rule changes show up on the next load. createDocument()
+  // stays raw, mirroring EPUB: TTS replays this same pipeline itself, and a
+  // pre-transformed document would double-apply the transformers.
+  const transformTarget = new EventTarget();
+  const transformed: (string | undefined)[] = new Array(xhtml.length).fill(undefined);
+  const transformSection = async (index: number): Promise<string> => {
+    const cached = transformed[index];
+    if (cached !== undefined) return cached;
+    const str = xhtml[index]!;
+    let result = str;
+    try {
+      const detail: { data: string | Promise<string>; type: string } = {
+        data: str,
+        type: 'application/xhtml+xml',
+      };
+      // Readonly, mirroring foliate's Loader.createURL dispatch. Selection
+      // scoped proofread rules compare their TOC-style sectionHref
+      // ("<index>#<anchor>") against this name via split('#')[0].
+      Object.defineProperty(detail, 'name', { value: String(index) });
+      transformTarget.dispatchEvent(new CustomEvent('data', { detail }));
+      const out = await detail.data;
+      // '' is the reader transform handler's error fallback.
+      if (typeof out === 'string' && out) result = out;
+    } catch {
+      // Keep the raw section on any transform failure.
+    }
+    transformed[index] = result;
+    return result;
+  };
+
   const urls: (string | undefined)[] = new Array(xhtml.length).fill(undefined);
   const sections: MarkdownSection[] = xhtml.map((str, index) => ({
     id: String(index),
@@ -187,6 +227,10 @@ export async function makeMarkdownBook(file: File): Promise<BookDoc> {
         urls[index] = URL.createObjectURL(new Blob([str], { type: 'application/xhtml+xml' }));
       }
       return urls[index]!;
+    },
+    loadContent: () => transformSection(index),
+    unload: () => {
+      transformed[index] = undefined;
     },
     loadText: async () => str,
     createDocument: async () => new DOMParser().parseFromString(str, 'application/xhtml+xml'),
@@ -213,6 +257,7 @@ export async function makeMarkdownBook(file: File): Promise<BookDoc> {
     dir: 'ltr',
     toc,
     sections,
+    transformTarget,
     splitTOCHref: (href: string): string[] => (href ? href.split('#') : []),
     getTOCFragment: (doc: Document, id: string): Element | null => doc.getElementById(id),
     resolveHref: (href: string) => {


### PR DESCRIPTION
Closes #5406

### Problem

Proofread replacement rules apply to the displayed text, but TTS did not stay in sync with them: replacements were not spoken once playback crossed into a new section, and when a rule added or deleted text the TTS highlight drifted away from the spoken words.

### Root cause

TTS builds its reading document with `section.createDocument()` whenever the target section is not the currently rendered one. That call parses the raw resource directly and bypasses the book loader's `data` event, which is where all display content transformers run (proofread, simplecc, punctuation, whitespace, ...). Three paths were affected:

- **Section auto-advance** (`#initTTSForSection`): the primary content was captured *before* `await onSectionChange` navigation, so after navigating the code always fell into the raw-document branch. Every auto-advanced section was spoken from the untransformed text.
- **`attachView` fallback** when the remounted view's primary content is not the TTS section.
- **Audio downloader** (`enumerateSection`): synthesized text and cache keys diverged from live playback.

Because highlight ranges are mapped by CFI from the TTS document into the live rendered document under a content-identical assumption, a proofread rule that changes text length made those CFIs anchor at wrong offsets, which is exactly the "TTS does not adapt" symptom in the issue.

### Fix

- New `transformTTSSectionDocument()` helper replays a raw section document through the book's existing `transformTarget` `data` event: the exact pipeline, transformer list, and view-settings context the display uses, with zero duplication. Books without a transform pipeline keep today's behavior.
- `#initTTSForSection` now prefers a live rendered document for the target section, re-queried *after* the `onSectionChange` navigation (and from any live view, since the multiview paginator keeps preloaded neighbors alive). Live documents carry the display transforms and highlights anchor into them by identity.
- The `attachView` fallback and the downloader's section enumerator route their fresh documents through the same helper, so downloaded audio cache keys match live playback.

TTS-only proofread rules (`onlyForTTS`) are untouched and still apply at the SSML preprocessing stage; with this change, regular display rules (plain and regex) are now reflected in TTS speech and highlighting by default, which is what the issue requests.

### Follow-up in this PR: Markdown books

Markdown books had no `transformTarget` at all, so display transformers (proofread included) never applied to them anywhere, on screen or in TTS. The MD book now exposes the same `transformTarget` `data` pipeline as EPUB/MOBI, and each section gains `loadContent()`, which the paginator renders via srcdoc when defined:

- The dispatch `name` is the bare section index, matching how selection-scoped proofread rules compare their TOC-style `sectionHref` (`"<index>#<anchor>"`) via `split('#')[0]`.
- Transformed content is cached per section and invalidated by `unload()` (the paginator unloads a section whenever its view is destroyed, e.g. on the viewer recreation a proofread rule change triggers), so rule changes show up on reload.
- `createDocument()` stays raw, mirroring EPUB: the TTS helper above replays the pipeline itself, and a pre-transformed document would double-apply the transformers.

### Tests

`src/__tests__/services/tts-proofread-doc-sync.test.ts` (written first, red before the fix):
- helper: no transformTarget passthrough, transform application (name/type contract with the reader's handler), empty-result and untouched-content fallbacks
- controller: an unrendered section is read through the display transform pipeline; the live rendered document is preferred after section navigation; books without a pipeline keep the raw document

`src/__tests__/utils/md.test.ts` (new describe, written first, red before the fix):
- the MD book exposes a transformTarget; `loadContent()` routes through `data` listeners with the section index as `name`; transform caching until `unload()`; `createDocument()` stays raw; empty-transform fallback

Verified: `pnpm test` (8065 tests), `pnpm test:browser` (330 tests), `pnpm lint`, `pnpm format:check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)