### PR TITLE
fix(tts): cut Edge trailing silence on iOS playout so sentence pauses are honored (#5414)

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-tts/ios/Sources/NativeTTSPlugin.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-tts/ios/Sources/NativeTTSPlugin.swift
@@ -66,6 +66,8 @@ struct PlayoutControlArgs: Decodable {
 }
 
 struct PlayoutEnqueueResponse: Encodable {
+  // Audible duration, i.e. up to where playback stops after the trailing
+  // silence is cut, not the whole file.
   let durationMs: Double
 }
 
@@ -950,7 +952,25 @@ class NativeTTSPlugin: Plugin, AVSpeechSynthesizerDelegate {
     let index: Int
     let url: URL
     let gapSec: Double
+    // Where speech ends; playback stops there instead of at the file end.
+    // 0 means "play the whole file" (bounds could not be determined).
+    let endSec: Double
   }
+
+  // Edge bakes silence into every utterance MP3 - measured at ~0.18s leading
+  // and ~0.8s trailing, so ~1s of dead air between sentences if the file is
+  // played whole. That swamps the configured inter-sentence gap and cannot be
+  // turned off from the settings, which is exactly what #5414 reported. Only
+  // the trailing silence is cut here: leaving the head intact keeps the item
+  // clock in the same frame as the word boundaries, with no offset to plumb
+  // back. Threshold and pad mirror pcm.ts (findSpeechBounds) - keep in sync.
+  private static let speechSilenceThreshold: Float = 0.005
+  private static let speechTailPadSec = 0.05
+
+  // Decoding + scanning runs off the main thread (a few ms per sentence, but
+  // it would land mid-playback). Serial, so queue order still follows enqueue
+  // order even if the caller ever stops awaiting each chunk in turn.
+  private let playoutAnalysisQueue = DispatchQueue(label: "com.bilingify.readest.tts.playout")
 
   private var playoutSession = 0
   private var playoutQueue: [PlayoutItem] = []
@@ -1025,24 +1045,40 @@ class NativeTTSPlugin: Plugin, AVSpeechSynthesizerDelegate {
           invoke.resolve(PlayoutEnqueueResponse(durationMs: 0))
           return
         }
-        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
-          "tts-playout-\(args.session)-\(args.index).mp3")
-        do {
-          try data.write(to: url)
-        } catch {
-          invoke.reject("Failed to write audio file: \(error.localizedDescription)")
-          return
+        self.playoutAnalysisQueue.async {
+          let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "tts-playout-\(args.session)-\(args.index).mp3")
+          do {
+            try data.write(to: url)
+          } catch {
+            invoke.reject("Failed to write audio file: \(error.localizedDescription)")
+            return
+          }
+          // Local file; the synchronous duration load is effectively instant.
+          let asset = AVURLAsset(url: url)
+          let total = CMTimeGetSeconds(asset.duration)
+          let fullEnd = total.isFinite ? total : 0
+          let endSec = self.speechEndSec(of: asset) ?? fullEnd
+          DispatchQueue.main.async {
+            // The session can turn over while the decode runs; drop the file
+            // rather than leaving it in the temp dir for a dead session.
+            guard args.session == self.playoutSession else {
+              try? FileManager.default.removeItem(at: url)
+              invoke.resolve(PlayoutEnqueueResponse(durationMs: 0))
+              return
+            }
+            self.playoutQueue.append(
+              PlayoutItem(
+                index: args.index, url: url, gapSec: (args.gapMs ?? 0) / 1000.0,
+                endSec: endSec))
+            if self.playoutPlaying && self.playoutCurrentIndex == -1
+              && self.playoutGapTimer == nil
+            {
+              self.playoutAdvance()
+            }
+            invoke.resolve(PlayoutEnqueueResponse(durationMs: endSec * 1000.0))
+          }
         }
-        // Local file; the synchronous duration load is effectively instant.
-        let asset = AVURLAsset(url: url)
-        let durationSec = CMTimeGetSeconds(asset.duration)
-        self.playoutQueue.append(
-          PlayoutItem(index: args.index, url: url, gapSec: (args.gapMs ?? 0) / 1000.0))
-        if self.playoutPlaying && self.playoutCurrentIndex == -1 && self.playoutGapTimer == nil {
-          self.playoutAdvance()
-        }
-        invoke.resolve(
-          PlayoutEnqueueResponse(durationMs: durationSec.isFinite ? durationSec * 1000.0 : 0))
       }
     } catch {
       invoke.reject("Failed to parse playout enqueue: \(error.localizedDescription)")
@@ -1061,6 +1097,68 @@ class NativeTTSPlugin: Plugin, AVSpeechSynthesizerDelegate {
           playing: (self.playoutPlayer?.rate ?? 0) != 0
         ))
     }
+  }
+
+  // End of the last sample above the speech threshold, plus a pad for a natural
+  // release. Decoded silence is dithered ringing rather than zeros, so this is
+  // an amplitude test, not an exact-zero one. Returns nil when the asset can't
+  // be read or holds no speech at all - callers then play it whole rather than
+  // cutting it to nothing.
+  private func speechEndSec(of asset: AVAsset) -> Double? {
+    guard let track = asset.tracks(withMediaType: .audio).first,
+      let reader = try? AVAssetReader(asset: asset)
+    else { return nil }
+    let output = AVAssetReaderTrackOutput(
+      track: track,
+      outputSettings: [
+        AVFormatIDKey: kAudioFormatLinearPCM,
+        AVLinearPCMBitDepthKey: 32,
+        AVLinearPCMIsFloatKey: true,
+        AVLinearPCMIsBigEndianKey: false,
+        AVLinearPCMIsNonInterleaved: false,
+      ])
+    output.alwaysCopiesSampleData = false
+    guard reader.canAdd(output) else { return nil }
+    reader.add(output)
+    guard reader.startReading() else { return nil }
+
+    var sampleRate = 0.0
+    var channels = 1
+    var frames = 0
+    var lastFrame = -1
+
+    while let buffer = output.copyNextSampleBuffer() {
+      if sampleRate == 0,
+        let desc = CMSampleBufferGetFormatDescription(buffer),
+        let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(desc)?.pointee
+      {
+        sampleRate = asbd.mSampleRate
+        channels = max(1, Int(asbd.mChannelsPerFrame))
+      }
+      guard let block = CMSampleBufferGetDataBuffer(buffer) else { continue }
+      var length = 0
+      var pointer: UnsafeMutablePointer<Int8>?
+      guard
+        CMBlockBufferGetDataPointer(
+          block, atOffset: 0, lengthAtOffsetOut: nil, totalLengthOut: &length,
+          dataPointerOut: &pointer) == kCMBlockBufferNoErr,
+        let raw = pointer
+      else { continue }
+      let count = length / MemoryLayout<Float>.size
+      raw.withMemoryRebound(to: Float.self, capacity: count) { samples in
+        for i in 0..<count where abs(samples[i]) > Self.speechSilenceThreshold {
+          lastFrame = frames + i / channels
+        }
+      }
+      frames += count / channels
+      CMSampleBufferInvalidate(buffer)
+    }
+    reader.cancelReading()
+
+    guard sampleRate > 0, lastFrame >= 0 else { return nil }
+    let total = Double(frames) / sampleRate
+    let end = min(total, Double(lastFrame + 1) / sampleRate + Self.speechTailPadSec)
+    return end > 0 ? end : nil
   }
 
   private func playoutAdvance() {
@@ -1084,6 +1182,13 @@ class NativeTTSPlugin: Plugin, AVSpeechSynthesizerDelegate {
     let playerItem = AVPlayerItem(url: item.url)
     // Pitch-preserving time stretch tuned for voice.
     playerItem.audioTimePitchAlgorithm = .timeDomain
+    // Stop at the end of speech rather than the end of the file, which cuts
+    // Edge's ~0.8s of baked-in trailing silence. The item still posts
+    // AVPlayerItemDidPlayToEndTime here, so the gap timer and advance below
+    // are unchanged, and item time stays the untrimmed original.
+    if item.endSec > 0 {
+      playerItem.forwardPlaybackEndTime = CMTime(seconds: item.endSec, preferredTimescale: 600)
+    }
     if let observer = playoutItemEndObserver {
       NotificationCenter.default.removeObserver(observer)
     }

--- a/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
@@ -249,6 +249,23 @@ describe('TTSPlayerSheet', () => {
     expect(saveSettings).toHaveBeenCalled();
   });
 
+  test('rate-derived pauses keep sub-second precision instead of collapsing to zero', () => {
+    // The gaps are sub-second by design (0.15s / 0.3s), so rounding them to a
+    // whole number erases both at every speed - no pause between sentences or
+    // paragraphs, and no control left to restore one. See #5414.
+    const props = makeProps();
+    render(<TTSPlayerSheet {...props} />);
+    fireEvent.click(screen.getByLabelText('Speed'));
+    const slider = screen.getByRole('slider', { name: 'Speed' });
+    fireEvent.change(slider, { target: { value: '1.5' } });
+    fireEvent.pointerUp(slider);
+    // Faster speech shortens the pauses, it must not erase them.
+    expect(props.onSetSentenceGap).toHaveBeenCalledWith(0.12);
+    expect(props.onSetParagraphGap).toHaveBeenCalledWith(0.24);
+    expect(viewSettings['ttsSentenceGap']).toBe(0.12);
+    expect(viewSettings['ttsParagraphGap']).toBe(0.24);
+  });
+
   test('voice button drills into the voice list and selects a voice', async () => {
     const props = makeProps();
     render(<TTSPlayerSheet {...props} />);

--- a/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
@@ -185,10 +185,13 @@ const TTSPlayerSheet = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, ttsLang]);
 
-  /* Scale a given `baseGap` based on a given `rate`. */
+  /* Scale a given `baseGap` based on a given `rate`. Gaps are sub-second
+   * (0.15s / 0.3s), so they have to keep two decimals — rounding to a whole
+   * number floors every one of them to 0 and silently removes the pauses
+   * along with any way to get them back (#5414). */
   const scaleGap = (baseGap: number, rate: number) => {
     const k = 0.6;
-    return Math.round(baseGap / Math.pow(rate, k));
+    return Math.round((baseGap / Math.pow(rate, k)) * 100) / 100;
   };
 
   const handleSelectRate = (value: number) => {

--- a/apps/readest-app/src/services/tts/BufferedTTSClient.ts
+++ b/apps/readest-app/src/services/tts/BufferedTTSClient.ts
@@ -38,9 +38,12 @@ import { TTSAudioBuffer, WebAudioPlayer, WebAudioPlayerEvent } from './WebAudioP
 // the screen off), not when it is fetched — schedule-ahead would otherwise
 // run foliate's mark cursor ahead of the voice and break prev/next/resume.
 
-// Natural pause between sentences, replacing Edge's baked-in ~300ms trailing
-// silence. Divided by the playback rate so pauses shrink with speed (#2033's
-// "gaps don't scale" complaint).
+// Natural pause between sentences, replacing the silence Edge bakes into every
+// utterance: measured at ~0.18s leading and ~0.8s trailing, so ~1s of dead air
+// per sentence if it is played as-is (see #5414). Divided by the playback rate
+// so pauses shrink with speed (#2033's "gaps don't scale" complaint). Note the
+// native path only cuts the trailing silence, so its audible gap also carries
+// the next utterance's ~0.18s of leading silence.
 export const DEFAULT_SENTENCE_GAP_SEC = 0.15;
 const TICKS_PER_SECOND = 10_000_000;
 
@@ -393,10 +396,12 @@ export class BufferedTTSClient implements TTSClient {
         this.#recordDurations(voiceId, mark.text, audio.boundaries);
 
         if (this.#player instanceof NativeAudioPlayer) {
-          // Native playout: no decode/trim/WSOLA — the raw MP3 goes to the
-          // AVPlayer, which time-stretches at the pitch-preserving native
-          // rate. Word boundaries stay in original media time, matching the
-          // player's media clock, so trimStartSec is 0 by construction.
+          // Native playout: no decode/WSOLA here — the raw MP3 goes to the
+          // AVPlayer, which stops it at the end of speech and time-stretches at
+          // the pitch-preserving native rate. Only the tail is cut, so the file
+          // still starts where it always did: word boundaries stay in original
+          // media time, matching the player's media clock, and trimStartSec is
+          // 0 by construction.
           const ready = await this.#player.waitUntilReady(generation);
           if (!ready || signal.aborted) return;
           const index = chunkMeta.length;


### PR DESCRIPTION
Fixes #5414.

## Problem

Edge TTS bakes silence into every utterance MP3. Measured against real audio
(`audio-24khz-48kbitrate-mono-mp3`, en-US-AriaNeural) with the same algorithm
`src/services/tts/pcm.ts` uses:

| clip | total | head | tail | total silence |
|---|---|---|---|---|
| 1 | 3.720s | 0.173s | 0.846s | 1.019s |
| 2 | 2.928s | 0.172s | 0.789s | 0.961s |
| 3 | 3.912s | 0.185s | 0.808s | 0.993s |

The WebAudio path strips all of it in `#prepareChunkBuffer` and inserts only the
configured gap. The iOS native playout added in #5085 does not: it hands the raw
MP3 to AVPlayer and then adds `gapSec` on top. The audible pause is therefore
`~0.8s tail + gapSec + item swap + ~0.18s head`, so setting Sentence Pause to 0
barely changes anything. That setting only ever controlled the small additive
gap.

v0.11.18 still ran iOS on `WebAudioPlayer`, which is why this shows up as a
0.11.20 regression.

## Fix

`playout_enqueue` scans the decoded samples with `AVAssetReader` for the last
one above the speech threshold, reusing the threshold and tail pad from
`pcm.ts`, and `playoutAdvance` stops the item there with
`forwardPlaybackEndTime`. Verified against the same three clips: cuts 0.868s,
0.811s and 0.830s.

Only the tail is cut. Leaving the leading silence in place keeps AVPlayer item
time in the same frame as the word boundaries, so no offset has to be plumbed
back through the media clock and the JS side is untouched. The tradeoff is that
the next utterance's ~0.18s of head silence is still audible in the gap, so iOS
lands at roughly `0.18 + gapSec` against the WebAudio path's `gapSec`.

The scan runs on a serial background queue so the decode never lands on the main
thread mid-playback, and the enqueue re-checks the session on the way back since
it can now turn over mid-decode. `playout_enqueue` also reports the audible
duration rather than the whole file, matching what the WebAudio path records for
the section timeline.

## Also in here

`scaleGap` in `TTSPlayerSheet` rounded the rate-derived gaps to whole seconds.
Both base gaps are sub-second (0.15s and 0.3s), so `Math.round` returned 0 at
every rate: since #5326 removed the pause sliders, both gaps have been silently
floored to 0 after any speed change with no UI left to restore them. Now rounds
to two decimals, with a regression test.

## Verification

- `pnpm test` (8069 passed), `pnpm lint`, `pnpm fmt:check`, `pnpm format:check` clean
- Swift plugin compiles for the iOS simulator; the one warning is pre-existing
- Trim math checked against real Edge audio via a standalone Swift harness

## Not verified

Nothing has played through AVPlayer with `forwardPlaybackEndTime` set. It is
documented to post `AVPlayerItemDidPlayToEndTime` at that time, which is what
the gap timer and advance hang off, but that has not been confirmed on a device
under a live rate change.

## Note on scope

The issue also mentions macOS and System TTS. macOS stays on the WebAudio path
and still trims, so it is not affected by this bug. The only new macOS pause in
0.11.20 is the 0.3s `DEFAULT_PARAGRAPH_GAP_SEC` from #5057, which is
engine-agnostic and does honor 0. Worth confirming separately with the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)