### PR TITLE
fix(proofread): match Unicode punctuation next to letters

### DIFF
--- a/apps/readest-app/src/__tests__/utils/replacement.test.ts
+++ b/apps/readest-app/src/__tests__/utils/replacement.test.ts
@@ -1027,6 +1027,179 @@ describe('proofreadTransformer', () => {
       expect(result).not.toContain('café');
     });
 
+    test('should replace Unicode punctuation adjacent to letters', async () => {
+      const rules: ProofreadRule[] = [
+        {
+          id: 'opening-quote',
+          scope: 'book',
+          pattern: '«',
+          replacement: '',
+          enabled: true,
+          isRegex: false,
+          caseSensitive: true,
+          order: 1,
+          wholeWord: true,
+        },
+        {
+          id: 'closing-quote',
+          scope: 'book',
+          pattern: '»',
+          replacement: '',
+          enabled: true,
+          isRegex: false,
+          caseSensitive: true,
+          order: 2,
+          wholeWord: true,
+        },
+      ];
+      const ctx = createMockContext(
+        rules,
+        '<section aria-labelledby="greeting"><h2 id="greeting" lang="ru" dir="auto">«Привет»</h2></section>',
+      );
+      const result = await proofreadTransformer.transform(ctx, {
+        docType: 'application/xhtml+xml',
+      });
+      const doc = new DOMParser().parseFromString(result, 'application/xhtml+xml');
+      const section = doc.querySelector('section');
+      const heading = doc.querySelector('#greeting');
+
+      expect(result).toContain('Привет');
+      expect(result).not.toMatch(/[«»]/u);
+      expect(section?.getAttribute('aria-labelledby')).toBe('greeting');
+      expect(heading?.getAttribute('lang')).toBe('ru');
+      expect(heading?.getAttribute('dir')).toBe('auto');
+    });
+
+    test('should replace punctuation adjacent to letters across scripts', async () => {
+      const rules: ProofreadRule[] = [
+        {
+          id: 'punctuation-regex',
+          scope: 'book',
+          pattern: '[«»،「」]',
+          replacement: '',
+          enabled: true,
+          isRegex: true,
+          caseSensitive: true,
+          order: 1,
+          wholeWord: false,
+        },
+      ];
+      const ctx = createMockContext(
+        rules,
+        '<p lang="ru">«Привет»</p><p lang="ar" dir="rtl">،مرحبا</p><p lang="zh">「你好」</p>',
+      );
+      const result = await proofreadTransformer.transform(ctx);
+      const doc = new DOMParser().parseFromString(result, 'text/html');
+      const arabic = doc.querySelector('[lang="ar"]');
+
+      expect(result).toContain('Привет');
+      expect(result).toContain('مرحبا');
+      expect(result).toContain('你好');
+      expect(result).not.toMatch(/[«»،「」]/u);
+      expect(arabic?.getAttribute('dir')).toBe('rtl');
+    });
+
+    test('should replace adjacent Unicode punctuation in the TTS-only pipeline', async () => {
+      const rules: ProofreadRule[] = [
+        {
+          id: 'tts-quotes',
+          scope: 'book',
+          pattern: '[«»]',
+          replacement: '',
+          enabled: true,
+          isRegex: true,
+          caseSensitive: true,
+          order: 1,
+          wholeWord: false,
+          onlyForTTS: true,
+        },
+      ];
+      const ctx = createMockContext(rules, '<speak xml:lang="ru">«Привет»</speak>');
+      const result = await proofreadTransformer.transform(ctx, {
+        docType: 'text/xml',
+        onlyForTTS: true,
+      });
+      const doc = new DOMParser().parseFromString(result, 'text/xml');
+
+      expect(result).toContain('Привет');
+      expect(result).not.toMatch(/[«»]/u);
+      expect(doc.documentElement.getAttribute('xml:lang')).toBe('ru');
+    });
+
+    test('should preserve Unicode word boundaries for matches containing letters', async () => {
+      const rules: ProofreadRule[] = [
+        {
+          id: 'cyrillic-word',
+          scope: 'book',
+          pattern: 'Привет',
+          replacement: 'Здравствуйте',
+          enabled: true,
+          isRegex: false,
+          caseSensitive: true,
+          order: 1,
+          wholeWord: true,
+        },
+      ];
+      const ctx = createMockContext(rules, '<p>СуперПривет Привет</p>');
+      const result = await proofreadTransformer.transform(ctx);
+
+      expect(result).toContain('СуперПривет Здравствуйте');
+    });
+
+    test('should preserve existing boundaries for non-punctuation marks and symbols', async () => {
+      const rules: ProofreadRule[] = [
+        {
+          id: 'combining-mark',
+          scope: 'book',
+          pattern: '\u0301',
+          replacement: '',
+          enabled: true,
+          isRegex: false,
+          caseSensitive: true,
+          order: 1,
+          wholeWord: true,
+        },
+        {
+          id: 'currency-symbol',
+          scope: 'book',
+          pattern: '€',
+          replacement: '',
+          enabled: true,
+          isRegex: false,
+          caseSensitive: true,
+          order: 2,
+          wholeWord: true,
+        },
+      ];
+      const decomposed = 'e\u0301';
+      const ctx = createMockContext(rules, `<p>${decomposed} A€B</p>`);
+      const result = await proofreadTransformer.transform(ctx);
+
+      expect(result).toContain(decomposed);
+      expect(result).toContain('A€B');
+    });
+
+    test('should preserve word-like connector punctuation in mixed regex patterns', async () => {
+      const rules: ProofreadRule[] = [
+        {
+          id: 'mixed-punctuation',
+          scope: 'book',
+          pattern: '[«_»]',
+          replacement: '',
+          enabled: true,
+          isRegex: true,
+          caseSensitive: true,
+          order: 1,
+          wholeWord: false,
+        },
+      ];
+      const ctx = createMockContext(rules, '<p>«Привет» foo_bar</p>');
+      const result = await proofreadTransformer.transform(ctx);
+
+      expect(result).toContain('Привет foo_bar');
+      expect(result).not.toMatch(/[«»]/u);
+    });
+
     test('should handle special regex characters in simple mode', async () => {
       const rules: ProofreadRule[] = [
         {

--- a/apps/readest-app/src/services/transformers/proofread.ts
+++ b/apps/readest-app/src/services/transformers/proofread.ts
@@ -9,6 +9,8 @@ interface NormalizedPattern {
 }
 
 const isUnicodeWordChar = (char: string): boolean => /[\p{L}\p{N}_]/u.test(char || '');
+const isUnicodePunctuationOnly = (text: string): boolean =>
+  /^\p{P}+$/u.test(text) && !isUnicodeWordChar(text);
 const hasUnicodeChars = (text: string): boolean => /[^\x00-\x7F]/.test(text);
 
 // Scripts that don't use spaces between words (no word boundaries)
@@ -84,8 +86,16 @@ function isValidMatch(text: string, match: RegExpExecArray, rule: ProofreadRule)
     if (!isExactMatch) return false;
   }
 
-  // Skip word boundary check for scripts without word boundaries (CJK, Thai, Lao, Khmer, Myanmar, Tibetan)
-  if (hasUnicodeChars(rule.pattern) && !isPureNoWordBoundaryScript(rule.pattern)) {
+  // Unicode punctuation has no word boundary of its own. Inspect the matched
+  // text rather than the pattern so regex classes such as `[«»]` work without
+  // changing the established behavior for symbols, combining marks, or words.
+  // Scripts without word boundaries (CJK, Thai, Lao, Khmer, Myanmar, Tibetan)
+  // continue to use the existing adjacent-character exception below.
+  if (
+    hasUnicodeChars(rule.pattern) &&
+    !isUnicodePunctuationOnly(match[0]) &&
+    !isPureNoWordBoundaryScript(rule.pattern)
+  ) {
     const charBefore = text[match.index - 1] ?? '';
     const charAfter = text[match.index + match[0].length] ?? '';
     // Only check word boundaries if adjacent chars are from scripts that use word boundaries


### PR DESCRIPTION
Closes #5257

## Summary

Fixes proofread replacement rules that could not match Unicode punctuation when it appeared directly next to letters.

For example, literal rules for `«` or `»`, and regex rules such as `[«»]`, can now transform text such as `«Привет»`.

## Changes

- Determine the punctuation exemption from the actual matched text rather than only from the rule pattern.
- Skip Unicode word-boundary validation when the matched text consists entirely of punctuation.
- Preserve the existing boundary behavior for letters, numbers, underscores, combining marks, and symbols.
- Preserve the existing handling for scripts that do not normally use whitespace between words.
- Keep document structure and attributes such as `lang`, `dir`, and `aria-labelledby` unchanged.

## Behavior

The following cases are supported:

- Literal Unicode punctuation next to letters, such as `«Привет»`.
- Regex punctuation classes such as `[«»]`.
- Punctuation adjacent to Cyrillic, Arabic, and CJK text.
- Punctuation-only replacements in the TTS transformation pipeline.
- Mixed regex patterns containing connector punctuation such as `_`.

Existing behavior remains unchanged for:

- Whole-word matching of Unicode words.
- Combining marks.
- Currency and other Unicode symbols.
- Word-like connector punctuation.

## Scope

This change is limited to the shared proofread transformer. It does not modify rule storage, the proofread rule editor, document parsing, or TTS playback.

Visible book-content replacements were manually verified with Cyrillic, Arabic, and CJK text, including punctuation-only regex rules and boundary cases involving `_` and `€`.

The TTS-only transformer path is covered by an automated test using SSML content, but a complete manual end-to-end TTS-only verification was not performed.

The standard Proofread Replacement Rules settings do not provide a `TTS only` option when creating or editing a rule. Existing rules display their `TTS only` state, but that state cannot be changed from the regular rule editor.

A `TTS only` control is available through the EPUB text-selection popup, but it is disabled for the `Current selection` scope and becomes available only after switching to the book or library scope. The selection-based proofread action is also unavailable for non-EPUB content.

These are pre-existing UI limitations and are not changed by this PR. Therefore, this PR verifies the TTS-only transformation behavior at the transformer level, but does not claim manual validation of final speech output across platforms, voices, or TTS engines.
