### PR TITLE
fix(reader): eink popup pointer triangle rendered solid black above selections

### DIFF
--- a/apps/readest-app/src/__tests__/components/popup-eink-triangle.test.tsx
+++ b/apps/readest-app/src/__tests__/components/popup-eink-triangle.test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+
+// Key handling is irrelevant to triangle layering and drags in EnvContext.
+vi.mock('@/hooks/useKeyDownActions', () => ({ useKeyDownActions: () => {} }));
+
+import Popup from '@/components/Popup';
+
+// E-ink popup pointer triangle regression: the popup is outlined by stacking a
+// white inner triangle over a black outer one. Popup positions itself above a
+// selection (dir 'up') using its ResizeObserver-measured height, and demotes
+// the inner triangle behind the outer whenever the triangle point falls inside
+// the popup rect. In e-ink mode the container gains a 1px border, so a
+// content-box measurement under-reports the rendered height by 2px, the popup
+// lands 2px too low, the point registers as "inside", and the inner white
+// triangle hides behind the black outer -> a solid black triangle. The
+// measurement must use the border box.
+
+let roCallback: ResizeObserverCallback | undefined;
+
+class MockResizeObserver {
+  constructor(cb: ResizeObserverCallback) {
+    roCallback = cb;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// A browser-faithful entry for a 44px-tall border-box container with 1px
+// e-ink borders: contentRect reports the 42px content box.
+const einkEntry = (target: Element) =>
+  [
+    {
+      target,
+      contentRect: { height: 42 },
+      borderBoxSize: [{ blockSize: 44, inlineSize: 200 }],
+    } as unknown as ResizeObserverEntry,
+  ] as ResizeObserverEntry[];
+
+describe('Popup e-ink triangle (popup above selection)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    roCallback = undefined;
+  });
+
+  test('keeps the inner triangle on top when the popup sits above the selection', () => {
+    const { container } = render(
+      <Popup
+        width={200}
+        height={44}
+        position={{ point: { x: 100, y: 400 }, dir: 'up' }}
+        trianglePosition={{ point: { x: 150, y: 560 }, dir: 'up' }}
+      >
+        <div />
+      </Popup>,
+    );
+
+    const popup = container.querySelector('#popup-container')!;
+    act(() => {
+      roCallback!(einkEntry(popup), new MockResizeObserver(() => {}) as unknown as ResizeObserver);
+    });
+
+    // The popup bottom must land exactly on the triangle attachment point
+    // (560 = point.y), not 2px past it.
+    const popupEl = popup as HTMLElement;
+    expect(popupEl.style.top).toBe('516px');
+
+    // The white inner triangle must stay above the black outer one, or e-ink
+    // renders a solid black triangle.
+    const inner = container.querySelector('.popup-triangle-inner')!;
+    expect(inner.className).toContain('z-50');
+    expect(inner.className).not.toContain('z-10');
+  });
+});

--- a/apps/readest-app/src/components/Popup.tsx
+++ b/apps/readest-app/src/components/Popup.tsx
@@ -93,7 +93,13 @@ const Popup = ({
     if (!containerRef.current) return;
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
-        const newHeight = entry.contentRect.height;
+        // Measure the border box: contentRect is the content box, which
+        // under-reports by 2px when e-ink mode adds the 1px container border.
+        // The height positions the popup against the triangle attachment
+        // point, so a short measurement drops the popup onto the triangle and
+        // flips triangleHidden, hiding the white inner triangle behind the
+        // black outer one (solid black triangle on e-ink).
+        const newHeight = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
         if (newHeight !== childrenHeight) {
           setChildrenHeight(newHeight);
           return;


### PR DESCRIPTION
## Problem

In e-ink mode, when the annotation toolbar is positioned above the selected text, the pointer triangle under it renders as a solid black triangle instead of the intended white triangle with a 1px black outline (reported from Android e-ink screenshots; reproduces identically on web Chrome with `data-eink` set).

## Root cause

The outline is drawn by stacking a white `.popup-triangle-inner` over a black `.popup-triangle-outer` (offset 1px), and `Popup` demotes the inner triangle behind the outer whenever the triangle attachment point falls inside the popup rect (`triangleHidden`, meant for the clamped-popup case). In normal themes both triangles share the popup color, so the demotion is invisible; in e-ink the black outer wins.

The demotion fired because the popup measures its height with `ResizeObserver` `contentRect` — the content box — while e-ink mode adds a 1px container border. The measurement came up 2px short, the popup-above reposition placed the popup bottom 2px past the triangle attachment point, and the point registered as inside the rect.

## Fix

Measure `entry.borderBoxSize[0].blockSize` (with a `contentRect` fallback) so the measured height matches the rendered box and the popup bottom lands exactly on the attachment point. This also removes the 2px overlap of the popup over the triangle in e-ink mode.

## Verification

- Reproduced and verified live in Chrome (dev-web, `data-eink='true'`): before the fix the inner triangle computed `z-index: 10` and the container bottom sat at `point.y + 2`; after the fix the triangle renders white with a black outline and the container bottom lands on `point.y`.
- Regression test `popup-eink-triangle.test.tsx` drives the ResizeObserver with a browser-faithful entry (content box 42 / border box 44 for an eink-bordered popup) and asserts the popup lands on the attachment point with the inner triangle on top; it fails against the previous measurement.
- `pnpm test` and `pnpm lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)