### PR TITLE
fix(ci): pin the AppImage tauri-cli fork to a known-good rev

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -216,16 +216,24 @@ jobs:
       # Linux uses the truly-portable AppImage tauri CLI fork (mirrors
       # release.yml). The nightly version is patched BEFORE `tauri build` so the
       # bundle filenames carry the stamp.
+      #
+      # PINNED to a rev, not the branch tip: on 2026-07-31 the fork rewrote the
+      # sharun bundler to re-download quick-sharun.sh on EVERY build instead of
+      # only when it is missing from the cache. That defeated the cache seed
+      # below, so both Linux legs pulled the moving main-branch script again and
+      # hung under Xvfb until the 45min step timeout (#4906). This rev is the
+      # last one that keeps the cache check, and it built every nightly through
+      # 2026-07-30. Bump it only together with a Linux AppImage build check.
       - name: Override tauri-cli with custom AppImage format (Linux)
         if: matrix.config.release == 'linux'
-        run: cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --force
+        run: cargo install tauri-cli --git https://github.com/tauri-apps/tauri --rev 162626969b382d52faebdf6c7264460bd9a47d1f --force
 
-      # The truly-portable AppImage bundler downloads quick-sharun.sh from
-      # Anylinux-AppImages@main ONLY when it is not already in the tauri tools
-      # cache. An upstream strace-mode change (2026-06-29) made bundling launch
-      # the app under Xvfb and hang forever, timing out the Linux legs (#4906).
-      # Seed the cache with the last known-good revision so the bundler never
-      # fetches the moving main-branch script.
+      # The truly-portable AppImage bundler at the rev pinned above downloads
+      # quick-sharun.sh from Anylinux-AppImages@main ONLY when it is not already
+      # in the tauri tools cache. An upstream strace-mode change (2026-06-29)
+      # made bundling launch the app under Xvfb and hang forever, timing out the
+      # Linux legs (#4906). Seed the cache with the last known-good revision so
+      # the bundler never fetches the moving main-branch script.
       - name: pin quick-sharun.sh for AppImage bundling (Linux)
         if: matrix.config.release == 'linux'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,16 +379,21 @@ jobs:
           echo "Uploading updated latest.json to GitHub release"
           gh release upload ${{ needs.get-release.outputs.release_tag }} latest.json --clobber
 
+      # PINNED to a rev, not the branch tip: on 2026-07-31 the fork rewrote the
+      # sharun bundler to re-download quick-sharun.sh on EVERY build instead of
+      # only when it is missing from the cache, which defeats the cache seed
+      # below and hangs the Linux legs under Xvfb (#4906). This rev is the last
+      # one that keeps the cache check. Keep in sync with nightly.yml.
       - name: Override tauri-cli with custom AppImage format (Linux)
         if: matrix.config.release == 'linux'
-        run: cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --force
+        run: cargo install tauri-cli --git https://github.com/tauri-apps/tauri --rev 162626969b382d52faebdf6c7264460bd9a47d1f --force
 
-      # The truly-portable AppImage bundler downloads quick-sharun.sh from
-      # Anylinux-AppImages@main ONLY when it is not already in the tauri tools
-      # cache. An upstream strace-mode change (2026-06-29) made bundling launch
-      # the app under Xvfb and hang forever (#4906). Seed the cache with the
-      # last known-good revision so the bundler never fetches the moving
-      # main-branch script. Keep in sync with nightly.yml.
+      # The truly-portable AppImage bundler at the rev pinned above downloads
+      # quick-sharun.sh from Anylinux-AppImages@main ONLY when it is not already
+      # in the tauri tools cache. An upstream strace-mode change (2026-06-29)
+      # made bundling launch the app under Xvfb and hang forever (#4906). Seed
+      # the cache with the last known-good revision so the bundler never fetches
+      # the moving main-branch script. Keep in sync with nightly.yml.
       - name: pin quick-sharun.sh for AppImage bundling (Linux)
         if: matrix.config.release == 'linux'
         run: |


### PR DESCRIPTION
## Problem

Both Linux legs of the nightly have failed for two days ([Jul 31](https://github.com/readest/readest/actions/runs/30669591443), [Aug 1](https://github.com/readest/readest/actions/runs/30720949885)). The `build desktop bundles` step hits its 45 minute timeout during AppImage bundling, leaving orphaned `xvfb-run`, `Xvfb` and `MiniBrowser` processes:

```
Bundling Readest_0.11.20-2026080206_amd64.AppImage
 Downloading https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/quick-sharun.sh
##[error]The action 'build desktop bundles' has timed out after 45 minutes.
```

The per-leg manifest fragments did their job (other platforms still shipped), but `nightly/latest.json` has been promoted twice with no `linux-x86_64` or `linux-aarch64` entries, so Linux nightly users have had no update available.

## Cause

`feat/truly-portable-appimage` moved from `16262696` (which built every green nightly through Jul 30) to `72e660b2` on Jul 31. That rewrite of `sharun.rs` dropped the cache check:

```diff
-  if !quick_sharun.exists() {
-    let data = download("https://raw.githubusercontent.com/.../refs/heads/main/useful-tools/quick-sharun.sh")?;
-    write_and_make_executable(&quick_sharun, data)?;
-  }
+  let data = download("https://raw.githubusercontent.com/.../refs/heads/main/useful-tools/quick-sharun.sh")?;
+  write_and_make_executable(&quick_sharun, data)?;
```

The bundler now re-downloads `quick-sharun.sh` on every build, overwriting the pinned copy that the `pin quick-sharun.sh` step seeds into the tools cache. That put the moving `main` script back in play and brought back the #4906 Xvfb hang the pin was added to prevent.

## Fix

Pin the CLI to `162626969b382d52faebdf6c7264460bd9a47d1f`, the last rev that honors the tools cache, so the seeded script is the one that actually runs. That bundler plus script pair is exactly what produced every green nightly through Jul 30.

`16262696` is the merge base of the current branch tip, not a dangling commit, so the rev stays fetchable.

`release.yml` carries the same two steps and would have hit this at the next release, so it is pinned too.

## Verification

`nightly.yml` dispatched from this branch. Since the build jobs check out `ref: main`, that run builds main's source with the fixed workflow, which is a true end to end test of the AppImage legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)