### PR TITLE
fix(search): keep search options on one line at any text scale

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/library-search-options-menu.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/library-search-options-menu.test.tsx
@@ -64,4 +64,26 @@ describe('LibrarySearchOptionsMenu', () => {
     fireEvent.click(screen.getByText('Match Case'));
     expect(onConfigChange).toHaveBeenLastCalledWith(expect.objectContaining({ matchCase: true }));
   });
+
+  // A device text scale of 1.25 (Android system font size) multiplies every
+  // declared font-size, but a hard-coded `w-56` box does not grow with it, so
+  // labels wrapped onto a second line and the menu grew past the landscape
+  // viewport with no way to scroll.
+  it('sizes to its content and stays scrollable so options never wrap', () => {
+    const { container } = render(
+      <LibrarySearchOptionsMenu config={config} onConfigChange={vi.fn()} />,
+    );
+
+    const menu = container.querySelector('.search-options') as HTMLElement;
+    expect(menu).toBeTruthy();
+    // No fixed width: the box tracks its content so scaled-up text still fits.
+    expect(menu.className).not.toMatch(/(^|\s)!?w-\d/);
+    // Overlong content scrolls instead of overflowing the screen.
+    expect(menu.className).toMatch(/overflow-y-auto/);
+    expect(menu.className).toMatch(/max-h-/);
+
+    for (const label of ['Contains', 'Whole Words', 'Regular Expression', 'Match Diacritics']) {
+      expect(screen.getByText(label).className).toMatch(/whitespace-nowrap/);
+    }
+  });
 });

--- a/apps/readest-app/src/app/library/components/LibrarySearchOptionsMenu.tsx
+++ b/apps/readest-app/src/app/library/components/LibrarySearchOptionsMenu.tsx
@@ -28,7 +28,7 @@ const Option: React.FC<OptionProps> = ({ label, isActive, onClick, disabled }) =
         <span style={{ minWidth: `${iconSize}px` }}>
           {isActive && <MdCheck className='text-base-content' />}
         </span>
-        <span className='ml-2'>{label}</span>
+        <span className='ml-2 whitespace-nowrap'>{label}</span>
       </div>
     </button>
   );
@@ -72,7 +72,13 @@ const LibrarySearchOptionsMenu: React.FC<LibrarySearchOptionsMenuProps> = ({
     <div
       role='menu'
       className={clsx(
-        'search-options dropdown-content border-base-200 bg-base-100 eink-bordered z-20 w-56 rounded-lg border p-1 shadow-2xl',
+        'search-options dropdown-content border-base-200 bg-base-100 eink-bordered z-20 rounded-lg border p-1 shadow-2xl',
+        // No fixed width: a device text scale (Android system font size) scales
+        // every font-size but not a `w-56` box, so labels wrapped and the menu
+        // outgrew the landscape viewport. `.dropdown-content` already sizes the
+        // box to its content and caps it at the viewport. Same scroll contract
+        // as the shared Menu component behind the view and settings menus.
+        'max-h-[calc(100vh-96px)] overflow-y-auto',
         menuClassName,
       )}
     >

--- a/apps/readest-app/src/app/reader/components/sidebar/SearchOptions.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/SearchOptions.tsx
@@ -35,7 +35,7 @@ const Option: React.FC<OptionProps> = ({ label, isActive, onClick, disabled, cap
       <span style={{ minWidth: `${useDefaultIconSize()}px` }}>
         {isActive && <MdCheck className='text-base-content' />}
       </span>
-      <span className='ml-2'>{label}</span>
+      <span className='ml-2 whitespace-nowrap'>{label}</span>
     </div>
     {caption && <span className='text-base-content/50 ml-2 text-xs'>{caption}</span>}
   </button>
@@ -72,7 +72,12 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({
   return (
     <div
       className={clsx(
-        'search-options dropdown-content border-base-200 z-20 w-56 border shadow-2xl',
+        'search-options dropdown-content border-base-200 z-20 border shadow-2xl',
+        // No fixed width: a device text scale (Android system font size) scales
+        // every font-size but not a `w-56` box, so labels wrapped onto a second
+        // line. `.dropdown-content` sizes the box to its content and caps it at
+        // the viewport; the max-height keeps a tall menu scrollable in landscape.
+        'max-h-[calc(100vh-96px)] overflow-y-auto',
         isEink ? 'bordercolor-content border-base-content !bg-base-100 border' : '',
         menuClassName,
       )}


### PR DESCRIPTION
## Problem

On Android, the search options dropdown rendered oversized: `Regular Expression` wrapped onto a second line and the menu grew tall enough to run off the screen, with no way to scroll to the last option in landscape.


## Root cause

Not font boosting, and not a wrong font-size in our CSS. The device had `font_scale = 1.25`, and Android WebView applies the system font size setting as a **uniform text zoom**: every declared size scales exactly (10 to 12.5, 14 to 17.5, 16 to 20), `html` and `body` included. `-webkit-text-size-adjust` was `100%` and irrelevant.

The bug is that the menu was pinned to a hard-coded `w-56` (224px), which does not scale with text zoom. At 1.25 the label column offered only 154px, so the longest label wrapped (row 46px to 76px), the menu reached 382px tall, and without `overflow-y-auto` the bottom item was unreachable in landscape.

## Fix

- Drop the fixed width. `:where(.dropdown-content)` in `globals.css` already provides `width: max-content` + `max-width: calc(100vw - 32px)` at zero specificity, so removing `w-56` is all that is needed.
- Add `whitespace-nowrap` to the label spans so an option is always one line.
- Add `max-h-[calc(100vh-96px)] overflow-y-auto`, the same scroll contract the shared `Menu` component gives the library view and settings menus.

The reader sidebar menu carried the identical `w-56`, so it is fixed alongside the library one.

`Menu` itself is deliberately not reused here: its base sets `border-0`, and `.border-0` is emitted after `.border` in the built CSS, so it would silently drop the 1px border on both menus (e-ink survives only via `eink-bordered`'s `!important`).

## Verification

Measured in the live WebView on a Xiaomi 13 at its real `font_scale = 1.25`:

| | before | after |
|---|---|---|
| Portrait | 224x382, longest label on 2 lines | 250x352, **0 wrapped rows** |
| Landscape | overflows viewport bottom by 46px, `canScroll: false` | clamps to 296.7px, **scrolls** (`scrollTop` 29.09), fits |

`pnpm test` (8137 passed), `pnpm lint`, and `pnpm format:check` all pass. Unit test added covering the content-sized box, the scroll contract, and nowrap labels.

Note: device verification applied the exact classes this change emits into the installed app's WebView over CDP, which validates the layout at the real device text scale but not the packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
