### PR TITLE
feat(reader): include book cover in annotation exports and Readwise sync (#5424)

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2144,5 +2144,8 @@
   "Search query is too long": "استعلام البحث طويل جدًا",
   "Favorites, To Read": "المفضلة، للقراءة لاحقًا",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "قواميس Babylon هي ملفات ‎.bgl‎ مفردة."
+  "Babylon dictionaries are single .bgl files.": "قواميس Babylon هي ملفات ‎.bgl‎ مفردة.",
+  "Cover Image": "صورة الغلاف",
+  "Public cover image URL (empty if unavailable)": "رابط عام لصورة الغلاف (فارغ إذا لم يكن متاحًا)",
+  "Include Book Cover": "تضمين غلاف الكتاب"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1976,5 +1976,8 @@
   "Search query is too long": "অনুসন্ধান শব্দটি খুব দীর্ঘ",
   "Favorites, To Read": "প্রিয়, পরে পড়ব",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon অভিধান হল একক .bgl ফাইল।"
+  "Babylon dictionaries are single .bgl files.": "Babylon অভিধান হল একক .bgl ফাইল।",
+  "Cover Image": "প্রচ্ছদ ছবি",
+  "Public cover image URL (empty if unavailable)": "প্রকাশ্য প্রচ্ছদ ছবির URL (অনুপলব্ধ হলে খালি)",
+  "Include Book Cover": "বইয়ের প্রচ্ছদ অন্তর্ভুক্ত করুন"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1934,5 +1934,8 @@
   "Search query is too long": "འཚོལ་ཚིག་རིང་དྲགས་པ།",
   "Favorites, To Read": "དགའ་པོ། ཀློག་རྒྱུ།",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon ཚིག་མཛོད་ནི་ .bgl ཡིག་ཆ་རྐྱང་པ་རེད།"
+  "Babylon dictionaries are single .bgl files.": "Babylon ཚིག་མཛོད་ནི་ .bgl ཡིག་ཆ་རྐྱང་པ་རེད།",
+  "Cover Image": "མདུན་ཤོག་པར་རིས།",
+  "Public cover image URL (empty if unavailable)": "སྤྱི་ཡོངས་མདུན་ཤོག་པར་རིས་ཀྱི་ URL （མེད་ན་སྟོང་པ།）",
+  "Include Book Cover": "དཔེ་དེབ་ཀྱི་མདུན་ཤོག་ཚུད་པ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1976,5 +1976,8 @@
   "Search query is too long": "Suchanfrage ist zu lang",
   "Favorites, To Read": "Favoriten, Leseliste",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon-Wörterbücher sind einzelne .bgl-Dateien."
+  "Babylon dictionaries are single .bgl files.": "Babylon-Wörterbücher sind einzelne .bgl-Dateien.",
+  "Cover Image": "Coverbild",
+  "Public cover image URL (empty if unavailable)": "Öffentliche Cover-Bild-URL (leer, falls nicht verfügbar)",
+  "Include Book Cover": "Buchcover einschließen"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1976,5 +1976,8 @@
   "Search query is too long": "Το ερώτημα αναζήτησης είναι πολύ μεγάλο",
   "Favorites, To Read": "Αγαπημένα, Για διάβασμα",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Τα λεξικά Babylon είναι μεμονωμένα αρχεία .bgl."
+  "Babylon dictionaries are single .bgl files.": "Τα λεξικά Babylon είναι μεμονωμένα αρχεία .bgl.",
+  "Cover Image": "Εικόνα εξωφύλλου",
+  "Public cover image URL (empty if unavailable)": "Δημόσιο URL εικόνας εξωφύλλου (κενό αν δεν είναι διαθέσιμο)",
+  "Include Book Cover": "Συμπερίληψη εξωφύλλου βιβλίου"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2018,5 +2018,8 @@
   "Search query is too long": "La consulta de búsqueda es demasiado larga",
   "Favorites, To Read": "Favoritos, Por leer",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Los diccionarios Babylon son archivos .bgl individuales."
+  "Babylon dictionaries are single .bgl files.": "Los diccionarios Babylon son archivos .bgl individuales.",
+  "Cover Image": "Imagen de portada",
+  "Public cover image URL (empty if unavailable)": "URL pública de la imagen de portada (vacía si no está disponible)",
+  "Include Book Cover": "Incluir portada del libro"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1976,5 +1976,8 @@
   "Search query is too long": "عبارت جستجو بسیار طولانی است",
   "Favorites, To Read": "علاقه‌مندی‌ها، برای خواندن",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "واژه‌نامه‌های Babylon فایل‌های ‎.bgl‎ منفرد هستند."
+  "Babylon dictionaries are single .bgl files.": "واژه‌نامه‌های Babylon فایل‌های ‎.bgl‎ منفرد هستند.",
+  "Cover Image": "تصویر جلد",
+  "Public cover image URL (empty if unavailable)": "نشانی اینترنتی عمومی تصویر جلد (در صورت در دسترس نبودن، خالی)",
+  "Include Book Cover": "گنجاندن جلد کتاب"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2018,5 +2018,8 @@
   "Search query is too long": "Requête de recherche trop longue",
   "Favorites, To Read": "Favoris, À lire",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Les dictionnaires Babylon sont des fichiers .bgl uniques."
+  "Babylon dictionaries are single .bgl files.": "Les dictionnaires Babylon sont des fichiers .bgl uniques.",
+  "Cover Image": "Image de couverture",
+  "Public cover image URL (empty if unavailable)": "URL publique de l'image de couverture (vide si indisponible)",
+  "Include Book Cover": "Inclure la couverture du livre"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2018,5 +2018,8 @@
   "Search query is too long": "שאילתת החיפוש ארוכה מדי",
   "Favorites, To Read": "מועדפים, לקריאה",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "מילוני Babylon הם קבצי ‎.bgl‎ בודדים."
+  "Babylon dictionaries are single .bgl files.": "מילוני Babylon הם קבצי ‎.bgl‎ בודדים.",
+  "Cover Image": "תמונת כריכה",
+  "Public cover image URL (empty if unavailable)": "כתובת URL ציבורית של תמונת הכריכה (ריק אם אינה זמינה)",
+  "Include Book Cover": "כלול כריכת ספר"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1976,5 +1976,8 @@
   "Search query is too long": "खोज क्वेरी बहुत लंबी है",
   "Favorites, To Read": "पसंदीदा, पढ़ने के लिए",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon शब्दकोश एकल .bgl फ़ाइलें होती हैं।"
+  "Babylon dictionaries are single .bgl files.": "Babylon शब्दकोश एकल .bgl फ़ाइलें होती हैं।",
+  "Cover Image": "कवर छवि",
+  "Public cover image URL (empty if unavailable)": "सार्वजनिक कवर छवि URL (अनुपलब्ध होने पर खाली)",
+  "Include Book Cover": "पुस्तक कवर शामिल करें"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1976,5 +1976,8 @@
   "Search query is too long": "A keresési kifejezés túl hosszú",
   "Favorites, To Read": "Kedvencek, Olvasandó",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "A Babylon szótárak önálló .bgl fájlok."
+  "Babylon dictionaries are single .bgl files.": "A Babylon szótárak önálló .bgl fájlok.",
+  "Cover Image": "Borítókép",
+  "Public cover image URL (empty if unavailable)": "Nyilvános borítókép-URL (üres, ha nem érhető el)",
+  "Include Book Cover": "Könyvborító hozzáadása"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1934,5 +1934,8 @@
   "Search query is too long": "Kata pencarian terlalu panjang",
   "Favorites, To Read": "Favorit, Akan Dibaca",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Kamus Babylon berupa berkas .bgl tunggal."
+  "Babylon dictionaries are single .bgl files.": "Kamus Babylon berupa berkas .bgl tunggal.",
+  "Cover Image": "Gambar Sampul",
+  "Public cover image URL (empty if unavailable)": "URL publik gambar sampul (kosong jika tidak tersedia)",
+  "Include Book Cover": "Sertakan Sampul Buku"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2018,5 +2018,8 @@
   "Search query is too long": "La query di ricerca è troppo lunga",
   "Favorites, To Read": "Preferiti, Da leggere",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "I dizionari Babylon sono singoli file .bgl."
+  "Babylon dictionaries are single .bgl files.": "I dizionari Babylon sono singoli file .bgl.",
+  "Cover Image": "Immagine di copertina",
+  "Public cover image URL (empty if unavailable)": "URL pubblico dell'immagine di copertina (vuoto se non disponibile)",
+  "Include Book Cover": "Includi copertina del libro"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1934,5 +1934,8 @@
   "Search query is too long": "検索語が長すぎます",
   "Favorites, To Read": "お気に入り、あとで読む",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon 辞書は単一の .bgl ファイルです。"
+  "Babylon dictionaries are single .bgl files.": "Babylon 辞書は単一の .bgl ファイルです。",
+  "Cover Image": "カバー画像",
+  "Public cover image URL (empty if unavailable)": "公開カバー画像URL（利用できない場合は空）",
+  "Include Book Cover": "ブックカバーを含める"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1934,5 +1934,8 @@
   "Search query is too long": "검색어가 너무 깁니다",
   "Favorites, To Read": "즐겨찾기, 읽을 책",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon 사전은 단일 .bgl 파일입니다."
+  "Babylon dictionaries are single .bgl files.": "Babylon 사전은 단일 .bgl 파일입니다.",
+  "Cover Image": "표지 이미지",
+  "Public cover image URL (empty if unavailable)": "공개 표지 이미지 URL (사용할 수 없으면 비어 있음)",
+  "Include Book Cover": "책 표지 포함"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1934,5 +1934,8 @@
   "Search query is too long": "Pertanyaan carian terlalu panjang",
   "Favorites, To Read": "Kegemaran, Untuk Dibaca",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Kamus Babylon ialah fail .bgl tunggal."
+  "Babylon dictionaries are single .bgl files.": "Kamus Babylon ialah fail .bgl tunggal.",
+  "Cover Image": "Imej Kulit",
+  "Public cover image URL (empty if unavailable)": "URL awam imej kulit (kosong jika tiada)",
+  "Include Book Cover": "Sertakan Kulit Buku"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1976,5 +1976,8 @@
   "Search query is too long": "Zoekopdracht is te lang",
   "Favorites, To Read": "Favorieten, Nog te lezen",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon-woordenboeken zijn losse .bgl-bestanden."
+  "Babylon dictionaries are single .bgl files.": "Babylon-woordenboeken zijn losse .bgl-bestanden.",
+  "Cover Image": "Omslagafbeelding",
+  "Public cover image URL (empty if unavailable)": "Openbare URL van omslagafbeelding (leeg indien niet beschikbaar)",
+  "Include Book Cover": "Boekomslag opnemen"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2060,5 +2060,8 @@
   "Search query is too long": "Zapytanie jest zbyt długie",
   "Favorites, To Read": "Ulubione, Do przeczytania",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Słowniki Babylon to pojedyncze pliki .bgl."
+  "Babylon dictionaries are single .bgl files.": "Słowniki Babylon to pojedyncze pliki .bgl.",
+  "Cover Image": "Obraz okładki",
+  "Public cover image URL (empty if unavailable)": "Publiczny adres URL obrazu okładki (pusty, jeśli niedostępny)",
+  "Include Book Cover": "Dołącz okładkę książki"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2018,5 +2018,8 @@
   "Search query is too long": "A consulta de pesquisa é muito longa",
   "Favorites, To Read": "Favoritos, Para ler",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Dicionários Babylon são arquivos .bgl individuais."
+  "Babylon dictionaries are single .bgl files.": "Dicionários Babylon são arquivos .bgl individuais.",
+  "Cover Image": "Imagem da capa",
+  "Public cover image URL (empty if unavailable)": "URL pública da imagem da capa (vazio se indisponível)",
+  "Include Book Cover": "Incluir capa do livro"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2018,5 +2018,8 @@
   "Search query is too long": "A consulta de pesquisa é demasiado longa",
   "Favorites, To Read": "Favoritos, Para ler",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Os dicionários Babylon são arquivos .bgl individuais."
+  "Babylon dictionaries are single .bgl files.": "Os dicionários Babylon são arquivos .bgl individuais.",
+  "Cover Image": "Imagem da capa",
+  "Public cover image URL (empty if unavailable)": "URL pública da imagem da capa (vazio se indisponível)",
+  "Include Book Cover": "Incluir capa do livro"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2018,5 +2018,8 @@
   "Search query is too long": "Interogarea de căutare este prea lungă",
   "Favorites, To Read": "Favorite, De citit",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Dicționarele Babylon sunt fișiere .bgl individuale."
+  "Babylon dictionaries are single .bgl files.": "Dicționarele Babylon sunt fișiere .bgl individuale.",
+  "Cover Image": "Imagine copertă",
+  "Public cover image URL (empty if unavailable)": "URL public al imaginii copertei (gol dacă nu este disponibil)",
+  "Include Book Cover": "Include coperta cărții"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2060,5 +2060,8 @@
   "Search query is too long": "Поисковый запрос слишком длинный",
   "Favorites, To Read": "Избранное, К прочтению",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Словари Babylon — это отдельные файлы .bgl."
+  "Babylon dictionaries are single .bgl files.": "Словари Babylon — это отдельные файлы .bgl.",
+  "Cover Image": "Изображение обложки",
+  "Public cover image URL (empty if unavailable)": "Публичный URL изображения обложки (пусто, если недоступно)",
+  "Include Book Cover": "Включить обложку книги"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1976,5 +1976,8 @@
   "Search query is too long": "සෙවුම් වචනය දිග වැඩියි",
   "Favorites, To Read": "ප්‍රියතම, කියවීමට",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon ශබ්දකෝෂ තනි .bgl ගොනු වේ."
+  "Babylon dictionaries are single .bgl files.": "Babylon ශබ්දකෝෂ තනි .bgl ගොනු වේ.",
+  "Cover Image": "ආවරණ රූපය",
+  "Public cover image URL (empty if unavailable)": "පොදු ආවරණ රූප URL (නොමැති නම් හිස්)",
+  "Include Book Cover": "පොත් ආවරණය ඇතුළත් කරන්න"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2060,5 +2060,8 @@
   "Search query is too long": "Iskalni niz je predolg",
   "Favorites, To Read": "Priljubljene, Za branje",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Slovarji Babylon so posamezne datoteke .bgl."
+  "Babylon dictionaries are single .bgl files.": "Slovarji Babylon so posamezne datoteke .bgl.",
+  "Cover Image": "Slika naslovnice",
+  "Public cover image URL (empty if unavailable)": "Javni URL slike naslovnice (prazno, če ni na voljo)",
+  "Include Book Cover": "Vključi naslovnico knjige"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1976,5 +1976,8 @@
   "Search query is too long": "Sökfrågan är för lång",
   "Favorites, To Read": "Favoriter, Att läsa",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon-ordböcker är enskilda .bgl-filer."
+  "Babylon dictionaries are single .bgl files.": "Babylon-ordböcker är enskilda .bgl-filer.",
+  "Cover Image": "Omslagsbild",
+  "Public cover image URL (empty if unavailable)": "Offentlig URL till omslagsbild (tom om otillgänglig)",
+  "Include Book Cover": "Inkludera bokomslag"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1976,5 +1976,8 @@
   "Search query is too long": "தேடல் சொற்றொடர் மிக நீளமாக உள்ளது",
   "Favorites, To Read": "பிடித்தவை, படிக்க வேண்டியவை",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon அகராதிகள் தனி .bgl கோப்புகள் ஆகும்."
+  "Babylon dictionaries are single .bgl files.": "Babylon அகராதிகள் தனி .bgl கோப்புகள் ஆகும்.",
+  "Cover Image": "அட்டைப் படம்",
+  "Public cover image URL (empty if unavailable)": "பொது அட்டைப் பட URL (கிடைக்கவில்லை எனில் காலி)",
+  "Include Book Cover": "புத்தக அட்டையைச் சேர்க்கவும்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1934,5 +1934,8 @@
   "Search query is too long": "คำค้นหายาวเกินไป",
   "Favorites, To Read": "รายการโปรด, จะอ่าน",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "พจนานุกรม Babylon เป็นไฟล์ .bgl ไฟล์เดียว"
+  "Babylon dictionaries are single .bgl files.": "พจนานุกรม Babylon เป็นไฟล์ .bgl ไฟล์เดียว",
+  "Cover Image": "ภาพปก",
+  "Public cover image URL (empty if unavailable)": "URL สาธารณะของภาพปก (ว่างหากไม่พร้อมใช้งาน)",
+  "Include Book Cover": "รวมปกหนังสือ"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1976,5 +1976,8 @@
   "Search query is too long": "Arama sorgusu çok uzun",
   "Favorites, To Read": "Favoriler, Okunacaklar",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon sözlükleri tek bir .bgl dosyasından oluşur."
+  "Babylon dictionaries are single .bgl files.": "Babylon sözlükleri tek bir .bgl dosyasından oluşur.",
+  "Cover Image": "Kapak Görseli",
+  "Public cover image URL (empty if unavailable)": "Herkese açık kapak görseli URL'si (kullanılamıyorsa boş)",
+  "Include Book Cover": "Kitap Kapağını Dahil Et"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2060,5 +2060,8 @@
   "Search query is too long": "Пошуковий запит задовгий",
   "Favorites, To Read": "Улюблене, До прочитання",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Словники Babylon — це окремі файли .bgl."
+  "Babylon dictionaries are single .bgl files.": "Словники Babylon — це окремі файли .bgl.",
+  "Cover Image": "Зображення обкладинки",
+  "Public cover image URL (empty if unavailable)": "Публічна URL-адреса зображення обкладинки (порожня, якщо недоступна)",
+  "Include Book Cover": "Включити обкладинку книги"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1976,5 +1976,8 @@
   "Search query is too long": "Qidiruv soʻrovi juda uzun",
   "Favorites, To Read": "Sevimlilar, Oʻqish uchun",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon lugʻatlari yakka .bgl fayllardan iborat."
+  "Babylon dictionaries are single .bgl files.": "Babylon lugʻatlari yakka .bgl fayllardan iborat.",
+  "Cover Image": "Muqova rasmi",
+  "Public cover image URL (empty if unavailable)": "Muqova rasmining ochiq URL manzili (mavjud bo'lmasa bo'sh)",
+  "Include Book Cover": "Kitob muqovasini qo'shish"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1934,5 +1934,8 @@
   "Search query is too long": "Từ khóa tìm kiếm quá dài",
   "Favorites, To Read": "Yêu thích, Sẽ đọc",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Từ điển Babylon là các tệp .bgl đơn lẻ."
+  "Babylon dictionaries are single .bgl files.": "Từ điển Babylon là các tệp .bgl đơn lẻ.",
+  "Cover Image": "Ảnh bìa",
+  "Public cover image URL (empty if unavailable)": "URL ảnh bìa công khai (trống nếu không có)",
+  "Include Book Cover": "Bao gồm bìa sách"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1934,5 +1934,8 @@
   "Search query is too long": "搜索词过长",
   "Favorites, To Read": "我的最爱、待读",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon 词典是单个 .bgl 文件。"
+  "Babylon dictionaries are single .bgl files.": "Babylon 词典是单个 .bgl 文件。",
+  "Cover Image": "封面图片",
+  "Public cover image URL (empty if unavailable)": "公开封面图片 URL（不可用时为空）",
+  "Include Book Cover": "包含书籍封面"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1934,5 +1934,8 @@
   "Search query is too long": "搜尋字詞過長",
   "Favorites, To Read": "我的最愛、待讀",
   "Babylon": "Babylon",
-  "Babylon dictionaries are single .bgl files.": "Babylon 字典是單一 .bgl 檔案。"
+  "Babylon dictionaries are single .bgl files.": "Babylon 字典是單一 .bgl 檔案。",
+  "Cover Image": "封面圖片",
+  "Public cover image URL (empty if unavailable)": "公開封面圖片 URL（無法使用時為空）",
+  "Include Book Cover": "包含書籍封面"
 }

--- a/apps/readest-app/src/__tests__/api/storage-upload-media-key.test.ts
+++ b/apps/readest-app/src/__tests__/api/storage-upload-media-key.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Issue #5424: exported annotations and Readwise pushes need a durable, public
+// cover URL. Covers are published to media/book_covers/<user-seg>/<coverHash>.png
+// in the public bucket and served from https://assets.readest.com — the key is
+// content-addressed so re-uploads are idempotent and the URL never rotates.
+
+const validateUserAndTokenMock = vi.fn();
+const getUploadSignedUrlMock = vi.fn();
+const getDownloadSignedUrlMock = vi.fn();
+
+vi.mock('@/utils/cors', () => ({
+  corsAllMethods: {},
+  runMiddleware: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/utils/access', () => ({
+  validateUserAndToken: (...a: unknown[]) => validateUserAndTokenMock(...a),
+  getStoragePlanData: vi.fn().mockReturnValue({ usage: 0, quota: 10 ** 12 }),
+  STORAGE_QUOTA_GRACE_BYTES: 0,
+}));
+vi.mock('@/utils/object', async (orig) => {
+  const actual = await orig<typeof import('@/utils/object')>();
+  return {
+    ...actual,
+    getUploadSignedUrl: (...a: unknown[]) => getUploadSignedUrlMock(...a),
+    getDownloadSignedUrl: (...a: unknown[]) => getDownloadSignedUrlMock(...a),
+  };
+});
+vi.mock('@/utils/supabase', () => ({
+  createSupabaseAdminClient: vi.fn(),
+}));
+
+import handler from '@/pages/api/storage/upload';
+
+const postMedia = async (body: Record<string, unknown>) => {
+  const req = {
+    method: 'POST',
+    headers: { authorization: 'Bearer tok' },
+    body,
+  } as unknown as NextApiRequest;
+  const json = vi.fn().mockReturnThis();
+  const status = vi.fn().mockReturnValue({ json });
+  const res = { status, json } as unknown as NextApiResponse;
+  await handler(req, res);
+  return { status, json };
+};
+
+beforeEach(() => {
+  validateUserAndTokenMock.mockReset().mockResolvedValue({
+    user: { id: 'abcdef12-3456-7890-abcd-ef1234567890' },
+    token: 'tok',
+  });
+  getUploadSignedUrlMock.mockReset().mockResolvedValue('https://r2/upload');
+  getDownloadSignedUrlMock.mockReset();
+});
+
+describe('POST /api/storage/upload — media book cover key', () => {
+  it('keys the cover by user segment + content hash and returns the public assets URL', async () => {
+    const { status, json } = await postMedia({
+      fileName: 'c0ffee42.png',
+      fileSize: 4096,
+      media: 'book_covers',
+    });
+
+    expect(getUploadSignedUrlMock).toHaveBeenCalledWith(
+      'media/book_covers/abcdef12/c0ffee42.png',
+      4096,
+      expect.any(Number),
+      expect.any(String),
+    );
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({
+      uploadUrl: 'https://r2/upload',
+      downloadUrl: 'https://assets.readest.com/media/book_covers/abcdef12/c0ffee42.png',
+    });
+  });
+
+  it('rejects unknown media kinds', async () => {
+    const { status } = await postMedia({
+      fileName: 'c0ffee42.png',
+      fileSize: 4096,
+      media: 'avatars',
+    });
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(getUploadSignedUrlMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects path traversal in the file name', async () => {
+    const { status } = await postMedia({
+      fileName: '../../evil.png',
+      fileSize: 4096,
+      media: 'book_covers',
+    });
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(getUploadSignedUrlMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/__tests__/services/readwise/ReadwiseClient.test.ts
+++ b/apps/readest-app/src/__tests__/services/readwise/ReadwiseClient.test.ts
@@ -94,6 +94,46 @@ describe('ReadwiseClient base URL', () => {
     expect((init.headers as Record<string, string>)['Authorization']).toBe('Token test-token');
   });
 
+  // Issue #5424: pass the book cover along so Readwise attaches it to the
+  // book; Readwise only accepts a fetchable URL (image_url, max 2047 chars),
+  // never image bytes, so local-only URLs must be dropped.
+  const pushedHighlight = () => {
+    const init = fetchMock.mock.calls[0]![1] as RequestInit;
+    return JSON.parse(init.body as string).highlights[0];
+  };
+
+  test('sends a resolved public cover URL as image_url', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const client = new ReadwiseClient(makeSettings());
+    const url = 'https://assets.readest.com/media/book_covers/abcdef12/c0ffee.png';
+    await client.pushHighlights([makeNote()], makeBook(), url);
+    expect(pushedHighlight().image_url).toBe(url);
+  });
+
+  test('falls back to a public cover URL from the book metadata', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const client = new ReadwiseClient(makeSettings());
+    const book = { ...makeBook(), coverImageUrl: 'https://example.com/cover.jpg' } as Book;
+    await client.pushHighlights([makeNote()], book);
+    expect(pushedHighlight().image_url).toBe('https://example.com/cover.jpg');
+  });
+
+  test('omits image_url when the only cover URL is local', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const client = new ReadwiseClient(makeSettings());
+    const book = { ...makeBook(), coverImageUrl: 'https://asset.localhost/cover.png' } as Book;
+    await client.pushHighlights([makeNote()], book);
+    expect(pushedHighlight()).not.toHaveProperty('image_url');
+  });
+
+  test('omits image_url when the cover option is disabled', async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const client = new ReadwiseClient(makeSettings({ includeCoverImage: false }));
+    const book = { ...makeBook(), coverImageUrl: 'https://example.com/cover.jpg' } as Book;
+    await client.pushHighlights([makeNote()], book, 'https://example.com/other.jpg');
+    expect(pushedHighlight()).not.toHaveProperty('image_url');
+  });
+
   test('validateToken uses the Tauri HTTP transport in the desktop app', async () => {
     vi.mocked(isTauriAppPlatform).mockReturnValue(true);
     const client = new ReadwiseClient(makeSettings({ baseUrl: 'https://example.com/api/v2' }));

--- a/apps/readest-app/src/__tests__/utils/cover-public-url.test.ts
+++ b/apps/readest-app/src/__tests__/utils/cover-public-url.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Book } from '@/types/book';
+import type { AppService } from '@/types/system';
+import { getPublicCoverUrl, isPublicImageUrl } from '@/utils/cover';
+
+// Issue #5424: annotations exported to markdown / pushed to Readwise reference
+// the book cover by a publicly fetchable URL. A cover already backed by a
+// public URL is reused as-is; otherwise the local cover.png is published to
+// media/book_covers/<user-seg>/<coverHash>.png and that URL is cached.
+
+const makeBook = (hash: string, overrides: Partial<Book> = {}): Book =>
+  ({
+    hash,
+    coverHash: `md5of${hash}`,
+    title: 'T',
+    author: 'A',
+    ...overrides,
+  }) as Book;
+
+const makeAppService = (uploadResult: string | undefined | Error) => {
+  const uploadFileToCloud = vi.fn(() =>
+    uploadResult instanceof Error ? Promise.reject(uploadResult) : Promise.resolve(uploadResult),
+  );
+  const exists = vi.fn().mockResolvedValue(true);
+  return {
+    service: { exists, uploadFileToCloud } as unknown as AppService,
+    exists,
+    uploadFileToCloud,
+  };
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('isPublicImageUrl', () => {
+  it('accepts http(s) URLs and rejects local ones', () => {
+    expect(isPublicImageUrl('https://example.com/c.png')).toBe(true);
+    expect(isPublicImageUrl('http://example.com/c.png')).toBe(true);
+    expect(isPublicImageUrl('http://localhost:3000/c.png')).toBe(false);
+    expect(isPublicImageUrl('http://127.0.0.1/c.png')).toBe(false);
+    expect(isPublicImageUrl('https://asset.localhost/c.png')).toBe(false);
+    expect(isPublicImageUrl('data:image/png;base64,AAAA')).toBe(false);
+    expect(isPublicImageUrl(undefined)).toBe(false);
+    expect(isPublicImageUrl(null)).toBe(false);
+  });
+});
+
+describe('getPublicCoverUrl', () => {
+  it('reuses an already-public coverImageUrl without uploading', async () => {
+    const { service, uploadFileToCloud } = makeAppService('https://assets.readest.com/x.png');
+    const book = makeBook('aaa1', { coverImageUrl: 'https://example.com/cover.jpg' });
+
+    await expect(getPublicCoverUrl(book, service)).resolves.toBe('https://example.com/cover.jpg');
+    expect(uploadFileToCloud).not.toHaveBeenCalled();
+  });
+
+  it('publishes the local cover named by its content hash', async () => {
+    const url = 'https://assets.readest.com/media/book_covers/abcdef12/md5ofbbb2.png';
+    const { service, uploadFileToCloud } = makeAppService(url);
+    const book = makeBook('bbb2', { coverImageUrl: 'https://asset.localhost/cover.png' });
+
+    await expect(getPublicCoverUrl(book, service)).resolves.toBe(url);
+    expect(uploadFileToCloud).toHaveBeenCalledWith(
+      'bbb2/cover.png',
+      'md5ofbbb2.png',
+      'Books',
+      expect.any(Function),
+      'bbb2',
+      false,
+      'book_covers',
+    );
+  });
+
+  it('caches a published URL for the session', async () => {
+    const url = 'https://assets.readest.com/media/book_covers/abcdef12/md5ofccc3.png';
+    const { service, uploadFileToCloud } = makeAppService(url);
+    const book = makeBook('ccc3');
+
+    await getPublicCoverUrl(book, service);
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000);
+    await expect(getPublicCoverUrl(book, service)).resolves.toBe(url);
+    expect(uploadFileToCloud).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined when there is no local cover file', async () => {
+    const { service, exists, uploadFileToCloud } = makeAppService('unused');
+    exists.mockResolvedValue(false);
+
+    await expect(getPublicCoverUrl(makeBook('ddd4'), service)).resolves.toBeUndefined();
+    expect(uploadFileToCloud).not.toHaveBeenCalled();
+  });
+
+  it('backs off after a failed upload, then retries', async () => {
+    const { service, uploadFileToCloud } = makeAppService(new Error('offline'));
+    const book = makeBook('eee5');
+
+    await expect(getPublicCoverUrl(book, service)).resolves.toBeUndefined();
+    await expect(getPublicCoverUrl(book, service)).resolves.toBeUndefined();
+    expect(uploadFileToCloud).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(61 * 1000);
+    await getPublicCoverUrl(book, service);
+    expect(uploadFileToCloud).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/note.test.ts
+++ b/apps/readest-app/src/__tests__/utils/note.test.ts
@@ -47,6 +47,31 @@ describe('renderNoteTemplate', () => {
     ],
   };
 
+  describe('Cover image line (issue #5424)', () => {
+    // The exact snippet the default export template uses: `|300` is Obsidian's
+    // image-width syntax (mirroring Readwise's rw-book-cover templates); other
+    // renderers treat it as part of the alt text and ignore it. The line and
+    // its trailing blank line must appear only when a cover URL was resolved,
+    // without leaving a stray blank line before the title.
+    const template =
+      '{% if coverImageUrl %}![cover|300]({{ coverImageUrl }})\n\n{% endif %}## {{ title }}';
+
+    it('renders the cover image before the title when a URL is present', () => {
+      const result = renderNoteTemplate(template, {
+        ...sampleData,
+        coverImageUrl: 'https://assets.readest.com/media/book_covers/abcdef12/c0ffee.png',
+      });
+      expect(result).toBe(
+        '![cover|300](https://assets.readest.com/media/book_covers/abcdef12/c0ffee.png)\n\n## The Great Gatsby',
+      );
+    });
+
+    it('omits the cover line entirely when no URL is present', () => {
+      const result = renderNoteTemplate(template, sampleData);
+      expect(result).toBe('## The Great Gatsby');
+    });
+  });
+
   describe('Variable substitution', () => {
     it('should substitute simple variables', () => {
       const template = 'Book: {{ title }} by {{ author }}';

--- a/apps/readest-app/src/app/reader/components/annotator/ExportMarkdownDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/ExportMarkdownDialog.tsx
@@ -3,6 +3,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { marked } from 'marked';
 import { useEnv } from '@/context/EnvContext';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useBookDataStore } from '@/store/bookDataStore';
 import { useReaderStore } from '@/store/readerStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { BooknoteGroup, HighlightColor, HighlightStyle, NoteExportConfig } from '@/types/book';
@@ -14,6 +15,7 @@ import {
   getHighlightColorLabel,
 } from '@/app/reader/utils/annotatorUtil';
 import { renderNoteTemplate, formatBlockQuote } from '@/utils/note';
+import { getPublicCoverUrl } from '@/utils/cover';
 import {
   AnnotationLinkType,
   buildAnnotationAppUrl,
@@ -49,12 +51,15 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
   onExport,
 }) => {
   const _ = useTranslation();
-  const { envConfig } = useEnv();
+  const { envConfig, appService } = useEnv();
   const { settings } = useSettingsStore();
+  const { getBookData } = useBookDataStore();
   const { getViewSettings } = useReaderStore();
   const viewSettings = getViewSettings(bookKey);
 
-  const defaultTemplate = `## {{ title }}
+  const defaultTemplate = `{% if coverImageUrl %}![cover|300]({{ coverImageUrl }})
+
+{% endif %}## {{ title }}
 **${_('Author')}**: {{ author }}
 
 **${_('Exported from Readest')}**: {{ exportDate | date('%Y-%m-%d') }}
@@ -100,11 +105,34 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
       // exclusion arrays; default to exporting everything.
       excludedColors: noteExportConfig.excludedColors ?? [],
       excludedStyles: noteExportConfig.excludedStyles ?? [],
+      // Configs persisted before the cover option existed.
+      includeCoverImage: noteExportConfig.includeCoverImage ?? false,
     };
   });
 
   const [showSource, setShowSource] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
+
+  // Resolving a cover URL may publish the local cover to public storage, so it
+  // runs only when the export actually references one: the checkbox in simple
+  // mode, the coverImageUrl variable in template mode.
+  const wantsCoverImage = exportConfig.useCustomTemplate
+    ? exportConfig.customTemplate.includes('coverImageUrl')
+    : exportConfig.includeCoverImage;
+  const [coverImageUrl, setCoverImageUrl] = useState<string | null>(null);
+  useEffect(() => {
+    if (!isOpen || !wantsCoverImage || coverImageUrl) return;
+    const book = getBookData(bookKey)?.book;
+    if (!book) return;
+    let cancelled = false;
+    getPublicCoverUrl(book, appService).then((url) => {
+      if (!cancelled) setCoverImageUrl(url ?? null);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, wantsCoverImage, bookKey, appService]);
 
   useEffect(() => {
     const customTemplate = exportConfig.customTemplate;
@@ -119,6 +147,7 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
   // Helper function to strip markdown formatting
   const stripMarkdown = (text: string): string => {
     return text
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, '') // Remove image embeds (cover)
       .replace(/^#{1,6}\s+/gm, '') // Remove headers
       .replace(/\*\*(.+?)\*\*/g, '$1') // Remove bold
       .replace(/\*(.+?)\*/g, '$1') // Remove italic
@@ -192,6 +221,7 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
         title: bookTitle,
         author: bookAuthor,
         exportDate: Date.now(),
+        coverImageUrl: coverImageUrl ?? '',
         chapters: sortedGroups.map((group) => ({
           title: group.label || _('Untitled'),
           annotations: group.booknotes.map((note) => ({
@@ -221,6 +251,14 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
       const sortedGroups = filteredGroups;
 
       const lines: string[] = [];
+
+      // Add cover image (placed first, mirroring Readwise's own exports).
+      // `|300` is Obsidian's image-width syntax; other renderers treat it as
+      // alt text and ignore it.
+      if (exportConfig.includeCoverImage && coverImageUrl) {
+        lines.push(`![cover|300](${coverImageUrl})`);
+        lines.push('');
+      }
 
       // Add title
       if (exportConfig.includeTitle) {
@@ -308,13 +346,21 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
     }
 
     return output;
-  }, [exportConfig, filteredGroups, bookTitle, bookAuthor, bookHash, _]);
+  }, [exportConfig, filteredGroups, bookTitle, bookAuthor, bookHash, coverImageUrl, _]);
 
   // Convert markdown to HTML for preview
   const htmlPreview = useMemo(() => {
     if (!markdownPreview) return '';
     const html = marked.parse(markdownPreview) as string;
-    return html.replace(/<a href=/g, '<a target="_blank" rel="noopener noreferrer" href=');
+    return (
+      html
+        .replace(/<a href=/g, '<a target="_blank" rel="noopener noreferrer" href=')
+        // The web app is cross-origin isolated (COEP: require-corp, see
+        // middleware.ts) and R2 attaches no CORP header, so a plain <img> to
+        // assets.readest.com is blocked. Requesting it with CORS satisfies
+        // COEP: the bucket allowlists the app origins for GET.
+        .replace(/<img /g, '<img crossorigin="anonymous" ')
+    );
   }, [markdownPreview]);
 
   const handleToggle = (field: keyof NoteExportConfig) => {
@@ -389,6 +435,17 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
                 disabled={exportConfig.useCustomTemplate}
               />
               <span className='text-sm'>{_('Export Date')}</span>
+            </label>
+
+            <label className='flex cursor-pointer items-center gap-2'>
+              <input
+                type='checkbox'
+                checked={exportConfig.includeCoverImage}
+                onChange={() => handleToggle('includeCoverImage')}
+                className='checkbox checkbox-sm'
+                disabled={exportConfig.useCustomTemplate}
+              />
+              <span className='text-sm'>{_('Cover Image')}</span>
             </label>
 
             <label className='flex cursor-pointer items-center gap-2'>
@@ -630,6 +687,10 @@ const ExportMarkdownDialog: React.FC<ExportMarkdownDialogProps> = ({
                         <li>
                           <code className='bg-base-300 rounded px-1'>exportDate</code> -{' '}
                           {_('Export date')}
+                        </li>
+                        <li>
+                          <code className='bg-base-300 rounded px-1'>coverImageUrl</code> -{' '}
+                          {_('Public cover image URL (empty if unavailable)')}
                         </li>
                         <li>
                           <code className='bg-base-300 rounded px-1'>chapters</code> -{' '}

--- a/apps/readest-app/src/app/reader/hooks/useReadwiseSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useReadwiseSync.ts
@@ -5,13 +5,14 @@ import { useEnv } from '@/context/EnvContext';
 import { useTranslation } from '@/hooks/useTranslation';
 import { eventDispatcher } from '@/utils/event';
 import { debounce } from '@/utils/debounce';
+import { getPublicCoverUrl } from '@/utils/cover';
 import { ReadwiseClient } from '@/services/readwise';
 
 const READWISE_SYNC_DEBOUNCE_MS = 5000;
 
 export const useReadwiseSync = (bookKey: string) => {
   const _ = useTranslation();
-  const { envConfig } = useEnv();
+  const { envConfig, appService } = useEnv();
   const { getConfig, getBookData } = useBookDataStore();
 
   // Read settings from store at call time to avoid stale closures
@@ -45,14 +46,18 @@ export const useReadwiseSync = (bookKey: string) => {
         );
         if (newNotes.length === 0) return;
 
-        const result = await client.pushHighlights(newNotes, book);
+        const coverImageUrl =
+          (settings.readwise.includeCoverImage ?? true)
+            ? await getPublicCoverUrl(book, appService)
+            : undefined;
+        const result = await client.pushHighlights(newNotes, book, coverImageUrl);
         if (result.success) {
           await updateLastSyncedAt(Date.now());
         } else if (!result.isNetworkError) {
           console.error('Readwise sync failed:', result.message);
         }
       }, READWISE_SYNC_DEBOUNCE_MS),
-    [bookKey, getBookData, getConfig, updateLastSyncedAt],
+    [bookKey, getBookData, getConfig, updateLastSyncedAt, appService],
   );
 
   // Manual "Push All": sends every annotation/excerpt regardless of sync timestamp
@@ -64,7 +69,11 @@ export const useReadwiseSync = (bookKey: string) => {
     const config = getConfig(bookKey);
     if (!book || !config?.booknotes) return;
 
-    const result = await client.pushHighlights(config.booknotes, book);
+    const coverImageUrl =
+      (settings.readwise.includeCoverImage ?? true)
+        ? await getPublicCoverUrl(book, appService)
+        : undefined;
+    const result = await client.pushHighlights(config.booknotes, book, coverImageUrl);
     if (result.success) {
       await updateLastSyncedAt(Date.now());
       eventDispatcher.dispatch('toast', {
@@ -78,7 +87,7 @@ export const useReadwiseSync = (bookKey: string) => {
       eventDispatcher.dispatch('toast', { message, type: 'error' });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [bookKey, getBookData, getConfig, updateLastSyncedAt]);
+  }, [bookKey, getBookData, getConfig, updateLastSyncedAt, appService]);
 
   // Cancel any pending debounced sync on unmount to avoid background network requests
   useEffect(() => {

--- a/apps/readest-app/src/components/settings/integrations/ReadwiseForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/ReadwiseForm.tsx
@@ -94,6 +94,18 @@ const ReadwiseForm: React.FC<ReadwiseFormProps> = ({ onBack }) => {
     await saveSettings(envConfig, newSettings);
   };
 
+  const handleToggleCoverImage = async () => {
+    const newSettings = {
+      ...settings,
+      readwise: {
+        ...settings.readwise,
+        includeCoverImage: !(settings.readwise?.includeCoverImage ?? true),
+      },
+    };
+    setSettings(newSettings);
+    await saveSettings(envConfig, newSettings);
+  };
+
   const lastSyncedAt = settings.readwise?.lastSyncedAt ?? 0;
   const lastSyncedLabel = lastSyncedAt ? new Date(lastSyncedAt).toLocaleString() : _('Never');
 
@@ -132,6 +144,13 @@ const ReadwiseForm: React.FC<ReadwiseFormProps> = ({ onBack }) => {
                 <Toggle
                   checked={settings.readwise?.enabled ?? false}
                   onChange={handleToggleEnabled}
+                />
+              </label>
+              <label className='flex min-h-14 items-center justify-between px-4'>
+                <SettingLabel>{_('Include Book Cover')}</SettingLabel>
+                <Toggle
+                  checked={settings.readwise?.includeCoverImage ?? true}
+                  onChange={handleToggleCoverImage}
                 />
               </label>
               {configuredBaseUrl && (

--- a/apps/readest-app/src/libs/storage.ts
+++ b/apps/readest-app/src/libs/storage.ts
@@ -45,6 +45,7 @@ export const uploadFile = async (
   onProgress?: ProgressHandler,
   bookHash?: string,
   temp = false,
+  media?: string,
 ) => {
   try {
     const response = await fetchWithAuth(API_ENDPOINTS.upload, {
@@ -57,6 +58,7 @@ export const uploadFile = async (
         fileSize: file.size,
         bookHash,
         temp,
+        media,
       }),
     });
 
@@ -67,7 +69,7 @@ export const uploadFile = async (
     } else {
       await tauriUpload(uploadUrl, fileFullPath, 'PUT', onProgress);
     }
-    return temp ? downloadUrl : undefined;
+    return temp || media ? downloadUrl : undefined;
   } catch (error) {
     console.error('File upload failed:', error);
     if (error instanceof Error) {

--- a/apps/readest-app/src/pages/api/storage/upload.ts
+++ b/apps/readest-app/src/pages/api/storage/upload.ts
@@ -7,7 +7,15 @@ import {
   STORAGE_QUOTA_GRACE_BYTES,
 } from '@/utils/access';
 import { getDownloadSignedUrl, getUploadSignedUrl, isSafeObjectKeyName } from '@/utils/object';
-import { READEST_PUBLIC_STORAGE_BASE_URL } from '@/services/constants';
+import {
+  READEST_PUBLIC_ASSETS_BASE_URL,
+  READEST_PUBLIC_STORAGE_BASE_URL,
+} from '@/services/constants';
+
+// Public media prefixes that may be uploaded into the public bucket. Keys are
+// content-addressed by the caller (media/<kind>/<user-seg>/<hash>.<ext>), so
+// unlike `temp/` objects they are durable and their URLs never rotate.
+const PUBLIC_MEDIA_KINDS = ['book_covers'];
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   await runMiddleware(req, res, corsAllMethods);
@@ -21,7 +29,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(403).json({ error: 'Not authenticated' });
   }
 
-  const { fileName, fileSize, bookHash, replicaKind, replicaId, temp = false } = req.body;
+  const { fileName, fileSize, bookHash, replicaKind, replicaId, temp = false, media } = req.body;
 
   // Reject object-key path traversal before building any key. `fileName` is
   // fully client-controlled and is interpolated into `${user.id}/${fileName}`;
@@ -29,6 +37,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // namespace (GHSA-mfmj-2frf-vhgw).
   if (!isSafeObjectKeyName(fileName)) {
     return res.status(400).json({ error: 'Invalid fileName' });
+  }
+
+  if (media) {
+    if (!PUBLIC_MEDIA_KINDS.includes(media)) {
+      return res.status(400).json({ error: 'Invalid media' });
+    }
+    try {
+      const userStr = user.id.split('-')[0];
+      const fileKey = `media/${media}/${userStr}/${fileName}`;
+      const bucketName = process.env['TEMP_STORAGE_PUBLIC_BUCKET_NAME'] || '';
+      const uploadUrl = await getUploadSignedUrl(fileKey, fileSize, 1800, bucketName);
+      return res.status(200).json({
+        uploadUrl,
+        downloadUrl: `${READEST_PUBLIC_ASSETS_BASE_URL}/${fileKey}`,
+      });
+    } catch (error) {
+      console.error('Error creating presigned post for media file:', error);
+      return res.status(500).json({ error: 'Could not create presigned post' });
+    }
   }
 
   if (temp) {

--- a/apps/readest-app/src/services/appService.ts
+++ b/apps/readest-app/src/services/appService.ts
@@ -343,6 +343,7 @@ export abstract class BaseAppService implements AppService {
     handleProgress: ProgressHandler,
     hash: string,
     temp: boolean = false,
+    media?: string,
   ) {
     return CloudSvc.uploadFileToCloud(
       this.fs,
@@ -353,6 +354,7 @@ export abstract class BaseAppService implements AppService {
       handleProgress,
       hash,
       temp,
+      media,
     );
   }
 

--- a/apps/readest-app/src/services/cloudService.ts
+++ b/apps/readest-app/src/services/cloudService.ts
@@ -96,11 +96,12 @@ export async function uploadFileToCloud(
   handleProgress: ProgressHandler,
   hash: string,
   temp: boolean = false,
+  media?: string,
 ): Promise<string | undefined> {
   console.log('Uploading file:', lfp, 'to', cfp);
   const file = await fs.openFile(lfp, base, cfp);
   const localFullpath = await resolveFilePath(lfp, base);
-  const downloadUrl = await uploadFile(file, localFullpath, handleProgress, hash, temp);
+  const downloadUrl = await uploadFile(file, localFullpath, handleProgress, hash, temp, media);
   const f = file as ClosableFile;
   if (f && f.close) {
     await f.close();

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -84,6 +84,7 @@ export const DEFAULT_READWISE_SETTINGS = {
   enabled: false,
   accessToken: '',
   lastSyncedAt: 0,
+  includeCoverImage: true,
 } as ReadwiseSettings;
 
 export const DEFAULT_HARDCOVER_SETTINGS = {
@@ -440,6 +441,8 @@ export const DEFAULT_NOTE_EXPORT_CONFIG: NoteExportConfig = {
   includeTitle: true,
   includeAuthor: true,
   includeDate: true,
+  // Off by default: including a cover publishes it to public storage.
+  includeCoverImage: false,
   includeChapterTitles: true,
   includeQuotes: true,
   includeNotes: true,
@@ -882,6 +885,9 @@ export const READEST_UPDATER_PUBKEY =
   'dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEJFMEQ1QjE2OEU1NEIzNTEKUldSUnMxU09GbHNOdmpEaWFMT1crRFpEV2VORzQ2MklxaFc0M1R0ci9xY2c1bENXS0xhM1R1L2sK';
 
 export const READEST_PUBLIC_STORAGE_BASE_URL = 'https://storage.readest.com';
+// Custom domain serving the readest-public bucket; durable media assets
+// (e.g. published book covers) are linked through this host.
+export const READEST_PUBLIC_ASSETS_BASE_URL = 'https://assets.readest.com';
 
 export const READEST_OPDS_USER_AGENT = 'Readest/1.0 (OPDS Browser)';
 

--- a/apps/readest-app/src/services/readwise/ReadwiseClient.ts
+++ b/apps/readest-app/src/services/readwise/ReadwiseClient.ts
@@ -2,6 +2,7 @@ import { Book, BookNote, HighlightColor } from '@/types/book';
 import { ReadwiseSettings } from '@/types/settings';
 import { READWISE_API_BASE_URL } from '@/services/constants';
 import { isTauriAppPlatform } from '@/services/environment';
+import { isPublicImageUrl } from '@/utils/cover';
 import { buildAnnotationWebUrl } from '@/utils/deeplink';
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 
@@ -59,20 +60,24 @@ export class ReadwiseClient {
   async pushHighlights(
     notes: BookNote[],
     book: Book,
+    coverImageUrl?: string,
   ): Promise<{ success: boolean; message?: string; isNetworkError?: boolean }> {
     const syncable = notes.filter(
       (n) => (n.type === 'annotation' || n.type === 'excerpt') && !n.deletedAt && n.text,
     );
     if (syncable.length === 0) return { success: true };
 
-    const isPublicUrl = (url?: string | null) =>
-      !!url && /^https?:\/\/(?!localhost|127\.|asset\.localhost)/.test(url);
+    // Readwise only accepts a fetchable image_url (max 2047 chars), never
+    // image bytes; the caller resolves/publishes a public URL (issue #5424)
+    // and the book's own metadata URL is the fallback.
+    const includeCover = this.config.includeCoverImage ?? true;
+    const coverUrl = includeCover ? (coverImageUrl ?? book.coverImageUrl) : undefined;
 
     const highlights = syncable.map((note) => ({
       text: note.text!,
       title: book.title,
       author: book.author,
-      ...(isPublicUrl(book.coverImageUrl) ? { image_url: book.coverImageUrl } : {}),
+      ...(isPublicImageUrl(coverUrl) ? { image_url: coverUrl } : {}),
       source_type: 'readest',
       category: 'books',
       note: note.note || undefined,

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -343,6 +343,9 @@ export interface NoteExportConfig {
   includeTitle: boolean;
   includeAuthor: boolean;
   includeDate: boolean;
+  // Include a public cover image link; requires publishing the cover to the
+  // public bucket (sign-in) unless the book already has a public cover URL.
+  includeCoverImage: boolean;
   includeChapterTitles: boolean;
   includeQuotes: boolean;
   includeNotes: boolean;

--- a/apps/readest-app/src/types/settings.ts
+++ b/apps/readest-app/src/types/settings.ts
@@ -90,6 +90,11 @@ export interface ReadwiseSettings {
   accessToken: string;
   lastSyncedAt: number;
   /**
+   * Send the book cover with pushed highlights (image_url). Optional so
+   * settings persisted before this option existed default to enabled.
+   */
+  includeCoverImage?: boolean;
+  /**
    * Advanced: override the Readwise API base URL (e.g. for a self-hosted,
    * Readwise-compatible receiver). When unset or blank, the official
    * `READWISE_API_BASE_URL` is used.

--- a/apps/readest-app/src/types/system.ts
+++ b/apps/readest-app/src/types/system.ts
@@ -194,6 +194,7 @@ export interface AppService {
     handleProgress: ProgressHandler,
     hash: string,
     temp?: boolean,
+    media?: string,
   ): Promise<string | undefined>;
   uploadReplicaFile(
     kind: string,

--- a/apps/readest-app/src/utils/cover.ts
+++ b/apps/readest-app/src/utils/cover.ts
@@ -1,0 +1,66 @@
+import { Book } from '@/types/book';
+import { AppService } from '@/types/system';
+import { getCoverFilename } from './book';
+
+/**
+ * True when the URL is fetchable by external services (Readwise, markdown
+ * readers), i.e. not a local dev server or the Tauri asset protocol.
+ */
+export const isPublicImageUrl = (url?: string | null): url is string =>
+  !!url && /^https?:\/\/(?!localhost|127\.|asset\.localhost)/.test(url);
+
+type CacheEntry = { url: string | null; expiresAt: number };
+const publishedCoverCache = new Map<string, CacheEntry>();
+// A published URL is content-addressed and durable, so a success is final for
+// the session. Failures (offline, signed out, no cover) retry soon: the
+// Readwise auto-sync calls this on every debounced push and must not turn an
+// outage into an upload loop.
+const FAILURE_TTL = 60 * 1000;
+
+/**
+ * Resolve a publicly accessible cover image URL for the book, or undefined
+ * when none can be provided. A public `coverImageUrl` from the book metadata
+ * wins; otherwise the local cover.png is published to the public bucket under
+ * media/book_covers/<user-seg>/<coverHash>.png (served via assets.readest.com).
+ */
+export const getPublicCoverUrl = async (
+  book: Book,
+  appService: AppService | null,
+): Promise<string | undefined> => {
+  if (isPublicImageUrl(book.coverImageUrl)) return book.coverImageUrl;
+  if (!appService) return undefined;
+
+  const cached = publishedCoverCache.get(book.hash);
+  if (cached && (cached.url || Date.now() < cached.expiresAt)) {
+    return cached.url ?? undefined;
+  }
+
+  try {
+    const fp = getCoverFilename(book);
+    if (!(await appService.exists(fp, 'Books'))) {
+      publishedCoverCache.set(book.hash, { url: null, expiresAt: Date.now() + FAILURE_TTL });
+      return undefined;
+    }
+    // Books imported before coverHash existed fall back to the book hash,
+    // which is just as stable per book (mirrors the Discord presence upload).
+    const fileName = `${book.coverHash || book.hash}.png`;
+    const url = await appService.uploadFileToCloud(
+      fp,
+      fileName,
+      'Books',
+      () => {},
+      book.hash,
+      false,
+      'book_covers',
+    );
+    publishedCoverCache.set(book.hash, {
+      url: url ?? null,
+      expiresAt: Date.now() + FAILURE_TTL,
+    });
+    return url ?? undefined;
+  } catch (error) {
+    console.warn('Failed to publish book cover:', error);
+    publishedCoverCache.set(book.hash, { url: null, expiresAt: Date.now() + FAILURE_TTL });
+    return undefined;
+  }
+};

--- a/apps/readest-app/src/utils/note.ts
+++ b/apps/readest-app/src/utils/note.ts
@@ -4,6 +4,8 @@ export type NoteTemplateData = {
   title: string;
   author: string;
   exportDate: number | string;
+  /** Public cover image URL; empty/absent when no cover could be resolved. */
+  coverImageUrl?: string;
   chapters: {
     title: string;
     annotations: {


### PR DESCRIPTION
Closes #5424

Include the book cover when exporting annotations, following Readwise's model: covers are referenced by a publicly fetchable URL, never embedded as base64 (Readwise's highlight API only accepts an `image_url` of max 2047 chars, and its own exports link hosted URLs).

### Changes

- **Storage API**: new `media` branch in `/api/storage/upload` that publishes covers to `media/book_covers/<user-id-first-segment>/<coverHash>.png` in the readest-public bucket, served from `https://assets.readest.com`. Keys are content-addressed (cover partial-MD5) so re-uploads are idempotent and URLs never rotate; kinds are validated against an allowlist.
- **Cover resolver** (`src/utils/cover.ts`): reuse an already-public `coverImageUrl` from book metadata, otherwise publish the local `cover.png`. Session cache for successes, 60s backoff for failures so the debounced Readwise auto-push cannot turn an outage into an upload loop.
- **Markdown export**: new "Cover Image" option (off by default since it publishes the cover) that prepends `![cover|300](url)` — Obsidian width syntax, mirroring Readwise's `rw-book-cover` convention; other renderers ignore the pipe. Also exposed as a `coverImageUrl` variable for custom templates, and image embeds are stripped in plain-text export.
- **Readwise sync**: resolve and pass the cover as `image_url` on every push, with an "Include Book Cover" toggle (on by default, matching the previous behavior of sending public metadata cover URLs).
- **COEP fix**: the web app is cross-origin isolated (`require-corp`), so the dialog preview loads the cover with `crossorigin="anonymous"`; the bucket CORS policy allowlists the app origins for GET.

### Testing

- 13 new unit tests: upload key shape, resolver cache/fallback/backoff, `image_url` inclusion rules, template rendering
- Verified end-to-end in Chrome on dev-web: cover uploaded to `media/book_covers/b3d61257/bb02...png`, served 200 from assets.readest.com, rendered in the export preview and in the exported markdown
- `pnpm test` (8151 passed), `pnpm lint`, `pnpm format:check` all green; i18n keys translated across all 33 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)