### PR TITLE
fix(library): keep subfolder groups for auto-imported books (#5423)

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2147,5 +2147,10 @@
   "Babylon dictionaries are single .bgl files.": "قواميس Babylon هي ملفات ‎.bgl‎ مفردة.",
   "Cover Image": "صورة الغلاف",
   "Public cover image URL (empty if unavailable)": "رابط عام لصورة الغلاف (فارغ إذا لم يكن متاحًا)",
-  "Include Book Cover": "تضمين غلاف الكتاب"
+  "Include Book Cover": "تضمين غلاف الكتاب",
+  "Watched Folders": "المجلدات المراقَبة",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "يعيد Readest فحص هذه المجلدات عند فتحه أو عودته إلى المقدمة ويستورد أي كتب جديدة. يحتفظ كل مجلد بالبنية التي استُورد بها.",
+  "No folders are watched.": "لا توجد مجلدات مراقَبة.",
+  "Flat": "بدون مجموعات",
+  "Stop watching": "إيقاف المراقبة"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1979,5 +1979,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon অভিধান হল একক .bgl ফাইল।",
   "Cover Image": "প্রচ্ছদ ছবি",
   "Public cover image URL (empty if unavailable)": "প্রকাশ্য প্রচ্ছদ ছবির URL (অনুপলব্ধ হলে খালি)",
-  "Include Book Cover": "বইয়ের প্রচ্ছদ অন্তর্ভুক্ত করুন"
+  "Include Book Cover": "বইয়ের প্রচ্ছদ অন্তর্ভুক্ত করুন",
+  "Watched Folders": "পর্যবেক্ষণ করা ফোল্ডার",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest খোলার সময় বা সামনে ফিরে আসার সময় এই ফোল্ডারগুলো আবার স্ক্যান করে এবং নতুন বই আমদানি করে। প্রতিটি ফোল্ডার আমদানির সময়ের কাঠামো বজায় রাখে।",
+  "No folders are watched.": "কোনো ফোল্ডার পর্যবেক্ষণ করা হচ্ছে না।",
+  "Flat": "দল ছাড়া",
+  "Stop watching": "পর্যবেক্ষণ বন্ধ করুন"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1937,5 +1937,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon ཚིག་མཛོད་ནི་ .bgl ཡིག་ཆ་རྐྱང་པ་རེད།",
   "Cover Image": "མདུན་ཤོག་པར་རིས།",
   "Public cover image URL (empty if unavailable)": "སྤྱི་ཡོངས་མདུན་ཤོག་པར་རིས་ཀྱི་ URL （མེད་ན་སྟོང་པ།）",
-  "Include Book Cover": "དཔེ་དེབ་ཀྱི་མདུན་ཤོག་ཚུད་པ།"
+  "Include Book Cover": "དཔེ་དེབ་ཀྱི་མདུན་ཤོག་ཚུད་པ།",
+  "Watched Folders": "ལྟ་རྟོག་བྱེད་བཞིན་པའི་ཡིག་སྣོད།",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest ཁ་ཕྱེ་བའམ་མདུན་ངོས་སུ་ལོག་སྐབས་ཡིག་སྣོད་འདི་དག་བསྐྱར་དུ་ཞིབ་བཤེར་བྱས་ཏེ་དེབ་གསར་པ་རྣམས་ནང་འདྲེན་བྱེད། ཡིག་སྣོད་རེ་རེས་ནང་འདྲེན་སྐབས་ཀྱི་སྒྲོམ་གཞི་འཛིན།",
+  "No folders are watched.": "ལྟ་རྟོག་བྱེད་བཞིན་པའི་ཡིག་སྣོད་མེད།",
+  "Flat": "ཚོགས་པ་མེད་པ།",
+  "Stop watching": "ལྟ་རྟོག་མཚམས་འཇོག"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1979,5 +1979,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon-Wörterbücher sind einzelne .bgl-Dateien.",
   "Cover Image": "Coverbild",
   "Public cover image URL (empty if unavailable)": "Öffentliche Cover-Bild-URL (leer, falls nicht verfügbar)",
-  "Include Book Cover": "Buchcover einschließen"
+  "Include Book Cover": "Buchcover einschließen",
+  "Watched Folders": "Überwachte Ordner",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest durchsucht diese Ordner erneut, wenn es geöffnet wird oder in den Vordergrund zurückkehrt, und importiert alle neuen Bücher. Jeder Ordner behält die Struktur, mit der er importiert wurde.",
+  "No folders are watched.": "Es werden keine Ordner überwacht.",
+  "Flat": "Flach",
+  "Stop watching": "Nicht mehr überwachen"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1979,5 +1979,10 @@
   "Babylon dictionaries are single .bgl files.": "Τα λεξικά Babylon είναι μεμονωμένα αρχεία .bgl.",
   "Cover Image": "Εικόνα εξωφύλλου",
   "Public cover image URL (empty if unavailable)": "Δημόσιο URL εικόνας εξωφύλλου (κενό αν δεν είναι διαθέσιμο)",
-  "Include Book Cover": "Συμπερίληψη εξωφύλλου βιβλίου"
+  "Include Book Cover": "Συμπερίληψη εξωφύλλου βιβλίου",
+  "Watched Folders": "Παρακολουθούμενοι φάκελοι",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Το Readest σαρώνει ξανά αυτούς τους φακέλους όταν ανοίγει ή επιστρέφει στο προσκήνιο και εισάγει τα νέα βιβλία. Κάθε φάκελος διατηρεί τη δομή με την οποία εισήχθη.",
+  "No folders are watched.": "Δεν παρακολουθείται κανένας φάκελος.",
+  "Flat": "Επίπεδο",
+  "Stop watching": "Διακοπή παρακολούθησης"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2021,5 +2021,10 @@
   "Babylon dictionaries are single .bgl files.": "Los diccionarios Babylon son archivos .bgl individuales.",
   "Cover Image": "Imagen de portada",
   "Public cover image URL (empty if unavailable)": "URL pública de la imagen de portada (vacía si no está disponible)",
-  "Include Book Cover": "Incluir portada del libro"
+  "Include Book Cover": "Incluir portada del libro",
+  "Watched Folders": "Carpetas vigiladas",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest vuelve a explorar estas carpetas cuando se abre o vuelve a primer plano e importa los libros nuevos. Cada carpeta conserva la estructura con la que se importó.",
+  "No folders are watched.": "No hay carpetas vigiladas.",
+  "Flat": "Plano",
+  "Stop watching": "Dejar de vigilar"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1979,5 +1979,10 @@
   "Babylon dictionaries are single .bgl files.": "واژه‌نامه‌های Babylon فایل‌های ‎.bgl‎ منفرد هستند.",
   "Cover Image": "تصویر جلد",
   "Public cover image URL (empty if unavailable)": "نشانی اینترنتی عمومی تصویر جلد (در صورت در دسترس نبودن، خالی)",
-  "Include Book Cover": "گنجاندن جلد کتاب"
+  "Include Book Cover": "گنجاندن جلد کتاب",
+  "Watched Folders": "پوشه‌های زیر نظر",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest هنگام باز شدن یا بازگشت به پیش‌زمینه این پوشه‌ها را دوباره بررسی می‌کند و کتاب‌های جدید را وارد می‌کند. هر پوشه ساختاری را که با آن وارد شده است حفظ می‌کند.",
+  "No folders are watched.": "هیچ پوشه‌ای زیر نظر نیست.",
+  "Flat": "بدون گروه",
+  "Stop watching": "توقف پایش"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2021,5 +2021,10 @@
   "Babylon dictionaries are single .bgl files.": "Les dictionnaires Babylon sont des fichiers .bgl uniques.",
   "Cover Image": "Image de couverture",
   "Public cover image URL (empty if unavailable)": "URL publique de l'image de couverture (vide si indisponible)",
-  "Include Book Cover": "Inclure la couverture du livre"
+  "Include Book Cover": "Inclure la couverture du livre",
+  "Watched Folders": "Dossiers surveillés",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest réanalyse ces dossiers à son ouverture ou à son retour au premier plan et importe les nouveaux livres. Chaque dossier conserve la structure avec laquelle il a été importé.",
+  "No folders are watched.": "Aucun dossier n'est surveillé.",
+  "Flat": "À plat",
+  "Stop watching": "Ne plus surveiller"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2021,5 +2021,10 @@
   "Babylon dictionaries are single .bgl files.": "מילוני Babylon הם קבצי ‎.bgl‎ בודדים.",
   "Cover Image": "תמונת כריכה",
   "Public cover image URL (empty if unavailable)": "כתובת URL ציבורית של תמונת הכריכה (ריק אם אינה זמינה)",
-  "Include Book Cover": "כלול כריכת ספר"
+  "Include Book Cover": "כלול כריכת ספר",
+  "Watched Folders": "תיקיות במעקב",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest סורק מחדש את התיקיות האלה כשהוא נפתח או חוזר לחזית ומייבא ספרים חדשים. כל תיקייה שומרת על המבנה שאיתו יובאה.",
+  "No folders are watched.": "אין תיקיות במעקב.",
+  "Flat": "ללא קבוצות",
+  "Stop watching": "הפסק מעקב"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1979,5 +1979,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon शब्दकोश एकल .bgl फ़ाइलें होती हैं।",
   "Cover Image": "कवर छवि",
   "Public cover image URL (empty if unavailable)": "सार्वजनिक कवर छवि URL (अनुपलब्ध होने पर खाली)",
-  "Include Book Cover": "पुस्तक कवर शामिल करें"
+  "Include Book Cover": "पुस्तक कवर शामिल करें",
+  "Watched Folders": "निगरानी वाले फ़ोल्डर",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest खुलने पर या अग्रभूमि में लौटने पर इन फ़ोल्डरों को दोबारा स्कैन करता है और नई किताबें आयात करता है। हर फ़ोल्डर वही संरचना बनाए रखता है जिसके साथ उसे आयात किया गया था।",
+  "No folders are watched.": "कोई फ़ोल्डर निगरानी में नहीं है।",
+  "Flat": "बिना समूह",
+  "Stop watching": "निगरानी बंद करें"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1979,5 +1979,10 @@
   "Babylon dictionaries are single .bgl files.": "A Babylon szótárak önálló .bgl fájlok.",
   "Cover Image": "Borítókép",
   "Public cover image URL (empty if unavailable)": "Nyilvános borítókép-URL (üres, ha nem érhető el)",
-  "Include Book Cover": "Könyvborító hozzáadása"
+  "Include Book Cover": "Könyvborító hozzáadása",
+  "Watched Folders": "Figyelt mappák",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "A Readest indításkor vagy előtérbe kerüléskor újra átvizsgálja ezeket a mappákat, és importálja az új könyveket. Minden mappa megtartja azt a szerkezetet, amellyel importálták.",
+  "No folders are watched.": "Nincs figyelt mappa.",
+  "Flat": "Csoportok nélkül",
+  "Stop watching": "Figyelés leállítása"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1937,5 +1937,10 @@
   "Babylon dictionaries are single .bgl files.": "Kamus Babylon berupa berkas .bgl tunggal.",
   "Cover Image": "Gambar Sampul",
   "Public cover image URL (empty if unavailable)": "URL publik gambar sampul (kosong jika tidak tersedia)",
-  "Include Book Cover": "Sertakan Sampul Buku"
+  "Include Book Cover": "Sertakan Sampul Buku",
+  "Watched Folders": "Folder yang dipantau",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest memindai ulang folder ini saat dibuka atau kembali ke latar depan dan mengimpor buku baru. Setiap folder mempertahankan struktur saat diimpor.",
+  "No folders are watched.": "Tidak ada folder yang dipantau.",
+  "Flat": "Datar",
+  "Stop watching": "Berhenti memantau"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2021,5 +2021,10 @@
   "Babylon dictionaries are single .bgl files.": "I dizionari Babylon sono singoli file .bgl.",
   "Cover Image": "Immagine di copertina",
   "Public cover image URL (empty if unavailable)": "URL pubblico dell'immagine di copertina (vuoto se non disponibile)",
-  "Include Book Cover": "Includi copertina del libro"
+  "Include Book Cover": "Includi copertina del libro",
+  "Watched Folders": "Cartelle monitorate",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest riesamina queste cartelle all'apertura o al ritorno in primo piano e importa i nuovi libri. Ogni cartella mantiene la struttura con cui è stata importata.",
+  "No folders are watched.": "Nessuna cartella è monitorata.",
+  "Flat": "Piatto",
+  "Stop watching": "Non monitorare più"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1937,5 +1937,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon 辞書は単一の .bgl ファイルです。",
   "Cover Image": "カバー画像",
   "Public cover image URL (empty if unavailable)": "公開カバー画像URL（利用できない場合は空）",
-  "Include Book Cover": "ブックカバーを含める"
+  "Include Book Cover": "ブックカバーを含める",
+  "Watched Folders": "監視中のフォルダ",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest は開いたときやフォアグラウンドに戻ったときにこれらのフォルダを再スキャンし、新しい本をインポートします。各フォルダはインポート時の構造を保ちます。",
+  "No folders are watched.": "監視中のフォルダはありません。",
+  "Flat": "フラット",
+  "Stop watching": "監視を解除"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1937,5 +1937,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon 사전은 단일 .bgl 파일입니다.",
   "Cover Image": "표지 이미지",
   "Public cover image URL (empty if unavailable)": "공개 표지 이미지 URL (사용할 수 없으면 비어 있음)",
-  "Include Book Cover": "책 표지 포함"
+  "Include Book Cover": "책 표지 포함",
+  "Watched Folders": "감시 중인 폴더",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest는 열리거나 포그라운드로 돌아올 때 이 폴더들을 다시 검색하여 새 책을 가져옵니다. 각 폴더는 가져올 때의 구조를 유지합니다.",
+  "No folders are watched.": "감시 중인 폴더가 없습니다.",
+  "Flat": "그룹 없음",
+  "Stop watching": "감시 중지"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1937,5 +1937,10 @@
   "Babylon dictionaries are single .bgl files.": "Kamus Babylon ialah fail .bgl tunggal.",
   "Cover Image": "Imej Kulit",
   "Public cover image URL (empty if unavailable)": "URL awam imej kulit (kosong jika tiada)",
-  "Include Book Cover": "Sertakan Kulit Buku"
+  "Include Book Cover": "Sertakan Kulit Buku",
+  "Watched Folders": "Folder yang dipantau",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest mengimbas semula folder ini apabila dibuka atau kembali ke latar depan dan mengimport buku baharu. Setiap folder mengekalkan struktur semasa ia diimport.",
+  "No folders are watched.": "Tiada folder dipantau.",
+  "Flat": "Rata",
+  "Stop watching": "Berhenti memantau"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1979,5 +1979,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon-woordenboeken zijn losse .bgl-bestanden.",
   "Cover Image": "Omslagafbeelding",
   "Public cover image URL (empty if unavailable)": "Openbare URL van omslagafbeelding (leeg indien niet beschikbaar)",
-  "Include Book Cover": "Boekomslag opnemen"
+  "Include Book Cover": "Boekomslag opnemen",
+  "Watched Folders": "Bewaakte mappen",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest scant deze mappen opnieuw wanneer het wordt geopend of terugkeert naar de voorgrond en importeert nieuwe boeken. Elke map behoudt de structuur waarmee deze is geïmporteerd.",
+  "No folders are watched.": "Er worden geen mappen bewaakt.",
+  "Flat": "Plat",
+  "Stop watching": "Niet meer bewaken"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2063,5 +2063,10 @@
   "Babylon dictionaries are single .bgl files.": "Słowniki Babylon to pojedyncze pliki .bgl.",
   "Cover Image": "Obraz okładki",
   "Public cover image URL (empty if unavailable)": "Publiczny adres URL obrazu okładki (pusty, jeśli niedostępny)",
-  "Include Book Cover": "Dołącz okładkę książki"
+  "Include Book Cover": "Dołącz okładkę książki",
+  "Watched Folders": "Obserwowane foldery",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest ponownie skanuje te foldery przy uruchomieniu lub powrocie na pierwszy plan i importuje nowe książki. Każdy folder zachowuje strukturę, z jaką został zaimportowany.",
+  "No folders are watched.": "Żaden folder nie jest obserwowany.",
+  "Flat": "Bez grup",
+  "Stop watching": "Przestań obserwować"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2021,5 +2021,10 @@
   "Babylon dictionaries are single .bgl files.": "Dicionários Babylon são arquivos .bgl individuais.",
   "Cover Image": "Imagem da capa",
   "Public cover image URL (empty if unavailable)": "URL pública da imagem da capa (vazio se indisponível)",
-  "Include Book Cover": "Incluir capa do livro"
+  "Include Book Cover": "Incluir capa do livro",
+  "Watched Folders": "Pastas monitoradas",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "O Readest verifica novamente essas pastas quando é aberto ou volta ao primeiro plano e importa os livros novos. Cada pasta mantém a estrutura com que foi importada.",
+  "No folders are watched.": "Nenhuma pasta está sendo monitorada.",
+  "Flat": "Plano",
+  "Stop watching": "Parar de monitorar"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2021,5 +2021,10 @@
   "Babylon dictionaries are single .bgl files.": "Os dicionários Babylon são arquivos .bgl individuais.",
   "Cover Image": "Imagem da capa",
   "Public cover image URL (empty if unavailable)": "URL pública da imagem da capa (vazio se indisponível)",
-  "Include Book Cover": "Incluir capa do livro"
+  "Include Book Cover": "Incluir capa do livro",
+  "Watched Folders": "Pastas monitorizadas",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "O Readest volta a analisar estas pastas quando abre ou regressa ao primeiro plano e importa os livros novos. Cada pasta mantém a estrutura com que foi importada.",
+  "No folders are watched.": "Não há pastas monitorizadas.",
+  "Flat": "Plano",
+  "Stop watching": "Deixar de monitorizar"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2021,5 +2021,10 @@
   "Babylon dictionaries are single .bgl files.": "Dicționarele Babylon sunt fișiere .bgl individuale.",
   "Cover Image": "Imagine copertă",
   "Public cover image URL (empty if unavailable)": "URL public al imaginii copertei (gol dacă nu este disponibil)",
-  "Include Book Cover": "Include coperta cărții"
+  "Include Book Cover": "Include coperta cărții",
+  "Watched Folders": "Foldere monitorizate",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest scanează din nou aceste foldere la deschidere sau la revenirea în prim-plan și importă cărțile noi. Fiecare folder păstrează structura cu care a fost importat.",
+  "No folders are watched.": "Niciun folder nu este monitorizat.",
+  "Flat": "Plat",
+  "Stop watching": "Oprește monitorizarea"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2063,5 +2063,10 @@
   "Babylon dictionaries are single .bgl files.": "Словари Babylon — это отдельные файлы .bgl.",
   "Cover Image": "Изображение обложки",
   "Public cover image URL (empty if unavailable)": "Публичный URL изображения обложки (пусто, если недоступно)",
-  "Include Book Cover": "Включить обложку книги"
+  "Include Book Cover": "Включить обложку книги",
+  "Watched Folders": "Отслеживаемые папки",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest повторно сканирует эти папки при запуске или возвращении на передний план и импортирует новые книги. Каждая папка сохраняет структуру, с которой была импортирована.",
+  "No folders are watched.": "Нет отслеживаемых папок.",
+  "Flat": "Без групп",
+  "Stop watching": "Прекратить отслеживание"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1979,5 +1979,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon ශබ්දකෝෂ තනි .bgl ගොනු වේ.",
   "Cover Image": "ආවරණ රූපය",
   "Public cover image URL (empty if unavailable)": "පොදු ආවරණ රූප URL (නොමැති නම් හිස්)",
-  "Include Book Cover": "පොත් ආවරණය ඇතුළත් කරන්න"
+  "Include Book Cover": "පොත් ආවරණය ඇතුළත් කරන්න",
+  "Watched Folders": "නිරීක්ෂණය කරන ෆෝල්ඩර",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest විවෘත වන විට හෝ ඉදිරියට පැමිණෙන විට මෙම ෆෝල්ඩර නැවත පරිලෝකනය කර නව පොත් ආයාත කරයි. සෑම ෆෝල්ඩරයක්ම ආයාත කළ ව්‍යූහය රඳවා ගනී.",
+  "No folders are watched.": "නිරීක්ෂණය කරන ෆෝල්ඩර නැත.",
+  "Flat": "කණ්ඩායම් නැත",
+  "Stop watching": "නිරීක්ෂණය නවත්වන්න"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2063,5 +2063,10 @@
   "Babylon dictionaries are single .bgl files.": "Slovarji Babylon so posamezne datoteke .bgl.",
   "Cover Image": "Slika naslovnice",
   "Public cover image URL (empty if unavailable)": "Javni URL slike naslovnice (prazno, če ni na voljo)",
-  "Include Book Cover": "Vključi naslovnico knjige"
+  "Include Book Cover": "Vključi naslovnico knjige",
+  "Watched Folders": "Nadzorovane mape",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest te mape znova pregleda ob zagonu ali vrnitvi v ospredje in uvozi nove knjige. Vsaka mapa ohrani strukturo, s katero je bila uvožena.",
+  "No folders are watched.": "Nobena mapa ni nadzorovana.",
+  "Flat": "Brez skupin",
+  "Stop watching": "Prenehaj nadzorovati"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1979,5 +1979,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon-ordböcker är enskilda .bgl-filer.",
   "Cover Image": "Omslagsbild",
   "Public cover image URL (empty if unavailable)": "Offentlig URL till omslagsbild (tom om otillgänglig)",
-  "Include Book Cover": "Inkludera bokomslag"
+  "Include Book Cover": "Inkludera bokomslag",
+  "Watched Folders": "Bevakade mappar",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest genomsöker dessa mappar igen när appen öppnas eller återgår till förgrunden och importerar nya böcker. Varje mapp behåller strukturen den importerades med.",
+  "No folders are watched.": "Inga mappar bevakas.",
+  "Flat": "Platt",
+  "Stop watching": "Sluta bevaka"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1979,5 +1979,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon அகராதிகள் தனி .bgl கோப்புகள் ஆகும்.",
   "Cover Image": "அட்டைப் படம்",
   "Public cover image URL (empty if unavailable)": "பொது அட்டைப் பட URL (கிடைக்கவில்லை எனில் காலி)",
-  "Include Book Cover": "புத்தக அட்டையைச் சேர்க்கவும்"
+  "Include Book Cover": "புத்தக அட்டையைச் சேர்க்கவும்",
+  "Watched Folders": "கண்காணிக்கப்படும் கோப்புறைகள்",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest திறக்கும்போது அல்லது முன்னணிக்குத் திரும்பும்போது இந்தக் கோப்புறைகளை மீண்டும் வருடி புதிய புத்தகங்களை இறக்குமதி செய்யும். ஒவ்வொரு கோப்புறையும் இறக்குமதி செய்யப்பட்ட அமைப்பைத் தக்கவைக்கும்.",
+  "No folders are watched.": "கண்காணிக்கப்படும் கோப்புறைகள் இல்லை.",
+  "Flat": "குழுக்கள் இல்லை",
+  "Stop watching": "கண்காணிப்பை நிறுத்து"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1937,5 +1937,10 @@
   "Babylon dictionaries are single .bgl files.": "พจนานุกรม Babylon เป็นไฟล์ .bgl ไฟล์เดียว",
   "Cover Image": "ภาพปก",
   "Public cover image URL (empty if unavailable)": "URL สาธารณะของภาพปก (ว่างหากไม่พร้อมใช้งาน)",
-  "Include Book Cover": "รวมปกหนังสือ"
+  "Include Book Cover": "รวมปกหนังสือ",
+  "Watched Folders": "โฟลเดอร์ที่เฝ้าดู",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest จะสแกนโฟลเดอร์เหล่านี้อีกครั้งเมื่อเปิดหรือกลับมาทำงานเบื้องหน้า และนำเข้าหนังสือใหม่ทั้งหมด แต่ละโฟลเดอร์จะคงโครงสร้างที่ใช้ตอนนำเข้าไว้",
+  "No folders are watched.": "ไม่มีโฟลเดอร์ที่เฝ้าดู",
+  "Flat": "ไม่จัดกลุ่ม",
+  "Stop watching": "หยุดเฝ้าดู"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1979,5 +1979,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon sözlükleri tek bir .bgl dosyasından oluşur.",
   "Cover Image": "Kapak Görseli",
   "Public cover image URL (empty if unavailable)": "Herkese açık kapak görseli URL'si (kullanılamıyorsa boş)",
-  "Include Book Cover": "Kitap Kapağını Dahil Et"
+  "Include Book Cover": "Kitap Kapağını Dahil Et",
+  "Watched Folders": "İzlenen klasörler",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest açıldığında veya ön plana döndüğünde bu klasörleri yeniden tarar ve yeni kitapları içe aktarır. Her klasör, içe aktarıldığı yapıyı korur.",
+  "No folders are watched.": "İzlenen klasör yok.",
+  "Flat": "Düz",
+  "Stop watching": "İzlemeyi bırak"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2063,5 +2063,10 @@
   "Babylon dictionaries are single .bgl files.": "Словники Babylon — це окремі файли .bgl.",
   "Cover Image": "Зображення обкладинки",
   "Public cover image URL (empty if unavailable)": "Публічна URL-адреса зображення обкладинки (порожня, якщо недоступна)",
-  "Include Book Cover": "Включити обкладинку книги"
+  "Include Book Cover": "Включити обкладинку книги",
+  "Watched Folders": "Відстежувані папки",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest повторно сканує ці папки під час запуску або повернення на передній план і імпортує нові книги. Кожна папка зберігає структуру, з якою її було імпортовано.",
+  "No folders are watched.": "Немає відстежуваних папок.",
+  "Flat": "Без груп",
+  "Stop watching": "Припинити відстеження"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1979,5 +1979,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon lugʻatlari yakka .bgl fayllardan iborat.",
   "Cover Image": "Muqova rasmi",
   "Public cover image URL (empty if unavailable)": "Muqova rasmining ochiq URL manzili (mavjud bo'lmasa bo'sh)",
-  "Include Book Cover": "Kitob muqovasini qo'shish"
+  "Include Book Cover": "Kitob muqovasini qo'shish",
+  "Watched Folders": "Kuzatilayotgan papkalar",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest ochilganda yoki old planga qaytganda bu papkalarni qayta skanerlaydi va yangi kitoblarni import qiladi. Har bir papka import qilingan tuzilmasini saqlab qoladi.",
+  "No folders are watched.": "Kuzatilayotgan papkalar yo'q.",
+  "Flat": "Guruhsiz",
+  "Stop watching": "Kuzatishni to'xtatish"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1937,5 +1937,10 @@
   "Babylon dictionaries are single .bgl files.": "Từ điển Babylon là các tệp .bgl đơn lẻ.",
   "Cover Image": "Ảnh bìa",
   "Public cover image URL (empty if unavailable)": "URL ảnh bìa công khai (trống nếu không có)",
-  "Include Book Cover": "Bao gồm bìa sách"
+  "Include Book Cover": "Bao gồm bìa sách",
+  "Watched Folders": "Thư mục được theo dõi",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest quét lại các thư mục này khi mở hoặc quay lại nền trước và nhập mọi sách mới. Mỗi thư mục giữ nguyên cấu trúc khi được nhập.",
+  "No folders are watched.": "Không có thư mục nào được theo dõi.",
+  "Flat": "Phẳng",
+  "Stop watching": "Ngừng theo dõi"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1937,5 +1937,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon 词典是单个 .bgl 文件。",
   "Cover Image": "封面图片",
   "Public cover image URL (empty if unavailable)": "公开封面图片 URL（不可用时为空）",
-  "Include Book Cover": "包含书籍封面"
+  "Include Book Cover": "包含书籍封面",
+  "Watched Folders": "监视的文件夹",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest 在打开或返回前台时会重新扫描这些文件夹并导入新书。每个文件夹保持导入时选择的结构。",
+  "No folders are watched.": "没有监视的文件夹。",
+  "Flat": "平铺",
+  "Stop watching": "停止监视"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1937,5 +1937,10 @@
   "Babylon dictionaries are single .bgl files.": "Babylon 字典是單一 .bgl 檔案。",
   "Cover Image": "封面圖片",
   "Public cover image URL (empty if unavailable)": "公開封面圖片 URL（無法使用時為空）",
-  "Include Book Cover": "包含書籍封面"
+  "Include Book Cover": "包含書籍封面",
+  "Watched Folders": "監視的資料夾",
+  "Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.": "Readest 在開啟或回到前景時會重新掃描這些資料夾並匯入新書。每個資料夾會保持匯入時選擇的結構。",
+  "No folders are watched.": "沒有監視的資料夾。",
+  "Flat": "平鋪",
+  "Stop watching": "停止監視"
 }

--- a/apps/readest-app/src/__tests__/app/library/import-from-folder-watched.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/import-from-folder-watched.test.tsx
@@ -1,0 +1,140 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ImportFromFolderDialog from '@/app/library/components/ImportFromFolderDialog';
+import type { WatchedFolder } from '@/app/library/components/WatchedFoldersPane';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string, options?: Record<string, string | number>) => {
+    if (!options) return key;
+    return key.replace(/{{(\w+)}}/g, (_match, name) => String(options[name] ?? ''));
+  },
+}));
+
+vi.mock('@/hooks/useKeyDownActions', () => ({
+  useKeyDownActions: () => ({ current: null }),
+}));
+
+vi.mock('@/components/Dialog', () => ({
+  __esModule: true,
+  default: ({
+    isOpen,
+    title,
+    children,
+  }: {
+    isOpen: boolean;
+    title?: string;
+    children: React.ReactNode;
+  }) =>
+    isOpen ? (
+      <div role='dialog' aria-label={title}>
+        {children}
+      </div>
+    ) : null,
+}));
+
+const WATCHED: WatchedFolder[] = [
+  { path: '/Users/me/Books', flatten: false },
+  { path: '/Users/me/Comics', flatten: true },
+];
+
+const setup = (overrides: Partial<React.ComponentProps<typeof ImportFromFolderDialog>> = {}) => {
+  const props = {
+    initialDirectory: '/Users/me/Books',
+    initialReadInPlace: true,
+    initialAutoImport: true,
+    watchedFolders: WATCHED,
+    onPickDirectory: vi.fn(),
+    onCancel: vi.fn(),
+    onConfirm: vi.fn(),
+    onUnwatchFolder: vi.fn(),
+    onSetWatchedFolderFlatten: vi.fn(),
+    ...overrides,
+  };
+  const utils = render(<ImportFromFolderDialog {...props} />);
+  return { ...utils, props };
+};
+
+const openPane = () => fireEvent.click(screen.getByText('Watched Folders'));
+
+afterEach(cleanup);
+
+describe('Import-from-Folder dialog: watched folders pane', () => {
+  it('hides the entry row when no folder is watched', () => {
+    setup({ watchedFolders: [] });
+
+    expect(screen.queryByText('Watched Folders')).toBeNull();
+  });
+
+  it('opens the pane in place of the import form and comes back', () => {
+    setup();
+    expect(screen.getByText('File Formats')).toBeTruthy();
+
+    openPane();
+    // The import form is replaced, not merely scrolled past — no OK button to
+    // hit while managing folders.
+    expect(screen.queryByText('File Formats')).toBeNull();
+    expect(screen.queryByText('OK')).toBeNull();
+    expect(screen.getByText('/Users/me/Books')).toBeTruthy();
+    expect(screen.getByText('/Users/me/Comics')).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText('Back'));
+    expect(screen.getByText('File Formats')).toBeTruthy();
+  });
+
+  it('shows each folder by name with its current structure', () => {
+    setup();
+    openPane();
+
+    expect(screen.getByText('Books')).toBeTruthy();
+    expect(screen.getByText('Comics')).toBeTruthy();
+    const selects = screen.getAllByLabelText('Folder Structure');
+    expect((selects[0] as HTMLSelectElement).value).toBe('keep');
+    expect((selects[1] as HTMLSelectElement).value).toBe('flatten');
+  });
+
+  it('reports a structure change for the right folder', () => {
+    const { props } = setup();
+    openPane();
+
+    fireEvent.change(screen.getAllByLabelText('Folder Structure')[1]!, {
+      target: { value: 'keep' },
+    });
+
+    expect(props.onSetWatchedFolderFlatten).toHaveBeenCalledWith('/Users/me/Comics', false);
+  });
+
+  it('reports a removal for the right folder', () => {
+    const { props } = setup();
+    openPane();
+
+    fireEvent.click(screen.getAllByLabelText('Stop watching')[0]!);
+
+    expect(props.onUnwatchFolder).toHaveBeenCalledWith('/Users/me/Books');
+  });
+
+  it('unticks auto-import when the folder being imported is unwatched', () => {
+    const { props } = setup();
+    openPane();
+    fireEvent.click(screen.getAllByLabelText('Stop watching')[0]!);
+    fireEvent.click(screen.getByLabelText('Back'));
+
+    // Confirming now must not re-add the folder the user just stopped watching.
+    fireEvent.click(screen.getByText('OK'));
+    expect(props.onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ directory: '/Users/me/Books', autoImport: false }),
+    );
+  });
+
+  it('keeps the import form in sync when the current folder changes structure', () => {
+    const { props } = setup();
+    openPane();
+    fireEvent.change(screen.getAllByLabelText('Folder Structure')[0]!, {
+      target: { value: 'flatten' },
+    });
+    fireEvent.click(screen.getByLabelText('Back'));
+
+    fireEvent.click(screen.getByText('OK'));
+    expect(props.onConfirm).toHaveBeenCalledWith(expect.objectContaining({ flatten: true }));
+  });
+});

--- a/apps/readest-app/src/__tests__/services/auto-import-folder-groups.test.ts
+++ b/apps/readest-app/src/__tests__/services/auto-import-folder-groups.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+
+import { selectNewImportableFiles, toWatchedFolderImports } from '@/services/bookService';
+import { getFolderImportGroupName } from '@/utils/path';
+
+/**
+ * Issue #5423: a watched folder imported with "Create groups from subfolders"
+ * grouped its books on the initial import, but every later auto-import dropped
+ * the new books into the library root. The group hint lives on each importer
+ * input (`basePath`), so these tests pin the mapping from a folder scan to that
+ * hint, and from the hint to the group name the importer derives.
+ */
+const WATCHED = '/lib/watched';
+const SCANNED = [
+  { fullPath: '/lib/watched/SciFi/dune.epub', size: 2048 },
+  { fullPath: '/lib/watched/Poetry/odes.epub', size: 2048 },
+  { fullPath: '/lib/watched/loose.epub', size: 2048 },
+];
+
+/** Same derivation `importBooks` runs per file, applied to the built inputs. */
+const groupNames = (files: Array<{ path: string; basePath?: string }>) =>
+  files.map((file) => (file.basePath ? getFolderImportGroupName(file.path, file.basePath) : ''));
+
+describe('auto-import: grouping of newly-found books', () => {
+  const scanFolder = (folder: string, entries: typeof SCANNED, flatten: boolean) => {
+    const fresh = selectNewImportableFiles(entries, {
+      extensions: ['epub'],
+      minSizeBytes: 0,
+      existingPaths: new Set<string>(),
+      osPlatform: 'linux',
+    });
+    return toWatchedFolderImports(folder, fresh, flatten);
+  };
+
+  it('mirrors subfolders as groups, like the initial import did', () => {
+    const files = scanFolder(WATCHED, SCANNED, false);
+
+    expect(files.every((file) => file.basePath === WATCHED)).toBe(true);
+    // The watched folder itself is the top-level group, each subfolder nests
+    // under it, and a book sitting loose in the root belongs to the folder's
+    // own group — exactly what a manual folder import produces.
+    expect(groupNames(files)).toEqual(['watched/SciFi', 'watched/Poetry', 'watched']);
+  });
+
+  it('keeps books in the library root for a flattened folder', () => {
+    const files = scanFolder(WATCHED, SCANNED, true);
+
+    expect(files.every((file) => file.basePath === undefined)).toBe(true);
+    expect(groupNames(files)).toEqual(['', '', '']);
+  });
+
+  it('derives the same groups from Windows paths', () => {
+    const folder = 'C:\\Users\\me\\Books';
+    const files = scanFolder(
+      folder,
+      [
+        { fullPath: 'C:\\Users\\me\\Books\\SciFi\\dune.epub', size: 2048 },
+        { fullPath: 'C:\\Users\\me\\Books\\loose.epub', size: 2048 },
+      ],
+      false,
+    );
+
+    expect(groupNames(files)).toEqual(['Books/SciFi', 'Books']);
+  });
+});

--- a/apps/readest-app/src/app/library/components/ImportFromFolderDialog.tsx
+++ b/apps/readest-app/src/app/library/components/ImportFromFolderDialog.tsx
@@ -4,7 +4,11 @@ import { MdFolderOpen } from 'react-icons/md';
 
 import { useTranslation } from '@/hooks/useTranslation';
 import { useKeyDownActions } from '@/hooks/useKeyDownActions';
+import { getFilename } from '@/utils/path';
 import Dialog from '@/components/Dialog';
+import BoxedList from '@/components/settings/primitives/BoxedList';
+import NavigationRow from '@/components/settings/primitives/NavigationRow';
+import WatchedFoldersPane, { type WatchedFolder } from './WatchedFoldersPane';
 
 /**
  * Per-extension grouping presented to the user. Each card is a single
@@ -124,6 +128,20 @@ interface ImportFromFolderDialogProps {
    */
   isRegisteredExternalRoot?: (directory: string) => boolean;
   /**
+   * Every folder currently in `settings.autoImportFolders`, with the folder
+   * structure each one auto-imports with. Drives the "Watched Folders"
+   * sub-page; an empty list (the default) hides its entry row entirely.
+   */
+  watchedFolders?: WatchedFolder[];
+  /**
+   * Stop auto-importing from `path`. Applied immediately by the caller, not on
+   * OK — the sub-page manages folders other than the one being imported, and
+   * Cancel must not silently undo the management the user just did.
+   */
+  onUnwatchFolder?: (path: string) => void;
+  /** Change the folder structure future auto-imports from `path` use. */
+  onSetWatchedFolderFlatten?: (path: string, flatten: boolean) => void;
+  /**
    * Pop the platform's native folder picker and return the chosen path,
    * or `undefined` when the user cancels. Required because folder
    * pickers vary between desktop (Tauri dialog) and Android (SAF) and
@@ -135,6 +153,8 @@ interface ImportFromFolderDialogProps {
 }
 
 const DEFAULT_SELECTED_GROUP_IDS = ['epub', 'pdf'];
+/** Shared by the import form and the watched-folders sub-page. */
+const DIALOG_BOX_CLASS = 'sm:min-w-[480px] sm:max-w-[480px] sm:h-auto sm:max-h-[90%]';
 const DEFAULT_MIN_SIZE_KB = 20;
 
 /**
@@ -156,6 +176,9 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
   initialReadInPlace = false,
   initialAutoImport = false,
   isRegisteredExternalRoot,
+  watchedFolders = [],
+  onUnwatchFolder,
+  onSetWatchedFolderFlatten,
   onPickDirectory,
   onCancel,
   onConfirm,
@@ -197,10 +220,19 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
   // folder is read in place; `effectiveAutoImport` enforces that.
   const [autoImport, setAutoImport] = useState<boolean>(initialAutoImport);
   const [picking, setPicking] = useState(false);
+  // Which screen the dialog shows: the import form, or the sub-page listing
+  // the folders already opted into auto-import.
+  const [view, setView] = useState<'import' | 'watched'>('import');
 
   const readInPlaceLocked = !!directory && (isRegisteredExternalRoot?.(directory) ?? false);
   const effectiveReadInPlace = readInPlaceLocked || readInPlace;
   const effectiveAutoImport = effectiveReadInPlace && autoImport;
+
+  /** Same normalization the caller matches watched roots with. */
+  const isCurrentDirectory = (path: string) => {
+    const normalize = (p: string) => p.replace(/\\/g, '/').replace(/\/+$/, '');
+    return !!directory && normalize(path) === normalize(directory);
+  };
 
   // Enter to confirm, Escape / Android Back to cancel. We must wire
   // `onCancel` even though <Dialog> also listens for Back, because
@@ -212,11 +244,17 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
     onConfirm: () => {
       // Block the Enter shortcut while a folder pick is in flight so
       // we don't dispatch a confirm with a stale directory.
-      if (picking) return;
+      if (picking || view !== 'import') return;
       handleConfirm();
     },
     onCancel: () => {
       if (picking) return;
+      // Android Back leaves the sub-page instead of the whole dialog (our
+      // handler consumes the event before <Dialog>'s own listener sees it).
+      if (view !== 'import') {
+        setView('import');
+        return;
+      }
       onCancel();
     },
   });
@@ -269,12 +307,44 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
 
   const confirmDisabled = !directory || selectedGroups.size === 0;
 
+  // The sub-page swaps out the dialog's body only: <Dialog> stays the root
+  // element of both branches, so switching views doesn't remount it (no
+  // replayed open animation, no lost scroll position on the way back).
+  if (view === 'watched') {
+    return (
+      <Dialog
+        isOpen
+        title={_('Import Books')}
+        onClose={onCancel}
+        boxClassName={DIALOG_BOX_CLASS}
+        contentClassName='!px-6 !py-2'
+      >
+        <WatchedFoldersPane
+          folders={watchedFolders}
+          onBack={() => setView('import')}
+          onUnwatch={(path) => {
+            // Keep the form honest: confirming right after unwatching the very
+            // folder being imported would put it straight back on the list.
+            if (isCurrentDirectory(path)) setAutoImport(false);
+            onUnwatchFolder?.(path);
+          }}
+          onSetFlatten={(path, flatten) => {
+            // Same reasoning for the structure radios — OK writes the folder's
+            // structure from the form, so the two must not disagree.
+            if (isCurrentDirectory(path)) setFolderMode(flatten ? 'flatten' : 'keep');
+            onSetWatchedFolderFlatten?.(path, flatten);
+          }}
+        />
+      </Dialog>
+    );
+  }
+
   return (
     <Dialog
       isOpen
       title={_('Import Books')}
       onClose={onCancel}
-      boxClassName='sm:min-w-[480px] sm:max-w-[480px] sm:h-auto sm:max-h-[90%]'
+      boxClassName={DIALOG_BOX_CLASS}
       contentClassName='!px-6 !py-2'
     >
       <div className='flex flex-col gap-4 pt-2'>
@@ -471,6 +541,18 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
             </span>
           </label>
         </div>
+
+        {/* Entry point to the watched-folders sub-page. Hidden until at least
+            one folder is watched — there is nothing to manage before that. */}
+        {watchedFolders.length > 0 && (
+          <BoxedList>
+            <NavigationRow
+              title={_('Watched Folders')}
+              status={watchedFolders.map((f) => getFilename(f.path) || f.path).join(', ')}
+              onClick={() => setView('watched')}
+            />
+          </BoxedList>
+        )}
 
         <div className='mt-1 flex justify-end gap-2 pb-2'>
           <button type='button' className='btn btn-ghost btn-sm' onClick={onCancel}>

--- a/apps/readest-app/src/app/library/components/WatchedFoldersPane.tsx
+++ b/apps/readest-app/src/app/library/components/WatchedFoldersPane.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { IoMdCloseCircleOutline } from 'react-icons/io';
+import { MdArrowBackIosNew, MdArrowForwardIos } from 'react-icons/md';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import { getDirFromUILanguage } from '@/utils/rtl';
+import { getFilename } from '@/utils/path';
+import BoxedList from '@/components/settings/primitives/BoxedList';
+import SettingsSelect from '@/components/settings/primitives/SettingsSelect';
+
+export interface WatchedFolder {
+  /** Absolute path, exactly as stored in `settings.autoImportFolders`. */
+  path: string;
+  /**
+   * `true` when this folder's auto-imported books go straight to the library
+   * root ("Import all into library"); `false` mirrors its subfolders as groups.
+   */
+  flatten: boolean;
+}
+
+interface WatchedFoldersPaneProps {
+  folders: WatchedFolder[];
+  onBack: () => void;
+  /** Stop auto-importing from `path`. The folder stays readable in place. */
+  onUnwatch: (path: string) => void;
+  onSetFlatten: (path: string, flatten: boolean) => void;
+}
+
+/**
+ * Sub-page of the Import-from-Folder dialog listing every folder the user has
+ * opted into auto-import, so a folder can be dropped or re-pointed without
+ * hunting down its path in the picker again — until this existed, unwatching
+ * meant re-selecting the exact folder and unticking a checkbox.
+ *
+ * Edits apply immediately (the caller persists them); Cancel on the parent
+ * dialog does not roll them back, same as any settings pane.
+ */
+const WatchedFoldersPane: React.FC<WatchedFoldersPaneProps> = ({
+  folders,
+  onBack,
+  onUnwatch,
+  onSetFlatten,
+}) => {
+  const _ = useTranslation();
+  const isRtl = getDirFromUILanguage() === 'rtl';
+  const BackIcon = isRtl ? MdArrowForwardIos : MdArrowBackIosNew;
+
+  return (
+    <div className='flex flex-col gap-3 pt-2'>
+      {/* Deliberately not <SubPageHeader>: its breadcrumb repeats the parent
+          label, which the dialog's own title bar already shows. */}
+      <div className='flex flex-col gap-1'>
+        <div className='flex items-center gap-1'>
+          <button
+            type='button'
+            onClick={onBack}
+            className='btn btn-ghost btn-sm px-1'
+            aria-label={_('Back')}
+            title={_('Back')}
+          >
+            <BackIcon className='h-4 w-4' />
+          </button>
+          <span className='text-base font-semibold tracking-tight'>{_('Watched Folders')}</span>
+        </div>
+        <span className='text-base-content/65 text-[0.85em] leading-relaxed'>
+          {_(
+            'Readest re-scans these folders when it opens or returns to the foreground and imports any new books. Each folder keeps the structure it was imported with.',
+          )}
+        </span>
+      </div>
+
+      {folders.length === 0 ? (
+        <span className='text-base-content/65 py-4 text-center text-[0.85em]'>
+          {_('No folders are watched.')}
+        </span>
+      ) : (
+        <BoxedList>
+          {folders.map((folder) => (
+            <div key={folder.path} className='flex items-center gap-2 py-2 pe-2'>
+              <div className='min-w-0 flex-1'>
+                <div className='truncate font-medium' title={folder.path}>
+                  {getFilename(folder.path) || folder.path}
+                </div>
+                <div className='text-base-content/65 truncate text-[0.85em]'>{folder.path}</div>
+              </div>
+              <SettingsSelect
+                value={folder.flatten ? 'flatten' : 'keep'}
+                onChange={(e) => onSetFlatten(folder.path, e.target.value === 'flatten')}
+                options={[
+                  { value: 'keep', label: _('Groups') },
+                  { value: 'flatten', label: _('Flat') },
+                ]}
+                ariaLabel={_('Folder Structure')}
+              />
+              <button
+                type='button'
+                onClick={() => onUnwatch(folder.path)}
+                className='btn btn-ghost btn-sm shrink-0 px-1'
+                aria-label={_('Stop watching')}
+                title={_('Stop watching')}
+              >
+                <IoMdCloseCircleOutline className='text-base-content/75 h-5 w-5' />
+              </button>
+            </div>
+          ))}
+        </BoxedList>
+      )}
+    </div>
+  );
+};
+
+export default WatchedFoldersPane;

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -13,6 +13,7 @@ import {
   collectKnownSourcePaths,
   normalizeFilePathForIndex,
   selectNewImportableFiles,
+  toWatchedFolderImports,
 } from '@/services/bookService';
 import { debounce } from '@/utils/debounce';
 import { DEFAULT_NEARBY_WORDS } from '@/utils/searchConfig';
@@ -27,7 +28,7 @@ import { ProgressPayload } from '@/utils/transfer';
 import { throttle } from '@/utils/throttle';
 import { transferManager } from '@/services/transferManager';
 import { isReadestCloudStorageActive } from '@/services/sync/cloudSyncProvider';
-import { getDirPath, getFilename, joinPaths } from '@/utils/path';
+import { getFilename, getFolderImportGroupName, joinPaths } from '@/utils/path';
 import { parseOpenWithFiles } from '@/helpers/openWith';
 import { isTauriAppPlatform, isWebAppPlatform } from '@/services/environment';
 import { checkForAppUpdates, checkAppReleaseNotes } from '@/helpers/updater';
@@ -880,8 +881,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
         let resolvedGroupId = groupId;
         let resolvedGroupName = groupId !== undefined ? getGroupName(groupId) : undefined;
         if (resolvedGroupId === undefined && path && basePath) {
-          const rootPath = getDirPath(basePath);
-          resolvedGroupName = getDirPath(path).replace(rootPath, '').replace(/^\//, '');
+          resolvedGroupName = getFolderImportGroupName(path, basePath);
           resolvedGroupId = getGroupId(resolvedGroupName);
         }
         // Read settings from the store at call-time rather than the
@@ -1002,8 +1002,14 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
           existingPaths,
           osPlatform,
         });
+        // Reproduce the folder's own "Folder Structure" choice: unless it was
+        // imported flat, each file carries the watched folder as `basePath` so
+        // `importBooks` seats the book in the group its subfolder implies —
+        // the same group the folder's initial import used (issue #5423).
+        newFiles.push(
+          ...toWatchedFolderImports(folder, fresh, isFlattenedAutoImportFolder(folder)),
+        );
         for (const entry of fresh) {
-          newFiles.push({ path: entry.fullPath });
           // Prevent the same file matching again via a later overlapping folder.
           const key = normalizeFilePathForIndex(entry.fullPath, osPlatform);
           if (key) existingPaths.add(key);
@@ -1419,6 +1425,21 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
   };
 
   /**
+   * `true` when auto-imports from `directory` should go straight to the library
+   * root because the user imported it with "Import all into library". Read from
+   * the live store: the scan runs long after the dialog wrote the setting, and
+   * the component closure can still hold the pre-write snapshot. A folder
+   * watched before this list existed isn't in it and therefore keeps the
+   * dialog's default, "Create groups from subfolders".
+   */
+  const isFlattenedAutoImportFolder = (directory: string): boolean => {
+    const target = normalizeRoot(directory);
+    if (!target) return false;
+    const roots = useSettingsStore.getState().settings.autoImportFlattenFolders ?? [];
+    return roots.some((r) => normalizeRoot(r) === target);
+  };
+
+  /**
    * Add `directory` to `settings.externalLibraryFolders` (and persist
    * settings) so the ingest layer's `shouldImportInPlace` will pick
    * up subsequent imports from the same folder automatically. No-op
@@ -1448,21 +1469,37 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
   /**
    * Add or remove `directory` from `settings.autoImportFolders` (and persist)
    * per the user's per-folder "Auto-import new books from this folder" choice.
-   * A no-op when the folder is already in the desired state. Errors are
-   * swallowed — the import itself still succeeds; we just won't watch (or stop
-   * watching) the folder until the next successful settings write.
+   * `flatten` records the same import's "Folder Structure" pick so later scans
+   * can group newly-found books exactly like this import did — it is tracked in
+   * a parallel list because only flattened folders need an entry. A no-op when
+   * the folder is already in the desired state. Errors are swallowed — the
+   * import itself still succeeds; we just won't watch (or stop watching) the
+   * folder until the next successful settings write.
    */
-  const setAutoImportFolder = async (directory: string, enabled: boolean): Promise<void> => {
+  const setAutoImportFolder = async (
+    directory: string,
+    enabled: boolean,
+    flatten: boolean,
+  ): Promise<void> => {
     const target = normalizeRoot(directory);
     if (!target) return;
     const liveSettings = useSettingsStore.getState().settings;
     const existing = liveSettings.autoImportFolders ?? [];
+    const existingFlatten = liveSettings.autoImportFlattenFolders ?? [];
     const present = existing.some((r) => normalizeRoot(r) === target);
-    if (enabled === present) return;
-    const next = enabled
-      ? [...existing, directory]
-      : existing.filter((r) => normalizeRoot(r) !== target);
-    const nextSettings = { ...liveSettings, autoImportFolders: next };
+    const flattenPresent = existingFlatten.some((r) => normalizeRoot(r) === target);
+    const flattenWanted = enabled && flatten;
+    if (enabled === present && flattenWanted === flattenPresent) return;
+    const without = (roots: string[]) => roots.filter((r) => normalizeRoot(r) !== target);
+    const next = enabled ? [...without(existing), directory] : without(existing);
+    const nextFlatten = flattenWanted
+      ? [...without(existingFlatten), directory]
+      : without(existingFlatten);
+    const nextSettings = {
+      ...liveSettings,
+      autoImportFolders: next,
+      autoImportFlattenFolders: nextFlatten,
+    };
     setSettings(nextSettings);
     try {
       await saveSettings(envConfig, nextSettings);
@@ -1521,7 +1558,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     // checkbox. `result.autoImport` already implies `readInPlace` (the dialog
     // gates it), so registration above has run; unchecking removes the folder
     // from the watched set while leaving it registered as read-in-place.
-    await setAutoImportFolder(result.directory, result.autoImport);
+    await setAutoImportFolder(result.directory, result.autoImport, result.flatten);
 
     // Re-grant scopes for the directory before scanning. This matters
     // when `result.directory` came from somewhere the dialog plugin
@@ -1571,12 +1608,15 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
       if (minSizeBytes > 0 && file.size < minSizeBytes) return false;
       return true;
     });
-    const toImportFiles = await Promise.all(
-      filtered.map(async (file) => {
-        const fullPath = await joinPaths(result.directory, file.path);
-        return result.flatten ? { path: fullPath } : { path: fullPath, basePath: result.directory };
-      }),
+    const entries = await Promise.all(
+      filtered.map(async (file) => ({
+        fullPath: await joinPaths(result.directory, file.path),
+        size: file.size,
+      })),
     );
+    // Same mapping the auto-import scan uses, so a folder's later scans group
+    // newly-found books exactly like this import does.
+    const toImportFiles = toWatchedFolderImports(result.directory, entries, result.flatten);
     if (toImportFiles.length === 0) {
       eventDispatcher.dispatch('toast', {
         type: 'info',

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -1432,6 +1432,18 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
    * watched before this list existed isn't in it and therefore keeps the
    * dialog's default, "Create groups from subfolders".
    */
+  /**
+   * The watched folders as the Import-from-Folder dialog's management sub-page
+   * wants them. Derived from `settings` (not the store snapshot) so removing or
+   * re-pointing a folder re-renders the list immediately.
+   */
+  const watchedFolders = (settings.autoImportFolders ?? []).map((path) => ({
+    path,
+    flatten: (settings.autoImportFlattenFolders ?? []).some(
+      (r) => normalizeRoot(r) === normalizeRoot(path),
+    ),
+  }));
+
   const isFlattenedAutoImportFolder = (directory: string): boolean => {
     const target = normalizeRoot(directory);
     if (!target) return false;
@@ -1490,10 +1502,15 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     const flattenPresent = existingFlatten.some((r) => normalizeRoot(r) === target);
     const flattenWanted = enabled && flatten;
     if (enabled === present && flattenWanted === flattenPresent) return;
+    // Append only when the folder isn't listed yet: re-adding an existing entry
+    // would move it to the end and shuffle the Watched Folders list under the
+    // user's finger every time they flip a row's structure.
     const without = (roots: string[]) => roots.filter((r) => normalizeRoot(r) !== target);
-    const next = enabled ? [...without(existing), directory] : without(existing);
+    const next = enabled ? (present ? existing : [...existing, directory]) : without(existing);
     const nextFlatten = flattenWanted
-      ? [...without(existingFlatten), directory]
+      ? flattenPresent
+        ? existingFlatten
+        : [...existingFlatten, directory]
       : without(existingFlatten);
     const nextSettings = {
       ...liveSettings,
@@ -2003,6 +2020,11 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
           initialReadInPlace={importFromFolderState.initialReadInPlace}
           initialAutoImport={importFromFolderState.initialAutoImport}
           isRegisteredExternalRoot={isRegisteredExternalRoot}
+          watchedFolders={watchedFolders}
+          onUnwatchFolder={(path) => void setAutoImportFolder(path, false, false)}
+          onSetWatchedFolderFlatten={(path, flatten) =>
+            void setAutoImportFolder(path, true, flatten)
+          }
           onPickDirectory={pickImportDirectory}
           onCancel={() => setImportFromFolderState(null)}
           onConfirm={(result) => {

--- a/apps/readest-app/src/services/backupService.ts
+++ b/apps/readest-app/src/services/backupService.ts
@@ -38,6 +38,7 @@ export const BACKUP_SETTINGS_BLACKLIST = [
   'customRootDir',
   'externalLibraryFolders',
   'autoImportFolders',
+  'autoImportFlattenFolders',
   'savedBookCoverForLockScreenPath',
   // Per-device identity — restoring causes sync identity / HLC collisions.
   'replicaDeviceId',

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -125,6 +125,27 @@ export function selectNewImportableFiles(
 }
 
 /**
+ * Turn the newly-found entries of one watched folder into importer inputs.
+ *
+ * `flatten` mirrors the Import-from-Folder dialog's "Folder Structure" choice
+ * for that folder. In the default "Create groups from subfolders" mode every
+ * file carries the watched folder as `basePath` — that hint is what makes
+ * `importBooks` derive a group from the subfolder the file lives in. Without it
+ * auto-imported books piled up in the library root while the same folder's
+ * initial import stayed grouped (issue #5423). Flattened folders ("Import all
+ * into library") omit the hint so their books keep landing in the root.
+ */
+export function toWatchedFolderImports(
+  folder: string,
+  entries: ScannedFileEntry[],
+  flatten: boolean,
+): Array<{ path: string; basePath?: string }> {
+  return entries.map(({ fullPath }) =>
+    flatten ? { path: fullPath } : { path: fullPath, basePath: folder },
+  );
+}
+
+/**
  * Collect all known local source paths from the library into a normalized set.
  *
  * Unlike `buildBookLookupIndex(...).byFilePath`, this includes soft-deleted

--- a/apps/readest-app/src/types/settings.ts
+++ b/apps/readest-app/src/types/settings.ts
@@ -337,6 +337,16 @@ export interface SystemSettings {
    * `BACKUP_SETTINGS_BLACKLIST`.
    */
   autoImportFolders?: string[];
+  /**
+   * The subset of {@link autoImportFolders} the user imported with "Import all
+   * into library" (flatten). Auto-imported books from those folders go straight
+   * to the library root; every other watched folder mirrors its subfolders as
+   * groups, matching the dialog's default "Create groups from subfolders" —
+   * which is also what a folder watched before this list existed falls back to.
+   * Device-local, and excluded from cloud settings backups alongside
+   * {@link autoImportFolders}.
+   */
+  autoImportFlattenFolders?: string[];
 
   keepLogin: boolean;
   alwaysOnTop: boolean;

--- a/apps/readest-app/src/utils/path.ts
+++ b/apps/readest-app/src/utils/path.ts
@@ -30,6 +30,18 @@ export const getDirPath = (filePath: string) => {
   return parts.join('/');
 };
 
+/**
+ * Group name a book imported from a folder belongs to: its directory made
+ * relative to the *parent* of `basePath`, so the imported folder itself
+ * becomes the top-level group ("Books") and every subfolder nests under it
+ * ("Books/SciFi"). Books sitting loose in `basePath` get the folder's own
+ * group. Backslashes are normalized, so Windows paths derive the same names.
+ */
+export const getFolderImportGroupName = (filePath: string, basePath: string) => {
+  const rootPath = getDirPath(basePath);
+  return getDirPath(filePath).replace(rootPath, '').replace(/^\//, '');
+};
+
 export const joinPaths = async (...paths: string[]) => {
   return await join(...paths);
 };


### PR DESCRIPTION
Fixes #5423.

## The bug

A folder imported with **Read books in place** + **Auto-import new books from this folder** + **Create groups from subfolders** grouped its books on the initial import, but every book auto-imported later landed at the library root instead of the group its subfolder implies.

Two causes, both in `src/app/library/page.tsx`:

1. **Grouping is carried by `SelectedFile.basePath`, nothing else.** `importBooks` → `processFile` derives a book's group from its directory relative to the *parent* of `basePath`, so the imported folder is the top-level group and subfolders nest under it. `runFolderImport` attaches `basePath` in keep mode; the watched-folder scan pushed a bare `{ path }`, so `groupId` stayed undefined and the book fell to the root.
2. **The per-folder "Folder Structure" pick was never persisted.** `settings.autoImportFolders` is only `string[]`; the keep/flatten radio lived in localStorage as a *global* "last used" default for the dialog, so the scan had nothing to reproduce.

## The fix

- `toWatchedFolderImports(folder, entries, flatten)` (`services/bookService.ts`) builds the importer inputs. **Both** the manual folder import and the auto-import scan call it, so the two paths cannot drift apart again.
- `getFolderImportGroupName(filePath, basePath)` extracted from `processFile` into `utils/path.ts`. Backslashes normalize, so Windows derives the same group names.
- New device-local `settings.autoImportFlattenFolders?: string[]` records the watched folders imported with "Import all into library"; it is a subset of `autoImportFolders` and is excluded from cloud settings backups alongside it.

**Folders watched before this change carry no recorded pick and fall back to "Create groups from subfolders"** — the dialog's default, and what the issue expects. The trade-off: someone who had watched a folder in *flatten* mode sees new books land in a folder-named group until they re-run the import once (or flip the row in the new pane below).

## Watched Folders pane

Auto-import folders could only be added or removed by re-opening the dialog on that exact path and toggling a checkbox, and nothing in the UI ever listed them. The second commit adds a **Watched Folders** sub-page to the Import-from-Folder dialog:

- Entry row under the Folder Structure radios, hidden until at least one folder is watched.
- One row per folder: name, full path, a Groups/Flat select, and a remove button. Empty state when the last one goes.
- Edits apply immediately (like any settings pane); Cancel does not roll them back. Editing the folder currently in the path field also updates the form behind the sub-page, so OK cannot rewrite what was just changed.
- `<Dialog>` stays the root of both branches (early return, not a wrapping ternary), so switching views does not remount the dialog — and the form's indentation stays out of the diff.

## Tests

- `src/__tests__/services/auto-import-folder-groups.test.ts` — scan → importer inputs → derived group names, for keep, flatten, and Windows paths.
- `src/__tests__/app/library/import-from-folder-watched.test.tsx` — drives the real dialog: entry row hidden when empty, open/back, per-row callbacks carrying the right path, and both form-sync cases.

`pnpm test` (8147 passed / 7 skipped), `pnpm lint`, and `pnpm format:check` are green after rebasing onto `main`. 5 new i18n keys extracted and translated across all 33 locales.

The pane was also checked in a browser (dark, `data-eink='true'`, live removal down to the empty state). The scan wiring itself is desktop/Android-only and was not exercised in a real Tauri build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
