### PR TITLE
fix(reader): give the toolbar controls a 44px touch target (#5401)

### DIFF
--- a/apps/readest-app/src/__tests__/android/header-touch-targets.android.test.ts
+++ b/apps/readest-app/src/__tests__/android/header-touch-targets.android.test.ts
@@ -1,0 +1,141 @@
+import path from 'node:path';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { tap } from './helpers/adb';
+import { CdpPage } from './helpers/cdp';
+import { detectAndroidEnv, openFixtureBook, waitFor } from './helpers/reader';
+
+// End-to-end coverage for issue #5401: on a Boox Tab Mini C the reader's top
+// bar was "nearly impossible to tap ... especially the close button", and a
+// miss turned the page instead.
+//
+// The bar is 44px tall but its controls only claimed a 32x32 hit box (24x24
+// plus an 8px halo for the close button), so a tap a few px above or below the
+// icon fell through to the book: the first such tap dismisses the toolbar and
+// the next one flips the page. DESIGN.md requires 44px+ targets on mobile and
+// ships `.touch-target` for exactly this.
+//
+// Hit testing is what jsdom cannot model, so this asserts against the real
+// WebView: every control in the bar must own at least the bar's full height,
+// and the close button a full 44x44.
+
+const FIXTURE = path.resolve(__dirname, '../fixtures/data/sample-alice.epub');
+/** Minimum touch target on mobile (DESIGN.md). Also the bar's own height. */
+const MIN_TOUCH_TARGET_PX = 44;
+
+interface ControlTarget {
+  label: string;
+  /** Rendered size of the control. */
+  box: [number, number];
+  /** Effective hit box, probed with elementFromPoint. */
+  hit: [number, number];
+}
+
+const viewportMetrics = (page: CdpPage) =>
+  page.evaluate<{ dpr: number; width: number; height: number }>(
+    `return { dpr: window.devicePixelRatio || 1, width: innerWidth, height: innerHeight };`,
+  );
+
+const isHeaderBarVisible = (page: CdpPage) =>
+  page.evaluate<boolean>(`
+    const bar = document.querySelector('.header-bar');
+    if (!bar) return false;
+    const style = getComputedStyle(bar);
+    return style.pointerEvents !== 'none' && parseFloat(style.opacity) > 0.9;
+  `);
+
+/** Tapping the middle of the page toggles the toolbar (usePagination). */
+const showHeaderBar = async (page: CdpPage): Promise<void> => {
+  if (await isHeaderBarVisible(page)) return;
+  const { dpr, width, height } = await viewportMetrics(page);
+  await tap(width * 0.5 * dpr, height * 0.5 * dpr);
+  await waitFor(() => isHeaderBarVisible(page), { label: 'header bar shown' });
+  // The bar animates its margin-top for 300ms when the status bar appears
+  // alongside it; measure the settled geometry, not a frame mid-transition.
+  await page.evaluate(`await new Promise((r) => setTimeout(r, 500)); return true;`);
+};
+
+/**
+ * Walk outward from each control's center with elementFromPoint until the hit
+ * test stops resolving to that control. This measures what the finger actually
+ * gets — pseudo-element halos, overlapping neighbors and clipping ancestors
+ * all included — which is the whole point of running it on a device.
+ */
+const measureHeaderControls = (page: CdpPage) =>
+  page.evaluate<ControlTarget[]>(`
+    const bar = document.querySelector('.header-bar');
+    if (!bar) return [];
+    const measure = (btn) => {
+      const b = btn.getBoundingClientRect();
+      const cx = b.x + b.width / 2;
+      const cy = b.y + b.height / 2;
+      const hits = (x, y) => {
+        const el = document.elementFromPoint(x, y);
+        return !!el && (el === btn || btn.contains(el));
+      };
+      let left = cx, right = cx, top = cy, bottom = cy;
+      while (left > 0 && hits(left - 1, cy)) left--;
+      while (right < window.innerWidth - 1 && hits(right + 1, cy)) right++;
+      while (top > 0 && hits(cx, top - 1)) top--;
+      while (bottom < window.innerHeight - 1 && hits(cx, bottom + 1)) bottom++;
+      return {
+        label: btn.getAttribute('aria-label') || btn.title || btn.id || 'unlabelled',
+        box: [Math.round(b.width), Math.round(b.height)],
+        hit: [Math.round(right - left + 1), Math.round(bottom - top + 1)],
+      };
+    };
+    return [...bar.querySelectorAll('button')]
+      .filter((btn) => btn.getBoundingClientRect().width > 0)
+      .map(measure);
+  `);
+
+const env = await detectAndroidEnv();
+if (!env) {
+  console.warn('[test:android] no adb device with Readest installed — skipping the Android lane');
+}
+
+describe.runIf(env)('Android reader header bar touch targets (#5401)', () => {
+  let page: CdpPage;
+
+  beforeAll(async () => {
+    page = await openFixtureBook(FIXTURE);
+  }, 180_000);
+
+  afterAll(() => {
+    page?.close();
+  });
+
+  beforeEach(async () => {
+    await showHeaderBar(page);
+  }, 60_000);
+
+  it('gives every header control at least the bar height to be tapped', async () => {
+    const controls = await measureHeaderControls(page);
+    // Guard the premise: an empty list would pass every assertion below.
+    expect(controls.length).toBeGreaterThan(2);
+
+    const tooShort = controls.filter(({ hit }) => hit[1] < MIN_TOUCH_TARGET_PX);
+    expect(
+      tooShort,
+      `controls shorter than ${MIN_TOUCH_TARGET_PX}px: ${JSON.stringify(tooShort)}`,
+    ).toEqual([]);
+  });
+
+  it('gives the close button a full 44x44 target', async () => {
+    const controls = await measureHeaderControls(page);
+    const close = controls.find(({ label }) => /close/i.test(label));
+    expect(
+      close,
+      `no close button among ${JSON.stringify(controls.map((c) => c.label))}`,
+    ).toBeDefined();
+    expect(close!.hit[0]).toBeGreaterThanOrEqual(MIN_TOUCH_TARGET_PX);
+    expect(close!.hit[1]).toBeGreaterThanOrEqual(MIN_TOUCH_TARGET_PX);
+  });
+
+  it('keeps the halos from swallowing a neighbor visible box', async () => {
+    // Expanding hit areas must not overshoot: every control has to keep at
+    // least its own rendered size, or a tap on one icon would fire another.
+    const controls = await measureHeaderControls(page);
+    const shrunk = controls.filter(({ box, hit }) => hit[0] < box[0] || hit[1] < box[1]);
+    expect(shrunk, `controls smaller than their icon: ${JSON.stringify(shrunk)}`).toEqual([]);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/HeaderBar.tsx
+++ b/apps/readest-app/src/app/reader/components/HeaderBar.tsx
@@ -215,8 +215,11 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
         }}
       >
         <div className='header-tools-start bg-base-100 sidebar-bookmark-toggler z-20 flex h-full min-w-0 items-center gap-x-4 pe-2 max-[350px]:gap-x-2'>
+          {/* h-full so this scroller spans the whole bar: `overflow-x-auto`
+              also clips vertically, and shrink-wrapped to the 32px icons it
+              cut the buttons' touch halos back down to 32px (#5401). */}
           <div
-            className='flex min-w-0 items-center gap-x-4 overflow-x-auto max-[350px]:gap-x-2'
+            className='flex h-full min-w-0 items-center gap-x-4 overflow-x-auto max-[350px]:gap-x-2'
             style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
           >
             {!isSideBarVisible && (

--- a/apps/readest-app/src/components/Button.tsx
+++ b/apps/readest-app/src/components/Button.tsx
@@ -15,7 +15,10 @@ const Button: React.FC<ButtonProps> = ({ icon, onClick, disabled = false, label,
   return (
     <button
       className={clsx(
-        'btn btn-ghost h-8 min-h-8 w-8 p-0',
+        // 32px of icon is below the 44px mobile touch target (DESIGN.md), and
+        // in the reader bars a miss falls through to the book and turns the
+        // page (#5401), so every one of these carries the halo.
+        'touch-target btn btn-ghost h-8 min-h-8 w-8 p-0',
         appService?.isMobileApp && 'hover:bg-transparent',
         disabled && 'cursor-default !bg-transparent opacity-50',
         className,

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -478,6 +478,15 @@ foliate-fxl {
   inset: -8px;
 }
 
+/* The desktop trio sits 8px apart, so -8px is the widest halo that still tiles
+   exactly — any more and a button would swallow its neighbor's edge. When
+   close is rendered alone (the reader header on mobile: minimize and maximize
+   need a window bar) there is no neighbor, so it takes the full 44px target
+   the tap deserves (#5401). */
+.window-button:only-child::before {
+  inset: -10px;
+}
+
 input[type='range'].slider-input {
   -webkit-appearance: none;
   appearance: none;


### PR DESCRIPTION
Closes #5401.

## The report

On a Boox Tab Mini C (7.8" color e-ink Android tablet) the reader's top bar is "nearly impossible to tap ... especially the close button", and tapping the X turns the page instead of closing the book.

## What is actually happening

Reproduced by forcing a connected Android device to the Tab Mini C's geometry (`wm size 1404x1872`, `wm density 320` -> 702x936 CSS px at dpr 2, matching the tablet) and probing the real WebView hit test. The bar is 44px tall, but its controls claim much less than that:

| control | icon | effective hit box |
| --- | --- | --- |
| Toggle Sidebar / Go to Library / Bookmark / Translation / Font & Layout / Notebook | 32x32 | **32x32** |
| Quick Action, View Options (dropdowns, already `touch-target`) | 32x32 | 54x54 |
| **Close Book** | 24x24 | **40x40** |

Two of nine controls clear the 44px minimum [DESIGN.md](https://github.com/readest/readest/blob/main/apps/readest-app/DESIGN.md#L728-L730) asks for on mobile, and the close button, the one the reporter singles out, is the smallest thing in the bar.

The page turn is the second half of it. A tap 3.5px below the bar resolves to `foliate-view`, and tracing it live shows why the reporter reads that as a page turn:

- first miss posts `iframe-single-click`, which only dismisses the toolbar (`renderer.start` stays 8424)
- the next tap flips the page (8424 -> 9126)

So a near miss looks like "the button did nothing", and the retry turns the page. On e-ink, where the refresh lag hides the dismissal, the two blur into one.

## The fix

Uses the `touch-target` idiom the project already ships for exactly this.

- **`src/components/Button.tsx`** - add `touch-target` to the shared reader icon button. It has 8 call sites, all reader chrome, so this covers the six undersized header controls and the footer bar's in one place.
- **`src/app/reader/components/HeaderBar.tsx`** - `h-full` on the start-tools scroller. `overflow-x-auto` clips vertically too, so shrink-wrapped to the 32px icons it cut those halos straight back down to 32px.
- **`src/styles/globals.css`** - a lone `.window-button` gets a -10px halo, exactly 44x44. Scoped to `:only-child` on purpose: the desktop trio sits 8px apart, where -8px is the widest halo that still tiles exactly, so a blanket bump would make each button swallow its neighbor's edge.

After (same device, same geometry): every control is at least 44px tall, and the close button is a full 44x44.

## Tests

New `src/__tests__/android/header-touch-targets.android.test.ts` measures each control by walking `elementFromPoint` outward from its center, so it sees pseudo-element halos, overlapping neighbors and clipping ancestors the way a finger does. Hit testing is what jsdom cannot model, so this follows the #5429 precedent of asserting on real hardware instead of mocks.

It fails on the released build with exactly the sizes in the table above, and it guards both directions: controls must reach 44px, and no control may end up smaller than its own icon (a halo must not swallow a neighbor).

`pnpm test`, `pnpm lint` and `pnpm format:check` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
