### PR TITLE
fix(library): release parsed book documents after import, closes #5387

### DIFF
--- a/apps/readest-app/src/__tests__/services/import-bookdoc-destroy.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-bookdoc-destroy.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Book } from '@/types/book';
+
+const mockOpen = vi.hoisted(() => vi.fn());
+const mockPartialMD5 = vi.hoisted(() => vi.fn());
+
+vi.mock('@/utils/md5', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/md5')>('@/utils/md5');
+  return { ...actual, partialMD5: mockPartialMD5 };
+});
+
+vi.mock('@/libs/document', async () => {
+  const actual = await vi.importActual<typeof import('@/libs/document')>('@/libs/document');
+  class MockDocumentLoader {
+    open() {
+      return mockOpen();
+    }
+  }
+  return { ...actual, DocumentLoader: MockDocumentLoader };
+});
+
+vi.mock('@/utils/txt', () => ({ TxtToEpubConverter: vi.fn() }));
+vi.mock('@/utils/svg', () => ({ svg2png: vi.fn() }));
+vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }));
+vi.mock('@/libs/storage', () => ({
+  downloadFile: vi.fn(),
+  uploadFile: vi.fn(),
+  deleteFile: vi.fn(),
+  createProgressHandler: vi.fn(),
+  batchGetDownloadUrls: vi.fn(),
+}));
+
+import { BaseAppService } from '@/services/appService';
+import { refreshBookMetadata } from '@/services/bookService';
+
+class TestAppService extends BaseAppService {
+  protected fs = {
+    openFile: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    copyFile: vi.fn(),
+    removeFile: vi.fn(),
+    readDir: vi.fn(),
+    createDir: vi.fn(),
+    removeDir: vi.fn(),
+    exists: vi.fn(),
+    stats: vi.fn(),
+    resolvePath: vi.fn(),
+    getURL: vi.fn(),
+    getBlobURL: vi.fn().mockResolvedValue(''),
+    getImageURL: vi.fn(),
+    getPrefix: vi.fn(),
+  };
+
+  protected resolvePath() {
+    return { baseDir: 0, basePrefix: async () => '', fp: '', base: 'Books' as const };
+  }
+
+  async init() {}
+  async setCustomRootDir() {}
+  async selectDirectory() {
+    return '';
+  }
+  async selectFiles() {
+    return [];
+  }
+  async saveFile() {
+    return false;
+  }
+  async saveImageToGallery() {
+    return false;
+  }
+  async ask() {
+    return false;
+  }
+  async openDatabase() {
+    return {} as ReturnType<BaseAppService['openDatabase']>;
+  }
+  async createWindow() {}
+  async getCacheDir() {
+    return '';
+  }
+  async clearWebviewCache() {}
+  async showNotification() {}
+
+  getFs() {
+    return this.fs;
+  }
+}
+
+const TEST_METADATA = {
+  title: 'Test Book',
+  author: 'Test Author',
+  language: 'en',
+  identifier: 'isbn-123',
+};
+
+// Importing a PDF opens a full pdf.js document (worker + parsed structures +
+// retained range chunks). Dropping the reference does NOT release it — the
+// dedicated worker survives GC — so importBook must call destroy() or batch
+// imports accumulate ~60 MB per PDF until the WebView renderer OOMs (#5387).
+describe('importBook BookDoc lifecycle', () => {
+  let service: TestAppService;
+  let mockDestroy: ReturnType<typeof vi.fn>;
+
+  const setupMockBookDoc = () => {
+    mockDestroy = vi.fn();
+    const bookDoc = {
+      metadata: TEST_METADATA,
+      getCover: vi.fn().mockResolvedValue(null),
+      destroy: mockDestroy,
+    };
+    mockOpen.mockResolvedValue({ book: bookDoc, format: 'PDF' });
+    return bookDoc;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TestAppService();
+    const fs = service.getFs();
+    fs.exists.mockResolvedValue(false);
+    fs.createDir.mockResolvedValue(undefined);
+    fs.writeFile.mockResolvedValue(undefined);
+    fs.removeDir.mockResolvedValue(undefined);
+    fs.readFile.mockResolvedValue('{}');
+    mockPartialMD5.mockResolvedValue('hash-abc');
+  });
+
+  it('destroys the loaded BookDoc after a successful import', async () => {
+    setupMockBookDoc();
+    const books: Book[] = [];
+    const mockFile = new File(['pdf content'], 'test.pdf', { type: 'application/pdf' });
+
+    const result = await service.importBook(mockFile, books);
+
+    expect(result).not.toBeNull();
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys the loaded BookDoc when the import fails after opening', async () => {
+    setupMockBookDoc();
+    service.getFs().createDir.mockRejectedValue(new Error('disk full'));
+    const mockFile = new File(['pdf content'], 'test.pdf', { type: 'application/pdf' });
+
+    await expect(service.importBook(mockFile, [])).rejects.toThrow();
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('imports normally when the BookDoc has no destroy method', async () => {
+    mockOpen.mockResolvedValue({
+      book: { metadata: TEST_METADATA, getCover: vi.fn().mockResolvedValue(null) },
+      format: 'EPUB',
+    });
+    const books: Book[] = [];
+    const mockFile = new File(['epub content'], 'test.epub', { type: 'application/epub+zip' });
+
+    const result = await service.importBook(mockFile, books);
+
+    expect(result).not.toBeNull();
+    expect(books.length).toBe(1);
+  });
+
+  it('destroys the BookDoc opened by refreshBookMetadata', async () => {
+    const bookDoc = setupMockBookDoc();
+    const fs = service.getFs();
+    fs.exists.mockResolvedValue(true);
+    fs.readFile.mockResolvedValue(new ArrayBuffer(8));
+    const book: Book = {
+      hash: 'hash-abc',
+      format: 'PDF',
+      title: 'Test Book',
+      sourceTitle: 'Test Book',
+      author: 'Test Author',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      deletedAt: null,
+    };
+
+    // loadBookContent goes through appService.loadBookContent → fs.openFile
+    fs.openFile.mockResolvedValue(new File(['pdf content'], 'test.pdf'));
+
+    const refreshed = await refreshBookMetadata(service.getFs() as never, book);
+
+    expect(refreshed).toBe(true);
+    expect(bookDoc.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/readest-app/src/libs/document.ts
+++ b/apps/readest-app/src/libs/document.ts
@@ -104,6 +104,10 @@ export interface BookDoc {
   transformTarget?: EventTarget;
   splitTOCHref(href: string): Array<string | number>;
   getCover(): Promise<Blob | null>;
+  // Formats backed by live parser state must be released explicitly: a PDF
+  // book holds a pdf.js document whose dedicated worker survives GC, so
+  // dropping the reference leaks the whole parsed file (#5387).
+  destroy?(): void | Promise<void>;
 }
 
 export const EXTS: Record<BookFormat, string> = {

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -409,11 +409,11 @@ export async function importBook(
   } = options;
   const isPseStream = typeof file === 'string' && isPseStreamFileName(file);
 
+  let loadedBook: BookDoc | undefined;
+  let fileobj: File | undefined;
   try {
-    let loadedBook: BookDoc;
     let format: BookFormat;
     let filename: string;
-    let fileobj: File | undefined;
     // When the Rust EPUB parser succeeds it gives us the partialMD5 for free,
     // so we can short-circuit the JS hashing pass below.
     let nativeHash: string | undefined;
@@ -729,15 +729,25 @@ export async function importBook(
       }
     }
     book.coverImageUrl = await generateCoverImageUrlFn(book);
-    const f = file as ClosableFile;
-    if (f && f.close) {
-      await f.close();
-    }
 
     return existingBook || book;
   } catch (error) {
     console.error('Error importing book:', error);
     throw error;
+  } finally {
+    // Release the parsed document (a PDF leaks its pdf.js worker otherwise,
+    // ~60 MB per imported file — #5387) and the opened file handle.
+    try {
+      await loadedBook?.destroy?.();
+    } catch (error) {
+      console.warn('Error destroying book document:', error);
+    }
+    const f = fileobj as ClosableFile | undefined;
+    if (f?.close) {
+      try {
+        await f.close();
+      } catch {}
+    }
   }
 }
 
@@ -870,12 +880,19 @@ export async function fetchBookDetails(
     await downloadBookFn(book);
   }
   const { file } = await loadBookContent(fs, book);
-  const bookDoc = (await new DocumentLoader(file).open()).book;
-  const f = file as ClosableFile;
-  if (f && f.close) {
-    await f.close();
+  let bookDoc: BookDoc | undefined;
+  try {
+    bookDoc = (await new DocumentLoader(file).open()).book;
+    return bookDoc.metadata;
+  } finally {
+    try {
+      await bookDoc?.destroy?.();
+    } catch {}
+    const f = file as ClosableFile;
+    if (f && f.close) {
+      await f.close();
+    }
   }
-  return bookDoc.metadata;
 }
 
 /**
@@ -886,32 +903,43 @@ export async function fetchBookDetails(
  */
 export async function refreshBookMetadata(fs: FileSystem, book: Book): Promise<boolean> {
   const { file } = await loadBookContent(fs, book);
-  const { book: bookDoc } = await new DocumentLoader(file).open();
-  if (!bookDoc) return false;
+  let bookDoc: BookDoc | undefined;
+  try {
+    ({ book: bookDoc } = await new DocumentLoader(file).open());
+    if (!bookDoc) return false;
 
-  book.metadata = bookDoc.metadata;
-  // PDF metaHash is salted with the original import filename (issue #5411),
-  // which is lost after import — keep the value stamped at import time.
-  if (book.format !== 'PDF' || !book.metaHash) {
-    book.metaHash = getMetadataHash(bookDoc.metadata);
-  }
-  const primaryLanguage = getPrimaryLanguage(bookDoc.metadata.language);
-  if (primaryLanguage) {
-    book.primaryLanguage = primaryLanguage;
-  }
+    book.metadata = bookDoc.metadata;
+    // PDF metaHash is salted with the original import filename (issue #5411),
+    // which is lost after import — keep the value stamped at import time.
+    if (book.format !== 'PDF' || !book.metaHash) {
+      book.metaHash = getMetadataHash(bookDoc.metadata);
+    }
+    const primaryLanguage = getPrimaryLanguage(bookDoc.metadata.language);
+    if (primaryLanguage) {
+      book.primaryLanguage = primaryLanguage;
+    }
 
-  // Update series info from metadata
-  if (book.metadata?.belongsTo?.series) {
-    const belongsTo = book.metadata.belongsTo.series;
-    const series = Array.isArray(belongsTo) ? belongsTo[0] : belongsTo;
-    if (series) {
-      book.metadata.series = formatTitle(series.name);
-      book.metadata.seriesIndex = parseFloat(series.position || '0');
-      if (series.total) book.metadata.seriesTotal = parseInt(series.total, 10);
+    // Update series info from metadata
+    if (book.metadata?.belongsTo?.series) {
+      const belongsTo = book.metadata.belongsTo.series;
+      const series = Array.isArray(belongsTo) ? belongsTo[0] : belongsTo;
+      if (series) {
+        book.metadata.series = formatTitle(series.name);
+        book.metadata.seriesIndex = parseFloat(series.position || '0');
+        if (series.total) book.metadata.seriesTotal = parseInt(series.total, 10);
+      }
+    }
+
+    return true;
+  } finally {
+    try {
+      await bookDoc?.destroy?.();
+    } catch {}
+    const f = file as ClosableFile;
+    if (f && f.close) {
+      await f.close();
     }
   }
-
-  return true;
 }
 
 export async function exportBook(


### PR DESCRIPTION
## Problem

Issue #5387: importing a batch of PDF files crashes the app on Android. The attached log shows the WebView renderer (`CrRendererMain`, 32-bit on the reporter's OPPO) dying with a Chromium OOM trap, after which crashpad aborts the host app because the renderer crash is unhandled.

## Root cause

Importing a PDF runs the full pdf.js parse (`getDocument` + `getMetadata` + `getOutline` + first-page cover render) but `importBook` never released the document. Its only cleanup tried `.close()` on the original `file` argument, a string path, so it was dead code. Dropping the reference frees nothing: a pdf.js document owns a dedicated worker, and dedicated workers survive GC. Every imported PDF leaked a live worker holding the parsed file (~60 MB for a 67 MB PDF). With the library page importing 4 files concurrently, a batch of N PDFs grows the renderer by roughly N x 60 MB until it OOMs.

The #3470 fix (`MAX_CONCURRENT_RANGES = 6`) is unrelated collateral: it bounds in-flight range reads to protect the native heap, but cannot bound what the worker retains, and cannot help when whole documents leak.

## Fix

- Declare `destroy?()` on the `BookDoc` interface.
- `importBook` destroys the loaded BookDoc and closes the opened `fileobj` in a `finally` block, covering error paths too.
- Same treatment for `refreshBookMetadata` and `fetchBookDetails`, which repeated the open-and-drop pattern.
- No-op for formats without `destroy` (EPUB, native bridges, PSE streams).

## Verification

On-device on a Xiaomi 13 against release 0.11.20, replaying the exact import code path via CDP with a 67 MB / 970-page PDF:

| | Renderer PSS over 6 imports | Leaked workers |
|---|---|---|
| Without destroy (current behavior) | 174 -> 225 -> 291 -> 359 -> 419 -> 476 -> 533 MB | 1 per import |
| With destroy | flat ~174 MB | 0 |

Forced GC between iterations reclaims nothing without destroy. Import time is unchanged (~5.1 s per file in both phases).

- New tests: `src/__tests__/services/import-bookdoc-destroy.test.ts` (written failing first)
- `pnpm test`: 8166 passed
- `pnpm lint`, `pnpm format:check`: clean

Closes #5387.

Follow-up (separate scope): handle `onRenderProcessGone` natively so a renderer death recovers instead of killing the app, as the reporter suggested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)