### PR TITLE
fix(web): make CORS preflight responses cacheable for authenticated requests

### DIFF
--- a/apps/readest-app/src/__tests__/middleware.test.ts
+++ b/apps/readest-app/src/__tests__/middleware.test.ts
@@ -7,6 +7,36 @@ const coep = (path: string) =>
     'Cross-Origin-Embedder-Policy',
   );
 
+describe('middleware CORS preflight', () => {
+  const preflight = (requestedHeaders?: string) =>
+    middleware(
+      new NextRequest('https://web.readest.com/api/sync', {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'http://tauri.localhost',
+          'access-control-request-method': 'POST',
+          ...(requestedHeaders && { 'access-control-request-headers': requestedHeaders }),
+        },
+      }),
+    );
+
+  it('echoes the requested headers instead of a wildcard so the preflight cache covers Authorization', () => {
+    // The Fetch spec excludes Authorization from wildcard matching in the
+    // preflight cache, so `Allow-Headers: *` forces a fresh OPTIONS round trip
+    // before every authenticated API call despite Max-Age (readest-web was
+    // serving ~4M preflights/day because of this).
+    const res = preflight('authorization,content-type');
+    expect(res.headers.get('Access-Control-Allow-Headers')).toBe('authorization,content-type');
+    expect(res.headers.get('Vary')).toContain('Access-Control-Request-Headers');
+    expect(res.headers.get('Access-Control-Max-Age')).toBe('86400');
+  });
+
+  it('allows Authorization and Content-Type when the preflight requests no headers', () => {
+    const res = preflight();
+    expect(res.headers.get('Access-Control-Allow-Headers')).toBe('Authorization, Content-Type');
+  });
+});
+
 describe('middleware cross-origin isolation headers', () => {
   it('serves COEP credentialless on the /s share landing so the R2 cover <img> loads', () => {
     // The cover redirects to a cross-origin R2 URL that can't carry a CORP

--- a/apps/readest-app/src/middleware.ts
+++ b/apps/readest-app/src/middleware.ts
@@ -11,7 +11,6 @@ const allowedOrigins = [
 
 const corsOptions = {
   'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-  'Access-Control-Allow-Headers': '*',
   'Access-Control-Max-Age': '86400',
 };
 
@@ -23,8 +22,15 @@ export function middleware(request: NextRequest) {
     const isAllowedOrigin = allowedOrigins.includes(origin);
 
     if (request.method === 'OPTIONS') {
+      // Echo the requested headers rather than answering `*`: the Fetch spec
+      // excludes `Authorization` from wildcard matching in the browser's
+      // preflight cache, so a wildcard answer forces a fresh OPTIONS round
+      // trip before every authenticated API call despite Max-Age.
+      const requestedHeaders = request.headers.get('access-control-request-headers');
       const preflightHeaders = new Headers({
         ...corsOptions,
+        'Access-Control-Allow-Headers': requestedHeaders || 'Authorization, Content-Type',
+        Vary: 'Origin, Access-Control-Request-Headers',
         ...(isAllowedOrigin && { 'Access-Control-Allow-Origin': origin }),
       });
 


### PR DESCRIPTION
### Problem

A 60s live tail of the readest-web worker (`wrangler tail readest-web`) showed **43% of all invocations are CORS preflight OPTIONS requests**, almost entirely from our own Tauri clients calling `/api/sync`, `/api/sync/replicas`, and `/api/send/inbox/claim`.

The preflights should be cached: the middleware sends `Access-Control-Max-Age: 86400`. But it also answers `Access-Control-Allow-Headers: *`, and the [Fetch spec excludes `Authorization` from wildcard matching in the preflight cache](https://fetch.spec.whatwg.org/#concept-cache) — so for authenticated requests the cached entry never satisfies the next call, and the browser re-preflights **every single API request**. Observed proof: a single client sent 10 OPTIONS + 9 POSTs to the identical `/api/sync` URL within 60 seconds.

### Fix

Echo `Access-Control-Request-Headers` back in the preflight response (falling back to `Authorization, Content-Type` when absent), and add the matching `Vary: Origin, Access-Control-Request-Headers`. With an explicit header list the preflight cache works, so browsers send one OPTIONS per URL per cache window (Chromium caps at 2h, WebKit at 10min) instead of one per request.

Also dropped `Access-Control-Allow-Headers` from actual (non-OPTIONS) responses — browsers only read it from preflight responses.

Expected impact: eliminates the stable-URL preflights, roughly 30% of total worker invocations. GET pulls with a changing `since=` query param still preflight (the cache is keyed by exact URL); that can be a follow-up.

### Verification

- New tests in `src/__tests__/middleware.test.ts` (written first, watched fail against the wildcard): echo case + no-requested-headers fallback
- Full suite passes; `pnpm lint` and `pnpm format:check` clean
- Post-deploy check: re-run the 60s `wrangler tail` and confirm the OPTIONS share collapses from ~43%

🤖 Generated with [Claude Code](https://claude.com/claude-code)