### PR TITLE
feat(library): add bulk Download to the select-mode action bar (#5244)

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2171,5 +2171,17 @@
   "A machine-readable file that Readest can import back into any book.": "ملف قابل للقراءة آليًا يمكن لريديست استيراده مرة أخرى إلى أي كتاب.",
   "Import highlights and notes exported from Readest or another reading app.": "استورد التظليلات والملاحظات المصدَّرة من ريديست أو من تطبيق قراءة آخر.",
   "Readest": "ريديست",
-  "Readest annotations file (.json)": "ملف تعليقات ريديست (.json)"
+  "Readest annotations file (.json)": "ملف تعليقات ريديست (.json)",
+  "Downloading {{count}} book(s)_one": "جارٍ تنزيل كتاب واحد",
+  "Downloading {{count}} book(s)_other": "جارٍ تنزيل {{count}} كتب",
+  "Downloading {{count}} book(s)_zero": "جارٍ تنزيل الكتب",
+  "Downloading {{count}} book(s)_two": "جارٍ تنزيل كتابين",
+  "Downloading {{count}} book(s)_few": "جارٍ تنزيل {{count}} كتب",
+  "Downloading {{count}} book(s)_many": "جارٍ تنزيل {{count}} كتاباً",
+  "Failed to download {{count}} book(s)_one": "فشل تنزيل كتاب واحد",
+  "Failed to download {{count}} book(s)_other": "فشل تنزيل {{count}} كتب",
+  "Failed to download {{count}} book(s)_zero": "فشل تنزيل الكتب",
+  "Failed to download {{count}} book(s)_two": "فشل تنزيل كتابين",
+  "Failed to download {{count}} book(s)_few": "فشل تنزيل {{count}} كتب",
+  "Failed to download {{count}} book(s)_many": "فشل تنزيل {{count}} كتاباً"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1995,5 +1995,9 @@
   "A machine-readable file that Readest can import back into any book.": "একটি মেশিন-পঠনযোগ্য ফাইল যা রিডেস্ট যেকোনো বইয়ে আবার ইম্পোর্ট করতে পারে।",
   "Import highlights and notes exported from Readest or another reading app.": "রিডেস্ট বা অন্য কোনো পড়ার অ্যাপ থেকে এক্সপোর্ট করা হাইলাইট ও নোট ইম্পোর্ট করুন।",
   "Readest": "রিডেস্ট",
-  "Readest annotations file (.json)": "রিডেস্ট টীকা ফাইল (.json)"
+  "Readest annotations file (.json)": "রিডেস্ট টীকা ফাইল (.json)",
+  "Downloading {{count}} book(s)_one": "{{count}} টি বই ডাউনলোড হচ্ছে",
+  "Downloading {{count}} book(s)_other": "{{count}} টি বই ডাউনলোড হচ্ছে",
+  "Failed to download {{count}} book(s)_one": "{{count}} টি বই ডাউনলোড ব্যর্থ",
+  "Failed to download {{count}} book(s)_other": "{{count}} টি বই ডাউনলোড ব্যর্থ"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1951,5 +1951,7 @@
   "A machine-readable file that Readest can import back into any book.": "Readest ཡིས་དེབ་གང་རུང་ནང་ཡང་བསྐྱར་ནང་འདྲེན་བྱེད་ཐུབ་པའི་འཕྲུལ་ཆས་ཀློག་རུང་བའི་ཡིག་ཆ་ཞིག",
   "Import highlights and notes exported from Readest or another reading app.": "Readest སམ་ཀློག་པའི་མཉེན་ཆས་གཞན་ནས་ཕྱིར་འདོན་བྱས་པའི་གསལ་སྟོན་དང་མཆན་འགྲེལ་ནང་འདྲེན་བྱེད།",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest མཆན་འགྲེལ་ཡིག་ཆ (.json)"
+  "Readest annotations file (.json)": "Readest མཆན་འགྲེལ་ཡིག་ཆ (.json)",
+  "Downloading {{count}} book(s)_other": "དཔེ་དེབ་ {{count}} ཕབ་ལེན་བྱེད་བཞིན་པ།",
+  "Failed to download {{count}} book(s)_other": "དཔེ་དེབ་ {{count}} ཕབ་ལེན་བྱས་མ་ཐུབ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1995,5 +1995,9 @@
   "A machine-readable file that Readest can import back into any book.": "Eine maschinenlesbare Datei, die Readest wieder in jedes Buch importieren kann.",
   "Import highlights and notes exported from Readest or another reading app.": "Importieren Sie Hervorhebungen und Notizen, die aus Readest oder einer anderen Leseanwendung exportiert wurden.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest-Anmerkungsdatei (.json)"
+  "Readest annotations file (.json)": "Readest-Anmerkungsdatei (.json)",
+  "Downloading {{count}} book(s)_one": "{{count}} Buch wird heruntergeladen",
+  "Downloading {{count}} book(s)_other": "{{count}} Bücher werden heruntergeladen",
+  "Failed to download {{count}} book(s)_one": "Fehler beim Herunterladen von {{count}} Buch",
+  "Failed to download {{count}} book(s)_other": "Fehler beim Herunterladen von {{count}} Büchern"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1995,5 +1995,9 @@
   "A machine-readable file that Readest can import back into any book.": "Ένα αρχείο αναγνώσιμο από μηχανή, το οποίο το Readest μπορεί να εισαγάγει ξανά σε οποιοδήποτε βιβλίο.",
   "Import highlights and notes exported from Readest or another reading app.": "Εισαγωγή επισημάνσεων και σημειώσεων που εξήχθησαν από το Readest ή από άλλη εφαρμογή ανάγνωσης.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Αρχείο σχολίων Readest (.json)"
+  "Readest annotations file (.json)": "Αρχείο σχολίων Readest (.json)",
+  "Downloading {{count}} book(s)_one": "Λήψη {{count}} βιβλίου",
+  "Downloading {{count}} book(s)_other": "Λήψη {{count}} βιβλίων",
+  "Failed to download {{count}} book(s)_one": "Αποτυχία λήψης {{count}} βιβλίου",
+  "Failed to download {{count}} book(s)_other": "Αποτυχία λήψης {{count}} βιβλίων"
 }

--- a/apps/readest-app/public/locales/en/translation.json
+++ b/apps/readest-app/public/locales/en/translation.json
@@ -94,5 +94,9 @@
   "{{count}} books unavailable_one": "{{count}} book unavailable",
   "{{count}} books unavailable_other": "{{count}} books unavailable",
   "{{count}}+ results_one": "{{count}}+ result",
-  "{{count}}+ results_other": "{{count}}+ results"
+  "{{count}}+ results_other": "{{count}}+ results",
+  "Downloading {{count}} book(s)_one": "Downloading {{count}} book",
+  "Downloading {{count}} book(s)_other": "Downloading {{count}} books",
+  "Failed to download {{count}} book(s)_one": "Failed to download {{count}} book",
+  "Failed to download {{count}} book(s)_other": "Failed to download {{count}} books"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2039,5 +2039,11 @@
   "A machine-readable file that Readest can import back into any book.": "Un archivo legible por máquina que Readest puede volver a importar en cualquier libro.",
   "Import highlights and notes exported from Readest or another reading app.": "Importa subrayados y notas exportados desde Readest u otra aplicación de lectura.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Archivo de anotaciones de Readest (.json)"
+  "Readest annotations file (.json)": "Archivo de anotaciones de Readest (.json)",
+  "Downloading {{count}} book(s)_one": "Descargando {{count}} libro",
+  "Downloading {{count}} book(s)_other": "Descargando {{count}} libros",
+  "Downloading {{count}} book(s)_many": "Descargando {{count}} libros",
+  "Failed to download {{count}} book(s)_one": "Error al descargar {{count}} libro",
+  "Failed to download {{count}} book(s)_other": "Error al descargar {{count}} libros",
+  "Failed to download {{count}} book(s)_many": "Error al descargar {{count}} libros"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1995,5 +1995,9 @@
   "A machine-readable file that Readest can import back into any book.": "فایلی ماشین‌خوان که Readest می‌تواند دوباره در هر کتابی وارد کند.",
   "Import highlights and notes exported from Readest or another reading app.": "هایلایت‌ها و یادداشت‌های خروجی‌گرفته‌شده از Readest یا برنامهٔ مطالعهٔ دیگر را وارد کنید.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "فایل یادداشت‌های Readest ‏(.json)"
+  "Readest annotations file (.json)": "فایل یادداشت‌های Readest ‏(.json)",
+  "Downloading {{count}} book(s)_one": "در حال دانلود {{count}} کتاب",
+  "Downloading {{count}} book(s)_other": "در حال دانلود {{count}} کتاب",
+  "Failed to download {{count}} book(s)_one": "دانلود {{count}} کتاب ناموفق بود",
+  "Failed to download {{count}} book(s)_other": "دانلود {{count}} کتاب ناموفق بود"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2039,5 +2039,11 @@
   "A machine-readable file that Readest can import back into any book.": "Un fichier lisible par machine que Readest peut réimporter dans n'importe quel livre.",
   "Import highlights and notes exported from Readest or another reading app.": "Importez les surlignages et les notes exportés depuis Readest ou une autre application de lecture.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Fichier d'annotations Readest (.json)"
+  "Readest annotations file (.json)": "Fichier d'annotations Readest (.json)",
+  "Downloading {{count}} book(s)_one": "Téléchargement de {{count}} livre",
+  "Downloading {{count}} book(s)_other": "Téléchargement de {{count}} livres",
+  "Downloading {{count}} book(s)_many": "Téléchargement de {{count}} livres",
+  "Failed to download {{count}} book(s)_one": "Échec du téléchargement de {{count}} livre",
+  "Failed to download {{count}} book(s)_other": "Échec du téléchargement de {{count}} livres",
+  "Failed to download {{count}} book(s)_many": "Échec du téléchargement de {{count}} livres"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2039,5 +2039,11 @@
   "A machine-readable file that Readest can import back into any book.": "קובץ קריא למכונה ש-Readest יכולה לייבא בחזרה לכל ספר.",
   "Import highlights and notes exported from Readest or another reading app.": "ייבא הדגשות והערות שיוצאו מ-Readest או מאפליקציית קריאה אחרת.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "קובץ הערות של Readest ‏(.json)"
+  "Readest annotations file (.json)": "קובץ הערות של Readest ‏(.json)",
+  "Downloading {{count}} book(s)_one": "מוריד ספר אחד",
+  "Downloading {{count}} book(s)_two": "מוריד {{count}} ספרים",
+  "Downloading {{count}} book(s)_other": "מוריד {{count}} ספרים",
+  "Failed to download {{count}} book(s)_one": "הורדת ספר אחד נכשלה",
+  "Failed to download {{count}} book(s)_two": "הורדת {{count}} ספרים נכשלה",
+  "Failed to download {{count}} book(s)_other": "הורדת {{count}} ספרים נכשלה"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1995,5 +1995,9 @@
   "A machine-readable file that Readest can import back into any book.": "एक मशीन-पठनीय फ़ाइल जिसे Readest किसी भी पुस्तक में वापस आयात कर सकता है।",
   "Import highlights and notes exported from Readest or another reading app.": "Readest या किसी अन्य रीडिंग ऐप से निर्यात किए गए हाइलाइट और नोट्स आयात करें।",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest एनोटेशन फ़ाइल (.json)"
+  "Readest annotations file (.json)": "Readest एनोटेशन फ़ाइल (.json)",
+  "Downloading {{count}} book(s)_one": "{{count}} किताब डाउनलोड हो रही है",
+  "Downloading {{count}} book(s)_other": "{{count}} किताबें डाउनलोड हो रही हैं",
+  "Failed to download {{count}} book(s)_one": "{{count}} किताब डाउनलोड करने में विफल",
+  "Failed to download {{count}} book(s)_other": "{{count}} किताबें डाउनलोड करने में विफल"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1995,5 +1995,9 @@
   "A machine-readable file that Readest can import back into any book.": "Géppel olvasható fájl, amelyet a Readest bármelyik könyvbe visszaimportálhat.",
   "Import highlights and notes exported from Readest or another reading app.": "Importálja a Readestből vagy másik olvasóalkalmazásból exportált kiemeléseket és jegyzeteket.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest jegyzetfájl (.json)"
+  "Readest annotations file (.json)": "Readest jegyzetfájl (.json)",
+  "Downloading {{count}} book(s)_one": "{{count}} könyv letöltése",
+  "Downloading {{count}} book(s)_other": "{{count}} könyv letöltése",
+  "Failed to download {{count}} book(s)_one": "{{count}} könyv letöltése sikertelen",
+  "Failed to download {{count}} book(s)_other": "{{count}} könyv letöltése sikertelen"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1951,5 +1951,7 @@
   "A machine-readable file that Readest can import back into any book.": "File yang dapat dibaca mesin dan bisa diimpor kembali oleh Readest ke buku mana pun.",
   "Import highlights and notes exported from Readest or another reading app.": "Impor sorotan dan catatan yang diekspor dari Readest atau aplikasi baca lain.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "File anotasi Readest (.json)"
+  "Readest annotations file (.json)": "File anotasi Readest (.json)",
+  "Downloading {{count}} book(s)_other": "Mengunduh {{count}} buku",
+  "Failed to download {{count}} book(s)_other": "Gagal mengunduh {{count}} buku"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2039,5 +2039,11 @@
   "A machine-readable file that Readest can import back into any book.": "Un file leggibile dalla macchina che Readest può reimportare in qualsiasi libro.",
   "Import highlights and notes exported from Readest or another reading app.": "Importa evidenziazioni e note esportate da Readest o da un'altra app di lettura.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "File di annotazioni Readest (.json)"
+  "Readest annotations file (.json)": "File di annotazioni Readest (.json)",
+  "Downloading {{count}} book(s)_one": "Download di {{count}} libro in corso",
+  "Downloading {{count}} book(s)_other": "Download di {{count}} libri in corso",
+  "Downloading {{count}} book(s)_many": "Download di {{count}} libri in corso",
+  "Failed to download {{count}} book(s)_one": "Download di {{count}} libro non riuscito",
+  "Failed to download {{count}} book(s)_other": "Download di {{count}} libri non riuscito",
+  "Failed to download {{count}} book(s)_many": "Download di {{count}} libri non riuscito"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1951,5 +1951,7 @@
   "A machine-readable file that Readest can import back into any book.": "Readest がどの本にも再インポートできる機械可読ファイルです。",
   "Import highlights and notes exported from Readest or another reading app.": "Readest または他の読書アプリからエクスポートしたハイライトとメモをインポートします。",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest の注釈ファイル (.json)"
+  "Readest annotations file (.json)": "Readest の注釈ファイル (.json)",
+  "Downloading {{count}} book(s)_other": "{{count}} 冊の書籍をダウンロードしています",
+  "Failed to download {{count}} book(s)_other": "{{count}} 冊の書籍のダウンロードに失敗しました"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1951,5 +1951,7 @@
   "A machine-readable file that Readest can import back into any book.": "Readest가 어떤 책으로도 다시 가져올 수 있는 기계 판독형 파일입니다.",
   "Import highlights and notes exported from Readest or another reading app.": "Readest 또는 다른 읽기 앱에서 내보낸 하이라이트와 메모를 가져옵니다.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest 주석 파일 (.json)"
+  "Readest annotations file (.json)": "Readest 주석 파일 (.json)",
+  "Downloading {{count}} book(s)_other": "책 {{count}}권 다운로드 중",
+  "Failed to download {{count}} book(s)_other": "책 {{count}}권 다운로드 실패"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1951,5 +1951,7 @@
   "A machine-readable file that Readest can import back into any book.": "Fail boleh baca mesin yang boleh diimport semula oleh Readest ke dalam mana-mana buku.",
   "Import highlights and notes exported from Readest or another reading app.": "Import sorotan dan nota yang dieksport daripada Readest atau apl bacaan lain.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Fail anotasi Readest (.json)"
+  "Readest annotations file (.json)": "Fail anotasi Readest (.json)",
+  "Downloading {{count}} book(s)_other": "Memuat turun {{count}} buku",
+  "Failed to download {{count}} book(s)_other": "Gagal memuat turun {{count}} buku"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1995,5 +1995,9 @@
   "A machine-readable file that Readest can import back into any book.": "Een machineleesbaar bestand dat Readest weer in elk boek kan importeren.",
   "Import highlights and notes exported from Readest or another reading app.": "Importeer markeringen en notities die zijn geëxporteerd uit Readest of een andere leesapp.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest-annotatiebestand (.json)"
+  "Readest annotations file (.json)": "Readest-annotatiebestand (.json)",
+  "Downloading {{count}} book(s)_one": "{{count}} boek wordt gedownload",
+  "Downloading {{count}} book(s)_other": "{{count}} boeken worden gedownload",
+  "Failed to download {{count}} book(s)_one": "Downloaden van {{count}} boek mislukt",
+  "Failed to download {{count}} book(s)_other": "Downloaden van {{count}} boeken mislukt"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2083,5 +2083,13 @@
   "A machine-readable file that Readest can import back into any book.": "Plik odczytywany maszynowo, który Readest może ponownie zaimportować do dowolnej książki.",
   "Import highlights and notes exported from Readest or another reading app.": "Importuj zaznaczenia i notatki wyeksportowane z Readest lub innej aplikacji do czytania.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Plik adnotacji Readest (.json)"
+  "Readest annotations file (.json)": "Plik adnotacji Readest (.json)",
+  "Downloading {{count}} book(s)_one": "Pobieranie {{count}} książki",
+  "Downloading {{count}} book(s)_other": "Pobieranie {{count}} książek",
+  "Downloading {{count}} book(s)_few": "Pobieranie {{count}} książek",
+  "Downloading {{count}} book(s)_many": "Pobieranie {{count}} książek",
+  "Failed to download {{count}} book(s)_one": "Nie udało się pobrać {{count}} książki",
+  "Failed to download {{count}} book(s)_other": "Nie udało się pobrać {{count}} książek",
+  "Failed to download {{count}} book(s)_few": "Nie udało się pobrać {{count}} książek",
+  "Failed to download {{count}} book(s)_many": "Nie udało się pobrać {{count}} książek"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2039,5 +2039,11 @@
   "A machine-readable file that Readest can import back into any book.": "Um arquivo legível por máquina que o Readest pode importar de volta para qualquer livro.",
   "Import highlights and notes exported from Readest or another reading app.": "Importe destaques e notas exportados do Readest ou de outro aplicativo de leitura.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Arquivo de anotações do Readest (.json)"
+  "Readest annotations file (.json)": "Arquivo de anotações do Readest (.json)",
+  "Downloading {{count}} book(s)_one": "Baixando {{count}} livro",
+  "Downloading {{count}} book(s)_many": "Baixando {{count}} livros",
+  "Downloading {{count}} book(s)_other": "Baixando {{count}} livros",
+  "Failed to download {{count}} book(s)_one": "Falha ao baixar {{count}} livro",
+  "Failed to download {{count}} book(s)_many": "Falha ao baixar {{count}} livros",
+  "Failed to download {{count}} book(s)_other": "Falha ao baixar {{count}} livros"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2039,5 +2039,11 @@
   "A machine-readable file that Readest can import back into any book.": "Um ficheiro legível por máquina que o Readest pode importar novamente para qualquer livro.",
   "Import highlights and notes exported from Readest or another reading app.": "Importe destaques e notas exportados do Readest ou de outra aplicação de leitura.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Ficheiro de anotações do Readest (.json)"
+  "Readest annotations file (.json)": "Ficheiro de anotações do Readest (.json)",
+  "Downloading {{count}} book(s)_one": "Baixando {{count}} livro",
+  "Downloading {{count}} book(s)_other": "Baixando {{count}} livros",
+  "Downloading {{count}} book(s)_many": "Baixando {{count}} livros",
+  "Failed to download {{count}} book(s)_one": "Falha ao baixar {{count}} livro",
+  "Failed to download {{count}} book(s)_other": "Falha ao baixar {{count}} livros",
+  "Failed to download {{count}} book(s)_many": "Falha ao baixar {{count}} livros"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2039,5 +2039,11 @@
   "A machine-readable file that Readest can import back into any book.": "Un fișier care poate fi citit de mașină și pe care Readest îl poate importa înapoi în orice carte.",
   "Import highlights and notes exported from Readest or another reading app.": "Importă evidențierile și notele exportate din Readest sau din altă aplicație de citit.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Fișier de adnotări Readest (.json)"
+  "Readest annotations file (.json)": "Fișier de adnotări Readest (.json)",
+  "Downloading {{count}} book(s)_one": "Se descarcă {{count}} carte",
+  "Downloading {{count}} book(s)_few": "Se descarcă {{count}} cărți",
+  "Downloading {{count}} book(s)_other": "Se descarcă {{count}} de cărți",
+  "Failed to download {{count}} book(s)_one": "Nu s-a putut descărca {{count}} carte",
+  "Failed to download {{count}} book(s)_few": "Nu s-au putut descărca {{count}} cărți",
+  "Failed to download {{count}} book(s)_other": "Nu s-au putut descărca {{count}} de cărți"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2083,5 +2083,13 @@
   "A machine-readable file that Readest can import back into any book.": "Машиночитаемый файл, который Readest может импортировать обратно в любую книгу.",
   "Import highlights and notes exported from Readest or another reading app.": "Импортируйте выделения и заметки, экспортированные из Readest или другого приложения для чтения.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Файл аннотаций Readest (.json)"
+  "Readest annotations file (.json)": "Файл аннотаций Readest (.json)",
+  "Downloading {{count}} book(s)_one": "Скачивание {{count}} книги",
+  "Downloading {{count}} book(s)_other": "Скачивание {{count}} книг",
+  "Downloading {{count}} book(s)_few": "Скачивание {{count}} книг",
+  "Downloading {{count}} book(s)_many": "Скачивание {{count}} книг",
+  "Failed to download {{count}} book(s)_one": "Не удалось скачать {{count}} книгу",
+  "Failed to download {{count}} book(s)_other": "Не удалось скачать {{count}} книг",
+  "Failed to download {{count}} book(s)_few": "Не удалось скачать {{count}} книг",
+  "Failed to download {{count}} book(s)_many": "Не удалось скачать {{count}} книг"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1995,5 +1995,9 @@
   "A machine-readable file that Readest can import back into any book.": "Readest හට ඕනෑම පොතකට නැවත ආයාත කළ හැකි යන්ත්‍ර-කියවිය හැකි ගොනුවකි.",
   "Import highlights and notes exported from Readest or another reading app.": "Readest වෙතින් හෝ වෙනත් කියවීමේ යෙදුමකින් නිර්යාත කළ උද්දීපන සහ සටහන් ආයාත කරන්න.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest සටහන් ගොනුව (.json)"
+  "Readest annotations file (.json)": "Readest සටහන් ගොනුව (.json)",
+  "Downloading {{count}} book(s)_one": "{{count}} පොත බාගනිමින්",
+  "Downloading {{count}} book(s)_other": "{{count}} පොත් බාගනිමින්",
+  "Failed to download {{count}} book(s)_one": "{{count}} පොත බාගැනීමට අසමත්",
+  "Failed to download {{count}} book(s)_other": "{{count}} පොත් බාගැනීමට අසමත්"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2083,5 +2083,13 @@
   "A machine-readable file that Readest can import back into any book.": "Strojno berljiva datoteka, ki jo lahko Readest znova uvozi v katero koli knjigo.",
   "Import highlights and notes exported from Readest or another reading app.": "Uvozite označbe in opombe, izvožene iz Readesta ali druge bralne aplikacije.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Datoteka opomb Readest (.json)"
+  "Readest annotations file (.json)": "Datoteka opomb Readest (.json)",
+  "Downloading {{count}} book(s)_one": "Prenašanje {{count}} knjige",
+  "Downloading {{count}} book(s)_two": "Prenašanje {{count}} knjig",
+  "Downloading {{count}} book(s)_few": "Prenašanje {{count}} knjig",
+  "Downloading {{count}} book(s)_other": "Prenašanje {{count}} knjig",
+  "Failed to download {{count}} book(s)_one": "Prenos {{count}} knjige ni uspel",
+  "Failed to download {{count}} book(s)_two": "Prenos {{count}} knjig ni uspel",
+  "Failed to download {{count}} book(s)_few": "Prenos {{count}} knjig ni uspel",
+  "Failed to download {{count}} book(s)_other": "Prenos {{count}} knjig ni uspel"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1995,5 +1995,9 @@
   "A machine-readable file that Readest can import back into any book.": "En maskinläsbar fil som Readest kan importera tillbaka till vilken bok som helst.",
   "Import highlights and notes exported from Readest or another reading app.": "Importera markeringar och anteckningar som exporterats från Readest eller en annan läsapp.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest-anteckningsfil (.json)"
+  "Readest annotations file (.json)": "Readest-anteckningsfil (.json)",
+  "Downloading {{count}} book(s)_one": "Laddar ner {{count}} bok",
+  "Downloading {{count}} book(s)_other": "Laddar ner {{count}} böcker",
+  "Failed to download {{count}} book(s)_one": "Kunde inte ladda ner {{count}} bok",
+  "Failed to download {{count}} book(s)_other": "Kunde inte ladda ner {{count}} böcker"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1995,5 +1995,9 @@
   "A machine-readable file that Readest can import back into any book.": "Readest எந்தப் புத்தகத்திற்கும் மீண்டும் இறக்குமதி செய்யக்கூடிய இயந்திரம் படிக்கக்கூடிய கோப்பு.",
   "Import highlights and notes exported from Readest or another reading app.": "Readest அல்லது வேறு வாசிப்பு செயலியிலிருந்து ஏற்றுமதி செய்யப்பட்ட சிறப்பிப்புகளையும் குறிப்புகளையும் இறக்குமதி செய்யவும்.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest குறிப்புக் கோப்பு (.json)"
+  "Readest annotations file (.json)": "Readest குறிப்புக் கோப்பு (.json)",
+  "Downloading {{count}} book(s)_one": "{{count}} புத்தகம் பதிவிறக்கப்படுகிறது",
+  "Downloading {{count}} book(s)_other": "{{count}} புத்தகங்கள் பதிவிறக்கப்படுகின்றன",
+  "Failed to download {{count}} book(s)_one": "{{count}} புத்தகத்தை பதிவிறக்க முடியவில்லை",
+  "Failed to download {{count}} book(s)_other": "{{count}} புத்தகங்களை பதிவிறக்க முடியவில்லை"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1951,5 +1951,7 @@
   "A machine-readable file that Readest can import back into any book.": "ไฟล์ที่เครื่องอ่านได้ ซึ่ง Readest สามารถนำเข้ากลับไปยังหนังสือเล่มใดก็ได้",
   "Import highlights and notes exported from Readest or another reading app.": "นำเข้าไฮไลต์และบันทึกที่ส่งออกจาก Readest หรือแอปอ่านหนังสืออื่น",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "ไฟล์คำอธิบายประกอบของ Readest (.json)"
+  "Readest annotations file (.json)": "ไฟล์คำอธิบายประกอบของ Readest (.json)",
+  "Downloading {{count}} book(s)_other": "กำลังดาวน์โหลดหนังสือ {{count}} เล่ม",
+  "Failed to download {{count}} book(s)_other": "ดาวน์โหลดหนังสือ {{count}} เล่มไม่สำเร็จ"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1995,5 +1995,9 @@
   "A machine-readable file that Readest can import back into any book.": "Readest'in herhangi bir kitaba geri aktarabileceği, makine tarafından okunabilir bir dosya.",
   "Import highlights and notes exported from Readest or another reading app.": "Readest'ten veya başka bir okuma uygulamasından dışa aktarılan vurguları ve notları içe aktarın.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest açıklama dosyası (.json)"
+  "Readest annotations file (.json)": "Readest açıklama dosyası (.json)",
+  "Downloading {{count}} book(s)_one": "{{count}} kitap indiriliyor",
+  "Downloading {{count}} book(s)_other": "{{count}} kitap indiriliyor",
+  "Failed to download {{count}} book(s)_one": "{{count}} kitap indirilemedi",
+  "Failed to download {{count}} book(s)_other": "{{count}} kitap indirilemedi"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2083,5 +2083,13 @@
   "A machine-readable file that Readest can import back into any book.": "Машиночитний файл, який Readest може імпортувати назад у будь-яку книгу.",
   "Import highlights and notes exported from Readest or another reading app.": "Імпортуйте виділення та нотатки, експортовані з Readest або іншого застосунку для читання.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Файл анотацій Readest (.json)"
+  "Readest annotations file (.json)": "Файл анотацій Readest (.json)",
+  "Downloading {{count}} book(s)_one": "Завантаження {{count}} книги",
+  "Downloading {{count}} book(s)_other": "Завантаження {{count}} книг",
+  "Downloading {{count}} book(s)_few": "Завантаження {{count}} книг",
+  "Downloading {{count}} book(s)_many": "Завантаження {{count}} книг",
+  "Failed to download {{count}} book(s)_one": "Не вдалося завантажити {{count}} книгу",
+  "Failed to download {{count}} book(s)_other": "Не вдалося завантажити {{count}} книг",
+  "Failed to download {{count}} book(s)_few": "Не вдалося завантажити {{count}} книг",
+  "Failed to download {{count}} book(s)_many": "Не вдалося завантажити {{count}} книг"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1995,5 +1995,9 @@
   "A machine-readable file that Readest can import back into any book.": "Readest istalgan kitobga qayta import qila oladigan mashina oʻqiy oladigan fayl.",
   "Import highlights and notes exported from Readest or another reading app.": "Readest yoki boshqa oʻqish ilovasidan eksport qilingan ajratmalar va eslatmalarni import qiling.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest izohlar fayli (.json)"
+  "Readest annotations file (.json)": "Readest izohlar fayli (.json)",
+  "Downloading {{count}} book(s)_one": "{{count}} ta kitob yuklab olinmoqda",
+  "Downloading {{count}} book(s)_other": "{{count}} ta kitob yuklab olinmoqda",
+  "Failed to download {{count}} book(s)_one": "{{count}} ta kitobni yuklab boʻlmadi",
+  "Failed to download {{count}} book(s)_other": "{{count}} ta kitobni yuklab boʻlmadi"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1951,5 +1951,7 @@
   "A machine-readable file that Readest can import back into any book.": "Tệp máy đọc được mà Readest có thể nhập lại vào bất kỳ cuốn sách nào.",
   "Import highlights and notes exported from Readest or another reading app.": "Nhập các đoạn tô sáng và ghi chú đã xuất từ Readest hoặc ứng dụng đọc khác.",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Tệp chú thích của Readest (.json)"
+  "Readest annotations file (.json)": "Tệp chú thích của Readest (.json)",
+  "Downloading {{count}} book(s)_other": "Đang tải xuống {{count}} cuốn sách",
+  "Failed to download {{count}} book(s)_other": "Không thể tải xuống {{count}} cuốn sách"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1951,5 +1951,7 @@
   "A machine-readable file that Readest can import back into any book.": "一种机器可读的文件，Readest 可以将其重新导入任意书籍。",
   "Import highlights and notes exported from Readest or another reading app.": "导入从 Readest 或其他阅读应用导出的高亮和笔记。",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest 标注文件 (.json)"
+  "Readest annotations file (.json)": "Readest 标注文件 (.json)",
+  "Downloading {{count}} book(s)_other": "正在下载 {{count}} 本书籍",
+  "Failed to download {{count}} book(s)_other": "{{count}} 本书籍下载失败"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1951,5 +1951,7 @@
   "A machine-readable file that Readest can import back into any book.": "一種機器可讀的檔案，Readest 可將其重新匯入任何書籍。",
   "Import highlights and notes exported from Readest or another reading app.": "匯入從 Readest 或其他閱讀應用程式匯出的螢光標記與筆記。",
   "Readest": "Readest",
-  "Readest annotations file (.json)": "Readest 註解檔案 (.json)"
+  "Readest annotations file (.json)": "Readest 註解檔案 (.json)",
+  "Downloading {{count}} book(s)_other": "正在下載 {{count}} 本書籍",
+  "Failed to download {{count}} book(s)_other": "{{count}} 本書籍下載失敗"
 }

--- a/apps/readest-app/src/__tests__/app/library/select-mode-actions.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/select-mode-actions.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => (key: string) => key,
@@ -41,10 +41,13 @@ const baseProps = {
   onGroup: noop,
   onDetails: noop,
   onStatus: noop,
+  onDownload: noop,
   onSend: noop,
   onDelete: noop,
   onCancel: noop,
 };
+
+const getAction = (label: string) => screen.getByText(label).closest('button') as HTMLButtonElement;
 
 describe('SelectModeActions height reporting', () => {
   // Regression for #5175: the fixed bottom popup overlaps the last book in list
@@ -90,5 +93,43 @@ describe('SelectModeActions height reporting', () => {
     resizeCallback?.([], {} as ResizeObserver);
 
     expect(onHeightChange).toHaveBeenCalledWith(176);
+  });
+});
+
+// Bulk download (#5244): selecting a group is the only practical way to pull a
+// few hundred books onto a new device.
+describe('SelectModeActions download', () => {
+  it('queues the selection when the download action is tapped', () => {
+    const onDownload = vi.fn();
+    render(<SelectModeActions {...baseProps} canDownload onDownload={onDownload} />);
+
+    fireEvent.click(getAction('Download'));
+
+    expect(onDownload).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the download action when nothing in the selection is uploaded', () => {
+    render(<SelectModeActions {...baseProps} canDownload={false} />);
+
+    expect(getAction('Download').className).toContain('btn-disabled');
+  });
+
+  it('places download right after details so it heads the wrapped row', () => {
+    render(<SelectModeActions {...baseProps} canDownload />);
+
+    const labels = Array.from(document.querySelectorAll('button')).map((button) =>
+      button.textContent?.trim(),
+    );
+    expect(labels).toEqual([
+      'Open',
+      'Group',
+      'Status',
+      'Details',
+      'Download',
+      'Send',
+      'Delete',
+      'Cancel',
+    ]);
+    expect(getAction('Download').className).toContain('max-[500px]:col-start-1');
   });
 });

--- a/apps/readest-app/src/__tests__/utils/library-utils.test.ts
+++ b/apps/readest-app/src/__tests__/utils/library-utils.test.ts
@@ -14,6 +14,7 @@ import {
   findGroupById,
   getGroupDisplayName,
   expandBookshelfSelection,
+  selectDownloadableBooks,
   buildGroupNameUpdatedAt,
   resolveCurrentShelfBooks,
   withTimeRemainingLast,
@@ -1198,6 +1199,84 @@ describe('expandBookshelfSelection', () => {
     // it was a hash from another view), the helper leaves it alone rather
     // than silently dropping it.
     expect(expandBookshelfSelection(['ghost-hash'], [])).toEqual(['ghost-hash']);
+  });
+});
+
+describe('selectDownloadableBooks', () => {
+  const createMockGroup = (overrides: Partial<BooksGroup> = {}): BooksGroup => ({
+    id: 'test-group',
+    name: 'Test Group',
+    displayName: 'Test Display Name',
+    books: [],
+    updatedAt: Date.now(),
+    ...overrides,
+  });
+
+  // Bulk download (#5244): a selected group stands in for every book it shows,
+  // so a 300-book folder can be pulled down in one action.
+  it('expands a group id into its cloud-only books', () => {
+    const cloudOnly = createMockBook({ hash: 'cloud-only', uploadedAt: 100 });
+    const nested = createMockBook({ hash: 'nested', groupName: 'MyDir/sub', uploadedAt: 100 });
+    const items: (Book | BooksGroup)[] = [
+      createMockGroup({ id: 'group-mydir', name: 'MyDir', books: [cloudOnly, nested] }),
+    ];
+
+    expect(selectDownloadableBooks(['group-mydir'], items, [cloudOnly, nested])).toEqual([
+      cloudOnly,
+      nested,
+    ]);
+  });
+
+  it('skips books that are already on this device', () => {
+    const local = createMockBook({ hash: 'local', uploadedAt: 100, downloadedAt: 200 });
+    const cloudOnly = createMockBook({ hash: 'cloud-only', uploadedAt: 100 });
+    const items: (Book | BooksGroup)[] = [local, cloudOnly];
+
+    expect(selectDownloadableBooks(['local', 'cloud-only'], items, [local, cloudOnly])).toEqual([
+      cloudOnly,
+    ]);
+  });
+
+  it('skips books that were never uploaded', () => {
+    const localOnly = createMockBook({ hash: 'local-only', downloadedAt: 200 });
+    const items: (Book | BooksGroup)[] = [localOnly];
+
+    expect(selectDownloadableBooks(['local-only'], items, [localOnly])).toEqual([]);
+  });
+
+  it('skips feed books, which have no file to fetch', () => {
+    const feed = createMockBook({
+      hash: 'feed',
+      uploadedAt: 100,
+      url: 'feed://%7B%22feedUrl%22%3A%22https%3A%2F%2Fexample.com%2Frss%22%7D',
+    });
+    const items: (Book | BooksGroup)[] = [feed];
+
+    expect(selectDownloadableBooks(['feed'], items, [feed])).toEqual([]);
+  });
+
+  it('skips soft-deleted books', () => {
+    const gone = createMockBook({ hash: 'gone', uploadedAt: 100, deletedAt: 300 });
+    const items: (Book | BooksGroup)[] = [gone];
+
+    expect(selectDownloadableBooks(['gone'], items, [gone])).toEqual([]);
+  });
+
+  it('deduplicates when a book and its parent group are both selected', () => {
+    const bookA = createMockBook({ hash: 'book-a', uploadedAt: 100 });
+    const bookB = createMockBook({ hash: 'book-b', uploadedAt: 100 });
+    const items: (Book | BooksGroup)[] = [
+      createMockGroup({ id: 'group-1', books: [bookA, bookB] }),
+    ];
+
+    expect(selectDownloadableBooks(['book-a', 'group-1'], items, [bookA, bookB])).toEqual([
+      bookA,
+      bookB,
+    ]);
+  });
+
+  it('returns an empty array when nothing is selected', () => {
+    expect(selectDownloadableBooks([], [], [])).toEqual([]);
   });
 });
 

--- a/apps/readest-app/src/app/library/components/Bookshelf.tsx
+++ b/apps/readest-app/src/app/library/components/Bookshelf.tsx
@@ -45,6 +45,7 @@ import {
   resolveEffectivePrimarySort,
   resolveEffectiveSecondarySort,
   resolveCurrentShelfBooks,
+  selectDownloadableBooks,
   selectRecentShelfBooks,
   withReadingStatus,
   withTimeRemainingLast,
@@ -82,7 +83,7 @@ interface BookshelfProps {
   handleImportBooks: (anchor: HTMLElement) => void;
   handleBookDownload: (
     book: Book,
-    options?: { redownload?: boolean; queued?: boolean },
+    options?: { redownload?: boolean; queued?: boolean; silent?: boolean },
   ) => Promise<boolean>;
   handleBookUpload: (book: Book, syncBooks?: boolean) => Promise<boolean>;
   handleBookDelete: (book: Book, syncBooks?: boolean) => Promise<boolean>;
@@ -704,6 +705,46 @@ const Bookshelf: React.FC<BookshelfProps> = ({
   );
 
   const selectedBooks = getSelectedBooks();
+
+  // Bulk download (#5244): a selected group stands in for every book it shows,
+  // which is how a 300-book folder gets onto a new device in one action. Only
+  // worth computing while the select-mode bar is up.
+  const downloadableBooks = isSelectMode
+    ? selectDownloadableBooks(selectedBooks, sortedBookshelfItems, filteredBooks)
+    : [];
+
+  const downloadSelectedBooks = async () => {
+    const books = downloadableBooks;
+    if (books.length === 0) return;
+    handleSetSelectMode(false);
+    // One summary up front rather than a toast per book: the Readest Cloud
+    // path returns as soon as each book is queued, but a file backend
+    // actually fetches them, and either way the user needs immediate feedback
+    // that the batch started.
+    eventDispatcher.dispatch('toast', {
+      type: 'info',
+      timeout: 2000,
+      message: _('Downloading {{count}} book(s)', { count: books.length }),
+    });
+    // Batched like the bulk delete path so a file backend isn't hit with
+    // hundreds of simultaneous fetches.
+    const concurrency = 20;
+    let failed = 0;
+    for (let i = 0; i < books.length; i += concurrency) {
+      const batch = books.slice(i, i + concurrency);
+      const results = await Promise.all(
+        batch.map((book) => handleBookDownload(book, { queued: true, silent: true })),
+      );
+      failed += results.filter((ok) => !ok).length;
+    }
+    if (failed > 0) {
+      eventDispatcher.dispatch('toast', {
+        type: 'error',
+        message: _('Failed to download {{count}} book(s)', { count: failed }),
+      });
+    }
+  };
+
   const isGridMode = viewMode === 'grid';
   const hasItems = sortedBookshelfItems.length > 0;
   // In grid mode the Import-Books "+" tile is rendered as an extra grid cell
@@ -970,10 +1011,12 @@ const Bookshelf: React.FC<BookshelfProps> = ({
             !!appService &&
             (appService.isIOSApp || appService.isAndroidApp || appService.isMacOSApp)
           }
+          canDownload={downloadableBooks.length > 0}
           onOpen={openSelectedBooks}
           onGroup={groupSelectedBooks}
           onDetails={openBookDetails}
           onStatus={showStatusSelection}
+          onDownload={downloadSelectedBooks}
           onSend={sendSelectedBook}
           onDelete={deleteSelectedBooks}
           onCancel={() => handleSetSelectMode(false)}

--- a/apps/readest-app/src/app/library/components/SelectModeActions.tsx
+++ b/apps/readest-app/src/app/library/components/SelectModeActions.tsx
@@ -6,6 +6,7 @@ import {
   MdOutlineCancel,
   MdInfoOutline,
   MdCheckCircleOutline,
+  MdOutlineCloudDownload,
 } from 'react-icons/md';
 import { IoShareSocialOutline } from 'react-icons/io5';
 import { LuFolderPlus } from 'react-icons/lu';
@@ -22,10 +23,15 @@ interface SelectModeActionsProps {
   // the book file to the OS share sheet), distinct from "Share Book" in
   // the per-item context menu, which generates a remote share link.
   sendEnabled?: boolean;
+  // False when nothing in the selection can be pulled from the cloud — every
+  // selected book is either already on this device or was never uploaded.
+  canDownload?: boolean;
   onOpen: () => void;
   onGroup: () => void;
   onDetails: () => void;
   onStatus: () => void;
+  // Queues every cloud-only book in the selection, groups included (#5244).
+  onDownload: () => void;
   // The macOS / iPad share popover is anchored to the selected book's
   // cover (located via its data-book-hash attribute), not to this
   // button — the user's visual focus is on the cover they just tapped.
@@ -43,10 +49,12 @@ const SelectModeActions: React.FC<SelectModeActionsProps> = ({
   selectedBooks,
   safeAreaBottom,
   sendEnabled = true,
+  canDownload = false,
   onOpen,
   onGroup,
   onDetails,
   onStatus,
+  onDownload,
   onSend,
   onDelete,
   onCancel,
@@ -134,13 +142,24 @@ const SelectModeActions: React.FC<SelectModeActionsProps> = ({
           <MdInfoOutline />
           <div>{_('Details')}</div>
         </button>
+        <button
+          onClick={onDownload}
+          className={clsx(
+            'flex flex-col items-center justify-center gap-1',
+            // Heads the second row on narrow viewports; everything after it
+            // (Send / Delete / Cancel) then flows behind it.
+            'max-[500px]:col-start-1',
+            !canDownload && 'btn-disabled opacity-50',
+          )}
+        >
+          <MdOutlineCloudDownload />
+          <div>{_('Download')}</div>
+        </button>
         {sendEnabled && (
           <button
             onClick={onSend}
             className={clsx(
               'flex flex-col items-center justify-center gap-1',
-              // Wraps to the start of the second row on narrow viewports.
-              'max-[500px]:col-start-1',
               (!hasSingleSelection || !hasValidBooks) && 'btn-disabled opacity-50',
             )}
           >
@@ -152,12 +171,6 @@ const SelectModeActions: React.FC<SelectModeActionsProps> = ({
           onClick={onDelete}
           className={clsx(
             'flex flex-col items-center justify-center gap-1',
-            // Without Send (Linux/Windows/web), Delete needs an explicit
-            // col-start-2 so the wrapped row {Delete, Cancel} stays centred
-            // under the 4-col grid. With Send present, the layout is
-            // {Send, Delete, Cancel} starting at col-start-1, so Delete
-            // naturally lands in col-start-2 without an override.
-            !sendEnabled && 'max-[500px]:col-start-2',
             !hasSelection && 'btn-disabled opacity-50',
           )}
         >

--- a/apps/readest-app/src/app/library/hooks/useBookTransferActions.ts
+++ b/apps/readest-app/src/app/library/hooks/useBookTransferActions.ts
@@ -16,6 +16,10 @@ import { runFileBookDownload, runFileBookUpload } from '@/services/sync/file/run
 interface BookDownloadOptions {
   redownload?: boolean;
   queued?: boolean;
+  // Bulk callers (the select-mode Download action, #5244) report one summary
+  // toast for the whole batch instead of one per book — a group can hold
+  // hundreds.
+  silent?: boolean;
 }
 
 /**
@@ -80,7 +84,7 @@ export const useBookTransferActions = (
 
   const handleBookDownload = useCallback(
     async (book: Book, downloadOptions: BookDownloadOptions = {}) => {
-      const { redownload = false, queued = false } = downloadOptions;
+      const { redownload = false, queued = false, silent = false } = downloadOptions;
       const settingsNow = useSettingsStore.getState().settings;
       const backends = getActiveFileSyncBackends(settingsNow);
       const readest = isReadestCloudEnabled(settingsNow);
@@ -90,13 +94,15 @@ export const useBookTransferActions = (
       if (useFileBackend) {
         const ok = await runFileBookDownload(envConfig, book);
         if (ok) await updateBook(envConfig, book);
-        eventDispatcher.dispatch('toast', {
-          type: ok ? 'info' : 'error',
-          timeout: 2000,
-          message: ok
-            ? _('Book downloaded: {{title}}', { title: book.title })
-            : _('Failed to download book: {{title}}', { title: book.title }),
-        });
+        if (!silent) {
+          eventDispatcher.dispatch('toast', {
+            type: ok ? 'info' : 'error',
+            timeout: 2000,
+            message: ok
+              ? _('Book downloaded: {{title}}', { title: book.title })
+              : _('Failed to download book: {{title}}', { title: book.title }),
+          });
+        }
         return ok;
       }
 
@@ -106,21 +112,25 @@ export const useBookTransferActions = (
             updateBookTransferProgress(book.hash, progress);
           });
           await updateBook(envConfig, book);
-          eventDispatcher.dispatch('toast', {
-            type: 'info',
-            timeout: 2000,
-            message: _('Book downloaded: {{title}}', {
-              title: book.title,
-            }),
-          });
+          if (!silent) {
+            eventDispatcher.dispatch('toast', {
+              type: 'info',
+              timeout: 2000,
+              message: _('Book downloaded: {{title}}', {
+                title: book.title,
+              }),
+            });
+          }
           return true;
         } catch {
-          eventDispatcher.dispatch('toast', {
-            message: _('Failed to download book: {{title}}', {
-              title: book.title,
-            }),
-            type: 'error',
-          });
+          if (!silent) {
+            eventDispatcher.dispatch('toast', {
+              message: _('Failed to download book: {{title}}', {
+                title: book.title,
+              }),
+              type: 'error',
+            });
+          }
           return false;
         }
       }
@@ -128,13 +138,15 @@ export const useBookTransferActions = (
       // Use transfer queue for normal downloads - priority 1 for manual downloads
       const transferId = transferManager.queueDownload(book, 1);
       if (transferId) {
-        eventDispatcher.dispatch('toast', {
-          type: 'info',
-          timeout: 2000,
-          message: _('Download queued: {{title}}', {
-            title: book.title,
-          }),
-        });
+        if (!silent) {
+          eventDispatcher.dispatch('toast', {
+            type: 'info',
+            timeout: 2000,
+            message: _('Download queued: {{title}}', {
+              title: book.title,
+            }),
+          });
+        }
         return true;
       }
       return false;

--- a/apps/readest-app/src/app/library/utils/libraryUtils.ts
+++ b/apps/readest-app/src/app/library/utils/libraryUtils.ts
@@ -155,6 +155,29 @@ export const expandBookshelfSelection = (ids: string[], items: (Book | BooksGrou
   return [...hashes];
 };
 
+/**
+ * The books a bulk Download should actually fetch (#5244): the selection
+ * expanded through {@link expandBookshelfSelection}, narrowed to the books that
+ * live in the cloud but not on this device. The predicate matches the per-book
+ * "Download Book" affordance — a feed book has no file to fetch (#5307), and a
+ * book that was never uploaded or is already local has nothing to pull down.
+ */
+export const selectDownloadableBooks = (
+  ids: string[],
+  items: (Book | BooksGroup)[],
+  books: Book[],
+): Book[] => {
+  const hashes = new Set(expandBookshelfSelection(ids, items));
+  return books.filter(
+    (book) =>
+      hashes.has(book.hash) &&
+      !book.deletedAt &&
+      !isFeedBook(book) &&
+      !!book.uploadedAt &&
+      !book.downloadedAt,
+  );
+};
+
 // Calibre custom column names and values, flattened for searching (#4811).
 const getCalibreColumnsText = (item: Book) =>
   (item.metadata?.calibreColumns ?? [])


### PR DESCRIPTION
Closes #5244.

Setting up a new device meant tapping the cloud badge on every book. Selecting a group now downloads everything it holds in one action.

## What changed

- **Download action in the select-mode bar**, placed right after Details so it heads the wrapped second row on narrow viewports. With Send present that is two full rows of four (`Open Group Status Details` / `Download Send Delete Cancel`); this also let the `!sendEnabled && col-start-2` hack on Delete go away.
- **`selectDownloadableBooks()`** expands group ids through the same rollup the bulk-delete path uses (nested sub-folders included), then narrows to books that are uploaded but not yet on this device. Feed books are skipped, since they have no file to fetch (#5307). The predicate matches the per-book "Download Book" affordance, so the bar and the cloud badge always agree.
- The action is **disabled** unless the selection expands to at least one such book, so a selection with nothing uploaded, or one that is already fully local, greys out instead of no-opping.
- **`handleBookDownload` gained a `silent` option.** Queuing a 300-book group would otherwise fire 300 toasts; the bulk path reports one summary up front and an error summary if any call fails. Downloads run 20 at a time, like `confirmDelete`, so a WebDAV/Drive backend is not hit with hundreds of parallel fetches.

## Testing

- New unit tests: 3 for the button (placement, disabled state, click) and 7 for the selection helper. Written failing first.
- `pnpm test` (8233 passed), `pnpm lint`, `pnpm format:check`.
- Drove the running app on the web dev server at 500px: the bar wraps with Download at the head of row two; with the local-only demo books the action renders disabled and does not respond; after marking them cloud-only it enables, queues both, and the summary toast interpolates the plural correctly.

## Note

On web / Linux / Windows, where Send is hidden, the wrapped row is `Download Delete Cancel` and the fourth grid column sits empty, so that row reads left-aligned. A four-column grid cannot centre three items; keeping Download at the head of the row was the priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)