### PR TITLE
feat(tts): fine-tune the mini player time info and transport (#5310)

### DIFF
--- a/apps/readest-app/src/__tests__/components/tts-mini-player-position.test.ts
+++ b/apps/readest-app/src/__tests__/components/tts-mini-player-position.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { getTTSMiniPlayerBottomOffset } from '@/app/reader/utils/ttsMiniPlayerPosition';
+import {
+  TTS_MINI_PLAYER_HEIGHT,
+  getTTSMiniPlayerBottomOffset,
+  getTTSMiniPlayerClearance,
+} from '@/app/reader/utils/ttsMiniPlayerPosition';
 import { DEFAULT_BOOK_LAYOUT, DEFAULT_VIEW_CONFIG } from '@/services/constants';
 import type { ViewSettings } from '@/types/book';
 
@@ -112,5 +116,31 @@ describe('getTTSMiniPlayerBottomOffset', () => {
     expect(
       getTTSMiniPlayerBottomOffset(settings({ marginBottomPx: 8 }), { barVisible: false }),
     ).toBe(16);
+  });
+});
+
+// Clearance is the band of book text the player is allowed to cover. Only the
+// persistent 'minimal' card earns one: the 'full' card is tied to the toolbar
+// and auto-hides with it (#5310), so reserving a band for it would permanently
+// steal a line of text for a card that is usually not on screen.
+describe('getTTSMiniPlayerClearance', () => {
+  it('reserves offset + card height + safe area for the minimal player', () => {
+    expect(getTTSMiniPlayerClearance(settings({ ttsPlayerStyle: 'minimal' }), 12)).toBe(
+      DEFAULT_BOOK_LAYOUT.marginBottomPx + TTS_MINI_PLAYER_HEIGHT + 12,
+    );
+  });
+
+  it('reserves nothing for the full player', () => {
+    expect(getTTSMiniPlayerClearance(settings({ ttsPlayerStyle: 'full' }), 12)).toBe(0);
+  });
+
+  it('treats an unset player style as full, matching the setting default', () => {
+    expect(getTTSMiniPlayerClearance(settings({ ttsPlayerStyle: undefined }), 12)).toBe(0);
+  });
+
+  it('tracks the resting offset when the footer band is off', () => {
+    expect(
+      getTTSMiniPlayerClearance(settings({ ttsPlayerStyle: 'minimal', showFooter: false }), 0),
+    ).toBe(16 + TTS_MINI_PLAYER_HEIGHT);
   });
 });

--- a/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
@@ -51,6 +51,7 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
   bookKey: 'b1',
   isPlaying: true,
   isEink: false,
+  visible: true,
   hasTimeline: true,
   timeoutTimestamp: 0,
   chapterRemainingSec: null as number | null,
@@ -80,7 +81,10 @@ describe('TTSMiniPlayer', () => {
     vi.clearAllMocks();
   });
 
-  test('minimal style shows only the time info, dropping chapter, title and cover', () => {
+  // #5310: the minimal card is down to one time. Elapsed is the half nobody
+  // listens by, and carrying both got the pair chopped off at any UI font size
+  // above 13px.
+  test('minimal style shows only the remaining time, dropping elapsed, chapter, title and cover', () => {
     viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
     getBookData.mockReturnValue({
       book: { title: 'Alice in Wonderland', coverImageUrl: 'blob:cover' },
@@ -89,8 +93,22 @@ describe('TTSMiniPlayer', () => {
     expect(screen.queryByText('Chapter 5')).toBeNull();
     expect(screen.queryByText('Alice in Wonderland')).toBeNull();
     expect(container.querySelector('img')).toBeNull();
-    expect(screen.getByText(/0:10/)).toBeTruthy();
-    expect(screen.getByText(/-1:30/)).toBeTruthy();
+    expect(screen.queryByText(/0:10/)).toBeNull();
+    expect(screen.getByText('-1:30')).toBeTruthy();
+  });
+
+  test('minimal style drops the seconds from the remaining time above an hour', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
+    // 2h01m30s left: the compact form keeps the row five columns wide.
+    const info = { position: 100, duration: 7390, measuredFraction: 0.1 };
+    render(<TTSMiniPlayer {...makeProps({ onGetPlaybackInfo: vi.fn().mockReturnValue(info) })} />);
+    expect(screen.getByText('-2:01')).toBeTruthy();
+  });
+
+  test('full style keeps the elapsed and the long-form remaining time', () => {
+    const info = { position: 100, duration: 7390, measuredFraction: 0.1 };
+    render(<TTSMiniPlayer {...makeProps({ onGetPlaybackInfo: vi.fn().mockReturnValue(info) })} />);
+    expect(screen.getByText('Chapter 5 · 0:01:40 · -2:01:30')).toBeTruthy();
   });
 
   test('minimal style stacks the sleep timer on a second line below the time', () => {
@@ -100,22 +118,22 @@ describe('TTSMiniPlayer', () => {
     const body = screen.getByLabelText('Open Read Aloud player');
     expect(body.className).toContain('flex-col');
     // Time row and timer chip are separate stacked children, so the timer
-    // cannot squeeze the elapsed time into truncation.
+    // cannot squeeze the remaining time into truncation.
     const timer = screen.getByText(/^1:(2\d|30)$/);
-    const elapsed = screen.getByText('0:10');
+    const remaining = screen.getByText('-1:30');
     expect(timer.parentElement).toBe(body);
-    expect(elapsed.parentElement?.parentElement).toBe(body);
+    expect(remaining.parentElement).toBe(body);
     vi.useRealTimers();
   });
 
-  test('minimal style centers the time and emphasizes elapsed over remaining', () => {
+  test('minimal style centers the remaining time at full weight', () => {
     viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
     render(<TTSMiniPlayer {...makeProps()} />);
     const body = screen.getByLabelText('Open Read Aloud player');
     expect(body.className).toContain('justify-center');
-    const elapsed = screen.getByText('0:10');
-    expect(elapsed.className).toContain('font-medium');
-    expect(screen.getByText(/-1:30/).className).toContain('text-base-content/60');
+    const remaining = screen.getByText('-1:30');
+    expect(remaining.className).toContain('font-medium');
+    expect(remaining.className).not.toContain('text-base-content/60');
   });
 
   test('sentence and paragraph skips and play/pause drive the transport callbacks', () => {
@@ -152,6 +170,64 @@ describe('TTSMiniPlayer', () => {
     fireEvent.click(screen.getByLabelText('Stop reading aloud'));
     expect(props.onStop).toHaveBeenCalled();
     expect(props.onExpand).not.toHaveBeenCalled();
+  });
+
+  // #5310: an accidental hit on a sixth crowded glyph ends the session, and
+  // stopping already lives on the toolbar TTS button that started it.
+  test('minimal style has no stop button, leaving five transport glyphs', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
+    render(<TTSMiniPlayer {...makeProps()} />);
+    expect(screen.queryByLabelText('Stop reading aloud')).toBeNull();
+    const transport = screen.getByLabelText('Next Sentence').closest('[dir="ltr"]');
+    expect(transport?.querySelectorAll('button')).toHaveLength(5);
+  });
+
+  // The transport, not the time, takes the row's slack -- otherwise the glyphs
+  // stay crammed against the right edge while the middle sits empty (#5310).
+  test('minimal style spreads the transport across the row', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
+    render(<TTSMiniPlayer {...makeProps()} />);
+    const transport = screen.getByLabelText('Next Sentence').closest('[dir="ltr"]');
+    expect(transport?.className).toContain('flex-1');
+    expect(transport?.className).toContain('justify-between');
+  });
+
+  // A content-sized box would re-center every glyph as the label narrows on
+  // "-10:00" -> "-9:59", so the time gets a fixed one.
+  test('minimal style gives the time a fixed box so the glyphs never shift', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
+    const width = (seconds: number) => {
+      const info = { position: 0, duration: seconds, measuredFraction: 0 };
+      render(
+        <TTSMiniPlayer {...makeProps({ onGetPlaybackInfo: vi.fn().mockReturnValue(info) })} />,
+      );
+      const time = screen.getByLabelText('Open Read Aloud player');
+      expect(time.className).not.toContain('flex-1');
+      const cls = time.className;
+      cleanup();
+      return cls;
+    };
+    // Same box class for a short and a long label; nothing is content-sized.
+    expect(width(83)).toContain('w-14');
+    expect(width(3599)).toContain('w-14');
+  });
+
+  test('minimal style shows a bare countdown when there is no playback timeline', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
+    render(
+      <TTSMiniPlayer
+        {...makeProps({
+          hasTimeline: false,
+          chapterRemainingSec: 300,
+          onGetPlaybackInfo: vi.fn().mockReturnValue(null),
+        })}
+      />,
+    );
+    // The wordy full-style phrasing does not fit the one slot the minimal card
+    // has, and the sign keeps it reading as the same quantity as the timeline
+    // case rather than a different one.
+    expect(screen.queryByText(/left in chapter/)).toBeNull();
+    expect(screen.getByText('-5:00')).toBeTruthy();
   });
 
   test('tapping the body expands the player sheet', () => {
@@ -205,6 +281,16 @@ describe('TTSMiniPlayer', () => {
   test('rests above the footer info band once the bar is dismissed', () => {
     render(<TTSMiniPlayer {...makeProps()} />);
     expect(screen.getByRole('status').style.bottom).toBe(`${DEFAULT_BOOK_LAYOUT.marginBottomPx}px`);
+  });
+
+  // The full card fades out with the reader chrome (#5310); it stays mounted so
+  // the opacity transition can run, hence the pointer-events lockout.
+  test('fades out and stops taking taps once hidden', () => {
+    render(<TTSMiniPlayer {...makeProps({ visible: false })} />);
+    const card = screen.getByRole('status');
+    expect(card.className).toContain('opacity-0');
+    expect(card.className).toContain('pointer-events-none');
+    expect(card.className).not.toContain('opacity-100');
   });
 
   test('without a timeline shows the estimated chapter remaining instead', () => {

--- a/apps/readest-app/src/__tests__/components/tts/useMiniPlayerAutoHide.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/useMiniPlayerAutoHide.test.tsx
@@ -1,0 +1,172 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The hook reads only hoveredBookKey off the reader store; mock the store so
+// the test can drive toolbar visibility without mounting the reader.
+let hoveredBookKey: string | null = null;
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({ hoveredBookKey }),
+}));
+
+const { useMiniPlayerAutoHide } = await import('@/app/reader/components/tts/useMiniPlayerAutoHide');
+
+const BOOK = 'book-1';
+
+const setHovered = (key: string | null) => {
+  hoveredBookKey = key;
+};
+
+describe('useMiniPlayerAutoHide', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setHovered(null);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('shows the full player when the session starts, then hides it after 5s', () => {
+    const { result } = renderHook(() => useMiniPlayerAutoHide(BOOK, 'full', true));
+    expect(result.current).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(4999);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('keeps the full player up for as long as the toolbar is shown', () => {
+    setHovered(BOOK);
+    const { result } = renderHook(() => useMiniPlayerAutoHide(BOOK, 'full', true));
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('re-shows the full player when the toolbar comes back, and hides 5s after it clears', () => {
+    const { result, rerender } = renderHook(() => useMiniPlayerAutoHide(BOOK, 'full', true));
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe(false);
+
+    setHovered(BOOK);
+    rerender();
+    expect(result.current).toBe(true);
+
+    setHovered('');
+    rerender();
+    expect(result.current).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('restarts the countdown when the toolbar reappears mid-countdown', () => {
+    const { result, rerender } = renderHook(() => useMiniPlayerAutoHide(BOOK, 'full', true));
+
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    setHovered(BOOK);
+    rerender();
+    setHovered('');
+    rerender();
+
+    // The stale 1s remainder of the first countdown must not fire.
+    act(() => {
+      vi.advanceTimersByTime(4999);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('ignores another book taking the toolbar', () => {
+    setHovered('book-2');
+    const { result } = renderHook(() => useMiniPlayerAutoHide(BOOK, 'full', true));
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('keeps the minimal player visible for the whole session', () => {
+    const { result } = renderHook(() => useMiniPlayerAutoHide(BOOK, 'minimal', true));
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('re-shows a hidden full player when the style switches to minimal', () => {
+    let style: 'full' | 'minimal' = 'full';
+    const { result, rerender } = renderHook(() => useMiniPlayerAutoHide(BOOK, style, true));
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe(false);
+
+    style = 'minimal';
+    rerender();
+    expect(result.current).toBe(true);
+  });
+
+  // The caller outlives every session, so the countdown has to be armed by the
+  // card appearing, not by the hook mounting.
+  it('does not burn the countdown before the card is on screen', () => {
+    let mounted = false;
+    const { result, rerender } = renderHook(() => useMiniPlayerAutoHide(BOOK, 'full', mounted));
+
+    // Book open, no session: an hour later the next session must still start
+    // from a visible card, even with the toolbar down the whole time.
+    act(() => {
+      vi.advanceTimersByTime(3_600_000);
+    });
+    expect(result.current).toBe(true);
+
+    mounted = true;
+    rerender();
+    expect(result.current).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('hands back a visible card when the full player sheet closes', () => {
+    let mounted = true;
+    const { result, rerender } = renderHook(() => useMiniPlayerAutoHide(BOOK, 'full', mounted));
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe(false);
+
+    // Sheet opens over the card, then closes.
+    mounted = false;
+    rerender();
+    mounted = true;
+    rerender();
+    expect(result.current).toBe(true);
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/time-format.test.ts
+++ b/apps/readest-app/src/__tests__/utils/time-format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { formatCountdown, formatPlaybackTime } from '@/utils/time';
+import { formatCompactTime, formatCountdown, formatPlaybackTime } from '@/utils/time';
 
 describe('formatPlaybackTime', () => {
   test('formats minutes and seconds by default', () => {
@@ -29,6 +29,39 @@ describe('formatPlaybackTime', () => {
 
   test('truncates fractional seconds', () => {
     expect(formatPlaybackTime(59.9)).toBe('0:59');
+  });
+});
+
+describe('formatCompactTime', () => {
+  test('formats minutes and seconds below one hour', () => {
+    expect(formatCompactTime(0)).toBe('0:00');
+    expect(formatCompactTime(5)).toBe('0:05');
+    expect(formatCompactTime(62)).toBe('1:02');
+    expect(formatCompactTime(3599)).toBe('59:59');
+  });
+
+  test('drops the seconds once the value reaches one hour', () => {
+    // The minimal mini player has room for one time; above an hour the
+    // seconds go rather than letting a three-part clock get truncated.
+    expect(formatCompactTime(3600)).toBe('1:00');
+    expect(formatCompactTime(3600 + 61)).toBe('1:01');
+    expect(formatCompactTime(7 * 3600 + 59 * 60 + 59)).toBe('7:59');
+  });
+
+  test('floors rather than rounding up across an hour boundary', () => {
+    // A second short of the boundary still reads as "under", both times.
+    expect(formatCompactTime(3599)).toBe('59:59');
+    expect(formatCompactTime(2 * 3600 - 1)).toBe('1:59');
+  });
+
+  test('clamps negative and non-finite input to zero', () => {
+    expect(formatCompactTime(-5)).toBe('0:00');
+    expect(formatCompactTime(Number.NaN)).toBe('0:00');
+    expect(formatCompactTime(Number.POSITIVE_INFINITY)).toBe('0:00');
+  });
+
+  test('truncates fractional seconds', () => {
+    expect(formatCompactTime(59.9)).toBe('0:59');
   });
 });
 

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -92,10 +92,7 @@ import Spinner from '@/components/Spinner';
 import KOSyncConflictResolver from './KOSyncResolver';
 import ImageViewer from './ImageViewer';
 import TableViewer from './TableViewer';
-import {
-  getTTSMiniPlayerBottomOffset,
-  TTS_MINI_PLAYER_HEIGHT,
-} from '../utils/ttsMiniPlayerPosition';
+import { getTTSMiniPlayerClearance } from '../utils/ttsMiniPlayerPosition';
 
 declare global {
   interface Window {
@@ -859,13 +856,10 @@ const FoliateViewer: React.FC<{
     // full-width blank bar that steals space from the book text.
     const showBottomFooter = footerReservesBand(viewSettings) && !viewSettings.vertical;
     const moreTopInset = showTopHeader ? Math.max(0, 16 - insets.top) : 0;
-    // Resting position (bottom bar dismissed): the card stacks above the
-    // footer band, so the reserved clearance is its bottom offset plus the
-    // card height.
+    // Only the persistent 'minimal' card reserves a band; the 'full' one
+    // auto-hides with the toolbar and overlaps instead (#5310).
     const miniPlayerClearance = viewState?.ttsEnabled
-      ? getTTSMiniPlayerBottomOffset(viewSettings) +
-        TTS_MINI_PLAYER_HEIGHT +
-        gridInsets.bottom * 0.33
+      ? getTTSMiniPlayerClearance(viewSettings, gridInsets.bottom * 0.33)
       : 0;
     const moreBottomInset = showBottomFooter
       ? Math.max(0, Math.max(miniPlayerClearance, 16) - insets.bottom)
@@ -1039,6 +1033,8 @@ const FoliateViewer: React.FC<{
     viewSettings?.scrolled,
     viewSettings?.noContinuousScroll,
     viewState?.ttsEnabled,
+    // Switching Player Style changes whether a band is reserved at all.
+    viewSettings?.ttsPlayerStyle,
     // footerReservesBand inputs: the band must collapse/return live when the
     // user flips these settings.
     viewSettings?.showStickyProgressBar,

--- a/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
@@ -10,6 +10,7 @@ import { Insets } from '@/types/misc';
 import { eventDispatcher } from '@/utils/event';
 import TTSMiniPlayer from './TTSMiniPlayer';
 import TTSPlayerSheet from './TTSPlayerSheet';
+import { useMiniPlayerAutoHide } from './useMiniPlayerAutoHide';
 
 interface TTSControlProps {
   bookKey: string;
@@ -34,8 +35,12 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
   const downloads = useTTSDownloads(bookKey, tts.getController, showPlayerSheet);
   const activeSectionIndex = useBookProgress(bookKey)?.index ?? null;
 
-  const isEink = getViewSettings(bookKey)?.isEink ?? false;
+  const viewSettings = getViewSettings(bookKey);
+  const isEink = viewSettings?.isEink ?? false;
+  const playerStyle = viewSettings?.ttsPlayerStyle ?? 'full';
   const hasTimeline = tts.ttsClientsInited && tts.handleSupportsPlaybackInfo();
+  const miniPlayerMounted = tts.showIndicator && !showPlayerSheet;
+  const miniPlayerVisible = useMiniPlayerAutoHide(bookKey, playerStyle, miniPlayerMounted);
 
   useEffect(() => {
     if (tts.showBackToCurrentTTSLocation) {
@@ -96,11 +101,12 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
       {/* One surface at a time: the sheet replaces the mini player while open.
           Mounts on showIndicator alone so the card appears the moment the
           session starts, before the TTS clients finish initializing. */}
-      {tts.showIndicator && !showPlayerSheet && (
+      {miniPlayerMounted && (
         <TTSMiniPlayer
           bookKey={bookKey}
           isPlaying={tts.isPlaying}
           isEink={isEink}
+          visible={miniPlayerVisible}
           hasTimeline={hasTimeline}
           timeoutTimestamp={tts.timeoutTimestamp}
           chapterRemainingSec={tts.chapterRemainingSec}

--- a/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
@@ -21,7 +21,7 @@ import { useBookProgress } from '@/store/readerProgressStore';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
 import { useTranslation } from '@/hooks/useTranslation';
-import { formatPlaybackTime } from '@/utils/time';
+import { formatCompactTime, formatPlaybackTime } from '@/utils/time';
 import { TTSPlaybackInfo, usePlaybackInfo } from './usePlaybackInfo';
 import { useCountdownLabel } from './useCountdownLabel';
 import { formatRate } from './SpeedRuler';
@@ -60,6 +60,7 @@ type TTSMiniPlayerProps = {
   bookKey: string;
   isPlaying: boolean;
   isEink: boolean;
+  visible: boolean;
   hasTimeline: boolean;
   timeoutTimestamp: number;
   chapterRemainingSec: number | null;
@@ -72,18 +73,21 @@ type TTSMiniPlayerProps = {
   onGetPlaybackInfo: () => TTSPlaybackInfo | null;
 };
 
-// Persistent mini-player shown while a TTS session is active: passive
-// progress line with buffer-ahead fill on the card's bottom edge and, per the
-// ttsPlayerStyle setting, one of two card layouts. 'full' (the default) is
-// the 0.11.18 card: book cover, book title, chapter + timestamps line, and a
-// sentence-only transport with a filled play blob. 'minimal' is chrome-free —
-// no cover, no titles, plain glyphs — with only the time info and the same
+// Mini-player shown while a TTS session is active: passive progress line with
+// buffer-ahead fill on the card's bottom edge and, per the ttsPlayerStyle
+// setting, one of two card layouts. 'full' (the default) is the 0.11.18 card:
+// book cover, book title, chapter + timestamps line, and a sentence-only
+// transport with a filled play blob; it rides with the reader chrome and fades
+// out with it (see useMiniPlayerAutoHide). 'minimal' is chrome-free — no cover,
+// no titles, plain glyphs — showing the remaining time alone plus the same
 // paragraph/sentence transport vocabulary as the full player sheet (#5101 —
-// the paragraph skips matter to eyes-off listeners).
+// the paragraph skips matter to eyes-off listeners); it stays up for the whole
+// session, which is why it is the style that reserves a band of book text.
 const TTSMiniPlayer = ({
   bookKey,
   isPlaying,
   isEink,
+  visible,
   hasTimeline,
   timeoutTimestamp,
   chapterRemainingSec,
@@ -155,16 +159,29 @@ const TTSMiniPlayer = ({
   const forceHours = total >= 3600;
   const playedPct = ready && total > 0 ? Math.min((position / total) * 100, 100) : 0;
   const bufferedPct = ready ? Math.max(playedPct, Math.min(measuredFraction, 1) * 100) : 0;
-  // The minimal style weights the two halves differently, so keep them split;
-  // the full style joins them into the 0.11.18 "elapsed · -remaining" string.
+  const remainingSec = Math.max(total - position, 0);
+  // The full style keeps the 0.11.18 "elapsed · -remaining" string. The minimal
+  // style shows the remaining time alone, compactly (#5310): elapsed is the
+  // half nobody listens by, and dropping it stops the pair from being chopped
+  // off at anything but the smallest UI font size.
   const elapsedLabel = hasTimeline && ready ? formatPlaybackTime(position, forceHours) : '';
   const remainingLabel =
-    hasTimeline && ready ? `-${formatPlaybackTime(Math.max(total - position, 0), forceHours)}` : '';
-  const timeLabel = elapsedLabel
-    ? `${elapsedLabel} · ${remainingLabel}`
-    : chapterRemainingSec !== null
+    hasTimeline && ready ? `-${formatPlaybackTime(remainingSec, forceHours)}` : '';
+  // Books with no playback timeline fall back to the chapter estimate. The
+  // full style has room to say what the number means; the minimal style spends
+  // its one slot on the number alone, in the same counting-down form as the
+  // timeline case so the two never read as different quantities.
+  const chapterLabel =
+    chapterRemainingSec !== null
       ? _('{{time}} left in chapter', { time: formatPlaybackTime(chapterRemainingSec) })
       : '';
+  const timeLabel = elapsedLabel ? `${elapsedLabel} · ${remainingLabel}` : chapterLabel;
+  const compactLabel =
+    hasTimeline && ready
+      ? `-${formatCompactTime(remainingSec)}`
+      : chapterRemainingSec !== null
+        ? `-${formatCompactTime(chapterRemainingSec)}`
+        : '';
 
   return (
     <div
@@ -172,7 +189,8 @@ const TTSMiniPlayer = ({
       aria-label={`${_('Reading aloud')}: ${book?.title ?? ''}`}
       className={clsx(
         'absolute z-40 inset-x-4 sm:inset-x-0 sm:mx-auto sm:w-full sm:max-w-md',
-        'pointer-events-auto transition-[bottom] duration-300',
+        'transition-[bottom,opacity] duration-300',
+        visible ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0',
       )}
       style={{
         bottom: `${bottomOffset}px`,
@@ -274,7 +292,7 @@ const TTSMiniPlayer = ({
             </div>
           </div>
         ) : (
-          <div className='text-base-content flex h-14 items-center gap-2 pe-1 ps-1.5'>
+          <div className='text-base-content flex h-14 items-center gap-2 px-3'>
             {/* Visible route into the full player: a settings glyph carrying
               the live speed as a superscript (the sheet is where speed and
               voice live). The time text expands too, but text alone reads
@@ -298,23 +316,25 @@ const TTSMiniPlayer = ({
                 if (e.key === 'Enter' || e.key === ' ') onExpand();
               }}
               aria-label={_('Open Read Aloud player')}
-              className='flex min-w-0 flex-1 cursor-pointer flex-col items-center justify-center gap-0.5'
+              className='flex w-14 min-w-0 cursor-pointer flex-col items-center justify-center gap-0.5'
             >
-              {/* Centered in the flexible middle; elapsed carries the weight,
-                  the remaining half stays dim. An armed sleep timer stacks on
-                  its own line so it can never squeeze the time into
+              {/* A fixed 4rem box, not a flexible or content-sized one: the
+                  former hogs the row and leaves the transport crammed against
+                  the right edge, the latter re-centers every glyph each time
+                  the label changes width ("-9:59" -> "-10:00"). Scales with the
+                  UI font since both the box and the text are rem-based (#5310).
+                  Default shrink is deliberate: on a tiny card at a large font
+                  scale the box gives way and the label truncates, rather than
+                  pushing a transport glyph off the edge. An armed sleep timer
+                  stacks on its own line so it can never squeeze the time into
                   truncation. */}
-              {elapsedLabel ? (
-                <span className='flex min-w-0 items-baseline gap-1 text-sm tabular-nums'>
-                  <span className='text-base-content truncate font-medium'>{elapsedLabel}</span>
-                  <span className='text-base-content/60 shrink-0'>· {remainingLabel}</span>
+              {compactLabel && (
+                // max-w-full is load-bearing: a nowrap span is a flex item in a
+                // column, and without it the cross size resolves to the text's
+                // width and spills over the transport instead of truncating.
+                <span className='text-base-content max-w-full truncate text-sm font-medium tabular-nums'>
+                  {compactLabel}
                 </span>
-              ) : (
-                timeLabel && (
-                  <span className='text-base-content/60 truncate text-xs tabular-nums'>
-                    {timeLabel}
-                  </span>
-                )
               )}
               {timerLabel && (
                 <span className='text-base-content/60 flex shrink-0 items-center gap-0.5 text-xs tabular-nums'>
@@ -323,7 +343,15 @@ const TTSMiniPlayer = ({
                 </span>
               )}
             </div>
-            <div dir='ltr' className='flex shrink-0 items-center'>
+            {/* The transport takes the slack and spreads into it, so the space
+                freed by the stop button becomes separation between glyphs
+                rather than dead middle. That is what stops "<<" and "<" from
+                being mistaken for each other on a phone (#5310). No gap on
+                purpose: a fixed one would add 16px to the row's min width and
+                start crushing the time box on a 360px phone, and it buys
+                nothing -- justify-between already does the spreading whenever
+                there is anything to spread. */}
+            <div dir='ltr' className='flex flex-1 items-center justify-between'>
               <button
                 type='button'
                 className='shrink-0 rounded-full p-1'
@@ -361,6 +389,10 @@ const TTSMiniPlayer = ({
               >
                 <MdKeyboardArrowRight size={iconSize26} />
               </button>
+              {/* No stop button here on purpose (#5310): five transport glyphs
+                  already crowd a phone, and an accidental hit on a sixth ends
+                  the session. Stopping lives on the same toolbar TTS button
+                  that started it. */}
               <button
                 type='button'
                 className='shrink-0 rounded-full p-1'
@@ -368,14 +400,6 @@ const TTSMiniPlayer = ({
                 onClick={() => onForward(false)}
               >
                 <MdKeyboardDoubleArrowRight size={iconSize26} />
-              </button>
-              <button
-                type='button'
-                className='text-base-content/70 ms-0.5 shrink-0 rounded-full p-1'
-                aria-label={_('Stop reading aloud')}
-                onClick={onStop}
-              >
-                <MdClose size={iconSize20} />
               </button>
             </div>
           </div>

--- a/apps/readest-app/src/app/reader/components/tts/useMiniPlayerAutoHide.ts
+++ b/apps/readest-app/src/app/reader/components/tts/useMiniPlayerAutoHide.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import type { TTSPlayerStyle } from '@/services/tts/types';
+import { useReaderStore } from '@/store/readerStore';
+
+// How long the full card lingers after the toolbar goes away.
+const LINGER_MS = 5000;
+
+/**
+ * Whether the TTS mini player should be on screen (#5310).
+ *
+ * The 'minimal' card is the eyes-off transport: it stays up for the whole
+ * session. The 'full' card rides with the reader chrome instead -- visible
+ * while the toolbar is, then lingering 5s after it clears so a dismissing tap
+ * doesn't yank it away mid-glance. That's what lets the reader text stop
+ * reserving a band for it (see getTTSMiniPlayerClearance).
+ *
+ * `mounted` is whether the card is on screen at all, and it is what arms the
+ * countdown -- the caller lives as long as the reader does, so keying off its
+ * own mount would burn the 5s at book-open and leave a session started without
+ * the toolbar (a headset or lock-screen button) with an invisible card. It also
+ * resets while the full player sheet has replaced the card, so closing the
+ * sheet hands back a visible one.
+ *
+ * With that, one branch covers both the session start and every later toolbar
+ * dismissal: no toolbar up means show the card and arm a fresh countdown.
+ * Re-running on hoveredBookKey also cancels a countdown in flight when the
+ * toolbar returns, so a stale remainder can never hide a card just summoned.
+ */
+export const useMiniPlayerAutoHide = (
+  bookKey: string,
+  playerStyle: TTSPlayerStyle,
+  mounted: boolean,
+) => {
+  const { hoveredBookKey } = useReaderStore();
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    if (!mounted || playerStyle === 'minimal' || hoveredBookKey === bookKey) {
+      setVisible(true);
+      return;
+    }
+    setVisible(true);
+    const timeout = setTimeout(() => setVisible(false), LINGER_MS);
+    return () => clearTimeout(timeout);
+  }, [mounted, playerStyle, hoveredBookKey, bookKey]);
+
+  return visible;
+};

--- a/apps/readest-app/src/app/reader/utils/ttsMiniPlayerPosition.ts
+++ b/apps/readest-app/src/app/reader/utils/ttsMiniPlayerPosition.ts
@@ -1,9 +1,8 @@
 import type { ViewSettings } from '@/types/book';
 import { footerInfoVisible } from './footerBand';
 
-// Card height of the TTS mini player (h-14). Reader text reserves this plus
-// the bottom offset below as clearance while a session is active;
-// FoliateViewer consumes it via applyMarginAndGap.
+// Card height of the TTS mini player (h-14). See getTTSMiniPlayerClearance for
+// when the reader text reserves a band of this height.
 export const TTS_MINI_PLAYER_HEIGHT = 56;
 
 // 64px mobile nav bar / 52px desktop footer bar, plus an 8px gap.
@@ -14,8 +13,8 @@ const BASE_OFFSET = 16;
 
 /**
  * Bottom offset (px) of the TTS mini player, excluding the safe-area inset
- * (applied separately as margin-bottom). The card stays visible for the whole
- * session and stacks above whatever occupies the bottom edge:
+ * (applied separately as margin-bottom). The card stacks above whatever
+ * occupies the bottom edge:
  *   - the bottom bar while it is shown (hoveredBookKey === bookKey), or the
  *     expanded action panel above it (panelTopOffset: measured distance from
  *     the bottom edge to the open panel's top, safe-area margin excluded)
@@ -35,4 +34,22 @@ export const getTTSMiniPlayerBottomOffset = (
     !viewSettings.vertical &&
     (footerInfoVisible(viewSettings) || viewSettings.showStickyProgressBar);
   return footerAtBottom ? Math.max(viewSettings.marginBottomPx, BASE_OFFSET) : BASE_OFFSET;
+};
+
+/**
+ * Band of book text (px) kept clear for the mini player while a TTS session is
+ * active, measured at the card's resting position (bottom bar dismissed).
+ * FoliateViewer consumes it via applyMarginAndGap.
+ *
+ * Only the 'minimal' card earns one. The 'full' card follows the toolbar and
+ * auto-hides with it (#5310), so a permanent reservation would cost a line of
+ * text for a card that is off screen most of the session; it overlaps the text
+ * during its brief visible window instead, exactly as the toolbars do.
+ */
+export const getTTSMiniPlayerClearance = (
+  viewSettings: ViewSettings,
+  safeAreaBottom: number,
+): number => {
+  if (viewSettings.ttsPlayerStyle !== 'minimal') return 0;
+  return getTTSMiniPlayerBottomOffset(viewSettings) + TTS_MINI_PLAYER_HEIGHT + safeAreaBottom;
 };

--- a/apps/readest-app/src/utils/time.ts
+++ b/apps/readest-app/src/utils/time.ts
@@ -50,6 +50,21 @@ export const formatPlaybackTime = (seconds: number, forceHours = false): string 
   return `${minutes}:${String(secs).padStart(2, '0')}`;
 };
 
+// Compact playback time for the minimal TTS mini player (#5310), which shows
+// the remaining time alone: m:ss below one hour, h:mm above. The seconds go
+// past the hour mark rather than letting a three-part clock get chopped off in
+// the narrow row -- at that range the seconds are noise anyway. Both forms fit
+// five columns of tabular-nums, so the row never re-layouts as time runs down.
+export const formatCompactTime = (seconds: number): string => {
+  const total = Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0;
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(total % 60).padStart(2, '0')}`;
+};
+
 // Countdown label for TTS sleep-timer chips: total minutes : seconds
 // (a 90-minute timer reads 90:00, matching the lock-screen convention).
 export const formatCountdown = (msLeft: number): string => {


### PR DESCRIPTION
Closes #5310.

Follow-up to #5101 / #5170, acting on the reporter's feedback on the 0.11.20 mini player.

## Minimal player style

**Remaining time only, compactly.** Carrying both elapsed and remaining meant the pair got chopped off at any UI font size above 13px, and elapsed is the half nobody listens by. New `formatCompactTime` renders `h:mm` above an hour and `m:ss` below, so the label is five tabular columns either way and the row never re-layouts as time runs down. The full style keeps its `elapsed / -remaining` string via the existing `formatPlaybackTime`.

Books with no playback timeline now show the same bare `-5:00` countdown instead of `5:00 left in chapter`. The sign keeps it reading as the same quantity as the timeline case rather than a different one; the full style, which has room for the phrasing, keeps it.

**No stop button.** An accidental hit on a sixth crowded glyph ends the session, and stopping already lives on the same toolbar button that started it. The full style keeps its X.

**A transport you can actually hit.** Removing the button alone does not space the remaining glyphs out, since a gapless flex just lets the flexible middle absorb the freed width. So the transport now takes the row's slack (`flex-1 justify-between`) and the time gets a fixed `w-14` box. Reversed, the glyphs stay crammed against the right edge with dead space in the middle; content-sized, every glyph re-centers each time the label narrows (`-10:00` to `-9:59`).

Row minimum works out to 312px (`px-3` 24 + speed button 46 + gaps 16 + time 56 + five glyphs 170), so it fits every viewport at or above 344px with room to spare. Below that the time box gives way and the label truncates rather than pushing a glyph off the edge.

## Full player style

The full card now rides with the reader chrome (`useMiniPlayerAutoHide`): visible while the toolbar is, then lingering 5s after it clears so a dismissing tap does not yank it away mid-glance. Because it is off screen for most of a session, it no longer reserves a band of book text, and overlaps during its brief visible window exactly as the toolbars do. Only the persistent minimal style reserves clearance now, via the new `getTTSMiniPlayerClearance`.

The hook is gated on the card being mounted rather than on its own mount: `TTSControl` lives as long as the reader does, so arming the countdown at mount would burn the 5s at book-open and leave a session started without the toolbar (a headset or lock-screen button) with an invisible card. The same gate resets while the player sheet has replaced the card, so closing the sheet hands back a visible one.

## Out of scope

The issue's third ask (replace the playback-settings glyph, drop the `1x` label) is deliberately not included.

## Testing

`pnpm test` 8183 passed / 7 skipped, `pnpm lint` and `pnpm format:check` clean. New coverage for `formatCompactTime` boundaries, `getTTSMiniPlayerClearance` per style, the auto-hide hook under fake timers (including the mount-gate and sheet-close cases), and the minimal card's label, missing stop button and fixed-width time box. Four existing `TTSMiniPlayer` expectations encoded the old two-time layout and were rewritten.

Layout verified by mirroring the Tailwind classes into a plain-CSS harness and checking 768 / 430 / 390 / 375 / 360 / 320px: no overlap, and the glyphs hold identical positions across `-9:28`, `-1:07` and `-59:59`.

Not yet exercised on a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
