### PR TITLE
fix(reader): lift the header into the notch on negative top margins

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/components/SectionInfo.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/SectionInfo.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import SectionInfo from '@/app/reader/components/SectionInfo';
 
 let currentBookData: { isFixedLayout: boolean } | undefined;
+let currentMarginTopPx = 44;
 
 vi.mock('@/context/EnvContext', () => ({
   useEnv: () => ({ appService: { isAndroidApp: false, isMobile: true } }),
@@ -16,7 +17,7 @@ vi.mock('@/store/readerStore', () => ({
   useReaderStore: () => ({
     hoveredBookKey: '',
     getView: () => null,
-    getViewSettings: () => ({ marginTopPx: 44 }),
+    getViewSettings: () => ({ marginTopPx: currentMarginTopPx }),
     setHoveredBookKey: vi.fn(),
   }),
 }));
@@ -76,6 +77,64 @@ describe('SectionInfo notch mask', () => {
 
     expect(notch.classList.contains('notch-masked')).toBe(false);
     expect(notch.classList.contains('bg-base-100')).toBe(false);
+  });
+});
+
+describe('SectionInfo title band on negative top margins (#5303)', () => {
+  // Decreasing the top margin below 16px must lift the title band into the
+  // notch instead of collapsing it (negative CSS height is invalid, so the
+  // title used to stay put and overlap the book text). The band bottom always
+  // equals the content top: max(topInset + marginTopPx, 16).
+  it('keeps the classic geometry at the default 44px margin', () => {
+    currentMarginTopPx = 44;
+    const { container } = render(<SectionInfo {...baseProps} />);
+    const info = container.querySelector('.sectioninfo') as HTMLElement;
+
+    expect(info.style.top).toBe('45px');
+    expect(info.style.height).toBe('44px');
+  });
+
+  it('lifts the band into the notch on a negative margin', () => {
+    currentMarginTopPx = -20;
+    const props = { ...baseProps, contentInsets: { top: 25, right: 0, bottom: 0, left: 0 } };
+    const { container } = render(<SectionInfo {...props} />);
+    const info = container.querySelector('.sectioninfo') as HTMLElement;
+
+    expect(info.style.top).toBe('9px');
+    expect(info.style.height).toBe('16px');
+  });
+
+  it('shrinks the scrolled-mode notch mask to the lifted content top', () => {
+    // Content now starts inside the notch; a full-height mask would occlude it.
+    currentMarginTopPx = -20;
+    const props = { ...baseProps, contentInsets: { top: 25, right: 0, bottom: 0, left: 0 } };
+    const { container } = render(<SectionInfo {...props} />);
+    const notch = container.querySelector('.notch-area') as HTMLElement;
+
+    expect(notch.style.clipPath).toBe('inset(0 0 calc(100% - 25px) 0)');
+  });
+
+  it('pins the band to the screen top at the negative-margin limit', () => {
+    currentMarginTopPx = -45;
+    const props = { ...baseProps, contentInsets: { top: 0, right: 0, bottom: 0, left: 0 } };
+    const { container } = render(<SectionInfo {...props} />);
+    const info = container.querySelector('.sectioninfo') as HTMLElement;
+    const notch = container.querySelector('.notch-area') as HTMLElement;
+
+    expect(info.style.top).toBe('0px');
+    expect(info.style.height).toBe('16px');
+    expect(notch.style.clipPath).toBe('inset(0 0 calc(100% - 16px) 0)');
+  });
+
+  it('stacks the title above the z-10 notch mask it now overlaps', () => {
+    // The lifted band sits inside the mask strip in scrolled mode; without a
+    // z-index of its own the z-10 mask paints over the title (z-auto loses to
+    // any positive z sibling regardless of DOM order).
+    currentMarginTopPx = -45;
+    const { container } = render(<SectionInfo {...baseProps} />);
+    const info = container.querySelector('.sectioninfo') as HTMLElement;
+
+    expect(info.classList.contains('z-10')).toBe(true);
   });
 });
 

--- a/apps/readest-app/src/__tests__/app/reader/components/SectionInfo.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/SectionInfo.test.tsx
@@ -136,6 +136,18 @@ describe('SectionInfo title band on negative top margins (#5303)', () => {
 
     expect(info.classList.contains('z-10')).toBe(true);
   });
+
+  it('stays below the header toolbar when the band is not lifted', () => {
+    // The desktop HeaderBar wrapper is z-auto, so its z-10 bar (and the z-20
+    // button groups confined inside that stacking context) lose to a later
+    // z-10 sibling. An unconditional z-10 here put the band over the toolbar
+    // and its hover trigger, making the buttons unclickable (PR #5447 CI).
+    currentMarginTopPx = 44;
+    const { container } = render(<SectionInfo {...baseProps} />);
+    const info = container.querySelector('.sectioninfo') as HTMLElement;
+
+    expect(info.classList.contains('z-10')).toBe(false);
+  });
 });
 
 describe('SectionInfo contrast against the page (#4901)', () => {

--- a/apps/readest-app/src/__tests__/utils/insets.test.ts
+++ b/apps/readest-app/src/__tests__/utils/insets.test.ts
@@ -1,7 +1,35 @@
 import { describe, expect, it } from 'vitest';
-import { getPanelTopInset } from '@/utils/insets';
+import { getHeaderBandGeometry, getPanelTopInset } from '@/utils/insets';
 
 const insets = (top: number) => ({ top, right: 0, bottom: 0, left: 0 });
+
+describe('getHeaderBandGeometry (#5303)', () => {
+  it('keeps the classic band below the safe area for margins of 16px and up', () => {
+    // Default mobile layout: notch 39px, margin 44px.
+    expect(getHeaderBandGeometry(39, 44)).toEqual({ top: 39, height: 44, bottom: 83 });
+    expect(getHeaderBandGeometry(39, 16)).toEqual({ top: 39, height: 16, bottom: 55 });
+    // Desktop: no notch, minimum margin is 16.
+    expect(getHeaderBandGeometry(0, 16)).toEqual({ top: 0, height: 16, bottom: 16 });
+  });
+
+  it('keeps a readable 16px band by borrowing from the notch below 16px margins', () => {
+    // The band bottom stays at the content top (topInset + margin) while the
+    // top lifts into the notch so the title is never clipped.
+    expect(getHeaderBandGeometry(39, 8)).toEqual({ top: 31, height: 16, bottom: 47 });
+    expect(getHeaderBandGeometry(39, 0)).toEqual({ top: 23, height: 16, bottom: 39 });
+  });
+
+  it('lifts the band into the notch on negative margins', () => {
+    expect(getHeaderBandGeometry(39, -20)).toEqual({ top: 3, height: 16, bottom: 19 });
+  });
+
+  it('pins the band to the screen top once the content top hits the 16px floor', () => {
+    // The renderer floors the content top at 16px (moreTopInset), so the band
+    // bottom must not go below 16 either — the two edges stay glued.
+    expect(getHeaderBandGeometry(39, -23)).toEqual({ top: 0, height: 16, bottom: 16 });
+    expect(getHeaderBandGeometry(39, -39)).toEqual({ top: 0, height: 16, bottom: 16 });
+  });
+});
 
 describe('getPanelTopInset', () => {
   it('respects the status bar on non-mobile panels when system UI is visible', () => {

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -880,7 +880,10 @@ const FoliateViewer: React.FC<{
       const footerVisible = showBottomFooter;
       const safeBottomPadding = appService?.hasSafeAreaInset ? gridInsets.bottom * 0.33 : 0;
       const footerBarHeight = safeBottomPadding + viewSettings.marginBottomPx;
-      const scrollTop = headerVisible ? gridInsets.top + viewSettings.marginTopPx : 0;
+      // topMargin, not the raw margin sum: it carries the 16px moreTopInset
+      // floor, so a negative top margin keeps the scroll viewport glued to the
+      // lifted header band instead of running under it (#5303).
+      const scrollTop = headerVisible ? topMargin : 0;
       const scrollBottom = footerVisible
         ? Math.max(footerBarHeight, miniPlayerClearance)
         : miniPlayerClearance;

--- a/apps/readest-app/src/app/reader/components/SectionInfo.tsx
+++ b/apps/readest-app/src/app/reader/components/SectionInfo.tsx
@@ -6,6 +6,7 @@ import { useThemeStore } from '@/store/themeStore';
 import { useReaderStore } from '@/store/readerStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { eventDispatcher } from '@/utils/event';
+import { getHeaderBandGeometry } from '@/utils/insets';
 import { useBookDataStore } from '@/store/bookDataStore';
 
 interface SectionInfoProps {
@@ -42,6 +43,10 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
     gridInsets.top,
     appService?.isAndroidApp && systemUIVisible ? statusBarHeight / 2 : 0,
   );
+  // Negative top margins lift the band (and the scrolled-mode notch mask)
+  // into the notch instead of collapsing it (#5303).
+  const band = getHeaderBandGeometry(topInset, viewSettings.marginTopPx);
+  const maskHeight = Math.min(topInset, band.bottom);
 
   const handleNotchClick = () => {
     if (eventDispatcher.dispatchSync('iframe-single-click')) return;
@@ -72,12 +77,14 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
         tabIndex={-1}
         onClick={handleNotchClick}
         style={{
-          clipPath: `inset(0 0 calc(100% - ${topInset}px) 0)`,
+          clipPath: `inset(0 0 calc(100% - ${maskHeight}px) 0)`,
         }}
       />
       <div
         className={clsx(
-          'sectioninfo absolute flex items-center overflow-hidden font-sans',
+          // z-10: the lifted band overlaps the notch mask (also z-10) at small
+          // margins; as the later sibling it must win, and z-auto would lose.
+          'sectioninfo absolute z-10 flex items-center overflow-hidden font-sans',
           isEink
             ? 'text-sm font-normal'
             : bookData?.isFixedLayout
@@ -99,10 +106,10 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
                 width: showDoubleBorder ? '32px' : `${contentInsets.right}px`,
               }
             : {
-                top: `${topInset}px`,
+                top: `${band.top}px`,
                 paddingInline: `calc(${horizontalGap / 2}% + ${contentInsets.left / 2}px)`,
                 width: '100%',
-                height: `${viewSettings.marginTopPx}px`,
+                height: `${band.height}px`,
               }
         }
       >

--- a/apps/readest-app/src/app/reader/components/SectionInfo.tsx
+++ b/apps/readest-app/src/app/reader/components/SectionInfo.tsx
@@ -82,9 +82,13 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
       />
       <div
         className={clsx(
-          // z-10: the lifted band overlaps the notch mask (also z-10) at small
-          // margins; as the later sibling it must win, and z-auto would lose.
-          'sectioninfo absolute z-10 flex items-center overflow-hidden font-sans',
+          'sectioninfo absolute flex items-center overflow-hidden font-sans',
+          // A lifted band overlaps the notch mask (z-10) and must win as the
+          // later sibling — z-auto would lose to any positive z. Only when
+          // lifted: an unconditional z-10 also covers the desktop HeaderBar
+          // (z-auto wrapper, so even its z-20 button groups stay below) and
+          // makes the toolbar unclickable.
+          !isVertical && band.top < topInset && 'z-10',
           isEink
             ? 'text-sm font-normal'
             : bookData?.isFixedLayout

--- a/apps/readest-app/src/utils/insets.ts
+++ b/apps/readest-app/src/utils/insets.ts
@@ -23,6 +23,23 @@ export const getViewInsets = (viewSettings: ViewSettings) => {
 };
 
 /**
+ * Geometry of the header title band (SectionInfo, non-vertical).
+ *
+ * The band bottom is glued to the content top — max(topInset + marginTopPx, 16),
+ * the same 16px floor the renderer keeps via moreTopInset in FoliateViewer — so
+ * the title never overlaps the book text. At margins of 16px and up the band is
+ * the classic [topInset, topInset + margin] strip below the safe area; below
+ * that it keeps a 16px readable height and lifts into the notch, reaching the
+ * screen top at the negative-margin limit (#5303).
+ */
+export const getHeaderBandGeometry = (topInset: number, marginTopPx: number) => {
+  const minHeight = 16;
+  const height = Math.max(marginTopPx, minHeight);
+  const top = Math.max(0, topInset + Math.min(marginTopPx, minHeight) - minHeight);
+  return { top, height, bottom: top + height };
+};
+
+/**
  * Top padding (px) for a slide-in panel (sidebar / notebook) so its toolbar
  * clears the device status bar, mirroring the reader header.
  *


### PR DESCRIPTION
Fixes #5303

### Problem

With the header shown, the section-title band occupies `[topInset, topInset + marginTopPx]`. The top margin can go negative (down to `-gridInsets.top`), but a negative band height is invalid CSS (falls back to `auto`), so the title stayed anchored below the safe area and overlapped the book text while the notch strip stayed blank. In scrolled mode the notch mask also kept covering `[0, gridInsets.top]`, occluding content that now starts inside the notch.

### Fix

Bottom-anchor the title band to the content top, with a 16px minimum height (the same floor the renderer keeps via `moreTopInset`, and enough for the text-xs title):

- `getHeaderBandGeometry(topInset, marginTopPx)` in `src/utils/insets.ts`: `height = max(margin, 16)`, `top = max(0, topInset + min(margin, 16) - 16)`. Invariant: band bottom == content top == `max(topInset + margin, 16)`.
- Margins >= 16px (all desktop, mobile defaults) render pixel-identical to before; below that the band keeps a readable 16px height and slides up into the notch, reaching the screen top at the negative limit.
- `SectionInfo` shrinks the scrolled-mode notch mask to `min(topInset, band.bottom)` so it no longer covers content that starts inside the notch, and the band gets `z-10` - the mask is `z-10` and paints over a z-auto title once they overlap.
- `FoliateViewer` scrolled-mode `scrollTop` reuses the floored `topMargin` so the scroll viewport stays glued to the band instead of running under it.

### Verification

- Unit tests for the band geometry and SectionInfo (including the stacking regression); full suite and lint pass.
- Verified on a Xiaomi 13 (44px cutout inset) by driving the real settings UI over CDP: margin 44 -> -44 via the minus button. In both paginated and scrolled modes the chapter title now sits inside the notch band with content directly below; scrolled content flows through the previously blank strip and passes under the masked title.

| baseline (44) | paginated at -44 | scrolled at -44, mid-content |
| --- | --- | --- |
| blank notch strip, title below it | title inside the notch band | title fixed in the notch, content scrolls beneath |

🤖 Generated with [Claude Code](https://claude.com/claude-code)