### PR TITLE
feat(stats): count TTS listening as reading time

### DIFF
--- a/apps/readest-app/src/__tests__/services/tts-session-manager.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-session-manager.test.ts
@@ -24,9 +24,34 @@ vi.mock('@/store/bookDataStore', () => ({
 vi.mock('@/store/settingsStore', () => ({
   useSettingsStore: { getState: () => ({ settings: { fake: true } }) },
 }));
-vi.mock('@/services/environment', () => ({ default: { env: 'test' } }));
+// getAPIBaseUrl is reached through TtsStatsRecorder -> @/libs/sync.
+vi.mock('@/services/environment', () => ({
+  default: { env: 'test' },
+  getAPIBaseUrl: () => 'https://example.invalid',
+}));
 vi.mock('@/utils/bridge', () => ({
   invokeUseBackgroundAudio: vi.fn().mockResolvedValue(undefined),
+}));
+
+const statsMocks = vi.hoisted(() => ({
+  instances: [] as Array<{
+    session: { bookKey: string };
+    onPlaybackState: ReturnType<typeof vi.fn>;
+    onMark: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+  }>,
+}));
+vi.mock('@/services/statistics/ttsStatsRecorder', () => ({
+  TtsStatsRecorder: class {
+    session: { bookKey: string };
+    onPlaybackState = vi.fn();
+    onMark = vi.fn();
+    stop = vi.fn(async () => {});
+    constructor(session: { bookKey: string }) {
+      this.session = session;
+      statsMocks.instances.push(this);
+    }
+  },
 }));
 
 import { TTSSessionManager, getBookHashFromKey } from '@/services/tts/TTSSessionManager';
@@ -86,6 +111,7 @@ describe('TTSSessionManager', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    statsMocks.instances.length = 0;
     manager = new TTSSessionManager();
     controller = new FakeController();
     playbackStates = [];
@@ -228,5 +254,40 @@ describe('TTSSessionManager', () => {
     expect(controller.shutdown).not.toHaveBeenCalled();
     expect(manager.getActiveSession()).toBeNull();
     expect(sessionEvents.at(-1)?.reason).toBe('released');
+  });
+
+  test('feeds playback transitions and position marks to the stats recorder', () => {
+    claim();
+    const recorder = statsMocks.instances[0]!;
+    expect(recorder.session.bookKey).toBe('hashA-r1');
+
+    controller.emitState('playing');
+    controller.emitMark('epubcfi(/6/8!/4/4)');
+    controller.emitState('paused');
+
+    expect(recorder.onPlaybackState.mock.calls.flat()).toEqual(['playing', 'paused']);
+    expect(recorder.onMark).toHaveBeenCalledWith('epubcfi(/6/8!/4/4)');
+  });
+
+  test('exposes the relayed playback state for listeners that mount mid-session', () => {
+    claim();
+    expect(manager.getPlaybackState()).toBeNull();
+    controller.emitState('playing');
+    expect(manager.getPlaybackState()).toBe('playing');
+  });
+
+  test('flushes the stats recorder when the session stops', async () => {
+    claim();
+    controller.emitState('playing');
+    await manager.stopActive('user');
+    expect(statsMocks.instances[0]!.stop).toHaveBeenCalled();
+  });
+
+  test('never orphans a stats recorder when the same session is re-claimed', () => {
+    claim();
+    // The recorder owns a heartbeat interval; an orphan would keep writing.
+    claim();
+    expect(statsMocks.instances).toHaveLength(2);
+    expect(statsMocks.instances[0]!.stop).toHaveBeenCalled();
   });
 });

--- a/apps/readest-app/src/__tests__/statistics/ReadingStatsTracker.test.tsx
+++ b/apps/readest-app/src/__tests__/statistics/ReadingStatsTracker.test.tsx
@@ -1,14 +1,25 @@
-import { cleanup, render, waitFor } from '@testing-library/react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BookProgress } from '@/types/book';
 
 const mocks = vi.hoisted(() => ({
   open: vi.fn(),
-  getBookData: vi.fn(() => null),
+  getBookData: vi.fn(() => null as unknown),
+  progress: null as BookProgress | null,
+  playbackState: null as 'playing' | 'paused' | null,
+  db: {
+    upsertBook: vi.fn(),
+    insertPageEvent: vi.fn(),
+    recomputeBookTotals: vi.fn(),
+  },
 }));
 
 vi.mock('@/context/EnvContext', () => ({ useEnv: () => ({ appService: {} }) }));
 vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ user: null }) }));
-vi.mock('@/store/readerProgressStore', () => ({ useBookProgress: () => null }));
+vi.mock('@/store/readerProgressStore', () => ({
+  useBookProgress: () => mocks.progress,
+  getBookProgress: () => mocks.progress,
+}));
 vi.mock('@/store/bookDataStore', () => ({
   useBookDataStore: () => mocks.getBookData,
 }));
@@ -21,7 +32,15 @@ vi.mock('@/services/statistics/statsSync', () => ({
 }));
 vi.mock('@/services/sync/syncCategories', () => ({ isSyncCategoryEnabled: () => false }));
 vi.mock('@/libs/sync', () => ({ SyncClient: class {} }));
+vi.mock('@/services/tts/TTSSessionManager', () => ({
+  ttsSessionManager: {
+    getPlaybackState: () => mocks.playbackState,
+    getActiveSession: () => (mocks.playbackState ? { bookHash: 'hash1' } : null),
+  },
+  getBookHashFromKey: (key: string) => key.split('-')[0],
+}));
 
+import { eventDispatcher } from '@/utils/event';
 import ReadingStatsTracker from '@/app/reader/components/ReadingStatsTracker';
 
 describe('ReadingStatsTracker', () => {
@@ -44,5 +63,118 @@ describe('ReadingStatsTracker', () => {
     await waitFor(() => {
       expect(warn).toHaveBeenCalledWith('[stats] background operation failed:', error);
     });
+  });
+});
+
+describe('ReadingStatsTracker while TTS plays', () => {
+  const BOOK_KEY = 'hash1-view1';
+
+  const setPage = (current: number) => {
+    mocks.progress = {
+      pageinfo: { current, next: current + 1, total: 100 },
+    } as unknown as BookProgress;
+  };
+
+  const mount = () => render(<ReadingStatsTracker bookKey={BOOK_KEY} />);
+
+  const settle = async (ms = 0) => {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ms);
+    });
+  };
+
+  const emitPlaybackState = async (state: string, bookKey = BOOK_KEY) => {
+    await act(async () => {
+      await eventDispatcher.dispatch('tts-playback-state', { bookKey, state });
+    });
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.open.mockResolvedValue(mocks.db);
+    mocks.db.upsertBook.mockResolvedValue(1);
+    mocks.db.insertPageEvent.mockResolvedValue(undefined);
+    mocks.db.recomputeBookTotals.mockResolvedValue(undefined);
+    mocks.getBookData.mockReturnValue({
+      book: { hash: 'md5-1', title: 'Book', author: 'Author' },
+    } as unknown as null);
+    mocks.playbackState = null;
+    setPage(0);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('records page dwell normally when TTS is idle', async () => {
+    const { rerender } = mount();
+    await settle();
+
+    await settle(30_000);
+    setPage(1);
+    rerender(<ReadingStatsTracker bookKey={BOOK_KEY} />);
+    await settle();
+
+    expect(mocks.db.insertPageEvent).toHaveBeenCalled();
+  });
+
+  it('stops recording page dwell while TTS is playing', async () => {
+    const { rerender } = mount();
+    await settle();
+    await emitPlaybackState('playing');
+
+    await settle(30_000);
+    setPage(1);
+    rerender(<ReadingStatsTracker bookKey={BOOK_KEY} />);
+    await settle(30_000);
+    setPage(2);
+    rerender(<ReadingStatsTracker bookKey={BOOK_KEY} />);
+    await settle();
+
+    expect(mocks.db.insertPageEvent).not.toHaveBeenCalled();
+  });
+
+  it('resumes recording once TTS stops', async () => {
+    const { rerender } = mount();
+    await settle();
+    await emitPlaybackState('playing');
+    await settle(30_000);
+    await emitPlaybackState('stopped');
+
+    await settle(30_000);
+    setPage(1);
+    rerender(<ReadingStatsTracker bookKey={BOOK_KEY} />);
+    await settle();
+
+    expect(mocks.db.insertPageEvent).toHaveBeenCalled();
+  });
+
+  it('starts dormant when mounted into an already-playing session', async () => {
+    mocks.playbackState = 'playing';
+    const { rerender } = mount();
+    await settle();
+
+    await settle(30_000);
+    setPage(1);
+    rerender(<ReadingStatsTracker bookKey={BOOK_KEY} />);
+    await settle();
+
+    expect(mocks.db.insertPageEvent).not.toHaveBeenCalled();
+  });
+
+  it('keeps recording when another book is the one being read aloud', async () => {
+    const { rerender } = mount();
+    await settle();
+    await emitPlaybackState('playing', 'hash2-view1');
+
+    await settle(30_000);
+    setPage(1);
+    rerender(<ReadingStatsTracker bookKey={BOOK_KEY} />);
+    await settle();
+
+    expect(mocks.db.insertPageEvent).toHaveBeenCalled();
   });
 });

--- a/apps/readest-app/src/__tests__/statistics/ttsStatsRecorder.test.ts
+++ b/apps/readest-app/src/__tests__/statistics/ttsStatsRecorder.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BookConfig, BookProgress } from '@/types/book';
+import type { TTSSession } from '@/services/tts/TTSSessionManager';
+
+type CFIProgress = {
+  fraction: number;
+  section: { current: number; total: number };
+  location: { current: number; next: number; total: number };
+  time: { section: number; total: number };
+};
+
+const mocks = vi.hoisted(() => ({
+  progress: null as BookProgress | null,
+  config: null as BookConfig | null,
+  book: null as { hash: string; title: string; author: string } | null,
+  db: {
+    upsertBook: vi.fn(),
+    insertPageEvent: vi.fn(),
+    recomputeBookTotals: vi.fn(),
+  },
+  open: vi.fn(),
+  pushStats: vi.fn(),
+  syncEnabled: false,
+  accessToken: null as string | null,
+}));
+
+vi.mock('@/services/environment', () => ({
+  default: { getAppService: async () => ({}) },
+}));
+vi.mock('@/services/statistics/statisticsDb', () => ({
+  StatisticsDb: { open: mocks.open },
+}));
+vi.mock('@/services/statistics/statsSync', () => ({ pushStats: mocks.pushStats }));
+vi.mock('@/services/sync/syncCategories', () => ({
+  isSyncCategoryEnabled: () => mocks.syncEnabled,
+}));
+vi.mock('@/libs/sync', () => ({ SyncClient: class {} }));
+vi.mock('@/utils/access', () => ({ getAccessToken: async () => mocks.accessToken }));
+vi.mock('@/store/readerProgressStore', () => ({ getBookProgress: () => mocks.progress }));
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: {
+    getState: () => ({
+      getBookData: () => (mocks.book ? { book: mocks.book } : null),
+      getConfig: () => mocks.config,
+    }),
+  },
+}));
+
+import {
+  pageFromFraction,
+  TTS_STATS_HEARTBEAT_MS,
+  TtsStatsRecorder,
+} from '@/services/statistics/ttsStatsRecorder';
+
+type RecordedEvent = { page: number; startTime: number; duration: number; totalPages: number };
+
+const insertedEvents = (): RecordedEvent[] =>
+  mocks.db.insertPageEvent.mock.calls.map((call) => (call as unknown[])[1] as RecordedEvent);
+
+const totalDuration = () => insertedEvents().reduce((sum, e) => sum + e.duration, 0);
+
+const makeSession = (opts: {
+  isViewAttached: boolean;
+  getCFIProgress?: (cfi: string) => Promise<CFIProgress | null>;
+}): TTSSession => {
+  const controller = {
+    isViewAttached: opts.isViewAttached,
+    view: { getCFIProgress: opts.getCFIProgress ?? (async () => null) },
+  };
+  return {
+    bookHash: 'hash-1',
+    bookKey: 'hash-1-view1',
+    controller,
+  } as unknown as TTSSession;
+};
+
+const setViewPage = (current: number, total: number) => {
+  mocks.progress = { pageinfo: { current, next: current + 1, total } } as unknown as BookProgress;
+};
+
+const cfiProgressAt = (fraction: number, location: number, locationTotal: number) => async () => ({
+  fraction,
+  section: { current: 2, total: 10 },
+  location: { current: location, next: location + 1, total: locationTotal },
+  time: { section: 0, total: 0 },
+});
+
+describe('pageFromFraction', () => {
+  it('maps a fraction onto a 1-based page within the layout', () => {
+    expect(pageFromFraction(0, 100)).toBe(1);
+    expect(pageFromFraction(0.5, 100)).toBe(51);
+    expect(pageFromFraction(0.999, 100)).toBe(100);
+  });
+
+  it('clamps out-of-range and degenerate inputs to a usable page', () => {
+    expect(pageFromFraction(1, 100)).toBe(100);
+    expect(pageFromFraction(-0.5, 100)).toBe(1);
+    expect(pageFromFraction(Number.NaN, 100)).toBe(1);
+    expect(pageFromFraction(0.5, 0)).toBe(1);
+  });
+});
+
+describe('TtsStatsRecorder', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.open.mockResolvedValue(mocks.db);
+    mocks.db.upsertBook.mockResolvedValue(1);
+    mocks.db.insertPageEvent.mockResolvedValue(undefined);
+    mocks.db.recomputeBookTotals.mockResolvedValue(undefined);
+    mocks.pushStats.mockResolvedValue(undefined);
+    mocks.book = { hash: 'md5-1', title: 'Book', author: 'Author' };
+    mocks.config = { progress: [1, 200], updatedAt: 0 } as BookConfig;
+    mocks.progress = null;
+    mocks.syncEnabled = false;
+    mocks.accessToken = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('credits listening time to the displayed page while a view is attached', async () => {
+    setViewPage(9, 200);
+    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: true }));
+
+    recorder.onPlaybackState('playing');
+    await vi.advanceTimersByTimeAsync(TTS_STATS_HEARTBEAT_MS);
+
+    setViewPage(10, 200);
+    await vi.advanceTimersByTimeAsync(TTS_STATS_HEARTBEAT_MS * 2);
+    await recorder.stop();
+
+    const events = insertedEvents();
+    expect(events[0]).toMatchObject({ page: 10, totalPages: 200 });
+    expect(events.some((e) => e.page === 11)).toBe(true);
+  });
+
+  it('renews the event on a long page so narration time is not lost to the 120s cap', async () => {
+    setViewPage(9, 200);
+    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: true }));
+
+    recorder.onPlaybackState('playing');
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await recorder.stop();
+
+    const events = insertedEvents();
+    expect(events.length).toBeGreaterThan(1);
+    expect(events.every((e) => e.page === 10)).toBe(true);
+    expect(events.every((e) => e.duration <= 120)).toBe(true);
+    expect(totalDuration()).toBeGreaterThanOrEqual(290);
+    expect(totalDuration()).toBeLessThanOrEqual(300);
+  });
+
+  it('stops accruing time while playback is paused', async () => {
+    setViewPage(9, 200);
+    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: true }));
+
+    recorder.onPlaybackState('playing');
+    await vi.advanceTimersByTimeAsync(60_000);
+    recorder.onPlaybackState('paused');
+    await vi.advanceTimersByTimeAsync(0);
+    const afterPause = totalDuration();
+
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+    await recorder.stop();
+
+    expect(afterPause).toBeGreaterThan(0);
+    expect(totalDuration()).toBe(afterPause);
+  });
+
+  it('derives the page from the TTS position when no view is attached', async () => {
+    const getCFIProgress = vi.fn(cfiProgressAt(0.25, 40, 160));
+    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: false, getCFIProgress }));
+
+    recorder.onMark('epubcfi(/6/8!/4/2)');
+    recorder.onPlaybackState('playing');
+    await vi.advanceTimersByTimeAsync(90_000);
+    await recorder.stop();
+
+    // 0.25 through a book the layout last measured at 200 pages -> page 51,
+    // on the same scale the reading tracker writes.
+    expect(insertedEvents()[0]).toMatchObject({ page: 51, totalPages: 200 });
+  });
+
+  it('falls back to foliate locations when the book has no laid-out page count', async () => {
+    mocks.config = { updatedAt: 0 } as BookConfig;
+    const getCFIProgress = vi.fn(cfiProgressAt(0.25, 40, 160));
+    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: false, getCFIProgress }));
+
+    recorder.onMark('epubcfi(/6/8!/4/2)');
+    recorder.onPlaybackState('playing');
+    await vi.advanceTimersByTimeAsync(90_000);
+    await recorder.stop();
+
+    expect(insertedEvents()[0]).toMatchObject({ page: 41, totalPages: 160 });
+  });
+
+  it('resolves the headless page at most once per unchanged CFI', async () => {
+    const getCFIProgress = vi.fn(cfiProgressAt(0.25, 40, 160));
+    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: false, getCFIProgress }));
+
+    recorder.onMark('epubcfi(/6/8!/4/2)');
+    recorder.onPlaybackState('playing');
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await recorder.stop();
+
+    expect(getCFIProgress).toHaveBeenCalledTimes(1);
+  });
+
+  it('records nothing when the book identity is unavailable', async () => {
+    mocks.book = null;
+    setViewPage(9, 200);
+    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: true }));
+
+    recorder.onPlaybackState('playing');
+    await vi.advanceTimersByTimeAsync(90_000);
+    await recorder.stop();
+
+    expect(mocks.db.insertPageEvent).not.toHaveBeenCalled();
+  });
+
+  it('keeps a failing CFI resolve from tearing down the session', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const getCFIProgress = vi.fn(async () => {
+      throw new Error('synthetic resolve failure');
+    });
+    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: false, getCFIProgress }));
+
+    recorder.onMark('epubcfi(/6/8!/4/2)');
+    recorder.onPlaybackState('playing');
+    await vi.advanceTimersByTimeAsync(90_000);
+    await expect(recorder.stop()).resolves.toBeUndefined();
+
+    expect(mocks.db.insertPageEvent).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('pushes stats on stop when stats sync is enabled and the user is signed in', async () => {
+    setViewPage(9, 200);
+    mocks.syncEnabled = true;
+    mocks.accessToken = 'token';
+    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: true }));
+
+    recorder.onPlaybackState('playing');
+    await vi.advanceTimersByTimeAsync(60_000);
+    await recorder.stop();
+
+    expect(mocks.pushStats).toHaveBeenCalled();
+  });
+
+  it('does not push stats when the user is signed out', async () => {
+    setViewPage(9, 200);
+    mocks.syncEnabled = true;
+    mocks.accessToken = null;
+    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: true }));
+
+    recorder.onPlaybackState('playing');
+    await vi.advanceTimersByTimeAsync(60_000);
+    await recorder.stop();
+
+    expect(mocks.pushStats).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/__tests__/statistics/ttsStatsRecorder.test.ts
+++ b/apps/readest-app/src/__tests__/statistics/ttsStatsRecorder.test.ts
@@ -2,13 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BookConfig, BookProgress } from '@/types/book';
 import type { TTSSession } from '@/services/tts/TTSSessionManager';
 
-type CFIProgress = {
-  fraction: number;
-  section: { current: number; total: number };
-  location: { current: number; next: number; total: number };
-  time: { section: number; total: number };
-};
-
 const mocks = vi.hoisted(() => ({
   progress: null as BookProgress | null,
   config: null as BookConfig | null,
@@ -59,13 +52,44 @@ const insertedEvents = (): RecordedEvent[] =>
 
 const totalDuration = () => insertedEvents().reduce((sum, e) => sum + e.duration, 0);
 
-const makeSession = (opts: {
-  isViewAttached: boolean;
-  getCFIProgress?: (cfi: string) => Promise<CFIProgress | null>;
-}): TTSSession => {
+const makeDoc = (text: string) =>
+  new DOMParser().parseFromString(`<html><body><p>${text}</p></body></html>`, 'text/html');
+
+// Halfway through a 100-character third section. With sizes [1000, 1000, 2000]
+// that is 3000/4000 = 0.75 of the way through the book.
+const SECTION_TEXT_LENGTH = 100;
+const sectionDocs = [makeDoc('a'), makeDoc('b'), makeDoc('x'.repeat(SECTION_TEXT_LENGTH))];
+
+const makeBook = () => ({
+  sections: sectionDocs.map((doc, i) => ({
+    size: i === 2 ? 2000 : 1000,
+    linear: 'yes',
+    createDocument: async () => doc,
+  })),
+});
+
+const resolveCFIToSectionMidpoint = () => ({
+  index: 2,
+  anchor: (doc: Document) => {
+    const textNode = doc.body.firstChild!.firstChild!;
+    const range = doc.createRange();
+    range.setStart(textNode, SECTION_TEXT_LENGTH / 2);
+    range.collapse(true);
+    return range;
+  },
+});
+
+/**
+ * `view.close()` nulls the view's own progress helpers, so a headless session
+ * only ever has the book and resolveCFI to work with. Model exactly that.
+ */
+const makeSession = (opts: { isViewAttached: boolean; hasBook?: boolean }): TTSSession => {
   const controller = {
     isViewAttached: opts.isViewAttached,
-    view: { getCFIProgress: opts.getCFIProgress ?? (async () => null) },
+    view: {
+      book: opts.hasBook === false ? undefined : makeBook(),
+      resolveCFI: resolveCFIToSectionMidpoint,
+    },
   };
   return {
     bookHash: 'hash-1',
@@ -77,13 +101,6 @@ const makeSession = (opts: {
 const setViewPage = (current: number, total: number) => {
   mocks.progress = { pageinfo: { current, next: current + 1, total } } as unknown as BookProgress;
 };
-
-const cfiProgressAt = (fraction: number, location: number, locationTotal: number) => async () => ({
-  fraction,
-  section: { current: 2, total: 10 },
-  location: { current: location, next: location + 1, total: locationTotal },
-  time: { section: 0, total: 0 },
-});
 
 describe('pageFromFraction', () => {
   it('maps a fraction onto a 1-based page within the layout', () => {
@@ -170,43 +187,61 @@ describe('TtsStatsRecorder', () => {
     expect(totalDuration()).toBe(afterPause);
   });
 
-  it('derives the page from the TTS position when no view is attached', async () => {
-    const getCFIProgress = vi.fn(cfiProgressAt(0.25, 40, 160));
-    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: false, getCFIProgress }));
+  // Regression: the first implementation resolved the headless page through
+  // view.getCFIProgress, but view.close() nulls the helpers that method depends
+  // on - so closing the book (the only way to reach this path) guaranteed it
+  // returned null and nothing was ever recorded.
+  it('derives the page from the book itself once the view has been closed', async () => {
+    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: false }));
 
     recorder.onMark('epubcfi(/6/8!/4/2)');
     recorder.onPlaybackState('playing');
     await vi.advanceTimersByTimeAsync(90_000);
     await recorder.stop();
 
-    // 0.25 through a book the layout last measured at 200 pages -> page 51,
+    // 0.75 through a book the layout last measured at 200 pages -> page 151,
     // on the same scale the reading tracker writes.
-    expect(insertedEvents()[0]).toMatchObject({ page: 51, totalPages: 200 });
+    expect(insertedEvents()[0]).toMatchObject({ page: 151, totalPages: 200 });
   });
 
   it('falls back to foliate locations when the book has no laid-out page count', async () => {
     mocks.config = { updatedAt: 0 } as BookConfig;
-    const getCFIProgress = vi.fn(cfiProgressAt(0.25, 40, 160));
-    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: false, getCFIProgress }));
+    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: false }));
 
     recorder.onMark('epubcfi(/6/8!/4/2)');
     recorder.onPlaybackState('playing');
     await vi.advanceTimersByTimeAsync(90_000);
     await recorder.stop();
 
-    expect(insertedEvents()[0]).toMatchObject({ page: 41, totalPages: 160 });
+    // size 3000 of 4000 at 1500 bytes per location -> location 2 (0-based).
+    expect(insertedEvents()[0]).toMatchObject({ page: 3, totalPages: 3 });
   });
 
   it('resolves the headless page at most once per unchanged CFI', async () => {
-    const getCFIProgress = vi.fn(cfiProgressAt(0.25, 40, 160));
-    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: false, getCFIProgress }));
+    const session = makeSession({ isViewAttached: false });
+    const resolveCFI = vi.fn(resolveCFIToSectionMidpoint);
+    (session.controller.view as unknown as { resolveCFI: unknown }).resolveCFI = resolveCFI;
+    const recorder = new TtsStatsRecorder(session);
 
     recorder.onMark('epubcfi(/6/8!/4/2)');
     recorder.onPlaybackState('playing');
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
     await recorder.stop();
 
-    expect(getCFIProgress).toHaveBeenCalledTimes(1);
+    expect(resolveCFI).toHaveBeenCalledTimes(1);
+  });
+
+  it('records nothing when the book is gone rather than guessing a page', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: false, hasBook: false }));
+
+    recorder.onMark('epubcfi(/6/8!/4/2)');
+    recorder.onPlaybackState('playing');
+    await vi.advanceTimersByTimeAsync(90_000);
+    await recorder.stop();
+
+    expect(mocks.db.insertPageEvent).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it('records nothing when the book identity is unavailable', async () => {
@@ -223,10 +258,11 @@ describe('TtsStatsRecorder', () => {
 
   it('keeps a failing CFI resolve from tearing down the session', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const getCFIProgress = vi.fn(async () => {
+    const session = makeSession({ isViewAttached: false });
+    (session.controller.view as unknown as { resolveCFI: unknown }).resolveCFI = () => {
       throw new Error('synthetic resolve failure');
-    });
-    const recorder = new TtsStatsRecorder(makeSession({ isViewAttached: false, getCFIProgress }));
+    };
+    const recorder = new TtsStatsRecorder(session);
 
     recorder.onMark('epubcfi(/6/8!/4/2)');
     recorder.onPlaybackState('playing');

--- a/apps/readest-app/src/app/reader/components/ReadingStatsTracker.tsx
+++ b/apps/readest-app/src/app/reader/components/ReadingStatsTracker.tsx
@@ -1,16 +1,18 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { useBookProgress } from '@/store/readerProgressStore';
+import { getBookProgress, useBookProgress } from '@/store/readerProgressStore';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useEnv } from '@/context/EnvContext';
 import { useAuth } from '@/context/AuthContext';
 import { StatisticsDb } from '@/services/statistics/statisticsDb';
 import { TrackerCore, type FlushedEvent } from '@/services/statistics/trackerCore';
+import { getBookHashFromKey, ttsSessionManager } from '@/services/tts/TTSSessionManager';
 import { DEFAULT_STATS_TRACKING_CONFIG } from '@/types/statistics';
 import { SyncClient } from '@/libs/sync';
 import { pushStats, pullStats } from '@/services/statistics/statsSync';
 import { isSyncCategoryEnabled } from '@/services/sync/syncCategories';
+import { eventDispatcher } from '@/utils/event';
 
 const nowSec = () => Math.floor(Date.now() / 1000);
 
@@ -32,6 +34,15 @@ export default function ReadingStatsTracker({ bookKey }: { bookKey: string }) {
   const dbRef = useRef<StatisticsDb | null>(null);
   const idleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // While this book is being read aloud, TtsStatsRecorder owns the clock and
+  // this tracker stands down — otherwise TTS auto-follow's relocations would
+  // bill the same wall-clock a second time. Seeded from the manager rather than
+  // the event bus alone, so opening the reader from the mini player mid-session
+  // doesn't miss the transition that already happened.
+  const ttsPlayingRef = useRef(
+    ttsSessionManager.getPlaybackState() === 'playing' &&
+      ttsSessionManager.getActiveSession()?.bookHash === getBookHashFromKey(bookKey),
+  );
 
   const bookData = getBookData(bookKey);
   const book = bookData?.book;
@@ -93,16 +104,42 @@ export default function ReadingStatsTracker({ bookKey }: { bookKey: string }) {
     );
   };
 
+  const openPageAt = (info: { current?: number; total: number } | undefined) => {
+    if (!info) return;
+    void persist(coreRef.current.onPage((info.current ?? 0) + 1, info.total || 1, nowSec()));
+    armIdle();
+  };
+
   // Page changes drive the tracker.
   useEffect(() => {
-    const info = progress?.pageinfo;
-    if (!info) return;
-    const page = (info.current ?? 0) + 1;
-    const total = info.total || 1;
-    void persist(coreRef.current.onPage(page, total, nowSec()));
-    armIdle();
+    if (ttsPlayingRef.current) return;
+    openPageAt(progress?.pageinfo);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [progress?.pageinfo]);
+
+  // Hand the clock to TtsStatsRecorder while this book is read aloud, and take
+  // it back afterwards. TTS turns pages to follow the narration, so without
+  // this the same minutes would be recorded by both.
+  useEffect(() => {
+    const bookHash = getBookHashFromKey(bookKey);
+    const onPlaybackState = (event: Event) => {
+      const detail = (event as CustomEvent).detail as { bookKey?: string; state?: string };
+      // Another book can be playing while this one is read manually.
+      if (!detail?.bookKey || getBookHashFromKey(detail.bookKey) !== bookHash) return;
+      const playing = detail.state === 'playing';
+      if (playing === ttsPlayingRef.current) return;
+      ttsPlayingRef.current = playing;
+      if (playing) {
+        if (idleRef.current) clearTimeout(idleRef.current);
+        void persist(coreRef.current.onIdle(nowSec()));
+      } else {
+        openPageAt(getBookProgress(bookKey)?.pageinfo);
+      }
+    };
+    eventDispatcher.on('tts-playback-state', onPlaybackState);
+    return () => eventDispatcher.off('tts-playback-state', onPlaybackState);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bookKey]);
 
   // Tab/window visibility.
   useEffect(() => {

--- a/apps/readest-app/src/services/statistics/ttsStatsRecorder.ts
+++ b/apps/readest-app/src/services/statistics/ttsStatsRecorder.ts
@@ -1,0 +1,270 @@
+// Reading statistics for listening.
+//
+// The reading tracker (ReadingStatsTracker) has exactly one input: page turns
+// reported by a laid-out view. TTS only ever reached it indirectly, through the
+// relocations auto-follow happens to produce - so listening with follow
+// suppressed, or with the book closed entirely (mini player, lock screen,
+// CarPlay), recorded nothing at all.
+//
+// This recorder gives listening its own clock, on the rule that the page being
+// narrated is the page being read. It writes the same KOReader
+// `page_stat_data` rows through the same StatisticsDb, so listening and
+// reading are indistinguishable downstream - which is the point.
+//
+// While it is running the reading tracker stands down (see
+// ReadingStatsTracker's tts-playback-state handler); exactly one of the two
+// owns the clock at any moment.
+
+import env from '@/services/environment';
+import { SyncClient } from '@/libs/sync';
+import { isSyncCategoryEnabled } from '@/services/sync/syncCategories';
+import { useBookDataStore } from '@/store/bookDataStore';
+import { getBookProgress } from '@/store/readerProgressStore';
+import { DEFAULT_STATS_TRACKING_CONFIG, type StatBook } from '@/types/statistics';
+import type { TTSSession } from '@/services/tts/TTSSessionManager';
+import { getAccessToken } from '@/utils/access';
+import { StatisticsDb } from './statisticsDb';
+import { pushStats } from './statsSync';
+import { TrackerCore, type FlushedEvent } from './trackerCore';
+
+/** How often playback is sampled. Also the renewal granularity below. */
+export const TTS_STATS_HEARTBEAT_MS = 30_000;
+
+// Close and reopen the current event once its dwell reaches this, so a page
+// whose narration runs long never hits TrackerCore's maxEventSeconds cap.
+// Sixty seconds against a 120s cap leaves a full heartbeat of slack, so even a
+// throttled background timer loses nothing.
+const RENEW_AFTER_SEC = 60;
+
+const PUSH_DEBOUNCE_MS = 10_000;
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+// Statistics are best-effort telemetry, and this recorder runs headless where
+// nothing is watching: a failed write must never surface as an unhandled
+// rejection or disturb playback.
+const runBestEffort = (work: Promise<unknown>): void => {
+  void work.catch((err) => console.warn('[stats] TTS background operation failed:', err));
+};
+
+/**
+ * Map a book-level progress fraction onto a 1-based page in a layout of
+ * `totalPages`. Used only when no view is attached, where foliate's size-domain
+ * fraction is the only position signal available.
+ */
+export const pageFromFraction = (fraction: number, totalPages: number): number => {
+  if (!Number.isFinite(fraction) || totalPages <= 0) return 1;
+  return Math.min(Math.max(Math.floor(fraction * totalPages) + 1, 1), totalPages);
+};
+
+interface ResolvedPage {
+  page: number;
+  totalPages: number;
+}
+
+export class TtsStatsRecorder {
+  readonly #session: TTSSession;
+  readonly #core = new TrackerCore(DEFAULT_STATS_TRACKING_CONFIG);
+  #db: StatisticsDb | null = null;
+  #dbPromise: Promise<StatisticsDb | null> | null = null;
+  #heartbeat: ReturnType<typeof setInterval> | null = null;
+  #pushTimer: ReturnType<typeof setTimeout> | null = null;
+  #playing = false;
+  #ticking = false;
+  #currentPage: number | null = null;
+  #dwellStartedAt = 0;
+  #lastCfi: string | null = null;
+  #resolvedCfi: string | null = null;
+  #resolvedPage: ResolvedPage | null = null;
+
+  constructor(session: TTSSession) {
+    this.#session = session;
+  }
+
+  onPlaybackState(state: 'playing' | 'paused'): void {
+    if (state === 'playing') {
+      if (this.#playing) return;
+      this.#playing = true;
+      // No idle timer, deliberately: reading arms one because a stationary page
+      // probably means the reader walked away, but audible narration is proof
+      // they did not. The heartbeat is the only timer here.
+      this.#heartbeat ??= setInterval(() => void this.#tick(), TTS_STATS_HEARTBEAT_MS);
+      void this.#tick();
+      return;
+    }
+    if (!this.#playing) return;
+    this.#playing = false;
+    this.#stopHeartbeat();
+    this.#flush();
+  }
+
+  /** The controller's canonical position signal, one per spoken sentence. */
+  onMark(cfi: string): void {
+    if (!cfi || this.#lastCfi === cfi) return;
+    this.#lastCfi = cfi;
+    // Credit a page turn as it happens rather than up to a heartbeat late - but
+    // only where the page is free to read. Headless it costs a getCFIProgress
+    // (which loads the section document), so there it waits for the heartbeat.
+    if (this.#playing && this.#session.controller.isViewAttached) void this.#tick();
+  }
+
+  async stop(): Promise<void> {
+    this.#playing = false;
+    this.#stopHeartbeat();
+    if (this.#pushTimer) {
+      clearTimeout(this.#pushTimer);
+      this.#pushTimer = null;
+    }
+    this.#currentPage = null;
+    await this.#persist(this.#core.onClose(nowSec()));
+    await this.#push();
+  }
+
+  #stopHeartbeat(): void {
+    if (!this.#heartbeat) return;
+    clearInterval(this.#heartbeat);
+    this.#heartbeat = null;
+  }
+
+  #flush(): void {
+    const events = this.#core.onIdle(nowSec());
+    // Drop the page too, so resuming opens a fresh dwell instead of measuring
+    // from a start time that stopped advancing while playback was paused.
+    this.#currentPage = null;
+    runBestEffort(this.#persist(events));
+  }
+
+  async #tick(): Promise<void> {
+    if (!this.#playing || this.#ticking) return;
+    this.#ticking = true;
+    try {
+      const resolved = await this.#resolvePage();
+      if (!resolved || !this.#playing) return;
+      const now = nowSec();
+      if (resolved.page !== this.#currentPage) {
+        await this.#persist(this.#core.onPage(resolved.page, resolved.totalPages, now));
+        this.#currentPage = resolved.page;
+        this.#dwellStartedAt = now;
+        return;
+      }
+      if (now - this.#dwellStartedAt < RENEW_AFTER_SEC) return;
+      // Renewal: TrackerCore caps one event at maxEventSeconds and discards the
+      // rest, which is the right safety net for a page someone walked away
+      // from. Reopening on the same page with a later start_time keeps the time
+      // without weakening that cap - the primary key is (book, page, start).
+      await this.#persist(this.#core.onIdle(now));
+      await this.#persist(this.#core.onPage(resolved.page, resolved.totalPages, now));
+      this.#dwellStartedAt = now;
+    } finally {
+      this.#ticking = false;
+    }
+  }
+
+  async #resolvePage(): Promise<ResolvedPage | null> {
+    const { bookKey, controller } = this.#session;
+    if (controller.isViewAttached) {
+      // A laid-out view knows the real page, in the same domain the reading
+      // tracker writes. Foliate's fraction is a size domain and does not map
+      // linearly onto screen pages, so prefer this wherever it exists.
+      const info = getBookProgress(bookKey)?.pageinfo;
+      if (info) return { page: (info.current ?? 0) + 1, totalPages: info.total || 1 };
+    }
+    const cfi = this.#lastCfi;
+    if (!cfi) return null;
+    if (this.#resolvedCfi === cfi) return this.#resolvedPage;
+
+    let progress: Awaited<ReturnType<typeof controller.view.getCFIProgress>> = null;
+    try {
+      progress = await controller.view.getCFIProgress(cfi);
+    } catch (err) {
+      console.warn('[stats] failed to resolve the TTS position to a page:', err);
+      return null;
+    }
+    if (!progress) return null;
+
+    const resolved = this.#pageFromProgress(progress);
+    this.#resolvedCfi = cfi;
+    this.#resolvedPage = resolved;
+    return resolved;
+  }
+
+  #pageFromProgress(
+    progress: NonNullable<Awaited<ReturnType<TTSSession['controller']['view']['getCFIProgress']>>>,
+  ): ResolvedPage | null {
+    // Stay on the layout's own scale so listening rows and reading rows remain
+    // comparable, which is what makes COUNT(DISTINCT page) meaningful.
+    const layoutPages = useBookDataStore.getState().getConfig(this.#session.bookKey)?.progress?.[1];
+    if (layoutPages && layoutPages > 0) {
+      return { page: pageFromFraction(progress.fraction, layoutPages), totalPages: layoutPages };
+    }
+    // Never laid out on this device: fall back to foliate's layout-independent
+    // locations. A different scale, but the alternative is recording nothing.
+    const { current, total } = progress.location;
+    if (total <= 0) return null;
+    return { page: Math.min(Math.max(current + 1, 1), total), totalPages: total };
+  }
+
+  #getStatBook(): StatBook | null {
+    const book = useBookDataStore.getState().getBookData(this.#session.bookKey)?.book;
+    if (!book?.hash) return null;
+    return { bookMd5: book.hash, title: book.title ?? '', authors: book.author ?? '' };
+  }
+
+  async #getDb(): Promise<StatisticsDb | null> {
+    if (this.#db) return this.#db;
+    // A failed open resolves null and stays cached: the recorder disables
+    // itself for the rest of the session rather than retrying every heartbeat.
+    this.#dbPromise ??= (async () => {
+      try {
+        const appService = await env.getAppService();
+        this.#db = await StatisticsDb.open(appService);
+        return this.#db;
+      } catch (err) {
+        console.warn('[stats] failed to open the statistics database for TTS:', err);
+        return null;
+      }
+    })();
+    return this.#dbPromise;
+  }
+
+  async #persist(events: FlushedEvent[]): Promise<void> {
+    if (events.length === 0) return;
+    const book = this.#getStatBook();
+    if (!book) return;
+    const db = await this.#getDb();
+    if (!db) return;
+    try {
+      const idBook = await db.upsertBook(book);
+      for (const e of events) await db.insertPageEvent(idBook, e);
+      await db.recomputeBookTotals(idBook);
+      this.#schedulePush();
+    } catch (err) {
+      // The statistics DB can be closed mid-write on app teardown; log and
+      // never reject (Sentry READEST-6).
+      console.warn('[stats] failed to persist TTS listening events:', err);
+    }
+  }
+
+  #schedulePush(): void {
+    // Trailing debounce that is never restarted: a multi-hour headless session
+    // must reach the server as it goes, not only when playback stops.
+    if (this.#pushTimer) return;
+    this.#pushTimer = setTimeout(() => {
+      this.#pushTimer = null;
+      runBestEffort(this.#push());
+    }, PUSH_DEBOUNCE_MS);
+  }
+
+  async #push(): Promise<void> {
+    const db = this.#db;
+    if (!db || !isSyncCategoryEnabled('stats')) return;
+    // No AuthContext headless, so the session token stands in for `user`.
+    const token = await getAccessToken().catch(() => null);
+    if (!token) return;
+    try {
+      await pushStats(db, new SyncClient());
+    } catch (err) {
+      console.warn('[stats] failed to push TTS listening events:', err);
+    }
+  }
+}

--- a/apps/readest-app/src/services/statistics/ttsStatsRecorder.ts
+++ b/apps/readest-app/src/services/statistics/ttsStatsRecorder.ts
@@ -15,6 +15,7 @@
 // ReadingStatsTracker's tts-playback-state handler); exactly one of the two
 // owns the clock at any moment.
 
+import * as foliateProgress from 'foliate-js/progress.js';
 import env from '@/services/environment';
 import { SyncClient } from '@/libs/sync';
 import { isSyncCategoryEnabled } from '@/services/sync/syncCategories';
@@ -22,6 +23,7 @@ import { useBookDataStore } from '@/store/bookDataStore';
 import { getBookProgress } from '@/store/readerProgressStore';
 import { DEFAULT_STATS_TRACKING_CONFIG, type StatBook } from '@/types/statistics';
 import type { TTSSession } from '@/services/tts/TTSSessionManager';
+import type { FoliateView } from '@/types/view';
 import { getAccessToken } from '@/utils/access';
 import { StatisticsDb } from './statisticsDb';
 import { pushStats } from './statsSync';
@@ -37,6 +39,40 @@ export const TTS_STATS_HEARTBEAT_MS = 30_000;
 const RENEW_AFTER_SEC = 60;
 
 const PUSH_DEBOUNCE_MS = 10_000;
+
+// The same constants foliate's view passes to its own SectionProgress
+// (view.js: `new SectionProgress(book.sections, 1500, 1600)`). Reusing them
+// keeps a headless fraction on exactly the scale an attached view would report.
+const SIZE_PER_LOC = 1500;
+const SIZE_PER_TIME_UNIT = 1600;
+
+interface SectionPosition {
+  index: number;
+  fraction: number;
+}
+
+interface BookPosition {
+  fraction: number;
+  location: { current: number; total: number };
+}
+
+// foliate/progress.js is untyped JS; these are the two constructors we use.
+interface ProgressModule {
+  PageProgress: new (
+    book: FoliateView['book'],
+    resolveNavigation: FoliateView['resolveCFI'],
+  ) => { getProgress(cfi: string): Promise<SectionPosition | null> };
+  SectionProgress: new (
+    sections: FoliateView['book']['sections'],
+    sizePerLoc: number,
+    sizePerTimeUnit: number,
+  ) => { getProgress(index: number, fractionInSection: number): BookPosition };
+}
+
+interface HeadlessResolver {
+  toSectionPosition(cfi: string): Promise<SectionPosition | null>;
+  toBookPosition(index: number, fractionInSection: number): BookPosition;
+}
 
 const nowSec = () => Math.floor(Date.now() / 1000);
 
@@ -76,6 +112,8 @@ export class TtsStatsRecorder {
   #lastCfi: string | null = null;
   #resolvedCfi: string | null = null;
   #resolvedPage: ResolvedPage | null = null;
+  #headless: HeadlessResolver | null = null;
+  #headlessUnavailable = false;
 
   constructor(session: TTSSession) {
     this.#session = session;
@@ -103,8 +141,8 @@ export class TtsStatsRecorder {
     if (!cfi || this.#lastCfi === cfi) return;
     this.#lastCfi = cfi;
     // Credit a page turn as it happens rather than up to a heartbeat late - but
-    // only where the page is free to read. Headless it costs a getCFIProgress
-    // (which loads the section document), so there it waits for the heartbeat.
+    // only where the page is free to read. Headless it costs a section document
+    // load, so there it waits for the heartbeat.
     if (this.#playing && this.#session.controller.isViewAttached) void this.#tick();
   }
 
@@ -173,24 +211,64 @@ export class TtsStatsRecorder {
     if (!cfi) return null;
     if (this.#resolvedCfi === cfi) return this.#resolvedPage;
 
-    let progress: Awaited<ReturnType<typeof controller.view.getCFIProgress>> = null;
+    const resolver = this.#getHeadlessResolver();
+    if (!resolver) return null;
+
+    let position: SectionPosition | null = null;
     try {
-      progress = await controller.view.getCFIProgress(cfi);
+      position = await resolver.toSectionPosition(cfi);
     } catch (err) {
       console.warn('[stats] failed to resolve the TTS position to a page:', err);
       return null;
     }
-    if (!progress) return null;
+    if (!position || position.index < 0) {
+      console.warn('[stats] could not place the TTS position in the book:', cfi);
+      return null;
+    }
 
-    const resolved = this.#pageFromProgress(progress);
+    const resolved = this.#pageFromProgress(
+      resolver.toBookPosition(position.index, position.fraction),
+    );
     this.#resolvedCfi = cfi;
     this.#resolvedPage = resolved;
     return resolved;
   }
 
-  #pageFromProgress(
-    progress: NonNullable<Awaited<ReturnType<TTSSession['controller']['view']['getCFIProgress']>>>,
-  ): ResolvedPage | null {
+  /**
+   * Build a progress resolver that survives the book being closed.
+   *
+   * `view.getCFIProgress` is not usable here: `view.close()` nulls the
+   * `#sectionProgress`/`#cfiProgress` helpers it reads (foliate view.js), so it
+   * returns null exactly when a headless session needs it. The book itself and
+   * `resolveCFI` (which delegates to `book.resolveCFI`) both survive, and they
+   * are all foliate's own progress classes require - so rebuild the same
+   * computation on top of those.
+   */
+  #getHeadlessResolver(): HeadlessResolver | null {
+    if (this.#headless || this.#headlessUnavailable) return this.#headless;
+    const view = this.#session.controller.view;
+    const book = view?.book;
+    if (!book?.sections?.length) {
+      console.warn('[stats] no book available to place the TTS position');
+      this.#headlessUnavailable = true;
+      return null;
+    }
+    try {
+      const { PageProgress, SectionProgress } = foliateProgress as unknown as ProgressModule;
+      const cfiProgress = new PageProgress(book, (cfi: string) => view.resolveCFI(cfi));
+      const sectionProgress = new SectionProgress(book.sections, SIZE_PER_LOC, SIZE_PER_TIME_UNIT);
+      this.#headless = {
+        toSectionPosition: (cfi) => cfiProgress.getProgress(cfi),
+        toBookPosition: (index, fraction) => sectionProgress.getProgress(index, fraction),
+      };
+    } catch (err) {
+      console.warn('[stats] failed to build the headless progress resolver:', err);
+      this.#headlessUnavailable = true;
+    }
+    return this.#headless;
+  }
+
+  #pageFromProgress(progress: BookPosition): ResolvedPage | null {
     // Stay on the layout's own scale so listening rows and reading rows remain
     // comparable, which is what makes COUNT(DISTINCT page) meaningful.
     const layoutPages = useBookDataStore.getState().getConfig(this.#session.bookKey)?.progress?.[1];

--- a/apps/readest-app/src/services/tts/TTSSessionManager.ts
+++ b/apps/readest-app/src/services/tts/TTSSessionManager.ts
@@ -4,11 +4,12 @@
 // bookKey is `${hash}-${uniqueId()}` — so sessions key by book HASH and treat
 // bookKey as ephemeral. The manager owns everything that must outlive the
 // reader's React hooks: the media bridge binding, the silent keep-alive, the
-// sleep timer, headless progress persistence, and the app-level playback
-// state relay. It is a per-webview singleton by design (multi-window desktop
-// keeps its current per-window behavior).
+// sleep timer, headless progress persistence, reading-statistics capture, and
+// the app-level playback state relay. It is a per-webview singleton by design
+// (multi-window desktop keeps its current per-window behavior).
 
 import env from '@/services/environment';
+import { TtsStatsRecorder } from '@/services/statistics/ttsStatsRecorder';
 import { stubTranslation as _ } from '@/utils/misc';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useSettingsStore } from '@/store/settingsStore';
@@ -53,6 +54,7 @@ export class TTSSessionManager extends EventTarget {
   #onSessionEnded: ((e: Event) => void) | null = null;
   #onHighlightMark: ((e: Event) => void) | null = null;
   #lastRelayedState: 'playing' | 'paused' | null = null;
+  #statsRecorder: TtsStatsRecorder | null = null;
   #sleepTimer: ReturnType<typeof setTimeout> | null = null;
   #sleepTimeoutSec = 0;
   #sleepFiresAt = 0;
@@ -98,6 +100,13 @@ export class TTSSessionManager extends EventTarget {
 
   getActiveSession(): TTSSession | null {
     return this.#session;
+  }
+
+  // The last state relayed on the tts-playback-state bus. Lets a listener that
+  // mounts mid-session (opening the reader from the mini player) seed itself
+  // instead of waiting for a transition that already happened.
+  getPlaybackState(): 'playing' | 'paused' | null {
+    return this.#lastRelayedState;
   }
 
   // The session survives; only the view goes away. The bridge stays bound so
@@ -239,7 +248,21 @@ export class TTSSessionManager extends EventTarget {
     this.#sleepFiresAt = 0;
   }
 
+  // Flush and drop the recorder. It owns a heartbeat interval, so it must never
+  // be replaced without going through here or the orphan keeps writing.
+  #releaseStatsRecorder(): void {
+    const recorder = this.#statsRecorder;
+    this.#statsRecorder = null;
+    if (!recorder) return;
+    void recorder.stop().catch((err) => console.warn('[stats] TTS stats flush failed:', err));
+  }
+
   #subscribe(controller: TTSController): void {
+    // Listening is reading, so it feeds the same page_stat_data table. The
+    // recorder lives here rather than in the reader because a headless session
+    // (library mini player, lock screen, CarPlay) has no React tree left.
+    this.#releaseStatsRecorder();
+    this.#statsRecorder = this.#session ? new TtsStatsRecorder(this.#session) : null;
     this.#onStateChange = (e: Event) => {
       const { state } = (e as CustomEvent<{ state: string }>).detail;
       const session = this.#session;
@@ -252,6 +275,9 @@ export class TTSSessionManager extends EventTarget {
       else if (state.includes('paused')) mapped = 'paused';
       if (!mapped || mapped === this.#lastRelayedState) return;
       this.#lastRelayedState = mapped;
+      // Before the relay: the reading tracker stands down on this same event,
+      // and the two must never bill the same wall-clock twice.
+      this.#statsRecorder?.onPlaybackState(mapped);
       eventDispatcher.dispatch('tts-playback-state', { bookKey: session.bookKey, state: mapped });
     };
     this.#onSessionEnded = (e: Event) => {
@@ -260,6 +286,7 @@ export class TTSSessionManager extends EventTarget {
     };
     this.#onHighlightMark = (e: Event) => {
       const { cfi } = (e as CustomEvent<{ cfi: string }>).detail;
+      this.#statsRecorder?.onMark(cfi);
       this.#persistLocation(cfi);
     };
     controller.addEventListener('tts-state-change', this.#onStateChange);
@@ -268,6 +295,10 @@ export class TTSSessionManager extends EventTarget {
   }
 
   #unsubscribe(controller: TTSController): void {
+    // Flush against the session the recorder was built for — every unbind path
+    // (stop, release, same-book controller swap) runs through here, and
+    // stopActive has already cleared #session by this point.
+    this.#releaseStatsRecorder();
     if (this.#onStateChange) {
       controller.removeEventListener('tts-state-change', this.#onStateChange);
     }


### PR DESCRIPTION
## Problem

Reading statistics are driven by exactly one input: page turns reported by a laid-out view (`ReadingStatsTracker`). TTS only ever reached that indirectly, through the relocations auto-follow happens to produce. So listening recorded partial time at best, and nothing at all when:

- auto-follow was suppressed (`useTTSControl.ts` `followingTTSLocationRef`) because you paged away
- the book was closed entirely and playback continued from the library mini player, the lock screen, or CarPlay

## Approach

`TtsStatsRecorder` gives listening its own clock, on one rule: **the page being narrated is the page being read**. It is owned by `TTSSessionManager` rather than the reader, because a headless session has no React tree left. It writes the same KOReader `page_stat_data` rows through the same `StatisticsDb`, so listening and reading are indistinguishable downstream, which is the point. No schema change, no read-vs-listened flag, sync untouched.

`ReadingStatsTracker` stands down while its own book is read aloud (matched by book hash, so reading book B while listening to book A still records), seeded from the session manager so opening the reader mid-session does not miss the transition. Exactly one of the two owns the clock at any moment.

Page numbers come from the live view where one is attached, and from the TTS position mapped onto the layout's own page count where none is.

Two deliberate departures from manual reading:

- **No idle timer.** Reading arms one because a stationary page probably means you walked away; audible narration is proof you did not.
- **Renewal every 60s.** `TrackerCore` caps a single event at `maxEventSeconds` and drops the excess. Reopening on the same page with a later `start_time` keeps the time without weakening that cap, since the primary key is `(book, page, start_time)`.

## Note on the second commit

The first implementation resolved the headless page through `view.getCFIProgress`. Driving the app in Chrome showed that path recorded nothing: `view.close()` nulls the `#sectionProgress` and `#cfiProgress` helpers that method reads, and it optional chains off them, so it returned null from the moment the book closed, which is the only moment the path runs. The unit tests could not see it because they stubbed `getCFIProgress` and never modelled a closed view.

The fix rebuilds the same computation from what `close()` leaves alone: `book` survives (`TTSController` already reads `book.sections` headless to keep speaking), `resolveCFI` delegates to `book.resolveCFI`, and foliate's `PageProgress` / `SectionProgress` need nothing else. It reuses view.js's own `1500, 1600` constants so the fraction stays on the same scale.

## Verification

`pnpm test` (8327 passed), `pnpm lint`, `pnpm format:check`. No `src-tauri/` changes.

Driven in Chrome on the web build, both paths:

- **Reader open** — `READING wrote p1/17 19s` as TTS starts, then `TTS wrote p1/17 60s` exactly 60s later, and no READING writes in between. The handoff holds and nothing is double billed.
- **Book closed** — `p9 63s` then `p11 30s` then `p12 60s` (a full renewal) then `p14 13s` (final flush on stop), pages advancing on the layout's own 17-page scale.

The regression test for the headless path models a closed view, with only `book` and `resolveCFI` present, and runs foliate's real progress classes over a synthetic book rather than stubbing the resolve away.

**Not verified:** Android screen-off, iOS lock screen, and CarPlay. Those are untouched by the above and want a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)