### PR TITLE
fix(android): stabilize the nightly e2e lane and the top-inset touch overlays

### DIFF
--- a/apps/readest-app/src/__tests__/android/helpers/reader.ts
+++ b/apps/readest-app/src/__tests__/android/helpers/reader.ts
@@ -27,6 +27,12 @@ export const detectAndroidEnv = async (): Promise<AndroidEnv | null> => {
   const serials = await listDeviceSerials();
   if (serials.length === 0) return null;
   if (!(await isPackageInstalled(APP_PKG))) return null;
+  // Pre-confirm the one-time "Viewing full screen" prompt. On a fresh device
+  // it pops over the top half of the screen the first time the reader hides
+  // the system bars and silently swallows every touch injected there — presses
+  // land in the app only below the prompt, which reads as unexplainable
+  // gesture flakiness rather than a visible failure.
+  await adbShell('settings put secure immersive_mode_confirmations confirmed').catch(() => {});
   return { serial: process.env['ANDROID_SERIAL'] ?? serials[0]! };
 };
 
@@ -88,6 +94,14 @@ export const patchGlobalViewSettings = async (
  */
 export const openFixtureBook = async (fixtureFile: string): Promise<CdpPage> => {
   const remote = `${REMOTE_FIXTURE_DIR}/${path.basename(fixtureFile)}`;
+  // Cold-start every time. When a previous test file left the reader open on
+  // this fixture, the VIEW intent re-imports the book and remounts
+  // foliate-view a beat AFTER the old, fully rendered reader has satisfied
+  // the readiness probes below — the caller's first evaluate then lands in
+  // the remount window and finds no foliate-view (nightly: "Cannot read
+  // properties of null (reading 'renderer')").
+  await adbShell(`am force-stop ${APP_PKG}`);
+  await sleep(1_000);
   await pushFile(fixtureFile, remote);
 
   // Register the file with MediaStore so a content:// URI exists — receivers

--- a/apps/readest-app/src/__tests__/android/top-band-selection.android.test.ts
+++ b/apps/readest-app/src/__tests__/android/top-band-selection.android.test.ts
@@ -9,6 +9,7 @@ import {
   getSelectionState,
   gotoChapter,
   openFixtureBook,
+  patchGlobalViewSettings,
   waitFor,
 } from './helpers/reader';
 
@@ -21,9 +22,20 @@ import {
 // selected nothing and no annotation popup appeared.
 //
 // The lane drives the installed app, so it exercises the WebView's real hit
-// testing — the part jsdom cannot model. Page-header-off geometry is forced by
-// overriding the renderer's `margin-top` instead of patching settings, so the
-// test runs against any build (release included) and leaves settings alone.
+// testing — the part jsdom cannot model. The page header is turned off by
+// seeding settings (debug build, run-as — like the rest of the lane), and the
+// compact margin is then forced by overriding the renderer's `margin-top` so
+// the text lands inside the band regardless of the device's safe-area inset.
+//
+// The band case asserts hit-test transparency with elementFromPoint rather
+// than a real long press: while the app is immersive, SystemUI captures any
+// injected touch that starts inside the hidden status bar's frame for its
+// swipe-down reveal, so gestures cannot be delivered up there on emulators.
+// elementFromPoint runs the same WebView hit test the touch pipeline uses,
+// and it is what both regressions actually broke (the trigger band in #5429
+// and the header wrapper's safe-area padding box after it). The control case
+// keeps the full gesture -> selection -> popup path, pressed below the inset
+// where injection is deliverable.
 
 const FIXTURE = path.resolve(__dirname, '../fixtures/data/sample-alice.epub');
 /** Height of the header hover trigger (`h-11` in HeaderBar). */
@@ -32,6 +44,7 @@ const TRIGGER_BAND_PX = 44;
 const COMPACT_MARGIN_TOP_PX = 16;
 
 interface LineTarget {
+  cssX: number;
   cssY: number;
   deviceX: number;
   deviceY: number;
@@ -126,6 +139,7 @@ const locateLine = (page: CdpPage, index: number) =>
     const cssX = line.x + Math.min(line.width, 160) / 2;
     const cssY = line.y + line.height / 2;
     return {
+      cssX,
       cssY,
       deviceX: Math.round(cssX * dpr),
       deviceY: Math.round(cssY * dpr),
@@ -140,11 +154,22 @@ if (!env) {
 
 describe.runIf(env)('Android selection under the header trigger band (#5429)', () => {
   let page: CdpPage;
+  let savedViewSettings: Record<string, unknown>;
 
   beforeAll(async () => {
+    // Page header OFF, like the reporter's setup. With the header on, the
+    // SectionInfo band owns the top strip; its geometry tracks
+    // viewSettings.marginTopPx, so overriding only the renderer margin below
+    // desyncs the two and the strip swallows the presses this test sends.
+    // Header off unmounts SectionInfo entirely. Patching settings needs the
+    // debug build, which the lane already requires elsewhere (run-as).
+    savedViewSettings = await patchGlobalViewSettings({ showHeader: false });
     page = await openFixtureBook(FIXTURE);
     await gotoChapter(page, 'chapter\\s*4');
-    // Page-header-off geometry: body text now renders inside the band.
+    // Compact page-header-off top margin. The raw renderer override (rather
+    // than the settings value) makes the geometry inset-agnostic: text starts
+    // 16px from the screen top even on devices whose safe-area inset would
+    // push the app-computed margin below the 44px trigger band.
     await setTopMargin(page, COMPACT_MARGIN_TOP_PX);
     // A chapter's opening page starts with a heading well below the band, so
     // page forward until one starts with body text (discover, don't assume —
@@ -160,44 +185,62 @@ describe.runIf(env)('Android selection under the header trigger band (#5429)', (
     );
   }, 180_000);
 
-  afterAll(() => {
+  afterAll(async () => {
     page?.close();
-  });
+    if (savedViewSettings) await patchGlobalViewSettings(savedViewSettings);
+  }, 60_000);
 
   beforeEach(async () => {
     // Each case asserts that the popup appears, so it must start with none.
     await dismissPopup(page);
     const sel = await getSelectionState(page);
-    if (sel.exists && !sel.collapsed) await dismissSelection(page);
-    else await clearDomSelection(page);
+    // Tap-dismiss even a collapsed caret: clearing only the DOM ranges leaves
+    // the WebView's touch-selection controller armed, and the next long-press
+    // then places a caret instead of selecting a word.
+    if (sel.exists) await dismissSelection(page);
+    await clearDomSelection(page);
     await hideHeaderBar(page);
     expect(await hasAnnotationPopup(page)).toBe(false);
   }, 60_000);
 
-  it('opens the annotation popup for the first line, which renders inside the band', async () => {
+  it('keeps the band transparent so a press reaches the first line', async () => {
     const line = await waitFor(() => locateLine(page, 0), { label: 'first line of the page' });
-    // Guard the premise: without this the test would silently pass by pressing
+    // Guard the premise: without this the test would silently pass by probing
     // a line the trigger never covered.
     expect(line.cssY).toBeLessThan(TRIGGER_BAND_PX);
 
-    await longPress(line.deviceX, line.deviceY);
-
-    // Assert the popup rather than a DOM selection: with the instant-highlight
-    // quick action on (the reporter's setup) the hold annotates instead of
-    // selecting, and the popup is what the user is denied either way.
-    const popup = await waitFor(() => hasAnnotationPopup(page), {
-      label: 'annotation popup for the first line',
-    });
-    expect(popup).toBe(true);
+    // Whatever owns this point receives the finger. Before the #5429 fix the
+    // hover trigger resolved here; after it, the header wrapper's safe-area
+    // padding box did. Both swallowed the long press that should have opened
+    // the annotation popup.
+    const owner = await page.evaluate<string>(`
+      const el = document.elementFromPoint(${line.cssX}, ${line.cssY});
+      if (!el) return 'none';
+      const view = document.querySelector('foliate-view');
+      if (view && (el === view || view.contains(el))) return 'reader';
+      return el.tagName + '.' + String(el.className);
+    `);
+    expect(owner).toBe('reader');
   });
 
   it('opens the annotation popup for a line below the trigger band', async () => {
     // Control: the same gesture on a line the trigger never covered always
     // worked, so a failure here means the harness, not the fix, is broken.
+    // Press mid-screen: adb injection cannot start inside the hidden status
+    // bar's frame (SystemUI captures it for its swipe-down reveal), and
+    // emulator WebViews place a caret instead of selecting a word for presses
+    // in the top region — neither is the overlay regression this control
+    // anchors, so keep the gesture well clear of both.
+    const { height } = await viewportMetrics(page);
+    const minY = Math.max(TRIGGER_BAND_PX * 2, height * 0.3);
     const line = await waitFor(
       async () => {
-        const l = await locateLine(page, 2);
-        return l && l.cssY > TRIGGER_BAND_PX ? l : null;
+        for (let i = 0; i < 16; i++) {
+          const l = await locateLine(page, i);
+          if (!l) return null;
+          if (l.cssY > minY) return l;
+        }
+        return null;
       },
       { label: 'a line below the trigger band' },
     );

--- a/apps/readest-app/src/app/reader/components/HeaderBar.tsx
+++ b/apps/readest-app/src/app/reader/components/HeaderBar.tsx
@@ -152,7 +152,11 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
   return (
     <div
       className={clsx(
-        'left-0 top-0 w-full',
+        // pointer-events-none: the wrapper is as tall as its safe-area
+        // padding, so on notch devices its box covers the top inset strip and
+        // swallowed long presses on text rendered there (#5429) — children
+        // that take input restore pointer-events themselves.
+        'pointer-events-none left-0 top-0 w-full',
         isHeaderVisible && 'bg-base-100',
         window.innerWidth < 640 ? 'fixed z-20' : 'absolute',
       )}
@@ -172,7 +176,7 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
         tabIndex={-1}
         className={clsx(
           'absolute top-0 z-10 h-11 w-full',
-          (isMobile || pointerInDoc) && 'pointer-events-none',
+          isMobile || pointerInDoc ? 'pointer-events-none' : 'pointer-events-auto',
         )}
         onClick={() => setHoveredBookKey(bookKey)}
         onMouseEnter={() => !appService?.isMobile && setHoveredBookKey(bookKey)}
@@ -218,10 +222,11 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
           {/* h-full so this scroller spans the whole bar: `overflow-x-auto`
               also clips vertically, and shrink-wrapped to the 32px icons it
               cut the buttons' touch halos back down to 32px (#5401). */}
-          <div
-            className='flex h-full min-w-0 items-center gap-x-4 overflow-x-auto max-[350px]:gap-x-2'
-            style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
-          >
+          {/* no-scrollbar: the overlay scrollbar of `overflow-x-auto` owns a
+              hit-test strip at the scroller's bottom edge on Android, which
+              cut the touch halos short of the 44px target (#5401) —
+              `scrollbar-width: none` alone does not remove that strip. */}
+          <div className='no-scrollbar flex h-full min-w-0 items-center gap-x-4 overflow-x-auto max-[350px]:gap-x-2'>
             {!isSideBarVisible && (
               <div className='hidden sm:flex'>
                 <SidebarToggler bookKey={bookKey} />

--- a/apps/readest-app/src/app/reader/components/HintInfo.tsx
+++ b/apps/readest-app/src/app/reader/components/HintInfo.tsx
@@ -62,15 +62,20 @@ const HintInfo: React.FC<SectionInfoProps> = ({
 
   return (
     <>
+      {/* Display-only: without pointer-events-none the invisible inset strip
+          swallows presses on text rendered inside the safe area (#5429). */}
       <div
-        className={clsx('absolute left-0 right-0 top-0 z-10', hintMessage ? '' : 'bg-transparent')}
+        className={clsx(
+          'pointer-events-none absolute left-0 right-0 top-0 z-10',
+          hintMessage ? '' : 'bg-transparent',
+        )}
         style={{
           height: `${topInset}px`,
         }}
       />
       <div
         className={clsx(
-          'hintinfo absolute flex items-center justify-end overflow-hidden ps-2',
+          'hintinfo pointer-events-none absolute flex items-center justify-end overflow-hidden ps-2',
           hintMessage ? '' : 'bg-transparent',
           isVertical ? 'writing-vertical-rl' : 'top-0 h-[44px]',
           isScrolled

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -418,10 +418,18 @@ foliate-fxl {
   position: relative;
 }
 
+/* Grow the hit area to the 44px mobile target (DESIGN.md) instead of bleeding
+   a fixed 12px past the icon: on narrow screens the reader header packs 32px
+   controls with 8px gaps, and a 12px bleed reached 4px into the neighboring
+   icon, so a tap on one icon fired the other. */
 .touch-target::before {
   content: '';
   position: absolute;
-  inset: -12px;
+  left: 50%;
+  top: 50%;
+  width: max(100%, 44px);
+  height: max(100%, 44px);
+  transform: translate(-50%, -50%);
 }
 
 .no-context-menu {


### PR DESCRIPTION
## Summary

Fixes the first failing nightly of the combined Android E2E lane ([run 30764355022](https://github.com/readest/readest/actions/runs/30764355022/job/91540338624)). The three new test files (#5430, #5432, #5437) had never run together on CI before; reproducing the sequence on a default-profile 320x640 AVD (the same device CI creates) surfaced three independent problems, two of them real app bugs.

### Test harness

- **`openFixtureBook` stale-reader race** (the `Cannot read properties of null (reading 'renderer')` beforeAll failures): when a previous test file left the reader open on the same fixture, the VIEW intent re-imports the book and remounts `foliate-view` *after* the old, fully rendered reader has already satisfied the readiness probes. The helper now force-stops the app first so every file cold-opens.
- **Android's one-time "Viewing full screen" prompt**: on a fresh device it covers the top half of the screen the first time the reader hides the system bars, and silently swallows every injected touch there — the source of the `timed out waiting for header bar shown` beforeEach failures and most of the gesture flakiness. The lane now pre-confirms it (`settings put secure immersive_mode_confirmations confirmed`).
- **Top-band test rework**: the band case now asserts hit-test transparency via `elementFromPoint` (SystemUI captures injected touches that start inside the hidden status bar's frame for its swipe-down reveal, so real gestures cannot be delivered up there on emulators); the control case keeps the full long-press → popup path, pressed mid-screen. The page header is seeded off so SectionInfo — whose geometry tracks the settings value this test bypasses — is unmounted.

### App fixes

- **Touch halos could fire the neighboring header icon** (the `Add Bookmark hit [29,40] vs box [32,32]` assertion): `.touch-target::before` bled a fixed 12px past the icon, which reaches 4px into the neighbor at the header's compact 8px gaps (≤350px screens — CI's viewport). The halo is now sized to `max(100%, 44px)` centered, preserving the DESIGN.md 44px target everywhere without ever covering a neighbor icon.
- **The header scroller's overlay scrollbar stole the bottom ~5px of every button's hit area** (verified on-device: hits were 40px tall, not 44). `scrollbar-width: none` does not remove the hit strip; the `no-scrollbar` utility (`::-webkit-scrollbar { display: none }`) does.
- **#5429 was back on notch devices**: the header wrapper's safe-area padding box and HintInfo's inset strip are invisible, handler-less layers that still swallowed presses on text rendered inside the top inset (reachable with small or negative top margins, #5303). Both are now pointer-transparent; interactive children restore `pointer-events` themselves.

## Test plan

- Full lane green on a default-profile 320x640 API 36 AVD matching CI: 5 files, 16/16 tests.
- Pixel 9 Pro AVD: 15/16 — `double-click` fails on that profile with or without these changes (passes on the CI profile; the double-tap → toolbar flow verified working via CDP probe), so it is a pre-existing local-emulator quirk, not a regression.
- `pnpm lint` and the full unit suite (8327 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)