### PR TITLE
fix: install playwright browsers in nix flake

### DIFF
--- a/ops/flake.nix
+++ b/ops/flake.nix
@@ -52,6 +52,7 @@
           xdg-utils
           patchelf
           wrapGAppsHook4
+          playwright-driver.browsers
           self.formatter.${pkgs.stdenv.hostPlatform.system}
         ];
 
@@ -105,6 +106,10 @@
             env = {
               GDK_BACKEND = "x11";
               LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+
+              PLAYWRIGHT_BROWSERS_PATH = pkgs.playwright-driver.browsers;
+              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = 1;
+              PLAYWRIGHT_HOST_PLATFORM_OVERRIDE = "ubuntu-24.04";
             } // extraEnv;
 
             shellHook = ''


### PR DESCRIPTION
Adds playwright to nix flake. This allows `pnpm test:browser` to be run inside the nix devshell.

Installing playwright browsers through pnpm does not work on non-FHS systems, so it has to be installed through nix. playwright itself can be installed through pnpm.