### PR TITLE
chore: update agent memories

### DIFF
--- a/apps/readest-app/.claude/memory/MEMORY.md
+++ b/apps/readest-app/.claude/memory/MEMORY.md
@@ -35,6 +35,7 @@
 - #5067 shelf progress never pulled `mergeBookMetadata` subset = what travels
 - [koplugin local_present sweep](koplugin-local-present-sweep-noop.md) UNFIXED; OR-merge defeats stale sweep; fix = rm readest_library.sqlite3
 - [10k library breaks /sync pull](sync-pull-10k-worker-1102.md) MERGED #5364; CF 1102; paged books pull synced_at ASC + tie-completion; old clients wedge till app update
+- [#5444 CORS preflight cache fix](cors-preflight-cache-fix-5444.md) VERIFIED in prod: OPTIONS -83% in minutes; wrangler OAuth token works for CF GraphQL analytics (1d max range)
 ## Build, Testing & CI
 - [Turbopack dev stale chunk phantom](turbopack-dev-stale-chunk-phantom.md) reload does NOT help; fiber String(f.type) to verify; rm -rf .next + restart
 - [Screenshot baselines unregenerable](vitest-screenshot-baseline-relative-path.md) FIXED in #5351; relative resolveScreenshotPath -> server.fs denies write; `--update` was a silent no-op; allowWrite is NOT it
@@ -42,6 +43,7 @@
 - [format:check gate](verify-format-check-gate.md) · [Worktree rebase submodule drift](worktree-rebase-submodule-drift.md)
 - Android CDP: [e2e lane](android-cdp-e2e-lane.md); [profiling](cdp-android-webview-profiling.md); [double-tap](android-e2e-doubletap-cdp-gesture.md)
 - [Android e2e local repro](android-e2e-local-repro-workflow.md) dev-android vs debug run-as
+- [Nightly e2e fix](android-e2e-nightly-fix-5453.md) PR #5453; immersive prompt eats touches (screencap first!); openFixtureBook cold-start; halo max(100%,44px); wrapper/HintInfo pointer-none
 - [iOS sim drive via dev-server relay](ios-sim-drive-via-dev-server-relay.md)
 - [iOS sim build+drive workflow](ios-sim-build-and-drive-workflow.md) `--target aarch64-sim`; CLI rename fails so take the app from the **xcarchive**, not `build/arm64-sim`
 - [Tauri Rust↔JS parser parity](tauri-parser-parity-tests.md)
@@ -67,7 +69,7 @@
 - [0.11.20 iOS .txt/.md share sheet lost](ios-txt-share-sheet-tauri211-fileassoc.md) MERGED #5415; tauri-cli 2.11 fileAssociations clobber hand-tuned CFBundleDocumentTypes; device-verify pending
 - [#5397 Photos save crash](ios-photos-add-usage-description-5397.md) MERGED #5405, device-verify pending; missing `NSPhotoLibraryAddUsageDescription`; "Save to Photos" is WebKit's menu not our code; key also un-hides "Save Image" in our share sheet
 ## Reader Features & UI
-- [TTS listening counts as reading stats](tts-listening-counts-as-reading-stats.md) committed bc1d8d5e5 on feat/tts-reading-stats, NOT pushed; TtsStatsRecorder in TTSSessionManager; background/CarPlay device-verify PENDING
+- [TTS listening counts as reading stats](tts-listening-counts-as-reading-stats.md) MERGED #5450; `view.getCFIProgress` is DEAD after `view.close()`, rebuild from book+resolveCFI; Android/iOS/CarPlay device verify PENDING
 - [#5398/#3870 annotations hub](annotations-hub-5398-3870.md) MERGED #5448; shared filterBooknotes/facets; toolbar = icon row + filter dropdown (must merge injected menuClassName); header search icon is per-tab contextual
 - [Mobile sheet virtuoso first-paint blank](mobile-sheet-virtuoso-first-paint-blank.md) PRE-EXISTING, no issue filed; blank until first touch
 - [PR #5389 library full-text search review](pr-5389-library-search-review.md) uncapped contains mode blocks; real-text bench 130MB/s; plan in .agents/plans

--- a/apps/readest-app/.claude/memory/android-e2e-nightly-fix-5453.md
+++ b/apps/readest-app/.claude/memory/android-e2e-nightly-fix-5453.md
@@ -1,0 +1,24 @@
+---
+name: android-e2e-nightly-fix-5453
+description: "First combined Android E2E nightly failed on 3 independent causes - openFixtureBook stale-reader race, Android's one-time 'Viewing full screen' prompt eating injected touches, touch-halo overlap + scrollbar hit-strip; PR #5453"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 9fa5b6e3-aa83-46fd-be87-4823e311c152
+  modified: 2026-08-02T21:58:33.475Z
+---
+
+Nightly android-e2e run 30764355022 (2026-08-02, first run of the 3 new e2e files together) → PR #5453 (fix/android-e2e-nightly). Root causes, each independently verified on a default-profile 320x640 AVD (what CI creates — `avdmanager` default hardware, mdpi, DPR 1) plus Pixel_9_Pro:
+
+1. **openFixtureBook stale-reader race** (`null (reading 'renderer')` in beforeAll): a previous test file's still-open reader satisfies the readiness probes instantly; the VIEW intent then remounts foliate-view and the caller's first evaluate lands in the gap. Fix: `am force-stop` + 1s sleep before the intent (cold-open per file).
+2. **Android's one-time "Viewing full screen" prompt** covers the top ~40% of a fresh device's screen when the app first hides system bars and SILENTLY eats every injected touch in its bounds — no DOM events at all. Looks like unexplainable per-position gesture flakiness ("first press works, later ones die" = prompt appears when immersive kicks in). Fix: `settings put secure immersive_mode_confirmations confirmed` in detectAndroidEnv. Diagnosed only by `adb exec-out screencap` — touch-log instrumentation showed nothing pre-DOM.
+3. **Touch halos** (#5437 follow-up): `.touch-target::before { inset: -12px }` reached 4px into the neighbor icon at compact `gap-x-2` (≤350px). Now sized `max(100%, 44px)` centered. Plus the header scroller's overlay scrollbar owns a ~5px hit strip at its bottom edge (hits were 40px not 44); `scrollbar-width: none` does NOT remove the strip, `.no-scrollbar` (`::-webkit-scrollbar{display:none}`) does.
+4. **#5429 back on notch devices**: header wrapper's safe-area padding box + HintInfo's inset strip are invisible handler-less layers that swallow presses on text inside the top inset (reachable via small/negative margins #5303). Both now `pointer-events-none`. SectionInfo's notch mask is fine — `min(topInset, band.bottom)` never overlaps content top.
+
+**Why:** these four are archetypes: cross-file app state through Android intents; system overlays invisible to DOM instrumentation; hit-area CSS interacting with clipping/scrollbars; decorative overlays needing pointer-events-none.
+
+**How to apply:** when an Android e2e gesture "does nothing" with zero DOM touch events, screencap FIRST — system overlays (immersive prompt, shade) are invisible to DOM probes. SystemUI also captures injected touches starting inside the hidden status bar frame (immersive reveal strip) — gestures cannot be delivered there on emulators; assert hit-test transparency via elementFromPoint instead. CDP `synthesizeTapGesture` with long duration fires long-press but ALSO a trailing tap that self-dismisses the popup — unreliable. `Input.dispatchTouchEvent` bypasses the gesture recognizer entirely (no long-press ever).
+
+Known quirk: double-click.android.test.ts fails on Pixel_9_Pro AVD regardless of these changes (passes on CI profile + 320px AVD; app flow verified OK via CDP probe). ci_like AVD exists locally (320x640, created via avdmanager no-profile; bump hw.ramSize from 96M or it won't boot). Emulators die if proxy env vars point at a dead proxy (127.0.0.1:8118) — launch with `env -u http_proxy ...`.
+
+Related: [[android-cdp-e2e-lane]], [[android-e2e-local-repro-workflow]], [[header-notch-negative-margin-5303]], [[toolbar-touch-target-5401]]

--- a/apps/readest-app/.claude/memory/cors-preflight-cache-fix-5444.md
+++ b/apps/readest-app/.claude/memory/cors-preflight-cache-fix-5444.md
@@ -1,0 +1,34 @@
+---
+name: cors-preflight-cache-fix-5444
+description: "#5444 CORS preflight cache fix VERIFIED in prod: OPTIONS dropped ~83% within minutes of deploy; also the recipe for querying CF worker metrics via wrangler OAuth token"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: bb9fe665-4482-4621-a277-a99332d2e005
+  modified: 2026-08-02T19:58:59.692Z
+---
+
+PR #5444 (`c181e6f5e`, merged 2026-08-02) replaced `Access-Control-Allow-Headers: *` with echoing
+`Access-Control-Request-Headers` (fallback `Authorization, Content-Type`) + `Vary: Origin,
+Access-Control-Request-Headers` in `src/middleware.ts`, because the Fetch spec excludes
+`Authorization` from wildcard matching in the browser preflight cache — so every authenticated call
+from Tauri clients (origin `http://tauri.localhost`) re-preflighted despite `Max-Age: 86400`.
+
+**Verified in production 2026-08-02** (deploy 19:35:50 UTC): minute-level zone analytics showed
+OPTIONS collapse from ~2,200/min (35–40% of all requests) to ~350/min (~7.6% share) within 20
+minutes — an ~84% OPTIONS reduction; total worker requests fell ~30%. Residual preflights are
+expected: first-hit per client per URL, and Chrome caps `Access-Control-Max-Age` at 2 hours
+regardless of the header.
+
+**How to check readest-web CF metrics** (no API token in .env files needed):
+- wrangler OAuth token from `~/.wrangler/config/default.toml` (`oauth_token = "..."`) works as a
+  Bearer token for `https://api.cloudflare.com/client/v4/graphql` and REST.
+- Account `69a7e6e1c1cf4ecba13b6eb603210dfe` (Readest), zone readest.com =
+  `f697810279605f42c6588e1abb3273b4`; worker `readest-web` serves web.readest.com,
+  web-cf.readest.com, api-cf.readest.com.
+- Dataset `httpRequestsAdaptiveGroups` with `clientRequestHTTPMethodName` + `datetimeHour`/
+  `datetimeMinute` dimensions; estimate = `count * avg.sampleInterval`. The zone plan rejects
+  time ranges wider than **1 day** per query — window the queries.
+- Deploy timestamps: REST `GET /accounts/{acct}/workers/scripts/readest-web/deployments`.
+- Note the OAuth token is short-lived; wrangler refreshes it when used. `npx wrangler whoami` can
+  take >120s behind the proxy.

--- a/apps/readest-app/.claude/memory/tts-listening-counts-as-reading-stats.md
+++ b/apps/readest-app/.claude/memory/tts-listening-counts-as-reading-stats.md
@@ -1,39 +1,46 @@
 ---
 name: tts-listening-counts-as-reading-stats
-description: "TTS playback now writes reading stats via TtsStatsRecorder; committed on feat/tts-reading-stats, device verification for background/CarPlay still pending"
+description: "TTS playback writes reading stats via TtsStatsRecorder; browser-verified with reader open, headless path fixed but not yet re-verified in a browser"
 metadata: 
   node_type: memory
   type: project
   originSessionId: 4e4bd750-d778-4598-bc3a-9f609af23449
-  modified: 2026-08-02T18:36:12.157Z
+  modified: 2026-08-02T20:18:01.771Z
 ---
 
-TTS listening now records reading statistics. Committed 2026-08-03 as
-`bc1d8d5e5` on branch `feat/tts-reading-stats` (worktree
-`/Users/chrox/dev/readest-feat-tts-reading-stats`, based on origin/main
-`4f44b79ec`). Not pushed, no PR yet.
+TTS listening now records reading statistics. **MERGED 2026-08-03 as PR #5450**
+(merge commit `c1b0a4ecd`). Worktree and branch removed.
 
 **Why it was broken:** the stats tracker's only input is `progress.pageinfo`
 changes. TTS reached it purely by accident, via the relocations auto-follow
-produces. With follow suppressed (`useTTSControl.ts` `followingTTSLocationRef`)
-or the reader closed, zero stats.
+produces. With follow suppressed or the reader closed, zero stats.
 
-**Shape of the fix:** `TtsStatsRecorder` (non-React) owned by
-`TTSSessionManager`, because that is the only thing alive during headless
-playback. Writes the same KOReader `page_stat_data` rows, no schema change.
-`ReadingStatsTracker` goes dormant on `tts-playback-state` = playing for its
-own book hash, so the two never double-count.
+**Shape:** `TtsStatsRecorder` (non-React) owned by `TTSSessionManager`, the only
+thing alive during headless playback. Same KOReader `page_stat_data` rows, no
+schema change. `ReadingStatsTracker` goes dormant on `tts-playback-state` =
+playing for its own book hash, so the two never double-count.
 
-**Known limitation, accepted deliberately:** when auto-follow is suppressed and
-the user paged away, the credited page is the DISPLAYED one, not the narrated
-one. Rationale: they are looking at it.
+**`view.getCFIProgress` is USELESS for anything headless.** `view.close()` nulls
+`#sectionProgress` and `#cfiProgress` (foliate `view.js:299-311`) and
+`getCFIProgress` optional-chains off them, so it returns null from the moment
+the book closes. Cost a full Chrome debugging round. What survives close(), and
+is enough to rebuild the same computation: `view.book`, `view.resolveCFI` (it
+delegates to `book.resolveCFI`), and foliate's `PageProgress` /
+`SectionProgress` constructed directly with view.js's own `1500, 1600`.
 
-**Still unverified (cannot be unit tested, see
-[[feedback-no-mock-only-platform-tests]]):** background/screen-off listening on
-Android, iOS lock screen, and CarPlay. The headless page number is derived from
-`view.getCFIProgress(cfi).fraction` x `BookConfig.progress[1]`; that whole path
-has only ever run under vitest. Also unverified: that `getBookData` really
-survives `clearViewState` in a real headless session (inferred from
-`#saveToDisk` reading `getConfig` successfully, not observed).
+**Verified in Chrome (web, localhost dev), both paths:**
+- Reader open: `READING wrote p1/17 19s` at TTS start, then
+  `TTS wrote p1/17 60s` exactly 60s later, no READING writes in between.
+- Book closed (headless): `p9 63s` -> `p11 30s` -> `p12 60s` (full renewal) ->
+  `p14 13s` (final flush on stop), pages advancing on the layout's own 17-page
+  scale.
 
-Related: [[tts-fixes]], [[tts-mini-player-tuning-5310]].
+**NOT verified:** Android screen-off, iOS lock screen, CarPlay. Untouched by
+any of this.
+
+**Two browser gotchas worth remembering:** two tabs on the same origin fight
+over the OPFS handle and the second renders blank (see the `sharedDb` comment
+in `statisticsDb.ts`); and `await import()` inside code under vitest fake timers
+never resolves on first load, so prefer a static import.
+
+Related: [[tts-fixes]], [[feedback-no-mock-only-platform-tests]].


### PR DESCRIPTION
## Summary

- Add the Android E2E nightly investigation memory (PR #5453): the one-time "Viewing full screen" prompt swallowing injected touches, the `openFixtureBook` stale-reader race, sized touch halos, and the pointer-transparent top-inset overlays.
- Add the CORS preflight cache memory (#5444) with production verification notes.
- Update the TTS reading-stats memory to its merged state (#5450).

🤖 Generated with [Claude Code](https://claude.com/claude-code)