### PR TITLE
feat(about): copy the version label to the clipboard on click

### DIFF
--- a/apps/readest-app/src/__tests__/components/AboutWindow.test.tsx
+++ b/apps/readest-app/src/__tests__/components/AboutWindow.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * AboutWindow — the version label doubles as a copy-to-clipboard control.
+ *
+ * On mobile there is no way to select the version string to paste it into a
+ * bug report (issue #5285), so tapping the label copies it. The label must
+ * keep its plain-text look: no button chrome, same classes as before.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+const { mockWriteTextToClipboard, mockDispatch } = vi.hoisted(() => ({
+  mockWriteTextToClipboard: vi.fn(async () => true),
+  mockDispatch: vi.fn(),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string, params?: Record<string, unknown>) =>
+    params ? s.replace(/\{\{(\w+)\}\}/g, (_m, k: string) => String(params[k] ?? '')) : s,
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: { hasUpdater: true } }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: { updateChannel: 'stable' } }),
+}));
+
+vi.mock('@/helpers/updater', () => ({
+  checkForAppUpdates: vi.fn(),
+  checkAppReleaseNotes: vi.fn(),
+}));
+
+vi.mock('@/utils/ua', () => ({
+  parseWebViewInfo: () => 'Chrome 148',
+}));
+
+vi.mock('@/utils/version', () => ({
+  getAppVersion: () => '0.11.20',
+}));
+
+vi.mock('@/utils/clipboard', () => ({
+  writeTextToClipboard: mockWriteTextToClipboard,
+}));
+
+vi.mock('@/utils/event', () => ({
+  eventDispatcher: { dispatch: mockDispatch, on: vi.fn(), off: vi.fn() },
+}));
+
+vi.mock('next/image', () => ({
+  default: ({ alt }: { alt: string }) => <span>{alt}</span>,
+}));
+
+vi.mock('@/components/SupportLinks', () => ({ default: () => null }));
+vi.mock('@/components/LegalLinks', () => ({ default: () => null }));
+vi.mock('@/components/Link', () => ({
+  default: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+vi.mock('@/components/Dialog', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+import { AboutWindow, setAboutDialogVisible } from '@/components/AboutWindow';
+
+const openDialog = async () => {
+  render(
+    <>
+      <div id='about_window' />
+      <AboutWindow />
+    </>,
+  );
+  setAboutDialogVisible(true);
+  return screen.findByText(/Version 0\.11\.20/);
+};
+
+describe('AboutWindow version label', () => {
+  beforeEach(() => {
+    mockWriteTextToClipboard.mockClear();
+    mockDispatch.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('copies the version and webview info when clicked', async () => {
+    const label = await openDialog();
+
+    fireEvent.click(label);
+
+    await waitFor(() => expect(mockWriteTextToClipboard).toHaveBeenCalledTimes(1));
+    expect(mockWriteTextToClipboard).toHaveBeenCalledWith('Version 0.11.20 (Chrome 148)');
+  });
+
+  it('shows a toast confirming the copy', async () => {
+    const label = await openDialog();
+
+    fireEvent.click(label);
+
+    await waitFor(() =>
+      expect(mockDispatch).toHaveBeenCalledWith(
+        'toast',
+        expect.objectContaining({ message: 'Copied to clipboard' }),
+      ),
+    );
+  });
+
+  it('keeps the plain-text look of the label', async () => {
+    const label = await openDialog();
+
+    // Same typography classes as the non-clickable label it replaces, and no
+    // daisyUI button chrome that would change how it renders.
+    expect(label.className).toContain('text-neutral-content');
+    expect(label.className).toContain('text-center');
+    expect(label.className).toContain('text-sm');
+    expect(label.className).not.toContain('btn');
+  });
+
+  it('exposes the label as an accessible control', async () => {
+    const label = await openDialog();
+
+    expect(label.tagName).toBe('BUTTON');
+    expect(label.getAttribute('title')).toBe('Copy');
+  });
+});

--- a/apps/readest-app/src/components/AboutWindow.tsx
+++ b/apps/readest-app/src/components/AboutWindow.tsx
@@ -6,6 +6,8 @@ import { useSettingsStore } from '@/store/settingsStore';
 import { checkForAppUpdates, checkAppReleaseNotes } from '@/helpers/updater';
 import { parseWebViewInfo } from '@/utils/ua';
 import { getAppVersion } from '@/utils/version';
+import { writeTextToClipboard } from '@/utils/clipboard';
+import { eventDispatcher } from '@/utils/event';
 import SupportLinks from './SupportLinks';
 import LegalLinks from './LegalLinks';
 import Dialog from './Dialog';
@@ -80,6 +82,21 @@ export const AboutWindow = () => {
     setUpdateStatus(null);
   };
 
+  const versionInfo = `${_('Version {{version}}', { version: getAppVersion() })} (${browserInfo})`;
+
+  // Mobile users can't select the version string to paste it into a bug
+  // report, so the label itself copies it.
+  const handleCopyVersion = async () => {
+    const copied = await writeTextToClipboard(versionInfo);
+    if (!copied) return;
+    eventDispatcher.dispatch('toast', {
+      type: 'info',
+      message: _('Copied to clipboard'),
+      className: 'whitespace-nowrap',
+      timeout: 2000,
+    });
+  };
+
   return (
     <Dialog
       id='about_window'
@@ -96,9 +113,14 @@ export const AboutWindow = () => {
             </div>
             <div className='flex select-text flex-col items-center'>
               <h2 className='mb-2 text-2xl font-bold'>Readest</h2>
-              <p className='text-neutral-content text-center text-sm'>
-                {_('Version {{version}}', { version: getAppVersion() })} {`(${browserInfo})`}
-              </p>
+              <button
+                type='button'
+                title={_('Copy')}
+                className='text-neutral-content text-center text-sm'
+                onClick={handleCopyVersion}
+              >
+                {versionInfo}
+              </button>
             </div>
             <div className='my-1 h-5'>
               {!updateStatus && (


### PR DESCRIPTION
Closes #5285

## Problem

On mobile there is no way to select the version string in the **About Readest** dialog, so users filing a bug report have to screenshot it or retype it by hand.

## Change

The version label itself becomes the copy control. Clicking it writes the full label — `Version 0.11.20 (Chrome 150.0.0.0)` — to the clipboard and confirms with the existing `Copied to clipboard` toast. It copies the webview info along with the version since that is exactly what a bug report needs.

Copying goes through `writeTextToClipboard`, so it uses the Tauri `clipboard-manager` plugin on Android/iOS where `navigator.clipboard` is unreliable.

## The label looks the same

The `<p>` became a `<button>`, which under Tailwind preflight renders identically. Measured in Chrome by inserting the original `<p>` into the button's exact flow slot and comparing:

- **Bounding box:** byte-identical (`x/y/width/height` all match).
- **Computed styles:** font family/size/weight, line-height, letter-spacing, color, text-align, background, border width, border-radius, margins, padding, text-transform, white-space, opacity, text-shadow, box-shadow — all identical.
- **Only diffs:** `cursor: default` → `pointer` (the clickable affordance) and `appearance: none` → `button` (no visual effect — background, borders, radius and shadow all still match).
- `user-select` stays `text` from the surrounding `select-text`, so selecting the version by hand still works. The issue suggested disabling selection; leaving it alone keeps desktop behaviour unchanged and the two do not conflict.

## Verification

- New `src/__tests__/components/AboutWindow.test.tsx` — 4 tests covering the clipboard write, the toast, the unchanged typography classes, and the button semantics. Written first, confirmed failing (3/4) before the fix.
- `pnpm test` — 8331 passed, 7 skipped.
- `pnpm lint` and `pnpm format:check` clean.
- Driven live in Chrome: clicking the label wrote the exact string to the **OS** clipboard (verified by pasting it back into a probe input), and the toast rendered.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
