### PR TITLE
feat(reader): tap the footer to show and dismiss the progress bar

### DIFF
--- a/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ProgressBar from '@/app/reader/components/ProgressBar';
@@ -228,12 +228,13 @@ describe('ProgressBar — sticky progress bar', () => {
   });
 });
 
-describe('ProgressBar — display-only footer overlay', () => {
-  // The footer overlay is stacked above the book but is purely informational:
-  // it must never intercept taps or text selection over book content, and it
-  // exposes no clickable tap targets. In scrolled mode (no reserved band) each
-  // info segment carries its own shrink-wrapped pill backdrop so it stays
-  // legible floating over the text instead of a full-width bar.
+describe('ProgressBar — footer overlay pointer contract', () => {
+  // The full-width overlay container stays passive so taps and text selection
+  // over book content pass through; only the strip (band modes) or the pills
+  // themselves (scrolled mode) are tap targets — see the tap-to-toggle suite.
+  // In scrolled mode (no reserved band) each info segment carries its own
+  // shrink-wrapped pill backdrop so it stays legible floating over the text
+  // instead of a full-width bar.
   const readerSettings = (overrides?: Partial<ViewSettings>) => {
     currentViewSettings = {
       ...baseSettings,
@@ -253,18 +254,6 @@ describe('ProgressBar — display-only footer overlay', () => {
     const progressInfo = container.querySelector('.progressinfo') as HTMLElement;
     expect(progressInfo.classList.contains('pointer-events-none')).toBe(true);
     expect(progressInfo.classList.contains('pointer-events-auto')).toBe(false);
-  });
-
-  it('exposes no interactive targets (display-only, no tap-to-toggle)', () => {
-    readerSettings({ showRemainingPages: true });
-
-    const { container } = renderProgressBar();
-
-    expect(container.querySelector('.pointer-events-auto')).toBeNull();
-    expect(container.querySelector('.cursor-pointer')).toBeNull();
-    expect(container.querySelector('.progress-restore-pad')).toBeNull();
-    // No showFooter write ever originates from tapping the footer.
-    expect(saveViewSettings.mock.calls.some((args) => args[2] === 'showFooter')).toBe(false);
   });
 
   it('wraps each info segment in its own pill backdrop in scrolled mode', () => {
@@ -287,6 +276,121 @@ describe('ProgressBar — display-only footer overlay', () => {
     const { container } = renderProgressBar();
 
     expect(container.querySelector('.progress-pill')).toBeNull();
+  });
+});
+
+describe('ProgressBar — tap to toggle visibility (#5293)', () => {
+  // Tapping the footer toggles the info's visibility without touching layout
+  // or settings: the reserved band stays, showFooter never changes, and the
+  // state is ephemeral — a fresh mount (book open) starts visible again.
+  // Where the strip sits on reserved margin space (paginated band, sticky
+  // bar, vertical side column) the whole strip is the tap target; in scrolled
+  // mode the info floats over book text, so only the pills are tappable and
+  // the strip keeps letting taps and text selection through.
+  const readerSettings = (overrides?: Partial<ViewSettings>) => {
+    currentViewSettings = {
+      ...baseSettings,
+      ...overrides,
+    } as ViewSettings;
+    currentProgress = makeProgress(2, 5);
+    currentBookData = { isFixedLayout: false };
+    currentRenderer = { page: 1, pages: 4 };
+  };
+
+  it('toggles the info visibility when the strip is tapped in paginated mode', () => {
+    readerSettings({ showRemainingPages: true });
+
+    const { container } = renderProgressBar();
+
+    const strip = container.querySelector('.progress-strip') as HTMLElement;
+    expect(strip).not.toBeNull();
+    expect(strip.classList.contains('pointer-events-auto')).toBe(true);
+    expect(strip.classList.contains('opacity-0')).toBe(false);
+
+    fireEvent.click(strip);
+    expect(strip.classList.contains('opacity-0')).toBe(true);
+    // The strip stays tappable while hidden so the same tap brings it back.
+    expect(strip.classList.contains('pointer-events-auto')).toBe(true);
+
+    fireEvent.click(strip);
+    expect(strip.classList.contains('opacity-0')).toBe(false);
+  });
+
+  it('never writes settings from the tap (visibility is ephemeral)', () => {
+    readerSettings({ showRemainingPages: true });
+
+    const { container } = renderProgressBar();
+
+    fireEvent.click(container.querySelector('.progress-strip') as HTMLElement);
+    expect(saveViewSettings).not.toHaveBeenCalled();
+  });
+
+  it('starts visible again on a fresh mount (state resets with the book)', () => {
+    readerSettings({ showRemainingPages: true });
+
+    const first = renderProgressBar();
+    fireEvent.click(first.container.querySelector('.progress-strip') as HTMLElement);
+    expect(
+      (first.container.querySelector('.progress-strip') as HTMLElement).classList.contains(
+        'opacity-0',
+      ),
+    ).toBe(true);
+    first.unmount();
+
+    const second = renderProgressBar();
+    expect(
+      (second.container.querySelector('.progress-strip') as HTMLElement).classList.contains(
+        'opacity-0',
+      ),
+    ).toBe(false);
+  });
+
+  it('keeps the strip passive in scrolled mode — the pills are the tap targets', () => {
+    readerSettings({ scrolled: true, showRemainingPages: true });
+
+    const { container } = renderProgressBar();
+
+    const strip = container.querySelector('.progress-strip') as HTMLElement;
+    expect(strip.classList.contains('pointer-events-auto')).toBe(false);
+
+    const pill = container.querySelector('.progress-pill') as HTMLElement;
+    expect(pill.classList.contains('pointer-events-auto')).toBe(true);
+
+    fireEvent.click(pill);
+    expect(strip.classList.contains('opacity-0')).toBe(true);
+  });
+
+  it('makes the whole strip tappable in scrolled mode when the sticky bar reserves the band', () => {
+    readerSettings({ scrolled: true, showStickyProgressBar: true });
+
+    const { container } = renderProgressBar();
+
+    const strip = container.querySelector('.progress-strip') as HTMLElement;
+    expect(strip.classList.contains('pointer-events-auto')).toBe(true);
+  });
+
+  it('makes the side column tappable in vertical mode', () => {
+    readerSettings({ vertical: true, showRemainingPages: true });
+
+    const { container } = renderProgressBar();
+
+    const strip = container.querySelector('.progress-strip') as HTMLElement;
+    expect(strip.classList.contains('pointer-events-auto')).toBe(true);
+  });
+
+  it('exposes no tap target when the footer has nothing to show', () => {
+    readerSettings({
+      showProgressInfo: false,
+      showRemainingTime: false,
+      showRemainingPages: false,
+      showCurrentTime: false,
+      showCurrentBatteryStatus: false,
+      showStickyProgressBar: false,
+    });
+
+    const { container } = renderProgressBar();
+
+    expect(container.querySelector('.pointer-events-auto')).toBeNull();
   });
 });
 

--- a/apps/readest-app/src/app/reader/components/ProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/ProgressBar.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Trans } from 'react-i18next';
 import type { Insets } from '@/types/misc';
 import { useEnv } from '@/context/EnvContext';
@@ -13,6 +13,7 @@ import {
   getChapterTickFractions,
   getReferencePageInfo,
 } from '@/utils/progress';
+import { footerInfoVisible, footerReservesBand } from '../utils/footerBand';
 import StatusInfo from './StatusInfo.tsx';
 import StickyProgressBar from './StickyProgressBar.tsx';
 import { convertPagesToTimeRemainingMinutes } from '@/app/library/utils/libraryUtils.ts';
@@ -135,19 +136,28 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
   const hasTimeInfo = viewSettings.showCurrentTime;
   const hasBatteryInfo = viewSettings.showCurrentBatteryStatus;
 
-  // The footer is display-only: the full-width container stays
-  // pointer-events-none so it never intercepts taps or text selection over
-  // book content along the bottom of the page. To hide it, use Settings →
-  // Layout → Show Footer.
-  //
+  // Tap to toggle (#5293): tapping the footer hides/shows the info without
+  // touching layout or settings — the reserved band stays so the book text
+  // never reflows, showFooter is never written, and the state resets when the
+  // book reopens. The full-width container stays pointer-events-none so taps
+  // and text selection over book content pass through; only the strip (or the
+  // pills in scrolled mode, see below) is a tap target.
+  const [dismissed, setDismissed] = useState(false);
+
   // Scrolled mode reserves no bottom band (footerReservesBand) — the info
   // floats over the book text, so each segment carries its own shrink-wrapped
-  // pill backdrop to stay legible instead of a full-width bar.
+  // pill backdrop to stay legible instead of a full-width bar. The pills
+  // double as the tap targets there: making the whole strip tappable would
+  // swallow taps and text selection over the last lines of the page, so the
+  // strip is only a target where it sits on reserved margin space (paginated
+  // band, sticky-bar band, vertical side column).
+  const hasFooterContent = stickyBarActive || footerInfoVisible(viewSettings);
+  const stripTappable = hasFooterContent && (isVertical || footerReservesBand(viewSettings));
   const pillClass =
     viewSettings.scrolled &&
     !isVertical &&
     !stickyBarActive &&
-    'progress-pill eink-bordered rounded-md bg-base-100/85 px-1.5';
+    'progress-pill eink-bordered pointer-events-auto cursor-pointer rounded-md bg-base-100/85 px-1.5';
   const showStatusInfo = hasTimeInfo || hasBatteryInfo;
 
   return (
@@ -197,8 +207,12 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
     >
       <div
         aria-hidden='true'
+        onClick={hasFooterContent ? () => setDismissed((prev) => !prev) : undefined}
         className={clsx(
-          'flex items-center',
+          'progress-strip flex items-center',
+          stripTappable && 'pointer-events-auto cursor-pointer',
+          dismissed && 'opacity-0',
+          !isEink && 'transition-opacity duration-300',
           isVertical ? 'h-full' : 'w-full',
           // Sticky bar grows on the left; the info widgets pack to the right
           // with even gaps. Without it, keep the 3-zone left/center/right row.


### PR DESCRIPTION
## What

Restores a tap toggle for the footer progress info, addressing #5293 (tap-to-toggle footer removed in 0.11.20).

- Tapping the footer strip hides the progress info; tapping the same spot brings it back.
- No setting for it: the toggle is always available whenever Show Footer is enabled.
- The visibility state is ephemeral. It is never written to view settings, and it resets to visible when the book is opened again.
- No layout change: the reserved bottom band stays, so hiding the info never reflows the book text (unlike toggling Show Footer).

## How

- `ProgressBar` keeps a local `dismissed` state and fades the info strip with `opacity-0` (no transition in e-ink mode). The band reservation and `showFooter` are untouched.
- Where the strip sits on reserved margin space (paginated band, sticky-bar band, vertical side column) the whole strip is the tap target, so the toggle is easy to hit both ways.
- In scrolled mode the info floats over the book text, so only the shrink-wrapped pills themselves are tappable; the strip stays `pointer-events-none` and keeps letting taps and text selection through (preserves the #5029 fix). While hidden, the pill boxes remain hit-testable at the same spots to restore.
- The full-width overlay container remains `pointer-events-none` throughout.

On desktop the bottom hover strip that reveals the footer toolbar still owns clicks at the bottom edge, so this is primarily a touch-device affordance, matching the requests in the issue.

## Testing

- New unit tests cover the toggle round trip, the ephemeral reset on remount, the scrolled-mode pill targets, the no-content case, and that no settings write ever originates from the tap.
- `pnpm test` (8333 passed) and `pnpm lint` pass.
- Verified live on the web build (scrolled mode): tapping a pill fades the info out with no content reflow and no page turn; tapping the same spot restores it.

Fixes #5293

🤖 Generated with [Claude Code](https://claude.com/claude-code)