### PR TITLE
fix(library): render the book context menu in-app on Linux desktop

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/book-context-menu-linux-inapp.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/book-context-menu-linux-inapp.test.tsx
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import type { Book } from '@/types/book';
+
+/**
+ * Issue #5360 — on Linux/Wayland the native GTK context menu is popped up
+ * asynchronously (JS → Tauri IPC → muda → GTK) long after the triggering
+ * two-finger tap has released the button, and the mapped popup is dismissed
+ * immediately (it flashes for one frame and disappears). The GTK3-on-Wayland
+ * popup path is not fixable from the app side, so Linux desktop renders the
+ * context menu in-app instead of popping the native menu.
+ */
+
+const popupSpy = vi.hoisted(() => vi.fn(async () => {}));
+const closeSpy = vi.hoisted(() => vi.fn(async () => {}));
+const menuNew = vi.hoisted(() => vi.fn(async () => ({ popup: popupSpy, close: closeSpy })));
+
+vi.mock('@tauri-apps/api/menu', () => ({
+  Menu: { new: menuNew },
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    innerSize: async () => ({ width: 2048, height: 1536 }),
+    scaleFactor: async () => 2,
+  }),
+}));
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  revealItemInDir: vi.fn(),
+}));
+
+const appService = vi.hoisted(() => ({
+  hasContextMenu: true,
+  isLinuxApp: true,
+  isAndroidApp: false,
+  isMobileApp: false,
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: { localBooksDir: '/books' } }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (text: string) => text,
+}));
+
+vi.mock('@/app/library/hooks/useOpenBook', () => ({
+  useOpenBook: () => ({ openBook: vi.fn() }),
+}));
+
+vi.mock('@/app/library/components/BookItem', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/library/components/GroupItem', () => ({
+  default: () => null,
+}));
+
+const BookshelfItem = (await import('@/app/library/components/BookshelfItem')).default;
+
+const book: Book = {
+  hash: 'hash-1',
+  format: 'EPUB',
+  title: 'Test Book',
+  author: 'Test Author',
+  createdAt: 0,
+  updatedAt: 0,
+  downloadedAt: 1,
+};
+
+const renderItem = (overrides: Partial<React.ComponentProps<typeof BookshelfItem>> = {}) => {
+  const props = {
+    mode: 'grid' as const,
+    item: book,
+    coverFit: 'crop' as const,
+    isSelectMode: false,
+    itemSelected: false,
+    transferProgress: null,
+    setLoading: vi.fn(),
+    toggleSelection: vi.fn(),
+    handleGroupBooks: vi.fn(),
+    handleBookDownload: vi.fn(async () => true),
+    handleBookUpload: vi.fn(async () => true),
+    handleBookDelete: vi.fn(async () => true),
+    handleSetSelectMode: vi.fn(),
+    handleShowDetailsBook: vi.fn(),
+    handleLibraryNavigation: vi.fn(),
+    handleUpdateReadingStatus: vi.fn(),
+    showTimeRemaining: false,
+    ...overrides,
+  };
+  return { ...render(<BookshelfItem {...props} />), props };
+};
+
+const openContextMenu = () =>
+  fireEvent.contextMenu(screen.getByRole('button', { name: 'Test Book' }), {
+    clientX: 10,
+    clientY: 20,
+  });
+
+describe('library context menu on Linux desktop (issue #5360)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appService.isLinuxApp = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the in-app menu instead of popping the native GTK menu', async () => {
+    renderItem();
+
+    openContextMenu();
+
+    // The downloaded, never-uploaded, statusless test book resolves to this
+    // ordered id list via getBookContextMenuItemIds.
+    const labels = [
+      'Select Book',
+      'Group Books',
+      'Mark as Finished',
+      'Mark as On hold',
+      'Show Book Details',
+      'Reveal in Folder',
+      'Search on Goodreads',
+      'Upload Book',
+      'Share Book',
+      'Delete',
+    ];
+    const menuItems = await screen.findAllByRole('menuitem');
+    expect(menuItems.map((el) => el.textContent)).toEqual(labels);
+
+    expect(menuNew).not.toHaveBeenCalled();
+    expect(popupSpy).not.toHaveBeenCalled();
+  });
+
+  it('runs the action and closes the menu when an item is clicked', async () => {
+    const { props } = renderItem();
+
+    openContextMenu();
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Show Book Details' }));
+
+    expect(props.handleShowDetailsBook).toHaveBeenCalledWith(book);
+    expect(screen.queryByRole('menuitem')).toBeNull();
+  });
+
+  it('dismisses the menu when clicking outside', async () => {
+    renderItem();
+
+    openContextMenu();
+    await screen.findAllByRole('menuitem');
+
+    const overlay = document.querySelector('.overlay');
+    expect(overlay).not.toBeNull();
+    fireEvent.click(overlay!);
+
+    expect(screen.queryByRole('menuitem')).toBeNull();
+  });
+
+  it('does not prewarm the native menu on pointer enter on Linux', async () => {
+    renderItem();
+
+    fireEvent.pointerOver(screen.getByRole('button', { name: 'Test Book' }));
+
+    // Menu construction crosses the Tauri IPC boundary for the native menu
+    // only; the in-app menu needs no prewarm.
+    expect(menuNew).not.toHaveBeenCalled();
+  });
+
+  it('keeps the native menu on non-Linux desktop platforms', async () => {
+    appService.isLinuxApp = false;
+    renderItem();
+
+    openContextMenu();
+
+    await vi.waitFor(() => expect(popupSpy).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('menuitem')).toBeNull();
+  });
+});

--- a/apps/readest-app/src/__tests__/app/library/book-context-menu-popup-position.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/book-context-menu-popup-position.test.tsx
@@ -4,47 +4,22 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import type { Book } from '@/types/book';
 
 /**
- * Issue #5181 — the library context menu flashes and disappears on Wayland
- * when opened with a touchpad two-finger tap.
+ * The native context menu (macOS and Windows; Linux renders it in-app, see
+ * book-context-menu-linux-inapp.test.tsx) is popped at an explicit position
+ * rather than through a positionless `menu.popup()`, which anchors to the
+ * current mouse location. Keyboard invocation — ContextMenu / Shift+F10 — has
+ * no mouse to anchor to, so the menu must open at the focused item instead of
+ * wherever the pointer was last left.
  *
- * `menu.popup()` without a position makes muda anchor the GTK popup to the
- * screen's root window (muda gtk show_context_menu). X11 has a real root
- * window so that works; Wayland has none, so the popup gets no parent and the
- * compositor refuses to map it:
- *
- *   Gdk-WARNING **: Couldn't map as window 0x… as popup because it doesn't
- *   have a parent
- *
- * Passing an explicit position makes muda anchor to the app window's own
- * GdkWindow instead, which always has a parent. So the popup call must carry
- * the pointer position from the triggering contextmenu event.
- *
- * CSS pixels are not window-logical pixels when the webview carries a page
- * zoom. WebKitGTK folds the desktop text-scaling factor into such a zoom
- * without reflecting it in devicePixelRatio (e.g. GDK scale 2 × 0.8 text
- * scale: CSS→physical is 1.6 while dPR reports 2), so both raw client
- * coordinates and clientX×dPR land the menu offset from the click by a
- * factor that grows with distance. The zoom-proof conversion is the click's
- * *fraction* of the CSS viewport mapped onto the window's logical size:
- * any uniform zoom cancels out of the ratio.
+ * CSS px are window-logical px on both platforms (Tauri leaves webview zoom
+ * hotkeys disabled), so the client coordinates pass through unchanged.
  */
 
 const popupSpy = vi.hoisted(() => vi.fn(async (_pos?: unknown) => {}));
 const menuNew = vi.hoisted(() => vi.fn(async () => ({ popup: popupSpy, close: vi.fn() })));
-const windowState = vi.hoisted(() => ({
-  innerSize: { width: 2560, height: 1600 },
-  scaleFactor: 2,
-}));
 
 vi.mock('@tauri-apps/api/menu', () => ({
   Menu: { new: menuNew },
-}));
-
-vi.mock('@tauri-apps/api/window', () => ({
-  getCurrentWindow: () => ({
-    innerSize: async () => windowState.innerSize,
-    scaleFactor: async () => windowState.scaleFactor,
-  }),
 }));
 
 vi.mock('@tauri-apps/plugin-opener', () => ({
@@ -113,7 +88,10 @@ const renderItem = () =>
     />,
   );
 
-describe('library context menu popup position (issue #5181)', () => {
+const popupPosition = () =>
+  popupSpy.mock.calls[0]![0] as unknown as { type: string; x: number; y: number };
+
+describe('library context menu popup position', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -122,15 +100,7 @@ describe('library context menu popup position (issue #5181)', () => {
     cleanup();
   });
 
-  const setViewport = (width: number, height: number) => {
-    Object.defineProperty(window, 'innerWidth', { value: width, configurable: true });
-    Object.defineProperty(window, 'innerHeight', { value: height, configurable: true });
-  };
-
   it('passes the contextmenu position to menu.popup in window-logical pixels', async () => {
-    // CSS viewport matches the window logical size (1280×800): no zoom, so
-    // the popup position equals the client coordinates.
-    setViewport(1280, 800);
     renderItem();
 
     fireEvent.contextMenu(screen.getByRole('button', { name: 'Test Book' }), {
@@ -139,28 +109,28 @@ describe('library context menu popup position (issue #5181)', () => {
     });
 
     await waitFor(() => expect(popupSpy).toHaveBeenCalled());
-    const pos = popupSpy.mock.calls[0]![0] as unknown as { type: string; x: number; y: number };
+    const pos = popupPosition();
     expect(pos.type).toBe('Logical');
     expect(pos.x).toBeCloseTo(123);
     expect(pos.y).toBeCloseTo(456);
   });
 
-  it('compensates a webview page zoom when mapping the click to window coordinates', async () => {
-    // A 0.8 page zoom inflates the CSS viewport to 1600×1000 while the
-    // window is still 1280×800 logical: client coordinates must shrink by
-    // the same ratio or the menu lands past the click (issue #5181).
-    setViewport(1600, 1000);
+  it('anchors a keyboard-invoked menu at the center of the focused item', async () => {
     renderItem();
 
-    fireEvent.contextMenu(screen.getByRole('button', { name: 'Test Book' }), {
-      clientX: 500,
-      clientY: 250,
-    });
+    const item = screen.getByRole('button', { name: 'Test Book' });
+    vi.spyOn(item, 'getBoundingClientRect').mockReturnValue({
+      left: 200,
+      top: 100,
+      width: 160,
+      height: 240,
+    } as DOMRect);
+
+    fireEvent.keyDown(item, { key: 'ContextMenu' });
 
     await waitFor(() => expect(popupSpy).toHaveBeenCalled());
-    const pos = popupSpy.mock.calls[0]![0] as unknown as { type: string; x: number; y: number };
-    expect(pos.type).toBe('Logical');
-    expect(pos.x).toBeCloseTo(400);
-    expect(pos.y).toBeCloseTo(200);
+    const pos = popupPosition();
+    expect(pos.x).toBeCloseTo(280);
+    expect(pos.y).toBeCloseTo(220);
   });
 });

--- a/apps/readest-app/src/app/library/components/BookContextMenuPopup.tsx
+++ b/apps/readest-app/src/app/library/components/BookContextMenuPopup.tsx
@@ -1,0 +1,116 @@
+import clsx from 'clsx';
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import { useThemeStore } from '@/store/themeStore';
+import { Overlay } from '@/components/Overlay';
+import ModalPortal from '@/components/ModalPortal';
+import MenuItem from '@/components/MenuItem';
+import Menu from '@/components/Menu';
+
+const VIEWPORT_PADDING = 8;
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+interface Size {
+  width: number;
+  height: number;
+}
+
+interface Bounds {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/**
+ * Place the menu with its top-left corner at the pointer, flipping to the
+ * other side of the pointer when it would run off the right/bottom edge and
+ * clamping to `bounds` as a last resort (matches native context menus).
+ */
+export const getContextMenuPosition = (point: Point, menu: Size, bounds: Bounds) => {
+  const fitsRight = point.x + menu.width <= bounds.right;
+  const left = Math.max(bounds.left, fitsRight ? point.x : point.x - menu.width);
+  const fitsBelow = point.y + menu.height <= bounds.bottom;
+  const top = Math.max(bounds.top, fitsBelow ? point.y : point.y - menu.height);
+  return { left, top };
+};
+
+export interface BookContextMenuItem {
+  text: string;
+  action: () => void;
+}
+
+interface BookContextMenuPopupProps {
+  position: Point;
+  items: BookContextMenuItem[];
+  onClose: () => void;
+}
+
+/**
+ * In-app replacement for the native context menu on Linux desktop: GTK3 menus
+ * popped over Wayland after the triggering button was already released (a
+ * touchpad two-finger tap) are dismissed as soon as they map, so the menu
+ * flashes and disappears (issue #5360). Rendered through ModalPortal because
+ * the bookshelf item wrapper carries a scale transform, which would turn a
+ * position:fixed popup inside it into an item-relative one.
+ */
+const BookContextMenuPopup: React.FC<BookContextMenuPopupProps> = ({
+  position,
+  items,
+  onClose,
+}) => {
+  const { safeAreaInsets: insets } = useThemeStore();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [placement, setPlacement] = useState<{ left: number; top: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!menuRef.current) return;
+    const { width, height } = menuRef.current.getBoundingClientRect();
+    setPlacement(
+      getContextMenuPosition(
+        position,
+        { width, height },
+        {
+          left: VIEWPORT_PADDING + (insets?.left ?? 0),
+          top: VIEWPORT_PADDING + (insets?.top ?? 0),
+          right: window.innerWidth - VIEWPORT_PADDING - (insets?.right ?? 0),
+          bottom: window.innerHeight - VIEWPORT_PADDING - (insets?.bottom ?? 0),
+        },
+      ),
+    );
+    menuRef.current.querySelector<HTMLButtonElement>('[role="menuitem"]')?.focus();
+  }, [position, insets]);
+
+  return (
+    <ModalPortal showOverlay={false}>
+      <Overlay onDismiss={onClose} className='z-0' />
+      <div
+        ref={menuRef}
+        className={clsx('absolute z-[1] w-max', !placement && 'invisible')}
+        style={{ left: placement?.left ?? 0, top: placement?.top ?? 0 }}
+      >
+        <Menu
+          className='dropdown-content no-triangle bg-base-100 rounded-box !relative z-[1] !mt-0 p-2 shadow'
+          onCancel={onClose}
+        >
+          {items.map(({ text, action }) => (
+            <MenuItem
+              key={text}
+              noIcon
+              label={text}
+              onClick={() => {
+                onClose();
+                action();
+              }}
+            />
+          ))}
+        </Menu>
+      </div>
+    </ModalPortal>
+  );
+};
+
+export default BookContextMenuPopup;

--- a/apps/readest-app/src/app/library/components/BookshelfItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookshelfItem.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { useLongPress } from '@/hooks/useLongPress';
 import { Menu } from '@tauri-apps/api/menu';
 import { LogicalPosition } from '@tauri-apps/api/dpi';
-import { getCurrentWindow } from '@tauri-apps/api/window';
 import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import { eventDispatcher } from '@/utils/event';
 import { openExternalUrl } from '@/utils/open';
@@ -375,22 +374,12 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
         return;
       }
       const menu = await ensureMenu();
-      // Pop up at an explicit window position: a positionless popup is
-      // anchored to the X11 root window, which doesn't exist on Wayland, so
-      // the menu fails to map and disappears immediately (issue #5181).
-      // CSS px are not window-logical px when the webview carries a page
-      // zoom (WebKitGTK folds the desktop text-scaling factor into one
-      // without reflecting it in devicePixelRatio), so map the click's
-      // fraction of the CSS viewport onto the window's logical size — any
-      // uniform zoom cancels out of the ratio.
-      const win = getCurrentWindow();
-      const [innerSize, scale] = await Promise.all([win.innerSize(), win.scaleFactor()]);
-      await menu.popup(
-        new LogicalPosition(
-          (position.x / window.innerWidth) * (innerSize.width / scale),
-          (position.y / window.innerHeight) * (innerSize.height / scale),
-        ),
-      );
+      // Pop up at an explicit position so keyboard invocation (ContextMenu /
+      // Shift+F10) anchors the menu to the item instead of wherever the mouse
+      // happens to sit. On macOS and Windows — the only platforms still on the
+      // native menu — CSS px are window-logical px, so the client coordinates
+      // pass through unchanged.
+      await menu.popup(new LogicalPosition(position.x, position.y));
     }, 100),
     [item, itemSelected, isSelectMode, settings.localBooksDir],
   );

--- a/apps/readest-app/src/app/library/components/BookshelfItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookshelfItem.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useEnv } from '@/context/EnvContext';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useLongPress } from '@/hooks/useLongPress';
-import { Menu, type MenuItemOptions } from '@tauri-apps/api/menu';
+import { Menu } from '@tauri-apps/api/menu';
 import { LogicalPosition } from '@tauri-apps/api/dpi';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { revealItemInDir } from '@tauri-apps/plugin-opener';
@@ -24,6 +24,7 @@ import {
 import { md5Fingerprint } from '@/utils/md5';
 import BookItem from './BookItem';
 import GroupItem from './GroupItem';
+import BookContextMenuPopup, { type BookContextMenuItem } from './BookContextMenuPopup';
 import { useOpenBook } from '../hooks/useOpenBook';
 
 export const generateBookshelfItems = (
@@ -161,7 +162,7 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
     [isSelectMode, handleLibraryNavigation],
   );
 
-  const buildBookMenu = async (book: Book) => {
+  const buildBookMenuItems = (book: Book): BookContextMenuItem[] => {
     const osPlatform = getOSPlatform();
     const fileRevealLabel =
       FILE_REVEAL_LABELS[osPlatform as FILE_REVEAL_PLATFORMS] || FILE_REVEAL_LABELS.default;
@@ -169,7 +170,7 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
     // in a single Menu.new({ items }) call. Appending items one-by-one with
     // un-awaited Menu.append() promises races on the Tauri IPC boundary and
     // shuffles the order on every open (issue #4389).
-    const itemOptions: Record<BookContextMenuItemId, MenuItemOptions> = {
+    const itemOptions: Record<BookContextMenuItemId, BookContextMenuItem> = {
       select: {
         text: itemSelected ? _('Deselect Book') : _('Select Book'),
         action: async () => {
@@ -257,14 +258,13 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
         },
       },
     };
-    const items = getBookContextMenuItemIds(book).map((id) => itemOptions[id]);
-    return Menu.new({ items });
+    return getBookContextMenuItemIds(book).map((id) => itemOptions[id]);
   };
 
-  const buildGroupMenu = async (group: BooksGroup) => {
+  const buildGroupMenuItems = (group: BooksGroup): BookContextMenuItem[] => {
     // Single Menu.new({ items }) call keeps the order deterministic — see the
     // note in bookContextMenuHandler about the Menu.append() IPC race (#4389).
-    const items: MenuItemOptions[] = [
+    return [
       {
         text: itemSelected ? _('Deselect Group') : _('Select Group'),
         action: async () => {
@@ -294,8 +294,17 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
         },
       },
     ];
-    return Menu.new({ items });
   };
+
+  const buildMenuItems = () =>
+    'format' in item ? buildBookMenuItems(item as Book) : buildGroupMenuItems(item as BooksGroup);
+
+  // In-app fallback for the native context menu: GTK3 menus popped over
+  // Wayland after the trigger button was already released (a touchpad
+  // two-finger tap) are dismissed as soon as they map, flashing for a single
+  // frame (issue #5360). The popup path (JS → Tauri IPC → muda → GTK) cannot
+  // beat a tap's instant release, so Linux renders the menu in-app instead.
+  const [inAppMenuPosition, setInAppMenuPosition] = useState<{ x: number; y: number } | null>(null);
 
   // Building the menu crosses the Tauri IPC boundary and takes long enough
   // that the popup visibly lags the right-click (issue #5181). Cache the
@@ -305,8 +314,7 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
 
   const ensureMenu = () => {
     if (!cachedMenuRef.current) {
-      const building =
-        'format' in item ? buildBookMenu(item as Book) : buildGroupMenu(item as BooksGroup);
+      const building = Menu.new({ items: buildMenuItems() });
       building.catch(() => {
         // A failed build must not poison the cache with a rejected promise.
         if (cachedMenuRef.current === building) cachedMenuRef.current = null;
@@ -362,6 +370,10 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
   const handleContextMenu = useCallback(
     throttle(async (position: { x: number; y: number }) => {
       if (!appService?.hasContextMenu) return;
+      if (appService.isLinuxApp) {
+        setInAppMenuPosition(position);
+        return;
+      }
       const menu = await ensureMenu();
       // Pop up at an explicit window position: a positionless popup is
       // anchored to the X11 root window, which doesn't exist on Wayland, so
@@ -441,7 +453,7 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
         }}
         onKeyDown={handleKeyDown}
         onPointerEnter={() => {
-          if (appService?.hasContextMenu) void ensureMenu();
+          if (appService?.hasContextMenu && !appService.isLinuxApp) void ensureMenu();
         }}
         {...itemDataAttrs}
         {...handlers}
@@ -470,6 +482,13 @@ const BookshelfItem: React.FC<BookshelfItemProps> = ({
           )}
         </div>
       </div>
+      {inAppMenuPosition && (
+        <BookContextMenuPopup
+          position={inAppMenuPosition}
+          items={buildMenuItems()}
+          onClose={() => setInAppMenuPosition(null)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Problem

On Linux/Wayland, opening the library context menu with a touchpad **two-finger tap** makes the menu flash for a single frame and disappear (#5360, #5181, #5041). A physical two-finger press, a mouse right-click, and X11 sessions all work.

## Root cause

The context menu is a native GTK3 menu popped through `menu.popup()` -> Tauri IPC -> muda -> `gtk_menu_popup_at_rect`. A tap emits its `BTN_RIGHT` press and release back to back, so the popup always maps **after** the button was released, and a GTK3 menu in that state does not survive on Wayland:

- On 0.11.18 (before #5182) the positionless popup was anchored to the X11 root window, which has no Wayland surface. The reporter's terminal recording shows the failure directly, once per attempt: `Gdk-WARNING: Couldn't map as window 0x... as popup because it doesn't have a parent`, after which GDK maps the menu as a fallback toplevel with a broken lifecycle.
- On 0.11.20 (with #5182) frame-by-frame analysis of the reporter's video shows the menu mapping correctly as an `xdg_popup` at the pointer, fully rendered, then vanishing within ~2 frames (~66 ms) with no further input. Cross-checking mutter 46 and GTK 3.24 sources: the compositor accepts the tap's grab serial (`grab_serial` is the press serial and persists after release) and has no path that dismisses a granted popup grab without input, so the popdown comes from the GTK3 menu-shell machinery when the menu maps after its trigger button is already up. The IPC round trip can never beat a tap's instant release, so this is not fixable from the app while using GTK3 menus.

## Fix

Linux desktop now renders the context menu **in-app** at the pointer instead of popping the native GTK menu. macOS and Windows keep their native menus.

- `BookContextMenuPopup.tsx` (new): pointer-anchored, viewport-clamped popup built from the existing `ModalPortal`/`Overlay`/`Menu`/`MenuItem` primitives, so theming, e-ink, and RTL come for free. The first item receives focus so Escape and keyboard navigation work. `ModalPortal` is required because the bookshelf item wrapper always carries a scale transform that would turn a `position: fixed` popup into an item-relative one.
- `BookshelfItem.tsx`: the book/group item lists are extracted into shared builders consumed by both the native `Menu.new` path and the new popup; `handleContextMenu` branches on `appService.isLinuxApp`, and the native menu hover prewarm is skipped on Linux.

## Follow-up: drop the superseded #5182 position math

With Linux off the native menu, #5182's Wayland machinery no longer earns its keep. Second commit removes the part that is now inert:

- **Removed** — the viewport-fraction conversion `(x / innerWidth) * (innerSize.width / scale)` and the two awaited IPC round trips it needed (`win.innerSize()`, `win.scaleFactor()`) on every right-click. It existed to compensate WebKitGTK folding the desktop text-scaling factor into a page zoom without reflecting it in `devicePixelRatio`. macOS and Windows are the only platforms left on the native menu, and there CSS px *are* window-logical px (Tauri leaves `zoomHotkeysEnabled` off, so no user-reachable webview zoom), which makes the formula an identity transform — costing exactly the IPC latency the menu cache was added to avoid.
- **Kept** — the explicit `menu.popup(position)`, but for a different reason than #5182 gave: keyboard invocation (ContextMenu / Shift+F10) has no mouse to anchor to, and a positionless popup opens wherever the pointer was last left. Also kept: the per-item menu cache + hover prewarm (an IPC-latency fix, not a Wayland one, still live on macOS/Windows) and the `useLongPress` event plumbing, which the in-app popup now depends on for `clientX/clientY`.

`book-context-menu-popup-position.test.tsx` is reframed around the surviving rationale: the zoom-compensation case and the `@tauri-apps/api/window` mock go, a keyboard-anchoring case takes their place.

Nothing else in the tree attempted this bug — history and a sweep of `src/` and `src-tauri/src/` for Wayland/GTK workarounds turn up only #5182. The 100 ms delay in `useLongPress` is the unrelated macOS input-loop fix (#3324).

## Tests

- New: on Linux the in-app menu renders with the exact item order from `getBookContextMenuItemIds`, the native `Menu.new`/`popup` is never called, item clicks run the action and close the menu, outside clicks dismiss, and non-Linux platforms keep the native path.
- Existing #5181 cache test still passes; popup-position test rewritten as above. Full suite green (8343 tests), lint and format clean.

Confirmed working on Linux desktop by the author. Still worth a pass before merge: the full gesture matrix — two-finger tap, two-finger press, mouse right-click, and the keyboard Menu key — on both Wayland and X11, plus a native-menu spot check on macOS/Windows for the position change above.

Fixes #5360

🤖 Generated with [Claude Code](https://claude.com/claude-code)
