### PR TITLE
fix(sync): gate dictionary preferences on the Dictionaries toggle

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -1453,7 +1453,7 @@
   "Data Sync": "مزامنة البيانات",
   "Manage Fonts": "إدارة الخطوط",
   "App settings": "إعدادات التطبيق",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "السمة وألوان التظليل والتكاملات (KOSync وReadwise وHardcover) وترتيب القواميس",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "السمة وألوان التظليل والتكاملات (KOSync وReadwise وHardcover)",
   "Required while Dictionaries sync is enabled": "مطلوب أثناء تفعيل مزامنة القواميس",
   "Resets in {{hours}} hr {{minutes}} min": "يُعاد الضبط خلال {{hours}} س {{minutes}} د",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "اختر رمز PIN مكوّنًا من 4 أرقام. ستحتاج إلى إدخاله في كل مرة تفتح فيها Readest. لا توجد طريقة لاستعادة رمز PIN المنسي. مسح بيانات التطبيق هو الطريقة الوحيدة لإعادة ضبطه.",

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1353,7 +1353,7 @@
   "Data Sync": "ডেটা সিঙ্ক",
   "Manage Fonts": "ফন্ট পরিচালনা",
   "App settings": "অ্যাপ সেটিংস",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "থিম, হাইলাইট রং, ইন্টিগ্রেশন (KOSync, Readwise, Hardcover) এবং অভিধানের ক্রম",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "থিম, হাইলাইট রং এবং ইন্টিগ্রেশন (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "অভিধান সিঙ্ক সক্রিয় থাকাকালীন প্রয়োজনীয়",
   "Resets in {{hours}} hr {{minutes}} min": "{{hours}} ঘ {{minutes}} মি পরে রিসেট হবে",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "একটি ৪-অঙ্কের পিন বেছে নিন। প্রতিবার Readest খোলার সময় আপনাকে এটি প্রবেশ করাতে হবে। ভুলে যাওয়া পিন পুনরুদ্ধারের কোনো উপায় নেই। অ্যাপের ডেটা মুছে ফেলাই এটি রিসেট করার একমাত্র উপায়।",

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1328,7 +1328,7 @@
   "Data Sync": "གཞི་གྲངས་མཉམ་འགྲོ།",
   "Manage Fonts": "ཡིག་གཟུགས་སྟངས་འཛིན།",
   "App settings": "མཉེན་ཆས་སྒྲིག་འགོད།",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "བརྗོད་གཞི། གསལ་རྟགས་ཁ་དོག ཟུང་འབྲེལ་ (KOSync, Readwise, Hardcover) དང་ཚིག་མཛོད་ཀྱི་གོ་རིམ།",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "བརྗོད་གཞི། གསལ་རྟགས་ཁ་དོག དང་ཟུང་འབྲེལ་ (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "ཚིག་མཛོད་ཁག་མཉམ་འགྲོ་སྤྱོད་སྐབས་དགོས་མཁོ་ཡོད།",
   "Resets in {{hours}} hr {{minutes}} min": "{{hours}} ཆུ་ཚོད་ {{minutes}} སྐར་མ་ནང་སླར་གསོ་བྱེད།",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "ཨང་གྲངས་བཞི་ཅན་གྱི་ PIN ཞིག་འདེམས་རོགས། Readest ཕྱེ་རུས་ཐེངས་རེར་ཁྱེད་ཀྱིས་དེ་ནང་འཇུག་དགོས། བརྗེད་སོང་བའི་ PIN ཞིག་སླར་གསོ་བྱེད་ཐབས་མེད། ཉེར་སྤྱོད་ཀྱི་གཞི་གྲངས་གཙང་སེལ་བྱེད་པ་ནི་སླར་སྒྲིག་བྱེད་ཐབས་གཅིག་པོ་ཡིན།",

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1353,7 +1353,7 @@
   "Data Sync": "Datensynchronisierung",
   "Manage Fonts": "Schriftarten verwalten",
   "App settings": "App-Einstellungen",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Design, Hervorhebungsfarben, Integrationen (KOSync, Readwise, Hardcover) und Wörterbuchreihenfolge",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Design, Hervorhebungsfarben und Integrationen (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Erforderlich, solange die Synchronisierung von Wörterbüchern aktiviert ist",
   "Resets in {{hours}} hr {{minutes}} min": "Zurückgesetzt in {{hours}} Std. {{minutes}} Min.",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Wählen Sie eine 4-stellige PIN. Sie müssen sie jedes Mal eingeben, wenn Sie Readest öffnen. Eine vergessene PIN kann nicht wiederhergestellt werden. Das Löschen der App-Daten ist die einzige Möglichkeit, sie zurückzusetzen.",

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1353,7 +1353,7 @@
   "Data Sync": "Συγχρονισμός δεδομένων",
   "Manage Fonts": "Διαχείριση γραμματοσειρών",
   "App settings": "Ρυθμίσεις εφαρμογής",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Θέμα, χρώματα επισήμανσης, ενσωματώσεις (KOSync, Readwise, Hardcover) και σειρά λεξικών",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Θέμα, χρώματα επισήμανσης και ενσωματώσεις (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Απαιτείται όσο είναι ενεργός ο συγχρονισμός Λεξικών",
   "Resets in {{hours}} hr {{minutes}} min": "Επαναφορά σε {{hours}} ώρ. {{minutes}} λεπ.",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Επιλέξτε ένα 4ψήφιο PIN. Θα πρέπει να το εισάγετε κάθε φορά που ανοίγετε το Readest. Δεν υπάρχει τρόπος ανάκτησης ενός ξεχασμένου PIN. Η εκκαθάριση των δεδομένων της εφαρμογής είναι ο μοναδικός τρόπος επαναφοράς του.",

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1378,7 +1378,7 @@
   "Data Sync": "Sincronización de datos",
   "Manage Fonts": "Administrar fuentes",
   "App settings": "Ajustes de la aplicación",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, colores de resaltado, integraciones (KOSync, Readwise, Hardcover) y orden de los diccionarios",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Tema, colores de resaltado e integraciones (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Necesario mientras la sincronización de Diccionarios esté activada",
   "Resets in {{hours}} hr {{minutes}} min": "Se restablece en {{hours}} h {{minutes}} min",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Elige un PIN de 4 dígitos. Tendrás que introducirlo cada vez que abras Readest. No hay forma de recuperar un PIN olvidado. Borrar los datos de la aplicación es la única forma de restablecerlo.",

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1353,7 +1353,7 @@
   "Data Sync": "همگام‌سازی داده‌ها",
   "Manage Fonts": "مدیریت قلم‌ها",
   "App settings": "تنظیمات برنامه",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "پوسته، رنگ‌های هایلایت، یکپارچه‌سازی‌ها (KOSync، Readwise، Hardcover) و ترتیب فرهنگ‌لغت‌ها",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "پوسته، رنگ‌های هایلایت و یکپارچه‌سازی‌ها (KOSync، Readwise، Hardcover)",
   "Required while Dictionaries sync is enabled": "هنگام فعال‌بودن همگام‌سازی فرهنگ‌لغت‌ها لازم است",
   "Resets in {{hours}} hr {{minutes}} min": "تنظیم مجدد در {{hours}} ساعت {{minutes}} دقیقه",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "یک پین ۴ رقمی انتخاب کنید. هر بار که Readest را باز می‌کنید باید آن را وارد کنید. راهی برای بازیابی پین فراموش‌شده وجود ندارد. پاک کردن داده‌های برنامه تنها راه بازنشانی آن است.",

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1378,7 +1378,7 @@
   "Data Sync": "Synchronisation des données",
   "Manage Fonts": "Gérer les polices",
   "App settings": "Paramètres de l’application",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Thème, couleurs de surlignage, intégrations (KOSync, Readwise, Hardcover) et ordre des dictionnaires",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Thème, couleurs de surlignage et intégrations (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Requis tant que la synchronisation des dictionnaires est activée",
   "Resets in {{hours}} hr {{minutes}} min": "Réinitialisation dans {{hours}} h {{minutes}} min",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Choisissez un code PIN à 4 chiffres. Vous devrez le saisir chaque fois que vous ouvrirez Readest. Il n'existe aucun moyen de récupérer un code PIN oublié. Effacer les données de l'application est le seul moyen de le réinitialiser.",

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1378,7 +1378,7 @@
   "Data Sync": "סנכרון נתונים",
   "Manage Fonts": "ניהול גופנים",
   "App settings": "הגדרות אפליקציה",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "ערכת נושא, צבעי הדגשה, שילובים (KOSync, Readwise, Hardcover) וסדר המילונים",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "ערכת נושא, צבעי הדגשה ושילובים (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "נדרש כל עוד סנכרון המילונים מופעל",
   "Resets in {{hours}} hr {{minutes}} min": "מתאפס בעוד {{hours}} ש׳ {{minutes}} ד׳",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "בחר PIN בן 4 ספרות. תצטרך להזין אותו בכל פעם שתפתח את Readest. אין דרך לשחזר PIN שנשכח. ניקוי נתוני האפליקציה הוא הדרך היחידה לאפס אותו.",

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1353,7 +1353,7 @@
   "Data Sync": "डेटा सिंक",
   "Manage Fonts": "फ़ॉन्ट प्रबंधित करें",
   "App settings": "ऐप सेटिंग्स",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "थीम, हाइलाइट रंग, एकीकरण (KOSync, Readwise, Hardcover) और शब्दकोश क्रम",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "थीम, हाइलाइट रंग और एकीकरण (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "शब्दकोश सिंक सक्षम होने पर आवश्यक",
   "Resets in {{hours}} hr {{minutes}} min": "{{hours}} घं {{minutes}} मि में रीसेट",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "एक 4-अंकों का पिन चुनें। Readest खोलने पर आपको हर बार इसे दर्ज करना होगा। भूले हुए पिन को पुनः प्राप्त करने का कोई तरीका नहीं है। ऐप डेटा मिटाना इसे रीसेट करने का एकमात्र तरीका है।",

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1353,7 +1353,7 @@
   "Data Sync": "Adatszinkronizálás",
   "Manage Fonts": "Betűtípusok kezelése",
   "App settings": "Alkalmazásbeállítások",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Téma, kiemelési színek, integrációk (KOSync, Readwise, Hardcover) és szótárak sorrendje",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Téma, kiemelési színek és integrációk (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Szükséges, amíg a Szótárak szinkronizálása be van kapcsolva",
   "Resets in {{hours}} hr {{minutes}} min": "Visszaállás {{hours}} ó {{minutes}} p múlva",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Válasszon egy 4 számjegyű PIN-kódot. Minden alkalommal meg kell adnia, amikor megnyitja a Readestet. Az elfelejtett PIN-kódot nem lehet visszaállítani. Az alkalmazás adatainak törlése az egyetlen módja a visszaállításának.",

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1328,7 +1328,7 @@
   "Data Sync": "Sinkronisasi Data",
   "Manage Fonts": "Kelola Fon",
   "App settings": "Pengaturan aplikasi",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, warna sorotan, integrasi (KOSync, Readwise, Hardcover), dan urutan kamus",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Tema, warna sorotan, dan integrasi (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Diperlukan saat sinkronisasi Kamus diaktifkan",
   "Resets in {{hours}} hr {{minutes}} min": "Direset dalam {{hours}} j {{minutes}} mnt",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Pilih PIN 4 digit. Anda harus memasukkannya setiap kali membuka Readest. Tidak ada cara untuk memulihkan PIN yang terlupa. Menghapus data aplikasi adalah satu-satunya cara untuk mengaturnya ulang.",

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1378,7 +1378,7 @@
   "Data Sync": "Sincronizzazione dati",
   "Manage Fonts": "Gestisci caratteri",
   "App settings": "Impostazioni app",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, colori delle evidenziazioni, integrazioni (KOSync, Readwise, Hardcover) e ordine dei dizionari",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Tema, colori delle evidenziazioni e integrazioni (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Necessario mentre la sincronizzazione dei Dizionari è attiva",
   "Resets in {{hours}} hr {{minutes}} min": "Si reimposta tra {{hours}} h {{minutes}} min",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Scegli un PIN di 4 cifre. Dovrai inserirlo ogni volta che apri Readest. Non c'è modo di recuperare un PIN dimenticato. Cancellare i dati dell'app è l'unico modo per reimpostarlo.",

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1328,7 +1328,7 @@
   "Data Sync": "データ同期",
   "Manage Fonts": "フォントを管理",
   "App settings": "アプリ設定",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "テーマ、ハイライトの色、連携 (KOSync、Readwise、Hardcover)、辞書の順序",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "テーマ、ハイライトの色、連携 (KOSync、Readwise、Hardcover)",
   "Required while Dictionaries sync is enabled": "辞書の同期が有効な間は必須",
   "Resets in {{hours}} hr {{minutes}} min": "{{hours}}時間{{minutes}}分でリセット",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "4桁のPINを設定してください。Readestを開くたびに入力する必要があります。忘れたPINを復元する方法はありません。アプリのデータを消去することがリセットする唯一の方法です。",

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1328,7 +1328,7 @@
   "Data Sync": "데이터 동기화",
   "Manage Fonts": "글꼴 관리",
   "App settings": "앱 설정",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "테마, 하이라이트 색상, 연동 (KOSync, Readwise, Hardcover), 사전 순서",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "테마, 하이라이트 색상, 연동 (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "사전 동기화가 켜져 있는 동안 필요",
   "Resets in {{hours}} hr {{minutes}} min": "{{hours}}시간 {{minutes}}분 후 재설정",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "4자리 PIN을 선택하세요. Readest를 열 때마다 입력해야 합니다. 잊어버린 PIN을 복구할 방법은 없습니다. 앱 데이터를 지우는 것이 PIN을 재설정하는 유일한 방법입니다.",

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1328,7 +1328,7 @@
   "Data Sync": "Penyegerakan Data",
   "Manage Fonts": "Urus Fon",
   "App settings": "Tetapan aplikasi",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, warna sorotan, integrasi (KOSync, Readwise, Hardcover), dan susunan kamus",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Tema, warna sorotan, dan integrasi (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Diperlukan semasa penyegerakan Kamus didayakan",
   "Resets in {{hours}} hr {{minutes}} min": "Set semula dalam {{hours}} j {{minutes}} min",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Pilih PIN 4 digit. Anda perlu memasukkannya setiap kali anda membuka Readest. Tiada cara untuk memulihkan PIN yang terlupa. Mengosongkan data aplikasi adalah satu-satunya cara untuk menetapkannya semula.",

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1353,7 +1353,7 @@
   "Data Sync": "Gegevenssynchronisatie",
   "Manage Fonts": "Lettertypen beheren",
   "App settings": "App-instellingen",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Thema, markeringskleuren, integraties (KOSync, Readwise, Hardcover) en woordenboekvolgorde",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Thema, markeringskleuren en integraties (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Vereist zolang synchronisatie van Woordenboeken is ingeschakeld",
   "Resets in {{hours}} hr {{minutes}} min": "Reset over {{hours}} u {{minutes}} min",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Kies een viercijferige pincode. Je moet deze elke keer invoeren wanneer je Readest opent. Een vergeten pincode kan niet worden hersteld. Het wissen van de app-gegevens is de enige manier om deze opnieuw in te stellen.",

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1403,7 +1403,7 @@
   "Data Sync": "Synchronizacja danych",
   "Manage Fonts": "Zarządzaj czcionkami",
   "App settings": "Ustawienia aplikacji",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Motyw, kolory podświetleń, integracje (KOSync, Readwise, Hardcover) oraz kolejność słowników",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Motyw, kolory podświetleń oraz integracje (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Wymagane, gdy włączona jest synchronizacja Słowników",
   "Resets in {{hours}} hr {{minutes}} min": "Resetuje się za {{hours}} godz. {{minutes}} min",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Wybierz 4-cyfrowy PIN. Będziesz musiał go wprowadzać za każdym razem, gdy otworzysz Readest. Nie ma sposobu na odzyskanie zapomnianego PIN-u. Wyczyszczenie danych aplikacji to jedyny sposób, aby go zresetować.",

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1374,7 +1374,7 @@
   "OPDS catalogs": "Catálogos OPDS",
   "Saved catalog URLs and (encrypted) credentials": "URLs de catálogos salvos e credenciais (criptografadas)",
   "App settings": "Configurações do aplicativo",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, cores de destaque, integrações (KOSync, Readwise, Hardcover) e ordem dos dicionários",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Tema, cores de destaque e integrações (KOSync, Readwise, Hardcover)",
   "Choose what syncs across your devices. Disabling a category stops this device from sending or receiving rows of that kind. Anything already on the server is left alone, re-enabling resumes from where you stopped.": "Escolha o que sincronizar entre seus dispositivos. Desativar uma categoria impede este dispositivo de enviar ou receber dados desse tipo. O que já está no servidor não é alterado; ao reativar, a sincronização retoma de onde parou.",
   "Required while Dictionaries sync is enabled": "Obrigatório enquanto a sincronização de Dicionários estiver ativada",
   "Manage Fonts": "Gerenciar fontes",

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1378,7 +1378,7 @@
   "Data Sync": "Sincronização de dados",
   "Manage Fonts": "Gerenciar fontes",
   "App settings": "Configurações do app",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, cores de destaque, integrações (KOSync, Readwise, Hardcover) e ordem dos dicionários",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Tema, cores de destaque e integrações (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Necessário enquanto a sincronização de Dicionários estiver ativada",
   "Resets in {{hours}} hr {{minutes}} min": "Repõe em {{hours}} h {{minutes}} min",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Escolha um PIN de 4 dígitos. Terá de o introduzir sempre que abrir o Readest. Não há forma de recuperar um PIN esquecido. Limpar os dados da aplicação é a única maneira de o redefinir.",

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1378,7 +1378,7 @@
   "Data Sync": "Sincronizare date",
   "Manage Fonts": "Gestionează fonturile",
   "App settings": "Setări aplicație",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Temă, culorile evidențierilor, integrări (KOSync, Readwise, Hardcover) și ordinea dicționarelor",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Temă, culorile evidențierilor și integrări (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Necesar cât timp sincronizarea Dicționarelor este activată",
   "Resets in {{hours}} hr {{minutes}} min": "Se resetează în {{hours}} h {{minutes}} min",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Alege un PIN din 4 cifre. Va trebui să îl introduci de fiecare dată când deschizi Readest. Nu există nicio modalitate de a recupera un PIN uitat. Ștergerea datelor aplicației este singura modalitate de a-l reseta.",

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1403,7 +1403,7 @@
   "Data Sync": "Синхронизация данных",
   "Manage Fonts": "Управление шрифтами",
   "App settings": "Настройки приложения",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Тема, цвета выделений, интеграции (KOSync, Readwise, Hardcover) и порядок словарей",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Тема, цвета выделений и интеграции (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Требуется, пока включена синхронизация Словарей",
   "Resets in {{hours}} hr {{minutes}} min": "Сброс через {{hours}} ч {{minutes}} мин",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Выберите 4-значный PIN-код. Вам нужно будет вводить его каждый раз при открытии Readest. Восстановить забытый PIN-код невозможно. Очистка данных приложения — единственный способ его сбросить.",

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1353,7 +1353,7 @@
   "Data Sync": "දත්ත සමමුහූර්තය",
   "Manage Fonts": "අකුරු කළමනාකරණය",
   "App settings": "යෙදුමේ සැකසුම්",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "තේමාව, උද්දීපන වර්ණ, ඒකාබද්ධතා (KOSync, Readwise, Hardcover) සහ ශබ්දකෝෂ අනුපිළිවෙල",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "තේමාව, උද්දීපන වර්ණ සහ ඒකාබද්ධතා (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "ශබ්දකෝෂ සමමුහූර්තය සක්‍රිය වී ඇති විට අවශ්‍යයි",
   "Resets in {{hours}} hr {{minutes}} min": "{{hours}} පැ {{minutes}} මි කින් යළි පිහිටුවයි",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "අංක 4ක PIN එකක් තෝරන්න. ඔබ Readest විවෘත කරන සෑම විටම ඔබට එය ඇතුළත් කිරීමට අවශ්‍ය වේ. අමතක වූ PIN එකක් ලබා ගැනීමට ක්‍රමයක් නැත. එය යළි පිහිටුවීමට ඇති එකම ක්‍රමය යෙදුම් දත්ත මකා දැමීමයි.",

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1403,7 +1403,7 @@
   "Data Sync": "Sinhronizacija podatkov",
   "Manage Fonts": "Upravljanje pisav",
   "App settings": "Nastavitve aplikacije",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, barve označb, integracije (KOSync, Readwise, Hardcover) in vrstni red slovarjev",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Tema, barve označb in integracije (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Zahtevano, dokler je sinhronizacija Slovarjev omogočena",
   "Resets in {{hours}} hr {{minutes}} min": "Ponastavi se čez {{hours}} h {{minutes}} min",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Izberite 4-mestno kodo PIN. Vnesti jo boste morali vsakič, ko boste odprli Readest. Pozabljene kode PIN ni mogoče obnoviti. Edini način za ponastavitev je brisanje podatkov aplikacije.",

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1353,7 +1353,7 @@
   "Data Sync": "Datasynkronisering",
   "Manage Fonts": "Hantera teckensnitt",
   "App settings": "Appinställningar",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, markeringsfärger, integrationer (KOSync, Readwise, Hardcover) och ordbokens ordning",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Tema, markeringsfärger och integrationer (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Krävs så länge synkronisering av Ordböcker är aktiverad",
   "Resets in {{hours}} hr {{minutes}} min": "Återställs om {{hours}} tim {{minutes}} min",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Välj en 4-siffrig PIN-kod. Du kommer att behöva ange den varje gång du öppnar Readest. Det finns inget sätt att återställa en glömd PIN-kod. Att rensa appdata är det enda sättet att återställa den.",

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1353,7 +1353,7 @@
   "Data Sync": "தரவு ஒத்திசைவு",
   "Manage Fonts": "எழுத்துருக்களை நிர்வகி",
   "App settings": "ஆப் அமைப்புகள்",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "தீம், ஹைலைட் வண்ணங்கள், ஒருங்கிணைப்புகள் (KOSync, Readwise, Hardcover) மற்றும் அகராதி வரிசை",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "தீம், ஹைலைட் வண்ணங்கள் மற்றும் ஒருங்கிணைப்புகள் (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "அகராதிகள் ஒத்திசைவு இயக்கத்தில் இருக்கும்போது தேவை",
   "Resets in {{hours}} hr {{minutes}} min": "{{hours}} மணி {{minutes}} நிமிடத்தில் மீட்டமைக்கப்படும்",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "4 இலக்க PIN ஒன்றைத் தேர்ந்தெடுக்கவும். Readest திறக்கும் ஒவ்வொரு முறையும் அதை உள்ளிட வேண்டும். மறந்துபோன PIN ஐ மீட்டெடுக்க வழியில்லை. அதை மீட்டமைக்க ஒரே வழி பயன்பாட்டுத் தரவை அழிப்பதே ஆகும்.",

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1328,7 +1328,7 @@
   "Data Sync": "ซิงค์ข้อมูล",
   "Manage Fonts": "จัดการแบบอักษร",
   "App settings": "การตั้งค่าแอป",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "ธีม สีไฮไลต์ การเชื่อมต่อ (KOSync, Readwise, Hardcover) และลำดับพจนานุกรม",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "ธีม สีไฮไลต์ และการเชื่อมต่อ (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "จำเป็นเมื่อเปิดใช้การซิงค์พจนานุกรม",
   "Resets in {{hours}} hr {{minutes}} min": "รีเซ็ตใน {{hours}} ชม. {{minutes}} นาที",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "เลือก PIN 4 หลัก คุณจะต้องป้อนทุกครั้งที่เปิด Readest ไม่มีวิธีกู้คืน PIN ที่ลืม การล้างข้อมูลแอปเป็นวิธีเดียวในการรีเซ็ต",

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1353,7 +1353,7 @@
   "Data Sync": "Veri eşitleme",
   "Manage Fonts": "Yazı tiplerini yönet",
   "App settings": "Uygulama ayarları",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Tema, vurgu renkleri, entegrasyonlar (KOSync, Readwise, Hardcover) ve sözlük sırası",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Tema, vurgu renkleri ve entegrasyonlar (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Sözlük eşitlemesi etkinken gereklidir",
   "Resets in {{hours}} hr {{minutes}} min": "{{hours}} sa {{minutes}} dk içinde sıfırlanır",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "4 haneli bir PIN seçin. Readest'i her açtığınızda bunu girmeniz gerekecek. Unutulan bir PIN'i kurtarmanın yolu yoktur. Uygulama verilerini temizlemek, sıfırlamanın tek yoludur.",

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1403,7 +1403,7 @@
   "Data Sync": "Синхронізація даних",
   "Manage Fonts": "Керування шрифтами",
   "App settings": "Налаштування застосунку",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Тема, кольори виділень, інтеграції (KOSync, Readwise, Hardcover) і порядок словників",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Тема, кольори виділень та інтеграції (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Потрібне, доки увімкнено синхронізацію Словників",
   "Resets in {{hours}} hr {{minutes}} min": "Скидання через {{hours}} год {{minutes}} хв",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Виберіть 4-значний PIN-код. Вам потрібно буде вводити його щоразу, коли ви відкриваєте Readest. Відновити забутий PIN-код неможливо. Очищення даних застосунку — єдиний спосіб його скинути.",

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1349,7 +1349,7 @@
   "OPDS catalogs": "OPDS kataloglari",
   "Saved catalog URLs and (encrypted) credentials": "Saqlangan katalog URL manzillari va (shifrlangan) hisob maʼlumotlari",
   "App settings": "Ilova sozlamalari",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Mavzu, belgilash ranglari, integratsiyalar (KOSync, Readwise, Hardcover) va lugʻatlar tartibi",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Mavzu, belgilash ranglari va integratsiyalar (KOSync, Readwise, Hardcover)",
   "Choose what syncs across your devices. Disabling a category stops this device from sending or receiving rows of that kind. Anything already on the server is left alone, re-enabling resumes from where you stopped.": "Qurilmalaringiz oʻrtasida nimani sinxronlashni tanlang. Toifani oʻchirib qoʻyish bu qurilmaning shu turdagi maʼlumotlarni yuborish yoki qabul qilishini toʻxtatadi. Serverdagi mavjud maʼlumotlar oʻzgarmaydi; qaytadan yoqilganda toʻxtagan joydan davom etadi.",
   "Required while Dictionaries sync is enabled": "Lugʻatlar sinxronlashi yoqilgan ekan, talab qilinadi",
   "Manage Fonts": "Shriftlarni boshqarish",

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1328,7 +1328,7 @@
   "Data Sync": "Đồng bộ dữ liệu",
   "Manage Fonts": "Quản lý phông chữ",
   "App settings": "Cài đặt ứng dụng",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "Chủ đề, màu tô sáng, tích hợp (KOSync, Readwise, Hardcover) và thứ tự từ điển",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "Chủ đề, màu tô sáng và tích hợp (KOSync, Readwise, Hardcover)",
   "Required while Dictionaries sync is enabled": "Bắt buộc khi đồng bộ Từ điển đang bật",
   "Resets in {{hours}} hr {{minutes}} min": "Đặt lại sau {{hours}} g {{minutes}} ph",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "Chọn mã PIN 4 chữ số. Bạn sẽ cần nhập mã mỗi khi mở Readest. Không có cách nào để khôi phục mã PIN đã quên. Xóa dữ liệu ứng dụng là cách duy nhất để đặt lại mã.",

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1328,7 +1328,7 @@
   "Data Sync": "数据同步",
   "Manage Fonts": "管理字体",
   "App settings": "应用设置",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "主题、高亮颜色、第三方集成（KOSync、Readwise、Hardcover）以及词典顺序",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "主题、高亮颜色以及第三方集成（KOSync、Readwise、Hardcover）",
   "Required while Dictionaries sync is enabled": "启用词典同步时必需",
   "Resets in {{hours}} hr {{minutes}} min": "{{hours}} 小时 {{minutes}} 分钟后重置",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "请设置一个 4 位数字 PIN 码。每次打开 Readest 时都需要输入。忘记的 PIN 码无法找回，清除应用数据是重置它的唯一方法。",

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1328,7 +1328,7 @@
   "Data Sync": "資料同步",
   "Manage Fonts": "管理字型",
   "App settings": "應用程式設定",
-  "Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order": "主題、螢光標記顏色、第三方整合（KOSync、Readwise、Hardcover）以及詞典順序",
+  "Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)": "主題、螢光標記顏色以及第三方整合（KOSync、Readwise、Hardcover）",
   "Required while Dictionaries sync is enabled": "啟用詞典同步時必須",
   "Resets in {{hours}} hr {{minutes}} min": "{{hours}} 小時 {{minutes}} 分鐘後重設",
   "Pick a 4-digit PIN. You will need to enter it every time you open Readest. There is no way to recover a forgotten PIN. Clearing the app data is the only way to reset it.": "請設定一組 4 位數的 PIN 碼。每次開啟 Readest 時都需要輸入。遺忘的 PIN 碼無法復原，清除應用程式資料是重設它的唯一方法。",

--- a/apps/readest-app/src/__tests__/services/sync/adapters/settings.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/adapters/settings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+  SETTINGS_DICTIONARY_FIELDS,
   SETTINGS_KIND,
   SETTINGS_REPLICA_ID,
   SETTINGS_SCHEMA_VERSION,
@@ -34,6 +35,23 @@ describe('settingsAdapter', () => {
     expect(SETTINGS_KIND).toBe('settings');
     expect(SETTINGS_SCHEMA_VERSION).toBe(1);
     expect(SETTINGS_REPLICA_ID).toBe('singleton');
+  });
+
+  test('every dictionary-category path is a real whitelist entry', () => {
+    // The 'dictionary' sync gate in replicaSettingsSync matches these
+    // paths against SETTINGS_WHITELIST by exact string. A typo or a
+    // renamed whitelist entry would silently reopen the leak in #5465,
+    // so pin the membership here.
+    for (const path of SETTINGS_DICTIONARY_FIELDS) {
+      expect(SETTINGS_WHITELIST).toContain(path);
+    }
+    // Conversely, every whitelisted dictionarySettings.* path must be
+    // gated — a new one added without updating the list would sync
+    // regardless of the Dictionaries toggle.
+    const whitelistedDictPaths = SETTINGS_WHITELIST.filter((p) =>
+      p.startsWith('dictionarySettings.'),
+    );
+    expect([...SETTINGS_DICTIONARY_FIELDS].sort()).toEqual(whitelistedDictPaths.slice().sort());
   });
 
   test('declares no `binary` capability — bundled metadata only', () => {

--- a/apps/readest-app/src/__tests__/services/sync/replicaSettingsSync.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/replicaSettingsSync.test.ts
@@ -63,6 +63,22 @@ const enableCredentialsSync = (): void => {
   } as never);
 };
 
+/**
+ * Flip the 'dictionary' sync category for the current test. Dictionary
+ * preferences (providerOrder / providerEnabled / webSearches / fontScale)
+ * ride the bundled settings row but belong to the user-facing
+ * "Dictionaries" toggle, not "App settings" — see issue #5465.
+ */
+const setDictionarySync = (enabled: boolean): void => {
+  const current = useSettingsStore.getState().settings;
+  useSettingsStore.setState({
+    settings: {
+      ...current,
+      syncCategories: { ...current?.syncCategories, dictionary: enabled },
+    } as never,
+  } as never);
+};
+
 beforeEach(() => {
   publishMock.mockReset();
   ensurePassphraseMock.mockReset();
@@ -215,6 +231,47 @@ describe('publishSettingsIfChanged', () => {
     const patch = publishMock.mock.calls[0]![1].patch as Partial<SystemSettings>;
     expect(patch.dictionarySettings?.providerOrder).toBeUndefined();
     expect(patch.dictionarySettings?.providerEnabled).toEqual({ a: true, b: true });
+  });
+
+  test('does NOT publish dictionarySettings when the dictionary category is OFF (issue #5465)', async () => {
+    setDictionarySync(false);
+    await publishSettingsIfChanged(
+      makeSettings({
+        dictionarySettings: {
+          providerOrder: ['imp-new'],
+          providerEnabled: { 'imp-new': true, 'builtin:systemDictionary': false },
+          webSearches: [{ id: 'web:y', name: 'Y', urlTemplate: 'https://y/?q=%WORD%' }],
+          fontScale: 1.2,
+        },
+      } as Partial<SystemSettings>),
+    );
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    const patch = publishMock.mock.calls[0]![1].patch as Partial<SystemSettings>;
+    expect(patch.dictionarySettings).toBeUndefined();
+    // Unrelated whitelisted settings ride the same row and still publish.
+    expect(patch.globalReadSettings?.customHighlightColors).toEqual(
+      baseHighlight.customHighlightColors,
+    );
+  });
+
+  test('markExplicitProviderOrderPublish does not override the OFF gate', async () => {
+    const { markExplicitProviderOrderPublish } = await import(
+      '@/services/sync/replicaSettingsSync'
+    );
+    setDictionarySync(false);
+    markExplicitProviderOrderPublish();
+    await publishSettingsIfChanged(
+      makeSettings({
+        dictionarySettings: {
+          providerOrder: ['imp-new', 'builtin:wiktionary'],
+          providerEnabled: { 'imp-new': true },
+          webSearches: [],
+        },
+      } as Partial<SystemSettings>),
+    );
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    const patch = publishMock.mock.calls[0]![1].patch as Partial<SystemSettings>;
+    expect(patch.dictionarySettings).toBeUndefined();
   });
 
   test('triggers the passphrase gate when an encrypted field gets meaningful content while locked', async () => {
@@ -772,6 +829,75 @@ describe('applyRemoteSettings', () => {
       { id: 'web:remote-y', name: 'Y', urlTemplate: 'https://y/?q=%WORD%' },
     ]);
     expect(dictMirror.defaultProviderId).toBe('local-x');
+  });
+
+  test('does NOT apply remote dictionarySettings when the dictionary category is OFF (issue #5465)', async () => {
+    const { useCustomDictionaryStore } = await import('@/store/customDictionaryStore');
+    const localDict = {
+      providerOrder: ['local-x'],
+      providerEnabled: { 'local-x': true },
+      defaultProviderId: 'local-x',
+      webSearches: [],
+    };
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      settings: makeSettings({ dictionarySettings: localDict } as Partial<SystemSettings>),
+    });
+    setDictionarySync(false);
+    useCustomDictionaryStore.setState({
+      ...useCustomDictionaryStore.getState(),
+      settings: { ...localDict },
+    });
+
+    applyRemoteSettings(makeEnvConfig(), {
+      name: 'singleton',
+      patch: {
+        dictionarySettings: {
+          providerOrder: ['remote-y'],
+          providerEnabled: { 'remote-y': true },
+          webSearches: [{ id: 'web:remote-y', name: 'Y', urlTemplate: 'https://y/?q=%WORD%' }],
+        },
+        globalReadSettings: { userHighlightColors: [{ name: 'mint', color: '#a8e6cf' }] },
+      } as unknown as Partial<SystemSettings>,
+    });
+
+    const merged = useSettingsStore.getState().settings;
+    expect(merged.dictionarySettings.providerOrder).toEqual(['local-x']);
+    expect(merged.dictionarySettings.providerEnabled).toEqual({ 'local-x': true });
+    expect(merged.dictionarySettings.webSearches).toEqual([]);
+    // Non-dictionary fields on the same row still apply.
+    expect(merged.globalReadSettings.userHighlightColors).toEqual([
+      { name: 'mint', color: '#a8e6cf' },
+    ]);
+    // The dictionary panel / reader popup mirror stays on the local values.
+    expect(useCustomDictionaryStore.getState().settings.providerOrder).toEqual(['local-x']);
+  });
+
+  test('a dictionary-only remote patch is a no-op when the category is OFF', () => {
+    useSettingsStore.setState({
+      ...useSettingsStore.getState(),
+      settings: makeSettings({
+        dictionarySettings: {
+          providerOrder: ['local-x'],
+          providerEnabled: { 'local-x': true },
+          webSearches: [],
+        },
+      } as Partial<SystemSettings>),
+    });
+    setDictionarySync(false);
+    const before = useSettingsStore.getState().settings;
+    applyRemoteSettings(makeEnvConfig(), {
+      name: 'singleton',
+      patch: {
+        dictionarySettings: {
+          providerOrder: ['remote-y'],
+          providerEnabled: { 'remote-y': true },
+          webSearches: [],
+        },
+      } as unknown as Partial<SystemSettings>,
+    });
+    expect(useSettingsStore.getState().settings).toBe(before);
+    expect(useSettingsStore.getState().saveSettings).not.toHaveBeenCalled();
   });
 
   test('deep-merges dictionarySettings without clobbering local fields', () => {

--- a/apps/readest-app/src/app/user/components/SyncCategoriesSection.tsx
+++ b/apps/readest-app/src/app/user/components/SyncCategoriesSection.tsx
@@ -53,10 +53,10 @@ const useCategoryCopy = (): Record<SyncCategory, CategoryCopy> => {
       description: _('Saved catalog URLs and (encrypted) credentials'),
     },
     settings: {
+      // Dictionary preferences ride this row too, but they're gated by the
+      // Dictionaries toggle above, so they're deliberately not listed here.
       title: _('App settings'),
-      description: _(
-        'Theme, highlight colours, integrations (KOSync, Readwise, Hardcover), and dictionary order',
-      ),
+      description: _('Theme, highlight colours, and integrations (KOSync, Readwise, Hardcover)'),
     },
     credentials: {
       title: _('Credentials'),

--- a/apps/readest-app/src/services/sync/adapters/settings.ts
+++ b/apps/readest-app/src/services/sync/adapters/settings.ts
@@ -28,7 +28,9 @@ export const SETTINGS_REPLICA_ID = 'singleton';
  *     (`customFonts`, `customTextures`, `customDictionaries`,
  *     `opdsCatalogs`). Note: `dictionarySettings` sub-fields
  *     (providerOrder / providerEnabled / webSearches) ARE bundled
- *     here — see entries below.
+ *     here — see entries below. They ride this row for transport but
+ *     are gated by the 'dictionary' sync category, not 'settings'
+ *     (see `SETTINGS_DICTIONARY_FIELDS`).
  */
 export const SETTINGS_WHITELIST = [
   'globalViewSettings.userStylesheet',
@@ -79,6 +81,36 @@ export const SETTINGS_WHITELIST = [
   's3.bucket',
   's3.accessKeyId',
   's3.secretAccessKey',
+] as const;
+
+/**
+ * Whitelisted paths that belong to the user-facing "Dictionaries" sync
+ * category rather than "App settings". They ride the bundled settings
+ * row because that's where the values live in SystemSettings, but the
+ * user reads the Manage Sync panel by category, not by transport: with
+ * Dictionaries off, provider order / enable flags / web searches must
+ * neither leave nor enter the device (#5465).
+ *
+ * `publishSettingsIfChanged` drops these from the push and
+ * `applyRemoteSettings` strips them from an incoming patch whenever
+ * `isSyncCategoryEnabled('dictionary')` is false.
+ *
+ * The dependency edge in `syncCategories.ts` (dictionary requires
+ * settings) still holds in the other direction: these can only travel
+ * while the settings row itself syncs.
+ *
+ * Re-enable semantics differ slightly from a whole-kind category: the
+ * settings row keeps pulling while Dictionaries is off, so its cursor
+ * advances past the discarded values and re-enabling doesn't backfill
+ * them. The local side does resume immediately — the push snapshot was
+ * never updated for these paths, so the next save publishes the local
+ * values — and any later remote edit lands normally under per-field LWW.
+ */
+export const SETTINGS_DICTIONARY_FIELDS = [
+  'dictionarySettings.providerOrder',
+  'dictionarySettings.providerEnabled',
+  'dictionarySettings.webSearches',
+  'dictionarySettings.fontScale',
 ] as const;
 
 /**

--- a/apps/readest-app/src/services/sync/replicaSettingsSync.ts
+++ b/apps/readest-app/src/services/sync/replicaSettingsSync.ts
@@ -36,6 +36,7 @@ import type { EnvConfigType } from '@/services/environment';
 import { useSettingsStore } from '@/store/settingsStore';
 import { publishReplicaUpsert } from '@/services/sync/replicaPublish';
 import {
+  SETTINGS_DICTIONARY_FIELDS,
   SETTINGS_ENCRYPTED_FIELDS,
   SETTINGS_KIND,
   SETTINGS_REPLICA_ID,
@@ -46,10 +47,11 @@ import {
 } from '@/services/sync/adapters/settings';
 import { cryptoSession } from '@/libs/crypto/session';
 import { ensurePassphraseUnlocked } from '@/services/sync/passphraseGate';
-import { isCredentialsSyncEnabled } from '@/services/sync/syncCategories';
+import { isCredentialsSyncEnabled, isSyncCategoryEnabled } from '@/services/sync/syncCategories';
 import { useCustomDictionaryStore } from '@/store/customDictionaryStore';
 
 const ENCRYPTED_PATHS: ReadonlySet<string> = new Set(SETTINGS_ENCRYPTED_FIELDS);
+const DICTIONARY_PATHS: ReadonlySet<string> = new Set(SETTINGS_DICTIONARY_FIELDS);
 
 /**
  * Plaintext connection metadata that belongs to a credential-bearing group
@@ -249,10 +251,16 @@ export const publishSettingsIfChanged = async (settings: SystemSettings): Promis
   // belt-and-braces filter in `publishReplicaUpsert` would still drop
   // the field at the wire, but doing it here also avoids the prompt.
   const credentialsSync = isCredentialsSyncEnabled();
+  // Dictionaries toggle (default ON). Dictionary preferences ride this
+  // row for transport but belong to the 'dictionary' category, so a user
+  // who turned Dictionaries off keeps provider order / enable flags /
+  // web searches local while the rest of the bundle keeps syncing (#5465).
+  const dictionarySync = isSyncCategoryEnabled('dictionary');
 
   for (const path of SETTINGS_WHITELIST) {
     const current = readPath(settings, path);
     if (current === undefined) continue;
+    if (!dictionarySync && DICTIONARY_PATHS.has(path)) continue;
 
     if (ENCRYPTED_PATHS.has(path)) {
       if (!credentialsSync) continue;
@@ -381,12 +389,20 @@ export const applyRemoteSettings = (
     setStoredLastSeenCipher(record.lastSeenCipher);
   }
 
-  if (!settings || Object.keys(record.patch).length === 0) return;
+  // Dictionaries toggle (default ON): strip the dictionary-category
+  // paths from an incoming patch when the user turned Dictionaries off.
+  // The local plaintext copy survives untouched, and the paths are also
+  // left out of the snapshot loop below so nothing echoes back (#5465).
+  const patch = isSyncCategoryEnabled('dictionary')
+    ? record.patch
+    : stripDictionaryPaths(record.patch);
+
+  if (!settings || Object.keys(patch).length === 0) return;
 
   // Mark the incoming values as "already published" so the
   // post-save publish hook sees no diff and stays quiet.
   for (const path of SETTINGS_WHITELIST) {
-    const v = readPath(record.patch, path);
+    const v = readPath(patch, path);
     if (v === undefined) continue;
     if (ENCRYPTED_PATHS.has(path) || CONNECTION_PATHS.has(path)) {
       // Both are push-hash tracked; the stored hash mirrors the just-applied
@@ -397,7 +413,7 @@ export const applyRemoteSettings = (
     }
   }
 
-  const merged: SystemSettings = mergeSettings(settings, record.patch);
+  const merged: SystemSettings = mergeSettings(settings, patch);
   setSettings(merged);
   saveSettings(envConfig, merged);
 
@@ -405,11 +421,28 @@ export const applyRemoteSettings = (
   // dictionary panel + reader popup re-render with the remote values
   // immediately. Without this, those views read from the store's own
   // cache (only refreshed on `loadCustomDictionaries` mount).
-  if (record.patch.dictionarySettings) {
-    useCustomDictionaryStore
-      .getState()
-      .applyRemoteDictionarySettings(record.patch.dictionarySettings);
+  if (patch.dictionarySettings) {
+    useCustomDictionaryStore.getState().applyRemoteDictionarySettings(patch.dictionarySettings);
   }
+};
+
+/**
+ * Rebuild a remote patch without the dictionary-category paths. The
+ * patch only ever carries whitelisted paths (the adapter builds it from
+ * SETTINGS_WHITELIST), so walking the whitelist reproduces it exactly
+ * minus the skipped entries — and drops now-empty parent groups so the
+ * `Object.keys(patch).length === 0` early return still fires for a
+ * dictionary-only row.
+ */
+const stripDictionaryPaths = (patch: Partial<SystemSettings>): Partial<SystemSettings> => {
+  const out: Record<string, unknown> = {};
+  for (const path of SETTINGS_WHITELIST) {
+    if (DICTIONARY_PATHS.has(path)) continue;
+    const v = readPath(patch, path);
+    if (v === undefined) continue;
+    writePath(out, path, v);
+  }
+  return out as Partial<SystemSettings>;
 };
 
 const mergeSettings = (current: SystemSettings, patch: Partial<SystemSettings>): SystemSettings => {

--- a/apps/readest-app/src/services/sync/syncCategories.ts
+++ b/apps/readest-app/src/services/sync/syncCategories.ts
@@ -34,9 +34,13 @@ export type { SyncCategory };
  * "If <key> is enabled, every value in the array must also be enabled."
  *
  * - `dictionary` requires `settings`: dictionary's `providerOrder`,
- *   `providerEnabled`, and `webSearches` live inside the bundled
- *   settings replica. Turning settings off while dictionary is on
- *   would silently break dictionary cross-device sync.
+ *   `providerEnabled`, `webSearches`, and `fontScale` live inside the
+ *   bundled settings replica. Turning settings off while dictionary is
+ *   on would silently break dictionary cross-device sync. The reverse
+ *   is NOT a dependency: those fields ride the settings row but are
+ *   gated by the `dictionary` category, so turning Dictionaries off
+ *   keeps them local while the rest of the bundle keeps syncing
+ *   (#5465, see `SETTINGS_DICTIONARY_FIELDS`).
  *
  * Add new edges here as we ship features that span replica kinds.
  */


### PR DESCRIPTION
Closes #5465

## Problem

A user turned **Dictionaries** sync off on their iPhone so it could stay on the system dictionary while their e-ink devices kept a shared set of imported dictionaries. It didn't hold: setting the iPhone to the system dictionary propagated to the other devices, and enabling a dictionary elsewhere came back to the iPhone.

The Manage Sync categories gate by *replica kind*, and dictionary preferences don't live in the dictionary kind:

| Toggle | Replica kind | What it gated |
| --- | --- | --- |
| Dictionaries | `dictionary` | Imported dictionary bundles (binaries + metadata) |
| App settings | `settings` | `dictionarySettings.providerOrder` / `.providerEnabled` / `.webSearches` / `.fontScale` |

Those four paths are whitelisted into the bundled `settings` row, so they were gated by **App settings**, not **Dictionaries**. The "use the system dictionary" switch is `providerEnabled[systemDictionary]`, which is exactly one of them.

The panel copy claimed the opposite on both rows: Dictionaries said "Imported dictionary bundles **and settings**", and App settings listed "and dictionary order".

## Fix

`SETTINGS_DICTIONARY_FIELDS` names the four paths, and both directions now gate on `isSyncCategoryEnabled('dictionary')`:

- **Push** - `publishSettingsIfChanged` skips them in the whitelist loop, next to the existing credentials short-circuit.
- **Pull** - `applyRemoteSettings` rebuilds the incoming patch without them, so the local values survive, the `customDictionaryStore` mirror isn't touched, and a dictionary-only row hits the existing empty-patch early return.

The rest of the bundled settings keep syncing throughout. The Dictionaries row description is now true as written; the App settings description drops "and dictionary order" (extracted and translated across all 33 locales).

## On the dependency edge

The `dictionary -> settings` edge in `CATEGORY_DEPENDENTS` stays. These fields still ride the settings row as transport, so `dictionary` on with `settings` off would mean they silently never travel, which is what the edge exists to prevent. It doesn't affect the reported case (Dictionaries off), and the "Required while Dictionaries sync is enabled" hint stays accurate. What changed is that riding the settings row no longer *implies* belonging to the settings category.

## Known nuance (documented in code)

Re-enabling Dictionaries does not backfill: the settings row kept pulling while gated, so its cursor advanced past the discarded values. The local side resumes pushing immediately, because the push snapshot was never updated while gated, and any later remote edit lands under per-field LWW. This matches the panel's stated "re-enabling resumes from where you stopped" semantics.

## Tests

4 new cases in `replicaSettingsSync.test.ts`, all confirmed failing before the fix:

- push omits `dictionarySettings` when the category is off, while sibling fields on the same row still publish
- `markExplicitProviderOrderPublish` does not override the off gate
- pull leaves local dictionary prefs and the store mirror alone, while non-dictionary fields from the same row still apply
- a dictionary-only remote patch is a no-op (no `setSettings`, no `saveSettings`)

Plus a membership guard in `adapters/settings.test.ts` pinning the gated list against the whitelist in both directions, so a renamed or newly-added `dictionarySettings.*` path can't silently reopen the leak.

## Verification

- `pnpm test` - 8343 passed, 7 skipped
- `pnpm lint` - clean
- `pnpm format:check` - clean

No Rust or Lua changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)