### PR TITLE
fix(opds): use the cover advertised by the feed entry

### DIFF
--- a/apps/readest-app/src/__tests__/services/opds-auto-download.test.ts
+++ b/apps/readest-app/src/__tests__/services/opds-auto-download.test.ts
@@ -34,6 +34,10 @@ vi.mock('@/services/opds/sourceMap', () => ({
   upsertOPDSSourceMapping: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('@/services/opds/cover', () => ({
+  applyOPDSCover: vi.fn().mockResolvedValue(true),
+}));
+
 vi.mock('@/services/opds/subscriptionState', () => ({
   loadSubscriptionState: vi.fn().mockResolvedValue({
     catalogId: 'cat-1',
@@ -55,6 +59,7 @@ import { syncSubscribedCatalogs } from '@/services/opds/autoDownload';
 import { checkFeedForNewItems } from '@/services/opds/feedChecker';
 import { saveSubscriptionState, loadSubscriptionState } from '@/services/opds/subscriptionState';
 import { upsertOPDSSourceMapping } from '@/services/opds/sourceMap';
+import { applyOPDSCover } from '@/services/opds/cover';
 import { downloadFile } from '@/libs/storage';
 
 const createMockAppService = () =>
@@ -165,6 +170,80 @@ describe('OPDS auto-download orchestrator', () => {
     expect(vi.mocked(downloadFile).mock.calls[0]![0]).toMatchObject({
       skipSslVerification: true,
     });
+  });
+
+  it('applies the feed-provided cover to the imported book (issue #5270)', async () => {
+    const catalogs: OPDSCatalog[] = [
+      {
+        id: 'cat-1',
+        name: 'Shelf',
+        url: 'https://shelf.example.com/opds',
+        autoDownload: true,
+        username: 'user',
+        password: 'pass',
+      },
+    ];
+    vi.mocked(checkFeedForNewItems).mockResolvedValue([
+      {
+        entryId: 'urn:shelf:1',
+        title: 'Issue 1',
+        acquisitionHref: '/dl/1.epub',
+        coverHref: '/cwa/opds/cover/572',
+        mimeType: 'application/epub+zip',
+        baseURL: 'https://shelf.example.com/opds',
+      },
+    ]);
+
+    const result = await syncSubscribedCatalogs(catalogs, appService, []);
+
+    expect(applyOPDSCover).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appService,
+        book: result.newBooks[0],
+        coverUrl: 'https://shelf.example.com/cwa/opds/cover/572',
+        username: 'user',
+        password: 'pass',
+      }),
+    );
+  });
+
+  it('skips the cover step for entries without artwork', async () => {
+    const catalogs: OPDSCatalog[] = [
+      { id: 'cat-1', name: 'Shelf', url: 'https://shelf.example.com/opds', autoDownload: true },
+    ];
+    vi.mocked(checkFeedForNewItems).mockResolvedValue([
+      {
+        entryId: 'urn:shelf:1',
+        title: 'Issue 1',
+        acquisitionHref: '/dl/1.epub',
+        mimeType: 'application/epub+zip',
+        baseURL: 'https://shelf.example.com/opds',
+      },
+    ]);
+
+    const result = await syncSubscribedCatalogs(catalogs, appService, []);
+    expect(result.totalNewBooks).toBe(1);
+    expect(applyOPDSCover).not.toHaveBeenCalled();
+  });
+
+  it('still imports the book when the feed cover cannot be fetched', async () => {
+    const catalogs: OPDSCatalog[] = [
+      { id: 'cat-1', name: 'Shelf', url: 'https://shelf.example.com/opds', autoDownload: true },
+    ];
+    vi.mocked(checkFeedForNewItems).mockResolvedValue([
+      {
+        entryId: 'urn:shelf:1',
+        title: 'Issue 1',
+        acquisitionHref: '/dl/1.epub',
+        coverHref: '/cwa/opds/cover/572',
+        mimeType: 'application/epub+zip',
+        baseURL: 'https://shelf.example.com/opds',
+      },
+    ]);
+    vi.mocked(applyOPDSCover).mockRejectedValueOnce(new Error('cover server down'));
+
+    const result = await syncSubscribedCatalogs(catalogs, appService, []);
+    expect(result.totalNewBooks).toBe(1);
   });
 
   it('handles import failure by adding to failedEntries', async () => {

--- a/apps/readest-app/src/__tests__/services/opds-cover.test.ts
+++ b/apps/readest-app/src/__tests__/services/opds-cover.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Book } from '@/types/book';
+import type { AppService } from '@/types/system';
+import type { OPDSGenericLink } from '@/types/opds';
+
+vi.mock('@/services/environment', () => ({
+  isWebAppPlatform: vi.fn(() => false),
+  isTauriAppPlatform: vi.fn(() => true),
+  getAPIBaseUrl: () => '/api',
+  getNodeAPIBaseUrl: () => '/node-api',
+}));
+
+vi.mock('@/libs/storage', () => ({
+  downloadFile: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/app/opds/utils/opdsReq', () => ({
+  probeAuth: vi.fn().mockResolvedValue(null),
+  needsProxy: vi.fn(() => false),
+  getProxiedURL: vi.fn((url: string) => url),
+}));
+
+import { applyOPDSCover, getOPDSCoverHref } from '@/services/opds/cover';
+import { downloadFile } from '@/libs/storage';
+import { probeAuth, getProxiedURL, needsProxy } from '@/app/opds/utils/opdsReq';
+
+const createMockAppService = (coverBytes = new Uint8Array([1, 2, 3]).buffer) =>
+  ({
+    resolveFilePath: vi.fn(async (path: string) => `/cache/${path}`),
+    readFile: vi.fn(async () => coverBytes),
+    writeFile: vi.fn(async () => {}),
+    deleteFile: vi.fn(async () => {}),
+    computeCoverHash: vi.fn(async () => 'opds-cover-hash'),
+    generateCoverImageUrl: vi.fn(async () => 'asset://books/h1/cover.png'),
+  }) as unknown as AppService;
+
+const createBook = (): Book =>
+  ({
+    hash: 'h1',
+    format: 'EPUB',
+    title: 'Test Book',
+    author: 'Author',
+    coverHash: 'embedded-cover-hash',
+    coverImageUrl: 'asset://books/h1/cover.png?stale',
+    createdAt: 0,
+    updatedAt: 0,
+  }) as Book;
+
+const publicationWith = (images: OPDSGenericLink[] | undefined) => ({ images });
+
+describe('getOPDSCoverHref', () => {
+  it('prefers the full cover link over the thumbnail', () => {
+    const pub = publicationWith([
+      { rel: 'http://opds-spec.org/image/thumbnail', href: '/cwa/opds/cover/572/thumb' },
+      { rel: 'http://opds-spec.org/image', href: '/cwa/opds/cover/572' },
+    ]);
+    expect(getOPDSCoverHref(pub)).toBe('/cwa/opds/cover/572');
+  });
+
+  it('accepts a cover rel given as an array', () => {
+    const pub = publicationWith([
+      { rel: ['alternate', 'x-stanza-cover-image'], href: '/cover.jpg' },
+    ]);
+    expect(getOPDSCoverHref(pub)).toBe('/cover.jpg');
+  });
+
+  it('falls back to the thumbnail when no full cover is advertised', () => {
+    const pub = publicationWith([
+      { rel: 'http://opds-spec.org/image/thumbnail', href: '/cwa/opds/cover/572/thumb' },
+    ]);
+    expect(getOPDSCoverHref(pub)).toBe('/cwa/opds/cover/572/thumb');
+  });
+
+  it('falls back to the first image when no cover rel matches', () => {
+    const pub = publicationWith([{ rel: 'alternate', href: '/some-image.png' }]);
+    expect(getOPDSCoverHref(pub)).toBe('/some-image.png');
+  });
+
+  it('returns undefined when the publication advertises no image', () => {
+    expect(getOPDSCoverHref(publicationWith([]))).toBeUndefined();
+    expect(getOPDSCoverHref(publicationWith(undefined))).toBeUndefined();
+    expect(
+      getOPDSCoverHref(publicationWith([{ rel: 'http://opds-spec.org/image' }])),
+    ).toBeUndefined();
+  });
+});
+
+describe('applyOPDSCover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(downloadFile).mockResolvedValue({});
+    vi.mocked(needsProxy).mockReturnValue(false);
+    vi.mocked(getProxiedURL).mockImplementation((url: string) => url);
+    vi.mocked(probeAuth).mockResolvedValue(null);
+  });
+
+  it('overwrites the extracted cover with the one from the OPDS feed', async () => {
+    const appService = createMockAppService();
+    const book = createBook();
+
+    const applied = await applyOPDSCover({
+      appService,
+      book,
+      coverUrl: 'https://cwa.example.com/cwa/opds/cover/572',
+    });
+
+    expect(applied).toBe(true);
+    expect(downloadFile).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'https://cwa.example.com/cwa/opds/cover/572' }),
+    );
+    expect(appService.writeFile).toHaveBeenCalledWith('h1/cover.png', 'Books', expect.anything());
+    // Keeps the coverHash === partialMD5(cover.png) invariant (issue #4544).
+    expect(book.coverHash).toBe('opds-cover-hash');
+    expect(book.coverImageUrl).toBe('asset://books/h1/cover.png');
+  });
+
+  it('removes the temporary download once the cover is stored', async () => {
+    const appService = createMockAppService();
+    await applyOPDSCover({
+      appService,
+      book: createBook(),
+      coverUrl: 'https://cwa.example.com/cover/1',
+    });
+    expect(appService.deleteFile).toHaveBeenCalled();
+  });
+
+  it('sends basic auth and custom headers through the same probe as the book download', async () => {
+    vi.mocked(probeAuth).mockResolvedValue('Basic dXNlcjpwYXNz');
+    const appService = createMockAppService();
+
+    await applyOPDSCover({
+      appService,
+      book: createBook(),
+      coverUrl: 'https://cwa.example.com/cover/1',
+      username: 'user',
+      password: 'pass',
+      customHeaders: { 'X-Token': 'secret' },
+    });
+
+    expect(downloadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Basic dXNlcjpwYXNz',
+          'X-Token': 'secret',
+        }),
+      }),
+    );
+  });
+
+  it('keeps the extracted cover when the OPDS cover fails to download', async () => {
+    vi.mocked(downloadFile).mockRejectedValue(new Error('404 Not Found'));
+    const appService = createMockAppService();
+    const book = createBook();
+
+    const applied = await applyOPDSCover({
+      appService,
+      book,
+      coverUrl: 'https://cwa.example.com/cover/1',
+    });
+
+    expect(applied).toBe(false);
+    expect(appService.writeFile).not.toHaveBeenCalled();
+    expect(book.coverHash).toBe('embedded-cover-hash');
+  });
+
+  it('keeps the extracted cover when the server returns an empty body', async () => {
+    const appService = createMockAppService(new ArrayBuffer(0));
+    const book = createBook();
+
+    const applied = await applyOPDSCover({
+      appService,
+      book,
+      coverUrl: 'https://cwa.example.com/cover/1',
+    });
+
+    expect(applied).toBe(false);
+    expect(appService.writeFile).not.toHaveBeenCalled();
+    expect(book.coverHash).toBe('embedded-cover-hash');
+  });
+});

--- a/apps/readest-app/src/__tests__/services/opds-feed-checker.test.ts
+++ b/apps/readest-app/src/__tests__/services/opds-feed-checker.test.ts
@@ -635,6 +635,40 @@ describe('OPDS feed checker', () => {
       expect(items[0]!.entryId).toBe('https://example.com/dl/book.epub');
     });
 
+    it('carries the entry cover href so the import can use it (issue #5270)', () => {
+      const feed: OPDSFeed = {
+        metadata: { title: 'Test' },
+        links: [],
+        publications: [
+          {
+            metadata: { id: 'urn:cover', title: 'Custom Cover' },
+            links: [
+              {
+                href: '/dl/cover.epub',
+                type: 'application/epub+zip',
+                rel: 'http://opds-spec.org/acquisition',
+                properties: {},
+              },
+            ],
+            images: [
+              { href: '/cwa/opds/cover/572/thumb', rel: 'http://opds-spec.org/image/thumbnail' },
+              { href: '/cwa/opds/cover/572', rel: 'http://opds-spec.org/image' },
+            ],
+          },
+        ],
+      };
+      const items = collectNewEntries(feed, new Set(), 'https://example.com');
+      expect(items[0]!.coverHref).toBe('/cwa/opds/cover/572');
+    });
+
+    it('leaves coverHref unset when the entry advertises no artwork', () => {
+      const xml = makeAcquisitionFeed([{ id: 'urn:a', title: 'Issue 1', href: '/dl/a' }]);
+      const doc = parseXML(xml);
+      const feed = getFeed(doc) as OPDSFeed;
+      const items = collectNewEntries(feed, new Set(), 'https://example.com');
+      expect(items[0]!.coverHref).toBeUndefined();
+    });
+
     it('returns empty when all entries are already known', () => {
       const xml = makeAcquisitionFeed([{ id: 'urn:a', title: 'Issue 1', href: '/dl/a' }]);
       const doc = parseXML(xml);

--- a/apps/readest-app/src/app/opds/components/PublicationView.tsx
+++ b/apps/readest-app/src/app/opds/components/PublicationView.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { IoPricetag } from 'react-icons/io5';
 import { Book } from '@/types/book';
 import { OPDSPublication, REL, SYMBOL, OPDSAcquisitionLink, OPDSStreamLink } from '@/types/opds';
+import { getOPDSCoverHref } from '@/services/opds/cover';
 import { useTranslation } from '@/hooks/useTranslation';
 import { getFileExtFromMimeType } from '@/libs/document';
 import { formatDate, formatLanguage } from '@/utils/book';
@@ -83,14 +84,11 @@ export function PublicationView({
     [publication.links],
   );
 
-  const coverImage = useMemo(() => {
-    const covers = publication.images?.filter((img) =>
-      REL.COVER.some((rel: string) => img.rel?.includes(rel)),
-    );
-    return covers?.[0] || publication.images?.[0];
-  }, [publication.images]);
+  // Same pick the download path stores as the book cover, so the detail view
+  // never previews artwork the library won't end up showing (issue #5270).
+  const coverHref = useMemo(() => getOPDSCoverHref(publication), [publication]);
 
-  const imageUrl = coverImage?.href ? resolveURL(coverImage.href, baseURL) : null;
+  const imageUrl = coverHref ? resolveURL(coverHref, baseURL) : null;
 
   const authors = useMemo(() => {
     const author = publication.metadata?.author;

--- a/apps/readest-app/src/app/opds/page.tsx
+++ b/apps/readest-app/src/app/opds/page.tsx
@@ -48,6 +48,7 @@ import { getPublicationDetailHref, parsePublicationDocument } from './utils/opds
 import { ImportError } from '@/services/errors';
 import { READEST_OPDS_USER_AGENT } from '@/services/constants';
 import { findBookByOPDSSources, upsertOPDSSourceMapping } from '@/services/opds/sourceMap';
+import { applyOPDSCover, getOPDSCoverHref } from '@/services/opds/cover';
 import { buildPseStreamFileName } from '@/services/opds/pseStream';
 import type { Book } from '@/types/book';
 import { FeedView } from './components/FeedView';
@@ -550,6 +551,8 @@ export default function BrowserPage() {
     };
   }, [basePublication, detailPublication]);
 
+  const publicationCoverHref = publication ? getOPDSCoverHref(publication) : undefined;
+
   const handleDownload = useCallback(
     async (
       href: string,
@@ -617,6 +620,23 @@ export default function BrowserPage() {
           const { library, setLibrary } = useLibraryStore.getState();
           try {
             const book = await appService.importBook(dstFilePath, library);
+            // The catalog's own artwork wins over the one embedded in the file
+            // (#5270) — applied before the cloud upload is queued so peers get
+            // the same cover. Best effort: never fail the import over it.
+            if (book && publicationCoverHref) {
+              try {
+                await applyOPDSCover({
+                  appService,
+                  book,
+                  coverUrl: resolveURL(publicationCoverHref, state.baseURL),
+                  username,
+                  password,
+                  customHeaders,
+                });
+              } catch (coverError) {
+                console.warn('OPDS: failed to apply the feed cover:', coverError);
+              }
+            }
             if (book && catalogSourceId) {
               try {
                 await upsertOPDSSourceMapping(appService, {
@@ -646,7 +666,7 @@ export default function BrowserPage() {
         throw e;
       }
     },
-    [user, state.baseURL, appService, libraryLoaded, catalogSourceId],
+    [user, state.baseURL, appService, libraryLoaded, catalogSourceId, publicationCoverHref],
   );
 
   const handleStream = useCallback(

--- a/apps/readest-app/src/services/opds/autoDownload.ts
+++ b/apps/readest-app/src/services/opds/autoDownload.ts
@@ -7,6 +7,7 @@ import { needsProxy, getProxiedURL, probeAuth, probeFilename } from '@/app/opds/
 import { resolveURL, parseMediaType, getFileExtFromPath } from '@/app/opds/utils/opdsUtils';
 import { normalizeOPDSCustomHeaders } from '@/app/opds/utils/customHeaders';
 import { READEST_OPDS_USER_AGENT } from '@/services/constants';
+import { applyOPDSCover } from './cover';
 import { checkFeedForNewItems } from './feedChecker';
 import {
   loadSubscriptionState,
@@ -93,6 +94,22 @@ async function downloadAndImport(
 
   const book = await appService.importBook(dstFilePath, books);
   if (!book) throw new Error(`importBook returned null for ${item.title}`);
+  // The catalog's own artwork wins over the one embedded in the file (#5270).
+  // Best effort: a failure here must not fail an otherwise good import.
+  if (item.coverHref) {
+    try {
+      await applyOPDSCover({
+        appService,
+        book,
+        coverUrl: resolveURL(item.coverHref, item.baseURL),
+        username,
+        password,
+        customHeaders,
+      });
+    } catch (error) {
+      console.warn(`[OPDS] failed to apply the feed cover for "${item.title}":`, error);
+    }
+  }
   try {
     await upsertOPDSSourceMapping(appService, {
       catalogId: catalog.contentId || catalog.id,

--- a/apps/readest-app/src/services/opds/cover.ts
+++ b/apps/readest-app/src/services/opds/cover.ts
@@ -1,0 +1,120 @@
+import type { Book } from '@/types/book';
+import type { AppService } from '@/types/system';
+import type { OPDSGenericLink } from '@/types/opds';
+import { REL } from '@/types/opds';
+import { downloadFile } from '@/libs/storage';
+import { getProxiedURL, needsProxy, probeAuth } from '@/app/opds/utils/opdsReq';
+import { READEST_OPDS_USER_AGENT } from '@/services/constants';
+import { getCoverFilename } from '@/utils/book';
+import { uniqueId } from '@/utils/misc';
+
+/**
+ * Exact-match a link's rel tokens. Substring matching is wrong here:
+ * `http://opds-spec.org/image/thumbnail` contains `http://opds-spec.org/image`,
+ * so a naive `includes` would accept the thumbnail as the full-size cover.
+ */
+const matchesRel = (link: OPDSGenericLink, rels: readonly string[]) => {
+  const linkRels = Array.isArray(link.rel) ? link.rel : (link.rel ?? '').split(/\s+/);
+  return linkRels.some((rel) => rels.includes(rel));
+};
+
+/**
+ * The href of the artwork an OPDS entry advertises for itself, or undefined
+ * when it advertises none. Catalogs that let users replace a book's cover
+ * (Calibre-Web Automated and friends) publish the replacement here while the
+ * EPUB/PDF file still carries the original, so this is the cover the library
+ * should show (issue #5270).
+ *
+ * Prefers the full-size `rel="…/image"` link, then the thumbnail, then
+ * whatever image came first. The href is returned as-is — resolve it against
+ * the feed's base URL before fetching.
+ */
+export const getOPDSCoverHref = (publication: {
+  // Optional at runtime: feeds without artwork parse to an entry with no
+  // `images`, and the detail-document merge can drop it.
+  images?: OPDSGenericLink[];
+}): string | undefined => {
+  const images = publication.images ?? [];
+  const cover =
+    images.find((img) => matchesRel(img, REL.COVER) && img.href) ??
+    images.find((img) => matchesRel(img, REL.THUMBNAIL) && img.href) ??
+    images.find((img) => img.href);
+  return cover?.href;
+};
+
+interface ApplyOPDSCoverParams {
+  appService: AppService;
+  /** Imported book; its `coverHash`/`coverImageUrl` are updated in place. */
+  book: Book;
+  /** Absolute URL of the cover advertised by the OPDS entry. */
+  coverUrl: string;
+  username?: string;
+  password?: string;
+  customHeaders?: Record<string, string>;
+}
+
+/**
+ * Replace an imported book's cover with the one the OPDS entry advertises.
+ *
+ * Best effort: any failure (offline, 404, empty body) leaves the cover
+ * extracted from the book file in place and returns false, so a catalog
+ * without usable artwork never degrades the import.
+ */
+export const applyOPDSCover = async ({
+  appService,
+  book,
+  coverUrl,
+  username = '',
+  password = '',
+  customHeaders = {},
+}: ApplyOPDSCoverParams): Promise<boolean> => {
+  const useProxy = needsProxy(coverUrl);
+  let downloadUrl = useProxy ? getProxiedURL(coverUrl, '', true, customHeaders) : coverUrl;
+  const headers: Record<string, string> = {
+    'User-Agent': READEST_OPDS_USER_AGENT,
+    Accept: 'image/*',
+    ...(!useProxy ? customHeaders : {}),
+  };
+  if (username || password) {
+    const authHeader = await probeAuth(coverUrl, username, password, useProxy, customHeaders);
+    if (authHeader) {
+      if (!useProxy) {
+        headers['Authorization'] = authHeader;
+      }
+      downloadUrl = useProxy ? getProxiedURL(coverUrl, authHeader, true, customHeaders) : coverUrl;
+    }
+  }
+
+  const tmpPath = await appService.resolveFilePath(`opds_cover_${uniqueId()}`, 'Cache');
+  try {
+    await downloadFile({
+      appService,
+      dst: tmpPath,
+      cfp: '',
+      url: downloadUrl,
+      headers,
+      singleThreaded: true,
+      // Same self-signed/private-CA workaround the book download uses (#4988).
+      skipSslVerification: true,
+    });
+    const bytes = (await appService.readFile(tmpPath, 'None', 'binary')) as ArrayBuffer;
+    if (!bytes?.byteLength) return false;
+    await appService.writeFile(getCoverFilename(book), 'Books', bytes);
+  } catch (error) {
+    console.warn('[OPDS] failed to apply the feed cover:', error);
+    return false;
+  } finally {
+    try {
+      await appService.deleteFile(tmpPath, 'None');
+    } catch {
+      // best effort cache cleanup
+    }
+  }
+
+  // Keep coverHash === partialMD5(cover.png) so cross-device cover sync still
+  // sees the truth (issue #4544), and refresh the URL the library renders from
+  // — on web it is a blob URL bound to the bytes we just replaced.
+  book.coverHash = await appService.computeCoverHash(book);
+  book.coverImageUrl = await appService.generateCoverImageUrl(book);
+  return true;
+};

--- a/apps/readest-app/src/services/opds/feedChecker.ts
+++ b/apps/readest-app/src/services/opds/feedChecker.ts
@@ -20,6 +20,7 @@ import {
   parseOPDSXML,
 } from '@/app/opds/utils/opdsUtils';
 import { normalizeOPDSCustomHeaders } from '@/app/opds/utils/customHeaders';
+import { getOPDSCoverHref } from './cover';
 import type { OPDSSubscriptionState, PendingItem } from './types';
 import { MAX_CRAWL_DEPTH, MAX_FEEDS_PER_CRAWL, MAX_PAGES_PER_FEED } from './types';
 
@@ -200,6 +201,7 @@ export function collectNewEntries(
       entryId,
       title: pub.metadata.title || acqLink.title || 'Untitled',
       acquisitionHref: acqLink.href,
+      coverHref: getOPDSCoverHref(pub),
       mimeType: acqLink.type ?? 'application/octet-stream',
       updated: pub.metadata.updated,
       baseURL,

--- a/apps/readest-app/src/services/opds/types.ts
+++ b/apps/readest-app/src/services/opds/types.ts
@@ -23,6 +23,8 @@ export interface PendingItem {
   entryId: string;
   title: string;
   acquisitionHref: string;
+  /** Cover advertised by the entry, preferred over the one inside the file (#5270). */
+  coverHref?: string;
   mimeType: string;
   updated?: string;
   baseURL: string;


### PR DESCRIPTION
## Problem

An OPDS entry can advertise its own cover art:

```xml
<link type="image/jpeg" href="/cwa/opds/cover/572" rel="http://opds-spec.org/image"/>
<link type="image/jpeg" href="/cwa/opds/cover/572" rel="http://opds-spec.org/image/thumbnail"/>
```

Catalogs like Calibre-Web Automated let a user replace a book's cover and serve
the replacement there without rewriting the EPUB/PDF. Readest ignored it: the
library showed whatever cover the downloaded file happened to contain.

Reported in #5270.

## Change

New `src/services/opds/cover.ts`:

- `getOPDSCoverHref(publication)` picks the entry's artwork: the full-size
  `rel=".../image"` link first, then the thumbnail, then any image.
- `applyOPDSCover(...)` downloads it through the same proxy, basic auth, custom
  header and `skipSslVerification` handling the book download uses, writes it
  over `Books/<hash>/cover.png`, and refreshes `coverHash` (keeping the
  `coverHash === partialMD5(cover.png)` invariant from #4544) and
  `coverImageUrl` (a blob URL bound to the replaced bytes on web).

Wired into both acquisition paths, after `importBook`:

- manual download (`app/opds/page.tsx`), applied before the cloud upload is
  queued so peers get the same artwork;
- auto-download subscriptions (`services/opds/autoDownload.ts`), with the href
  carried on `PendingItem.coverHref` from `collectNewEntries`.

`PublicationView` now uses the same helper, so the detail-view preview and the
stored cover cannot disagree.

It is best effort throughout: a 404, an offline server or an empty body leaves
the file-extracted cover in place and the import still succeeds.

### Drive-by fix

Cover/thumbnail rel matching compared by substring, and
`http://opds-spec.org/image/thumbnail` contains `http://opds-spec.org/image`,
so an entry that lists its thumbnail first had the thumbnail picked as the
full-size cover. Matching is now on exact rel tokens (a unit test covers it).

## Scope

Cover only. The metadata half of #5270 (title/author/publisher from the feed
being discarded at import) is unchanged, so the issue stays open.

Re-downloading a book you already own now replaces its cover with the
catalog's, including a cover edited by hand. That seemed right for an explicit
"Download Again"; happy to gate it on first import instead.

## Verification

- `pnpm test`: 8342 passed. 15 new tests covering cover selection, the
  download/write/hash path, both failure modes, `coverHref` propagation through
  `collectNewEntries`, and the auto-download wiring.
- `pnpm lint` and `pnpm format:check` clean. No Rust or Lua changes.
- End to end against a local OPDS feed serving `sample-alice.epub` plus a
  deliberately different cover image: the library cover came out as the
  2738-byte feed cover. With the wiring disabled the same check produced
  327217 bytes, the EPUB's embedded cover, so it does discriminate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
