### PR TITLE
feat(reader): show the image description in the image viewer

### DIFF
--- a/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
@@ -156,6 +156,73 @@ describe('ImageViewer', () => {
     expect(reachedScale).toBeGreaterThanOrEqual(50);
   });
 
+  // #5232: EPUBs often keep the caption or table description of an
+  // illustration in the image's `alt` attribute, which was invisible once the
+  // image was opened full screen.
+  describe('image description caption', () => {
+    const caption = 'Tabella di come creare una buona abitudine';
+
+    it('shows the image description over the zoomed image', () => {
+      const { container } = render(
+        <ImageViewer
+          src='blob:test-image'
+          caption={caption}
+          onClose={vi.fn()}
+          gridInsets={gridInsets}
+        />,
+      );
+
+      expect(container.querySelector('.image-caption')?.textContent).toBe(caption);
+      // The zoomed image carries the book's own description too, instead of the
+      // placeholder used when the book provides none.
+      expect(container.querySelector('img')!.getAttribute('alt')).toBe(caption);
+    });
+
+    it('renders nothing when the image has no description', () => {
+      const { container } = render(
+        <ImageViewer src='blob:test-image' onClose={vi.fn()} gridInsets={gridInsets} />,
+      );
+
+      expect(container.querySelector('.image-caption')).toBeNull();
+    });
+
+    // The caption sits over the bottom of the image, so tapping the image must
+    // get it out of the way (and bring it back).
+    it('toggles the caption when the image is tapped', () => {
+      const { container } = render(
+        <ImageViewer
+          src='blob:test-image'
+          caption={caption}
+          onClose={vi.fn()}
+          gridInsets={gridInsets}
+        />,
+      );
+      const img = container.querySelector('img')!;
+
+      fireEvent.click(img);
+      expect(container.querySelector('.image-caption')).toBeNull();
+
+      fireEvent.click(img);
+      expect(container.querySelector('.image-caption')?.textContent).toBe(caption);
+    });
+
+    it('does not close the viewer when the caption itself is tapped', () => {
+      const onClose = vi.fn();
+      const { container } = render(
+        <ImageViewer
+          src='blob:test-image'
+          caption={caption}
+          onClose={onClose}
+          gridInsets={gridInsets}
+        />,
+      );
+
+      fireEvent.click(container.querySelector('.image-caption')!);
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
   // Trackpad pinch flicker (#4742): on macOS a trackpad pinch-to-zoom arrives
   // as a rapid stream of ctrl+wheel events. With the 0.05s transition left on,
   // each event restarts the in-flight transition from its interpolated

--- a/apps/readest-app/src/__tests__/reader/utils/documentImages.test.ts
+++ b/apps/readest-app/src/__tests__/reader/utils/documentImages.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+
+import { collectDocumentImages } from '@/app/reader/utils/documentImages';
+
+const docFromBody = (body: string) =>
+  new DOMParser().parseFromString(`<html><body>${body}</body></html>`, 'text/html');
+
+const getCFI = (index: number) => `cfi-${index}`;
+
+describe('collectDocumentImages', () => {
+  // #5232: EPUBs often carry the caption/table description of an illustration
+  // in the `alt` attribute rather than a <figcaption>, so the image viewer
+  // needs it alongside the src to show it while the image is zoomed.
+  it('captures the alt text of every image in document order', () => {
+    const doc = docFromBody(`
+      <div class="figure">
+        <p><img alt="Tabella di come creare una buona abitudine" src="https://book/07b.jpg"/></p>
+      </div>
+      <p><img alt="Second figure" src="https://book/08.jpg"/></p>
+    `);
+
+    const images = collectDocumentImages([{ doc, index: 3 }], getCFI);
+
+    expect(images).toEqual([
+      {
+        src: 'https://book/07b.jpg',
+        cfi: 'cfi-3',
+        alt: 'Tabella di come creare una buona abitudine',
+      },
+      { src: 'https://book/08.jpg', cfi: 'cfi-3', alt: 'Second figure' },
+    ]);
+  });
+
+  it('reports no description for images without usable alt text', () => {
+    const doc = docFromBody(`
+      <img src="https://book/a.jpg"/>
+      <img alt="   " src="https://book/b.jpg"/>
+    `);
+
+    const images = collectDocumentImages([{ doc, index: 0 }], getCFI);
+
+    expect(images.map((image) => image.alt)).toEqual(['', '']);
+  });
+
+  // Full-page illustrations are frequently wrapped in <svg><image/></svg>,
+  // where the accessible description lives in the SVG <title> instead.
+  it('uses the SVG <title> as the description for svg-wrapped images', () => {
+    const doc = docFromBody(
+      `<svg viewBox="0 0 100 100"><title>Diagram of the habit loop</title>` +
+        `<image href="https://book/diagram.png"/></svg>`,
+    );
+
+    const images = collectDocumentImages([{ doc, index: 1 }], getCFI);
+
+    expect(images).toEqual([
+      { src: 'https://book/diagram.png', cfi: 'cfi-1', alt: 'Diagram of the habit loop' },
+    ]);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -72,6 +72,7 @@ import { useBookCoverAutoSave } from '../hooks/useAutoSaveBookCover';
 import { useDiscordPresence } from '@/hooks/useDiscordPresence';
 import { manageSyntaxHighlighting } from '@/utils/highlightjs';
 import { getViewInsets } from '@/utils/insets';
+import { collectDocumentImages, DocumentImage } from '../utils/documentImages';
 import { footerReservesBand } from '../utils/footerBand';
 import { showTransientSearchHighlight } from '../utils/searchHighlight';
 import { handleA11yNavigation } from '@/utils/a11y';
@@ -565,49 +566,27 @@ const FoliateViewer: React.FC<{
   const autoscrollAnchor = useMiddleClickAutoscroll(bookKey, viewRef, containerRef);
 
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  // The description of the image on screen, kept next to `selectedImage` so the
+  // two can never drift apart (the pressed image may be missing from the list).
+  const [selectedImageAlt, setSelectedImageAlt] = useState<string>('');
   const [selectedTableHtml, setSelectedTableHtml] = useState<string | null>(null);
-  const [imageList, setImageList] = useState<{ src: string; cfi: string | null }[]>([]);
+  const [imageList, setImageList] = useState<DocumentImage[]>([]);
   const [currentImageIndex, setCurrentImageIndex] = useState<number>(0);
 
   const handleImagePress = useCallback(async (src: string) => {
     try {
       // Get all images from the current document
-      const docs = viewRef.current?.renderer.getContents();
-      const allImages: { src: string; cfi: string | null }[] = [];
-
-      docs?.forEach(({ doc, index }) => {
-        const elements = doc.querySelectorAll('img, svg');
-        elements.forEach((el) => {
-          if (index === undefined) return;
-          if (el.localName === 'img') {
-            const img = el as HTMLImageElement;
-            if (img.src && img.parentNode) {
-              const range = doc.createRange();
-              range.selectNodeContents(img);
-              const cfi = viewRef.current?.getCFI(index, range) || null;
-              allImages.push({ src: img.src, cfi });
-            }
-          } else if (el.localName === 'svg') {
-            const svg = el as unknown as SVGSVGElement;
-            const svgImage = svg.querySelector('image');
-            const href =
-              svgImage?.getAttribute('href') ||
-              svgImage?.getAttributeNS('http://www.w3.org/1999/xlink', 'href');
-            if (href) {
-              const range = doc.createRange();
-              range.selectNodeContents(svg);
-              const cfi = viewRef.current?.getCFI(index, range) || null;
-              allImages.push({ src: href, cfi });
-            }
-          }
-        });
-      });
+      const allImages = collectDocumentImages(
+        viewRef.current?.renderer.getContents() ?? [],
+        (index, range) => viewRef.current?.getCFI(index, range) || null,
+      );
 
       // Find the index of the pressed image
       const index = allImages.findIndex((img) => img.src === src);
 
       setImageList(allImages);
       setCurrentImageIndex(index >= 0 ? index : 0);
+      setSelectedImageAlt(index >= 0 ? allImages[index]!.alt : '');
 
       const dataUrl = await convertBlobUrlToDataUrl(src);
       setSelectedImage(dataUrl);
@@ -625,9 +604,10 @@ const FoliateViewer: React.FC<{
       const newIndex = currentImageIndex - 1;
       setCurrentImageIndex(newIndex);
       try {
-        const { src, cfi } = imageList[newIndex]!;
+        const { src, cfi, alt } = imageList[newIndex]!;
         const dataUrl = await convertBlobUrlToDataUrl(src);
         setSelectedImage(dataUrl);
+        setSelectedImageAlt(alt);
         if (cfi && viewRef.current) {
           viewRef.current?.goTo(cfi);
         }
@@ -642,9 +622,10 @@ const FoliateViewer: React.FC<{
       const newIndex = currentImageIndex + 1;
       setCurrentImageIndex(newIndex);
       try {
-        const { src, cfi } = imageList[newIndex]!;
+        const { src, cfi, alt } = imageList[newIndex]!;
         const dataUrl = await convertBlobUrlToDataUrl(src);
         setSelectedImage(dataUrl);
+        setSelectedImageAlt(alt);
         if (cfi && viewRef.current) {
           viewRef.current?.goTo(cfi);
         }
@@ -656,6 +637,7 @@ const FoliateViewer: React.FC<{
 
   const handleCloseImage = useCallback(() => {
     setSelectedImage(null);
+    setSelectedImageAlt('');
     setImageList([]);
     setCurrentImageIndex(0);
   }, []);
@@ -1054,6 +1036,7 @@ const FoliateViewer: React.FC<{
         <ImageViewer
           gridInsets={gridInsets}
           src={selectedImage}
+          caption={selectedImageAlt}
           onClose={handleCloseImage}
           onPrevious={currentImageIndex > 0 ? handlePreviousImage : undefined}
           onNext={currentImageIndex < imageList.length - 1 ? handleNextImage : undefined}

--- a/apps/readest-app/src/app/reader/components/ImageViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/ImageViewer.tsx
@@ -13,6 +13,9 @@ import ZoomControls from './ZoomControls';
 interface ImageViewerProps {
   gridInsets: Insets;
   src: string | null;
+  // The image's description (its `alt` text), shown over the zoomed image when
+  // the book provides one (#5232).
+  caption?: string;
   onClose: () => void;
   onPrevious?: () => void;
   onNext?: () => void;
@@ -28,6 +31,7 @@ const FALLBACK_DOUBLE_CLICK_SCALE = 2;
 
 const ImageViewer: React.FC<ImageViewerProps> = ({
   src,
+  caption,
   onClose,
   onPrevious,
   onNext,
@@ -52,6 +56,9 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
   const [isDragging, setIsDragging] = useState(false);
   const [isWheelZooming, setIsWheelZooming] = useState(false);
   const [showZoomLabel, setShowZoomLabel] = useState(true);
+  // Unlike the zoom badge the caption does not time out — it is content, not
+  // chrome — so tapping the image is what gets it off the artwork.
+  const [showCaption, setShowCaption] = useState(true);
   const lastTouchDistance = useRef<number>(0);
   const dragStart = useRef({ x: 0, y: 0 });
   const wasDragging = useRef(false);
@@ -486,6 +493,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
     }
 
     setShowZoomLabel((prev) => !prev);
+    setShowCaption((prev) => !prev);
   };
 
   const cursorStyle = scale > 1 ? (isDragging ? 'grabbing' : 'grab') : 'default';
@@ -566,7 +574,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
           role='none'
           src={decodeURIComponent(src)}
           ref={imageRef}
-          alt={_('Zoomed')}
+          alt={caption || _('Zoomed')}
           className='transform-gpu select-none object-contain'
           draggable={false}
           width={0}
@@ -596,6 +604,20 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
           }}
         />
       </div>
+
+      {/* Sibling of the click-to-close container above, so reading (or
+          scrolling) the description never dismisses the viewer. */}
+      {caption && showCaption && (
+        <div
+          // The description comes from the book, whose language need not match
+          // the UI's, so let the text pick its own direction.
+          dir='auto'
+          className='image-caption eink-bordered not-eink:text-white not-eink:bg-black/50 absolute bottom-4 left-1/2 z-10 max-h-[30%] w-[calc(100%-2rem)] max-w-2xl -translate-x-1/2 overflow-y-auto rounded-lg px-4 py-2 text-center text-sm'
+          style={{ marginBottom: `${gridInsets.bottom}px` }}
+        >
+          {caption}
+        </div>
+      )}
 
       {showZoomLabel && (
         <div

--- a/apps/readest-app/src/app/reader/utils/documentImages.ts
+++ b/apps/readest-app/src/app/reader/utils/documentImages.ts
@@ -1,0 +1,42 @@
+export interface DocumentImage {
+  src: string;
+  cfi: string | null;
+  // The image's own description: the `alt` attribute, or the SVG <title> for
+  // svg-wrapped images. Empty when the book provides none.
+  alt: string;
+}
+
+// Every image of the rendered sections, in document order, so the image viewer
+// can page through them and caption each one with its own description (#5232).
+export const collectDocumentImages = (
+  contents: { doc: Document; index?: number }[],
+  getCFI: (index: number, range: Range) => string | null,
+): DocumentImage[] => {
+  const images: DocumentImage[] = [];
+  contents.forEach(({ doc, index }) => {
+    if (index === undefined) return;
+    doc.querySelectorAll('img, svg').forEach((el) => {
+      const cfiOf = (node: Element) => {
+        const range = doc.createRange();
+        range.selectNodeContents(node);
+        return getCFI(index, range);
+      };
+      if (el.localName === 'img') {
+        const img = el as HTMLImageElement;
+        if (img.src && img.parentNode) {
+          images.push({ src: img.src, cfi: cfiOf(img), alt: (img.alt || '').trim() });
+        }
+      } else if (el.localName === 'svg') {
+        const svgImage = el.querySelector('image');
+        const href =
+          svgImage?.getAttribute('href') ||
+          svgImage?.getAttributeNS('http://www.w3.org/1999/xlink', 'href');
+        if (href) {
+          const title = el.querySelector('title')?.textContent || '';
+          images.push({ src: href, cfi: cfiOf(el), alt: title.trim() });
+        }
+      }
+    });
+  });
+  return images;
+};


### PR DESCRIPTION
Closes #5232

## Problem

Many EPUBs keep the caption or the table description of an illustration in the `img` `alt` attribute rather than in a `<figcaption>`, as in the example from the issue:

```html
<div class="figure">
  <p class="center">
    <img alt="Tabella di come creare una buona abitudine" src="../Images/07b.jpg" width="85%"/>
  </p>
</div>
```

That text was invisible once the image was opened full screen, which is exactly when the reader wants it.

## Change

- `collectDocumentImages()` (new, extracted from the inline loop in `FoliateViewer.handleImagePress`) now captures each image's own description alongside its `src` and CFI: the `alt` attribute for `<img>`, and the SVG `<title>` for images wrapped in `<svg><image/></svg>`, which is where the description lives for full-page illustrations. Whitespace-only `alt` counts as no description.
- `ImageViewer` takes an optional `caption` and renders it over the bottom of the zoomed image.
- `FoliateViewer` keeps the description next to `selectedImage` and updates it when opening, paging to the previous/next image, and closing.

Notes on the behavior:

- The caption does not time out the way the zoom badge does, since it is content rather than chrome. Tapping the image gets it off the artwork and brings it back.
- It renders as a sibling of the click-to-close container, so reading or scrolling a long description never dismisses the viewer.
- `dir='auto'`, because the book's language need not match the UI's. Long descriptions scroll inside the panel (`max-h-[30%]`), and the panel is offset by the bottom safe-area inset.
- The description is kept in its own state rather than derived from `imageList[currentImageIndex]`: when the tapped image is not found in the list the index falls back to `0`, which would caption the image with a different image's description.

## Verification

- 7 new unit tests, written failing first: description extraction and ordering in `documentImages.test.ts`, and caption rendering, the tap toggle, and the no-description case in `ImageViewer.test.tsx`.
- `pnpm test` (8370 passed, 7 skipped), `pnpm lint`, `pnpm format:check` all clean. No `src-tauri/` or koplugin changes, so those gates do not apply.
- Driven in a real browser against a purpose-built EPUB carrying one long `alt` and one `alt=""`: the caption shows the right text, toggles on tap, clears when paging to the image with no description, and stays legible under `[data-eink='true']` (white panel, 1px border, via `eink-bordered`).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
