### PR TITLE
fix(linux): explain the missing file picker in SteamOS Gaming Mode

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2186,5 +2186,6 @@
   "Progress Bar": "شريط التقدم",
   "Current Time": "الوقت الحالي",
   "Battery Status": "حالة البطارية",
-  "Battery Percentage": "نسبة البطارية"
+  "Battery Percentage": "نسبة البطارية",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "منتقي الملفات في النظام غير متاح في وضع الألعاب. يرجى التبديل إلى وضع سطح المكتب لاختيار الملفات."
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2002,5 +2002,6 @@
   "Progress Bar": "অগ্রগতি বার",
   "Current Time": "বর্তমান সময়",
   "Battery Status": "ব্যাটারি অবস্থা",
-  "Battery Percentage": "ব্যাটারি শতাংশ"
+  "Battery Percentage": "ব্যাটারি শতাংশ",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "গেমিং মোডে সিস্টেম ফাইল নির্বাচক উপলব্ধ নয়। ফাইল নির্বাচন করতে অনুগ্রহ করে ডেস্কটপ মোডে যান।"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1956,5 +1956,6 @@
   "Progress Bar": "ཡར་འཕེལ་ཕྲ་རིང་།",
   "Current Time": "ད་ལྟའི་དུས་ཚོད།",
   "Battery Status": "གློག་རྫས་གནས་བབ།",
-  "Battery Percentage": "གློག་རྫས་བརྒྱ་ཆ།"
+  "Battery Percentage": "གློག་རྫས་བརྒྱ་ཆ།",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "རྩེད་མོའི་རྣམ་པའི་ནང་དུ་མ་ལག་གི་ཡིག་ཆ་འདེམས་ཆས་སྤྱོད་མི་ཐུབ། ཡིག་ཆ་འདེམས་པའི་ཆེད་དུ་ཅོག་ངོས་རྣམ་པར་བརྗེ་རོགས།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2002,5 +2002,6 @@
   "Progress Bar": "Fortschrittsleiste",
   "Current Time": "Aktuelle Uhrzeit",
   "Battery Status": "Akkustand",
-  "Battery Percentage": "Akkustand in Prozent"
+  "Battery Percentage": "Akkustand in Prozent",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Die Systemdateiauswahl ist im Gaming-Modus nicht verfügbar. Bitte wechseln Sie in den Desktop-Modus, um Dateien auszuwählen."
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2002,5 +2002,6 @@
   "Progress Bar": "Γραμμή προόδου",
   "Current Time": "Τρέχουσα ώρα",
   "Battery Status": "Κατάσταση μπαταρίας",
-  "Battery Percentage": "Ποσοστό μπαταρίας"
+  "Battery Percentage": "Ποσοστό μπαταρίας",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Ο επιλογέας αρχείων συστήματος δεν είναι διαθέσιμος στη λειτουργία παιχνιδιού. Μεταβείτε στη λειτουργία επιφάνειας εργασίας για να επιλέξετε αρχεία."
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2048,5 +2048,6 @@
   "Progress Bar": "Barra de progreso",
   "Current Time": "Hora actual",
   "Battery Status": "Estado de la batería",
-  "Battery Percentage": "Porcentaje de batería"
+  "Battery Percentage": "Porcentaje de batería",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "El selector de archivos del sistema no está disponible en el modo de juego. Cambia al modo de escritorio para seleccionar archivos."
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2002,5 +2002,6 @@
   "Progress Bar": "نوار پیشرفت",
   "Current Time": "زمان فعلی",
   "Battery Status": "وضعیت باتری",
-  "Battery Percentage": "درصد باتری"
+  "Battery Percentage": "درصد باتری",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "انتخابگر پروندهٔ سیستم در حالت بازی در دسترس نیست. لطفاً برای انتخاب پرونده‌ها به حالت دسکتاپ بروید."
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2048,5 +2048,6 @@
   "Progress Bar": "Barre de progression",
   "Current Time": "Heure actuelle",
   "Battery Status": "État de la batterie",
-  "Battery Percentage": "Pourcentage de batterie"
+  "Battery Percentage": "Pourcentage de batterie",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Le sélecteur de fichiers du système n'est pas disponible en mode jeu. Veuillez passer en mode bureau pour sélectionner des fichiers."
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2048,5 +2048,6 @@
   "Progress Bar": "סרגל התקדמות",
   "Current Time": "השעה הנוכחית",
   "Battery Status": "מצב סוללה",
-  "Battery Percentage": "אחוזי סוללה"
+  "Battery Percentage": "אחוזי סוללה",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "בוחר הקבצים של המערכת אינו זמין במצב משחק. יש לעבור למצב שולחן עבודה כדי לבחור קבצים."
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2002,5 +2002,6 @@
   "Progress Bar": "प्रगति पट्टी",
   "Current Time": "वर्तमान समय",
   "Battery Status": "बैटरी स्थिति",
-  "Battery Percentage": "बैटरी प्रतिशत"
+  "Battery Percentage": "बैटरी प्रतिशत",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "गेमिंग मोड में सिस्टम फ़ाइल चयनकर्ता उपलब्ध नहीं है। फ़ाइलें चुनने के लिए कृपया डेस्कटॉप मोड में जाएँ।"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2002,5 +2002,6 @@
   "Progress Bar": "Folyamatjelző",
   "Current Time": "Aktuális idő",
   "Battery Status": "Akkumulátor állapota",
-  "Battery Percentage": "Akkumulátor százalék"
+  "Battery Percentage": "Akkumulátor százalék",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "A rendszer fájlválasztója nem érhető el játék módban. A fájlok kiválasztásához váltson asztali módba."
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1956,5 +1956,6 @@
   "Progress Bar": "Bilah Progres",
   "Current Time": "Waktu Sekarang",
   "Battery Status": "Status Baterai",
-  "Battery Percentage": "Persentase Baterai"
+  "Battery Percentage": "Persentase Baterai",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Pemilih berkas sistem tidak tersedia dalam Mode Gaming. Silakan beralih ke Mode Desktop untuk memilih berkas."
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2048,5 +2048,6 @@
   "Progress Bar": "Barra di avanzamento",
   "Current Time": "Ora attuale",
   "Battery Status": "Stato della batteria",
-  "Battery Percentage": "Percentuale batteria"
+  "Battery Percentage": "Percentuale batteria",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Il selettore file di sistema non è disponibile in modalità gaming. Passa alla modalità desktop per selezionare i file."
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1956,5 +1956,6 @@
   "Progress Bar": "進捗バー",
   "Current Time": "現在時刻",
   "Battery Status": "バッテリー状態",
-  "Battery Percentage": "バッテリー残量（％）"
+  "Battery Percentage": "バッテリー残量（％）",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "ゲーミングモードではシステムのファイル選択ダイアログを利用できません。ファイルを選択するにはデスクトップモードに切り替えてください。"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1956,5 +1956,6 @@
   "Progress Bar": "진행률 표시줄",
   "Current Time": "현재 시간",
   "Battery Status": "배터리 상태",
-  "Battery Percentage": "배터리 백분율"
+  "Battery Percentage": "배터리 백분율",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "게이밍 모드에서는 시스템 파일 선택기를 사용할 수 없습니다. 파일을 선택하려면 데스크톱 모드로 전환하세요."
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1956,5 +1956,6 @@
   "Progress Bar": "Bar Kemajuan",
   "Current Time": "Waktu Sekarang",
   "Battery Status": "Status Bateri",
-  "Battery Percentage": "Peratusan Bateri"
+  "Battery Percentage": "Peratusan Bateri",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Pemilih fail sistem tidak tersedia dalam Mod Permainan. Sila tukar ke Mod Desktop untuk memilih fail."
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2002,5 +2002,6 @@
   "Progress Bar": "Voortgangsbalk",
   "Current Time": "Huidige tijd",
   "Battery Status": "Batterijstatus",
-  "Battery Percentage": "Batterijpercentage"
+  "Battery Percentage": "Batterijpercentage",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "De systeembestandskiezer is niet beschikbaar in de gamingmodus. Schakel over naar de desktopmodus om bestanden te selecteren."
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2094,5 +2094,6 @@
   "Progress Bar": "Pasek postępu",
   "Current Time": "Aktualny czas",
   "Battery Status": "Stan baterii",
-  "Battery Percentage": "Procent baterii"
+  "Battery Percentage": "Procent baterii",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Systemowy selektor plików jest niedostępny w trybie gier. Aby wybrać pliki, przełącz się na tryb pulpitu."
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2048,5 +2048,6 @@
   "Progress Bar": "Barra de progresso",
   "Current Time": "Hora atual",
   "Battery Status": "Status da bateria",
-  "Battery Percentage": "Porcentagem da bateria"
+  "Battery Percentage": "Porcentagem da bateria",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "O seletor de arquivos do sistema não está disponível no Modo Jogo. Mude para o Modo Desktop para selecionar arquivos."
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2048,5 +2048,6 @@
   "Progress Bar": "Barra de progresso",
   "Current Time": "Hora atual",
   "Battery Status": "Estado da bateria",
-  "Battery Percentage": "Porcentagem da bateria"
+  "Battery Percentage": "Porcentagem da bateria",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "O seletor de ficheiros do sistema não está disponível no Modo de Jogo. Mude para o Modo de Ambiente de Trabalho para selecionar ficheiros."
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2048,5 +2048,6 @@
   "Progress Bar": "Bară de progres",
   "Current Time": "Ora curentă",
   "Battery Status": "Starea bateriei",
-  "Battery Percentage": "Procentul bateriei"
+  "Battery Percentage": "Procentul bateriei",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Selectorul de fișiere al sistemului nu este disponibil în modul de joc. Treceți la modul desktop pentru a selecta fișiere."
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2094,5 +2094,6 @@
   "Progress Bar": "Полоса прогресса",
   "Current Time": "Текущее время",
   "Battery Status": "Состояние батареи",
-  "Battery Percentage": "Процент заряда батареи"
+  "Battery Percentage": "Процент заряда батареи",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Системный диалог выбора файлов недоступен в игровом режиме. Чтобы выбрать файлы, переключитесь в режим рабочего стола."
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2002,5 +2002,6 @@
   "Progress Bar": "ප්‍රගති තීරුව",
   "Current Time": "වත්මන් වේලාව",
   "Battery Status": "බැටරි තත්ත්වය",
-  "Battery Percentage": "බැටරි ප්‍රතිශතය"
+  "Battery Percentage": "බැටරි ප්‍රතිශතය",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "ක්‍රීඩා ප්‍රකාරයේදී පද්ධති ගොනු තෝරකය නොමැත. ගොනු තේරීමට කරුණාකර ඩෙස්ක්ටොප් ප්‍රකාරයට මාරු වන්න."
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2094,5 +2094,6 @@
   "Progress Bar": "Vrstica napredka",
   "Current Time": "Trenutni čas",
   "Battery Status": "Stanje baterije",
-  "Battery Percentage": "Odstotek baterije"
+  "Battery Percentage": "Odstotek baterije",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Sistemski izbirnik datotek v igralnem načinu ni na voljo. Za izbiro datotek preklopite v namizni način."
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2002,5 +2002,6 @@
   "Progress Bar": "Förloppsindikator",
   "Current Time": "Aktuell tid",
   "Battery Status": "Batteristatus",
-  "Battery Percentage": "Batteriprocent"
+  "Battery Percentage": "Batteriprocent",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Systemets filväljare är inte tillgänglig i spelläge. Byt till skrivbordsläge för att välja filer."
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2002,5 +2002,6 @@
   "Progress Bar": "முன்னேற்றப் பட்டி",
   "Current Time": "தற்போதைய நேரம்",
   "Battery Status": "பேட்டரி நிலை",
-  "Battery Percentage": "பேட்டரி சதவீதம்"
+  "Battery Percentage": "பேட்டரி சதவீதம்",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "கேமிங் பயன்முறையில் கணினி கோப்புத் தேர்வி கிடைக்காது. கோப்புகளைத் தேர்ந்தெடுக்க டெஸ்க்டாப் பயன்முறைக்கு மாறவும்."
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1956,5 +1956,6 @@
   "Progress Bar": "แถบความคืบหน้า",
   "Current Time": "เวลาปัจจุบัน",
   "Battery Status": "สถานะแบตเตอรี่",
-  "Battery Percentage": "เปอร์เซ็นต์แบตเตอรี่"
+  "Battery Percentage": "เปอร์เซ็นต์แบตเตอรี่",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "ตัวเลือกไฟล์ของระบบไม่พร้อมใช้งานในโหมดเกม โปรดสลับไปยังโหมดเดสก์ท็อปเพื่อเลือกไฟล์"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2002,5 +2002,6 @@
   "Progress Bar": "İlerleme Çubuğu",
   "Current Time": "Şu Anki Saat",
   "Battery Status": "Pil Durumu",
-  "Battery Percentage": "Pil Yüzdesi"
+  "Battery Percentage": "Pil Yüzdesi",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Sistem dosya seçici Oyun Modunda kullanılamıyor. Dosyaları seçmek için lütfen Masaüstü Moduna geçin."
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2094,5 +2094,6 @@
   "Progress Bar": "Смуга прогресу",
   "Current Time": "Поточний час",
   "Battery Status": "Стан батареї",
-  "Battery Percentage": "Відсоток заряду батареї"
+  "Battery Percentage": "Відсоток заряду батареї",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Системний діалог вибору файлів недоступний в ігровому режимі. Щоб вибрати файли, перейдіть у режим робочого столу."
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2002,5 +2002,6 @@
   "Progress Bar": "Jarayon paneli",
   "Current Time": "Joriy vaqt",
   "Battery Status": "Batareya holati",
-  "Battery Percentage": "Batareya foizi"
+  "Battery Percentage": "Batareya foizi",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Tizim fayl tanlagichi o'yin rejimida mavjud emas. Fayllarni tanlash uchun ish stoli rejimiga o'ting."
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1956,5 +1956,6 @@
   "Progress Bar": "Thanh tiến độ",
   "Current Time": "Thời gian hiện tại",
   "Battery Status": "Trạng thái pin",
-  "Battery Percentage": "Phần trăm pin"
+  "Battery Percentage": "Phần trăm pin",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "Trình chọn tệp của hệ thống không khả dụng trong Chế độ chơi game. Vui lòng chuyển sang Chế độ máy tính để chọn tệp."
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1956,5 +1956,6 @@
   "Progress Bar": "进度条",
   "Current Time": "当前时间",
   "Battery Status": "电量",
-  "Battery Percentage": "电量百分比"
+  "Battery Percentage": "电量百分比",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "游戏模式下无法使用系统文件选择器。请切换到桌面模式以选择文件。"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1956,5 +1956,6 @@
   "Progress Bar": "進度列",
   "Current Time": "目前時間",
   "Battery Status": "電池狀態",
-  "Battery Percentage": "電池百分比"
+  "Battery Percentage": "電池百分比",
+  "The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.": "遊戲模式下無法使用系統檔案選擇器。請切換到桌面模式以選取檔案。"
 }

--- a/apps/readest-app/src/__tests__/hooks/useFileSelector.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useFileSelector.test.ts
@@ -11,18 +11,30 @@ vi.mock('@/services/environment', () => ({
   isTauriAppPlatform: () => true,
 }));
 
+const envMock: Record<string, string> = {};
+const invokeMock = vi.fn(async (cmd: string, args?: { name?: string }) => {
+  if (cmd === 'get_environment_variable') return envMock[args?.name ?? ''] ?? '';
+  return '';
+});
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (cmd: string, args?: { name?: string }) => invokeMock(cmd, args),
+}));
+
 import { useFileSelector } from '@/hooks/useFileSelector';
+import { eventDispatcher } from '@/utils/event';
 
 const _ = (key: string) => key;
 
 const makeAppService = (
-  platform: 'ios' | 'android',
+  platform: 'ios' | 'android' | 'linux',
   picked: string[],
 ): { appService: AppService; selectFiles: ReturnType<typeof vi.fn> } => {
   const selectFiles = vi.fn(async () => picked);
   const appService = {
     isIOSApp: platform === 'ios',
     isAndroidApp: platform === 'android',
+    isLinuxApp: platform === 'linux',
     selectFiles,
   } as unknown as AppService;
   return { appService, selectFiles };
@@ -30,6 +42,8 @@ const makeAppService = (
 
 beforeEach(() => {
   basenameMock.mockClear();
+  invokeMock.mockClear();
+  for (const key of Object.keys(envMock)) delete envMock[key];
 });
 
 describe('useFileSelector cover selection', () => {
@@ -70,5 +84,50 @@ describe('useFileSelector cover selection', () => {
 
     expect(selectFiles).toHaveBeenCalledWith(expect.any(String), ['png', 'jpg', 'jpeg', 'gif']);
     expect(result.files).toHaveLength(1);
+  });
+});
+
+describe('useFileSelector under gamescope (SteamOS Gaming Mode, #3049)', () => {
+  test('Linux in a gamescope session: explains that the file dialog cannot appear', async () => {
+    envMock['GAMESCOPE_WAYLAND_DISPLAY'] = 'gamescope-0';
+    const dispatchSpy = vi.spyOn(eventDispatcher, 'dispatch').mockResolvedValue();
+    const { appService } = makeAppService('linux', []);
+    const { selectFiles: select } = useFileSelector(appService, _);
+
+    const result = await select({ type: 'books', multiple: true });
+
+    // The gamescope session runs no XDG portal backend, so the FileChooser
+    // dialog never opens and the empty result looks exactly like a user
+    // cancel. Without a toast the import button is a silent no-op.
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'toast',
+      expect.objectContaining({
+        type: 'info',
+        message: expect.stringContaining('Gaming Mode'),
+      }),
+    );
+    expect(result.files).toHaveLength(0);
+    dispatchSpy.mockRestore();
+  });
+
+  test('Linux on a regular desktop: no toast, dialog result is untouched', async () => {
+    const dispatchSpy = vi.spyOn(eventDispatcher, 'dispatch').mockResolvedValue();
+    const { appService } = makeAppService('linux', ['/home/user/books/book.epub']);
+    const { selectFiles: select } = useFileSelector(appService, _);
+
+    const result = await select({ type: 'books', multiple: true });
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(result.files).toHaveLength(1);
+    dispatchSpy.mockRestore();
+  });
+
+  test('non-Linux platforms never probe the environment', async () => {
+    const { appService } = makeAppService('android', ['content://media/external/file/42']);
+    const { selectFiles: select } = useFileSelector(appService, _);
+
+    await select({ type: 'books', multiple: true });
+
+    expect(invokeMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/readest-app/src/hooks/useFileSelector.ts
+++ b/apps/readest-app/src/hooks/useFileSelector.ts
@@ -1,8 +1,10 @@
 import { AppService } from '@/types/system';
 import { isTauriAppPlatform } from '@/services/environment';
+import { invoke } from '@tauri-apps/api/core';
 import { basename } from '@tauri-apps/api/path';
 import { isContentURI, isFileURI, stubTranslation as _ } from '@/utils/misc';
 import { getFilename } from '@/utils/path';
+import { eventDispatcher } from '@/utils/event';
 import { BOOK_ACCEPT_FORMATS, SUPPORTED_BOOK_EXTS } from '@/services/constants';
 
 export interface FileSelectorOptions {
@@ -70,11 +72,37 @@ const resolveTauriFileName = async (path: string, appService: AppService): Promi
   return getFilename(path);
 };
 
+const isGamescopeSession = async (): Promise<boolean> => {
+  try {
+    const [gamescopeDisplay, currentDesktop] = await Promise.all([
+      invoke<string>('get_environment_variable', { name: 'GAMESCOPE_WAYLAND_DISPLAY' }),
+      invoke<string>('get_environment_variable', { name: 'XDG_CURRENT_DESKTOP' }),
+    ]);
+    return !!gamescopeDisplay || currentDesktop.toLowerCase().includes('gamescope');
+  } catch {
+    return false;
+  }
+};
+
 const selectFileTauri = async (
   options: FileSelectorOptions,
   appService: AppService,
   _: (key: string) => string,
 ): Promise<SelectedFile[]> => {
+  // A gamescope session (SteamOS Gaming Mode) runs no XDG portal backend, so
+  // the FileChooser dialog can never appear, and the sandboxed Flatpak relies
+  // on that dialog to grant file access — there is no in-app fallback. The
+  // failed dialog resolves to null, indistinguishable from a user cancel, so
+  // explain up front instead of silently no-oping (#3049).
+  if (appService.isLinuxApp && (await isGamescopeSession())) {
+    eventDispatcher.dispatch('toast', {
+      type: 'info',
+      message: _(
+        'The system file picker is not available in Gaming Mode. Please switch to Desktop Mode to select files.',
+      ),
+      timeout: 5000,
+    });
+  }
   // Android's SAF picker filters by MIME type. Niche/custom extensions
   // (e.g. ".mrexpt" from Moon+ Reader) have no registered MIME and would
   // appear greyed-out, so for those cases we ask the native side for an


### PR DESCRIPTION
## Summary

In SteamOS Gaming Mode the "Import Books" action silently did nothing (#3049). The gamescope session runs no XDG desktop portal backend, so the `org.freedesktop.portal.FileChooser` dialog that the sandboxed Flatpak relies on for granting file access can never appear there, and the failed dialog resolves to `null`, which is indistinguishable from a user cancel.

An in-app file browser is not an option: Readest's security model deliberately grants file access only through the system chooser, so without the portal the sandbox cannot see the files at all.

## Changes

- `useFileSelector.selectFileTauri` now detects a gamescope session on Linux (via the existing `get_environment_variable` command: `GAMESCOPE_WAYLAND_DISPLAY` set, or `XDG_CURRENT_DESKTOP` containing `gamescope`) and shows an info toast telling the user the system file picker is unavailable in Gaming Mode and to switch to Desktop Mode. The toast is dispatched before the dialog attempt so it appears whether the portal call errors or hangs.
- Applies to every picker routed through the hook (books, fonts, dictionaries, covers). No Rust changes.
- New i18n key translated across all 33 locales.

## Testing

- New unit tests: gamescope session shows the toast, a regular Linux desktop does not, non-Linux platforms never probe the environment. The first test failed before the fix.
- `pnpm test` (8373 passed), `pnpm lint`, `pnpm format:check` all clean.

Fixes #3049

🤖 Generated with [Claude Code](https://claude.com/claude-code)
