### PR TITLE
fix(opds): apply the metadata advertised by the feed entry

### DIFF
--- a/apps/readest-app/src/__tests__/services/opds-feed-checker.test.ts
+++ b/apps/readest-app/src/__tests__/services/opds-feed-checker.test.ts
@@ -661,6 +661,35 @@ describe('OPDS feed checker', () => {
       expect(items[0]!.coverHref).toBe('/cwa/opds/cover/572');
     });
 
+    it('carries the entry metadata so the import can apply it (issue #5270)', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <id>urn:test:feed</id>
+  <title>Test Feed</title>
+  <entry>
+    <id>urn:meta</id>
+    <title>Feed Title</title>
+    <author><name>Jane Doe</name></author>
+    <dc:language>fr</dc:language>
+    <category term="FIC009000" label="Fantasy"/>
+    <summary type="text">A summary.</summary>
+    <link href="/dl/a.epub" type="application/epub+zip"
+          rel="http://opds-spec.org/acquisition"/>
+  </entry>
+</feed>`;
+      const doc = parseXML(xml);
+      const feed = getFeed(doc) as OPDSFeed;
+      const items = collectNewEntries(feed, new Set(), 'https://example.com');
+      expect(items[0]!.metadata).toMatchObject({
+        title: 'Feed Title',
+        author: 'Jane Doe',
+        language: 'fr',
+        subject: ['Fantasy'],
+        description: 'A summary.',
+      });
+    });
+
     it('leaves coverHref unset when the entry advertises no artwork', () => {
       const xml = makeAcquisitionFeed([{ id: 'urn:a', title: 'Issue 1', href: '/dl/a' }]);
       const doc = parseXML(xml);

--- a/apps/readest-app/src/__tests__/services/opds-metadata.test.ts
+++ b/apps/readest-app/src/__tests__/services/opds-metadata.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import type { Book } from '@/types/book';
+import type { OPDSPublication } from '@/types/opds';
+import { SYMBOL } from '@/types/opds';
+import { getOPDSBookMetadata, applyOPDSMetadata } from '@/services/opds/metadata';
+
+type PublicationMetadata = OPDSPublication['metadata'];
+
+describe('getOPDSBookMetadata', () => {
+  it('maps the fields the feed provides to BookMetadata', () => {
+    const metadata: PublicationMetadata = {
+      title: 'Feed Title',
+      subtitle: 'Feed Subtitle',
+      author: [
+        { name: 'Jane Doe', links: [] },
+        { name: 'John Smith', links: [] },
+      ],
+      publisher: 'Feed Press',
+      published: '2020-01-02',
+      language: 'fr',
+      identifier: 'urn:isbn:9780316769488',
+      subject: [{ name: 'Fantasy', code: 'FIC009000' }, { name: 'Adventure' }],
+      [SYMBOL.CONTENT]: { value: '<p>A <b>fine</b> book.</p>', type: 'html' },
+    };
+    const result = getOPDSBookMetadata({ metadata });
+    expect(result.title).toBe('Feed Title');
+    expect(result.subtitle).toBe('Feed Subtitle');
+    expect(result.author).toEqual(['Jane Doe', 'John Smith']);
+    expect(result.publisher).toBe('Feed Press');
+    expect(result.published).toBe('2020-01-02');
+    expect(result.language).toBe('fr');
+    expect(result.identifier).toBe('urn:isbn:9780316769488');
+    expect(result.subject).toEqual(['Fantasy', 'Adventure']);
+    expect(result.description).toContain('<b>fine</b>');
+  });
+
+  it('omits fields the feed does not provide', () => {
+    expect(getOPDSBookMetadata({})).toEqual({});
+    expect(getOPDSBookMetadata({ metadata: {} })).toEqual({});
+    // Blank strings and empty lists are "not provided", not overrides.
+    expect(getOPDSBookMetadata({ metadata: { title: '   ', author: [], subject: [] } })).toEqual(
+      {},
+    );
+  });
+
+  it('keeps a single author as a plain string', () => {
+    const result = getOPDSBookMetadata({
+      metadata: { author: [{ name: 'Solo Author', links: [] }] },
+    });
+    expect(result.author).toBe('Solo Author');
+  });
+
+  it('flattens person-shaped and string-shaped names (OPDS 2.0 JSON)', () => {
+    // parsePublicationDocument casts raw JSON, where authors/publishers may be
+    // plain strings rather than person objects.
+    const metadata = {
+      author: ['Plain Name'],
+      publisher: [
+        { name: 'Pub A', links: [] },
+        { name: 'Pub B', links: [] },
+      ],
+    } as unknown as PublicationMetadata;
+    const result = getOPDSBookMetadata({ metadata });
+    expect(result.author).toBe('Plain Name');
+    expect(result.publisher).toBe('Pub A, Pub B');
+  });
+
+  it('prefers typed content over the plain description and sanitizes it', () => {
+    const metadata: PublicationMetadata = {
+      description: 'plain fallback',
+      [SYMBOL.CONTENT]: { value: '<p>rich</p><script>evil()</script>', type: 'html' },
+    };
+    const result = getOPDSBookMetadata({ metadata });
+    expect(result.description).toContain('<p>rich</p>');
+    expect(result.description).not.toContain('script');
+    expect(result.description).not.toContain('plain fallback');
+
+    const plainOnly = getOPDSBookMetadata({ metadata: { description: 'Just text' } });
+    expect(plainOnly.description).toBe('Just text');
+
+    const contentField = getOPDSBookMetadata({
+      metadata: { content: { value: '<p>from content</p>', type: 'html' } },
+    });
+    expect(contentField.description).toContain('<p>from content</p>');
+  });
+
+  it('passes a language list through', () => {
+    const result = getOPDSBookMetadata({ metadata: { language: ['de', 'en'] } });
+    expect(result.language).toEqual(['de', 'en']);
+  });
+
+  it('falls back to the subject code when there is no label and accepts plain strings', () => {
+    const withCode = getOPDSBookMetadata({ metadata: { subject: [{ code: 'sci-fi' }] } });
+    expect(withCode.subject).toEqual(['sci-fi']);
+    const plain = getOPDSBookMetadata({
+      metadata: { subject: ['History'] as unknown as PublicationMetadata['subject'] },
+    });
+    expect(plain.subject).toEqual(['History']);
+  });
+});
+
+describe('applyOPDSMetadata', () => {
+  const createBook = (): Book =>
+    ({
+      hash: 'h1',
+      format: 'EPUB',
+      title: 'File Title',
+      sourceTitle: 'File Title',
+      author: 'File Author',
+      primaryLanguage: 'en',
+      metaHash: 'meta-1',
+      metadata: {
+        title: 'File Title',
+        author: 'File Author',
+        language: 'en',
+        publisher: 'File Press',
+        description: 'File description',
+        series: 'File Series',
+        seriesIndex: 2,
+      },
+      createdAt: 0,
+      updatedAt: 0,
+    }) as Book;
+
+  it('applies feed fields over the file metadata and keeps file-only fields', () => {
+    const book = createBook();
+    applyOPDSMetadata(book, {
+      title: 'Feed Title',
+      author: ['Jane Doe', 'John Smith'],
+      language: 'fr',
+      subject: ['Fantasy'],
+    });
+    expect(book.metadata?.title).toBe('Feed Title');
+    expect(book.metadata?.subject).toEqual(['Fantasy']);
+    // Fields the feed omitted keep the file's values.
+    expect(book.metadata?.publisher).toBe('File Press');
+    expect(book.metadata?.series).toBe('File Series');
+    expect(book.metadata?.seriesIndex).toBe(2);
+    // Denormalized fields are re-derived from the merged metadata.
+    expect(book.title).toBe('Feed Title');
+    expect(book.primaryLanguage).toBe('fr');
+    expect(book.author).toContain('Jane Doe');
+    expect(book.author).toContain('John Smith');
+  });
+
+  it('keeps derived fields the feed says nothing about', () => {
+    const book = createBook();
+    // Simulates "Download Again" on a book whose title the user edited: the
+    // edited title lives on book.title, not book.metadata.title.
+    book.title = 'User Edited Title';
+    applyOPDSMetadata(book, { description: '<p>New description</p>' });
+    expect(book.metadata?.description).toBe('<p>New description</p>');
+    expect(book.title).toBe('User Edited Title');
+    expect(book.author).toBe('File Author');
+    expect(book.primaryLanguage).toBe('en');
+  });
+
+  it('bumps the metadata sync clock so the change propagates like an edit', () => {
+    const book = createBook();
+    const before = Date.now();
+    applyOPDSMetadata(book, { title: 'Feed Title' });
+    expect(book.metadataUpdatedAt).toBeGreaterThanOrEqual(before);
+    expect(book.updatedAt).toBe(book.metadataUpdatedAt);
+  });
+
+  it('is a no-op when the feed provided nothing', () => {
+    const book = createBook();
+    const snapshot = structuredClone(book);
+    applyOPDSMetadata(book, {});
+    expect(book).toEqual(snapshot);
+  });
+
+  it('never touches sourceTitle or metaHash', () => {
+    const book = createBook();
+    applyOPDSMetadata(book, { title: 'Feed Title' });
+    expect(book.sourceTitle).toBe('File Title');
+    expect(book.metaHash).toBe('meta-1');
+  });
+
+  it('derives the isbn from a urn:isbn identifier', () => {
+    const book = createBook();
+    applyOPDSMetadata(book, { identifier: 'urn:isbn:9780316769488' });
+    expect(book.metadata?.identifier).toBe('urn:isbn:9780316769488');
+    expect(book.metadata?.isbn).toBe('9780316769488');
+  });
+});

--- a/apps/readest-app/src/app/opds/page.tsx
+++ b/apps/readest-app/src/app/opds/page.tsx
@@ -49,6 +49,7 @@ import { ImportError } from '@/services/errors';
 import { READEST_OPDS_USER_AGENT } from '@/services/constants';
 import { findBookByOPDSSources, upsertOPDSSourceMapping } from '@/services/opds/sourceMap';
 import { applyOPDSCover, getOPDSCoverHref } from '@/services/opds/cover';
+import { applyOPDSMetadata, getOPDSBookMetadata } from '@/services/opds/metadata';
 import { buildPseStreamFileName } from '@/services/opds/pseStream';
 import type { Book } from '@/types/book';
 import { FeedView } from './components/FeedView';
@@ -620,6 +621,13 @@ export default function BrowserPage() {
           const { library, setLibrary } = useLibraryStore.getState();
           try {
             const book = await appService.importBook(dstFilePath, library);
+            // The catalog's curated metadata wins over the file's embedded
+            // record (#5270) — applied before the cloud upload is queued so
+            // peers get the same fields. `publication` already carries the
+            // detail-document merge (#4749), so this is the fullest record.
+            if (book && publication) {
+              applyOPDSMetadata(book, getOPDSBookMetadata(publication));
+            }
             // The catalog's own artwork wins over the one embedded in the file
             // (#5270) — applied before the cloud upload is queued so peers get
             // the same cover. Best effort: never fail the import over it.
@@ -666,7 +674,15 @@ export default function BrowserPage() {
         throw e;
       }
     },
-    [user, state.baseURL, appService, libraryLoaded, catalogSourceId, publicationCoverHref],
+    [
+      user,
+      state.baseURL,
+      appService,
+      libraryLoaded,
+      catalogSourceId,
+      publication,
+      publicationCoverHref,
+    ],
   );
 
   const handleStream = useCallback(

--- a/apps/readest-app/src/services/opds/autoDownload.ts
+++ b/apps/readest-app/src/services/opds/autoDownload.ts
@@ -8,6 +8,7 @@ import { resolveURL, parseMediaType, getFileExtFromPath } from '@/app/opds/utils
 import { normalizeOPDSCustomHeaders } from '@/app/opds/utils/customHeaders';
 import { READEST_OPDS_USER_AGENT } from '@/services/constants';
 import { applyOPDSCover } from './cover';
+import { applyOPDSMetadata } from './metadata';
 import { checkFeedForNewItems } from './feedChecker';
 import {
   loadSubscriptionState,
@@ -94,6 +95,11 @@ async function downloadAndImport(
 
   const book = await appService.importBook(dstFilePath, books);
   if (!book) throw new Error(`importBook returned null for ${item.title}`);
+  // The catalog's curated metadata wins over the file's embedded record
+  // (#5270). Retry items rebuilt from FailedEntry carry none and skip.
+  if (item.metadata) {
+    applyOPDSMetadata(book, item.metadata);
+  }
   // The catalog's own artwork wins over the one embedded in the file (#5270).
   // Best effort: a failure here must not fail an otherwise good import.
   if (item.coverHref) {

--- a/apps/readest-app/src/services/opds/feedChecker.ts
+++ b/apps/readest-app/src/services/opds/feedChecker.ts
@@ -21,6 +21,7 @@ import {
 } from '@/app/opds/utils/opdsUtils';
 import { normalizeOPDSCustomHeaders } from '@/app/opds/utils/customHeaders';
 import { getOPDSCoverHref } from './cover';
+import { getOPDSBookMetadata } from './metadata';
 import type { OPDSSubscriptionState, PendingItem } from './types';
 import { MAX_CRAWL_DEPTH, MAX_FEEDS_PER_CRAWL, MAX_PAGES_PER_FEED } from './types';
 
@@ -197,11 +198,13 @@ export function collectNewEntries(
     if (!acqLink) continue;
 
     seenInBatch.add(entryId);
+    const metadata = getOPDSBookMetadata(pub);
     items.push({
       entryId,
       title: pub.metadata.title || acqLink.title || 'Untitled',
       acquisitionHref: acqLink.href,
       coverHref: getOPDSCoverHref(pub),
+      metadata: Object.keys(metadata).length ? metadata : undefined,
       mimeType: acqLink.type ?? 'application/octet-stream',
       updated: pub.metadata.updated,
       baseURL,

--- a/apps/readest-app/src/services/opds/metadata.ts
+++ b/apps/readest-app/src/services/opds/metadata.ts
@@ -1,0 +1,117 @@
+import type { Book } from '@/types/book';
+import type { BookMetadata } from '@/libs/document';
+import type { OPDSPublication, OPDSSubject } from '@/types/opds';
+import { SYMBOL } from '@/types/opds';
+import { getOPDSDescriptionHtml } from '@/app/opds/utils/opdsContent';
+import { formatAuthors, formatTitle, getPrimaryLanguage } from '@/utils/book';
+import { normalizeMetadataIsbn } from '@/utils/isbn';
+
+/**
+ * BookMetadata subset an OPDS entry can provide. Mirrors MarkdownMetadata's
+ * widening of `author`: a feed with several <author> entries stays a list of
+ * names (formatAuthors handles both shapes).
+ */
+export type OPDSBookMetadata = Omit<Partial<BookMetadata>, 'author'> & {
+  author?: string | string[];
+};
+
+// Atom parses persons to {name, links}; OPDS 2.0 JSON is cast unparsed, so
+// authors/publishers there may be plain strings or a single object.
+type PersonLike = string | { name?: string } | undefined;
+
+const personNames = (value: PersonLike | PersonLike[] | undefined): string[] => {
+  const values = Array.isArray(value) ? value : [value];
+  return values.map((v) => (typeof v === 'string' ? v : (v?.name ?? '')).trim()).filter(Boolean);
+};
+
+const subjectNames = (value: string | OPDSSubject | Array<string | OPDSSubject> | undefined) => {
+  if (!value) return [];
+  const values = Array.isArray(value) ? value : [value];
+  return values
+    .map((s) => (typeof s === 'string' ? s : s?.name || s?.code || '').trim())
+    .filter(Boolean);
+};
+
+/**
+ * The BookMetadata fields an OPDS entry advertises for itself. Catalogs that
+ * let users curate metadata (Calibre-Web Automated and friends) publish the
+ * curated record in the feed while the EPUB/PDF file still carries the
+ * original, so these are the values the library should show (issue #5270).
+ * Only fields the feed actually provides are emitted — blanks and empty lists
+ * are "not provided", never overrides.
+ */
+export const getOPDSBookMetadata = (publication: {
+  metadata?: OPDSPublication['metadata'];
+}): OPDSBookMetadata => {
+  const meta = publication.metadata;
+  if (!meta) return {};
+  const result: OPDSBookMetadata = {};
+
+  const title = meta.title?.trim();
+  if (title) result.title = title;
+  const subtitle = meta.subtitle?.trim();
+  if (subtitle) result.subtitle = subtitle;
+
+  const authors = personNames(meta.author);
+  if (authors.length) result.author = authors.length === 1 ? authors[0] : authors;
+
+  const publishers = personNames(meta.publisher);
+  if (publishers.length) result.publisher = publishers.join(', ');
+
+  const published = meta.published?.trim();
+  if (published) result.published = published;
+
+  const language = Array.isArray(meta.language)
+    ? meta.language.map((lang) => lang.trim()).filter(Boolean)
+    : meta.language?.trim();
+  if (language?.length) result.language = language;
+
+  const identifier = meta.identifier?.trim();
+  if (identifier) result.identifier = identifier;
+
+  const subjects = subjectNames(meta.subject);
+  if (subjects.length) result.subject = subjects;
+
+  // Same precedence as PublicationView: the typed Atom <content>/<summary>
+  // first, then the OPDS 2.0 plain description; sanitized because BookDetailView
+  // renders the description as HTML.
+  const content = meta[SYMBOL.CONTENT] || meta.content;
+  const description = getOPDSDescriptionHtml(content ?? meta.description);
+  if (description) result.description = description;
+
+  return result;
+};
+
+/**
+ * Merge the metadata an OPDS entry advertises into an imported book: per
+ * field, the feed wins and the file fills the rest (series, custom columns,
+ * an ISBN the feed does not repeat). Denormalized fields (title, author,
+ * primaryLanguage) are re-derived only when the feed provided their source,
+ * so "Download Again" cannot reset a user-edited title with a feed that says
+ * nothing about it. Bumps the metadata sync clock like a manual edit —
+ * metadata travels in the book row itself, so unlike coverUpdatedAt there is
+ * no upload-first hazard. Never touches sourceTitle (locates the cloud file)
+ * or metaHash (dedupe stays file-derived).
+ *
+ * Mutates in place like applyOPDSCover: both call sites run before the
+ * library is saved, and the library page is not mounted during OPDS
+ * downloads.
+ */
+export const applyOPDSMetadata = (book: Book, opdsMetadata: OPDSBookMetadata): void => {
+  if (!Object.keys(opdsMetadata).length) return;
+  const metadata = { ...book.metadata, ...opdsMetadata } as BookMetadata;
+  normalizeMetadataIsbn(metadata);
+  book.metadata = metadata;
+  if (opdsMetadata.language) {
+    book.primaryLanguage = getPrimaryLanguage(metadata.language);
+  }
+  if (opdsMetadata.title) {
+    book.title = formatTitle(metadata.title);
+  }
+  if (opdsMetadata.author) {
+    book.author = formatAuthors(metadata.author, book.primaryLanguage);
+  }
+  const now = Date.now();
+  book.updatedAt = now;
+  book.metadataUpdatedAt = now;
+};

--- a/apps/readest-app/src/services/opds/types.ts
+++ b/apps/readest-app/src/services/opds/types.ts
@@ -1,4 +1,5 @@
 import type { Book } from '@/types/book';
+import type { OPDSBookMetadata } from './metadata';
 
 // --- Constants ---
 
@@ -25,6 +26,8 @@ export interface PendingItem {
   acquisitionHref: string;
   /** Cover advertised by the entry, preferred over the one inside the file (#5270). */
   coverHref?: string;
+  /** Metadata advertised by the entry, applied over the file's own (#5270). */
+  metadata?: OPDSBookMetadata;
   mimeType: string;
   updated?: string;
   baseURL: string;

--- a/apps/readest-app/src/types/opds.ts
+++ b/apps/readest-app/src/types/opds.ts
@@ -115,12 +115,12 @@ export interface OPDSBaseLink {
   templated?: boolean;
 }
 
-interface OPDSPerson {
+export interface OPDSPerson {
   name?: string;
   links: Array<{ href: string; type?: string }>;
 }
 
-interface OPDSSubject {
+export interface OPDSSubject {
   name?: string;
   code?: string;
   scheme?: string;


### PR DESCRIPTION
## Summary

The metadata half of #5270 (the cover half shipped in #5471): an OPDS entry's curated record (title, author, publisher, language, subjects, identifier, description) was discarded at import, so the library only ever showed what the EPUB/PDF file embedded. Catalogs like Calibre-Web Automated publish user-curated metadata in the feed while the file keeps the original, so the feed is the record the library should show.

## Changes

- New `src/services/opds/metadata.ts`:
  - `getOPDSBookMetadata(publication)` maps the OPDS record to `BookMetadata`, emitting only fields the feed actually provides. The description takes the typed Atom `<content>`/`<summary>` before the OPDS 2.0 plain description and is sanitized, matching what the publication view renders.
  - `applyOPDSMetadata(book, metadata)` merges per field: the feed wins, the file fills the rest (series, Calibre columns, an ISBN the feed does not repeat). Denormalized fields (`title`, `author`, `primaryLanguage`) are re-derived only when the feed provided their source, so "Download Again" against a feed that says nothing about the title cannot reset a user-edited one. Bumps `updatedAt` and `metadataUpdatedAt` so the change propagates like a manual edit; `sourceTitle` and `metaHash` stay file-derived so cloud file lookup and dedupe are untouched.
- Wired at the same two acquisition sites as the cover fix: the interactive download in `app/opds/page.tsx` (where the publication already carries the detail-document merge from #4749, so it is the fullest record) and the auto-download path via a new `PendingItem.metadata` filled in `collectNewEntries`. Retry items rebuilt from `FailedEntry` carry none and skip, same as `coverHref`.

Known behavior change, consistent with the cover half: "Download Again" on a book you already own replaces hand-edited metadata with the catalog's record for the fields the feed provides.

## Testing

- 14 new unit tests (mapping table, merge semantics, sync clock, ISBN normalization, `sourceTitle`/`metaHash` preservation, `collectNewEntries` carrying the record); full `pnpm test` suite green (8392 passed), `pnpm lint` and format checks clean.
- Verified end to end against a local Atom feed advertising a title/author/description different from the EPUB's embedded ones: the imported book persists and renders the feed's record in the library, and with the wiring disabled it falls back to the embedded metadata, so the check discriminates.

Closes #5270

🤖 Generated with [Claude Code](https://claude.com/claude-code)