### PR TITLE
fix(reader): stop the header hover strip from covering the page text

### DIFF
--- a/apps/readest-app/e2e/pages/ReaderPage.ts
+++ b/apps/readest-app/e2e/pages/ReaderPage.ts
@@ -64,6 +64,25 @@ export class ReaderPage extends BasePage {
     }
   }
 
+  /** Whether the header bar is currently taking pointer events. */
+  async isHeaderRevealed(): Promise<boolean> {
+    // The bar auto-hides with `opacity-0 pointer-events-none`, which Playwright
+    // still reports as visible (it keeps a bounding box), so read the styles.
+    return this.headerBar.evaluate((bar) => {
+      const style = getComputedStyle(bar);
+      return style.pointerEvents !== 'none' && Number(style.opacity) > 0.1;
+    });
+  }
+
+  /** Hide the header and footer bars by tapping the middle of the page. */
+  async hideChrome(): Promise<void> {
+    if (!(await this.isHeaderRevealed())) return;
+    const box = await this.viewer.boundingBox();
+    if (!box) return;
+    await this.page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    await expect.poll(() => this.isHeaderRevealed()).toBe(false);
+  }
+
   // --- pagination & progress ---
 
   async nextPage(): Promise<void> {
@@ -150,6 +169,95 @@ export class ReaderPage extends BasePage {
     await this.page.locator('[data-setting-id="settings.control.customizeToolbar"]').click();
     await this.page.getByRole('button', { name, exact: true }).click();
     await this.page.keyboard.press('Escape');
+  }
+
+  /**
+   * Turn the in-page header band (the running section title) on or off from
+   * the settings dialog. With it off the book text moves up to the compact top
+   * margin, right under the header bar's hover strip.
+   */
+  async setPageHeaderVisible(visible: boolean): Promise<void> {
+    await this.revealHeader();
+    await this.headerBar.locator('button[aria-label="Font & Layout"]').click();
+    await this.page.locator('[data-tab="Layout"]').click();
+
+    const toggle = this.page
+      .locator('[data-setting-id="settings.layout.showHeader"]')
+      .getByRole('checkbox')
+      .first();
+    await toggle.waitFor({ state: 'visible' });
+    await toggle.setChecked(visible);
+
+    await this.page.keyboard.press('Escape');
+    await this.hideChrome();
+  }
+
+  /**
+   * Geometry of the topmost line of book text on the current page, in
+   * top-document coordinates, plus whatever element the browser hit-tests at
+   * its middle (`'reader'` when the press would reach the book).
+   *
+   * Reading the line out of the section document and asking the top document
+   * who owns that point runs the same hit test the pointer pipeline uses, which
+   * is what an overlay strip breaks.
+   */
+  private async firstLineHitTest(): Promise<{ top: number; owner: string } | null> {
+    return this.page.evaluate(() => {
+      const view = document.querySelector('foliate-view') as HTMLElement & {
+        renderer: { getContents: () => { doc?: Document }[] };
+      };
+      if (!view) return null;
+      const lines: { top: number; left: number; height: number; width: number }[] = [];
+      for (const { doc } of view.renderer.getContents()) {
+        const frame = doc?.defaultView?.frameElement?.getBoundingClientRect();
+        if (!doc || !frame) continue;
+        const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
+        let node: Node | null;
+        while ((node = walker.nextNode())) {
+          if ((node.textContent ?? '').trim().length < 10) continue;
+          const range = doc.createRange();
+          range.selectNodeContents(node);
+          for (const rect of range.getClientRects()) {
+            // Skip slivers (inline markup) and anything off the visible page.
+            if (rect.width < 40 || rect.height < 5) continue;
+            const left = frame.left + rect.left;
+            const top = frame.top + rect.top;
+            if (left < 0 || left > window.innerWidth - 40) continue;
+            if (top < 0 || top + rect.height > window.innerHeight) continue;
+            lines.push({ top, left, height: rect.height, width: rect.width });
+          }
+        }
+      }
+      const line = lines.sort((a, b) => a.top - b.top)[0];
+      if (!line) return null;
+      const el = document.elementFromPoint(
+        line.left + Math.min(line.width, 160) / 2,
+        line.top + line.height / 2,
+      );
+      const viewer = document.querySelector('.foliate-viewer');
+      const owner =
+        el && viewer?.contains(el) ? 'reader' : `${el?.tagName}.${String(el?.className)}`;
+      return { top: line.top, owner };
+    });
+  }
+
+  /**
+   * Page forward until the topmost line of the page starts within `maxTop` px
+   * of the cell top, then hit-test it (see {@link firstLineHitTest}). A chapter
+   * opens on a heading that sits well below the top, so the caller cannot
+   * assume the first page has a line up there.
+   */
+  async firstLineHitTestNearTop(
+    maxTop: number,
+    maxPages = 8,
+  ): Promise<{ top: number; owner: string } | null> {
+    let hit = await this.firstLineHitTest();
+    for (let i = 0; i < maxPages && (!hit || hit.top >= maxTop); i += 1) {
+      await this.nextPage();
+      await this.page.waitForTimeout(400);
+      hit = await this.firstLineHitTest();
+    }
+    return hit;
   }
 
   // --- bookmarks ---

--- a/apps/readest-app/e2e/tests/annotation.spec.ts
+++ b/apps/readest-app/e2e/tests/annotation.spec.ts
@@ -64,6 +64,26 @@ test.describe('Annotation', () => {
     expect(copied).toMatch(/\/o\/book\/[^/]+\/annotation\/[^?]+\?cfi=/);
   });
 
+  test('leaves the first line of text hittable when the page header is off', async ({
+    openBook,
+  }) => {
+    // #4977: the header bar's hover strip was a fixed 44px, the default page
+    // header margin. With the page header off the text moves up to the 16px
+    // compact margin and rendered under the strip, which took the press that
+    // should have started a selection. Desktop Chrome is the platform that
+    // still arms the strip (mobile keeps it inert since #5429).
+    const TRIGGER_BAND_PX = 44;
+    const reader = await openBook();
+    await reader.openTocChapter(3);
+    await reader.setPageHeaderVisible(false);
+
+    const hit = await reader.firstLineHitTestNearTop(TRIGGER_BAND_PX);
+
+    // Guard the premise: a line the strip never reached proves nothing.
+    expect(hit?.top).toBeLessThan(TRIGGER_BAND_PX);
+    expect(hit?.owner).toBe('reader');
+  });
+
   test('deletes an annotation', async ({ openBook }) => {
     const reader = await openBook();
 

--- a/apps/readest-app/src/__tests__/android/top-band-selection.android.test.ts
+++ b/apps/readest-app/src/__tests__/android/top-band-selection.android.test.ts
@@ -14,12 +14,15 @@ import {
 } from './helpers/reader';
 
 // End-to-end coverage for issue #5429: the header bar renders an invisible
-// 44px-tall hover trigger across the top of the reader. Its height matches the
-// page-header margin (marginTopPx = 44), so with the page header ON the text
-// starts right below it — but with the page header OFF the top margin shrinks
-// to compactMarginTopPx = 16 and the first line renders *underneath* the
-// trigger, which swallowed the touch on mobile: long-pressing the first line
-// selected nothing and no annotation popup appeared.
+// hover trigger across the top of the reader. It used to be a fixed 44px tall,
+// matching the default page-header margin (marginTopPx = 44), so with the page
+// header ON the text starts right below it — but with the page header OFF the
+// top margin shrinks to compactMarginTopPx = 16 and the first line rendered
+// *underneath* the trigger, which swallowed the touch on mobile: long-pressing
+// the first line selected nothing and no annotation popup appeared. The trigger
+// is inert on mobile since #5429 and no taller than the content top since
+// #4977; 44px stays the widest band it can ever cover, so it is still the
+// bound this lane probes under.
 //
 // The lane drives the installed app, so it exercises the WebView's real hit
 // testing — the part jsdom cannot model. The page header is turned off by
@@ -38,7 +41,7 @@ import {
 // where injection is deliverable.
 
 const FIXTURE = path.resolve(__dirname, '../fixtures/data/sample-alice.epub');
-/** Height of the header hover trigger (`h-11` in HeaderBar). */
+/** Tallest the header hover trigger can get (getHeaderTriggerHeight). */
 const TRIGGER_BAND_PX = 44;
 /** `compactMarginTopPx` — the top margin when the page header is off. */
 const COMPACT_MARGIN_TOP_PX = 16;

--- a/apps/readest-app/src/__tests__/utils/insets.test.ts
+++ b/apps/readest-app/src/__tests__/utils/insets.test.ts
@@ -1,7 +1,25 @@
 import { describe, expect, it } from 'vitest';
-import { getHeaderBandGeometry, getPanelTopInset } from '@/utils/insets';
+import { ViewSettings } from '@/types/book';
+import { getHeaderBandGeometry, getHeaderTriggerHeight, getPanelTopInset } from '@/utils/insets';
 
 const insets = (top: number) => ({ top, right: 0, bottom: 0, left: 0 });
+
+const viewSettings = (overrides: Partial<ViewSettings>) =>
+  ({
+    showHeader: true,
+    showFooter: true,
+    vertical: false,
+    writingMode: 'auto',
+    marginTopPx: 44,
+    marginBottomPx: 44,
+    marginLeftPx: 16,
+    marginRightPx: 16,
+    compactMarginTopPx: 16,
+    compactMarginBottomPx: 16,
+    compactMarginLeftPx: 16,
+    compactMarginRightPx: 16,
+    ...overrides,
+  }) as ViewSettings;
 
 describe('getHeaderBandGeometry (#5303)', () => {
   it('keeps the classic band below the safe area for margins of 16px and up', () => {
@@ -28,6 +46,46 @@ describe('getHeaderBandGeometry (#5303)', () => {
     // bottom must not go below 16 either — the two edges stay glued.
     expect(getHeaderBandGeometry(39, -23)).toEqual({ top: 0, height: 16, bottom: 16 });
     expect(getHeaderBandGeometry(39, -39)).toEqual({ top: 0, height: 16, bottom: 16 });
+  });
+});
+
+describe('getHeaderTriggerHeight (#4977)', () => {
+  // The trigger is a lid: whatever it covers cannot be selected or long
+  // pressed. It must stop where the book text starts, which is the renderer's
+  // top margin (FoliateViewer.applyMarginAndGap), never the fixed 44px of the
+  // toolbar it reveals.
+  it('keeps the full toolbar-height strip when the page header reserves it', () => {
+    expect(getHeaderTriggerHeight(0, viewSettings({}))).toBe(44);
+    // A notch pushes the text further down; the strip stays toolbar-sized.
+    expect(getHeaderTriggerHeight(39, viewSettings({}))).toBe(44);
+  });
+
+  it('shrinks to the compact margin when the page header is off', () => {
+    // The regression: text starts 16px from the top, under a 44px strip.
+    expect(getHeaderTriggerHeight(0, viewSettings({ showHeader: false }))).toBe(16);
+    expect(getHeaderTriggerHeight(39, viewSettings({ showHeader: false }))).toBe(16);
+    expect(
+      getHeaderTriggerHeight(0, viewSettings({ showHeader: false, compactMarginTopPx: 8 })),
+    ).toBe(8);
+  });
+
+  it('follows a reduced top margin while the page header is on', () => {
+    // The renderer floors the content top at 16px (moreTopInset), like the
+    // title band does.
+    expect(getHeaderTriggerHeight(0, viewSettings({ marginTopPx: 24 }))).toBe(24);
+    expect(getHeaderTriggerHeight(0, viewSettings({ marginTopPx: 8 }))).toBe(16);
+    expect(getHeaderTriggerHeight(39, viewSettings({ marginTopPx: -20 }))).toBe(19);
+  });
+
+  it('uses the compact margin in vertical writing mode, where the band is sideways', () => {
+    expect(getHeaderTriggerHeight(0, viewSettings({ vertical: true }))).toBe(16);
+    expect(getHeaderTriggerHeight(0, viewSettings({ writingMode: 'vertical-rl' }))).toBe(16);
+  });
+
+  it('collapses instead of going negative when the text starts above the cell', () => {
+    expect(
+      getHeaderTriggerHeight(0, viewSettings({ showHeader: false, compactMarginTopPx: -20 })),
+    ).toBe(0);
   });
 });
 

--- a/apps/readest-app/src/app/reader/components/HeaderBar.tsx
+++ b/apps/readest-app/src/app/reader/components/HeaderBar.tsx
@@ -19,6 +19,7 @@ import { getHighlightColorHex } from '../utils/annotatorUtil';
 import { annotationToolQuickActions } from './annotator/AnnotationTools';
 import { AnnotationToolType } from '@/types/annotator';
 import { saveViewSettings } from '@/helpers/settings';
+import { getHeaderTriggerHeight } from '@/utils/insets';
 import { HighlighterIcon } from '@/components/HighlighterIcon';
 import Dropdown from '@/components/Dropdown';
 import ModalPortal from '@/components/ModalPortal';
@@ -142,6 +143,7 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
   const insets = window.innerWidth < 640 ? screenInsets : gridInsets;
   const isHeaderVisible = hoveredBookKey === bookKey || isDropdownOpen;
   const isMobile = appService?.isMobile || window.innerWidth < 640;
+  const triggerHeight = viewSettings ? getHeaderTriggerHeight(gridInsets.top, viewSettings) : 0;
 
   useSpatialNavigation(headerRef, isHeaderVisible);
   const trafficLightInHeader =
@@ -167,17 +169,21 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
       {/*
         Hover trigger area. Mobile has no hover and toggles the bars by tapping
         the page (usePagination), so this must not take pointer events there —
-        it is 44px tall, the same as the page-header margin, so with the page
-        header off (compact 16px margin) it covered the first line of text and
-        swallowed long presses on it (#5429). Mirrors the footer's trigger.
+        it used to be a fixed 44px tall, the same as the default page-header
+        margin, so with the page header off (compact 16px margin) it covered the
+        first line of text and swallowed long presses on it (#5429). Mirrors the
+        footer's trigger. Its height now tracks the content top on every
+        platform, so the strip can never reach past where the text starts and
+        block a selection (#4977).
       */}
       <div
         role='none'
         tabIndex={-1}
         className={clsx(
-          'absolute top-0 z-10 h-11 w-full',
+          'absolute top-0 z-10 w-full',
           isMobile || pointerInDoc ? 'pointer-events-none' : 'pointer-events-auto',
         )}
+        style={{ height: `${triggerHeight}px` }}
         onClick={() => setHoveredBookKey(bookKey)}
         onMouseEnter={() => !appService?.isMobile && setHoveredBookKey(bookKey)}
         onTouchStart={() => !appService?.isMobile && setHoveredBookKey(bookKey)}

--- a/apps/readest-app/src/utils/insets.ts
+++ b/apps/readest-app/src/utils/insets.ts
@@ -40,6 +40,28 @@ export const getHeaderBandGeometry = (topInset: number, marginTopPx: number) => 
 };
 
 /**
+ * Height (px) of the header bar's hover trigger — the invisible strip along the
+ * top of the book cell that reveals the toolbar.
+ *
+ * The strip is a lid: whatever it covers cannot be selected, long pressed or
+ * clicked. Sized to the toolbar it reveals (44px) it matched the default top
+ * margin and nothing else, so any smaller margin — the page header off, a
+ * reduced margin, vertical writing mode — left it hanging over the first line
+ * of text and swallowing presses on it (#4977, #5429). So it stops at the
+ * content top instead: the renderer's `margin-top`, see
+ * FoliateViewer.applyMarginAndGap, which floors at 16px via moreTopInset while
+ * the page header is on and drops the safe-area inset when it is off.
+ */
+export const getHeaderTriggerHeight = (topInset: number, viewSettings: ViewSettings) => {
+  const maxHeight = 44;
+  const isVertical = viewSettings.vertical || viewSettings.writingMode.includes('vertical');
+  const marginTopPx = getViewInsets(viewSettings).top;
+  const contentTop =
+    viewSettings.showHeader && !isVertical ? Math.max(topInset + marginTopPx, 16) : marginTopPx;
+  return Math.min(maxHeight, Math.max(0, contentTop));
+};
+
+/**
  * Top padding (px) for a slide-in panel (sidebar / notebook) so its toolbar
  * clears the device status bar, mirroring the reader header.
  *


### PR DESCRIPTION
Closes #4977.

## The bug

The header bar's invisible hover trigger was `h-11` — 44px, sized to the **toolbar it reveals**, which merely happened to equal the default `marginTopPx`. It is a lid: whatever it covers cannot be selected, long pressed or clicked. Any smaller content top left it hanging over the first line of text and swallowing the press that should have started a selection:

- the page header off → the compact 16px margin,
- a reduced top margin,
- vertical writing mode.

## Why the #5429 gate wasn't enough

#5429 made the strip `pointer-events-none` when `appService.isMobile || innerWidth < 640`, which covers the reporter's **native** iPad app. But that gate reads the platform from the user agent, and iPad Safari reports a desktop one — `getOSPlatform()` returns `'macos'` there, as `src/utils/misc.ts` already documents. So the web build kept the bug on the very device the report came from, and touch laptops were exposed the same way.

Geometry beats UA sniffing here, and it is also what the issue asks for: *"the top bar's activation margin shouldn't overlap with where text is displayed on the screen."*

## The fix

`getHeaderTriggerHeight(topInset, viewSettings)` in `src/utils/insets.ts` — `min(44, contentTop)`, where `contentTop` mirrors the renderer's `margin-top` from `FoliateViewer.applyMarginAndGap` (floors at 16px via `moreTopInset` while the page header is on; drops the safe-area inset when it is off). Same "glued to the content top" rule its neighbour `getHeaderBandGeometry` already applies to the title band.

At default settings the strip is still 44px, so revealing the toolbar is unchanged. The #5429 mobile gate stays.

## Testing

- `getHeaderTriggerHeight` unit cases in `src/__tests__/utils/insets.test.ts` (page header on/off, reduced and negative margins, vertical writing mode, notch insets).
- A Playwright case that turns the page header off and hit-tests the topmost line of text. Desktop Chromium is non-mobile, so it is the only lane where the strip is armed. Proven red first — without the fix it reports the owner of the first line as `DIV.absolute top-0 z-10 h-11 w-full pointer-events-auto`, the strip itself.
- New `ReaderPage` helpers: `setPageHeaderVisible`, `hideChrome`, `firstLineHitTestNearTop`.
- `pnpm test` 8386 passed / 7 skipped · `pnpm lint` · `pnpm format:check` · `npx playwright test` 17/17.

No Rust or Lua changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)