### PR TITLE
fix(sync): handle OneDrive OAuth callbacks

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.*
 @InvokeArg
 class AuthRequestArgs {
     var authUrl: String? = null
+    var callbackUrl: String? = null
 }
 
 @InvokeArg
@@ -202,8 +203,6 @@ interface KeyDownInterceptor {
 )
 class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
     private val implementation = NativeBridge()
-    private var redirectScheme = "readest"
-    private var redirectHost = "auth-callback"
     private var webViewRef: WebView? = null
     private val billingManager by lazy {
         BillingManager(activity)
@@ -247,6 +246,7 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
         private const val REQUEST_MANAGE_STORAGE = 1001
         private const val FOLDER_PICKER_REQUEST_CODE = 1002
         var pendingInvoke: Invoke? = null
+        private var pendingAuthCallbackTarget: OAuthCallbackTarget? = null
         var pendingFolderPickerInvoke: Invoke? = null
         private var instance: NativeBridgePlugin? = null
         fun getInstance(): NativeBridgePlugin? = instance
@@ -293,19 +293,13 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
         // OAuth callback uses a custom scheme on intent.data and is handled
         // separately from any user-shared content.
         intent.data?.let { uri ->
-            val scheme = uri.scheme ?: ""
-            val isReadestAuth = scheme == "readest" && uri.host == "auth-callback"
-            // Google Drive sign-in uses the reverse-DNS "iOS URL scheme"
-            // (com.googleusercontent.apps.<id>:/oauthredirect) registered as a
-            // BROWSABLE deep link; resolve it through the same pending invoke as
-            // the Supabase readest://auth-callback flow.
-            val isGoogleOAuth = scheme.startsWith("com.googleusercontent.apps.")
-            if (isReadestAuth || isGoogleOAuth) {
+            if (pendingAuthCallbackTarget?.matches(uri.toString()) == true) {
                 val result = JSObject().apply {
                     put("redirectUrl", uri.toString())
                 }
                 pendingInvoke?.resolve(result)
                 pendingInvoke = null
+                pendingAuthCallbackTarget = null
                 return
             }
         }
@@ -447,15 +441,20 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
     @Command
     fun auth_with_custom_tab(invoke: Invoke) {
         val args = invoke.parseArgs(AuthRequestArgs::class.java)
+        val callbackTarget = args.callbackUrl?.let(OAuthCallbackTarget::parse)
+        if (callbackTarget == null) {
+            invoke.reject("Invalid OAuth callback URL")
+            return
+        }
         val uri = Uri.parse(args.authUrl)
 
         val customTabsIntent = CustomTabsIntent.Builder().build()
         customTabsIntent.intent.flags = Intent.FLAG_ACTIVITY_NO_HISTORY
 
         Log.d("NativeBridgePlugin", "Launching OAuth URL: ${args.authUrl}")
-        customTabsIntent.launchUrl(activity, uri)
-
         pendingInvoke = invoke
+        pendingAuthCallbackTarget = callbackTarget
+        customTabsIntent.launchUrl(activity, uri)
     }
 
     @Command

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/OAuthCallbackTarget.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/OAuthCallbackTarget.kt
@@ -1,0 +1,36 @@
+package com.readest.native_bridge
+
+import java.net.URI
+import java.net.URISyntaxException
+import java.util.Locale
+
+internal data class OAuthCallbackTarget(
+    private val scheme: String,
+    private val userInfo: String?,
+    private val host: String?,
+    private val port: Int,
+    private val path: String,
+) {
+    fun matches(callbackUrl: String): Boolean = parse(callbackUrl) == this
+
+    companion object {
+        fun parse(url: String): OAuthCallbackTarget? = try {
+            val uri = URI(url)
+            val scheme = uri.scheme ?: return null
+            OAuthCallbackTarget(
+                scheme = scheme.lowercase(Locale.ROOT),
+                userInfo = uri.rawUserInfo,
+                host = uri.host?.lowercase(Locale.ROOT),
+                port = uri.port,
+                path = normalizeRootPath(uri.rawPath),
+            )
+        } catch (_: URISyntaxException) {
+            null
+        }
+
+        private fun normalizeRootPath(path: String?): String = when (path) {
+            null, "", "/" -> ""
+            else -> path
+        }
+    }
+}

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/OAuthCallbackTarget.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/OAuthCallbackTarget.kt
@@ -14,18 +14,20 @@ internal data class OAuthCallbackTarget(
     fun matches(callbackUrl: String): Boolean = parse(callbackUrl) == this
 
     companion object {
-        fun parse(url: String): OAuthCallbackTarget? = try {
-            val uri = URI(url)
-            val scheme = uri.scheme ?: return null
-            OAuthCallbackTarget(
-                scheme = scheme.lowercase(Locale.ROOT),
-                userInfo = uri.rawUserInfo,
-                host = uri.host?.lowercase(Locale.ROOT),
-                port = uri.port,
-                path = normalizeRootPath(uri.rawPath),
-            )
-        } catch (_: URISyntaxException) {
-            null
+        fun parse(url: String): OAuthCallbackTarget? {
+            return try {
+                val uri = URI(url)
+                val scheme = uri.scheme ?: return null
+                OAuthCallbackTarget(
+                    scheme = scheme.lowercase(Locale.ROOT),
+                    userInfo = uri.rawUserInfo,
+                    host = uri.host?.lowercase(Locale.ROOT),
+                    port = uri.port,
+                    path = normalizeRootPath(uri.rawPath),
+                )
+            } catch (_: URISyntaxException) {
+                null
+            }
         }
 
         private fun normalizeRootPath(path: String?): String = when (path) {

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/test/java/OAuthCallbackTargetTest.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/test/java/OAuthCallbackTargetTest.kt
@@ -1,0 +1,64 @@
+package com.readest.native_bridge
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OAuthCallbackTargetTest {
+    @Test
+    fun oneDriveCallback_acceptsProviderRootSlash() {
+        val target = OAuthCallbackTarget.parse("readest-onedrive://auth")
+
+        assertNotNull(target)
+        assertTrue(
+            target!!.matches("readest-onedrive://auth/?code=CODE&state=STATE"),
+        )
+    }
+
+    @Test
+    fun oneDriveCallback_rejectsWrongHost() {
+        val target = OAuthCallbackTarget.parse("readest-onedrive://auth")
+
+        assertNotNull(target)
+        assertFalse(
+            target!!.matches("readest-onedrive://attacker/?code=CODE&state=STATE"),
+        )
+        assertFalse(
+            target.matches("readest-onedrive://auth:1234/?code=CODE&state=STATE"),
+        )
+    }
+
+    @Test
+    fun googleCallback_requiresItsRegisteredPath() {
+        val target = OAuthCallbackTarget.parse(
+            "com.googleusercontent.apps.cid:/oauthredirect",
+        )
+
+        assertNotNull(target)
+        assertTrue(
+            target!!.matches(
+                "com.googleusercontent.apps.cid:/oauthredirect?code=CODE&state=STATE",
+            ),
+        )
+        assertFalse(
+            target.matches(
+                "com.googleusercontent.apps.cid:/other?code=CODE&state=STATE",
+            ),
+        )
+    }
+
+    @Test
+    fun supabaseCallback_requiresItsRegisteredHost() {
+        val target = OAuthCallbackTarget.parse("readest://auth-callback")
+
+        assertNotNull(target)
+        assertTrue(target!!.matches("readest://auth-callback#access_token=TOKEN"))
+        assertFalse(target.matches("readest://other#access_token=TOKEN"))
+    }
+
+    @Test
+    fun invalidCallbackUrl_isRejected() {
+        assertTrue(OAuthCallbackTarget.parse("not a URI") == null)
+    }
+}

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
@@ -5,6 +5,10 @@ use std::collections::HashMap;
 #[serde(rename_all = "camelCase")]
 pub struct AuthRequest {
     pub auth_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub callback_scheme: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub callback_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/tests/auth_request.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/tests/auth_request.rs
@@ -1,0 +1,39 @@
+use serde_json::json;
+use tauri_plugin_native_bridge::AuthRequest;
+
+#[test]
+fn preserves_platform_callback_fields_across_the_mobile_bridge() {
+    let request: AuthRequest = serde_json::from_value(json!({
+        "authUrl": "https://provider.example/authorize",
+        "callbackScheme": "readest-onedrive",
+        "callbackUrl": "readest-onedrive://auth"
+    }))
+    .unwrap();
+
+    assert_eq!(request.callback_scheme.as_deref(), Some("readest-onedrive"));
+    assert_eq!(
+        request.callback_url.as_deref(),
+        Some("readest-onedrive://auth")
+    );
+    assert_eq!(
+        serde_json::to_value(request).unwrap(),
+        json!({
+            "authUrl": "https://provider.example/authorize",
+            "callbackScheme": "readest-onedrive",
+            "callbackUrl": "readest-onedrive://auth"
+        }),
+    );
+}
+
+#[test]
+fn omits_unused_callback_fields() {
+    let request: AuthRequest = serde_json::from_value(json!({
+        "authUrl": "https://provider.example/authorize"
+    }))
+    .unwrap();
+
+    assert_eq!(
+        serde_json::to_value(request).unwrap(),
+        json!({"authUrl": "https://provider.example/authorize"}),
+    );
+}

--- a/apps/readest-app/src/__tests__/services/sync/providers/oauth/oauthAndroid.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/providers/oauth/oauthAndroid.test.ts
@@ -44,6 +44,7 @@ describe('runAndroidOAuth', () => {
     const authUrl = vi.mocked(authWithCustomTab).mock.calls[0]![0].authUrl;
     expect(authUrl).toContain('code_challenge=');
     expect(authUrl).toContain('accounts.google.com');
+    expect(vi.mocked(authWithCustomTab).mock.calls[0]![0].callbackUrl).toBe(CONFIG.redirectUri);
     expect(tokens.accessToken).toBe('AT');
     expect(tokens.refreshToken).toBe('RT');
     expect(fetchFn).toHaveBeenCalledTimes(1);

--- a/apps/readest-app/src/__tests__/services/sync/providers/oauth/parseRedirect.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/providers/oauth/parseRedirect.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { parseRedirect } from '@/services/sync/providers/oauth/parseRedirect';
 
 const REDIRECT_URI = 'com.googleusercontent.apps.cid:/oauthredirect';
+const ONEDRIVE_REDIRECT_URI = 'readest-onedrive://auth';
 
 describe('parseRedirect', () => {
   test('returns the code when target, state and code are all valid', () => {
@@ -17,6 +18,26 @@ describe('parseRedirect', () => {
   test('rejects a right-scheme but wrong-path redirect', () => {
     const url = 'com.googleusercontent.apps.cid:/somethingelse?code=AUTH_CODE&state=STATE';
     expect(() => parseRedirect(url, 'STATE', REDIRECT_URI)).toThrow(/target mismatch/i);
+  });
+
+  test('accepts a root slash added to an authority-style redirect URI', () => {
+    const url = `${ONEDRIVE_REDIRECT_URI}/?code=AUTH_CODE&state=STATE`;
+    expect(parseRedirect(url, 'STATE', ONEDRIVE_REDIRECT_URI)).toEqual({ code: 'AUTH_CODE' });
+  });
+
+  test('rejects a right-scheme but wrong-host redirect', () => {
+    const url = 'readest-onedrive://attacker/?code=SECRET_CODE&state=SECRET_STATE';
+    let thrown: unknown;
+    try {
+      parseRedirect(url, 'STATE', ONEDRIVE_REDIRECT_URI);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(/target mismatch/i);
+    expect((thrown as Error).message).not.toContain('SECRET_CODE');
+    expect((thrown as Error).message).not.toContain('SECRET_STATE');
   });
 
   test('surfaces a provider error param ahead of the CSRF/code checks', () => {

--- a/apps/readest-app/src/app/auth/page.tsx
+++ b/apps/readest-app/src/app/auth/page.tsx
@@ -109,11 +109,12 @@ export default function AuthPage() {
       throw new Error('No backend connected');
     }
     supabase.auth.signOut();
+    const redirectTo = getTauriRedirectTo(true);
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider,
       options: {
         skipBrowserRedirect: true,
-        redirectTo: getTauriRedirectTo(true),
+        redirectTo,
       },
     });
 
@@ -129,7 +130,7 @@ export default function AuthPage() {
         handleOAuthUrl(res.redirectUrl);
       }
     } else if (appService?.isAndroidApp) {
-      const res = await authWithCustomTab({ authUrl: data.url });
+      const res = await authWithCustomTab({ authUrl: data.url, callbackUrl: redirectTo });
       if (res) {
         handleOAuthUrl(res.redirectUrl);
       }

--- a/apps/readest-app/src/app/auth/utils/nativeAuth.ts
+++ b/apps/readest-app/src/app/auth/utils/nativeAuth.ts
@@ -12,6 +12,11 @@ export interface AuthRequest {
   callbackScheme?: string;
 }
 
+export interface CustomTabAuthRequest extends AuthRequest {
+  /** Exact custom-scheme URI Android must accept for this authorization attempt. */
+  callbackUrl: string;
+}
+
 export interface AuthResponse {
   redirectUrl: string;
 }
@@ -46,7 +51,7 @@ export async function authWithSafari(request: AuthRequest): Promise<AuthResponse
   }
 }
 
-export async function authWithCustomTab(request: AuthRequest): Promise<AuthResponse> {
+export async function authWithCustomTab(request: CustomTabAuthRequest): Promise<AuthResponse> {
   const result = await invoke<AuthResponse>('plugin:native-bridge|auth_with_custom_tab', {
     payload: request,
   });

--- a/apps/readest-app/src/services/sync/providers/oauth/oauthAndroid.ts
+++ b/apps/readest-app/src/services/sync/providers/oauth/oauthAndroid.ts
@@ -16,8 +16,8 @@
  * Custom Tab renders inside the host task and keeps the process at foreground
  * importance; the redirect resolves through a native field that survives a WebView
  * reload. The native command opens consent AND resolves with the redirect URL in
- * one round trip, recognising it by the reverse-DNS scheme parsed from the auth
- * URL's `redirect_uri`.
+ * one round trip, matching it against the exact redirect URI supplied for the
+ * current authorization attempt.
  *
  * The iOS-type client has NO secret and needs NO Android SHA-1 — Google validates
  * the redirect by string-matching the client-id-derived scheme, and PKCE is the
@@ -45,8 +45,8 @@ export const runAndroidOAuth = (config: OAuthClientConfig, fetchFn: FetchFn): Pr
   // single native round-trip — so it needs the auth URL, which `runOAuthFlow`
   // only hands to `openUrl`. Bridge the two with a deferred: `openUrl` supplies
   // the URL, and `awaitRedirect` (invoked first) waits for it before driving the
-  // Custom Tab. The native side recognises the redirect by its reverse-DNS
-  // scheme, so only the auth URL needs to cross over.
+  // Custom Tab. The native side matches the exact callback target, so both the
+  // auth URL and callback URL cross the bridge.
   let provideAuthUrl!: (url: string) => void;
   const authUrlReady = new Promise<string>((resolve) => {
     provideAuthUrl = resolve;
@@ -61,7 +61,7 @@ export const runAndroidOAuth = (config: OAuthClientConfig, fetchFn: FetchFn): Pr
     },
     awaitRedirect: async () => {
       const authUrl = await authUrlReady;
-      const { redirectUrl } = await authWithCustomTab({ authUrl });
+      const { redirectUrl } = await authWithCustomTab({ authUrl, callbackUrl: redirectUri });
       return redirectUrl;
     },
     redirectUri,

--- a/apps/readest-app/src/services/sync/providers/oauth/parseRedirect.ts
+++ b/apps/readest-app/src/services/sync/providers/oauth/parseRedirect.ts
@@ -1,5 +1,5 @@
 /**
- * Parse the OAuth redirect Google sends back after the consent screen and pull
+ * Parse the OAuth redirect a provider sends back after the consent screen and pull
  * out the authorization `code`, with redirect-target and CSRF protection.
  *
  * The authorization-code flow returns its result as query parameters on a
@@ -17,7 +17,7 @@
  * used with the author's explicit permission.
  */
 
-/** Redirect query-parameter names Google returns. */
+/** Redirect query-parameter names OAuth providers return. */
 const REDIRECT_PARAM = {
   code: 'code',
   state: 'state',
@@ -38,9 +38,10 @@ export interface RedirectResult {
  * @param redirectUrl - the full redirect URL captured from the deep-link intent.
  * @param expectedState - the `state` we generated for this authorization attempt
  *   (see `buildAuthUrl`); the redirect's `state` must equal it.
- * @param expectedRedirectUri - the exact reverse-DNS redirect URI we requested;
- *   the redirect's scheme + path must match it. Defense-in-depth on top of the
- *   ingress scheme filter so a scheme-prefix-but-wrong-path URL cannot slip in.
+ * @param expectedRedirectUri - the exact redirect URI we requested; the
+ *   redirect's scheme, authority, and path must match it. A missing path and
+ *   root path are equivalent because providers may canonicalize the former to
+ *   `/` when returning a custom-scheme callback.
  * @returns the authorization `code` on success.
  * @throws if the URL is not our redirect target, the provider reported an error,
  *   the `state` fails the CSRF check, or no `code` is present — each with a
@@ -54,14 +55,23 @@ export const parseRedirect = (
   const url = new URL(redirectUrl);
   const expected = new URL(expectedRedirectUri);
 
-  // Target guard: the redirect must be aimed at the exact scheme + path we
-  // registered. A custom-scheme URL parses with `protocol` = the scheme (incl.
-  // trailing ':') and `pathname` = the part after it. Anything else is not our
-  // redirect, so reject before reading any of its params.
-  if (url.protocol !== expected.protocol || url.pathname !== expected.pathname) {
+  const normalizeRootPath = (pathname: string) => (pathname === '/' ? '' : pathname);
+  const describeTarget = (target: URL) =>
+    `${target.protocol}${target.host ? `//${target.host}` : ''}${target.pathname}`;
+
+  // Target guard: compare every routing component before reading parameters.
+  // Microsoft may return `scheme://host/` for a registered `scheme://host`, so
+  // only that empty-path/root-path distinction is normalized.
+  if (
+    url.protocol !== expected.protocol ||
+    url.username !== expected.username ||
+    url.password !== expected.password ||
+    url.host !== expected.host ||
+    normalizeRootPath(url.pathname) !== normalizeRootPath(expected.pathname)
+  ) {
     throw new Error(
-      `OAuth redirect target mismatch: expected "${expected.protocol}${expected.pathname}", ` +
-        `got "${url.protocol}${url.pathname}"`,
+      `OAuth redirect target mismatch: expected "${describeTarget(expected)}", ` +
+        `got "${describeTarget(url)}"`,
     );
   }
 


### PR DESCRIPTION
Closes #5253

## Summary

- Fix OneDrive authorization callbacks that left Android waiting indefinitely or caused desktop connection failures after successful Microsoft sign-in.
- Accept Microsoft's documented root-slash normalization without weakening callback-target or OAuth state validation.

## Root Cause

Microsoft [documents that redirect URIs without a path segment are returned with a trailing slash](https://learn.microsoft.com/en-us/entra/identity-platform/reply-url#what-are-the-restrictions-of-redirect-uris-for-microsoft-entra-applications). As a result, the registered `readest-onedrive://auth` callback can be returned as `readest-onedrive://auth/`, but the shared parser treated those forms as different targets.

On Android, the native Custom Tab bridge only recognized the existing Supabase and Google Drive callback shapes, so a OneDrive callback did not resolve the pending authorization request.

## Changes

- Treat only an empty callback path and `/` as equivalent while continuing to require the scheme, authority, port, and non-root path to match.
- Pass the expected callback URL through the TypeScript and Rust mobile bridge using Tauri's documented [mobile plugin argument serialization](https://v2.tauri.app/develop/plugins/develop-mobile/#command-arguments).
- Match Android OAuth callbacks against the callback target supplied for the current authorization attempt, following Tauri's guidance to [validate the expected format of received deep links](https://v2.tauri.app/plugin/deep-linking/).
- Preserve the existing Google Drive and Supabase Custom Tab behavior.
- Add automated regression coverage for Microsoft callback normalization, invalid targets, mobile bridge serialization, and Android callback matching.

## Behavior

- OneDrive authorization can return to Readest and complete after Microsoft adds a trailing slash to the callback.
- Redirects with an unexpected scheme, host, port, or path remain rejected.
- OAuth `state` validation and PKCE behavior remain unchanged, consistent with Microsoft's [authorization code flow guidance for desktop and mobile apps](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow).

## Scope

- The shared callback normalization applies to native OneDrive flows on Android, iOS, macOS, Windows, and Linux.
- Android additionally uses the per-request native callback matcher.
- The web OneDrive callback flow and synchronization data behavior are unchanged.