### PR TITLE
fix(android): correct the package name in the native-tts unit test

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-tts/android/src/test/java/ExampleUnitTest.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-tts/android/src/test/java/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package com.readest.native-tts
+package com.readest.native_tts
 
 import org.junit.Test
 


### PR DESCRIPTION
## Summary

The native-tts plugin's example unit test declares `package com.readest.native-tts`, which is not valid Kotlin (hyphens cannot appear in package names). Any attempt to compile the module's test source set fails with "Expecting a top level declaration" before a single test runs. This renames the package to the module namespace `com.readest.native_tts`, matching what the native-bridge plugin's test already uses.

Nothing in CI compiles this today, which is why it went unnoticed; it surfaced while running the plugin unit test tasks locally during the review of #5479.

## Verification

`:tauri-plugin-native-tts:testDebugUnitTest` now compiles and passes (1/1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)