### PR TITLE
feat(reader): horizontal scrolling mode for fixed layout books

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2191,7 +2191,6 @@
   "Narration": "السرد",
   "Includes narration": "يتضمّن سردًا صوتيًا",
   "Back to Read Aloud": "العودة إلى القراءة بصوت عالٍ",
-  "Paginated": "عرض الصفحات",
   "Vertical Scrolling": "التمرير العمودي",
   "Horizontal Scrolling": "التمرير الأفقي"
 }

--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2190,5 +2190,8 @@
   "Book narration": "سرد الكتاب",
   "Narration": "السرد",
   "Includes narration": "يتضمّن سردًا صوتيًا",
-  "Back to Read Aloud": "العودة إلى القراءة بصوت عالٍ"
+  "Back to Read Aloud": "العودة إلى القراءة بصوت عالٍ",
+  "Paginated": "عرض الصفحات",
+  "Vertical Scrolling": "التمرير العمودي",
+  "Horizontal Scrolling": "التمرير الأفقي"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2007,7 +2007,6 @@
   "Narration": "বর্ণনা",
   "Includes narration": "কথিত বর্ণনা রয়েছে",
   "Back to Read Aloud": "জোরে পড়ায় ফিরুন",
-  "Paginated": "পৃষ্ঠা বিভক্ত",
   "Vertical Scrolling": "উল্লম্ব স্ক্রলিং",
   "Horizontal Scrolling": "অনুভূমিক স্ক্রলিং"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2006,5 +2006,8 @@
   "Book narration": "বইয়ের বর্ণনা",
   "Narration": "বর্ণনা",
   "Includes narration": "কথিত বর্ণনা রয়েছে",
-  "Back to Read Aloud": "জোরে পড়ায় ফিরুন"
+  "Back to Read Aloud": "জোরে পড়ায় ফিরুন",
+  "Paginated": "পৃষ্ঠা বিভক্ত",
+  "Vertical Scrolling": "উল্লম্ব স্ক্রলিং",
+  "Horizontal Scrolling": "অনুভূমিক স্ক্রলিং"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1960,5 +1960,8 @@
   "Book narration": "དཔེ་དེབ་ཀྱི་ཀློག་སྒྲ།",
   "Narration": "ཀློག་སྒྲ།",
   "Includes narration": "ཀློག་སྒྲ་ཡོད།",
-  "Back to Read Aloud": "སྐད་སྒྲས་ཀློག་སར་ཕྱིར་ལོག་པ།"
+  "Back to Read Aloud": "སྐད་སྒྲས་ཀློག་སར་ཕྱིར་ལོག་པ།",
+  "Paginated": "ཤོག་ངོས་རིམ་པ།",
+  "Vertical Scrolling": "འཕྱང་ཐིག་འཁོར་རྒྱུག",
+  "Horizontal Scrolling": "ཐད་ཐིག་འཁོར་རྒྱུག"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1961,7 +1961,6 @@
   "Narration": "ཀློག་སྒྲ།",
   "Includes narration": "ཀློག་སྒྲ་ཡོད།",
   "Back to Read Aloud": "སྐད་སྒྲས་ཀློག་སར་ཕྱིར་ལོག་པ།",
-  "Paginated": "ཤོག་ངོས་རིམ་པ།",
   "Vertical Scrolling": "འཕྱང་ཐིག་འཁོར་རྒྱུག",
   "Horizontal Scrolling": "ཐད་ཐིག་འཁོར་རྒྱུག"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2006,5 +2006,8 @@
   "Book narration": "Erzählstimme des Buches",
   "Narration": "Erzählstimme",
   "Includes narration": "Mit Erzählstimme",
-  "Back to Read Aloud": "Zurück zum Vorlesen"
+  "Back to Read Aloud": "Zurück zum Vorlesen",
+  "Paginated": "Paginiert",
+  "Vertical Scrolling": "Vertikales Scrollen",
+  "Horizontal Scrolling": "Horizontales Scrollen"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2007,7 +2007,6 @@
   "Narration": "Erzählstimme",
   "Includes narration": "Mit Erzählstimme",
   "Back to Read Aloud": "Zurück zum Vorlesen",
-  "Paginated": "Paginiert",
   "Vertical Scrolling": "Vertikales Scrollen",
   "Horizontal Scrolling": "Horizontales Scrollen"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2006,5 +2006,8 @@
   "Book narration": "Αφήγηση βιβλίου",
   "Narration": "Αφήγηση",
   "Includes narration": "Περιλαμβάνει αφήγηση",
-  "Back to Read Aloud": "Επιστροφή στην Εκφώνηση"
+  "Back to Read Aloud": "Επιστροφή στην Εκφώνηση",
+  "Paginated": "Σελιδοποιημένο",
+  "Vertical Scrolling": "Κατακόρυφη κύλιση",
+  "Horizontal Scrolling": "Οριζόντια κύλιση"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2007,7 +2007,6 @@
   "Narration": "Αφήγηση",
   "Includes narration": "Περιλαμβάνει αφήγηση",
   "Back to Read Aloud": "Επιστροφή στην Εκφώνηση",
-  "Paginated": "Σελιδοποιημένο",
   "Vertical Scrolling": "Κατακόρυφη κύλιση",
   "Horizontal Scrolling": "Οριζόντια κύλιση"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2053,7 +2053,6 @@
   "Narration": "Narración",
   "Includes narration": "Incluye narración",
   "Back to Read Aloud": "Volver a la lectura en voz alta",
-  "Paginated": "Paginado",
   "Vertical Scrolling": "Desplazamiento vertical",
   "Horizontal Scrolling": "Desplazamiento horizontal"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2052,5 +2052,8 @@
   "Book narration": "Narración del libro",
   "Narration": "Narración",
   "Includes narration": "Incluye narración",
-  "Back to Read Aloud": "Volver a la lectura en voz alta"
+  "Back to Read Aloud": "Volver a la lectura en voz alta",
+  "Paginated": "Paginado",
+  "Vertical Scrolling": "Desplazamiento vertical",
+  "Horizontal Scrolling": "Desplazamiento horizontal"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2007,7 +2007,6 @@
   "Narration": "روایت",
   "Includes narration": "شامل روایت صوتی",
   "Back to Read Aloud": "بازگشت به خواندن با صدای بلند",
-  "Paginated": "صفحه‌بندی‌شده",
   "Vertical Scrolling": "پیمایش عمودی",
   "Horizontal Scrolling": "پیمایش افقی"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2006,5 +2006,8 @@
   "Book narration": "روایت کتاب",
   "Narration": "روایت",
   "Includes narration": "شامل روایت صوتی",
-  "Back to Read Aloud": "بازگشت به خواندن با صدای بلند"
+  "Back to Read Aloud": "بازگشت به خواندن با صدای بلند",
+  "Paginated": "صفحه‌بندی‌شده",
+  "Vertical Scrolling": "پیمایش عمودی",
+  "Horizontal Scrolling": "پیمایش افقی"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2053,7 +2053,6 @@
   "Narration": "Narration",
   "Includes narration": "Contient une narration",
   "Back to Read Aloud": "Retour à la lecture à voix haute",
-  "Paginated": "Paginé",
   "Vertical Scrolling": "Défilement vertical",
   "Horizontal Scrolling": "Défilement horizontal"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2052,5 +2052,8 @@
   "Book narration": "Narration du livre",
   "Narration": "Narration",
   "Includes narration": "Contient une narration",
-  "Back to Read Aloud": "Retour à la lecture à voix haute"
+  "Back to Read Aloud": "Retour à la lecture à voix haute",
+  "Paginated": "Paginé",
+  "Vertical Scrolling": "Défilement vertical",
+  "Horizontal Scrolling": "Défilement horizontal"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2052,5 +2052,8 @@
   "Book narration": "קריינות הספר",
   "Narration": "קריינות",
   "Includes narration": "כולל קריינות",
-  "Back to Read Aloud": "חזרה להקראה"
+  "Back to Read Aloud": "חזרה להקראה",
+  "Paginated": "מדופדף",
+  "Vertical Scrolling": "גלילה אנכית",
+  "Horizontal Scrolling": "גלילה אופקית"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2053,7 +2053,6 @@
   "Narration": "קריינות",
   "Includes narration": "כולל קריינות",
   "Back to Read Aloud": "חזרה להקראה",
-  "Paginated": "מדופדף",
   "Vertical Scrolling": "גלילה אנכית",
   "Horizontal Scrolling": "גלילה אופקית"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2007,7 +2007,6 @@
   "Narration": "वाचन",
   "Includes narration": "वाचन शामिल है",
   "Back to Read Aloud": "ज़ोर से पढ़ने पर लौटें",
-  "Paginated": "पृष्ठांकित",
   "Vertical Scrolling": "ऊर्ध्वाधर स्क्रॉलिंग",
   "Horizontal Scrolling": "क्षैतिज स्क्रॉलिंग"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2006,5 +2006,8 @@
   "Book narration": "पुस्तक का वाचन",
   "Narration": "वाचन",
   "Includes narration": "वाचन शामिल है",
-  "Back to Read Aloud": "ज़ोर से पढ़ने पर लौटें"
+  "Back to Read Aloud": "ज़ोर से पढ़ने पर लौटें",
+  "Paginated": "पृष्ठांकित",
+  "Vertical Scrolling": "ऊर्ध्वाधर स्क्रॉलिंग",
+  "Horizontal Scrolling": "क्षैतिज स्क्रॉलिंग"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2006,5 +2006,8 @@
   "Book narration": "A könyv narrációja",
   "Narration": "Narráció",
   "Includes narration": "Narrációt tartalmaz",
-  "Back to Read Aloud": "Vissza a felolvasáshoz"
+  "Back to Read Aloud": "Vissza a felolvasáshoz",
+  "Paginated": "Lapozott",
+  "Vertical Scrolling": "Függőleges görgetés",
+  "Horizontal Scrolling": "Vízszintes görgetés"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2007,7 +2007,6 @@
   "Narration": "Narráció",
   "Includes narration": "Narrációt tartalmaz",
   "Back to Read Aloud": "Vissza a felolvasáshoz",
-  "Paginated": "Lapozott",
   "Vertical Scrolling": "Függőleges görgetés",
   "Horizontal Scrolling": "Vízszintes görgetés"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1961,7 +1961,6 @@
   "Narration": "Narasi",
   "Includes narration": "Menyertakan narasi",
   "Back to Read Aloud": "Kembali ke Baca Nyaring",
-  "Paginated": "Berhalaman",
   "Vertical Scrolling": "Gulir Vertikal",
   "Horizontal Scrolling": "Gulir Horizontal"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1960,5 +1960,8 @@
   "Book narration": "Narasi buku",
   "Narration": "Narasi",
   "Includes narration": "Menyertakan narasi",
-  "Back to Read Aloud": "Kembali ke Baca Nyaring"
+  "Back to Read Aloud": "Kembali ke Baca Nyaring",
+  "Paginated": "Berhalaman",
+  "Vertical Scrolling": "Gulir Vertikal",
+  "Horizontal Scrolling": "Gulir Horizontal"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2053,7 +2053,6 @@
   "Narration": "Narrazione",
   "Includes narration": "Include la narrazione",
   "Back to Read Aloud": "Torna alla lettura ad alta voce",
-  "Paginated": "Paginato",
   "Vertical Scrolling": "Scorrimento verticale",
   "Horizontal Scrolling": "Scorrimento orizzontale"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2052,5 +2052,8 @@
   "Book narration": "Narrazione del libro",
   "Narration": "Narrazione",
   "Includes narration": "Include la narrazione",
-  "Back to Read Aloud": "Torna alla lettura ad alta voce"
+  "Back to Read Aloud": "Torna alla lettura ad alta voce",
+  "Paginated": "Paginato",
+  "Vertical Scrolling": "Scorrimento verticale",
+  "Horizontal Scrolling": "Scorrimento orizzontale"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1960,5 +1960,8 @@
   "Book narration": "書籍のナレーション",
   "Narration": "ナレーション",
   "Includes narration": "ナレーション付き",
-  "Back to Read Aloud": "読み上げに戻る"
+  "Back to Read Aloud": "読み上げに戻る",
+  "Paginated": "ページめくり",
+  "Vertical Scrolling": "縦スクロール",
+  "Horizontal Scrolling": "横スクロール"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1961,7 +1961,6 @@
   "Narration": "ナレーション",
   "Includes narration": "ナレーション付き",
   "Back to Read Aloud": "読み上げに戻る",
-  "Paginated": "ページめくり",
   "Vertical Scrolling": "縦スクロール",
   "Horizontal Scrolling": "横スクロール"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1960,5 +1960,8 @@
   "Book narration": "책 낭독",
   "Narration": "낭독",
   "Includes narration": "낭독 포함",
-  "Back to Read Aloud": "소리 내어 읽기로 돌아가기"
+  "Back to Read Aloud": "소리 내어 읽기로 돌아가기",
+  "Paginated": "페이지 넘김",
+  "Vertical Scrolling": "세로 스크롤",
+  "Horizontal Scrolling": "가로 스크롤"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1961,7 +1961,6 @@
   "Narration": "낭독",
   "Includes narration": "낭독 포함",
   "Back to Read Aloud": "소리 내어 읽기로 돌아가기",
-  "Paginated": "페이지 넘김",
   "Vertical Scrolling": "세로 스크롤",
   "Horizontal Scrolling": "가로 스크롤"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1961,7 +1961,6 @@
   "Narration": "Narasi",
   "Includes narration": "Menyertakan narasi",
   "Back to Read Aloud": "Kembali ke Baca Lantang",
-  "Paginated": "Berhalaman",
   "Vertical Scrolling": "Tatal Menegak",
   "Horizontal Scrolling": "Tatal Mengufuk"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1960,5 +1960,8 @@
   "Book narration": "Narasi buku",
   "Narration": "Narasi",
   "Includes narration": "Menyertakan narasi",
-  "Back to Read Aloud": "Kembali ke Baca Lantang"
+  "Back to Read Aloud": "Kembali ke Baca Lantang",
+  "Paginated": "Berhalaman",
+  "Vertical Scrolling": "Tatal Menegak",
+  "Horizontal Scrolling": "Tatal Mengufuk"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2006,5 +2006,8 @@
   "Book narration": "Vertelstem van het boek",
   "Narration": "Vertelstem",
   "Includes narration": "Met vertelstem",
-  "Back to Read Aloud": "Terug naar Voorlezen"
+  "Back to Read Aloud": "Terug naar Voorlezen",
+  "Paginated": "Gepagineerd",
+  "Vertical Scrolling": "Verticaal scrollen",
+  "Horizontal Scrolling": "Horizontaal scrollen"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2007,7 +2007,6 @@
   "Narration": "Vertelstem",
   "Includes narration": "Met vertelstem",
   "Back to Read Aloud": "Terug naar Voorlezen",
-  "Paginated": "Gepagineerd",
   "Vertical Scrolling": "Verticaal scrollen",
   "Horizontal Scrolling": "Horizontaal scrollen"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2098,5 +2098,8 @@
   "Book narration": "Narracja książki",
   "Narration": "Narracja",
   "Includes narration": "Zawiera narrację",
-  "Back to Read Aloud": "Powrót do czytania na głos"
+  "Back to Read Aloud": "Powrót do czytania na głos",
+  "Paginated": "Stronicowanie",
+  "Vertical Scrolling": "Przewijanie pionowe",
+  "Horizontal Scrolling": "Przewijanie poziome"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2099,7 +2099,6 @@
   "Narration": "Narracja",
   "Includes narration": "Zawiera narrację",
   "Back to Read Aloud": "Powrót do czytania na głos",
-  "Paginated": "Stronicowanie",
   "Vertical Scrolling": "Przewijanie pionowe",
   "Horizontal Scrolling": "Przewijanie poziome"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2053,7 +2053,6 @@
   "Narration": "Narração",
   "Includes narration": "Inclui narração",
   "Back to Read Aloud": "Voltar à leitura em voz alta",
-  "Paginated": "Paginado",
   "Vertical Scrolling": "Rolagem vertical",
   "Horizontal Scrolling": "Rolagem horizontal"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2052,5 +2052,8 @@
   "Book narration": "Narração do livro",
   "Narration": "Narração",
   "Includes narration": "Inclui narração",
-  "Back to Read Aloud": "Voltar à leitura em voz alta"
+  "Back to Read Aloud": "Voltar à leitura em voz alta",
+  "Paginated": "Paginado",
+  "Vertical Scrolling": "Rolagem vertical",
+  "Horizontal Scrolling": "Rolagem horizontal"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2053,7 +2053,6 @@
   "Narration": "Narração",
   "Includes narration": "Inclui narração",
   "Back to Read Aloud": "Voltar à leitura em voz alta",
-  "Paginated": "Paginado",
   "Vertical Scrolling": "Rolagem Vertical",
   "Horizontal Scrolling": "Rolagem Horizontal"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2052,5 +2052,8 @@
   "Book narration": "Narração do livro",
   "Narration": "Narração",
   "Includes narration": "Inclui narração",
-  "Back to Read Aloud": "Voltar à leitura em voz alta"
+  "Back to Read Aloud": "Voltar à leitura em voz alta",
+  "Paginated": "Paginado",
+  "Vertical Scrolling": "Rolagem Vertical",
+  "Horizontal Scrolling": "Rolagem Horizontal"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2052,5 +2052,8 @@
   "Book narration": "Narațiunea cărții",
   "Narration": "Narațiune",
   "Includes narration": "Include narațiune",
-  "Back to Read Aloud": "Înapoi la citirea cu voce tare"
+  "Back to Read Aloud": "Înapoi la citirea cu voce tare",
+  "Paginated": "Paginat",
+  "Vertical Scrolling": "Derulare verticală",
+  "Horizontal Scrolling": "Derulare orizontală"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2053,7 +2053,6 @@
   "Narration": "Narațiune",
   "Includes narration": "Include narațiune",
   "Back to Read Aloud": "Înapoi la citirea cu voce tare",
-  "Paginated": "Paginat",
   "Vertical Scrolling": "Derulare verticală",
   "Horizontal Scrolling": "Derulare orizontală"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2098,5 +2098,8 @@
   "Book narration": "Озвучка книги",
   "Narration": "Озвучка",
   "Includes narration": "Есть озвучка",
-  "Back to Read Aloud": "Вернуться к чтению вслух"
+  "Back to Read Aloud": "Вернуться к чтению вслух",
+  "Paginated": "Постраничный",
+  "Vertical Scrolling": "Вертикальная прокрутка",
+  "Horizontal Scrolling": "Горизонтальная прокрутка"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2099,7 +2099,6 @@
   "Narration": "Озвучка",
   "Includes narration": "Есть озвучка",
   "Back to Read Aloud": "Вернуться к чтению вслух",
-  "Paginated": "Постраничный",
   "Vertical Scrolling": "Вертикальная прокрутка",
   "Horizontal Scrolling": "Горизонтальная прокрутка"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2007,7 +2007,6 @@
   "Narration": "ආඛ්‍යානය",
   "Includes narration": "ආඛ්‍යානය ඇතුළත්",
   "Back to Read Aloud": "ශබ්ද නඟා කියවීමට ආපසු යන්න",
-  "Paginated": "පිටු වශයෙන්",
   "Vertical Scrolling": "සිරස් අනුචලනය",
   "Horizontal Scrolling": "තිරස් අනුචලනය"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2006,5 +2006,8 @@
   "Book narration": "පොතේ ආඛ්‍යානය",
   "Narration": "ආඛ්‍යානය",
   "Includes narration": "ආඛ්‍යානය ඇතුළත්",
-  "Back to Read Aloud": "ශබ්ද නඟා කියවීමට ආපසු යන්න"
+  "Back to Read Aloud": "ශබ්ද නඟා කියවීමට ආපසු යන්න",
+  "Paginated": "පිටු වශයෙන්",
+  "Vertical Scrolling": "සිරස් අනුචලනය",
+  "Horizontal Scrolling": "තිරස් අනුචලනය"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2098,5 +2098,8 @@
   "Book narration": "Pripovedovanje knjige",
   "Narration": "Pripovedovanje",
   "Includes narration": "Vsebuje pripovedovanje",
-  "Back to Read Aloud": "Nazaj na glasno branje"
+  "Back to Read Aloud": "Nazaj na glasno branje",
+  "Paginated": "Po straneh",
+  "Vertical Scrolling": "Navpično pomikanje",
+  "Horizontal Scrolling": "Vodoravno pomikanje"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2099,7 +2099,6 @@
   "Narration": "Pripovedovanje",
   "Includes narration": "Vsebuje pripovedovanje",
   "Back to Read Aloud": "Nazaj na glasno branje",
-  "Paginated": "Po straneh",
   "Vertical Scrolling": "Navpično pomikanje",
   "Horizontal Scrolling": "Vodoravno pomikanje"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2007,7 +2007,6 @@
   "Narration": "Berättarröst",
   "Includes narration": "Med berättarröst",
   "Back to Read Aloud": "Tillbaka till uppläsningen",
-  "Paginated": "Sidindelad",
   "Vertical Scrolling": "Vertikal rullning",
   "Horizontal Scrolling": "Horisontell rullning"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2006,5 +2006,8 @@
   "Book narration": "Bokens berättarröst",
   "Narration": "Berättarröst",
   "Includes narration": "Med berättarröst",
-  "Back to Read Aloud": "Tillbaka till uppläsningen"
+  "Back to Read Aloud": "Tillbaka till uppläsningen",
+  "Paginated": "Sidindelad",
+  "Vertical Scrolling": "Vertikal rullning",
+  "Horizontal Scrolling": "Horisontell rullning"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2006,5 +2006,8 @@
   "Book narration": "புத்தகத்தின் விவரிப்பு",
   "Narration": "விவரிப்பு",
   "Includes narration": "விவரிப்பு உள்ளடங்கும்",
-  "Back to Read Aloud": "உரக்க வாசித்தலுக்குத் திரும்பு"
+  "Back to Read Aloud": "உரக்க வாசித்தலுக்குத் திரும்பு",
+  "Paginated": "பக்கங்களாக",
+  "Vertical Scrolling": "செங்குத்து உருட்டல்",
+  "Horizontal Scrolling": "கிடைமட்ட உருட்டல்"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2007,7 +2007,6 @@
   "Narration": "விவரிப்பு",
   "Includes narration": "விவரிப்பு உள்ளடங்கும்",
   "Back to Read Aloud": "உரக்க வாசித்தலுக்குத் திரும்பு",
-  "Paginated": "பக்கங்களாக",
   "Vertical Scrolling": "செங்குத்து உருட்டல்",
   "Horizontal Scrolling": "கிடைமட்ட உருட்டல்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1960,5 +1960,8 @@
   "Book narration": "การบรรยายของหนังสือ",
   "Narration": "การบรรยาย",
   "Includes narration": "มีการบรรยายเสียง",
-  "Back to Read Aloud": "กลับไปที่การอ่านออกเสียง"
+  "Back to Read Aloud": "กลับไปที่การอ่านออกเสียง",
+  "Paginated": "แบ่งหน้า",
+  "Vertical Scrolling": "เลื่อนแนวตั้ง",
+  "Horizontal Scrolling": "เลื่อนแนวนอน"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1961,7 +1961,6 @@
   "Narration": "การบรรยาย",
   "Includes narration": "มีการบรรยายเสียง",
   "Back to Read Aloud": "กลับไปที่การอ่านออกเสียง",
-  "Paginated": "แบ่งหน้า",
   "Vertical Scrolling": "เลื่อนแนวตั้ง",
   "Horizontal Scrolling": "เลื่อนแนวนอน"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2006,5 +2006,8 @@
   "Book narration": "Kitap anlatımı",
   "Narration": "Anlatım",
   "Includes narration": "Anlatım içerir",
-  "Back to Read Aloud": "Sesli Okumaya Dön"
+  "Back to Read Aloud": "Sesli Okumaya Dön",
+  "Paginated": "Sayfalı",
+  "Vertical Scrolling": "Dikey Kaydırma",
+  "Horizontal Scrolling": "Yatay Kaydırma"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2007,7 +2007,6 @@
   "Narration": "Anlatım",
   "Includes narration": "Anlatım içerir",
   "Back to Read Aloud": "Sesli Okumaya Dön",
-  "Paginated": "Sayfalı",
   "Vertical Scrolling": "Dikey Kaydırma",
   "Horizontal Scrolling": "Yatay Kaydırma"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2098,5 +2098,8 @@
   "Book narration": "Озвучення книги",
   "Narration": "Озвучення",
   "Includes narration": "Містить озвучення",
-  "Back to Read Aloud": "Повернутися до читання вголос"
+  "Back to Read Aloud": "Повернутися до читання вголос",
+  "Paginated": "Посторінково",
+  "Vertical Scrolling": "Вертикальна прокрутка",
+  "Horizontal Scrolling": "Горизонтальна прокрутка"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2099,7 +2099,6 @@
   "Narration": "Озвучення",
   "Includes narration": "Містить озвучення",
   "Back to Read Aloud": "Повернутися до читання вголос",
-  "Paginated": "Посторінково",
   "Vertical Scrolling": "Вертикальна прокрутка",
   "Horizontal Scrolling": "Горизонтальна прокрутка"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2007,7 +2007,6 @@
   "Narration": "Ovozli oʻqish",
   "Includes narration": "Ovozli oʻqish mavjud",
   "Back to Read Aloud": "Ovoz chiqarib oʻqishga qaytish",
-  "Paginated": "Sahifalangan",
   "Vertical Scrolling": "Vertikal aylantirish",
   "Horizontal Scrolling": "Gorizontal aylantirish"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2006,5 +2006,8 @@
   "Book narration": "Kitobning ovozli oʻqishi",
   "Narration": "Ovozli oʻqish",
   "Includes narration": "Ovozli oʻqish mavjud",
-  "Back to Read Aloud": "Ovoz chiqarib oʻqishga qaytish"
+  "Back to Read Aloud": "Ovoz chiqarib oʻqishga qaytish",
+  "Paginated": "Sahifalangan",
+  "Vertical Scrolling": "Vertikal aylantirish",
+  "Horizontal Scrolling": "Gorizontal aylantirish"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1960,5 +1960,8 @@
   "Book narration": "Lời kể của sách",
   "Narration": "Lời kể",
   "Includes narration": "Có lời kể",
-  "Back to Read Aloud": "Quay lại đọc to"
+  "Back to Read Aloud": "Quay lại đọc to",
+  "Paginated": "Phân trang",
+  "Vertical Scrolling": "Cuộn dọc",
+  "Horizontal Scrolling": "Cuộn ngang"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1961,7 +1961,6 @@
   "Narration": "Lời kể",
   "Includes narration": "Có lời kể",
   "Back to Read Aloud": "Quay lại đọc to",
-  "Paginated": "Phân trang",
   "Vertical Scrolling": "Cuộn dọc",
   "Horizontal Scrolling": "Cuộn ngang"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1961,7 +1961,6 @@
   "Narration": "有声朗读",
   "Includes narration": "含有声朗读",
   "Back to Read Aloud": "回到朗读位置",
-  "Paginated": "分页",
   "Vertical Scrolling": "垂直滚动",
   "Horizontal Scrolling": "水平滚动"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1960,5 +1960,8 @@
   "Book narration": "书籍朗读",
   "Narration": "有声朗读",
   "Includes narration": "含有声朗读",
-  "Back to Read Aloud": "回到朗读位置"
+  "Back to Read Aloud": "回到朗读位置",
+  "Paginated": "分页",
+  "Vertical Scrolling": "垂直滚动",
+  "Horizontal Scrolling": "水平滚动"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1960,5 +1960,8 @@
   "Book narration": "書籍朗讀",
   "Narration": "有聲朗讀",
   "Includes narration": "含有聲朗讀",
-  "Back to Read Aloud": "回到朗讀位置"
+  "Back to Read Aloud": "回到朗讀位置",
+  "Paginated": "分頁",
+  "Vertical Scrolling": "垂直滾動",
+  "Horizontal Scrolling": "水平滾動"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1961,7 +1961,6 @@
   "Narration": "有聲朗讀",
   "Includes narration": "含有聲朗讀",
   "Back to Read Aloud": "回到朗讀位置",
-  "Paginated": "分頁",
   "Vertical Scrolling": "垂直滾動",
   "Horizontal Scrolling": "水平滾動"
 }

--- a/apps/readest-app/src/__tests__/document/fixed-layout-container-position.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-container-position.test.ts
@@ -18,4 +18,10 @@ describe('fixed-layout containerPosition (READEST-11)', () => {
     // fixed-EPUB books in scrolled mode (READEST-11); the setter must exist.
     expect(typeof descriptor?.set).toBe('function');
   });
+
+  it('observes scroll-direction for horizontal scroll mode (readest#4995)', () => {
+    const observed = (FixedLayout as unknown as { observedAttributes: string[] })
+      .observedAttributes;
+    expect(observed).toContain('scroll-direction');
+  });
 });

--- a/apps/readest-app/src/__tests__/document/fixed-layout-horizontal-scroll.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-horizontal-scroll.browser.test.ts
@@ -41,6 +41,19 @@ const mount = (dir: 'ltr' | 'rtl' = 'ltr', pages = 5): Renderer => {
 const pageEls = (renderer: HTMLElement): HTMLElement[] =>
   Array.from(renderer.shadowRoot!.querySelectorAll<HTMLElement>('.scroll-page'));
 
+// Index of the .scroll-page whose rect contains the viewport's horizontal
+// center, i.e. the page a reader would call "the current page".
+const visiblePageIndex = (renderer: HTMLElement): number => {
+  const host = renderer.getBoundingClientRect();
+  const centerX = host.left + host.width / 2;
+  return pageEls(renderer).findIndex((el) => {
+    const rect = el.getBoundingClientRect();
+    return rect.left <= centerX && rect.right >= centerX;
+  });
+};
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 let renderer: Renderer | null = null;
 
 afterEach(() => {
@@ -86,5 +99,47 @@ describe('fixed-layout horizontal scroll mode (readest#4995)', () => {
     const first = pages[0]!.getBoundingClientRect();
     const second = pages[1]!.getBoundingClientRect();
     expect(second.top).toBeGreaterThan(first.bottom - 1);
+  });
+
+  // RTL horizontal scroll must use the browser's negative-scrollLeft
+  // convention, which is keyed off the SCROLLING element's own computed
+  // `direction`, not a descendant's. Regression coverage for a bug where
+  // `direction: rtl` was set on a non-scrolling child container instead of
+  // the host: the host stayed 'ltr', scrollLeft never went negative
+  // (assignments clamped to 0), and every anchor round trip teleported the
+  // reader (readest#4995 review finding).
+  it('puts the RTL host in the negative-scrollLeft convention', () => {
+    renderer = mount('rtl');
+    expect(getComputedStyle(renderer).direction).toBe('rtl');
+    renderer.scrollLeft = -100;
+    expect(renderer.scrollLeft).toBeLessThan(0);
+  });
+
+  it('preserves the visible page across a scroll-gap change in RTL horizontal mode', async () => {
+    renderer = mount('rtl');
+    const pages = pageEls(renderer);
+    // Center page 2 in the viewport (scrolling deeper into the RTL strip,
+    // i.e. further negative scrollLeft).
+    const host = renderer.getBoundingClientRect();
+    const centerX = host.left + host.width / 2;
+    const target = pages[2]!.getBoundingClientRect();
+    const delta = target.left + target.width / 2 - centerX;
+    renderer.scrollLeft += delta;
+    // let the scroll settle (handleScrollEvent's idle debounce).
+    await wait(200);
+
+    const before = visiblePageIndex(renderer);
+    expect(before).toBe(2);
+
+    renderer.setAttribute('scroll-gap', '8');
+
+    expect(visiblePageIndex(renderer)).toBe(before);
+  });
+
+  it('clears the host direction when an RTL book switches back to vertical', () => {
+    renderer = mount('rtl');
+    expect(getComputedStyle(renderer).direction).toBe('rtl');
+    renderer.setAttribute('scroll-direction', 'vertical');
+    expect(getComputedStyle(renderer).direction).toBe('ltr');
   });
 });

--- a/apps/readest-app/src/__tests__/document/fixed-layout-horizontal-scroll.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-horizontal-scroll.browser.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Registers the <foliate-fxl> custom element (the fixed-layout / PDF renderer).
+import 'foliate-js/fixed-layout.js';
+
+// Horizontal scroll mode (readest#4995): pages joined at their left/right
+// edges along the reading direction, each scaled fit-to-height. Placeholder
+// geometry is laid out for every page up front, so these assertions do not
+// need to wait for iframe loads.
+
+const PAGE_HTML = `<!doctype html><html><head><style>
+  html, body { margin: 0; height: 1000px; }
+</style></head><body></body></html>`;
+
+const makeBook = (sectionCount: number, dir: 'ltr' | 'rtl' = 'ltr') => ({
+  dir,
+  rendition: { viewport: { width: 600, height: 1000 }, spread: 'none' },
+  sections: Array.from({ length: sectionCount }, () => ({
+    load: async () => ({ src: 'srcdoc', data: PAGE_HTML }),
+    linear: 'yes',
+  })),
+});
+
+type Renderer = HTMLElement & {
+  open(book: unknown): void;
+  next(distance?: number): Promise<void>;
+  containerPosition: number;
+};
+
+const mount = (dir: 'ltr' | 'rtl' = 'ltr', pages = 5): Renderer => {
+  const renderer = document.createElement('foliate-fxl') as Renderer;
+  renderer.style.width = '600px';
+  renderer.style.height = '400px';
+  renderer.setAttribute('flow', 'scrolled');
+  renderer.setAttribute('scroll-direction', 'horizontal');
+  document.body.append(renderer);
+  renderer.open(makeBook(pages, dir));
+  return renderer;
+};
+
+const pageEls = (renderer: HTMLElement): HTMLElement[] =>
+  Array.from(renderer.shadowRoot!.querySelectorAll<HTMLElement>('.scroll-page'));
+
+let renderer: Renderer | null = null;
+
+afterEach(() => {
+  renderer?.remove();
+  renderer = null;
+});
+
+describe('fixed-layout horizontal scroll mode (readest#4995)', () => {
+  it('lays pages side by side, scaled fit-to-height', () => {
+    renderer = mount('ltr');
+    const pages = pageEls(renderer);
+    expect(pages.length).toBe(5);
+    const first = pages[0]!.getBoundingClientRect();
+    const second = pages[1]!.getBoundingClientRect();
+    // fit-to-height: host is 400px tall, pages are 600x1000 -> 240x400.
+    expect(first.height).toBeCloseTo(400, 0);
+    expect(first.width).toBeCloseTo(240, 0);
+    // side by side, reading left to right.
+    expect(second.left).toBeGreaterThan(first.right - 1);
+    expect(second.top).toBeCloseTo(first.top, 0);
+    // the strip overflows horizontally, not vertically.
+    expect(renderer.scrollWidth).toBeGreaterThan(renderer.clientWidth);
+    expect(renderer.scrollHeight).toBeLessThanOrEqual(renderer.clientHeight + 1);
+  });
+
+  it('reverses the strip for RTL books and starts on page 0', () => {
+    renderer = mount('rtl');
+    const pages = pageEls(renderer);
+    const first = pages[0]!.getBoundingClientRect();
+    const second = pages[1]!.getBoundingClientRect();
+    // page 0 sits to the RIGHT of page 1 (manga order).
+    expect(first.left).toBeGreaterThan(second.left);
+    // reading start: page 0 visible in the viewport.
+    const host = renderer.getBoundingClientRect();
+    expect(first.right).toBeLessThanOrEqual(host.right + 1);
+    expect(first.left).toBeGreaterThanOrEqual(host.left - 1);
+  });
+
+  it('switches back to a vertical strip when scroll-direction resets', () => {
+    renderer = mount('ltr');
+    renderer.setAttribute('scroll-direction', 'vertical');
+    const pages = pageEls(renderer);
+    const first = pages[0]!.getBoundingClientRect();
+    const second = pages[1]!.getBoundingClientRect();
+    expect(second.top).toBeGreaterThan(first.bottom - 1);
+  });
+});

--- a/apps/readest-app/src/__tests__/document/fixed-layout-horizontal-scroll.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-horizontal-scroll.browser.test.ts
@@ -142,4 +142,56 @@ describe('fixed-layout horizontal scroll mode (readest#4995)', () => {
     renderer.setAttribute('scroll-direction', 'vertical');
     expect(getComputedStyle(renderer).direction).toBe('ltr');
   });
+
+  const waitFor = async (fn: () => boolean, timeout = 4000): Promise<void> => {
+    const start = performance.now();
+    while (!fn()) {
+      if (performance.now() - start > timeout) throw new Error('waitFor timed out');
+      await new Promise((r) => setTimeout(r, 30));
+    }
+  };
+
+  it('translates vertical wheel ticks into horizontal scrolling', () => {
+    renderer = mount('ltr');
+    const before = renderer.scrollLeft;
+    renderer.dispatchEvent(
+      new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true }),
+    );
+    expect(renderer.scrollLeft).toBeGreaterThan(before);
+    // ctrl+wheel is pinch zoom, never scrolling.
+    const zoomed = renderer.scrollLeft;
+    renderer.dispatchEvent(
+      new WheelEvent('wheel', { deltaY: 120, ctrlKey: true, bubbles: true, cancelable: true }),
+    );
+    expect(renderer.scrollLeft).toBe(zoomed);
+  });
+
+  it('scrolls RTL books leftward (negative scrollLeft) on wheel down', () => {
+    renderer = mount('rtl');
+    renderer.dispatchEvent(
+      new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true }),
+    );
+    expect(renderer.scrollLeft).toBeLessThan(0);
+  });
+
+  it('advances one viewport width on next()', async () => {
+    renderer = mount('ltr');
+    const before = renderer.scrollLeft;
+    await renderer.next();
+    // scrollBy uses smooth behavior; poll until it lands.
+    await waitFor(() => renderer!.scrollLeft >= before + renderer!.clientWidth - 1);
+  });
+
+  it('exposes containerPosition as reading progression on both directions', () => {
+    renderer = mount('ltr');
+    renderer.containerPosition = 100;
+    expect(renderer.scrollLeft).toBeCloseTo(100, 0);
+    expect(renderer.containerPosition).toBeCloseTo(100, 0);
+    renderer.remove();
+
+    renderer = mount('rtl');
+    renderer.containerPosition = 100;
+    expect(renderer.scrollLeft).toBeCloseTo(-100, 0);
+    expect(renderer.containerPosition).toBeCloseTo(100, 0);
+  });
 });

--- a/apps/readest-app/src/__tests__/document/fixed-layout-horizontal-scroll.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-horizontal-scroll.browser.test.ts
@@ -166,6 +166,27 @@ describe('fixed-layout horizontal scroll mode (readest#4995)', () => {
     expect(renderer.scrollLeft).toBe(zoomed);
   });
 
+  // Regression coverage for readest#4727 in horizontal mode: the iframe wheel
+  // listener installed by #loadScrollPage must translate the tick itself here,
+  // unlike vertical mode. In vertical mode the native scroll chain already
+  // consumes the tick, so JS must stay hands off. In horizontal mode the host
+  // only overflows horizontally, so a vertical wheel tick has nothing for the
+  // native chain to consume, and without a manual translation the first tick
+  // of every gesture over a page is silently swallowed.
+  it('translates a wheel landing on a page iframe into horizontal scroll', async () => {
+    renderer = mount('ltr');
+    await waitFor(() => {
+      const f = renderer!.shadowRoot?.querySelector<HTMLIFrameElement>('.scroll-page iframe');
+      return !!(f && f.style.display && f.style.display !== 'none' && f.contentDocument);
+    });
+    const iframe = renderer.shadowRoot!.querySelector<HTMLIFrameElement>('.scroll-page iframe')!;
+    const before = renderer.scrollLeft;
+    iframe.contentDocument!.dispatchEvent(
+      new WheelEvent('wheel', { deltaY: 120, bubbles: true, cancelable: true }),
+    );
+    expect(renderer.scrollLeft).toBeCloseTo(before + 120, 0);
+  });
+
   it('scrolls RTL books leftward (negative scrollLeft) on wheel down', () => {
     renderer = mount('rtl');
     renderer.dispatchEvent(

--- a/apps/readest-app/src/__tests__/document/fixed-layout-scroll-mode.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-scroll-mode.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from 'vitest';
 
 import { captureScrollModeAnchor, restoreScrollModeAnchor } from 'foliate-js/fixed-layout.js';
 
+// The helpers are 1-D interval math along the scroll axis: vertical mode feeds
+// offsetTop/offsetHeight, horizontal mode (readest#4995) feeds
+// offsetLeft/offsetWidth, so the fields are axis-neutral (start/size/scrollPos).
 describe('fixed-layout scroll mode anchor preservation', () => {
   it('captures the current intra-page offset', () => {
     const anchor = captureScrollModeAnchor(
       [
-        { index: 0, top: 0, height: 1000 },
-        { index: 1, top: 1008, height: 1000 },
+        { index: 0, start: 0, size: 1000 },
+        { index: 1, start: 1008, size: 1000 },
       ],
       1350,
       1,
@@ -16,15 +19,15 @@ describe('fixed-layout scroll mode anchor preservation', () => {
     expect(anchor).toEqual({
       index: 1,
       fraction: 0.342,
-      scrollTop: 1350,
+      scrollPos: 1350,
     });
   });
 
   it('restores the same intra-page position after page sizes change', () => {
     const anchor = captureScrollModeAnchor(
       [
-        { index: 0, top: 0, height: 1000 },
-        { index: 1, top: 1008, height: 1000 },
+        { index: 0, start: 0, size: 1000 },
+        { index: 1, start: 1008, size: 1000 },
       ],
       1350,
       1,
@@ -32,8 +35,8 @@ describe('fixed-layout scroll mode anchor preservation', () => {
 
     const restored = restoreScrollModeAnchor(
       [
-        { index: 0, top: 0, height: 900 },
-        { index: 1, top: 908, height: 900 },
+        { index: 0, start: 0, size: 900 },
+        { index: 1, start: 908, size: 900 },
       ],
       anchor,
       5000,
@@ -43,13 +46,26 @@ describe('fixed-layout scroll mode anchor preservation', () => {
     expect(restored).not.toBe(908);
   });
 
-  it('falls back to the previous scrollTop when the anchor page disappears', () => {
+  it('falls back to the previous scroll position when the anchor page disappears', () => {
     const restored = restoreScrollModeAnchor(
-      [{ index: 0, top: 0, height: 900 }],
-      { index: 1, fraction: 0.4, scrollTop: 1350 },
+      [{ index: 0, start: 0, size: 900 }],
+      { index: 1, fraction: 0.4, scrollPos: 1350 },
       1200,
     );
 
     expect(restored).toBe(1200);
+  });
+
+  it('anchors horizontal page metrics the same way (offsetLeft/offsetWidth)', () => {
+    const anchor = captureScrollModeAnchor(
+      [
+        { index: 0, start: 0, size: 240 },
+        { index: 1, start: 248, size: 480 },
+      ],
+      368,
+      0,
+    );
+
+    expect(anchor).toEqual({ index: 1, fraction: 0.25, scrollPos: 368 });
   });
 });

--- a/apps/readest-app/src/__tests__/document/fixed-layout-scroll-wheel-delta.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-scroll-wheel-delta.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeScrollWheelDelta } from 'foliate-js/fixed-layout.js';
+
+// Horizontal scroll mode translates vertical wheel ticks into horizontal
+// scrolling (pdf.js behavior, readest#4995). Translation must stand down for
+// pinch zoom (ctrl), horizontal-dominant trackpad pans, vertical mode, and
+// whenever the strip has vertical overflow for the tick to consume (a zoomed
+// page pans vertically first).
+describe('computeScrollWheelDelta', () => {
+  const base = {
+    deltaX: 0,
+    deltaY: 120,
+    ctrlKey: false,
+    horizontal: true,
+    rtl: false,
+    verticalOverflow: false,
+  };
+
+  it('translates vertical wheel to forward horizontal scroll (LTR)', () => {
+    expect(computeScrollWheelDelta(base)).toEqual({ left: 120 });
+  });
+
+  it('flips the sign for RTL books', () => {
+    expect(computeScrollWheelDelta({ ...base, rtl: true })).toEqual({ left: -120 });
+  });
+
+  it('scrolls backward on wheel up', () => {
+    expect(computeScrollWheelDelta({ ...base, deltaY: -120 })).toEqual({ left: -120 });
+  });
+
+  it('stands down in vertical mode', () => {
+    expect(computeScrollWheelDelta({ ...base, horizontal: false })).toBeNull();
+  });
+
+  it('stands down for pinch zoom (ctrl+wheel)', () => {
+    expect(computeScrollWheelDelta({ ...base, ctrlKey: true })).toBeNull();
+  });
+
+  it('stands down while the strip overflows vertically (zoomed page)', () => {
+    expect(computeScrollWheelDelta({ ...base, verticalOverflow: true })).toBeNull();
+  });
+
+  it('leaves horizontal-dominant trackpad pans to native scrolling', () => {
+    expect(computeScrollWheelDelta({ ...base, deltaX: 200, deltaY: 120 })).toBeNull();
+  });
+});

--- a/apps/readest-app/src/__tests__/services/view-settings-defaults.test.ts
+++ b/apps/readest-app/src/__tests__/services/view-settings-defaults.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_BOOK_LAYOUT } from '@/services/constants';
+
+describe('view settings defaults', () => {
+  it('defaults scrolledDirection to vertical (readest#4995)', () => {
+    expect(DEFAULT_BOOK_LAYOUT.scrolledDirection).toBe('vertical');
+  });
+});

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -874,6 +874,10 @@ const FoliateViewer: React.FC<{
       setScrollMargins({ top: 0, bottom: 0 });
     }
     viewRef.current?.renderer.setAttribute('gap', `${viewSettings.gapPercent}%`);
+    viewRef.current?.renderer.setAttribute(
+      'scroll-direction',
+      viewSettings.scrolledDirection === 'horizontal' ? 'horizontal' : 'vertical',
+    );
     if (viewSettings.scrolled) {
       viewRef.current?.renderer.setAttribute('flow', 'scrolled');
       if (viewSettings.noContinuousScroll) {

--- a/apps/readest-app/src/app/reader/components/ViewMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/ViewMenu.tsx
@@ -11,6 +11,7 @@ import { IoMdExpand } from 'react-icons/io';
 import { IoShareOutline } from 'react-icons/io5';
 import { TbArrowAutofitWidth } from 'react-icons/tb';
 import { TbColumns1, TbColumns2 } from 'react-icons/tb';
+import { TbCarouselVertical, TbCarouselHorizontal } from 'react-icons/tb';
 
 import {
   MAX_ZOOM_LEVEL,
@@ -334,23 +335,56 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
             >
               <button
                 title={_('Single Page')}
-                onClick={setSpreadMode.bind(null, 'none')}
+                onClick={() => {
+                  setSpreadMode('none');
+                  if (isScrolledMode) setScrolledMode(false);
+                }}
                 className={clsx(
                   'hover:bg-base-300 text-base-content rounded-full p-2',
-                  spreadMode === 'none' && 'bg-base-300/75',
+                  !isScrolledMode && spreadMode === 'none' && 'bg-base-300/75',
                 )}
               >
                 <TbColumns1 />
               </button>
               <button
                 title={_('Auto Spread')}
-                onClick={setSpreadMode.bind(null, 'auto')}
+                onClick={() => {
+                  setSpreadMode('auto');
+                  if (isScrolledMode) setScrolledMode(false);
+                }}
                 className={clsx(
                   'hover:bg-base-300 text-base-content rounded-full p-2',
-                  spreadMode === 'auto' && 'bg-base-300/75',
+                  !isScrolledMode && spreadMode === 'auto' && 'bg-base-300/75',
                 )}
               >
                 <TbColumns2 />
+              </button>
+              <button
+                title={_('Vertical Scrolling')}
+                onClick={() => {
+                  setScrolledDirection('vertical');
+                  if (!isScrolledMode) setScrolledMode(true);
+                }}
+                className={clsx(
+                  'hover:bg-base-300 text-base-content rounded-full p-2',
+                  isScrolledMode && scrolledDirection === 'vertical' && 'bg-base-300/75',
+                )}
+              >
+                <TbCarouselVertical />
+              </button>
+              <button
+                title={_('Horizontal Scrolling')}
+                onClick={() => {
+                  if (webtoonMode) setWebtoonMode(false);
+                  setScrolledDirection('horizontal');
+                  if (!isScrolledMode) setScrolledMode(true);
+                }}
+                className={clsx(
+                  'hover:bg-base-300 text-base-content rounded-full p-2',
+                  isScrolledMode && scrolledDirection === 'horizontal' && 'bg-base-300/75',
+                )}
+              >
+                <TbCarouselHorizontal />
               </button>
               <div className='bg-base-300 mx-2 h-6 w-[1px]' />
               <button
@@ -389,32 +423,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
 
       <MenuItem label={_('Font & Layout')} shortcut='Shift+F' onClick={openFontLayoutMenu} />
 
-      {bookData.isFixedLayout ? (
-        <>
-          <MenuItem
-            label={_('Paginated')}
-            Icon={!isScrolledMode ? MdCheck : undefined}
-            onClick={() => setScrolledMode(false)}
-          />
-          <MenuItem
-            label={_('Vertical Scrolling')}
-            Icon={isScrolledMode && scrolledDirection === 'vertical' ? MdCheck : undefined}
-            onClick={() => {
-              setScrolledDirection('vertical');
-              setScrolledMode(true);
-            }}
-          />
-          <MenuItem
-            label={_('Horizontal Scrolling')}
-            Icon={isScrolledMode && scrolledDirection === 'horizontal' ? MdCheck : undefined}
-            onClick={() => {
-              if (webtoonMode) setWebtoonMode(false);
-              setScrolledDirection('horizontal');
-              setScrolledMode(true);
-            }}
-          />
-        </>
-      ) : (
+      {!bookData.isFixedLayout && (
         <MenuItem
           label={_('Scrolled Mode')}
           shortcut='Shift+J'

--- a/apps/readest-app/src/app/reader/components/ViewMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/ViewMenu.tsx
@@ -64,6 +64,9 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
 
   const { themeMode, isDarkMode, setThemeMode } = useThemeStore();
   const [isScrolledMode, setScrolledMode] = useState(viewSettings!.scrolled);
+  const [scrolledDirection, setScrolledDirection] = useState(
+    viewSettings!.scrolledDirection ?? 'vertical',
+  );
   const [webtoonMode, setWebtoonMode] = useState(viewSettings!.webtoonMode ?? false);
   const [isParagraphMode, setParagraphMode] = useState(
     viewSettings?.paragraphMode?.enabled ?? false,
@@ -139,6 +142,15 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
   };
 
   useEffect(() => {
+    if (scrolledDirection === (viewSettings.scrolledDirection ?? 'vertical')) return;
+    viewSettings.scrolledDirection = scrolledDirection;
+    getView(bookKey)?.renderer.setAttribute('scroll-direction', scrolledDirection);
+    setViewSettings(bookKey, viewSettings);
+    saveViewSettings(envConfig, bookKey, 'scrolledDirection', scrolledDirection, false, false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scrolledDirection]);
+
+  useEffect(() => {
     if (isScrolledMode === viewSettings!.scrolled) return;
     viewSettings!.scrolled = isScrolledMode;
     if (!isScrolledMode && webtoonMode) setWebtoonMode(false);
@@ -162,6 +174,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
       // scrolled / zoomLevel effects rather than duplicating their renderer wiring.
       if (!isScrolledMode) setScrolledMode(true);
       if (zoomLevel !== 100) setZoomLevel(100);
+      if (scrolledDirection !== 'vertical') setScrolledDirection('vertical');
       saveViewSettings(envConfig, bookKey, 'scrolled', true, false, false);
     }
     setViewSettings(bookKey, viewSettings);
@@ -376,12 +389,39 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
 
       <MenuItem label={_('Font & Layout')} shortcut='Shift+F' onClick={openFontLayoutMenu} />
 
-      <MenuItem
-        label={_('Scrolled Mode')}
-        shortcut='Shift+J'
-        Icon={isScrolledMode ? MdCheck : undefined}
-        onClick={toggleScrolledMode}
-      />
+      {bookData.isFixedLayout ? (
+        <>
+          <MenuItem
+            label={_('Paginated')}
+            Icon={!isScrolledMode ? MdCheck : undefined}
+            onClick={() => setScrolledMode(false)}
+          />
+          <MenuItem
+            label={_('Vertical Scrolling')}
+            Icon={isScrolledMode && scrolledDirection === 'vertical' ? MdCheck : undefined}
+            onClick={() => {
+              setScrolledDirection('vertical');
+              setScrolledMode(true);
+            }}
+          />
+          <MenuItem
+            label={_('Horizontal Scrolling')}
+            Icon={isScrolledMode && scrolledDirection === 'horizontal' ? MdCheck : undefined}
+            onClick={() => {
+              if (webtoonMode) setWebtoonMode(false);
+              setScrolledDirection('horizontal');
+              setScrolledMode(true);
+            }}
+          />
+        </>
+      ) : (
+        <MenuItem
+          label={_('Scrolled Mode')}
+          shortcut='Shift+J'
+          Icon={isScrolledMode ? MdCheck : undefined}
+          onClick={toggleScrolledMode}
+        />
+      )}
 
       <MenuItem
         label={_('Auto Scroll')}

--- a/apps/readest-app/src/app/reader/components/ViewMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/ViewMenu.tsx
@@ -147,7 +147,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
     viewSettings.scrolledDirection = scrolledDirection;
     getView(bookKey)?.renderer.setAttribute('scroll-direction', scrolledDirection);
     setViewSettings(bookKey, viewSettings);
-    saveViewSettings(envConfig, bookKey, 'scrolledDirection', scrolledDirection, false, false);
+    saveViewSettings(envConfig, bookKey, 'scrolledDirection', scrolledDirection, true, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrolledDirection]);
 

--- a/apps/readest-app/src/app/reader/hooks/usePagination.ts
+++ b/apps/readest-app/src/app/reader/hooks/usePagination.ts
@@ -150,9 +150,10 @@ export const viewPagination = (
       default: {
         const forward = !(side === 'left' || side === 'up');
         // Snap so the view's bottom edge lands between lines (not for vertical flow).
-        const snapped = viewSettings.vertical
-          ? distance
-          : snapScrolledDistanceToLines(view, distance, forward);
+        const snapped =
+          viewSettings.vertical || viewSettings.scrolledDirection === 'horizontal'
+            ? distance
+            : snapScrolledDistanceToLines(view, distance, forward);
         return forward ? view.next(snapped) : view.prev(snapped);
       }
     }

--- a/apps/readest-app/src/app/reader/hooks/usePagination.ts
+++ b/apps/readest-app/src/app/reader/hooks/usePagination.ts
@@ -151,7 +151,9 @@ export const viewPagination = (
         const forward = !(side === 'left' || side === 'up');
         // Snap so the view's bottom edge lands between lines (not for vertical flow).
         const snapped =
-          viewSettings.vertical || viewSettings.scrolledDirection === 'horizontal'
+          viewSettings.vertical ||
+          (viewSettings.scrolledDirection === 'horizontal' &&
+            view.book.rendition?.layout === 'pre-paginated')
             ? distance
             : snapScrolledDistanceToLines(view, distance, forward);
         return forward ? view.next(snapped) : view.prev(snapped);

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -296,6 +296,7 @@ export const DEFAULT_BOOK_LAYOUT: BookLayout = {
   compactMarginRightPx: 16,
   gapPercent: 5,
   scrolled: false,
+  scrolledDirection: 'vertical',
   webtoonMode: false,
   noContinuousScroll: false,
   disableClick: false,

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -207,6 +207,7 @@ export interface BookLayout {
   compactMarginPx?: number; // deprecated
   gapPercent: number;
   scrolled: boolean;
+  scrolledDirection: 'vertical' | 'horizontal';
   webtoonMode: boolean;
   noContinuousScroll: boolean;
   disableClick: boolean;


### PR DESCRIPTION
Closes #4995

Adds a horizontal scrolling mode for fixed-layout books (PDF, fixed-layout EPUB, CBZ comics): pages joined at their left/right edges along the reading direction, each scaled fit-to-height, with smooth native scrolling — like pdf.js's horizontal scroll mode.

**Depends on readest/foliate-js#65 — merge that first** (this PR's submodule pointer references its head commit).

## What's included

- Pages flow along the reading direction: LTR books scroll left-to-right, RTL books (manga) right-to-left, starting on page 0.
- Fit-to-height at 100% zoom; pinch and zoom level scale relative to that, and a zoomed page taller than the viewport pans vertically (mirror of vertical mode's horizontal panning).
- Lazy loading, the page scheduler, overlayers, and annotations reuse the existing scroll-mode machinery unchanged.
- Mouse wheel: vertical ticks translate to horizontal scrolling, standing down for ctrl pinch-zoom, trackpad horizontal pans, and vertical overflow (a zoomed page pans vertically first). Works for gestures starting over a page too (the #4727 iframe listener translates in horizontal mode where native chaining cannot).
- next/prev (tap zones, arrow keys, volume keys) advance one viewport width; Auto Scroll advances in reading order on both LTR and RTL via the renderer's progression-space `containerPosition` contract.
- View menu: the fixed-layout icon row's first group is now a 4-way selector — Single Page, Auto Spread, Vertical Scrolling, Horizontal Scrolling (Tabler carousel icons, title tooltips); reflowable books keep the plain Scrolled Mode toggle. Webtoon Mode stays vertical (two-way interlock). Shift+J toggles paginated/scrolled, reusing the last direction.
- New per-book view setting `scrolledDirection` (`'vertical'` default) saved per-book like zoomMode/spreadMode; old configs and clients are unaffected.
- i18n: `Vertical Scrolling` / `Horizontal Scrolling` translated across all 33 locales.

## Testing

- 17 new tests written failing-first: axis-neutral anchor unit tests, `computeScrollWheelDelta` unit tests, settings default, and real-Chromium browser tests covering side-by-side fit-to-height layout, RTL ordering + negative-scrollLeft convention + anchor round trips, wheel translation on both host and iframe paths, `next()` distance, `containerPosition` semantics, and direction switching.
- Full suites green: 8410 unit, 347 browser, Biome + tsgo clean.
- Manually verified on web against a real 2752-page PDF: mode switching preserves position, wheel and arrow navigation, zoom, and the vertical/paginated round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)