### PR TITLE
fix(library): select books in the recently read shelf and pull it with the grid

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/recent-shelf-select-mode.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/recent-shelf-select-mode.test.tsx
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { Book } from '@/types/book';
+import { BookMetadata } from '@/libs/document';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+// BookItem pulls in Env/Auth/router/settings providers; the selection wiring
+// under test lives in RecentShelf itself, so render a marker stub that records
+// the select-mode props each slide passes down.
+vi.mock('@/app/library/components/BookItem', () => ({
+  default: ({
+    book,
+    isSelectMode,
+    bookSelected,
+  }: {
+    book: Book;
+    isSelectMode: boolean;
+    bookSelected: boolean;
+  }) => (
+    <div
+      data-testid={`book-item-${book.hash}`}
+      data-select-mode={isSelectMode}
+      data-selected={bookSelected}
+    />
+  ),
+}));
+
+import RecentShelf from '@/app/library/components/RecentShelf';
+
+// jsdom has no ResizeObserver; the shelf only uses it to place scroll arrows.
+beforeEach(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+const createBook = (hash: string): Book =>
+  ({
+    hash,
+    format: 'EPUB',
+    title: `Book ${hash}`,
+    author: 'Test Author',
+    createdAt: 1000,
+    updatedAt: 2000,
+    progress: [1, 100],
+    metadata: {} as BookMetadata,
+  }) as Book;
+
+const noop = () => {};
+
+const baseProps = {
+  books: [createBook('aaa'), createBook('bbb')],
+  coverFit: 'crop' as const,
+  autoColumns: true,
+  fixedColumns: 6,
+  handleBookUpload: noop,
+  handleBookDownload: noop,
+  showBookDetailsModal: noop,
+  showTimeRemaining: false,
+  isSelectMode: false,
+  selectedBooks: new Set<string>(),
+  toggleSelection: noop,
+  handleSetSelectMode: noop,
+};
+
+const tapSlide = (title: string) => {
+  const slide = screen.getByRole('button', { name: title });
+  fireEvent.pointerDown(slide, { pointerId: 1, clientX: 10, clientY: 10, pointerType: 'touch' });
+  fireEvent.pointerUp(slide, { pointerId: 1, clientX: 10, clientY: 10, pointerType: 'touch' });
+};
+
+describe('RecentShelf select mode', () => {
+  it('tap toggles selection instead of opening the book while in select mode', () => {
+    const onOpenBook = vi.fn();
+    const toggleSelection = vi.fn();
+    render(
+      <RecentShelf
+        {...baseProps}
+        isSelectMode
+        onOpenBook={onOpenBook}
+        toggleSelection={toggleSelection}
+      />,
+    );
+
+    tapSlide('Book aaa');
+
+    expect(toggleSelection).toHaveBeenCalledWith('aaa');
+    expect(onOpenBook).not.toHaveBeenCalled();
+  });
+
+  it('tap opens the book when not in select mode', () => {
+    const onOpenBook = vi.fn();
+    const toggleSelection = vi.fn();
+    render(
+      <RecentShelf {...baseProps} onOpenBook={onOpenBook} toggleSelection={toggleSelection} />,
+    );
+
+    tapSlide('Book aaa');
+
+    expect(onOpenBook).toHaveBeenCalledWith(baseProps.books[0]);
+    expect(toggleSelection).not.toHaveBeenCalled();
+  });
+
+  it('long-press enters select mode and selects the book, like the grid', () => {
+    vi.useFakeTimers();
+    const onOpenBook = vi.fn();
+    const toggleSelection = vi.fn();
+    const handleSetSelectMode = vi.fn();
+    render(
+      <RecentShelf
+        {...baseProps}
+        onOpenBook={onOpenBook}
+        toggleSelection={toggleSelection}
+        handleSetSelectMode={handleSetSelectMode}
+      />,
+    );
+
+    const slide = screen.getByRole('button', { name: 'Book aaa' });
+    fireEvent.pointerDown(slide, { pointerId: 1, clientX: 10, clientY: 10, pointerType: 'touch' });
+    vi.advanceTimersByTime(600);
+    fireEvent.pointerUp(slide, { pointerId: 1, clientX: 10, clientY: 10, pointerType: 'touch' });
+
+    expect(handleSetSelectMode).toHaveBeenCalledWith(true);
+    expect(toggleSelection).toHaveBeenCalledWith('aaa');
+    expect(onOpenBook).not.toHaveBeenCalled();
+  });
+
+  it('keyboard activation toggles selection while in select mode', () => {
+    const onOpenBook = vi.fn();
+    const toggleSelection = vi.fn();
+    render(
+      <RecentShelf
+        {...baseProps}
+        isSelectMode
+        onOpenBook={onOpenBook}
+        toggleSelection={toggleSelection}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Book bbb' }), { key: 'Enter' });
+
+    expect(toggleSelection).toHaveBeenCalledWith('bbb');
+    expect(onOpenBook).not.toHaveBeenCalled();
+  });
+
+  it('passes selection state down so the checkmark badge renders', () => {
+    render(
+      <RecentShelf
+        {...baseProps}
+        isSelectMode
+        selectedBooks={new Set(['bbb'])}
+        onOpenBook={noop}
+      />,
+    );
+
+    expect(screen.getByTestId('book-item-aaa').dataset['selectMode']).toBe('true');
+    expect(screen.getByTestId('book-item-aaa').dataset['selected']).toBe('false');
+    expect(screen.getByTestId('book-item-bbb').dataset['selected']).toBe('true');
+  });
+});

--- a/apps/readest-app/src/__tests__/hooks/usePullToRefresh.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/usePullToRefresh.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { useRef } from 'react';
+import { usePullToRefresh } from '@/hooks/usePullToRefresh';
+
+// jsdom has no Touch/TouchEvent constructors; the hook only reads
+// touches[0].clientX/clientY, so a plain Event with the fields grafted on is a
+// faithful stand-in.
+const touchEvent = (type: string, x: number, y: number): Event => {
+  const e = new Event(type, { bubbles: true });
+  const touch = { clientX: x, clientY: y };
+  Object.assign(e, { touches: [touch], changedTouches: [touch] });
+  return e;
+};
+
+// The library scroller holds the recently-read shelf (Virtuoso Header) and the
+// book grid (Virtuoso List) as siblings, each tagged .transform-wrapper. The
+// pull gesture must drag every wrapper, not just the first, or the shelf stays
+// pinned while the grid slides down.
+const Harness = ({ onRefresh }: { onRefresh: () => void }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  usePullToRefresh(ref, onRefresh);
+  return (
+    <div>
+      <div data-testid='scroller' ref={ref}>
+        <div data-testid='recent-shelf' className='transform-wrapper' />
+        <div data-testid='book-grid' className='transform-wrapper' />
+      </div>
+    </div>
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('usePullToRefresh', () => {
+  it('drags every transform-wrapper in the scroller during the pull', () => {
+    const { getByTestId } = render(<Harness onRefresh={() => {}} />);
+    const scroller = getByTestId('scroller');
+
+    scroller.dispatchEvent(touchEvent('touchstart', 0, 0));
+    scroller.dispatchEvent(touchEvent('touchmove', 0, 50));
+
+    const shelfTransform = getByTestId('recent-shelf').style.transform;
+    const gridTransform = getByTestId('book-grid').style.transform;
+    expect(gridTransform).toMatch(/^translate3d\(0, .+px, 0\)$/);
+    expect(shelfTransform).toBe(gridTransform);
+  });
+
+  it('resets every transform-wrapper when the pull is released early', () => {
+    const { getByTestId } = render(<Harness onRefresh={() => {}} />);
+    const scroller = getByTestId('scroller');
+
+    scroller.dispatchEvent(touchEvent('touchstart', 0, 0));
+    scroller.dispatchEvent(touchEvent('touchmove', 0, 50));
+    scroller.dispatchEvent(touchEvent('touchend', 0, 50));
+
+    expect(getByTestId('recent-shelf').style.transform).toBe('translateY(0)');
+    expect(getByTestId('book-grid').style.transform).toBe('translateY(0)');
+  });
+});

--- a/apps/readest-app/src/app/library/components/Bookshelf.tsx
+++ b/apps/readest-app/src/app/library/components/Bookshelf.tsx
@@ -243,6 +243,10 @@ const Bookshelf: React.FC<BookshelfProps> = ({
 
   const { setCurrentBookshelf, setLibrary, updateBooks } = useLibraryStore();
   const { setSelectedBooks, getSelectedBooks, toggleSelectedBook } = useLibraryStore();
+  // The raw Set from the store: its identity only changes when the selection
+  // does, so memos keyed on it stay stable across unrelated re-renders
+  // (getSelectedBooks() allocates a fresh array per call).
+  const { selectedBooks: selectedBookSet } = useLibraryStore();
   const { getGroupName } = useLibraryStore();
 
   const uiLanguage = localStorage?.getItem('i18nextLng') || '';
@@ -797,14 +801,11 @@ const Bookshelf: React.FC<BookshelfProps> = ({
     [libraryBooks],
   );
 
-  // A top-level quick-resume strip: hidden while searching, inside a group,
-  // selecting, or when nothing has been read yet.
+  // A top-level quick-resume strip: hidden while searching, inside a group, or
+  // when nothing has been read yet. It stays up in select mode so shelf books
+  // can be selected in place, just like the grid.
   const showRecentShelf =
-    settings.libraryRecentShelfEnabled &&
-    !queryTerm &&
-    !groupId &&
-    !isSelectMode &&
-    recentBooks.length > 0;
+    settings.libraryRecentShelfEnabled && !queryTerm && !groupId && recentBooks.length > 0;
 
   const recentShelfHeader = useMemo(
     () =>
@@ -814,7 +815,11 @@ const Bookshelf: React.FC<BookshelfProps> = ({
           coverFit={coverFit as LibraryCoverFitType}
           autoColumns={settings.libraryAutoColumns}
           fixedColumns={settings.libraryColumns}
+          isSelectMode={isSelectMode}
+          selectedBooks={selectedBookSet}
           onOpenBook={openRecentBook}
+          toggleSelection={toggleSelection}
+          handleSetSelectMode={handleSetSelectMode}
           handleBookUpload={handleBookUpload}
           handleBookDownload={handleBookDownload}
           showBookDetailsModal={handleShowDetailsBook}
@@ -827,7 +832,11 @@ const Bookshelf: React.FC<BookshelfProps> = ({
       coverFit,
       settings.libraryAutoColumns,
       settings.libraryColumns,
+      isSelectMode,
+      selectedBookSet,
       openRecentBook,
+      toggleSelection,
+      handleSetSelectMode,
       handleBookUpload,
       handleBookDownload,
       handleShowDetailsBook,

--- a/apps/readest-app/src/app/library/components/RecentShelf.tsx
+++ b/apps/readest-app/src/app/library/components/RecentShelf.tsx
@@ -19,7 +19,11 @@ interface RecentShelfProps {
   // Mirror the bookshelf grid's column model so covers are the same size.
   autoColumns: boolean;
   fixedColumns: number;
+  isSelectMode: boolean;
+  selectedBooks: ReadonlySet<string>;
   onOpenBook: (book: Book) => void;
+  toggleSelection: (hash: string) => void;
+  handleSetSelectMode: (selectMode: boolean) => void;
   handleBookUpload: (book: Book) => void;
   handleBookDownload: (book: Book, options?: { redownload?: boolean; queued?: boolean }) => void;
   showBookDetailsModal: (book: Book) => void;
@@ -39,34 +43,57 @@ const RECENT_SLIDE_WIDTH =
 type RecentSlideProps = Pick<
   RecentShelfProps,
   | 'coverFit'
+  | 'isSelectMode'
   | 'onOpenBook'
+  | 'toggleSelection'
+  | 'handleSetSelectMode'
   | 'handleBookUpload'
   | 'handleBookDownload'
   | 'showBookDetailsModal'
   | 'showTimeRemaining'
-> & { book: Book };
+> & { book: Book; bookSelected: boolean };
 
 const RecentSlide: React.FC<RecentSlideProps> = ({
   book,
   coverFit,
+  isSelectMode,
+  bookSelected,
   onOpenBook,
+  toggleSelection,
+  handleSetSelectMode,
   handleBookUpload,
   handleBookDownload,
   showBookDetailsModal,
   showTimeRemaining,
 }) => {
+  // Same select vocabulary as the grid (`BookshelfItem`): long-press enters
+  // select mode and selects; while in select mode a tap toggles instead of
+  // opening the book.
+  const handleSelect = () => {
+    if (!isSelectMode) handleSetSelectMode(true);
+    toggleSelection(book.hash);
+  };
+
+  const handleActivate = () => {
+    if (isSelectMode) {
+      handleSelect();
+    } else {
+      onOpenBook(book);
+    }
+  };
+
   // Pointer-based tap, exactly like the grid (`BookItem` stops click
   // propagation). A swipe-to-scroll moves past useLongPress's moveThreshold and
   // cancels the tap, so horizontal scrolling never opens a book.
-  const { pressing, handlers } = useLongPress({ onTap: () => onOpenBook(book) }, [
-    book,
-    onOpenBook,
-  ]);
+  const { pressing, handlers } = useLongPress(
+    { onTap: handleActivate, onLongPress: handleSelect },
+    [book, isSelectMode, onOpenBook, toggleSelection, handleSetSelectMode],
+  );
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      onOpenBook(book);
+      handleActivate();
     }
   };
 
@@ -92,8 +119,8 @@ const RecentSlide: React.FC<RecentSlideProps> = ({
             mode='grid'
             book={book}
             coverFit={coverFit}
-            isSelectMode={false}
-            bookSelected={false}
+            isSelectMode={isSelectMode}
+            bookSelected={bookSelected}
             transferProgress={null}
             handleBookUpload={handleBookUpload}
             handleBookDownload={handleBookDownload}
@@ -118,7 +145,11 @@ const RecentShelf: React.FC<RecentShelfProps> = ({
   coverFit,
   autoColumns,
   fixedColumns,
+  isSelectMode,
+  selectedBooks,
   onOpenBook,
+  toggleSelection,
+  handleSetSelectMode,
   handleBookUpload,
   handleBookDownload,
   showBookDetailsModal,
@@ -180,7 +211,10 @@ const RecentShelf: React.FC<RecentShelfProps> = ({
   };
 
   return (
-    <div className='recent-shelf select-none pt-3'>
+    // `transform-wrapper` opts the shelf into the pull-to-refresh drag: the
+    // pull translates every wrapper in the scroller, and the shelf lives in the
+    // Virtuoso Header — a sibling of the book list, not a descendant.
+    <div className='recent-shelf transform-wrapper select-none pt-3'>
       <h3 className='text-base-content/60 mb-1 ps-4 text-xs font-medium sm:ps-6'>
         {_('Recently read')}
       </h3>
@@ -200,7 +234,11 @@ const RecentShelf: React.FC<RecentShelfProps> = ({
                 key={book.hash}
                 book={book}
                 coverFit={coverFit}
+                isSelectMode={isSelectMode}
+                bookSelected={selectedBooks.has(book.hash)}
                 onOpenBook={onOpenBook}
+                toggleSelection={toggleSelection}
+                handleSetSelectMode={handleSetSelectMode}
                 handleBookUpload={handleBookUpload}
                 handleBookDownload={handleBookDownload}
                 showBookDetailsModal={showBookDetailsModal}

--- a/apps/readest-app/src/hooks/usePullToRefresh.ts
+++ b/apps/readest-app/src/hooks/usePullToRefresh.ts
@@ -24,6 +24,10 @@ function createApprFunction(MAX: number, k: number) {
   return (x: number) => MAX * (1 - Math.exp((-k * x) / MAX));
 }
 
+function getWrappers(el: HTMLElement): HTMLElement[] {
+  return Array.from(el.querySelectorAll<HTMLElement>('.transform-wrapper'));
+}
+
 export const usePullToRefresh = (
   ref: React.RefObject<HTMLDivElement | null>,
   onTriggerStage1: () => Promise<void> | void,
@@ -79,8 +83,10 @@ export const usePullToRefresh = (
         // Update loading spinner position and opacity with parallax if it exists
         updateLoadingSpinnerPosition(parentEl, transformValue, dy);
 
-        const wrapper = el.querySelector('.transform-wrapper') as HTMLElement;
-        if (wrapper) {
+        // The scroller can hold several transform targets (e.g. the recently
+        // read shelf in the Virtuoso Header plus the book list) — drag them
+        // all in lockstep so the whole shelf follows the pull.
+        for (const wrapper of getWrappers(el)) {
           wrapper.style.transform = `translate3d(0, ${transformValue}px, 0)`;
         }
       }
@@ -124,7 +130,7 @@ export const usePullToRefresh = (
         const el = ref.current;
         if (!el) return;
 
-        const wrapper = el.querySelector('.transform-wrapper') as HTMLElement;
+        const wrappers = getWrappers(el);
         const parentEl = el.parentNode as HTMLDivElement;
 
         const y = endEvent.changedTouches[0]!.clientY;
@@ -143,7 +149,7 @@ export const usePullToRefresh = (
           const transformValue = appr(dy);
           const targetPosition = Math.min(transformValue, MAX_LOADING_POSITION);
 
-          if (wrapper) {
+          for (const wrapper of wrappers) {
             wrapper.style.transition = 'transform 0.2s ease-out';
             wrapper.style.transform = `translateY(${targetPosition}px)`;
           }
@@ -177,7 +183,7 @@ export const usePullToRefresh = (
             // Update both wrapper and spinner position to maintain parallax consistency
             const newTransform = targetPosition + pullDelta;
             if (newTransform > 0) {
-              if (wrapper) {
+              for (const wrapper of wrappers) {
                 wrapper.style.transform = `translateY(${newTransform}px)`;
               }
 
@@ -194,7 +200,7 @@ export const usePullToRefresh = (
 
             // User pulled up significantly, reset
             if (pullDelta < -30) {
-              if (wrapper) {
+              for (const wrapper of wrappers) {
                 wrapper.style.transition = 'transform 0.3s ease-out';
                 wrapper.style.transform = 'translateY(0)';
               }
@@ -215,19 +221,21 @@ export const usePullToRefresh = (
           } finally {
             isLoading = false;
             hideLoadingSpinner(parentEl);
-            if (wrapper) {
+            for (const wrapper of wrappers) {
               wrapper.style.transition = 'transform 0.3s ease-out';
               wrapper.style.transform = 'translateY(0)';
-              setTimeout(() => {
-                if (wrapper) wrapper.style.transition = '';
-              }, 300);
             }
+            setTimeout(() => {
+              for (const wrapper of wrappers) {
+                wrapper.style.transition = '';
+              }
+            }, 300);
             el.removeEventListener('touchstart', handleLoadingTouchStart);
             el.removeEventListener('touchmove', handleLoadingTouchMove);
           }
         } else {
           hideLoadingSpinner(parentEl);
-          if (wrapper) {
+          for (const wrapper of wrappers) {
             wrapper.style.transition = 'transform 0.2s';
             wrapper.style.transform = 'translateY(0)';
           }


### PR DESCRIPTION
## Summary

Two fixes for the recently read shelf at the top of the library:

- **Selection**: entering select mode unmounted the whole shelf, and its slides had no selection wiring (tap always opened the book, `BookItem` received a hardcoded `isSelectMode={false}`), so shelf books could not be selected at all. The shelf now stays mounted in select mode and mirrors the grid's vocabulary: tap toggles selection, long press enters select mode and selects, keyboard activation follows the same path, and the checkmark badge/dim overlay render. Since shelf slides share hashes with their grid counterparts, selecting in either place marks both, and all bulk actions work on shelf-selected books.
- **Pull to refresh** (Android/iOS): the pull translated only the first `.transform-wrapper` in the scroller, which is the Virtuoso List, so the shelf, rendered in the Virtuoso Header as a *sibling* of the list, stayed pinned while the grid slid down. `usePullToRefresh` now drags every wrapper in lockstep through all gesture stages (drag, snap-to-loading, drag-while-loading, pull-up cancel, reset), and the shelf root opts in with the `transform-wrapper` class.

The shelf selection state is passed as the store's `selectedBooks` `Set` (stable identity between selection changes) rather than `getSelectedBooks()`, which allocates a fresh array per call and would churn the Virtuoso Header identity on every render.

## Verification

- New unit tests, written failing-first:
  - `recent-shelf-select-mode.test.tsx` drives the real `useLongPress` pointer path: tap-toggles vs tap-opens, long-press entry, keyboard activation, checkmark props.
  - `usePullToRefresh.test.tsx` renders a scroller with two wrappers and asserts both are dragged and reset together.
- Full suite green (8537 tests), `pnpm lint` clean.
- **Device-verified on a Xiaomi 13** (adb + CDP `Input.synthesizeScrollGesture`, since adb swipes deliver no `touchmove`): a per-frame recorder sampled both wrappers during a real pull. Across 411 frames (102 actively dragging), the shelf transform was bit-identical to the grid transform in every frame, peaked at ~86px per the Android damping curve, the refresh spinner appeared, and both reset to `translateY(0px)` after the refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)