### PR TITLE
fix(library): make search history chips translucent like the search input

### DIFF
--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -1828,26 +1828,18 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
         !librarySearchQuery.trim() &&
         librarySearchHistory.length > 0 && (
           <div className='relative my-1 flex shrink-0 items-center px-4 sm:px-6'>
-            <div
-              aria-hidden='true'
-              className='from-base-200 eink:hidden sm:start-6 pointer-events-none absolute start-4 top-0 z-[1] h-full w-3 bg-gradient-to-r to-transparent'
-            />
-            <div className='no-scrollbar flex flex-1 gap-1.5 overflow-x-auto'>
+            <div className='no-scrollbar not-eink:[mask-image:linear-gradient(to_right,transparent,black_12px,black_calc(100%_-_12px),transparent)] flex flex-1 gap-1.5 overflow-x-auto'>
               {librarySearchHistory.map((term) => (
                 <button
                   key={term}
                   type='button'
                   onClick={() => handleSearchQueryApply(term)}
-                  className='hover:bg-base-300/50 text-base-content/70 bg-base-100 max-w-[60%] flex-shrink-0 whitespace-nowrap rounded-full px-3 py-0.5 text-xs'
+                  className='bg-base-300/45 hover:bg-base-300/70 text-base-content/70 max-w-[60%] flex-shrink-0 whitespace-nowrap rounded-full px-3 py-0.5 text-xs'
                 >
                   <p className='truncate'>{term}</p>
                 </button>
               ))}
             </div>
-            <div
-              aria-hidden='true'
-              className='from-base-200 eink:hidden sm:end-14 pointer-events-none absolute end-12 top-0 z-[1] h-full w-6 bg-gradient-to-l to-transparent'
-            />
             <button
               type='button'
               onClick={() => {


### PR DESCRIPTION
## Problem

With a custom background texture on the library page, the search history chips rendered as opaque `bg-base-100` pills on top of the image, while the search input above them is translucent (`bg-base-300/45`). The scroll edge fade elements also painted solid `base-200` gradients over the texture, visible as a smear right before the clear button.

| Before | After |
| --- | --- |
| Opaque chips + gradient smear over the texture | Chips show the texture through at the same 45% tint as the input; edges fade the chips themselves |

## Fix

- Chips now use `bg-base-300/45` / `hover:bg-base-300/70`, matching the search input exactly in every theme.
- The two absolutely positioned gradient overlay divs are replaced with a CSS `mask-image` fade (12px per edge) on the scroll container, so scrolled-out chips dissolve to transparent instead of having theme color painted over the background image. The mask is symmetric, which keeps it correct in RTL, and is `not-eink:` gated like the old overlays were. Autoprefixer emits `-webkit-mask-image` for older WebKit.

## Verification

- Previewed on a Xiaomi 13 (physical device) with a paper texture background via CDP: chips show the texture through, the smear band before the clear button is gone.
- Verified in Chrome against the web dev server: computed chip background is `oklch(... / 0.45)`, the Tailwind-generated mask compiles correctly, and with 10 long history terms the row scrolls with clean fades at both edges.
- `pnpm lint` and the full `pnpm test` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)