### PR TITLE
chore: update agent memories

### DIFF
--- a/apps/readest-app/.claude/memory/MEMORY.md
+++ b/apps/readest-app/.claude/memory/MEMORY.md
@@ -7,7 +7,7 @@
 ## Safety & Security
 - [Google RTDN verify downgrade](google-rtdn-worker-verify-downgrade-incident.md) googleapis dead on workerd; order_id suffix blocked renewals
 - [In-place delete wiped originals](in-place-delete-wiped-originals.md) never `fs.removeFile` `external`
-- [#5084/#5265 "Delete locally" wiped Drive](gdrive-delete-locally-wiped-cloud-5084.md) MERGED #5376; stale `filePath` beats the managed copy → no-source → no `uploadedAt` → stale-record cleanup deletes on Drive
+- [#5084/#5265 "Delete locally" wiped Drive](gdrive-delete-locally-wiped-cloud-5084.md) MERGED #5376; no-source book → stale-record cleanup deletes on Drive
 - [#4703 backup zip Win paths](backup-windows-zip-paths-4703.md) · [#4639 download_file scope](download-file-scope-android-regression.md)
 - [#5147 Drive "Untitled" root files](gdrive-untitled-root-files-5147.md) atomic multipart create
 - [Security advisories 2026-06](security-advisories-web-2026-06.md)
@@ -24,26 +24,32 @@
 - [Inline-block column overflow](inline-block-column-overflow.md) `#demoteUnfragmentableBoxes`
 - FXL/PDF: [#4683 scroll reset](fixed-layout-paginated-scroll-reset-4683.md); [#4587 spread seam](pdf-spread-canvas-seam-4587.md); #4857 spine seam; [#4984 auto-spread](fxl-portrait-autospread-offcenter-4984.md)
 - Scrolled: [#4727 wheel](pdf-scroll-mode-wheel-double-4727.md); [#4436 header center](scrolled-header-title-center-4436.md); [Duokan cover](duokan-fullscreen-cover-scroll.md)
-- [#5375 SVG cover stretch](svg-cover-stretch-duokan-5375.md) exact snippet fine on Chrome; stretch = duokan-fullscreen path only (par=none + fill); need reporter's file
+- [#5375 SVG cover stretch](svg-cover-stretch-duokan-5375.md) SUPERSEDED by #5263 letterbox
+- [#5263 Duokan fullscreen cover letterbox](duokan-fullscreen-cover-letterbox-5263.md) ALL MERGED (foliate#63+#64, readest#5473); 3 fixes: letterbox, bleed-wrapper blank cover, rect-less anchor unseeded scrollBounds = dead swipe (Xiaomi-verified); sideways illus = book script; adb gestures deliver NO touchmove; stale .next cache trap
 ## Critical Files (Most Bug-Prone)
 - `src/utils/style.ts` EPUB CSS hub · `packages/foliate-js/paginator.js` · `src/services/tts/TTSController.ts`
 - `src/hooks/useSafeAreaInsets.ts` · `src/app/reader/components/FoliateViewer.tsx` · `.../annotator/Annotator.tsx`
 ## Sync Notes
 - Resolved/stable sync memories → [Sync Fixes](sync-fixes.md) (providers, WebDAV, Drive, KOSync, koplugin, transfer queue)
+- [#5426 BookOrbit integration](bookorbit-integration-5426.md) MERGED #5487; plugin API spec, UTC identity keys, xcfi bridge, useKOSync provider param, proxy SSRF pattern; live-server smoke still pending
 - [#5062 multi-provider cloud sync](multi-provider-cloud-sync-5062.md) MERGED #5122; native verify pending
+- [#5253 OneDrive OAuth trailing slash](onedrive-oauth-callback-slash-5253.md) MERGED #5479; MS returns scheme://host/; Rust AuthRequest DROPS unknown TS fields at run_mobile_plugin (callbackScheme never reached iOS); device verify pending
 - [deleted_at OR cursor invariant](sync-deleted-at-cursor-invariant.md) notes/configs OR load-bearing
+- [#5465 dictionary prefs vs Dictionaries toggle](dictionary-prefs-settings-replica-category-5465.md) MERGED #5470; category gates by replica KIND; dict prefs ride the bundled settings row
 - #5067 shelf progress never pulled `mergeBookMetadata` subset = what travels
 - [koplugin local_present sweep](koplugin-local-present-sweep-noop.md) UNFIXED; OR-merge defeats stale sweep; fix = rm readest_library.sqlite3
 - [10k library breaks /sync pull](sync-pull-10k-worker-1102.md) MERGED #5364; CF 1102; paged books pull synced_at ASC + tie-completion; old clients wedge till app update
-- [#5444 CORS preflight cache fix](cors-preflight-cache-fix-5444.md) VERIFIED in prod: OPTIONS -83% in minutes; wrangler OAuth token works for CF GraphQL analytics (1d max range)
 ## Build, Testing & CI
-- [Turbopack dev stale chunk phantom](turbopack-dev-stale-chunk-phantom.md) reload does NOT help; fiber String(f.type) to verify; rm -rf .next + restart
+- [Turbopack dev stale chunk phantom](turbopack-dev-stale-chunk-phantom.md) reload/restart do NOT help; fiber String(f.type) or throwaway console.log to verify; rm -rf .next before EVERY dev start
 - [Screenshot baselines unregenerable](vitest-screenshot-baseline-relative-path.md) FIXED in #5351; relative resolveScreenshotPath -> server.fs denies write; `--update` was a silent no-op; allowWrite is NOT it
 - #4906 nightly sharun hang pre-seed + timeouts
 - [format:check gate](verify-format-check-gate.md) · [Worktree rebase submodule drift](worktree-rebase-submodule-drift.md)
 - Android CDP: [e2e lane](android-cdp-e2e-lane.md); [profiling](cdp-android-webview-profiling.md); [double-tap](android-e2e-doubletap-cdp-gesture.md)
 - [Android e2e local repro](android-e2e-local-repro-workflow.md) dev-android vs debug run-as
 - [Nightly e2e fix](android-e2e-nightly-fix-5453.md) PR #5453; immersive prompt eats touches (screencap first!); openFixtureBook cold-start; halo max(100%,44px); wrapper/HintInfo pointer-none
+- [Web e2e local flake](web-e2e-local-devserver-cold-compile-flake.md) "no visible book section" = `next dev` cold compile under 4 workers, NOT your change; warm dev-web first, CI uses prod build
+- [Chrome clipboard paste probe](chrome-clipboard-paste-probe.md) verify copies with a real cmd+V into an injected input, never `clipboard.readText()`
+- [Settings panel screenshot](settings-panel-screenshot-via-playwright.md) throwaway spec in `e2e/tests` + `openBook`; `.modal-box` matches 5 -> `.first()`; tall viewport or the section clips
 - [iOS sim drive via dev-server relay](ios-sim-drive-via-dev-server-relay.md)
 - [iOS sim build+drive workflow](ios-sim-build-and-drive-workflow.md) `--target aarch64-sim`; CLI rename fails so take the app from the **xcarchive**, not `build/arm64-sim`
 - [Tauri Rust↔JS parser parity](tauri-parser-parity-tests.md)
@@ -55,6 +61,7 @@
 - [iOS SPM Sentry proxy hang](ios-spm-sentry-proxy-tls-download.md)
 - [CI/PR delivery + push keepalive](ci-pr-delivery-and-push.md) fork pushes need SSH; `gh` HTTPS lacks `workflow` scope
 - [tauri 2.11 remote ACL app commands](tauri-211-remote-acl-app-commands.md) webdriver = remote origin
+- [Kotlin never compiled in CI](android-kotlin-unit-test-gradle-recipe.md) #5479 shipped unparseable Kotlin, checks green; compile plugin Kotlin locally via gen/android gradlew (init does NOT gen tauri.settings.gradle, copy+sed from main worktree); CI job discarded by user
 ## Platform Compat
 - Sentry #5112/#5053/#5070: native dumps = SEPARATE helper, never re-exec
 - [#5227 drop sentry NDK](sentry-crash-reporting-4914.md) `ndk.enable=false`; READEST-P = WebView renderer death (onRenderProcessGone)
@@ -68,34 +75,31 @@
 - #4885 iOS brightness lock · [#4917 iOS share .txt stuck](ios-share-txt-stuck-supportstext.md)
 - [0.11.20 iOS .txt/.md share sheet lost](ios-txt-share-sheet-tauri211-fileassoc.md) MERGED #5415; tauri-cli 2.11 fileAssociations clobber hand-tuned CFBundleDocumentTypes; device-verify pending
 - [#5397 Photos save crash](ios-photos-add-usage-description-5397.md) MERGED #5405, device-verify pending; missing `NSPhotoLibraryAddUsageDescription`; "Save to Photos" is WebKit's menu not our code; key also un-hides "Save Image" in our share sheet
+- [#3049 SteamOS Gaming Mode import dead](steamos-gamescope-file-dialog-3049.md) MERGED #5475; gamescope has no FileChooser portal backend; in-app browser REJECTED (chooser = scope grant, security model); detect via `GAMESCOPE_WAYLAND_DISPLAY` env command, toast BEFORE dialog; `<input type=file>` fallback also portals
 ## Reader Features & UI
+- [#4995 FXL horizontal scrolling](fxl-horizontal-scroll-4995.md) MERGED foliate#65+readest#5485; host-level direction:rtl, progression coords, wheel translation incl iframe first tick, skipGlobal=true; CDP scroll gestures CANNOT test it
+- [#5452 Copy Link annotation tool](annotation-toolbar-copylink-5452.md) MERGED #5464; opt-in = in ALL_ but not DEFAULT_ tool list, tray is the complement; deep links resolve off cfi so noteId can be synthetic
+- [#5232 image viewer alt caption](image-viewer-alt-caption-5232.md) MERGED #5472; description = img `alt` OR svg `<title>`; own state not derived (findIndex falls back to 0 = wrong caption); img `role='none'` kills alt as a11y name
+- [#4977 top bar blocks text selection](header-trigger-overlaps-text-4977.md) hover strip was a fixed 44px lid; size it to the content top, not to the toolbar; #5429's mobile gate misses iPad *web* (desktop UA)
+- [#5293 tap-to-toggle progress bar](tap-toggle-progress-bar-5293.md) MERGED #5466; optionless ephemeral opacity toggle; strip target only on reserved band, pills in scrolled; extension-world MouseEvent dispatch never fires React onClick — verify with trusted clicks
 - [TTS listening counts as reading stats](tts-listening-counts-as-reading-stats.md) MERGED #5450; `view.getCFIProgress` is DEAD after `view.close()`, rebuild from book+resolveCFI; Android/iOS/CarPlay device verify PENDING
-- [#5398/#3870 annotations hub](annotations-hub-5398-3870.md) MERGED #5448; shared filterBooknotes/facets; toolbar = icon row + filter dropdown (must merge injected menuClassName); header search icon is per-tab contextual
+- [#5480 Media Overlays narration](media-overlay-narration-5480.md) MERGED; foliate needed NO changes; 3 review findings UNFIXED (preload TOCTOU, RTL page-follow, skip-nav hop); pre-#5480 imports lack badge
+- Resolved/stable feature memories → [Reader Feature Fixes](reader-feature-fixes.md) (PDF viewer, selection, dict, toolbar, RSVP, widgets, paragraph mode, misc)
 - [Mobile sheet virtuoso first-paint blank](mobile-sheet-virtuoso-first-paint-blank.md) PRE-EXISTING, no issue filed; blank until first touch
 - [PR #5389 library full-text search review](pr-5389-library-search-review.md) uncapped contains mode blocks; real-text bench 130MB/s; plan in .agents/plans
-- Resolved/stable feature memories → [Reader Feature Fixes](reader-feature-fixes.md) (PDF viewer, selection, dict, toolbar, RSVP, widgets, misc)
-- [#5406 TTS vs proofread doc sync](tts-proofread-doc-sync-5406.md) MERGED #5416; createDocument bypasses transformTarget 'data' transforms so auto-advanced sections spoke raw text; TTS docs now replay the display pipeline; same PR gives MD books a transformTarget + loadContent srcdoc path (createDocument stays raw or TTS double-transforms)
-- [#5262 clip sign-in capture](clip-signin-interactive-capture-5262.md) MERGED #5377; browser cookies unreachable; interactive clip mode + Safari share-ext DOM capture; xcodegen-in-worktree symlink trick
-- [#5294 web-novel URL import](webnovel-url-import-5294.md) MERGED #5381; multi-chapter buildEpub not feed-book; re-import updates in place via metaHash but exact-URL-keyed; sanitizeForParsing strips ALL meta → clip pickMetaContent dead code UNFIXED
 - [Readest Voice self-hosted TTS](selfhosted-premium-tts-plans.md) APPROVED 2026-07-08; not started
 - [#4584 tap-death](issue-4584-tap-death-investigation.md) UNFIXED; likely WebView-148
-- [#5352 Discord cover -> book icon](discord-cover-fallback-5352.md) MERGED #5382; NOT book-specific; temp key was hourly -> content-addressed; negative cache split missing-cover vs transient; no Content-Type + no log still open
 - [#5353 italic last glyph clipped](italic-synthetic-oblique-clip-5353.md) Android WebView >=~148 synthetic-oblique regression; no-italic-face fonts only; not Readest code
-- [#5216 Persian RLM half-space](rlm-bidi-mark-shaping-5216.md) PR #5361 MERGED but sanitizer half is dead code; XMLSerializer never emits `&#x200f;`; real cause = font-fallback shaping
-- [#5362 image zoom % was fit-relative](image-viewer-fit-relative-zoom-5362.md) MERGED #5365; `will-change` does NOT pin raster scale; dataUrl is byte-exact; SR is the wrong tool
 - [#5250 invert img dead w/ overrideColor](invert-img-dark-override-5250.md) PR #5383 open, VERIFIED on Xiaomi 13; #4763 dup `filter` last-wins + multiply-on-black; test the cascade not string presence
-- Paragraph mode: [toggle/resume #4717](paragraph-mode-toggle-resume-4717.md); [exit #4474](paragraph-mode-accidental-exit-4474.md); [#5275 styling](paragraph-mode-styling-5275.md) MERGED #5338; solid backdrop or ghosting; [#5246 display settings](paragraph-mode-display-settings-5246.md) MERGED #5403; font on frame or 66ch won't scale
-- [#5414 Edge silence untrimmed on iOS](edge-tts-baked-silence-ios-native-5414.md) MERGED #5417, device-verify pending; Edge MP3s = ~1s baked silence (0.18 head + 0.8 tail), native AVPlayer path never trimmed it; TAIL-only fix via `forwardPlaybackEndTime`; macOS NOT affected; also fixed #5326 `scaleGap` Math.round zeroing both gaps
-- [#5178 auto-hide cursor](autohide-cursor-5178.md) MERGED #5404; dormant foliate CursorAutohider + attr on view NOT renderer; `autohideCursor` top-level SystemSettings (not whitelisted = per-device); shipped default-on
-- [#5342 footer pills go black](footer-pill-vs-blend-5342.md) MERGED #5347; blend composites the container as a group; pill bg and `mix-blend-difference` cannot coexist
-- [#5351 popup restyle](popup-filter-containing-block-5351.md) MERGED; ancestor `filter` = containing block + stacking context; new `theme-dark:` variant; `text-foreground` is an undefined token
-- [#5303 negative top margin lifts header into notch](header-notch-negative-margin-5303.md) MERGED #5447, VERIFIED Xiaomi 13; band bottom==content top, 16px floor; z-10 ONLY when lifted else it covers desktop toolbar (CI e2e)
-- [#5394 Ambient Mode (light sensor)](ambient-mode-light-sensor-5394.md) MERGED; `emitOrQueue` is one-shot-only (streams = unbounded queue), chain `void` async subscription toggles, themeStore vs `getThemeCode` defaults must match
+- [#5414 Edge silence untrimmed on iOS](edge-tts-baked-silence-ios-native-5414.md) MERGED #5417, device-verify pending; ~1s baked silence, TAIL-only trim via `forwardPlaybackEndTime`; also fixed #5326 `scaleGap` Math.round zeroing both gaps
 - Proofread: [#4700](proofread-enhancements-4700.md); [#4781 CRDT](proofread-per-book-crdt-sync.md); #4859 edit toggle; [#5277 fonts lost](proofread-rule-change-font-loss-5277.md) MERGED #5345; recreateViewer double-mount + non-idempotent transformStylesheet
 - [OPDS fixes](opds-fixes.md) #4479 #4502 #4503 #4749 #4782 #4272 Basic-400s TLS#4988 Calibre-authors#5183 http-selflinks#5300
+- [#5270 OPDS feed cover+metadata](opds-feed-cover-5270.md) BOTH MERGED #5471+#5477; rel `includes` substring trap; feed-wins per-field merge, derived fields only when feed provides source; dev-mode proxy allows localhost = drive a real local feed in e2e
 - koplugin: [#4374 cover upload](koplugin-cover-upload.md); #5094 gesture + upload current; [#4954 slow open](koplugin-library-open-mosaic-cache-4954.md)
 - Calibre: [plugin push #4863](calibre-plugin-push-4863.md) OAuth localhost relay; `uploaded_at` != blob #5325; status marks #5332; [custom columns #4811](calibre-custom-columns-4811.md)
 ## Library Fixes
+- [Search history chips over textures](library-search-history-mask-fade-5488.md) MERGED #5488; chips `bg-base-300/45` like the input; edge fades = symmetric `mask-image` on the scroll container, never painted `from-base-200` overlays (smear over bg images); sidebar SearchBar still old pattern
+- [#5119 Then-by asc/desc](library-then-by-sort-order-5119.md) MERGED #5474; direction moved INTO `createBookSorter`; `librarySortBy2`->`libraryThenSortBy` needed a settings migration; URL cleanup strips defaults but falls back to the stored setting, so deep links lie
 - [Book action platform surfaces](book-actions-platform-surfaces.md) · [menu append race #4389](tauri-menu-append-race-4389.md)
 - [iOS cover picker no-op](ios-cover-picker-nofilter-5346.md) MERGED #5346; `noFilter=isIOSApp` forced Files picker + dropped HEIC; `$APPCACHE` bare dir missing from fs scope (sim-only)
 - TXT: [#4390 author](txt-author-recognition-4390.md); [#4658 chapter measure-word](txt-chapter-measure-word-4658.md)
@@ -108,10 +112,12 @@
 - memo comparator swallows new prop
 - [#5175 select bar hides last book](select-mode-actions-overlap-last-book-5175.md) measure bar height into Virtuoso Footer spacer
 - [#5222 bookshelf import menu](bookshelf-import-menu-popup-5247.md) MERGED #5247; Virtuoso clips dropdown-content, use fixed anchored popup
+- [#5360 Wayland tap kills native menu](wayland-tap-context-menu-5360.md) MERGED #5467; Linux = in-app menu; GTK3+muda popup can't survive tap; video-frame forensics; Wayland device verify pending
 ## Architecture & Patterns
 - foliate-js submodule `packages/foliate-js/`; multiview paginator preloads adjacent sections
 - [#5097/#5308 encoded href](epub-encoded-href-reserved-chars-5097.md) `decodeURI` keeps reserved chars; #5308 = stale nav.json cache, MERGED #5311
 - [#5273 undeclared cover.jpg](epub-undeclared-cover-entry-5273.md) MERGED #5339 + foliate#61; cover resolution DUPLICATED in foliate + Rust `resolve_cover_path`
+- [#5455 OPF `<item></item>` skipped](epub-opf-expanded-item-tags-5455.md) MERGED #5463; quick-xml Empty-only match; #5339 fallback masks it on dev builds
 - [Turso "concurrent use forbidden"](turso-concurrent-use-forbidden.md) `op_lock` async mutex
 - Markdown: [.md support #774](markdown-md-support-774.md); resume position #4862; footnotes #5074
 - [#5279 md YAML frontmatter](markdown-yaml-frontmatter-5279.md) MERGED #5344; http covers stay `coverImageUrl` (CORS), data URIs decoded; isbn = identifier; dedup race UNFIXED
@@ -133,5 +139,6 @@
 - [No mock-only platform tests](feedback-no-mock-only-platform-tests.md) call-sequence tests over mocked Tauri IPC restate the impl; skip them
 - [No test seams in prod](feedback_no_test_seams_in_prod.md) · [no lookbehind regex](feedback_no_lookbehind_regex.md)
 - i18n: [en plurals manual](feedback_en_plurals_manual.md); [i18n:extract prunes keys](i18n-extract-prunes-keys.md); {{provider}} case suffixes #5102
+- [Label rename = key rename](i18n-label-rename-workflow.md) derive new translations by stripping the changed word from each locale's OLD value; mirror in `commandRegistry.ts`; extract only appends
 - [Dependabot transitive fixes](dependabot-pnpm-overrides.md) `pnpm-workspace.yaml` `overrides:` · [deps security recipe](deps-security-overrides-workflow.md) MERGED #5335; version-keyed, bound `<nextMajor` · [gstack upgrade](feedback_gstack_upgrade.md)
 - [Next page-export check webpack-only](nextjs-page-export-webpack-only-check.md) MERGED #5336; turbopack `build-web` misses it, CI cannot catch; `rm -rf .next` if lint trips

--- a/apps/readest-app/.claude/memory/android-cdp-e2e-lane.md
+++ b/apps/readest-app/.claude/memory/android-cdp-e2e-lane.md
@@ -5,6 +5,7 @@ metadata:
   node_type: memory
   type: project
   originSessionId: 16f94822-04b0-4be3-a47e-8a2e3cab290a
+  modified: 2026-08-04T05:34:59.609Z
 ---
 
 New test tier (PR #4545, merged 2026-06-12): `pnpm test:android` → `scripts/test-android.sh` → `vitest.android.config.mts` (node env, serial, retry 1) → `src/__tests__/android/*.android.test.ts`. Helpers in `src/__tests__/android/helpers/`: `adb.ts` (tap/longPress/`motionGesture` = one-shell DOWN/MOVE/UP chain), `cdp.ts` (forward `webview_devtools_remote_<pid>`, node:http discovery with Host header, `CdpPage.evaluate` async-IIFE), `reader.ts` (fixture open + probes). Soft-skips without adb/device/app. Covers the [[android-hyphen-selection-bounds-1553]] cases: prone long-press → app handles, drag repair clamp, tap dismissal, handle-drag extension, mid-paragraph native handles, cross-page corner-dwell auto-turn.
@@ -17,5 +18,8 @@ Gotchas:
 - Corner auto-turn (#1354) zone is the reading area INSET by content margins — a drag point in the bottom margin is ignored by `cornerAt`; aim ~4% inside the text area.
 - adb `input motionevent` 5px moves are under touch slop → no pointermove; make post-turn drag movements large.
 - Verified green on Xiaomi 13 (physical) AND fresh Pixel_9_Pro AVD (`emulator -avd Pixel_9_Pro`, install the aarch64 dev APK), ~21 s.
+- Pull-to-refresh / touch-drag verification: `Input.synthesizeScrollGesture {x, y, yDistance: +260, speed: 350, gestureSourceType: 'touch', preventFling: true}` delivers a real touchstart/touchmove/touchend stream (POSITIVE yDistance = finger travels DOWN = top overscroll); adb `input swipe`/motionevent does NOT reliably deliver touchmove to the page. `CdpPage.send` is TS-private — reach it with a cast through `unknown`. Observe mid-gesture DOM with a page-side rAF recorder pushed into `window.__x`, and write results to a host file via `node:fs` from the spec (vitest swallows console.log); launch to LIBRARY page with `monkey -p PKG -c android.intent.category.LAUNCHER 1`, find the CDP target whose url does NOT include '/reader'.
 
 CI: `.github/workflows/android-e2e.yml` — ubuntu-latest + KVM udev rule, debug x86_64 APK (`tauri android build --debug --target x86_64`; gradle skips keystore.properties when absent so NO signing secrets), `reactivecircus/android-emulator-runner@v2` (api 34, AVD snapshot cached), nightly + workflow_dispatch + `e2e-android` PR label; not PR-blocking. NOTE: emulator-runner not SHA-pinned yet (repo convention pins by SHA).
+
+Live CSS preview on a bundled device build (no rebuild): `adb forward tcp:9333 localabstract:webview_devtools_remote_<pid>` (find via `cat /proc/net/unix | grep devtools`), then websocket to `/devtools/page/<id>` — Chromium 111+ rejects the handshake with 403 unless you omit the Origin header (`websocket-client` needs `suppress_origin=True`). `Runtime.evaluate` can toggle classes already in the shipped CSS bundle (e.g. `bg-base-300/45` via `classList.add('bg-base-300/45')`) and inline-style anything new (masks etc.), then `adb exec-out screencap` for the after shot. Used for the #search-history translucency fix (library page.tsx chips).

--- a/apps/readest-app/.claude/memory/android-kotlin-unit-test-gradle-recipe.md
+++ b/apps/readest-app/.claude/memory/android-kotlin-unit-test-gradle-recipe.md
@@ -1,0 +1,20 @@
+---
+name: android-kotlin-unit-test-gradle-recipe
+description: CI never compiles plugin Kotlin (PR checks have no Android job) — compile locally via gen/android gradlew; recipe for the missing generated files
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 9514654c-db01-441e-b22c-ec393f217bb0
+  modified: 2026-08-04T04:36:57.782Z
+---
+
+**Nothing in PR checks compiles Kotlin.** `build_tauri_app` is desktop-only; `android-e2e.yml` runs nightly or behind the `e2e-android` label. PR #5479 shipped Kotlin that didn't parse and CI stayed green. **Any PR touching `src-tauri/plugins/*/android/` Kotlin must be compiled locally before approving.**
+
+**Why:** Kotlin compile/test errors land on main unnoticed and only surface in the nightly Android lane.
+
+**How to apply — run plugin unit tests in a worktree:**
+1. `pnpm worktree:new` runs `tauri android init`, but init does NOT generate `gen/android/tauri.settings.gradle` or `gen/android/app/tauri.build.gradle.kts` (only `tauri android build/dev` does). Copy both from the main worktree (`/Users/chrox/dev/readest/apps/readest-app/src-tauri/gen/android/`), rewriting paths: `sed 's|/dev/readest/|/dev/readest-<wt>/|g' tauri.settings.gradle`; also copy `local.properties`.
+2. `cd gen/android && ./gradlew :tauri-plugin-native-bridge:testFossDebugUnitTest :tauri-plugin-native-tts:testDebugUnitTest` (native-bridge has foss/googleplay flavors; native-tts has none).
+3. junit is already wired (`testImplementation junit:4.13.2` in plugin build.gradle.kts).
+
+Notes: the copied `tauri.settings.gradle` references cargo-registry plugin paths, so this only works on a machine with the registry populated. A standalone harness (own settings.gradle including just `:tauri-android` + the two plugins) also works — plugins depend only on `project(":tauri-android")` from `packages/tauri` + maven artifacts; needs `android.useAndroidX=true` in gradle.properties and AGP 8.11/Kotlin 1.9.25 matching gen/android. A `kotlin_test` CI job was drafted 2026-08-04 but the user discarded it; the native-tts `ExampleUnitTest.kt` invalid package (`com.readest.native-tts`) it caught was fixed in #5484 (MERGED).

--- a/apps/readest-app/.claude/memory/annotation-toolbar-copylink-5452.md
+++ b/apps/readest-app/.claude/memory/annotation-toolbar-copylink-5452.md
@@ -1,0 +1,19 @@
+---
+name: annotation-toolbar-copylink-5452
+description: Copy Link in the reader selection toolbar is opt-in purely via ALL_ vs DEFAULT_ tool lists; it resolves the note at the selection CFI
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 1fe0d4e7-c41d-496e-a9ca-e3976830677e
+  modified: 2026-08-03T13:42:13.175Z
+---
+
+#5452 asked for the sidebar's per-note Copy (#5441) to be reachable from the reader's own selection toolbar. MERGED #5464 (a5da929) as a `copylink` tool that copies the bare annotation URL.
+
+Opt-in is entirely the two lists in `src/utils/annotationToolbar.ts`: a type in `ALL_ANNOTATION_TOOL_TYPES` but NOT in `DEFAULT_ANNOTATION_TOOLBAR_ITEMS` never renders in the popup, while `getAvailableToolTypes` (canonical-order complement of the visible list) surfaces it in the Customize Toolbar "Available" tray for default AND already-customized users. `share` uses the same trick (#4014). No extra flag or gating code is needed for a new opt-in tool.
+
+`handleCopyLink` in Annotator.tsx: cfi = `selection.cfi || view.getCFI(...)`; noteId = first non-deleted booknote at that cfi, else `uniqueId()`. Deep-link resolution (`useOpenAnnotationLink`, the `/o` landing page) navigates off the **cfi** only and the noteId merely has to be present, so a plain unhighlighted selection still yields a working position link. Link form follows `noteExportConfig.linkType` ('app' on tauri, 'web' elsewhere).
+
+`tooltip` in the `annotationToolButtons` registry is ONLY rendered for quick actions (QuickActionMenu). Non-quick-action entries (annotate, proofread, copylink) carry dead i18n keys by existing convention.
+
+Verified in Chrome against a real library: the toolbar's link is byte-identical (note id + cfi) to what the sidebar's own Copy emits for the same note. See [[chrome-clipboard-paste-probe]] and [[web-e2e-local-devserver-cold-compile-flake]].

--- a/apps/readest-app/.claude/memory/bookorbit-integration-5426.md
+++ b/apps/readest-app/.claude/memory/bookorbit-integration-5426.md
@@ -1,0 +1,30 @@
+---
+name: bookorbit-integration-5426
+description: "BookOrbit integration (#5426) — plugin API protocol, xcfi bridge, identity keys, branch feat/bookorbit-integration"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 2feb3b1c-398c-4ee5-9b98-c5267fb8ebb9
+  modified: 2026-08-04T08:03:02.511Z
+---
+
+# BookOrbit integration (#5426) — MERGED #5487 (2026-08-04)
+
+Merged as 9bce2192d; worktree and local branch removed. Spec/plan docs were in the gitignored `.agents/plans/` of the deleted worktree — this memory is the surviving reference. Spec+plan in `.agents/plans/2026-08-04-bookorbit-integration-{design,plan}.md` (gitignored — local only).
+
+**Protocol** (source of truth: `bookorbit/bookorbit` monorepo, `server/src/modules/koreader/` + `koreader-plugin/bookorbit.koplugin/`; the standalone `bookorbit-koplugin` repo does NOT exist — the plugin zip is served by the BookOrbit server itself):
+- Base `{server}/api/v1/koreader`; auth `x-auth-user` + `x-auth-key` (md5 password, KOSync-style); creds minted in BookOrbit web UI — NEVER call `users/create`.
+- Plugin API `/plugin/`: `version` (capabilities incl. `bookmarkSync`), `match-check`, `annotations/exchange(-ack)`, `bookmarks/exchange(-ack)`, `page-stats`, `book-states`. Limits: ≤20 books, ≤50 changes, ≤5000 keys, ≤50 stats books/request.
+- Exchange identity key `k = md5(datetime + "|" + pos0)`; deletion detection via complete key list (`keysComplete`); server pushes down add/edit/delete + `more` paging; device acks with `verified`/`corrected`.
+- Positions are crengine toStringV2 xpointers ONLY (`posFormat: 'xpointer'|'pdf'`; CFI never crosses the plugin API — their server converts for its web reader). `src/utils/xcfi.ts` is the bridge; `BookNote.xpointer0/1` already cache them.
+
+**Key design decisions:**
+- Identity datetimes derived from `createdAt` in **UTC** + `deviceTime` sent as UTC → all Readest devices derive identical keys. Remote-born note identities persisted in `BookOrbitSyncStore` (sqlite `bookorbit-sync` schema) — not re-derivable.
+- Note ids for pulled annotations use the koplugin's `generateNoteId` derivation (`md5("ko:"+hash+":"+type+":"+pos0+":"+pos1).slice(0,7)`) so notes dedupe across the readest.koplugin path.
+- Progress sync reuses `useKOSync` via a `KosyncProgressProvider` param (`bookOrbitProgressProvider` derives a KOSyncSettings pointed at `{server}/api/v1/koreader`); FoliateViewer mounts the hook twice with two conflict resolvers.
+- Stats: `PageStatEvent` maps 1:1; new `'bookorbit-push'` CursorKey in statisticsDb; no user account gate.
+- Layout: `src/services/bookorbit/{types,noteMapping,BookOrbitClient,BookOrbitSyncStore,annotationExchange,bookmarkExchange,notesPass,statsPush}.ts`, hooks `useBookOrbitNotesSync` (Annotator) + provider (FoliateViewer), `/api/bookorbit` proxy (anchored endpoint whitelist), `BookOrbitForm` + panel row.
+
+**CodeQL SSRF on proxies:** `js/request-forgery` flags any self-hosted-server proxy (`/api/kosync` alert #14, `/api/bookorbit` alert #124) — repo pattern is harden then dismiss as false positive (user-provided host is the feature). Real hardening added to bookorbit proxy: `redirect: 'error'` (public server must not 3xx the proxy onto an internal address) + anchored endpoint whitelist + isLanAddress; kosync proxy still follows redirects (untouched for CWA http→https compat). Dismissal comment max 280 chars via `gh api -X PATCH .../code-scanning/alerts/N`.
+
+**Still pending post-merge:** manual smoke against a real BookOrbit server (highlight round-trip, KOReader-created highlight pull, deletes, dogears, stats, status, conflict prompt). Fixed-layout (PDF posFormat) annotations and the catalog API are not supported in v1.

--- a/apps/readest-app/.claude/memory/chrome-clipboard-paste-probe.md
+++ b/apps/readest-app/.claude/memory/chrome-clipboard-paste-probe.md
@@ -1,0 +1,17 @@
+---
+name: chrome-clipboard-paste-probe
+description: Read the real system clipboard during Chrome-driven verification without triggering a clipboard-read permission prompt
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 1fe0d4e7-c41d-496e-a9ca-e3976830677e
+  modified: 2026-08-03T13:42:30.728Z
+---
+
+To confirm an in-app "copy" really wrote the system clipboard while driving the app with claude-in-chrome, do NOT call `navigator.clipboard.readText()` - it needs the clipboard-read permission and Chrome prompts for it.
+
+Instead use a paste probe: `javascript_tool` injects a fixed-position `<input>` at the top-left, `computer left_click` focuses it, `computer key cmd+v` pastes, then `javascript_tool` reads `.value` and removes the node. This exercises the real OS clipboard end to end and stubs nothing. Used on #5452 to prove the toolbar's Copy Link output matched the sidebar's byte for byte ([[annotation-toolbar-copylink-5452]]).
+
+Two quirks seen in that session, both pre-existing and unrelated to the change under test:
+- The sidebar's annotation list painted blank until scrolled (same family as [[mobile-sheet-virtuoso-first-paint-blank]]).
+- After closing the reader settings dialog, double-click word selection stopped raising the annotation popup until a drag-select was done. Observed once, NOT reproduced or filed - reproduce before treating it as real.

--- a/apps/readest-app/.claude/memory/dictionary-prefs-settings-replica-category-5465.md
+++ b/apps/readest-app/.claude/memory/dictionary-prefs-settings-replica-category-5465.md
@@ -1,0 +1,38 @@
+---
+name: dictionary-prefs-settings-replica-category-5465
+description: "#5465 dictionary prefs synced despite Dictionaries=off; Manage Sync category != replica kind, and the settings row bundles other categories' fields"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 6d5b1b39-cf60-42e5-bc19-5a3c18b5866a
+  modified: 2026-08-03T14:48:20.675Z
+---
+
+MERGED 2026-08-03 as PR #5470 (squash `1fcaa506b`). Reporter device-verify pending:
+older peers keep pushing dict prefs, so only the updated device discards on arrival.
+
+**The trap:** `isSyncCategoryEnabled(kind)` gates by *replica kind*, so a Manage Sync
+toggle only covers what its own kind carries. `dictionarySettings.providerOrder /
+providerEnabled / webSearches / fontScale` are whitelisted into the **bundled
+`settings` row**, so they were gated by "App settings" while the user was flipping
+"Dictionaries". The Dictionaries toggle only ever gated the dictionary *bundles*
+(binary + metadata). The panel copy even claimed the opposite on both rows.
+
+Fix: `SETTINGS_DICTIONARY_FIELDS` in `services/sync/adapters/settings.ts`;
+`publishSettingsIfChanged` skips those paths and `applyRemoteSettings` rebuilds the
+incoming patch without them when `isSyncCategoryEnabled('dictionary')` is false.
+The `dictionary -> settings` edge in `CATEGORY_DEPENDENTS` stays — they still need
+the settings row as transport, it just no longer *implies* they belong to it.
+
+**Why:** any future field added to `SETTINGS_WHITELIST` silently inherits the
+"App settings" toggle regardless of which category the user thinks owns it. Same
+shape as the `credentials` meta-toggle, which already had to solve this by
+cross-cutting the OPDS + settings rows.
+
+**How to apply:** when adding a whitelisted setting that a user would find under a
+different Manage Sync row, add it to a category path-set and gate both the push loop
+and the pull patch — the adapter whitelist alone is the wrong altitude. Re-enable
+does not backfill (the settings cursor advanced past the discarded values); local
+values do republish, because the push snapshot was never updated while gated.
+
+Related: [[multi-provider-cloud-sync-5062]], [[sync-fixes]]

--- a/apps/readest-app/.claude/memory/duokan-fullscreen-cover-letterbox-5263.md
+++ b/apps/readest-app/.claude/memory/duokan-fullscreen-cover-letterbox-5263.md
@@ -1,0 +1,32 @@
+---
+name: duokan-fullscreen-cover-letterbox-5263
+description: "#5263 THREE bugs fixed: covers letterbox (contain + black bars) instead of stretching; duokan-bleed positioned wrapper = blank page; rect-less restore anchor left #scrollBounds unseeded = swipe dead on cover until any tap-turn. Xiaomi device-verified."
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 2a2a5d20-fd55-4652-801b-c179b8adc316
+  modified: 2026-08-03T16:06:50.346Z
+---
+
+Issue #5263 (2026-08-04: foliate#63 (letterbox+blank, 4088d28) + foliate#64 (swipe seed, f6bce4c) BOTH MERGED; #5473 MERGED — issue #5263 fully resolved):
+
+**Behavior change decided by chrox in-thread + chat:** `duokan-page-fullscreen` covers no longer stretch (`object-fit: fill` + `preserveAspectRatio: none` removed). New behavior = real Duokan parity: image pinned inset-0 100%/100%, `object-fit: contain` (the general image rule), `background-color: #000` on the pinned element paints the letterbox bars. This supersedes the "stretch is intended" resolution of #5375 ([[svg-cover-stretch-duokan-5375]]).
+
+**Second root cause found (blank cover page):** the King's Proposal 8 book declares `duokan-bleed: leftright` on `.illus`; Readest's `transformStylesheet` duokan-bleed handling (style.ts ~1042) adds `position: relative !important` to that wrapper, so the pinned img resolved `height:100%` against the wrapper -> wrapper 100% of zero-height body -> img 470x0 -> page renders BLANK. Fix: fullscreen branch forces `position: static` on ancestors between img and body (inline important beats stylesheet important). Reproduced on-device (v0.11.20 arm64 APK, API-36 emulator): page 1/247 fully blank.
+
+- foliate-js commit fc7a8b5 on branch `fix/duokan-fullscreen-cover-letterbox` (paginator.js setImageSize); app branch `fix/duokan-cover-letterbox-5263` (temp-index built off origin/main, dev tree untouched) with submodule bump + browser tests + fixture `repro-5263.epub` (= repro-4379 + `<style>.cover{position:relative}</style>`).
+- Scrolled-mode cleanup branch also removes `background-color` (el) and `position` (ancestors) now.
+- Tests: `paginator-duokan-cover.browser.test.ts` 5 pass (letterbox assertions replaced the old `object-fit: fill` one).
+
+**Swipe complaint (still open):** "swipe doesn't turn pages on cover page". Emulator repro on 0.11.20: swipe failed ONCE on the stretched cover but worked on the blank cover — however the headless emulator (hvf/Vulkan AND swiftshader) crashed 3x around exactly this test, so the observation is untrustworthy (likely mid-ANR). Web build + fix + CDP `Input.dispatchTouchEvent` swipes: cover page turns fine. Needs real-device re-check after the fix ships. Foliate touch listeners are `{passive:false}` on both the custom element and each iframe doc; no img-specific gesture code found in app or paginator.
+
+**Sideways illustrations complaint = book's own script, not Readest:** the book (乐园杂音 07) ships `script.js` that on non-desktop UAs (`/windows|x11|mac/i` fails) adds class `change` -> `necessary.css` `img.change { transform: rotate(90deg); max-width:90vh; max-height:100vw }` to landscape `.kuchie` images so they fill a portrait phone page. Windows renders "normally" because the UA regex matches. By design (Duokan-ecosystem convention); reply on issue, no code change.
+
+**Repro workflow that worked:** GitHub release APK (`gh release download v0.11.20 -p '*arm64.apk'`) + `emulator -avd Pixel_9_Pro -no-snapshot-load -no-window`; import via app "+" tile -> DocumentsUI (VIEW intents with file:// or shell content:// grants DON'T import); web import via drop-event needs DESKTOP UA context (drop did nothing with `isMobile: true` Playwright emulation); Playwright + `context.newCDPSession` + `Input.dispatchTouchEvent` gives real touch swipes on desktop Chromium (`hasTouch: true`), extension-world synthetic TouchEvents do NOT drive the app's gesture pipeline.
+
+Related: [[duokan-fullscreen-cover-scroll]] (#4379 scrolled-mode gating, still valid), [[svg-cover-stretch-duokan-5375]].
+
+
+**THIRD root cause (swipe dead on cover, device-verified 2026-08-04, foliate f0d39b4):** restoring at the cover resolves the saved CFI (`epubcfi(/6/2!/4/2,,/2)`) to a range `start=(div.cover,0), end=(img,0)` — end boundary INSIDE the pinned img -> `getClientRects()` EMPTY (abs-positioned content has no in-flow boxes). `#scrollToAnchor`'s `if (!rect) return` bailed without `#scrollTo`, `#scrollBounds` stayed unseeded, and `scrollBy`/`snap`'s unseeded guards silently dropped every swipe (Push style; finger trace: touchstart-unseeded -> 50x scrollBy-bail -> snap-bail). Any tap-turn seeds via `#scrollToPage` -> "works after you interact" = reporter's "sometimes, first open". Fix: rect-less bail (and zero-contentPages bail) falls back to `#scrollToPage(pagesBeforePrimary)` / scrolled `#scrollTo(viewOffset)`. `#afterScroll` refreshes `#anchor` to the visible range after page/snap scrolls so the fallback cannot cause stale jump-backs.
+
+**Debug workflow that cracked it:** release+devtools build (`tauri android build -t aarch64 -- --features devtools`) + `__pgLog`/`__atLog` instrumentation read over CDP (`webview_devtools_remote_<pid>` forward). KEY TRAPS: (1) adb-synthesized gestures (`input swipe`, chained `input motionevent`) deliver touchstart/touchend but ZERO touchmove into the WebView — only real fingers drive the gesture pipeline; ask the user to swipe. (2) `tauri android build` reuses a STALE Next build cache — a "fixed" APK shipped the previous bundle (probe: leftover `__pgLog` global proved staleness); `rm -rf .next out` before the build. (3) Seeded-ness is probeable without instrumentation: `renderer.scrollBy(50,0)` moves `containerPosition` iff `#scrollBounds` is seeded. (4) `view.goTo({index})` no-ops from console; use `view.renderer.goTo({index, anchor})`. (5) The web harness can't repro the full swipe symptom (fill/expand timing differs; user confirmed web-unreproducible) — no browser regression test for the swipe, coverage is the letterbox/blank tests only.

--- a/apps/readest-app/.claude/memory/epub-opf-expanded-item-tags-5455.md
+++ b/apps/readest-app/.claude/memory/epub-opf-expanded-item-tags-5455.md
@@ -1,0 +1,33 @@
+---
+name: epub-opf-expanded-item-tags-5455
+description: "#5455 native Rust OPF parser skipped `<item></item>` / `<meta></meta>` (Event::Empty only) - fix + why the bug is invisible on Android and masked by the undeclared-cover fallback"
+metadata:
+  node_type: memory
+  type: project
+---
+
+Issue #5455 (reported on iOS, OPDS-downloaded book has no library cover). **MERGED as PR #5463** (2026-08-03, merge commit `8ad906bc4`); issue closed. Ships in the release after 0.11.20.
+
+**Root cause.** `epub_parser.rs` matched manifest `<item>` and metadata `<meta>` only under `Ok(Event::Empty(e))`. quick-xml emits `Empty` **only** for self-closing tags; the equivalent `<item ...></item>` is `Start` + `End`, so an OPF serialised that way (BookOrbit and other OPDS servers do it) yielded an **empty manifest** in BOTH `parse_opf_cover_inputs` (no cover) and `locate_toc_sources` (no nav, no NCX on the open hot path). Fix = `reader.config_mut().expand_empty_elements = true` on both readers + move item/meta handling into the `Start` arm. Empty→Start+End also keeps `in_manifest`/`in_metadata` balanced for a degenerate `<manifest/>`.
+
+**Two things that hide this bug — budget for them before reproducing:**
+1. `resolve_cover_path` falls back to `find_undeclared_cover_entry` (zip entry named `*cover.{jpg,png,…}` / `*couv.*`). **That fallback is #5339, merged 2026-07-26 — AFTER the 0.11.20 release (2026-07-20).** So on any `dev` build (and on any local build whose versionName still says 0.11.20) a book whose cover entry is named `cover.jpg` shows a cover even with the manifest defect present, while released 0.11.20 (what the OP runs) shows none. Reproducing on a dev build needs the cover image named something else (used `images/front.jpg`). Always check ancestry against the user's released version before concluding "can't reproduce".
+2. The native fast path is only attempted for a **string path matching `/\.epub$/i`** (`bookService.ts` → `tryNativeParseEpub`). See [[android-nativefile-remotefile-io]] for the platform I/O split.
+
+**Which flows actually reach the Rust parser** (this explains the reporter's iOS asymmetry):
+- OPDS auto-download → `services/opds/autoDownload.ts` calls `appService.importBook(dstFilePath, books)` with a **real path** → native parser → bug visible.
+- Android file picker → tauri dialog returns `content://com.android.fileexplorer.myprovider/...../x.epub`. It passes the `.epub` regex but `Path::exists()` is false in Rust → bridge catches, warns, returns null → **foliate-js fallback**, cover fine. So the bug is effectively invisible for Android picker imports; don't try to reproduce it that way.
+- Presumably the same on iOS for a Files/iCloud pick (security-scoped URL → raw `File::open` fails → JS fallback), which is why the reporter's manual import kept the cover.
+
+**Device-probe recipe (Xiaomi 13, no library pollution)** — see [[cdp-android-webview-profiling]] for the CDP setup:
+- `adb shell appops set com.bilingify.readest MANAGE_EXTERNAL_STORAGE allow` + restart the app, then CDP-`invoke('parse_epub_metadata', {filePath:'/storage/emulated/0/Download/x.epub'})`. Without the appop it's `partial_md5 failed: Permission denied`. Reset to `default` when done.
+- The Tauri **fs plugin scope is separate**: importing that same `/sdcard` path through the app fails with `forbidden path`, and `invoke('allow_paths_in_scopes', …)` did **not** lift it. So `location.href = '/library?file=<sdcard path>'` (a real ingress route, `helpers/openWith.ts` reads `?file=`) can't be used to drive an end-to-end import from `/sdcard`.
+- Hooking `window.__TAURI_INTERNALS__.invoke` (even via `Page.addScriptToEvaluateOnNewDocument`) records **zero** of the app's invokes — the bundled `@tauri-apps/api` doesn't route through that property at call time. Don't waste time on it; probe the command directly instead.
+
+**Verified on Xiaomi 13** (fixture pair: identical EPUBs differing only in OPF serialisation): pre-fix build → expanded `coverBytes: 0`, `navPath: null` vs self-closing `86726` / `OEBPS/nav.xhtml`; rebuilt with the fix → both identical. `pnpm dev-android` reinstalls over the sideloaded release build with `-r`, data preserved (see [[android-sideload-same-versioncode]]).
+
+**OP's real file** (`readest_test.epub`, Neuromancer via BookOrbit/calibre 9.1.0, attached to the issue 2026-08-03): every `<item>`/`<meta>` expanded; cover declared as `<item id="cover" href="cover.jpg" properties="cover-image">` with `OEBPS/cover.jpg` (1649x2475, 702 KB) present, plus a decoy `OEBPS/inserted_file_001_.jpeg`, and `<item id="nav" href="../nav.xhtml">` pointing OUTSIDE the OPF dir. Pre-fix: `manifest_len 0`, `cover_id None`, `resolve_cover None`, `nav_href None` → on released 0.11.20 that means **no cover at all**. Post-fix: `manifest_len 41`, `cover_id Some("cover")`, `resolve_cover Some("OEBPS/cover.jpg")`, `nav_href Some("../nav.xhtml")`, cover 74230 B; same numbers on-device. foliate-js parses the file fine either way (cover 702274 B, 35 sections, 9 TOC items), which is why their manual iCloud import kept the cover.
+
+**Still open in the same function:** when `resolve_cover_path` returns a path that is NOT in the zip, `parse_epub_metadata_sync`'s `Err(_) => (None, None)` arm gives up instead of falling through to `find_undeclared_cover_entry`. Didn't bite this book (`OEBPS/cover.jpg` exists), no issue filed.
+
+Related: [[epub-undeclared-cover-entry-5273]] (the fallback that masks this), [[tauri-parser-parity-tests]] (`test:tauri` parity suite would catch this class, but it is **not** wired into CI — chrox declined adding the 993 KB OP file as a fixture).

--- a/apps/readest-app/.claude/memory/fxl-horizontal-scroll-4995.md
+++ b/apps/readest-app/.claude/memory/fxl-horizontal-scroll-4995.md
@@ -1,0 +1,26 @@
+---
+name: fxl-horizontal-scroll-4995
+description: "#4995 horizontal scrolling for fixed-layout books: scroll-direction attr, host-level direction:rtl, progression coords, wheel translation; CDP scroll gestures cannot test it"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 48bc5696-2015-4f7d-96c4-f4b473b7dbdf
+  modified: 2026-08-04T05:40:29.068Z
+---
+
+# #4995 Horizontal scrolling mode for fixed-layout books
+
+BOTH MERGED 2026-08-04: foliate#65 (squash 663e630) then readest#5485 (merge 69985e5e5). Rebase lesson: #5480 landed i18n keys concurrently; all 33 locale conflicts were tail-of-file key appends, union-merged from git stages (:1 base additions/removals applied onto :2) with a throwaway script. Worktree submodule `origin` points at the local checkout; push foliate via an added `github` remote. Squash-merged foliate PRs need the app pointer re-aimed at the squash commit (tree-identical, so `git diff old new` empty).
+
+Design decisions that will bite if forgotten:
+
+- **`scroll-direction` attribute** (vertical|horizontal) on `foliate-fxl`, orthogonal to `flow="scrolled"`; app setting `scrolledDirection` in ViewSettings. Direction change destroys+re-inits scroll mode preserving page index.
+- **`direction: rtl` must live on the HOST element** (the scroller), NOT `.scroll-container` — scrollLeft sign conventions follow the scrolling element's own computed direction; on a child it never activates and every anchor restore teleports (caught by per-task review, verified in Chromium).
+- **Two coordinate spaces** in fixed-layout.js: content coords (anchors, pinch origin; RTL normalized `scrollWidth - clientWidth + scrollLeft`) vs reading progression (`containerPosition`, start/end/atStart/atEnd; RTL = `-scrollLeft`). Auto Scroll works unchanged because fixed-layout has no `scrollProp`, so useAutoScroll's sign defaults +1 and progression absorbs RTL.
+- **Wheel translation** `computeScrollWheelDelta` (null on ctrl / vertical overflow / deltaX-dominant / vertical mode): host listener passive:false attached ONLY in horizontal mode, plus the #4727 iframe-doc listener also translates (in horizontal mode the native chain cannot consume a vertical delta, so the first tick of every gesture over an interactive page was swallowed; translating there cannot double-scroll).
+- **`saveViewSettings` skipGlobal=true for scrolledDirection** (like zoomMode/spreadMode, unlike webtoonMode) — global save bled 'horizontal' into reflowable books and disabled `snapScrolledDistanceToLines`; usePagination also gates the skip on `layout === 'pre-paginated'`.
+- **ViewMenu effect order is load-bearing**: the scrolledDirection effect must be declared BEFORE the isScrolledMode effect so the attribute lands before flow flips (else vertical strip builds then rebuilds).
+- **0.5px epsilon guard in `#restoreScrollModeAnchor`**: any programmatic scroll write (even same value) cancels an in-flight smooth scroll (CSSOM spec), and the ResizeObserver's initial callback fires mid `next()` animation.
+- UI: 4-icon group in the fixed-layout View menu row (TbColumns1/TbColumns2/TbCarouselVertical/TbCarouselHorizontal), user-requested mid-build replacing a three-item text menu; 'Paginated' i18n key was added then pruned.
+
+**Testing trap:** Chrome-extension/CDP synthetic scroll gestures CANNOT test horizontal wheel translation — they abort with ZERO DOM wheel events when no scroller exists along the gesture axis (verified: window+iframe capture hooks saw nothing while the sidebar scrolled fine). Only JS-dispatched WheelEvents (vitest browser tests) or real hardware exercise the handler. Related: [[duokan-fullscreen-cover-letterbox-5263]] (adb gestures deliver no touchmove).

--- a/apps/readest-app/.claude/memory/header-trigger-overlaps-text-4977.md
+++ b/apps/readest-app/.claude/memory/header-trigger-overlaps-text-4977.md
@@ -1,0 +1,21 @@
+---
+name: header-trigger-overlaps-text-4977
+description: "#4977 top bar blocks text selection — header hover trigger was a fixed 44px lid; fixed by sizing it to the content top (getHeaderTriggerHeight)"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: d7118b42-d67a-4f24-80a0-6376930aacf0
+  modified: 2026-08-03T17:30:18.914Z
+---
+
+#4977 (iPadOS 26.5, 0.11.17): "top bar's activation margin sits above the text, text at the top of the page cannot be selected." Same root cause as #5429.
+
+**Root cause:** `HeaderBar`'s invisible hover trigger was `h-11` — 44px, sized to the *toolbar it reveals*, which happened to equal the DEFAULT `marginTopPx`. Any smaller content top (page header off -> `compactMarginTopPx` 16, a reduced margin, vertical writing mode) left the strip hanging over the first line, and it swallowed the press that should have started a selection.
+
+**Fix (2026-08-04, on `dev`, not yet a PR):** `getHeaderTriggerHeight(topInset, viewSettings)` in `src/utils/insets.ts` — `min(44, contentTop)` where `contentTop` mirrors `FoliateViewer.applyMarginAndGap`'s `margin-top`: `showHeader && !vertical ? max(topInset + marginTopPx, 16) : marginTopPx` (the header-off branch drops the safe-area inset; the header-on branch floors at 16 via `moreTopInset`). Same "glued to the content top" rule as [[svg-cover-stretch-duokan-5375]]'s neighbour `getHeaderBandGeometry`.
+
+**Why the platform gate wasn't enough:** #5429 (b17f06186) made the strip `pointer-events-none` when `appService.isMobile || innerWidth < 640`. That covers the reporter's NATIVE iPad app (OS_TYPE 'ios'), so #4977 was already fixed on `dev` for them — but NOT the web build on iPadOS: `getOSPlatform()` reads the UA and iPad Safari reports desktop ("Macintosh"), which `src/utils/misc.ts:89` documents explicitly. Touch laptops/2-in-1s were exposed the same way. Geometry beats UA sniffing here.
+
+**How to apply:** an overlay strip anchored to a screen edge must be sized from the content it must not cover, never from the chrome it reveals. Check the whole family: the FooterBar trigger is `h-[52px]` with the same mobile-only gate.
+
+**Coverage:** `getHeaderTriggerHeight` unit cases in `src/__tests__/utils/insets.test.ts`; real hit testing in `e2e/tests/annotation.spec.ts` ("first line of text hittable when the page header is off") — desktop Chromium is non-mobile, so it is the only lane where the strip is armed. New `ReaderPage` helpers: `setPageHeaderVisible`, `hideChrome`, `firstLineHitTestNearTop`. Verify red by stashing only `HeaderBar.tsx` — but see [[turbopack-dev-stale-chunk-phantom]], the stash churn poisons the dev server.

--- a/apps/readest-app/.claude/memory/i18n-label-rename-workflow.md
+++ b/apps/readest-app/.claude/memory/i18n-label-rename-workflow.md
@@ -1,0 +1,23 @@
+---
+name: i18n-label-rename-workflow
+description: "Renaming a settings label renames its i18n key — derive the new translations from each locale's own old value, and mirror the rename in commandRegistry.ts"
+metadata:
+  node_type: memory
+  type: feedback
+---
+
+Because this repo is key-as-content, **renaming a UI label renames the translation key** in all 33 locales. Copy-only PRs (#5287 dropping "Show" from the Header & Footer rows, #5301 "Column Gap" -> "Additional Margin") are therefore i18n PRs.
+
+**Don't retranslate the new label from scratch.** Recover each locale's *old* value and strip the changed word from it — that keeps the result in the translator's own terminology instead of substituting yours:
+
+```
+git show <base>:apps/readest-app/public/locales/<code>/translation.json
+```
+
+For #5287 that turned `"Show Remaining Time": "Verbleibende Zeit anzeigen"` into `"Remaining Time": "Verbleibende Zeit"` mechanically, for every locale, with no guesswork. Check first whether the new key already exists (`Reading Progress` did) — the extractor reuses it and you get one fewer string to write.
+
+**Also grep `src/services/commandRegistry.ts`.** It mirrors a subset of settings labels as `labelKey` for the settings-search palette; a rename that misses it silently desyncs the palette from the panel. Its `keywords` arrays are separate, so leaving `'show'` in them keeps the old search term working after the label loses it.
+
+**Partial revert without diff churn:** `pnpm i18n:extract` only ever *appends* re-added keys, so restoring a key you'd renamed lands it at the bottom of the file and shows as a move in the diff. Instead rebuild each JSON by walking the base commit's key order, taking the current value for keys that survived and the base value for the ones you're restoring, then appending genuinely-new keys. Re-run `pnpm i18n:extract` afterwards and confirm it is a no-op — that proves the file is exactly what the scanner would produce.
+
+Related: [[i18n-extract-prunes-keys]], [[feedback_en_plurals_manual]], [[settings-panel-screenshot-via-playwright]].

--- a/apps/readest-app/.claude/memory/image-viewer-alt-caption-5232.md
+++ b/apps/readest-app/.claude/memory/image-viewer-alt-caption-5232.md
@@ -1,0 +1,20 @@
+---
+name: image-viewer-alt-caption-5232
+description: "#5232 image viewer shows the book's own image description (img alt / svg title); MERGED #5472"
+metadata:
+  node_type: memory
+  type: project
+---
+
+MERGED #5472 (2026-08-03). EPUBs often keep an illustration's caption or table description in the `img` `alt` attribute rather than a `<figcaption>`, and it was invisible once the image opened full screen.
+
+Where the description lives, by markup shape: `<img alt>` for plain images, the SVG **`<title>`** for `<svg><image/></svg>` wrappers (very common for full-page illustrations and covers). Whitespace-only alt counts as none. Both are read in `collectDocumentImages()` in `src/app/reader/utils/documentImages.ts`, extracted from the inline loop that used to live in `FoliateViewer.handleImagePress`.
+
+Two non-obvious bits:
+
+- The caption is its **own** state (`selectedImageAlt`) next to `selectedImage`, NOT derived from `imageList[currentImageIndex]`. When the tapped image is not found in the list, the index falls back to `0`, so a derived caption would silently label the image with a *different* image's description. Any future change here must keep the two updated together across open / prev / next / close.
+- The zoomed `<img>` carries `role='none'` (presentation), so the `alt` is **not** an accessible name no matter what you put in it. Screen readers get the description from the visible `.image-caption` text node instead. Do not "fix" a11y by only touching `alt`.
+
+UI rule that drove the design: the caption does not share the zoom badge's 2s auto-hide, because it is content rather than chrome. Tapping the image toggles it off the artwork (`showCaption`, flipped in the same handler as `showZoomLabel`). It renders as a **sibling** of the click-to-close container so reading or scrolling a long description never dismisses the viewer, uses `dir='auto'` (book language != UI language), and is offset by the bottom inset.
+
+Local browser verification needs a purpose-built EPUB (the `sample-alice.epub` fixture has no alt-bearing inline figures) and the worktree port trap in [[web-e2e-local-devserver-cold-compile-flake]]. Related: [[invert-img-dark-override-5250]].

--- a/apps/readest-app/.claude/memory/library-search-history-mask-fade-5488.md
+++ b/apps/readest-app/.claude/memory/library-search-history-mask-fade-5488.md
@@ -1,0 +1,23 @@
+---
+name: library-search-history-mask-fade-5488
+description: "PR #5488 library search history chips over background textures - translucent bg-base-300/45 like the input, scroll edge fades must be mask-image on the container (painted from-base-200 overlays smear over images); reader sidebar SearchBar still uses old pattern"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: b25fa0d9-2e12-45ae-98df-a486d7b7c801
+  modified: 2026-08-04T08:24:43.404Z
+---
+
+PR #5488 (MERGED 2026-08-04): with a library background texture, the search history chips (`src/app/library/page.tsx`) were opaque `bg-base-100` pills and the two absolutely-positioned `from-base-200` gradient fade divs painted a visible smear over the image (worst right before the clear X).
+
+Fix pattern (reusable wherever scroll-edge fades sit on a texture/image background):
+
+- Chips match the search input exactly: `bg-base-300/45 hover:bg-base-300/70` (input is `bg-base-300/45` in LibraryHeader).
+- Edge fades = `mask-image` on the scroll container itself, NOT painted gradient overlays: `not-eink:[mask-image:linear-gradient(to_right,transparent,black_12px,black_calc(100%_-_12px),transparent)]`. The mask dissolves the chips; overlays paint theme color on top of whatever is behind.
+- Keep the mask SYMMETRIC: CSS gradients have no logical (start/end) direction, so an asymmetric `to right` mask puts the wider fade on the wrong side in RTL. 12px each edge preserved the first chip's rounded cap better than 24px.
+- Tailwind 3.4 arbitrary property + custom `not-eink` variant compiles fine; autoprefixer (in postcss.config) emits `-webkit-mask-image`, so no manual prefix class.
+- `eink:hidden` on the old overlays maps to `not-eink:` gating the mask.
+
+Still using the old painted-overlay pattern: reader sidebar `src/app/reader/components/sidebar/SearchBar.tsx` (~line 400) - fine there because the sidebar is always solid base-200, but it will smear if that panel ever gets textures.
+
+Verification: CDP live-preview on the Xiaomi (see [[android-cdp-e2e-lane]] recipe - suppress_origin, classList toggle of classes already in the shipped bundle, inline-style the mask) plus Chrome against dev-web with `localStorage['search-history-library']` seeded; history row only renders when `librarySearchTarget === 'text'` (`/library?search=text`, but the [[library-then-by-sort-order-5119]] URL cleanup strips it and falls back to the stored target - toggle via the search bar's leading icon).

--- a/apps/readest-app/.claude/memory/library-then-by-sort-order-5119.md
+++ b/apps/readest-app/.claude/memory/library-then-by-sort-order-5119.md
@@ -1,0 +1,50 @@
+---
+name: library-then-by-sort-order-5119
+description: "#5119 independent Then-by asc/desc: secondary direction lives inside createBookSorter, and Bookshelf URL-param cleanup silently overrides hand-made deep links"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 7391c0bc-86de-4d9e-933c-f90b19ff49d3
+  modified: 2026-08-03T16:49:36.145Z
+---
+
+Issue #5119, MERGED as #5474 (2026-08-04): the library's "Then by" secondary sort
+got its own Ascending/Descending, stored as `libraryThenSortAscending` (default `true`) with URL
+param `thenOrder`. Same pass dropped every `2` suffix: setting `librarySortBy2` ->
+`libraryThenSortBy`, URL params `sort2`/`order2` -> `thenSort`/`thenOrder`.
+
+The *setting* rename needed `migrateLibraryThenSort()` in `settingsService.ts` — `librarySortBy2`
+had been persisted since 2026-05-29 (#4347), so a bare rename would silently reset everyone's
+"Then by" to None. Migrate-then-`delete` the legacy key, otherwise a later explicit `'none'` gets
+resurrected on the next load. The *URL param* rename needs no compat shim: the params are only a
+per-view override that ViewMenu always writes in lockstep with the setting, so a stale
+`?sort2=...` link just falls back to the (migrated) stored value. Only a link shared to a
+different user loses the override.
+
+Two things that are easy to get wrong:
+
+1. **Direction must move inside `createBookSorter`.** `Bookshelf.tsx` used to multiply the whole
+   comparator by `sortOrderMultiplier`, which flipped the tiebreaker along with the primary key —
+   that IS the bug in #5119. `createBookSorter(sortBy, lang, secondary, sortAscending,
+   secondaryAscending)` now applies both directions itself, so book-vs-book comparisons must
+   NOT be multiplied again. Group-vs-group and group-vs-book comparisons still use the external
+   `sortOrderMultiplier` (they only look at the primary key).
+   `createWithinGroupSorter` takes `secondaryAscending` as its 6th arg; series index stays
+   ascending always.
+
+2. **`updateUrlParams` strips params that equal the app default, but the fallback is the user's
+   stored setting.** `if (params.get('thenOrder') === 'asc') params.delete('thenOrder')` — after
+   the strip, `thenSortOrder` falls back to `settings.libraryThenSortAscending`. So a hand-crafted
+   deep link like `?thenOrder=asc` is silently overridden when the stored setting says desc. Same
+   latent behavior already exists for `sort`/`order`. Consequence when verifying in the browser:
+   driving sort state by typing URLs lies to you — use the View menu (it writes setting + param
+   together), or `console.log` the resolved `{sortBy, sortOrder, thenSortBy, thenSortOrder}` from
+   the `sortedBookshelfItems` memo.
+
+Good live-verification recipe: search `q=` down to a handful of same-author/same-progress books
+(ties on the primary key are what make the secondary observable), list view, then toggle
+Then by → Ascending/Descending in the menu and watch the block reverse. See
+[[web-e2e-local-devserver-cold-compile-flake]] for why the list paints blank until first scroll.
+
+Related: [[i18n-label-rename-workflow]] was not needed here — the menu reuses the existing
+`Ascending`/`Descending` keys.

--- a/apps/readest-app/.claude/memory/media-overlay-narration-5480.md
+++ b/apps/readest-app/.claude/memory/media-overlay-narration-5480.md
@@ -1,0 +1,24 @@
+---
+name: media-overlay-narration-5480
+description: "PR #5480 EPUB 3 Media Overlays narration MERGED; architecture map + 3 minor review findings left unfixed (preload TOCTOU race, RTL page-follow, skip-navigation hop)"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: c46eb2fb-779e-451f-8ab7-137974cf360c
+  modified: 2026-08-04T04:36:35.000Z
+---
+
+PR #5480 (closes #3924) MERGED 2026-08-04: books with EPUB 3 Media Overlays play their own recorded narration through the existing Read Aloud stack. All logic in `src/services/tts/mediaOverlay/` (parseSmil → MediaOverlaySection → MediaOverlayTTS → MediaOverlayClient); marks are section-global par ordinals, so marks↔clips are 1:1 with no text-to-audio alignment.
+
+Key facts not obvious from the code:
+- foliate-js needed NO changes: it already exposes `section.mediaOverlay`, `book.loadText/loadBlob`, and `book.media` (camelCased `media:*` meta incl. narrator/duration). The Tauri native EPUB bridge drives the same foliate `EPUB.init()`, so narration/badge work on that path too.
+- `TTSClient` widenings: `TTSCapabilities.continuousTimeline` (skip controller paragraph gap) and `stop(handover?)` (stay rolling between utterances). `mediaClock` capability now gates timeline/`getPlaybackInfo` instead of `=== ttsEdgeClient`.
+- Per-book `viewSettings.ttsUseNarration` (default true) is separate from `ttsVoice` because ttsVoice inherits the global default and can't distinguish "never chose" from "chose synthetic".
+- `Book.hasNarration` is derived on import, NOT synced; books imported pre-#5480 show no headphones badge until re-imported.
+
+Minor review findings left UNFIXED at merge:
+1. Preload TOCTOU: `MediaOverlayClient.speak` preload guard `!this.#audio` is checked pre-await; a concurrent preload for a different audio file can revoke the element under active playback. Fix: also require `!this.#audioLoad`.
+2. RTL/vertical page-follow: `isBeyondPage` (useTTSControl) and `isSoundingSentenceOnScreen` assume off-page content at coords >= `renderer.end`; in RTL pagination follow silently never fires (benign degrade).
+3. `#initTTSForSection` calls `onSectionChange` (navigates view) before discovering an advertised overlay's SMIL is unusable, so the view can visibly hop through a skipped section.
+
+iOS Tauri Now Playing unverified; #3924's cloud-sync/KOReader parity asks are still open. Real-EPUB e2e suite is opt-in: `READEST_MO_EPUB=<path> pnpm test media-overlay-real-epub` (W3C moby-dick-mo.epub). Related: [[tts-listening-counts-as-reading-stats]], [[edge-tts-baked-silence-ios-native-5414]].

--- a/apps/readest-app/.claude/memory/onedrive-oauth-callback-slash-5253.md
+++ b/apps/readest-app/.claude/memory/onedrive-oauth-callback-slash-5253.md
@@ -1,0 +1,17 @@
+---
+name: onedrive-oauth-callback-slash-5253
+description: "#5253 OneDrive OAuth hang/fail: Microsoft appends / to scheme://host callbacks; fixed in #5479 + Rust bridge was dropping TS fields"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 9514654c-db01-441e-b22c-ec393f217bb0
+  modified: 2026-08-04T04:36:47.734Z
+---
+
+**#5253 / PR #5479 (MERGED 2026-08-04): OneDrive OAuth callbacks hung Android, failed desktop.**
+
+- Root cause: Microsoft canonicalizes a path-less redirect URI to a trailing slash, so registered `readest-onedrive://auth` comes back as `readest-onedrive://auth/`. `parseRedirect` compared pathname strictly (`''` vs `'/'`) and threw on desktop; Android's `onNewIntent` only matched the hardcoded Supabase/Google callback shapes so the Custom Tab invoke never resolved.
+- Fix shape: normalize ONLY empty-vs-root path in `parseRedirect.ts` (also added host/username/password comparison, which the old protocol+pathname guard lacked); Android matches per-request via `OAuthCallbackTarget` passed as `callbackUrl` through the bridge.
+- **Rust `models.rs` AuthRequest silently drops unknown TS fields at the `run_mobile_plugin` hop** (serde ignores unknowns). `callbackScheme` never reached iOS before #5479, so ASWebAuthenticationSession always used the fallback `readest` scheme — adding fields to the TS interface is NOT enough, they must be added to the Rust struct too (`skip_serializing_if = "Option::is_none"`).
+- The PR as submitted did not compile (Kotlin expression-body `return` in `OAuthCallbackTarget.parse`); I pushed the block-body fix. See [[android-kotlin-unit-test-gradle-recipe]] for why CI missed it and how to compile locally.
+- iOS/Android device verification of the OneDrive flow still pending as of merge.

--- a/apps/readest-app/.claude/memory/opds-feed-cover-5270.md
+++ b/apps/readest-app/.claude/memory/opds-feed-cover-5270.md
@@ -1,0 +1,29 @@
+---
+name: opds-feed-cover-5270
+description: "#5270 OPDS feed cover ignored at import; rel substring match trap; dev-mode proxy allows localhost so a local OPDS feed can be driven end to end"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: a11c86f6-7e70-420b-b0f3-bfb1f3314391
+  modified: 2026-08-03T17:41:43.218Z
+---
+
+**#5270 "readest doesn't use the covers / metadata provided by OPDS"** — cover half MERGED #5471 (2026-08-03, `11ae9e135`). **Metadata half MERGED #5477** (2026-08-04, `ffdcfca0a`). Issue fully resolved.
+
+**Metadata half:** new `src/services/opds/metadata.ts` — `getOPDSBookMetadata(pub)` (pure map to `OPDSBookMetadata`, a `Partial<BookMetadata>` with `author` widened to `string | string[]` like MarkdownMetadata; emits only non-empty fields; description = typed content `SYMBOL.CONTENT || content` before plain `description`, through `getOPDSDescriptionHtml` since BookDetailView renders HTML) + `applyOPDSMetadata(book, m)` (per-field feed-wins merge, `normalizeMetadataIsbn`, re-derives title/author/primaryLanguage ONLY for feed-provided sources so "Download Again" can't reset a user-edited title via a silent feed, bumps `updatedAt`+`metadataUpdatedAt` — unlike coverUpdatedAt there's no upload-first hazard because metadata travels in the book row; never touches `sourceTitle`/`metaHash`). Wired in `page.tsx handleDownload` (add `publication` to the useCallback deps!) and autoDownload via `PendingItem.metadata` filled in `collectNewEntries` (map there — the Symbol-keyed content must not need to serialize). `OPDSPerson`/`OPDSSubject` had to become exported (tsgo TS4023 on the exported signature).
+
+New `src/services/opds/cover.ts` holds both halves of the fix:
+- `getOPDSCoverHref(pub)` — full `rel=".../image"`, then thumbnail, then any image.
+- `applyOPDSCover({appService, book, coverUrl, username, password, customHeaders})` — reuses the book download's proxy/basic-auth/custom-header/`skipSslVerification` path, writes over `Books/<hash>/cover.png`, then refreshes `coverHash` + `coverImageUrl`. Best effort; failure keeps the extracted cover.
+
+Wired after `importBook` in BOTH acquisition paths: `app/opds/page.tsx` `handleDownload` (before the cloud upload is queued) and `services/opds/autoDownload.ts` (href rides on the new `PendingItem.coverHref`, filled in `collectNewEntries`).
+
+**The trap that made the pre-existing cover picker wrong:** `REL.COVER.some(rel => img.rel?.includes(rel))` is a *substring* test, and `http://opds-spec.org/image/thumbnail` CONTAINS `http://opds-spec.org/image`. An entry listing its thumbnail first had the thumbnail chosen as the full-size cover. Match exact rel tokens instead (`Array.isArray(rel) ? rel : (rel ?? '').split(/\s+/)`), like `opdsPublication.ts` already did. `PublicationCard`'s THUMBNAIL filter is safe by luck (the reverse containment does not hold).
+
+**Cover sync fields:** set `coverHash` (the `coverHash === partialMD5(cover.png)` invariant, [[bug-patterns]] / #4544) but deliberately NOT `coverUpdatedAt` — matches what `importBook` itself does. Bumping `coverUpdatedAt` on an already-`uploadedAt` book would make peers fetch a cover the cloud does not have yet; `library/page.tsx handleUpdateMetadata` only bumps it after a successful `uploadBookCover`. New books propagate fine anyway: `needsCoverRefresh` returns true on `!local.coverDownloadedAt`.
+
+**E2E trap (2026-08-04):** the local-feed verification failed twice NOT because of the code but because `next dev` served stale chunks — see [[turbopack-dev-stale-chunk-phantom]]: `rm -rf .next` before EVERY dev-server start. The stale runs doubled as the negative control (library showed the EPUB's "Alice's Adventures in Wonderland"; fresh chunks showed the feed's title). Dump the persisted record from the page via IndexedDB `AppFileSystem`/`files`, key `Readest/Books/library.json` — faster than driving the details UI.
+
+**Verifying an OPDS change end to end locally (reusable):** `src/app/api/opds/proxy/route.ts` has `isPrivateHostAllowed = () => process.env.NODE_ENV === 'development'`, so under `pnpm dev-web` the SSRF guard lets `http://localhost:*` through and a throwaway Node OPDS feed server works. Recipe: serve an Atom acquisition feed + `sample-alice.epub` + a *deliberately different* cover PNG, then a throwaway spec in `e2e/tests` navigates `/opds?url=<encoded feed>`, clicks Download, and reads the library cover's byte length via `fetch(img.src)` in the page. OPDS cover 2738 B vs the EPUB's embedded 327217 B made it unambiguous, and disabling the wiring flipped the number, which is what proves the check discriminates. See [[settings-panel-screenshot-via-playwright]], [[web-e2e-local-devserver-cold-compile-flake]].
+
+Known behavior change, flagged in the PR and not objected to: "Download Again" on a book you already own replaces a hand-edited cover with the catalog's.

--- a/apps/readest-app/.claude/memory/reader-feature-fixes.md
+++ b/apps/readest-app/.claude/memory/reader-feature-fixes.md
@@ -39,3 +39,16 @@ Moved from MEMORY.md to keep the index small. One line per memory; open the link
 - [Android image callout freeze](android-image-callout-freeze.md) `.no-context-menu` ANCESTOR
 - Inline-img vertical-align (#4866) · [Table dark-mode tint #4419](table-dark-mode-tint-4419.md) · [footnote aside border #4438](footnote-aside-namespace-order-4438.md)
 - [Russian NBSP #4769](russian-hanging-prepositions-nbsp-4769.md)
+- [#5398/#3870 annotations hub](annotations-hub-5398-3870.md) MERGED #5448; shared filterBooknotes/facets; toolbar = icon row + filter dropdown (merge injected menuClassName); header search icon per-tab
+- [#5406 TTS vs proofread doc sync](tts-proofread-doc-sync-5406.md) MERGED #5416; createDocument bypassed transformTarget 'data' transforms; TTS docs replay display pipeline; MD books get transformTarget + srcdoc path
+- [#5262 clip sign-in capture](clip-signin-interactive-capture-5262.md) MERGED #5377; interactive clip mode + Safari share-ext DOM capture; xcodegen-in-worktree symlink trick
+- [#5294 web-novel URL import](webnovel-url-import-5294.md) MERGED #5381; buildEpub not feed-book; re-import in place via metaHash, exact-URL-keyed; clip pickMetaContent dead code UNFIXED
+- [#5352 Discord cover -> book icon](discord-cover-fallback-5352.md) MERGED #5382; content-addressed temp key; negative cache split missing vs transient; no Content-Type + no log still open
+- [#5216 Persian RLM half-space](rlm-bidi-mark-shaping-5216.md) PR #5361 MERGED; sanitizer half dead code; real cause = font-fallback shaping
+- [#5362 image zoom % was fit-relative](image-viewer-fit-relative-zoom-5362.md) MERGED #5365; `will-change` does NOT pin raster scale; dataUrl byte-exact
+- Paragraph mode: [toggle/resume #4717](paragraph-mode-toggle-resume-4717.md); [exit #4474](paragraph-mode-accidental-exit-4474.md); [#5275 styling](paragraph-mode-styling-5275.md) MERGED #5338 solid backdrop or ghosting; [#5246 display settings](paragraph-mode-display-settings-5246.md) MERGED #5403 font on frame or 66ch won't scale
+- [#5178 auto-hide cursor](autohide-cursor-5178.md) MERGED #5404; dormant foliate CursorAutohider; attr on view NOT renderer; top-level SystemSettings, default-on
+- [#5342 footer pills go black](footer-pill-vs-blend-5342.md) MERGED #5347; pill bg and `mix-blend-difference` cannot coexist
+- [#5351 popup restyle](popup-filter-containing-block-5351.md) MERGED; ancestor `filter` = containing block + stacking context; `theme-dark:` variant; `text-foreground` undefined token
+- [#5303 header notch negative margin](header-notch-negative-margin-5303.md) MERGED #5447, VERIFIED Xiaomi 13; z-10 ONLY when lifted else covers desktop toolbar
+- [#5394 Ambient Mode (light sensor)](ambient-mode-light-sensor-5394.md) MERGED; `emitOrQueue` one-shot-only; themeStore vs `getThemeCode` defaults must match

--- a/apps/readest-app/.claude/memory/recent-read-shelf-3797.md
+++ b/apps/readest-app/.claude/memory/recent-read-shelf-3797.md
@@ -5,6 +5,7 @@ metadata:
   node_type: memory
   type: project
   originSessionId: d5f79cf1-9e58-4ae4-9f8a-46a8e8ca625f
+  modified: 2026-08-04T08:10:14.783Z
 ---
 
 Opt-in "Recently read" strip in the library Virtuoso header (PR #4829, issue #3797). `selectRecentShelfBooks(books, count)` in `libraryUtils.ts` (filter `!deletedAt && progress != null`, sort by `updatedAt` desc, slice 12). Setting `libraryRecentShelfEnabled` (default false) + View-menu toggle. Rendered via the Virtuoso `Header` through `BookshelfListContext` (stable identity → no grid re-render churn); list `<Virtuoso>` needs explicit `context={listContext}`.
@@ -12,5 +13,11 @@ Opt-in "Recently read" strip in the library Virtuoso header (PR #4829, issue #37
 **Reuse, don't reimplement:** each slide renders the real `BookItem` (identical cover/title/progress/badges). The open path was extracted to `src/app/library/hooks/useOpenBook.ts` (in-place stale-record probe + `makeBookAvailable` on-demand download for cloud-only synced books + navigate) and is shared by `BookshelfItem` AND the recent shelf. Do NOT open via the select-mode `navigateToReader` path — it skips the download, so a recently-read book that synced (progress + `updatedAt`) without its blob fails to open on a second device.
 
 **Alignment gotcha (cost several iterations):** a horizontal flex strip with `basis-1/N` does NOT match a CSS-grid column when the grid has a row gap — CSS Grid subtracts the gap from each track, flex `basis` does not (covers come out too wide at 2/3 cols where `BOOKSHELF_GRID_CLASSES` uses `gap-x-4`; matches at `sm+` where `gap-x-0`). Fix: size each slide with the grid's own formula `flexBasis: calc((100% - (var(--rs-cols) - 1) * var(--rs-gap)) / var(--rs-cols))`, with `--rs-cols` (responsive `3/4/6/8/12` ladder when auto, else `libraryColumns`) and `--rs-gap` (`1rem` base / `0px` sm+, mirroring `gap-x-4 sm:gap-x-0`) set on the row. Also `min-w-0` on each flex item, else image covers expand to intrinsic width. Verified 0.00-0.02px edge diff vs a real CSS grid at N=2/3/4/5 (standalone HTML repro + getBoundingClientRect).
+
+**Select mode + pull-to-refresh fixes MERGED in PR #5486** (2026-08-04; worktree and branch cleaned up; the dev working tree still carries the pre-merge file copies until the next pull).
+
+**Pull-to-refresh (2026-08-04):** the shelf lives in the Virtuoso Header — a SIBLING of the List, and `usePullToRefresh` translated only the first `.transform-wrapper` (the List), so the shelf stayed pinned during the pull. Fix: hook now drags ALL `.transform-wrapper`s under the scroller in lockstep; shelf root carries the class. Any future scroller sibling that should ride the pull just adds `transform-wrapper`. Xiaomi 13-verified via CDP `Input.synthesizeScrollGesture` + rAF transform recorder (see [[android-cdp-e2e-lane]]).
+
+**Select mode (2026-08-04):** the shelf originally unmounted in select mode (`!isSelectMode` in `showRecentShelf`) and `RecentSlide` hardcoded `isSelectMode={false}` — users could not select shelf books at all. Now wired like the grid: shelf stays mounted, tap toggles in select mode, long-press enters select mode + selects, `BookItem` gets real `isSelectMode`/`bookSelected`. Pass the store's `selectedBooks` **Set** (stable identity) into the header memo, not `getSelectedBooks()` (fresh array per call → would churn the Virtuoso Header identity every render). Tests: `recent-shelf-select-mode.test.tsx` (stub BookItem, real useLongPress via pointer events + fake timers).
 
 Arrows: plain scroll div + `scrollBy`, shown on overflow (`scrollLeft`/`scrollWidth`, `ResizeObserver`), centered on `.bookitem-main` via measure; `start-2`/`end-2` + `rtl:rotate-180`. Swipe never opens (useLongPress moveThreshold). i18n: `i18n:extract` churns every locale (see [[i18n-extract-prunes-keys]]) — added the 2 keys manually; bo/si/ta/bn best-effort.

--- a/apps/readest-app/.claude/memory/settings-panel-screenshot-via-playwright.md
+++ b/apps/readest-app/.claude/memory/settings-panel-screenshot-via-playwright.md
@@ -1,0 +1,25 @@
+---
+name: settings-panel-screenshot-via-playwright
+description: "Recipe for eyeballing a settings-panel change: throwaway spec in e2e/tests driving the real web build, with the two gotchas that bite"
+metadata:
+  node_type: memory
+  type: project
+---
+
+To actually *look* at a reader-settings change instead of trusting the diff, drop a throwaway spec into `e2e/tests/` (Playwright's `testDir`) and delete it afterwards. The `openBook` fixture in `e2e/fixtures/base.ts` handles import-and-open, so the whole thing is a few lines:
+
+```ts
+const reader = await openBook();
+await reader.revealHeader();
+await reader.headerBar.locator('button[aria-label="Font & Layout"]').click();
+await page.locator('[data-tab="Layout"]').click();
+```
+
+Two gotchas cost several iterations on #5287:
+
+- **`.modal-box` resolves to 5 elements** (settings, About, Keyboard Shortcuts, Software Update, Proofread Rules are all mounted), so a bare locator is a strict-mode violation. Use `.first()`.
+- **Screenshotting the `[data-setting-id=...]` section directly gives you a clipped image** — the element is taller than its scroll container. Set a tall viewport (`page.setViewportSize({ width: 1280, height: 1200 })`), `el.scrollIntoView({ block: 'end' })`, and screenshot the modal box instead of the section.
+
+Toggle the dependent rows on first (`page.getByText(label, { exact: true }).click()`), otherwise everything below the parent switch renders disabled and you can't judge the real thing.
+
+Warm `pnpm dev-web` before running, per [[web-e2e-local-devserver-cold-compile-flake]]. Clean up `tmp-*.png`, `test-results/`, and `playwright-report/` before committing.

--- a/apps/readest-app/.claude/memory/steamos-gamescope-file-dialog-3049.md
+++ b/apps/readest-app/.claude/memory/steamos-gamescope-file-dialog-3049.md
@@ -1,0 +1,26 @@
+---
+name: steamos-gamescope-file-dialog-3049
+description: "#3049 SteamOS Gaming Mode: import dialog never appears — gamescope session has no FileChooser portal backend; fixed with info toast (MERGED #5475); in-app browser rejected, chooser IS the scope-grant security model"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 99db45a5-e590-4336-b798-a10f50869721
+  modified: 2026-08-03T17:05:38.968Z
+---
+
+Issue #3049 (open, reported 2026-01-24, researched 2026-08-04): Readest Flatpak added to Steam as non-Steam app; "Import Books" does nothing in SteamOS Gaming Mode, works in Desktop Mode.
+
+**Root cause (not a Readest bug per se):**
+- Dialog chain: `useFileSelector.ts` `selectFileTauri` → `nativeAppService.ts:757` `openDialog()` → tauri-plugin-dialog 2.7.1 → rfd 0.16 **gtk3 backend** (`GtkFileChooserNative`; no ashpd in Cargo.lock — the `xdg-portal` feature is NOT enabled).
+- Flathub manifest (sibling checkout `/Users/chrox/dev/com.bilingify.readest/com.bilingify.readest.yml`) has **no `--filesystem=` entries** — all host file access flows through the FileChooser portal (GtkFileChooserNative auto-delegates to portal when sandboxed).
+- Gaming Mode's gamescope session runs no portal backend → `org.freedesktop.portal.FileChooser` interface absent (same wall UnleashedRecomp PR #1437 hit). Dialog yields nothing; JS gets `null` = **indistinguishable from user cancel** (`page.tsx:1206` silently no-ops). So env detection, not error handling, is the trigger.
+
+**Dead end:** falling back to `selectFileWeb` (`<input type=file>`) does NOT dodge it — WebKitGTK's file chooser is also GtkFileChooserNative → same portal → same failure.
+
+**Decision (chrox, 2026-08-04): info toast only.** In-app file browser REJECTED — Readest's security model deliberately relies on the system chooser to add the picked paths to the fs access scope; a manifest `--filesystem` grant would defeat it. Upstream fix (Valve shipping a portal backend in the gamescope session): no sign of it.
+
+**MERGED #5475** (2026-08-04, squash ba6e1fcb3; worktree and branch cleaned up): `useFileSelector.selectFileTauri` checks `isLinuxApp` + gamescope (existing `get_environment_variable` command — no Rust change needed; `GAMESCOPE_WAYLAND_DISPLAY` set OR `XDG_CURRENT_DESKTOP` contains "gamescope") and dispatches an info toast BEFORE opening the dialog (robust whether the portal call errors or hangs). Covers books/fonts/dictionaries/covers; `selectDirectory` (auto-import folder picker) NOT covered. i18n key translated across all 33 locales. Root-cause comment posted: issue #3049 comment 5169305873.
+
+Flatseal `--filesystem=home` alone does NOT fix it — GTK still portals when sandboxed. Non-flatpak builds (AppImage/deb) likely work in Gaming Mode (unsandboxed → in-process GTK dialog).
+
+Related: [[book-actions-platform-surfaces]], [[wayland-tap-context-menu-5360]] (Linux windowing quirks).

--- a/apps/readest-app/.claude/memory/svg-cover-stretch-duokan-5375.md
+++ b/apps/readest-app/.claude/memory/svg-cover-stretch-duokan-5375.md
@@ -5,7 +5,7 @@ metadata:
   node_type: memory
   type: project
   originSessionId: 032f04ee-bbd2-4726-9c37-47e99c910fca
-  modified: 2026-07-28T14:50:16.046Z
+  modified: 2026-08-03T16:07:01.774Z
 ---
 
 Issue #5375 (2026-07-28): cover.xhtml wraps cover.jpg in `<svg viewBox="0 0 1000 1333" width="100%" height="100%" preserveAspectRatio="xMidYMid meet">`; reporter (Windows 10, Readest 0.11.20) says the cover is stretched.
@@ -18,6 +18,8 @@ Verification on Chrome (web dev build, same code as the v0.11.20 tag for this pa
 **Conclusion:** the reported markup alone is fine; the reporter's real book is almost certainly a Duokan/DangDang-flavored EPUB whose html root carries `data-duokan-page-fullscreen` (that ecosystem uses exactly this SVG cover structure). The "bug" is the feature's aspect-ratio-ignoring stretch on viewports whose aspect differs from the cover. Need the reporter's file to confirm. A fix would be scaling+cropping (cover-style) or honoring `meet` instead of `fill` in the fullscreen path — but note the stretch was chosen deliberately to match Duokan's native render.
 
 Attribute origin found: `paginator.js` ~3303/~3391 stamps EVERY spine itemref property as `data-<prop>=""` on the content document root, so `<itemref properties="duokan-page-fullscreen"/>` in the OPF spine is the usual trigger (a literal attribute on the book's `<html>` also works since the check is `hasAttribute`). Early greps missed it because the mapping is generic (`'data-' + prop`).
+
+**SUPERSEDED (2026-08-04):** the stretch behavior was REMOVED for #5263 — fullscreen covers now letterbox (contain + black bars), see [[duokan-fullscreen-cover-letterbox-5263]]. Historical resolution below.
 
 **Resolution (2026-07-28):** replied on #5375 (comment 5105708791) that the stretch is the intended Duokan full-screen page behavior, aspect ratio deliberately not preserved. Reference chain: #3424 + #3914 (requests to render duokan-page-fullscreen truly full screen like Duokan Reader), #4643 (led to `object-fit: fill` instead of `contain`), #4961 (chrox: by design, no extra option, book maker's trade-off), #5263 (OPEN, same symptom; its two attached books verified to declare `duokan-page-fullscreen` on the cover itemref; also complains swipe doesn't turn pages on that page + Android-only sideways illustrations, both unverified).
 

--- a/apps/readest-app/.claude/memory/sync-fixes.md
+++ b/apps/readest-app/.claude/memory/sync-fixes.md
@@ -28,3 +28,4 @@ Moved from MEMORY.md to keep the index small. One line per memory; open the link
 - Google Drive: [research](gdrive-sync-provider-research.md); [multi-PR status](gdrive-provider-multipr-status.md); [full walk every sync](gdrive-fullwalk-every-sync-no-source-cursor.md)
 - [S3/R2 provider](s3-r2-sync-provider.md) MERGED #5051 · [OneDrive provider](onedrive-sync-provider.md) MERGED #5048
 - [Hardcover edition_id #4792](hardcover-progress-edition-id-4792.md)
+- [#5444 CORS preflight cache fix](cors-preflight-cache-fix-5444.md) VERIFIED prod: OPTIONS -83%; wrangler OAuth token works for CF GraphQL analytics (1d max range)

--- a/apps/readest-app/.claude/memory/tap-toggle-progress-bar-5293.md
+++ b/apps/readest-app/.claude/memory/tap-toggle-progress-bar-5293.md
@@ -1,0 +1,21 @@
+---
+name: tap-toggle-progress-bar-5293
+description: "#5293 tap-to-toggle footer restored as optionless ephemeral toggle, MERGED #5466; React onClick verify needs trusted clicks, not extension-dispatched MouseEvents"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: add34f3b-a05d-4745-a0ea-a4ad715f67a0
+  modified: 2026-08-03T13:42:45.781Z
+---
+
+#5293 (tap-to-toggle footer removed in 0.11.20 by #5029) fixed, MERGED #5466 (2026-08-03).
+
+Design per maintainer: NO setting; active whenever showFooter is on. Tap hides/shows the ProgressBar info via local `useState` + `opacity-0` on `.progress-strip` — opacity keeps hit-testing, so the same spot restores it while invisible. Band reservation and `showFooter` are untouched (no reflow, never persisted, resets on book open/remount).
+
+Tap-target split: the strip is `pointer-events-auto` only where it sits on reserved margin space (paginated band, sticky-bar band, vertical side column). Scrolled mode keeps the strip `pointer-events-none` and makes the floating pills the targets (`pointer-events-auto` in pillClass), preserving the #5029 fix that the strip never blocks taps/selection over bottom text.
+
+**Why desktop clicks don't reach it:** FooterBar's 52px hover trigger strip (z-10, pointer-events-auto on ≥640px non-mobile) covers the band and reveals the toolbar on hover — the toggle is a touch-first feature by design. Android quirk: hidden PageNavigationButtons keep invisible 16px corner targets above the strip (pre-existing).
+
+**Verification gotcha (React 19 + Chrome extension):** a `dispatchEvent(new MouseEvent('click', {bubbles:true}))` from the extension's isolated world bubbles all the way to `#document` but React's delegated onClick NEVER fires (0 invocations — verified by wrapping `__reactProps$` onClick). Calling the `__reactProps$*.onClick` directly works, and a real trusted click (computer tool `left_click`) works. Only trusted clicks exercise React handlers end-to-end; don't conclude a handler is broken from isolated-world synthetic dispatch.
+
+Related: [[footer-pill-vs-blend-5342]], [[header-notch-negative-margin-5303]]

--- a/apps/readest-app/.claude/memory/turbopack-dev-stale-chunk-phantom.md
+++ b/apps/readest-app/.claude/memory/turbopack-dev-stale-chunk-phantom.md
@@ -5,11 +5,15 @@ metadata:
   node_type: memory
   type: feedback
   originSessionId: 138d91ff-f7d6-465b-8a89-35b703957a3c
-  modified: 2026-08-02T16:31:29.923Z
+  modified: 2026-08-03T17:29:59.725Z
 ---
 
 During the annotations-hub live smoke (2026-08-03), a long-running `pnpm dev-web` served a BooknoteView chunk that predated 3 committed revisions — even after `location.reload()`. Symptom looked like a real regression (toolbar missing, list blank); hours of debugging risk.
 
 **Why:** many rapid worktree commits + HMR cycles left Turbopack's in-memory/disk module graph inconsistent; reload re-served the stale compiled chunk.
 
+Same failure hit the Playwright web lane (2026-08-04, #4977): after a `git stash push` / `git stash pop` cycle to prove a test red then green, the dev server went back to serving the pre-fix chunk and the new test failed again — the giveaway was a class name (`h-11`) in the assertion output that no longer existed in the source. Playwright asserting on rendered class names is a free identity check; if the DOM shows classes you deleted, it's this, not your fix.
+
 **How to apply:** before treating a live-smoke anomaly as a code bug, verify the browser executes the current source: grab the component's fiber from a DOM node (`Object.keys(el).find(k=>k.startsWith('__reactFiber$'))`, walk `.return`, `String(f.type)`) and grep it for a symbol only the newest revision contains. If stale: kill dev server, `rm -rf .next`, restart. Also note the claude-in-chrome extension BLOCKS returning large innerHTML/source strings ("Cookie/query string data") — return booleans (`src.includes('x')`) instead.
+
+**Recurred 2026-08-04 (#5270 metadata e2e), and RESTART ALONE IS NOT THE CURE:** a `pnpm dev-web` started *after* all edits in a fresh worktree still served page.tsx without the new wiring (an adjacent old `console.log` fired, the new lines didn't — cheap identity check: add a throwaway `console.log` next to the new code and watch for it in the spec's `page.on('console')`). After `rm -rf .next` + restart it worked; then a plain server restart *reusing the existing .next* served stale chunks AGAIN. When verifying code changes through `next dev`, `rm -rf .next` before EVERY server start, not just once.

--- a/apps/readest-app/.claude/memory/wayland-tap-context-menu-5360.md
+++ b/apps/readest-app/.claude/memory/wayland-tap-context-menu-5360.md
@@ -1,0 +1,23 @@
+---
+name: wayland-tap-context-menu-5360
+description: "#5360/#5181/#5041 Wayland two-finger-tap kills native GTK context menu; fix = in-app menu on Linux"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 35f7577d-29e3-492f-83f6-b154ca92acb9
+  modified: 2026-08-03T14:41:01.999Z
+---
+
+**#5360 (dup #5181/#5041): library context menu flashes and vanishes on GNOME Wayland when opened by touchpad two-finger TAP.** Physical press/mouse work; X11 works. Fix MERGED #5467 (2026-08-03): render the menu in-app on Linux desktop instead of popping the native GTK menu.
+
+**Why (two distinct defects, both evidence-backed):**
+1. **Pre-#5182 (≤0.11.18):** positionless `menu.popup()` made muda anchor `gtk_menu_popup_at_rect` to `screen().root_window()` — no Wayland parent → GDK fell back to mapping the menu as an `xdg_toplevel`. Reporter's terminal video shows the smoking gun 3×: `Gdk-WARNING: Couldn't map as window 0x… as popup because it doesn't have a parent`.
+2. **Post-#5182 (0.11.20):** frame extraction of the reporter's video (ffmpeg + magick compare on adjacent frames) proves the menu now maps as a real `xdg_popup` at the correct pointer position, fully rendered, then vanishes within ≤2 frames (~66 ms) with zero further input. Verified against mutter 46 + GTK 3.24 sources: the grab serial check passes for a tap (mutter `grab_serial` = press serial, persists after release; GDK passes `press_serial`), and no compositor path dismisses a granted popup grab without input — so the popdown is client-side (GTK menushell/muda), tap-specific because the popup path (JS → 2 window queries → Tauri IPC → muda → GTK) always loses the race against a tap's instant BTN_RIGHT release. Not fixable from the app while using GTK3 menus.
+
+**Fix:** `BookshelfItem` branches on `appService.isLinuxApp` (inside `hasContextMenu`): Linux → `BookContextMenuPopup` (in-app, ModalPortal + Overlay + Menu/MenuItem primitives, viewport-clamped at pointer, first menuitem focused so Escape works); macOS/Windows keep the native cached `Menu.new` path. Item lists share one builder (`buildBookMenuItems`/`buildGroupMenuItems`, `BookContextMenuItem = {text, action}` is assignable to Tauri `MenuItemOptions`).
+
+**Gotchas:** the bookshelf item wrapper always carries a `scale-100/95` transform → `position:fixed` inside it is item-relative, ModalPortal is mandatory. Standalone `dropdown-content` needs `!relative` (ImportMenuPopup precedent, [[bookshelf-import-menu-popup-5247]]). muda's GTK popup uses a synthetic ButtonPress with only the time stamped — that hack survives held-button releases, not taps.
+
+**Debug technique that cracked it:** download the reporter's GitHub video attachments, `ffmpeg -i` extract frames, `magick compare -metric AE` adjacent frames to find the flash, Read the frames as images. Terminal-recording videos can contain the decisive warning text.
+
+Device verify on a real Wayland box PENDING (no Linux hardware in the session).

--- a/apps/readest-app/.claude/memory/web-e2e-local-devserver-cold-compile-flake.md
+++ b/apps/readest-app/.claude/memory/web-e2e-local-devserver-cold-compile-flake.md
@@ -1,0 +1,17 @@
+---
+name: web-e2e-local-devserver-cold-compile-flake
+description: "Local web e2e failures \"no visible book section found in the viewer\" are next dev cold-compile contention, not a real regression"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 1fe0d4e7-c41d-496e-a9ca-e3976830677e
+  modified: 2026-08-03T13:42:17.471Z
+---
+
+Adding a 6th test to `e2e/tests/annotation.spec.ts` made 2-4 PRE-EXISTING tests fail locally with `no visible book section found in the viewer` (ReaderPage.visibleSectionFrame gives up after 30 x 400ms = 12s).
+
+Not a regression. `playwright.config.ts` runs 4 workers against `pnpm dev-web` locally, so a 6th parallel cold page load starves Next's on-demand compile past that 12s budget. Proof from #5464: the same tests pass 5/5 with the new test excluded, 6/6 with `--workers=1`, and 6/6 (plus the whole 16-test suite) when a `pnpm dev-web` server is already warm on :3000 (`reuseExistingServer: !CI` picks it up).
+
+So before blaming a change for e2e flake: start dev-web yourself, poll `http://localhost:3000/library` until it answers, then run playwright. CI is unaffected - it runs `pnpm start-web` (production build) with 2 retries.
+
+The flip side, from working out of a worktree (#5232): that same `reuseExistingServer` reuses a :3000 server belonging to **another checkout**, and the spec then silently exercises code without your change - it fails (or worse, passes) for reasons that have nothing to do with the diff. `PLAYWRIGHT_BASE_URL` is not read; `playwright.config.ts` hardcodes `PORT = 3000`. Check `lsof -p $(lsof -ti :3000) | grep cwd` before trusting a run from a worktree. Fix: `pnpm exec dotenv -e .env.web -- next dev -p <other-port>` in the worktree plus a throwaway `playwright.tmp.config.ts` (testDir `./e2e/tests`, `baseURL` on that port, no `webServer` block), then `npx playwright test --config=playwright.tmp.config.ts`. Note `dotenv` on PATH is the **Ruby gem** and rejects `-e`; `pnpm exec` picks the dotenv-cli the package scripts use.


### PR DESCRIPTION
Batch of session memories accumulated since #5458.

New memories cover: FXL horizontal scroll (#4995), Duokan fullscreen cover letterbox (#5263), media overlay narration (#5480), OPDS feed cover and metadata (#5270), library then-by sort order (#5119), search history mask fade over textures (#5488), SteamOS Gaming Mode file dialog (#3049), Wayland tap context menu (#5360), OneDrive OAuth callback slash (#5253), annotation toolbar Copy Link (#5452), image viewer alt captions (#5232), dictionary prefs replica category (#5465), EPUB expanded OPF item tags (#5455), plus workflow recipes (Android Kotlin unit test gradle setup, Chrome clipboard paste probe, settings panel screenshots via Playwright, web e2e cold-compile flake, i18n label rename workflow, BookOrbit integration notes).

Updated aggregators and existing memories: MEMORY.md index, android-cdp-e2e-lane (CDP live CSS preview on device), reader-feature-fixes, sync-fixes, recent-read-shelf, svg-cover-stretch, turbopack dev stale chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)