### PR TITLE
fix(reader): correct reading ruler transitions and line bounds

### DIFF
--- a/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ProgressBar.test.tsx
@@ -168,6 +168,21 @@ describe('ProgressBar — decorative footer is not focusable', () => {
     expect(progressInfo).not.toBeNull();
     expect(progressInfo!.hasAttribute('tabindex')).toBe(false);
   });
+
+  it('stays above the reading ruler filter layer', () => {
+    currentViewSettings = {
+      ...baseSettings,
+    } as ViewSettings;
+    currentProgress = makeProgress(2, 5);
+    currentBookData = { isFixedLayout: false };
+    currentRenderer = { page: 1, pages: 4 };
+
+    const { container } = renderProgressBar();
+
+    // ReadingRuler uses z-[5]. Reader chrome must paint above it so the
+    // backdrop filter cannot blur the footer when the ruler reaches the bottom.
+    expect(container.querySelector('.progressinfo')?.classList.contains('z-10')).toBe(true);
+  });
 });
 
 describe('ProgressBar — sticky progress bar', () => {

--- a/apps/readest-app/src/__tests__/components/ReadingRuler.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ReadingRuler.test.tsx
@@ -17,7 +17,12 @@ type RulerTestRect = {
 
 // Mutable doubles read lazily by the store mock so individual tests can drive
 // the progress range and the scrolled-mode visible contents.
-let mockProgress: { range: unknown; pageinfo: { current: number } } | null = null;
+let mockProgress: {
+  range: unknown;
+  location: string;
+  fraction: number;
+  pageinfo: { current: number };
+} | null = null;
 let mockContents: Array<{ doc: unknown }> = [];
 
 vi.mock('@/context/EnvContext', () => {
@@ -278,12 +283,52 @@ describe('ReadingRuler', () => {
     expect(saveViewSettings).not.toHaveBeenCalled();
   });
 
+  it('resets on a new visible location within the same estimated page', async () => {
+    mockProgress = {
+      range: null,
+      location: 'epubcfi(/6/2!/4/2)',
+      fraction: 0.1,
+      pageinfo: { current: 4 },
+    };
+    const props = {
+      bookKey: 'book-1',
+      isVertical: false,
+      rtl: false,
+      lines: 2,
+      position: 96.9,
+      opacity: 0.5,
+      color: 'transparent' as const,
+      bookFormat: 'EPUB' as BookFormat,
+      viewSettings,
+      gridInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    };
+
+    const { container, rerender } = render(<ReadingRuler {...props} />);
+    const rulerTop = () =>
+      parseFloat((container.querySelector('.ruler') as HTMLDivElement).style.top);
+    expect(rulerTop()).toBeCloseTo(96.9, 5);
+
+    // Foliate's pageinfo is a coarse estimated reading location, so adjacent
+    // visual pages can share it. The visible CFI still changes on the real turn.
+    mockProgress = {
+      range: null,
+      location: 'epubcfi(/6/2!/4/18)',
+      fraction: 0.11,
+      pageinfo: { current: 4 },
+    };
+    rerender(<ReadingRuler {...props} />);
+
+    await waitFor(() => {
+      expect(rulerTop()).toBeLessThan(20);
+    });
+  });
+
   // Regression: issue #4386 — in scrolled mode the ruler used to re-snap on every
   // relocate fired while scrolling, so its position crept down the page. It must
   // stay fixed on screen while scrolling; snapping only happens on click.
   it('keeps the ruler fixed on screen while scrolling in scrolled mode', () => {
     const lineRects = makeLineRects(50, 100, 40);
-    mockProgress = { range: {}, pageinfo: { current: 0 } };
+    mockProgress = { range: {}, location: 'page-1', fraction: 0.1, pageinfo: { current: 0 } };
     mockContents = makeScrolledContents(0, lineRects);
     const scrolledSettings = { ...viewSettings, scrolled: true } as ViewSettings;
 
@@ -310,7 +355,7 @@ describe('ReadingRuler', () => {
 
     // Simulate scrolling: a new relocate range arrives with the content shifted
     // up, but the section/page is unchanged.
-    mockProgress = { range: {}, pageinfo: { current: 0 } };
+    mockProgress = { range: {}, location: 'page-1', fraction: 0.1, pageinfo: { current: 0 } };
     mockContents = makeScrolledContents(-130, lineRects);
     rerender(<ReadingRuler {...props} />);
 
@@ -322,7 +367,12 @@ describe('ReadingRuler', () => {
   // progress right-to-left, so advancing the ruler forward must move the band to
   // the LEFT. It used to run backwards because rtl was false for vertical-rl.
   it('advances the vertical-rl ruler band to the left on a forward move', async () => {
-    mockProgress = { range: makeVerticalColumnsRange(), pageinfo: { current: 0 } };
+    mockProgress = {
+      range: makeVerticalColumnsRange(),
+      location: 'page-1',
+      fraction: 0.1,
+      pageinfo: { current: 0 },
+    };
     const verticalSettings = { ...viewSettings } as ViewSettings;
 
     const { container } = render(
@@ -363,7 +413,12 @@ describe('ReadingRuler', () => {
 
   // The vertical-lr (Mongolian) counterpart moves the other way: forward => right.
   it('advances the vertical-lr ruler band to the right on a forward move', async () => {
-    mockProgress = { range: makeVerticalColumnsRange(), pageinfo: { current: 0 } };
+    mockProgress = {
+      range: makeVerticalColumnsRange(),
+      location: 'page-1',
+      fraction: 0.1,
+      pageinfo: { current: 0 },
+    };
     const verticalSettings = { ...viewSettings } as ViewSettings;
 
     const { container } = render(
@@ -403,7 +458,7 @@ describe('ReadingRuler', () => {
 
   it('still snaps the ruler to lines when advancing by click in scrolled mode', async () => {
     const lineRects = makeLineRects(50, 100, 40);
-    mockProgress = { range: {}, pageinfo: { current: 0 } };
+    mockProgress = { range: {}, location: 'page-1', fraction: 0.1, pageinfo: { current: 0 } };
     mockContents = makeScrolledContents(0, lineRects);
     const scrolledSettings = { ...viewSettings, scrolled: true } as ViewSettings;
 

--- a/apps/readest-app/src/__tests__/components/ReadingRuler.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ReadingRuler.test.tsx
@@ -24,6 +24,7 @@ let mockProgress: {
   pageinfo: { current: number };
 } | null = null;
 let mockContents: Array<{ doc: unknown }> = [];
+let mockColumnCount = 1;
 
 vi.mock('@/context/EnvContext', () => {
   // Stable envConfig ref; an unstable one would churn the throttled save → ruler
@@ -37,7 +38,9 @@ vi.mock('@/store/readerStore', () => {
   // renders); the ReadingRuler cache effect lists getView as a dependency, so an
   // unstable ref would make it re-run on every render.
   const getProgress = () => mockProgress;
-  const getView = () => ({ renderer: { columnCount: 1, getContents: () => mockContents } });
+  const getView = () => ({
+    renderer: { columnCount: mockColumnCount, getContents: () => mockContents },
+  });
   const store = { getProgress, getView };
   return { useReaderStore: () => store };
 });
@@ -109,6 +112,46 @@ const makeScrolledContents = (
   return [{ doc }];
 };
 
+const makePaginatedContent = (
+  frameLeft: number,
+  frameWidth: number,
+  lineRects: RulerTestRect[],
+): {
+  doc: unknown;
+  range: { getClientRects: () => RulerTestRect[]; startContainer: object };
+} => {
+  const doc: {
+    body: object;
+    createRange: () => unknown;
+    defaultView: { frameElement: { getBoundingClientRect: () => DOMRect } };
+  } = {
+    body: {},
+    createRange: () => range,
+    defaultView: {
+      frameElement: {
+        getBoundingClientRect: () =>
+          ({
+            x: frameLeft,
+            y: 0,
+            top: 0,
+            left: frameLeft,
+            right: frameLeft + frameWidth,
+            bottom: 1000,
+            width: frameWidth,
+            height: 1000,
+            toJSON: () => ({}),
+          }) as DOMRect,
+      },
+    },
+  };
+  const range = {
+    startContainer: { ownerDocument: doc },
+    selectNodeContents: () => {},
+    getClientRects: () => lineRects,
+  };
+  return { doc, range };
+};
+
 vi.mock('@/helpers/settings', () => ({
   saveViewSettings: (...args: unknown[]) => saveViewSettings(...args),
 }));
@@ -132,6 +175,7 @@ describe('ReadingRuler', () => {
     vi.clearAllMocks();
     mockProgress = null;
     mockContents = [];
+    mockColumnCount = 1;
 
     Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
       configurable: true,
@@ -321,6 +365,67 @@ describe('ReadingRuler', () => {
     await waitFor(() => {
       expect(rulerTop()).toBeLessThan(20);
     });
+  });
+
+  it('advances into the next visible document before turning a two-page spread', async () => {
+    mockColumnCount = 2;
+    const left = makePaginatedContent(0, 400, [
+      { top: 450, bottom: 490, left: 40, right: 360, width: 320, height: 40 },
+    ]);
+    const right = makePaginatedContent(400, 400, [
+      { top: 100, bottom: 140, left: 40, right: 360, width: 320, height: 40 },
+      { top: 200, bottom: 240, left: 40, right: 360, width: 320, height: 40 },
+    ]);
+    const nextSpread = makePaginatedContent(800, 400, [
+      { top: 100, bottom: 140, left: 40, right: 360, width: 320, height: 40 },
+    ]);
+    mockContents = [{ doc: left.doc }, { doc: right.doc }, { doc: nextSpread.doc }];
+    mockProgress = {
+      range: left.range,
+      location: 'epubcfi(/6/2!/4/2)',
+      fraction: 0.1,
+      pageinfo: { current: 4 },
+    };
+
+    const { container } = render(
+      <ReadingRuler
+        bookKey='book-1'
+        isVertical={false}
+        rtl={false}
+        lines={1}
+        position={47}
+        opacity={0.5}
+        color='transparent'
+        bookFormat='EPUB'
+        viewSettings={viewSettings}
+        gridInsets={{ top: 0, right: 0, bottom: 0, left: 0 }}
+      />,
+    );
+    const rulerLeft = () =>
+      parseFloat((container.querySelector('.ruler') as HTMLDivElement).style.left);
+
+    await waitFor(() => expect(rulerLeft()).toBeLessThan(400));
+
+    const consumed = eventDispatcher.dispatchSync('reading-ruler-move', {
+      bookKey: 'book-1',
+      direction: 'forward',
+    });
+
+    expect(consumed).toBe(true);
+    await waitFor(() => expect(rulerLeft()).toBeGreaterThan(400));
+
+    expect(
+      eventDispatcher.dispatchSync('reading-ruler-move', {
+        bookKey: 'book-1',
+        direction: 'forward',
+      }),
+    ).toBe(true);
+    expect(
+      eventDispatcher.dispatchSync('reading-ruler-move', {
+        bookKey: 'book-1',
+        direction: 'forward',
+      }),
+    ).toBe(false);
   });
 
   // Regression: issue #4386 — in scrolled mode the ruler used to re-snap on every

--- a/apps/readest-app/src/app/reader/components/ProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/ProgressBar.tsx
@@ -164,7 +164,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
     <div
       role='presentation'
       className={clsx(
-        'progressinfo pointer-events-none absolute bottom-0 flex items-center justify-between font-sans',
+        'progressinfo pointer-events-none absolute bottom-0 z-10 flex items-center justify-between font-sans',
         isEink ? 'text-sm font-normal' : 'text-xs font-extralight',
         // The blend keeps the info legible over an unthemed fixed-layout page,
         // but it composites the whole container as a group -- with the pills on

--- a/apps/readest-app/src/app/reader/components/ReadingRuler.tsx
+++ b/apps/readest-app/src/app/reader/components/ReadingRuler.tsx
@@ -119,6 +119,44 @@ const filterVisibleColumns = (
     }))
     .filter((c) => c.lines.length > 0);
 
+// A paginated spread can join the final page of one section with the first page
+// of the next. Foliate's relocate range belongs to only one document, so include
+// the other on-screen documents or the ruler will treat the section boundary as
+// the end of the whole spread and turn past the adjacent page.
+const buildPaginatedColumns = (
+  view: FoliateView | null,
+  primaryRange: Range,
+  containerRect: DOMRect,
+  columnCount: number,
+  rtl: boolean,
+): ReadingRulerColumn[] => {
+  const primaryDoc = primaryRange.startContainer?.ownerDocument;
+  const mappedRects = mapRangeRectsToOverlay(primaryRange, containerRect);
+
+  for (const { doc } of view?.renderer.getContents() ?? []) {
+    if (doc === primaryDoc || !doc.body) continue;
+    const frame = doc.defaultView?.frameElement?.getBoundingClientRect();
+    if (!frame || frame.right <= containerRect.left || frame.left >= containerRect.right) continue;
+
+    try {
+      const range = doc.createRange();
+      range.selectNodeContents(doc.body);
+      mappedRects.push(...mapRangeRectsToOverlay(range, containerRect));
+    } catch {
+      // A renderer view can disappear while a page turn is settling.
+    }
+  }
+
+  const visibleRects = mappedRects.filter((rect) => {
+    const centerX = (rect.left + rect.right) / 2;
+    return centerX >= 0 && centerX <= containerRect.width;
+  });
+  return filterVisibleColumns(
+    buildReadingRulerColumns(visibleRects, columnCount, containerRect.width, rtl),
+    containerRect.height,
+  );
+};
+
 interface ReadingRulerProps {
   bookKey: string;
   isVertical: boolean;
@@ -301,10 +339,12 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
       const halfBlock = Math.max(0, (bandSizeRef.current || fallbackRulerSize) / 2 - padding);
       const anchor = center - halfBlock;
       if (isMultiColumn) {
-        const mapped = mapRangeRectsToOverlay(range, containerRect);
-        const cols = filterVisibleColumns(
-          buildReadingRulerColumns(mapped, columnCount, containerRect.width, rtl),
-          dimension,
+        const cols = buildPaginatedColumns(
+          getView(bookKey),
+          range,
+          containerRect,
+          columnCount,
+          rtl,
         );
         columnsRef.current = cols;
         lineBoxesRef.current = [];
@@ -476,14 +516,9 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
       // lands on the last line (so reading continues from where it left off).
       const forward = direction === 'forward';
 
-      if (isMultiColumn && range) {
+      if (isMultiColumn) {
         try {
-          const mapped = mapRangeRectsToOverlay(range, containerRect);
-          const columns = filterVisibleColumns(
-            buildReadingRulerColumns(mapped, columnCount, containerRect.width, rtl),
-            containerDimension,
-          );
-          columnsRef.current = columns;
+          const columns = columnsRef.current;
           // Forward: first line group of the first column. Backward: last line
           // group of the last column.
           const block = forward

--- a/apps/readest-app/src/app/reader/components/ReadingRuler.tsx
+++ b/apps/readest-app/src/app/reader/components/ReadingRuler.tsx
@@ -165,14 +165,15 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
 
   const isDragging = useRef(false);
   const dragPointerOffsetRef = useRef(0);
-  const lastPageRef = useRef<number | null>(null);
+  const lastLocationRef = useRef<string | null>(null);
+  const lastFractionRef = useRef<number | null>(null);
   const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentPositionRef = useRef(position);
   const lineBoxesRef = useRef<ReadingRulerLineBox[]>([]);
   const columnsRef = useRef<ReadingRulerColumn[]>([]);
   const activeColumnIndexRef = useRef(0);
   const bandSizeRef = useRef(0);
-  const cachePageRef = useRef<number | null>(null);
+  const cacheLocationRef = useRef<string | null>(null);
   // In scrolled mode, set when a tap advances past the view edge and scrolls the
   // view; the next relocate realigns the band to the start/end of the new view.
   const pendingScrollAlignRef = useRef<'forward' | 'backward' | null>(null);
@@ -277,11 +278,12 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
   useEffect(() => {
     const range = progress?.range ?? null;
     const containerRect = containerRef.current?.getBoundingClientRect();
-    const page = progress?.pageinfo?.current ?? null;
+    const location = progress?.location ?? null;
     // Page changes are handled by the auto-move effect; here we only (re)derive
     // the band on initial mount and on resize/relayout.
-    const pageChanged = cachePageRef.current !== null && cachePageRef.current !== page;
-    cachePageRef.current = page;
+    const locationChanged =
+      cacheLocationRef.current !== null && cacheLocationRef.current !== location;
+    cacheLocationRef.current = location;
 
     if (!supportsLineSnap || !range || !containerRect) {
       lineBoxesRef.current = [];
@@ -309,7 +311,7 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
         const idx = Math.max(0, Math.min(activeColumnIndexRef.current, cols.length - 1));
         const col = cols[idx];
         setActiveColumnRect(col ? { left: col.left, right: col.right } : null);
-        if (!pageChanged) {
+        if (!locationChanged) {
           const block = snapReadingRulerColumns(idx, anchor, anchor, lines, 'forward', cols);
           if (block) {
             activeColumnIndexRef.current = block.columnIndex;
@@ -344,7 +346,7 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
             scrolledPlacedRef.current = true;
             scrolledPlacedDimensionRef.current = dimension;
           }
-        } else if (!pageChanged) {
+        } else if (!locationChanged) {
           // In scrolled mode, only snap the band on the initial mount or after the
           // viewport dimension changes (resize/relayout). A plain scroll fires a
           // relocate without changing the dimension; re-snapping then would walk
@@ -375,7 +377,7 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     progress?.range,
-    progress?.pageinfo?.current,
+    progress?.location,
     containerSize.width,
     containerSize.height,
     isVertical,
@@ -542,15 +544,20 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
       setRulerPosition(targetPosition, true);
     };
 
-    const currentPage = progress.pageinfo.current;
+    const currentLocation = progress.location;
+    const currentFraction = progress.fraction;
     const range = progress.range;
 
     // Only auto-move if page actually changed (not on initial load)
-    if (lastPageRef.current !== null && lastPageRef.current !== currentPage) {
-      const direction = currentPage > lastPageRef.current ? 'forward' : 'backward';
+    if (lastLocationRef.current !== null && lastLocationRef.current !== currentLocation) {
+      const direction =
+        lastFractionRef.current !== null && currentFraction < lastFractionRef.current
+          ? 'backward'
+          : 'forward';
       requestAnimationFrame(() => performAutoMove(range, direction));
     }
-    lastPageRef.current = currentPage;
+    lastLocationRef.current = currentLocation;
+    lastFractionRef.current = currentFraction;
 
     return () => {
       if (animationTimeoutRef.current) {
@@ -559,7 +566,8 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    progress?.pageinfo?.current,
+    progress?.location,
+    progress?.fraction,
     viewSettings.scrolled,
     isVertical,
     rtl,


### PR DESCRIPTION
Refs #5174

## Summary

- Reset the reading ruler to visible text after real paginated page turns.
- Preserve reading order across section boundaries in two-page spreads.
- Align the ruler with contiguous rendered text lines and prevent it from covering adjacent lines.
- Keep footer content outside the reading-ruler filter.
- Recompute ruler geometry after viewport or typography reflow without treating it as a page turn.

## Cause

The ruler relied on coarse estimated page numbers and viewport-relative positioning. Adjacent visual pages can share the same estimated page, while a two-page spread can contain documents from different publication sections.

Renderer reflow can also change the visible location while preserving the current content anchor. Treating that relocation as navigation caused the ruler to animate toward the beginning or end of another page.

Line geometry is derived from [`Range.getClientRects()`](https://www.w3.org/TR/cssom-view/#extensions-to-the-range-interface), including fragmented inline content. Line grouping follows the contiguous rendered-line model used by [Immersive Reader Line Focus](https://support.microsoft.com/en-us/education/onenote/use-line-focus-in-immersive-reader-for-office-for-the-web-and-onenote).

## Changes

- Detect real page transitions from the visible location, using the estimated page and reading fraction only to determine direction.
- Use Foliate's renderer relocation reason to distinguish anchor-preserving reflow from user navigation.
- Invalidate cached line geometry when either viewport dimension changes.
- Include every visible Foliate document when building two-page spread geometry.
- Group only visually contiguous lines and derive the ruler band from their rendered bounds.
- Constrain padding independently on each edge so nearby text is not tinted.
- Keep unusually tall text inside the ruler while preventing image or element rectangles from expanding it across the viewport.
- Preserve the existing page-transition timing and movement animation.
- Keep the progress footer above the reading-ruler overlay.

## Behavior

- Forward page turns place the ruler on the first visible line group.
- Backward page turns place it on the last visible line group.
- Cross-section spreads advance through both visible pages before turning the spread.
- Viewport, font, line-height, and margin reflow re-snap against updated geometry without page-turn animation.
- Scrolled mode remains fixed during ordinary scrolling but refreshes after actual reflow.
- RTL and vertical writing continue to use logical reading order.

## Scope

- The line-aware behavior applies to reflowable text rendered through the shared Foliate DOM path on web and Tauri platforms.
- Fixed-layout and image-only formats retain the existing size and positioning fallback.
- Image-heavy reflowable publications are protected by the geometry cap but were not manually verified.
- The focused reader tests pass with 76 assertions. The full suite passes with 672 test files and 8,599 tests, together with type checking, lint, formatting, and diff checks.

## Not Included

The following feature requests from #5174 are not included in this PR and remain subject to maintainer direction:

- New settings for configuring reading-ruler movement independently from page-turn controls. For example, taps could move the ruler while swipes or volume buttons continue turning pages.
- A new optional setting for repeating the previous page's last line at the top of the next page.
- Exact preservation of the same text passage when repagination switches between one-page and two-page layouts. This requires a persistent DOM Range or CFI anchor and will be tracked in a separate bug report.