### PR TITLE
feat(reader): support adding bookmarks with a pull-down gesture

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2200,5 +2200,9 @@
   "Sync Highlights and Bookmarks": "مزامنة التظليلات والعلامات المرجعية",
   "Sync Reading Statistics": "مزامنة إحصائيات القراءة",
   "Sync Reading Status": "مزامنة حالة القراءة",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "أنشئ بيانات اعتماد KOReader في BookOrbit ضمن الإعدادات > التكاملات > KOReader، ثم أدخلها هنا مع عنوان الخادم الخاص بك."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "أنشئ بيانات اعتماد KOReader في BookOrbit ضمن الإعدادات > التكاملات > KOReader، ثم أدخلها هنا مع عنوان الخادم الخاص بك.",
+  "Release to remove bookmark": "أفلت لإزالة العلامة",
+  "Pull down to remove bookmark": "اسحب لأسفل لإزالة العلامة",
+  "Release to add bookmark": "أفلت لإضافة علامة",
+  "Pull down to add bookmark": "اسحب لأسفل لإضافة علامة"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2016,5 +2016,9 @@
   "Sync Highlights and Bookmarks": "হাইলাইট ও বুকমার্ক সিঙ্ক করুন",
   "Sync Reading Statistics": "পড়ার পরিসংখ্যান সিঙ্ক করুন",
   "Sync Reading Status": "পড়ার অবস্থা সিঙ্ক করুন",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit-এ সেটিংস > ইন্টিগ্রেশন > KOReader-এ KOReader শংসাপত্র তৈরি করুন, তারপর সেগুলি আপনার সার্ভারের ঠিকানাসহ এখানে লিখুন।"
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit-এ সেটিংস > ইন্টিগ্রেশন > KOReader-এ KOReader শংসাপত্র তৈরি করুন, তারপর সেগুলি আপনার সার্ভারের ঠিকানাসহ এখানে লিখুন।",
+  "Release to remove bookmark": "বুকমার্ক সরাতে ছেড়ে দিন",
+  "Pull down to remove bookmark": "বুকমার্ক সরাতে নিচে টানুন",
+  "Release to add bookmark": "বুকমার্ক যোগ করতে ছেড়ে দিন",
+  "Pull down to add bookmark": "বুকমার্ক যোগ করতে নিচে টানুন"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1970,5 +1970,9 @@
   "Sync Highlights and Bookmarks": "གསལ་མདངས་དང་དཔེ་རྟགས་མཉམ་འགྲིག",
   "Sync Reading Statistics": "ཀློག་པའི་གྲངས་ཐོ་མཉམ་འགྲིག",
   "Sync Reading Status": "ཀློག་པའི་གནས་སྟངས་མཉམ་འགྲིག",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit ནང་ སྒྲིག་འགོད > མཉམ་སྦྲེལ > KOReader ནང་ KOReader ཐོབ་ཐང་བཟོས་རྗེས་ ཞབས་ཞུ་བའི་ཁ་བྱང་དང་མཉམ་དུ་འདིར་བྲིས།"
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit ནང་ སྒྲིག་འགོད > མཉམ་སྦྲེལ > KOReader ནང་ KOReader ཐོབ་ཐང་བཟོས་རྗེས་ ཞབས་ཞུ་བའི་ཁ་བྱང་དང་མཉམ་དུ་འདིར་བྲིས།",
+  "Release to remove bookmark": "དེབ་གྲངས་འདོར་བར་ལག་པ་གློད།",
+  "Pull down to remove bookmark": "དེབ་གྲངས་འདོར་བར་མར་འཐེན།",
+  "Release to add bookmark": "དེབ་གྲངས་སྣོན་པར་ལག་པ་གློད།",
+  "Pull down to add bookmark": "དེབ་གྲངས་སྣོན་པར་མར་འཐེན།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2016,5 +2016,9 @@
   "Sync Highlights and Bookmarks": "Markierungen und Lesezeichen synchronisieren",
   "Sync Reading Statistics": "Lesestatistiken synchronisieren",
   "Sync Reading Status": "Lesestatus synchronisieren",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Erstellen Sie KOReader-Zugangsdaten in BookOrbit unter Einstellungen > Integrationen > KOReader und geben Sie sie hier zusammen mit Ihrer Serveradresse ein."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Erstellen Sie KOReader-Zugangsdaten in BookOrbit unter Einstellungen > Integrationen > KOReader und geben Sie sie hier zusammen mit Ihrer Serveradresse ein.",
+  "Release to remove bookmark": "Loslassen, um Lesezeichen zu entfernen",
+  "Pull down to remove bookmark": "Herunterziehen, um Lesezeichen zu entfernen",
+  "Release to add bookmark": "Loslassen, um Lesezeichen hinzuzufügen",
+  "Pull down to add bookmark": "Herunterziehen, um Lesezeichen hinzuzufügen"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2016,5 +2016,9 @@
   "Sync Highlights and Bookmarks": "Συγχρονισμός επισημάνσεων και σελιδοδεικτών",
   "Sync Reading Statistics": "Συγχρονισμός στατιστικών ανάγνωσης",
   "Sync Reading Status": "Συγχρονισμός κατάστασης ανάγνωσης",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Δημιουργήστε διαπιστευτήρια KOReader στο BookOrbit από Ρυθμίσεις > Ενσωματώσεις > KOReader και εισαγάγετέ τα εδώ μαζί με τη διεύθυνση του διακομιστή σας."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Δημιουργήστε διαπιστευτήρια KOReader στο BookOrbit από Ρυθμίσεις > Ενσωματώσεις > KOReader και εισαγάγετέ τα εδώ μαζί με τη διεύθυνση του διακομιστή σας.",
+  "Release to remove bookmark": "Αφήστε για αφαίρεση σελιδοδείκτη",
+  "Pull down to remove bookmark": "Τραβήξτε προς τα κάτω για αφαίρεση σελιδοδείκτη",
+  "Release to add bookmark": "Αφήστε για προσθήκη σελιδοδείκτη",
+  "Pull down to add bookmark": "Τραβήξτε προς τα κάτω για προσθήκη σελιδοδείκτη"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2062,5 +2062,9 @@
   "Sync Highlights and Bookmarks": "Sincronizar resaltados y marcadores",
   "Sync Reading Statistics": "Sincronizar estadísticas de lectura",
   "Sync Reading Status": "Sincronizar estado de lectura",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Crea credenciales de KOReader en BookOrbit en Ajustes > Integraciones > KOReader y luego introdúcelas aquí junto con la dirección de tu servidor."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Crea credenciales de KOReader en BookOrbit en Ajustes > Integraciones > KOReader y luego introdúcelas aquí junto con la dirección de tu servidor.",
+  "Release to remove bookmark": "Suelta para eliminar marcador",
+  "Pull down to remove bookmark": "Desliza hacia abajo para eliminar marcador",
+  "Release to add bookmark": "Suelta para agregar marcador",
+  "Pull down to add bookmark": "Desliza hacia abajo para agregar marcador"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2016,5 +2016,9 @@
   "Sync Highlights and Bookmarks": "همگام‌سازی هایلایت‌ها و نشانک‌ها",
   "Sync Reading Statistics": "همگام‌سازی آمار مطالعه",
   "Sync Reading Status": "همگام‌سازی وضعیت مطالعه",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "در BookOrbit از مسیر تنظیمات > یکپارچه‌سازی‌ها > KOReader اطلاعات ورود KOReader بسازید و سپس آن‌ها را همراه با نشانی سرور خود اینجا وارد کنید."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "در BookOrbit از مسیر تنظیمات > یکپارچه‌سازی‌ها > KOReader اطلاعات ورود KOReader بسازید و سپس آن‌ها را همراه با نشانی سرور خود اینجا وارد کنید.",
+  "Release to remove bookmark": "برای حذف نشانک رها کنید",
+  "Pull down to remove bookmark": "برای حذف نشانک به پایین بکشید",
+  "Release to add bookmark": "برای افزودن نشانک رها کنید",
+  "Pull down to add bookmark": "برای افزودن نشانک به پایین بکشید"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2062,5 +2062,9 @@
   "Sync Highlights and Bookmarks": "Synchroniser les surlignages et les signets",
   "Sync Reading Statistics": "Synchroniser les statistiques de lecture",
   "Sync Reading Status": "Synchroniser le statut de lecture",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Créez des identifiants KOReader dans BookOrbit via Paramètres > Intégrations > KOReader, puis saisissez-les ici avec l'adresse de votre serveur."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Créez des identifiants KOReader dans BookOrbit via Paramètres > Intégrations > KOReader, puis saisissez-les ici avec l'adresse de votre serveur.",
+  "Release to remove bookmark": "Relâchez pour supprimer le marque-page",
+  "Pull down to remove bookmark": "Tirez vers le bas pour supprimer le marque-page",
+  "Release to add bookmark": "Relâchez pour ajouter un marque-page",
+  "Pull down to add bookmark": "Tirez vers le bas pour ajouter un marque-page"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2062,5 +2062,9 @@
   "Sync Highlights and Bookmarks": "סנכרון הדגשות וסימניות",
   "Sync Reading Statistics": "סנכרון סטטיסטיקות קריאה",
   "Sync Reading Status": "סנכרון סטטוס קריאה",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "צור פרטי התחברות של KOReader ב-BookOrbit תחת הגדרות > אינטגרציות > KOReader, ולאחר מכן הזן אותם כאן יחד עם כתובת השרת שלך."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "צור פרטי התחברות של KOReader ב-BookOrbit תחת הגדרות > אינטגרציות > KOReader, ולאחר מכן הזן אותם כאן יחד עם כתובת השרת שלך.",
+  "Release to remove bookmark": "שחרר להסרת הסימנייה",
+  "Pull down to remove bookmark": "משוך למטה להסרת הסימנייה",
+  "Release to add bookmark": "שחרר להוספת סימנייה",
+  "Pull down to add bookmark": "משוך למטה להוספת סימנייה"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2016,5 +2016,9 @@
   "Sync Highlights and Bookmarks": "हाइलाइट और बुकमार्क सिंक करें",
   "Sync Reading Statistics": "पठन आँकड़े सिंक करें",
   "Sync Reading Status": "पठन स्थिति सिंक करें",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit में सेटिंग्स > इंटीग्रेशन > KOReader में KOReader क्रेडेंशियल बनाएँ, फिर उन्हें अपने सर्वर पते के साथ यहाँ दर्ज करें।"
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit में सेटिंग्स > इंटीग्रेशन > KOReader में KOReader क्रेडेंशियल बनाएँ, फिर उन्हें अपने सर्वर पते के साथ यहाँ दर्ज करें।",
+  "Release to remove bookmark": "मार्कर हटाने के लिए छोड़ें",
+  "Pull down to remove bookmark": "मार्कर हटाने के लिए नीचे खींचें",
+  "Release to add bookmark": "मार्कर जोड़ने के लिए छोड़ें",
+  "Pull down to add bookmark": "मार्कर जोड़ने के लिए नीचे खींचें"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2016,5 +2016,9 @@
   "Sync Highlights and Bookmarks": "Kiemelések és könyvjelzők szinkronizálása",
   "Sync Reading Statistics": "Olvasási statisztikák szinkronizálása",
   "Sync Reading Status": "Olvasási állapot szinkronizálása",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Hozzon létre KOReader hitelesítő adatokat a BookOrbitban a Beállítások > Integrációk > KOReader menüpontban, majd adja meg őket itt a szerver címével együtt."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Hozzon létre KOReader hitelesítő adatokat a BookOrbitban a Beállítások > Integrációk > KOReader menüpontban, majd adja meg őket itt a szerver címével együtt.",
+  "Release to remove bookmark": "Engedje el a könyvjelző eltávolításához",
+  "Pull down to remove bookmark": "Húzza le a könyvjelző eltávolításához",
+  "Release to add bookmark": "Engedje el könyvjelző hozzáadásához",
+  "Pull down to add bookmark": "Húzza le könyvjelző hozzáadásához"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1970,5 +1970,9 @@
   "Sync Highlights and Bookmarks": "Sinkronkan Sorotan dan Markah",
   "Sync Reading Statistics": "Sinkronkan Statistik Membaca",
   "Sync Reading Status": "Sinkronkan Status Membaca",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Buat kredensial KOReader di BookOrbit melalui Pengaturan > Integrasi > KOReader, lalu masukkan di sini bersama alamat server Anda."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Buat kredensial KOReader di BookOrbit melalui Pengaturan > Integrasi > KOReader, lalu masukkan di sini bersama alamat server Anda.",
+  "Release to remove bookmark": "Lepaskan untuk menghapus penanda",
+  "Pull down to remove bookmark": "Tarik ke bawah untuk menghapus penanda",
+  "Release to add bookmark": "Lepaskan untuk menambahkan penanda",
+  "Pull down to add bookmark": "Tarik ke bawah untuk menambahkan penanda"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2062,5 +2062,9 @@
   "Sync Highlights and Bookmarks": "Sincronizza evidenziazioni e segnalibri",
   "Sync Reading Statistics": "Sincronizza statistiche di lettura",
   "Sync Reading Status": "Sincronizza stato di lettura",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Crea le credenziali KOReader in BookOrbit in Impostazioni > Integrazioni > KOReader, poi inseriscile qui insieme all'indirizzo del tuo server."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Crea le credenziali KOReader in BookOrbit in Impostazioni > Integrazioni > KOReader, poi inseriscile qui insieme all'indirizzo del tuo server.",
+  "Release to remove bookmark": "Rilascia per rimuovere il segnalibro",
+  "Pull down to remove bookmark": "Trascina verso il basso per rimuovere il segnalibro",
+  "Release to add bookmark": "Rilascia per aggiungere il segnalibro",
+  "Pull down to add bookmark": "Trascina verso il basso per aggiungere il segnalibro"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1970,5 +1970,9 @@
   "Sync Highlights and Bookmarks": "ハイライトとブックマークを同期",
   "Sync Reading Statistics": "読書統計を同期",
   "Sync Reading Status": "読書ステータスを同期",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbitの「設定 > 連携 > KOReader」でKOReaderの認証情報を作成し、サーバーアドレスと一緒にここに入力してください。"
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbitの「設定 > 連携 > KOReader」でKOReaderの認証情報を作成し、サーバーアドレスと一緒にここに入力してください。",
+  "Release to remove bookmark": "指を離してブックマークを削除",
+  "Pull down to remove bookmark": "下に引いてブックマークを削除",
+  "Release to add bookmark": "指を離してブックマークを追加",
+  "Pull down to add bookmark": "下に引いてブックマークを追加"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1970,5 +1970,9 @@
   "Sync Highlights and Bookmarks": "하이라이트 및 북마크 동기화",
   "Sync Reading Statistics": "읽기 통계 동기화",
   "Sync Reading Status": "읽기 상태 동기화",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit의 설정 > 통합 > KOReader에서 KOReader 자격 증명을 만든 다음 서버 주소와 함께 여기에 입력하세요."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit의 설정 > 통합 > KOReader에서 KOReader 자격 증명을 만든 다음 서버 주소와 함께 여기에 입력하세요.",
+  "Release to remove bookmark": "손을 떼면 북마크 제거",
+  "Pull down to remove bookmark": "아래로 당겨 북마크 제거",
+  "Release to add bookmark": "손을 떼면 북마크 추가",
+  "Pull down to add bookmark": "아래로 당겨 북마크 추가"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1970,5 +1970,9 @@
   "Sync Highlights and Bookmarks": "Segerakkan Sorotan dan Penanda Buku",
   "Sync Reading Statistics": "Segerakkan Statistik Pembacaan",
   "Sync Reading Status": "Segerakkan Status Pembacaan",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Cipta kelayakan KOReader dalam BookOrbit di Tetapan > Integrasi > KOReader, kemudian masukkannya di sini bersama alamat pelayan anda."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Cipta kelayakan KOReader dalam BookOrbit di Tetapan > Integrasi > KOReader, kemudian masukkannya di sini bersama alamat pelayan anda.",
+  "Release to remove bookmark": "Lepaskan untuk mengalih keluar tandabuku",
+  "Pull down to remove bookmark": "Tarik ke bawah untuk mengalih keluar tandabuku",
+  "Release to add bookmark": "Lepaskan untuk menambah tandabuku",
+  "Pull down to add bookmark": "Tarik ke bawah untuk menambah tandabuku"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2016,5 +2016,9 @@
   "Sync Highlights and Bookmarks": "Markeringen en bladwijzers synchroniseren",
   "Sync Reading Statistics": "Leesstatistieken synchroniseren",
   "Sync Reading Status": "Leesstatus synchroniseren",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Maak KOReader-inloggegevens aan in BookOrbit onder Instellingen > Integraties > KOReader en voer ze hier in samen met je serveradres."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Maak KOReader-inloggegevens aan in BookOrbit onder Instellingen > Integraties > KOReader en voer ze hier in samen met je serveradres.",
+  "Release to remove bookmark": "Laat los om bladwijzer te verwijderen",
+  "Pull down to remove bookmark": "Trek omlaag om bladwijzer te verwijderen",
+  "Release to add bookmark": "Laat los om bladwijzer toe te voegen",
+  "Pull down to add bookmark": "Trek omlaag om bladwijzer toe te voegen"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2108,5 +2108,9 @@
   "Sync Highlights and Bookmarks": "Synchronizuj zakreślenia i zakładki",
   "Sync Reading Statistics": "Synchronizuj statystyki czytania",
   "Sync Reading Status": "Synchronizuj status czytania",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Utwórz dane logowania KOReader w BookOrbit w Ustawienia > Integracje > KOReader, a następnie wprowadź je tutaj wraz z adresem serwera."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Utwórz dane logowania KOReader w BookOrbit w Ustawienia > Integracje > KOReader, a następnie wprowadź je tutaj wraz z adresem serwera.",
+  "Release to remove bookmark": "Puść, aby usunąć zakładkę",
+  "Pull down to remove bookmark": "Pociągnij w dół, aby usunąć zakładkę",
+  "Release to add bookmark": "Puść, aby dodać zakładkę",
+  "Pull down to add bookmark": "Pociągnij w dół, aby dodać zakładkę"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2062,5 +2062,9 @@
   "Sync Highlights and Bookmarks": "Sincronizar destaques e marcadores",
   "Sync Reading Statistics": "Sincronizar estatísticas de leitura",
   "Sync Reading Status": "Sincronizar status de leitura",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Crie credenciais do KOReader no BookOrbit em Configurações > Integrações > KOReader e insira-as aqui junto com o endereço do seu servidor."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Crie credenciais do KOReader no BookOrbit em Configurações > Integrações > KOReader e insira-as aqui junto com o endereço do seu servidor.",
+  "Release to remove bookmark": "Solte para remover marcador",
+  "Pull down to remove bookmark": "Puxe para baixo para remover marcador",
+  "Release to add bookmark": "Solte para adicionar marcador",
+  "Pull down to add bookmark": "Puxe para baixo para adicionar marcador"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2062,5 +2062,9 @@
   "Sync Highlights and Bookmarks": "Sincronizar destaques e marcadores",
   "Sync Reading Statistics": "Sincronizar estatísticas de leitura",
   "Sync Reading Status": "Sincronizar estado de leitura",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Crie credenciais KOReader no BookOrbit em Definições > Integrações > KOReader e introduza-as aqui juntamente com o endereço do seu servidor."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Crie credenciais KOReader no BookOrbit em Definições > Integrações > KOReader e introduza-as aqui juntamente com o endereço do seu servidor.",
+  "Release to remove bookmark": "Solte para remover marcador",
+  "Pull down to remove bookmark": "Puxe para baixo para remover marcador",
+  "Release to add bookmark": "Solte para adicionar marcador",
+  "Pull down to add bookmark": "Puxe para baixo para adicionar marcador"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2062,5 +2062,9 @@
   "Sync Highlights and Bookmarks": "Sincronizează evidențierile și semnele de carte",
   "Sync Reading Statistics": "Sincronizează statisticile de lectură",
   "Sync Reading Status": "Sincronizează starea lecturii",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Creați date de autentificare KOReader în BookOrbit din Setări > Integrări > KOReader, apoi introduceți-le aici împreună cu adresa serverului."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Creați date de autentificare KOReader în BookOrbit din Setări > Integrări > KOReader, apoi introduceți-le aici împreună cu adresa serverului.",
+  "Release to remove bookmark": "Eliberați pentru a elimina marcajul",
+  "Pull down to remove bookmark": "Trageți în jos pentru a elimina marcajul",
+  "Release to add bookmark": "Eliberați pentru a adăuga marcajul",
+  "Pull down to add bookmark": "Trageți în jos pentru a adăuga marcajul"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2108,5 +2108,9 @@
   "Sync Highlights and Bookmarks": "Синхронизировать выделения и закладки",
   "Sync Reading Statistics": "Синхронизировать статистику чтения",
   "Sync Reading Status": "Синхронизировать статус чтения",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Создайте учётные данные KOReader в BookOrbit в разделе Настройки > Интеграции > KOReader, затем введите их здесь вместе с адресом сервера."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Создайте учётные данные KOReader в BookOrbit в разделе Настройки > Интеграции > KOReader, затем введите их здесь вместе с адресом сервера.",
+  "Release to remove bookmark": "Отпустите, чтобы удалить закладку",
+  "Pull down to remove bookmark": "Потяните вниз, чтобы удалить закладку",
+  "Release to add bookmark": "Отпустите, чтобы добавить закладку",
+  "Pull down to add bookmark": "Потяните вниз, чтобы добавить закладку"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2016,5 +2016,9 @@
   "Sync Highlights and Bookmarks": "උද්දීපන සහ පිටු සලකුණු සමමුහුර්ත කරන්න",
   "Sync Reading Statistics": "කියවීමේ සංඛ්‍යාලේඛන සමමුහුර්ත කරන්න",
   "Sync Reading Status": "කියවීමේ තත්ත්වය සමමුහුර්ත කරන්න",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit හි සැකසුම් > ඒකාබද්ධතා > KOReader යටතේ KOReader අක්තපත්‍ර සාදා, ඉන්පසු ඒවා ඔබගේ සේවාදායක ලිපිනය සමඟ මෙහි ඇතුළත් කරන්න."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit හි සැකසුම් > ඒකාබද්ධතා > KOReader යටතේ KOReader අක්තපත්‍ර සාදා, ඉන්පසු ඒවා ඔබගේ සේවාදායක ලිපිනය සමඟ මෙහි ඇතුළත් කරන්න.",
+  "Release to remove bookmark": "සටහන් ඉවත් කිරීමට අත හරින්න",
+  "Pull down to remove bookmark": "සටහන් ඉවත් කිරීමට පහළට අදින්න",
+  "Release to add bookmark": "සටහන් එකතු කිරීමට අත හරින්න",
+  "Pull down to add bookmark": "සටහන් එකතු කිරීමට පහළට අදින්න"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2108,5 +2108,9 @@
   "Sync Highlights and Bookmarks": "Sinhroniziraj poudarke in zaznamke",
   "Sync Reading Statistics": "Sinhroniziraj bralno statistiko",
   "Sync Reading Status": "Sinhroniziraj bralni status",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "V BookOrbitu ustvarite poverilnice KOReader v Nastavitve > Integracije > KOReader, nato jih vnesite tukaj skupaj z naslovom strežnika."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "V BookOrbitu ustvarite poverilnice KOReader v Nastavitve > Integracije > KOReader, nato jih vnesite tukaj skupaj z naslovom strežnika.",
+  "Release to remove bookmark": "Spustite za odstranitev zaznamka",
+  "Pull down to remove bookmark": "Povlecite navzdol za odstranitev zaznamka",
+  "Release to add bookmark": "Spustite za dodajanje zaznamka",
+  "Pull down to add bookmark": "Povlecite navzdol za dodajanje zaznamka"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2016,5 +2016,9 @@
   "Sync Highlights and Bookmarks": "Synkronisera markeringar och bokmärken",
   "Sync Reading Statistics": "Synkronisera lässtatistik",
   "Sync Reading Status": "Synkronisera lässtatus",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Skapa KOReader-inloggningsuppgifter i BookOrbit under Inställningar > Integrationer > KOReader och ange dem här tillsammans med din serveradress."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Skapa KOReader-inloggningsuppgifter i BookOrbit under Inställningar > Integrationer > KOReader och ange dem här tillsammans med din serveradress.",
+  "Release to remove bookmark": "Släpp för att ta bort bokmärke",
+  "Pull down to remove bookmark": "Dra nedåt för att ta bort bokmärke",
+  "Release to add bookmark": "Släpp för att lägga till bokmärke",
+  "Pull down to add bookmark": "Dra nedåt för att lägga till bokmärke"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2016,5 +2016,9 @@
   "Sync Highlights and Bookmarks": "தனிப்படுத்தல்கள் மற்றும் புத்தகக்குறிகளை ஒத்திசைக்கவும்",
   "Sync Reading Statistics": "வாசிப்பு புள்ளிவிவரங்களை ஒத்திசைக்கவும்",
   "Sync Reading Status": "வாசிப்பு நிலையை ஒத்திசைக்கவும்",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit-இல் அமைப்புகள் > ஒருங்கிணைப்புகள் > KOReader என்பதில் KOReader சான்றுகளை உருவாக்கி, பின்னர் உங்கள் சேவையக முகவரியுடன் அவற்றை இங்கே உள்ளிடவும்."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit-இல் அமைப்புகள் > ஒருங்கிணைப்புகள் > KOReader என்பதில் KOReader சான்றுகளை உருவாக்கி, பின்னர் உங்கள் சேவையக முகவரியுடன் அவற்றை இங்கே உள்ளிடவும்.",
+  "Release to remove bookmark": "புக்மார்க் நீக்க விடுவிக்கவும்",
+  "Pull down to remove bookmark": "புக்மார்க் நீக்க கீழே இழுக்கவும்",
+  "Release to add bookmark": "புக்மார்க் சேர்க்க விடுவிக்கவும்",
+  "Pull down to add bookmark": "புக்மார்க் சேர்க்க கீழே இழுக்கவும்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1970,5 +1970,9 @@
   "Sync Highlights and Bookmarks": "ซิงค์ไฮไลต์และที่คั่นหนังสือ",
   "Sync Reading Statistics": "ซิงค์สถิติการอ่าน",
   "Sync Reading Status": "ซิงค์สถานะการอ่าน",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "สร้างข้อมูลรับรอง KOReader ใน BookOrbit ที่ การตั้งค่า > การเชื่อมต่อ > KOReader แล้วกรอกที่นี่พร้อมกับที่อยู่เซิร์ฟเวอร์ของคุณ"
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "สร้างข้อมูลรับรอง KOReader ใน BookOrbit ที่ การตั้งค่า > การเชื่อมต่อ > KOReader แล้วกรอกที่นี่พร้อมกับที่อยู่เซิร์ฟเวอร์ของคุณ",
+  "Release to remove bookmark": "ปล่อยเพื่อลบบุ๊กมาร์ก",
+  "Pull down to remove bookmark": "ดึงลงเพื่อลบบุ๊กมาร์ก",
+  "Release to add bookmark": "ปล่อยเพื่อเพิ่มบุ๊กมาร์ก",
+  "Pull down to add bookmark": "ดึงลงเพื่อเพิ่มบุ๊กมาร์ก"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2016,5 +2016,9 @@
   "Sync Highlights and Bookmarks": "Vurguları ve Yer İmlerini Eşitle",
   "Sync Reading Statistics": "Okuma İstatistiklerini Eşitle",
   "Sync Reading Status": "Okuma Durumunu Eşitle",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit'te Ayarlar > Entegrasyonlar > KOReader altında KOReader kimlik bilgileri oluşturun, ardından bunları sunucu adresinizle birlikte buraya girin."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit'te Ayarlar > Entegrasyonlar > KOReader altında KOReader kimlik bilgileri oluşturun, ardından bunları sunucu adresinizle birlikte buraya girin.",
+  "Release to remove bookmark": "Yer işaretini kaldırmak için bırakın",
+  "Pull down to remove bookmark": "Yer işaretini kaldırmak için aşağı çekin",
+  "Release to add bookmark": "Yer işareti eklemek için bırakın",
+  "Pull down to add bookmark": "Yer işareti eklemek için aşağı çekin"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2108,5 +2108,9 @@
   "Sync Highlights and Bookmarks": "Синхронізувати виділення та закладки",
   "Sync Reading Statistics": "Синхронізувати статистику читання",
   "Sync Reading Status": "Синхронізувати статус читання",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Створіть облікові дані KOReader у BookOrbit у розділі Налаштування > Інтеграції > KOReader, а потім введіть їх тут разом з адресою сервера."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Створіть облікові дані KOReader у BookOrbit у розділі Налаштування > Інтеграції > KOReader, а потім введіть їх тут разом з адресою сервера.",
+  "Release to remove bookmark": "Відпустіть, щоб видалити закладку",
+  "Pull down to remove bookmark": "Потягніть вниз, щоб видалити закладку",
+  "Release to add bookmark": "Відпустіть, щоб додати закладку",
+  "Pull down to add bookmark": "Потягніть вниз, щоб додати закладку"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2016,5 +2016,9 @@
   "Sync Highlights and Bookmarks": "Ajratishlar va xatcho‘plarni sinxronlash",
   "Sync Reading Statistics": "O‘qish statistikasini sinxronlash",
   "Sync Reading Status": "O‘qish holatini sinxronlash",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit’da Sozlamalar > Integratsiyalar > KOReader bo‘limida KOReader hisob ma’lumotlarini yarating, so‘ng ularni server manzili bilan birga shu yerga kiriting."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "BookOrbit’da Sozlamalar > Integratsiyalar > KOReader bo‘limida KOReader hisob ma’lumotlarini yarating, so‘ng ularni server manzili bilan birga shu yerga kiriting.",
+  "Release to remove bookmark": "Xatchoʻpni olib tashlash uchun qoʻyib yuboring",
+  "Pull down to remove bookmark": "Xatchoʻpni olib tashlash uchun pastga torting",
+  "Release to add bookmark": "Xatchoʻp qoʻshish uchun qoʻyib yuboring",
+  "Pull down to add bookmark": "Xatchoʻp qoʻshish uchun pastga torting"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1970,5 +1970,9 @@
   "Sync Highlights and Bookmarks": "Đồng bộ phần tô sáng và dấu trang",
   "Sync Reading Statistics": "Đồng bộ thống kê đọc",
   "Sync Reading Status": "Đồng bộ trạng thái đọc",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Tạo thông tin đăng nhập KOReader trong BookOrbit tại Cài đặt > Tích hợp > KOReader, sau đó nhập chúng vào đây cùng với địa chỉ máy chủ của bạn."
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "Tạo thông tin đăng nhập KOReader trong BookOrbit tại Cài đặt > Tích hợp > KOReader, sau đó nhập chúng vào đây cùng với địa chỉ máy chủ của bạn.",
+  "Release to remove bookmark": "Thả ra để xóa đánh dấu",
+  "Pull down to remove bookmark": "Kéo xuống để xóa đánh dấu",
+  "Release to add bookmark": "Thả ra để thêm đánh dấu",
+  "Pull down to add bookmark": "Kéo xuống để thêm đánh dấu"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1970,5 +1970,9 @@
   "Sync Highlights and Bookmarks": "同步高亮与书签",
   "Sync Reading Statistics": "同步阅读统计",
   "Sync Reading Status": "同步阅读状态",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "在 BookOrbit 的“设置 > 集成 > KOReader”中创建 KOReader 凭据，然后连同服务器地址一起填写在这里。"
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "在 BookOrbit 的“设置 > 集成 > KOReader”中创建 KOReader 凭据，然后连同服务器地址一起填写在这里。",
+  "Release to remove bookmark": "松手移除书签",
+  "Pull down to remove bookmark": "下拉移除书签",
+  "Release to add bookmark": "松手添加书签",
+  "Pull down to add bookmark": "下拉添加书签"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1970,5 +1970,9 @@
   "Sync Highlights and Bookmarks": "同步標記與書籤",
   "Sync Reading Statistics": "同步閱讀統計",
   "Sync Reading Status": "同步閱讀狀態",
-  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "在 BookOrbit 的「設定 > 整合 > KOReader」中建立 KOReader 憑證，然後連同伺服器位址一併填寫在這裡。"
+  "Create KOReader credentials in BookOrbit under Settings > Integrations > KOReader, then enter them here with your server address.": "在 BookOrbit 的「設定 > 整合 > KOReader」中建立 KOReader 憑證，然後連同伺服器位址一併填寫在這裡。",
+  "Release to remove bookmark": "鬆手移除書籤",
+  "Pull down to remove bookmark": "下拉移除書籤",
+  "Release to add bookmark": "鬆手添加書籤",
+  "Pull down to add bookmark": "下拉添加書籤"
 }

--- a/apps/readest-app/src/__tests__/app/bookmarkPullGesture.test.ts
+++ b/apps/readest-app/src/__tests__/app/bookmarkPullGesture.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BOOKMARK_PULL_ACTIVATION_PX,
+  BOOKMARK_PULL_TRIGGER_PX,
+  BOOKMARK_PULL_LINEAR_PX,
+  BOOKMARK_PULL_DAMPING,
+  shouldActivatePull,
+  computePullOffset,
+  isPastPullThreshold,
+  previewRibbonFilled,
+  pullRibbonHeight,
+  pullHintShift,
+  canPullBookmark,
+} from '@/app/reader/utils/bookmarkPullGesture';
+
+describe('bookmarkPullGesture pure helpers', () => {
+  describe('shouldActivatePull', () => {
+    it('activates only on a downward-dominant move past the threshold', () => {
+      const t = BOOKMARK_PULL_ACTIVATION_PX;
+      expect(shouldActivatePull(0, t)).toBe(true); // exactly at threshold, straight down
+      expect(shouldActivatePull(0, t - 1)).toBe(false); // below threshold
+      expect(shouldActivatePull(10, t + 10)).toBe(true); // down-dominant
+    });
+
+    it('never activates on upward moves (unlike brightness, direction matters)', () => {
+      expect(shouldActivatePull(0, -BOOKMARK_PULL_ACTIVATION_PX)).toBe(false);
+      expect(shouldActivatePull(0, -200)).toBe(false);
+    });
+
+    it('does not activate on horizontal-dominant or tie moves', () => {
+      const t = BOOKMARK_PULL_ACTIVATION_PX;
+      expect(shouldActivatePull(t + 5, t + 4)).toBe(false); // horizontal-dominant
+      expect(shouldActivatePull(t, t)).toBe(false); // tie is not "> "
+      expect(shouldActivatePull(-(t + 5), t + 4)).toBe(false); // magnitude counts for dx
+    });
+  });
+
+  describe('computePullOffset', () => {
+    it('tracks the finger 1:1 through the linear range (which covers the trigger)', () => {
+      expect(computePullOffset(0)).toBe(0);
+      expect(computePullOffset(50)).toBe(50);
+      expect(computePullOffset(BOOKMARK_PULL_TRIGGER_PX)).toBe(BOOKMARK_PULL_TRIGGER_PX);
+      expect(computePullOffset(BOOKMARK_PULL_LINEAR_PX)).toBe(BOOKMARK_PULL_LINEAR_PX);
+      expect(BOOKMARK_PULL_LINEAR_PX).toBeGreaterThanOrEqual(BOOKMARK_PULL_TRIGGER_PX);
+    });
+
+    it('rubber-bands past the linear range', () => {
+      const dy = BOOKMARK_PULL_LINEAR_PX + 100;
+      expect(computePullOffset(dy)).toBeCloseTo(
+        BOOKMARK_PULL_LINEAR_PX + 100 * BOOKMARK_PULL_DAMPING,
+        10,
+      );
+      // still monotonic
+      expect(computePullOffset(dy + 1)).toBeGreaterThan(computePullOffset(dy));
+    });
+
+    it('clamps upward drags to zero', () => {
+      expect(computePullOffset(-1)).toBe(0);
+      expect(computePullOffset(-500)).toBe(0);
+    });
+  });
+
+  describe('isPastPullThreshold', () => {
+    it('flips exactly at the trigger distance', () => {
+      expect(isPastPullThreshold(BOOKMARK_PULL_TRIGGER_PX - 1)).toBe(false);
+      expect(isPastPullThreshold(BOOKMARK_PULL_TRIGGER_PX)).toBe(true);
+    });
+  });
+
+  describe('previewRibbonFilled', () => {
+    it('always previews the post-release bookmark state', () => {
+      // bookmarked, below threshold: release does nothing -> stays bookmarked -> filled
+      expect(previewRibbonFilled(true, false)).toBe(true);
+      // bookmarked, past threshold: release removes -> outline
+      expect(previewRibbonFilled(true, true)).toBe(false);
+      // not bookmarked, below threshold: release does nothing -> outline
+      expect(previewRibbonFilled(false, false)).toBe(false);
+      // not bookmarked, past threshold: release adds -> filled
+      expect(previewRibbonFilled(false, true)).toBe(true);
+    });
+  });
+
+  describe('pullRibbonHeight', () => {
+    it('hangs at rest height until the page edge passes it, then rides the edge', () => {
+      expect(pullRibbonHeight(0, 92)).toBe(92);
+      expect(pullRibbonHeight(60, 92)).toBe(92);
+      expect(pullRibbonHeight(92, 92)).toBe(92);
+      expect(pullRibbonHeight(150, 92)).toBe(150);
+    });
+  });
+
+  describe('pullHintShift', () => {
+    const hintHeight = 20;
+    const pinTop = 55;
+    it('rides the page edge (no shift) until the hint reaches the pin position', () => {
+      expect(pullHintShift(0, hintHeight, pinTop)).toBe(0);
+      expect(pullHintShift(hintHeight + pinTop, hintHeight, pinTop)).toBe(0);
+    });
+
+    it('pins: shifts up by exactly the overshoot once past the pin position', () => {
+      expect(pullHintShift(hintHeight + pinTop + 40, hintHeight, pinTop)).toBe(-40);
+      expect(pullHintShift(hintHeight + pinTop + 1, hintHeight, pinTop)).toBe(-1);
+    });
+  });
+
+  describe('canPullBookmark', () => {
+    const eligible = { scrolled: false, vertical: false, isEink: false, isFixedLayout: false };
+    it('allows only paginated reflowable horizontal-writing non-eink books', () => {
+      expect(canPullBookmark(eligible)).toBe(true);
+      expect(canPullBookmark({ ...eligible, scrolled: true })).toBe(false);
+      expect(canPullBookmark({ ...eligible, vertical: true })).toBe(false);
+      expect(canPullBookmark({ ...eligible, isEink: true })).toBe(false);
+      expect(canPullBookmark({ ...eligible, isFixedLayout: true })).toBe(false);
+    });
+  });
+});

--- a/apps/readest-app/src/__tests__/app/reader/components/BookmarkPullDown.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/BookmarkPullDown.test.tsx
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act, cleanup } from '@testing-library/react';
+import BookmarkPullDown from '@/app/reader/components/BookmarkPullDown';
+import {
+  registerBookmarkPullDoc,
+  setBookmarkPullHandlers,
+  BOOKMARK_PULL_TRIGGER_PX,
+} from '@/app/reader/utils/bookmarkPullGesture';
+import { setLayeredTurnTouchClaimed } from '@/app/reader/utils/iframeEventHandlers';
+import { eventDispatcher } from '@/utils/event';
+
+const BOOK_KEY = 'book-1';
+
+let currentViewSettings: Record<string, unknown>;
+let currentRibbonVisible: boolean;
+let currentHoveredBookKey: string | null = null;
+let hoverCalls: (string | null)[] = [];
+
+vi.mock('@/store/readerStore', () => {
+  const buildState = () => ({
+    viewStates: { [BOOK_KEY]: { ribbonVisible: currentRibbonVisible } },
+    hoveredBookKey: currentHoveredBookKey,
+    getViewSettings: () => currentViewSettings,
+    setHoveredBookKey: (key: string | null) => {
+      hoverCalls.push(key);
+      currentHoveredBookKey = key;
+    },
+  });
+  const useReaderStore = <R,>(selector?: (s: ReturnType<typeof buildState>) => R) => {
+    const state = buildState();
+    return selector ? selector(state) : state;
+  };
+  useReaderStore.getState = buildState;
+  return { useReaderStore };
+});
+
+vi.mock('@/store/bookDataStore', () => {
+  const buildState = () => ({
+    getBookData: () => ({ isFixedLayout: false }),
+  });
+  const useBookDataStore = <R,>(selector?: (s: ReturnType<typeof buildState>) => R) => {
+    const state = buildState();
+    return selector ? selector(state) : state;
+  };
+  useBookDataStore.getState = buildState;
+  return { useBookDataStore };
+});
+
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({ safeAreaInsets: { top: 48, right: 0, bottom: 0, left: 0 } }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+vi.mock('@/app/reader/utils/iframeEventHandlers', () => ({
+  setLayeredTurnTouchClaimed: vi.fn(),
+}));
+
+// Deterministic rAF: callbacks queue up and run only when the test flushes
+// them with an explicit timestamp, so the release spring can be stepped.
+let rafQueue: FrameRequestCallback[] = [];
+const flushRaf = (now: number) => {
+  const cbs = rafQueue;
+  rafQueue = [];
+  cbs.forEach((cb) => cb(now));
+};
+
+const touchEvent = (type: string, y: number, x = 200): Event => {
+  const event = new Event(type, { cancelable: true, bubbles: true });
+  const point = { screenX: x, screenY: y, clientX: x, clientY: y };
+  Object.assign(event, {
+    touches: type === 'touchend' || type === 'touchcancel' ? [] : [point],
+    changedTouches: [point],
+  });
+  return event;
+};
+
+const dispatchTouch = (type: string, y: number, x = 200) => {
+  act(() => {
+    document.dispatchEvent(touchEvent(type, y, x));
+  });
+};
+
+describe('BookmarkPullDown', () => {
+  let slide: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+    rafQueue = [];
+    currentViewSettings = { scrolled: false, vertical: false, isEink: false };
+    currentRibbonVisible = false;
+    currentHoveredBookKey = null;
+    hoverCalls = [];
+    slide = document.createElement('div');
+    vi.mocked(setLayeredTurnTouchClaimed).mockClear();
+    registerBookmarkPullDoc(BOOK_KEY, document);
+  });
+
+  afterEach(() => {
+    setBookmarkPullHandlers(BOOK_KEY, null);
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  const renderComponent = (ribbonHidden = false) =>
+    render(
+      <BookmarkPullDown
+        bookKey={BOOK_KEY}
+        ribbonHidden={ribbonHidden}
+        slideRef={{ current: slide }}
+      />,
+    );
+
+  it('shows nothing at rest without a bookmark, and the resting ribbon with one', () => {
+    const { container, rerender } = renderComponent();
+    expect(container.querySelector('.ribbon')).toBeNull();
+    expect(container.querySelector('.bookmark-pull-band')).toBeNull();
+
+    currentRibbonVisible = true;
+    rerender(
+      <BookmarkPullDown bookKey={BOOK_KEY} ribbonHidden={false} slideRef={{ current: slide }} />,
+    );
+    expect(container.querySelector('.ribbon')).not.toBeNull();
+  });
+
+  it('does not engage in scrolled mode', () => {
+    const { container } = renderComponent();
+    currentViewSettings = { scrolled: true, vertical: false, isEink: false };
+    dispatchTouch('touchstart', 300);
+    dispatchTouch('touchmove', 400);
+    expect(container.querySelector('.bookmark-pull-band')).toBeNull();
+  });
+
+  it('activates on a downward drag, flips at the threshold, and previews the release state', () => {
+    const { container, getByText } = renderComponent();
+
+    dispatchTouch('touchstart', 300);
+    // below activation: still nothing
+    dispatchTouch('touchmove', 310);
+    expect(container.querySelector('.bookmark-pull-band')).toBeNull();
+
+    // past activation: band + "pull down" hint; outline ribbon previews "still no bookmark"
+    dispatchTouch('touchmove', 330);
+    expect(container.querySelector('.bookmark-pull-band')).not.toBeNull();
+    expect(getByText('Pull down to add bookmark')).toBeTruthy();
+    const polygon = container.querySelector('.bookmark-pull-ribbon polygon') as SVGElement;
+    expect(polygon.getAttribute('fill')).toBe('none');
+
+    // past the trigger: "release" hint; filled ribbon previews "will be bookmarked"
+    dispatchTouch('touchmove', 300 + BOOKMARK_PULL_TRIGGER_PX + 10);
+    expect(getByText('Release to add bookmark')).toBeTruthy();
+    expect(polygon.getAttribute('fill')).toBe('#F44336');
+
+    // offset applied to the slide wrapper on the next frame (1:1 in the linear range)
+    act(() => flushRaf(0));
+    expect(slide.style.transform).toBe(`translate3d(0, ${BOOKMARK_PULL_TRIGGER_PX + 10}px, 0)`);
+  });
+
+  it('toggles the bookmark on release past the threshold and springs back', () => {
+    const { container } = renderComponent();
+    const dispatchSpy = vi.spyOn(eventDispatcher, 'dispatch');
+
+    dispatchTouch('touchstart', 300);
+    dispatchTouch('touchmove', 330);
+    dispatchTouch('touchmove', 300 + BOOKMARK_PULL_TRIGGER_PX + 20);
+    dispatchTouch('touchend', 300 + BOOKMARK_PULL_TRIGGER_PX + 20);
+
+    expect(dispatchSpy).toHaveBeenCalledWith('toggle-bookmark', { bookKey: BOOK_KEY });
+    expect(setLayeredTurnTouchClaimed).toHaveBeenCalledWith(BOOK_KEY, false);
+
+    // spring back: first frame seeds the clock, a +400ms frame finishes it
+    act(() => flushRaf(1000));
+    act(() => flushRaf(1400));
+    expect(container.querySelector('.bookmark-pull-band')).toBeNull();
+    expect(slide.style.transform).toBe('');
+    dispatchSpy.mockRestore();
+  });
+
+  it('does not toggle when released below the threshold', () => {
+    renderComponent();
+    const dispatchSpy = vi.spyOn(eventDispatcher, 'dispatch');
+
+    dispatchTouch('touchstart', 300);
+    dispatchTouch('touchmove', 350);
+    dispatchTouch('touchend', 350);
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith('toggle-bookmark', { bookKey: BOOK_KEY });
+    dispatchSpy.mockRestore();
+  });
+
+  it('dismisses the visible toolbars instead of engaging the pull', () => {
+    currentHoveredBookKey = BOOK_KEY;
+    const { container } = renderComponent();
+    const dispatchSpy = vi.spyOn(eventDispatcher, 'dispatch');
+
+    dispatchTouch('touchstart', 300);
+    dispatchTouch('touchmove', 330);
+    expect(hoverCalls).toEqual(['']); // bars dismissed by the pull
+    expect(container.querySelector('.bookmark-pull-band')).toBeNull(); // gesture yields
+
+    dispatchTouch('touchmove', 300 + BOOKMARK_PULL_TRIGGER_PX + 20);
+    dispatchTouch('touchend', 300 + BOOKMARK_PULL_TRIGGER_PX + 20);
+    expect(dispatchSpy).not.toHaveBeenCalledWith('toggle-bookmark', { bookKey: BOOK_KEY });
+    dispatchSpy.mockRestore();
+  });
+
+  it('shows remove wording while bookmarked', () => {
+    currentRibbonVisible = true;
+    const { getByText } = renderComponent();
+
+    dispatchTouch('touchstart', 300);
+    dispatchTouch('touchmove', 330);
+    expect(getByText('Pull down to remove bookmark')).toBeTruthy();
+
+    dispatchTouch('touchmove', 300 + BOOKMARK_PULL_TRIGGER_PX + 30);
+    expect(getByText('Release to remove bookmark')).toBeTruthy();
+  });
+});

--- a/apps/readest-app/src/__tests__/app/reader/components/Ribbon.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/Ribbon.test.tsx
@@ -11,7 +11,7 @@ describe('Ribbon', () => {
     // In scrolled mode SectionInfo paints a `bg-base-100` `notch-area` mask over the
     // top safe-area strip at z-10. The ribbon renders earlier in the DOM, so it must
     // sit on a higher layer than z-10 or its upper (unsafe-area) half gets covered.
-    const { container } = render(<Ribbon width='5%' />);
+    const { container } = render(<Ribbon />);
     const ribbon = container.querySelector('.ribbon') as HTMLElement;
 
     expect(ribbon).not.toBeNull();
@@ -21,8 +21,18 @@ describe('Ribbon', () => {
     expect(ribbon.classList.contains('pointer-events-none')).toBe(true);
   });
 
+  it('hangs at the top-right corner (#1359)', () => {
+    const { container } = render(<Ribbon />);
+    const ribbon = container.querySelector('.ribbon') as HTMLElement;
+
+    expect(ribbon.classList.contains('right-0')).toBe(true);
+    expect(ribbon.classList.contains('top-0')).toBe(true);
+    // `inset-0` anchored it to the left edge; the ribbon lives on the right now.
+    expect(ribbon.classList.contains('inset-0')).toBe(false);
+  });
+
   it('spans the safe-area inset plus the header bar height', () => {
-    const { container } = render(<Ribbon width='5%' />);
+    const { container } = render(<Ribbon />);
     const ribbon = container.querySelector('.ribbon') as HTMLElement;
 
     expect(ribbon.style.height).toBe('92px'); // 48px safe-area top + 44px header bar

--- a/apps/readest-app/src/app/reader/components/BookmarkPullDown.tsx
+++ b/apps/readest-app/src/app/reader/components/BookmarkPullDown.tsx
@@ -1,0 +1,378 @@
+import clsx from 'clsx';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { RiArrowDownLine } from 'react-icons/ri';
+
+import { useReaderStore } from '@/store/readerStore';
+import { useBookDataStore } from '@/store/bookDataStore';
+import { useThemeStore } from '@/store/themeStore';
+import { useTranslation } from '@/hooks/useTranslation';
+import { eventDispatcher } from '@/utils/event';
+import { setLayeredTurnTouchClaimed } from '@/app/reader/utils/iframeEventHandlers';
+import {
+  BOOKMARK_PULL_ACTIVATION_PX,
+  canPullBookmark,
+  computePullOffset,
+  isPastPullThreshold,
+  previewRibbonFilled,
+  pullHintShift,
+  pullRibbonHeight,
+  setBookmarkPullHandlers,
+  shouldActivatePull,
+  type BookmarkPullHandlers,
+} from '@/app/reader/utils/bookmarkPullGesture';
+import Ribbon from './Ribbon';
+
+const SPRING_MS = 250;
+const RIBBON_BODY_HEIGHT = 44; // matches Ribbon.tsx: safe-area top + header bar height
+const HINT_PIN_INSET = 12;
+const HINT_BOTTOM_GAP = 6;
+
+interface BookmarkPullDownProps {
+  bookKey: string;
+  /** Mirror of the resting ribbon's `hoveredBookKey` suppression in BookCell. */
+  ribbonHidden: boolean;
+  /** The page-content wrapper this gesture slides down. */
+  slideRef: React.RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * Pull-down-to-bookmark (#1359), after the WeRead interaction. Owns all
+ * bookmark-ribbon rendering for a book cell: the resting `Ribbon` while idle,
+ * and during a pull the slate band, the hint row and the preview ribbon whose
+ * fill always shows the state a release would produce.
+ *
+ * Gesture events arrive through the `bookmarkPullGesture` bridge (capture
+ * phase on each section document, registered by `FoliateViewer`). Ownership
+ * mirrors `useBrightnessGesture`: one-way arbitration against the paginator,
+ * `stopImmediatePropagation` once active, layered-turn claim cleanup on
+ * release. The continuous offset is written imperatively (rAF-batched) to the
+ * slide wrapper / band / hint / preview so only discrete transitions
+ * (activation, threshold) re-render.
+ */
+const BookmarkPullDown: React.FC<BookmarkPullDownProps> = ({ bookKey, ribbonHidden, slideRef }) => {
+  const _ = useTranslation();
+  const { safeAreaInsets } = useThemeStore();
+  const ribbonVisible = useReaderStore((s) => !!s.viewStates[bookKey]?.ribbonVisible);
+
+  const [pulling, setPulling] = useState(false);
+  const [pastThreshold, setPastThreshold] = useState(false);
+  // Bookmark state captured at activation. Hint wording and preview fill are
+  // derived from it so they stay frozen through the release spring even
+  // though the actual toggle (and `ribbonVisible`) flips at touchend.
+  const [removeMode, setRemoveMode] = useState(false);
+
+  const bandRef = useRef<HTMLDivElement | null>(null);
+  const hintRef = useRef<HTMLDivElement | null>(null);
+  const ribbonBoxRef = useRef<HTMLDivElement | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const polygonRef = useRef<SVGPolygonElement | null>(null);
+
+  // Per-gesture state.
+  const armedRef = useRef(false);
+  const activeRef = useRef(false);
+  const startXRef = useRef(0);
+  const startYRef = useRef(0);
+  const baseOffsetRef = useRef(0);
+  const offsetRef = useRef(0);
+  const pastRef = useRef(false);
+  const rafIdRef = useRef<number | null>(null);
+  const pendingOffsetRef = useRef<number | null>(null);
+  const springRafIdRef = useRef<number | null>(null);
+
+  const restHeightRef = useRef(RIBBON_BODY_HEIGHT);
+  restHeightRef.current = (safeAreaInsets?.top || 0) + RIBBON_BODY_HEIGHT;
+  const pinTopRef = useRef(HINT_PIN_INSET);
+  pinTopRef.current = (safeAreaInsets?.top || 0) + HINT_PIN_INSET;
+
+  const applyOffset = useCallback(
+    (offset: number) => {
+      offsetRef.current = offset;
+      const slide = slideRef.current;
+      if (slide) slide.style.transform = offset > 0 ? `translate3d(0, ${offset}px, 0)` : '';
+      const band = bandRef.current;
+      if (band) band.style.height = `${offset}px`;
+      const hint = hintRef.current;
+      if (hint) {
+        const shift = pullHintShift(
+          offset - HINT_BOTTOM_GAP,
+          hint.offsetHeight || 20,
+          pinTopRef.current,
+        );
+        hint.style.transform = shift ? `translateY(${shift}px)` : '';
+      }
+      const svg = svgRef.current;
+      const polygon = polygonRef.current;
+      if (svg && polygon) {
+        const rest = restHeightRef.current;
+        const width = ribbonBoxRef.current?.clientWidth || 32;
+        // The resting ribbon notches at 22% of its height; freeze that depth
+        // in px so the notch doesn't stretch into a spike as the tail grows.
+        const notch = Math.round(rest * 0.22);
+        const height = pullRibbonHeight(offset, rest);
+        svg.setAttribute('height', `${height}`);
+        svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+        polygon.setAttribute(
+          'points',
+          `${width},${height} ${width / 2},${height - notch} 0,${height} 0,0 ${width},0`,
+        );
+      }
+    },
+    [slideRef],
+  );
+
+  const cancelMoveRaf = useCallback(() => {
+    if (rafIdRef.current !== null) {
+      cancelAnimationFrame(rafIdRef.current);
+      rafIdRef.current = null;
+    }
+    pendingOffsetRef.current = null;
+  }, []);
+
+  const scheduleOffset = useCallback(
+    (offset: number) => {
+      pendingOffsetRef.current = offset;
+      if (rafIdRef.current === null) {
+        rafIdRef.current = requestAnimationFrame(() => {
+          rafIdRef.current = null;
+          if (pendingOffsetRef.current !== null) {
+            applyOffset(pendingOffsetRef.current);
+            pendingOffsetRef.current = null;
+          }
+        });
+      }
+    },
+    [applyOffset],
+  );
+
+  const resetGesture = useCallback(() => {
+    armedRef.current = false;
+    activeRef.current = false;
+    baseOffsetRef.current = 0;
+  }, []);
+
+  const finishPull = useCallback(() => {
+    applyOffset(0);
+    resetGesture();
+    pastRef.current = false;
+    setPastThreshold(false);
+    setPulling(false);
+  }, [applyOffset, resetGesture]);
+
+  const cancelSpring = useCallback(() => {
+    if (springRafIdRef.current !== null) {
+      cancelAnimationFrame(springRafIdRef.current);
+      springRafIdRef.current = null;
+    }
+  }, []);
+
+  const springBack = useCallback(() => {
+    cancelMoveRaf();
+    cancelSpring();
+    const from = offsetRef.current;
+    if (from <= 0) {
+      finishPull();
+      return;
+    }
+    let startTs: number | null = null;
+    const step = (ts: number) => {
+      if (startTs === null) startTs = ts;
+      const progress = Math.min(1, (ts - startTs) / SPRING_MS);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      applyOffset(from * (1 - eased));
+      if (progress < 1) {
+        springRafIdRef.current = requestAnimationFrame(step);
+      } else {
+        springRafIdRef.current = null;
+        finishPull();
+      }
+    };
+    springRafIdRef.current = requestAnimationFrame(step);
+  }, [applyOffset, cancelMoveRaf, cancelSpring, finishPull]);
+
+  // The bridge invokes whatever handlers are installed for this bookKey, so
+  // the callbacks read all runtime-variable state through refs.
+  useEffect(() => {
+    const handlers: BookmarkPullHandlers = {
+      onTouchStart: (doc, e) => {
+        if (e.touches.length !== 1) {
+          resetGesture();
+          return;
+        }
+        const t = e.touches[0];
+        if (!t) return;
+        if (springRafIdRef.current !== null) {
+          // Re-grab mid-spring: keep the pull engaged from the current offset.
+          cancelSpring();
+          startXRef.current = t.screenX;
+          startYRef.current = t.screenY;
+          baseOffsetRef.current = offsetRef.current;
+          armedRef.current = true;
+          activeRef.current = true;
+          setRemoveMode(!!useReaderStore.getState().viewStates[bookKey]?.ribbonVisible);
+          return;
+        }
+        resetGesture();
+        const selection = doc.getSelection?.();
+        if (selection && !selection.isCollapsed) return; // don't hijack selection
+        const viewSettings = useReaderStore.getState().getViewSettings(bookKey);
+        const bookData = useBookDataStore.getState().getBookData(bookKey);
+        if (!viewSettings) return;
+        if (
+          !canPullBookmark({
+            scrolled: !!viewSettings.scrolled,
+            vertical: !!viewSettings.vertical,
+            isEink: !!viewSettings.isEink,
+            isFixedLayout: !!bookData?.isFixedLayout,
+          })
+        ) {
+          return;
+        }
+        // screenX/screenY, not clientX/clientY: in paginated mode the iframe
+        // document is many screens wide, so client coordinates are document
+        // coordinates; screen coordinates match the app viewport.
+        startXRef.current = t.screenX;
+        startYRef.current = t.screenY;
+        armedRef.current = true;
+      },
+      onTouchMove: (_doc, e) => {
+        if (!armedRef.current) return;
+        if (e.touches.length !== 1) {
+          if (activeRef.current) springBack();
+          resetGesture();
+          return;
+        }
+        const t = e.touches[0];
+        if (!t) return;
+        const dx = t.screenX - startXRef.current;
+        const dy = t.screenY - startYRef.current + baseOffsetRef.current;
+        if (!activeRef.current) {
+          if (!shouldActivatePull(dx, dy)) {
+            // One-way ownership: once the sequence is clearly horizontal (a
+            // page turn) or upward, this gesture may not claim it later.
+            if (
+              (Math.abs(dx) >= BOOKMARK_PULL_ACTIVATION_PX && Math.abs(dx) > Math.abs(dy)) ||
+              dy <= -BOOKMARK_PULL_ACTIVATION_PX
+            ) {
+              resetGesture();
+            }
+            return;
+          }
+          const store = useReaderStore.getState();
+          if (store.hoveredBookKey) {
+            // The toolbars are up: this pull dismisses them; bookmarking
+            // stays a reading-surface gesture.
+            store.setHoveredBookKey('');
+            resetGesture();
+            return;
+          }
+          activeRef.current = true;
+          pastRef.current = false;
+          setPastThreshold(false);
+          setRemoveMode(!!store.viewStates[bookKey]?.ribbonVisible);
+          setPulling(true);
+        }
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        const offset = computePullOffset(dy);
+        scheduleOffset(offset);
+        const past = isPastPullThreshold(offset);
+        if (past !== pastRef.current) {
+          pastRef.current = past;
+          setPastThreshold(past);
+        }
+      },
+      onTouchEnd: (_doc, e) => {
+        if (!activeRef.current) {
+          resetGesture();
+          return;
+        }
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        // This capture-phase owner prevents the normal iframe touchend
+        // forwarder from seeing the release, so clear its per-touch state.
+        setLayeredTurnTouchClaimed(bookKey, false);
+        if (e.touches.length === 0 && pastRef.current) {
+          eventDispatcher.dispatch('toggle-bookmark', { bookKey });
+        }
+        springBack();
+        resetGesture();
+      },
+      onTouchCancel: () => {
+        if (!activeRef.current) {
+          resetGesture();
+          return;
+        }
+        setLayeredTurnTouchClaimed(bookKey, false);
+        springBack();
+        resetGesture();
+      },
+    };
+    setBookmarkPullHandlers(bookKey, handlers);
+    return () => setBookmarkPullHandlers(bookKey, null);
+  }, [bookKey, cancelSpring, resetGesture, scheduleOffset, springBack]);
+
+  useEffect(() => {
+    return () => {
+      cancelMoveRaf();
+      cancelSpring();
+    };
+  }, [cancelMoveRaf, cancelSpring]);
+
+  const filled = previewRibbonFilled(removeMode, pastThreshold);
+  const hintText = removeMode
+    ? pastThreshold
+      ? _('Release to remove bookmark')
+      : _('Pull down to remove bookmark')
+    : pastThreshold
+      ? _('Release to add bookmark')
+      : _('Pull down to add bookmark');
+
+  return (
+    <>
+      {!pulling && ribbonVisible && !ribbonHidden && <Ribbon />}
+      {pulling && (
+        <div className='pointer-events-none absolute inset-0 z-20'>
+          <div
+            ref={bandRef}
+            className='bookmark-pull-band absolute left-0 right-0 top-0 overflow-hidden bg-[#6C717A]'
+            style={{ height: 0 }}
+          >
+            <div
+              ref={hintRef}
+              className='absolute bottom-1.5 right-12 flex items-center gap-1.5 text-sm text-white/90'
+            >
+              <RiArrowDownLine
+                aria-hidden
+                className={clsx('transition-transform duration-200', pastThreshold && 'rotate-180')}
+              />
+              <span>{hintText}</span>
+            </div>
+          </div>
+          <div
+            ref={ribbonBoxRef}
+            className='bookmark-pull-ribbon absolute right-0 top-0 flex w-8 justify-center sm:w-6'
+          >
+            <svg
+              ref={svgRef}
+              width='100%'
+              height='0'
+              xmlns='http://www.w3.org/2000/svg'
+              style={{ overflow: 'visible' }}
+              shapeRendering='geometricPrecision'
+            >
+              <polygon
+                ref={polygonRef}
+                fill={filled ? '#F44336' : 'none'}
+                stroke={filled ? 'none' : 'rgba(255,255,255,0.9)'}
+                strokeWidth={filled ? 0 : 2}
+                strokeLinejoin='round'
+              />
+            </svg>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default BookmarkPullDown;

--- a/apps/readest-app/src/app/reader/components/BooksGrid.tsx
+++ b/apps/readest-app/src/app/reader/components/BooksGrid.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { Insets } from '@/types/misc';
 import { useEnv } from '@/context/EnvContext';
@@ -19,7 +19,7 @@ import HeaderBar from './HeaderBar';
 import PageNavigationButtons from './PageNavigationButtons';
 import FooterBar from './footerbar/FooterBar';
 import ProgressBar from './ProgressBar';
-import Ribbon from './Ribbon';
+import BookmarkPullDown from './BookmarkPullDown';
 import Annotator from './annotator/Annotator';
 import FootnotePopup from './FootnotePopup';
 import HintInfo from './HintInfo';
@@ -123,6 +123,10 @@ const BookCellInner: React.FC<BookCellProps> = ({
   // though saveViewSettings mutates viewSettings in place (#4898).
   const { viewInsets, contentInsets } = useContentInsets(viewSettings, gridInsets);
 
+  // The page content (viewer + its header/footer chrome) that the pull-down
+  // bookmark gesture slides as one block.
+  const slideRef = useRef<HTMLDivElement | null>(null);
+
   // Stable callback so HeaderBar doesn't see a new prop reference per
   // BooksGrid render.
   const onDropdownOpenChange = useCallback(
@@ -133,7 +137,6 @@ const BookCellInner: React.FC<BookCellProps> = ({
   if (!book || !config || !bookDoc || !viewSettings || !viewState) return null;
 
   const { section, pageinfo, sectionLabel } = progress || {};
-  const isBookmarked = viewState.ribbonVisible;
   const viewerKey = viewState.viewerKey;
   const horizontalGapPercent = viewSettings.gapPercent;
   const showHeader = viewSettings.showHeader;
@@ -151,7 +154,6 @@ const BookCellInner: React.FC<BookCellProps> = ({
         appServiceHasRoundedWindow && 'rounded-window',
       )}
     >
-      {isBookmarked && !hoveredBookKey && <Ribbon width={`${horizontalGapPercent}%`} />}
       <HeaderBar
         bookKey={bookKey}
         gridInsets={gridInsets}
@@ -163,49 +165,69 @@ const BookCellInner: React.FC<BookCellProps> = ({
         onGoToLibrary={onGoToLibrary}
         onDropdownOpenChange={onDropdownOpenChange}
       />
-      <FoliateViewer
-        key={viewerKey}
-        bookKey={bookKey}
-        bookDoc={bookDoc}
-        config={config}
-        gridInsets={gridInsets}
-        contentInsets={contentInsets}
-      />
-      {viewSettings.vertical && viewSettings.scrolled && (
-        <>
-          {(showFooter || viewSettings.doubleBorder) && (
-            <div
-              className='bg-base-100 absolute left-0 top-0 h-full'
-              style={{
-                width: `calc(${contentInsets.left + (viewSettings.doubleBorder ? 32 : 0)}px)`,
-                height: `calc(100%)`,
-              }}
-            />
-          )}
-          {(showHeader || viewSettings.doubleBorder) && (
-            <div
-              className='bg-base-100 absolute right-0 top-0 h-full'
-              style={{
-                width: `calc(${contentInsets.right + (viewSettings.doubleBorder ? 32 : 0)}px)`,
-                height: `calc(100%)`,
-              }}
-            />
-          )}
-        </>
-      )}
-      {viewSettings.vertical && viewSettings.doubleBorder && (
-        <DoubleBorder
-          showHeader={showHeader}
-          showFooter={showFooter}
-          borderColor={viewSettings.borderColor}
-          horizontalGap={horizontalGapPercent}
-          insets={viewInsets}
-        />
-      )}
-      {showHeader && (
-        <SectionInfo
+      {/*
+        bg-base-100: while the pull-down bookmark gesture translates this
+        wrapper, the transform makes it a stacking context, which isolates the
+        texture's mix-blend-mode (.foliate-viewer::before) from any backdrop
+        outside it — the page visibly brightens for the duration of the drag.
+        An opaque background inside the wrapper keeps the blend backdrop with
+        the transformed group, so the drag is luminance-invariant.
+      */}
+      <div ref={slideRef} className='bg-base-100 absolute inset-0'>
+        <FoliateViewer
+          key={viewerKey}
           bookKey={bookKey}
-          section={sectionLabel}
+          bookDoc={bookDoc}
+          config={config}
+          gridInsets={gridInsets}
+          contentInsets={contentInsets}
+        />
+        {viewSettings.vertical && viewSettings.scrolled && (
+          <>
+            {(showFooter || viewSettings.doubleBorder) && (
+              <div
+                className='bg-base-100 absolute left-0 top-0 h-full'
+                style={{
+                  width: `calc(${contentInsets.left + (viewSettings.doubleBorder ? 32 : 0)}px)`,
+                  height: `calc(100%)`,
+                }}
+              />
+            )}
+            {(showHeader || viewSettings.doubleBorder) && (
+              <div
+                className='bg-base-100 absolute right-0 top-0 h-full'
+                style={{
+                  width: `calc(${contentInsets.right + (viewSettings.doubleBorder ? 32 : 0)}px)`,
+                  height: `calc(100%)`,
+                }}
+              />
+            )}
+          </>
+        )}
+        {viewSettings.vertical && viewSettings.doubleBorder && (
+          <DoubleBorder
+            showHeader={showHeader}
+            showFooter={showFooter}
+            borderColor={viewSettings.borderColor}
+            horizontalGap={horizontalGapPercent}
+            insets={viewInsets}
+          />
+        )}
+        {showHeader && (
+          <SectionInfo
+            bookKey={bookKey}
+            section={sectionLabel}
+            showDoubleBorder={viewSettings.vertical && viewSettings.doubleBorder}
+            isScrolled={viewSettings.scrolled}
+            isVertical={viewSettings.vertical}
+            isEink={viewSettings.isEink}
+            horizontalGap={horizontalGapPercent}
+            contentInsets={contentInsets}
+            gridInsets={gridInsets}
+          />
+        )}
+        <HintInfo
+          bookKey={bookKey}
           showDoubleBorder={viewSettings.vertical && viewSettings.doubleBorder}
           isScrolled={viewSettings.scrolled}
           isVertical={viewSettings.vertical}
@@ -214,39 +236,30 @@ const BookCellInner: React.FC<BookCellProps> = ({
           contentInsets={contentInsets}
           gridInsets={gridInsets}
         />
-      )}
-      <HintInfo
-        bookKey={bookKey}
-        showDoubleBorder={viewSettings.vertical && viewSettings.doubleBorder}
-        isScrolled={viewSettings.scrolled}
-        isVertical={viewSettings.vertical}
-        isEink={viewSettings.isEink}
-        horizontalGap={horizontalGapPercent}
-        contentInsets={contentInsets}
-        gridInsets={gridInsets}
-      />
-      {viewSettings.readingRulerEnabled && viewState?.inited && (
-        <ReadingRuler
-          bookKey={bookKey}
-          isVertical={viewSettings.vertical}
-          rtl={viewSettings.rtl}
-          lines={viewSettings.readingRulerLines}
-          position={viewSettings.readingRulerPosition}
-          opacity={viewSettings.readingRulerOpacity}
-          color={viewSettings.readingRulerColor}
-          bookFormat={book.format}
-          viewSettings={viewSettings}
-          gridInsets={gridInsets}
-        />
-      )}
-      {showFooter && (
-        <ProgressBar
-          bookKey={bookKey}
-          horizontalGap={horizontalGapPercent}
-          contentInsets={contentInsets}
-          gridInsets={gridInsets}
-        />
-      )}
+        {viewSettings.readingRulerEnabled && viewState?.inited && (
+          <ReadingRuler
+            bookKey={bookKey}
+            isVertical={viewSettings.vertical}
+            rtl={viewSettings.rtl}
+            lines={viewSettings.readingRulerLines}
+            position={viewSettings.readingRulerPosition}
+            opacity={viewSettings.readingRulerOpacity}
+            color={viewSettings.readingRulerColor}
+            bookFormat={book.format}
+            viewSettings={viewSettings}
+            gridInsets={gridInsets}
+          />
+        )}
+        {showFooter && (
+          <ProgressBar
+            bookKey={bookKey}
+            horizontalGap={horizontalGapPercent}
+            contentInsets={contentInsets}
+            gridInsets={gridInsets}
+          />
+        )}
+      </div>
+      <BookmarkPullDown bookKey={bookKey} ribbonHidden={!!hoveredBookKey} slideRef={slideRef} />
       <PageNavigationButtons bookKey={bookKey} isDropdownOpen={isDropdownOpen} />
       <Annotator bookKey={bookKey} contentInsets={contentInsets} />
       <SearchResultsNav bookKey={bookKey} gridInsets={gridInsets} />

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -16,6 +16,7 @@ import { useParallelViewStore } from '@/store/parallelViewStore';
 import { useMouseEvent, useTouchEvent, useOpenMediaEvent } from '../hooks/useIframeEvents';
 import { useCapturedTurn, applyPageTurnAttributes } from '../hooks/useCapturedTurn';
 import { useBrightnessGesture } from '../hooks/useBrightnessGesture';
+import { registerBookmarkPullDoc } from '../utils/bookmarkPullGesture';
 import BrightnessOverlay from './BrightnessOverlay';
 import { usePagination, viewPagination } from '../hooks/usePagination';
 import { useFoliateEvents } from '../hooks/useFoliateEvents';
@@ -451,6 +452,7 @@ const FoliateViewer: React.FC<{
         detail.doc.addEventListener('touchcancel', handleTouchCancel.bind(null, bookKey));
         registerBrightnessListeners(detail.doc);
         registerSpeedListeners(detail.doc);
+        registerBookmarkPullDoc(bookKey, detail.doc);
       }
     }
   };

--- a/apps/readest-app/src/app/reader/components/Ribbon.tsx
+++ b/apps/readest-app/src/app/reader/components/Ribbon.tsx
@@ -2,11 +2,7 @@ import clsx from 'clsx';
 import React from 'react';
 import { useThemeStore } from '@/store/themeStore';
 
-interface RibbonProps {
-  width: string;
-}
-
-const Ribbon: React.FC<RibbonProps> = ({}) => {
+const Ribbon: React.FC = () => {
   const { safeAreaInsets } = useThemeStore();
 
   // z-20 keeps the ribbon above the scrolled-mode `notch-area` mask (z-10 in
@@ -14,7 +10,7 @@ const Ribbon: React.FC<RibbonProps> = ({}) => {
   return (
     <div
       className={clsx(
-        'ribbon pointer-events-none absolute inset-0 z-20 flex w-8 justify-center sm:w-6',
+        'ribbon pointer-events-none absolute right-0 top-0 z-20 flex w-8 justify-center sm:w-6',
       )}
       style={{
         height: `${(safeAreaInsets?.top || 0) + 44}px`,

--- a/apps/readest-app/src/app/reader/utils/bookmarkPullGesture.ts
+++ b/apps/readest-app/src/app/reader/utils/bookmarkPullGesture.ts
@@ -1,0 +1,118 @@
+/**
+ * Pure helpers + doc-registration bridge for the pull-down-to-bookmark gesture
+ * (#1359), modeled on the WeRead interaction:
+ *
+ * Dragging the page down in paginated mode slides it away from the top edge,
+ * revealing a band with a hint and a ribbon that always previews the bookmark
+ * state a release would produce. Pulling past `BOOKMARK_PULL_TRIGGER_PX` and
+ * releasing toggles the bookmark at the current location.
+ *
+ * The gesture listeners attach per iframe document (capture phase, from
+ * `FoliateViewer.docLoadHandler` — same lifecycle as the brightness/speed
+ * gestures) but the state and UI live in `BookmarkPullDown`, mounted per book
+ * cell. This module bridges the two: docs delegate to whatever handlers the
+ * component has currently installed for that bookKey.
+ */
+
+export const BOOKMARK_PULL_ACTIVATION_PX = 18;
+export const BOOKMARK_PULL_TRIGGER_PX = 100;
+export const BOOKMARK_PULL_LINEAR_PX = 120;
+export const BOOKMARK_PULL_DAMPING = 0.35;
+
+/**
+ * True when movement is downward-dominant past the activation threshold.
+ * Direction matters (unlike the brightness gesture): only a pull DOWN may
+ * claim the sequence, so upward wobble stays with the paginator.
+ */
+export const shouldActivatePull = (
+  deltaX: number,
+  deltaY: number,
+  threshold = BOOKMARK_PULL_ACTIVATION_PX,
+): boolean => deltaY >= threshold && deltaY > Math.abs(deltaX);
+
+/**
+ * Page offset for a finger travel of `deltaY` px: 1:1 through the linear
+ * range (which covers the trigger distance, so the pull feels direct up to
+ * the decision point), rubber-banded beyond it.
+ */
+export const computePullOffset = (deltaY: number): number => {
+  if (deltaY <= 0) return 0;
+  if (deltaY <= BOOKMARK_PULL_LINEAR_PX) return deltaY;
+  return BOOKMARK_PULL_LINEAR_PX + (deltaY - BOOKMARK_PULL_LINEAR_PX) * BOOKMARK_PULL_DAMPING;
+};
+
+export const isPastPullThreshold = (offset: number): boolean => offset >= BOOKMARK_PULL_TRIGGER_PX;
+
+/**
+ * Whether the band ribbon renders filled (vs outline). It always previews the
+ * state a release right now would leave: below the threshold that is the
+ * current state, past it the toggled one.
+ */
+export const previewRibbonFilled = (bookmarked: boolean, pastThreshold: boolean): boolean =>
+  bookmarked !== pastThreshold;
+
+/**
+ * Preview ribbon height: it hangs from the viewport top at its resting size
+ * until the descending page edge passes its tail, then the tail rides the
+ * page edge.
+ */
+export const pullRibbonHeight = (offset: number, restHeight: number): number =>
+  Math.max(restHeight, offset);
+
+/**
+ * translateY for the hint row, which is bottom-anchored inside the band (so it
+ * rides just above the page edge) until its top reaches `pinTop`, where it
+ * stays pinned while the pull continues.
+ */
+export const pullHintShift = (offset: number, hintHeight: number, pinTop: number): number =>
+  0 - Math.max(0, offset - hintHeight - pinTop);
+
+/**
+ * The gesture exists only where a vertical drag has no other meaning and the
+ * continuous slide can look right: paginated (not scrolled) reflowable books
+ * in horizontal writing mode, and never on e-ink (ghosting).
+ */
+export const canPullBookmark = (mode: {
+  scrolled: boolean;
+  vertical: boolean;
+  isEink: boolean;
+  isFixedLayout: boolean;
+}): boolean => !mode.scrolled && !mode.vertical && !mode.isEink && !mode.isFixedLayout;
+
+export interface BookmarkPullHandlers {
+  onTouchStart: (doc: Document, event: TouchEvent) => void;
+  onTouchMove: (doc: Document, event: TouchEvent) => void;
+  onTouchEnd: (doc: Document, event: TouchEvent) => void;
+  onTouchCancel: (doc: Document, event: TouchEvent) => void;
+}
+
+const pullHandlers = new Map<string, BookmarkPullHandlers>();
+
+/** Install (or with `null` remove) the live handlers for a book. */
+export const setBookmarkPullHandlers = (
+  bookKey: string,
+  handlers: BookmarkPullHandlers | null,
+): void => {
+  if (handlers) pullHandlers.set(bookKey, handlers);
+  else pullHandlers.delete(bookKey);
+};
+
+/**
+ * Attach the capture-phase, non-passive touch listeners to a section document.
+ * Capture phase is required so an active pull's `stopImmediatePropagation` can
+ * suppress foliate-js's own bubble-phase paginator listeners (see
+ * `useBrightnessGesture`). Called once per doc from `docLoadHandler`, inside
+ * its `isEventListenersAdded` guard; registration order puts these after the
+ * brightness/speed listeners, so those gestures win their claims first.
+ */
+export const registerBookmarkPullDoc = (bookKey: string, doc: Document): void => {
+  const opts = { capture: true, passive: false } as const;
+  doc.addEventListener('touchstart', (e) => pullHandlers.get(bookKey)?.onTouchStart(doc, e), opts);
+  doc.addEventListener('touchmove', (e) => pullHandlers.get(bookKey)?.onTouchMove(doc, e), opts);
+  doc.addEventListener('touchend', (e) => pullHandlers.get(bookKey)?.onTouchEnd(doc, e), opts);
+  doc.addEventListener(
+    'touchcancel',
+    (e) => pullHandlers.get(bookKey)?.onTouchCancel(doc, e),
+    opts,
+  );
+};


### PR DESCRIPTION
Fixes #1359.

Pulling the page down in paginated mode reveals a band with a hint and a preview ribbon, following the reference interaction from the issue: the hint (`Pull down to add/remove bookmark`) rides just above the descending page edge until it pins below the safe area, the arrow rotates at the ~100px trigger distance (`Release to add/remove bookmark`), and the ribbon at the top-right always previews the bookmark state a release would produce — filled when releasing would leave a bookmark, outline otherwise, with its tail riding the page edge. Releasing past the threshold toggles the bookmark through the existing `toggle-bookmark` path, then the page springs back.

- The gesture attaches capture-phase listeners per section document (same lifecycle and one-way arbitration as the brightness / autoscroll-speed gestures) and claims only downward-dominant drags, so page turns, slide/curl captured turns, and selection are unaffected.
- Scope: paginated reflowable horizontal-writing books, touch input, not e-ink.
- While the toolbars are visible, a pull dismisses them instead of engaging the bookmark.
- The slide wrapper carries its own `bg-base-100`: its transform creates a stacking context that would otherwise isolate the background texture's `mix-blend-mode` from the page backdrop, visibly brightening the page during the drag (measured +3.8% luminance on device; invariant after the fix).
- The resting red ribbon moves from the top-left to the top-right corner, style unchanged.
- The four hint strings are translated across all locales.

Tested with new unit tests for the gesture math and component behavior, a Playwright + CDP touch smoke on the web build, and on-device verification on a Xiaomi 13 (CDP `synthesizeScrollGesture`): band growth, both preview-fill transitions, bookmark toggling both ways, toolbar dismissal, and luminance invariance while dragging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)