### PR TITLE
fix(opds): invalidate cached covers when the entry's updated value changes

### DIFF
--- a/apps/readest-app/src/__tests__/app/opds/publication-card.test.tsx
+++ b/apps/readest-app/src/__tests__/app/opds/publication-card.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { OPDSPublication } from '@/types/opds';
+import { PublicationCard } from '@/app/opds/components/PublicationCard';
+
+vi.mock('@/components/CachedImage', () => ({
+  CachedImage: ({ cacheVersion }: { cacheVersion?: string }) => (
+    <div data-testid='cached-image' data-cache-version={cacheVersion ?? ''} />
+  ),
+}));
+
+const publication: OPDSPublication = {
+  metadata: {
+    title: 'Updated Cover Entry',
+    updated: '2025-06-01T00:00:00Z',
+  },
+  links: [],
+  images: [{ rel: 'http://opds-spec.org/image', href: '/covers/1.jpg' }],
+};
+
+describe('PublicationCard cover cache version (issue #5492)', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("passes the entry's Atom updated value so a replaced cover invalidates the cache", () => {
+    render(
+      <PublicationCard
+        publication={publication}
+        baseURL='https://catalog.example.com/opds'
+        onClick={vi.fn()}
+        resolveURL={(href, base) => new URL(href, base).toString()}
+        onGenerateCachedImageUrl={vi.fn(async (url: string) => url)}
+      />,
+    );
+
+    expect(screen.getByTestId('cached-image').getAttribute('data-cache-version')).toBe(
+      '2025-06-01T00:00:00Z',
+    );
+  });
+});

--- a/apps/readest-app/src/__tests__/app/opds/publication-view.test.tsx
+++ b/apps/readest-app/src/__tests__/app/opds/publication-view.test.tsx
@@ -17,7 +17,9 @@ vi.mock('@/hooks/useTranslation', () => ({
 }));
 
 vi.mock('@/components/CachedImage', () => ({
-  CachedImage: () => <div data-testid='cached-image' />,
+  CachedImage: ({ cacheVersion }: { cacheVersion?: string }) => (
+    <div data-testid='cached-image' data-cache-version={cacheVersion ?? ''} />
+  ),
 }));
 
 vi.mock('@/utils/nav', () => ({
@@ -290,5 +292,33 @@ describe('PublicationView', () => {
 
     expect(screen.queryByRole('button', { name: 'Plain Tag' })).toBeNull();
     expect(screen.getByText('Plain Tag')).toBeTruthy();
+  });
+
+  it("passes the entry's Atom updated value to the cover so a replaced cover refreshes (issue #5492)", () => {
+    const updatedPublication: OPDSPublication = {
+      metadata: {
+        title: 'Replaced Cover Entry',
+        updated: '2025-06-01T00:00:00Z',
+      },
+      links: [],
+      images: [{ rel: 'http://opds-spec.org/image', href: '/covers/1.jpg' }],
+    };
+
+    render(
+      <DropdownProvider>
+        <PublicationView
+          publication={updatedPublication}
+          baseURL='https://catalog.example.com/opds'
+          resolveURL={(href, base) => new URL(href, base).toString()}
+          onDownload={vi.fn(async () => null)}
+          onNavigate={vi.fn()}
+          onGenerateCachedImageUrl={vi.fn(async (url: string) => url)}
+        />
+      </DropdownProvider>,
+    );
+
+    expect(screen.getByTestId('cached-image').getAttribute('data-cache-version')).toBe(
+      '2025-06-01T00:00:00Z',
+    );
   });
 });

--- a/apps/readest-app/src/__tests__/components/cached-image.test.tsx
+++ b/apps/readest-app/src/__tests__/components/cached-image.test.tsx
@@ -1,0 +1,123 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CachedImage, clearImageCache } from '@/components/CachedImage';
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ fill: _fill, ...props }: Record<string, unknown> & { fill?: boolean }) => {
+    // biome-ignore lint/a11y/useAltText: test mock; alt comes from spread props
+    return <img {...props} />;
+  },
+}));
+
+const renderImage = (
+  onGenerateCachedImageUrl: (url: string, cacheVersion?: string) => Promise<string>,
+  cacheVersion?: string,
+) =>
+  render(
+    <CachedImage
+      src='https://catalog.example.com/cover/1'
+      alt='Book cover'
+      width={28}
+      height={41}
+      cacheVersion={cacheVersion}
+      onGenerateCachedImageUrl={onGenerateCachedImageUrl}
+    />,
+  );
+
+describe('CachedImage cache versioning (issue #5492)', () => {
+  beforeEach(() => {
+    cleanup();
+    clearImageCache();
+  });
+
+  it('serves an unchanged URL and version from the cache', async () => {
+    const generate = vi.fn(async (url: string) => `blob:${url}`);
+
+    const { rerender } = renderImage(generate, '2024-01-01T00:00:00Z');
+    await waitFor(() => {
+      expect(screen.getByRole('img').getAttribute('src')).toBe(
+        'blob:https://catalog.example.com/cover/1',
+      );
+    });
+
+    rerender(
+      <CachedImage
+        src='https://catalog.example.com/cover/1'
+        alt='Book cover'
+        width={28}
+        height={41}
+        cacheVersion='2024-01-01T00:00:00Z'
+        onGenerateCachedImageUrl={generate}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('img').getAttribute('src')).toBe(
+        'blob:https://catalog.example.com/cover/1',
+      );
+    });
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  it('regenerates the image when the cache version changes at the same URL', async () => {
+    // Simulates a server-side cover replacement: same URL, new Atom <updated>.
+    const generate = vi.fn(
+      async (url: string, cacheVersion?: string) => `blob:${url}#${cacheVersion ?? 'none'}`,
+    );
+
+    const { rerender } = renderImage(generate, '2024-01-01T00:00:00Z');
+    await waitFor(() => {
+      expect(screen.getByRole('img').getAttribute('src')).toBe(
+        'blob:https://catalog.example.com/cover/1#2024-01-01T00:00:00Z',
+      );
+    });
+
+    rerender(
+      <CachedImage
+        src='https://catalog.example.com/cover/1'
+        alt='Book cover'
+        width={28}
+        height={41}
+        cacheVersion='2025-06-01T00:00:00Z'
+        onGenerateCachedImageUrl={generate}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('img').getAttribute('src')).toBe(
+        'blob:https://catalog.example.com/cover/1#2025-06-01T00:00:00Z',
+      );
+    });
+    expect(generate).toHaveBeenCalledTimes(2);
+    expect(generate).toHaveBeenLastCalledWith(
+      'https://catalog.example.com/cover/1',
+      '2025-06-01T00:00:00Z',
+    );
+  });
+
+  it('keeps caching by URL alone when no version is provided', async () => {
+    const generate = vi.fn(async (url: string) => `blob:${url}`);
+
+    const { rerender } = renderImage(generate);
+    await waitFor(() => {
+      expect(screen.getByRole('img').getAttribute('src')).toBe(
+        'blob:https://catalog.example.com/cover/1',
+      );
+    });
+
+    rerender(
+      <CachedImage
+        src='https://catalog.example.com/cover/1'
+        alt='Book cover'
+        width={28}
+        height={41}
+        onGenerateCachedImageUrl={generate}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('img').getAttribute('src')).toBe(
+        'blob:https://catalog.example.com/cover/1',
+      );
+    });
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/opds-cover.test.ts
+++ b/apps/readest-app/src/__tests__/services/opds-cover.test.ts
@@ -20,7 +20,8 @@ vi.mock('@/app/opds/utils/opdsReq', () => ({
   getProxiedURL: vi.fn((url: string) => url),
 }));
 
-import { applyOPDSCover, getOPDSCoverHref } from '@/services/opds/cover';
+import { md5 } from 'js-md5';
+import { applyOPDSCover, getOPDSCoverHref, getOPDSImageCacheFilename } from '@/services/opds/cover';
 import { downloadFile } from '@/libs/storage';
 import { probeAuth, getProxiedURL, needsProxy } from '@/app/opds/utils/opdsReq';
 
@@ -176,5 +177,27 @@ describe('applyOPDSCover', () => {
     expect(applied).toBe(false);
     expect(appService.writeFile).not.toHaveBeenCalled();
     expect(book.coverHash).toBe('embedded-cover-hash');
+  });
+});
+
+describe('getOPDSImageCacheFilename', () => {
+  const url = 'https://catalog.example.com/covers/1.jpg';
+
+  it('keeps the historical URL-only key when the entry has no updated value', () => {
+    // Existing caches for catalogs without <updated> must stay valid.
+    expect(getOPDSImageCacheFilename(url)).toBe(`img_${md5(url)}.png`);
+  });
+
+  it('changes the key when the updated value changes (issue #5492)', () => {
+    const before = getOPDSImageCacheFilename(url, '2024-01-01T00:00:00Z');
+    const after = getOPDSImageCacheFilename(url, '2025-06-01T00:00:00Z');
+    expect(before).not.toBe(after);
+    expect(before).not.toBe(getOPDSImageCacheFilename(url));
+  });
+
+  it('is stable for the same URL and updated value', () => {
+    expect(getOPDSImageCacheFilename(url, '2025-06-01T00:00:00Z')).toBe(
+      getOPDSImageCacheFilename(url, '2025-06-01T00:00:00Z'),
+    );
   });
 });

--- a/apps/readest-app/src/app/opds/components/FeedView.tsx
+++ b/apps/readest-app/src/app/opds/components/FeedView.tsx
@@ -16,7 +16,7 @@ interface FeedViewProps {
   resolveURL: (url: string, base: string) => string;
   onNavigate: (url: string) => void;
   onPublicationSelect: (groupIndex: number, itemIndex: number) => void;
-  onGenerateCachedImageUrl: (url: string) => Promise<string>;
+  onGenerateCachedImageUrl: (url: string, cacheVersion?: string) => Promise<string>;
   isOPDSCatalog: (type?: string) => boolean;
   onAddCatalog?: () => void;
 }

--- a/apps/readest-app/src/app/opds/components/PublicationCard.tsx
+++ b/apps/readest-app/src/app/opds/components/PublicationCard.tsx
@@ -10,7 +10,7 @@ interface PublicationCardProps {
   baseURL: string;
   onClick: () => void;
   resolveURL: (url: string, base: string) => string;
-  onGenerateCachedImageUrl: (url: string) => Promise<string>;
+  onGenerateCachedImageUrl: (url: string, cacheVersion?: string) => Promise<string>;
 }
 
 export function PublicationCard({
@@ -58,6 +58,7 @@ export function PublicationCard({
           fill
           className='object-cover'
           sizes='(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw'
+          cacheVersion={publication.metadata?.updated}
           onGenerateCachedImageUrl={onGenerateCachedImageUrl}
         />
       </figure>

--- a/apps/readest-app/src/app/opds/components/PublicationView.tsx
+++ b/apps/readest-app/src/app/opds/components/PublicationView.tsx
@@ -39,7 +39,7 @@ interface PublicationViewProps {
     onProgress?: (progress: { progress: number; total: number }) => void,
   ) => Promise<Book | null | undefined>;
   onStream?: (href: string, count: number, title: string, author: string) => void;
-  onGenerateCachedImageUrl: (url: string) => Promise<string>;
+  onGenerateCachedImageUrl: (url: string, cacheVersion?: string) => Promise<string>;
 }
 
 export function PublicationView({
@@ -194,6 +194,7 @@ export function PublicationView({
               fill
               className='object-cover'
               sizes='(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw'
+              cacheVersion={publication.metadata?.updated}
               onGenerateCachedImageUrl={onGenerateCachedImageUrl}
             />
           </div>

--- a/apps/readest-app/src/app/opds/page.tsx
+++ b/apps/readest-app/src/app/opds/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import clsx from 'clsx';
-import { md5 } from 'js-md5';
 import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { isOPDSCatalog, getPublication, getFeed, getOpenSearch } from 'foliate-js/opds.js';
@@ -48,7 +47,7 @@ import { getPublicationDetailHref, parsePublicationDocument } from './utils/opds
 import { ImportError } from '@/services/errors';
 import { READEST_OPDS_USER_AGENT } from '@/services/constants';
 import { findBookByOPDSSources, upsertOPDSSourceMapping } from '@/services/opds/sourceMap';
-import { applyOPDSCover, getOPDSCoverHref } from '@/services/opds/cover';
+import { applyOPDSCover, getOPDSCoverHref, getOPDSImageCacheFilename } from '@/services/opds/cover';
 import { applyOPDSMetadata, getOPDSBookMetadata } from '@/services/opds/metadata';
 import { buildPseStreamFileName } from '@/services/opds/pseStream';
 import type { Book } from '@/types/book';
@@ -709,7 +708,7 @@ export default function BrowserPage() {
   );
 
   const handleGenerateCachedImageUrl = useCallback(
-    async (url: string) => {
+    async (url: string, cacheVersion?: string) => {
       if (!appService) return url;
       const username = usernameRef.current || '';
       const password = passwordRef.current || '';
@@ -718,7 +717,7 @@ export default function BrowserPage() {
         return needsProxy(url) ? getProxiedURL(url, '', true) : url;
       }
 
-      const cachedKey = `img_${md5(url)}.png`;
+      const cachedKey = getOPDSImageCacheFilename(url, cacheVersion);
       const cachePrefix = await appService.resolveFilePath('', 'Cache');
       const cachedPath = `${cachePrefix}/${cachedKey}`;
       if (await appService.exists(cachedPath, 'None')) {

--- a/apps/readest-app/src/components/CachedImage.tsx
+++ b/apps/readest-app/src/components/CachedImage.tsx
@@ -11,12 +11,23 @@ interface CachedImageProps {
   sizes?: string;
   width?: number;
   height?: number;
-  onGenerateCachedImageUrl: (url: string) => Promise<string>;
+  /**
+   * Optional version tag for the image behind `src` (e.g. an OPDS entry's
+   * Atom `<updated>` value). Caching is keyed by URL + version, so a server
+   * that replaces the image at an unchanged URL and bumps the version gets a
+   * fresh fetch instead of the stale cached copy (issue #5492).
+   */
+  cacheVersion?: string;
+  onGenerateCachedImageUrl: (url: string, cacheVersion?: string) => Promise<string>;
   fallback?: React.ReactNode;
 }
 
 const imageUrlCache = new Map<string, string>();
 const loadingPromises = new Map<string, Promise<string>>();
+
+// '\n' cannot appear in a URL, so the key never collides with a plain URL key.
+const toCacheKey = (src: string, cacheVersion?: string) =>
+  cacheVersion ? `${src}\n${cacheVersion}` : src;
 
 const CachedImageComponent = ({
   src,
@@ -26,13 +37,16 @@ const CachedImageComponent = ({
   sizes,
   width,
   height,
+  cacheVersion,
   onGenerateCachedImageUrl,
   fallback,
 }: CachedImageProps) => {
   const [cachedUrl, setCachedUrl] = useState<string | null>(() => {
-    return src ? imageUrlCache.get(src) || null : null;
+    return src ? imageUrlCache.get(toCacheKey(src, cacheVersion)) || null : null;
   });
-  const [loading, setLoading] = useState(() => !src || !imageUrlCache.has(src));
+  const [loading, setLoading] = useState(
+    () => !src || !imageUrlCache.has(toCacheKey(src, cacheVersion)),
+  );
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
@@ -43,7 +57,8 @@ const CachedImageComponent = ({
       return;
     }
 
-    const cached = imageUrlCache.get(src);
+    const cacheKey = toCacheKey(src, cacheVersion);
+    const cached = imageUrlCache.get(cacheKey);
     if (cached) {
       setTimeout(() => {
         setCachedUrl(cached);
@@ -59,20 +74,20 @@ const CachedImageComponent = ({
         setLoading(true);
         setError(null);
 
-        let loadPromise = loadingPromises.get(src);
+        let loadPromise = loadingPromises.get(cacheKey);
 
         if (!loadPromise) {
-          loadPromise = onGenerateCachedImageUrl(src);
-          loadingPromises.set(src, loadPromise);
+          loadPromise = onGenerateCachedImageUrl(src, cacheVersion);
+          loadingPromises.set(cacheKey, loadPromise);
           loadPromise.finally(() => {
-            loadingPromises.delete(src);
+            loadingPromises.delete(cacheKey);
           });
         }
 
         const url = await loadPromise;
 
         if (!cancelled) {
-          imageUrlCache.set(src, url);
+          imageUrlCache.set(cacheKey, url);
           setCachedUrl(url);
           setLoading(false);
         }
@@ -89,7 +104,7 @@ const CachedImageComponent = ({
     return () => {
       cancelled = true;
     };
-  }, [src, onGenerateCachedImageUrl]);
+  }, [src, cacheVersion, onGenerateCachedImageUrl]);
 
   if (loading) {
     return (
@@ -143,7 +158,8 @@ const arePropsEqual = (prevProps: CachedImageProps, nextProps: CachedImageProps)
     prevProps.className === nextProps.className &&
     prevProps.sizes === nextProps.sizes &&
     prevProps.width === nextProps.width &&
-    prevProps.height === nextProps.height
+    prevProps.height === nextProps.height &&
+    prevProps.cacheVersion === nextProps.cacheVersion
   );
 };
 

--- a/apps/readest-app/src/services/opds/cover.ts
+++ b/apps/readest-app/src/services/opds/cover.ts
@@ -1,3 +1,4 @@
+import { md5 } from 'js-md5';
 import type { Book } from '@/types/book';
 import type { AppService } from '@/types/system';
 import type { OPDSGenericLink } from '@/types/opds';
@@ -41,6 +42,17 @@ export const getOPDSCoverHref = (publication: {
     images.find((img) => img.href);
   return cover?.href;
 };
+
+/**
+ * Cache filename for a downloaded OPDS image. Some catalogs replace the cover
+ * bytes at an unchanged URL and only advance the entry's Atom `<updated>`
+ * value, so when the entry carries one it participates in the key and the
+ * replacement invalidates the cached file (issue #5492). Entries without
+ * `<updated>` keep the historical URL-only key, so their existing cache files
+ * stay valid.
+ */
+export const getOPDSImageCacheFilename = (url: string, updated?: string): string =>
+  `img_${md5(updated ? `${url}\n${updated}` : url)}.png`;
 
 interface ApplyOPDSCoverParams {
   appService: AppService;


### PR DESCRIPTION
Fixes #5492

## Problem

Some OPDS catalogs replace a book's cover bytes at an unchanged cover URL and only advance the Atom entry's `<updated>` value. Readest kept showing the old image in both the publication grid and the detail view, even after refreshing or reopening the catalog.

## Root cause

OPDS covers are cached in two Readest-owned layers keyed by the cover URL alone:

- the in-memory `imageUrlCache` map in `CachedImage`, and
- the on-disk `img_<md5(url)>.png` cache written by `handleGenerateCachedImageUrl` for catalogs that use auth or custom headers (on web this lives in OPFS and survives reloads).

The feed parser already extracts `metadata.updated`, but the value never reached either cache key. (The no-auth proxied path is unaffected: the proxy serves image streams with `Cache-Control: no-store`.)

## Fix

Thread the entry's `updated` value through as an optional `cacheVersion`:

- `PublicationCard` and `PublicationView` pass `publication.metadata?.updated` to `CachedImage`.
- `CachedImage` keys its in-memory cache and in-flight promises by URL + version, forwards the version to `onGenerateCachedImageUrl`, and includes the new prop in its memo comparator.
- The disk filename is computed by a new `getOPDSImageCacheFilename(url, updated?)` helper that hashes URL and `updated` together.

Entries without `<updated>` keep the exact historical URL-only keys, so their behavior and existing cache files are unchanged, as requested in the issue.

## Tests

Written test-first (confirmed failing before the fix):

- `CachedImage` regenerates the image when `cacheVersion` changes at the same URL, serves unchanged URL + version from the cache, and still caches by URL alone when no version is given.
- `PublicationCard` and `PublicationView` pass the entry's `updated` value to the cover.
- `getOPDSImageCacheFilename` keeps the legacy URL-only key without `updated`, changes when `updated` changes, and is stable for identical inputs.

`pnpm test` (8617 passed), `pnpm lint`, and `pnpm format:check` are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)