### PR TITLE
fix(reader): style annotation toolbar customizer and flatten popup chrome

### DIFF
--- a/apps/readest-app/src/__tests__/components/ProofreadPopup.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ProofreadPopup.test.tsx
@@ -275,6 +275,36 @@ describe('ProofreadPopup Component', () => {
     });
   });
 
+  /**
+   * `Popup` caps the popup at the space available above the selection. When the
+   * selection sits near the top of the viewport that cap can be shorter than the
+   * form, and with `overflow: visible` the excess simply painted outside the
+   * rounded box: the scope row (the last child) hung past the bottom edge.
+   *
+   * Invariant: the scope row is pinned outside the scrollable region, so the
+   * upper content absorbs any shortfall and the scope select stays reachable.
+   */
+  describe('Constrained Popup Height', () => {
+    it('pins the scope row outside the scrollable region so it cannot overflow', () => {
+      const { container } = renderWithProviders(<ProofreadPopup {...defaultProps} />);
+
+      const select = container.querySelector('select') as HTMLSelectElement;
+      const scopeRow = select.closest('div') as HTMLElement;
+      expect(scopeRow.className).toContain('shrink-0');
+
+      const scrollArea = container.querySelector('.overflow-y-auto');
+      expect(scrollArea).not.toBeNull();
+      expect(scrollArea!.contains(select)).toBe(false);
+    });
+
+    it('clips the popup surface so no child paints past the rounded box', () => {
+      const { container } = renderWithProviders(<ProofreadPopup {...defaultProps} />);
+
+      const popup = container.querySelector('.popup-container') as HTMLElement;
+      expect(popup.className).toContain('overflow-hidden');
+    });
+  });
+
   describe('Click Outside Behavior', () => {
     it('should not call onClose when clicking inside the menu', () => {
       renderWithProviders(<ProofreadPopup {...defaultProps} />);

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotationNotesSurface.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotationNotesSurface.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+
+/**
+ * The note cards shown when tapping an annotation are `.popup-container`s, so
+ * they should wear the same chrome as every other popup (Popup.tsx): a
+ * `base-300` surface that flips to `base-100` on dark themes, `base-content`
+ * text, and a hairline border.
+ *
+ * They used to hardcode `bg-gray-600` + `text-white` instead, which left a dark
+ * slate card hanging off the popup's tan `base-300` triangle on light themes,
+ * and forced `eink:` overrides on every text node to stay legible.
+ */
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: { isMobile: false }, envConfig: {} }),
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({ getConfig: () => ({ viewSettings: {} }), setConfig: vi.fn() }),
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({ setHoveredBookKey: vi.fn() }),
+}));
+
+vi.mock('@/store/sidebarStore', () => ({
+  useSidebarStore: () => ({ setSideBarVisible: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useResponsiveSize', () => ({
+  useResponsiveSize: (n: number) => n,
+}));
+
+import AnnotationNotes from '@/app/reader/components/annotator/AnnotationNotes';
+
+dayjs.extend(relativeTime);
+
+afterEach(() => {
+  cleanup();
+});
+
+const renderNotes = () =>
+  render(
+    <AnnotationNotes
+      bookKey='test'
+      isVertical={false}
+      notes={[
+        {
+          id: 'n1',
+          type: 'annotation',
+          cfi: 'epubcfi(/6/2!/4/1:0)',
+          note: 'Gryphon',
+          text: 'Gryphon',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      ]}
+      toolsVisible={false}
+      triangleDir='up'
+      popupWidth={240}
+      popupHeight={120}
+      onDismiss={() => {}}
+    />,
+  );
+
+describe('AnnotationNotes popup surface', () => {
+  it('paints the note card with the shared popup surface, not a hardcoded gray', () => {
+    const { container } = renderNotes();
+
+    const card = container.querySelector('.popup-container') as HTMLElement;
+    expect(card).not.toBeNull();
+    expect(card.className).not.toMatch(/bg-gray-/);
+    expect(card.className).toContain('bg-base-300');
+    expect(card.className).toContain('theme-dark:bg-base-100');
+  });
+
+  it('uses base-content text so no eink-only color override is needed', () => {
+    const { container } = renderNotes();
+
+    expect(container.querySelector('[class*="text-white"]')).toBeNull();
+  });
+});

--- a/apps/readest-app/src/__tests__/components/settings/AnnotationToolbarCustomizerEink.test.tsx
+++ b/apps/readest-app/src/__tests__/components/settings/AnnotationToolbarCustomizerEink.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
 
 /**
  * Regression guard for issue #4839 (display error under e-ink mode).
@@ -54,5 +54,18 @@ describe('AnnotationToolbarCustomizer e-ink toolbar preview', () => {
     const toolbarPreview = container.querySelector('.selection-popup') as HTMLElement;
     expect(toolbarPreview).not.toBeNull();
     expect(toolbarPreview.classList.contains('eink-bordered')).toBe(true);
+  });
+
+  /**
+   * The preview surface mirrors the real popup's theme-aware fill
+   * (`bg-base-300`, `base-100` under dark themes), so it is *light* on light
+   * themes. A hardcoded white empty-state hint only worked against the old
+   * fixed dark `bg-gray-600` fill and would be unreadable now.
+   */
+  it('keeps the empty-toolbar hint readable against the theme-aware preview surface', () => {
+    const { getByText } = render(<AnnotationToolbarCustomizer bookKey='test' onBack={() => {}} />);
+    fireEvent.click(getByText('Clear all'));
+    const hint = getByText('No tools, drag one here');
+    expect(hint.className).not.toMatch(/text-white/);
   });
 });

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationNotes.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationNotes.tsx
@@ -58,7 +58,7 @@ const AnnotationNotes: React.FC<AnnotationNotesProps> = ({
 
   return (
     <div
-      className={clsx('annotation-notes absolute flex rounded-lg text-white')}
+      className={clsx('annotation-notes text-base-content absolute flex rounded-lg')}
       style={{
         ...(isVertical
           ? {
@@ -98,8 +98,12 @@ const AnnotationNotes: React.FC<AnnotationNotesProps> = ({
             role='none'
             key={note.id || index}
             onClick={() => handleShowAnnotation?.(note)}
+            // Popup surface tokens, but no border of its own: the enclosing
+            // Popup already draws the bubble outline that the triangle is
+            // aligned to, and a second one doubles it along the triangle side.
             className={clsx(
-              'popup-container cursor-pointer rounded-lg bg-gray-600 shadow-lg transition-colors',
+              'popup-container cursor-pointer rounded-lg transition-colors',
+              'not-eink:shadow-lg bg-base-300 theme-dark:bg-base-100',
             )}
             style={
               isVertical
@@ -116,7 +120,6 @@ const AnnotationNotes: React.FC<AnnotationNotesProps> = ({
                 dir='auto'
                 className={clsx(
                   'm-4 hyphens-auto text-justify font-sans text-sm',
-                  'not-eink:text-white eink:text-base-content',
                   isVertical && 'writing-vertical-rl',
                 )}
                 style={
@@ -130,7 +133,7 @@ const AnnotationNotes: React.FC<AnnotationNotesProps> = ({
               >
                 <div className={clsx('flex flex-col justify-between gap-2')}>
                   {note.note}
-                  <span className='not-eink:text-white/50 eink:text-base-content/50 text-sm sm:text-xs'>
+                  <span className='text-base-content/50 text-sm sm:text-xs'>
                     {dayjs(note.createdAt).fromNow()}
                   </span>
                 </div>

--- a/apps/readest-app/src/app/reader/components/annotator/ProofreadPopup.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/ProofreadPopup.tsx
@@ -136,112 +136,118 @@ const ProofreadPopup: React.FC<ProofreadPopupProps> = ({
         width={popupWidth}
         minHeight={popupHeight}
         position={position}
-        className='flex flex-col justify-between rounded-lg'
+        // `Popup` caps the height at the room above the selection, which can be
+        // shorter than this form. Clip here and let the body scroll so nothing
+        // paints past the rounded box.
+        className='flex flex-col overflow-hidden rounded-lg'
         onDismiss={onDismiss}
       >
-        <div className='flex flex-col gap-4 p-4'>
-          <div className='flex items-center gap-2 text-xs text-base-content/70'>
-            <span className='text-nowrap font-medium'>{_('Selected text:')}</span>
-            <span className='line-clamp-1 flex-1 select-text break-words font-bold text-primary'>
-              &quot;{selection?.text || ''}&quot;
-            </span>
-            {onManage && (
-              <button
-                type='button'
-                onClick={onManage}
-                aria-label={_('Proofread Replacement Rules')}
-                title={_('Proofread Replacement Rules')}
-                className='shrink-0 rounded p-1 hover:bg-base-200 text-base-content/70 hover:text-base-content transition-colors'
+        <div className='min-h-0 flex-1 overflow-y-auto'>
+          <div className='flex flex-col gap-4 p-4'>
+            <div className='flex items-center gap-2 text-xs text-base-content/70'>
+              <span className='text-nowrap font-medium'>{_('Selected text:')}</span>
+              <span className='line-clamp-1 flex-1 select-text break-words font-bold text-primary'>
+                &quot;{selection?.text || ''}&quot;
+              </span>
+              {onManage && (
+                <button
+                  type='button'
+                  onClick={onManage}
+                  aria-label={_('Proofread Replacement Rules')}
+                  title={_('Proofread Replacement Rules')}
+                  className='shrink-0 rounded p-1 hover:bg-base-200 text-base-content/70 hover:text-base-content transition-colors'
+                >
+                  <RiListSettingsLine size={16} />
+                </button>
+              )}
+            </div>
+
+            <div className='flex items-center justify-between gap-2'>
+              <label
+                htmlFor='replacement-input'
+                className='shrink-0 text-xs font-medium text-base-content/80'
               >
-                <RiListSettingsLine size={16} />
+                {_('Replace with:')}
+              </label>
+              <input
+                ref={inputRef}
+                type='text'
+                value={replacementText}
+                onChange={handleInputChange}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && replacementText) {
+                    handleApply();
+                  }
+                }}
+                placeholder={_('Enter text...')}
+                className='bg-base-200 text-base-content placeholder:text-base-content/40 border-base-300 focus:border-primary focus:ring-primary eink-bordered w-full flex-1 rounded-md border p-2 text-sm transition-all focus:outline-none focus:ring-1'
+              />
+              <button
+                onClick={handleApply}
+                disabled={!replacementText}
+                className='btn btn-sm btn-contrast shrink-0 font-medium px-2'
+              >
+                {_('Apply')}
               </button>
-            )}
+            </div>
           </div>
 
-          <div className='flex items-center justify-between gap-2'>
-            <label
-              htmlFor='replacement-input'
-              className='shrink-0 text-xs font-medium text-base-content/80'
-            >
-              {_('Replace with:')}
+          <div className='flex flex-wrap items-center gap-4 p-4'>
+            <label className='flex cursor-pointer items-center gap-2'>
+              <span className='line-clamp-1 text-xs' title={_('Case sensitive:')}>
+                {_('Case sensitive:')}
+              </span>
+              <Toggle
+                checked={caseSensitive}
+                onChange={(e) => setCaseSensitive(e.target.checked)}
+                className={toggleClassName(isDarkMode)}
+              />
             </label>
-            <input
-              ref={inputRef}
-              type='text'
-              value={replacementText}
-              onChange={handleInputChange}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && replacementText) {
-                  handleApply();
-                }
-              }}
-              placeholder={_('Enter text...')}
-              className='bg-base-200 text-base-content placeholder:text-base-content/40 border-base-300 focus:border-primary focus:ring-primary eink-bordered w-full flex-1 rounded-md border p-2 text-sm transition-all focus:outline-none focus:ring-1'
-            />
-            <button
-              onClick={handleApply}
-              disabled={!replacementText}
-              className='btn btn-sm btn-contrast shrink-0 font-medium px-2'
+
+            <label
+              className={clsx(
+                'flex items-center gap-2',
+                isRegex ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
+              )}
             >
-              {_('Apply')}
-            </button>
+              <span className='line-clamp-1 text-xs' title={_('Whole word:')}>
+                {_('Whole word:')}
+              </span>
+              <Toggle
+                className={toggleClassName(isDarkMode)}
+                disabled={isRegex}
+                checked={isRegex ? false : wholeWord}
+                onChange={(e) => setWholeWord(e.target.checked)}
+              />
+            </label>
+
+            <label className='flex cursor-pointer items-center gap-2'>
+              <span className='line-clamp-1 text-xs' title={_('Regex:')}>
+                {_('Regex:')}
+              </span>
+
+              <Toggle
+                className={toggleClassName(isDarkMode)}
+                checked={isRegex}
+                onChange={(e) => setIsRegex(e.target.checked)}
+              />
+            </label>
+
+            <label className='flex cursor-pointer items-center gap-2'>
+              <span className='line-clamp-1 text-xs' title={_('Only for TTS:')}>
+                {_('Only for TTS:')}
+              </span>
+              <Toggle
+                className={toggleClassName(isDarkMode)}
+                disabled={scope === 'selection'}
+                checked={onlyForTTS}
+                onChange={(e) => setOnlyForTTS(e.target.checked)}
+              />
+            </label>
           </div>
         </div>
-
-        <div className='flex flex-wrap items-center gap-4 p-4'>
-          <label className='flex cursor-pointer items-center gap-2'>
-            <span className='line-clamp-1 text-xs' title={_('Case sensitive:')}>
-              {_('Case sensitive:')}
-            </span>
-            <Toggle
-              checked={caseSensitive}
-              onChange={(e) => setCaseSensitive(e.target.checked)}
-              className={toggleClassName(isDarkMode)}
-            />
-          </label>
-
-          <label
-            className={clsx(
-              'flex items-center gap-2',
-              isRegex ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
-            )}
-          >
-            <span className='line-clamp-1 text-xs' title={_('Whole word:')}>
-              {_('Whole word:')}
-            </span>
-            <Toggle
-              className={toggleClassName(isDarkMode)}
-              disabled={isRegex}
-              checked={isRegex ? false : wholeWord}
-              onChange={(e) => setWholeWord(e.target.checked)}
-            />
-          </label>
-
-          <label className='flex cursor-pointer items-center gap-2'>
-            <span className='line-clamp-1 text-xs' title={_('Regex:')}>
-              {_('Regex:')}
-            </span>
-
-            <Toggle
-              className={toggleClassName(isDarkMode)}
-              checked={isRegex}
-              onChange={(e) => setIsRegex(e.target.checked)}
-            />
-          </label>
-
-          <label className='flex cursor-pointer items-center gap-2'>
-            <span className='line-clamp-1 text-xs' title={_('Only for TTS:')}>
-              {_('Only for TTS:')}
-            </span>
-            <Toggle
-              className={toggleClassName(isDarkMode)}
-              disabled={scope === 'selection'}
-              checked={onlyForTTS}
-              onChange={(e) => setOnlyForTTS(e.target.checked)}
-            />
-          </label>
-        </div>
-        <div className='flex flex-1 items-center justify-between gap-2 p-4'>
+        {/* Pinned: the scope select stays reachable however tight the popup is. */}
+        <div className='flex shrink-0 items-center justify-between gap-2 p-4'>
           <label
             htmlFor='scope-select'
             className='line-clamp-1 text-xs font-medium text-base-content/80'

--- a/apps/readest-app/src/app/reader/components/annotator/TranslatorPopup.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/TranslatorPopup.tsx
@@ -196,7 +196,9 @@ const TranslatorPopup: React.FC<TranslatorPopupProps> = ({
             </div>
           )}
         </div>
-        <div className='border-base-content/20 bg-base-200/40 flex shrink-0 items-center justify-between gap-2 rounded-b-lg border-t px-4 py-2'>
+        {/* No top border or tinted fill: the footer reads as part of the popup
+            surface, so its provider select can sit flush on the same color. */}
+        <div className='flex shrink-0 items-center justify-between gap-2 rounded-b-lg px-4 py-2'>
           <div className='line-clamp-1 text-xs text-base-content/60'>
             {provider &&
               !loading &&

--- a/apps/readest-app/src/components/Select.tsx
+++ b/apps/readest-app/src/components/Select.tsx
@@ -28,7 +28,9 @@ export default function Select({
       onChange={onChange}
       onKeyDown={(e) => e.stopPropagation()}
       className={clsx(
-        'select bg-base-200 h-8 min-h-8 max-w-[60%] truncate rounded-md border-none text-sm',
+        // Transparent so the select takes the color of whatever surface it sits
+        // on (these all live in popups) instead of tinting a block onto it.
+        'select bg-transparent h-8 min-h-8 max-w-[60%] truncate rounded-md border-none text-sm',
         'focus:outline-none focus:ring-0 focus-visible:outline-none',
         className,
       )}

--- a/apps/readest-app/src/components/settings/AnnotationToolbarCustomizer.tsx
+++ b/apps/readest-app/src/components/settings/AnnotationToolbarCustomizer.tsx
@@ -113,12 +113,13 @@ const Zone: React.FC<{
           'flex min-h-12 flex-wrap items-center gap-2 rounded-lg p-2',
           isToolbar
             ? // A faithful, content-width preview of the real popup, start-aligned
-              // with the Available row below it. Off e-ink it mirrors the popup's
-              // dark fill; in e-ink the dark fill is dropped entirely and
-              // `eink-bordered` renders it as the popup's e-ink chrome instead
-              // (.popup-container): a base-100 surface with a 1px base-content
-              // border, so it doesn't paint as a solid black bar (#4839).
-              'selection-popup text-base-content rounded-lg border font-sans not-eink:border-base-content/20 not-eink:shadow-2xl bg-base-300 theme-dark:bg-base-100 w-fit max-w-full'
+              // with the Available row below it. Off e-ink it mirrors Popup.tsx's
+              // `.popup-container` chrome. That chrome earns its e-ink treatment
+              // from `[data-eink] .popup-container` in globals.css, which this
+              // plain div doesn't match — so `eink-bordered` supplies the same
+              // thing here (base-100 surface, 1px base-content border) and keeps
+              // the row from painting as a solid black bar (#4839).
+              'selection-popup eink-bordered text-base-content w-fit max-w-full border font-sans not-eink:border-base-content/20 not-eink:shadow-2xl bg-base-300 theme-dark:bg-base-100'
             : 'bg-base-200/60',
         )}
       >
@@ -126,9 +127,12 @@ const Zone: React.FC<{
           <span
             className={clsx(
               'px-1 text-sm',
-              // In e-ink the toolbar surface turns base-100, so the white hint would
-              // vanish; fall back to base-content there (#4839).
-              isToolbar ? 'not-eink:text-white/70 eink:text-base-content' : 'text-base-content/50',
+              // The toolbar surface is theme-aware (base-300, base-100 on dark
+              // themes and in e-ink), so the hint tracks base-content rather
+              // than a fixed white; e-ink takes it at full opacity (#4839).
+              isToolbar
+                ? 'not-eink:text-base-content/50 eink:text-base-content'
+                : 'text-base-content/50',
             )}
           >
             {emptyHint}

--- a/apps/readest-app/src/components/settings/AnnotationToolbarCustomizer.tsx
+++ b/apps/readest-app/src/components/settings/AnnotationToolbarCustomizer.tsx
@@ -81,7 +81,7 @@ const ToolChip: React.FC<ToolChipProps> = ({ type, label, variant, onActivate })
         'flex cursor-grab touch-none select-none items-center active:cursor-grabbing',
         isToolbar
           ? // Mirror the live toolbar's AnnotationToolButton: icon-only 32×32.
-            'h-8 min-h-8 w-8 justify-center rounded-md p-0 not-eink:hover:bg-gray-500 eink:hover:border'
+            'h-8 min-h-8 w-8 justify-center rounded-md p-0 not-eink:hover:bg-base-200 eink:hover:border'
           : // Available tools are labeled so they're identifiable off the bar.
             'eink-bordered border-base-300 bg-base-100 gap-1.5 rounded-md border px-2.5 py-1.5 text-sm',
         isDragging && 'shadow-lg',
@@ -118,7 +118,7 @@ const Zone: React.FC<{
               // `eink-bordered` renders it as the popup's e-ink chrome instead
               // (.popup-container): a base-100 surface with a 1px base-content
               // border, so it doesn't paint as a solid black bar (#4839).
-              'selection-popup eink-bordered w-fit max-w-full not-eink:bg-gray-600 not-eink:text-white'
+              'selection-popup text-base-content rounded-lg border font-sans not-eink:border-base-content/20 not-eink:shadow-2xl bg-base-300 theme-dark:bg-base-100 w-fit max-w-full'
             : 'bg-base-200/60',
         )}
       >


### PR DESCRIPTION
This should've been added in #5351, but I completely forgot to do so.

# Before

<img width="576" height="344" alt="image" src="https://github.com/user-attachments/assets/17ecbd45-811c-411f-bd2c-b5a0c19589a6" />

# After

<img width="576" height="334" alt="image" src="https://github.com/user-attachments/assets/0dd0f98e-8c8e-4f14-9a83-d49784e71328" />

---

## Follow-up commits

Added on top while reviewing.

### Customize Toolbar preview keeps its e-ink treatment

The preview copied `Popup.tsx`'s `.popup-container` chrome but not the class itself, so the `[data-eink='true'] .popup-container` rule in `globals.css` stopped matching and the preview lost its e-ink surface. That is the #4839 failure mode, and it broke `AnnotationToolbarCustomizerEink.test.tsx`. Restoring `eink-bordered` supplies the same base-100 fill and 1px base-content border without changing how the preview looks off e-ink.

The empty-state hint was still `text-white/70`, which only worked against the old fixed dark `bg-gray-600` fill. The new surface is theme-aware and light on light themes, so the hint now tracks `base-content`. Covered by a new test, since it only renders when the toolbar is empty.

Checked in the browser against the live annotation toolbar: background, border, radius, text color, font, shadow and chip metrics all compute identically.

### Popup selects match the popup surface

`Select` is transparent instead of painting a `bg-base-200` block onto the popup it sits on, so it picks up the surface color in light, dark and e-ink alike. The translator footer also drops its top border and tinted fill so the footer reads as part of the popup rather than a separate bar.

### Proofread scope row no longer overflows the popup

`Popup` caps the height at the room available above the selection, which can be shorter than the proofread form (220px available against 262px of content in the case observed). With `overflow: visible` the excess simply painted outside the rounded box, leaving the scope row hanging past the bottom edge. The surface now clips, the body scrolls, and the scope row is pinned so the select stays reachable however tight the popup is. Two tests guard the structure.

### Annotation note cards use the popup surface

The cards shown when tapping an annotation still hardcoded `bg-gray-600` and `text-white`, so on light themes a dark slate card hung off the popup's tan `base-300` triangle. They now use the same surface tokens as the rest of the popup family, which also makes the `eink:` color overrides on every text node unnecessary.

The card deliberately keeps no border of its own. The enclosing `Popup` already draws the bubble outline that the triangle geometry is aligned to, and adding a second one doubled the line along the triangle side.
