### PR TITLE
fix(db): close only the target connection when closing a native database

### DIFF
--- a/apps/readest-app/src/__tests__/database/native-close-isolation.tauri.test.ts
+++ b/apps/readest-app/src/__tests__/database/native-close-isolation.tauri.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdir, remove } from '@tauri-apps/plugin-fs';
+import { NativeDatabaseService } from '@/services/database/nativeDatabaseService';
+
+// Nested under the webdriver capability's allowed fs scope
+// (**/.readest-test-sandbox-tauri/**), in a subdir of our own so cleanup
+// cannot collide with other test files using the same sandbox root.
+const SANDBOX_DIR = `${process.env['CWD']}/.readest-test-sandbox-tauri/db-close-isolation`;
+
+describe('NativeDatabaseService (native Tauri)', () => {
+  beforeAll(async () => {
+    await mkdir(SANDBOX_DIR, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await remove(SANDBOX_DIR, { recursive: true });
+  });
+
+  // The plugin's arg-less close() drains every open connection app-wide, so a
+  // service closing "its own" database must pass its path or it kills every
+  // other database too (statistics.db "database ... not loaded", READEST-6).
+  it('closing one database leaves other connections loaded', async () => {
+    const a = await NativeDatabaseService.open(`sqlite:${SANDBOX_DIR}/close-isolation-a.db`);
+    const b = await NativeDatabaseService.open(`sqlite:${SANDBOX_DIR}/close-isolation-b.db`);
+    try {
+      await b.close();
+      await expect(a.select<{ one: number }>('SELECT 1 AS one')).resolves.toEqual([{ one: 1 }]);
+    } finally {
+      await a.close().catch(() => {});
+    }
+  });
+});

--- a/apps/readest-app/src/services/database/nativeDatabaseService.ts
+++ b/apps/readest-app/src/services/database/nativeDatabaseService.ts
@@ -49,6 +49,9 @@ export class NativeDatabaseService implements DatabaseService {
     // and every written byte sits in the -wal sidecar, which file-level copy
     // or sync of the containing directory can miss.
     await this.execute('PRAGMA wal_checkpoint(TRUNCATE)').catch(() => {});
-    await this.db.close();
+    // The plugin's arg-less close() drains EVERY open connection app-wide;
+    // pass our path so closing this database cannot tear down the others
+    // (statistics.db etc. dying with "database ... not loaded", READEST-6).
+    await this.db.close(this.db.path);
   }
 }


### PR DESCRIPTION
## Problem

On native platforms, every reading-statistics operation can start failing mid-session with:

```
[stats] failed to persist reading events: "database sqlite:/private/var/.../statistics.db not loaded"
[stats] median page duration failed: ...
```

and stays broken until the app restarts (Sentry READEST-6 attributed this to teardown races, but it fires during active use).

## Root cause

The turso plugin's `close` command with no `db` argument drains **every** open connection in the app (`commands.rs` close-all branch). `NativeDatabaseService.close()` called the guest-js `Database.close()` without a path, so any service closing its own database also tore down every other connection:

- TTS book cache (`bookCacheStore.close()` at session end)
- OPDS source map (open -> op -> close on every call)
- library search index (LRU eviction and background index completion)
- Reedy instrumentation

Once `statistics.db` was torn down, the memoised `StatisticsDb` singleton kept issuing queries against the dead connection, so stats never recovered. Web is unaffected: the WASM service closes only its own connection.

## Fix

Pass the connection's own path: `this.db.close(this.db.path)`.

## Test

New Tauri integration test (`native-close-isolation.tauri.test.ts`) exercises the real IPC path: open two databases, close one, assert the other still answers queries. Verified failing with the exact production error before the fix, passing after.

- `pnpm test:tauri`: 113 passed
- `pnpm test`: 8617 passed
- `pnpm lint`, `pnpm format:check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)