### PR TITLE
fix(reader): render fixed layout documents edge to edge in scrolled mode

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/components/SectionInfo.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/SectionInfo.test.tsx
@@ -78,6 +78,20 @@ describe('SectionInfo notch mask', () => {
     expect(notch.classList.contains('notch-masked')).toBe(false);
     expect(notch.classList.contains('bg-base-100')).toBe(false);
   });
+
+  it('keeps the notch transparent for fixed-layout documents so they render edge to edge', () => {
+    // FXL pages in scrolled mode fill the screen and their chrome overlays the
+    // page (mix-blend-difference title, #4901) instead of reserving bands. The
+    // reflowable notch mask would paint an opaque strip over the page at the
+    // camera hole / status bar, clipping the document.
+    currentBookData = { isFixedLayout: true };
+    const { container } = render(<SectionInfo {...baseProps} />);
+    const notch = container.querySelector('.notch-area') as HTMLElement;
+
+    expect(notch.classList.contains('notch-masked')).toBe(false);
+    expect(notch.classList.contains('bg-base-100')).toBe(false);
+    currentBookData = undefined;
+  });
 });
 
 describe('SectionInfo title band on negative top margins (#5303)', () => {

--- a/apps/readest-app/src/app/reader/components/SectionInfo.tsx
+++ b/apps/readest-app/src/app/reader/components/SectionInfo.tsx
@@ -71,7 +71,10 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
           // mis-tile at the seam (#4486). clip-path also clips hit-testing,
           // keeping the click target the inset strip only.
           'notch-area absolute inset-0 z-10',
-          isScrolled && !isVertical && 'notch-masked bg-base-100',
+          // Fixed-layout pages fill the screen edge to edge and their chrome
+          // overlays the page (mix-blend-difference title, #4901); the opaque
+          // mask would clip the document at the camera hole / status bar.
+          isScrolled && !isVertical && !bookData?.isFixedLayout && 'notch-masked bg-base-100',
         )}
         role='none'
         tabIndex={-1}


### PR DESCRIPTION
## Problem

For fixed layout documents in scrolled mode, the document should render from edge to edge, but an opaque band the height of the top safe area inset covered the page at the display cutout (camera hole). The page scrolled under the band and was visibly clipped.

## Root cause

In scrolled mode `SectionInfo` paints a `notch-masked bg-base-100` strip clipped to the top inset so reflowable text does not show clipped under the status bar. The fixed layout DOM underneath is already edge to edge (the `foliate-fxl` host spans the full viewport and ignores renderer margins), and FXL chrome is designed to overlay the page rather than reserve bands (the section title already uses `mix-blend-difference`, #4901). The mask therefore wrongly occluded the document at the camera hole.

## Fix

Skip the mask classes when `bookData.isFixedLayout`, keeping the transparent notch area as the scroll-to-top tap target.

## Verification

- New unit test (fails before, passes after) plus the full suite, lint, and format checks
- Reproduced and verified on a Xiaomi 13: with the mask classes removed the page renders under the camera hole edge to edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)