### PR TITLE
fix(opds): substitute percent-encoded {searchTerms} in OpenSearch templates (#5500)

### DIFF
--- a/apps/readest-app/src/__tests__/app/opds/opds-utils.test.ts
+++ b/apps/readest-app/src/__tests__/app/opds/opds-utils.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock dependencies before importing the module under test
-vi.mock('foliate-js/opds.js', () => ({
+vi.mock('foliate-js/opds.js', async (importOriginal) => ({
+  ...((await importOriginal()) as object),
   isOPDSCatalog: vi.fn((type: string) => {
     return (
       type.includes('application/opds+json') ||
@@ -44,11 +45,13 @@ vi.mock('@/app/opds/utils/opdsReq', () => ({
   fetchWithAuth: vi.fn(),
 }));
 
+import { getOpenSearch } from 'foliate-js/opds.js';
 import {
   groupByArray,
   parseMediaType,
   isSearchLink,
   expandOPDSSearchTemplate,
+  normalizeOpenSearchTemplates,
   resolveURL,
   getFileExtFromPath,
   getSafeDOMParserMimeType,
@@ -60,7 +63,7 @@ import {
   getUnaddedPopularCatalogs,
   formatContributorName,
 } from '@/app/opds/utils/opdsUtils';
-import type { OPDSBaseLink, OPDSCatalog } from '@/types/opds';
+import type { OPDSBaseLink, OPDSCatalog, OPDSSearch } from '@/types/opds';
 import { fetchWithAuth } from '@/app/opds/utils/opdsReq';
 
 const mockFetchWithAuth = vi.mocked(fetchWithAuth);
@@ -325,6 +328,61 @@ describe('opdsUtils', () => {
 
     it('returns the href unchanged when there are no template variables', () => {
       expect(expandOPDSSearchTemplate('/search', 'foo')).toBe('/search');
+    });
+  });
+
+  describe('normalizeOpenSearchTemplates', () => {
+    const openSearchDoc = (template: string): Document =>
+      new DOMParser().parseFromString(
+        `<?xml version="1.0" encoding="UTF-8"?>
+         <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+           <ShortName>Calibre</ShortName>
+           <Url type="application/atom+xml;profile=opds-catalog" template="${template}"/>
+         </OpenSearchDescription>`,
+        'application/xml',
+      );
+
+    const searchFor = (template: string, term: string) => {
+      const search = getOpenSearch(normalizeOpenSearchTemplates(openSearchDoc(template))) as
+        | OPDSSearch
+        | undefined;
+      return {
+        params: search?.params.map((param) => param.name) ?? [],
+        url: search?.search(new Map([[undefined, new Map([['searchTerms', term]])]])),
+      };
+    };
+
+    // readest issue #5500: a Nextcloud-hosted Calibre2OPDS catalog publishes its
+    // OpenSearch template with the placeholder braces percent-encoded, so the
+    // literal `{searchTerms}` reached the server instead of the typed term.
+    it('substitutes a percent-encoded {searchTerms} placeholder', () => {
+      expect(searchFor('https://cal/opds/search?query=%7BsearchTerms%7D', 'Prime')).toEqual({
+        params: ['searchTerms'],
+        url: 'https://cal/opds/search?query=Prime',
+      });
+    });
+
+    it('substitutes lowercase percent-encoded braces', () => {
+      expect(searchFor('https://cal/opds/search?query=%7bsearchTerms%7d', 'Prime')).toEqual({
+        params: ['searchTerms'],
+        url: 'https://cal/opds/search?query=Prime',
+      });
+    });
+
+    it('leaves a template with literal braces working', () => {
+      expect(searchFor('https://cal/opds/search?query={searchTerms}', 'Prime')).toEqual({
+        params: ['searchTerms'],
+        url: 'https://cal/opds/search?query=Prime',
+      });
+    });
+
+    it('keeps percent escapes other than braces intact', () => {
+      expect(
+        searchFor('https://cal/opds/search?path=a%2Fb&amp;query=%7BsearchTerms%7D', 'Prime'),
+      ).toEqual({
+        params: ['searchTerms'],
+        url: 'https://cal/opds/search?path=a%2Fb&query=Prime',
+      });
     });
   });
 

--- a/apps/readest-app/src/app/opds/page.tsx
+++ b/apps/readest-app/src/app/opds/page.tsx
@@ -32,6 +32,7 @@ import {
   isSearchLink,
   looksLikeXMLContent,
   MIME,
+  normalizeOpenSearchTemplates,
   parseMediaType,
   parseOPDSXML,
   resolveURL,
@@ -289,7 +290,7 @@ export default function BrowserPage() {
               addToHistory(url, newState, 'publication', null);
             }
           } else if (localName === 'OpenSearchDescription') {
-            const search = getOpenSearch(doc) as OPDSSearch;
+            const search = getOpenSearch(normalizeOpenSearchTemplates(doc)) as OPDSSearch;
             const newState = {
               search,
               baseURL: responseURL,

--- a/apps/readest-app/src/app/opds/utils/opdsUtils.ts
+++ b/apps/readest-app/src/app/opds/utils/opdsUtils.ts
@@ -179,6 +179,32 @@ export const expandOPDSSearchTemplate = (templateHref: string, queryTerm: string
   return expandURITemplate(templateHref, new Map([[textVar, queryTerm]]));
 };
 
+/**
+ * Decode the percent-encoded placeholder braces in an OpenSearch description's
+ * `Url` templates.
+ *
+ * Some catalogs (a Nextcloud-hosted Calibre2OPDS instance in readest issue
+ * #5500) publish their template with the braces escaped -- e.g.
+ * `...?query=%7BsearchTerms%7D` instead of `...?query={searchTerms}`. foliate-js
+ * only recognizes literal braces, so the placeholder is never treated as a
+ * parameter: the search form shows no fields and the request goes out with the
+ * placeholder intact, making the catalog search for the literal string
+ * `{searchTerms}`.
+ *
+ * Only `%7B`/`%7D` are decoded, so any other escape in the template (an encoded
+ * path segment, a URL passed as a query parameter) is preserved as sent.
+ */
+export const normalizeOpenSearchTemplates = (doc: Document): Document => {
+  for (const el of Array.from(doc.documentElement.children)) {
+    if (el.localName !== 'Url') continue;
+    const template = el.getAttribute('template');
+    if (!template) continue;
+    const decoded = template.replace(/%7b/gi, '{').replace(/%7d/gi, '}');
+    if (decoded !== template) el.setAttribute('template', decoded);
+  }
+  return doc;
+};
+
 export const resolveURL = (url: string, relativeTo: string): string => {
   if (!url) return '';
   if (relativeTo.includes('/api/opds/proxy?url=')) {


### PR DESCRIPTION
Fixes #5500.

## Problem

Some catalogs publish their OpenSearch `Url` template with the placeholder braces percent-encoded:

```xml
<Url type="application/atom+xml" template="https://cal/opds/search?query=%7BsearchTerms%7D"/>
```

foliate-js matches placeholders with `/{(?:([^}]+?):)?(.+?)(\?)?}/g` — literal braces only — so the encoded placeholder is never recognized as a parameter:

| template | `params` | resulting URL |
| --- | --- | --- |
| `?query={searchTerms}` | `['searchTerms']` | `?query=Prime` |
| `?query=%7BsearchTerms%7D` | `[]` | `?query=%7BsearchTerms%7D` |

The search form therefore renders no fields, and the request goes out with the placeholder intact — which the server decodes back to a literal `{searchTerms}`. The reporter (an authenticated Nextcloud Calibre2OPDS catalog) got a results page headed `All books matching: /{searchTerms}/` instead of results for the term they typed.

## Fix

`normalizeOpenSearchTemplates()` decodes `%7B`/`%7D` in each `Url[template]` attribute before the OpenSearch description document reaches `getOpenSearch`.

Only the braces are decoded, so every other escape in the template (an encoded path segment, a URL passed as a query parameter) survives exactly as sent — unlike the whole-URL `decodeURIComponent` the Atom search path uses.

## Tests

Four cases in `opds-utils.test.ts`, run end-to-end against the real `getOpenSearch` rather than a stub: uppercase escapes, lowercase escapes, literal braces still working, and other percent escapes preserved. The file's `foliate-js/opds.js` mock now spreads the real module so only `isOPDSCatalog` stays stubbed.

## Verification

- `pnpm test` — 8631 passed, 16 skipped
- `pnpm lint` — clean
- `pnpm format:check` — clean

No Rust or Lua files touched.

## Note

The reporter's catalog is authenticated and not publicly reachable, so this is verified against a synthesized OpenSearch description matching the template shape they described. Their report that "normalizing the percent-encoded template before substituting the search term fixed the problem locally" matches this change.

The same class of bug exists for OPDS 2.0 JSON templated links (`expandOPDSSearchTemplate` also relies on literal braces via `getVariables`), but no catalog has been reported doing that, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)