### PR TITLE
fix(koplugin): guard nil response on login/OTP failure

### DIFF
--- a/apps/readest.koplugin/readest_supabaseauth.lua
+++ b/apps/readest.koplugin/readest_supabaseauth.lua
@@ -86,7 +86,7 @@ function SupabaseAuthClient:sign_in_password(email, password)
         return res.status == 200, res.body
     else
         logger.dbg("SupabaseAuthClient:sign_in_password failure:", res)
-        return false, res.body
+        return false, { msg = tostring(res) }
     end
 end
 
@@ -135,7 +135,7 @@ function SupabaseAuthClient:verify_otp(email, token, type)
         return res.status == 200, res.body
     else
         logger.dbg("SupabaseAuthClient:verify_otp failure:", res)
-        return false, res.body
+        return false, { msg = tostring(res) }
     end
 end
 

--- a/apps/readest.koplugin/readest_supabaseauth.lua
+++ b/apps/readest.koplugin/readest_supabaseauth.lua
@@ -12,6 +12,19 @@ local SupabaseAuthClient = {
     api_key = nil,
 }
 
+-- Normalize the outcome of a Spore call so every endpoint hands callers a
+-- table they can read `.msg` off unconditionally. When the request raises (no
+-- network, TLS failure, timeout, unexpected status) pcall returns an error
+-- string, and indexing a string with `.body` silently yields nil rather than
+-- erroring - which is how a failed login used to reach the UI as nil.
+local function unwrap(name, expected_status, ok, res)
+    if not ok then
+        logger.dbg("SupabaseAuthClient:" .. name .. " failure:", res)
+        return false, { msg = tostring(res) }
+    end
+    return res.status == expected_status, res.body or {}
+end
+
 function SupabaseAuthClient:new(o)
     if o == nil then o = {} end
     setmetatable(o, self)
@@ -82,12 +95,7 @@ function SupabaseAuthClient:sign_in_password(email, password)
         })
     end)
     socketutil:reset_timeout()
-    if ok then
-        return res.status == 200, res.body
-    else
-        logger.dbg("SupabaseAuthClient:sign_in_password failure:", res)
-        return false, { msg = tostring(res) }
-    end
+    return unwrap("sign_in_password", 200, ok, res)
 end
 
 function SupabaseAuthClient:sign_in_otp(email, callback)
@@ -103,12 +111,7 @@ function SupabaseAuthClient:sign_in_otp(email, callback)
                 email = email,
             })
         end)
-        if ok then
-            callback(res.status == 200, res.body)
-        else
-            logger.dbg("SupabaseAuthClient:sign_in_otp failure:", res)
-            callback(false, res.body)
-        end
+        callback(unwrap("sign_in_otp", 200, ok, res))
     end)
     self.client:enable("AsyncHTTP", {thread = co})
     coroutine.resume(co)
@@ -131,12 +134,7 @@ function SupabaseAuthClient:verify_otp(email, token, type)
         })
     end)
     socketutil:reset_timeout()
-    if ok then
-        return res.status == 200, res.body
-    else
-        logger.dbg("SupabaseAuthClient:verify_otp failure:", res)
-        return false, { msg = tostring(res) }
-    end
+    return unwrap("verify_otp", 200, ok, res)
 end
 
 function SupabaseAuthClient:refresh_token(refresh_token, callback)
@@ -152,12 +150,7 @@ function SupabaseAuthClient:refresh_token(refresh_token, callback)
                 refresh_token = refresh_token,
             })
         end)
-        if ok then
-            callback(res.status == 200, res.body)
-        else
-            logger.dbg("SupabaseAuthClient:refresh_token failure:", res)
-            callback(false, res.body)
-        end
+        callback(unwrap("refresh_token", 200, ok, res))
     end)
     self.client:enable("AsyncHTTP", {thread = co})
     coroutine.resume(co)
@@ -179,12 +172,7 @@ function SupabaseAuthClient:sign_out(access_token, callback)
         local ok, res = pcall(function()
             return self.client:sign_out()
         end)
-        if ok then
-            callback(res.status == 204, res.body)
-        else
-            logger.dbg("SupabaseAuthClient:sign_out failure:", res)
-            callback(false, res.body)
-        end
+        callback(unwrap("sign_out", 204, ok, res))
     end)
     self.client:enable("AsyncHTTP", {thread = co})
     coroutine.resume(co)
@@ -206,12 +194,7 @@ function SupabaseAuthClient:get_user(access_token, callback)
         local ok, res = pcall(function()
             return self.client:get_user()
         end)
-        if ok then
-            callback(res.status == 200, res.body)
-        else
-            logger.dbg("SupabaseAuthClient:get_user failure:", res)
-            callback(false, res.body)
-        end
+        callback(unwrap("get_user", 200, ok, res))
     end)
     self.client:enable("AsyncHTTP", {thread = co})
     coroutine.resume(co)

--- a/apps/readest.koplugin/readest_syncauth.lua
+++ b/apps/readest.koplugin/readest_syncauth.lua
@@ -185,7 +185,7 @@ function SyncAuth:doLogin(settings, path, email, password, menu)
         })
     else
         UIManager:show(InfoMessage:new{
-            text = T(_("Login failed: %1"), response.msg or _("unknown error")),
+            text = T(_("Login failed: %1"), response and response.msg or _("unknown error")),
             timeout = 3,
         })
     end

--- a/apps/readest.koplugin/spec/spec_helper.lua
+++ b/apps/readest.koplugin/spec/spec_helper.lua
@@ -201,6 +201,7 @@ fakes.DataStorage = {
 fakes.Device = {
     canUseWAL = function() return true end,
     screen    = { getWidth = function() return 600 end, getHeight = function() return 800 end },
+    setIgnoreInput = function() end,
 }
 
 function M.reset()

--- a/apps/readest.koplugin/spec/syncauth_spec.lua
+++ b/apps/readest.koplugin/spec/syncauth_spec.lua
@@ -1,0 +1,155 @@
+-- syncauth_spec.lua
+-- Regression tests for the login failure path.
+--
+-- When the HTTP request raises (no network, TLS failure, timeout), the pcall
+-- inside SupabaseAuthClient hands back an error *string*, not a response
+-- table. Indexing a string with `.body` silently yields nil, so the client
+-- used to return `false, nil` and SyncAuth:doLogin then crashed on
+-- `response.msg`.
+
+require("spec_helper")
+require("spec.koreader_stubs")
+
+-- The Spore client the module builds in init(); each test swaps in its own.
+local spore_client
+
+package.preload["Spore"] = function()
+    return {
+        new_from_spec = function() return spore_client end,
+    }
+end
+package.preload["socketutil"] = function()
+    return {
+        set_timeout = function() end,
+        reset_timeout = function() end,
+    }
+end
+
+local UIManager = require("ui/uimanager")
+local InfoMessage = require("ui/widget/infomessage")
+local ffiutil = require("ffi/util")
+
+-- readest_syncauth captures `T = require("ffi/util").template` in an upvalue
+-- at load time, so the substituting version has to be installed *before* the
+-- require below - patching it later would not reach the captured function.
+ffiutil.template = function(str, ...)
+    local args = { ... }
+    return (str:gsub("%%(%d)", function(i) return tostring(args[tonumber(i)]) end))
+end
+
+local SupabaseAuthClient = require("readest_supabaseauth")
+local SyncAuth = require("readest_syncauth")
+
+-- A Spore client whose endpoint calls all behave the same way.
+local function newAuthClient(endpoint)
+    spore_client = {
+        reset_middlewares = function() end,
+        enable = function() end,
+        sign_in_password = endpoint,
+        verify_otp = endpoint,
+        refresh_token = endpoint,
+    }
+    return SupabaseAuthClient:new{
+        service_spec = "supabase-auth-api.json",
+        api_key = "anon-key",
+    }
+end
+
+describe("SupabaseAuthClient error propagation", function()
+    it("returns a message table when sign_in_password raises", function()
+        local client = newAuthClient(function()
+            error("connection refused", 0)
+        end)
+
+        local ok, res = client:sign_in_password("reader@example.com", "hunter2")
+
+        assert.is_false(ok)
+        assert.is_table(res)
+        assert.is_string(res.msg)
+        assert.truthy(res.msg:find("connection refused", 1, true))
+    end)
+
+    it("returns a message table when verify_otp raises", function()
+        local client = newAuthClient(function()
+            error("connection refused", 0)
+        end)
+
+        local ok, res = client:verify_otp("reader@example.com", "123456")
+
+        assert.is_false(ok)
+        assert.is_table(res)
+        assert.truthy(res.msg:find("connection refused", 1, true))
+    end)
+
+    it("delivers a message table to the refresh_token callback on failure", function()
+        local client = newAuthClient(function()
+            error("connection refused", 0)
+        end)
+
+        local got_ok, got_res
+        client:refresh_token("stale-token", function(ok, res)
+            got_ok, got_res = ok, res
+        end)
+
+        assert.is_false(got_ok)
+        assert.is_table(got_res)
+        assert.truthy(got_res.msg:find("connection refused", 1, true))
+    end)
+
+    it("still forwards the parsed body on an HTTP error status", function()
+        local client = newAuthClient(function()
+            return { status = 400, body = { msg = "Invalid login credentials" } }
+        end)
+
+        local ok, res = client:sign_in_password("reader@example.com", "wrong")
+
+        assert.is_false(ok)
+        assert.are.equal("Invalid login credentials", res.msg)
+    end)
+end)
+
+describe("SyncAuth:doLogin failure handling", function()
+    local shown
+    local sign_in_password
+    local orig = {}
+
+    before_each(function()
+        shown = {}
+        orig.getSupabaseAuthClient = SyncAuth.getSupabaseAuthClient
+        orig.show = UIManager.show
+        orig.new = InfoMessage.new
+        SyncAuth.getSupabaseAuthClient = function()
+            return { sign_in_password = function() return sign_in_password() end }
+        end
+        InfoMessage.new = function(_, o) return o or {} end
+        UIManager.show = function(_, widget) table.insert(shown, widget) end
+    end)
+
+    after_each(function()
+        SyncAuth.getSupabaseAuthClient = orig.getSupabaseAuthClient
+        UIManager.show = orig.show
+        InfoMessage.new = orig.new
+    end)
+
+    local function lastShownText()
+        local widget = shown[#shown]
+        return widget and widget.text
+    end
+
+    it("does not crash when the client reports failure without a response", function()
+        sign_in_password = function() return false, nil end
+
+        assert.has_no.errors(function()
+            SyncAuth:doLogin({}, "/plugin", "reader@example.com", "hunter2", nil)
+        end)
+        assert.are.equal("Login failed: unknown error", lastShownText())
+    end)
+
+    it("surfaces the message the client reports", function()
+        sign_in_password = function() return false, { msg = "Invalid login credentials" } end
+
+        SyncAuth:doLogin({}, "/plugin", "reader@example.com", "wrong", nil)
+
+        assert.are.equal("Login failed: Invalid login credentials", lastShownText())
+    end)
+end)


### PR DESCRIPTION
sign_in_password and verify_otp returned res.body as the second value on pcall failure, which is nil when res is an error string. doLogin then indexed response.msg on the nil value, crashing KOReader when the network request failed during login.

Return a table with the error message from the auth client, and guard the caller against a nil response.