### PR TITLE
feat(reader): support Apple Pencil double tap and squeeze as page turners

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2207,5 +2207,8 @@
   "Pull down to add bookmark": "اسحب لأسفل لإضافة علامة",
   "Sign in to Readest": "تسجيل الدخول إلى Readest",
   "Sync your library, reading progress, and highlights across your devices.": "زامن مكتبتك وتقدم القراءة والتمييزات عبر جميع أجهزتك.",
-  "or continue with email": "أو المتابعة عبر البريد الإلكتروني"
+  "or continue with email": "أو المتابعة عبر البريد الإلكتروني",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "اضغط على زر في جهاز التحكم عن بُعد أو لوحة المفاتيح، أو استخدم إيماءة Apple Pencil، بعد النقر على \"تعيين مفتاح\".",
+  "Pencil Double Tap": "نقر مزدوج على Apple Pencil",
+  "Pencil Squeeze": "ضغط Apple Pencil"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2023,5 +2023,8 @@
   "Pull down to add bookmark": "বুকমার্ক যোগ করতে নিচে টানুন",
   "Sign in to Readest": "Readest-এ সাইন ইন করুন",
   "Sync your library, reading progress, and highlights across your devices.": "আপনার লাইব্রেরি, পড়ার অগ্রগতি এবং হাইলাইটগুলি আপনার সব ডিভাইসে সিঙ্ক করুন।",
-  "or continue with email": "অথবা ইমেইল দিয়ে চালিয়ে যান"
+  "or continue with email": "অথবা ইমেইল দিয়ে চালিয়ে যান",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"কী সেট করুন\" ট্যাপ করার পর আপনার রিমোট কন্ট্রোলার বা কীবোর্ডের একটি বোতাম চাপুন, অথবা Apple Pencil জেসচার ব্যবহার করুন।",
+  "Pencil Double Tap": "Apple Pencil ডাবল ট্যাপ",
+  "Pencil Squeeze": "Apple Pencil স্কুইজ"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1977,5 +1977,8 @@
   "Pull down to add bookmark": "དེབ་གྲངས་སྣོན་པར་མར་འཐེན།",
   "Sign in to Readest": "Readest ལ་ཐོ་འཇུག་བྱེད།",
   "Sync your library, reading progress, and highlights across your devices.": "ཁྱེད་ཀྱི་དཔེ་མཛོད་དང་། ཀློག་པའི་ཡར་འཕེལ། གཙོ་གནད་བཅས་ཁྱེད་ཀྱི་སྒྲིག་ཆས་ཡོངས་ལ་མཉམ་སྒྲིག་བྱེད།",
-  "or continue with email": "ཡང་ན་གློག་འཕྲིན་བརྒྱུད་ནས་མུ་མཐུད།"
+  "or continue with email": "ཡང་ན་གློག་འཕྲིན་བརྒྱུད་ནས་མུ་མཐུད།",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"མཐེབ་གཞི་གཏན་འཁེལ།\" ལ་རེག་རྗེས། ཁྱེད་ཀྱི་རྒྱང་འཐེན་སྒྲིག་ཆས་སམ་མཐེབ་གཞི་གང་རུང་གི་ཐོག་མཐེབ་གཅིག་གནོན་པའམ། ཡང་ན་ Apple Pencil གྱི་ལག་བརྡ་བེད་སྤྱོད་བྱོས།",
+  "Pencil Double Tap": "Apple Pencil ཐེངས་གཉིས་རེག་པ།",
+  "Pencil Squeeze": "Apple Pencil བཙིར་བ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2023,5 +2023,8 @@
   "Pull down to add bookmark": "Herunterziehen, um Lesezeichen hinzuzufügen",
   "Sign in to Readest": "Bei Readest anmelden",
   "Sync your library, reading progress, and highlights across your devices.": "Synchronisieren Sie Ihre Bibliothek, Ihren Lesefortschritt und Ihre Markierungen auf all Ihren Geräten.",
-  "or continue with email": "oder mit E-Mail fortfahren"
+  "or continue with email": "oder mit E-Mail fortfahren",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Drücken Sie eine Taste auf Ihrer Fernbedienung oder Tastatur oder verwenden Sie eine Apple Pencil-Geste, nachdem Sie auf \"Taste festlegen\" getippt haben.",
+  "Pencil Double Tap": "Apple Pencil Doppeltippen",
+  "Pencil Squeeze": "Apple Pencil Zusammendrücken"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2023,5 +2023,8 @@
   "Pull down to add bookmark": "Τραβήξτε προς τα κάτω για προσθήκη σελιδοδείκτη",
   "Sign in to Readest": "Συνδεθείτε στο Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Συγχρονίστε τη βιβλιοθήκη, την πρόοδο ανάγνωσης και τις επισημάνσεις σας σε όλες τις συσκευές σας.",
-  "or continue with email": "ή συνεχίστε με email"
+  "or continue with email": "ή συνεχίστε με email",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Πατήστε ένα κουμπί στο τηλεχειριστήριο ή το πληκτρολόγιό σας, ή χρησιμοποιήστε μια χειρονομία Apple Pencil, αφού πατήσετε «Ορισμός πλήκτρου».",
+  "Pencil Double Tap": "Διπλό άγγιγμα Apple Pencil",
+  "Pencil Squeeze": "Πίεση Apple Pencil"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2069,5 +2069,8 @@
   "Pull down to add bookmark": "Desliza hacia abajo para agregar marcador",
   "Sign in to Readest": "Inicia sesión en Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Sincroniza tu biblioteca, progreso de lectura y resaltados en todos tus dispositivos.",
-  "or continue with email": "o continúa con tu correo electrónico"
+  "or continue with email": "o continúa con tu correo electrónico",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Pulse un botón en su mando a distancia o teclado, o use un gesto del Apple Pencil, después de tocar \"Asignar tecla\".",
+  "Pencil Double Tap": "Doble toque del Apple Pencil",
+  "Pencil Squeeze": "Apretón del Apple Pencil"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2023,5 +2023,8 @@
   "Pull down to add bookmark": "برای افزودن نشانک به پایین بکشید",
   "Sign in to Readest": "ورود به Readest",
   "Sync your library, reading progress, and highlights across your devices.": "کتابخانه، وضعیت مطالعه و هایلایت‌های خود را در همه دستگاه‌هایتان همگام‌سازی کنید.",
-  "or continue with email": "یا با ایمیل ادامه دهید"
+  "or continue with email": "یا با ایمیل ادامه دهید",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "پس از ضربه زدن به «تنظیم کلید»، دکمه‌ای روی کنترلر یا صفحه‌کلید خود فشار دهید یا از حرکت Apple Pencil استفاده کنید.",
+  "Pencil Double Tap": "دو ضربه روی Apple Pencil",
+  "Pencil Squeeze": "فشردن Apple Pencil"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2069,5 +2069,8 @@
   "Pull down to add bookmark": "Tirez vers le bas pour ajouter un marque-page",
   "Sign in to Readest": "Connectez-vous à Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Synchronisez votre bibliothèque, votre progression de lecture et vos surlignages sur tous vos appareils.",
-  "or continue with email": "ou continuer par e-mail"
+  "or continue with email": "ou continuer par e-mail",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Appuyez sur un bouton de votre télécommande ou de votre clavier, ou utilisez un geste de l'Apple Pencil, après avoir appuyé sur « Définir la touche ».",
+  "Pencil Double Tap": "Double toucher Apple Pencil",
+  "Pencil Squeeze": "Pression Apple Pencil"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2069,5 +2069,8 @@
   "Pull down to add bookmark": "משוך למטה להוספת סימנייה",
   "Sign in to Readest": "התחבר אל Readest",
   "Sync your library, reading progress, and highlights across your devices.": "סנכרן את הספרייה, התקדמות הקריאה וההדגשות שלך בכל המכשירים שלך.",
-  "or continue with email": "או המשך עם אימייל"
+  "or continue with email": "או המשך עם אימייל",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "לחץ על כפתור בשלט הרחוק או במקלדת, או השתמש במחוות Apple Pencil, לאחר הקשה על \"הגדר מקש\".",
+  "Pencil Double Tap": "הקשה כפולה על Apple Pencil",
+  "Pencil Squeeze": "לחיצה על Apple Pencil"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2023,5 +2023,8 @@
   "Pull down to add bookmark": "मार्कर जोड़ने के लिए नीचे खींचें",
   "Sign in to Readest": "Readest में साइन इन करें",
   "Sync your library, reading progress, and highlights across your devices.": "अपनी लाइब्रेरी, पढ़ने की प्रगति और हाइलाइट्स को अपने सभी डिवाइस पर सिंक करें।",
-  "or continue with email": "या ईमेल से जारी रखें"
+  "or continue with email": "या ईमेल से जारी रखें",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"कुंजी सेट करें\" दबाने के बाद अपने रिमोट कंट्रोलर या कीबोर्ड पर एक बटन दबाएं, या Apple Pencil जेस्चर का उपयोग करें।",
+  "Pencil Double Tap": "Apple Pencil डबल टैप",
+  "Pencil Squeeze": "Apple Pencil स्क्वीज़"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2023,5 +2023,8 @@
   "Pull down to add bookmark": "Húzza le könyvjelző hozzáadásához",
   "Sign in to Readest": "Jelentkezzen be a Readestbe",
   "Sync your library, reading progress, and highlights across your devices.": "Szinkronizálja könyvtárát, olvasási haladását és kiemeléseit az összes eszközén.",
-  "or continue with email": "vagy folytassa e-maillel"
+  "or continue with email": "vagy folytassa e-maillel",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Nyomjon meg egy gombot a távirányítón vagy a billentyűzeten, vagy használjon Apple Pencil kézmozdulatot a „Billentyű beállítása” érintése után.",
+  "Pencil Double Tap": "Apple Pencil dupla koppintás",
+  "Pencil Squeeze": "Apple Pencil összenyomás"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1977,5 +1977,8 @@
   "Pull down to add bookmark": "Tarik ke bawah untuk menambahkan penanda",
   "Sign in to Readest": "Masuk ke Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Sinkronkan perpustakaan, progres membaca, dan sorotan Anda di semua perangkat Anda.",
-  "or continue with email": "atau lanjutkan dengan email"
+  "or continue with email": "atau lanjutkan dengan email",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Tekan tombol pada remote controller atau keyboard Anda, atau gunakan gerakan Apple Pencil, setelah mengetuk \"Atur tombol\".",
+  "Pencil Double Tap": "Ketuk Dua Kali Apple Pencil",
+  "Pencil Squeeze": "Remas Apple Pencil"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2069,5 +2069,8 @@
   "Pull down to add bookmark": "Trascina verso il basso per aggiungere il segnalibro",
   "Sign in to Readest": "Accedi a Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Sincronizza la tua biblioteca, il progresso di lettura e le evidenziazioni su tutti i tuoi dispositivi.",
-  "or continue with email": "oppure continua con l'email"
+  "or continue with email": "oppure continua con l'email",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Premi un pulsante sul telecomando o sulla tastiera, oppure usa un gesto di Apple Pencil, dopo aver toccato \"Imposta tasto\".",
+  "Pencil Double Tap": "Doppio tocco Apple Pencil",
+  "Pencil Squeeze": "Pressione Apple Pencil"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1977,5 +1977,8 @@
   "Pull down to add bookmark": "下に引いてブックマークを追加",
   "Sign in to Readest": "Readest にサインイン",
   "Sync your library, reading progress, and highlights across your devices.": "ライブラリ、読書進捗、ハイライトをすべてのデバイスで同期します。",
-  "or continue with email": "またはメールで続行"
+  "or continue with email": "またはメールで続行",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "「キーを設定」をタップした後、リモコンまたはキーボードのボタンを押すか、Apple Pencilのジェスチャを使用してください。",
+  "Pencil Double Tap": "Apple Pencilのダブルタップ",
+  "Pencil Squeeze": "Apple Pencilのスクイーズ"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1977,5 +1977,8 @@
   "Pull down to add bookmark": "아래로 당겨 북마크 추가",
   "Sign in to Readest": "Readest에 로그인",
   "Sync your library, reading progress, and highlights across your devices.": "라이브러리, 읽기 진행 상황, 하이라이트를 모든 기기에서 동기화합니다.",
-  "or continue with email": "또는 이메일로 계속"
+  "or continue with email": "또는 이메일로 계속",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"키 설정\"을 탭한 후 리모컨 또는 키보드의 버튼을 누르거나 Apple Pencil 제스처를 사용하세요.",
+  "Pencil Double Tap": "Apple Pencil 이중 탭",
+  "Pencil Squeeze": "Apple Pencil 스퀴즈"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1977,5 +1977,8 @@
   "Pull down to add bookmark": "Tarik ke bawah untuk menambah tandabuku",
   "Sign in to Readest": "Log masuk ke Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Segerakkan perpustakaan, kemajuan bacaan dan penonjolan anda merentas semua peranti anda.",
-  "or continue with email": "atau teruskan dengan e-mel"
+  "or continue with email": "atau teruskan dengan e-mel",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Tekan butang pada pengawal jauh atau papan kekunci anda, atau gunakan gerak isyarat Apple Pencil, selepas mengetuk \"Tetapkan kekunci\".",
+  "Pencil Double Tap": "Ketik Dua Kali Apple Pencil",
+  "Pencil Squeeze": "Picit Apple Pencil"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2023,5 +2023,8 @@
   "Pull down to add bookmark": "Trek omlaag om bladwijzer toe te voegen",
   "Sign in to Readest": "Inloggen bij Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Synchroniseer je bibliotheek, leesvoortgang en markeringen op al je apparaten.",
-  "or continue with email": "of ga verder met e-mail"
+  "or continue with email": "of ga verder met e-mail",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Druk op een knop op uw afstandsbediening of toetsenbord, of gebruik een Apple Pencil-gebaar, nadat u op \"Toets instellen\" hebt getikt.",
+  "Pencil Double Tap": "Apple Pencil dubbel tikken",
+  "Pencil Squeeze": "Apple Pencil knijpen"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2115,5 +2115,8 @@
   "Pull down to add bookmark": "Pociągnij w dół, aby dodać zakładkę",
   "Sign in to Readest": "Zaloguj się do Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Synchronizuj bibliotekę, postęp czytania i zaznaczenia na wszystkich swoich urządzeniach.",
-  "or continue with email": "lub kontynuuj przez e-mail"
+  "or continue with email": "lub kontynuuj przez e-mail",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Naciśnij przycisk na pilocie lub klawiaturze, albo użyj gestu Apple Pencil, po dotknięciu \"Ustaw klawisz\".",
+  "Pencil Double Tap": "Dwukrotne stuknięcie Apple Pencil",
+  "Pencil Squeeze": "Ściśnięcie Apple Pencil"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2069,5 +2069,8 @@
   "Pull down to add bookmark": "Puxe para baixo para adicionar marcador",
   "Sign in to Readest": "Entre no Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Sincronize sua biblioteca, progresso de leitura e destaques em todos os seus dispositivos.",
-  "or continue with email": "ou continue com e-mail"
+  "or continue with email": "ou continue com e-mail",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Pressione um botão no controle remoto ou teclado, ou use um gesto do Apple Pencil, após tocar em \"Definir tecla\".",
+  "Pencil Double Tap": "Toque duplo no Apple Pencil",
+  "Pencil Squeeze": "Aperto no Apple Pencil"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2069,5 +2069,8 @@
   "Pull down to add bookmark": "Puxe para baixo para adicionar marcador",
   "Sign in to Readest": "Inicie sessão no Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Sincronize a sua biblioteca, o progresso de leitura e os destaques em todos os seus dispositivos.",
-  "or continue with email": "ou continue com o e-mail"
+  "or continue with email": "ou continue com o e-mail",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Pressione um botão no seu controle remoto ou teclado, ou use um gesto do Apple Pencil, após tocar em \"Definir tecla\".",
+  "Pencil Double Tap": "Toque duplo no Apple Pencil",
+  "Pencil Squeeze": "Aperto no Apple Pencil"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2069,5 +2069,8 @@
   "Pull down to add bookmark": "Trageți în jos pentru a adăuga marcajul",
   "Sign in to Readest": "Conectează-te la Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Sincronizează-ți biblioteca, progresul citirii și evidențierile pe toate dispozitivele tale.",
-  "or continue with email": "sau continuă cu e-mailul"
+  "or continue with email": "sau continuă cu e-mailul",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Apăsați un buton pe telecomandă sau tastatură, sau folosiți un gest Apple Pencil, după ce atingeți \"Setează tasta\".",
+  "Pencil Double Tap": "Atingere dublă Apple Pencil",
+  "Pencil Squeeze": "Strângere Apple Pencil"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2115,5 +2115,8 @@
   "Pull down to add bookmark": "Потяните вниз, чтобы добавить закладку",
   "Sign in to Readest": "Войдите в Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Синхронизируйте свою библиотеку, прогресс чтения и выделения на всех своих устройствах.",
-  "or continue with email": "или продолжите с помощью эл. почты"
+  "or continue with email": "или продолжите с помощью эл. почты",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Нажмите кнопку на пульте дистанционного управления или клавиатуре либо используйте жест Apple Pencil после нажатия \"Назначить клавишу\".",
+  "Pencil Double Tap": "Двойное касание Apple Pencil",
+  "Pencil Squeeze": "Сжатие Apple Pencil"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2023,5 +2023,8 @@
   "Pull down to add bookmark": "සටහන් එකතු කිරීමට පහළට අදින්න",
   "Sign in to Readest": "Readest වෙත පුරන්න",
   "Sync your library, reading progress, and highlights across your devices.": "ඔබේ පුස්තකාලය, කියවීමේ ප්‍රගතිය සහ ඉස්මතු කිරීම් ඔබේ සියලුම උපාංග හරහා සමමුහුර්ත කරන්න.",
-  "or continue with email": "නැතහොත් විද්‍යුත් තැපෑලෙන් ඉදිරියට යන්න"
+  "or continue with email": "නැතහොත් විද්‍යුත් තැපෑලෙන් ඉදිරියට යන්න",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"යතුර සකසන්න\" තට්ටු කිරීමෙන් පසු ඔබේ දුරස්ථ පාලකයේ හෝ යතුරු පුවරුවේ බොත්තමක් එබෙන්න, නැතහොත් Apple Pencil ඉංගිතයක් භාවිතා කරන්න.",
+  "Pencil Double Tap": "Apple Pencil දෙවරක් තට්ටු කිරීම",
+  "Pencil Squeeze": "Apple Pencil තද කිරීම"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2115,5 +2115,8 @@
   "Pull down to add bookmark": "Povlecite navzdol za dodajanje zaznamka",
   "Sign in to Readest": "Prijavite se v Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Sinhronizirajte knjižnico, napredek branja in označbe v vseh svojih napravah.",
-  "or continue with email": "ali nadaljujte z e-pošto"
+  "or continue with email": "ali nadaljujte z e-pošto",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Pritisnite gumb na daljinskem upravljalniku ali tipkovnici, ali uporabite potezo Apple Pencil, po tapkanju na \"Nastavi tipko\".",
+  "Pencil Double Tap": "Dvojni dotik Apple Pencil",
+  "Pencil Squeeze": "Stisk Apple Pencil"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2023,5 +2023,8 @@
   "Pull down to add bookmark": "Dra nedåt för att lägga till bokmärke",
   "Sign in to Readest": "Logga in på Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Synka ditt bibliotek, dina läsframsteg och markeringar på alla dina enheter.",
-  "or continue with email": "eller fortsätt med e-post"
+  "or continue with email": "eller fortsätt med e-post",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Tryck på en knapp på din fjärrkontroll eller tangentbord, eller använd en Apple Pencil-gest, efter att ha tryckt på \"Ange tangent\".",
+  "Pencil Double Tap": "Apple Pencil dubbeltryck",
+  "Pencil Squeeze": "Apple Pencil klämning"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2023,5 +2023,8 @@
   "Pull down to add bookmark": "புக்மார்க் சேர்க்க கீழே இழுக்கவும்",
   "Sign in to Readest": "Readest-இல் உள்நுழையவும்",
   "Sync your library, reading progress, and highlights across your devices.": "உங்கள் நூலகம், வாசிப்பு முன்னேற்றம் மற்றும் சிறப்பம்சங்களை உங்கள் எல்லா சாதனங்களிலும் ஒத்திசைக்கவும்.",
-  "or continue with email": "அல்லது மின்னஞ்சல் மூலம் தொடரவும்"
+  "or continue with email": "அல்லது மின்னஞ்சல் மூலம் தொடரவும்",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"விசை அமை\" தட்டிய பிறகு உங்கள் ரிமோட் கன்ட்ரோலர் அல்லது கீபோர்டில் ஒரு பட்டனை அழுத்தவும், அல்லது Apple Pencil சைகையைப் பயன்படுத்தவும்.",
+  "Pencil Double Tap": "Apple Pencil இரட்டைத் தட்டு",
+  "Pencil Squeeze": "Apple Pencil அழுத்துதல்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1977,5 +1977,8 @@
   "Pull down to add bookmark": "ดึงลงเพื่อเพิ่มบุ๊กมาร์ก",
   "Sign in to Readest": "ลงชื่อเข้าใช้ Readest",
   "Sync your library, reading progress, and highlights across your devices.": "ซิงค์คลังหนังสือ ความคืบหน้าการอ่าน และไฮไลต์ของคุณในทุกอุปกรณ์ของคุณ",
-  "or continue with email": "หรือดำเนินการต่อด้วยอีเมล"
+  "or continue with email": "หรือดำเนินการต่อด้วยอีเมล",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "กดปุ่มบนรีโมทคอนโทรลหรือคีย์บอร์ด หรือใช้ท่าทาง Apple Pencil หลังจากแตะ \"ตั้งปุ่ม\"",
+  "Pencil Double Tap": "แตะสองครั้งบน Apple Pencil",
+  "Pencil Squeeze": "บีบ Apple Pencil"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2023,5 +2023,8 @@
   "Pull down to add bookmark": "Yer işareti eklemek için aşağı çekin",
   "Sign in to Readest": "Readest'e giriş yapın",
   "Sync your library, reading progress, and highlights across your devices.": "Kütüphanenizi, okuma ilerlemenizi ve vurgularınızı tüm cihazlarınızda senkronize edin.",
-  "or continue with email": "veya e-posta ile devam edin"
+  "or continue with email": "veya e-posta ile devam edin",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"Tuş ayarla\" düğmesine dokunduktan sonra uzaktan kumandanızdaki veya klavyenizdeki bir düğmeye basın ya da bir Apple Pencil hareketi kullanın.",
+  "Pencil Double Tap": "Apple Pencil çift dokunma",
+  "Pencil Squeeze": "Apple Pencil sıkma"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2115,5 +2115,8 @@
   "Pull down to add bookmark": "Потягніть вниз, щоб додати закладку",
   "Sign in to Readest": "Увійдіть у Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Синхронізуйте свою бібліотеку, проґрес читання та виділення на всіх своїх пристроях.",
-  "or continue with email": "або продовжте з ел. поштою"
+  "or continue with email": "або продовжте з ел. поштою",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Натисніть кнопку на пульті або клавіатурі, або скористайтеся жестом Apple Pencil після натискання \"Призначити клавішу\".",
+  "Pencil Double Tap": "Подвійний дотик Apple Pencil",
+  "Pencil Squeeze": "Стискання Apple Pencil"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2023,5 +2023,8 @@
   "Pull down to add bookmark": "Xatchoʻp qoʻshish uchun pastga torting",
   "Sign in to Readest": "Readest hisobiga kiring",
   "Sync your library, reading progress, and highlights across your devices.": "Kutubxonangiz, oʻqish jarayoni va belgilashlaringizni barcha qurilmalaringizda sinxronlang.",
-  "or continue with email": "yoki e-pochta bilan davom eting"
+  "or continue with email": "yoki e-pochta bilan davom eting",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"Tugmani o'rnatish\" tugmasini bosgandan so'ng masofadan boshqarish pultingiz yoki klaviaturangizdagi tugmani bosing yoki Apple Pencil imo-ishorasidan foydalaning.",
+  "Pencil Double Tap": "Apple Pencil ikki marta bosish",
+  "Pencil Squeeze": "Apple Pencil qisish"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1977,5 +1977,8 @@
   "Pull down to add bookmark": "Kéo xuống để thêm đánh dấu",
   "Sign in to Readest": "Đăng nhập vào Readest",
   "Sync your library, reading progress, and highlights across your devices.": "Đồng bộ thư viện, tiến trình đọc và điểm nổi bật của bạn trên tất cả thiết bị của bạn.",
-  "or continue with email": "hoặc tiếp tục bằng email"
+  "or continue with email": "hoặc tiếp tục bằng email",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Nhấn một nút trên bộ điều khiển từ xa hoặc bàn phím, hoặc dùng cử chỉ Apple Pencil, sau khi chạm \"Đặt phím\".",
+  "Pencil Double Tap": "Chạm hai lần Apple Pencil",
+  "Pencil Squeeze": "Bóp Apple Pencil"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1977,5 +1977,8 @@
   "Pull down to add bookmark": "下拉添加书签",
   "Sign in to Readest": "登录 Readest",
   "Sync your library, reading progress, and highlights across your devices.": "将您的书库、阅读进度和高亮在您的所有设备间同步。",
-  "or continue with email": "或使用邮箱继续"
+  "or continue with email": "或使用邮箱继续",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "点击「设置按键」后，按下遥控器或键盘上的按钮，或使用 Apple Pencil 手势。",
+  "Pencil Double Tap": "Apple Pencil 轻点两下",
+  "Pencil Squeeze": "Apple Pencil 轻捏"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1977,5 +1977,8 @@
   "Pull down to add bookmark": "下拉添加書籤",
   "Sign in to Readest": "登入 Readest",
   "Sync your library, reading progress, and highlights across your devices.": "將您的書庫、閱讀進度和高亮在您的所有裝置間同步。",
-  "or continue with email": "或使用電子郵件繼續"
+  "or continue with email": "或使用電子郵件繼續",
+  "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "點擊「設定按鍵」後，按下遙控器或鍵盤上的按鈕，或使用 Apple Pencil 手勢。",
+  "Pencil Double Tap": "Apple Pencil 點兩下",
+  "Pencil Squeeze": "Apple Pencil 輕捏"
 }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
@@ -291,6 +291,52 @@ class MediaKeyHandler {
   }
 }
 
+// Forwards Apple Pencil gestures to JS as native page-turner keys (#5501).
+// Double tap: Pencil 2 / Pro; squeeze: Pencil Pro on iPadOS 17.5+. The
+// system-level pencil preference is honored when set to Off (.ignore); any
+// other preferred action fires the user's in-app binding, since Readest has
+// no drawing tools the system actions could apply to. Unlike MediaKeyHandler
+// this is passive (no MPRemoteCommandCenter claim, never fires on iPhone),
+// so it stays attached for the app's lifetime.
+class PencilGestureHandler: NSObject, UIPencilInteractionDelegate {
+  private weak var webView: WKWebView?
+
+  init(webView: WKWebView) {
+    self.webView = webView
+  }
+
+  // iOS 15.0-17.4 double tap; on 17.5+ the system calls didReceiveTap instead.
+  @available(iOS, deprecated: 17.5)
+  func pencilInteractionDidTap(_ interaction: UIPencilInteraction) {
+    guard UIPencilInteraction.preferredTapAction != .ignore else { return }
+    forward("PencilDoubleTap")
+  }
+
+  @available(iOS 17.5, *)
+  func pencilInteraction(
+    _ interaction: UIPencilInteraction, didReceiveTap tap: UIPencilInteraction.Tap
+  ) {
+    guard UIPencilInteraction.preferredTapAction != .ignore else { return }
+    forward("PencilDoubleTap")
+  }
+
+  @available(iOS 17.5, *)
+  func pencilInteraction(
+    _ interaction: UIPencilInteraction, didReceiveSqueeze squeeze: UIPencilInteraction.Squeeze
+  ) {
+    guard squeeze.phase == .ended else { return }
+    guard UIPencilInteraction.preferredSqueezeAction != .ignore else { return }
+    forward("PencilSqueeze")
+  }
+
+  private func forward(_ name: String) {
+    DispatchQueue.main.async { [weak self] in
+      self?.webView?.evaluateJavaScript(
+        "try { window.onNativeKeyDown('\(name)', 0); } catch (_) {}", completionHandler: nil)
+    }
+  }
+}
+
 class WebViewLifecycleManager: NSObject {
   private weak var webView: WKWebView?
   private var originalNavigationDelegate: WKNavigationDelegate?
@@ -522,6 +568,7 @@ class NativeBridgePlugin: Plugin {
   private var currentOrientationMask: UIInterfaceOrientationMask = .all
   private var originalDelegate: UIApplicationDelegate?
   private var webViewLifecycleManager: WebViewLifecycleManager?
+  private var pencilGestureHandler: PencilGestureHandler?
   private var traitChangeRegistered = false
 
   // Screen-brightness management. `UIScreen.main.brightness` is a *global*
@@ -553,6 +600,14 @@ class NativeBridgePlugin: Plugin {
     webViewLifecycleManager = WebViewLifecycleManager()
     webViewLifecycleManager?.startMonitoring(webView: webview)
     logger.log("NativeBridgePlugin: WebView lifecycle monitoring activated")
+
+    // Forward Apple Pencil double-tap / squeeze gestures as native keys for
+    // the hardware page turner (#5501).
+    let pencilHandler = PencilGestureHandler(webView: webview)
+    pencilGestureHandler = pencilHandler
+    let pencilInteraction = UIPencilInteraction()
+    pencilInteraction.delegate = pencilHandler
+    webview.addInteraction(pencilInteraction)
 
     // The WKWebView never fires the `prefers-color-scheme` media query
     // `change` event while the app stays foregrounded, so observe the

--- a/apps/readest-app/src/__tests__/app/reader/hooks/usePagination-pencilKeys.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/usePagination-pencilKeys.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { HardwarePageTurnerSettings } from '@/types/settings';
+
+// Real deviceStore + eventDispatcher; only the native bridge boundary is
+// mocked so we can observe the interceptKeys calls (#5501 pencil gestures
+// must not claim media-key interception).
+const h = vi.hoisted(() => ({
+  appService: { isMobileApp: true } as { isMobileApp: boolean },
+  viewSettings: { volumeKeysToFlip: false } as Record<string, unknown> | null,
+  viewState: { inited: true } as Record<string, unknown> | null,
+  settingsState: {
+    settings: { hardwarePageTurner: undefined as HardwarePageTurnerSettings | undefined },
+  },
+}));
+
+vi.mock('@/utils/bridge', () => ({
+  interceptKeys: vi.fn(),
+  getScreenBrightness: vi.fn(),
+  setScreenBrightness: vi.fn(),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: h.appService }),
+}));
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: Object.assign(
+    () => ({
+      getViewSettings: () => h.viewSettings,
+      getViewState: () => h.viewState,
+      hoveredBookKey: null,
+      setHoveredBookKey: vi.fn(),
+    }),
+    { getState: () => ({ hoveredBookKey: null }) },
+  ),
+}));
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({ getBookData: () => ({}) }),
+}));
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: Object.assign(
+    (selector?: (s: typeof h.settingsState) => unknown) =>
+      selector ? selector(h.settingsState) : h.settingsState,
+    { getState: () => h.settingsState },
+  ),
+}));
+vi.mock('@/store/sidebarStore', () => ({
+  useSidebarStore: Object.assign(() => ({}), { getState: () => ({ sideBarBookKey: 'book-1' }) }),
+}));
+
+import { interceptKeys } from '@/utils/bridge';
+import { eventDispatcher } from '@/utils/event';
+import { useDeviceControlStore } from '@/store/deviceStore';
+import { usePagination } from '@/app/reader/hooks/usePagination';
+import type { FoliateView } from '@/types/view';
+
+const BOOK_KEY = 'book-1';
+
+const PENCIL_TURNER: HardwarePageTurnerSettings = {
+  enabled: true,
+  bindings: {
+    pagePrev: { source: 'native', id: 'PencilSqueeze', label: 'Pencil Squeeze' },
+    pageNext: { source: 'native', id: 'PencilDoubleTap', label: 'Pencil Double Tap' },
+    sectionPrev: null,
+    sectionNext: null,
+    refresh: null,
+  },
+};
+
+const MEDIA_TURNER: HardwarePageTurnerSettings = {
+  enabled: true,
+  bindings: {
+    pagePrev: { source: 'native', id: 'MediaPrevious', label: 'Media Previous' },
+    pageNext: { source: 'native', id: 'MediaNext', label: 'Media Next' },
+    sectionPrev: null,
+    sectionNext: null,
+    refresh: null,
+  },
+};
+
+const makeView = () => ({
+  renderer: { scrolled: false },
+  book: { dir: 'ltr' as const },
+  next: vi.fn(),
+  prev: vi.fn(),
+});
+
+const setupWithView = (view: ReturnType<typeof makeView> | null = null) => {
+  const viewRef = { current: view as unknown as FoliateView | null };
+  const containerRef = { current: null };
+  return renderHook(() => usePagination(BOOK_KEY, viewRef, containerRef));
+};
+
+const pressNativeKey = async (keyName: string) => {
+  await act(async () => {
+    await eventDispatcher.dispatch('native-key-down', { keyName });
+  });
+};
+
+beforeEach(() => {
+  useDeviceControlStore.setState({
+    volumeKeysIntercepted: false,
+    volumeKeysInterceptionCount: 0,
+    pageTurnerKeysIntercepted: false,
+    pageTurnerKeysInterceptionCount: 0,
+  });
+  vi.clearAllMocks();
+  delete window.onNativeKeyDown;
+  h.appService = { isMobileApp: true };
+  h.viewSettings = { volumeKeysToFlip: false };
+  h.viewState = { inited: true };
+  h.settingsState.settings.hardwarePageTurner = undefined;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('usePagination Apple Pencil bindings (#5501)', () => {
+  test('a bound pencil double tap turns to the next page', async () => {
+    h.settingsState.settings.hardwarePageTurner = PENCIL_TURNER;
+    const view = makeView();
+    setupWithView(view);
+
+    await pressNativeKey('PencilDoubleTap');
+
+    expect(view.next).toHaveBeenCalled();
+    expect(view.prev).not.toHaveBeenCalled();
+  });
+
+  test('a bound pencil squeeze turns to the previous page', async () => {
+    h.settingsState.settings.hardwarePageTurner = PENCIL_TURNER;
+    const view = makeView();
+    setupWithView(view);
+
+    await pressNativeKey('PencilSqueeze');
+
+    expect(view.prev).toHaveBeenCalled();
+  });
+
+  test('pencil-only bindings install forwarding but never media-key interception', () => {
+    h.settingsState.settings.hardwarePageTurner = PENCIL_TURNER;
+    setupWithView();
+
+    expect(window.onNativeKeyDown).toBeDefined();
+    expect(interceptKeys).not.toHaveBeenCalledWith(
+      expect.objectContaining({ pageTurnerKeys: true }),
+    );
+  });
+
+  test('media-key bindings still acquire native interception', () => {
+    h.settingsState.settings.hardwarePageTurner = MEDIA_TURNER;
+    setupWithView();
+
+    expect(interceptKeys).toHaveBeenCalledWith({ pageTurnerKeys: true });
+  });
+
+  test('mixed pencil and media bindings acquire interception and both keys work', async () => {
+    h.settingsState.settings.hardwarePageTurner = {
+      enabled: true,
+      bindings: {
+        pagePrev: { source: 'native', id: 'PencilSqueeze', label: 'Pencil Squeeze' },
+        pageNext: { source: 'native', id: 'MediaNext', label: 'Media Next' },
+        sectionPrev: null,
+        sectionNext: null,
+        refresh: null,
+      },
+    };
+    const view = makeView();
+    setupWithView(view);
+
+    expect(interceptKeys).toHaveBeenCalledWith({ pageTurnerKeys: true });
+    await pressNativeKey('PencilSqueeze');
+    expect(view.prev).toHaveBeenCalled();
+    await pressNativeKey('MediaNext');
+    expect(view.next).toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/__tests__/store/device-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/device-store.test.ts
@@ -313,4 +313,15 @@ describe('deviceStore', () => {
       });
     });
   });
+
+  // ── Pencil gesture forwarding (#5501) ──────────────────────────
+  describe('ensureKeyForwarding', () => {
+    test('installs the native key handler without touching interception', async () => {
+      const { interceptKeys } = await import('@/utils/bridge');
+      useDeviceControlStore.getState().ensureKeyForwarding();
+
+      expect(window.onNativeKeyDown).toBeDefined();
+      expect(interceptKeys).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/readest-app/src/__tests__/utils/hardwareKeys.test.ts
+++ b/apps/readest-app/src/__tests__/utils/hardwareKeys.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeDomKeyEvent,
   matchesBinding,
   resolvePageTurn,
+  isPencilNativeKey,
 } from '@/utils/keybinding';
 import { HardwarePageTurnerSettings } from '@/types/settings';
 
@@ -104,5 +105,46 @@ describe('resolvePageTurn', () => {
   test('returns null when the feature is disabled', () => {
     const disabled = { ...settings, enabled: false };
     expect(resolvePageTurn(disabled, { source: 'native', id: 'MediaNext' })).toBeNull();
+  });
+});
+
+describe('Apple Pencil native keys (#5501)', () => {
+  test('maps pencil gesture ids to friendly labels', () => {
+    expect(normalizeNativeKey('PencilDoubleTap')).toEqual({
+      source: 'native',
+      id: 'PencilDoubleTap',
+      label: 'Pencil Double Tap',
+    });
+    expect(normalizeNativeKey('PencilSqueeze')).toEqual({
+      source: 'native',
+      id: 'PencilSqueeze',
+      label: 'Pencil Squeeze',
+    });
+  });
+
+  test('isPencilNativeKey identifies pencil ids only', () => {
+    expect(isPencilNativeKey('PencilDoubleTap')).toBe(true);
+    expect(isPencilNativeKey('PencilSqueeze')).toBe(true);
+    expect(isPencilNativeKey('MediaNext')).toBe(false);
+    expect(isPencilNativeKey('VolumeUp')).toBe(false);
+  });
+
+  test('resolvePageTurn resolves bound pencil gestures', () => {
+    const pencilSettings: HardwarePageTurnerSettings = {
+      enabled: true,
+      bindings: {
+        pagePrev: { source: 'native', id: 'PencilSqueeze', label: 'Pencil Squeeze' },
+        pageNext: { source: 'native', id: 'PencilDoubleTap', label: 'Pencil Double Tap' },
+        sectionPrev: null,
+        sectionNext: null,
+        refresh: null,
+      },
+    };
+    expect(resolvePageTurn(pencilSettings, { source: 'native', id: 'PencilDoubleTap' })).toBe(
+      'pageNext',
+    );
+    expect(resolvePageTurn(pencilSettings, { source: 'native', id: 'PencilSqueeze' })).toBe(
+      'pagePrev',
+    );
   });
 });

--- a/apps/readest-app/src/app/reader/hooks/usePagination.ts
+++ b/apps/readest-app/src/app/reader/hooks/usePagination.ts
@@ -8,7 +8,12 @@ import { useDeviceControlStore } from '@/store/deviceStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useSidebarStore } from '@/store/sidebarStore';
 import { eventDispatcher } from '@/utils/event';
-import { resolvePageTurn, normalizeDomKeyEvent, KeyCandidate } from '@/utils/keybinding';
+import {
+  resolvePageTurn,
+  normalizeDomKeyEvent,
+  isPencilNativeKey,
+  KeyCandidate,
+} from '@/utils/keybinding';
 import { refreshEinkScreen } from '@/utils/bridge';
 import { isTauriAppPlatform } from '@/services/environment';
 import { tauriGetWindowLogicalPosition } from '@/utils/window';
@@ -197,6 +202,7 @@ export const usePagination = (
     releaseVolumeKeyInterception,
     acquirePageTurnerKeyInterception,
     releasePageTurnerKeyInterception,
+    ensureKeyForwarding,
   } = useDeviceControlStore();
   // Reactive subscription: drives the effect dependency array below. The
   // handlers themselves re-read via getState() to avoid stale closures.
@@ -478,20 +484,29 @@ export const usePagination = (
 
   // Hardware page turner: native-key + DOM-key listeners and native
   // media-key interception, re-evaluated whenever the setting changes.
+  // Pencil gestures are forwarded unconditionally by the iOS bridge, so they
+  // only need the JS forwarding handler — acquiring media-key interception
+  // for them would claim MPRemoteCommandCenter next/prev-track and drag the
+  // app into the Now Playing eligibility rules (#4691).
   useEffect(() => {
-    const hasNativeBinding =
-      hardwarePageTurner?.bindings.pagePrev?.source === 'native' ||
-      hardwarePageTurner?.bindings.pageNext?.source === 'native' ||
-      hardwarePageTurner?.bindings.sectionPrev?.source === 'native' ||
-      hardwarePageTurner?.bindings.sectionNext?.source === 'native' ||
-      hardwarePageTurner?.bindings.refresh?.source === 'native';
+    const bindings = hardwarePageTurner?.bindings;
+    const nativeBindings = [
+      bindings?.pagePrev,
+      bindings?.pageNext,
+      bindings?.sectionPrev,
+      bindings?.sectionNext,
+      bindings?.refresh,
+    ].filter((b) => b?.source === 'native');
+    const hasNativeBinding = nativeBindings.length > 0;
+    const hasMediaKeyBinding = nativeBindings.some((b) => b && !isPencilNativeKey(b.id));
     const needsNativeInterception =
-      !!appService?.isMobileApp && !!hardwarePageTurner?.enabled && hasNativeBinding;
+      !!appService?.isMobileApp && !!hardwarePageTurner?.enabled && hasMediaKeyBinding;
 
     if (needsNativeInterception) {
       acquirePageTurnerKeyInterception();
     }
     if (hasNativeBinding) {
+      if (appService?.isMobileApp) ensureKeyForwarding();
       eventDispatcher.on('native-key-down', handleHardwareNativeKey);
     }
     window.addEventListener('keydown', handleHardwareDomKey, true);
@@ -507,15 +522,12 @@ export const usePagination = (
       window.removeEventListener('keydown', handleHardwareDomKey, true);
       window.removeEventListener('message', handleHardwareDomKey);
     };
+    // The media-vs-pencil decision depends on binding ids, not just sources,
+    // and every persist creates a fresh settings object — key the effect on
+    // object identity. Re-running acquire/release on any change is safe
+    // because interception is reference-counted.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    hardwarePageTurner?.enabled,
-    hardwarePageTurner?.bindings.pagePrev?.source,
-    hardwarePageTurner?.bindings.pageNext?.source,
-    hardwarePageTurner?.bindings.sectionPrev?.source,
-    hardwarePageTurner?.bindings.sectionNext?.source,
-    hardwarePageTurner?.bindings.refresh?.source,
-  ]);
+  }, [hardwarePageTurner]);
 
   // Touch swipe page flip for fixed-layout books — registered as a touch interceptor
   // so it participates in the priority-based consumption chain.

--- a/apps/readest-app/src/components/settings/PageTurnerSettings.tsx
+++ b/apps/readest-app/src/components/settings/PageTurnerSettings.tsx
@@ -173,9 +173,13 @@ const PageTurnerSettings: React.FC<PageTurnerSettingsProps> = ({ bookKey, onRegi
       <BoxedList
         title={_('Page Turner')}
         data-setting-id='settings.control.pageTurner'
-        description={_(
-          'Press a button on your remote controller or keyboard after tapping "Set key".',
-        )}
+        description={
+          appService?.isIOSApp
+            ? _(
+                'Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping "Set key".',
+              )
+            : _('Press a button on your remote controller or keyboard after tapping "Set key".')
+        }
       >
         {appService?.isMobileApp && (
           <SettingsSwitchRow

--- a/apps/readest-app/src/store/deviceStore.ts
+++ b/apps/readest-app/src/store/deviceStore.ts
@@ -38,6 +38,7 @@ type DeviceControlState = {
   acquirePageTurnerKeyInterception: () => void;
   releasePageTurnerKeyInterception: () => void;
   setKeyLearnMode: (enabled: boolean) => void;
+  ensureKeyForwarding: () => void;
   listenToNativeTouchEvents: () => void;
 };
 
@@ -115,6 +116,13 @@ export const useDeviceControlStore = create<DeviceControlState>((set, get) => ({
   setKeyLearnMode: (enabled: boolean) => {
     window.onNativeKeyDown = handleNativeKeyDown;
     interceptKeys({ learnMode: enabled });
+  },
+
+  // Apple Pencil gestures are forwarded by the iOS bridge without any
+  // interception being acquired (#5501), so the JS-side forwarding handler
+  // must be installable on its own.
+  ensureKeyForwarding: () => {
+    window.onNativeKeyDown = handleNativeKeyDown;
   },
 
   listenToNativeTouchEvents: () => {

--- a/apps/readest-app/src/utils/keybinding.ts
+++ b/apps/readest-app/src/utils/keybinding.ts
@@ -22,7 +22,16 @@ const NATIVE_KEY_LABELS: Record<string, string> = {
   MediaRewind: _('Media Rewind'),
   VolumeUp: _('Volume Up'),
   VolumeDown: _('Volume Down'),
+  PencilDoubleTap: _('Pencil Double Tap'),
+  PencilSqueeze: _('Pencil Squeeze'),
 };
+
+// Apple Pencil gestures forwarded by the iOS native bridge (#5501). They ride
+// the native-key channel but must not trigger media-key interception, which
+// claims MPRemoteCommandCenter and affects Now Playing (see usePagination).
+const PENCIL_NATIVE_KEYS = new Set(['PencilDoubleTap', 'PencilSqueeze']);
+
+export const isPencilNativeKey = (id: string): boolean => PENCIL_NATIVE_KEYS.has(id);
 
 const DOM_KEY_LABELS: Record<string, string> = {
   ArrowLeft: _('Arrow Left'),


### PR DESCRIPTION
Closes #5501

## Summary

Apple Pencil gestures can now be bound as custom page turners on iPadOS through the existing Page Turner "Set key" learn mode:

- **Double tap** (Apple Pencil 2 / Pro) and **squeeze** (Apple Pencil Pro, iPadOS 17.5+) are forwarded by a new passive `UIPencilInteraction` attached to the WKWebView, riding the existing native-key channel as `PencilDoubleTap` / `PencilSqueeze`.
- Binding works exactly like a remote-controller key: tap "Set key" on any action slot (previous/next page, previous/next section) and perform the gesture.
- The system-level pencil preference is honored when set to Off (`.ignore`); any other system action fires the in-app binding since Readest has no drawing tools the system actions could apply to.
- Pencil-only bindings do **not** acquire media-key interception, so they never claim `MPRemoteCommandCenter` next/prev-track or affect Now Playing eligibility (#4691 territory). A new `ensureKeyForwarding` store action installs the JS forwarding handler independently of interception.
- The Page Turner settings description mentions Apple Pencil on iOS; the three new strings are translated across all 33 non-English locales.

## Testing

- New unit tests: pencil id labels/resolution in `hardwareKeys.test.ts`, `ensureKeyForwarding` in `device-store.test.ts`, and `usePagination-pencilKeys.test.ts` covering page turns via pencil keys, the no-media-interception guarantee for pencil-only bindings, and mixed pencil+media bindings.
- Full suite green: 8650 passed. `pnpm lint` and `pnpm format:check` clean.
- Swift plugin compile-checked against the iphonesimulator SDK (`swift build --triple arm64-apple-ios15.0-simulator`).
- **Device verification pending**: the Simulator cannot emulate pencil gestures, so double tap/squeeze need manual verification on an iPad with Apple Pencil Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)