### PR TITLE
feat(send): clip locally opened html and xhtml pages with the browser extension

### DIFF
--- a/apps/readest-app/extensions/send-to-readest/README.md
+++ b/apps/readest-app/extensions/send-to-readest/README.md
@@ -30,6 +30,36 @@ server writes the bytes to R2 and inserts a `send_inbox` row; the next
 Readest client to open drains the inbox and imports the EPUB as-is — no
 further server-side conversion.
 
+### Locally opened pages (`file://`)
+
+A saved web page, an exported HTML report, a loose `.xhtml` chapter — if
+the user can open it in a tab, the extension clips it through the exact
+same converter. Three things differ:
+
+- **Chrome requires "Allow access to file URLs"** on the extension's own
+  row in `chrome://extensions`; `host_permissions` alone does not grant it.
+  The popup checks `chrome.extension.isAllowedFileSchemeAccess()` first and
+  offers a button straight to that page, because without the toggle the
+  capture-script inject dies with an opaque host-permission error.
+- **Images survive, including local siblings.** An extension page holding
+  file access *can* read `file://` URLs (a content script in the page
+  cannot, and the rendered `<img>` taints a canvas, so the bundler is the
+  only route). A "Save Page As, Complete" therefore keeps its
+  `<name>_files/` images, a single-file save keeps its inlined `data:`
+  images, and an HTML-only save keeps whatever it still points at on the
+  original CDN.
+
+  Reading local files is fenced twice, because the EPUB we build is
+  uploaded: the clipped page must itself be `file://` (so a remote page
+  pointing an `<img>` at the disk reads nothing), and the asset must sit
+  under that page's own directory (so a crafted local page can't harvest
+  the rest of the disk). A page at the filesystem root gets nothing.
+- **The source URL never leaves the machine.** `X-Readest-Url` is sent only
+  for `http(s)` pages — the inbox endpoint rejects anything else anyway, and
+  an absolute path out of someone's home directory isn't ours to upload. The
+  file name stands in for the site name on the generated cover and, when the
+  page declares no `<title>`, as the book title.
+
 ## Why client-side conversion
 
 The previous version (`0.1.0`) sent only the page URL — the server then
@@ -133,7 +163,7 @@ toolbar badge updates, the lazy-load scroll dance (incl.
 phase. From the `apps/readest-app` workspace root:
 
 ```bash
-pnpm test:extension      # 47 shell tests, ~1 s
+pnpm test:extension      # 54 shell tests, ~1 s
 pnpm build-browser-ext   # production webpack build (catches alias / stub regressions)
 pnpm test                # full suite — also runs the extension tests via vitest's default glob
 ```
@@ -166,7 +196,7 @@ Two parallel translation surfaces:
 
 | Folder | Scope | When it's read |
 |---|---|---|
-| `src/locales/<lang>.json` | 29 runtime UI strings — popup, errors, status, badges. `{ "<english source>": "<translation>" }`. | At runtime by the `_(...)` helper. Falls through to the English key when an entry is missing or set to the `__STRING_NOT_TRANSLATED__` sentinel. |
+| `src/locales/<lang>.json` | 31 runtime UI strings — popup, errors, status, badges. `{ "<english source>": "<translation>" }`. | At runtime by the `_(...)` helper. Falls through to the English key when an entry is missing or set to the `__STRING_NOT_TRANSLATED__` sentinel. |
 | `_locales/<lang>/messages.json` | Three manifest fields — `app_name`, `app_description`, `action_title` — referenced as `__MSG_*__` in `manifest.json`. | At install time + by the Chrome Web Store listing. Chrome falls back to `default_locale` (en) automatically, so a locale file is only needed when you want to override the toolbar tooltip / store copy. |
 
 The full set of supported locales lives in

--- a/apps/readest-app/extensions/send-to-readest/popup.html
+++ b/apps/readest-app/extensions/send-to-readest/popup.html
@@ -102,6 +102,18 @@
         opacity: 0.5;
         cursor: default;
       }
+      button.secondary {
+        width: 100%;
+        margin-top: 8px;
+        padding: 9px 12px;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--fg);
+        background: var(--raised);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        cursor: pointer;
+      }
       button.link {
         background: transparent;
         border: 0;
@@ -188,6 +200,11 @@
         <p id="page-url" class="page-url"></p>
       </div>
       <button id="send" class="primary" disabled data-i18n="Send to Readest"></button>
+      <button
+        id="enable-file-access"
+        class="secondary hidden"
+        data-i18n="Allow access to file URLs"
+      ></button>
       <div id="progress" class="progress">
         <div class="progress-label" id="progress-label"></div>
         <div class="progress-bar indeterminate"><div class="progress-bar-fill"></div></div>

--- a/apps/readest-app/extensions/send-to-readest/src/__test-utils__/chromeMock.ts
+++ b/apps/readest-app/extensions/send-to-readest/src/__test-utils__/chromeMock.ts
@@ -35,11 +35,15 @@ export interface ChromeMock {
     executeScript: Mock;
   };
   runtime: {
+    id: string;
     sendMessage: Mock;
     connect: Mock;
     onMessage: { addListener: Mock };
     onConnect: { addListener: Mock };
     lastError: chrome.runtime.LastError | undefined;
+  };
+  extension: {
+    isAllowedFileSchemeAccess: Mock;
   };
   i18n: {
     getUILanguage: Mock;
@@ -91,6 +95,7 @@ export function installChromeMock(): ChromeMock {
       executeScript: vi.fn(async () => [{ frameId: 0, documentId: 'x' }]),
     },
     runtime: {
+      id: 'test-extension-id',
       sendMessage: vi.fn(async () => undefined),
       connect: vi.fn(() => ({
         name: '',
@@ -102,6 +107,11 @@ export function installChromeMock(): ChromeMock {
       onMessage: { addListener: vi.fn() },
       onConnect: { addListener: vi.fn() },
       lastError: undefined,
+    },
+    extension: {
+      // Chrome gates `file://` access behind a per-extension user toggle.
+      // Default to granted so existing tests stay unaffected.
+      isAllowedFileSchemeAccess: vi.fn(async () => true),
     },
     i18n: {
       getUILanguage: vi.fn(() => 'en'),

--- a/apps/readest-app/extensions/send-to-readest/src/background/service-worker.ts
+++ b/apps/readest-app/extensions/send-to-readest/src/background/service-worker.ts
@@ -28,6 +28,7 @@ import type {
 } from '../lib/messages';
 import { readToken } from '../lib/auth';
 import { translate as _ } from '../lib/i18n';
+import { hasFileSchemeAccess, isClippableUrl, isLocalFileUrl } from '../lib/localPage';
 import { setBadge } from './badge';
 import { clipAndUploadViaOffscreen } from './offscreen';
 
@@ -140,8 +141,14 @@ async function runClip(tabId: number): Promise<void> {
   try {
     const tab = await chrome.tabs.get(tabId).catch(() => null);
     if (!tab || !tab.url) return emitError('no-active-tab', _('No active tab'));
-    if (!/^https?:/i.test(tab.url)) {
+    if (!isClippableUrl(tab.url)) {
       return emitError('restricted-page', _('This page cannot be clipped'));
+    }
+    // The popup already surfaces this with a button to the toggle; re-check
+    // here because the SW also serves clips the popup never gated (a stale
+    // popup, a keyboard-invoked clip).
+    if (isLocalFileUrl(tab.url) && !(await hasFileSchemeAccess())) {
+      return emitError('restricted-page', _('Readest needs permission to read local files.'));
     }
 
     const stored = await readToken();

--- a/apps/readest-app/extensions/send-to-readest/src/background/upload.test.ts
+++ b/apps/readest-app/extensions/send-to-readest/src/background/upload.test.ts
@@ -93,6 +93,21 @@ describe('uploadEpub', () => {
     expect(init?.body).toBe(sampleEpub);
   });
 
+  test('omits X-Readest-Url for a local page', async () => {
+    // The inbox endpoint 400s on a non-http(s) source URL, and an absolute
+    // path off the user's disk has no business leaving the machine.
+    fetchSpy.mockResolvedValueOnce(blobOk({ id: 'inbox-local' }));
+    const result = await uploadEpub({
+      ...sampleArgs,
+      sourceUrl: 'file:///Users/me/Documents/Saved%20Page.html',
+    });
+
+    expect(result).toEqual({ ok: true, id: 'inbox-local' });
+    const headers = fetchSpy.mock.calls[0]![1]?.headers as Record<string, string>;
+    expect(headers['X-Readest-Url']).toBeUndefined();
+    expect(headers['X-Readest-Title']).toBe("UTF-8''Hello%2C%20World");
+  });
+
   test('encodes non-ASCII titles correctly', async () => {
     fetchSpy.mockResolvedValueOnce(blobOk({ id: 'inbox-2' }));
     await uploadEpub({ ...sampleArgs, title: '机器学习 ✅' });

--- a/apps/readest-app/extensions/send-to-readest/src/background/upload.ts
+++ b/apps/readest-app/extensions/send-to-readest/src/background/upload.ts
@@ -70,16 +70,23 @@ export async function uploadEpub(opts: {
   sourceUrl: string;
 }): Promise<UploadResult | UploadError> {
   const target = opts.endpoint;
+  // Only a real web address travels. A page clipped off the user's disk has
+  // a `file://` source the inbox endpoint rejects outright (400), and an
+  // absolute path from someone's home directory has no business leaving the
+  // machine — the EPUB itself already carries everything the import needs.
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${opts.token}`,
+    'Content-Type': 'application/epub+zip',
+    'X-Readest-Title': encodeHeaderValue(opts.title || 'Page clip'),
+  };
+  if (/^https?:\/\//i.test(opts.sourceUrl)) {
+    headers['X-Readest-Url'] = encodeHeaderValue(opts.sourceUrl);
+  }
   let res: Response;
   try {
     res = await fetch(target, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${opts.token}`,
-        'Content-Type': 'application/epub+zip',
-        'X-Readest-Title': encodeHeaderValue(opts.title || 'Page clip'),
-        'X-Readest-Url': encodeHeaderValue(opts.sourceUrl),
-      },
+      headers,
       body: opts.epub,
     });
   } catch (err) {

--- a/apps/readest-app/extensions/send-to-readest/src/lib/localPage.test.ts
+++ b/apps/readest-app/extensions/send-to-readest/src/lib/localPage.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import {
+  installChromeMock,
+  uninstallChromeMock,
+  type ChromeMock,
+} from '../__test-utils__/chromeMock';
+import {
+  extensionSettingsUrl,
+  hasFileSchemeAccess,
+  isClippableUrl,
+  isLocalFileUrl,
+} from './localPage';
+
+let chromeMock: ChromeMock;
+
+beforeEach(() => {
+  chromeMock = installChromeMock();
+});
+afterEach(() => {
+  uninstallChromeMock();
+});
+
+describe('isClippableUrl', () => {
+  test('accepts remote pages and locally opened files', () => {
+    expect(isClippableUrl('https://example.com/article')).toBe(true);
+    expect(isClippableUrl('http://example.com/article')).toBe(true);
+    expect(isClippableUrl('file:///Users/me/Saved%20Page.html')).toBe(true);
+    expect(isClippableUrl('file:///C:/Users/me/chapter.xhtml')).toBe(true);
+  });
+
+  test('rejects browser-internal and script-bearing schemes', () => {
+    expect(isClippableUrl('chrome://extensions')).toBe(false);
+    expect(isClippableUrl('devtools://devtools/bundled/inspector.html')).toBe(false);
+    expect(isClippableUrl('about:blank')).toBe(false);
+    expect(isClippableUrl('data:text/html,<h1>hi</h1>')).toBe(false);
+    expect(isClippableUrl('javascript:alert(1)')).toBe(false);
+    expect(isClippableUrl(undefined)).toBe(false);
+    expect(isClippableUrl('')).toBe(false);
+  });
+});
+
+describe('isLocalFileUrl', () => {
+  test('only matches the file scheme', () => {
+    expect(isLocalFileUrl('file:///Users/me/a.html')).toBe(true);
+    expect(isLocalFileUrl('FILE:///Users/me/a.html')).toBe(true);
+    expect(isLocalFileUrl('https://example.com/file.html')).toBe(false);
+    expect(isLocalFileUrl(undefined)).toBe(false);
+  });
+});
+
+describe('hasFileSchemeAccess', () => {
+  test('reports what Chrome says', async () => {
+    chromeMock.extension.isAllowedFileSchemeAccess.mockResolvedValue(true);
+    expect(await hasFileSchemeAccess()).toBe(true);
+    chromeMock.extension.isAllowedFileSchemeAccess.mockResolvedValue(false);
+    expect(await hasFileSchemeAccess()).toBe(false);
+  });
+
+  test('fails open when the API is missing or throws', async () => {
+    // `chrome.extension` is trimmed down under MV3 and parts of it are
+    // foreground-only, so a service worker may not be able to ask at all.
+    // Treating "can't tell" as "denied" would block local clips on a
+    // browser where the toggle is already on.
+    chromeMock.extension.isAllowedFileSchemeAccess.mockRejectedValue(new Error('nope'));
+    expect(await hasFileSchemeAccess()).toBe(true);
+
+    (chromeMock as unknown as { extension: undefined }).extension = undefined;
+    expect(await hasFileSchemeAccess()).toBe(true);
+  });
+});
+
+describe('extensionSettingsUrl', () => {
+  test('deep-links to this extension own row', () => {
+    expect(extensionSettingsUrl()).toBe('chrome://extensions/?id=test-extension-id');
+  });
+});

--- a/apps/readest-app/extensions/send-to-readest/src/lib/localPage.ts
+++ b/apps/readest-app/extensions/send-to-readest/src/lib/localPage.ts
@@ -1,0 +1,50 @@
+/**
+ * Which tabs the clipper will act on, and the extra permission a locally
+ * opened page needs.
+ *
+ * Beyond remote pages we accept `file://` tabs — a saved web page, an
+ * exported HTML/XHTML document, anything the user opened straight off
+ * disk. The converter treats those exactly like a remote page (site rule
+ * → Readability → EPUB); only the assets differ, since nothing on a
+ * `file://` page is fetchable from an extension context.
+ *
+ * Everything else stays out: `chrome://`, `devtools://`, `about:`,
+ * `data:`, `javascript:` and the Web Store are either uninjectable or
+ * carry nothing worth clipping.
+ */
+
+export function isClippableUrl(url: string | undefined): url is string {
+  return !!url && /^(https?|file):/i.test(url);
+}
+
+export function isLocalFileUrl(url: string | undefined): boolean {
+  return !!url && /^file:/i.test(url);
+}
+
+/**
+ * Chrome gates `file://` access behind a per-extension user toggle
+ * ("Allow access to file URLs" on the extension's own settings page);
+ * `<all_urls>` alone is not enough. Without it `chrome.scripting.
+ * executeScript` fails on a local tab with an opaque host-permission
+ * error, so both the popup and the service worker check first and point
+ * the user at the toggle instead.
+ *
+ * Fails OPEN. `chrome.extension` is a trimmed-down MV3 surface and parts
+ * of it are foreground-only, so a service worker may not have this method
+ * at all. "Can't tell" must not read as "denied" — that would block every
+ * local clip on a browser where the toggle is already on. When we can't
+ * ask, let the clip run and surface whatever real error the inject hits.
+ */
+export async function hasFileSchemeAccess(): Promise<boolean> {
+  try {
+    const allowed = await chrome.extension?.isAllowedFileSchemeAccess?.();
+    return allowed !== false;
+  } catch {
+    return true;
+  }
+}
+
+/** The extension's own row on `chrome://extensions`, where the toggle lives. */
+export function extensionSettingsUrl(): string {
+  return `chrome://extensions/?id=${chrome.runtime.id}`;
+}

--- a/apps/readest-app/extensions/send-to-readest/src/locales/ar.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/ar.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "السماح بالوصول إلى عناوين URL للملفات",
   "Article is too large to send": "المقالة أكبر من أن يتم إرسالها",
   "Building EPUB…": "جارٍ إنشاء EPUB…",
   "Capture script could not start on this page": "لم يتمكن نص الالتقاط من البدء في هذه الصفحة",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "تعذر بدء صفحة المحول",
   "Open web.readest.com": "فتح web.readest.com",
   "Page took too long to read": "استغرقت قراءة الصفحة وقتًا طويلاً",
+  "Readest needs permission to read local files.": "يحتاج Readest إلى إذن لقراءة الملفات المحلية.",
   "Reading page…": "جارٍ قراءة الصفحة…",
   "Saved to your library.": "تم الحفظ في مكتبتك.",
   "Send to Readest": "إرسال إلى Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/bn.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/bn.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "ফাইল URL-এ অ্যাক্সেসের অনুমতি দিন",
   "Article is too large to send": "নিবন্ধটি পাঠানোর জন্য খুব বড়",
   "Building EPUB…": "EPUB তৈরি হচ্ছে…",
   "Capture script could not start on this page": "ক্যাপচার স্ক্রিপ্ট এই পৃষ্ঠায় শুরু হতে পারেনি",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "কনভার্টার পৃষ্ঠা শুরু হতে ব্যর্থ",
   "Open web.readest.com": "web.readest.com খুলুন",
   "Page took too long to read": "পৃষ্ঠাটি পড়তে অনেক বেশি সময় লেগেছে",
+  "Readest needs permission to read local files.": "স্থানীয় ফাইল পড়ার জন্য Readest-এর অনুমতি প্রয়োজন।",
   "Reading page…": "পৃষ্ঠা পড়া হচ্ছে…",
   "Saved to your library.": "আপনার লাইব্রেরিতে সংরক্ষিত হয়েছে।",
   "Send to Readest": "Readest-এ পাঠান",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/bo.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/bo.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "ཡིག་ཆའི་URL ལ་འཛུལ་ཞུགས་ཆོག་པ།",
   "Article is too large to send": "རྩོམ་ཡིག་འདི་ནི་གཏོང་ཐུབ་པ་ལས་ཆེ་དྲགས་འདུག",
   "Building EPUB…": "EPUB བཟོ་བཞིན་པ…",
   "Capture script could not start on this page": "ཤོག་འདིའི་ནང་འཛིན་སྐུལ་འདྲེན་འགོ་འཛུགས་མ་ཐུབ།",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "བསྒྱུར་བྱེད་ཤོག་འགོ་འཛུགས་མ་ཐུབ།",
   "Open web.readest.com": "web.readest.com ཁ་ཕྱེ།",
   "Page took too long to read": "ཤོག་ཀློག་པར་དུས་ཚོད་མང་དྲགས་སོང་།",
+  "Readest needs permission to read local files.": "Readest ལ་ས་གནས་ཡིག་ཆ་ཀློག་པའི་ཆོག་མཆན་དགོས།",
   "Reading page…": "ཤོག་ཀློག་བཞིན་པ…",
   "Saved to your library.": "ཁྱེད་ཀྱི་དཔེ་མཛོད་དུ་ཉར་ཟིན།",
   "Send to Readest": "Readest ལ་གཏོང་།",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/de.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/de.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Zugriff auf Datei-URLs zulassen",
   "Article is too large to send": "Artikel ist zu groß zum Senden",
   "Building EPUB…": "EPUB wird erstellt…",
   "Capture script could not start on this page": "Erfassungsskript konnte auf dieser Seite nicht gestartet werden",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Konverterseite konnte nicht gestartet werden",
   "Open web.readest.com": "web.readest.com öffnen",
   "Page took too long to read": "Seite hat zu lange zum Lesen gebraucht",
+  "Readest needs permission to read local files.": "Readest benötigt die Berechtigung, lokale Dateien zu lesen.",
   "Reading page…": "Seite wird gelesen…",
   "Saved to your library.": "In Ihrer Bibliothek gespeichert.",
   "Send to Readest": "An Readest senden",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/el.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/el.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Να επιτρέπεται η πρόσβαση σε URL αρχείων",
   "Article is too large to send": "Το άρθρο είναι πολύ μεγάλο για να σταλεί",
   "Building EPUB…": "Δημιουργία EPUB…",
   "Capture script could not start on this page": "Το σενάριο λήψης δεν μπόρεσε να ξεκινήσει σε αυτή τη σελίδα",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Η σελίδα μετατροπής δεν μπόρεσε να ξεκινήσει",
   "Open web.readest.com": "Άνοιγμα του web.readest.com",
   "Page took too long to read": "Η σελίδα χρειάστηκε πολύ χρόνο για να διαβαστεί",
+  "Readest needs permission to read local files.": "Το Readest χρειάζεται άδεια για να διαβάζει τοπικά αρχεία.",
   "Reading page…": "Ανάγνωση σελίδας…",
   "Saved to your library.": "Αποθηκεύτηκε στη βιβλιοθήκη σας.",
   "Send to Readest": "Αποστολή στο Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/es.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/es.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Permitir acceso a URLs de archivos",
   "Article is too large to send": "El artículo es demasiado grande para enviarlo",
   "Building EPUB…": "Creando EPUB…",
   "Capture script could not start on this page": "El script de captura no pudo iniciarse en esta página",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "La página del conversor no pudo iniciarse",
   "Open web.readest.com": "Abrir web.readest.com",
   "Page took too long to read": "La página tardó demasiado en leerse",
+  "Readest needs permission to read local files.": "Readest necesita permiso para leer archivos locales.",
   "Reading page…": "Leyendo la página…",
   "Saved to your library.": "Guardado en tu biblioteca.",
   "Send to Readest": "Enviar a Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/fa.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/fa.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "اجازه دسترسی به نشانی‌های فایل",
   "Article is too large to send": "مقاله برای ارسال خیلی بزرگ است",
   "Building EPUB…": "در حال ساخت EPUB…",
   "Capture script could not start on this page": "اسکریپت ضبط در این صفحه شروع نشد",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "صفحه مبدل شروع نشد",
   "Open web.readest.com": "باز کردن web.readest.com",
   "Page took too long to read": "خواندن صفحه بیش از حد طول کشید",
+  "Readest needs permission to read local files.": "Readest برای خواندن فایل‌های محلی به اجازه نیاز دارد.",
   "Reading page…": "در حال خواندن صفحه…",
   "Saved to your library.": "در کتابخانه شما ذخیره شد.",
   "Send to Readest": "ارسال به Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/fr.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/fr.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Autoriser l'accès aux URL de fichier",
   "Article is too large to send": "L'article est trop volumineux pour être envoyé",
   "Building EPUB…": "Création de l’EPUB…",
   "Capture script could not start on this page": "Le script de capture n’a pas pu démarrer sur cette page",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Le démarrage de la page du convertisseur a échoué",
   "Open web.readest.com": "Ouvrir web.readest.com",
   "Page took too long to read": "La page a mis trop de temps à être lue",
+  "Readest needs permission to read local files.": "Readest a besoin d'une autorisation pour lire les fichiers locaux.",
   "Reading page…": "Lecture de la page…",
   "Saved to your library.": "Enregistré dans votre bibliothèque.",
   "Send to Readest": "Envoyer vers Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/he.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/he.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "אפשר גישה לכתובות של קבצים",
   "Article is too large to send": "המאמר גדול מדי לשליחה",
   "Building EPUB…": "יצירת EPUB…",
   "Capture script could not start on this page": "הסקריפט ללכידה לא הצליח להתחיל בדף זה",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "דף הממיר לא הצליח להתחיל",
   "Open web.readest.com": "פתח את web.readest.com",
   "Page took too long to read": "קריאת הדף ארכה זמן רב מדי",
+  "Readest needs permission to read local files.": "Readest זקוק להרשאה כדי לקרוא קבצים מקומיים.",
   "Reading page…": "קורא את הדף…",
   "Saved to your library.": "נשמר בספרייה שלך.",
   "Send to Readest": "שלח ל-Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/hi.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/hi.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "फ़ाइल URL तक पहुंच की अनुमति दें",
   "Article is too large to send": "लेख भेजने के लिए बहुत बड़ा है",
   "Building EPUB…": "EPUB बनाया जा रहा है…",
   "Capture script could not start on this page": "इस पृष्ठ पर कैप्चर स्क्रिप्ट प्रारंभ नहीं हो सकी",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "कनवर्टर पृष्ठ प्रारंभ नहीं हो सका",
   "Open web.readest.com": "web.readest.com खोलें",
   "Page took too long to read": "पृष्ठ पढ़ने में बहुत समय लगा",
+  "Readest needs permission to read local files.": "स्थानीय फ़ाइलें पढ़ने के लिए Readest को अनुमति चाहिए।",
   "Reading page…": "पृष्ठ पढ़ा जा रहा है…",
   "Saved to your library.": "आपकी लाइब्रेरी में सहेजा गया।",
   "Send to Readest": "Readest पर भेजें",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/hu.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/hu.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Hozzáférés engedélyezése a fájl-URL-ekhez",
   "Article is too large to send": "A cikk túl nagy a küldéshez",
   "Building EPUB…": "EPUB készítése…",
   "Capture script could not start on this page": "A rögzítő szkript nem tudott elindulni ezen az oldalon",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Az átalakító oldal indítása nem sikerült",
   "Open web.readest.com": "web.readest.com megnyitása",
   "Page took too long to read": "Az oldal beolvasása túl sokáig tartott",
+  "Readest needs permission to read local files.": "A Readestnek engedélyre van szüksége a helyi fájlok olvasásához.",
   "Reading page…": "Oldal beolvasása…",
   "Saved to your library.": "Elmentve a könyvtáradba.",
   "Send to Readest": "Küldés a Readestbe",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/id.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/id.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Izinkan akses ke URL file",
   "Article is too large to send": "Artikel terlalu besar untuk dikirim",
   "Building EPUB…": "Membangun EPUB…",
   "Capture script could not start on this page": "Skrip pengambilan tidak dapat dimulai di halaman ini",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Halaman pengonversi gagal dimulai",
   "Open web.readest.com": "Buka web.readest.com",
   "Page took too long to read": "Pembacaan halaman memakan waktu terlalu lama",
+  "Readest needs permission to read local files.": "Readest memerlukan izin untuk membaca file lokal.",
   "Reading page…": "Membaca halaman…",
   "Saved to your library.": "Disimpan ke perpustakaan Anda.",
   "Send to Readest": "Kirim ke Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/it.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/it.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Consenti l'accesso agli URL dei file",
   "Article is too large to send": "L'articolo è troppo grande per essere inviato",
   "Building EPUB…": "Creazione dell’EPUB…",
   "Capture script could not start on this page": "Lo script di acquisizione non è riuscito ad avviarsi su questa pagina",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Avvio della pagina del convertitore non riuscito",
   "Open web.readest.com": "Apri web.readest.com",
   "Page took too long to read": "La pagina ha impiegato troppo tempo per essere letta",
+  "Readest needs permission to read local files.": "Readest ha bisogno dell'autorizzazione per leggere i file locali.",
   "Reading page…": "Lettura della pagina…",
   "Saved to your library.": "Salvato nella tua libreria.",
   "Send to Readest": "Invia a Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/ja.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/ja.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "ファイルの URL へのアクセスを許可する",
   "Article is too large to send": "記事のサイズが大きすぎて送信できません",
   "Building EPUB…": "EPUB を作成中…",
   "Capture script could not start on this page": "このページで取得スクリプトを開始できませんでした",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "オフスクリーンページの起動に失敗しました",
   "Open web.readest.com": "web.readest.com を開く",
   "Page took too long to read": "ページの読み込みに時間がかかりすぎました",
+  "Readest needs permission to read local files.": "ローカル ファイルを読み取るには Readest に権限が必要です。",
   "Reading page…": "ページを読み取り中…",
   "Saved to your library.": "ライブラリに保存しました。",
   "Send to Readest": "Readest に送信",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/ko.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/ko.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "파일 URL에 대한 액세스 허용",
   "Article is too large to send": "문서가 너무 커서 보낼 수 없습니다",
   "Building EPUB…": "EPUB 생성 중…",
   "Capture script could not start on this page": "이 페이지에서 캡처 스크립트를 시작할 수 없습니다",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "오프스크린 페이지를 시작하지 못했습니다",
   "Open web.readest.com": "web.readest.com 열기",
   "Page took too long to read": "페이지 읽기에 시간이 너무 오래 걸렸습니다",
+  "Readest needs permission to read local files.": "로컬 파일을 읽으려면 Readest에 권한이 필요합니다.",
   "Reading page…": "페이지 읽는 중…",
   "Saved to your library.": "라이브러리에 저장되었습니다.",
   "Send to Readest": "Readest로 보내기",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/ms.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/ms.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Benarkan akses kepada URL fail",
   "Article is too large to send": "Artikel terlalu besar untuk dihantar",
   "Building EPUB…": "Membina EPUB…",
   "Capture script could not start on this page": "Skrip tangkap tidak dapat dimulakan pada halaman ini",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Halaman penukar gagal dimulakan",
   "Open web.readest.com": "Buka web.readest.com",
   "Page took too long to read": "Pembacaan halaman mengambil masa terlalu lama",
+  "Readest needs permission to read local files.": "Readest memerlukan kebenaran untuk membaca fail tempatan.",
   "Reading page…": "Membaca halaman…",
   "Saved to your library.": "Disimpan ke perpustakaan anda.",
   "Send to Readest": "Hantar ke Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/nl.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/nl.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Toegang tot bestands-URL's toestaan",
   "Article is too large to send": "Artikel is te groot om te versturen",
   "Building EPUB…": "EPUB wordt opgebouwd…",
   "Capture script could not start on this page": "Het opnamescript kon niet starten op deze pagina",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Converter-pagina kon niet starten",
   "Open web.readest.com": "web.readest.com openen",
   "Page took too long to read": "Het lezen van de pagina duurde te lang",
+  "Readest needs permission to read local files.": "Readest heeft toestemming nodig om lokale bestanden te lezen.",
   "Reading page…": "Pagina lezen…",
   "Saved to your library.": "Opgeslagen in je bibliotheek.",
   "Send to Readest": "Naar Readest sturen",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/pl.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/pl.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Zezwól na dostęp do adresów URL plików",
   "Article is too large to send": "Artykuł jest zbyt duży, aby go wysłać",
   "Building EPUB…": "Tworzenie EPUB…",
   "Capture script could not start on this page": "Skrypt przechwytujący nie mógł uruchomić się na tej stronie",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Strona konwertera nie mogła się uruchomić",
   "Open web.readest.com": "Otwórz web.readest.com",
   "Page took too long to read": "Wczytanie strony trwało zbyt długo",
+  "Readest needs permission to read local files.": "Readest potrzebuje uprawnień do odczytu plików lokalnych.",
   "Reading page…": "Wczytywanie strony…",
   "Saved to your library.": "Zapisano w Twojej bibliotece.",
   "Send to Readest": "Wyślij do Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/pt-BR.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/pt-BR.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Permitir acesso a URLs de arquivos",
   "Article is too large to send": "O artigo é grande demais para ser enviado",
   "Building EPUB…": "Criando EPUB…",
   "Capture script could not start on this page": "O script de captura não pôde iniciar nesta página",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "A página do conversor não iniciou",
   "Open web.readest.com": "Abrir web.readest.com",
   "Page took too long to read": "A leitura da página demorou demais",
+  "Readest needs permission to read local files.": "O Readest precisa de permissão para ler arquivos locais.",
   "Reading page…": "Lendo a página…",
   "Saved to your library.": "Salvo na sua biblioteca.",
   "Send to Readest": "Enviar para o Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/pt.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/pt.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Permitir acesso a URLs de ficheiros",
   "Article is too large to send": "O artigo é demasiado grande para enviar",
   "Building EPUB…": "A criar EPUB…",
   "Capture script could not start on this page": "O script de captura não conseguiu iniciar nesta página",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "A página do conversor não iniciou",
   "Open web.readest.com": "Abrir web.readest.com",
   "Page took too long to read": "A leitura da página demorou demasiado",
+  "Readest needs permission to read local files.": "O Readest precisa de permissão para ler ficheiros locais.",
   "Reading page…": "A ler a página…",
   "Saved to your library.": "Guardado na sua biblioteca.",
   "Send to Readest": "Enviar para Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/ro.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/ro.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Permite accesul la adresele URL ale fișierelor",
   "Article is too large to send": "Articolul este prea mare pentru a fi trimis",
   "Building EPUB…": "Se construiește EPUB…",
   "Capture script could not start on this page": "Scriptul de captură nu a putut porni pe această pagină",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Pagina convertorului nu a putut porni",
   "Open web.readest.com": "Deschide web.readest.com",
   "Page took too long to read": "Citirea paginii a durat prea mult",
+  "Readest needs permission to read local files.": "Readest are nevoie de permisiune pentru a citi fișiere locale.",
   "Reading page…": "Se citește pagina…",
   "Saved to your library.": "Salvat în biblioteca dvs.",
   "Send to Readest": "Trimite la Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/ru.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/ru.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Разрешить доступ к файлам по URL",
   "Article is too large to send": "Статья слишком велика для отправки",
   "Building EPUB…": "Создание EPUB…",
   "Capture script could not start on this page": "Сценарий захвата не смог запуститься на этой странице",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Страница преобразователя не запустилась",
   "Open web.readest.com": "Открыть web.readest.com",
   "Page took too long to read": "Чтение страницы заняло слишком много времени",
+  "Readest needs permission to read local files.": "Readest нужно разрешение на чтение локальных файлов.",
   "Reading page…": "Чтение страницы…",
   "Saved to your library.": "Сохранено в вашей библиотеке.",
   "Send to Readest": "Отправить в Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/si.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/si.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "ගොනු URL වෙත ප්‍රවේශය ඉඩ දෙන්න",
   "Article is too large to send": "ලිපිය යැවීමට ඉතා විශාලයි",
   "Building EPUB…": "EPUB ගොඩනඟමින්…",
   "Capture script could not start on this page": "මෙම පිටුවේ ග්‍රහණ ස්ක්‍රිප්ටය ආරම්භ කළ නොහැකි විය",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "පරිවර්තක පිටුව ආරම්භ වීමට අසමත් විය",
   "Open web.readest.com": "web.readest.com විවෘත කරන්න",
   "Page took too long to read": "පිටුව කියවීමට වැඩි කාලයක් ගත විය",
+  "Readest needs permission to read local files.": "දේශීය ගොනු කියවීමට Readest හට අවසර අවශ්‍යයි.",
   "Reading page…": "පිටුව කියවමින්…",
   "Saved to your library.": "ඔබේ පුස්තකාලයට සුරැකිණි.",
   "Send to Readest": "Readest වෙත යවන්න",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/sl.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/sl.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Dovoli dostop do URL-jev datotek",
   "Article is too large to send": "Članek je prevelik za pošiljanje",
   "Building EPUB…": "Ustvarjanje EPUB…",
   "Capture script could not start on this page": "Skripta za zajem ni mogla začeti na tej strani",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Strani pretvornika ni bilo mogoče zagnati",
   "Open web.readest.com": "Odpri web.readest.com",
   "Page took too long to read": "Branje strani je trajalo predolgo",
+  "Readest needs permission to read local files.": "Readest potrebuje dovoljenje za branje lokalnih datotek.",
   "Reading page…": "Branje strani…",
   "Saved to your library.": "Shranjeno v vašo knjižnico.",
   "Send to Readest": "Pošlji v Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/sv.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/sv.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Tillåt åtkomst till fil-URL:er",
   "Article is too large to send": "Artikeln är för stor för att skickas",
   "Building EPUB…": "Skapar EPUB…",
   "Capture script could not start on this page": "Insamlingsskriptet kunde inte starta på den här sidan",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Konverteringssidan kunde inte starta",
   "Open web.readest.com": "Öppna web.readest.com",
   "Page took too long to read": "Sidan tog för lång tid att läsa",
+  "Readest needs permission to read local files.": "Readest behöver behörighet för att läsa lokala filer.",
   "Reading page…": "Läser sidan…",
   "Saved to your library.": "Sparad i ditt bibliotek.",
   "Send to Readest": "Skicka till Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/ta.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/ta.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "கோப்பு URL-களுக்கான அணுகலை அனுமதி",
   "Article is too large to send": "கட்டுரை அனுப்ப மிக பெரியது",
   "Building EPUB…": "EPUB உருவாக்கப்படுகிறது…",
   "Capture script could not start on this page": "இந்த பக்கத்தில் கைப்பற்றும் ஸ்கிரிப்ட் தொடங்க முடியவில்லை",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "மாற்றியின் பக்கம் தொடங்க முடியவில்லை",
   "Open web.readest.com": "web.readest.com திற",
   "Page took too long to read": "பக்கம் வாசிக்க அதிக நேரம் ஆனது",
+  "Readest needs permission to read local files.": "உள்ளூர் கோப்புகளைப் படிக்க Readest-க்கு அனுமதி தேவை.",
   "Reading page…": "பக்கம் வாசிக்கப்படுகிறது…",
   "Saved to your library.": "உங்கள் நூலகத்தில் சேமிக்கப்பட்டது.",
   "Send to Readest": "Readest-க்கு அனுப்பு",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/th.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/th.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "อนุญาตให้เข้าถึง URL ของไฟล์",
   "Article is too large to send": "บทความมีขนาดใหญ่เกินกว่าจะส่ง",
   "Building EPUB…": "กำลังสร้าง EPUB…",
   "Capture script could not start on this page": "สคริปต์การจับไม่สามารถเริ่มทำงานบนหน้านี้",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "หน้าตัวแปลงเริ่มทำงานไม่สำเร็จ",
   "Open web.readest.com": "เปิด web.readest.com",
   "Page took too long to read": "การอ่านหน้าใช้เวลานานเกินไป",
+  "Readest needs permission to read local files.": "Readest ต้องได้รับสิทธิ์ในการอ่านไฟล์ในเครื่อง",
   "Reading page…": "กำลังอ่านหน้า…",
   "Saved to your library.": "บันทึกลงในคลังของคุณแล้ว",
   "Send to Readest": "ส่งไปยัง Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/tr.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/tr.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Dosya URL'lerine erişime izin ver",
   "Article is too large to send": "Makale göndermek için çok büyük",
   "Building EPUB…": "EPUB oluşturuluyor…",
   "Capture script could not start on this page": "Yakalama betiği bu sayfada başlayamadı",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Dönüştürücü sayfası başlatılamadı",
   "Open web.readest.com": "web.readest.com sayfasını aç",
   "Page took too long to read": "Sayfanın okunması çok uzun sürdü",
+  "Readest needs permission to read local files.": "Readest'in yerel dosyaları okumak için izne ihtiyacı var.",
   "Reading page…": "Sayfa okunuyor…",
   "Saved to your library.": "Kitaplığınıza kaydedildi.",
   "Send to Readest": "Readest'e gönder",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/uk.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/uk.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Дозволити доступ до URL файлів",
   "Article is too large to send": "Стаття занадто велика для надсилання",
   "Building EPUB…": "Створення EPUB…",
   "Capture script could not start on this page": "Скрипт захоплення не зміг запуститися на цій сторінці",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Не вдалося запустити сторінку конвертера",
   "Open web.readest.com": "Відкрити web.readest.com",
   "Page took too long to read": "Сторінка читалася занадто довго",
+  "Readest needs permission to read local files.": "Readest потрібен дозвіл на читання локальних файлів.",
   "Reading page…": "Читання сторінки…",
   "Saved to your library.": "Збережено у вашій бібліотеці.",
   "Send to Readest": "Надіслати до Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/uz.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/uz.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Fayl URL manzillariga ruxsat berish",
   "Article is too large to send": "Maqola yuborish uchun juda katta",
   "Building EPUB…": "EPUB yaratilmoqda…",
   "Capture script could not start on this page": "Saqlash skripti ushbu sahifada ishga tushmadi",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Aylantirgich sahifasi ishga tushmadi",
   "Open web.readest.com": "web.readest.com sahifasini ochish",
   "Page took too long to read": "Sahifani o‘qish juda uzoq vaqt oldi",
+  "Readest needs permission to read local files.": "Readest mahalliy fayllarni oʻqish uchun ruxsat talab qiladi.",
   "Reading page…": "Sahifa o‘qilmoqda…",
   "Saved to your library.": "Kutubxonangizga saqlandi.",
   "Send to Readest": "Readest'ga yuborish",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/vi.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/vi.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "Cho phép truy cập URL tệp",
   "Article is too large to send": "Bài viết quá lớn để gửi",
   "Building EPUB…": "Đang tạo EPUB…",
   "Capture script could not start on this page": "Tập lệnh chụp không thể khởi động trên trang này",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "Trang chuyển đổi không khởi động được",
   "Open web.readest.com": "Mở web.readest.com",
   "Page took too long to read": "Trang đọc mất quá nhiều thời gian",
+  "Readest needs permission to read local files.": "Readest cần quyền để đọc tệp cục bộ.",
   "Reading page…": "Đang đọc trang…",
   "Saved to your library.": "Đã lưu vào thư viện của bạn.",
   "Send to Readest": "Gửi đến Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/zh-CN.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/zh-CN.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "允许访问文件网址",
   "Article is too large to send": "文章过大,无法发送",
   "Building EPUB…": "正在构建 EPUB…",
   "Capture script could not start on this page": "抓取脚本无法在此页面启动",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "转换器页面启动失败",
   "Open web.readest.com": "打开 web.readest.com",
   "Page took too long to read": "页面读取耗时过长",
+  "Readest needs permission to read local files.": "Readest 需要读取本地文件的权限。",
   "Reading page…": "正在读取页面…",
   "Saved to your library.": "已保存到你的书库。",
   "Send to Readest": "发送到 Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/locales/zh-TW.json
+++ b/apps/readest-app/extensions/send-to-readest/src/locales/zh-TW.json
@@ -1,4 +1,5 @@
 {
+  "Allow access to file URLs": "允許存取檔案網址",
   "Article is too large to send": "文章過大，無法傳送",
   "Building EPUB…": "正在建立 EPUB…",
   "Capture script could not start on this page": "擷取指令碼無法在此頁面啟動",
@@ -13,6 +14,7 @@
   "Offscreen page failed to start": "轉換器頁面啟動失敗",
   "Open web.readest.com": "開啟 web.readest.com",
   "Page took too long to read": "頁面讀取耗時過長",
+  "Readest needs permission to read local files.": "Readest 需要讀取本機檔案的權限。",
   "Reading page…": "正在讀取頁面…",
   "Saved to your library.": "已儲存到您的書庫。",
   "Send to Readest": "傳送至 Readest",

--- a/apps/readest-app/extensions/send-to-readest/src/popup/popup.test.ts
+++ b/apps/readest-app/extensions/send-to-readest/src/popup/popup.test.ts
@@ -28,6 +28,7 @@ const POPUP_DOM = `
       <div class="progress-label" id="progress-label">Preparing…</div>
       <div class="progress-bar indeterminate"><div class="progress-bar-fill"></div></div>
     </div>
+    <button id="enable-file-access" class="secondary hidden">Allow access to file URLs</button>
     <p id="status" class="status"></p>
   </section>
   <section id="signed-out-view" class="sign-in hidden">
@@ -112,6 +113,46 @@ describe('popup — initial render', () => {
     await loadPopup();
     expect(document.getElementById('page-title')?.textContent).toBe('This page cannot be clipped');
     expect((document.getElementById('send') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test('clips a locally opened file:// page when file access is granted', async () => {
+    chromeMock.tabs.query.mockResolvedValue([
+      { id: 3, url: 'file:///Users/me/Saved%20Page.html', title: 'Saved Page' },
+    ] as unknown as chrome.tabs.Tab[]);
+    await loadPopup();
+
+    expect(document.getElementById('page-title')?.textContent).toBe('Saved Page');
+    expect((document.getElementById('send') as HTMLButtonElement).disabled).toBe(false);
+    expect(document.getElementById('enable-file-access')?.classList.contains('hidden')).toBe(true);
+  });
+
+  test('prompts for the file-access toggle instead of failing opaquely', async () => {
+    // Without "Allow access to file URLs" the capture-script inject dies
+    // with an unreadable host-permission error — tell the user what to do.
+    chromeMock.extension.isAllowedFileSchemeAccess.mockResolvedValue(false);
+    chromeMock.tabs.query.mockResolvedValue([
+      { id: 3, url: 'file:///Users/me/Saved%20Page.html', title: 'Saved Page' },
+    ] as unknown as chrome.tabs.Tab[]);
+    await loadPopup();
+
+    expect((document.getElementById('send') as HTMLButtonElement).disabled).toBe(true);
+    expect(document.getElementById('enable-file-access')?.classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('status')?.textContent).toContain('local files');
+  });
+
+  test('the file-access button opens this extension own settings page', async () => {
+    chromeMock.extension.isAllowedFileSchemeAccess.mockResolvedValue(false);
+    chromeMock.tabs.query.mockResolvedValue([
+      { id: 3, url: 'file:///Users/me/Saved%20Page.html', title: 'Saved Page' },
+    ] as unknown as chrome.tabs.Tab[]);
+    await loadPopup();
+
+    document
+      .getElementById('enable-file-access')!
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(chromeMock.tabs.create).toHaveBeenCalledWith({
+      url: 'chrome://extensions/?id=test-extension-id',
+    });
   });
 });
 

--- a/apps/readest-app/extensions/send-to-readest/src/popup/popup.ts
+++ b/apps/readest-app/extensions/send-to-readest/src/popup/popup.ts
@@ -9,6 +9,12 @@
 
 import type { ClipProgress, ClipRequest, StatusRequest, StatusResponse } from '../lib/messages';
 import { localizeDom, translate as _ } from '../lib/i18n';
+import {
+  extensionSettingsUrl,
+  hasFileSchemeAccess,
+  isClippableUrl,
+  isLocalFileUrl,
+} from '../lib/localPage';
 
 const LOGIN_URL = 'https://web.readest.com/';
 
@@ -27,6 +33,7 @@ const pageTitle = $('page-title');
 const pageUrl = $('page-url');
 const sendBtn = $<HTMLButtonElement>('send');
 const openReadestBtn = $<HTMLButtonElement>('open-readest');
+const enableFileAccessBtn = $<HTMLButtonElement>('enable-file-access');
 const progressEl = $('progress');
 const progressLabel = $('progress-label');
 const progressBar = progressEl.querySelector('.progress-bar') as HTMLDivElement;
@@ -115,15 +122,16 @@ async function init(): Promise<void> {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   if (tab) currentTabId = tab.id ?? null;
 
-  if (!tab || !tab.url || !/^https?:/i.test(tab.url)) {
+  if (!tab || !isClippableUrl(tab.url)) {
     pageTitle.textContent = _('This page cannot be clipped');
     pageUrl.textContent = '';
     sendBtn.disabled = true;
     return;
   }
 
-  pageTitle.textContent = tab.title || tab.url;
-  pageUrl.textContent = tab.url;
+  const url = tab.url;
+  pageTitle.textContent = tab.title || url;
+  pageUrl.textContent = url;
 
   const status = await chrome.runtime.sendMessage<StatusRequest, StatusResponse>({
     type: 'send-to-readest:status',
@@ -135,6 +143,16 @@ async function init(): Promise<void> {
   }
 
   showSignedIn();
+
+  // A local page needs "Allow access to file URLs" on top of the extension's
+  // host permissions. Ask for it up front — otherwise the clip dies deep in
+  // `chrome.scripting.executeScript` with an unreadable permission error.
+  if (isLocalFileUrl(url) && !(await hasFileSchemeAccess())) {
+    sendBtn.disabled = true;
+    enableFileAccessBtn.classList.remove('hidden');
+    setStatus(_('Readest needs permission to read local files.'));
+    return;
+  }
 
   if (status.inFlight || status.lastProgress) {
     render(status.lastProgress);
@@ -153,6 +171,10 @@ sendBtn.addEventListener('click', async () => {
 
 openReadestBtn.addEventListener('click', () => {
   chrome.tabs.create({ url: LOGIN_URL });
+});
+
+enableFileAccessBtn.addEventListener('click', () => {
+  chrome.tabs.create({ url: extensionSettingsUrl() });
 });
 
 chrome.runtime.onMessage.addListener((message: unknown): void => {

--- a/apps/readest-app/src/__tests__/services/send-asset-bundler.test.ts
+++ b/apps/readest-app/src/__tests__/services/send-asset-bundler.test.ts
@@ -163,4 +163,111 @@ describe('bundleAssets', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(result.images).toHaveLength(0);
   });
+
+  // A page clipped from a `file://` tab (a saved web page opened from disk)
+  // resolves its relative images to `file://` siblings. An extension page
+  // holding file access CAN read those, so a "Save Page As, Complete" keeps
+  // its `<name>_files/` images instead of degrading to alt text.
+  test('embeds a file:// sibling image when the page itself came off disk', async () => {
+    const html = `<img src="Saved%20Page_files/hero.png" alt="hero">`;
+    const result = await bundleAssets(html, 'file:///Users/me/Saved%20Page.html');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'file:///Users/me/Saved%20Page_files/hero.png',
+      expect.objectContaining({ redirect: 'follow' }),
+    );
+    expect(result.images).toHaveLength(1);
+    expect(result.missing).toBe(0);
+    expect(result.html).toContain('src="images/');
+  });
+
+  // Exfiltration guard. Reading local files is only ever appropriate for a
+  // page that is itself local; a remote page pointing an <img> at the disk
+  // would otherwise have us bundle private files into an EPUB and upload it.
+  test('never reads a file:// asset referenced by a remote page', async () => {
+    const html = `<img src="file:///Users/me/.ssh/id_rsa.png" alt="nope">`;
+    const result = await bundleAssets(html, 'https://evil.example.com/post');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.images).toHaveLength(0);
+    expect(result.missing).toBe(1);
+    expect(result.html).not.toContain('src=');
+  });
+
+  // Same concern one step down: a local page may only reach its own folder,
+  // so a crafted .html can't harvest images from elsewhere on the disk.
+  test('never reads a file:// asset outside the local page own directory', async () => {
+    const html = `<img src="../../Pictures/private.png" alt="nope">`;
+    const result = await bundleAssets(html, 'file:///Users/me/clips/Saved%20Page.html');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.images).toHaveLength(0);
+    expect(result.missing).toBe(1);
+  });
+
+  test('does not treat a filesystem-root page as licence to read the whole disk', async () => {
+    const html = `<img src="/etc/secret.png" alt="nope">`;
+    const result = await bundleAssets(html, 'file:///page.html');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.images).toHaveLength(0);
+  });
+
+  test('still inlines data: images on a local page (single-file saved pages)', async () => {
+    const dataUrl = 'data:image/png;base64,iVBORw0KGgo=';
+    const html = `<img src="${dataUrl}">`;
+    const result = await bundleAssets(html, 'file:///Users/me/Saved%20Page.html');
+    expect(fetchSpy).toHaveBeenCalledWith(dataUrl, expect.objectContaining({ redirect: 'follow' }));
+    expect(result.images).toHaveLength(1);
+    expect(result.missing).toBe(0);
+  });
+});
+
+/**
+ * Clipping must be deterministic: the same page with the same assets has to
+ * produce the same EPUB every time, or two devices clipping one URL disagree
+ * on the bytes. The total-size budget is the one place where that can slip,
+ * because it has to decide *which* images to drop.
+ */
+describe('bundleAssets — determinism under the size budget', () => {
+  // Just under the 5 MB per-asset cap, so seven of them overrun the 30 MB
+  // total and the bundler has to leave one out.
+  const CHUNK = 4.5 * 1024 * 1024;
+  const COUNT = 7;
+
+  function chunk(seed: number): ArrayBuffer {
+    const bytes = new Uint8Array(CHUNK);
+    // Distinct content per image, or identical sha256 paths would collapse
+    // them into a single entry and the budget would never be reached.
+    bytes[0] = seed;
+    bytes[1] = seed >> 8;
+    return bytes.buffer as ArrayBuffer;
+  }
+
+  test('drops the last image in document order, not whichever fetch finished last', async () => {
+    const urls = Array.from({ length: COUNT }, (_, i) => `https://cdn.example.com/${i}.png`);
+    const html = urls.map((u) => `<img src="${u}">`).join('');
+
+    // Invert completion order: the first image in the document resolves last.
+    // Under a completion-ordered budget that is exactly the one that gets
+    // dropped, which is the bug.
+    const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      const index = urls.indexOf(url);
+      // Image 0 lands long after every other one has been accounted for.
+      await new Promise((r) => setTimeout(r, index === 0 ? 250 : 5));
+      return new Response(chunk(index), {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      });
+    });
+
+    try {
+      const result = await bundleAssets(html, 'https://example.com/article');
+
+      expect(result.images).toHaveLength(COUNT - 1);
+      expect(result.missing).toBe(1);
+      // The surviving set is the document-order prefix, every time.
+      const survivingSeeds = result.images.map((img) => new Uint8Array(img.bytes)[0]);
+      expect(survivingSeeds.sort((a, b) => a! - b!)).toEqual([0, 1, 2, 3, 4, 5]);
+    } finally {
+      spy.mockRestore();
+    }
+  }, 30_000);
 });

--- a/apps/readest-app/src/__tests__/services/send-convert-local-page.test.ts
+++ b/apps/readest-app/src/__tests__/services/send-convert-local-page.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { convertPageToEpub } from '@/services/send/conversion/convertToEpub';
+
+/**
+ * Clipping a page the user opened from disk (`file:///…/saved.html`) with
+ * the browser extension. Same converter as a remote clip, but nothing on
+ * the page is fetchable: Chrome forbids extension contexts from reading
+ * `file://` URLs, so images, favicons and author avatars must be skipped
+ * rather than attempted, and the cover has no hostname to fall back on.
+ */
+
+const BODY = 'The regional water board met on Tuesday to review the drought plan. '.repeat(12);
+
+/** A 1x1 transparent PNG, so a bundled image has real bytes to hash. */
+const PNG = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+  0x42, 0x60, 0x82,
+]);
+
+function savedHtml(): string {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <title>Drought Plan Review</title>
+    <link rel="icon" href="favicon.ico">
+  </head>
+  <body>
+    <nav>Home About Contact Subscribe Log in</nav>
+    <header>THE DAILY BANNER</header>
+    <article>
+      <h1>Drought Plan Review</h1>
+      <p>${BODY}</p>
+      <p><img src="Drought%20Plan%20Review_files/chart.png" alt="rainfall chart"></p>
+      <p>${BODY}</p>
+    </article>
+    <footer>Copyright 2026 The Daily. All rights reserved.</footer>
+  </body>
+</html>`;
+}
+
+/** What Chrome's `outerHTML` yields for a document parsed as XHTML: XML
+ *  serialization, so void elements are self-closed and the root carries
+ *  the XHTML namespace. */
+function savedXhtml(): string {
+  return `<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head>
+    <title>Drought Plan Review</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <nav>Home About Contact</nav>
+    <article>
+      <h1>Drought Plan Review</h1>
+      <p>${BODY}</p>
+      <hr />
+      <p>${BODY}</p>
+    </article>
+  </body></html>`;
+}
+
+async function chapterOf(file: File): Promise<string> {
+  const { BlobReader, TextWriter, ZipReader } = await import('@zip.js/zip.js');
+  const reader = new ZipReader(new BlobReader(file));
+  const entries = await reader.getEntries();
+  const entry = entries.find((e) => e.filename === 'OEBPS/chapter1.xhtml');
+  if (!entry || !('getData' in entry) || !entry.getData) throw new Error('chapter1.xhtml missing');
+  const html = await entry.getData(new TextWriter());
+  await reader.close();
+  return html;
+}
+
+async function entryNames(file: File): Promise<string> {
+  const { BlobReader, ZipReader } = await import('@zip.js/zip.js');
+  const reader = new ZipReader(new BlobReader(file));
+  const names = (await reader.getEntries()).map((e) => e.filename).join('\n');
+  await reader.close();
+  return names;
+}
+
+async function coverOf(file: File): Promise<string> {
+  const { BlobReader, TextWriter, ZipReader } = await import('@zip.js/zip.js');
+  const reader = new ZipReader(new BlobReader(file));
+  const entries = await reader.getEntries();
+  const entry = entries.find((e) => e.filename === 'OEBPS/cover.svg');
+  if (!entry || !('getData' in entry) || !entry.getData) throw new Error('cover.svg missing');
+  const svg = await entry.getData(new TextWriter());
+  await reader.close();
+  return svg;
+}
+
+describe('convertPageToEpub — locally opened file:// page', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('network disabled in tests'));
+  });
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  test('extracts the article body from a saved .html page and drops page chrome', async () => {
+    const book = await convertPageToEpub(
+      savedHtml(),
+      'file:///Users/me/Documents/Drought%20Plan%20Review.html',
+    );
+    expect(book.title).toBe('Drought Plan Review');
+
+    const chapter = await chapterOf(book.file);
+    expect(chapter).toContain('regional water board');
+    expect(chapter).not.toContain('THE DAILY BANNER');
+    expect(chapter).not.toContain('All rights reserved');
+  });
+
+  test('converts a saved .xhtml page (XML-serialized markup)', async () => {
+    const book = await convertPageToEpub(
+      savedXhtml(),
+      'file:///Users/me/Documents/Drought%20Plan%20Review.xhtml',
+    );
+    expect(book.title).toBe('Drought Plan Review');
+    expect(book.file.size).toBeGreaterThan(0);
+    const chapter = await chapterOf(book.file);
+    expect(chapter).toContain('regional water board');
+  });
+
+  test('embeds the sibling images of a saved page', async () => {
+    // "Save Page As, Complete" writes assets to `<name>_files/`. An
+    // extension page holding file access can read those back, so they
+    // belong in the EPUB rather than degrading to alt text.
+    fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('chart.png')) {
+        return new Response(PNG, { status: 200, headers: { 'content-type': 'image/png' } });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const book = await convertPageToEpub(
+      savedHtml(),
+      'file:///Users/me/Documents/Drought%20Plan%20Review.html',
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'file:///Users/me/Documents/Drought%20Plan%20Review_files/chart.png',
+      expect.objectContaining({ redirect: 'follow' }),
+    );
+    const chapter = await chapterOf(book.file);
+    expect(chapter).toContain('src="images/');
+    expect(await entryNames(book.file)).toContain('OEBPS/images/');
+  });
+
+  test('makes no remote request while clipping a local page', async () => {
+    // The `<link rel=icon>` and the well-known favicon paths resolve to a
+    // "null" origin here; nothing about a local page should touch the net.
+    fetchSpy.mockResolvedValue(
+      new Response(PNG, { status: 200, headers: { 'content-type': 'image/png' } }),
+    );
+    await convertPageToEpub(savedHtml(), 'file:///Users/me/Documents/Drought%20Plan%20Review.html');
+    for (const call of fetchSpy.mock.calls) {
+      expect(String(call[0])).toMatch(/^file:/);
+    }
+  });
+
+  test('titles an untitled local page after its file, not its path', async () => {
+    // The path would otherwise land in the library as the book title and,
+    // via `X-Readest-Title`, on the server.
+    const untitled = `<!doctype html><html><body><article>
+      <p>${BODY}</p><p>${BODY}</p>
+    </article></body></html>`;
+    const book = await convertPageToEpub(
+      untitled,
+      'file:///Users/me/Documents/Drought%20Plan%20Review.html',
+    );
+    expect(book.title).toBe('Drought Plan Review');
+    expect(book.title).not.toContain('/Users/me');
+  });
+
+  test('falls back to the file name for the cover label (no hostname to use)', async () => {
+    const book = await convertPageToEpub(
+      savedHtml(),
+      'file:///Users/me/Documents/Drought%20Plan%20Review.html',
+    );
+    const svg = await coverOf(book.file);
+    // Without a site name the cover renders a "·" placeholder avatar and no
+    // bottom line — the decoded file name is the only meaningful label a
+    // local page has.
+    expect(svg).toContain('Drought Plan Review');
+    expect(svg).not.toContain('>·<');
+  });
+});

--- a/apps/readest-app/src/__tests__/services/send-convert-page-unified.test.ts
+++ b/apps/readest-app/src/__tests__/services/send-convert-page-unified.test.ts
@@ -119,6 +119,21 @@ describe('convertPageToEpub — clipping channel unification', () => {
     await reader.close();
   });
 
+  test('resolves relative image URLs against the page, not the calling realm', async () => {
+    // Readability rewrites relative refs against the parsed document's base
+    // URI, which `DOMParser` inherits from whoever called it — the
+    // extension's `chrome-extension://` offscreen page, the Tauri webview's
+    // `tauri://localhost`, jsdom's `http://localhost:3000`. Left alone, the
+    // same article clipped from two channels resolves its images to two
+    // different (and unfetchable) origins.
+    const html = HTML.replace('https://example.com/hero.png', 'img/hero.png');
+    await convertPageToEpub(html, URL_STR);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://example.com/articles/img/hero.png',
+      expect.objectContaining({ redirect: 'follow' }),
+    );
+  });
+
   test('re-converting the same (html, url) yields a byte-identical EPUB', async () => {
     const first = new Uint8Array(await (await convertPageToEpub(HTML, URL_STR)).file.arrayBuffer());
     const second = new Uint8Array(
@@ -126,5 +141,60 @@ describe('convertPageToEpub — clipping channel unification', () => {
     );
     expect(first.byteLength).toBe(second.byteLength);
     expect(Array.from(first.subarray(0, 256))).toEqual(Array.from(second.subarray(0, 256)));
+  });
+});
+
+/**
+ * Changing which images a clip can fetch changes the EPUB bytes, and so the
+ * import-time file hash. That is only safe because library dedup falls back
+ * to `metaHash`, which is derived from title + authors + identifier, and the
+ * identifier is `stableIdentifier(url)` rather than anything content-shaped.
+ * If that ever stops holding, a re-clip starts duplicating library entries.
+ */
+describe('convertPageToEpub — re-clip identity', () => {
+  const RELATIVE = HTML.replace('https://example.com/hero.png', 'img/hero.png');
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => pngResponse());
+  });
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  async function opfMetadata(file: File) {
+    const { BlobReader, TextWriter, ZipReader } = await import('@zip.js/zip.js');
+    const reader = new ZipReader(new BlobReader(file));
+    const entry = (await reader.getEntries()).find((e) => e.filename === 'content.opf');
+    if (!entry || !('getData' in entry) || !entry.getData) throw new Error('content.opf missing');
+    const opf = await entry.getData(new TextWriter());
+    await reader.close();
+    const pick = (tag: string) => opf.match(new RegExp(`<${tag}[^>]*>([^<]*)</${tag}>`))?.[1] ?? '';
+    return {
+      title: pick('dc:title'),
+      author: pick('dc:creator'),
+      identifier: pick('dc:identifier'),
+      language: pick('dc:language'),
+    };
+  }
+
+  test('a clip whose images newly resolve keeps its metadata hash, so it dedups instead of duplicating', async () => {
+    const { getMetadataHash } = await import('@/utils/book');
+
+    // Before: the image could not be fetched, so it was dropped.
+    fetchSpy.mockImplementation(async () => new Response('nope', { status: 404 }));
+    const dropped = await convertPageToEpub(RELATIVE, URL_STR);
+    // After: the same page, same URL, but the image now resolves and embeds.
+    fetchSpy.mockImplementation(async () => pngResponse());
+    const embedded = await convertPageToEpub(RELATIVE, URL_STR);
+
+    const a = new Uint8Array(await dropped.file.arrayBuffer());
+    const b = new Uint8Array(await embedded.file.arrayBuffer());
+    expect(a.byteLength).not.toBe(b.byteLength);
+
+    const [ma, mb] = [await opfMetadata(dropped.file), await opfMetadata(embedded.file)];
+    expect(ma).toEqual(mb);
+    expect(ma.identifier).toMatch(/^readest:/);
+    expect(getMetadataHash(ma)).toBe(getMetadataHash(mb));
   });
 });

--- a/apps/readest-app/src/services/send/conversion/assetBundler.ts
+++ b/apps/readest-app/src/services/send/conversion/assetBundler.ts
@@ -181,6 +181,40 @@ function mimeFromContentType(contentType: string | null, url: string): string {
   return 'application/octet-stream';
 }
 
+/**
+ * Whether an asset URL is worth a fetch.
+ *
+ * `http(s):` and `data:` always are. `file:` is the interesting case: an
+ * extension page holding "Allow access to file URLs" *can* read local
+ * files, which is what lets a page saved with a `<name>_files/` folder keep
+ * its images instead of degrading to alt text. That capability is also a
+ * disclosure risk, since the EPUB we build gets uploaded, so it is fenced
+ * twice:
+ *
+ *   1. The page being clipped must itself be local. A remote page pointing
+ *      an `<img>` at `file:///…` must never cause a disk read.
+ *   2. The asset must live under the page's own directory. `new URL` has
+ *      already normalized away any `..`, so a prefix test is sufficient to
+ *      keep a crafted local page from harvesting the rest of the disk. A
+ *      page sitting at the filesystem root gets nothing — its "directory"
+ *      is `/`, which would otherwise mean everything.
+ */
+function isFetchableAssetUrl(url: string, pageUrl: string): boolean {
+  if (/^(https?|data):/i.test(url)) return true;
+  if (!/^file:/i.test(url)) return false;
+  let page: URL;
+  let asset: URL;
+  try {
+    page = new URL(pageUrl);
+    asset = new URL(url);
+  } catch {
+    return false;
+  }
+  if (page.protocol !== 'file:' || asset.protocol !== 'file:') return false;
+  const dir = page.pathname.slice(0, page.pathname.lastIndexOf('/') + 1);
+  return dir.length > 1 && asset.pathname.startsWith(dir);
+}
+
 interface FetchedAsset {
   url: string;
   path: string;
@@ -313,33 +347,60 @@ export async function bundleAssets(
   // Bounded-concurrency fetch loop. `MAX_CONCURRENCY` workers pull from a
   // shared cursor so we never hammer a single origin with N requests. Each
   // fetch owns its own timeout — see `fetchAsset`.
+  //
+  // Results are parked by index rather than committed as they land, because
+  // the size budget below has to decide which images to drop and that
+  // decision must not depend on which fetch happened to win the race. A
+  // clip has to be reproducible: the same page with the same assets must
+  // produce the same EPUB bytes on every device, every time.
+  const settled = new Array<FetchedAsset | null>(uniqueUrls.length).fill(null);
+  const resolved = new Array<boolean>(uniqueUrls.length).fill(false);
+
+  // Bytes owned by the unbroken run of assets already resolved from the front
+  // of the document. Consulted only to stop dispatching once the budget is
+  // provably spent, so an image-heavy page does not download megabytes it is
+  // going to discard. The authoritative accounting is the in-order pass below,
+  // so this staying approximate cannot affect the output.
+  let prefixCursor = 0;
+  let prefixBytes = 0;
+  const settledPrefixBytes = (): number => {
+    while (prefixCursor < resolved.length && resolved[prefixCursor]) {
+      prefixBytes += settled[prefixCursor]?.bytes.byteLength ?? 0;
+      prefixCursor++;
+    }
+    return prefixBytes;
+  };
+
   let cursor = 0;
   const worker = async () => {
     while (cursor < uniqueUrls.length) {
       const i = cursor++;
       const url = uniqueUrls[i]!;
-      if (totalBytes >= MAX_TOTAL_ASSET_BYTES) {
-        missing++;
-        continue;
-      }
-      try {
-        const asset = await fetchAsset(url, pageUrl);
-        if (asset && totalBytes + asset.bytes.byteLength <= MAX_TOTAL_ASSET_BYTES) {
-          fetched.set(url, asset);
-          totalBytes += asset.bytes.byteLength;
-        } else {
-          missing++;
+      if (isFetchableAssetUrl(url, pageUrl) && settledPrefixBytes() < MAX_TOTAL_ASSET_BYTES) {
+        try {
+          settled[i] = await fetchAsset(url, pageUrl);
+        } catch (err) {
+          console.warn('[clip/bundle] image fetch failed', {
+            url,
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
-      } catch (err) {
-        missing++;
-        console.warn('[clip/bundle] image fetch failed', {
-          url,
-          error: err instanceof Error ? err.message : String(err),
-        });
       }
+      resolved[i] = true;
     }
   };
   await Promise.all(Array.from({ length: MAX_CONCURRENCY }, worker));
+
+  // Apply the budget strictly in document order.
+  for (let i = 0; i < uniqueUrls.length; i++) {
+    const asset = settled[i];
+    if (!asset || totalBytes + asset.bytes.byteLength > MAX_TOTAL_ASSET_BYTES) {
+      missing++;
+      continue;
+    }
+    fetched.set(uniqueUrls[i]!, asset);
+    totalBytes += asset.bytes.byteLength;
+  }
   console.log('[clip/bundle] done', {
     fetched: fetched.size,
     missing,

--- a/apps/readest-app/src/services/send/conversion/convertToEpub.ts
+++ b/apps/readest-app/src/services/send/conversion/convertToEpub.ts
@@ -156,6 +156,29 @@ async function htmlToBook(
   return { file, title, author };
 }
 
+/**
+ * Parse a captured page into a document Readability can extract from.
+ *
+ * `DOMParser` gives the new document the *calling realm's* base URI —
+ * `chrome-extension://<id>/offscreen.html` in the extension, `tauri://…`
+ * in the desktop webview — and Readability rewrites every relative
+ * `href`/`src` against it. Injecting the page's own URL as `<base>` makes
+ * those resolve to where the assets actually live: identical absolute URLs
+ * on every clip channel (which is what keeps the EPUBs byte-identical),
+ * and `file://` siblings for a page opened from disk, which the asset
+ * bundler then skips instead of fetching from the extension's origin.
+ *
+ * `sanitizeForParsing` strips any `<base>` the page itself shipped, so
+ * there is never an author-supplied one to preserve.
+ */
+function parsePageDocument(html: string, pageUrl: string): Document {
+  const doc = new DOMParser().parseFromString(sanitizeForParsing(html), 'text/html');
+  const base = doc.createElement('base');
+  base.setAttribute('href', pageUrl);
+  doc.head.insertBefore(base, doc.head.firstChild);
+  return doc;
+}
+
 interface RuleExtracted {
   content: string;
   title?: string;
@@ -294,11 +317,32 @@ function extractSiteName(doc: Document, pageUrl: string): string {
     const value = doc.querySelector(sel)?.getAttribute('content')?.trim();
     if (value) return value;
   }
+  return hostnameFallback(pageUrl);
+}
+
+/** Decoded file name (no extension) of a `file://` URL — what stands in for
+ *  the hostname when the "page" came off the user's own disk. */
+function fileNameFromUrl(pageUrl: string): string {
   try {
-    return new URL(pageUrl).hostname.replace(/^www\./, '');
+    const last = new URL(pageUrl).pathname.split('/').pop() ?? '';
+    return decodeURIComponent(last)
+      .replace(/\.[^.]+$/, '')
+      .trim();
   } catch {
     return '';
   }
+}
+
+/** Last-resort title for a page that declares none. A remote page has only
+ *  its URL to offer; a local one has a file name, which beats putting the
+ *  user's absolute path in the library (and in the upload headers). */
+function titleFallback(pageUrl: string): string {
+  try {
+    if (new URL(pageUrl).protocol === 'file:') return fileNameFromUrl(pageUrl) || pageUrl;
+  } catch {
+    /* unparseable — the raw string is all we have */
+  }
+  return pageUrl;
 }
 
 /**
@@ -340,7 +384,9 @@ async function buildArticleCover(
   const metaImageUrl = ruleImageUrl
     ? null
     : resolveMetaImage(doc, META_FALLBACK.authorImage, pageUrl);
-  const candidateImageUrl = ruleImageUrl || metaImageUrl;
+  // Only http(s) is reachable — on a page clipped from disk both of these
+  // resolve to unfetchable `file://` siblings.
+  const candidateImageUrl = [ruleImageUrl, metaImageUrl].find((u) => u && /^https?:/i.test(u));
   if (candidateImageUrl) {
     authorImage =
       (await fetchAuthorImage(candidateImageUrl, pageUrl).catch(() => null)) ?? undefined;
@@ -383,7 +429,11 @@ function pickImageUrlFromSelector(doc: Document, selector: string, pageUrl: stri
 
 function hostnameFallback(pageUrl: string): string {
   try {
-    return new URL(pageUrl).hostname.replace(/^www\./, '');
+    const parsed = new URL(pageUrl);
+    // A page opened from disk has no hostname — label the cover with the
+    // file name instead, or the avatar degrades to a "·" placeholder.
+    if (parsed.protocol === 'file:') return fileNameFromUrl(pageUrl);
+    return parsed.hostname.replace(/^www\./, '');
   } catch {
     return '';
   }
@@ -461,7 +511,7 @@ export async function convertPageToEpub(html: string, url: string): Promise<Conv
       title: ruleResult?.title || null,
     });
     if (ruleResult && ruleText.length >= 400) {
-      const title = ruleResult.title || extractHtmlTitle(html, url);
+      const title = ruleResult.title || extractHtmlTitle(html, titleFallback(url));
       const byline = ruleResult.byline || '';
       const bundle = await bundleAssets(ruleResult.content, url);
       const cover = await buildArticleCover(html, url, title, byline, rule);
@@ -478,8 +528,7 @@ export async function convertPageToEpub(html: string, url: string): Promise<Conv
 
   let parsed: { title?: string | null; content?: string | null; byline?: string | null } | null;
   try {
-    const doc = new DOMParser().parseFromString(sanitizeForParsing(html), 'text/html');
-    parsed = new Readability(doc).parse();
+    parsed = new Readability(parsePageDocument(html, url)).parse();
   } catch (err) {
     console.warn('[clip/page] readability threw', {
       error: err instanceof Error ? err.message : String(err),
@@ -534,7 +583,7 @@ export async function convertPageToEpub(html: string, url: string): Promise<Conv
   const title =
     parsed.title?.trim() ||
     (metaDoc ? pickMetaContent(metaDoc, META_FALLBACK.title) : null) ||
-    extractHtmlTitle(html, url);
+    extractHtmlTitle(html, titleFallback(url));
   const byline =
     parsed.byline?.trim() ||
     (metaDoc ? pickMetaContent(metaDoc, META_FALLBACK.byline) : null) ||
@@ -598,8 +647,7 @@ export async function convertToEpub(input: ConvertInput): Promise<ConvertedBook>
     case 'article': {
       let parsed: { title?: string | null; content?: string | null; byline?: string | null } | null;
       try {
-        const doc = new DOMParser().parseFromString(sanitizeForParsing(input.html), 'text/html');
-        parsed = new Readability(doc).parse();
+        parsed = new Readability(parsePageDocument(input.html, input.url)).parse();
       } catch (err) {
         throw new ConversionError(`Could not extract article: ${String(err)}`, 'parse_failed');
       }

--- a/apps/readest-app/src/services/send/conversion/faviconFetcher.ts
+++ b/apps/readest-app/src/services/send/conversion/faviconFetcher.ts
@@ -167,10 +167,13 @@ export async function fetchBestFavicon(
   const candidates = extractIconCandidates(doc, pageUrl);
 
   // Always check the well-known fallback paths last — some sites omit the
-  // <link> tag but still host /apple-touch-icon.png.
+  // <link> tag but still host /apple-touch-icon.png. A `file://` page has
+  // no real origin (`new URL(...).origin` is the string "null"), so guard
+  // on the scheme rather than on emptiness.
   let origin: string;
   try {
-    origin = new URL(pageUrl).origin;
+    const parsed = new URL(pageUrl);
+    origin = /^https?:$/i.test(parsed.protocol) ? parsed.origin : '';
   } catch {
     origin = '';
   }
@@ -181,10 +184,12 @@ export async function fetchBestFavicon(
   }
 
   // De-dupe so a `<link rel="apple-touch-icon" href="/apple-touch-icon.png">`
-  // doesn't compete with the same URL added as a hosted fallback.
+  // doesn't compete with the same URL added as a hosted fallback. Drop any
+  // candidate we can't actually fetch — a page opened from disk declares
+  // its icon as a `file://` sibling, which no browser lets us read.
   const seen = new Set<string>();
   const ordered = candidates.filter((c) => {
-    if (seen.has(c.url)) return false;
+    if (!/^https?:/i.test(c.url) || seen.has(c.url)) return false;
     seen.add(c.url);
     return true;
   });


### PR DESCRIPTION
## What

Makes Send to Readest work on a page the user opened from disk: a saved web page, an exported HTML report, a loose `.xhtml` chapter. Previously the extension refused any tab that was not `http(s)`.

## Why it did not work

Four independent gates, each fatal on its own:

| Gate | Symptom |
|---|---|
| `popup.ts` / `service-worker.ts` both tested `/^https?:/i` | "This page cannot be clipped", Send disabled |
| Chrome's per-extension **Allow access to file URLs** toggle | `chrome.scripting.executeScript` fails with an opaque host-permission error; `host_permissions` alone is not enough |
| `/api/send/inbox/file` 400s on a non-`http(s)` `X-Readest-Url` | upload rejected even when everything upstream worked |
| The asset bundler only ever fetched `http(s)`/`data:` | local images had nowhere to come from |

## Changes

**Extension** — new `src/lib/localPage.ts` (scheme test, file-access check, settings deep link). The popup accepts `file:` and, when access is off, disables Send and offers a button straight to `chrome://extensions/?id=<id>` rather than letting the clip fail opaquely. The service worker mirrors the gate. `uploadEpub` sends `X-Readest-Url` only for `http(s)`, which doubles as privacy: an absolute path out of someone's home directory should not reach the server.

The access check **fails open** — `chrome.extension` is trimmed under MV3, so a context that cannot ask surfaces the real error instead of a false "missing permission".

**Shared converter** — a local page keeps its images. An extension page holding file access *can* read `file://` URLs, so a "Save Page As, Complete" keeps its `<name>_files/` assets. (A content script in the page cannot — `fetch` and `XMLHttpRequest` are both blocked and the rendered `<img>` taints a canvas — so the bundler is the only route.) `fetchBestFavicon` drops unfetchable candidates and no longer builds `"null/favicon.ico"` out of a `file://` page's `"null"` origin. A local page with no `<title>` is named after its file rather than its absolute path, and the cover label falls back to the file name instead of a placeholder avatar.

`.xhtml` needed no converter work: `DOMParser` handles Chrome's XML serialization. There are tests pinning that.

### Reading local files is fenced twice

The EPUB we build gets uploaded, so this capability is deliberately narrow:

1. **The clipped page must itself be `file://`.** A remote page pointing an `<img>` at the disk reads nothing.
2. **The asset must sit under that page's own directory.** `new URL` has already normalized away any `..`, so a prefix test keeps a crafted local page from harvesting the rest of the disk. A page at the filesystem root gets nothing, since its "directory" would be `/`.

Both rules have unit tests, and rule 1 is also verified end to end in a real browser (below).

## Determinism

A clip of one URL, or of one offline page, has to produce the same EPUB with the same hash every time. Two bugs broke that; both are fixed here.

**1. Base URI.** `DOMParser` gives the parsed document the **calling realm's** base URI, and Readability rewrites every relative `href`/`src` against it. So relative image paths resolved to `chrome-extension://<id>/...` in the extension and `tauri://localhost/...` on desktop. Those images were silently dropped, and the same article clipped from two channels did **not** produce the byte-identical EPUB that `convertPageToEpub` documents. `parsePageDocument()` now injects `<base href>` from the page URL before Readability runs.

**2. Asset budget applied in completion order.** Which images survived a 30 MB overrun depended on which download won the race — identical inputs, different bytes, different hash. Results are now parked by index and the budget applied strictly in document order, so an overrun always truncates the tail. Dispatch still stops early once the settled document prefix has spent the budget, so an image-heavy page does not download bytes it will discard. The regression test forces the first image to resolve last; it fails on the old code with `[1,2,3,4,5,6]` instead of `[0,1,2,3,4,5]`.

What remains non-deterministic is input, not code: a transient fetch failure, or the page's own HTML differing between loads. That is exactly why library identity rests on the URL-derived identifier rather than on byte equality.

> [!NOTE]
> This changes remote clips too: a page with relative image paths now produces different (correct) EPUB bytes. It does **not** duplicate library entries. Dedup falls back to `metaHash` = `md5(title | authors | identifiers)`, and the identifier is `stableIdentifier(url)`, which nothing here touches — so `importBook` misses on `byHash`, hits on `byMetaKey`, and updates the existing entry in place (`existingBook.hash = hash`, config migrated to the new directory). `books.push` runs only when there is no existing book. What the user sees is the normal `byMetaKey` behaviour for any re-clip of changed content: the entry re-uploads (`uploadedAt` cleared) and its title/author are refreshed from the file, so a manual rename would be overwritten. Pinned by a test that asserts differing bytes but an identical `getMetadataHash`.

## Verification

Unit tests written before each fix, each confirmed to fail without it (including reverting `titleFallback` to check it was not passing for the wrong reason).

One caveat for anyone editing the budget-determinism test: the first version of it **passed on the buggy code**, because staggered fetch delays let the scheduler accidentally produce document order. It only becomes a real test once image 0 is forced to resolve well after all the others. A race test that does not reliably lose is not a test.

Then driven in a **real Chromium** with the extension loaded via Playwright, using the actual MV3 service worker, a real `file://` tab and a mock inbox endpoint:

- **A saved page clips end to end.** Unzipped: article body present; nav/banner/footer gone; the `data:` image embedded; the `<name>_files/` sibling embedded with bytes **identical** to the source file (`cmp` clean); cover labelled from the file name; no `X-Readest-Url`.
- **Security:** a remote page referencing `file:///…` uploads with no image entry and no leaked bytes.
- `chrome.extension.isAllowedFileSchemeAccess` **is** callable from an MV3 service worker and returns a real boolean.
- A local `.xhtml` reports `contentType: application/xhtml+xml` and serializes via `outerHTML` as XML with `xmlns` and self-closed tags.
- Denied path: the real service worker reports `{phase:'error', code:'restricted-page', message:'Readest needs permission to read local files.'}`.
- Remote clip still uploads and still sends `X-Readest-Url`.
- **Before/after on the base-URI fix:** `../img/hero.png` on a page served at `/posts/article` embeds with the fix; reverting the `<base>` injection and rebuilding drops it silently.

`pnpm test` 8665 passed / 16 skipped - `pnpm lint` clean - `pnpm format:check` clean - `pnpm build-browser-ext` compiles - extension `i18n:check` exits 0 (2 new strings translated across all 33 locales). No Rust touched.

## Known limitation

The favicon path stays `http(s)`-only on purpose, so a saved page does not carry its real site icon onto the generated cover; the file-name label and initial stand in. Cover art is cosmetic, and article images were the thing worth widening the blast radius for. Extending `fetchBestFavicon` under the same two fences would be a small follow-up if it's wanted.

## Not verified

Chrome's own enforcement (that it blocks the inject when the toggle is off) is not reproducible under `--load-extension`, which re-installs with the `ALLOW_FILE_ACCESS` creation flag on every launch and overwrites the pref. The denied path was exercised by stubbing the verdict in the live service worker, which covers our guard but not Chrome's. A 30-second manual check would close it: load `extensions/send-to-readest/dist` unpacked, leave **Allow access to file URLs** off, open the popup on a local page, and confirm the prompt appears instead of a failed clip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


