### PR TITLE
fix(library): stop watched-folder scans from blocking the main thread

### DIFF
--- a/apps/readest-app/src-tauri/src/dir_scanner.rs
+++ b/apps/readest-app/src-tauri/src/dir_scanner.rs
@@ -10,7 +10,7 @@ pub struct ScannedFile {
 }
 
 #[tauri::command]
-pub fn read_dir(
+pub async fn read_dir(
     app: AppHandle,
     path: String,
     recursive: bool,
@@ -23,13 +23,28 @@ pub fn read_dir(
         return Err("Permission denied: Path not in filesystem scope".to_string());
     }
 
+    // The walk stats every matching file; on a large watched folder that is
+    // thousands of syscalls. A sync command would run them inline on the IPC
+    // dispatch thread and freeze the UI on every focus-triggered scan
+    // (issue #5494) — offload to the blocking pool like the parsers do.
+    tauri::async_runtime::spawn_blocking(move || read_dir_sync(&path, recursive, &extensions))
+        .await
+        .map_err(|e| format!("join error: {e}"))?
+}
+
+fn read_dir_sync(
+    path: &str,
+    recursive: bool,
+    extensions: &[String],
+) -> Result<Vec<ScannedFile>, String> {
+    let path_buf = std::path::PathBuf::from(path);
     let mut files = Vec::new();
 
     let normalized_extensions: Vec<String> =
         extensions.iter().map(|ext| ext.to_lowercase()).collect();
 
     if recursive {
-        for entry_result in WalkDir::new(&path).into_iter() {
+        for entry_result in WalkDir::new(path).into_iter() {
             match entry_result {
                 Ok(entry) => {
                     if entry.file_type().is_file() {

--- a/apps/readest-app/src/__tests__/services/app-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/app-service.test.ts
@@ -323,8 +323,13 @@ describe('BaseAppService', () => {
 
     test('readDirectory delegates to fs.readDir', async () => {
       const result = await service.readDirectory('dir', 'Books');
-      expect(mockFs.readDir).toHaveBeenCalledWith('dir', 'Books');
+      expect(mockFs.readDir).toHaveBeenCalledWith('dir', 'Books', undefined);
       expect(result).toEqual([{ path: 'a.txt', size: 10 }]);
+    });
+
+    test('readDirectory forwards the extensions filter to fs.readDir', async () => {
+      await service.readDirectory('dir', 'Books', ['epub', 'mobi']);
+      expect(mockFs.readDir).toHaveBeenCalledWith('dir', 'Books', ['epub', 'mobi']);
     });
 
     test('getImageURL delegates to fs', async () => {

--- a/apps/readest-app/src/__tests__/utils/join-scanned-path.test.ts
+++ b/apps/readest-app/src/__tests__/utils/join-scanned-path.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+
+import { joinScannedPath } from '@/utils/path';
+import { normalizeFilePathForIndex } from '@/services/bookService';
+
+/**
+ * Issue #5494: the watched-folder scan joined every scanned relative path back
+ * to its folder root with the async Tauri `join()` — one IPC round-trip per
+ * file, ~1200 per window focus on a Calibre-style 400-book folder, all queued
+ * on the same main thread the recursive scan was already blocking. The join is
+ * pure string work: the scan returns host-separator relative paths and the
+ * root comes from the folder picker in native form. `joinScannedPath` pins
+ * that equivalence.
+ */
+describe('joinScannedPath', () => {
+  it('joins posix roots with forward slashes', () => {
+    expect(joinScannedPath('/lib/watched', 'SciFi/dune.epub')).toBe('/lib/watched/SciFi/dune.epub');
+    expect(joinScannedPath('/lib/watched', 'loose.epub')).toBe('/lib/watched/loose.epub');
+  });
+
+  it('joins windows roots with backslashes', () => {
+    expect(joinScannedPath('C:\\Books', 'SciFi\\dune.epub')).toBe('C:\\Books\\SciFi\\dune.epub');
+  });
+
+  it('does not double up separators when the root has a trailing one', () => {
+    expect(joinScannedPath('/lib/watched/', 'dune.epub')).toBe('/lib/watched/dune.epub');
+    expect(joinScannedPath('C:\\Books\\', 'dune.epub')).toBe('C:\\Books\\dune.epub');
+  });
+
+  it('produces the same byFilePath index key as a native-join path', () => {
+    // Membership against `collectKnownSourcePaths` is what keeps the scan from
+    // re-importing on every focus — the cheap join must key identically to the
+    // `filePath` values stored by earlier native-join imports.
+    const stored = normalizeFilePathForIndex('C:\\Books\\SciFi\\dune.epub', 'windows');
+    const scanned = normalizeFilePathForIndex(
+      joinScannedPath('C:\\Books', 'SciFi\\dune.epub'),
+      'windows',
+    );
+    expect(scanned).toBe(stored);
+  });
+});

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -28,7 +28,7 @@ import { ProgressPayload } from '@/utils/transfer';
 import { throttle } from '@/utils/throttle';
 import { transferManager } from '@/services/transferManager';
 import { isReadestCloudStorageActive } from '@/services/sync/cloudSyncProvider';
-import { getFilename, getFolderImportGroupName, joinPaths } from '@/utils/path';
+import { getFilename, getFolderImportGroupName, joinScannedPath } from '@/utils/path';
 import { parseOpenWithFiles } from '@/helpers/openWith';
 import { isTauriAppPlatform, isWebAppPlatform } from '@/services/environment';
 import { checkForAppUpdates, checkAppReleaseNotes } from '@/helpers/updater';
@@ -304,6 +304,11 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
   // Tracks paths that failed to import in this session so auto-import does not
   // re-attempt (and re-toast) them on every subsequent folder scan.
   const autoImportFailedPathsRef = useRef<Set<string>>(new Set());
+  // Folders whose fs/asset scopes were already granted this session. Each
+  // `allowPathsInScopes` call makes tauri-plugin-persisted-scope rewrite its
+  // whole state file on the main thread, so grant once, not on every focus
+  // scan (issue #5494).
+  const autoImportGrantedFoldersRef = useRef<Set<string>>(new Set());
 
   const getScrollKey = (group: string) => `library-scroll-${group || 'all'}`;
 
@@ -988,14 +993,15 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     const newFiles: SelectedFile[] = [];
     for (const folder of folders) {
       try {
-        await appService.allowPathsInScopes?.([folder], true);
-        const items = await appService.readDirectory(folder, 'None');
-        const entries = await Promise.all(
-          items.map(async (item) => ({
-            fullPath: await joinPaths(folder, item.path),
-            size: item.size,
-          })),
-        );
+        if (!autoImportGrantedFoldersRef.current.has(folder)) {
+          await appService.allowPathsInScopes?.([folder], true);
+          autoImportGrantedFoldersRef.current.add(folder);
+        }
+        const items = await appService.readDirectory(folder, 'None', SUPPORTED_BOOK_EXTS);
+        const entries = items.map((item) => ({
+          fullPath: joinScannedPath(folder, item.path),
+          size: item.size,
+        }));
         const fresh = selectNewImportableFiles(entries, {
           extensions: SUPPORTED_BOOK_EXTS,
           minSizeBytes: AUTO_IMPORT_MIN_SIZE_BYTES,
@@ -1589,7 +1595,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     const minSizeBytes = Math.max(0, Math.floor(result.minSizeKB)) * 1024;
     let files;
     try {
-      files = await appService.readDirectory(result.directory, 'None');
+      files = await appService.readDirectory(result.directory, 'None', exts);
     } catch (e) {
       // readDirectory can reject for a few related reasons:
       //   - iOS handed us a virtual / file-provider path that the OS
@@ -1619,18 +1625,18 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
       });
       return;
     }
+    // Re-filter by extension because the JS fallback of readDirectory ignores
+    // the extensions argument (only the native Rust walk filters in-scan).
     const filtered = files.filter((file) => {
       const ext = file.path.split('.').pop()?.toLowerCase() || '';
       if (!exts.includes(ext)) return false;
       if (minSizeBytes > 0 && file.size < minSizeBytes) return false;
       return true;
     });
-    const entries = await Promise.all(
-      filtered.map(async (file) => ({
-        fullPath: await joinPaths(result.directory, file.path),
-        size: file.size,
-      })),
-    );
+    const entries = filtered.map((file) => ({
+      fullPath: joinScannedPath(result.directory, file.path),
+      size: file.size,
+    }));
     // Same mapping the auto-import scan uses, so a folder's later scans group
     // newly-found books exactly like this import does.
     const toImportFiles = toWatchedFolderImports(result.directory, entries, result.flatten);

--- a/apps/readest-app/src/services/appService.ts
+++ b/apps/readest-app/src/services/appService.ts
@@ -220,8 +220,8 @@ export abstract class BaseAppService implements AppService {
     return prefix ? `${prefix}/${path}` : path;
   }
 
-  async readDirectory(path: string, base: BaseDir): Promise<FileItem[]> {
-    return await this.fs.readDir(path, base);
+  async readDirectory(path: string, base: BaseDir, extensions?: string[]): Promise<FileItem[]> {
+    return await this.fs.readDir(path, base, extensions);
   }
 
   async exists(path: string, base: BaseDir): Promise<boolean> {

--- a/apps/readest-app/src/services/nativeAppService.ts
+++ b/apps/readest-app/src/services/nativeAppService.ts
@@ -459,7 +459,7 @@ export const nativeFileSystem: FileSystem = {
       }
     }
   },
-  async readDir(path: string, base: BaseDir) {
+  async readDir(path: string, base: BaseDir, extensions?: string[]) {
     const { fp, baseDir } = this.resolvePath(path, base);
 
     const getRelativePath = (filePath: string, basePath: string): string => {
@@ -473,13 +473,17 @@ export const nativeFileSystem: FileSystem = {
       return relativePath;
     };
 
-    // Use Rust WalkDir for massive performance gain on absolute paths
+    // Use Rust WalkDir for massive performance gain on absolute paths.
+    // `extensions` filters inside the walk, so non-matching files (e.g. the
+    // covers and metadata sidecars of a Calibre-style folder) are neither
+    // stat'ed nor serialized over IPC. The JS fallback below ignores the
+    // filter — callers that pass it must still tolerate extra entries.
     if (!baseDir || baseDir === 0) {
       try {
         const files = await invoke<{ path: string; size: number }[]>('read_dir', {
           path: fp,
           recursive: true,
-          extensions: ['*'],
+          extensions: extensions?.length ? extensions : ['*'],
         });
 
         return files.map((file) => ({

--- a/apps/readest-app/src/types/system.ts
+++ b/apps/readest-app/src/types/system.ts
@@ -61,7 +61,7 @@ export interface FileSystem {
   readFile(path: string, base: BaseDir, mode: 'text' | 'binary'): Promise<string | ArrayBuffer>;
   writeFile(path: string, base: BaseDir, content: string | ArrayBuffer | File): Promise<void>;
   removeFile(path: string, base: BaseDir): Promise<void>;
-  readDir(path: string, base: BaseDir): Promise<FileItem[]>;
+  readDir(path: string, base: BaseDir, extensions?: string[]): Promise<FileItem[]>;
   createDir(path: string, base: BaseDir, recursive?: boolean): Promise<void>;
   removeDir(path: string, base: BaseDir, recursive?: boolean): Promise<void>;
   exists(path: string, base: BaseDir): Promise<boolean>;
@@ -133,7 +133,7 @@ export interface AppService {
   getCachedImageUrl(pathOrUrl: string): Promise<string>;
   selectDirectory(mode: SelectDirectoryMode): Promise<string>;
   selectFiles(name: string, extensions: string[]): Promise<string[]>;
-  readDirectory(path: string, base: BaseDir): Promise<FileItem[]>;
+  readDirectory(path: string, base: BaseDir, extensions?: string[]): Promise<FileItem[]>;
   /**
    * Best-effort: extend the Tauri `fs_scope` and `asset_protocol_scope`
    * to cover the given paths. No-op on web. Used after a directory or

--- a/apps/readest-app/src/utils/path.ts
+++ b/apps/readest-app/src/utils/path.ts
@@ -45,3 +45,16 @@ export const getFolderImportGroupName = (filePath: string, basePath: string) => 
 export const joinPaths = async (...paths: string[]) => {
   return await join(...paths);
 };
+
+/**
+ * Join a folder root with a relative path returned by a directory scan, using
+ * the root's own separator style. Equivalent to {@link joinPaths} for these
+ * inputs (native-form root from the folder picker, host-separator relative
+ * path from the scan) but pure string work — no IPC round-trip. That matters
+ * when the watched-folder scan joins hundreds of paths on every window focus
+ * (issue #5494).
+ */
+export const joinScannedPath = (root: string, relativePath: string) => {
+  const sep = root.includes('\\') ? '\\' : '/';
+  return root.replace(/[\\/]+$/, '') + sep + relativePath;
+};


### PR DESCRIPTION
Fixes #5494

## Problem

With a few hundred books in a watched folder, the library becomes sluggish and books are hard to open reliably. The auto-import scan re-runs on **every window focus**, and it had four compounding costs — the worst being that nearly all of it executed on the main IPC dispatch thread, the same thread every book-open / file-exists probe queues behind:

1. **`dir_scanner::read_dir` was a sync Tauri command** — the entire recursive `WalkDir` plus one `stat` syscall per file ran inline on the IPC thread, freezing the UI on every focus. It was the only heavy command in the repo not using `spawn_blocking` (cf. `epub_parser.rs`).
2. **The scan requested `extensions: ['*']`** — a Calibre-style tree holds ~3× files vs books (`cover.jpg`, `metadata.opf` per book), all of which were stat'ed, serialized over IPC, and filtered in JS.
3. **One `plugin:path|join` IPC round-trip per returned file** (~1200 per focus for a 400-book tree) before any filtering, each handled on the already-blocked main thread.
4. **`allowPathsInScopes` on every scan** — each grant makes `tauri-plugin-persisted-scope` rewrite its whole state file synchronously.

## Changes

- Make `read_dir` `async` and offload the walk to `tauri::async_runtime::spawn_blocking`.
- Plumb an optional `extensions` filter through `readDirectory`/`FileSystem.readDir` down to the Rust walk, so non-book files are neither stat'ed nor returned. Both the auto-import scan and the manual folder import pass their extension lists; callers still post-filter since the JS fallback ignores the hint.
- Add pure `joinScannedPath` helper and use it in both scan paths — equivalent output to the async `join()` for these inputs (unit tests pin the `byFilePath`-key equivalence, including Windows separators) with zero IPC.
- Grant watched-folder fs scopes once per session instead of on every scan.

Steady state, a focus scan is now one async IPC call per watched folder, with the walk off the main thread.

## Verification

- New unit tests for `joinScannedPath` (posix/windows separators, trailing-separator roots, index-key equivalence with stored native-join paths); full suite, Biome + tsgo, `cargo fmt/clippy/test` all pass.
- Live-tested the release build on Linux with a 400-book watched folder in nested subfolders + 800 sidecar files (1200 total): initial auto-import of all 400 books completes in ~12 s with the UI responsive throughout; a focus-triggered rescan detects and imports a newly added book ~6 s after refocus (incl. the 800 ms debounce); subfolder groups (#5423 behavior) preserved; opening in-place books from the watched folder works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)