### PR TITLE
fix(reader): keep the reading ruler anchored to its text across repagination

### DIFF
--- a/apps/readest-app/src/__tests__/components/ReadingRuler.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ReadingRuler.test.tsx
@@ -561,6 +561,73 @@ describe('ReadingRuler', () => {
     });
   });
 
+  // Regression: issue #5491 — resizing repaginates the book and fires a relocate
+  // with a new location; the ruler used to treat that as a page turn and snap to
+  // the first/last line group of the page. It must instead re-attach to the same
+  // text via the anchor captured when the band was placed.
+  it('re-anchors the band to the same text after a resize reflow', async () => {
+    // The anchored text's line: at 300 before the reflow, at 600 after.
+    const anchorRect = { top: 300, bottom: 340, left: 50, right: 750, width: 700, height: 40 };
+    const doc: Record<string, unknown> = {};
+    const anchorRange = {
+      startContainer: { nodeType: 3, length: 20, ownerDocument: doc },
+      startOffset: 0,
+      setStart: () => {},
+      setEnd: () => {},
+      getClientRects: () => [anchorRect],
+    };
+    Object.assign(doc, {
+      defaultView: {},
+      caretRangeFromPoint: () => anchorRange,
+    });
+    const makeRange = (rects: RulerTestRect[]) => ({
+      startContainer: { ownerDocument: doc },
+      getClientRects: () => rects,
+    });
+
+    mockProgress = {
+      range: makeRange(makeLineRects(9, 100, 40)),
+      location: 'epubcfi(/6/2!/4/2)',
+      fraction: 0.1,
+      pageinfo: { current: 4 },
+    };
+    const props = {
+      bookKey: 'book-1',
+      isVertical: false,
+      rtl: false,
+      lines: 2,
+      position: 33,
+      opacity: 0.5,
+      color: 'transparent' as const,
+      bookFormat: 'EPUB' as BookFormat,
+      viewSettings,
+      gridInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    };
+
+    const { container, rerender } = render(<ReadingRuler {...props} />);
+    const rulerTop = () =>
+      parseFloat((container.querySelector('.ruler') as HTMLDivElement).style.top);
+    // Mount snaps to the line at 300 -> block 300..440 -> centered at 37%.
+    expect(rulerTop()).toBeCloseTo(37, 1);
+
+    // Reflow: the same text now lives at 600. The location CFI changes and the
+    // fraction drifts down, which the old code read as a backward page turn.
+    anchorRect.top = 600;
+    anchorRect.bottom = 640;
+    mockProgress = {
+      range: makeRange(makeLineRects(9, 100, 40)),
+      location: 'epubcfi(/6/2!/4/18)',
+      fraction: 0.09,
+      pageinfo: { current: 4 },
+    };
+    rerender(<ReadingRuler {...props} />);
+
+    await waitFor(() => {
+      // Band re-attaches to the anchored text: block 600..740 -> 67%.
+      expect(rulerTop()).toBeCloseTo(67, 1);
+    });
+  });
+
   it('still snaps the ruler to lines when advancing by click in scrolled mode', async () => {
     const lineRects = makeLineRects(50, 100, 40);
     mockProgress = { range: {}, location: 'page-1', fraction: 0.1, pageinfo: { current: 0 } };

--- a/apps/readest-app/src/__tests__/utils/readingRuler.test.ts
+++ b/apps/readest-app/src/__tests__/utils/readingRuler.test.ts
@@ -10,6 +10,8 @@ import {
   getReadingRulerMoveDirection,
   isReadingRulerMoveKey,
   snapReadingRulerColumns,
+  snapReadingRulerColumnsToAnchor,
+  snapReadingRulerToAnchor,
   snapReadingRulerToLines,
   stepReadingRulerPosition,
 } from '@/app/reader/utils/readingRuler';
@@ -371,5 +373,85 @@ describe('snapReadingRulerColumns', () => {
 
   it('returns null when there are no columns', () => {
     expect(snapReadingRulerColumns(0, 0, 36, 2, 'forward', [])).toBeNull();
+  });
+});
+
+// Anchor-based re-snapping (issue #5491): after a resize/reflow the band is
+// re-attached to the line containing the anchored text's new position, instead
+// of drifting to whatever text now sits at the band's old screen position.
+describe('snapReadingRulerToAnchor', () => {
+  const boxes = [
+    { start: 100, end: 140 },
+    { start: 200, end: 240 },
+    { start: 300, end: 340 },
+    { start: 400, end: 440 },
+  ];
+
+  it('returns the block of N lines starting at the line containing the anchor', () => {
+    expect(snapReadingRulerToAnchor(220, 2, boxes)).toEqual({ start: 200, end: 340 });
+  });
+
+  it('clamps the block at the last line', () => {
+    expect(snapReadingRulerToAnchor(420, 2, boxes)).toEqual({ start: 400, end: 440 });
+  });
+
+  it('snaps to the nearest line when the anchor sits just outside it', () => {
+    // 10px above the 100..140 line: within half a line height (20) of it.
+    expect(snapReadingRulerToAnchor(150, 1, boxes)).toEqual({ start: 100, end: 140 });
+  });
+
+  it('returns null when the anchor is far from any line', () => {
+    // 170 is 30px away from both surrounding lines, beyond the 20px tolerance.
+    expect(snapReadingRulerToAnchor(170, 1, boxes)).toBeNull();
+    expect(snapReadingRulerToAnchor(600, 1, boxes)).toBeNull();
+  });
+
+  it('returns null when there are no lines', () => {
+    expect(snapReadingRulerToAnchor(100, 1, [])).toBeNull();
+  });
+});
+
+describe('snapReadingRulerColumnsToAnchor', () => {
+  const columns = [
+    {
+      left: 40,
+      right: 360,
+      lines: [
+        { start: 100, end: 140 },
+        { start: 200, end: 240 },
+      ],
+    },
+    {
+      left: 440,
+      right: 760,
+      lines: [
+        { start: 100, end: 140 },
+        { start: 200, end: 240 },
+      ],
+    },
+  ];
+
+  it('snaps within the column that contains the anchor point', () => {
+    expect(snapReadingRulerColumnsToAnchor(120, 500, 1, columns)).toEqual({
+      columnIndex: 1,
+      start: 100,
+      end: 140,
+    });
+  });
+
+  it('falls back to the nearest column when the anchor is in the gutter', () => {
+    expect(snapReadingRulerColumnsToAnchor(220, 380, 1, columns)).toEqual({
+      columnIndex: 0,
+      start: 200,
+      end: 240,
+    });
+  });
+
+  it('returns null when there are no columns', () => {
+    expect(snapReadingRulerColumnsToAnchor(120, 500, 1, [])).toBeNull();
+  });
+
+  it('returns null when the anchor misses every line in the column', () => {
+    expect(snapReadingRulerColumnsToAnchor(600, 500, 1, columns)).toBeNull();
   });
 });

--- a/apps/readest-app/src/app/reader/components/ReadingRuler.tsx
+++ b/apps/readest-app/src/app/reader/components/ReadingRuler.tsx
@@ -20,6 +20,8 @@ import {
   ReadingRulerColumn,
   ReadingRulerLineBox,
   snapReadingRulerColumns,
+  snapReadingRulerColumnsToAnchor,
+  snapReadingRulerToAnchor,
   snapReadingRulerToLines,
   stepReadingRulerPosition,
 } from '../utils/readingRuler';
@@ -49,6 +51,47 @@ const mapRangeRectsToOverlay = (range: Range, containerRect: DOMRect): OverlayRe
     width: r.width,
     height: r.height,
   }));
+};
+
+type CaretDoc = Document & {
+  caretRangeFromPoint?: (x: number, y: number) => Range | null;
+  caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null;
+};
+
+// Hit-test a top-document point against each content document and return a
+// one-character Range on the text there, or null when the point hits no text.
+// Coordinates are converted into each iframe's own space via its frame offset.
+const caretRangeAtPoint = (docs: Document[], x: number, y: number): Range | null => {
+  for (const doc of docs) {
+    const frame = doc.defaultView?.frameElement?.getBoundingClientRect();
+    if (frame && (x < frame.left || x > frame.right || y < frame.top || y > frame.bottom)) continue;
+    try {
+      const caretDoc = doc as CaretDoc;
+      const docX = x - (frame?.left ?? 0);
+      const docY = y - (frame?.top ?? 0);
+      let range: Range | null = null;
+      if (caretDoc.caretRangeFromPoint) {
+        range = caretDoc.caretRangeFromPoint(docX, docY);
+      } else if (caretDoc.caretPositionFromPoint) {
+        const pos = caretDoc.caretPositionFromPoint(docX, docY);
+        if (pos) {
+          range = doc.createRange();
+          range.setStart(pos.offsetNode, pos.offset);
+        }
+      }
+      const node = range?.startContainer;
+      if (!range || !node || node.nodeType !== Node.TEXT_NODE) continue;
+      // Expand to one character so the range keeps a real client rect.
+      const length = (node as Text).length;
+      const offset = Math.min(range.startOffset, Math.max(0, length - 1));
+      range.setStart(node, offset);
+      range.setEnd(node, Math.min(length, offset + 1));
+      return range;
+    } catch {
+      /* try the next document */
+    }
+  }
+  return null;
 };
 
 // Visible line boxes for the single-column / vertical path. Rects are mapped to
@@ -210,6 +253,11 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
   const lineBoxesRef = useRef<ReadingRulerLineBox[]>([]);
   const columnsRef = useRef<ReadingRulerColumn[]>([]);
   const activeColumnIndexRef = useRef(0);
+  // Range on the text at the band's block start. The section DOM survives
+  // repagination, so this keeps identifying the same passage across reflows
+  // (issue #5491): resize re-snaps re-attach the band to it, and the auto-move
+  // effect only treats a relocate as a page turn once this text left the screen.
+  const anchorRangeRef = useRef<Range | null>(null);
   const bandSizeRef = useRef(0);
   const cacheLocationRef = useRef<string | null>(null);
   // In scrolled mode, set when a tap advances past the view edge and scrolls the
@@ -271,6 +319,73 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
     [throttledSave],
   );
 
+  // Capture a Range on the text at the band's block start so the band can be
+  // re-attached to the same passage after a repagination. Clears the anchor when
+  // no text is found at the band position (so a stale anchor can't yank the
+  // band back to an old passage later).
+  const captureAnchor = useCallback(
+    (blockStart: number, blockEnd: number) => {
+      if (!supportsLineSnap) return;
+      const containerRect = containerRef.current?.getBoundingClientRect();
+      if (!containerRect) {
+        anchorRangeRef.current = null;
+        return;
+      }
+      // Probe a few px into the first line of the block.
+      const main = blockStart + Math.min(10, Math.max(1, (blockEnd - blockStart) / 2));
+      const col = isMultiColumn ? columnsRef.current[activeColumnIndexRef.current] : null;
+      const crossStart = col?.left ?? 0;
+      const crossEnd = col?.right ?? (isVertical ? containerRect.height : containerRect.width);
+      const docs: Document[] = [];
+      for (const { doc } of getView(bookKey)?.renderer?.getContents?.() ?? []) {
+        if (doc) docs.push(doc);
+      }
+      const primaryDoc = getProgress(bookKey)?.range?.startContainer?.ownerDocument;
+      if (primaryDoc && !docs.includes(primaryDoc)) docs.push(primaryDoc);
+      // Sample across the line: the column/container centre first, then
+      // off-centre in case the anchor line is short.
+      for (const frac of [0.5, 0.3, 0.7]) {
+        const cross = crossStart + (crossEnd - crossStart) * frac;
+        const ox = isVertical ? (rtl ? containerRect.width - main : main) : cross;
+        const oy = isVertical ? cross : main;
+        const range = caretRangeAtPoint(docs, ox + containerRect.left, oy + containerRect.top);
+        if (range) {
+          anchorRangeRef.current = range;
+          return;
+        }
+      }
+      anchorRangeRef.current = null;
+    },
+    [supportsLineSnap, isMultiColumn, isVertical, rtl, getView, getProgress, bookKey],
+  );
+
+  // Resolve the anchored text's current position and rebuild the band's block
+  // around it. Returns null when the anchor is missing, detached, or off-screen
+  // (a real page turn) so the caller falls back to page-relative placement.
+  const resolveAnchorBlock = useCallback(
+    (containerRect: DOMRect): { start: number; end: number; columnIndex?: number } | null => {
+      const range = anchorRangeRef.current;
+      const doc = range?.startContainer?.ownerDocument;
+      if (!range || !doc?.defaultView) return null;
+      try {
+        const rects = mapRangeRectsToOverlay(range, containerRect);
+        const rect = rects.find((r) => r.width > 0 && r.height > 0) ?? rects[0];
+        if (!rect) return null;
+        const cx = (rect.left + rect.right) / 2;
+        const cy = (rect.top + rect.bottom) / 2;
+        if (cx < 0 || cx > containerRect.width || cy < 0 || cy > containerRect.height) return null;
+        const main = isVertical ? (rtl ? containerRect.width - cx : cx) : cy;
+        if (isMultiColumn) {
+          return snapReadingRulerColumnsToAnchor(main, cx, lines, columnsRef.current);
+        }
+        return snapReadingRulerToAnchor(main, lines, lineBoxesRef.current);
+      } catch {
+        return null;
+      }
+    },
+    [isVertical, rtl, lines, isMultiColumn],
+  );
+
   // Size the band to the real text block plus symmetric padding, centered on
   // the block so the breathing room is equal on both sides.
   const applyBlock = useCallback(
@@ -286,8 +401,9 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
       const centerPct =
         dimension > 0 ? ((start + end) / 2 / dimension) * 100 : currentPositionRef.current;
       setRulerPosition(centerPct, animate);
+      captureAnchor(start, end);
     },
-    [padding, maxBandSize, setRulerPosition],
+    [padding, maxBandSize, setRulerPosition, captureAnchor],
   );
 
   // Track container size for overlay calculations
@@ -352,13 +468,18 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
         const col = cols[idx];
         setActiveColumnRect(col ? { left: col.left, right: col.right } : null);
         if (!locationChanged) {
-          const block = snapReadingRulerColumns(idx, anchor, anchor, lines, 'forward', cols);
-          if (block) {
+          // A resize/relayout keeps the anchored text on screen: re-attach the
+          // band to it. Fall back to the screen-position snap when no anchor
+          // resolves (initial mount, or the text reflowed off the page).
+          const block =
+            resolveAnchorBlock(containerRect) ??
+            snapReadingRulerColumns(idx, anchor, anchor, lines, 'forward', cols);
+          if (block && 'columnIndex' in block && block.columnIndex !== undefined) {
             activeColumnIndexRef.current = block.columnIndex;
             const target = cols[block.columnIndex];
             if (target) setActiveColumnRect({ left: target.left, right: target.right });
-            applyBlock(block.start, block.end, dimension, false);
           }
+          if (block) applyBlock(block.start, block.end, dimension, false);
         }
       } else {
         const scrolled = !!viewSettings.scrolled;
@@ -396,7 +517,10 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
             scrolledPlacedRef.current &&
             scrolledPlacedDimensionRef.current === dimension;
           if (!alreadyPlaced) {
+            // Paginated resize/relayout: prefer re-attaching the band to the
+            // anchored text over snapping at the band's old screen position.
             const block =
+              (!scrolled ? resolveAnchorBlock(containerRect) : null) ??
               snapReadingRulerToLines(anchor, anchor, lines, 'forward', derivBoxes) ??
               snapReadingRulerToLines(Infinity, Infinity, lines, 'backward', derivBoxes);
             if (block) {
@@ -430,6 +554,7 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
     bookKey,
     getView,
     applyBlock,
+    resolveAnchorBlock,
   ]);
 
   // Fade in on mount (delayed to prevent flash before content loads)
@@ -576,6 +701,9 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
         containerDimension,
       );
 
+      // No line geometry to re-capture from; drop the old anchor so it can't
+      // yank the band back to a stale passage on a later reflow.
+      anchorRangeRef.current = null;
       setRulerPosition(targetPosition, true);
     };
 
@@ -589,7 +717,31 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
         lastFractionRef.current !== null && currentFraction < lastFractionRef.current
           ? 'backward'
           : 'forward';
-      requestAnimationFrame(() => performAutoMove(range, direction));
+      requestAnimationFrame(() => {
+        // A resize/reflow relocate keeps the anchored text on screen; re-attach
+        // the band to it instead of treating the relocate as a page turn
+        // (issue #5491). A real page turn replaces the page contents, so the
+        // anchor resolves off-screen and falls through to the auto-move.
+        const containerRect = containerRef.current?.getBoundingClientRect();
+        const dimension = containerRect
+          ? isVertical
+            ? containerRect.width
+            : containerRect.height
+          : 0;
+        if (containerRect && dimension > 0) {
+          const block = resolveAnchorBlock(containerRect);
+          if (block) {
+            if (block.columnIndex !== undefined) {
+              activeColumnIndexRef.current = block.columnIndex;
+              const col = columnsRef.current[block.columnIndex];
+              if (col) setActiveColumnRect({ left: col.left, right: col.right });
+            }
+            applyBlock(block.start, block.end, dimension, true);
+            return;
+          }
+        }
+        performAutoMove(range, direction);
+      });
     }
     lastLocationRef.current = currentLocation;
     lastFractionRef.current = currentFraction;
@@ -617,6 +769,7 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
     applyBlock,
     clampPosition,
     setRulerPosition,
+    resolveAnchorBlock,
   ]);
 
   const handlePointerDown = useCallback(
@@ -671,6 +824,27 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
     [isVertical, rtl, clampPosition],
   );
 
+  // Re-anchor to whatever text the dragged band landed on, so a later reflow
+  // keeps it there instead of restoring the pre-drag passage. A dragged band is
+  // not line-aligned, so refine to the first cached line it covers before
+  // probing (a probe at the band edge could hit the paragraph gap above).
+  const captureAnchorAtCurrent = useCallback(() => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const dimension = isVertical ? rect.width : rect.height;
+    if (dimension <= 0) return;
+    const center = (currentPositionRef.current / 100) * dimension;
+    const halfBlock = Math.max(0, (bandSizeRef.current || fallbackRulerSize) / 2 - padding);
+    const blockStart = center - halfBlock;
+    const blockEnd = center + halfBlock;
+    const boxes = isMultiColumn
+      ? (columnsRef.current[activeColumnIndexRef.current]?.lines ?? [])
+      : lineBoxesRef.current;
+    const firstLine = boxes.find((b) => b.end > blockStart && b.start < blockEnd);
+    if (firstLine) captureAnchor(firstLine.start, firstLine.end);
+    else captureAnchor(blockStart, blockEnd);
+  }, [isVertical, isMultiColumn, fallbackRulerSize, padding, captureAnchor]);
+
   const handlePointerUp = useCallback(
     (e: React.PointerEvent) => {
       if (!isDragging.current) return;
@@ -678,8 +852,9 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
       dragPointerOffsetRef.current = 0;
       e.currentTarget.releasePointerCapture(e.pointerId);
       throttledSave(currentPositionRef.current);
+      captureAnchorAtCurrent();
     },
-    [throttledSave],
+    [throttledSave, captureAnchorAtCurrent],
   );
 
   useEffect(() => {
@@ -763,7 +938,10 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
         const wasConsumed = isTouchDraggingRef.current;
         if (wasConsumed) {
           isDragging.current = false;
-          if (detail.phase === 'end') throttledSave(currentPositionRef.current);
+          if (detail.phase === 'end') {
+            throttledSave(currentPositionRef.current);
+            captureAnchorAtCurrent();
+          }
         }
         touchInRulerRef.current = false;
         isTouchDraggingRef.current = false;
@@ -858,6 +1036,9 @@ const ReadingRuler: React.FC<ReadingRulerProps> = ({
       }
       bandSizeRef.current = fallbackRulerSize;
       setBandSize(fallbackRulerSize);
+      // Fixed stepping has no line geometry; drop the anchor so it can't yank
+      // the band back to a stale passage on a later reflow.
+      anchorRangeRef.current = null;
       setRulerPosition(nextPosition, true);
       return true;
     };

--- a/apps/readest-app/src/app/reader/utils/readingRuler.ts
+++ b/apps/readest-app/src/app/reader/utils/readingRuler.ts
@@ -336,6 +336,77 @@ export const snapReadingRulerColumns = (
 };
 
 /**
+ * Block of `lines` real text lines starting at the line containing `anchorPos`
+ * (px along the ruler axis), or null when no line is within half a line height
+ * of the anchor. Used to re-attach the band to the same text after the page is
+ * repaginated (issue #5491): the caller resolves the anchored text's new
+ * position and rebuilds the band around it.
+ */
+export const snapReadingRulerToAnchor = (
+  anchorPos: number,
+  lines: number,
+  lineBoxes: ReadingRulerLineBox[],
+): ReadingRulerLineBox | null => {
+  if (lineBoxes.length === 0) return null;
+
+  let idx = lineBoxes.findIndex((b) => anchorPos >= b.start && anchorPos <= b.end);
+  if (idx === -1) {
+    const heights = lineBoxes
+      .map((b) => b.end - b.start)
+      .filter((h) => h > 0)
+      .sort((a, b) => a - b);
+    const medianHeight = heights[Math.floor(heights.length / 2)] ?? 0;
+    let bestDist = Infinity;
+    lineBoxes.forEach((b, i) => {
+      const dist = anchorPos < b.start ? b.start - anchorPos : anchorPos - b.end;
+      if (dist < bestDist) {
+        bestDist = dist;
+        idx = i;
+      }
+    });
+    if (idx === -1 || bestDist > medianHeight * 0.5) return null;
+  }
+
+  const count = Math.max(1, Math.floor(lines));
+  const startBox = lineBoxes[idx];
+  const endBox = lineBoxes[Math.min(idx + count - 1, lineBoxes.length - 1)];
+  if (!startBox || !endBox) return null;
+  return { start: startBox.start, end: endBox.end };
+};
+
+/**
+ * Column-aware anchor snap: pick the column containing `anchorCross` (px along
+ * the cross axis; nearest column when the point falls in the gutter), then the
+ * line block containing `anchorMain` within it.
+ */
+export const snapReadingRulerColumnsToAnchor = (
+  anchorMain: number,
+  anchorCross: number,
+  lines: number,
+  columns: ReadingRulerColumn[],
+): { columnIndex: number; start: number; end: number } | null => {
+  let columnIndex = -1;
+  let bestDist = Infinity;
+  columns.forEach((c, i) => {
+    const dist =
+      anchorCross < c.left
+        ? c.left - anchorCross
+        : anchorCross > c.right
+          ? anchorCross - c.right
+          : 0;
+    if (dist < bestDist) {
+      bestDist = dist;
+      columnIndex = i;
+    }
+  });
+
+  const col = columns[columnIndex];
+  if (!col) return null;
+  const block = snapReadingRulerToAnchor(anchorMain, lines, col.lines);
+  return block ? { columnIndex, start: block.start, end: block.end } : null;
+};
+
+/**
  * Whether an arrow-key side should move the reading ruler in the current layout.
  * In vertical writing mode only Up/Down move the ruler (Left/Right turn pages);
  * in horizontal mode all four sides move the ruler. Applies to keyboard nav only


### PR DESCRIPTION
Fixes #5491

### Problem

In paginated mode, resizing the reader window repaginates the content or switches between one-page and two-page layouts. During this reflow the reading ruler visibly drifted and settled over a different line or passage instead of staying attached to the text it was highlighting.

Two causes:

1. A resize makes foliate re-layout and fire a relocate whose location CFI changed. The ruler's auto-move effect treated any location change as a page turn and snapped the band to the first or last line group of the page, with the direction picked by a fraction comparison that is meaningless across a reflow.
2. Even when the CFI stayed the same, the re-snap path rebuilt the block from the band's screen position (percentage), which points at different text after a reflow. It also drifted one line per relayout whenever the band-size cap made the reconstructed block start diverge from the real block start.

### Fix

The band now keeps a logical text anchor: a one-character DOM Range on its block-start text, captured with `caretRangeFromPoint` after every placement (snap, auto-move, tap advance, drag). The section DOM survives repagination (only the CSS column layout changes), so after a reflow the range resolves to the text's new geometry and the band re-snaps around it via new pure helpers `snapReadingRulerToAnchor` / `snapReadingRulerColumnsToAnchor`.

Paginated page turns always replace the whole spread, so "anchored text still on screen after a relocate" reliably distinguishes a reflow from a real page turn: real turns find the anchor off-screen and fall through to the existing page-relative auto-move. Scrolled mode placement is unchanged. When the anchored passage itself reflows past the page break, the band falls back to the previous page-relative behavior and re-anchors from its new position.

Details:
- Drag-end capture refines to the first cached line box the band covers before probing, since a dragged band edge is not line-aligned and a raw probe can hit the paragraph gap and grab the previous line.
- Caret hits on non-text nodes (margins, gutters) are rejected and the probe retries at other cross-axis fractions of the column; the anchor is cleared on the no-geometry fallback paths so a stale range cannot yank the band back later.

### Verification

- Unit tests for the new anchor-snap helpers and a component regression test that simulates a resize relocate (band must re-attach to the anchored text at its new position instead of auto-moving); tests were written first and fail without the fix.
- Verified live in Chrome with a reflowable EPUB: two-column to one-column window resize round trips, sidebar open/close reflows (same code path), and re-wrapped lines all keep the band on the same sentence; tap advance within and across columns and page-turn auto-move still behave as before.
- `pnpm test` (8633 passed), `pnpm lint`, `pnpm format:check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)