### PR TITLE
test(reader): deflake DictionarySheet expand/collapse toggle test

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/annotator/DictionarySheet.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/annotator/DictionarySheet.test.tsx
@@ -393,15 +393,18 @@ describe('DictionarySheet — expand / collapse', () => {
 
     // Wait for the lookup to finish (source label visible).
     await waitFor(() => screen.getByText('CMU American English spelling'));
-    const card = screen.getByTestId('dict-card');
+    // Re-query the card and poll on every step: asserting synchronously on a
+    // captured node flaked on slow CI runners, where a late async re-render
+    // could race the click (stale node → the toggle never reaches React).
+    const expanded = () => screen.getByTestId('dict-card').getAttribute('aria-expanded');
     // With ≤ 3 results the sheet defaults to expanded.
-    await waitFor(() => expect(card.getAttribute('aria-expanded')).toBe('true'));
+    await waitFor(() => expect(expanded()).toBe('true'));
 
-    fireEvent.click(card);
-    expect(card.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(screen.getByTestId('dict-card'));
+    await waitFor(() => expect(expanded()).toBe('false'));
 
-    fireEvent.click(card);
-    expect(card.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.click(screen.getByTestId('dict-card'));
+    await waitFor(() => expect(expanded()).toBe('true'));
   });
 
   it('defaults to collapsed when more than 3 providers have results', async () => {


### PR DESCRIPTION
The `toggles aria-expanded when a card is tapped` test failed once on the `test_web_app (2)` shard ([example run](https://github.com/readest/readest/actions/runs/31019292334/job/92351513303)) with `aria-expanded` stuck at `'true'` after the click, and passed on rerun. It was not reproducible locally (15 consecutive runs green).

Root cause is in the test, not the component: it captured the card node once and asserted `aria-expanded` synchronously right after `fireEvent.click`. On a slow, loaded runner a late async re-render can land between the capture and the click — the captured node goes stale, the dispatched click bubbles through a detached subtree and never reaches React's root listener, and the frozen attribute still reads `'true'`.

Fix: re-query `dict-card` for every click and poll each assertion with `waitFor`, so the test always interacts with and reads the live DOM. Coverage is unchanged — tap collapses, tap again re-expands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)