### PR TITLE
feat(library): show the page count in book details (#5516)

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2210,5 +2210,6 @@
   "or continue with email": "أو المتابعة عبر البريد الإلكتروني",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "اضغط على زر في جهاز التحكم عن بُعد أو لوحة المفاتيح، أو استخدم إيماءة Apple Pencil، بعد النقر على \"تعيين مفتاح\".",
   "Pencil Double Tap": "نقر مزدوج على Apple Pencil",
-  "Pencil Squeeze": "ضغط Apple Pencil"
+  "Pencil Squeeze": "ضغط Apple Pencil",
+  "Pages": "الصفحات"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2026,5 +2026,6 @@
   "or continue with email": "অথবা ইমেইল দিয়ে চালিয়ে যান",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"কী সেট করুন\" ট্যাপ করার পর আপনার রিমোট কন্ট্রোলার বা কীবোর্ডের একটি বোতাম চাপুন, অথবা Apple Pencil জেসচার ব্যবহার করুন।",
   "Pencil Double Tap": "Apple Pencil ডাবল ট্যাপ",
-  "Pencil Squeeze": "Apple Pencil স্কুইজ"
+  "Pencil Squeeze": "Apple Pencil স্কুইজ",
+  "Pages": "পৃষ্ঠা সংখ্যা"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1980,5 +1980,6 @@
   "or continue with email": "ཡང་ན་གློག་འཕྲིན་བརྒྱུད་ནས་མུ་མཐུད།",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"མཐེབ་གཞི་གཏན་འཁེལ།\" ལ་རེག་རྗེས། ཁྱེད་ཀྱི་རྒྱང་འཐེན་སྒྲིག་ཆས་སམ་མཐེབ་གཞི་གང་རུང་གི་ཐོག་མཐེབ་གཅིག་གནོན་པའམ། ཡང་ན་ Apple Pencil གྱི་ལག་བརྡ་བེད་སྤྱོད་བྱོས།",
   "Pencil Double Tap": "Apple Pencil ཐེངས་གཉིས་རེག་པ།",
-  "Pencil Squeeze": "Apple Pencil བཙིར་བ།"
+  "Pencil Squeeze": "Apple Pencil བཙིར་བ།",
+  "Pages": "ཤོག་གྲངས།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2026,5 +2026,6 @@
   "or continue with email": "oder mit E-Mail fortfahren",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Drücken Sie eine Taste auf Ihrer Fernbedienung oder Tastatur oder verwenden Sie eine Apple Pencil-Geste, nachdem Sie auf \"Taste festlegen\" getippt haben.",
   "Pencil Double Tap": "Apple Pencil Doppeltippen",
-  "Pencil Squeeze": "Apple Pencil Zusammendrücken"
+  "Pencil Squeeze": "Apple Pencil Zusammendrücken",
+  "Pages": "Seiten"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2026,5 +2026,6 @@
   "or continue with email": "ή συνεχίστε με email",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Πατήστε ένα κουμπί στο τηλεχειριστήριο ή το πληκτρολόγιό σας, ή χρησιμοποιήστε μια χειρονομία Apple Pencil, αφού πατήσετε «Ορισμός πλήκτρου».",
   "Pencil Double Tap": "Διπλό άγγιγμα Apple Pencil",
-  "Pencil Squeeze": "Πίεση Apple Pencil"
+  "Pencil Squeeze": "Πίεση Apple Pencil",
+  "Pages": "Σελίδες"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2072,5 +2072,6 @@
   "or continue with email": "o continúa con tu correo electrónico",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Pulse un botón en su mando a distancia o teclado, o use un gesto del Apple Pencil, después de tocar \"Asignar tecla\".",
   "Pencil Double Tap": "Doble toque del Apple Pencil",
-  "Pencil Squeeze": "Apretón del Apple Pencil"
+  "Pencil Squeeze": "Apretón del Apple Pencil",
+  "Pages": "Páginas"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2026,5 +2026,6 @@
   "or continue with email": "یا با ایمیل ادامه دهید",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "پس از ضربه زدن به «تنظیم کلید»، دکمه‌ای روی کنترلر یا صفحه‌کلید خود فشار دهید یا از حرکت Apple Pencil استفاده کنید.",
   "Pencil Double Tap": "دو ضربه روی Apple Pencil",
-  "Pencil Squeeze": "فشردن Apple Pencil"
+  "Pencil Squeeze": "فشردن Apple Pencil",
+  "Pages": "صفحات"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2072,5 +2072,6 @@
   "or continue with email": "ou continuer par e-mail",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Appuyez sur un bouton de votre télécommande ou de votre clavier, ou utilisez un geste de l'Apple Pencil, après avoir appuyé sur « Définir la touche ».",
   "Pencil Double Tap": "Double toucher Apple Pencil",
-  "Pencil Squeeze": "Pression Apple Pencil"
+  "Pencil Squeeze": "Pression Apple Pencil",
+  "Pages": "Pages"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2072,5 +2072,6 @@
   "or continue with email": "או המשך עם אימייל",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "לחץ על כפתור בשלט הרחוק או במקלדת, או השתמש במחוות Apple Pencil, לאחר הקשה על \"הגדר מקש\".",
   "Pencil Double Tap": "הקשה כפולה על Apple Pencil",
-  "Pencil Squeeze": "לחיצה על Apple Pencil"
+  "Pencil Squeeze": "לחיצה על Apple Pencil",
+  "Pages": "דפים"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2026,5 +2026,6 @@
   "or continue with email": "या ईमेल से जारी रखें",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"कुंजी सेट करें\" दबाने के बाद अपने रिमोट कंट्रोलर या कीबोर्ड पर एक बटन दबाएं, या Apple Pencil जेस्चर का उपयोग करें।",
   "Pencil Double Tap": "Apple Pencil डबल टैप",
-  "Pencil Squeeze": "Apple Pencil स्क्वीज़"
+  "Pencil Squeeze": "Apple Pencil स्क्वीज़",
+  "Pages": "कुल पृष्ठ"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2026,5 +2026,6 @@
   "or continue with email": "vagy folytassa e-maillel",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Nyomjon meg egy gombot a távirányítón vagy a billentyűzeten, vagy használjon Apple Pencil kézmozdulatot a „Billentyű beállítása” érintése után.",
   "Pencil Double Tap": "Apple Pencil dupla koppintás",
-  "Pencil Squeeze": "Apple Pencil összenyomás"
+  "Pencil Squeeze": "Apple Pencil összenyomás",
+  "Pages": "Oldalak"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1980,5 +1980,6 @@
   "or continue with email": "atau lanjutkan dengan email",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Tekan tombol pada remote controller atau keyboard Anda, atau gunakan gerakan Apple Pencil, setelah mengetuk \"Atur tombol\".",
   "Pencil Double Tap": "Ketuk Dua Kali Apple Pencil",
-  "Pencil Squeeze": "Remas Apple Pencil"
+  "Pencil Squeeze": "Remas Apple Pencil",
+  "Pages": "Jumlah Halaman"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2072,5 +2072,6 @@
   "or continue with email": "oppure continua con l'email",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Premi un pulsante sul telecomando o sulla tastiera, oppure usa un gesto di Apple Pencil, dopo aver toccato \"Imposta tasto\".",
   "Pencil Double Tap": "Doppio tocco Apple Pencil",
-  "Pencil Squeeze": "Pressione Apple Pencil"
+  "Pencil Squeeze": "Pressione Apple Pencil",
+  "Pages": "Pagine"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1980,5 +1980,6 @@
   "or continue with email": "またはメールで続行",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "「キーを設定」をタップした後、リモコンまたはキーボードのボタンを押すか、Apple Pencilのジェスチャを使用してください。",
   "Pencil Double Tap": "Apple Pencilのダブルタップ",
-  "Pencil Squeeze": "Apple Pencilのスクイーズ"
+  "Pencil Squeeze": "Apple Pencilのスクイーズ",
+  "Pages": "ページ数"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1980,5 +1980,6 @@
   "or continue with email": "또는 이메일로 계속",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"키 설정\"을 탭한 후 리모컨 또는 키보드의 버튼을 누르거나 Apple Pencil 제스처를 사용하세요.",
   "Pencil Double Tap": "Apple Pencil 이중 탭",
-  "Pencil Squeeze": "Apple Pencil 스퀴즈"
+  "Pencil Squeeze": "Apple Pencil 스퀴즈",
+  "Pages": "페이지 수"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1980,5 +1980,6 @@
   "or continue with email": "atau teruskan dengan e-mel",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Tekan butang pada pengawal jauh atau papan kekunci anda, atau gunakan gerak isyarat Apple Pencil, selepas mengetuk \"Tetapkan kekunci\".",
   "Pencil Double Tap": "Ketik Dua Kali Apple Pencil",
-  "Pencil Squeeze": "Picit Apple Pencil"
+  "Pencil Squeeze": "Picit Apple Pencil",
+  "Pages": "Jumlah Halaman"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2026,5 +2026,6 @@
   "or continue with email": "of ga verder met e-mail",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Druk op een knop op uw afstandsbediening of toetsenbord, of gebruik een Apple Pencil-gebaar, nadat u op \"Toets instellen\" hebt getikt.",
   "Pencil Double Tap": "Apple Pencil dubbel tikken",
-  "Pencil Squeeze": "Apple Pencil knijpen"
+  "Pencil Squeeze": "Apple Pencil knijpen",
+  "Pages": "Pagina's"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2118,5 +2118,6 @@
   "or continue with email": "lub kontynuuj przez e-mail",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Naciśnij przycisk na pilocie lub klawiaturze, albo użyj gestu Apple Pencil, po dotknięciu \"Ustaw klawisz\".",
   "Pencil Double Tap": "Dwukrotne stuknięcie Apple Pencil",
-  "Pencil Squeeze": "Ściśnięcie Apple Pencil"
+  "Pencil Squeeze": "Ściśnięcie Apple Pencil",
+  "Pages": "Strony"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2072,5 +2072,6 @@
   "or continue with email": "ou continue com e-mail",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Pressione um botão no controle remoto ou teclado, ou use um gesto do Apple Pencil, após tocar em \"Definir tecla\".",
   "Pencil Double Tap": "Toque duplo no Apple Pencil",
-  "Pencil Squeeze": "Aperto no Apple Pencil"
+  "Pencil Squeeze": "Aperto no Apple Pencil",
+  "Pages": "Páginas"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2072,5 +2072,6 @@
   "or continue with email": "ou continue com o e-mail",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Pressione um botão no seu controle remoto ou teclado, ou use um gesto do Apple Pencil, após tocar em \"Definir tecla\".",
   "Pencil Double Tap": "Toque duplo no Apple Pencil",
-  "Pencil Squeeze": "Aperto no Apple Pencil"
+  "Pencil Squeeze": "Aperto no Apple Pencil",
+  "Pages": "Páginas"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2072,5 +2072,6 @@
   "or continue with email": "sau continuă cu e-mailul",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Apăsați un buton pe telecomandă sau tastatură, sau folosiți un gest Apple Pencil, după ce atingeți \"Setează tasta\".",
   "Pencil Double Tap": "Atingere dublă Apple Pencil",
-  "Pencil Squeeze": "Strângere Apple Pencil"
+  "Pencil Squeeze": "Strângere Apple Pencil",
+  "Pages": "Pagini"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2118,5 +2118,6 @@
   "or continue with email": "или продолжите с помощью эл. почты",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Нажмите кнопку на пульте дистанционного управления или клавиатуре либо используйте жест Apple Pencil после нажатия \"Назначить клавишу\".",
   "Pencil Double Tap": "Двойное касание Apple Pencil",
-  "Pencil Squeeze": "Сжатие Apple Pencil"
+  "Pencil Squeeze": "Сжатие Apple Pencil",
+  "Pages": "Страницы"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2026,5 +2026,6 @@
   "or continue with email": "නැතහොත් විද්‍යුත් තැපෑලෙන් ඉදිරියට යන්න",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"යතුර සකසන්න\" තට්ටු කිරීමෙන් පසු ඔබේ දුරස්ථ පාලකයේ හෝ යතුරු පුවරුවේ බොත්තමක් එබෙන්න, නැතහොත් Apple Pencil ඉංගිතයක් භාවිතා කරන්න.",
   "Pencil Double Tap": "Apple Pencil දෙවරක් තට්ටු කිරීම",
-  "Pencil Squeeze": "Apple Pencil තද කිරීම"
+  "Pencil Squeeze": "Apple Pencil තද කිරීම",
+  "Pages": "පිටු ගණන"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2118,5 +2118,6 @@
   "or continue with email": "ali nadaljujte z e-pošto",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Pritisnite gumb na daljinskem upravljalniku ali tipkovnici, ali uporabite potezo Apple Pencil, po tapkanju na \"Nastavi tipko\".",
   "Pencil Double Tap": "Dvojni dotik Apple Pencil",
-  "Pencil Squeeze": "Stisk Apple Pencil"
+  "Pencil Squeeze": "Stisk Apple Pencil",
+  "Pages": "Strani"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2026,5 +2026,6 @@
   "or continue with email": "eller fortsätt med e-post",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Tryck på en knapp på din fjärrkontroll eller tangentbord, eller använd en Apple Pencil-gest, efter att ha tryckt på \"Ange tangent\".",
   "Pencil Double Tap": "Apple Pencil dubbeltryck",
-  "Pencil Squeeze": "Apple Pencil klämning"
+  "Pencil Squeeze": "Apple Pencil klämning",
+  "Pages": "Sidor"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2026,5 +2026,6 @@
   "or continue with email": "அல்லது மின்னஞ்சல் மூலம் தொடரவும்",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"விசை அமை\" தட்டிய பிறகு உங்கள் ரிமோட் கன்ட்ரோலர் அல்லது கீபோர்டில் ஒரு பட்டனை அழுத்தவும், அல்லது Apple Pencil சைகையைப் பயன்படுத்தவும்.",
   "Pencil Double Tap": "Apple Pencil இரட்டைத் தட்டு",
-  "Pencil Squeeze": "Apple Pencil அழுத்துதல்"
+  "Pencil Squeeze": "Apple Pencil அழுத்துதல்",
+  "Pages": "பக்கங்கள்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1980,5 +1980,6 @@
   "or continue with email": "หรือดำเนินการต่อด้วยอีเมล",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "กดปุ่มบนรีโมทคอนโทรลหรือคีย์บอร์ด หรือใช้ท่าทาง Apple Pencil หลังจากแตะ \"ตั้งปุ่ม\"",
   "Pencil Double Tap": "แตะสองครั้งบน Apple Pencil",
-  "Pencil Squeeze": "บีบ Apple Pencil"
+  "Pencil Squeeze": "บีบ Apple Pencil",
+  "Pages": "จำนวนหน้า"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2026,5 +2026,6 @@
   "or continue with email": "veya e-posta ile devam edin",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"Tuş ayarla\" düğmesine dokunduktan sonra uzaktan kumandanızdaki veya klavyenizdeki bir düğmeye basın ya da bir Apple Pencil hareketi kullanın.",
   "Pencil Double Tap": "Apple Pencil çift dokunma",
-  "Pencil Squeeze": "Apple Pencil sıkma"
+  "Pencil Squeeze": "Apple Pencil sıkma",
+  "Pages": "Sayfalar"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2118,5 +2118,6 @@
   "or continue with email": "або продовжте з ел. поштою",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Натисніть кнопку на пульті або клавіатурі, або скористайтеся жестом Apple Pencil після натискання \"Призначити клавішу\".",
   "Pencil Double Tap": "Подвійний дотик Apple Pencil",
-  "Pencil Squeeze": "Стискання Apple Pencil"
+  "Pencil Squeeze": "Стискання Apple Pencil",
+  "Pages": "Сторінки"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2026,5 +2026,6 @@
   "or continue with email": "yoki e-pochta bilan davom eting",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"Tugmani o'rnatish\" tugmasini bosgandan so'ng masofadan boshqarish pultingiz yoki klaviaturangizdagi tugmani bosing yoki Apple Pencil imo-ishorasidan foydalaning.",
   "Pencil Double Tap": "Apple Pencil ikki marta bosish",
-  "Pencil Squeeze": "Apple Pencil qisish"
+  "Pencil Squeeze": "Apple Pencil qisish",
+  "Pages": "Sahifalar"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1980,5 +1980,6 @@
   "or continue with email": "hoặc tiếp tục bằng email",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Nhấn một nút trên bộ điều khiển từ xa hoặc bàn phím, hoặc dùng cử chỉ Apple Pencil, sau khi chạm \"Đặt phím\".",
   "Pencil Double Tap": "Chạm hai lần Apple Pencil",
-  "Pencil Squeeze": "Bóp Apple Pencil"
+  "Pencil Squeeze": "Bóp Apple Pencil",
+  "Pages": "Số trang"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1980,5 +1980,6 @@
   "or continue with email": "或使用邮箱继续",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "点击「设置按键」后，按下遥控器或键盘上的按钮，或使用 Apple Pencil 手势。",
   "Pencil Double Tap": "Apple Pencil 轻点两下",
-  "Pencil Squeeze": "Apple Pencil 轻捏"
+  "Pencil Squeeze": "Apple Pencil 轻捏",
+  "Pages": "页数"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1980,5 +1980,6 @@
   "or continue with email": "或使用電子郵件繼續",
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "點擊「設定按鍵」後，按下遙控器或鍵盤上的按鈕，或使用 Apple Pencil 手勢。",
   "Pencil Double Tap": "Apple Pencil 點兩下",
-  "Pencil Squeeze": "Apple Pencil 輕捏"
+  "Pencil Squeeze": "Apple Pencil 輕捏",
+  "Pages": "頁數"
 }

--- a/apps/readest-app/src/__tests__/app/reader/components/sidebar/BookCard.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/sidebar/BookCard.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import BookCard from '@/app/reader/components/sidebar/BookCard';
+import { Book } from '@/types/book';
+
+const mocks = vi.hoisted(() => ({
+  dispatchSync: vi.fn(),
+  config: { progress: undefined as [number, number] | undefined },
+}));
+
+vi.mock('@/utils/event', () => ({
+  eventDispatcher: { dispatchSync: mocks.dispatchSync },
+}));
+
+vi.mock('@/store/sidebarStore', () => ({
+  useSidebarStore: { getState: () => ({ sideBarBookKey: 'abc123-0' }) },
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: { getState: () => ({ getConfig: () => mocks.config }) },
+}));
+
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({ isDarkMode: false }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: { librarySkeuomorphicCovers: false } }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+vi.mock('@/hooks/useResponsiveSize', () => ({
+  useResponsiveSize: (n: number) => n,
+}));
+
+vi.mock('@/components/BookCover', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+afterEach(() => {
+  mocks.dispatchSync.mockClear();
+  mocks.config.progress = undefined;
+  cleanup();
+});
+
+const book = {
+  hash: 'abc123',
+  title: 'Test Book',
+  author: 'Test Author',
+  format: 'EPUB',
+  progress: [10, 200],
+} as Book;
+
+const clickInfo = (container: HTMLElement) => {
+  const button = container.querySelector('button[aria-label="More Info"]');
+  expect(button).toBeTruthy();
+  fireEvent.click(button!);
+};
+
+describe('BookCard book details', () => {
+  // The reader holds the Book snapshot taken when the book was opened, so its
+  // page count is the previous session's — or missing entirely on a first
+  // read. Book Details must show the count for the current layout (#5516).
+  it('overrides the stale snapshot progress with the live config progress', () => {
+    mocks.config.progress = [42, 317];
+    const { container } = render(<BookCard book={book} />);
+
+    clickInfo(container);
+
+    expect(mocks.dispatchSync).toHaveBeenCalledWith(
+      'show-book-details',
+      expect.objectContaining({ hash: 'abc123', progress: [42, 317] }),
+    );
+  });
+
+  it('keeps the book as-is when the view has not reported progress yet', () => {
+    const { container } = render(<BookCard book={book} />);
+
+    clickInfo(container);
+
+    expect(mocks.dispatchSync).toHaveBeenCalledWith('show-book-details', book);
+  });
+});

--- a/apps/readest-app/src/__tests__/components/BookDetailView.test.tsx
+++ b/apps/readest-app/src/__tests__/components/BookDetailView.test.tsx
@@ -201,6 +201,25 @@ describe('BookDetailView file path row', () => {
   });
 });
 
+describe('BookDetailView page count', () => {
+  // The page count is only known once the book has been laid out by the
+  // reader, so it rides on book.progress ([current, total]) instead of being
+  // computed at import time (#5516).
+  it('shows the total page count of an opened book', () => {
+    const { getByText } = renderView({ book: makeBook({ progress: [42, 317] }) });
+
+    expect(getByText('Pages')).toBeTruthy();
+    expect(getByText('317')).toBeTruthy();
+  });
+
+  it('falls back to Unknown for a book that has never been opened', () => {
+    const { getByText } = renderView({ book: makeBook() });
+
+    const label = getByText('Pages');
+    expect(label.parentElement!.textContent).toContain('Unknown');
+  });
+});
+
 describe('BookDetailView tags and subjects', () => {
   it('normalizes clicked tag and subject values before shelf navigation', () => {
     const onMetadataValueClick = vi.fn();

--- a/apps/readest-app/src/app/reader/components/sidebar/BookCard.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/BookCard.tsx
@@ -8,7 +8,9 @@ import { eventDispatcher } from '@/utils/event';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
 import { formatAuthors, formatTitle } from '@/utils/book';
 import BookCover from '@/components/BookCover';
+import { useBookDataStore } from '@/store/bookDataStore';
 import { useSettingsStore } from '@/store/settingsStore';
+import { useSidebarStore } from '@/store/sidebarStore';
 
 const BookCard = ({ book }: { book: Book }) => {
   const { title, author } = book;
@@ -19,7 +21,12 @@ const BookCard = ({ book }: { book: Book }) => {
   const bookCoverRef = useRef<HTMLDivElement | null>(null);
 
   const showBookDetails = () => {
-    eventDispatcher.dispatchSync('show-book-details', book);
+    // `book` is the snapshot taken when the reader opened it, so its page count
+    // is the previous session's — and missing altogether on a first read. The
+    // live config carries the count for the layout on screen now (#5516).
+    const { sideBarBookKey } = useSidebarStore.getState();
+    const progress = useBookDataStore.getState().getConfig(sideBarBookKey)?.progress;
+    eventDispatcher.dispatchSync('show-book-details', progress ? { ...book, progress } : book);
   };
 
   return (

--- a/apps/readest-app/src/components/metadata/BookDetailView.tsx
+++ b/apps/readest-app/src/components/metadata/BookDetailView.tsx
@@ -283,42 +283,27 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({
                     {formatLanguage(metadata?.language) || _('Unknown')}
                   </p>
                 </div>
-                <div className='col-span-2 overflow-hidden sm:col-span-3'>
-                  <div className='flex items-center gap-1'>
-                    <span className='font-bold'>{_('Subjects')}</span>
-                    {subjects.length > 3 && (
-                      <button
-                        type='button'
-                        aria-label={_('Subjects')}
-                        aria-expanded={subjectsExpanded}
-                        onClick={() => setSubjectsExpanded((expanded) => !expanded)}
-                      >
-                        {subjectsExpanded ? <MdExpandLess /> : <MdExpandMore />}
-                      </button>
-                    )}
-                  </div>
-                  <div className='mt-1 flex flex-wrap gap-1'>
-                    {visibleSubjects.length
-                      ? visibleSubjects.map((subject) => renderMetadataChip('subject', subject))
-                      : _('Unknown')}
-                  </div>
-                </div>
-                <div className='col-span-2 overflow-hidden sm:col-span-3'>
-                  <span className='font-bold'>{_('Tags')}</span>
-                  <div className='mt-1 flex flex-wrap gap-1'>
-                    {book.tags?.length
-                      ? book.tags.map((tag) => renderMetadataChip('tag', tag))
-                      : _('Unknown')}
-                  </div>
-                </div>
-                <div className='overflow-hidden'>
+                <div className='overflow-hidden pe-1 text-end sm:text-start'>
                   <span className='font-bold'>{_('Format')}</span>
                   <p className='text-neutral-content text-sm'>{book.format || _('Unknown')}</p>
                 </div>
-                <div className='overflow-hidden pe-1 text-end sm:text-start'>
+                <div className='overflow-hidden'>
                   <span className='font-bold'>{_('File Size')}</span>
                   <p className='text-neutral-content text-sm'>
                     {formatBytes(fileSize) || _('Unknown')}
+                  </p>
+                </div>
+                {/*
+                  The same total the footer bar counts against: foliate's
+                  SectionProgress derives it from the spine's byte sizes when the
+                  book is opened (reflowable), or from the spine length for fixed
+                  layout. Nothing computes it at import time, so it lands in
+                  book.progress ([current, total]) on the first open (#5516).
+                */}
+                <div className='overflow-hidden pe-1 text-end sm:text-start'>
+                  <span className='font-bold'>{_('Pages')}</span>
+                  <p className='text-neutral-content text-sm'>
+                    {book.progress?.[1] || _('Unknown')}
                   </p>
                 </div>
                 <div className='col-span-2 overflow-hidden sm:col-span-1'>
@@ -362,6 +347,39 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({
                     </p>
                   </div>
                 )}
+                {/*
+                  Subjects and Tags are full-width chip lists, so they close out
+                  the section: leaving them mid-grid pushed every following cell
+                  onto a fresh row and left holes in the two-column layout.
+                */}
+                <div className='col-span-2 overflow-hidden sm:col-span-3'>
+                  <div className='flex items-center gap-1'>
+                    <span className='font-bold'>{_('Subjects')}</span>
+                    {subjects.length > 3 && (
+                      <button
+                        type='button'
+                        aria-label={_('Subjects')}
+                        aria-expanded={subjectsExpanded}
+                        onClick={() => setSubjectsExpanded((expanded) => !expanded)}
+                      >
+                        {subjectsExpanded ? <MdExpandLess /> : <MdExpandMore />}
+                      </button>
+                    )}
+                  </div>
+                  <div className='mt-1 flex flex-wrap gap-1'>
+                    {visibleSubjects.length
+                      ? visibleSubjects.map((subject) => renderMetadataChip('subject', subject))
+                      : _('Unknown')}
+                  </div>
+                </div>
+                <div className='col-span-2 overflow-hidden sm:col-span-3'>
+                  <span className='font-bold'>{_('Tags')}</span>
+                  <div className='mt-1 flex flex-wrap gap-1'>
+                    {book.tags?.length
+                      ? book.tags.map((tag) => renderMetadataChip('tag', tag))
+                      : _('Unknown')}
+                  </div>
+                </div>
               </div>
             </div>
           )}


### PR DESCRIPTION
Closes #5516

## What

Book Details gains a **Pages** field, so the length of a book can be checked without opening it.

| Desktop | Mobile |
| --- | --- |
| `Publisher / Published / Updated`<br>`Added / Language / Format`<br>`File Size / Pages / Identifier` | `File Size` left, `Pages` end-aligned |

## Where the number comes from

Nothing is computed at import time. The count is the total foliate already reports through the `relocate` event, which `readerStore.setProgress` persists as `book.progress` (`[current, total]`):

- **reflowable** — `SectionProgress` derives it from the spine items' byte sizes when the book is opened (`ceil(sizeTotal / 1500)`), the same total the footer bar counts against
- **fixed layout (PDF/CBZ)** — the spine length, i.e. the real page count

That value is already persisted to `Books/<hash>/config.json` and synced on the book-configs channel, so the field fills in on the first open and needs no new `Book` field or migration. Books that have never been opened show `Unknown`, as do books whose progress has not synced to this device yet.

Note this also means `Pages` can be populated while `File Size` is `Unknown`: `getBookFileSize` requires the file to be present locally, whereas `progress` is synced metadata.

## Reader sidebar

The reader holds the `Book` snapshot captured when it opened the file, so its `progress` is the previous session's and is absent entirely on a first read. `BookCard` merges the live `bookData.config.progress` in at dispatch time. Doing it there rather than in the render path matters: passing a freshly spread `{...book}` down would defeat `BookCover`'s `memo` and re-decode the cover on every page turn.

The library path needs no such fix, since `libraryStore.updateBookProgress` refreshes the library copy immutably on every relocate.

## Drive-by

Subjects and Tags move to the end of the metadata section. Both are full-width chip lists, so mid-grid they pushed every following cell onto a fresh row and left holes in the two-column mobile layout. The mobile end-alignment class alternates by position, so it moved with them.

## Testing

- New tests written first and confirmed failing before the fix: `BookDetailView.test.tsx` (count shown / `Unknown` fallback) and a new `BookCard.test.tsx` (live config progress overrides the stale snapshot).
- `pnpm test` 8693 passed, 16 skipped. `pnpm lint` and `pnpm format:check` clean. No Rust or Lua changes.
- Eyeballed at 1280px and 400px via Playwright, and live in Chrome against a 710-book library.
- New `Pages` key translated across all 33 locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)