### PR TITLE
feat(reader): jump to an entered page number from the progress label

### DIFF
--- a/apps/readest-app/e2e/pages/ReaderPage.ts
+++ b/apps/readest-app/e2e/pages/ReaderPage.ts
@@ -23,9 +23,13 @@ export class ReaderPage extends BasePage {
   readonly annotationPopup: Locator;
   readonly noteEditor: Locator;
   readonly annotationItems: Locator;
+  readonly pageJumpInput: Locator;
 
   constructor(page: Page) {
     super(page);
+    // Both the desktop footer bar and the mobile navigation panel render a
+    // page-jump input; pick whichever one the current layout displays.
+    this.pageJumpInput = page.locator('input[aria-label="Go to Page"]:visible').first();
     this.viewer = page.locator('.foliate-viewer').first();
     this.foliateView = page.locator('foliate-view').first();
     this.headerBar = page.locator('.header-bar').first();
@@ -94,18 +98,23 @@ export class ReaderPage extends BasePage {
   }
 
   /**
-   * Current reading position as a number parsed from the footer's
-   * "Reading Progress" label. The label is in the DOM regardless of whether
-   * the footer is visually revealed, so no reveal is needed.
+   * Current reading position as a number parsed from the footer's page-jump
+   * label ("94 / 251" with the default fraction progress style). The label is
+   * in the DOM regardless of whether the footer is visually revealed, so no
+   * reveal is needed.
    */
   async readingProgress(): Promise<number> {
-    const label =
-      (await this.page
-        .locator('span[title="Reading Progress"]')
-        .first()
-        .getAttribute('aria-label')) ?? '';
-    const match = label.match(/(\d+(?:\.\d+)?)/);
+    const value = await this.pageJumpInput.inputValue();
+    const match = value.match(/(\d+(?:\.\d+)?)/);
     return match ? Number(match[1]) : Number.NaN;
+  }
+
+  /** Jump to a page by typing into the footer's page-jump input. */
+  async goToPage(page: number): Promise<void> {
+    await this.revealFooter();
+    await this.pageJumpInput.click();
+    await this.pageJumpInput.fill(String(page));
+    await this.pageJumpInput.press('Enter');
   }
 
   // --- sidebar / table of contents ---

--- a/apps/readest-app/e2e/tests/reading.spec.ts
+++ b/apps/readest-app/e2e/tests/reading.spec.ts
@@ -21,6 +21,22 @@ test.describe('Reading', () => {
     await expect.poll(() => reader.readingProgress()).toBeGreaterThan(startProgress);
   });
 
+  test('jumps to an entered page number', async ({ openBook }) => {
+    const reader = await openBook();
+    const startProgress = await reader.readingProgress();
+    const total = Number((await reader.pageJumpInput.inputValue()).split('/')[1]);
+    const target = Math.max(2, Math.round(total / 2));
+
+    await reader.goToPage(target);
+
+    // The jump aims at the middle of the target page, so the reported start
+    // of the landed page may be off by one.
+    await expect
+      .poll(async () => Math.abs((await reader.readingProgress()) - target))
+      .toBeLessThanOrEqual(1);
+    expect(await reader.readingProgress()).not.toBe(startProgress);
+  });
+
   test('finds matches with in-book search', async ({ openBook }) => {
     const reader = await openBook();
 

--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2211,5 +2211,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "اضغط على زر في جهاز التحكم عن بُعد أو لوحة المفاتيح، أو استخدم إيماءة Apple Pencil، بعد النقر على \"تعيين مفتاح\".",
   "Pencil Double Tap": "نقر مزدوج على Apple Pencil",
   "Pencil Squeeze": "ضغط Apple Pencil",
-  "Pages": "الصفحات"
+  "Pages": "الصفحات",
+  "Go to Page": "الانتقال إلى الصفحة"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2027,5 +2027,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"কী সেট করুন\" ট্যাপ করার পর আপনার রিমোট কন্ট্রোলার বা কীবোর্ডের একটি বোতাম চাপুন, অথবা Apple Pencil জেসচার ব্যবহার করুন।",
   "Pencil Double Tap": "Apple Pencil ডাবল ট্যাপ",
   "Pencil Squeeze": "Apple Pencil স্কুইজ",
-  "Pages": "পৃষ্ঠা সংখ্যা"
+  "Pages": "পৃষ্ঠা সংখ্যা",
+  "Go to Page": "পৃষ্ঠায় যান"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1981,5 +1981,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"མཐེབ་གཞི་གཏན་འཁེལ།\" ལ་རེག་རྗེས། ཁྱེད་ཀྱི་རྒྱང་འཐེན་སྒྲིག་ཆས་སམ་མཐེབ་གཞི་གང་རུང་གི་ཐོག་མཐེབ་གཅིག་གནོན་པའམ། ཡང་ན་ Apple Pencil གྱི་ལག་བརྡ་བེད་སྤྱོད་བྱོས།",
   "Pencil Double Tap": "Apple Pencil ཐེངས་གཉིས་རེག་པ།",
   "Pencil Squeeze": "Apple Pencil བཙིར་བ།",
-  "Pages": "ཤོག་གྲངས།"
+  "Pages": "ཤོག་གྲངས།",
+  "Go to Page": "ཤོག་ངོས་སུ་སྐྱོད།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2027,5 +2027,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Drücken Sie eine Taste auf Ihrer Fernbedienung oder Tastatur oder verwenden Sie eine Apple Pencil-Geste, nachdem Sie auf \"Taste festlegen\" getippt haben.",
   "Pencil Double Tap": "Apple Pencil Doppeltippen",
   "Pencil Squeeze": "Apple Pencil Zusammendrücken",
-  "Pages": "Seiten"
+  "Pages": "Seiten",
+  "Go to Page": "Zu Seite springen"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2027,5 +2027,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Πατήστε ένα κουμπί στο τηλεχειριστήριο ή το πληκτρολόγιό σας, ή χρησιμοποιήστε μια χειρονομία Apple Pencil, αφού πατήσετε «Ορισμός πλήκτρου».",
   "Pencil Double Tap": "Διπλό άγγιγμα Apple Pencil",
   "Pencil Squeeze": "Πίεση Apple Pencil",
-  "Pages": "Σελίδες"
+  "Pages": "Σελίδες",
+  "Go to Page": "Μετάβαση σε σελίδα"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2073,5 +2073,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Pulse un botón en su mando a distancia o teclado, o use un gesto del Apple Pencil, después de tocar \"Asignar tecla\".",
   "Pencil Double Tap": "Doble toque del Apple Pencil",
   "Pencil Squeeze": "Apretón del Apple Pencil",
-  "Pages": "Páginas"
+  "Pages": "Páginas",
+  "Go to Page": "Ir a la página"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2027,5 +2027,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "پس از ضربه زدن به «تنظیم کلید»، دکمه‌ای روی کنترلر یا صفحه‌کلید خود فشار دهید یا از حرکت Apple Pencil استفاده کنید.",
   "Pencil Double Tap": "دو ضربه روی Apple Pencil",
   "Pencil Squeeze": "فشردن Apple Pencil",
-  "Pages": "صفحات"
+  "Pages": "صفحات",
+  "Go to Page": "رفتن به صفحه"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2073,5 +2073,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Appuyez sur un bouton de votre télécommande ou de votre clavier, ou utilisez un geste de l'Apple Pencil, après avoir appuyé sur « Définir la touche ».",
   "Pencil Double Tap": "Double toucher Apple Pencil",
   "Pencil Squeeze": "Pression Apple Pencil",
-  "Pages": "Pages"
+  "Pages": "Pages",
+  "Go to Page": "Aller à la page"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2073,5 +2073,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "לחץ על כפתור בשלט הרחוק או במקלדת, או השתמש במחוות Apple Pencil, לאחר הקשה על \"הגדר מקש\".",
   "Pencil Double Tap": "הקשה כפולה על Apple Pencil",
   "Pencil Squeeze": "לחיצה על Apple Pencil",
-  "Pages": "דפים"
+  "Pages": "דפים",
+  "Go to Page": "עבור לעמוד"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2027,5 +2027,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"कुंजी सेट करें\" दबाने के बाद अपने रिमोट कंट्रोलर या कीबोर्ड पर एक बटन दबाएं, या Apple Pencil जेस्चर का उपयोग करें।",
   "Pencil Double Tap": "Apple Pencil डबल टैप",
   "Pencil Squeeze": "Apple Pencil स्क्वीज़",
-  "Pages": "कुल पृष्ठ"
+  "Pages": "कुल पृष्ठ",
+  "Go to Page": "पृष्ठ पर जाएँ"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2027,5 +2027,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Nyomjon meg egy gombot a távirányítón vagy a billentyűzeten, vagy használjon Apple Pencil kézmozdulatot a „Billentyű beállítása” érintése után.",
   "Pencil Double Tap": "Apple Pencil dupla koppintás",
   "Pencil Squeeze": "Apple Pencil összenyomás",
-  "Pages": "Oldalak"
+  "Pages": "Oldalak",
+  "Go to Page": "Ugrás oldalra"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1981,5 +1981,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Tekan tombol pada remote controller atau keyboard Anda, atau gunakan gerakan Apple Pencil, setelah mengetuk \"Atur tombol\".",
   "Pencil Double Tap": "Ketuk Dua Kali Apple Pencil",
   "Pencil Squeeze": "Remas Apple Pencil",
-  "Pages": "Jumlah Halaman"
+  "Pages": "Jumlah Halaman",
+  "Go to Page": "Pergi ke Halaman"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2073,5 +2073,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Premi un pulsante sul telecomando o sulla tastiera, oppure usa un gesto di Apple Pencil, dopo aver toccato \"Imposta tasto\".",
   "Pencil Double Tap": "Doppio tocco Apple Pencil",
   "Pencil Squeeze": "Pressione Apple Pencil",
-  "Pages": "Pagine"
+  "Pages": "Pagine",
+  "Go to Page": "Vai alla pagina"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1981,5 +1981,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "「キーを設定」をタップした後、リモコンまたはキーボードのボタンを押すか、Apple Pencilのジェスチャを使用してください。",
   "Pencil Double Tap": "Apple Pencilのダブルタップ",
   "Pencil Squeeze": "Apple Pencilのスクイーズ",
-  "Pages": "ページ数"
+  "Pages": "ページ数",
+  "Go to Page": "ページにジャンプ"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1981,5 +1981,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"키 설정\"을 탭한 후 리모컨 또는 키보드의 버튼을 누르거나 Apple Pencil 제스처를 사용하세요.",
   "Pencil Double Tap": "Apple Pencil 이중 탭",
   "Pencil Squeeze": "Apple Pencil 스퀴즈",
-  "Pages": "페이지 수"
+  "Pages": "페이지 수",
+  "Go to Page": "페이지로 이동"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1981,5 +1981,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Tekan butang pada pengawal jauh atau papan kekunci anda, atau gunakan gerak isyarat Apple Pencil, selepas mengetuk \"Tetapkan kekunci\".",
   "Pencil Double Tap": "Ketik Dua Kali Apple Pencil",
   "Pencil Squeeze": "Picit Apple Pencil",
-  "Pages": "Jumlah Halaman"
+  "Pages": "Jumlah Halaman",
+  "Go to Page": "Pergi ke Halaman"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2027,5 +2027,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Druk op een knop op uw afstandsbediening of toetsenbord, of gebruik een Apple Pencil-gebaar, nadat u op \"Toets instellen\" hebt getikt.",
   "Pencil Double Tap": "Apple Pencil dubbel tikken",
   "Pencil Squeeze": "Apple Pencil knijpen",
-  "Pages": "Pagina's"
+  "Pages": "Pagina's",
+  "Go to Page": "Ga naar pagina"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2119,5 +2119,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Naciśnij przycisk na pilocie lub klawiaturze, albo użyj gestu Apple Pencil, po dotknięciu \"Ustaw klawisz\".",
   "Pencil Double Tap": "Dwukrotne stuknięcie Apple Pencil",
   "Pencil Squeeze": "Ściśnięcie Apple Pencil",
-  "Pages": "Strony"
+  "Pages": "Strony",
+  "Go to Page": "Przejdź do strony"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2073,5 +2073,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Pressione um botão no controle remoto ou teclado, ou use um gesto do Apple Pencil, após tocar em \"Definir tecla\".",
   "Pencil Double Tap": "Toque duplo no Apple Pencil",
   "Pencil Squeeze": "Aperto no Apple Pencil",
-  "Pages": "Páginas"
+  "Pages": "Páginas",
+  "Go to Page": "Ir para a página"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2073,5 +2073,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Pressione um botão no seu controle remoto ou teclado, ou use um gesto do Apple Pencil, após tocar em \"Definir tecla\".",
   "Pencil Double Tap": "Toque duplo no Apple Pencil",
   "Pencil Squeeze": "Aperto no Apple Pencil",
-  "Pages": "Páginas"
+  "Pages": "Páginas",
+  "Go to Page": "Ir para a página"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2073,5 +2073,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Apăsați un buton pe telecomandă sau tastatură, sau folosiți un gest Apple Pencil, după ce atingeți \"Setează tasta\".",
   "Pencil Double Tap": "Atingere dublă Apple Pencil",
   "Pencil Squeeze": "Strângere Apple Pencil",
-  "Pages": "Pagini"
+  "Pages": "Pagini",
+  "Go to Page": "Mergi la pagina"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2119,5 +2119,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Нажмите кнопку на пульте дистанционного управления или клавиатуре либо используйте жест Apple Pencil после нажатия \"Назначить клавишу\".",
   "Pencil Double Tap": "Двойное касание Apple Pencil",
   "Pencil Squeeze": "Сжатие Apple Pencil",
-  "Pages": "Страницы"
+  "Pages": "Страницы",
+  "Go to Page": "Перейти к странице"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2027,5 +2027,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"යතුර සකසන්න\" තට්ටු කිරීමෙන් පසු ඔබේ දුරස්ථ පාලකයේ හෝ යතුරු පුවරුවේ බොත්තමක් එබෙන්න, නැතහොත් Apple Pencil ඉංගිතයක් භාවිතා කරන්න.",
   "Pencil Double Tap": "Apple Pencil දෙවරක් තට්ටු කිරීම",
   "Pencil Squeeze": "Apple Pencil තද කිරීම",
-  "Pages": "පිටු ගණන"
+  "Pages": "පිටු ගණන",
+  "Go to Page": "පිටුවට යන්න"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2119,5 +2119,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Pritisnite gumb na daljinskem upravljalniku ali tipkovnici, ali uporabite potezo Apple Pencil, po tapkanju na \"Nastavi tipko\".",
   "Pencil Double Tap": "Dvojni dotik Apple Pencil",
   "Pencil Squeeze": "Stisk Apple Pencil",
-  "Pages": "Strani"
+  "Pages": "Strani",
+  "Go to Page": "Pojdi na stran"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2027,5 +2027,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Tryck på en knapp på din fjärrkontroll eller tangentbord, eller använd en Apple Pencil-gest, efter att ha tryckt på \"Ange tangent\".",
   "Pencil Double Tap": "Apple Pencil dubbeltryck",
   "Pencil Squeeze": "Apple Pencil klämning",
-  "Pages": "Sidor"
+  "Pages": "Sidor",
+  "Go to Page": "Gå till sida"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2027,5 +2027,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"விசை அமை\" தட்டிய பிறகு உங்கள் ரிமோட் கன்ட்ரோலர் அல்லது கீபோர்டில் ஒரு பட்டனை அழுத்தவும், அல்லது Apple Pencil சைகையைப் பயன்படுத்தவும்.",
   "Pencil Double Tap": "Apple Pencil இரட்டைத் தட்டு",
   "Pencil Squeeze": "Apple Pencil அழுத்துதல்",
-  "Pages": "பக்கங்கள்"
+  "Pages": "பக்கங்கள்",
+  "Go to Page": "பக்கத்திற்குச் செல்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1981,5 +1981,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "กดปุ่มบนรีโมทคอนโทรลหรือคีย์บอร์ด หรือใช้ท่าทาง Apple Pencil หลังจากแตะ \"ตั้งปุ่ม\"",
   "Pencil Double Tap": "แตะสองครั้งบน Apple Pencil",
   "Pencil Squeeze": "บีบ Apple Pencil",
-  "Pages": "จำนวนหน้า"
+  "Pages": "จำนวนหน้า",
+  "Go to Page": "ไปที่หน้า"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2027,5 +2027,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"Tuş ayarla\" düğmesine dokunduktan sonra uzaktan kumandanızdaki veya klavyenizdeki bir düğmeye basın ya da bir Apple Pencil hareketi kullanın.",
   "Pencil Double Tap": "Apple Pencil çift dokunma",
   "Pencil Squeeze": "Apple Pencil sıkma",
-  "Pages": "Sayfalar"
+  "Pages": "Sayfalar",
+  "Go to Page": "Sayfaya Git"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2119,5 +2119,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Натисніть кнопку на пульті або клавіатурі, або скористайтеся жестом Apple Pencil після натискання \"Призначити клавішу\".",
   "Pencil Double Tap": "Подвійний дотик Apple Pencil",
   "Pencil Squeeze": "Стискання Apple Pencil",
-  "Pages": "Сторінки"
+  "Pages": "Сторінки",
+  "Go to Page": "Перейти до сторінки"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2027,5 +2027,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "\"Tugmani o'rnatish\" tugmasini bosgandan so'ng masofadan boshqarish pultingiz yoki klaviaturangizdagi tugmani bosing yoki Apple Pencil imo-ishorasidan foydalaning.",
   "Pencil Double Tap": "Apple Pencil ikki marta bosish",
   "Pencil Squeeze": "Apple Pencil qisish",
-  "Pages": "Sahifalar"
+  "Pages": "Sahifalar",
+  "Go to Page": "Sahifaga o'tish"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1981,5 +1981,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "Nhấn một nút trên bộ điều khiển từ xa hoặc bàn phím, hoặc dùng cử chỉ Apple Pencil, sau khi chạm \"Đặt phím\".",
   "Pencil Double Tap": "Chạm hai lần Apple Pencil",
   "Pencil Squeeze": "Bóp Apple Pencil",
-  "Pages": "Số trang"
+  "Pages": "Số trang",
+  "Go to Page": "Đi đến trang"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1981,5 +1981,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "点击「设置按键」后，按下遥控器或键盘上的按钮，或使用 Apple Pencil 手势。",
   "Pencil Double Tap": "Apple Pencil 轻点两下",
   "Pencil Squeeze": "Apple Pencil 轻捏",
-  "Pages": "页数"
+  "Pages": "页数",
+  "Go to Page": "跳转到页码"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1981,5 +1981,6 @@
   "Press a button on your remote controller or keyboard, or use an Apple Pencil gesture, after tapping \"Set key\".": "點擊「設定按鍵」後，按下遙控器或鍵盤上的按鈕，或使用 Apple Pencil 手勢。",
   "Pencil Double Tap": "Apple Pencil 點兩下",
   "Pencil Squeeze": "Apple Pencil 輕捏",
-  "Pages": "頁數"
+  "Pages": "頁數",
+  "Go to Page": "跳轉到頁碼"
 }

--- a/apps/readest-app/src/__tests__/components/footerbar-page-jump.test.ts
+++ b/apps/readest-app/src/__tests__/components/footerbar-page-jump.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clampPage,
+  findReferencePageHref,
+  fractionForPage,
+  parsePageInput,
+} from '@/app/reader/components/footerbar/pageJump';
+
+describe('parsePageInput', () => {
+  it('parses plain page numbers', () => {
+    expect(parsePageInput('94')).toBe(94);
+    expect(parsePageInput(' 12 ')).toBe(12);
+  });
+
+  it('parses the page portion of a "current / total" field', () => {
+    expect(parsePageInput('120 / 251')).toBe(120);
+    expect(parsePageInput('94/251')).toBe(94);
+    expect(parsePageInput('7 / ')).toBe(7);
+  });
+
+  it('rejects non-numeric and non-positive input', () => {
+    expect(parsePageInput('')).toBeNull();
+    expect(parsePageInput('abc')).toBeNull();
+    expect(parsePageInput('abc / 251')).toBeNull();
+    expect(parsePageInput('12.5')).toBeNull();
+    expect(parsePageInput('-3')).toBeNull();
+    expect(parsePageInput('0')).toBeNull();
+    expect(parsePageInput('0 / 251')).toBeNull();
+  });
+});
+
+describe('clampPage', () => {
+  it('clamps to the valid page range', () => {
+    expect(clampPage(0, 251)).toBe(1);
+    expect(clampPage(94, 251)).toBe(94);
+    expect(clampPage(9999, 251)).toBe(251);
+  });
+});
+
+describe('fractionForPage', () => {
+  it('targets the middle of the requested page', () => {
+    // Page N of T equal-size pages spans [(N-1)/T, N/T); aiming at the middle
+    // keeps the jump inside page N even when page boundaries shift slightly.
+    expect(fractionForPage(1, 251)).toBeCloseTo(0.5 / 251);
+    expect(fractionForPage(94, 251)).toBeCloseTo(93.5 / 251);
+    expect(fractionForPage(251, 251)).toBeCloseTo(250.5 / 251);
+  });
+
+  it('stays within [0, 1] and handles empty books', () => {
+    expect(fractionForPage(1, 0)).toBe(0);
+    expect(fractionForPage(500, 10)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('findReferencePageHref', () => {
+  const pageList = [
+    { label: 'xii', href: 'front.html#p12' },
+    {
+      label: '1',
+      href: 'ch01.html#p1',
+      subitems: [{ label: '2', href: 'ch01.html#p2' }],
+    },
+    { label: '3 ', href: 'ch02.html#p3' },
+  ];
+
+  it('finds the href matching a numeric page label, including nested items', () => {
+    expect(findReferencePageHref(pageList, 1)).toBe('ch01.html#p1');
+    expect(findReferencePageHref(pageList, 2)).toBe('ch01.html#p2');
+    expect(findReferencePageHref(pageList, 3)).toBe('ch02.html#p3');
+  });
+
+  it('returns null when the page is not in the list', () => {
+    expect(findReferencePageHref(pageList, 42)).toBeNull();
+    expect(findReferencePageHref([], 1)).toBeNull();
+    expect(findReferencePageHref(undefined, 1)).toBeNull();
+  });
+});

--- a/apps/readest-app/src/__tests__/components/page-jump-input.test.tsx
+++ b/apps/readest-app/src/__tests__/components/page-jump-input.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+import PageJumpInput from '@/app/reader/components/footerbar/PageJumpInput';
+
+interface MockState {
+  progress: unknown;
+  viewSettings: unknown;
+  bookData: unknown;
+  hoveredBookKey: string;
+}
+
+const mocks = vi.hoisted(() => {
+  const view = { goTo: vi.fn(), goToFraction: vi.fn() };
+  const state: MockState = {
+    progress: null,
+    viewSettings: null,
+    bookData: null,
+    hoveredBookKey: '',
+  };
+  return { view, state };
+});
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    hoveredBookKey: mocks.state.hoveredBookKey,
+    getView: () => mocks.view,
+    getProgress: () => mocks.state.progress,
+    getViewSettings: () => mocks.state.viewSettings,
+  }),
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({
+    getBookData: () => mocks.state.bookData,
+  }),
+}));
+
+const setup = ({
+  progressStyle = 'fraction',
+  isFixedLayout = false,
+  pageList = undefined as unknown,
+  showFraction = false,
+} = {}) => {
+  mocks.state.progress = {
+    pageinfo: { current: 93, next: 94, total: 251 },
+    section: { current: 4, total: 30 },
+    pageItem: undefined,
+  };
+  mocks.state.viewSettings = { progressStyle };
+  mocks.state.bookData = { isFixedLayout, bookDoc: { pageList } };
+  const utils = render(<PageJumpInput bookKey='book1' showFraction={showFraction} />);
+  const input = utils.getByRole('textbox', { name: 'Go to Page' }) as HTMLInputElement;
+  return { ...utils, input };
+};
+
+beforeEach(() => {
+  mocks.view.goTo.mockClear();
+  mocks.view.goToFraction.mockClear();
+});
+
+afterEach(() => cleanup());
+
+describe('PageJumpInput', () => {
+  it('shows the page fraction as its idle label', () => {
+    const { input } = setup();
+    expect(input.value).toBe('94 / 251');
+  });
+
+  it('shows a percentage label when that progress style is selected', () => {
+    const { input } = setup({ progressStyle: 'percentage' });
+    expect(input.value).toBe('37%');
+  });
+
+  it('always shows the page fraction when showFraction is set', () => {
+    const { input } = setup({ progressStyle: 'percentage', showFraction: true });
+    expect(input.value).toBe('94 / 251');
+  });
+
+  it('renders nothing without valid progress', () => {
+    mocks.state.progress = null;
+    mocks.state.viewSettings = { progressStyle: 'fraction' };
+    mocks.state.bookData = { isFixedLayout: false, bookDoc: {} };
+    const { queryByRole } = render(<PageJumpInput bookKey='book1' />);
+    expect(queryByRole('textbox')).toBeNull();
+  });
+
+  it('keeps the same text on focus so the layout stays stable', () => {
+    const { input } = setup();
+    fireEvent.focus(input);
+    expect(input.value).toBe('94 / 251');
+  });
+
+  it('swaps a percentage label to the page fraction on focus', () => {
+    const { input } = setup({ progressStyle: 'percentage' });
+    fireEvent.focus(input);
+    expect(input.value).toBe('94 / 251');
+  });
+
+  it('jumps on Enter after the page portion is typed over', () => {
+    const { input } = setup();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '120 / 251' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mocks.view.goToFraction).toHaveBeenCalledTimes(1);
+    expect(mocks.view.goToFraction.mock.calls[0]![0]).toBeCloseTo(119.5 / 251);
+    expect(input.value).toBe('94 / 251');
+  });
+
+  it('jumps when the whole field is replaced with a bare number', () => {
+    const { input } = setup();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '120' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mocks.view.goToFraction.mock.calls[0]![0]).toBeCloseTo(119.5 / 251);
+  });
+
+  it('clamps out-of-range pages to the last page', () => {
+    const { input } = setup();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '9999 / 251' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mocks.view.goToFraction.mock.calls[0]![0]).toBeCloseTo(250.5 / 251);
+  });
+
+  it('ignores non-numeric input', () => {
+    const { input } = setup();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'abc / 251' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mocks.view.goToFraction).not.toHaveBeenCalled();
+    expect(mocks.view.goTo).not.toHaveBeenCalled();
+    expect(input.value).toBe('94 / 251');
+  });
+
+  it('cancels editing on Escape without jumping', () => {
+    const { input } = setup();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '200 / 251' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(mocks.view.goToFraction).not.toHaveBeenCalled();
+    expect(input.value).toBe('94 / 251');
+  });
+
+  it('jumps to the spine page directly for fixed layout books', () => {
+    const { input } = setup({ isFixedLayout: true });
+    expect(input.value).toBe('5 / 30');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '10 / 30' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mocks.view.goTo).toHaveBeenCalledWith(9);
+    expect(mocks.view.goToFraction).not.toHaveBeenCalled();
+  });
+
+  it('jumps via the page list href for the reference progress style', () => {
+    const { input } = setup({
+      progressStyle: 'reference',
+      pageList: [
+        { label: '1', href: 'ch01.html#p1' },
+        { label: '2', href: 'ch01.html#p2' },
+      ],
+    });
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '2 / 2' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mocks.view.goTo).toHaveBeenCalledWith('ch01.html#p2');
+    expect(mocks.view.goToFraction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/app/reader/components/footerbar/DesktopFooterBar.tsx
+++ b/apps/readest-app/src/app/reader/components/footerbar/DesktopFooterBar.tsx
@@ -6,11 +6,10 @@ import { RiArrowGoBackLine, RiArrowGoForwardLine } from 'react-icons/ri';
 import { RiArrowLeftDoubleLine, RiArrowRightDoubleLine } from 'react-icons/ri';
 import { useReaderStore } from '@/store/readerStore';
 import { useTranslation } from '@/hooks/useTranslation';
-import { useBookDataStore } from '@/store/bookDataStore';
-import { formatProgress, getReferencePageInfo } from '@/utils/progress';
 import type { FooterBarChildProps } from './types';
 import { getNavigationIcon } from './utils';
 import Button from '@/components/Button';
+import PageJumpInput from './PageJumpInput';
 
 const DesktopFooterBar: React.FC<FooterBarChildProps> = ({
   bookKey,
@@ -22,34 +21,14 @@ const DesktopFooterBar: React.FC<FooterBarChildProps> = ({
   onSpeakText,
 }) => {
   const _ = useTranslation();
-  const { hoveredBookKey, getView, getViewState, getProgress, getViewSettings } = useReaderStore();
-  const { getBookData } = useBookDataStore();
+  const { hoveredBookKey, getView, getViewState, getViewSettings } = useReaderStore();
   const view = getView(bookKey);
-  const bookData = getBookData(bookKey);
-  const progress = getProgress(bookKey);
   const viewState = getViewState(bookKey);
   const viewSettings = getViewSettings(bookKey);
-  const progressStyle = viewSettings?.progressStyle || 'percentage';
 
   const [progressValue, setProgressValue] = React.useState(
     progressValid ? progressFraction * 100 : 0,
   );
-
-  const { section, pageinfo } = progress || {};
-  const template = progressStyle === 'fraction' ? '{current} / {total}' : '{percent}%';
-  const pageInfo = bookData?.isFixedLayout ? section : pageinfo;
-  const referenceInfo =
-    progressStyle === 'reference'
-      ? getReferencePageInfo({
-          pageList: bookData?.bookDoc?.pageList,
-          pageItem: progress?.pageItem,
-          fraction: progressFraction,
-          referencePageCount: viewSettings?.referencePageCount,
-        })
-      : null;
-  const progressInfo = referenceInfo
-    ? `${referenceInfo.current} / ${referenceInfo.total}`
-    : formatProgress(pageInfo?.current, pageInfo?.total, template, false, 'en', 0);
 
   const rangeInputRef = useRef<HTMLInputElement>(null);
 
@@ -120,15 +99,7 @@ const DesktopFooterBar: React.FC<FooterBarChildProps> = ({
         label={_('Go Forward')}
         disabled={!view?.history.canGoForward}
       />
-      {progressValid && (
-        <span
-          title={_('Reading Progress')}
-          aria-label={`${_('Reading Progress')}: ${Math.round(progressFraction * 100)}%`}
-          className='mx-2 text-nowrap text-center text-sm'
-        >
-          <span aria-hidden='true'>{progressInfo}</span>
-        </span>
-      )}
+      {progressValid && <PageJumpInput bookKey={bookKey} className='mx-2 text-sm' />}
       <input
         ref={rangeInputRef}
         type='range'

--- a/apps/readest-app/src/app/reader/components/footerbar/NavigationPanel.tsx
+++ b/apps/readest-app/src/app/reader/components/footerbar/NavigationPanel.tsx
@@ -10,6 +10,7 @@ import { NavigationHandlers } from './types';
 import { getNavigationIcon } from './utils';
 import Button from '@/components/Button';
 import Slider from '@/components/Slider';
+import PageJumpInput from './PageJumpInput';
 
 interface NavigationPanelProps {
   bookKey: string;
@@ -79,14 +80,21 @@ export const NavigationPanel: React.FC<NavigationPanelProps> = ({
           : bottomOffset,
       }}
     >
-      <div className='flex w-full items-center justify-between gap-x-6'>
-        <Slider
-          label={_('Reading Progress')}
-          heightPx={sliderHeight}
-          bubbleLabel={`${Math.round(progressValue)}%`}
-          initialValue={progressValue}
-          onChange={handleProgressChange}
-        />
+      <div className='flex w-full flex-col items-center gap-y-4'>
+        {progressValid && (
+          <div className='eink-bordered bg-base-100 rounded-full px-2 py-1'>
+            <PageJumpInput bookKey={bookKey} showFraction className='text-base' />
+          </div>
+        )}
+        <div className='flex w-full items-center justify-between gap-x-6'>
+          <Slider
+            label={_('Reading Progress')}
+            heightPx={sliderHeight}
+            bubbleLabel={`${Math.round(progressValue)}%`}
+            initialValue={progressValue}
+            onChange={handleProgressChange}
+          />
+        </div>
       </div>
       <div className='flex w-full items-center justify-between gap-x-6'>
         <Button

--- a/apps/readest-app/src/app/reader/components/footerbar/PageJumpInput.tsx
+++ b/apps/readest-app/src/app/reader/components/footerbar/PageJumpInput.tsx
@@ -1,0 +1,152 @@
+import clsx from 'clsx';
+import React, { useEffect, useRef, useState } from 'react';
+import { useReaderStore } from '@/store/readerStore';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useBookDataStore } from '@/store/bookDataStore';
+import { formatProgress, getReferencePageInfo } from '@/utils/progress';
+import { clampPage, findReferencePageHref, fractionForPage, parsePageInput } from './pageJump';
+
+interface PageJumpInputProps {
+  bookKey: string;
+  /** Always show '{current} / {total}' regardless of the progress style. */
+  showFraction?: boolean;
+  className?: string;
+}
+
+/**
+ * The footer bar's progress label, editable in place: clicking it selects the
+ * current page number inside the "94 / 251" text so a target page can be
+ * typed over it. Enter jumps there; Escape or blur cancels. An invisible
+ * sizer span reserves the label's width so toggling edit mode never shifts
+ * the surrounding layout.
+ */
+const PageJumpInput: React.FC<PageJumpInputProps> = ({ bookKey, showFraction, className }) => {
+  const _ = useTranslation();
+  const { hoveredBookKey, getView, getProgress, getViewSettings } = useReaderStore();
+  const { getBookData } = useBookDataStore();
+  const view = getView(bookKey);
+  const bookData = getBookData(bookKey);
+  const progress = getProgress(bookKey);
+  const viewSettings = getViewSettings(bookKey);
+  const progressStyle = viewSettings?.progressStyle || 'percentage';
+
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [selectLength, setSelectLength] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!editing) return;
+    // Select the current page portion so typing replaces it. The rAF runs
+    // after the browser's own click handling, which would otherwise collapse
+    // the selection to a caret on mouse-up.
+    const raf = requestAnimationFrame(() => {
+      inputRef.current?.setSelectionRange(0, selectLength);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [editing, selectLength]);
+
+  useEffect(() => {
+    // The footer bar hid (or another book took focus) mid-edit.
+    if (hoveredBookKey !== bookKey && document.activeElement === inputRef.current) {
+      inputRef.current?.blur();
+    }
+  }, [hoveredBookKey, bookKey]);
+
+  const { section, pageinfo } = progress || {};
+  const pageInfo = bookData?.isFixedLayout ? section : pageinfo;
+  const progressValid = !!pageInfo && pageInfo.total > 0 && pageInfo.current >= 0;
+  if (!progressValid) return null;
+
+  const progressFraction = (pageInfo.current + 1) / pageInfo.total;
+  const referenceInfo =
+    progressStyle === 'reference'
+      ? getReferencePageInfo({
+          pageList: bookData?.bookDoc?.pageList,
+          pageItem: progress?.pageItem,
+          fraction: progressFraction,
+          referencePageCount: viewSettings?.referencePageCount,
+        })
+      : null;
+  const template =
+    showFraction || progressStyle === 'fraction' ? '{current} / {total}' : '{percent}%';
+  const displayText = referenceInfo
+    ? `${referenceInfo.current} / ${referenceInfo.total}`
+    : formatProgress(pageInfo.current, pageInfo.total, template, false, 'en', 0);
+
+  const total = referenceInfo ? referenceInfo.total : pageInfo.total;
+  const currentLabel = referenceInfo ? referenceInfo.current : String(pageInfo.current + 1);
+
+  const jumpToPage = (page: number) => {
+    if (!view) return;
+    const target = clampPage(page, total);
+    if (referenceInfo) {
+      const href = findReferencePageHref(bookData?.bookDoc?.pageList, target);
+      if (href) view.goTo(href);
+      else view.goToFraction(fractionForPage(target, total));
+    } else if (bookData?.isFixedLayout) {
+      view.goTo(target - 1);
+    } else {
+      view.goToFraction(fractionForPage(target, total));
+    }
+  };
+
+  const stopEditing = () => {
+    setEditing(false);
+    inputRef.current?.blur();
+  };
+
+  const commitDraft = () => {
+    const page = parsePageInput(draft);
+    if (page !== null) jumpToPage(page);
+    stopEditing();
+  };
+
+  const text = editing ? draft : displayText;
+
+  return (
+    <div
+      className={clsx(
+        'relative flex items-center rounded-md text-nowrap transition-colors',
+        editing
+          ? 'eink-bordered bg-base-content/10'
+          : 'hover:bg-base-content/10 cursor-pointer bg-transparent',
+        className,
+      )}
+    >
+      {/* Invisible sizer: the box is always as wide as its text, so swapping
+          between label and edit modes never shifts the surrounding layout. */}
+      <span aria-hidden='true' className='invisible whitespace-pre px-1 py-0.5'>
+        {text}
+      </span>
+      <input
+        ref={inputRef}
+        type='text'
+        inputMode='numeric'
+        enterKeyHint='go'
+        title={_('Go to Page')}
+        aria-label={_('Go to Page')}
+        value={text}
+        className='absolute inset-0 h-full w-full bg-transparent text-center focus:outline-none'
+        onFocus={() => {
+          // Keep the "current / total" text as-is (percentage style swaps to
+          // it) and pre-select the page portion for type-over editing.
+          setDraft(`${currentLabel} / ${total}`);
+          setSelectLength(currentLabel.length);
+          setEditing(true);
+        }}
+        onBlur={() => setEditing(false)}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          // Keep keystrokes away from the reader's page-turn shortcuts and
+          // the footer bar's spatial navigation.
+          e.stopPropagation();
+          if (e.key === 'Enter') commitDraft();
+          else if (e.key === 'Escape') stopEditing();
+        }}
+      />
+    </div>
+  );
+};
+
+export default PageJumpInput;

--- a/apps/readest-app/src/app/reader/components/footerbar/pageJump.ts
+++ b/apps/readest-app/src/app/reader/components/footerbar/pageJump.ts
@@ -1,0 +1,46 @@
+export interface PageListItem {
+  label?: string;
+  href?: string;
+  subitems?: PageListItem[] | null;
+}
+
+/**
+ * Parse user input as a 1-based page number. The edit field keeps its
+ * "94 / 251" shape while the page portion is typed over, so a trailing
+ * "/ total" is accepted and ignored.
+ */
+export function parsePageInput(text: string): number | null {
+  const match = text.match(/^\s*(\d+)\s*(?:\/\s*\d*\s*)?$/);
+  if (!match) return null;
+  const page = parseInt(match[1]!, 10);
+  return page > 0 ? page : null;
+}
+
+export function clampPage(page: number, total: number): number {
+  return Math.min(Math.max(page, 1), total);
+}
+
+/**
+ * Fraction that lands inside 1-based page N of `total` equal-size pages.
+ * Page N spans [(N-1)/T, N/T); aiming at the middle keeps the jump inside
+ * the page even when the paginator's boundaries shift slightly.
+ */
+export function fractionForPage(page: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.min(1, Math.max(0, (page - 0.5) / total));
+}
+
+/** Exact href for a reference page label, when the book has a page list. */
+export function findReferencePageHref(
+  pageList: PageListItem[] | null | undefined,
+  page: number,
+): string | null {
+  if (!pageList?.length) return null;
+  const target = String(page);
+  for (const item of pageList) {
+    if (item.label?.trim() === target && item.href) return item.href;
+    const nested = findReferencePageHref(item.subitems, page);
+    if (nested) return nested;
+  }
+  return null;
+}

--- a/apps/readest-app/src/types/view.ts
+++ b/apps/readest-app/src/types/view.ts
@@ -75,7 +75,7 @@ export interface FoliateView extends HTMLElement {
   open: (book: BookDoc) => Promise<void>;
   close: () => void;
   init: (options: { lastLocation: string }) => void;
-  goTo: (href: string) => void;
+  goTo: (target: string | number) => void;
   goToFraction: (fraction: number) => void;
   getSectionFractions: () => number[];
   prev: (distance?: number) => void;
@@ -145,11 +145,11 @@ export const wrappedFoliateView = (originalView: FoliateView): FoliateView => {
   // Foliate's runtime implementation returns a Promise. Returning a Promise
   // here is compatible with the void return type in TypeScript and lets callers
   // that know about the promise (e.g. tests, async handlers) await completion.
-  originalView.goTo = (href: string): Promise<void> => {
+  originalView.goTo = (target: string | number): Promise<void> => {
     // Cross-section jumps can take seconds (the target section's images block
     // its iframe load); surface start/end so the viewer can show a spinner.
     originalView.dispatchEvent(new CustomEvent('navigate-start'));
-    return Promise.resolve(originalGoTo(href)).finally(() => {
+    return Promise.resolve(originalGoTo(target)).finally(() => {
       originalView.dispatchEvent(new CustomEvent('navigate-end'));
     });
   };


### PR DESCRIPTION
## Summary

Closes #3392

The footer bar's progress label ("94 / 251") is now an in-place page-number input on both desktop and mobile:

- **Desktop**: clicking the label selects the current page inside the "94 / 251" text; typing replaces it and Enter jumps there. Escape or clicking away cancels. The input keeps its text and width when entering edit mode (an invisible sizer span reserves the label width), so the surrounding footer controls never shift.
- **Mobile**: the progress panel gains the same control as a pill label above the progress slider, always shown as "current / total" (the slider bubble already shows the percentage). Tapping it opens the numeric keyboard.
- Jump targets per book type: reflowable books map the page onto the reading fraction (aiming at the middle of the target page), fixed-layout books go to the spine page directly, and the reference progress style resolves the book's page-list href when one exists (falling back to a fraction estimate). Out-of-range input clamps to the last page; jumps push history so Go Back returns to the previous spot.
- The percentage progress style keeps its "39%" label; focusing swaps to "94 / 251" so the typed number is unambiguous.
- E-ink: the edit state uses `eink-bordered`; the mobile pill is `eink-bordered` too.
- e2e: `ReaderPage.readingProgress()` now reads the page-jump input (the old `span[title="Reading Progress"]` is gone), and a new page-jump spec covers the flow.

## Test plan

- [x] Unit tests for the pure jump logic (parse/clamp/fraction/page-list lookup) and the input component behavior (focus/type-over/Enter/Escape/clamp/fixed-layout/reference)
- [x] `pnpm test` (8714 passed), `pnpm lint`, `pnpm format:check`
- [x] Playwright web e2e: reading spec incl. new "jumps to an entered page number" test
- [x] Verified live in Chrome (desktop + narrow mobile layout, light/dark/sepia, e-ink edit state): label click selects the page, typing + Enter jumps, layout stays stable
- [x] Device check: software keyboard vs bottom progress panel on Android/iOS apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)