### PR TITLE
fix(annotator): return to the selection toolbar after closing a lookup popup (#5213)

### DIFF
--- a/apps/readest-app/e2e/pages/ReaderPage.ts
+++ b/apps/readest-app/e2e/pages/ReaderPage.ts
@@ -22,6 +22,8 @@ export class ReaderPage extends BasePage {
   readonly searchResults: Locator;
   readonly annotationPopup: Locator;
   readonly dictionaryPopup: Locator;
+  readonly translatorPopup: Locator;
+  readonly proofreadPopup: Locator;
   readonly noteEditor: Locator;
   readonly annotationItems: Locator;
 
@@ -39,6 +41,8 @@ export class ReaderPage extends BasePage {
     // The dictionary shares Popup's `.popup-container` chrome with the
     // translator, so key off its results header test id instead.
     this.dictionaryPopup = page.locator('.popup-container:has([data-testid="dict-title"])');
+    this.translatorPopup = page.locator('.popup-container:has(h1:text-is("Original Text"))');
+    this.proofreadPopup = page.locator('.popup-container:has-text("Selected text:")');
     this.noteEditor = page.locator('.note-editor-container');
     this.annotationItems = page.locator('li.booknote-item[role="button"]');
   }

--- a/apps/readest-app/e2e/pages/ReaderPage.ts
+++ b/apps/readest-app/e2e/pages/ReaderPage.ts
@@ -21,6 +21,7 @@ export class ReaderPage extends BasePage {
   readonly tocItems: Locator;
   readonly searchResults: Locator;
   readonly annotationPopup: Locator;
+  readonly dictionaryPopup: Locator;
   readonly noteEditor: Locator;
   readonly annotationItems: Locator;
 
@@ -35,6 +36,9 @@ export class ReaderPage extends BasePage {
     this.tocItems = page.locator('.toc-list [role="treeitem"]');
     this.searchResults = page.locator('.search-results li[role="button"]');
     this.annotationPopup = page.locator('.selection-popup');
+    // The dictionary shares Popup's `.popup-container` chrome with the
+    // translator, so key off its results header test id instead.
+    this.dictionaryPopup = page.locator('.popup-container:has([data-testid="dict-title"])');
     this.noteEditor = page.locator('.note-editor-container');
     this.annotationItems = page.locator('li.booknote-item[role="button"]');
   }

--- a/apps/readest-app/e2e/tests/annotation.spec.ts
+++ b/apps/readest-app/e2e/tests/annotation.spec.ts
@@ -20,6 +20,25 @@ test.describe('Annotation', () => {
     await expect(reader.annotationItems).toHaveCount(1);
   });
 
+  test('closing the dictionary popup returns to the selection toolbar (#5213)', async ({
+    openBook,
+  }) => {
+    const reader = await openBook();
+
+    await reader.selectText();
+    await reader.popupTool('Dictionary').click();
+    await expect(reader.dictionaryPopup).toBeVisible();
+    await expect(reader.annotationPopup).toBeHidden();
+
+    await reader.page.keyboard.press('Escape');
+
+    await expect(reader.dictionaryPopup).toBeHidden();
+    // The selection survives the lookup, so its toolbar must come back with
+    // it — before the fix the dismiss discarded both.
+    await expect(reader.annotationPopup).toBeVisible();
+    await expect(reader.popupTool('Highlight')).toBeVisible();
+  });
+
   test('changes the highlight color', async ({ openBook }) => {
     const reader = await openBook();
 

--- a/apps/readest-app/e2e/tests/annotation.spec.ts
+++ b/apps/readest-app/e2e/tests/annotation.spec.ts
@@ -39,6 +39,42 @@ test.describe('Annotation', () => {
     await expect(reader.popupTool('Highlight')).toBeVisible();
   });
 
+  // The translator and proofread popups keep the selection alive by the same
+  // mechanism as the dictionary, so their dismiss lands on the same toolbar.
+  test('closing the translator popup returns to the selection toolbar (#5213)', async ({
+    openBook,
+  }) => {
+    const reader = await openBook();
+
+    await reader.selectText();
+    await reader.popupTool('Translate').click();
+    await expect(reader.translatorPopup).toBeVisible();
+    await expect(reader.annotationPopup).toBeHidden();
+
+    await reader.page.keyboard.press('Escape');
+
+    await expect(reader.translatorPopup).toBeHidden();
+    await expect(reader.annotationPopup).toBeVisible();
+    await expect(reader.popupTool('Highlight')).toBeVisible();
+  });
+
+  test('closing the proofread popup returns to the selection toolbar (#5213)', async ({
+    openBook,
+  }) => {
+    const reader = await openBook();
+
+    await reader.selectText();
+    await reader.popupTool('Proofread').click();
+    await expect(reader.proofreadPopup).toBeVisible();
+    await expect(reader.annotationPopup).toBeHidden();
+
+    await reader.page.keyboard.press('Escape');
+
+    await expect(reader.proofreadPopup).toBeHidden();
+    await expect(reader.annotationPopup).toBeVisible();
+    await expect(reader.popupTool('Highlight')).toBeVisible();
+  });
+
   test('changes the highlight color', async ({ openBook }) => {
     const reader = await openBook();
 

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -1096,6 +1096,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     setShowAnnotPopup(true);
     setShowDeepLPopup(false);
     setShowDictionaryPopup(false);
+    setShowProofreadPopup(false);
   };
 
   const handleCopy = (dismissPopup = true) => {
@@ -1905,13 +1906,16 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     .map(buildToolButton)
     .filter((button): button is NonNullable<typeof button> => button !== null);
 
-  // The in-app dictionary never deselects (handleDictionary), so a genuine
-  // selection is still live when the popup closes — return to its toolbar
-  // instead of discarding it (#5213). Word Lens gloss taps and taps on an
-  // existing highlight synthesize their selection with isTextSelected left
-  // false, and an empty toolbar has nothing to return to: both keep the
-  // full dismiss.
-  const handleDismissDictionaryPopup = () => {
+  // The lookup popups never deselect (handleDictionary / handleTranslation /
+  // handleProofread only flip popup flags), so a genuine selection is still
+  // live when one closes — return to its toolbar instead of discarding it
+  // (#5213). Word Lens gloss taps and taps on an existing highlight
+  // synthesize their selection with isTextSelected left false, and an empty
+  // toolbar has nothing to return to: those keep the full dismiss. The
+  // consuming actions are a different class by design — copy, share, search,
+  // and TTS spend the selection (TTS deselects deliberately), and highlight /
+  // annotate replace it with the created annotation — so they are not here.
+  const handleDismissPopupShowToolbar = () => {
     if (isTextSelected.current && toolButtons.length > 0) {
       handleShowAnnotPopup();
     } else {
@@ -1941,7 +1945,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
               <DictionarySheet
                 word={selection?.text as string}
                 lang={bookData.bookDoc?.metadata.language as string}
-                onDismiss={handleDismissDictionaryPopup}
+                onDismiss={handleDismissPopupShowToolbar}
                 onManage={onManage}
               />
             );
@@ -1955,7 +1959,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
               trianglePosition={trianglePosition}
               popupWidth={dictPopupWidth}
               popupHeight={dictPopupHeight}
-              onDismiss={handleDismissDictionaryPopup}
+              onDismiss={handleDismissPopupShowToolbar}
               onManage={onManage}
             />
           );
@@ -1967,7 +1971,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
           trianglePosition={trianglePosition}
           popupWidth={transPopupWidth}
           popupHeight={transPopupHeight}
-          onDismiss={handleDismissPopupAndSelection}
+          onDismiss={handleDismissPopupShowToolbar}
         />
       )}
       {showAnnotPopup &&
@@ -2005,7 +2009,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
           trianglePosition={trianglePosition}
           popupWidth={proofreadPopupWidth}
           popupHeight={proofreadPopupHeight}
-          onDismiss={handleDismissPopupAndSelection}
+          onDismiss={handleDismissPopupShowToolbar}
           onManage={() => {
             handleDismissPopupAndSelection();
             setProofreadRulesVisibility(true);

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -1905,6 +1905,20 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     .map(buildToolButton)
     .filter((button): button is NonNullable<typeof button> => button !== null);
 
+  // The in-app dictionary never deselects (handleDictionary), so a genuine
+  // selection is still live when the popup closes — return to its toolbar
+  // instead of discarding it (#5213). Word Lens gloss taps and taps on an
+  // existing highlight synthesize their selection with isTextSelected left
+  // false, and an empty toolbar has nothing to return to: both keep the
+  // full dismiss.
+  const handleDismissDictionaryPopup = () => {
+    if (isTextSelected.current && toolButtons.length > 0) {
+      handleShowAnnotPopup();
+    } else {
+      handleDismissPopupAndSelection();
+    }
+  };
+
   return (
     <div ref={containerRef} role='toolbar' tabIndex={-1}>
       {showDictionaryPopup &&
@@ -1927,7 +1941,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
               <DictionarySheet
                 word={selection?.text as string}
                 lang={bookData.bookDoc?.metadata.language as string}
-                onDismiss={handleDismissPopupAndSelection}
+                onDismiss={handleDismissDictionaryPopup}
                 onManage={onManage}
               />
             );
@@ -1941,7 +1955,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
               trianglePosition={trianglePosition}
               popupWidth={dictPopupWidth}
               popupHeight={dictPopupHeight}
-              onDismiss={handleDismissPopupAndSelection}
+              onDismiss={handleDismissDictionaryPopup}
               onManage={onManage}
             />
           );


### PR DESCRIPTION
Refs #5213

## Summary

- Closing the dictionary, translator, or proofread popup discards the selection: the text stays selected in the page but the toolbar is gone, so highlighting or copying means selecting again. The reporter hits this through the dictionary quick action, which they currently disable entirely to do anything else with the text.
- Closing any of these lookup popups (or the small-screen dictionary sheet) now returns to the selection toolbar whenever the selection is still alive.

## Root Cause

All three popup handlers keep the selection by design — `handleDictionary`, `handleTranslation`, and `handleProofread` only flip popup flags — so the selection intentionally outlives the popup. But every popup's `onDismiss` was `handleDismissPopupAndSelection`, which deselects and clears the selection state on the way out, discarding the still-live selection the UI was conceptually holding. Fixing only the dictionary would have left one dismiss boundary carrying two semantics, so the three lookup popups share one handler.

The other toolbar actions are a different class and stay put: copy, share, search, and TTS spend the selection (TTS deselects deliberately so playback doesn't leave a stray highlight), and highlight / annotate replace it with the created annotation, moving the context to the highlight options or the notebook note editor.

## Changes

- One shared `handleDismissPopupShowToolbar` in `Annotator.tsx`: when `isTextSelected.current` is set (the genuine selection pipeline in `useTextSelector`) and `toolButtons.length > 0` (the existing empty-toolbar render gate), it runs the established `handleShowAnnotPopup()` transition; otherwise it falls back to the previous full dismiss.
- Wired to `DictionaryPopup`, `DictionarySheet`, `TranslatorPopup`, and `ProofreadPopup`. `handleShowAnnotPopup` now also hides the proofread popup, so the transition leaves exactly one popup visible — previously a proofread dismiss would have stacked it on top of the toolbar.
- Three regression tests in `e2e/tests/annotation.spec.ts` (dictionary, translator, proofread) plus popup locators on `ReaderPage`, keyed on content hooks since the popups share Popup's `.popup-container` chrome.

## Behavior

- Select text → Dictionary / Translate / Proofread → close: the toolbar returns on the same selection and every tool works without re-selecting.
- This also covers the quick-action flow the report is actually about: long-press a word, the dictionary opens instantly, close it, and the toolbar is there to highlight or copy. Previously that close discarded the selection.
- Intentionally preserved: Word Lens gloss lookups and taps on existing highlights (both synthesize their selection with `isTextSelected` left false), the system-dictionary path, empty-toolbar configurations, the `onManage` settings paths, and all consuming actions listed above.

## Scope

- One component (`Annotator.tsx`) plus e2e files. The popups are format-agnostic, so all formats and reading modes share the fix; the desktop popup and mobile sheet share the handler.
- Out of scope: the issue's other ask — firing the dictionary quick action only for single words. Multi-word terms (phrasal verbs, CJK idioms) are legitimate lookups and CJK text has no whitespace word boundaries, so any length or word-count gate would be an unreliable predicate. The issue stays open for that decision.

## Testing

- **Automated:** the three new Playwright e2e tests (select → popup tool → Escape → popup hidden, toolbar visible) were verified failing before the fix at exactly the toolbar assertion and pass after; the full annotation spec passes 10/10. The full unit suite passes (8693 tests) under the repository-pinned Node 24. `pnpm lint` (tsgo + biome) and `pnpm format:check` clean.
- **Unverified:** visual selection persistence after the popup closes on iOS/Android touch WebViews (the code path never calls `deselect`, but on-device confirmation is pending); the `DictionarySheet` small-screen presentation has no e2e coverage (Playwright runs desktop Chromium; the handler is shared with the tested popup paths).