### PR TITLE
fix(kosync): stop re-prompting resolved sync conflicts on window re-activation (#5527)

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useKOSync.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useKOSync.test.tsx
@@ -69,6 +69,9 @@ const h = vi.hoisted(() => {
     getProgressMock: vi.fn(),
     updateProgressMock: vi.fn(async (..._args: unknown[]) => {}),
     eventListeners: new Map<string, Set<(e: CustomEvent) => void>>(),
+    // Captured useWindowActiveChanged callback — lets tests simulate the
+    // window losing/regaining visibility (e.g. a system dictionary popup).
+    activeCallback: null as ((isActive: boolean) => void) | null,
   };
 });
 
@@ -80,8 +83,10 @@ vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => (s: string) => s,
 }));
 
-vi.mock('./useWindowActiveChanged', () => ({
-  useWindowActiveChanged: () => {},
+vi.mock('@/app/reader/hooks/useWindowActiveChanged', () => ({
+  useWindowActiveChanged: (cb: (isActive: boolean) => void) => {
+    h.activeCallback = cb;
+  },
 }));
 
 vi.mock('@/store/settingsStore', () => ({
@@ -195,6 +200,7 @@ beforeEach(() => {
   h.goTo.mockClear();
   h.goToFraction.mockClear();
   h.eventListeners.clear();
+  h.activeCallback = null;
 });
 
 afterEach(() => {
@@ -254,5 +260,87 @@ describe('useKOSync — no clobbering when the pull is unresolved (#5065)', () =
     expect(h.updateProgressMock).toHaveBeenCalled();
     // Restore for other tests.
     h.view.getCFIProgress = vi.fn(async () => ({ fraction: 0.6 }));
+  });
+});
+
+describe('useKOSync — no phantom re-prompt after resolving (#5527)', () => {
+  test('a report echoed from this same device never prompts, even when its XPointer cannot be resolved', async () => {
+    // The server holds what THIS device pushed. Its percentage was computed
+    // with the same formula as the local one, so they compare directly; the
+    // XPointer round-trip (which can fail or mis-anchor) must not force a
+    // conflict the way it does for other-device reports (#5065).
+    h.remote = {
+      progress: h.XPOINTER,
+      percentage: 0.14,
+      timestamp: Math.floor(Date.now() / 1000) + 10_000,
+      device_id: 'this-device',
+    };
+    h.getProgressMock.mockResolvedValue(h.remote);
+    h.cfiResolves = false;
+
+    const { result } = renderHook(() => useKOSync('h1-view1'));
+    await settle();
+
+    expect(result.current.syncState).toBe('synced');
+    expect(result.current.conflictDetails).toBeNull();
+  });
+
+  test('an already-resolved unchanged remote report does not re-prompt on window re-activation', async () => {
+    // Genuine conflict on open: remote resolves to 0.6 vs local 0.14.
+    const { result } = renderHook(() => useKOSync('h1-view1'));
+    await settle();
+    expect(result.current.syncState).toBe('conflict');
+
+    await act(async () => {
+      result.current.resolveWithLocal();
+      await flushMicrotasks();
+    });
+    expect(result.current.syncState).toBe('synced');
+
+    // System dictionary popup: window hidden, then visible again. The re-pull
+    // still returns the exact report the user just resolved (the resolve-time
+    // push may not have landed on the server yet).
+    await act(async () => {
+      h.activeCallback?.(false);
+      await flushMicrotasks();
+    });
+    await act(async () => {
+      h.activeCallback?.(true);
+      await flushMicrotasks();
+    });
+
+    expect(result.current.syncState).toBe('synced');
+    expect(result.current.conflictDetails).toBeNull();
+  });
+
+  test('a NEW remote report after resolution still prompts', async () => {
+    const { result } = renderHook(() => useKOSync('h1-view1'));
+    await settle();
+    expect(result.current.syncState).toBe('conflict');
+
+    await act(async () => {
+      result.current.resolveWithLocal();
+      await flushMicrotasks();
+    });
+    expect(result.current.syncState).toBe('synced');
+
+    // KOReader pushed a genuinely new position while we were away.
+    h.getProgressMock.mockResolvedValue({
+      progress: '/body/DocFragment[326]/body/div/p[9]/text().0',
+      percentage: 0.2,
+      timestamp: Math.floor(Date.now() / 1000) + 20_000,
+      device_id: 'other-device',
+    });
+
+    await act(async () => {
+      h.activeCallback?.(false);
+      await flushMicrotasks();
+    });
+    await act(async () => {
+      h.activeCallback?.(true);
+      await flushMicrotasks();
+    });
+
+    expect(result.current.syncState).toBe('conflict');
   });
 });

--- a/apps/readest-app/src/app/reader/hooks/useKOSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useKOSync.ts
@@ -76,6 +76,11 @@ export const useKOSync = (bookKey: string, provider: KosyncProgressProvider = ko
   const [conflictDetails, setConflictDetails] = useState<SyncDetails | null>(null);
   const [errorMessage] = useState<string | null>(null);
   const hasPulledOnce = useRef(false);
+  // The remote report the user last settled via the conflict dialog. A re-pull
+  // (window re-activation, e.g. returning from a system dictionary popup) that
+  // returns this exact unchanged report must not re-open the dialog — only a
+  // report that changed since is a new conflict (#5527).
+  const resolvedRemoteRef = useRef<KoSyncProgress | null>(null);
 
   // Reactive subscription: drives the auto-push effect and the initial
   // pull-on-open effect below. Reads from readerProgressStore.
@@ -251,6 +256,19 @@ export const useKOSync = (bookKey: string, provider: KosyncProgressProvider = ko
           percentage: formatProgressPercentage(remotePercentage),
         });
       }
+    } else if (isSameDevice) {
+      // A report this device pushed carries a percentage computed with the
+      // same formula as localPercentage, so the two compare directly. Don't
+      // round-trip our own XPointer through the CREngine drift correction:
+      // it can mis-anchor or fail to resolve, and an 'unresolved' failure
+      // would force a phantom conflict on every window re-activation (#5527).
+      // The #5065 protection exists for OTHER devices' positions; overwriting
+      // this device's own stale echo is fine.
+      showConflictDetails =
+        Math.abs(localPercentage - remotePercentage) > conflictProgressDiffThreshold;
+      remotePreview = _('Approximately {{percentage}}%', {
+        percentage: formatProgressPercentage(remotePercentage),
+      });
     } else {
       // KOReader's reported percentage comes from its own pagination, so it's
       // not directly comparable to Readest's progress. Resolve the remote
@@ -345,6 +363,16 @@ export const useKOSync = (bookKey: string, provider: KosyncProgressProvider = ko
         applyRemoteProgress(book, bookDoc, remoteProgress);
         setSyncState('synced');
       } else if (strategy === 'prompt') {
+        const resolved = resolvedRemoteRef.current;
+        const isAlreadyResolved =
+          !!resolved &&
+          resolved.progress === remoteProgress.progress &&
+          resolved.timestamp === remoteProgress.timestamp &&
+          resolved.device_id === remoteProgress.device_id;
+        if (isAlreadyResolved) {
+          setSyncState('synced');
+          return;
+        }
         // Only stay in the conflict state when there's an actual conflict to
         // resolve; otherwise return to 'synced' so auto-push keeps working.
         const hasConflict = await promptedSync(book, bookDoc, progress, remoteProgress);
@@ -432,6 +460,7 @@ export const useKOSync = (bookKey: string, provider: KosyncProgressProvider = ko
   });
 
   const resolveWithLocal = () => {
+    resolvedRemoteRef.current = conflictDetails?.remote ?? null;
     pushProgress();
     pushProgress.flush();
     setSyncState('synced');
@@ -447,6 +476,7 @@ export const useKOSync = (bookKey: string, provider: KosyncProgressProvider = ko
     if (!book || !bookDoc || !remote || !view) return;
     if (!remote.progress && getRemoteFraction(remote) === undefined) return;
 
+    resolvedRemoteRef.current = remote;
     applyRemoteProgress(book, bookDoc, remote);
     setSyncState('synced');
     setConflictDetails(null);


### PR DESCRIPTION
Closes #5527

### Problem

On Android, closing a system dictionary popup (e.g. DictTango) re-showed the KOSync conflict dialog every time, even right after the user had resolved it. Any app switch that toggles window visibility could do the same.

`useKOSync` re-pulls remote progress on every window re-activation and rebuilt the conflict state from scratch. Two holes turned that into a phantom-conflict loop:

1. **No memory of the resolution.** If the re-pull returned the exact report the user had just settled (the resolve-time push may not have landed on the server yet), the identical conflict re-prompted.
2. **Same-device echoes took the fragile comparison path.** Once the resolve-time push lands, the pull returns this device's own report, but `promptedSync` still round-tripped its XPointer through the CREngine drift correction. The drift anchor treats our foliate-locations percentage as CREngine data and can mis-anchor near section boundaries, and a resolution failure hits the #5065 "unresolved means conflict" rule, which unconditionally forces the prompt. That rule protects other devices' positions; applied to our own echo it creates a conflict loop with ourselves.

### Fix

- Remember the remote report settled via the conflict dialog (`progress` + `timestamp` + `device_id`); a re-pull returning that identical report goes straight to `synced`. A report that changed since resolution (KOReader genuinely pushed new progress) still prompts.
- Compare same-device reports by percentage directly: the pushed percentage was computed with the same formula as the local one, so no XPointer resolution is needed. The #5065 protection still applies to other-device reports.

Both apply to the BookOrbit provider too since it shares the hook.

### Tests

- New: a same-device echo never prompts, even when its XPointer cannot be resolved.
- New: an already-resolved unchanged remote report does not re-prompt on window re-activation (simulates the dictionary popup).
- New positive control: a new remote report after resolution still prompts.

The two bug tests failed with `expected 'conflict' to be 'synced'` before the fix. Full suite (8717 tests), `pnpm lint`, and `pnpm format:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)