### PR TITLE
fix(annotator): fall back to the selection toolbar when the dictionary quick action gets a multi-word selection

### DIFF
--- a/apps/readest-app/src/__tests__/utils/word-lookup-term.test.ts
+++ b/apps/readest-app/src/__tests__/utils/word-lookup-term.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { isSingleLookupTerm } from '../../utils/word';
+
+describe('isSingleLookupTerm', () => {
+  it('rejects empty and whitespace-only text', () => {
+    expect(isSingleLookupTerm('')).toBe(false);
+    expect(isSingleLookupTerm('   ')).toBe(false);
+    expect(isSingleLookupTerm('\n\t')).toBe(false);
+  });
+
+  it('accepts a single word in space-delimited scripts', () => {
+    expect(isSingleLookupTerm('serendipity')).toBe(true);
+    expect(isSingleLookupTerm('café')).toBe(true);
+    expect(isSingleLookupTerm("don't")).toBe(true);
+    expect(isSingleLookupTerm('mother-in-law')).toBe(true);
+    expect(isSingleLookupTerm('  hello  ')).toBe(true);
+  });
+
+  it('rejects multi-word selections in space-delimited scripts', () => {
+    expect(isSingleLookupTerm('hello world')).toBe(false);
+    expect(isSingleLookupTerm('the quick brown fox jumps')).toBe(false);
+    expect(isSingleLookupTerm('hello\nworld')).toBe(false);
+    expect(isSingleLookupTerm('hello world')).toBe(false);
+  });
+
+  it('accepts short CJK words, compounds, and idioms', () => {
+    expect(isSingleLookupTerm('你好')).toBe(true);
+    expect(isSingleLookupTerm('图书馆')).toBe(true);
+    expect(isSingleLookupTerm('四面楚歌')).toBe(true);
+    expect(isSingleLookupTerm('中华人民共和国')).toBe(true);
+    expect(isSingleLookupTerm('素晴らしい')).toBe(true);
+    expect(isSingleLookupTerm('コンピューター')).toBe(true);
+    expect(isSingleLookupTerm('走り出した')).toBe(true);
+    expect(isSingleLookupTerm('안녕하세요')).toBe(true);
+  });
+
+  it('accepts CJK terms up to 8 characters and rejects longer runs', () => {
+    expect(isSingleLookupTerm('一二三四五六七八')).toBe(true);
+    expect(isSingleLookupTerm('一二三四五六七八九')).toBe(false);
+    expect(isSingleLookupTerm('我今天下午去了图书馆看书')).toBe(false);
+    expect(isSingleLookupTerm('今日は本を読みました')).toBe(false);
+  });
+
+  it('counts CJK length in code points, not UTF-16 units', () => {
+    expect(isSingleLookupTerm('𠮷野家')).toBe(true);
+    expect(isSingleLookupTerm('𠮷'.repeat(9))).toBe(false);
+  });
+
+  it('rejects CJK selections containing whitespace or punctuation', () => {
+    expect(isSingleLookupTerm('你好 世界')).toBe(false);
+    expect(isSingleLookupTerm('你好　世界')).toBe(false);
+    expect(isSingleLookupTerm('你好，世界')).toBe(false);
+    expect(isSingleLookupTerm('読みました。')).toBe(false);
+    expect(isSingleLookupTerm('안녕하세요 세계')).toBe(false);
+  });
+
+  it('accepts short mixed CJK/Latin terms', () => {
+    expect(isSingleLookupTerm('iPhone手机')).toBe(true);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -54,7 +54,7 @@ import {
 } from '../../utils/deferredAction';
 import { Insets } from '@/types/misc';
 import { runSimpleCC } from '@/utils/simplecc';
-import { getWordCount } from '@/utils/word';
+import { getWordCount, isSingleLookupTerm } from '@/utils/word';
 import { getIndexFromCfi } from '@/utils/cfi';
 import { writeTextToClipboard } from '@/utils/clipboard';
 import { buildAnnotationUrl } from '@/utils/deeplink';
@@ -939,7 +939,14 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
           handleSearch();
           break;
         case 'dictionary':
-          handleDictionary();
+          // A dictionary lookup only makes sense for a single word (or a short
+          // CJK term); on a longer selection fall back to the annotation
+          // toolbar so highlighting and copying stay reachable (#5213).
+          if (selection && isSingleLookupTerm(selection.text)) {
+            handleDictionary();
+          } else {
+            handleShowAnnotPopup();
+          }
           break;
         case 'translate':
           handleTranslation();

--- a/apps/readest-app/src/utils/word.ts
+++ b/apps/readest-app/src/utils/word.ts
@@ -89,3 +89,20 @@ export const getWordCount = (text: string): number => {
   if (!text) return 0;
   return text.trim().split(/\s+/).filter(Boolean).length;
 };
+
+// Whether the selected text plausibly denotes a single dictionary lookup term
+// rather than a passage. Space-delimited scripts: one whitespace-free token.
+// CJK has no spaces between words, so a length cap stands in for the word
+// boundary: compounds, idioms, and conjugated forms worth looking up run to
+// ~8 characters, while longer runs (or anything containing punctuation) are
+// phrases a dictionary lookup can't answer.
+const MAX_CJK_LOOKUP_CHARS = 8;
+export const isSingleLookupTerm = (text: string): boolean => {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  if (/\s/u.test(trimmed)) return false;
+  const cjkPattern = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+  if (!cjkPattern.test(trimmed)) return true;
+  if (/[\p{P}\p{S}]/u.test(trimmed)) return false;
+  return [...trimmed].length <= MAX_CJK_LOOKUP_CHARS;
+};


### PR DESCRIPTION
## Summary

A dictionary lookup only makes sense for a single word or a short CJK term. When the selection was longer, the instant dictionary quick action still fired and left no way to highlight or copy the text. Now such selections show the normal annotation toolbar instead, keeping all actions reachable.

- New `isSingleLookupTerm` helper in `src/utils/word.ts`: a selection qualifies for the instant dictionary when it is a single whitespace-free token for space-delimited scripts, or a CJK run of at most 8 characters with no punctuation. CJK has no word spaces and `Intl.Segmenter` splits exactly the units worth looking up (4-char idioms, conjugated Japanese verbs, katakana compounds) into multiple word-like segments, so a length cap stands in for the word boundary there.
- Only the `dictionary` case of the quick action dispatch changes; translate/copy/search/TTS/share still make sense on passages and are untouched. The Android touchend deferral and the desktop long-press gate stay in front of the fallback.
- The other half of the issue (returning to the selection toolbar after closing the lookup popup) was already handled in #5526.

Closes #5213

## Test plan

- New unit tests for `isSingleLookupTerm` covering single words, hyphenated and apostrophe forms, multi-word rejection, CJK compounds/idioms up to the 8-char cap, code-point counting for surrogate-pair Han, and whitespace/punctuation rejection.
- Full suite: 8725 passed; `pnpm lint` and `pnpm format:check` clean.
- Verified live in Chrome (web build): with Quick Action = Dictionary, a multi-word drag now shows the annotation toolbar while a single-word drag still opens the dictionary popup; closing the popup returns to the toolbar per #5526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)