### PR TITLE
fix(reader): discard booknotes without a CFI to prevent an app crash

### DIFF
--- a/apps/readest-app/src/__tests__/store/book-data-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/book-data-store.test.ts
@@ -209,9 +209,58 @@ describe('bookDataStore', () => {
 
       warnSpy.mockRestore();
     });
+
+    // A note with no cfi has no location and can never be rendered or navigated
+    // to, but `CFI.compare` dereferences its arguments — so a null/undefined cfi
+    // reaching a sort comparator or findNearestCfi throws during render and drops
+    // the whole app to the error boundary. File sync, backup restore and the
+    // Foliate importer all parse untrusted JSON straight into booknotes, so the
+    // store is the choke point that keeps them out of live state.
+    test('discards booknotes without a usable cfi', () => {
+      const data = makeBookData('book1', { booknotes: [] });
+      useBookDataStore.setState({ booksData: { book1: data } });
+
+      useBookDataStore.getState().setConfig('book1', {
+        booknotes: [
+          makeBookNote({ id: 'good', cfi: 'epubcfi(/2/4)' }),
+          makeBookNote({ id: 'null-cfi', cfi: null as unknown as string }),
+          makeBookNote({ id: 'undef-cfi', cfi: undefined as unknown as string }),
+          makeBookNote({ id: 'empty-cfi', cfi: '' }),
+        ],
+      });
+
+      const booknotes = useBookDataStore.getState().getConfig('book1')!.booknotes!;
+      expect(booknotes.map((n) => n.id)).toEqual(['good']);
+    });
+
+    test('leaves booknotes untouched when the update does not carry them', () => {
+      const notes = [makeBookNote({ id: 'good', cfi: 'epubcfi(/2/4)' })];
+      const data = makeBookData('book1', { booknotes: notes });
+      useBookDataStore.setState({ booksData: { book1: data } });
+
+      useBookDataStore.getState().setConfig('book1', { location: 'loc' });
+
+      expect(useBookDataStore.getState().getConfig('book1')!.booknotes).toBe(notes);
+    });
   });
 
   describe('updateBooknotes', () => {
+    test('discards booknotes without a usable cfi', () => {
+      const data = makeBookData('book1', { booknotes: [] });
+      useBookDataStore.setState({ booksData: { book1: data } });
+
+      useBookDataStore
+        .getState()
+        .updateBooknotes('book1', [
+          makeBookNote({ id: 'good', cfi: 'epubcfi(/2/4)' }),
+          makeBookNote({ id: 'null-cfi', cfi: null as unknown as string }),
+          makeBookNote({ id: 'empty-cfi', cfi: '' }),
+        ]);
+
+      const booknotes = useBookDataStore.getState().getConfig('book1')!.booknotes!;
+      expect(booknotes.map((n) => n.id)).toEqual(['good']);
+    });
+
     test('deduplicates booknotes by id-type-cfi', () => {
       const data = makeBookData('book1', { booknotes: [] });
       useBookDataStore.setState({ booksData: { book1: data } });

--- a/apps/readest-app/src/__tests__/utils/cfi.test.ts
+++ b/apps/readest-app/src/__tests__/utils/cfi.test.ts
@@ -70,6 +70,27 @@ describe('findNearestCfi', () => {
     expect(findNearestCfi(sortedCfis, null)).toBeNull();
     expect(findNearestCfi(sortedCfis, undefined)).toBeNull();
   });
+
+  // A booknote synced from a row whose `cfi` column is SQL NULL arrives as a
+  // literal `null` despite BookNote.cfi being typed `string`. It reaches here
+  // through BooknoteView's `nearestCfi` useMemo, so an unguarded CFI.compare
+  // throws during render and takes the whole app down to the error boundary.
+  it('should skip null/empty entries instead of throwing', () => {
+    const withHoles = [
+      'epubcfi(/6/4!/4/2:0)',
+      null as unknown as string,
+      'epubcfi(/6/6!/4/4:0)',
+      undefined as unknown as string,
+      'epubcfi(/6/10!/4/6:0)',
+    ];
+    expect(() => findNearestCfi(withHoles, 'epubcfi(/6/6!/4/6:0)')).not.toThrow();
+    expect(findNearestCfi(withHoles, 'epubcfi(/6/6!/4/6:0)')).toBe('epubcfi(/6/6!/4/4:0)');
+  });
+
+  it('should return null when every entry is invalid', () => {
+    const allNull = [null, null] as unknown as string[];
+    expect(findNearestCfi(allNull, 'epubcfi(/6/6!/4/4:0)')).toBeNull();
+  });
 });
 
 describe('createCfiLocationMatcher', () => {

--- a/apps/readest-app/src/store/bookDataStore.ts
+++ b/apps/readest-app/src/store/bookDataStore.ts
@@ -80,6 +80,22 @@ interface BookDataState {
   clearBookData: (keyOrId: string) => void;
 }
 
+/**
+ * Drop booknotes that carry no CFI. Such a note has no anchor in the book: it
+ * can't be rendered, navigated to, or ordered against anything. Worse, it is
+ * actively dangerous — `CFI.compare` dereferences both of its arguments, so a
+ * null/undefined cfi reaching a sort comparator or `findNearestCfi` throws
+ * during render and drops the whole app to the error boundary.
+ *
+ * `BookNote.cfi` is typed `string`, but that isn't enforced at runtime for data
+ * we didn't create: file sync (`services/sync/file/wire.ts`), backup restore,
+ * and the Foliate importer all parse foreign JSON straight into booknotes.
+ * Every write to `config.booknotes` funnels through this store, so discard them
+ * here rather than defending each of the many CFI comparison sites.
+ */
+const discardUnanchoredBooknotes = (booknotes: BookNote[]): BookNote[] =>
+  booknotes.filter((booknote) => booknote.cfi);
+
 export const useBookDataStore = create<BookDataState>((set, get) => ({
   booksData: {},
   getBookData: (keyOrId: string) => {
@@ -109,12 +125,15 @@ export const useBookDataStore = create<BookDataState>((set, get) => ({
         console.warn('No config found for book', id);
         return state;
       }
+      const update = partialConfig.booknotes
+        ? { ...partialConfig, booknotes: discardUnanchoredBooknotes(partialConfig.booknotes) }
+        : partialConfig;
       return {
         booksData: {
           ...state.booksData,
           [id]: {
             ...state.booksData[id]!,
-            config: { ...config, ...partialConfig },
+            config: { ...config, ...update },
           },
         },
       };
@@ -168,7 +187,12 @@ export const useBookDataStore = create<BookDataState>((set, get) => ({
       const book = state.booksData[id];
       if (!book) return state;
       const dedupedBooknotes = Array.from(
-        new Map(booknotes.map((item) => [`${item.id}-${item.type}-${item.cfi}`, item])).values(),
+        new Map(
+          discardUnanchoredBooknotes(booknotes).map((item) => [
+            `${item.id}-${item.type}-${item.cfi}`,
+            item,
+          ]),
+        ).values(),
       );
       updatedConfig = {
         ...book.config,

--- a/apps/readest-app/src/utils/cfi.ts
+++ b/apps/readest-app/src/utils/cfi.ts
@@ -79,15 +79,23 @@ export function findNearestCfi(
   sortedCfis: string[],
   location: string | null | undefined,
 ): string | null {
-  if (!location || sortedCfis.length === 0) return null;
+  if (!location) return null;
+
+  // `CFI.compare` dereferences both arguments, so a hole in the array throws.
+  // A booknote whose stored `cfi` is NULL round-trips through sync as a literal
+  // null despite BookNote.cfi being typed `string`, and this runs inside a
+  // render-phase useMemo — an unguarded throw here reaches the app error
+  // boundary and replaces the whole reader with the crash screen.
+  const cfis = sortedCfis.filter((cfi) => typeof cfi === 'string' && cfi.length > 0);
+  if (cfis.length === 0) return null;
 
   const target = CFI.collapse(location);
   let lo = 0;
-  let hi = sortedCfis.length;
+  let hi = cfis.length;
 
   while (lo < hi) {
     const mid = (lo + hi) >>> 1;
-    if (CFI.compare(sortedCfis[mid]!, target) <= 0) {
+    if (CFI.compare(cfis[mid]!, target) <= 0) {
       lo = mid + 1;
     } else {
       hi = mid;
@@ -96,9 +104,9 @@ export function findNearestCfi(
 
   // lo is the first index where cfi > target
   // The nearest item at or before target is lo - 1
-  if (lo === 0) return sortedCfis[0]!;
-  if (lo >= sortedCfis.length) return sortedCfis[sortedCfis.length - 1]!;
-  return sortedCfis[lo - 1]!;
+  if (lo === 0) return cfis[0]!;
+  if (lo >= cfis.length) return cfis[cfis.length - 1]!;
+  return cfis[lo - 1]!;
 }
 
 /**


### PR DESCRIPTION
## The crash

A user on Windows (WebView2) hit the App Router error boundary, which replaced the entire app with the "Oops!" screen:

```
TypeError: Cannot read properties of null (reading 'start')
    at Module.y (http://tauri.localhost/_next/static/chunks/9047-05f0a66f529a4f25.js:1:9934)
    at a (http://tauri.localhost/_next/static/chunks/9047-05f0a66f529a4f25.js:1:5729)
```

`Module.y` is a minified ESM namespace export, which narrows it to `CFI.compare` (`import * as CFI from 'foliate-js/epubcfi.js'`, re-exported as `CFI` from `libs/document.ts`). A unit test reproduces the identical frames unminified:

```
TypeError: Cannot read properties of null (reading 'start')
 > Module.compare  packages/foliate-js/epubcfi.js:166:11
 > findNearestCfi  src/utils/cfi.ts:90:13
```

## Root cause

`CFI.compare()` dereferences both of its arguments (`if (a.start || b.start)`) with no validation. Measured behaviour:

| argument | result |
| --- | --- |
| `''` | returns `-1`, no throw |
| `null` | throws `Cannot read properties of null (reading 'start')` |
| `undefined` | throws the `undefined` variant |

**The empty string is safe.** `transformBookNoteFromDB` normalizes a NULL column to `cfi: ''`, so the Readest cloud sync path can produce a useless note but never this crash.

A literal `null` only arrives from paths that parse foreign JSON without going through `transform.ts`:

- **File sync** (WebDAV / Dropbox / OneDrive / S3 / local folder): `services/sync/file/wire.ts` `parseRemotePayload` is a bare `JSON.parse` plus a `schemaVersion` check, `merge.ts` adopts remote notes by id, and `useFileSync.ts` puts them into live state via `setConfig`.
- **Backup restore**: `backupService.ts` merges an unvalidated user zip's `config.json`.
- **Foliate importer** (Linux): `providers/foliate.ts` does `cfi: annotation.value` over `JSON.parse(...) as unknown`.

Everything the app itself creates is already guarded, and `useNotesSync` / `useBookOrbitNotesSync` already discard notes whose xpointer to CFI conversion fails.

`store/readerStore.ts` already filtered cfi-less notes (commit `1936136`, "fix: handle synced bookmarks without cfi"), but only in `initViewState`, so file sync's later `setConfig` walked straight past it.

Note that a single bad note can slip past the sort comparator that runs just before `findNearestCfi` in `BooknoteView`: `Array.prototype.sort` never invokes the comparator for a group of length <= 1.

## The fix

Discard unanchored booknotes in `bookDataStore` at both `setConfig` and `updateBooknotes`. Every write to `config.booknotes` funnels through those two, so no ingest path (current or future) can put a note with no CFI into live state, and the filtered array is what `saveConfig` persists, so affected on-disk data heals itself on the next save. One predicate covers `null`, `undefined` and `''`.

Also hardened `findNearestCfi`, which was the only helper in `utils/cfi.ts` calling `CFI.compare` without a try/catch, unlike `isCfiInLocation` and `createCfiLocationMatcher`.

## Testing

- New tests in `src/__tests__/store/book-data-store.test.ts` (discard via both setters, and that an update not carrying booknotes leaves them untouched) and `src/__tests__/utils/cfi.test.ts` (the reproduction, plus the all-invalid case).
- `pnpm test`: 8719 passed, 16 skipped.
- `pnpm lint` and `pnpm format:check` clean.

## Follow-up found while tracing this (not fixed here)

The koplugin never emits a `cfi` key (`readest_syncannotations.lua:88-118`) but does keep Readest's note `id` on pull, and postgrest-js builds its `?columns=` list as the union of keys across the batch. A KOReader round-trip therefore NULLs out a previously-good cfi through `ON CONFLICT DO UPDATE`. The comment at `src/__tests__/utils/transform.test.ts:205-228` assumes an omitted column "is left untouched on UPDATE", which the `columns=` union defeats. That produces a surviving but anchorless annotation rather than a crash, and this PR now silently discards those notes, so it is worth fixing at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
