### PR TITLE
fix(tts): settle Edge TTS synthesis when the Tauri WebSocket dies before turn.end

### DIFF
--- a/apps/readest-app/src/__tests__/libs/edgeTTS-tauri-ws.test.ts
+++ b/apps/readest-app/src/__tests__/libs/edgeTTS-tauri-ws.test.ts
@@ -1,0 +1,161 @@
+// #5230: on the Tauri transport, an Edge-side close (or a plugin read error)
+// before `turn.end` must reject the synthesis promise. The old listener only
+// handled Text/Binary messages, so the promise never settled, the retry/skip
+// machinery never ran, and the static in-flight map poisoned that sentence
+// until app restart — playback stuck "playing" with no audio.
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const connectMock = vi.fn();
+
+vi.mock('@tauri-apps/plugin-websocket', () => ({
+  default: {
+    connect: (...args: unknown[]) => connectMock(...args),
+  },
+}));
+
+vi.mock('@/services/environment', () => ({
+  getAPIBaseUrl: () => 'http://api.test',
+  isTauriAppPlatform: () => true,
+}));
+
+vi.mock('@/utils/fetch', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+import { EdgeSpeechTTS, type EdgeTTSPayload } from '@/libs/edgeTTS';
+
+type FakeMessage = unknown;
+
+class FakeTauriWs {
+  listeners: Array<(msg: FakeMessage) => void> = [];
+  sent: unknown[] = [];
+  disconnected = false;
+
+  addListener(cb: (msg: FakeMessage) => void) {
+    this.listeners.push(cb);
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== cb);
+    };
+  }
+
+  async send(message: unknown) {
+    this.sent.push(message);
+  }
+
+  async disconnect() {
+    this.disconnected = true;
+  }
+
+  emit(msg: FakeMessage) {
+    for (const listener of [...this.listeners]) listener(msg);
+  }
+}
+
+const makePayload = (text: string): EdgeTTSPayload => ({
+  lang: 'en',
+  text,
+  voice: 'en-US-AriaNeural',
+  rate: 1.0,
+  pitch: 1.0,
+});
+
+const flushMicrotasks = async (rounds = 10) => {
+  for (let i = 0; i < rounds; i++) await Promise.resolve();
+};
+
+// The transport awaits a dynamic import and crypto.subtle.digest, which can
+// resolve on macrotasks — a pure microtask drain is not enough to reach the
+// socket writes.
+const flushTasks = async (rounds = 5) => {
+  for (let i = 0; i < rounds; i++) {
+    if (vi.isFakeTimers()) await vi.advanceTimersByTimeAsync(0);
+    else await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
+
+// Resolves to 'pending' when `p` has not settled by the end of the current
+// microtask drain — the pre-fix hang manifests as 'pending', not a timeout.
+const settleState = (p: Promise<unknown>) =>
+  Promise.race([
+    p.then(
+      () => 'resolved',
+      () => 'rejected',
+    ),
+    flushMicrotasks().then(() => 'pending'),
+  ]);
+
+describe('EdgeSpeechTTS Tauri WebSocket transport (#5230)', () => {
+  let ws: FakeTauriWs;
+
+  beforeEach(() => {
+    ws = new FakeTauriWs();
+    connectMock.mockReset();
+    connectMock.mockResolvedValue(ws);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Wraps the request promise in an object: returning it bare from an async
+  // helper would make `await startRequest(...)` adopt it — hanging the test
+  // whenever the promise (correctly or not) never settles.
+  const startRequest = async (text: string) => {
+    const tts = new EdgeSpeechTTS('wss');
+    const promise = tts.createAudioData(makePayload(text));
+    // Swallow rejection so an unawaited failure can't nuke the test run.
+    promise.catch(() => {});
+    await flushTasks();
+    expect(ws.sent.length).toBe(2); // config + ssml content sent
+    return { promise };
+  };
+
+  test('rejects when the server closes before turn.end', async () => {
+    const { promise } = await startRequest('close before turn.end');
+    ws.emit({ type: 'Close', data: { code: 1006, reason: '' } });
+    expect(await settleState(promise)).toBe('rejected');
+    await expect(promise).rejects.toThrow(/closed/i);
+  });
+
+  test('rejects when the plugin reports a read error (plain string message)', async () => {
+    const { promise } = await startRequest('read error sentence');
+    // tauri-plugin-websocket serializes read errors as a bare string with no
+    // `type` field (see the plugin's `impl Serialize for Error`).
+    ws.emit('Connection reset without closing handshake');
+    expect(await settleState(promise)).toBe('rejected');
+    await expect(promise).rejects.toThrow(/Connection reset/);
+  });
+
+  test('rejects after prolonged silence (half-open socket)', async () => {
+    vi.useFakeTimers();
+    const { promise } = await startRequest('half-open socket sentence');
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(await settleState(promise)).toBe('rejected');
+    await expect(promise).rejects.toThrow(/timed out/i);
+  });
+
+  test('still resolves audio and boundaries on a normal turn.end flow', async () => {
+    const { promise } = await startRequest('happy path sentence');
+    // Binary frame: 2-byte big-endian header length (0) + audio payload.
+    ws.emit({ type: 'Binary', data: [0, 0, 9, 8, 7, 6] });
+    ws.emit({
+      type: 'Text',
+      data: 'Path: audio.metadata\r\n\r\n{"Metadata":[{"Type":"WordBoundary","Data":{"Offset":1000000,"Duration":2000000,"text":{"Text":"happy"}}}]}',
+    });
+    ws.emit({ type: 'Text', data: 'Path: turn.end\r\n\r\n' });
+    const { data, boundaries } = await promise;
+    expect(new Uint8Array(data)).toEqual(new Uint8Array([9, 8, 7, 6]));
+    expect(boundaries).toEqual([{ offset: 1000000, duration: 2000000, text: 'happy' }]);
+    expect(ws.disconnected).toBe(true);
+  });
+
+  test('ping/pong keep-alive frames do not settle the request', async () => {
+    const { promise } = await startRequest('ping does not settle');
+    ws.emit({ type: 'Ping', data: [] });
+    ws.emit({ type: 'Pong', data: [] });
+    expect(await settleState(promise)).toBe('pending');
+    ws.emit({ type: 'Text', data: 'Path: turn.end\r\n\r\n' });
+    // turn.end with zero audio bytes stays the permanent no-audio error.
+    await expect(promise).rejects.toThrow('No audio data received.');
+  });
+});

--- a/apps/readest-app/src/libs/edgeTTS.ts
+++ b/apps/readest-app/src/libs/edgeTTS.ts
@@ -1,5 +1,6 @@
 import { md5 } from 'js-md5';
 import WebSocket from 'isomorphic-ws';
+import type TauriWebSocketConnection from '@tauri-apps/plugin-websocket';
 import { randomMd5 } from '@/utils/misc';
 import { LRUCache } from '@/utils/lru';
 import { genSSML } from '@/utils/ssml';
@@ -350,6 +351,11 @@ export const hashTTSPayload = (payload: EdgeTTSPayload): string => {
 
 export type EDGE_TTS_PROTOCOL = 'wss' | 'https';
 
+// Inactivity budget for the Tauri WebSocket transport. Synthesis frames
+// stream continuously once the request is sent; a socket silent this long is
+// dead and would otherwise hang playback forever (#5230).
+const WS_INACTIVITY_TIMEOUT_MS = 30_000;
+
 export class EdgeSpeechTTS {
   static voices = genVoiceList(EDGE_TTS_VOICES);
   private static audioCache = new LRUCache<string, Blob>(200);
@@ -474,24 +480,61 @@ export class EdgeSpeechTTS {
     const config = genSendContent(configHeaders, configContent);
 
     if (isTauriAppPlatform()) {
+      // Every exit path must settle this promise (#5230): the plugin's channel
+      // delivers a server close as a `Close` message and a connection read
+      // error as a bare string (no `type` field) — ignoring them left the
+      // promise pending forever, wedging the whole speak pipeline (and the
+      // static inflight map poisoned that sentence until app restart).
       return new Promise(async (resolve, reject) => {
+        let ws: TauriWebSocketConnection | null = null;
+        let settled = false;
+        let unlisten: (() => void) | null = null;
+        let inactivityTimer: ReturnType<typeof setTimeout> | null = null;
+        const cleanup = () => {
+          if (inactivityTimer !== null) clearTimeout(inactivityTimer);
+          inactivityTimer = null;
+          unlisten?.();
+          unlisten = null;
+          void ws?.disconnect().catch(() => {});
+        };
+        const settle = (complete: () => void) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          complete();
+        };
+        // Frames stream steadily during synthesis, so prolonged silence means
+        // a half-open socket (e.g. a mobile network handover) that will never
+        // error or close on its own. Reject so the caller's retry can open a
+        // fresh connection.
+        const armInactivityTimer = () => {
+          if (inactivityTimer !== null) clearTimeout(inactivityTimer);
+          inactivityTimer = setTimeout(() => {
+            settle(() => reject(new Error('WebSocket timed out waiting for audio.')));
+          }, WS_INACTIVITY_TIMEOUT_MS);
+        };
         try {
           const TauriWebSocket = (await import('@tauri-apps/plugin-websocket')).default;
-          const ws = await TauriWebSocket.connect(url, { headers: baseHeaders });
+          ws = await TauriWebSocket.connect(url, { headers: baseHeaders });
           let audioData = new ArrayBuffer(0);
           const boundaries: TTSWordBoundary[] = [];
-          const messageUnlisten = await ws.addListener((msg) => {
+          unlisten = ws.addListener((msg) => {
+            if (settled) return;
+            armInactivityTimer();
+            if (typeof msg === 'string') {
+              return settle(() => reject(new Error(`WebSocket error occurred: ${msg}`)));
+            }
             if (msg.type === 'Text') {
               const { headers, body } = getHeadersAndData(msg.data as string);
               if (headers['Path'] === 'audio.metadata') {
                 boundaries.push(...parseAudioMetadataBody(body.trim()));
               } else if (headers['Path'] === 'turn.end') {
-                ws.disconnect();
-                messageUnlisten();
-                if (!audioData.byteLength) {
-                  return reject(new Error('No audio data received.'));
-                }
-                resolve({ response: new Response(audioData), boundaries });
+                settle(() => {
+                  if (!audioData.byteLength) {
+                    return reject(new Error('No audio data received.'));
+                  }
+                  resolve({ response: new Response(audioData), boundaries });
+                });
               }
             } else if (msg.type === 'Binary') {
               let buffer: ArrayBufferLike;
@@ -509,12 +552,16 @@ export class EdgeSpeechTTS {
                 merged.set(new Uint8Array(newBody), audioData.byteLength);
                 audioData = merged.buffer;
               }
+            } else if (msg.type === 'Close') {
+              settle(() => reject(new Error('WebSocket closed before audio completed.')));
             }
+            // Ping/Pong frames only refresh the inactivity timer.
           });
+          armInactivityTimer();
           await ws.send(config);
           await ws.send(content);
         } catch (error) {
-          reject(new Error(`WebSocket error occurred: ${error}`));
+          settle(() => reject(new Error(`WebSocket error occurred: ${error}`)));
         }
       });
     } else if (isCloudflareWorkers()) {


### PR DESCRIPTION
Fixes #5230

## Root cause

The Tauri branch of `EdgeSpeechTTS.#fetchEdgeSpeechWs` only handled `Text` and `Binary` channel messages. `tauri-plugin-websocket` delivers a server close as a `Close` message and a connection read error as a **bare string** (its Rust `impl Serialize for Error`), so whenever Edge dropped the socket without sending `turn.end` — a routine transient on mobile networks — the synthesis promise never settled:

- `#synthesizeWithRetry` retries only on rejection, so the retry/skip machinery never ran.
- `TTSController.#speak` sat in state `playing` awaiting `preloadSSML`, leaving the player UI showing playback with dead pause/play controls.
- The static `EdgeSpeechTTS.inflight` dedup map kept the pending promise keyed by that sentence, so every later attempt joined the same dead promise until app restart. This is why the stall looked reproducible at specific sentences and why users had to restart playback *after* the bad spot. It also stalled offline audio downloads, which share the same synthesize path.

The browser and Cloudflare branches of the same function already register close/error handlers; the Tauri branch was the divergent one.

## Fix

Every exit path now settles the promise:

- reject on a `Close` message,
- reject on a read-error string message,
- reject after 30s of socket silence (`WS_INACTIVITY_TIMEOUT_MS`) to cover half-open sockets after a network handover; synthesis frames stream continuously, so silence that long means a dead connection,
- `Ping`/`Pong` frames only refresh the inactivity timer.

`turn.end` with zero audio bytes keeps the permanent `No audio data received.` error (skip immediately, no retry); transport failures stay retryable. With rejections propagating, the existing recovery works as designed: 3 retries on fresh connections, then auto-skip of the sentence under the consecutive-skip budget, then a clean stop if a whole run is unreachable — and the inflight maps clear, so no sentence can be poisoned.

## Tests

`src/__tests__/libs/edgeTTS-tauri-ws.test.ts` drives the transport with a fake Tauri socket: close-before-turn.end, read-error string, and half-open silence all hung (`pending`) against the old code and reject now; happy-path resolution and ping/pong neutrality guard existing behavior. Full suite (8763 tests), `pnpm lint`, and `pnpm format:check` pass.

## Device verification (Xiaomi 13, dev-android build, the reported book)

- The exact repro wedge transition (`session N abort -> speak -> session N+1 start`) now completes in tens of milliseconds, repeatedly.
- A live Edge socket drop (`connection not found`) was absorbed by retry attempt 1/3 with no audible interruption.
- 37s of forced offline (Wi-Fi + data off) mid-playback: every synthesize rejected fast, previously-cached sentences kept playing from the per-book cache, uncached ones were skipped with logged reasons, and playback ended in the designed clean stop (TTS bar dismissed) instead of a phantom playing state; after restoring the network, restarting playback synthesized normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)