### PR TITLE
fix(window): avoid unavailable title-bar APIs on mobile

### DIFF
--- a/apps/readest-app/src/__tests__/components/WindowButtons.test.tsx
+++ b/apps/readest-app/src/__tests__/components/WindowButtons.test.tsx
@@ -54,6 +54,15 @@ describe('WindowButtons', () => {
     expect(startDragging).not.toHaveBeenCalled();
   });
 
+  it('keeps a caller-provided close action available when the platform has no window bar', () => {
+    const onClose = vi.fn();
+    render(<WindowButtons onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
   it('keeps title-bar dragging enabled on desktop platforms', async () => {
     hasWindowBar = true;
     render(<WindowButtonsHarness />);

--- a/apps/readest-app/src/__tests__/components/WindowButtons.test.tsx
+++ b/apps/readest-app/src/__tests__/components/WindowButtons.test.tsx
@@ -1,0 +1,68 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import WindowButtons from '@/components/WindowButtons';
+
+const startDragging = vi.fn().mockResolvedValue(undefined);
+let hasWindowBar = false;
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: { hasWindowBar } }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+vi.mock('@/services/environment', () => ({
+  isTauriAppPlatform: () => true,
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    startDragging,
+    toggleMaximize: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+const WindowButtonsHarness = () => {
+  const headerRef = useRef<HTMLDivElement>(null);
+  return (
+    <>
+      <div ref={headerRef} data-testid='header' />
+      <WindowButtons headerRef={headerRef} />
+    </>
+  );
+};
+
+describe('WindowButtons', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    hasWindowBar = false;
+  });
+
+  it('does not register desktop title-bar gestures when the platform has no window bar', async () => {
+    render(<WindowButtonsHarness />);
+
+    await act(async () => {
+      fireEvent.mouseDown(screen.getByTestId('header'), { buttons: 1, detail: 1 });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(startDragging).not.toHaveBeenCalled();
+  });
+
+  it('keeps title-bar dragging enabled on desktop platforms', async () => {
+    hasWindowBar = true;
+    render(<WindowButtonsHarness />);
+
+    await act(async () => {
+      fireEvent.mouseDown(screen.getByTestId('header'), { buttons: 1, detail: 1 });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(startDragging).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/readest-app/src/__tests__/libs/edgeTTS-tauri-ws.test.ts
+++ b/apps/readest-app/src/__tests__/libs/edgeTTS-tauri-ws.test.ts
@@ -107,8 +107,7 @@ describe('EdgeSpeechTTS Tauri WebSocket transport (#5230)', () => {
     const promise = tts.createAudioData(makePayload(text));
     // Swallow rejection so an unawaited failure can't nuke the test run.
     promise.catch(() => {});
-    await flushTasks();
-    expect(ws.sent.length).toBe(2); // config + ssml content sent
+    await vi.waitFor(() => expect(ws.sent).toHaveLength(2)); // config + ssml content sent
     return { promise };
   };
 

--- a/apps/readest-app/src/__tests__/libs/edgeTTS-tauri-ws.test.ts
+++ b/apps/readest-app/src/__tests__/libs/edgeTTS-tauri-ws.test.ts
@@ -30,6 +30,7 @@ class FakeTauriWs {
   listeners: Array<(msg: FakeMessage) => void> = [];
   sent: unknown[] = [];
   disconnected = false;
+  disconnectShouldReject = false;
 
   addListener(cb: (msg: FakeMessage) => void) {
     this.listeners.push(cb);
@@ -44,6 +45,7 @@ class FakeTauriWs {
 
   async disconnect() {
     this.disconnected = true;
+    if (this.disconnectShouldReject) throw new Error('socket already closed');
   }
 
   emit(msg: FakeMessage) {
@@ -146,6 +148,20 @@ describe('EdgeSpeechTTS Tauri WebSocket transport (#5230)', () => {
     const { data, boundaries } = await promise;
     expect(new Uint8Array(data)).toEqual(new Uint8Array([9, 8, 7, 6]));
     expect(boundaries).toEqual([{ offset: 1000000, duration: 2000000, text: 'happy' }]);
+    expect(ws.disconnected).toBe(true);
+  });
+
+  test('absorbs a cleanup disconnect race after synthesis completes', async () => {
+    const { promise } = await startRequest('disconnect race sentence');
+    ws.disconnectShouldReject = true;
+    ws.emit({ type: 'Binary', data: [0, 0, 9, 8, 7, 6] });
+    ws.emit({ type: 'Text', data: 'Path: turn.end\r\n\r\n' });
+
+    await expect(promise).resolves.toEqual({
+      data: new Uint8Array([9, 8, 7, 6]).buffer,
+      boundaries: [],
+    });
+    await flushTasks();
     expect(ws.disconnected).toBe(true);
   });
 

--- a/apps/readest-app/src/components/WindowButtons.tsx
+++ b/apps/readest-app/src/components/WindowButtons.tsx
@@ -146,7 +146,7 @@ const WindowButtons: React.FC<WindowButtonsProps> = ({
   };
 
   useEffect(() => {
-    if (!isTauriAppPlatform()) return;
+    if (!isTauriAppPlatform() || !appService?.hasWindowBar) return;
     const headerElement = headerRef?.current;
     if (!headerElement) return;
 
@@ -164,7 +164,7 @@ const WindowButtons: React.FC<WindowButtonsProps> = ({
       headerElement.removeEventListener('pointercancel', handlePointerUp);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [appService?.hasWindowBar, headerRef]);
 
   const handleMinimize = async () => {
     if (onMinimize) {


### PR DESCRIPTION
## Summary

- Prevent mobile Tauri builds from registering desktop title-bar drag and maximize gestures when the platform has no window bar. This avoids Android `Plugin window not initialized` errors reported by Sentry.
- Preserve caller-provided close controls on mobile while disabling only the desktop title-bar gestures.
- Add regression coverage for mobile close behavior, mobile/desktop window gestures, and rejected Edge TTS WebSocket cleanup.

## Test Coverage

```text
WindowButtons capability gate
├── Mobile (`hasWindowBar = false`) → no desktop window call ✅
├── Mobile + `onClose` → close button invokes callback ✅
└── Desktop (`hasWindowBar = true`) → title-bar dragging remains enabled ✅

Edge TTS cleanup
└── Completed synthesis + rejected disconnect → synthesis still resolves ✅
```

Coverage audit: all changed paths and user flows covered (100%).

## Pre-Landing Review

No issues found. Adversarial review also passed cleanly.

## Design Review

Design Review (lite): no findings. This changes platform behavior only and does not alter the rendered UI.

## Eval Results

No prompt-related files changed; evals were skipped.

## Scope Drift

Scope Check: CLEAN.

## Plan Completion

No plan file detected.

## Verification Results

- Full Vitest suite: 8,767 passed, 16 skipped
- WindowButtons regression tests: 3 passed
- TypeScript and Biome lint: passed
- Biome format check: passed
- Next.js production build: passed
- Repository pre-push checks: passed

## TODOS

No TODO items completed in this PR.

## Test plan

- [x] Mobile Tauri headers do not invoke desktop window APIs
- [x] Mobile caller-provided close controls remain functional
- [x] Desktop title-bar dragging remains enabled
- [x] Edge TTS cleanup races do not create unhandled failures
- [x] Full unit suite, lint, formatting, and production build pass

🤖 Generated with OpenAI Codex
