### PR TITLE
fix(sentry): symbolicate Windows panic stack traces

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,6 +128,11 @@ jobs:
         with:
           targets: ${{ matrix.config.rust_target }}
 
+      - name: configure Windows debug symbols
+        if: matrix.config.release == 'windows'
+        shell: bash
+        run: echo "CARGO_PROFILE_RELEASE_DEBUG=line-tables-only" >> "$GITHUB_ENV"
+
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: nightly-${{ matrix.config.os }}-${{ matrix.config.release }}-${{ matrix.config.arch }}-cargo
@@ -278,6 +283,22 @@ jobs:
             pnpm tauri build ${{ matrix.config.args }}
           fi
 
+      - name: upload Windows debug files to Sentry
+        if: matrix.config.release == 'windows'
+        shell: bash
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: readest
+          SENTRY_PROJECT: readest
+        run: |
+          if [ -n "${SENTRY_AUTH_TOKEN:-}" ]; then
+            pnpm --filter @readest/readest-app exec sentry-cli debug-files upload \
+              --include-sources --wait \
+              target/${{ matrix.config.rust_target }}/release/readest.pdb
+          else
+            echo "Skipping Sentry debug-file upload: SENTRY_AUTH_TOKEN is not configured"
+          fi
+
       # Portable Windows build: rebuild with NEXT_PUBLIC_PORTABLE_APP=true and
       # ship the raw exe (mirrors release.yml). Runs after the NSIS build above.
       - name: build and sign portable binaries (Windows only)
@@ -289,6 +310,9 @@ jobs:
           TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: readest
+          SENTRY_PROJECT: readest
         run: |
           set -euo pipefail
           version="${{ needs.compute-version.outputs.nightly_version }}"
@@ -315,6 +339,14 @@ jobs:
           echo "NEXT_PUBLIC_PORTABLE_APP=true" >> .env.local
           pnpm tauri build ${{ matrix.config.args }}
           popd
+
+          if [ -n "${SENTRY_AUTH_TOKEN:-}" ]; then
+            pnpm --filter @readest/readest-app exec sentry-cli debug-files upload \
+              --include-sources --wait \
+              target/${{ matrix.config.rust_target }}/release/readest.pdb
+          else
+            echo "Skipping Sentry debug-file upload: SENTRY_AUTH_TOKEN is not configured"
+          fi
 
           if [ "$arch" = "x86_64" ]; then
             bin_file="Readest_${version}_x64-portable.exe"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,6 +262,11 @@ jobs:
         with:
           targets: ${{ matrix.config.rust_target }}
 
+      - name: configure Windows debug symbols
+        if: matrix.config.release == 'windows'
+        shell: bash
+        run: echo "CARGO_PROFILE_RELEASE_DEBUG=line-tables-only" >> "$GITHUB_ENV"
+
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.config.os }}-${{ matrix.config.release }}-${{ matrix.config.arch }}-cargo
@@ -432,6 +437,22 @@ jobs:
           releaseBody: ${{ needs.get-release.outputs.release_note }}
           args: ${{ matrix.config.args || '' }}
 
+      - name: upload Windows debug files to Sentry
+        if: matrix.config.release == 'windows'
+        shell: bash
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: readest
+          SENTRY_PROJECT: readest
+        run: |
+          if [ -n "${SENTRY_AUTH_TOKEN:-}" ]; then
+            pnpm --filter @readest/readest-app exec sentry-cli debug-files upload \
+              --include-sources --wait \
+              target/${{ matrix.config.rust_target }}/release/readest.pdb
+          else
+            echo "Skipping Sentry debug-file upload: SENTRY_AUTH_TOKEN is not configured"
+          fi
+
       # Attest the freshly built desktop bundles (installers, AppImage, dmg,
       # updater archives + their .sig). tauri-action reports their on-disk paths
       # as a JSON array; fromJSON('"\n"') yields a real newline to join them into
@@ -457,6 +478,9 @@ jobs:
           TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: readest
+          SENTRY_PROJECT: readest
         shell: bash
         run: |
           echo "Building Portable Binaries"
@@ -465,6 +489,13 @@ jobs:
           pnpm tauri build ${{ matrix.config.args }}
 
           popd
+          if [ -n "${SENTRY_AUTH_TOKEN:-}" ]; then
+            pnpm --filter @readest/readest-app exec sentry-cli debug-files upload \
+              --include-sources --wait \
+              target/${{ matrix.config.rust_target }}/release/readest.pdb
+          else
+            echo "Skipping Sentry debug-file upload: SENTRY_AUTH_TOKEN is not configured"
+          fi
           echo "Uploading Portable Binaries"
           arch=${{ matrix.config.arch }}
           version=${{ needs.get-release.outputs.release_version }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,6 +2310,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6666,6 +6678,7 @@ dependencies = [
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
+ "sentry-debug-images",
  "sentry-panic",
  "sentry-tracing",
  "tokio",
@@ -6708,6 +6721,16 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00950648aa0d371c7f57057434ad5671bd4c106390df7e7284739330786a01b6"
+dependencies = [
+ "findshlibs",
+ "sentry-core",
 ]
 
 [[package]]

--- a/apps/readest-app/docs/sentry-symbolication.md
+++ b/apps/readest-app/docs/sentry-symbolication.md
@@ -37,12 +37,20 @@ Covers every `platform: javascript` issue (the reader/TTS crashes on
 Validate on the next nightly: open a symbolicated JS issue and confirm real
 file:line frames appear.
 
-## Native debug files (not yet enabled — follow-up)
+## Native debug files (partially implemented)
 
-The credentials + env are already wired for these jobs; each still needs a small,
-build-touching change that must be validated on a real native build (the Android
-and iOS builds are fragile — see the build gotchas in project memory), so they
-are intentionally left as a focused follow-up rather than shipped unverified.
+### Windows (implemented)
+
+- Sentry's `debug-images` integration attaches loaded-module identifiers to
+  native panic events.
+- Release and nightly Windows builds emit line-table PDBs and upload them with
+  source context. The installer PDB is uploaded before the portable rebuild
+  overwrites it, then the portable PDB is uploaded after that rebuild.
+- Uploads are skipped when `SENTRY_AUTH_TOKEN` is unavailable, so fork builds
+  continue normally.
+
+Validate on the next Windows release: open a native panic and confirm the stack
+contains Readest source file and line information.
 
 ### Android
 - **Kotlin/Java stacks + ANRs** (e.g. `RustWebViewClient in shouldOverride`)

--- a/apps/readest-app/src-tauri/Cargo.toml
+++ b/apps/readest-app/src-tauri/Cargo.toml
@@ -116,6 +116,7 @@ mobi = "0.8"
 sentry = { version = "0.42", default-features = false, features = [
   "backtrace",
   "contexts",
+  "debug-images",
   "panic",
   "reqwest",
   "rustls",

--- a/apps/readest-app/src-tauri/src/sentry_config.rs
+++ b/apps/readest-app/src-tauri/src/sentry_config.rs
@@ -219,6 +219,73 @@ mod tests {
     }
 
     #[test]
+    fn windows_panic_events_are_symbolicated() {
+        let manifest = include_str!("../Cargo.toml");
+        assert!(
+            manifest.contains("\"debug-images\""),
+            "Sentry must attach loaded-image metadata so server-side PDB symbolication can match panic addresses"
+        );
+
+        for (name, workflow, portable_step) in [
+            (
+                "release",
+                include_str!("../../../../.github/workflows/release.yml"),
+                "- name: build and upload portable binaries (Windows only)\n        if: matrix.config.os == 'windows-latest'",
+            ),
+            (
+                "nightly",
+                include_str!("../../../../.github/workflows/nightly.yml"),
+                "- name: build and sign portable binaries (Windows only)\n        if: matrix.config.os == 'windows-latest'",
+            ),
+        ] {
+            assert!(
+                workflow.contains("CARGO_PROFILE_RELEASE_DEBUG=line-tables-only"),
+                "{name} Windows builds must emit line-table PDBs"
+            );
+            let upload_positions = workflow
+                .match_indices("sentry-cli debug-files upload")
+                .map(|(position, _)| position)
+                .collect::<Vec<_>>();
+            assert_eq!(upload_positions.len(), 2, "{name} must upload the installer and portable-build PDBs");
+            assert_eq!(
+                workflow
+                    .matches("target/${{ matrix.config.rust_target }}/release/readest.pdb")
+                    .count(),
+                2,
+                "{name} must upload each Readest PDB before it can be overwritten"
+            );
+            assert_eq!(
+                workflow.matches("--include-sources --wait").count(),
+                2,
+                "{name} PDB uploads must include source context and finish processing"
+            );
+            assert_eq!(
+                workflow
+                    .matches(r#"if [ -n "${SENTRY_AUTH_TOKEN:-}" ]; then"#)
+                    .count(),
+                2,
+                "{name} must not fail builds that do not have Sentry credentials"
+            );
+            assert!(
+                workflow.contains("- name: upload Windows debug files to Sentry\n        if: matrix.config.release == 'windows'"),
+                "{name} installer PDB upload must be limited to Windows"
+            );
+            let portable_step_position = workflow
+                .find(portable_step)
+                .unwrap_or_else(|| panic!("{name} portable build must be limited to Windows"));
+            let portable_build_position = workflow[portable_step_position..]
+                .find("pnpm tauri build ${{ matrix.config.args }}")
+                .map(|position| portable_step_position + position)
+                .unwrap_or_else(|| panic!("{name} portable build command must exist"));
+            assert!(
+                upload_positions[0] < portable_build_position
+                    && portable_build_position < upload_positions[1],
+                "{name} must upload the installer PDB before the portable rebuild and the portable PDB after it"
+            );
+        }
+    }
+
+    #[test]
     fn dsn_is_none_when_unset_or_blank() {
         assert_eq!(dsn_from_env(None), None);
         assert_eq!(dsn_from_env(Some("")), None);


### PR DESCRIPTION
## Summary

- attach Sentry loaded-module metadata so Windows panic addresses can be matched to debug files
- emit line-table PDBs for Windows release and nightly builds, uploading both installer and portable variants with source context
- keep builds working without Sentry credentials and guard the workflow behavior with a regression test
- document the Windows native symbolication setup and next-release validation

## Test plan

- `pnpm test` (8,767 passed, 16 skipped)
- `pnpm lint`
- `pnpm format:check`
- `pnpm fmt:check`
- `pnpm clippy:check`
- `pnpm test:rust` (92 passed)
- parse `.github/workflows/release.yml` and `.github/workflows/nightly.yml` as YAML
- `windows_panic_events_are_symbolicated` regression test

## Follow-up validation

- confirm a native Windows panic from the next release resolves to Readest source files and line numbers in Sentry (READEST-10)
