### PR TITLE
fix(annotator): re-anchor the note bubble when a highlight is resized (#5538)

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/hooks/useAnnotationEditor.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useAnnotationEditor.test.ts
@@ -30,10 +30,14 @@ vi.mock('@/store/readerStore', () => ({
     getProgress: () => ({ page: 3 }),
   }),
 }));
-vi.mock('@/app/reader/utils/annotatorUtil', () => ({
-  getHandlePositionsFromRange: () => null,
-}));
+vi.mock('@/app/reader/utils/annotatorUtil', async () => {
+  const actual = await vi.importActual<typeof import('@/app/reader/utils/annotatorUtil')>(
+    '@/app/reader/utils/annotatorUtil',
+  );
+  return { ...actual, getHandlePositionsFromRange: () => null };
+});
 
+import { NOTE_PREFIX } from '@/types/view';
 import { useAnnotationEditor } from '@/app/reader/hooks/useAnnotationEditor';
 
 const annotation = {
@@ -46,12 +50,12 @@ const annotation = {
   note: '',
 } as unknown as BookNote;
 
-const setup = () => {
+const setup = (edited: BookNote = annotation) => {
   const setSelection = vi.fn();
   const hook = renderHook(() =>
     useAnnotationEditor({
       bookKey: 'book-1',
-      annotation,
+      annotation: edited,
       getAnnotationText: vi.fn(async () => 'edited text'),
       setSelection: setSelection as never,
     }),
@@ -91,5 +95,29 @@ describe('useAnnotationEditor applyAnnotationRange', () => {
     expect(h.updateBooknotes).not.toHaveBeenCalled();
     expect(h.saveConfig).not.toHaveBeenCalled();
     expect(setSelection).not.toHaveBeenCalled();
+  });
+
+  // Adjusting the boundaries of a highlight that carries a note moves the record
+  // to a new CFI, and both of its overlays are keyed by that CFI. Tearing down
+  // only the highlight overlay left the note bubble stranded at the old anchor
+  // while a fresh one was drawn at the new one, so a single highlight ended up
+  // showing several note markers — and the stale ones resolved to no record at
+  // all when clicked (#5538).
+  test('re-anchors the note bubble overlay instead of stranding it at the old cfi', async () => {
+    const noted = { ...annotation, note: 'my note' } as BookNote;
+    h.annotations = [{ ...noted }];
+    const { result } = setup(noted);
+
+    await result.current.applyAnnotationRange(range, 2, false, false);
+
+    const calls = h.view.addAnnotation.mock.calls as [BookNote & { value?: string }, boolean?][];
+    const bubbleCalls = calls.filter(([note]) => note.value?.startsWith(NOTE_PREFIX));
+    expect(bubbleCalls).toContainEqual([
+      expect.objectContaining({ value: `${NOTE_PREFIX}old-cfi` }),
+      true,
+    ]);
+    expect(bubbleCalls).toContainEqual([
+      expect.objectContaining({ value: `${NOTE_PREFIX}new-cfi` }),
+    ]);
   });
 });

--- a/apps/readest-app/src/app/reader/hooks/useAnnotationEditor.ts
+++ b/apps/readest-app/src/app/reader/hooks/useAnnotationEditor.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import { BookNote } from '@/types/book';
+import { NOTE_PREFIX } from '@/types/view';
 import { TextSelection } from '@/utils/sel';
 import { useEnv } from '@/context/EnvContext';
 import { useReaderStore } from '@/store/readerStore';
@@ -8,6 +9,7 @@ import { useBookDataStore } from '@/store/bookDataStore';
 import {
   getHandlePositionsFromRange as getHandlePositionsForBook,
   HandlePositions,
+  removeBookNoteOverlays,
 } from '../utils/annotatorUtil';
 
 interface UseAnnotationEditorProps {
@@ -69,9 +71,19 @@ export const useAnnotationEditor = ({
             updatedAt: Date.now(),
           };
 
+          // Both overlays of a unified record are keyed by its cfi, so a moved
+          // range must tear down *both* — dropping only the highlight left the
+          // note bubble stranded at the old anchor while a new one was drawn at
+          // the new one, so one highlight showed several note markers (#5538).
           const views = getViewsById(bookKey.split('-')[0]!);
-          views.forEach((v) => v?.addAnnotation(editingAnnotationRef.current, true));
+          const hasNote = !!existingAnnotation.note?.trim();
+          views.forEach((v) => removeBookNoteOverlays(v, editingAnnotationRef.current));
           views.forEach((v) => v?.addAnnotation(updatedAnnotation));
+          if (hasNote) {
+            views.forEach((v) =>
+              v?.addAnnotation({ ...updatedAnnotation, value: `${NOTE_PREFIX}${newCfi}` }),
+            );
+          }
           editingAnnotationRef.current = updatedAnnotation;
 
           if (!isDragging) {


### PR DESCRIPTION
Closes #5538.

## The bug

Expanding or shrinking a highlight that carries a note appeared to create a second note. The `BookNote` record was never duplicated: the **overlay** was.

A unified annotation draws two overlays, and both are keyed by the record's CFI:

- the highlight, `value = cfi`
- the note bubble, `value = ${NOTE_PREFIX}${cfi}`

`applyAnnotationRange` tore down only the highlight overlay when the range moved. The progress sync effect in `Annotator.tsx` then drew a fresh bubble at the new CFI, so every boundary adjustment left one more dead bubble at the previous anchor. That reads as a single highlight carrying several notes. The orphans are also unclickable: `onShowAnnotation` looks the record up by exact CFI, so a stale bubble resolves to nothing.

The stacking is easy to miss because `Overlayer.bubble` anchors to the right edge of the range's first line box, so orphans left by end-handle drags inside the same line sit at identical coordinates.

## The fix

Tear down both overlays through the existing `removeBookNoteOverlays` helper, then redraw the bubble at the new CFI so it tracks the drag the same way the highlight already does.

## Verification

- New unit test in `useAnnotationEditor.test.ts`, written failing first: it asserts the bubble overlay at the old CFI is removed and one is added at the new CFI. It fails on the unmodified hook.
- `pnpm test` (8764 passed, 16 skipped), `pnpm lint`, `pnpm format:check` all clean.
- Manual run in Chrome against `pnpm dev-web`: created a highlight, attached a note, then repeatedly expanded and shrank both handles.
  - Before: the overlayer held 11 groups where 8 were expected after 3 edits, with 4 bubbles stacked at identical coordinates; shrinking the highlight separated them into one highlight with two visible note markers.
  - After: 8 groups and 3 bubbles across every edit, the bubble moves with the range, and the config keeps exactly one record with its note intact.

## Out of scope, noted while verifying

Rapid handle drags can occasionally leak a stale highlight overlay as well. `applyAnnotationRange` awaits `getAnnotationText` between reading `editingAnnotationRef.current` and the remove/add, and `handleDragEnd`'s commit can overlap the last in-flight drag apply. This reproduces on the unmodified baseline, so it is pre-existing and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)