### PR TITLE
feat(user): add a Danger Zone with Delete All Books

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2220,5 +2220,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "تُخزَّن مكتبتك في iCloud Drive الخاص بك وتُحتسب ضمن مساحة تخزينه.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "زامن مكتبتك وتقدم القراءة والتمييزات مع iCloud Drive الخاص بك.",
-  "Sync with iCloud": "المزامنة مع iCloud"
+  "Sync with iCloud": "المزامنة مع iCloud",
+  "Delete All Books?": "حذف جميع الكتب؟",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "لا يمكن التراجع عن هذا الإجراء. ستتم إزالة كل كتاب من هذا الجهاز ومن مكتبتك السحابية في Readest، إلى جانب تقدم القراءة والإشارات المرجعية والتعليقات. تحتفظ الكتب التي استوردتها في مكانها بملفاتها الأصلية، وتبقى الكتب المرفوعة إلى التخزين السحابي هناك حتى تحذفها من «إدارة التخزين». تحتفظ الأجهزة الأخرى التي سجّلت الدخول بنسخها الخاصة.",
+  "Danger Zone": "منطقة الخطر",
+  "Delete All Books": "حذف جميع الكتب",
+  "All books deleted.": "تم حذف جميع الكتب.",
+  "Failed to delete books. Please try again later.": "تعذّر حذف الكتب. يرجى المحاولة مرة أخرى لاحقًا."
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2036,5 +2036,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "আপনার লাইব্রেরি আপনার iCloud Drive-এ সংরক্ষিত হয় এবং এর স্টোরেজে গণনা করা হয়।",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "আপনার লাইব্রেরি, পড়ার অগ্রগতি এবং হাইলাইটগুলি আপনার iCloud Drive-এর সাথে সিঙ্ক করুন।",
-  "Sync with iCloud": "iCloud-এর সাথে সিঙ্ক করুন"
+  "Sync with iCloud": "iCloud-এর সাথে সিঙ্ক করুন",
+  "Delete All Books?": "সমস্ত বই মুছে ফেলবেন?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "এই ক্রিয়াটি পূর্বাবস্থায় ফেরানো যাবে না। পড়ার অগ্রগতি, বুকমার্ক এবং টীকা সহ প্রতিটি বই এই ডিভাইস এবং আপনার Readest ক্লাউড লাইব্রেরি থেকে সরিয়ে ফেলা হবে। যে বইগুলি আপনি নিজ স্থানে আমদানি করেছেন সেগুলির মূল ফাইল অক্ষত থাকে, এবং ক্লাউড স্টোরেজে আপলোড করা বইগুলি «স্টোরেজ ম্যানেজমেন্ট» থেকে না সরানো পর্যন্ত সেখানেই থাকে। সাইন ইন করা অন্যান্য ডিভাইসে নিজস্ব অনুলিপি থেকে যায়।",
+  "Danger Zone": "বিপজ্জনক অঞ্চল",
+  "Delete All Books": "সমস্ত বই মুছুন",
+  "All books deleted.": "সমস্ত বই মুছে ফেলা হয়েছে।",
+  "Failed to delete books. Please try again later.": "বই মুছতে ব্যর্থ হয়েছে। পরে আবার চেষ্টা করুন।"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1990,5 +1990,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "ཁྱེད་ཀྱི་དཔེ་མཛོད་ iCloud Drive ནང་ཉར་ཚགས་བྱས་ཡོད་ལ་དེའི་གསོག་ཚད་ནང་རྩིས་བཞེས་བྱེད།",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "ཁྱེད་ཀྱི་དཔེ་མཛོད་དང་། ཀློག་པའི་ཡར་འཕེལ། གཙོ་གནད་བཅས་ཁྱེད་ཀྱི་ iCloud Drive དང་མཉམ་སྒྲིག་བྱེད།",
-  "Sync with iCloud": "iCloud དང་མཉམ་བསྒྲིགས་བྱེད།"
+  "Sync with iCloud": "iCloud དང་མཉམ་བསྒྲིགས་བྱེད།",
+  "Delete All Books?": "དེབ་ཡོངས་རྫོགས་བསུབ་དགོས་སམ།",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "བྱ་བ་འདི་ཕྱིར་བསྡུ་མི་ཐུབ། དེབ་རེ་རེ་དང་ཀློག་པའི་འཕེལ་རིམ། དེབ་རྟགས། མཆན་བུ་བཅས་ཐབས་ཆས་འདི་དང་ཁྱེད་ཀྱི་ Readest སྤྲིན་གྱི་དཔེ་མཛོད་ནས་བསུབ་འགྲོ། རང་གནས་སུ་ནང་འདྲེན་བྱས་པའི་དེབ་ཀྱི་མ་ཕྱི་ཡིག་ཆ་གནས་ཐུབ། སྤྲིན་གསོག་ནང་ཡར་འཇུག་བྱས་པའི་དེབ་རྣམས་ཁྱེད་ཀྱིས་ «སྣོད་གསོག་དོ་དམ་བྱེད་པ» ནང་ནས་མ་བསུབས་བར་དུ་གནས། ཐོ་འགོད་བྱས་པའི་ཐབས་ཆས་གཞན་ལ་རང་གི་འདྲ་བཤུས་གནས།",
+  "Danger Zone": "ཉེན་ཁའི་ས་ཁུལ།",
+  "Delete All Books": "དེབ་ཡོངས་རྫོགས་བསུབ།",
+  "All books deleted.": "དེབ་ཡོངས་རྫོགས་བསུབས་ཟིན།",
+  "Failed to delete books. Please try again later.": "དེབ་བསུབ་མ་ཐུབ། རྗེས་སུ་ཡང་བསྐྱར་ཚོད་ལྟ་གནང་།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2036,5 +2036,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Ihre Bibliothek wird in Ihrem iCloud Drive gespeichert und zählt zu dessen Speicherplatz.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Synchronisieren Sie Ihre Bibliothek, Ihren Lesefortschritt und Ihre Markierungen mit Ihrem iCloud Drive.",
-  "Sync with iCloud": "Mit iCloud synchronisieren"
+  "Sync with iCloud": "Mit iCloud synchronisieren",
+  "Delete All Books?": "Alle Bücher löschen?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Diese Aktion kann nicht rückgängig gemacht werden. Jedes Buch wird von diesem Gerät und aus Ihrer Readest-Cloud-Bibliothek entfernt, zusammen mit Lesefortschritt, Lesezeichen und Anmerkungen. Bücher, die Sie an Ort und Stelle importiert haben, behalten ihre Originaldateien, und in den Cloud-Speicher hochgeladene Bücher bleiben dort, bis Sie sie unter „Speicher verwalten“ entfernen. Andere angemeldete Geräte behalten ihre eigenen Kopien.",
+  "Danger Zone": "Gefahrenzone",
+  "Delete All Books": "Alle Bücher löschen",
+  "All books deleted.": "Alle Bücher gelöscht.",
+  "Failed to delete books. Please try again later.": "Bücher konnten nicht gelöscht werden. Bitte versuchen Sie es später erneut."
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2036,5 +2036,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Η βιβλιοθήκη σας αποθηκεύεται στο iCloud Drive σας και προσμετράται στον αποθηκευτικό του χώρο.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Συγχρονίστε τη βιβλιοθήκη, την πρόοδο ανάγνωσης και τις επισημάνσεις σας με το iCloud Drive σας.",
-  "Sync with iCloud": "Συγχρονισμός με iCloud"
+  "Sync with iCloud": "Συγχρονισμός με iCloud",
+  "Delete All Books?": "Διαγραφή όλων των βιβλίων;",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Αυτή η ενέργεια δεν μπορεί να αναιρεθεί. Κάθε βιβλίο θα αφαιρεθεί από αυτή τη συσκευή και από τη βιβλιοθήκη σας στο cloud του Readest, μαζί με την πρόοδο ανάγνωσης, τους σελιδοδείκτες και τις σημειώσεις. Τα βιβλία που εισαγάγατε επιτόπου διατηρούν τα αρχικά τους αρχεία και τα βιβλία που ανεβάσατε στον αποθηκευτικό χώρο cloud παραμένουν εκεί μέχρι να τα αφαιρέσετε από τη «Διαχείριση αποθήκευσης». Οι άλλες συνδεδεμένες συσκευές διατηρούν τα δικά τους αντίγραφα.",
+  "Danger Zone": "Ζώνη κινδύνου",
+  "Delete All Books": "Διαγραφή όλων των βιβλίων",
+  "All books deleted.": "Όλα τα βιβλία διαγράφηκαν.",
+  "Failed to delete books. Please try again later.": "Αποτυχία διαγραφής βιβλίων. Δοκιμάστε ξανά αργότερα."
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2082,5 +2082,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Tu biblioteca se guarda en tu iCloud Drive y cuenta para su almacenamiento.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Sincroniza tu biblioteca, progreso de lectura y resaltados con tu iCloud Drive.",
-  "Sync with iCloud": "Sincronizar con iCloud"
+  "Sync with iCloud": "Sincronizar con iCloud",
+  "Delete All Books?": "¿Eliminar todos los libros?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Esta acción no se puede deshacer. Todos los libros se eliminarán de este dispositivo y de tu biblioteca en la nube de Readest, junto con el progreso de lectura, los marcadores y las anotaciones. Los libros que importaste en su ubicación original conservan sus archivos, y los libros subidos al almacenamiento en la nube permanecen allí hasta que los elimines en «Administrar almacenamiento». Los demás dispositivos con sesión iniciada conservan sus propias copias.",
+  "Danger Zone": "Zona de peligro",
+  "Delete All Books": "Eliminar todos los libros",
+  "All books deleted.": "Todos los libros eliminados.",
+  "Failed to delete books. Please try again later.": "No se pudieron eliminar los libros. Inténtalo de nuevo más tarde."
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2036,5 +2036,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "کتابخانه شما در iCloud Drive ذخیره می‌شود و در فضای ذخیره‌سازی آن محاسبه می‌شود.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "کتابخانه، وضعیت مطالعه و هایلایت‌های خود را با iCloud Drive خود همگام‌سازی کنید.",
-  "Sync with iCloud": "همگام‌سازی با iCloud"
+  "Sync with iCloud": "همگام‌سازی با iCloud",
+  "Delete All Books?": "همه کتاب‌ها حذف شوند؟",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "این عمل قابل بازگشت نیست. همه کتاب‌ها همراه با پیشرفت مطالعه، نشانک‌ها و یادداشت‌ها از این دستگاه و از کتابخانه ابری Readest شما حذف می‌شوند. کتاب‌هایی که در محل خود وارد کرده‌اید فایل‌های اصلی خود را حفظ می‌کنند و کتاب‌های بارگذاری‌شده در فضای ابری تا زمانی که آن‌ها را از «مدیریت فضای ذخیره‌سازی» حذف نکنید باقی می‌مانند. دستگاه‌های دیگری که وارد شده‌اند نسخه‌های خود را نگه می‌دارند.",
+  "Danger Zone": "منطقه خطر",
+  "Delete All Books": "حذف همه کتاب‌ها",
+  "All books deleted.": "همه کتاب‌ها حذف شدند.",
+  "Failed to delete books. Please try again later.": "حذف کتاب‌ها انجام نشد. لطفاً بعداً دوباره تلاش کنید."
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2082,5 +2082,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Votre bibliothèque est stockée dans votre iCloud Drive et compte dans son espace de stockage.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Synchronisez votre bibliothèque, votre progression de lecture et vos surlignages avec votre iCloud Drive.",
-  "Sync with iCloud": "Synchroniser avec iCloud"
+  "Sync with iCloud": "Synchroniser avec iCloud",
+  "Delete All Books?": "Supprimer tous les livres ?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Cette action est irréversible. Tous les livres seront supprimés de cet appareil et de votre bibliothèque cloud Readest, ainsi que la progression de lecture, les signets et les annotations. Les livres importés sur place conservent leurs fichiers d'origine, et les livres téléversés vers le stockage cloud y restent jusqu'à ce que vous les supprimiez dans « Gérer le stockage ». Les autres appareils connectés conservent leurs propres copies.",
+  "Danger Zone": "Zone de danger",
+  "Delete All Books": "Supprimer tous les livres",
+  "All books deleted.": "Tous les livres ont été supprimés.",
+  "Failed to delete books. Please try again later.": "Échec de la suppression des livres. Veuillez réessayer plus tard."
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2082,5 +2082,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "הספרייה שלך מאוחסנת ב-iCloud Drive שלך ונספרת בשטח האחסון שלו.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "סנכרן את הספרייה, התקדמות הקריאה וההדגשות שלך עם iCloud Drive שלך.",
-  "Sync with iCloud": "סנכרון עם iCloud"
+  "Sync with iCloud": "סנכרון עם iCloud",
+  "Delete All Books?": "למחוק את כל הספרים?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "לא ניתן לבטל פעולה זו. כל הספרים יוסרו ממכשיר זה ומספריית הענן שלך ב-Readest, יחד עם התקדמות הקריאה, הסימניות וההערות. ספרים שייבאת במקומם שומרים על הקבצים המקוריים שלהם, וספרים שהועלו לאחסון הענן יישארו שם עד שתסיר אותם ב«נהל אחסון». מכשירים אחרים שמחוברים לחשבון שומרים על העותקים שלהם.",
+  "Danger Zone": "אזור מסוכן",
+  "Delete All Books": "מחק את כל הספרים",
+  "All books deleted.": "כל הספרים נמחקו.",
+  "Failed to delete books. Please try again later.": "מחיקת הספרים נכשלה. נסה שוב מאוחר יותר."
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2036,5 +2036,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "आपकी लाइब्रेरी आपकी iCloud Drive में संग्रहीत होती है और उसके स्टोरेज में गिनी जाती है।",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "अपनी लाइब्रेरी, पढ़ने की प्रगति और हाइलाइट्स को अपनी iCloud Drive से सिंक करें।",
-  "Sync with iCloud": "iCloud के साथ सिंक करें"
+  "Sync with iCloud": "iCloud के साथ सिंक करें",
+  "Delete All Books?": "सभी पुस्तकें हटाएँ?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "यह क्रिया पूर्ववत नहीं की जा सकती। हर पुस्तक इस डिवाइस और आपकी Readest क्लाउड लाइब्रेरी से हटा दी जाएगी, साथ ही पठन प्रगति, बुकमार्क और टिप्पणियाँ भी। जिन पुस्तकों को आपने उनके स्थान पर ही आयात किया था, उनकी मूल फ़ाइलें बनी रहती हैं, और क्लाउड स्टोरेज पर अपलोड की गई पुस्तकें तब तक वहीं रहती हैं जब तक आप उन्हें «स्टोरेज प्रबंधित करें» में से नहीं हटाते। साइन इन किए गए अन्य डिवाइस अपनी प्रतियाँ रखते हैं।",
+  "Danger Zone": "खतरनाक क्षेत्र",
+  "Delete All Books": "सभी पुस्तकें हटाएँ",
+  "All books deleted.": "सभी पुस्तकें हटा दी गईं।",
+  "Failed to delete books. Please try again later.": "पुस्तकें हटाने में विफल। कृपया बाद में पुनः प्रयास करें।"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2036,5 +2036,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Könyvtára az iCloud Drive-on tárolódik, és beleszámít annak tárhelyébe.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Szinkronizálja könyvtárát, olvasási haladását és kiemeléseit a iCloud Drive-jával.",
-  "Sync with iCloud": "iCloud szinkronizálása"
+  "Sync with iCloud": "iCloud szinkronizálása",
+  "Delete All Books?": "Törli az összes könyvet?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Ez a művelet nem vonható vissza. Minden könyv törlődik erről az eszközről és a Readest felhőkönyvtárából, az olvasási előrehaladással, a könyvjelzőkkel és a jegyzetekkel együtt. A helyben importált könyvek megtartják az eredeti fájljaikat, a felhőtárhelyre feltöltött könyvek pedig ott maradnak, amíg el nem távolítja őket a «Tárhely kezelése» részben. A többi bejelentkezett eszköz megtartja a saját másolatát.",
+  "Danger Zone": "Veszélyzóna",
+  "Delete All Books": "Összes könyv törlése",
+  "All books deleted.": "Az összes könyv törölve.",
+  "Failed to delete books. Please try again later.": "Nem sikerült törölni a könyveket. Kérjük, próbálja újra később."
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1990,5 +1990,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Perpustakaan Anda disimpan di iCloud Drive Anda dan dihitung dalam penyimpanannya.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Sinkronkan perpustakaan, progres membaca, dan sorotan Anda dengan iCloud Drive Anda.",
-  "Sync with iCloud": "Sinkronkan dengan iCloud"
+  "Sync with iCloud": "Sinkronkan dengan iCloud",
+  "Delete All Books?": "Hapus semua buku?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Tindakan ini tidak dapat dibatalkan. Setiap buku akan dihapus dari perangkat ini dan dari pustaka cloud Readest Anda, beserta kemajuan baca, markah, dan anotasi. Buku yang Anda impor di tempat tetap menyimpan berkas aslinya, dan buku yang diunggah ke penyimpanan cloud tetap ada di sana sampai Anda menghapusnya di «Kelola Penyimpanan». Perangkat lain yang masuk tetap menyimpan salinannya sendiri.",
+  "Danger Zone": "Zona Berbahaya",
+  "Delete All Books": "Hapus Semua Buku",
+  "All books deleted.": "Semua buku telah dihapus.",
+  "Failed to delete books. Please try again later.": "Gagal menghapus buku. Silakan coba lagi nanti."
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2082,5 +2082,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "La tua biblioteca è archiviata nel tuo iCloud Drive e occupa il suo spazio di archiviazione.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Sincronizza la tua biblioteca, il progresso di lettura e le evidenziazioni con il tuo iCloud Drive.",
-  "Sync with iCloud": "Sincronizza con iCloud"
+  "Sync with iCloud": "Sincronizza con iCloud",
+  "Delete All Books?": "Eliminare tutti i libri?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Questa azione non può essere annullata. Tutti i libri verranno rimossi da questo dispositivo e dalla tua libreria cloud Readest, insieme a progressi di lettura, segnalibri e annotazioni. I libri importati sul posto conservano i file originali e i libri caricati sull'archiviazione cloud restano lì finché non li rimuovi da «Gestisci archiviazione». Gli altri dispositivi con accesso effettuato conservano le proprie copie.",
+  "Danger Zone": "Zona pericolosa",
+  "Delete All Books": "Elimina tutti i libri",
+  "All books deleted.": "Tutti i libri sono stati eliminati.",
+  "Failed to delete books. Please try again later.": "Impossibile eliminare i libri. Riprova più tardi."
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1990,5 +1990,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "ライブラリは iCloud Drive に保存され、その容量を消費します。",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "ライブラリ、読書進捗、ハイライトを iCloud Drive と同期します。",
-  "Sync with iCloud": "iCloud と同期"
+  "Sync with iCloud": "iCloud と同期",
+  "Delete All Books?": "すべての本を削除しますか？",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "この操作は取り消せません。すべての本が、読書の進捗、ブックマーク、注釈とともに、このデバイスと Readest クラウドライブラリから削除されます。その場で読み込んだ本は元のファイルが保持され、クラウドストレージにアップロードされた本は「ストレージ管理」から削除するまで残ります。サインイン済みの他のデバイスにはそれぞれのコピーが残ります。",
+  "Danger Zone": "危険な操作",
+  "Delete All Books": "すべての本を削除",
+  "All books deleted.": "すべての本を削除しました。",
+  "Failed to delete books. Please try again later.": "本の削除に失敗しました。しばらくしてからもう一度お試しください。"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1990,5 +1990,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "라이브러리는 iCloud Drive에 저장되며 해당 저장 공간을 사용합니다.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "라이브러리, 읽기 진행 상황, 하이라이트를 iCloud Drive와 동기화합니다.",
-  "Sync with iCloud": "iCloud와 동기화"
+  "Sync with iCloud": "iCloud와 동기화",
+  "Delete All Books?": "모든 책을 삭제하시겠습니까?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "이 작업은 되돌릴 수 없습니다. 모든 책이 읽기 진행률, 북마크, 주석과 함께 이 기기와 Readest 클라우드 서재에서 삭제됩니다. 원래 위치에서 가져온 책은 원본 파일이 유지되며, 클라우드 저장소에 업로드된 책은 「저장소 관리」에서 삭제할 때까지 남아 있습니다. 로그인된 다른 기기에는 각자의 사본이 남아 있습니다.",
+  "Danger Zone": "위험 구역",
+  "Delete All Books": "모든 책 삭제",
+  "All books deleted.": "모든 책이 삭제되었습니다.",
+  "Failed to delete books. Please try again later.": "책을 삭제하지 못했습니다. 나중에 다시 시도해 주세요."
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1990,5 +1990,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Perpustakaan anda disimpan dalam iCloud Drive anda dan dikira dalam storannya.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Segerakkan perpustakaan, kemajuan bacaan dan penonjolan anda dengan iCloud Drive anda.",
-  "Sync with iCloud": "Segerakkan dengan iCloud"
+  "Sync with iCloud": "Segerakkan dengan iCloud",
+  "Delete All Books?": "Padam semua buku?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Tindakan ini tidak boleh dibatalkan. Setiap buku akan dialih keluar daripada peranti ini dan daripada pustaka awan Readest anda, bersama kemajuan bacaan, penanda buku dan anotasi. Buku yang anda import di tempat asalnya mengekalkan fail asalnya, dan buku yang dimuat naik ke storan awan kekal di sana sehingga anda mengalih keluarnya di «Urus Penyimpanan». Peranti lain yang telah log masuk mengekalkan salinan masing-masing.",
+  "Danger Zone": "Zon Bahaya",
+  "Delete All Books": "Padam Semua Buku",
+  "All books deleted.": "Semua buku telah dipadam.",
+  "Failed to delete books. Please try again later.": "Gagal memadam buku. Sila cuba lagi kemudian."
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2036,5 +2036,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Je bibliotheek wordt opgeslagen in je iCloud Drive en telt mee voor de opslagruimte.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Synchroniseer je bibliotheek, leesvoortgang en markeringen met je iCloud Drive.",
-  "Sync with iCloud": "Synchroniseren met iCloud"
+  "Sync with iCloud": "Synchroniseren met iCloud",
+  "Delete All Books?": "Alle boeken verwijderen?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Deze actie kan niet ongedaan worden gemaakt. Elk boek wordt van dit apparaat en uit je Readest-cloudbibliotheek verwijderd, samen met leesvoortgang, bladwijzers en aantekeningen. Boeken die je ter plaatse hebt geïmporteerd behouden hun originele bestanden, en boeken die naar de cloudopslag zijn geüpload blijven daar totdat je ze verwijdert via ‘Opslag beheren’. Andere aangemelde apparaten behouden hun eigen kopieën.",
+  "Danger Zone": "Gevarenzone",
+  "Delete All Books": "Alle boeken verwijderen",
+  "All books deleted.": "Alle boeken verwijderd.",
+  "Failed to delete books. Please try again later.": "Kan boeken niet verwijderen. Probeer het later opnieuw."
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2128,5 +2128,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Twoja biblioteka jest przechowywana w iCloud Drive i wlicza się do jego miejsca.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Synchronizuj bibliotekę, postęp czytania i zaznaczenia ze swoim iCloud Drive.",
-  "Sync with iCloud": "Synchronizuj z iCloud"
+  "Sync with iCloud": "Synchronizuj z iCloud",
+  "Delete All Books?": "Usunąć wszystkie książki?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Tej operacji nie można cofnąć. Wszystkie książki zostaną usunięte z tego urządzenia oraz z Twojej biblioteki w chmurze Readest, wraz z postępem czytania, zakładkami i adnotacjami. Książki zaimportowane w miejscu zachowują swoje oryginalne pliki, a książki przesłane do pamięci w chmurze pozostaną tam, dopóki nie usuniesz ich w sekcji „Zarządzaj pamięcią”. Inne zalogowane urządzenia zachowują własne kopie.",
+  "Danger Zone": "Strefa zagrożenia",
+  "Delete All Books": "Usuń wszystkie książki",
+  "All books deleted.": "Usunięto wszystkie książki.",
+  "Failed to delete books. Please try again later.": "Nie udało się usunąć książek. Spróbuj ponownie później."
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2082,5 +2082,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Sua biblioteca é armazenada no seu iCloud Drive e conta no armazenamento dele.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Sincronize sua biblioteca, progresso de leitura e destaques com o seu iCloud Drive.",
-  "Sync with iCloud": "Sincronizar com iCloud"
+  "Sync with iCloud": "Sincronizar com iCloud",
+  "Delete All Books?": "Excluir todos os livros?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Esta ação não pode ser desfeita. Todos os livros serão removidos deste dispositivo e da sua biblioteca na nuvem do Readest, junto com o progresso de leitura, marcadores e anotações. Os livros que você importou no local mantêm seus arquivos originais, e os livros enviados para o armazenamento na nuvem permanecem lá até que você os remova em «Gerenciar armazenamento». Os outros dispositivos conectados mantêm suas próprias cópias.",
+  "Danger Zone": "Zona de perigo",
+  "Delete All Books": "Excluir todos os livros",
+  "All books deleted.": "Todos os livros foram excluídos.",
+  "Failed to delete books. Please try again later.": "Falha ao excluir os livros. Tente novamente mais tarde."
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2082,5 +2082,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "A sua biblioteca é guardada no seu iCloud Drive e conta para o respetivo armazenamento.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Sincronize a sua biblioteca, o progresso de leitura e os destaques com o seu iCloud Drive.",
-  "Sync with iCloud": "Sincronizar com iCloud"
+  "Sync with iCloud": "Sincronizar com iCloud",
+  "Delete All Books?": "Eliminar todos os livros?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Esta ação não pode ser anulada. Todos os livros serão removidos deste dispositivo e da sua biblioteca na nuvem do Readest, juntamente com o progresso de leitura, marcadores e anotações. Os livros que importou no local mantêm os ficheiros originais, e os livros carregados para o armazenamento na nuvem permanecem lá até que os remova em «Gerir Armazenamento». Os outros dispositivos com sessão iniciada mantêm as suas próprias cópias.",
+  "Danger Zone": "Zona de perigo",
+  "Delete All Books": "Eliminar todos os livros",
+  "All books deleted.": "Todos os livros foram eliminados.",
+  "Failed to delete books. Please try again later.": "Não foi possível eliminar os livros. Tente novamente mais tarde."
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2082,5 +2082,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Biblioteca ta este stocată în iCloud Drive și ocupă din spațiul său de stocare.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Sincronizează-ți biblioteca, progresul citirii și evidențierile cu iCloud Drive-ul tău.",
-  "Sync with iCloud": "Sincronizare cu iCloud"
+  "Sync with iCloud": "Sincronizare cu iCloud",
+  "Delete All Books?": "Ștergeți toate cărțile?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Această acțiune nu poate fi anulată. Toate cărțile vor fi eliminate de pe acest dispozitiv și din biblioteca dvs. din cloud Readest, împreună cu progresul lecturii, marcajele și adnotările. Cărțile importate pe loc își păstrează fișierele originale, iar cărțile încărcate în stocarea din cloud rămân acolo până când le eliminați din «Gestionați stocarea». Celelalte dispozitive conectate își păstrează propriile copii.",
+  "Danger Zone": "Zonă periculoasă",
+  "Delete All Books": "Ștergeți toate cărțile",
+  "All books deleted.": "Toate cărțile au fost șterse.",
+  "Failed to delete books. Please try again later.": "Ștergerea cărților a eșuat. Încercați din nou mai târziu."
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2128,5 +2128,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Ваша библиотека хранится в iCloud Drive и учитывается в его хранилище.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Синхронизируйте свою библиотеку, прогресс чтения и выделения с вашим iCloud Drive.",
-  "Sync with iCloud": "Синхронизировать с iCloud"
+  "Sync with iCloud": "Синхронизировать с iCloud",
+  "Delete All Books?": "Удалить все книги?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Это действие нельзя отменить. Все книги будут удалены с этого устройства и из вашей облачной библиотеки Readest вместе с прогрессом чтения, закладками и заметками. Книги, импортированные на месте, сохранят свои исходные файлы, а книги, загруженные в облачное хранилище, останутся там, пока вы не удалите их в разделе «Управление хранилищем». На других устройствах, где выполнен вход, останутся собственные копии.",
+  "Danger Zone": "Опасная зона",
+  "Delete All Books": "Удалить все книги",
+  "All books deleted.": "Все книги удалены.",
+  "Failed to delete books. Please try again later.": "Не удалось удалить книги. Повторите попытку позже."
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2036,5 +2036,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "ඔබේ පුස්තකාලය ඔබේ iCloud Drive හි ගබඩා වන අතර එහි ආචයනයට ගණන් ගැනේ.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "ඔබේ පුස්තකාලය, කියවීමේ ප්‍රගතිය සහ ඉස්මතු කිරීම් ඔබේ iCloud Drive සමඟ සමමුහුර්ත කරන්න.",
-  "Sync with iCloud": "iCloud සමඟ සමමුහුර්ත කරන්න"
+  "Sync with iCloud": "iCloud සමඟ සමමුහුර්ත කරන්න",
+  "Delete All Books?": "සියලු පොත් මකන්නද?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "මෙම ක්‍රියාව අහෝසි කළ නොහැක. කියවීමේ ප්‍රගතිය, පිටු සලකුණු සහ විවරණ සමඟ සෑම පොතක්ම මෙම උපාංගයෙන් සහ ඔබේ Readest වලාකුළු පුස්තකාලයෙන් ඉවත් කරනු ලැබේ. ඔබ එහිම ආයාත කළ පොත්වල මුල් ගොනු පවතී, සහ වලාකුළු ගබඩාවට උඩුගත කළ පොත් ඔබ «ගබඩා කළමනාකරණය කරන්න» තුළින් ඉවත් කරන තුරු එහි පවතී. පුරනය වී ඇති අනෙකුත් උපාංග ඒවායේම පිටපත් තබා ගනී.",
+  "Danger Zone": "අනතුරුදායක කලාපය",
+  "Delete All Books": "සියලු පොත් මකන්න",
+  "All books deleted.": "සියලු පොත් මකා දමන ලදී.",
+  "Failed to delete books. Please try again later.": "පොත් මැකීමට අසමත් විය. පසුව නැවත උත්සාහ කරන්න."
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2128,5 +2128,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Vaša knjižnica je shranjena v iCloud Drive in šteje v njegov prostor za shranjevanje.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Sinhronizirajte knjižnico, napredek branja in označbe s svojim iCloud Drive.",
-  "Sync with iCloud": "Sinhroniziraj z iCloud"
+  "Sync with iCloud": "Sinhroniziraj z iCloud",
+  "Delete All Books?": "Izbrišem vse knjige?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Tega dejanja ni mogoče razveljaviti. Vse knjige bodo odstranjene iz te naprave in iz vaše knjižnice v oblaku Readest, skupaj z napredkom branja, zaznamki in opombami. Knjige, ki ste jih uvozili na mestu, ohranijo svoje izvirne datoteke, knjige, naložene v shrambo v oblaku, pa ostanejo tam, dokler jih ne odstranite v razdelku »Upravljaj shrambo«. Druge prijavljene naprave obdržijo svoje kopije.",
+  "Danger Zone": "Nevarno območje",
+  "Delete All Books": "Izbriši vse knjige",
+  "All books deleted.": "Vse knjige so izbrisane.",
+  "Failed to delete books. Please try again later.": "Knjig ni bilo mogoče izbrisati. Poskusite znova pozneje."
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2036,5 +2036,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Ditt bibliotek lagras i din iCloud Drive och räknas mot dess lagringsutrymme.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Synka ditt bibliotek, dina läsframsteg och markeringar med din iCloud Drive.",
-  "Sync with iCloud": "Synka med iCloud"
+  "Sync with iCloud": "Synka med iCloud",
+  "Delete All Books?": "Radera alla böcker?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Den här åtgärden kan inte ångras. Alla böcker tas bort från den här enheten och från ditt Readest-molnbibliotek, tillsammans med läsförlopp, bokmärken och anteckningar. Böcker som du importerat på plats behåller sina originalfiler, och böcker som laddats upp till molnlagringen ligger kvar tills du tar bort dem under ”Hantera lagring”. Andra inloggade enheter behåller sina egna kopior.",
+  "Danger Zone": "Farozon",
+  "Delete All Books": "Radera alla böcker",
+  "All books deleted.": "Alla böcker har raderats.",
+  "Failed to delete books. Please try again later.": "Det gick inte att radera böckerna. Försök igen senare."
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2036,5 +2036,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "உங்கள் நூலகம் உங்கள் iCloud Drive-இல் சேமிக்கப்படுகிறது மற்றும் அதன் சேமிப்பகத்தில் கணக்கிடப்படுகிறது.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "உங்கள் நூலகம், வாசிப்பு முன்னேற்றம் மற்றும் சிறப்பம்சங்களை உங்கள் iCloud Drive உடன் ஒத்திசைக்கவும்.",
-  "Sync with iCloud": "iCloud உடன் ஒத்திசைக்கவும்"
+  "Sync with iCloud": "iCloud உடன் ஒத்திசைக்கவும்",
+  "Delete All Books?": "எல்லா புத்தகங்களையும் நீக்கவா?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "இந்தச் செயலைத் திரும்பப் பெற முடியாது. வாசிப்பு முன்னேற்றம், புத்தகக்குறிகள் மற்றும் குறிப்புகளுடன் ஒவ்வொரு புத்தகமும் இந்தச் சாதனத்திலிருந்தும் உங்கள் Readest கிளவுட் நூலகத்திலிருந்தும் அகற்றப்படும். நீங்கள் அவ்விடத்திலேயே இறக்குமதி செய்த புத்தகங்களின் அசல் கோப்புகள் அப்படியே இருக்கும், கிளவுட் சேமிப்பில் பதிவேற்றப்பட்ட புத்தகங்கள் «சேமிப்பை நிர்வகி» பகுதியில் நீங்கள் அகற்றும் வரை அங்கேயே இருக்கும். உள்நுழைந்துள்ள மற்ற சாதனங்கள் தங்கள் சொந்த நகல்களை வைத்திருக்கும்.",
+  "Danger Zone": "அபாய மண்டலம்",
+  "Delete All Books": "எல்லா புத்தகங்களையும் நீக்கு",
+  "All books deleted.": "எல்லா புத்தகங்களும் நீக்கப்பட்டன.",
+  "Failed to delete books. Please try again later.": "புத்தகங்களை நீக்க முடியவில்லை. பிறகு மீண்டும் முயற்சிக்கவும்."
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1990,5 +1990,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "คลังหนังสือของคุณถูกจัดเก็บใน iCloud Drive และนับรวมในพื้นที่จัดเก็บของมัน",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "ซิงค์คลังหนังสือ ความคืบหน้าการอ่าน และไฮไลต์ของคุณกับ iCloud Drive ของคุณ",
-  "Sync with iCloud": "ซิงค์กับ iCloud"
+  "Sync with iCloud": "ซิงค์กับ iCloud",
+  "Delete All Books?": "ลบหนังสือทั้งหมดหรือไม่",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "การกระทำนี้ไม่สามารถย้อนกลับได้ หนังสือทุกเล่มจะถูกลบออกจากอุปกรณ์นี้และจากคลังหนังสือบนคลาวด์ Readest ของคุณ พร้อมกับความคืบหน้าการอ่าน บุ๊กมาร์ก และคำอธิบายประกอบ หนังสือที่คุณนำเข้าในตำแหน่งเดิมจะยังคงไฟล์ต้นฉบับไว้ และหนังสือที่อัปโหลดไปยังพื้นที่เก็บข้อมูลบนคลาวด์จะยังคงอยู่จนกว่าคุณจะลบออกใน «จัดการพื้นที่เก็บข้อมูล» อุปกรณ์อื่นที่ลงชื่อเข้าใช้จะยังคงเก็บสำเนาของตนเองไว้",
+  "Danger Zone": "โซนอันตราย",
+  "Delete All Books": "ลบหนังสือทั้งหมด",
+  "All books deleted.": "ลบหนังสือทั้งหมดแล้ว",
+  "Failed to delete books. Please try again later.": "ลบหนังสือไม่สำเร็จ โปรดลองอีกครั้งในภายหลัง"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2036,5 +2036,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Kütüphaneniz iCloud Drive'ınızda saklanır ve depolama alanından düşülür.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Kütüphanenizi, okuma ilerlemenizi ve vurgularınızı iCloud Drive'ınızla senkronize edin.",
-  "Sync with iCloud": "iCloud ile senkronize et"
+  "Sync with iCloud": "iCloud ile senkronize et",
+  "Delete All Books?": "Tüm kitaplar silinsin mi?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Bu işlem geri alınamaz. Tüm kitaplar; okuma ilerlemesi, yer imleri ve notlarla birlikte bu cihazdan ve Readest bulut kitaplığınızdan kaldırılacak. Yerinde içe aktardığınız kitapların özgün dosyaları korunur ve bulut depolamaya yüklenen kitaplar, «Depolamayı Yönet» bölümünden kaldırana kadar orada kalır. Oturum açılmış diğer cihazlar kendi kopyalarını korur.",
+  "Danger Zone": "Tehlikeli Bölge",
+  "Delete All Books": "Tüm Kitapları Sil",
+  "All books deleted.": "Tüm kitaplar silindi.",
+  "Failed to delete books. Please try again later.": "Kitaplar silinemedi. Lütfen daha sonra tekrar deneyin."
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2128,5 +2128,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Ваша бібліотека зберігається в iCloud Drive і враховується в його сховищі.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Синхронізуйте свою бібліотеку, проґрес читання та виділення з вашим iCloud Drive.",
-  "Sync with iCloud": "Синхронізувати з iCloud"
+  "Sync with iCloud": "Синхронізувати з iCloud",
+  "Delete All Books?": "Видалити всі книги?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Цю дію неможливо скасувати. Усі книги буде вилучено з цього пристрою та з вашої хмарної бібліотеки Readest разом із прогресом читання, закладками й примітками. Книги, імпортовані на місці, зберігають свої вихідні файли, а книги, вивантажені у хмарне сховище, залишаються там, доки ви не видалите їх у розділі «Керування сховищем». Інші пристрої, до яких ви увійшли, зберігають власні копії.",
+  "Danger Zone": "Небезпечна зона",
+  "Delete All Books": "Видалити всі книги",
+  "All books deleted.": "Усі книги видалено.",
+  "Failed to delete books. Please try again later.": "Не вдалося видалити книги. Спробуйте пізніше."
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2036,5 +2036,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Kutubxonangiz iCloud Drive’da saqlanadi va uning xotirasidan hisoblanadi.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Kutubxonangiz, oʻqish jarayoni va belgilashlaringizni iCloud Drive bilan sinxronlang.",
-  "Sync with iCloud": "iCloud bilan sinxronlash"
+  "Sync with iCloud": "iCloud bilan sinxronlash",
+  "Delete All Books?": "Barcha kitoblar oʻchirilsinmi?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Bu amalni bekor qilib boʻlmaydi. Har bir kitob oʻqish jarayoni, xatchoʻplar va izohlar bilan birga ushbu qurilmadan va Readest bulutli kutubxonangizdan olib tashlanadi. Joyida import qilingan kitoblarning asl fayllari saqlanib qoladi, bulutli xotiraga yuklangan kitoblar esa siz ularni «Xotirani boshqarish» boʻlimidan oʻchirmaguningizcha oʻsha yerda qoladi. Tizimga kirgan boshqa qurilmalar oʻz nusxalarini saqlab qoladi.",
+  "Danger Zone": "Xavfli hudud",
+  "Delete All Books": "Barcha kitoblarni oʻchirish",
+  "All books deleted.": "Barcha kitoblar oʻchirildi.",
+  "Failed to delete books. Please try again later.": "Kitoblarni oʻchirib boʻlmadi. Keyinroq qayta urinib koʻring."
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1990,5 +1990,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "Thư viện của bạn được lưu trong iCloud Drive và tính vào dung lượng lưu trữ của nó.",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "Đồng bộ thư viện, tiến trình đọc và điểm nổi bật của bạn với iCloud Drive của bạn.",
-  "Sync with iCloud": "Đồng bộ với iCloud"
+  "Sync with iCloud": "Đồng bộ với iCloud",
+  "Delete All Books?": "Xóa tất cả sách?",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "Không thể hoàn tác thao tác này. Mọi cuốn sách sẽ bị xóa khỏi thiết bị này và khỏi thư viện đám mây Readest của bạn, cùng với tiến độ đọc, dấu trang và chú thích. Những sách bạn nhập tại chỗ vẫn giữ nguyên tệp gốc, còn sách đã tải lên bộ nhớ đám mây vẫn ở đó cho đến khi bạn xóa chúng trong «Quản lý bộ nhớ». Các thiết bị khác đã đăng nhập vẫn giữ bản sao riêng.",
+  "Danger Zone": "Vùng nguy hiểm",
+  "Delete All Books": "Xóa tất cả sách",
+  "All books deleted.": "Đã xóa tất cả sách.",
+  "Failed to delete books. Please try again later.": "Không xóa được sách. Vui lòng thử lại sau."
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1990,5 +1990,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "您的书库存储在您的 iCloud 云盘中，并占用其存储空间。",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "将您的书库、阅读进度和高亮与您的 iCloud 云盘同步。",
-  "Sync with iCloud": "与 iCloud 同步"
+  "Sync with iCloud": "与 iCloud 同步",
+  "Delete All Books?": "删除所有图书？",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "此操作无法撤销。所有图书将连同阅读进度、书签和批注一起从本设备和您的 Readest 云端书库中删除。就地导入的图书会保留其原始文件，已上传到云存储的图书会一直保留，直到您在「管理存储」中将其移除。其他已登录设备仍保留各自的副本。",
+  "Danger Zone": "危险区域",
+  "Delete All Books": "删除所有图书",
+  "All books deleted.": "已删除所有图书。",
+  "Failed to delete books. Please try again later.": "删除图书失败。请稍后重试。"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1990,5 +1990,11 @@
   "Your library is stored in your iCloud Drive and counts against its storage.": "您的書庫儲存在您的 iCloud 雲碟中，並佔用其儲存空間。",
   "iCloud": "iCloud",
   "Sync your library, reading progress, and highlights with your iCloud Drive.": "將您的書庫、閱讀進度和高亮與您的 iCloud 雲碟同步。",
-  "Sync with iCloud": "與 iCloud 同步"
+  "Sync with iCloud": "與 iCloud 同步",
+  "Delete All Books?": "刪除所有書籍？",
+  "This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.": "此操作無法復原。所有書籍將連同閱讀進度、書籤與註解一併從本裝置和您的 Readest 雲端書庫中刪除。就地匯入的書籍會保留其原始檔案，已上傳至雲端儲存空間的書籍會持續保留，直到您在「管理儲存」中將其移除。其他已登入的裝置仍保有各自的副本。",
+  "Danger Zone": "危險區域",
+  "Delete All Books": "刪除所有書籍",
+  "All books deleted.": "已刪除所有書籍。",
+  "Failed to delete books. Please try again later.": "刪除書籍失敗。請稍後再試。"
 }

--- a/apps/readest-app/src/app/user/components/AccountActions.tsx
+++ b/apps/readest-app/src/app/user/components/AccountActions.tsx
@@ -5,12 +5,16 @@ import { UserPlan } from '@/types/quota';
 
 interface DeleteConfirmationModalProps {
   show: boolean;
+  title: string;
+  message: string;
   onCancel: () => void;
   onConfirm: () => void;
 }
 
 const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
   show,
+  title,
+  message,
   onCancel,
   onConfirm,
 }) => {
@@ -20,12 +24,8 @@ const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
   return (
     <div className='fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4'>
       <div className='w-full max-w-md rounded-2xl bg-white p-6'>
-        <h3 className='mb-4 text-xl font-bold text-gray-800'>{_('Delete Your Account?')}</h3>
-        <p className='mb-6 text-gray-600'>
-          {_(
-            'This action cannot be undone. All your data in the cloud will be permanently deleted.',
-          )}
-        </p>
+        <h3 className='mb-4 text-xl font-bold text-gray-800'>{title}</h3>
+        <p className='mb-6 text-gray-600'>{message}</p>
         <div className='flex flex-col gap-3 sm:flex-row'>
           <button
             onClick={onCancel}
@@ -52,6 +52,7 @@ interface AccountActionsProps {
   onResetPassword: () => void;
   onUpdateEmail: () => void;
   onConfirmDelete: () => void;
+  onConfirmDeleteAllBooks: () => void;
   onRestorePurchase?: () => void;
   onManageSubscription?: () => void;
   onManageStorage?: () => void;
@@ -66,6 +67,7 @@ const AccountActions: React.FC<AccountActionsProps> = ({
   onResetPassword,
   onUpdateEmail,
   onConfirmDelete,
+  onConfirmDeleteAllBooks,
   onRestorePurchase,
   onManageSubscription,
   onManageStorage,
@@ -74,24 +76,36 @@ const AccountActions: React.FC<AccountActionsProps> = ({
 }) => {
   const _ = useTranslation();
   const { appService } = useEnv();
-  const [showConfirmDelete, setShowConfirmDelete] = useState(false);
+  const [pendingAction, setPendingAction] = useState<'account' | 'books' | null>(null);
 
-  const handleDeleteRequest = () => {
-    setShowConfirmDelete(true);
+  const confirmations = {
+    account: {
+      title: _('Delete Your Account?'),
+      message: _(
+        'This action cannot be undone. All your data in the cloud will be permanently deleted.',
+      ),
+      onConfirm: onConfirmDelete,
+    },
+    books: {
+      title: _('Delete All Books?'),
+      message: _(
+        'This action cannot be undone. Every book will be removed from this device and from your Readest cloud library, along with reading progress, bookmarks, and annotations. Books you imported in place keep their original files, and books uploaded to cloud storage stay there until you remove them under Manage Storage. Other signed-in devices keep their own copies.',
+      ),
+      onConfirm: onConfirmDeleteAllBooks,
+    },
   };
-
-  const handleCancelDelete = () => {
-    setShowConfirmDelete(false);
-  };
+  const confirmation = pendingAction ? confirmations[pendingAction] : null;
 
   return (
     <>
       <DeleteConfirmationModal
-        show={showConfirmDelete}
-        onCancel={handleCancelDelete}
+        show={!!confirmation}
+        title={confirmation?.title ?? ''}
+        message={confirmation?.message ?? ''}
+        onCancel={() => setPendingAction(null)}
         onConfirm={async () => {
-          await onConfirmDelete();
-          setShowConfirmDelete(false);
+          await confirmation?.onConfirm();
+          setPendingAction(null);
         }}
       />
       <div className='flex flex-col gap-4 md:grid md:grid-cols-2 lg:grid-cols-3'>
@@ -154,12 +168,23 @@ const AccountActions: React.FC<AccountActionsProps> = ({
         >
           {_('Sign Out')}
         </button>
-        <button
-          onClick={handleDeleteRequest}
-          className='w-full rounded-lg bg-red-100 px-6 py-3 font-medium text-red-600 transition-colors hover:bg-red-200 md:w-auto'
-        >
-          {_('Delete Account')}
-        </button>
+      </div>
+      <div className='mt-8 flex flex-col gap-3 rounded-lg border border-red-200 p-4'>
+        <h3 className='text-sm font-semibold text-red-600'>{_('Danger Zone')}</h3>
+        <div className='flex flex-col gap-4 md:grid md:grid-cols-2 lg:grid-cols-3'>
+          <button
+            onClick={() => setPendingAction('books')}
+            className='w-full rounded-lg bg-red-100 px-6 py-3 font-medium text-red-600 transition-colors hover:bg-red-200 md:w-auto'
+          >
+            {_('Delete All Books')}
+          </button>
+          <button
+            onClick={() => setPendingAction('account')}
+            className='w-full rounded-lg bg-red-100 px-6 py-3 font-medium text-red-600 transition-colors hover:bg-red-200 md:w-auto'
+          >
+            {_('Delete Account')}
+          </button>
+        </div>
       </div>
     </>
   );

--- a/apps/readest-app/src/app/user/page.tsx
+++ b/apps/readest-app/src/app/user/page.tsx
@@ -91,8 +91,13 @@ const ProfilePage = () => {
   useTheme({ systemUIVisible: false });
 
   const { quotas, userProfilePlan = 'free' } = useQuotaStats();
-  const { handleLogout, handleResetPassword, handleUpdateEmail, handleConfirmDelete } =
-    useUserActions();
+  const {
+    handleLogout,
+    handleResetPassword,
+    handleUpdateEmail,
+    handleConfirmDelete,
+    handleDeleteAllBooks,
+  } = useUserActions();
 
   const { availablePlans, iapAvailable } = useAvailablePlans({
     hasIAP: appService?.hasIAP || false,
@@ -238,6 +243,13 @@ const ProfilePage = () => {
     handleConfirmDelete(_('Failed to delete user. Please try again later.'));
   };
 
+  const handleDeleteAllBooksWithMessage = () => {
+    handleDeleteAllBooks(
+      _('All books deleted.'),
+      _('Failed to delete books. Please try again later.'),
+    );
+  };
+
   const handleManageStorage = () => {
     setShowStorageManager(true);
   };
@@ -350,6 +362,7 @@ const ProfilePage = () => {
                         onResetPassword={handleResetPassword}
                         onUpdateEmail={handleUpdateEmail}
                         onConfirmDelete={handleDeleteWithMessage}
+                        onConfirmDeleteAllBooks={handleDeleteAllBooksWithMessage}
                         onRestorePurchase={handleIAPRestorePurchase}
                         onManageSubscription={handleManageSubscription}
                         onManageStorage={handleManageStorage}

--- a/apps/readest-app/src/hooks/useUserActions.ts
+++ b/apps/readest-app/src/hooks/useUserActions.ts
@@ -2,13 +2,15 @@ import { useRouter } from 'next/navigation';
 import { useEnv } from '@/context/EnvContext';
 import { useAuth } from '@/context/AuthContext';
 import { deleteUser } from '@/libs/user';
+import { deleteAllBooks } from '@/services/deleteLibraryService';
+import { useLibraryStore } from '@/store/libraryStore';
 import { eventDispatcher } from '@/utils/event';
 import { saveSysSettings } from '@/helpers/settings';
 import { navigateToLibrary, navigateToResetPassword, navigateToUpdatePassword } from '@/utils/nav';
 
 export const useUserActions = () => {
   const router = useRouter();
-  const { envConfig } = useEnv();
+  const { envConfig, appService } = useEnv();
   const { logout } = useAuth();
 
   const handleLogout = () => {
@@ -38,10 +40,29 @@ export const useUserActions = () => {
     }
   };
 
+  const handleDeleteAllBooks = async (successMessage: string, errorMessage: string) => {
+    if (!appService) return;
+    try {
+      await deleteAllBooks(appService);
+      useLibraryStore.getState().setLibrary([]);
+      eventDispatcher.dispatch('toast', {
+        type: 'success',
+        message: successMessage,
+      });
+    } catch (error) {
+      console.error('Error deleting all books:', error);
+      eventDispatcher.dispatch('toast', {
+        type: 'error',
+        message: errorMessage,
+      });
+    }
+  };
+
   return {
     handleLogout,
     handleUpdateEmail,
     handleResetPassword,
     handleConfirmDelete,
+    handleDeleteAllBooks,
   };
 };

--- a/apps/readest-app/src/libs/user.ts
+++ b/apps/readest-app/src/libs/user.ts
@@ -3,6 +3,7 @@ import { getUserID } from '@/utils/access';
 import { fetchWithAuth } from '@/utils/fetch';
 
 const API_ENDPOINT = getAPIBaseUrl() + '/user/delete';
+const LIBRARY_API_ENDPOINT = getAPIBaseUrl() + '/user/library';
 
 export const deleteUser = async () => {
   try {
@@ -17,5 +18,21 @@ export const deleteUser = async () => {
   } catch (error) {
     console.error('User deletion failed:', error);
     throw new Error('User deletion failed');
+  }
+};
+
+export const deleteCloudLibrary = async () => {
+  try {
+    const userId = await getUserID();
+    if (!userId) {
+      throw new Error('Not authenticated');
+    }
+
+    await fetchWithAuth(LIBRARY_API_ENDPOINT, {
+      method: 'DELETE',
+    });
+  } catch (error) {
+    console.error('Cloud library deletion failed:', error);
+    throw new Error('Cloud library deletion failed');
   }
 };

--- a/apps/readest-app/src/pages/api/user/library.ts
+++ b/apps/readest-app/src/pages/api/user/library.ts
@@ -1,0 +1,35 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { corsAllMethods, runMiddleware } from '@/utils/cors';
+import { createSupabaseAdminClient } from '@/utils/supabase';
+import { validateUserAndToken } from '@/utils/access';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await runMiddleware(req, res, corsAllMethods);
+
+  if (req.method !== 'DELETE') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const { user, token } = await validateUserAndToken(req.headers['authorization']);
+    if (!user || !token) {
+      return res.status(403).json({ error: 'Not authenticated' });
+    }
+
+    // Hard delete rather than a `deleted_at` tombstone: a tombstone would pull
+    // down to every other signed-in device and clear its local library too.
+    // `book_configs` / `book_notes` / `files` key off `auth.users`, not `books`,
+    // so nothing here cascades — their rows are left behind, keyed by
+    // `book_hash`, and line up again if the same book is ever re-added.
+    const supabaseAdmin = createSupabaseAdminClient();
+    const { error } = await supabaseAdmin.from('books').delete().eq('user_id', user.id);
+    if (error) {
+      return res.status(500).json({ error: error.message });
+    }
+
+    res.status(200).json({ message: 'Cloud library deleted successfully' });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ error: 'Something went wrong' });
+  }
+}

--- a/apps/readest-app/src/services/deleteLibraryService.ts
+++ b/apps/readest-app/src/services/deleteLibraryService.ts
@@ -1,0 +1,36 @@
+import { AppService } from '@/types/system';
+import { deleteCloudLibrary } from '@/libs/user';
+
+/**
+ * Wipe the user's whole library: the cloud `books` rows first, then every book
+ * on this device.
+ *
+ * The cloud call goes first on purpose. It is the recoverable half — if it
+ * fails, nothing local has been touched yet and the user still has every book.
+ * The local purge is irreversible, so it only runs once the network step has
+ * succeeded.
+ *
+ * Both halves are hard removals rather than `deletedAt` tombstones. Tombstones
+ * would be pushed back up on the next sync, refilling the very rows we just
+ * deleted and clearing the library on every other signed-in device.
+ */
+export const deleteAllBooks = async (appService: AppService): Promise<void> => {
+  await deleteCloudLibrary();
+
+  const books = await appService.loadLibraryBooks();
+  for (const book of books) {
+    try {
+      // 'purge' erases the whole Books/<hash>/ dir — the book file, cover,
+      // config.json (progress, bookmarks, annotations), nav.json and the TTS
+      // cache. Its `source.kind === 'managed'` guard is why this must go
+      // through deleteBook: books imported in place keep their original file
+      // at the user-controlled path (see the in-place delete regression).
+      await appService.deleteBook(book, 'purge');
+    } catch (error) {
+      // One unreadable book must not strand the rest of the library.
+      console.error('Failed to purge book:', book.hash, error);
+    }
+  }
+
+  await appService.saveLibraryBooks([], { replace: true });
+};


### PR DESCRIPTION
## Summary

Groups the destructive account actions into their own **Danger Zone** section at the end of the account page, and adds a **Delete All Books** action alongside Delete Account.

Delete Account previously sat as the last cell of the same flat grid as Sign Out and Reset Password. It now lives in a bordered section of its own.

## What Delete All Books does

Hard-deletes the user's rows in `public.books`, then purges every book on this device.

**Cloud first, local second.** The cloud call is the recoverable half: if it fails, nothing local has been touched and the user still has every book. The local purge is irreversible, so it only runs once the network step succeeds.

**Hard removals on both sides, not `deletedAt` tombstones.** A tombstone would be pushed back up on the next sync, refilling the very rows just deleted, and would pull down to every other signed-in device and clear its local library too.

**The local pass goes through `appService.deleteBook(book, 'purge')`** rather than a new bulk path, so the `source.kind === 'managed'` guard keeps in-place-import originals untouched at their user-controlled paths. `'purge'` also clears `config.json` (progress, bookmarks, annotations), `nav.json` and the TTS cache. The library is then replaced via `saveLibraryBooks([], { replace: true })` — the default merge-floor save deliberately refuses to drop books.

One book failing to purge logs and continues rather than stranding the rest.

## Scope

Left intact by design, and spelled out in the confirmation modal:

- Uploaded book files in cloud storage and their `files` rows — still managed under Manage Storage
- `book_configs`, `book_notes`, `stat_books`, `stat_pages` — orphaned by `book_hash`, and they line up again if the same book is re-added
- Other signed-in devices keep their own local copies

Verified against `docker/volumes/db/init/schema.sql`: `book_configs` / `book_notes` / `files` key off `auth.users`, not `books`, so nothing blocks the delete and nothing cascades.

## Known limits

- `/api/user/library` is a new endpoint. The action fails until the web app deploys.
- The wipe is not account-wide. Another signed-in device still holds its own `library.json` and will re-push those books when one is next touched. The modal says so rather than hiding it.

## Test plan

- `pnpm test` — 8768 passed, 16 skipped, 0 failed
- `pnpm lint` — clean
- `pnpm format:check` — clean
- No `src-tauri/` or koplugin changes, so the Rust and Lua gates do not apply
- 6 new i18n keys extracted and translated across all 33 locales, zero `__STRING_NOT_TRANSLATED__` remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)