### PR TITLE
fix(iap): consume Google Play one-time purchases so storage add-ons can be repurchased

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/googleplay/java/com/readest/native_bridge/BillingManager.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/googleplay/java/com/readest/native_bridge/BillingManager.kt
@@ -264,24 +264,37 @@ class BillingManager(private val activity: Activity) : PurchasesUpdatedListener 
     }
 
     private fun handlePurchase(purchase: Purchase) {
-        // Acknowledge the purchase
         if (purchase.purchaseState == Purchase.PurchaseState.PURCHASED) {
-            if (!purchase.isAcknowledged) {
+            // Only subscriptions are acknowledged here. One-time products are
+            // consumables that the server consumes after verification (consume
+            // implies acknowledge); an unverified purchase must stay
+            // unacknowledged so Google Play auto-refunds it after 3 days.
+            if (isSubscriptionPurchase(purchase) && !purchase.isAcknowledged) {
                 val acknowledgePurchaseParams = AcknowledgePurchaseParams.newBuilder()
                     .setPurchaseToken(purchase.purchaseToken)
                     .build()
-                    
+
                 billingClient.acknowledgePurchase(acknowledgePurchaseParams) { billingResult ->
                     if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
                         Log.d(TAG, "Purchase acknowledged")
                     }
                 }
             }
-            
+
             val purchaseData = convertToPurchaseData(purchase, "purchased")
             purchaseCallback?.invoke(purchaseData)
             purchaseCallback = null
         }
+    }
+
+    private fun isSubscriptionPurchase(purchase: Purchase): Boolean {
+        val productId = purchase.products.firstOrNull() ?: return false
+        val cached = productsCache[productId]
+        if (cached != null) {
+            return cached.productType == BillingClient.ProductType.SUBS
+        }
+        return productId.contains("monthly") || productId.contains("yearly") ||
+            productId.contains("subscription")
     }
 
     private fun convertToPurchaseData(purchase: Purchase, state: String): PurchaseData {

--- a/apps/readest-app/src/__tests__/api/google-iap-verify-consume.test.ts
+++ b/apps/readest-app/src/__tests__/api/google-iap-verify-consume.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Storage add-ons are consumable one-time products: users buy the same SKU
+// repeatedly to stack storage. Google Play blocks repurchase of an owned
+// (acknowledged but unconsumed) product with ITEM_ALREADY_OWNED, so the verify
+// route must consume product purchases after recording them — and must never
+// consume subscriptions.
+
+const mocks = vi.hoisted(() => ({
+  validateUserAndToken: vi.fn(),
+  verifyPurchase: vi.fn(),
+  acknowledgePurchase: vi.fn(),
+  consumeProductPurchase: vi.fn(),
+  processPurchaseData: vi.fn(),
+}));
+
+vi.mock('@/utils/access', () => ({
+  validateUserAndToken: mocks.validateUserAndToken,
+}));
+
+vi.mock('@/libs/payment/iap/google/verifier', () => ({
+  getGoogleIAPVerifier: () => ({
+    verifyPurchase: mocks.verifyPurchase,
+    acknowledgePurchase: mocks.acknowledgePurchase,
+    consumeProductPurchase: mocks.consumeProductPurchase,
+  }),
+}));
+
+vi.mock('@/libs/payment/iap/google/server', () => ({
+  processPurchaseData: mocks.processPurchaseData,
+}));
+
+import { POST } from '@/app/api/google/iap-verify/route';
+
+const verifyParams = {
+  packageName: 'com.bilingify.readest',
+  productId: 'com.bilingify.readest.purchase.storage.1gb',
+  orderId: 'GPA.1111-2222-3333-44444',
+  purchaseToken: 'storage-token-1',
+};
+
+const postVerify = async (body: Record<string, string>) => {
+  const request = new NextRequest('http://localhost:3000/api/google/iap-verify', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-token',
+    },
+    body: JSON.stringify(body),
+  });
+  return POST(request);
+};
+
+describe('/api/google/iap-verify consumption', () => {
+  beforeEach(() => {
+    mocks.validateUserAndToken.mockReset();
+    mocks.verifyPurchase.mockReset();
+    mocks.acknowledgePurchase.mockReset();
+    mocks.consumeProductPurchase.mockReset();
+    mocks.processPurchaseData.mockReset();
+
+    mocks.validateUserAndToken.mockResolvedValue({
+      user: { id: 'user-1', email: 'u@example.com' },
+      token: 'test-token',
+    });
+    mocks.processPurchaseData.mockResolvedValue({
+      platform: 'android',
+      status: 'active',
+      productId: verifyParams.productId,
+      orderId: verifyParams.orderId,
+    });
+    mocks.acknowledgePurchase.mockResolvedValue(undefined);
+    mocks.consumeProductPurchase.mockResolvedValue(undefined);
+  });
+
+  it('consumes a verified one-time product instead of acknowledging it', async () => {
+    mocks.verifyPurchase.mockResolvedValue({
+      success: true,
+      status: 'active',
+      purchaseType: 'product',
+      purchaseData: { purchaseState: 0, consumptionState: 0, acknowledgementState: 0 },
+    });
+
+    const response = await postVerify(verifyParams);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.purchase).toBeDefined();
+    expect(mocks.consumeProductPurchase).toHaveBeenCalledTimes(1);
+    expect(mocks.consumeProductPurchase).toHaveBeenCalledWith(verifyParams);
+    expect(mocks.acknowledgePurchase).not.toHaveBeenCalled();
+  });
+
+  it('consumes an already-acknowledged product purchase (stuck pre-fix purchases)', async () => {
+    mocks.verifyPurchase.mockResolvedValue({
+      success: true,
+      status: 'active',
+      purchaseType: 'product',
+      purchaseData: { purchaseState: 0, consumptionState: 0, acknowledgementState: 1 },
+    });
+
+    const response = await postVerify(verifyParams);
+
+    expect(response.status).toBe(200);
+    expect(mocks.consumeProductPurchase).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not consume a pending product purchase', async () => {
+    mocks.verifyPurchase.mockResolvedValue({
+      success: true,
+      status: 'cancelled',
+      purchaseType: 'product',
+      purchaseData: { purchaseState: 2, consumptionState: 0, acknowledgementState: 0 },
+    });
+
+    const response = await postVerify(verifyParams);
+
+    expect(response.status).toBe(200);
+    expect(mocks.consumeProductPurchase).not.toHaveBeenCalled();
+  });
+
+  it('does not consume a product that is already consumed', async () => {
+    mocks.verifyPurchase.mockResolvedValue({
+      success: true,
+      status: 'active',
+      purchaseType: 'product',
+      purchaseData: { purchaseState: 0, consumptionState: 1, acknowledgementState: 1 },
+    });
+
+    const response = await postVerify(verifyParams);
+
+    expect(response.status).toBe(200);
+    expect(mocks.consumeProductPurchase).not.toHaveBeenCalled();
+    expect(mocks.acknowledgePurchase).not.toHaveBeenCalled();
+  });
+
+  it('acknowledges subscriptions and never consumes them', async () => {
+    mocks.verifyPurchase.mockResolvedValue({
+      success: true,
+      status: 'active',
+      purchaseType: 'subscription',
+      purchaseData: { paymentState: 1, acknowledgementState: 0 },
+    });
+
+    const response = await postVerify({
+      ...verifyParams,
+      productId: 'com.bilingify.readest.plus.monthly',
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.acknowledgePurchase).toHaveBeenCalledTimes(1);
+    expect(mocks.consumeProductPurchase).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/__tests__/libs/payment/google-iap-restore-verify.test.ts
+++ b/apps/readest-app/src/__tests__/libs/payment/google-iap-restore-verify.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { IAPPurchase } from '@/utils/iap';
+
+// Storage purchases bought before the server learned to consume them stay
+// "owned" on Google Play forever, blocking repurchase. Restore is the only
+// flow that sees those stuck purchases, so it must send each restored one-time
+// Android purchase through the verify endpoint (which consumes it server-side).
+
+const mocks = vi.hoisted(() => ({
+  getAccessToken: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: mocks.invoke }));
+vi.mock('@/utils/access', () => ({ getAccessToken: mocks.getAccessToken }));
+vi.mock('@/services/environment', () => ({ getNodeAPIBaseUrl: () => 'https://node.test/api' }));
+
+import { verifyGooglePurchaseProducts } from '@/libs/payment/iap/client';
+
+const purchaseDate = '2026-08-01T00:00:00Z';
+
+describe('verifyGooglePurchaseProducts', () => {
+  beforeEach(() => {
+    mocks.getAccessToken.mockReset();
+    mocks.getAccessToken.mockResolvedValue('jwt');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts each restored Android one-time purchase to the verify endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const purchases: IAPPurchase[] = [
+      {
+        platform: 'android',
+        productId: 'com.bilingify.readest.purchase.storage.1gb',
+        orderId: 'GPA.1',
+        purchaseToken: 'tok-1',
+        packageName: 'com.bilingify.readest',
+        purchaseDate,
+      },
+      {
+        platform: 'android',
+        productId: 'com.bilingify.readest.plus.monthly',
+        orderId: 'GPA.2',
+        purchaseToken: 'tok-2',
+        packageName: 'com.bilingify.readest',
+        purchaseDate,
+      },
+      {
+        platform: 'ios',
+        productId: 'com.bilingify.readest.purchase.storage.1gb',
+        transactionId: 't1',
+        originalTransactionId: 't0',
+        purchaseDate,
+      },
+    ];
+
+    await verifyGooglePurchaseProducts(purchases);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://node.test/api/google/iap-verify');
+    expect(init.headers['Authorization']).toBe('Bearer jwt');
+    expect(JSON.parse(init.body)).toEqual({
+      packageName: 'com.bilingify.readest',
+      productId: 'com.bilingify.readest.purchase.storage.1gb',
+      orderId: 'GPA.1',
+      purchaseToken: 'tok-1',
+    });
+  });
+
+  it('does nothing when no restored purchase is an Android one-time product', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await verifyGooglePurchaseProducts([
+      {
+        platform: 'android',
+        productId: 'com.bilingify.readest.plus.monthly',
+        orderId: 'GPA.2',
+        purchaseToken: 'tok-2',
+        packageName: 'com.bilingify.readest',
+        purchaseDate,
+      },
+    ]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/__tests__/libs/payment/google-verifier.test.ts
+++ b/apps/readest-app/src/__tests__/libs/payment/google-verifier.test.ts
@@ -8,13 +8,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const apiMocks = vi.hoisted(() => ({
   subscriptionsGet: vi.fn(),
   productsGet: vi.fn(),
+  productsConsume: vi.fn(),
 }));
 
 vi.mock('@googleapis/androidpublisher', () => ({
   androidpublisher: () => ({
     purchases: {
       subscriptions: { get: apiMocks.subscriptionsGet },
-      products: { get: apiMocks.productsGet },
+      products: { get: apiMocks.productsGet, consume: apiMocks.productsConsume },
     },
   }),
 }));
@@ -74,5 +75,43 @@ describe('GoogleIAPVerifier.verifyPurchase', () => {
 
     expect(result.success).toBe(true);
     expect(result.status).toBe('active');
+  });
+});
+
+// One-time products (storage add-ons) are consumables: Google Play only allows
+// repurchasing a SKU after the previous purchase has been consumed.
+describe('GoogleIAPVerifier.consumeProductPurchase', () => {
+  beforeEach(() => {
+    vi.stubEnv('GOOGLE_IAP_SERVICE_ACCOUNT_KEY', '{"client_email":"t@t","private_key":"k"}');
+    apiMocks.productsConsume.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('consumes a one-time product purchase via the Play API', async () => {
+    apiMocks.productsConsume.mockResolvedValue({});
+
+    await new GoogleIAPVerifier().consumeProductPurchase({
+      ...params,
+      productId: 'com.bilingify.readest.purchase.storage.1gb',
+    });
+
+    expect(apiMocks.productsConsume).toHaveBeenCalledWith({
+      packageName: 'com.bilingify.readest',
+      productId: 'com.bilingify.readest.purchase.storage.1gb',
+      token: 'token-1',
+    });
+  });
+
+  it('propagates consume failures to the caller', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    apiMocks.productsConsume.mockRejectedValue(new Error('consume failed'));
+
+    await expect(new GoogleIAPVerifier().consumeProductPurchase(params)).rejects.toThrow(
+      'consume failed',
+    );
   });
 });

--- a/apps/readest-app/src/app/api/google/iap-verify/route.ts
+++ b/apps/readest-app/src/app/api/google/iap-verify/route.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod';
 import { NextResponse } from 'next/server';
 import { validateUserAndToken } from '@/utils/access';
-import { getGoogleIAPVerifier, VerifyPurchaseParams } from '@/libs/payment/iap/google/verifier';
+import {
+  getGoogleIAPVerifier,
+  ProductPurchase,
+  VerifyPurchaseParams,
+} from '@/libs/payment/iap/google/verifier';
 import { processPurchaseData, VerifiedPurchase } from '@/libs/payment/iap/google/server';
 import { IAPError } from '@/libs/payment/iap/types';
 
@@ -60,7 +64,19 @@ export async function POST(request: Request) {
     let purchase: VerifiedPurchase;
     try {
       purchase = await processPurchaseData(user, verifyParams, verificationResult);
-      if (verificationResult.purchaseData?.acknowledgementState === 0) {
+      if (verificationResult.purchaseType === 'product') {
+        // One-time products (storage add-ons) are consumables: consuming
+        // (which implicitly acknowledges) lets the user repurchase the SKU.
+        const productData = verificationResult.purchaseData as ProductPurchase;
+        if (productData.purchaseState === 0 && productData.consumptionState === 0) {
+          try {
+            await googleIAPVerifier.consumeProductPurchase(verifyParams);
+            purchase.acknowledgementState = 1;
+          } catch (consumeError) {
+            console.error('Failed to consume purchase:', consumeError);
+          }
+        }
+      } else if (verificationResult.purchaseData?.acknowledgementState === 0) {
         try {
           await googleIAPVerifier.acknowledgePurchase(verifyParams);
           purchase.acknowledgementState = 1;

--- a/apps/readest-app/src/app/user/page.tsx
+++ b/apps/readest-app/src/app/user/page.tsx
@@ -20,6 +20,7 @@ import { Toast } from '@/components/Toast';
 import {
   purchaseIAPProduct,
   restoreIAPPurchases,
+  verifyGooglePurchaseProducts,
   getSubscriptionSuccessUrl as getIAPSubscriptionSuccessUrl,
 } from '@/libs/payment/iap/client';
 import { isPurchaseProduct } from '@/libs/payment/iap/utils';
@@ -198,15 +199,25 @@ const ProfilePage = () => {
     try {
       const purchases = await restoreIAPPurchases();
       if (purchases.length > 0) {
+        // Restored one-time purchases (storage add-ons) may still be
+        // unconsumed on Google Play, blocking repurchase; re-verifying lets
+        // the server consume them.
+        await verifyGooglePurchaseProducts(purchases);
         const restoredSubscriptions = purchases
           .filter((p) => !isPurchaseProduct(p.productId))
           .sort((a, b) => new Date(b.purchaseDate).getTime() - new Date(a.purchaseDate).getTime());
         const purchase = restoredSubscriptions[0];
 
-        if (!purchase) {
+        if (purchase) {
+          router.push(getIAPSubscriptionSuccessUrl(purchase));
+        } else if (purchases.some((p) => isPurchaseProduct(p.productId))) {
+          eventDispatcher.dispatch('toast', {
+            type: 'info',
+            message: _('Purchases restored successfully.'),
+          });
+        } else {
           throw new Error('No subscription found in restored purchases');
         }
-        router.push(getIAPSubscriptionSuccessUrl(purchase));
       } else {
         eventDispatcher.dispatch('toast', {
           type: 'info',

--- a/apps/readest-app/src/libs/payment/iap/client.ts
+++ b/apps/readest-app/src/libs/payment/iap/client.ts
@@ -1,6 +1,8 @@
 import { AvailablePlan } from '@/types/quota';
+import { getNodeAPIBaseUrl } from '@/services/environment';
+import { getAccessToken } from '@/utils/access';
 import { IAPService, IAPPurchase, IAPProduct } from '@/utils/iap';
-import { mapProductIdToInterval, mapProductIdToUserPlan } from './utils';
+import { isPurchaseProduct, mapProductIdToInterval, mapProductIdToUserPlan } from './utils';
 
 const SUBSCRIPTION_SUCCESS_PATH = '/user/subscription/success';
 
@@ -32,6 +34,42 @@ export const restoreIAPPurchases = async () => {
   const iapService = new IAPService();
   const purchases = await iapService.restorePurchases();
   return purchases;
+};
+
+// One-time products (storage add-ons) restored from Google Play may still be
+// unconsumed — e.g. bought before the server learned to consume them — which
+// blocks repurchasing the same SKU. Re-verifying them lets the server record
+// and consume each one; replays are deduped by purchase token server-side.
+export const verifyGooglePurchaseProducts = async (purchases: IAPPurchase[]) => {
+  const products = purchases.filter(
+    (p) => p.platform === 'android' && isPurchaseProduct(p.productId) && p.purchaseToken,
+  );
+  if (products.length === 0) return;
+
+  try {
+    const token = await getAccessToken();
+    if (!token) return;
+
+    await Promise.allSettled(
+      products.map((purchase) =>
+        fetch(`${getNodeAPIBaseUrl()}/google/iap-verify`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            packageName: purchase.packageName,
+            productId: purchase.productId,
+            orderId: purchase.orderId,
+            purchaseToken: purchase.purchaseToken,
+          }),
+        }),
+      ),
+    );
+  } catch (error) {
+    console.error('Failed to verify restored purchase products:', error);
+  }
 };
 
 export const initializeIAP = async () => {

--- a/apps/readest-app/src/libs/payment/iap/google/verifier.ts
+++ b/apps/readest-app/src/libs/payment/iap/google/verifier.ts
@@ -223,6 +223,24 @@ export class GoogleIAPVerifier {
     }
   }
 
+  // One-time products (storage add-ons) are consumables: Google Play only
+  // allows repurchasing a SKU after the previous purchase has been consumed.
+  // Consuming also implicitly acknowledges the purchase.
+  async consumeProductPurchase(params: VerifyPurchaseParams): Promise<void> {
+    const { purchaseToken, productId, packageName } = params;
+
+    try {
+      await this.androidPublisher.purchases.products.consume({
+        packageName,
+        productId,
+        token: purchaseToken,
+      });
+    } catch (error) {
+      console.error('Failed to consume product purchase:', error);
+      throw error;
+    }
+  }
+
   async cancelSubscription(params: VerifyPurchaseParams): Promise<void> {
     const { purchaseToken, productId, packageName } = params;
 


### PR DESCRIPTION
## Problem

Storage add-ons (`.purchase.storage.1gb/2gb/5gb/10gb`) are consumable products: users buy the same SKU repeatedly to stack storage ("Each additional purchase adds more space"). But on Google Play nothing ever consumed them:

- the Android `BillingManager` acknowledged every purchase locally, and
- the `/api/google/iap-verify` route only acknowledged after verification.

An acknowledged-but-unconsumed one-time (INAPP) product is treated by Google Play as permanently owned, so a second `launchBillingFlow` for the same SKU fails with `ITEM_ALREADY_OWNED`. Each storage tier could be bought exactly once, ever. iOS is unaffected (`finishTransaction` is the StoreKit consumable equivalent).

## Fix

- **Verifier**: new `consumeProductPurchase` calling the Play Developer API `purchases.products.consume`. Consuming implicitly acknowledges and makes the SKU repurchasable.
- **Verify route**: after the payment row is recorded, one-time products are consumed instead of acknowledged, gated on `purchaseState === 0 && consumptionState === 0` (pending or already-consumed purchases are skipped). Subscriptions keep the acknowledge-only path.
- **Android client**: `handlePurchase` acknowledges subscriptions only. One-time products stay unacknowledged locally so Google Play auto-refunds them after 3 days if server verification never completes (entitlement is only granted server-side at verify time).
- **Stuck purchases from before this fix**: the restore flow now re-posts every restored Android one-time purchase to the verify endpoint, which consumes it server-side. Replays are deduped by the `google_purchase_token` upsert, so nothing is double-granted. A storage-only restore now shows a success toast instead of the misleading "Failed to restore purchases".

Notes:
- Each repurchase gets a fresh purchase token, so every buy creates a new `payments` row and `updateUserStorage` stacks correctly.
- Consumed purchases no longer appear in `queryPurchasesAsync`; storage entitlement already lives server-side, so restore does not depend on Google returning them.
- The RTDN webhook ignores `oneTimeProductNotification`, so there is no interaction with server-side consume.

## Test plan

- [x] New unit tests: verifier consume call and error propagation; route consumes products (fresh and already-acknowledged), skips pending and already-consumed, never consumes subscriptions; restore helper only posts Android one-time purchases
- [x] `pnpm test` (8777 passed), `pnpm lint`, `pnpm format:check`, `pnpm fmt:check`, `pnpm clippy:check`, `pnpm test:rust`
- [ ] Device verify with live Play billing: buy the same storage tier twice; second purchase must not fail with "already owned". Existing stuck buyers unstick via Restore Purchases once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)