### PR TITLE
feat(tts): speak Japanese ruby readings instead of the base kanji

### DIFF
--- a/apps/readest-app/src/__tests__/document/overlayer-highlight-blocks.test.ts
+++ b/apps/readest-app/src/__tests__/document/overlayer-highlight-blocks.test.ts
@@ -14,6 +14,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { Overlayer } from 'foliate-js/overlayer.js';
+import { expandRangeOverRuby } from '@/utils/ruby';
 
 interface RectLike {
   left: number;
@@ -207,5 +208,86 @@ describe('Overlayer rect splitting across block types', () => {
     const text = covered.join('');
     expect(text).toContain('Before the image.');
     expect(text).toContain('After the image.');
+  });
+});
+
+describe('Overlayer ruby annotations', () => {
+  beforeEach(() => {
+    covered = [];
+    Object.defineProperty(Range.prototype, 'getClientRects', {
+      value: stubGetClientRects,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    if (realGetClientRects) {
+      Object.defineProperty(Range.prototype, 'getClientRects', realGetClientRects);
+    } else {
+      delete (Range.prototype as { getClientRects?: unknown }).getClientRects;
+    }
+  });
+
+  // Furigana renders on its own line above the base, so its rects would draw a
+  // second box floating over the annotation instead of on the highlighted text.
+  it('never contributes rects for ruby annotations', () => {
+    document.body.innerHTML = `
+      <section>
+        <p id="p1">空には<ruby>数多<rp>(</rp><rt>あまた</rt><rp>)</rp></ruby>の星がある。</p>
+      </section>`;
+    const range = document.createRange();
+    range.selectNodeContents(byId('p1'));
+
+    const { draw } = drawSpy();
+    new Overlayer(document).add('annotation', range, draw);
+
+    const text = covered.join('');
+    expect(text).toContain('空には');
+    expect(text).toContain('数多');
+    expect(text).toContain('の星がある。');
+    expect(text).not.toContain('あまた');
+    expect(text).not.toContain('(');
+  });
+
+  it('never contributes rects for an injected gloss', () => {
+    document.body.innerHTML = `
+      <section>
+        <p id="p1">これは<ruby class="wl-gloss" cfi-skip=""
+          >辞書<rt cfi-inert="">dictionary</rt></ruby>です。</p>
+      </section>`;
+    const range = document.createRange();
+    range.selectNodeContents(byId('p1'));
+
+    const { draw } = drawSpy();
+    new Overlayer(document).add('annotation', range, draw);
+
+    const text = covered.join('');
+    expect(text).toContain('辞書');
+    expect(text).not.toContain('dictionary');
+  });
+
+  // The TTS highlight anchors on whichever side of the ruby is spoken. When
+  // that is the reading, the range starts inside the <rt> whose rects are now
+  // dropped — expandRangeOverRuby widens it so the base is painted instead.
+  it('paints the base of a ruby the range only entered through its reading', () => {
+    document.body.innerHTML = `
+      <section>
+        <p id="p1">空には<ruby>数多<rt>あまた</rt></ruby>の星がある。</p>
+      </section>`;
+    const rt = byId('p1').querySelector('rt')!;
+    const tail = byId('p1').lastChild as Text;
+    const range = document.createRange();
+    range.setStart(rt.firstChild!, 0);
+    range.setEnd(tail, tail.length);
+
+    const { draw } = drawSpy();
+    new Overlayer(document).add('annotation', expandRangeOverRuby(range), draw);
+
+    const text = covered.join('');
+    expect(text).toContain('数多');
+    expect(text).toContain('の星がある。');
+    expect(text).not.toContain('あまた');
   });
 });

--- a/apps/readest-app/src/__tests__/document/tts.test.ts
+++ b/apps/readest-app/src/__tests__/document/tts.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { textWalker } from 'foliate-js/text-walker.js';
 import { TTS } from 'foliate-js/tts.js';
-import { createRejectFilter } from '@/utils/node';
+import { createTTSNodeFilter } from '@/services/tts/nodeFilter';
 import { filterSSMLWithLang, parseSSMLMarks } from '@/utils/ssml';
 
 const createHTMLDoc = (bodyHTML: string, attrs: Record<string, string> = {}): Document => {
@@ -34,20 +34,8 @@ const stripTags = (ssml: string): string => ssml.replace(/<[^>]+\/?>/g, '').trim
 
 const highlight = vi.fn();
 
-/** Node filter mirroring the footnote rules TTSController passes to TTS. */
-const ttsNodeFilter = createRejectFilter({
-  tags: ['rt', 'canvas', 'br'],
-  classes: [
-    'annotationLayer',
-    'epubtype-footnote',
-    'duokan-footnote-content',
-    'duokan-footnote-item',
-  ],
-  attributeTokens: [
-    { tag: 'aside', attribute: 'epub:type', tokens: ['footnote', 'endnote', 'note', 'rearnote'] },
-  ],
-  contents: [{ tag: 'a', content: /^[\[\(]?[\*\d]+[\)\]]?$/ }],
-});
+/** The exact filter TTSController passes to TTS. */
+const ttsNodeFilter = createTTSNodeFilter();
 
 describe('TTS', () => {
   describe('plain HTML document', () => {
@@ -357,6 +345,70 @@ describe('TTS', () => {
     it('should not reject an element missing the attribute', () => {
       const aside = document.createElement('aside');
       expect(ttsNodeFilter(aside)).toBe(NodeFilter.FILTER_SKIP);
+    });
+  });
+
+  describe('ruby (furigana) readings', () => {
+    const speak = (bodyHTML: string): string => {
+      const doc = createHTMLDoc(bodyHTML, { lang: 'ja' });
+      const tts = new TTS(doc, textWalker, ttsNodeFilter, highlight, 'sentence');
+      return stripTags(tts.start()!);
+    };
+
+    it('speaks a kana reading instead of the bare-text ruby base', () => {
+      expect(speak('<p><ruby>数多<rt>あまた</rt></ruby>の星</p>')).toBe('あまたの星');
+    });
+
+    it('speaks a kana reading instead of an <rb> ruby base', () => {
+      expect(speak('<p><ruby><rb>数多</rb><rt>あまた</rt></ruby>の星</p>')).toBe('あまたの星');
+    });
+
+    it('speaks an author-assigned katakana reading', () => {
+      expect(speak('<p><ruby>神聖文字<rt>ヒエログリフ</rt></ruby>を読む</p>')).toBe(
+        'ヒエログリフを読む',
+      );
+    });
+
+    it('speaks a gaiji image base through its reading', () => {
+      expect(
+        speak(
+          '<p><ruby><rb><img class="gaiji" src="00007.gif" alt="喰"/></rb><rt>く</rt></ruby>い殺され</p>',
+        ),
+      ).toBe('くい殺され');
+    });
+
+    it('keeps <rp> fallback parentheses out of the speech', () => {
+      expect(speak('<p><ruby>数多<rp>(</rp><rt>あまた</rt><rp>)</rp></ruby>の星</p>')).toBe(
+        'あまたの星',
+      );
+    });
+
+    it('keeps speaking the base when the ruby is an emphasis dot', () => {
+      expect(speak('<p><ruby>本当<rt>・・</rt></ruby>に読む</p>')).toBe('本当に読む');
+    });
+
+    it('keeps speaking the base for a pinyin ruby', () => {
+      expect(speak('<p><ruby>学生<rt>xuéshēng</rt></ruby></p>')).toBe('学生');
+    });
+
+    it('keeps speaking the base under an injected WordLens gloss', () => {
+      expect(
+        speak(
+          '<p><ruby class="wl-gloss" cfi-skip="">辞書<rt cfi-inert="">じしょ</rt></ruby>を引く</p>',
+        ),
+      ).toBe('辞書を引く');
+    });
+
+    it('anchors the highlight range on the spoken reading', () => {
+      const doc = createHTMLDoc('<p><ruby>数多<rt>あまた</rt></ruby>の星</p>', { lang: 'ja' });
+      const tts = new TTS(doc, textWalker, ttsNodeFilter, highlight, 'sentence');
+      tts.start();
+      // The single sentence mark spans the reading through the trailing text,
+      // never the muted kanji base.
+      const range = tts.getLastRange() ?? tts.setMark('0');
+      expect(range).toBeTruthy();
+      expect(range!.toString()).not.toContain('数多');
+      expect(range!.startContainer.parentElement?.tagName.toLowerCase()).toBe('rt');
     });
   });
 

--- a/apps/readest-app/src/__tests__/utils/ruby.test.ts
+++ b/apps/readest-app/src/__tests__/utils/ruby.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { isKanaReading, isMutedRubyNode } from '@/utils/ruby';
+
+const parse = (html: string): Document =>
+  new DOMParser().parseFromString(`<!DOCTYPE html><html><body>${html}</body></html>`, 'text/html');
+
+/** Every text node of the body, in document order. */
+const textNodes = (doc: Document): Text[] => {
+  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
+  const out: Text[] = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) out.push(n as Text);
+  return out;
+};
+
+/** The text that survives the ruby mute rule, i.e. what TTS would speak. */
+const spokenText = (html: string): string =>
+  textNodes(parse(html))
+    .filter((n) => !isMutedRubyNode(n))
+    .map((n) => n.data)
+    .join('');
+
+describe('isKanaReading', () => {
+  it('accepts hiragana and katakana readings', () => {
+    expect(isKanaReading('あまた')).toBe(true);
+    expect(isKanaReading('ヒエログリフ')).toBe(true);
+    expect(isKanaReading('コーヒー')).toBe(true);
+    expect(isKanaReading('ヴィクトリア・アルベルト')).toBe(true);
+  });
+
+  it('rejects emphasis dot marks used as ruby', () => {
+    expect(isKanaReading('・')).toBe(false);
+    expect(isKanaReading('・・・')).toBe(false);
+    expect(isKanaReading('﹅')).toBe(false);
+    expect(isKanaReading('●')).toBe(false);
+    expect(isKanaReading('、')).toBe(false);
+  });
+
+  it('rejects non-kana glosses', () => {
+    expect(isKanaReading('')).toBe(false);
+    expect(isKanaReading('   ')).toBe(false);
+    expect(isKanaReading('hieroglyph')).toBe(false);
+    expect(isKanaReading('shēng')).toBe(false);
+    expect(isKanaReading('ㄕㄥ')).toBe(false);
+    expect(isKanaReading('神聖')).toBe(false);
+    expect(isKanaReading('かん字')).toBe(false);
+  });
+});
+
+describe('isMutedRubyNode', () => {
+  it('mutes the base and speaks the reading for group ruby', () => {
+    expect(spokenText('<p><ruby>数多<rt>あまた</rt></ruby>の</p>')).toBe('あまたの');
+  });
+
+  it('handles an explicit <rb> base', () => {
+    expect(spokenText('<p><ruby><rb>数多</rb><rt>あまた</rt></ruby>の</p>')).toBe('あまたの');
+  });
+
+  it('concatenates interleaved mono ruby pairs', () => {
+    expect(spokenText('<p><ruby>漢<rt>かん</rt>字<rt>じ</rt></ruby></p>')).toBe('かんじ');
+  });
+
+  it('keeps okurigana whose <rt> is empty', () => {
+    // The empty <rt> pads the okurigana so it renders without a reading; the
+    // base run it annotates is the pronunciation itself and must be spoken.
+    expect(spokenText('<p><ruby>振<rt>ふ</rt>り<rt></rt>仮名<rt>がな</rt></ruby></p>')).toBe(
+      'ふりがな',
+    );
+  });
+
+  it('speaks the reading when the base is a gaiji image', () => {
+    expect(
+      spokenText('<p><ruby><rb><img class="gaiji" alt="喰"/></rb><rt>く</rt></ruby>い殺され</p>'),
+    ).toBe('くい殺され');
+  });
+
+  it('drops <rp> fallback parentheses', () => {
+    expect(spokenText('<p><ruby>数多<rp>(</rp><rt>あまた</rt><rp>)</rp></ruby></p>')).toBe(
+      'あまた',
+    );
+  });
+
+  it('keeps the base when the reading is an emphasis dot', () => {
+    expect(spokenText('<p><ruby>本当<rt>・・</rt></ruby>に</p>')).toBe('本当に');
+  });
+
+  it('keeps the base when the reading is pinyin or a latin gloss', () => {
+    expect(spokenText('<p><ruby>生<rt>shēng</rt></ruby></p>')).toBe('生');
+    expect(spokenText('<p><ruby>神聖文字<rt>hieroglyph</rt></ruby></p>')).toBe('神聖文字');
+  });
+
+  it('keeps the base for injected WordLens glosses', () => {
+    expect(
+      spokenText(
+        '<p><ruby class="wl-gloss" cfi-skip="">辞書<rt cfi-inert="">じしょ</rt></ruby></p>',
+      ),
+    ).toBe('辞書');
+  });
+
+  it('mutes a trailing <rtc> annotation layer', () => {
+    expect(spokenText('<p><ruby>東京<rt>とうきょう</rt><rtc>Tokyo</rtc></ruby></p>')).toBe(
+      'とうきょう',
+    );
+  });
+
+  it('mutes a stray <rt> outside any <ruby>', () => {
+    expect(spokenText('<p>a<rt>x</rt>b</p>')).toBe('ab');
+  });
+
+  it('leaves text with no ruby ancestor alone', () => {
+    expect(spokenText('<p>吾輩は猫である</p>')).toBe('吾輩は猫である');
+  });
+
+  it('never mutes the <ruby> element itself so its children are visited', () => {
+    const doc = parse('<p><ruby>数多<rt>あまた</rt></ruby></p>');
+    expect(isMutedRubyNode(doc.querySelector('ruby')!)).toBe(false);
+  });
+
+  it('mutes an <rb> element node, not just its text', () => {
+    const doc = parse('<p><ruby><rb>数多</rb><rt>あまた</rt></ruby></p>');
+    expect(isMutedRubyNode(doc.querySelector('rb')!)).toBe(true);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
@@ -132,6 +132,11 @@ const TTSMiniPlayer = ({
   // platform. The panels' paddings are constant and the slide is
   // transform-only, so subtracting the in-flight translate yields the settled
   // top edge even mid-animation.
+  // A book can carry a coverImageUrl that no longer resolves (cover never
+  // extracted, file pruned). Showing the browser's broken-image glyph in the
+  // card is worse than showing no cover at all.
+  const [coverFailed, setCoverFailed] = useState(false);
+
   const [panelTopOffset, setPanelTopOffset] = useState(0);
   useLayoutEffect(() => {
     const cell = document.getElementById(`gridcell-${bookKey}`);
@@ -232,12 +237,13 @@ const TTSMiniPlayer = ({
               aria-label={_('Open Read Aloud player')}
               className='flex min-w-0 flex-1 cursor-pointer items-center gap-2'
             >
-              {book?.coverImageUrl ? (
+              {book?.coverImageUrl && !coverFailed ? (
                 // eslint-disable-next-line @next/next/no-img-element
                 <img
                   src={book.coverImageUrl}
                   alt=''
                   className='h-10 w-10 shrink-0 rounded-lg object-cover'
+                  onError={() => setCoverFailed(true)}
                 />
               ) : null}
               <div className='flex min-w-0 flex-col'>

--- a/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
@@ -142,6 +142,11 @@ const TTSPlayerSheet = ({
   const premiumBadge =
     !user || (userProfilePlan !== undefined && !isDownloadPremium) ? _('Premium') : undefined;
 
+  // A book can carry a coverImageUrl that no longer resolves (cover never
+  // extracted, file pruned). A broken <img> still occupies its h-32 box, so
+  // drop it from the layout entirely rather than leaving a blank band above
+  // the title.
+  const [coverFailed, setCoverFailed] = useState(false);
   const [view, setView] = useState<SheetView>('main');
   const [voiceGroups, setVoiceGroups] = useState<TTSVoicesGroup[]>([]);
   const [rate, setRate] = useState(viewSettings?.ttsRate ?? 1.0);
@@ -335,12 +340,13 @@ const TTSPlayerSheet = ({
         // desktop, where the mobile drag handle (and its clearance) is
         // hidden; on mobile the handle already provides the gap.
         <div className='flex w-full flex-col items-center gap-4 pb-4 sm:pt-4'>
-          {book?.coverImageUrl ? (
+          {book?.coverImageUrl && !coverFailed ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img
               src={book.coverImageUrl}
               alt=''
               className='not-eink:shadow-lg eink-bordered h-32 w-auto rounded-xl object-cover'
+              onError={() => setCoverFailed(true)}
             />
           ) : null}
           <div className='flex w-full flex-col items-center gap-0.5 text-center'>

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -11,7 +11,8 @@ import {
   TTSMark,
   TTSVoice,
 } from './types';
-import { createRejectFilter } from '@/utils/node';
+import { createTTSNodeFilter } from './nodeFilter';
+import { expandRangeOverRuby } from '@/utils/ruby';
 import { WebSpeechClient } from './WebSpeechClient';
 import { NativeTTSClient } from './NativeTTSClient';
 import { EdgeTTSClient } from './EdgeTTSClient';
@@ -83,31 +84,6 @@ export interface TTSViewBindings {
   preprocessCallback?: (ssml: string) => Promise<string>;
   onSectionChange?: (sectionIndex: number) => Promise<void>;
 }
-
-// Node filter shared by the live TTS instance and the timeline enumeration —
-// the two MUST segment identically or timeline sentences drift from marks.
-const createTTSNodeFilter = () =>
-  createRejectFilter({
-    tags: ['rt', 'canvas', 'br'],
-    // Footnotes/endnotes are hidden in the rendered page (see the
-    // `.epubtype-footnote`/`aside[epub|type]` rules in getPageLayoutStyles);
-    // skip them in TTS too, including for background sections whose
-    // documents are loaded without those styles.
-    classes: [
-      'annotationLayer',
-      'epubtype-footnote',
-      'duokan-footnote-content',
-      'duokan-footnote-item',
-    ],
-    attributeTokens: [
-      {
-        tag: 'aside',
-        attribute: 'epub:type',
-        tokens: ['footnote', 'endnote', 'note', 'rearnote'],
-      },
-    ],
-    contents: [{ tag: 'a', content: /^[\[\(]?[\*\d]+[\)\]]?$/ }],
-  });
 
 // Silence inserted between paragraphs when auto-advancing during continuous
 // playback. Unlike the Edge-only inter-sentence gap, this applies to every
@@ -489,7 +465,7 @@ export class TTSController extends EventTarget {
         return;
       }
       try {
-        const cfi = this.view.getCFI(index, range);
+        const cfi = this.view.getCFI(index, expandRangeOverRuby(range));
         const visibleRange = this.view.resolveCFI(cfi).anchor(doc);
         // A stale range (re-applied after a relocate that changed the section
         // content) resolves to nothing in the current doc; overlayer.add would

--- a/apps/readest-app/src/services/tts/nodeFilter.ts
+++ b/apps/readest-app/src/services/tts/nodeFilter.ts
@@ -1,0 +1,32 @@
+import { createRejectFilter } from '@/utils/node';
+import { isMutedRubyNode } from '@/utils/ruby';
+
+// Node filter shared by the live TTS instance and the timeline enumeration —
+// the two MUST segment identically or timeline sentences drift from marks.
+export const createTTSNodeFilter = () => {
+  const reject = createRejectFilter({
+    tags: ['canvas', 'br'],
+    // Footnotes/endnotes are hidden in the rendered page (see the
+    // `.epubtype-footnote`/`aside[epub|type]` rules in getPageLayoutStyles);
+    // skip them in TTS too, including for background sections whose
+    // documents are loaded without those styles.
+    classes: [
+      'annotationLayer',
+      'epubtype-footnote',
+      'duokan-footnote-content',
+      'duokan-footnote-item',
+    ],
+    attributeTokens: [
+      {
+        tag: 'aside',
+        attribute: 'epub:type',
+        tokens: ['footnote', 'endnote', 'note', 'rearnote'],
+      },
+    ],
+    contents: [{ tag: 'a', content: /^[\[\(]?[\*\d]+[\)\]]?$/ }],
+  });
+  // Ruby is decided per base-run/reading pair rather than by tag name: a kana
+  // <rt> is spoken in place of the kanji it annotates, anything else keeps the
+  // pre-#5539 behaviour of speaking the base and dropping the annotation.
+  return (node: Node): number => (isMutedRubyNode(node) ? NodeFilter.FILTER_REJECT : reject(node));
+};

--- a/apps/readest-app/src/services/tts/wordHighlight.ts
+++ b/apps/readest-app/src/services/tts/wordHighlight.ts
@@ -4,6 +4,8 @@
 // TTS-only proofread rule) is skipped without advancing the search cursor so
 // later words still align.
 
+import { isMutedRubyNode } from '@/utils/ruby';
+
 export interface TTSWordOffset {
   start: number;
   end: number;
@@ -12,18 +14,16 @@ export interface TTSWordOffset {
 // Edge TTS word-boundary offsets are in 100-nanosecond ticks.
 const TICKS_PER_SECOND = 10_000_000;
 
-// Gloss markup (<rt cfi-inert>) and any cfi-inert subtree is injected, non-book
-// content — invisible to CFI and to spoken text (the TTS node filter rejects
-// <rt>). Word-offset matching must ignore it too, or boundary words (gloss-free)
-// won't align with the walked text.
+// Any cfi-inert subtree is injected, non-book content — invisible to CFI and to
+// spoken text. Word-offset matching must ignore it too, or boundary words
+// (gloss-free) won't align with the walked text. Ruby follows the same rule the
+// TTS node filter applies, so whichever side of a ruby pair is muted there is
+// muted here: for a kana reading that is the base, otherwise the annotation.
 const isInertText = (node: Node): boolean => {
+  if (isMutedRubyNode(node)) return true;
   let p: Node | null = node.parentNode;
   while (p) {
-    if (p.nodeType === Node.ELEMENT_NODE) {
-      const el = p as Element;
-      const tag = el.tagName.toLowerCase();
-      if (tag === 'rt' || tag === 'rp' || el.hasAttribute('cfi-inert')) return true;
-    }
+    if (p.nodeType === Node.ELEMENT_NODE && (p as Element).hasAttribute('cfi-inert')) return true;
     p = p.parentNode;
   }
   return false;

--- a/apps/readest-app/src/utils/ruby.ts
+++ b/apps/readest-app/src/utils/ruby.ts
@@ -1,0 +1,94 @@
+// Ruby (furigana) helpers shared by TTS text extraction and TTS highlighting.
+//
+// Japanese kanji readings are not derivable from the base characters: most
+// kanji have several readings picked by context, proper names follow no rule
+// at all, fiction authors deliberately assign readings (義訓 — 神聖文字 glossed
+// as ヒエログリフ), and older EPUBs render rare kanji as an <img> so the base
+// carries no text whatsoever. The <rt> is the only ground truth, so TTS speaks
+// it and mutes the base run it annotates (#5539).
+//
+// The swap is gated on the reading being kana, which is what keeps every other
+// use of ruby markup working as before: emphasis dots (傍点), pinyin, zhuyin,
+// latin/kanji glosses and Readest's own injected WordLens glosses all keep
+// speaking the base and muting the annotation, exactly as they did before.
+
+// Kana letters proper — the marks that make a reading pronounceable. Notably
+// excludes ・ (U+30FB), which is a separator inside katakana loanwords but is
+// also the character books use for emphasis dots.
+const KANA_LETTER = /[ぁ-ゖゝ-ゟァ-ヺヽ-ヿ]/;
+// Everything a kana reading may otherwise contain: voicing marks, the
+// prolonged sound mark ー, the loanword separator ・, and whitespace.
+const KANA_TEXT = /^[ぁ-ゖ゛-ゟァ-ヿ\s]+$/;
+
+/** Whether an `<rt>` holds a Japanese reading rather than a gloss or an emphasis mark. */
+export const isKanaReading = (text: string): boolean =>
+  KANA_LETTER.test(text) && KANA_TEXT.test(text);
+
+// Injected, non-book annotations (WordLens glosses) are marked `cfi-inert`;
+// they are never book content and so never speech.
+const isSpokenReading = (rt: Element): boolean =>
+  !rt.closest('[cfi-inert]') && isKanaReading(rt.textContent ?? '');
+
+/**
+ * The `<rt>` annotating the base run that `child` — a direct child of `<ruby>` —
+ * belongs to. Ruby content alternates base run / annotation, so it is simply
+ * the next `<rt>` sibling.
+ */
+const rtForBaseRun = (child: Node): Element | null => {
+  for (let node = child.nextSibling; node; node = node.nextSibling) {
+    if (node.nodeType !== Node.ELEMENT_NODE) continue;
+    const name = (node as Element).tagName.toLowerCase();
+    // A second annotation layer (double-sided ruby) rather than a mono pair:
+    // its readings are not interleaved with the bases, so leave the base alone.
+    if (name === 'rtc') return null;
+    if (name === 'rt') return node as Element;
+  }
+  return null;
+};
+
+/**
+ * Whether `node` is the silent side of its ruby pair — the side TTS must not
+ * speak. That is the base run when its reading is spoken in its place, and the
+ * annotation otherwise. `<rp>` and `<rtc>` are always silent, and so is an
+ * `<rt>` that ended up outside any `<ruby>`.
+ *
+ * Nodes with no ruby involvement are never muted.
+ */
+export const isMutedRubyNode = (node: Node): boolean => {
+  const el = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+  if (!el?.closest) return false;
+  if (el.closest('rp, rtc')) return true;
+  const rt = el.closest('rt');
+  if (rt) return !isSpokenReading(rt);
+  const ruby = el.closest('ruby');
+  if (!ruby || node === ruby) return false;
+  // Climb to the direct child of <ruby> holding this node — the base run whose
+  // reading decides whether it is spoken.
+  let child: Node = node;
+  while (child.parentNode && child.parentNode !== ruby) child = child.parentNode;
+  if (child.parentNode !== ruby) return false;
+  const reading = rtForBaseRun(child);
+  return !!reading && isSpokenReading(reading);
+};
+
+const rubyAncestor = (node: Node): Element | null => {
+  const el = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+  return el?.closest?.('ruby') ?? null;
+};
+
+/**
+ * Widen a range that starts or ends inside a `<ruby>` so it covers the whole
+ * element. TTS ranges are anchored on the text it speaks, which for a Japanese
+ * book is now the `<rt>` reading — and the overlayer never paints `<rt>`, so an
+ * unexpanded range would highlight nothing at all. Expanding puts the highlight
+ * on the base the reader is actually looking at.
+ */
+export const expandRangeOverRuby = (range: Range): Range => {
+  const startRuby = rubyAncestor(range.startContainer);
+  const endRuby = rubyAncestor(range.endContainer);
+  if (!startRuby && !endRuby) return range;
+  const expanded = range.cloneRange();
+  if (startRuby) expanded.setStartBefore(startRuby);
+  if (endRuby) expanded.setEndAfter(endRuby);
+  return expanded;
+};


### PR DESCRIPTION
Fixes #5539

Bundles readest/foliate-js#67 (merged); the submodule pointer here is on that merged commit.

## Problem

Since #1608 TTS skips `<rt>`, so kanji are not read twice — but that means it always speaks the base and lets the engine guess the reading. Japanese is the worst case for that: most kanji have several readings picked by context (数多 → あまた vs 数多く → かずおおく), proper names follow no rule at all (角田 is legitimately かくた / かどた / すみだ / つのだ), and fiction authors deliberately assign readings, writing 神聖文字 and glossing it ヒエログリフ. The furigana the publisher shipped is the only source of truth, and it was being thrown away. Older Japanese EPUBs are worse still: they render rare kanji as an `<img>` inside the ruby, so `<ruby><rb><img alt="喰"/></rb><rt>く</rt></ruby>い殺され` was read as 「いころされ」 — the word simply vanished.

## Approach

The swap happens in the **node filter**, never by rewriting text. The TTS document is usually the live rendered document, and even for background sections it has to stay content-identical or highlight CFIs drift at the wrong offsets (the rule `transformTTSSectionDocument` exists to enforce, #5406). Both the live-range walk and the cloned-fragment walk use the same filter, so marks stay aligned.

`src/utils/ruby.ts` decides, **per base-run / reading pair**, which side is muted. The `<rt>` is spoken in place of its base when it holds a kana reading — at least one real kana letter and nothing but kana, `ー`, `・`, voicing marks and whitespace.

That single rule self-gates to Japanese and covers every case in the issue:

| Markup | Spoken |
|---|---|
| `<ruby>数多<rt>あまた</rt></ruby>` (no `<rb>`) | あまた |
| `<ruby><rb>神聖文字</rb><rt>ヒエログリフ</rt></ruby>` | ヒエログリフ |
| `<ruby>漢<rt>かん</rt>字<rt>じ</rt></ruby>` | かんじ |
| `振<rt>ふ</rt>り<rt></rt>仮名<rt>がな</rt>` | ふりがな — an empty `<rt>` pads okurigana, so its base is the pronunciation and stays |
| `<rb><img alt="喰"/></rb><rt>く</rt>` | く — the gaiji case, fixed for free |
| `<rp>(</rp>…<rp>)</rp>` | excluded, as before |
| `<rt>・・</rt>` emphasis dots (傍点) | not kana, so the base is still spoken |
| pinyin, zhuyin, latin or kanji glosses | not kana, so the base is still spoken |
| injected WordLens `[cfi-inert]` glosses | always muted |

No setting: the kana test is the gate, so books that use ruby for anything else are untouched.

## Highlighting

A range anchored on a reading lies inside the `<rt>`, and foliate no longer paints ruby annotations (readest/foliate-js#67), so `expandRangeOverRuby` widens such ranges to the whole `<ruby>`. The result is a highlight on the base the reader is looking at, never a detached box over the furigana. This also fixes the same problem for user annotations: a highlight drawn across a ruby word no longer paints its furigana.

`wordHighlight.isInertText` follows the same rule so Edge word-boundary offsets line up with the spoken reading instead of drifting.

`createTTSNodeFilter` moved out of `TTSController` into `src/services/tts/nodeFilter.ts` so the tests exercise the real filter rather than a duplicated copy — the live instance and the timeline enumeration must segment identically.

## Also here

`TTSMiniPlayer` / `TTSPlayerSheet` now drop a `coverImageUrl` that fails to load. A broken `<img>` still occupied its box: a blank 128px band above the title in the sheet, and the browser's broken-image glyph in the mini player card.

## Testing

New: `utils/ruby.test.ts` for the pairing and kana rules, ruby cases in `document/tts.test.ts` for the generated SSML and mark anchoring, and ruby cases in `document/overlayer-highlight-blocks.test.ts` for the rect exclusion and the expansion. Each of the foliate changes is proven necessary by a test that fails without it.

Verified in Chrome against a purpose-built Japanese EPUB covering all eight variants above — the real pipeline produced あまた / ヒエログリフ / かんじ / ふりがな / あまた / 本当 (dots kept) / すみだ / ひとけ, the TTS highlight box hugged the base line with the furigana outside it, and a user highlight across 数多 covered only the base.

`pnpm test` (8797) and `pnpm test:browser` (347) pass; `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
