### PR TITLE
feat(a11y): name the open book in the window title

### DIFF
--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -492,6 +492,9 @@ pub fn run() {
     let builder = builder.plugin(macos::traffic_light::init());
 
     #[cfg(target_os = "macos")]
+    let builder = builder.plugin(macos::window::init());
+
+    #[cfg(target_os = "macos")]
     let builder = builder.plugin(macos::safari_auth::init());
 
     #[cfg(target_os = "ios")]
@@ -663,11 +666,14 @@ pub fn run() {
             #[cfg(all(not(target_os = "macos"), desktop))]
             let win_builder = win_builder.inner_size(800.0, 600.0).resizable(true);
 
+            // The overlay title bar draws its title over the app's own header,
+            // so `macos::window::init()` hides the title text and the window
+            // can carry a real name for the Window menu and VoiceOver.
             #[cfg(target_os = "macos")]
             let win_builder = win_builder
                 .decorations(true)
                 .title_bar_style(TitleBarStyle::Overlay)
-                .title("");
+                .title("Readest");
 
             #[cfg(all(not(target_os = "macos"), desktop))]
             let win_builder = {

--- a/apps/readest-app/src-tauri/src/macos/window.rs
+++ b/apps/readest-app/src-tauri/src/macos/window.rs
@@ -22,12 +22,13 @@
 //! calls are sound. The `Mutex` around the saved frame exists only to
 //! make the `static` safe, mirroring the statics in `traffic_light.rs`.
 
-use cocoa::appkit::NSWindowStyleMask;
+use cocoa::appkit::{NSWindow, NSWindowStyleMask, NSWindowTitleVisibility};
 use cocoa::base::{id, nil, NO, YES};
 use cocoa::foundation::NSUInteger;
 use cocoa::foundation::{NSPoint, NSRect, NSSize};
 use objc::{msg_send, sel, sel_impl};
 use std::sync::Mutex;
+use tauri::plugin::{Builder, TauriPlugin};
 
 /// The main window's real frame, captured immediately before the Tahoe
 /// defensive hide zeroes it. `None` while no defensive hide is pending.
@@ -217,6 +218,31 @@ pub fn restore_main_window_frame(window: &tauri::WebviewWindow) {
         let _: () = msg_send![ns_window as id, setFrame: frame display: YES];
     }
     saved_frame.take();
+}
+
+/// Hides the title text of every window so each one can carry a real title.
+///
+/// `TitleBarStyle::Overlay` only makes the title bar transparent and extends
+/// the content view underneath it — AppKit still draws the title string
+/// centered on top of Readest's own header. The windows therefore shipped with
+/// an empty title, which left window switchers, the Window menu and VoiceOver
+/// with nothing to announce. Hiding the text instead lets the frontend put the
+/// open book's name in the title (see `tauriSetWindowTitle`) without any of it
+/// being painted over the header.
+///
+/// Runs on window ready so it also covers the reader windows the frontend
+/// creates at runtime (`src/utils/nav.ts`).
+pub fn init<R: tauri::Runtime>() -> TauriPlugin<R> {
+    Builder::new("window_title")
+        .on_window_ready(|window| {
+            let Ok(ns_window) = window.ns_window() else {
+                return;
+            };
+            unsafe {
+                (ns_window as id).setTitleVisibility_(NSWindowTitleVisibility::NSWindowTitleHidden);
+            }
+        })
+        .build()
 }
 
 #[cfg(test)]

--- a/apps/readest-app/src/__tests__/utils/nav.test.ts
+++ b/apps/readest-app/src/__tests__/utils/nav.test.ts
@@ -346,7 +346,9 @@ describe('showReaderWindow', () => {
 
     const constructorCall = vi.mocked(WebviewWindow).mock.calls[0]!;
     const options = constructorCall[1]!;
-    expect(options.title).toBe('');
+    // The overlay title bar hides its title text natively, so the window is
+    // named like every other platform's.
+    expect(options.title).toBe('Readest');
     expect(options.decorations).toBe(true);
     expect(options.titleBarStyle).toBe('overlay');
   });

--- a/apps/readest-app/src/__tests__/utils/window.test.ts
+++ b/apps/readest-app/src/__tests__/utils/window.test.ts
@@ -24,7 +24,12 @@ vi.mock('@/utils/event', () => ({
 
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { type as osType } from '@tauri-apps/plugin-os';
-import { tauriHandleOnCloseWindow, tauriHandleToggleFullScreen } from '@/utils/window';
+import {
+  formatAppWindowTitle,
+  tauriHandleOnCloseWindow,
+  tauriHandleToggleFullScreen,
+  tauriSetWindowTitle,
+} from '@/utils/window';
 
 type CloseHandler = (event: { preventDefault: () => void }) => Promise<void> | void;
 
@@ -170,5 +175,50 @@ describe('tauriHandleToggleFullScreen', () => {
     await tauriHandleToggleFullScreen();
 
     expect(win.setFullscreen).toHaveBeenCalledWith(true);
+  });
+});
+
+describe('formatAppWindowTitle', () => {
+  test('names the open book so windows are distinguishable in Alt+Tab', () => {
+    expect(formatAppWindowTitle('The Hobbit')).toBe('Readest - The Hobbit');
+  });
+
+  test('falls back to the app name when no book is open', () => {
+    expect(formatAppWindowTitle()).toBe('Readest');
+    expect(formatAppWindowTitle('')).toBe('Readest');
+  });
+
+  test('ignores a blank book title', () => {
+    expect(formatAppWindowTitle('   ')).toBe('Readest');
+  });
+
+  test('trims the book title', () => {
+    expect(formatAppWindowTitle('  The Hobbit \n')).toBe('Readest - The Hobbit');
+  });
+});
+
+describe('tauriSetWindowTitle', () => {
+  function makeTitledWindow() {
+    const win = { setTitle: vi.fn().mockResolvedValue(undefined) };
+    vi.mocked(getCurrentWindow).mockReturnValue(
+      win as unknown as ReturnType<typeof getCurrentWindow>,
+    );
+    return win;
+  }
+
+  test('titles the calling window after the open book', async () => {
+    const win = makeTitledWindow();
+
+    await tauriSetWindowTitle('The Hobbit');
+
+    expect(win.setTitle).toHaveBeenCalledWith('Readest - The Hobbit');
+  });
+
+  test('resets to the app name when no book is open', async () => {
+    const win = makeTitledWindow();
+
+    await tauriSetWindowTitle();
+
+    expect(win.setTitle).toHaveBeenCalledWith('Readest');
   });
 });

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -74,6 +74,7 @@ import {
   tauriHandleSetAlwaysOnTop,
   tauriHandleToggleFullScreen,
   tauriQuitApp,
+  tauriSetWindowTitle,
 } from '@/utils/window';
 
 import { LibraryGroupByType } from '@/types/settings';
@@ -503,6 +504,14 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
       lockScreenOrientation({ orientation: 'auto' });
     }
   }, [appService]);
+
+  // Drop the book name the reader put in the window title, so a window back on
+  // the library does not keep announcing a book that is no longer open.
+  useEffect(() => {
+    if (appService?.hasWindow) {
+      tauriSetWindowTitle();
+    }
+  }, [appService?.hasWindow]);
 
   useEffect(() => {
     if (appService?.hasWindow) {

--- a/apps/readest-app/src/app/reader/components/BooksGrid.tsx
+++ b/apps/readest-app/src/app/reader/components/BooksGrid.tsx
@@ -10,6 +10,7 @@ import { useSidebarStore } from '@/store/sidebarStore';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { getGridTemplate, getInsetEdges } from '@/utils/grid';
+import { tauriSetWindowTitle } from '@/utils/window';
 import { useContentInsets } from '../hooks/useContentInsets';
 import SearchResultsNav from './sidebar/SearchResultsNav';
 import BooknotesNav from './sidebar/BooknotesNav';
@@ -301,8 +302,14 @@ const BooksGrid: React.FC<BooksGridProps> = ({ bookKeys, onCloseBook, onGoToLibr
     const bookData = getBookData(sideBarBookKey);
     if (!bookData || !bookData.book) return;
     document.title = bookData.book.title;
+    // The OS window title is invisible but is what Alt+Tab and screen readers
+    // announce, so name the book there too — otherwise every window is just
+    // "Readest" and blind users cannot tell them apart.
+    if (appService?.hasWindow) {
+      tauriSetWindowTitle(bookData.book.title);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sideBarBookKey]);
+  }, [sideBarBookKey, appService?.hasWindow]);
 
   // Memoize the per-book grid insets array — its identity is the input
   // to BookCell.gridInsets, and BookCell is React.memo'd. As long as

--- a/apps/readest-app/src/utils/nav.ts
+++ b/apps/readest-app/src/utils/nav.ts
@@ -16,7 +16,7 @@ const createReaderWindow = (appService: AppService, url: string) => {
     height: 600,
     center: true,
     resizable: true,
-    title: appService.isMacOSApp ? '' : 'Readest',
+    title: 'Readest',
     decorations: !!appService.isMacOSApp,
     // Linux stays opaque: a transparent WebKitGTK window turns invisible when
     // its web process is busy (#3682). macOS uses native decorations instead.
@@ -78,7 +78,7 @@ export const ensureMainLibraryWindow = async (appService: AppService) => {
     height: 600,
     center: true,
     resizable: true,
-    title: appService.isMacOSApp ? '' : 'Readest',
+    title: 'Readest',
     decorations: !!appService.isMacOSApp,
     // Linux stays opaque: a transparent WebKitGTK window turns invisible when
     // its web process is busy (#3682). macOS uses native decorations instead.

--- a/apps/readest-app/src/utils/window.ts
+++ b/apps/readest-app/src/utils/window.ts
@@ -4,6 +4,23 @@ import { exit } from '@tauri-apps/plugin-process';
 import { type as osType } from '@tauri-apps/plugin-os';
 import { eventDispatcher } from './event';
 
+const APP_NAME = 'Readest';
+
+/**
+ * The OS window title, e.g. `Readest - The Hobbit`. It is never drawn in the
+ * UI — desktop windows are either decorationless (Windows/Linux) or hide their
+ * title text (the macOS overlay title bar) — but window switchers and screen
+ * readers announce it, so it has to name the open book to tell windows apart.
+ */
+export const formatAppWindowTitle = (bookTitle?: string) => {
+  const title = bookTitle?.trim();
+  return title ? `${APP_NAME} - ${title}` : APP_NAME;
+};
+
+export const tauriSetWindowTitle = async (bookTitle?: string) => {
+  await getCurrentWindow().setTitle(formatAppWindowTitle(bookTitle));
+};
+
 export const tauriGetWindowLogicalPosition = async () => {
   const currentWindow = getCurrentWindow();
   const factor = await currentWindow.scaleFactor();


### PR DESCRIPTION
## Problem

Every Readest window is titled `Readest`. On Windows, blind users cycle windows with Alt+Tab, and the screen reader announces only the window title, so with two books open there is no way to tell the windows apart.

## Change

Title each window `Readest - <Book Title>` while a book is open, and reset it to `Readest` when the window goes back to the library. With several books open side by side the title follows the active (sidebar) book, matching what `document.title` already did.

**Nothing changes visually:**

| Platform | Why the title is not drawn |
| --- | --- |
| Windows / Linux | windows are created with `decorations(false)`, so the OS title only ever reaches window switchers and screen readers |
| macOS | `TitleBarStyle::Overlay` only makes the title bar transparent and extends the content view under it, so AppKit still draws the title string over Readest's own header. That is why these windows shipped with an empty title. A new `macos::window::init()` plugin sets `titleVisibility = .hidden` on window ready instead, so the title bar stays blank while the window carries a real name for VoiceOver, the Window menu and Mission Control. It runs on window ready, so reader windows created at runtime are covered too. |
| iOS / Android | gated behind `appService.hasWindow`, untouched |
| Web | `document.title` keeps showing the bare book title, so tab and bookmark text is unchanged |

With the title text hidden natively, the macOS placeholder empty titles in `lib.rs` and `nav.ts` become a plain `Readest`, so a window with no book open still has a name.

## Verification

- `pnpm test` (8812 passed), `pnpm lint`, `pnpm fmt:check`, `pnpm clippy:check`, `pnpm test:rust` (91 passed)
- New unit tests for `formatAppWindowTitle` and `tauriSetWindowTitle`
- macOS release build: the title bar renders blank, and the library window reports `AXTitle=[Readest]` to the accessibility API (it read empty before this change). Verified separately with a standalone AppKit probe that `titleVisibility = .hidden` does not blank `AXTitle`.
- Not yet verified on hardware: the Windows Alt+Tab text itself, and the live title swap when a book opens (needs a Windows box and a GUI click respectively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)