### PR TITLE
fix(rsvp): respect safe area insets in landscape

### DIFF
--- a/apps/readest-app/src/__tests__/components/rsvp-overlay-context.test.tsx
+++ b/apps/readest-app/src/__tests__/components/rsvp-overlay-context.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 
 import RSVPOverlay from '@/app/reader/components/rsvp/RSVPOverlay';
 import type { RSVPController, RsvpState } from '@/services/rsvp';
+import type { Insets } from '@/types/misc';
 
 beforeAll(() => {
   if (!Element.prototype.scrollIntoView) {
@@ -102,11 +103,15 @@ const buildController = (state: RsvpState) => {
   return controller;
 };
 
-const renderOverlay = (state: RsvpState, fontFamily?: string) => {
+const renderOverlay = (
+  state: RsvpState,
+  fontFamily?: string,
+  gridInsets: Insets = { top: 0, bottom: 0, left: 0, right: 0 },
+) => {
   const controller = buildController(state);
   const result = render(
     <RSVPOverlay
-      gridInsets={{ top: 0, bottom: 0, left: 0, right: 0 }}
+      gridInsets={gridInsets}
       controller={controller as unknown as RSVPController}
       chapters={[]}
       currentChapterHref={null}
@@ -130,6 +135,40 @@ describe('RSVPOverlay — capture lifecycle', () => {
     const { getByTestId } = renderOverlay(state);
 
     expect(getByTestId('rsvp-overlay').getAttribute('data-capture-blocking-overlay')).toBe('true');
+  });
+});
+
+describe('RSVPOverlay — safe area insets', () => {
+  afterEach(() => cleanup());
+
+  const wordState = () =>
+    buildState({ words: [{ text: 'hello', orpIndex: 1, pauseMultiplier: 1 }], currentIndex: 0 });
+
+  test('pads the full-screen surface horizontally so landscape notches never clip it', () => {
+    const { getByTestId } = renderOverlay(wordState(), undefined, {
+      top: 0,
+      right: 44,
+      bottom: 21,
+      left: 59,
+    });
+
+    const overlay = getByTestId('rsvp-overlay');
+    expect(overlay.style.paddingLeft).toBe('59px');
+    expect(overlay.style.paddingRight).toBe('44px');
+  });
+
+  test('keeps the existing vertical inset treatment', () => {
+    const { getByTestId } = renderOverlay(wordState(), undefined, {
+      top: 47,
+      right: 0,
+      bottom: 34,
+      left: 0,
+    });
+
+    const overlay = getByTestId('rsvp-overlay');
+    expect(overlay.style.paddingTop).toBe('47px');
+    // Bottom bars only need a fraction of the home-indicator inset.
+    expect(overlay.style.paddingBottom).toBe(`${34 * 0.33}px`);
   });
 });
 

--- a/apps/readest-app/src/app/reader/components/rsvp/RSVPOverlay.tsx
+++ b/apps/readest-app/src/app/reader/components/rsvp/RSVPOverlay.tsx
@@ -691,6 +691,11 @@ const RSVPOverlay: React.FC<RSVPOverlayProps> = ({
       style={{
         paddingTop: `${gridInsets.top}px`,
         paddingBottom: `${gridInsets.bottom * 0.33}px`,
+        // Physical (not logical) padding: in landscape the notch and rounded
+        // corners sit on a fixed side of the device, so these must not flip
+        // with the book's reading direction.
+        paddingLeft: `${gridInsets.left}px`,
+        paddingRight: `${gridInsets.right}px`,
         backgroundColor: bgColor,
         color: fgColor,
         backdropFilter: 'none',


### PR DESCRIPTION
## Problem

The RSVP (speed reading) overlay is a full-screen surface, but it only padded its top and bottom edges with the safe area insets. In landscape the notch and the rounded corners sit on the left/right, so they cut into the overlay's chrome:

- header: close button, chapter selector, WPM / "Audio pace" picker
- context panel edges
- the transport row (audio toggle, skip, play/pause, settings gear)

## Fix

Pad the overlay root's left and right edges from `gridInsets` as well. Applying it on the root insets every child in one place, and the background still paints edge to edge because padding sits inside the background box.

Physical `paddingLeft`/`paddingRight` are used rather than the logical properties DESIGN.md normally calls for: the notch sits on a fixed side of the *device*, so this padding must not flip with an RTL book's reading direction.

Absolutely positioned descendants (the dictionary popup) resolve against the fixed root's padding box, which still spans the full screen, so their placement is unchanged.

## Tests

New `RSVPOverlay - safe area insets` block. Written first: the horizontal assertion failed (`expected '' to be '59px'`) while the vertical one passed, pinning down existing behaviour before the change.

## Verification

- `pnpm test src/__tests__/components/rsvp-overlay-context.test.tsx` - 33 passed
- `pnpm lint` - clean
- `pnpm format:check` - clean for the touched files

Not verified on a device or in a browser: on web `appService.hasSafeAreaInset` is false, so the insets are all zero and a notch cannot be reproduced there without patching the store.

## Known remaining case

`gridInsets` is per book cell, and in split view the cell edges that do not touch the screen border are zeroed. With two books open in landscape, the overlay opened from the left-hand book would still have no right-side padding. Covering that means sourcing the overlay's insets from the screen rather than from the cell, which is left out of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)