### PR TITLE
fix(layout): keep code block indentation when overriding book layout

### DIFF
--- a/apps/readest-app/src/__tests__/services/transformers/transformers.test.ts
+++ b/apps/readest-app/src/__tests__/services/transformers/transformers.test.ts
@@ -237,6 +237,54 @@ describe('whitespaceTransformer', () => {
       );
       expect(result).toBe('');
     });
+
+    test('preserves indentation inside <pre>', async () => {
+      const html = '<pre><code>&lt;div&gt;\n    &lt;a/&gt;\n        &lt;b/&gt;\n</code></pre>';
+      const result = await whitespaceTransformer.transform(
+        makeCtx({ content: html, viewSettings: settings }),
+      );
+      expect(result).toBe(html);
+    });
+
+    test('preserves spaces inside inline <code>', async () => {
+      const html = '<p>run <code>a    b</code> now</p>';
+      const result = await whitespaceTransformer.transform(
+        makeCtx({ content: html, viewSettings: settings }),
+      );
+      expect(result).toBe(html);
+    });
+
+    test('still collapses spaces outside <pre>', async () => {
+      const html = '<p>hello   world</p><pre>  keep  me  </pre><p>a   b</p>';
+      const result = await whitespaceTransformer.transform(
+        makeCtx({ content: html, viewSettings: settings }),
+      );
+      expect(result).toBe('<p>hello world</p><pre>  keep  me  </pre><p>a b</p>');
+    });
+
+    test('preserves nbsp entities inside <pre>', async () => {
+      const html = '<pre>a&nbsp;&nbsp;b</pre>';
+      const result = await whitespaceTransformer.transform(
+        makeCtx({ content: html, viewSettings: settings }),
+      );
+      expect(result).toBe(html);
+    });
+
+    test('handles <pre> with attributes and uppercase tags', async () => {
+      const html = '<PRE class="x">a    b</PRE>';
+      const result = await whitespaceTransformer.transform(
+        makeCtx({ content: html, viewSettings: settings }),
+      );
+      expect(result).toBe(html);
+    });
+
+    test('collapses spaces in text between two <pre> blocks', async () => {
+      const html = '<pre>a    b</pre>x   y<pre>c    d</pre>';
+      const result = await whitespaceTransformer.transform(
+        makeCtx({ content: html, viewSettings: settings }),
+      );
+      expect(result).toBe('<pre>a    b</pre>x y<pre>c    d</pre>');
+    });
   });
 
   describe('when overrideLayout is false', () => {

--- a/apps/readest-app/src/services/transformers/whitespace.ts
+++ b/apps/readest-app/src/services/transformers/whitespace.ts
@@ -1,21 +1,33 @@
 import type { Transformer } from './types';
 
+// `pre` and `code` are rendered with `white-space: pre-wrap !important` (see
+// getPageLayoutStyles), so runs of spaces inside them are real indentation, not
+// the fake spacing this transformer normalizes away. Skip those regions.
+const PRESERVED_REGIONS = /<(pre|code)\b[^>]*>[\s\S]*?<\/\1\s*>/gi;
+
+const collapseWhitespace = (content: string) =>
+  content
+    // Replace &nbsp; but skip literal "&amp;nbsp;"
+    .replace(/(&amp;)?&nbsp;/g, (match, amp) => (amp ? match : ' '))
+    // Replace literal non-breaking space characters (U+00A0) with normal spaces
+    .replace(/\u00A0/g, ' ')
+    // Collapse consecutive spaces into one
+    .replace(/ {2,}/g, ' ');
+
 export const whitespaceTransformer: Transformer = {
   name: 'whitespace',
 
   transform: async (ctx) => {
     const viewSettings = ctx.viewSettings;
-    if (viewSettings.overrideLayout) {
-      const cleaned = ctx.content
-        // Replace &nbsp; but skip literal "&amp;nbsp;"
-        .replace(/(&amp;)?&nbsp;/g, (match, amp) => (amp ? match : ' '))
-        // Replace literal non-breaking space characters (U+00A0) with normal spaces
-        .replace(/\u00A0/g, ' ')
-        // Collapse consecutive spaces into one
-        .replace(/ {2,}/g, ' ');
-      return cleaned;
-    } else {
-      return ctx.content;
+    if (!viewSettings.overrideLayout) return ctx.content;
+
+    let cleaned = '';
+    let lastIndex = 0;
+    for (const match of ctx.content.matchAll(PRESERVED_REGIONS)) {
+      const start = match.index!;
+      cleaned += collapseWhitespace(ctx.content.slice(lastIndex, start)) + match[0];
+      lastIndex = start + match[0].length;
     }
+    return cleaned + collapseWhitespace(ctx.content.slice(lastIndex));
   },
 };


### PR DESCRIPTION
## Problem

Turning on **Override Book Layout** flattened the indentation of code blocks. Nested code that should step in by 4 / 8 / 12 spaces rendered with a single space per level.

The symptom (runs of spaces collapsing to one, newlines preserved) looks exactly like a CSS `white-space: pre-line` regression, but it is not CSS. Comparing the iframe's `srcdoc` (the pre-parse source string) against `pre.textContent` shows the whitespace is already gone **before the iframe parses the HTML**:

| Override | srcdoc indents | DOM indents |
| --- | --- | --- |
| off | `0, 4, 8, 4` | `0, 4, 8, 4` |
| on | `0, 0, 0, 1, 1, 1` | `0, 1, 1, 1` |

## Root cause

`src/services/transformers/whitespace.ts` reads `viewSettings.overrideLayout` and, when on, ran `.replace(/ {2,}/g, ' ')` over the entire section HTML string. The transformer exists to normalize books that fake spacing with runs of `&nbsp;`, but it applied blindly, so `<pre>` indentation was collapsed along with it.

This is easy to miss: grepping `overrideLayout` only hits `style.ts`, `LayoutPanel.tsx`, `constants.ts` and `types/book.ts`, which makes the setting look CSS-only. The transformer reads it too.

## Fix

Skip `<pre>` and `<code>` regions when collapsing. Those two are exactly the elements `getPageLayoutStyles` forces to `white-space: pre-wrap !important`, so their space runs are real indentation rather than the fake `&nbsp;` spacing this transformer targets. Content outside those regions goes through the original collapse logic unchanged.

## Tests

Six tests added, written first and confirmed failing against the old code:

- preserves indentation inside `<pre>`
- preserves spaces inside inline `<code>`
- still collapses spaces outside `<pre>`
- preserves `&nbsp;` entities inside `<pre>`
- handles `<pre>` with attributes and uppercase tags
- collapses spaces in text between two `<pre>` blocks

## Verification

- `pnpm test` — 8789 passed, 16 skipped
- `pnpm lint` — clean
- `pnpm format:check` — clean
- Verified in Chrome on a real EPUB with override **on**: srcdoc and DOM indents both back to `0, 4, 8, 4`, paragraph `text-indent` still 2em so the override itself still works, and no U+00A0 left in body text so `&nbsp;` normalization is intact.

No `src-tauri/` or koplugin changes, so the Rust and Lua gates do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)