### PR TITLE
fix(docker): apply db migrations on first boot and let the font CDN be overridden (#5550)

### DIFF
--- a/apps/readest-app/src/__tests__/docker/db-bootstrap-migrations.test.ts
+++ b/apps/readest-app/src/__tests__/docker/db-bootstrap-migrations.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { basename, resolve } from 'path';
+
+/**
+ * Regression guard: a fresh Docker deployment only ever ran
+ * `docker/volumes/db/init/schema.sql` (#5550).
+ *
+ * `schema.sql` is the hand-written base schema; every schema change since has
+ * landed as an incremental file under `docker/volumes/db/migrations/`, and
+ * nothing mounted those into the db container. Self-hosters therefore booted a
+ * database missing `files.replica_id`, the `replicas` table and the
+ * `claim_inbox_item` RPC, so file upload, replica sync and Send to Readest all
+ * failed against an otherwise healthy stack.
+ *
+ * The fix wires the migrations directory into the first-boot sequence, so this
+ * test asserts the wiring rather than the contents of `schema.sql` — folding
+ * each migration into `schema.sql` by hand is exactly the process that drifted.
+ */
+
+const DOCKER_DIR = resolve(process.cwd(), '../../docker');
+const MIGRATIONS_DIR = resolve(DOCKER_DIR, 'volumes/db/migrations');
+const INITDB_DIR = '/docker-entrypoint-initdb.d';
+
+const compose = readFileSync(resolve(DOCKER_DIR, 'compose.yaml'), 'utf-8');
+
+/** `- ./volumes/db/roles.sql:/docker-entrypoint-initdb.d/...:Z` → [source, target]. */
+const dbServiceMounts = (): { source: string; target: string }[] => {
+  const start = compose.indexOf('\n  db:');
+  const end = compose.indexOf('\n  kong:');
+  return [...compose.slice(start, end).matchAll(/^\s*- (\S+?):(\/\S+?)(?::[a-zA-Z,]+)?$/gm)].map(
+    ([, source, target]) => ({ source: source!, target: target! }),
+  );
+};
+
+const migrationFiles = readdirSync(MIGRATIONS_DIR)
+  .filter((name) => name.endsWith('.sql'))
+  .sort();
+
+/** Every SQL file the db container executes on first boot, in execution order. */
+const bootstrapSql = (): string => {
+  const mounts = dbServiceMounts();
+  const files: string[] = [];
+
+  for (const { source, target } of mounts) {
+    if (target.startsWith(`${INITDB_DIR}/`) && target.endsWith('.sql')) {
+      files.push(resolve(DOCKER_DIR, source));
+    }
+  }
+
+  // A shell hook mounted directly under the init dir applies the migrations
+  // directory; count its files only when the hook really globs that mount.
+  const hook = mounts.find(
+    ({ target }) => target.startsWith(`${INITDB_DIR}/`) && target.endsWith('.sh'),
+  );
+  const migrationsMount = mounts.find(({ source }) =>
+    source.replace(/\/$/, '').endsWith('db/migrations'),
+  );
+  if (hook && migrationsMount) {
+    const script = readFileSync(resolve(DOCKER_DIR, hook.source), 'utf-8');
+    if (script.includes(`${migrationsMount.target}/*.sql`)) {
+      files.push(...migrationFiles.map((name) => resolve(MIGRATIONS_DIR, name)));
+    }
+  }
+
+  return files.map((file) => readFileSync(file, 'utf-8')).join('\n');
+};
+
+describe('docker db bootstrap (#5550)', () => {
+  it('mounts the migrations directory into the db container', () => {
+    expect(dbServiceMounts().map(({ source }) => source)).toContain('./volumes/db/migrations');
+  });
+
+  it('runs the migration hook after the supabase image applies its own schema', () => {
+    const hook = dbServiceMounts().find(
+      ({ target }) => target.startsWith(`${INITDB_DIR}/`) && target.endsWith('.sh'),
+    );
+    expect(hook).toBeDefined();
+    // The image ships `${INITDB_DIR}/migrate.sh`, which creates the auth schema
+    // and runs `init-scripts/100-schema.sql`. Glob order decides who goes first.
+    expect(basename(hook!.target) > 'migrate.sh').toBe(true);
+  });
+
+  it('applies every migration by glob, so new ones need no compose edit', () => {
+    const hook = dbServiceMounts().find(({ target }) => target.endsWith('.sh'))!;
+    const script = readFileSync(resolve(DOCKER_DIR, hook.source), 'utf-8');
+    const migrationsMount = dbServiceMounts().find(
+      ({ source }) => source === './volumes/db/migrations',
+    )!;
+    expect(script).toContain(`${migrationsMount.target}/*.sql`);
+  });
+
+  it.each([
+    ['files.replica_id', /ADD COLUMN IF NOT EXISTS replica_id/],
+    ['files.replica_kind', /ADD COLUMN IF NOT EXISTS replica_kind/],
+    ['the replicas table', /CREATE TABLE IF NOT EXISTS public\.replicas\b/],
+    ['the claim_inbox_item RPC', /CREATE OR REPLACE FUNCTION public\.claim_inbox_item/],
+    ['the book_shares table', /CREATE TABLE IF NOT EXISTS public\.book_shares\b/],
+    ['the reading stats tables', /CREATE TABLE IF NOT EXISTS public\.stat_books\b/],
+  ])('creates %s on first boot', (_label, pattern) => {
+    expect(bootstrapSql()).toMatch(pattern);
+  });
+});

--- a/apps/readest-app/src/services/runtimeConfig.ts
+++ b/apps/readest-app/src/services/runtimeConfig.ts
@@ -5,6 +5,7 @@ export interface ReadestRuntimeConfig {
   objectStorageType?: string;
   storageFixedQuota?: number;
   translationFixedQuota?: number;
+  fontBaseUrl?: string;
 }
 
 declare global {
@@ -42,4 +43,11 @@ export const getServerRuntimeConfig = (): ReadestRuntimeConfig => ({
       process.env['TRANSLATION_FIXED_QUOTA'] ?? process.env['NEXT_PUBLIC_TRANSLATION_FIXED_QUOTA'];
     return raw ? parseInt(raw, 10) : undefined;
   })(),
+  // Base URL of the directory holding the self-hosted CJK webfont bundles.
+  // Readest's own CDN only answers CORS for readest.com origins, so a
+  // self-hosted deployment on a custom domain has to serve them itself (#5550).
+  // `||` not `??`: compose passes the variable through even when it is unset,
+  // and an empty string would build root-relative font URLs.
+  fontBaseUrl:
+    process.env['FONT_BASE_URL'] || process.env['NEXT_PUBLIC_FONT_BASE_URL'] || undefined,
 });

--- a/apps/readest-app/src/styles/fonts.ts
+++ b/apps/readest-app/src/styles/fonts.ts
@@ -1,3 +1,4 @@
+import { getRuntimeConfig } from '@/services/runtimeConfig';
 import { isCJKEnv } from '@/utils/misc';
 import { getFilename } from '@/utils/path';
 import { md5Fingerprint } from '@/utils/md5';
@@ -35,13 +36,32 @@ const getAdditionalBasicFontLinks = () => `
     .join('&')}&display=swap" crossorigin="anonymous">
 `;
 
-const getAdditionalCJKFontLinks = () => `
+// CJK bundles Readest serves itself. The default CDN only answers CORS for
+// readest.com origins, so a self-hosted deployment on a custom domain gets each
+// of these blocked unless it points FONT_BASE_URL at a host it controls (#5550).
+const hostedCJKFonts = [
+  'Huiwen-MinchoGBK',
+  'KingHwa_OldSong',
+  'Source Han Serif CN',
+  'GuanKiapTsingKhai-T',
+];
+
+const DEFAULT_FONT_BASE_URL = 'https://storage.readest.com/public/font/dist';
+
+const getFontBaseUrl = () =>
+  (getRuntimeConfig()?.fontBaseUrl || DEFAULT_FONT_BASE_URL).replace(/\/+$/, '');
+
+const getAdditionalCJKFontLinks = () => {
+  const fontBaseUrl = getFontBaseUrl();
+  return `
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/misans-webfont@1.0.4/misans-l3/misans-l3/result.min.css" crossorigin="anonymous" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/lxgw-wenkai-screen-web/1.520.0/lxgwwenkaigbscreen/result.css" crossorigin="anonymous" />
-  <link rel='stylesheet' href='https://storage.readest.com/public/font/dist/Huiwen-MinchoGBK/result.css' crossorigin="anonymous" />
-  <link rel='stylesheet' href='https://storage.readest.com/public/font/dist/KingHwa_OldSong/result.css' crossorigin="anonymous" />
-  <link rel='stylesheet' href='https://storage.readest.com/public/font/dist/Source%20Han%20Serif%20CN/result.css' crossorigin="anonymous" />
-  <link rel='stylesheet' href='https://storage.readest.com/public/font/dist/GuanKiapTsingKhai-T/result.css' crossorigin="anonymous" />
+  ${hostedCJKFonts
+    .map(
+      (family) =>
+        `<link rel='stylesheet' href='${fontBaseUrl}/${encodeURIComponent(family)}/result.css' crossorigin="anonymous" />`,
+    )
+    .join('\n  ')}
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?${cjkGoogleFonts
     .map(
       ({ family, weights }) =>
@@ -49,6 +69,7 @@ const getAdditionalCJKFontLinks = () => `
     )
     .join('&')}&display=swap" crossorigin="anonymous" />
 `;
+};
 
 const getAdditionalCJKFontFaces = () => `
   @font-face {

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -3,6 +3,11 @@
 HOST_IP=localhost
 READEST_IMAGE=ghcr.io/readest/readest:latest
 
+# browser-facing urls, derived from HOST_IP unless set here. behind an https
+# reverse proxy, point both at the single public origin (see README).
+# SUPABASE_PUBLIC_URL=https://your-domain.com
+# S3_PUBLIC_ENDPOINT=https://your-domain.com
+
 # db(psql) config
 # change to strong password, min 32 chars
 POSTGRES_PASSWORD=your-super-secret-postgres-password
@@ -52,3 +57,10 @@ S3_BUCKET_NAME=readest-files
 # 1GB fixed quota for storage and 50k for translations
 STORAGE_FIXED_QUOTA=1073741824
 TRANSLATION_FIXED_QUOTA=50000
+
+# where the reader loads the self-hosted CJK webfont bundles from.
+# leave empty to use Readest's CDN (https://storage.readest.com/public/font/dist),
+# which only sends CORS headers for readest.com origins - if you serve the app
+# from your own domain and want those fonts, mirror the bundles and point this
+# at the directory that holds them, e.g. https://your-domain.com/fonts
+FONT_BASE_URL=

--- a/docker/README.md
+++ b/docker/README.md
@@ -86,6 +86,30 @@ docker compose -f compose.yaml -f compose.build.yaml up --build -d
 - Readest app: `http://localhost:3000`
 - MinIO console: `http://localhost:9001` (login with `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD`)
 
+### Upgrading an existing deployment
+
+pulling a newer client image does not touch the database volume, and the first-boot
+hook only runs when that volume is empty. so after an upgrade, apply any new
+migrations yourself:
+
+```bash
+cd docker
+docker compose pull
+docker compose up -d
+docker compose exec db /docker-entrypoint-initdb.d/zz-readest-migrations.sh
+```
+
+the script records what it applied in `readest_meta.migrations` and skips those
+next time, so it is safe to repeat after every upgrade.
+
+if you had previously patched your database by hand, the script may stop on an
+`already exists` error. record that file as applied and run it again:
+
+```bash
+docker compose exec db psql -U supabase_admin -c \
+  "INSERT INTO readest_meta.migrations (name) VALUES ('002_add_book_shares.sql') ON CONFLICT DO NOTHING"
+```
+
 ### Hot Reload (development)
 
 > **Prerequisites**: submodules must be initialized (see above).
@@ -112,6 +136,67 @@ to also remove volumes (database and storage data):
 cd docker
 docker compose down -v
 ```
+
+---
+
+## Database schema
+
+| path                          | role                                                                       |
+| ----------------------------- | -------------------------------------------------------------------------- |
+| `volumes/db/init/schema.sql`  | base schema (books, book_configs, book_notes, files)                         |
+| `volumes/db/migrations/*.sql` | every schema change since, applied in filename order                         |
+| `volumes/db/apply-migrations.sh` | applies the migrations and records them in `readest_meta.migrations`      |
+
+on an empty database volume the supabase image runs everything under
+`/docker-entrypoint-initdb.d` in glob order: its own `migrate.sh` (supabase core
+schema plus `init-scripts/100-schema.sql`, which is `schema.sql`), then
+`zz-readest-migrations.sh`, which is `apply-migrations.sh`. it globs the mounted
+migrations directory, so adding a migration file needs no compose change.
+
+---
+
+## Serving from a custom domain
+
+the browser talks to three of these services directly, so each needs a URL that
+resolves from outside the docker network:
+
+| variable              | what the browser uses it for                                   |
+| --------------------- | -------------------------------------------------------------- |
+| `SITE_URL`            | the readest client itself                                        |
+| `SUPABASE_PUBLIC_URL` | kong, which routes `/auth/v1/…` and `/rest/v1/…`                 |
+| `S3_PUBLIC_ENDPOINT`  | minio, reached through path-style presigned URLs                 |
+
+`SUPABASE_PUBLIC_URL` and `S3_PUBLIC_ENDPOINT` default to `http://${HOST_IP}:<port>`,
+which suits a plain IP/port deployment; set them in `docker/.env` to override that.
+putting everything on one origin also means no cross-origin requests at all:
+
+```env
+HOST_IP=your-domain.com
+SITE_URL=https://your-domain.com
+API_EXTERNAL_URL=https://your-domain.com
+ADDITIONAL_REDIRECT_URLS=https://your-domain.com/**
+SUPABASE_PUBLIC_URL=https://your-domain.com
+S3_PUBLIC_ENDPOINT=https://your-domain.com
+```
+
+if a proxy sits in front, forward the `Host` header unchanged to minio or the
+presigned signatures will not match, and lift the request body size limit so book
+uploads are not truncated.
+
+### CJK fonts on a custom domain
+
+the reader loads a few CJK webfont bundles from Readest's CDN, which only sends
+`Access-Control-Allow-Origin` for readest.com origins, so the browser blocks them
+on a self-hosted domain. mirror
+`https://storage.readest.com/public/font/dist/<Family>/` (and the `.woff2` files it
+references) onto a path your proxy serves, then point the client at it:
+
+```env
+FONT_BASE_URL=https://your-domain.com/fonts
+```
+
+leaving `FONT_BASE_URL` empty keeps the default CDN. system and Google fonts are
+unaffected either way.
 
 ---
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -179,9 +179,11 @@ SUPABASE_PUBLIC_URL=https://your-domain.com
 S3_PUBLIC_ENDPOINT=https://your-domain.com
 ```
 
-if a proxy sits in front, forward the `Host` header unchanged to minio or the
-presigned signatures will not match, and lift the request body size limit so book
-uploads are not truncated.
+`nginx.conf.example` is a working starting point for terminating TLS in front of
+the stack. two things it gets right that are easy to miss: the `Host` header has
+to reach minio unchanged or the presigned signatures will not verify, and the
+request body limit has to be lifted on the bucket location or large book uploads
+are truncated.
 
 ### CJK fonts on a custom domain
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -9,6 +9,12 @@ services:
       - ./volumes/db/roles.sql:/docker-entrypoint-initdb.d/init-scripts/99-roles.sql:Z
       - ./volumes/db/jwt.sql:/docker-entrypoint-initdb.d/init-scripts/99-jwt.sql:Z
       - ./volumes/db/init/schema.sql:/docker-entrypoint-initdb.d/init-scripts/100-schema.sql:Z
+      # Incremental migrations on top of the base schema above. The hook name
+      # sorts after the image's own migrate.sh, so it runs once the Supabase
+      # core schema and 100-schema.sql exist. It globs the mounted directory,
+      # so a new migration file needs no compose edit (#5550).
+      - ./volumes/db/migrations:/readest-migrations:Z
+      - ./volumes/db/apply-migrations.sh:/docker-entrypoint-initdb.d/zz-readest-migrations.sh:Z
       - db-data:/var/lib/postgresql/data:Z
       - db-config:/etc/postgresql-custom
     environment:
@@ -126,12 +132,15 @@ services:
       - "3000:3000"
     environment:
       SUPABASE_URL: http://kong:8000
-      SUPABASE_PUBLIC_URL: http://${HOST_IP}:${KONG_HTTP_PORT:-8000}
+      # Browser-facing URLs. The HOST_IP defaults suit a plain IP/port
+      # deployment; behind an HTTPS reverse proxy, set them in .env to the
+      # single public origin (see README).
+      SUPABASE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL:-http://${HOST_IP}:${KONG_HTTP_PORT:-8000}}
       SUPABASE_ANON_KEY: ${ANON_KEY}
       SUPABASE_ADMIN_KEY: ${SERVICE_ROLE_KEY}
       API_BASE_URL: ${SITE_URL}
       S3_ENDPOINT: http://minio:9000
-      S3_PUBLIC_ENDPOINT: http://${HOST_IP}:9000
+      S3_PUBLIC_ENDPOINT: ${S3_PUBLIC_ENDPOINT:-http://${HOST_IP}:9000}
       S3_REGION: us-east-1
       S3_BUCKET_NAME: ${S3_BUCKET_NAME}
       S3_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
@@ -139,6 +148,7 @@ services:
       OBJECT_STORAGE_TYPE: ${OBJECT_STORAGE_TYPE:-s3}
       STORAGE_FIXED_QUOTA: ${STORAGE_FIXED_QUOTA:-1073741824}
       TRANSLATION_FIXED_QUOTA: ${TRANSLATION_FIXED_QUOTA:-50000}
+      FONT_BASE_URL: ${FONT_BASE_URL:-}
     depends_on:
       - kong
       - minio

--- a/docker/nginx.conf.example
+++ b/docker/nginx.conf.example
@@ -1,0 +1,64 @@
+# Example nginx site config for serving the compose stack from one HTTPS origin.
+#
+# Copy to your nginx sites directory, replace your-domain.com and the certificate
+# paths, then set the matching values in docker/.env (see README).
+#
+# Everything lives on a single origin, so the browser never makes a cross-origin
+# request and none of the CORS configuration below the proxy has to change.
+# The upstream ports are the compose defaults; consider binding them to loopback
+# (127.0.0.1:3000:3000 and so on) so only nginx can reach them.
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name your-domain.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    # nginx < 1.25.1 wants `listen 443 ssl http2;` above instead of this line.
+    http2 on;
+    server_name your-domain.com;
+
+    ssl_certificate     /etc/letsencrypt/live/your-domain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/your-domain.com/privkey.pem;
+
+    # Readest web client. Only small JSON bodies pass through here: book uploads
+    # go straight to MinIO with a presigned URL, not through this location.
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Supabase through kong. supabase-js appends /auth/v1 and /rest/v1 to
+    # SUPABASE_PUBLIC_URL, and kong declares routes on exactly those prefixes.
+    location ~ ^/(auth|rest)/v1/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # MinIO. The presigned URLs are path-style, so the bucket name is the first
+    # path segment: this must match S3_BUCKET_NAME. Host has to be forwarded
+    # unchanged or the presigned signature will not verify, and the body limit
+    # has to be lifted or large books are truncated on upload.
+    location /readest-files/ {
+        proxy_pass http://127.0.0.1:9000;
+        proxy_set_header Host $host;
+        client_max_body_size 0;
+        proxy_request_buffering off;
+    }
+
+    # Optional: serve mirrored CJK webfont bundles yourself and point the client
+    # at them with FONT_BASE_URL=https://your-domain.com/fonts (see README).
+    # location /fonts/ {
+    #     alias /srv/readest-fonts/;
+    # }
+}

--- a/docker/volumes/db/apply-migrations.sh
+++ b/docker/volumes/db/apply-migrations.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Applies Readest's incremental schema migrations (volumes/db/migrations).
+#
+# `volumes/db/init/schema.sql` is only the base schema; every schema change
+# since then ships as a numbered file under `migrations/`, and nothing applied
+# them to a self-hosted database. Fresh deployments therefore came up without
+# `files.replica_id`, the `replicas` table or the `claim_inbox_item` RPC, so
+# uploads, replica sync and Send to Readest all failed (issue #5550).
+#
+# The supabase/postgres image runs `/docker-entrypoint-initdb.d/*` in glob order
+# on first boot. This script is mounted there as `zz-readest-migrations.sh`,
+# which sorts after the image's own `migrate.sh` — by the time it runs, the
+# Supabase core schema and `init-scripts/100-schema.sql` are in place.
+#
+# Applied files are recorded in `readest_meta.migrations`, so it is also safe to
+# run by hand after pulling a newer image (see docker/README.md):
+#
+#   docker compose exec db /docker-entrypoint-initdb.d/zz-readest-migrations.sh
+
+set -e
+
+export PGDATABASE="${POSTGRES_DB:-postgres}"
+export PGHOST="${POSTGRES_HOST:-localhost}"
+export PGPORT="${POSTGRES_PORT:-5432}"
+export PGPASSWORD="${POSTGRES_PASSWORD:-}"
+
+# Run as supabase_admin, like the image's own migrations pass: `postgres` is
+# demoted from superuser during first boot, and supabase_admin's default
+# privileges already grant anon/authenticated/service_role on new public tables.
+psql_admin() {
+  psql -v ON_ERROR_STOP=1 --no-password --no-psqlrc -U supabase_admin "$@"
+}
+
+# The ledger lives outside `public` on purpose: PostgREST exposes `public`, and
+# the default privileges there would hand anon full access to the table.
+psql_admin -c "CREATE SCHEMA IF NOT EXISTS readest_meta"
+psql_admin -c "CREATE TABLE IF NOT EXISTS readest_meta.migrations (
+  name text PRIMARY KEY,
+  applied_at timestamp with time zone NOT NULL DEFAULT now()
+)"
+
+for sql in /readest-migrations/*.sql; do
+  [ -f "$sql" ] || continue
+  name="$(basename "$sql")"
+  if [ -n "$(psql_admin -tAc "SELECT 1 FROM readest_meta.migrations WHERE name = '$name'")" ]; then
+    echo "readest-migrations: $name already applied, skipping"
+    continue
+  fi
+  echo "readest-migrations: applying $name"
+  psql_admin -f "$sql"
+  psql_admin -c "INSERT INTO readest_meta.migrations (name) VALUES ('$name')"
+done


### PR DESCRIPTION
Fixes #5550

## Missing schema on a fresh self-hosted stack

The reported errors (`Could not find the 'replica_id' column of 'files'`, `Could not find the function public.claim_inbox_item`) are not gaps in `schema.sql`. `compose.yaml` only ever mounted `volumes/db/init/schema.sql`, so none of the 18 files in `volumes/db/migrations/` reached the database. A fresh deployment therefore came up without `files.replica_id` / `replica_kind` (007), `public.replicas` (003), `claim_inbox_item` (012), `book_shares` (002) or the reading stats tables (014).

Rather than fold the migrations into `schema.sql` by hand (the process that drifted in the first place), the migrations directory is now mounted into the db container alongside `volumes/db/apply-migrations.sh`. The hook globs the mount, so a new migration file needs no compose change.

Two constraints shaped this, both checked against upstream sources:

- The `supabase/postgres` image does `COPY migrations/db /docker-entrypoint-initdb.d/`, so it already owns `init-scripts/` and `migrations/` inside that path. Bind-mounting either as a directory would shadow the Supabase core schema and the database would come up with no `auth` schema. docker-library's entrypoint runs `/docker-entrypoint-initdb.d/*` in glob order and skips directories, so a `zz-` prefixed `.sh` sorting after the image's own `migrate.sh` is the only safe directory-level hook.
- It connects as `supabase_admin`. Migration 003 has no explicit `GRANT` for `replicas`; it relies on `alter default privileges`, which Supabase's initial schema configures for `postgres` and `supabase_admin` only, so a table created by any other role would be invisible to PostgREST. `postgres` is also demoted from superuser during first boot.

Applied files are recorded in `readest_meta.migrations`, deliberately outside `public` so PostgREST does not expose it. That makes the script re-runnable, which existing deployments need since the initdb hook only fires on an empty volume:

```bash
docker compose exec db /docker-entrypoint-initdb.d/zz-readest-migrations.sh
```

Note: no Readest migration defines `device_id`. That column only appears in the KOReader sync client, so the third error in the report looks unrelated to the schema.

## Font CDN CORS

`src/styles/fonts.ts` hardcoded `storage.readest.com/public/font/dist`, which only answers CORS for readest.com origins. The base URL now comes from runtime config (`FONT_BASE_URL`, with the CDN as the default), following the same path as the other container-configurable values through `runtimeConfig.ts` and `/runtime-config.js`.

## Custom domain

`SUPABASE_PUBLIC_URL` and `S3_PUBLIC_ENDPOINT` can now be set directly instead of only being derived from `HOST_IP`, so the stack can be served from a single HTTPS origin. `docker/nginx.conf.example` is a starting point for that; book uploads go straight to MinIO with a presigned URL, so the `Host` header has to reach it unchanged and the body limit has to be lifted on the bucket location.

## Verification

`pnpm test` (8829 passing), `pnpm lint` and `pnpm format:check` are green. `src/__tests__/docker/db-bootstrap-migrations.test.ts` guards the wiring: that the migrations directory is mounted, that the hook sorts after `migrate.sh`, that it applies files by glob, and that a first boot creates the objects the client needs.

Not verified: the migrations have not been executed against a live Postgres, and the nginx config has not been through `nginx -t`. Both are reasoned from the upstream `migrate.sh`, `Dockerfile-15`, `00000000000000-initial-schema.sql` and the pinned docker-library entrypoint, plus this repo's `kong.yml` and `utils/s3.ts`, but a real `docker compose up -d` on a clean volume is worth doing before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)