### PR TITLE
fix(translate): restore Azure Translator, keep paragraph layout, preserve inline formatting

### DIFF
--- a/apps/readest-app/src/__tests__/app/api/azure-translate.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/azure-translate.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const validateUserAndTokenMock = vi.hoisted(() => vi.fn());
+vi.mock('@/utils/access', () => ({
+  validateUserAndToken: (...args: unknown[]) => validateUserAndTokenMock(...args),
+}));
+
+import { POST } from '@/app/api/azure-translate/route';
+
+const BING_PAGE = `
+  <html><script>var IG:"01CE353230DE4BFD8A44466FDD91401A";</script>
+  <div data-iid="translator.5025"></div>
+  <script>var params_AbusePreventionHelper = [1786092445798,"page-token",3600000];</script>
+  </html>
+`;
+
+const makeReq = (
+  query = 'endpoint=translate',
+  init: {
+    body?: string;
+    origin?: string | null;
+    contentLength?: string | null;
+    authorization?: string;
+  } = {},
+) => {
+  const body = init.body ?? 'text=Hello&to=fr';
+  const headers: Record<string, string> = {
+    authorization: init.authorization ?? 'Bearer test-token',
+  };
+  if (init.origin !== null) headers['origin'] = init.origin ?? 'https://web.readest.com';
+  if (init.contentLength !== null) {
+    headers['content-length'] = init.contentLength ?? String(new TextEncoder().encode(body).length);
+  }
+  return new NextRequest(`https://web.readest.com/api/azure-translate?${query}`, {
+    method: 'POST',
+    body,
+    headers,
+  });
+};
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  validateUserAndTokenMock.mockReset().mockImplementation(async (authorization: string | null) => ({
+    user: authorization ? { id: authorization } : null,
+    token: authorization,
+  }));
+  fetchSpy = vi.fn().mockResolvedValue(
+    new Response('[{"translations":[{"text":"Bonjour"}]}]', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('azure-translate proxy route', () => {
+  it('returns 403 before reading the body or fetching when unauthenticated', async () => {
+    validateUserAndTokenMock.mockResolvedValue({ user: null, token: null });
+    const request = makeReq();
+    const textSpy = vi.spyOn(request, 'text');
+
+    const res = await POST(request);
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Not authenticated' });
+    expect(textSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an unknown endpoint without fetching', async () => {
+    const res = await POST(makeReq('endpoint=evil'));
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('never lets a caller redirect the upstream fetch elsewhere', async () => {
+    // `endpoint` is matched against a fixed allowlist rather than used as a
+    // URL, so a caller cannot point the proxy at an arbitrary host.
+    const res = await POST(makeReq('endpoint=https://evil.example.com'));
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('parses the translator page server-side and returns only the auth params', async () => {
+    fetchSpy.mockResolvedValue(new Response(BING_PAGE, { status: 200 }));
+
+    const res = await POST(makeReq('endpoint=auth'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ig).toBe('01CE353230DE4BFD8A44466FDD91401A');
+    expect(body.iid).toBe('translator.5025');
+    expect(body.key).toBe('1786092445798');
+    expect(body.token).toBe('page-token');
+    expect(typeof body.expiresAt).toBe('number');
+    // The 650KB page itself must never reach the browser.
+    expect(JSON.stringify(body)).not.toContain('params_AbusePreventionHelper');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe('https://www.bing.com/translator');
+  });
+
+  it('returns 502 when the translator page can no longer be parsed', async () => {
+    fetchSpy.mockResolvedValue(new Response('<html>redesigned</html>', { status: 200 }));
+    const res = await POST(makeReq('endpoint=auth'));
+    expect(res.status).toBe(502);
+  });
+
+  it('forwards translate requests to ttranslatev3 with the telemetry query', async () => {
+    const res = await POST(makeReq('endpoint=translate&isVertical=1&IG=IG1&IID=translator.5025'));
+
+    expect(res.status).toBe(200);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toContain('https://www.bing.com/ttranslatev3');
+    expect(String(url)).toContain('IG=IG1');
+    expect(String(url)).toContain('IID=translator.5025');
+    expect(String(url)).not.toContain('endpoint=');
+    // Bing rejects the call without a browser Referer.
+    expect((init as RequestInit).headers).toMatchObject({
+      Referer: 'https://www.bing.com/translator',
+    });
+    expect((init as RequestInit).body).toBe('text=Hello&to=fr');
+  });
+
+  it('rejects cross-origin requests without fetching', async () => {
+    const res = await POST(makeReq('endpoint=translate', { origin: 'https://evil.example.com' }));
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests without an Origin header', async () => {
+    const res = await POST(makeReq('endpoint=translate', { origin: null }));
+    expect(res.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects oversized bodies without fetching', async () => {
+    const res = await POST(
+      makeReq('endpoint=translate', { contentLength: String(100_000 * 3 + 1) }),
+    );
+    expect(res.status).toBe(413);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('passes through the upstream status code and body', async () => {
+    fetchSpy.mockResolvedValue(
+      new Response('{"statusCode":205,"errorMessage":""}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const res = await POST(makeReq('endpoint=translate'));
+    expect(res.status).toBe(200);
+    // The 205-in-a-200 signal must survive the hop so the client re-authenticates.
+    expect(await res.json()).toEqual({ statusCode: 205, errorMessage: '' });
+  });
+
+  it('returns 502 when the upstream is unreachable', async () => {
+    fetchSpy.mockRejectedValue(new Error('network down'));
+    const res = await POST(makeReq('endpoint=translate'));
+    expect(res.status).toBe(502);
+  });
+
+  it('rejects concurrent requests beyond the limit', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    fetchSpy.mockImplementation(async () => {
+      await gate;
+      return new Response('[]', { status: 200 });
+    });
+
+    const inflight = [
+      POST(makeReq('endpoint=translate')),
+      POST(makeReq('endpoint=translate')),
+      POST(makeReq('endpoint=translate')),
+    ];
+    // Let the three in-flight requests occupy every slot before the fourth.
+    await Promise.resolve();
+    const rejected = await POST(makeReq('endpoint=translate'));
+    expect(rejected.status).toBe(429);
+
+    release();
+    await Promise.all(inflight);
+  });
+
+  it('sets an upstream timeout', async () => {
+    await POST(makeReq('endpoint=translate'));
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextTranslation.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextTranslation.test.ts
@@ -39,7 +39,7 @@ describe('createTranslationTargetNode', () => {
     expect(wrapper.getAttribute('dir')).toBe('auto');
   });
 
-  it('builds the expected nested structure with the translated text', () => {
+  it('builds a single flat wrapper carrying the translated text', () => {
     const wrapper = createTranslationTargetNode({
       translatedText: 'مرحبا بالعالم',
       lang: 'ar',
@@ -49,11 +49,43 @@ describe('createTranslationTargetNode', () => {
     });
 
     expect(wrapper.classList.contains('translation-target')).toBe(true);
+    expect(wrapper.classList.contains('translation-target-toc')).toBe(true);
     expect(wrapper.getAttribute('translation-element-mark')).toBe('1');
-    const block = wrapper.querySelector('.translation-target-toc');
-    expect(block).not.toBeNull();
-    const inner = wrapper.querySelector('.target-inner');
-    expect(inner?.textContent).toBe('مرحبا بالعالم');
+    expect(wrapper.textContent).toBe('مرحبا بالعالم');
+    // Flattened from three nested <font>s: the CFI path into translated text
+    // is two levels shallower, and no element nests inside the wrapper.
+    expect(wrapper.children.length).toBe(0);
+  });
+
+  it('is a <font>, the one tag book CSS never styles and layout tolerates', () => {
+    const wrapper = createTranslationTargetNode({
+      translatedText: 'hi',
+      lang: 'en',
+      targetBlockClassName: 'translation-target-block',
+      hidden: false,
+      widthLineBreak: false,
+    });
+    expect(wrapper.tagName).toBe('FONT');
+  });
+
+  it('carries sanitized inline markup when given a content fragment', () => {
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(document.createTextNode('那只'));
+    const bold = document.createElement('b');
+    bold.textContent = '敏捷';
+    fragment.appendChild(bold);
+    fragment.appendChild(document.createTextNode('的狐狸'));
+
+    const wrapper = createTranslationTargetNode({
+      content: fragment,
+      lang: 'zh',
+      targetBlockClassName: 'translation-target-block',
+      hidden: false,
+      widthLineBreak: false,
+    });
+
+    expect(wrapper.textContent).toBe('那只敏捷的狐狸');
+    expect(wrapper.querySelector('b')?.textContent).toBe('敏捷');
   });
 
   it('marks the wrapper hidden when hidden is true', () => {

--- a/apps/readest-app/src/__tests__/app/reader/translation-markup.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/translation-markup.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractSourcePayload,
+  sanitizeTranslatedMarkup,
+  splitMarkupIntoChunks,
+} from '@/app/reader/utils/translationMarkup';
+import { splitTextIntoChunks } from '@/services/translators/utils';
+
+const el = (html: string): HTMLElement => {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div;
+};
+
+const html = (fragment: DocumentFragment | null) => {
+  if (!fragment) return null;
+  const host = document.createElement('div');
+  host.appendChild(fragment);
+  return host.innerHTML;
+};
+
+describe('extractSourcePayload', () => {
+  it('reports plain text as having no markup', () => {
+    const payload = extractSourcePayload(el('Veganism is growing.'));
+    expect(payload.hasMarkup).toBe(false);
+    expect(payload.html).toBe('');
+    expect(payload.text).toBe('Veganism is growing.');
+  });
+
+  it('serializes inline markup and collects its attributes', () => {
+    const payload = extractSourcePayload(el('A <span class="whisper">hush</span> fell.'));
+    expect(payload.hasMarkup).toBe(true);
+    expect(payload.html).toBe('A <span class="whisper">hush</span> fell.');
+    expect(payload.allowedAttrs.has('span|class|whisper')).toBe(true);
+  });
+
+  it('never sends previously injected translation targets back to the translator', () => {
+    const source = el('Original text.');
+    const target = document.createElement('font');
+    target.className = 'translation-target';
+    target.textContent = '译文';
+    source.appendChild(target);
+
+    const payload = extractSourcePayload(source);
+    expect(payload.text).toBe('Original text.');
+    expect(payload.text).not.toContain('译文');
+  });
+
+  it('drops a11y skip links', () => {
+    const source = el('Real prose.<span cfi-inert="">Skip to next section</span>');
+    expect(extractSourcePayload(source).text).toBe('Real prose.');
+  });
+
+  it('keeps WordLens base text but drops the injected reading', () => {
+    const source = el('The <ruby class="wl-gloss">辞書<rt>じしょ</rt></ruby> is open.');
+    const payload = extractSourcePayload(source);
+    expect(payload.text).toBe('The 辞書 is open.');
+    expect(payload.text).not.toContain('じしょ');
+  });
+});
+
+describe('sanitizeTranslatedMarkup', () => {
+  const allow = (...keys: string[]) => new Set(keys);
+
+  it('keeps allowlisted inline tags', () => {
+    const out = sanitizeTranslatedMarkup('那只<b>敏捷</b>的狐狸', allow());
+    expect(html(out)).toBe('那只<b>敏捷</b>的狐狸');
+  });
+
+  it('unwraps disallowed tags but keeps their text', () => {
+    const out = sanitizeTranslatedMarkup('a<div>b</div><p>c</p>', allow());
+    expect(html(out)).toBe('abc');
+  });
+
+  it('drops script elements and their content is not executed as markup', () => {
+    const out = sanitizeTranslatedMarkup('safe<script>alert(1)</script>', allow());
+    expect(html(out)).not.toContain('<script');
+  });
+
+  it('drops event handlers, style and unexpected attributes', () => {
+    const out = sanitizeTranslatedMarkup(
+      '<span onclick="alert(1)" style="color:red" id="x">hi</span>',
+      allow(),
+    );
+    expect(html(out)).toBe('<span>hi</span>');
+  });
+
+  it('keeps an attribute only when the source echoed that exact value', () => {
+    const kept = sanitizeTranslatedMarkup(
+      '<span class="whisper">轻声</span>',
+      allow('span|class|whisper'),
+    );
+    expect(html(kept)).toBe('<span class="whisper">轻声</span>');
+
+    const dropped = sanitizeTranslatedMarkup(
+      '<span class="injected">轻声</span>',
+      allow('span|class|whisper'),
+    );
+    expect(html(dropped)).toBe('<span>轻声</span>');
+  });
+
+  it('refuses a javascript: href the source never contained', () => {
+    const out = sanitizeTranslatedMarkup(
+      '<a href="javascript:alert(1)">click</a>',
+      allow('a|href|#chapter2'),
+    );
+    expect(html(out)).toBe('<a>click</a>');
+  });
+
+  it('normalizes unbalanced tags rather than leaking them into the DOM', () => {
+    const out = sanitizeTranslatedMarkup('start <i>unclosed italic', allow());
+    expect(html(out)).toBe('start <i>unclosed italic</i>');
+  });
+
+  it('preserves nested inline markup', () => {
+    const out = sanitizeTranslatedMarkup('<b>粗<i>斜</i></b>', allow());
+    expect(html(out)).toBe('<b>粗<i>斜</i></b>');
+  });
+
+  it('returns null when nothing meaningful survives, so callers can fall back', () => {
+    expect(sanitizeTranslatedMarkup('', allow())).toBeNull();
+    expect(sanitizeTranslatedMarkup('<script>alert(1)</script>', allow())).toBeNull();
+  });
+
+  it('only emits tags the paragraph-layout rule tolerates', () => {
+    // A <sup> is allowlisted; a <div> is not and must be unwrapped, otherwise
+    // preserved markup would make the enclosing source div lose its layout.
+    const out = sanitizeTranslatedMarkup('x<sup>1</sup><div>y</div>', allow());
+    expect(html(out)).toBe('x<sup>1</sup>y');
+  });
+});
+
+describe('splitMarkupIntoChunks', () => {
+  const split = (html: string, max: number) =>
+    splitMarkupIntoChunks(html, max, splitTextIntoChunks);
+
+  /** Text of an HTML string, as the browser would render it. */
+  const textOf = (html: string) => {
+    const host = document.createElement('div');
+    host.innerHTML = html;
+    return host.textContent ?? '';
+  };
+
+  it('returns a single chunk when the markup already fits', () => {
+    const html = 'A <b>bold</b> claim.';
+    expect(split(html, 1000)).toEqual([html]);
+  });
+
+  it('keeps every chunk within the budget', () => {
+    const html = `Sentence one is here. <i>Emphasised middle part.</i> ` + 'Tail text. '.repeat(40);
+    const chunks = split(html, 200);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) expect(chunk.length).toBeLessThanOrEqual(200);
+  });
+
+  it('loses no text across the split', () => {
+    const html = `Intro text here. <i>${'italic words '.repeat(20)}</i>then <b>bold</b> tail.`;
+    const chunks = split(html, 150);
+    expect(chunks.join('').length).toBeGreaterThan(0);
+    expect(textOf(chunks.join(''))).toBe(textOf(html));
+  });
+
+  it('produces chunks that are each well-formed on their own', () => {
+    const html = `Start <i>${'long italic run '.repeat(20)}</i> end.`;
+    for (const chunk of split(html, 160)) {
+      const host = document.createElement('div');
+      host.innerHTML = chunk;
+      // Re-serializing a well-formed fragment is a fixed point.
+      expect(host.innerHTML).toBe(chunk);
+    }
+  });
+
+  it('re-opens formatting that straddles a boundary', () => {
+    const html = `<i>${'italic sentence here. '.repeat(15)}</i>`;
+    const chunks = split(html, 120);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Every chunk carries its own <i>, so nothing renders unformatted.
+    for (const chunk of chunks) expect(chunk.startsWith('<i>')).toBe(true);
+    expect(textOf(chunks.join(''))).toBe(textOf(html));
+  });
+
+  it('preserves attributes on every chunk of a split run', () => {
+    const html = `<span class="whisper">${'quiet words here. '.repeat(15)}</span>`;
+    const chunks = split(html, 130);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) expect(chunk).toContain('class="whisper"');
+  });
+
+  it('escapes markup-significant characters in text', () => {
+    const chunks = split('5 &lt; 6 &amp; 7 &gt; 6', 1000);
+    expect(textOf(chunks.join(''))).toBe('5 < 6 & 7 > 6');
+  });
+
+  it('unwraps disallowed tags rather than emitting them', () => {
+    const chunks = split('a<div>b</div>c', 1000);
+    expect(chunks.join('')).toBe('abc');
+  });
+
+  it('gives up when a single tag’s overhead cannot fit, so callers fall back', () => {
+    expect(split('<span class="a-very-long-class-name-here">x</span>', 10)).toEqual([]);
+  });
+
+  it('handles nested formatting without unbalancing it', () => {
+    const html = `<b>bold ${'and '.repeat(30)}<i>then italic</i></b>`;
+    const chunks = split(html, 140);
+    expect(textOf(chunks.join(''))).toBe(textOf(html));
+    for (const chunk of chunks) {
+      const host = document.createElement('div');
+      host.innerHTML = chunk;
+      expect(host.innerHTML).toBe(chunk);
+    }
+  });
+});

--- a/apps/readest-app/src/__tests__/services/translators/providers.test.ts
+++ b/apps/readest-app/src/__tests__/services/translators/providers.test.ts
@@ -546,15 +546,53 @@ describe('yandexProvider', () => {
 // ---------------------------------------------------------------------------
 // Azure Translator Provider
 // ---------------------------------------------------------------------------
+describe('parseBingAuthParams', () => {
+  it('extracts the auth material from the translator page', async () => {
+    const { parseBingAuthParams } = await import('@/services/translators/providers/azureShared');
+    const params = parseBingAuthParams(BING_PAGE, 1_000_000);
+    expect(params.ig).toBe('01CE353230DE4BFD8A44466FDD91401A');
+    expect(params.iid).toBe('translator.5025');
+    expect(params.key).toBe('1786092445798');
+    expect(params.token).toBe('page-token');
+    // one hour TTL less the 60s safety margin
+    expect(params.expiresAt).toBe(1_000_000 + 3_600_000 - 60_000);
+  });
+
+  it('stamps expiry against the supplied clock, not the page timestamp', async () => {
+    const { parseBingAuthParams } = await import('@/services/translators/providers/azureShared');
+    // The page's own `key` timestamp is far in the past; a skewed client must
+    // still get an expiry relative to when it actually fetched the page.
+    expect(parseBingAuthParams(BING_PAGE, 5_000).expiresAt).toBe(5_000 + 3_600_000 - 60_000);
+  });
+
+  it('throws when the page markup no longer carries the auth params', async () => {
+    const { parseBingAuthParams } = await import('@/services/translators/providers/azureShared');
+    expect(() => parseBingAuthParams('<html>nothing here</html>', 0)).toThrow(
+      'could not parse the translator page',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Azure Translator Provider (backed by the Bing Translator web API)
+// ---------------------------------------------------------------------------
+const BING_PAGE = `
+  <html><script>var IG:"01CE353230DE4BFD8A44466FDD91401A";</script>
+  <div data-iid="translator.5025"></div>
+  <script>var params_AbusePreventionHelper = [1786092445798,"page-token",3600000];</script>
+  </html>
+`;
+
 describe('azureProvider', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    vi.mocked(tauriFetch).mockReset();
     // The yandex suite above flips the platform mock to Tauri; azure uses
     // window.fetch off Tauri, so restore the default for these tests
     vi.mocked(isTauriAppPlatform).mockReturnValue(false);
-    // Suppress expected error noise from token fetch failure tests.
+    // Suppress expected error noise from auth failure tests.
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    // Reset the module-level token cache between tests by re-importing
+    // Reset the module-level auth cache between tests by re-importing
     vi.resetModules();
   });
 
@@ -562,17 +600,27 @@ describe('azureProvider', () => {
     vi.restoreAllMocks();
   });
 
-  /** Helper: mock fetch to handle token + translation in sequence */
-  function mockTokenAndTranslation(translationResponse: unknown) {
+  const translationBody = (text: string) => ({
+    ok: true,
+    status: 200,
+    json: async () => [{ translations: [{ text }] }],
+  });
+
+  /** Web path: proxy returns parsed auth params as JSON, then a translation. */
+  function mockProxyAuthAndTranslation(text: string) {
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
-        text: async () => 'mock-token',
+        status: 200,
+        json: async () => ({
+          ig: 'IG1',
+          iid: 'translator.5025',
+          key: '1786092445798',
+          token: 'proxy-token',
+          expiresAt: Date.now() + 3_600_000,
+        }),
       })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => translationResponse,
-      });
+      .mockResolvedValueOnce(translationBody(text));
   }
 
   it('returns empty array for empty input', async () => {
@@ -582,58 +630,274 @@ describe('azureProvider', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('translates text with token authentication', async () => {
-    mockTokenAndTranslation([{ translations: [{ text: 'Bonjour' }] }]);
+  it('translates text through the same-origin proxy in web builds', async () => {
+    mockProxyAuthAndTranslation('Bonjour');
+
+    const { azureProvider } = await import('@/services/translators/providers/azure');
+    const result = await azureProvider.translate(['Hello'], 'en', 'fr', 'user-token');
+    expect(result).toEqual(['Bonjour']);
+
+    const urls = mockFetch.mock.calls.map((call) => String(call[0]));
+    expect(urls[0]).toContain('/api/azure-translate?endpoint=auth');
+    expect(urls[1]).toContain('/api/azure-translate?endpoint=translate');
+    // The browser must never be asked to fetch bing.com directly — it has no
+    // CORS headers, so such a request would be blocked.
+    expect(urls.some((url) => url.includes('bing.com'))).toBe(false);
+  });
+
+  it('requires authentication only in web builds', async () => {
+    const { azureProvider } = await import('@/services/translators/providers/azure');
+    expect(azureProvider.authRequired).toBe(true);
+
+    vi.mocked(isTauriAppPlatform).mockReturnValue(true);
+    expect(azureProvider.authRequired).toBe(false);
+  });
+
+  it('splits texts over the 1000 character limit and rejoins them', async () => {
+    // Bing answers `statusCode: 400` above 1000 characters, so a long
+    // paragraph must go out in chunks rather than fail outright.
+    const sentTexts: string[] = [];
+    mockFetch.mockImplementation(async (url: string, init: RequestInit) => {
+      if (String(url).includes('endpoint=auth')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ig: 'IG1',
+            iid: 'translator.5025',
+            key: '1',
+            token: 't',
+            expiresAt: Date.now() + 3_600_000,
+          }),
+        };
+      }
+      const text = new URLSearchParams(init.body as string).get('text')!;
+      sentTexts.push(text);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [{ translations: [{ text: `<${text}>` }] }],
+      };
+    });
+
+    const sentence = 'The quick brown fox jumps over the lazy dog. ';
+    const long = sentence.repeat(60); // ~2640 chars
+    const { azureProvider } = await import('@/services/translators/providers/azure');
+    const [result] = await azureProvider.translate([long], 'en', 'fr', 'user-token');
+
+    expect(sentTexts.length).toBeGreaterThan(1);
+    expect(sentTexts.every((text) => text.length <= 1000)).toBe(true);
+    // Nothing may be dropped or reordered when the pieces are stitched back.
+    expect(sentTexts.join('')).toBe(long);
+    expect(result).toBe(sentTexts.map((text) => `<${text}>`).join(''));
+  });
+
+  it('never exceeds the concurrency the proxy allows', async () => {
+    // Bing translates one text per request, so an unbounded fan-out over a
+    // page of paragraphs gets the surplus rejected with 429 by the proxy.
+    let inFlight = 0;
+    let peakInFlight = 0;
+    mockFetch.mockImplementation(async (url: string) => {
+      inFlight++;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight--;
+      return String(url).includes('endpoint=auth')
+        ? {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              ig: 'IG1',
+              iid: 'translator.5025',
+              key: '1',
+              token: 't',
+              expiresAt: Date.now() + 3_600_000,
+            }),
+          }
+        : translationBody('translated');
+    });
+
+    const { azureProvider } = await import('@/services/translators/providers/azure');
+    const lines = Array.from({ length: 24 }, (_, index) => `line ${index}`);
+    const result = await azureProvider.translate(lines, 'en', 'fr', 'user-token');
+
+    expect(result).toHaveLength(24);
+    expect(result.every((line) => line === 'translated')).toBe(true);
+    expect(peakInFlight).toBeLessThanOrEqual(3);
+    // All 24 lines still go out — the cap throttles, it must not drop work.
+    const translateCalls = mockFetch.mock.calls.filter((call) =>
+      String(call[0]).includes('endpoint=translate'),
+    );
+    expect(translateCalls).toHaveLength(24);
+  });
+
+  it('rejects in web builds when there is no user token', async () => {
+    const { azureProvider } = await import('@/services/translators/providers/azure');
+    await expect(azureProvider.translate(['Hello'], 'en', 'fr')).rejects.toThrow(
+      'azure translate requires authentication in web builds',
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('scrapes bing directly on Tauri, bypassing the proxy', async () => {
+    vi.mocked(isTauriAppPlatform).mockReturnValue(true);
+    vi.mocked(tauriFetch)
+      .mockResolvedValueOnce({ ok: true, status: 200, text: async () => BING_PAGE } as Response)
+      .mockResolvedValueOnce(translationBody('Bonjour') as unknown as Response);
 
     const { azureProvider } = await import('@/services/translators/providers/azure');
     const result = await azureProvider.translate(['Hello'], 'en', 'fr');
     expect(result).toEqual(['Bonjour']);
+
+    const urls = vi.mocked(tauriFetch).mock.calls.map((call) => String(call[0]));
+    expect(urls[0]).toBe('https://www.bing.com/translator');
+    expect(urls[1]).toContain('https://www.bing.com/ttranslatev3');
+    // IG/IID are mandatory — the endpoint answers statusCode 400 without them.
+    expect(urls[1]).toContain('IG=01CE353230DE4BFD8A44466FDD91401A');
+    expect(urls[1]).toContain('IID=translator.5025');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('reuses cached auth params across calls', async () => {
+    mockProxyAuthAndTranslation('Bonjour');
+    mockFetch.mockResolvedValueOnce(translationBody('Monde'));
+
+    const { azureProvider } = await import('@/services/translators/providers/azure');
+    await azureProvider.translate(['Hello'], 'en', 'fr', 'user-token');
+    await azureProvider.translate(['World'], 'en', 'fr', 'user-token');
+
+    const authCalls = mockFetch.mock.calls.filter((call) =>
+      String(call[0]).includes('endpoint=auth'),
+    );
+    expect(authCalls).toHaveLength(1);
+  });
+
+  it('re-authenticates once when the token is rejected with statusCode 205', async () => {
+    // Bing signals an expired token inside an HTTP 200 body, so a plain
+    // response.ok check would silently return no translation.
+    mockProxyAuthAndTranslation('unused');
+    mockFetch.mockReset();
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ig: 'IG1',
+          iid: 'translator.5025',
+          key: '1',
+          token: 'stale',
+          expiresAt: Date.now() + 3_600_000,
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ statusCode: 205 }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ig: 'IG1',
+          iid: 'translator.5025',
+          key: '2',
+          token: 'fresh',
+          expiresAt: Date.now() + 3_600_000,
+        }),
+      })
+      .mockResolvedValueOnce(translationBody('Bonjour'));
+
+    const { azureProvider } = await import('@/services/translators/providers/azure');
+    const result = await azureProvider.translate(['Hello'], 'en', 'fr', 'user-token');
+    expect(result).toEqual(['Bonjour']);
+
+    const authCalls = mockFetch.mock.calls.filter((call) =>
+      String(call[0]).includes('endpoint=auth'),
+    );
+    expect(authCalls).toHaveLength(2);
+  });
+
+  it('throws rather than looping when re-authentication still fails', async () => {
+    const authResponse = {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ig: 'IG1',
+        iid: 'translator.5025',
+        key: '1',
+        token: 'stale',
+        expiresAt: Date.now() + 3_600_000,
+      }),
+    };
+    const rejected = { ok: true, status: 200, json: async () => ({ statusCode: 205 }) };
+    mockFetch
+      .mockResolvedValueOnce(authResponse)
+      .mockResolvedValueOnce(rejected)
+      .mockResolvedValueOnce(authResponse)
+      .mockResolvedValueOnce(rejected);
+
+    const { azureProvider } = await import('@/services/translators/providers/azure');
+    await expect(azureProvider.translate(['Hello'], 'en', 'fr', 'user-token')).rejects.toThrow(
+      'bing translate failed with status 205',
+    );
   });
 
   it('preserves empty strings', async () => {
-    mockTokenAndTranslation([{ translations: [{ text: 'Monde' }] }]);
+    mockProxyAuthAndTranslation('Monde');
 
     const { azureProvider } = await import('@/services/translators/providers/azure');
-    const result = await azureProvider.translate(['', 'World'], 'en', 'fr');
+    const result = await azureProvider.translate(['', 'World'], 'en', 'fr', 'user-token');
     expect(result[0]).toBe('');
     expect(result[1]).toBe('Monde');
   });
 
-  it('throws when token fetch fails', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 403,
-    });
+  it('throws when the auth request fails', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 403, json: async () => ({}) });
 
     const { azureProvider } = await import('@/services/translators/providers/azure');
-    await expect(azureProvider.translate(['Hello'], 'en', 'fr')).rejects.toThrow(
-      'Failed to get auth token: 403',
+    await expect(azureProvider.translate(['Hello'], 'en', 'fr', 'user-token')).rejects.toThrow(
+      'bing translate auth failed with status 403',
     );
   });
 
   it('throws when translation request fails', async () => {
+    mockProxyAuthAndTranslation('unused');
+    mockFetch.mockReset();
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
-        text: async () => 'token',
+        status: 200,
+        json: async () => ({
+          ig: 'IG1',
+          iid: 'translator.5025',
+          key: '1',
+          token: 't',
+          expiresAt: Date.now() + 3_600_000,
+        }),
       })
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        json: async () => ({}),
-      });
+      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
 
     const { azureProvider } = await import('@/services/translators/providers/azure');
-    await expect(azureProvider.translate(['Hello'], 'en', 'fr')).rejects.toThrow(
-      'Translation failed with status 500',
+    await expect(azureProvider.translate(['Hello'], 'en', 'fr', 'user-token')).rejects.toThrow(
+      'bing translate failed with status 500',
     );
   });
 
   it('falls back to original text when response format is unexpected', async () => {
-    mockTokenAndTranslation([]);
+    mockProxyAuthAndTranslation('unused');
+    mockFetch.mockReset();
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ig: 'IG1',
+          iid: 'translator.5025',
+          key: '1',
+          token: 't',
+          expiresAt: Date.now() + 3_600_000,
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => [] });
 
     const { azureProvider } = await import('@/services/translators/providers/azure');
-    const result = await azureProvider.translate(['Hello'], 'en', 'fr');
+    const result = await azureProvider.translate(['Hello'], 'en', 'fr', 'user-token');
     expect(result).toEqual(['Hello']);
   });
 

--- a/apps/readest-app/src/__tests__/utils/a11y.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/a11y.browser.test.ts
@@ -7,7 +7,8 @@ import { handleA11yNavigation } from '@/utils/a11y';
 // descendants are all inline formatting tags — so nesting any other element
 // (e.g. the next-section skip link) inside such a paragraph drops the match.
 // This needs the real :has() engine, so it runs as a browser test.
-const PARAGRAPH_SELECTOR = 'p, blockquote, dd, div:not(:has(*:not(b, a, em, i, strong, u, span)))';
+const PARAGRAPH_SELECTOR =
+  'p, blockquote, dd, div:not(:has(*:not(b, a, em, i, strong, u, span, font)))';
 
 const NEXT_SECTION_ID = 'readest-skip-link-next-section';
 

--- a/apps/readest-app/src/__tests__/utils/epubcfi-translation-stability.test.ts
+++ b/apps/readest-app/src/__tests__/utils/epubcfi-translation-stability.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import * as CFI from 'foliate-js/epubcfi.js';
+import {
+  createTranslationTargetNode,
+  setSourceVisibility,
+} from '@/app/reader/hooks/useTextTranslation';
+
+/**
+ * A highlight must land on the same text whether or not translation is on, and
+ * whether it was created before or after translating. Translation appends its
+ * target node to the end of the source element, which leaves every preceding
+ * text-node offset and element index untouched — these tests lock that in, so a
+ * future change (injecting mid-element, or wrapping the source) cannot silently
+ * shift saved CFIs.
+ */
+const XHTML = (str: string) => new DOMParser().parseFromString(str, 'application/xhtml+xml');
+
+const WORD = 'growth';
+
+const page = () =>
+  XHTML(`<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>T</title></head>
+  <body id="b">
+    <p id="p1">First paragraph</p>
+    <div id="p2">Veganism is experiencing unprecedented growth globally.</div>
+    <p id="p3">Third paragraph here</p>
+  </body>
+</html>`);
+
+const translated = (doc: Document) => {
+  const el = doc.getElementById('p2')!;
+  el.appendChild(
+    createTranslationTargetNode({
+      translatedText: '素食主义正在经历前所未有的增长。',
+      lang: 'zh',
+      targetBlockClassName: 'translation-target-block',
+      hidden: false,
+      widthLineBreak: false,
+    }),
+  );
+  return doc;
+};
+
+/** CFI of the word inside #p2's own text node. */
+const cfiForWord = (doc: Document) => {
+  const el = doc.getElementById('p2')!;
+  const textNode = Array.from(el.childNodes).find(
+    (n) => n.nodeType === Node.TEXT_NODE && n.textContent!.includes(WORD),
+  ) as Text;
+  const start = textNode.textContent!.indexOf(WORD);
+  const range = doc.createRange();
+  range.setStart(textNode, start);
+  range.setEnd(textNode, start + WORD.length);
+  return CFI.fromRange(range);
+};
+
+const resolve = (doc: Document, cfi: string) =>
+  CFI.toRange(doc, CFI.parse(cfi))?.toString() ?? null;
+
+describe('CFI stability across translation', () => {
+  it('produces the same CFI before and after the translation node is appended', () => {
+    expect(cfiForWord(translated(page()))).toBe(cfiForWord(page()));
+  });
+
+  it('resolves a pre-translation CFI to the same word after translating', () => {
+    const cfi = cfiForWord(page());
+    expect(resolve(translated(page()), cfi)).toBe(WORD);
+  });
+
+  it('resolves a post-translation CFI to the same word once translation is off', () => {
+    const cfi = cfiForWord(translated(page()));
+    expect(resolve(page(), cfi)).toBe(WORD);
+  });
+
+  it('keeps a source CFI resolvable when the original text is hidden', () => {
+    // Previously the original's text nodes were blanked (textContent = ''),
+    // which destroyed the anchor: the highlight had nothing left to resolve to.
+    // The original is now wrapped in a cfi-skip element instead, so indices and
+    // offsets survive being hidden.
+    const cfi = cfiForWord(page());
+
+    const doc = translated(page());
+    setSourceVisibility(doc.getElementById('p2')!, false);
+
+    expect(doc.getElementById('p2')!.querySelector('[cfi-skip]')).not.toBeNull();
+    expect(resolve(doc, cfi)).toBe(WORD);
+  });
+
+  it('restores the original in place when it is shown again', () => {
+    const doc = translated(page());
+    const el = doc.getElementById('p2')!;
+    const before = el.textContent;
+
+    setSourceVisibility(el, false);
+    setSourceVisibility(el, true);
+
+    expect(el.querySelector('[cfi-skip]')).toBeNull();
+    expect(el.textContent).toBe(before);
+    expect(resolve(doc, cfiForWord(page()))).toBe(WORD);
+  });
+
+  it('produces the same source CFI whether the original is shown or hidden', () => {
+    const shown = translated(page());
+    const hidden = translated(page());
+    setSourceVisibility(hidden.getElementById('p2')!, false);
+
+    // Generating a CFI needs the text present; hiding must not move it.
+    const cfi = cfiForWord(shown);
+    expect(resolve(hidden, cfi)).toBe(WORD);
+  });
+
+  it('keeps CFIs of following elements stable when an earlier element is translated', () => {
+    const cfiOf = (doc: Document) => {
+      const textNode = doc.getElementById('p3')!.firstChild as Text;
+      const range = doc.createRange();
+      range.setStart(textNode, 0);
+      range.setEnd(textNode, 5);
+      return CFI.fromRange(range);
+    };
+    const before = cfiOf(page());
+    expect(cfiOf(translated(page()))).toBe(before);
+    expect(resolve(translated(page()), before)).toBe('Third');
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/paragraph-layout-translation.browser.test.ts
+++ b/apps/readest-app/src/__tests__/utils/paragraph-layout-translation.browser.test.ts
@@ -1,0 +1,186 @@
+import { describe, test, expect, afterEach } from 'vitest';
+
+import { getStyles, ThemeCode } from '@/utils/style';
+import { ViewSettings } from '@/types/book';
+import {
+  createTranslationTargetNode,
+  setSourceVisibility,
+} from '@/app/reader/hooks/useTextTranslation';
+import {
+  DEFAULT_BOOK_FONT,
+  DEFAULT_BOOK_LAYOUT,
+  DEFAULT_BOOK_LANGUAGE,
+  DEFAULT_BOOK_STYLE,
+  DEFAULT_VIEW_CONFIG,
+  DEFAULT_TTS_CONFIG,
+  DEFAULT_TRANSLATOR_CONFIG,
+  DEFAULT_ANNOTATOR_CONFIG,
+  DEFAULT_SCREEN_CONFIG,
+} from '@/services/constants';
+
+// The paragraph-layout rule only matches a <div> whose descendants are all
+// inline formatting tags. Translation appends its <font> wrappers *inside* the
+// source paragraph, so if <font> is not treated as inline formatting the
+// enclosing <div> silently drops the rule and reverts to the book's default
+// line spacing. Uses the real emitted CSS and the real :has() engine.
+const LINE_HEIGHT = 2;
+const FONT_SIZE_PX = 16;
+
+function makeViewSettings(overrides: Partial<ViewSettings> = {}): ViewSettings {
+  return {
+    ...DEFAULT_BOOK_FONT,
+    ...DEFAULT_BOOK_LAYOUT,
+    ...DEFAULT_BOOK_LANGUAGE,
+    ...DEFAULT_BOOK_STYLE,
+    ...DEFAULT_VIEW_CONFIG,
+    ...DEFAULT_TTS_CONFIG,
+    ...DEFAULT_TRANSLATOR_CONFIG,
+    ...DEFAULT_ANNOTATOR_CONFIG,
+    ...DEFAULT_SCREEN_CONFIG,
+    ...overrides,
+  } as ViewSettings;
+}
+
+const themeCode: ThemeCode = {
+  bg: '#ffffff',
+  fg: '#000000',
+  primary: '#3366cc',
+  isDarkMode: false,
+  palette: {
+    'base-100': '#ffffff',
+    'base-200': '#f0f0f0',
+    'base-300': '#e0e0e0',
+    'base-content': '#000000',
+    neutral: '#808080',
+    'neutral-content': '#ffffff',
+    primary: '#3366cc',
+    secondary: '#6699cc',
+    accent: '#33cc99',
+  },
+} as ThemeCode;
+
+const iframes: HTMLIFrameElement[] = [];
+
+const renderSection = (bodyHtml: string) => {
+  const iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+  iframes.push(iframe);
+  const doc = iframe.contentDocument!;
+  const style = doc.createElement('style');
+  style.textContent =
+    `html, body { font-size: ${FONT_SIZE_PX}px; }` +
+    getStyles(makeViewSettings({ lineHeight: LINE_HEIGHT, useBookLayout: false }), themeCode);
+  doc.head.appendChild(style);
+  doc.body.innerHTML = bodyHtml;
+  return { doc, win: iframe.contentWindow! };
+};
+
+const appendTranslation = (el: HTMLElement) =>
+  el.appendChild(
+    createTranslationTargetNode({
+      translatedText: '译文',
+      lang: 'zh',
+      targetBlockClassName: 'translation-target-block',
+      hidden: false,
+      widthLineBreak: false,
+    }),
+  );
+
+afterEach(() => {
+  while (iframes.length) iframes.pop()!.remove();
+});
+
+describe('paragraph layout survives translation injection', () => {
+  test('keeps a <div> paragraph line spacing after the translation node is appended', () => {
+    const { doc, win } = renderSection(
+      `<div class="para">Veganism is experiencing unprecedented growth globally.</div>`,
+    );
+    const para = doc.querySelector('.para') as HTMLElement;
+    const before = win.getComputedStyle(para).lineHeight;
+    expect(before).toBe(`${LINE_HEIGHT * FONT_SIZE_PX}px`);
+
+    appendTranslation(para);
+
+    // The bug: the appended <font> made the :has() test fail, so the div lost
+    // the override and fell back to the book default ("normal").
+    expect(win.getComputedStyle(para).lineHeight).toBe(before);
+  });
+
+  test('keeps line spacing on a <div> that also holds inline markup and links', () => {
+    // Mirrors the real reported paragraph: <i> and <a> children plus the
+    // appended translation wrapper.
+    const { doc, win } = renderSection(
+      `<div class="para">Veganism is <i>experiencing</i> unprecedented ` +
+        `<a href="#x">growth</a> globally.</div>`,
+    );
+    const para = doc.querySelector('.para') as HTMLElement;
+    const before = win.getComputedStyle(para).lineHeight;
+    expect(before).toBe(`${LINE_HEIGHT * FONT_SIZE_PX}px`);
+
+    appendTranslation(para);
+
+    expect(win.getComputedStyle(para).lineHeight).toBe(before);
+  });
+
+  test('keeps line spacing for a book that uses <font> markup of its own', () => {
+    // Same root cause without translation involved at all: an EPUB that styles
+    // runs with <font> would lose the paragraph overrides.
+    const { doc, win } = renderSection(
+      `<div class="para">A <font color="red">red</font> word.</div>`,
+    );
+    const para = doc.querySelector('.para') as HTMLElement;
+    expect(win.getComputedStyle(para).lineHeight).toBe(`${LINE_HEIGHT * FONT_SIZE_PX}px`);
+  });
+
+  test('keeps line spacing when the translation carries preserved inline markup', () => {
+    // Markup round-tripped for #1582 lands inside the source paragraph, and
+    // :has() inspects *all* descendants — so the sanitizer's allowlist has to
+    // stay a subset of the layout allowlist or formatting re-breaks layout.
+    const { doc, win } = renderSection(
+      `<div class="para">Veganism is <i>really</i> growing.</div>`,
+    );
+    const para = doc.querySelector('.para') as HTMLElement;
+    const before = win.getComputedStyle(para).lineHeight;
+
+    const fragment = doc.createDocumentFragment();
+    fragment.appendChild(doc.createTextNode('素食主义'));
+    for (const tag of ['b', 'i', 'em', 'strong', 'u', 'span', 'sup', 'sub', 'small', 'mark']) {
+      const marked = doc.createElement(tag);
+      marked.textContent = tag;
+      fragment.appendChild(marked);
+    }
+    para.appendChild(
+      createTranslationTargetNode({
+        content: fragment,
+        lang: 'zh',
+        targetBlockClassName: 'translation-target-block',
+        hidden: false,
+        widthLineBreak: false,
+      }),
+    );
+
+    expect(win.getComputedStyle(para).lineHeight).toBe(before);
+  });
+
+  test('keeps line spacing while the original text is hidden', () => {
+    const { doc, win } = renderSection(`<div class="para">Veganism is growing.</div>`);
+    const para = doc.querySelector('.para') as HTMLElement;
+    const before = win.getComputedStyle(para).lineHeight;
+
+    appendTranslation(para);
+    setSourceVisibility(para, false);
+
+    expect(para.querySelector('[cfi-skip]')).not.toBeNull();
+    expect(win.getComputedStyle(para).lineHeight).toBe(before);
+  });
+
+  test('still ignores a <div> that contains a real block child', () => {
+    // The rule must keep excluding container divs — only inline formatting
+    // descendants qualify a div as paragraph-like.
+    const { doc, win } = renderSection(
+      `<div class="para">Wrapper<div>an actual block child</div></div>`,
+    );
+    const para = doc.querySelector('.para') as HTMLElement;
+    expect(win.getComputedStyle(para).lineHeight).not.toBe(`${LINE_HEIGHT * FONT_SIZE_PX}px`);
+  });
+});

--- a/apps/readest-app/src/app/api/azure-translate/route.ts
+++ b/apps/readest-app/src/app/api/azure-translate/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  BING_REQUEST_HEADERS,
+  BING_TRANSLATE_URL,
+  BING_TRANSLATOR_URL,
+  parseBingAuthParams,
+} from '@/services/translators/providers/azureShared';
+import { validateUserAndToken } from '@/utils/access';
+
+/**
+ * Same-origin proxy for the Bing Translator web API, used by the `azure`
+ * translation provider in web builds. bing.com sends no CORS headers at all,
+ * so a browser cannot call it directly; the client calls this route and the
+ * request is made server-side.
+ * Only two fixed upstream endpoints are exposed — no arbitrary URL is ever
+ * fetched, so there is no SSRF surface.
+ *
+ * The `auth` endpoint parses the ~650KB translator page here and returns only
+ * the auth material, so that markup never crosses the wire to the browser.
+ */
+const MAX_BODY_CHARS = 100_000;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_REQUESTS = 60;
+const MAX_CONCURRENT_REQUESTS = 3;
+const UPSTREAM_TIMEOUT_MS = 15_000;
+
+const requestBudgets = new Map<string, { count: number; resetAt: number; active: number }>();
+// Response constructor throws when these statuses carry a body.
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+
+export async function POST(request: NextRequest) {
+  const { user, token } = await validateUserAndToken(request.headers.get('authorization'));
+  if (!user || !token) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 403 });
+  }
+
+  const origin = request.headers.get('origin');
+  let originHost: string | null = null;
+  try {
+    originHost = origin ? new URL(origin).host : null;
+  } catch {
+    // leave originHost null — treated as a mismatch below
+  }
+  if (originHost !== request.nextUrl.host) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const endpoint = request.nextUrl.searchParams.get('endpoint');
+  if (endpoint !== 'auth' && endpoint !== 'translate') {
+    return NextResponse.json({ error: 'Unknown endpoint' }, { status: 400 });
+  }
+
+  const now = Date.now();
+  let budget = requestBudgets.get(user.id);
+  if (!budget || budget.resetAt <= now) {
+    budget = {
+      count: 0,
+      resetAt: now + RATE_LIMIT_WINDOW_MS,
+      active: budget?.active ?? 0,
+    };
+    requestBudgets.set(user.id, budget);
+  }
+  if (budget.count >= RATE_LIMIT_REQUESTS || budget.active >= MAX_CONCURRENT_REQUESTS) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      { status: 429, headers: { 'Retry-After': String(Math.ceil((budget.resetAt - now) / 1000)) } },
+    );
+  }
+  budget.count++;
+  budget.active++;
+
+  try {
+    const signal = AbortSignal.any([request.signal, AbortSignal.timeout(UPSTREAM_TIMEOUT_MS)]);
+
+    if (endpoint === 'auth') {
+      try {
+        const response = await fetch(BING_TRANSLATOR_URL, {
+          method: 'GET',
+          headers: { 'User-Agent': BING_REQUEST_HEADERS['User-Agent'] },
+          signal,
+        });
+        if (!response.ok) {
+          return NextResponse.json(
+            { error: 'Upstream request failed' },
+            { status: response.status },
+          );
+        }
+        return NextResponse.json(parseBingAuthParams(await response.text(), Date.now()));
+      } catch {
+        return NextResponse.json({ error: 'Upstream request failed' }, { status: 502 });
+      }
+    }
+
+    const contentLength = request.headers.get('content-length');
+    if (contentLength !== null) {
+      const declaredLength = Number(contentLength);
+      if (
+        !Number.isSafeInteger(declaredLength) ||
+        declaredLength < 0 ||
+        declaredLength > MAX_BODY_CHARS * 3
+      ) {
+        return NextResponse.json({ error: 'Invalid request body size' }, { status: 413 });
+      }
+    }
+    const body = await request.text();
+    if (body.length > MAX_BODY_CHARS) {
+      return NextResponse.json({ error: 'Request body too large' }, { status: 413 });
+    }
+
+    const url = new URL(BING_TRANSLATE_URL);
+    request.nextUrl.searchParams.forEach((value, key) => {
+      if (key !== 'endpoint') url.searchParams.append(key, value);
+    });
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: BING_REQUEST_HEADERS,
+        body,
+        signal,
+      });
+      const responseBody = NULL_BODY_STATUSES.has(response.status) ? null : await response.text();
+      return new NextResponse(responseBody, {
+        status: response.status,
+        headers: { 'Content-Type': response.headers.get('Content-Type') ?? 'application/json' },
+      });
+    } catch {
+      return NextResponse.json({ error: 'Upstream request failed' }, { status: 502 });
+    }
+  } finally {
+    budget.active--;
+  }
+}

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -157,6 +157,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
   const containerRef = React.useRef<HTMLDivElement>(null);
 
   const [selection, setSelection] = useState<TextSelection | null>(null);
+  const [translationEpoch, setTranslationEpoch] = useState(0);
   const [showAnnotPopup, setShowAnnotPopup] = useState(false);
   const [showDictionaryPopup, setShowDictionaryPopup] = useState(false);
   const [showDeepLPopup, setShowDeepLPopup] = useState(false);
@@ -1084,7 +1085,29 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
       console.warn(e);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [progress, annotationIndex]);
+  }, [progress, annotationIndex, translationEpoch]);
+
+  // Translations are appended long after a section's annotations were drawn, so
+  // a highlight anchored inside translated text has nothing to attach to at
+  // draw time. Bumping this re-runs the draw effect above once the inserts
+  // settle; they arrive in bursts, hence the debounce.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const handleTranslationInserted = (event: CustomEvent) => {
+      const detail = event.detail as { bookKey: string } | undefined;
+      if (!detail || detail.bookKey !== bookKey) return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        setTranslationEpoch((epoch) => epoch + 1);
+      }, 150);
+    };
+    eventDispatcher.on('translation-inserted', handleTranslationInserted);
+    return () => {
+      if (timer) clearTimeout(timer);
+      eventDispatcher.off('translation-inserted', handleTranslationInserted);
+    };
+  }, [bookKey]);
 
   useEffect(() => {
     if (!config.booknotes || !selection?.cfi || !showAnnotationNotes) return;

--- a/apps/readest-app/src/app/reader/hooks/useTextTranslation.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextTranslation.ts
@@ -10,22 +10,58 @@ import { walkTextNodes } from '@/utils/walk';
 import { debounce } from '@/utils/debounce';
 import { getLocale } from '@/utils/misc';
 import { getDirFromLanguage } from '@/utils/rtl';
+import { getTranslators } from '@/services/translators';
+import {
+  extractSourcePayload,
+  sanitizeTranslatedMarkup,
+  splitMarkupIntoChunks,
+} from '@/app/reader/utils/translationMarkup';
+import { splitTextIntoChunks } from '@/services/translators/utils';
 
+/**
+ * Markup inflates the payload and the provider's length cap counts the tags,
+ * while the chunker splits on sentence boundaries and would cut through a tag.
+ * Rather than build markup-aware chunking, longer formatted paragraphs fall
+ * back to the plain-text path (losing formatting, exactly as before).
+ *
+ * Set to the verified hard limit of the only provider that currently opts in:
+ * Bing accepts exactly 1000 UTF-16 code units and answers `statusCode: 400` at
+ * 1001. Anything lower needlessly gives up formatting on paragraphs that would
+ * have fit.
+ */
+const MAX_MARKUP_PAYLOAD_CHARS = 1000;
+
+/**
+ * Builds the node appended to a source paragraph to carry its translation.
+ *
+ * A single <font> rather than nested wrappers: it keeps the CFI path into
+ * translated text two levels shallower, and puts `display: block` on the
+ * element itself instead of on a block nested inside an inline parent. <font>
+ * specifically because book CSS never targets it (so the wrapper picks up no
+ * styling from the book) and because it is on INLINE_FORMATTING_TAGS, so the
+ * enclosing source div keeps its paragraph layout.
+ *
+ * `content` may be a plain string or a sanitized fragment carrying the source's
+ * inline formatting — the markup inside is *meant* to inherit the book's rules
+ * so the translation matches the original's styling.
+ */
 export const createTranslationTargetNode = ({
   translatedText,
+  content,
   lang,
   targetBlockClassName,
   hidden,
   widthLineBreak,
 }: {
-  translatedText: string;
+  translatedText?: string;
+  content?: DocumentFragment;
   lang: string;
   targetBlockClassName: string;
   hidden: boolean;
   widthLineBreak: boolean;
 }) => {
   const wrapper = document.createElement('font');
-  wrapper.className = `translation-target ${hidden ? 'hidden' : ''}`;
+  wrapper.className = `translation-target ${targetBlockClassName} ${hidden ? 'hidden' : ''}`.trim();
   wrapper.setAttribute('translation-element-mark', '1');
   wrapper.setAttribute('lang', lang);
   // Set the base direction from the target language so justified RTL text
@@ -36,16 +72,44 @@ export const createTranslationTargetNode = ({
     wrapper.appendChild(document.createElement('br'));
   }
 
-  const blockWrapper = document.createElement('font');
-  blockWrapper.className = `translation-target ${targetBlockClassName}`;
-
-  const inner = document.createElement('font');
-  inner.className = 'translation-target target-inner target-inner-theme-none';
-  inner.textContent = translatedText;
-
-  blockWrapper.appendChild(inner);
-  wrapper.appendChild(blockWrapper);
+  if (content) {
+    wrapper.appendChild(content);
+  } else {
+    wrapper.appendChild(document.createTextNode(translatedText ?? ''));
+  }
   return wrapper;
+};
+
+const SOURCE_HIDDEN_CLASS = 'translation-source-hidden';
+
+/**
+ * Hides or restores a paragraph's original text.
+ *
+ * The original is wrapped in a `cfi-skip` element rather than having its text
+ * erased. cfi-skip hoists the wrapper's children for indexing, so every source
+ * text node keeps the exact index and offset it had unwrapped — a highlight on
+ * the original still resolves whether or not the original is on screen. Erasing
+ * the text (the previous approach) destroyed that anchor.
+ */
+export const setSourceVisibility = (el: HTMLElement, visible: boolean) => {
+  const existing = el.querySelector(`:scope > .${SOURCE_HIDDEN_CLASS}`);
+  if (visible) {
+    if (existing) existing.replaceWith(...Array.from(existing.childNodes));
+    return;
+  }
+  if (existing) return;
+
+  const sourceNodes = Array.from(el.childNodes).filter(
+    (node) =>
+      !(node.nodeType === Node.ELEMENT_NODE && (node as Element).closest('.translation-target')),
+  );
+  if (!sourceNodes.length) return;
+
+  const hider = document.createElement('font');
+  hider.className = SOURCE_HIDDEN_CLASS;
+  hider.setAttribute('cfi-skip', '');
+  el.insertBefore(hider, sourceNodes[0]!);
+  sourceNodes.forEach((node) => hider.appendChild(node));
 };
 
 export function useTextTranslation(
@@ -74,6 +138,11 @@ export function useTextTranslation(
   } as UseTranslatorOptions);
 
   const translateRef = useRef(translate);
+  // `translationProvider` is a loose string in settings, so match by name
+  // rather than narrowing to TranslatorName.
+  const translatorPreservesMarkup = !!getTranslators().find(
+    (translator) => translator.name === provider,
+  )?.preservesMarkup;
   const observerRef = useRef<IntersectionObserver | null>(null);
   const translatedElements = useRef<HTMLElement[]>([]);
   const allTextNodes = useRef<HTMLElement[]>([]);
@@ -247,59 +316,43 @@ export function useTextTranslation(
     }
 
     const updateSourceNodes = (element: HTMLElement) => {
-      const hasDirectText = Array.from(element.childNodes).some(
-        (node) => node.nodeType === Node.TEXT_NODE && node.textContent?.trim() !== '',
-      );
-      if (hasDirectText) {
-        element.classList.add('translation-source');
-
-        const textNodes = Array.from(element.childNodes).filter(
-          (node) => node.nodeType === Node.TEXT_NODE && node.textContent?.trim() !== '',
-        );
-
-        if (!element.hasAttribute('original-text-stored')) {
-          element.setAttribute(
-            'original-text-nodes',
-            JSON.stringify(textNodes.map((node) => node.textContent)),
-          );
-          element.setAttribute('original-text-stored', 'true');
-        }
-      }
-      const isSource = element.classList.contains('translation-source');
-      if (isSource) {
-        const textNodes = Array.from(element.childNodes).filter(
-          (node) => node.nodeType === Node.TEXT_NODE,
-        ) as Text[];
-
-        if (showTranslateSourceRef.current) {
-          const originalTexts = JSON.parse(element.getAttribute('original-text-nodes') || '[]');
-          textNodes.forEach((textNode, index) => {
-            if (originalTexts[index] !== undefined) {
-              textNode.textContent = originalTexts[index];
-            }
-          });
-        } else {
-          textNodes.forEach((textNode) => {
-            textNode.textContent = '';
-          });
-        }
-      }
-      for (const child of Array.from(element.childNodes)) {
-        if (child.nodeType !== Node.ELEMENT_NODE) continue;
-        const node = child as HTMLElement;
-        if (!node.classList.contains('translation-target')) {
-          updateSourceNodes(node);
-        }
-      }
+      element.classList.add('translation-source');
+      setSourceVisibility(element, !!showTranslateSourceRef.current);
     };
 
     try {
-      const translated = await translateRef.current([text]);
-      const translatedText = translated[0];
+      // Round-trip the paragraph's inline markup when the provider repositions
+      // tags for us; otherwise send bare text. Markup is split at run
+      // boundaries so a long formatted paragraph still keeps its formatting
+      // instead of falling back — each chunk is well-formed on its own.
+      const payload = extractSourcePayload(el);
+      const markupChunks =
+        translatorPreservesMarkup && payload.hasMarkup
+          ? splitMarkupIntoChunks(payload.html, MAX_MARKUP_PAYLOAD_CHARS, splitTextIntoChunks)
+          : [];
+      const useMarkup = markupChunks.length > 0;
+
+      const translated = await translateRef.current(useMarkup ? markupChunks : [text]);
+      const translatedText = translated.join('');
       if (!translatedText || text === translatedText) return;
 
+      let content: DocumentFragment | undefined;
+      if (useMarkup) {
+        // Sanitize per chunk: each was translated independently, and a chunk
+        // that loses everything must not discard its siblings.
+        const combined = el.ownerDocument.createDocumentFragment();
+        for (const chunk of translated) {
+          const part = sanitizeTranslatedMarkup(chunk, payload.allowedAttrs, el.ownerDocument);
+          if (part) combined.appendChild(part);
+        }
+        content = combined.childNodes.length ? combined : undefined;
+      }
+
       const wrapper = createTranslationTargetNode({
+        // Falls back to the raw string when markup was not used or did not
+        // survive sanitizing, which is exactly the previous behaviour.
         translatedText,
+        content,
         lang: targetLang || getLocale(),
         targetBlockClassName,
         hidden: !enabled.current,
@@ -314,6 +367,9 @@ export function useTextTranslation(
         updateSourceNodes(el);
         el.appendChild(wrapper);
         translatedElements.current.push(el);
+        // Translations land long after the section's annotations were drawn, so
+        // any highlight anchored inside this paragraph has to be re-attached.
+        eventDispatcher.dispatch('translation-inserted', { bookKey, element: el });
       });
     } catch (err) {
       console.warn('Translation failed:', err);

--- a/apps/readest-app/src/app/reader/utils/translationMarkup.ts
+++ b/apps/readest-app/src/app/reader/utils/translationMarkup.ts
@@ -1,0 +1,272 @@
+import { INLINE_FORMATTING_TAGS, isInlineFormattingTag } from '@/utils/inlineTags';
+
+/**
+ * Carrying a paragraph's inline formatting through translation (#1582).
+ *
+ * The translator is what maps formatting onto the translated wording — send it
+ * `The <b>quick</b> brown fox` and Bing returns `那只<b>敏捷</b>的棕色狐狸`, with
+ * the tag on the semantically matching word even though the sentence reordered.
+ * We therefore round-trip markup rather than trying to re-align runs ourselves.
+ *
+ * The response is untrusted markup that ends up inside the book's DOM, so it is
+ * parsed detached and rebuilt through an allowlist — never assigned as
+ * innerHTML. Attributes use *echo validation*: an attribute survives only if
+ * that exact tag/name/value appeared in the source we sent. That keeps book
+ * styling hooks like `<span class="whisper">` (the small-font case in #1582)
+ * while making it impossible for the response to introduce a class, href, style
+ * or handler of its own.
+ */
+
+/** Attributes worth preserving; anything else is dropped outright. */
+const PRESERVABLE_ATTRS = ['class', 'href', 'lang', 'dir'] as const;
+
+/**
+ * Runtime-injected content that is not part of the book: translation targets,
+ * a11y skip links, and WordLens ruby glosses. It must never be fed to the
+ * translator (a gloss would come back translated as if it were prose).
+ */
+const INJECTED_SELECTOR = '.translation-target, [cfi-inert]';
+const GLOSS_SELECTOR = 'ruby.wl-gloss, .wl-gloss';
+
+export interface SourcePayload {
+  /** Serialized inline markup, empty when the source is plain text. */
+  html: string;
+  /** Plain-text form, always populated — the fallback payload. */
+  text: string;
+  /** True when the source carries inline markup worth round-tripping. */
+  hasMarkup: boolean;
+  /** Echo-validation set of `tag|name|value` triples seen in the source. */
+  allowedAttrs: Set<string>;
+}
+
+const attrKey = (tag: string, name: string, value: string) =>
+  `${tag.toLowerCase()}|${name.toLowerCase()}|${value}`;
+
+/**
+ * Strips runtime-injected nodes from a detached clone of `el`, so what we send
+ * is the book's own markup and nothing else.
+ */
+const cleanClone = (el: HTMLElement): HTMLElement => {
+  const clone = el.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll(INJECTED_SELECTOR).forEach((node) => node.remove());
+  // A gloss wraps real book text: keep the base text, drop the injected reading.
+  clone.querySelectorAll(GLOSS_SELECTOR).forEach((gloss) => {
+    gloss.querySelectorAll('rt, rp').forEach((node) => node.remove());
+    gloss.replaceWith(...Array.from(gloss.childNodes));
+  });
+  return clone;
+};
+
+export const extractSourcePayload = (el: HTMLElement): SourcePayload => {
+  const clone = cleanClone(el);
+  const text = clone.textContent ?? '';
+
+  const allowedAttrs = new Set<string>();
+  let hasMarkup = false;
+  for (const descendant of Array.from(clone.querySelectorAll('*'))) {
+    const tag = descendant.tagName.toLowerCase();
+    if (isInlineFormattingTag(tag)) {
+      hasMarkup = true;
+      for (const name of PRESERVABLE_ATTRS) {
+        const value = descendant.getAttribute(name);
+        if (value !== null) allowedAttrs.add(attrKey(tag, name, value));
+      }
+    }
+  }
+
+  return { html: hasMarkup ? clone.innerHTML : '', text, hasMarkup, allowedAttrs };
+};
+
+/**
+ * Rebuilds the translator's response as a detached fragment containing only
+ * allowlisted inline tags and echo-validated attributes. Disallowed elements
+ * are unwrapped so their text is never lost. Returns null when nothing
+ * meaningful survives, so callers can fall back to the plain-text path.
+ */
+export const sanitizeTranslatedMarkup = (
+  html: string,
+  allowedAttrs: Set<string>,
+  doc: Document = document,
+): DocumentFragment | null => {
+  // Parsed in a detached document: no scripts run, no resources are fetched,
+  // and unbalanced tags are normalized by the parser.
+  const parsed = new DOMParser().parseFromString(html, 'text/html');
+  const fragment = doc.createDocumentFragment();
+
+  const convert = (source: Node, target: Node) => {
+    for (const child of Array.from(source.childNodes)) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        target.appendChild(doc.createTextNode(child.textContent ?? ''));
+        continue;
+      }
+      if (child.nodeType !== Node.ELEMENT_NODE) continue; // comments, CDATA, …
+
+      const element = child as Element;
+      const tag = element.tagName.toLowerCase();
+      if (!isInlineFormattingTag(tag)) {
+        // Unwrap: drop the tag, keep its text.
+        convert(element, target);
+        continue;
+      }
+
+      const rebuilt = doc.createElement(tag);
+      for (const name of PRESERVABLE_ATTRS) {
+        const value = element.getAttribute(name);
+        if (value !== null && allowedAttrs.has(attrKey(tag, name, value))) {
+          rebuilt.setAttribute(name, value);
+        }
+      }
+      convert(element, rebuilt);
+      target.appendChild(rebuilt);
+    }
+  };
+
+  convert(parsed.body, fragment);
+
+  return (fragment.textContent ?? '').trim() ? fragment : null;
+};
+
+/** Tags the sanitizer will keep — exported for tests and documentation. */
+export const SANITIZER_ALLOWED_TAGS = INLINE_FORMATTING_TAGS;
+
+interface Ancestor {
+  tag: string;
+  attrs: Array<[string, string]>;
+}
+
+/** A stretch of text together with the inline elements enclosing it. */
+interface Run {
+  text: string;
+  ancestors: Ancestor[];
+}
+
+const escapeText = (text: string) =>
+  text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const escapeAttr = (value: string) =>
+  value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+
+const openTag = ({ tag, attrs }: Ancestor) =>
+  attrs.length
+    ? `<${tag} ${attrs.map(([name, value]) => `${name}="${escapeAttr(value)}"`).join(' ')}>`
+    : `<${tag}>`;
+
+const sameAncestor = (a: Ancestor, b: Ancestor) =>
+  a.tag === b.tag &&
+  a.attrs.length === b.attrs.length &&
+  a.attrs.every(([name, value], i) => b.attrs[i]?.[0] === name && b.attrs[i]?.[1] === value);
+
+/** Flattens an element into text runs, each tagged with its inline ancestors. */
+const collectRuns = (root: Node): Run[] => {
+  const runs: Run[] = [];
+  const visit = (node: Node, ancestors: Ancestor[]) => {
+    for (const child of Array.from(node.childNodes)) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        const text = child.textContent ?? '';
+        if (text) runs.push({ text, ancestors });
+        continue;
+      }
+      if (child.nodeType !== Node.ELEMENT_NODE) continue;
+      const element = child as Element;
+      const tag = element.tagName.toLowerCase();
+      if (!isInlineFormattingTag(tag)) {
+        visit(element, ancestors); // unwrap: keep the text, drop the tag
+        continue;
+      }
+      const attrs = PRESERVABLE_ATTRS.map(
+        (name) => [name, element.getAttribute(name)] as [string, string | null],
+      ).filter((pair): pair is [string, string] => pair[1] !== null);
+      visit(element, [...ancestors, { tag, attrs }]);
+    }
+  };
+  visit(root, []);
+  return runs;
+};
+
+/** Serializes runs into well-formed HTML, opening each tag only once. */
+const serializeRuns = (runs: Run[]): string => {
+  let html = '';
+  let open: Ancestor[] = [];
+  for (const run of runs) {
+    let shared = 0;
+    while (
+      shared < open.length &&
+      shared < run.ancestors.length &&
+      sameAncestor(open[shared]!, run.ancestors[shared]!)
+    ) {
+      shared++;
+    }
+    for (let i = open.length - 1; i >= shared; i--) html += `</${open[i]!.tag}>`;
+    for (let i = shared; i < run.ancestors.length; i++) html += openTag(run.ancestors[i]!);
+    html += escapeText(run.text);
+    open = run.ancestors;
+  }
+  for (let i = open.length - 1; i >= 0; i--) html += `</${open[i]!.tag}>`;
+  return html;
+};
+
+/**
+ * Splits a paragraph's inline markup into chunks that each fit `maxChars`
+ * *including their tags*, and that are each well-formed on their own.
+ *
+ * Formatting that straddles a boundary is re-opened in the next chunk, so an
+ * <i> spanning the split becomes two <i> elements — visually identical, and it
+ * keeps every chunk independently translatable. Without this, a formatted
+ * paragraph over the provider's cap had to fall back to plain text and lose its
+ * formatting entirely (#1582); the plain-text chunker splits on sentence
+ * boundaries and would cut through a tag.
+ *
+ * Returns an empty array when the markup cannot be chunked (a single tag's own
+ * overhead exceeds the budget), so callers fall back to the plain-text path.
+ */
+export const splitMarkupIntoChunks = (
+  html: string,
+  maxChars: number,
+  splitLongText: (text: string, maxLength: number) => string[],
+): string[] => {
+  const parsed = new DOMParser().parseFromString(html, 'text/html');
+  const runs = collectRuns(parsed.body);
+  if (!runs.length) return [];
+
+  const chunks: string[] = [];
+  let current: Run[] = [];
+
+  const flush = () => {
+    if (!current.length) return;
+    chunks.push(serializeRuns(current));
+    current = [];
+  };
+
+  for (const run of runs) {
+    // Budget left for this run's text once its wrappers are accounted for.
+    const overhead = serializeRuns([{ text: '', ancestors: run.ancestors }]).length;
+    if (overhead >= maxChars) return [];
+
+    let remaining = run.text;
+    while (remaining) {
+      const projected = serializeRuns([...current, { text: remaining, ancestors: run.ancestors }]);
+      if (projected.length <= maxChars) {
+        current.push({ text: remaining, ancestors: run.ancestors });
+        break;
+      }
+      const budget = maxChars - serializeRuns(current).length - overhead;
+      // Not enough room left in this chunk to say anything useful — close it.
+      if (budget <= 0 || (current.length && budget < remaining.length / 4)) {
+        flush();
+        continue;
+      }
+      const [head, ...rest] = splitLongText(remaining, budget);
+      if (!head) {
+        if (!current.length) return [];
+        flush();
+        continue;
+      }
+      current.push({ text: head, ancestors: run.ancestors });
+      remaining = rest.join('');
+      flush();
+    }
+  }
+  flush();
+
+  return chunks.every((chunk) => chunk.length <= maxChars) ? chunks : [];
+};

--- a/apps/readest-app/src/services/translators/providers/azure.ts
+++ b/apps/readest-app/src/services/translators/providers/azure.ts
@@ -2,100 +2,235 @@ import { stubTranslation as _ } from '@/utils/misc';
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import { isTauriAppPlatform } from '@/services/environment';
 import { TranslationProvider } from '../types';
+import { splitTextIntoChunks } from '../utils';
 import { normalizeToFullLang } from '@/utils/lang';
+import {
+  BING_REQUEST_HEADERS,
+  BING_TRANSLATE_URL,
+  BING_TRANSLATOR_URL,
+  BingAuthParams,
+  isBingAuthParams,
+  parseBingAuthParams,
+} from './azureShared';
 
-interface TokenCache {
-  token: string;
-  expiresAt: number;
+/**
+ * Microsoft's free translation backend, reached the same way the Bing
+ * Translator frontend reaches it. The provider keeps the `azure` name and
+ * "Azure Translator" label so existing user settings keep working.
+ *
+ * It used to mint a bearer token from https://edge.microsoft.com/translate/auth
+ * and call api-edge.cognitive.microsofttranslator.com. Microsoft retired that
+ * token endpoint (it 404s for every request now, as part of the Edge
+ * translation shutdown dated 2026-07-30), leaving the translate API reachable
+ * but unusable. The auth material now comes from the www.bing.com/translator
+ * page instead.
+ *
+ * Constraints:
+ * - the token is short-lived (the page advertises one hour) and an expired one
+ *   comes back as `statusCode: 205` inside an HTTP 200, so the body has to be
+ *   inspected rather than just `response.ok`;
+ * - bing.com sends no CORS headers, so a browser cannot call it at all. In the
+ *   Tauri app the requests go out directly; in web builds they go through the
+ *   same-origin proxy at /api/azure-translate.
+ */
+const PROXY_URL = '/api/azure-translate';
+// Must not exceed the per-user concurrency the proxy allows, or the surplus
+// requests come straight back as 429. Bing translates one text per request, so
+// a page of paragraphs would otherwise fan out unbounded.
+const MAX_CONCURRENT_REQUESTS = 3;
+// Bing answers `statusCode: 400` above exactly 1000 UTF-16 code units — the
+// cap counts code units, not bytes, so CJK and emoji measure the same as ASCII
+// (verified empirically: 1000 passes, 1001 fails, for all three).
+const MAX_CHARS_PER_REQUEST = 1000;
+// Bing rejects a translate call that omits these telemetry identifiers with
+// `statusCode: 400`, so they are forwarded alongside the token.
+const buildTranslateQuery = (auth: BingAuthParams) =>
+  new URLSearchParams({ isVertical: '1', IG: auth.ig, IID: auth.iid });
+
+let cachedAuth: BingAuthParams | null = null;
+// Concurrent lines must not each scrape the translator page, so the in-flight
+// request is shared between callers.
+let authPromise: Promise<BingAuthParams> | null = null;
+let activeRequests = 0;
+const requestQueue: Array<() => void> = [];
+
+/**
+ * Caps outbound requests across every concurrent `translate()` call — the
+ * counter is module-level because the proxy budgets per user, not per call.
+ * A task holds at most one slot at a time (auth is awaited before a translate
+ * slot is taken), so this cannot deadlock.
+ */
+async function withRequestLimit<T>(task: () => Promise<T>): Promise<T> {
+  if (activeRequests < MAX_CONCURRENT_REQUESTS) {
+    activeRequests++;
+  } else {
+    await new Promise<void>((resolve) => requestQueue.push(resolve));
+  }
+  try {
+    return await task();
+  } finally {
+    const next = requestQueue.shift();
+    // Hand the occupied slot straight over; leaving activeRequests untouched
+    // makes the transfer atomic with respect to fresh callers.
+    if (next) next();
+    else activeRequests--;
+  }
 }
 
-let tokenCache: TokenCache | null = null;
-
-const getAuthToken = async (): Promise<string> => {
-  const now = Date.now();
-
-  if (tokenCache && tokenCache.expiresAt > now) {
-    return tokenCache.token;
+const requireWebToken = (token?: string | null) => {
+  if (!token) {
+    throw new Error('azure translate requires authentication in web builds');
   }
-
-  try {
-    const fetch = isTauriAppPlatform() ? tauriFetch : window.fetch;
-    const tokenResponse = await fetch('https://edge.microsoft.com/translate/auth', {
-      method: 'GET',
-      headers: {
-        'User-Agent': 'Mozilla/5.0',
-      },
-    });
-
-    if (!tokenResponse.ok) {
-      throw new Error(`Failed to get auth token: ${tokenResponse.status}`);
-    }
-
-    const token = await tokenResponse.text();
-    const expiresAt = now + 8 * 60 * 1000;
-
-    tokenCache = {
-      token,
-      expiresAt,
-    };
-
-    return token;
-  } catch (error) {
-    console.error('Error getting Microsoft translation auth token:', error);
-    throw error;
-  }
+  return token;
 };
+
+async function fetchAuthParams(token?: string | null): Promise<BingAuthParams> {
+  if (isTauriAppPlatform()) {
+    const response = await withRequestLimit(() =>
+      tauriFetch(BING_TRANSLATOR_URL, {
+        method: 'GET',
+        headers: { 'User-Agent': BING_REQUEST_HEADERS['User-Agent'] },
+      }),
+    );
+    if (!response.ok) {
+      throw new Error(`bing translate auth failed with status ${response.status}`);
+    }
+    return parseBingAuthParams(await response.text(), Date.now());
+  }
+
+  // The translator page is ~650KB of markup; the proxy parses it server-side
+  // and returns just the auth material.
+  const response = await withRequestLimit(() =>
+    window.fetch(`${PROXY_URL}?endpoint=auth`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${requireWebToken(token)}` },
+    }),
+  );
+  if (!response.ok) {
+    throw new Error(`bing translate auth failed with status ${response.status}`);
+  }
+  const data = await response.json().catch(() => null);
+  if (!isBingAuthParams(data)) {
+    throw new Error('bing translate auth failed: malformed response');
+  }
+  return data;
+}
+
+async function getAuthParams(token?: string | null): Promise<BingAuthParams> {
+  if (cachedAuth && cachedAuth.expiresAt > Date.now()) {
+    return cachedAuth;
+  }
+  authPromise ??= fetchAuthParams(token)
+    .then((auth) => {
+      cachedAuth = auth;
+      return auth;
+    })
+    .finally(() => {
+      authPromise = null;
+    });
+  return authPromise;
+}
+
+async function translateChunk(
+  chunk: string,
+  fromLang: string,
+  toLang: string,
+  token?: string | null,
+  retryAuth = true,
+): Promise<string> {
+  const auth = await getAuthParams(token);
+  const body = new URLSearchParams({
+    fromLang,
+    text: chunk,
+    to: toLang,
+    token: auth.token,
+    key: auth.key,
+  });
+  const query = buildTranslateQuery(auth);
+
+  const response = await withRequestLimit(() =>
+    isTauriAppPlatform()
+      ? tauriFetch(`${BING_TRANSLATE_URL}?${query}`, {
+          method: 'POST',
+          headers: BING_REQUEST_HEADERS,
+          body: body.toString(),
+        })
+      : window.fetch(`${PROXY_URL}?endpoint=translate&${query}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: `Bearer ${requireWebToken(token)}`,
+          },
+          body: body.toString(),
+        }),
+  );
+
+  if (!response.ok) {
+    throw new Error(`bing translate failed with status ${response.status}`);
+  }
+
+  const data = await response.json().catch(() => null);
+  // A rejected or expired token answers `statusCode: 205` with HTTP 200.
+  const statusCode = typeof data?.statusCode === 'number' ? data.statusCode : null;
+  if (statusCode !== null && statusCode !== 200) {
+    if (statusCode === 205 && retryAuth) {
+      // Drop the params this attempt used so the retry scrapes a fresh page,
+      // without discarding params another call may have just refreshed.
+      if (cachedAuth?.token === auth.token) cachedAuth = null;
+      return translateChunk(chunk, fromLang, toLang, token, false);
+    }
+    throw new Error(`bing translate failed with status ${statusCode}`);
+  }
+
+  if (Array.isArray(data) && data.length > 0 && data[0]?.translations) {
+    return data[0].translations[0]?.text || chunk;
+  }
+  return chunk;
+}
 
 export const azureProvider: TranslationProvider = {
   name: 'azure',
   label: _('Azure Translator'),
-  translate: async (text: string[], sourceLang: string, targetLang: string): Promise<string[]> => {
+  get authRequired() {
+    return !isTauriAppPlatform();
+  },
+  // Verified against the live endpoint: `The <b>quick</b> brown fox …` comes
+  // back as `那只<b>敏捷</b>的棕色狐狸 …`, with the tag on the matching word
+  // despite the reordering, with or without an explicit textType=html.
+  preservesMarkup: true,
+  translate: async (
+    text: string[],
+    sourceLang: string,
+    targetLang: string,
+    token?: string | null,
+  ): Promise<string[]> => {
     if (!text.length) return [];
+    if (!isTauriAppPlatform()) requireWebToken(token);
+
+    const normalized = sourceLang ? normalizeToFullLang(sourceLang) : '';
+    // Bing spells auto-detection `auto-detect`; an empty or `auto` source
+    // language means the same thing here.
+    const fromLang =
+      !normalized || normalized.toLowerCase() === 'auto' ? 'auto-detect' : normalized;
+    const toLang = normalizeToFullLang(targetLang);
 
     const results: string[] = [];
-    const msSourceLang = sourceLang ? normalizeToFullLang(sourceLang) : '';
-    const msTargetLang = normalizeToFullLang(targetLang);
-
-    const translationPromises = text.map(async (line, index) => {
-      if (!line?.trim().length) {
-        results[index] = line;
-        return;
-      }
-
-      const url = 'https://api-edge.cognitive.microsofttranslator.com/translate';
-      const params = new URLSearchParams({
-        to: msTargetLang,
-        'api-version': '3.0',
-      });
-      if (msSourceLang && msSourceLang.toLowerCase() !== 'auto') {
-        params.append('from', msSourceLang);
-      }
-
-      const token = await getAuthToken();
-      const fetch = isTauriAppPlatform() ? tauriFetch : window.fetch;
-      const response = await fetch(`${url}?${params.toString()}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify([{ Text: line }]),
-      });
-
-      if (!response.ok) {
-        throw new Error(`Translation failed with status ${response.status}`);
-      }
-
-      const data = await response.json();
-
-      if (Array.isArray(data) && data.length > 0 && data[0].translations) {
-        results[index] = data[0].translations[0].text || line;
-      } else {
-        results[index] = line;
-      }
-    });
-
-    await Promise.all(translationPromises);
+    await Promise.all(
+      text.map(async (line, index) => {
+        if (!line?.trim().length) {
+          results[index] = line;
+          return;
+        }
+        // Bing caps a single request at 1000 characters, so longer paragraphs
+        // go out as several chunks and are stitched back together.
+        const translated = await Promise.all(
+          splitTextIntoChunks(line, MAX_CHARS_PER_REQUEST).map((chunk) =>
+            translateChunk(chunk, fromLang, toLang, token),
+          ),
+        );
+        results[index] = translated.join('');
+      }),
+    );
 
     return results;
   },

--- a/apps/readest-app/src/services/translators/providers/azureShared.ts
+++ b/apps/readest-app/src/services/translators/providers/azureShared.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared constants and parsing for the Bing Translator web API: used both by
+ * the client provider ('./azure', which calls Bing directly on Tauri) and by
+ * the same-origin web proxy ('@/app/api/azure-translate/route'). Keep this
+ * module free of platform-specific imports so it loads in both bundles.
+ *
+ * Microsoft retired the tokenless endpoint the provider used to rely on
+ * (https://edge.microsoft.com/translate/auth now 404s for every request, as
+ * part of the Edge translation shutdown dated 2026-07-30), so the auth token
+ * is now taken from the www.bing.com/translator page the same way the Bing
+ * Translator frontend does.
+ */
+export const BING_ORIGIN = 'https://www.bing.com';
+export const BING_TRANSLATOR_URL = `${BING_ORIGIN}/translator`;
+export const BING_TRANSLATE_URL = `${BING_ORIGIN}/ttranslatev3`;
+export const BING_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+  'Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0';
+export const BING_REQUEST_HEADERS = {
+  'Content-Type': 'application/x-www-form-urlencoded',
+  'User-Agent': BING_USER_AGENT,
+  Referer: BING_TRANSLATOR_URL,
+};
+
+/**
+ * `key` and `token` authenticate the translate call; `ig` and `iid` are
+ * telemetry identifiers that the endpoint nonetheless rejects requests
+ * without (omitting them answers `statusCode: 400`).
+ */
+export interface BingAuthParams {
+  ig: string;
+  iid: string;
+  key: string;
+  token: string;
+  expiresAt: number;
+}
+
+// The page advertises a one-hour lifetime; retire the token slightly early so
+// a request already in flight cannot land just after it expires.
+const EXPIRY_SAFETY_MARGIN_MS = 60_000;
+
+export const isBingAuthParams = (value: unknown): value is BingAuthParams => {
+  const params = value as Partial<BingAuthParams> | null;
+  return (
+    !!params &&
+    typeof params.ig === 'string' &&
+    typeof params.iid === 'string' &&
+    typeof params.key === 'string' &&
+    typeof params.token === 'string' &&
+    typeof params.expiresAt === 'number'
+  );
+};
+
+/**
+ * Extracts the auth material the translate endpoint requires from the
+ * translator page markup. `now` is injected so the proxy can stamp the expiry
+ * against its own clock rather than trusting the page's timestamp, which
+ * would drift on a client whose clock is skewed.
+ */
+export const parseBingAuthParams = (html: string, now: number): BingAuthParams => {
+  // params_AbusePreventionHelper = [<key>,"<token>",<ttlMs>]
+  const abusePrevention = html.match(
+    /params_AbusePreventionHelper\s*=\s*\[\s*(\d+)\s*,\s*"([^"]+)"\s*,\s*(\d+)\s*\]/,
+  );
+  const ig = html.match(/IG\s*:\s*"([A-Fa-f0-9]+)"/);
+  const iid = html.match(/data-iid\s*=\s*"([^"]+)"/);
+
+  if (!abusePrevention || !ig || !iid) {
+    throw new Error('bing translate auth failed: could not parse the translator page');
+  }
+
+  return {
+    ig: ig[1]!,
+    iid: iid[1]!,
+    key: abusePrevention[1]!,
+    token: abusePrevention[2]!,
+    expiresAt: now + Math.max(Number(abusePrevention[3]) - EXPIRY_SAFETY_MARGIN_MS, 0),
+  };
+};

--- a/apps/readest-app/src/services/translators/providers/yandex.ts
+++ b/apps/readest-app/src/services/translators/providers/yandex.ts
@@ -3,6 +3,7 @@ import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import { isTauriAppPlatform } from '@/services/environment';
 import { normalizeToShortLang } from '@/utils/lang';
 import { TranslationProvider } from '../types';
+import { splitTextIntoChunks } from '../utils';
 import { YANDEX_REQUEST_HEADERS, YANDEX_SESSION_URL, YANDEX_TRANSLATE_URL } from './yandexShared';
 
 /**
@@ -179,53 +180,6 @@ async function getSession(token?: string | null, signal?: AbortSignal): Promise<
       signal.removeEventListener('abort', abort);
     });
   });
-}
-
-/**
- * Splits a long text into chunks of at most `maxLength` UTF-16 code units,
- * breaking on sentence ends, newlines or spaces whenever possible without
- * splitting a Unicode grapheme cluster.
- */
-function splitTextIntoChunks(text: string, maxLength: number): string[] {
-  if (text.length <= maxLength) return [text];
-
-  const boundaries = Array.from(
-    new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(text),
-    ({ index }) => index,
-  );
-  boundaries.push(text.length);
-
-  const chunks: string[] = [];
-  let start = 0;
-  while (start < text.length) {
-    let end = start;
-    for (const boundary of boundaries) {
-      if (boundary <= start) continue;
-      if (boundary - start > maxLength) break;
-      end = boundary;
-    }
-    if (end === start) {
-      throw new Error('yandex translate cannot fit a grapheme cluster within the request limit');
-    }
-
-    const window = text.slice(start, end);
-    let cut = end;
-    const sentenceEnd = Math.max(
-      window.lastIndexOf('. '),
-      window.lastIndexOf('! '),
-      window.lastIndexOf('? '),
-      window.lastIndexOf('\n'),
-    );
-    if (sentenceEnd > maxLength / 2) {
-      cut = start + sentenceEnd + 1;
-    } else {
-      const space = window.lastIndexOf(' ');
-      if (space > maxLength / 2) cut = start + space + 1;
-    }
-    chunks.push(text.slice(start, cut));
-    start = cut;
-  }
-  return chunks;
 }
 
 async function translateChunk(

--- a/apps/readest-app/src/services/translators/types.ts
+++ b/apps/readest-app/src/services/translators/types.ts
@@ -6,6 +6,15 @@ export interface TranslationProvider {
   authRequired?: boolean;
   quotaExceeded?: boolean;
   /**
+   * The upstream API carries inline HTML through translation, repositioning
+   * tags onto the semantically matching words in the target language. When set,
+   * the reader sends a paragraph's inline markup instead of its bare text so
+   * italics/bold/font-size runs survive (#1582); otherwise it sends plain text.
+   * Set this only for providers actually verified against the live API — a
+   * provider that echoes tags positionally would scramble the formatting.
+   */
+  preservesMarkup?: boolean;
+  /**
    * Marks a provider as temporarily unavailable. Disabled providers are
    * filtered out of `getTranslators()` / `getTranslator()`, so the UI never
    * lists them and the fallback logic in `useTranslator` skips over them.

--- a/apps/readest-app/src/services/translators/utils.ts
+++ b/apps/readest-app/src/services/translators/utils.ts
@@ -4,6 +4,54 @@ import { getLocale } from '@/utils/misc';
 
 const DAILY_USAGE_KEY = 'translationDailyUsage';
 
+/**
+ * Splits a long text into chunks of at most `maxLength` UTF-16 code units,
+ * breaking on sentence ends, newlines or spaces whenever possible without
+ * splitting a Unicode grapheme cluster. Shared by the providers whose upstream
+ * APIs cap the length of a single request.
+ */
+export function splitTextIntoChunks(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) return [text];
+
+  const boundaries = Array.from(
+    new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(text),
+    ({ index }) => index,
+  );
+  boundaries.push(text.length);
+
+  const chunks: string[] = [];
+  let start = 0;
+  while (start < text.length) {
+    let end = start;
+    for (const boundary of boundaries) {
+      if (boundary <= start) continue;
+      if (boundary - start > maxLength) break;
+      end = boundary;
+    }
+    if (end === start) {
+      throw new Error('translate cannot fit a grapheme cluster within the request limit');
+    }
+
+    const window = text.slice(start, end);
+    let cut = end;
+    const sentenceEnd = Math.max(
+      window.lastIndexOf('. '),
+      window.lastIndexOf('! '),
+      window.lastIndexOf('? '),
+      window.lastIndexOf('\n'),
+    );
+    if (sentenceEnd > maxLength / 2) {
+      cut = start + sentenceEnd + 1;
+    } else {
+      const space = window.lastIndexOf(' ');
+      if (space > maxLength / 2) cut = start + space + 1;
+    }
+    chunks.push(text.slice(start, cut));
+    start = cut;
+  }
+  return chunks;
+}
+
 export const saveDailyUsage = (usage: number, date?: string) => {
   if (typeof window !== 'undefined') {
     const isoDate = date || new Date().toISOString().split('T')[0]!;

--- a/apps/readest-app/src/utils/inlineTags.ts
+++ b/apps/readest-app/src/utils/inlineTags.ts
@@ -1,0 +1,41 @@
+/**
+ * Inline formatting tags — the single source of truth for "this element is a
+ * text run, not a block".
+ *
+ * Two consumers must agree on this set, which is why it lives here:
+ *
+ * - `getParagraphLayoutStyles()` treats a <div> as paragraph-like only when
+ *   every *descendant* is one of these, so a div carrying only inline markup
+ *   still gets line-height / indent / spacing overrides.
+ * - the translation sanitizer only keeps these tags, so preserved formatting
+ *   inside a translation can never contain a tag that would make the enclosing
+ *   source div fail the rule above and silently drop its layout.
+ *
+ * Anything injected into a book paragraph at runtime must use a tag from this
+ * list (or be added to it). `<font>` is here both because older EPUBs use it
+ * and because Readest's own translation wrapper is a <font>.
+ */
+export const INLINE_FORMATTING_TAGS = [
+  'a',
+  'b',
+  'em',
+  'i',
+  'strong',
+  'u',
+  'span',
+  'font',
+  'sup',
+  'sub',
+  'small',
+  'mark',
+] as const;
+
+export type InlineFormattingTag = (typeof INLINE_FORMATTING_TAGS)[number];
+
+/** Comma-separated form for use inside a CSS selector list. */
+export const INLINE_FORMATTING_SELECTOR = INLINE_FORMATTING_TAGS.join(', ');
+
+const tagSet: ReadonlySet<string> = new Set<string>(INLINE_FORMATTING_TAGS);
+
+export const isInlineFormattingTag = (tagName: string): boolean =>
+  tagSet.has(tagName.toLowerCase());

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -16,6 +16,7 @@ import {
 } from '@/styles/themes';
 import { createFontCSS, CustomFont } from '@/styles/fonts';
 import { readStoredAmbientIsDarkMode } from './ambientLight';
+import { INLINE_FORMATTING_SELECTOR } from './inlineTags';
 import { getOSPlatform } from './misc';
 import { SCROLL_WRAPPER_CLASS, SCROLL_WRAPPER_FIT_CLASS } from './scrollable';
 
@@ -570,7 +571,13 @@ const getParagraphLayoutStyles = (
       text-align: unset;
       hyphens: unset;
   }
-  p, blockquote, dd, div:not(:has(*:not(b, a, em, i, strong, u, span))) {
+  /* The div clause treats a div as paragraph-like only when every descendant is
+     inline formatting (INLINE_FORMATTING_TAGS). Anything injected into a book
+     paragraph at runtime — the translation target, its preserved markup, the
+     a11y skip link — must use a tag from that list, or the enclosing div drops
+     this whole rule and reverts to the book's default line spacing, indent and
+     hyphenation. */
+  p, blockquote, dd, div:not(:has(*:not(${INLINE_FORMATTING_SELECTOR}))) {
     line-height: ${lineSpacing} ${overrideLayout ? '!important' : ''};
     word-spacing: ${wordSpacing}px ${overrideLayout ? '!important' : ''};
     letter-spacing: ${letterSpacing}px ${overrideLayout ? '!important' : ''};
@@ -739,6 +746,11 @@ const getTranslationStyles = (showSource: boolean) => `
   .translation-source {
   }
   .translation-target {
+  }
+  /* The original is wrapped rather than erased so its CFIs stay resolvable;
+     cfi-skip keeps the wrapper invisible to CFI indexing. */
+  .translation-source-hidden {
+    display: none !important;
   }
   .translation-target.hidden {
     display: none !important;


### PR DESCRIPTION
## Why

Azure Translator stopped working entirely: every paragraph failed with
`Failed to get auth token: 404`. Microsoft retired
`https://edge.microsoft.com/translate/auth` as part of the Edge translation
shutdown dated **2026-07-30** — the whole `/translate/*` namespace on that host
now 404s for any UA, header or path variant. The translate API itself is still
alive (it answers a clean 401), but no public path can mint a token for it
anymore. Nothing regressed on our side; `azure.ts` had not changed since it was
written.

Fixing that surfaced three further problems in the same area, so they are fixed
together here.

## What changed

### 1. Azure Translator restored (first commit)

Auth material now comes from the `www.bing.com/translator` page and requests go
to `www.bing.com/ttranslatev3`, which returns the same response shape the
provider already parsed. Verified against the live service:

- **bing.com sends no CORS headers**, unlike the old Microsoft endpoints which
  allowed any origin. A browser cannot call it at all, so web builds go through
  a new same-origin proxy at `/api/azure-translate` (mirroring the existing
  yandex proxy: auth, origin check, rate limit, fixed endpoints only, no SSRF
  surface). The provider now reports `authRequired` in web builds. **Tauri is
  unaffected and still calls out directly with no sign-in.**
- **`IG` and `IID` are mandatory**, not telemetry decoration — omitting either
  is answered with `statusCode: 400`.
- **Failures hide inside HTTP 200**: an expired token is `statusCode: 205`, an
  over-long text is `statusCode: 400`. `response.ok` alone is not enough. A 205
  invalidates the cached params and retries once.
- **The cap is exactly 1000 UTF-16 code units**, counting code units rather than
  bytes — CJK and emoji measure the same as ASCII (1000 passes, 1001 fails, for
  all three). Longer texts are chunked, reusing the splitter that already lived
  in the yandex provider; it moves to `translators/utils` so both share it.

Outbound requests are capped at the concurrency the proxy allows. Bing
translates one text per request, so an unbounded fan-out over a page of
paragraphs had the surplus come straight back as 429.

### 2. Source paragraphs no longer lose their layout

`getParagraphLayoutStyles` treats a `<div>` as paragraph-like only when every
descendant is inline formatting. The translation target is appended inside the
source paragraph as a `<font>`, which was not on that list — so the div stopped
matching and silently dropped the **whole** rule: line-height, word and letter
spacing, text-indent and hyphenation all reverted to the book default. A book
that uses `<font>` markup of its own hit the same latent bug with no translation
involved.

The tag list becomes `INLINE_FORMATTING_TAGS`, shared by the layout rule and the
translation sanitizer so preserved formatting can never emit a tag that breaks
layout. This is the third time this rule has been broken this way (after the
a11y skip link), so the constant now carries the reasoning.

### 3. Translated text keeps its inline formatting — closes #1582

Formatting died because the pipeline sent `el.textContent` and wrote back plain
text. It now round-trips the paragraph's inline markup, because the translator
is what maps formatting onto the translated wording:

```
IN : The <b>quick</b> brown fox jumps over the <i>lazy</i> dog.
OUT: 那只<b>敏捷</b>的棕色狐狸跳过了那只<i>懒惰</i>的狗。
```

The tags land on the semantically matching words despite the reordering.
Providers declare this with a `preservesMarkup` capability flag, set only for
the provider actually verified against a live API; everything else falls back to
today's plain-text path.

The response is untrusted markup destined for the book DOM, so it is parsed
detached and rebuilt through an allowlist — never assigned as `innerHTML`.
Attributes use **echo validation**: an attribute survives only when that exact
tag/name/value appeared in the source we sent. So `<span class="whisper">` (the
small-font case in the issue) survives, while the response cannot introduce a
class, `href`, `style` or event handler of its own.

Markup is split at run boundaries so a formatted paragraph over the provider's
cap keeps its formatting rather than falling back. Formatting straddling a
boundary is re-opened in the next chunk, so every chunk is well-formed and
independently translatable. Content Readest injects (skip links, WordLens
glosses) is stripped before sending, so it is never translated as if it were
prose.

### 4. Highlights on the original survive hiding it

Hiding the original erased its text nodes, which destroyed the anchor for any
highlight on it. It is now wrapped in a `cfi-skip` element and hidden with CSS:
`cfi-skip` hoists the wrapper's children for indexing, so text nodes keep the
exact index and offset they had unwrapped. The stash-and-restore of original
text is no longer needed and is removed.

The target node also collapses from three nested wrappers to one, shortening the
CFI path into translated text and putting the block display on the element
itself rather than a block nested inside an inline parent. Since translations
are inserted lazily, each insert now asks the annotator to re-attach annotations
falling inside it.

**Translation nodes stay visible to CFI**, so highlights on translated text keep
working.

## Verification

- `pnpm test` — 8899 passed
- `pnpm test:browser` — 353 passed
- `pnpm lint`, `pnpm format:check` — clean
- No Rust, Lua or i18n changes.

Verified in Chrome against a real book:

- 21/21 proxy calls returned 200, **zero 429s**, console clean.
- All 4 markup-bearing paragraphs kept their formatting, including one at 3389
  characters of HTML that needed chunking. Before this change, 0 of 4 did.
- 8 `<div>` paragraphs, **0 with lost line-height**, no disallowed tags emitted
  into translations.

New regression tests cover the CFI invariants (including the original hidden),
the sanitizer's adversarial cases, the chunker's guarantees, and the
paragraph-layout rule under real `:has()`.

## Notes for review

- **Web builds now require sign-in for this provider**, because bing.com cannot
  be called from a browser and the proxy is authenticated, following the yandex
  precedent. Desktop and mobile are unaffected.
- `preservesMarkup` is enabled only for the provider verified against the live
  API. Google, DeepL and Yandex document equivalent modes but are left off until
  someone runs them.
- **Known, deliberate:** reading progress can still anchor inside translated
  text, since `paginator.js` excludes only `cfi-inert` nodes from its
  visible-range walk. On a book with no native `<font>` this makes *remote*
  progress sync fail (`Element index 0 out of bounds for tag font`). This is
  pre-existing and harmless locally. A fix keyed on `translation-element-mark`
  was considered and deliberately not taken, because translations are meant to
  stay visible to CFI.
- Collapsing the wrappers changes the CFI path into translated text, so a
  highlight saved inside translated text before this change will not resolve. It
  degrades silently (skipped, record kept) rather than mis-anchoring, and
  translated-text highlighting was not a shipped feature.
- The visual separator between original and translation, requested in a
  follow-up comment on #1582, is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
