### PR TITLE
feat(translate): preserve inline formatting with Google too

### DIFF
--- a/apps/readest-app/src/__tests__/services/translators/providers.test.ts
+++ b/apps/readest-app/src/__tests__/services/translators/providers.test.ts
@@ -965,3 +965,21 @@ describe('provider registry availability handling', () => {
     expect(getTranslatorDisplayLabel(google, true, (s) => s)).toBe('Google Translate');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Inline-markup capability (#1582)
+// ---------------------------------------------------------------------------
+describe('preservesMarkup capability', () => {
+  it('is enabled only for providers verified against their live API', async () => {
+    const { getTranslators } = await import('@/services/translators');
+    const capable = getTranslators()
+      .filter((translator) => translator.preservesMarkup)
+      .map((translator) => translator.name)
+      .sort();
+    // Bing/Azure and Google both reposition inline tags onto the matching
+    // words. DeepL must stay out: it drops <em> outright and empties <b> when a
+    // sentence also carries <i>, so markup would claim formatting that is not
+    // there. Yandex is simply unverified.
+    expect(capable).toEqual(['azure', 'google']);
+  });
+});

--- a/apps/readest-app/src/services/translators/providers/deepl.ts
+++ b/apps/readest-app/src/services/translators/providers/deepl.ts
@@ -12,6 +12,16 @@ export const deeplProvider: TranslationProvider = {
   name: 'deepl',
   label: _('DeepL'),
   authRequired: true,
+  // No `preservesMarkup`: round-tripping inline markup through this endpoint
+  // corrupts it, silently and inconsistently. Measured against the live API —
+  // `<b>` and `<i>` alone survive, but `<em>` is dropped outright, and when a
+  // sentence carries both bold and italic the bold content is moved outside
+  // its own tag, leaving an empty `<b></b>` so nothing renders bold. Losing
+  // the formatting while keeping the text (the plain-text path) is better than
+  // emitting markup that lies about it.
+  // DeepL proper supports `tag_handling=html`, but that would have to be set
+  // by the /deepl/translate service, which lives outside this repo; passing the
+  // field from here is ignored.
   quotaExceeded: false,
   translate: async (
     text: string[],

--- a/apps/readest-app/src/services/translators/providers/google.ts
+++ b/apps/readest-app/src/services/translators/providers/google.ts
@@ -7,6 +7,12 @@ import { TranslationProvider } from '../types';
 export const googleProvider: TranslationProvider = {
   name: 'google',
   label: _('Google Translate'),
+  // Verified against the live endpoint with the exact request built below:
+  // inline tags come back on the semantically matching words even when the
+  // sentence reorders, including nested tags, class and href attributes, and
+  // non-Latin targets. Note this needs no extra parameter — adding
+  // `format=html` makes the endpoint strip the tags instead of keeping them.
+  preservesMarkup: true,
   translate: async (text: string[], sourceLang: string, targetLang: string): Promise<string[]> => {
     if (!text.length) return [];
 


### PR DESCRIPTION
Follow-up to #5555, which landed inline-formatting preservation (#1582) but
enabled it for one provider only. This adds **Google**, and records why **DeepL**
is deliberately left out.

Both were measured against their real endpoints rather than their documentation.

| Case | Azure/Bing (#5555) | Google (this PR) | DeepL |
| --- | --- | --- | --- |
| `<b>` / `<i>` / `<strong>` alone | ok | ok | ok |
| `<em>` alone | ok | ok | **tag dropped entirely** |
| bold + italic in one sentence | ok | ok | **`<b></b>` emptied, nothing renders bold** |
| nested tags | ok | ok | — |
| `class` / `href` attributes | ok | ok | ok |
| non-Latin target | ok | ok | — |

## Google

Repositions inline tags onto the semantically matching words, the same way the
Bing endpoint does:

```
IN : The <b>quick</b> brown fox jumps over the <i>lazy</i> dog.
OUT: <b>敏捷</b>的棕色狐狸跳过了<i>懒惰</i>的狗。
```

It needs **no extra parameter** — verified with the exact request the provider
already builds. Adding `format=html` would be actively wrong: the endpoint then
*strips* the tags instead of keeping them.

This matters beyond one more provider: Google is the first markup-capable
provider reachable without a subscription.

## DeepL stays on the plain-text path

Round-tripping markup through `/deepl/translate` corrupts it silently and
**inconsistently**, which is worse than failing outright — `<b>`, `<i>` and
`<strong>` survive on their own, but `<em>` is dropped, and a sentence carrying
both bold and italic comes back with the bold content moved outside its own tag:

```
OUT: 敏捷的<b></b>棕色狐狸跳过<i>懒惰的</i>狗。
```

Keeping the text and losing the formatting is better than emitting markup that
claims formatting the reader cannot see. The measurements are recorded next to
the provider so nobody flips the flag later without evidence.

DeepL proper does support `tag_handling=html`, but that has to be set by the
`/deepl/translate` service, which lives outside this repo — passing the field
from the client is ignored.

## Note on #1582

`translationProvider` still defaults to `deepl`, so a user on default settings
continues to see unformatted translations. **#1582 should stay open** until
either that service sets `tag_handling` or the default changes.

## Verification

- `pnpm test` — 8900 passed; `pnpm lint`, `pnpm format:check` clean.
- A registry test asserts the capability list is exactly `['azure', 'google']`,
  so adding a provider to it becomes a deliberate act.
- Behaviour was verified at the provider's live endpoint. The in-app pipeline
  itself is provider-agnostic and was verified end to end in #5555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
