### PR TITLE
fix(reader): keep the cursor visible while text is selected

### DIFF
--- a/apps/readest-app/src/__tests__/reader/autohide-cursor.test.ts
+++ b/apps/readest-app/src/__tests__/reader/autohide-cursor.test.ts
@@ -13,6 +13,17 @@ const createView = (): HTMLElement => document.createElement('foliate-view');
 const move = (el: HTMLElement, screenX: number, screenY: number) =>
   el.dispatchEvent(new MouseEvent('mousemove', { screenX, screenY }));
 
+const selectText = () => {
+  const paragraph = document.createElement('p');
+  paragraph.textContent = 'a selected passage';
+  document.body.appendChild(paragraph);
+  const range = document.createRange();
+  range.selectNodeContents(paragraph);
+  const selection = document.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+};
+
 beforeAll(async () => {
   await import('foliate-js/view.js');
 });
@@ -23,6 +34,8 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  document.getSelection()?.removeAllRanges();
+  document.body.replaceChildren();
 });
 
 describe('foliate-view autohide-cursor', () => {
@@ -59,6 +72,38 @@ describe('foliate-view autohide-cursor', () => {
 
     move(view, 6, 9);
     expect(view.style.cursor).not.toBe('none');
+  });
+
+  test('keeps the cursor visible while a selection is active', () => {
+    const view = createView();
+    view.setAttribute('autohide-cursor', '');
+
+    // Arm the idle timer, then select without moving again: double-click and
+    // keyboard word selection fire no further mousemove.
+    move(view, 5, 5);
+    selectText();
+    vi.advanceTimersByTime(IDLE_HIDE_MS);
+    expect(view.style.cursor).not.toBe('none');
+
+    // A paused selection drag re-arms the timer while the selection stands.
+    move(view, 6, 9);
+    vi.advanceTimersByTime(IDLE_HIDE_MS);
+    expect(view.style.cursor).not.toBe('none');
+  });
+
+  test('hides again once the selection is cleared', () => {
+    const view = createView();
+    view.setAttribute('autohide-cursor', '');
+
+    move(view, 5, 5);
+    selectText();
+    vi.advanceTimersByTime(IDLE_HIDE_MS);
+    expect(view.style.cursor).not.toBe('none');
+
+    document.getSelection()!.removeAllRanges();
+    move(view, 6, 9);
+    vi.advanceTimersByTime(IDLE_HIDE_MS);
+    expect(view.style.cursor).toBe('none');
   });
 
   test('never hides without the attribute', () => {


### PR DESCRIPTION
## Problem

With **Auto-hide cursor** on, the pointer is blanked 1s after the last `mousemove` regardless of what the reader is doing, so it disappears in the middle of a text selection:

- **Paused selection drag** - you hold the button and stop to think about where to end the selection, and the cursor vanishes while you are still aiming with it.
- **Double-click word select** - fires no `mousemove` at all, so the already armed timer just runs and blanks the pointer on a brand new selection.

## Fix

foliate-js `CursorAutohider` now skips hiding while the element's document holds a non-collapsed selection (readest/foliate-js#68, merged).

The guard sits in `hide()` rather than at arm time, which is what makes it cover both cases: a selection created *after* the timer was armed (double-click) as well as the timer re-armed *while* a selection stands (paused drag).

`ownerDocument` resolves to the right scope for either instance: the top document for the host `<foliate-view>`, and the section's iframe document for the per-section clone created in `#onLoad`, which is where reader selections actually live.

## Behaviour notes

- No stuck-visible state: autohide resumes as soon as the selection collapses, which any click does, and the next mousemove re-arms the timer.
- The consuming actions (copy, share, search, TTS, highlight/annotate) deselect, so autohide comes straight back.
- The lookup popups deliberately keep the selection live while open (`Annotator.tsx`), so the cursor now also stays visible for as long as you are aiming at one, which is the behaviour you want there.
- Desktop only - autohide is already gated behind `!appService?.isMobile`.

## Testing

`src/__tests__/reader/autohide-cursor.test.ts` gains two cases, both confirmed failing against the old code before the fix (`expected 'none' not to be 'none'`). They drive the real foliate-js class through the real custom element, not a mock.

- `pnpm test` - 8901 passed, 16 skipped, no regressions
- `pnpm lint`, `pnpm format:check` - clean

No Rust or Lua changes, so those gates do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)