### PR TITLE
fix(annotator): draw the highlight color check in the content color

### DIFF
--- a/apps/readest-app/src/app/reader/components/annotator/HighlightOptions.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/HighlightOptions.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import React, { useEffect, useRef, useState } from 'react';
-import { FaCheckCircle } from 'react-icons/fa';
+import { FaCheck } from 'react-icons/fa';
 import { MdLibraryAddCheck } from 'react-icons/md';
 import { DEFAULT_HIGHLIGHT_COLORS, HighlightColor, HighlightStyle } from '@/types/book';
 import { useEnv } from '@/context/EnvContext';
@@ -71,6 +71,7 @@ const HighlightOptions: React.FC<HighlightOptionsProps> = ({
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const suppressTapRef = useRef(false);
   const colorStripRef = useRef<HTMLDivElement | null>(null);
+  const size10 = useResponsiveSize(10);
   const size16 = useResponsiveSize(16);
   const size30 = useResponsiveSize(30);
   const highlightOptionsHeightPx = useResponsiveSize(OPTIONS_HEIGHT_PIX);
@@ -312,14 +313,15 @@ const HighlightOptions: React.FC<HighlightOptionsProps> = ({
                   style={{
                     width: size16,
                     height: size16,
-                    backgroundColor: selectedColor !== color ? swatchColor : 'transparent',
+                    backgroundColor: isBwEink ? einkFgColor : swatchColor,
                   }}
-                  className='rounded-full p-0'
+                  className='flex items-center justify-center rounded-full p-0'
                 >
                   {selectedColor === color && (
-                    <FaCheckCircle
-                      size={size16}
-                      style={{ fill: isBwEink ? einkFgColor : swatchColor }}
+                    <FaCheck
+                      size={size10}
+                      className='text-base-content'
+                      style={isBwEink ? { color: einkBgColor } : undefined}
                     />
                   )}
                 </button>


### PR DESCRIPTION
The selected color swatch in the annotation popup drew its check with
`FaCheckCircle`, whose check glyph is knocked out of the disc rather than
painted. The glyph was therefore transparent and showed whatever sat behind the
swatch, which is the color strip (`bg-base-300`), so the check read as a pale
strip-colored mark instead of ink.

The swatch is now a plain colored circle with a `FaCheck` painted over it in
`base-content`.

Setting the button background to `bg-base-content` behind the knockout would
have been a smaller change, but FontAwesome insets its disc by 8 of 512 viewBox
units, so at 16px the content color would have leaked a quarter-pixel dark ring
around every selected swatch.

B&W e-ink keeps its inverted pair (foreground disc, background check), since
`base-content` there can match the disc and disappear.

## Verification

- `pnpm lint` passes.
- `pnpm test:browser` passes, including the `annotation-popup-layout` screenshot
  test that renders this exact strip. The glyph change stays inside the
  configured mismatch tolerance, so the stored baselines still match and were
  left untouched.
- Rendered the new swatch geometry in Chrome at 6x to confirm the check is
  centered, proportional to the 16px disc, and free of any edge ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
