### PR TITLE
fix(tts): keep the WebView alive while paused so Bluetooth Play resumes (#5561)

### DIFF
--- a/apps/readest-app/src/__tests__/services/tts-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller.test.ts
@@ -1442,14 +1442,50 @@ describe('TTSController', () => {
       expect(startKeepAlive).not.toHaveBeenCalled();
     });
 
-    test('stops the keep-alive when playback is paused', async () => {
+    // A paused session is still a live session: its lock-screen / Bluetooth
+    // transport handlers run in the WebView. Dropping the keep-alive at pause
+    // let Android freeze the hidden page, after which Play from a headset only
+    // flipped the notification (the media session lives in the app process)
+    // while the reader never woke up to speak. See #5561.
+    test('keeps the keep-alive running while paused so transport still reaches the page', async () => {
       const c = await makeAndroidNativeController();
       vi.spyOn(c, 'forward').mockResolvedValue();
       c.speak('<speak>hello</speak>');
       await vi.waitFor(() => expect(startKeepAlive).toHaveBeenCalled(), { timeout: 5000 });
+      startKeepAlive.mockClear();
+      stopKeepAlive.mockClear();
 
       await c.pause();
 
+      expect(startKeepAlive).toHaveBeenCalled();
+      expect(stopKeepAlive).not.toHaveBeenCalled();
+    });
+
+    // Buffered engines earn the exemption for free only while they are actually
+    // speaking; a paused WebAudio session emits nothing either, so it needs the
+    // tone exactly as the direct-speak engines do.
+    test('starts the keep-alive when a buffered (Edge) session is paused', async () => {
+      const c = await makeAndroidNativeController();
+      c.ttsClient = c.ttsEdgeClient; // mediaClock === true
+      vi.spyOn(c, 'forward').mockResolvedValue();
+      c.speak('<speak>hello</speak>');
+      await vi.waitFor(() => expect(c.state).toBe('playing'), { timeout: 5000 });
+      expect(startKeepAlive).not.toHaveBeenCalled();
+
+      await c.pause();
+
+      expect(startKeepAlive).toHaveBeenCalled();
+    });
+
+    test('does not keep the page awake while paused off Android', async () => {
+      await controller.initViewTTS(0);
+      vi.spyOn(controller, 'forward').mockResolvedValue();
+      controller.speak('<speak>hello</speak>');
+      await vi.waitFor(() => expect(controller.state).toBe('playing'), { timeout: 5000 });
+
+      await controller.pause();
+
+      expect(startKeepAlive).not.toHaveBeenCalled();
       expect(stopKeepAlive).toHaveBeenCalled();
     });
 

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -239,17 +239,25 @@ export class TTSController extends EventTarget {
     });
   }
 
-  // A direct-speak engine (Android system TTS) renders its audio in the OS, not
-  // the WebView, and advances sentence-to-sentence from JS timers here. With the
-  // screen locked the hidden WebView would be throttled/frozen and that loop
-  // stalls — so keep an inaudible tone playing to hold the page "audible" and
-  // its timers alive, exactly the exemption Edge/WebAudio playback earns for
-  // free. Android-only (iOS drives playout through its own native audio
-  // session); a no-op for buffered engines that already emit audible output.
-  // See #4408.
-  #syncNativeAudioKeepAlive() {
+  // Keep the hidden WebView schedulable, in the two cases where it would
+  // otherwise fall silent and get frozen by Chromium. Android-only (iOS drives
+  // playout through its own native audio session).
+  //
+  //   - Playing a direct-speak engine (Android system TTS): its audio renders
+  //     in the OS, not the WebView, and the sentence-to-sentence advance runs
+  //     on JS timers here, so the loop stalls once the page is throttled. See
+  //     #4408. Buffered engines earn the exemption for free while speaking.
+  //
+  //   - Paused, whatever the engine: no engine emits audio while paused, and
+  //     the media-session play/pause/next handlers live in this page. Let it
+  //     freeze and Play from a Bluetooth headset only flips the notification —
+  //     the native foreground service answers, the reader never wakes to speak,
+  //     and the in-app player drifts out of sync until the app is foregrounded.
+  //     See #5561.
+  #syncAudioKeepAlive() {
+    const directSpeak = this.ttsClient.getCapabilities().mediaClock === false;
     const needsKeepAlive =
-      !!this.appService?.isAndroidApp && this.ttsClient.getCapabilities().mediaClock === false;
+      !!this.appService?.isAndroidApp && (directSpeak || this.state.includes('paused'));
     if (needsKeepAlive) {
       startAudioKeepAlive();
     } else {
@@ -990,8 +998,8 @@ export class TTSController extends EventTarget {
   // left to pause on.
   async #stopAtChapterBoundary() {
     if (await this.#initTTSForNextSection()) {
-      stopAudioKeepAlive();
       this.state = 'forward-paused';
+      this.#syncAudioKeepAlive();
     } else {
       this.#terminate('ended');
       await this.stop();
@@ -1082,7 +1090,7 @@ export class TTSController extends EventTarget {
       try {
         console.log('[TTS] speak');
         this.state = 'playing';
-        this.#syncNativeAudioKeepAlive();
+        this.#syncAudioKeepAlive();
 
         signal.addEventListener('abort', () => {
           resolve();
@@ -1245,7 +1253,7 @@ export class TTSController extends EventTarget {
 
   async pause() {
     this.state = 'paused';
-    stopAudioKeepAlive();
+    this.#syncAudioKeepAlive();
     if (!(await this.ttsClient.pause().catch((e) => this.error(e)))) {
       await this.stop();
       this.state = 'stop-paused';

--- a/apps/readest-app/src/services/tts/WebAudioPlayer.ts
+++ b/apps/readest-app/src/services/tts/WebAudioPlayer.ts
@@ -125,21 +125,26 @@ export const ensureSharedAudioContext = async (): Promise<void> => {
   }
 };
 
-// Inaudible background keep-alive for direct-speak engines (Android system TTS).
+// Inaudible background keep-alive for a page that must stay schedulable.
 //
-// When the screen locks the WebView page becomes hidden, and Chromium throttles
-// (and eventually freezes) a hidden page's timers and task queues — which stalls
-// the JS-driven per-sentence auto-advance loop that direct-speak engines rely on
-// (their audio renders in the external TTS engine, not the WebView). A page that
-// is emitting audio is exempt from that throttling: that is precisely why Edge
-// TTS keeps reading with the screen off (its speech is audible WebAudio output)
-// while system TTS stops after a page. Merely having a running-but-idle context
-// does NOT earn the exemption — Chromium keys off actual, non-silent output — so
-// we play a continuous 40 Hz tone at ~-62 dBFS: below the reach of phone
-// speakers and masked to inaudibility by the speech, but non-silent enough to
-// keep the page "audible" and its timers alive. See #4408.
+// When the app is backgrounded (or the screen locks) the WebView page becomes
+// hidden, and Chromium throttles — then outright freezes — a hidden page's
+// timers and task queues. A page that is emitting audio is exempt: that is
+// precisely why Edge TTS keeps reading with the screen off (its speech is
+// audible WebAudio output) while system TTS stops after a page. Merely having a
+// running-but-idle context does NOT earn the exemption — Chromium keys off
+// actual, non-silent output — so we play a continuous 40 Hz tone at ~-62 dBFS:
+// below the reach of phone speakers and masked to inaudibility by the speech,
+// but non-silent enough to keep the page "audible" and its timers alive.
+//
+// Two things depend on it: the JS-driven per-sentence auto-advance loop that
+// direct-speak engines rely on while playing (#4408), and — for EVERY engine —
+// the media-session transport handlers of a *paused* session, which live in the
+// page even though the notification itself is served by the native foreground
+// service (#5561).
 const KEEP_ALIVE_FREQ_HZ = 40;
 const KEEP_ALIVE_GAIN = 0.0008;
+let keepAliveCtx: AudioContext | null = null;
 let keepAliveOsc: OscillatorNode | null = null;
 let keepAliveGain: GainNode | null = null;
 
@@ -147,9 +152,15 @@ export const startAudioKeepAlive = (): void => {
   if (typeof AudioContext === 'undefined') return;
   if (keepAliveOsc) return;
   try {
-    const ctx = getSharedContext() as unknown as AudioContext;
-    // The gesture handler already resumed the shared context; nudge it best-
-    // effort in case autoplay policy left it suspended.
+    // A context of its OWN, never the shared one: buffered engines suspend the
+    // shared context to pause (WebAudioPlayer.pauseContext), which would
+    // silence the tone exactly when a paused session needs it — and resuming
+    // that context to feed the tone would un-pause the speech.
+    if (!keepAliveCtx) keepAliveCtx = new AudioContext();
+    const ctx = keepAliveCtx;
+    // TTS only ever starts from a user gesture, so the page has sticky
+    // activation and the context comes up running; nudge it best-effort in
+    // case autoplay policy left it suspended.
     if (ctx.state !== 'running') void ctx.resume();
     const osc = ctx.createOscillator();
     osc.frequency.value = KEEP_ALIVE_FREQ_HZ;
@@ -171,9 +182,15 @@ export const stopAudioKeepAlive = (): void => {
     keepAliveOsc?.stop();
     keepAliveOsc?.disconnect();
     keepAliveGain?.disconnect();
+    // Close rather than suspend: an idle-but-running context still renders
+    // silence to an open output stream, and unlike the shared context this one
+    // has no other use. A later start() builds a fresh one, which is also the
+    // path that has to work when Pause arrives with the app already hidden.
+    void keepAliveCtx?.close();
   } catch (err) {
     console.warn('[TTS] audio keep-alive stop failed', err);
   }
+  keepAliveCtx = null;
   keepAliveOsc = null;
   keepAliveGain = null;
 };


### PR DESCRIPTION
Fixes #5561.

## Symptom

Pause read-aloud from a Bluetooth headset, wait a few seconds, press Play: nothing happens. The reading session is clearly still alive, because opening Readest and pressing Play in-app resumes from the same position. Reported against five different Android TextToSpeech engines.

## Root cause

`TTSController.pause()` called `stopAudioKeepAlive()`. That inaudible 40 Hz tone (added in #4408) is the only thing making the WebView page *audible*, and audibility is what exempts a hidden page from Chromium's throttle-then-freeze of its task queues.

So once the session is paused and the app is backgrounded, the page emits nothing and freezes. The media-session transport handlers (`ttsMediaBridge` -> `TTSController`) live in that page.

`MediaPlaybackService` runs in the app's main process, which the foreground service keeps alive, so the native half keeps answering: the lock-screen card flips to PLAYING and the silent ExoPlayer keep-alive resumes. But no speech starts, and the in-app mini player drifts out of sync. Foregrounding the app thaws the page, which is why in-app Play always worked.

## Not engine-specific

The report said Edge TTS was unaffected. Measured on a Xiaomi 13 / Android 16, Edge freezes at the same point as system TTS, so that was most likely a shorter test rather than immunity. The fix therefore covers every engine while paused.

Page timers, app backgrounded and session paused:

| Condition | Page timers |
| --- | --- |
| No keep-alive, system TTS | dead after 68s |
| No keep-alive, Edge | dead after 68s |
| Web Lock held | dead after 71s (not a freeze blocker on Android WebView) |
| Keep-alive tone, created while visible | 117s, no gaps |
| Keep-alive tone, created while hidden | 167s, no gaps, still ticking |

## Change

- `TTSController`: `#syncNativeAudioKeepAlive` becomes `#syncAudioKeepAlive`, gated on `isAndroidApp && (mediaClock === false || state.includes('paused'))`. Called from `pause()` and `#stopAtChapterBoundary()`. `#terminate()` and `shutdown()` still stop the tone outright, since that is the session actually ending.
- `WebAudioPlayer`: the tone moves to its own `AudioContext`. Buffered engines pause by suspending the *shared* context (`pauseContext`), which would silence the tone exactly when a paused session needs it, and resuming that context to feed the tone would un-pause the speech. `stopAudioKeepAlive` now closes the dedicated context so an idle one does not hold an output stream open.

A fresh `AudioContext` created while `visibilityState === 'hidden'` comes up `running` (sticky activation from the gesture that started TTS), which is what makes creating it at pause time safe when Pause arrives from the headset.

## Verification

Built with `pnpm dev-android` and installed on a Xiaomi 13 (Android 16) with a Bluetooth headset connected, using system TTS:

- Backgrounded, paused, waited 150s (the previous build's page died at 68s), then Play produced four Google TTS synthesis requests. Speech resumed and the in-app player stayed in sync.
- Confirmed with the physical headset button as well.

Note for anyone reproducing this on MIUI: `adb shell input keyevent 126/127/85` is **not** equivalent to a Bluetooth button. Logcat shows `SmartPower: press media key`, and MIUI un-throttles the app on a media-key press, so software keys always resume and hide the bug. `adb shell cmd media_session dispatch play` takes the same `dispatchMediaKeyEvent` path AVRCP uses and does reproduce it.

Unit tests: three cases in `tts-controller.test.ts` covering paused direct-speak, paused buffered, and paused off-Android. The previous "stops the keep-alive when playback is paused" test encoded the bug and was replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)