### PR TITLE
chore(store): replace Play listing images instead of appending

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,7 +24,12 @@ platform :android do
       skip_upload_metadata: false,
       skip_upload_images: false,
       skip_upload_screenshots: false,
-      skip_upload_changelogs: false
+      skip_upload_changelogs: false,
+      # Without this supply ADDS images instead of replacing them, so a release
+      # would leave the previous set on the listing alongside the new one and
+      # push the phone screenshots past Play's limit of 8. With it, whatever is
+      # in metadata-play is exactly what the listing ends up with.
+      sync_image_upload: true
     )
   end
   

--- a/fastlane/metadata/README.md
+++ b/fastlane/metadata/README.md
@@ -78,7 +78,10 @@ correctly on both Play and F-Droid.
 Editing these files now changes the live listings on the next release run.
 
 - **Play** — `upload_production` uploads metadata, images, screenshots and
-  changelogs from `metadata-play`. The `upload_internal` and `upload_beta` lanes
+  changelogs from `metadata-play`, with `sync_image_upload: true` so the upload
+  REPLACES the live imagery instead of adding to it. This directory is therefore
+  authoritative: anything added by hand in Play Console and not mirrored here
+  gets deleted on the next release. The `upload_internal` and `upload_beta` lanes
   still skip all of it on purpose: Play's listing text and imagery are
   store-level, not track-level, so uploading from a test track would rewrite the
   live production listing.


### PR DESCRIPTION
Follow-up to #5573, which left this as the one open flag.

`supply`'s `sync_image_upload` defaults to **false**, meaning an upload adds images to whatever is already on the listing rather than replacing them. The next release would have left the old screenshots in place alongside the new ones, putting the phone set at 10 images against Play's limit of 8.

With it on, `fastlane/metadata-play` becomes authoritative: the listing ends up with exactly what the directory holds.

The trade-off, now written into the README: anything added by hand in Play Console and not mirrored in the repo gets deleted on the next release. That is the intended behaviour given the point of #5573 was to make this directory the source of truth, but it is worth knowing before the first automated run.

Only `upload_production` is affected. `upload_internal` and `upload_beta` still set `skip_upload_images: true`, so the flag never applies to them.