### PR TITLE
fix(opds): make the title bar draggable in the online library view

### DIFF
--- a/apps/readest-app/src/__tests__/app/opds/navigation-titlebar.test.tsx
+++ b/apps/readest-app/src/__tests__/app/opds/navigation-titlebar.test.tsx
@@ -1,0 +1,83 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Navigation } from '@/app/opds/components/Navigation';
+
+const startDragging = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: { hasWindowBar: true, isMobile: false } }),
+}));
+
+vi.mock('@/context/DropdownContext', () => ({
+  useDropdownContext: () => null,
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+vi.mock('@/hooks/useTrafficLight', () => ({
+  useTrafficLight: () => ({ isTrafficLightVisible: false }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: { globalViewSettings: { isEink: false } } }),
+}));
+
+vi.mock('@/services/environment', () => ({
+  isTauriAppPlatform: () => true,
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    startDragging,
+    toggleMaximize: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+const renderNavigation = () =>
+  render(
+    <Navigation
+      onGoStart={vi.fn()}
+      onSearch={vi.fn()}
+      canGoBack={false}
+      canGoForward={false}
+      hasSearch={true}
+    />,
+  );
+
+const mouseDown = async (element: Element) => {
+  await act(async () => {
+    fireEvent.mouseDown(element, { buttons: 1, detail: 1 });
+    await Promise.resolve();
+  });
+};
+
+describe('OPDS Navigation title bar dragging (issue #5584)', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('drags the window when the OPDS header chrome is pressed', async () => {
+    renderNavigation();
+
+    await mouseDown(screen.getByRole('banner'));
+
+    expect(startDragging).toHaveBeenCalledOnce();
+  });
+
+  it('does not drag the window when the search field is pressed', async () => {
+    renderNavigation();
+
+    await mouseDown(screen.getByPlaceholderText('Search in OPDS Catalog...'));
+
+    expect(startDragging).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/app/opds/components/Navigation.tsx
+++ b/apps/readest-app/src/app/opds/components/Navigation.tsx
@@ -143,7 +143,7 @@ export function Navigation({
       </div>
 
       <div className='flex-grow px-3 sm:px-5'>
-        <div className='relative flex w-full items-center'>
+        <div className='exclude-title-bar-mousedown relative flex w-full items-center'>
           <span className='text-base-content/50 absolute left-3'>
             <FaSearch className='h-4 w-4' />
           </span>
@@ -258,6 +258,7 @@ export function Navigation({
 
         <WindowButtons
           className='window-buttons flex h-full items-center'
+          headerRef={headerRef}
           onClose={() => {
             handleGoLibrary();
           }}

--- a/apps/readest-app/src/components/WindowButtons.tsx
+++ b/apps/readest-app/src/components/WindowButtons.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from '@/hooks/useTranslation';
 
 interface WindowButtonsProps {
   className?: string;
-  headerRef?: React.RefObject<HTMLDivElement | null>;
+  headerRef?: React.RefObject<HTMLElement | null>;
   showMinimize?: boolean;
   showMaximize?: boolean;
   showClose?: boolean;


### PR DESCRIPTION
Closes #5584

## Problem

On desktop, the window cannot be dragged by its title bar while the OPDS online library is open. The reader and library title bars drag normally.

## Root cause

Window dragging is not native: `WindowButtons` attaches `mousedown` / `pointer*` listeners to the page's header element and calls `getCurrentWindow().startDragging()`. It only does so when it receives a `headerRef`:

```ts
const headerElement = headerRef?.current;
if (!headerElement) return;
```

The OPDS `Navigation` header created a `headerRef` for traffic-light centering but never passed it to `WindowButtons`, so the effect bailed out and no drag listener was ever installed. Library, reader, auth, and profile headers all pass theirs, which is why only the online library view is affected. The gap has been there since the OPDS browser was added.

## Fix

- Pass `headerRef` to `WindowButtons` in the OPDS header.
- Widen the `headerRef` prop to `RefObject<HTMLElement | null>` so the OPDS `<header>` element fits (previously `HTMLDivElement`), matching what `useTrafficLight` already accepts.
- Mark the search field wrapper with `exclude-title-bar-mousedown`, the same exclusion `LibraryHeader` puts on its search box, so pressing the search input focuses it instead of starting a window drag now that the header is a drag surface.

Back / forward / home / add-catalog buttons and the facets dropdown were already excluded by the existing `.btn` and `.dropdown-container` rules.

## Testing

- New `src/__tests__/app/opds/navigation-titlebar.test.tsx`: pressing the OPDS header chrome starts a window drag; pressing the search field does not. The first case fails before the fix.
- `pnpm test` (8954 passed), `pnpm lint`, `pnpm -w format:check` all green via the pre-push hook.

Not verified by dragging the window in a running macOS build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)