### PR TITLE
fix(opds): filter incompatible download formats and offer one-click EPUB

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2226,5 +2226,7 @@
   "Danger Zone": "منطقة الخطر",
   "Delete All Books": "حذف جميع الكتب",
   "All books deleted.": "تم حذف جميع الكتب.",
-  "Failed to delete books. Please try again later.": "تعذّر حذف الكتب. يرجى المحاولة مرة أخرى لاحقًا."
+  "Failed to delete books. Please try again later.": "تعذّر حذف الكتب. يرجى المحاولة مرة أخرى لاحقًا.",
+  "Download {{format}}": "تنزيل {{format}}",
+  "More formats": "صيغ أخرى"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2042,5 +2042,7 @@
   "Danger Zone": "বিপজ্জনক অঞ্চল",
   "Delete All Books": "সমস্ত বই মুছুন",
   "All books deleted.": "সমস্ত বই মুছে ফেলা হয়েছে।",
-  "Failed to delete books. Please try again later.": "বই মুছতে ব্যর্থ হয়েছে। পরে আবার চেষ্টা করুন।"
+  "Failed to delete books. Please try again later.": "বই মুছতে ব্যর্থ হয়েছে। পরে আবার চেষ্টা করুন।",
+  "Download {{format}}": "{{format}} ডাউনলোড করুন",
+  "More formats": "আরও ফরম্যাট"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1996,5 +1996,7 @@
   "Danger Zone": "ཉེན་ཁའི་ས་ཁུལ།",
   "Delete All Books": "དེབ་ཡོངས་རྫོགས་བསུབ།",
   "All books deleted.": "དེབ་ཡོངས་རྫོགས་བསུབས་ཟིན།",
-  "Failed to delete books. Please try again later.": "དེབ་བསུབ་མ་ཐུབ། རྗེས་སུ་ཡང་བསྐྱར་ཚོད་ལྟ་གནང་།"
+  "Failed to delete books. Please try again later.": "དེབ་བསུབ་མ་ཐུབ། རྗེས་སུ་ཡང་བསྐྱར་ཚོད་ལྟ་གནང་།",
+  "Download {{format}}": "{{format}} ཕབ་ལེན།",
+  "More formats": "རྣམ་པ་གཞན།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2042,5 +2042,7 @@
   "Danger Zone": "Gefahrenzone",
   "Delete All Books": "Alle Bücher löschen",
   "All books deleted.": "Alle Bücher gelöscht.",
-  "Failed to delete books. Please try again later.": "Bücher konnten nicht gelöscht werden. Bitte versuchen Sie es später erneut."
+  "Failed to delete books. Please try again later.": "Bücher konnten nicht gelöscht werden. Bitte versuchen Sie es später erneut.",
+  "Download {{format}}": "{{format}} herunterladen",
+  "More formats": "Weitere Formate"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2042,5 +2042,7 @@
   "Danger Zone": "Ζώνη κινδύνου",
   "Delete All Books": "Διαγραφή όλων των βιβλίων",
   "All books deleted.": "Όλα τα βιβλία διαγράφηκαν.",
-  "Failed to delete books. Please try again later.": "Αποτυχία διαγραφής βιβλίων. Δοκιμάστε ξανά αργότερα."
+  "Failed to delete books. Please try again later.": "Αποτυχία διαγραφής βιβλίων. Δοκιμάστε ξανά αργότερα.",
+  "Download {{format}}": "Λήψη {{format}}",
+  "More formats": "Περισσότερες μορφές"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2088,5 +2088,7 @@
   "Danger Zone": "Zona de peligro",
   "Delete All Books": "Eliminar todos los libros",
   "All books deleted.": "Todos los libros eliminados.",
-  "Failed to delete books. Please try again later.": "No se pudieron eliminar los libros. Inténtalo de nuevo más tarde."
+  "Failed to delete books. Please try again later.": "No se pudieron eliminar los libros. Inténtalo de nuevo más tarde.",
+  "Download {{format}}": "Descargar {{format}}",
+  "More formats": "Más formatos"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2042,5 +2042,7 @@
   "Danger Zone": "منطقه خطر",
   "Delete All Books": "حذف همه کتاب‌ها",
   "All books deleted.": "همه کتاب‌ها حذف شدند.",
-  "Failed to delete books. Please try again later.": "حذف کتاب‌ها انجام نشد. لطفاً بعداً دوباره تلاش کنید."
+  "Failed to delete books. Please try again later.": "حذف کتاب‌ها انجام نشد. لطفاً بعداً دوباره تلاش کنید.",
+  "Download {{format}}": "دانلود {{format}}",
+  "More formats": "قالب‌های دیگر"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2088,5 +2088,7 @@
   "Danger Zone": "Zone de danger",
   "Delete All Books": "Supprimer tous les livres",
   "All books deleted.": "Tous les livres ont été supprimés.",
-  "Failed to delete books. Please try again later.": "Échec de la suppression des livres. Veuillez réessayer plus tard."
+  "Failed to delete books. Please try again later.": "Échec de la suppression des livres. Veuillez réessayer plus tard.",
+  "Download {{format}}": "Télécharger {{format}}",
+  "More formats": "Autres formats"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2088,5 +2088,7 @@
   "Danger Zone": "אזור מסוכן",
   "Delete All Books": "מחק את כל הספרים",
   "All books deleted.": "כל הספרים נמחקו.",
-  "Failed to delete books. Please try again later.": "מחיקת הספרים נכשלה. נסה שוב מאוחר יותר."
+  "Failed to delete books. Please try again later.": "מחיקת הספרים נכשלה. נסה שוב מאוחר יותר.",
+  "Download {{format}}": "הורדת {{format}}",
+  "More formats": "תבניות נוספות"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2042,5 +2042,7 @@
   "Danger Zone": "खतरनाक क्षेत्र",
   "Delete All Books": "सभी पुस्तकें हटाएँ",
   "All books deleted.": "सभी पुस्तकें हटा दी गईं।",
-  "Failed to delete books. Please try again later.": "पुस्तकें हटाने में विफल। कृपया बाद में पुनः प्रयास करें।"
+  "Failed to delete books. Please try again later.": "पुस्तकें हटाने में विफल। कृपया बाद में पुनः प्रयास करें।",
+  "Download {{format}}": "{{format}} डाउनलोड करें",
+  "More formats": "अन्य प्रारूप"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2042,5 +2042,7 @@
   "Danger Zone": "Veszélyzóna",
   "Delete All Books": "Összes könyv törlése",
   "All books deleted.": "Az összes könyv törölve.",
-  "Failed to delete books. Please try again later.": "Nem sikerült törölni a könyveket. Kérjük, próbálja újra később."
+  "Failed to delete books. Please try again later.": "Nem sikerült törölni a könyveket. Kérjük, próbálja újra később.",
+  "Download {{format}}": "{{format}} letöltése",
+  "More formats": "További formátumok"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1996,5 +1996,7 @@
   "Danger Zone": "Zona Berbahaya",
   "Delete All Books": "Hapus Semua Buku",
   "All books deleted.": "Semua buku telah dihapus.",
-  "Failed to delete books. Please try again later.": "Gagal menghapus buku. Silakan coba lagi nanti."
+  "Failed to delete books. Please try again later.": "Gagal menghapus buku. Silakan coba lagi nanti.",
+  "Download {{format}}": "Unduh {{format}}",
+  "More formats": "Format lainnya"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2088,5 +2088,7 @@
   "Danger Zone": "Zona pericolosa",
   "Delete All Books": "Elimina tutti i libri",
   "All books deleted.": "Tutti i libri sono stati eliminati.",
-  "Failed to delete books. Please try again later.": "Impossibile eliminare i libri. Riprova più tardi."
+  "Failed to delete books. Please try again later.": "Impossibile eliminare i libri. Riprova più tardi.",
+  "Download {{format}}": "Scarica {{format}}",
+  "More formats": "Altri formati"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1996,5 +1996,7 @@
   "Danger Zone": "危険な操作",
   "Delete All Books": "すべての本を削除",
   "All books deleted.": "すべての本を削除しました。",
-  "Failed to delete books. Please try again later.": "本の削除に失敗しました。しばらくしてからもう一度お試しください。"
+  "Failed to delete books. Please try again later.": "本の削除に失敗しました。しばらくしてからもう一度お試しください。",
+  "Download {{format}}": "{{format}} をダウンロード",
+  "More formats": "他の形式"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1996,5 +1996,7 @@
   "Danger Zone": "위험 구역",
   "Delete All Books": "모든 책 삭제",
   "All books deleted.": "모든 책이 삭제되었습니다.",
-  "Failed to delete books. Please try again later.": "책을 삭제하지 못했습니다. 나중에 다시 시도해 주세요."
+  "Failed to delete books. Please try again later.": "책을 삭제하지 못했습니다. 나중에 다시 시도해 주세요.",
+  "Download {{format}}": "{{format}} 다운로드",
+  "More formats": "다른 형식"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1996,5 +1996,7 @@
   "Danger Zone": "Zon Bahaya",
   "Delete All Books": "Padam Semua Buku",
   "All books deleted.": "Semua buku telah dipadam.",
-  "Failed to delete books. Please try again later.": "Gagal memadam buku. Sila cuba lagi kemudian."
+  "Failed to delete books. Please try again later.": "Gagal memadam buku. Sila cuba lagi kemudian.",
+  "Download {{format}}": "Muat turun {{format}}",
+  "More formats": "Format lain"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2042,5 +2042,7 @@
   "Danger Zone": "Gevarenzone",
   "Delete All Books": "Alle boeken verwijderen",
   "All books deleted.": "Alle boeken verwijderd.",
-  "Failed to delete books. Please try again later.": "Kan boeken niet verwijderen. Probeer het later opnieuw."
+  "Failed to delete books. Please try again later.": "Kan boeken niet verwijderen. Probeer het later opnieuw.",
+  "Download {{format}}": "{{format}} downloaden",
+  "More formats": "Meer formaten"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2134,5 +2134,7 @@
   "Danger Zone": "Strefa zagrożenia",
   "Delete All Books": "Usuń wszystkie książki",
   "All books deleted.": "Usunięto wszystkie książki.",
-  "Failed to delete books. Please try again later.": "Nie udało się usunąć książek. Spróbuj ponownie później."
+  "Failed to delete books. Please try again later.": "Nie udało się usunąć książek. Spróbuj ponownie później.",
+  "Download {{format}}": "Pobierz {{format}}",
+  "More formats": "Więcej formatów"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2088,5 +2088,7 @@
   "Danger Zone": "Zona de perigo",
   "Delete All Books": "Excluir todos os livros",
   "All books deleted.": "Todos os livros foram excluídos.",
-  "Failed to delete books. Please try again later.": "Falha ao excluir os livros. Tente novamente mais tarde."
+  "Failed to delete books. Please try again later.": "Falha ao excluir os livros. Tente novamente mais tarde.",
+  "Download {{format}}": "Baixar {{format}}",
+  "More formats": "Mais formatos"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2088,5 +2088,7 @@
   "Danger Zone": "Zona de perigo",
   "Delete All Books": "Eliminar todos os livros",
   "All books deleted.": "Todos os livros foram eliminados.",
-  "Failed to delete books. Please try again later.": "Não foi possível eliminar os livros. Tente novamente mais tarde."
+  "Failed to delete books. Please try again later.": "Não foi possível eliminar os livros. Tente novamente mais tarde.",
+  "Download {{format}}": "Transferir {{format}}",
+  "More formats": "Mais formatos"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2088,5 +2088,7 @@
   "Danger Zone": "Zonă periculoasă",
   "Delete All Books": "Ștergeți toate cărțile",
   "All books deleted.": "Toate cărțile au fost șterse.",
-  "Failed to delete books. Please try again later.": "Ștergerea cărților a eșuat. Încercați din nou mai târziu."
+  "Failed to delete books. Please try again later.": "Ștergerea cărților a eșuat. Încercați din nou mai târziu.",
+  "Download {{format}}": "Descarcă {{format}}",
+  "More formats": "Mai multe formate"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2134,5 +2134,7 @@
   "Danger Zone": "Опасная зона",
   "Delete All Books": "Удалить все книги",
   "All books deleted.": "Все книги удалены.",
-  "Failed to delete books. Please try again later.": "Не удалось удалить книги. Повторите попытку позже."
+  "Failed to delete books. Please try again later.": "Не удалось удалить книги. Повторите попытку позже.",
+  "Download {{format}}": "Скачать {{format}}",
+  "More formats": "Другие форматы"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2042,5 +2042,7 @@
   "Danger Zone": "අනතුරුදායක කලාපය",
   "Delete All Books": "සියලු පොත් මකන්න",
   "All books deleted.": "සියලු පොත් මකා දමන ලදී.",
-  "Failed to delete books. Please try again later.": "පොත් මැකීමට අසමත් විය. පසුව නැවත උත්සාහ කරන්න."
+  "Failed to delete books. Please try again later.": "පොත් මැකීමට අසමත් විය. පසුව නැවත උත්සාහ කරන්න.",
+  "Download {{format}}": "{{format}} බාගන්න",
+  "More formats": "තවත් ආකෘති"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2134,5 +2134,7 @@
   "Danger Zone": "Nevarno območje",
   "Delete All Books": "Izbriši vse knjige",
   "All books deleted.": "Vse knjige so izbrisane.",
-  "Failed to delete books. Please try again later.": "Knjig ni bilo mogoče izbrisati. Poskusite znova pozneje."
+  "Failed to delete books. Please try again later.": "Knjig ni bilo mogoče izbrisati. Poskusite znova pozneje.",
+  "Download {{format}}": "Prenesi {{format}}",
+  "More formats": "Več formatov"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2042,5 +2042,7 @@
   "Danger Zone": "Farozon",
   "Delete All Books": "Radera alla böcker",
   "All books deleted.": "Alla böcker har raderats.",
-  "Failed to delete books. Please try again later.": "Det gick inte att radera böckerna. Försök igen senare."
+  "Failed to delete books. Please try again later.": "Det gick inte att radera böckerna. Försök igen senare.",
+  "Download {{format}}": "Ladda ner {{format}}",
+  "More formats": "Fler format"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2042,5 +2042,7 @@
   "Danger Zone": "அபாய மண்டலம்",
   "Delete All Books": "எல்லா புத்தகங்களையும் நீக்கு",
   "All books deleted.": "எல்லா புத்தகங்களும் நீக்கப்பட்டன.",
-  "Failed to delete books. Please try again later.": "புத்தகங்களை நீக்க முடியவில்லை. பிறகு மீண்டும் முயற்சிக்கவும்."
+  "Failed to delete books. Please try again later.": "புத்தகங்களை நீக்க முடியவில்லை. பிறகு மீண்டும் முயற்சிக்கவும்.",
+  "Download {{format}}": "{{format}} பதிவிறக்கு",
+  "More formats": "மேலும் வடிவங்கள்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1996,5 +1996,7 @@
   "Danger Zone": "โซนอันตราย",
   "Delete All Books": "ลบหนังสือทั้งหมด",
   "All books deleted.": "ลบหนังสือทั้งหมดแล้ว",
-  "Failed to delete books. Please try again later.": "ลบหนังสือไม่สำเร็จ โปรดลองอีกครั้งในภายหลัง"
+  "Failed to delete books. Please try again later.": "ลบหนังสือไม่สำเร็จ โปรดลองอีกครั้งในภายหลัง",
+  "Download {{format}}": "ดาวน์โหลด {{format}}",
+  "More formats": "รูปแบบอื่น"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2042,5 +2042,7 @@
   "Danger Zone": "Tehlikeli Bölge",
   "Delete All Books": "Tüm Kitapları Sil",
   "All books deleted.": "Tüm kitaplar silindi.",
-  "Failed to delete books. Please try again later.": "Kitaplar silinemedi. Lütfen daha sonra tekrar deneyin."
+  "Failed to delete books. Please try again later.": "Kitaplar silinemedi. Lütfen daha sonra tekrar deneyin.",
+  "Download {{format}}": "{{format}} indir",
+  "More formats": "Diğer biçimler"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2134,5 +2134,7 @@
   "Danger Zone": "Небезпечна зона",
   "Delete All Books": "Видалити всі книги",
   "All books deleted.": "Усі книги видалено.",
-  "Failed to delete books. Please try again later.": "Не вдалося видалити книги. Спробуйте пізніше."
+  "Failed to delete books. Please try again later.": "Не вдалося видалити книги. Спробуйте пізніше.",
+  "Download {{format}}": "Завантажити {{format}}",
+  "More formats": "Інші формати"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2042,5 +2042,7 @@
   "Danger Zone": "Xavfli hudud",
   "Delete All Books": "Barcha kitoblarni oʻchirish",
   "All books deleted.": "Barcha kitoblar oʻchirildi.",
-  "Failed to delete books. Please try again later.": "Kitoblarni oʻchirib boʻlmadi. Keyinroq qayta urinib koʻring."
+  "Failed to delete books. Please try again later.": "Kitoblarni oʻchirib boʻlmadi. Keyinroq qayta urinib koʻring.",
+  "Download {{format}}": "{{format}} yuklab olish",
+  "More formats": "Boshqa formatlar"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1996,5 +1996,7 @@
   "Danger Zone": "Vùng nguy hiểm",
   "Delete All Books": "Xóa tất cả sách",
   "All books deleted.": "Đã xóa tất cả sách.",
-  "Failed to delete books. Please try again later.": "Không xóa được sách. Vui lòng thử lại sau."
+  "Failed to delete books. Please try again later.": "Không xóa được sách. Vui lòng thử lại sau.",
+  "Download {{format}}": "Tải xuống {{format}}",
+  "More formats": "Định dạng khác"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1996,5 +1996,7 @@
   "Danger Zone": "危险区域",
   "Delete All Books": "删除所有图书",
   "All books deleted.": "已删除所有图书。",
-  "Failed to delete books. Please try again later.": "删除图书失败。请稍后重试。"
+  "Failed to delete books. Please try again later.": "删除图书失败。请稍后重试。",
+  "Download {{format}}": "下载 {{format}}",
+  "More formats": "更多格式"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1996,5 +1996,7 @@
   "Danger Zone": "危險區域",
   "Delete All Books": "刪除所有書籍",
   "All books deleted.": "已刪除所有書籍。",
-  "Failed to delete books. Please try again later.": "刪除書籍失敗。請稍後再試。"
+  "Failed to delete books. Please try again later.": "刪除書籍失敗。請稍後再試。",
+  "Download {{format}}": "下載 {{format}}",
+  "More formats": "更多格式"
 }

--- a/apps/readest-app/src/__tests__/app/opds/publication-view.test.tsx
+++ b/apps/readest-app/src/__tests__/app/opds/publication-view.test.tsx
@@ -13,7 +13,10 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('@/hooks/useTranslation', () => ({
-  useTranslation: () => (s: string) => s,
+  // Mirrors i18next interpolation so `Download {{format}}` renders like it does
+  // in the app instead of leaking the placeholder into assertions.
+  useTranslation: () => (s: string, opts?: Record<string, string>) =>
+    opts ? s.replace(/\{\{(\w+)\}\}/g, (_m, key) => String(opts[key] ?? '')) : s,
 }));
 
 vi.mock('@/components/CachedImage', () => ({
@@ -320,5 +323,113 @@ describe('PublicationView', () => {
     expect(screen.getByTestId('cached-image').getAttribute('data-cache-version')).toBe(
       '2025-06-01T00:00:00Z',
     );
+  });
+
+  // readest issue #5583
+  describe('download format selection', () => {
+    const acq = (href: string, type?: string, title?: string) => ({
+      rel: REL.ACQ,
+      href,
+      ...(type ? { type } : {}),
+      ...(title ? { title } : {}),
+    });
+
+    const renderWith = (links: OPDSPublication['links'], onDownload = vi.fn(async () => null)) => {
+      render(
+        <DropdownProvider>
+          <PublicationView
+            publication={{ metadata: { title: 'Formats' }, links, images: [] }}
+            baseURL='https://calibre.example.com/opds'
+            resolveURL={(href, base) => new URL(href, base).toString()}
+            onDownload={onDownload}
+            onNavigate={vi.fn()}
+            onGenerateCachedImageUrl={vi.fn(async (url: string) => url)}
+          />
+        </DropdownProvider>,
+      );
+      return onDownload;
+    };
+
+    it('hides formats Readest cannot import, collapsing to a one-click download', () => {
+      const onDownload = renderWith([
+        acq('/get/kfx/56/Calibre_Library'),
+        acq('/get/epub/56/Calibre_Library', 'application/epub+zip'),
+      ]);
+
+      const button = screen.getByRole('button', { name: 'Download EPUB' });
+      fireEvent.click(button);
+
+      expect(onDownload).toHaveBeenCalledWith(
+        '/get/epub/56/Calibre_Library',
+        'application/epub+zip',
+        expect.any(Function),
+      );
+      expect(screen.queryByText('KFX')).toBeNull();
+    });
+
+    const mixedFormats = [
+      acq('/get/pdf/1/lib', 'application/pdf'),
+      acq('/get/epub/1/lib', 'application/epub+zip'),
+      acq('/get/mobi/1/lib', 'application/x-mobipocket-ebook'),
+    ];
+
+    it('downloads the EPUB on the primary click even when it is not first in the feed', () => {
+      const onDownload = renderWith(mixedFormats);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Download EPUB' }));
+
+      expect(onDownload).toHaveBeenCalledWith(
+        '/get/epub/1/lib',
+        'application/epub+zip',
+        expect.any(Function),
+      );
+    });
+
+    it('keeps every format reachable behind the caret, best first', () => {
+      renderWith(mixedFormats);
+
+      fireEvent.click(screen.getByRole('button', { name: 'More formats' }));
+
+      const entries = screen.getAllByText(/^(EPUB|MOBI|PDF)$/).map((el) => el.textContent);
+      expect(entries).toEqual(['EPUB', 'MOBI', 'PDF']);
+    });
+
+    // The issue explicitly asks not to fall back to the next available format,
+    // so with no EPUB the button has no default action.
+    it('offers no default action when the preferred format is absent', () => {
+      const onDownload = renderWith([
+        acq('/get/pdf/1/lib', 'application/pdf'),
+        acq('/get/mobi/1/lib', 'application/x-mobipocket-ebook'),
+      ]);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Download' }));
+
+      expect(onDownload).not.toHaveBeenCalled();
+      expect(screen.getByText('PDF')).toBeTruthy();
+      expect(screen.getByText('MOBI')).toBeTruthy();
+    });
+
+    // Filtering must never strip a book's only path to a file.
+    it('still lists the links when every format is incompatible', () => {
+      renderWith([acq('/get/kfx/1/lib'), acq('/get/lit/1/lib')]);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Download' }));
+      expect(screen.getByText('KFX')).toBeTruthy();
+      expect(screen.getByText('LIT')).toBeTruthy();
+    });
+
+    it('names a single non-preferred format instead of a bare Download', () => {
+      renderWith([acq('/get/pdf/1/lib', 'application/pdf')]);
+      expect(screen.getByRole('button', { name: 'Download PDF' })).toBeTruthy();
+    });
+
+    // Was `idx.toString()`, so an unrecognised format rendered as "0"/"1".
+    it('never labels a menu entry with its array index', () => {
+      renderWith([acq('/download/1'), acq('/download/2')]);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Download' }));
+      expect(screen.queryByText('0')).toBeNull();
+      expect(screen.queryByText('1')).toBeNull();
+    });
   });
 });

--- a/apps/readest-app/src/__tests__/services/opds-feed-checker.test.ts
+++ b/apps/readest-app/src/__tests__/services/opds-feed-checker.test.ts
@@ -441,6 +441,51 @@ describe('OPDS feed checker', () => {
       expect(getAcquisitionLink(pub)!.href).toBe('/dl/book.cbz');
     });
 
+    // readest issue #5583: a Calibre entry that also carries KFX must not have
+    // that picked over the EPUB sitting next to it.
+    it('prefers EPUB over a format Readest cannot import', () => {
+      const pub: OPDSPublication = {
+        metadata: { id: 'urn:test:kfx-epub', title: 'KFX vs EPUB' },
+        links: [
+          {
+            href: '/get/kfx/56/Calibre_Library',
+            rel: 'http://opds-spec.org/acquisition',
+            properties: {},
+          },
+          {
+            href: '/get/epub/56/Calibre_Library',
+            type: 'application/epub+zip',
+            rel: 'http://opds-spec.org/acquisition',
+            properties: {},
+          },
+        ],
+        images: [],
+      };
+      expect(getAcquisitionLink(pub)!.href).toBe('/get/epub/56/Calibre_Library');
+    });
+
+    // Downloading it would only fail at import, leaving a failed-download entry
+    // behind, so the entry is skipped outright.
+    it('skips an entry whose only formats are ones Readest cannot import', () => {
+      const pub: OPDSPublication = {
+        metadata: { id: 'urn:test:kfx-only', title: 'KFX only' },
+        links: [
+          {
+            href: '/get/kfx/56/Calibre_Library',
+            rel: 'http://opds-spec.org/acquisition',
+            properties: {},
+          },
+          {
+            href: '/get/lit/56/Calibre_Library',
+            rel: 'http://opds-spec.org/acquisition',
+            properties: {},
+          },
+        ],
+        images: [],
+      };
+      expect(getAcquisitionLink(pub)).toBeUndefined();
+    });
+
     it('treats PDF and CBZ as the same tier (uses feed order to break ties)', () => {
       const pub: OPDSPublication = {
         metadata: { id: 'urn:test:pdf-cbz', title: 'PDF vs CBZ' },

--- a/apps/readest-app/src/__tests__/services/opds/formats.test.ts
+++ b/apps/readest-app/src/__tests__/services/opds/formats.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import type { OPDSAcquisitionLink } from '@/types/opds';
+import { REL } from '@/types/opds';
+import {
+  classifyAcquisitionLink,
+  getFormatExt,
+  getFormatName,
+  getFormatTier,
+} from '@/services/opds/formats';
+
+const link = (partial: Partial<OPDSAcquisitionLink> & { href: string }): OPDSAcquisitionLink => ({
+  rel: REL.ACQ,
+  ...partial,
+});
+
+describe('classifyAcquisitionLink', () => {
+  describe('supported', () => {
+    // Real shape served by a Calibre content server: lowercase format token in
+    // the path, plus a genuine media type (verified 2026-08-09).
+    it('accepts a Calibre EPUB link', () => {
+      expect(
+        classifyAcquisitionLink(
+          link({ href: '/get/epub/56/Calibre_Library', type: 'application/epub+zip' }),
+        ),
+      ).toBe('supported');
+    });
+
+    it('accepts every format Readest can import', () => {
+      const hrefs = [
+        '/dl/book.epub',
+        '/dl/book.mobi',
+        '/dl/book.azw3',
+        '/dl/book.cbz',
+        '/dl/book.fb2',
+        '/dl/book.pdf',
+        '/dl/book.txt',
+        '/dl/book.md',
+      ];
+      for (const href of hrefs) {
+        expect(classifyAcquisitionLink(link({ href }))).toBe('supported');
+      }
+    });
+
+    // Feeds that serve a real EPUB but label it octet-stream must not lose
+    // their only download.
+    it('recovers a supported format from the href when the type is octet-stream', () => {
+      expect(
+        classifyAcquisitionLink(link({ href: '/dl/book.epub', type: 'application/octet-stream' })),
+      ).toBe('supported');
+    });
+
+    // The download handler opens text/html in a browser rather than importing
+    // it, so it stays a valid path.
+    it('keeps text/html as the open-in-browser escape hatch', () => {
+      expect(classifyAcquisitionLink(link({ href: '/landing', type: 'text/html' }))).toBe(
+        'supported',
+      );
+    });
+
+    // Standard Ebooks serves *.kepub.epub as application/kepub+zip. The file is
+    // a valid EPUB, so the href extension wins over the unrecognised mime.
+    it('accepts a Kobo kepub whose href still ends in .epub', () => {
+      expect(
+        classifyAcquisitionLink(
+          link({ href: '/ebooks/x/downloads/y.kepub.epub', type: 'application/kepub+zip' }),
+        ),
+      ).toBe('supported');
+    });
+  });
+
+  describe('unsupported', () => {
+    // The whole point of issue #5583. Calibre has no mime for KFX, so the
+    // lowercase path token is the only signal available.
+    it('rejects a Calibre KFX link identified only by its path token', () => {
+      expect(classifyAcquisitionLink(link({ href: '/get/kfx/56/Calibre_Library' }))).toBe(
+        'unsupported',
+      );
+    });
+
+    it('rejects Calibre-Web style /opds/download/<id>/<format>/ hrefs', () => {
+      expect(classifyAcquisitionLink(link({ href: '/opds/download/123/lit/' }))).toBe(
+        'unsupported',
+      );
+    });
+
+    // Standard Ebooks: no extension in the href and "XHTML" is not a file
+    // extension, so only the mime arm catches this one.
+    it('rejects the Standard Ebooks XHTML link by media type', () => {
+      expect(
+        classifyAcquisitionLink(
+          link({
+            href: '/ebooks/author/title/text/single-page',
+            type: 'application/xhtml+xml',
+            title: 'XHTML',
+          }),
+        ),
+      ).toBe('unsupported');
+    });
+
+    it('rejects an Adobe ACSM fulfillment link', () => {
+      expect(
+        classifyAcquisitionLink(
+          link({ href: '/fulfill/123', type: 'application/vnd.adobe.adept+xml' }),
+        ),
+      ).toBe('unsupported');
+    });
+
+    it('rejects an incompatible format named only in the link title', () => {
+      expect(classifyAcquisitionLink(link({ href: '/download/9912', title: 'DjVu' }))).toBe(
+        'unsupported',
+      );
+    });
+
+    it('rejects incompatible formats by href extension', () => {
+      for (const href of ['/dl/book.rtf', '/dl/book.docx', '/dl/book.lrf', '/dl/book.prc']) {
+        expect(classifyAcquisitionLink(link({ href }))).toBe('unsupported');
+      }
+    });
+  });
+
+  describe('unknown', () => {
+    // Dropping a link needs a positively named incompatible format. A script
+    // extension is not one -- this may well serve an EPUB.
+    it('keeps a script-extension href', () => {
+      expect(classifyAcquisitionLink(link({ href: '/download/book.php?id=1' }))).toBe('unknown');
+    });
+
+    it('keeps an extensionless href with no type', () => {
+      expect(classifyAcquisitionLink(link({ href: '/download/1' }))).toBe('unknown');
+    });
+
+    // "prc" appears inside the word, not as a token -- must not match.
+    it('does not match an incompatible token embedded in a longer word', () => {
+      expect(classifyAcquisitionLink(link({ href: '/library/sprocket/1' }))).toBe('unknown');
+    });
+  });
+});
+
+describe('getFormatExt', () => {
+  it('names the format for a button label', () => {
+    expect(getFormatExt(link({ href: '/get/epub/1/lib', type: 'application/epub+zip' }))).toBe(
+      'epub',
+    );
+    expect(getFormatExt(link({ href: '/dl/book.pdf' }))).toBe('pdf');
+    expect(getFormatExt(link({ href: '/download/1' }))).toBe('');
+  });
+});
+
+describe('getFormatName', () => {
+  // A menu listing incompatible formats has to tell them apart; getFormatExt
+  // returns '' for those, which would render every entry identically.
+  it('names formats Readest cannot import', () => {
+    expect(getFormatName(link({ href: '/get/kfx/1/lib' }))).toBe('kfx');
+    expect(getFormatName(link({ href: '/get/lit/1/lib' }))).toBe('lit');
+    expect(getFormatName(link({ href: '/dl/book.rtf' }))).toBe('rtf');
+  });
+
+  it('still prefers the importable name when there is one', () => {
+    expect(getFormatName(link({ href: '/get/epub/1/lib', type: 'application/epub+zip' }))).toBe(
+      'epub',
+    );
+  });
+
+  it('returns empty when nothing names the format', () => {
+    expect(getFormatName(link({ href: '/download/1' }))).toBe('');
+  });
+});
+
+describe('getFormatTier', () => {
+  it('ranks advanced EPUB above plain EPUB above MOBI above PDF', () => {
+    const advanced = getFormatTier(
+      link({ href: '/dl/book.epub', type: 'application/epub+zip', title: 'Advanced epub' }),
+    );
+    const plain = getFormatTier(link({ href: '/dl/book.epub', type: 'application/epub+zip' }));
+    const mobi = getFormatTier(
+      link({ href: '/dl/book.mobi', type: 'application/x-mobipocket-ebook' }),
+    );
+    const pdf = getFormatTier(link({ href: '/dl/book.pdf', type: 'application/pdf' }));
+
+    expect(advanced).toBeLessThan(plain);
+    expect(plain).toBeLessThan(mobi);
+    expect(mobi).toBeLessThan(pdf);
+  });
+});

--- a/apps/readest-app/src/app/opds/components/PublicationView.tsx
+++ b/apps/readest-app/src/app/opds/components/PublicationView.tsx
@@ -4,11 +4,17 @@ import clsx from 'clsx';
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { IoPricetag } from 'react-icons/io5';
+import { MdArrowDropDown } from 'react-icons/md';
 import { Book } from '@/types/book';
 import { OPDSPublication, REL, SYMBOL, OPDSAcquisitionLink, OPDSStreamLink } from '@/types/opds';
 import { getOPDSCoverHref } from '@/services/opds/cover';
+import {
+  classifyAcquisitionLink,
+  getFormatName,
+  getFormatTier,
+  pickPreferredLink,
+} from '@/services/opds/formats';
 import { useTranslation } from '@/hooks/useTranslation';
-import { getFileExtFromMimeType } from '@/libs/document';
 import { formatDate, formatLanguage } from '@/utils/book';
 import { getImportErrorMessage, ImportError } from '@/services/errors';
 import { eventDispatcher } from '@/utils/event';
@@ -163,14 +169,95 @@ export function PublicationView({
     }
   };
 
-  const getAcquisitionLabel = (rel: string): string => {
+  // `formatExt` names the format the button would fetch. Only the generic
+  // Download label takes it: the entitlement rels describe an action rather
+  // than a file, so "Borrow EPUB" would read wrong (#5583).
+  const getAcquisitionLabel = (rel: string, formatExt?: string): string => {
     if (rel === REL.ACQ + '/open-access') return _('Open Access');
     if (rel === REL.ACQ + '/borrow') return _('Borrow');
     if (rel === REL.ACQ + '/buy') return _('Buy');
     if (rel === REL.ACQ + '/subscribe') return _('Subscribe');
     if (rel === REL.ACQ + '/sample') return _('Sample');
-    return _('Download');
+    return formatExt
+      ? _('Download {{format}}', { format: formatExt.toUpperCase() })
+      : _('Download');
   };
+
+  const formatMenu = (links: OPDSAcquisitionLink[]) => (
+    <div
+      // Stays absolutely positioned (daisyui's default). Forcing `relative`
+      // here puts the menu in flow inside the fixed-height detail column, and
+      // `justify-between` then shoves the whole button row 156px up the moment
+      // it opens.
+      className={clsx(
+        'dropdown-content no-triangle',
+        'border-base-300 eink-bordered !bg-base-200 z-20 mt-2 max-w-[80vw] min-w-max',
+        'rounded-2xl border shadow-2xl',
+      )}
+    >
+      {links.map((link, idx: number) => (
+        <MenuItem
+          key={idx}
+          noIcon
+          transient
+          label={link.title || getFormatName(link).toUpperCase() || _('Download')}
+          onClick={() => handleActionButton(link.href!, link.type)}
+        />
+      ))}
+    </div>
+  );
+
+  // DESIGN.md §4.1/§4.4: one solid primary per surface, everything else quieter.
+  // `btn-contrast` sets its background with `!important`, so it survives the
+  // `bg-base-300/50` tint the Dropdown puts on an open toggle -- a plain
+  // `btn-primary` half would turn beige while its sibling stayed filled. The
+  // secondary gets a soft surface rather than a bare ghost: a transparent half
+  // has no shape to split, so its caret rendered as a detached sliver.
+  const SOLID_ACTION = 'btn btn-contrast';
+  const FLAT_ACTION =
+    'btn eink-bordered border-transparent !bg-base-200 hover:!bg-base-300 text-base-content';
+
+  /**
+   * A default action plus, when there is more than one format to choose from, a
+   * caret that opens the full list.
+   *
+   * The halves are separated by a 1px gap showing the page behind rather than a
+   * border: `btn-contrast` declares its own border `!important`, so a seam
+   * colour set here is ignored. The gap also survives e-ink, where hover does
+   * not exist and two same-tone buttons would otherwise flatten into one.
+   */
+  const splitDownloadButton = (
+    label: string,
+    onPrimary: () => void,
+    menuLinks: OPDSAcquisitionLink[],
+    solid = true,
+  ) => (
+    <div className='flex gap-px'>
+      <button
+        type='button'
+        onClick={onPrimary}
+        disabled={downloading}
+        className={clsx(
+          solid ? SOLID_ACTION : FLAT_ACTION,
+          'min-w-20 rounded-l-3xl rounded-r-none px-4',
+        )}
+      >
+        {label}
+      </button>
+      <Dropdown
+        label={_('More formats')}
+        className='dropdown-bottom dropdown-end'
+        buttonClassName={clsx(
+          solid ? SOLID_ACTION : FLAT_ACTION,
+          'w-10 rounded-l-none rounded-r-3xl px-0',
+        )}
+        disabled={downloading}
+        toggleButton={<MdArrowDropDown size={20} />}
+      >
+        {formatMenu(menuLinks)}
+      </Dropdown>
+    </div>
+  );
 
   const content = publication.metadata?.[SYMBOL.CONTENT] || publication.metadata?.content;
   const description = publication.metadata?.description;
@@ -200,7 +287,11 @@ export function PublicationView({
           </div>
         </div>
 
-        <div className='flex h-44 min-w-0 flex-col justify-between max-[320px]:h-32 sm:h-56 md:h-64'>
+        {/* Min-height, not height: `justify-between` still pins the actions to
+            the bottom alongside the cover, but a narrow viewport that wraps the
+            action row onto a second line grows the column instead of spilling
+            the buttons over the description. */}
+        <div className='flex min-h-44 min-w-0 flex-1 flex-col justify-between max-[320px]:min-h-32 sm:min-h-56 md:min-h-64'>
           <div className='flex flex-col'>
             {publication.metadata?.subtitle && (
               <p className='text-base-content/60 mb-1 text-sm'>{publication.metadata.subtitle}</p>
@@ -240,70 +331,92 @@ export function PublicationView({
                 const validLinks = links.filter((l) => l.href);
                 if (validLinks.length === 0) return null;
 
+                // Drop formats Readest cannot import — unless that would leave
+                // nothing, in which case the incompatible links are still the
+                // only path this book has (#5583).
+                const compatible = validLinks.filter(
+                  (l) => classifyAcquisitionLink(l) !== 'unsupported',
+                );
+                const usableLinks = compatible.length > 0 ? compatible : validLinks;
+                const menuLinks = [...usableLinks].sort(
+                  (a, b) => getFormatTier(a) - getFormatTier(b),
+                );
+                const preferred = pickPreferredLink(usableLinks)!;
+                // Only an EPUB earns a default action. Anything else and the
+                // user picks, rather than the app quietly taking second best.
+                const hasDefaultAction = getFormatTier(preferred) <= 1;
+                const primaryLabel = getAcquisitionLabel(
+                  rel,
+                  hasDefaultAction || usableLinks.length === 1
+                    ? getFormatName(preferred)
+                    : undefined,
+                );
+                const showCaret = usableLinks.length > 1;
+
                 return (
-                  <div key={rel} className='flex gap-1'>
+                  <div key={rel} className='flex flex-wrap items-center gap-2'>
                     {downloadedBook ? (
                       <>
+                        {/* Reading the copy you already have is the primary
+                            action here, so it takes the one solid button and
+                            re-downloading drops to flat. */}
                         <button
                           type='button'
-                          onClick={() =>
-                            handleActionButton(validLinks[0]!.href!, validLinks[0]!.type)
-                          }
+                          onClick={() => handleActionButton(preferred.href!, preferred.type)}
                           disabled={downloading}
-                          className='btn btn-primary btn-success min-w-20 rounded-3xl'
+                          className={clsx(SOLID_ACTION, 'min-w-20 rounded-3xl px-4')}
                         >
                           {_('Open & Read')}
                         </button>
-                        <button
-                          type='button'
-                          onClick={() =>
-                            handleActionButton(validLinks[0]!.href!, validLinks[0]!.type, true)
-                          }
-                          disabled={downloading}
-                          className='btn btn-primary min-w-20 rounded-3xl'
-                        >
-                          {_('Download Again')}
-                        </button>
+                        {showCaret ? (
+                          splitDownloadButton(
+                            _('Download Again'),
+                            () => handleActionButton(preferred.href!, preferred.type, true),
+                            menuLinks,
+                            false,
+                          )
+                        ) : (
+                          <button
+                            type='button'
+                            onClick={() =>
+                              handleActionButton(preferred.href!, preferred.type, true)
+                            }
+                            disabled={downloading}
+                            className={clsx(FLAT_ACTION, 'min-w-20 rounded-3xl px-4')}
+                          >
+                            {_('Download Again')}
+                          </button>
+                        )}
                       </>
-                    ) : validLinks.length === 1 ? (
+                    ) : !showCaret ? (
                       <button
                         type='button'
-                        onClick={() =>
-                          handleActionButton(validLinks[0]!.href!, validLinks[0]!.type)
-                        }
+                        onClick={() => handleActionButton(preferred.href!, preferred.type)}
                         disabled={downloading}
-                        className='btn btn-primary min-w-20 rounded-3xl'
+                        className={clsx(SOLID_ACTION, 'min-w-20 rounded-3xl px-4')}
                       >
-                        {getAcquisitionLabel(rel)}
+                        {primaryLabel}
                       </button>
+                    ) : hasDefaultAction ? (
+                      splitDownloadButton(
+                        primaryLabel,
+                        () => handleActionButton(preferred.href!, preferred.type),
+                        menuLinks,
+                      )
                     ) : (
                       <Dropdown
                         label={_('Download')}
                         className='dropdown-bottom dropdown-center flex justify-center'
-                        buttonClassName='btn btn-primary min-w-20 rounded-3xl p-0 bg-primary hover:bg-primary'
+                        buttonClassName={clsx(SOLID_ACTION, 'min-w-20 gap-1 rounded-3xl px-4')}
                         disabled={downloading}
-                        toggleButton={<div>{getAcquisitionLabel(rel)}</div>}
+                        toggleButton={
+                          <div className='flex items-center gap-1'>
+                            {primaryLabel}
+                            <MdArrowDropDown size={18} />
+                          </div>
+                        }
                       >
-                        <div
-                          className={clsx(
-                            'delete-menu dropdown-content no-triangle !relative',
-                            'border-base-300 !bg-base-200 z-20 mt-2 max-w-[80vw] shadow-2xl',
-                          )}
-                        >
-                          {validLinks.map((link, idx: number) => (
-                            <MenuItem
-                              key={idx}
-                              noIcon
-                              transient
-                              label={
-                                link.title ||
-                                getFileExtFromMimeType(link.type || '').toUpperCase() ||
-                                idx.toString()
-                              }
-                              onClick={() => handleActionButton(link.href!, link.type)}
-                            />
-                          ))}
-                        </div>
+                        {formatMenu(menuLinks)}
                       </Dropdown>
                     )}
                   </div>
@@ -339,25 +452,26 @@ export function PublicationView({
                 return null;
               })}
 
-              <div className='flex h-12 w-12 items-center justify-center'>
-                {downloading && progress && progress > 0 && (
-                  <div
-                    className='radial-progress flex items-center justify-center'
-                    style={
-                      {
-                        '--value': progress,
-                        '--size': '2.5rem',
-                        fontSize: '0.6rem',
-                        lineHeight: '0.8rem',
-                      } as React.CSSProperties
-                    }
-                    aria-valuenow={progress || 0}
-                    role='progressbar'
-                  >
-                    {progress}%
-                  </div>
-                )}
-              </div>
+              {/* Rendered only while a download is running. A permanently
+                  mounted 48px slot left a dead gap after the actions on every
+                  viewport, and cost real width on narrow ones. */}
+              {downloading && progress !== null && progress > 0 && (
+                <div
+                  className='radial-progress flex items-center justify-center'
+                  style={
+                    {
+                      '--value': progress,
+                      '--size': '2.5rem',
+                      fontSize: '0.6rem',
+                      lineHeight: '0.8rem',
+                    } as React.CSSProperties
+                  }
+                  aria-valuenow={progress}
+                  role='progressbar'
+                >
+                  {progress}%
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/apps/readest-app/src/services/opds/feedChecker.ts
+++ b/apps/readest-app/src/services/opds/feedChecker.ts
@@ -10,17 +10,12 @@ import type {
   OPDSStreamLink,
 } from '@/types/opds';
 import { REL } from '@/types/opds';
-import { MIMETYPES } from '@/libs/document';
 import { isWebAppPlatform } from '@/services/environment';
 import { fetchWithAuth } from '@/app/opds/utils/opdsReq';
-import {
-  resolveURL,
-  parseMediaType,
-  looksLikeXMLContent,
-  parseOPDSXML,
-} from '@/app/opds/utils/opdsUtils';
+import { resolveURL, looksLikeXMLContent, parseOPDSXML } from '@/app/opds/utils/opdsUtils';
 import { normalizeCustomHeaders } from '@/utils/customHeaders';
 import { getOPDSCoverHref } from './cover';
+import { classifyAcquisitionLink, pickPreferredLink } from './formats';
 import { getOPDSBookMetadata } from './metadata';
 import type { OPDSSubscriptionState, PendingItem } from './types';
 import { MAX_CRAWL_DEPTH, MAX_FEEDS_PER_CRAWL, MAX_PAGES_PER_FEED } from './types';
@@ -51,84 +46,24 @@ function isSafeAcquisitionLink(link: AnyAcqLink): link is ValidAcqLink {
   return rels.some((r) => SAFE_ACQ_RELS.includes(r));
 }
 
-// Tier 0 (best) → 4 (worst). See getAcquisitionLink for the policy.
-type FormatTier = 0 | 1 | 2 | 3 | 4;
-
-// When a feed omits the link `type` (or returns the uninformative
-// application/octet-stream), fall back to inferring the format from the
-// href extension and the human-readable link title. Order matters here:
-// AZW3 must match before AZW, EPUB 3 before plain EPUB.
-const INFERENCE_RULES: ReadonlyArray<{ mime: string; href: RegExp; title: RegExp }> = [
-  { mime: 'application/epub+zip', href: /\.epub3(?:[?#]|$)/i, title: /\bepub\s*3\b|\bepub3\b/i },
-  { mime: 'application/epub+zip', href: /\.epub(?:[?#]|$)/i, title: /\bepub\b/i },
-  { mime: 'application/x-mobi8-ebook', href: /\.azw3(?:[?#]|$)/i, title: /\bazw\s*3\b|\bazw3\b/i },
-  { mime: 'application/vnd.amazon.ebook', href: /\.azw(?:[?#]|$)/i, title: /\bazw\b/i },
-  { mime: 'application/x-mobipocket-ebook', href: /\.mobi(?:[?#]|$)/i, title: /\bmobi\b/i },
-  { mime: 'application/pdf', href: /\.pdf(?:[?#]|$)/i, title: /\bpdf\b/i },
-  { mime: 'application/vnd.comicbook+zip', href: /\.cbz(?:[?#]|$)/i, title: /\bcbz\b/i },
-  { mime: 'application/x-fictionbook+xml', href: /\.fb2(?:[?#]|$)/i, title: /\bfb2\b/i },
-];
-
-function inferMediaType(link: ValidAcqLink): string {
-  const title = link.title ?? '';
-  for (const rule of INFERENCE_RULES) {
-    if (rule.href.test(link.href) || rule.title.test(title)) return rule.mime;
-  }
-  return '';
-}
-
-function getEffectiveMediaType(link: ValidAcqLink): string {
-  const declared = parseMediaType(link.type)?.mediaType ?? '';
-  // Treat octet-stream as "the server didn't actually tell us" — most
-  // OPDS feeds emit a real media type for known formats, and falling back
-  // to href/title inference recovers from servers that don't.
-  if (declared && declared !== 'application/octet-stream') return declared;
-  return inferMediaType(link);
-}
-
-function isAdvancedEpub(link: ValidAcqLink, mediaType: string): boolean {
-  if (mediaType !== 'application/epub+zip') return false;
-  const version = parseMediaType(link.type)?.parameters?.['version'];
-  if (version && /^3(\.|$)/.test(version)) return true;
-  const title = link.title?.toLowerCase() ?? '';
-  if (title.includes('advanced')) return true;
-  if (title.includes('epub3') || title.includes('epub 3')) return true;
-  if (/\.epub3(?:[?#.]|$)/i.test(link.href)) return true;
-  return false;
-}
-
-function getFormatTier(link: ValidAcqLink): FormatTier {
-  const mediaType = getEffectiveMediaType(link);
-  if (MIMETYPES.EPUB.includes(mediaType)) {
-    return isAdvancedEpub(link, mediaType) ? 0 : 1;
-  }
-  if (
-    MIMETYPES.MOBI.includes(mediaType) ||
-    MIMETYPES.AZW.includes(mediaType) ||
-    MIMETYPES.AZW3.includes(mediaType)
-  ) {
-    return 2;
-  }
-  if (MIMETYPES.PDF.includes(mediaType) || MIMETYPES.CBZ.includes(mediaType)) {
-    return 3;
-  }
-  return 4;
-}
-
 /**
  * Pick the best acquisition link on a publication for unattended download.
  *
  * 1. Filter to safe rels (acquisition / acquisition/open-access), drop
  *    indirect links — leaves entries we can fetch directly.
- * 2. Prefer open-access over plain acquisition.
- * 3. Within those, rank by format tier:
+ * 2. Drop formats Readest cannot import — downloading them only to fail at
+ *    import wastes the transfer and leaves a failed entry behind (#5583).
+ * 3. Prefer open-access over plain acquisition.
+ * 4. Within those, rank by format tier:
  *    Advanced EPUB / EPUB3 > EPUB > MOBI/AZW/AZW3 > PDF/CBZ > other.
  *    Ties resolve by feed order.
  *
- * Returns undefined when no safe link exists — the entry is skipped.
+ * Returns undefined when no usable link exists — the entry is skipped.
  */
 export function getAcquisitionLink(pub: OPDSPublication): ValidAcqLink | undefined {
-  const acqLinks = pub.links.filter(isSafeAcquisitionLink);
+  const acqLinks = pub.links
+    .filter(isSafeAcquisitionLink)
+    .filter((link) => classifyAcquisitionLink(link) !== 'unsupported');
   if (acqLinks.length === 0) return undefined;
 
   const openAccess = acqLinks.filter((link) => {
@@ -137,16 +72,7 @@ export function getAcquisitionLink(pub: OPDSPublication): ValidAcqLink | undefin
   });
   const candidates = openAccess.length > 0 ? openAccess : acqLinks;
 
-  let best = candidates[0]!;
-  let bestTier = getFormatTier(best);
-  for (let i = 1; i < candidates.length && bestTier > 0; i++) {
-    const tier = getFormatTier(candidates[i]!);
-    if (tier < bestTier) {
-      best = candidates[i]!;
-      bestTier = tier;
-    }
-  }
-  return best;
+  return pickPreferredLink(candidates);
 }
 
 /**

--- a/apps/readest-app/src/services/opds/formats.ts
+++ b/apps/readest-app/src/services/opds/formats.ts
@@ -1,0 +1,202 @@
+import { MIMETYPES, getFileExtFromMimeType } from '@/libs/document';
+import { SUPPORTED_BOOK_EXTS } from '@/services/constants';
+import { parseMediaType } from '@/app/opds/utils/opdsUtils';
+
+/** Minimal shape shared by every OPDS link we need to identify a format from. */
+export interface FormatLink {
+  href?: string;
+  type?: string;
+  title?: string;
+}
+
+// When a feed omits the link `type` (or returns the uninformative
+// application/octet-stream), fall back to inferring the format from the
+// href extension and the human-readable link title. Order matters here:
+// AZW3 must match before AZW, EPUB 3 before plain EPUB.
+const INFERENCE_RULES: ReadonlyArray<{ mime: string; href: RegExp; title: RegExp }> = [
+  { mime: 'application/epub+zip', href: /\.epub3(?:[?#]|$)/i, title: /\bepub\s*3\b|\bepub3\b/i },
+  { mime: 'application/epub+zip', href: /\.epub(?:[?#]|$)/i, title: /\bepub\b/i },
+  { mime: 'application/x-mobi8-ebook', href: /\.azw3(?:[?#]|$)/i, title: /\bazw\s*3\b|\bazw3\b/i },
+  { mime: 'application/vnd.amazon.ebook', href: /\.azw(?:[?#]|$)/i, title: /\bazw\b/i },
+  { mime: 'application/x-mobipocket-ebook', href: /\.mobi(?:[?#]|$)/i, title: /\bmobi\b/i },
+  { mime: 'application/pdf', href: /\.pdf(?:[?#]|$)/i, title: /\bpdf\b/i },
+  { mime: 'application/vnd.comicbook+zip', href: /\.cbz(?:[?#]|$)/i, title: /\bcbz\b/i },
+  { mime: 'application/x-fictionbook+xml', href: /\.fb2(?:[?#]|$)/i, title: /\bfb2\b/i },
+];
+
+// Media types that positively identify a document Readest cannot import.
+// `text/html` is deliberately absent -- the download handler opens it in a
+// browser instead, so it stays a usable path.
+const UNSUPPORTED_MIMETYPES = [
+  'application/xhtml+xml',
+  'application/vnd.adobe.adept+xml',
+  'application/vnd.adobe.adept+xml;type=other',
+];
+
+// Ebook formats Readest cannot open, distinctive enough to match anywhere in a
+// link's path or title. Calibre names the format in the URL
+// (`/get/kfx/56/Calibre_Library`) and Calibre-Web puts it in the last segment
+// (`/opds/download/123/lit/`), so a bare extension check is not enough.
+const UNSUPPORTED_FORMAT_TOKENS = [
+  'kfx',
+  'azw4',
+  'azw8',
+  'lit',
+  'lrf',
+  'lrx',
+  'djvu',
+  'docx',
+  'htmlz',
+  'chm',
+  'acsm',
+  'ibooks',
+  'odt',
+  'rtf',
+  'snb',
+  'tcr',
+  'pml',
+];
+
+// Formats whose token doubles as an ordinary word or path segment (`/opds/doc/`
+// is a plausible endpoint). Matched only as a trailing file extension so they
+// cannot condemn an unrelated URL.
+const UNSUPPORTED_EXTS_ONLY = ['doc', 'rb', 'prc', 'pdb'];
+
+const hrefPath = (href: string): string => href.split(/[?#]/)[0] || '';
+
+const hrefExt = (href: string): string =>
+  (hrefPath(href).match(/\.([a-z0-9]+)$/i)?.[1] ?? '').toLowerCase();
+
+const tokenize = (value: string): string[] =>
+  value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+
+const inferMediaType = (link: FormatLink): string => {
+  const href = link.href ?? '';
+  const title = link.title ?? '';
+  for (const rule of INFERENCE_RULES) {
+    if ((href && rule.href.test(href)) || (title && rule.title.test(title))) return rule.mime;
+  }
+  return '';
+};
+
+export const getEffectiveMediaType = (link: FormatLink): string => {
+  const declared = parseMediaType(link.type)?.mediaType ?? '';
+  // Treat octet-stream as "the server didn't actually tell us" -- most
+  // OPDS feeds emit a real media type for known formats, and falling back
+  // to href/title inference recovers from servers that don't.
+  if (declared && declared !== 'application/octet-stream') return declared;
+  return inferMediaType(link);
+};
+
+/**
+ * The file extension this link would import as, or '' when the format cannot
+ * be named. Used for button labels and menu entries.
+ */
+export const getFormatExt = (link: FormatLink): string => {
+  const fromMediaType = getFileExtFromMimeType(getEffectiveMediaType(link));
+  if (fromMediaType) return fromMediaType;
+  const ext = hrefExt(link.href ?? '');
+  return SUPPORTED_BOOK_EXTS.includes(ext) ? ext : '';
+};
+
+/**
+ * Best human-readable name for the link's format, '' when it cannot be named.
+ *
+ * Unlike getFormatExt this also names formats Readest cannot import, so a menu
+ * listing them stays distinguishable instead of repeating a generic label.
+ */
+export const getFormatName = (link: FormatLink): string => {
+  const supported = getFormatExt(link);
+  if (supported) return supported;
+  const ext = hrefExt(link.href ?? '');
+  if (ext) return ext;
+  const tokens = [...tokenize(hrefPath(link.href ?? '')), ...tokenize(link.title ?? '')];
+  return (
+    tokens.find(
+      (token) => UNSUPPORTED_FORMAT_TOKENS.includes(token) || UNSUPPORTED_EXTS_ONLY.includes(token),
+    ) ?? ''
+  );
+};
+
+/**
+ * Whether Readest can import what this acquisition link points at.
+ *
+ * Deliberately asymmetric: a link is only reported `unsupported` when its
+ * format is positively named as one we cannot open. Href extensions lie
+ * (`/download/book.php?id=1` may well serve an EPUB), so anything we cannot
+ * identify stays `unknown` and is kept.
+ */
+export const classifyAcquisitionLink = (
+  link: FormatLink,
+): 'supported' | 'unsupported' | 'unknown' => {
+  const href = link.href ?? '';
+  const declared = parseMediaType(link.type)?.mediaType ?? '';
+
+  // The download handler opens HTML in a browser rather than importing it.
+  if (declared === 'text/html') return 'supported';
+  if (getFileExtFromMimeType(getEffectiveMediaType(link))) return 'supported';
+  const ext = hrefExt(href);
+  if (SUPPORTED_BOOK_EXTS.includes(ext)) return 'supported';
+
+  if (declared && UNSUPPORTED_MIMETYPES.includes(declared)) return 'unsupported';
+  if (UNSUPPORTED_EXTS_ONLY.includes(ext)) return 'unsupported';
+
+  const tokens = [...tokenize(hrefPath(href)), ...tokenize(link.title ?? '')];
+  if (tokens.some((token) => UNSUPPORTED_FORMAT_TOKENS.includes(token))) return 'unsupported';
+
+  return 'unknown';
+};
+
+// Tier 0 (best) -> 4 (worst). See getFormatTier for the policy.
+export type FormatTier = 0 | 1 | 2 | 3 | 4;
+
+const isAdvancedEpub = (link: FormatLink, mediaType: string): boolean => {
+  if (mediaType !== 'application/epub+zip') return false;
+  const version = parseMediaType(link.type)?.parameters?.['version'];
+  if (version && /^3(\.|$)/.test(version)) return true;
+  const title = link.title?.toLowerCase() ?? '';
+  if (title.includes('advanced')) return true;
+  if (title.includes('epub3') || title.includes('epub 3')) return true;
+  if (/\.epub3(?:[?#.]|$)/i.test(link.href ?? '')) return true;
+  return false;
+};
+
+/**
+ * Rank a link by how well Readest reads the format:
+ * Advanced EPUB / EPUB3 > EPUB > MOBI/AZW/AZW3 > PDF/CBZ > other.
+ */
+export const getFormatTier = (link: FormatLink): FormatTier => {
+  const mediaType = getEffectiveMediaType(link);
+  if (MIMETYPES.EPUB.includes(mediaType)) {
+    return isAdvancedEpub(link, mediaType) ? 0 : 1;
+  }
+  if (
+    MIMETYPES.MOBI.includes(mediaType) ||
+    MIMETYPES.AZW.includes(mediaType) ||
+    MIMETYPES.AZW3.includes(mediaType)
+  ) {
+    return 2;
+  }
+  if (MIMETYPES.PDF.includes(mediaType) || MIMETYPES.CBZ.includes(mediaType)) {
+    return 3;
+  }
+  return 4;
+};
+
+/** The link Readest would rather download, by format tier then feed order. */
+export const pickPreferredLink = <T extends FormatLink>(links: T[]): T | undefined => {
+  let best = links[0];
+  if (!best) return undefined;
+  let bestTier = getFormatTier(best);
+  for (let i = 1; i < links.length && bestTier > 0; i++) {
+    const tier = getFormatTier(links[i]!);
+    if (tier < bestTier) {
+      best = links[i]!;
+      bestTier = tier;
+    }
+  }
+  return best;
+};


### PR DESCRIPTION
Closes #5583

## Problem

Browsing an online catalog, the acquisition button listed every format the feed offered.

- **Incompatible formats were offered.** Calibre serves KFX/LIT/AZW4 next to EPUB; Standard Ebooks serves an `application/xhtml+xml` link. Readest cannot import any of them, so the download ran to completion and then failed at import.
- **Reaching an EPUB took two clicks** whenever a book had more than one format, with no default action.
- **Unknown formats rendered as array indices.** The menu label fell back to `idx.toString()`, so a format with no title and no recognised media type showed as literally `0`, `1`.

## Approach

New `src/services/opds/formats.ts` is the single place that identifies an acquisition link's format. It absorbs the ranking logic that already lived in `feedChecker.ts` and adds a three-way classifier:

```
classifyAcquisitionLink(link) -> 'supported' | 'unsupported' | 'unknown'
```

Deliberately asymmetric. A link is reported `unsupported` only when its format is **positively named** as one Readest cannot open, either by media type or by a format token in the href path or link title. Href extensions lie (`/download/book.php?id=1` may well serve an EPUB), so anything unidentifiable stays `unknown` and is kept.

Both surfaces now share it:

- `getAcquisitionLink` drops unsupported links before ranking and returns `undefined` when none survive, so **unattended auto-download stops fetching books it cannot import**. Previously a tier-4 "other" link could be picked as a last resort.
- The detail view renders a **split button** when several compatible formats exist: the primary click takes the EPUB, a caret opens the full list. With no EPUB there is no default action, matching the issue's request not to silently fall back. A single format names itself ("Download PDF") so a one-click download is never a surprise. If *every* format is incompatible the links are shown anyway, since they are the only path that book has.

`Download Again` gets the same treatment. It previously hard-coded `validLinks[0]`, so format choice vanished entirely once a book was in the library.

## Verified against real catalogs

Driven in Chrome against `pnpm dev-web` (2026-08-09):

- **Calibre** (local content server): acquisition hrefs are `/get/<fmt>/<id>/<library>` with a **lowercase** token plus a real mime (`/get/azw3/56/Calibre_Library` -> `application/x-mobi8-ebook`). Calibre emits a genuine mime only for formats it knows, so for KFX the path token is the only signal. That is why the token arm is load-bearing rather than belt-and-braces. The test library had no KFX, so that path is covered by unit tests, not end to end.
- **Standard Ebooks** (1494 entries): five links per book, including `XHTML` (`application/xhtml+xml`, href `.../single-page`). No extension, and "XHTML" is not a file extension, so only the media-type arm catches it. All five were listed before this change.

## Layout fixes found while verifying

- The menu carried `!relative`, putting it in flow inside the fixed-height detail column. Opening it shoved the button row **156px up the page** (measured).
- The action row could not wrap, so on a narrow viewport the buttons ran off the right edge. The column is now min-height rather than fixed, so a wrapped row grows it instead of spilling over the description.
- The metadata column was content-sized and wrapped the actions long before it needed to; it now takes the available width.
- Per DESIGN.md §4.1/§4.4 the row had two saturated pills. `Open & Read` keeps the single solid button and `Download Again` drops to a soft secondary.
- The dropdown toggle carried `p-0`, leaving **1px of slack** around a 90px label while the sibling button kept the normal 16px padding.
- A permanently mounted 48px progress slot left a dead gap after the actions on every viewport.

## Tests

`pnpm test` 8982 passed, `pnpm lint` clean.

- `src/__tests__/services/opds/formats.test.ts` (new): three-way classification incl. both real catalog shapes, octet-stream recovery, and the `unknown` cases that must not be dropped.
- `opds-feed-checker.test.ts`: EPUB chosen over KFX; a KFX-only entry skipped.
- `publication-view.test.tsx`: incompatible formats hidden, split-button primary click, menu ordering, no default action without an EPUB, all-incompatible fallback, and no index labels.

## Not included

No new setting, no per-catalog preference, no changes to the download handler in `page.tsx`.

Two locale keys added (`Download {{format}}`, `More formats`) across 33 locales. `pnpm i18n:extract` also surfaced 6 keys belonging to already-landed work (annotation counts, purchases); those are left out to keep this diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)