### PR TITLE
fix(sync): drop the Origin header from OAuth token requests

### DIFF
--- a/apps/readest-app/src-tauri/Cargo.toml
+++ b/apps/readest-app/src-tauri/Cargo.toml
@@ -48,7 +48,14 @@ tauri-plugin-log = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-os = "2"
-tauri-plugin-http = { version = "2", features = ["dangerous-settings"] }
+# `unsafe-headers` lets callers pass fetch-spec "forbidden" headers (Origin,
+# Referer, Cookie, ...) instead of having the plugin silently drop them. Needed
+# so the OAuth token exchange can opt out of the webview Origin the plugin would
+# otherwise stamp on it, which Microsoft rejects with AADSTS90023.
+tauri-plugin-http = { version = "2", features = [
+  "dangerous-settings",
+  "unsafe-headers",
+] }
 tauri-plugin-shell = "2"
 tauri-plugin-process = "2"
 tauri-plugin-oauth = "2"

--- a/apps/readest-app/src/__tests__/services/sync/providers/oauth/tokenEndpoint.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/providers/oauth/tokenEndpoint.test.ts
@@ -96,6 +96,26 @@ describe('tokenEndpoint', () => {
     ).rejects.toThrow(/HTTP 400: invalid_grant — bad code/);
   });
 
+  test('sends an empty Origin so the native HTTP client omits the header', async () => {
+    const captured: RequestInit[] = [];
+    const fetchFn = (async (_url: string, init: RequestInit) => {
+      captured.push(init);
+      return jsonResponse({ access_token: 'AT', expires_in: 3600 });
+    }) as unknown as FetchFn;
+    const tokenEndpoint = 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
+    await exchangeCode(
+      { code: 'C', verifier: 'V', clientId: 'cid', redirectUri: 'R', tokenEndpoint },
+      fetchFn,
+    );
+    await refreshAccessToken({ refreshToken: 'RT', clientId: 'cid', tokenEndpoint }, fetchFn);
+    // Microsoft rejects a token redemption that carries any Origin (AADSTS90023);
+    // both the exchange and the hourly refresh must drop it.
+    expect(captured).toHaveLength(2);
+    for (const init of captured) {
+      expect((init.headers as Record<string, string>)['Origin']).toBe('');
+    }
+  });
+
   test('exchangeCode posts to the given tokenEndpoint', async () => {
     let seenUrl = '';
     const fetchFn = (async (url: string) => {

--- a/apps/readest-app/src/services/sync/providers/oauth/tokenEndpoint.ts
+++ b/apps/readest-app/src/services/sync/providers/oauth/tokenEndpoint.ts
@@ -49,6 +49,21 @@ const CONTENT_TYPE_HEADER = 'Content-Type';
 const HTTP_POST = 'POST';
 
 /**
+ * An empty `Origin` is `@tauri-apps/plugin-http`'s opt-out from the header:
+ * without it the plugin stamps every native request with the webview origin
+ * (`tauri://localhost` on macOS/iOS/Linux, `http://tauri.localhost` elsewhere).
+ * Microsoft reads any `Origin` on a token request as a browser cross-origin
+ * redemption and refuses it for our native custom-scheme redirect — `AADSTS90023:
+ * Cross-origin token redemption is permitted only for the 'Single-Page
+ * Application' client-type`. A native OAuth client is not a browser, so no
+ * `Origin` belongs here for any provider. The opt-out needs the `unsafe-headers`
+ * feature on `tauri-plugin-http` (see `src-tauri/Cargo.toml`); on web the header
+ * is a no-op, since browsers drop it and send the real page origin.
+ */
+const ORIGIN_HEADER = 'Origin';
+const NO_ORIGIN = '';
+
+/**
  * Injected fetch implementation. Typed narrowly to exactly what this module
  * needs so callers can pass the platform's `fetch` (or a stub in tests).
  */
@@ -132,7 +147,7 @@ const requestTokens = async (
 ): Promise<TokenSet> => {
   const res = await fetchFn(tokenEndpoint, {
     method: HTTP_POST,
-    headers: { [CONTENT_TYPE_HEADER]: FORM_CONTENT_TYPE },
+    headers: { [CONTENT_TYPE_HEADER]: FORM_CONTENT_TYPE, [ORIGIN_HEADER]: NO_ORIGIN },
     body: params.toString(),
   });
 


### PR DESCRIPTION
## Problem

Fixes #5597.

OneDrive sign-in failed on every native platform with:

```
AADSTS90023: Cross-origin token redemption is permitted only for the
'Single-Page Application' client-type or 'Native' client-type with origin
registered in AllowedOriginForNativeAppCorsRequestInOAuthToken allow list
```

The cause is not in our OAuth code. `tauri-plugin-http` appends the webview's
origin to **every** native request (`commands.rs`, "ensure we have an Origin
header set"): `tauri://localhost` on macOS/iOS/Linux, `http://tauri.localhost`
on Windows/Android. Microsoft reads any `Origin` on a token request as a
browser cross-origin redemption and refuses it for the Native client type that
`readest-onedrive://auth` registers under.

Google's token endpoint ignores `Origin`, which is why the same shared
`tokenEndpoint.ts` path kept working for Google Drive and only Microsoft broke.

Worth noting for future debugging: the plugin's changelog for 2.5.6 reads
"Fixed an issue that caused the Origin header to always be `null` on macOS, iOS
and Linux". `Cargo.lock` is gitignored and the dependency is pinned only to
`"2"`, so this behaviour can change under us with no diff in the repo.

## Fix

Two halves, and either one alone is a silent no-op:

- `tokenEndpoint.ts` sends `Origin: ''`, the plugin's documented opt-out
  (changelog 2.0.1), on both the code exchange and the hourly refresh.
- `Cargo.toml` enables the `unsafe-headers` feature the opt-out requires.
  Without it the plugin drops the forbidden header and then re-adds the webview
  origin anyway.

A native OAuth client is not a browser, so no `Origin` belongs on this request
for any provider. On web the header is a no-op: browsers drop forbidden header
names and send the real page origin, which is what the SPA app registration
expects.

Note that `unsafe-headers` is app-wide. It also stops dropping
`Referer`/`Cookie`/`Host`, so the deliberate `Origin`/`Referer` spoofs in
`yandexShared.ts` and `edgeTTS.ts` now reach the wire as intended. Given the
http scope is already `https://*:*` and the plugin carries no ambient
credentials, the added surface is marginal.

## Verification

- New unit test asserting both the exchange and the refresh send the sentinel.
- `pnpm test` (8983), `pnpm lint`, `pnpm format:check`, `pnpm fmt:check`,
  `pnpm clippy:check`, `pnpm test:rust` (91).
- `cargo tree -p tauri-plugin-http -f "{p} feats={f}"` confirms the feature
  resolves onto the dependency.
- Real Chromium silently drops `Origin: ''`, so the web SPA flow is untouched.
- **macOS**: OneDrive OAuth now completes.
- **Android (Xiaomi 13)**: OneDrive OAuth now completes. Probed the installed
  APK through its own HTTP plugin against a header-echo server: the request
  carrying the sentinel arrived with no `origin` header, while one without it
  arrived with `origin: http://tauri.localhost`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
