### PR TITLE
fix(android): stop claiming APKs and other downloads as openable books

### DIFF
--- a/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -69,9 +69,7 @@
                 <data android:mimeType="application/vnd.amazon.mobi8-ebook" />
                 <data android:mimeType="application/vnd.comicbook+zip" />
                 <data android:mimeType="application/x-cbz" />
-                <data android:mimeType="application/zip" />
                 <data android:mimeType="text/plain" />
-                <data android:mimeType="application/octet-stream"/>
                 <data android:mimeType="application/x-font-ttf"/>
                 <data android:mimeType="application/x-font-otf"/>
             </intent-filter>
@@ -83,17 +81,28 @@
 
                 <data android:scheme="content" />
                 <data android:scheme="file" />
+                <data android:host="*" />
                 <data android:mimeType="*/*" />
                 <data android:pathPattern=".*\\.epub" />
+                <data android:pathSuffix=".epub" />
                 <data android:pathPattern=".*\\.pdf" />
+                <data android:pathSuffix=".pdf" />
                 <data android:pathPattern=".*\\.fb2" />
+                <data android:pathSuffix=".fb2" />
                 <data android:pathPattern=".*\\.fb2.zip" />
+                <data android:pathSuffix=".fb2.zip" />
                 <data android:pathPattern=".*\\.mobi" />
+                <data android:pathSuffix=".mobi" />
                 <data android:pathPattern=".*\\.azw" />
+                <data android:pathSuffix=".azw" />
                 <data android:pathPattern=".*\\.azw3" />
+                <data android:pathSuffix=".azw3" />
                 <data android:pathPattern=".*\\.cbz" />
+                <data android:pathSuffix=".cbz" />
                 <data android:pathPattern=".*\\.zip" />
+                <data android:pathSuffix=".zip" />
                 <data android:pathPattern=".*\\.txt" />
+                <data android:pathSuffix=".txt" />
             </intent-filter>
 
             <intent-filter>

--- a/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -70,6 +70,7 @@
                 <data android:mimeType="application/vnd.comicbook+zip" />
                 <data android:mimeType="application/x-cbz" />
                 <data android:mimeType="text/plain" />
+                <data android:mimeType="text/markdown" />
                 <data android:mimeType="application/x-font-ttf"/>
                 <data android:mimeType="application/x-font-otf"/>
             </intent-filter>
@@ -103,6 +104,8 @@
                 <data android:pathSuffix=".zip" />
                 <data android:pathPattern=".*\\.txt" />
                 <data android:pathSuffix=".txt" />
+                <data android:pathPattern=".*\\.md" />
+                <data android:pathSuffix=".md" />
             </intent-filter>
 
             <intent-filter>


### PR DESCRIPTION
## Problem

Downloaded APKs (and images, videos, archives, basically anything) offer Readest in the "Open with" chooser on Android, and stick to it once a user taps Always.

## Root cause

The second `ACTION_VIEW` intent filter in `AndroidManifest.xml` was meant to match books by file extension:

```xml
<data android:scheme="content" />
<data android:scheme="file" />
<data android:mimeType="*/*" />
<data android:pathPattern=".*\\.epub" />
...
```

It declares no `android:host`. Per the [`<data>` docs](https://developer.android.com/guide/topics/manifest/data-element), *"if a host is not specified, the port attribute and all the path attributes are ignored"* (`IntentFilter.matchData()` only walks `mDataPaths` when `mDataAuthorities != null`). Every `pathPattern` in that filter was therefore dead code, and what actually got registered was:

> scheme `content` or `file` + MIME `*/*` = Readest handles any VIEW intent for any file of any type

An APK fires `ACTION_VIEW` with `application/vnd.android.package-archive`, matches at the same `MATCH_CATEGORY_TYPE` rank as the system package installer, and lands in the chooser.

`application/octet-stream` in the sibling filter widened this further: it is what generic download sources report for arbitrary binaries, APKs included.

## Fix

1. Keep the explicit, unambiguous ebook MIME types ungated, so extension-less `content://` URIs (Downloads `msf:` documents and similar) still open.
2. Move the generic types out of that list. `*/*` now sits behind `android:host="*"`, which makes the extension attributes live again, so unknown or mislabelled types are only claimed when the path ends in a format we can open.
3. List `pathSuffix` next to each `pathPattern`. `PatternMatcher`'s simple glob does not backtrack, so `.*\\.epub` misses `My.Book.epub`; `pathSuffix` is exact but needs API 31+, and the pair covers `minSdk = 26` through current.

`ACTION_SEND` / `SEND_MULTIPLE` keep `*/*` on purpose. Those are share sheet targets, always an explicit user choice, and never become a default handler.

A second commit adds Markdown to these filters (`text/markdown` and `.md`). It was the one format Readest opens that the hand written VIEW filters never listed, so it previously resolved only through the generated `tauri-file-associations` block.

## Verification

Manifest is well formed (`xmllint --noout`). No TS or Rust sources changed, so `pnpm test` / `pnpm lint` / clippy are unaffected.

Device check still pending, and worth doing on hardware:

```bash
# should list only the system package installer, not com.bilingify.readest
adb shell pm query-activities -a android.intent.action.VIEW \
  -t application/vnd.android.package-archive \
  -d "content://com.android.providers.downloads.documents/document/1"

# should still list Readest
adb shell pm query-activities -a android.intent.action.VIEW \
  -t application/epub+zip \
  -d "content://com.android.externalstorage.documents/document/primary:Download/book.epub"
```

Note that an existing "always open with Readest" preference survives the upgrade. Clearing it needs Settings > Apps > Readest > Open by default > Clear defaults, or a reinstall.

## Trade-off

`.azw3` / `.fb2` files served as `application/octet-stream` through a provider whose URI path carries no filename (some Downloads `msf:` URIs) will no longer offer Readest in the chooser. Importing them through the in-app file picker still works. This is the deliberate cost of not claiming every unknown binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)