### PR TITLE
fix(library): checkpoint, serialize, and pool folder imports

### DIFF
--- a/apps/readest-app/src/__tests__/services/import-hash-race.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-hash-race.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Book } from '@/types/book';
+
+const mockOpen = vi.hoisted(() => vi.fn());
+const mockPartialMD5 = vi.hoisted(() => vi.fn());
+
+vi.mock('@/utils/md5', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/md5')>('@/utils/md5');
+  return { ...actual, partialMD5: mockPartialMD5 };
+});
+
+vi.mock('@/libs/document', async () => {
+  const actual = await vi.importActual<typeof import('@/libs/document')>('@/libs/document');
+  class MockDocumentLoader {
+    open() {
+      return mockOpen();
+    }
+  }
+  return { ...actual, DocumentLoader: MockDocumentLoader };
+});
+
+vi.mock('@/utils/txt', () => ({ TxtToEpubConverter: vi.fn() }));
+vi.mock('@/utils/svg', () => ({ svg2png: vi.fn() }));
+vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }));
+vi.mock('@/libs/storage', () => ({
+  downloadFile: vi.fn(),
+  uploadFile: vi.fn(),
+  deleteFile: vi.fn(),
+  createProgressHandler: vi.fn(),
+  batchGetDownloadUrls: vi.fn(),
+}));
+
+import { BaseAppService } from '@/services/appService';
+import { buildBookLookupIndex } from '@/services/bookService';
+
+class TestAppService extends BaseAppService {
+  protected fs = {
+    openFile: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    copyFile: vi.fn(),
+    removeFile: vi.fn(),
+    readDir: vi.fn(),
+    createDir: vi.fn(),
+    removeDir: vi.fn(),
+    exists: vi.fn(),
+    stats: vi.fn(),
+    resolvePath: vi.fn(),
+    getURL: vi.fn(),
+    getBlobURL: vi.fn().mockResolvedValue(''),
+    getImageURL: vi.fn(),
+    getPrefix: vi.fn(),
+  };
+
+  protected resolvePath() {
+    return { baseDir: 0, basePrefix: async () => '', fp: '', base: 'Books' as const };
+  }
+
+  override osPlatform = 'linux' as BaseAppService['osPlatform'];
+
+  async init() {}
+  async setCustomRootDir() {}
+  async selectDirectory() {
+    return '';
+  }
+  async selectFiles() {
+    return [];
+  }
+  async saveFile() {
+    return false;
+  }
+  async saveImageToGallery() {
+    return false;
+  }
+  async ask() {
+    return false;
+  }
+  async openDatabase() {
+    return {} as ReturnType<BaseAppService['openDatabase']>;
+  }
+  async createWindow() {}
+  async getCacheDir() {
+    return '';
+  }
+  async clearWebviewCache() {}
+  async showNotification() {}
+
+  getFs() {
+    return this.fs;
+  }
+}
+
+const TEST_METADATA = {
+  title: 'Race Book',
+  author: 'Race Author',
+  language: 'en',
+  identifier: 'race-id-1',
+};
+
+/**
+ * The folder import pool runs several importBook calls concurrently against
+ * one shared `books` array / lookup index. Each call reads `byHash` right
+ * after `partialMD5` resolves but only writes the index much later (after
+ * createDir / writeFile / cover awaits). Two files with identical bytes in
+ * flight together therefore both miss the lookup and both push a row — one
+ * source of the duplicate library entries in #5601. importBook must re-check
+ * the index synchronously before pushing and adopt the winner's row instead.
+ */
+describe('importBook concurrent same-hash race', () => {
+  let service: TestAppService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TestAppService();
+    const fs = service.getFs();
+    fs.openFile.mockImplementation(
+      async (path: string) => new File(['same-bytes'], path.split('/').pop()!),
+    );
+    fs.exists.mockResolvedValue(false);
+    fs.createDir.mockResolvedValue(undefined);
+    fs.writeFile.mockResolvedValue(undefined);
+    fs.removeDir.mockResolvedValue(undefined);
+    fs.readFile.mockResolvedValue('{}');
+
+    mockOpen.mockImplementation(async () => ({
+      book: {
+        metadata: { ...TEST_METADATA },
+        getCover: vi.fn().mockResolvedValue(null),
+        destroy: vi.fn(),
+      },
+      format: 'EPUB',
+    }));
+  });
+
+  const gateBothImportsOnHash = () => {
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let arrived = 0;
+    mockPartialMD5.mockImplementation(async () => {
+      arrived += 1;
+      if (arrived === 2) release();
+      await barrier;
+      return 'same-hash-race';
+    });
+  };
+
+  it('does not push duplicate rows when two identical files import concurrently (books.find arm)', async () => {
+    gateBothImportsOnHash();
+    const books: Book[] = [];
+
+    const [a, b] = await Promise.all([
+      service.importBook('/watched/copy-one.epub', books),
+      service.importBook('/watched/copy-two.epub', books),
+    ]);
+
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(books).toHaveLength(1);
+    expect(a).toBe(b);
+  });
+
+  it('does not push duplicate rows when two identical files import concurrently (lookupIndex arm)', async () => {
+    gateBothImportsOnHash();
+    const books: Book[] = [];
+    const lookupIndex = buildBookLookupIndex(books, 'linux');
+
+    const [a, b] = await Promise.all([
+      service.importBook('/watched/copy-one.epub', books, { lookupIndex }),
+      service.importBook('/watched/copy-two.epub', books, { lookupIndex }),
+    ]);
+
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(books).toHaveLength(1);
+    expect(a).toBe(b);
+    expect(lookupIndex.byHash.get('same-hash-race')).toBe(a);
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/checkpoint.test.ts
+++ b/apps/readest-app/src/__tests__/utils/checkpoint.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createThrottledCheckpoint } from '@/utils/checkpoint';
+
+/**
+ * Import checkpointing (#5601): during a long folder import the library index
+ * must be persisted periodically — not once at the very end — so a crash/kill
+ * mid-import loses at most one interval of work instead of the entire run.
+ * The saver must coalesce bursts (full-library serialization is expensive),
+ * never overlap two saves, and guarantee a final save via flush().
+ */
+describe('createThrottledCheckpoint', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('saves immediately on the first touch and coalesces touches within the interval', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const checkpoint = createThrottledCheckpoint(save, 1000);
+
+    checkpoint.touch();
+    expect(save).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(500);
+    checkpoint.touch();
+    checkpoint.touch();
+    expect(save).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(500);
+    checkpoint.touch();
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+
+  it('never overlaps saves even when a save outlives the interval', async () => {
+    let resolveSave!: () => void;
+    const save = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    const checkpoint = createThrottledCheckpoint(save, 1000);
+
+    checkpoint.touch();
+    expect(save).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5000);
+    checkpoint.touch();
+    expect(save).toHaveBeenCalledTimes(1);
+
+    resolveSave();
+    await vi.advanceTimersByTimeAsync(1000);
+    checkpoint.touch();
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+
+  it('flush() is a no-op when the state is already saved', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const checkpoint = createThrottledCheckpoint(save, 1000);
+
+    checkpoint.touch();
+    await checkpoint.flush();
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it('flush() waits for the in-flight save and then persists dirty state', async () => {
+    let resolveSave!: () => void;
+    const save = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSave = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+    const checkpoint = createThrottledCheckpoint(save, 1000);
+
+    checkpoint.touch();
+    checkpoint.touch(); // dirty while save #1 is in flight
+    const flushed = checkpoint.flush();
+    resolveSave();
+    await flushed;
+
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+
+  it('a failed touch-save keeps the state dirty so flush() retries', async () => {
+    const save = vi.fn().mockRejectedValueOnce(new Error('disk full')).mockResolvedValue(undefined);
+    const checkpoint = createThrottledCheckpoint(save, 1000);
+
+    checkpoint.touch();
+    await vi.advanceTimersByTimeAsync(0);
+
+    await checkpoint.flush();
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+
+  it('flush() propagates a save failure', async () => {
+    const save = vi.fn().mockRejectedValue(new Error('disk full'));
+    const checkpoint = createThrottledCheckpoint(save, 1000);
+
+    checkpoint.touch();
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(checkpoint.flush()).rejects.toThrow('disk full');
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/concurrency.test.ts
+++ b/apps/readest-app/src/__tests__/utils/concurrency.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { runWithConcurrency } from '@/utils/concurrency';
+import { createSerialRunner, runWithConcurrency } from '@/utils/concurrency';
 
 /**
  * Tests for the shared bounded-concurrency runner used by nav build,
@@ -98,5 +98,54 @@ describe('runWithConcurrency', () => {
       active -= 1;
     });
     expect(peak).toBe(1);
+  });
+});
+
+/**
+ * Serializer for whole import runs (#5601): the manual Import-from-Folder
+ * flow and the watched-folder auto-scan can otherwise overlap, each building
+ * its own lookup index over the same library and double-importing the same
+ * files. Runs must execute strictly one after another, and one run's failure
+ * must not wedge the queue.
+ */
+describe('createSerialRunner', () => {
+  test('runs tasks strictly in submission order, one at a time', async () => {
+    const enqueue = createSerialRunner();
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = enqueue(async () => {
+      events.push('first:start');
+      await firstGate;
+      events.push('first:end');
+      return 1;
+    });
+    const second = enqueue(async () => {
+      events.push('second:start');
+      return 2;
+    });
+
+    await wait(2);
+    expect(events).toEqual(['first:start']);
+
+    releaseFirst();
+    await expect(first).resolves.toBe(1);
+    await expect(second).resolves.toBe(2);
+    expect(events).toEqual(['first:start', 'first:end', 'second:start']);
+  });
+
+  test('a rejected run propagates to its caller without blocking later runs', async () => {
+    const enqueue = createSerialRunner();
+
+    const failing = enqueue(async () => {
+      throw new Error('import exploded');
+    });
+    const following = enqueue(async () => 'ok');
+
+    await expect(failing).rejects.toThrow('import exploded');
+    await expect(following).resolves.toBe('ok');
   });
 });

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -16,6 +16,8 @@ import {
   toWatchedFolderImports,
 } from '@/services/bookService';
 import { debounce } from '@/utils/debounce';
+import { createSerialRunner, runWithConcurrency } from '@/utils/concurrency';
+import { createThrottledCheckpoint } from '@/utils/checkpoint';
 import { DEFAULT_NEARBY_WORDS } from '@/utils/searchConfig';
 import { clearLibrarySearchHistory, loadLibrarySearchHistory } from './utils/searchHistory';
 import type { LibrarySearchTarget } from '@/types/book';
@@ -128,6 +130,18 @@ import TransferQueuePanel from './components/TransferQueuePanel';
 
 /** Skip tiny non-book artifacts during folder auto-scan (matches the manual import dialog default). */
 const AUTO_IMPORT_MIN_SIZE_BYTES = 20 * 1024;
+
+const IMPORT_CONCURRENCY = 4;
+// How often the library index is persisted during a long import (#5601). A
+// crash/kill mid-run loses at most this much work instead of the entire run;
+// keep it long enough that the full-library serialization stays a rounding
+// error next to the per-file parse/copy work.
+const IMPORT_CHECKPOINT_INTERVAL_MS = 15 * 1000;
+// One import run at a time, app-wide: the manual Import-from-Folder flow and
+// the watched-folder auto-scan must not interleave — each builds a lookup
+// index over the same live library array, so overlapping runs re-import the
+// same files as duplicate rows (#5601).
+const enqueueImportRun = createSerialRunner();
 const LIBRARY_SEARCH_MODES: LibrarySearchConfig['mode'][] = [
   'contains',
   'whole-words',
@@ -849,7 +863,17 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [demoBooks, libraryLoaded]);
 
-  const importBooks = async (
+  const importBooks = (
+    files: SelectedFile[],
+    groupId?: string,
+    options: { silent?: boolean } = {},
+  ): Promise<{ failedPaths: string[] }> =>
+    // Whole runs are serialized (see enqueueImportRun); the lookup index is
+    // built inside the run so a queued run sees everything the previous one
+    // imported.
+    enqueueImportRun(() => importBooksRun(files, groupId, options));
+
+  const importBooksRun = async (
     files: SelectedFile[],
     groupId?: string,
     options: { silent?: boolean } = {},
@@ -934,22 +958,33 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
       }
     };
 
-    const concurrency = 4;
-    for (let i = 0; i < files.length; i += concurrency) {
-      const batch = files.slice(i, i + concurrency);
-      const importedBooks = (await Promise.all(batch.map(processFile))).filter((book) => !!book);
-      // Update store state per batch (so the UI can render imported books
-      // incrementally) but defer disk persistence until the entire batch is
-      // done — saving library.json once per batch of 4 books was the dominant
-      // cost for large imports.
-      await updateBooks(envConfig, importedBooks, { skipSave: true });
-    }
+    // Periodically persist the library index while the run is in flight so a
+    // crash/kill mid-import (#5601: WebKit resource exhaustion during bulk
+    // TXT folder import) loses at most one interval of work instead of the
+    // whole run — the book dirs are written per file, and index rows that
+    // never reach disk are what re-imports and duplicate rows are made of.
+    // Saving per book would bring back the "library.json save dominates large
+    // imports" cost, hence the throttle.
+    const checkpoint = createThrottledCheckpoint(async () => {
+      const currentLibrary = useLibraryStore.getState().library;
+      const currentAppService = await envConfig.getAppService();
+      await currentAppService.saveLibraryBooks(currentLibrary);
+    }, IMPORT_CHECKPOINT_INTERVAL_MS);
 
-    // Persist the full library once after every file in the batch is done.
+    // A true worker pool (not the old barrier batches of 4): a slow file no
+    // longer stalls three finished siblings, and each completed book streams
+    // into the store immediately so the shelf renders incrementally.
+    await runWithConcurrency(files, IMPORT_CONCURRENCY, async (selectedFile) => {
+      const book = await processFile(selectedFile);
+      if (book) {
+        await updateBooks(envConfig, [book], { skipSave: true });
+        checkpoint.touch();
+      }
+    });
+
+    // Persist whatever the last checkpoint hasn't covered.
     if (successfulImports.length > 0) {
-      const finalLibrary = useLibraryStore.getState().library;
-      const finalAppService = await envConfig.getAppService();
-      await finalAppService.saveLibraryBooks(finalLibrary);
+      await checkpoint.flush();
     }
 
     pushLibrary();

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -674,14 +674,27 @@ export async function importBook(
     // Never overwrite the config file only when it's not existed
     if (!existingBook) {
       await saveBookConfigFn(book, INIT_BOOK_CONFIG);
-      books.push(book);
-      if (lookupIndex) {
-        lookupIndex.byHash.set(book.hash, book);
-        if (book.metaHash) {
-          const key = `${book.metaHash}:${book.format}`;
-          const list = lookupIndex.byMetaKey.get(key);
-          if (list) list.push(book);
-          else lookupIndex.byMetaKey.set(key, [book]);
+      // Concurrent imports of identical bytes (the folder-import pool) both
+      // read `byHash` right after hashing but only write it here, after the
+      // createDir/writeFile/cover awaits — so both miss and both would push a
+      // row (#5601). Re-check synchronously after the last await and adopt
+      // the winner's row instead; the winner already wrote the same
+      // Books/<hash>/ files, ours were idempotent rewrites.
+      const raced = lookupIndex
+        ? lookupIndex.byHash.get(book.hash)
+        : books.find((b) => b.hash === book.hash);
+      if (raced) {
+        existingBook = raced;
+      } else {
+        books.push(book);
+        if (lookupIndex) {
+          lookupIndex.byHash.set(book.hash, book);
+          if (book.metaHash) {
+            const key = `${book.metaHash}:${book.format}`;
+            const list = lookupIndex.byMetaKey.get(key);
+            if (list) list.push(book);
+            else lookupIndex.byMetaKey.set(key, [book]);
+          }
         }
       }
     } else if (metaHashMatch && oldBookDir && oldBookDir !== getDir(book)) {

--- a/apps/readest-app/src/utils/checkpoint.ts
+++ b/apps/readest-app/src/utils/checkpoint.ts
@@ -1,0 +1,64 @@
+/**
+ * Periodic-persistence helper for long batch operations (#5601).
+ *
+ * A folder import used to write `library.json` once, after every file was
+ * done — killing the app mid-run lost the whole index while hundreds of book
+ * dirs were already on disk, and each relaunch re-imported and re-accumulated
+ * rows. This throttles full-index saves during the run so a crash loses at
+ * most `intervalMs` of work:
+ *
+ *   - `touch()` after each unit of work: saves immediately on the first call,
+ *     then at most once per `intervalMs`. Failures are logged and the state
+ *     stays dirty so a later touch/flush retries.
+ *   - `flush()` at the end: waits for any in-flight save, persists remaining
+ *     dirty state, and propagates failure to the caller.
+ *
+ * Saves never overlap — the full-library serialization is expensive and
+ * `safeSaveJSON` must not race itself.
+ */
+export interface ThrottledCheckpoint {
+  touch(): void;
+  flush(): Promise<void>;
+}
+
+export const createThrottledCheckpoint = (
+  save: () => Promise<void>,
+  intervalMs: number,
+): ThrottledCheckpoint => {
+  let dirty = false;
+  let saving: Promise<void> | null = null;
+  let lastStart = -Infinity;
+
+  const runSave = () => {
+    dirty = false;
+    lastStart = Date.now();
+    const current = save().finally(() => {
+      if (saving === current) saving = null;
+    });
+    saving = current;
+    return current;
+  };
+
+  return {
+    touch() {
+      dirty = true;
+      if (!saving && Date.now() - lastStart >= intervalMs) {
+        runSave().catch((error) => {
+          dirty = true;
+          console.warn('Checkpoint save failed; will retry on flush:', error);
+        });
+      }
+    },
+    async flush() {
+      while (saving || dirty) {
+        if (saving) {
+          // A touch-initiated save: its own catch handler re-dirties on
+          // failure, so just wait it out and loop.
+          await saving.catch(() => undefined);
+        } else {
+          await runSave();
+        }
+      }
+    },
+  };
+};

--- a/apps/readest-app/src/utils/concurrency.ts
+++ b/apps/readest-app/src/utils/concurrency.ts
@@ -37,6 +37,25 @@ export interface ConcurrencyTaskFailure<T> {
 
 export type ConcurrencyTaskOutcome<T, R> = ConcurrencyTaskSuccess<T, R> | ConcurrencyTaskFailure<T>;
 
+/**
+ * Serializer for whole async runs. Each enqueued run starts only after every
+ * previously enqueued run has settled; a run's rejection propagates to its
+ * own caller but never blocks the queue.
+ *
+ * Used to single-flight library imports (#5601): the manual Import-from-Folder
+ * flow and the watched-folder auto-scan would otherwise interleave, each
+ * building its own lookup index over the same library array and pushing
+ * duplicate rows for the same files.
+ */
+export function createSerialRunner(): <T>(run: () => Promise<T>) => Promise<T> {
+  let tail: Promise<unknown> = Promise.resolve();
+  return <T>(run: () => Promise<T>): Promise<T> => {
+    const next = tail.then(run, run);
+    tail = next.catch(() => undefined);
+    return next;
+  };
+}
+
 export async function runWithConcurrency<T, R>(
   items: T[],
   concurrency: number,


### PR DESCRIPTION
Fixes #5601. Follow-up to #5607.

## Summary

#5607 fixed the per-file leaks (TXT source handle, chapter HTML residency). This PR fixes the structural problems in the folder import pipeline that produced the rest of #5601: the unbounded crash blast radius (815 index rows for 428 source files after repeated mid-import kills) and the double-import races.

## Root Causes

1. `library.json` was persisted once, after the entire batch. Book dirs, covers, and configs are written per file, so killing the app at file 300 of 428 left 300 book directories with zero index rows. Partial rows leaked in through unrelated savers (sync updateLibrary, the throttled bookDataStore save), and `saveLibraryBooks` merges with disk, so rows accumulated across restart cycles instead of converging.
2. The import loop was a lockstep batch of 4 (`Promise.all` per slice): one slow file held three finished conversions in memory, and nothing streamed to disk.
3. The manual Import-from-Folder flow (fire-and-forget) and the watched-folder auto-scan could interleave, each building its own lookup index over the same live library array.
4. Within one batch, two files with identical bytes both read `byHash` right after hashing but only registered themselves after the createDir/writeFile/cover awaits, so both missed and both pushed a row.

## Changes

- Replace the batch loop with the existing `runWithConcurrency` worker pool (concurrency unchanged at 4); each completed book streams into the store immediately.
- New `createThrottledCheckpoint` (`src/utils/checkpoint.ts`): the library index is saved on a 15 s throttle during the run (leading + trailing edge, saves never overlap, failed saves stay dirty and retry) with a guaranteed `flush()` at the end. A mid-import kill now loses at most one interval of work, and the restart dedupes against everything already checkpointed.
- New `createSerialRunner` (`src/utils/concurrency.ts`): whole `importBooks` runs are serialized, so the manual flow and the auto-scan can no longer interleave.
- `importBook` re-checks the hash index synchronously right before pushing a new row and adopts the winner's row instead, so concurrent imports of identical bytes collapse into one entry whose tail still records the loser's path (`displaceSourcePath`).

## Testing

- New mechanism tests, written failing-first: `import-hash-race.test.ts` (a barrier on `partialMD5` forces both concurrent imports past the dedupe read; asserts a single row in both the `books.find` and `lookupIndex` arms), `checkpoint.test.ts` (throttle, overlap, retry, and flush semantics), and serial-runner ordering/failure-isolation cases in `concurrency.test.ts`.
- Full suite green: 9007 tests. Lint clean.
- Device verification on a Xiaomi 13: imported a 170-file TXT folder in place, force-killed the app mid-import, relaunched, and re-ran. The checkpoint preserved all 94 rows saved before the kill, the resumed run completed at exactly baseline + 170 rows with zero duplicate hashes or metaKeys, a third run added zero rows, and PSS stayed bounded (~282 MB peak) throughout.

## Remaining (out of scope)

- macOS import reads route through the asset protocol into WebKit.Networking; that process's footprint during a large import is untouched by this PR (noted on #5601).
- Android `allow_paths_in_scopes` returns Ok without actually extending fs/asset scope for a path never granted via the picker, so the "restored last folder, user hits OK" flow fails every file open. Found while device-testing; needs its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
