### PR TITLE
fix(translation): gate Enable Translation on book availability

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2315,5 +2315,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "تُضاف الكتب الواردة إلى مكتبتك بعد قبولك كل طلب نقل.",
   "Only book files are accepted; other file types are declined automatically.": "تُقبل ملفات الكتب فقط؛ وتُرفض أنواع الملفات الأخرى تلقائيًا.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "اكتشاف الأجهزة عبر البث المتعدد غير متاح؛ قد تحتاج الأجهزة إلى تحديث يدوي.",
-  "On": "مفعّل"
+  "On": "مفعّل",
+  "Not available for this book.": "غير متاح لهذا الكتاب."
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2091,5 +2091,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "প্রতিটি স্থানান্তর অনুরোধ গ্রহণের পর প্রাপ্ত বই আপনার লাইব্রেরিতে যুক্ত হয়।",
   "Only book files are accepted; other file types are declined automatically.": "শুধুমাত্র বইয়ের ফাইল গৃহীত হয়; অন্যান্য ফাইল স্বয়ংক্রিয়ভাবে প্রত্যাখ্যাত হয়।",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "মাল্টিকাস্টের মাধ্যমে ডিভাইস খোঁজা যাচ্ছে না; ম্যানুয়ালি রিফ্রেশ করার প্রয়োজন হতে পারে।",
-  "On": "চালু"
+  "On": "চালু",
+  "Not available for this book.": "এই বইয়ের জন্য উপলব্ধ নয়।"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2035,5 +2035,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "བརྒྱུད་སྐུར་རེ་འདུན་རེ་རེ་དང་ལེན་བྱས་རྗེས་འབྱོར་བའི་དེབ་དཔེ་མཛོད་ནང་སྣོན་རྒྱུ།",
   "Only book files are accepted; other file types are declined automatically.": "དེབ་ཡིག་ཆ་ཁོ་ན་དང་ལེན་བྱེད། ཡིག་ཆ་རིགས་གཞན་རང་འགུལ་གྱིས་ཁས་མི་ལེན།",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Multicast བརྒྱུད་སྒྲིག་ཆས་འཚོལ་མི་ཐུབ། ལག་ཐོག་གསར་སྒྱུར་དགོས་སྲིད།",
-  "On": "ཁ་ཕྱེ།"
+  "On": "ཁ་ཕྱེ།",
+  "Not available for this book.": "དེབ་འདིར་བེད་སྤྱོད་མི་ཐུབ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2091,5 +2091,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Eingehende Bücher werden Ihrer Bibliothek hinzugefügt, nachdem Sie jede Übertragungsanfrage angenommen haben.",
   "Only book files are accepted; other file types are declined automatically.": "Es werden nur Buchdateien angenommen; andere Dateitypen werden automatisch abgelehnt.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Geräteerkennung über Multicast ist nicht verfügbar; Geräte müssen möglicherweise manuell aktualisiert werden.",
-  "On": "Ein"
+  "On": "Ein",
+  "Not available for this book.": "Für dieses Buch nicht verfügbar."
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2091,5 +2091,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Τα εισερχόμενα βιβλία προστίθενται στη βιβλιοθήκη σας αφού αποδεχτείτε κάθε αίτημα μεταφοράς.",
   "Only book files are accepted; other file types are declined automatically.": "Γίνονται δεκτά μόνο αρχεία βιβλίων· οι άλλοι τύποι αρχείων απορρίπτονται αυτόματα.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Η ανακάλυψη συσκευών μέσω multicast δεν είναι διαθέσιμη· ίσως χρειαστεί χειροκίνητη ανανέωση.",
-  "On": "Ενεργό"
+  "On": "Ενεργό",
+  "Not available for this book.": "Μη διαθέσιμο για αυτό το βιβλίο."
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2147,5 +2147,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Los libros entrantes se añaden a tu biblioteca después de aceptar cada solicitud de transferencia.",
   "Only book files are accepted; other file types are declined automatically.": "Solo se aceptan archivos de libros; los demás tipos de archivo se rechazan automáticamente.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "La detección de dispositivos por multicast no está disponible; puede que necesites actualizar manualmente.",
-  "On": "Activado"
+  "On": "Activado",
+  "Not available for this book.": "No disponible para este libro."
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2091,5 +2091,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "کتاب‌های دریافتی پس از پذیرش هر درخواست انتقال به کتابخانه شما افزوده می‌شوند.",
   "Only book files are accepted; other file types are declined automatically.": "فقط فایل‌های کتاب پذیرفته می‌شوند؛ سایر انواع فایل به‌طور خودکار رد می‌شوند.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "یافتن دستگاه‌ها از طریق مالتی‌کست در دسترس نیست؛ ممکن است نیاز به به‌روزرسانی دستی باشد.",
-  "On": "روشن"
+  "On": "روشن",
+  "Not available for this book.": "برای این کتاب در دسترس نیست."
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2147,5 +2147,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Les livres entrants sont ajoutés à votre bibliothèque après acceptation de chaque demande de transfert.",
   "Only book files are accepted; other file types are declined automatically.": "Seuls les fichiers de livres sont acceptés ; les autres types de fichiers sont refusés automatiquement.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "La découverte d’appareils par multicast est indisponible ; une actualisation manuelle peut être nécessaire.",
-  "On": "Activé"
+  "On": "Activé",
+  "Not available for this book.": "Non disponible pour ce livre."
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2147,5 +2147,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "ספרים נכנסים מתווספים לספרייה לאחר אישור כל בקשת העברה.",
   "Only book files are accepted; other file types are declined automatically.": "רק קובצי ספרים מתקבלים; סוגי קבצים אחרים נדחים אוטומטית.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "גילוי מכשירים באמצעות multicast אינו זמין; ייתכן שיידרש רענון ידני.",
-  "On": "פעיל"
+  "On": "פעיל",
+  "Not available for this book.": "לא זמין עבור ספר זה."
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2091,5 +2091,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "प्रत्येक स्थानांतरण अनुरोध स्वीकार करने के बाद प्राप्त पुस्तकें आपकी लाइब्रेरी में जुड़ जाती हैं।",
   "Only book files are accepted; other file types are declined automatically.": "केवल पुस्तक फ़ाइलें स्वीकार की जाती हैं; अन्य फ़ाइल प्रकार स्वतः अस्वीकार कर दिए जाते हैं।",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "मल्टीकास्ट के माध्यम से डिवाइस खोज उपलब्ध नहीं है; डिवाइस को मैन्युअल रूप से रीफ़्रेश करने की आवश्यकता हो सकती है।",
-  "On": "चालू"
+  "On": "चालू",
+  "Not available for this book.": "इस पुस्तक के लिए उपलब्ध नहीं है।"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2091,5 +2091,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "A beérkező könyvek az egyes átviteli kérések elfogadása után kerülnek a könyvtárába.",
   "Only book files are accepted; other file types are declined automatically.": "Csak könyvfájlok fogadhatók; a többi fájltípus automatikusan elutasításra kerül.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "A multicast alapú eszközkeresés nem érhető el; kézi frissítésre lehet szükség.",
-  "On": "Be"
+  "On": "Be",
+  "Not available for this book.": "Ehhez a könyvhöz nem érhető el."
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2035,5 +2035,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Buku yang masuk ditambahkan ke perpustakaan setelah Anda menerima setiap permintaan transfer.",
   "Only book files are accepted; other file types are declined automatically.": "Hanya berkas buku yang diterima; jenis berkas lain ditolak secara otomatis.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Penemuan perangkat melalui multicast tidak tersedia; perangkat mungkin perlu disegarkan secara manual.",
-  "On": "Aktif"
+  "On": "Aktif",
+  "Not available for this book.": "Tidak tersedia untuk buku ini."
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2147,5 +2147,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "I libri in arrivo vengono aggiunti alla tua libreria dopo aver accettato ogni richiesta di trasferimento.",
   "Only book files are accepted; other file types are declined automatically.": "Vengono accettati solo file di libri; gli altri tipi di file vengono rifiutati automaticamente.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Il rilevamento dei dispositivi via multicast non è disponibile; potrebbe essere necessario un aggiornamento manuale.",
-  "On": "Attivo"
+  "On": "Attivo",
+  "Not available for this book.": "Non disponibile per questo libro."
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2035,5 +2035,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "受信した本は、各転送リクエストを受け入れた後にライブラリに追加されます。",
   "Only book files are accepted; other file types are declined automatically.": "本のファイルのみ受け入れられ、その他のファイルは自動的に拒否されます。",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "マルチキャストによるデバイス検出が利用できません。手動での更新が必要な場合があります。",
-  "On": "オン"
+  "On": "オン",
+  "Not available for this book.": "この本では利用できません。"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2035,5 +2035,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "수신한 책은 각 전송 요청을 수락한 후 라이브러리에 추가됩니다.",
   "Only book files are accepted; other file types are declined automatically.": "책 파일만 수락되며, 다른 파일 형식은 자동으로 거절됩니다.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "멀티캐스트를 통한 기기 검색을 사용할 수 없습니다. 수동 새로고침이 필요할 수 있습니다.",
-  "On": "켜짐"
+  "On": "켜짐",
+  "Not available for this book.": "이 책에서는 사용할 수 없습니다."
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2035,5 +2035,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Buku yang diterima ditambahkan ke perpustakaan anda selepas anda menerima setiap permintaan pemindahan.",
   "Only book files are accepted; other file types are declined automatically.": "Hanya fail buku diterima; jenis fail lain ditolak secara automatik.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Penemuan peranti melalui multicast tidak tersedia; peranti mungkin perlu dimuat semula secara manual.",
-  "On": "Hidup"
+  "On": "Hidup",
+  "Not available for this book.": "Tidak tersedia untuk buku ini."
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2091,5 +2091,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Binnenkomende boeken worden aan uw bibliotheek toegevoegd nadat u elk overdrachtsverzoek accepteert.",
   "Only book files are accepted; other file types are declined automatically.": "Alleen boekbestanden worden geaccepteerd; andere bestandstypen worden automatisch geweigerd.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Apparaatdetectie via multicast is niet beschikbaar; apparaten moeten mogelijk handmatig vernieuwd worden.",
-  "On": "Aan"
+  "On": "Aan",
+  "Not available for this book.": "Niet beschikbaar voor dit boek."
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2203,5 +2203,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Przychodzące książki są dodawane do biblioteki po zaakceptowaniu każdej prośby o przesłanie.",
   "Only book files are accepted; other file types are declined automatically.": "Akceptowane są tylko pliki książek; inne typy plików są automatycznie odrzucane.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Wykrywanie urządzeń przez multicast jest niedostępne; może być potrzebne ręczne odświeżenie.",
-  "On": "Wł."
+  "On": "Wł.",
+  "Not available for this book.": "Niedostępne dla tej książki."
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2147,5 +2147,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Os livros recebidos são adicionados à sua biblioteca depois que você aceita cada solicitação de transferência.",
   "Only book files are accepted; other file types are declined automatically.": "Somente arquivos de livros são aceitos; outros tipos de arquivo são recusados automaticamente.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "A descoberta de dispositivos por multicast não está disponível; pode ser necessário atualizar manualmente.",
-  "On": "Ativado"
+  "On": "Ativado",
+  "Not available for this book.": "Não disponível para este livro."
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2147,5 +2147,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Os livros recebidos são adicionados à sua biblioteca depois de aceitar cada pedido de transferência.",
   "Only book files are accepted; other file types are declined automatically.": "Apenas ficheiros de livros são aceites; outros tipos de ficheiro são recusados automaticamente.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "A deteção de dispositivos por multicast não está disponível; pode ser necessária uma atualização manual.",
-  "On": "Ativado"
+  "On": "Ativado",
+  "Not available for this book.": "Não disponível para este livro."
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2147,5 +2147,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Cărțile primite sunt adăugate în bibliotecă după ce acceptați fiecare cerere de transfer.",
   "Only book files are accepted; other file types are declined automatically.": "Sunt acceptate doar fișierele de cărți; celelalte tipuri de fișiere sunt refuzate automat.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Descoperirea dispozitivelor prin multicast nu este disponibilă; poate fi necesară o reîmprospătare manuală.",
-  "On": "Activat"
+  "On": "Activat",
+  "Not available for this book.": "Indisponibil pentru această carte."
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2203,5 +2203,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Входящие книги добавляются в библиотеку после подтверждения каждого запроса на передачу.",
   "Only book files are accepted; other file types are declined automatically.": "Принимаются только файлы книг; другие типы файлов отклоняются автоматически.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Обнаружение устройств через multicast недоступно; может потребоваться обновить список вручную.",
-  "On": "Вкл."
+  "On": "Вкл.",
+  "Not available for this book.": "Недоступно для этой книги."
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2091,5 +2091,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "එක් එක් හුවමාරු ඉල්ලීම පිළිගත් පසු ලැබෙන පොත් ඔබගේ පුස්තකාලයට එකතු වේ.",
   "Only book files are accepted; other file types are declined automatically.": "පොත් ගොනු පමණක් පිළිගැනේ; වෙනත් ගොනු වර්ග ස්වයංක්‍රීයව ප්‍රතික්ෂේප වේ.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Multicast හරහා උපාංග සොයාගැනීම නොමැත; අතින් නැවුම් කිරීමට සිදු විය හැක.",
-  "On": "සක්‍රියයි"
+  "On": "සක්‍රියයි",
+  "Not available for this book.": "මෙම පොත සඳහා නොමැත."
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2203,5 +2203,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Prejete knjige so dodane v knjižnico, ko sprejmete vsako zahtevo za prenos.",
   "Only book files are accepted; other file types are declined automatically.": "Sprejete so le datoteke knjig; druge vrste datotek so samodejno zavrnjene.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Odkrivanje naprav prek multicasta ni na voljo; morda bo potrebna ročna osvežitev.",
-  "On": "Vklopljeno"
+  "On": "Vklopljeno",
+  "Not available for this book.": "Ni na voljo za to knjigo."
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2091,5 +2091,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Inkommande böcker läggs till i ditt bibliotek efter att du accepterat varje överföringsförfrågan.",
   "Only book files are accepted; other file types are declined automatically.": "Endast bokfiler accepteras; andra filtyper avböjs automatiskt.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Enhetsidentifiering via multicast är inte tillgänglig; enheter kan behöva uppdateras manuellt.",
-  "On": "På"
+  "On": "På",
+  "Not available for this book.": "Inte tillgängligt för den här boken."
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2091,5 +2091,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "ஒவ்வொரு பரிமாற்றக் கோரிக்கையையும் ஏற்றபின் பெறப்படும் புத்தகங்கள் உங்கள் நூலகத்தில் சேர்க்கப்படும்.",
   "Only book files are accepted; other file types are declined automatically.": "புத்தகக் கோப்புகள் மட்டுமே ஏற்கப்படும்; பிற வகைக் கோப்புகள் தானாக நிராகரிக்கப்படும்.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "மல்டிகாஸ்ட் வழியாக சாதனங்களைக் கண்டறிய முடியவில்லை; கைமுறையாகப் புதுப்பிக்க வேண்டியிருக்கலாம்.",
-  "On": "இயக்கத்தில்"
+  "On": "இயக்கத்தில்",
+  "Not available for this book.": "இந்தப் புத்தகத்திற்குக் கிடைக்கவில்லை."
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2035,5 +2035,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "หนังสือที่ได้รับจะถูกเพิ่มในคลังของคุณหลังจากที่คุณยอมรับคำขอถ่ายโอนแต่ละรายการ",
   "Only book files are accepted; other file types are declined automatically.": "ยอมรับเฉพาะไฟล์หนังสือเท่านั้น ไฟล์ประเภทอื่นจะถูกปฏิเสธโดยอัตโนมัติ",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "ไม่สามารถค้นหาอุปกรณ์ผ่านมัลติแคสต์ได้ อาจต้องรีเฟรชด้วยตนเอง",
-  "On": "เปิด"
+  "On": "เปิด",
+  "Not available for this book.": "ไม่พร้อมใช้งานสำหรับหนังสือเล่มนี้"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2091,5 +2091,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Gelen kitaplar, her aktarım isteğini kabul ettikten sonra kitaplığınıza eklenir.",
   "Only book files are accepted; other file types are declined automatically.": "Yalnızca kitap dosyaları kabul edilir; diğer dosya türleri otomatik olarak reddedilir.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Multicast üzerinden cihaz bulma kullanılamıyor; cihazların elle yenilenmesi gerekebilir.",
-  "On": "Açık"
+  "On": "Açık",
+  "Not available for this book.": "Bu kitap için kullanılamıyor."
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2203,5 +2203,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Вхідні книги додаються до бібліотеки після підтвердження кожного запиту на передавання.",
   "Only book files are accepted; other file types are declined automatically.": "Приймаються лише файли книг; інші типи файлів автоматично відхиляються.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Виявлення пристроїв через multicast недоступне; можливо, знадобиться оновити список вручну.",
-  "On": "Увімк."
+  "On": "Увімк.",
+  "Not available for this book.": "Недоступно для цієї книги."
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2091,5 +2091,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Kelgan kitoblar har bir uzatish so‘rovini qabul qilganingizdan keyin kutubxonangizga qo‘shiladi.",
   "Only book files are accepted; other file types are declined automatically.": "Faqat kitob fayllari qabul qilinadi; boshqa fayl turlari avtomatik rad etiladi.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Multicast orqali qurilmalarni topib bo‘lmaydi; qo‘lda yangilash kerak bo‘lishi mumkin.",
-  "On": "Yoqilgan"
+  "On": "Yoqilgan",
+  "Not available for this book.": "Bu kitob uchun mavjud emas."
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2035,5 +2035,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "Sách nhận được sẽ được thêm vào thư viện sau khi bạn chấp nhận từng yêu cầu truyền.",
   "Only book files are accepted; other file types are declined automatically.": "Chỉ chấp nhận tệp sách; các loại tệp khác sẽ tự động bị từ chối.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Không thể phát hiện thiết bị qua multicast; có thể cần làm mới thủ công.",
-  "On": "Bật"
+  "On": "Bật",
+  "Not available for this book.": "Không khả dụng cho sách này."
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2035,5 +2035,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "接收的图书会在您接受每次传输请求后加入书库。",
   "Only book files are accepted; other file types are declined automatically.": "仅接受图书文件，其他类型的文件将被自动拒绝。",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "无法通过组播发现设备，可能需要手动刷新。",
-  "On": "已开启"
+  "On": "已开启",
+  "Not available for this book.": "此书不支持此功能。"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2035,5 +2035,6 @@
   "Incoming books are added to your library after you accept each transfer request.": "接收的書籍會在您接受每次傳輸要求後加入書庫。",
   "Only book files are accepted; other file types are declined automatically.": "僅接受書籍檔案，其他類型的檔案將被自動拒絕。",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "無法透過多播探索裝置，可能需要手動重新整理。",
-  "On": "已開啟"
+  "On": "已開啟",
+  "Not available for this book.": "此書不支援此功能。"
 }

--- a/apps/readest-app/src/__tests__/components/settings/LangPanel.test.tsx
+++ b/apps/readest-app/src/__tests__/components/settings/LangPanel.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * LangPanel — "Enable Translation" availability gate (issue #5600).
+ *
+ * Translation is not available for PDFs, and the reader's toolbar toggler has
+ * always refused to turn it on for them. Settings → Language offered the same
+ * switch with no gate, so turning it on there translated the PDF text layer
+ * paragraph by paragraph and burned the daily AI translation quota — after
+ * which every selection popped a "Daily translation quota reached" toast.
+ *
+ * The switch must follow the toolbar's rule: off + unavailable => locked, but
+ * an already-on book stays toggleable so the user can turn it back off.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/react';
+
+import LangPanel from '@/components/settings/LangPanel';
+import type { Book, BookFormat, ViewSettings } from '@/types/book';
+
+const state = vi.hoisted(() => ({
+  format: 'EPUB' as BookFormat,
+  primaryLanguage: 'fr',
+  translationEnabled: false,
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ token: null }),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {} }),
+}));
+
+vi.mock('@/helpers/settings', () => ({
+  saveViewSettings: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/hooks/useResetSettings', () => ({
+  useResetViewSettings: () => vi.fn(),
+}));
+
+vi.mock('@/hooks/useKeyDownActions', () => ({
+  useKeyDownActions: () => {},
+}));
+
+const viewSettings = () =>
+  ({
+    uiLanguage: '',
+    translationEnabled: state.translationEnabled,
+    translationProvider: 'deepl',
+    translateTargetLang: 'en',
+    showTranslateSource: true,
+    ttsReadAloudText: 'both',
+    replaceQuotationMarks: false,
+    convertChineseVariant: 'none',
+  }) as unknown as ViewSettings;
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({
+    settings: { globalViewSettings: viewSettings() },
+    applyUILanguage: vi.fn(),
+    activeSettingsItemId: null,
+    setActiveSettingsItemId: vi.fn(),
+  }),
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    getView: () => null,
+    getViewSettings: () => viewSettings(),
+    setViewSettings: vi.fn(),
+    recreateViewer: vi.fn(),
+  }),
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({
+    getBookData: () => ({
+      book: { format: state.format, primaryLanguage: state.primaryLanguage } as Book,
+    }),
+  }),
+}));
+
+const getEnableTranslationToggle = () => {
+  const row = screen.getByText('Enable Translation').closest('label')!;
+  return row.querySelector('input[type="checkbox"]') as HTMLInputElement;
+};
+
+describe('LangPanel — Enable Translation availability', () => {
+  beforeEach(() => {
+    state.format = 'EPUB';
+    state.primaryLanguage = 'fr';
+    state.translationEnabled = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('allows enabling translation for a translatable book', () => {
+    render(<LangPanel bookKey='book-1' onRegisterReset={vi.fn()} />);
+
+    expect(getEnableTranslationToggle().disabled).toBe(false);
+    expect(screen.queryByText('Not available for this book.')).toBeNull();
+  });
+
+  it('locks the switch for a PDF, where translation is not available', () => {
+    state.format = 'PDF';
+
+    render(<LangPanel bookKey='book-1' onRegisterReset={vi.fn()} />);
+
+    expect(getEnableTranslationToggle().disabled).toBe(true);
+    expect(screen.getByText('Not available for this book.')).toBeTruthy();
+  });
+
+  it('locks the switch when the book is already in the target language', () => {
+    state.primaryLanguage = 'en';
+
+    render(<LangPanel bookKey='book-1' onRegisterReset={vi.fn()} />);
+
+    expect(getEnableTranslationToggle().disabled).toBe(true);
+  });
+
+  it('keeps the switch usable on a PDF that already has translation on', () => {
+    state.format = 'PDF';
+    state.translationEnabled = true;
+
+    render(<LangPanel bookKey='book-1' onRegisterReset={vi.fn()} />);
+
+    expect(getEnableTranslationToggle().disabled).toBe(false);
+  });
+});

--- a/apps/readest-app/src/components/settings/LangPanel.tsx
+++ b/apps/readest-app/src/components/settings/LangPanel.tsx
@@ -4,6 +4,7 @@ import { useEnv } from '@/context/EnvContext';
 import { useAuth } from '@/context/AuthContext';
 import { useReaderStore } from '@/store/readerStore';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useBookDataStore } from '@/store/bookDataStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { saveViewSettings } from '@/helpers/settings';
 import {
@@ -11,6 +12,7 @@ import {
   getTranslators,
   isTranslatorAvailable,
 } from '@/services/translators';
+import { isTranslationAvailable } from '@/services/translators/utils';
 import { useResetViewSettings } from '@/hooks/useResetSettings';
 import { useKeyDownActions } from '@/hooks/useKeyDownActions';
 import { TRANSLATED_LANGS, TRANSLATOR_LANGS } from '@/services/constants';
@@ -36,6 +38,7 @@ const LangPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset 
   const { settings, applyUILanguage, activeSettingsItemId, setActiveSettingsItemId } =
     useSettingsStore();
   const { getView, getViewSettings, setViewSettings, recreateViewer } = useReaderStore();
+  const { getBookData } = useBookDataStore();
   const view = getView(bookKey);
   const viewSettings = getViewSettings(bookKey) || settings.globalViewSettings;
 
@@ -53,6 +56,16 @@ const LangPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset 
   );
   const [showCustomDictionaries, setShowCustomDictionaries] = useState(false);
   const [showWordLens, setShowWordLens] = useState(false);
+
+  // Translation is unavailable for PDFs and for books already in the target
+  // language (issue #5600). The reader toolbar's toggler has always refused
+  // those; ungated here, turning it on for a PDF translated the text layer
+  // paragraph by paragraph and drained the daily AI translation quota. An
+  // already-on book keeps the switch live so it can be turned back off.
+  const translationAvailable = isTranslationAvailable(
+    getBookData(bookKey)?.book,
+    translateTargetLang,
+  );
 
   // Android Back / Esc: when a sub-page is open, intercept and step back to the
   // language list instead of letting <Dialog>'s listener close the whole
@@ -333,9 +346,12 @@ const LangPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset 
       <BoxedList title={_('Translation')} data-setting-id='settings.language.translationEnabled'>
         <SettingsSwitchRow
           label={_('Enable Translation')}
+          description={
+            bookKey && !translationAvailable ? _('Not available for this book.') : undefined
+          }
           checked={translationEnabled}
           onChange={() => setTranslationEnabled(!translationEnabled)}
-          disabled={!bookKey}
+          disabled={!bookKey || (!translationAvailable && !translationEnabled)}
         />
         <SettingsSwitchRow
           label={_('Show Source Text')}


### PR DESCRIPTION
Fixes #5600

## Problem

The reporter got a "Daily translation quota reached" toast on **every text selection** in a PDF, without ever having used AI translation deliberately.

Two things combine:

1. `isTranslationAvailable()` already excludes PDFs, and the reader toolbar's `TranslationToggler` honours it. But the Settings -> Language -> Translation -> **Enable Translation** switch was gated only on `disabled={!bookKey}`. Turning it on for a PDF let `useTextTranslation` walk the PDF text layer and translate it paragraph by paragraph, which drains the daily AI translation quota.
2. Once the quota is gone, every selection in a PDF pops the toast: a selection there fires `contextmenu`, which opens `TranslatorPopup`, which immediately calls `translate()` and hits `ErrorCodes.DAILY_QUOTA_EXCEEDED`.

## Change

`LangPanel` now applies the same `isTranslationAvailable(book, translateTargetLang)` rule as the toolbar. The switch is locked for PDFs, for books with no declared language (or `und`), and for books already in the target language.

- **Escape hatch preserved**: if translation is already on for such a book, the switch stays live so the user can turn it back off (the workaround suggested on the issue).
- **The lock says why**: unavailable rows now show `Not available for this book.` instead of a silently greyed out switch, which is the confusion that produced this report. New i18n key translated across all 33 locales.

## Verification

- New test `src/__tests__/components/settings/LangPanel.test.tsx` (4 cases: translatable book unlocked with no notice, PDF locked with notice, same-language locked, already-on PDF still toggleable). Written first, the two "locks" cases failed before the fix.
- `pnpm test` (8997 passed, 16 skipped), `pnpm lint`, `pnpm format:check` all clean.
- Dogfooded in Chrome against `pnpm dev-web`:
  - PDF (`format: PDF`): switch disabled, notice shown, a programmatic click on it is a no-op.
  - Chinese EPUB with **Translate To = Simplified Chinese**: correctly locked (same language).
  - Same book switched to **Translate To = English**: switch unlocks and the notice disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)