### PR TITLE
fix(translate): send Bing language codes in the Azure provider

### DIFF
--- a/apps/readest-app/src/__tests__/services/translators/providers.test.ts
+++ b/apps/readest-app/src/__tests__/services/translators/providers.test.ts
@@ -12,32 +12,10 @@ vi.mock('@/utils/misc', () => ({
   stubTranslation: (s: string) => s,
 }));
 
-vi.mock('@/utils/lang', () => ({
-  normalizeToShortLang: vi.fn((lang: string) => {
-    const map: Record<string, string> = {
-      'en-US': 'en',
-      'fr-FR': 'fr',
-      'zh-CN': 'zh',
-      AUTO: 'auto',
-      en: 'en',
-      fr: 'fr',
-      de: 'de',
-      zh: 'zh',
-      auto: 'auto',
-    };
-    return map[lang] ?? lang;
-  }),
-  normalizeToFullLang: vi.fn((lang: string) => {
-    const map: Record<string, string> = {
-      en: 'en',
-      fr: 'fr',
-      de: 'de',
-      zh: 'zh-Hans',
-      auto: 'auto',
-    };
-    return map[lang] ?? lang;
-  }),
-}));
+// @/utils/lang is deliberately NOT mocked: the providers' language-code
+// handling against the real normalizers is part of what these tests verify.
+// A hand-rolled lang mock previously hid that normalizeToFullLang maximizes
+// bare subtags ('en' -> 'en-US'), which Bing rejects with statusCode 400.
 
 // Mock Tauri HTTP plugin
 vi.mock('@tauri-apps/plugin-http', () => ({
@@ -756,6 +734,33 @@ describe('azureProvider', () => {
     expect(urls[1]).toContain('IG=01CE353230DE4BFD8A44466FDD91401A');
     expect(urls[1]).toContain('IID=translator.5025');
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('sends Bing language codes rather than maximized culture codes', async () => {
+    // Bing's ttranslatev3 answers `statusCode: 400` for region-maximized
+    // codes like en-US or de-DE (verified live 2026-08-11); it only accepts
+    // its own list — bare subtags plus script variants like zh-Hans. The
+    // retired api-edge endpoint tolerated full culture codes, so the
+    // migration must not keep maximizing.
+    vi.mocked(isTauriAppPlatform).mockReturnValue(true);
+    const sentBodies: URLSearchParams[] = [];
+    vi.mocked(tauriFetch).mockImplementation(async (url, init) => {
+      if (String(url).includes('/translator')) {
+        return { ok: true, status: 200, text: async () => BING_PAGE } as Response;
+      }
+      sentBodies.push(new URLSearchParams(String(init?.body ?? '')));
+      return translationBody('translated') as unknown as Response;
+    });
+
+    const { azureProvider } = await import('@/services/translators/providers/azure');
+    await azureProvider.translate(['Hello'], 'AUTO', 'en');
+    await azureProvider.translate(['Hello'], 'en', 'zh-CN');
+
+    expect(sentBodies[0]!.get('fromLang')).toBe('auto-detect');
+    expect(sentBodies[0]!.get('to')).toBe('en');
+    expect(sentBodies[1]!.get('fromLang')).toBe('en');
+    // Bing spells simplified Chinese zh-Hans, never zh-CN.
+    expect(sentBodies[1]!.get('to')).toBe('zh-Hans');
   });
 
   it('reuses cached auth params across calls', async () => {

--- a/apps/readest-app/src/services/translators/providers/azure.ts
+++ b/apps/readest-app/src/services/translators/providers/azure.ts
@@ -3,7 +3,7 @@ import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import { isTauriAppPlatform } from '@/services/environment';
 import { TranslationProvider } from '../types';
 import { splitTextIntoChunks } from '../utils';
-import { normalizeToFullLang } from '@/utils/lang';
+import { normalizeToShortLang } from '@/utils/lang';
 import {
   BING_REQUEST_HEADERS,
   BING_TRANSLATE_URL,
@@ -207,12 +207,16 @@ export const azureProvider: TranslationProvider = {
     if (!text.length) return [];
     if (!isTauriAppPlatform()) requireWebToken(token);
 
-    const normalized = sourceLang ? normalizeToFullLang(sourceLang) : '';
+    // Bing only accepts its own language list — bare subtags plus script
+    // variants like zh-Hans — and answers `statusCode: 400` for maximized
+    // culture codes such as en-US or de-DE (the retired api-edge endpoint
+    // tolerated them, so this must not go back to normalizeToFullLang).
+    const normalized = sourceLang ? normalizeToShortLang(sourceLang) : '';
     // Bing spells auto-detection `auto-detect`; an empty or `auto` source
     // language means the same thing here.
     const fromLang =
       !normalized || normalized.toLowerCase() === 'auto' ? 'auto-detect' : normalized;
-    const toLang = normalizeToFullLang(targetLang);
+    const toLang = normalizeToShortLang(targetLang);
 
     const results: string[] = [];
     await Promise.all(


### PR DESCRIPTION
## Problem

Since #5555 migrated the Azure provider to Bing's `ttranslatev3`, translating to any non-Chinese target language fails with "Unable to fetch the translation. Try again later." on every platform (reproduced in the Tauri app on a Xiaomi 13; the web proxy path is equally affected).

## Root cause

`azure.ts` normalized languages with `normalizeToFullLang()`, which maximizes codes (`en -> en-US`, `de -> de-DE`). The retired `api-edge.cognitive.microsofttranslator.com` endpoint tolerated full culture codes, but `ttranslatev3` accepts only Bing's own list (bare subtags plus script variants like `zh-Hans`) and answers `statusCode: 400` inside an HTTP 200 for anything else. Chinese targets kept working because `zh` variants normalize to `zh-Hans`/`zh-Hant`, which masked the regression during the #5555 verification.

The providers test suite did not catch it because it mocked `@/utils/lang` with a fake `normalizeToFullLang` that mapped `en -> en` instead of the real `en -> en-US`.

## Fix

- Normalize source and target with `normalizeToShortLang()` like the deepl/google/yandex providers, which yields exactly Bing's codes (including `zh-CN -> zh-Hans`, `zh-TW -> zh-Hant`, `pt-BR -> pt`).
- Remove the hand-rolled `@/utils/lang` mock so the provider tests exercise the real normalizers, and add a regression test asserting the wire values (`to=en`, `to=zh-Hans`, `fromLang=auto-detect`); it failed with `en-US` before the fix.

## Verification

- On-device controlled experiment through the app's own `plugin:http|fetch`: `to=en`, `ja`, `zh-Hans` translate; `to=en-US`, `zh-CN`, `de-DE` all return `statusCode: 400`.
- Rebuilt APK on the Xiaomi 13: the translator popup now renders the Chinese translation via Azure Translator with no console errors.
- Live sweep of all 42 normalized codes for the selectable target languages: every one returns a real translation, zero 400s.
- `pnpm test` (full suite), `pnpm lint`, and `pnpm format:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)