### PR TITLE
fix(library): stop a long press from selecting and then deselecting a book

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/bookshelf-item-longpress-select.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/bookshelf-item-longpress-select.test.tsx
@@ -1,0 +1,172 @@
+import { useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+import type { Book } from '@/types/book';
+
+/**
+ * Issue #5596 — long-pressing a book on Android selected it and then
+ * deselected it again ~100ms later, while the finger was still down.
+ *
+ * A long press produces two independent signals: our own 500ms timer and the
+ * WebView's native `contextmenu` event, and on Android both are wired to the
+ * same "select this item" action. Whichever arrives first cancels the other,
+ * so on most devices only one of them runs — but when the WebView fires
+ * `contextmenu` *after* our timer has already fired, the item is toggled
+ * twice by a single press.
+ */
+
+vi.mock('@tauri-apps/api/menu', () => ({
+  Menu: { new: vi.fn(async () => ({ popup: vi.fn(), close: vi.fn() })) },
+}));
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  revealItemInDir: vi.fn(),
+}));
+
+const appService = vi.hoisted(() => ({
+  hasContextMenu: false,
+  isLinuxApp: false,
+  isAndroidApp: true,
+  isMobileApp: true,
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: { localBooksDir: '/books' } }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (text: string) => text,
+}));
+
+vi.mock('@/app/library/hooks/useOpenBook', () => ({
+  useOpenBook: () => ({ openBook: vi.fn() }),
+}));
+
+vi.mock('@/app/library/components/BookItem', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/library/components/GroupItem', () => ({
+  default: () => null,
+}));
+
+const BookshelfItem = (await import('@/app/library/components/BookshelfItem')).default;
+
+const book: Book = {
+  hash: 'hash-1',
+  format: 'EPUB',
+  title: 'Test Book',
+  author: 'Test Author',
+  createdAt: 0,
+  updatedAt: 0,
+  downloadedAt: 1,
+};
+
+/**
+ * Mirrors the library page: select mode and the selected set live above the
+ * item, so every toggle re-renders it with new props.
+ */
+const Harness = ({ onToggle }: { onToggle: (id: string) => void }) => {
+  const [isSelectMode, setIsSelectMode] = useState(false);
+  const [selected, setSelected] = useState(false);
+  return (
+    <BookshelfItem
+      mode='grid'
+      item={book}
+      coverFit='crop'
+      isSelectMode={isSelectMode}
+      itemSelected={selected}
+      transferProgress={null}
+      setLoading={vi.fn()}
+      toggleSelection={(id: string) => {
+        setSelected((prev) => !prev);
+        onToggle(id);
+      }}
+      handleGroupBooks={vi.fn()}
+      handleBookDownload={vi.fn(async () => true)}
+      handleBookUpload={vi.fn(async () => true)}
+      handleBookDelete={vi.fn(async () => true)}
+      handleSetSelectMode={setIsSelectMode}
+      handleShowDetailsBook={vi.fn()}
+      handleLibraryNavigation={vi.fn()}
+      handleUpdateReadingStatus={vi.fn()}
+      showTimeRemaining={false}
+    />
+  );
+};
+
+const getItem = () => screen.getByRole('button', { name: 'Test Book' });
+
+describe('long-press selection on Android (issue #5596)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it('selects once when the WebView fires contextmenu after the long-press timer', () => {
+    const onToggle = vi.fn();
+    render(<Harness onToggle={onToggle} />);
+    const item = getItem();
+
+    fireEvent.pointerDown(item, { pointerId: 1, clientX: 50, clientY: 50 });
+    // Our own long-press timer wins the race and selects the book.
+    act(() => void vi.advanceTimersByTime(500));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    // The WebView's native long-press callout lands a moment later, still
+    // within the same press.
+    fireEvent.contextMenu(item, { clientX: 50, clientY: 50 });
+    act(() => void vi.advanceTimersByTime(500));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    // Lifting the finger must not count as a tap either.
+    fireEvent.pointerUp(item, { pointerId: 1, clientX: 50, clientY: 50 });
+    act(() => void vi.advanceTimersByTime(500));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('selects once when the WebView fires contextmenu before the long-press timer', () => {
+    const onToggle = vi.fn();
+    render(<Harness onToggle={onToggle} />);
+    const item = getItem();
+
+    fireEvent.pointerDown(item, { pointerId: 1, clientX: 50, clientY: 50 });
+    act(() => void vi.advanceTimersByTime(300));
+    fireEvent.contextMenu(item, { clientX: 50, clientY: 50 });
+    act(() => void vi.advanceTimersByTime(500));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    fireEvent.pointerUp(item, { pointerId: 1, clientX: 50, clientY: 50 });
+    act(() => void vi.advanceTimersByTime(500));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('still toggles on a plain tap once select mode is on', () => {
+    const onToggle = vi.fn();
+    render(<Harness onToggle={onToggle} />);
+    const item = getItem();
+
+    fireEvent.pointerDown(item, { pointerId: 1, clientX: 50, clientY: 50 });
+    act(() => void vi.advanceTimersByTime(500));
+    fireEvent.pointerUp(item, { pointerId: 1, clientX: 50, clientY: 50 });
+    act(() => void vi.advanceTimersByTime(500));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    fireEvent.pointerDown(item, { pointerId: 2, clientX: 50, clientY: 50 });
+    fireEvent.pointerUp(item, { pointerId: 2, clientX: 50, clientY: 50 });
+    act(() => void vi.advanceTimersByTime(500));
+    expect(onToggle).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/readest-app/src/hooks/useLongPress.ts
+++ b/apps/readest-app/src/hooks/useLongPress.ts
@@ -145,12 +145,21 @@ export const useLongPress = (
 
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {
+      // A touch long press produces two independent signals: our own timer and
+      // the WebView's native `contextmenu`. Callers wire both to the same
+      // action, so only the first one to arrive may run it. `contextmenu`
+      // arriving first cancels the timer through reset() below; when the timer
+      // won the race it has already fired for this press, and running
+      // onContextMenu too would toggle the item twice (issue #5596).
+      const handledByTimer = isLongPressTriggered.current;
       if (onContextMenu) {
         e.preventDefault();
         e.stopPropagation();
-        setTimeout(() => {
-          onContextMenu(e);
-        }, 100);
+        if (!handledByTimer) {
+          setTimeout(() => {
+            onContextMenu(e);
+          }, 100);
+        }
       }
       reset();
     },


### PR DESCRIPTION
Fixes #5596

## Symptom

On a Samsung Galaxy Tab S11 Ultra (Android 16), long-pressing a book in the library selected it and then deselected it again a moment later, leaving select mode on with nothing selected, so the Delete action stayed disabled. It did not reproduce on the reporter's phone or on my Android 16 phone.

Stepping the reporter's screen recording frame by frame at 20fps pins the mechanism:

| t | selection | finger |
| --- | --- | --- |
| 1.40s - 1.55s | not selected | down |
| 1.60s - 1.75s | **selected** | down |
| 1.80s - 2.15s | **deselected** | **still down** |

Both transitions happen mid-press, which rules out the tap / pointer-up path. One press ran the select action twice.

## Cause

A touch long press produces two independent signals:

1. the 500ms timer in `useLongPress` (`onLongPress`)
2. the WebView's native `contextmenu` event

`BookshelfItem` wires both to the same `handleSelectItem`, and only the first to arrive is meant to run it. `contextmenu` arriving first cancels the timer through `reset()`. The other order was unguarded: when the device detected its long press *after* our timer had already fired, `handleContextMenu` scheduled `onContextMenu` anyway and the item toggled twice.

Chrome's own long press timeout is also around 500ms, so which signal wins is decided by scheduling jitter and the device's touch-and-hold delay. That is why this shows up on some devices and not others.

The `throttle(fn, 100)` around the select action was never a guard here. `handleSelectItem` is `useCallback(throttle(...), [isSelectMode])`, so the first toggle flips `isSelectMode` and React mints a fresh throttle closure with `lastCall = 0`; the second call runs unconditionally. Even on a shared instance, the 100ms `setTimeout` in `handleContextMenu` exactly equals the 100ms throttle window, so `remaining = 0` passes the `<= 0` test.

## Fix

`handleContextMenu` snapshots `isLongPressTriggered.current` and skips `onContextMenu` when the timer already handled this press. It still calls `preventDefault()`, so the native Android callout stays suppressed.

Both race orders now converge on exactly one select action per press. Desktop right-click is untouched: `handlePointerDown` returns early for non-primary buttons, so no timer ever runs for it, and the Linux in-app menu path (#5360) still fires because no long press preceded it.

## Tests

New `src/__tests__/app/library/bookshelf-item-longpress-select.test.tsx` drives a real `BookshelfItem` through a stateful harness that mirrors the library page (select mode and the selected set live above the item, so every toggle re-renders it). It covers:

- `contextmenu` after the long-press timer (the reported failure; asserted 2 toggles before the fix, 1 after)
- `contextmenu` before the long-press timer (the order that already worked)
- a plain tap once select mode is on

## Verification

- `pnpm test` - 9014 passed, 16 skipped, 0 failures
- `pnpm lint` - clean
- `pnpm format:check` - clean
- No `src-tauri/` or Lua changes, so those gates do not apply.

Device verification on an affected tablet is still pending; I do not have a Galaxy Tab to hand.

## Noted, not fixed

`RecentShelf` uses `useLongPress` with `onLongPress` but no `onContextMenu`, so on Android a `contextmenu` that wins the race calls `reset()` and cancels the select outright. Long-press-select on the recent shelf is likely flaky under the same conditions. Different symptom from this issue and unverified on device, so it is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)