### PR TITLE
fix(ci): stop cargo pulling the flutter SDK for the localsend dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4239,7 +4239,7 @@ dependencies = [
 [[package]]
 name = "localsend"
 version = "0.1.0"
-source = "git+https://github.com/localsend/localsend?rev=ff2995c9523c5fae407f7d444d0986b2c6ae568e#ff2995c9523c5fae407f7d444d0986b2c6ae568e"
+source = "git+https://github.com/readest/localsend?rev=8802cb037fc38a92bc932681d18e7a79e813b688#8802cb037fc38a92bc932681d18e7a79e813b688"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/apps/readest-app/src-tauri/Cargo.toml
+++ b/apps/readest-app/src-tauri/Cargo.toml
@@ -78,7 +78,13 @@ tauri-plugin-webdriver = { version = "0.2", optional = true }
 # LocalSend protocol v2.2 (discovery + HTTPS transfer). Upstream's own
 # protocol core, pinned by rev; `discovery` pulls `http`+`crypto`+`multicast`,
 # WebRTC/v3 stays off.
-localsend = { git = "https://github.com/localsend/localsend", rev = "ff2995c9523c5fae407f7d444d0986b2c6ae568e", default-features = false, features = ["discovery"] }
+#
+# Sourced from our fork, which only adds `update = none` to upstream's flutter
+# submodule. Cargo updates every submodule of a git dependency, so upstream
+# pulls the whole Flutter SDK (552 MB checked out) and blows past MAX_PATH on
+# Windows. The fork's `readest` branch tracks the same upstream rev
+# (ff2995c9523c5fae407f7d444d0986b2c6ae568e); rebase it when bumping.
+localsend = { git = "https://github.com/readest/localsend", rev = "8802cb037fc38a92bc932681d18e7a79e813b688", default-features = false, features = ["discovery"] }
 uuid = { version = "1", features = ["v4"] }
 pem = "4"
 anyhow = "1"


### PR DESCRIPTION
## Problem

Nightly [run 31437261971](https://github.com/readest/readest/actions/runs/31437261971) failed on **both Windows arches** while checking out the `localsend` git dependency:

```
path too long: 'C:/Users/runneradmin/.cargo/git/checkouts/localsend-347f023daa6e6a88/ff2995c/
support/submodules/flutter/dev/integration_tests/android_engine_test/android/app/src/main/
kotlin/com/example/native_driver_test/fixtures/
BlueOrangeGradientSurfaceViewPlatformViewFactory.kt'; class=Filesystem (30)
```

Cargo recursively initializes and updates **every** submodule declared by a git dependency. It has no `submodules = false` and no way to fetch only `packages/core`, so upstream's single `.gitmodules` entry drags in the entire Flutter SDK. On Windows the resulting Flutter paths exceed `MAX_PATH` and the checkout fails outright.

macOS, Linux and Android passed only because they have no such path limit. They still paid the download: the checkout is **552 MB** on disk, on CI and on every contributor's machine.

## Fix

Cargo honors a submodule update strategy of `none` ([`utils.rs:423`](https://github.com/rust-lang/cargo/blob/rust-1.92.0/src/cargo/sources/git/utils.rs#L423)), so the crate is now sourced from `readest/localsend`. That fork's only delta against the pinned upstream rev is one line:

```diff
 [submodule "support/submodules/flutter"]
 	path = support/submodules/flutter
 	url = https://github.com/flutter/flutter.git
+	update = none
```

`packages/core` is untouched (`git diff ff2995c..8802cb0 -- packages/core` is empty), so the compiled crate is unchanged. Cargo now reports:

```
Skipping git submodule `https://github.com/flutter/flutter.git` due to update strategy in .gitmodules
```

and the checkout drops **552 MB to 39 MB** on every platform.

## Why not crates.io

`localsend` on crates.io is `wylited/localsend`, an unrelated third-party reimplementation: different module tree, zero declared features (so `features = ["discovery"]` fails to resolve), no TLS at all (its `fingerprint` is a random `Uuid::new_v4()`), pulls `native-dialog`, last published 2025-01. Upstream publishes no core crate under any name, so a git dependency is inherent here.

## Verification

- `pnpm fmt:check` clean
- `pnpm clippy:check` exit 0
- `pnpm test:rust` 97 passed, 0 failed (includes `localsend::identity` tests)
- Cleared `~/.cargo/git/{db,checkouts}/localsend-*` and re-fetched: Flutter skipped, `support/submodules/flutter` empty, `packages/core/Cargo.toml` present

Note that PR checks don't build Windows bundles, so the Windows path is fixed by construction rather than exercised here. Worth a `workflow_dispatch` nightly run after merge to confirm end to end.

## Follow-up

When bumping `localsend`, rebase that one commit onto the new upstream rev in the fork and re-pin. Pointing back at `localsend/localsend` brings the Windows failure back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)