### PR TITLE
fix(localsend): let Readest devices discover each other

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -259,7 +259,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1991,7 +1991,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2391,7 +2391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2892,8 +2892,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -3045,7 +3045,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3521,7 +3521,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4239,7 +4239,7 @@ dependencies = [
 [[package]]
 name = "localsend"
 version = "0.1.0"
-source = "git+https://github.com/readest/localsend?rev=8802cb037fc38a92bc932681d18e7a79e813b688#8802cb037fc38a92bc932681d18e7a79e813b688"
+source = "git+https://github.com/readest/localsend?rev=3721994985277e49e7e1ee4ed97601ad5405fc87#3721994985277e49e7e1ee4ed97601ad5405fc87"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -4569,7 +4569,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4807,7 +4807,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5399,7 +5399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -6201,7 +6201,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6819,7 +6819,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6877,7 +6877,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7613,7 +7613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8419,7 +8419,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tracing",
  "url",
- "windows-registry 0.5.3",
+ "windows-registry",
  "windows-result 0.3.4",
 ]
 
@@ -9016,10 +9016,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9521,7 +9521,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9820,7 +9820,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10484,7 +10484,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10731,17 +10731,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/apps/readest-app/src-tauri/Cargo.toml
+++ b/apps/readest-app/src-tauri/Cargo.toml
@@ -84,7 +84,7 @@ tauri-plugin-webdriver = { version = "0.2", optional = true }
 # pulls the whole Flutter SDK (552 MB checked out) and blows past MAX_PATH on
 # Windows. The fork's `readest` branch tracks the same upstream rev
 # (ff2995c9523c5fae407f7d444d0986b2c6ae568e); rebase it when bumping.
-localsend = { git = "https://github.com/readest/localsend", rev = "8802cb037fc38a92bc932681d18e7a79e813b688", default-features = false, features = ["discovery"] }
+localsend = { git = "https://github.com/readest/localsend", rev = "3721994985277e49e7e1ee4ed97601ad5405fc87", default-features = false, features = ["discovery"] }
 uuid = { version = "1", features = ["v4"] }
 pem = "4"
 anyhow = "1"

--- a/apps/readest-app/src-tauri/src/localsend/commands.rs
+++ b/apps/readest-app/src-tauri/src/localsend/commands.rs
@@ -4,12 +4,33 @@ use super::LocalSendState;
 use std::collections::{HashMap, HashSet};
 use tauri::{AppHandle, Emitter, Runtime, State};
 
+fn local_ips() -> Vec<String> {
+    if_addrs::get_if_addrs()
+        .unwrap_or_default()
+        .iter()
+        // VPN tunnels (tun0/utun4/ppp0/wg0) carry addresses peers on the LAN
+        // never see; including them would add misleading "#<n>" device tags.
+        .filter(|iface| {
+            let name = iface.name.as_str();
+            !["tun", "utun", "ppp", "wg"]
+                .iter()
+                .any(|prefix| name.starts_with(prefix))
+        })
+        .filter_map(|iface| match iface.ip() {
+            std::net::IpAddr::V4(ip) if !ip.is_loopback() => Some(ip.to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
 fn status_of(service: &RunningService) -> LocalSendStatus {
     LocalSendStatus {
         running: true,
         alias: service.identity.alias.clone(),
         port: service.port,
         fingerprint: service.identity.fingerprint.clone(),
+        device_model: service.identity.device_model.clone(),
+        local_ips: local_ips(),
         multicast_error: service.multicast_error.clone(),
     }
 }
@@ -20,6 +41,8 @@ fn stopped_status() -> LocalSendStatus {
         alias: String::new(),
         port: 0,
         fingerprint: String::new(),
+        device_model: String::new(),
+        local_ips: Vec::new(),
         multicast_error: None,
     }
 }
@@ -117,20 +140,26 @@ pub async fn localsend_announce(
     discovery.announce().await;
     if scan {
         // HTTP fallback for networks/platforms without multicast (iOS):
-        // probe every host on each local /24 at the protocol default port.
+        // probe every host on each local /24. LocalSend apps sit on the
+        // protocol default port, Readest peers on the first port of their
+        // own range, so both are probed.
         use localsend::model::discovery::ProtocolType;
         for iface in if_addrs::get_if_addrs().unwrap_or_default() {
             if let std::net::IpAddr::V4(ip) = iface.ip() {
                 if !ip.is_loopback() {
-                    let _ = discovery
-                        .scan_subnet(ip, localsend::multicast::DEFAULT_PORT, ProtocolType::Https)
-                        .await;
+                    for port in SCAN_PORTS {
+                        let _ = discovery.scan_subnet(ip, port, ProtocolType::Https).await;
+                    }
                 }
             }
         }
     }
     Ok(())
 }
+
+/// The ports a subnet scan probes: the LocalSend app's fixed port and the
+/// first port of Readest's own range (see [`service::PORT_RANGE`]).
+const SCAN_PORTS: [u16; 2] = [localsend::multicast::DEFAULT_PORT, service::FIRST_PORT];
 
 #[tauri::command]
 pub async fn localsend_respond<R: Runtime>(
@@ -268,7 +297,7 @@ pub async fn localsend_send_files<R: Runtime>(
                 size,
                 file_type: input.mime_type,
                 sha256: None,
-                preview: None,
+                preview: input.preview,
                 metadata: None,
             },
             path,
@@ -300,4 +329,17 @@ pub async fn localsend_cancel_send(state: State<'_, LocalSendState>) -> Result<(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scan_covers_localsend_and_readest_ports() {
+        // The scan must find LocalSend apps (protocol default port) and
+        // Readest peers, which bind the first free port of their own range.
+        assert_eq!(SCAN_PORTS[0], localsend::multicast::DEFAULT_PORT);
+        assert_eq!(SCAN_PORTS[1], *service::PORT_RANGE.start());
+    }
 }

--- a/apps/readest-app/src-tauri/src/localsend/events.rs
+++ b/apps/readest-app/src-tauri/src/localsend/events.rs
@@ -21,6 +21,11 @@ pub struct LocalSendStatus {
     pub alias: String,
     pub port: u16,
     pub fingerprint: String,
+    /// OS name announced to peers ("macOS", "Android", ...).
+    pub device_model: String,
+    /// Non-loopback IPv4 addresses of this host; the UI derives the
+    /// "#<last-octet>" device tag from them.
+    pub local_ips: Vec<String>,
     pub multicast_error: Option<String>,
 }
 
@@ -42,6 +47,9 @@ pub struct DevicePayload {
     pub host: String,
     pub port: u16,
     pub protocol: String,
+    /// An IPv4 address of the device when one is known; the UI derives the
+    /// "#<last-octet>" tag from it (`host` may be IPv6).
+    pub ipv4_host: Option<String>,
 }
 
 #[derive(Clone, Serialize)]
@@ -57,6 +65,8 @@ pub struct FilePayload {
     pub file_name: String,
     pub size: u64,
     pub file_type: String,
+    /// Base64 thumbnail from the sender, passed through for the accept dialog.
+    pub preview: Option<String>,
 }
 
 #[derive(Clone, Serialize)]
@@ -129,6 +139,9 @@ pub struct SendFileInput {
     pub path: String,
     pub file_name: String,
     pub mime_type: String,
+    /// Base64 thumbnail shown by the receiver (LocalSend `preview` field).
+    #[serde(default)]
+    pub preview: Option<String>,
 }
 
 pub fn device_type_str(t: &Option<localsend::model::discovery::DeviceType>) -> Option<String> {
@@ -168,10 +181,23 @@ mod tests {
             host: "192.168.1.2".into(),
             port: 53317,
             protocol: "https".into(),
+            ipv4_host: Some("192.168.1.2".into()),
         })
         .unwrap();
         assert_eq!(json["deviceModel"], "Readest");
         assert_eq!(json["deviceType"], "desktop");
+        assert_eq!(json["ipv4Host"], "192.168.1.2");
+
+        let json = serde_json::to_value(FilePayload {
+            id: "f".into(),
+            file_name: "b.epub".into(),
+            size: 1,
+            file_type: "application/epub+zip".into(),
+            preview: Some("aGk=".into()),
+        })
+        .unwrap();
+        assert_eq!(json["fileName"], "b.epub");
+        assert_eq!(json["preview"], "aGk=");
 
         let json = serde_json::to_value(ReceiveFileDonePayload {
             session_id: "s".into(),

--- a/apps/readest-app/src-tauri/src/localsend/service.rs
+++ b/apps/readest-app/src-tauri/src/localsend/service.rs
@@ -5,8 +5,10 @@
 use crate::localsend::events::*;
 use crate::localsend::identity::Identity;
 use localsend::discovery::{
-    DiscoveryConfig, DiscoveryEvent, DiscoveryHandle, DEFAULT_DISCOVERY_TIMEOUT,
+    DeviceChannel, DiscoveredDevice, DiscoveryConfig, DiscoveryEvent, DiscoveryHandle, HttpChannel,
+    DEFAULT_DISCOVERY_TIMEOUT,
 };
+use localsend::http::dto_v2::RegisterDtoV2;
 use localsend::http::server::common::save::FileUploadTarget;
 use localsend::http::server::v2::{PrepareUploadDecisionV2, ServerEventV2, SessionEndReasonV2};
 use localsend::http::server::web::{WebConfig, WebI18n};
@@ -28,7 +30,8 @@ use tokio_util::sync::CancellationToken;
 /// free lets both run on one device. Discovery still works: the multicast
 /// socket shares UDP 53317 (SO_REUSEPORT) and every announce carries Readest's
 /// real HTTP port, so peers reach it on whatever port it bound.
-pub const PORT_RANGE: std::ops::RangeInclusive<u16> = 53318..=53327;
+pub const FIRST_PORT: u16 = 53318;
+pub const PORT_RANGE: std::ops::RangeInclusive<u16> = FIRST_PORT..=53327;
 
 pub type PendingMap = Arc<StdMutex<HashMap<String, PendingReceive>>>;
 pub type ReceivingMap = Arc<StdMutex<HashMap<String, ReceiveSession>>>;
@@ -217,10 +220,27 @@ fn spawn_event_pump<R: Runtime>(
     let pending = service.pending.clone();
     let receiving = service.receiving.clone();
     let send_cancel = service.send_cancel.clone();
+    let self_fingerprint = service.identity.fingerprint.clone();
     tauri::async_runtime::spawn(async move {
         loop {
             tokio::select! {
                 event = server_rx.recv() => match event {
+                    Some(ServerEventV2::Register { ip, info }) => {
+                        // A peer answering this device's announcement (or
+                        // probing it during a scan) registers with the HTTP
+                        // server; feed it into the discovery store, as the
+                        // discovery crate documents. Without this, the
+                        // announcing side never learns who answered.
+                        let host = match ip.scope_id {
+                            Some(scope_id) => format!("{}%{scope_id}", ip.ip),
+                            None => ip.ip.to_string(),
+                        };
+                        let discovery = discovery.clone();
+                        let self_fingerprint = self_fingerprint.clone();
+                        tauri::async_runtime::spawn(async move {
+                            register_peer(&discovery, &self_fingerprint, host, info).await;
+                        });
+                    }
                     Some(event) => {
                         handle_server_event(&app, &pending, &receiving, &send_cancel, event)
                     }
@@ -235,12 +255,50 @@ fn spawn_event_pump<R: Runtime>(
     });
 }
 
+/// Puts a peer that registered with this device's HTTP server into the
+/// discovery store. Its own registrations (multicast loopback of a scan
+/// probing this host) are ignored.
+pub async fn register_peer(
+    discovery: &DiscoveryHandle,
+    self_fingerprint: &str,
+    host: String,
+    info: RegisterDtoV2,
+) {
+    if info.fingerprint == self_fingerprint {
+        return;
+    }
+    let device = DiscoveredDevice {
+        alias: info.alias,
+        version: info.version,
+        device_model: info.device_model,
+        device_type: info.device_type,
+        fingerprint: info.fingerprint,
+        channel: DeviceChannel::Http(HttpChannel {
+            host,
+            port: info.port,
+            protocol: info.protocol,
+        }),
+        download: info.download,
+    };
+    discovery.add_device(device).await;
+}
+
 pub fn device_payloads(discovery: &DiscoveryHandle) -> Vec<DevicePayload> {
     discovery
         .devices()
         .into_iter()
         .filter_map(|stateful| {
             let http = stateful.get_best_channel().and_then(|c| c.http())?;
+            // The best channel may be IPv6; a multi-homed device usually also
+            // has an IPv4 channel, whose last octet is the "#<n>" tag shown
+            // in the UI.
+            let ipv4_host = stateful
+                .get_ranked_channels()
+                .into_iter()
+                .filter_map(|channel| channel.http())
+                .map(|http| http.host.as_str())
+                .find(|host| host.parse::<std::net::Ipv4Addr>().is_ok())
+                .map(str::to_string);
             Some(DevicePayload {
                 alias: stateful.device.alias.clone(),
                 device_model: stateful.device.device_model.clone(),
@@ -249,6 +307,7 @@ pub fn device_payloads(discovery: &DiscoveryHandle) -> Vec<DevicePayload> {
                 host: http.host.clone(),
                 port: http.port,
                 protocol: http.protocol.as_str().to_string(),
+                ipv4_host,
             })
         })
         .collect()
@@ -271,6 +330,7 @@ fn handle_server_event<R: Runtime>(
     event: ServerEventV2,
 ) {
     match event {
+        // Register events are consumed by the event pump before this point.
         ServerEventV2::Register { .. } => {}
         ServerEventV2::PrepareUpload {
             session_id,
@@ -301,6 +361,7 @@ fn handle_server_event<R: Runtime>(
                         file_name: f.file_name.clone(),
                         size: f.size,
                         file_type: f.file_type.clone(),
+                        preview: f.preview.clone(),
                     })
                     .collect(),
             };
@@ -765,7 +826,113 @@ mod tests {
     fn port_range_avoids_localsend_default() {
         // 53317 is left free for the LocalSend app, which has no fallback.
         assert!(!PORT_RANGE.contains(&53317));
-        assert_eq!(*PORT_RANGE.start(), 53318);
+        assert_eq!(*PORT_RANGE.start(), FIRST_PORT);
         assert_eq!(*PORT_RANGE.end(), 53327);
+    }
+
+    fn test_discovery(identity: &Identity) -> Arc<DiscoveryHandle> {
+        // Port 0 keeps the test off the real LocalSend multicast group; the
+        // handle works without multicast either way.
+        let (_stop_tx, stop_rx) = oneshot::channel::<()>();
+        tauri::async_runtime::block_on(localsend::discovery::start(
+            DiscoveryConfig {
+                group: DEFAULT_MULTICAST_GROUP,
+                group_v6: None,
+                port: 0,
+                interface_filter: InterfaceFilter::default(),
+                device: identity.multicast_device(FIRST_PORT),
+                identity: identity.device_identity(),
+                timeout: DEFAULT_DISCOVERY_TIMEOUT,
+                event_tx: None,
+            },
+            stop_rx,
+        ))
+        .into()
+    }
+
+    fn register_dto(fingerprint: &str) -> RegisterDtoV2 {
+        RegisterDtoV2 {
+            alias: "Phone".into(),
+            version: "2.1".into(),
+            device_model: Some("Android".into()),
+            device_type: None,
+            fingerprint: fingerprint.into(),
+            port: FIRST_PORT,
+            protocol: ProtocolType::Https,
+            download: false,
+        }
+    }
+
+    #[test]
+    fn register_peer_adds_answering_device() {
+        let dir = std::env::temp_dir().join(format!("ls-rp-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = std::fs::remove_file(dir.join("identity.pem"));
+        let identity = Identity::load_or_generate(&dir, "Readest".into(), "macOS".into()).unwrap();
+        let discovery = test_discovery(&identity);
+
+        tauri::async_runtime::block_on(register_peer(
+            &discovery,
+            &identity.fingerprint,
+            "192.168.2.135".into(),
+            register_dto("peer-fp"),
+        ));
+
+        let devices = device_payloads(&discovery);
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].fingerprint, "peer-fp");
+        assert_eq!(devices[0].host, "192.168.2.135");
+        assert_eq!(devices[0].port, FIRST_PORT);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn device_payload_carries_ipv4_host_for_multi_homed_device() {
+        let dir = std::env::temp_dir().join(format!("ls-v4-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = std::fs::remove_file(dir.join("identity.pem"));
+        let identity = Identity::load_or_generate(&dir, "Readest".into(), "macOS".into()).unwrap();
+        let discovery = test_discovery(&identity);
+
+        tauri::async_runtime::block_on(async {
+            register_peer(
+                &discovery,
+                &identity.fingerprint,
+                "fe80::5442:82ff:febd:e7eb%3".into(),
+                register_dto("peer-fp"),
+            )
+            .await;
+            register_peer(
+                &discovery,
+                &identity.fingerprint,
+                "192.168.2.135".into(),
+                register_dto("peer-fp"),
+            )
+            .await;
+        });
+
+        let devices = device_payloads(&discovery);
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].ipv4_host.as_deref(), Some("192.168.2.135"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn register_peer_ignores_own_fingerprint() {
+        let dir = std::env::temp_dir().join(format!("ls-rs-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = std::fs::remove_file(dir.join("identity.pem"));
+        let identity = Identity::load_or_generate(&dir, "Readest".into(), "macOS".into()).unwrap();
+        let discovery = test_discovery(&identity);
+
+        tauri::async_runtime::block_on(register_peer(
+            &discovery,
+            &identity.fingerprint,
+            "192.168.2.120".into(),
+            register_dto(&identity.fingerprint.clone()),
+        ));
+
+        assert!(device_payloads(&discovery).is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/apps/readest-app/src/__tests__/services/localsend/deviceModel.test.ts
+++ b/apps/readest-app/src/__tests__/services/localsend/deviceModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { localSendDeviceModel } from '@/services/localsend/deviceModel';
+import { ipTag, localSendDeviceModel } from '@/services/localsend/deviceModel';
 
 describe('localSendDeviceModel', () => {
   it('maps each OS to the name peers show as the device tag', () => {
@@ -18,5 +18,20 @@ describe('localSendDeviceModel', () => {
   it('only splits iPad out of iOS, never other platforms', () => {
     expect(localSendDeviceModel('android', true)).toBe('Android');
     expect(localSendDeviceModel('macos', true)).toBe('macOS');
+  });
+});
+
+describe('ipTag', () => {
+  it('tags an IPv4 address with its last octet', () => {
+    expect(ipTag('192.168.2.120')).toBe('#120');
+    expect(ipTag('10.0.0.7')).toBe('#7');
+  });
+
+  it('returns null for anything that is not a dotted IPv4 address', () => {
+    expect(ipTag('fe80::1')).toBe(null);
+    expect(ipTag('fe80::1%3')).toBe(null);
+    expect(ipTag('mac.local')).toBe(null);
+    expect(ipTag('')).toBe(null);
+    expect(ipTag('1.2.3.256')).toBe(null);
   });
 });

--- a/apps/readest-app/src/__tests__/services/localsend/formats.test.ts
+++ b/apps/readest-app/src/__tests__/services/localsend/formats.test.ts
@@ -7,6 +7,7 @@ const file = (id: string, fileName: string): LocalSendFile => ({
   fileName,
   size: 1,
   fileType: 'application/octet-stream',
+  preview: null,
 });
 
 describe('partitionSupportedFiles', () => {

--- a/apps/readest-app/src/__tests__/services/localsend/preview.test.ts
+++ b/apps/readest-app/src/__tests__/services/localsend/preview.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { previewDataUrl } from '@/services/localsend/preview';
+
+describe('previewDataUrl', () => {
+  it('wraps a JPEG thumbnail in a data URL', () => {
+    expect(previewDataUrl('/9j/4AAQSkZJRg==')).toBe('data:image/jpeg;base64,/9j/4AAQSkZJRg==');
+  });
+
+  it('wraps a PNG thumbnail in a data URL', () => {
+    expect(previewDataUrl('iVBORw0KGgoAAAANSUhEUg==')).toBe(
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==',
+    );
+  });
+
+  it('rejects previews that are missing, unrecognized, or not base64', () => {
+    expect(previewDataUrl(null)).toBe(null);
+    expect(previewDataUrl(undefined)).toBe(null);
+    expect(previewDataUrl('')).toBe(null);
+    // Unknown magic bytes: refuse rather than guess a mime type.
+    expect(previewDataUrl('AAAAAAAAAAAA')).toBe(null);
+    // A data URL prefix or any non-base64 character must not pass through
+    // into the img src.
+    expect(previewDataUrl('data:image/jpeg;base64,/9j/AAA')).toBe(null);
+    expect(previewDataUrl('/9j/"><script>')).toBe(null);
+  });
+
+  it('rejects absurdly large previews from a hostile peer', () => {
+    expect(previewDataUrl(`/9j/${'A'.repeat(512 * 1024)}`)).toBe(null);
+  });
+});

--- a/apps/readest-app/src/__tests__/store/localsendStore.test.ts
+++ b/apps/readest-app/src/__tests__/store/localsendStore.test.ts
@@ -5,7 +5,9 @@ import type { ReceiveRequest, TransferProgress } from '@/services/localsend/type
 const request: ReceiveRequest = {
   sessionId: 's1',
   sender: { alias: 'Phone', deviceModel: null, deviceType: 'mobile', fingerprint: 'F' },
-  files: [{ id: 'f1', fileName: 'a.epub', size: 10, fileType: 'application/epub+zip' }],
+  files: [
+    { id: 'f1', fileName: 'a.epub', size: 10, fileType: 'application/epub+zip', preview: null },
+  ],
 };
 const progress: TransferProgress = {
   sessionId: 's1',

--- a/apps/readest-app/src/components/localsend/DevicePickerDialog.tsx
+++ b/apps/readest-app/src/components/localsend/DevicePickerDialog.tsx
@@ -12,6 +12,7 @@ import {
   listLocalSendDevices,
   sendLocalSendFiles,
 } from '@/services/localsend/service';
+import { ipTag } from '@/services/localsend/deviceModel';
 import type { LocalSendDevice, SendFileInput } from '@/services/localsend/types';
 
 interface DevicePickerDialogProps {
@@ -173,7 +174,9 @@ const DevicePickerDialog: React.FC<DevicePickerDialogProps> = ({ files, onClose 
                   <div className='flex min-w-0 flex-col'>
                     <span className='truncate text-sm'>{device.alias}</span>
                     <span className='text-base-content/60 truncate text-xs'>
-                      {device.deviceModel || device.host}
+                      {[ipTag(device.ipv4Host ?? device.host), device.deviceModel]
+                        .filter(Boolean)
+                        .join(' ') || device.host}
                     </span>
                   </div>
                 </button>

--- a/apps/readest-app/src/components/localsend/LocalSendManager.tsx
+++ b/apps/readest-app/src/components/localsend/LocalSendManager.tsx
@@ -200,6 +200,8 @@ const LocalSendManager: React.FC = () => {
             port: event.payload.port,
             alias: current?.alias ?? '',
             fingerprint: current?.fingerprint ?? '',
+            deviceModel: current?.deviceModel ?? '',
+            localIps: current?.localIps ?? [],
             multicastError: current?.multicastError ?? null,
             ...(event.payload.error ? { multicastError: event.payload.error } : {}),
           } as LocalSendStatus);

--- a/apps/readest-app/src/components/localsend/ReceiveRequestDialog.tsx
+++ b/apps/readest-app/src/components/localsend/ReceiveRequestDialog.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useThemeStore } from '@/store/themeStore';
 import { partitionSupportedFiles } from '@/services/localsend/formats';
+import { previewDataUrl } from '@/services/localsend/preview';
 import type { ReceiveRequest } from '@/services/localsend/types';
 import { formatBytes } from '@/utils/book';
 import Alert from '@/components/Alert';
@@ -37,7 +38,9 @@ const ReceiveRequestDialog: React.FC<ReceiveRequestDialogProps> = ({
   return (
     <div
       className={clsx(
-        'localsend-receive-alert fixed bottom-0 left-0 right-0 z-50 flex justify-center',
+        // z-[60]: must stack above the device picker (z-50), or an incoming
+        // request hides under an open picker sheet and can never be answered.
+        'localsend-receive-alert fixed bottom-0 left-0 right-0 z-[60] flex justify-center',
       )}
       style={{ paddingBottom: `${(safeAreaInsets?.bottom || 0) + 16}px` }}
     >
@@ -53,14 +56,26 @@ const ReceiveRequestDialog: React.FC<ReceiveRequestDialogProps> = ({
         onConfirm={() => onAccept(supported.map((file) => file.id))}
       >
         <div className='flex flex-col gap-1 ps-9 text-sm'>
-          {supported.slice(0, MAX_LISTED_FILES).map((file) => (
-            <div key={file.id} className='flex min-w-0 items-baseline justify-between gap-3'>
-              <span className='truncate'>{file.fileName}</span>
-              <span className='text-base-content/60 shrink-0 text-xs'>
-                {formatBytes(file.size)}
-              </span>
-            </div>
-          ))}
+          {supported.slice(0, MAX_LISTED_FILES).map((file) => {
+            const cover = previewDataUrl(file.preview);
+            return (
+              <div key={file.id} className='flex min-w-0 items-center justify-between gap-3'>
+                <span className='flex min-w-0 items-center gap-2'>
+                  {cover && (
+                    <img
+                      src={cover}
+                      alt=''
+                      className='eink-bordered h-10 w-7 shrink-0 rounded-sm object-cover'
+                    />
+                  )}
+                  <span className='truncate'>{file.fileName}</span>
+                </span>
+                <span className='text-base-content/60 shrink-0 text-xs'>
+                  {formatBytes(file.size)}
+                </span>
+              </div>
+            );
+          })}
           {supported.length > MAX_LISTED_FILES && (
             <div className='text-base-content/60 text-xs'>
               {_('and {{count}} more', { count: supported.length - MAX_LISTED_FILES })}

--- a/apps/readest-app/src/components/settings/integrations/LocalSendForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/LocalSendForm.tsx
@@ -8,9 +8,21 @@ import {
   setLocalSendEnabled,
 } from '@/services/localsend/devicePrefs';
 import { getLocalSendStatus } from '@/services/localsend/service';
+import { ipTag } from '@/services/localsend/deviceModel';
+import type { LocalSendStatus } from '@/services/localsend/types';
 import { eventDispatcher } from '@/utils/event';
 import SubPageHeader from '../SubPageHeader';
 import { BoxedList, SettingsInput, SettingsRow, SettingsSwitchRow, Tips } from '../primitives';
+
+/**
+ * "#120 macOS"-style tag: the last octet of this host's IPv4 address plus
+ * the announced OS name, so the user can tell peers which device to pick
+ * when aliases collide.
+ */
+const deviceTag = (status: LocalSendStatus): string => {
+  const tags = status.localIps.map(ipTag).filter(Boolean);
+  return [...new Set(tags), status.deviceModel].filter(Boolean).join(' ');
+};
 
 interface LocalSendFormProps {
   onBack: () => void;
@@ -86,7 +98,11 @@ const LocalSendForm: React.FC<LocalSendFormProps> = ({ onBack }) => {
 
       {enabled && status?.running && (
         <BoxedList>
-          <SettingsRow label={_('Visible as')} description={status.alias} asLabel={false}>
+          <SettingsRow
+            label={_('Visible as')}
+            description={[status.alias, deviceTag(status)].filter(Boolean).join(' · ')}
+            asLabel={false}
+          >
             <span className='text-base-content/70 text-sm'>
               {_('Port {{port}}', { port: status.port })}
             </span>

--- a/apps/readest-app/src/services/localsend/bookFile.ts
+++ b/apps/readest-app/src/services/localsend/bookFile.ts
@@ -1,9 +1,26 @@
 import type { Book } from '@/types/book';
 import type { AppService } from '@/types/system';
 import { EXTS, MIMETYPES } from '@/libs/document';
-import { getLocalBookFilename } from '@/utils/book';
+import { getCoverFilename, getLocalBookFilename } from '@/utils/book';
 import { makeSafeFilename } from '@/utils/misc';
+import { coverPreviewBase64 } from './preview';
 import type { SendFileInput } from './types';
+
+/** Best-effort cover thumbnail for the receiver's accept dialog. */
+async function resolveCoverPreview(
+  book: Book,
+  appService: AppService,
+): Promise<string | undefined> {
+  try {
+    const coverPath = getCoverFilename(book);
+    if (!(await appService.exists(coverPath, 'Books'))) return undefined;
+    const bytes = await appService.readFile(coverPath, 'Books', 'binary');
+    if (typeof bytes === 'string') return undefined;
+    return (await coverPreviewBase64(bytes)) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Resolve the on-disk file for a book so it can be handed to the LocalSend
@@ -30,5 +47,10 @@ export async function resolveBookSendFile(
   const ext = EXTS[book.format] ?? 'bin';
   const mimeType = MIMETYPES[book.format]?.[0] ?? 'application/octet-stream';
   const fileName = `${makeSafeFilename(book.sourceTitle || book.title || book.hash)}.${ext}`;
-  return { path: await appService.resolveFilePath(path, base), fileName, mimeType };
+  return {
+    path: await appService.resolveFilePath(path, base),
+    fileName,
+    mimeType,
+    preview: await resolveCoverPreview(book, appService),
+  };
 }

--- a/apps/readest-app/src/services/localsend/deviceModel.ts
+++ b/apps/readest-app/src/services/localsend/deviceModel.ts
@@ -5,6 +5,19 @@ import type { OsPlatform } from '@/types/system';
  * (the chip beside the alias). `isTablet` splits iOS into iPad/iPhone —
  * callers derive it from the screen, since Tauri reports both as `ios`.
  */
+/**
+ * Short tag identifying a device on the LAN by the last octet of its IPv4
+ * address, e.g. `#120` for 192.168.2.120. Users read it out ("send to #120
+ * macOS") so peers know which list entry to pick when aliases collide.
+ * Returns null for non-IPv4 hosts.
+ */
+export function ipTag(host: string): string | null {
+  const octets = host.split('.');
+  if (octets.length !== 4) return null;
+  if (!octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255)) return null;
+  return `#${Number(octets[3])}`;
+}
+
 export function localSendDeviceModel(os: OsPlatform, isTablet: boolean): string {
   switch (os) {
     case 'android':

--- a/apps/readest-app/src/services/localsend/preview.ts
+++ b/apps/readest-app/src/services/localsend/preview.ts
@@ -1,0 +1,49 @@
+/** Longest edge of the cover thumbnail embedded in a transfer request. */
+const COVER_PREVIEW_MAX_EDGE = 192;
+
+/** Upper bound on a peer-supplied preview; larger payloads are dropped. */
+const MAX_PREVIEW_BASE64_LENGTH = 256 * 1024;
+
+/**
+ * Turns the base64 `preview` of a LocalSend file DTO into an `img`-safe data
+ * URL. The bytes come from an arbitrary peer, so only well-formed base64 with
+ * a recognized image signature passes; anything else returns null and the UI
+ * falls back to no thumbnail.
+ */
+export function previewDataUrl(preview: string | null | undefined): string | null {
+  if (!preview) return null;
+  const base64 = preview.trim();
+  if (!base64 || base64.length > MAX_PREVIEW_BASE64_LENGTH) return null;
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(base64)) return null;
+  const mime = base64.startsWith('/9j/')
+    ? 'image/jpeg'
+    : base64.startsWith('iVBOR')
+      ? 'image/png'
+      : base64.startsWith('UklGR')
+        ? 'image/webp'
+        : null;
+  return mime ? `data:${mime};base64,${base64}` : null;
+}
+
+/**
+ * Downscales a cover image to a small JPEG and returns its raw base64 (the
+ * LocalSend `preview` wire format), or null when the image cannot be decoded.
+ */
+export async function coverPreviewBase64(bytes: ArrayBuffer): Promise<string | null> {
+  try {
+    const bitmap = await createImageBitmap(new Blob([bytes]));
+    const scale = Math.min(1, COVER_PREVIEW_MAX_EDGE / Math.max(bitmap.width, bitmap.height));
+    const width = Math.max(1, Math.round(bitmap.width * scale));
+    const height = Math.max(1, Math.round(bitmap.height * scale));
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+    if (!context) return null;
+    context.drawImage(bitmap, 0, 0, width, height);
+    bitmap.close();
+    return canvas.toDataURL('image/jpeg', 0.7).split(',')[1] || null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/readest-app/src/services/localsend/types.ts
+++ b/apps/readest-app/src/services/localsend/types.ts
@@ -3,6 +3,10 @@ export interface LocalSendStatus {
   alias: string;
   port: number;
   fingerprint: string;
+  /** OS name announced to peers ("macOS", "Android", ...). */
+  deviceModel: string;
+  /** Non-loopback IPv4 addresses; source of the "#<last-octet>" device tag. */
+  localIps: string[];
   multicastError: string | null;
 }
 
@@ -14,6 +18,8 @@ export interface LocalSendDevice {
   host: string;
   port: number;
   protocol: string;
+  /** An IPv4 address when known; source of the "#<last-octet>" tag (`host` may be IPv6). */
+  ipv4Host: string | null;
 }
 
 export interface LocalSendFile {
@@ -21,6 +27,8 @@ export interface LocalSendFile {
   fileName: string;
   size: number;
   fileType: string;
+  /** Base64 thumbnail from the sender (LocalSend `preview` wire field). */
+  preview: string | null;
 }
 
 export interface ReceiveRequest {
@@ -68,6 +76,8 @@ export interface SendFileInput {
   path: string;
   fileName: string;
   mimeType: string;
+  /** Base64 thumbnail shown by the receiver (LocalSend `preview` wire field). */
+  preview?: string;
 }
 
 export const LOCALSEND_EVENTS = {


### PR DESCRIPTION
## Problem

Readest devices could not discover each other over LocalSend, while the LocalSend app could see every Readest device and Readest could see the LocalSend app. Verified on macOS + Xiaomi hardware; three stacked causes:

1. **A configured OS proxy silently kills every HTTPS register.** The upstream client enables reqwest's `system-proxy` feature, and reqwest never exposes `TlsInfo` on proxied connections (both CONNECT and SOCKS paths hardcode it off). The protocol needs the peer certificate from TlsInfo in HTTPS mode, so on a machine with a system proxy every register fails with `TLS info not found` and the device store stays empty. `NO_PROXY` env does not bypass reqwest's system-proxy matcher, so there is no user-side workaround.
2. **Incoming register requests were dropped.** Peers answering our announcement register with our HTTP server, but `ServerEventV2::Register` was ignored, so the announcing side never learned who answered (the discovery crate documents feeding these back via `add_device`; the LocalSend app does the equivalent, which is why it always saw Readest).
3. **The subnet-scan fallback probed only 53317**, where a Readest peer never listens (Readest binds 53318+).

## Fix

- Bump the `readest/localsend` fork rev to include [`fix(client): bypass system proxies for LAN requests`](https://github.com/readest/localsend/commit/3721994985277e49e7e1ee4ed97601ad5405fc87) — LocalSend traffic is LAN-only, a proxy can never help it.
- Feed `Register` server events into the discovery store (`register_peer`, self-fingerprint guarded).
- Scan both 53317 (LocalSend app) and 53318 (first Readest port).

## Also included

- **Device tags**: Settings shows `Visible as <alias> · #<ip-octet> <os>` and picker rows show `#<octet> <model>` (matching the LocalSend app's convention), so users can tell peers which entry to pick when aliases collide. VPN tunnel interfaces are excluded; an IPv4 host is preferred for the tag when the best channel is IPv6.
- **Cover previews**: books are sent with a downscaled JPEG cover in the protocol's `preview` field, and the accept dialog renders peer-supplied previews (base64 validated, image magic sniffed, size-capped).
- **Receive dialog stacking**: raised above the device picker so an incoming request is never hidden under an open picker sheet.

## Verification

- Hardware, both directions (macOS dev build + Xiaomi 13 APK from this branch): discovery is instant both ways with tags shown; accept dialogs render cover thumbnails on both platforms; transfers complete and dedup existing books; a fake LocalSend device confirmed the outgoing prepare-upload carries the preview and that incoming registers populate the picker.
- `cargo test -p Readest --lib` (10 localsend tests, 5 new), `pnpm test` (9021 passed), `pnpm lint`, `fmt:check`, `clippy:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)