### PR TITLE
fix(popup): stop mounting the filtered pointer triangle at rest

### DIFF
--- a/apps/readest-app/src/__tests__/components/popup-resting-triangle.test.tsx
+++ b/apps/readest-app/src/__tests__/components/popup-resting-triangle.test.tsx
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+// Key handling is irrelevant to the resting triangle DOM.
+vi.mock('@/hooks/useKeyDownActions', () => ({ useKeyDownActions: () => {} }));
+
+import Popup from '@/components/Popup';
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// WebKitGTK present-path regression (#5609 and the sidebar-close variant on
+// #5618): FootnotePopup keeps a closed <Popup> mounted in every book cell, so
+// the pointer-triangle divs sit at the cell origin with no position at all.
+// Since #5351 the outer triangle carries a `drop-shadow` filter; an
+// always-mounted filtered element at the window origin makes WebKitGTK stop
+// presenting an ~80x124 device-px rect there (stale/black square on Linux,
+// bisected to #5351 and verified fixed by removing the filter). The popup must
+// not render the triangles at all while it has no triangle position.
+describe('Popup resting state (no position)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  test('renders no triangle elements without a trianglePosition', () => {
+    const { container } = render(
+      <Popup width={200} height={44}>
+        <div />
+      </Popup>,
+    );
+    expect(container.querySelector('.popup-triangle-outer')).toBeNull();
+    expect(container.querySelector('.popup-triangle-inner')).toBeNull();
+    cleanup();
+  });
+
+  test('drops the drop-shadow filter while the triangle is hidden', () => {
+    // Triangle point inside the popup rect -> triangleHidden. The invisible
+    // element must not keep the filter: visibility hides the pixels but the
+    // filter still creates the pathological compositor state.
+    const { container } = render(
+      <Popup
+        width={200}
+        height={44}
+        position={{ point: { x: 100, y: 400 }, dir: 'down' }}
+        trianglePosition={{ point: { x: 150, y: 420 }, dir: 'down' }}
+      >
+        <div />
+      </Popup>,
+    );
+    const outer = container.querySelector('.popup-triangle-outer');
+    expect(outer).not.toBeNull();
+    expect(outer!.classList.contains('invisible')).toBe(true);
+    expect(outer!.className).not.toContain('drop-shadow');
+    cleanup();
+  });
+});

--- a/apps/readest-app/src/app/reader/components/BooksGrid.tsx
+++ b/apps/readest-app/src/app/reader/components/BooksGrid.tsx
@@ -152,16 +152,6 @@ const BookCellInner: React.FC<BookCellProps> = ({
       data-view-transition-root=''
       className={clsx(
         'relative h-full w-full overflow-hidden',
-        // WebKitGTK stops repainting an ~80x124 device-px rect at the window
-        // origin while the reader mounts, freezing whatever painted there
-        // first — a stale base-100 square over the sidebar, black on dark
-        // themes (#5609; upstream engine defect, blends and view transitions
-        // ruled out — it reproduces on reflowable books with no active
-        // blend). `isolate` gives the cell its own stacking context, which
-        // re-layerizes the corner so the frozen region only ever captures
-        // already-correct pixels — the same masking the resting Ribbon's
-        // top-left layer provided before #5493 moved it top-right.
-        'isolate',
         appServiceHasRoundedWindow && 'rounded-window',
       )}
     >

--- a/apps/readest-app/src/components/Popup.tsx
+++ b/apps/readest-app/src/components/Popup.tsx
@@ -151,13 +151,21 @@ const Popup = ({
     // re-anchoring it off the viewport and demoting its z-50 under later reader
     // chrome. The triangle shadow lives on the triangle itself.
     <div>
-      <div
-        className={clsx(
-          'popup-triangle-outer text-base-content/20 not-eink:drop-shadow-xl absolute z-50',
-          triangleHidden ? 'invisible' : 'visible',
-        )}
-        style={outerTriangleStyles}
-      />
+      {/* Never mount the triangles without a position, and never combine
+          `invisible` with the drop-shadow: FootnotePopup keeps a closed Popup
+          mounted in every book cell, and an always-mounted filtered element at
+          the cell origin makes WebKitGTK stop presenting an ~80x124 device-px
+          rect there — the Linux stale/black corner square (#5609, bisected to
+          #5351's triangle filter). */}
+      {trianglePosition && (
+        <div
+          className={clsx(
+            'popup-triangle-outer text-base-content/20 absolute z-50',
+            triangleHidden ? 'invisible' : 'not-eink:drop-shadow-xl visible',
+          )}
+          style={outerTriangleStyles}
+        />
+      )}
       <div
         id='popup-container'
         ref={containerRef}
@@ -183,13 +191,15 @@ const Popup = ({
       >
         {children}
       </div>
-      <div
-        className={clsx(
-          'popup-triangle-inner text-base-300 theme-dark:text-base-100 absolute z-50',
-          triangleHidden ? 'invisible' : 'visible',
-        )}
-        style={innerTriangleStyles}
-      />
+      {trianglePosition && (
+        <div
+          className={clsx(
+            'popup-triangle-inner text-base-300 theme-dark:text-base-100 absolute z-50',
+            triangleHidden ? 'invisible' : 'visible',
+          )}
+          style={innerTriangleStyles}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Fixes #5609.

## Root cause

#5351 put \`not-eink:drop-shadow-xl\` — a CSS \`filter\` — on the popup pointer triangle. \`FootnotePopup\` keeps a closed \`Popup\` mounted in every book cell, so an always-mounted filtered element sits at the cell origin whenever a book is open. On WebKitGTK (Flatpak GNOME 49/50 runtimes; reproduced on NVIDIA + X11) that element makes the compositor stop presenting an ~80×124 device-px rect at the window origin: whatever was last presented there sticks. That is the stale/black corner square — page pixels frozen over the open sidebar originally, sidebar pixels frozen after dismissal under #5618's \`isolate\` (as reported in [this comment](https://github.com/readest/readest/pull/5618#issuecomment-5248736671)), and uninitialized black after a window resize.

## Evidence

- Official release debs on the GNOME 50 Flatpak runtime: 0.11.18 and 0.11.20 clean, 0.12.1 bad.
- \`git bisect run\` over v0.11.20..v0.12.1 with an automated Flatpak trial (fresh one-book profile, scripted sidebar toggle, ImageMagick corner sampling; fully deterministic — identical configs produce byte-identical screenshots) → first bad commit is e05b7d5bb (#5351).
- Removing only the triangle filter on vanilla v0.12.1 flips the trial from bad to clean.
- With this fix on main: the open-sidebar corner renders intact, and closed-state screenshots are md5-identical across repeated open/close cycles. Verified interactively on the real library as well.

## Change

- Render the pointer triangles only when the popup has a \`trianglePosition\` (at rest \`FootnotePopup\` passes none, so nothing mounts at the origin).
- Apply the drop-shadow only while the triangle is actually visible — never \`invisible\` + filter, which is exactly the pathological combination.
- Revert #5618: the \`isolate\` on the book cell was a mitigation for this same defect; with the root cause fixed it is no longer needed.

The underlying WebKitGTK misbehavior (an invisible filtered element pinning a never-presented region) still deserves an upstream report; this PR removes the trigger on our side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)