### PR TITLE
fix(sync): recover KOReader progress when a chapter is not well-formed XML

### DIFF
--- a/apps/readest-app/src/__tests__/foliate-epub-malformed-xhtml.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-epub-malformed-xhtml.test.ts
@@ -1,0 +1,124 @@
+// Regression test for #5625: a chapter declared `application/xhtml+xml` in the
+// manifest whose markup is not well-formed XML (Adobe InDesign / Digital
+// Editions ship an unclosed `<meta charset="utf-8">` constantly) yields a
+// `parsererror` document with a NULL `document.body`.
+//
+// `loadItem`/`loadReplaced` — the render path — already retries such a file as
+// `text/html`. `loadDocument`, which backs `Section.createDocument()`, did not,
+// so every off-screen consumer got the error document instead of the chapter:
+// XPointer->CFI conversion (`src/utils/xcfi.ts`) reads `document.body.children`
+// and threw `TypeError: Cannot read properties of null (reading 'children')`,
+// which is what broke KOReader progress sync in the report.
+import { describe, expect, it } from 'vitest';
+
+import { EPUB } from 'foliate-js/epub.js';
+import type { BookDoc } from '@/libs/document';
+import { getCFIFromXPointer } from '@/utils/xcfi';
+
+const CONTAINER = `<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`;
+
+const opf = (items: { id: string; href: string }[]) => `<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="BookID" version="2.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Malformed XHTML</dc:title>
+    <dc:language>en</dc:language>
+    <dc:identifier id="BookID">urn:uuid:12345</dc:identifier>
+  </metadata>
+  <manifest>
+    ${items.map(({ id, href }) => `<item id="${id}" href="${href}" media-type="application/xhtml+xml"/>`).join('\n    ')}
+  </manifest>
+  <spine>
+    ${items.map(({ id }) => `<itemref idref="${id}"/>`).join('\n    ')}
+  </spine>
+</package>`;
+
+const wellFormed = `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><meta charset="utf-8"/></head>
+<body><p>Chapter 1</p></body></html>`;
+
+// Verbatim shape of the reported book: no XML declaration, and a void `<meta>`
+// left unclosed inside `<head>`, which makes the XML parser bail at `</head>`.
+const malformed = `<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-GB">
+	<head>
+	<meta charset="utf-8">
+	<title>Chapter 2</title>
+	</head>
+	<body>
+	<p>First</p>
+	<p>Second</p>
+	</body>
+</html>`;
+
+type Section = { createDocument: () => Promise<Document> };
+
+const openEpub = async (files: Record<string, string>) => {
+  const epub = new EPUB({
+    entries: Object.keys(files).map((filename) => ({ filename })),
+    loadText: async (name: string) => files[name] ?? null,
+    loadBlob: async (name: string) =>
+      files[name] == null ? null : new Blob([files[name]!], { type: 'application/xhtml+xml' }),
+    getSize: (name: string) => files[name]?.length ?? 0,
+    sha1: undefined,
+  });
+  await epub.init();
+  return (epub.sections ?? []) as Section[];
+};
+
+const openFixture = () =>
+  openEpub({
+    'META-INF/container.xml': CONTAINER,
+    'OEBPS/content.opf': opf([
+      { id: 'ch1', href: 'ch1.html' },
+      { id: 'ch2', href: 'ch2.html' },
+    ]),
+    'OEBPS/ch1.html': wellFormed,
+    'OEBPS/ch2.html': malformed,
+  });
+
+describe('createDocument on a section that is not well-formed XML (#5625)', () => {
+  it('retries as HTML so the chapter body is reachable', async () => {
+    const sections = await openFixture();
+    const doc = await sections[1]!.createDocument();
+
+    // The XML parse produces `<parsererror>` and a null body; the HTML retry
+    // must give back the real chapter instead.
+    expect(doc.querySelector('parsererror')).toBeNull();
+    expect(doc.body).not.toBeNull();
+    expect(Array.from(doc.body.querySelectorAll('p')).map((p) => p.textContent)).toEqual([
+      'First',
+      'Second',
+    ]);
+  });
+
+  it('still parses a well-formed section as XHTML', async () => {
+    const sections = await openFixture();
+    const doc = await sections[0]!.createDocument();
+
+    expect(doc.documentElement.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
+    expect(doc.body.querySelector('p')?.textContent).toBe('Chapter 1');
+  });
+
+  // The whole chain the KOReader plugin depends on: a CREngine XPointer naming
+  // a section OTHER than the rendered one, so `getCFIFromXPointer` has to build
+  // its converter from `createDocument()`. This is the exact call that raised
+  // "TypeError: Cannot read properties of null (reading 'children')".
+  it('converts a KOReader XPointer that lands in that section', async () => {
+    const sections = await openFixture();
+    const bookDoc = { sections } as unknown as BookDoc;
+
+    // DocFragment[2] is CREngine's 1-based number for spine index 1.
+    const cfi = await getCFIFromXPointer(
+      '/body/DocFragment[2]/body/p[2]/text().3',
+      undefined,
+      undefined,
+      bookDoc,
+    );
+
+    expect(cfi).toMatch(/^epubcfi\(/);
+  });
+});

--- a/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
@@ -41,11 +41,17 @@ const h = vi.hoisted(() => {
     setViewSettingsMock: vi.fn(),
     recreateViewerMock: vi.fn(),
     cfiCompareMock: vi.fn((_a: string, _b: string) => 0),
-    view: { renderer: { getContents: () => [], primaryIndex: 0 }, goTo: vi.fn() },
+    getCFIFromXPointerMock: vi.fn(async (..._args: unknown[]) => ''),
+    view: {
+      renderer: { getContents: () => [], primaryIndex: 0 },
+      goTo: vi.fn(),
+      goToFraction: vi.fn(),
+    },
     state: {
       syncedConfigs: [] as unknown[] | null,
-      progress: { location: 'cfi-loc' } as { location: string } | null,
+      progress: { location: 'cfi-loc' } as { location: string; fraction?: number } | null,
       viewSettings: { proofreadRules: [] } as { proofreadRules: unknown[] } | null,
+      bookDoc: {} as unknown,
     },
     eventListeners: new Map<string, Set<(e: CustomEvent) => void>>(),
   };
@@ -76,7 +82,7 @@ vi.mock('@/store/bookDataStore', () => ({
     getConfig: () => h.config,
     setConfig: vi.fn(),
     saveConfig: h.saveConfigMock,
-    getBookData: () => ({ book: h.book }),
+    getBookData: () => ({ book: h.book, bookDoc: h.state.bookDoc }),
   }),
 }));
 
@@ -112,7 +118,7 @@ vi.mock('@/utils/serializer', () => ({
 }));
 
 vi.mock('@/utils/xcfi', () => ({
-  getCFIFromXPointer: vi.fn(async () => ''),
+  getCFIFromXPointer: (...args: unknown[]) => h.getCFIFromXPointerMock(...args),
   getXPointerFromCFI: vi.fn(async () => ({ xpointer: '' })),
 }));
 
@@ -157,11 +163,16 @@ beforeEach(() => {
   h.setViewSettingsMock.mockClear();
   h.recreateViewerMock.mockClear();
   h.view.goTo.mockClear();
+  h.view.goToFraction.mockClear();
   h.cfiCompareMock.mockReset();
   h.cfiCompareMock.mockReturnValue(0);
+  h.getCFIFromXPointerMock.mockReset();
+  h.getCFIFromXPointerMock.mockResolvedValue('');
+  h.book.format = 'PDF';
   h.state.syncedConfigs = [];
   h.state.progress = { location: 'cfi-loc' };
   h.state.viewSettings = { proofreadRules: [] };
+  h.state.bookDoc = {};
   h.eventListeners.clear();
 });
 
@@ -383,5 +394,105 @@ describe('useProgressSync', () => {
     // The pending push is flushed immediately — Device A's last local position
     // reaches the cloud before the reader tears down.
     expect(pushCallCount()).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// Issue #5625. The Readest KOReader plugin pushes `progress` + `xpointer` and
+// never a `location`, so the CREngine XPointer is the ONLY precise handle on
+// the remote position. When converting it throws — a chapter whose XHTML isn't
+// well-formed used to make `createDocument()` hand back a body-less
+// `parsererror` document — the rejection escaped `applyRemoteProgress`
+// entirely: the reader stayed put, the proofread merge never ran, and the
+// debounced auto-push then overwrote the newer Kobo position with the older
+// local one.
+describe('useProgressSync — KOReader-origin config (#5625)', () => {
+  // [current, total] as CREngine paginates it, matching the reported payload.
+  const KO_PROGRESS: [number, number] = [176, 411];
+  const KO_FRACTION = 176 / 411;
+  const koConfig = (extra: Record<string, unknown> = {}) => ({
+    bookHash: 'h1',
+    metaHash: 'm1',
+    progress: KO_PROGRESS,
+    xpointer: '/body/DocFragment[14]/body/p[45]/text().0',
+    updatedAt: 3000,
+    ...extra,
+  });
+
+  beforeEach(() => {
+    h.book.format = 'EPUB';
+    h.state.progress = { location: 'cfi-loc', fraction: 0.05 };
+  });
+
+  test('feeds the KOReader page fraction in as the DocFragment drift anchor', async () => {
+    h.state.syncedConfigs = [koConfig()];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.getCFIFromXPointerMock).toHaveBeenCalledTimes(1);
+    expect(h.getCFIFromXPointerMock.mock.calls[0]![4]).toBeCloseTo(KO_FRACTION, 6);
+  });
+
+  test('does not anchor on the percentage when the remote config carries its own CFI', async () => {
+    // A Readest-origin config: its xpointer was derived from that same CFI, so
+    // the nominal DocFragment is already exact and its [page, total] is
+    // foliate's pagination, not CREngine's — re-anchoring on it would move the
+    // target to the wrong section.
+    h.state.syncedConfigs = [koConfig({ location: 'epubcfi(/6/24!/4/20/1:58)' })];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.getCFIFromXPointerMock.mock.calls[0]![4]).toBeUndefined();
+  });
+
+  test('a failed XPointer conversion still lets the rest of the pull run', async () => {
+    h.getCFIFromXPointerMock.mockRejectedValue(new Error('Failed to convert XPointer'));
+    h.state.viewSettings = {
+      proofreadRules: [{ id: 'local', scope: 'book', pattern: 'a', updatedAt: 100 }],
+    };
+    h.state.syncedConfigs = [
+      koConfig({
+        viewSettings: {
+          proofreadRules: [{ id: 'remote', scope: 'book', pattern: 'b', updatedAt: 200 }],
+        },
+      }),
+    ];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    // The throw used to reject applyRemoteProgress before this point.
+    expect(h.setViewSettingsMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('falls back to the reported fraction when the XPointer cannot be converted', async () => {
+    h.getCFIFromXPointerMock.mockRejectedValue(new Error('Failed to convert XPointer'));
+    h.state.syncedConfigs = [koConfig()];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.view.goToFraction).toHaveBeenCalledTimes(1);
+    expect(h.view.goToFraction.mock.calls[0]![0]).toBeCloseTo(KO_FRACTION, 6);
+  });
+
+  test('never walks the reader backwards on that fallback', async () => {
+    // Local is already past the Kobo position; an approximate jump would be a
+    // regression, and the auto-push will carry the local position forward.
+    h.getCFIFromXPointerMock.mockRejectedValue(new Error('Failed to convert XPointer'));
+    h.state.progress = { location: 'cfi-loc', fraction: 0.9 };
+    h.state.syncedConfigs = [koConfig()];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.view.goToFraction).not.toHaveBeenCalled();
+  });
+
+  test('prefers the converted CFI over the approximate fraction', async () => {
+    h.getCFIFromXPointerMock.mockResolvedValue('epubcfi(/6/30!/4/90/1:0)');
+    h.cfiCompareMock.mockReturnValue(-1);
+    h.state.syncedConfigs = [koConfig()];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.view.goTo).toHaveBeenCalledWith('epubcfi(/6/30!/4/90/1:0)');
+    expect(h.view.goToFraction).not.toHaveBeenCalled();
   });
 });

--- a/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
@@ -5,7 +5,7 @@ import { useSync } from '@/hooks/useSync';
 import { BookConfig, FIXED_LAYOUT_FORMATS } from '@/types/book';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useReaderStore } from '@/store/readerStore';
-import { useBookProgress } from '@/store/readerProgressStore';
+import { getBookProgress, useBookProgress } from '@/store/readerProgressStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { mergeProofreadRules } from '@/utils/proofread';
@@ -22,6 +22,15 @@ import { isMalformedLocationCfi } from '@/utils/cfi';
 // still sync out even if the server keeps timing out (high Android network
 // concurrency, captive portal, transient 5xx). Total window ≈ 15.5s.
 const PULL_RETRY_DELAYS_MS = [1500, 4000, 10000];
+
+// `[current, total]` 1-based page numbers -> a 0..1 reading fraction, or
+// `undefined` when the record carries no usable page count.
+const getConfigFraction = (config: BookConfig): number | undefined => {
+  const [current, total] = config.progress ?? [];
+  if (!current || !total || total <= 0) return undefined;
+  const fraction = current / total;
+  return Number.isFinite(fraction) ? Math.min(fraction, 1) : undefined;
+};
 
 export const useProgressSync = (bookKey: string) => {
   const _ = useTranslation();
@@ -230,18 +239,37 @@ export const useProgressSync = (bookKey: string) => {
       const xpointer = syncedConfig.xpointer;
       const bookData = getBookData(bookKey);
       const view = getView(bookKey);
+      // The Readest KOReader plugin pushes `progress` + `xpointer` and never a
+      // `location`, so its [page, total] is CREngine's own pagination. That
+      // doubles as the anchor that corrects CREngine<->foliate DocFragment
+      // drift and as the last-resort target when the XPointer won't convert.
+      // A config that carries a CFI came from Readest, whose [page, total] is
+      // foliate's pagination and whose xpointer was derived from that same
+      // CFI — re-anchoring on it would only move the target off (#5109).
+      const remoteFraction = syncedConfig.location ? undefined : getConfigFraction(syncedConfig);
+      let xpointerUnresolved = false;
       if (xpointer && view && bookData && bookData.bookDoc) {
         const pContents = view.renderer.getContents();
         const pIdx = view.renderer.primaryIndex;
         const content = pContents.find((x) => x.index === pIdx) ?? pContents[0];
-        const candidateCFI = await getCFIFromXPointer(
-          xpointer,
-          content?.doc,
-          content?.index,
-          bookData.bookDoc,
-        );
-        if (!remoteCFILocation || CFI.compare(remoteCFILocation, candidateCFI) < 0) {
-          remoteCFILocation = candidateCFI;
+        try {
+          const candidateCFI = await getCFIFromXPointer(
+            xpointer,
+            content?.doc,
+            content?.index,
+            bookData.bookDoc,
+            remoteFraction,
+          );
+          if (!remoteCFILocation || CFI.compare(remoteCFILocation, candidateCFI) < 0) {
+            remoteCFILocation = candidateCFI;
+          }
+        } catch (error) {
+          // Never let one unconvertible XPointer reject the whole pull — the
+          // proofread merge below still has to run, and swallowing the rest
+          // silently is what let the debounced auto-push overwrite a newer
+          // remote position with the local one (#5625).
+          console.warn('Failed to convert XPointer to CFI', error);
+          xpointerUnresolved = true;
         }
       }
       // Reading progress applies below. Proofread (find/replace) rules merge
@@ -262,6 +290,22 @@ export const useProgressSync = (bookKey: string) => {
               message: _('Reading Progress Synced'),
             });
           }
+        }
+      } else if (xpointerUnresolved && remoteFraction !== undefined) {
+        // No CFI anywhere and the XPointer didn't resolve: the reported
+        // fraction is all that's left. CREngine and foliate paginate
+        // differently, so it's approximate — only ever move FORWARD with it,
+        // matching the CFI branch, so an imprecise jump can't lose the reader's
+        // place.
+        const localFraction = getBookProgress(bookKey)?.fraction;
+        const isPreview = useReaderStore.getState().getViewState(bookKey)?.previewMode;
+        if (view && !isPreview && (localFraction ?? 0) < remoteFraction) {
+          view.goToFraction(remoteFraction);
+          setHoveredBookKey(null);
+          eventDispatcher.dispatch('hint', {
+            bookKey,
+            message: _('Reading Progress Synced'),
+          });
         }
       }
       // Merge book/selection-scope proofread rules from the remote config by id.


### PR DESCRIPTION
Fixes #5625

## Problem

Reading progress pushed from the Readest KOReader plugin never moved the reader, and roughly five seconds later the debounced auto-push overwrote the newer remote position with the older local one.

The plugin sends `progress` + `xpointer` and never a `location`, so the CREngine XPointer is the only precise handle on the remote position. Converting it loads the target section through `Section.createDocument()` whenever that section is not the rendered one.

For a book whose chapters declare `application/xhtml+xml` but are not well-formed XML, `loadDocument` returned a `parsererror` document with a **null** `body`. `XCFI.resolveXPointerPath` walks `this.document.body.children`, so it threw exactly what the report shows:

```
TypeError: Cannot read properties of null (reading 'children')
```

The throw escaped `applyRemoteProgress` entirely (no `try`/`catch`), so the reader never moved, the proofread rule merge never ran, and the auto-push then clobbered the Kobo position.

## Root cause

One missing fallback in foliate-js. `loadReplaced` (the **render** path) has always retried such a section as `text/html`; `loadDocument`, which backs `Section.createDocument()` (the **off-screen** path), did not. Fixed in readest/foliate-js#70, bumped here.

## Changes

foliate-js submodule bump plus, in `applyRemoteProgress`:

- **`try`/`catch` around the conversion**, so one unconvertible XPointer can no longer reject the whole pull and skip the proofread merge.
- **Feed the KOReader page fraction in as the DocFragment drift anchor**, which the KOSync path (`useKOSync.ts`) already did. Gated to a config with no CFI of its own: a record carrying a CFI came from Readest, whose `[page, total]` is foliate's pagination and whose xpointer was derived from that same CFI, so re-anchoring on it would only move the target off (#5109).
- **Fall back to that fraction when the XPointer will not convert at all.** CREngine and foliate paginate differently so it is approximate, therefore it only ever moves **forward**, matching the existing CFI branch, so an imprecise jump cannot lose the reader's place.

## On "Defect 3" in the report (render fallback does not run)

Not reproducible, and I do not think it is real. Probing real Chromium and WebKit via Playwright, `doc.querySelector('parsererror')` **does** match a malformed XHTML parse (the error block is `<parsererror>` in the XHTML namespace), so `loadReplaced` recovers correctly. The report looked for the literal console string `Invalid XHTML`, but the code logs `doc.querySelector('parsererror')?.innerText ?? 'Invalid XHTML'`, so the parsererror text wins and that string never appears.

Confirmed against the reported book in the running app: it renders clean, and `bookDoc.sections[13].createDocument()` returns the real chapter (98 `<p>` elements, `p[45]` being the exact reported position).

## Verification

- New `foliate-epub-malformed-xhtml.test.ts` builds an EPUB with a malformed chapter and covers `createDocument()` plus the full XPointer conversion. Without the submodule bump it fails with the reported `TypeError` verbatim.
- Six new cases in `useProgressSync.test.tsx` for the drift anchor, the anchor gate, the non-aborting catch, the fraction fallback, its forward-only guard, and CFI-beats-fraction.
- `pnpm test` 9032 passed / 16 skipped, `pnpm lint` and `pnpm format:check` clean.
- Verified in Chrome against the reporter's EPUB (bookHash `802f7eb4adb4d236935ff78ada5b205d`); all 32 of its spine files carry the unclosed `<meta charset="utf-8">`.
- Checked the drift anchor cannot misfire on that book: the KOReader fraction `176/411 = 0.4282` falls inside spine section 13's size range `0.4111..0.4473`, so `resolveSpineSectionIndex` keeps the nominal index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)