### PR TITLE
feat(ci): Added new step to release workflow to send release notes to a Discord channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     outputs:
       release_id: ${{ steps.get-release.outputs.release_id }}
       release_tag: ${{ steps.get-release.outputs.release_tag }}
+      release_title: ${{ steps.get-release.outputs.release_title }}
+      release_url: ${{ steps.get-release.outputs.release_url }}
       release_note: ${{ steps.get-release-notes.outputs.release_note }}
       release_version: ${{ steps.get-release-notes.outputs.release_version }}
 
@@ -35,6 +37,8 @@ jobs:
             })
             core.setOutput('release_id', data.id);
             core.setOutput('release_tag', data.tag_name);
+            core.setOutput('release_title', data.name);
+            core.setOutput('release_url', data.html_url);
       - name: get release notes
         id: get-release-notes
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -73,8 +77,10 @@ jobs:
             })
             const notes = process.env.release_note.split(/\d+\.\s/).filter(Boolean);
             const formattedNotes = notes.map(note => `* ${note.trim()}`).join("\n");
-            const body = `## Release Highlight\n${formattedNotes}\n\n${data.body}`;
-            github.rest.repos.updateRelease({
+            const body = `## Release Highlights\n${formattedNotes}\n\n${data.body}`;
+            core.setOutput('release_description', body);
+
+            await github.rest.repos.updateRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: process.env.release_id,
@@ -82,6 +88,81 @@ jobs:
               draft: false,
               prerelease: false
             })
+      - name: send release description to Discord
+        id: update-discord
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          discord_webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          release_tag: ${{ needs.get-release.outputs.release_tag }}
+          release_title: ${{ needs.get-release.outputs.release_title }}
+          release_url: ${{ needs.get-release.outputs.release_url }}
+          release_description: ${{ steps.update-release.outputs.release_description }}
+        with:
+          script: |
+            let payload = process.env.release_description;
+
+            // Replace @username with markdown link
+            payload = payload.replace(
+              /(?<![/@\w])@((?!-)(?!.*?--)[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,37})(?![.\w/-])(?!.*\])/g,
+              (match, name) => `[@${name}](https://github.com/${name})`
+            );
+
+            // Convert PR, issue, and changelog links to markdown format
+            // Extract existing markdown links and replace them with placeholders
+            const markdownLinks = [];
+            const textWithoutMarkdownLinks = payload.replace(/\[.*?\]\(.*?\)/g, (link) => {
+                markdownLinks.push(link);
+                return `__MARKDOWN_LINK_PLACEHOLDER_${markdownLinks.length - 1}__`;
+            });
+
+            // Convert standalone PR, issue, and changelog URLs to markdown format
+            let processedText = textWithoutMarkdownLinks
+                .replace(/https:\/\/github\.com\/([\w-]+)\/([\w-]+)\/pull\/(\d+)/g, (match, owner, repo, prNumber) => `[#${prNumber}](${match})`)
+                .replace(/https:\/\/github\.com\/([\w-]+)\/([\w-]+)\/issues\/(\d+)/g, (match, owner, repo, issueNumber) => `[#${issueNumber}](${match})`)
+                .replace(/https:\/\/github\.com\/([\w-]+)\/([\w-]+)\/compare\/([v\w.-]+)\.\.\.([v\w.-]+)/g, (match, owner, repo, fromVersion, toVersion) => `[${fromVersion}...${toVersion}](${match})`);
+
+            // Reinsert the original markdown links
+            payload = processedText.replace(/__MARKDOWN_LINK_PLACEHOLDER_(\d+)__/g, (match, index) => markdownLinks[parseInt(index, 10)]);
+            
+            // Enforce Discord's max lengths
+            const embedTitle = (process.env.release_title || process.env.release_tag || '').substring(0, 256);
+            const embedUrl = process.env.release_url;
+            const embedDescription = (payload || '').substring(0, 4096);
+
+            let attempt = 0;
+            while (attempt <= 3) {
+                try {
+                    const response = await fetch(`${process.env.discord_webhook}?wait=true`, {
+                        method: 'POST',
+                        body: JSON.stringify({
+                            embeds: [{
+                                title: embedTitle,
+                                url: embedUrl,
+                                description: embedDescription
+                            }]
+                        }),
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                    if (response.status === 429) {
+                        // Rate limited, get retry-after
+                        const retryAfter = parseInt(response.headers.get('retry-after') || '1', 10);
+                        core.warning(`Rate limited by Discord. Retrying after ${retryAfter} seconds (attempt ${attempt + 1}/3)`);
+                        await new Promise(res => setTimeout(res, retryAfter * 1000));
+                        attempt++;
+                        continue;
+                    }
+                    const data = await response.json();
+                    if (!response.ok) {
+                        core.setFailed(`Discord webhook error: ${JSON.stringify(data)}`);
+                    } else {
+                        core.info(JSON.stringify(data));
+                    }
+                    break;
+                } catch (err) {
+                    core.setFailed(err.message);
+                    break;
+                }
+            }
 
   build-koreader-plugin:
     needs: get-release


### PR DESCRIPTION
To enable this functionality you will need to create a Discord channel with a webhook for GitHub to communicate with

### In Discord:
1. Create a new Text channel
2. Open the new channel's settings
3. Under Permissions, disallow @everyone for all permissions except "View Channel" and "Read Message History" (the webhook runs at system perms, so it'll ignore these)
4. Under Integrations, create a webhook with a name and image. (The name and avatar you choose here will show up as the user sending the messages to the channel)
5. Copy the webhook URL

### In GitHub:
1. Create a new repository secret in the Readest repo
    - name: DISCORD_WEBHOOK
    - value: [copied webhook url]