### PR TITLE
fix(reader): commit settled image zoom into the layout size, closes #5633

### DIFF
--- a/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ImageViewer.test.tsx
@@ -96,11 +96,11 @@ describe('ImageViewer', () => {
   // pixel per device pixel — no interpolation, identical detail everywhere.
   const measuredViewer = ({
     naturalWidth,
-    offsetWidth,
+    fitWidth,
     dpr,
   }: {
     naturalWidth: number;
-    offsetWidth: number;
+    fitWidth: number;
     dpr: number;
   }) => {
     Object.defineProperty(window, 'devicePixelRatio', { value: dpr, configurable: true });
@@ -110,9 +110,21 @@ describe('ImageViewer', () => {
     const img = container.querySelector('img')!;
     Object.defineProperty(img, 'naturalWidth', { value: naturalWidth, configurable: true });
     Object.defineProperty(img, 'naturalHeight', { value: naturalWidth, configurable: true });
-    // `offsetWidth` is the laid-out (untransformed) width, so it stays the
-    // fit-to-screen size at any zoom level.
-    Object.defineProperty(img, 'offsetWidth', { value: offsetWidth, configurable: true });
+    // jsdom has no layout; give the viewer container a square viewport so the
+    // (square) image's computed fit size equals `fitWidth`.
+    const viewer = container.querySelector('[aria-label="Image viewer"]') as HTMLElement;
+    viewer.getBoundingClientRect = () =>
+      ({
+        width: fitWidth,
+        height: fitWidth,
+        top: 0,
+        left: 0,
+        right: fitWidth,
+        bottom: fitWidth,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
     act(() => {
       fireEvent.load(img);
     });
@@ -125,7 +137,7 @@ describe('ImageViewer', () => {
   it('reports the fraction of the image resolution actually shown when fit to screen', () => {
     // 1600 image px painted across 400 CSS px * dpr 2 = 800 device px: half the
     // image's detail is on screen, so the badge must not claim 100%.
-    const { container } = measuredViewer({ naturalWidth: 1600, offsetWidth: 400, dpr: 2 });
+    const { container } = measuredViewer({ naturalWidth: 1600, fitWidth: 400, dpr: 2 });
 
     expect(zoomPercent(container)).toBe(50);
   });
@@ -133,7 +145,7 @@ describe('ImageViewer', () => {
   it('double-click zooms to exactly 1:1 (100% = one image pixel per device pixel)', () => {
     // Pixel-perfect needs scale 1200 / (400 * 1) = 3, which the old fixed 2x
     // double-click could never land on.
-    const { container, img } = measuredViewer({ naturalWidth: 1200, offsetWidth: 400, dpr: 1 });
+    const { container, img } = measuredViewer({ naturalWidth: 1200, fitWidth: 400, dpr: 1 });
 
     act(() => {
       fireEvent.doubleClick(img);
@@ -146,7 +158,7 @@ describe('ImageViewer', () => {
   it('keeps 1:1 reachable for images larger than the old zoom ceiling', () => {
     // 1:1 needs scale 50 here, far past the old MAX_SCALE of 8 — the full
     // resolution of a large illustration was simply unreachable.
-    const { img } = measuredViewer({ naturalWidth: 20000, offsetWidth: 400, dpr: 1 });
+    const { img } = measuredViewer({ naturalWidth: 20000, fitWidth: 400, dpr: 1 });
 
     act(() => {
       fireEvent.wheel(img, { deltaY: -20000, ctrlKey: true, clientX: 100, clientY: 100 });
@@ -154,6 +166,96 @@ describe('ImageViewer', () => {
 
     const reachedScale = Number(/scale\(([\d.]+)\)/.exec(img.style.transform)![1]);
     expect(reachedScale).toBeGreaterThanOrEqual(50);
+  });
+
+  // iOS WebKit rasterizes the image at its *layout* size and only stretches
+  // that raster for `transform: scale`, so zooming in showed a fit-to-screen
+  // resolution image no matter how much detail the source had (#5633).
+  // Chromium re-rasterizes at the transformed scale, which is why the same
+  // code was sharp on Android. The viewer must commit a settled zoom into the
+  // image's layout size so WebKit repaints it with enough pixels, and keep the
+  // transform only for the in-flight gesture.
+  describe('committing zoom into the layout size (#5633)', () => {
+    it('commits a settled discrete zoom into the layout size', () => {
+      vi.useFakeTimers();
+      try {
+        // pixelPerfectScale = 1600 / (400 * 2) = 2, which is also what
+        // double-click zooms to.
+        const { img } = measuredViewer({ naturalWidth: 1600, fitWidth: 400, dpr: 2 });
+
+        expect(img.style.width).toBe('400px');
+
+        act(() => {
+          fireEvent.doubleClick(img);
+        });
+        // The gesture itself rides on the transform.
+        expect(img.style.transform).toContain('scale(2)');
+
+        act(() => {
+          vi.advanceTimersByTime(1000);
+        });
+        // Settled: the zoom lives in the layout size, the transform is unity.
+        expect(img.style.width).toBe('800px');
+        expect(img.style.transform).toContain('scale(1)');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('keeps a streaming wheel pinch on the transform, then commits up to 1:1', () => {
+      vi.useFakeTimers();
+      try {
+        const { img } = measuredViewer({ naturalWidth: 1600, fitWidth: 400, dpr: 2 });
+
+        act(() => {
+          // Far past pixel-perfect (2): caps at maxScale 8.
+          fireEvent.wheel(img, { deltaY: -20000, ctrlKey: true, clientX: 200, clientY: 200 });
+        });
+        // Mid-gesture: layout still at fit size, zoom entirely on the transform.
+        expect(img.style.width).toBe('400px');
+        expect(img.style.transform).toContain('scale(8)');
+
+        // Two steps: the wheel gesture first settles (200ms), which is what
+        // arms the commit timer; then the commit fires.
+        act(() => {
+          vi.advanceTimersByTime(500);
+        });
+        act(() => {
+          vi.advanceTimersByTime(500);
+        });
+        // Committed layout is clamped to the image's own resolution (1:1);
+        // beyond that the transform magnifies, as extra raster pixels would
+        // add memory but no detail.
+        expect(img.style.width).toBe('800px');
+        expect(img.style.transform).toContain('scale(4)');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('caps the committed raster size for huge images', () => {
+      vi.useFakeTimers();
+      try {
+        // 1:1 would need a 20000px-wide layout; committing that would OOM the
+        // iOS WebContent process (cf. #5118), so the layout caps at 4096
+        // device px on the long side.
+        const { img } = measuredViewer({ naturalWidth: 20000, fitWidth: 400, dpr: 1 });
+
+        act(() => {
+          fireEvent.wheel(img, { deltaY: -20000, ctrlKey: true, clientX: 200, clientY: 200 });
+        });
+
+        act(() => {
+          vi.advanceTimersByTime(500);
+        });
+        act(() => {
+          vi.advanceTimersByTime(500);
+        });
+        expect(img.style.width).toBe('4096px');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   // #5232: EPUBs often keep the caption or table description of an

--- a/apps/readest-app/src/app/reader/components/ImageViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/ImageViewer.tsx
@@ -28,6 +28,13 @@ const WHEEL_SENSITIVITY = 0.001;
 // Double-click magnification used when 1:1 is not a zoom in (see
 // `doubleClickScale`), which is what double-click always did before.
 const FALLBACK_DOUBLE_CLICK_SCALE = 2;
+// How long after the last scale change (and past the 0.05s discrete-zoom
+// transition) a settled zoom is committed into the layout size.
+const COMMIT_ZOOM_DELAY_MS = 100;
+// Committed layout cap in device pixels on the long side: enough for full
+// detail on any book illustration, while a huge scan can't balloon the layer
+// backing store and OOM the iOS WebContent process (cf. #5118).
+const MAX_COMMIT_RASTER_DIM = 4096;
 
 const ImageViewer: React.FC<ImageViewerProps> = ({
   src,
@@ -52,6 +59,17 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
   // one device pixel, so the zoom badge can report true resolution instead of a
   // fit-relative number that meant something different on every device (#5362).
   const [pixelPerfectScale, setPixelPerfectScale] = useState<number | null>(null);
+  // The image's fit-to-screen size in CSS px, and the zoom factor committed
+  // into its layout size. iOS WebKit rasterizes the image at its layout size
+  // and only stretches that raster for `transform: scale`, so zooming in
+  // showed a fit-to-screen resolution image no matter how much detail the
+  // source had (#5633); Chromium re-rasterizes at the transformed scale, which
+  // is why the same code was sharp on Android. Settled zoom is therefore
+  // committed into the layout size (fit × renderScale) so WebKit repaints the
+  // image with enough pixels, and the transform carries only the in-flight
+  // gesture (scale / renderScale).
+  const [fitSize, setFitSize] = useState<{ width: number; height: number } | null>(null);
+  const [renderScale, setRenderScale] = useState(1);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
   const [isWheelZooming, setIsWheelZooming] = useState(false);
@@ -66,27 +84,70 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
   const imageRef = useRef<HTMLImageElement>(null);
   const zoomLabelTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const wheelZoomEndTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Suppresses the transform transition for the render that commits a zoom
+  // into the layout size: that render swaps layout size and transform in the
+  // same frame, and animating the transform part would wobble the image.
+  const commitJustApplied = useRef(false);
 
   // Escape (desktop) and Android Back key → close the viewer.
   useKeyDownActions({ onCancel: onClose });
 
-  const measurePixelPerfectScale = useCallback(() => {
+  const measureFit = useCallback(() => {
     const img = imageRef.current;
-    // `offsetWidth` is the laid-out width, which ignores the zoom transform, so
-    // it stays the fit-to-screen size at any zoom level.
-    if (!img?.naturalWidth || !img.offsetWidth) return;
+    // Computed from the container rect instead of `offsetWidth` because once a
+    // zoom is committed the laid-out size is no longer the fit size. Replicates
+    // the pre-measure CSS fit (`width/height: auto` capped by `maxWidth/
+    // maxHeight: 100%`): shrink to the container, never upscale.
+    const containerRect = containerRef.current?.getBoundingClientRect();
+    if (!img?.naturalWidth || !img.naturalHeight) return;
+    if (!containerRect?.width || !containerRect.height) return;
+    const fitRatio = Math.min(
+      1,
+      containerRect.width / img.naturalWidth,
+      containerRect.height / img.naturalHeight,
+    );
+    const fitWidth = img.naturalWidth * fitRatio;
     const dpr = window.devicePixelRatio || 1;
-    setPixelPerfectScale(img.naturalWidth / (img.offsetWidth * dpr));
+    setFitSize({ width: fitWidth, height: img.naturalHeight * fitRatio });
+    setPixelPerfectScale(img.naturalWidth / (fitWidth * dpr));
   }, []);
 
   // A cached image can already be decoded before the load event would fire, and
   // rotating the device or resizing the window changes the fit size.
   useEffect(() => {
     setPixelPerfectScale(null);
-    measurePixelPerfectScale();
-    window.addEventListener('resize', measurePixelPerfectScale);
-    return () => window.removeEventListener('resize', measurePixelPerfectScale);
-  }, [src, measurePixelPerfectScale]);
+    setFitSize(null);
+    setRenderScale(1);
+    measureFit();
+    window.addEventListener('resize', measureFit);
+    return () => window.removeEventListener('resize', measureFit);
+  }, [src, measureFit]);
+
+  // Commit a settled zoom into the layout size (see the `fitSize` note). The
+  // commit is clamped to 1:1 with the image's resolution — beyond that the
+  // transform magnifies, as extra raster pixels would add memory but no
+  // detail — and to the raster budget for huge images.
+  useEffect(() => {
+    if (isDragging || isWheelZooming || !fitSize || !pixelPerfectScale) return;
+    const dpr = window.devicePixelRatio || 1;
+    const budgetScale = MAX_COMMIT_RASTER_DIM / (Math.max(fitSize.width, fitSize.height) * dpr);
+    const target = Math.min(
+      Math.max(scale, 1),
+      Math.max(1, Math.min(pixelPerfectScale, budgetScale)),
+    );
+    if (target === renderScale) return;
+    const timer = setTimeout(() => {
+      commitJustApplied.current = true;
+      setRenderScale(target);
+    }, COMMIT_ZOOM_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [scale, isDragging, isWheelZooming, fitSize, pixelPerfectScale, renderScale]);
+
+  // Clear after the committing render: the next transform-changing render
+  // recomputes the transition with the flag down, restoring the smoothing.
+  useEffect(() => {
+    commitJustApplied.current = false;
+  }, [renderScale]);
 
   // Percentage of the image's own resolution: 100% means one image pixel per
   // device pixel, so it reads the same on every device and matches what an
@@ -580,22 +641,34 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
           width={0}
           height={0}
           sizes='100vw'
-          onLoad={measurePixelPerfectScale}
+          onLoad={measureFit}
           onClick={handleImageClick}
           onMouseDown={handleImageMouseDown}
           onDoubleClick={onDoubleClick}
           style={{
-            width: 'auto',
-            height: 'auto',
-            maxWidth: '100%',
-            maxHeight: '100%',
-            transform: `scale(${scale}) translate(${position.x / scale}px, ${position.y / scale}px)`,
+            // Once measured, the layout size is explicit so committed zoom can
+            // grow it past the container (`flexShrink` keeps the centering
+            // flexbox from clamping it back to the container size).
+            ...(fitSize
+              ? {
+                  width: `${fitSize.width * renderScale}px`,
+                  height: `${fitSize.height * renderScale}px`,
+                  maxWidth: 'none',
+                  maxHeight: 'none',
+                }
+              : { width: 'auto', height: 'auto', maxWidth: '100%', maxHeight: '100%' }),
+            flexShrink: 0,
+            transform: `scale(${scale / renderScale}) translate(${(position.x * renderScale) / scale}px, ${(position.y * renderScale) / scale}px)`,
             // No transition during continuous gestures: the 0.05s ease made the
             // image lag behind a moving pointer, which flickered on desktop
             // (#4451). The same lag flickered a trackpad pinch (a rapid
             // ctrl+wheel stream) on macOS (#4742). Keep the smoothing only for
-            // discrete zoom (buttons, double-click, keyboard).
-            transition: isDragging || isWheelZooming ? 'none' : 'transform 0.05s ease-out',
+            // discrete zoom (buttons, double-click, keyboard) and suppress it
+            // for the render that commits a zoom into the layout size.
+            transition:
+              isDragging || isWheelZooming || commitJustApplied.current
+                ? 'none'
+                : 'transform 0.05s ease-out',
             // Promote to a GPU layer so transform changes don't repaint the
             // page (the `transform-gpu` class is overridden by this inline
             // transform, so its hint is lost).


### PR DESCRIPTION
## The problem

#5633: at the same zoom level the image viewer is noticeably blurrier on iOS than on Android. The image data path already delivers the full-resolution original; the loss is in the render path.

## Root cause

iOS WebKit rasterizes the `<img>` at its layout (fit-to-screen) size and only stretches that raster for `transform: scale`, so zooming in showed a fit-to-screen resolution image no matter how much detail the source had. Chromium re-rasterizes at the transformed scale, which is why the identical code was sharp on Android.

Proven with a 3-panel test page on the iOS Simulator (same JPEG from the reporter's EPUB, same displayed size):

| Panel | Rendering | Result |
| --- | --- | --- |
| A | fit layout + `transform: scale` + `willChange` (current code) | blurry |
| B | zoom committed into the layout size | sharp |
| C | `transform: scale` without layer promotion | blurry |

Panel C shows that dropping the GPU-layer hint is not a fix; the layout size itself must grow.

## The fix

Gestures keep riding on the transform (fast, composited). Once the zoom settles (drag/pinch/wheel stream ends plus 100 ms), the scale is committed into the image's layout `width`/`height` (fit size x renderScale) and the transform drops to `scale(scale / renderScale)`, forcing WebKit to repaint and re-decode the image with enough pixels.

- The committed layout is clamped to 1:1 with the image resolution (extra raster pixels add memory but no detail) and to a 4096 device px per-side raster budget so a huge scan cannot OOM the iOS WebContent process.
- The fit size is now computed from the container rect and natural size instead of `offsetWidth`, because once a zoom is committed the laid-out size is no longer the fit size.
- The translate is recomputed against the applied transform factor so the on-screen rect is identical across the commit (verified: 691.46 -> 691.5 px, no visible jump), and the transform transition is suppressed for exactly the committing render so nothing wobbles.

## Verification

- 3 new unit tests for the contract (commit on settle, transform-only while a pinch streams, raster budget cap), written failing first; full suite and lint green.
- Instrumented the live viewer in the web app: double-click zooms on the transform (`scale(1.48837)`, exactly pixel-perfect for a 1383x2048 image at dpr 2), then commits to a 691.5x1024 px layout (exactly the image's native size in CSS px) with `scale(1)` and no geometry jump.
- WebKit rendering delta verified on the iOS Simulator with the reproduction EPUB from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)