### PR TITLE
fix(ci): gate build_tauri_app on tauri paths and give webdriver its own timeout

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -267,8 +267,18 @@ jobs:
         working-directory: apps/readest-app
         run: pnpm test:lua
 
+  # The desktop app build + webdriver tests need a full Rust compile, by far
+  # the slowest PR check, so every step after checkout is skipped when neither
+  # the Rust backend, the vendored native packages, nor the tauri test harness
+  # changed. Frontend-only PRs are covered by the web build/test jobs. The job
+  # still runs and reports success so it stays green as a required check.
   build_tauri_app:
     runs-on: ubuntu-latest
+    # pull-requests: read lets dorny/paths-filter list a PR's changed files
+    # via the REST API (the top-level grant is contents: read only).
+    permissions:
+      contents: read
+      pull-requests: read
     env:
       SCCACHE_GHA_ENABLED: 'true'
       RUSTC_WRAPPER: sccache
@@ -277,10 +287,27 @@ jobs:
         with:
           submodules: 'true'
 
+      - name: detect tauri-related changes
+        id: changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+        with:
+          filters: |
+            tauri:
+              - 'apps/readest-app/src-tauri/**'
+              - 'apps/readest-app/src/**/*.tauri.test.ts'
+              - 'apps/readest-app/vitest.tauri.config.mts'
+              - 'apps/readest-app/vitest.tauri.setup.ts'
+              - 'apps/readest-app/scripts/test-tauri.sh'
+              - 'packages/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/pull-request.yml'
+
       - name: setup pnpm
+        if: steps.changes.outputs.tauri == 'true'
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
       - name: setup node
+        if: steps.changes.outputs.tauri == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24
@@ -289,6 +316,7 @@ jobs:
       # The tauri tests run `next dev`, whose Turbopack cache lives in
       # `.next/dev/cache` (a different path from the `next build` cache).
       - name: cache Turbopack dev cache
+        if: steps.changes.outputs.tauri == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: apps/readest-app/.next/dev/cache
@@ -297,14 +325,17 @@ jobs:
             turbo-dev-tauri-${{ runner.os }}-
 
       - name: install Dependencies
+        if: steps.changes.outputs.tauri == 'true'
         working-directory: apps/readest-app
         run: |
           pnpm install --frozen-lockfile --prefer-offline && pnpm setup-vendors
 
       - name: setup sccache
+        if: steps.changes.outputs.tauri == 'true'
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
       - name: install Rust toolchain
+        if: steps.changes.outputs.tauri == 'true'
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           toolchain: stable
@@ -320,6 +351,7 @@ jobs:
           cache: false
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: steps.changes.outputs.tauri == 'true'
         with:
           # cache-workspace-crates caches the path/workspace crates too: the
           # vendored tauri fork (packages/tauri, packages/tauri-plugins, wired
@@ -336,15 +368,18 @@ jobs:
           cache-workspace-crates: 'true'
 
       - name: Cache apt packages
+        if: steps.changes.outputs.tauri == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /var/cache/apt/archives
           key: apt-tauri-${{ runner.os }}
       - name: install system dependencies
+        if: steps.changes.outputs.tauri == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libfontconfig-dev libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libsoup-3.0-dev xvfb
 
       - name: run tauri tests
+        if: steps.changes.outputs.tauri == 'true'
         working-directory: apps/readest-app
         run: xvfb-run pnpm test:pr:tauri

--- a/apps/readest-app/scripts/test-tauri.sh
+++ b/apps/readest-app/scripts/test-tauri.sh
@@ -10,6 +10,11 @@ DEV_PORT=3000
 WEBDRIVER_PORT=4445
 POLL_INTERVAL=3
 TIMEOUT=300
+# `tauri dev` compiles the Rust backend before it launches the binary, and a
+# cold CI cache can spend 5+ minutes in that compile, so the WebDriver wait
+# needs its own budget rather than sharing (and losing) the dev-server one.
+# A crashed app still fails fast via the liveness check in the wait loop.
+WEBDRIVER_TIMEOUT=900
 
 cleanup() {
   if [[ -n "${TAURI_PID:-}" ]]; then
@@ -56,14 +61,14 @@ dotenv -e .env.tauri -- tauri dev --features webdriver --no-watch \
   --config '{"build":{"beforeDevCommand":""},"app":{"security":{"capabilities":["default","desktop-capability","webdriver-remote"]}}}' &
 TAURI_PID=$!
 
-echo "Waiting for WebDriver server on port $WEBDRIVER_PORT (timeout ${TIMEOUT}s)..."
+echo "Waiting for WebDriver server on port $WEBDRIVER_PORT (timeout ${WEBDRIVER_TIMEOUT}s)..."
 elapsed=0
 while ! curl -sf "http://127.0.0.1:${WEBDRIVER_PORT}/status" >/dev/null 2>&1; do
   if ! kill -0 "$TAURI_PID" 2>/dev/null; then
     echo "ERROR: Tauri app exited before WebDriver became ready."
     exit 1
   fi
-  if (( elapsed >= TIMEOUT )); then
+  if (( elapsed >= WEBDRIVER_TIMEOUT )); then
     echo "ERROR: Timed out waiting for WebDriver on port $WEBDRIVER_PORT."
     exit 1
   fi


### PR DESCRIPTION
## What happened on PR #5639

`build_tauri_app` failed with `ERROR: Timed out waiting for WebDriver on port 4445` six seconds after the app binary launched. The log shows why:

- 09:45:43 `Waiting for WebDriver server on port 4445 (timeout 300s)...` (wait starts when `tauri dev` is spawned)
- 09:50:38 `Finished dev profile in 4m 54s` (the Rust compile ran inside the wait window)
- 09:50:44 bogus timeout, with ~5s of the 300s budget left for the app to boot

`test-tauri.sh` started the WebDriver timer before `tauri dev`'s cargo build, so any cold-cache compile longer than ~5 minutes fails the job regardless of the change under test.

## Fixes

1. **test-tauri.sh**: the WebDriver wait gets its own 900s budget (`WEBDRIVER_TIMEOUT`), so the compile no longer eats it. A crashed app still fails fast through the existing liveness check.
2. **pull-request.yml**: every step of `build_tauri_app` after checkout is skipped when neither `src-tauri/`, the vendored native packages (`packages/`), the tauri test harness (`*.tauri.test.ts`, `vitest.tauri.*`, `scripts/test-tauri.sh`), the lockfile, nor this workflow changed. This mirrors how `rust_lint` and the koplugin steps are already gated with `dorny/paths-filter`, and the job still reports success so it stays green as a required check. Frontend-only PRs (like #5639) skip the slowest PR check entirely; their coverage lives in the web build/test jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)