### PR TITLE
fix(novel): retry transient fetch failures and backfill work metadata

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/import-novel-dialog.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/import-novel-dialog.test.tsx
@@ -43,6 +43,7 @@ const toc: NovelToc = {
   title: 'My Novel',
   author: 'Author X',
   coverUrl: null,
+  weak: { title: false, author: false },
   chapters: Array.from({ length: 6 }, (_, i) => ({
     title: `Chapter ${i + 1}`,
     url: `https://n.example.org/c/${i + 1}`,

--- a/apps/readest-app/src/__tests__/services/novel/chapter-list.test.ts
+++ b/apps/readest-app/src/__tests__/services/novel/chapter-list.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseChapterList } from '@/services/novel/chapterList';
+import { parseChapterList, parseWorkMetadata } from '@/services/novel/chapterList';
 
 const cnChapter = (n: number) => `<dd><a href="/book/1/${n}.html">第${n}章 陨落的天才</a></dd>`;
 
@@ -123,5 +123,78 @@ describe('parseChapterList', () => {
 </body></html>`;
     const toc = parseChapterList(page, 'https://www.example.com/book/2/')!;
     expect(toc.title).toBe('神墓');
+  });
+});
+
+/** A bare chapter-index page: no per-work metadata at all, and a site-wide
+ *  `meta[name=author]` naming the site operator rather than the writer. */
+const indexOnlyPage = `<!DOCTYPE html><html><head>
+<title>Navigate Work | Example Archive</title>
+<meta name="author" content="Example Archive Foundation"/>
+</head><body>
+<h2 class="heading">Chapter Index for <a href="/works/42">A Work</a></h2>
+<ol class="chapter index group">
+${Array.from({ length: 6 }, (_, i) => `<li><a href="/works/42/chapters/${100 + i}">${i + 1}. part ${i + 1}</a></li>`).join('\n')}
+</ol>
+</body></html>`;
+
+/** The same work's chapter page, which does carry the real metadata. */
+const workChapterPage = `<!DOCTYPE html><html><head>
+<title>A Work - Chapter 2 - Ann Author - Fandom [Example Archive]</title>
+<meta name="author" content="Example Archive Foundation"/>
+</head><body>
+<h2 class="title heading">A Work</h2>
+<h3 class="byline heading">Ann Author</h3>
+<div id="chapters"><h3 class="title">Chapter 2: part 2</h3></div>
+</body></html>`;
+
+describe('metadata confidence', () => {
+  it('marks title and author weak when only page-level guesses are available', () => {
+    const toc = parseChapterList(indexOnlyPage, 'https://archive.example.org/works/42/navigate')!;
+    expect(toc.weak).toEqual({ title: true, author: true });
+    expect(toc.title).toBe('Navigate Work');
+  });
+
+  it('does not mark fields weak when real work metadata is present', () => {
+    const toc = parseChapterList(cnPage, 'https://www.example.com/book/1/')!;
+    expect(toc.weak).toEqual({ title: false, author: false });
+  });
+});
+
+describe('parseWorkMetadata', () => {
+  it('reads the work title and byline from a chapter page', () => {
+    const meta = parseWorkMetadata(
+      workChapterPage,
+      'https://archive.example.org/works/42/chapters/101',
+    );
+    expect(meta).toEqual({ title: 'A Work', author: 'Ann Author' });
+  });
+
+  it('prefers og metadata over headings', () => {
+    const page = workChapterPage.replace(
+      '<h2 class="title heading">A Work</h2>',
+      '<meta property="og:novel:book_name" content="Canonical Title"/><h2 class="title heading">A Work</h2>',
+    );
+    expect(parseWorkMetadata(page, 'https://archive.example.org/x').title).toBe('Canonical Title');
+  });
+
+  it('ignores a heading that is just the chapter title', () => {
+    const page = `<!DOCTYPE html><html><head><title>Chapter 7 - My Novel</title></head><body>
+<h1 class="title">Chapter 7</h1>
+</body></html>`;
+    expect(parseWorkMetadata(page, 'https://novels.example.org/x').title).toBeNull();
+  });
+
+  it('strips a leading "by" from the byline', () => {
+    const page = workChapterPage.replace(
+      '<h3 class="byline heading">Ann Author</h3>',
+      '<h3 class="byline heading">by Ann Author</h3>',
+    );
+    expect(parseWorkMetadata(page, 'https://archive.example.org/x').author).toBe('Ann Author');
+  });
+
+  it('never reports the site-wide author meta as the work author', () => {
+    const page = workChapterPage.replace('<h3 class="byline heading">Ann Author</h3>', '');
+    expect(parseWorkMetadata(page, 'https://archive.example.org/x').author).toBeNull();
   });
 });

--- a/apps/readest-app/src/__tests__/services/novel/novel-import.test.ts
+++ b/apps/readest-app/src/__tests__/services/novel/novel-import.test.ts
@@ -55,6 +55,7 @@ const toc = (over: Partial<NovelToc> = {}): NovelToc => ({
   title: 'My Novel',
   author: 'Author X',
   coverUrl: null,
+  weak: { title: false, author: false },
   chapters: Array.from({ length: 6 }, (_, i) => ({
     title: `Chapter ${i + 1}: Part ${i + 1}`,
     url: `${BASE}/novel/7/${i + 1}`,
@@ -175,5 +176,178 @@ describe('downloadNovel', () => {
     });
     const files = await unzipEpub(book.file);
     expect(files.has('OEBPS/cover.svg')).toBe(true);
+  });
+});
+
+describe('chapter-page metadata fallback', () => {
+  // A chapter index that names the page, not the work, and credits the site
+  // operator instead of the writer.
+  const bareTocPage = `<!DOCTYPE html><html><head>
+<title>Navigate Work | Example Archive</title>
+<meta name="author" content="Example Archive Foundation"/>
+</head><body><ol>
+${Array.from({ length: 6 }, (_, i) => `<li><a href="/novel/7/${i + 1}">${i + 1}. part ${i + 1}</a></li>`).join('\n')}
+</ol></body></html>`;
+
+  const richChapterPage = (n: number) => `<!DOCTYPE html><html><head>
+<title>A Work - Chapter ${n} - Ann Author - Fandom [Example Archive]</title>
+<meta name="author" content="Example Archive Foundation"/>
+</head><body>
+<h2 class="title heading">A Work</h2>
+<h3 class="byline heading">Ann Author</h3>
+<div id="content">
+${Array.from({ length: 10 }, (_, i) => `<p>Chapter ${n} paragraph ${i} with plenty of narrative text to satisfy extraction quality floors.</p>`).join('\n')}
+</div>
+</body></html>`;
+
+  const fetchPage = async (url: string) => {
+    if (url === TOC_URL) return { html: bareTocPage, finalUrl: url };
+    const m = url.match(/\/novel\/7\/([0-9]+)$/);
+    if (m) return { html: richChapterPage(parseInt(m[1]!, 10)), finalUrl: url };
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+
+  it('fills weak title and author from the first chapter page', async () => {
+    const toc = await fetchNovelToc(TOC_URL, { fetchPage });
+    expect(toc.title).toBe('A Work');
+    expect(toc.author).toBe('Ann Author');
+    expect(toc.chapters).toHaveLength(6);
+  });
+
+  it('keeps the chapter-index metadata when the page already knows the work', async () => {
+    const strong = bareTocPage.replace(
+      '<title>Navigate Work | Example Archive</title>',
+      '<title>Navigate Work | Example Archive</title><meta property="og:novel:book_name" content="Indexed Title"/><meta property="og:novel:author" content="Indexed Author"/>',
+    );
+    const toc = await fetchNovelToc(TOC_URL, {
+      fetchPage: async (url: string) =>
+        url === TOC_URL ? { html: strong, finalUrl: url } : fetchPage(url),
+    });
+    expect(toc.title).toBe('Indexed Title');
+    expect(toc.author).toBe('Indexed Author');
+  });
+
+  it('does not fetch a chapter when the index metadata is strong', async () => {
+    const strong = bareTocPage.replace(
+      '<meta name="author" content="Example Archive Foundation"/>',
+      '<meta property="og:novel:book_name" content="Indexed Title"/><meta property="og:novel:author" content="Indexed Author"/>',
+    );
+    const seen: string[] = [];
+    await fetchNovelToc(TOC_URL, {
+      fetchPage: async (url: string) => {
+        seen.push(url);
+        return url === TOC_URL ? { html: strong, finalUrl: url } : fetchPage(url);
+      },
+    });
+    expect(seen).toEqual([TOC_URL]);
+  });
+
+  it('keeps the weak metadata when the chapter page cannot be fetched', async () => {
+    const toc = await fetchNovelToc(TOC_URL, {
+      fetchPage: async (url: string) => {
+        if (url === TOC_URL) return { html: bareTocPage, finalUrl: url };
+        throw new ConversionError('nope', 'fetch_failed');
+      },
+    });
+    expect(toc.title).toBe('Navigate Work');
+    expect(toc.chapters).toHaveLength(6);
+  });
+});
+
+describe('transient upstream failures', () => {
+  // What a Cloudflare-fronted origin (AO3 and friends) returns while it is
+  // briefly unreachable — the URL is fine, the site just isn't answering yet.
+  const transient = () =>
+    new ConversionError('The site is temporarily unavailable (HTTP 525).', 'fetch_transient');
+
+  // Counts attempts at the flapping URL only: an unrelated backfill fetch of
+  // the first chapter must not be mistaken for a retry.
+  const flaky = (failures: number, failUrl: string = TOC_URL) => {
+    const calls = { count: 0 };
+    const inner = makeFetchPage();
+    const fetchPage = async (url: string) => {
+      if (url === failUrl) {
+        calls.count += 1;
+        if (calls.count <= failures) throw transient();
+      }
+      return inner(url);
+    };
+    return { fetchPage, calls };
+  };
+
+  it('retries the chapter-list fetch until the origin answers', async () => {
+    vi.useFakeTimers();
+    try {
+      const { fetchPage, calls } = flaky(2);
+      const pending = fetchNovelToc(TOC_URL, { fetchPage });
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(pending).resolves.toMatchObject({ title: 'My Novel' });
+      expect(calls.count).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('surfaces the transient error once the retry budget is spent', async () => {
+    vi.useFakeTimers();
+    try {
+      const { fetchPage, calls } = flaky(99);
+      const pending = fetchNovelToc(TOC_URL, { fetchPage });
+      const assertion = expect(pending).rejects.toThrow(/temporarily unavailable/);
+      await vi.advanceTimersByTimeAsync(30_000);
+      await assertion;
+      expect(calls.count).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('treats a hung origin as transient and retries it', async () => {
+    vi.useFakeTimers();
+    try {
+      let calls = 0;
+      const inner = makeFetchPage();
+      // A struggling origin usually hangs rather than answering 52x, so the
+      // per-request deadline has to be retryable too.
+      const fetchPage = async (url: string) => {
+        if (url !== TOC_URL) return inner(url);
+        calls += 1;
+        if (calls <= 2) return new Promise<never>(() => {});
+        return inner(url);
+      };
+      const pending = fetchNovelToc(TOC_URL, { fetchPage });
+      await vi.advanceTimersByTimeAsync(120_000);
+      await expect(pending).resolves.toMatchObject({ title: 'My Novel' });
+      expect(calls).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports a hung origin as a timeout, not as a cancellation', async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = fetchNovelToc(TOC_URL, { fetchPage: () => new Promise<never>(() => {}) });
+      const assertion = expect(pending).rejects.toThrow(/took too long/);
+      await vi.advanceTimersByTimeAsync(120_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries a flapping chapter instead of writing a placeholder', async () => {
+    vi.useFakeTimers();
+    try {
+      const { fetchPage } = flaky(2, `${BASE}/novel/7/3`);
+      const pending = downloadNovel(toc(), TOC_URL, { fetchPage });
+      await vi.advanceTimersByTimeAsync(30_000);
+      const book = await pending;
+      expect(book.failures).toBe(0);
+      const files = await unzipEpub(book.file);
+      expect(files.get('OEBPS/chapter3.xhtml')).not.toContain('could not be downloaded');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/readest-app/src/services/novel/chapterList.ts
+++ b/apps/readest-app/src/services/novel/chapterList.ts
@@ -20,6 +20,17 @@ export interface NovelToc {
   author: string;
   coverUrl: string | null;
   chapters: NovelChapterLink[];
+  /**
+   * Fields that came from a page-level guess (the `<title>` tag, a site-wide
+   * `meta[name=author]`) rather than real per-work metadata. A chapter-index
+   * page is often just a list of links, so a chapter page may know better.
+   */
+  weak: { title: boolean; author: boolean };
+}
+
+export interface WorkMetadata {
+  title: string | null;
+  author: string | null;
 }
 
 /** Fewer links than this is not a chapter list. */
@@ -157,25 +168,30 @@ const cleanTitleTag = (raw: string): string => {
   return first.replace(/(最新章节列表|最新章节|章节列表|章节目录|全文阅读|无弹窗)+$/, '').trim();
 };
 
+/** Meta tags that name the work itself, as opposed to the page or the site. */
+const WORK_TITLE_META = [
+  'meta[property="og:novel:book_name"]',
+  'meta[property="og:title"]',
+  'meta[name="twitter:title"]',
+];
+const WORK_AUTHOR_META = ['meta[property="og:novel:author"]', 'meta[property="books:author"]'];
+
 const extractMetadata = (
   doc: Document,
   pageUrl: string,
-): { title: string; author: string; coverUrl: string | null } => {
+): { title: string; author: string; coverUrl: string | null; weak: NovelToc['weak'] } => {
+  const workTitle = metaContent(doc, WORK_TITLE_META);
   const title =
-    metaContent(doc, [
-      'meta[property="og:novel:book_name"]',
-      'meta[property="og:title"]',
-      'meta[name="twitter:title"]',
-    ]) ||
+    workTitle ||
     cleanTitleTag(doc.querySelector('title')?.textContent || '') ||
     new URL(pageUrl).hostname;
 
+  // `meta[name=author]` is routinely set site-wide (to the operator, not the
+  // writer), so it counts as a guess rather than work metadata.
+  const workAuthor = metaContent(doc, WORK_AUTHOR_META);
   const author =
-    metaContent(doc, [
-      'meta[property="og:novel:author"]',
-      'meta[property="books:author"]',
-      'meta[name="author"]',
-    ]) ||
+    workAuthor ||
+    metaContent(doc, ['meta[name="author"]']) ||
     doc.body?.textContent?.match(/作者[:：]\s*([^\s，,。；;、]{1,32})/)?.[1] ||
     '';
 
@@ -191,8 +207,46 @@ const extractMetadata = (
       /* unparseable cover URL — cover is optional */
     }
   }
-  return { title, author, coverUrl };
+  return { title, author, coverUrl, weak: { title: !workTitle, author: !workAuthor } };
 };
+
+/** Headings a chapter page uses for the work title and the writer's byline. */
+const WORK_TITLE_HEADINGS = ['h1[class*="title"]', 'h2[class*="title"]'];
+const WORK_AUTHOR_HEADINGS = ['[class*="byline"]', '[rel="author"]', '[class*="author"]'];
+
+const headingText = (doc: Document, selectors: string[]): string | null => {
+  for (const selector of selectors) {
+    const text = doc.querySelector(selector)?.textContent?.replace(/\s+/g, ' ').trim();
+    // A heading naming the chapter ("Chapter 7") describes this page, not the
+    // work — the same test that recognizes chapter links recognizes it here.
+    if (text && !isChapterText(text)) return text;
+  }
+  return null;
+};
+
+/**
+ * Work title and author as advertised by a single chapter page. Chapter pages
+ * usually carry the real per-work metadata even when the chapter-index page is
+ * nothing but a list of links, so this backfills what the index couldn't say.
+ * Returns `null` per field when the page offers no better answer than the
+ * index already had — notably the site-wide `meta[name=author]`, which is
+ * deliberately not consulted here.
+ */
+export function parseWorkMetadata(html: string, _pageUrl?: string): WorkMetadata {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const titleTag = cleanTitleTag(doc.querySelector('title')?.textContent || '');
+  return {
+    title:
+      metaContent(doc, WORK_TITLE_META) ||
+      headingText(doc, WORK_TITLE_HEADINGS) ||
+      (titleTag && !isChapterText(titleTag) ? titleTag : null) ||
+      null,
+    author:
+      metaContent(doc, WORK_AUTHOR_META) ||
+      headingText(doc, WORK_AUTHOR_HEADINGS)?.replace(/^by\s+/i, '') ||
+      null,
+  };
+}
 
 /**
  * Parse a web-novel TOC page into title/author/cover metadata plus an ordered

--- a/apps/readest-app/src/services/novel/novelImport.ts
+++ b/apps/readest-app/src/services/novel/novelImport.ts
@@ -10,11 +10,15 @@ import {
   stableIdentifier,
   stripTags,
 } from '@/services/send/conversion/convertToEpub';
-import { isLikelyBotBlock, pageNavigateHeaders } from '@/services/send/conversion/httpHeaders';
+import {
+  isLikelyBotBlock,
+  isTransientUpstreamError,
+  pageNavigateHeaders,
+} from '@/services/send/conversion/httpHeaders';
 import { ConversionError } from '@/services/send/conversion/types';
 import type { ConvertedBook, EpubChapter, EpubImage } from '@/services/send/conversion/types';
-import { parseChapterList } from './chapterList';
-import type { NovelToc } from './chapterList';
+import { parseChapterList, parseWorkMetadata } from './chapterList';
+import type { NovelChapterLink, NovelToc, WorkMetadata } from './chapterList';
 
 /** Hard cap — a runaway TOC heuristic must not schedule tens of thousands of
  *  requests. Real novels top out around this size. */
@@ -59,6 +63,63 @@ export function isNovelImportCancelled(err: unknown): boolean {
   return err instanceof DOMException && err.name === 'AbortError';
 }
 
+const isTransientFetchError = (err: unknown): boolean =>
+  err instanceof ConversionError && err.code === 'fetch_transient';
+
+/** Extra attempts for an origin that is briefly unreachable, and the base
+ *  delay between them (linear backoff: 1s, then 2s). */
+const TRANSIENT_RETRIES = 2;
+const TRANSIENT_BACKOFF_MS = 1000;
+
+/**
+ * Wrap a fetcher with the per-request deadline and a backoff retry, so a
+ * briefly-unreachable origin doesn't fail the import outright. A site fronted
+ * by Cloudflare can 52x — or simply hang — on most requests for minutes at a
+ * time while staying perfectly readable in between, which otherwise leaves the
+ * user hammering the button by hand.
+ */
+const withTransientRetry =
+  (fetchPage: FetchPage): FetchPage =>
+  async (url, signal) => {
+    for (let attempt = 0; ; attempt++) {
+      const deadline = new AbortController();
+      const onAbort = () => deadline.abort();
+      signal?.addEventListener('abort', onAbort, { once: true });
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let failure: unknown;
+      try {
+        const page = fetchPage(url, deadline.signal);
+        // Race rather than trusting the fetcher to observe the abort, so a
+        // hung origin can never wedge the import. The deadline expiring is a
+        // retryable failure, not the user cancelling.
+        page.catch(() => {});
+        return await Promise.race([
+          page,
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => {
+              deadline.abort();
+              reject(
+                new ConversionError(
+                  'The site took too long to respond. Try again in a moment.',
+                  'fetch_transient',
+                ),
+              );
+            }, PAGE_FETCH_TIMEOUT_MS);
+          }),
+        ]);
+      } catch (err) {
+        failure = err;
+      } finally {
+        clearTimeout(timer);
+        signal?.removeEventListener('abort', onAbort);
+      }
+      if (attempt >= TRANSIENT_RETRIES || !isTransientFetchError(failure)) throw failure;
+      if (signal?.aborted) throw abortError();
+      await new Promise((resolve) => setTimeout(resolve, TRANSIENT_BACKOFF_MS * (attempt + 1)));
+      if (signal?.aborted) throw abortError();
+    }
+  };
+
 /**
  * Fetch a page over the Tauri HTTP client with browser-shaped headers.
  * Novel-site chapter pages are server-rendered, so plain HTTP is enough —
@@ -67,29 +128,26 @@ export function isNovelImportCancelled(err: unknown): boolean {
  */
 const defaultFetchPage: FetchPage = async (url, signal) => {
   const { fetch: tauriFetch } = await import('@tauri-apps/plugin-http');
-  const ac = new AbortController();
-  const timer = setTimeout(() => ac.abort(), PAGE_FETCH_TIMEOUT_MS);
-  const onAbort = () => ac.abort();
-  signal?.addEventListener('abort', onAbort, { once: true });
-  try {
-    const res = await tauriFetch(url, {
-      headers: pageNavigateHeaders(),
-      signal: ac.signal,
-      redirect: 'follow',
-    });
-    if (!res.ok) {
+  const res = await tauriFetch(url, {
+    headers: pageNavigateHeaders(),
+    signal,
+    redirect: 'follow',
+  });
+  if (!res.ok) {
+    if (isTransientUpstreamError(res.status)) {
       throw new ConversionError(
-        isLikelyBotBlock(res.status)
-          ? `The site blocked the request (HTTP ${res.status}). Try again later.`
-          : `Could not fetch the page (HTTP ${res.status}).`,
-        'fetch_failed',
+        `The site is temporarily unavailable (HTTP ${res.status}). Try again in a moment.`,
+        'fetch_transient',
       );
     }
-    return { html: await res.text(), finalUrl: res.url || url };
-  } finally {
-    clearTimeout(timer);
-    signal?.removeEventListener('abort', onAbort);
+    throw new ConversionError(
+      isLikelyBotBlock(res.status)
+        ? `The site blocked the request (HTTP ${res.status}). Try again later.`
+        : `Could not fetch the page (HTTP ${res.status}).`,
+      'fetch_failed',
+    );
   }
+  return { html: await res.text(), finalUrl: res.url || url };
 };
 
 const defaultFetchCover: FetchCover = (url, referer) =>
@@ -105,7 +163,7 @@ export async function fetchNovelToc(
   url: string,
   options: FetchNovelTocOptions = {},
 ): Promise<NovelToc> {
-  const fetchPage = options.fetchPage ?? defaultFetchPage;
+  const fetchPage = withTransientRetry(options.fetchPage ?? defaultFetchPage);
   const { html, finalUrl } = await fetchPage(url, options.signal);
   const toc = parseChapterList(html, finalUrl);
   if (!toc) {
@@ -114,7 +172,40 @@ export async function fetchNovelToc(
       'parse_failed',
     );
   }
-  return { ...toc, chapters: toc.chapters.slice(0, MAX_NOVEL_CHAPTERS) };
+  const chapters = toc.chapters.slice(0, MAX_NOVEL_CHAPTERS);
+  return {
+    ...toc,
+    ...(await backfillMetadata(toc, chapters, fetchPage, options.signal)),
+    chapters,
+  };
+}
+
+/**
+ * A chapter-index page is often just a list of links, with the work's real
+ * title and author only on the chapter pages. When the index could offer no
+ * more than a page-level guess, ask the first chapter instead. Best-effort:
+ * the guess stands if that fetch or parse comes up empty.
+ */
+async function backfillMetadata(
+  toc: NovelToc,
+  chapters: NovelChapterLink[],
+  fetchPage: FetchPage,
+  signal?: AbortSignal,
+): Promise<Partial<NovelToc>> {
+  const first = chapters[0];
+  if (!first || (!toc.weak.title && !toc.weak.author)) return {};
+  let found: WorkMetadata;
+  try {
+    const { html } = await fetchPage(first.url, signal);
+    found = parseWorkMetadata(html);
+  } catch (err) {
+    if (isNovelImportCancelled(err) || signal?.aborted) throw abortError();
+    return {};
+  }
+  return {
+    ...(toc.weak.title && found.title ? { title: found.title } : {}),
+    ...(toc.weak.author && found.author ? { author: found.author } : {}),
+  };
 }
 
 const escapeHtml = (s: string): string =>
@@ -189,7 +280,7 @@ export async function downloadNovel(
   sourceUrl: string,
   options: NovelDownloadOptions = {},
 ): Promise<NovelBook> {
-  const fetchPage = options.fetchPage ?? defaultFetchPage;
+  const fetchPage = withTransientRetry(options.fetchPage ?? defaultFetchPage);
   const fetchCover = options.fetchCover ?? defaultFetchCover;
   const translate = options.translate ?? ((key: string) => key);
   const { onProgress, signal } = options;
@@ -207,6 +298,8 @@ export async function downloadNovel(
     } catch (err) {
       // One retry on transient network errors; user cancellation propagates.
       if (isNovelImportCancelled(err) || signal?.aborted) throw abortError();
+      // A 52x has already been retried with backoff — don't double up.
+      if (isTransientFetchError(err)) throw err;
       return await fetchPage(url, signal);
     }
   };

--- a/apps/readest-app/src/services/send/conversion/httpHeaders.ts
+++ b/apps/readest-app/src/services/send/conversion/httpHeaders.ts
@@ -62,3 +62,13 @@ export function imageFetchHeaders(referer: string | null): Record<string, string
 export function isLikelyBotBlock(status: number): boolean {
   return status === 401 || status === 403 || status === 429 || status === 503;
 }
+
+/**
+ * True if the status says the origin behind a CDN was briefly unreachable
+ * rather than the request being wrong — Cloudflare's 52x family (525 is an
+ * edge-to-origin TLS handshake failure) plus the standard gateway errors.
+ * These are worth retrying; a 404 or a bot block is not.
+ */
+export function isTransientUpstreamError(status: number): boolean {
+  return status === 502 || status === 504 || (status >= 520 && status <= 527);
+}

--- a/apps/readest-app/src/services/send/conversion/types.ts
+++ b/apps/readest-app/src/services/send/conversion/types.ts
@@ -60,6 +60,7 @@ export class ConversionError extends Error {
       | 'empty_input'
       | 'parse_failed'
       | 'fetch_failed'
+      | 'fetch_transient'
       | 'login_wall',
   ) {
     super(message);


### PR DESCRIPTION
## Summary

Closes #5612.

Two problems hit while importing a web novel from a CDN-fronted site.

**The import failed on the first hiccup.** An origin that is briefly unreachable answers with a 52x status, or simply hangs, and every one of those aborted the import outright even though the site stayed perfectly readable in between. Fetching a chapter list on a Xiaomi 13 took five manual taps on "Fetch Chapters" before one got through.

**The book got the wrong title and author.** A chapter-index page is often nothing but a list of links, carrying no metadata for the work itself. The title fell back to the page `<title>` (which names the page's function, not the work) and the author to a site-wide `meta[name=author]` (the site operator, not the writer).

## Transient fetch failures

- `isTransientUpstreamError()` classifies the statuses that mean "the origin behind the CDN was briefly unreachable" rather than "the request was wrong": the 520-527 family plus 502 and 504. A 404 or a bot block stays non-retryable. 503 is left to the existing `isLikelyBotBlock()`, which already claims it.
- New `fetch_transient` code on `ConversionError`, so the retry path is explicit instead of matching on message text.
- `withTransientRetry()` wraps the page fetcher with one coherent policy: the per-request deadline plus 2 retries at 1s and 2s. It applies in both `fetchNovelToc()` and `downloadNovel()`, so the chapter-list fetch now gets retries it never had. The existing single retry in `fetchChapter()` skips transient errors so the two do not compound.

### A hang is the more common failure

Verifying the first cut on device showed the retry never firing: the run failed at 15s with "Request canceled", which is the timeout path, not a 52x. Against a struggling origin a hang turns out to be more common than a clean error status, and that case was both unretryable and mislabeled as a user cancellation.

So the wrapper races the fetch against its own deadline instead of trusting the fetcher to observe the abort. A hung origin can no longer wedge the import, and it now reports "The site took too long to respond". This also lifts the deadline plumbing out of `defaultFetchPage`, which gets simpler as a result.

## Chapter-page metadata fallback

`NovelToc` now reports which fields were a page-level guess. Only `og:novel:*`, `og:title`, `twitter:title` and `books:author` count as real work metadata; `meta[name=author]` is demoted to a guess. That demotion is the crux, because the wrong author was *present* and confident, so a plain "is it missing?" check would never have fired.

`parseWorkMetadata()` reads a chapter page for the work title and byline: og tags first, then heading conventions (`h1/h2[class*=title]`, `[class*=byline]`, `[rel=author]`, stripping a leading "by"), then the cleaned `<title>`. Two guards keep it honest:

- any candidate matching the existing `isChapterText()` test is rejected, so a page whose only heading is "Chapter 7" returns `null` rather than making the chapter title the book title;
- `meta[name=author]` is deliberately not consulted, so the fallback cannot re-supply the same bad value.

`fetchNovelToc()` fetches the first chapter only when a field is weak, and fills only those fields. Best-effort: if that fetch or parse comes up empty the original guess stands, so a flaky origin cannot turn a working import into a failed one. It reuses the retry wrapper, and cancellation still propagates.

Trade-off worth flagging: because `meta[name=author]` is now treated as a guess, a site that sets it per-work incurs one extra chapter fetch on the preview. The value stays correct either way, since the fallback only overrides when the chapter page has a better signal.

## Testing

- 16 new tests: 5 covering transient failures (retry until the origin answers, the error surfacing once the budget is spent, a hung origin retried, a timeout reported as a timeout rather than a cancellation, a flapping chapter resolving instead of writing a placeholder), 7 covering metadata confidence and `parseWorkMetadata()`, and 4 covering the fallback wiring in `fetchNovelToc()`.
- Full suite: 9034 passed, 16 skipped. `pnpm lint` and `pnpm format:check` clean.
- Validated the parser against real saved page HTML: the index page's metadata is flagged weak on both fields, and the chapter page resolves the correct title and author.
- Verified the retry on a Xiaomi 13 against a live flapping origin: the fetch that previously needed five taps now completes on one, in 3s, and the chapter download ran to 8/8.

Two caveats on device coverage. The successful device fetch landed on its first attempt, so a retry firing was not directly observed on hardware; that behavior is covered by the unit tests. And the metadata fallback has not yet been exercised on device, because the phone dropped off USB before the final build could install. The parser is validated against the real page HTML, but an end-to-end import with the corrected title and author is still pending.

## Not addressed here

**Chapters can be silently truncated.** A body cut short mid-stream still arrives as a successful HTTP 200, so nothing rejects it and extraction produces a stub chapter while `failures` still reports 0. A contributing factor: `CHAPTER_QUALITY_FLOOR` is checked against the intermediate extracted content, but the `<h1>` prefix, media stripping and `sanitizeHtml` all run afterwards, so a chapter can clear the 100-char floor and still land in the EPUB at a few dozen characters. Worth a follow-up that rejects an incomplete page at fetch time and re-checks the floor on the final chapter HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
