### PR TITLE
fix(sanitizer): render Persian/Arabic half-space by converting misused RLM to ZWNJ

### DIFF
--- a/apps/readest-app/src/__tests__/services/transformers/transformers.test.ts
+++ b/apps/readest-app/src/__tests__/services/transformers/transformers.test.ts
@@ -723,6 +723,46 @@ describe('sanitizerTransformer', () => {
     expect(result).toMatch(/^<\?xml version="1\.0" encoding="utf-8"\?>/);
     expect(result).toContain('<!DOCTYPE html');
   });
+
+  const sanitize = async (text: string) => {
+    const html = `<html><head></head><body><p>${text}</p></body></html>`;
+    return sanitizerTransformer.transform(makeCtx({ content: html }));
+  };
+
+  test('converts RLM misused as half-space between Arabic letters to ZWNJ', async () => {
+    // "mi-ravam" written with RLM (U+200F) instead of ZWNJ (U+200C)
+    const result = await sanitize('می\u200Fروم');
+    expect(result).toContain('می\u200Cروم');
+    expect(result).not.toContain('\u200F');
+  });
+
+  test('converts a run of consecutive RLMs between Arabic letters, preserving length', async () => {
+    const result = await sanitize('ا\u200F\u200Fب');
+    expect(result).toContain('ا\u200C\u200Cب');
+    expect(result).not.toContain('\u200F');
+  });
+
+  test('converts RLM after an Arabic letter with a diacritic', async () => {
+    // letter + kasra (U+0650) + RLM + letter
+    const result = await sanitize('بِ\u200Fب');
+    expect(result).toContain('بِ\u200Cب');
+  });
+
+  test('leaves RLM between Arabic-script digits untouched', async () => {
+    // RLM between digits is a live bidi hint that keeps the digit runs
+    // separate; swapping it for ZWNJ would flip their visual order.
+    const persianDigits = await sanitize('۱\u200F۲');
+    expect(persianDigits).toContain('۱\u200F۲');
+    const arabicDigits = await sanitize('١\u200F٢');
+    expect(arabicDigits).toContain('١\u200F٢');
+  });
+
+  test('leaves RLM next to Latin text or at a text boundary untouched', async () => {
+    const latin = await sanitize('abc\u200Fا');
+    expect(latin).toContain('abc\u200Fا');
+    const boundary = await sanitize('\u200Fاب');
+    expect(boundary).toContain('\u200Fاب');
+  });
 });
 
 // =============================================================================

--- a/apps/readest-app/src/services/transformers/sanitizer.ts
+++ b/apps/readest-app/src/services/transformers/sanitizer.ts
@@ -6,6 +6,21 @@ const DOCTYPE_XHTML11 = `<!DOCTYPE html PUBLIC
 "-//W3C//DTD XHTML 1.1//EN"
 "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">`;
 
+// Legacy Persian/Arabic ebooks misuse the RLM (U+200F) as a half-space between
+// the parts of a compound word (e.g. mi-ravam, ketab-ha). RLM is an invisible
+// bidi control that does NOT break the cursive join, so those words render
+// wrong. The correct half-space is the ZWNJ (U+200C). Swap a run of RLMs for
+// ZWNJs ONLY when it sits between two Arabic-script non-digit characters: an
+// RLM next to a digit is a live bidi hint (it keeps adjacent digit runs
+// visually separate), and one next to Latin text or a boundary can be a
+// genuine direction mark, so both are left intact. The character classes are
+// the Arabic blocks minus the Arabic-Indic (U+0660-0669) and extended
+// (U+06F0-06F9) digits, ending at U+FEFC to exclude the BOM. Both marks are
+// single UTF-16 code units replaced one-for-one, so the text length is
+// unchanged and CFIs / annotations stay valid.
+const RLM_HALF_SPACE_REGEX =
+  /([\u0600-\u065F\u066A-\u06EF\u06FA-\u06FF\uFB50-\uFDFF\uFE70-\uFEFC])(\u200F+)(?=[\u0600-\u065F\u066A-\u06EF\u06FA-\u06FF\uFB50-\uFDFF\uFE70-\uFEFC])/gu;
+
 export const sanitizerTransformer: Transformer = {
   name: 'sanitizer',
 
@@ -59,23 +74,10 @@ export const sanitizerTransformer: Transformer = {
       .replaceAll('&#8206;', '\u200E')
       .replaceAll('&#x200f;', '\u200F')
       .replaceAll('&#8207;', '\u200F');
-    // Legacy Persian/Arabic ebooks misuse the RLM (U+200F) as a half-space
-    // between the parts of a compound word (e.g. mi-ravam, ketab-ha). RLM is an
-    // invisible bidi control that does NOT break the cursive join, so those
-    // words render wrong. The correct half-space is the ZWNJ (U+200C). Swap
-    // RLM -> ZWNJ ONLY when it sits between two Arabic-script letters, so any
-    // RLM used as a genuine direction hint (next to digits/Latin, or at a
-    // boundary) is left intact. Both marks are single UTF-16 code units, so the
-    // text length is unchanged and CFIs / annotations stay valid.
-    const halfSpace = new RegExp(
-      '([\u0600-\u06FF\uFB50-\uFDFF\uFE70-\uFEFF])\u200F(?=[\u0600-\u06FF\uFB50-\uFDFF\uFE70-\uFEFF])',
-      'gu',
+    serialized = serialized.replace(
+      RLM_HALF_SPACE_REGEX,
+      (_match, letter: string, rlms: string) => letter + '\u200C'.repeat(rlms.length),
     );
-    let prevSerialized;
-    do {
-      prevSerialized = serialized;
-      serialized = serialized.replace(halfSpace, '$1\u200C');
-    } while (serialized !== prevSerialized);
     serialized = '<?xml version="1.0" encoding="utf-8"?>' + DOCTYPE_XHTML11 + serialized;
     serialized = serialized.replace(/(<head[^>]*>)/i, '\n$1');
     serialized = serialized.replace(/(<\/body>)(<\/html>)/i, '$1\n$2');

--- a/apps/readest-app/src/services/transformers/sanitizer.ts
+++ b/apps/readest-app/src/services/transformers/sanitizer.ts
@@ -59,6 +59,23 @@ export const sanitizerTransformer: Transformer = {
       .replaceAll('&#8206;', '\u200E')
       .replaceAll('&#x200f;', '\u200F')
       .replaceAll('&#8207;', '\u200F');
+    // Legacy Persian/Arabic ebooks misuse the RLM (U+200F) as a half-space
+    // between the parts of a compound word (e.g. mi-ravam, ketab-ha). RLM is an
+    // invisible bidi control that does NOT break the cursive join, so those
+    // words render wrong. The correct half-space is the ZWNJ (U+200C). Swap
+    // RLM -> ZWNJ ONLY when it sits between two Arabic-script letters, so any
+    // RLM used as a genuine direction hint (next to digits/Latin, or at a
+    // boundary) is left intact. Both marks are single UTF-16 code units, so the
+    // text length is unchanged and CFIs / annotations stay valid.
+    const halfSpace = new RegExp(
+      '([\u0600-\u06FF\uFB50-\uFDFF\uFE70-\uFEFF])\u200F(?=[\u0600-\u06FF\uFB50-\uFDFF\uFE70-\uFEFF])',
+      'gu',
+    );
+    let prevSerialized;
+    do {
+      prevSerialized = serialized;
+      serialized = serialized.replace(halfSpace, '$1\u200C');
+    } while (serialized !== prevSerialized);
     serialized = '<?xml version="1.0" encoding="utf-8"?>' + DOCTYPE_XHTML11 + serialized;
     serialized = serialized.replace(/(<head[^>]*>)/i, '\n$1');
     serialized = serialized.replace(/(<\/body>)(<\/html>)/i, '$1\n$2');


### PR DESCRIPTION
## Problem

Many older Persian/Arabic EPUBs misuse the Right-to-Left Mark (RLM, U+200F)
as a half-space between the parts of a compound word. RLM is an invisible bidi control that does **not** break
the cursive joining form, so these words render joined and broken.

#5216/#5361 fixed a related-but-different issue: it *preserves* U+200F through
sanitization so XMLSerializer no longer turns it into `&#x200f;`. But
preserving the RLM doesn't fix rendering - the character that actually
produces a half-space is the Zero Width Non-Joiner (ZWNJ, U+200C). So the
bug persists in the current release.

## Fix

In `sanitizer.ts`, after the existing chain restores U+200F to its literal
form, swap RLM -> ZWNJ **only when it sits between two Arabic-script letters**.
This is the safe-swap rule: an RLM next to a digit, a Latin letter, or at a
text boundary can be a genuine direction hint, so it is left untouched.

Both marks are single UTF-16 code units, so the transformation is
length-preserving and existing CFIs / annotations stay valid.

## Testing

Verified the swap logic and its placement in the sanitizer pipeline against
the cases above (including consecutive RLMs and length preservation), and
confirmed correct rendering in the reader with a sample Persian EPUB.
[rlm_test_u+200f.zip](https://github.com/user-attachments/files/30986949/rlm_test_u%2B200f.zip)

Closes #5216 