### PR TITLE
fix(markdown): title imported books after the file, not the first heading

### DIFF
--- a/apps/readest-app/src/__tests__/utils/md.test.ts
+++ b/apps/readest-app/src/__tests__/utils/md.test.ts
@@ -168,14 +168,25 @@ describe('makeMarkdownBook', () => {
     expect(doc.querySelector('h1')?.getAttribute('id')).toBeTruthy();
   });
 
-  it('resolves the title from frontmatter, then first H1, then filename', async () => {
+  it('resolves the title from frontmatter, then the filename', async () => {
     const fm = await make('---\ntitle: From Front\nauthor: Jane Doe\n---\n\n# Ignored\n');
     expect(fm.metadata.title).toBe('From Front');
     expect(fm.metadata.author).toBe('Jane Doe');
-    const h1 = await make('# The Heading\n\nbody\n');
-    expect(h1.metadata.title).toBe('The Heading');
     const fn = await make('just text\n', 'My Notes.md');
     expect(fn.metadata.title).toBe('My Notes');
+  });
+
+  // A heading is body content, not metadata: only frontmatter — an explicit
+  // metadata block — may override the name the user gave the file. Taking the
+  // first H1 instead made `demo.md` import as "按顺序总结", and every note whose
+  // first line is a heading landed in the library under that heading.
+  it('titles the book after the file, not the first heading', async () => {
+    const h1 = await make('# The Heading\n\nbody\n', 'demo.md');
+    expect(h1.metadata.title).toBe('demo');
+    // The H1 is picked by tag name, not position, so a later one hijacked the
+    // title even when the document opened with an H2.
+    const laterH1 = await make('## Intro\n\n# Buried Heading\n\nbody\n', 'Reading Notes.markdown');
+    expect(laterH1.metadata.title).toBe('Reading Notes');
   });
 
   // Issue #5279: the two frontmatter shapes the reporter attached, each pairing

--- a/apps/readest-app/src/utils/md.ts
+++ b/apps/readest-app/src/utils/md.ts
@@ -236,10 +236,12 @@ export async function makeMarkdownBook(file: File): Promise<BookDoc> {
     createDocument: async () => new DOMParser().parseFromString(str, 'application/xhtml+xml'),
   }));
 
-  const title =
-    frontmatter.title ||
-    (headingEls.find((h) => h.tagName === 'H1')?.textContent ?? '').trim() ||
-    file.name.replace(/\.(?:md|markdown)$/i, '');
+  // The filename is the title unless frontmatter — an explicit metadata block —
+  // says otherwise. A heading is body content: preferring the first <h1> made
+  // every note whose first line is a heading import under that heading instead
+  // of its own name, and the <h1> was matched by tag name rather than position,
+  // so one buried mid-document could win even when the file opened with an <h2>.
+  const title = frontmatter.title || file.name.replace(/\.(?:md|markdown)$/i, '');
 
   const book = {
     metadata: {


### PR DESCRIPTION
## Problem

Importing a Markdown file names the book after the first line of the content instead of the file. A `demo.md` whose first line is `# <heading>` lands in the library under that heading.

Reported as a Windows and iOS issue, but it is not platform specific. Markdown never reaches the native parsers and never converts to EPUB the way `.txt` does, so `makeMarkdownBook` is the only code that titles a markdown book on any platform. Reproduced on the web build in Chrome. "Sometimes" just means "when the file contains an `<h1>`".

## Cause

The title chain in `src/utils/md.ts`, unchanged since #4816:

```ts
const title =
  frontmatter.title ||
  (headingEls.find((h) => h.tagName === 'H1')?.textContent ?? '').trim() ||
  file.name.replace(/\.(?:md|markdown)$/i, '');
```

The `<h1>` was matched by tag name rather than position, so one buried mid-document could win even when the file opened with an `<h2>`.

## Fix

A heading is body content, not metadata. The filename is the title, and YAML frontmatter stays the sole override:

```ts
const title = frontmatter.title || file.name.replace(/\.(?:md|markdown)$/i, '');
```

## Existing libraries are unaffected

`metaHash` for markdown is `title|authors|identifier`, so the title change moves it, but nothing re-titles an imported book:

- Re-importing the same file matches on the content `hash` first, and that branch of `importBook` preserves `existingBook.title`. Only the metaHash branch overwrites it.
- Reopening re-derives the title from the stored copy at `<hash>/<safeTitle>.md`, which is already named after the existing title.

## Verification

- New test covers both the frontmatter to filename chain and the buried `<h1>` case, written failing first.
- `pnpm test`: 9052 passed, 16 skipped.
- `pnpm lint` and `pnpm format:check` clean. No `src-tauri/` or Lua changes.
- Chrome against `pnpm dev-web`: dropped the same file into the library before and after the fix. Before, it imported as its opening heading; after, as `demo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
