### PR TITLE
fix(reader): stop iOS 16 WebContent crash when opening a book

### DIFF
--- a/apps/readest-app/scripts/ios16-fonts-ready-repro.py
+++ b/apps/readest-app/scripts/ios16-fonts-ready-repro.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Standalone repro for the iOS <= 16 WebKit fonts.ready WebContent crash.
+#
+# Serves a page whose @font-face request never completes, accesses
+# document.fonts.ready (creating the JS deferred promise), then swaps the
+# stylesheet's textContent. The next natural render tick rebuilds the style
+# resolver, purges the still-loading face (CSSFontFaceSet::purge), drops the
+# active count to zero and resolves the ready promise synchronously inside
+# style resolution.
+#
+# Affected engines (iOS 16.x WKWebView/Safari): the WebContent process dies;
+# Safari shows "A problem repeatedly occurred" or reloads a blank page.
+# Unaffected engines: the status line keeps counting "STILL ALIVE".
+#
+# Usage:  python3 ios16-fonts-ready-repro.py [port]   # default 0.0.0.0:8817
+#         open http://<this-mac-lan-ip>:<port>/ in Safari on the test device
+import socket
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PAGE = b"""<!doctype html>
+<meta name=viewport content="width=device-width, initial-scale=1">
+<title>fonts.ready purge repro</title>
+<body>
+<p id=t style="font-size:24px">Text that will force the NeverLoads font to start fetching.</p>
+<p id=status>booting...</p>
+<script>
+const status = document.getElementById('status')
+const log = m => { status.textContent = m; console.log(m) }
+
+// Sequencing matters (WebCore FontFaceSet, safari-7615-branch):
+// - The ready promise starts pending only if the FontFaceSet wrapper is
+//   created before loadEventFinished, or while processingLoadEvent.
+// - documentDidFinishLoading() runs right after the load event dispatch
+//   and resolves the promise UNLESS a font face is actively loading.
+// - completedLoading() resolves only once m_isDocumentLoaded is true.
+// So: inside the load handler, create the promise AND start a font fetch
+// that never completes; after the handler returns the promise stays
+// pending until the purge resolves it inside style resolution.
+addEventListener('load', () => {
+  // Step 1: create the JS deferred promise while processingLoadEvent.
+  document.fonts.ready.then(() => log('fonts.ready RESOLVED (engine survived)'))
+
+  // Step 2: inject the @font-face and force a synchronous layout so the
+  // (never-completing) font request starts before the handler returns.
+  const style = document.createElement('style')
+  style.id = 's'
+  style.textContent =
+    "@font-face { font-family: NeverLoads; src: url('/slow-font.woff2'); }" +
+    '#t { font-family: NeverLoads, serif; }'
+  document.head.appendChild(style)
+  void document.body.offsetWidth
+  log('font status after forced layout: ' + document.fonts.status)
+
+  // Step 3: with the font still in flight, swap the stylesheet like
+  // foliate's setStyles does. Do NOT force layout from JS; the natural
+  // rendering update rebuilds the style resolver with script disallowed,
+  // purges the loading face and resolves the ready promise there.
+  setTimeout(() => {
+    document.getElementById('s').textContent = '#t { color: red; }'
+    log('stylesheet swapped, waiting for render tick...')
+    let n = 0
+    setInterval(() => log('STILL ALIVE ' + (++n) + 's after swap (engine not affected)'), 1000)
+  }, 1000)
+})
+</script>
+"""
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/slow-font.woff2':
+            # Headers sent, body never delivered: the face stays Loading.
+            self.send_response(200)
+            self.send_header('Content-Type', 'font/woff2')
+            self.send_header('Content-Length', '100000')
+            self.end_headers()
+            time.sleep(600)
+            return
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.send_header('Content-Length', str(len(PAGE)))
+        self.end_headers()
+        self.wfile.write(PAGE)
+
+    def log_message(self, fmt, *args):
+        print('[%s] %s' % (self.address_string(), fmt % args), flush=True)
+
+
+def lan_ip():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(('192.0.2.1', 80))
+        return s.getsockname()[0]
+    finally:
+        s.close()
+
+
+if __name__ == '__main__':
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8817
+    server = ThreadingHTTPServer(('0.0.0.0', port), Handler)
+    print('Serving repro at http://%s:%d/' % (lan_ip(), port), flush=True)
+    print('Open it in Safari on the test device.', flush=True)
+    print('Crash = blank page / "A problem repeatedly occurred".', flush=True)
+    print('No crash = "STILL ALIVE Ns after swap" keeps counting.', flush=True)
+    server.serve_forever()

--- a/apps/readest-app/src/__tests__/foliate-fonts-ready-webkit.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-fonts-ready-webkit.test.ts
@@ -1,0 +1,106 @@
+// Regression test for the iOS <= 16 WebContent crash on book open.
+//
+// WebKit before Safari 17 (branch 7615 and earlier) resolves the
+// `document.fonts.ready` promise synchronously while purging still-loading
+// `@font-face`s during a style resolver rebuild (CSSFontFaceSet::purge ->
+// FontFaceSet::completedLoading -> DeferredPromise::callFunction). Script
+// execution is disallowed at that point, so the release assert kills the
+// WebContent process. The deferring guard only landed in WebKit 616
+// (Safari/iOS 17), the same release that shipped URL.canParse.
+//
+// The JS-visible promise is created lazily on first access of `.ready`, so
+// on affected engines fontsReady() must never touch it and must fall back
+// to polling `fonts.status`.
+import { describe, expect, it } from 'vitest';
+
+import { fontsReady } from 'foliate-js/paginator.js';
+
+const IOS16_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 16_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+const IOS17_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+const OLD_CHROME_UA =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36';
+
+interface FakeDocOptions {
+  userAgent: string;
+  hasCanParse: boolean;
+  status?: 'loading' | 'loaded';
+}
+
+const makeFakeDoc = ({ userAgent, hasCanParse, status = 'loading' }: FakeDocOptions) => {
+  let readyAccessed = false;
+  const readyPromise = Promise.resolve();
+  const fonts = {
+    status,
+    get ready() {
+      readyAccessed = true;
+      return readyPromise;
+    },
+  };
+  const win = {
+    navigator: { userAgent },
+    URL: hasCanParse ? { canParse: () => true } : {},
+    setTimeout: (fn: () => void, ms: number) => setTimeout(fn, ms),
+  };
+  const doc = { fonts, defaultView: win };
+  return {
+    doc,
+    readyPromise,
+    wasReadyAccessed: () => readyAccessed,
+    finishLoading: () => {
+      fonts.status = 'loaded';
+    },
+  };
+};
+
+describe('fontsReady', () => {
+  it('never accesses fonts.ready on WebKit without URL.canParse (iOS <= 16)', async () => {
+    const fake = makeFakeDoc({ userAgent: IOS16_UA, hasCanParse: false });
+    const promise = fontsReady(fake.doc);
+    expect(fake.wasReadyAccessed()).toBe(false);
+
+    let resolved = false;
+    promise.then(() => {
+      resolved = true;
+    });
+    await new Promise((r) => setTimeout(r, 150));
+    expect(resolved).toBe(false);
+
+    fake.finishLoading();
+    await promise;
+    expect(fake.wasReadyAccessed()).toBe(false);
+  });
+
+  it('resolves without touching fonts.ready when fonts are already loaded on iOS <= 16', async () => {
+    const fake = makeFakeDoc({ userAgent: IOS16_UA, hasCanParse: false, status: 'loaded' });
+    await fontsReady(fake.doc);
+    expect(fake.wasReadyAccessed()).toBe(false);
+  });
+
+  it('returns fonts.ready on WebKit with URL.canParse (iOS >= 17)', () => {
+    const fake = makeFakeDoc({ userAgent: IOS17_UA, hasCanParse: true });
+    expect(fontsReady(fake.doc)).toBe(fake.readyPromise);
+    expect(fake.wasReadyAccessed()).toBe(true);
+  });
+
+  it('returns fonts.ready on non-WebKit engines even without URL.canParse', () => {
+    // Old Chrome/Firefox lack URL.canParse but do not have the WebKit bug;
+    // they must keep the exact `fonts.ready` semantics.
+    const fake = makeFakeDoc({ userAgent: OLD_CHROME_UA, hasCanParse: false });
+    expect(fontsReady(fake.doc)).toBe(fake.readyPromise);
+    expect(fake.wasReadyAccessed()).toBe(true);
+  });
+
+  it('resolves when the document has no fonts API', async () => {
+    await expect(fontsReady({} as never)).resolves.toBeUndefined();
+    await expect(fontsReady(null as never)).resolves.toBeUndefined();
+  });
+
+  it('resolves without touching fonts.ready on a detached document', async () => {
+    const fake = makeFakeDoc({ userAgent: IOS16_UA, hasCanParse: false });
+    const detached = { fonts: fake.doc.fonts, defaultView: null };
+    await expect(fontsReady(detached as never)).resolves.toBeUndefined();
+    expect(fake.wasReadyAccessed()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

A lifetime supporter reported that Readest on iOS 16.7 (iPhone 8 Plus) crashes back to the home screen the moment any EPUB is opened, with a `com.apple.WebKit.WebContent.ips` generated every time and no jetsam events (not OOM). The crash log shows a release assert (`EXC_BREAKPOINT`) resolving the `FontFaceSet` ready promise:

```
WTFCrashWithInfo
WebCore::DeferredPromise::callFunction
WebCore::DOMPromiseProxyWithResolveCallback<IDLInterface<FontFaceSet>>::resolve
WebCore::CSSFontFaceSet::remove / purge
WebCore::CSSFontSelector::buildStarted
WebCore::Style::Scope::createDocumentResolver
WebCore::Document::resolveStyle
```

## Root cause

WebKit before Safari 17 resolves `document.fonts.ready` synchronously when a style resolver rebuild purges still-loading font faces, which is forbidden mid style resolution. Readest hits this deterministically on every book open:

1. foliate-js accesses `doc.fonts.ready` inside the section iframe load handler, so the promise starts pending (`FontFaceSet` is created while `processingLoadEvent`).
2. The injected `@font-face` fonts start fetching during that same handler, so `documentDidFinishLoading` keeps the promise pending.
3. Applying theme and view settings swaps the stylesheet text content, invalidating the style resolver.
4. The next render tick rebuilds the resolver, purges the still-loading faces, drops the active count to zero and resolves the promise synchronously inside style resolution, tripping the assert.

iOS 17 defers the resolution to a queued task ([safari-7616-branch guard](https://github.com/WebKit/WebKit/blob/safari-7616-branch/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp#L69)), which is why newer devices are unaffected.

## Fix

Bump foliate-js (readest/foliate-js#71) so the paginator never touches `fonts.ready` on the affected engines (`AppleWebKit/605` UA without `URL.canParse`, the same WebKit release boundary as the guard) and polls `fonts.status` instead. The crashing promise only exists if JS accesses `.ready`, so this removes the crash entirely while keeping exact `fonts.ready` semantics everywhere else.

Also adds `scripts/ios16-fonts-ready-repro.py`, a standalone page that isolates the engine bug from app timing, for verifying which shipped iOS security trains carry the fatal assert (an iOS 15.7 device did not reproduce it in-app; public WebKit sources for iOS 15 are identical, so shipped trains apparently diverge).

## Testing

- New `foliate-fonts-ready-webkit.test.ts` exercises the real paginator helper: never touches `.ready` on affected engines, resolves on `fonts.status`, keeps `fonts.ready` on iOS 17+/non-WebKit, handles missing fonts API and detached documents.
- Full suite (9057 tests), `pnpm lint`, `pnpm format:check` pass.
- Repro page validated on Chrome and macOS Safari 18 (both unaffected engines survive with the harness armed).
- Device verification on iOS 16 pending (no iOS 16 hardware/simulator runtime available; needs the reporter or a TestFlight build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)