### PR TITLE
fix(koplugin): extract self-update with ffi/archiver on KOReader 2026.07+

### DIFF
--- a/apps/readest.koplugin/readest_selfupdate.lua
+++ b/apps/readest.koplugin/readest_selfupdate.lua
@@ -104,6 +104,33 @@ function SelfUpdate:checkForUpdate(plugin_path, installed_version)
     end
 end
 
+-- KOReader v2026.07 dropped Device:unpackArchive in favor of the ffi/archiver
+-- module, so calling it on current releases crashes (readest/readest#5645).
+-- Older releases (< v2025.08) only have Device:unpackArchive, so try it first.
+function SelfUpdate:unpackArchive(archive, extract_to)
+    if Device.unpackArchive then
+        return Device:unpackArchive(archive, extract_to)
+    end
+    local has_archiver, Archiver = pcall(require, "ffi/archiver")
+    if not has_archiver then
+        return false, "no archive extraction API available"
+    end
+    local dest_root = extract_to:gsub("/+$", "")
+    local arc = Archiver.Reader:new()
+    local ok = arc:open(archive)
+    if ok then
+        for entry in arc:iterate() do
+            if not arc:extractToPath(entry.path, dest_root .. "/" .. entry.path) then
+                break
+            end
+        end
+        ok = not arc.err
+    end
+    local err = arc.err
+    arc:close()
+    return ok, err
+end
+
 function SelfUpdate:downloadAndInstall(plugin_path, version)
     local ConfirmBox = require("ui/widget/confirmbox")
     local DataStorage = require("datastorage")
@@ -159,7 +186,7 @@ function SelfUpdate:downloadAndInstall(plugin_path, version)
 
     local parent_dir = plugin_path:match("(.*/)")
 
-    local ok, err = Device:unpackArchive(tmp_path, parent_dir)
+    local ok, err = self:unpackArchive(tmp_path, parent_dir)
     os.remove(tmp_path)
 
     if ok then

--- a/apps/readest.koplugin/spec/selfupdate_spec.lua
+++ b/apps/readest.koplugin/spec/selfupdate_spec.lua
@@ -1,0 +1,137 @@
+-- selfupdate_spec.lua
+-- Regression for readest/readest#5645: KOReader v2026.07 dropped
+-- Device:unpackArchive (koreader/koreader@751b49784), so tapping "Update"
+-- crashed with "attempt to call method 'unpackArchive' (a nil value)".
+-- SelfUpdate must extract with ffi/archiver when the Device method is gone,
+-- while still delegating to Device:unpackArchive on older KOReader.
+
+require("spec_helper")
+require("spec.koreader_stubs")
+
+-- Fake ffi/archiver reproducing the Reader API surface the plugin uses:
+-- Reader:new/open/iterate/extractToPath/close, with `err` cleared on every
+-- call (close included) exactly like KOReader's base/ffi/archiver.lua — the
+-- helper must capture `err` BEFORE close or it reports nil.
+local archiver = {
+    entries = {},
+    extracted = {},
+    open_ok = true,
+    fail_on = nil,
+    opened = nil,
+    closed = false,
+}
+
+local FakeReader = {}
+FakeReader.__index = FakeReader
+
+function FakeReader:new()
+    return setmetatable({}, FakeReader)
+end
+
+function FakeReader:open(filepath)
+    self.err = nil
+    archiver.opened = filepath
+    if not archiver.open_ok then
+        self.err = "open failed"
+        return false
+    end
+    return true
+end
+
+function FakeReader:iterate()
+    local i = 0
+    return function()
+        i = i + 1
+        return archiver.entries[i]
+    end
+end
+
+function FakeReader:extractToPath(key, dest_path)
+    self.err = nil
+    if archiver.fail_on == key then
+        self.err = "extract failed"
+        return false
+    end
+    table.insert(archiver.extracted, { src = key, dest = dest_path })
+    return true
+end
+
+function FakeReader:close()
+    self.err = nil
+    archiver.closed = true
+end
+
+package.preload["ffi/archiver"] = function()
+    return { Reader = FakeReader }
+end
+
+local Device = require("device")
+local SelfUpdate = require("readest_selfupdate")
+
+describe("SelfUpdate:unpackArchive", function()
+    before_each(function()
+        archiver.entries = {}
+        archiver.extracted = {}
+        archiver.open_ok = true
+        archiver.fail_on = nil
+        archiver.opened = nil
+        archiver.closed = false
+        Device.unpackArchive = nil
+    end)
+
+    it("extracts with ffi/archiver when Device:unpackArchive is unavailable", function()
+        archiver.entries = {
+            { path = "readest.koplugin/main.lua" },
+            { path = "readest.koplugin/_meta.lua" },
+        }
+
+        local ok, err = SelfUpdate:unpackArchive("/tmp/update.zip", "/plugins/")
+
+        assert.is_true(ok)
+        assert.is_nil(err)
+        assert.are.equal("/tmp/update.zip", archiver.opened)
+        assert.are.equal(2, #archiver.extracted)
+        assert.are.equal("/plugins/readest.koplugin/main.lua", archiver.extracted[1].dest)
+        assert.are.equal("/plugins/readest.koplugin/_meta.lua", archiver.extracted[2].dest)
+        assert.is_true(archiver.closed)
+    end)
+
+    it("delegates to Device:unpackArchive when available (older KOReader)", function()
+        local called
+        Device.unpackArchive = function(_, archive, extract_to)
+            called = { archive = archive, extract_to = extract_to }
+            return true
+        end
+
+        local ok = SelfUpdate:unpackArchive("/tmp/update.zip", "/plugins/")
+
+        assert.is_true(ok)
+        assert.are.equal("/tmp/update.zip", called.archive)
+        assert.are.equal("/plugins/", called.extract_to)
+        assert.is_nil(archiver.opened)
+    end)
+
+    it("reports the archiver error when extraction fails", function()
+        archiver.entries = {
+            { path = "readest.koplugin/main.lua" },
+            { path = "readest.koplugin/_meta.lua" },
+        }
+        archiver.fail_on = "readest.koplugin/main.lua"
+
+        local ok, err = SelfUpdate:unpackArchive("/tmp/update.zip", "/plugins/")
+
+        assert.is_false(ok)
+        assert.are.equal("extract failed", err)
+        assert.is_true(archiver.closed)
+    end)
+
+    it("reports the open error when the archive cannot be read", function()
+        archiver.open_ok = false
+
+        local ok, err = SelfUpdate:unpackArchive("/tmp/update.zip", "/plugins/")
+
+        assert.is_false(ok)
+        assert.are.equal("open failed", err)
+        assert.are.equal(0, #archiver.extracted)
+    end)
+end)


### PR DESCRIPTION
## Problem

Updating the Readest plugin from KOReader's menu crashes on KOReader 2026.07+ (#5645):

```
readest_selfupdate.lua:162: attempt to call method 'unpackArchive' (a nil value)
```

KOReader removed `Device:unpackArchive` in koreader/koreader@751b49784 (first shipped in stable v2026.07) after migrating its own callers to the `ffi/archiver` module. The plugin's self-update still called the dropped method, so every update attempt on current KOReader crashed at the install step.

## Fix

Add `SelfUpdate:unpackArchive(archive, extract_to)`:

- Delegates to `Device:unpackArchive` when it still exists (KOReader <= v2026.03; also keeps the native Android implementation on old releases, and releases older than v2025.08 have no `ffi/archiver` at all).
- Otherwise extracts with `ffi/archiver`'s `Reader` (open / iterate / extractToPath / close), the same pattern the removed Device method used internally, capturing `arc.err` before `close()` since close resets it.
- Returns `false` with a message instead of crashing if neither API is available, which surfaces through the existing "Failed to install update" InfoMessage.

## Testing

- New `spec/selfupdate_spec.lua` (busted): reproduces the crash shape (Device without `unpackArchive`), covers the archiver extraction path, delegation to the old Device method, and error propagation on open/extract failures. Fails with the exact production error before the fix, passes after.
- `pnpm test:lua`: 292 successes / 0 failures.
- `pnpm lint:lua` clean; pre-push ran `format:check`, `tsgo`+biome, and the full vitest suite (9063 passed).

Closes #5645

🤖 Generated with [Claude Code](https://claude.com/claude-code)