### PR TITLE
fix(reader): render fixed-layout pages as authored in dark mode, closes #5649

### DIFF
--- a/apps/readest-app/src/__tests__/utils/fixed-layout-styles.test.ts
+++ b/apps/readest-app/src/__tests__/utils/fixed-layout-styles.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/utils/misc', async (importOriginal) => {
 });
 
 import { applyFixedlayoutStyles, ThemeCode } from '@/utils/style';
-import { ViewSettings } from '@/types/book';
+import { BookFormat, ViewSettings } from '@/types/book';
 import {
   DEFAULT_BOOK_FONT,
   DEFAULT_BOOK_LAYOUT,
@@ -59,9 +59,9 @@ function makeThemeCode(overrides: Partial<ThemeCode> = {}): ThemeCode {
 }
 
 /** Run applyFixedlayoutStyles on a fresh document and return the injected CSS. */
-function fixedLayoutCss(vs: ViewSettings, theme: ThemeCode): string {
+function fixedLayoutCss(vs: ViewSettings, theme: ThemeCode, format: BookFormat = 'PDF'): string {
   const doc = document.implementation.createHTMLDocument('test');
-  applyFixedlayoutStyles(doc, vs, theme);
+  applyFixedlayoutStyles(doc, vs, theme, format);
   return doc.getElementById('fixed-layout-styles')?.textContent ?? '';
 }
 
@@ -104,5 +104,28 @@ describe('applyFixedlayoutStyles contrast filter', () => {
       makeThemeCode(),
     );
     expect(css).not.toContain('contrast(');
+  });
+});
+
+describe('applyFixedlayoutStyles page colors', () => {
+  const darkTheme = makeThemeCode({ isDarkMode: true, bg: '#342e25', fg: '#ffd595' });
+
+  it('keeps book-authored pages out of dark mode so their text stays as authored (#5649)', () => {
+    const css = fixedLayoutCss(makeViewSettings(), darkTheme, 'EPUB');
+    expect(css).toContain('color-scheme: light');
+    expect(css).not.toContain('color-scheme: dark');
+  });
+
+  it('does not paint the theme background over book-authored pages', () => {
+    const css = fixedLayoutCss(makeViewSettings(), darkTheme, 'EPUB');
+    expect(css).not.toMatch(/body\s*{[^}]*background-color/);
+  });
+
+  it('still themes app-rendered pages (PDF, comics) in dark mode', () => {
+    for (const format of ['PDF', 'CBZ'] as const) {
+      const css = fixedLayoutCss(makeViewSettings(), darkTheme, format);
+      expect(css).toContain('color-scheme: dark');
+      expect(css).toMatch(/body\s*{[^}]*background-color: var\(--theme-bg-color\)/);
+    }
   });
 });

--- a/apps/readest-app/src/__tests__/utils/style.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style.test.ts
@@ -234,6 +234,26 @@ describe('transformStylesheet', () => {
     });
   });
 
+  describe('fixed-layout documents', () => {
+    it('leaves authored colors alone so the page renders as authored (#5649)', () => {
+      const css = '.text { color: #000000; } .named { color: black; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL, true);
+      expect(result).toBe(css);
+    });
+
+    it('leaves authored font sizes and viewport units alone', () => {
+      const css = '.text { font-size: 24px; width: 50vw; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL, true);
+      expect(result).toBe(css);
+    });
+
+    it('still transforms reflowable stylesheets', () => {
+      const css = '.text { color: #000000; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL, false);
+      expect(result).toContain('color: var(--theme-fg-color)');
+    });
+  });
+
   describe('font-weight normal to var(--font-weight)', () => {
     it('replaces font-weight: normal with var(--font-weight)', () => {
       const css = '.text { font-weight: normal; }';

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -281,7 +281,13 @@ const FoliateViewer: React.FC<{
           const viewSettings = getViewSettings(bookKey);
           const bookData = getBookData(bookKey);
           if (viewSettings && detail.type === 'text/css')
-            return transformStylesheet(data, width, height, viewSettings.vertical);
+            return transformStylesheet(
+              data,
+              width,
+              height,
+              viewSettings.vertical,
+              bookData?.isFixedLayout,
+            );
           const isHtml = detail.type === 'application/xhtml+xml' || detail.type === 'text/html';
           if (viewSettings && bookData && isHtml) {
             const ctx: TransformContext = {
@@ -367,7 +373,7 @@ const FoliateViewer: React.FC<{
       });
 
       if (bookDoc.rendition?.layout === 'pre-paginated') {
-        applyFixedlayoutStyles(detail.doc, viewSettings);
+        applyFixedlayoutStyles(detail.doc, viewSettings, undefined, bookData.book?.format);
         const themeCode = getThemeCode();
         if (bookData.book?.format === 'PDF' && themeCode && renderer) {
           renderer.pageColors = viewSettings.applyThemeToPDF
@@ -934,7 +940,7 @@ const FoliateViewer: React.FC<{
       const docs = viewRef.current.renderer.getContents();
       docs.forEach(({ doc }) => {
         if (bookDoc.rendition?.layout === 'pre-paginated') {
-          applyFixedlayoutStyles(doc, viewSettings);
+          applyFixedlayoutStyles(doc, viewSettings, undefined, bookData?.book?.format);
         }
         applyThemeModeClass(doc, isDarkMode);
         applyScrollModeClass(doc, viewSettings.scrolled || false);

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -6,7 +6,7 @@ import {
   CJK_SANS_SERIF_FONTS,
   CJK_SERIF_FONTS,
 } from '@/services/constants';
-import { ViewSettings } from '@/types/book';
+import { BookFormat, FIXED_LAYOUT_FORMATS, ViewSettings } from '@/types/book';
 import {
   themes,
   Palette,
@@ -981,7 +981,18 @@ export const applyTranslationStyle = (viewSettings: ViewSettings) => {
   document.head.appendChild(styleElement);
 };
 
-export const transformStylesheet = (css: string, vw: number, vh: number, vertical: boolean) => {
+export const transformStylesheet = (
+  css: string,
+  vw: number,
+  vh: number,
+  vertical: boolean,
+  isFixedLayout = false,
+) => {
+  // Fixed-layout pages are authored against their own viewport: rescaling font
+  // sizes, resolving vw/vh against the reader viewport or repainting colors
+  // breaks the authored page. Leave them exactly as the book wrote them (#5649).
+  if (isFixedLayout) return css;
+
   const isMobile = ['ios', 'android'].includes(getOSPlatform());
   const fontScale = isMobile ? 1.25 : 1;
   const isInlineStyle = !css.includes('{');
@@ -1306,11 +1317,17 @@ export const applyFixedlayoutStyles = (
   document: Document,
   viewSettings: ViewSettings,
   themeCode?: ThemeCode,
+  format?: BookFormat,
 ) => {
   if (!themeCode) {
     themeCode = getThemeCode();
   }
   const { bg, fg, primary, isDarkMode } = themeCode;
+  // PDF and comic pages are rendered by the app, so they take the theme colors.
+  // Fixed-layout EPUB pages are authored by the book: theming the page repaints
+  // the background the book drew and, because a dark color scheme also swaps the
+  // browser default text color, recolors text the book never colored (#5649).
+  const appRendered = !format || FIXED_LAYOUT_FORMATS.has(format);
   const isEink = viewSettings.isEink;
   const overrideColor = viewSettings.overrideColor!;
   const invertImgColorInDark = viewSettings.invertImgColorInDark!;
@@ -1332,11 +1349,11 @@ export const applyFixedlayoutStyles = (
       --theme-bg-color: ${bg};
       --theme-fg-color: ${fg};
       --theme-primary-color: ${primary};
-      color-scheme: ${isDarkMode ? 'dark' : 'light'};
+      color-scheme: ${appRendered && isDarkMode ? 'dark' : 'light'};
     }
     body {
       position: relative;
-      background-color: var(--theme-bg-color);
+      ${appRendered ? 'background-color: var(--theme-bg-color);' : ''}
     }
     ${isEink ? getEinkSelectionStyles() : ''}
     #canvas {


### PR DESCRIPTION
## Problem

Closes #5649. In dark mode, text in a fixed-layout (pre-paginated) EPUB followed the app theme instead of the book. Two independent paths were rewriting it, both with all default settings (Invert Image In Dark Mode and Override Book Color off):

1. **Linked stylesheets.** `getDocTransformHandler` ran `transformStylesheet` on every `text/css` resource with no fixed-layout gate, so an authored `color: #000000` became `var(--theme-fg-color)`. Measured on a repro book: `rgb(91,70,54)` in sepia, `rgb(255,213,149)` in dark. The inline `<style>` path (`services/transformers/style.ts`) already skipped fixed layout; the resource path did not. The same transform also rescaled fixed-layout font sizes (divided by 1.25 on mobile), resolved `vw`/`vh` against the reader viewport, and rewrote the book's `font-family: serif` to `unset`.
2. **Color scheme.** `applyFixedlayoutStyles` set `color-scheme: dark` with no explicit `color`, so text the book never colored fell back to the browser dark default (`rgb(255,255,255)`), which no theme variable controls.

Fixed-layout documents receive only `applyFixedlayoutStyles`: foliate's fixed-layout renderer has no `setStyles`, so `getStyles`/`getColorStyles` never reach them. That makes it the single lever for these pages.

## Fix

- Skip `transformStylesheet` for fixed-layout books, matching what the inline `<style>` transformer already did.
- Keep book-authored pages (EPUB) on `color-scheme: light` and stop painting the theme background over them. This part is load-bearing: each fixed-layout page is its own iframe (letterboxing lives outside it), so `body { background-color: var(--theme-bg-color) }` colors the page itself. Restoring authored text without it would put black text on a theme-dark page.
- PDF and comic pages are rendered by the app, not authored by a book, so they keep the theme background and dark color scheme they had (gated on `FIXED_LAYOUT_FORMATS`).

## Verification

Built a minimal fixed-layout EPUB (the attachment on the issue is a corrupt zip) with one page backed by a background image and one with no background, each carrying a line with `color: #000000` from a linked stylesheet and a line with no color declared.

- Before, in dark mode: explicit-black line computed `rgb(255,213,149)`, uncolored line `rgb(255,255,255)`, page background the theme color.
- After: the delivered stylesheet is byte-identical to the book's, both lines compute `rgb(0,0,0)`, the authored background image renders, and the page with no background renders white on the dark surround.
- PDF and CBZ still compute `color-scheme: dark` with the theme background; a reflowable EPUB is unchanged.
- `pnpm test` (9069 passed), `pnpm lint`, `pnpm format:check` all pass.

## Trade-offs

- Fixed-layout EPUB pages now render as authored (white by default) in dark and sepia rather than tinted. That is what the issue asks for and matches other readers, but it is a visible change for text-only fixed-layout pages that declare no background.
- Fixed-layout linked CSS is no longer rewritten at all, so a book's `user-select: none` now blocks selection there. Inline `<style>` already behaved this way; forcing selection belongs at doc load rather than in a rewrite of the book's CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)