### PR TITLE
fix(reader): disable text autosizing in fixed-layout books, closes #5641

### DIFF
--- a/apps/readest-app/src/__tests__/utils/fixed-layout-styles.test.ts
+++ b/apps/readest-app/src/__tests__/utils/fixed-layout-styles.test.ts
@@ -129,3 +129,11 @@ describe('applyFixedlayoutStyles page colors', () => {
     }
   });
 });
+
+describe('applyFixedlayoutStyles text autosizing', () => {
+  it('disables Chrome-for-Android text autosizing that misplaces per-letter positioned text (#5641)', () => {
+    const css = fixedLayoutCss(makeViewSettings(), makeThemeCode(), 'EPUB');
+    expect(css).toContain('-webkit-text-size-adjust: none');
+    expect(css).toMatch(/[^-]text-size-adjust: none/);
+  });
+});

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1350,6 +1350,10 @@ export const applyFixedlayoutStyles = (
       --theme-fg-color: ${fg};
       --theme-primary-color: ${primary};
       color-scheme: ${appRendered && isDarkMode ? 'dark' : 'light'};
+      /* Chrome for Android's text autosizing rescales line metrics and shifts
+         absolutely positioned per-letter text in fixed-layout books (#5641). */
+      -webkit-text-size-adjust: none;
+      text-size-adjust: none;
     }
     body {
       position: relative;


### PR DESCRIPTION
## Problem

In Chrome for Android (native app and web app), fixed-layout EPUBs that position individual letters with `position: absolute` (typical of InDesign comic exports, e.g. Captain Underpants) render some words with a spurious tab-sized gap before letters whose `top` offset differs from their neighbors (descenders, diacritics).

## Root cause

Chrome for Android's text autosizing (Blink `TextAutosizer`, absent on desktop Chrome and Firefox) rescales font/line metrics on pages it judges as not mobile-optimized, shifting the precisely positioned per-letter spans. Reflowable books already opt out via `text-size-adjust: none` in `getFontStyles`, but that CSS is delivered through `renderer.setStyles`, which the fixed-layout renderer does not implement. Fixed-layout documents only ever receive `applyFixedlayoutStyles`, so they were the one path never getting the opt-out. Root cause was confirmed by the reporter in #5641: toggling Chrome's Desktop Site mode (which suppresses the autosizing heuristics) makes the gap disappear.

## Fix

Add `-webkit-text-size-adjust: none` / `text-size-adjust: none` to the stylesheet `applyFixedlayoutStyles` injects, matching what reflowable books already get.

## Testing

- New unit test in `src/__tests__/utils/fixed-layout-styles.test.ts` asserting the injected fixed-layout stylesheet carries both declarations (fails without the fix).
- `pnpm test` (9074 passed), `pnpm lint`, `pnpm format:check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)