### PR TITLE
fix(ui): size the alert surface off its container, not its content

### DIFF
--- a/apps/readest-app/src/__tests__/components/alert-width-stability.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/alert-width-stability.browser.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * The alert surface must not resize with its own content.
+ *
+ * Every call site mounts the alert as the lone child of a
+ * `fixed inset-x-0 flex justify-center` bar. A flex item sizes to its content
+ * unless it is given a definite width, so the alert box measured itself off its
+ * longest line and jumped whenever that text changed — most visibly in
+ * DeleteConfirmAlert, where flipping the purge toggle swaps in a longer
+ * description and relabels the confirm button (issue: the popup grows/shrinks
+ * mid-interaction).
+ *
+ * Needs real layout and real Tailwind, so it runs as a browser test.
+ */
+
+import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest';
+import { render, cleanup, fireEvent, screen } from '@testing-library/react';
+import { page } from 'vitest/browser';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: null }),
+}));
+vi.mock('@/store/deviceStore', () => ({
+  useDeviceControlStore: () => ({
+    acquireBackKeyInterception: vi.fn(),
+    releaseBackKeyInterception: vi.fn(),
+  }),
+}));
+
+const { default: Alert } = await import('@/components/Alert');
+const { default: DeleteConfirmAlert } = await import('@/components/DeleteConfirmAlert');
+await import('@/styles/globals.css');
+
+beforeAll(async () => {
+  await page.viewport(1024, 768);
+});
+afterEach(() => cleanup());
+
+// The container both DeleteConfirmAlert call sites (Bookshelf, BookDetailModal)
+// and the plain-Alert ones (StorageManager, ClipSignInAlert) render into.
+const AlertBar: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className='fixed bottom-0 left-0 right-0 z-50 flex justify-center'>{children}</div>
+);
+
+const alertWidth = () => screen.getByRole('alert').getBoundingClientRect().width;
+
+describe('Alert width stability', () => {
+  it('keeps the delete popup at one width across the purge toggle', () => {
+    render(
+      <AlertBar>
+        <DeleteConfirmAlert
+          title='Confirm Deletion'
+          message='Are you sure to delete 1 selected book(s)?'
+          showPurgeToggle
+          onCancel={vi.fn()}
+          onConfirm={vi.fn()}
+        />
+      </AlertBar>,
+    );
+
+    const before = alertWidth();
+    fireEvent.click(screen.getByRole('checkbox'));
+    // The toggle swapped in the longer warning copy and the longer button label.
+    expect(screen.getByText('Purge & Delete')).toBeTruthy();
+    expect(alertWidth()).toBe(before);
+  });
+
+  it('sizes the delete popup like every other alert', () => {
+    const { unmount } = render(
+      <AlertBar>
+        <Alert title='Confirm Deletion' message='Short.' onCancel={vi.fn()} onConfirm={vi.fn()} />
+      </AlertBar>,
+    );
+    const plain = alertWidth();
+    unmount();
+
+    render(
+      <AlertBar>
+        <DeleteConfirmAlert
+          title='Confirm Deletion'
+          message='Are you sure to delete 1 selected book(s)?'
+          showPurgeToggle
+          onCancel={vi.fn()}
+          onConfirm={vi.fn()}
+        />
+      </AlertBar>,
+    );
+    expect(alertWidth()).toBe(plain);
+  });
+
+  it('does not size a plain alert off its message', () => {
+    const { unmount } = render(
+      <AlertBar>
+        <Alert title='Title' message='Short.' onCancel={vi.fn()} onConfirm={vi.fn()} />
+      </AlertBar>,
+    );
+    const short = alertWidth();
+    unmount();
+
+    render(
+      <AlertBar>
+        <Alert
+          title='Title'
+          message={'A considerably longer message that would otherwise stretch the alert surface.'}
+          onCancel={vi.fn()}
+          onConfirm={vi.fn()}
+        />
+      </AlertBar>,
+    );
+    expect(alertWidth()).toBe(short);
+  });
+});

--- a/apps/readest-app/src/components/Alert.tsx
+++ b/apps/readest-app/src/components/Alert.tsx
@@ -27,7 +27,12 @@ const Alert: React.FC<{
   const divRef = useKeyDownActions({ onCancel, onConfirm });
 
   return (
-    <div className={clsx('z-[130] flex justify-center px-4')}>
+    // `w-full` is load-bearing: every call site mounts this as the lone child
+    // of a `flex justify-center` bar, and a flex item without a definite width
+    // sizes to its content. Without it the surface below measured itself off
+    // its longest line, so the box resized whenever the text changed (e.g. the
+    // delete confirmation's purge toggle swapping in longer copy mid-dialog).
+    <div className='z-[130] flex w-full justify-center px-4'>
       <div
         ref={divRef}
         role='alert'

--- a/apps/readest-app/src/components/DeleteConfirmAlert.tsx
+++ b/apps/readest-app/src/components/DeleteConfirmAlert.tsx
@@ -26,45 +26,47 @@ const DeleteConfirmAlert: React.FC<{
   const [purgeData, setPurgeData] = useState(false);
 
   return (
-    <Alert
-      title={title}
-      message={message}
-      confirmLabel={purgeData ? _('Purge & Delete') : _('Delete')}
-      confirmButtonClassName={purgeData ? 'btn-error' : 'btn-warning'}
-      onCancel={onCancel}
-      onConfirm={() => onConfirm(purgeData)}
-    >
-      {showPurgeToggle && (
-        <label
-          className={clsx(
-            'eink-bordered flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors',
-            purgeData
-              ? 'not-eink:border-error/40 not-eink:bg-error/10'
-              : 'not-eink:border-base-content/10 not-eink:bg-base-100/60',
-          )}
-        >
-          <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
-            <span className={clsx('text-sm font-medium', purgeData && 'not-eink:text-error')}>
-              {_('Purge all reading data')}
-            </span>
-            <span className='text-neutral-content text-xs'>
-              {purgeData
-                ? _(
-                    'This permanently erases reading progress, notes, and bookmarks. This cannot be undone.',
-                  )
-                : _('Also erase reading progress, notes, and bookmarks.')}
-            </span>
-          </div>
-          <input
-            type='checkbox'
-            className={clsx('toggle toggle-sm shrink-0', purgeData && 'not-eink:toggle-error')}
-            checked={purgeData}
-            onChange={(e) => setPurgeData(e.target.checked)}
-            aria-label={_('Purge all reading data')}
-          />
-        </label>
-      )}
-    </Alert>
+    <div className='w-full max-w-md'>
+      <Alert
+        title={title}
+        message={message}
+        confirmLabel={purgeData ? _('Purge & Delete') : _('Delete')}
+        confirmButtonClassName={purgeData ? 'btn-error' : 'btn-warning'}
+        onCancel={onCancel}
+        onConfirm={() => onConfirm(purgeData)}
+      >
+        {showPurgeToggle && (
+          <label
+            className={clsx(
+              'eink-bordered flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors',
+              purgeData
+                ? 'not-eink:border-error/40 not-eink:bg-error/10'
+                : 'not-eink:border-base-content/10 not-eink:bg-base-100/60',
+            )}
+          >
+            <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
+              <span className={clsx('text-sm font-medium', purgeData && 'not-eink:text-error')}>
+                {_('Purge all reading data')}
+              </span>
+              <span className='text-neutral-content text-xs'>
+                {purgeData
+                  ? _(
+                      'This permanently erases reading progress, notes, and bookmarks. This cannot be undone.',
+                    )
+                  : _('Also erase reading progress, notes, and bookmarks.')}
+              </span>
+            </div>
+            <input
+              type='checkbox'
+              className={clsx('toggle toggle-sm shrink-0', purgeData && 'not-eink:toggle-error')}
+              checked={purgeData}
+              onChange={(e) => setPurgeData(e.target.checked)}
+              aria-label={_('Purge all reading data')}
+            />
+          </label>
+        )}
+      </Alert>
+    </div>
   );
 };
 

--- a/apps/readest-app/src/components/DeleteConfirmAlert.tsx
+++ b/apps/readest-app/src/components/DeleteConfirmAlert.tsx
@@ -26,47 +26,45 @@ const DeleteConfirmAlert: React.FC<{
   const [purgeData, setPurgeData] = useState(false);
 
   return (
-    <div className='w-full max-w-md'>
-      <Alert
-        title={title}
-        message={message}
-        confirmLabel={purgeData ? _('Purge & Delete') : _('Delete')}
-        confirmButtonClassName={purgeData ? 'btn-error' : 'btn-warning'}
-        onCancel={onCancel}
-        onConfirm={() => onConfirm(purgeData)}
-      >
-        {showPurgeToggle && (
-          <label
-            className={clsx(
-              'eink-bordered flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors',
-              purgeData
-                ? 'not-eink:border-error/40 not-eink:bg-error/10'
-                : 'not-eink:border-base-content/10 not-eink:bg-base-100/60',
-            )}
-          >
-            <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
-              <span className={clsx('text-sm font-medium', purgeData && 'not-eink:text-error')}>
-                {_('Purge all reading data')}
-              </span>
-              <span className='text-neutral-content text-xs'>
-                {purgeData
-                  ? _(
-                      'This permanently erases reading progress, notes, and bookmarks. This cannot be undone.',
-                    )
-                  : _('Also erase reading progress, notes, and bookmarks.')}
-              </span>
-            </div>
-            <input
-              type='checkbox'
-              className={clsx('toggle toggle-sm shrink-0', purgeData && 'not-eink:toggle-error')}
-              checked={purgeData}
-              onChange={(e) => setPurgeData(e.target.checked)}
-              aria-label={_('Purge all reading data')}
-            />
-          </label>
-        )}
-      </Alert>
-    </div>
+    <Alert
+      title={title}
+      message={message}
+      confirmLabel={purgeData ? _('Purge & Delete') : _('Delete')}
+      confirmButtonClassName={purgeData ? 'btn-error' : 'btn-warning'}
+      onCancel={onCancel}
+      onConfirm={() => onConfirm(purgeData)}
+    >
+      {showPurgeToggle && (
+        <label
+          className={clsx(
+            'eink-bordered flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors',
+            purgeData
+              ? 'not-eink:border-error/40 not-eink:bg-error/10'
+              : 'not-eink:border-base-content/10 not-eink:bg-base-100/60',
+          )}
+        >
+          <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
+            <span className={clsx('text-sm font-medium', purgeData && 'not-eink:text-error')}>
+              {_('Purge all reading data')}
+            </span>
+            <span className='text-neutral-content text-xs'>
+              {purgeData
+                ? _(
+                    'This permanently erases reading progress, notes, and bookmarks. This cannot be undone.',
+                  )
+                : _('Also erase reading progress, notes, and bookmarks.')}
+            </span>
+          </div>
+          <input
+            type='checkbox'
+            className={clsx('toggle toggle-sm shrink-0', purgeData && 'not-eink:toggle-error')}
+            checked={purgeData}
+            onChange={(e) => setPurgeData(e.target.checked)}
+            aria-label={_('Purge all reading data')}
+          />
+        </label>
+      )}
+    </Alert>
   );
 };
 


### PR DESCRIPTION
## Summary

Fixed the delete confirmation popup's width jumping when toggling the purge option.

https://github.com/user-attachments/assets/edc5db83-121c-4c67-9f4d-d67e2060d8a3

## Fix

Every call site mounts `Alert` as the lone child of a `flex justify-center` bar. A flex item without a definite width sizes to its content, so the alert box measured itself off its own longest line: the delete confirmation resized mid-dialog whenever the purge toggle swapped in longer copy, and no two alerts in the app rendered at the same width.

Added `w-full` to the alert wrapper so the existing `max-w-md sm:max-w-lg md:max-w-xl` caps decide the width instead. This supersedes the original `max-w-md` wrapper around `DeleteConfirmAlert`, which pinned that one component while leaving the other alerts jittery, and pinned it 160px below the shared desktop cap.

Covered by `alert-width-stability.browser.test.tsx`, which measures real laid-out widths in Chromium (jsdom has no layout engine). It fails on `main` with the reported jump.