### PR TITLE
ci: raise nightly and release build timeouts to 90 minutes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,7 +83,7 @@ jobs:
     runs-on: ${{ matrix.config.os }}
     # Backstop only — must stay ABOVE setup time + the per-step timeouts below,
     # because a job-level timeout reports `cancelled` and skips assemble-manifest.
-    timeout-minutes: 75
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -182,7 +182,9 @@ jobs:
       - name: build and sign Android apks
         if: matrix.config.release == 'android'
         shell: bash
-        timeout-minutes: 55
+        # Two full Android builds (universal + arm64) already run ~50min on a
+        # cold cache, so 55 left no headroom. Stays under the job backstop above.
+        timeout-minutes: 75
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/28.2.13676358

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,9 @@ jobs:
             args: '--target aarch64-pc-windows-msvc --bundles nsis'
 
     runs-on: ${{ matrix.config.os }}
-    timeout-minutes: 60
+    # The Android build alone runs ~50min on a cold cache, so 60 was not enough
+    # headroom once setup and signing are counted.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
## Problem

The Android leg runs two full builds (universal and arm64). On a cold cache it takes about 50 minutes, so:

- `release.yml` `build-tauri` had a 60 minute job timeout, and the Android leg kept hitting it.
- `nightly.yml` capped the Android step at 55 minutes. The last successful nightly ran Android 22:12 to 23:04 (52 minutes), 3 minutes under the limit.

## Change

- `release.yml` `build-tauri`: job timeout 60 -> 90.
- `nightly.yml` `build`: job backstop 75 -> 90.
- `nightly.yml` "build and sign Android apks" step: 55 -> 75.

The nightly step timeout has to move as well. It is the binding limit for the Android leg there, so bumping only the job level would not have given the build any extra room.

75 for the step stays below the 90 minute job backstop on purpose: as the file already notes, a job level timeout reports `cancelled`, which makes the `assemble-manifest` guard treat the run as cancelled and skip promoting `latest.json` for every platform (#4906). A hung build has to fail at the step.

Desktop (45) and Windows (30) step timeouts are unchanged. Those legs finish in about 30 minutes.

## Test

YAML parse checked for both workflows. No app code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)