### PR TITLE
fix(opds): stop auto-downloaded books from vanishing on restart

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useOPDSSubscriptions.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useOPDSSubscriptions.test.tsx
@@ -77,8 +77,11 @@ describe('useOPDSSubscriptions', () => {
     useLibraryStore.getState().setLibrary([]);
     // Subsequent checks find nothing new (the entry is in knownEntryIds).
     mockedSync.mockResolvedValue({ newBooks: [], totalNewBooks: 0, errors: [] });
-    mockedSync.mockImplementationOnce(async () => {
+    mockedSync.mockImplementationOnce(async (_catalogs, _appService, _books, onBooksImported) => {
       const book = makeBook('new-book', { downloadedAt: Date.now() });
+      // The real service persists the imported books (via the callback)
+      // before recording their entries in knownEntryIds.
+      await onBooksImported?.([book]);
       return { newBooks: [book], totalNewBooks: 1, errors: [] };
     });
 
@@ -102,11 +105,12 @@ describe('useOPDSSubscriptions', () => {
 
     // Subsequent checks find nothing new (the entry is in knownEntryIds).
     mockedSync.mockResolvedValue({ newBooks: [], totalNewBooks: 0, errors: [] });
-    mockedSync.mockImplementationOnce(async (_catalogs, _appService, books) => {
+    mockedSync.mockImplementationOnce(async (_catalogs, _appService, books, onBooksImported) => {
       const row = books.find((b) => b.hash === 'dead-book')!;
       row.deletedAt = null;
       row.updatedAt = Date.now();
       row.downloadedAt = Date.now();
+      await onBooksImported?.([row]);
       return { newBooks: [row], totalNewBooks: 1, errors: [] };
     });
 

--- a/apps/readest-app/src/__tests__/hooks/useOPDSSubscriptions.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useOPDSSubscriptions.test.tsx
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { Book } from '@/types/book';
+import type { OPDSCatalog } from '@/types/opds';
+import type { SystemSettings } from '@/types/settings';
+
+const saveLibraryBooks = vi.fn<(books: Book[]) => Promise<void>>(async () => {});
+const appService = { saveLibraryBooks };
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService }),
+}));
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: null }),
+}));
+const translate = (key: string) => key;
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => translate,
+}));
+vi.mock('@/services/transferManager', () => ({
+  transferManager: { queueUpload: vi.fn() },
+}));
+vi.mock('@/services/opds', () => ({
+  syncSubscribedCatalogs: vi.fn(),
+}));
+
+import { syncSubscribedCatalogs } from '@/services/opds';
+import { useLibraryStore } from '@/store/libraryStore';
+import { useSettingsStore } from '@/store/settingsStore';
+import { useOPDSSubscriptions } from '@/hooks/useOPDSSubscriptions';
+
+const mockedSync = vi.mocked(syncSubscribedCatalogs);
+
+const makeBook = (hash: string, overrides: Partial<Book> = {}): Book =>
+  ({
+    hash,
+    format: 'EPUB',
+    title: `Book ${hash}`,
+    sourceTitle: `Book ${hash}`,
+    author: 'Author',
+    createdAt: 1000,
+    updatedAt: 1000,
+    uploadedAt: null,
+    downloadedAt: 1000,
+    deletedAt: null,
+    ...overrides,
+  }) as Book;
+
+const catalog = {
+  id: 'cat-1',
+  name: 'Feed',
+  url: 'https://opds.example.com/feed',
+  autoDownload: true,
+} as OPDSCatalog;
+
+const settle = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+beforeEach(() => {
+  useSettingsStore.setState({
+    settings: { opdsCatalogs: [catalog] } as unknown as SystemSettings,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  useLibraryStore.setState({ library: [], libraryLoaded: false, visibleLibrary: [] });
+});
+
+describe('useOPDSSubscriptions', () => {
+  test('persists a genuinely new downloaded book', async () => {
+    useLibraryStore.getState().setLibrary([]);
+    // Subsequent checks find nothing new (the entry is in knownEntryIds).
+    mockedSync.mockResolvedValue({ newBooks: [], totalNewBooks: 0, errors: [] });
+    mockedSync.mockImplementationOnce(async () => {
+      const book = makeBook('new-book', { downloadedAt: Date.now() });
+      return { newBooks: [book], totalNewBooks: 1, errors: [] };
+    });
+
+    renderHook(() => useOPDSSubscriptions());
+    await settle();
+
+    expect(saveLibraryBooks).toHaveBeenCalled();
+    const saved = saveLibraryBooks.mock.lastCall![0];
+    expect(saved.some((b) => b.hash === 'new-book')).toBe(true);
+    expect(useLibraryStore.getState().visibleLibrary.some((b) => b.hash === 'new-book')).toBe(true);
+  });
+
+  test('persists the resurrection of a previously deleted book (#5658)', async () => {
+    // A tombstoned row for the same file is already in the library — the user
+    // deleted the book at some point. importBook resurrects that row IN PLACE
+    // (clears deletedAt on the existing object) and returns it, rather than
+    // returning a fresh row.
+    const tombstoned = makeBook('dead-book', { deletedAt: 123 });
+    useLibraryStore.getState().setLibrary([tombstoned]);
+    expect(useLibraryStore.getState().visibleLibrary).toHaveLength(0);
+
+    // Subsequent checks find nothing new (the entry is in knownEntryIds).
+    mockedSync.mockResolvedValue({ newBooks: [], totalNewBooks: 0, errors: [] });
+    mockedSync.mockImplementationOnce(async (_catalogs, _appService, books) => {
+      const row = books.find((b) => b.hash === 'dead-book')!;
+      row.deletedAt = null;
+      row.updatedAt = Date.now();
+      row.downloadedAt = Date.now();
+      return { newBooks: [row], totalNewBooks: 1, errors: [] };
+    });
+
+    renderHook(() => useOPDSSubscriptions());
+    await settle();
+
+    // The resurrection must reach disk: the subscription state has already
+    // recorded the feed entry as known, so if the library is not saved the
+    // book stays tombstoned on disk and is never downloaded again.
+    expect(saveLibraryBooks).toHaveBeenCalled();
+    const saved = saveLibraryBooks.mock.lastCall![0];
+    const savedRow = saved.find((b) => b.hash === 'dead-book');
+    expect(savedRow?.deletedAt).toBeNull();
+    // And the book must show up on the shelf without a restart.
+    expect(useLibraryStore.getState().visibleLibrary.some((b) => b.hash === 'dead-book')).toBe(
+      true,
+    );
+  });
+});

--- a/apps/readest-app/src/__tests__/services/opds-auto-download.test.ts
+++ b/apps/readest-app/src/__tests__/services/opds-auto-download.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Book } from '@/types/book';
 import type { OPDSCatalog } from '@/types/opds';
 import type { AppService } from '@/types/system';
 import type { OPDSSubscriptionState, PendingItem } from '@/services/opds/types';
@@ -361,5 +362,80 @@ describe('OPDS auto-download orchestrator', () => {
     await syncSubscribedCatalogs(catalogs, appService, []);
 
     expect(downloadFile).toHaveBeenCalledTimes(1);
+  });
+
+  // The module-level loadSubscriptionState mock resolves one SHARED state
+  // object that earlier tests' runs mutate (knownEntryIds grows across
+  // tests); these tests need a pristine state per call.
+  const freshStatePerLoad = () => {
+    vi.mocked(loadSubscriptionState).mockImplementation(async (_appService, catalogId) => ({
+      catalogId,
+      lastCheckedAt: 0,
+      knownEntryIds: [],
+      failedEntries: [],
+    }));
+  };
+
+  it('persists imported books before recording their entries as known (#5658)', async () => {
+    // Once an entry lands in knownEntryIds it is never downloaded again, so
+    // the library rows must be on disk first — a kill between the two writes
+    // must lose at most the "already known" marker, never the books.
+    freshStatePerLoad();
+    const catalogs: OPDSCatalog[] = [
+      { id: 'cat-1', name: 'Shelf', url: 'https://shelf.example.com/opds', autoDownload: true },
+    ];
+    vi.mocked(checkFeedForNewItems).mockResolvedValue([
+      {
+        entryId: 'urn:shelf:1',
+        title: 'Issue 1',
+        acquisitionHref: '/dl/1.epub',
+        mimeType: 'application/epub+zip',
+        baseURL: 'https://shelf.example.com/opds',
+      },
+    ]);
+
+    const callOrder: string[] = [];
+    const onBooksImported = vi.fn(async (books: Book[]) => {
+      expect(books).toHaveLength(1);
+      callOrder.push('persist-library');
+    });
+    vi.mocked(saveSubscriptionState).mockImplementation(async () => {
+      callOrder.push('save-state');
+    });
+
+    const result = await syncSubscribedCatalogs(catalogs, appService, [], onBooksImported);
+
+    expect(result.totalNewBooks).toBe(1);
+    expect(onBooksImported).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(['persist-library', 'save-state']);
+  });
+
+  it('does not record entries as known when persisting the library fails', async () => {
+    freshStatePerLoad();
+    const catalogs: OPDSCatalog[] = [
+      { id: 'cat-1', name: 'Shelf', url: 'https://shelf.example.com/opds', autoDownload: true },
+    ];
+    vi.mocked(checkFeedForNewItems).mockResolvedValue([
+      {
+        entryId: 'urn:shelf:1',
+        title: 'Issue 1',
+        acquisitionHref: '/dl/1.epub',
+        mimeType: 'application/epub+zip',
+        baseURL: 'https://shelf.example.com/opds',
+      },
+    ]);
+
+    const onBooksImported = vi.fn(async () => {
+      throw new Error('disk full');
+    });
+
+    const result = await syncSubscribedCatalogs(catalogs, appService, [], onBooksImported);
+
+    // The catalog run fails and is surfaced, and the entry stays unknown so
+    // the next sync retries the download (imports are idempotent).
+    expect(result.errors).toHaveLength(1);
+    for (const call of vi.mocked(saveSubscriptionState).mock.calls) {
+      expect((call[1] as OPDSSubscriptionState).knownEntryIds).not.toContain('urn:shelf:1');
+    }
   });
 });

--- a/apps/readest-app/src/hooks/useOPDSSubscriptions.ts
+++ b/apps/readest-app/src/hooks/useOPDSSubscriptions.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
+import type { Book } from '@/types/book';
 import { useAuth } from '@/context/AuthContext';
 import { useEnv } from '@/context/EnvContext';
 import { useLibraryStore } from '@/store/libraryStore';
@@ -31,35 +32,43 @@ export function useOPDSSubscriptions() {
       try {
         isSyncingRef.current = true;
         const librarySnapshot = [...useLibraryStore.getState().library];
-        const { newBooks, totalNewBooks, errors } = await syncSubscribedCatalogs(
-          catalogs,
-          appService,
-          librarySnapshot,
-        );
 
-        if (totalNewBooks > 0) {
+        // Runs per catalog, BEFORE the service records the downloaded entries
+        // in knownEntryIds — an entry in there is never downloaded again, so
+        // the library rows must reach disk first or a kill between the two
+        // writes loses the books for good (#5658).
+        const persistImportedBooks = async (imported: Book[]) => {
           const currentLibrary = useLibraryStore.getState().library;
           const existingHashes = new Set(currentLibrary.map((b) => b.hash));
           // Two feed entries can resolve to the same file; importBook returns
           // the same row for both, so dedupe by hash before merging.
-          const importedBooks = [...new Map(newBooks.map((b) => [b.hash, b])).values()];
+          const importedBooks = [...new Map(imported.map((b) => [b.hash, b])).values()];
           const uniqueNewBooks = importedBooks.filter((b) => !existingHashes.has(b.hash));
           // Save even when uniqueNewBooks is empty: a re-downloaded book that
           // was previously deleted is already in currentLibrary as a tombstoned
           // row that importBook resurrected in place (cleared its `deletedAt`).
-          // The feed entry is already persisted in knownEntryIds by this point,
-          // so skipping the save would leave the book tombstoned on disk after
-          // a restart and never downloaded again (#5658).
+          // Skipping the save would leave the book tombstoned on disk after a
+          // restart and never downloaded again (#5658).
           const merged = [...uniqueNewBooks, ...currentLibrary];
           useLibraryStore.getState().setLibrary(merged);
-          appService.saveLibraryBooks(merged);
+          await appService.saveLibraryBooks(merged);
+        };
 
+        const { newBooks, totalNewBooks, errors } = await syncSubscribedCatalogs(
+          catalogs,
+          appService,
+          librarySnapshot,
+          persistImportedBooks,
+        );
+
+        if (totalNewBooks > 0) {
           // Mirror the manual OPDS download path: queue cloud upload for each
           // newly imported book when the user is logged in and Readest Cloud
           // storage is active. Delay so the transfer manager has a chance
           // to finish initializing if this fires right after libraryLoaded.
           const { settings: currentSettings } = useSettingsStore.getState();
           if (user && isReadestCloudStorageActive(currentSettings)) {
+            const importedBooks = [...new Map(newBooks.map((b) => [b.hash, b])).values()];
             const booksToUpload = importedBooks.filter((b) => !b.uploadedAt);
             if (booksToUpload.length > 0) {
               setTimeout(() => {

--- a/apps/readest-app/src/hooks/useOPDSSubscriptions.ts
+++ b/apps/readest-app/src/hooks/useOPDSSubscriptions.ts
@@ -40,20 +40,27 @@ export function useOPDSSubscriptions() {
         if (totalNewBooks > 0) {
           const currentLibrary = useLibraryStore.getState().library;
           const existingHashes = new Set(currentLibrary.map((b) => b.hash));
-          const uniqueNewBooks = newBooks.filter((b) => !existingHashes.has(b.hash));
-          if (uniqueNewBooks.length > 0) {
-            const merged = [...uniqueNewBooks, ...currentLibrary];
-            useLibraryStore.getState().setLibrary(merged);
-            appService.saveLibraryBooks(merged);
-          }
+          // Two feed entries can resolve to the same file; importBook returns
+          // the same row for both, so dedupe by hash before merging.
+          const importedBooks = [...new Map(newBooks.map((b) => [b.hash, b])).values()];
+          const uniqueNewBooks = importedBooks.filter((b) => !existingHashes.has(b.hash));
+          // Save even when uniqueNewBooks is empty: a re-downloaded book that
+          // was previously deleted is already in currentLibrary as a tombstoned
+          // row that importBook resurrected in place (cleared its `deletedAt`).
+          // The feed entry is already persisted in knownEntryIds by this point,
+          // so skipping the save would leave the book tombstoned on disk after
+          // a restart and never downloaded again (#5658).
+          const merged = [...uniqueNewBooks, ...currentLibrary];
+          useLibraryStore.getState().setLibrary(merged);
+          appService.saveLibraryBooks(merged);
 
           // Mirror the manual OPDS download path: queue cloud upload for each
           // newly imported book when the user is logged in and Readest Cloud
           // storage is active. Delay so the transfer manager has a chance
           // to finish initializing if this fires right after libraryLoaded.
           const { settings: currentSettings } = useSettingsStore.getState();
-          if (user && isReadestCloudStorageActive(currentSettings) && uniqueNewBooks.length > 0) {
-            const booksToUpload = uniqueNewBooks.filter((b) => !b.uploadedAt);
+          if (user && isReadestCloudStorageActive(currentSettings)) {
+            const booksToUpload = importedBooks.filter((b) => !b.uploadedAt);
             if (booksToUpload.length > 0) {
               setTimeout(() => {
                 for (const book of booksToUpload) {

--- a/apps/readest-app/src/services/opds/autoDownload.ts
+++ b/apps/readest-app/src/services/opds/autoDownload.ts
@@ -136,6 +136,7 @@ async function syncCatalog(
   catalog: OPDSCatalog,
   appService: AppService,
   books: Book[],
+  onBooksImported?: (newBooks: Book[]) => Promise<void>,
 ): Promise<{ newBooks: Book[]; state: OPDSSubscriptionState }> {
   const state = await loadSubscriptionState(appService, catalog.id);
 
@@ -217,6 +218,16 @@ async function syncCatalog(
     }
   }
 
+  // Persist the imported books BEFORE recording their entries as known: an
+  // entry in knownEntryIds is never downloaded again, so a kill between the
+  // two writes would otherwise lose the library rows for good while the
+  // marker survives (#5658). In the reverse order a kill merely costs a
+  // redundant re-download — imports are idempotent. A failed persist throws
+  // out of the catalog run, leaving the entries unknown for the next sync.
+  if (newBooks.length > 0) {
+    await onBooksImported?.(newBooks);
+  }
+
   state.knownEntryIds = pruneKnownEntryIds([...state.knownEntryIds, ...newKnownIds]);
   state.failedEntries = updatedFailedEntries;
   state.lastCheckedAt = Date.now();
@@ -238,6 +249,7 @@ export async function syncSubscribedCatalogs(
   catalogs: OPDSCatalog[],
   appService: AppService,
   books: Book[],
+  onBooksImported?: (newBooks: Book[]) => Promise<void>,
 ): Promise<SyncResult> {
   const eligible = catalogs.filter((c) => c.autoDownload && !c.disabled);
   if (eligible.length === 0) {
@@ -249,7 +261,7 @@ export async function syncSubscribedCatalogs(
 
   for (const catalog of eligible) {
     try {
-      const { newBooks } = await syncCatalog(catalog, appService, books);
+      const { newBooks } = await syncCatalog(catalog, appService, books, onBooksImported);
       allNewBooks.push(...newBooks);
     } catch (reason) {
       console.error(`OPDS sync: catalog "${catalog.name}" failed:`, reason);


### PR DESCRIPTION
Closes #5658

### The bug

On an install where the OPDS books' hashes match tombstoned library rows (any previously deleted book leaves a `deletedAt` row in library.json), auto-download permanently loses the books:

1. `importBook` finds the tombstoned row by hash and resurrects it **in place** (`existingBook.deletedAt = null`), returning the existing row instead of a fresh one.
2. `useOPDSSubscriptions` built `existingHashes` from the full library *including tombstoned rows*, so the resurrected book was filtered out of `uniqueNewBooks` and `setLibrary`/`saveLibraryBooks` were skipped entirely. The resurrection never reached disk.
3. `syncCatalog` had already persisted the feed entries into `knownEntryIds`, so after a restart the book is tombstoned again (invisible) and never downloaded again.

Reinstalling clears the tombstones, which is why the reporter could not reproduce on a fresh install; the "0.11 -> 0.12 migration" guess is a red herring (the latent bug shipped with auto-download itself in #3844). Not related to the import checkpoint work either: #5615 is not in v0.12.1.

### The fix

- **Persist resurrections** (first commit): mirror the manual OPDS download path, which saves unconditionally after import. Always merge and save the library when a sync imported books, dedupe imported books by hash (two feed entries can resolve to one file), and derive the cloud upload queue from all imported books without `uploadedAt`, so a resurrected book whose cloud copy is gone is re-uploaded.
- **Close the kill window** (second commit): `syncCatalog` saved `knownEntryIds` right after the downloads while the library was only saved after the whole run, fire-and-forget - a swipe-kill in between produced the same "gone and never re-synced" signature via a different path. `syncCatalog` now invokes an `onBooksImported` callback with each catalog's imported books before saving subscription state; the hook merges the books into the store and awaits `saveLibraryBooks` there. Write order is now book files -> library.json -> knownEntryIds, so a kill at any point costs at most a redundant re-download (imports are idempotent). A failed persist aborts the catalog run and leaves the entries unknown for the next sync.

### Tests

- `useOPDSSubscriptions.test.tsx` (new): a resurrected tombstoned book must be persisted with `deletedAt: null` and appear on the shelf; a genuinely new book still persists. The resurrection test fails on the unfixed hook.
- `opds-auto-download.test.ts`: the imported books are persisted before `saveSubscriptionState` (call-order assertion), and a failing persist keeps the entries out of `knownEntryIds`. Both fail without the service change.

Full suite (9078 tests), `pnpm lint`, and `pnpm format:check` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)