### PR TITLE
fix(iap): re-verify restored iOS one-time purchases with the server

### DIFF
--- a/apps/readest-app/src/__tests__/libs/payment/apple-iap-restore-verify.test.ts
+++ b/apps/readest-app/src/__tests__/libs/payment/apple-iap-restore-verify.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { IAPPurchase } from '@/utils/iap';
+
+// An iOS storage purchase whose one-shot client verification never reached the
+// server (network failure, app closed mid-flow) is recorded nowhere: the App
+// Store webhook deliberately ignores one-time purchase events. Restore is the
+// only flow that sees the transaction again, so it must send each restored
+// one-time iOS purchase through the verify endpoint (deduped server-side by
+// original transaction id).
+
+const mocks = vi.hoisted(() => ({
+  getAccessToken: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: mocks.invoke }));
+vi.mock('@/utils/access', () => ({ getAccessToken: mocks.getAccessToken }));
+vi.mock('@/services/environment', () => ({ getNodeAPIBaseUrl: () => 'https://node.test/api' }));
+
+import { verifyApplePurchaseProducts } from '@/libs/payment/iap/client';
+
+const purchaseDate = '2026-08-13T01:17:01Z';
+
+describe('verifyApplePurchaseProducts', () => {
+  beforeEach(() => {
+    mocks.getAccessToken.mockReset();
+    mocks.getAccessToken.mockResolvedValue('jwt');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts each restored iOS one-time purchase to the verify endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const purchases: IAPPurchase[] = [
+      {
+        platform: 'ios',
+        productId: 'com.bilingify.readest.storage.1gb.purchase',
+        transactionId: '450003083195506',
+        originalTransactionId: '450003083195506',
+        purchaseDate,
+      },
+      {
+        platform: 'ios',
+        productId: 'com.bilingify.readest.plus.monthly',
+        transactionId: 't2',
+        originalTransactionId: 't2',
+        purchaseDate,
+      },
+      {
+        platform: 'android',
+        productId: 'com.bilingify.readest.purchase.storage.1gb',
+        orderId: 'GPA.1',
+        purchaseToken: 'tok-1',
+        packageName: 'com.bilingify.readest',
+        purchaseDate,
+      },
+    ];
+
+    await verifyApplePurchaseProducts(purchases);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://node.test/api/apple/iap-verify');
+    expect(init.headers['Authorization']).toBe('Bearer jwt');
+    expect(JSON.parse(init.body)).toEqual({
+      transactionId: '450003083195506',
+      originalTransactionId: '450003083195506',
+    });
+  });
+
+  it('does nothing when no restored purchase is an iOS one-time product', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await verifyApplePurchaseProducts([
+      {
+        platform: 'ios',
+        productId: 'com.bilingify.readest.plus.monthly',
+        transactionId: 't2',
+        originalTransactionId: 't2',
+        purchaseDate,
+      },
+    ]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/app/user/page.tsx
+++ b/apps/readest-app/src/app/user/page.tsx
@@ -20,6 +20,7 @@ import { Toast } from '@/components/Toast';
 import {
   purchaseIAPProduct,
   restoreIAPPurchases,
+  verifyApplePurchaseProducts,
   verifyGooglePurchaseProducts,
   getSubscriptionSuccessUrl as getIAPSubscriptionSuccessUrl,
 } from '@/libs/payment/iap/client';
@@ -201,8 +202,11 @@ const ProfilePage = () => {
       if (purchases.length > 0) {
         // Restored one-time purchases (storage add-ons) may still be
         // unconsumed on Google Play, blocking repurchase; re-verifying lets
-        // the server consume them.
+        // the server consume them. On iOS, restore is the only flow that can
+        // record a purchase whose original verification never reached the
+        // server, so re-verify those too.
         await verifyGooglePurchaseProducts(purchases);
+        await verifyApplePurchaseProducts(purchases);
         const restoredSubscriptions = purchases
           .filter((p) => !isPurchaseProduct(p.productId))
           .sort((a, b) => new Date(b.purchaseDate).getTime() - new Date(a.purchaseDate).getTime());

--- a/apps/readest-app/src/libs/payment/iap/client.ts
+++ b/apps/readest-app/src/libs/payment/iap/client.ts
@@ -72,6 +72,42 @@ export const verifyGooglePurchaseProducts = async (purchases: IAPPurchase[]) => 
   }
 };
 
+// An iOS storage purchase whose one-shot client verification never reached the
+// server (network failure, app closed mid-flow) is recorded nowhere: the App
+// Store webhook deliberately ignores one-time purchase events. Restore is the
+// only flow that sees the transaction again, so re-verify each restored
+// one-time iOS purchase; replays are deduped by original transaction id
+// server-side.
+export const verifyApplePurchaseProducts = async (purchases: IAPPurchase[]) => {
+  const products = purchases.filter(
+    (p) => p.platform === 'ios' && isPurchaseProduct(p.productId) && p.originalTransactionId,
+  );
+  if (products.length === 0) return;
+
+  try {
+    const token = await getAccessToken();
+    if (!token) return;
+
+    await Promise.allSettled(
+      products.map((purchase) =>
+        fetch(`${getNodeAPIBaseUrl()}/apple/iap-verify`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            transactionId: purchase.transactionId || purchase.originalTransactionId,
+            originalTransactionId: purchase.originalTransactionId,
+          }),
+        }),
+      ),
+    );
+  } catch (error) {
+    console.error('Failed to verify restored purchase products:', error);
+  }
+};
+
 export const initializeIAP = async () => {
   const iapService = new IAPService();
   await iapService.initialize();


### PR DESCRIPTION
## Problem

An iOS storage add-on purchase whose one-shot client verification never reaches the server is recorded nowhere, so the user pays but never gets the storage credited. This happened in production: a valid CHN-storefront 1 GB purchase (verified via the App Store Server API order lookup) had no `payments` row and no `storage_purchased_bytes` credit.

Three gaps line up to lose the purchase:

1. Verification is a single client-side fetch from the post-purchase success page to `apple/iap-verify`; a network failure or the app closing mid-flow drops it.
2. `StoreKitManager.swift` finishes `.purchased` transactions even when no JS handler is waiting, so a transaction delivered while the WebView is not listening is silently dropped.
3. The App Store webhook deliberately ignores one-time purchase events (they cannot be attributed to a user without `appAccountToken`), so there is no server-side fallback.

The restore flow was the intended recovery path, but it only re-verified Google Play products (#5545): `verifyGooglePurchaseProducts` filters on `platform === 'android'`. On iOS, Restore Purchases showed a "restored successfully" toast while the server still learned nothing.

## Fix

Add `verifyApplePurchaseProducts`, the iOS mirror of the Google restore re-verify, and call it from `handleIAPRestorePurchase`. Each restored one-time iOS transaction is posted to `apple/iap-verify`, where replays are deduped by `apple_original_transaction_id` and `updateUserStorage` recomputes the plan quota. Affected users now self-heal by tapping Restore Purchases.

Restored StoreKit 1 transactions carry `original?.transactionIdentifier`, which is all the verify route needs.

## Testing

- New unit test `apple-iap-restore-verify.test.ts` (failed before the fix, passes after): restored iOS one-time purchases are posted to the verify endpoint; subscriptions and Android purchases are skipped.
- Full suite: 9076 tests pass; `pnpm lint` and `pnpm format:check` clean.

## Follow-ups (not in this PR)

- Set `appAccountToken` at purchase time so ONE_TIME_CHARGE webhooks become attributable server-side.
- iOS storage SKUs are Non-Consumable in App Store Connect, so the same tier cannot be purchased twice on iOS, contradicting the stacking design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)