### PR TITLE
fix(koplugin): push reading stats in bounded chunks, closes #5666

### DIFF
--- a/apps/readest.koplugin/readest_syncstats.lua
+++ b/apps/readest.koplugin/readest_syncstats.lua
@@ -159,6 +159,14 @@ function SyncStats:applyRemote(books, pages, live_book_id)
     conn:close()
 end
 
+-- Page events per push request. A large backlog (e.g. a fresh push cursor
+-- after pulling the full multi-device history, #5666) cannot go out as one
+-- request: the sync client's 10s total socket timeout kills it, the cursor
+-- never advances, and every retry re-sends the same payload — wedging "Push
+-- stats now" forever. Mirrors PUSH_CHUNK in the app's statsSync.ts and the
+-- server's stat_pages batch size.
+local PUSH_CHUNK = 500
+
 function SyncStats:push(settings, client, interactive)
     -- `settings` is the plain readest_sync data table (see main.lua:init), so
     -- the cursor is a field; persist by saving the whole table back to
@@ -175,33 +183,65 @@ function SyncStats:push(settings, client, interactive)
         end
         return
     end
-    local max_start = cursor
-    for _, p in ipairs(pages) do if p.start_time > max_start then max_start = p.start_time end end
-    logger.dbg("ReadestStats push: dispatching " .. #pages .. " page(s); new cursor would be "
-        .. tostring(max_start))
-    -- pushChanges declares books/notes/configs as required_params (shared /sync
-    -- POST contract, readest-sync-api.json); include them empty so Spore sends
-    -- the request — the server defaults each to [] and processes statBooks/
-    -- statPages independently (apps/readest-app/src/pages/api/sync.ts).
-    client:pushChanges(
-        { books = {}, notes = {}, configs = {}, statBooks = books, statPages = pages },
-        function(success, body, status)
-            logger.dbg("ReadestStats push: response success=" .. tostring(success)
-                .. " status=" .. tostring(status))
-            if success then
-                settings.stats_push_cursor = max_start
-                G_reader_settings:saveSetting("readest_sync", settings)
-                logger.dbg("ReadestStats push: cursor advanced to " .. tostring(max_start))
-                if interactive then
-                    UIManager:show(InfoMessage:new{ text = _("Reading statistics pushed"), timeout = 2 })
-                end
-            else
-                logger.dbg("ReadestStats push: failed, cursor unchanged; body=" .. tostring(body))
-                if interactive then
-                    UIManager:show(InfoMessage:new{ text = _("Failed to push reading statistics"), timeout = 2 })
-                end
+    local book_by_hash = {}
+    for _, b in ipairs(books) do book_by_hash[b.book_hash] = b end
+    local function pushFrom(i)
+        if i > #pages then
+            logger.dbg("ReadestStats push: all " .. #pages .. " page(s) pushed")
+            if interactive then
+                UIManager:show(InfoMessage:new{ text = _("Reading statistics pushed"), timeout = 2 })
             end
-        end)
+            return
+        end
+        local last = math.min(i + PUSH_CHUNK - 1, #pages)
+        -- Never split a start_time across chunks (pages are ordered by
+        -- start_time): advancing the cursor past it would drop the remaining
+        -- same-second events on resume.
+        while last < #pages and pages[last + 1].start_time == pages[last].start_time do
+            last = last + 1
+        end
+        local chunk_pages, chunk_books, seen = {}, {}, {}
+        for j = i, last do
+            local p = pages[j]
+            table.insert(chunk_pages, p)
+            local b = p.book_hash and book_by_hash[p.book_hash]
+            if b and not seen[p.book_hash] then
+                seen[p.book_hash] = true
+                table.insert(chunk_books, b)
+            end
+        end
+        logger.dbg("ReadestStats push: dispatching pages " .. i .. ".." .. last
+            .. " of " .. #pages)
+        -- pushChanges declares books/notes/configs as required_params (shared
+        -- /sync POST contract, readest-sync-api.json); include them empty so
+        -- Spore sends the request — the server defaults each to [] and
+        -- processes statBooks/statPages independently
+        -- (apps/readest-app/src/pages/api/sync.ts).
+        client:pushChanges(
+            { books = {}, notes = {}, configs = {}, statBooks = chunk_books, statPages = chunk_pages },
+            function(success, body, status)
+                logger.dbg("ReadestStats push: response success=" .. tostring(success)
+                    .. " status=" .. tostring(status))
+                if success then
+                    settings.stats_push_cursor = pages[last].start_time
+                    G_reader_settings:saveSetting("readest_sync", settings)
+                    logger.dbg("ReadestStats push: cursor advanced to "
+                        .. tostring(settings.stats_push_cursor))
+                    -- nextTick so the next chunk starts from the event loop:
+                    -- chaining inside the callback would nest a coroutine
+                    -- resume per chunk on the synchronous (non-Turbo) HTTP
+                    -- path and could blow the C stack on a huge backlog.
+                    UIManager:nextTick(function() pushFrom(last + 1) end)
+                else
+                    logger.dbg("ReadestStats push: failed, cursor kept at "
+                        .. tostring(settings.stats_push_cursor) .. "; body=" .. tostring(body))
+                    if interactive then
+                        UIManager:show(InfoMessage:new{ text = _("Failed to push reading statistics"), timeout = 2 })
+                    end
+                end
+            end)
+    end
+    pushFrom(1)
 end
 
 function SyncStats:pull(settings, client, interactive, logout_fn, ui)

--- a/apps/readest.koplugin/spec/syncstats_spec.lua
+++ b/apps/readest.koplugin/spec/syncstats_spec.lua
@@ -3,17 +3,7 @@
 -- applyRemote upsert with max-duration conflict resolution.
 
 local spec_helper = require("spec_helper")
-
--- Minimal KOReader stubs the module pulls at require-time.
-package.preload["ui/widget/infomessage"] = function()
-    return { new = function() return {} end }
-end
-package.preload["ui/uimanager"] = function()
-    return { show = function() end }
-end
-package.preload["readest_i18n"] = function()
-    return function(s) return s end
-end
+local stubs = require("spec.koreader_stubs")
 
 local SQ3 = require("lua-ljsqlite3/init")
 local DataStorage = require("datastorage")
@@ -45,11 +35,38 @@ describe("readest_syncstats", function()
 
     before_each(function()
         spec_helper.reset()
+        stubs.reset()
         os.remove(statsDbPath())
         seedDb()
         package.loaded["readest_syncstats"] = nil
         SyncStats = require("readest_syncstats")
     end)
+
+    -- Chunked pushes chain via UIManager:nextTick; run them to completion.
+    local function drainScheduled()
+        while stubs.UIManager:drain() > 0 do end
+    end
+
+    -- Seed one book plus a page event per entry of `starts` (page = index).
+    local function seedPageEvents(starts)
+        local conn = SQ3.open(statsDbPath())
+        conn:exec("INSERT INTO book (title, authors, md5) VALUES ('T', 'A', 'md5-big');")
+        conn:exec("BEGIN;")
+        local stmt = conn:prepare(
+            "INSERT INTO page_stat_data (id_book, page, start_time, duration, total_pages) VALUES (1, ?, ?, 5, 9);")
+        for i, start in ipairs(starts) do
+            stmt:reset():bind(i, start):step()
+        end
+        stmt:close()
+        conn:exec("COMMIT;")
+        conn:close()
+    end
+
+    local function sequentialStarts(n)
+        local starts = {}
+        for i = 1, n do starts[i] = i end
+        return starts
+    end
 
     it("collects only events past the cursor, joined with md5", function()
         local conn = SQ3.open(statsDbPath())
@@ -339,6 +356,104 @@ describe("readest_syncstats", function()
         assert.is_nil(captured.missing) -- satisfied the pushChanges required_params
         assert.are.equal(2, #captured.payload.statPages)
         assert.are.equal(250, settings.stats_push_cursor) -- max start_time; only set on success
+    end)
+
+    -- #5666: a device with a large backlog (fresh push cursor after pulling the
+    -- full multi-device history) must not send everything in one request — the
+    -- sync client's 10s total socket timeout kills it, the cursor never
+    -- advances, and every retry re-sends the same payload, wedging "Push stats
+    -- now" forever. Mirror the app's statsSync.ts: bounded chunks, cursor
+    -- advanced per successful chunk.
+    it("pushes a large backlog in bounded chunks, advancing the cursor per chunk (#5666)", function()
+        seedPageEvents(sequentialStarts(1001))
+        local settings = { stats_push_cursor = 0 }
+        local calls, cursor_at_call = {}, {}
+        local client = { pushChanges = function(_, payload, cb)
+            table.insert(calls, payload)
+            table.insert(cursor_at_call, settings.stats_push_cursor)
+            cb(true)
+        end }
+
+        SyncStats:push(settings, client, false)
+        drainScheduled()
+
+        assert.are.equal(3, #calls)
+        assert.are.equal(500, #calls[1].statPages)
+        assert.are.equal(500, #calls[2].statPages)
+        assert.are.equal(1, #calls[3].statPages)
+        -- each chunk resumes where the previous one ended
+        assert.are.equal(501, calls[2].statPages[1].start_time)
+        assert.are.equal(1001, calls[3].statPages[1].start_time)
+        -- the cursor advanced after every successful chunk, not once at the end
+        assert.are.same({ 0, 500, 1000 }, cursor_at_call)
+        assert.are.equal(1001, settings.stats_push_cursor)
+        -- every chunk redeclares the stat books its pages reference
+        for _, payload in ipairs(calls) do
+            assert.are.equal(1, #payload.statBooks)
+            assert.are.equal("md5-big", payload.statBooks[1].book_hash)
+        end
+    end)
+
+    it("keeps partial progress when a chunk fails, and a retry resumes from the cursor", function()
+        seedPageEvents(sequentialStarts(1000))
+        local settings = { stats_push_cursor = 0 }
+        local n = 0
+        local client = { pushChanges = function(_, _payload, cb)
+            n = n + 1
+            cb(n ~= 2) -- second chunk fails (e.g. socket timeout)
+        end }
+
+        -- Patch show/new on the instances the module captured (whichever spec
+        -- file's stub won the package.loaded race — see koreader_stubs.lua).
+        local InfoMessage = require("ui/widget/infomessage")
+        local UIManager = require("ui/uimanager")
+        local orig_new, orig_show = InfoMessage.new, UIManager.show
+        local shown = {}
+        InfoMessage.new = function(_, o) return { text = o and o.text } end
+        UIManager.show = function(_, w) table.insert(shown, w and w.text) end
+
+        SyncStats:push(settings, client, true)
+        drainScheduled()
+
+        InfoMessage.new, UIManager.show = orig_new, orig_show
+        assert.are.equal(500, settings.stats_push_cursor) -- first chunk's progress kept
+        assert.are.same({ "Failed to push reading statistics" }, shown)
+
+        -- the retry picks up after the last successful chunk
+        local retry_calls = {}
+        local retry_client = { pushChanges = function(_, payload, cb)
+            table.insert(retry_calls, payload)
+            cb(true)
+        end }
+        SyncStats:push(settings, retry_client, false)
+        drainScheduled()
+
+        assert.are.equal(1, #retry_calls)
+        assert.are.equal(500, #retry_calls[1].statPages)
+        assert.are.equal(501, retry_calls[1].statPages[1].start_time)
+        assert.are.equal(1000, settings.stats_push_cursor)
+    end)
+
+    it("never splits page events sharing a start_time across chunks", function()
+        -- 499 distinct seconds, then 3 events in the same second (split view /
+        -- same-second turns). Cutting between them would advance the cursor
+        -- past the unsent ones and drop them on resume.
+        local starts = sequentialStarts(499)
+        for _ = 1, 3 do starts[#starts + 1] = 500 end
+        seedPageEvents(starts)
+        local settings = { stats_push_cursor = 0 }
+        local calls = {}
+        local client = { pushChanges = function(_, payload, cb)
+            table.insert(calls, payload)
+            cb(true)
+        end }
+
+        SyncStats:push(settings, client, false)
+        drainScheduled()
+
+        assert.are.equal(1, #calls)
+        assert.are.equal(502, #calls[1].statPages)
+        assert.are.equal(500, settings.stats_push_cursor)
     end)
 
     -- The "Push stats now" / "Pull stats now" menu entries call push/pull with


### PR DESCRIPTION
## Problem

Fixes #5666. "Push stats now" in the KOReader plugin failed with "Failed to push reading statistics" on every attempt, on every device with a large stats backlog.

The push collected the entire backlog past `stats_push_cursor` and sent it as ONE `/sync` request, under the sync client's 10s total socket timeout (`readest_syncclient.lua`). The server additionally processes `stat_pages` in sequential 500-row select+upsert batches, so a multi-thousand-event payload cannot complete in time. Because the cursor only advances on success, every retry re-sent the same payload: the push was wedged forever.

The reporter hit this right after upgrading storage: going all-in on cloud sync pulled the complete multi-device reading history into the local `statistics.sqlite3` (the koplugin stats pull is intentionally unpaginated), leaving the push cursor far behind a now-huge backlog on both their Kindle and Kobo.

The Readest app solved this exact problem in `statsSync.ts` (PUSH_CHUNK, per-chunk cursor advance); the koplugin never got that fix.

## Fix

Mirror `statsSync.ts` in `readest_syncstats.lua`:

- send 500 page events per request (matches the app's chunk and the server's batch size), with each chunk redeclaring the stat books its pages reference
- never split events sharing a `start_time` across chunks, since advancing the cursor past it would drop the remaining same-second events on resume
- advance and persist `stats_push_cursor` after EACH successful chunk, so a failed or interrupted push keeps its partial progress and the retry resumes from the cursor instead of restarting
- chain chunks via `UIManager:nextTick`: chaining inside the response callback would nest a coroutine resume per chunk on the synchronous (non-Turbo) HTTP path and could overflow the C stack on a huge backlog

Every attempt now makes durable forward progress, so wedged devices drain their backlog after the plugin update with no user action needed.

## Tests

Three new busted specs (written first, confirmed failing against the old single-request code):

- pushes a 1001-event backlog as 3 chunks, cursor advancing per chunk, each chunk resuming where the previous ended
- keeps partial progress when a chunk fails (cursor stays at the last successful chunk, failure toast shown) and a retry resumes from the cursor
- never splits page events sharing a start_time across chunks

Also switched `syncstats_spec.lua` to the shared `spec/koreader_stubs.lua` preloads; its private `ui/uimanager` / `infomessage` preloads were dead code losing the `package.loaded` race to other spec files in full-suite runs.

- `pnpm test:lua`: 295 successes / 0 failures
- `pnpm lint:lua`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)