### PR TITLE
feat(reader): jump to the start or end of the book with Home/End

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2316,5 +2316,7 @@
   "Only book files are accepted; other file types are declined automatically.": "تُقبل ملفات الكتب فقط؛ وتُرفض أنواع الملفات الأخرى تلقائيًا.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "اكتشاف الأجهزة عبر البث المتعدد غير متاح؛ قد تحتاج الأجهزة إلى تحديث يدوي.",
   "On": "مفعّل",
-  "Not available for this book.": "غير متاح لهذا الكتاب."
+  "Not available for this book.": "غير متاح لهذا الكتاب.",
+  "Start of Book": "بداية الكتاب",
+  "End of Book": "نهاية الكتاب"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2092,5 +2092,7 @@
   "Only book files are accepted; other file types are declined automatically.": "শুধুমাত্র বইয়ের ফাইল গৃহীত হয়; অন্যান্য ফাইল স্বয়ংক্রিয়ভাবে প্রত্যাখ্যাত হয়।",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "মাল্টিকাস্টের মাধ্যমে ডিভাইস খোঁজা যাচ্ছে না; ম্যানুয়ালি রিফ্রেশ করার প্রয়োজন হতে পারে।",
   "On": "চালু",
-  "Not available for this book.": "এই বইয়ের জন্য উপলব্ধ নয়।"
+  "Not available for this book.": "এই বইয়ের জন্য উপলব্ধ নয়।",
+  "Start of Book": "বইয়ের শুরু",
+  "End of Book": "বইয়ের শেষ"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2036,5 +2036,7 @@
   "Only book files are accepted; other file types are declined automatically.": "དེབ་ཡིག་ཆ་ཁོ་ན་དང་ལེན་བྱེད། ཡིག་ཆ་རིགས་གཞན་རང་འགུལ་གྱིས་ཁས་མི་ལེན།",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Multicast བརྒྱུད་སྒྲིག་ཆས་འཚོལ་མི་ཐུབ། ལག་ཐོག་གསར་སྒྱུར་དགོས་སྲིད།",
   "On": "ཁ་ཕྱེ།",
-  "Not available for this book.": "དེབ་འདིར་བེད་སྤྱོད་མི་ཐུབ།"
+  "Not available for this book.": "དེབ་འདིར་བེད་སྤྱོད་མི་ཐུབ།",
+  "Start of Book": "དཔེ་དེབ་ཀྱི་མགོ།",
+  "End of Book": "དཔེ་དེབ་ཀྱི་མཇུག"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2092,5 +2092,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Es werden nur Buchdateien angenommen; andere Dateitypen werden automatisch abgelehnt.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Geräteerkennung über Multicast ist nicht verfügbar; Geräte müssen möglicherweise manuell aktualisiert werden.",
   "On": "Ein",
-  "Not available for this book.": "Für dieses Buch nicht verfügbar."
+  "Not available for this book.": "Für dieses Buch nicht verfügbar.",
+  "Start of Book": "Buchanfang",
+  "End of Book": "Buchende"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2092,5 +2092,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Γίνονται δεκτά μόνο αρχεία βιβλίων· οι άλλοι τύποι αρχείων απορρίπτονται αυτόματα.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Η ανακάλυψη συσκευών μέσω multicast δεν είναι διαθέσιμη· ίσως χρειαστεί χειροκίνητη ανανέωση.",
   "On": "Ενεργό",
-  "Not available for this book.": "Μη διαθέσιμο για αυτό το βιβλίο."
+  "Not available for this book.": "Μη διαθέσιμο για αυτό το βιβλίο.",
+  "Start of Book": "Αρχή βιβλίου",
+  "End of Book": "Τέλος βιβλίου"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2148,5 +2148,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Solo se aceptan archivos de libros; los demás tipos de archivo se rechazan automáticamente.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "La detección de dispositivos por multicast no está disponible; puede que necesites actualizar manualmente.",
   "On": "Activado",
-  "Not available for this book.": "No disponible para este libro."
+  "Not available for this book.": "No disponible para este libro.",
+  "Start of Book": "Inicio del libro",
+  "End of Book": "Fin del libro"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2092,5 +2092,7 @@
   "Only book files are accepted; other file types are declined automatically.": "فقط فایل‌های کتاب پذیرفته می‌شوند؛ سایر انواع فایل به‌طور خودکار رد می‌شوند.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "یافتن دستگاه‌ها از طریق مالتی‌کست در دسترس نیست؛ ممکن است نیاز به به‌روزرسانی دستی باشد.",
   "On": "روشن",
-  "Not available for this book.": "برای این کتاب در دسترس نیست."
+  "Not available for this book.": "برای این کتاب در دسترس نیست.",
+  "Start of Book": "ابتدای کتاب",
+  "End of Book": "انتهای کتاب"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2148,5 +2148,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Seuls les fichiers de livres sont acceptés ; les autres types de fichiers sont refusés automatiquement.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "La découverte d’appareils par multicast est indisponible ; une actualisation manuelle peut être nécessaire.",
   "On": "Activé",
-  "Not available for this book.": "Non disponible pour ce livre."
+  "Not available for this book.": "Non disponible pour ce livre.",
+  "Start of Book": "Début du livre",
+  "End of Book": "Fin du livre"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2148,5 +2148,7 @@
   "Only book files are accepted; other file types are declined automatically.": "רק קובצי ספרים מתקבלים; סוגי קבצים אחרים נדחים אוטומטית.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "גילוי מכשירים באמצעות multicast אינו זמין; ייתכן שיידרש רענון ידני.",
   "On": "פעיל",
-  "Not available for this book.": "לא זמין עבור ספר זה."
+  "Not available for this book.": "לא זמין עבור ספר זה.",
+  "Start of Book": "תחילת הספר",
+  "End of Book": "סוף הספר"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2092,5 +2092,7 @@
   "Only book files are accepted; other file types are declined automatically.": "केवल पुस्तक फ़ाइलें स्वीकार की जाती हैं; अन्य फ़ाइल प्रकार स्वतः अस्वीकार कर दिए जाते हैं।",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "मल्टीकास्ट के माध्यम से डिवाइस खोज उपलब्ध नहीं है; डिवाइस को मैन्युअल रूप से रीफ़्रेश करने की आवश्यकता हो सकती है।",
   "On": "चालू",
-  "Not available for this book.": "इस पुस्तक के लिए उपलब्ध नहीं है।"
+  "Not available for this book.": "इस पुस्तक के लिए उपलब्ध नहीं है।",
+  "Start of Book": "पुस्तक की शुरुआत",
+  "End of Book": "पुस्तक का अंत"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2092,5 +2092,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Csak könyvfájlok fogadhatók; a többi fájltípus automatikusan elutasításra kerül.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "A multicast alapú eszközkeresés nem érhető el; kézi frissítésre lehet szükség.",
   "On": "Be",
-  "Not available for this book.": "Ehhez a könyvhöz nem érhető el."
+  "Not available for this book.": "Ehhez a könyvhöz nem érhető el.",
+  "Start of Book": "Könyv eleje",
+  "End of Book": "Könyv vége"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2036,5 +2036,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Hanya berkas buku yang diterima; jenis berkas lain ditolak secara otomatis.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Penemuan perangkat melalui multicast tidak tersedia; perangkat mungkin perlu disegarkan secara manual.",
   "On": "Aktif",
-  "Not available for this book.": "Tidak tersedia untuk buku ini."
+  "Not available for this book.": "Tidak tersedia untuk buku ini.",
+  "Start of Book": "Awal buku",
+  "End of Book": "Akhir buku"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2148,5 +2148,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Vengono accettati solo file di libri; gli altri tipi di file vengono rifiutati automaticamente.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Il rilevamento dei dispositivi via multicast non è disponibile; potrebbe essere necessario un aggiornamento manuale.",
   "On": "Attivo",
-  "Not available for this book.": "Non disponibile per questo libro."
+  "Not available for this book.": "Non disponibile per questo libro.",
+  "Start of Book": "Inizio del libro",
+  "End of Book": "Fine del libro"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2036,5 +2036,7 @@
   "Only book files are accepted; other file types are declined automatically.": "本のファイルのみ受け入れられ、その他のファイルは自動的に拒否されます。",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "マルチキャストによるデバイス検出が利用できません。手動での更新が必要な場合があります。",
   "On": "オン",
-  "Not available for this book.": "この本では利用できません。"
+  "Not available for this book.": "この本では利用できません。",
+  "Start of Book": "本の先頭",
+  "End of Book": "本の末尾"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2036,5 +2036,7 @@
   "Only book files are accepted; other file types are declined automatically.": "책 파일만 수락되며, 다른 파일 형식은 자동으로 거절됩니다.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "멀티캐스트를 통한 기기 검색을 사용할 수 없습니다. 수동 새로고침이 필요할 수 있습니다.",
   "On": "켜짐",
-  "Not available for this book.": "이 책에서는 사용할 수 없습니다."
+  "Not available for this book.": "이 책에서는 사용할 수 없습니다.",
+  "Start of Book": "책의 처음",
+  "End of Book": "책의 끝"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2036,5 +2036,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Hanya fail buku diterima; jenis fail lain ditolak secara automatik.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Penemuan peranti melalui multicast tidak tersedia; peranti mungkin perlu dimuat semula secara manual.",
   "On": "Hidup",
-  "Not available for this book.": "Tidak tersedia untuk buku ini."
+  "Not available for this book.": "Tidak tersedia untuk buku ini.",
+  "Start of Book": "Permulaan buku",
+  "End of Book": "Penghujung buku"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2092,5 +2092,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Alleen boekbestanden worden geaccepteerd; andere bestandstypen worden automatisch geweigerd.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Apparaatdetectie via multicast is niet beschikbaar; apparaten moeten mogelijk handmatig vernieuwd worden.",
   "On": "Aan",
-  "Not available for this book.": "Niet beschikbaar voor dit boek."
+  "Not available for this book.": "Niet beschikbaar voor dit boek.",
+  "Start of Book": "Begin van het boek",
+  "End of Book": "Einde van het boek"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2204,5 +2204,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Akceptowane są tylko pliki książek; inne typy plików są automatycznie odrzucane.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Wykrywanie urządzeń przez multicast jest niedostępne; może być potrzebne ręczne odświeżenie.",
   "On": "Wł.",
-  "Not available for this book.": "Niedostępne dla tej książki."
+  "Not available for this book.": "Niedostępne dla tej książki.",
+  "Start of Book": "Początek książki",
+  "End of Book": "Koniec książki"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2148,5 +2148,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Somente arquivos de livros são aceitos; outros tipos de arquivo são recusados automaticamente.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "A descoberta de dispositivos por multicast não está disponível; pode ser necessário atualizar manualmente.",
   "On": "Ativado",
-  "Not available for this book.": "Não disponível para este livro."
+  "Not available for this book.": "Não disponível para este livro.",
+  "Start of Book": "Início do livro",
+  "End of Book": "Fim do livro"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2148,5 +2148,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Apenas ficheiros de livros são aceites; outros tipos de ficheiro são recusados automaticamente.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "A deteção de dispositivos por multicast não está disponível; pode ser necessária uma atualização manual.",
   "On": "Ativado",
-  "Not available for this book.": "Não disponível para este livro."
+  "Not available for this book.": "Não disponível para este livro.",
+  "Start of Book": "Início do livro",
+  "End of Book": "Fim do livro"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2148,5 +2148,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Sunt acceptate doar fișierele de cărți; celelalte tipuri de fișiere sunt refuzate automat.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Descoperirea dispozitivelor prin multicast nu este disponibilă; poate fi necesară o reîmprospătare manuală.",
   "On": "Activat",
-  "Not available for this book.": "Indisponibil pentru această carte."
+  "Not available for this book.": "Indisponibil pentru această carte.",
+  "Start of Book": "Începutul cărții",
+  "End of Book": "Sfârșitul cărții"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2204,5 +2204,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Принимаются только файлы книг; другие типы файлов отклоняются автоматически.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Обнаружение устройств через multicast недоступно; может потребоваться обновить список вручную.",
   "On": "Вкл.",
-  "Not available for this book.": "Недоступно для этой книги."
+  "Not available for this book.": "Недоступно для этой книги.",
+  "Start of Book": "Начало книги",
+  "End of Book": "Конец книги"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2092,5 +2092,7 @@
   "Only book files are accepted; other file types are declined automatically.": "පොත් ගොනු පමණක් පිළිගැනේ; වෙනත් ගොනු වර්ග ස්වයංක්‍රීයව ප්‍රතික්ෂේප වේ.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Multicast හරහා උපාංග සොයාගැනීම නොමැත; අතින් නැවුම් කිරීමට සිදු විය හැක.",
   "On": "සක්‍රියයි",
-  "Not available for this book.": "මෙම පොත සඳහා නොමැත."
+  "Not available for this book.": "මෙම පොත සඳහා නොමැත.",
+  "Start of Book": "පොතේ ආරම්භය",
+  "End of Book": "පොතේ අවසානය"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2204,5 +2204,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Sprejete so le datoteke knjig; druge vrste datotek so samodejno zavrnjene.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Odkrivanje naprav prek multicasta ni na voljo; morda bo potrebna ročna osvežitev.",
   "On": "Vklopljeno",
-  "Not available for this book.": "Ni na voljo za to knjigo."
+  "Not available for this book.": "Ni na voljo za to knjigo.",
+  "Start of Book": "Začetek knjige",
+  "End of Book": "Konec knjige"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2092,5 +2092,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Endast bokfiler accepteras; andra filtyper avböjs automatiskt.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Enhetsidentifiering via multicast är inte tillgänglig; enheter kan behöva uppdateras manuellt.",
   "On": "På",
-  "Not available for this book.": "Inte tillgängligt för den här boken."
+  "Not available for this book.": "Inte tillgängligt för den här boken.",
+  "Start of Book": "Bokens början",
+  "End of Book": "Bokens slut"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2092,5 +2092,7 @@
   "Only book files are accepted; other file types are declined automatically.": "புத்தகக் கோப்புகள் மட்டுமே ஏற்கப்படும்; பிற வகைக் கோப்புகள் தானாக நிராகரிக்கப்படும்.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "மல்டிகாஸ்ட் வழியாக சாதனங்களைக் கண்டறிய முடியவில்லை; கைமுறையாகப் புதுப்பிக்க வேண்டியிருக்கலாம்.",
   "On": "இயக்கத்தில்",
-  "Not available for this book.": "இந்தப் புத்தகத்திற்குக் கிடைக்கவில்லை."
+  "Not available for this book.": "இந்தப் புத்தகத்திற்குக் கிடைக்கவில்லை.",
+  "Start of Book": "புத்தகத்தின் தொடக்கம்",
+  "End of Book": "புத்தகத்தின் முடிவு"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2036,5 +2036,7 @@
   "Only book files are accepted; other file types are declined automatically.": "ยอมรับเฉพาะไฟล์หนังสือเท่านั้น ไฟล์ประเภทอื่นจะถูกปฏิเสธโดยอัตโนมัติ",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "ไม่สามารถค้นหาอุปกรณ์ผ่านมัลติแคสต์ได้ อาจต้องรีเฟรชด้วยตนเอง",
   "On": "เปิด",
-  "Not available for this book.": "ไม่พร้อมใช้งานสำหรับหนังสือเล่มนี้"
+  "Not available for this book.": "ไม่พร้อมใช้งานสำหรับหนังสือเล่มนี้",
+  "Start of Book": "ต้นเล่ม",
+  "End of Book": "ท้ายเล่ม"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2092,5 +2092,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Yalnızca kitap dosyaları kabul edilir; diğer dosya türleri otomatik olarak reddedilir.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Multicast üzerinden cihaz bulma kullanılamıyor; cihazların elle yenilenmesi gerekebilir.",
   "On": "Açık",
-  "Not available for this book.": "Bu kitap için kullanılamıyor."
+  "Not available for this book.": "Bu kitap için kullanılamıyor.",
+  "Start of Book": "Kitabın başı",
+  "End of Book": "Kitabın sonu"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2204,5 +2204,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Приймаються лише файли книг; інші типи файлів автоматично відхиляються.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Виявлення пристроїв через multicast недоступне; можливо, знадобиться оновити список вручну.",
   "On": "Увімк.",
-  "Not available for this book.": "Недоступно для цієї книги."
+  "Not available for this book.": "Недоступно для цієї книги.",
+  "Start of Book": "Початок книги",
+  "End of Book": "Кінець книги"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2092,5 +2092,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Faqat kitob fayllari qabul qilinadi; boshqa fayl turlari avtomatik rad etiladi.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Multicast orqali qurilmalarni topib bo‘lmaydi; qo‘lda yangilash kerak bo‘lishi mumkin.",
   "On": "Yoqilgan",
-  "Not available for this book.": "Bu kitob uchun mavjud emas."
+  "Not available for this book.": "Bu kitob uchun mavjud emas.",
+  "Start of Book": "Kitob boshi",
+  "End of Book": "Kitob oxiri"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2036,5 +2036,7 @@
   "Only book files are accepted; other file types are declined automatically.": "Chỉ chấp nhận tệp sách; các loại tệp khác sẽ tự động bị từ chối.",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "Không thể phát hiện thiết bị qua multicast; có thể cần làm mới thủ công.",
   "On": "Bật",
-  "Not available for this book.": "Không khả dụng cho sách này."
+  "Not available for this book.": "Không khả dụng cho sách này.",
+  "Start of Book": "Đầu sách",
+  "End of Book": "Cuối sách"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2036,5 +2036,7 @@
   "Only book files are accepted; other file types are declined automatically.": "仅接受图书文件，其他类型的文件将被自动拒绝。",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "无法通过组播发现设备，可能需要手动刷新。",
   "On": "已开启",
-  "Not available for this book.": "此书不支持此功能。"
+  "Not available for this book.": "此书不支持此功能。",
+  "Start of Book": "书籍开头",
+  "End of Book": "书籍结尾"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2036,5 +2036,7 @@
   "Only book files are accepted; other file types are declined automatically.": "僅接受書籍檔案，其他類型的檔案將被自動拒絕。",
   "Device discovery via multicast is unavailable; devices may need a manual refresh.": "無法透過多播探索裝置，可能需要手動重新整理。",
   "On": "已開啟",
-  "Not available for this book.": "此書不支援此功能。"
+  "Not available for this book.": "此書不支援此功能。",
+  "Start of Book": "書籍開頭",
+  "End of Book": "書籍結尾"
 }

--- a/apps/readest-app/src/__tests__/components/useBookShortcuts.test.tsx
+++ b/apps/readest-app/src/__tests__/components/useBookShortcuts.test.tsx
@@ -15,6 +15,7 @@ const mockView = {
   prev: vi.fn(),
   next: vi.fn(),
   pan: vi.fn(),
+  goToFraction: vi.fn(),
   renderer: {
     scrolled: false,
     setAttribute: vi.fn(),
@@ -23,6 +24,11 @@ const mockView = {
     back: vi.fn(),
     forward: vi.fn(),
   },
+};
+
+const currentViewState = {
+  ttsEnabled: false,
+  inited: true,
 };
 
 const currentViewSettings = {
@@ -38,7 +44,7 @@ const currentViewSettings = {
 vi.mock('@/store/readerStore', () => ({
   useReaderStore: () => ({
     getView: () => mockView,
-    getViewState: () => ({ ttsEnabled: false }),
+    getViewState: () => currentViewState,
     getViewSettings: () => currentViewSettings,
     setViewSettings: vi.fn(),
   }),
@@ -127,6 +133,7 @@ describe('useBookShortcuts', () => {
     currentViewSettings.vertical = false;
     currentViewSettings.rtl = false;
     currentViewSettings.paragraphMode.enabled = false;
+    currentViewState.inited = true;
     mockView.book.dir = 'ltr';
   });
 
@@ -176,6 +183,32 @@ describe('useBookShortcuts', () => {
     shortcutState.actions?.['onGoNext']?.();
 
     expect(mockView.next).toHaveBeenCalledWith(72);
+  });
+
+  it('jumps to the start of the book on Home, ignoring the reading ruler (#5660)', () => {
+    vi.spyOn(eventDispatcher, 'dispatchSync').mockReturnValue(true);
+
+    render(<Harness />);
+    shortcutState.actions?.['onGoBookStart']?.();
+
+    expect(mockView.goToFraction).toHaveBeenCalledWith(0);
+  });
+
+  it('jumps to the end of the book on End (#5660)', () => {
+    render(<Harness />);
+    shortcutState.actions?.['onGoBookEnd']?.();
+
+    expect(mockView.goToFraction).toHaveBeenCalledWith(1);
+  });
+
+  it('ignores book start/end jumps until the view finished initializing (#5660)', () => {
+    currentViewState.inited = false;
+
+    render(<Harness />);
+    shortcutState.actions?.['onGoBookStart']?.();
+    shortcutState.actions?.['onGoBookEnd']?.();
+
+    expect(mockView.goToFraction).not.toHaveBeenCalled();
   });
 
   it('dispatches rsvp-start for the current book when the RSVP shortcut fires', () => {

--- a/apps/readest-app/src/__tests__/helpers/shortcuts.test.ts
+++ b/apps/readest-app/src/__tests__/helpers/shortcuts.test.ts
@@ -56,6 +56,20 @@ describe('TTS navigation shortcuts', () => {
   });
 });
 
+describe('Book start/end shortcuts (#5660)', () => {
+  it('binds Home to the start of the book and End to the end of the book', async () => {
+    const shortcuts = await getDefaults();
+    expect(shortcuts.onGoBookStart.keys).toEqual(['Home']);
+    expect(shortcuts.onGoBookEnd.keys).toEqual(['End']);
+  });
+
+  it('lists both under Navigation so they show up in the shortcuts help', async () => {
+    const shortcuts = await getDefaults();
+    expect(shortcuts.onGoBookStart.section).toBe('Navigation');
+    expect(shortcuts.onGoBookEnd.section).toBe('Navigation');
+  });
+});
+
 describe('Proofread selection shortcut (#4717)', () => {
   it('binds alt+p alongside ctrl+p/cmd+p so it avoids the print conflict', async () => {
     const shortcuts = await getDefaults();

--- a/apps/readest-app/src/app/reader/hooks/useBookShortcuts.ts
+++ b/apps/readest-app/src/app/reader/hooks/useBookShortcuts.ts
@@ -187,6 +187,19 @@ const useBookShortcuts = ({ sideBarBookKey, bookKeys }: UseBookShortcutsProps) =
     getView(sideBarBookKey)?.next(distance);
   };
 
+  // Home / End (#5660). The view is registered in the store before its opening
+  // navigation runs, so a jump fired in that window is discarded by it anyway —
+  // after needlessly paging in the far end of the book. Wait for `inited`.
+  const goBookStart = () => {
+    if (!getViewState(sideBarBookKey ?? '')?.inited) return;
+    getView(sideBarBookKey)?.goToFraction(0);
+  };
+
+  const goBookEnd = () => {
+    if (!getViewState(sideBarBookKey ?? '')?.inited) return;
+    getView(sideBarBookKey)?.goToFraction(1);
+  };
+
   const goBack = () => {
     getView(sideBarBookKey)?.history.back();
   };
@@ -428,6 +441,8 @@ const useBookShortcuts = ({ sideBarBookKey, bookKeys }: UseBookShortcutsProps) =
       onGoNextSection: goNextSection,
       onGoLeftSection: goLeftSection,
       onGoRightSection: goRightSection,
+      onGoBookStart: goBookStart,
+      onGoBookEnd: goBookEnd,
       onGoBack: goBack,
       onGoForward: goForward,
       onZoomIn: zoomIn,

--- a/apps/readest-app/src/helpers/shortcuts.ts
+++ b/apps/readest-app/src/helpers/shortcuts.ts
@@ -260,6 +260,16 @@ const DEFAULT_SHORTCUTS = {
     description: _('Scroll Half Page Up'),
     section: 'Navigation',
   },
+  onGoBookStart: {
+    keys: ['Home'],
+    description: _('Start of Book'),
+    section: 'Navigation',
+  },
+  onGoBookEnd: {
+    keys: ['End'],
+    description: _('End of Book'),
+    section: 'Navigation',
+  },
   onGoBack: {
     keys: ['shift+ArrowLeft', 'shift+h', 'alt+ArrowLeft'],
     description: _('Go Back'),


### PR DESCRIPTION
Closes #5660.

`Home` and `End` had no binding in the reader. This adds them to the Navigation section of the shortcut table:

| Action | Key | Description shown in `Shift+?` |
| --- | --- | --- |
| `onGoBookStart` | `Home` | Start of Book |
| `onGoBookEnd` | `End` | End of Book |

Both route through `view.goToFraction(0 | 1)`, which covers reflowable and fixed-layout books in paginated and scrolled modes with one call.

The handlers wait for the view's `inited` flag. `setFoliateView` registers the view between `view.open()` and `view.init({ lastLocation })`, so a jump fired in that window is discarded by the opening navigation anyway, after needlessly paging in the far end of the book. On a large PDF that is a visible stall for nothing.

Strings extracted and translated across all 33 locales.

## Verification

`pnpm test` (9085 passed), `pnpm lint`, `pnpm format:check` all clean. No `src-tauri/` or koplugin changes.

Driven in Chrome against `pnpm dev-web`:

| Case | Home | End |
| --- | --- | --- |
| EPUB paginated, focus on the top document | 11/68 to 1/68 | to the last page (`next()` confirmed a no-op there) |
| EPUB paginated, focus inside the book iframe | n/a | forwarded as `iframe-keydown`, jumped correctly |
| EPUB scrolled mode | to 1/68 | to 68/68 |
| PDF (fixed layout) | to page 1 of 10 | to page 10 of 10 |
| Typing in the search box | no navigation (existing input guard) | n/a |

Both entries render under Navigation in the keyboard shortcuts dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)