### PR TITLE
fix(sync): never show a future Last Synced time from a clock-skewed peer

### DIFF
--- a/apps/readest-app/src/__tests__/utils/time.test.ts
+++ b/apps/readest-app/src/__tests__/utils/time.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import dayjs from 'dayjs';
-import { initDayjs } from '@/utils/time';
+import { clampSyncTimeForDisplay, initDayjs } from '@/utils/time';
 
 describe('initDayjs', () => {
   beforeEach(() => {
@@ -131,5 +131,19 @@ describe('initDayjs', () => {
     initDayjs('ja');
     const formatted = dayjs('2024-01-15').format('dddd');
     expect(formatted).toBe('月曜日');
+  });
+});
+
+describe('clampSyncTimeForDisplay', () => {
+  it('returns a past sync timestamp unchanged', () => {
+    const past = Date.now() - 60_000;
+    expect(clampSyncTimeForDisplay(past)).toBe(past);
+  });
+
+  it('clamps a future timestamp from a clock-skewed peer to now (#5661)', () => {
+    const before = Date.now();
+    const clamped = clampSyncTimeForDisplay(before + 3_600_000);
+    expect(clamped).toBeGreaterThanOrEqual(before);
+    expect(clamped).toBeLessThanOrEqual(Date.now());
   });
 });

--- a/apps/readest-app/src/app/library/components/SettingsMenu.tsx
+++ b/apps/readest-app/src/app/library/components/SettingsMenu.tsx
@@ -41,6 +41,7 @@ import {
 import { selectDirectory } from '@/utils/bridge';
 import { nextThemeMode } from '@/utils/ambientLight';
 import dayjs from 'dayjs';
+import { clampSyncTimeForDisplay } from '@/utils/time';
 import UserAvatar from '@/components/UserAvatar';
 import MenuItem from '@/components/MenuItem';
 import Quota from '@/components/Quota';
@@ -304,7 +305,7 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
   const syncRowLabel = providerLastError
     ? _('Sync failed')
     : lastSyncTime
-      ? _('Synced {{time}}', { time: dayjs(lastSyncTime).fromNow() })
+      ? _('Synced {{time}}', { time: dayjs(clampSyncTimeForDisplay(lastSyncTime)).fromNow() })
       : _('Never synced');
 
   return (

--- a/apps/readest-app/src/app/reader/components/SyncInfoDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/SyncInfoDialog.tsx
@@ -3,6 +3,7 @@ import Dialog from '@/components/Dialog';
 import { useTranslation } from '@/hooks/useTranslation';
 import { BookMetadata } from '@/libs/document';
 import { formatLocaleDateTime, getMetadataHashInfo } from '@/utils/book';
+import { clampSyncTimeForDisplay } from '@/utils/time';
 
 interface SyncInfoDialogProps {
   isOpen: boolean;
@@ -33,7 +34,9 @@ const SyncInfoDialog: React.FC<SyncInfoDialogProps> = ({
   const info = metadata ? getMetadataHashInfo(metadata) : undefined;
   const displayHash = storedMetaHash || info?.metaHash || '';
   const placeholder = _('(none)');
-  const lastSyncedLabel = lastSyncedAt ? formatLocaleDateTime(lastSyncedAt) : _('Never synced');
+  const lastSyncedLabel = lastSyncedAt
+    ? formatLocaleDateTime(clampSyncTimeForDisplay(lastSyncedAt))
+    : _('Never synced');
 
   return (
     <Dialog

--- a/apps/readest-app/src/app/reader/components/ViewMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/ViewMenu.tsx
@@ -36,6 +36,7 @@ import { eventDispatcher } from '@/utils/event';
 import { getMaxInlineSize } from '@/utils/config';
 import { nextThemeMode } from '@/utils/ambientLight';
 import dayjs from 'dayjs';
+import { clampSyncTimeForDisplay } from '@/utils/time';
 import { saveViewSettings } from '@/helpers/settings';
 import { tauriHandleToggleFullScreen } from '@/utils/window';
 import MenuItem from '@/components/MenuItem';
@@ -473,7 +474,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
             ? _('Sign in to Sync')
             : lastSyncTime
               ? _('Synced {{time}}', {
-                  time: dayjs(lastSyncTime).fromNow(),
+                  time: dayjs(clampSyncTimeForDisplay(lastSyncTime)).fromNow(),
                 })
               : _('Never synced')
         }

--- a/apps/readest-app/src/utils/time.ts
+++ b/apps/readest-app/src/utils/time.ts
@@ -35,6 +35,12 @@ export const initDayjs = (locale: string) => {
   dayjs.extend(relativeTime);
 };
 
+// "Last synced" labels show the newest pulled record's timestamp, which is the
+// AUTHORING device's clock — a clock-skewed peer can stamp the future and the
+// label would read "Synced in an hour" (#5661). Clamp to local now at display
+// time only; the record-derived pull cursor must never be clamped.
+export const clampSyncTimeForDisplay = (time: number): number => Math.min(time, Date.now());
+
 // Clock-style playback time for the TTS scrubber: m:ss below one hour,
 // h:mm:ss above. Pass forceHours so both labels of a row share the format
 // chosen by the total's magnitude and the row never re-layouts when the


### PR DESCRIPTION
## Problem

Closes #5661, a reader's tablet shows "Synced in an hour" and "LAST SYNCED" an hour in the future whenever their phone syncs first.

The Last Synced labels display the newest pulled record's `updated_at`, which is stamped by the **authoring** device's clock. A peer whose epoch clock is ahead (typically a mis-set time zone compensated by a manually adjusted clock, so the wall display still looks correct) makes every other device render a sync time in the future.

## Fix

Add `clampSyncTimeForDisplay` (`Math.min(time, Date.now())`) and apply it at the three display sites:

- reader Sync Info dialog (absolute "LAST SYNCED" timestamp)
- reader view menu ("Synced {{time}}" relative label)
- library settings menu sync row

The record-derived pull cursor is intentionally left unclamped, and server-side last-writer-wins is unchanged; a skewed peer's records still win conflicts until clocks catch up. This PR only guarantees the label never claims the device synced in the future.

## Testing

- New unit tests for `clampSyncTimeForDisplay` (past passes through, future clamps to now), written first and confirmed failing before the fix
- `pnpm test`: 9082 passed / 16 skipped
- `pnpm lint`, `pnpm format:check`: clean

Ref #5661

🤖 Generated with [Claude Code](https://claude.com/claude-code)