### PR TITLE
fix(reader): update progress during Auto Scroll and put slider overlay values on top

### DIFF
--- a/apps/readest-app/src/__tests__/components/slider-overlays.test.tsx
+++ b/apps/readest-app/src/__tests__/components/slider-overlays.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import AutoScrollSpeedOverlay from '@/app/reader/components/AutoScrollSpeedOverlay';
+import BrightnessOverlay from '@/app/reader/components/BrightnessOverlay';
+
+// Issue #5635: while the swipe gesture adjusts the value, the finger sits on
+// or below the capsule, hiding a readout placed under the slider. The value
+// must sit at the top of the slider and the icon at the bottom.
+const expectValueAboveIcon = (root: HTMLElement, valueText: string) => {
+  const capsule = root.querySelector('.flex-col')!;
+  expect(capsule).not.toBeNull();
+  const children = Array.from(capsule.children);
+  const valueIdx = children.findIndex((c) => c.textContent === valueText);
+  const trackIdx = children.findIndex((c) => c.classList.contains('h-40'));
+  const iconIdx = children.findIndex((c) => c.tagName.toLowerCase() === 'svg');
+  expect(valueIdx).toBeGreaterThanOrEqual(0);
+  expect(trackIdx).toBeGreaterThanOrEqual(0);
+  expect(iconIdx).toBeGreaterThanOrEqual(0);
+  expect(valueIdx).toBeLessThan(trackIdx);
+  expect(trackIdx).toBeLessThan(iconIdx);
+};
+
+describe('vertical slider overlays', () => {
+  afterEach(cleanup);
+
+  it('shows the speed value above the slider and the icon below it', () => {
+    const { container } = render(<AutoScrollSpeedOverlay visible speed={120} />);
+    expectValueAboveIcon(container, '120%');
+  });
+
+  it('shows the brightness value above the slider and the icon below it', () => {
+    const { container } = render(<BrightnessOverlay visible level={0.4} />);
+    expectValueAboveIcon(container, '40');
+  });
+});

--- a/apps/readest-app/src/__tests__/document/paginator-scrolled.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/paginator-scrolled.browser.test.ts
@@ -491,4 +491,57 @@ describe('Paginator scrolled mode (browser)', () => {
     expect(last).toBeDefined();
     expect(last!.index).toBe(next);
   });
+
+  // Regression for issue #5635: the scrolled-mode relocate is a trailing-only
+  // debounce, so a scroll that never pauses (the Auto Scroll reading mode)
+  // reset the timer on every frame and reading progress never updated until
+  // the scrolling stopped. A continuous scroll burst must emit periodic
+  // 'scroll' relocates while it is still in progress.
+  it('should emit periodic relocates while a continuous scroll never pauses', async () => {
+    paginator = createPaginator();
+    paginator.open(book);
+    paginator.setAttribute('flow', 'scrolled');
+
+    const sections = book.sections!;
+    // A tall section so the whole burst stays inside it.
+    const K = sections.findIndex((s) => s.linear !== 'no' && (s.size ?? 0) > 8000);
+    expect(K).toBeGreaterThanOrEqual(0);
+
+    const stabilized = waitForStabilized(paginator);
+    await paginator.goTo({ index: K, anchor: 0 });
+    await stabilized;
+    await waitForFillComplete(paginator);
+
+    // Freeze the loaded set so preloads don't interleave with the burst.
+    paginator.setAttribute('no-preload', '');
+
+    const container = paginator.shadowRoot!.getElementById('container')!;
+
+    // Consume #justAnchored from the navigation with isolated nudges whose
+    // trailing debounce settles before the burst starts.
+    for (const top of [10, 20]) {
+      container.scrollTop = top;
+      container.dispatchEvent(new Event('scroll'));
+      await new Promise((r) => setTimeout(r, 350));
+    }
+
+    let during = 0;
+    const onReloc = (e: Event) => {
+      if ((e as CustomEvent).detail.reason === 'scroll') during += 1;
+    };
+    paginator.addEventListener('relocate', onReloc as EventListener);
+
+    // Continuous burst for 2.5s with no pause ever longer than the 250ms
+    // debounce, mimicking Auto Scroll's per-frame steps.
+    const burstStart = Date.now();
+    while (Date.now() - burstStart < 2500) {
+      container.scrollTop += 4;
+      container.dispatchEvent(new Event('scroll'));
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    // Snapshot before the trailing debounce can fire: only relocates emitted
+    // while the scrolling was still in progress count.
+    paginator.removeEventListener('relocate', onReloc as EventListener);
+    expect(during).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/apps/readest-app/src/app/reader/components/AutoScrollSpeedOverlay.tsx
+++ b/apps/readest-app/src/app/reader/components/AutoScrollSpeedOverlay.tsx
@@ -43,14 +43,14 @@ const AutoScrollSpeedOverlay: React.FC<AutoScrollSpeedOverlayProps> = ({ visible
           'bg-base-100/90 not-eink:shadow-md',
         )}
       >
-        <MdSpeed className='text-base-content h-4 w-4' />
+        <span className='text-base-content text-xs tabular-nums'>{speed}%</span>
         <div className='bg-base-content/20 relative h-40 w-1.5 overflow-hidden rounded-full'>
           <div
             className='bg-base-content absolute bottom-0 left-0 w-full rounded-full'
             style={{ height: `${fillPercent}%` }}
           />
         </div>
-        <span className='text-base-content text-xs tabular-nums'>{speed}%</span>
+        <MdSpeed className='text-base-content h-4 w-4' />
       </div>
     </div>
   );

--- a/apps/readest-app/src/app/reader/components/BrightnessOverlay.tsx
+++ b/apps/readest-app/src/app/reader/components/BrightnessOverlay.tsx
@@ -45,14 +45,14 @@ const BrightnessOverlay: React.FC<BrightnessOverlayProps> = ({ visible, level })
           'bg-base-100/90 not-eink:shadow-md',
         )}
       >
-        <PiSun className='text-base-content h-4 w-4' />
+        <span className='text-base-content text-xs tabular-nums'>{valuePercent}</span>
         <div className='bg-base-content/20 relative h-40 w-1.5 overflow-hidden rounded-full'>
           <div
             className='bg-base-content absolute bottom-0 left-0 w-full rounded-full'
             style={{ height: `${fillPercent}%` }}
           />
         </div>
-        <span className='text-base-content text-xs tabular-nums'>{valuePercent}</span>
+        <PiSun className='text-base-content h-4 w-4' />
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes items 2 and 3 of #5635 (item 1, jitter, is tracked separately in the issue).

## Progress doesn't update while scrolling

The scrolled-mode relocate in the foliate paginator sits behind a 250ms trailing debounce. Auto Scroll steps the container every frame, so the timer reset forever and the percentage / time remaining only updated once scrolling paused. The paginator now forces a relocate at most once per second while an unbroken run of scroll events lasts (readest/foliate-js#72); the trailing debounce still reports the final position. Finger drags keep today's behavior (report on release), matching the preload skip rationale from #4785.

- Submodule bump to readest/foliate-js@fd91451, the squash-merged main tip of readest/foliate-js#72.
- New regression test: a 2.5s continuous scroll burst must emit at least two 'scroll' relocates while still in progress (was zero).

## Speed / brightness overlay readout hidden by the finger

While the swipe gesture adjusts the value, the finger sits on or below the edge capsule, hiding the readout under the slider. The value label now sits at the top of the slider and the icon at the bottom, in both the Auto Scroll speed overlay and the brightness overlay, with a DOM-order unit test.

## Verification

- `pnpm test`: 9089 passed
- `pnpm test:browser`: 357 passed (includes the new regression test)
- `pnpm lint` and `pnpm format:check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
