### PR TITLE
feat(reader): scroll Auto Scroll smoothly at low speeds

### DIFF
--- a/apps/readest-app/src/__tests__/reader/utils/autoscroller.test.ts
+++ b/apps/readest-app/src/__tests__/reader/utils/autoscroller.test.ts
@@ -152,9 +152,11 @@ const createPacedHarness = () => {
   let frameCb: FrameRequestCallback | null = null;
   let time = 0;
   const deltas: number[] = [];
+  const subpixels: number[] = [];
   const onStop = vi.fn();
   const scroller = new PacedScroller({
     scrollBy: (delta) => deltas.push(delta),
+    onSubpixel: (offset) => subpixels.push(offset),
     onStop,
     raf: (cb) => {
       frameCb = cb;
@@ -176,7 +178,7 @@ const createPacedHarness = () => {
   };
   const scrolledTotal = () => deltas.reduce((a, b) => a + b, 0);
   const hasPendingFrame = () => frameCb !== null;
-  return { scroller, deltas, onStop, step, advanceIdle, scrolledTotal, hasPendingFrame };
+  return { scroller, deltas, subpixels, onStop, step, advanceIdle, scrolledTotal, hasPendingFrame };
 };
 
 describe('PacedScroller', () => {
@@ -188,6 +190,31 @@ describe('PacedScroller', () => {
     expect(scroller.active).toBe(true);
     expect(scroller.paused).toBe(false);
     expect(hasPendingFrame()).toBe(true);
+  });
+
+  // Scroll offsets quantize to whole CSS pixels in both Blink and WebKit, so a
+  // slow session only emits a scrollBy every few frames. The carried remainder
+  // is reported every frame so the caller can render the motion in between.
+  test('reports the carried sub-pixel remainder on every frame', () => {
+    const { scroller, step, deltas, subpixels } = createPacedHarness();
+    scroller.start(5); // 5px/s: one whole pixel every 200ms
+    step(50);
+    step(50);
+    step(50);
+    expect(deltas).toEqual([]);
+    expect(subpixels).toEqual([0.25, 0.5, 0.75]);
+    step(50);
+    expect(deltas).toEqual([1]);
+    expect(subpixels.at(-1)).toBeCloseTo(0);
+  });
+
+  test('clears the sub-pixel remainder when the session stops', () => {
+    const { scroller, step, subpixels } = createPacedHarness();
+    scroller.start(5);
+    step(50);
+    expect(subpixels.at(-1)).toBeCloseTo(0.25);
+    scroller.stop();
+    expect(subpixels.at(-1)).toBe(0);
   });
 
   test('scrolls at the configured velocity', () => {

--- a/apps/readest-app/src/app/reader/hooks/useAutoScroll.ts
+++ b/apps/readest-app/src/app/reader/hooks/useAutoScroll.ts
@@ -83,6 +83,16 @@ export const useAutoScroll = (
           stallStartRef.current = null;
         }
       },
+      // Whole pixels are all a scroll offset can express, so the remainder is
+      // rendered as a sub-pixel transform on the scrollport. Without it a slow
+      // session visibly steps: at the minimum speed of 5px/s the page jumps a
+      // whole pixel every 200ms instead of gliding.
+      onSubpixel: (offset) => {
+        const renderer = viewRef.current?.renderer;
+        if (!renderer) return;
+        const sign = renderer.scrollProp === 'scrollLeft' ? -1 : 1;
+        renderer.subpixelOffset = sign * offset;
+      },
       onStop: () => {
         setActive(false);
         setPaused(false);

--- a/apps/readest-app/src/app/reader/utils/autoscroller.ts
+++ b/apps/readest-app/src/app/reader/utils/autoscroller.ts
@@ -18,6 +18,9 @@ export const AUTOSCROLL_MAX_VELOCITY = 4000;
 
 interface AutoscrollerOptions {
   scrollBy: (delta: number) => void;
+  // Called every frame with the remainder still carried between whole-pixel
+  // steps, so the caller can render the motion the scroll position cannot.
+  onSubpixel?: (offset: number) => void;
   onStop?: () => void;
   raf?: (cb: FrameRequestCallback) => number;
   caf?: (id: number) => void;
@@ -167,7 +170,9 @@ export class PacedScroller {
     if (!this.#active) return;
     this.#active = false;
     this.#paused = false;
+    this.#residual = 0;
     this.#cancelFrame();
+    this.#opts.onSubpixel?.(0);
     this.#opts.onStop?.();
   }
 
@@ -196,6 +201,7 @@ export class PacedScroller {
       // scrollBy may stop the session (e.g. the book ended); don't re-arm then.
       if (!this.#active || this.#paused) return;
     }
+    this.#opts.onSubpixel?.(this.#residual);
     this.#frameId = (this.#opts.raf ?? requestAnimationFrame)((t) => this.#tick(t));
   }
 }

--- a/apps/readest-app/src/types/view.ts
+++ b/apps/readest-app/src/types/view.ts
@@ -26,6 +26,9 @@ export interface Renderer extends HTMLElement {
   atStart: boolean;
   atEnd: boolean;
   containerPosition: number;
+  // Sub-pixel remainder of the scroll position, rendered as a transform on the
+  // scrollport because scroll offsets themselves quantize to whole CSS pixels.
+  subpixelOffset: number;
   scrollProp: 'scrollLeft' | 'scrollTop';
   sideProp: 'width' | 'height';
   pageColors?: {


### PR DESCRIPTION
Auto Scroll stepped visibly instead of gliding, worst at the slow end.

### Cause

Scroll offsets quantize to whole CSS pixels in both engines, measured at dpr 2:

| | `scrollTop = 100.5` reads back | min rendered step |
|---|---|---|
| Chromium | 101 | 1 CSS px |
| WebKit (desktop and iOS 18.5) | 100 | 1 CSS px |

A read-modify-write of `+0.1` per frame never moves at all, which is why `PacedScroller` already carried the fraction itself and only emitted whole pixels. But a whole pixel is the smallest thing a scroll offset can render, so at the minimum speed (`AUTO_SCROLL_BASE_PX_PER_SEC` 20 x 25% = **5px/s**) the page jumps one pixel every 200ms. Even at 100% it steps every 50ms. No amount of scroll-side tuning improves this.

### Fix

`PacedScroller` now reports the carried remainder every frame, and the session renders it through the paginator's new `subpixelOffset` (readest/foliate-js#74): a composited transform on the scrollport, always under one pixel.

Whole pixels stay in the scroll position, so progress, relocate, preloading, annotations and the reading ruler all keep seeing a position within 1px of truth. The transform is applied to the scrollport rather than its children on purpose, since a transform on the children shrinks the container's scrollable overflow and desynchronizes the scroll math, which is what caused #5663. The offset is cleared when the session stops.

### What each engine actually renders

Measured on rasterized pixels, not geometry: a black bar moved in ten 0.1px steps, with the intensity weighted centroid of its antialiased edge recovered from screenshots.

| engine | frames that moved | step size |
|---|---|---|
| WebKit (iOS 18.5, macOS) | 10 / 10 | ~0.2 device px, continuous |
| Chromium | 2 / 10 | 1 device px |

**WebKit becomes fully continuous. Blink still snaps composited layers to whole device pixels**, so Chrome / Android WebView / WebView2 improve from a 1 CSS px step to a 1 device px step: 2x finer at dpr 2, ~3x at dpr 3. Better everywhere, no regression anywhere, but only WebKit is truly smooth.

The snap is not a matter of transform syntax. `translateY`, `translateY + translateZ(0)` and `translate3d` all give identical 1 device px steps in Blink; a plain `top` offset is worse still (2 device px). A compositor driven WAAPI animation does interpolate sub-pixel in Blink, but driving the remainder that way needs a scroll resync at every whole pixel (every 200ms at the minimum speed), which risks trading a small steady step for a visible periodic hitch. Left as a possible follow-up rather than folded in here.

### Verification

iPhone XR / iOS 18.5, 5px/s for 2s, recording the on-screen position of a marker every frame:

| | distinct on-screen positions | largest single jump | distance |
|---|---|---|---|
| before | 11 of 122 frames | 1 px | 10 px |
| after | 121 of 121 frames | 0.105 px | 10 px |

Same distance travelled, so speeds are unchanged; only the granularity.

End to end in the web app under WebKit, driving the real UI (Shift+J then Shift+A): 150 of 150 frames distinct, largest jump 0.52px, container transform `translateY(-0.9024px)`, and after stopping `subpixelOffset` is 0 with the inline transform cleared.

`pnpm test` 9091 passed (2 new `PacedScroller` tests covering the per-frame remainder and the reset on stop), `pnpm lint` clean. No Rust or Lua changes.

Note on ordering: this bumps the foliate-js submodule, as does the still-open #5678. Whichever merges second needs a one-line pointer resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
