### PR TITLE
feat(tts): scroll to the current chapter when opening Offline Audio

### DIFF
--- a/apps/readest-app/src/__tests__/components/tts/TTSChaptersView.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSChaptersView.test.tsx
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => (key: string, opts?: Record<string, unknown>) =>
     opts ? Object.entries(opts).reduce((s, [k, v]) => s.replace(`{{${k}}}`, String(v)), key) : key,
@@ -39,7 +41,10 @@ const makeDownloads = (overrides: Partial<UseTTSDownloadsResult> = {}): UseTTSDo
 });
 
 describe('TTSChaptersView', () => {
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+  });
 
   test('lists every chapter with a download control', () => {
     render(
@@ -88,5 +93,22 @@ describe('TTSChaptersView', () => {
   test('marks the currently playing chapter', () => {
     render(<TTSChaptersView downloads={makeDownloads()} activeSectionIndex={1} isEink={false} />);
     expect(screen.getByLabelText('Now playing')).toBeTruthy();
+  });
+
+  test('scrolls instantly to the playing chapter on open', () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    render(<TTSChaptersView downloads={makeDownloads()} activeSectionIndex={1} isEink={false} />);
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'instant', block: 'start' });
+  });
+
+  test('does not scroll when no chapter is playing', () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    render(
+      <TTSChaptersView downloads={makeDownloads()} activeSectionIndex={null} isEink={false} />,
+    );
+    expect(scrollIntoView).not.toHaveBeenCalled();
   });
 });

--- a/apps/readest-app/src/app/reader/components/tts/TTSChaptersView.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSChaptersView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import clsx from 'clsx';
 import { MdGraphicEq } from 'react-icons/md';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -27,6 +27,14 @@ const TTSChaptersView: React.FC<TTSChaptersViewProps> = ({
   const completeCount = chapters.filter((c) => statusOf(c) === 'complete').length;
   const anyIncomplete = completeCount < chapters.length;
   const busy = download.activeChapterKey !== null;
+
+  const activeRowRef = useRef<HTMLDivElement | null>(null);
+
+  // Opening the list jumps straight to the currently playing chapter so the
+  // current and next chapters are in view without manual scrolling.
+  useEffect(() => {
+    activeRowRef.current?.scrollIntoView?.({ behavior: 'instant', block: 'start' });
+  }, []);
 
   return (
     <div className='flex w-full flex-col pb-4'>
@@ -67,6 +75,7 @@ const TTSChaptersView: React.FC<TTSChaptersViewProps> = ({
           return (
             <div
               key={chapter.key}
+              ref={isPlaying ? activeRowRef : undefined}
               className='flex w-full items-center gap-3 rounded-lg px-2 py-2'
               style={{ paddingInlineStart: `${8 + chapter.depth * 14}px` }}
             >


### PR DESCRIPTION
closes #5683

### Cause
For big books the chapter list in Offline Audio can be hundreds of entries long. The app already marks the currently playing chapter with an icon, but the list opens scrolled to the top, so reaching the current and next chapters means manually scrolling past everything above them.

### Fix
When the Offline Audio view opens, the chapter list instantly scrolls the playing chapter to the top of the visible area (`scrollIntoView` with `behavior: 'instant'`, `block: 'start'` — no animation). It reuses the same `isPlaying` logic that drives the now-playing icon, so there is no new bookkeeping. The effect runs once on open, so the list does not re-jump as playback advances while it stays open, and it is a no-op when no chapter is active.

### Verification
- New unit tests: the list scrolls exactly once with `{ behavior: 'instant', block: 'start' }` when a chapter is playing, and not at all when none is.
- Manual: debug APK built for Android, installed on the emulator; the list opens on the current chapter with the next chapters right below.
- The 11 full-suite test failures (zip.js in novel-import/document/series-metadata/cover tests) were confirmed pre-existing: identical failures on the previous commit `b07baf52` without this change.