### PR TITLE
fix(library): allow unchecking Read books in place for registered folders, closes #5680

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -1714,7 +1714,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} قاموس غير مدعوم ومعطل",
   "No new dictionaries were imported": "لم يتم استيراد أي قواميس جديدة",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "اقرأ الكتب من مجلداتها الأصلية بدلاً من نسخها إلى المكتبة. يوفر مساحة على القرص؛ ولا يزال الرفع التلقائي إلى السحابة يعمل إذا كان مفعلاً.",
-  "This folder is an external library. Books here are always read in place.": "هذا المجلد هو مكتبة خارجية. تُقرأ الكتب هنا دائمًا من مكانها.",
   "Swipe to Paginate": "اسحب لتصفح الصفحات",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "شارك بيانات الاستخدام المجهولة لنفهم كيف يُستخدم Readest ونحسّنه.",
   "Anonymous, aggregated feature usage": "استخدام مجهول ومجمَّع للميزات",
@@ -2318,5 +2317,6 @@
   "On": "مفعّل",
   "Not available for this book.": "غير متاح لهذا الكتاب.",
   "Start of Book": "بداية الكتاب",
-  "End of Book": "نهاية الكتاب"
+  "End of Book": "نهاية الكتاب",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "هذا المجلد مكتبة خارجية. ألغِ التحديد للتوقف عن قراءة كتبه من مكانها؛ وستُنسخ الكتب إلى المكتبة في عمليات الاستيراد القادمة."
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -1590,7 +1590,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}}টি অভিধান অসমর্থিত এবং নিষ্ক্রিয়",
   "No new dictionaries were imported": "কোনো নতুন অভিধান আমদানি করা হয়নি",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "বইগুলিকে লাইব্রেরিতে অনুলিপি করার পরিবর্তে তাদের মূল ফোল্ডার থেকে পড়ুন। ডিস্ক স্পেস সঞ্চয় করে; সক্ষম থাকলে ক্লাউড স্বয়ংক্রিয়-আপলোড এখনও কাজ করে।",
-  "This folder is an external library. Books here are always read in place.": "এই ফোল্ডারটি একটি বহিরাগত লাইব্রেরি। এখানে বইগুলি সর্বদা মূল স্থানে পড়া হয়।",
   "Swipe to Paginate": "পৃষ্ঠা পরিবর্তনে সোয়াইপ করুন",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "বেনামি ব্যবহারের ডেটা শেয়ার করুন যাতে আমরা বুঝতে পারি Readest কীভাবে ব্যবহৃত হয় এবং এটি উন্নত করতে পারি।",
   "Anonymous, aggregated feature usage": "বেনামি, সমষ্টিগত ফিচার ব্যবহার",
@@ -2094,5 +2093,6 @@
   "On": "চালু",
   "Not available for this book.": "এই বইয়ের জন্য উপলব্ধ নয়।",
   "Start of Book": "বইয়ের শুরু",
-  "End of Book": "বইয়ের শেষ"
+  "End of Book": "বইয়ের শেষ",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "এই ফোল্ডারটি একটি বাহ্যিক লাইব্রেরি। এর বইগুলি নিজ স্থানে পড়া বন্ধ করতে টিক তুলে দিন; পরবর্তী ইমপোর্টে বইগুলি লাইব্রেরিতে কপি করা হবে।"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -1559,7 +1559,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "ཚིག་མཛོད་ {{count}} ལ་རྒྱབ་སྐྱོར་མེད་ཅིང་སྤོ་ཟུར་བྱས་ཡོད།",
   "No new dictionaries were imported": "ཚིག་མཛོད་གསར་པ་ནང་འདྲེན་མ་བྱུང་།",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "དཔེ་ཆ་དཔེ་མཛོད་དུ་ཕབ་ལེན་མི་བྱེད་པར་ཁོ་ཚོའི་ཐོག་མའི་ཡིག་སྣོད་ནས་ཀློག་པ། སྒྲིག་ཆས་ས་ཆ་ཉར་ཚགས་བྱེད་པ། སྔོན་ཆད་སྤྲིན་གྱི་རང་འགུལ་སྦྱར་འཇུག་གནས་སྟངས་ཡོད་ན་འདས་ལྡན་པ་ཡིན།",
-  "This folder is an external library. Books here are always read in place.": "ཡིག་སྣོད་འདི་ནི་ཕྱི་ཕྱོགས་ཀྱི་དཔེ་མཛོད་ཡིན། འདིར་ཡོད་པའི་དཔེ་ཆ་རྣམས་རྟག་ཏུ་རང་གི་ས་གནས་སུ་ཀློག་པ་ཡིན།",
   "Swipe to Paginate": "མཆོངས་གཤིབ་ཀྱིས་ཤོག་ངོས་སྒྱུར་བ།",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Readest བཀོལ་སྤྱོད་ཇི་ལྟར་བྱས་པ་རྟོགས་ཤིང་ལེགས་སྒྱུར་གྱི་ཆེད་དུ་མིང་མེད་སྤྱོད་སྦྱོར་གྱི་གནས་ཚུལ་མཉམ་སྤྱོད་གནང་རོགས།",
   "Anonymous, aggregated feature usage": "མིང་མེད་པའི་སྤྱི་སྡོམ་ནུས་པའི་སྤྱོད་སྦྱོར།",
@@ -2038,5 +2037,6 @@
   "On": "ཁ་ཕྱེ།",
   "Not available for this book.": "དེབ་འདིར་བེད་སྤྱོད་མི་ཐུབ།",
   "Start of Book": "དཔེ་དེབ་ཀྱི་མགོ།",
-  "End of Book": "དཔེ་དེབ་ཀྱི་མཇུག"
+  "End of Book": "དཔེ་དེབ་ཀྱི་མཇུག",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "སྣོད་འདི་ནི་ཕྱིའི་དཔེ་མཛོད་ཅིག་ཡིན། འདེམས་རྟགས་ཕྱིར་བསུབ་ན་དེའི་དཔེ་ཆ་རང་ས་ནས་ཀློག་མཚམས་འཇོག་ངེས། ཕྱིས་ཀྱི་ནང་འདྲེན་སྐབས་དཔེ་ཆ་དཔེ་མཛོད་ནང་དུ་འདྲ་བཤུས་བྱེད་ངེས།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -1590,7 +1590,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} Wörterbücher werden nicht unterstützt und sind deaktiviert",
   "No new dictionaries were imported": "Keine neuen Wörterbücher importiert",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Liest Bücher aus ihren ursprünglichen Ordnern, anstatt sie in die Bibliothek zu kopieren. Spart Speicherplatz; Cloud-Auto-Upload funktioniert weiterhin, falls aktiviert.",
-  "This folder is an external library. Books here are always read in place.": "Dieser Ordner ist eine externe Bibliothek. Bücher hier werden immer am Originalort gelesen.",
   "Swipe to Paginate": "Wischen zum Blättern",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Teile anonyme Nutzungsdaten, damit wir verstehen können, wie Readest verwendet wird, und es verbessern können.",
   "Anonymous, aggregated feature usage": "Anonyme, aggregierte Funktionsnutzung",
@@ -2094,5 +2093,6 @@
   "On": "Ein",
   "Not available for this book.": "Für dieses Buch nicht verfügbar.",
   "Start of Book": "Buchanfang",
-  "End of Book": "Buchende"
+  "End of Book": "Buchende",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Dieser Ordner ist eine externe Bibliothek. Deaktivieren Sie das Kästchen, um seine Bücher nicht mehr direkt am Speicherort zu lesen; künftige Importe kopieren die Bücher in die Bibliothek."
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -1590,7 +1590,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} λεξικά δεν υποστηρίζονται και είναι απενεργοποιημένα",
   "No new dictionaries were imported": "Δεν εισήχθησαν νέα λεξικά",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Διαβάστε βιβλία από τους αρχικούς τους φακέλους αντί να τα αντιγράφετε στη βιβλιοθήκη. Εξοικονομεί χώρο στο δίσκο· η αυτόματη μεταφόρτωση στο cloud εξακολουθεί να λειτουργεί εάν είναι ενεργοποιημένη.",
-  "This folder is an external library. Books here are always read in place.": "Αυτός ο φάκελος είναι εξωτερική βιβλιοθήκη. Τα βιβλία εδώ διαβάζονται πάντα στη θέση τους.",
   "Swipe to Paginate": "Σύρετε για Σελιδοποίηση",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Μοιραστείτε ανώνυμα δεδομένα χρήσης για να καταλάβουμε πώς χρησιμοποιείται το Readest και να το βελτιώσουμε.",
   "Anonymous, aggregated feature usage": "Ανώνυμη, συγκεντρωτική χρήση λειτουργιών",
@@ -2094,5 +2093,6 @@
   "On": "Ενεργό",
   "Not available for this book.": "Μη διαθέσιμο για αυτό το βιβλίο.",
   "Start of Book": "Αρχή βιβλίου",
-  "End of Book": "Τέλος βιβλίου"
+  "End of Book": "Τέλος βιβλίου",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Αυτός ο φάκελος είναι εξωτερική βιβλιοθήκη. Καταργήστε την επιλογή για να σταματήσει η επιτόπια ανάγνωση των βιβλίων του· οι μελλοντικές εισαγωγές θα αντιγράφουν τα βιβλία στη βιβλιοθήκη."
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -1621,7 +1621,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} diccionarios no son compatibles y están deshabilitados",
   "No new dictionaries were imported": "No se importaron diccionarios nuevos",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Lee los libros desde sus carpetas originales en lugar de copiarlos a la biblioteca. Ahorra espacio en disco; la carga automática en la nube sigue funcionando si está habilitada.",
-  "This folder is an external library. Books here are always read in place.": "Esta carpeta es una biblioteca externa. Los libros aquí siempre se leen desde su ubicación original.",
   "Swipe to Paginate": "Deslizar para Pasar Página",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Comparte datos de uso anónimos para que podamos entender cómo se usa Readest y mejorarlo.",
   "Anonymous, aggregated feature usage": "Uso de funciones anónimo y agregado",
@@ -2150,5 +2149,6 @@
   "On": "Activado",
   "Not available for this book.": "No disponible para este libro.",
   "Start of Book": "Inicio del libro",
-  "End of Book": "Fin del libro"
+  "End of Book": "Fin del libro",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Esta carpeta es una biblioteca externa. Desmarca para dejar de leer sus libros en su ubicación original; las próximas importaciones copiarán los libros a la biblioteca."
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -1590,7 +1590,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} فرهنگ لغت پشتیبانی نمی‌شوند و غیرفعال‌اند",
   "No new dictionaries were imported": "هیچ فرهنگ لغت جدیدی وارد نشد",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "کتاب‌ها را به جای کپی‌کردن در کتابخانه، از پوشه‌های اصلی‌شان بخوانید. در فضای دیسک صرفه‌جویی می‌کند؛ بارگذاری خودکار ابری در صورت فعال بودن همچنان کار می‌کند.",
-  "This folder is an external library. Books here are always read in place.": "این پوشه یک کتابخانه‌ی بیرونی است. کتاب‌های این پوشه همیشه از همان مکان خوانده می‌شوند.",
   "Swipe to Paginate": "کشیدن برای ورق زدن",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "داده‌های استفاده ناشناس را به اشتراک بگذارید تا بفهمیم Readest چگونه استفاده می‌شود و آن را بهبود دهیم.",
   "Anonymous, aggregated feature usage": "استفاده ناشناس و کلی از ویژگی‌ها",
@@ -2094,5 +2093,6 @@
   "On": "روشن",
   "Not available for this book.": "برای این کتاب در دسترس نیست.",
   "Start of Book": "ابتدای کتاب",
-  "End of Book": "انتهای کتاب"
+  "End of Book": "انتهای کتاب",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "این پوشه یک کتابخانه خارجی است. برای توقف خواندن کتاب‌ها از محل اصلی، تیک را بردارید؛ در واردسازی‌های بعدی کتاب‌ها به کتابخانه کپی می‌شوند."
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -1621,7 +1621,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} dictionnaires ne sont pas pris en charge et sont désactivés",
   "No new dictionaries were imported": "Aucun nouveau dictionnaire n’a été importé",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Lit les livres depuis leur dossier d’origine au lieu de les copier dans la bibliothèque. Économise de l’espace disque ; l’envoi automatique vers le cloud continue de fonctionner s’il est activé.",
-  "This folder is an external library. Books here are always read in place.": "Ce dossier est une bibliothèque externe. Les livres y sont toujours lus depuis leur emplacement d’origine.",
   "Swipe to Paginate": "Glisser pour Tourner la Page",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Partagez des données d'utilisation anonymes pour nous aider à comprendre comment Readest est utilisé et à l'améliorer.",
   "Anonymous, aggregated feature usage": "Utilisation des fonctionnalités anonyme et agrégée",
@@ -2150,5 +2149,6 @@
   "On": "Activé",
   "Not available for this book.": "Non disponible pour ce livre.",
   "Start of Book": "Début du livre",
-  "End of Book": "Fin du livre"
+  "End of Book": "Fin du livre",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Ce dossier est une bibliothèque externe. Décochez pour cesser de lire ses livres sur place ; les prochaines importations copieront les livres dans la bibliothèque."
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -1621,7 +1621,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} מילונים אינם נתמכים ומושבתים",
   "No new dictionaries were imported": "לא יובאו מילונים חדשים",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "קריאת ספרים מתיקיותיהם המקוריות במקום העתקתם לספרייה. חוסך מקום בדיסק; העלאה אוטומטית לענן עדיין פועלת אם היא מופעלת.",
-  "This folder is an external library. Books here are always read in place.": "תיקייה זו היא ספרייה חיצונית. הספרים בה נקראים תמיד ממיקומם המקורי.",
   "Swipe to Paginate": "החלקה להחלפת עמוד",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "שתפו נתוני שימוש אנונימיים כדי שנוכל להבין כיצד נעשה שימוש ב‑Readest ולשפר אותו.",
   "Anonymous, aggregated feature usage": "שימוש בתכונות באופן אנונימי ומצרפי",
@@ -2150,5 +2149,6 @@
   "On": "פעיל",
   "Not available for this book.": "לא זמין עבור ספר זה.",
   "Start of Book": "תחילת הספר",
-  "End of Book": "סוף הספר"
+  "End of Book": "סוף הספר",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "תיקייה זו היא ספרייה חיצונית. בטלו את הסימון כדי להפסיק לקרוא את הספרים במקומם; בייבואים הבאים הספרים יועתקו לספרייה."
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -1590,7 +1590,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} शब्दकोश असमर्थित और अक्षम हैं",
   "No new dictionaries were imported": "कोई नया शब्दकोश आयात नहीं किया गया",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "पुस्तकों को लाइब्रेरी में कॉपी करने के बजाय उनके मूल फ़ोल्डर से पढ़ें। डिस्क स्थान बचाता है; क्लाउड ऑटो-अपलोड सक्षम होने पर भी काम करता है।",
-  "This folder is an external library. Books here are always read in place.": "यह फ़ोल्डर एक बाहरी लाइब्रेरी है। यहाँ की पुस्तकें हमेशा अपने मूल स्थान पर ही पढ़ी जाती हैं।",
   "Swipe to Paginate": "पन्ना बदलने के लिए स्वाइप करें",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "गुमनाम उपयोग डेटा साझा करें ताकि हम समझ सकें कि Readest कैसे उपयोग किया जाता है और इसे बेहतर बना सकें।",
   "Anonymous, aggregated feature usage": "गुमनाम, समग्र सुविधा उपयोग",
@@ -2094,5 +2093,6 @@
   "On": "चालू",
   "Not available for this book.": "इस पुस्तक के लिए उपलब्ध नहीं है।",
   "Start of Book": "पुस्तक की शुरुआत",
-  "End of Book": "पुस्तक का अंत"
+  "End of Book": "पुस्तक का अंत",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "यह फ़ोल्डर एक बाहरी लाइब्रेरी है। इसकी किताबें मूल स्थान से पढ़ना बंद करने के लिए टिक हटाएँ; आगे के आयात में किताबें लाइब्रेरी में कॉपी की जाएँगी।"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -1590,7 +1590,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} szótár nem támogatott, és le van tiltva",
   "No new dictionaries were imported": "Nem importáltunk új szótárakat",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Olvassa a könyveket az eredeti mappáikból, ahelyett, hogy a könyvtárba másolná őket. Lemezterületet takarít meg; a felhő automatikus feltöltése továbbra is működik, ha engedélyezve van.",
-  "This folder is an external library. Books here are always read in place.": "Ez a mappa egy külső könyvtár. Az itt található könyvek mindig a saját helyükön nyílnak meg.",
   "Swipe to Paginate": "Lapozás húzással",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Oszd meg az anonim használati adatokat, hogy megérthessük, hogyan használják a Readestet, és továbbfejleszthessük.",
   "Anonymous, aggregated feature usage": "Anonim, összesített funkcióhasználat",
@@ -2094,5 +2093,6 @@
   "On": "Be",
   "Not available for this book.": "Ehhez a könyvhöz nem érhető el.",
   "Start of Book": "Könyv eleje",
-  "End of Book": "Könyv vége"
+  "End of Book": "Könyv vége",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Ez a mappa külső könyvtár. Törölje a jelölést, hogy a könyveit ne az eredeti helyükről olvassa; a későbbi importálások a könyveket a könyvtárba másolják."
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -1559,7 +1559,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} kamus tidak didukung dan dinonaktifkan",
   "No new dictionaries were imported": "Tidak ada kamus baru yang diimpor",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Baca buku dari folder aslinya alih-alih menyalinnya ke perpustakaan. Menghemat ruang disk; unggah otomatis ke awan tetap berfungsi jika diaktifkan.",
-  "This folder is an external library. Books here are always read in place.": "Folder ini adalah pustaka eksternal. Buku di sini selalu dibaca di tempat aslinya.",
   "Swipe to Paginate": "Geser untuk Pindah Halaman",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Bagikan data penggunaan anonim agar kami dapat memahami bagaimana Readest digunakan dan meningkatkannya.",
   "Anonymous, aggregated feature usage": "Penggunaan fitur anonim dan agregat",
@@ -2038,5 +2037,6 @@
   "On": "Aktif",
   "Not available for this book.": "Tidak tersedia untuk buku ini.",
   "Start of Book": "Awal buku",
-  "End of Book": "Akhir buku"
+  "End of Book": "Akhir buku",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Folder ini adalah pustaka eksternal. Hapus centang untuk berhenti membaca bukunya di tempat; impor berikutnya akan menyalin buku ke pustaka."
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -1621,7 +1621,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} dizionari non sono supportati e sono disattivati",
   "No new dictionaries were imported": "Nessun nuovo dizionario importato",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Legge i libri dalle loro cartelle originali invece di copiarli nella libreria. Risparmia spazio su disco; il caricamento automatico sul cloud continua a funzionare se attivato.",
-  "This folder is an external library. Books here are always read in place.": "Questa cartella è una libreria esterna. I libri vengono sempre letti dalla loro posizione originale.",
   "Swipe to Paginate": "Scorri per Sfogliare",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Condividi dati di utilizzo anonimi per aiutarci a capire come viene usato Readest e a migliorarlo.",
   "Anonymous, aggregated feature usage": "Utilizzo delle funzionalità anonimo e aggregato",
@@ -2150,5 +2149,6 @@
   "On": "Attivo",
   "Not available for this book.": "Non disponibile per questo libro.",
   "Start of Book": "Inizio del libro",
-  "End of Book": "Fine del libro"
+  "End of Book": "Fine del libro",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Questa cartella è una libreria esterna. Deseleziona per smettere di leggere i suoi libri nella posizione originale; le prossime importazioni copieranno i libri nella libreria."
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -1559,7 +1559,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} 件の辞書が非対応のため無効になっています",
   "No new dictionaries were imported": "新しい辞書は読み込まれませんでした",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "ライブラリにコピーせず、元のフォルダから直接書籍を読み込みます。ディスク容量を節約でき、自動アップロードが有効ならクラウド同期も引き続き機能します。",
-  "This folder is an external library. Books here are always read in place.": "このフォルダは外部ライブラリです。ここの書籍は常に元の場所から読み込まれます。",
   "Swipe to Paginate": "スワイプでページ送り",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Readestがどのように使われているかを把握し、改善するために匿名の使用データを共有してください。",
   "Anonymous, aggregated feature usage": "匿名で集計された機能の使用状況",
@@ -2038,5 +2037,6 @@
   "On": "オン",
   "Not available for this book.": "この本では利用できません。",
   "Start of Book": "本の先頭",
-  "End of Book": "本の末尾"
+  "End of Book": "本の末尾",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "このフォルダは外部ライブラリです。チェックを外すと元の場所から直接読み込まなくなり、以降のインポートでは本がライブラリにコピーされます。"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -1559,7 +1559,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}}개의 사전이 지원되지 않아 비활성화되었습니다",
   "No new dictionaries were imported": "가져온 새 사전이 없습니다",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "도서를 라이브러리에 복사하지 않고 원래 폴더에서 직접 읽어옵니다. 디스크 공간을 절약하며, 자동 업로드가 켜져 있으면 클라우드 동기화도 그대로 작동합니다.",
-  "This folder is an external library. Books here are always read in place.": "이 폴더는 외부 라이브러리입니다. 여기 도서는 항상 원래 위치에서 읽힙니다.",
   "Swipe to Paginate": "스와이프로 페이지 넘기기",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Readest이 어떻게 사용되는지 파악하고 개선할 수 있도록 익명 사용 데이터를 공유해 주세요.",
   "Anonymous, aggregated feature usage": "익명으로 집계된 기능 사용량",
@@ -2038,5 +2037,6 @@
   "On": "켜짐",
   "Not available for this book.": "이 책에서는 사용할 수 없습니다.",
   "Start of Book": "책의 처음",
-  "End of Book": "책의 끝"
+  "End of Book": "책의 끝",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "이 폴더는 외부 라이브러리입니다. 선택을 해제하면 원래 위치에서 책을 읽지 않으며, 이후 가져오기에서는 책이 라이브러리로 복사됩니다."
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -1559,7 +1559,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} kamus tidak disokong dan dilumpuhkan",
   "No new dictionaries were imported": "Tiada kamus baharu diimport",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Baca buku dari folder asalnya tanpa menyalinnya ke perpustakaan. Menjimatkan ruang cakera; muat naik automatik ke awan masih berfungsi jika diaktifkan.",
-  "This folder is an external library. Books here are always read in place.": "Folder ini ialah perpustakaan luaran. Buku di sini sentiasa dibaca di lokasi asalnya.",
   "Swipe to Paginate": "Leret untuk Tukar Halaman",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Kongsi data penggunaan tanpa nama supaya kami dapat memahami cara Readest digunakan dan menambah baiknya.",
   "Anonymous, aggregated feature usage": "Penggunaan ciri tanpa nama dan teragregat",
@@ -2038,5 +2037,6 @@
   "On": "Hidup",
   "Not available for this book.": "Tidak tersedia untuk buku ini.",
   "Start of Book": "Permulaan buku",
-  "End of Book": "Penghujung buku"
+  "End of Book": "Penghujung buku",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Folder ini ialah perpustakaan luaran. Nyahtanda untuk berhenti membaca bukunya di tempat asal; import akan datang akan menyalin buku ke perpustakaan."
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -1590,7 +1590,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} woordenboeken worden niet ondersteund en zijn uitgeschakeld",
   "No new dictionaries were imported": "Er zijn geen nieuwe woordenboeken geïmporteerd",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Lees boeken vanuit hun oorspronkelijke mappen in plaats van ze naar de bibliotheek te kopiëren. Bespaart schijfruimte; automatische uploads naar de cloud blijven werken als ze ingeschakeld zijn.",
-  "This folder is an external library. Books here are always read in place.": "Deze map is een externe bibliotheek. De boeken hier worden altijd op hun oorspronkelijke locatie gelezen.",
   "Swipe to Paginate": "Vegen om door te bladeren",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Deel anonieme gebruiksgegevens zodat we kunnen begrijpen hoe Readest wordt gebruikt en het kunnen verbeteren.",
   "Anonymous, aggregated feature usage": "Anoniem, geaggregeerd functiegebruik",
@@ -2094,5 +2093,6 @@
   "On": "Aan",
   "Not available for this book.": "Niet beschikbaar voor dit boek.",
   "Start of Book": "Begin van het boek",
-  "End of Book": "Einde van het boek"
+  "End of Book": "Einde van het boek",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Deze map is een externe bibliotheek. Vink uit om de boeken niet langer op hun oorspronkelijke locatie te lezen; toekomstige imports kopiëren de boeken naar de bibliotheek."
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -1652,7 +1652,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} słowników jest nieobsługiwanych i wyłączonych",
   "No new dictionaries were imported": "Nie zaimportowano żadnych nowych słowników",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Odczytuj książki z ich pierwotnych folderów zamiast kopiować je do biblioteki. Oszczędza miejsce na dysku; automatyczne przesyłanie do chmury nadal działa, jeśli jest włączone.",
-  "This folder is an external library. Books here are always read in place.": "Ten folder jest zewnętrzną biblioteką. Książki są w nim zawsze otwierane w ich pierwotnej lokalizacji.",
   "Swipe to Paginate": "Przesuń, aby przewinąć stronę",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Udostępnij anonimowe dane o użytkowaniu, abyśmy mogli zrozumieć, jak Readest jest używany, i go ulepszać.",
   "Anonymous, aggregated feature usage": "Anonimowe, zagregowane użycie funkcji",
@@ -2206,5 +2205,6 @@
   "On": "Wł.",
   "Not available for this book.": "Niedostępne dla tej książki.",
   "Start of Book": "Początek książki",
-  "End of Book": "Koniec książki"
+  "End of Book": "Koniec książki",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Ten folder jest zewnętrzną biblioteką. Odznacz, aby przestać czytać jego książki z oryginalnej lokalizacji; przyszłe importy skopiują książki do biblioteki."
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -1621,7 +1621,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} dicionários não são suportados e estão desativados",
   "No new dictionaries were imported": "Nenhum dicionário novo foi importado",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Lê os livros a partir das pastas originais em vez de copiá-los para a biblioteca. Economiza espaço em disco; o envio automático para a nuvem continua funcionando se estiver ativado.",
-  "This folder is an external library. Books here are always read in place.": "Esta pasta é uma biblioteca externa. Os livros aqui são sempre lidos no local original.",
   "Swipe to Paginate": "Deslizar para Virar Página",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Compartilhe dados de uso anônimos para que possamos entender como o Readest é usado e melhorá-lo.",
   "Anonymous, aggregated feature usage": "Uso de recursos anônimo e agregado",
@@ -2150,5 +2149,6 @@
   "On": "Ativado",
   "Not available for this book.": "Não disponível para este livro.",
   "Start of Book": "Início do livro",
-  "End of Book": "Fim do livro"
+  "End of Book": "Fim do livro",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Esta pasta é uma biblioteca externa. Desmarque para parar de ler os livros no local original; as próximas importações copiarão os livros para a biblioteca."
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -1621,7 +1621,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} dicionários não são suportados e estão desativados",
   "No new dictionaries were imported": "Nenhum dicionário novo foi importado",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Lê os livros a partir das pastas originais em vez de os copiar para a biblioteca. Poupa espaço em disco; o envio automático para a nuvem continua a funcionar se estiver ativado.",
-  "This folder is an external library. Books here are always read in place.": "Esta pasta é uma biblioteca externa. Os livros aqui são sempre lidos no local original.",
   "Swipe to Paginate": "Deslizar para Mudar de Página",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Partilhe dados de utilização anónimos para podermos perceber como o Readest é utilizado e melhorá-lo.",
   "Anonymous, aggregated feature usage": "Utilização de funcionalidades anónima e agregada",
@@ -2150,5 +2149,6 @@
   "On": "Ativado",
   "Not available for this book.": "Não disponível para este livro.",
   "Start of Book": "Início do livro",
-  "End of Book": "Fim do livro"
+  "End of Book": "Fim do livro",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Esta pasta é uma biblioteca externa. Desmarque para deixar de ler os livros no local original; as próximas importações copiarão os livros para a biblioteca."
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -1621,7 +1621,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} de dicționare nu sunt acceptate și sunt dezactivate",
   "No new dictionaries were imported": "Nu au fost importate dicționare noi",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Citește cărțile din folderele lor originale în loc să le copieze în bibliotecă. Economisește spațiu pe disc; încărcarea automată în cloud funcționează în continuare dacă este activată.",
-  "This folder is an external library. Books here are always read in place.": "Acest folder este o bibliotecă externă. Cărțile de aici sunt întotdeauna citite din locația originală.",
   "Swipe to Paginate": "Glisare pentru a Schimba Pagina",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Partajează date anonime de utilizare pentru a ne ajuta să înțelegem cum este folosit Readest și să-l îmbunătățim.",
   "Anonymous, aggregated feature usage": "Utilizare anonimă și agregată a funcțiilor",
@@ -2150,5 +2149,6 @@
   "On": "Activat",
   "Not available for this book.": "Indisponibil pentru această carte.",
   "Start of Book": "Începutul cărții",
-  "End of Book": "Sfârșitul cărții"
+  "End of Book": "Sfârșitul cărții",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Acest dosar este o bibliotecă externă. Debifați pentru a nu mai citi cărțile din locația lor originală; importurile viitoare vor copia cărțile în bibliotecă."
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -1652,7 +1652,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} словарей не поддерживаются и отключены",
   "No new dictionaries were imported": "Новые словари не были импортированы",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Читать книги из их исходных папок вместо копирования в библиотеку. Экономит место на диске; автозагрузка в облако по-прежнему работает, если включена.",
-  "This folder is an external library. Books here are always read in place.": "Эта папка — внешняя библиотека. Книги в ней всегда открываются по исходному пути.",
   "Swipe to Paginate": "Смахивание для перелистывания",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Поделитесь анонимными данными об использовании, чтобы мы могли понять, как используется Readest, и улучшить его.",
   "Anonymous, aggregated feature usage": "Анонимное, агрегированное использование функций",
@@ -2206,5 +2205,6 @@
   "On": "Вкл.",
   "Not available for this book.": "Недоступно для этой книги.",
   "Start of Book": "Начало книги",
-  "End of Book": "Конец книги"
+  "End of Book": "Конец книги",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Эта папка — внешняя библиотека. Снимите флажок, чтобы перестать читать её книги на месте; при последующих импортах книги будут копироваться в библиотеку."
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -1590,7 +1590,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "ශබ්දකෝෂ {{count}}ක් සහාය නොදක්වන අතර අක්‍රිය කර ඇත",
   "No new dictionaries were imported": "නව ශබ්දකෝෂ ආයාත කර නැත",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "පොත් පුස්තකාලයට පිටපත් කරනවාට වඩා ඒවායේ මුල් ෆෝල්ඩරවලින් කියවන්න. තැටි ඉඩ ඉතිරි කරයි; සක්‍රිය නම් වලාකුළු ස්වයංක්‍රීය උඩුගත කිරීම තවමත් ක්‍රියා කරයි.",
-  "This folder is an external library. Books here are always read in place.": "මෙම ෆෝල්ඩරය බාහිර පුස්තකාලයකි. මෙහි ඇති පොත් සැමවිටම ඔවුන්ගේ මුල් ස්ථානයේ සිට කියවනු ලැබේ.",
   "Swipe to Paginate": "පිටු මාරුවට ස්වයිප් කරන්න",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Readest භාවිතය වටහාගෙන එය වඩාත් යහපත් කිරීමට අපට හැකි වන පරිදි අනාමික භාවිත දත්ත බෙදාගන්න.",
   "Anonymous, aggregated feature usage": "අනාමික, ඒකරාශී වූ විශේෂාංග භාවිතය",
@@ -2094,5 +2093,6 @@
   "On": "සක්‍රියයි",
   "Not available for this book.": "මෙම පොත සඳහා නොමැත.",
   "Start of Book": "පොතේ ආරම්භය",
-  "End of Book": "පොතේ අවසානය"
+  "End of Book": "පොතේ අවසානය",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "මෙම ෆෝල්ඩරය බාහිර පුස්තකාලයකි. එහි පොත් ඒවා ඇති තැනින්ම කියවීම නැවැත්වීමට සලකුණ ඉවත් කරන්න; ඉදිරි ආයාත වලදී පොත් පුස්තකාලයට පිටපත් වේ."
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -1652,7 +1652,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} slovarjev ni podprtih in so onemogočeni",
   "No new dictionaries were imported": "Novi slovarji niso bili uvoženi",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Berite knjige iz njihovih izvirnih map, namesto da bi jih kopirali v knjižnico. Prihrani prostor na disku; samodejno nalaganje v oblak še naprej deluje, če je omogočeno.",
-  "This folder is an external library. Books here are always read in place.": "Ta mapa je zunanja knjižnica. Knjige v njej se vedno berejo na izvirnem mestu.",
   "Swipe to Paginate": "Drsanje za listanje",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Delite anonimne podatke o uporabi, da bomo razumeli, kako se Readest uporablja, in ga lahko izboljšali.",
   "Anonymous, aggregated feature usage": "Anonimna, združena uporaba funkcij",
@@ -2206,5 +2205,6 @@
   "On": "Vklopljeno",
   "Not available for this book.": "Ni na voljo za to knjigo.",
   "Start of Book": "Začetek knjige",
-  "End of Book": "Konec knjige"
+  "End of Book": "Konec knjige",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Ta mapa je zunanja knjižnica. Odkljukajte, da knjig ne berete več z izvirnega mesta; prihodnji uvozi bodo knjige kopirali v knjižnico."
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -1590,7 +1590,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} ordböcker stöds inte och är inaktiverade",
   "No new dictionaries were imported": "Inga nya ordböcker importerades",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Läs böcker direkt från deras ursprungsmappar i stället för att kopiera dem till biblioteket. Sparar diskutrymme; automatisk uppladdning till molnet fungerar fortfarande om den är aktiverad.",
-  "This folder is an external library. Books here are always read in place.": "Den här mappen är ett externt bibliotek. Böckerna här läses alltid från sin ursprungsplats.",
   "Swipe to Paginate": "Svep för att Bläddra",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Dela anonyma användningsdata så att vi kan förstå hur Readest används och göra det bättre.",
   "Anonymous, aggregated feature usage": "Anonym, aggregerad funktionsanvändning",
@@ -2094,5 +2093,6 @@
   "On": "På",
   "Not available for this book.": "Inte tillgängligt för den här boken.",
   "Start of Book": "Bokens början",
-  "End of Book": "Bokens slut"
+  "End of Book": "Bokens slut",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Den här mappen är ett externt bibliotek. Avmarkera för att sluta läsa dess böcker på plats; framtida importer kopierar böckerna till biblioteket."
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -1590,7 +1590,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} அகராதிகள் ஆதரிக்கப்படவில்லை மற்றும் முடக்கப்பட்டுள்ளன",
   "No new dictionaries were imported": "புதிய அகராதிகள் எதுவும் இறக்குமதி செய்யப்படவில்லை",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "புத்தகங்களை நூலகத்திற்கு நகலெடுக்காமல், அவற்றின் அசல் கோப்புறைகளில் இருந்தே வாசிக்கவும். வட்டக் கொள்ளளவை சேமிக்கும்; இயக்கப்பட்டிருந்தால் கிளவுட் தானியங்கு பதிவேற்றம் இன்னும் வேலை செய்யும்.",
-  "This folder is an external library. Books here are always read in place.": "இந்த கோப்புறை ஒரு வெளிப்புற நூலகம். இங்குள்ள புத்தகங்கள் எப்போதும் அவற்றின் அசல் இடத்திலேயே வாசிக்கப்படும்.",
   "Swipe to Paginate": "பக்கம் மாற்ற ஸ்வைப் செய்யவும்",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Readest எவ்வாறு பயன்படுத்தப்படுகிறது என்பதைப் புரிந்து கொள்ளவும் அதை மேம்படுத்தவும் அநாமதேய பயன்பாட்டுத் தரவைப் பகிரவும்.",
   "Anonymous, aggregated feature usage": "அநாமதேய, தொகுக்கப்பட்ட அம்சப் பயன்பாடு",
@@ -2094,5 +2093,6 @@
   "On": "இயக்கத்தில்",
   "Not available for this book.": "இந்தப் புத்தகத்திற்குக் கிடைக்கவில்லை.",
   "Start of Book": "புத்தகத்தின் தொடக்கம்",
-  "End of Book": "புத்தகத்தின் முடிவு"
+  "End of Book": "புத்தகத்தின் முடிவு",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "இந்தக் கோப்புறை ஒரு வெளிப்புற நூலகம். அதன் புத்தகங்களை இருக்கும் இடத்திலிருந்தே படிப்பதை நிறுத்த குறியை நீக்கவும்; இனிவரும் இறக்குமதிகளில் புத்தகங்கள் நூலகத்திற்கு நகலெடுக்கப்படும்."
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -1559,7 +1559,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "พจนานุกรม {{count}} รายการไม่รองรับและถูกปิดใช้งาน",
   "No new dictionaries were imported": "ไม่มีพจนานุกรมใหม่ถูกนำเข้า",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "อ่านหนังสือจากโฟลเดอร์ต้นฉบับโดยตรงแทนการคัดลอกเข้าคลังหนังสือ ช่วยประหยัดพื้นที่ดิสก์ การอัปโหลดอัตโนมัติไปยังคลาวด์ยังคงทำงานหากเปิดใช้งานอยู่",
-  "This folder is an external library. Books here are always read in place.": "โฟลเดอร์นี้เป็นคลังหนังสือภายนอก หนังสือในนี้จะถูกเปิดอ่านจากตำแหน่งเดิมเสมอ",
   "Swipe to Paginate": "ปัดเพื่อเปลี่ยนหน้า",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "แชร์ข้อมูลการใช้งานแบบไม่ระบุตัวตนเพื่อให้เราเข้าใจว่ามีการใช้ Readest อย่างไรและปรับปรุงให้ดียิ่งขึ้น",
   "Anonymous, aggregated feature usage": "การใช้คุณสมบัติแบบไม่ระบุตัวตนและรวมข้อมูล",
@@ -2038,5 +2037,6 @@
   "On": "เปิด",
   "Not available for this book.": "ไม่พร้อมใช้งานสำหรับหนังสือเล่มนี้",
   "Start of Book": "ต้นเล่ม",
-  "End of Book": "ท้ายเล่ม"
+  "End of Book": "ท้ายเล่ม",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "โฟลเดอร์นี้เป็นคลังหนังสือภายนอก ยกเลิกการเลือกเพื่อหยุดอ่านหนังสือจากตำแหน่งเดิม การนำเข้าครั้งต่อไปจะคัดลอกหนังสือเข้าคลังหนังสือ"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -1590,7 +1590,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} sözlük desteklenmiyor ve devre dışı bırakıldı",
   "No new dictionaries were imported": "Yeni sözlük içe aktarılmadı",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Kitapları kitaplığa kopyalamak yerine orijinal klasörlerinden okuyun. Disk alanından tasarruf sağlar; etkinleştirilmişse bulut otomatik yüklemesi yine de çalışır.",
-  "This folder is an external library. Books here are always read in place.": "Bu klasör harici bir kitaplıktır. İçindeki kitaplar her zaman bulundukları yerden okunur.",
   "Swipe to Paginate": "Sayfa Çevirmek için Kaydır",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Readest'in nasıl kullanıldığını anlayıp geliştirebilmemiz için anonim kullanım verilerini paylaşın.",
   "Anonymous, aggregated feature usage": "Anonim, toplu özellik kullanımı",
@@ -2094,5 +2093,6 @@
   "On": "Açık",
   "Not available for this book.": "Bu kitap için kullanılamıyor.",
   "Start of Book": "Kitabın başı",
-  "End of Book": "Kitabın sonu"
+  "End of Book": "Kitabın sonu",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Bu klasör harici bir kitaplıktır. Kitaplarını bulundukları yerden okumayı durdurmak için işareti kaldırın; sonraki içe aktarmalarda kitaplar kitaplığa kopyalanır."
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -1652,7 +1652,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} словників не підтримуються і вимкнено",
   "No new dictionaries were imported": "Нові словники не імпортовано",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Читайте книги з їхніх початкових тек, замість копіювання до бібліотеки. Заощаджує місце на диску; автозавантаження до хмари продовжує працювати, якщо ввімкнено.",
-  "This folder is an external library. Books here are always read in place.": "Ця тека — зовнішня бібліотека. Книги в ній завжди читаються з початкового розташування.",
   "Swipe to Paginate": "Гортання для перегортання",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Поділіться анонімними даними використання, щоб ми могли зрозуміти, як використовується Readest, і покращити його.",
   "Anonymous, aggregated feature usage": "Анонімне, агреговане використання функцій",
@@ -2206,5 +2205,6 @@
   "On": "Увімк.",
   "Not available for this book.": "Недоступно для цієї книги.",
   "Start of Book": "Початок книги",
-  "End of Book": "Кінець книги"
+  "End of Book": "Кінець книги",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Ця тека — зовнішня бібліотека. Зніміть позначку, щоб припинити читати її книги на місці; під час наступних імпортів книги копіюватимуться в бібліотеку."
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -1590,7 +1590,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} ta lug‘at qo‘llab-quvvatlanmaydi va o‘chirilgan",
   "No new dictionaries were imported": "Yangi lug‘atlar import qilinmadi",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Kitoblarni kutubxonaga ko‘chirish o‘rniga ularning asl papkalaridan o‘qing. Disk joyini tejaydi; yoqilgan bo‘lsa, bulutga avtomatik yuklash hamon ishlaydi.",
-  "This folder is an external library. Books here are always read in place.": "Bu papka tashqi kutubxonadir. Bu yerdagi kitoblar har doim o‘z joyidan o‘qiladi.",
   "Swipe to Paginate": "Sahifani aylantirish uchun suring",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Readest qanday ishlatilishini tushunish va uni yaxshilash uchun anonim foydalanish maʼlumotlarini ulashing.",
   "Anonymous, aggregated feature usage": "Anonim, jamlangan funksiya foydalanishi",
@@ -2094,5 +2093,6 @@
   "On": "Yoqilgan",
   "Not available for this book.": "Bu kitob uchun mavjud emas.",
   "Start of Book": "Kitob boshi",
-  "End of Book": "Kitob oxiri"
+  "End of Book": "Kitob oxiri",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Bu jild tashqi kutubxona. Kitoblarini joyida o‘qishni to‘xtatish uchun belgini olib tashlang; keyingi importlarda kitoblar kutubxonaga nusxalanadi."
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -1559,7 +1559,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} từ điển không được hỗ trợ và đã bị vô hiệu hóa",
   "No new dictionaries were imported": "Không có từ điển mới nào được nhập",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "Đọc sách trực tiếp từ thư mục gốc thay vì sao chép vào thư viện. Tiết kiệm dung lượng đĩa; tự động tải lên đám mây vẫn hoạt động nếu được bật.",
-  "This folder is an external library. Books here are always read in place.": "Thư mục này là thư viện ngoài. Sách trong đây luôn được đọc tại vị trí gốc.",
   "Swipe to Paginate": "Vuốt để Sang Trang",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "Chia sẻ dữ liệu sử dụng ẩn danh để chúng tôi có thể hiểu cách Readest được sử dụng và cải thiện nó.",
   "Anonymous, aggregated feature usage": "Sử dụng tính năng ẩn danh và tổng hợp",
@@ -2038,5 +2037,6 @@
   "On": "Bật",
   "Not available for this book.": "Không khả dụng cho sách này.",
   "Start of Book": "Đầu sách",
-  "End of Book": "Cuối sách"
+  "End of Book": "Cuối sách",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Thư mục này là thư viện ngoài. Bỏ chọn để ngừng đọc sách tại chỗ; các lần nhập sau sẽ sao chép sách vào thư viện."
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -1559,7 +1559,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} 个词典不受支持，已停用",
   "No new dictionaries were imported": "未导入任何新词典",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "直接从图书的原始文件夹读取,无需复制到书库。可节省磁盘空间;若启用了自动上传,云端同步仍正常工作。",
-  "This folder is an external library. Books here are always read in place.": "此文件夹是外部书库,其中的图书始终在原位置读取。",
   "Swipe to Paginate": "滑动翻页",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "分享匿名使用数据，帮助我们了解 Readest 的使用情况并加以改进。",
   "Anonymous, aggregated feature usage": "匿名、聚合的功能使用数据",
@@ -2038,5 +2037,6 @@
   "On": "已开启",
   "Not available for this book.": "此书不支持此功能。",
   "Start of Book": "书籍开头",
-  "End of Book": "书籍结尾"
+  "End of Book": "书籍结尾",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "此文件夹是外部书库。取消勾选后将不再就地读取其中的书籍；之后的导入会把书籍复制到书库中。"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -1559,7 +1559,6 @@
   "{{count}} dictionary is unsupported and disabled_other": "{{count}} 個字典不受支援,已停用",
   "No new dictionaries were imported": "未匯入任何新字典",
   "Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.": "直接從原始資料夾讀取書籍,不複製到書庫。可節省磁碟空間;若已啟用自動上傳,雲端同步仍正常運作。",
-  "This folder is an external library. Books here are always read in place.": "此資料夾是外部書庫,其中的書籍一律從原位置讀取。",
   "Swipe to Paginate": "滑動翻頁",
   "Share anonymous usage data so we can understand how Readest is used and make it better.": "分享匿名使用資料，協助我們了解 Readest 的使用情形並加以改進。",
   "Anonymous, aggregated feature usage": "匿名、聚合的功能使用資料",
@@ -2038,5 +2037,6 @@
   "On": "已開啟",
   "Not available for this book.": "此書不支援此功能。",
   "Start of Book": "書籍開頭",
-  "End of Book": "書籍結尾"
+  "End of Book": "書籍結尾",
+  "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "此資料夾是外部書庫。取消勾選後將不再就地讀取其中的書籍；之後的匯入會把書籍複製到書庫中。"
 }

--- a/apps/readest-app/src/__tests__/app/library/import-from-folder-read-in-place.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/import-from-folder-read-in-place.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ImportFromFolderDialog from '@/app/library/components/ImportFromFolderDialog';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string, options?: Record<string, string | number>) => {
+    if (!options) return key;
+    return key.replace(/{{(\w+)}}/g, (_match, name) => String(options[name] ?? ''));
+  },
+}));
+
+vi.mock('@/hooks/useKeyDownActions', () => ({
+  useKeyDownActions: () => ({ current: null }),
+}));
+
+vi.mock('@/components/Dialog', () => ({
+  __esModule: true,
+  default: ({
+    isOpen,
+    title,
+    children,
+  }: {
+    isOpen: boolean;
+    title?: string;
+    children: React.ReactNode;
+  }) =>
+    isOpen ? (
+      <div role='dialog' aria-label={title}>
+        {children}
+      </div>
+    ) : null,
+}));
+
+const REGISTERED = '/Users/me/Books';
+
+const setup = (overrides: Partial<React.ComponentProps<typeof ImportFromFolderDialog>> = {}) => {
+  const props = {
+    initialDirectory: REGISTERED,
+    isRegisteredExternalRoot: (dir: string) => dir === REGISTERED,
+    onPickDirectory: vi.fn(),
+    onCancel: vi.fn(),
+    onConfirm: vi.fn(),
+    ...overrides,
+  };
+  const utils = render(<ImportFromFolderDialog {...props} />);
+  return { ...utils, props };
+};
+
+const getReadInPlaceCheckbox = (): HTMLInputElement =>
+  screen.getByText('Read books in place').closest('label')!.querySelector('input')!;
+
+afterEach(cleanup);
+
+describe('Import-from-Folder dialog: read-in-place toggle (#5680)', () => {
+  it('shows the toggle ON but editable for a registered external folder', () => {
+    setup();
+
+    const checkbox = getReadInPlaceCheckbox();
+    expect(checkbox.checked).toBe(true);
+    expect(checkbox.disabled).toBe(false);
+  });
+
+  it('reports readInPlace: false when unchecked on a registered folder', () => {
+    const { props } = setup({ initialAutoImport: true });
+
+    fireEvent.click(getReadInPlaceCheckbox());
+    expect(getReadInPlaceCheckbox().checked).toBe(false);
+
+    fireEvent.click(screen.getByText('OK'));
+    expect(props.onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ directory: REGISTERED, readInPlace: false, autoImport: false }),
+    );
+  });
+
+  it('turns the toggle on when picking a registered folder', async () => {
+    setup({
+      initialDirectory: '/Users/me/Downloads',
+      initialReadInPlace: false,
+      onPickDirectory: vi.fn().mockResolvedValue(REGISTERED),
+    });
+
+    expect(getReadInPlaceCheckbox().checked).toBe(false);
+
+    fireEvent.click(screen.getByLabelText('Choose a folder'));
+    await waitFor(() => expect(getReadInPlaceCheckbox().checked).toBe(true));
+  });
+
+  it('keeps the persisted last choice for unregistered folders', () => {
+    setup({ initialDirectory: '/Users/me/Downloads', initialReadInPlace: false });
+
+    const checkbox = getReadInPlaceCheckbox();
+    expect(checkbox.checked).toBe(false);
+    expect(checkbox.disabled).toBe(false);
+  });
+});

--- a/apps/readest-app/src/app/library/components/ImportFromFolderDialog.tsx
+++ b/apps/readest-app/src/app/library/components/ImportFromFolderDialog.tsx
@@ -69,8 +69,10 @@ export interface ImportFromFolderResult {
    * notes) still live in Readest's data dir. Deleting such a book from
    * Readest only removes those Readest-side sidecars; the original
    * source file under the registered folder is left untouched.
-   * Defaults to `false`, which keeps the legacy "copy into Readest"
-   * behaviour and leaves the registered folder list untouched.
+   * When `false`, books are copied into Readest (the legacy behaviour)
+   * and the directory is removed from `settings.externalLibraryFolders`
+   * if it was registered — unchecking the box on a registered folder is
+   * how users turn in-place mode off again (#5680).
    */
   readInPlace: boolean;
   /**
@@ -120,11 +122,12 @@ interface ImportFromFolderDialogProps {
   /**
    * Predicate the dialog uses to decide whether the currently-displayed
    * folder is already registered as an external library folder. When
-   * `true`, the "Read in place" toggle is forced ON and locked, with a
-   * note explaining that imports from this folder are always in-place
-   * (until the user removes it from Settings, which v1 doesn't expose).
-   * Implementations should match by exact string after the same path
-   * normalization the importer uses.
+   * `true`, the "Read in place" toggle defaults to ON (reflecting the
+   * folder's actual state) but stays editable — unchecking it and
+   * confirming tells the caller to unregister the folder, so future
+   * imports copy books into the library again (#5680). Implementations
+   * should match by exact string after the same path normalization the
+   * importer uses.
    */
   isRegisteredExternalRoot?: (directory: string) => boolean;
   /**
@@ -207,13 +210,15 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
   // root regardless of where it lived on disk. The caller seeds this
   // from localStorage so the user's last choice is restored.
   const [folderMode, setFolderMode] = useState<'keep' | 'flatten'>(initialFolderMode);
-  // "Read in place" toggle. When the directory is already registered
-  // as an external library folder we force this ON and hide the
-  // toggle's interactive surface — see {@link readInPlaceLocked}
-  // below — because imports from a registered folder are always
-  // in-place by design (the importer's `shouldImportInPlace` check is
-  // path-prefix based and ignores any per-import opt-out).
-  const [readInPlace, setReadInPlace] = useState<boolean>(initialReadInPlace);
+  // "Read in place" toggle. `null` means the user hasn't touched the box
+  // for the currently-shown folder, so it reflects reality: ON when the
+  // folder is already registered as an external library folder, otherwise
+  // the caller-persisted last choice. An explicit click overrides both —
+  // unchecking a registered folder makes OK report `readInPlace: false`,
+  // which the caller turns into an unregistration (#5680). Picking a
+  // different folder resets the override so the box snaps back to that
+  // folder's actual state.
+  const [readInPlaceChoice, setReadInPlaceChoice] = useState<boolean | null>(null);
   // "Auto-import new books from this folder" — a sub-option of "Read in
   // place". Auto-import scans the folder on every open/focus and reads its
   // books in place, so it is only offered (and only takes effect) when the
@@ -224,9 +229,9 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
   // the folders already opted into auto-import.
   const [view, setView] = useState<'import' | 'watched'>('import');
 
-  const readInPlaceLocked = !!directory && (isRegisteredExternalRoot?.(directory) ?? false);
-  const effectiveReadInPlace = readInPlaceLocked || readInPlace;
-  const effectiveAutoImport = effectiveReadInPlace && autoImport;
+  const isRegisteredRoot = !!directory && (isRegisteredExternalRoot?.(directory) ?? false);
+  const readInPlace = readInPlaceChoice ?? (isRegisteredRoot || initialReadInPlace);
+  const effectiveAutoImport = readInPlace && autoImport;
 
   /** Same normalization the caller matches watched roots with. */
   const isCurrentDirectory = (path: string) => {
@@ -276,7 +281,13 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
     setPicking(true);
     try {
       const picked = await onPickDirectory();
-      if (picked) setDirectory(picked);
+      if (picked) {
+        setDirectory(picked);
+        // A different folder is a different context: drop any explicit
+        // read-in-place override so the box shows the picked folder's
+        // actual state (ON when registered, last choice otherwise).
+        setReadInPlaceChoice(null);
+      }
     } finally {
       setPicking(false);
     }
@@ -300,7 +311,7 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
       selectedGroupIds: selectedIds,
       minSizeKB: safeMinSizeKB,
       flatten: folderMode === 'flatten',
-      readInPlace: effectiveReadInPlace,
+      readInPlace,
       autoImport: effectiveAutoImport,
     });
   };
@@ -444,28 +455,30 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
             copied into Books/<hash>/ as before. When ON, the chosen
             folder is registered in `settings.externalLibraryFolders`
             and the importer keeps each book at its original path —
-            no copy. See `runFolderImport` and `shouldImportInPlace`
-            in ingestService for the downstream effects (cloud sync,
-            symmetric local delete). */}
+            no copy. Unchecking it for an already-registered folder
+            unregisters it on OK. See `runFolderImport` and
+            `shouldImportInPlace` in ingestService for the downstream
+            effects (cloud sync, symmetric local delete). */}
         <div className='flex flex-col gap-1.5'>
           <label
             className={clsx(
               'flex items-start gap-2 rounded-md px-1 py-1 text-sm',
-              readInPlaceLocked ? 'cursor-default' : 'cursor-pointer hover:bg-base-200/50',
+              'cursor-pointer hover:bg-base-200/50',
             )}
           >
             <input
               type='checkbox'
               className='checkbox checkbox-sm mt-0.5'
-              checked={effectiveReadInPlace}
-              disabled={readInPlaceLocked}
-              onChange={(e) => setReadInPlace(e.target.checked)}
+              checked={readInPlace}
+              onChange={(e) => setReadInPlaceChoice(e.target.checked)}
             />
             <span className='select-none'>
               <span className='block'>{_('Read books in place')}</span>
               <span className='text-base-content/60 block text-xs'>
-                {readInPlaceLocked
-                  ? _('This folder is an external library. Books here are always read in place.')
+                {isRegisteredRoot
+                  ? _(
+                      'This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.',
+                    )
                   : _(
                       'Read books from their original folders instead of copying them into the library. Saves disk space; cloud auto-upload still works if enabled.',
                     )}
@@ -475,7 +488,7 @@ const ImportFromFolderDialog: React.FC<ImportFromFolderDialogProps> = ({
           {/* Auto-import sub-option. Only shown when the folder is read in
               place — auto-import re-scans and reads books straight from the
               folder, so it has no meaning for copied imports. */}
-          {effectiveReadInPlace && (
+          {readInPlace && (
             <label className='ms-6 flex cursor-pointer items-start gap-2 rounded-md px-1 py-1 text-sm hover:bg-base-200/50'>
               <input
                 type='checkbox'

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -1331,12 +1331,15 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
         selectedGroupIds: [],
         minSizeKB: 0,
         flatten: false,
-        // URL ingress / drag-drop don't go through the dialog and so
-        // can't set this. Default to the legacy "copy" behaviour;
-        // already-registered external roots will still be detected
-        // by `runFolderImport` itself via the prefix check, so books
-        // under a registered folder are imported in-place either way.
-        readInPlace: false,
+        // URL ingress / drag-drop don't go through the dialog, so no
+        // user expressed an in-place choice here — pass the folder's
+        // actual registration state. A registered root stays registered
+        // (register is a no-op) and keeps importing in place; anything
+        // else keeps the legacy "copy" behaviour (unregister is a
+        // no-op). A blanket `false` would silently unregister a
+        // registered root now that `runFolderImport` treats OFF as
+        // "stop reading this folder in place" (#5680).
+        readInPlace: isRegisteredExternalRoot(dirPath),
         // Non-dialog path never opts into auto-import.
         autoImport: false,
       });
@@ -1543,6 +1546,32 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
   };
 
   /**
+   * Remove `directory` from `settings.externalLibraryFolders` (and persist
+   * settings) — the symmetric counterpart of
+   * {@link registerExternalLibraryFolder}, run when the user unchecks "Read
+   * books in place" for a registered folder (#5680). Subsequent imports from
+   * the folder copy books into Books/<hash>/ again; books previously imported
+   * in place keep working (the reader falls back to `book.filePath`) and are
+   * converted to managed copies as re-imports encounter them. A no-op when
+   * the folder isn't registered.
+   */
+  const unregisterExternalLibraryFolder = async (directory: string): Promise<void> => {
+    const target = normalizeRoot(directory);
+    if (!target) return;
+    const liveSettings = useSettingsStore.getState().settings;
+    const existing = liveSettings.externalLibraryFolders ?? [];
+    const next = existing.filter((r) => normalizeRoot(r) !== target);
+    if (next.length === existing.length) return;
+    const nextSettings = { ...liveSettings, externalLibraryFolders: next };
+    setSettings(nextSettings);
+    try {
+      await saveSettings(envConfig, nextSettings);
+    } catch (e) {
+      console.error('Failed to persist externalLibraryFolders update:', e);
+    }
+  };
+
+  /**
    * Add or remove `directory` from `settings.autoImportFolders` (and persist)
    * per the user's per-folder "Auto-import new books from this folder" choice.
    * `flatten` records the same import's "Folder Structure" pick so later scans
@@ -1631,9 +1660,15 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     // ingest layer's `shouldImportInPlace` does a path-prefix match
     // against `settings.externalLibraryFolders`). Register here so the
     // bookkeeping survives across launches and so subsequent imports
-    // from the same folder don't have to re-trigger the toggle.
+    // from the same folder don't have to re-trigger the toggle. The
+    // OFF branch unregisters so unchecking the box on a registered
+    // folder turns in-place mode off again (#5680) — callers that
+    // bypass the dialog must pass the folder's actual registration
+    // state, not a blanket `false` (see handleImportBooksFromDirectory).
     if (result.readInPlace) {
       await registerExternalLibraryFolder(result.directory);
+    } else {
+      await unregisterExternalLibraryFolder(result.directory);
     }
     // Opt this folder into (or out of) auto-import per the dialog's per-folder
     // checkbox. `result.autoImport` already implies `readInPlace` (the dialog


### PR DESCRIPTION
## Summary

Fixes #5680.

Once a folder had been imported with **Read books in place**, the Import from Folder dialog forced the checkbox ON and disabled on every subsequent import, with a note pointing to a Settings surface that was never built. There was no way anywhere to turn in-place mode off again (the Watched Folders pane only manages auto-import folders, so a read-in-place-only folder had no management surface at all).

## Changes

- **`ImportFromFolderDialog`**: the checkbox is now always editable. It defaults to ON for a registered folder (reflecting its actual state) and to the persisted last choice otherwise; picking a different folder resets it to that folder's state. The helper text for registered folders explains that unchecking stops in-place mode.
- **Library page**: new `unregisterExternalLibraryFolder` (symmetric counterpart of `registerExternalLibraryFolder`). Confirming with the box unchecked removes the folder from `settings.externalLibraryFolders`, so this import and future imports copy books into the library again. Auto-import is unwatched via the existing cascade (it requires in-place).
- **Drag-drop / URL ingress** (`handleImportBooksFromDirectory`): now passes the folder's actual registration state instead of a blanket `readInPlace: false`, so the bypass path can never silently unregister a folder.
- **i18n**: retired the locked-state string; added the new hint, translated across all 33 locales.

Converting back is safe by design: `resolveBookContentSource` prefers the managed `Books/<hash>/` copy over `book.filePath`, so books previously imported in place keep working and become managed copies as re-imports encounter them. Originals under the folder are never touched.

## Test plan

- New `import-from-folder-read-in-place.test.tsx` (4 tests), written failing against the old locked behavior:
  - toggle is ON but editable for a registered folder
  - unchecking + OK reports `readInPlace: false` (and drops `autoImport`)
  - picking a registered folder turns the toggle on
  - unregistered folders keep the persisted last choice
- Full suite: 9095 tests pass; `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)