### PR TITLE
fix(sync): create the replica bundle dir before downloading, closes #5675

### DIFF
--- a/apps/readest-app/src/__tests__/services/app-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/app-service.test.ts
@@ -42,6 +42,7 @@ vi.mock('@/services/cloudService', () => ({
   downloadCloudFile: vi.fn().mockResolvedValue(undefined),
   downloadBookCovers: vi.fn().mockResolvedValue(undefined),
   downloadBook: vi.fn().mockResolvedValue(undefined),
+  downloadReplicaFileFromCloud: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@/services/fontService', () => ({
@@ -463,6 +464,84 @@ describe('BaseAppService', () => {
 
       // Should not have tried to read the backup file
       expect(mockFs.readFile).not.toHaveBeenCalledWith('library_backup.json', 'Books', 'text');
+    });
+  });
+
+  // Issue #5675: the native downloader writes with `File::create`, which does
+  // NOT create parent directories — a missing bundle dir surfaces as
+  // "No such file or directory (os error 2)". The pull path only mints (and
+  // mkdirs) a bundle dir for records it has never seen; a record whose
+  // directory was lost afterwards, a transfer replayed from the persisted
+  // queue, or a Retry All all reach the download with no directory. Book
+  // downloads already guard this (cloudService.downloadBook), replica
+  // downloads did not.
+  describe('downloadReplicaFile', () => {
+    test('creates the bundle directory before downloading', async () => {
+      await service.downloadReplicaFile(
+        'font',
+        'c1',
+        'Georgia.ttf',
+        'v04c1uy/Georgia.ttf',
+        'Fonts',
+      );
+
+      expect(mockFs.createDir).toHaveBeenCalledWith('v04c1uy', 'Fonts', true);
+    });
+
+    test('creates the directory before the download starts, not after', async () => {
+      const CloudSvc = await import('@/services/cloudService');
+      await service.downloadReplicaFile(
+        'font',
+        'c1',
+        'Georgia.ttf',
+        'v04c1uy/Georgia.ttf',
+        'Fonts',
+      );
+
+      const mkdirOrder = (mockFs.createDir as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0]!;
+      const downloadOrder = (CloudSvc.downloadReplicaFileFromCloud as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0]!;
+      expect(mkdirOrder).toBeLessThan(downloadOrder);
+    });
+
+    test('nested bundle paths create the full parent chain', async () => {
+      await service.downloadReplicaFile(
+        'dictionary',
+        'd1',
+        'concise.css',
+        'bundle-1/assets/concise.css',
+        'Dictionaries',
+      );
+
+      expect(mockFs.createDir).toHaveBeenCalledWith('bundle-1/assets', 'Dictionaries', true);
+    });
+
+    test('a flat legacy path with no bundle dir does not create a directory', async () => {
+      await service.downloadReplicaFile('font', 'c1', 'Georgia.ttf', 'Georgia.ttf', 'Fonts');
+
+      expect(mockFs.createDir).not.toHaveBeenCalled();
+    });
+
+    test('still downloads to the resolved absolute destination', async () => {
+      const CloudSvc = await import('@/services/cloudService');
+      await service.downloadReplicaFile(
+        'font',
+        'c1',
+        'Georgia.ttf',
+        'v04c1uy/Georgia.ttf',
+        'Fonts',
+      );
+
+      expect(CloudSvc.downloadReplicaFileFromCloud).toHaveBeenCalledWith(
+        service,
+        expect.objectContaining({
+          kind: 'font',
+          replicaId: 'c1',
+          filename: 'Georgia.ttf',
+          dst: expect.stringContaining('v04c1uy/Georgia.ttf'),
+        }),
+      );
     });
   });
 });

--- a/apps/readest-app/src/__tests__/services/transfer-manager.test.ts
+++ b/apps/readest-app/src/__tests__/services/transfer-manager.test.ts
@@ -988,4 +988,100 @@ describe('TransferManager', () => {
       expect(t.replicaFiles?.map((f) => f.logical)).toEqual(['webster.mdx', 'webster.mdd']);
     });
   });
+
+  // Replica transfers are background sync (fonts / textures / dictionaries /
+  // OPDS catalogs pull and push on their own). They must never toast — a
+  // library with a dozen synced fonts otherwise fires a dozen success toasts
+  // on a fresh device, and a dozen "Failed to download file" toasts when the
+  // download breaks (issue #5675).
+  describe('replica transfers are silent background work', () => {
+    const makeReplicaAppService = () =>
+      ({
+        uploadBook: vi.fn().mockResolvedValue(undefined),
+        downloadBook: vi.fn().mockResolvedValue(undefined),
+        deleteBook: vi.fn().mockResolvedValue(undefined),
+        uploadReplicaFile: vi.fn().mockResolvedValue(undefined),
+        downloadReplicaFile: vi.fn().mockResolvedValue(undefined),
+        isMacOSApp: false,
+      }) as Record<string, unknown>;
+
+    const replicaFiles = [{ logical: 'Georgia.ttf', lfp: 'b1/Georgia.ttf', byteSize: 10 }];
+
+    const toastsOfType = (type: string) =>
+      (eventDispatcher.dispatch as Mock).mock.calls.filter(
+        (c) => c[0] === 'toast' && (c[1] as Record<string, unknown>)?.['type'] === type,
+      );
+
+    test('queueReplicaDownload marks the transfer as background', async () => {
+      const appService = makeReplicaAppService();
+      await transferManager.initialize(appService as never, () => [], vi.fn(), translationFn);
+
+      const id = transferManager.queueReplicaDownload(
+        'font',
+        'c1',
+        'Georgia Regular',
+        replicaFiles,
+        'Fonts',
+      );
+      expect(useTransferStore.getState().transfers[id!]!.isBackground).toBe(true);
+    });
+
+    test('queueReplicaUpload marks the transfer as background', async () => {
+      const appService = makeReplicaAppService();
+      await transferManager.initialize(appService as never, () => [], vi.fn(), translationFn);
+
+      const id = transferManager.queueReplicaUpload(
+        'font',
+        'c1',
+        'Georgia Regular',
+        replicaFiles,
+        'Fonts',
+      );
+      expect(useTransferStore.getState().transfers[id!]!.isBackground).toBe(true);
+    });
+
+    test('a successful replica download dispatches no toast', async () => {
+      const appService = makeReplicaAppService();
+      await transferManager.initialize(appService as never, () => [], vi.fn(), translationFn);
+
+      transferManager.queueReplicaDownload('font', 'c1', 'Georgia Regular', replicaFiles, 'Fonts');
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(toastsOfType('info')).toHaveLength(0);
+    });
+
+    test('a failing replica download dispatches no error toast once retries are exhausted', async () => {
+      const appService = makeReplicaAppService();
+      // Native Tauri rejections arrive as plain strings, which is what the
+      // real os-error-2 failure looks like.
+      appService['downloadReplicaFile'] = vi
+        .fn()
+        .mockRejectedValue('No such file or directory (os error 2)');
+      await transferManager.initialize(appService as never, () => [], vi.fn(), translationFn);
+
+      const id = transferManager.queueReplicaDownload(
+        'font',
+        'c1',
+        'Georgia Regular',
+        replicaFiles,
+        'Fonts',
+      );
+      await vi.advanceTimersByTimeAsync(60000);
+
+      expect(useTransferStore.getState().transfers[id!]!.status).toBe('failed');
+      expect(toastsOfType('error')).toHaveLength(0);
+    });
+
+    test('a failing foreground book upload still toasts', async () => {
+      const book = makeBook({ hash: 'h1', title: 'Loud Book' });
+      const appService = makeReplicaAppService();
+      (appService['uploadBook'] as Mock).mockRejectedValue(new Error('Network fail'));
+      await transferManager.initialize(appService as never, () => [book], vi.fn(), translationFn);
+
+      transferManager.queueUpload(book);
+      await vi.advanceTimersByTimeAsync(60000);
+
+      expect(toastsOfType('error').length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/apps/readest-app/src/services/appService.ts
+++ b/apps/readest-app/src/services/appService.ts
@@ -18,6 +18,7 @@ import { SchemaType } from '@/services/database/migrate';
 import { Book, BookConfig, BookContent, ImportBookOptions, ViewSettings } from '@/types/book';
 import type { BookNav } from '@/services/nav';
 import { getLibraryFilename, getLibraryBackupFilename } from '@/utils/book';
+import { getDirPath } from '@/utils/path';
 
 import { getOSPlatform } from '@/utils/misc';
 import { isStoragePermissionError, requestStoragePermission } from '@/utils/permission';
@@ -384,6 +385,19 @@ export abstract class BaseAppService implements AppService {
     base: BaseDir,
     onProgress?: ProgressHandler,
   ) {
+    // The native downloader writes with `File::create`, which does not create
+    // parent directories, so a missing bundle dir fails as an opaque
+    // "No such file or directory (os error 2)" (issue #5675). The pull path
+    // only mkdirs when it MINTS a bundle dir for a record it has never seen —
+    // a record whose directory was lost afterwards (custom root dir changed,
+    // external storage cleared), a transfer replayed from the persisted queue,
+    // and Retry All all arrive here with nothing on disk. Book downloads have
+    // always guarded this (see cloudService.downloadBook); do the same here.
+    // `createDir` is recursive, so this is a no-op when the dir exists.
+    const bundleDir = getDirPath(lfp);
+    if (bundleDir) {
+      await this.fs.createDir(bundleDir, base, true);
+    }
     // Resolve the relative `<bundleDir>/<filename>` lfp against the
     // replica's base dir before downloading. Mirrors how upload uses
     // `resolveFilePath(opts.lfp, opts.base)`. Without this, the writer

--- a/apps/readest-app/src/services/transferManager.ts
+++ b/apps/readest-app/src/services/transferManager.ts
@@ -232,7 +232,9 @@ class TransferManager {
 
     const id = store.addReplicaTransfer(replicaKind, replicaId, displayTitle, 'upload', {
       priority: opts.priority,
-      isBackground: opts.isBackground,
+      // Replica transfers are background sync by default — see the note on
+      // queueReplicaDownload.
+      isBackground: opts.isBackground ?? true,
       files,
       base,
       reincarnation: opts.reincarnation,
@@ -260,7 +262,12 @@ class TransferManager {
 
     const id = store.addReplicaTransfer(replicaKind, replicaId, displayTitle, 'download', {
       priority: opts.priority,
-      isBackground: opts.isBackground,
+      // Replica bundles (fonts, textures, dictionaries, OPDS catalogs) sync on
+      // their own schedule, not because the user asked for this file right
+      // now. Toasting each one turns a fresh device into a wall of
+      // notifications, so they are background — and therefore silent — unless
+      // a caller explicitly opts into the foreground.
+      isBackground: opts.isBackground ?? true,
       files,
       base,
     });
@@ -286,7 +293,8 @@ class TransferManager {
 
     const id = store.addReplicaTransfer(replicaKind, replicaId, displayTitle, 'delete', {
       priority: opts.priority,
-      isBackground: opts.isBackground,
+      // Background by default — see the note on queueReplicaDownload.
+      isBackground: opts.isBackground ?? true,
       files: filenames.map((logical) => ({ logical, lfp: '', byteSize: 0 })),
     });
     this.persistQueue();
@@ -483,20 +491,27 @@ class TransferManager {
           this.processQueue();
         }, delay);
       } else {
-        if (errorMessage.includes('Not authenticated')) {
-          eventDispatcher.dispatch('toast', {
-            type: 'error',
-            message: _('Please log in to continue'),
-          });
-        } else if (isQuotaError) {
-          this.recordQuotaFailure();
-        } else {
-          const errorMessages = getTransferMessages(transfer, _).failure;
+        // Background work fails quietly. The success path has always honoured
+        // `isBackground`; the failure path did not, so a broken replica sync
+        // fired one toast per file (issue #5675 — sixteen "Failed to download
+        // file" toasts for sixteen fonts). The failure is still recorded on
+        // the transfer, which is what the Transfer Queue panel reads.
+        if (!transfer.isBackground) {
+          if (errorMessage.includes('Not authenticated')) {
+            eventDispatcher.dispatch('toast', {
+              type: 'error',
+              message: _('Please log in to continue'),
+            });
+          } else if (isQuotaError) {
+            this.recordQuotaFailure();
+          } else {
+            const errorMessages = getTransferMessages(transfer, _).failure;
 
-          eventDispatcher.dispatch('toast', {
-            type: 'error',
-            message: errorMessages[transfer.type],
-          });
+            eventDispatcher.dispatch('toast', {
+              type: 'error',
+              message: errorMessages[transfer.type],
+            });
+          }
         }
 
         useTransferStore.getState().setTransferStatus(transfer.id, 'failed', errorMessage);


### PR DESCRIPTION
## Problem

Reported in #5675: custom fonts added on one device show up on another by name, but every one of them fails to download. The Transfer Queue shows `Completed: 0, Failed: 16`, each labelled **Unknown error**.

The metadata side is fine. A download is only queued once the server row carries a manifest, and the manifest is committed only after the binary upload succeeds, so the bytes really are in storage. The failure is local.

`download_file` writes with `File::create`, which does not create parent directories. When the destination bundle directory is missing the transfer fails with `No such file or directory (os error 2)`.

The pull path only creates a bundle dir when it **mints a fresh one** for a record it has never seen (`useReplicaPull.createBundleDir`, reached solely on `applyRow`'s `!local` branch). Directory creation is fused with id minting, so reusing an existing `bundleDir` skips the `mkdir` entirely. Three routes then reach the download with nothing on disk:

- a record whose directory was lost afterwards, which is easy because the record and the files live in different places: `settings.json` stays in `AppConfig` while `Fonts/` follows `customRootDir` (`nativeAppService.getPathResolver` applies the custom root to `Fonts` but not to `Settings`). Changing the root, or clearing external storage, orphans every bundle dir while the records survive.
- a transfer replayed from the persisted queue
- Retry All

Book downloads have always guarded this (`cloudService.downloadBook` calls `createDir` first); replica downloads did not.

This is not isolated to one user. Sentry shows `failed to get metadata of path: .../Readest/Fonts/<bundleDir>/<file> ... (os error 2)` across Android, iOS and Windows on 0.11.18 through 0.12.1.

## Changes

**1. Create the destination directory in `downloadReplicaFile`.** Done at the download rather than in `applyRow`, so all three routes are covered. `createDir` is recursive, so it is a no-op when the directory exists.

**2. Keep replica sync transfers silent.** Fonts, textures, dictionaries and OPDS catalogs sync on their own schedule, so a fresh device fired one success toast per file and a broken sync fired one error toast per file. Replica transfers now default to `isBackground`, and the failure path honors that flag. It previously ignored it while the success path respected it, which is why the errors were the loudest part. Failures are still recorded on the transfer for the Transfer Queue panel.

## Verification

Reproduced and fixed on a Xiaomi 2211133C (Android, `customRootDir` on external storage), driving the app over CDP:

| bundle dir | result |
| --- | --- |
| missing | `failed`, `retry: 3`, queue shows `Unknown error`; console shows the real cause `No such file or directory (os error 2)` |
| present | `completed`, 379588 bytes exact, `Georgia:loaded`, `@font-face` injected |

The full loop was also verified before the change: import, binary upload, manifest commit, pull on a simulated fresh device, download, mount. Font sync is not broken on a genuinely fresh device, which is why this only bites records that outlive their directory.

`pnpm test` 9107 passed / 16 skipped, `pnpm lint` and `pnpm format:check` clean. No Rust touched.

## Follow-up worth doing separately

`transferManager` maps any non-`Error` rejection to the literal `Unknown error`. Tauri commands reject with a **string** (`transfer_file.rs` serializes its error enum via `serialize_str`), so every native failure, Forbidden path, HTTP 403/404, network, and disk error alike, arrives as that one useless label. Confirmed both in a unit test and live on device. Accepting `typeof error === 'string'` would have made #5675 self-diagnosing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)