### PR TITLE
feat(sync): add cloud shelves and safe provider deletion

### DIFF
--- a/apps/readest-app/docs/architecture.md
+++ b/apps/readest-app/docs/architecture.md
@@ -371,7 +371,7 @@ and (sometimes) the native shell.
 
 ### 6.1 Sync
 
-Two sync paths coexist:
+Three sync paths coexist:
 
 The first is **legacy KOReader-compatible sync** for reading progress,
 implemented by `src/services/sync/KOSyncClient.ts` against `pages/api/sync.ts`
@@ -386,6 +386,15 @@ category adapters in `src/services/sync/adapters/*` (annotations, settings,
 dictionaries, fonts, textures, OPDS catalogs). The orchestrator is
 `replicaSyncManager.ts`. A cursor store (`replicaCursorStore.ts`) tracks "where
 I last pulled to" per category so syncs are incremental.
+
+The third is **third-party file sync**, a provider-neutral engine under
+`src/services/sync/file` with adapters for WebDAV, Google Drive, S3, OneDrive,
+and iCloud. It stores shared shelf metadata in `library.json` alongside book
+files, covers, and per-book config. Remote-only books appear as cloud-backed
+shelf rows with their cover and reading config; the book file stays remote
+until the user opens or downloads it. A library tombstone removes the row from
+other devices, but provider bytes are deleted only when the user explicitly
+chooses the cloud-and-device deletion action.
 
 ### 6.2 Cloud library
 

--- a/apps/readest-app/docs/code-layout.md
+++ b/apps/readest-app/docs/code-layout.md
@@ -213,13 +213,18 @@ This is shared infrastructure code, not an HTTP backend directory.
 
 ### `src/services/sync`
 
-Sync clients and replica-sync orchestration.
+Sync clients and orchestration.
 
 - legacy/remote sync client code such as `KOSyncClient.ts`
 - replica sync flow: bootstrap, publish, pull, apply, persistence, cursor storage, encryption, and passphrase handling
 - adapter subdirectory for sync categories such as dictionary, font, texture, OPDS catalog, and settings
+- provider-neutral file sync under `file/`, with WebDAV, Google Drive, S3,
+  OneDrive, and iCloud adapters under `providers/`; it reconciles shared
+  `library.json` metadata, covers, per-book config, and book files
 
-This is mostly client-side sync orchestration talking to backend endpoints like `src/pages/api/sync.ts` and `src/pages/api/sync/replicas.ts`.
+This is mostly client-side sync orchestration talking to backend endpoints like
+`src/pages/api/sync.ts` and `src/pages/api/sync/replicas.ts`, or directly to the
+selected third-party file provider.
 
 ### `src/services/send`
 

--- a/apps/readest-app/src/__tests__/app/library/useBookTransferActions.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/useBookTransferActions.test.tsx
@@ -70,11 +70,11 @@ const makeBook = (over: Partial<Book> = {}): Book => ({
   ...over,
 });
 
-const setup = () => {
+const setup = (appService: AppService | null = null) => {
   const updateBook = vi.fn(async (_envConfig: EnvConfigType, _book: Book) => {});
   const updateBookTransferProgress = vi.fn((_bookHash: string, _progress: ProgressPayload) => {});
   const { result } = renderHook(() =>
-    useBookTransferActions(envConfig, null, updateBook, updateBookTransferProgress),
+    useBookTransferActions(envConfig, appService, updateBook, updateBookTransferProgress),
   );
   return { result, updateBook };
 };
@@ -121,7 +121,7 @@ describe('useBookTransferActions upload routing (issue #5062)', () => {
 });
 
 describe('useBookTransferActions download routing (issue #5062)', () => {
-  it('uses the native (queue-backed) path when the book is already in Readest Cloud storage', async () => {
+  it('tries file mirrors first because uploadedAt does not identify which provider has the book (#5009)', async () => {
     routing.readestEnabled = true;
     routing.backends = ['webdav'];
 
@@ -129,8 +129,39 @@ describe('useBookTransferActions download routing (issue #5062)', () => {
     const book = makeBook({ uploadedAt: 12345 });
     const ok = await result.current.handleBookDownload(book, { queued: true });
 
-    expect(runFileBookDownload).not.toHaveBeenCalled();
+    expect(runFileBookDownload).toHaveBeenCalledWith(envConfig, book);
+    expect(queueDownload).not.toHaveBeenCalled();
+    expect(ok).toBe(true);
+  });
+
+  it('falls back to Readest Cloud when no enabled file mirror holds the book', async () => {
+    routing.readestEnabled = true;
+    routing.backends = ['webdav'];
+    runFileBookDownload.mockResolvedValueOnce(false);
+
+    const { result } = setup();
+    const book = makeBook({ uploadedAt: 12345 });
+    const ok = await result.current.handleBookDownload(book, { queued: true });
+
+    expect(runFileBookDownload).toHaveBeenCalledWith(envConfig, book);
     expect(queueDownload).toHaveBeenCalledWith(book, 1);
+    expect(ok).toBe(true);
+  });
+
+  it('falls back to an immediate Readest Cloud download when opening a cloud-shelf book', async () => {
+    routing.readestEnabled = true;
+    routing.backends = ['webdav'];
+    runFileBookDownload.mockResolvedValueOnce(false);
+    const downloadBook = vi.fn(async () => {});
+
+    const { result, updateBook } = setup({ downloadBook } as unknown as AppService);
+    const book = makeBook({ uploadedAt: 12345 });
+    const ok = await result.current.handleBookDownload(book, { queued: false });
+
+    expect(runFileBookDownload).toHaveBeenCalledWith(envConfig, book);
+    expect(downloadBook).toHaveBeenCalledWith(book, false, false, expect.any(Function));
+    expect(queueDownload).not.toHaveBeenCalled();
+    expect(updateBook).toHaveBeenCalledWith(envConfig, book);
     expect(ok).toBe(true);
   });
 

--- a/apps/readest-app/src/__tests__/services/cloud-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/cloud-service.test.ts
@@ -393,6 +393,19 @@ describe('cloudService', () => {
   });
 
   describe('uploadBook', () => {
+    test('clears stale file-sync deletion authorization when reviving a book', async () => {
+      const book = createMockBook({
+        deletedAt: 100,
+        fileSyncDeletionRequestedAt: 100,
+      });
+      const resolveFilePath = vi.fn(async (path: string, base: BaseDir) => `${base}:${path}`);
+
+      await uploadBook(mockFs, resolveFilePath, book);
+
+      expect(book.deletedAt).toBeNull();
+      expect(book.fileSyncDeletionRequestedAt).toBeNull();
+    });
+
     test('uses an existing managed copy before a stale filePath', async () => {
       const book = createMockBook({ filePath: '/Users/me/Library/missing.epub' });
       const managedPath = `${book.hash}/${book.title}.epub`;

--- a/apps/readest-app/src/__tests__/services/import-metahash.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-metahash.test.ts
@@ -158,6 +158,26 @@ describe('importBook metaHash deduplication', () => {
     expect(existingBook.metaHash).toBe(metaHash);
   });
 
+  it('clears file-sync deletion authorization when re-importing the same hash', async () => {
+    const existingBook = makeBook({
+      deletedAt: 100,
+      fileSyncDeletionRequestedAt: 100,
+    });
+    const books: Book[] = [existingBook];
+
+    mockPartialMD5.mockResolvedValue(existingBook.hash);
+    setupMockBookDoc();
+
+    const result = await service.importBook(
+      new File(['same content'], 'test.epub', { type: 'application/epub+zip' }),
+      books,
+    );
+
+    expect(result).toBe(existingBook);
+    expect(existingBook.deletedAt).toBeNull();
+    expect(existingBook.fileSyncDeletionRequestedAt).toBeNull();
+  });
+
   // Cross-device file-update convergence (issue #4544 §E): re-importing an
   // edited file re-keys the hash and clears uploadedAt so the new bytes get
   // re-uploaded; the old entry is soft-deleted. Peers then pull the deleted

--- a/apps/readest-app/src/__tests__/services/sync/file/appLocalStore.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/appLocalStore.test.ts
@@ -12,7 +12,7 @@ import { createAppLocalStore } from '@/services/sync/file/appLocalStore';
  * runs while the library store hasn't loaded yet (the app launched straight
  * into the reader / settings, never mounting the Library view), the engine's
  * addBookToLibrary / updateBookMetadata used to merge against the EMPTY
- * in-memory library and persist a downloaded book (or a metadata update) as
+ * in-memory library and persist a synced book (or a metadata update) as
  * the *entire* library, wiping everything already on disk. The store bridge
  * now hydrates from disk first.
  */
@@ -63,8 +63,20 @@ describe('createAppLocalStore — library hydration (data-loss guard)', () => {
     expect(appService.loadLibraryBooks).toHaveBeenCalledTimes(1);
     expect(savedLibrary).not.toBeNull();
     const hashes = savedLibrary!.map((b) => b.hash).sort();
-    // The downloaded book is appended; a, b must survive (no clobber to [c]).
+    // The synced book is appended; a, b must survive (no clobber to [c]).
     expect(hashes).toEqual(['a', 'b', 'c']);
+  });
+
+  test('addBookToLibrary preserves a metadata-only cloud-shelf row (#5009)', async () => {
+    await makeStore().addBookToLibrary(
+      makeBook('c', { uploadedAt: 900, downloadedAt: null, coverDownloadedAt: 800 }),
+    );
+
+    expect(savedLibrary!.find((book) => book.hash === 'c')).toMatchObject({
+      uploadedAt: 900,
+      downloadedAt: null,
+      coverDownloadedAt: 800,
+    });
   });
 
   test('updateBookMetadata does not wipe the library when the store is unloaded', async () => {
@@ -84,6 +96,67 @@ describe('createAppLocalStore — library hydration (data-loss guard)', () => {
 
     expect(appService.loadLibraryBooks).not.toHaveBeenCalled();
     expect(savedLibrary!.map((b) => b.hash).sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  test('serializes concurrent cloud-shelf additions so neither row is overwritten', async () => {
+    useLibraryStore.getState().setLibrary([makeBook('a'), makeBook('b')]);
+    const originalSave = appService.saveLibraryBooks;
+    vi.mocked(appService.saveLibraryBooks).mockImplementation(async (books: Book[]) => {
+      // Force the first add to finish last. Without a serialized commit, both
+      // calls snapshot [a, b] and the delayed [a, b, c] write drops d.
+      if (books.some((book) => book.hash === 'c') && !books.some((book) => book.hash === 'd')) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      savedLibrary = books;
+    });
+
+    const store = makeStore();
+    await Promise.all([
+      store.addBookToLibrary(makeBook('c')),
+      store.addBookToLibrary(makeBook('d')),
+    ]);
+
+    expect(savedLibrary!.map((book) => book.hash).sort()).toEqual(['a', 'b', 'c', 'd']);
+    expect(
+      useLibraryStore
+        .getState()
+        .library.map((book) => book.hash)
+        .sort(),
+    ).toEqual(['a', 'b', 'c', 'd']);
+    appService.saveLibraryBooks = originalSave;
+  });
+
+  test('replaces an older tombstone when a newer live cloud row is discovered', async () => {
+    useLibraryStore.getState().setLibrary([
+      makeBook('a', {
+        deletedAt: 100,
+        fileSyncDeletionRequestedAt: 100,
+      }),
+      makeBook('b'),
+    ]);
+
+    await makeStore().addBookToLibrary(
+      makeBook('a', {
+        updatedAt: 200,
+        deletedAt: null,
+        fileSyncDeletionRequestedAt: null,
+        downloadedAt: null,
+        uploadedAt: 200,
+      }),
+    );
+
+    expect(savedLibrary!.find((book) => book.hash === 'a')).toMatchObject({
+      deletedAt: null,
+      fileSyncDeletionRequestedAt: null,
+      downloadedAt: null,
+      uploadedAt: 200,
+    });
+    expect(
+      useLibraryStore
+        .getState()
+        .visibleLibrary.map((book) => book.hash)
+        .sort(),
+    ).toEqual(['a', 'b']);
   });
 
   test('deleteBookLocally removes the managed copy and persists the tombstone (#4860)', async () => {

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-deletion-sync.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-deletion-sync.test.ts
@@ -157,7 +157,7 @@ describe('FileSyncEngine.syncLibrary — deletion propagation (#4860)', () => {
     expect(res.booksDeleted).toBe(0);
   });
 
-  test('GCs the remote hash directory of a locally-deleted book', async () => {
+  test('GCs the remote hash directory when the tombstone explicitly authorizes file deletion', async () => {
     const captured: Captured = { writes: [], deletedDirs: [] };
     const provider = fakeProvider({
       readText: async () => null, // fresh remote index
@@ -169,12 +169,111 @@ describe('FileSyncEngine.syncLibrary — deletion propagation (#4860)', () => {
     });
     const store = fakeStore();
 
-    await new FileSyncEngine(provider, store).syncLibrary(
+    const deleted = makeBook('h1', {
+      updatedAt: 100,
+      deletedAt: 100,
+      fileSyncDeletionRequestedAt: 100,
+    });
+
+    await new FileSyncEngine(provider, store).syncLibrary([deleted], {
+      strategy: 'silent',
+      syncBooks: true,
+      deviceId: 'd',
+    });
+
+    expect(captured.deletedDirs).toContain('/Readest/books/h1');
+    const pushed = JSON.parse(libraryWrite(captured)!.body) as RemoteLibraryIndex;
+    expect(pushed.books.find((book) => book.hash === 'h1')?.fileSyncDeletionRequestedAt).toBe(100);
+  });
+
+  test('does not GC provider bytes for an ambiguous tombstone without explicit file-delete intent (#5695)', async () => {
+    const captured: Captured = { writes: [], deletedDirs: [] };
+    const provider = fakeProvider({
+      readText: async () => null,
+      list: async (path: string) =>
+        path.endsWith('/books')
+          ? [{ name: 'h1', path: '/Readest/books/h1', isDirectory: true }]
+          : [],
+      captured,
+    });
+
+    await new FileSyncEngine(provider, fakeStore()).syncLibrary(
       [makeBook('h1', { updatedAt: 100, deletedAt: 100 })],
       { strategy: 'silent', syncBooks: true, deviceId: 'd' },
     );
 
-    expect(captured.deletedDirs).toContain('/Readest/books/h1');
+    // A library tombstone still hides the row, but it is not sufficient proof
+    // that the user chose "Remove from Cloud & Device". Preserving bytes is the
+    // safe default for older or accidentally-tombstoned rows.
+    expect(captured.deletedDirs).toEqual([]);
+  });
+
+  test('does not GC provider bytes when delete authorization belongs to an older tombstone', async () => {
+    const captured: Captured = { writes: [], deletedDirs: [] };
+    const provider = fakeProvider({
+      readText: async () => null,
+      list: async (path: string) =>
+        path.endsWith('/books')
+          ? [{ name: 'h1', path: '/Readest/books/h1', isDirectory: true }]
+          : [],
+      captured,
+    });
+
+    await new FileSyncEngine(provider, fakeStore()).syncLibrary(
+      [
+        makeBook('h1', {
+          updatedAt: 200,
+          deletedAt: 200,
+          fileSyncDeletionRequestedAt: 100,
+        }),
+      ],
+      { strategy: 'silent', syncBooks: true, deviceId: 'd' },
+    );
+
+    expect(captured.deletedDirs).toEqual([]);
+  });
+
+  test('a newer live remote row revives an older tombstone instead of deleting the new provider copy', async () => {
+    const captured: Captured = { writes: [], deletedDirs: [] };
+    const remoteLive = makeBook('h1', { updatedAt: 300, deletedAt: null });
+    const provider = fakeProvider({
+      readText: async (path: string) =>
+        path.endsWith('library.json') ? JSON.stringify(makeIndex([remoteLive])) : null,
+      list: async (path: string) =>
+        path.endsWith('/books')
+          ? [{ name: 'h1', path: '/Readest/books/h1', isDirectory: true }]
+          : [
+              {
+                name: 'Revived.epub',
+                path: '/Readest/books/h1/Revived.epub',
+                isDirectory: false,
+                size: 50,
+              },
+            ],
+      captured,
+    });
+    const addBookToLibrary = vi.fn<(book: Book) => Promise<void>>(async () => {});
+
+    await new FileSyncEngine(provider, fakeStore({ addBookToLibrary })).syncLibrary(
+      [
+        makeBook('h1', {
+          updatedAt: 100,
+          deletedAt: 100,
+          fileSyncDeletionRequestedAt: 100,
+        }),
+      ],
+      { strategy: 'silent', syncBooks: true, deviceId: 'd' },
+    );
+
+    expect(captured.deletedDirs).toEqual([]);
+    expect(addBookToLibrary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hash: 'h1',
+        deletedAt: null,
+        downloadedAt: null,
+      }),
+    );
+    expect(addBookToLibrary.mock.calls[0]![0].fileSyncDeletionRequestedAt).toBeFalsy();
   });
 
   test('does not GC a hash dir that is no longer on the server', async () => {

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-metadata-sync.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-metadata-sync.test.ts
@@ -293,7 +293,7 @@ describe('FileSyncEngine soft-delete propagation', () => {
     const provider = makeProvider(null, null, capture);
     // The GC sweep is separate, so the deleted book's hash dir + file still
     // exist remotely. Passing the deleted book in (it stays in allBooksMap)
-    // must keep the discovery pass from re-adding it as a download candidate.
+    // must keep the discovery pass from re-adding it as a cloud-shelf candidate.
     provider.list = vi.fn(async (path: string) => {
       if (path.endsWith('/books'))
         return [{ name: 'h1', path: '/Readest/books/h1', isDirectory: true }];
@@ -312,7 +312,7 @@ describe('FileSyncEngine soft-delete propagation', () => {
     });
 
     expect(addBookToLibrary).not.toHaveBeenCalled();
-    expect(result.booksDownloaded).toBe(0);
+    expect(result.booksAdded).toBe(0);
     expect(capture.index!.books.find((b) => b.hash === 'h1')!.deletedAt).toBe(500);
   });
 });

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-sync-paths.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-sync-paths.test.ts
@@ -9,9 +9,9 @@ import type { RemoteBookConfig, RemoteLibraryIndex } from '@/services/sync/file/
 /**
  * Coverage for the engine paths the behavior-preservation gate
  * (engine-metadata-sync) does not execute: streaming upload + HEAD
- * short-circuit, remote-only discovery -> streaming download -> addBook, and
- * the receive (pull-only) strategy. These carry the OOM-avoidance and
- * idempotency value of the original WebDAV sync.
+ * short-circuit, remote-only discovery -> metadata-only shelf addition,
+ * explicit streaming download, and the receive (pull-only) strategy. These
+ * carry the OOM-avoidance and idempotency value of the original WebDAV sync.
  */
 
 const makeBook = (hash: string, overrides: Partial<Book> = {}): Book => ({
@@ -110,10 +110,25 @@ describe('FileSyncEngine.pushBookFile — streaming upload', () => {
   });
 });
 
-describe('FileSyncEngine.syncLibrary — remote discovery + streaming download', () => {
-  test('discovers a remote-only book, streams it down, and adds it to the library', async () => {
+describe('FileSyncEngine.syncLibrary — remote discovery + cloud shelf (#5009)', () => {
+  test('adds a remote-only book as metadata without downloading its file', async () => {
     const downloadStream = vi.fn(async () => true);
+    const readBinary = vi.fn(async (path: string) =>
+      path.endsWith('/cover.png') ? new ArrayBuffer(3) : null,
+    );
+    const remoteConfig: RemoteBookConfig = {
+      schemaVersion: 1,
+      bookHash: 'h2',
+      config: { progress: [2, 10], updatedAt: 20 },
+      booknotes: [],
+      writerDeviceId: 'peer',
+      writerVersion: 'readest-webdav-1',
+      updatedAt: 20,
+    };
     const provider = fakeProvider({
+      readText: async (path: string) =>
+        path.endsWith('/config.json') ? JSON.stringify(remoteConfig) : null,
+      readBinary,
       list: async (path: string) =>
         path.endsWith('/books')
           ? [{ name: 'h2', path: '/Readest/books/h2', isDirectory: true }]
@@ -129,7 +144,14 @@ describe('FileSyncEngine.syncLibrary — remote discovery + streaming download',
     });
     const addBookToLibrary = vi.fn<(book: Book) => Promise<void>>(async () => {});
     const prepareLocalBookPath = vi.fn(async () => '/local/h2/Remote.epub');
-    const store = fakeStore({ addBookToLibrary, prepareLocalBookPath });
+    const saveBookCover = vi.fn(async () => {});
+    const saveBookConfig = vi.fn(async () => {});
+    const store = fakeStore({
+      addBookToLibrary,
+      prepareLocalBookPath,
+      saveBookCover,
+      saveBookConfig,
+    });
 
     const res = await new FileSyncEngine(provider, store).syncLibrary([], {
       strategy: 'silent',
@@ -137,13 +159,67 @@ describe('FileSyncEngine.syncLibrary — remote discovery + streaming download',
       deviceId: 'd',
     });
 
-    expect(downloadStream).toHaveBeenCalledWith(
-      '/Readest/books/h2/Remote.epub',
-      '/local/h2/Remote.epub',
+    expect(downloadStream).not.toHaveBeenCalled();
+    expect(prepareLocalBookPath).not.toHaveBeenCalled();
+    expect(readBinary).toHaveBeenCalledTimes(1);
+    expect(readBinary).toHaveBeenCalledWith('/Readest/books/h2/cover.png');
+    expect(saveBookCover).toHaveBeenCalledTimes(1);
+    expect(saveBookConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ hash: 'h2' }),
+      expect.objectContaining({ progress: [2, 10] }),
     );
     expect(addBookToLibrary).toHaveBeenCalledTimes(1);
-    expect(addBookToLibrary.mock.calls[0]![0].hash).toBe('h2');
-    expect(res.booksDownloaded).toBe(1);
+    expect(addBookToLibrary.mock.calls[0]![0]).toMatchObject({
+      hash: 'h2',
+      downloadedAt: null,
+    });
+    expect(addBookToLibrary.mock.calls[0]![0].uploadedAt).toEqual(expect.any(Number));
+    expect(addBookToLibrary.mock.calls[0]![0].coverDownloadedAt).toEqual(expect.any(Number));
+    expect(res.configsDownloaded).toBe(1);
+    expect(res.booksAdded).toBe(1);
+  });
+
+  test('still adds the cloud-shelf row when optional cover and config pulls fail', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const provider = fakeProvider({
+      readText: async (path: string) => {
+        if (path.endsWith('/config.json')) throw new Error('config unavailable');
+        return null;
+      },
+      readBinary: async () => {
+        throw new Error('cover unavailable');
+      },
+      list: async (path: string) =>
+        path.endsWith('/books')
+          ? [{ name: 'h2', path: '/Readest/books/h2', isDirectory: true }]
+          : [
+              {
+                name: 'Remote.epub',
+                path: '/Readest/books/h2/Remote.epub',
+                isDirectory: false,
+                size: 50,
+              },
+            ],
+    });
+    const addBookToLibrary = vi.fn<(book: Book) => Promise<void>>(async () => {});
+
+    const res = await new FileSyncEngine(provider, fakeStore({ addBookToLibrary })).syncLibrary(
+      [],
+      {
+        strategy: 'silent',
+        syncBooks: false,
+        deviceId: 'd',
+      },
+    );
+
+    expect(addBookToLibrary).toHaveBeenCalledWith(
+      expect.objectContaining({ hash: 'h2', uploadedAt: expect.any(Number), downloadedAt: null }),
+    );
+    expect(res.booksAdded).toBe(1);
+    expect(res.failures).toBe(0);
+    expect(warn).toHaveBeenCalledWith('file sync: cover download failed', 'h2', expect.any(Error));
+    expect(warn).toHaveBeenCalledWith('file sync: config download failed', 'h2', expect.any(Error));
+    warn.mockRestore();
   });
 });
 
@@ -736,7 +812,7 @@ describe('FileSyncEngine.syncLibrary — empty-dir record', () => {
     });
     const res = await new FileSyncEngine(provider, fakeStore()).syncLibrary([], opts);
 
-    expect(res.booksDownloaded).toBe(0);
+    expect(res.booksAdded).toBe(0);
     const idx = JSON.parse(
       captured.writes.find((w) => w.path.endsWith('library.json'))!.body,
     ) as RemoteLibraryIndex;
@@ -785,7 +861,7 @@ describe('FileSyncEngine.syncLibrary — empty-dir record', () => {
       opts,
     );
 
-    expect(res.booksDownloaded).toBe(1);
+    expect(res.booksAdded).toBe(1);
     const idx = JSON.parse(
       captured.writes.find((w) => w.path.endsWith('library.json'))!.body,
     ) as RemoteLibraryIndex;

--- a/apps/readest-app/src/app/library/hooks/useBookTransferActions.ts
+++ b/apps/readest-app/src/app/library/hooks/useBookTransferActions.ts
@@ -88,22 +88,35 @@ export const useBookTransferActions = (
       const settingsNow = useSettingsStore.getState().settings;
       const backends = getActiveFileSyncBackends(settingsNow);
       const readest = isReadestCloudEnabled(settingsNow);
-      // Prefer Readest Cloud when the book is actually in its storage — that is
-      // the resumable, queue-backed path. Otherwise fetch it from a file mirror.
-      const useFileBackend = backends.length > 0 && !(readest && book.uploadedAt);
-      if (useFileBackend) {
+      // `uploadedAt` proves that some cloud copy exists, but it does not encode
+      // provenance: the file-sync engine stamps it for WebDAV/Drive/S3/etc. too.
+      // Try the enabled file mirrors first so a metadata-only shelf row is not
+      // misrouted into Readest Cloud. When none has the file, fall through to
+      // the native, resumable path if that backend is also enabled (#5009).
+      if (backends.length > 0) {
         const ok = await runFileBookDownload(envConfig, book);
-        if (ok) await updateBook(envConfig, book);
-        if (!silent) {
-          eventDispatcher.dispatch('toast', {
-            type: ok ? 'info' : 'error',
-            timeout: 2000,
-            message: ok
-              ? _('Book downloaded: {{title}}', { title: book.title })
-              : _('Failed to download book: {{title}}', { title: book.title }),
-          });
+        if (ok) {
+          await updateBook(envConfig, book);
+          if (!silent) {
+            eventDispatcher.dispatch('toast', {
+              type: 'info',
+              timeout: 2000,
+              message: _('Book downloaded: {{title}}', { title: book.title }),
+            });
+          }
+          return true;
         }
-        return ok;
+
+        if (!readest || !book.uploadedAt) {
+          if (!silent) {
+            eventDispatcher.dispatch('toast', {
+              type: 'error',
+              timeout: 2000,
+              message: _('Failed to download book: {{title}}', { title: book.title }),
+            });
+          }
+          return false;
+        }
       }
 
       if (redownload || !queued) {

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -1134,9 +1134,20 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
         if (deleteAction === 'local' || deleteAction === 'both' || deleteAction === 'purge') {
           await appService?.deleteBook(book, deleteAction === 'purge' ? 'purge' : 'local');
           if (deleteAction === 'both' || deleteAction === 'purge') {
-            book.deletedAt = Date.now();
+            const deletedAt = Date.now();
+            book.deletedAt = deletedAt;
+            // A library tombstone alone is not permission to destroy bytes on
+            // a third-party file mirror. Bind the explicit cloud-and-device
+            // intent to this exact tombstone so the file-sync engine can
+            // distinguish it from a local-only or indirectly-created delete
+            // (#5695, the third recurrence of #5084).
+            book.fileSyncDeletionRequestedAt = deletedAt;
             book.downloadedAt = null;
             book.coverDownloadedAt = null;
+          } else {
+            // "Remove from Device Only" must never leave stale authorization
+            // from an older delete/re-import cycle on the live row.
+            book.fileSyncDeletionRequestedAt = null;
           }
           await updateBook(envConfig, book);
           if (ttsSessionManager.getSessionByHash(book.hash)) {

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -540,6 +540,7 @@ export async function importBook(
     if (existingBook) {
       if (!transient) {
         existingBook.deletedAt = null;
+        existingBook.fileSyncDeletionRequestedAt = null;
       }
       existingBook.createdAt = Date.now();
       existingBook.updatedAt = Date.now();

--- a/apps/readest-app/src/services/cloudService.ts
+++ b/apps/readest-app/src/services/cloudService.ts
@@ -221,6 +221,7 @@ export async function uploadBook(
   completedFiles.count++;
 
   book.deletedAt = null;
+  book.fileSyncDeletionRequestedAt = null;
   book.updatedAt = Date.now();
   book.uploadedAt = Date.now();
   book.downloadedAt = Date.now();

--- a/apps/readest-app/src/services/sync/file/appLocalStore.ts
+++ b/apps/readest-app/src/services/sync/file/appLocalStore.ts
@@ -32,6 +32,24 @@ const resolveLocalSource = async (
   return null;
 };
 
+// Cloud-shelf discovery prepares covers/configs concurrently, but library
+// persistence is a read-modify-write transaction. Serialize commits per app
+// service so two providers or two remote books cannot save L+A / L+B over each
+// other. Weak keys avoid retaining an app instance after its environment dies.
+const libraryAddQueues = new WeakMap<AppService, Promise<void>>();
+const serializeLibraryAdd = async (
+  appService: AppService,
+  work: () => Promise<void>,
+): Promise<void> => {
+  const queue = libraryAddQueues.get(appService) ?? Promise.resolve();
+  const run = queue.then(work, work);
+  libraryAddQueues.set(
+    appService,
+    run.catch(() => {}),
+  );
+  await run;
+};
+
 /**
  * The app-backed {@link LocalStore} used by every file-sync consumer (the
  * reader hook and the library "Sync now" form). Consolidating the buffered +
@@ -111,25 +129,46 @@ export const createAppLocalStore = ({
       book.coverImageUrl = null;
     }
     book.syncedAt = Date.now();
-    book.downloadedAt = Date.now();
+    // The caller owns file availability. Library discovery deliberately adds
+    // cloud-shelf rows with `downloadedAt: null`; stamping them here would turn
+    // metadata-only sync back into a false claim that the EPUB/PDF is on disk.
     if (!book.metaHash) book.metaHash = book.hash;
-    // Hydrate from disk if the store hasn't loaded yet. Merging against an
-    // empty in-memory array would persist this book as the *entire* library
-    // and clobber whatever is on disk. Mirrors useLibraryStore.updateBooks'
-    // hardening; the Sync-now caller also hydrates up front, so this is
-    // belt-and-suspenders for a data-loss path.
-    let library = useLibraryStore.getState().library;
-    if (!useLibraryStore.getState().libraryLoaded) {
-      library = await appService.loadLibraryBooks();
-      useLibraryStore.getState().setLibrary(library);
-    }
-    // Avoid duplicates if the user runs Sync now twice quickly.
-    if (library.find((b) => b.hash === book.hash)) return;
-    const newLibrary = [...library, book];
-    await appService.saveLibraryBooks(newLibrary);
-    // Update the store last so subscribers re-render against a library that's
-    // already persisted on disk.
-    useLibraryStore.getState().setLibrary(newLibrary);
+    await serializeLibraryAdd(appService, async () => {
+      // Hydrate from disk if the store hasn't loaded yet. Merging against an
+      // empty in-memory array would persist this book as the *entire* library
+      // and clobber whatever is on disk. Mirrors useLibraryStore.updateBooks'
+      // hardening; the Sync-now caller also hydrates up front, so this is
+      // belt-and-suspenders for a data-loss path.
+      let library = useLibraryStore.getState().library;
+      if (!useLibraryStore.getState().libraryLoaded) {
+        library = await appService.loadLibraryBooks();
+        useLibraryStore.getState().setLibrary(library);
+      }
+
+      const existingIndex = library.findIndex((candidate) => candidate.hash === book.hash);
+      if (existingIndex >= 0) {
+        const existing = library[existingIndex]!;
+        // A newer live remote row is a re-import/revival of this hash. Replace
+        // the older tombstone with the metadata-only row; every other duplicate
+        // remains an idempotent no-op.
+        if (
+          !existing.deletedAt ||
+          book.deletedAt ||
+          (book.updatedAt ?? 0) <= (existing.deletedAt ?? 0)
+        ) {
+          return;
+        }
+      }
+
+      const newLibrary =
+        existingIndex >= 0
+          ? [...library.slice(0, existingIndex), book, ...library.slice(existingIndex + 1)]
+          : [...library, book];
+      await appService.saveLibraryBooks(newLibrary);
+      // Update the store last so subscribers re-render against a library that's
+      // already persisted on disk.
+      useLibraryStore.getState().setLibrary(newLibrary);
+    });
   },
 
   updateBookMetadata: async (book) => {

--- a/apps/readest-app/src/services/sync/file/engine.ts
+++ b/apps/readest-app/src/services/sync/file/engine.ts
@@ -68,12 +68,13 @@ export interface SyncLibraryResult {
   filesUploaded: number;
   filesAlreadyInSync: number;
   coversUploaded: number;
-  booksDownloaded: number;
+  /** Remote-only books added to the local shelf without downloading their files (#5009). */
+  booksAdded: number;
   /** Local books removed because a peer's tombstone propagated to this device (#4860). */
   booksDeleted: number;
   /** Already-local books whose metadata was refreshed from a newer index copy (#4756). */
   metadataUpdated: number;
-  /** Distinct books that had any sync activity (pushed, downloaded, or reconciled). */
+  /** Distinct books that had any sync activity (pushed, added, or reconciled). */
   booksSynced: number;
   failures: number;
   /** Per-book failure breakdown for the diagnostic log in the Settings UI. */
@@ -427,8 +428,9 @@ export class FileSyncEngine {
    * plus cover + config best-effort — the explicit per-book Download action
    * (Book Details / bookshelf cloud button) for a third-party provider.
    * The on-disk filename is resolved by listing the dir (titles go stale).
-   * Returns false when the remote holds no book file. syncLibrary's discovery
-   * loop covers the library-wide variant of this.
+   * Returns false when the remote holds no book file. `syncLibrary` only adds
+   * metadata-only shelf rows; it deliberately leaves this binary transfer to
+   * the explicit action.
    */
   async downloadBookFile(book: Book): Promise<boolean> {
     const dirPath = buildBookDirPath(this.provider.rootPath, book.hash);
@@ -485,9 +487,9 @@ export class FileSyncEngine {
   /**
    * Sync every book in `books` against the remote in sequence (predictable
    * progress bar; no parallel PUTs that upset shared servers). Per book:
-   * pull index → reconcile metadata (LWW) → discover remote-only books and
-   * download them → pull-merge-push each local config + cover + (optionally)
-   * file → re-push the merged index.
+   * pull index → reconcile metadata (LWW) → add remote-only cloud-shelf rows
+   * → pull-merge-push each local config + cover + (optionally) file → re-push
+   * the merged index.
    *
    * Strategy gating: 'silent' two-way, 'send' push-only (blind, local
    * authoritative), 'receive' pull-only. Single-book failures are caught and
@@ -501,7 +503,7 @@ export class FileSyncEngine {
       filesUploaded: 0,
       filesAlreadyInSync: 0,
       coversUploaded: 0,
-      booksDownloaded: 0,
+      booksAdded: 0,
       booksDeleted: 0,
       metadataUpdated: 0,
       booksSynced: 0,
@@ -656,11 +658,7 @@ export class FileSyncEngine {
       if (uploadedHashes.has(book.hash)) stampCloudCopy(book.hash);
     }
 
-    const remoteBooksToDownload: Book[] = [];
-    // The remote source of truth for a book's on-disk filename is the per-hash
-    // directory listing — NOT the book's title (which may be stale). We always
-    // resolve the path by listing the hash dir.
-    const explicitRemotePaths = new Map<string, string>();
+    const remoteBooksToAdd: Book[] = [];
 
     // Metadata reconciliation for books present BOTH locally and in the shared
     // library.json (#4756). Last-writer-wins on `book.updatedAt`: when a peer's
@@ -743,6 +741,10 @@ export class FileSyncEngine {
         const deleted: Book = {
           ...local,
           deletedAt: rb.deletedAt,
+          // Carry the peer's explicit provider-file deletion intent with the
+          // tombstone. Older/ambiguous tombstones intentionally leave this
+          // absent, which hides the row without destroying recoverable bytes.
+          fileSyncDeletionRequestedAt: rb.fileSyncDeletionRequestedAt,
           downloadedAt: null,
           coverDownloadedAt: null,
           updatedAt: Math.max(local.updatedAt ?? 0, rb.updatedAt ?? 0),
@@ -780,7 +782,10 @@ export class FileSyncEngine {
       // 1) Seed with hashes from the remote index (when the file exists).
       if (remoteIndex && remoteIndex.books) {
         for (const rb of remoteIndex.books) {
-          if (!allBooksMap.has(rb.hash) && !rb.deletedAt) {
+          const local = allBooksMap.get(rb.hash);
+          const revivesLocalTombstone =
+            !!local?.deletedAt && (rb.updatedAt ?? 0) > (local.deletedAt ?? 0);
+          if ((!local || revivesLocalTombstone) && !rb.deletedAt) {
             candidateHashes.add(rb.hash);
             // Provisionally register the indexed book — fields refreshed below
             // once we've inspected the actual hash dir. Strip the pushing
@@ -862,8 +867,7 @@ export class FileSyncEngine {
                 updatedAt: Date.now(),
               };
 
-          explicitRemotePaths.set(hash, fileEntry.path);
-          remoteBooksToDownload.push(book);
+          remoteBooksToAdd.push(book);
           allBooksMap.set(hash, book);
         } catch (e) {
           noteAbort(e);
@@ -872,78 +876,58 @@ export class FileSyncEngine {
       }
     }
 
-    // Discovery+download is NOT gated on `syncBooks`. The toggle controls
-    // whether the *push* side ships binaries to the remote — pulling books
-    // that exist remotely but not locally is the whole point of a sync.
+    // Discovery is NOT gated on `syncBooks`. The toggle controls whether this
+    // device uploads local book files. A remote-only book is materialised as a
+    // cloud-shelf row with its cover and reading config, while the immutable
+    // book file stays on the provider until the user opens or downloads it
+    // explicitly (#5009). This keeps secondary devices lightweight regardless
+    // of which FileSyncProvider transport is active.
     if (canPull) {
-      let downloadStarted = 0;
+      let addStarted = 0;
       await runPool(
-        remoteBooksToDownload,
+        remoteBooksToAdd,
         concurrency,
         async (rb) => {
           options.onProgress?.({
             book: rb,
-            index: downloadStarted,
-            total: remoteBooksToDownload.length,
+            index: addStarted,
+            total: remoteBooksToAdd.length,
             action: 'downloading',
           });
-          downloadStarted += 1;
+          addStarted += 1;
           try {
-            const explicitPath = explicitRemotePaths.get(rb.hash);
-            // Prefer the streaming downloader. On Tauri/Android we MUST take
-            // this path — moving a 30 MB epub through the WebView<->Rust IPC
-            // bridge as a single Uint8Array crashes the renderer.
-            let written = false;
-            if (this.provider.downloadStream && explicitPath) {
-              const dst = await this.store.prepareLocalBookPath(rb);
-              written = await this.provider.downloadStream(explicitPath, dst);
-            } else {
-              const remotePath = explicitPath ?? buildBookFilePath(this.provider.rootPath, rb);
-              const fileBytes = await this.provider.readBinary(remotePath);
-              if (fileBytes) {
-                await this.store.saveBookFile(rb, fileBytes);
-                written = true;
+            try {
+              const coverBytes = await this.pullBookCover(rb.hash);
+              if (coverBytes) {
+                await this.store.saveBookCover(rb, coverBytes);
+                rb.coverDownloadedAt = Date.now();
               }
+            } catch (e) {
+              console.warn('file sync: cover download failed', rb.hash, e);
             }
-            if (written) {
-              try {
-                const coverBytes = await this.pullBookCover(rb.hash);
-                if (coverBytes) await this.store.saveBookCover(rb, coverBytes);
-              } catch (e) {
-                console.warn('file sync: cover download failed', rb.hash, e);
+
+            // Pull the remote config so progress, bookmarks and annotations
+            // are ready before the placeholder appears. Best-effort: a missing
+            // config or cover must not hide an otherwise downloadable book.
+            try {
+              const emptyLocal: BookConfig = { updatedAt: 0, booknotes: [] };
+              const pullResult = await this.pullBookConfig(rb, emptyLocal);
+              if (pullResult.applied && pullResult.mergedConfig) {
+                await this.store.saveBookConfig(rb, pullResult.mergedConfig);
+                result.configsDownloaded += 1;
               }
-              // Pull the remote config so progress, bookmarks and annotations
-              // travel with the book. Best-effort: a missing config is not a
-              // failure.
-              try {
-                const emptyLocal: BookConfig = { updatedAt: 0, booknotes: [] };
-                const pullResult = await this.pullBookConfig(rb, emptyLocal);
-                if (pullResult.applied && pullResult.mergedConfig) {
-                  await this.store.saveBookConfig(rb, pullResult.mergedConfig);
-                  result.configsDownloaded += 1;
-                }
-              } catch (e) {
-                console.warn('file sync: config download failed', rb.hash, e);
-              }
-              // We just pulled its bytes, so the file is on the remote: the row is
-              // cloud-backed (#5084) and addBookToLibrary persists the stamp.
-              rb.uploadedAt = Date.now();
-              await this.store.addBookToLibrary(rb);
-              result.booksDownloaded += 1;
-              syncedHashes.add(rb.hash);
-              // Record it so a later push-side sync doesn't HEAD-probe it back.
-              uploadedHashes.add(rb.hash);
-            } else {
-              // No bytes returned (typically a 404 we couldn't resolve).
-              result.failures += 1;
-              result.failedBooks.push({
-                hash: rb.hash,
-                title: rb.title || rb.hash,
-                phase: 'download',
-                reason: 'No bytes returned (file may have been moved or deleted on the server)',
-              });
-              console.warn('file sync: book download produced no bytes', rb.hash, explicitPath);
+            } catch (e) {
+              console.warn('file sync: config download failed', rb.hash, e);
             }
+
+            rb.uploadedAt = rb.uploadedAt ?? Date.now();
+            rb.downloadedAt = null;
+            await this.store.addBookToLibrary(rb);
+            result.booksAdded += 1;
+            syncedHashes.add(rb.hash);
+            // Discovery confirmed the immutable file exists remotely. Record
+            // it so future incremental passes do not HEAD-probe or re-discover it.
+            uploadedHashes.add(rb.hash);
           } catch (e) {
             noteAbort(e);
             result.failures += 1;
@@ -953,16 +937,16 @@ export class FileSyncEngine {
               phase: 'download',
               reason: formatFailureReason(e),
             });
-            console.warn('file sync: book download failed', rb.hash, e);
+            console.warn('file sync: cloud-shelf add failed', rb.hash, e);
           }
         },
         aborted,
       );
     }
 
-    // Books we just downloaded already exist on the remote — don't re-push
+    // Books we just added already exist on the remote — don't re-push
     // them. Only push books already present in the caller-supplied library.
-    const downloadedHashes = new Set(remoteBooksToDownload.map((b) => b.hash));
+    const addedHashes = new Set(remoteBooksToAdd.map((b) => b.hash));
     // A book's config/cover only need pushing when it changed locally since the
     // last index push (incremental; full-sync re-checks everything). Its FILE,
     // by contrast, is immutable per hash and only needs uploading when the
@@ -978,7 +962,7 @@ export class FileSyncEngine {
     const booksToPush = books.filter(
       (b) =>
         !isEffectivelyDeleted(b) &&
-        !downloadedHashes.has(b.hash) &&
+        !addedHashes.has(b.hash) &&
         (configChanged(b) || needsFilePush(b)),
     );
     result.totalBooks = booksToPush.length;
@@ -1090,14 +1074,18 @@ export class FileSyncEngine {
         }
       }
 
-      // GC the remote per-hash directory of every tombstoned book whose files
-      // still linger on the server (#4860). Scoped to dirs the discovery scan
-      // actually saw, so a dir removed on a previous sync is never re-DELETEd
-      // and 'send' mode (which never lists) is a safe no-op. This is what makes
-      // a deletion reclaim server space instead of leaving orphaned book files.
-      const dirsToGc = Array.from(remoteHashDirs).filter(
-        (hash) => indexByHash.get(hash)?.deletedAt,
-      );
+      // GC only when the current tombstone carries a matching, explicit
+      // provider-file deletion authorization (#5695). `deletedAt` by itself is
+      // library membership state and can come from older clients or indirect
+      // cleanup paths; treating it as permission to destroy the only remaining
+      // copy is what made "Remove from Device Only" destructive. Equality binds
+      // the authorization to this deletion and rejects a stale marker left by a
+      // prior delete/re-import cycle. Discovery scoping still avoids repeated
+      // DELETEs, and send mode (which never lists) remains a safe no-op.
+      const dirsToGc = Array.from(remoteHashDirs).filter((hash) => {
+        const book = indexByHash.get(hash);
+        return !!book?.deletedAt && book.fileSyncDeletionRequestedAt === book.deletedAt;
+      });
       await runPool(dirsToGc, concurrency, async (hash) => {
         try {
           await deleteRemoteBookDir(this.provider, hash);
@@ -1139,6 +1127,8 @@ export class FileSyncEngine {
           const r = remoteAllByHash.get(b.hash);
           if (!r) return true;
           if (!!r.deletedAt !== !!b.deletedAt) return true;
+          if ((r.fileSyncDeletionRequestedAt ?? 0) !== (b.fileSyncDeletionRequestedAt ?? 0))
+            return true;
           return (b.updatedAt ?? 0) > (r.updatedAt ?? 0);
         });
 

--- a/apps/readest-app/src/services/sync/file/wire.ts
+++ b/apps/readest-app/src/services/sync/file/wire.ts
@@ -158,5 +158,8 @@ export const stripDeviceLocalFields = (book: Book): Book => {
   for (const field of DEVICE_LOCAL_BOOK_FIELDS) {
     delete copy[field];
   }
+  // Delete authorization belongs to one tombstone only. Never publish or
+  // adopt it on a live row after a re-import/revival.
+  if (!copy.deletedAt) delete copy.fileSyncDeletionRequestedAt;
   return copy;
 };

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -115,6 +115,12 @@ export interface Book {
   createdAt: number;
   updatedAt: number;
   deletedAt?: number | null;
+  /**
+   * Positive authorization to delete this book's directory from third-party
+   * file-sync providers. Must equal the current `deletedAt` tombstone; a plain
+   * tombstone hides the library row but preserves provider bytes (#5695).
+   */
+  fileSyncDeletionRequestedAt?: number | null;
 
   uploadedAt?: number | null;
   downloadedAt?: number | null;


### PR DESCRIPTION
## Summary

- add `fileSyncDeletionRequestedAt` so a library tombstone deletes third-party provider bytes only when the user explicitly requested cloud-file deletion
- preserve provider files for local-only and ambiguous/legacy deletions, and clear stale authorization on re-import, upload, or newer remote revival
- implement metadata-only Cloud Shelf sync in the shared file-sync engine: sync book rows, covers, and progress while downloading EPUB/PDF files only on open or explicit download
- apply Cloud Shelf behavior to WebDAV, Google Drive, S3, OneDrive, and iCloud, including file-provider-first routing with Readest Cloud fallback
- serialize concurrent shelf additions so multiple remote books cannot overwrite each other in the local library

## Verification

- `pnpm test -- --watch=false`: 728 files passed, 4 skipped; 9,126 tests passed, 16 skipped
- `pnpm lint`: TypeScript and Biome passed across 2,030 files
- `pnpm build`: production Next.js build, TypeScript, and static export passed
- adversarial data-safety re-review: clean after regression fixes

## Test coverage

Coverage audit: 86% of changed executable paths (59/69).

- deletion authorization: matching, missing, stale, re-import, upload revival, and newer-live-row cases covered
- Cloud Shelf: no binary download, cover/config sync, optional metadata failures, concurrent additions, and tombstone replacement covered
- explicit download: buffered/streaming paths plus queued and immediate Readest Cloud fallbacks covered
- provider scope: shared engine and registry cover WebDAV, Google Drive, S3, OneDrive, and iCloud

No relevant saved implementation plan was found. Live-provider end-to-end testing was not run because provider credentials are not configured in this workspace.

## Documentation

- `docs/architecture.md`: documented third-party file sync as the third sync path, including cloud-shelf rows and explicit provider-file deletion semantics
- `docs/code-layout.md`: documented the shared file-sync engine and its WebDAV, Google Drive, S3, OneDrive, and iCloud adapters

Documentation debt: third-party file sync has reference and explanation coverage, but no task-oriented setup guide in this repository.

Closes #5695
Closes #5009
