### PR TITLE
feat(sync): optional document metadata on KOSync progress uploads

### DIFF
--- a/apps/readest-app/src/__tests__/components/settings/KOSyncFormSendMetadata.test.tsx
+++ b/apps/readest-app/src/__tests__/components/settings/KOSyncFormSendMetadata.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { SystemSettings } from '@/types/settings';
+import { useSettingsStore } from '@/store/settingsStore';
+
+const saveSettings = vi.fn(async () => {});
+
+vi.mock('@tauri-apps/plugin-os', () => ({ type: vi.fn(async () => 'macos') }));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({
+    envConfig: { getAppService: async () => ({ saveSettings }) },
+    appService: null,
+  }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+vi.mock('@/utils/settingsSync', () => ({
+  broadcastGlobalSettings: vi.fn(),
+}));
+
+import KOSyncForm from '@/components/settings/integrations/KOSyncForm';
+
+const settings = {
+  kosync: {
+    enabled: true,
+    serverUrl: 'https://sync.example.com',
+    username: 'alice',
+    userkey: 'key',
+    password: '',
+    deviceId: 'device-1',
+    deviceName: 'Readest',
+    checksumMethod: 'binary',
+    strategy: 'prompt',
+  },
+} as unknown as SystemSettings;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useSettingsStore.setState({ settings } as never);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('KOSyncForm Send Document Metadata setting', () => {
+  test('defaults off and persists both toggle states', async () => {
+    render(<KOSyncForm onBack={vi.fn()} />);
+
+    const toggle = screen.getByRole('checkbox', { name: 'Send Document Metadata' });
+    expect((toggle as HTMLInputElement).checked).toBe(false);
+
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(useSettingsStore.getState().settings.kosync.sendMetadata).toBe(true);
+    });
+    expect(saveSettings).toHaveBeenLastCalledWith(
+      expect.objectContaining({ kosync: expect.objectContaining({ sendMetadata: true }) }),
+    );
+
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(useSettingsStore.getState().settings.kosync.sendMetadata).toBe(false);
+    });
+    expect(saveSettings).toHaveBeenLastCalledWith(
+      expect.objectContaining({ kosync: expect.objectContaining({ sendMetadata: false }) }),
+    );
+  });
+});

--- a/apps/readest-app/src/__tests__/services/sync/KOSyncClient.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/KOSyncClient.test.ts
@@ -250,6 +250,56 @@ describe('KOSyncClient.updateProgress – document metadata', () => {
     expect(body['percentage']).toBe(0.14);
   });
 
+  it('newline-joins structured authors instead of sending localized display punctuation', async () => {
+    const mock = setFetch(() => jsonResponse(200, {}));
+
+    const book = {
+      ...makeBook(),
+      author: 'Alexandre Dumas et Auguste Maquet',
+      format: 'EPUB',
+      metadata: {
+        author: [{ name: { en: 'Alexandre Dumas' } }, { name: { en: 'Auguste Maquet' } }],
+      },
+    } as unknown as Book;
+    const client = new KOSyncClient(makeConfig({ userkey: 'key', sendMetadata: true }));
+    await client.updateProgress(book, '/body/DocFragment[12]', 0.14);
+
+    const metadata = sentBody(mock)['metadata'] as Record<string, string>;
+    expect(metadata['authors']).toBe('Alexandre Dumas\nAuguste Maquet');
+  });
+
+  it.each([
+    {
+      label: 'trims string contributors and string names',
+      metadataAuthors: [' Alexandre Dumas ', { name: ' Auguste Maquet ' }],
+      expected: 'Alexandre Dumas\nAuguste Maquet',
+    },
+    {
+      label: 'uses the first non-empty translated name when the user language is missing',
+      metadataAuthors: [null, { name: { fr: ' Victor Hugo ' } }],
+      expected: 'Victor Hugo',
+    },
+    {
+      label: 'falls back to the display author when no structured name is usable',
+      metadataAuthors: [null, {}, { name: { en: '  ' } }],
+      expected: 'Fallback Author',
+    },
+  ])('$label', async ({ metadataAuthors, expected }) => {
+    const mock = setFetch(() => jsonResponse(200, {}));
+    const book = {
+      ...makeBook(),
+      author: 'Fallback Author',
+      format: 'EPUB',
+      metadata: { author: metadataAuthors },
+    } as unknown as Book;
+    const client = new KOSyncClient(makeConfig({ userkey: 'key', sendMetadata: true }));
+
+    await client.updateProgress(book, '/body/DocFragment[12]', 0.14);
+
+    const metadata = sentBody(mock)['metadata'] as Record<string, string>;
+    expect(metadata['authors']).toBe(expected);
+  });
+
   it('names the file by its source title when that differs from the display title', async () => {
     const mock = setFetch(() => jsonResponse(200, {}));
 

--- a/apps/readest-app/src/__tests__/services/sync/KOSyncClient.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/KOSyncClient.test.ts
@@ -204,3 +204,68 @@ describe('KOSyncClient – custom headers', () => {
     expect(headers['x-auth-key']).toBe('real-key');
   });
 });
+
+describe('KOSyncClient.updateProgress – document metadata', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const sentBody = (mock: FetchMock): Record<string, unknown> => {
+    const [, init] = mock.mock.calls[0] as [string, RequestInit];
+    return JSON.parse(init.body as string);
+  };
+
+  it('omits metadata by default, matching KOReader', async () => {
+    const mock = setFetch(() => jsonResponse(200, {}));
+
+    const client = new KOSyncClient(makeConfig({ userkey: 'key' }));
+    await client.updateProgress(makeBook(), '/body/DocFragment[12]', 0.14);
+
+    expect(sentBody(mock)).not.toHaveProperty('metadata');
+  });
+
+  it('sends filename, title and authors when Send Document Metadata is on', async () => {
+    const mock = setFetch(() => jsonResponse(200, {}));
+
+    const book = {
+      ...makeBook(),
+      title: 'The Count of Monte Cristo',
+      author: 'Alexandre Dumas',
+      format: 'EPUB',
+    } as Book;
+    const client = new KOSyncClient(makeConfig({ userkey: 'key', sendMetadata: true }));
+    await client.updateProgress(book, '/body/DocFragment[12]', 0.14);
+
+    const body = sentBody(mock);
+    expect(body['metadata']).toEqual({
+      filename: 'The Count of Monte Cristo.epub',
+      title: 'The Count of Monte Cristo',
+      authors: 'Alexandre Dumas',
+    });
+    // The standard fields are unchanged next to it.
+    expect(body['document']).toBe(book.hash);
+    expect(body['percentage']).toBe(0.14);
+  });
+
+  it('names the file by its source title when that differs from the display title', async () => {
+    const mock = setFetch(() => jsonResponse(200, {}));
+
+    const book = {
+      ...makeBook(),
+      title: 'A Title the Reader Edited',
+      sourceTitle: 'original_import_name',
+      author: 'Someone',
+      format: 'EPUB',
+    } as Book;
+    const client = new KOSyncClient(makeConfig({ userkey: 'key', sendMetadata: true }));
+    await client.updateProgress(book, '/body/DocFragment[1]', 0.5);
+
+    const metadata = sentBody(mock)['metadata'] as Record<string, string>;
+    expect(metadata['filename']).toBe('original_import_name.epub');
+    // The title stays the one the user sees.
+    expect(metadata['title']).toBe('A Title the Reader Edited');
+  });
+});

--- a/apps/readest-app/src/components/settings/integrations/KOSyncForm.tsx
+++ b/apps/readest-app/src/components/settings/integrations/KOSyncForm.tsx
@@ -183,6 +183,13 @@ const KOSyncForm: React.FC<KOSyncFormProps> = ({ onBack }) => {
     await saveSettings(envConfig, newSettings);
   };
 
+  const handleToggleSendMetadata = async () => {
+    const kosync = { ...settings.kosync, sendMetadata: !settings.kosync.sendMetadata };
+    const newSettings = { ...settings, kosync };
+    setSettings(newSettings);
+    await saveSettings(envConfig, newSettings);
+  };
+
   const description: string = isConfigured
     ? _('Sync as {{userDisplayName}}', { userDisplayName: settings.kosync.username })
     : _('Connect to your KOReader Sync server.');
@@ -235,6 +242,17 @@ const KOSyncForm: React.FC<KOSyncFormProps> = ({ onBack }) => {
                   options={[{ value: 'binary', label: _('File Content') }]}
                 />
               </div>
+              {/* Mirrors KOReader's "Send document metadata" setting: include
+                  filename/title/authors in progress uploads so custom sync
+                  servers can tell which book a document hash is. Off by
+                  default, like KOReader. */}
+              <label className='flex min-h-14 items-center justify-between px-4'>
+                <SettingLabel>{_('Send Document Metadata')}</SettingLabel>
+                <Toggle
+                  checked={settings.kosync.sendMetadata ?? false}
+                  onChange={handleToggleSendMetadata}
+                />
+              </label>
               <div className='-me-2 flex min-h-14 items-center justify-between gap-3 px-4'>
                 <SettingLabel>{_('Device Name')}</SettingLabel>
                 <input

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -77,6 +77,7 @@ export const DEFAULT_KOSYNC_SETTINGS = {
   deviceName: '',
   checksumMethod: 'binary',
   strategy: 'prompt',
+  sendMetadata: false,
   enabled: false,
 } as KOSyncSettings;
 

--- a/apps/readest-app/src/services/sync/KOSyncClient.ts
+++ b/apps/readest-app/src/services/sync/KOSyncClient.ts
@@ -4,6 +4,7 @@ import { KOSyncSettings } from '@/types/settings';
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import { KoSyncProxyPayload } from '@/types/kosync';
 import { isLanAddress } from '@/utils/network';
+import { makeSafeFilename } from '@/utils/misc';
 import { normalizeCustomHeaders } from '@/utils/customHeaders';
 import { getAPIBaseUrl, isTauriAppPlatform } from '../environment';
 
@@ -231,6 +232,22 @@ export class KOSyncClient {
       percentage,
       device: this.config.deviceName,
       device_id: this.config.deviceId,
+      // The optional metadata field KOReader 2026.05+ sends when "Send
+      // document metadata" is enabled (koreader/koreader#15306), also
+      // implemented by CrossPoint 1.5.0+. The official server ignores it;
+      // custom servers may use it to identify the book behind the hash.
+      // `authors` is a single string in KOReader's format (newline-joined
+      // when there are several), which Book.author already is. The extension
+      // is the lowercased format, the same value as EXTS in libs/document,
+      // not imported here so this client stays off the document lib's
+      // foliate-js dependency chain.
+      ...(this.config.sendMetadata && {
+        metadata: {
+          filename: `${makeSafeFilename(book.sourceTitle || book.title)}.${book.format.toLowerCase()}`,
+          title: book.title,
+          authors: book.author,
+        },
+      }),
     };
 
     try {

--- a/apps/readest-app/src/services/sync/KOSyncClient.ts
+++ b/apps/readest-app/src/services/sync/KOSyncClient.ts
@@ -4,9 +4,35 @@ import { KOSyncSettings } from '@/types/settings';
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import { KoSyncProxyPayload } from '@/types/kosync';
 import { isLanAddress } from '@/utils/network';
-import { makeSafeFilename } from '@/utils/misc';
+import { getUserLang, makeSafeFilename } from '@/utils/misc';
 import { normalizeCustomHeaders } from '@/utils/customHeaders';
 import { getAPIBaseUrl, isTauriAppPlatform } from '../environment';
+
+const getContributorName = (contributor: unknown): string => {
+  if (typeof contributor === 'string') return contributor.trim();
+  if (!contributor || typeof contributor !== 'object') return '';
+
+  const name = (contributor as { name?: unknown }).name;
+  if (typeof name === 'string') return name.trim();
+  if (!name || typeof name !== 'object') return '';
+
+  const names = name as Record<string, unknown>;
+  const preferredName = names[getUserLang()];
+  if (typeof preferredName === 'string' && preferredName.trim()) return preferredName.trim();
+
+  const fallbackName = Object.values(names).find(
+    (value): value is string => typeof value === 'string' && !!value.trim(),
+  );
+  return fallbackName?.trim() ?? '';
+};
+
+const getMetadataAuthors = (book: Book): string => {
+  const contributors = book.metadata?.author as unknown;
+  if (!Array.isArray(contributors)) return book.author;
+
+  const authors = contributors.map(getContributorName).filter(Boolean);
+  return authors.length > 0 ? authors.join('\n') : book.author;
+};
 
 /**
  * Interface for KOSync progress response from the server
@@ -236,16 +262,17 @@ export class KOSyncClient {
       // document metadata" is enabled (koreader/koreader#15306), also
       // implemented by CrossPoint 1.5.0+. The official server ignores it;
       // custom servers may use it to identify the book behind the hash.
-      // `authors` is a single string in KOReader's format (newline-joined
-      // when there are several), which Book.author already is. The extension
-      // is the lowercased format, the same value as EXTS in libs/document,
-      // not imported here so this client stays off the document lib's
-      // foliate-js dependency chain.
+      // `authors` is a single string in KOReader's format, newline-joined
+      // when there are several. Book.author uses locale-specific display
+      // punctuation, so recover the individual names from structured metadata.
+      // The extension is the lowercased format, the same value as EXTS in
+      // libs/document, not imported here so this client stays off the document
+      // lib's foliate-js dependency chain.
       ...(this.config.sendMetadata && {
         metadata: {
           filename: `${makeSafeFilename(book.sourceTitle || book.title)}.${book.format.toLowerCase()}`,
           title: book.title,
-          authors: book.author,
+          authors: getMetadataAuthors(book),
         },
       }),
     };

--- a/apps/readest-app/src/types/settings.ts
+++ b/apps/readest-app/src/types/settings.ts
@@ -84,6 +84,14 @@ export interface KOSyncSettings {
   checksumMethod: KOSyncChecksumMethod;
   strategy: KOSyncStrategy;
   customHeaders?: Record<string, string>;
+  /**
+   * Include the book's filename, title and authors in progress uploads, in the
+   * optional `metadata` field KOReader 2026.05+ sends when "Send document
+   * metadata" is enabled. The official sync server ignores it; custom
+   * KOSync-compatible servers may use it to identify what is being read.
+   * Off by default, matching KOReader.
+   */
+  sendMetadata?: boolean;
 }
 
 export interface BookOrbitSettings {


### PR DESCRIPTION
KOReader 2026.05 added an opt-in **"Send document metadata"** setting ([koreader/koreader#15306](https://github.com/koreader/koreader/pull/15306)): when enabled, progress uploads carry an optional `metadata` field with the document's filename, title and authors. The official sync server ignores it; custom KOSync-compatible servers use it to tell which book a document hash is, so books identify themselves instead of needing a manual pairing step per book. CrossPoint shipped the same field in 1.5.0. Readest is currently the main KOSync client without it.

This adds the same opt-in to Readest: a **Send Document Metadata** toggle in the KOReader Sync settings (off by default, matching KOReader's privacy stance), and the `metadata` field on progress uploads when enabled. Field shapes follow KOReader exactly: `authors` is a single string, newline-joined when there are several. Readest derives that value from structured metadata instead of the locale-formatted `Book.author` display string.

Real-world case: I run a KOSync-compatible tracker ([shelvd.io](https://shelvd.io)), with a user who syncs from a CrossPoint device and Readest on iOS against the same account. Their CrossPoint books now identify and match themselves automatically, while their Readest books still land as anonymous hashes to pair by hand. This would also help the hash-divergence problem discussed in #1838: when a Calibre re-export changes a file's checksum, a server that receives title and authors can still recognize both hashes as the same book, which a hash-only upload never allows.

Implementation notes:

- `filename` derives from `sourceTitle`/`title` plus the lowercased format rather than importing `EXTS`, keeping `KOSyncClient` off the document lib's foliate-js dependency chain (values are identical today).
- Stored configs without the new key behave as before (`sendMetadata` is optional and treated as off).
- Tests: metadata absent by default, exact field shape when enabled, multi-author newline serialization and fallbacks, setting persistence, and `sourceTitle` naming the file while `title` stays the user-visible one.