### PR TITLE
feat(tts): symmetric minimal mini-player with centered play button

### DIFF
--- a/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
@@ -178,18 +178,54 @@ describe('TTSMiniPlayer', () => {
     viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
     render(<TTSMiniPlayer {...makeProps()} />);
     expect(screen.queryByLabelText('Stop reading aloud')).toBeNull();
-    const transport = screen.getByLabelText('Next Sentence').closest('[dir="ltr"]');
-    expect(transport?.querySelectorAll('button')).toHaveLength(5);
+    const row = screen.getByLabelText('Next Sentence').closest('[dir="ltr"]');
+    // The settings glyph plus five transport glyphs; stop is not among them.
+    expect(row?.querySelectorAll('button')).toHaveLength(6);
   });
 
-  // The transport, not the time, takes the row's slack -- otherwise the glyphs
-  // stay crammed against the right edge while the middle sits empty (#5310).
-  test('minimal style spreads the transport across the row', () => {
+  // The transport halves, not the time, take the row's slack -- otherwise the
+  // glyphs stay crammed against the edges while the sides sit empty (#5310).
+  test('minimal style spreads each transport half across its side', () => {
     viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
     render(<TTSMiniPlayer {...makeProps()} />);
-    const transport = screen.getByLabelText('Next Sentence').closest('[dir="ltr"]');
-    expect(transport?.className).toContain('flex-1');
-    expect(transport?.className).toContain('justify-between');
+    const left = screen.getByLabelText('Previous Sentence').parentElement;
+    const right = screen.getByLabelText('Next Sentence').parentElement;
+    expect(left?.className).toContain('justify-between');
+    expect(right?.className).toContain('justify-between');
+  });
+
+  // #5636: the card reads as a symmetric transport. The play glyph sits in the
+  // exact middle of the card so it doubles as a halfway mark against the
+  // progress line on the bottom edge, and the remaining time moves to the far
+  // right where it hangs over the un-played part of that line.
+  test('minimal style centers the play button and puts the time on the right', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
+    render(<TTSMiniPlayer {...makeProps()} />);
+    const play = screen.getByLabelText('Pause');
+    const row = play.parentElement;
+    // All seven items sit in one between-spread row, mirrored widths about the
+    // middle: the equal gaps are what land the play glyph on the midpoint.
+    expect(row?.className).toContain('justify-between');
+    expect(row?.children).toHaveLength(7);
+    const items = Array.from(row?.children ?? []);
+    expect(items[0]).toBe(screen.getByLabelText('Playback settings'));
+    expect(items[1]).toBe(screen.getByLabelText('Previous Paragraph'));
+    expect(items[2]).toBe(screen.getByLabelText('Previous Sentence'));
+    expect(items[3]).toBe(play);
+    expect(items[4]).toBe(screen.getByLabelText('Next Sentence'));
+    expect(items[5]).toBe(screen.getByLabelText('Next Paragraph'));
+    // The time box ends the row, mirroring the settings glyph that starts it.
+    expect(items[6]).toBe(screen.getByLabelText('Open Read Aloud player'));
+  });
+
+  // The two end boxes share one fixed width -- with the skip glyphs paired off,
+  // that is what makes the item widths mirror, so the even between-spread gaps
+  // put the play glyph dead-center rather than merely near it.
+  test('minimal style gives the settings glyph the same fixed box as the time', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
+    render(<TTSMiniPlayer {...makeProps()} />);
+    expect(screen.getByLabelText('Playback settings').className).toContain('w-14');
+    expect(screen.getByLabelText('Open Read Aloud player').className).toContain('w-14');
   });
 
   // A content-sized box would re-center every glyph as the label narrows on

--- a/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
@@ -298,21 +298,76 @@ const TTSMiniPlayer = ({
             </div>
           </div>
         ) : (
-          <div className='text-base-content flex h-14 items-center gap-2 px-3'>
+          // A symmetric transport (#5636): one between-spread row whose item
+          // widths mirror about the middle -- a fixed box at each end, two skip
+          // glyphs each side -- so the equal gaps land the play glyph on the
+          // card's exact midpoint, where it doubles as a halfway mark against
+          // the progress line on the bottom edge, and the remaining time sits
+          // on the far right where it hangs over the un-played part of that
+          // line. The spreading is also what keeps "<<" and "<" from being
+          // mistaken for each other on a phone (#5310). The row is dir=ltr
+          // because the progress line it annotates fills physically
+          // left-to-right.
+          <div dir='ltr' className='text-base-content flex h-14 items-center justify-between px-3'>
             {/* Visible route into the full player: a settings glyph carrying
-              the live speed as a superscript (the sheet is where speed and
-              voice live). The time text expands too, but text alone reads
-              as a label, not an affordance. */}
+                the live speed as a superscript (the sheet is where speed and
+                voice live). The time text expands too, but text alone reads
+                as a label, not an affordance. */}
             <button
               type='button'
               aria-label={_('Playback settings')}
               onClick={onExpand}
-              className='text-base-content/70 flex shrink-0 rounded-full p-1 pe-4'
+              className='text-base-content/70 flex w-14 shrink justify-center rounded-full p-1'
             >
               <SpeedSettingsIcon
                 size={iconSize26}
                 label={formatRate(viewSettings?.ttsRate ?? 1.0)}
               />
+            </button>
+            <button
+              type='button'
+              className='shrink-0 rounded-full p-1'
+              aria-label={_('Previous Paragraph')}
+              onClick={() => onBackward(false)}
+            >
+              <MdKeyboardDoubleArrowLeft size={iconSize26} />
+            </button>
+            <button
+              type='button'
+              className='shrink-0 rounded-full p-1'
+              aria-label={_('Previous Sentence')}
+              onClick={() => onBackward(true)}
+            >
+              <MdKeyboardArrowLeft size={iconSize26} />
+            </button>
+            <button
+              type='button'
+              className='shrink-0 rounded-full p-1'
+              aria-label={isPlaying ? _('Pause') : _('Play')}
+              onClick={onTogglePlay}
+            >
+              {/* Same canvas size for both glyphs, or the row shifts on toggle. */}
+              {isPlaying ? <MdOutlinePause size={iconSize26} /> : <MdPlayArrow size={iconSize26} />}
+            </button>
+            <button
+              type='button'
+              className='shrink-0 rounded-full p-1'
+              aria-label={_('Next Sentence')}
+              onClick={() => onForward(true)}
+            >
+              <MdKeyboardArrowRight size={iconSize26} />
+            </button>
+            {/* No stop button on purpose (#5310): five transport glyphs already
+                crowd a phone, and an accidental hit on a sixth ends the
+                session. Stopping lives on the same toolbar TTS button that
+                started it. */}
+            <button
+              type='button'
+              className='shrink-0 rounded-full p-1'
+              aria-label={_('Next Paragraph')}
+              onClick={() => onForward(false)}
+            >
+              <MdKeyboardDoubleArrowRight size={iconSize26} />
             </button>
             <div
               role='button'
@@ -324,16 +379,16 @@ const TTSMiniPlayer = ({
               aria-label={_('Open Read Aloud player')}
               className='flex w-14 min-w-0 cursor-pointer flex-col items-center justify-center gap-0.5'
             >
-              {/* A fixed 4rem box, not a flexible or content-sized one: the
-                  former hogs the row and leaves the transport crammed against
-                  the right edge, the latter re-centers every glyph each time
-                  the label changes width ("-9:59" -> "-10:00"). Scales with the
-                  UI font since both the box and the text are rem-based (#5310).
-                  Default shrink is deliberate: on a tiny card at a large font
-                  scale the box gives way and the label truncates, rather than
-                  pushing a transport glyph off the edge. An armed sleep timer
-                  stacks on its own line so it can never squeeze the time into
-                  truncation. */}
+              {/* A fixed 4rem box matching the settings glyph's, not a flexible
+                  or content-sized one: the latter would re-position every glyph
+                  each time the label changes width ("-9:59" -> "-10:00"), and
+                  the mirrored pair is what keeps the play glyph centered.
+                  Scales with the UI font since both the box and the text are
+                  rem-based (#5310). Default shrink is deliberate: on a tiny
+                  card at a large font scale the box gives way and the label
+                  truncates, rather than pushing a transport glyph off the
+                  edge. An armed sleep timer stacks on its own line so it can
+                  never squeeze the time into truncation. */}
               {compactLabel && (
                 // max-w-full is load-bearing: a nowrap span is a flex item in a
                 // column, and without it the cross size resolves to the text's
@@ -348,65 +403,6 @@ const TTSMiniPlayer = ({
                   {timerLabel}
                 </span>
               )}
-            </div>
-            {/* The transport takes the slack and spreads into it, so the space
-                freed by the stop button becomes separation between glyphs
-                rather than dead middle. That is what stops "<<" and "<" from
-                being mistaken for each other on a phone (#5310). No gap on
-                purpose: a fixed one would add 16px to the row's min width and
-                start crushing the time box on a 360px phone, and it buys
-                nothing -- justify-between already does the spreading whenever
-                there is anything to spread. */}
-            <div dir='ltr' className='flex flex-1 items-center justify-between'>
-              <button
-                type='button'
-                className='shrink-0 rounded-full p-1'
-                aria-label={_('Previous Paragraph')}
-                onClick={() => onBackward(false)}
-              >
-                <MdKeyboardDoubleArrowLeft size={iconSize26} />
-              </button>
-              <button
-                type='button'
-                className='shrink-0 rounded-full p-1'
-                aria-label={_('Previous Sentence')}
-                onClick={() => onBackward(true)}
-              >
-                <MdKeyboardArrowLeft size={iconSize26} />
-              </button>
-              <button
-                type='button'
-                className='shrink-0 rounded-full p-1'
-                aria-label={isPlaying ? _('Pause') : _('Play')}
-                onClick={onTogglePlay}
-              >
-                {/* Same canvas size for both glyphs, or the row shifts on toggle. */}
-                {isPlaying ? (
-                  <MdOutlinePause size={iconSize26} />
-                ) : (
-                  <MdPlayArrow size={iconSize26} />
-                )}
-              </button>
-              <button
-                type='button'
-                className='shrink-0 rounded-full p-1'
-                aria-label={_('Next Sentence')}
-                onClick={() => onForward(true)}
-              >
-                <MdKeyboardArrowRight size={iconSize26} />
-              </button>
-              {/* No stop button here on purpose (#5310): five transport glyphs
-                  already crowd a phone, and an accidental hit on a sixth ends
-                  the session. Stopping lives on the same toolbar TTS button
-                  that started it. */}
-              <button
-                type='button'
-                className='shrink-0 rounded-full p-1'
-                aria-label={_('Next Paragraph')}
-                onClick={() => onForward(false)}
-              >
-                <MdKeyboardDoubleArrowRight size={iconSize26} />
-              </button>
             </div>
           </div>
         )}


### PR DESCRIPTION
Closes #5636.

Rearranges the minimal TTS mini-player into a symmetric transport: the speed glyph keeps the left end, the remaining time moves to the far right, and the play/pause button sits on the card's exact midpoint.

### How

All seven items live in one between-spread flex row whose widths mirror about the middle: a fixed 4rem box at each end (the speed glyph now gets the same fixed box the time already had) and two skip glyphs per side. With mirrored widths, the equal `justify-between` gaps land the play glyph dead-center - verified in-browser: play button center exactly equals row center, and all six gaps measure equal.

As requested in the issue, the centered play button doubles as a halfway mark against the progress line on the card's bottom edge, and the remaining time sits over the un-played portion of that line. The row is `dir=ltr` because the progress line it annotates fills physically left-to-right.

### Before

`[speed] [time] [<< < play > >>]`

### After

`[speed] [<<] [<] [play] [>] [>>] [time]`

### Tests

- New: row order and centered play button; matching fixed end boxes
- Updated: transport glyph count and spread assertions for the flat row
- `pnpm test` (9069 passed), `pnpm lint`, `pnpm format:check` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)