### PR TITLE
feat(reader): resume Auto Scroll when reopening a book

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/hooks/useAutoScroll.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useAutoScroll.test.ts
@@ -1,0 +1,158 @@
+import { StrictMode } from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+
+import { FoliateView } from '@/types/view';
+import { eventDispatcher } from '@/utils/event';
+
+const BOOK_KEY = 'book-1';
+
+const h = vi.hoisted(() => ({
+  viewSettings: { scrolled: true, autoScrollSpeed: 100, autoScrollRunning: false } as Record<
+    string,
+    unknown
+  >,
+  inited: false,
+  previewMode: false,
+  setAutoScrollEnabled: vi.fn(),
+  saveViewSettings: vi.fn(),
+}));
+
+vi.mock('@/store/readerStore', () => {
+  const state = {
+    get viewStates() {
+      return { [BOOK_KEY]: { inited: h.inited, previewMode: h.previewMode } };
+    },
+    getViewSettings: () => h.viewSettings,
+    getViewState: () => ({ inited: h.inited, previewMode: h.previewMode }),
+    setAutoScrollEnabled: h.setAutoScrollEnabled,
+  };
+  return {
+    useReaderStore: (selector?: (s: typeof state) => unknown) =>
+      selector ? selector(state) : state,
+  };
+});
+vi.mock('@/context/EnvContext', () => ({ useEnv: () => ({ envConfig: {} }) }));
+vi.mock('@/hooks/useTranslation', () => ({ useTranslation: () => (s: string) => s }));
+vi.mock('@/helpers/settings', () => ({ saveViewSettings: h.saveViewSettings }));
+
+import { useAutoScroll } from '@/app/reader/hooks/useAutoScroll';
+
+const viewRef = {
+  current: {
+    next: vi.fn(),
+    renderer: {
+      scrolled: true,
+      scrollProp: 'scrollTop',
+      containerPosition: 0,
+      atEnd: false,
+      subpixelOffset: 0,
+    },
+  },
+} as unknown as React.RefObject<FoliateView | null>;
+
+const setup = () => renderHook(() => useAutoScroll(BOOK_KEY, viewRef));
+
+const toggle = async () => {
+  await act(async () => {
+    await eventDispatcher.dispatch('autoscroll-toggle', { bookKey: BOOK_KEY });
+  });
+};
+
+const savedRunning = () =>
+  h.saveViewSettings.mock.calls
+    .filter((call) => call[2] === 'autoScrollRunning')
+    .map((call) => call[3]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.viewSettings = { scrolled: true, autoScrollSpeed: 100, autoScrollRunning: false };
+  h.inited = false;
+  h.previewMode = false;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// Issue #5631: a session that was still running when the book was closed is
+// resumed on reopen, so Auto Scroll readers don't re-toggle it every time.
+describe('useAutoScroll session persistence', () => {
+  test('records the running session so a reopen can resume it', async () => {
+    h.inited = true;
+    const { result } = setup();
+    await toggle();
+
+    expect(result.current.active).toBe(true);
+    expect(savedRunning()).toEqual([true]);
+  });
+
+  test('clears the record when the session is explicitly stopped', async () => {
+    h.inited = true;
+    const { result } = setup();
+    await toggle();
+    h.saveViewSettings.mockClear();
+
+    act(() => result.current.stop());
+
+    expect(result.current.active).toBe(false);
+    expect(savedRunning()).toEqual([false]);
+  });
+
+  // StrictMode mounts, tears down, and remounts every effect. The teardown
+  // takes the same path closing the book does, so the "don't clear on close"
+  // exemption must not survive into the remounted session.
+  test('clears the record on an explicit stop after a StrictMode remount', async () => {
+    h.inited = true;
+    const { result } = renderHook(() => useAutoScroll(BOOK_KEY, viewRef), { wrapper: StrictMode });
+    await toggle();
+    h.saveViewSettings.mockClear();
+
+    act(() => result.current.stop());
+
+    expect(savedRunning()).toEqual([false]);
+  });
+
+  test('keeps the record when the book is closed mid-session', async () => {
+    h.inited = true;
+    const { unmount } = setup();
+    await toggle();
+    h.saveViewSettings.mockClear();
+
+    unmount();
+
+    expect(savedRunning()).toEqual([]);
+  });
+
+  test('resumes the session when a book with a recorded session is opened', () => {
+    h.viewSettings['autoScrollRunning'] = true;
+    h.inited = true;
+    const { result } = setup();
+
+    expect(result.current.active).toBe(true);
+    expect(h.setAutoScrollEnabled).toHaveBeenCalledWith(BOOK_KEY, true);
+  });
+
+  test('does not resume before the view is inited', () => {
+    h.viewSettings['autoScrollRunning'] = true;
+    const { result } = setup();
+
+    expect(result.current.active).toBe(false);
+  });
+
+  test('does not resume onto a deep-link landing the user has not confirmed', () => {
+    h.viewSettings['autoScrollRunning'] = true;
+    h.inited = true;
+    h.previewMode = true;
+    const { result } = setup();
+
+    expect(result.current.active).toBe(false);
+  });
+
+  test('does not resume a book that was closed with no session running', () => {
+    h.inited = true;
+    const { result } = setup();
+
+    expect(result.current.active).toBe(false);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -806,16 +806,16 @@ const FoliateViewer: React.FC<{
       } else {
         await view.goToFraction(0);
       }
-      setViewInited(bookKey, true);
-
       // The reader is showing a deep-link target, not the user's actual reading
       // position. Mark the view as a preview so progress writers (auto-save,
       // cloud sync, kosync) skip until the user takes a reading action. The
       // flag clears on the first user-initiated relocate (page / scroll) in
-      // docRelocateHandler below.
+      // docRelocateHandler below. Set before `inited` so everything that starts
+      // reading on init (e.g. Auto Scroll resume) already sees the preview.
       if (overrideLocation) {
         setPreviewMode(bookKey, true);
       }
+      setViewInited(bookKey, true);
       if (overrideLocation && searchParams?.get('highlight') === 'search') {
         librarySearchHighlightTimerRef.current = await showTransientHighlight(
           view,

--- a/apps/readest-app/src/app/reader/hooks/useAutoScroll.ts
+++ b/apps/readest-app/src/app/reader/hooks/useAutoScroll.ts
@@ -33,14 +33,19 @@ export interface AutoScrollState {
 // A tap on the page pauses/resumes instead of turning the page or toggling the
 // bars; manual wheel/drag input simply composes with the paced scrolling since
 // every frame is a relative containerPosition step. Escape or leaving scrolled
-// mode stops the session; the session state is never persisted.
+// mode stops the session.
+//
+// Whether a session is engaged is remembered per book (#5631): a book closed
+// mid-session reopens scrolling, so readers who use the mode all the time don't
+// re-toggle it after every app suspend. Only an explicit stop clears it.
 export const useAutoScroll = (
   bookKey: string,
   viewRef: React.RefObject<FoliateView | null>,
 ): AutoScrollState => {
   const _ = useTranslation();
   const { envConfig } = useEnv();
-  const { getViewSettings, setAutoScrollEnabled } = useReaderStore();
+  const { getViewSettings, getViewState, setAutoScrollEnabled } = useReaderStore();
+  const inited = useReaderStore((state) => state.viewStates[bookKey]?.inited);
   const viewSettings = getViewSettings(bookKey);
   const [active, setActive] = useState(false);
   const [paused, setPaused] = useState(false);
@@ -49,6 +54,10 @@ export const useAutoScroll = (
   // Undoes the per-session window listeners; set on start.
   const sessionCleanupRef = useRef<(() => void) | null>(null);
   const stallStartRef = useRef<number | null>(null);
+  // Closing the book tears the session down through the same stop() path an
+  // explicit stop takes — but it must leave the resume flag alone, since a
+  // session that was still running at close is exactly what reopening resumes.
+  const closingRef = useRef(false);
 
   const scrollerRef = useRef<PacedScroller | null>(null);
   if (!scrollerRef.current) {
@@ -97,6 +106,9 @@ export const useAutoScroll = (
         setActive(false);
         setPaused(false);
         setAutoScrollEnabled(bookKey, false);
+        if (!closingRef.current) {
+          saveViewSettings(envConfig, bookKey, 'autoScrollRunning', false, true, false);
+        }
         sessionCleanupRef.current?.();
         sessionCleanupRef.current = null;
       },
@@ -139,6 +151,7 @@ export const useAutoScroll = (
     setActive(true);
     setPaused(false);
     setAutoScrollEnabled(bookKey, true);
+    saveViewSettings(envConfig, bookKey, 'autoScrollRunning', true, true, false);
 
     const onKeydown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') scroller.stop();
@@ -184,8 +197,27 @@ export const useAutoScroll = (
     if (!scrolled) scrollerRef.current?.stop();
   }, [scrolled]);
 
+  // Resume the session the book was closed in (#5631). Waits for the view to
+  // be inited: the renderer is in the store before init, but has no laid-out
+  // content to scroll until then. A deep-link landing (?cfi=, library search
+  // hit) is skipped — scrolling it unprompted would promote the preview into
+  // the reading position the user never navigated to.
   useEffect(() => {
-    return () => scrollerRef.current?.stop();
+    if (!inited) return;
+    if (getViewState(bookKey)?.previewMode) return;
+    if (!getViewSettings(bookKey)?.autoScrollRunning) return;
+    startSession();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inited]);
+
+  useEffect(() => {
+    // Re-armed on every mount: StrictMode tears the effect down and sets this
+    // up again, and a latched flag would suppress every later stop's write.
+    closingRef.current = false;
+    return () => {
+      closingRef.current = true;
+      scrollerRef.current?.stop();
+    };
   }, []);
 
   return {

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -344,6 +344,7 @@ export const DEFAULT_BOOK_LAYOUT: BookLayout = {
   allowScript: false,
   hideScrollbar: false,
   autoScrollSpeed: 100,
+  autoScrollRunning: false,
 };
 
 export const DEFAULT_BOOK_LANGUAGE: BookLanguage = {

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -233,6 +233,10 @@ export interface BookLayout {
   hideScrollbar: boolean;
   /* Auto Scroll (#4998) speed as a percentage; 100 = AUTO_SCROLL_BASE_PX_PER_SEC. */
   autoScrollSpeed: number;
+  /* True when a session was still running as the book was closed, so reopening
+     the book resumes it (#5631). Per book: written with the global write
+     skipped, and cleared by any explicit stop. */
+  autoScrollRunning: boolean;
 }
 
 export interface BookStyle {


### PR DESCRIPTION
Closes #5631

## Problem

Auto Scroll is session-only, so it is off again every time a book is reopened. On iOS, where the app gets suspended often, that means re-toggling it several times a day. The speed already sticks, which makes the mode resetting feel inconsistent.

## Approach

No new setting. A session that is **explicitly stopped** stays stopped; one that was still running when the book closed comes back on the next open.

- New per-book view setting `autoScrollRunning`. `startSession()` persists `true`; `onStop` persists `false` for every explicit stop (View menu toggle, `Shift+A`, Escape, end of book, leaving scrolled mode). The unmount teardown that runs when the book closes is exempt, which is what makes "not stopped at close" resumable.
- Written with the global write skipped, so it never reaches `globalViewSettings`, and `serializeConfig` prunes it when it equals the default: a stopped book stores no key at all.
- A resume effect keyed on `viewState.inited` restarts the session on open (`flow=scrolled` is set before `view.init()`, but there is nothing laid out to scroll until inited).

### Deep links

The resume is skipped when `previewMode` is set. Otherwise opening a `?cfi=` deep link (library full-text-search hit, shared annotation) would start scrolling with no user action and promote the preview into the reading position the user never navigated to. That required moving `setPreviewMode` above `setViewInited` in `FoliateViewer.openBook`, so the flag is visible when the resume effect fires rather than depending on React batching the two store writes.

### StrictMode

The "closing" ref is re-armed on every mount. `reactStrictMode` makes React run setup then cleanup then setup, and the cleanup latched the ref, which silently suppressed every later stop's write: Escape stopped the scrolling but the flag stayed set, so the book auto-scrolled again on the next open. Covered by a regression test using `renderHook(..., { wrapper: StrictMode })`; plain `renderHook` passes either way.

## Testing

- `pnpm test` (9096 passed, 16 skipped), `pnpm lint`, `pnpm format:check`
- 8 new tests in `useAutoScroll.test.ts`
- Verified end to end in Chrome against `pnpm dev-web`: start Auto Scroll, book config gets `autoScrollRunning: true`, leave to the library, reopen and the scroll position advances with no input; Escape, the flag is pruned from the config, reopen and there is no movement.