### PR TITLE
feat(reader): right-to-left page order for fixed-layout books

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2319,5 +2319,7 @@
   "Start of Book": "بداية الكتاب",
   "End of Book": "نهاية الكتاب",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "هذا المجلد مكتبة خارجية. ألغِ التحديد للتوقف عن قراءة كتبه من مكانها؛ وستُنسخ الكتب إلى المكتبة في عمليات الاستيراد القادمة.",
-  "More Settings": "مزيد من الإعدادات"
+  "More Settings": "مزيد من الإعدادات",
+  "Right-to-Left Pages": "صفحات من اليمين إلى اليسار",
+  "Send Document Metadata": "إرسال البيانات الوصفية للمستند"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2095,5 +2095,7 @@
   "Start of Book": "বইয়ের শুরু",
   "End of Book": "বইয়ের শেষ",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "এই ফোল্ডারটি একটি বাহ্যিক লাইব্রেরি। এর বইগুলি নিজ স্থানে পড়া বন্ধ করতে টিক তুলে দিন; পরবর্তী ইমপোর্টে বইগুলি লাইব্রেরিতে কপি করা হবে।",
-  "More Settings": "আরও সেটিংস"
+  "More Settings": "আরও সেটিংস",
+  "Right-to-Left Pages": "ডান থেকে বামে পৃষ্ঠা",
+  "Send Document Metadata": "নথির মেটাডেটা পাঠান"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2039,5 +2039,7 @@
   "Start of Book": "དཔེ་དེབ་ཀྱི་མགོ།",
   "End of Book": "དཔེ་དེབ་ཀྱི་མཇུག",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "སྣོད་འདི་ནི་ཕྱིའི་དཔེ་མཛོད་ཅིག་ཡིན། འདེམས་རྟགས་ཕྱིར་བསུབ་ན་དེའི་དཔེ་ཆ་རང་ས་ནས་ཀློག་མཚམས་འཇོག་ངེས། ཕྱིས་ཀྱི་ནང་འདྲེན་སྐབས་དཔེ་ཆ་དཔེ་མཛོད་ནང་དུ་འདྲ་བཤུས་བྱེད་ངེས།",
-  "More Settings": "སྒྲིག་སྟངས་གཞན།"
+  "More Settings": "སྒྲིག་སྟངས་གཞན།",
+  "Right-to-Left Pages": "ཤོག་ངོས་གཡས་ནས་གཡོན།",
+  "Send Document Metadata": "ཡིག་ཆའི་གནས་ཚུལ་བསྐུར་བ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2095,5 +2095,7 @@
   "Start of Book": "Buchanfang",
   "End of Book": "Buchende",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Dieser Ordner ist eine externe Bibliothek. Deaktivieren Sie das Kästchen, um seine Bücher nicht mehr direkt am Speicherort zu lesen; künftige Importe kopieren die Bücher in die Bibliothek.",
-  "More Settings": "Weitere Einstellungen"
+  "More Settings": "Weitere Einstellungen",
+  "Right-to-Left Pages": "Seiten von rechts nach links",
+  "Send Document Metadata": "Dokument-Metadaten senden"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2095,5 +2095,7 @@
   "Start of Book": "Αρχή βιβλίου",
   "End of Book": "Τέλος βιβλίου",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Αυτός ο φάκελος είναι εξωτερική βιβλιοθήκη. Καταργήστε την επιλογή για να σταματήσει η επιτόπια ανάγνωση των βιβλίων του· οι μελλοντικές εισαγωγές θα αντιγράφουν τα βιβλία στη βιβλιοθήκη.",
-  "More Settings": "Περισσότερες ρυθμίσεις"
+  "More Settings": "Περισσότερες ρυθμίσεις",
+  "Right-to-Left Pages": "Σελίδες από δεξιά προς τα αριστερά",
+  "Send Document Metadata": "Αποστολή μεταδεδομένων εγγράφου"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2151,5 +2151,7 @@
   "Start of Book": "Inicio del libro",
   "End of Book": "Fin del libro",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Esta carpeta es una biblioteca externa. Desmarca para dejar de leer sus libros en su ubicación original; las próximas importaciones copiarán los libros a la biblioteca.",
-  "More Settings": "Más configuraciones"
+  "More Settings": "Más configuraciones",
+  "Right-to-Left Pages": "Páginas de derecha a izquierda",
+  "Send Document Metadata": "Enviar metadatos del documento"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2095,5 +2095,7 @@
   "Start of Book": "ابتدای کتاب",
   "End of Book": "انتهای کتاب",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "این پوشه یک کتابخانه خارجی است. برای توقف خواندن کتاب‌ها از محل اصلی، تیک را بردارید؛ در واردسازی‌های بعدی کتاب‌ها به کتابخانه کپی می‌شوند.",
-  "More Settings": "تنظیمات بیشتر"
+  "More Settings": "تنظیمات بیشتر",
+  "Right-to-Left Pages": "صفحات راست به چپ",
+  "Send Document Metadata": "ارسال فراداده سند"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2151,5 +2151,7 @@
   "Start of Book": "Début du livre",
   "End of Book": "Fin du livre",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Ce dossier est une bibliothèque externe. Décochez pour cesser de lire ses livres sur place ; les prochaines importations copieront les livres dans la bibliothèque.",
-  "More Settings": "Plus de paramètres"
+  "More Settings": "Plus de paramètres",
+  "Right-to-Left Pages": "Pages de droite à gauche",
+  "Send Document Metadata": "Envoyer les métadonnées du document"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2151,5 +2151,7 @@
   "Start of Book": "תחילת הספר",
   "End of Book": "סוף הספר",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "תיקייה זו היא ספרייה חיצונית. בטלו את הסימון כדי להפסיק לקרוא את הספרים במקומם; בייבואים הבאים הספרים יועתקו לספרייה.",
-  "More Settings": "הגדרות נוספות"
+  "More Settings": "הגדרות נוספות",
+  "Right-to-Left Pages": "עמודים מימין לשמאל",
+  "Send Document Metadata": "שליחת מטא-נתונים של המסמך"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2095,5 +2095,7 @@
   "Start of Book": "पुस्तक की शुरुआत",
   "End of Book": "पुस्तक का अंत",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "यह फ़ोल्डर एक बाहरी लाइब्रेरी है। इसकी किताबें मूल स्थान से पढ़ना बंद करने के लिए टिक हटाएँ; आगे के आयात में किताबें लाइब्रेरी में कॉपी की जाएँगी।",
-  "More Settings": "अधिक सेटिंग्स"
+  "More Settings": "अधिक सेटिंग्स",
+  "Right-to-Left Pages": "दाएँ से बाएँ पृष्ठ",
+  "Send Document Metadata": "दस्तावेज़ मेटाडेटा भेजें"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2095,5 +2095,7 @@
   "Start of Book": "Könyv eleje",
   "End of Book": "Könyv vége",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Ez a mappa külső könyvtár. Törölje a jelölést, hogy a könyveit ne az eredeti helyükről olvassa; a későbbi importálások a könyveket a könyvtárba másolják.",
-  "More Settings": "További beállítások"
+  "More Settings": "További beállítások",
+  "Right-to-Left Pages": "Oldalak jobbról balra",
+  "Send Document Metadata": "Dokumentum metaadatainak küldése"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2039,5 +2039,7 @@
   "Start of Book": "Awal buku",
   "End of Book": "Akhir buku",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Folder ini adalah pustaka eksternal. Hapus centang untuk berhenti membaca bukunya di tempat; impor berikutnya akan menyalin buku ke pustaka.",
-  "More Settings": "Pengaturan Lainnya"
+  "More Settings": "Pengaturan Lainnya",
+  "Right-to-Left Pages": "Halaman Kanan ke Kiri",
+  "Send Document Metadata": "Kirim Metadata Dokumen"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2151,5 +2151,7 @@
   "Start of Book": "Inizio del libro",
   "End of Book": "Fine del libro",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Questa cartella è una libreria esterna. Deseleziona per smettere di leggere i suoi libri nella posizione originale; le prossime importazioni copieranno i libri nella libreria.",
-  "More Settings": "Altre impostazioni"
+  "More Settings": "Altre impostazioni",
+  "Right-to-Left Pages": "Pagine da destra a sinistra",
+  "Send Document Metadata": "Invia metadati del documento"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2039,5 +2039,7 @@
   "Start of Book": "本の先頭",
   "End of Book": "本の末尾",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "このフォルダは外部ライブラリです。チェックを外すと元の場所から直接読み込まなくなり、以降のインポートでは本がライブラリにコピーされます。",
-  "More Settings": "その他の設定"
+  "More Settings": "その他の設定",
+  "Right-to-Left Pages": "右から左のページ送り",
+  "Send Document Metadata": "ドキュメントのメタデータを送信"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2039,5 +2039,7 @@
   "Start of Book": "책의 처음",
   "End of Book": "책의 끝",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "이 폴더는 외부 라이브러리입니다. 선택을 해제하면 원래 위치에서 책을 읽지 않으며, 이후 가져오기에서는 책이 라이브러리로 복사됩니다.",
-  "More Settings": "추가 설정"
+  "More Settings": "추가 설정",
+  "Right-to-Left Pages": "오른쪽에서 왼쪽으로 페이지 넘김",
+  "Send Document Metadata": "문서 메타데이터 전송"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2039,5 +2039,7 @@
   "Start of Book": "Permulaan buku",
   "End of Book": "Penghujung buku",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Folder ini ialah perpustakaan luaran. Nyahtanda untuk berhenti membaca bukunya di tempat asal; import akan datang akan menyalin buku ke perpustakaan.",
-  "More Settings": "Tetapan Lain"
+  "More Settings": "Tetapan Lain",
+  "Right-to-Left Pages": "Halaman Kanan ke Kiri",
+  "Send Document Metadata": "Hantar Metadata Dokumen"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2095,5 +2095,7 @@
   "Start of Book": "Begin van het boek",
   "End of Book": "Einde van het boek",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Deze map is een externe bibliotheek. Vink uit om de boeken niet langer op hun oorspronkelijke locatie te lezen; toekomstige imports kopiëren de boeken naar de bibliotheek.",
-  "More Settings": "Meer instellingen"
+  "More Settings": "Meer instellingen",
+  "Right-to-Left Pages": "Pagina's van rechts naar links",
+  "Send Document Metadata": "Documentmetadata verzenden"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2207,5 +2207,7 @@
   "Start of Book": "Początek książki",
   "End of Book": "Koniec książki",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Ten folder jest zewnętrzną biblioteką. Odznacz, aby przestać czytać jego książki z oryginalnej lokalizacji; przyszłe importy skopiują książki do biblioteki.",
-  "More Settings": "Więcej ustawień"
+  "More Settings": "Więcej ustawień",
+  "Right-to-Left Pages": "Strony od prawej do lewej",
+  "Send Document Metadata": "Wysyłaj metadane dokumentu"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2151,5 +2151,7 @@
   "Start of Book": "Início do livro",
   "End of Book": "Fim do livro",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Esta pasta é uma biblioteca externa. Desmarque para parar de ler os livros no local original; as próximas importações copiarão os livros para a biblioteca.",
-  "More Settings": "Mais configurações"
+  "More Settings": "Mais configurações",
+  "Right-to-Left Pages": "Páginas da direita para a esquerda",
+  "Send Document Metadata": "Enviar metadados do documento"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2151,5 +2151,7 @@
   "Start of Book": "Início do livro",
   "End of Book": "Fim do livro",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Esta pasta é uma biblioteca externa. Desmarque para deixar de ler os livros no local original; as próximas importações copiarão os livros para a biblioteca.",
-  "More Settings": "Mais configurações"
+  "More Settings": "Mais configurações",
+  "Right-to-Left Pages": "Páginas da direita para a esquerda",
+  "Send Document Metadata": "Enviar metadados do documento"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2151,5 +2151,7 @@
   "Start of Book": "Începutul cărții",
   "End of Book": "Sfârșitul cărții",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Acest dosar este o bibliotecă externă. Debifați pentru a nu mai citi cărțile din locația lor originală; importurile viitoare vor copia cărțile în bibliotecă.",
-  "More Settings": "Mai multe setări"
+  "More Settings": "Mai multe setări",
+  "Right-to-Left Pages": "Pagini de la dreapta la stânga",
+  "Send Document Metadata": "Trimite metadatele documentului"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2207,5 +2207,7 @@
   "Start of Book": "Начало книги",
   "End of Book": "Конец книги",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Эта папка — внешняя библиотека. Снимите флажок, чтобы перестать читать её книги на месте; при последующих импортах книги будут копироваться в библиотеку.",
-  "More Settings": "Другие настройки"
+  "More Settings": "Другие настройки",
+  "Right-to-Left Pages": "Страницы справа налево",
+  "Send Document Metadata": "Отправлять метаданные документа"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2095,5 +2095,7 @@
   "Start of Book": "පොතේ ආරම්භය",
   "End of Book": "පොතේ අවසානය",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "මෙම ෆෝල්ඩරය බාහිර පුස්තකාලයකි. එහි පොත් ඒවා ඇති තැනින්ම කියවීම නැවැත්වීමට සලකුණ ඉවත් කරන්න; ඉදිරි ආයාත වලදී පොත් පුස්තකාලයට පිටපත් වේ.",
-  "More Settings": "තවත් සැකසුම්"
+  "More Settings": "තවත් සැකසුම්",
+  "Right-to-Left Pages": "දකුණේ සිට වමට පිටු",
+  "Send Document Metadata": "ලේඛන පාරදත්ත යවන්න"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2207,5 +2207,7 @@
   "Start of Book": "Začetek knjige",
   "End of Book": "Konec knjige",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Ta mapa je zunanja knjižnica. Odkljukajte, da knjig ne berete več z izvirnega mesta; prihodnji uvozi bodo knjige kopirali v knjižnico.",
-  "More Settings": "Več nastavitev"
+  "More Settings": "Več nastavitev",
+  "Right-to-Left Pages": "Strani od desne proti levi",
+  "Send Document Metadata": "Pošlji metapodatke dokumenta"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2095,5 +2095,7 @@
   "Start of Book": "Bokens början",
   "End of Book": "Bokens slut",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Den här mappen är ett externt bibliotek. Avmarkera för att sluta läsa dess böcker på plats; framtida importer kopierar böckerna till biblioteket.",
-  "More Settings": "Fler inställningar"
+  "More Settings": "Fler inställningar",
+  "Right-to-Left Pages": "Sidor från höger till vänster",
+  "Send Document Metadata": "Skicka dokumentmetadata"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2095,5 +2095,7 @@
   "Start of Book": "புத்தகத்தின் தொடக்கம்",
   "End of Book": "புத்தகத்தின் முடிவு",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "இந்தக் கோப்புறை ஒரு வெளிப்புற நூலகம். அதன் புத்தகங்களை இருக்கும் இடத்திலிருந்தே படிப்பதை நிறுத்த குறியை நீக்கவும்; இனிவரும் இறக்குமதிகளில் புத்தகங்கள் நூலகத்திற்கு நகலெடுக்கப்படும்.",
-  "More Settings": "மேலும் அமைப்புகள்"
+  "More Settings": "மேலும் அமைப்புகள்",
+  "Right-to-Left Pages": "வலமிருந்து இடமாகப் பக்கங்கள்",
+  "Send Document Metadata": "ஆவண மீத்தரவை அனுப்பு"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2039,5 +2039,7 @@
   "Start of Book": "ต้นเล่ม",
   "End of Book": "ท้ายเล่ม",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "โฟลเดอร์นี้เป็นคลังหนังสือภายนอก ยกเลิกการเลือกเพื่อหยุดอ่านหนังสือจากตำแหน่งเดิม การนำเข้าครั้งต่อไปจะคัดลอกหนังสือเข้าคลังหนังสือ",
-  "More Settings": "การตั้งค่าเพิ่มเติม"
+  "More Settings": "การตั้งค่าเพิ่มเติม",
+  "Right-to-Left Pages": "หน้าจากขวาไปซ้าย",
+  "Send Document Metadata": "ส่งข้อมูลเมตาของเอกสาร"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2095,5 +2095,7 @@
   "Start of Book": "Kitabın başı",
   "End of Book": "Kitabın sonu",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Bu klasör harici bir kitaplıktır. Kitaplarını bulundukları yerden okumayı durdurmak için işareti kaldırın; sonraki içe aktarmalarda kitaplar kitaplığa kopyalanır.",
-  "More Settings": "Diğer ayarlar"
+  "More Settings": "Diğer ayarlar",
+  "Right-to-Left Pages": "Sağdan Sola Sayfalar",
+  "Send Document Metadata": "Belge Meta Verilerini Gönder"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2207,5 +2207,7 @@
   "Start of Book": "Початок книги",
   "End of Book": "Кінець книги",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Ця тека — зовнішня бібліотека. Зніміть позначку, щоб припинити читати її книги на місці; під час наступних імпортів книги копіюватимуться в бібліотеку.",
-  "More Settings": "Інші налаштування"
+  "More Settings": "Інші налаштування",
+  "Right-to-Left Pages": "Сторінки справа наліво",
+  "Send Document Metadata": "Надсилати метадані документа"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2095,5 +2095,7 @@
   "Start of Book": "Kitob boshi",
   "End of Book": "Kitob oxiri",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Bu jild tashqi kutubxona. Kitoblarini joyida o‘qishni to‘xtatish uchun belgini olib tashlang; keyingi importlarda kitoblar kutubxonaga nusxalanadi.",
-  "More Settings": "Boshqa sozlamalar"
+  "More Settings": "Boshqa sozlamalar",
+  "Right-to-Left Pages": "Oʻngdan chapga sahifalar",
+  "Send Document Metadata": "Hujjat metamaʼlumotlarini yuborish"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2039,5 +2039,7 @@
   "Start of Book": "Đầu sách",
   "End of Book": "Cuối sách",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "Thư mục này là thư viện ngoài. Bỏ chọn để ngừng đọc sách tại chỗ; các lần nhập sau sẽ sao chép sách vào thư viện.",
-  "More Settings": "Cài đặt khác"
+  "More Settings": "Cài đặt khác",
+  "Right-to-Left Pages": "Trang từ phải sang trái",
+  "Send Document Metadata": "Gửi siêu dữ liệu tài liệu"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2039,5 +2039,7 @@
   "Start of Book": "书籍开头",
   "End of Book": "书籍结尾",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "此文件夹是外部书库。取消勾选后将不再就地读取其中的书籍；之后的导入会把书籍复制到书库中。",
-  "More Settings": "更多设置"
+  "More Settings": "更多设置",
+  "Right-to-Left Pages": "从右到左翻页",
+  "Send Document Metadata": "发送文档元数据"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2039,5 +2039,7 @@
   "Start of Book": "書籍開頭",
   "End of Book": "書籍結尾",
   "This folder is an external library. Uncheck to stop reading its books in place; future imports will copy books into the library.": "此資料夾是外部書庫。取消勾選後將不再就地讀取其中的書籍；之後的匯入會把書籍複製到書庫中。",
-  "More Settings": "更多設定"
+  "More Settings": "更多設定",
+  "Right-to-Left Pages": "從右到左翻頁",
+  "Send Document Metadata": "傳送文件中繼資料"
 }

--- a/apps/readest-app/src/__tests__/components/ViewMenu.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ViewMenu.test.tsx
@@ -1,0 +1,168 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ViewMenu from '@/app/reader/components/ViewMenu';
+
+const mockView = {
+  book: { dir: undefined as string | undefined },
+  renderer: {
+    setAttribute: vi.fn(),
+    setStyles: undefined,
+  },
+};
+
+const mockBookData = {
+  isFixedLayout: true,
+  bookDoc: {
+    dir: undefined as string | undefined,
+    rendition: { layout: 'pre-paginated' },
+    sections: [{ pageSpread: '' }],
+  },
+};
+
+const currentViewSettings = {
+  scrolled: false,
+  scrolledDirection: 'vertical',
+  webtoonMode: false,
+  paragraphMode: { enabled: false },
+  zoomLevel: 100,
+  contrast: 100,
+  zoomMode: 'fit-page',
+  spreadMode: 'auto',
+  keepCoverSpread: true,
+  invertImgColorInDark: false,
+  applyThemeToPDF: false,
+  vertical: false,
+  writingMode: 'auto',
+};
+
+const mockRecreateViewer = vi.fn();
+const mockSaveViewSettings = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: { hasAmbientLightSensor: false } }),
+}));
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: null }),
+}));
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({ themeMode: 'auto', isDarkMode: false, setThemeMode: vi.fn() }),
+}));
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    getView: () => mockView,
+    getViewSettings: () => currentViewSettings,
+    getViewState: () => ({}),
+    getProgress: () => null,
+    setViewSettings: vi.fn(),
+    recreateViewer: mockRecreateViewer,
+  }),
+}));
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({
+    getConfig: () => ({}),
+    getBookData: () => mockBookData,
+  }),
+}));
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({
+    setSettingsDialogOpen: vi.fn(),
+    setSettingsDialogBookKey: vi.fn(),
+  }),
+}));
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+vi.mock('@/hooks/useResponsiveSize', () => ({
+  useResponsiveSize: (n: number) => n,
+}));
+vi.mock('@/helpers/settings', () => ({
+  saveViewSettings: (...args: unknown[]) => mockSaveViewSettings(...args),
+}));
+vi.mock('@/services/constants', () => ({
+  MAX_ZOOM_LEVEL: 200,
+  MIN_ZOOM_LEVEL: 50,
+  ZOOM_STEP: 10,
+  MAX_CONTRAST: 200,
+  MIN_CONTRAST: 50,
+  CONTRAST_STEP: 10,
+}));
+vi.mock('@/utils/style', () => ({ getStyles: vi.fn() }));
+vi.mock('@/utils/nav', () => ({ navigateToLogin: vi.fn() }));
+vi.mock('@/utils/webtoon', () => ({ getScrollGapAttr: vi.fn() }));
+vi.mock('@/app/reader/hooks/useCapturedTurn', () => ({ applyPageTurnAttributes: vi.fn() }));
+vi.mock('@/utils/config', () => ({ getMaxInlineSize: () => 720 }));
+vi.mock('@/utils/ambientLight', () => ({ nextThemeMode: (mode: string) => mode }));
+vi.mock('@/utils/window', () => ({ tauriHandleToggleFullScreen: vi.fn() }));
+
+describe('ViewMenu right-to-left pages toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSaveViewSettings.mockResolvedValue(undefined);
+    mockView.book.dir = undefined;
+    mockBookData.isFixedLayout = true;
+    mockBookData.bookDoc.dir = undefined;
+    mockBookData.bookDoc.rendition = { layout: 'pre-paginated' };
+    currentViewSettings.writingMode = 'auto';
+    currentViewSettings.vertical = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows the toggle for fixed-layout books', () => {
+    render(<ViewMenu bookKey='book-1' />);
+    expect(screen.getByText('Right-to-Left Pages')).toBeTruthy();
+  });
+
+  it('hides the toggle for reflowable books', () => {
+    mockBookData.isFixedLayout = false;
+    mockBookData.bookDoc.rendition = { layout: 'reflowable' };
+
+    render(<ViewMenu bookKey='book-1' />);
+    expect(screen.queryByText('Right-to-Left Pages')).toBeNull();
+  });
+
+  it('switches an LTR book to RTL page order and recreates the viewer', async () => {
+    render(<ViewMenu bookKey='book-1' />);
+
+    fireEvent.click(screen.getByText('Right-to-Left Pages'));
+
+    await waitFor(() => {
+      expect(mockSaveViewSettings).toHaveBeenCalledWith(
+        expect.anything(),
+        'book-1',
+        'writingMode',
+        'horizontal-rl',
+        true,
+      );
+      expect(mockView.book.dir).toBe('rtl');
+      expect(mockRecreateViewer).toHaveBeenCalledWith(expect.anything(), 'book-1');
+    });
+  });
+
+  it('switches a native RTL book back to LTR page order', async () => {
+    mockBookData.bookDoc.dir = 'rtl';
+    mockView.book.dir = 'rtl';
+
+    render(<ViewMenu bookKey='book-1' />);
+
+    fireEvent.click(screen.getByText('Right-to-Left Pages'));
+
+    await waitFor(() => {
+      expect(mockSaveViewSettings).toHaveBeenCalledWith(
+        expect.anything(),
+        'book-1',
+        'writingMode',
+        'horizontal-tb',
+        true,
+      );
+      expect(mockView.book.dir).toBe('ltr');
+      expect(mockRecreateViewer).toHaveBeenCalledWith(expect.anything(), 'book-1');
+    });
+  });
+});

--- a/apps/readest-app/src/__tests__/components/useBookShortcuts.test.tsx
+++ b/apps/readest-app/src/__tests__/components/useBookShortcuts.test.tsx
@@ -57,9 +57,12 @@ vi.mock('@/store/sidebarStore', () => ({
   }),
 }));
 
+const mockSetSettingsDialogOpen = vi.fn();
+const mockSetSettingsDialogBookKey = vi.fn();
 vi.mock('@/store/settingsStore', () => ({
   useSettingsStore: () => ({
-    setSettingsDialogOpen: vi.fn(),
+    setSettingsDialogOpen: mockSetSettingsDialogOpen,
+    setSettingsDialogBookKey: mockSetSettingsDialogBookKey,
   }),
 }));
 
@@ -218,5 +221,13 @@ describe('useBookShortcuts', () => {
     shortcutState.actions?.['onStartRSVP']?.();
 
     expect(dispatchSpy).toHaveBeenCalledWith('rsvp-start', { bookKey: 'book-1' });
+  });
+
+  it('targets the active book when the settings shortcut opens the dialog (#5591)', () => {
+    render(<Harness />);
+    shortcutState.actions?.['onOpenFontLayoutSettings']?.();
+
+    expect(mockSetSettingsDialogBookKey).toHaveBeenCalledWith('book-1');
+    expect(mockSetSettingsDialogOpen).toHaveBeenCalledWith(true);
   });
 });

--- a/apps/readest-app/src/__tests__/document/pdf-canvas-memory-cap.test.ts
+++ b/apps/readest-app/src/__tests__/document/pdf-canvas-memory-cap.test.ts
@@ -75,6 +75,7 @@ vi.mock('@pdfjs/pdf.min.mjs', () => {
     numPages: 3,
     getPage: vi.fn(async () => makePage()),
     getMetadata: vi.fn(async () => ({ metadata: undefined, info: {} })),
+    getViewerPreferences: vi.fn(async () => null),
     getOutline: vi.fn(async () => null),
     getDestination: vi.fn(),
     getPageIndex: vi.fn(),

--- a/apps/readest-app/src/__tests__/document/pdf-spread-seam.test.ts
+++ b/apps/readest-app/src/__tests__/document/pdf-spread-seam.test.ts
@@ -50,6 +50,7 @@ vi.mock('@pdfjs/pdf.min.mjs', () => {
     numPages: 3,
     getPage: vi.fn(async () => makePage()),
     getMetadata: vi.fn(async () => ({ metadata: undefined, info: {} })),
+    getViewerPreferences: vi.fn(async () => null),
     getOutline: vi.fn(async () => null),
     getDestination: vi.fn(),
     getPageIndex: vi.fn(),

--- a/apps/readest-app/src/__tests__/document/pdf-viewer-preferences-direction.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/pdf-viewer-preferences-direction.browser.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { makePDF } from 'foliate-js/pdf.js';
+
+// PDFs bound right-to-left (Japanese photo books, manga) declare it in the
+// catalog's ViewerPreferences as /Direction /R2L. makePDF must surface that as
+// book.dir so the fixed-layout renderer pairs and orders spreads right-to-left
+// without the user hunting for the writing-mode setting (readest#5591).
+
+// Minimal two-page PDFs generated with pypdf; the first carries
+// /ViewerPreferences << /Direction /R2L >>, the second no viewer preferences.
+const R2L_PDF_BASE64 =
+  'JVBERi0xLjMKJeLjz9MKMSAwIG9iago8PAovUHJvZHVjZXIgKHB5cGRmKQo+PgplbmRvYmoKMiAwIG9iago8PAovVHlwZSAvUGFnZXMKL0NvdW50IDIKL0tpZHMgWyA0IDAgUiA1IDAgUiBdCj4+CmVuZG9iagozIDAgb2JqCjw8Ci9UeXBlIC9DYXRhbG9nCi9QYWdlcyAyIDAgUgovVmlld2VyUHJlZmVyZW5jZXMgPDwKL0RpcmVjdGlvbiAvUjJMCj4+Cj4+CmVuZG9iago0IDAgb2JqCjw8Ci9UeXBlIC9QYWdlCi9SZXNvdXJjZXMgPDwKPj4KL01lZGlhQm94IFsgMC4wIDAuMCAyMDAgMzAwIF0KL1BhcmVudCAyIDAgUgo+PgplbmRvYmoKNSAwIG9iago8PAovVHlwZSAvUGFnZQovUmVzb3VyY2VzIDw8Cj4+Ci9NZWRpYUJveCBbIDAuMCAwLjAgMjAwIDMwMCBdCi9QYXJlbnQgMiAwIFIKPj4KZW5kb2JqCnhyZWYKMCA2CjAwMDAwMDAwMDAgNjU1MzUgZiAKMDAwMDAwMDAxNSAwMDAwMCBuIAowMDAwMDAwMDU0IDAwMDAwIG4gCjAwMDAwMDAxMTkgMDAwMDAgbiAKMDAwMDAwMDIwOSAwMDAwMCBuIAowMDAwMDAwMzAzIDAwMDAwIG4gCnRyYWlsZXIKPDwKL1NpemUgNgovUm9vdCAzIDAgUgovSW5mbyAxIDAgUgo+PgpzdGFydHhyZWYKMzk3CiUlRU9GCg==';
+
+const PLAIN_PDF_BASE64 =
+  'JVBERi0xLjMKJeLjz9MKMSAwIG9iago8PAovUHJvZHVjZXIgKHB5cGRmKQo+PgplbmRvYmoKMiAwIG9iago8PAovVHlwZSAvUGFnZXMKL0NvdW50IDIKL0tpZHMgWyA0IDAgUiA1IDAgUiBdCj4+CmVuZG9iagozIDAgb2JqCjw8Ci9UeXBlIC9DYXRhbG9nCi9QYWdlcyAyIDAgUgo+PgplbmRvYmoKNCAwIG9iago8PAovVHlwZSAvUGFnZQovUmVzb3VyY2VzIDw8Cj4+Ci9NZWRpYUJveCBbIDAuMCAwLjAgMjAwIDMwMCBdCi9QYXJlbnQgMiAwIFIKPj4KZW5kb2JqCjUgMCBvYmoKPDwKL1R5cGUgL1BhZ2UKL1Jlc291cmNlcyA8PAo+PgovTWVkaWFCb3ggWyAwLjAgMC4wIDIwMCAzMDAgXQovUGFyZW50IDIgMCBSCj4+CmVuZG9iagp4cmVmCjAgNgowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMTUgMDAwMDAgbiAKMDAwMDAwMDA1NCAwMDAwMCBuIAowMDAwMDAwMTE5IDAwMDAwIG4gCjAwMDAwMDAxNjggMDAwMDAgbiAKMDAwMDAwMDI2MiAwMDAwMCBuIAp0cmFpbGVyCjw8Ci9TaXplIDYKL1Jvb3QgMyAwIFIKL0luZm8gMSAwIFIKPj4Kc3RhcnR4cmVmCjM1NgolJUVPRgo=';
+
+const toFile = (base64: string, name: string): File => {
+  const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+  return new File([bytes], name, { type: 'application/pdf' });
+};
+
+type PDFBook = { dir?: string; destroy?: () => void };
+
+describe('makePDF viewer preferences direction', () => {
+  it('marks PDFs declaring /Direction /R2L as rtl', async () => {
+    const book = (await makePDF(toFile(R2L_PDF_BASE64, 'r2l.pdf'))) as PDFBook;
+    try {
+      expect(book.dir).toBe('rtl');
+    } finally {
+      book.destroy?.();
+    }
+  });
+
+  it('leaves PDFs without a direction preference alone', async () => {
+    const book = (await makePDF(toFile(PLAIN_PDF_BASE64, 'plain.pdf'))) as PDFBook;
+    try {
+      expect(book.dir).toBeUndefined();
+    } finally {
+      book.destroy?.();
+    }
+  });
+});

--- a/apps/readest-app/src/__tests__/foliate-pdf-range-concurrency.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-pdf-range-concurrency.test.ts
@@ -46,6 +46,7 @@ vi.mock('@pdfjs/pdf.min.mjs', () => {
       cleanup: vi.fn(),
     })),
     getMetadata: vi.fn(async () => ({ metadata: undefined, info: {} })),
+    getViewerPreferences: vi.fn(async () => null),
     getOutline: vi.fn(async () => null),
     getDestination: vi.fn(),
     getPageIndex: vi.fn(),

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -355,6 +355,10 @@ const FoliateViewer: React.FC<{
         writingDir?.vertical || viewSettings.writingMode.includes('vertical') || false;
       const newRtl =
         writingDir?.rtl ||
+        // Fixed-layout books carry no writing mode; their direction may come
+        // from the document itself (PDF ViewerPreferences /Direction /R2L),
+        // and page-turn taps and swipes must follow it.
+        bookDoc.dir === 'rtl' ||
         getDirFromUILanguage() === 'rtl' ||
         viewSettings.writingMode.includes('rl') ||
         false;

--- a/apps/readest-app/src/app/reader/components/ViewMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/ViewMenu.tsx
@@ -60,7 +60,8 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
   const { envConfig, appService } = useEnv();
   const { getConfig, getBookData } = useBookDataStore();
   const { setSettingsDialogOpen, setSettingsDialogBookKey } = useSettingsStore();
-  const { getView, getViewSettings, getViewState, getProgress, setViewSettings } = useReaderStore();
+  const { getView, getViewSettings, getViewState, getProgress, setViewSettings, recreateViewer } =
+    useReaderStore();
   const config = getConfig(bookKey)!;
   const bookData = getBookData(bookKey)!;
   const viewSettings = getViewSettings(bookKey)!;
@@ -84,6 +85,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
     viewSettings!.invertImgColorInDark,
   );
   const [applyThemeToPDF, setApplyThemeToPDF] = useState(viewSettings!.applyThemeToPDF!);
+  const [rtlSpread, setRtlSpread] = useState(bookData?.bookDoc?.dir === 'rtl');
 
   const zoomIn = () => setZoomLevel((prev) => Math.min(prev + ZOOM_STEP, MAX_ZOOM_LEVEL));
   const zoomOut = () => setZoomLevel((prev) => Math.max(prev - ZOOM_STEP, MIN_ZOOM_LEVEL));
@@ -249,6 +251,22 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
     saveViewSettings(envConfig, bookKey, 'keepCoverSpread', keepCoverSpread, true, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [keepCoverSpread]);
+
+  useEffect(() => {
+    const bookDoc = bookData?.bookDoc;
+    if (!bookDoc || rtlSpread === (bookDoc.dir === 'rtl')) return;
+    // Writing mode is per-book only (no global fallback), and horizontal-rl is
+    // what flips both the spread order and the page progression, so the toggle
+    // rides the same setting the Layout panel edits instead of a new one.
+    const writingMode = rtlSpread ? 'horizontal-rl' : 'horizontal-tb';
+    viewSettings.vertical = false;
+    saveViewSettings(envConfig, bookKey, 'writingMode', writingMode, true).then(() => {
+      const view = getView(bookKey);
+      if (view) view.book.dir = rtlSpread ? 'rtl' : 'ltr';
+      recreateViewer(envConfig, bookKey);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rtlSpread]);
 
   const lastSyncTime = Math.max(
     config?.lastSyncedAtConfig || 0,
@@ -424,6 +442,11 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
               Icon={keepCoverSpread ? MdCheck : undefined}
               onClick={() => setKeepCoverSpread(!keepCoverSpread)}
               disabled={spreadMode === 'none'}
+            />
+            <MenuItem
+              label={_('Right-to-Left Pages')}
+              Icon={rtlSpread ? MdCheck : undefined}
+              onClick={() => setRtlSpread(!rtlSpread)}
             />
             <MenuItem label={_('Webtoon Mode')} toggled={webtoonMode} onClick={toggleWebtoonMode} />
           </>

--- a/apps/readest-app/src/app/reader/hooks/useBookShortcuts.ts
+++ b/apps/readest-app/src/app/reader/hooks/useBookShortcuts.ts
@@ -27,7 +27,7 @@ interface UseBookShortcutsProps {
 const useBookShortcuts = ({ sideBarBookKey, bookKeys }: UseBookShortcutsProps) => {
   const { getView, getViewState, getViewSettings, setViewSettings } = useReaderStore();
   const { toggleSideBar, setSideBarBookKey } = useSidebarStore();
-  const { setSettingsDialogOpen } = useSettingsStore();
+  const { setSettingsDialogOpen, setSettingsDialogBookKey } = useSettingsStore();
   const { getBookData } = useBookDataStore();
   const { toggleNotebook } = useNotebookStore();
   const { getNextBookKey } = useBooksManager();
@@ -416,7 +416,10 @@ const useBookShortcuts = ({ sideBarBookKey, bookKeys }: UseBookShortcutsProps) =
       onStartRSVP: startRSVP,
       onToggleAutoScroll: toggleAutoScroll,
       onToggleToolbar: toggleToolbar,
-      onOpenFontLayoutSettings: () => setSettingsDialogOpen(true),
+      onOpenFontLayoutSettings: () => {
+        if (sideBarBookKey) setSettingsDialogBookKey(sideBarBookKey);
+        setSettingsDialogOpen(true);
+      },
       onShowSearchBar: showSearchBar,
       onToggleFullscreen: toggleFullscreen,
       onToggleTTS: toggleTTS,

--- a/apps/readest-app/vitest.browser.config.mts
+++ b/apps/readest-app/vitest.browser.config.mts
@@ -15,6 +15,12 @@ export default defineConfig({
   },
   resolve: {
     conditions: ['development'],
+    alias: {
+      // The @pdfjs alias from tsconfig only resolves within the app's own
+      // source files.  foliate-js/pdf.js lives outside that scope, so Vite
+      // needs an explicit alias to find the vendored pdfjs build.
+      '@pdfjs': resolve(import.meta.dirname, 'public/vendor/pdfjs'),
+    },
   },
   optimizeDeps: {
     include: [


### PR DESCRIPTION
Closes #5591

For books bound right-to-left (Japanese photo books, manga, and other RTL-bound PDFs), two-page spreads paired and ordered the pages left-to-right, so facing pages appeared swapped and page turns ran the wrong way. The RTL machinery existed in the fixed-layout renderer, but PDFs had no way to reach it: the loader never detected the document's binding direction, and the only manual control (Settings > Layout > Writing Mode) is hidden behind a language heuristic and lives far from the spread controls.

## Changes

- **Right-to-Left Pages toggle in the View menu** for fixed-layout books, next to Auto Spread and Separate Cover Page where users look for spread behavior. It drives the existing per-book `writingMode` setting (`horizontal-rl` / `horizontal-tb`), so it stays consistent with the Layout panel, persists, and syncs like any view setting.
- **Auto-detection for PDFs**: `makePDF` now reads the catalog's ViewerPreferences and sets `book.dir = 'rtl'` when the PDF declares `/Direction /R2L` (readest/foliate-js#75). Properly authored Japanese PDFs open with correct spreads with no settings needed.
- **Page-turn direction follows the document**: the `viewSettings.rtl` derivation now also considers the loaded document's `dir`, so taps and swipes map correctly for auto-detected RTL books (previously it only looked at the writing-mode setting).
- **Fix: Shift+F opened Settings without a book key**, so changes there targeted a ghost `''` book: nothing applied to the open book and `recreateViewer('')` threw "Book not found". The shortcut now passes the active book key like the menu entry does.

## Tests

- `ViewMenu.test.tsx`: toggle renders only for fixed-layout books; switches writingMode `horizontal-rl`/`horizontal-tb`, sets `view.book.dir`, and recreates the viewer (both directions).
- `pdf-viewer-preferences-direction.browser.test.ts`: loads minimal R2L-flagged and unflagged PDFs through the real `makePDF` in Chromium and asserts `book.dir`. Needed the `@pdfjs` alias mirrored into `vitest.browser.config.mts` (it was already in the jsdom config for the same reason).
- `useBookShortcuts.test.tsx`: the settings shortcut sets the dialog's book key.
- Existing jsdom PDF tests' stubs gained `getViewerPreferences`.

All written failing-first per the repo's test-first rule.

## Verification

Verified in `dev-web` with the PDF attached to #5591 (a Japanese photo book with no ViewerPreferences, no language metadata):

- The new toggle flips the book between LTR and RTL: cover side switches, spread pairing reverses (renderer contents go from `[5,6]` to `[6,5]`), progress footer mirrors, and the state persists across reopen.
- A crafted `/Direction /R2L` PDF opens right-to-left automatically with writing mode still `auto`.

i18n: the new label (plus the previously untranslated "Send Document Metadata" key that extraction surfaced) translated across all 33 locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
