### PR TITLE
fix(sync): keep a book's reference page count on all devices, closes #5716

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
@@ -37,7 +37,7 @@ const h = vi.hoisted(() => {
     user: { id: 'u1' },
     syncConfigsMock: vi.fn(async () => {}),
     syncBooksMock: vi.fn(async () => {}),
-    saveConfigMock: vi.fn(async () => {}),
+    saveConfigMock: vi.fn(async (..._args: unknown[]) => {}),
     setViewSettingsMock: vi.fn(),
     recreateViewerMock: vi.fn(),
     cfiCompareMock: vi.fn((_a: string, _b: string) => 0),
@@ -50,7 +50,13 @@ const h = vi.hoisted(() => {
     state: {
       syncedConfigs: [] as unknown[] | null,
       progress: { location: 'cfi-loc' } as { location: string; fraction?: number } | null,
-      viewSettings: { proofreadRules: [] } as { proofreadRules: unknown[] } | null,
+      viewSettings: { proofreadRules: [] } as {
+        proofreadRules: unknown[];
+        referencePageCount?: number;
+      } | null,
+      isPrimary: true,
+      hasView: true,
+      previewMode: false,
       bookDoc: {} as unknown,
     },
     eventListeners: new Map<string, Set<(e: CustomEvent) => void>>(),
@@ -88,13 +94,21 @@ vi.mock('@/store/bookDataStore', () => ({
 
 vi.mock('@/store/readerStore', () => ({
   useReaderStore: h.makeStore({
-    getView: () => h.view,
+    getView: () => (h.state.hasView ? h.view : null),
     getProgress: () => h.state.progress,
     getViewSettings: () => h.state.viewSettings,
-    setViewSettings: h.setViewSettingsMock,
+    // Mirror the real store: setViewSettings replaces this view's settings, so
+    // a later getViewSettings in the same pass sees the update.
+    setViewSettings: (key: string, vs: unknown) => {
+      h.state.viewSettings = vs as typeof h.state.viewSettings;
+      h.setViewSettingsMock(key, vs);
+    },
     recreateViewer: h.recreateViewerMock,
     setHoveredBookKey: vi.fn(),
-    getViewState: () => ({ previewMode: false }),
+    getViewState: () => ({
+      previewMode: h.state.previewMode,
+      isPrimary: h.state.isPrimary,
+    }),
   }),
 }));
 
@@ -172,6 +186,10 @@ beforeEach(() => {
   h.state.syncedConfigs = [];
   h.state.progress = { location: 'cfi-loc' };
   h.state.viewSettings = { proofreadRules: [] };
+  h.config = { progress: [5, 100], location: 'cfi-loc', updatedAt: 1000 };
+  h.state.isPrimary = true;
+  h.state.hasView = true;
+  h.state.previewMode = false;
   h.state.bookDoc = {};
   h.eventListeners.clear();
 });
@@ -361,6 +379,273 @@ describe('useProgressSync', () => {
     expect(h.setViewSettingsMock).not.toHaveBeenCalled();
     expect(h.saveConfigMock).not.toHaveBeenCalled();
     expect(h.recreateViewerMock).not.toHaveBeenCalled();
+  });
+
+  // referencePageCount describes the BOOK (its paperback-equivalent page count),
+  // not the device, so a peer that knows the count must be able to hand it over.
+  // The local config in this harness carries updatedAt: 1000, so a synced config
+  // below is "older" or "newer" relative to that.
+  test('adopts a synced referencePageCount when this device has none', async () => {
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 0 };
+    h.state.syncedConfigs = [
+      // Older than the local config: a device with no count of its own still
+      // takes the remote one, because 0 means "never set".
+      {
+        bookHash: 'h1',
+        metaHash: 'm1',
+        updatedAt: 500,
+        viewSettings: { referencePageCount: 8235 },
+      },
+    ];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.setViewSettingsMock).toHaveBeenCalledTimes(1);
+    const applied = h.setViewSettingsMock.mock.calls[0]![1] as { referencePageCount?: number };
+    expect(applied.referencePageCount).toBe(8235);
+    // Persisted too, so the value survives the next open and pushes back up.
+    // Assert the payload, not just that a write happened.
+    expect(h.saveConfigMock).toHaveBeenCalledTimes(1);
+    const saved = h.saveConfigMock.mock.calls[0]![2] as {
+      viewSettings?: { referencePageCount?: number };
+    };
+    expect(saved.viewSettings?.referencePageCount).toBe(8235);
+  });
+
+  test('takes a newer synced referencePageCount over the local one', async () => {
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 300 };
+    h.state.syncedConfigs = [
+      {
+        bookHash: 'h1',
+        metaHash: 'm1',
+        updatedAt: 5000,
+        viewSettings: { referencePageCount: 8235 },
+      },
+    ];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    const applied = h.setViewSettingsMock.mock.calls[0]![1] as { referencePageCount?: number };
+    expect(applied.referencePageCount).toBe(8235);
+  });
+
+  test('keeps a local referencePageCount when the synced config is older', async () => {
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 300 };
+    h.state.syncedConfigs = [
+      {
+        bookHash: 'h1',
+        metaHash: 'm1',
+        updatedAt: 500,
+        viewSettings: { referencePageCount: 8235 },
+      },
+    ];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.setViewSettingsMock).not.toHaveBeenCalled();
+    expect(h.saveConfigMock).not.toHaveBeenCalled();
+  });
+
+  // Never skip adoption: a device left holding 0 prunes the key from its next
+  // push (0 equals the global default) and flattens the row for every device.
+  // Losing the count without the user asking is the outcome this change exists
+  // to stop. Pushing needs a live view, so the clock bump cannot out-rank a peer
+  // before the view has relocated.
+  test('adopts the count even when the book has no live view', async () => {
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.hasView = false;
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 0 };
+    h.state.syncedConfigs = [
+      {
+        bookHash: 'h1',
+        metaHash: 'm1',
+        updatedAt: 5000,
+        viewSettings: { referencePageCount: 8235 },
+      },
+    ];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    const applied = h.setViewSettingsMock.mock.calls[0]![1] as { referencePageCount?: number };
+    expect(applied.referencePageCount).toBe(8235);
+  });
+
+  // `config` carries the previewed position during a deep-link preview, which
+  // useProgressAutoSave deliberately never persists. So adopt in memory, but do
+  // not write the config; a push can only come from a non-preview session.
+  // This pins THIS write only. The proofread merge further down the same pull
+  // has no preview guard of its own, so a pull that also changes a rule still
+  // persists the previewed position -- pre-existing, and noted in the PR.
+  test('adopts the count in memory during a preview without writing to disk', async () => {
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.previewMode = true;
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 0 };
+    h.state.syncedConfigs = [
+      {
+        bookHash: 'h1',
+        metaHash: 'm1',
+        updatedAt: 5000,
+        viewSettings: { referencePageCount: 8235 },
+      },
+    ];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    const applied = h.setViewSettingsMock.mock.calls[0]![1] as { referencePageCount?: number };
+    expect(applied.referencePageCount).toBe(8235);
+    expect(h.saveConfigMock).not.toHaveBeenCalled();
+  });
+
+  // The adoption awaits a disk write, and a page turn during that yield replaces
+  // the store's config object. The position compare below it must therefore
+  // re-read the config, not reuse the snapshot taken at the top of the pull, or
+  // it walks the reader back to a position already passed.
+  test('re-reads the position after the awaited write, not the snapshot', async () => {
+    h.cfiCompareMock.mockReturnValue(-1);
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 0 };
+    h.state.syncedConfigs = [
+      {
+        bookHash: 'h1',
+        metaHash: 'm1',
+        updatedAt: 5000,
+        location: 'cfi-remote',
+        viewSettings: { referencePageCount: 8235 },
+      },
+    ];
+    // The reader turns a page while the adoption's write is in flight. The real
+    // store REPLACES the config object (readerStore.setProgress), which is what
+    // makes the snapshot taken at the top of the pull go stale, so the mock must
+    // replace it too rather than mutate in place.
+    h.saveConfigMock.mockImplementationOnce(async () => {
+      h.config = { ...h.config, location: 'cfi-after-turn' };
+    });
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.cfiCompareMock).toHaveBeenCalledWith('cfi-after-turn', 'cfi-remote');
+  });
+
+  // A failed disk write must not reject the pull. Aborting here would skip the
+  // position work while the pull gate is already open, and the debounced push
+  // would then overwrite a newer remote position with the local one (#5625).
+  test('a failed config write does not abort the rest of the pull', async () => {
+    h.cfiCompareMock.mockReturnValue(-1);
+    h.saveConfigMock.mockRejectedValueOnce(new Error('disk full'));
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 0 };
+    h.state.syncedConfigs = [
+      {
+        bookHash: 'h1',
+        metaHash: 'm1',
+        updatedAt: 5000,
+        location: 'cfi-remote',
+        viewSettings: { referencePageCount: 8235 },
+      },
+    ];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.saveConfigMock).toHaveBeenCalled();
+    expect(h.view.goTo).toHaveBeenCalledWith('cfi-remote');
+  });
+
+  // Only the primary view owns config.json. A second view of the same book must
+  // still take the value in memory, but must not write the shared config.
+  test('a non-primary view adopts the count without writing to disk', async () => {
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.isPrimary = false;
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 0 };
+    h.state.syncedConfigs = [
+      {
+        bookHash: 'h1',
+        metaHash: 'm1',
+        updatedAt: 500,
+        viewSettings: { referencePageCount: 8235 },
+      },
+    ];
+    renderHook(() => useProgressSync('h1-view2'));
+    await advance(0);
+
+    const applied = h.setViewSettingsMock.mock.calls[0]![1] as { referencePageCount?: number };
+    expect(applied.referencePageCount).toBe(8235);
+    expect(h.saveConfigMock).not.toHaveBeenCalled();
+  });
+
+  test('keeps the local referencePageCount when the synced config carries none', async () => {
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 300 };
+    h.state.syncedConfigs = [{ bookHash: 'h1', metaHash: 'm1', updatedAt: 5000, viewSettings: {} }];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.setViewSettingsMock).not.toHaveBeenCalled();
+    expect(h.saveConfigMock).not.toHaveBeenCalled();
+  });
+
+  // The tie-break is deliberate: mergeBookConfig resolves an equal clock in the
+  // remote's favour, and this mirrors it.
+  test('adopts a synced referencePageCount on an equal updatedAt', async () => {
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 300 };
+    h.state.syncedConfigs = [
+      {
+        bookHash: 'h1',
+        metaHash: 'm1',
+        updatedAt: 1000,
+        viewSettings: { referencePageCount: 8235 },
+      },
+    ];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    const applied = h.setViewSettingsMock.mock.calls[0]![1] as { referencePageCount?: number };
+    expect(applied.referencePageCount).toBe(8235);
+  });
+
+  test('does not rewrite the config when the counts already agree', async () => {
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 8235 };
+    h.state.syncedConfigs = [
+      {
+        bookHash: 'h1',
+        metaHash: 'm1',
+        updatedAt: 5000,
+        viewSettings: { referencePageCount: 8235 },
+      },
+    ];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.setViewSettingsMock).not.toHaveBeenCalled();
+    expect(h.saveConfigMock).not.toHaveBeenCalled();
+  });
+
+  // The proofread merge runs straight after the page-count adoption and spreads
+  // the same view-settings object, so it must not drop the count it just gained.
+  test('keeps the adopted page count when proofread rules merge in the same pull', async () => {
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 0 };
+    h.state.syncedConfigs = [
+      {
+        bookHash: 'h1',
+        metaHash: 'm1',
+        viewSettings: {
+          referencePageCount: 8235,
+          proofreadRules: [{ id: 'remote', scope: 'book', pattern: 'b', updatedAt: 200 }],
+        },
+      },
+    ];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    const last = h.setViewSettingsMock.mock.calls.at(-1)![1] as {
+      referencePageCount?: number;
+      proofreadRules: { id: string }[];
+    };
+    expect(last.referencePageCount).toBe(8235);
+    expect(last.proofreadRules.map((r) => r.id)).toEqual(['remote']);
   });
 
   test('sync-book-progress flushes the pending cloud push on book close', async () => {

--- a/apps/readest-app/src/__tests__/services/import-metahash.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-metahash.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Book } from '@/types/book';
-import { getMetadataHash } from '@/utils/book';
+import { getMetadataHash, INIT_BOOK_CONFIG } from '@/utils/book';
 
 const mockOpen = vi.hoisted(() => vi.fn());
 const mockPartialMD5 = vi.hoisted(() => vi.fn());
@@ -814,5 +814,125 @@ describe('importBook with BookLookupIndex', () => {
     expect(lookupIndex.byFilePath.get('/lib/a.epub')).toBe(inPlaceBook);
     expect(lookupIndex.byFilePath.has('/lib/b.epub')).toBe(false);
     expect(lookupIndex.byFilePath.has('https://example.com/c.epub')).toBe(false);
+  });
+});
+
+// A book directory can already hold a config.json when importBook runs. The
+// backup restore is the clearest case: it extracts every file of an orphan hash
+// dir (one absent from the archive's library.json), config.json included, and
+// then calls importBook on the extracted file -- while its sibling branch, for a
+// dir the library does know, carefully merges that same config. Stamping
+// INIT_BOOK_CONFIG over it discards the reading position, the bookmarks and the
+// annotations the restore just recovered.
+describe('importBook preserves an existing book config', () => {
+  let service: TestAppService;
+
+  const configWrites = (fs: ReturnType<TestAppService['getFs']>, path: string) =>
+    fs.writeFile.mock.calls.filter((c: unknown[]) => c[0] === path);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TestAppService();
+    const fs = service.getFs();
+    fs.exists.mockResolvedValue(false);
+    fs.createDir.mockResolvedValue(undefined);
+    fs.writeFile.mockResolvedValue(undefined);
+    fs.removeDir.mockResolvedValue(undefined);
+    fs.readFile.mockResolvedValue('{}');
+  });
+
+  // fs is mocked, so "never written" is exactly "content unchanged".
+  it('leaves an existing config.json untouched when adding a new book', async () => {
+    const books: Book[] = [];
+
+    mockPartialMD5.mockResolvedValue('restored-hash');
+    setupMockBookDoc();
+
+    const fs = service.getFs();
+    fs.exists.mockImplementation(async (path: string) => path === 'restored-hash/config.json');
+
+    const mockFile = new File(['content'], 'test.epub', { type: 'application/epub+zip' });
+    const result = await service.importBook(mockFile, books);
+
+    expect(result?.hash).toBe('restored-hash');
+    expect(configWrites(fs, 'restored-hash/config.json')).toHaveLength(0);
+  });
+
+  // The restore passes overwrite: true, which re-writes a book file that is
+  // already on disk. The config must still survive that.
+  it('leaves an existing config.json untouched on an overwrite import', async () => {
+    const books: Book[] = [];
+
+    mockPartialMD5.mockResolvedValue('restored-hash');
+    setupMockBookDoc();
+
+    const fs = service.getFs();
+    // Both the book file and the config are already present, so `overwrite`
+    // genuinely re-writes the book file on this run.
+    fs.exists.mockImplementation(async (path: string) => path.startsWith('restored-hash/'));
+
+    const mockFile = new File(['content'], 'test.epub', { type: 'application/epub+zip' });
+    await service.importBook(mockFile, books, { overwrite: true });
+
+    expect(configWrites(fs, 'restored-hash/config.json')).toHaveLength(0);
+  });
+
+  it('still initializes config.json for a new book that has none', async () => {
+    const books: Book[] = [];
+
+    mockPartialMD5.mockResolvedValue('fresh-hash');
+    setupMockBookDoc();
+
+    const fs = service.getFs();
+    const mockFile = new File(['content'], 'test.epub', { type: 'application/epub+zip' });
+    await service.importBook(mockFile, books);
+
+    const writes = configWrites(fs, 'fresh-hash/config.json');
+    expect(writes).toHaveLength(1);
+    expect(JSON.parse(writes[0]![2] as string).updatedAt).toBe(INIT_BOOK_CONFIG.updatedAt);
+  });
+
+  // Same clobber on the metaHash migration path: the book moves to a new hash
+  // directory, the OLD directory has no config to migrate, but the NEW directory
+  // already holds one.
+  it('does not overwrite an existing config when migrating to a new hash directory', async () => {
+    const metaHash = getMetadataHash(TEST_METADATA);
+    const existingBook = makeBook({ hash: 'old-hash-123', metaHash });
+    const books: Book[] = [existingBook];
+
+    mockPartialMD5.mockResolvedValue('new-hash-456');
+    setupMockBookDoc();
+
+    const fs = service.getFs();
+    fs.exists.mockImplementation(async (path: string) => {
+      if (path === 'old-hash-123/config.json') return false;
+      if (path === 'old-hash-123') return true;
+      if (path === 'new-hash-456/config.json') return true;
+      return false;
+    });
+
+    const mockFile = new File(['new content'], 'test.epub', { type: 'application/epub+zip' });
+    await service.importBook(mockFile, books);
+
+    expect(configWrites(fs, 'new-hash-456/config.json')).toHaveLength(0);
+    // The migration itself still completes.
+    expect(fs.removeDir).toHaveBeenCalledWith('old-hash-123', 'Books', true);
+  });
+
+  it('still initializes config.json when neither directory has one', async () => {
+    const metaHash = getMetadataHash(TEST_METADATA);
+    const existingBook = makeBook({ hash: 'old-hash-123', metaHash });
+    const books: Book[] = [existingBook];
+
+    mockPartialMD5.mockResolvedValue('new-hash-456');
+    setupMockBookDoc();
+
+    const fs = service.getFs();
+    fs.exists.mockImplementation(async (path: string) => path === 'old-hash-123');
+
+    const mockFile = new File(['new content'], 'test.epub', { type: 'application/epub+zip' });
+    await service.importBook(mockFile, books);
+
+    expect(configWrites(fs, 'new-hash-456/config.json')).toHaveLength(1);
   });
 });

--- a/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
@@ -234,7 +234,61 @@ export const useProgressSync = (bookKey: string) => {
       if (syncedConfig.location && isMalformedLocationCfi(syncedConfig.location)) {
         syncedConfig = { ...syncedConfig, location: undefined };
       }
-      const configCFI = config?.location;
+      // referencePageCount belongs to the edition, not to the device. The app sent
+      // it to the server, but nothing read it back. Thus a count set on one device
+      // did not reach the others. Then a push from a device without the count
+      // replaced view_settings, which the server keeps as one value.
+      //
+      // This runs before the position work below. No await is between the read at
+      // the top of this function and the clock comparison here.
+      //
+      // Examine the value first. A bad value would go to config.json and back to
+      // the server. The maximum agrees with the input. The minimum is higher than
+      // the input minimum of 0, because 0 means "not set".
+      const remoteCount = syncedConfig.viewSettings?.referencePageCount;
+      const remotePageCount =
+        typeof remoteCount === 'number' && remoteCount >= 0.1 && remoteCount <= 10000
+          ? remoteCount
+          : undefined;
+      const pageCountViewSettings = getViewSettings(bookKey);
+      const localPageCount = pageCountViewSettings?.referencePageCount;
+      const pageCountViewState = useReaderStore.getState().getViewState(bookKey);
+      // The last writer wins on the ROW clock, and a tie goes to the remote value.
+      // Each page turn stamps that clock. Thus a device that only reads can win
+      // against a device that edited. This fault is not new. The project corrected
+      // it three times with one clock for each field: reading_status (#4634),
+      // cover_hash (#4544) and metadata (#5438). A correction here alone does not
+      // help, because peers still push the full view_settings value on the row
+      // clock. The !localPageCount test makes the usual case work: a device with no
+      // count takes the remote count.
+      if (
+        pageCountViewSettings &&
+        remotePageCount &&
+        remotePageCount !== localPageCount &&
+        (!localPageCount || (syncedConfig.updatedAt ?? 0) >= (config.updatedAt ?? 0))
+      ) {
+        const adopted = { ...pageCountViewSettings, referencePageCount: remotePageCount };
+        setViewSettings(bookKey, adopted);
+        // Only the primary view owns the config on the disk. saveViewSettings does
+        // the same. The write also stops during a preview, because `config` then
+        // holds the previewed position, which useProgressAutoSave does not keep.
+        // The value stays in memory, so the app does not lose it.
+        if (pageCountViewState?.isPrimary && !pageCountViewState.previewMode) {
+          try {
+            await saveConfig(envConfig, bookKey, { ...config, viewSettings: adopted }, settings);
+          } catch (error) {
+            // The remainder of the pull must continue. The gate is already open.
+            // If this stops the pull, the delayed push writes the local position
+            // over a newer remote position (#5625). The XPointer catch below gives
+            // the same reason.
+            console.warn('Failed to persist the synced reference page count', error);
+          }
+        }
+      }
+      // Read the config again. The write above can wait for the disk, and a page
+      // turn in that time replaces the config in the store. The older position
+      // would move the reader back.
+      const configCFI = (getConfig(bookKey) ?? config)?.location;
       let remoteCFILocation = syncedConfig.location;
       const xpointer = syncedConfig.xpointer;
       const bookData = getBookData(bookKey);
@@ -273,7 +327,8 @@ export const useProgressSync = (bookKey: string) => {
         }
       }
       // Reading progress applies below. Proofread (find/replace) rules merge
-      // separately just after; other config fields remain device-local.
+      // separately just after, and referencePageCount was adopted above; every
+      // other config field remains device-local.
       // TODO: general config sync via a more robust profile-based solution.
       if (remoteCFILocation && configCFI) {
         if (CFI.compare(configCFI, remoteCFILocation) < 0) {
@@ -313,10 +368,10 @@ export const useProgressSync = (bookKey: string) => {
       // Item-level CRDT (see utils/proofread.ts) keeps a concurrent edit on
       // another device from being lost to whole-config last-writer-wins, and
       // tombstones stop a deleted rule from being resurrected by a stale peer.
+      const localViewSettings = getViewSettings(bookKey);
       const remoteRules = (syncedConfig.viewSettings?.proofreadRules ?? []).filter(
         (r) => r.scope !== 'library',
       );
-      const localViewSettings = getViewSettings(bookKey);
       const localRules = localViewSettings?.proofreadRules ?? [];
       if (localViewSettings && (remoteRules.length || localRules.length)) {
         const mergedRules = mergeProofreadRules(localRules, remoteRules);
@@ -327,7 +382,8 @@ export const useProgressSync = (bookKey: string) => {
             await saveConfig(
               envConfig,
               bookKey,
-              { ...config, viewSettings: updatedViewSettings, updatedAt: Date.now() },
+              // Re-read for the same reason as configCFI above.
+              { ...(getConfig(bookKey) ?? config), viewSettings: updatedViewSettings },
               settings,
             );
           }

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -674,7 +674,13 @@ export async function importBook(
     if (existingBook) existingBook.coverHash = coverHash;
     // Never overwrite the config file only when it's not existed
     if (!existingBook) {
-      await saveBookConfigFn(book, INIT_BOOK_CONFIG);
+      // A config.json for this hash can already be on the disk. It holds the
+      // reading position, the bookmarks and the notes. The backup restore extracts
+      // one, and then it imports the book file. Write the empty config only when
+      // no config is present, so the import keeps what the restore recovered.
+      if (!(await fs.exists(getConfigFilename(book), 'Books'))) {
+        await saveBookConfigFn(book, INIT_BOOK_CONFIG);
+      }
       // Concurrent imports of identical bytes (the folder-import pool) both
       // read `byHash` right after hashing but only write it here, after the
       // createDir/writeFile/cover awaits — so both miss and both would push a
@@ -714,7 +720,9 @@ export async function importBook(
           config.bookHash = hash;
           config.metaHash = metaHash;
           await fs.writeFile(getConfigFilename(book), 'Books', serializeRawConfig(config));
-        } else {
+        } else if (!(await fs.exists(getConfigFilename(book), 'Books'))) {
+          // No config to move, but the new hash directory can already hold one.
+          // This is the same fault as the new-book path above.
           await saveBookConfigFn(book, INIT_BOOK_CONFIG);
         }
       }


### PR DESCRIPTION
Closes #5716

## The problem

The reference page count belongs to the book, not to the device. The reader sets it when the book has no publisher page list. The `reference` progress style maps the reading position onto that number.

The app sends the count to the server. It does not read the count back. Thus the count stays on one device.

A second device then makes the fault worse. That device holds no count. Its next push replaces `view_settings` in the record. The server keeps `view_settings` as one value. Thus the count is lost on all devices.

Two standard installations show this behaviour. An external tool is not necessary.

## What this change does

The reader now takes the count from a pulled record.

The last writer wins on the config `updatedAt` clock, and a tie goes to the remote value. A device that holds no count takes the remote count, whatever the clock shows.

The app keeps the value in memory in all cases. It writes the value to the disk only from the primary view, and never during a deep-link preview. In a preview the config holds the previewed position, which `useProgressAutoSave` does not persist.

The app examines the value first. The value comes through `JSON.parse` from a server column. A bad value would go to the disk and back to the server. Thus the app accepts a number from 0.1 to 10000 only.

## Limits

- Each page turn stamps the config clock. Thus a device that only reads can win against a device that edited. This fault is not new, and it applies to each value on that clock. The project corrected the same fault three times with one clock for each field: `reading_status` (#4634), `cover_hash` (#4544) and the metadata group (#5438). A correction for this one field does not help, because peers still push the full `view_settings` value on the row clock.
- On the wire, 0 and "not set" are the same. Thus you cannot clear the count, and the app undoes the clear. The device reads the old count again on the next open, because the clock test does not apply when the local count is 0. A device that still holds the old count also sends it back.
- The count moves on Readest Cloud sync only. The file-sync backends remove `viewSettings` from the wire.
- If the first pull fails each time, the app opens the push gate without a pull. That device holds no count, and its push removes the count from the record.
- A KOReader push writes NULL to `view_settings`. Thus that push removes the count from the record.
- A file-sync pull can remove the count for one session. The reader continues to show it, and the next open takes the count again.

## The second fault

`importBook` wrote an empty config for each new book. That write removed an existing `Books/<hash>/config.json`, which holds the reading position, the bookmarks and the notes.

The backup restore shows the cost. For a book directory that the archive's `library.json` does not list, the restore extracts each file, and `config.json` is one of them. Then it imports the book file. The import removed what the restore had recovered.

The comment above that code already gave the correct rule. The code did not obey it. The app now writes the empty config only when no config is present. It does this at both places that always wrote one.

The guard changes behaviour only when the library holds no record for that hash, because `buildBookLookupIndex` keeps a deleted book in `byHash`. A delete that is not a purge keeps the record, so a new import of that book already took the other path. The orphan directory in a backup, or a lost `library.json`, are the cases that change.

## The second commit

A review of the first commit found that the validation branch had no test. The second commit adds the two tests, and corrects three comments. It also corrects two statements in the first commit's message. This description holds the corrected text.

The proofread write below the new code lost its explicit `updatedAt: Date.now()`. `saveConfig` stamps that value itself, so the behaviour does not change.

## Tests

- 19 new tests: 14 in `useProgressSync.test.tsx` and 5 in `import-metahash.test.ts`. If you remove the two changes, 14 of them fail. The other five state that unchanged behaviour holds.
- Four tests examine paths that are easy to leave untested. A `saveConfig` that fails must not stop the pull. The position comparison must read the config again after the write. A value that is not a number, and a value outside the range, must not be taken.
- The full test suite shows the same failures as `upstream/main`, and 19 more tests pass.
- `tsgo --noEmit`, `biome lint` and `biome format` are clean.
- A person tested the change on a Linux build with a live account. A book whose record held a count showed a percentage before the change, and the correct pages after it.
