### PR TITLE
fix(reader): restore scrolled PDF highlights

### DIFF
--- a/apps/readest-app/src/__tests__/document/fixed-layout-scroll-annotation.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-scroll-annotation.browser.test.ts
@@ -74,6 +74,7 @@ describe('fixed-layout scroll-mode PDF annotations (readest#5586)', () => {
 
     await waitFor(() => renderStarted && overlayers.length === 1);
     const staleOverlayer = overlayers[0]!;
+    expect(staleOverlayer.isConnected).toBe(true);
 
     finishRender();
 

--- a/apps/readest-app/src/__tests__/document/fixed-layout-scroll-annotation.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/fixed-layout-scroll-annotation.browser.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import 'foliate-js/fixed-layout.js';
+
+// Regression test for readest#5586. PDF pages rebuild their text-layer DOM in
+// the async onZoom callback. Any annotation overlayer created before that
+// callback settles holds Range objects into the old DOM and must be recreated
+// so the reader can re-anchor its saved highlights against the new text layer.
+
+const PAGE_HTML = `<!doctype html><html><head><style>
+  html, body { margin: 0; width: 600px; height: 1000px; }
+</style></head><body><div class="textLayer">highlighted text</div></body></html>`;
+
+const waitFor = async (condition: () => boolean, timeout = 4000): Promise<void> => {
+  const start = performance.now();
+  while (!condition()) {
+    if (performance.now() - start > timeout) throw new Error('waitFor timed out');
+    await new Promise((resolve) => setTimeout(resolve, 30));
+  }
+};
+
+type Renderer = HTMLElement & {
+  open(book: unknown): void;
+  destroy(): void;
+};
+
+let renderer: Renderer | null = null;
+
+afterEach(() => {
+  renderer?.destroy();
+  renderer?.remove();
+  renderer = null;
+});
+
+describe('fixed-layout scroll-mode PDF annotations (readest#5586)', () => {
+  it('recreates the overlayer after an async PDF text-layer render', async () => {
+    let finishRender!: () => void;
+    const renderFinished = new Promise<void>((resolve) => {
+      finishRender = resolve;
+    });
+    let renderStarted = false;
+    const book = {
+      dir: 'ltr',
+      rendition: { viewport: { width: 600, height: 1000 }, spread: 'none' },
+      sections: [
+        {
+          load: async () => ({
+            src: 'srcdoc',
+            data: PAGE_HTML,
+            onZoom: () => {
+              renderStarted = true;
+              return renderFinished;
+            },
+          }),
+          linear: 'yes',
+        },
+      ],
+    };
+
+    renderer = document.createElement('foliate-fxl') as Renderer;
+    renderer.style.width = '600px';
+    renderer.style.height = '400px';
+    renderer.setAttribute('flow', 'scrolled');
+
+    const overlayers: SVGSVGElement[] = [];
+    renderer.addEventListener('create-overlayer', (event) => {
+      const element = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      overlayers.push(element);
+      (event as CustomEvent).detail.attach({ element, redraw: () => {} });
+    });
+
+    document.body.append(renderer);
+    renderer.open(book);
+
+    await waitFor(() => renderStarted && overlayers.length === 1);
+    const staleOverlayer = overlayers[0]!;
+
+    finishRender();
+
+    await waitFor(() => overlayers.length > 1);
+    expect(staleOverlayer.isConnected).toBe(false);
+    expect(overlayers.at(-1)!.isConnected).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #5586.

## Summary

- Refreshes the fixed-layout annotation overlay after asynchronous PDF rendering replaces the text layer.
- Preserves saved and synced highlights when scrolling between PDF pages.
- Adds a browser regression test for the render-to-overlay lifecycle.
- Updates foliate-js to readest/foliate-js#76.

## Root cause

In continuous-scroll PDFs, the annotation overlay could be created before asynchronous `onZoom` rendering completed. PDF.js then replaced the text layer, invalidating the stored ranges while the annotation remained present in the sidebar.

## Verification

- `pnpm lint`
- `pnpm test`: 9,124 passed, 16 skipped
- `pnpm test:browser -- --maxWorkers=1 --no-file-parallelism`: 363 passed, 1 skipped
- `pnpm build`
- Pre-push formatting, lint, type-check, and unit-test gate

## Test coverage

The browser regression covers asynchronous PDF rendering, stale-overlay retention while rendering is pending, removal after completion, and attachment of the replacement overlay. A full persisted-annotation E2E flow remains outside this focused renderer test.

## Documentation

No updates required. This restores existing documented behavior and changes no public API, setup flow, or architecture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of PDF annotations in fixed-layout documents when scrolling and zooming, helping ensure annotations remain correctly positioned and displayed after rendering completes.
  - Updated document rendering components to provide more consistent annotation behavior in these scenarios.

- **Tests**
  - Added automated browser coverage for annotation updates during asynchronous rendering, scrolling, and fixed-layout PDF workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->