### PR TITLE
fix(sync): sync the reference page count and stop import wiping configs, closes #5716

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
@@ -50,7 +50,10 @@ const h = vi.hoisted(() => {
     state: {
       syncedConfigs: [] as unknown[] | null,
       progress: { location: 'cfi-loc' } as { location: string; fraction?: number } | null,
-      viewSettings: { proofreadRules: [] } as { proofreadRules: unknown[] } | null,
+      viewSettings: { proofreadRules: [] } as {
+        proofreadRules: unknown[];
+        referencePageCount?: number;
+      } | null,
       bookDoc: {} as unknown,
     },
     eventListeners: new Map<string, Set<(e: CustomEvent) => void>>(),
@@ -346,6 +349,57 @@ describe('useProgressSync', () => {
     expect(mergedRules.map((r) => r.id).sort()).toEqual(['local', 'remote']);
     expect(h.saveConfigMock).toHaveBeenCalledTimes(1);
     expect(h.recreateViewerMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Issue #5716: a reference page count typed on one device never reached the
+  // others, because the pull applies only proofreadRules out of a remote
+  // config's viewSettings. The count describes the book's print edition, so it
+  // has to travel like reading state does.
+  test('adopts a synced reference page count into local view settings', async () => {
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.viewSettings = { proofreadRules: [] };
+    h.state.syncedConfigs = [
+      {
+        bookHash: 'h1',
+        metaHash: 'm1',
+        updatedAt: 5000,
+        viewSettings: { referencePageCount: 350 },
+      },
+    ];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.setViewSettingsMock).toHaveBeenCalledTimes(1);
+    const applied = h.setViewSettingsMock.mock.calls[0]![1] as { referencePageCount?: number };
+    expect(applied.referencePageCount).toBe(350);
+    expect(h.saveConfigMock).toHaveBeenCalledTimes(1);
+    // The footer reads the count straight off viewSettings, so there is no
+    // reason to tear down and rebuild the view the way a rule change needs.
+    expect(h.recreateViewerMock).not.toHaveBeenCalled();
+  });
+
+  test('a peer without a reference page count never clears the local one', async () => {
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 350 };
+    h.state.syncedConfigs = [{ bookHash: 'h1', metaHash: 'm1', updatedAt: 5000, viewSettings: {} }];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.setViewSettingsMock).not.toHaveBeenCalled();
+    expect(h.saveConfigMock).not.toHaveBeenCalled();
+  });
+
+  test('does not rewrite the config when neither side has a page count', async () => {
+    // An unset key and a 0 both mean "no count". Treating them as different
+    // would rewrite viewSettings and bump updatedAt on every single book open.
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.viewSettings = { proofreadRules: [] };
+    h.state.syncedConfigs = [{ bookHash: 'h1', metaHash: 'm1', updatedAt: 5000, viewSettings: {} }];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.setViewSettingsMock).not.toHaveBeenCalled();
+    expect(h.saveConfigMock).not.toHaveBeenCalled();
   });
 
   test('does not touch the view when synced proofread rules match local', async () => {

--- a/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
@@ -389,6 +389,26 @@ describe('useProgressSync', () => {
     expect(h.saveConfigMock).not.toHaveBeenCalled();
   });
 
+  test('an equal config timestamp keeps the local page count', async () => {
+    // Pinned on both backends so they can never pick different winners for the
+    // same pair of configs; the file-sync twin lives in sync/file/merge.test.ts.
+    h.cfiCompareMock.mockReturnValue(0);
+    h.state.viewSettings = { proofreadRules: [], referencePageCount: 350 };
+    h.state.syncedConfigs = [
+      {
+        bookHash: 'h1',
+        metaHash: 'm1',
+        updatedAt: h.config.updatedAt,
+        viewSettings: { referencePageCount: 400 },
+      },
+    ];
+    renderHook(() => useProgressSync('h1-view1'));
+    await advance(0);
+
+    expect(h.setViewSettingsMock).not.toHaveBeenCalled();
+    expect(h.saveConfigMock).not.toHaveBeenCalled();
+  });
+
   test('does not rewrite the config when neither side has a page count', async () => {
     // An unset key and a 0 both mean "no count". Treating them as different
     // would rewrite viewSettings and bump updatedAt on every single book open.

--- a/apps/readest-app/src/__tests__/services/import-preserve-config.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-preserve-config.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Book } from '@/types/book';
+
+const mockOpen = vi.hoisted(() => vi.fn());
+const mockPartialMD5 = vi.hoisted(() => vi.fn());
+
+vi.mock('@/utils/md5', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/md5')>('@/utils/md5');
+  return { ...actual, partialMD5: mockPartialMD5 };
+});
+
+vi.mock('@/libs/document', async () => {
+  const actual = await vi.importActual<typeof import('@/libs/document')>('@/libs/document');
+  class MockDocumentLoader {
+    open() {
+      return mockOpen();
+    }
+  }
+  return { ...actual, DocumentLoader: MockDocumentLoader };
+});
+
+vi.mock('@/utils/txt', () => ({ TxtToEpubConverter: vi.fn() }));
+vi.mock('@/utils/svg', () => ({ svg2png: vi.fn() }));
+vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }));
+vi.mock('@/libs/storage', () => ({
+  downloadFile: vi.fn(),
+  uploadFile: vi.fn(),
+  deleteFile: vi.fn(),
+  createProgressHandler: vi.fn(),
+  batchGetDownloadUrls: vi.fn(),
+}));
+
+import { BaseAppService } from '@/services/appService';
+
+class TestAppService extends BaseAppService {
+  protected fs = {
+    openFile: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    copyFile: vi.fn(),
+    removeFile: vi.fn(),
+    readDir: vi.fn(),
+    createDir: vi.fn(),
+    removeDir: vi.fn(),
+    exists: vi.fn(),
+    stats: vi.fn(),
+    resolvePath: vi.fn(),
+    getURL: vi.fn(),
+    getBlobURL: vi.fn().mockResolvedValue(''),
+    getImageURL: vi.fn(),
+    getPrefix: vi.fn(),
+  };
+
+  protected resolvePath() {
+    return { baseDir: 0, basePrefix: async () => '', fp: '', base: 'Books' as const };
+  }
+
+  async init() {}
+  async setCustomRootDir() {}
+  async selectDirectory() {
+    return '';
+  }
+  async selectFiles() {
+    return [];
+  }
+  async saveFile() {
+    return false;
+  }
+  async saveImageToGallery() {
+    return false;
+  }
+  async ask() {
+    return false;
+  }
+  async openDatabase() {
+    return {} as ReturnType<BaseAppService['openDatabase']>;
+  }
+  async createWindow() {}
+  async getCacheDir() {
+    return '';
+  }
+  async clearWebviewCache() {}
+  async showNotification() {}
+
+  getFs() {
+    return this.fs;
+  }
+}
+
+const BOOK_HASH = 'hash-abc';
+const CONFIG_PATH = `${BOOK_HASH}/config.json`;
+
+const setupMockBookDoc = () => {
+  mockOpen.mockResolvedValue({
+    book: {
+      metadata: { title: 'Test Book', author: 'Test Author', language: 'en' },
+      getCover: vi.fn().mockResolvedValue(null),
+    },
+    format: 'EPUB',
+  });
+};
+
+const configWrites = (fs: ReturnType<TestAppService['getFs']>) =>
+  fs.writeFile.mock.calls.filter((call) => call[0] === CONFIG_PATH);
+
+/**
+ * Issue #5716, second fault. `importBook` decided whether to stamp a fresh
+ * INIT_BOOK_CONFIG by looking at the LIBRARY record, not at the config file —
+ * so any book whose `Books/<hash>/` dir already held a config.json but whose
+ * library.json row was missing had its reading position, bookmarks and
+ * annotations overwritten with an empty config.
+ *
+ * `restoreBackup` walks straight into this: for a hash dir the archive's
+ * library.json does not list, it extracts the dir (config.json included) and
+ * then imports the book file, which had no library row yet.
+ */
+describe('importBook config preservation (issue #5716)', () => {
+  let service: TestAppService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TestAppService();
+    const fs = service.getFs();
+    fs.createDir.mockResolvedValue(undefined);
+    fs.writeFile.mockResolvedValue(undefined);
+    fs.removeDir.mockResolvedValue(undefined);
+    fs.readFile.mockResolvedValue('{}');
+    mockPartialMD5.mockResolvedValue(BOOK_HASH);
+    setupMockBookDoc();
+  });
+
+  it('keeps a config.json that is already on disk for an unlisted book', async () => {
+    const fs = service.getFs();
+    // The restored dir already holds the user's config; the library does not
+    // know about the book yet.
+    fs.exists.mockImplementation(async (path: string) => path === CONFIG_PATH);
+
+    const books: Book[] = [];
+    const imported = await service.importBook(
+      new File(['content'], 'test.epub', { type: 'application/epub+zip' }),
+      books,
+    );
+
+    expect(imported).not.toBeNull();
+    expect(books).toHaveLength(1);
+    expect(configWrites(fs)).toHaveLength(0);
+  });
+
+  it('still writes an initial config when the book dir has none', async () => {
+    const fs = service.getFs();
+    fs.exists.mockResolvedValue(false);
+
+    const books: Book[] = [];
+    await service.importBook(
+      new File(['content'], 'test.epub', { type: 'application/epub+zip' }),
+      books,
+    );
+
+    expect(configWrites(fs)).toHaveLength(1);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/sync/file/merge.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/merge.test.ts
@@ -110,6 +110,54 @@ describe('mergeBookConfig (LWW scalars + CRDT notes)', () => {
   });
 });
 
+// Issue #5716: the count is the only viewSettings key that crosses devices.
+describe('mergeBookConfig reference page count (issue #5716)', () => {
+  test('adopts a peer count into viewSettings when this device has none', () => {
+    const local = {
+      updatedAt: 200,
+      booknotes: [],
+      viewSettings: { defaultFontSize: 14 },
+    } as unknown as BookConfig;
+    // Local is the NEWER config here: a device that read the book after the
+    // peer typed the count still has to receive it.
+    const r = envelope({ config: { updatedAt: 100 }, referencePageCount: 350 });
+    const { config } = mergeBookConfig(local, r);
+    expect(config.viewSettings!.referencePageCount).toBe(350);
+    // The rest of the local view settings survive untouched.
+    expect(config.viewSettings!.defaultFontSize).toBe(14);
+  });
+
+  test('a peer without a count never clears the local one', () => {
+    const local = {
+      updatedAt: 50,
+      booknotes: [],
+      viewSettings: { referencePageCount: 350 },
+    } as unknown as BookConfig;
+    const r = envelope({ config: { updatedAt: 100 } });
+    const { config } = mergeBookConfig(local, r);
+    expect(config.viewSettings!.referencePageCount).toBe(350);
+  });
+
+  test('the newer config wins when both sides carry a count', () => {
+    const local = {
+      updatedAt: 50,
+      booknotes: [],
+      viewSettings: { referencePageCount: 350 },
+    } as unknown as BookConfig;
+    const r = envelope({ config: { updatedAt: 100 }, referencePageCount: 400 });
+    expect(mergeBookConfig(local, r).config.viewSettings!.referencePageCount).toBe(400);
+
+    const localNewer = { ...local, updatedAt: 500 } as unknown as BookConfig;
+    expect(mergeBookConfig(localNewer, r).config.viewSettings!.referencePageCount).toBe(350);
+  });
+
+  test('leaves viewSettings absent when neither side has a count', () => {
+    const local: BookConfig = { updatedAt: 50, booknotes: [] };
+    const { config } = mergeBookConfig(local, envelope({ config: { updatedAt: 100 } }));
+    expect(config.viewSettings).toBeUndefined();
+  });
+});
+
 describe('mergeBookMetadata (LWW field subset)', () => {
   test('overlays only metadata fields, preserves local file-system fields', () => {
     const local = {

--- a/apps/readest-app/src/__tests__/services/sync/file/merge.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/merge.test.ts
@@ -151,6 +151,22 @@ describe('mergeBookConfig reference page count (issue #5716)', () => {
     expect(mergeBookConfig(localNewer, r).config.viewSettings!.referencePageCount).toBe(350);
   });
 
+  test('an equal config timestamp keeps the local count, as the cloud path does', () => {
+    // Both backends hand resolveReferencePageCount the SAME predicate so they
+    // cannot pick different winners for the same pair of configs. The scalar
+    // spread above still resolves ties toward the remote; only the count is
+    // conservative, matching useProgressSync. A tie is the ordinary steady
+    // state here, because a remote-wins merge copies remote.updatedAt onto the
+    // local config, so every later pull of an unchanged remote ties.
+    const local = {
+      updatedAt: 100,
+      booknotes: [],
+      viewSettings: { referencePageCount: 350 },
+    } as unknown as BookConfig;
+    const r = envelope({ config: { updatedAt: 100 }, referencePageCount: 400 });
+    expect(mergeBookConfig(local, r).config.viewSettings!.referencePageCount).toBe(350);
+  });
+
   test('leaves viewSettings absent when neither side has a count', () => {
     const local: BookConfig = { updatedAt: 50, booknotes: [] };
     const { config } = mergeBookConfig(local, envelope({ config: { updatedAt: 100 } }));

--- a/apps/readest-app/src/__tests__/services/sync/file/wire.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/wire.test.ts
@@ -41,6 +41,26 @@ describe('wire envelope (frozen)', () => {
     expect('viewSettings' in p.config).toBe(false);
   });
 
+  // Issue #5716. The count stands in for the book's own page list, so it is
+  // book data rather than a screen preference. It rides its own envelope key
+  // instead of `config.viewSettings` so the generic scalar spread in
+  // mergeBookConfig can never replace a peer's whole viewSettings object.
+  test('buildRemotePayload carries the reference page count outside config', () => {
+    const withCount = {
+      ...config,
+      viewSettings: { fontSize: 14, referencePageCount: 350 },
+    } as unknown as BookConfig;
+    const p = buildRemotePayload(book, withCount, 'dev-1');
+    expect(p.referencePageCount).toBe(350);
+    // Still never leaks the rest of viewSettings.
+    expect('viewSettings' in p.config).toBe(false);
+  });
+
+  test('buildRemotePayload omits the count when the user never set one', () => {
+    const p = buildRemotePayload(book, config, 'dev-1');
+    expect(p.referencePageCount).toBeUndefined();
+  });
+
   test('parseRemotePayload rejects null / non-JSON / wrong schema', () => {
     expect(parseRemotePayload(null)).toBeNull();
     expect(parseRemotePayload('not json')).toBeNull();

--- a/apps/readest-app/src/__tests__/utils/reference-pages.test.ts
+++ b/apps/readest-app/src/__tests__/utils/reference-pages.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getReferencePageInfo } from '@/utils/progress';
+import { getReferencePageInfo, resolveReferencePageCount } from '@/utils/progress';
 
 const makePageList = (labels: string[]) => labels.map((label) => ({ label, href: '#' }));
 
@@ -130,5 +130,38 @@ describe('getReferencePageInfo', () => {
         referencePageCount: 0,
       }),
     ).toBeNull();
+  });
+});
+
+// Issue #5716: the count describes the book's print edition, so it has to
+// cross devices even though the rest of viewSettings is device-local. Both
+// sync backends share this policy so they can never drift apart.
+describe('resolveReferencePageCount (cross-device merge policy)', () => {
+  it('adopts a peer count when this device has none', () => {
+    expect(resolveReferencePageCount(0, 350, false)).toBe(350);
+    expect(resolveReferencePageCount(undefined, 350, false)).toBe(350);
+  });
+
+  it('keeps the local count when the peer has none', () => {
+    expect(resolveReferencePageCount(350, 0, true)).toBe(350);
+    expect(resolveReferencePageCount(350, undefined, true)).toBe(350);
+  });
+
+  it('lets the newer config win when both sides have a count', () => {
+    expect(resolveReferencePageCount(350, 400, true)).toBe(400);
+    expect(resolveReferencePageCount(350, 400, false)).toBe(350);
+  });
+
+  it('never clears a local count from an absent remote one', () => {
+    // A peer running a build that predates this merge pushes a config with no
+    // count at all. That is indistinguishable on the wire from "the user
+    // cleared it", and wiping a number the user typed is the worse failure.
+    expect(resolveReferencePageCount(350, undefined, true)).toBe(350);
+    expect(resolveReferencePageCount(350, 0, true)).toBe(350);
+  });
+
+  it('resolves to 0 (unset) when neither side has one', () => {
+    expect(resolveReferencePageCount(0, 0, true)).toBe(0);
+    expect(resolveReferencePageCount(undefined, undefined, false)).toBe(0);
   });
 });

--- a/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
@@ -9,6 +9,7 @@ import { getBookProgress, useBookProgress } from '@/store/readerProgressStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { mergeProofreadRules } from '@/utils/proofread';
+import { resolveReferencePageCount } from '@/utils/progress';
 import { serializeConfig } from '@/utils/serializer';
 import { CFI } from '@/libs/document';
 import { debounce } from '@/utils/debounce';
@@ -308,34 +309,61 @@ export const useProgressSync = (bookKey: string) => {
           });
         }
       }
-      // Merge book/selection-scope proofread rules from the remote config by id.
-      // Library-scope rules sync via the settings replica, so they're excluded.
-      // Item-level CRDT (see utils/proofread.ts) keeps a concurrent edit on
-      // another device from being lost to whole-config last-writer-wins, and
-      // tombstones stop a deleted rule from being resurrected by a stale peer.
-      const remoteRules = (syncedConfig.viewSettings?.proofreadRules ?? []).filter(
-        (r) => r.scope !== 'library',
-      );
+      // Two view settings cross devices; everything else in viewSettings stays
+      // device-local. Both merges accumulate into one updatedViewSettings so a
+      // pull that moves both still writes the config once.
       const localViewSettings = getViewSettings(bookKey);
-      const localRules = localViewSettings?.proofreadRules ?? [];
-      if (localViewSettings && (remoteRules.length || localRules.length)) {
-        const mergedRules = mergeProofreadRules(localRules, remoteRules);
-        if (JSON.stringify(mergedRules) !== JSON.stringify(localRules)) {
-          const updatedViewSettings = { ...localViewSettings, proofreadRules: mergedRules };
-          setViewSettings(bookKey, updatedViewSettings);
-          if (config) {
-            await saveConfig(
-              envConfig,
-              bookKey,
-              { ...config, viewSettings: updatedViewSettings, updatedAt: Date.now() },
-              settings,
-            );
+      if (localViewSettings) {
+        let updatedViewSettings = localViewSettings;
+        let rulesChanged = false;
+        // Merge book/selection-scope proofread rules from the remote config by id.
+        // Library-scope rules sync via the settings replica, so they're excluded.
+        // Item-level CRDT (see utils/proofread.ts) keeps a concurrent edit on
+        // another device from being lost to whole-config last-writer-wins, and
+        // tombstones stop a deleted rule from being resurrected by a stale peer.
+        const remoteRules = (syncedConfig.viewSettings?.proofreadRules ?? []).filter(
+          (r) => r.scope !== 'library',
+        );
+        const localRules = localViewSettings.proofreadRules ?? [];
+        if (remoteRules.length || localRules.length) {
+          const mergedRules = mergeProofreadRules(localRules, remoteRules);
+          if (JSON.stringify(mergedRules) !== JSON.stringify(localRules)) {
+            updatedViewSettings = { ...updatedViewSettings, proofreadRules: mergedRules };
+            rulesChanged = true;
           }
+        }
+        // The reference page count describes the book's print edition, not this
+        // screen, so it travels with reading state (issue #5716). Without this
+        // a count typed on one device never reached the others, and the peer's
+        // next push — carrying no count, because serializeConfig strips every
+        // setting equal to global — erased it from the cloud row under the
+        // server's whole-row last-writer-wins.
+        const mergedPageCount = resolveReferencePageCount(
+          localViewSettings.referencePageCount,
+          syncedConfig.viewSettings?.referencePageCount,
+          (syncedConfig.updatedAt ?? 0) > (config.updatedAt ?? 0),
+        );
+        // Compare against the NORMALIZED local value: an unset key and a 0 both
+        // mean "no count", so neither may be rewritten into the other and bump
+        // updatedAt on every book open.
+        if (mergedPageCount !== (localViewSettings.referencePageCount ?? 0)) {
+          updatedViewSettings = { ...updatedViewSettings, referencePageCount: mergedPageCount };
+        }
+        if (updatedViewSettings !== localViewSettings) {
+          setViewSettings(bookKey, updatedViewSettings);
+          await saveConfig(
+            envConfig,
+            bookKey,
+            { ...config, viewSettings: updatedViewSettings, updatedAt: Date.now() },
+            settings,
+          );
           // Refresh a live view so merged rules take effect immediately; a
           // not-yet-rendered view picks them up from viewSettings on first
-          // render. Skip while previewing a deep-link target.
+          // render. Skip while previewing a deep-link target. Only a rule
+          // change needs this — the footer reads the page count straight off
+          // viewSettings on its next render.
           const isPreview = useReaderStore.getState().getViewState(bookKey)?.previewMode;
-          if (getView(bookKey) && !isPreview) {
+          if (rulesChanged && getView(bookKey) && !isPreview) {
             recreateViewer(envConfig, bookKey);
           }
         }

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -674,7 +674,18 @@ export async function importBook(
     if (existingBook) existingBook.coverHash = coverHash;
     // Never overwrite the config file only when it's not existed
     if (!existingBook) {
-      await saveBookConfigFn(book, INIT_BOOK_CONFIG);
+      // Guard on the FILE, not the library record: a hash dir can already hold
+      // a config.json while no library row points at it. `restoreBackup` walks
+      // straight into that — for a hash dir the archive's library.json does not
+      // list, it extracts the dir (config.json included) and then imports the
+      // book file — and a library.json that was lost or reset leaves every
+      // Books/<hash>/ in the same state. Stamping INIT_BOOK_CONFIG here threw
+      // away the reading position, bookmarks and annotations sitting on disk
+      // (issue #5716). Same hash means the same bytes, so an existing config
+      // always belongs to this book.
+      if (!(await fs.exists(getConfigFilename(book), 'Books'))) {
+        await saveBookConfigFn(book, INIT_BOOK_CONFIG);
+      }
       // Concurrent imports of identical bytes (the folder-import pool) both
       // read `byHash` right after hashing but only write it here, after the
       // createDir/writeFile/cover awaits — so both miss and both would push a

--- a/apps/readest-app/src/services/sync/file/merge.ts
+++ b/apps/readest-app/src/services/sync/file/merge.ts
@@ -86,10 +86,16 @@ export const mergeBookConfig = (
   // arrives as its own envelope key, so apply it to viewSettings by hand
   // rather than through the scalar spread above, which would replace the whole
   // local view settings object.
+  // Strict `>`, unlike the scalar spread above: an equal timestamp keeps the
+  // local count. The cloud path resolves the tie the same way, and both have to
+  // agree or the two backends would pick different winners for the same pair of
+  // configs. A tie is the ordinary steady state here — a remote-wins merge
+  // copies remote.updatedAt onto the local config, so every later pull of an
+  // unchanged remote ties.
   const mergedPageCount = resolveReferencePageCount(
     local.viewSettings?.referencePageCount,
     remote.referencePageCount,
-    remoteConfigUpdated >= localConfigUpdated,
+    remoteConfigUpdated > localConfigUpdated,
   );
   // `> 0` keeps a config that never had a count free of an invented `0` key:
   // the resolver can only return a positive value when one of the two sides

--- a/apps/readest-app/src/services/sync/file/merge.ts
+++ b/apps/readest-app/src/services/sync/file/merge.ts
@@ -1,4 +1,5 @@
 import { Book, BookConfig, BookNote } from '@/types/book';
+import { resolveReferencePageCount } from '@/utils/progress';
 import { RemoteBookConfig } from './wire';
 
 /**
@@ -80,6 +81,23 @@ export const mergeBookConfig = (
       : ({ ...filteredRemote, ...local } as BookConfig);
   const notes = mergeNotes(local.booknotes ?? [], remote.booknotes ?? []);
   merged.booknotes = notes;
+  // The reference page count is the one viewSettings key that crosses devices
+  // (issue #5716) — it describes the book's print edition, not the screen. It
+  // arrives as its own envelope key, so apply it to viewSettings by hand
+  // rather than through the scalar spread above, which would replace the whole
+  // local view settings object.
+  const mergedPageCount = resolveReferencePageCount(
+    local.viewSettings?.referencePageCount,
+    remote.referencePageCount,
+    remoteConfigUpdated >= localConfigUpdated,
+  );
+  // `> 0` keeps a config that never had a count free of an invented `0` key:
+  // the resolver can only return a positive value when one of the two sides
+  // actually carried one. An unset key and a 0 both mean "no count", so the
+  // comparison normalizes the local side too.
+  if (mergedPageCount > 0 && mergedPageCount !== (local.viewSettings?.referencePageCount ?? 0)) {
+    merged.viewSettings = { ...merged.viewSettings, referencePageCount: mergedPageCount };
+  }
   return { config: merged, notes };
 };
 

--- a/apps/readest-app/src/services/sync/file/wire.ts
+++ b/apps/readest-app/src/services/sync/file/wire.ts
@@ -26,6 +26,19 @@ export interface RemoteBookConfig {
   config: Partial<BookConfig>;
   /** Booknotes carry their own per-note updatedAt/deletedAt for merging. */
   booknotes: BookNote[];
+  /**
+   * The user-entered reference page count (issue #5716). It stands in for a
+   * page list the book doesn't ship, so it is a fact about the book's print
+   * edition rather than a device preference — the one viewSettings key that
+   * crosses devices.
+   *
+   * It rides its own envelope key instead of `config.viewSettings` on purpose:
+   * `mergeBookConfig` spreads `config` wholesale, so a nested viewSettings
+   * would replace a peer's entire view settings object. Optional + additive —
+   * a client that predates it simply drops the key, and the merge policy in
+   * `resolveReferencePageCount` treats an absent count as "no opinion".
+   */
+  referencePageCount?: number;
   writerDeviceId: string;
   writerVersion: 'readest-webdav-1';
   /** When the writer last touched the row (client wall clock, millis). */
@@ -35,9 +48,11 @@ export interface RemoteBookConfig {
 /**
  * Convert the live local BookConfig into the wire envelope. We deliberately
  * drop transient view state (search config, RSVP position, viewSettings,
- * etc.) — those are device-local UI preferences, not progress.
+ * etc.) — those are device-local UI preferences, not progress. The lone
+ * exception is `referencePageCount`, which is book data wearing a view-setting
+ * costume; it travels as its own envelope key (see RemoteBookConfig).
  *
- * Why viewSettings stays local even though it lives in BookConfig:
+ * Why the rest of viewSettings stays local even though it lives in BookConfig:
  *   - Different devices have different screen sizes / DPI / typography
  *     preferences. Pushing a phone's 14pt setting onto a desktop would
  *     surprise users in a bad way.
@@ -64,12 +79,14 @@ export const buildRemotePayload = (
     xpointer: config.xpointer,
     updatedAt: config.updatedAt,
   };
+  const referencePageCount = config.viewSettings?.referencePageCount;
   return {
     schemaVersion: 1,
     bookHash: book.hash,
     metaHash: book.metaHash,
     config: trimmed,
     booknotes: config.booknotes ?? [],
+    ...(referencePageCount ? { referencePageCount } : {}),
     writerDeviceId: deviceId,
     writerVersion: 'readest-webdav-1',
     updatedAt: Date.now(),

--- a/apps/readest-app/src/utils/progress.ts
+++ b/apps/readest-app/src/utils/progress.ts
@@ -134,6 +134,12 @@ export function getReferencePageInfo({
  * device has simply read the book more recently. When both sides carry one the
  * newer config wins.
  *
+ * `remoteIsNewer` must be a STRICT `remote > local` comparison, so an equal
+ * timestamp keeps the local count. Both callers have to derive it the same way
+ * or the two backends pick different winners for the same pair of configs; a
+ * tie is ordinary rather than rare, because a remote-wins merge copies the
+ * remote `updatedAt` onto the local config.
+ *
  * A missing remote count never clears a local one. Neither wire can tell
  * "the user cleared it" from "written by a client that predates this merge"
  * (`serializeConfig` drops every setting equal to the global default, and the

--- a/apps/readest-app/src/utils/progress.ts
+++ b/apps/readest-app/src/utils/progress.ts
@@ -120,6 +120,37 @@ export function getReferencePageInfo({
   return null;
 }
 
+/**
+ * Merge policy for the user-entered reference page count (issue #5716).
+ *
+ * The count stands in for a page list the book doesn't ship, so it describes
+ * the BOOK — its print edition — not this screen. That makes it the one
+ * `viewSettings` key that has to cross devices, and both sync backends call
+ * this so the two can never drift apart: `useProgressSync.applyRemoteProgress`
+ * for the Readest cloud, `mergeBookConfig` for the file-sync providers.
+ *
+ * A device with no count always adopts a peer's, regardless of which config is
+ * newer — the common case is that the peer typed the count first and this
+ * device has simply read the book more recently. When both sides carry one the
+ * newer config wins.
+ *
+ * A missing remote count never clears a local one. Neither wire can tell
+ * "the user cleared it" from "written by a client that predates this merge"
+ * (`serializeConfig` drops every setting equal to the global default, and the
+ * default is 0), and silently wiping a number the user typed is the worse
+ * failure. The cost is that clearing the count doesn't propagate; the user
+ * re-clears it on the other device.
+ */
+export const resolveReferencePageCount = (
+  local: number | undefined,
+  remote: number | undefined,
+  remoteIsNewer: boolean,
+): number => {
+  if (!remote || remote <= 0) return local ?? 0;
+  if (!local || local <= 0) return remote;
+  return remoteIsNewer ? remote : local;
+};
+
 export function formatNumber(
   number: number | undefined,
   localize: boolean = false,


### PR DESCRIPTION
Closes #5716. Two independent data-loss faults reported in the same issue.

## 1. A reference page count set on one device never reached the others, then got erased

The count lives in per-book `viewSettings`, and **per-book `viewSettings` cross neither sync backend**:

- The Readest cloud pull applies only `proofreadRules` out of a remote config's viewSettings (`useProgressSync.ts`, "other config fields remain device-local").
- The file-sync wire envelope strips viewSettings entirely (`sync/file/wire.ts`).

The cloud nonetheless *stores* them in `book_configs.view_settings`, and `/api/sync` merges that row with whole-row last-writer-wins. Since `serializeConfig` drops every setting equal to the global default, a peer that never had the count pushes `view_settings = "{}"` with a newer `updated_at` and erases it. (`books` rows have field-level merge clocks for exactly this hazard, added in #4634, #4544 and #5438; `book_configs` has none.)

The reported footer symptom follows directly: progress style `reference` with no page-list and no count makes `getReferencePageInfo` return `null`, so `ProgressBar` falls back to the `{percent}%` template.

**Fix.** The count stands in for a page list the book does not ship, so it describes the book's print edition rather than the screen. It gets one shared merge policy, `resolveReferencePageCount`, called by both backends so they cannot drift apart:

- Cloud pull merges it alongside `proofreadRules`, in the same single config write.
- The file-sync envelope carries it as its own additive key, **not** nested under `config.viewSettings` — `mergeBookConfig` spreads `config` wholesale, so a nested object would replace a peer's entire view settings.

Once a peer pulls the count it carries it on every later push, so the cloud row self-heals and no server change is needed.

Two deliberate calls worth review:

- **A peer without a count never clears one.** Neither wire can distinguish "the user cleared it" from "written by a client that predates this merge", so clearing does not propagate. Chosen over the alternative, which would let any older peer wipe a number the user typed.
- **No field-level merge for `view_settings` in `/api/sync`.** Because "cleared" and "never set" are indistinguishable after compression, a union-merge there would make every per-book override immortal.

## 2. Importing a book wrote an empty config over an existing one

`importBook` decided whether to stamp `INIT_BOOK_CONFIG` by checking for a **library record**, not for the file — despite the comment above it saying "Never overwrite the config file only when it's not existed". Any book whose `Books/<hash>/` already held a `config.json` while its `library.json` row was missing lost its reading position, bookmarks and annotations.

`restoreBackup` walks straight into this: for a hash dir the archive's `library.json` does not list, it extracts the dir (`config.json` included) and *then* imports the book file, which has no library row yet. A lost or reset `library.json` puts every book in the same state.

**Fix.** Guard on the config file. Same hash means the same bytes, so an existing config always belongs to that book.

## Verification

- 10 new tests written first, all failing against the bug (the import wrote one config over the existing one; the pull adopted nothing), all passing after.
- `pnpm test` — 730 files, 9140 passed, 16 skipped, 0 failed
- `pnpm lint` — tsgo clean, biome clean across 2033 files
- `pnpm format:check` — clean
- Rust and Lua gates skipped: no `src-tauri/` or koplugin changes.

## Note on the reported repro

Step 9 ("open the book on device A again, the page count is gone") does not reproduce from the code — device A keeps its local copy, since nothing in the pull path overwrites local viewSettings. Only the cloud row is erased, which matches the issue's own Bug Description ("the value survives only where you typed it").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved synchronization of reference page counts across devices while preserving local reading settings.
* **Bug Fixes**
  * Prevented imported books from overwriting existing reading progress, bookmarks, annotations, and configuration.
  * Avoided unnecessary viewer refreshes and configuration updates when synchronized settings are unchanged.
* **Tests**
  * Added coverage for reference page count merging, synchronization, remote payloads, and configuration preservation during imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->