### PR TITLE
fix(reader): drop the 500-result cap from in-book search

### DIFF
--- a/apps/readest-app/src/__tests__/components/SearchBar.test.tsx
+++ b/apps/readest-app/src/__tests__/components/SearchBar.test.tsx
@@ -110,4 +110,13 @@ describe('SearchBar', () => {
     expect(mocks.searchLibraryBooks).toHaveBeenCalledTimes(1);
     expect(mocks.searchLibraryBooks.mock.calls[0]![3].sectionIndex).toBe(4);
   });
+
+  // The library scan caps each book at 500 matches; in-book search must not
+  // inherit that cap and silently stop at 500 results.
+  it('searches the book without a result cap', async () => {
+    mocks.progress = null;
+    await renderBar();
+
+    expect(mocks.searchLibraryBooks.mock.calls[0]![3].maxResultsPerBook).toBe(Infinity);
+  });
 });

--- a/apps/readest-app/src/__tests__/services/library-search-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/library-search-service.test.ts
@@ -434,6 +434,32 @@ describe('searchLibraryBooks', () => {
     await session.close();
   });
 
+  it('searches without a cap when maxResultsPerBook is unlimited', async () => {
+    const book = makeBook('uncapped', 'Uncapped');
+    const file = makeFile('# Chapter\ntext');
+    const service = makeService(new Map([['uncapped', file]]));
+    const session = createLibrarySearchSession(service);
+    const cached = await session.open(book);
+    Object.assign(cached.bookDoc, {
+      sections: [{ id: '0', createDocument: async () => makeDocument('a'.repeat(600)) }],
+    });
+    const events = [];
+
+    for await (const event of searchLibraryBooks(service, [book], 'a', {
+      config: { ...config, mode: 'fuzzy' },
+      session,
+      maxResultsPerBook: Infinity,
+    })) {
+      events.push(event);
+    }
+
+    const result = events.find((event) => event.type === 'result');
+    const completed = events.find((event) => event.type === 'completed');
+    expect(result?.result.subitems).toHaveLength(600);
+    expect(completed).toMatchObject({ matchCount: 600, truncated: false });
+    await session.close();
+  });
+
   it('caps each book independently and continues to later books', async () => {
     const first = makeBook('partial', 'Partial');
     const second = makeBook('remainder', 'Remainder');

--- a/apps/readest-app/src/app/reader/components/sidebar/SearchBar.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/SearchBar.tsx
@@ -225,6 +225,10 @@ const SearchBar: React.FC<SearchBarProps> = ({ isVisible, bookKey, onHideSearchB
           signal: controller.signal,
           session,
           sectionIndex,
+          // The library sweep caps each book so no single book floods the
+          // shared results list; in-book search has no such competition and
+          // must report every match.
+          maxResultsPerBook: Infinity,
         })) {
           if (stopped()) return;
           if (event.type === 'progress') {

--- a/apps/readest-app/src/services/librarySearchService.ts
+++ b/apps/readest-app/src/services/librarySearchService.ts
@@ -97,6 +97,10 @@ export interface LibrarySearchOptions {
   // Restrict matching to one section (reader "current chapter" scope). Index
   // population is never restricted: a live scan still writes every section.
   sectionIndex?: number;
+  // Per-book match budget. A library-wide sweep keeps the default cap so one
+  // book cannot flood the results list; reader in-book search passes Infinity
+  // because there the one book's matches are the entire result set.
+  maxResultsPerBook?: number;
 }
 
 const DEFAULT_CONFIG: LibrarySearchConfig = {
@@ -459,6 +463,7 @@ export async function* searchLibraryBooks(
 ): AsyncGenerator<LibrarySearchEvent> {
   const config: LibrarySearchConfig = { ...DEFAULT_CONFIG, ...options.config, scope: 'book' };
   const { signal } = options;
+  const maxResultsPerBook = options.maxResultsPerBook ?? MAX_BOOK_SEARCH_RESULTS;
   let searchedBooks = 0;
   let skippedBooks = 0;
   let erroredBooks = 0;
@@ -637,7 +642,7 @@ export async function* searchLibraryBooks(
         const totalSections = meta!.totalSections;
         for (const section of sections) {
           if (signal?.aborted) return;
-          const remaining = MAX_BOOK_SEARCH_RESULTS - bookMatches;
+          const remaining = maxResultsPerBook - bookMatches;
           if (remaining <= 0) {
             bookTruncated = true;
             break;
@@ -760,7 +765,7 @@ export async function* searchLibraryBooks(
                   },
                 );
               }
-              const remaining = MAX_BOOK_SEARCH_RESULTS - bookMatches;
+              const remaining = maxResultsPerBook - bookMatches;
               if (options.sectionIndex != null && options.sectionIndex !== sectionIndex) {
                 // Scoped search: this section is only extracted for the index.
               } else if (remaining <= 0) {


### PR DESCRIPTION
Closes #5724.

## Problem

`searchLibraryBooks` enforces `MAX_BOOK_SEARCH_RESULTS = 500` per book so that one book cannot flood a library-wide sweep. PR #5389 rewired the reader's in-book search onto that same generator, so reader search inherited the budget and silently stopped at 500 matches. The sidebar footer then read a plain "500 results" with no truncation marker, unlike the library UI which shows "500+".

The cap makes sense for a whole-library scan and none at all for a single book, where that book's matches are the entire result set.

## Fix

Make the per-book budget an option instead of a constant:

- `LibrarySearchOptions.maxResultsPerBook` defaults to `MAX_BOOK_SEARCH_RESULTS`, so the library scan and its "500+" marker are unchanged.
- The reader's `SearchBar` passes `Infinity`.

No matcher needed changing: `Infinity` is already the no-limit default in `findContainsMatches`, `filterWholeWordMatches`, `findRegexMatches`, `findFuzzyMatches` and `findNearbyMatches`, and it survives the search worker's `postMessage` (structured clone, not JSON).

## Tests

Both written first and confirmed failing before the fix:

- `library-search-service.test.ts` - `maxResultsPerBook: Infinity` returns all 600 matches and reports `truncated: false`, alongside the existing tests that still assert the 500 cap for the library path.
- `SearchBar.test.tsx` - the reader passes `maxResultsPerBook: Infinity` to the service.

## Verification

- `pnpm test` - 9133 passed, 16 skipped
- `pnpm lint` - clean
- `pnpm format:check` - clean

## Note

The reader sidebar's `SearchResults.tsx` renders `results.map` with no virtualization, and foliate's `view.search` adds one annotation per CFI, so a very common word in a long book now materializes every match in the DOM. If that proves slow in practice, the follow-up is virtualizing that list rather than reinstating a cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In-book searches now display all matching results without the standard per-book limit.
  * Search limits can be configured for different search scenarios.

* **Bug Fixes**
  * Fixed in-book searches stopping after 500 results, ensuring extensive searches return complete results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->