### PR TITLE
fix(reader): neutralize fixed backgrounds and drop negative margins

### DIFF
--- a/apps/readest-app/src/__tests__/utils/style.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style.test.ts
@@ -351,6 +351,21 @@ describe('transformStylesheet', () => {
       expect(result).toContain('var(--fixed, fixed)');
     });
 
+    it('rewrites fixed after a data URI whose semicolons would end the declaration match', () => {
+      const css = '.d { background: url(data:image/png;base64,AAAA) no-repeat fixed top left; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('url(data:image/png;base64,AAAA)');
+      expect(result).toContain('no-repeat scroll top left');
+    });
+
+    it('does not corrupt a quoted url containing a closing paren and the word fixed', () => {
+      const css = '.q { background: url("weird) fixed.png") fixed; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('url("weird) fixed.png")');
+      expect(result).toContain('scroll');
+      expect(result).not.toContain('scroll.png');
+    });
+
     it('rewrites fixed in inline styles', () => {
       const css = 'background-image: url(t1.png); background-attachment: fixed';
       const result = transformStylesheet(css, VW, VH, VERTICAL);

--- a/apps/readest-app/src/__tests__/utils/style.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style.test.ts
@@ -345,6 +345,12 @@ describe('transformStylesheet', () => {
       expect(result).toContain('url(images/fixed.png)');
     });
 
+    it('does not touch fixed inside var() or other functions', () => {
+      const css = '.b { background-attachment: var(--fixed, fixed); }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('var(--fixed, fixed)');
+    });
+
     it('rewrites fixed in inline styles', () => {
       const css = 'background-image: url(t1.png); background-attachment: fixed';
       const result = transformStylesheet(css, VW, VH, VERTICAL);
@@ -384,6 +390,32 @@ describe('transformStylesheet', () => {
       const css = '.band { background-color: blue; margin: -2em -2em 1em -2em !important; }';
       const result = transformStylesheet(css, VW, VH, VERTICAL);
       expect(result).toContain(OVERRIDE);
+    });
+
+    it('zeroes only the side whose resolved value is negative', () => {
+      const css = '.band { background-color: red; margin: 1em -2em 3em 4em; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('margin-right: 0 !important');
+      expect(result).not.toContain('margin-left: 0 !important');
+    });
+
+    it('resolves later declarations over earlier ones per side', () => {
+      const css = '.band { background-color: red; margin: -2em; margin-left: 1em; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('margin-right: 0 !important');
+      expect(result).not.toContain('margin-left: 0 !important');
+    });
+
+    it('detects a painting background declared after background: none', () => {
+      const css = '.band { background: none; background-color: red; margin: 0 -2em; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain(OVERRIDE);
+    });
+
+    it('treats alpha-zero colors as non-painting', () => {
+      const css = '.hang { background-color: rgba(0, 0, 0, 0); margin: 0 -2em; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).not.toContain('margin-right: 0 !important');
     });
 
     it('leaves negative margins alone when the rule paints no background', () => {

--- a/apps/readest-app/src/__tests__/utils/style.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style.test.ts
@@ -311,6 +311,118 @@ describe('transformStylesheet', () => {
     });
   });
 
+  describe('background-attachment fixed (issue 5711)', () => {
+    it('rewrites background-attachment: fixed to scroll', () => {
+      const css =
+        '#b1 { background-image: url(../Images/t1.png); background-attachment: fixed; background-position: top left; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('background-attachment: scroll');
+      expect(result).not.toMatch(/background-attachment\s*:\s*fixed/);
+    });
+
+    it('rewrites the fixed keyword inside the background shorthand', () => {
+      const css = '.hero { background: url(../Images/t2.png) no-repeat fixed bottom right; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('no-repeat scroll bottom right');
+      expect(result).not.toMatch(/\bfixed\b/);
+    });
+
+    it('rewrites every layer of a multi-layer background-attachment list', () => {
+      const css = '.multi { background-attachment: fixed, scroll, fixed; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('background-attachment: scroll, scroll, scroll');
+    });
+
+    it('preserves !important when rewriting fixed', () => {
+      const css = '.b { background-attachment: fixed !important; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('background-attachment: scroll !important');
+    });
+
+    it('does not touch url() values containing the word fixed', () => {
+      const css = '.logo { background: url(images/fixed.png) no-repeat; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('url(images/fixed.png)');
+    });
+
+    it('rewrites fixed in inline styles', () => {
+      const css = 'background-image: url(t1.png); background-attachment: fixed';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('background-attachment: scroll');
+    });
+
+    it('does not touch position: fixed', () => {
+      const css = '.pinned { position: fixed; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain('position: fixed');
+    });
+  });
+
+  describe('negative horizontal margins with background (issue 5711)', () => {
+    const OVERRIDE = 'margin-left: 0 !important; margin-right: 0 !important;';
+
+    it('zeroes horizontal margins when the shorthand has negative left/right components', () => {
+      const css =
+        'h1.title { background-color: #0069B7; color: white; margin: -2em -2em 1.5em -2em; padding-top: 3em; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain(OVERRIDE);
+    });
+
+    it('zeroes horizontal margins for a two-value shorthand with a negative horizontal component', () => {
+      const css = '.band { background-color: red; margin: 1em -3em; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain(OVERRIDE);
+    });
+
+    it('zeroes horizontal margins for negative margin-left/right longhands', () => {
+      const css = '.band { background: #333; margin-left: -32px; margin-right: -1.5em; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain(OVERRIDE);
+    });
+
+    it('wins over an authored !important margin via later cascade order', () => {
+      const css = '.band { background-color: blue; margin: -2em -2em 1em -2em !important; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).toContain(OVERRIDE);
+    });
+
+    it('leaves negative margins alone when the rule paints no background', () => {
+      const css = '.hang { margin-left: -1em; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).not.toContain(OVERRIDE);
+    });
+
+    it('leaves negative margins alone when the background is none or transparent', () => {
+      const css = '.hang { background: none; margin-left: -1em; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).not.toContain(OVERRIDE);
+    });
+
+    it('leaves rules alone when only the vertical margin is negative', () => {
+      const css = '.band { background-color: red; margin: -2em 1em 2em; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).not.toContain(OVERRIDE);
+    });
+
+    it('preserves auto centering when the horizontal component is auto', () => {
+      const css = '.pull { background-color: red; margin: -1em auto; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).not.toContain(OVERRIDE);
+    });
+
+    it('skips shorthands containing calc() or var()', () => {
+      const css = '.band { background-color: red; margin: calc(0px - 2em) 0; }';
+      const result = transformStylesheet(css, VW, VH, VERTICAL);
+      expect(result).not.toContain(OVERRIDE);
+    });
+
+    it('does not zero margins when vertical is true', () => {
+      const css = 'h1.title { background-color: blue; margin: -2em -2em 1.5em -2em; }';
+      const result = transformStylesheet(css, VW, VH, true);
+      expect(result).not.toContain(OVERRIDE);
+    });
+  });
+
   describe('hardcoded pixel width clamping', () => {
     it('adds max-width and border-box when width exceeds viewport', () => {
       const css = '.calibre8 { display: block; width: 1200px; padding: 2em 0 0 1em; }';

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1098,6 +1098,55 @@ export const transformStylesheet = (
     return selector + block;
   });
 
+  // Fixed-attachment backgrounds anchor to the iframe viewport, which the
+  // paginator lays out as one huge multi-column strip and moves with
+  // transforms, so the image lands far from its element and Blink smears the
+  // text painted over it (#5711). Inside a transformed subtree the spec
+  // demands scroll behavior anyway, so rewrite fixed to scroll. url() values
+  // are masked first so a file named fixed.png is not rewritten.
+  css = css.replace(
+    /((?:^|[{;\s])background(?:-attachment)?\s*:)([^;{}]*)/gi,
+    (match, prop: string, value: string) => {
+      if (!/\bfixed\b/i.test(value)) return match;
+      const urls: string[] = [];
+      const masked = value.replace(/url\([^)]*\)/gi, (url) => {
+        urls.push(url);
+        return `READEST_URL_${urls.length - 1}_PLACEHOLDER`;
+      });
+      const rewritten = masked.replace(/\bfixed\b/gi, 'scroll');
+      return prop + rewritten.replace(/READEST_URL_(\d+)_PLACEHOLDER/g, (_, i) => urls[+i]!);
+    },
+  );
+
+  // Books authored for Duokan fake full-bleed bands with negative horizontal
+  // margins sized to Duokan's fixed 2em page padding. Columns are not clipped,
+  // so any overhang past the column box paints onto the adjacent page (#5711).
+  // Duokan's layout does not exist here, so drop the trick: zero the
+  // horizontal margins on rules that also paint a background (hanging indents
+  // keep their layout). The band stops at the column edge instead of
+  // full-bleeding, the same rendering the issue reporter picked as their
+  // custom-CSS workaround.
+  if (!vertical) {
+    const hasNegativeHorizontalMargin = (block: string): boolean => {
+      if (/(?:^|[^a-z-])margin-(?:left|right)\s*:\s*-/i.test(block)) return true;
+      const shorthand = /(?:^|[^a-z-])margin\s*:\s*([^;!}]+)/i.exec(block);
+      // calc()/var() shorthands are too ambiguous to split on whitespace
+      if (!shorthand || shorthand[1]!.includes('(')) return false;
+      const parts = shorthand[1]!.trim().split(/\s+/);
+      if (parts.length < 1 || parts.length > 4) return false;
+      const [top, right = top!, , left = right] = parts;
+      return right!.startsWith('-') || left.startsWith('-');
+    };
+    css = css.replace(ruleRegex, (match, selector, block: string) => {
+      const bgMatch = /background(?:-color|-image)?\s*:\s*([^;!}]+)/i.exec(block);
+      if (!bgMatch || /^(?:none|transparent)\s*$/i.test(bgMatch[1]!.trim())) return match;
+      if (!hasNegativeHorizontalMargin(block)) return match;
+      return (
+        selector + block.replace(/}$/, ' margin-left: 0 !important; margin-right: 0 !important; }')
+      );
+    });
+  }
+
   // unset font-family for body when set to serif or sans-serif
   css = css.replace(ruleRegex, (_, selector, block) => {
     if (/\bbody\b/i.test(selector)) {

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1102,48 +1102,70 @@ export const transformStylesheet = (
   // paginator lays out as one huge multi-column strip and moves with
   // transforms, so the image lands far from its element and Blink smears the
   // text painted over it (#5711). Inside a transformed subtree the spec
-  // demands scroll behavior anyway, so rewrite fixed to scroll. url() values
-  // are masked first so a file named fixed.png is not rewritten.
+  // demands scroll behavior anyway, so rewrite fixed to scroll. Function
+  // tokens (url(), var(), gradients) are masked first so a file named
+  // fixed.png or a custom property like var(--fixed) is not rewritten.
   css = css.replace(
     /((?:^|[{;\s])background(?:-attachment)?\s*:)([^;{}]*)/gi,
     (match, prop: string, value: string) => {
       if (!/\bfixed\b/i.test(value)) return match;
-      const urls: string[] = [];
-      const masked = value.replace(/url\([^)]*\)/gi, (url) => {
-        urls.push(url);
-        return `READEST_URL_${urls.length - 1}_PLACEHOLDER`;
+      const fns: string[] = [];
+      const masked = value.replace(/[\w-]*\([^)]*\)/g, (fn) => {
+        fns.push(fn);
+        return `READEST_FN_${fns.length - 1}_PLACEHOLDER`;
       });
       const rewritten = masked.replace(/\bfixed\b/gi, 'scroll');
-      return prop + rewritten.replace(/READEST_URL_(\d+)_PLACEHOLDER/g, (_, i) => urls[+i]!);
+      return prop + rewritten.replace(/READEST_FN_(\d+)_PLACEHOLDER/g, (_, i) => fns[+i]!);
     },
   );
 
   // Books authored for Duokan fake full-bleed bands with negative horizontal
   // margins sized to Duokan's fixed 2em page padding. Columns are not clipped,
   // so any overhang past the column box paints onto the adjacent page (#5711).
-  // Duokan's layout does not exist here, so drop the trick: zero the
-  // horizontal margins on rules that also paint a background (hanging indents
-  // keep their layout). The band stops at the column edge instead of
-  // full-bleeding, the same rendering the issue reporter picked as their
-  // custom-CSS workaround.
+  // Duokan's layout does not exist here, so drop the trick: zero each
+  // horizontal margin whose resolved value is negative on rules that also
+  // paint a background (hanging indents keep their layout). The band stops at
+  // the column edge instead of full-bleeding, the same rendering the issue
+  // reporter picked as their custom-CSS workaround.
   if (!vertical) {
-    const hasNegativeHorizontalMargin = (block: string): boolean => {
-      if (/(?:^|[^a-z-])margin-(?:left|right)\s*:\s*-/i.test(block)) return true;
-      const shorthand = /(?:^|[^a-z-])margin\s*:\s*([^;!}]+)/i.exec(block);
-      // calc()/var() shorthands are too ambiguous to split on whitespace
-      if (!shorthand || shorthand[1]!.includes('(')) return false;
-      const parts = shorthand[1]!.trim().split(/\s+/);
-      if (parts.length < 1 || parts.length > 4) return false;
-      const [top, right = top!, , left = right] = parts;
-      return right!.startsWith('-') || left.startsWith('-');
-    };
     css = css.replace(ruleRegex, (match, selector, block: string) => {
-      const bgMatch = /background(?:-color|-image)?\s*:\s*([^;!}]+)/i.exec(block);
-      if (!bgMatch || /^(?:none|transparent)\s*$/i.test(bgMatch[1]!.trim())) return match;
-      if (!hasNegativeHorizontalMargin(block)) return match;
-      return (
-        selector + block.replace(/}$/, ' margin-left: 0 !important; margin-right: 0 !important; }')
+      const bgValues = [
+        ...block.matchAll(/(?:^|[^-a-z])background(?:-color|-image)?\s*:\s*([^;!}]+)/gi),
+      ].map((m) => m[1]!.trim());
+      const paints = bgValues.some(
+        (v) =>
+          !/^(?:none|transparent)$/i.test(v) &&
+          !/^(?:rgba|hsla)\([^)]*[,\s]0(?:\.0+)?\s*\)$/i.test(v),
       );
+      if (!paints) return match;
+      // Resolve each side's final value in declaration order; the shorthand
+      // sets both sides. !important precedence between declarations of the
+      // same block is ignored: getting it wrong can only leave an authored
+      // negative margin in place, never break a valid layout.
+      let left = '';
+      let right = '';
+      for (const decl of block.matchAll(/(?:^|[^-a-z])margin(-left|-right)?\s*:\s*([^;!}]+)/gi)) {
+        const side = decl[1];
+        const value = decl[2]!.trim();
+        if (side === '-left') {
+          left = value;
+        } else if (side === '-right') {
+          right = value;
+        } else {
+          // calc()/var() shorthands are too ambiguous to split on whitespace
+          if (value.includes('(')) continue;
+          const parts = value.split(/\s+/);
+          if (parts.length < 1 || parts.length > 4) continue;
+          const [top, r = top!, , l = r] = parts;
+          right = r!;
+          left = l;
+        }
+      }
+      const overrides =
+        (left.startsWith('-') ? ' margin-left: 0 !important;' : '') +
+        (right.startsWith('-') ? ' margin-right: 0 !important;' : '');
+      if (!overrides) return match;
+      return selector + block.replace(/}$/, `${overrides} }`);
     });
   }
 

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1102,9 +1102,17 @@ export const transformStylesheet = (
   // paginator lays out as one huge multi-column strip and moves with
   // transforms, so the image lands far from its element and Blink smears the
   // text painted over it (#5711). Inside a transformed subtree the spec
-  // demands scroll behavior anyway, so rewrite fixed to scroll. Function
-  // tokens (url(), var(), gradients) are masked first so a file named
-  // fixed.png or a custom property like var(--fixed) is not rewritten.
+  // demands scroll behavior anyway, so rewrite fixed to scroll. url() tokens
+  // are masked across the sheet before the declaration split: an unquoted
+  // data URI may contain semicolons that would end the declaration match
+  // early, and a quoted url may contain closing parens or the word fixed.
+  // Remaining function tokens (var(), gradients) are masked per value so a
+  // custom property like var(--fixed) is not rewritten either.
+  const urlTokens: string[] = [];
+  css = css.replace(/url\(\s*(?:"[^"]*"|'[^']*'|[^)]*)\s*\)/gi, (url) => {
+    urlTokens.push(url);
+    return `READEST_URL_${urlTokens.length - 1}_PLACEHOLDER`;
+  });
   css = css.replace(
     /((?:^|[{;\s])background(?:-attachment)?\s*:)([^;{}]*)/gi,
     (match, prop: string, value: string) => {
@@ -1118,6 +1126,7 @@ export const transformStylesheet = (
       return prop + rewritten.replace(/READEST_FN_(\d+)_PLACEHOLDER/g, (_, i) => fns[+i]!);
     },
   );
+  css = css.replace(/READEST_URL_(\d+)_PLACEHOLDER/g, (_, i) => urlTokens[+i]!);
 
   // Books authored for Duokan fake full-bleed bands with negative horizontal
   // margins sized to Duokan's fixed 2em page padding. Columns are not clipped,


### PR DESCRIPTION
Fixes #5711

Books authored for Duokan use two CSS patterns that break in the paginated reader:

1. **`background-attachment: fixed`** on decorative title images. The paginator lays sections out as one wide multi-column strip inside an iframe moved with transforms, so a fixed background anchors to that viewport instead of its element: the image lands far from the title and Blink smears the text painted over it into a garbled band. `transformStylesheet` now rewrites `fixed` to `scroll` (the behavior the spec mandates inside a transformed subtree), covering the longhand, the `background:` shorthand, and multi-layer lists; `url()` values are masked first so a file named `fixed.png` survives.

2. **Negative horizontal margins + background** as a full-bleed trick (`margin: -2em -2em 1.5em -2em`, sized to Duokan's fixed 2em page padding). CSS columns are not clipped, so the overhang paints onto the adjacent page. Duokan's layout does not exist here, so the trick is simply dropped: rules that paint a background and have a negative horizontal margin get `margin-left/right: 0 !important` appended. The band stops at the column edge instead of full-bleeding, which is the same rendering the issue reporter chose as their custom-CSS workaround. Rules without a painted background are untouched so hanging indents keep their layout, `margin: -1em auto` centering is preserved, and `calc()`/`var()` shorthands are skipped.

Verified in Chrome with the reproduction files from the issue:

| | Before | After |
| --- | --- | --- |
| Fixed-attachment logo | garbled band, logo at viewport origin | crisp title, logo at the element's top left |
| Negative-margin header | blue band overlaps the adjacent page's text | band stops at the column edge, neighbor clear |

18 new unit tests in `src/__tests__/utils/style.test.ts`; full suite (9156 tests) and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page layout rendering by preventing fixed background attachments from causing display issues.
  * Corrected negative horizontal margins for elements with visible backgrounds in non-vertical layouts.
  * Preserved URLs, vertical margins, transparent backgrounds, and other supported CSS behavior during adjustments.

* **Tests**
  * Added coverage for background attachment rewriting and margin handling across shorthand, layered, inline, and priority-based styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->