### PR TITLE
fix(annotator): drop the selection when the instant dictionary opens, closes #5585

### DIFF
--- a/apps/readest-app/e2e/pages/ReaderPage.ts
+++ b/apps/readest-app/e2e/pages/ReaderPage.ts
@@ -389,6 +389,62 @@ export class ReaderPage extends BasePage {
     await this.annotationPopup.waitFor({ state: 'visible' });
   }
 
+  /**
+   * Select a single word of book text.
+   *
+   * The instant quick action only fires for a single lookup term, and it fires
+   * off the selection itself — so unlike {@link selectText} this waits for no
+   * popup, leaving the spec to say which one it expects.
+   */
+  async selectWord(): Promise<void> {
+    await this.openTocChapter(3);
+    const frame = await this.visibleSectionFrame();
+
+    await frame.locator('body').evaluate(() => {
+      const paragraphs = Array.from(document.querySelectorAll('p'));
+      const target = paragraphs.find((p) => (p.textContent ?? '').trim().length > 60);
+      if (!target) {
+        throw new Error('no selectable paragraph in the visible section');
+      }
+      const walker = document.createTreeWalker(target, NodeFilter.SHOW_TEXT);
+      let textNode = walker.nextNode();
+      let word: { node: Node; start: number; end: number } | null = null;
+      while (textNode && !word) {
+        const text = textNode.textContent ?? '';
+        const match = /[A-Za-z]{4,}/.exec(text);
+        if (match) {
+          word = { node: textNode, start: match.index, end: match.index + match[0].length };
+        }
+        textNode = walker.nextNode();
+      }
+      if (!word) {
+        throw new Error('no single word found in the target paragraph');
+      }
+      const range = document.createRange();
+      range.setStart(word.node, word.start);
+      range.setEnd(word.node, word.end);
+      const selection = document.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+  }
+
+  /** The text currently selected inside the on-screen book section. */
+  async selectedSectionText(): Promise<string> {
+    const frame = await this.visibleSectionFrame();
+    return frame.locator('body').evaluate(() => document.getSelection()?.toString() ?? '');
+  }
+
+  /**
+   * Turn on an instant quick action (`Instant Dictionary`, `Instant Highlight`,
+   * …) from the header bar's quick-action dropdown.
+   */
+  async setQuickAction(action: string): Promise<void> {
+    await this.revealHeader();
+    await this.headerBar.getByRole('button', { name: 'Enable Quick Action on Selection' }).click();
+    await this.page.getByRole('menuitem', { name: `Instant ${action}` }).click();
+  }
+
   /** A tool button inside the annotation popup, by its accessible name. */
   popupTool(name: string | RegExp): Locator {
     return this.annotationPopup.getByRole('button', { name });

--- a/apps/readest-app/e2e/tests/annotation.spec.ts
+++ b/apps/readest-app/e2e/tests/annotation.spec.ts
@@ -75,6 +75,30 @@ test.describe('Annotation', () => {
     await expect(reader.popupTool('Highlight')).toBeVisible();
   });
 
+  // The instant dictionary is the other side of the #5213 boundary: the word was
+  // tapped to be looked up, not selected, so the lookup owns the gesture end to
+  // end — nothing is left to highlight or copy afterwards.
+  test('the instant dictionary drops the selection and dismisses clean (#5585)', async ({
+    openBook,
+  }) => {
+    const reader = await openBook();
+
+    await reader.setQuickAction('Dictionary');
+    await reader.selectWord();
+
+    await expect(reader.dictionaryPopup).toBeVisible();
+    await expect(reader.annotationPopup).toBeHidden();
+    // iOS paints its native selection handles and blue highlight above web
+    // content, i.e. on top of the popup, so the lookup deselects as it opens.
+    expect(await reader.selectedSectionText()).toBe('');
+
+    await reader.page.keyboard.press('Escape');
+
+    await expect(reader.dictionaryPopup).toBeHidden();
+    // No live selection left, so the dismiss has no toolbar to return to.
+    await expect(reader.annotationPopup).toBeHidden();
+  });
+
   test('changes the highlight color', async ({ openBook }) => {
     const reader = await openBook();
 

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -945,6 +945,15 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
           // toolbar so highlighting and copying stay reachable (#5213).
           if (selection && isSingleLookupTerm(selection.text)) {
             handleDictionary();
+            // The instant lookup consumes the gesture: the word was tapped to be
+            // looked up, not selected. Drop the selection so iOS's native
+            // handles and blue highlight — painted above web content — don't sit
+            // on top of the popup, and so dismissing it has no live selection to
+            // return a toolbar to (#5585, the other side of #5213's boundary).
+            // Clear the flag before deselecting: the selectionchange this fires
+            // would otherwise dismiss the popup we just opened.
+            isTextSelected.current = false;
+            view?.deselect();
           } else {
             handleShowAnnotPopup();
           }


### PR DESCRIPTION
Closes #5585.

## The bug

With **Instant Dictionary** on, tapping a word opened the lookup popup, and dismissing that popup opened the text selection toolbar on top of the reader.

#5213 taught every lookup popup to return to the selection toolbar while a selection is still live (`handleDismissPopupShowToolbar`), and the in-app dictionary never deselects. On phones the lookup renders as `DictionarySheet` (`innerWidth < 640`), so a backdrop tap goes through `onDismiss` and raises the toolbar, which is exactly the report's "tap anywhere on the screen".

The instant quick action is the other side of that boundary: the word was tapped to be *looked up*, not selected, so the lookup owns the gesture end to end and there is nothing left to highlight or copy afterwards. Per the issue discussion this is behaviour, not a new setting.

## The fix

`handleQuickAction`'s `case 'dictionary'` now clears `isTextSelected` and deselects as the popup opens.

The order is load bearing: `view.deselect()` fires a `selectionchange` whose empty-selection branch in `useTextSelector` calls `handleDismissPopup()` while the flag is still set, which would close the popup we just opened.

The same change fixes a second, iOS-only report: the selection grabbers and the blue selection highlight painted **on top of** the dictionary window, because WKWebView draws selection UI in a native overlay above web content. With no selection there is nothing to paint.

**Scope is the instant quick action only.** The selection toolbar route into the dictionary is untouched: keeping its selection alive so the word can still be highlighted or copied afterwards is exactly what #5213 asked for. Instant Translate and Proofread are unchanged (not reported).

## Testing

New e2e case in `annotation.spec.ts`, "the instant dictionary drops the selection and dismisses clean (#5585)". It fails on the current code with `Expected: "" / Received: "Alice"` and passes with the fix. New `ReaderPage` helpers: `selectWord()`, `selectedSectionText()`, `setQuickAction()`.

The full `annotation.spec.ts` suite passes locally, including all three #5213 return-to-toolbar cases.

> [!NOTE]
> `pnpm test` currently reports 8 failures on `main` itself, all PDF cases (`pdf-canvas-memory-cap`, `pdf-spread-seam`, `foliate-pdf-range-concurrency`) failing on `pdf.getViewerPreferences is not a function` from foliate-js `2691386`. They are unrelated to this PR and predate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an instant Dictionary quick action for selected words in the reader.

* **Bug Fixes**
  * Word selections are now cleared when opening Dictionary lookup.
  * Prevented selection highlights and handles from remaining over the lookup popup.
  * Prevented the annotation toolbar from reappearing after dismissing Dictionary lookup.

* **Tests**
  * Added end-to-end coverage for Dictionary lookup selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->