### PR TITLE
fix(eink): make e-ink highlights and chips visible, closes #5667

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/utils/annotatorUtil.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/utils/annotatorUtil.test.ts
@@ -4,6 +4,7 @@ import {
   filterBooknotes,
   filterExportGroups,
   findAnnotationAtCfi,
+  getAnnotationOverlayColor,
   mergeRestyledAnnotation,
   summarizeAnnotations,
 } from '@/app/reader/utils/annotatorUtil';
@@ -215,5 +216,64 @@ describe('summarizeAnnotations', () => {
 
   it('returns zeroes for an empty list', () => {
     expect(summarizeAnnotations([])).toEqual({ highlights: 0, notes: 0 });
+  });
+});
+
+/**
+ * B&W e-ink composites highlight overlays with `mix-blend-mode: difference` at
+ * full opacity (useTheme.ts), so the fill is an inversion mask, not a paint
+ * color. Difference is `|backdrop - source|`, which makes black its identity
+ * element: a black mask leaves the page pixel-for-pixel unchanged and the
+ * highlight simply does not exist. Masking with the theme background therefore
+ * erased every highlight in dark mode, and because overlays keep the fill they
+ * were drawn with, switching back to light stayed broken until reload (#5667).
+ *
+ * Underline and squiggly are stroked without a blend mode, so they still take
+ * the theme ink.
+ */
+describe('getAnnotationOverlayColor', () => {
+  const LIGHT_EINK = { isBwEink: true, isDarkMode: false };
+  const DARK_EINK = { isBwEink: true, isDarkMode: true };
+  const PAGE = [255, 255, 255];
+  const INK = [0, 0, 0];
+
+  const toRgb = (hex: string) => [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16));
+  // How the compositor resolves `mix-blend-mode: difference` per channel.
+  const difference = (backdrop: number[], source: number[]) =>
+    backdrop.map((channel, i) => Math.abs(channel - source[i]!));
+
+  it('masks the highlight with one theme-independent color', () => {
+    expect(getAnnotationOverlayColor('highlight', '#fef08a', DARK_EINK)).toBe(
+      getAnnotationOverlayColor('highlight', '#fef08a', LIGHT_EINK),
+    );
+  });
+
+  it('swaps page and ink on a light e-ink page', () => {
+    const mask = toRgb(getAnnotationOverlayColor('highlight', '#fef08a', LIGHT_EINK));
+
+    expect(difference(PAGE, mask)).toEqual(INK);
+    expect(difference(INK, mask)).toEqual(PAGE);
+  });
+
+  it('swaps page and ink on a dark e-ink page', () => {
+    const mask = toRgb(getAnnotationOverlayColor('highlight', '#fef08a', DARK_EINK));
+
+    // The dark page paints ink where light paints page, so the same mask has
+    // to invert both. A mask of `#000000` returned the backdrop untouched.
+    expect(difference(INK, mask)).toEqual(PAGE);
+    expect(difference(PAGE, mask)).toEqual(INK);
+  });
+
+  it('strokes the unblended styles in the theme ink', () => {
+    expect(getAnnotationOverlayColor('underline', '#fef08a', LIGHT_EINK)).toBe('#000000');
+    expect(getAnnotationOverlayColor('squiggly', '#fef08a', DARK_EINK)).toBe('#ffffff');
+  });
+
+  it('passes the annotation color through off B&W e-ink', () => {
+    for (const style of ['highlight', 'underline', 'squiggly'] as const) {
+      expect(
+        getAnnotationOverlayColor(style, '#fef08a', { isBwEink: false, isDarkMode: true }),
+      ).toBe('#fef08a');
+    }
   });
 });

--- a/apps/readest-app/src/__tests__/components/annotator/HighlightOptionsSwatch.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/HighlightOptionsSwatch.test.tsx
@@ -23,13 +23,19 @@ let mockHighlightStyles: Record<HighlightStyle, HighlightColor> = {
 // Settings seed `customHighlightColors` with the default palette, so the named
 // colors always resolve to a hex through it (see DEFAULT_READSETTINGS).
 let mockCustomColors: Record<string, string> = { ...HIGHLIGHT_COLOR_HEX };
+let mockViewSettings = { isEink: false, isColorEink: false };
+let mockIsDarkMode = false;
 
 vi.mock('@/context/EnvContext', () => ({
   useEnv: () => ({ envConfig: {}, appService: null }),
 }));
 
 vi.mock('@/store/themeStore', () => ({
-  useThemeStore: () => ({ isDarkMode: false }),
+  useThemeStore: () => ({
+    get isDarkMode() {
+      return mockIsDarkMode;
+    },
+  }),
 }));
 
 vi.mock('@/hooks/useTranslation', () => ({
@@ -51,7 +57,9 @@ vi.mock('@/store/settingsStore', () => ({
         userHighlightColors: [],
         defaultHighlightLabels: {},
       },
-      globalViewSettings: { isEink: false, isColorEink: false },
+      get globalViewSettings() {
+        return mockViewSettings;
+      },
     },
   }),
 }));
@@ -97,6 +105,8 @@ const getStyleGlyph = (container: HTMLElement, style: HighlightStyle) => {
 afterEach(() => {
   mockHighlightStyles = { highlight: 'yellow', underline: 'red', squiggly: 'blue' };
   mockCustomColors = { ...HIGHLIGHT_COLOR_HEX };
+  mockViewSettings = { isEink: false, isColorEink: false };
+  mockIsDarkMode = false;
   cleanup();
 });
 
@@ -160,5 +170,65 @@ describe('underline and squiggly rule color', () => {
 
     expect(getStyleGlyph(container, 'underline').style.color).toBe('');
     expect(getStyleGlyph(container, 'underline').className).toContain('text-base-content');
+  });
+});
+
+/**
+ * `[data-eink='true'] [class*='text-base-content']` in globals.css flattens the
+ * ink with `!important`, which outranks an inline `color`. The marker glyph and
+ * the selected-color check both sit on a base-content chip and set their own
+ * contrasting ink inline, so carrying that class painted them base-content on
+ * base-content: a solid black square with an invisible "A", and a color swatch
+ * with no visible check (#5667). Their color is always explicit, so they must
+ * not opt into the override at all.
+ */
+describe('e-ink chip legibility', () => {
+  const getCheck = (container: HTMLElement) => {
+    const check = container.querySelector<SVGElement>('button[aria-label^="Select"] svg');
+    if (!check) throw new Error('selected color check not rendered');
+    return check;
+  };
+
+  it('keeps the marker glyph off the e-ink ink override', () => {
+    mockViewSettings = { isEink: true, isColorEink: false };
+    const { container } = renderOptions('yellow');
+    const glyph = getStyleGlyph(container, 'highlight');
+
+    expect(glyph.style.backgroundColor).toBe('rgb(0, 0, 0)');
+    expect(glyph.style.color).toBe('rgb(255, 255, 255)');
+    expect(glyph.className).not.toContain('text-base-content');
+  });
+
+  it('inverts the marker glyph with the theme, so a dark page reads too', () => {
+    mockViewSettings = { isEink: true, isColorEink: false };
+    mockIsDarkMode = true;
+    const { container } = renderOptions('yellow');
+    const glyph = getStyleGlyph(container, 'highlight');
+
+    expect(glyph.style.backgroundColor).toBe('rgb(255, 255, 255)');
+    expect(glyph.style.color).toBe('rgb(0, 0, 0)');
+  });
+
+  it('keeps the selected-color check off the e-ink ink override', () => {
+    mockViewSettings = { isEink: true, isColorEink: false };
+    const { container } = renderOptions('yellow');
+
+    expect(getCheck(container).style.color).toBe('rgb(255, 255, 255)');
+    expect(getCheck(container).classList.contains('text-base-content')).toBe(false);
+  });
+
+  it('still flattens the rule glyphs to the theme ink, which needs the override', () => {
+    mockViewSettings = { isEink: true, isColorEink: false };
+    const { container } = renderOptions('yellow');
+
+    expect(getStyleGlyph(container, 'underline').className).toContain('text-base-content');
+  });
+
+  it('leaves color e-ink on the real palette, where the check reads as content ink', () => {
+    mockViewSettings = { isEink: true, isColorEink: true };
+    const { container } = renderOptions('yellow');
+
+    expect(getStyleGlyph(container, 'highlight').style.backgroundColor).toBe('rgb(250, 204, 21)');
+    expect(getCheck(container).classList.contains('text-base-content')).toBe(true);
   });
 });

--- a/apps/readest-app/src/__tests__/components/eink-base-content-bg.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/eink-base-content-bg.browser.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * globals.css flattens tinted surfaces on e-ink with
+ * `[data-eink='true'] [class*='bg-base-content']`, so a translucent
+ * `bg-base-content/10` chip becomes a solid, full-contrast block instead of a
+ * wash the panel can't render.
+ *
+ * `[class*=…]` matches the whole class attribute as a string, so it also fires
+ * on variant-prefixed utilities: `hover:bg-base-content/10` and even
+ * `not-eink:hover:bg-base-content/10` painted their element solid black at
+ * rest, on every screen. That swallowed the footer bar's page indicator and the
+ * progress panel's page bubble whole -- black box, black text (#5667) -- and is
+ * the same trap that was papered over per-element with `eink-inverted` (#4454).
+ *
+ * Assert resolved colors, not the class string: the whole defect is a selector
+ * matching class text it was never meant to match.
+ */
+
+import { describe, it, expect, afterEach, beforeAll } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { page } from 'vitest/browser';
+
+await import('@/styles/globals.css');
+
+beforeAll(async () => {
+  await page.viewport(800, 600);
+});
+afterEach(() => {
+  cleanup();
+  document.documentElement.removeAttribute('data-eink');
+  document.documentElement.removeAttribute('data-theme');
+});
+
+const TRANSPARENT = 'rgba(0, 0, 0, 0)';
+
+const measure = (eink: boolean) => {
+  document.documentElement.setAttribute('data-theme', 'default-light');
+  if (eink) document.documentElement.setAttribute('data-eink', 'true');
+  const { container } = render(
+    <>
+      <div data-testid='rest' className='hover:bg-base-content/10 bg-transparent' />
+      <div data-testid='not-eink-rest' className='not-eink:hover:bg-base-content/10' />
+      <div data-testid='flattened' className='bg-base-content/10' />
+      <div data-testid='ink' className='bg-base-content' />
+    </>,
+  );
+  const bg = (id: string) =>
+    getComputedStyle(container.querySelector<HTMLElement>(`[data-testid="${id}"]`)!)
+      .backgroundColor;
+  return {
+    rest: bg('rest'),
+    notEinkRest: bg('not-eink-rest'),
+    flattened: bg('flattened'),
+    ink: bg('ink'),
+  };
+};
+
+describe('e-ink bg-base-content flattening', () => {
+  it('leaves a hover-only tint transparent at rest', () => {
+    const { rest, notEinkRest } = measure(true);
+
+    expect(rest).toBe(TRANSPARENT);
+    expect(notEinkRest).toBe(TRANSPARENT);
+  });
+
+  it('still flattens a tint that is actually applied', () => {
+    const { flattened, ink } = measure(true);
+
+    expect(flattened).toBe(ink);
+  });
+
+  it('does not touch either off e-ink', () => {
+    const { rest, notEinkRest, flattened, ink } = measure(false);
+
+    expect(rest).toBe(TRANSPARENT);
+    expect(notEinkRest).toBe(TRANSPARENT);
+    expect(flattened).not.toBe(ink);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -67,6 +67,7 @@ import { transformContent } from '@/services/transformService';
 import {
   buildTTSSentenceHighlight,
   decideAnnotationDraw,
+  getAnnotationOverlayColor,
   getHighlightColorHex,
   mergeRestyledAnnotation,
   removeBookNoteOverlays,
@@ -507,8 +508,6 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     const { style, color } = annotation as BookNote;
     const value = (annotation as BookNote & { value?: string }).value;
     const hexColor = getHighlightColorHex(settings, color);
-    const einkBgColor = isDarkMode ? '#000000' : '#ffffff';
-    const einkFgColor = isDarkMode ? '#ffffff' : '#000000';
     // Choose what to draw from the overlay's `value` (cfi vs NOTE_PREFIX+cfi),
     // not from `annotation.note`: a unified record (style + note) is added as
     // two overlays and must draw a highlight for the cfi overlay AND a bubble
@@ -522,7 +521,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
       draw(Overlayer.bubble, { writingMode });
     } else if (kind === 'highlight') {
       draw(Overlayer.highlight, {
-        color: isBwEink ? einkBgColor : hexColor,
+        color: getAnnotationOverlayColor('highlight', hexColor, { isBwEink, isDarkMode }),
         vertical: viewSettings.vertical,
       });
     } else if (kind === 'underline' || kind === 'squiggly') {
@@ -540,7 +539,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
         : (lineHeightValue - fontSizeValue) / 2 - strokeWidth + horizontalCompensation;
       draw(Overlayer[kind], {
         writingMode,
-        color: isBwEink ? einkFgColor : hexColor,
+        color: getAnnotationOverlayColor(kind, hexColor, { isBwEink, isDarkMode }),
         padding,
       });
     }

--- a/apps/readest-app/src/app/reader/components/annotator/HighlightOptions.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/HighlightOptions.tsx
@@ -248,7 +248,14 @@ const HighlightOptions: React.FC<HighlightOptionsProps> = ({
                 ...(style === 'squiggly' && { textDecorationStyle: 'wavy' }),
               }}
               className={clsx(
-                'text-base-content decoration-inherit rounded-sm p-0 leading-none',
+                'decoration-inherit rounded-sm p-0 leading-none',
+                // The marker glyph always sets its own ink above, so it must
+                // stay off `text-base-content`: the e-ink rule for that class
+                // flattens the color with `!important`, which outranks the
+                // inline style and painted the "A" base-content on a
+                // base-content chip -- a solid black square (#5667). The rules
+                // carry no inline ink and do want the flattening.
+                style !== 'highlight' && 'text-base-content',
                 style === 'highlight' ? 'flex items-center justify-center' : 'text-center',
                 style === 'underline' || style === 'squiggly' ? 'sm:mt-[-2px]' : '',
               )}
@@ -337,7 +344,10 @@ const HighlightOptions: React.FC<HighlightOptionsProps> = ({
                   {selectedColor === color && (
                     <FaCheck
                       size={size10}
-                      className='text-base-content'
+                      // Same reason as the marker glyph: on B&W e-ink the dot
+                      // is a base-content disc, so the check sets its own
+                      // contrasting ink and must not be flattened back.
+                      className={clsx(!isBwEink && 'text-base-content')}
                       style={isBwEink ? { color: einkBgColor } : undefined}
                     />
                   )}

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -31,6 +31,7 @@ import {
   ttsSessionManager,
   TTS_STOP_AT_CHAPTER_END,
 } from '@/services/tts/TTSSessionManager';
+import { getAnnotationOverlayColor } from '../utils/annotatorUtil';
 
 interface UseTTSControlProps {
   bookKey: string;
@@ -718,14 +719,13 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
 
   // TTS highlight options
   const getTTSHighlightOptions = useCallback(
-    (ttsHighlightOptions: TTSHighlightOptions, isEink: boolean) => {
-      const einkBgColor = isDarkMode ? '#000000' : '#ffffff';
-      const color = isEink ? einkBgColor : ttsHighlightOptions.color;
-      return {
-        ...ttsHighlightOptions,
-        color,
-      };
-    },
+    (ttsHighlightOptions: TTSHighlightOptions, isBwEink: boolean) => ({
+      ...ttsHighlightOptions,
+      color: getAnnotationOverlayColor(ttsHighlightOptions.style, ttsHighlightOptions.color, {
+        isBwEink,
+        isDarkMode,
+      }),
+    }),
     [isDarkMode],
   );
 
@@ -733,11 +733,19 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     const ttsHighlightOptions = viewSettings?.ttsHighlightOptions;
     if (ttsControllerRef.current && ttsHighlightOptions) {
       ttsControllerRef.current.updateHighlightOptions(
-        getTTSHighlightOptions(ttsHighlightOptions, viewSettings!.isEink),
+        getTTSHighlightOptions(
+          ttsHighlightOptions,
+          viewSettings!.isEink && !viewSettings!.isColorEink,
+        ),
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [viewSettings?.ttsHighlightOptions, viewSettings?.isEink, getTTSHighlightOptions]);
+  }, [
+    viewSettings?.ttsHighlightOptions,
+    viewSettings?.isEink,
+    viewSettings?.isColorEink,
+    getTTSHighlightOptions,
+  ]);
 
   useEffect(() => {
     if (ttsControllerRef.current && viewSettings?.ttsHighlightGranularity) {
@@ -906,7 +914,10 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
         await ttsController.init();
         await ttsController.initViewTTS(ttsFromIndex);
         ttsController.updateHighlightOptions(
-          getTTSHighlightOptions(viewSettings.ttsHighlightOptions, viewSettings.isEink),
+          getTTSHighlightOptions(
+            viewSettings.ttsHighlightOptions,
+            viewSettings.isEink && !viewSettings.isColorEink,
+          ),
         );
         ttsController.setHighlightGranularity(viewSettings.ttsHighlightGranularity ?? 'word');
         // A recording has no audio for arbitrary text: it only exists as the

--- a/apps/readest-app/src/app/reader/utils/annotatorUtil.ts
+++ b/apps/readest-app/src/app/reader/utils/annotatorUtil.ts
@@ -318,6 +318,34 @@ export function buildTTSSentenceHighlight(
 
 export type AnnotationDrawKind = 'bubble' | 'highlight' | 'underline' | 'squiggly' | 'none';
 
+/** Overlay styles the reader draws: the annotation styles plus the extra
+ *  strokes only the TTS highlight offers. */
+export type OverlayStyle = HighlightStyle | 'strikethrough' | 'outline';
+
+/**
+ * Color to draw an annotation or TTS overlay in.
+ *
+ * On B&W e-ink the highlight overlay is composited with `mix-blend-mode:
+ * difference` at full opacity (see `useTheme.ts`), so its color is an inversion
+ * mask rather than paint: difference is `|backdrop - source|`, so white swaps
+ * page and ink around each other while black is the identity and leaves the
+ * page untouched. Masking with the theme background therefore erased every
+ * highlight on a dark page, and since overlays keep the fill they were drawn
+ * with, going back to light stayed broken until reload (#5667). One mask
+ * inverts both themes, so it must not follow the theme at all.
+ *
+ * The remaining styles are stroked without a blend mode and take the theme ink.
+ */
+export function getAnnotationOverlayColor<T extends string | undefined>(
+  style: OverlayStyle,
+  hexColor: T,
+  { isBwEink, isDarkMode }: { isBwEink: boolean; isDarkMode: boolean },
+): T | string {
+  if (!isBwEink) return hexColor;
+  if (style === 'highlight') return '#ffffff';
+  return isDarkMode ? '#ffffff' : '#000000';
+}
+
 /**
  * Decide what an overlay should draw for an annotation. The bubble vs.
  * highlight choice keys off the overlay's `value` prefix — NOT `annotation.note`

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -544,7 +544,14 @@ input[type='range'].slider-input {
   color: theme('colors.base-content') !important;
 }
 
-[data-eink='true'] [class*='bg-base-content'] {
+/* E-ink cannot render a translucent wash, so a tinted base-content surface is
+   flattened to solid ink. `[class*=…]` matches the class attribute as plain
+   text, so skip elements whose only match is variant-prefixed: `hover:`,
+   `not-eink:hover:`, `group-hover:` and friends were painted solid at rest, on
+   every screen, which swallowed the footer bar's page indicator whole (#5667)
+   and forced `eink-inverted` workarounds elsewhere (#4454). A variant that
+   really does want ink on e-ink (`eink:bg-base-content`) emits its own rule. */
+[data-eink='true'] [class*='bg-base-content']:not([class*=':bg-base-content']) {
   background-color: theme('colors.base-content') !important;
 }
 


### PR DESCRIPTION
Closes #5667.

## The highlight overlay was masked with black on a dark page

On B&W e-ink the highlight overlay is composited with `mix-blend-mode: difference` at full opacity (`useTheme.ts`), so its color is an **inversion mask**, not paint. Difference is `|backdrop - source|`, which makes black the identity element.

`Annotator.tsx` filled it with the theme background, which is `#000000` in dark mode, so every highlight left the page pixel-for-pixel unchanged. And because overlays keep the fill they were drawn with, switching back to light mode stayed broken until reload, which is exactly what the reporter saw.

One white mask inverts page and ink in **both** themes, so the fill must not follow the theme at all. `getAnnotationOverlayColor` now owns that decision; the TTS read-along highlight took the same wrong color and goes through the same helper (it also ignored the configured style, so an underline-style TTS highlight was masked as if it were blended).

## The style chips painted their ink on top of itself

The marker glyph and the selected-color check sit on a base-content chip and set their own contrasting ink inline, but they also carried `text-base-content`, whose e-ink rule flattens the color with `!important` and therefore outranks an inline style. Both ended up base-content on base-content: a solid black square with an invisible "A", and a color dot with no visible check. Their color is always explicit, so they no longer opt into the override. The underline and squiggly glyphs carry no inline ink and still do.

## The page indicator was painted solid at rest

`[data-eink='true'] [class*='bg-base-content']` matches the class attribute as plain text, so it also fired on variant-prefixed utilities. `hover:bg-base-content/10` and even `not-eink:hover:bg-base-content/10` were painted solid on every screen, which swallowed the footer bar's page indicator and the progress panel's page bubble whole, and had already forced per-element `eink-inverted` workarounds (#4454). The rule now skips elements whose only match is variant-prefixed. `eink:bg-base-content` emits its own, higher-specificity rule and is unaffected.

## Testing

- `getAnnotationOverlayColor` unit tests run the actual difference-blend math and assert the mask swaps page and ink on both a light and a dark e-ink page, so a theme-dependent mask cannot come back.
- Swatch tests cover the marker glyph and check under B&W e-ink, dark e-ink, and color e-ink.
- A new browser test loads the real `globals.css` in Chromium and asserts the at-rest background of a hover-only tint, that an applied tint is still flattened, and that neither changes off e-ink.
- `pnpm test` 9194 passed, `pnpm lint` clean, `pnpm format:check` clean.
- Verified in Chrome on the book from the issue thread, in light and dark e-ink mode: highlights render as inverted blocks in both, the marker "A" and the color check read, and the page indicator shows "1 / 643".

## Not fixed here

`transientHighlight.ts` draws the footnote/link jump flash with a fixed `#808080` and has never been e-ink aware. Under a difference blend that washes page and ink to nearly the same gray. Separate defect, separate feature, filing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved annotation visibility on monochrome e-ink displays, including highlights, underlines, squiggles, markers, and selection indicators.
  * Corrected annotation colors for dark mode and light mode on B&W e-ink screens.
  * Improved text-to-speech highlighting to match annotation display settings.
  * Fixed e-ink background rendering so hover-only styles remain transparent until activated.
  * Preserved configured annotation colors on color e-ink displays and non-e-ink screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->