### PR TITLE
feat(library): show download progress overlay on book covers

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/recent-shelf-select-mode.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/recent-shelf-select-mode.test.tsx
@@ -72,6 +72,7 @@ const baseProps = {
   selectedBooks: new Set<string>(),
   toggleSelection: noop,
   handleSetSelectMode: noop,
+  transferProgress: {},
 };
 
 const tapSlide = (title: string) => {

--- a/apps/readest-app/src/__tests__/app/library/useBookTransferActions.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/useBookTransferActions.test.tsx
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
+import type { SetStateAction } from 'react';
 
 import type { Book } from '@/types/book';
 import type { EnvConfigType } from '@/services/environment';
 import type { AppService } from '@/types/system';
+import type { ProgressHandler } from '@/utils/transfer';
 
 /**
  * Issue #5062 — cloud sync providers are independently selectable, so a
@@ -69,13 +71,20 @@ const makeBook = (over: Partial<Book> = {}): Book => ({
   ...over,
 });
 
+type ProgressState = { [key: string]: number | null };
+
 const setup = (appService: AppService | null = null) => {
   const updateBook = vi.fn(async (_envConfig: EnvConfigType, _book: Book) => {});
-  const setBooksTransferProgress = vi.fn();
+  // Mimic React's functional state updates so tests can assert the actual
+  // progress transitions (indeterminate start, percentage updates, cleanup).
+  let progressState: ProgressState = {};
+  const setBooksTransferProgress = vi.fn((updater: SetStateAction<ProgressState>) => {
+    progressState = typeof updater === 'function' ? updater(progressState) : updater;
+  });
   const { result } = renderHook(() =>
     useBookTransferActions(envConfig, appService, updateBook, setBooksTransferProgress),
   );
-  return { result, updateBook };
+  return { result, updateBook, getProgress: () => progressState };
 };
 
 beforeEach(() => {
@@ -176,5 +185,47 @@ describe('useBookTransferActions download routing (issue #5062)', () => {
     expect(queueDownload).not.toHaveBeenCalled();
     expect(updateBook).toHaveBeenCalledWith(envConfig, book);
     expect(ok).toBe(true);
+  });
+
+  it('shows indeterminate progress while a file-backend download runs and clears it on completion', async () => {
+    routing.backends = ['gdrive'];
+    let release!: (ok: boolean) => void;
+    runFileBookDownload.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((res) => {
+          release = res;
+        }),
+    );
+
+    const { result, getProgress } = setup();
+    const book = makeBook({ uploadedAt: 12345 });
+    const promise = result.current.handleBookDownload(book, { queued: true });
+
+    // The native plugin cannot report a byte total up front, so the entry
+    // starts indeterminate (-1) until progress events arrive.
+    expect(getProgress()).toEqual({ [book.hash]: -1 });
+
+    release(true);
+    await promise;
+    expect(getProgress()).toEqual({});
+  });
+
+  it('reports percentage progress from a direct download and clears it on completion', async () => {
+    const downloadBook = vi.fn(
+      async (_book: Book, _redownload: boolean, _reuse: boolean, onProgress?: ProgressHandler) => {
+        onProgress?.({ progress: 50, total: 100, transferSpeed: 0 });
+      },
+    );
+
+    const { result, getProgress } = setup({ downloadBook } as unknown as AppService);
+    const book = makeBook({ uploadedAt: 12345 });
+    const promise = result.current.handleBookDownload(book, { queued: false });
+
+    // The direct-download progress handler emits synchronously; the throttled
+    // leading edge lands 50% before the transfer resolves.
+    expect(getProgress()).toEqual({ [book.hash]: 50 });
+
+    await promise;
+    expect(getProgress()).toEqual({});
   });
 });

--- a/apps/readest-app/src/__tests__/app/library/useBookTransferActions.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/useBookTransferActions.test.tsx
@@ -4,7 +4,6 @@ import { renderHook } from '@testing-library/react';
 import type { Book } from '@/types/book';
 import type { EnvConfigType } from '@/services/environment';
 import type { AppService } from '@/types/system';
-import type { ProgressPayload } from '@/utils/transfer';
 
 /**
  * Issue #5062 — cloud sync providers are independently selectable, so a
@@ -72,9 +71,9 @@ const makeBook = (over: Partial<Book> = {}): Book => ({
 
 const setup = (appService: AppService | null = null) => {
   const updateBook = vi.fn(async (_envConfig: EnvConfigType, _book: Book) => {});
-  const updateBookTransferProgress = vi.fn((_bookHash: string, _progress: ProgressPayload) => {});
+  const setBooksTransferProgress = vi.fn();
   const { result } = renderHook(() =>
-    useBookTransferActions(envConfig, appService, updateBook, updateBookTransferProgress),
+    useBookTransferActions(envConfig, appService, updateBook, setBooksTransferProgress),
   );
   return { result, updateBook };
 };
@@ -129,7 +128,7 @@ describe('useBookTransferActions download routing (issue #5062)', () => {
     const book = makeBook({ uploadedAt: 12345 });
     const ok = await result.current.handleBookDownload(book, { queued: true });
 
-    expect(runFileBookDownload).toHaveBeenCalledWith(envConfig, book);
+    expect(runFileBookDownload).toHaveBeenCalledWith(envConfig, book, expect.any(Function));
     expect(queueDownload).not.toHaveBeenCalled();
     expect(ok).toBe(true);
   });
@@ -143,7 +142,7 @@ describe('useBookTransferActions download routing (issue #5062)', () => {
     const book = makeBook({ uploadedAt: 12345 });
     const ok = await result.current.handleBookDownload(book, { queued: true });
 
-    expect(runFileBookDownload).toHaveBeenCalledWith(envConfig, book);
+    expect(runFileBookDownload).toHaveBeenCalledWith(envConfig, book, expect.any(Function));
     expect(queueDownload).toHaveBeenCalledWith(book, 1);
     expect(ok).toBe(true);
   });
@@ -158,7 +157,7 @@ describe('useBookTransferActions download routing (issue #5062)', () => {
     const book = makeBook({ uploadedAt: 12345 });
     const ok = await result.current.handleBookDownload(book, { queued: false });
 
-    expect(runFileBookDownload).toHaveBeenCalledWith(envConfig, book);
+    expect(runFileBookDownload).toHaveBeenCalledWith(envConfig, book, expect.any(Function));
     expect(downloadBook).toHaveBeenCalledWith(book, false, false, expect.any(Function));
     expect(queueDownload).not.toHaveBeenCalled();
     expect(updateBook).toHaveBeenCalledWith(envConfig, book);
@@ -173,7 +172,7 @@ describe('useBookTransferActions download routing (issue #5062)', () => {
     const book = makeBook({ uploadedAt: null });
     const ok = await result.current.handleBookDownload(book, { queued: true });
 
-    expect(runFileBookDownload).toHaveBeenCalledWith(envConfig, book);
+    expect(runFileBookDownload).toHaveBeenCalledWith(envConfig, book, expect.any(Function));
     expect(queueDownload).not.toHaveBeenCalled();
     expect(updateBook).toHaveBeenCalledWith(envConfig, book);
     expect(ok).toBe(true);

--- a/apps/readest-app/src/__tests__/app/library/useBookTransferActions.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/useBookTransferActions.test.tsx
@@ -5,7 +5,7 @@ import type { SetStateAction } from 'react';
 import type { Book } from '@/types/book';
 import type { EnvConfigType } from '@/services/environment';
 import type { AppService } from '@/types/system';
-import type { ProgressHandler } from '@/utils/transfer';
+import { INDETERMINATE_PROGRESS, type ProgressHandler } from '@/utils/transfer';
 
 /**
  * Issue #5062 — cloud sync providers are independently selectable, so a
@@ -23,7 +23,15 @@ const routing = vi.hoisted(() => ({
 }));
 
 const runFileBookUpload = vi.hoisted(() => vi.fn(async () => true));
-const runFileBookDownload = vi.hoisted(() => vi.fn(async () => true));
+const runFileBookDownload = vi.hoisted(() =>
+  vi.fn(
+    async (
+      _envConfig: EnvConfigType,
+      _book: Book,
+      _onProgress?: ProgressHandler,
+    ): Promise<boolean> => true,
+  ),
+);
 const queueUpload = vi.hoisted(() => vi.fn(() => 'transfer-1'));
 const queueDownload = vi.hoisted(() => vi.fn(() => 'transfer-1'));
 
@@ -71,7 +79,7 @@ const makeBook = (over: Partial<Book> = {}): Book => ({
   ...over,
 });
 
-type ProgressState = { [key: string]: number | null };
+type ProgressState = { [key: string]: number };
 
 const setup = (appService: AppService | null = null) => {
   const updateBook = vi.fn(async (_envConfig: EnvConfigType, _book: Book) => {});
@@ -202,8 +210,8 @@ describe('useBookTransferActions download routing (issue #5062)', () => {
     const promise = result.current.handleBookDownload(book, { queued: true });
 
     // The native plugin cannot report a byte total up front, so the entry
-    // starts indeterminate (-1) until progress events arrive.
-    expect(getProgress()).toEqual({ [book.hash]: -1 });
+    // starts indeterminate until progress events arrive.
+    expect(getProgress()).toEqual({ [book.hash]: INDETERMINATE_PROGRESS });
 
     release(true);
     await promise;
@@ -211,21 +219,68 @@ describe('useBookTransferActions download routing (issue #5062)', () => {
   });
 
   it('reports percentage progress from a direct download and clears it on completion', async () => {
-    const downloadBook = vi.fn(
-      async (_book: Book, _redownload: boolean, _reuse: boolean, onProgress?: ProgressHandler) => {
-        onProgress?.({ progress: 50, total: 100, transferSpeed: 0 });
-      },
-    );
+    vi.useFakeTimers();
+    try {
+      let release!: () => void;
+      let emit!: ProgressHandler;
+      const downloadBook = vi.fn(
+        (_book: Book, _redownload: boolean, _reuse: boolean, onProgress?: ProgressHandler) => {
+          emit = onProgress!;
+          return new Promise<void>((res) => {
+            release = res;
+          });
+        },
+      );
 
-    const { result, getProgress } = setup({ downloadBook } as unknown as AppService);
-    const book = makeBook({ uploadedAt: 12345 });
-    const promise = result.current.handleBookDownload(book, { queued: false });
+      const { result, getProgress } = setup({ downloadBook } as unknown as AppService);
+      const book = makeBook({ uploadedAt: 12345 });
+      const promise = result.current.handleBookDownload(book, { queued: false });
 
-    // The direct-download progress handler emits synchronously; the throttled
-    // leading edge lands 50% before the transfer resolves.
-    expect(getProgress()).toEqual({ [book.hash]: 50 });
+      // The overlay is primed before the first byte — without this the cover
+      // stays blank across the signed-URL round trip, auth and TLS handshake
+      // for the queued:false callers (useOpenBook, the details modal's
+      // Redownload), which is the "no visual feedback" symptom this exists to
+      // remove. The kick takes the throttle's leading edge, so the first real
+      // percentage lands on the trailing edge.
+      expect(getProgress()).toEqual({ [book.hash]: INDETERMINATE_PROGRESS });
 
-    await promise;
-    expect(getProgress()).toEqual({});
+      emit({ progress: 50, total: 100, transferSpeed: 0 });
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(getProgress()).toEqual({ [book.hash]: 50 });
+
+      release();
+      await promise;
+      expect(getProgress()).toEqual({});
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('ignores a progress event that arrives after the transfer finished', async () => {
+    // Tauri delivers Channel messages over IPC independently of the invoke
+    // response, so the downloader's last payload can land after the command
+    // resolved. Nothing clears the entry a second time, so a late event that
+    // re-armed the throttle would leave the cover stuck behind a stale overlay
+    // with its action button gone, permanently.
+    vi.useFakeTimers();
+    try {
+      routing.backends = ['gdrive'];
+      let late!: ProgressHandler;
+      runFileBookDownload.mockImplementationOnce(async (_env, _book, onProgress) => {
+        late = onProgress!;
+        return true;
+      });
+
+      const { result, getProgress } = setup();
+      const book = makeBook({ uploadedAt: 12345 });
+      await result.current.handleBookDownload(book, { queued: true });
+      expect(getProgress()).toEqual({});
+
+      late({ progress: 90, total: 100, transferSpeed: 0 });
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(getProgress()).toEqual({});
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-sync-paths.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-sync-paths.test.ts
@@ -278,7 +278,11 @@ describe('FileSyncEngine.downloadBookFile', () => {
     const ok = await new FileSyncEngine(provider, store).downloadBookFile(makeBook('h1'));
 
     expect(ok).toBe(true);
-    expect(downloadStream).toHaveBeenCalledWith('/Readest/books/h1/B.epub', '/local/h1/B.epub');
+    expect(downloadStream).toHaveBeenCalledWith(
+      '/Readest/books/h1/B.epub',
+      '/local/h1/B.epub',
+      undefined,
+    );
   });
 });
 

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-sync-paths.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-sync-paths.test.ts
@@ -284,6 +284,26 @@ describe('FileSyncEngine.downloadBookFile', () => {
       undefined,
     );
   });
+
+  test('forwards an onProgress handler to the streaming downloader', async () => {
+    const onProgress = vi.fn();
+    const downloadStream = vi.fn(async () => true);
+    const prepareLocalBookPath = vi.fn(async () => '/local/h1/B.epub');
+    const provider = fakeProvider({ list: hashDirListing(true), downloadStream });
+    const store = fakeStore({ prepareLocalBookPath });
+
+    const ok = await new FileSyncEngine(provider, store).downloadBookFile(
+      makeBook('h1'),
+      onProgress,
+    );
+
+    expect(ok).toBe(true);
+    expect(downloadStream).toHaveBeenCalledWith(
+      '/Readest/books/h1/B.epub',
+      '/local/h1/B.epub',
+      onProgress,
+    );
+  });
 });
 
 describe('FileSyncEngine.syncLibrary — receive strategy is pull-only', () => {

--- a/apps/readest-app/src/__tests__/store/transfer-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/transfer-store.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect, beforeEach } from 'vitest';
-import { useTransferStore, TransferItem, TransferStatus } from '@/store/transferStore';
+import {
+  selectActiveBookDownloadProgress,
+  useTransferStore,
+  TransferItem,
+  TransferStatus,
+} from '@/store/transferStore';
+import { INDETERMINATE_PROGRESS } from '@/utils/transfer';
 
 const initialState = {
   transfers: {} as Record<string, TransferItem>,
@@ -613,6 +619,87 @@ describe('transferStore', () => {
       };
       useTransferStore.getState().restoreTransfers(legacy, false);
       expect(useTransferStore.getState().transfers['legacy1']!.kind).toBe('book');
+    });
+  });
+
+  // ── selectActiveBookDownloadProgress ─────────────────────────────
+  //
+  // The cover transfer overlay derives its queue progress from this selector
+  // instead of mirroring rows into a second React state. A mirror needs both
+  // writers to agree on who owns an entry, and got it wrong three ways: stale
+  // completed rows (which persist as history and survive restarts) deleted
+  // live progress, rows cleared out of the queue orphaned their entry, and a
+  // restored `pending` row painted a frozen 0%.
+  describe('selectActiveBookDownloadProgress', () => {
+    const row = (over: Partial<TransferItem>): TransferItem =>
+      ({
+        id: over.id ?? 't1',
+        kind: 'book',
+        bookHash: 'h1',
+        bookTitle: 'Book',
+        type: 'download',
+        status: 'in_progress',
+        progress: 0,
+        totalBytes: 0,
+        transferredBytes: 0,
+        transferSpeed: 0,
+        retryCount: 0,
+        maxRetries: 3,
+        createdAt: 1,
+        priority: 10,
+        isBackground: false,
+        ...over,
+      }) as TransferItem;
+
+    const select = (...rows: TransferItem[]) =>
+      selectActiveBookDownloadProgress(Object.fromEntries(rows.map((r) => [r.id, r])));
+
+    test('returns an empty map for an empty queue', () => {
+      expect(selectActiveBookDownloadProgress({})).toEqual({});
+    });
+
+    test('reports an in_progress download as its percentage', () => {
+      expect(select(row({ status: 'in_progress', progress: 42 }))).toEqual({ h1: 42 });
+    });
+
+    test('reports a pending download as indeterminate, not a frozen 0%', () => {
+      // A queued-but-not-started row has no bytes yet. Reporting its literal
+      // `progress: 0` renders a stuck "0%" on the cover — which is what a
+      // restored row (restoreTransfers resets in_progress -> pending/0) shows
+      // on every launch, permanently when the queue is paused.
+      expect(select(row({ status: 'pending', progress: 0 }))).toEqual({
+        h1: INDETERMINATE_PROGRESS,
+      });
+    });
+
+    test('ignores completed, failed and cancelled rows', () => {
+      expect(
+        select(
+          row({ id: 'a', bookHash: 'done', status: 'completed', progress: 100 }),
+          row({ id: 'b', bookHash: 'bad', status: 'failed', progress: 30 }),
+          row({ id: 'c', bookHash: 'gone', status: 'cancelled', progress: 30 }),
+        ),
+      ).toEqual({});
+    });
+
+    test('a stale completed row never masks a live download of the same book', () => {
+      // queueDownload only dedups against pending/in_progress rows, so a
+      // completed row and a fresh active row for one book coexist. The result
+      // must not depend on which is visited first.
+      const stale = row({ id: 'old', status: 'completed', progress: 100 });
+      const live = row({ id: 'new', status: 'in_progress', progress: 12 });
+      expect(select(stale, live)).toEqual({ h1: 12 });
+      expect(select(live, stale)).toEqual({ h1: 12 });
+    });
+
+    test('ignores uploads, deletes and replica transfers', () => {
+      expect(
+        select(
+          row({ id: 'a', bookHash: 'up', type: 'upload' }),
+          row({ id: 'b', bookHash: 'del', type: 'delete' }),
+          row({ id: 'c', bookHash: 'rep', kind: 'replica' }),
+        ),
+      ).toEqual({});
     });
   });
 });

--- a/apps/readest-app/src/app/library/components/BookItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookItem.tsx
@@ -105,6 +105,23 @@ const BookItem: React.FC<BookItemProps> = ({
           )}
           onAspectRatioChange={setCoverAspect}
         />
+        {transferProgress !== null && transferProgress !== 100 && (
+          <div
+            className='absolute inset-0 flex items-center justify-center bg-black/40'
+            role='progressbar'
+            aria-valuenow={transferProgress === -1 ? undefined : Math.round(transferProgress)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            {transferProgress === -1 ? (
+              <span className='loading loading-spinner loading-sm text-white' />
+            ) : (
+              <span className='text-sm font-semibold text-white drop-shadow-sm'>
+                {Math.round(transferProgress)}%
+              </span>
+            )}
+          </div>
+        )}
         {bookSelected && (
           <div className='absolute inset-0 bg-black opacity-30 transition-opacity duration-300'></div>
         )}
@@ -186,50 +203,38 @@ const BookItem: React.FC<BookItemProps> = ({
                 <LiaHeadphonesSolid size={iconSize15} />
               </div>
             )}
-            {transferProgress !== null ? (
-              transferProgress === 100 ? null : (
-                <div
-                  className='radial-progress'
-                  style={
-                    {
-                      '--value': transferProgress,
-                      '--size': `${iconSize15}px`,
-                      '--thickness': '2px',
-                    } as React.CSSProperties
-                  }
-                  role='progressbar'
-                ></div>
-              )
-            ) : (
-              // A feed book has no file to move either way, so it never gets a
-              // cloud badge — it would only queue a transfer that fails (#5307).
-              !isFeedBook(book) &&
-              (!book.uploadedAt || (book.uploadedAt && !book.downloadedAt)) && (
-                <button
-                  aria-label={!book.uploadedAt ? _('Upload Book') : _('Download Book')}
-                  className='show-cloud-button -m-2 p-2'
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onClick={() => {
-                    if (!user) {
-                      navigateToLogin(router);
-                      return;
-                    }
-                    if (!book.uploadedAt) {
-                      handleBookUpload(book);
-                    } else if (!book.downloadedAt) {
-                      handleBookDownload(book, { queued: true });
-                    }
-                  }}
-                >
-                  {!book.uploadedAt && isReadestCloudStorageActive(settings) && (
-                    <LiaCloudUploadAltSolid size={iconSize15} />
-                  )}
-                  {book.uploadedAt && !book.downloadedAt && (
-                    <LiaCloudDownloadAltSolid size={iconSize15} />
-                  )}
-                </button>
-              )
-            )}
+            {transferProgress !== null
+              ? // Progress is rendered as a cover overlay; keep the row's action
+                // buttons hidden while a transfer is active.
+                null
+              : // A feed book has no file to move either way, so it never gets a
+                // cloud badge — it would only queue a transfer that fails (#5307).
+                !isFeedBook(book) &&
+                (!book.uploadedAt || (book.uploadedAt && !book.downloadedAt)) && (
+                  <button
+                    aria-label={!book.uploadedAt ? _('Upload Book') : _('Download Book')}
+                    className='show-cloud-button -m-2 p-2'
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={() => {
+                      if (!user) {
+                        navigateToLogin(router);
+                        return;
+                      }
+                      if (!book.uploadedAt) {
+                        handleBookUpload(book);
+                      } else if (!book.downloadedAt) {
+                        handleBookDownload(book, { queued: true });
+                      }
+                    }}
+                  >
+                    {!book.uploadedAt && isReadestCloudStorageActive(settings) && (
+                      <LiaCloudUploadAltSolid size={iconSize15} />
+                    )}
+                    {book.uploadedAt && !book.downloadedAt && (
+                      <LiaCloudDownloadAltSolid size={iconSize15} />
+                    )}
+                  </button>
+                )}
           </div>
         </div>
       </div>

--- a/apps/readest-app/src/app/library/components/BookItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookItem.tsx
@@ -109,6 +109,7 @@ const BookItem: React.FC<BookItemProps> = ({
           <div
             className='absolute inset-0 flex items-center justify-center bg-black/40'
             role='progressbar'
+            aria-label={book.title}
             aria-valuenow={transferProgress === -1 ? undefined : Math.round(transferProgress)}
             aria-valuemin={0}
             aria-valuemax={100}

--- a/apps/readest-app/src/app/library/components/BookItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookItem.tsx
@@ -20,6 +20,7 @@ import { navigateToLogin } from '@/utils/nav';
 import { isReadestCloudStorageActive } from '@/services/sync/cloudSyncProvider';
 import { isFeedBook } from '@/services/rss/feedBookUrl';
 import { formatAuthors, formatDescription, formatSeries } from '@/utils/book';
+import { INDETERMINATE_PROGRESS } from '@/utils/transfer';
 import ReadingProgress from './ReadingProgress';
 import BookCover from '@/components/BookCover';
 
@@ -72,6 +73,12 @@ const BookItem: React.FC<BookItemProps> = ({
 
   const seriesText = formatSeries(book.metadata?.series, book.metadata?.seriesIndex);
 
+  // One condition drives both the cover overlay and the hiding of the row's
+  // transfer buttons, so the cover can never end up showing neither. The
+  // entry is removed once the transfer settles, including at 100%.
+  const isTransferring = transferProgress !== null;
+  const isIndeterminate = transferProgress === INDETERMINATE_PROGRESS;
+
   return (
     <div
       role='none'
@@ -105,19 +112,22 @@ const BookItem: React.FC<BookItemProps> = ({
           )}
           onAspectRatioChange={setCoverAspect}
         />
-        {transferProgress !== null && transferProgress !== 100 && (
+        {isTransferring && (
+          // E-ink cannot render a translucent wash — it dithers over the cover
+          // art — and has no shadows, so the scrim becomes a solid base-100
+          // panel with a 1px base-content border and ink-colored content.
           <div
-            className='absolute inset-0 flex items-center justify-center bg-black/40'
+            className='absolute inset-0 flex items-center justify-center bg-black/40 eink:border eink:border-base-content eink:bg-base-100'
             role='progressbar'
-            aria-label={book.title}
-            aria-valuenow={transferProgress === -1 ? undefined : Math.round(transferProgress)}
+            aria-label={_('Downloading {{title}}', { title: book.title })}
+            aria-valuenow={isIndeterminate ? undefined : Math.round(transferProgress)}
             aria-valuemin={0}
             aria-valuemax={100}
           >
-            {transferProgress === -1 ? (
-              <span className='loading loading-spinner loading-sm text-white' />
+            {isIndeterminate ? (
+              <span className='loading loading-spinner loading-sm text-white eink:text-base-content' />
             ) : (
-              <span className='text-sm font-semibold text-white drop-shadow-sm'>
+              <span className='eink:text-base-content text-sm font-semibold text-white not-eink:drop-shadow-sm'>
                 {Math.round(transferProgress)}%
               </span>
             )}
@@ -204,9 +214,10 @@ const BookItem: React.FC<BookItemProps> = ({
                 <LiaHeadphonesSolid size={iconSize15} />
               </div>
             )}
-            {transferProgress !== null
+            {isTransferring
               ? // Progress is rendered as a cover overlay; keep the row's action
-                // buttons hidden while a transfer is active.
+                // buttons hidden while a transfer is active. Same condition as
+                // the overlay, so a book can never show neither.
                 null
               : // A feed book has no file to move either way, so it never gets a
                 // cloud badge — it would only queue a transfer that fails (#5307).

--- a/apps/readest-app/src/app/library/components/Bookshelf.tsx
+++ b/apps/readest-app/src/app/library/components/Bookshelf.tsx
@@ -936,7 +936,7 @@ const Bookshelf: React.FC<BookshelfProps> = ({
           handleLibraryNavigation={handleLibraryNavigation}
           handleUpdateReadingStatus={handleUpdateReadingStatus}
           transferProgress={
-            'hash' in item ? booksTransferProgress[(item as Book).hash] || null : null
+            'hash' in item ? (booksTransferProgress[(item as Book).hash] ?? null) : null
           }
           showTimeRemaining={showTimeRemaining}
         />

--- a/apps/readest-app/src/app/library/components/Bookshelf.tsx
+++ b/apps/readest-app/src/app/library/components/Bookshelf.tsx
@@ -26,6 +26,7 @@ import { useThemeStore } from '@/store/themeStore';
 import { useAutoFocus } from '@/hooks/useAutoFocus';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useLibraryStore } from '@/store/libraryStore';
+import { selectActiveBookDownloadProgress, useTransferStore } from '@/store/transferStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
 import { navigateToLibrary, navigateToReader, showReaderWindow } from '@/utils/nav';
@@ -94,7 +95,8 @@ interface BookshelfProps {
   handleShowDetailsBook: (book: Book) => void;
   handleLibraryNavigation: (targetGroup: string) => void;
   handlePushLibrary: () => Promise<void>;
-  booksTransferProgress: { [key: string]: number | null };
+  /** Direct (non-queued) downloads only; queue transfers are read from the store. */
+  booksTransferProgress: { [key: string]: number };
   contentSearch: ContentSearchRequest | null;
   onSearchContents: () => void;
   onSearchProgress?: (value: number | null) => void;
@@ -816,6 +818,18 @@ const Bookshelf: React.FC<BookshelfProps> = ({
     [libraryBooks],
   );
 
+  // Cover transfer overlay progress for every book on screen, from both
+  // sources: queued downloads live in the transfer store, direct ones in
+  // `booksTransferProgress`. Merged on read so neither has to reconcile
+  // against the other's lifecycle, and so the recent strip and the grid
+  // cannot disagree about the same book. Selecting `transfers` keeps the
+  // subscription off the store's unrelated UI fields.
+  const transfers = useTransferStore((state) => state.transfers);
+  const transferProgress = useMemo(
+    () => ({ ...selectActiveBookDownloadProgress(transfers), ...booksTransferProgress }),
+    [transfers, booksTransferProgress],
+  );
+
   // A top-level quick-resume strip: hidden while searching, inside a group, or
   // when nothing has been read yet. It stays up in select mode so shelf books
   // can be selected in place, just like the grid.
@@ -839,11 +853,13 @@ const Bookshelf: React.FC<BookshelfProps> = ({
           handleBookDownload={handleBookDownload}
           showBookDetailsModal={handleShowDetailsBook}
           showTimeRemaining={showTimeRemaining}
+          transferProgress={transferProgress}
         />
       ) : null,
     [
       showRecentShelf,
       recentBooks,
+      transferProgress,
       coverFit,
       settings.libraryAutoColumns,
       settings.libraryColumns,
@@ -935,9 +951,7 @@ const Bookshelf: React.FC<BookshelfProps> = ({
           handleShowDetailsBook={handleShowDetailsBook}
           handleLibraryNavigation={handleLibraryNavigation}
           handleUpdateReadingStatus={handleUpdateReadingStatus}
-          transferProgress={
-            'hash' in item ? (booksTransferProgress[(item as Book).hash] ?? null) : null
-          }
+          transferProgress={'hash' in item ? (transferProgress[(item as Book).hash] ?? null) : null}
           showTimeRemaining={showTimeRemaining}
         />
       );
@@ -950,7 +964,7 @@ const Bookshelf: React.FC<BookshelfProps> = ({
       viewMode,
       coverFit,
       isSelectMode,
-      booksTransferProgress,
+      transferProgress,
       iconSize15,
       handleImportBooks,
       toggleSelection,

--- a/apps/readest-app/src/app/library/components/RecentShelf.tsx
+++ b/apps/readest-app/src/app/library/components/RecentShelf.tsx
@@ -28,6 +28,12 @@ interface RecentShelfProps {
   handleBookDownload: (book: Book, options?: { redownload?: boolean; queued?: boolean }) => void;
   showBookDetailsModal: (book: Book) => void;
   showTimeRemaining: boolean;
+  /**
+   * Cover transfer progress by book hash. A book can appear here and in the
+   * grid at once, so both have to read the same map — otherwise the strip
+   * offers a Download button for a book the grid already shows downloading.
+   */
+  transferProgress: { [key: string]: number };
 }
 
 /**
@@ -51,7 +57,7 @@ type RecentSlideProps = Pick<
   | 'handleBookDownload'
   | 'showBookDetailsModal'
   | 'showTimeRemaining'
-> & { book: Book; bookSelected: boolean };
+> & { book: Book; bookSelected: boolean; transferProgress: number | null };
 
 const RecentSlide: React.FC<RecentSlideProps> = ({
   book,
@@ -65,6 +71,7 @@ const RecentSlide: React.FC<RecentSlideProps> = ({
   handleBookDownload,
   showBookDetailsModal,
   showTimeRemaining,
+  transferProgress,
 }) => {
   // Same select vocabulary as the grid (`BookshelfItem`): long-press enters
   // select mode and selects; while in select mode a tap toggles instead of
@@ -121,7 +128,7 @@ const RecentSlide: React.FC<RecentSlideProps> = ({
             coverFit={coverFit}
             isSelectMode={isSelectMode}
             bookSelected={bookSelected}
-            transferProgress={null}
+            transferProgress={transferProgress}
             handleBookUpload={handleBookUpload}
             handleBookDownload={handleBookDownload}
             showBookDetailsModal={showBookDetailsModal}
@@ -154,6 +161,7 @@ const RecentShelf: React.FC<RecentShelfProps> = ({
   handleBookDownload,
   showBookDetailsModal,
   showTimeRemaining,
+  transferProgress,
 }) => {
   const _ = useTranslation();
   // `--rs-cols` mirrors the grid's column count: the responsive ladder
@@ -243,6 +251,7 @@ const RecentShelf: React.FC<RecentShelfProps> = ({
                 handleBookDownload={handleBookDownload}
                 showBookDetailsModal={showBookDetailsModal}
                 showTimeRemaining={showTimeRemaining}
+                transferProgress={transferProgress[book.hash] ?? null}
               />
             ))}
           </div>

--- a/apps/readest-app/src/app/library/hooks/useBookTransferActions.ts
+++ b/apps/readest-app/src/app/library/hooks/useBookTransferActions.ts
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
+import { useCallback, type Dispatch, type SetStateAction } from 'react';
 import type { Book } from '@/types/book';
 import type { EnvConfigType } from '@/services/environment';
 import type { AppService } from '@/types/system';
-import type { ProgressPayload } from '@/utils/transfer';
+import { createProgressThrottle, type ProgressPayload } from '@/utils/transfer';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useSettingsStore } from '@/store/settingsStore';
 import { eventDispatcher } from '@/utils/event';
@@ -34,9 +34,32 @@ export const useBookTransferActions = (
   envConfig: EnvConfigType,
   appService: AppService | null,
   updateBook: (envConfig: EnvConfigType, book: Book) => Promise<void>,
-  updateBookTransferProgress: (bookHash: string, progress: ProgressPayload) => void,
+  setBooksTransferProgress: Dispatch<SetStateAction<{ [key: string]: number | null }>>,
 ) => {
   const _ = useTranslation();
+
+  // Per-book helpers for the cover progress overlay. Progress is throttled
+  // per transfer (native plugins emit dense per-chunk bursts) and the entry
+  // is dropped once the transfer finishes, so a stale value cannot linger.
+  // When the backend cannot report a byte total (chunked response / buffered
+  // fallback) the entry is set to -1, which the overlay renders as an
+  // indeterminate spinner instead of a frozen 0%.
+  const progressSetter = (bookHash: string) => (progress: ProgressPayload) => {
+    setBooksTransferProgress((prev) => {
+      const next = progress.total > 0 ? (progress.progress / progress.total) * 100 : -1;
+      if (prev[bookHash] === next) return prev;
+      return { ...prev, [bookHash]: next };
+    });
+  };
+
+  const clearProgress = (bookHash: string) => {
+    setBooksTransferProgress((prev) => {
+      if (prev[bookHash] == null) return prev;
+      const next = { ...prev };
+      delete next[bookHash];
+      return next;
+    });
+  };
 
   const handleBookUpload = useCallback(
     async (book: Book, _syncBooks = true) => {
@@ -94,7 +117,17 @@ export const useBookTransferActions = (
       // misrouted into Readest Cloud. When none has the file, fall through to
       // the native, resumable path if that backend is also enabled (#5009).
       if (backends.length > 0) {
-        const ok = await runFileBookDownload(envConfig, book);
+        const progressThrottle = createProgressThrottle(progressSetter(book.hash), 100);
+        // Kick the overlay off immediately (indeterminate); the native transfer
+        // plugin then reports byte progress through runFileBookDownload.
+        progressThrottle.push({ progress: 0, total: 0, transferSpeed: 0 });
+        let ok = false;
+        try {
+          ok = await runFileBookDownload(envConfig, book, (p) => progressThrottle.push(p));
+        } finally {
+          progressThrottle.flush();
+          clearProgress(book.hash);
+        }
         if (ok) {
           await updateBook(envConfig, book);
           if (!silent) {
@@ -120,10 +153,12 @@ export const useBookTransferActions = (
       }
 
       if (redownload || !queued) {
+        const progressThrottle = createProgressThrottle(progressSetter(book.hash), 100);
         try {
-          await appService?.downloadBook(book, false, redownload, (progress) => {
-            updateBookTransferProgress(book.hash, progress);
-          });
+          await appService?.downloadBook(book, false, redownload, (progress) =>
+            progressThrottle.push(progress),
+          );
+          progressThrottle.flush();
           await updateBook(envConfig, book);
           if (!silent) {
             eventDispatcher.dispatch('toast', {
@@ -136,6 +171,8 @@ export const useBookTransferActions = (
           }
           return true;
         } catch {
+          progressThrottle.cancel();
+          clearProgress(book.hash);
           if (!silent) {
             eventDispatcher.dispatch('toast', {
               message: _('Failed to download book: {{title}}', {

--- a/apps/readest-app/src/app/library/hooks/useBookTransferActions.ts
+++ b/apps/readest-app/src/app/library/hooks/useBookTransferActions.ts
@@ -159,6 +159,7 @@ export const useBookTransferActions = (
             progressThrottle.push(progress),
           );
           progressThrottle.flush();
+          clearProgress(book.hash);
           await updateBook(envConfig, book);
           if (!silent) {
             eventDispatcher.dispatch('toast', {

--- a/apps/readest-app/src/app/library/hooks/useBookTransferActions.ts
+++ b/apps/readest-app/src/app/library/hooks/useBookTransferActions.ts
@@ -2,7 +2,7 @@ import { useCallback, type Dispatch, type SetStateAction } from 'react';
 import type { Book } from '@/types/book';
 import type { EnvConfigType } from '@/services/environment';
 import type { AppService } from '@/types/system';
-import { createProgressThrottle, type ProgressPayload } from '@/utils/transfer';
+import { createProgressThrottle, toProgressPercent, type ProgressPayload } from '@/utils/transfer';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useSettingsStore } from '@/store/settingsStore';
 import { eventDispatcher } from '@/utils/event';
@@ -12,6 +12,13 @@ import {
   isReadestCloudEnabled,
 } from '@/services/sync/cloudSyncProvider';
 import { runFileBookDownload, runFileBookUpload } from '@/services/sync/file/runLibrarySync';
+
+/**
+ * One throttle runs per in-flight transfer, and every emit re-renders the
+ * visible shelf, so a bulk download multiplies this rate by the batch size.
+ * Matches the cadence of the single page-level throttle this replaced.
+ */
+const PROGRESS_THROTTLE_MS = 500;
 
 interface BookDownloadOptions {
   redownload?: boolean;
@@ -34,31 +41,50 @@ export const useBookTransferActions = (
   envConfig: EnvConfigType,
   appService: AppService | null,
   updateBook: (envConfig: EnvConfigType, book: Book) => Promise<void>,
-  setBooksTransferProgress: Dispatch<SetStateAction<{ [key: string]: number | null }>>,
+  setBooksTransferProgress: Dispatch<SetStateAction<{ [key: string]: number }>>,
 ) => {
   const _ = useTranslation();
 
-  // Per-book helpers for the cover progress overlay. Progress is throttled
-  // per transfer (native plugins emit dense per-chunk bursts) and the entry
-  // is dropped once the transfer finishes, so a stale value cannot linger.
-  // When the backend cannot report a byte total (chunked response / buffered
-  // fallback) the entry is set to -1, which the overlay renders as an
-  // indeterminate spinner instead of a frozen 0%.
-  const progressSetter = (bookHash: string) => (progress: ProgressPayload) => {
-    setBooksTransferProgress((prev) => {
-      const next = progress.total > 0 ? (progress.progress / progress.total) * 100 : -1;
-      if (prev[bookHash] === next) return prev;
-      return { ...prev, [bookHash]: next };
-    });
-  };
-
-  const clearProgress = (bookHash: string) => {
-    setBooksTransferProgress((prev) => {
-      if (prev[bookHash] == null) return prev;
-      const next = { ...prev };
-      delete next[bookHash];
-      return next;
-    });
+  /**
+   * Per-book progress reporting for the cover overlay: returns the handler to
+   * hand to the transfer, and the teardown to run once it settles.
+   *
+   * Progress is throttled per transfer (native plugins emit dense per-chunk
+   * bursts) and the entry is dropped on teardown, so a stale value cannot
+   * linger. The overlay starts indeterminate rather than blank, since no
+   * backend knows the byte total until its first progress event.
+   *
+   * `done()` latches: Tauri delivers Channel progress messages over IPC
+   * independently of the invoke response, so a final payload can arrive after
+   * the transfer resolved. Nothing clears the entry a second time, so a late
+   * event that re-armed the throttle would strand the cover behind a stale
+   * overlay with its action button gone, permanently.
+   */
+  const trackProgress = (bookHash: string) => {
+    let settled = false;
+    const throttle = createProgressThrottle((progress: ProgressPayload) => {
+      setBooksTransferProgress((prev) => {
+        const next = toProgressPercent(progress);
+        if (prev[bookHash] === next) return prev;
+        return { ...prev, [bookHash]: next };
+      });
+    }, PROGRESS_THROTTLE_MS);
+    throttle.push({ progress: 0, total: 0, transferSpeed: 0 });
+    return {
+      onProgress: (progress: ProgressPayload) => {
+        if (!settled) throttle.push(progress);
+      },
+      done: () => {
+        settled = true;
+        throttle.cancel();
+        setBooksTransferProgress((prev) => {
+          if (prev[bookHash] == null) return prev;
+          const next = { ...prev };
+          delete next[bookHash];
+          return next;
+        });
+      },
+    };
   };
 
   const handleBookUpload = useCallback(
@@ -117,16 +143,12 @@ export const useBookTransferActions = (
       // misrouted into Readest Cloud. When none has the file, fall through to
       // the native, resumable path if that backend is also enabled (#5009).
       if (backends.length > 0) {
-        const progressThrottle = createProgressThrottle(progressSetter(book.hash), 100);
-        // Kick the overlay off immediately (indeterminate); the native transfer
-        // plugin then reports byte progress through runFileBookDownload.
-        progressThrottle.push({ progress: 0, total: 0, transferSpeed: 0 });
+        const tracker = trackProgress(book.hash);
         let ok = false;
         try {
-          ok = await runFileBookDownload(envConfig, book, (p) => progressThrottle.push(p));
+          ok = await runFileBookDownload(envConfig, book, tracker.onProgress);
         } finally {
-          progressThrottle.flush();
-          clearProgress(book.hash);
+          tracker.done();
         }
         if (ok) {
           await updateBook(envConfig, book);
@@ -153,13 +175,10 @@ export const useBookTransferActions = (
       }
 
       if (redownload || !queued) {
-        const progressThrottle = createProgressThrottle(progressSetter(book.hash), 100);
+        const tracker = trackProgress(book.hash);
         try {
-          await appService?.downloadBook(book, false, redownload, (progress) =>
-            progressThrottle.push(progress),
-          );
-          progressThrottle.flush();
-          clearProgress(book.hash);
+          await appService?.downloadBook(book, false, redownload, tracker.onProgress);
+          tracker.done();
           await updateBook(envConfig, book);
           if (!silent) {
             eventDispatcher.dispatch('toast', {
@@ -172,8 +191,7 @@ export const useBookTransferActions = (
           }
           return true;
         } catch {
-          progressThrottle.cancel();
-          clearProgress(book.hash);
+          tracker.done();
           if (!silent) {
             eventDispatcher.dispatch('toast', {
               message: _('Failed to download book: {{title}}', {

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -301,8 +301,10 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
       | typeof LibraryGroupByType.Subject;
     groupName: string;
   } | null>(null);
+  // Direct (non-queued) download progress, keyed by book hash. Entries are
+  // added and removed by useBookTransferActions, its only writer.
   const [booksTransferProgress, setBooksTransferProgress] = useState<{
-    [key: string]: number | null;
+    [key: string]: number;
   }>({});
   const [pendingNavigationBookIds, setPendingNavigationBookIds] = useState<string[] | null>(null);
   const isInitiating = useRef(false);
@@ -1095,36 +1097,9 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
   });
 
   // Queue downloads (the TransferQueuePanel path) report progress into the
-  // transfer store, not through the transfer actions hook, so mirror active
-  // download transfers back into booksTransferProgress to drive the cover
-  // progress overlay. The entry is dropped when the transfer leaves
-  // pending/in_progress (completed, failed, cancelled).
-  useEffect(() => {
-    const syncFromTransferQueue = () => {
-      const { transfers } = useTransferStore.getState();
-      setBooksTransferProgress((prev) => {
-        let merged = prev;
-        let changed = false;
-        for (const t of Object.values(transfers)) {
-          if (t.kind !== 'book' || t.type !== 'download') continue;
-          const active = t.status === 'pending' || t.status === 'in_progress';
-          if (active && merged[t.bookHash] !== t.progress) {
-            if (!changed) merged = { ...prev };
-            merged[t.bookHash] = t.progress;
-            changed = true;
-          } else if (!active && merged[t.bookHash] != null) {
-            if (!changed) merged = { ...prev };
-            delete merged[t.bookHash];
-            changed = true;
-          }
-        }
-        return changed ? merged : prev;
-      });
-    };
-    syncFromTransferQueue();
-    return useTransferStore.subscribe(syncFromTransferQueue);
-  }, []);
-
+  // transfer store instead of through this hook. Bookshelf reads them straight
+  // from the store via `selectActiveBookDownloadProgress` and merges them with
+  // this state, so `booksTransferProgress` keeps a single writer.
   const { handleBookUpload, handleBookDownload } = useBookTransferActions(
     envConfig,
     appService,

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -26,8 +26,6 @@ import { getBookWithUpdatedMetadata, listFormater } from '@/utils/book';
 import { getImportErrorMessage } from '@/services/errors';
 import { ingestFile } from '@/services/ingestService';
 import { eventDispatcher } from '@/utils/event';
-import { ProgressPayload } from '@/utils/transfer';
-import { throttle } from '@/utils/throttle';
 import { transferManager } from '@/services/transferManager';
 import { isReadestCloudStorageActive } from '@/services/sync/cloudSyncProvider';
 import { getFilename, getFolderImportGroupName, joinScannedPath } from '@/utils/path';
@@ -1096,20 +1094,42 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
     scanAndImport: autoImportFromWatchedFolders,
   });
 
-  const updateBookTransferProgress = throttle((bookHash: string, progress: ProgressPayload) => {
-    if (progress.total === 0) return;
-    const progressPct = (progress.progress / progress.total) * 100;
-    setBooksTransferProgress((prev) => ({
-      ...prev,
-      [bookHash]: progressPct,
-    }));
-  }, 500);
+  // Queue downloads (the TransferQueuePanel path) report progress into the
+  // transfer store, not through the transfer actions hook, so mirror active
+  // download transfers back into booksTransferProgress to drive the cover
+  // progress overlay. The entry is dropped when the transfer leaves
+  // pending/in_progress (completed, failed, cancelled).
+  useEffect(() => {
+    const syncFromTransferQueue = () => {
+      const { transfers } = useTransferStore.getState();
+      setBooksTransferProgress((prev) => {
+        let merged = prev;
+        let changed = false;
+        for (const t of Object.values(transfers)) {
+          if (t.kind !== 'book' || t.type !== 'download') continue;
+          const active = t.status === 'pending' || t.status === 'in_progress';
+          if (active && merged[t.bookHash] !== t.progress) {
+            if (!changed) merged = { ...prev };
+            merged[t.bookHash] = t.progress;
+            changed = true;
+          } else if (!active && merged[t.bookHash] != null) {
+            if (!changed) merged = { ...prev };
+            delete merged[t.bookHash];
+            changed = true;
+          }
+        }
+        return changed ? merged : prev;
+      });
+    };
+    syncFromTransferQueue();
+    return useTransferStore.subscribe(syncFromTransferQueue);
+  }, []);
 
   const { handleBookUpload, handleBookDownload } = useBookTransferActions(
     envConfig,
     appService,
     updateBook,
-    updateBookTransferProgress,
+    setBooksTransferProgress,
   );
 
   const handleBookDelete = (deleteAction: DeleteAction) => {

--- a/apps/readest-app/src/services/sync/file/engine.ts
+++ b/apps/readest-app/src/services/sync/file/engine.ts
@@ -1,4 +1,5 @@
 import { Book, BookConfig, BookNote } from '@/types/book';
+import type { ProgressHandler } from '@/utils/transfer';
 import { FileHead, FileSyncError, FileSyncProvider } from './provider';
 import { LocalStore } from './localStore';
 import {
@@ -432,7 +433,7 @@ export class FileSyncEngine {
    * metadata-only shelf rows; it deliberately leaves this binary transfer to
    * the explicit action.
    */
-  async downloadBookFile(book: Book): Promise<boolean> {
+  async downloadBookFile(book: Book, onProgress?: ProgressHandler): Promise<boolean> {
     const dirPath = buildBookDirPath(this.provider.rootPath, book.hash);
     const entries = await this.provider.list(dirPath);
     const fileEntry = entries.find(
@@ -443,7 +444,7 @@ export class FileSyncEngine {
     let written = false;
     if (this.provider.downloadStream) {
       const dst = await this.store.prepareLocalBookPath(book);
-      written = await this.provider.downloadStream(fileEntry.path, dst);
+      written = await this.provider.downloadStream(fileEntry.path, dst, onProgress);
     } else {
       const bytes = await this.provider.readBinary(fileEntry.path);
       if (bytes) {

--- a/apps/readest-app/src/services/sync/file/provider.ts
+++ b/apps/readest-app/src/services/sync/file/provider.ts
@@ -14,8 +14,9 @@
  * on auth / not-found / network / conflict without knowing the backend.
  */
 
-export type FileSyncErrorCode = 'AUTH_FAILED' | 'NOT_FOUND' | 'NETWORK' | 'CONFLICT' | 'UNKNOWN';
+import type { ProgressHandler } from '@/utils/transfer';
 
+export type FileSyncErrorCode = 'AUTH_FAILED' | 'NOT_FOUND' | 'NETWORK' | 'CONFLICT' | 'UNKNOWN';
 export class FileSyncError extends Error {
   code: FileSyncErrorCode;
   /** HTTP status when the request reached the server, if applicable. */
@@ -81,7 +82,12 @@ export interface FileSyncProvider {
   uploadStream?(remotePath: string, localPath: string): Promise<boolean>;
   /**
    * Optional streaming download: GET `remotePath` straight to `localPath`.
-   * Same ownership + fallback rules as {@link uploadStream}.
+   * Same ownership + fallback rules as {@link uploadStream}. When the backend
+   * can observe bytes as they arrive, it reports them through `onProgress`.
    */
-  downloadStream?(remotePath: string, localPath: string): Promise<boolean>;
+  downloadStream?(
+    remotePath: string,
+    localPath: string,
+    onProgress?: ProgressHandler,
+  ): Promise<boolean>;
 }

--- a/apps/readest-app/src/services/sync/file/runLibrarySync.ts
+++ b/apps/readest-app/src/services/sync/file/runLibrarySync.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import type { Book } from '@/types/book';
 import type { EnvConfigType } from '@/services/environment';
+import type { ProgressHandler } from '@/utils/transfer';
 import type { TranslationFunc } from '@/hooks/useTranslation';
 import type { SystemSettings } from '@/types/settings';
 import type { UserPlan } from '@/types/quota';
@@ -214,13 +215,14 @@ export const runFileBookUpload = async (envConfig: EnvConfigType, book: Book): P
 export const runFileBookDownload = async (
   envConfig: EnvConfigType,
   book: Book,
+  onProgress?: ProgressHandler,
 ): Promise<boolean> => {
   const backends = getActiveFileSyncBackends(useSettingsStore.getState().settings);
   for (const kind of backends) {
     try {
       const engine = await buildEngine(envConfig, kind);
       if (!engine) continue;
-      if (!(await engine.downloadBookFile(book))) continue;
+      if (!(await engine.downloadBookFile(book, onProgress))) continue;
       book.downloadedAt = Date.now();
       if (!book.coverDownloadedAt) book.coverDownloadedAt = Date.now();
       return true;

--- a/apps/readest-app/src/services/sync/providers/gdrive/GoogleDriveProvider.ts
+++ b/apps/readest-app/src/services/sync/providers/gdrive/GoogleDriveProvider.ts
@@ -35,6 +35,7 @@
 
 import { isTauriAppPlatform } from '@/services/environment';
 import { tauriDownload, tauriUpload } from '@/utils/transfer';
+import type { ProgressHandler } from '@/utils/transfer';
 import {
   FileEntry,
   FileHead,
@@ -787,13 +788,17 @@ class DriveProviderImpl {
    * media URL needs a bearer token (the session-URI shortcut is upload-only).
    * Returns `false` when the file is absent or the transport swallows a failure.
    */
-  async downloadStream(remotePath: string, localPath: string): Promise<boolean> {
+  async downloadStream(
+    remotePath: string,
+    localPath: string,
+    onProgress?: ProgressHandler,
+  ): Promise<boolean> {
     logDriveOp('downloadStream', remotePath);
     try {
       const fileId = await this.resolveFile(remotePath);
       if (fileId === null) return false;
       const token = await this.auth.getAccessToken();
-      await tauriDownload(mediaDownloadUrl(fileId), localPath, undefined, {
+      await tauriDownload(mediaDownloadUrl(fileId), localPath, onProgress, {
         Authorization: `Bearer ${token}`,
       });
       return true;
@@ -932,7 +937,8 @@ export const createGoogleDriveProvider = (
 
   if (isTauriAppPlatform()) {
     provider.uploadStream = (remotePath, localPath) => impl.uploadStream(remotePath, localPath);
-    provider.downloadStream = (remotePath, localPath) => impl.downloadStream(remotePath, localPath);
+    provider.downloadStream = (remotePath, localPath, onProgress) =>
+      impl.downloadStream(remotePath, localPath, onProgress);
   }
 
   return provider;

--- a/apps/readest-app/src/services/sync/providers/onedrive/OneDriveProvider.ts
+++ b/apps/readest-app/src/services/sync/providers/onedrive/OneDriveProvider.ts
@@ -17,6 +17,7 @@ import {
   FileSyncProvider,
 } from '@/services/sync/file/provider';
 import { tauriDownload, tauriUpload } from '@/utils/transfer';
+import type { ProgressHandler } from '@/utils/transfer';
 import {
   childrenUrl,
   contentUrl,
@@ -284,10 +285,14 @@ class OneDriveProviderImpl {
    * The content URL needs a bearer token. Returns `false` when the transport
    * swallows a failure (e.g. the remote file is absent).
    */
-  async downloadStream(remotePath: string, localPath: string): Promise<boolean> {
+  async downloadStream(
+    remotePath: string,
+    localPath: string,
+    onProgress?: ProgressHandler,
+  ): Promise<boolean> {
     try {
       const token = await this.auth.getAccessToken();
-      await tauriDownload(contentUrl(remotePath), localPath, undefined, {
+      await tauriDownload(contentUrl(remotePath), localPath, onProgress, {
         Authorization: `Bearer ${token}`,
       });
       return true;
@@ -393,7 +398,8 @@ export const createOneDriveProvider = (
 
   if (isTauriAppPlatform()) {
     provider.uploadStream = (remotePath, localPath) => impl.uploadStream(remotePath, localPath);
-    provider.downloadStream = (remotePath, localPath) => impl.downloadStream(remotePath, localPath);
+    provider.downloadStream = (remotePath, localPath, onProgress) =>
+      impl.downloadStream(remotePath, localPath, onProgress);
   }
 
   return provider;

--- a/apps/readest-app/src/services/sync/providers/s3/S3Provider.ts
+++ b/apps/readest-app/src/services/sync/providers/s3/S3Provider.ts
@@ -37,6 +37,7 @@ import { AwsClient } from 'aws4fetch';
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import { isTauriAppPlatform } from '@/services/environment';
 import { tauriDownload, tauriUpload } from '@/utils/transfer';
+import type { ProgressHandler } from '@/utils/transfer';
 import {
   FileEntry,
   FileHead,
@@ -338,10 +339,14 @@ class S3ProviderImpl {
   }
 
   /** Streaming download via a presigned GET URL; same contract as upload. */
-  async downloadStream(remotePath: string, localPath: string): Promise<boolean> {
+  async downloadStream(
+    remotePath: string,
+    localPath: string,
+    onProgress?: ProgressHandler,
+  ): Promise<boolean> {
     try {
       const url = await this.presign(HTTP_GET, remotePath);
-      await tauriDownload(url, localPath);
+      await tauriDownload(url, localPath, onProgress);
       return true;
     } catch (e) {
       console.warn('S3Provider.downloadStream failed', remotePath, e);
@@ -435,7 +440,8 @@ export const createS3Provider = (
 
   if (isTauriAppPlatform()) {
     provider.uploadStream = (remotePath, localPath) => impl.uploadStream(remotePath, localPath);
-    provider.downloadStream = (remotePath, localPath) => impl.downloadStream(remotePath, localPath);
+    provider.downloadStream = (remotePath, localPath, onProgress) =>
+      impl.downloadStream(remotePath, localPath, onProgress);
   }
 
   return provider;

--- a/apps/readest-app/src/services/sync/providers/webdav/WebDAVProvider.ts
+++ b/apps/readest-app/src/services/sync/providers/webdav/WebDAVProvider.ts
@@ -107,10 +107,10 @@ export const createWebDAVProvider = (settings: WebDAVSettings): FileSyncProvider
         return false;
       }
     };
-    provider.downloadStream = async (remotePath, localPath) => {
+    provider.downloadStream = async (remotePath, localPath, onProgress) => {
       const url = buildRequestUrl(settings.serverUrl, remotePath);
       try {
-        await tauriDownload(url, localPath, undefined, authHeaders());
+        await tauriDownload(url, localPath, onProgress, authHeaders());
         return true;
       } catch (e) {
         console.warn('WebDAVProvider.downloadStream failed', remotePath, e);

--- a/apps/readest-app/src/store/transferStore.ts
+++ b/apps/readest-app/src/store/transferStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { BaseDir } from '@/types/system';
+import { INDETERMINATE_PROGRESS } from '@/utils/transfer';
 
 export type TransferType = 'upload' | 'download' | 'delete';
 export type TransferStatus = 'pending' | 'in_progress' | 'completed' | 'failed' | 'cancelled';
@@ -142,6 +143,36 @@ const generateTransferId = (): string => {
  */
 export const isFailedLikeTransfer = (t: TransferItem): boolean =>
   t.status === 'failed' || (t.status === 'cancelled' && t.cancelReason !== 'policy');
+
+/**
+ * Per-book download progress for the covers' transfer overlay, keyed by book
+ * hash. Derived on read rather than mirrored into a second state: the queue
+ * keeps completed and failed rows as history (they are persisted to
+ * localStorage and restored on launch), and Clear Pending / Clear Completed
+ * remove rows outright, so any copy of this data has to be reconciled against
+ * both — and gets it wrong when a stale row outlives a live one for the same
+ * book. Only pending/in_progress rows are reported, which makes the result
+ * independent of iteration order and of whatever history the queue holds.
+ *
+ * A pending row has no bytes yet, so it reports {@link INDETERMINATE_PROGRESS}
+ * rather than its literal `progress: 0` — `restoreTransfers` resets interrupted
+ * transfers to pending/0, which would otherwise paint a frozen "0%" on every
+ * launch, permanently while the queue is paused.
+ */
+export const selectActiveBookDownloadProgress = (
+  transfers: Record<string, TransferItem>,
+): Record<string, number> => {
+  const progress: Record<string, number> = {};
+  for (const t of Object.values(transfers)) {
+    if (t.kind !== 'book' || t.type !== 'download') continue;
+    // in_progress always wins over pending, whichever is visited first.
+    if (t.status === 'in_progress') progress[t.bookHash] = t.progress;
+    else if (t.status === 'pending' && progress[t.bookHash] === undefined) {
+      progress[t.bookHash] = INDETERMINATE_PROGRESS;
+    }
+  }
+  return progress;
+};
 
 export const useTransferStore = create<TransferState>((set, get) => ({
   transfers: {},

--- a/apps/readest-app/src/utils/transfer.ts
+++ b/apps/readest-app/src/utils/transfer.ts
@@ -15,6 +15,18 @@ export interface ProgressPayload {
 
 export type ProgressHandler = (progress: ProgressPayload) => void;
 
+/**
+ * Percentage sentinel for "running, but the byte total is unknown". Chunked
+ * responses, buffered fallbacks and queued-but-not-started transfers have no
+ * total to divide by; reporting 0 there renders as a frozen 0%, so progress
+ * surfaces render this as an indeterminate state instead.
+ */
+export const INDETERMINATE_PROGRESS = -1;
+
+/** Bytes to a 0-100 percentage, or {@link INDETERMINATE_PROGRESS}. */
+export const toProgressPercent = (progress: ProgressPayload): number =>
+  progress.total > 0 ? (progress.progress / progress.total) * 100 : INDETERMINATE_PROGRESS;
+
 export interface ProgressThrottle {
   /** Record a progress payload, emitting at most once per interval. */
   push: (progress: ProgressPayload) => void;


### PR DESCRIPTION
Clicking a book's cloud download icon gave no visual feedback: third-party file-backend downloads (WebDAV/Drive/S3/OneDrive) ran without reporting any progress, and the queue path's initial 0% was swallowed by a || null in Bookshelf.

## Changes
- Thread byte progress from the native transfer plugin through FileSyncProvider.downloadStream → engine.downloadBookFile → runFileBookDownload; fixed the gdrive/s3/onedrive provider wrappers that dropped the onProgress argument.
- Mirror transfer-queue download progress into booksTransferProgress so Readest Cloud queue downloads show the overlay too.
- Render progress on the cover as a percentage overlay (indeterminate spinner when the backend reports no byte total), replacing the old row radial.
<img width="950" height="673" alt="demo" src="https://github.com/user-attachments/assets/b12450cb-09e7-44b0-a154-c0b93e8ba956" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full-cover book transfer indicators with spinners for indeterminate progress and percentages for measurable progress.
  * Added progress reporting for downloads from supported cloud and file-sync providers.
  * Transfer actions remain hidden throughout active transfers.

* **Bug Fixes**
  * Corrected display of transfers at 0% progress.
  * Improved progress cleanup after transfers complete or fail.
  * Prevented stale progress events from updating finished transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->