### PR TITLE
fix(wordlens): key the manifest diff on pack routing fields too

### DIFF
--- a/apps/readest-app/scripts/sync-wordlens-r2.mjs
+++ b/apps/readest-app/scripts/sync-wordlens-r2.mjs
@@ -53,13 +53,16 @@ export function planSync(local, remote, { force = false } = {}) {
     .sort();
 }
 
-// What clients actually act on: the schema version plus each pack's file -> sha256.
-// Order and derived fields (bytes, entries) are ignored, so a manifest regenerated
-// with identical content never triggers a pointless upload.
+// What clients actually act on: the schema version, each pack's source/target (how
+// resolvePack routes a book language to a pack) and its file/sha256 (what gets fetched
+// and cache-busted). Order and derived fields (bytes, entries) are ignored, so a
+// manifest regenerated with identical content never triggers a pointless upload.
+// source/target are redundant today — packEntry reads them from the pack's meta, which
+// sha256 covers — but they are what routing depends on, so the key states it outright.
 const manifestKey = (m) =>
   JSON.stringify([
     m?.schemaVersion ?? null,
-    (m?.packs ?? []).map((p) => [p.file, p.sha256]).sort(),
+    (m?.packs ?? []).map((p) => [p.source, p.target, p.file, p.sha256]).sort(),
   ]);
 
 // Does the manifest itself need republishing? planSync can't answer this: RETIRING a

--- a/apps/readest-app/src/__tests__/scripts/sync-wordlens-r2.test.ts
+++ b/apps/readest-app/src/__tests__/scripts/sync-wordlens-r2.test.ts
@@ -87,6 +87,19 @@ describe('manifestChanged', () => {
     expect(manifestChanged(local, null)).toBe(true);
   });
 
+  // resolvePack routes on source/target, so they belong in the key even though the
+  // generator cannot currently diverge them from the hash: packEntry reads both out of
+  // the pack's meta, which sha256 covers. Keeps the key honest if that ever changes.
+  it('is true when a pack is rerouted to another language, hash unchanged', () => {
+    const rerouted = { ...pack('en-vi', 'ccc'), target: 'vt' };
+    const remote = {
+      schemaVersion: 1,
+      packs: [pack('en-zh', 'aaa'), pack('en-es', 'bbb'), rerouted],
+    };
+    expect(planSync(local, remote)).toEqual([]); // file + sha256 both match
+    expect(manifestChanged(local, remote)).toBe(true);
+  });
+
   it('ignores pack ordering and derived fields the client never diffs on', () => {
     const remote = {
       schemaVersion: 1,


### PR DESCRIPTION
## Summary

Review follow-up to #5738, which merged before this last commit could be pushed.

`manifestKey` (the helper deciding whether the R2 manifest needs republishing) compared only each pack's `file` and `sha256`. But `resolvePack` in `src/services/wordlens/glossPacks.ts` routes a book's language to a pack through `source` and `target`, so the key did not state what clients actually depend on.

This is redundant in practice, and I want to be clear about that rather than overstate the fix: `packEntry` derives `source` and `target` from the pack's `meta`, and `sha256` hashes the whole file including that `meta`, so routing cannot shift without the hash shifting. There is no reachable path today where a rerouted pack keeps its hash. Adding the two fields costs one line and keeps the key honest if either half of that invariant changes.

## Testing

- New case: a pack rerouted to another language with `file` and `sha256` unchanged. It asserts `planSync` plans no upload (both fields match) while `manifestChanged` returns true, which is the exact pairing that would otherwise leave a corrected manifest unpublished. Written first, failed first.
- `pnpm test` 9217 passed / 16 skipped, `pnpm lint` and `pnpm format:check` clean

No `src-tauri/` or koplugin files changed, so the Rust and Lua checks do not apply.

## Still pending from the two merged PRs

Packs are served from R2, not bundled, and nothing has been synced yet. The live CDN manifest lists 14 packs, so both **`en-vi` (#5737)** and **`en-hu` (#5738)** are merged but invisible to clients. One `WORDLENS_R2_BUCKET=<bucket> pnpm wordlens:sync` publishes both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language pack synchronization to detect changes when a pack’s source or target language is updated, even if the file itself is unchanged.
  * Prevented unnecessary uploads when the existing pack already matches the manifest.

* **Tests**
  * Added coverage for detecting language-routing changes and avoiding redundant uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->