### PR TITLE
feat(annotator): support text selection tools in footnote popups

### DIFF
--- a/apps/readest-app/src/__tests__/utils/footnote-cfi-mapping.test.ts
+++ b/apps/readest-app/src/__tests__/utils/footnote-cfi-mapping.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import * as CFI from 'foliate-js/epubcfi.js';
+import { getExtractMapping } from 'foliate-js/footnotes.js';
+import {
+  FootnoteExtractMapping,
+  getFootnoteSelectionCfi,
+  getFootnoteLocalCfi,
+} from '@/app/reader/utils/footnoteCfi';
+
+const XHTML = (str: string) => new DOMParser().parseFromString(str, 'application/xhtml+xml');
+
+const SECTION = `<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Notes</title></head>
+  <body id="body01">
+    <h1>Notes</h1>
+    <ol class="notes">
+      <li id="fn1">First note with <em>emphasis</em> inside.</li>
+      <li id="fn2">Second note text, quite a bit longer than the first one.</li>
+      <li id="fn3">Third note.</li>
+    </ol>
+    <dl>
+      <dt id="dt1">term</dt>
+      <dd>first definition line</dd>
+      <dd>second definition line</dd>
+      <dt id="dt2">other term</dt>
+      <dd>other definition</dd>
+    </dl>
+    <div class="paragraph-notes">
+      <p id="pn1"><a id="pn1a" href="#r1">1.</a> A paragraph-style note body.</p>
+      <p id="pn2"><a id="pn2a" href="#r2">2.</a> Another paragraph-style note.</p>
+    </div>
+  </body>
+</html>`;
+
+const BASE_CFI = 'epubcfi(/6/12)';
+
+// Simulate exactly what foliate-js FootnoteHandler#showFragment does to the
+// popup document: compute the mapping, then extract the range into the body.
+const simulatePopup = (
+  doc: Document,
+  buildRange: (doc: Document) => Range,
+): FootnoteExtractMapping | null => {
+  const range = buildRange(doc);
+  const mapping = getExtractMapping(range) as FootnoteExtractMapping | null;
+  const frag = range.extractContents();
+  doc.body.replaceChildren();
+  doc.body.appendChild(frag);
+  return mapping;
+};
+
+// Resolve a full (spine-prefixed) CFI against a document, the way
+// epub.js resolveCFI does: shift off the spine part, then toRange.
+const resolveInDoc = (doc: Document, cfi: string): Range | null => {
+  const parts = CFI.parse(cfi) as { parent?: unknown[] } & unknown[];
+  ((parts.parent ?? parts) as unknown[]).shift();
+  return CFI.toRange(doc, parts) as Range | null;
+};
+
+// The extraction ranges used by FootnoteHandler#showFragment branches.
+const liContents = (doc: Document) => {
+  const range = doc.createRange();
+  range.selectNodeContents(doc.getElementById('fn2')!);
+  return range;
+};
+const dtRun = (doc: Document) => {
+  const dt = doc.getElementById('dt1')!;
+  const range = doc.createRange();
+  range.setStartBefore(dt);
+  let sibling = dt.nextElementSibling;
+  let lastDD = null;
+  while (sibling && sibling.matches('dd')) {
+    lastDD = sibling;
+    sibling = sibling.nextElementSibling;
+  }
+  range.setEndAfter(lastDD || dt);
+  return range;
+};
+const paragraphRun = (doc: Document) => {
+  const p1 = doc.getElementById('pn1')!;
+  const range = doc.createRange();
+  range.setStartBefore(p1);
+  range.setEndBefore(doc.getElementById('pn2')!);
+  return range;
+};
+
+describe('footnote popup CFI mapping', () => {
+  const roundTrip = (
+    buildExtractRange: (doc: Document) => Range,
+    buildSelection: (popupDoc: Document) => Range,
+  ) => {
+    const popupDoc = XHTML(SECTION);
+    const pristineDoc = XHTML(SECTION);
+    const mapping = simulatePopup(popupDoc, buildExtractRange);
+    expect(mapping).not.toBeNull();
+    const selection = buildSelection(popupDoc);
+    const cfi = getFootnoteSelectionCfi(selection, mapping!, BASE_CFI);
+    expect(cfi).toBeTruthy();
+    const resolved = resolveInDoc(pristineDoc, cfi!);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.toString()).toBe(selection.toString());
+    return { popupDoc, pristineDoc, mapping: mapping!, cfi: cfi! };
+  };
+
+  it('maps a text selection inside an extracted <li> back to the pristine document', () => {
+    const { cfi } = roundTrip(liContents, (popupDoc) => {
+      // "Second note text" without the trailing part
+      const text = popupDoc.body.firstChild!;
+      const range = popupDoc.createRange();
+      range.setStart(text, 7);
+      range.setEnd(text, 16);
+      return range;
+    });
+    expect(cfi).toContain('epubcfi(/6/12!');
+  });
+
+  it('maps a selection spanning elements in a <dt>/<dd> extraction', () => {
+    roundTrip(dtRun, (popupDoc) => {
+      // from inside the dt text to inside the second dd text
+      const dt = popupDoc.getElementById('dt1')!;
+      const dds = popupDoc.querySelectorAll('dd');
+      const range = popupDoc.createRange();
+      range.setStart(dt.firstChild!, 1);
+      range.setEnd(dds[1]!.firstChild!, 6);
+      return range;
+    });
+  });
+
+  it('maps a selection in a paragraph-run extraction (setStartBefore/setEndBefore)', () => {
+    roundTrip(paragraphRun, (popupDoc) => {
+      const p = popupDoc.getElementById('pn1')!;
+      // text node after the <a>: " A paragraph-style note body."
+      const text = p.childNodes[1]!;
+      const range = popupDoc.createRange();
+      range.setStart(text, 3);
+      range.setEnd(text, 12);
+      return range;
+    });
+  });
+
+  it('maps a select-all selection (body-level boundaries) via normalization', () => {
+    roundTrip(liContents, (popupDoc) => {
+      const range = popupDoc.createRange();
+      range.setStart(popupDoc.body, 0);
+      range.setEnd(popupDoc.body, popupDoc.body.childNodes.length);
+      return range;
+    });
+  });
+
+  it('reverse-maps a pristine-document annotation CFI into the popup', () => {
+    const popupDoc = XHTML(SECTION);
+    const pristineDoc = XHTML(SECTION);
+    const mapping = simulatePopup(popupDoc, liContents)!;
+
+    // An annotation on "note text" inside fn2 of the pristine document
+    const fn2Text = pristineDoc.getElementById('fn2')!.firstChild!;
+    const noteRange = pristineDoc.createRange();
+    noteRange.setStart(fn2Text, 7);
+    noteRange.setEnd(fn2Text, 16);
+    const bookCfi = CFI.joinIndir(BASE_CFI, CFI.fromRange(noteRange)) as string;
+
+    const localCfi = getFootnoteLocalCfi(bookCfi, mapping, popupDoc);
+    expect(localCfi).toBeTruthy();
+    const localRange = resolveInDoc(popupDoc, localCfi!);
+    expect(localRange).not.toBeNull();
+    expect(localRange!.toString()).toBe(noteRange.toString());
+  });
+
+  it('rejects reverse-mapping an annotation outside the extracted region', () => {
+    const popupDoc = XHTML(SECTION);
+    const pristineDoc = XHTML(SECTION);
+    // popup shows fn2's contents only
+    const mapping = simulatePopup(popupDoc, liContents)!;
+
+    // annotation in fn1 (different container) must not map into the popup
+    const fn1Text = pristineDoc.getElementById('fn1')!.firstChild!;
+    const outside = pristineDoc.createRange();
+    outside.setStart(fn1Text, 0);
+    outside.setEnd(fn1Text, 5);
+    const bookCfi = CFI.joinIndir(BASE_CFI, CFI.fromRange(outside)) as string;
+    expect(getFootnoteLocalCfi(bookCfi, mapping, popupDoc)).toBeNull();
+  });
+
+  it('rejects reverse-mapping a same-container sibling outside a partial extraction', () => {
+    const popupDoc = XHTML(SECTION);
+    const pristineDoc = XHTML(SECTION);
+    // popup shows dt1 + its two dds; dt2/dd stay outside but share the <dl>
+    const mapping = simulatePopup(popupDoc, dtRun)!;
+
+    const dt2Text = pristineDoc.getElementById('dt2')!.firstChild!;
+    const outside = pristineDoc.createRange();
+    outside.setStart(dt2Text, 0);
+    outside.setEnd(dt2Text, 5);
+    const bookCfi = CFI.joinIndir(BASE_CFI, CFI.fromRange(outside)) as string;
+    expect(getFootnoteLocalCfi(bookCfi, mapping, popupDoc)).toBeNull();
+  });
+
+  it('returns null mapping for a range with text-node boundaries (resolved CFI anchors)', () => {
+    const doc = XHTML(SECTION);
+    const text = doc.getElementById('fn2')!.firstChild!;
+    const range = doc.createRange();
+    range.setStart(text, 2);
+    range.setEnd(text, 10);
+    expect(getExtractMapping(range)).toBeNull();
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/footnote-cfi-mapping.test.ts
+++ b/apps/readest-app/src/__tests__/utils/footnote-cfi-mapping.test.ts
@@ -87,6 +87,16 @@ describe('footnote popup CFI mapping', () => {
   const roundTrip = (
     buildExtractRange: (doc: Document) => Range,
     buildSelection: (popupDoc: Document) => Range,
+    // Where the mapped CFI must land in the PRISTINE document. Text equality
+    // alone would pass an off-by-one first-level index that happens to hit
+    // identical text elsewhere, so anchor assertions are what catch a delta
+    // regression.
+    expectPristine?: (pristineDoc: Document) => {
+      startContainer: Node;
+      startOffset: number;
+      endContainer: Node;
+      endOffset: number;
+    },
   ) => {
     const popupDoc = XHTML(SECTION);
     const pristineDoc = XHTML(SECTION);
@@ -98,43 +108,103 @@ describe('footnote popup CFI mapping', () => {
     const resolved = resolveInDoc(pristineDoc, cfi!);
     expect(resolved).not.toBeNull();
     expect(resolved!.toString()).toBe(selection.toString());
+    if (expectPristine) {
+      const expected = expectPristine(pristineDoc);
+      expect(resolved!.startContainer).toBe(expected.startContainer);
+      expect(resolved!.startOffset).toBe(expected.startOffset);
+      expect(resolved!.endContainer).toBe(expected.endContainer);
+      expect(resolved!.endOffset).toBe(expected.endOffset);
+    }
     return { popupDoc, pristineDoc, mapping: mapping!, cfi: cfi! };
   };
 
   it('maps a text selection inside an extracted <li> back to the pristine document', () => {
-    const { cfi } = roundTrip(liContents, (popupDoc) => {
-      // "Second note text" without the trailing part
-      const text = popupDoc.body.firstChild!;
-      const range = popupDoc.createRange();
-      range.setStart(text, 7);
-      range.setEnd(text, 16);
-      return range;
-    });
+    const { cfi } = roundTrip(
+      liContents,
+      (popupDoc) => {
+        // "Second note text" without the trailing part
+        const text = popupDoc.body.firstChild!;
+        const range = popupDoc.createRange();
+        range.setStart(text, 7);
+        range.setEnd(text, 16);
+        return range;
+      },
+      (pristineDoc) => {
+        const text = pristineDoc.getElementById('fn2')!.firstChild!;
+        return { startContainer: text, startOffset: 7, endContainer: text, endOffset: 16 };
+      },
+    );
     expect(cfi).toContain('epubcfi(/6/12!');
   });
 
   it('maps a selection spanning elements in a <dt>/<dd> extraction', () => {
-    roundTrip(dtRun, (popupDoc) => {
-      // from inside the dt text to inside the second dd text
-      const dt = popupDoc.getElementById('dt1')!;
-      const dds = popupDoc.querySelectorAll('dd');
-      const range = popupDoc.createRange();
-      range.setStart(dt.firstChild!, 1);
-      range.setEnd(dds[1]!.firstChild!, 6);
-      return range;
-    });
+    roundTrip(
+      dtRun,
+      (popupDoc) => {
+        // from inside the dt text to inside the second dd text
+        const dt = popupDoc.getElementById('dt1')!;
+        const dds = popupDoc.querySelectorAll('dd');
+        const range = popupDoc.createRange();
+        range.setStart(dt.firstChild!, 1);
+        range.setEnd(dds[1]!.firstChild!, 6);
+        return range;
+      },
+      (pristineDoc) => ({
+        startContainer: pristineDoc.getElementById('dt1')!.firstChild!,
+        startOffset: 1,
+        endContainer: pristineDoc.querySelectorAll('dd')[1]!.firstChild!,
+        endOffset: 6,
+      }),
+    );
   });
 
   it('maps a selection in a paragraph-run extraction (setStartBefore/setEndBefore)', () => {
-    roundTrip(paragraphRun, (popupDoc) => {
-      const p = popupDoc.getElementById('pn1')!;
-      // text node after the <a>: " A paragraph-style note body."
-      const text = p.childNodes[1]!;
-      const range = popupDoc.createRange();
-      range.setStart(text, 3);
-      range.setEnd(text, 12);
-      return range;
-    });
+    roundTrip(
+      paragraphRun,
+      (popupDoc) => {
+        const p = popupDoc.getElementById('pn1')!;
+        // text node after the <a>: " A paragraph-style note body."
+        const text = p.childNodes[1]!;
+        const range = popupDoc.createRange();
+        range.setStart(text, 3);
+        range.setEnd(text, 12);
+        return range;
+      },
+      (pristineDoc) => {
+        const text = pristineDoc.getElementById('pn1')!.childNodes[1]!;
+        return { startContainer: text, startOffset: 3, endContainer: text, endOffset: 12 };
+      },
+    );
+  });
+
+  it('preserves a non-zero element-container end boundary (offsets survive normalization)', () => {
+    roundTrip(
+      dtRun,
+      (popupDoc) => {
+        // End boundary sits ON the <dl>-less popup body at a child index: the
+        // raw CFI step for an element carries no offset, so the boundary must
+        // be pushed into the preceding child's text or it collapses to the
+        // element start and the mapped range loses everything after it.
+        const dt = popupDoc.getElementById('dt1')!;
+        const range = popupDoc.createRange();
+        range.setStart(dt.firstChild!, 0);
+        range.setEnd(popupDoc.body, 2);
+        return range;
+      },
+      (pristineDoc) => {
+        const dt = pristineDoc.getElementById('dt1')!;
+        // body offset 2 is the boundary before the first <dd>, i.e. the end of
+        // the inter-element whitespace that follows <dt> — normalization must
+        // land there rather than collapsing to the container's start.
+        const afterDt = dt.nextSibling as Text;
+        return {
+          startContainer: dt.firstChild!,
+          startOffset: 0,
+          endContainer: afterDt,
+          endOffset: afterDt.data.length,
+        };
+      },
+    );
   });
 
   it('maps a select-all selection (body-level boundaries) via normalization', () => {
@@ -192,6 +262,28 @@ describe('footnote popup CFI mapping', () => {
     outside.setEnd(dt2Text, 5);
     const bookCfi = CFI.joinIndir(BASE_CFI, CFI.fromRange(outside)) as string;
     expect(getFootnoteLocalCfi(bookCfi, mapping, popupDoc)).toBeNull();
+  });
+
+  it('returns null when the selection boundary cannot be pushed below the popup body', () => {
+    const popupDoc = XHTML(SECTION);
+    const mapping = simulatePopup(popupDoc, liContents)!;
+    // An emptied popup body has nothing under it to anchor to, so the mapped
+    // path is the body step alone and there is no fragment-level index to shift.
+    popupDoc.body.replaceChildren();
+    const range = popupDoc.createRange();
+    range.setStart(popupDoc.body, 0);
+    range.collapse(true);
+    expect(getFootnoteSelectionCfi(range, mapping, BASE_CFI)).toBeNull();
+  });
+
+  it('returns null when the container CFI is unparseable', () => {
+    const popupDoc = XHTML(SECTION);
+    const mapping = simulatePopup(popupDoc, liContents)!;
+    const range = popupDoc.createRange();
+    range.selectNodeContents(popupDoc.body.firstChild!);
+    expect(
+      getFootnoteSelectionCfi(range, { ...mapping, containerCfi: 'not a cfi' }, BASE_CFI),
+    ).toBeNull();
   });
 
   it('returns null mapping for a range with text-node boundaries (resolved CFI anchors)', () => {

--- a/apps/readest-app/src/app/reader/components/BooksGrid.tsx
+++ b/apps/readest-app/src/app/reader/components/BooksGrid.tsx
@@ -262,10 +262,13 @@ const BookCellInner: React.FC<BookCellProps> = ({
       </div>
       <BookmarkPullDown bookKey={bookKey} ribbonHidden={!!hoveredBookKey} slideRef={slideRef} />
       <PageNavigationButtons bookKey={bookKey} isDropdownOpen={isDropdownOpen} />
-      <Annotator bookKey={bookKey} contentInsets={contentInsets} />
       <SearchResultsNav bookKey={bookKey} gridInsets={gridInsets} />
       <BooknotesNav bookKey={bookKey} gridInsets={gridInsets} toc={bookDoc.toc || []} />
       <FootnotePopup bookKey={bookKey} bookDoc={bookDoc} />
+      {/* After FootnotePopup so the selection toolbar and lookup popups stack
+          above the footnote popup (and its dismiss overlay) when the user
+          selects text inside it. */}
+      <Annotator bookKey={bookKey} contentInsets={contentInsets} />
       <FooterBar
         bookKey={bookKey}
         bookFormat={book.format}

--- a/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
+++ b/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
@@ -3,8 +3,12 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { MdArrowBack } from 'react-icons/md';
 
 import { BookDoc } from '@/libs/document';
+import { BookNote } from '@/types/book';
+import { useEnv } from '@/context/EnvContext';
 import { useReaderStore } from '@/store/readerStore';
 import { useBookDataStore } from '@/store/bookDataStore';
+import { useSettingsStore } from '@/store/settingsStore';
+import { useThemeStore } from '@/store/themeStore';
 import { useFoliateEvents } from '../hooks/useFoliateEvents';
 import { useCustomFontStore } from '@/store/customFontStore';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
@@ -15,7 +19,13 @@ import { mountAdditionalFonts, mountCustomFont } from '@/styles/fonts';
 import { eventDispatcher } from '@/utils/event';
 import { shouldCheckAsFootnote } from '../utils/footnoteHeuristics';
 import { showTransientHighlight } from '../utils/transientHighlight';
-import { FoliateView } from '@/types/view';
+import { drawAnnotationOverlay } from '../utils/annotatorUtil';
+import {
+  FootnoteExtractMapping,
+  getFootnoteLocalCfi,
+  getFootnoteSelectionCfi,
+} from '../utils/footnoteCfi';
+import { FoliateView, NOTE_PREFIX } from '@/types/view';
 import { isCJKLang } from '@/utils/lang';
 import { Overlay } from '@/components/Overlay';
 import Popup from '@/components/Popup';
@@ -36,6 +46,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
   const [popupPosition, setPopupPosition] = useState<Position | null>();
   const [showPopup, setShowPopup] = useState(false);
 
+  const { appService } = useEnv();
   const { getBookData } = useBookDataStore();
   const { getView, getViewSettings } = useReaderStore();
   const { getLoadedFonts } = useCustomFontStore();
@@ -44,6 +55,19 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
   const [footnoteHandler] = useState(() => new FootnoteHandler());
   const containerRef = useRef<HTMLDivElement>(null);
   const footnoteHrefRef = useRef<string | null>(null);
+  // How the current popup document maps back onto the pristine section (from
+  // the footnote handler's render event), plus the popup document itself once
+  // loaded. Null while no mappable popup is open.
+  const popupMapRef = useRef<{
+    index: number;
+    extract: FootnoteExtractMapping | null;
+    doc?: Document;
+  } | null>(null);
+  // Annotation overlays currently drawn in the popup document, keyed by
+  // booknote id, so the sync effect below can restyle/remove them.
+  const drawnNotesRef = useRef(new Map<string, { value: string; updatedAt: number }>());
+  const [popupContentEpoch, setPopupContentEpoch] = useState(0);
+  const booknotes = useBookDataStore((s) => s.booksData[bookKey.split('-')[0]!]?.config?.booknotes);
   const historyRef = useRef<{ items: Record<string, unknown>[]; index: number }>({
     items: [],
     index: -1,
@@ -136,11 +160,102 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
         });
       });
       view.addEventListener('load', (e: CustomEvent) => {
-        const { doc } = e.detail;
+        const { doc, index } = e.detail as { doc: Document; index: number };
         const bookData = getBookData(bookKey)!;
         mountAdditionalFonts(doc, isCJKLang(bookData.book?.primaryLanguage));
         getLoadedFonts().forEach((font) => {
           mountCustomFont(doc, font);
+        });
+
+        // Surface text selections made inside the popup document to the
+        // Annotator. The CFI is mapped into the pristine section when the
+        // extraction mapping allows it; without one the toolbar still shows,
+        // with the CFI-dependent tools disabled.
+        const report = () => {
+          if (!doc.defaultView) return; // popup already torn down
+          const sel = doc.getSelection();
+          if (!sel || sel.isCollapsed || !sel.toString().trim()) {
+            eventDispatcher.dispatch('footnote-selection', { key: bookKey });
+            return;
+          }
+          const range = sel.getRangeAt(0);
+          const info = popupMapRef.current;
+          const extract = info && info.index === index ? info.extract : null;
+          const cfi = extract
+            ? (getFootnoteSelectionCfi(range, extract, view.getCFI(index)) ?? undefined)
+            : undefined;
+          eventDispatcher.dispatch('footnote-selection', {
+            key: bookKey,
+            range,
+            index,
+            cfi,
+            href: footnoteHrefRef.current?.split('#')[0],
+          });
+        };
+        let selectionTimer: ReturnType<typeof setTimeout> | null = null;
+        doc.addEventListener('selectionchange', () => {
+          if (selectionTimer) clearTimeout(selectionTimer);
+          selectionTimer = setTimeout(report, 250);
+        });
+        doc.addEventListener('pointerup', () => {
+          if (selectionTimer) clearTimeout(selectionTimer);
+          report();
+        });
+        if (appService?.isMobile) {
+          // Same as the main view: the selection handles suffice on mobile.
+          doc.addEventListener('contextmenu', (ev: Event) => ev.preventDefault());
+        }
+
+        const info = popupMapRef.current;
+        if (info && info.index === index) {
+          popupMapRef.current = { ...info, doc };
+        }
+        setPopupContentEpoch((epoch) => epoch + 1);
+      });
+      // Style callback for annotation overlays drawn in the popup document
+      // (the annotation-sync effect below adds them with mapped local CFIs).
+      view.addEventListener('draw-annotation', (e: Event) => {
+        const viewSettings = getViewSettings(bookKey)!;
+        drawAnnotationOverlay((e as CustomEvent).detail, {
+          settings: useSettingsStore.getState().settings,
+          viewSettings,
+          isDarkMode: useThemeStore.getState().isDarkMode,
+          isMobile: !!appService?.isMobile,
+        });
+      });
+      // A click on a drawn overlay reports the popup-local value; map it back
+      // to its booknote and open the toolbar in the annotated state so the
+      // highlight can be restyled or deleted, like in the main view.
+      view.addEventListener('show-annotation', (e: Event) => {
+        const detail = (e as CustomEvent).detail as {
+          value: string;
+          index: number;
+          range: Range;
+          rect?: { left: number; right: number; top: number; bottom: number };
+        };
+        let noteId: string | null = null;
+        for (const [key, drawn] of drawnNotesRef.current) {
+          if (drawn.value === detail.value) {
+            noteId = key.split('#')[0]!;
+            break;
+          }
+        }
+        if (!noteId) return;
+        const shard = bookKey.split('-')[0]!;
+        const note = (useBookDataStore.getState().booksData[shard]?.config?.booknotes ?? []).find(
+          (n) => n.id === noteId && !n.deletedAt,
+        );
+        if (!note) return;
+        const isNote = detail.value.startsWith(NOTE_PREFIX);
+        eventDispatcher.dispatch('footnote-selection', {
+          key: bookKey,
+          range: detail.range,
+          index: detail.index,
+          cfi: note.cfi,
+          href: footnoteHrefRef.current?.split('#')[0],
+          annotated: true,
+          isNote,
+          rect: isNote ? detail.rect : undefined,
         });
       });
       footnoteViewRef.current = view;
@@ -171,8 +286,12 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     const handleRender = (e: Event) => {
       const detail = (e as CustomEvent).detail;
       // console.log('render footnote', detail);
-      const { view, href } = detail;
+      const { view, href, index, extract } = detail;
       footnoteHrefRef.current = href;
+      popupMapRef.current = { index: index ?? -1, extract: extract ?? null };
+      drawnNotesRef.current.clear();
+      // A new popup document invalidates any selection made in the previous one
+      eventDispatcher.dispatch('footnote-selection', { key: bookKey });
       sizeAdjustCountRef.current = 0;
       view.addEventListener('relocate', () => {
         if (sizeAdjustCountRef.current >= maxSizeAdjustCount) return;
@@ -304,6 +423,9 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
 
   const handleDismissPopup = () => {
     closePopup();
+    popupMapRef.current = null;
+    drawnNotesRef.current.clear();
+    eventDispatcher.dispatch('footnote-selection', { key: bookKey });
     historyRef.current = { items: [], index: -1 };
     canGoBackRef.current = false;
     sizeAdjustCountRef.current = 0;
@@ -322,6 +444,12 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     const { element, footnote } = event.detail;
     const gridFrame = document.querySelector(`#gridcell-${bookKey}`);
     if (!gridFrame) return;
+    // This popup shows text synthesized from a data/alt attribute in the host
+    // document: there is no book document behind it, so no CFI mapping.
+    footnoteViewRef.current = null;
+    popupMapRef.current = null;
+    drawnNotesRef.current.clear();
+    eventDispatcher.dispatch('footnote-selection', { key: bookKey });
     const rect = gridFrame.getBoundingClientRect();
     const viewSettings = getViewSettings(bookKey)!;
     const triangPos = getPosition(element, rect, popupPadding, viewSettings.vertical);
@@ -373,6 +501,78 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       footnoteRef.current?.replaceChildren(footnoteViewRef.current);
     }
   }, [footnoteRef]);
+
+  // Mirror the book's highlight annotations into the popup document: draw the
+  // ones whose CFIs map into the extracted fragment, keep them in sync as the
+  // user highlights/restyles/deletes via the selection toolbar, and remove
+  // overlays whose records are gone. The popup view resolves the mapped local
+  // CFI itself and calls the draw-annotation listener registered above.
+  useEffect(() => {
+    const view = footnoteViewRef.current;
+    const info = popupMapRef.current;
+    const doc = info?.doc;
+    if (!showPopup || !view || !doc || !info.extract) return;
+    const drawn = drawnNotesRef.current;
+    const seen = new Set<string>();
+    // A unified record draws two overlays like in the main view: the
+    // highlight (value = local cfi, keyed by id) and the note bubble
+    // (value = NOTE_PREFIX + local cfi, keyed by `id#note`).
+    const upsert = (key: string, value: string, note: BookNote) => {
+      seen.add(key);
+      const prev = drawn.get(key);
+      if (prev && prev.updatedAt === note.updatedAt && prev.value === value) return;
+      if (prev && prev.value !== value) {
+        view.addAnnotation({ ...note, value: prev.value }, true);
+      }
+      view.addAnnotation({ ...note, value });
+      drawn.set(key, { value, updatedAt: note.updatedAt });
+    };
+    for (const note of booknotes ?? []) {
+      if (note.type !== 'annotation' || note.deletedAt || (!note.style && !note.note)) continue;
+      const value = getFootnoteLocalCfi(note.cfi, info.extract, doc);
+      if (!value) continue;
+      if (note.style) upsert(note.id, value, note);
+      if (note.note) upsert(`${note.id}#note`, `${NOTE_PREFIX}${value}`, note);
+    }
+    for (const [key, prev] of drawn) {
+      if (seen.has(key)) continue;
+      view.addAnnotation({ value: prev.value } as BookNote & { value: string }, true);
+      drawn.delete(key);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [booknotes, showPopup, popupContentEpoch]);
+
+  // Data-attribute footnotes render a plain <p> in the host document; watch
+  // the host selection while such a popup is open and surface it to the
+  // Annotator (without a CFI — synthesized text has no anchor in the book).
+  useEffect(() => {
+    if (!showPopup) return undefined;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let hadSelection = false;
+    const report = () => {
+      if (footnoteViewRef.current) return; // a real footnote popup owns its own doc
+      const container = footnoteRef.current;
+      const sel = document.getSelection();
+      if (!container || !sel) return;
+      const range = sel.isCollapsed || !sel.toString().trim() ? null : sel.getRangeAt(0);
+      if (range && container.contains(range.commonAncestorContainer)) {
+        hadSelection = true;
+        eventDispatcher.dispatch('footnote-selection', { key: bookKey, range, index: -1 });
+      } else if (hadSelection) {
+        hadSelection = false;
+        eventDispatcher.dispatch('footnote-selection', { key: bookKey });
+      }
+    };
+    const onSelectionChange = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(report, 250);
+    };
+    document.addEventListener('selectionchange', onSelectionChange);
+    return () => {
+      if (timer) clearTimeout(timer);
+      document.removeEventListener('selectionchange', onSelectionChange);
+    };
+  }, [showPopup, bookKey]);
 
   return (
     <div ref={containerRef} role='toolbar' tabIndex={-1}>

--- a/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
+++ b/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
@@ -17,6 +17,7 @@ import { getPopupPosition, getPosition, Position } from '@/utils/sel';
 import { FootnoteHandler } from 'foliate-js/footnotes.js';
 import { mountAdditionalFonts, mountCustomFont } from '@/styles/fonts';
 import { eventDispatcher } from '@/utils/event';
+import { getCfiSpinePrefix } from '@/utils/cfi';
 import { shouldCheckAsFootnote } from '../utils/footnoteHeuristics';
 import { showTransientHighlight } from '../utils/transientHighlight';
 import { drawAnnotationOverlay } from '../utils/annotatorUtil';
@@ -68,6 +69,17 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
   const drawnNotesRef = useRef(new Map<string, { value: string; updatedAt: number }>());
   const [popupContentEpoch, setPopupContentEpoch] = useState(0);
   const booknotes = useBookDataStore((s) => s.booksData[bookKey.split('-')[0]!]?.config?.booknotes);
+
+  // Point the popup at a new (or no) source document: drop the CFI mapping and
+  // the drawn-overlay bookkeeping, and tell the Annotator that any selection
+  // made in the previous popup document is gone.
+  const resetPopupAnnotationState = (
+    map: { index: number; extract: FootnoteExtractMapping | null; doc?: Document } | null = null,
+  ) => {
+    popupMapRef.current = map;
+    drawnNotesRef.current.clear();
+    eventDispatcher.dispatch('footnote-selection', { key: bookKey });
+  };
   const historyRef = useRef<{ items: Record<string, unknown>[]; index: number }>({
     items: [],
     index: -1,
@@ -138,8 +150,8 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     };
     const handleBeforeRender = (e: Event) => {
       const detail = (e as CustomEvent).detail;
-      const { view } = detail;
-      view.addEventListener('link', (e: Event) => {
+      const { view: popupView } = detail;
+      popupView.addEventListener('link', (e: Event) => {
         e.preventDefault();
         const { detail: popupLinkDetail } = e as CustomEvent;
         const footnoteAnchorId = getHashFromHref(footnoteHrefRef.current);
@@ -159,7 +171,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
           setShowPopup(false);
         });
       });
-      view.addEventListener('load', (e: CustomEvent) => {
+      popupView.addEventListener('load', (e: CustomEvent) => {
         const { doc, index } = e.detail as { doc: Document; index: number };
         const bookData = getBookData(bookKey)!;
         mountAdditionalFonts(doc, isCJKLang(bookData.book?.primaryLanguage));
@@ -182,7 +194,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
           const info = popupMapRef.current;
           const extract = info && info.index === index ? info.extract : null;
           const cfi = extract
-            ? (getFootnoteSelectionCfi(range, extract, view.getCFI(index)) ?? undefined)
+            ? (getFootnoteSelectionCfi(range, extract, popupView.getCFI(index)) ?? undefined)
             : undefined;
           eventDispatcher.dispatch('footnote-selection', {
             key: bookKey,
@@ -214,7 +226,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       });
       // Style callback for annotation overlays drawn in the popup document
       // (the annotation-sync effect below adds them with mapped local CFIs).
-      view.addEventListener('draw-annotation', (e: Event) => {
+      popupView.addEventListener('draw-annotation', (e: Event) => {
         const viewSettings = getViewSettings(bookKey)!;
         drawAnnotationOverlay((e as CustomEvent).detail, {
           settings: useSettingsStore.getState().settings,
@@ -226,7 +238,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       // A click on a drawn overlay reports the popup-local value; map it back
       // to its booknote and open the toolbar in the annotated state so the
       // highlight can be restyled or deleted, like in the main view.
-      view.addEventListener('show-annotation', (e: Event) => {
+      popupView.addEventListener('show-annotation', (e: Event) => {
         const detail = (e as CustomEvent).detail as {
           value: string;
           index: number;
@@ -258,9 +270,9 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
           rect: isNote ? detail.rect : undefined,
         });
       });
-      footnoteViewRef.current = view;
-      footnoteRef.current?.replaceChildren(view);
-      const { renderer } = view;
+      footnoteViewRef.current = popupView;
+      footnoteRef.current?.replaceChildren(popupView);
+      const { renderer } = popupView;
       const viewSettings = getViewSettings(bookKey)!;
       const backButtonMargin = canGoBackRef.current ? 32 : 0;
       renderer.setAttribute('flow', 'scrolled');
@@ -288,10 +300,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       // console.log('render footnote', detail);
       const { view, href, index, extract } = detail;
       footnoteHrefRef.current = href;
-      popupMapRef.current = { index: index ?? -1, extract: extract ?? null };
-      drawnNotesRef.current.clear();
-      // A new popup document invalidates any selection made in the previous one
-      eventDispatcher.dispatch('footnote-selection', { key: bookKey });
+      resetPopupAnnotationState({ index: index ?? -1, extract: extract ?? null });
       sizeAdjustCountRef.current = 0;
       view.addEventListener('relocate', () => {
         if (sizeAdjustCountRef.current >= maxSizeAdjustCount) return;
@@ -423,9 +432,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
 
   const handleDismissPopup = () => {
     closePopup();
-    popupMapRef.current = null;
-    drawnNotesRef.current.clear();
-    eventDispatcher.dispatch('footnote-selection', { key: bookKey });
+    resetPopupAnnotationState();
     historyRef.current = { items: [], index: -1 };
     canGoBackRef.current = false;
     sizeAdjustCountRef.current = 0;
@@ -447,9 +454,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     // This popup shows text synthesized from a data/alt attribute in the host
     // document: there is no book document behind it, so no CFI mapping.
     footnoteViewRef.current = null;
-    popupMapRef.current = null;
-    drawnNotesRef.current.clear();
-    eventDispatcher.dispatch('footnote-selection', { key: bookKey });
+    resetPopupAnnotationState();
     const rect = gridFrame.getBoundingClientRect();
     const viewSettings = getViewSettings(bookKey)!;
     const triangPos = getPosition(element, rect, popupPadding, viewSettings.vertical);
@@ -527,8 +532,16 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       view.addAnnotation({ ...note, value });
       drawn.set(key, { value, updatedAt: note.updatedAt });
     };
+    // Only notes anchored in the popup's own section can map into it, and a
+    // heavy library carries thousands elsewhere. Reject those with a pure
+    // string compare of the spine prefix (id assertions stripped, since a
+    // foreign/imported CFI may spell them differently) before paying for the
+    // parse and DOM work inside getFootnoteLocalCfi.
+    const stripAssertions = (prefix: string | null) => prefix?.replace(/\[[^\]]*\]/g, '') ?? null;
+    const sectionPrefix = stripAssertions(getCfiSpinePrefix(view.getCFI(info.index)));
     for (const note of booknotes ?? []) {
       if (note.type !== 'annotation' || note.deletedAt || (!note.style && !note.note)) continue;
+      if (sectionPrefix && stripAssertions(getCfiSpinePrefix(note.cfi)) !== sectionPrefix) continue;
       const value = getFootnoteLocalCfi(note.cfi, info.extract, doc);
       if (!value) continue;
       if (note.style) upsert(note.id, value, note);
@@ -567,10 +580,18 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       if (timer) clearTimeout(timer);
       timer = setTimeout(report, 250);
     };
+    // Report the finished drag immediately instead of waiting out the debounce,
+    // matching the popup-document path.
+    const onPointerUp = () => {
+      if (timer) clearTimeout(timer);
+      report();
+    };
     document.addEventListener('selectionchange', onSelectionChange);
+    document.addEventListener('pointerup', onPointerUp);
     return () => {
       if (timer) clearTimeout(timer);
       document.removeEventListener('selectionchange', onSelectionChange);
+      document.removeEventListener('pointerup', onPointerUp);
     };
   }, [showPopup, bookKey]);
 

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { RiDeleteBinLine } from 'react-icons/ri';
 
 import * as CFI from 'foliate-js/epubcfi.js';
-import { Overlayer } from 'foliate-js/overlayer.js';
 import { useEnv } from '@/context/EnvContext';
 import {
   BookNote,
@@ -66,9 +65,7 @@ import { TransformContext } from '@/services/transformers/types';
 import { transformContent } from '@/services/transformService';
 import {
   buildTTSSentenceHighlight,
-  decideAnnotationDraw,
-  getAnnotationOverlayColor,
-  getHighlightColorHex,
+  drawAnnotationOverlay,
   mergeRestyledAnnotation,
   removeBookNoteOverlays,
 } from '../../utils/annotatorUtil';
@@ -364,8 +361,102 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
   const handleDismissPopupAndSelection = () => {
     handleDismissPopup();
     view?.deselect();
+    // A popup-window selection lives in its own document (the footnote popup
+    // view's iframe or the host document), which view.deselect() can't reach.
+    if (selection?.popup) {
+      selection.range.startContainer.ownerDocument?.getSelection()?.removeAllRanges();
+    }
     isTextSelected.current = false;
   };
+
+  // Whether the currently shown selection came from the footnote popup, for
+  // event handlers that only know the incoming event, not the selection state.
+  const selectionIsPopupRef = useRef(false);
+  useEffect(() => {
+    selectionIsPopupRef.current = !!selection?.popup;
+  }, [selection]);
+
+  // Selections made inside the footnote popup window (FootnotePopup) arrive
+  // via this event: the popup renders its own foliate view (or a host-document
+  // element for data-attribute footnotes), so the per-section listeners
+  // attached in onLoad below never see them. A detail without a range means
+  // the popup selection was cleared or the popup closed.
+  useEffect(() => {
+    const onFootnoteSelection = async (event: CustomEvent) => {
+      const detail = event.detail as {
+        key: string;
+        range?: Range;
+        index?: number;
+        cfi?: string;
+        href?: string;
+        annotated?: boolean;
+        isNote?: boolean;
+        rect?: TextSelection['rect'];
+      };
+      if (detail.key !== bookKey) return;
+      if (!detail.range) {
+        if (selectionIsPopupRef.current) handleDismissPopup();
+        return;
+      }
+      // A click on an overlay drawn in the popup: a highlight opens the
+      // toolbar in its annotated state (Delete Highlight + style options), a
+      // note bubble opens the note view — like the same clicks in the main
+      // view, minus the range-edit handles, which only operate on main view
+      // documents.
+      if (detail.annotated && detail.cfi) {
+        const { booknotes = [] } = getConfig(bookKey)!;
+        const annotation = booknotes.find(
+          (b) =>
+            b.type === 'annotation' &&
+            !b.deletedAt &&
+            b.cfi === detail.cfi &&
+            (detail.isNote ? b.note : b.style),
+        );
+        if (annotation) {
+          if (detail.isNote) {
+            setShowAnnotationNotes(true);
+            setHighlightOptionsVisible(false);
+          } else {
+            if (annotation.style && annotation.color) {
+              setSelectedStyle(annotation.style);
+              setSelectedColor(annotation.color);
+            }
+            setShowAnnotationNotes(false);
+            setAnnotationNotes([]);
+          }
+          setEditingAnnotation(null);
+          setSelection({
+            key: bookKey,
+            text: annotation.text || (await getAnnotationText(detail.range)),
+            range: detail.range,
+            index: detail.index ?? -1,
+            cfi: detail.cfi,
+            href: detail.href,
+            rect: detail.isNote ? detail.rect : undefined,
+            page: annotation.page ?? getBookProgress(bookKey)?.page ?? 0,
+            annotated: true,
+            popup: true,
+          });
+          return;
+        }
+      }
+      setSelection({
+        key: bookKey,
+        text: await getAnnotationText(detail.range),
+        range: detail.range,
+        index: detail.index ?? -1,
+        cfi: detail.cfi,
+        href: detail.href,
+        page: getBookProgress(bookKey)?.page ?? 0,
+        popup: true,
+      });
+    };
+    eventDispatcher.on('footnote-selection', onFootnoteSelection);
+    return () => {
+      eventDispatcher.off('footnote-selection', onFootnoteSelection);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bookKey]);
 
   const onLoad = (event: Event) => {
     const detail = (event as CustomEvent).detail;
@@ -502,47 +593,12 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
 
   const onDrawAnnotation = (event: Event) => {
     const viewSettings = getViewSettings(bookKey)!;
-    const isBwEink = viewSettings.isEink && !viewSettings.isColorEink;
-    const detail = (event as CustomEvent).detail;
-    const { draw, annotation, doc, range } = detail;
-    const { style, color } = annotation as BookNote;
-    const value = (annotation as BookNote & { value?: string }).value;
-    const hexColor = getHighlightColorHex(settings, color);
-    // Choose what to draw from the overlay's `value` (cfi vs NOTE_PREFIX+cfi),
-    // not from `annotation.note`: a unified record (style + note) is added as
-    // two overlays and must draw a highlight for the cfi overlay AND a bubble
-    // for the note overlay. Keying off `note` drew only the bubble (#4511).
-    const kind = decideAnnotationDraw(value, style);
-    if (kind === 'bubble') {
-      const { defaultView } = doc;
-      const node = range.startContainer;
-      const el = node.nodeType === 1 ? node : node.parentElement;
-      const { writingMode } = defaultView.getComputedStyle(el);
-      draw(Overlayer.bubble, { writingMode });
-    } else if (kind === 'highlight') {
-      draw(Overlayer.highlight, {
-        color: getAnnotationOverlayColor('highlight', hexColor, { isBwEink, isDarkMode }),
-        vertical: viewSettings.vertical,
-      });
-    } else if (kind === 'underline' || kind === 'squiggly') {
-      const { defaultView } = doc;
-      const node = range.startContainer;
-      const el = node.nodeType === 1 ? node : node.parentElement;
-      const { writingMode, lineHeight, fontSize } = defaultView.getComputedStyle(el);
-      const fontSizeValue = parseFloat(fontSize) || viewSettings.defaultFontSize;
-      const lineHeightValue = parseFloat(lineHeight) || viewSettings.lineHeight * fontSizeValue;
-      const strokeWidth = 2;
-      const verticalCompensation = appService?.isMobile ? 0 : -1;
-      const horizontalCompensation = appService?.isMobile ? -1 : 0;
-      const padding = viewSettings.vertical
-        ? (lineHeightValue - fontSizeValue) / 2 - strokeWidth + verticalCompensation
-        : (lineHeightValue - fontSizeValue) / 2 - strokeWidth + horizontalCompensation;
-      draw(Overlayer[kind], {
-        writingMode,
-        color: getAnnotationOverlayColor(kind, hexColor, { isBwEink, isDarkMode }),
-        padding,
-      });
-    }
+    drawAnnotationOverlay((event as CustomEvent).detail, {
+      settings,
+      viewSettings,
+      isDarkMode,
+      isMobile: !!appService?.isMobile,
+    });
   };
 
   const onShowAnnotation = (event: Event) => {
@@ -1158,7 +1214,10 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     });
 
     const { booknotes: annotations = [] } = config;
-    const cfi = view?.getCFI(selection.index, selection.range);
+    // A popup-window range is not in a main view document; use the CFI the
+    // popup mapped into the pristine section (absent for data-attribute
+    // footnotes, which have no real text node to anchor to).
+    const cfi = selection.popup ? selection.cfi : view?.getCFI(selection.index, selection.range);
     if (!cfi) return;
     const annotation: BookNote = {
       id: uniqueId(),
@@ -1196,7 +1255,8 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
   // required to be present.
   const handleCopyLink = () => {
     if (!selection) return;
-    const cfi = selection.cfi || view?.getCFI(selection.index, selection.range);
+    const cfi =
+      selection.cfi || (selection.popup ? null : view?.getCFI(selection.index, selection.range));
     if (!cfi) return;
     const noteId = config.booknotes?.find((note) => note.cfi === cfi && !note.deletedAt)?.id;
     const linkType = viewSettings.noteExportConfig?.linkType ?? DEFAULT_NOTE_EXPORT_CONFIG.linkType;
@@ -1231,7 +1291,9 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     if (!selection || !selection.text) return null;
     setHighlightOptionsVisible(true);
     const { booknotes: annotations = [] } = config;
-    const cfi = view?.getCFI(selection.index, selection.range);
+    // Popup-window selections carry the CFI mapped into the pristine section;
+    // recomputing from the popup range would yield an unresolvable path.
+    const cfi = selection.popup ? selection.cfi : view?.getCFI(selection.index, selection.range);
     if (!cfi) return null;
     const style = highlightStyle || settings.globalReadSettings.highlightStyle;
     const color = settings.globalReadSettings.highlightStyles[style];
@@ -1363,8 +1425,12 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
 
   const handleAnnotate = () => {
     if (!selection || !selection.text) return;
-    const { sectionHref: href } = progress;
-    selection.href = href;
+    // A popup selection already carries the footnote target's href; the
+    // current reading position would file the note under the wrong section.
+    if (!selection.popup) {
+      const { sectionHref: href } = progress;
+      selection.href = href;
+    }
     const created = handleHighlight(true);
     setNotebookVisible(true);
     setNotebookNewAnnotation(selection);
@@ -1422,6 +1488,9 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
 
   const handleSpeakText = async (oneTime = false) => {
     if (!selection || !selection.text) return;
+    // TTS walks the main view's documents; a popup-window range can't seed it
+    // (the toolbar button is disabled, this guards the keyboard shortcut).
+    if (selection.popup) return;
     setShowAnnotPopup(false);
     setEditingAnnotation(null);
     eventDispatcher.dispatch('tts-speak', {
@@ -1444,6 +1513,9 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
       setProofreadRulesVisibility(true);
       return;
     }
+    // Proofread rules anchor to a CFI; a popup selection without one (data-
+    // attribute footnotes) has nothing to attach to.
+    if (selection.popup && !selection.cfi) return;
     setShowAnnotPopup(false);
     setShowProofreadPopup(true);
 
@@ -1901,6 +1973,10 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     !!selection?.text &&
     selection.text.trim().length > 0;
   const globalToggleActive = !!currentAnnotation?.global;
+  // A popup-window selection without a CFI (data-attribute footnotes render
+  // synthesized text with no real text node in the book) can't anchor
+  // anything; and TTS always needs a range in a main view document.
+  const popupSelectionNoCfi = !!selection?.popup && !selection?.cfi;
   const buildToolButton = (type: AnnotationToolType) => {
     const def = annotationToolButtons.find((button) => button.type === type);
     if (!def) return null;
@@ -1909,15 +1985,26 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
       case 'copy':
         return { tooltipText: _(label), Icon, onClick: handleCopy };
       case 'copylink':
-        return { tooltipText: _(label), Icon, onClick: handleCopyLink };
+        return {
+          tooltipText: _(label),
+          Icon,
+          onClick: handleCopyLink,
+          disabled: popupSelectionNoCfi,
+        };
       case 'highlight':
         return {
           tooltipText: selectionAnnotated ? _('Delete Highlight') : _(label),
           Icon: selectionAnnotated ? RiDeleteBinLine : Icon,
           onClick: handleHighlight,
+          disabled: popupSelectionNoCfi,
         };
       case 'annotate':
-        return { tooltipText: _(label), Icon, onClick: handleAnnotate };
+        return {
+          tooltipText: _(label),
+          Icon,
+          onClick: handleAnnotate,
+          disabled: popupSelectionNoCfi,
+        };
       case 'search':
         return { tooltipText: _(label), Icon, onClick: handleSearch };
       case 'dictionary':
@@ -1925,13 +2012,18 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
       case 'translate':
         return { tooltipText: _(label), Icon, onClick: handleTranslation };
       case 'tts':
-        return { tooltipText: _(label), Icon, onClick: handleSpeakText };
+        return {
+          tooltipText: _(label),
+          Icon,
+          onClick: handleSpeakText,
+          disabled: !!selection?.popup,
+        };
       case 'proofread':
         return {
           tooltipText: _(label),
           Icon,
           onClick: handleProofread,
-          disabled: !supportsProofread(bookData.book?.format),
+          disabled: !supportsProofread(bookData.book?.format) || popupSelectionNoCfi,
         };
       case 'share':
         return { tooltipText: _(label), Icon, onClick: handleShare };

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -381,6 +381,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
   // element for data-attribute footnotes), so the per-section listeners
   // attached in onLoad below never see them. A detail without a range means
   // the popup selection was cleared or the popup closed.
+  const footnoteSelectionEpochRef = useRef(0);
   useEffect(() => {
     const onFootnoteSelection = async (event: CustomEvent) => {
       const detail = event.detail as {
@@ -394,6 +395,10 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
         rect?: TextSelection['rect'];
       };
       if (detail.key !== bookKey) return;
+      // Every event for this book advances the epoch so a handler still
+      // awaiting getAnnotationText below can detect it was superseded — a
+      // cleared or newer selection must not be overwritten by stale state.
+      const epoch = ++footnoteSelectionEpochRef.current;
       if (!detail.range) {
         if (selectionIsPopupRef.current) handleDismissPopup();
         return;
@@ -413,6 +418,8 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
             (detail.isNote ? b.note : b.style),
         );
         if (annotation) {
+          const text = annotation.text || (await getAnnotationText(detail.range));
+          if (epoch !== footnoteSelectionEpochRef.current) return;
           if (detail.isNote) {
             setShowAnnotationNotes(true);
             setHighlightOptionsVisible(false);
@@ -427,7 +434,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
           setEditingAnnotation(null);
           setSelection({
             key: bookKey,
-            text: annotation.text || (await getAnnotationText(detail.range)),
+            text,
             range: detail.range,
             index: detail.index ?? -1,
             cfi: detail.cfi,
@@ -440,9 +447,11 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
           return;
         }
       }
+      const text = await getAnnotationText(detail.range);
+      if (epoch !== footnoteSelectionEpochRef.current) return;
       setSelection({
         key: bookKey,
-        text: await getAnnotationText(detail.range),
+        text,
         range: detail.range,
         index: detail.index ?? -1,
         cfi: detail.cfi,
@@ -1206,6 +1215,13 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
 
     if (!viewSettings?.copyToNotebook) return;
 
+    // A popup-window range is not in a main view document; use the CFI the
+    // popup mapped into the pristine section (absent for data-attribute
+    // footnotes, which have no real text node to anchor to). Resolve it
+    // before the toast so an unanchorable excerpt isn't reported as saved.
+    const cfi = selection.popup ? selection.cfi : view?.getCFI(selection.index, selection.range);
+    if (!cfi) return;
+
     eventDispatcher.dispatch('toast', {
       type: 'info',
       message: _('Copied to notebook'),
@@ -1214,11 +1230,6 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     });
 
     const { booknotes: annotations = [] } = config;
-    // A popup-window range is not in a main view document; use the CFI the
-    // popup mapped into the pristine section (absent for data-attribute
-    // footnotes, which have no real text node to anchor to).
-    const cfi = selection.popup ? selection.cfi : view?.getCFI(selection.index, selection.range);
-    if (!cfi) return;
     const annotation: BookNote = {
       id: uniqueId(),
       type: 'excerpt',
@@ -1425,6 +1436,9 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
 
   const handleAnnotate = () => {
     if (!selection || !selection.text) return;
+    // A popup selection without a CFI has nothing to anchor a note to (the
+    // toolbar button is disabled, this guards the keyboard shortcut).
+    if (selection.popup && !selection.cfi) return;
     // A popup selection already carries the footnote target's href; the
     // current reading position would file the note under the wrong section.
     if (!selection.popup) {

--- a/apps/readest-app/src/app/reader/components/notebook/Notebook.tsx
+++ b/apps/readest-app/src/app/reader/components/notebook/Notebook.tsx
@@ -207,7 +207,11 @@ const Notebook: React.FC = ({}) => {
     const view = getView(sideBarBookKey);
     const config = getConfig(sideBarBookKey)!;
 
-    const cfi = view?.getCFI(selection.index, selection.range);
+    // A footnote-popup selection's range lives in the popup document, not a
+    // main view section; recomputing here would yield an unresolvable CFI
+    // that misses the existing highlight and forks a second record. Use the
+    // CFI the popup already mapped into the pristine section.
+    const cfi = selection.popup ? selection.cfi : view?.getCFI(selection.index, selection.range);
     if (!cfi) return;
 
     const { booknotes: annotations = [] } = config;

--- a/apps/readest-app/src/app/reader/utils/annotatorUtil.ts
+++ b/apps/readest-app/src/app/reader/utils/annotatorUtil.ts
@@ -1,3 +1,4 @@
+import { Overlayer } from 'foliate-js/overlayer.js';
 import { HIGHLIGHT_COLOR_HEX } from '@/services/constants';
 import {
   BookNote,
@@ -5,6 +6,7 @@ import {
   DEFAULT_HIGHLIGHT_COLORS,
   HighlightColor,
   HighlightStyle,
+  ViewSettings,
 } from '@/types/book';
 import { uniqueId } from '@/utils/misc';
 import { SystemSettings } from '@/types/settings';
@@ -360,6 +362,65 @@ export function decideAnnotationDraw(
   if (style === 'highlight') return 'highlight';
   if (style === 'underline' || style === 'squiggly') return style;
   return 'none';
+}
+
+/**
+ * Style callback for foliate's `draw-annotation` overlay event. Shared by the
+ * main view (Annotator) and the footnote popup view (FootnotePopup, which
+ * draws mapped copies of annotations inside the popup document).
+ */
+export function drawAnnotationOverlay(
+  detail: {
+    draw: (func: unknown, opts?: Record<string, unknown>) => void;
+    annotation: BookNote & { value?: string };
+    doc: Document;
+    range: Range;
+  },
+  ctx: {
+    settings: SystemSettings;
+    viewSettings: ViewSettings;
+    isDarkMode: boolean;
+    isMobile: boolean;
+  },
+): void {
+  const { draw, annotation, doc, range } = detail;
+  const { settings, viewSettings, isDarkMode, isMobile } = ctx;
+  const isBwEink = viewSettings.isEink && !viewSettings.isColorEink;
+  const { style, color, value } = annotation;
+  const hexColor = getHighlightColorHex(settings, color);
+  // Choose what to draw from the overlay's `value` (cfi vs NOTE_PREFIX+cfi),
+  // not from `annotation.note`: a unified record (style + note) is added as
+  // two overlays and must draw a highlight for the cfi overlay AND a bubble
+  // for the note overlay. Keying off `note` drew only the bubble (#4511).
+  const kind = decideAnnotationDraw(value, style);
+  const startElement = () => {
+    const node = range.startContainer;
+    return node.nodeType === 1 ? (node as Element) : node.parentElement!;
+  };
+  if (kind === 'bubble') {
+    const { writingMode } = doc.defaultView!.getComputedStyle(startElement());
+    draw(Overlayer.bubble, { writingMode });
+  } else if (kind === 'highlight') {
+    draw(Overlayer.highlight, {
+      color: getAnnotationOverlayColor('highlight', hexColor, { isBwEink, isDarkMode }),
+      vertical: viewSettings.vertical,
+    });
+  } else if (kind === 'underline' || kind === 'squiggly') {
+    const { writingMode, lineHeight, fontSize } = doc.defaultView!.getComputedStyle(startElement());
+    const fontSizeValue = parseFloat(fontSize) || viewSettings.defaultFontSize;
+    const lineHeightValue = parseFloat(lineHeight) || viewSettings.lineHeight * fontSizeValue;
+    const strokeWidth = 2;
+    const verticalCompensation = isMobile ? 0 : -1;
+    const horizontalCompensation = isMobile ? -1 : 0;
+    const padding = viewSettings.vertical
+      ? (lineHeightValue - fontSizeValue) / 2 - strokeWidth + verticalCompensation
+      : (lineHeightValue - fontSizeValue) / 2 - strokeWidth + horizontalCompensation;
+    draw(Overlayer[kind], {
+      writingMode,
+      color: getAnnotationOverlayColor(kind, hexColor, { isBwEink, isDarkMode }),
+      padding,
+    });
+  }
 }
 
 /**

--- a/apps/readest-app/src/app/reader/utils/footnoteCfi.ts
+++ b/apps/readest-app/src/app/reader/utils/footnoteCfi.ts
@@ -40,9 +40,11 @@ const boundaryParts = (node: Node, offset: number): CfiPart[] | null => {
 };
 
 // Element-container boundaries lose their child offset when serialized (CFI
-// offsets only apply to character-data steps), so a boundary sitting on the
-// popup <body> itself (e.g. a select-all) must be pushed down into the
-// nearest text position before mapping.
+// offsets only apply to character-data steps), so any boundary sitting on an
+// element (a select-all on <body>, a triple-click ending on a block, ...)
+// must be pushed down to the equivalent text position before mapping —
+// otherwise the CFI resolves at the element's start instead of the child
+// offset the boundary meant.
 const descendToStart = (node: Node): [Node, number] => {
   let n: Node = node;
   while (n.nodeType === Node.ELEMENT_NODE && n.firstChild) n = n.firstChild;
@@ -55,16 +57,18 @@ const descendToEnd = (node: Node): [Node, number] => {
   return [n, n.nodeType === Node.TEXT_NODE ? (n.nodeValue?.length ?? 0) : n.childNodes.length];
 };
 
-const normalizeBoundary = (
-  body: HTMLElement,
-  node: Node,
-  offset: number,
-  isEnd: boolean,
-): [Node, number] => {
-  if (node !== body) return [node, offset];
-  const child = body.childNodes[isEnd ? offset - 1 : offset];
-  if (!child) return [node, offset];
-  return isEnd ? descendToEnd(child) : descendToStart(child);
+const normalizeBoundary = (node: Node, offset: number, isEnd: boolean): [Node, number] => {
+  if (node.nodeType !== Node.ELEMENT_NODE) return [node, offset];
+  const children = node.childNodes;
+  const child = children[isEnd ? offset - 1 : offset];
+  if (child) return isEnd ? descendToEnd(child) : descendToStart(child);
+  // A start boundary after the last child is the same point as the end of
+  // that child; a boundary in a childless element (offset 0) serializes
+  // losslessly as the element step itself.
+  if (!isEnd && offset > 0 && children.length > 0) {
+    return descendToEnd(children[children.length - 1]!);
+  }
+  return [node, offset];
 };
 
 // Translate a selection range inside the (mutated) footnote popup document
@@ -76,13 +80,12 @@ export const getFootnoteSelectionCfi = (
   baseCfi: string,
 ): string | null => {
   try {
-    const body = range.startContainer.ownerDocument?.body;
-    if (!body) return null;
+    if (!range.startContainer.ownerDocument?.body) return null;
     const containerParts = parseSinglePath(mapping.containerCfi);
     if (!containerParts?.length) return null;
 
     const mapBoundary = (node: Node, offset: number, isEnd: boolean): string | null => {
-      const [n, o] = normalizeBoundary(body, node, offset, isEnd);
+      const [n, o] = normalizeBoundary(node, offset, isEnd);
       const parts = boundaryParts(n, o);
       // parts[0] is the popup <body> step; below it lies the fragment
       if (!parts || parts.length < 2) return null;

--- a/apps/readest-app/src/app/reader/utils/footnoteCfi.ts
+++ b/apps/readest-app/src/app/reader/utils/footnoteCfi.ts
@@ -1,0 +1,146 @@
+import * as CFI from 'foliate-js/epubcfi.js';
+
+// Mapping info emitted by foliate-js FootnoteHandler's `render` event
+// (see getExtractMapping in foliate-js/footnotes.js). The popup document's
+// body holds the fragment extracted from the pristine section document;
+// this describes how CFI paths translate between the two:
+// - `containerCfi`: collapsed CFI (document part only) of the element the
+//   fragment was extracted from,
+// - `delta`: constant shift of every first-level child-step index (2 x the
+//   number of container element children preceding the extraction start),
+// - `firstIndex`/`lastIndex`: the range of first-level indices (in pristine
+//   document terms) the fragment covers, for reverse-mapping bounds.
+export interface FootnoteExtractMapping {
+  containerCfi: string;
+  delta: number;
+  firstIndex: number;
+  lastIndex: number;
+}
+
+interface CfiPart {
+  index: number;
+  id?: string;
+  offset?: number;
+}
+
+const parseSinglePath = (cfi: string): CfiPart[] | null => {
+  const parsed = CFI.parse(cfi) as CfiPart[][] | { parent?: unknown };
+  if (!Array.isArray(parsed)) return null;
+  return parsed[0] ?? null;
+};
+
+// CFI parts of a collapsed point, from the document root down to the point.
+const boundaryParts = (node: Node, offset: number): CfiPart[] | null => {
+  const doc = node.ownerDocument;
+  if (!doc) return null;
+  const range = doc.createRange();
+  range.setStart(node, offset);
+  range.collapse(true);
+  return parseSinglePath(CFI.fromRange(range) as string);
+};
+
+// Element-container boundaries lose their child offset when serialized (CFI
+// offsets only apply to character-data steps), so a boundary sitting on the
+// popup <body> itself (e.g. a select-all) must be pushed down into the
+// nearest text position before mapping.
+const descendToStart = (node: Node): [Node, number] => {
+  let n: Node = node;
+  while (n.nodeType === Node.ELEMENT_NODE && n.firstChild) n = n.firstChild;
+  return [n, 0];
+};
+
+const descendToEnd = (node: Node): [Node, number] => {
+  let n: Node = node;
+  while (n.nodeType === Node.ELEMENT_NODE && n.lastChild) n = n.lastChild;
+  return [n, n.nodeType === Node.TEXT_NODE ? (n.nodeValue?.length ?? 0) : n.childNodes.length];
+};
+
+const normalizeBoundary = (
+  body: HTMLElement,
+  node: Node,
+  offset: number,
+  isEnd: boolean,
+): [Node, number] => {
+  if (node !== body) return [node, offset];
+  const child = body.childNodes[isEnd ? offset - 1 : offset];
+  if (!child) return [node, offset];
+  return isEnd ? descendToEnd(child) : descendToStart(child);
+};
+
+// Translate a selection range inside the (mutated) footnote popup document
+// into a CFI that resolves in the pristine section document, joined onto the
+// section's spine base CFI. Returns null when the range cannot be mapped.
+export const getFootnoteSelectionCfi = (
+  range: Range,
+  mapping: FootnoteExtractMapping,
+  baseCfi: string,
+): string | null => {
+  try {
+    const body = range.startContainer.ownerDocument?.body;
+    if (!body) return null;
+    const containerParts = parseSinglePath(mapping.containerCfi);
+    if (!containerParts?.length) return null;
+
+    const mapBoundary = (node: Node, offset: number, isEnd: boolean): string | null => {
+      const [n, o] = normalizeBoundary(body, node, offset, isEnd);
+      const parts = boundaryParts(n, o);
+      // parts[0] is the popup <body> step; below it lies the fragment
+      if (!parts || parts.length < 2) return null;
+      const [, first, ...rest] = parts as [CfiPart, CfiPart, ...CfiPart[]];
+      const mapped = [...containerParts, { ...first, index: first.index + mapping.delta }, ...rest];
+      return CFI.joinIndir(baseCfi, CFI.toString([mapped]) as string) as string;
+    };
+
+    const start = mapBoundary(range.startContainer, range.startOffset, false);
+    if (!start) return null;
+    if (range.collapsed) return start;
+    const end = mapBoundary(range.endContainer, range.endOffset, true);
+    if (!end) return null;
+    return CFI.buildRange(start, end) as string;
+  } catch {
+    return null;
+  }
+};
+
+// Translate a stored (pristine-document) annotation CFI into one that
+// resolves inside the footnote popup document, so the annotation can be
+// drawn in the popup. Returns null when the annotation lies outside the
+// extracted fragment.
+export const getFootnoteLocalCfi = (
+  bookCfi: string,
+  mapping: FootnoteExtractMapping,
+  popupDoc: Document,
+): string | null => {
+  try {
+    const containerParts = parseSinglePath(mapping.containerCfi);
+    if (!containerParts?.length || !popupDoc.body) return null;
+    const bodyParts = boundaryParts(popupDoc.body, 0);
+    if (!bodyParts?.length) return null;
+
+    const mapPath = (parts: CfiPart[][]): CfiPart[][] | null => {
+      const docParts = parts[parts.length - 1];
+      if (!docParts || docParts.length <= containerParts.length) return null;
+      for (let i = 0; i < containerParts.length; i++) {
+        if (docParts[i]!.index !== containerParts[i]!.index) return null;
+      }
+      const first = docParts[containerParts.length]!;
+      if (first.index < mapping.firstIndex || first.index > mapping.lastIndex) return null;
+      const rest = docParts.slice(containerParts.length + 1);
+      return [
+        ...parts.slice(0, -1),
+        [...bodyParts, { ...first, index: first.index - mapping.delta }, ...rest],
+      ];
+    };
+
+    const parsed = CFI.parse(bookCfi);
+    const mappedStart = mapPath(CFI.collapse(parsed) as CfiPart[][]);
+    if (!mappedStart) return null;
+    const mappedEnd = mapPath(CFI.collapse(parsed, true) as CfiPart[][]);
+    if (!mappedEnd) return null;
+    const startStr = CFI.toString(mappedStart) as string;
+    const endStr = CFI.toString(mappedEnd) as string;
+    return startStr === endStr ? startStr : (CFI.buildRange(startStr, endStr) as string);
+  } catch {
+    return null;
+  }
+};

--- a/apps/readest-app/src/types/view.ts
+++ b/apps/readest-app/src/types/view.ts
@@ -88,7 +88,7 @@ export interface FoliateView extends HTMLElement {
   isOverflowY: () => boolean;
   goLeft: () => void;
   goRight: () => void;
-  getCFI: (index: number, range: Range) => string;
+  getCFI: (index: number, range?: Range) => string;
   getCFIProgress: (cfi: string) => Promise<{
     fraction: number;
     section: { current: number; total: number };

--- a/apps/readest-app/src/utils/sel.ts
+++ b/apps/readest-app/src/utils/sel.ts
@@ -35,6 +35,11 @@ export interface TextSelection {
   // Native Android selection handles were suppressed for this selection
   // (Blink hyphen bounds bug, issue #1553) — the app draws its own handles.
   handlesSuppressed?: boolean;
+  // Selection made inside the footnote/annotation popup window rather than a
+  // main book document. `cfi` (when present) already points into the pristine
+  // section document; tools that need a live main-document range or that
+  // cannot work without a CFI must be disabled accordingly.
+  popup?: boolean;
 }
 
 const frameRect = (frame: Frame, rect?: Rect, sx = 1, sy = 1) => {


### PR DESCRIPTION
Closes #5646

Selections inside the footnote popup window now surface the annotation toolbar, so text in footnotes can be highlighted, underlined, annotated, copied, searched, looked up, and translated.

### The CFI problem

The popup document is a mutated copy of the section: foliate's `FootnoteHandler` extracts the note fragment into an empty body, so a CFI computed against the popup cannot resolve in the pristine document. A CFI child step's index depends only on the number of preceding *element* siblings, so for the element-aligned ranges the handler builds, every first-level index shifts by a constant delta and deeper steps are untouched. The footnote handler now emits that mapping on its `render` event (readest/foliate-js#77), and a new `footnoteCfi.ts` utility splices popup-local paths onto the pristine container path (and back). Round-trip tests over every extraction branch live in `src/__tests__/utils/footnote-cfi-mapping.test.ts`.

### What works in the popup

- Highlights/underlines save against the real book position (id assertions like `[n2_8_2]` keep them robust), draw immediately inside the popup, redraw when the popup reopens, and are removed on delete
- Clicking a drawn highlight opens the toolbar in its annotated state (restyle/delete); clicking a note bubble opens the note view — matching the main-view flows, minus the range-edit handles (main-view-only)
- Annotate merges the note into the existing highlight record: the notebook save now uses the popup's mapped CFI instead of recomputing one from the popup range (which forked a second, mis-anchored record), and the note bubble overlay draws in the popup
- Popups whose text is synthesized from a data/`alt` attribute have no real text node to anchor to: copy/search/dictionary/translate stay enabled, while highlight/annotate/copylink/proofread are disabled. TTS is disabled for all popup selections since it reads from the main view documents

### Notes

- The Annotator now renders after FootnotePopup so the selection toolbar stacks above the popup and its dismiss overlay (both use z-50; DOM order decides)
- The `draw-annotation` styling logic moved from Annotator into `annotatorUtil.drawAnnotationOverlay` so the popup view reuses it
- The submodule pointer references the readest/foliate-js#77 branch head and needs a bump once that PR merges

Verified in Chrome on the web app: selection toolbar in real footnote popups, highlight round-trip (popup -> booknote -> main document -> reopened popup), unified highlight+note record, disabled tools on alt-attribute popups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Select text directly within footnote popups and create annotations with accurate locations.
  - Existing highlights, underlines, squiggles, and annotation markers now appear in footnote popups.
  - Selecting an annotation in a footnote popup opens the corresponding note.
- **Bug Fixes**
  - Improved popup stacking so selection and lookup controls remain accessible.
  - Prevented unsupported actions when popup selections cannot be mapped reliably.
  - Improved annotation saving for selections made in footnotes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->