### PR TITLE
fix(tts): make sentence and paragraph pauses consistent

### DIFF
--- a/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
@@ -109,7 +109,6 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
   ttsLang: 'en',
   isPlaying: true,
   hasTimeline: true,
-  hasGapControl: false,
   timeoutOption: 0,
   timeoutTimestamp: 0,
   chapterRemainingSec: null as number | null,
@@ -118,8 +117,6 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
   onBackward: vi.fn(),
   onForward: vi.fn(),
   onSetRate: vi.fn(),
-  onSetSentenceGap: vi.fn(),
-  onSetParagraphGap: vi.fn(),
   onGetVoices: vi.fn().mockResolvedValue(voiceGroups),
   onSetVoice: vi.fn(),
   onGetVoiceId: vi.fn().mockReturnValue('ava'),
@@ -255,23 +252,6 @@ describe('TTSPlayerSheet', () => {
     expect(viewSettings['ttsRate']).toBe(1.5);
     expect(settings.globalViewSettings.ttsRate).toBe(1.5);
     expect(saveSettings).toHaveBeenCalled();
-  });
-
-  test('rate-derived pauses keep sub-second precision instead of collapsing to zero', () => {
-    // The gaps are sub-second by design (0.15s / 0.3s), so rounding them to a
-    // whole number erases both at every speed - no pause between sentences or
-    // paragraphs, and no control left to restore one. See #5414.
-    const props = makeProps();
-    render(<TTSPlayerSheet {...props} />);
-    fireEvent.click(screen.getByLabelText('Speed'));
-    const slider = screen.getByRole('slider', { name: 'Speed' });
-    fireEvent.change(slider, { target: { value: '1.5' } });
-    fireEvent.pointerUp(slider);
-    // Faster speech shortens the pauses, it must not erase them.
-    expect(props.onSetSentenceGap).toHaveBeenCalledWith(0.12);
-    expect(props.onSetParagraphGap).toHaveBeenCalledWith(0.24);
-    expect(viewSettings['ttsSentenceGap']).toBe(0.12);
-    expect(viewSettings['ttsParagraphGap']).toBe(0.24);
   });
 
   test('voice button drills into the voice list and selects a voice', async () => {

--- a/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
@@ -56,6 +56,8 @@ let mockProgress = {
 const mockViewSettings = {
   ttsLocation: null as string | null,
   ttsRate: 1,
+  ttsSentenceGap: 0.15,
+  ttsParagraphGap: 0.3,
   ttsHighlightOptions: { style: 'highlight', color: '#ffff00' },
   isEink: false,
   ttsMediaMetadata: 'sentence',
@@ -83,6 +85,24 @@ vi.mock('@/store/readerStore', () => {
     selector ? selector(store) : store;
   useReaderStore.getState = () => store;
   return { useReaderStore };
+});
+
+const mockSettings = {
+  globalViewSettings: { ttsRate: 1, ttsSentenceGap: 0.15, ttsParagraphGap: 0.3 },
+};
+const mockSaveSettings = vi.fn();
+vi.mock('@/store/settingsStore', () => {
+  // Lazy accessors only: the factory is hoisted above the consts it reads.
+  const state = {
+    get settings() {
+      return mockSettings;
+    },
+    setSettings: vi.fn(),
+    saveSettings: (...args: unknown[]) => mockSaveSettings(...args),
+  };
+  return {
+    useSettingsStore: Object.assign(() => state, { getState: () => state }),
+  };
 });
 
 vi.mock('@/store/bookDataStore', () => {
@@ -1104,16 +1124,42 @@ describe('useTTSControl gap control (handleSetSentenceGap / handleSupportsGapCon
     };
   };
 
-  it('handleSetSentenceGap calls controller.setSentenceGap directly, without stop/start', async () => {
-    const controller = await startSession();
-    controller.state = 'playing';
+  // Both the player sheet's speed ruler and the RSVP overlay's `tts-set-rate`
+  // land here, so deriving the pauses at this one funnel is what keeps them
+  // from going stale against the rate they were scaled for (#5750).
+  it('a rate change re-derives and persists both pauses', async () => {
+    const controller = (await startSession()) as unknown as {
+      setSentenceGap: ReturnType<typeof vi.fn>;
+      setParagraphGap: ReturnType<typeof vi.fn>;
+    };
 
-    act(() => {
-      hookResult!.handleSetSentenceGap(0.5);
+    await act(async () => {
+      hookResult!.handleSetRate(2);
+      for (let i = 0; i < 10; i++) await Promise.resolve();
     });
 
-    expect(controller.setSentenceGap).toHaveBeenCalledWith(0.5);
-    expect(controller.stop).not.toHaveBeenCalled();
-    expect(controller.start).not.toHaveBeenCalled();
+    expect(controller.setSentenceGap).toHaveBeenCalledWith(0.1);
+    expect(controller.setParagraphGap).toHaveBeenCalledWith(0.2);
+    expect(mockViewSettings.ttsSentenceGap).toBe(0.1);
+    expect(mockViewSettings.ttsParagraphGap).toBe(0.2);
+    expect(mockSettings.globalViewSettings.ttsSentenceGap).toBe(0.1);
+    expect(mockSettings.globalViewSettings.ttsParagraphGap).toBe(0.2);
+    expect(mockSaveSettings).toHaveBeenCalled();
+  });
+
+  it('the tts-set-rate bus re-derives the pauses too', async () => {
+    const controller = (await startSession()) as unknown as {
+      setSentenceGap: ReturnType<typeof vi.fn>;
+      setParagraphGap: ReturnType<typeof vi.fn>;
+    };
+
+    await act(async () => {
+      await eventDispatcher.dispatch('tts-set-rate', { bookKey: 'book-1', rate: 1.5 });
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+    });
+
+    expect(mockViewSettings.ttsRate).toBe(1.5);
+    expect(controller.setSentenceGap).toHaveBeenCalledWith(0.12);
+    expect(controller.setParagraphGap).toHaveBeenCalledWith(0.24);
   });
 });

--- a/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
@@ -1147,6 +1147,24 @@ describe('useTTSControl gap control (handleSetSentenceGap / handleSupportsGapCon
     expect(mockSaveSettings).toHaveBeenCalled();
   });
 
+  // The RSVP overlay can set the rate before Read Aloud has ever started, and
+  // it persists ttsRate either way. Skipping the derivation when there is no
+  // controller yet would leave the stored pauses scaled for the old rate, to be
+  // picked up by the next session — the exact staleness this funnel removes.
+  it('derives the pauses even with no session running', async () => {
+    mockViewSettings.ttsSentenceGap = 0.15;
+    mockViewSettings.ttsParagraphGap = 0.3;
+    render(<CaptureHarness />);
+
+    await act(async () => {
+      hookResult!.handleSetRate(1.5);
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+    });
+
+    expect(mockViewSettings.ttsSentenceGap).toBe(0.12);
+    expect(mockViewSettings.ttsParagraphGap).toBe(0.24);
+  });
+
   it('the tts-set-rate bus re-derives the pauses too', async () => {
     const controller = (await startSession()) as unknown as {
       setSentenceGap: ReturnType<typeof vi.fn>;

--- a/apps/readest-app/src/__tests__/services/edge-tts-client-playback.test.ts
+++ b/apps/readest-app/src/__tests__/services/edge-tts-client-playback.test.ts
@@ -157,7 +157,7 @@ describe('EdgeTTSClient Web Audio playback', () => {
 
   test('chunks are scheduled with a rate-scaled gap and no element restarts', async () => {
     const client = await startClient();
-    await client.setRate(1); // gap = 0.15 / 1
+    await client.setRate(1); // default gap, unscaled at 1.0x
     const { done } = collectSpeak(client, new AbortController().signal);
     await flush();
     await flush();
@@ -165,6 +165,47 @@ describe('EdgeTTSClient Web Audio playback', () => {
     expect(second!.startedAt! - first!.endTime).toBeCloseTo(0.15, 5);
     await ctx().advanceTo(5);
     await done;
+  });
+
+  test('the gap it is given is scheduled as-is at a faster rate', async () => {
+    const client = await startClient();
+    await client.setRate(2);
+    // The gap arrives already scaled for 2x (see scaleGapForRate). Scaling it
+    // again here left 0.05s between sentences and ran them together (#5750).
+    client.setSentenceGap(0.1);
+    const { done } = collectSpeak(client, new AbortController().signal);
+    await flush();
+    await flush();
+    const [first, second] = ctx().sources;
+    expect(second!.startedAt! - first!.endTime).toBeCloseTo(0.1, 5);
+    await ctx().advanceTo(5);
+    await done;
+  });
+
+  test('the next paragraph starts a pause after the last one, not after its synthesis', async () => {
+    // One speak() is one paragraph. The pause between them belongs on the
+    // audio clock, so a slow synthesis eats into it instead of adding to it —
+    // that is what made paragraph pauses swing with the network (#5750).
+    parsedMarks = [{ name: '0', text: 'Only sentence.', language: 'en' }];
+    const client = await startClient();
+    await client.setRate(1);
+    client.setParagraphGap(0.3);
+
+    const { done } = collectSpeak(client, new AbortController().signal);
+    await flush();
+    await flush();
+    const first = ctx().sources[0]!;
+    await ctx().advanceTo(1.03); // starts at 0.03, 1s long
+    await done;
+
+    const { done: nextDone } = collectSpeak(client, new AbortController().signal);
+    await flush();
+    await flush();
+    const second = ctx().sources[1]!;
+    expect(second.startedAt! - first.endTime).toBeCloseTo(0.3, 5);
+
+    await ctx().advanceTo(5);
+    await nextDone;
   });
 
   test('setSentenceGap before speaking changes the observed gap', async () => {

--- a/apps/readest-app/src/__tests__/services/tts-auto-advance.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/services/tts-auto-advance.browser.test.tsx
@@ -87,10 +87,13 @@ vi.mock('@/services/tts/EdgeTTSClient', () => ({
   // mock factory replaces the whole module, so it must re-export it too.
   DEFAULT_SENTENCE_GAP_SEC: 0.15,
   EdgeTTSClient: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
-    // TTSController.setSentenceGap always forwards to the real ttsEdgeClient
-    // instance regardless of the active engine, so this mock needs the method
-    // even though the other two client mocks don't.
-    Object.assign(this, makeMockTTSClient('edge'), { setSentenceGap: () => {} });
+    // TTSController.setSentenceGap/setParagraphGap always forward to the real
+    // ttsEdgeClient instance regardless of the active engine, so this mock
+    // needs both methods even though the other two client mocks don't.
+    Object.assign(this, makeMockTTSClient('edge'), {
+      setSentenceGap: () => {},
+      setParagraphGap: () => {},
+    });
   }),
 }));
 vi.mock('@/services/tts/NativeTTSClient', () => ({

--- a/apps/readest-app/src/__tests__/services/tts-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller.test.ts
@@ -16,7 +16,10 @@ vi.mock('@/services/tts/WebSpeechClient', () => ({
 
 vi.mock('@/services/tts/EdgeTTSClient', () => ({
   EdgeTTSClient: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
-    Object.assign(this, createMockTTSClient('edge'), { setSentenceGap: vi.fn() });
+    Object.assign(this, createMockTTSClient('edge'), {
+      setSentenceGap: vi.fn(),
+      setParagraphGap: vi.fn(),
+    });
   }),
 }));
 
@@ -191,6 +194,10 @@ describe('TTSController', () => {
   });
 
   afterEach(async () => {
+    // Before anything that awaits a real timer: a fake-timer test that fails
+    // mid-way never reaches its own useRealTimers, and would hang every test
+    // after it on this shared clock.
+    vi.useRealTimers();
     // Ensure controller is stopped after each test
     try {
       await controller.stop();
@@ -1188,6 +1195,50 @@ describe('TTSController', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(forwardSpy).toHaveBeenCalledWith(false, true);
+    });
+
+    test('the paragraph gap is waited out as given, not re-scaled by the rate', async () => {
+      // The gap arrives already scaled for the rate (see scaleGapForRate);
+      // dividing it again here cut every paragraph pause in half at 2x (#5750).
+      vi.useFakeTimers();
+      await controller.init();
+      await controller.initViewTTS(0);
+      controller.setParagraphGap(0.3);
+      await controller.setRate(2);
+      const forwardSpy = vi.spyOn(controller, 'forward').mockResolvedValue();
+      speakingControllers.push(controller);
+
+      await controller.speak('<speak>hello</speak>');
+      await vi.advanceTimersByTimeAsync(290);
+      expect(forwardSpy).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(20);
+      expect(forwardSpy).toHaveBeenCalledWith(false, true);
+      vi.useRealTimers();
+    });
+
+    test('a client that schedules its own gaps is not made to wait twice', async () => {
+      // The buffered client puts the paragraph pause on the audio clock, where
+      // the next paragraph's synthesis and decode hide inside it. Sleeping here
+      // as well would add the gap twice and put the network back on top (#5750).
+      vi.useFakeTimers();
+      await controller.init();
+      await controller.initViewTTS(0);
+      controller.setParagraphGap(0.3);
+      controller.ttsClient.getCapabilities = vi.fn().mockReturnValue({
+        wordBoundaries: true,
+        mediaClock: true,
+        gapControl: true,
+        liveRateChange: false,
+        scheduledGaps: true,
+      });
+      const forwardSpy = vi.spyOn(controller, 'forward').mockResolvedValue();
+      speakingControllers.push(controller);
+
+      await controller.speak('<speak>hello</speak>');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(forwardSpy).toHaveBeenCalledWith(false, true);
+      vi.useRealTimers();
     });
   });
 

--- a/apps/readest-app/src/__tests__/services/tts-gap.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-gap.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+
+import { scaleGapForRate } from '@/services/tts/gap';
+
+describe('scaleGapForRate', () => {
+  test('leaves the base gap untouched at 1.0x', () => {
+    expect(scaleGapForRate(0.15, 1)).toBe(0.15);
+    expect(scaleGapForRate(0.3, 1)).toBe(0.3);
+  });
+
+  test('shortens pauses as the voice speeds up, more gently than 1/rate', () => {
+    // 1/rate would give 0.10s and 0.075s: fast speech runs the sentences
+    // together long before the pause stops being useful.
+    expect(scaleGapForRate(0.15, 1.5)).toBe(0.12);
+    expect(scaleGapForRate(0.15, 2)).toBe(0.1);
+    expect(scaleGapForRate(0.3, 1.5)).toBe(0.24);
+    expect(scaleGapForRate(0.3, 2)).toBe(0.2);
+  });
+
+  test('lengthens pauses below 1.0x', () => {
+    expect(scaleGapForRate(0.15, 0.5)).toBe(0.23);
+  });
+
+  test('keeps two decimals so sub-second gaps survive the rounding', () => {
+    // Rounding to a whole number floors every gap to 0, silently removing the
+    // pauses along with any way to get them back (#5414).
+    for (const rate of [0.5, 0.8, 1, 1.25, 1.5, 2, 3]) {
+      expect(scaleGapForRate(0.15, rate)).toBeGreaterThan(0);
+    }
+  });
+
+  test('a non-positive rate falls back to the base gap', () => {
+    expect(scaleGapForRate(0.15, 0)).toBe(0.15);
+    expect(scaleGapForRate(0.15, -1)).toBe(0.15);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts-web-audio-player.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-web-audio-player.test.ts
@@ -160,6 +160,80 @@ describe('WebAudioPlayer session end', () => {
   });
 });
 
+describe('WebAudioPlayer paragraph handover', () => {
+  // One paragraph per session: the pause between them is silence on the audio
+  // clock, not a JS sleep, so synthesis and decode of the next paragraph hide
+  // inside it instead of adding to it (#5750).
+  const endParagraph = async (
+    ctx: FakeAudioContext,
+    player: WebAudioPlayer,
+    onEvent: (e: WebAudioPlayerEvent) => void,
+    seconds: number,
+  ) => {
+    const gen = player.startSession(onEvent);
+    player.scheduleChunk(gen, makeBuffer(seconds), {
+      trimStartSec: 0,
+      mediaScale: 1,
+      gapSec: 0.15,
+    });
+    player.endSession(gen);
+    await ctx.advanceTo(SAFETY + seconds);
+    // The controller's handover stop, after the session ended on its own.
+    player.abortSession();
+  };
+
+  test('the next paragraph is scheduled a gap after the previous one ended', async () => {
+    const { ctx, player, onEvent } = setup();
+    await player.ensureContext();
+    await endParagraph(ctx, player, onEvent, 2);
+
+    const next = player.startSession(onEvent, { startAfterPreviousSec: 0.3 });
+    player.scheduleChunk(next, makeBuffer(1), { trimStartSec: 0, mediaScale: 1, gapSec: 0.15 });
+
+    expect(ctx.sources[1]!.startedAt).toBeCloseTo(SAFETY + 2 + 0.3, 5);
+  });
+
+  test('a pipeline that missed the deadline starts as soon as it can', async () => {
+    const { ctx, player, onEvent } = setup();
+    await player.ensureContext();
+    await endParagraph(ctx, player, onEvent, 2);
+    await ctx.advanceTo(SAFETY + 2 + 1); // synthesis took a second
+
+    const next = player.startSession(onEvent, { startAfterPreviousSec: 0.3 });
+    player.scheduleChunk(next, makeBuffer(1), { trimStartSec: 0, mediaScale: 1, gapSec: 0.15 });
+
+    expect(ctx.sources[1]!.startedAt).toBeCloseTo(SAFETY + 2 + 1 + SAFETY, 5);
+  });
+
+  test('a session aborted mid-playback carries nothing over', async () => {
+    const { ctx, player, onEvent } = setup();
+    await player.ensureContext();
+    const gen = player.startSession(onEvent);
+    player.scheduleChunk(gen, makeBuffer(2), { trimStartSec: 0, mediaScale: 1, gapSec: 0.15 });
+    await ctx.advanceTo(1);
+    player.abortSession(); // a stop or a skip, not the end of a paragraph
+
+    const next = player.startSession(onEvent, { startAfterPreviousSec: 0.3 });
+    player.scheduleChunk(next, makeBuffer(1), { trimStartSec: 0, mediaScale: 1, gapSec: 0.15 });
+
+    expect(ctx.sources[1]!.startedAt).toBeCloseTo(1 + SAFETY, 5);
+  });
+
+  test('the carry-over is consumed once, not by every later session', async () => {
+    const { ctx, player, onEvent } = setup();
+    await player.ensureContext();
+    await endParagraph(ctx, player, onEvent, 2);
+    const next = player.startSession(onEvent, { startAfterPreviousSec: 0.3 });
+    player.scheduleChunk(next, makeBuffer(1), { trimStartSec: 0, mediaScale: 1, gapSec: 0.15 });
+    player.abortSession(); // stopped before it ever ended
+
+    const third = player.startSession(onEvent, { startAfterPreviousSec: 0.3 });
+    player.scheduleChunk(third, makeBuffer(1), { trimStartSec: 0, mediaScale: 1, gapSec: 0.15 });
+
+    expect(ctx.sources[2]!.startedAt).toBeCloseTo(ctx.currentTime + SAFETY, 5);
+  });
+});
+
 describe('WebAudioPlayer abort', () => {
   test('abort stops pending sources, resolves waiters false, silences events', async () => {
     const { ctx, player, events, onEvent } = setup();

--- a/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
@@ -134,8 +134,6 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
           onBackward={tts.handleBackward}
           onForward={tts.handleForward}
           onSetRate={tts.handleSetRate}
-          onSetSentenceGap={tts.handleSetSentenceGap}
-          onSetParagraphGap={tts.handleSetParagraphGap}
           onGetVoices={tts.handleGetVoices}
           onSetVoice={tts.handleSetVoice}
           onGetVoiceId={tts.handleGetVoiceId}

--- a/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
@@ -17,8 +17,6 @@ import { RiVoiceAiFill } from 'react-icons/ri';
 import { useRouter } from 'next/navigation';
 import { TTSVoicesGroup } from '@/services/tts';
 import { MEDIA_OVERLAY_VOICE_ID } from '@/services/tts/mediaOverlay';
-import { DEFAULT_SENTENCE_GAP_SEC } from '@/services/tts/EdgeTTSClient';
-import { DEFAULT_PARAGRAPH_GAP_SEC } from '@/services/tts/TTSController';
 import { useEnv } from '@/context/EnvContext';
 import { useAuth } from '@/context/AuthContext';
 import { useReaderStore } from '@/store/readerStore';
@@ -42,8 +40,6 @@ import { TTS_STOP_AT_CHAPTER_END } from '@/services/tts/TTSSessionManager';
 import type { UseTTSDownloadsResult } from '@/app/reader/hooks/useTTSDownloads';
 
 type SheetView = 'main' | 'speed' | 'voice' | 'timer' | 'chapters';
-
-export const formatGap = (sec: number) => `${parseFloat(sec.toFixed(2))}s`;
 
 const getTTSTimeoutOptions = (_: TranslationFunc) => {
   return [
@@ -79,8 +75,6 @@ type TTSPlayerSheetProps = {
   onBackward: (byMark: boolean) => void;
   onForward: (byMark: boolean) => void;
   onSetRate: (rate: number) => void;
-  onSetSentenceGap: (sec: number) => void;
-  onSetParagraphGap: (sec: number) => void;
   onGetVoices: (lang: string) => Promise<TTSVoicesGroup[]>;
   onSetVoice: (voice: string, lang: string) => void;
   onGetVoiceId: () => string;
@@ -109,8 +103,6 @@ const TTSPlayerSheet = ({
   onBackward,
   onForward,
   onSetRate,
-  onSetSentenceGap,
-  onSetParagraphGap,
   onGetVoices,
   onSetVoice,
   onGetVoiceId,
@@ -198,35 +190,20 @@ const TTSPlayerSheet = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, ttsLang]);
 
-  /* Scale a given `baseGap` based on a given `rate`. Gaps are sub-second
-   * (0.15s / 0.3s), so they have to keep two decimals — rounding to a whole
-   * number floors every one of them to 0 and silently removes the pauses
-   * along with any way to get them back (#5414). */
-  const scaleGap = (baseGap: number, rate: number) => {
-    const k = 0.6;
-    return Math.round((baseGap / Math.pow(rate, k)) * 100) / 100;
-  };
-
   const handleSelectRate = (value: number) => {
     setRate(value);
+    // The pauses are derived from the rate and persisted by onSetRate's handler
+    // — every entry point that changes the rate has to re-derive them, so only
+    // one of them may own it (#5750).
     onSetRate(value);
-
-    const gap = scaleGap(DEFAULT_SENTENCE_GAP_SEC, value);
-    const paragraphGap = scaleGap(DEFAULT_PARAGRAPH_GAP_SEC, value);
-    onSetSentenceGap(gap);
-    onSetParagraphGap(paragraphGap);
 
     const vs = getViewSettings(bookKey)!;
     vs.ttsRate = value;
-    vs.ttsSentenceGap = gap;
-    vs.ttsParagraphGap = paragraphGap;
     setViewSettings(bookKey, vs);
     // Read the store fresh at call time: a `settings` captured at render goes
     // stale if anything else persisted settings since this sheet mounted.
     const { settings, setSettings, saveSettings } = useSettingsStore.getState();
     settings.globalViewSettings.ttsRate = value;
-    settings.globalViewSettings.ttsSentenceGap = gap;
-    settings.globalViewSettings.ttsParagraphGap = paragraphGap;
     setSettings(settings);
     saveSettings(envConfig, settings);
   };

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -1128,9 +1128,13 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleSetRate = useCallback(
     throttle(async (rate: number) => {
+      // Before the controller check: the rate is persisted whether or not a
+      // session is running (the RSVP overlay can set it with Read Aloud
+      // stopped), so the pauses have to follow it either way or the next
+      // session starts with pauses scaled for the old rate.
+      applyRateScaledGaps(rate);
       const ttsController = ttsControllerRef.current;
       if (!ttsController) return;
-      applyRateScaledGaps(rate);
       // Native MO / Edge AVPlayer can change rate without tearing down the
       // session. stop→start on continuous narration was racing the rate
       // invoke and often left playback at the old speed.

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -4,6 +4,7 @@ import { useAuth } from '@/context/AuthContext';
 import { useThemeStore } from '@/store/themeStore';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useReaderStore } from '@/store/readerStore';
+import { useSettingsStore } from '@/store/settingsStore';
 import { useBookProgress } from '@/store/readerProgressStore';
 import { useProofreadStore } from '@/store/proofreadStore';
 import { TransformContext } from '@/services/transformers/types';
@@ -17,6 +18,7 @@ import {
 } from '@/services/tts';
 import { DEFAULT_SENTENCE_GAP_SEC } from '@/services/tts/EdgeTTSClient';
 import { DEFAULT_PARAGRAPH_GAP_SEC } from '@/services/tts/TTSController';
+import { scaleGapForRate } from '@/services/tts/gap';
 import { eventDispatcher } from '@/utils/event';
 import { genSSMLRaw, parseSSMLLang } from '@/utils/ssml';
 import { throttle } from '@/utils/throttle';
@@ -45,7 +47,7 @@ const PAGE_FOLLOW_INTERVAL_MS = 200;
 
 export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProps) => {
   const _ = useTranslation();
-  const { appService } = useEnv();
+  const { appService, envConfig } = useEnv();
   const { user } = useAuth();
   const { isDarkMode } = useThemeStore();
   const getBookData = useBookDataStore((s) => s.getBookData);
@@ -1089,6 +1091,35 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // The pauses between sentences and between paragraphs are derived from the
+  // playback rate, so every entry point that changes the rate has to re-derive
+  // them or they stay scaled for the previous one. They all funnel through
+  // handleSetRate, which makes this the single owner: scaling the gap here AND
+  // again at schedule time gave base/rate^1.6 (#5750).
+  const applyRateScaledGaps = useCallback(
+    (rate: number) => {
+      const sentenceGap = scaleGapForRate(DEFAULT_SENTENCE_GAP_SEC, rate);
+      const paragraphGap = scaleGapForRate(DEFAULT_PARAGRAPH_GAP_SEC, rate);
+      // Live: both are read at schedule time, so neither needs a restart.
+      ttsControllerRef.current?.setSentenceGap(sentenceGap);
+      ttsControllerRef.current?.setParagraphGap(paragraphGap);
+      const viewSettings = getViewSettings(bookKey);
+      if (viewSettings) {
+        viewSettings.ttsSentenceGap = sentenceGap;
+        viewSettings.ttsParagraphGap = paragraphGap;
+        setViewSettings(bookKey, viewSettings);
+      }
+      // Read the store fresh at call time: a `settings` captured at render goes
+      // stale if anything else persisted settings since this hook mounted.
+      const { settings, setSettings, saveSettings } = useSettingsStore.getState();
+      settings.globalViewSettings.ttsSentenceGap = sentenceGap;
+      settings.globalViewSettings.ttsParagraphGap = paragraphGap;
+      setSettings(settings);
+      saveSettings(envConfig, settings);
+    },
+    [bookKey, envConfig, getViewSettings, setViewSettings],
+  );
+
   // Rate/voice/timeout/bar controls
   // rate range: 0.5 - 3, 1.0 is normal speed.
   // Short throttle: live AVPlayer rate changes are cheap; the old 3s window
@@ -1099,6 +1130,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     throttle(async (rate: number) => {
       const ttsController = ttsControllerRef.current;
       if (!ttsController) return;
+      applyRateScaledGaps(rate);
       // Native MO / Edge AVPlayer can change rate without tearing down the
       // session. stop→start on continuous narration was racing the rate
       // invoke and often left playback at the old speed.
@@ -1119,18 +1151,6 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     }, 200),
     [],
   );
-
-  // Inter-sentence gap: read live at schedule time by the controller, so
-  // changing it must not stop/restart playback like handleSetRate does.
-  const handleSetSentenceGap = useCallback((sec: number) => {
-    ttsControllerRef.current?.setSentenceGap(sec);
-  }, []);
-
-  // Paragraph gap: applies to every TTS client (not Edge-only), read live by
-  // the controller when auto-advancing, so no stop/restart here either.
-  const handleSetParagraphGap = useCallback((sec: number) => {
-    ttsControllerRef.current?.setParagraphGap(sec);
-  }, []);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleSetVoice = useCallback(
@@ -1208,8 +1228,6 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     handleForward,
     handlePause,
     handleSetRate,
-    handleSetSentenceGap,
-    handleSetParagraphGap,
     handleSetVoice,
     handleGetVoices,
     handleGetVoiceId,

--- a/apps/readest-app/src/services/tts/BufferedTTSClient.ts
+++ b/apps/readest-app/src/services/tts/BufferedTTSClient.ts
@@ -7,7 +7,7 @@ import { TTSWordBoundary } from '@/libs/edgeTTS';
 import { TTSGranularity, TTSMark, TTSVoice, TTSVoicesGroup } from './types';
 import { AppService } from '@/types/system';
 import { parseSSMLMarks } from '@/utils/ssml';
-import { TTSController } from './TTSController';
+import { DEFAULT_PARAGRAPH_GAP_SEC, TTSController } from './TTSController';
 import { TTSUtils } from './TTSUtils';
 import { findBoundaryIndexAtTime } from './wordHighlight';
 import { applyEdgeFade, findSpeechBounds } from './pcm';
@@ -38,12 +38,13 @@ import { TTSAudioBuffer, WebAudioPlayer, WebAudioPlayerEvent } from './WebAudioP
 // the screen off), not when it is fetched — schedule-ahead would otherwise
 // run foliate's mark cursor ahead of the voice and break prev/next/resume.
 
-// Natural pause between sentences, replacing the silence Edge bakes into every
-// utterance: measured at ~0.18s leading and ~0.8s trailing, so ~1s of dead air
-// per sentence if it is played as-is (see #5414). Divided by the playback rate
-// so pauses shrink with speed (#2033's "gaps don't scale" complaint). Note the
-// native path only cuts the trailing silence, so its audible gap also carries
-// the next utterance's ~0.18s of leading silence.
+// Natural pause between sentences at 1.0x, replacing the silence Edge bakes
+// into every utterance: measured at ~0.18s leading and ~0.8s trailing, so ~1s
+// of dead air per sentence if it is played as-is (see #5414). The rate scaling
+// happens once, before the value reaches this client (see scaleGapForRate);
+// what arrives here is wall-clock seconds of silence. Note the native path only
+// cuts the trailing silence, so its audible gap also carries the next
+// utterance's ~0.18s of leading silence.
 export const DEFAULT_SENTENCE_GAP_SEC = 0.15;
 const TICKS_PER_SECOND = 10_000_000;
 
@@ -99,6 +100,7 @@ export class BufferedTTSClient implements TTSClient {
   #rate = 1.0;
   #pitch = 1.0;
   #sentenceGapSec = DEFAULT_SENTENCE_GAP_SEC;
+  #paragraphGapSec = DEFAULT_PARAGRAPH_GAP_SEC;
 
   // iOS plays natively (app-process AVPlayer): audio in the app's own audio
   // session makes Now Playing, pause-slot retention, AirPods routing, and the
@@ -224,15 +226,22 @@ export class BufferedTTSClient implements TTSClient {
 
     // startSession before ensureContext: starting a session declares playback
     // intent, clearing any lingering user-pause so the context may resume.
-    const generation = this.#player.startSession((event: WebAudioPlayerEvent) => {
-      if (event.type === 'chunk-start') {
-        queue.push({ kind: 'chunk-start', index: event.chunkIndex });
-      } else if (event.type === 'session-end') {
-        queue.push({ kind: 'session-end' });
-      } else {
-        queue.push({ kind: 'error', message: event.message });
-      }
-    });
+    const generation = this.#player.startSession(
+      (event: WebAudioPlayerEvent) => {
+        if (event.type === 'chunk-start') {
+          queue.push({ kind: 'chunk-start', index: event.chunkIndex });
+        } else if (event.type === 'session-end') {
+          queue.push({ kind: 'session-end' });
+        } else {
+          queue.push({ kind: 'error', message: event.message });
+        }
+      },
+      // One speak() is one paragraph, so the pause before this session's first
+      // sample is the inter-paragraph pause. Scheduling it against the previous
+      // session's end is what hides synthesis and decode inside the pause; when
+      // they overrun it the player just starts as soon as it can (#5750).
+      { startAfterPreviousSec: this.#paragraphGapSec },
+    );
     this.#activeGeneration = generation;
     await this.#player.ensureContext();
     this.#isPlaying = true;
@@ -417,7 +426,7 @@ export class BufferedTTSClient implements TTSClient {
           chunkMeta.push(meta);
           try {
             const durationSec = await this.#player.scheduleRawChunk(generation, index, audio.data, {
-              gapSec: this.#sentenceGapSec / rate,
+              gapSec: this.#sentenceGapSec,
             });
             meta.trimmedDurationSec = durationSec;
             this.#recordDurations(voiceId, mark.text, audio.boundaries, durationSec);
@@ -456,7 +465,7 @@ export class BufferedTTSClient implements TTSClient {
         this.#player.scheduleChunk(generation, prepared.buffer, {
           trimStartSec: prepared.trimStartSec,
           mediaScale: prepared.trimmedDurationSec / prepared.buffer.duration,
-          gapSec: this.#sentenceGapSec / rate,
+          gapSec: this.#sentenceGapSec,
         });
       }
       if (!signal.aborted && this.#activeGeneration === generation) {
@@ -604,6 +613,10 @@ export class BufferedTTSClient implements TTSClient {
     this.#sentenceGapSec = sec;
   }
 
+  setParagraphGap(sec: number): void {
+    this.#paragraphGapSec = sec;
+  }
+
   registerSectionManifest(section: number, marks: string[]): Promise<void> | void {
     if (this.provider instanceof CachingProvider) {
       return this.provider.registerSectionManifest(section, marks);
@@ -728,6 +741,10 @@ export class BufferedTTSClient implements TTSClient {
       // The native player time-stretches live; the web path bakes the rate
       // into the scheduled buffers, so it needs a session restart.
       liveRateChange: this.#player instanceof NativeAudioPlayer,
+      // Only the web path carries an audio clock across sessions; the native
+      // queue starts each session fresh, so its paragraph pause stays with the
+      // controller.
+      scheduledGaps: !(this.#player instanceof NativeAudioPlayer),
     };
   }
 

--- a/apps/readest-app/src/services/tts/TTSAudioPlayer.ts
+++ b/apps/readest-app/src/services/tts/TTSAudioPlayer.ts
@@ -14,15 +14,22 @@
 // decode (AVPlayer streams the compressed file and time-stretches natively).
 // A driver implements exactly one of them.
 
-import type { ChunkTiming, TTSAudioBuffer, WebAudioPlayerEvent } from './WebAudioPlayer';
+import type {
+  ChunkTiming,
+  SessionOptions,
+  TTSAudioBuffer,
+  WebAudioPlayerEvent,
+} from './WebAudioPlayer';
 
 export interface TTSAudioPlayer {
   // The web driver resolves with its AudioContext; callers only await.
   ensureContext(): Promise<unknown>;
   // Returns a generation token; events for older generations must be ignored
   // by the caller. The onEvent callback delivers chunk-start (audible),
-  // session-end, and error events.
-  startSession(onEvent: (event: WebAudioPlayerEvent) => void): number;
+  // session-end, and error events. A driver that cannot schedule silence
+  // against the previous session ignores opts (and reports scheduledGaps
+  // false), leaving the pause to the controller.
+  startSession(onEvent: (event: WebAudioPlayerEvent) => void, opts?: SessionOptions): number;
   // PCM path (web): schedule a prepared buffer gaplessly.
   scheduleChunk?(generation: number, buffer: TTSAudioBuffer, timing: ChunkTiming): void;
   // Raw path (native): enqueue the compressed chunk; resolves with its

--- a/apps/readest-app/src/services/tts/TTSClient.ts
+++ b/apps/readest-app/src/services/tts/TTSClient.ts
@@ -29,6 +29,10 @@ export interface TTSCapabilities {
   // highlight. Chapter-only audiobook mappings keep location/navigation but
   // disable the visual overlay.
   textHighlight?: boolean;
+  // Schedules the pause between two blocks itself, as silence on its own audio
+  // clock. The controller must not also sleep for it: doing both plays the gap
+  // twice and puts synthesis latency on top of it instead of inside it (#5750).
+  scheduledGaps?: boolean;
 }
 
 export interface TTSClient {

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -919,23 +919,33 @@ export class TTSController extends EventTarget {
     this.ttsEdgeClient.setSentenceGap(sec);
   }
 
-  // Universal (not Edge-only) paragraph-to-paragraph gap. See
-  // DEFAULT_PARAGRAPH_GAP_SEC and #delayParagraphGap for where it's applied.
+  // Universal (not Edge-only) paragraph-to-paragraph gap, in wall-clock
+  // seconds at the current rate. See DEFAULT_PARAGRAPH_GAP_SEC and
+  // #delayParagraphGap for where it's applied.
   setParagraphGap(sec: number): void {
     this.#paragraphGapSec = sec;
+    // The buffered client needs it too: it schedules this pause as silence on
+    // its own audio clock rather than letting #delayParagraphGap sleep for it.
+    this.ttsEdgeClient.setParagraphGap(sec);
   }
 
   // Abortable delay inserted before auto-advancing to the next paragraph.
-  // Scales with rate like the sentence gap so pauses shrink with speed.
-  // Races against `signal` so a stop()/pause() during the gap resolves
-  // immediately instead of leaving a stray forward() to fire afterward.
+  // Already scaled for the rate before it gets here (see scaleGapForRate), so
+  // this waits it out as given. Races against `signal` so a stop()/pause()
+  // during the gap resolves immediately instead of leaving a stray forward()
+  // to fire afterward.
   //
   // Skipped entirely for a continuous timeline (recorded narration): the audio
   // for the next paragraph is the same recording playing on, so padding it adds
   // silence the narrator did not leave and pushes the highlight behind the voice.
   async #delayParagraphGap(signal: AbortSignal): Promise<void> {
-    if (this.ttsClient.getCapabilities().continuousTimeline) return;
-    const ms = (this.#paragraphGapSec / this.ttsRate) * 1000;
+    const capabilities = this.ttsClient.getCapabilities();
+    if (capabilities.continuousTimeline) return;
+    // Already scheduled as silence on the client's own audio clock, with the
+    // next paragraph's synthesis and decode running inside it. Sleeping here
+    // too would play the pause twice and put that latency back on top (#5750).
+    if (capabilities.scheduledGaps) return;
+    const ms = this.#paragraphGapSec * 1000;
     if (ms <= 0 || signal.aborted) return;
     await new Promise<void>((resolve) => {
       const onAbort = () => {

--- a/apps/readest-app/src/services/tts/WebAudioPlayer.ts
+++ b/apps/readest-app/src/services/tts/WebAudioPlayer.ts
@@ -67,6 +67,15 @@ export interface ChunkTiming {
   gapSec: number;
 }
 
+export interface SessionOptions {
+  // Silence to leave between the previous session's last sample and this
+  // session's first one, scheduled on the audio clock. A paragraph is one
+  // session, so this is the inter-paragraph pause: putting it here (rather
+  // than sleeping between sessions) lets the next paragraph's synthesis and
+  // decode run *inside* the pause instead of extending it (#5750).
+  startAfterPreviousSec?: number;
+}
+
 export type WebAudioPlayerEvent =
   | { type: 'chunk-start'; chunkIndex: number }
   | { type: 'session-end' }
@@ -202,6 +211,10 @@ export class WebAudioPlayer implements TTSAudioPlayer {
   #generation = 0;
   #session: PlayerSession | null = null;
   #userPaused = false;
+  // Audio-clock time the last naturally-ended session stopped sounding, or 0
+  // when there is nothing to hand over (first session, or one that was aborted
+  // mid-playback by a stop/seek/skip). Consumed by the next startSession.
+  #carryOverEndTime = 0;
 
   constructor(createContext?: () => TTSAudioContext) {
     this.#createContext = createContext ?? getSharedContext;
@@ -231,14 +244,18 @@ export class WebAudioPlayer implements TTSAudioPlayer {
     return buffer;
   }
 
-  startSession(onEvent: (event: WebAudioPlayerEvent) => void): number {
+  startSession(onEvent: (event: WebAudioPlayerEvent) => void, opts?: SessionOptions): number {
     this.abortSession();
     const generation = ++this.#generation;
+    // Consume the handover once: a session that is later aborted must not pass
+    // the same deadline on to the one after it.
+    const carryOver = this.#carryOverEndTime;
+    this.#carryOverEndTime = 0;
     this.#session = {
       generation,
       onEvent,
       chunks: [],
-      nextStartTime: 0,
+      nextStartTime: carryOver > 0 ? carryOver + Math.max(0, opts?.startAfterPreviousSec ?? 0) : 0,
       ended: false,
       endedEmitted: false,
       waiters: [],
@@ -289,6 +306,11 @@ export class WebAudioPlayer implements TTSAudioPlayer {
     const session = this.#session;
     if (!session) return;
     this.#session = null;
+    // A session cut short (stop, seek, skip to another sentence) has no end to
+    // hand over: its scheduled tail never sounds, so the next session must
+    // start from the live clock. The handover between two paragraphs aborts
+    // too, but only after session-end already recorded the real end time.
+    if (!session.endedEmitted) this.#carryOverEndTime = 0;
     for (const chunk of session.chunks) {
       chunk.source.onended = null;
       try {
@@ -404,6 +426,11 @@ export class WebAudioPlayer implements TTSAudioPlayer {
     if (!session.ended || session.endedEmitted) return;
     if (session.chunks.some((c) => !c.ended)) return;
     session.endedEmitted = true;
+    // Hand the audio clock to the next session. The last chunk's own trailing
+    // gap is dropped: it was never sounded (nothing follows it in this
+    // session), and the next session brings its own inter-paragraph pause.
+    const last = session.chunks[session.chunks.length - 1];
+    this.#carryOverEndTime = last ? last.startTime + last.duration : 0;
     session.onEvent({ type: 'session-end' });
   }
 

--- a/apps/readest-app/src/services/tts/gap.ts
+++ b/apps/readest-app/src/services/tts/gap.ts
@@ -1,0 +1,20 @@
+// The one place a TTS pause is scaled for the playback rate.
+//
+// Pauses have to shrink as the voice speeds up or they dominate the reading,
+// but dividing by the rate shrinks them faster than the speech itself
+// compresses, and sentences run together at 2x (#2033 asked for the opposite:
+// gaps that scale at all). The exponent below keeps a gentler curve —
+// 0.15s at 1.0x, 0.12s at 1.5x, 0.10s at 2.0x.
+//
+// Everything downstream treats the result as wall-clock seconds of silence and
+// must NOT scale it again: doing it here AND at schedule time gave
+// base/rate^1.6, which is 0.60s at 0.5x and 0.085s at 2x (#5750).
+const RATE_EXPONENT = 0.6;
+
+export const scaleGapForRate = (baseGapSec: number, rate: number): number => {
+  if (!(rate > 0)) return baseGapSec;
+  // Two decimals: the gaps are sub-second by design, so rounding to a whole
+  // number floors every one of them to 0 and silently removes the pauses along
+  // with any way to get them back (#5414).
+  return Math.round((baseGapSec / Math.pow(rate, RATE_EXPONENT)) * 100) / 100;
+};


### PR DESCRIPTION
Closes #5750.

Two independent causes, both audible as "pauses are either perfect or too short/long".

## 1. The gap was scaled for the playback rate twice

`TTSPlayerSheet` derived the pause as `base / rate^0.6` and persisted that (#5326), and then `BufferedTTSClient` and `TTSController` divided by the rate **again** at schedule time. The effective gap was `base / rate^1.6`, correct only at 1.0x:

| rate | sentence gap before | after |
| --- | --- | --- |
| 0.5x | 0.60s | 0.30s |
| 1.0x | 0.22s | 0.22s |
| 1.5x | 0.13s | 0.19s |
| 2.0x | 0.085s | 0.16s |

(sentence gap including the 20ms/50ms trim pads; the paragraph gap was off by the same factor.)

The curve now lives in one place, `scaleGapForRate` in `src/services/tts/gap.ts`, and the derivation moved from the player sheet into `useTTSControl.handleSetRate`. That is the single funnel both the speed ruler and the RSVP overlay's `tts-set-rate` already pass through, so the stored value can no longer be left scaled for a rate the user has since changed (the bus path used to persist `ttsRate` without re-deriving the gaps). The persisted setting keeps its current meaning, "the gap at the current rate", so nothing needs migrating.

## 2. The paragraph pause was on the wall clock, not the audio clock

One `speak()` is one paragraph. The next paragraph's session was built only after a JS `setTimeout` had elapsed: session teardown, SSML preprocess, synthesis, decode, and then a first chunk scheduled at `ctx.currentTime + 0.03`. None of that latency was compensated, so paragraph pauses swung with the network while pauses *inside* a paragraph stayed sample exact. Dialogue-heavy fiction, where a paragraph is often one sentence, takes that path on nearly every pause.

`WebAudioPlayer` now remembers where a naturally ended session stopped sounding and starts the next one at that point plus `startAfterPreviousSec`, so synthesis and decode run inside the pause instead of after it; when they overrun it, the player just starts as soon as it can, which is today's behaviour. `TTSController` skips its own sleep for clients that report the new `scheduledGaps` capability. A session cut short by a stop or a skip carries nothing over, so manual navigation stays immediate, and iOS (`NativeAudioPlayer`, which starts each session fresh) keeps the controller-side pause.

## Notes for review

- The page turn and the first sentence highlight of a paragraph now happen up to one paragraph gap earlier, before the audio starts, rather than after the JS sleep. I think it reads better (the page is ready before the voice), but it is a real timing change worth hearing on device.
- Not addressed here: `#prepareChunkBuffer` replaces Edge's prosody-dependent trailing silence with one constant, so a full stop, a question, and a comma split all get the same pause. That is the remaining "sometimes too short" contributor and a separate change.

## Testing

- `pnpm test`: 9312 passed, 16 skipped
- `pnpm lint`, `pnpm format:check`: clean
- Each new test was confirmed to fail without its fix: the sentence gap at 2x (`edge-tts-client-playback`), the paragraph delay at 2x and the double-wait guard (`tts-controller`), the handover deadline (`tts-web-audio-player`, `edge-tts-client-playback`).
- `tts-controller.test.ts` now resets fake timers in `afterEach`: a failing fake-timer test used to hang every test after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text-to-speech pacing when changing playback speed.
  - Sentence and paragraph pauses now adjust smoothly with playback rate.
  - Fixed paragraph transitions to prevent duplicated or mistimed delays.
  - Improved continuity between naturally completed narration sections.
  - Ensured interrupted playback clears leftover timing correctly.

- **Improvements**
  - Paragraph pause settings now work consistently across supported audio playback modes.
  - Playback settings are updated and saved automatically when the narration rate changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->