### PR TITLE
feat(reader): pair local audiobooks with ebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 | **OPDS/Calibre Integration**               | Integrate OPDS/Calibre to access online libraries and catalogs.                                                        | ✅         |
 | **Translate with DeepL and Yandex**        | From a single sentence to the entire book—translate instantly.                                                         | ✅         |
 | **Text-to-Speech (TTS) Support**           | Enjoy smooth, multilingual narration—even within a single book.                                                        | ✅         |
-| [**Read-Along Narration**][link-readalong] | Play a book's own recorded narration with the text highlighted in step — Kindle Immersion Reading / Audible Read & Listen, on the open EPUB standard. Reads EPUB 3 Media Overlays; pair an ebook with its audiobook using [Storyteller][link-storyteller]. | ✅         |
+| [**Read-Along Narration**][link-readalong] | Play embedded EPUB 3 Media Overlays with timed highlighting, or pair a reflowable EPUB locally with DRM-free MP3, M4A, or M4B narration. [Storyteller][link-storyteller] remains an option for generating phrase-aligned EPUBs. | ✅         |
 | **Sync across Platforms**                  | Synchronize book files, reading progress, notes, and bookmarks across all supported platforms.                         | ✅         |
 | [**Sync with Koreader**][link-kosync-wiki] | Synchronize reading progress, notes, and bookmarks with [Koreader][link-koreader] devices.                             | ✅         |
 | **Accessibility**                          | Provides full keyboard navigation and support for screen readers such as VoiceOver, TalkBack, NVDA, and Orca.         | ✅         |

--- a/apps/readest-app/AGENTS.md
+++ b/apps/readest-app/AGENTS.md
@@ -98,7 +98,7 @@ See [docs/safe-area-insets.md](docs/safe-area-insets.md) for rules on handling t
 
 ### Read Aloud
 
-Four engines sit behind `TTSClient`, including recorded-narration playback from EPUB 3 Media Overlays (a Kindle Immersion Reading equivalent). Gate behaviour on `TTSCapabilities`, never on client identity. See [docs/read-along-narration.md](docs/read-along-narration.md).
+Four engines sit behind `TTSClient`, including recorded-narration playback from EPUB 3 Media Overlays and device-local audiobook pairings. Gate behaviour on `TTSCapabilities`, never on client identity. See [docs/read-along-narration.md](docs/read-along-narration.md).
 
 ### Design System
 

--- a/apps/readest-app/docs/architecture.md
+++ b/apps/readest-app/docs/architecture.md
@@ -436,15 +436,15 @@ Four Read Aloud backends behind one interface (`src/services/tts`):
 - `EdgeTTSClient` going through `src/app/api/tts/edge` for streaming Microsoft
   Edge voices,
 - `MediaOverlayClient` (`tts/mediaOverlay/`), which plays a book's own recorded
-  narration from EPUB 3 Media Overlays instead of synthesizing — a Kindle
-  Immersion Reading equivalent. It also replaces foliate's text segmentation
-  with the SMIL par list, so marks and audio clips are 1:1 and the rest of the
-  stack (timeline, scrubber, media session, highlighting) is untouched. See
-  [read-along-narration.md](read-along-narration.md).
+  narration from embedded EPUB 3 Media Overlays or a device-local audiobook
+  paired to a reflowable EPUB. Embedded overlays replace foliate's text
+  segmentation with the SMIL par list; paired audiobooks use chapter mappings
+  from `src/services/audiobook` and disable text highlighting when no phrase
+  timing is available. See [read-along-narration.md](read-along-narration.md).
 
 `TTSCapabilities` (`wordBoundaries`, `mediaClock`, `gapControl`,
-`liveRateChange`) is how the controller and UI degrade per engine; gate on it
-rather than comparing client identities.
+`liveRateChange`, `continuousTimeline`, `textHighlight`) is how the controller
+and UI degrade per engine; gate on it rather than comparing client identities.
 
 Edge Read Aloud also supports persistent Offline Audio downloads. A durable,
 per-book queue (`ttsDownloadManager` + `ttsDownloadStore`) resumes when that

--- a/apps/readest-app/docs/book-config.md
+++ b/apps/readest-app/docs/book-config.md
@@ -38,6 +38,10 @@ Version 1 documents these fields as the supported integration surface:
 - `xpointer`: current reading location as XPointer for KOReader interoperability.
 - `booknotes`: bookmarks, annotations, and excerpts.
 - `rsvpPosition`: RSVP reading position.
+- `audiobook`: optional device-local manifest for a paired audiobook, including
+  copied file paths, chapter timing, and ebook-to-audio chapter mappings. Audio
+  files live under `Books/<book hash>/audiobook/`; neither the manifest nor the
+  files are included in cloud or file sync.
 - `updatedAt`: last config update timestamp in milliseconds.
 
 `viewSettings` and `searchConfig` are persisted app state. They are partial

--- a/apps/readest-app/docs/code-layout.md
+++ b/apps/readest-app/docs/code-layout.md
@@ -288,6 +288,12 @@ Translation provider integration.
 
 Mixed integration code. Some providers are used via server APIs to avoid exposing secrets.
 
+### `src/services/audiobook`
+
+Device-local companion-audiobook support: metadata parsing, chapter mapping,
+preview playback, and copied-file lifecycle. `src/services/tts/pairedAudiobook.ts`
+adapts a saved pairing for the Read Aloud stack.
+
 ### `src/services/tts`
 
 Read Aloud abstraction and implementations.
@@ -295,8 +301,10 @@ Read Aloud abstraction and implementations.
 - `WebSpeechClient.ts`: browser TTS
 - `NativeTTSClient.ts`: native/Tauri TTS
 - `EdgeTTSClient.ts`: remote/provider-backed TTS
-- `mediaOverlay/`: a book's own recorded narration (EPUB 3 Media Overlays)
-  played in place of synthesis — see
+- `mediaOverlay/`: a book's own recorded narration, from embedded EPUB 3 Media
+  Overlays or a device-local audiobook pairing, played in place of synthesis
+- `pairedAudiobook.ts`: turns saved ebook/audio chapter mappings into narration
+  sections consumed by the recorded-audio client — see
   [read-along-narration.md](read-along-narration.md)
 - `ttsDownloadManager.ts` + `src/store/ttsDownloadStore.ts`: durable per-book
   Offline Audio queue and progress state

--- a/apps/readest-app/docs/read-along-narration.md
+++ b/apps/readest-app/docs/read-along-narration.md
@@ -1,10 +1,10 @@
-## Read-Along Narration (EPUB 3 Media Overlays)
+## Read-Along Narration
 
-When a book ships with a recorded human narration, Readest plays that recording
-instead of synthesizing speech — while keeping everything else Read Aloud
-already does: the moving highlight, page-following, sentence/paragraph skip, the
+Readest can play a recorded human narration instead of synthesizing speech while
+keeping the rest of Read Aloud: highlighting, page-following, chapter skip, the
 scrubber and seek, speed, sleep timer, lock-screen and CarPlay controls, and
-background sessions.
+background sessions. Narration can come from an EPUB 3 Media Overlay or from a
+separate audiobook paired to a reflowable EPUB.
 
 ### Prior art
 
@@ -12,6 +12,9 @@ Synchronized read-along is a feature the major ecosystems have converged on:
 
 - **Kindle Immersion Reading** — Kindle text highlighted in step with an Audible
   narration, via Amazon's Whispersync for Voice pairing.
+- **[Continuum](https://continuumreader.app/)** — pairs DRM-free ebooks and
+  audiobooks by asking for one known chapter match, filling the rest in sequence,
+  and requiring the user to review mismatches before saving.
 - **Audible Read & Listen** (launched February 2026) — the same thing inside the
   Audible app, with word-level highlighting as the narrator speaks. Requires
   owning both the Audible audiobook *and* the matching Kindle ebook.
@@ -22,10 +25,9 @@ Synchronized read-along is a feature the major ecosystems have converged on:
   and companion media rather than synchronized text highlighting — adjacent, not
   equivalent.
 
-Readest's version is the Kindle/Audible experience built on the **open EPUB
-standard** rather than a store-side pairing of two purchases. It needs no account
-and no matching entitlements: any narrated EPUB you own or generate plays, on
-every platform Readest runs on.
+Readest's version needs no account or matching entitlements. Any narrated EPUB
+you own or generate plays on every platform Readest runs on, and DRM-free MP3,
+M4A, or M4B files can be paired locally with an ordinary EPUB.
 
 The recording is read from **EPUB 3 Media Overlays**: a SMIL file per spine
 section whose `<par>` elements each pair a text fragment
@@ -54,18 +56,35 @@ Alternatives if you'd rather not run a service:
 Gutenberg pairings) and [aeneas](https://github.com/readbeyond/aeneas) (the
 forced-alignment library underneath several such tools).
 
-Readest deliberately does **not** do the alignment itself. Dropping a bare MP3
-next to a book gives no timings, and inventing them would mean shipping a
-speech-recognition model. Alignment is a separate, one-time, offline job; tools
-like Storyteller already do it well.
+Readest deliberately does **not** infer sentence or word timings itself. Tools
+like Storyteller remain the route to exact phrase-level highlighting. Pairing a
+separate audiobook instead provides chapter-level alignment: each mapped ebook
+chapter becomes one highlight and one timed audio clip.
+
+### Pairing a separate audiobook
+
+The pairing wizard follows Continuum's anchor-and-review flow:
+
+1. Open a reflowable EPUB's book menu and choose **Pair Audiobook**.
+2. Select one M4B file or a naturally ordered set of MP3/M4A tracks.
+3. Choose one ebook chapter and the audio chapter or track known to match it.
+4. Readest fills the mapping in both directions by position. Review every row,
+   leave ebook chapters without audio, reuse an audio chapter where necessary,
+   and ignore extra tracks before creating the association.
+
+The wizard reports chapter-count mismatches rather than hiding them. Audio and
+the association stay under `Books/<book hash>/audiobook/` on the current device;
+they are not uploaded by Readest cloud or file sync. Normal reading progress is
+still synced, so another device with its own local pairing resumes at the same
+ebook chapter.
 
 ### Using it
 
-1. Import the narrated EPUB as usual.
-2. Open **Read Aloud**. For a book that carries narration, the narrator is
-   selected automatically and appears at the top of the **Voice** list (named
-   from the EPUB's `media:narrator` metadata, or "Book narration" when the book
-   declares none).
+1. Import a narrated EPUB as usual, or pair a separate audiobook from the book
+   menu.
+2. Open **Read Aloud**. The recording is selected automatically and appears at
+   the top of the **Voice** list (named from available narrator metadata, or
+   "Book narration" when none is declared).
 3. To use a synthetic voice for that book instead, pick one from the same Voice
    list. The choice is remembered per book; picking the narrator again returns
    to the recording.
@@ -78,6 +97,10 @@ Two behaviours worth knowing:
   read-alongs, and what Storyteller produces at its finest granularity) gives
   true word-by-word highlighting for free. Readest does not interpolate word
   positions inside a clip, so the highlight can never drift out of sync.
+- **Paired audiobooks highlight by chapter.** A separate audiobook has no text
+  timings, so the mapped chapter remains highlighted while its audio chapter or
+  track plays. Switching between reading and listening therefore resumes at
+  chapter granularity.
 - **Unnarrated sections are skipped.** Publishers routinely leave front matter,
   indexes and notes out of the recording. Playback steps over those sections
   rather than stalling on silence; starting Read Aloud in unnarrated front
@@ -91,7 +114,7 @@ had. `TTSClient` abstracts *where audio comes from*; foliate's `TTS` class
 abstracts *how text is cut into marks*. Recorded narration is exactly "a
 different audio source with a different segmentation".
 
-Everything lives in `src/services/tts/mediaOverlay/`:
+Embedded Media Overlay support lives in `src/services/tts/mediaOverlay/`:
 
 | File | Role |
 | --- | --- |
@@ -99,6 +122,12 @@ Everything lives in `src/services/tts/mediaOverlay/`:
 | `MediaOverlaySection.ts` | Per-section index: resolves each par's text fragment to a DOM `Range` in the section document, groups pars into blocks by nearest block-level ancestor, and builds the SSML the controller consumes. |
 | `MediaOverlayTTS.ts` | Stands in for foliate's `TTS`. Same navigation surface (`start`/`resume`/`next`/`prev`/`nextMark`/`prevMark`/`from`/`setMark`/`getLastRange`), but marks come from the par list. |
 | `MediaOverlayClient.ts` | `implements TTSClient`. Plays clips off one `HTMLMediaElement`, emitting a `boundary` as each par becomes audible. |
+
+Separate audiobooks reuse the same client and mark iterator. The additional
+pieces are `src/services/audiobook/` (metadata, positional mapping, and local
+storage) plus `src/services/tts/pairedAudiobook.ts`, which turns each mapped TOC
+chapter into a `NarrationPar`. A chapter table embedded in an M4B supplies clip
+boundaries; a standalone track without chapter metadata becomes one clip.
 
 Consequences of that shape:
 
@@ -146,9 +175,10 @@ Consequences of that shape:
   layout only; scrolled layout keeps its at-mark behaviour.
 
 Selection is the existing Voice picker: `TTSController.getVoices` prepends a
-narration group for books that have overlays, and `setVoice` routes
-`MEDIA_OVERLAY_VOICE_ID` to the narration client, rebuilding the section's mark
-source (the two segment differently, so the instance itself is replaced).
+narration group for books that have an embedded or paired recording, and
+`setVoice` routes `MEDIA_OVERLAY_VOICE_ID` to the narration client, rebuilding
+the section's mark source (the two segment differently, so the instance itself
+is replaced).
 `ttsUseNarration` on `TTSConfig` records the per-book opt-out; it is separate
 from `ttsVoice` because `ttsVoice` inherits the global default and so cannot
 distinguish "never chose" from "chose a synthetic voice for this book".
@@ -174,29 +204,32 @@ reader's own highlight style.
 - **Sub-sentence page-following needs a clock.** It is driven by
   `getChunkProgress()`, so engines without one (Web Speech) keep the old
   behaviour: a sentence straddling a page break waits for the next mark.
-- **iOS Tauri** plays narration through the same in-process AVPlayer as Edge
-  TTS (`NativeNarrationPlayer` → native-tts `playout` load/seek). A plain
-  `HTMLMediaElement` is interrupted when the media session claims the app's
-  non-mixable `.playback` session; web / Android / desktop keep using
-  `HTMLAudioElement`.
+- **Mobile Tauri** plays narration through `NativeNarrationPlayer`: AVPlayer on
+  iOS and ExoPlayer on Android. Paired audiobooks are streamed directly from
+  their local path. Desktop Tauri streams its asset URL through
+  `HTMLAudioElement`; web uses a blob URL.
 
 ### The library badge
 
-A book that carries narration shows a headphones badge on its library cover.
+A book that carries embedded narration shows a headphones badge on its library
+cover.
 `Book.hasNarration` is set at import time (`importBook` in
 `src/services/bookService.ts`) because the library list never opens the file. It
 is derived from the file on every import, like `format`, so it needs none of the
 field-level LWW timestamps that user-editable book fields carry.
 
 Consequence: **books already in the library before this shipped carry no badge
-until they are re-imported.** Narration itself still works on them — only the
-badge is missing, because nothing has re-read the file since.
+until they are re-imported.** Embedded narration itself still works on them —
+only the badge is missing, because nothing has re-read the file since.
 
 ### Tests
 
 `src/__tests__/services/tts/media-overlay-*.test.ts` covers the SMIL parser, the
 section index, the mark iterator, the client (against a fake media element), and
 controller-level narration selection, timeline exactness, and section skipping.
+Audiobook mapping, metadata, storage, section generation, and native playback
+routing are covered by the `audiobook-*`, `paired-audiobook-section`, and
+`media-overlay-android-native` service tests.
 
 `media-overlay-real-epub.test.ts` runs the real `DocumentLoader` against a real
 Media Overlays book. The fixture is a ~10 MB binary and is not committed, so the

--- a/apps/readest-app/docs/read-along-narration.md
+++ b/apps/readest-app/docs/read-along-narration.md
@@ -1,10 +1,11 @@
 ## Read-Along Narration
 
 Readest can play a recorded human narration instead of synthesizing speech while
-keeping the rest of Read Aloud: highlighting, page-following, chapter skip, the
-scrubber and seek, speed, sleep timer, lock-screen and CarPlay controls, and
-background sessions. Narration can come from an EPUB 3 Media Overlay or from a
-separate audiobook paired to a reflowable EPUB.
+keeping the rest of Read Aloud: page-following, chapter skip, the scrubber and
+seek, speed, sleep timer, lock-screen and CarPlay controls, and background
+sessions. Narration can come from an EPUB 3 Media Overlay, which also supplies
+timed text highlighting, or from a separate audiobook paired to a reflowable
+EPUB.
 
 ### Prior art
 
@@ -58,8 +59,8 @@ forced-alignment library underneath several such tools).
 
 Readest deliberately does **not** infer sentence or word timings itself. Tools
 like Storyteller remain the route to exact phrase-level highlighting. Pairing a
-separate audiobook instead provides chapter-level alignment: each mapped ebook
-chapter becomes one highlight and one timed audio clip.
+separate audiobook instead provides chapter-level alignment for navigation and
+playback, without drawing a text highlight that would imply finer timing.
 
 ### Pairing a separate audiobook
 
@@ -72,11 +73,20 @@ The pairing wizard follows Continuum's anchor-and-review flow:
    leave ebook chapters without audio, reuse an audio chapter where necessary,
    and ignore extra tracks before creating the association.
 
+When one audio chapter is reused for consecutive ebook chapters, Readest treats
+them as one continuous run. Chapters in the same spine document share one text
+span; runs crossing spine documents divide the clip into equal chapter slices
+so playback continues instead of restarting the recording at every section
+boundary.
+
 The wizard reports chapter-count mismatches rather than hiding them. Audio and
 the association stay under `Books/<book hash>/audiobook/` on the current device;
 they are not uploaded by Readest cloud or file sync. Normal reading progress is
 still synced, so another device with its own local pairing resumes at the same
-ebook chapter.
+ebook chapter. Replacements use new file paths and persist the new association
+before removing old audio. Re-importing or deduplicating an edited EPUB copies
+the paired files and rewrites those paths before retiring the previous book
+directory.
 
 ### Using it
 
@@ -97,10 +107,11 @@ Two behaviours worth knowing:
   read-alongs, and what Storyteller produces at its finest granularity) gives
   true word-by-word highlighting for free. Readest does not interpolate word
   positions inside a clip, so the highlight can never drift out of sync.
-- **Paired audiobooks highlight by chapter.** A separate audiobook has no text
-  timings, so the mapped chapter remains highlighted while its audio chapter or
-  track plays. Switching between reading and listening therefore resumes at
-  chapter granularity.
+- **Paired audiobooks do not highlight text.** A separate audiobook has no
+  sentence or word timings, so highlighting a whole mapped chapter would be
+  misleading. Readest instead maps the current page proportionally into that
+  chapter's audio span when narration starts and offers a return-to-narration
+  action if the reader moves elsewhere while audio continues.
 - **Unnarrated sections are skipped.** Publishers routinely leave front matter,
   indexes and notes out of the recording. Playback steps over those sections
   rather than stalling on silence; starting Read Aloud in unnarrated front
@@ -146,9 +157,10 @@ Consequences of that shape:
   `SectionTimeline`, so a narrated chapter reports the recording's real length
   with no `~`. It is deliberately not routed through the text-keyed duration
   cache in `ttsDuration.ts`, where two identical sentences would collide.
-- **Capabilities, not identity checks.** The client reports
-  `{ wordBoundaries: false, mediaClock: true, gapControl: false, liveRateChange: true, continuousTimeline: true }`,
-  and `ensureTimeline`/`supportsPlaybackInfo`/`getPlaybackInfo` gate on
+- **Capabilities, not identity checks.** Embedded overlays report
+  `{ wordBoundaries: false, textHighlight: true, mediaClock: true, gapControl: false, liveRateChange: true, continuousTimeline: true }`;
+  a paired audiobook reports the same clock capabilities with
+  `textHighlight: false`. `ensureTimeline`/`supportsPlaybackInfo`/`getPlaybackInfo` gate on
   `mediaClock` rather than comparing against the Edge client — which is what
   `TTSCapabilities` in `TTSClient.ts` existed for.
 - **A continuous timeline is handed over, not stopped.** `continuousTimeline`

--- a/apps/readest-app/docs/read-along-narration.md
+++ b/apps/readest-app/docs/read-along-narration.md
@@ -79,14 +79,14 @@ span; runs crossing spine documents divide the clip into equal chapter slices
 so playback continues instead of restarting the recording at every section
 boundary.
 
-The wizard reports chapter-count mismatches rather than hiding them. Audio and
-the association stay under `Books/<book hash>/audiobook/` on the current device;
-they are not uploaded by Readest cloud or file sync. Normal reading progress is
-still synced, so another device with its own local pairing resumes at the same
-ebook chapter. Replacements use new file paths and persist the new association
-before removing old audio. Re-importing or deduplicating an edited EPUB copies
-the paired files and rewrites those paths before retiring the previous book
-directory.
+The wizard reports chapter-count mismatches rather than hiding them. Audio stays
+under `Books/<book hash>/audiobook/`, while the association is stored in that
+book's device-local `config.json`; neither is uploaded by Readest cloud or file
+sync. Normal reading progress is still synced, so another device with its own
+local pairing resumes at the same ebook chapter. Replacements use new file paths
+and persist the new association before removing old audio. Re-importing or
+deduplicating an edited EPUB copies the paired files and rewrites those paths
+before retiring the previous book directory.
 
 ### Using it
 

--- a/apps/readest-app/package.json
+++ b/apps/readest-app/package.json
@@ -189,6 +189,7 @@
     "marked": "^15.0.12",
     "marked-footnote": "^1.4.0",
     "marked-katex-extension": "^5.1.10",
+    "music-metadata": "^11.14.0",
     "nanoid": "^5.1.6",
     "next": "16.2.11",
     "next-view-transitions": "^0.3.5",

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-tts/android/src/main/java/NativeTTSPlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-tts/android/src/main/java/NativeTTSPlugin.kt
@@ -40,8 +40,14 @@ import android.app.Service
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
+import android.net.Uri
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import java.io.File
 
 data class TTSVoiceData(
     val id: String,
@@ -104,6 +110,14 @@ class SetMediaSessionActiveArgs {
   var bookAuthor: String? = null
 }
 
+@InvokeArg
+class PlayoutControlArgs {
+    var action: String? = null
+    var rate: Double? = null
+    var path: String? = null
+    var positionMs: Double? = null
+}
+
 @TauriPlugin(
   permissions = [
     Permission(strings = [Manifest.permission.POST_NOTIFICATIONS], alias = "postNotification")
@@ -127,6 +141,31 @@ class NativeTTSPlugin(private val activity: Activity) : Plugin(activity) {
     private var isSpeaking = AtomicBoolean(false)
     private var currentRate = AtomicReference<Float>(1.0f)
     private var currentPitch = AtomicReference<Float>(1.0f)
+
+    // Continuous local-file playback for EPUB Media Overlays and paired
+    // audiobooks. The WebView cannot expose Android app-private files as a
+    // seekable Blob without first reading the whole file into memory; ExoPlayer
+    // can seek and stream the original file path directly.
+    private var playoutPlayer: ExoPlayer? = null
+    private var playoutSession = 0
+    private var playoutCurrentIndex = -1
+    private var playoutRate = 1.0f
+    private var playoutLoadedPath: String? = null
+    private val playoutListener = object : Player.Listener {
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            if (playbackState == Player.STATE_ENDED && playoutCurrentIndex >= 0) {
+                playoutCurrentIndex = -1
+                emitPlayoutEvent("ended", 0)
+            }
+        }
+
+        override fun onPlayerError(error: PlaybackException) {
+            if (playoutCurrentIndex < 0) return
+            Log.e(TAG, "Native narration playback failed", error)
+            playoutCurrentIndex = -1
+            emitPlayoutEvent("error", 0)
+        }
+    }
 
     private val eventChannels = ConcurrentHashMap<String, Channel<TTSMessageEvent>>()
     private val speakingJobs = ConcurrentHashMap<String, Job>()
@@ -572,6 +611,118 @@ class NativeTTSPlugin(private val activity: Activity) : Plugin(activity) {
             invoke.reject("Failed to set media session active state: ${e.message}")
         }
     }
+
+    @Command
+    fun playout_control(invoke: Invoke) {
+        val args = invoke.parseArgs(PlayoutControlArgs::class.java)
+        val action = args.action ?: ""
+
+        activity.runOnUiThread {
+            try {
+                when (action) {
+                    "start-session" -> {
+                        cancelIdleTimer()
+                        abortPlayout()
+                        playoutSession += 1
+                        invoke.resolve(JSObject().apply { put("session", playoutSession) })
+                    }
+                    "end-session" -> {
+                        if (playoutCurrentIndex < 0) emitPlayoutEvent("session-end")
+                        invoke.resolve(JSObject().apply { put("session", JSONObject.NULL) })
+                    }
+                    "abort" -> {
+                        abortPlayout()
+                        invoke.resolve(JSObject().apply { put("session", JSONObject.NULL) })
+                    }
+                    "pause" -> {
+                        playoutPlayer?.pause()
+                        invoke.resolve(JSObject().apply { put("session", JSONObject.NULL) })
+                    }
+                    "resume" -> {
+                        playoutPlayer?.play()
+                        invoke.resolve(JSObject().apply { put("session", JSONObject.NULL) })
+                    }
+                    "set-rate" -> {
+                        playoutRate = (args.rate ?: 1.0).toFloat()
+                        playoutPlayer?.setPlaybackSpeed(playoutRate)
+                        invoke.resolve(JSObject().apply { put("session", JSONObject.NULL) })
+                    }
+                    "load" -> {
+                        val path = args.path
+                        if (path.isNullOrEmpty()) {
+                            invoke.reject("playout load requires path")
+                        } else {
+                            loadContinuousFile(path, args.positionMs ?: 0.0)
+                            invoke.resolve(JSObject().apply { put("session", playoutSession) })
+                        }
+                    }
+                    "seek" -> {
+                        playoutPlayer?.seekTo((args.positionMs ?: 0.0).coerceAtLeast(0.0).toLong())
+                        invoke.resolve(JSObject().apply { put("session", JSONObject.NULL) })
+                    }
+                    else -> invoke.reject("Unknown playout action: $action")
+                }
+            } catch (e: Exception) {
+                invoke.reject("Native narration control failed: ${e.message}")
+            }
+        }
+    }
+
+    @Command
+    fun playout_position(invoke: Invoke) {
+        activity.runOnUiThread {
+            val player = playoutPlayer
+            invoke.resolve(JSObject().apply {
+                put("session", playoutSession)
+                put("index", playoutCurrentIndex)
+                put("positionMs", player?.currentPosition ?: 0L)
+                put("playing", player?.isPlaying ?: false)
+            })
+        }
+    }
+
+    private fun ensurePlayoutPlayer(): ExoPlayer {
+        return playoutPlayer ?: ExoPlayer.Builder(activity).build().also { player ->
+            player.addListener(playoutListener)
+            player.setPlaybackSpeed(playoutRate)
+            playoutPlayer = player
+        }
+    }
+
+    private fun loadContinuousFile(path: String, positionMs: Double) {
+        val file = File(path)
+        require(file.isFile) { "Narration file not found: $path" }
+        val player = ensurePlayoutPlayer()
+        val startMs = positionMs.coerceAtLeast(0.0).toLong()
+
+        if (playoutLoadedPath == path && player.currentMediaItem != null) {
+            player.seekTo(startMs)
+        } else {
+            player.setMediaItem(MediaItem.fromUri(Uri.fromFile(file)), startMs)
+            player.prepare()
+            playoutLoadedPath = path
+        }
+        // Loading and resuming are separate operations, matching the web and
+        // iOS clocks used by MediaOverlayClient.
+        player.pause()
+        playoutCurrentIndex = 0
+        emitPlayoutEvent("chunk-start", 0)
+    }
+
+    private fun abortPlayout() {
+        playoutCurrentIndex = -1
+        playoutPlayer?.stop()
+        playoutPlayer?.clearMediaItems()
+        playoutLoadedPath = null
+    }
+
+    private fun emitPlayoutEvent(type: String, index: Int? = null) {
+        trigger("playout_events", JSObject().apply {
+            put("type", type)
+            put("session", playoutSession)
+            index?.let { put("index", it) }
+        })
+    }
     
     private fun startIdleTimer() {
         idleHandler.removeCallbacks(idleShutdownRunnable)
@@ -584,6 +735,7 @@ class NativeTTSPlugin(private val activity: Activity) : Plugin(activity) {
 
     private fun shutdownTTSEngine() {
         try {
+            abortPlayout()
             MediaPlaybackService.requestDeactivation()
             MediaPlaybackService.pluginEventTrigger = null
 
@@ -619,6 +771,8 @@ class NativeTTSPlugin(private val activity: Activity) : Plugin(activity) {
             eventChannels.clear()
             speakingJobs.values.forEach { it.cancel() }
             speakingJobs.clear()
+            playoutPlayer?.release()
+            playoutPlayer = null
 
             Log.d(TAG, "Plugin destroyed successfully")
         } catch (e: Exception) {

--- a/apps/readest-app/src/__tests__/app/reader/components/audiobook/AudiobookChapterPicker.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/audiobook/AudiobookChapterPicker.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import AudiobookChapterPicker from '@/app/reader/components/audiobook/AudiobookChapterPicker';
+import type { AudiobookChapter } from '@/types/book';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (value: string, params?: Record<string, string>) =>
+    Object.entries(params ?? {}).reduce(
+      (result, [key, replacement]) => result.replace(`{{${key}}}`, replacement),
+      value,
+    ),
+}));
+
+const chapters: AudiobookChapter[] = Array.from({ length: 300 }, (_, index) => ({
+  id: `audio-0:${index}`,
+  fileId: 'audio-0',
+  label: `Track ${index + 1}`,
+  start: index * 60,
+  end: (index + 1) * 60,
+}));
+
+describe('AudiobookChapterPicker', () => {
+  it('renders one searchable audio list instead of duplicating it for every ebook row', () => {
+    const onSelect = vi.fn();
+    const onPreview = vi.fn();
+    const { getAllByRole, getByRole, queryByRole } = render(
+      <AudiobookChapterPicker
+        chapters={chapters}
+        value='audio-0:0'
+        onSelect={onSelect}
+        onPreview={onPreview}
+        previewingId={null}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(getAllByRole('option')).toHaveLength(301);
+    fireEvent.change(getByRole('searchbox', { name: 'Search audio chapters' }), {
+      target: { value: 'Track 299' },
+    });
+
+    expect(getAllByRole('option')).toHaveLength(2);
+    expect(queryByRole('option', { name: /Track 1 ·/ })).toBeNull();
+    fireEvent.click(getByRole('option', { name: /Track 299 ·/ }));
+    expect(onSelect).toHaveBeenCalledWith('audio-0:298');
+
+    fireEvent.click(getByRole('button', { name: 'Preview Track 299' }));
+    expect(onPreview).toHaveBeenCalledWith(chapters[298]);
+  });
+});

--- a/apps/readest-app/src/__tests__/app/reader/components/audiobook/AudiobookChapterPicker.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/audiobook/AudiobookChapterPicker.test.tsx
@@ -24,7 +24,7 @@ describe('AudiobookChapterPicker', () => {
   it('renders one searchable audio list instead of duplicating it for every ebook row', () => {
     const onSelect = vi.fn();
     const onPreview = vi.fn();
-    const { getAllByRole, getByRole, queryByRole } = render(
+    const { container, getByRole } = render(
       <AudiobookChapterPicker
         chapters={chapters}
         value='audio-0:0'
@@ -35,17 +35,18 @@ describe('AudiobookChapterPicker', () => {
       />,
     );
 
-    expect(getAllByRole('option')).toHaveLength(301);
+    expect(container.querySelectorAll('[role="option"]')).toHaveLength(301);
     fireEvent.change(getByRole('searchbox', { name: 'Search audio chapters' }), {
       target: { value: 'Track 299' },
     });
 
-    expect(getAllByRole('option')).toHaveLength(2);
-    expect(queryByRole('option', { name: /Track 1 ·/ })).toBeNull();
-    fireEvent.click(getByRole('option', { name: /Track 299 ·/ }));
+    const filteredOptions = container.querySelectorAll<HTMLElement>('[role="option"]');
+    expect(filteredOptions).toHaveLength(2);
+    expect(container.textContent).not.toContain('Track 1 ·');
+    fireEvent.click(filteredOptions[1]!);
     expect(onSelect).toHaveBeenCalledWith('audio-0:298');
 
-    fireEvent.click(getByRole('button', { name: 'Preview Track 299' }));
+    fireEvent.click(container.querySelector('button[aria-label="Preview Track 299"]')!);
     expect(onPreview).toHaveBeenCalledWith(chapters[298]);
   });
 });

--- a/apps/readest-app/src/__tests__/app/reader/components/audiobook/AudiobookPairingDialog.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/audiobook/AudiobookPairingDialog.test.tsx
@@ -108,17 +108,24 @@ describe('AudiobookPairingDialog', () => {
   });
 
   it('shows book context and mounts only one audio option list while editing a large mapping', () => {
-    render(<AudiobookPairingDialog bookKey='book-hash-view' bookDoc={bookDoc} onClose={vi.fn()} />);
+    const { container } = render(
+      <AudiobookPairingDialog bookKey='book-hash-view' bookDoc={bookDoc} onClose={vi.fn()} />,
+    );
 
-    expect(screen.getByRole('dialog', { name: 'Manage Audiobook' })).toBeTruthy();
-    expect(screen.getByText('A Very Good Book')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'Edit Mapping' }));
+    expect(container.querySelector('[role="dialog"]')?.getAttribute('aria-label')).toBe(
+      'Manage Audiobook',
+    );
+    expect(container.textContent).toContain('A Very Good Book');
+    const editButton = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Edit Mapping',
+    );
+    fireEvent.click(editButton!);
 
-    expect(screen.getByRole('heading', { name: 'Review Chapter Mapping' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Save Changes' })).toBeTruthy();
-    expect(screen.queryAllByRole('option')).toHaveLength(0);
+    expect(container.textContent).toContain('Review Chapter Mapping');
+    expect(container.textContent).toContain('Save Changes');
+    expect(container.querySelectorAll('[role="option"]')).toHaveLength(0);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Audio for Chapter 1' }));
-    expect(screen.getAllByRole('option')).toHaveLength(301);
+    fireEvent.click(container.querySelector('button[aria-label="Audio for Chapter 1"]')!);
+    expect(container.querySelectorAll('[role="option"]')).toHaveLength(301);
   });
 });

--- a/apps/readest-app/src/__tests__/app/reader/components/audiobook/AudiobookPairingDialog.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/audiobook/AudiobookPairingDialog.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AudiobookPairingDialog from '@/app/reader/components/audiobook/AudiobookPairingDialog';
+import type { BookDoc } from '@/libs/document';
+import type { AudiobookChapter, PairedAudiobook } from '@/types/book';
+
+const h = vi.hoisted(() => {
+  const chapters: AudiobookChapter[] = Array.from({ length: 300 }, (_, index) => ({
+    id: `audio-0:${index}`,
+    fileId: 'audio-0',
+    label: `Track ${index + 1}`,
+    start: index * 60,
+    end: (index + 1) * 60,
+  }));
+  const association: PairedAudiobook = {
+    version: 1,
+    files: [
+      {
+        id: 'audio-0',
+        name: 'book.m4b',
+        path: 'book-hash/audiobook/book.m4b',
+        duration: chapters.length * 60,
+      },
+    ],
+    chapters,
+    mappings: chapters.map((chapter, index) => ({
+      ebookChapterId: `chapter-${index + 1}.xhtml`,
+      audioChapterId: chapter.id,
+    })),
+    createdAt: 1,
+  };
+  return {
+    association,
+    config: { audiobook: association as PairedAudiobook | undefined, updatedAt: 1 },
+    book: { hash: 'book-hash', title: 'A Very Good Book', format: 'EPUB' },
+  };
+});
+
+vi.mock('@/components/Dialog', () => ({
+  default: ({ title, children }: { title: string; children: ReactNode }) => (
+    <div role='dialog' aria-label={title}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (value: string, params?: Record<string, string | number>) =>
+    Object.entries(params ?? {}).reduce(
+      (result, [key, replacement]) => result.replace(`{{${key}}}`, String(replacement)),
+      value,
+    ),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: null, envConfig: {} }),
+}));
+
+vi.mock('@/hooks/useFileSelector', () => ({
+  useFileSelector: () => ({ selectFiles: vi.fn() }),
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      getConfig: () => h.config,
+      getBookData: () => ({ book: h.book }),
+      setConfig: vi.fn(),
+      saveConfig: vi.fn(),
+    }),
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: {
+    getState: () => ({
+      getViewSettings: vi.fn(),
+      setViewSettings: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: {} }),
+}));
+
+const bookDoc = {
+  toc: Array.from({ length: 300 }, (_, index) => ({
+    id: index,
+    label: `Chapter ${index + 1}`,
+    href: `chapter-${index + 1}.xhtml`,
+    index,
+  })),
+} as unknown as BookDoc;
+
+describe('AudiobookPairingDialog', () => {
+  beforeEach(() => {
+    h.config.audiobook = h.association;
+  });
+
+  it('identifies the ebook on the first pairing step', () => {
+    h.config.audiobook = undefined;
+    render(<AudiobookPairingDialog bookKey='book-hash-view' bookDoc={bookDoc} onClose={vi.fn()} />);
+
+    expect(screen.getByRole('dialog', { name: 'Pair Audiobook' })).toBeTruthy();
+    expect(screen.getByText(/Pair a local recording with “A Very Good Book”/)).toBeTruthy();
+  });
+
+  it('shows book context and mounts only one audio option list while editing a large mapping', () => {
+    render(<AudiobookPairingDialog bookKey='book-hash-view' bookDoc={bookDoc} onClose={vi.fn()} />);
+
+    expect(screen.getByRole('dialog', { name: 'Manage Audiobook' })).toBeTruthy();
+    expect(screen.getByText('A Very Good Book')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Mapping' }));
+
+    expect(screen.getByRole('heading', { name: 'Review Chapter Mapping' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Save Changes' })).toBeTruthy();
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Audio for Chapter 1' }));
+    expect(screen.getAllByRole('option')).toHaveLength(301);
+  });
+});

--- a/apps/readest-app/src/__tests__/app/reader/components/audiobook/AudiobookStepProgress.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/audiobook/AudiobookStepProgress.test.tsx
@@ -21,5 +21,6 @@ describe('Audiobook StepProgress', () => {
     expect(steps[1]?.classList.contains('step-neutral')).toBe(true);
     expect(steps[2]?.classList.contains('step-neutral')).toBe(false);
     expect(steps[1]?.getAttribute('aria-current')).toBe('step');
+    expect(Array.from(steps, (step) => step.textContent)).toEqual(['Files', 'Align', 'Review']);
   });
 });

--- a/apps/readest-app/src/__tests__/app/reader/components/audiobook/AudiobookStepProgress.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/audiobook/AudiobookStepProgress.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import StepProgress from '@/app/reader/components/audiobook/AudiobookStepProgress';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (value: string) => value,
+}));
+
+describe('Audiobook StepProgress', () => {
+  it('uses daisyUI steps and marks progress through the current step', () => {
+    const { getByRole } = render(<StepProgress current={2} />);
+
+    const progress = getByRole('progressbar', { name: 'Audiobook pairing progress' });
+    const steps = progress.querySelectorAll('li.step');
+
+    expect(progress.classList.contains('steps')).toBe(true);
+    expect(progress.classList.contains('steps-horizontal')).toBe(true);
+    expect(steps).toHaveLength(3);
+    expect(steps[0]?.classList.contains('step-neutral')).toBe(true);
+    expect(steps[1]?.classList.contains('step-neutral')).toBe(true);
+    expect(steps[2]?.classList.contains('step-neutral')).toBe(false);
+    expect(steps[1]?.getAttribute('aria-current')).toBe('step');
+  });
+});

--- a/apps/readest-app/src/__tests__/hooks/useFileSelector.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useFileSelector.test.ts
@@ -21,7 +21,7 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: (cmd: string, args?: { name?: string }) => invokeMock(cmd, args),
 }));
 
-import { useFileSelector } from '@/hooks/useFileSelector';
+import { FILE_SELECTION_PRESETS, useFileSelector } from '@/hooks/useFileSelector';
 import { eventDispatcher } from '@/utils/event';
 
 const _ = (key: string) => key;
@@ -84,6 +84,25 @@ describe('useFileSelector cover selection', () => {
 
     expect(selectFiles).toHaveBeenCalledWith(expect.any(String), ['png', 'jpg', 'jpeg', 'gif']);
     expect(result.files).toHaveLength(1);
+  });
+});
+
+describe('useFileSelector audiobook selection', () => {
+  test('web: advertises M4B explicitly when the browser has no MIME registration for it', () => {
+    expect(FILE_SELECTION_PRESETS.audio.accept.split(',')).toContain('.m4b');
+  });
+
+  test('Android: uses an unfiltered picker so M4B files are selectable, then filters locally', async () => {
+    basenameMock.mockResolvedValueOnce('Novel.m4b');
+    const { appService, selectFiles } = makeAppService('android', [
+      'content://com.android.providers.downloads/document/42',
+    ]);
+    const { selectFiles: select } = useFileSelector(appService, _);
+
+    const result = await select({ type: 'audio', multiple: true });
+
+    expect(selectFiles).toHaveBeenCalledWith(expect.any(String), []);
+    expect(result.files).toEqual([expect.objectContaining({ name: 'Novel.m4b' })]);
   });
 });
 

--- a/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useProgressSync.test.tsx
@@ -117,7 +117,18 @@ vi.mock('@/store/libraryStore', () => ({
 }));
 
 vi.mock('@/utils/serializer', () => ({
-  serializeConfig: () => JSON.stringify({ progress: [5, 100], location: 'cfi-loc' }),
+  serializeConfig: () =>
+    JSON.stringify({
+      progress: [5, 100],
+      location: 'cfi-loc',
+      audiobook: {
+        version: 1,
+        files: [{ path: 'h1/audiobook/private.m4b' }],
+        chapters: [],
+        mappings: [],
+        createdAt: 1,
+      },
+    }),
 }));
 
 vi.mock('@/utils/xcfi', () => ({
@@ -212,6 +223,16 @@ describe('useProgressSync', () => {
 
     expect(h.syncConfigsMock).toHaveBeenCalledWith(expect.any(Array), 'h1', 'm1', 'push');
     expect(h.syncBooksMock).not.toHaveBeenCalled();
+  });
+
+  test('does not upload the device-local audiobook association', async () => {
+    renderHook(() => useProgressSync('h1-view1'));
+    await flushAutoSync();
+
+    const push = h.syncConfigsMock.mock.calls.find((call) => (call as unknown[])[3] === 'push') as
+      | unknown[]
+      | undefined;
+    expect((push?.[0] as unknown[])?.[0]).not.toHaveProperty('audiobook');
   });
 
   test('retries the first pull on failure with backoff, then releases the gate', async () => {

--- a/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
@@ -206,6 +206,7 @@ const { mockSessionManager } = vi.hoisted(() => ({
     getSessionByHash: vi.fn((_hash: string) => null as unknown),
     getActiveSession: vi.fn(() => null as unknown),
     stopActive: vi.fn().mockResolvedValue(undefined),
+    stopBook: vi.fn().mockResolvedValue(undefined),
     stopController: vi.fn(
       async (_bookHash: string, controller: { shutdown: () => Promise<void> }) =>
         controller.shutdown().catch(() => {}),
@@ -566,6 +567,34 @@ describe('useTTSControl handleStop resilience (#4676)', () => {
     });
 
     expect(setTTSEnabled).toHaveBeenCalledWith('book-1', false);
+  });
+
+  it('keeps an awaited tts-stop dispatch pending until controller shutdown finishes', async () => {
+    const controller = await startSession();
+    let finishShutdown!: () => void;
+    const teardown = new Promise<void>((resolve) => {
+      finishShutdown = resolve;
+    });
+    controller.shutdown.mockReturnValueOnce(teardown);
+    mockSessionManager.stopBook.mockReturnValueOnce(teardown);
+
+    let firstStopped = false;
+    let secondStopped = false;
+    const firstStop = eventDispatcher.dispatch('tts-stop', { bookKey: 'book-1' }).then(() => {
+      firstStopped = true;
+    });
+    const secondStop = eventDispatcher.dispatch('tts-stop', { bookKey: 'book-1' }).then(() => {
+      secondStopped = true;
+    });
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+
+    expect(firstStopped).toBe(false);
+    expect(secondStopped).toBe(false);
+    expect(mockSessionManager.stopBook).toHaveBeenCalledWith('book', 'user');
+    finishShutdown();
+    await Promise.all([firstStop, secondStop]);
+    expect(firstStopped).toBe(true);
+    expect(secondStopped).toBe(true);
   });
 
   it('disables TTS even when controller.shutdown never resolves', async () => {

--- a/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // --- Dependency mocks (must be set up before importing the hook) ---
@@ -146,6 +146,7 @@ vi.mock('@/services/tts', () => ({
       pause: vi.fn().mockResolvedValue(undefined),
       resume: vi.fn().mockResolvedValue(undefined),
       start: vi.fn().mockResolvedValue(undefined),
+      startFromRange: vi.fn().mockReturnValue('<speak>hello</speak>'),
       stop: vi.fn().mockResolvedValue(undefined),
       shutdown: vi.fn().mockResolvedValue(undefined),
       forward: vi.fn().mockResolvedValue(undefined),
@@ -162,6 +163,7 @@ vi.mock('@/services/tts', () => ({
       getSentenceProgress: vi.fn().mockReturnValue(null),
       isSoundingSentenceOnScreen: vi.fn().mockReturnValue(false),
       getCurrentHighlightCfi: vi.fn().mockReturnValue(null),
+      getCurrentPlaybackCfi: vi.fn().mockReturnValue(null),
       reapplyCurrentHighlight: vi.fn(),
       terminated: false,
       isViewAttached: true,
@@ -347,6 +349,7 @@ describe('useTTSControl reading a selection aloud', () => {
     });
     const controller = ttsControllerInstances[0] as unknown as {
       speak: ReturnType<typeof vi.fn>;
+      startFromRange: ReturnType<typeof vi.fn>;
     };
     return { range, controller };
   };
@@ -356,7 +359,7 @@ describe('useTTSControl reading a selection aloud', () => {
 
     const { range, controller } = await speakSelection();
 
-    expect(mockView.tts.from).toHaveBeenCalledWith(range);
+    expect(controller.startFromRange).toHaveBeenCalledWith(range);
     // Not a one-shot: the session goes on from that passage rather than being
     // stopped by the one-time callback as soon as the first clip ends.
     expect(controller.speak).toHaveBeenCalledWith(expect.anything(), false, expect.any(Function));
@@ -430,6 +433,28 @@ describe('useTTSControl back-to-position prompt', () => {
 
   it('appears when the reader has paged away from the sentence entirely', async () => {
     expect(await startSessionThenRelocate(false)).toBe('true');
+  });
+
+  it('returns to the live narration position instead of a stale saved mark', async () => {
+    const BackHarness = () => {
+      const tts = useTTSControl({ bookKey: 'book-1' });
+      return <button onClick={tts.handleBackToCurrentTTSLocation}>Back</button>;
+    };
+    render(<BackHarness />);
+    await act(async () => {
+      const p = eventDispatcher.dispatch('tts-speak', { bookKey: 'book-1' });
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      while (pendingInitResolvers.length > 0) pendingInitResolvers.shift()!();
+      await p;
+    });
+    const controller = ttsControllerInstances[0] as unknown as {
+      getCurrentPlaybackCfi: ReturnType<typeof vi.fn>;
+    };
+    controller.getCurrentPlaybackCfi.mockReturnValue('live-narration-cfi');
+
+    fireEvent.click(screen.getByText('Back'));
+
+    expect(mockView.resolveNavigation).toHaveBeenLastCalledWith('live-narration-cfi');
   });
 });
 
@@ -972,6 +997,7 @@ describe('useTTSControl background session lifecycle', () => {
       attachView: vi.fn().mockResolvedValue(undefined),
       getSpeakingLang: vi.fn().mockReturnValue('en'),
       getCurrentHighlightCfi: vi.fn().mockReturnValue(null),
+      getCurrentPlaybackCfi: vi.fn().mockReturnValue(null),
       isSoundingSentenceOnScreen: vi.fn().mockReturnValue(false),
       getSpokenSentence: vi.fn().mockReturnValue(null),
       updateHighlightOptions: vi.fn(),

--- a/apps/readest-app/src/__tests__/services/audiobook-mapping.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-mapping.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TOCItem } from '@/libs/document';
+import {
+  buildSequentialAudiobookMappings,
+  collectAudiobookTextChapters,
+} from '@/services/audiobook/mapping';
+
+describe('collectAudiobookTextChapters', () => {
+  it('flattens nested TOC entries in reading order and drops duplicate hrefs', () => {
+    const toc: TOCItem[] = [
+      {
+        id: 0,
+        label: 'Part One',
+        href: 'part-1.xhtml',
+        index: 0,
+        subitems: [
+          { id: 1, label: 'Chapter 1', href: 'chapter-1.xhtml', index: 0 },
+          { id: 2, label: 'Chapter 2', href: 'chapter-2.xhtml', index: 0 },
+        ],
+      },
+      { id: 3, label: 'Chapter 2 again', href: 'chapter-2.xhtml', index: 0 },
+      { id: 4, label: 'Chapter 3', href: 'chapter-3.xhtml#start', index: 0 },
+    ];
+
+    expect(collectAudiobookTextChapters(toc)).toEqual([
+      { id: 'part-1.xhtml', label: 'Part One', href: 'part-1.xhtml' },
+      { id: 'chapter-1.xhtml', label: 'Chapter 1', href: 'chapter-1.xhtml' },
+      { id: 'chapter-2.xhtml', label: 'Chapter 2', href: 'chapter-2.xhtml' },
+      {
+        id: 'chapter-3.xhtml#start',
+        label: 'Chapter 3',
+        href: 'chapter-3.xhtml#start',
+      },
+    ]);
+  });
+});
+
+describe('buildSequentialAudiobookMappings', () => {
+  const ebookChapterIds = ['cover', 'introduction', 'chapter-1', 'chapter-2'];
+  const audioChapterIds = ['track-1', 'track-2', 'track-3'];
+
+  it('maps forward and backward from the selected anchor pair', () => {
+    expect(
+      buildSequentialAudiobookMappings(ebookChapterIds, audioChapterIds, {
+        ebookChapterId: 'introduction',
+        audioChapterId: 'track-1',
+      }),
+    ).toEqual([
+      { ebookChapterId: 'introduction', audioChapterId: 'track-1' },
+      { ebookChapterId: 'chapter-1', audioChapterId: 'track-2' },
+      { ebookChapterId: 'chapter-2', audioChapterId: 'track-3' },
+    ]);
+  });
+
+  it('leaves audio before the anchor and ebook chapters after the available audio unmapped', () => {
+    expect(
+      buildSequentialAudiobookMappings(ebookChapterIds, audioChapterIds, {
+        ebookChapterId: 'cover',
+        audioChapterId: 'track-2',
+      }),
+    ).toEqual([
+      { ebookChapterId: 'cover', audioChapterId: 'track-2' },
+      { ebookChapterId: 'introduction', audioChapterId: 'track-3' },
+    ]);
+  });
+
+  it('returns no mappings when either anchor no longer exists', () => {
+    expect(
+      buildSequentialAudiobookMappings(ebookChapterIds, audioChapterIds, {
+        ebookChapterId: 'missing',
+        audioChapterId: 'track-1',
+      }),
+    ).toEqual([]);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/audiobook-metadata.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-metadata.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { parseBlob } from 'music-metadata';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { buildAudiobookChapters } from '@/services/audiobook/metadata';
+import { buildAudiobookChapters, parseAudiobookFile } from '@/services/audiobook/metadata';
+
+vi.mock('music-metadata', () => ({ parseBlob: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(parseBlob).mockReset();
+});
 
 describe('buildAudiobookChapters', () => {
   it('converts MP4 chapter timescales and derives missing end times', () => {
@@ -57,5 +64,50 @@ describe('buildAudiobookChapters', () => {
         end: 91,
       },
     ]);
+  });
+});
+
+describe('parseAudiobookFile', () => {
+  it('reads title, narrator, duration, and fallback chapter metadata', async () => {
+    vi.mocked(parseBlob).mockResolvedValue({
+      format: { duration: 90, chapters: [], trackInfo: [], tagTypes: [] },
+      common: {
+        title: 'Opening',
+        album: 'The Book',
+        albumartist: 'A Narrator',
+        track: { no: null, of: null },
+        disk: { no: null, of: null },
+        movementIndex: { no: null, of: null },
+      },
+      native: {},
+      quality: { warnings: [] },
+    });
+
+    await expect(
+      parseAudiobookFile(new File(['audio'], 'book.m4b'), 'audio-0'),
+    ).resolves.toMatchObject({
+      id: 'audio-0',
+      title: 'The Book',
+      narrator: 'A Narrator',
+      duration: 90,
+      chapters: [{ label: 'Opening', start: 0, end: 90 }],
+    });
+  });
+
+  it('rejects audio whose duration cannot be determined', async () => {
+    vi.mocked(parseBlob).mockResolvedValue({
+      format: { chapters: [], trackInfo: [], tagTypes: [] },
+      common: {
+        track: { no: null, of: null },
+        disk: { no: null, of: null },
+        movementIndex: { no: null, of: null },
+      },
+      native: {},
+      quality: { warnings: [] },
+    });
+
+    await expect(parseAudiobookFile(new File(['audio'], 'broken.m4b'), 'audio-0')).rejects.toThrow(
+      'Could not determine the duration of broken.m4b',
+    );
   });
 });

--- a/apps/readest-app/src/__tests__/services/audiobook-metadata.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-metadata.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAudiobookChapters } from '@/services/audiobook/metadata';
+
+describe('buildAudiobookChapters', () => {
+  it('converts MP4 chapter timescales and derives missing end times', () => {
+    expect(
+      buildAudiobookChapters('audio-0', 'Novel.m4b', 75, [
+        { title: 'Opening', start: 0, timeScale: 1_000 },
+        { title: 'Chapter 1', start: 15_000, timeScale: 1_000 },
+        { title: 'Chapter 2', start: 45_000, timeScale: 1_000 },
+      ]),
+    ).toEqual([
+      {
+        id: 'audio-0:0',
+        fileId: 'audio-0',
+        label: 'Opening',
+        start: 0,
+        end: 15,
+      },
+      {
+        id: 'audio-0:1',
+        fileId: 'audio-0',
+        label: 'Chapter 1',
+        start: 15,
+        end: 45,
+      },
+      {
+        id: 'audio-0:2',
+        fileId: 'audio-0',
+        label: 'Chapter 2',
+        start: 45,
+        end: 75,
+      },
+    ]);
+  });
+
+  it('uses ID3 chapter seconds directly', () => {
+    expect(
+      buildAudiobookChapters('audio-1', 'Track.mp3', 30, [
+        { title: 'First', start: 2, end: 12 },
+        { title: 'Second', start: 12, end: 30 },
+      ]),
+    ).toEqual([
+      { id: 'audio-1:0', fileId: 'audio-1', label: 'First', start: 2, end: 12 },
+      { id: 'audio-1:1', fileId: 'audio-1', label: 'Second', start: 12, end: 30 },
+    ]);
+  });
+
+  it('falls back to one full-file chapter when the file has no chapter table', () => {
+    expect(buildAudiobookChapters('audio-2', '03 - The Journey.mp3', 91, [])).toEqual([
+      {
+        id: 'audio-2:0',
+        fileId: 'audio-2',
+        label: '03 - The Journey',
+        start: 0,
+        end: 91,
+      },
+    ]);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/audiobook-preview.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-preview.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AudiobookPreviewPlayer } from '@/services/audiobook/preview';
+import type { AppService } from '@/types/system';
+
+class FakeAudio {
+  static instances: FakeAudio[] = [];
+  src = '';
+  currentTime = 0;
+  play = vi.fn().mockResolvedValue(undefined);
+  pause = vi.fn();
+  listeners = new Map<string, Set<() => void>>();
+
+  constructor() {
+    FakeAudio.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: () => void) {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: () => void) {
+    this.listeners.get(type)?.delete(listener);
+  }
+}
+
+const createObjectURL = vi.fn(() => 'blob:audiobook-preview');
+const revokeObjectURL = vi.fn();
+
+const makeAppService = (overrides: Partial<AppService> = {}) =>
+  ({
+    appPlatform: 'web',
+    isMobileApp: false,
+    openFile: vi.fn(),
+    resolveFilePath: vi.fn(),
+    ...overrides,
+  }) as AppService;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  FakeAudio.instances = [];
+  createObjectURL.mockClear();
+  revokeObjectURL.mockClear();
+  vi.stubGlobal('Audio', FakeAudio);
+  Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL });
+  Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('AudiobookPreviewPlayer', () => {
+  it('previews the selected clip and toggles it off without retaining a blob URL', async () => {
+    const onStopped = vi.fn();
+    const player = new AudiobookPreviewPlayer(makeAppService(), onStopped);
+    const file = new File(['audio'], 'book.m4b', { type: 'audio/mp4' });
+
+    expect(await player.toggle({ id: 'audio-0:1', file, start: 12, end: 42 })).toBe(true);
+    const audio = FakeAudio.instances[0]!;
+    expect(audio.src).toBe('blob:audiobook-preview');
+    expect(audio.currentTime).toBe(12);
+    expect(audio.play).toHaveBeenCalledOnce();
+
+    expect(await player.toggle({ id: 'audio-0:1', file, start: 12, end: 42 })).toBe(false);
+    expect(audio.pause).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:audiobook-preview');
+    expect(onStopped).toHaveBeenCalledWith('audio-0:1');
+  });
+
+  it('stops at the end of a short chapter preview and closes files it opened', async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const opened = Object.assign(new File(['audio'], 'stored.m4b'), { close });
+    const appService = makeAppService({
+      openFile: vi.fn().mockResolvedValue(opened),
+    });
+    const onStopped = vi.fn();
+    const player = new AudiobookPreviewPlayer(appService, onStopped);
+
+    await player.toggle({
+      id: 'audio-0:0',
+      path: 'hash/audiobook/stored.m4b',
+      base: 'Books',
+      start: 5,
+      end: 7,
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(FakeAudio.instances[0]!.pause).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+    expect(onStopped).toHaveBeenCalledWith('audio-0:0');
+  });
+});

--- a/apps/readest-app/src/__tests__/services/audiobook-preview.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-preview.test.ts
@@ -5,9 +5,10 @@ import type { AppService } from '@/types/system';
 
 class FakeAudio {
   static instances: FakeAudio[] = [];
+  static playImplementations: Array<() => Promise<void>> = [];
   src = '';
   currentTime = 0;
-  play = vi.fn().mockResolvedValue(undefined);
+  play = vi.fn(() => FakeAudio.playImplementations.shift()?.() ?? Promise.resolve());
   pause = vi.fn();
   listeners = new Map<string, Set<() => void>>();
 
@@ -41,6 +42,7 @@ const makeAppService = (overrides: Partial<AppService> = {}) =>
 beforeEach(() => {
   vi.useFakeTimers();
   FakeAudio.instances = [];
+  FakeAudio.playImplementations = [];
   createObjectURL.mockClear();
   revokeObjectURL.mockClear();
   vi.stubGlobal('Audio', FakeAudio);
@@ -92,5 +94,35 @@ describe('AudiobookPreviewPlayer', () => {
     expect(FakeAudio.instances[0]!.pause).toHaveBeenCalledOnce();
     expect(close).toHaveBeenCalledOnce();
     expect(onStopped).toHaveBeenCalledWith('audio-0:0');
+  });
+
+  it('serializes rapid preview switches so a stale request cannot stop the latest clip', async () => {
+    let resolveFirstPlay!: () => void;
+    FakeAudio.playImplementations = [
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirstPlay = resolve;
+        }),
+      () => Promise.resolve(),
+    ];
+    const onStopped = vi.fn();
+    const player = new AudiobookPreviewPlayer(makeAppService(), onStopped);
+    const file = new File(['audio'], 'book.m4b', { type: 'audio/mp4' });
+
+    const first = player.toggle({ id: 'first', file, start: 0, end: 1 });
+    for (let index = 0; index < 10 && !resolveFirstPlay; index += 1) await Promise.resolve();
+    const second = player.toggle({ id: 'second', file, start: 10, end: 25 });
+    for (let index = 0; index < 10; index += 1) await Promise.resolve();
+    const instancesBeforeFirstResolved = FakeAudio.instances.length;
+
+    resolveFirstPlay();
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(true);
+    expect(instancesBeforeFirstResolved).toBe(1);
+    expect(FakeAudio.instances).toHaveLength(2);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(FakeAudio.instances[1]!.pause).not.toHaveBeenCalled();
+    expect(onStopped).not.toHaveBeenCalledWith('second');
   });
 });

--- a/apps/readest-app/src/__tests__/services/audiobook-preview.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-preview.test.ts
@@ -1,5 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const tauriMocks = vi.hoisted(() => ({
+  addPluginListener: vi.fn(),
+  invoke: vi.fn(),
+  unregister: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  addPluginListener: tauriMocks.addPluginListener,
+  convertFileSrc: vi.fn((path: string) => path),
+  invoke: tauriMocks.invoke,
+}));
+
 import { AudiobookPreviewPlayer } from '@/services/audiobook/preview';
 import type { AppService } from '@/types/system';
 
@@ -45,6 +57,11 @@ beforeEach(() => {
   FakeAudio.playImplementations = [];
   createObjectURL.mockClear();
   revokeObjectURL.mockClear();
+  tauriMocks.unregister.mockReset();
+  tauriMocks.addPluginListener.mockResolvedValue({ unregister: tauriMocks.unregister });
+  tauriMocks.invoke.mockImplementation(async (command: string) =>
+    command === 'plugin:native-tts|playout_control' ? { session: 1 } : undefined,
+  );
   vi.stubGlobal('Audio', FakeAudio);
   Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL });
   Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL });
@@ -124,5 +141,19 @@ describe('AudiobookPreviewPlayer', () => {
     await vi.advanceTimersByTimeAsync(1_000);
     expect(FakeAudio.instances[1]!.pause).not.toHaveBeenCalled();
     expect(onStopped).not.toHaveBeenCalledWith('second');
+  });
+
+  it('unregisters the native playback listener when a mobile preview stops', async () => {
+    const appService = makeAppService({
+      appPlatform: 'tauri',
+      isMobileApp: true,
+      resolveFilePath: vi.fn().mockResolvedValue('/books/book.m4b'),
+    });
+    const player = new AudiobookPreviewPlayer(appService, vi.fn());
+
+    await player.toggle({ id: 'chapter-1', path: 'book.m4b', start: 0, end: 30 });
+    await player.stop();
+
+    expect(tauriMocks.unregister).toHaveBeenCalledOnce();
   });
 });

--- a/apps/readest-app/src/__tests__/services/audiobook-storage.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-storage.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { AudiobookChapterMapping, PairedAudiobook } from '@/types/book';
 import {
   importPairedAudiobook,
+  replacePairedAudiobook,
   removePairedAudiobook,
   type AudiobookStorage,
 } from '@/services/audiobook/storage';
@@ -46,10 +47,9 @@ describe('paired audiobook storage', () => {
     ]);
 
     expect(storage.createDir).toHaveBeenCalledWith('book-hash/audiobook', 'Books', true);
-    expect(storage.writeFile).toHaveBeenCalledWith(
-      'book-hash/audiobook/audio-0-01_ Opening_.mp3',
-      'Books',
-      file,
+    expect(storage.writeFile).toHaveBeenCalledWith(association.files[0]!.path, 'Books', file);
+    expect(association.files[0]!.path).toMatch(
+      /^book-hash\/audiobook\/\d+-audio-0-01_ Opening_\.mp3$/,
     );
     expect(association).toMatchObject({
       version: 1,
@@ -59,7 +59,7 @@ describe('paired audiobook storage', () => {
         {
           id: 'audio-0',
           name: '01: Opening?.mp3',
-          path: 'book-hash/audiobook/audio-0-01_ Opening_.mp3',
+          path: association.files[0]!.path,
           duration: 42,
         },
       ],
@@ -80,7 +80,7 @@ describe('paired audiobook storage', () => {
     const storage = makeStorage();
     const file = new File([], 'Novel.m4b', { type: 'audio/mp4' });
 
-    await importPairedAudiobook(
+    const association = await importPairedAudiobook(
       storage,
       'book-hash',
       [],
@@ -109,7 +109,7 @@ describe('paired audiobook storage', () => {
     expect(storage.copyFile).toHaveBeenCalledWith(
       '/picked/Novel.m4b',
       'None',
-      'book-hash/audiobook/audio-0-Novel.m4b',
+      association.files[0]!.path,
       'Books',
     );
     expect(storage.writeFile).not.toHaveBeenCalled();
@@ -125,12 +125,17 @@ describe('paired audiobook storage', () => {
       createdAt: 1,
     };
 
-    await removePairedAudiobook(storage, 'book-hash', association);
+    const persist = vi.fn().mockResolvedValue(undefined);
+    await removePairedAudiobook(storage, 'book-hash', association, persist);
 
+    expect(persist).toHaveBeenCalledWith(undefined);
     expect(storage.deleteDir).toHaveBeenCalledWith('book-hash/audiobook', 'Books', true);
+    expect(persist.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(storage.deleteDir).mock.invocationCallOrder[0]!,
+    );
   });
 
-  it('deletes files left behind when an existing pairing is replaced', async () => {
+  it('persists a replacement before deleting files left behind by the previous pairing', async () => {
     const storage = makeStorage();
     const file = new File(['new'], 'new.mp3', { type: 'audio/mpeg' });
     const previous: PairedAudiobook = {
@@ -141,7 +146,8 @@ describe('paired audiobook storage', () => {
       createdAt: 1,
     };
 
-    await importPairedAudiobook(
+    const persist = vi.fn().mockResolvedValue(undefined);
+    await replacePairedAudiobook(
       storage,
       'book-hash',
       [],
@@ -165,8 +171,134 @@ describe('paired audiobook storage', () => {
         },
       ],
       previous,
+      persist,
     );
 
+    expect(persist).toHaveBeenCalledOnce();
     expect(storage.deleteFile).toHaveBeenCalledWith('book-hash/audiobook/old.mp3', 'Books');
+    expect(persist.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(storage.deleteFile).mock.invocationCallOrder.at(-1)!,
+    );
+  });
+
+  it('never deletes paths outside the current book audiobook directory', async () => {
+    const storage = makeStorage();
+    const file = new File(['new'], 'new.mp3', { type: 'audio/mpeg' });
+    const previous: PairedAudiobook = {
+      version: 1,
+      files: [
+        { id: 'safe', name: 'safe.mp3', path: 'book-hash/audiobook/safe.mp3', duration: 10 },
+        { id: 'other', name: 'other.epub', path: 'other-book/book.epub', duration: 10 },
+        {
+          id: 'traversal',
+          name: 'private.json',
+          path: 'book-hash/audiobook/../../private.json',
+          duration: 10,
+        },
+        { id: 'absolute', name: 'absolute', path: '/private/absolute', duration: 10 },
+      ],
+      chapters: [],
+      mappings: [],
+      createdAt: 1,
+    };
+
+    await replacePairedAudiobook(
+      storage,
+      'book-hash',
+      [],
+      [
+        {
+          file,
+          metadata: {
+            id: 'audio-0',
+            name: file.name,
+            duration: 20,
+            chapters: [
+              {
+                id: 'audio-0:0',
+                fileId: 'audio-0',
+                label: 'New',
+                start: 0,
+                end: 20,
+              },
+            ],
+          },
+        },
+      ],
+      previous,
+      vi.fn().mockResolvedValue(undefined),
+    );
+
+    expect(storage.deleteFile).toHaveBeenCalledTimes(1);
+    expect(storage.deleteFile).toHaveBeenCalledWith('book-hash/audiobook/safe.mp3', 'Books');
+  });
+
+  it('rolls back newly copied files and preserves old files when config persistence fails', async () => {
+    const storage = makeStorage();
+    const file = new File(['new'], 'new.mp3', { type: 'audio/mpeg' });
+    const previous: PairedAudiobook = {
+      version: 1,
+      files: [{ id: 'old-0', name: 'old.mp3', path: 'book-hash/audiobook/old.mp3', duration: 10 }],
+      chapters: [],
+      mappings: [],
+      createdAt: 1,
+    };
+    const persistError = new Error('config write failed');
+
+    await expect(
+      replacePairedAudiobook(
+        storage,
+        'book-hash',
+        [],
+        [
+          {
+            file,
+            metadata: {
+              id: 'audio-0',
+              name: file.name,
+              duration: 20,
+              chapters: [
+                {
+                  id: 'audio-0:0',
+                  fileId: 'audio-0',
+                  label: 'New',
+                  start: 0,
+                  end: 20,
+                },
+              ],
+            },
+          },
+        ],
+        previous,
+        vi.fn().mockRejectedValue(persistError),
+      ),
+    ).rejects.toBe(persistError);
+
+    const deletedPaths = vi.mocked(storage.deleteFile).mock.calls.map(([path]) => path);
+    expect(deletedPaths).not.toContain('book-hash/audiobook/old.mp3');
+    expect(deletedPaths).toHaveLength(1);
+    expect(deletedPaths[0]).toMatch(/^book-hash\/audiobook\/\d+-audio-0-new\.mp3$/);
+  });
+
+  it('does not remove files when clearing the persisted association fails', async () => {
+    const storage = makeStorage();
+    const association: PairedAudiobook = {
+      version: 1,
+      files: [],
+      chapters: [],
+      mappings: [],
+      createdAt: 1,
+    };
+
+    await expect(
+      removePairedAudiobook(
+        storage,
+        'book-hash',
+        association,
+        vi.fn().mockRejectedValue(new Error('config write failed')),
+      ),
+    ).rejects.toThrow('config write failed');
+
+    expect(storage.deleteDir).not.toHaveBeenCalled();
   });
 });

--- a/apps/readest-app/src/__tests__/services/audiobook-storage.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-storage.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AudiobookChapterMapping, PairedAudiobook } from '@/types/book';
+import {
+  importPairedAudiobook,
+  removePairedAudiobook,
+  type AudiobookStorage,
+} from '@/services/audiobook/storage';
+
+const makeStorage = (): AudiobookStorage => ({
+  createDir: vi.fn().mockResolvedValue(undefined),
+  copyFile: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  deleteFile: vi.fn().mockResolvedValue(undefined),
+  deleteDir: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('paired audiobook storage', () => {
+  it('copies selected files into the book directory and persists relative paths', async () => {
+    const storage = makeStorage();
+    const file = new File(['audio'], '01: Opening?.mp3', { type: 'audio/mpeg' });
+    const mappings: AudiobookChapterMapping[] = [
+      { ebookChapterId: 'opening.xhtml', audioChapterId: 'audio-0:0' },
+    ];
+
+    const association = await importPairedAudiobook(storage, 'book-hash', mappings, [
+      {
+        file,
+        metadata: {
+          id: 'audio-0',
+          name: file.name,
+          duration: 42,
+          title: 'The Book',
+          narrator: 'A Narrator',
+          chapters: [
+            {
+              id: 'audio-0:0',
+              fileId: 'audio-0',
+              label: 'Opening',
+              start: 0,
+              end: 42,
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(storage.createDir).toHaveBeenCalledWith('book-hash/audiobook', 'Books', true);
+    expect(storage.writeFile).toHaveBeenCalledWith(
+      'book-hash/audiobook/audio-0-01_ Opening_.mp3',
+      'Books',
+      file,
+    );
+    expect(association).toMatchObject({
+      version: 1,
+      title: 'The Book',
+      narrator: 'A Narrator',
+      files: [
+        {
+          id: 'audio-0',
+          name: '01: Opening?.mp3',
+          path: 'book-hash/audiobook/audio-0-01_ Opening_.mp3',
+          duration: 42,
+        },
+      ],
+      chapters: [
+        {
+          id: 'audio-0:0',
+          fileId: 'audio-0',
+          label: 'Opening',
+          start: 0,
+          end: 42,
+        },
+      ],
+      mappings,
+    });
+  });
+
+  it('copies a native picker path without streaming the full audiobook through JavaScript', async () => {
+    const storage = makeStorage();
+    const file = new File([], 'Novel.m4b', { type: 'audio/mp4' });
+
+    await importPairedAudiobook(
+      storage,
+      'book-hash',
+      [],
+      [
+        {
+          file,
+          sourcePath: '/picked/Novel.m4b',
+          metadata: {
+            id: 'audio-0',
+            name: file.name,
+            duration: 3_600,
+            chapters: [
+              {
+                id: 'audio-0:0',
+                fileId: 'audio-0',
+                label: 'Novel',
+                start: 0,
+                end: 3_600,
+              },
+            ],
+          },
+        },
+      ],
+    );
+
+    expect(storage.copyFile).toHaveBeenCalledWith(
+      '/picked/Novel.m4b',
+      'None',
+      'book-hash/audiobook/audio-0-Novel.m4b',
+      'Books',
+    );
+    expect(storage.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('removes only the paired-audio directory', async () => {
+    const storage = makeStorage();
+    const association: PairedAudiobook = {
+      version: 1,
+      files: [],
+      chapters: [],
+      mappings: [],
+      createdAt: 1,
+    };
+
+    await removePairedAudiobook(storage, 'book-hash', association);
+
+    expect(storage.deleteDir).toHaveBeenCalledWith('book-hash/audiobook', 'Books', true);
+  });
+
+  it('deletes files left behind when an existing pairing is replaced', async () => {
+    const storage = makeStorage();
+    const file = new File(['new'], 'new.mp3', { type: 'audio/mpeg' });
+    const previous: PairedAudiobook = {
+      version: 1,
+      files: [{ id: 'old-0', name: 'old.mp3', path: 'book-hash/audiobook/old.mp3', duration: 10 }],
+      chapters: [],
+      mappings: [],
+      createdAt: 1,
+    };
+
+    await importPairedAudiobook(
+      storage,
+      'book-hash',
+      [],
+      [
+        {
+          file,
+          metadata: {
+            id: 'audio-0',
+            name: file.name,
+            duration: 20,
+            chapters: [
+              {
+                id: 'audio-0:0',
+                fileId: 'audio-0',
+                label: 'New',
+                start: 0,
+                end: 20,
+              },
+            ],
+          },
+        },
+      ],
+      previous,
+    );
+
+    expect(storage.deleteFile).toHaveBeenCalledWith('book-hash/audiobook/old.mp3', 'Books');
+  });
+});

--- a/apps/readest-app/src/__tests__/services/audiobook-storage.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-storage.test.ts
@@ -115,6 +115,39 @@ describe('paired audiobook storage', () => {
     expect(storage.writeFile).not.toHaveBeenCalled();
   });
 
+  it('removes every partially imported file when a later copy fails', async () => {
+    const storage = makeStorage();
+    vi.mocked(storage.copyFile)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('copy failed'));
+    const importFile = (index: number): Parameters<typeof importPairedAudiobook>[3][number] => ({
+      file: new File([], `${index}.mp3`, { type: 'audio/mpeg' }),
+      sourcePath: `/picked/${index}.mp3`,
+      metadata: {
+        id: `audio-${index}`,
+        name: `${index}.mp3`,
+        duration: 10,
+        chapters: [
+          {
+            id: `audio-${index}:0`,
+            fileId: `audio-${index}`,
+            label: `Chapter ${index}`,
+            start: 0,
+            end: 10,
+          },
+        ],
+      },
+    });
+
+    await expect(
+      importPairedAudiobook(storage, 'book-hash', [], [importFile(1), importFile(2)]),
+    ).rejects.toThrow('copy failed');
+
+    const attemptedPaths = vi.mocked(storage.copyFile).mock.calls.map(([, , path]) => path);
+    expect(storage.deleteFile).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(storage.deleteFile).mock.calls.map(([path]) => path)).toEqual(attemptedPaths);
+  });
+
   it('removes only the paired-audio directory', async () => {
     const storage = makeStorage();
     const association: PairedAudiobook = {

--- a/apps/readest-app/src/__tests__/services/import-metahash.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-metahash.test.ts
@@ -257,6 +257,101 @@ describe('importBook metaHash deduplication', () => {
     expect(fs.removeDir).toHaveBeenCalledWith('old-hash-123', 'Books', true);
   });
 
+  it('copies paired audiobook files and rewrites their paths before removing the old hash', async () => {
+    const metaHash = getMetadataHash(TEST_METADATA);
+    const existingBook = makeBook({ hash: 'old-hash-123', metaHash });
+    const books: Book[] = [existingBook];
+    mockPartialMD5.mockResolvedValue('new-hash-456');
+    setupMockBookDoc();
+
+    const fs = service.getFs();
+    fs.exists.mockImplementation(async (path: string) =>
+      ['old-hash-123/config.json', 'old-hash-123'].includes(path),
+    );
+    fs.readFile.mockResolvedValue(
+      JSON.stringify({
+        audiobook: {
+          version: 1,
+          files: [
+            {
+              id: 'audio-0',
+              name: 'book.m4b',
+              path: 'old-hash-123/audiobook/1-audio-0-book.m4b',
+              duration: 100,
+            },
+          ],
+          chapters: [],
+          mappings: [],
+          createdAt: 1,
+        },
+      }),
+    );
+
+    await service.importBook(
+      new File(['new content'], 'test.epub', { type: 'application/epub+zip' }),
+      books,
+    );
+
+    expect(fs.createDir).toHaveBeenCalledWith('new-hash-456/audiobook', 'Books', true);
+    expect(fs.copyFile).toHaveBeenCalledWith(
+      'old-hash-123/audiobook/1-audio-0-book.m4b',
+      'Books',
+      'new-hash-456/audiobook/1-audio-0-book.m4b',
+      'Books',
+    );
+    const configWrite = fs.writeFile.mock.calls.find(
+      (call: unknown[]) => call[0] === 'new-hash-456/config.json',
+    );
+    const writtenConfig = JSON.parse(configWrite![2] as string);
+    expect(writtenConfig.audiobook.files[0].path).toBe('new-hash-456/audiobook/1-audio-0-book.m4b');
+    expect(
+      fs.writeFile.mock.invocationCallOrder[fs.writeFile.mock.calls.indexOf(configWrite!)],
+    ).toBeLessThan(fs.removeDir.mock.invocationCallOrder[0]!);
+  });
+
+  it('keeps the old book directory when paired-audio migration fails', async () => {
+    const metaHash = getMetadataHash(TEST_METADATA);
+    const existingBook = makeBook({ hash: 'old-hash-123', metaHash });
+    const books: Book[] = [existingBook];
+    mockPartialMD5.mockResolvedValue('new-hash-456');
+    setupMockBookDoc();
+
+    const fs = service.getFs();
+    fs.exists.mockImplementation(async (path: string) =>
+      ['old-hash-123/config.json', 'old-hash-123'].includes(path),
+    );
+    fs.readFile.mockResolvedValue(
+      JSON.stringify({
+        audiobook: {
+          version: 1,
+          files: [
+            {
+              id: 'audio-0',
+              name: 'book.m4b',
+              path: 'old-hash-123/audiobook/1-audio-0-book.m4b',
+              duration: 100,
+            },
+          ],
+          chapters: [],
+          mappings: [],
+          createdAt: 1,
+        },
+      }),
+    );
+    fs.copyFile.mockRejectedValue(new Error('audio copy failed'));
+
+    await expect(
+      service.importBook(
+        new File(['new content'], 'test.epub', { type: 'application/epub+zip' }),
+        books,
+      ),
+    ).rejects.toThrow('audio copy failed');
+
+    expect(fs.removeDir).not.toHaveBeenCalledWith('old-hash-123', 'Books', true);
+    expect(existingBook.hash).toBe('old-hash-123');
+    expect(existingBook.deletedAt).toBeNull();
+  });
+
   it('should prefer exact file hash match over metaHash match', async () => {
     const metaHash = getMetadataHash(TEST_METADATA);
 
@@ -640,6 +735,67 @@ describe('importBook metaHash aggregation', () => {
     expect(writtenConfig.bookHash).toBe('exact-hash');
     // Merged booknotes from both
     expect(writtenConfig.booknotes).toHaveLength(2);
+  });
+
+  it('preserves a duplicate pairing when the progress-winning config has none', async () => {
+    const metaHash = getMetadataHash(TEST_METADATA);
+    const exactMatch = makeBook({ hash: 'exact-hash', metaHash });
+    const pairedDuplicate = makeBook({ hash: 'paired-hash', metaHash });
+    const books: Book[] = [exactMatch, pairedDuplicate];
+    mockPartialMD5.mockResolvedValue('exact-hash');
+    setupMockBookDoc();
+
+    const fs = service.getFs();
+    fs.exists.mockImplementation(async (path: string) => {
+      if (path.endsWith('/config.json')) return true;
+      return path === 'paired-hash';
+    });
+    fs.readFile.mockImplementation(async (path: string) => {
+      if (path === 'exact-hash/config.json') {
+        return JSON.stringify({ progress: [90, 100], location: 'winner' });
+      }
+      if (path === 'paired-hash/config.json') {
+        return JSON.stringify({
+          progress: [10, 100],
+          audiobook: {
+            version: 1,
+            files: [
+              {
+                id: 'audio-0',
+                name: 'book.m4b',
+                path: 'paired-hash/audiobook/1-audio-0-book.m4b',
+                duration: 100,
+              },
+            ],
+            chapters: [],
+            mappings: [],
+            createdAt: 1,
+          },
+        });
+      }
+      return '{}';
+    });
+
+    await service.importBook(
+      new File(['same content'], 'test.epub', { type: 'application/epub+zip' }),
+      books,
+    );
+
+    expect(fs.copyFile).toHaveBeenCalledWith(
+      'paired-hash/audiobook/1-audio-0-book.m4b',
+      'Books',
+      'exact-hash/audiobook/1-audio-0-book.m4b',
+      'Books',
+    );
+    const configWrite = fs.writeFile.mock.calls.find(
+      (call: unknown[]) => call[0] === 'exact-hash/config.json',
+    );
+    const writtenConfig = JSON.parse(configWrite![2] as string);
+    expect(writtenConfig.progress).toEqual([90, 100]);
+    expect(writtenConfig.audiobook.files[0].path).toBe('exact-hash/audiobook/1-audio-0-book.m4b');
+    expect(
+      fs.writeFile.mock.invocationCallOrder[fs.writeFile.mock.calls.indexOf(configWrite!)],
+    ).toBeLessThan(fs.removeDir.mock.invocationCallOrder[0]!);
   });
 });
 

--- a/apps/readest-app/src/__tests__/services/import-metahash.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-metahash.test.ts
@@ -352,6 +352,48 @@ describe('importBook metaHash deduplication', () => {
     expect(existingBook.deletedAt).toBeNull();
   });
 
+  it('rejects paired-audio paths outside the book being migrated', async () => {
+    const metaHash = getMetadataHash(TEST_METADATA);
+    const existingBook = makeBook({ hash: 'old-hash-123', metaHash });
+    const books: Book[] = [existingBook];
+    mockPartialMD5.mockResolvedValue('new-hash-456');
+    setupMockBookDoc();
+
+    const fs = service.getFs();
+    fs.exists.mockImplementation(async (path: string) =>
+      ['old-hash-123/config.json', 'old-hash-123'].includes(path),
+    );
+    fs.readFile.mockResolvedValue(
+      JSON.stringify({
+        audiobook: {
+          version: 1,
+          files: [
+            {
+              id: 'audio-0',
+              name: 'book.m4b',
+              path: 'another-book/audiobook/book.m4b',
+              duration: 100,
+            },
+          ],
+          chapters: [],
+          mappings: [],
+          createdAt: 1,
+        },
+      }),
+    );
+
+    await expect(
+      service.importBook(
+        new File(['new content'], 'test.epub', { type: 'application/epub+zip' }),
+        books,
+      ),
+    ).rejects.toThrow('Invalid paired audiobook path');
+
+    expect(fs.copyFile).not.toHaveBeenCalled();
+    expect(fs.removeDir).not.toHaveBeenCalledWith('old-hash-123', 'Books', true);
+    expect(existingBook.hash).toBe('old-hash-123');
+  });
+
   it('should prefer exact file hash match over metaHash match', async () => {
     const metaHash = getMetadataHash(TEST_METADATA);
 

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-android-native.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-android-native.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+  addPluginListener: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/path', () => ({
+  tempDir: vi.fn(async () => '/tmp'),
+  join: vi.fn(async (...parts: string[]) => parts.join('/')),
+}));
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  BaseDirectory: { Temp: 1 },
+  writeFile: vi.fn(async () => undefined),
+  remove: vi.fn(async () => undefined),
+}));
+
+vi.mock('@/utils/misc', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/misc')>()),
+  getOSPlatform: () => 'android',
+}));
+
+import { addPluginListener, invoke, type PluginListener } from '@tauri-apps/api/core';
+import { writeFile } from '@tauri-apps/plugin-fs';
+import type { BookDoc } from '@/libs/document';
+import type { TTSController } from '@/services/tts/TTSController';
+import {
+  loadMediaOverlaySection,
+  type MediaOverlaySection,
+} from '@/services/tts/mediaOverlay/MediaOverlaySection';
+import { MediaOverlayClient } from '@/services/tts/mediaOverlay/MediaOverlayClient';
+
+class ForbiddenAudio {
+  constructor() {
+    throw new Error('MediaOverlayClient buffered an Android audiobook in an HTML audio element');
+  }
+}
+
+let client: MediaOverlayClient;
+let section: MediaOverlaySection;
+let controlCalls: Array<Record<string, unknown>>;
+
+const setup = async () => {
+  const doc = new DOMParser().parseFromString(
+    '<!DOCTYPE html><html><body><p id="chapter">Chapter</p></body></html>',
+    'text/html',
+  );
+  const book = {
+    sections: [{ mediaOverlay: { href: 'ch1.smil', id: 'smil1' } }],
+    loadText: async () =>
+      '<smil xmlns="http://www.w3.org/ns/SMIL"><body><par><text src="ch1.xhtml#chapter"/><audio src="book.m4b" clipBegin="0s" clipEnd="10s"/></par></body></smil>',
+    loadBlob: vi.fn(async () => new Blob([new Uint8Array(8)])),
+  } as unknown as BookDoc;
+  section = (await loadMediaOverlaySection(book, 0, doc, 'en'))!;
+  client = new MediaOverlayClient({ dispatchSpeakMark: vi.fn() } as unknown as TTSController);
+  await client.init();
+  client.attachSource({
+    loadBlob: vi.fn(async () => new Blob([new Uint8Array(8)])),
+    resolvePath: vi.fn(async () => '/books/hash/audiobook/book.m4b'),
+  });
+  client.setSection(section);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('NEXT_PUBLIC_APP_PLATFORM', 'tauri');
+  vi.stubGlobal('Audio', ForbiddenAudio);
+  controlCalls = [];
+  vi.mocked(addPluginListener).mockResolvedValue({
+    unregister: vi.fn(),
+  } as unknown as PluginListener);
+  vi.mocked(invoke).mockImplementation(async (command: string, args?: unknown) => {
+    const payload = (args as { payload?: Record<string, unknown> })?.payload ?? {};
+    if (command === 'plugin:native-tts|playout_control') {
+      controlCalls.push(payload);
+      return payload['action'] === 'start-session'
+        ? ({ session: 11 } as unknown)
+        : ({ session: null } as unknown);
+    }
+    if (command === 'plugin:native-tts|playout_position') {
+      return { session: 11, index: 0, positionMs: 0, playing: true } as unknown;
+    }
+    return undefined as unknown;
+  });
+});
+
+afterEach(async () => {
+  await client?.shutdown();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe('MediaOverlayClient on Android Tauri', () => {
+  test('streams a paired audiobook from its native path without buffering it', async () => {
+    await setup();
+    const utterance = client.speak(section.ssmlForBlock(0)!, new AbortController().signal);
+    await utterance.next();
+
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(controlCalls.find((call) => call['action'] === 'load')?.['path']).toBe(
+      '/books/hash/audiobook/book.m4b',
+    );
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-client.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-client.test.ts
@@ -164,6 +164,40 @@ describe('MediaOverlayClient capabilities', () => {
     const groups = await client.getVoices('en');
     expect(groups[0]!.voices[0]!.name).toBe('Book narration');
   });
+
+  test('can load clips and a narrator name from an external narration source', async () => {
+    [section] = await makeSection(WORD_SMIL);
+    const loadBlob = vi.fn(async () => new Blob([new Uint8Array(8)], { type: 'audio/mpeg' }));
+    client = new MediaOverlayClient({ dispatchSpeakMark: vi.fn() } as unknown as TTSController);
+    await client.init();
+    client.attachSource({ narrator: 'External Narrator', loadBlob });
+    client.setSection(section);
+
+    expect((await client.getVoices('en'))[0]!.voices[0]!.name).toBe('External Narrator');
+    const iter = client.speak(section.ssmlForBlock(0)!, new AbortController().signal);
+    await iter.next();
+
+    expect(loadBlob).toHaveBeenCalledWith('OEBPS/ch1.mp3');
+  });
+
+  test('streams an external narration URL without loading it into a blob', async () => {
+    [section] = await makeSection(WORD_SMIL);
+    const loadBlob = vi.fn(async () => new Blob([new Uint8Array(8)]));
+    client = new MediaOverlayClient({ dispatchSpeakMark: vi.fn() } as unknown as TTSController);
+    await client.init();
+    client.attachSource({
+      loadBlob,
+      resolveUrl: vi.fn(async () => 'http://asset.localhost/books/ch1.mp3'),
+    });
+    client.setSection(section);
+
+    const iter = client.speak(section.ssmlForBlock(0)!, new AbortController().signal);
+    await iter.next();
+
+    expect(audio().src).toBe('http://asset.localhost/books/ch1.mp3');
+    expect(loadBlob).not.toHaveBeenCalled();
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
 });
 
 describe('MediaOverlayClient playback', () => {

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-client.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-client.test.ts
@@ -144,7 +144,18 @@ describe('MediaOverlayClient capabilities', () => {
       gapControl: false,
       liveRateChange: true,
       continuousTimeline: true,
+      textHighlight: true,
     });
+  });
+
+  test('disables text highlighting for a source without fine text timing', async () => {
+    await setup();
+    client.attachSource({
+      loadBlob: async () => new Blob([new Uint8Array(8)]),
+      textHighlight: false,
+    });
+
+    expect(client.getCapabilities().textHighlight).toBe(false);
   });
 
   test('offers the narrator as its only voice', async () => {
@@ -326,6 +337,16 @@ describe('MediaOverlayClient playback', () => {
 
     expect(audio().seeks).toEqual([3]);
     expect(audio().currentTime).toBe(3);
+  });
+
+  test('starts at a requested position inside the first narration clip', async () => {
+    await setup();
+    client.setNextChunkPosition(1.5);
+    const iter = client.speak(section.ssmlForBlock(1)!, new AbortController().signal);
+    await iter.next();
+
+    expect(audio().seeks).toEqual([4.5]);
+    expect(audio().currentTime).toBe(4.5);
   });
 
   test('resumes mid-block from the requested mark', async () => {

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
@@ -222,6 +222,45 @@ describe('narration selection', () => {
     expect((await controller.getVoices('en'))[0]!.voices[0]!.name).toBe('External Narrator');
   });
 
+  test('starts paired narration at the current text position without drawing a chapter highlight', async () => {
+    const view = makePairedView();
+    const appService = {
+      openFile: vi.fn(async () => new File(['audio'], 'chapter.mp3')),
+      resolveFilePath: vi.fn(async () => '/books/chapter.mp3'),
+    } as unknown as AppService;
+    const controller = new TTSController(appService, view);
+    controller.pairedAudiobook = PAIRED_AUDIOBOOK;
+    await controller.init();
+    await controller.initViewTTS(0);
+
+    const doc = view.tts!.doc;
+    const text = doc.querySelector('p')!.firstChild as Text;
+    const page = doc.createRange();
+    page.setStart(text, 2);
+    page.setEnd(text, text.length);
+    const setStart = vi.spyOn(controller.ttsMediaOverlayClient, 'setNextChunkPosition');
+    const overlayer = { remove: vi.fn(), add: vi.fn() };
+    (
+      view.renderer as unknown as { getContents: () => unknown[]; primaryIndex: number }
+    ).getContents = () => [{ doc, index: 1, overlayer }];
+    (view.renderer as unknown as { primaryIndex: number }).primaryIndex = 1;
+    view.getCFI = vi.fn((_index, range: Range) => `cfi:${range.toString()}`);
+
+    expect(controller.startFromRange(page)).toContain('<mark name="0"/>');
+    expect(setStart).toHaveBeenCalledOnce();
+    expect(setStart.mock.calls[0]![0]).toBeGreaterThan(0);
+
+    const location = vi.fn();
+    controller.addEventListener('tts-highlight-mark', location);
+    controller.dispatchSpeakMark({ offset: 0, name: '0', text: 'Chapter', language: 'en' });
+
+    expect(overlayer.add).not.toHaveBeenCalled();
+    expect((location.mock.calls[0]![0] as CustomEvent).detail.cfi).not.toContain('Chapter 1Text.');
+    vi.spyOn(controller.ttsMediaOverlayClient, 'getChunkProgress').mockReturnValue(0.75);
+    expect(controller.getCurrentPlaybackCfi()).toMatch(/^cfi:.$/);
+    expect(controller.isSoundingSentenceOnScreen()).toBe(false);
+  });
+
   test('the narrator leads the voice list, and only for narrated books', async () => {
     const narrated = new TTSController(null, makeView([true]));
     await narrated.init();

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
@@ -244,7 +244,7 @@ describe('narration selection', () => {
       view.renderer as unknown as { getContents: () => unknown[]; primaryIndex: number }
     ).getContents = () => [{ doc, index: 1, overlayer }];
     (view.renderer as unknown as { primaryIndex: number }).primaryIndex = 1;
-    view.getCFI = vi.fn((_index, range: Range) => `cfi:${range.toString()}`);
+    view.getCFI = vi.fn((_index: number, range?: Range) => `cfi:${range?.toString() ?? ''}`);
 
     expect(controller.startFromRange(page)).toContain('<mark name="0"/>');
     expect(setStart).toHaveBeenCalledOnce();

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
@@ -153,6 +153,10 @@ const makePairedView = () => {
 beforeEach(() => {
   vi.spyOn(console, 'log').mockImplementation(() => {});
   vi.spyOn(console, 'warn').mockImplementation(() => {});
+  Object.defineProperty(window, '__TAURI_INTERNALS__', {
+    configurable: true,
+    value: { convertFileSrc: vi.fn((path: string) => `asset://${path}`) },
+  });
   vi.stubGlobal(
     'Audio',
     class {
@@ -222,6 +226,31 @@ describe('narration selection', () => {
     expect((await controller.getVoices('en'))[0]!.voices[0]!.name).toBe('External Narrator');
   });
 
+  test('streams a paired audiobook from a direct asset URL on desktop Tauri', async () => {
+    const view = makePairedView();
+    const appService = {
+      appPlatform: 'tauri',
+      isMobileApp: false,
+      openFile: vi.fn(async () => new File(['audio'], 'chapter.mp3')),
+      resolveFilePath: vi.fn(async () => '/books/hash/audiobook/chapter.mp3'),
+    } as unknown as AppService;
+    const controller = new TTSController(appService, view);
+    controller.pairedAudiobook = PAIRED_AUDIOBOOK;
+    const attachSource = vi.spyOn(controller.ttsMediaOverlayClient, 'attachSource');
+
+    await controller.init();
+
+    const source = attachSource.mock.calls.at(-1)?.[0];
+    await expect(source?.resolveUrl?.(PAIRED_AUDIOBOOK.files[0]!.path)).resolves.toBe(
+      'asset:///books/hash/audiobook/chapter.mp3',
+    );
+    expect(appService.resolveFilePath).toHaveBeenCalledWith(
+      PAIRED_AUDIOBOOK.files[0]!.path,
+      'Books',
+    );
+    expect(appService.openFile).not.toHaveBeenCalled();
+  });
+
   test('starts paired narration at the current text position without drawing a chapter highlight', async () => {
     const view = makePairedView();
     const appService = {
@@ -259,6 +288,39 @@ describe('narration selection', () => {
     vi.spyOn(controller.ttsMediaOverlayClient, 'getChunkProgress').mockReturnValue(0.75);
     expect(controller.getCurrentPlaybackCfi()).toMatch(/^cfi:.$/);
     expect(controller.isSoundingSentenceOnScreen()).toBe(false);
+  });
+
+  test('keeps paired-audiobook scrubber preview and seek aligned with the audio offset', async () => {
+    const view = makePairedView();
+    const appService = {
+      openFile: vi.fn(async () => new File(['audio'], 'chapter.mp3')),
+      resolveFilePath: vi.fn(async () => '/books/chapter.mp3'),
+    } as unknown as AppService;
+    const controller = new TTSController(appService, view);
+    controller.pairedAudiobook = PAIRED_AUDIOBOOK;
+    view.getCFI = vi.fn((_index: number, range?: Range) => `cfi:${range?.toString() ?? ''}`);
+    await controller.init();
+    await controller.initViewTTS(0);
+    await controller.ensureTimeline();
+    controller.dispatchSpeakMark({ offset: 0, name: '0', text: 'Chapter 1', language: 'en' });
+
+    const locations: { cfi: string; preview?: boolean }[] = [];
+    controller.addEventListener('tts-highlight-mark', (event) => {
+      locations.push((event as CustomEvent<{ cfi: string; preview?: boolean }>).detail);
+    });
+    controller.previewSeekTime(15);
+
+    const seekWithin = vi
+      .spyOn(controller.ttsMediaOverlayClient, 'seekToChunkPosition')
+      .mockResolvedValue(true);
+    await controller.seekToTime(20);
+
+    expect(locations).toHaveLength(2);
+    expect(locations[0]!.preview).toBe(true);
+    expect(locations[0]!.cfi).toMatch(/^cfi:.$/);
+    expect(locations[1]!.preview).toBeUndefined();
+    expect(locations[1]!.cfi).toMatch(/^cfi:.$/);
+    expect(seekWithin).toHaveBeenCalledWith(20);
   });
 
   test('the narrator leads the voice list, and only for narrated books', async () => {

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { TTSController } from '@/services/tts/TTSController';
 import type { TTSClient, TTSMessageEvent } from '@/services/tts/TTSClient';
 import { MEDIA_OVERLAY_VOICE_ID } from '@/services/tts/mediaOverlay';
+import type { PairedAudiobook } from '@/types/book';
+import type { AppService } from '@/types/system';
 import type { FoliateView } from '@/types/view';
 
 // Synthesis clients replaced with fakes; the narration client is the real one,
@@ -120,6 +122,34 @@ const makePlainView = () => {
   return view;
 };
 
+const PAIRED_AUDIOBOOK: PairedAudiobook = {
+  version: 1,
+  narrator: 'External Narrator',
+  files: [{ id: 'audio-0', name: 'chapter.mp3', path: 'hash/audiobook/chapter.mp3', duration: 30 }],
+  chapters: [{ id: 'audio-0:0', fileId: 'audio-0', label: 'Chapter 1', start: 0, end: 30 }],
+  mappings: [{ ebookChapterId: 'chapter.xhtml', audioChapterId: 'audio-0:0' }],
+  createdAt: 1,
+};
+
+const makePairedView = () => {
+  const docs = [makeDoc('<p>Front matter.</p>'), makeDoc('<h1>Chapter 1</h1><p>Text.</p>')];
+  return {
+    book: {
+      toc: [{ id: 0, label: 'Chapter 1', href: 'chapter.xhtml', index: 0 }],
+      sections: [
+        { id: 'front.xhtml', createDocument: vi.fn().mockResolvedValue(docs[0]) },
+        { id: 'chapter.xhtml', createDocument: vi.fn().mockResolvedValue(docs[1]) },
+      ],
+      splitTOCHref: (href: string) => href.split('#'),
+    },
+    renderer: { getContents: () => [], primaryIndex: 0 },
+    language: { isCJK: false, canonical: 'en' },
+    getCFI: vi.fn().mockReturnValue('epubcfi(/6/2!/4/2)'),
+    resolveCFI: vi.fn().mockReturnValue({ anchor: () => null }),
+    tts: null,
+  } as unknown as FoliateView;
+};
+
 beforeEach(() => {
   vi.spyOn(console, 'log').mockImplementation(() => {});
   vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -171,6 +201,25 @@ describe('narration selection', () => {
 
     expect(controller.narrationAvailable).toBe(false);
     expect(controller.ttsClient).toBe(controller.ttsEdgeClient);
+  });
+
+  test('a paired audiobook is offered as narration without EPUB media overlays', async () => {
+    const view = makePairedView();
+    const appService = {
+      openFile: vi.fn(async () => new File(['audio'], 'chapter.mp3')),
+    } as unknown as AppService;
+    const controller = new TTSController(appService, view);
+    controller.pairedAudiobook = PAIRED_AUDIOBOOK;
+
+    await controller.init();
+    await controller.initViewTTS(0);
+
+    expect(controller.narrationAvailable).toBe(true);
+    expect(controller.narrationActive).toBe(true);
+    expect(view.book.sections[0]!.createDocument).not.toHaveBeenCalled();
+    expect(view.book.sections[1]!.createDocument).toHaveBeenCalled();
+    expect(view.tts!.start()).toContain('<mark name="0"/>');
+    expect((await controller.getVoices('en'))[0]!.voices[0]!.name).toBe('External Narrator');
   });
 
   test('the narrator leads the voice list, and only for narrated books', async () => {

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
@@ -282,6 +282,23 @@ describe('narration mark source and timeline', () => {
     expect(timeline!.getMeasuredFraction()).toBeCloseTo(1, 5);
   });
 
+  test('seeks inside the active narration clip instead of restarting it', async () => {
+    const controller = new TTSController(null, makeView([true]));
+    await controller.init();
+    await controller.initViewTTS(0);
+    await controller.ensureTimeline();
+    controller.dispatchSpeakMark({ offset: 0, name: '0', text: 'First', language: 'en' });
+    const seekWithin = vi
+      .spyOn(controller.ttsMediaOverlayClient, 'seekToChunkPosition')
+      .mockResolvedValue(true);
+    const stop = vi.spyOn(controller.ttsMediaOverlayClient, 'stop');
+
+    await controller.seekToTime(2);
+
+    expect(seekWithin).toHaveBeenCalledWith(2);
+    expect(stop).not.toHaveBeenCalled();
+  });
+
   test('synthesis still uses foliate segmentation for the same book', async () => {
     const controller = new TTSController(null, makeView([true]));
     controller.useNarration = false;

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-native.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-native.test.ts
@@ -161,4 +161,35 @@ describe('MediaOverlayClient on iOS Tauri', () => {
 
     expect(controlCalls.filter((c) => c['action'] === 'start-session')).toHaveLength(2);
   });
+
+  test('shutdown awaits one native abort', async () => {
+    await setup();
+    const iter = client.speak(section.ssmlForBlock(0)!, new AbortController().signal);
+    await iter.next();
+
+    let finishAbort!: () => void;
+    const abortGate = new Promise<void>((resolve) => {
+      finishAbort = resolve;
+    });
+    vi.mocked(invoke).mockImplementation(async (cmd: string, args?: unknown) => {
+      const payload = (args as { payload?: Record<string, unknown> })?.payload ?? {};
+      if (cmd === 'plugin:native-tts|playout_control') {
+        controlCalls.push(payload);
+        if (payload['action'] === 'abort') await abortGate;
+        return { session: null } as unknown;
+      }
+      return undefined as unknown;
+    });
+
+    let settled = false;
+    const shutdown = client.shutdown().then(() => {
+      settled = true;
+    });
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+
+    expect(settled).toBe(false);
+    finishAbort();
+    await shutdown;
+    expect(controlCalls.filter((call) => call['action'] === 'abort')).toHaveLength(1);
+  });
 });

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-native.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-native.test.ts
@@ -25,6 +25,7 @@ vi.mock('@/utils/misc', async (importOriginal) => ({
 }));
 
 import { addPluginListener, invoke, type PluginListener } from '@tauri-apps/api/core';
+import { writeFile } from '@tauri-apps/plugin-fs';
 import type { BookDoc } from '@/libs/document';
 import type { TTSController } from '@/services/tts/TTSController';
 import {
@@ -130,6 +131,22 @@ describe('MediaOverlayClient on iOS Tauri', () => {
     const step = await pending;
 
     expect(step.value?.code).toBe('error');
+  });
+
+  test('plays a paired local audiobook from its existing path without staging a copy', async () => {
+    await setup();
+    client.attachSource({
+      narrator: 'External Narrator',
+      loadBlob: vi.fn(async () => new Blob([new Uint8Array(8)])),
+      resolvePath: vi.fn(async () => '/books/hash/audiobook/book.m4b'),
+    });
+    const iter = client.speak(section.ssmlForBlock(0)!, new AbortController().signal);
+    await iter.next();
+
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(controlCalls.find((call) => call['action'] === 'load')?.['path']).toBe(
+      '/books/hash/audiobook/book.m4b',
+    );
   });
 
   test('invalidatePlayback makes the next block open a fresh native session', async () => {

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-tts.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-tts.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { BookDoc } from '@/libs/document';
 import {
   loadMediaOverlaySection,
-  type MediaOverlaySection,
+  MediaOverlaySection,
+  type NarrationPar,
 } from '@/services/tts/mediaOverlay/MediaOverlaySection';
 import { MediaOverlayTTS } from '@/services/tts/mediaOverlay/MediaOverlayTTS';
 import { parseSSMLMarks } from '@/utils/ssml';
@@ -215,5 +216,38 @@ describe('MediaOverlayTTS', () => {
     target.setEnd(doc.body, 0);
 
     expect(marksOf(tts.from(target))).toEqual(['0', '1', '2']);
+  });
+
+  test('maps a page position proportionally into an approximately timed chapter', () => {
+    const approximateDoc = new DOMParser().parseFromString(
+      '<!DOCTYPE html><html><body><p>abcdefghij</p></body></html>',
+      'text/html',
+    );
+    const text = approximateDoc.querySelector('p')!.firstChild as Text;
+    const chapter = approximateDoc.createRange();
+    chapter.selectNodeContents(text);
+    const approximateSection = new MediaOverlaySection(
+      [
+        {
+          markName: '0',
+          blockIndex: 0,
+          range: chapter,
+          text: 'Chapter',
+          audioHref: 'chapter.m4b',
+          clipBegin: 20,
+          clipEnd: 120,
+        } satisfies NarrationPar,
+      ],
+      'en',
+      'approximate',
+    );
+    const tts = new MediaOverlayTTS(approximateDoc, approximateSection, highlight);
+    const page = approximateDoc.createRange();
+    page.setStart(text, 5);
+    page.setEnd(text, 8);
+
+    expect(marksOf(tts.from(page))).toEqual(['0']);
+    expect(tts.takeStartPosition()).toBeCloseTo(50, 5);
+    expect(tts.getPlaybackRange(0.75)?.toString()).toBe('h');
   });
 });

--- a/apps/readest-app/src/__tests__/services/tts/native-narration-player.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/native-narration-player.test.ts
@@ -136,4 +136,32 @@ describe('NativeNarrationPlayer', () => {
     expect(controlCalls.filter((c) => c['action'] === 'start-session').length).toBe(2);
     await player.shutdown();
   });
+
+  test('polls the native clock only while playback is active', async () => {
+    vi.useFakeTimers();
+    try {
+      const player = new NativeNarrationPlayer();
+      await player.loadPath('hash/audiobook/book.m4b', '/books/hash/audiobook/book.m4b', 0);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      const positionCalls = () =>
+        vi
+          .mocked(invoke)
+          .mock.calls.filter(([command]) => command === 'plugin:native-tts|playout_position')
+          .length;
+      expect(positionCalls()).toBe(0);
+
+      await player.play();
+      await vi.advanceTimersByTimeAsync(250);
+      expect(positionCalls()).toBe(1);
+
+      player.pause();
+      const pausedCalls = positionCalls();
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(positionCalls()).toBe(pausedCalls);
+      await player.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/readest-app/src/__tests__/services/tts/native-narration-player.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/native-narration-player.test.ts
@@ -17,7 +17,7 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
 }));
 
 import { addPluginListener, invoke, type PluginListener } from '@tauri-apps/api/core';
-import { writeFile } from '@tauri-apps/plugin-fs';
+import { remove, writeFile } from '@tauri-apps/plugin-fs';
 import { NativeNarrationPlayer } from '@/services/tts/mediaOverlay/NativeNarrationPlayer';
 
 describe('NativeNarrationPlayer', () => {
@@ -74,6 +74,20 @@ describe('NativeNarrationPlayer', () => {
     );
 
     await player.shutdown();
+  });
+
+  test('loads an existing local audiobook path without copying or deleting it', async () => {
+    const player = new NativeNarrationPlayer();
+    await player.loadPath('hash/audiobook/book.m4b', '/books/hash/audiobook/book.m4b', 20);
+
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(controlCalls.find((call) => call['action'] === 'load')).toMatchObject({
+      path: '/books/hash/audiobook/book.m4b',
+      positionMs: 20_000,
+    });
+
+    await player.shutdown();
+    expect(remove).not.toHaveBeenCalledWith('/books/hash/audiobook/book.m4b');
   });
 
   test('ended events notify listeners', async () => {

--- a/apps/readest-app/src/__tests__/services/tts/paired-audiobook-section.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/paired-audiobook-section.test.ts
@@ -79,6 +79,7 @@ describe('paired audiobook narration sections', () => {
       },
     ]);
     expect(section?.blockCount).toBe(2);
+    expect(section?.textTiming).toBe('approximate');
   });
 
   it('plays a shared audio chapter once and spans every mapped ebook chapter', () => {

--- a/apps/readest-app/src/__tests__/services/tts/paired-audiobook-section.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/paired-audiobook-section.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BookDoc } from '@/libs/document';
+import type { PairedAudiobook } from '@/types/book';
+import {
+  findPairedAudiobookSection,
+  loadPairedAudiobookSection,
+} from '@/services/tts/pairedAudiobook';
+
+const makeDoc = (body: string): Document =>
+  new DOMParser().parseFromString(`<!doctype html><html><body>${body}</body></html>`, 'text/html');
+
+const book = {
+  toc: [
+    { id: 0, label: 'Cover', href: 'front.xhtml', index: 0 },
+    { id: 1, label: 'Chapter 1', href: 'chapter.xhtml#one', index: 0 },
+    { id: 2, label: 'Chapter 2', href: 'chapter.xhtml#two', index: 0 },
+    { id: 3, label: 'Chapter 3', href: 'last.xhtml', index: 0 },
+  ],
+  sections: [{ id: 'front.xhtml' }, { id: 'chapter.xhtml' }, { id: 'last.xhtml' }],
+  splitTOCHref: (href: string) => href.split('#'),
+} as unknown as BookDoc;
+
+const association: PairedAudiobook = {
+  version: 1,
+  narrator: 'Jane Reader',
+  files: [
+    { id: 'audio-0', name: 'Part 1.m4b', path: 'hash/audiobook/part-1.m4b', duration: 90 },
+    { id: 'audio-1', name: 'Part 2.mp3', path: 'hash/audiobook/part-2.mp3', duration: 40 },
+  ],
+  chapters: [
+    { id: 'audio-0:0', fileId: 'audio-0', label: 'One', start: 5, end: 35 },
+    { id: 'audio-0:1', fileId: 'audio-0', label: 'Two', start: 35, end: 90 },
+    { id: 'audio-1:0', fileId: 'audio-1', label: 'Three', start: 0, end: 40 },
+  ],
+  mappings: [
+    { ebookChapterId: 'chapter.xhtml#one', audioChapterId: 'audio-0:0' },
+    { ebookChapterId: 'chapter.xhtml#two', audioChapterId: 'audio-0:1' },
+    { ebookChapterId: 'last.xhtml', audioChapterId: 'audio-1:0' },
+  ],
+  createdAt: 1,
+};
+
+describe('paired audiobook narration sections', () => {
+  it('finds the next or previous spine section that has a mapped audio chapter', () => {
+    expect(findPairedAudiobookSection(book, association, 0, 1)).toBe(1);
+    expect(findPairedAudiobookSection(book, association, 2, -1)).toBe(2);
+    expect(findPairedAudiobookSection(book, association, 0, -1)).toBe(-1);
+  });
+
+  it('turns mapped TOC chapters into external narration clips', () => {
+    const doc = makeDoc(
+      '<h1 id="one">Chapter 1</h1><p>First text.</p><h1 id="two">Chapter 2</h1><p>Second text.</p>',
+    );
+    const section = loadPairedAudiobookSection(book, association, 1, doc, 'en');
+
+    expect(
+      section?.pars.map((par) => ({
+        text: par.text,
+        audioHref: par.audioHref,
+        clipBegin: par.clipBegin,
+        clipEnd: par.clipEnd,
+        range: par.range.toString(),
+      })),
+    ).toEqual([
+      {
+        text: 'Chapter 1',
+        audioHref: 'hash/audiobook/part-1.m4b',
+        clipBegin: 5,
+        clipEnd: 35,
+        range: 'Chapter 1First text.',
+      },
+      {
+        text: 'Chapter 2',
+        audioHref: 'hash/audiobook/part-1.m4b',
+        clipBegin: 35,
+        clipEnd: 90,
+        range: 'Chapter 2Second text.',
+      },
+    ]);
+    expect(section?.blockCount).toBe(2);
+  });
+
+  it('plays a shared audio chapter once and spans every mapped ebook chapter', () => {
+    const shared: PairedAudiobook = {
+      ...association,
+      mappings: [
+        { ebookChapterId: 'chapter.xhtml#one', audioChapterId: 'audio-0:0' },
+        { ebookChapterId: 'chapter.xhtml#two', audioChapterId: 'audio-0:0' },
+      ],
+    };
+    const doc = makeDoc(
+      '<h1 id="one">Chapter 1</h1><p>First text.</p><h1 id="two">Chapter 2</h1><p>Second text.</p>',
+    );
+
+    const section = loadPairedAudiobookSection(book, shared, 1, doc, 'en');
+
+    expect(section?.pars).toHaveLength(1);
+    expect(section?.pars[0]?.text).toBe('Chapter 1');
+    expect(section?.pars[0]?.range.toString()).toBe('Chapter 1First text.Chapter 2Second text.');
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts/paired-audiobook-section.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/paired-audiobook-section.test.ts
@@ -82,6 +82,20 @@ describe('paired audiobook narration sections', () => {
     expect(section?.textTiming).toBe('approximate');
   });
 
+  it('resolves named and empty TOC anchors to the following chapter text', () => {
+    const doc = makeDoc(
+      '<a name="one"></a><h1>Chapter 1</h1><p>First text.</p>' +
+        '<a id="two"></a><h1>Chapter 2</h1><p>Second text.</p>',
+    );
+
+    const section = loadPairedAudiobookSection(book, association, 1, doc, 'en');
+
+    expect(section?.pars.map((par) => par.range.toString())).toEqual([
+      'Chapter 1First text.',
+      'Chapter 2Second text.',
+    ]);
+  });
+
   it('plays a shared audio chapter once and spans every mapped ebook chapter', () => {
     const shared: PairedAudiobook = {
       ...association,
@@ -99,5 +113,28 @@ describe('paired audiobook narration sections', () => {
     expect(section?.pars).toHaveLength(1);
     expect(section?.pars[0]?.text).toBe('Chapter 1');
     expect(section?.pars[0]?.range.toString()).toBe('Chapter 1First text.Chapter 2Second text.');
+  });
+
+  it('splits a shared audio chapter across consecutive EPUB spine sections', () => {
+    const shared: PairedAudiobook = {
+      ...association,
+      mappings: [
+        { ebookChapterId: 'chapter.xhtml#one', audioChapterId: 'audio-0:0' },
+        { ebookChapterId: 'chapter.xhtml#two', audioChapterId: 'audio-0:0' },
+        { ebookChapterId: 'last.xhtml', audioChapterId: 'audio-0:0' },
+      ],
+    };
+    const chapterDoc = makeDoc(
+      '<h1 id="one">Chapter 1</h1><p>First text.</p><h1 id="two">Chapter 2</h1><p>Second text.</p>',
+    );
+    const lastDoc = makeDoc('<h1>Chapter 3</h1><p>Third text.</p>');
+
+    const chapterSection = loadPairedAudiobookSection(book, shared, 1, chapterDoc, 'en');
+    const lastSection = loadPairedAudiobookSection(book, shared, 2, lastDoc, 'en');
+
+    expect(chapterSection?.pars).toHaveLength(1);
+    expect(chapterSection?.pars[0]).toMatchObject({ clipBegin: 5, clipEnd: 25 });
+    expect(lastSection?.pars).toHaveLength(1);
+    expect(lastSection?.pars[0]).toMatchObject({ clipBegin: 25, clipEnd: 35 });
   });
 });

--- a/apps/readest-app/src/app/reader/components/ReaderContent.tsx
+++ b/apps/readest-app/src/app/reader/components/ReaderContent.tsx
@@ -40,6 +40,7 @@ import Notebook from './notebook/Notebook';
 import LocalSendManager from '@/components/localsend/LocalSendManager';
 import BooksGrid from './BooksGrid';
 import SettingsDialog from '@/components/settings/SettingsDialog';
+import AudiobookPairingDialog from './audiobook/AudiobookPairingDialog';
 
 const ReaderContent: React.FC<{ ids?: string; settings: SystemSettings }> = ({ ids, settings }) => {
   const _ = useTranslation();
@@ -54,6 +55,7 @@ const ReaderContent: React.FC<{ ids?: string; settings: SystemSettings }> = ({ i
   const { initViewState, getViewState, clearViewState } = useReaderStore();
   const { isSettingsDialogOpen, settingsDialogBookKey } = useSettingsStore();
   const [showDetailsBook, setShowDetailsBook] = useState<Book | null>(null);
+  const [audiobookBookKey, setAudiobookBookKey] = useState<string | null>(null);
   const [shareDialogState, setShareDialogState] = useState<{
     book: Book;
     cfi: string | null;
@@ -105,6 +107,15 @@ const ReaderContent: React.FC<{ ids?: string; settings: SystemSettings }> = ({ i
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const handleManageAudiobook = (event: CustomEvent) => {
+      const detail = event.detail as { bookKey?: string } | undefined;
+      if (detail?.bookKey) setAudiobookBookKey(detail.bookKey);
+    };
+    eventDispatcher.on('manage-audiobook', handleManageAudiobook);
+    return () => eventDispatcher.off('manage-audiobook', handleManageAudiobook);
   }, []);
 
   useEffect(() => {
@@ -304,6 +315,13 @@ const ReaderContent: React.FC<{ ids?: string; settings: SystemSettings }> = ({ i
         onGoToLibrary={handleCloseBooksToLibrary}
       />
       {isSettingsDialogOpen && <SettingsDialog bookKey={settingsDialogBookKey} />}
+      {audiobookBookKey && getBookData(audiobookBookKey)?.bookDoc && (
+        <AudiobookPairingDialog
+          bookKey={audiobookBookKey}
+          bookDoc={getBookData(audiobookBookKey)!.bookDoc!}
+          onClose={() => setAudiobookBookKey(null)}
+        />
+      )}
       <Notebook />
       <LocalSendManager />
       {showDetailsBook && (

--- a/apps/readest-app/src/app/reader/components/audiobook/AudiobookChapterPicker.tsx
+++ b/apps/readest-app/src/app/reader/components/audiobook/AudiobookChapterPicker.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { MdCheck, MdClose, MdPlayArrow, MdStop } from 'react-icons/md';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import type { AudiobookChapter } from '@/types/book';
+
+export const formatAudiobookTimecode = (seconds: number): string => {
+  const total = Math.max(0, Math.round(seconds));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const remainder = total % 60;
+  return hours > 0
+    ? `${hours}:${String(minutes).padStart(2, '0')}:${String(remainder).padStart(2, '0')}`
+    : `${minutes}:${String(remainder).padStart(2, '0')}`;
+};
+
+interface AudiobookChapterPickerProps {
+  chapters: AudiobookChapter[];
+  value: string;
+  previewingId: string | null;
+  onSelect: (chapterId: string) => void;
+  onPreview: (chapter: AudiobookChapter) => void;
+  onClose: () => void;
+}
+
+const AudiobookChapterPicker = ({
+  chapters,
+  value,
+  previewingId,
+  onSelect,
+  onPreview,
+  onClose,
+}: AudiobookChapterPickerProps) => {
+  const _ = useTranslation();
+  const [query, setQuery] = useState('');
+  const filtered = useMemo(() => {
+    const normalized = query.trim().toLocaleLowerCase();
+    if (!normalized) return chapters;
+    return chapters.filter((chapter) => chapter.label.toLocaleLowerCase().includes(normalized));
+  }, [chapters, query]);
+
+  return (
+    <div className='eink-bordered border-base-300 bg-base-100 mt-3 overflow-hidden rounded-lg border'>
+      <div className='border-base-200 flex items-center gap-2 border-b p-2'>
+        <input
+          type='search'
+          className='input input-sm eink-bordered min-w-0 flex-1'
+          aria-label={_('Search audio chapters')}
+          placeholder={_('Search audio chapters')}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          autoFocus
+        />
+        <button
+          type='button'
+          className='btn btn-ghost btn-sm btn-square'
+          aria-label={_('Close audio chapter picker')}
+          onClick={onClose}
+        >
+          <MdClose className='h-5 w-5' />
+        </button>
+      </div>
+      <div
+        className='divide-base-200 max-h-64 overflow-y-auto divide-y'
+        role='listbox'
+        aria-label={_('Audio chapters')}
+      >
+        <button
+          type='button'
+          role='option'
+          aria-selected={!value}
+          className='hover:bg-base-200 flex min-h-11 w-full items-center gap-3 px-3 py-2 text-start'
+          onClick={() => onSelect('')}
+        >
+          <span className='min-w-0 flex-1'>{_('No audio')}</span>
+          {!value && <MdCheck className='h-5 w-5 flex-shrink-0' />}
+        </button>
+        {filtered.map((chapter) => {
+          const selected = chapter.id === value;
+          const previewing = chapter.id === previewingId;
+          return (
+            <div key={chapter.id} className='flex min-h-12 items-center gap-1 pe-2'>
+              <button
+                type='button'
+                role='option'
+                aria-selected={selected}
+                className='hover:bg-base-200 flex min-w-0 flex-1 items-center gap-3 px-3 py-2 text-start'
+                onClick={() => onSelect(chapter.id)}
+              >
+                <span className='min-w-0 flex-1 truncate'>
+                  {chapter.label} · {formatAudiobookTimecode(chapter.end - chapter.start)}
+                </span>
+                {selected && <MdCheck className='h-5 w-5 flex-shrink-0' />}
+              </button>
+              <button
+                type='button'
+                className='btn btn-ghost btn-sm btn-square flex-shrink-0'
+                aria-label={
+                  previewing
+                    ? _('Stop previewing {{chapter}}', { chapter: chapter.label })
+                    : _('Preview {{chapter}}', { chapter: chapter.label })
+                }
+                onClick={() => onPreview(chapter)}
+              >
+                {previewing ? <MdStop className='h-5 w-5' /> : <MdPlayArrow className='h-5 w-5' />}
+              </button>
+            </div>
+          );
+        })}
+        {filtered.length === 0 && (
+          <p className='text-neutral-content px-3 py-5 text-center text-sm'>
+            {_('No matching audio chapters')}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AudiobookChapterPicker;

--- a/apps/readest-app/src/app/reader/components/audiobook/AudiobookPairingDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/audiobook/AudiobookPairingDialog.tsx
@@ -460,10 +460,10 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
           <label className='font-medium' htmlFor='audiobook-ebook-anchor'>
             {_('Ebook chapter')}
           </label>
-          <div className='relative w-full sm:max-w-[60%]'>
+          <div className='hover:bg-base-200/60 focus-within:bg-base-200/60 flex w-full items-center rounded-md sm:max-w-[60%]'>
             <select
               id='audiobook-ebook-anchor'
-              className='select w-full appearance-none !border-0 !bg-transparent pe-8 shadow-none focus:outline-none'
+              className='select h-9 min-w-0 flex-1 cursor-pointer !appearance-none truncate !border-0 !bg-transparent !bg-none !pe-1 !ps-2 text-end focus:!border-0 focus:!shadow-none focus:!outline-none focus:!ring-0'
               value={selectedEbookChapterId}
               onChange={(event) => setSelectedEbookChapterId(event.target.value)}
             >
@@ -473,7 +473,10 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
                 </option>
               ))}
             </select>
-            <MdArrowDropDown className='pointer-events-none absolute end-2 top-1/2 h-5 w-5 -translate-y-1/2' />
+            <MdArrowDropDown
+              aria-hidden='true'
+              className='text-base-content/55 pointer-events-none h-5 w-5 flex-shrink-0'
+            />
           </div>
         </div>
         <div className='flex min-h-16 flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between'>
@@ -481,10 +484,10 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
             {_('Audio chapter or track')}
           </label>
           <div className='flex w-full items-center sm:max-w-[60%]'>
-            <div className='relative min-w-0 flex-1'>
+            <div className='hover:bg-base-200/60 focus-within:bg-base-200/60 flex min-w-0 flex-1 items-center rounded-md'>
               <select
                 id='audiobook-audio-anchor'
-                className='select w-full appearance-none !border-0 !bg-transparent pe-8 shadow-none focus:outline-none'
+                className='select h-9 min-w-0 flex-1 cursor-pointer !appearance-none truncate !border-0 !bg-transparent !bg-none !pe-1 !ps-2 text-end focus:!border-0 focus:!shadow-none focus:!outline-none focus:!ring-0'
                 value={selectedAudioChapterId}
                 onChange={(event) => setSelectedAudioChapterId(event.target.value)}
               >
@@ -494,7 +497,10 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
                   </option>
                 ))}
               </select>
-              <MdArrowDropDown className='pointer-events-none absolute end-2 top-1/2 h-5 w-5 -translate-y-1/2' />
+              <MdArrowDropDown
+                aria-hidden='true'
+                className='text-base-content/55 pointer-events-none h-5 w-5 flex-shrink-0'
+              />
             </div>
             {audioChapterById.get(selectedAudioChapterId) && (
               <button

--- a/apps/readest-app/src/app/reader/components/audiobook/AudiobookPairingDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/audiobook/AudiobookPairingDialog.tsx
@@ -1,8 +1,15 @@
 'use client';
 
 import clsx from 'clsx';
-import { useMemo, useState } from 'react';
-import { MdAudiotrack, MdDeleteOutline, MdFolderOpen } from 'react-icons/md';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import {
+  MdArrowDropDown,
+  MdAudiotrack,
+  MdDeleteOutline,
+  MdFolderOpen,
+  MdPlayArrow,
+  MdStop,
+} from 'react-icons/md';
 
 import Dialog from '@/components/Dialog';
 import { useEnv } from '@/context/EnvContext';
@@ -14,8 +21,9 @@ import {
   collectAudiobookTextChapters,
 } from '@/services/audiobook/mapping';
 import { parseAudiobookFile, type ParsedAudiobookFile } from '@/services/audiobook/metadata';
+import { AudiobookPreviewPlayer } from '@/services/audiobook/preview';
 import {
-  importPairedAudiobook,
+  replacePairedAudiobook,
   removePairedAudiobook,
   type AudiobookImportFile,
 } from '@/services/audiobook/storage';
@@ -24,6 +32,7 @@ import { useReaderStore } from '@/store/readerStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import type { AudiobookChapter, AudiobookChapterMapping, PairedAudiobook } from '@/types/book';
 import { eventDispatcher } from '@/utils/event';
+import AudiobookChapterPicker, { formatAudiobookTimecode } from './AudiobookChapterPicker';
 import StepProgress from './AudiobookStepProgress';
 
 type WizardStep = 'summary' | 'select' | 'anchor' | 'review';
@@ -36,17 +45,8 @@ interface AudiobookPairingDialogProps {
 
 interface PreparedImportFile extends AudiobookImportFile {
   metadata: ParsedAudiobookFile;
+  previewPath?: string;
 }
-
-const formatTimecode = (seconds: number): string => {
-  const total = Math.max(0, Math.round(seconds));
-  const hours = Math.floor(total / 3600);
-  const minutes = Math.floor((total % 3600) / 60);
-  const remainder = total % 60;
-  return hours > 0
-    ? `${hours}:${String(minutes).padStart(2, '0')}:${String(remainder).padStart(2, '0')}`
-    : `${minutes}:${String(remainder).padStart(2, '0')}`;
-};
 
 const selectedFileName = (selected: SelectedFile): string =>
   selected.file?.name || selected.name || selected.path || '';
@@ -62,6 +62,27 @@ const SurfaceHeader = ({ title, description }: { title: string; description: str
     <p className='text-neutral-content leading-relaxed'>{description}</p>
   </div>
 );
+
+const WizardActions = ({ children }: { children: ReactNode }) => (
+  <div className='border-base-200 bg-base-100 sticky bottom-0 z-10 -mx-6 mt-5 flex justify-end gap-2 border-t px-6 py-4 sm:-mx-8 sm:px-8'>
+    {children}
+  </div>
+);
+
+const closeFiles = async (files: File[]) => {
+  await Promise.allSettled(
+    files.map((file) => {
+      const close = (file as File & { close?: () => Promise<void> }).close;
+      return close ? close.call(file) : Promise.resolve();
+    }),
+  );
+};
+
+const nativeFilePath = (file: File): string | undefined => {
+  const getNativeLocation = (file as File & { getNativeLocation?: () => { path: string } })
+    .getNativeLocation;
+  return getNativeLocation?.call(file).path;
+};
 
 const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingDialogProps) => {
   const _ = useTranslation();
@@ -84,6 +105,9 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
   const [busyMessage, setBusyMessage] = useState('');
   const [error, setError] = useState('');
   const [confirmRemove, setConfirmRemove] = useState(false);
+  const [activeMappingChapterId, setActiveMappingChapterId] = useState<string | null>(null);
+  const [previewingAudioChapterId, setPreviewingAudioChapterId] = useState<string | null>(null);
+  const previewPlayerRef = useRef<AudiobookPreviewPlayer | null>(null);
 
   const ebookChapters = useMemo(() => collectAudiobookTextChapters(bookDoc.toc ?? []), [bookDoc]);
   const importedAudioChapters = useMemo(
@@ -94,6 +118,7 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
     step === 'review' && preparedFiles.length === 0
       ? (association?.chapters ?? [])
       : importedAudioChapters;
+  const audioChapterById = new Map(audioChapters.map((chapter) => [chapter.id, chapter]));
   const mappedAudioIds = new Set(Object.values(mappings));
   const mappedCount = Object.keys(mappings).filter((id) => mappings[id]).length;
   const unmappedEbookCount = Math.max(0, ebookChapters.length - mappedCount);
@@ -102,6 +127,25 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
   ).length;
   const book = getBookData(bookKey)?.book;
   const busy = !!busyMessage;
+
+  useEffect(() => {
+    if (!appService) return;
+    const player = new AudiobookPreviewPlayer(appService, (chapterId) => {
+      setPreviewingAudioChapterId((current) => (current === chapterId ? null : current));
+    });
+    previewPlayerRef.current = player;
+    return () => {
+      previewPlayerRef.current = null;
+      void player.dispose();
+    };
+  }, [appService]);
+
+  useEffect(
+    () => () => {
+      void closeFiles(preparedFiles.map(({ file }) => file));
+    },
+    [preparedFiles],
+  );
 
   const persistAssociation = async (nextAssociation: PairedAudiobook | undefined) => {
     const current = getConfig(bookKey);
@@ -116,6 +160,7 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
       viewSettings,
       updatedAt: Date.now(),
     };
+    await saveConfig(envConfig, bookKey, updatedConfig, settings);
     setConfig(bookKey, { audiobook: nextAssociation, viewSettings });
     const liveViewSettings = useReaderStore.getState().getViewSettings(bookKey);
     if (liveViewSettings && nextAssociation) {
@@ -123,7 +168,6 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
         .getState()
         .setViewSettings(bookKey, { ...liveViewSettings, ttsUseNarration: true });
     }
-    await saveConfig(envConfig, bookKey, updatedConfig, settings);
   };
 
   const prepareSelectedFiles = async () => {
@@ -145,6 +189,7 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
       collator.compare(selectedFileName(a), selectedFileName(b)),
     );
     const nextFiles: PreparedImportFile[] = [];
+    const openedFiles: File[] = [];
     try {
       for (let index = 0; index < selected.length; index += 1) {
         setBusyMessage(
@@ -155,10 +200,14 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
         );
         const source = selected[index]!;
         const file = source.file ?? (await appService.openFile(source.path!, 'None'));
+        openedFiles.push(file);
         const metadata = await parseAudiobookFile(file, `audio-${index}`);
         nextFiles.push({
           file,
           metadata,
+          ...(nativeFilePath(file) || source.path
+            ? { previewPath: nativeFilePath(file) ?? source.path }
+            : {}),
           // Native copy avoids routing a multi-hour audiobook through JS.
           // iOS picker URLs are security-scoped, so openFile's cached
           // NativeFile remains the safe copy source there.
@@ -173,6 +222,7 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
       setMappings({});
       setStep('anchor');
     } catch (cause) {
+      await closeFiles(openedFiles);
       setError(cause instanceof Error ? cause.message : _('Failed to read audiobook files.'));
     } finally {
       setBusyMessage('');
@@ -212,25 +262,54 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
       mappings[id] ? [{ ebookChapterId: id, audioChapterId: mappings[id] }] : [],
     );
 
+  const togglePreview = async (chapter: AudiobookChapter) => {
+    if (!appService || !previewPlayerRef.current) return;
+    setError('');
+    const prepared = preparedFiles.find(({ metadata }) => metadata.id === chapter.fileId);
+    const stored = association?.files.find((file) => file.id === chapter.fileId);
+    try {
+      await eventDispatcher.dispatch('tts-stop', { bookKey });
+      const playing = await previewPlayerRef.current.toggle({
+        id: chapter.id,
+        ...(prepared?.previewPath
+          ? { path: prepared.previewPath, base: 'None' as const }
+          : stored
+            ? { path: stored.path, base: 'Books' as const }
+            : prepared
+              ? { file: prepared.file }
+              : {}),
+        start: chapter.start,
+        end: chapter.end,
+      });
+      setPreviewingAudioChapterId(playing ? chapter.id : null);
+    } catch (cause) {
+      setPreviewingAudioChapterId(null);
+      setError(cause instanceof Error ? cause.message : _('Failed to preview the audiobook.'));
+    }
+  };
+
   const savePairing = async () => {
     if (!appService || !book) return;
     setError('');
     setBusyMessage(_('Saving audiobook'));
     try {
-      eventDispatcher.dispatch('tts-stop', { bookKey });
-      const nextAssociation = preparedFiles.length
-        ? await importPairedAudiobook(
-            appService,
-            book.hash,
-            orderedMappings(),
-            preparedFiles,
-            association ?? undefined,
-          )
-        : association
-          ? { ...association, mappings: orderedMappings() }
-          : null;
+      await eventDispatcher.dispatch('tts-stop', { bookKey });
+      await previewPlayerRef.current?.stop();
+      let nextAssociation: PairedAudiobook | null;
+      if (preparedFiles.length) {
+        nextAssociation = await replacePairedAudiobook(
+          appService,
+          book.hash,
+          orderedMappings(),
+          preparedFiles,
+          association ?? undefined,
+          persistAssociation,
+        );
+      } else {
+        nextAssociation = association ? { ...association, mappings: orderedMappings() } : null;
+        if (nextAssociation) await persistAssociation(nextAssociation);
+      }
       if (!nextAssociation) throw new Error(_('Select audiobook files before saving.'));
-      await persistAssociation(nextAssociation);
       eventDispatcher.dispatch('toast', {
         type: 'info',
         message: _('Audiobook paired successfully.'),
@@ -248,9 +327,9 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
     setError('');
     setBusyMessage(_('Removing audiobook'));
     try {
-      eventDispatcher.dispatch('tts-stop', { bookKey });
-      await removePairedAudiobook(appService, book.hash, association);
-      await persistAssociation(undefined);
+      await eventDispatcher.dispatch('tts-stop', { bookKey });
+      await previewPlayerRef.current?.stop();
+      await removePairedAudiobook(appService, book.hash, association, persistAssociation);
       eventDispatcher.dispatch('toast', {
         type: 'info',
         message: _('Audiobook removed from this device.'),
@@ -283,7 +362,7 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
                 {_('{{files}} files · {{chapters}} audio chapters · {{duration}}', {
                   files: association.files.length,
                   chapters: association.chapters.length,
-                  duration: formatTimecode(totalDuration),
+                  duration: formatAudiobookTimecode(totalDuration),
                 })}
               </p>
             </div>
@@ -334,8 +413,11 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
     <>
       <StepProgress current={1} />
       <SurfaceHeader
-        title={_('Choose Audiobook Files')}
-        description={_('Select one M4B file or a set of MP3 or M4A tracks in playback order.')}
+        title={_('Pair Audiobook')}
+        description={_(
+          'Pair a local recording with “{{book}}”. Select one M4B file or a set of MP3 or M4A tracks in playback order.',
+          { book: book?.title ?? _('this ebook') },
+        )}
       />
       <button
         type='button'
@@ -374,34 +456,66 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
         )}
       />
       <div className='eink-bordered border-base-200 bg-base-100 divide-base-200 mb-5 rounded-lg border divide-y'>
-        <label className='flex min-h-16 flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between'>
-          <span className='font-medium'>{_('Ebook chapter')}</span>
-          <select
-            className='select select-bordered eink-bordered settings-content w-full sm:max-w-[60%]'
-            value={selectedEbookChapterId}
-            onChange={(event) => setSelectedEbookChapterId(event.target.value)}
-          >
-            {ebookChapters.map((chapter) => (
-              <option key={chapter.id} value={chapter.id}>
-                {chapter.label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className='flex min-h-16 flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between'>
-          <span className='font-medium'>{_('Audio chapter or track')}</span>
-          <select
-            className='select select-bordered eink-bordered settings-content w-full sm:max-w-[60%]'
-            value={selectedAudioChapterId}
-            onChange={(event) => setSelectedAudioChapterId(event.target.value)}
-          >
-            {importedAudioChapters.map((chapter) => (
-              <option key={chapter.id} value={chapter.id}>
-                {chapter.label} · {formatTimecode(chapter.end - chapter.start)}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className='flex min-h-16 flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between'>
+          <label className='font-medium' htmlFor='audiobook-ebook-anchor'>
+            {_('Ebook chapter')}
+          </label>
+          <div className='relative w-full sm:max-w-[60%]'>
+            <select
+              id='audiobook-ebook-anchor'
+              className='select w-full appearance-none !border-0 !bg-transparent pe-8 shadow-none focus:outline-none'
+              value={selectedEbookChapterId}
+              onChange={(event) => setSelectedEbookChapterId(event.target.value)}
+            >
+              {ebookChapters.map((chapter) => (
+                <option key={chapter.id} value={chapter.id}>
+                  {chapter.label}
+                </option>
+              ))}
+            </select>
+            <MdArrowDropDown className='pointer-events-none absolute end-2 top-1/2 h-5 w-5 -translate-y-1/2' />
+          </div>
+        </div>
+        <div className='flex min-h-16 flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between'>
+          <label className='font-medium' htmlFor='audiobook-audio-anchor'>
+            {_('Audio chapter or track')}
+          </label>
+          <div className='flex w-full items-center sm:max-w-[60%]'>
+            <div className='relative min-w-0 flex-1'>
+              <select
+                id='audiobook-audio-anchor'
+                className='select w-full appearance-none !border-0 !bg-transparent pe-8 shadow-none focus:outline-none'
+                value={selectedAudioChapterId}
+                onChange={(event) => setSelectedAudioChapterId(event.target.value)}
+              >
+                {importedAudioChapters.map((chapter) => (
+                  <option key={chapter.id} value={chapter.id}>
+                    {chapter.label} · {formatAudiobookTimecode(chapter.end - chapter.start)}
+                  </option>
+                ))}
+              </select>
+              <MdArrowDropDown className='pointer-events-none absolute end-2 top-1/2 h-5 w-5 -translate-y-1/2' />
+            </div>
+            {audioChapterById.get(selectedAudioChapterId) && (
+              <button
+                type='button'
+                className='btn btn-ghost btn-sm btn-square flex-shrink-0'
+                aria-label={
+                  previewingAudioChapterId === selectedAudioChapterId
+                    ? _('Stop audio preview')
+                    : _('Preview selected audio chapter')
+                }
+                onClick={() => togglePreview(audioChapterById.get(selectedAudioChapterId)!)}
+              >
+                {previewingAudioChapterId === selectedAudioChapterId ? (
+                  <MdStop className='h-5 w-5' />
+                ) : (
+                  <MdPlayArrow className='h-5 w-5' />
+                )}
+              </button>
+            )}
+          </div>
+        </div>
       </div>
       {ebookChapters.length !== importedAudioChapters.length && (
         <p className='bg-base-200/60 text-neutral-content mb-5 rounded-lg px-4 py-3 text-[0.85em]'>
@@ -414,7 +528,7 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
           )}
         </p>
       )}
-      <div className='flex justify-end gap-2'>
+      <WizardActions>
         <button className='btn btn-ghost' disabled={busy} onClick={() => setStep('select')}>
           {_('Back')}
         </button>
@@ -425,12 +539,9 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
         >
           {_('Review Mapping')}
         </button>
-      </div>
+      </WizardActions>
     </>
   );
-
-  const chapterOptionLabel = (chapter: AudiobookChapter) =>
-    `${chapter.label} · ${formatTimecode(chapter.end - chapter.start)}`;
 
   const renderReview = () => (
     <>
@@ -454,31 +565,80 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
         </p>
       )}
       <div className='eink-bordered border-base-200 bg-base-100 divide-base-200 mb-5 rounded-lg border divide-y'>
-        {ebookChapters.map((chapter) => (
-          <label
-            key={chapter.id}
-            className='flex min-h-16 flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between'
-          >
-            <span className='min-w-0 font-medium sm:max-w-[38%] sm:truncate' title={chapter.label}>
-              {chapter.label}
-            </span>
-            <select
-              aria-label={_('Audio for {{chapter}}', { chapter: chapter.label })}
-              className='select select-bordered eink-bordered settings-content w-full sm:max-w-[60%]'
-              value={mappings[chapter.id] ?? ''}
-              onChange={(event) => updateMapping(chapter.id, event.target.value)}
+        {ebookChapters.map((chapter) => {
+          const mappedId = mappings[chapter.id] ?? '';
+          const mappedAudio = audioChapterById.get(mappedId);
+          const pickerOpen = activeMappingChapterId === chapter.id;
+          return (
+            <div
+              key={chapter.id}
+              className='flex min-h-16 flex-col gap-2 px-4 py-3 sm:flex-row sm:items-start sm:justify-between'
             >
-              <option value=''>{_('No audio')}</option>
-              {audioChapters.map((audioChapter) => (
-                <option key={audioChapter.id} value={audioChapter.id}>
-                  {chapterOptionLabel(audioChapter)}
-                </option>
-              ))}
-            </select>
-          </label>
-        ))}
+              <span
+                className='min-w-0 pt-2 font-medium sm:max-w-[38%] sm:truncate'
+                title={chapter.label}
+              >
+                {chapter.label}
+              </span>
+              <div className='w-full sm:max-w-[60%]'>
+                <div className='flex min-h-10 items-center'>
+                  <button
+                    type='button'
+                    className='hover:bg-base-200 flex min-w-0 flex-1 items-center rounded-md px-2 py-2 text-start'
+                    aria-label={_('Audio for {{chapter}}', { chapter: chapter.label })}
+                    aria-haspopup='listbox'
+                    aria-expanded={pickerOpen}
+                    onClick={() =>
+                      setActiveMappingChapterId((current) =>
+                        current === chapter.id ? null : chapter.id,
+                      )
+                    }
+                  >
+                    <span className='min-w-0 flex-1 truncate text-sm'>
+                      {mappedAudio
+                        ? `${mappedAudio.label} · ${formatAudiobookTimecode(mappedAudio.end - mappedAudio.start)}`
+                        : _('No audio')}
+                    </span>
+                    <MdArrowDropDown className='h-5 w-5 flex-shrink-0' />
+                  </button>
+                  {mappedAudio && (
+                    <button
+                      type='button'
+                      className='btn btn-ghost btn-sm btn-square flex-shrink-0'
+                      aria-label={
+                        previewingAudioChapterId === mappedAudio.id
+                          ? _('Stop previewing {{chapter}}', { chapter: mappedAudio.label })
+                          : _('Preview {{chapter}}', { chapter: mappedAudio.label })
+                      }
+                      onClick={() => togglePreview(mappedAudio)}
+                    >
+                      {previewingAudioChapterId === mappedAudio.id ? (
+                        <MdStop className='h-5 w-5' />
+                      ) : (
+                        <MdPlayArrow className='h-5 w-5' />
+                      )}
+                    </button>
+                  )}
+                </div>
+                {pickerOpen && (
+                  <AudiobookChapterPicker
+                    chapters={audioChapters}
+                    value={mappedId}
+                    previewingId={previewingAudioChapterId}
+                    onSelect={(audioChapterId) => {
+                      updateMapping(chapter.id, audioChapterId);
+                      setActiveMappingChapterId(null);
+                    }}
+                    onPreview={togglePreview}
+                    onClose={() => setActiveMappingChapterId(null)}
+                  />
+                )}
+              </div>
+            </div>
+          );
+        })}
       </div>
-      <div className='flex justify-end gap-2'>
+      <WizardActions>
         <button
           className='btn btn-ghost'
           disabled={busy}
@@ -491,9 +651,9 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
           disabled={mappedCount === 0 || busy}
           onClick={savePairing}
         >
-          {_('Create Association')}
+          {association ? _('Save Changes') : _('Pair Audiobook')}
         </button>
-      </div>
+      </WizardActions>
     </>
   );
 
@@ -502,7 +662,7 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
       id='audiobook-pairing-dialog'
       isOpen
       dismissible={!busy}
-      title={_('Audiobook')}
+      title={association ? _('Manage Audiobook') : _('Pair Audiobook')}
       onClose={onClose}
       boxClassName='sm:h-[80%] sm:min-w-[620px] sm:max-w-[720px]'
       contentClassName='!px-6 sm:!px-8'

--- a/apps/readest-app/src/app/reader/components/audiobook/AudiobookPairingDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/audiobook/AudiobookPairingDialog.tsx
@@ -1,0 +1,565 @@
+'use client';
+
+import clsx from 'clsx';
+import { useMemo, useState } from 'react';
+import { MdAudiotrack, MdDeleteOutline, MdFolderOpen } from 'react-icons/md';
+
+import Dialog from '@/components/Dialog';
+import { useEnv } from '@/context/EnvContext';
+import { useFileSelector, type SelectedFile } from '@/hooks/useFileSelector';
+import { useTranslation } from '@/hooks/useTranslation';
+import type { BookDoc } from '@/libs/document';
+import {
+  buildSequentialAudiobookMappings,
+  collectAudiobookTextChapters,
+} from '@/services/audiobook/mapping';
+import { parseAudiobookFile, type ParsedAudiobookFile } from '@/services/audiobook/metadata';
+import {
+  importPairedAudiobook,
+  removePairedAudiobook,
+  type AudiobookImportFile,
+} from '@/services/audiobook/storage';
+import { useBookDataStore } from '@/store/bookDataStore';
+import { useReaderStore } from '@/store/readerStore';
+import { useSettingsStore } from '@/store/settingsStore';
+import type { AudiobookChapter, AudiobookChapterMapping, PairedAudiobook } from '@/types/book';
+import { eventDispatcher } from '@/utils/event';
+
+type WizardStep = 'summary' | 'select' | 'anchor' | 'review';
+
+interface AudiobookPairingDialogProps {
+  bookKey: string;
+  bookDoc: BookDoc;
+  onClose: () => void;
+}
+
+interface PreparedImportFile extends AudiobookImportFile {
+  metadata: ParsedAudiobookFile;
+}
+
+const formatTimecode = (seconds: number): string => {
+  const total = Math.max(0, Math.round(seconds));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const remainder = total % 60;
+  return hours > 0
+    ? `${hours}:${String(minutes).padStart(2, '0')}:${String(remainder).padStart(2, '0')}`
+    : `${minutes}:${String(remainder).padStart(2, '0')}`;
+};
+
+const selectedFileName = (selected: SelectedFile): string =>
+  selected.file?.name || selected.name || selected.path || '';
+
+const mappingRecord = (mappings: AudiobookChapterMapping[]): Record<string, string> =>
+  Object.fromEntries(
+    mappings.map(({ ebookChapterId, audioChapterId }) => [ebookChapterId, audioChapterId]),
+  );
+
+const StepProgress = ({ current }: { current: number }) => {
+  const _ = useTranslation();
+  return (
+    <div
+      className='mb-5 grid grid-cols-3 gap-2'
+      role='progressbar'
+      aria-label={_('Audiobook pairing progress')}
+      aria-valuemin={1}
+      aria-valuemax={3}
+      aria-valuenow={current}
+    >
+      {[1, 2, 3].map((step) => (
+        <div
+          key={step}
+          className={clsx(
+            'eink-bordered flex h-8 items-center justify-center rounded-md border text-xs font-semibold',
+            step <= current
+              ? 'border-base-content bg-base-content text-base-100'
+              : 'border-base-300 bg-base-100 text-neutral-content',
+          )}
+        >
+          {step}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const SurfaceHeader = ({ title, description }: { title: string; description: string }) => (
+  <div className='mb-5'>
+    <h2 className='mb-1.5 text-lg font-semibold tracking-tight'>{title}</h2>
+    <p className='text-neutral-content leading-relaxed'>{description}</p>
+  </div>
+);
+
+const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingDialogProps) => {
+  const _ = useTranslation();
+  const { envConfig, appService } = useEnv();
+  const { settings } = useSettingsStore();
+  const { selectFiles } = useFileSelector(appService, _);
+  const getConfig = useBookDataStore((state) => state.getConfig);
+  const getBookData = useBookDataStore((state) => state.getBookData);
+  const setConfig = useBookDataStore((state) => state.setConfig);
+  const saveConfig = useBookDataStore((state) => state.saveConfig);
+  const initialAssociation = getConfig(bookKey)?.audiobook ?? null;
+  const [association] = useState<PairedAudiobook | null>(initialAssociation);
+  const [step, setStep] = useState<WizardStep>(association ? 'summary' : 'select');
+  const [preparedFiles, setPreparedFiles] = useState<PreparedImportFile[]>([]);
+  const [selectedEbookChapterId, setSelectedEbookChapterId] = useState('');
+  const [selectedAudioChapterId, setSelectedAudioChapterId] = useState('');
+  const [mappings, setMappings] = useState<Record<string, string>>(
+    mappingRecord(association?.mappings ?? []),
+  );
+  const [busyMessage, setBusyMessage] = useState('');
+  const [error, setError] = useState('');
+  const [confirmRemove, setConfirmRemove] = useState(false);
+
+  const ebookChapters = useMemo(() => collectAudiobookTextChapters(bookDoc.toc ?? []), [bookDoc]);
+  const importedAudioChapters = useMemo(
+    () => preparedFiles.flatMap(({ metadata }) => metadata.chapters),
+    [preparedFiles],
+  );
+  const audioChapters =
+    step === 'review' && preparedFiles.length === 0
+      ? (association?.chapters ?? [])
+      : importedAudioChapters;
+  const mappedAudioIds = new Set(Object.values(mappings));
+  const mappedCount = Object.keys(mappings).filter((id) => mappings[id]).length;
+  const unmappedEbookCount = Math.max(0, ebookChapters.length - mappedCount);
+  const unusedAudioCount = audioChapters.filter(
+    (chapter) => !mappedAudioIds.has(chapter.id),
+  ).length;
+  const book = getBookData(bookKey)?.book;
+  const busy = !!busyMessage;
+
+  const persistAssociation = async (nextAssociation: PairedAudiobook | undefined) => {
+    const current = getConfig(bookKey);
+    if (!current) throw new Error(_('Book configuration is unavailable'));
+    const viewSettings = {
+      ...current.viewSettings,
+      ...(nextAssociation ? { ttsUseNarration: true } : {}),
+    };
+    const updatedConfig = {
+      ...current,
+      audiobook: nextAssociation,
+      viewSettings,
+      updatedAt: Date.now(),
+    };
+    setConfig(bookKey, { audiobook: nextAssociation, viewSettings });
+    const liveViewSettings = useReaderStore.getState().getViewSettings(bookKey);
+    if (liveViewSettings && nextAssociation) {
+      useReaderStore
+        .getState()
+        .setViewSettings(bookKey, { ...liveViewSettings, ttsUseNarration: true });
+    }
+    await saveConfig(envConfig, bookKey, updatedConfig, settings);
+  };
+
+  const prepareSelectedFiles = async () => {
+    if (!appService) return;
+    setError('');
+    const result = await selectFiles({ type: 'audio', multiple: true });
+    if (result.error) {
+      setError(result.error);
+      return;
+    }
+    if (!result.files.length) return;
+    if (!ebookChapters.length) {
+      setError(_('This book has no table of contents to map to audio chapters.'));
+      return;
+    }
+
+    const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+    const selected = [...result.files].sort((a, b) =>
+      collator.compare(selectedFileName(a), selectedFileName(b)),
+    );
+    const nextFiles: PreparedImportFile[] = [];
+    try {
+      for (let index = 0; index < selected.length; index += 1) {
+        setBusyMessage(
+          _('Reading audio metadata {{current}} of {{total}}', {
+            current: index + 1,
+            total: selected.length,
+          }),
+        );
+        const source = selected[index]!;
+        const file = source.file ?? (await appService.openFile(source.path!, 'None'));
+        const metadata = await parseAudiobookFile(file, `audio-${index}`);
+        nextFiles.push({
+          file,
+          metadata,
+          // Native copy avoids routing a multi-hour audiobook through JS.
+          // iOS picker URLs are security-scoped, so openFile's cached
+          // NativeFile remains the safe copy source there.
+          ...(source.path && !appService.isIOSApp ? { sourcePath: source.path } : {}),
+        });
+      }
+      const chapters = nextFiles.flatMap(({ metadata }) => metadata.chapters);
+      if (!chapters.length) throw new Error(_('No playable audio chapters were found.'));
+      setPreparedFiles(nextFiles);
+      setSelectedEbookChapterId(ebookChapters[0]!.id);
+      setSelectedAudioChapterId(chapters[0]!.id);
+      setMappings({});
+      setStep('anchor');
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : _('Failed to read audiobook files.'));
+    } finally {
+      setBusyMessage('');
+    }
+  };
+
+  const buildAutomaticMapping = () => {
+    const automatic = buildSequentialAudiobookMappings(
+      ebookChapters.map(({ id }) => id),
+      importedAudioChapters.map(({ id }) => id),
+      {
+        ebookChapterId: selectedEbookChapterId,
+        audioChapterId: selectedAudioChapterId,
+      },
+    );
+    setMappings(mappingRecord(automatic));
+    setStep('review');
+  };
+
+  const editExistingMapping = () => {
+    setPreparedFiles([]);
+    setMappings(mappingRecord(association?.mappings ?? []));
+    setStep('review');
+  };
+
+  const updateMapping = (ebookChapterId: string, audioChapterId: string) => {
+    setMappings((current) => {
+      const next = { ...current };
+      if (audioChapterId) next[ebookChapterId] = audioChapterId;
+      else delete next[ebookChapterId];
+      return next;
+    });
+  };
+
+  const orderedMappings = (): AudiobookChapterMapping[] =>
+    ebookChapters.flatMap(({ id }) =>
+      mappings[id] ? [{ ebookChapterId: id, audioChapterId: mappings[id] }] : [],
+    );
+
+  const savePairing = async () => {
+    if (!appService || !book) return;
+    setError('');
+    setBusyMessage(_('Saving audiobook'));
+    try {
+      eventDispatcher.dispatch('tts-stop', { bookKey });
+      const nextAssociation = preparedFiles.length
+        ? await importPairedAudiobook(
+            appService,
+            book.hash,
+            orderedMappings(),
+            preparedFiles,
+            association ?? undefined,
+          )
+        : association
+          ? { ...association, mappings: orderedMappings() }
+          : null;
+      if (!nextAssociation) throw new Error(_('Select audiobook files before saving.'));
+      await persistAssociation(nextAssociation);
+      eventDispatcher.dispatch('toast', {
+        type: 'info',
+        message: _('Audiobook paired successfully.'),
+      });
+      onClose();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : _('Failed to save the audiobook.'));
+    } finally {
+      setBusyMessage('');
+    }
+  };
+
+  const removePairing = async () => {
+    if (!appService || !book || !association) return;
+    setError('');
+    setBusyMessage(_('Removing audiobook'));
+    try {
+      eventDispatcher.dispatch('tts-stop', { bookKey });
+      await removePairedAudiobook(appService, book.hash, association);
+      await persistAssociation(undefined);
+      eventDispatcher.dispatch('toast', {
+        type: 'info',
+        message: _('Audiobook removed from this device.'),
+      });
+      onClose();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : _('Failed to remove the audiobook.'));
+    } finally {
+      setBusyMessage('');
+    }
+  };
+
+  const renderSummary = () => {
+    if (!association) return null;
+    const totalDuration = association.files.reduce((total, file) => total + file.duration, 0);
+    return (
+      <>
+        <SurfaceHeader
+          title={_('Paired Audiobook')}
+          description={_('Manage the local recording paired with this ebook.')}
+        />
+        <div className='eink-bordered border-base-200 bg-base-100 mb-5 rounded-lg border'>
+          <div className='flex min-h-14 items-center gap-3 px-4 py-3'>
+            <span className='bg-base-200 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full'>
+              <MdAudiotrack className='h-5 w-5' />
+            </span>
+            <div className='min-w-0 flex-1'>
+              <p className='truncate font-medium'>{association.title || book?.title}</p>
+              <p className='text-neutral-content text-[0.85em]'>
+                {_('{{files}} files · {{chapters}} audio chapters · {{duration}}', {
+                  files: association.files.length,
+                  chapters: association.chapters.length,
+                  duration: formatTimecode(totalDuration),
+                })}
+              </p>
+            </div>
+          </div>
+        </div>
+        {confirmRemove ? (
+          <div className='eink-bordered border-error/50 bg-base-100 mb-5 rounded-lg border p-4'>
+            <p className='font-medium'>{_('Remove audiobook files from this device?')}</p>
+            <p className='text-neutral-content mt-1 text-[0.85em]'>
+              {_('The ebook, notes, and reading progress will be kept.')}
+            </p>
+            <div className='mt-4 flex justify-end gap-2'>
+              <button
+                className='btn btn-ghost'
+                disabled={busy}
+                onClick={() => setConfirmRemove(false)}
+              >
+                {_('Cancel')}
+              </button>
+              <button className='btn btn-error' disabled={busy} onClick={removePairing}>
+                {_('Remove')}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className='flex flex-wrap justify-end gap-2'>
+            <button
+              className='btn btn-ghost text-error'
+              disabled={busy}
+              onClick={() => setConfirmRemove(true)}
+            >
+              <MdDeleteOutline className='h-5 w-5' />
+              {_('Remove')}
+            </button>
+            <button className='btn btn-ghost' disabled={busy} onClick={() => setStep('select')}>
+              {_('Replace Audio')}
+            </button>
+            <button className='btn btn-contrast' disabled={busy} onClick={editExistingMapping}>
+              {_('Edit Mapping')}
+            </button>
+          </div>
+        )}
+      </>
+    );
+  };
+
+  const renderSelect = () => (
+    <>
+      <StepProgress current={1} />
+      <SurfaceHeader
+        title={_('Choose Audiobook Files')}
+        description={_('Select one M4B file or a set of MP3 or M4A tracks in playback order.')}
+      />
+      <button
+        type='button'
+        onClick={prepareSelectedFiles}
+        disabled={busy}
+        className={clsx(
+          'eink-bordered group flex min-h-28 w-full flex-col items-center justify-center gap-3',
+          'border-base-200 bg-base-100 rounded-lg border px-6 py-5',
+          'hover:border-base-300 hover:bg-base-200/60 transition-colors duration-150',
+          'focus-visible:ring-base-content/15 focus-visible:outline-none focus-visible:ring-2',
+        )}
+      >
+        <span className='bg-base-200 group-hover:bg-base-content group-hover:text-base-100 flex h-10 w-10 items-center justify-center rounded-full transition-colors duration-150'>
+          <MdFolderOpen className='h-6 w-6' />
+        </span>
+        <span className='font-medium'>{_('Select Audio Files')}</span>
+        <span className='text-neutral-content text-[0.85em]'>MP3 · M4A · M4B</span>
+      </button>
+      {association && (
+        <div className='mt-5 flex justify-start'>
+          <button className='btn btn-ghost' disabled={busy} onClick={() => setStep('summary')}>
+            {_('Back')}
+          </button>
+        </div>
+      )}
+    </>
+  );
+
+  const renderAnchor = () => (
+    <>
+      <StepProgress current={2} />
+      <SurfaceHeader
+        title={_('Align One Chapter')}
+        description={_(
+          'Choose one known match. Readest will map the remaining chapters sequentially from it.',
+        )}
+      />
+      <div className='eink-bordered border-base-200 bg-base-100 divide-base-200 mb-5 rounded-lg border divide-y'>
+        <label className='flex min-h-16 flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between'>
+          <span className='font-medium'>{_('Ebook chapter')}</span>
+          <select
+            className='select select-bordered eink-bordered settings-content w-full sm:max-w-[60%]'
+            value={selectedEbookChapterId}
+            onChange={(event) => setSelectedEbookChapterId(event.target.value)}
+          >
+            {ebookChapters.map((chapter) => (
+              <option key={chapter.id} value={chapter.id}>
+                {chapter.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className='flex min-h-16 flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between'>
+          <span className='font-medium'>{_('Audio chapter or track')}</span>
+          <select
+            className='select select-bordered eink-bordered settings-content w-full sm:max-w-[60%]'
+            value={selectedAudioChapterId}
+            onChange={(event) => setSelectedAudioChapterId(event.target.value)}
+          >
+            {importedAudioChapters.map((chapter) => (
+              <option key={chapter.id} value={chapter.id}>
+                {chapter.label} · {formatTimecode(chapter.end - chapter.start)}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      {ebookChapters.length !== importedAudioChapters.length && (
+        <p className='bg-base-200/60 text-neutral-content mb-5 rounded-lg px-4 py-3 text-[0.85em]'>
+          {_(
+            '{{ebook}} ebook chapters and {{audio}} audio chapters were found. Unmatched items will stay unpaired.',
+            {
+              ebook: ebookChapters.length,
+              audio: importedAudioChapters.length,
+            },
+          )}
+        </p>
+      )}
+      <div className='flex justify-end gap-2'>
+        <button className='btn btn-ghost' disabled={busy} onClick={() => setStep('select')}>
+          {_('Back')}
+        </button>
+        <button
+          className='btn btn-contrast'
+          disabled={!selectedEbookChapterId || !selectedAudioChapterId || busy}
+          onClick={buildAutomaticMapping}
+        >
+          {_('Review Mapping')}
+        </button>
+      </div>
+    </>
+  );
+
+  const chapterOptionLabel = (chapter: AudiobookChapter) =>
+    `${chapter.label} · ${formatTimecode(chapter.end - chapter.start)}`;
+
+  const renderReview = () => (
+    <>
+      <StepProgress current={3} />
+      <SurfaceHeader
+        title={_('Review Chapter Mapping')}
+        description={_(
+          'Adjust any row, reuse an audio chapter, or leave an ebook chapter without audio.',
+        )}
+      />
+      {(unmappedEbookCount > 0 || unusedAudioCount > 0) && (
+        <p className='bg-base-200/60 text-neutral-content mb-4 rounded-lg px-4 py-3 text-[0.85em]'>
+          {_(
+            '{{mapped}} mapped · {{unmapped}} ebook chapters without audio · {{unused}} unused audio chapters',
+            {
+              mapped: mappedCount,
+              unmapped: unmappedEbookCount,
+              unused: unusedAudioCount,
+            },
+          )}
+        </p>
+      )}
+      <div className='eink-bordered border-base-200 bg-base-100 divide-base-200 mb-5 rounded-lg border divide-y'>
+        {ebookChapters.map((chapter) => (
+          <label
+            key={chapter.id}
+            className='flex min-h-16 flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between'
+          >
+            <span className='min-w-0 font-medium sm:max-w-[38%] sm:truncate' title={chapter.label}>
+              {chapter.label}
+            </span>
+            <select
+              aria-label={_('Audio for {{chapter}}', { chapter: chapter.label })}
+              className='select select-bordered eink-bordered settings-content w-full sm:max-w-[60%]'
+              value={mappings[chapter.id] ?? ''}
+              onChange={(event) => updateMapping(chapter.id, event.target.value)}
+            >
+              <option value=''>{_('No audio')}</option>
+              {audioChapters.map((audioChapter) => (
+                <option key={audioChapter.id} value={audioChapter.id}>
+                  {chapterOptionLabel(audioChapter)}
+                </option>
+              ))}
+            </select>
+          </label>
+        ))}
+      </div>
+      <div className='flex justify-end gap-2'>
+        <button
+          className='btn btn-ghost'
+          disabled={busy}
+          onClick={() => setStep(preparedFiles.length ? 'anchor' : 'summary')}
+        >
+          {_('Back')}
+        </button>
+        <button
+          className='btn btn-contrast'
+          disabled={mappedCount === 0 || busy}
+          onClick={savePairing}
+        >
+          {_('Create Association')}
+        </button>
+      </div>
+    </>
+  );
+
+  return (
+    <Dialog
+      id='audiobook-pairing-dialog'
+      isOpen
+      dismissible={!busy}
+      title={_('Audiobook')}
+      onClose={onClose}
+      boxClassName='sm:h-[80%] sm:min-w-[620px] sm:max-w-[720px]'
+      contentClassName='!px-6 sm:!px-8'
+      useOverlayScroll
+    >
+      <div className='pb-6 pt-2'>
+        {busyMessage && (
+          <div
+            className='bg-base-200/60 mb-4 flex items-center gap-3 rounded-lg px-4 py-3'
+            role='status'
+          >
+            <span className='loading loading-spinner loading-sm' />
+            <span>{busyMessage}</span>
+          </div>
+        )}
+        {error && (
+          <div
+            className='eink-bordered border-error/50 bg-base-100 text-error mb-4 rounded-lg border px-4 py-3'
+            role='alert'
+          >
+            {error}
+          </div>
+        )}
+        {step === 'summary' && renderSummary()}
+        {step === 'select' && renderSelect()}
+        {step === 'anchor' && renderAnchor()}
+        {step === 'review' && renderReview()}
+      </div>
+    </Dialog>
+  );
+};
+
+export default AudiobookPairingDialog;

--- a/apps/readest-app/src/app/reader/components/audiobook/AudiobookPairingDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/audiobook/AudiobookPairingDialog.tsx
@@ -24,6 +24,7 @@ import { useReaderStore } from '@/store/readerStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import type { AudiobookChapter, AudiobookChapterMapping, PairedAudiobook } from '@/types/book';
 import { eventDispatcher } from '@/utils/event';
+import StepProgress from './AudiobookStepProgress';
 
 type WizardStep = 'summary' | 'select' | 'anchor' | 'review';
 
@@ -54,34 +55,6 @@ const mappingRecord = (mappings: AudiobookChapterMapping[]): Record<string, stri
   Object.fromEntries(
     mappings.map(({ ebookChapterId, audioChapterId }) => [ebookChapterId, audioChapterId]),
   );
-
-const StepProgress = ({ current }: { current: number }) => {
-  const _ = useTranslation();
-  return (
-    <div
-      className='mb-5 grid grid-cols-3 gap-2'
-      role='progressbar'
-      aria-label={_('Audiobook pairing progress')}
-      aria-valuemin={1}
-      aria-valuemax={3}
-      aria-valuenow={current}
-    >
-      {[1, 2, 3].map((step) => (
-        <div
-          key={step}
-          className={clsx(
-            'eink-bordered flex h-8 items-center justify-center rounded-md border text-xs font-semibold',
-            step <= current
-              ? 'border-base-content bg-base-content text-base-100'
-              : 'border-base-300 bg-base-100 text-neutral-content',
-          )}
-        >
-          {step}
-        </div>
-      ))}
-    </div>
-  );
-};
 
 const SurfaceHeader = ({ title, description }: { title: string; description: string }) => (
   <div className='mb-5'>

--- a/apps/readest-app/src/app/reader/components/audiobook/AudiobookStepProgress.tsx
+++ b/apps/readest-app/src/app/reader/components/audiobook/AudiobookStepProgress.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from '@/hooks/useTranslation';
 
 const StepProgress = ({ current }: { current: number }) => {
   const _ = useTranslation();
+  const labels = [_('Files'), _('Align'), _('Review')];
 
   return (
     <ul
@@ -16,14 +17,19 @@ const StepProgress = ({ current }: { current: number }) => {
       aria-valuemax={3}
       aria-valuenow={current}
     >
-      {[1, 2, 3].map((step) => (
-        <li
-          key={step}
-          className={clsx('step', step <= current && 'step-neutral')}
-          aria-label={_('Step {{step}}', { step })}
-          aria-current={step === current ? 'step' : undefined}
-        />
-      ))}
+      {labels.map((label, index) => {
+        const step = index + 1;
+        return (
+          <li
+            key={step}
+            className={clsx('step', step <= current && 'step-neutral')}
+            aria-label={_('Step {{step}}: {{label}}', { step, label })}
+            aria-current={step === current ? 'step' : undefined}
+          >
+            {label}
+          </li>
+        );
+      })}
     </ul>
   );
 };

--- a/apps/readest-app/src/app/reader/components/audiobook/AudiobookStepProgress.tsx
+++ b/apps/readest-app/src/app/reader/components/audiobook/AudiobookStepProgress.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import clsx from 'clsx';
+
+import { useTranslation } from '@/hooks/useTranslation';
+
+const StepProgress = ({ current }: { current: number }) => {
+  const _ = useTranslation();
+
+  return (
+    <ul
+      className='steps steps-horizontal mb-5 w-full'
+      role='progressbar'
+      aria-label={_('Audiobook pairing progress')}
+      aria-valuemin={1}
+      aria-valuemax={3}
+      aria-valuenow={current}
+    >
+      {[1, 2, 3].map((step) => (
+        <li
+          key={step}
+          className={clsx('step', step <= current && 'step-neutral')}
+          aria-label={_('Step {{step}}', { step })}
+          aria-current={step === current ? 'step' : undefined}
+        />
+      ))}
+    </ul>
+  );
+};
+
+export default StepProgress;

--- a/apps/readest-app/src/app/reader/components/sidebar/BookMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/BookMenu.tsx
@@ -34,9 +34,14 @@ const BookMenu: React.FC<BookMenuProps> = ({ menuClassName, setIsDropdownOpen })
   const { getVisibleLibrary } = useLibraryStore();
   const { openParallelView } = useBooksManager();
   const { sideBarBookKey } = useSidebarStore();
-  const { getConfig } = useBookDataStore();
+  const { getConfig, getBookData } = useBookDataStore();
   const { parallelViews, setParallel, unsetParallel } = useParallelViewStore();
   const viewSettings = getViewSettings(sideBarBookKey!);
+  const bookData = sideBarBookKey ? getBookData(sideBarBookKey) : null;
+  const canPairAudiobook =
+    bookData?.book?.format === 'EPUB' &&
+    bookData.bookDoc?.rendition?.layout !== 'pre-paginated' &&
+    !!bookData.bookDoc?.toc?.length;
 
   const [isSortedTOC, setIsSortedTOC] = React.useState(viewSettings?.sortedTOC || false);
 
@@ -124,6 +129,10 @@ const BookMenu: React.FC<BookMenuProps> = ({ menuClassName, setIsDropdownOpen })
     eventDispatcher.dispatch('clear-annotations', { bookKey: sideBarBookKey });
     setIsDropdownOpen?.(false);
   };
+  const handleManageAudiobook = () => {
+    eventDispatcher.dispatch('manage-audiobook', { bookKey: sideBarBookKey });
+    setIsDropdownOpen?.(false);
+  };
 
   return (
     <Menu
@@ -197,6 +206,14 @@ const BookMenu: React.FC<BookMenuProps> = ({ menuClassName, setIsDropdownOpen })
       )}
       <hr aria-hidden='true' className='border-base-200 my-1' />
       <MenuItem label={_('Proofread')} onClick={showProofreadRulesWindow} />
+      {canPairAudiobook && (
+        <MenuItem
+          label={
+            getConfig(sideBarBookKey!)?.audiobook ? _('Manage Audiobook') : _('Pair Audiobook')
+          }
+          onClick={handleManageAudiobook}
+        />
+      )}
       <hr aria-hidden='true' className='border-base-200 my-1' />
       <MenuItem label={_('Export Annotations')} onClick={handleExportAnnotations} />
       <MenuItem label={_('Import Annotations')} onClick={handleImportAnnotations} />

--- a/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
@@ -79,6 +79,7 @@ export const useProgressSync = (bookKey: string) => {
       serializeConfig(newConfig, settings.globalViewSettings, DEFAULT_BOOK_SEARCH_CONFIG),
     );
     delete compressedConfig.booknotes;
+    delete compressedConfig.audiobook;
     // The /api/sync POST handler piggybacks books.progress + books.updated_at
     // off this configs push (saves the separate syncBooks round-trip that
     // used to keep the library record fresh while a reader stayed open —

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -885,6 +885,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
         // this, only runs on the background-session reattach path), so set the
         // book key here or the per-book audio cache never gets a hash to open.
         ttsController.bookKey = bookKey;
+        ttsController.pairedAudiobook = bookData.config?.audiobook;
         ttsControllerRef.current = ttsController;
         setTtsController(ttsController);
         ttsSessionManager.claim(bookKey, ttsController, {

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -983,8 +983,11 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
 
   const handleTTSStop = async (event: CustomEvent) => {
     const { bookKey: ttsBookKey } = event.detail;
-    if (ttsControllerRef.current && bookKey === ttsBookKey) {
-      handleStop(bookKey);
+    if (bookKey !== ttsBookKey) return;
+    if (ttsControllerRef.current) {
+      await handleStop(bookKey);
+    } else {
+      await ttsSessionManager.stopBook(getBookHashFromKey(bookKey), 'user');
     }
   };
 

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -450,6 +450,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
 
       const { anchor, index: ttsSectionIndex } = view.resolveCFI(cfi);
       if (viewSectionIndex !== ttsSectionIndex) {
+        if (!preview && !followingTTSLocationRef.current) return;
         // TTS crossed into a new section before the view caught up. The
         // `await onSectionChange` path in TTSController fires renderer.goTo
         // via handleSectionChange, but the new paginator's #goTo can resolve
@@ -608,7 +609,14 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     // sentence's ttsLocation (a sentence spanning a page break), so the word
     // position is the correct reference — otherwise the back-to-TTS button
     // wrongly appears after the view follows the word onto the next page.
-    const highlightCfi = ttsController.getCurrentHighlightCfi() ?? ttsLocation;
+    const highlightCfi =
+      ttsController.getCurrentPlaybackCfi() ??
+      ttsController.getCurrentHighlightCfi() ??
+      ttsLocation;
+    if (highlightCfi !== ttsLocation) {
+      viewSettings.ttsLocation = highlightCfi;
+      setViewSettings(bookKey, viewSettings);
+    }
     // ...and a sentence that straddles a page break keeps its start cfi on the
     // page behind once the view follows the voice, so a recording — which has no
     // word cfi to fall back on — needs the layout asked directly.
@@ -638,7 +646,8 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
   const handleBackToCurrentTTSLocation = () => {
     const view = getView(bookKey);
     const viewSettings = getViewSettings(bookKey);
-    const ttsLocation = viewSettings?.ttsLocation;
+    const ttsLocation =
+      ttsControllerRef.current?.getCurrentPlaybackCfi() ?? viewSettings?.ttsLocation;
     if (!view || !ttsLocation) return;
 
     const resolved = view.resolveNavigation(ttsLocation);
@@ -933,9 +942,9 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
           speakSelection && !narrateSelection
             ? genSSMLRaw(ttsSpeakRange!.toString().trim())
             : narrateSelection
-              ? view.tts?.from(ttsSpeakRange!)
+              ? ttsController.startFromRange(ttsSpeakRange!)
               : ttsFromRange
-                ? view.tts?.from(ttsFromRange)
+                ? ttsController.startFromRange(ttsFromRange)
                 : view.tts?.start();
         if (ssml) {
           const lang = parseSSMLLang(ssml, primaryLang) || 'en';

--- a/apps/readest-app/src/hooks/useFileSelector.ts
+++ b/apps/readest-app/src/hooks/useFileSelector.ts
@@ -107,12 +107,12 @@ const selectFileTauri = async (
     });
   }
   // Android's SAF picker filters by MIME type. Niche/custom extensions
-  // (e.g. ".mrexpt" from Moon+ Reader) have no registered MIME and would
-  // appear greyed-out, so for those cases we ask the native side for an
-  // unfiltered picker and re-apply the extension whitelist on the
-  // resulting paths below. We extend the same treatment to 'generic'
-  // selections because callers there typically pass arbitrary extensions
-  // that SAF likewise cannot match (e.g. mrexpt, txt).
+  // (e.g. ".mrexpt" from Moon+ Reader and audiobook ".m4b") have no registered
+  // MIME and would appear greyed-out, so for those cases we ask the native side
+  // for an unfiltered picker and re-apply the extension whitelist on the
+  // resulting paths below. We extend the same treatment to 'generic' selections
+  // because callers there typically pass arbitrary extensions that SAF likewise
+  // cannot match (e.g. mrexpt, txt).
   //
   // Image selections are the exception on iOS: image extensions all map to
   // real UTTypes, so passing them lets the dialog plugin open the Photos
@@ -124,7 +124,10 @@ const selectFileTauri = async (
   const noFilter =
     (appService?.isIOSApp && !isImageSelection) ||
     (appService?.isAndroidApp &&
-      (options.type === 'books' || options.type === 'dictionaries' || options.type === 'generic'));
+      (options.type === 'books' ||
+        options.type === 'dictionaries' ||
+        options.type === 'audio' ||
+        options.type === 'generic'));
   const exts = noFilter ? [] : options.extensions || [];
   const title = options.dialogTitle || _('Select Files');
   const paths = (await appService?.selectFiles(_(title), exts)) || [];
@@ -197,8 +200,8 @@ export const FILE_SELECTION_PRESETS = {
     dialogTitle: _('Select Video'),
   },
   audio: {
-    accept: 'audio/*',
-    extensions: ['mp3', 'wav', 'ogg', 'flac', 'm4a'],
+    accept: 'audio/*,.m4b',
+    extensions: ['mp3', 'wav', 'ogg', 'flac', 'm4a', 'm4b'],
     dialogTitle: _('Select Audio'),
   },
   books: {

--- a/apps/readest-app/src/services/audiobook/mapping.ts
+++ b/apps/readest-app/src/services/audiobook/mapping.ts
@@ -1,0 +1,59 @@
+import type { TOCItem } from '@/libs/document';
+import type { AudiobookChapterMapping } from '@/types/book';
+
+export interface AudiobookTextChapter {
+  id: string;
+  label: string;
+  href: string;
+  cfi?: string;
+}
+
+export interface AudiobookMappingAnchor {
+  ebookChapterId: string;
+  audioChapterId: string;
+}
+
+export const collectAudiobookTextChapters = (toc: TOCItem[]): AudiobookTextChapter[] => {
+  const chapters: AudiobookTextChapter[] = [];
+  const seenHrefs = new Set<string>();
+
+  const visit = (items: TOCItem[]) => {
+    for (const item of items) {
+      const href = item.href.trim();
+      if (href && !seenHrefs.has(href)) {
+        seenHrefs.add(href);
+        chapters.push({
+          id: href,
+          label: item.label.trim() || href,
+          href,
+          ...(item.cfi ? { cfi: item.cfi } : {}),
+        });
+      }
+      if (item.subitems?.length) visit(item.subitems);
+    }
+  };
+
+  visit(toc);
+  return chapters;
+};
+
+/**
+ * Continuum-style anchor mapping: pair the selected ebook/audio chapters,
+ * then fill both directions by ordinal. Entries that fall outside either list
+ * stay unmapped so the review UI can make the mismatch explicit.
+ */
+export const buildSequentialAudiobookMappings = (
+  ebookChapterIds: string[],
+  audioChapterIds: string[],
+  anchor: AudiobookMappingAnchor,
+): AudiobookChapterMapping[] => {
+  const ebookAnchorIndex = ebookChapterIds.indexOf(anchor.ebookChapterId);
+  const audioAnchorIndex = audioChapterIds.indexOf(anchor.audioChapterId);
+  if (ebookAnchorIndex < 0 || audioAnchorIndex < 0) return [];
+
+  const offset = ebookAnchorIndex - audioAnchorIndex;
+  return audioChapterIds.flatMap((audioChapterId, audioIndex) => {
+    const ebookChapterId = ebookChapterIds[audioIndex + offset];
+    return ebookChapterId ? [{ ebookChapterId, audioChapterId }] : [];
+  });
+};

--- a/apps/readest-app/src/services/audiobook/metadata.ts
+++ b/apps/readest-app/src/services/audiobook/metadata.ts
@@ -1,0 +1,94 @@
+import type { IChapter } from 'music-metadata';
+
+import type { AudiobookChapter } from '@/types/book';
+import { getBaseFilename } from '@/utils/path';
+
+export interface ParsedAudiobookFile {
+  id: string;
+  name: string;
+  duration: number;
+  title?: string;
+  narrator?: string;
+  chapters: AudiobookChapter[];
+}
+
+const chapterTime = (value: number | undefined, timeScale: number | undefined): number | null => {
+  if (value === undefined || !Number.isFinite(value)) return null;
+  return timeScale && timeScale > 0 ? value / timeScale : value;
+};
+
+export const buildAudiobookChapters = (
+  fileId: string,
+  fileName: string,
+  duration: number,
+  sourceChapters: Pick<IChapter, 'title' | 'start' | 'end' | 'timeScale'>[],
+): AudiobookChapter[] => {
+  const starts = sourceChapters.map((chapter) => chapterTime(chapter.start, chapter.timeScale));
+  const chapters = sourceChapters.flatMap((chapter, index) => {
+    const start = starts[index] ?? null;
+    const explicitEnd = chapterTime(chapter.end, chapter.timeScale);
+    const end = explicitEnd ?? starts[index + 1] ?? duration;
+    if (start === null || end === null || end <= start) return [];
+
+    return [
+      {
+        id: `${fileId}:${index}`,
+        fileId,
+        label: chapter.title.trim() || `Chapter ${index + 1}`,
+        start,
+        end,
+      },
+    ];
+  });
+
+  if (chapters.length) return chapters;
+  return [
+    {
+      id: `${fileId}:0`,
+      fileId,
+      label: getBaseFilename(fileName),
+      start: 0,
+      end: duration,
+    },
+  ];
+};
+
+export const parseAudiobookFile = async (
+  file: File,
+  fileId: string,
+): Promise<ParsedAudiobookFile> => {
+  // Keep the parser's sizeable codec graph out of the reader's initial chunk;
+  // it is only needed after the user opens the pairing wizard and picks audio.
+  const { parseBlob } = await import('music-metadata');
+  const metadata = await parseBlob(file, {
+    duration: true,
+    includeChapters: true,
+    skipCovers: true,
+  });
+  const duration = metadata.format.duration ?? 0;
+  if (!Number.isFinite(duration) || duration <= 0) {
+    throw new Error(`Could not determine the duration of ${file.name}`);
+  }
+
+  const chapters = buildAudiobookChapters(
+    fileId,
+    file.name,
+    duration,
+    metadata.format.chapters ?? [],
+  );
+  if (!metadata.format.chapters?.length && metadata.common.title?.trim()) {
+    chapters[0]!.label = metadata.common.title.trim();
+  }
+
+  const title = metadata.common.album?.trim() || metadata.common.work?.trim() || undefined;
+  const narrator =
+    metadata.common.albumartist?.trim() || metadata.common.artist?.trim() || undefined;
+  return {
+    id: fileId,
+    name: file.name,
+    duration,
+    ...(title ? { title } : {}),
+    ...(narrator ? { narrator } : {}),
+    chapters,
+  };
+};

--- a/apps/readest-app/src/services/audiobook/preview.ts
+++ b/apps/readest-app/src/services/audiobook/preview.ts
@@ -1,0 +1,108 @@
+import { convertFileSrc } from '@tauri-apps/api/core';
+
+import type { AppService, BaseDir } from '@/types/system';
+import { NativeNarrationPlayer } from '@/services/tts/mediaOverlay/NativeNarrationPlayer';
+
+const PREVIEW_SECONDS = 15;
+
+export interface AudiobookPreviewClip {
+  id: string;
+  file?: File;
+  path?: string;
+  base?: BaseDir;
+  start: number;
+  end: number;
+}
+
+type ClosablePreviewFile = File & { close?: () => Promise<void> };
+
+export class AudiobookPreviewPlayer {
+  #appService: AppService;
+  #onStopped: (id: string) => void;
+  #activeId: string | null = null;
+  #audio: HTMLAudioElement | null = null;
+  #nativePlayer: NativeNarrationPlayer | null = null;
+  #objectUrl: string | null = null;
+  #ownedFile: ClosablePreviewFile | null = null;
+  #timer: ReturnType<typeof setTimeout> | null = null;
+  #endedListener: (() => void) | null = null;
+
+  constructor(appService: AppService, onStopped: (id: string) => void) {
+    this.#appService = appService;
+    this.#onStopped = onStopped;
+  }
+
+  async toggle(clip: AudiobookPreviewClip): Promise<boolean> {
+    if (this.#activeId === clip.id) {
+      await this.stop();
+      return false;
+    }
+    await this.stop();
+
+    this.#activeId = clip.id;
+    try {
+      if (this.#appService.appPlatform === 'tauri' && this.#appService.isMobileApp && clip.path) {
+        this.#nativePlayer ??= new NativeNarrationPlayer();
+        const path = await this.#appService.resolveFilePath(clip.path, clip.base ?? 'None');
+        await this.#nativePlayer.loadPath(clip.id, path, clip.start);
+        await this.#nativePlayer.play();
+      } else {
+        const audio = new Audio();
+        let url: string;
+        if (this.#appService.appPlatform === 'tauri' && clip.path) {
+          const path = await this.#appService.resolveFilePath(clip.path, clip.base ?? 'None');
+          url = convertFileSrc(path);
+        } else {
+          let file = clip.file;
+          if (!file && clip.path) {
+            file = await this.#appService.openFile(clip.path, clip.base ?? 'None');
+            this.#ownedFile = file as ClosablePreviewFile;
+          }
+          if (!file) throw new Error('Audiobook preview source is unavailable');
+          url = URL.createObjectURL(file);
+          this.#objectUrl = url;
+        }
+        audio.src = url;
+        audio.currentTime = clip.start;
+        this.#endedListener = () => void this.stop();
+        audio.addEventListener('ended', this.#endedListener);
+        this.#audio = audio;
+        await audio.play();
+      }
+
+      const duration = Math.min(PREVIEW_SECONDS, Math.max(0, clip.end - clip.start));
+      if (duration > 0) {
+        this.#timer = setTimeout(() => void this.stop(), duration * 1000);
+      }
+      return true;
+    } catch (error) {
+      await this.stop();
+      throw error;
+    }
+  }
+
+  async stop(): Promise<void> {
+    const stoppedId = this.#activeId;
+    this.#activeId = null;
+    if (this.#timer) clearTimeout(this.#timer);
+    this.#timer = null;
+    const nativePlayer = this.#nativePlayer;
+    this.#nativePlayer = null;
+    await nativePlayer?.release();
+    if (this.#audio) {
+      this.#audio.pause();
+      if (this.#endedListener) this.#audio.removeEventListener('ended', this.#endedListener);
+    }
+    this.#audio = null;
+    this.#endedListener = null;
+    if (this.#objectUrl) URL.revokeObjectURL(this.#objectUrl);
+    this.#objectUrl = null;
+    if (this.#ownedFile?.close) await this.#ownedFile.close().catch(() => undefined);
+    this.#ownedFile = null;
+    if (stoppedId) this.#onStopped(stoppedId);
+  }
+
+  async dispose(): Promise<void> {
+    await this.stop();
+  }
+}

--- a/apps/readest-app/src/services/audiobook/preview.ts
+++ b/apps/readest-app/src/services/audiobook/preview.ts
@@ -106,7 +106,7 @@ export class AudiobookPreviewPlayer {
     this.#timer = null;
     const nativePlayer = this.#nativePlayer;
     this.#nativePlayer = null;
-    await nativePlayer?.release();
+    await nativePlayer?.shutdown();
     if (this.#audio) {
       this.#audio.pause();
       if (this.#endedListener) this.#audio.removeEventListener('ended', this.#endedListener);

--- a/apps/readest-app/src/services/audiobook/preview.ts
+++ b/apps/readest-app/src/services/audiobook/preview.ts
@@ -26,18 +26,32 @@ export class AudiobookPreviewPlayer {
   #ownedFile: ClosablePreviewFile | null = null;
   #timer: ReturnType<typeof setTimeout> | null = null;
   #endedListener: (() => void) | null = null;
+  #transition = Promise.resolve();
 
   constructor(appService: AppService, onStopped: (id: string) => void) {
     this.#appService = appService;
     this.#onStopped = onStopped;
   }
 
-  async toggle(clip: AudiobookPreviewClip): Promise<boolean> {
+  #enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const pending = this.#transition.then(operation);
+    this.#transition = pending.then(
+      () => undefined,
+      () => undefined,
+    );
+    return pending;
+  }
+
+  toggle(clip: AudiobookPreviewClip): Promise<boolean> {
+    return this.#enqueue(() => this.#toggle(clip));
+  }
+
+  async #toggle(clip: AudiobookPreviewClip): Promise<boolean> {
     if (this.#activeId === clip.id) {
-      await this.stop();
+      await this.#stop();
       return false;
     }
-    await this.stop();
+    await this.#stop();
 
     this.#activeId = clip.id;
     try {
@@ -76,12 +90,16 @@ export class AudiobookPreviewPlayer {
       }
       return true;
     } catch (error) {
-      await this.stop();
+      await this.#stop();
       throw error;
     }
   }
 
-  async stop(): Promise<void> {
+  stop(): Promise<void> {
+    return this.#enqueue(() => this.#stop());
+  }
+
+  async #stop(): Promise<void> {
     const stoppedId = this.#activeId;
     this.#activeId = null;
     if (this.#timer) clearTimeout(this.#timer);

--- a/apps/readest-app/src/services/audiobook/storage.ts
+++ b/apps/readest-app/src/services/audiobook/storage.ts
@@ -1,0 +1,70 @@
+import type { ParsedAudiobookFile } from './metadata';
+import type { AudiobookChapterMapping, PairedAudiobook, AudiobookFile } from '@/types/book';
+import type { AppService } from '@/types/system';
+import { makeSafeFilename } from '@/utils/misc';
+
+export type AudiobookStorage = Pick<
+  AppService,
+  'createDir' | 'copyFile' | 'writeFile' | 'deleteFile' | 'deleteDir'
+>;
+
+export interface AudiobookImportFile {
+  file: File;
+  sourcePath?: string;
+  metadata: ParsedAudiobookFile;
+}
+
+export const getAudiobookDirectory = (bookHash: string): string => `${bookHash}/audiobook`;
+
+export const importPairedAudiobook = async (
+  storage: AudiobookStorage,
+  bookHash: string,
+  mappings: AudiobookChapterMapping[],
+  importFiles: AudiobookImportFile[],
+  previous?: PairedAudiobook,
+): Promise<PairedAudiobook> => {
+  const directory = getAudiobookDirectory(bookHash);
+  await storage.createDir(directory, 'Books', true);
+
+  const files: AudiobookFile[] = [];
+  for (const { file, sourcePath, metadata } of importFiles) {
+    const filename = `${metadata.id}-${makeSafeFilename(metadata.name)}`;
+    const path = `${directory}/${filename}`;
+    if (sourcePath) {
+      await storage.copyFile(sourcePath, 'None', path, 'Books');
+    } else {
+      await storage.writeFile(path, 'Books', file);
+    }
+    files.push({
+      id: metadata.id,
+      name: metadata.name,
+      path,
+      duration: metadata.duration,
+    });
+  }
+
+  const nextPaths = new Set(files.map((file) => file.path));
+  for (const oldFile of previous?.files ?? []) {
+    if (!nextPaths.has(oldFile.path)) await storage.deleteFile(oldFile.path, 'Books');
+  }
+
+  const title = importFiles.find(({ metadata }) => metadata.title)?.metadata.title;
+  const narrator = importFiles.find(({ metadata }) => metadata.narrator)?.metadata.narrator;
+  return {
+    version: 1,
+    ...(title ? { title } : {}),
+    ...(narrator ? { narrator } : {}),
+    files,
+    chapters: importFiles.flatMap(({ metadata }) => metadata.chapters),
+    mappings,
+    createdAt: Date.now(),
+  };
+};
+
+export const removePairedAudiobook = async (
+  storage: AudiobookStorage,
+  bookHash: string,
+  _association: PairedAudiobook,
+): Promise<void> => {
+  await storage.deleteDir(getAudiobookDirectory(bookHash), 'Books', true);
+};

--- a/apps/readest-app/src/services/audiobook/storage.ts
+++ b/apps/readest-app/src/services/audiobook/storage.ts
@@ -16,6 +16,30 @@ export interface AudiobookImportFile {
 
 export const getAudiobookDirectory = (bookHash: string): string => `${bookHash}/audiobook`;
 
+export const isAudiobookFilePath = (bookHash: string, path: string): boolean => {
+  const prefix = `${getAudiobookDirectory(bookHash)}/`;
+  const filename = path.startsWith(prefix) ? path.slice(prefix.length) : '';
+  return (
+    filename.length > 0 &&
+    filename !== '.' &&
+    filename !== '..' &&
+    !filename.includes('/') &&
+    !filename.includes('\\')
+  );
+};
+
+const deleteAudiobookFiles = async (
+  storage: AudiobookStorage,
+  bookHash: string,
+  files: AudiobookFile[],
+): Promise<void> => {
+  for (const file of files) {
+    if (isAudiobookFilePath(bookHash, file.path)) {
+      await storage.deleteFile(file.path, 'Books');
+    }
+  }
+};
+
 export const importPairedAudiobook = async (
   storage: AudiobookStorage,
   bookHash: string,
@@ -25,27 +49,30 @@ export const importPairedAudiobook = async (
 ): Promise<PairedAudiobook> => {
   const directory = getAudiobookDirectory(bookHash);
   await storage.createDir(directory, 'Books', true);
+  const createdAt = Math.max(Date.now(), (previous?.createdAt ?? 0) + 1);
 
   const files: AudiobookFile[] = [];
-  for (const { file, sourcePath, metadata } of importFiles) {
-    const filename = `${metadata.id}-${makeSafeFilename(metadata.name)}`;
-    const path = `${directory}/${filename}`;
-    if (sourcePath) {
-      await storage.copyFile(sourcePath, 'None', path, 'Books');
-    } else {
-      await storage.writeFile(path, 'Books', file);
+  const createdPaths: string[] = [];
+  try {
+    for (const { file, sourcePath, metadata } of importFiles) {
+      const filename = `${createdAt}-${metadata.id}-${makeSafeFilename(metadata.name)}`;
+      const path = `${directory}/${filename}`;
+      createdPaths.push(path);
+      if (sourcePath) {
+        await storage.copyFile(sourcePath, 'None', path, 'Books');
+      } else {
+        await storage.writeFile(path, 'Books', file);
+      }
+      files.push({
+        id: metadata.id,
+        name: metadata.name,
+        path,
+        duration: metadata.duration,
+      });
     }
-    files.push({
-      id: metadata.id,
-      name: metadata.name,
-      path,
-      duration: metadata.duration,
-    });
-  }
-
-  const nextPaths = new Set(files.map((file) => file.path));
-  for (const oldFile of previous?.files ?? []) {
-    if (!nextPaths.has(oldFile.path)) await storage.deleteFile(oldFile.path, 'Books');
+  } catch (error) {
+    await Promise.allSettled(createdPaths.map((path) => storage.deleteFile(path, 'Books')));
+    throw error;
   }
 
   const title = importFiles.find(({ metadata }) => metadata.title)?.metadata.title;
@@ -57,14 +84,50 @@ export const importPairedAudiobook = async (
     files,
     chapters: importFiles.flatMap(({ metadata }) => metadata.chapters),
     mappings,
-    createdAt: Date.now(),
+    createdAt,
   };
+};
+
+export const replacePairedAudiobook = async (
+  storage: AudiobookStorage,
+  bookHash: string,
+  mappings: AudiobookChapterMapping[],
+  importFiles: AudiobookImportFile[],
+  previous: PairedAudiobook | undefined,
+  persist: (association: PairedAudiobook) => Promise<void>,
+): Promise<PairedAudiobook> => {
+  const association = await importPairedAudiobook(
+    storage,
+    bookHash,
+    mappings,
+    importFiles,
+    previous,
+  );
+  try {
+    await persist(association);
+  } catch (error) {
+    await Promise.allSettled(
+      association.files.map((file) => storage.deleteFile(file.path, 'Books')),
+    );
+    throw error;
+  }
+
+  const nextPaths = new Set(association.files.map((file) => file.path));
+  const obsolete = (previous?.files ?? []).filter((file) => !nextPaths.has(file.path));
+  try {
+    await deleteAudiobookFiles(storage, bookHash, obsolete);
+  } catch (error) {
+    console.warn('Failed to remove replaced audiobook files:', error);
+  }
+  return association;
 };
 
 export const removePairedAudiobook = async (
   storage: AudiobookStorage,
   bookHash: string,
   _association: PairedAudiobook,
+  persist: (association: undefined) => Promise<void>,
 ): Promise<void> => {
+  await persist(undefined);
   await storage.deleteDir(getAudiobookDirectory(bookHash), 'Books', true);
 };

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -7,6 +7,7 @@ import {
   BookFormat,
   BookLookupIndex,
   BookNote,
+  PairedAudiobook,
   FIXED_LAYOUT_FORMATS,
   ImportBookOptions,
 } from '@/types/book';
@@ -27,6 +28,7 @@ import { partialMD5, md5 } from '@/utils/md5';
 import { getBaseFilename, getFilename } from '@/utils/path';
 import { BookDoc, DocumentLoader } from '@/libs/document';
 import { hasMediaOverlays } from '@/services/tts/mediaOverlay';
+import { getAudiobookDirectory, isAudiobookFilePath } from '@/services/audiobook/storage';
 import { tryNativeParseEpub } from '@/utils/tauriEpubBridge';
 import { tryNativeParseMobi } from '@/utils/tauriMobiBridge';
 import { isPseStreamFileName, openPseStreamBook, parsePseStreamFileName } from './opds/pseStream';
@@ -292,21 +294,59 @@ export async function computeCoverHash(fs: FileSystem, book: Book): Promise<stri
 
 // --- Book Merge ---
 
+interface BookMergeResult {
+  configData?: string;
+  duplicates: Book[];
+  audiobookSourceHash?: string;
+}
+
+const migratePairedAudiobook = async (
+  fs: FileSystem,
+  association: PairedAudiobook,
+  sourceHash: string,
+  targetHash: string,
+): Promise<PairedAudiobook> => {
+  if (sourceHash === targetHash) return association;
+
+  const targetDirectory = getAudiobookDirectory(targetHash);
+  await fs.createDir(targetDirectory, 'Books', true);
+  const copiedPaths: string[] = [];
+  try {
+    const files = [];
+    for (const file of association.files) {
+      if (!isAudiobookFilePath(sourceHash, file.path)) {
+        throw new Error(`Invalid paired audiobook path: ${file.path}`);
+      }
+      const filename = file.path.slice(`${getAudiobookDirectory(sourceHash)}/`.length);
+      const path = `${targetDirectory}/${filename}`;
+      await fs.copyFile(file.path, 'Books', path, 'Books');
+      copiedPaths.push(path);
+      files.push({ ...file, path });
+    }
+    return { ...association, files };
+  } catch (error) {
+    await Promise.allSettled(copiedPaths.map((path) => fs.removeFile(path, 'Books')));
+    throw error;
+  }
+};
+
 /**
  * Merge duplicate book entries that share the same metaHash and format as `book`.
  * Finds all other matching books in the array, selects the base config with the
  * largest reading progress page number, merges booknotes from all configs
- * (deduplicating by id, latest updatedAt wins), soft-deletes duplicates
- * (sets deletedAt), and cleans up their directories.
+ * (deduplicating by id, latest updatedAt wins), and returns the duplicates for
+ * importBook to retire after the merged config is durable.
  *
- * @returns The merged config as a JSON string, or undefined if no duplicates were found.
+ * Cleanup is deliberately deferred to importBook: the merged config and any
+ * paired audio must be durable in the survivor directory before a duplicate
+ * directory can be removed.
  */
 export async function mergeBooks(
   fs: FileSystem,
   books: Book[],
   book: Book,
   lookupIndex?: BookLookupIndex,
-): Promise<string | undefined> {
+): Promise<BookMergeResult | undefined> {
   if (!book.metaHash) return undefined;
 
   const metaKey = `${book.metaHash}:${book.format}`;
@@ -319,13 +359,13 @@ export async function mergeBooks(
   if (duplicates.length === 0) return undefined;
 
   const allCandidates = [book, ...duplicates];
-  const configs: Partial<BookConfig>[] = [];
+  const configs: Array<{ book: Book; config: Partial<BookConfig> }> = [];
   for (const candidate of allCandidates) {
     const configPath = getConfigFilename(candidate);
     if (await fs.exists(configPath, 'Books')) {
       try {
         const str = (await fs.readFile(configPath, 'Books', 'text')) as string;
-        configs.push(JSON.parse(str));
+        configs.push({ book: candidate, config: JSON.parse(str) });
       } catch {
         /* ignore corrupt configs */
       }
@@ -333,16 +373,18 @@ export async function mergeBooks(
   }
 
   let mergedConfigData: string | undefined;
+  let audiobookSourceHash: string | undefined;
   if (configs.length > 0) {
-    const base = configs.reduce((best, cfg) => {
-      const bestPage = best.progress?.[0] ?? 0;
-      const cfgPage = cfg.progress?.[0] ?? 0;
-      return cfgPage > bestPage ? cfg : best;
+    const baseEntry = configs.reduce((best, entry) => {
+      const bestPage = best.config.progress?.[0] ?? 0;
+      const entryPage = entry.config.progress?.[0] ?? 0;
+      return entryPage > bestPage ? entry : best;
     });
+    const base = baseEntry.config;
 
     const noteMap = new Map<string, BookNote>();
-    for (const cfg of configs) {
-      for (const note of cfg.booknotes ?? []) {
+    for (const { config } of configs) {
+      for (const note of config.booknotes ?? []) {
         const existing = noteMap.get(note.id);
         if (!existing || (note.updatedAt || 0) > (existing.updatedAt || 0)) {
           noteMap.set(note.id, note);
@@ -351,18 +393,22 @@ export async function mergeBooks(
     }
     base.booknotes = [...noteMap.values()];
 
+    const audiobookEntry = base.audiobook
+      ? baseEntry
+      : configs
+          .filter(({ config }) => config.audiobook)
+          .sort(
+            (a, b) => (b.config.audiobook?.createdAt ?? 0) - (a.config.audiobook?.createdAt ?? 0),
+          )[0];
+    if (audiobookEntry?.config.audiobook) {
+      base.audiobook = audiobookEntry.config.audiobook;
+      audiobookSourceHash = audiobookEntry.book.hash;
+    }
+
     mergedConfigData = serializeRawConfig(base);
   }
 
-  for (const dup of duplicates) {
-    dup.deletedAt = Date.now();
-    const dupDir = getDir(dup);
-    if (await fs.exists(dupDir, 'Books')) {
-      await fs.removeDir(dupDir, 'Books', true);
-    }
-  }
-
-  return mergedConfigData;
+  return { configData: mergedConfigData, duplicates, audiobookSourceHash };
 }
 
 // --- Book Import ---
@@ -416,6 +462,13 @@ export async function importBook(
   // the opened RemoteFile/NativeFile so we can close it right after convert
   // (and still in outer `finally` for non-TXT ClosableFile paths).
   let openedSource: ClosableFile | undefined;
+  let rollbackBook: Book | undefined;
+  let rollbackSnapshot: Book | undefined;
+  const rememberBookState = (book: Book) => {
+    if (rollbackBook) return;
+    rollbackBook = book;
+    rollbackSnapshot = { ...book };
+  };
   try {
     let format: BookFormat;
     let filename: string;
@@ -538,6 +591,7 @@ export async function importBook(
     let metaHashMatch = false;
     let oldBookDir: string | undefined;
     if (existingBook) {
+      rememberBookState(existingBook);
       if (!transient) {
         existingBook.deletedAt = null;
         existingBook.fileSyncDeletionRequestedAt = null;
@@ -548,6 +602,7 @@ export async function importBook(
 
     // Aggregate all books with same metaHash and format, deduplicating into one entry
     let bestConfigData: string | undefined;
+    let mergeResult: BookMergeResult | undefined;
     if (!transient && metaHash) {
       if (!existingBook) {
         const metaKey = `${metaHash}:${format}`;
@@ -557,13 +612,15 @@ export async function importBook(
         if (firstMatch) {
           oldBookDir = getDir(firstMatch);
           existingBook = firstMatch;
+          rememberBookState(existingBook);
           metaHashMatch = true;
           existingBook.createdAt = Date.now();
           existingBook.updatedAt = Date.now();
         }
       }
       if (existingBook) {
-        bestConfigData = await mergeBooks(fs, books, existingBook, lookupIndex);
+        mergeResult = await mergeBooks(fs, books, existingBook, lookupIndex);
+        bestConfigData = mergeResult?.configData;
       }
     }
 
@@ -672,6 +729,24 @@ export async function importBook(
     const coverHash = await computeCoverHash(fs, book);
     book.coverHash = coverHash;
     if (existingBook) existingBook.coverHash = coverHash;
+    const prepareConfig = async (
+      configData: string,
+      audiobookSourceHash?: string,
+    ): Promise<Partial<BookConfig>> => {
+      const config: Partial<BookConfig> = JSON.parse(configData);
+      config.bookHash = hash;
+      config.metaHash = metaHash;
+      if (config.audiobook && audiobookSourceHash) {
+        config.audiobook = await migratePairedAudiobook(
+          fs,
+          config.audiobook,
+          audiobookSourceHash,
+          hash,
+        );
+      }
+      return config;
+    };
+
     // Never overwrite the config file only when it's not existed
     if (!existingBook) {
       // Guard on the FILE, not the library record: a hash dir can already hold
@@ -713,32 +788,50 @@ export async function importBook(
       // Migrate config from old directory to new directory, updating bookHash and metaHash
       // Use aggregated best config when available from deduplication
       if (bestConfigData) {
-        const config: Partial<BookConfig> = JSON.parse(bestConfigData);
-        config.bookHash = hash;
-        config.metaHash = metaHash;
+        const config = await prepareConfig(bestConfigData, mergeResult?.audiobookSourceHash);
         await fs.writeFile(getConfigFilename(book), 'Books', serializeRawConfig(config));
       } else {
         const oldConfigPath = `${oldBookDir}/config.json`;
         if (await fs.exists(oldConfigPath, 'Books')) {
           const configData = (await fs.readFile(oldConfigPath, 'Books', 'text')) as string;
-          const config: Partial<BookConfig> = JSON.parse(configData);
-          config.bookHash = hash;
-          config.metaHash = metaHash;
+          const config = await prepareConfig(configData, oldBookDir);
           await fs.writeFile(getConfigFilename(book), 'Books', serializeRawConfig(config));
         } else {
           await saveBookConfigFn(book, INIT_BOOK_CONFIG);
         }
       }
-      // Clean up old directory
-      if (await fs.exists(oldBookDir, 'Books')) {
-        await fs.removeDir(oldBookDir, 'Books', true);
-      }
     } else if (bestConfigData) {
       // Exact hash match with duplicates removed — adopt the best config
-      const config: Partial<BookConfig> = JSON.parse(bestConfigData);
-      config.bookHash = hash;
-      config.metaHash = metaHash;
+      const config = await prepareConfig(bestConfigData, mergeResult?.audiobookSourceHash);
       await fs.writeFile(getConfigFilename(book), 'Books', serializeRawConfig(config));
+    }
+
+    // Past this point the target book/config is authoritative. A later cleanup
+    // failure must leave the library pointing at the new hash, not roll it back
+    // to a directory whose retirement may already have started.
+    rollbackBook = undefined;
+    rollbackSnapshot = undefined;
+
+    // The target config and its paired audio are durable. Duplicate and old
+    // hash directories can now be retired without leaving a surviving config
+    // pointing at files that were just deleted.
+    const cleanupDirectories = new Set<string>();
+    for (const duplicate of mergeResult?.duplicates ?? []) {
+      duplicate.deletedAt = Date.now();
+      cleanupDirectories.add(getDir(duplicate));
+    }
+    if (metaHashMatch && oldBookDir && oldBookDir !== getDir(book)) {
+      cleanupDirectories.add(oldBookDir);
+    }
+    cleanupDirectories.delete(getDir(book));
+    for (const directory of cleanupDirectories) {
+      try {
+        if (await fs.exists(directory, 'Books')) {
+          await fs.removeDir(directory, 'Books', true);
+        }
+      } catch (error) {
+        console.warn('Failed to clean up merged book directory:', directory, error);
+      }
     }
 
     // update file links with url or path or content uri
@@ -782,6 +875,11 @@ export async function importBook(
 
     return existingBook || book;
   } catch (error) {
+    if (rollbackBook && rollbackSnapshot) {
+      const target = rollbackBook as unknown as Record<string, unknown>;
+      for (const key of Object.keys(target)) delete target[key];
+      Object.assign(target, rollbackSnapshot);
+    }
     console.error('Error importing book:', error);
     throw error;
   } finally {

--- a/apps/readest-app/src/services/tts/SectionTimeline.ts
+++ b/apps/readest-app/src/services/tts/SectionTimeline.ts
@@ -105,7 +105,9 @@ export class SectionTimeline {
   // Map seconds (at the current rate) to a sentence, clamping past-the-end
   // seeks to the last sentence so an over-estimated total is never a dead
   // gesture. Null only for an empty timeline.
-  sentenceAtTime(seconds: number): { index: number; sentence: TimelineSentence } | null {
+  sentenceAtTime(
+    seconds: number,
+  ): { index: number; sentence: TimelineSentence; withinMediaSec: number } | null {
     const n = this.#sentences.length;
     if (n === 0) return null;
     const target = Math.max(0, seconds) * this.#rate;
@@ -124,7 +126,11 @@ export class SectionTimeline {
     }
     // Binary search finds the last sentence starting at or before the target;
     // past-the-end targets land on the final sentence by construction.
-    return { index, sentence: this.#sentences[index]! };
+    const withinMediaSec = Math.min(
+      Math.max(target - this.#prefix[index]!, 0),
+      this.#durations[index]!,
+    );
+    return { index, sentence: this.#sentences[index]!, withinMediaSec };
   }
 
   // Locate the timeline sentence containing (or last starting at or before)

--- a/apps/readest-app/src/services/tts/TTSClient.ts
+++ b/apps/readest-app/src/services/tts/TTSClient.ts
@@ -25,6 +25,10 @@ export interface TTSCapabilities {
   // utterances, so the controller must not insert its own pauses between them —
   // the recording already contains the pauses its narrator made.
   continuousTimeline?: boolean;
+  // Whether the source has text timing precise enough to draw a meaningful
+  // highlight. Chapter-only audiobook mappings keep location/navigation but
+  // disable the visual overlay.
+  textHighlight?: boolean;
 }
 
 export interface TTSClient {
@@ -69,4 +73,7 @@ export interface TTSClient {
   // Continuous recordings use this so chapter-scale clips do not snap back to
   // their start when the scrubber moves inside them.
   seekToChunkPosition?(seconds: number): Promise<boolean>;
+  // Apply an initial offset to the next chunk that starts playing. Used when a
+  // chapter-only recording estimates the current page's position in its track.
+  setNextChunkPosition?(seconds: number): void;
 }

--- a/apps/readest-app/src/services/tts/TTSClient.ts
+++ b/apps/readest-app/src/services/tts/TTSClient.ts
@@ -65,4 +65,8 @@ export interface TTSClient {
   // rather than position/duration so it cannot skew between two calls, and so a
   // playback rate change cannot be applied to one but not the other.
   getChunkProgress?(): number | null;
+  // Move within the currently audible chunk while keeping its play/pause state.
+  // Continuous recordings use this so chapter-scale clips do not snap back to
+  // their start when the scrubber moves inside them.
+  seekToChunkPosition?(seconds: number): Promise<boolean>;
 }

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -1008,6 +1008,13 @@ export class TTSController extends EventTarget {
     if (!timeline) return;
     const target = timeline.sentenceAtTime(seconds);
     if (!target) return;
+    if (
+      target.index === this.#currentSentenceIndex &&
+      this.ttsClient.getCapabilities().continuousTimeline &&
+      (await this.ttsClient.seekToChunkPosition?.(target.withinMediaSec))
+    ) {
+      return;
+    }
     const isPlaying = this.state === 'playing';
     // While playing, this is a handover to the utterance about to be spoken
     // below; only a stopped session should actually be silenced here.

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -1,5 +1,6 @@
 import { FoliateView, ViewTTS } from '@/types/view';
 import { AppService } from '@/types/system';
+import type { PairedAudiobook } from '@/types/book';
 import { SectionItem } from '@/libs/document';
 import { transformTTSSectionDocument } from './transformDoc';
 import { filterSSMLWithLang, parseSSMLMarks } from '@/utils/ssml';
@@ -38,6 +39,7 @@ import {
   MediaOverlayTTS,
   MEDIA_OVERLAY_VOICE_ID,
 } from './mediaOverlay';
+import { findPairedAudiobookSection, loadPairedAudiobookSection } from './pairedAudiobook';
 
 // App-wide monotonic sequence for 'tts-position' events. A fresh TTSController
 // is constructed per `tts-speak`, so a per-instance counter would restart at 0
@@ -161,6 +163,7 @@ export class TTSController extends EventTarget {
   // book's own recording.
   #mediaOverlaySection: MediaOverlaySection | null = null;
   #useNarration = true;
+  #pairedAudiobook: PairedAudiobook | null = null;
 
   ttsLang: string = '';
   ttsRate: number = 1.0;
@@ -314,7 +317,7 @@ export class TTSController extends EventTarget {
     let newTts: ViewTTS;
     let narration: MediaOverlaySection | null = null;
     if (this.narrationActive) {
-      narration = await loadMediaOverlaySection(view.book, sectionIndex, doc, this.ttsLang);
+      narration = await this.#loadNarrationSection(view, sectionIndex, doc);
     }
     if (narration) {
       newTts = new MediaOverlayTTS(doc, narration, this.#getHighlighter());
@@ -357,7 +360,7 @@ export class TTSController extends EventTarget {
     this.#ttsDoc = doc;
     if (narration) {
       this.#mediaOverlaySection = narration;
-      this.ttsMediaOverlayClient.attachBook(view.book);
+      this.#attachNarrationSource(view.book);
       this.ttsMediaOverlayClient.setSection(narration);
     }
     // The timeline maps the old document's ranges; rebuild lazily.
@@ -399,7 +402,7 @@ export class TTSController extends EventTarget {
     // voice for this book) is what overrides it. Deliberately last, so it wins
     // over the globally remembered preferred client.
     if (this.narrationAvailable) {
-      this.ttsMediaOverlayClient.attachBook(this.view.book);
+      this.#attachNarrationSource(this.view.book);
       if (this.useNarration && (await this.ttsMediaOverlayClient.init())) {
         this.ttsClient = this.ttsMediaOverlayClient;
       }
@@ -407,7 +410,10 @@ export class TTSController extends EventTarget {
   }
 
   get narrationAvailable(): boolean {
-    return this.#attached && hasMediaOverlays(this.view?.book);
+    return (
+      this.#attached &&
+      (this.#pairedAudiobookAvailable(this.view?.book) || hasMediaOverlays(this.view?.book))
+    );
   }
 
   get narrationActive(): boolean {
@@ -422,6 +428,65 @@ export class TTSController extends EventTarget {
 
   get useNarration(): boolean {
     return this.#useNarration;
+  }
+
+  set pairedAudiobook(value: PairedAudiobook | null | undefined) {
+    this.#pairedAudiobook = value ?? null;
+  }
+
+  get pairedAudiobook(): PairedAudiobook | null {
+    return this.#pairedAudiobook;
+  }
+
+  #pairedAudiobookAvailable(book: FoliateView['book'] | null | undefined): boolean {
+    return !!(
+      this.appService &&
+      book &&
+      this.#pairedAudiobook &&
+      findPairedAudiobookSection(book, this.#pairedAudiobook, 0, 1) >= 0
+    );
+  }
+
+  #usesPairedAudiobook(book: FoliateView['book']): boolean {
+    return this.#pairedAudiobookAvailable(book);
+  }
+
+  #attachNarrationSource(book: FoliateView['book']): void {
+    if (this.#usesPairedAudiobook(book) && this.#pairedAudiobook && this.appService) {
+      const narrator = this.#pairedAudiobook.narrator;
+      this.ttsMediaOverlayClient.attachSource({
+        ...(narrator ? { narrator } : {}),
+        loadBlob: async (href) => await this.appService!.openFile(href, 'Books'),
+        resolveUrl: async (href) => {
+          const appService = this.appService!;
+          if (appService.appPlatform !== 'tauri' || appService.isMobileApp) return null;
+          const file = await appService.openFile(href, 'Books');
+          return 'url' in file && typeof file.url === 'string' ? file.url : null;
+        },
+        resolvePath: async (href) => await this.appService!.resolveFilePath(href, 'Books'),
+      });
+      return;
+    }
+    this.ttsMediaOverlayClient.attachBook(book);
+  }
+
+  #findNarratedSection(book: FoliateView['book'], from: number, direction: 1 | -1): number {
+    if (this.#usesPairedAudiobook(book) && this.#pairedAudiobook) {
+      return findPairedAudiobookSection(book, this.#pairedAudiobook, from, direction);
+    }
+    return findNarratedSection(book, from, direction);
+  }
+
+  #loadNarrationSection(
+    view: FoliateView,
+    sectionIndex: number,
+    doc: Document,
+  ): Promise<MediaOverlaySection | null> | MediaOverlaySection | null {
+    const lang = this.ttsLang || view.language?.canonical || 'en';
+    if (this.#usesPairedAudiobook(view.book) && this.#pairedAudiobook) {
+      return loadPairedAudiobookSection(view.book, this.#pairedAudiobook, sectionIndex, doc, lang);
+    }
+    return loadMediaOverlaySection(view.book, sectionIndex, doc, lang);
   }
 
   #getPrimaryContent() {
@@ -531,7 +596,7 @@ export class TTSController extends EventTarget {
     // indexes and notes are routinely left out. Step over those sections in
     // whichever direction playback is moving instead of stalling on silence.
     if (this.narrationActive) {
-      const narrated = findNarratedSection(this.view.book, sectionIndex, direction);
+      const narrated = this.#findNarratedSection(this.view.book, sectionIndex, direction);
       if (narrated === -1) return false;
       sectionIndex = narrated;
     }
@@ -575,12 +640,7 @@ export class TTSController extends EventTarget {
     }
 
     if (this.narrationActive) {
-      const narration = await loadMediaOverlaySection(
-        this.view.book,
-        sectionIndex,
-        doc,
-        this.ttsLang || this.view.language?.canonical || 'en',
-      );
+      const narration = await this.#loadNarrationSection(this.view, sectionIndex, doc);
       if (narration) {
         this.#mediaOverlaySection = narration;
         this.ttsMediaOverlayClient.setSection(narration);

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -456,6 +456,7 @@ export class TTSController extends EventTarget {
       const narrator = this.#pairedAudiobook.narrator;
       this.ttsMediaOverlayClient.attachSource({
         ...(narrator ? { narrator } : {}),
+        textHighlight: false,
         loadBlob: async (href) => await this.appService!.openFile(href, 'Books'),
         resolveUrl: async (href) => {
           const appService = this.appService!;
@@ -526,6 +527,7 @@ export class TTSController extends EventTarget {
 
   #getHighlighter() {
     return (range: Range) => {
+      if (this.ttsClient.getCapabilities().textHighlight === false) return;
       // Suppress the sentence highlight that foliate's setMark draws when the
       // active client highlights word-by-word. The flag is only set around the
       // synchronous setMark call, so word draws (dispatchSpeakWord) and paused
@@ -580,6 +582,22 @@ export class TTSController extends EventTarget {
       const fromSectionIndex = (index || this.#getPrimaryContent()?.index) ?? 0;
       await this.#initTTSForSection(fromSectionIndex);
     }
+  }
+
+  // Position the text iterator and, for a chapter-only audiobook mapping,
+  // carry the current page's proportional offset into the first audio chunk.
+  startFromRange(range: Range): string | undefined {
+    const tts = this.#getTts();
+    const ssml = tts?.from(range);
+    if (
+      this.ttsClient.getCapabilities().textHighlight === false &&
+      tts &&
+      'takeStartPosition' in tts
+    ) {
+      const position = tts.takeStartPosition();
+      if (position !== null) this.ttsClient.setNextChunkPosition?.(position);
+    }
+    return ssml;
   }
 
   async #initTTSForSection(sectionIndex: number): Promise<boolean> {
@@ -976,6 +994,7 @@ export class TTSController extends EventTarget {
   }
 
   #drawSeekPreview(range: Range) {
+    if (this.ttsClient.getCapabilities().textHighlight === false) return;
     const content = this.#getPrimaryContent();
     if (!content) return;
     const { doc, index, overlayer } = content;
@@ -1552,6 +1571,15 @@ export class TTSController extends EventTarget {
     return this.ttsClient.getChunkProgress?.() ?? null;
   }
 
+  #getCurrentPlaybackRange(): Range | undefined {
+    const tts = this.#getTts();
+    if (!tts) return undefined;
+    if (this.ttsClient.getCapabilities().textHighlight === false && 'getPlaybackRange' in tts) {
+      return tts.getPlaybackRange(this.ttsClient.getChunkProgress?.());
+    }
+    return tts.getLastRange();
+  }
+
   dispatchSpeakMark(mark?: TTSMark): { sectionIndex: number; sentenceIndex: number } | null {
     let located: { sectionIndex: number; sentenceIndex: number } | null = null;
     this.#resetSpeakWords();
@@ -1581,7 +1609,11 @@ export class TTSController extends EventTarget {
             };
           }
         }
-        const cfi = this.view.getCFI(this.#ttsSectionIndex, range);
+        const playbackRange =
+          this.ttsClient.getCapabilities().textHighlight === false
+            ? (this.#getCurrentPlaybackRange() ?? range)
+            : range;
+        const cfi = this.view.getCFI(this.#ttsSectionIndex, playbackRange);
         this.dispatchEvent(new CustomEvent('tts-highlight-mark', { detail: { cfi } }));
         this.#dispatchPosition(cfi, 'sentence');
       } catch {
@@ -1605,6 +1637,7 @@ export class TTSController extends EventTarget {
   // never reappears over it; otherwise it re-draws the sentence.
   reapplyCurrentHighlight() {
     if (!this.#attached) return;
+    if (this.ttsClient.getCapabilities().textHighlight === false) return;
     if (this.#wordHighlightActive && this.#lastSpeakWordRange) {
       this.#getHighlighter()(this.#lastSpeakWordRange.cloneRange());
       return;
@@ -1641,7 +1674,11 @@ export class TTSController extends EventTarget {
   // a phrase-timed recording has no such cfi, so ask the layout instead.
   isSoundingSentenceOnScreen(): boolean {
     if (!this.#attached) return false;
-    const range = this.#getTts()?.getLastRange();
+    // Approximate chapter mapping already exposes a single live-position CFI;
+    // judging its full chapter as a "sentence on screen" is what hid the return
+    // button on every page in that chapter.
+    if (this.ttsClient.getCapabilities().textHighlight === false) return false;
+    const range = this.#getCurrentPlaybackRange();
     if (!range) return false;
     try {
       const { renderer } = this.view;
@@ -1668,6 +1705,22 @@ export class TTSController extends EventTarget {
     }
   }
 
+  // Live playback location for navigation. For paired audiobooks this is a
+  // one-character estimate derived from track progress, not the whole chapter
+  // range; synthesized and precisely timed narration retain their normal mark.
+  getCurrentPlaybackCfi(): string | null {
+    const wordCfi = this.getCurrentHighlightCfi();
+    if (wordCfi) return wordCfi;
+    if (!this.#attached || this.#ttsSectionIndex < 0) return null;
+    const range = this.#getCurrentPlaybackRange();
+    if (!range) return null;
+    try {
+      return this.view.getCFI(this.#ttsSectionIndex, range) || null;
+    } catch {
+      return null;
+    }
+  }
+
   // Re-emit the controller's current position on the canonical 'tts-position'
   // signal with a fresh (monotonic) sequence. Lets a follower that engages
   // mid-session (paragraph / RSVP mode entered while TTS is already playing or
@@ -1685,7 +1738,7 @@ export class TTSController extends EventTarget {
         }
       } catch {}
     }
-    const range = this.#getTts()?.getLastRange();
+    const range = this.#getCurrentPlaybackRange();
     if (!range) return;
     try {
       const cfi = this.view.getCFI(this.#ttsSectionIndex, range);

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -2,6 +2,7 @@ import { FoliateView, ViewTTS } from '@/types/view';
 import { AppService } from '@/types/system';
 import type { PairedAudiobook } from '@/types/book';
 import { SectionItem } from '@/libs/document';
+import { convertFileSrc } from '@tauri-apps/api/core';
 import { transformTTSSectionDocument } from './transformDoc';
 import { filterSSMLWithLang, parseSSMLMarks } from '@/utils/ssml';
 import { Overlayer } from 'foliate-js/overlayer.js';
@@ -461,8 +462,7 @@ export class TTSController extends EventTarget {
         resolveUrl: async (href) => {
           const appService = this.appService!;
           if (appService.appPlatform !== 'tauri' || appService.isMobileApp) return null;
-          const file = await appService.openFile(href, 'Books');
-          return 'url' in file && typeof file.url === 'string' ? file.url : null;
+          return convertFileSrc(await appService.resolveFilePath(href, 'Books'));
         },
         resolvePath: async (href) => await this.appService!.resolveFilePath(href, 'Books'),
       });
@@ -985,7 +985,7 @@ export class TTSController extends EventTarget {
     if (!timeline || this.#timelineSectionIndex !== this.#ttsSectionIndex) return;
     const target = timeline.sentenceAtTime(seconds);
     if (!target) return;
-    const range = target.sentence.range;
+    const range = this.#rangeAtSeekTarget(target.sentence, target.withinMediaSec);
     try {
       const cfi = this.view.getCFI(this.#ttsSectionIndex, range);
       this.dispatchEvent(new CustomEvent('tts-highlight-mark', { detail: { cfi, preview: true } }));
@@ -1017,6 +1017,27 @@ export class TTSController extends EventTarget {
     }
   }
 
+  // A paired audiobook has only chapter-level timing. Convert the scrubber's
+  // exact audio offset into the same proportional one-character text location
+  // used by live playback, while precisely timed narration stays par-snapped.
+  #rangeAtSeekTarget(sentence: TimelineSentence, withinMediaSec: number): Range {
+    if (this.ttsClient.getCapabilities().textHighlight !== false) return sentence.range;
+    const duration = sentence.duration;
+    const length = rangeTextExcludingInert(sentence.range).length;
+    if (!duration || !Number.isFinite(duration) || length <= 1) return sentence.range;
+    const fraction = Math.min(Math.max(withinMediaSec / duration, 0), 1);
+    const offset = Math.min(Math.floor(fraction * length), length - 1);
+    return getTextSubRange(sentence.range, offset, offset + 1) ?? sentence.range;
+  }
+
+  #dispatchSeekLocation(range: Range) {
+    try {
+      const cfi = this.view.getCFI(this.#ttsSectionIndex, range);
+      this.dispatchEvent(new CustomEvent('tts-highlight-mark', { detail: { cfi } }));
+      this.#dispatchPosition(cfi, 'sentence');
+    } catch {}
+  }
+
   // Sentence-snapped seek through the same navigation machinery as prev/next:
   // foliate's from(range) returns the paragraph SSML sliced at the target
   // sentence, so highlighting, page-follow, and mark bookkeeping come free.
@@ -1027,11 +1048,13 @@ export class TTSController extends EventTarget {
     if (!timeline) return;
     const target = timeline.sentenceAtTime(seconds);
     if (!target) return;
+    const range = this.#rangeAtSeekTarget(target.sentence, target.withinMediaSec);
     if (
       target.index === this.#currentSentenceIndex &&
       this.ttsClient.getCapabilities().continuousTimeline &&
       (await this.ttsClient.seekToChunkPosition?.(target.withinMediaSec))
     ) {
+      this.#dispatchSeekLocation(range);
       return;
     }
     const isPlaying = this.state === 'playing';
@@ -1040,7 +1063,10 @@ export class TTSController extends EventTarget {
     await this.stop(isPlaying);
     if (!isPlaying) this.state = 'forward-paused';
     this.#currentSentenceIndex = target.index;
-    const ssml = this.#getTts()?.from(target.sentence.range);
+    const ssml = this.#getTts()?.from(range);
+    if (this.ttsClient.getCapabilities().textHighlight === false) {
+      this.ttsClient.setNextChunkPosition?.(target.withinMediaSec);
+    }
     await this.#handleNavigationWithSSML(ssml, isPlaying);
     if (!isPlaying) this.reapplyCurrentHighlight();
   }

--- a/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayClient.ts
+++ b/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayClient.ts
@@ -84,6 +84,7 @@ interface ClipRun {
 
 export interface NarrationAudioSource {
   narrator?: string;
+  textHighlight?: boolean;
   loadBlob: (href: string) => Promise<Blob>;
   resolveUrl?: (href: string) => Promise<string | null>;
   resolvePath?: (href: string) => Promise<string | null>;
@@ -126,6 +127,7 @@ export class MediaOverlayClient implements TTSClient {
   #objectUrl: string | null = null;
   #audioLoad: { href: string; promise: Promise<NarrationClock> } | null = null;
   #currentPar: NarrationPar | null = null;
+  #nextChunkPosition: number | null = null;
   #handoverTimer: ReturnType<typeof setTimeout> | null = null;
   #rate = 1;
   #lang = 'en';
@@ -164,6 +166,7 @@ export class MediaOverlayClient implements TTSClient {
   // Media Overlays; only the blob provider and narrator label differ.
   attachSource(source: NarrationAudioSource | null): void {
     this.#source = source;
+    this.#nextChunkPosition = null;
   }
 
   // The narration index for the section now playing; rebuilt on every section
@@ -354,7 +357,10 @@ export class MediaOverlayClient implements TTSClient {
       return;
     }
 
-    for (const run of toRuns(pars)) {
+    const runs = toRuns(pars);
+    const requestedStart = this.#nextChunkPosition;
+    this.#nextChunkPosition = null;
+    for (const [runIndex, run] of runs.entries()) {
       if (signal.aborted) return;
 
       let audio: NarrationClock;
@@ -377,14 +383,19 @@ export class MediaOverlayClient implements TTSClient {
       // the paragraph's first word ("me me"). Move the playhead only for a real
       // discontinuity: session start, a sentence skip, a scrub, a new audio file.
       const first = run.pars[0]!;
+      const requestedPosition =
+        runIndex === 0 && requestedStart !== null
+          ? first.clipBegin + Math.min(Math.max(requestedStart, 0), first.clipEnd - first.clipBegin)
+          : null;
       const alreadyRolling =
         audio.currentTime >= first.clipBegin - CLIP_CONTINUITY_TOLERANCE_SEC &&
         audio.currentTime < first.clipEnd;
-      if (!alreadyRolling) {
+      if (requestedPosition !== null || !alreadyRolling) {
+        const position = requestedPosition ?? first.clipBegin;
         // Native seek is async (plugin invoke); assigning currentTime alone can
         // race with play() and start from the previous playhead.
-        if (this.#native && this.#player) await this.#player.seek(first.clipBegin);
-        else audio.currentTime = first.clipBegin;
+        if (this.#native && this.#player) await this.#player.seek(position);
+        else audio.currentTime = position;
       }
       try {
         await audio.play();
@@ -519,7 +530,12 @@ export class MediaOverlayClient implements TTSClient {
       gapControl: false,
       liveRateChange: true,
       continuousTimeline: true,
+      textHighlight: this.#source?.textHighlight !== false,
     };
+  }
+
+  setNextChunkPosition(seconds: number): void {
+    this.#nextChunkPosition = Number.isFinite(seconds) ? Math.max(seconds, 0) : null;
   }
 
   getChunkPosition(): number | null {

--- a/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayClient.ts
+++ b/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayClient.ts
@@ -10,10 +10,11 @@
 // pars in a paragraph are contiguous audio, and re-seeking between them would
 // put an audible seam in the middle of a narrated sentence.
 //
-// On iOS Tauri the clock is an in-process AVPlayer (NativeNarrationPlayer):
-// HTMLAudioElement is interrupted when TTSMediaBridge claims the app's
-// non-mixable .playback session — the same constraint that moved Edge TTS to
-// NativeAudioPlayer. Everywhere else a plain HTMLAudioElement is enough.
+// On mobile Tauri the clock is an in-process native player
+// (NativeNarrationPlayer). iOS needs it so TTSMediaBridge and narration share
+// one playback session; Android needs it so multi-hour local files can stream
+// from disk without buffering the whole audiobook through the WebView.
+// Desktop and web use a plain HTMLAudioElement.
 
 import type { BookDoc } from '@/libs/document';
 import { getOSPlatform, stubTranslation as _ } from '@/utils/misc';
@@ -49,7 +50,8 @@ const HANDOVER_GRACE_MS = 1000;
 // Inline of isTauriAppPlatform(): importing @/services/environment pulls the
 // app-service graph into unit tests that only need the platform bit.
 const isNativeNarrationPlatform = (): boolean =>
-  getOSPlatform() === 'ios' && process.env['NEXT_PUBLIC_APP_PLATFORM'] === 'tauri';
+  ['android', 'ios'].includes(getOSPlatform()) &&
+  process.env['NEXT_PUBLIC_APP_PLATFORM'] === 'tauri';
 
 // Container blobs come out of the zip with no MIME type, and a media element
 // given a typeless blob URL refuses to decode it ("Format error"), so the type
@@ -80,6 +82,13 @@ interface ClipRun {
   pars: NarrationPar[];
 }
 
+export interface NarrationAudioSource {
+  narrator?: string;
+  loadBlob: (href: string) => Promise<Blob>;
+  resolveUrl?: (href: string) => Promise<string | null>;
+  resolvePath?: (href: string) => Promise<string | null>;
+}
+
 // Minimal clock surface shared by HTMLAudioElement and NativeNarrationPlayer.
 interface NarrationClock {
   currentTime: number;
@@ -108,7 +117,7 @@ export class MediaOverlayClient implements TTSClient {
   initialized = false;
   controller?: TTSController;
 
-  #book: BookDoc | null = null;
+  #source: NarrationAudioSource | null = null;
   #section: MediaOverlaySection | null = null;
   #native = isNativeNarrationPlatform();
   #player: NativeNarrationPlayer | null = null;
@@ -141,7 +150,20 @@ export class MediaOverlayClient implements TTSClient {
   // session, independently of the section, so the voice list can name the
   // narrator before any section has been indexed.
   attachBook(book: BookDoc | null): void {
-    this.#book = book;
+    this.attachSource(
+      book?.loadBlob
+        ? {
+            narrator: book.media?.narrator,
+            loadBlob: (href) => book.loadBlob!(href),
+          }
+        : null,
+    );
+  }
+
+  // External audiobook files use the same clock and clip machinery as EPUB
+  // Media Overlays; only the blob provider and narrator label differ.
+  attachSource(source: NarrationAudioSource | null): void {
+    this.#source = source;
   }
 
   // The narration index for the section now playing; rebuilt on every section
@@ -151,7 +173,7 @@ export class MediaOverlayClient implements TTSClient {
   }
 
   #narratorName(): string {
-    return this.#book?.media?.narrator?.trim() || _('Book narration');
+    return this.#source?.narrator?.trim() || _('Book narration');
   }
 
   // Concurrent callers share one load. Playback and the controller's
@@ -172,15 +194,19 @@ export class MediaOverlayClient implements TTSClient {
   }
 
   async #loadAudio(href: string): Promise<NarrationClock> {
-    if (!this.#book?.loadBlob) throw new Error('Book cannot load narration audio');
-
-    const blob = audioBlobWithType(href, await this.#book.loadBlob(href));
+    if (!this.#source) throw new Error('Book cannot load narration audio');
 
     if (this.#native && this.#player) {
+      const path = await this.#source.resolvePath?.(href).catch(() => null);
       // Keep any prior native session's file until the new one is staged; load()
       // replaces the AVPlayer item. Do not call #releaseAudio (that aborts).
       this.#cancelHandover();
-      await this.#player.load(href, blob, 0);
+      if (path) {
+        await this.#player.loadPath(href, path, 0);
+      } else {
+        const blob = audioBlobWithType(href, await this.#source.loadBlob(href));
+        await this.#player.load(href, blob, 0);
+      }
       this.#player.playbackRate = this.#rate;
       this.#player.pause();
       this.#audio = this.#player;
@@ -189,8 +215,14 @@ export class MediaOverlayClient implements TTSClient {
       return this.#player;
     }
 
+    const directUrl = await this.#source.resolveUrl?.(href).catch(() => null);
     this.#releaseAudio();
-    const url = URL.createObjectURL(blob);
+    let url = directUrl ?? null;
+    if (!url) {
+      const blob = audioBlobWithType(href, await this.#source.loadBlob(href));
+      url = URL.createObjectURL(blob);
+      this.#objectUrl = url;
+    }
     const audio = new Audio();
     audio.src = url;
     // Speed changes must not raise the narrator's pitch.
@@ -198,7 +230,6 @@ export class MediaOverlayClient implements TTSClient {
     audio.playbackRate = this.#rate;
     this.#audio = audio;
     this.#audioHref = href;
-    this.#objectUrl = url;
     return audio;
   }
 
@@ -469,7 +500,7 @@ export class MediaOverlayClient implements TTSClient {
   }
 
   #voices(): TTSVoice[] {
-    if (!this.#book) return [];
+    if (!this.#source) return [];
     return [{ id: MEDIA_OVERLAY_VOICE_ID, name: this.#narratorName(), lang: this.#lang }];
   }
 
@@ -524,6 +555,6 @@ export class MediaOverlayClient implements TTSClient {
     }
     this.#currentPar = null;
     this.#section = null;
-    this.#book = null;
+    this.#source = null;
   }
 }

--- a/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayClient.ts
+++ b/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayClient.ts
@@ -575,11 +575,10 @@ export class MediaOverlayClient implements TTSClient {
 
   async shutdown(): Promise<void> {
     this.initialized = false;
+    const player = this.#player;
+    this.#player = null;
     this.#releaseAudio();
-    if (this.#player) {
-      await this.#player.shutdown();
-      this.#player = null;
-    }
+    if (player) await player.shutdown();
     this.#currentPar = null;
     this.#section = null;
     this.#source = null;

--- a/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayClient.ts
+++ b/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayClient.ts
@@ -538,6 +538,17 @@ export class MediaOverlayClient implements TTSClient {
     return Math.min(Math.max(elapsed / duration, 0), 1);
   }
 
+  async seekToChunkPosition(seconds: number): Promise<boolean> {
+    const audio = this.#audio;
+    const par = this.#currentPar;
+    if (!audio || !par) return false;
+    const within = Math.min(Math.max(seconds, 0), par.clipEnd - par.clipBegin);
+    const position = par.clipBegin + within;
+    if (this.#native && this.#player) await this.#player.seek(position);
+    else audio.currentTime = position;
+    return true;
+  }
+
   getVoiceId(): string {
     return MEDIA_OVERLAY_VOICE_ID;
   }

--- a/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlaySection.ts
+++ b/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlaySection.ts
@@ -24,6 +24,8 @@ export interface NarrationPar {
   clipEnd: number;
 }
 
+export type NarrationTextTiming = 'exact' | 'approximate';
+
 const SSML_NS = 'http://www.w3.org/2001/10/synthesis';
 
 // Mirrors foliate's `blockTags` in tts.js (not exported), so paragraph-level
@@ -113,12 +115,14 @@ const escapeXML = (text: string): string =>
 export class MediaOverlaySection {
   readonly pars: NarrationPar[];
   readonly blocks: NarrationPar[][] = [];
+  readonly textTiming: NarrationTextTiming;
   #lang: string;
   #byMark: Map<string, NarrationPar>;
 
-  constructor(pars: NarrationPar[], lang: string) {
+  constructor(pars: NarrationPar[], lang: string, textTiming: NarrationTextTiming = 'exact') {
     this.pars = pars;
     this.#lang = lang || 'en';
+    this.textTiming = textTiming;
     this.#byMark = new Map(pars.map((par) => [par.markName, par]));
     for (const par of pars) {
       (this.blocks[par.blockIndex] ??= []).push(par);

--- a/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayTTS.ts
+++ b/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayTTS.ts
@@ -13,12 +13,69 @@
 
 import type { MediaOverlaySection, NarrationPar } from './MediaOverlaySection';
 
+const textFractionAt = (outer: Range, target: Range): number => {
+  try {
+    const outerDoc = outer.startContainer.ownerDocument ?? outer.startContainer;
+    const targetDoc = target.startContainer.ownerDocument ?? target.startContainer;
+    if (outerDoc !== targetDoc) return 0;
+    const relation = outer.comparePoint(target.startContainer, target.startOffset);
+    if (relation < 0) return 0;
+    if (relation > 0) return 1;
+    const total = outer.toString().length;
+    if (total <= 0) return 0;
+    const prefix = outer.cloneRange();
+    prefix.setEnd(target.startContainer, target.startOffset);
+    return Math.min(Math.max(prefix.toString().length / total, 0), 1);
+  } catch {
+    return 0;
+  }
+};
+
+const textRangeAt = (outer: Range, fraction: number): Range => {
+  const doc = outer.startContainer.ownerDocument!;
+  const root = doc.body ?? outer.commonAncestorContainer;
+  const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const segments: { node: Text; start: number; end: number }[] = [];
+  let total = 0;
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const text = node as Text;
+    if (!outer.intersectsNode(text)) continue;
+    const start = text === outer.startContainer ? outer.startOffset : 0;
+    const end = text === outer.endContainer ? outer.endOffset : text.length;
+    if (end <= start) continue;
+    segments.push({ node: text, start, end });
+    total += end - start;
+  }
+
+  if (!segments.length || total <= 0) return outer.cloneRange();
+  let offset = Math.min(Math.max(fraction, 0), 1) * total;
+  for (const segment of segments) {
+    const length = segment.end - segment.start;
+    if (offset < length) {
+      const start = segment.start + Math.floor(offset);
+      const range = doc.createRange();
+      range.setStart(segment.node, start);
+      range.setEnd(segment.node, Math.min(start + 1, segment.end));
+      return range;
+    }
+    offset -= length;
+  }
+
+  const last = segments.at(-1)!;
+  const range = doc.createRange();
+  range.setStart(last.node, Math.max(last.start, last.end - 1));
+  range.setEnd(last.node, last.end);
+  return range;
+};
+
 export class MediaOverlayTTS {
   readonly doc: Document;
   highlight: (range: Range) => void;
   #section: MediaOverlaySection;
   #blockIndex = -1;
   #lastMark: string | null = null;
+  #pendingStartPosition: number | null = null;
+  #playbackProgress = 0;
 
   constructor(doc: Document, section: MediaOverlaySection, highlight: (range: Range) => void) {
     this.doc = doc;
@@ -39,6 +96,8 @@ export class MediaOverlayTTS {
     if (!block?.length) return undefined;
     this.#blockIndex = blockIndex;
     this.#lastMark = mark;
+    this.#pendingStartPosition = null;
+    this.#playbackProgress = 0;
     if (paused) {
       const par = mark ? this.#section.parByMark(mark) : block[0];
       if (par) this.highlight(par.range.cloneRange());
@@ -94,6 +153,7 @@ export class MediaOverlayTTS {
   setMark(mark: string): Range | undefined {
     const par = this.#section.parByMark(mark);
     if (!par) return undefined;
+    if (this.#lastMark !== mark) this.#playbackProgress = 0;
     this.#blockIndex = par.blockIndex;
     this.#lastMark = mark;
     this.highlight(par.range.cloneRange());
@@ -103,6 +163,26 @@ export class MediaOverlayTTS {
   getLastRange(): Range | undefined {
     if (!this.#lastMark) return undefined;
     return this.#section.parByMark(this.#lastMark)?.range.cloneRange();
+  }
+
+  // The one-character text location corresponding to the active recording
+  // position. Exact Media Overlays retain their publisher-authored par range;
+  // chapter-only pairings use a linear text/audio estimate for navigation.
+  getPlaybackRange(progress?: number | null): Range | undefined {
+    if (!this.#lastMark) return undefined;
+    const par = this.#section.parByMark(this.#lastMark);
+    if (!par) return undefined;
+    if (this.#section.textTiming === 'exact') return par.range.cloneRange();
+    if (progress !== null && progress !== undefined && Number.isFinite(progress)) {
+      this.#playbackProgress = Math.min(Math.max(progress, 0), 1);
+    }
+    return textRangeAt(par.range, this.#playbackProgress);
+  }
+
+  takeStartPosition(): number | null {
+    const position = this.#pendingStartPosition;
+    this.#pendingStartPosition = null;
+    return position;
   }
 
   // Resume at the par a location falls inside: the first one still running at
@@ -128,6 +208,13 @@ export class MediaOverlayTTS {
       pars.at(-1);
     // Unlike foliate's `from`, this leaves #lastMark pointing at the resolved
     // par so a later resume() picks up there instead of the block start.
-    return target ? this.#enter(target.blockIndex, target.markName) : this.#enter(0, null);
+    if (!target) return this.#enter(0, null);
+    const ssml = this.#enter(target.blockIndex, target.markName);
+    if (this.#section.textTiming === 'approximate') {
+      const fraction = textFractionAt(target.range, range);
+      this.#playbackProgress = fraction;
+      this.#pendingStartPosition = (target.clipEnd - target.clipBegin) * fraction;
+    }
+    return ssml;
   }
 }

--- a/apps/readest-app/src/services/tts/mediaOverlay/NativeNarrationPlayer.ts
+++ b/apps/readest-app/src/services/tts/mediaOverlay/NativeNarrationPlayer.ts
@@ -1,13 +1,11 @@
-// Continuous long-file playout for Media Overlay on iOS Tauri.
+// Continuous long-file playout for Media Overlay on mobile Tauri.
 //
 // Edge TTS already plays through an in-process AVPlayer (NativeAudioPlayer)
-// because WebKit HTMLMediaElement / WebAudio cannot own the app's
-// non-mixable .playback session — Now Playing, mute switch, and AirPods all
-// fight it. Media Overlay used HTMLAudioElement and was interrupted ~0.5s
-// after play() when TTSMediaBridge claimed that session. This player routes
-// narration through the same native playout AVPlayer via load/seek, staging
-// chapter audio to a temp file (100 MB clips cannot cross the plugin as
-// base64).
+// because WebKit HTMLMediaElement / WebAudio cannot own the app's non-mixable
+// playback session. Android uses the same interface so local audiobooks stream
+// through ExoPlayer rather than being copied into a WebView Blob. This player
+// stages container blobs to a temp file, while paired audiobooks can hand the
+// native player their existing path directly.
 
 import { addPluginListener, invoke, PluginListener } from '@tauri-apps/api/core';
 import { join, tempDir } from '@tauri-apps/api/path';
@@ -49,6 +47,7 @@ export class NativeNarrationPlayer {
   #href: string | null = null;
   #stagedPath: string | null = null;
   #stagedHref: string | null = null;
+  #ownsStagedPath = false;
   #rate = 1;
   #userPaused = true;
   #ended = false;
@@ -135,6 +134,25 @@ export class NativeNarrationPlayer {
   async load(href: string, blob: Blob, startSec = 0): Promise<void> {
     await this.ensureReady();
     const path = await this.#stageBlob(href, blob);
+    await this.#loadResolvedPath(href, path, startSec);
+  }
+
+  // Paired audiobooks already live as ordinary files under Books/<hash>.
+  // Hand AVPlayer that path directly: copying a multi-hour M4B through a Blob
+  // and a second temp file would double I/O and briefly hold the whole book in
+  // memory. The caller owns the path, so release() must never delete it.
+  async loadPath(href: string, path: string, startSec = 0): Promise<void> {
+    await this.ensureReady();
+    if (this.#ownsStagedPath && this.#stagedPath && this.#stagedPath !== path) {
+      await remove(this.#stagedPath).catch(() => undefined);
+    }
+    this.#stagedHref = href;
+    this.#stagedPath = path;
+    this.#ownsStagedPath = false;
+    await this.#loadResolvedPath(href, path, startSec);
+  }
+
+  async #loadResolvedPath(href: string, path: string, startSec: number): Promise<void> {
     this.#href = href;
     this.#ended = false;
     await invoke('plugin:native-tts|playout_control', {
@@ -195,9 +213,11 @@ export class NativeNarrationPlayer {
     this.#href = null;
     this.#stopPolling();
     const path = this.#stagedPath;
+    const ownsPath = this.#ownsStagedPath;
     this.#stagedPath = null;
     this.#stagedHref = null;
-    if (path) {
+    this.#ownsStagedPath = false;
+    if (path && ownsPath) {
       await remove(path).catch(() => undefined);
     }
     this.#nativeSession = null;
@@ -219,7 +239,7 @@ export class NativeNarrationPlayer {
 
   async #stageBlob(href: string, blob: Blob): Promise<string> {
     if (this.#stagedHref === href && this.#stagedPath) return this.#stagedPath;
-    if (this.#stagedPath) {
+    if (this.#stagedPath && this.#ownsStagedPath) {
       await remove(this.#stagedPath).catch(() => undefined);
     }
     const name = `mo-narration-${hashHref(href)}.${fileExtension(href)}`;
@@ -228,6 +248,7 @@ export class NativeNarrationPlayer {
     const path = await join(await tempDir(), name);
     this.#stagedHref = href;
     this.#stagedPath = path;
+    this.#ownsStagedPath = true;
     return path;
   }
 

--- a/apps/readest-app/src/services/tts/mediaOverlay/NativeNarrationPlayer.ts
+++ b/apps/readest-app/src/services/tts/mediaOverlay/NativeNarrationPlayer.ts
@@ -111,7 +111,6 @@ export class NativeNarrationPlayer {
       return res.session;
     });
     await this.#nativeSession;
-    this.#startPolling();
   }
 
   // Forget the native session id after another engine (Edge) aborted the shared
@@ -190,11 +189,14 @@ export class NativeNarrationPlayer {
     await invoke('plugin:native-tts|playout_control', { payload: { action: 'resume' } });
     this.#cache.playing = true;
     this.#cache.at = performance.now();
+    this.#startPolling();
   }
 
   pause(): void {
+    const mediaSec = this.currentTime;
     this.#userPaused = true;
-    this.#cache.playing = false;
+    this.#cache = { mediaSec, playing: false, at: performance.now() };
+    this.#stopPolling();
     void invoke('plugin:native-tts|playout_control', { payload: { action: 'pause' } }).catch(
       () => {},
     );
@@ -299,7 +301,7 @@ export class NativeNarrationPlayer {
   }
 
   async #poll(): Promise<void> {
-    if (this.#resolvedSession === null || this.#ended) return;
+    if (this.#resolvedSession === null || this.#ended || this.#userPaused) return;
     try {
       const pos = await invoke<PlayoutPosition>('plugin:native-tts|playout_position');
       if (pos.session !== this.#resolvedSession) return;

--- a/apps/readest-app/src/services/tts/pairedAudiobook.ts
+++ b/apps/readest-app/src/services/tts/pairedAudiobook.ts
@@ -1,0 +1,178 @@
+import type { BookDoc, TOCItem } from '@/libs/document';
+import { collectAudiobookTextChapters } from '@/services/audiobook/mapping';
+import type { AudiobookChapter, AudiobookFile, PairedAudiobook } from '@/types/book';
+import { MediaOverlaySection, type NarrationPar } from './mediaOverlay/MediaOverlaySection';
+
+interface PairedChapterEntry {
+  tocItems: TOCItem[];
+  sectionIndex: number;
+  audioChapter: AudiobookChapter;
+  audioFile: AudiobookFile;
+}
+
+interface TextPoint {
+  node: Text;
+  offset: number;
+}
+
+const sectionIndexForHref = (book: BookDoc, href: string): number => {
+  const [sectionId] = book.splitTOCHref(href) as [string | undefined];
+  if (!sectionId) return -1;
+  return book.sections.findIndex(
+    (section) => section.id === sectionId || section.href === sectionId,
+  );
+};
+
+const pairedChapterEntries = (
+  book: BookDoc,
+  association: PairedAudiobook,
+): PairedChapterEntry[] => {
+  const tocByHref = new Map(
+    collectAudiobookTextChapters(book.toc ?? []).map((chapter) => [chapter.href, chapter]),
+  );
+  const rawTocByHref = new Map<string, TOCItem>();
+  const visit = (items: TOCItem[]) => {
+    for (const item of items) {
+      if (item.href && !rawTocByHref.has(item.href)) rawTocByHref.set(item.href, item);
+      if (item.subitems?.length) visit(item.subitems);
+    }
+  };
+  visit(book.toc ?? []);
+
+  const chapterById = new Map(association.chapters.map((chapter) => [chapter.id, chapter]));
+  const fileById = new Map(association.files.map((file) => [file.id, file]));
+  const mappingByEbook = new Map(
+    association.mappings.map((mapping) => [mapping.ebookChapterId, mapping.audioChapterId]),
+  );
+  const usedAudioChapters = new Set<string>();
+  const entries: PairedChapterEntry[] = [];
+
+  for (const { href } of tocByHref.values()) {
+    const audioChapterId = mappingByEbook.get(href);
+    if (!audioChapterId) continue;
+    const audioChapter = chapterById.get(audioChapterId);
+    const audioFile = audioChapter ? fileById.get(audioChapter.fileId) : undefined;
+    const tocItem = rawTocByHref.get(href);
+    const sectionIndex = sectionIndexForHref(book, href);
+    if (!audioChapter || !audioFile || !tocItem || sectionIndex < 0) continue;
+
+    // Continuum permits several ebook chapters to point at one audio chapter.
+    // Consecutive chapters in the same document become one text span over one
+    // clip. A later non-consecutive duplicate remains skipped so sequential
+    // playback never rewinds and repeats the recording.
+    if (usedAudioChapters.has(audioChapterId)) {
+      const previous = entries.at(-1);
+      if (previous?.audioChapter.id === audioChapterId && previous.sectionIndex === sectionIndex) {
+        previous.tocItems.push(tocItem);
+      }
+      continue;
+    }
+    usedAudioChapters.add(audioChapterId);
+    entries.push({ tocItems: [tocItem], sectionIndex, audioChapter, audioFile });
+  }
+
+  return entries;
+};
+
+const readableTextPoints = (root: Node): { first: TextPoint; last: TextPoint } | null => {
+  const doc = root.ownerDocument ?? (root as Document);
+  const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let first: TextPoint | null = null;
+  let last: TextPoint | null = null;
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const text = node as Text;
+    if (!text.data.trim()) continue;
+    first ??= { node: text, offset: text.data.length - text.data.trimStart().length };
+    last = { node: text, offset: text.data.trimEnd().length };
+  }
+  return first && last ? { first, last } : null;
+};
+
+const fragmentId = (href: string): string | null => {
+  const hashIndex = href.indexOf('#');
+  if (hashIndex < 0) return null;
+  const raw = href.slice(hashIndex + 1);
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+};
+
+const chapterStart = (doc: Document, href: string): TextPoint | null => {
+  const id = fragmentId(href);
+  const root = (id ? doc.getElementById(id) : null) ?? doc.body;
+  return root ? (readableTextPoints(root)?.first ?? null) : null;
+};
+
+const chapterRange = (
+  doc: Document,
+  href: string,
+  nextHrefInSection: string | undefined,
+): Range | null => {
+  const start = chapterStart(doc, href);
+  const bodyPoints = doc.body ? readableTextPoints(doc.body) : null;
+  if (!start || !bodyPoints) return null;
+  const next = nextHrefInSection ? chapterStart(doc, nextHrefInSection) : null;
+  const end = next ?? bodyPoints.last;
+  const range = doc.createRange();
+  try {
+    range.setStart(start.node, start.offset);
+    range.setEnd(end.node, end.offset);
+  } catch {
+    return null;
+  }
+  return range.collapsed ? null : range;
+};
+
+export const findPairedAudiobookSection = (
+  book: BookDoc,
+  association: PairedAudiobook,
+  from: number,
+  direction: 1 | -1,
+): number => {
+  const narrated = new Set(
+    pairedChapterEntries(book, association).map((entry) => entry.sectionIndex),
+  );
+  for (let index = from; index >= 0 && index < book.sections.length; index += direction) {
+    if (narrated.has(index)) return index;
+  }
+  return -1;
+};
+
+export const loadPairedAudiobookSection = (
+  book: BookDoc,
+  association: PairedAudiobook,
+  sectionIndex: number,
+  doc: Document,
+  lang: string,
+): MediaOverlaySection | null => {
+  const allToc = collectAudiobookTextChapters(book.toc ?? []);
+  const tocInSection = allToc.filter(
+    (chapter) => sectionIndexForHref(book, chapter.href) === sectionIndex,
+  );
+  const nextHref = new Map<string, string>();
+  for (let index = 0; index < tocInSection.length - 1; index += 1) {
+    nextHref.set(tocInSection[index]!.href, tocInSection[index + 1]!.href);
+  }
+
+  const pars: NarrationPar[] = [];
+  for (const entry of pairedChapterEntries(book, association)) {
+    if (entry.sectionIndex !== sectionIndex) continue;
+    const firstTocItem = entry.tocItems[0]!;
+    const lastTocItem = entry.tocItems.at(-1)!;
+    const range = chapterRange(doc, firstTocItem.href, nextHref.get(lastTocItem.href));
+    if (!range) continue;
+    pars.push({
+      markName: String(pars.length),
+      blockIndex: pars.length,
+      range,
+      text: firstTocItem.label.trim() || entry.audioChapter.label,
+      audioHref: entry.audioFile.path,
+      clipBegin: entry.audioChapter.start,
+      clipEnd: entry.audioChapter.end,
+    });
+  }
+
+  return pars.length ? new MediaOverlaySection(pars, lang) : null;
+};

--- a/apps/readest-app/src/services/tts/pairedAudiobook.ts
+++ b/apps/readest-app/src/services/tts/pairedAudiobook.ts
@@ -174,5 +174,5 @@ export const loadPairedAudiobookSection = (
     });
   }
 
-  return pars.length ? new MediaOverlaySection(pars, lang) : null;
+  return pars.length ? new MediaOverlaySection(pars, lang, 'approximate') : null;
 };

--- a/apps/readest-app/src/services/tts/pairedAudiobook.ts
+++ b/apps/readest-app/src/services/tts/pairedAudiobook.ts
@@ -8,6 +8,14 @@ interface PairedChapterEntry {
   sectionIndex: number;
   audioChapter: AudiobookChapter;
   audioFile: AudiobookFile;
+  clipBegin: number;
+  clipEnd: number;
+}
+
+interface PairedChapterCandidate
+  extends Omit<PairedChapterEntry, 'tocItems' | 'clipBegin' | 'clipEnd'> {
+  tocItem: TOCItem;
+  orderIndex: number;
 }
 
 interface TextPoint {
@@ -44,10 +52,9 @@ const pairedChapterEntries = (
   const mappingByEbook = new Map(
     association.mappings.map((mapping) => [mapping.ebookChapterId, mapping.audioChapterId]),
   );
-  const usedAudioChapters = new Set<string>();
-  const entries: PairedChapterEntry[] = [];
+  const candidates: PairedChapterCandidate[] = [];
 
-  for (const { href } of tocByHref.values()) {
+  for (const [orderIndex, { href }] of [...tocByHref.values()].entries()) {
     const audioChapterId = mappingByEbook.get(href);
     if (!audioChapterId) continue;
     const audioChapter = chapterById.get(audioChapterId);
@@ -56,21 +63,50 @@ const pairedChapterEntries = (
     const sectionIndex = sectionIndexForHref(book, href);
     if (!audioChapter || !audioFile || !tocItem || sectionIndex < 0) continue;
 
-    // Continuum permits several ebook chapters to point at one audio chapter.
-    // Consecutive chapters in the same document become one text span over one
-    // clip. A later non-consecutive duplicate remains skipped so sequential
-    // playback never rewinds and repeats the recording.
-    if (usedAudioChapters.has(audioChapterId)) {
-      const previous = entries.at(-1);
-      if (previous?.audioChapter.id === audioChapterId && previous.sectionIndex === sectionIndex) {
-        previous.tocItems.push(tocItem);
-      }
-      continue;
-    }
-    usedAudioChapters.add(audioChapterId);
-    entries.push({ tocItems: [tocItem], sectionIndex, audioChapter, audioFile });
+    candidates.push({ tocItem, sectionIndex, audioChapter, audioFile, orderIndex });
   }
 
+  const entries: PairedChapterEntry[] = [];
+  for (let index = 0; index < candidates.length; ) {
+    const first = candidates[index]!;
+    let end = index + 1;
+    while (
+      end < candidates.length &&
+      candidates[end]!.audioChapter.id === first.audioChapter.id &&
+      candidates[end]!.orderIndex === candidates[end - 1]!.orderIndex + 1
+    ) {
+      end += 1;
+    }
+
+    const run = candidates.slice(index, end);
+    const duration = first.audioChapter.end - first.audioChapter.start;
+    for (const [runIndex, candidate] of run.entries()) {
+      // A chapter-only pairing has no finer timing signal. Divide one reused
+      // clip into equal chapter slices so a run can cross spine documents
+      // without replaying the whole recording at every section boundary.
+      const clipBegin = first.audioChapter.start + (duration * runIndex) / run.length;
+      const clipEnd = first.audioChapter.start + (duration * (runIndex + 1)) / run.length;
+      const previous = entries.at(-1);
+      if (
+        previous?.audioChapter.id === candidate.audioChapter.id &&
+        previous.sectionIndex === candidate.sectionIndex &&
+        runIndex > 0
+      ) {
+        previous.tocItems.push(candidate.tocItem);
+        previous.clipEnd = clipEnd;
+      } else {
+        entries.push({
+          tocItems: [candidate.tocItem],
+          sectionIndex: candidate.sectionIndex,
+          audioChapter: candidate.audioChapter,
+          audioFile: candidate.audioFile,
+          clipBegin,
+          clipEnd,
+        });
+      }
+    }
+    index = end;
+  }
   return entries;
 };
 
@@ -101,8 +137,22 @@ const fragmentId = (href: string): string | null => {
 
 const chapterStart = (doc: Document, href: string): TextPoint | null => {
   const id = fragmentId(href);
-  const root = (id ? doc.getElementById(id) : null) ?? doc.body;
-  return root ? (readableTextPoints(root)?.first ?? null) : null;
+  if (!id) return doc.body ? (readableTextPoints(doc.body)?.first ?? null) : null;
+
+  const root = doc.getElementById(id) ?? doc.getElementsByName(id).item(0);
+  if (!root) return null;
+  const point = readableTextPoints(root)?.first;
+  if (point) return point;
+
+  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    const text = node as Text;
+    if (!text.data.trim()) continue;
+    if (root.compareDocumentPosition(text) & Node.DOCUMENT_POSITION_FOLLOWING) {
+      return { node: text, offset: text.data.length - text.data.trimStart().length };
+    }
+  }
+  return null;
 };
 
 const chapterRange = (
@@ -169,8 +219,8 @@ export const loadPairedAudiobookSection = (
       range,
       text: firstTocItem.label.trim() || entry.audioChapter.label,
       audioHref: entry.audioFile.path,
-      clipBegin: entry.audioChapter.start,
-      clipEnd: entry.audioChapter.end,
+      clipBegin: entry.clipBegin,
+      clipEnd: entry.clipEnd,
     });
   }
 

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -564,6 +564,12 @@ export interface BookConfig {
   rsvpPosition?: { cfi: string; wordText: string };
   searchConfig?: Partial<BookSearchConfig>;
   viewSettings?: Partial<ViewSettings>;
+  /**
+   * A device-local recording paired with this ebook. The audio files live
+   * under Books/<hash>/audiobook/ and are deliberately excluded from cloud
+   * sync; ordinary reading progress remains the shared cross-device state.
+   */
+  audiobook?: PairedAudiobook;
 
   lastSyncedAtConfig?: number;
   lastSyncedAtNotes?: number;
@@ -572,6 +578,36 @@ export interface BookConfig {
   foliateImportedAt?: number;
 
   updatedAt: number;
+}
+
+export interface AudiobookFile {
+  id: string;
+  name: string;
+  path: string;
+  duration: number;
+}
+
+export interface AudiobookChapter {
+  id: string;
+  fileId: string;
+  label: string;
+  start: number;
+  end: number;
+}
+
+export interface AudiobookChapterMapping {
+  ebookChapterId: string;
+  audioChapterId: string;
+}
+
+export interface PairedAudiobook {
+  version: 1;
+  title?: string;
+  narrator?: string;
+  files: AudiobookFile[];
+  chapters: AudiobookChapter[];
+  mappings: AudiobookChapterMapping[];
+  createdAt: number;
 }
 
 export interface BookDataRecord {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       marked-katex-extension:
         specifier: ^5.1.10
         version: 5.1.10(katex@0.16.45)(marked@15.0.12)
+      music-metadata:
+        specifier: ^11.14.0
+        version: 11.14.0
       nanoid:
         specifier: ^5.1.6
         version: 5.1.11
@@ -1286,6 +1289,9 @@ packages:
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
@@ -3468,6 +3474,13 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -5465,6 +5478,10 @@ packages:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
 
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
+
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
@@ -6432,6 +6449,10 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
+  media-typer@2.0.0:
+    resolution: {integrity: sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q==}
+    engines: {node: '>=18'}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
@@ -6647,6 +6668,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  music-metadata@11.14.0:
+    resolution: {integrity: sha512-RyOSq98kuVfXB1emJ+NjBF0av8Ph3oBuqNy+Z5sFFfLhjYrkBQEB53V8u+U0RNTVwNo20WoPUwNkfKwZfrOqmQ==}
+    engines: {node: '>=18'}
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -7855,6 +7880,10 @@ packages:
   strnum@2.3.0:
     resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -8070,6 +8099,10 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -8163,6 +8196,10 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   underscore@1.13.8:
     resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
@@ -8625,6 +8662,9 @@ packages:
 
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
+
+  win-guid@0.2.1:
+    resolution: {integrity: sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==}
 
   workerd@1.20260507.1:
     resolution: {integrity: sha512-z7JhsFSe6+X1b5fUHaVpo15VM1IRMJiLofEkq8iKdCo+Veqc+FUg5lIsuz8NwePxuSKrXtO4ZQpGkQLbPVXFhg==}
@@ -9928,6 +9968,8 @@ snapshots:
     optional: true
 
   '@blazediff/core@1.9.1': {}
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@braintree/sanitize-url@7.1.2': {}
 
@@ -11922,6 +11964,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -14176,6 +14227,15 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   filelist@1.0.6:
     dependencies:
       minimatch: 5.1.9
@@ -15367,6 +15427,8 @@ snapshots:
 
   media-typer@1.1.0: {}
 
+  media-typer@2.0.0: {}
+
   memoize-one@5.2.1: {}
 
   merge-descriptors@2.0.0: {}
@@ -15720,6 +15782,21 @@ snapshots:
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
+
+  music-metadata@11.14.0:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      content-type: 2.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      file-type: 21.3.4
+      media-typer: 2.0.0
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+      win-guid: 0.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   mute-stream@2.0.0: {}
 
@@ -17068,6 +17145,10 @@ snapshots:
 
   strnum@2.3.0: {}
 
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -17289,6 +17370,12 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
   totalist@3.0.1: {}
 
   tough-cookie@6.0.1:
@@ -17368,6 +17455,8 @@ snapshots:
       mime-types: 3.0.2
 
   typescript@5.9.3: {}
+
+  uint8array-extras@1.5.0: {}
 
   underscore@1.13.8: {}
 
@@ -17950,6 +18039,8 @@ snapshots:
       stackback: 0.0.2
 
   wildcard@2.0.1: {}
+
+  win-guid@0.2.1: {}
 
   workerd@1.20260507.1:
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Pair a DRM-free local MP3, M4A, or M4B audiobook with a reflowable EPUB and keep the files device-local.
- Add a Continuum-style Files → Align → Review workflow using daisyUI steps, automatic chapter matching, search, audio previews, and manual corrections.
- Start recorded narration from the reader's current page, keep scrubber and page position aligned, show a return-to-narration action after manual page turns, and suppress misleading coarse text highlighting.
- Support web, desktop, iOS, and Android playback, including Android background audio and media controls, safe pairing replacement/removal, migration during book deduplication, and teardown ordering for the shared native player.

## Test Coverage

```text
CODE PATHS (53/70, 76%)
├── Mapping + metadata
│   ├── [★★★ TESTED] nested TOC, dedupe, forward/backward anchor mapping
│   ├── [★★★ TESTED] timescales, fallback chapters, parse failures
│   └── [GAP ×3] blank/CFI fields, missing audio anchor, invalid rows/alternate tags
├── Storage + book deduplication
│   ├── [★★★ TESTED] web/native imports and partial-import rollback
│   ├── [★★★ TESTED] safe replace/remove ordering and persistence rollback
│   ├── [★★★ TESTED] paired-file migration, validation, config rollback
│   └── [GAP ×3] timestamps/cleanup warnings, later-file migration rollback,
│                competing pairings/cleanup failure
├── Paired narration sections
│   ├── [★★★ TESTED] next/previous search, anchors, shared runs, cross-spine slicing
│   └── [GAP ×3] missing association pieces, malformed/empty DOM,
│                nonconsecutive reuse/label fallback
├── Preview + media transport
│   ├── [★★★ TESTED] file toggle, timer, owned-file cleanup
│   ├── [★★★ REGRESSION] rapid switches serialize; stale timer cannot stop latest
│   ├── [★★★ REGRESSION] mobile preview shutdown unregisters its listener
│   ├── [★★★ REGRESSION] native media-overlay shutdown awaits exactly one abort
│   ├── [★★★ TESTED] direct URL and mocked iOS/Android native routing
│   ├── [GAP] rejected queued operation recovers and permits the next operation
│   └── [GAP] desktop/ended/zero/missing-source/play-error and seek boundaries
├── Controller + approximate range mapping
│   ├── [★★★ TESTED] start-at-page, live CFI, scrub preview, same-clip seek
│   ├── [★★★ REGRESSION] concurrent tts-stop callers await the shared teardown
│   └── [GAP ×2] multi-node/boundary state and paired precedence/reattach/
│                cross-chapter restart
└── Android native bridge
    └── [GAP ×4] [→E2E] ExoPlayer lifecycle, path validation/reuse,
                         events/position, cleanup/errors

USER FLOWS (4/13, 31%)
├── [★ TESTED] new-pair dialog identity
├── [★★ TESTED] existing summary → edit mapping with large list
├── [★★ TESTED] picker search/select/preview callback
├── [★★★ TESTED] reader start position, live CFI, scrub preview/seek integration
├── [GAP] [→E2E] BookMenu eligibility → event → dialog mount/close
├── [GAP ×2] [→E2E] picker cancel/provider/no-TOC and metadata-failure cleanup
├── [GAP] [→E2E] complete new pairing → align → review → save
├── [GAP] [→E2E] replace/edit existing mapping → save
├── [GAP] [→E2E] prepared/stored/native preview switching and recovery errors
├── [GAP ×2] [→E2E] removal cancel/success and failure recovery
└── [GAP] [→E2E] cross-section follow guard

COVERAGE: 57/83 paths tested (69%)
Code paths: 53/70 (76%) | User flows: 4/13 (31%)
QUALITY: ★★★:43 | ★★:12 | ★:2
GAPS: 26 across 13 grouped findings
TEST FILES: 817 → 826 (+9 on branch)
FOCUSED VERIFICATION: 2 files; 37/37 tests passed
GATE: default minimum 60% met; target 80% missed
```

Legend: ★★★ behavior plus edge/error coverage; ★★ happy path; ★ smoke test; `[→E2E]` needs integration/device coverage.

## Verification

- `pnpm test`: 746 files passed, 4 skipped; 9,353 tests passed, 16 skipped.
- `pnpm lint`: TypeScript and Biome passed.
- `pnpm format:check`: 2,099 files passed.
- `pnpm build`: Next.js production build and static export passed.
- `pnpm fmt:check`, `pnpm clippy:check`, and `pnpm test:rust`: Rust formatting and lint passed; 111 Rust tests passed.
- Physical Xiaomi 13 (`2211133C`, Android 16) flow verified with Project Gutenberg's EPUB3 edition of *Alice's Adventures in Wonderland* and 12 AAC/mp4a audiobook tracks: pairing, current-page start, scrubbing, page-follow recovery, chapter handoff, background controls, and removal. Subsequent teardown hardening is covered by automated regression tests.

## Pre-Landing Review

No actionable issues remain after the final adversarial rerun. The review caught and fixed concurrent native-player teardown races before push.

## Design Review

Lite review passed with no findings. The pairing flow uses daisyUI steps, logical RTL spacing, existing modal/action patterns, and e-ink-safe borders and contrast.

## Eval Results

Skipped: this branch does not change prompt files.

## Scope Check

CLEAN. The diff is limited to local audiobook pairing, recorded-narration playback, persistence/migration, native transport, and their tests/documentation.

## Plan Completion

No implementation plan file was detected.

## TODOs

No existing TODO items were completed by this branch.

## Documentation

- Documented local DRM-free MP3/M4A/M4B pairing in the public feature overview.
- Added the device-local audiobook manifest, storage, sync exclusions, service layout, and TTS capability behavior to contributor references.
- Corrected the recorded-audio storage description: files live under the audiobook directory while pairing metadata lives in the book config.
- Coverage now includes reference, how-to, and architectural explanation; no diagram drift was found.

Closes #5741

🤖 Generated with OpenAI Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pair local audiobooks with reflowable EPUBs through guided chapter mapping, editing, replacement, and removal.
  * Preview chapters, search audiobook content, and choose “No audio” where needed.
  * Play paired audiobooks natively on supported mobile platforms with seeking, playback controls, and narrator metadata.
  * Support approximate narration timing and proportional navigation when precise text highlighting is unavailable.
* **Bug Fixes**
  * Improved audiobook file selection, storage cleanup, duplicate-book migration, and playback continuity.
* **Documentation**
  * Added guidance for pairing, mapping, playback behavior, and platform capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->