### PR TITLE
fix(reader): keep chapter images openable after repeated footnote popups

### DIFF
--- a/apps/readest-app/src/__tests__/foliate-epub-resource-refcount.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-epub-resource-refcount.test.ts
@@ -1,0 +1,166 @@
+// Regression test for the footnote-popup vs. illustration bug: in a novel whose
+// notes and pictures share a chapter file, opening a footnote popup a few times
+// made the chapter's illustrations impossible to open until the book was closed
+// and reopened.
+//
+// `FootnoteHandler#showFragment` opens a SECOND `foliate-view` on the same book
+// object, so the popup runs `section.load()` for a section the reading view is
+// already holding, and dismissing it runs `section.unload()` (`view.close()` ->
+// `Paginator.destroy()` -> `#destroyAllViews()` -> `sections[i].unload()`).
+//
+// `Loader.ref()` keyed its "already counted this child" list by `parent`, but
+// top-level section loads pass `parent === undefined`, so every top-level load
+// in the book shared one bucket. Once an href landed in that bucket every later
+// `ref()` was a no-op while `unref()` still decremented, so the refcount
+// underflowed to zero on the second popup and revoked the live section's blob
+// URL together with all of its children -- the illustrations. An `<img>` that
+// has already decoded stays painted after its blob URL is revoked, so the page
+// looked fine and only the tap-to-zoom broke.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { EPUB } from 'foliate-js/epub.js';
+
+const CONTAINER = `<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`;
+
+const OPF = `<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="BookID" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Novel With Notes And Pictures</dc:title>
+    <dc:language>zh</dc:language>
+    <dc:identifier id="BookID">urn:uuid:12345</dc:identifier>
+  </metadata>
+  <manifest>
+    <item id="chapter1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="pic" href="pic.png" media-type="image/png"/>
+  </manifest>
+  <spine>
+    <itemref idref="chapter1"/>
+  </spine>
+</package>`;
+
+// The reported layout: the note's target and the illustration live in the same
+// chapter file, so the popup loads the very section being read.
+const CHAPTER = `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
+  <body>
+    <p>text with a note<a epub:type="noteref" href="#fn1">[1]</a></p>
+    <img src="pic.png" alt="illustration"/>
+    <aside id="fn1" epub:type="footnote"><p>the note body</p></aside>
+  </body>
+</html>`;
+
+const FILES: Record<string, string> = {
+  'META-INF/container.xml': CONTAINER,
+  'OEBPS/content.opf': OPF,
+  'OEBPS/chapter1.xhtml': CHAPTER,
+  'OEBPS/pic.png': 'PNG-BYTES',
+};
+
+type Section = {
+  load: () => Promise<string>;
+  loadContent: () => Promise<string | undefined>;
+  unload: () => void;
+};
+
+const openEpub = async (files: Record<string, string>) => {
+  const epub = new EPUB({
+    entries: Object.keys(files).map((filename) => ({ filename })),
+    loadText: async (name: string) => files[name] ?? null,
+    loadBlob: async (name: string) => (files[name] == null ? null : new Blob([files[name]!])),
+    getSize: (name: string) => files[name]?.length ?? 0,
+    // only used to deobfuscate fonts, which this fixture doesn't have
+    sha1: undefined,
+  });
+  await epub.init();
+  return { sections: (epub.sections ?? []) as Section[] };
+};
+
+// jsdom implements neither half of the object-URL API.
+const originalCreate = URL.createObjectURL;
+const originalRevoke = URL.revokeObjectURL;
+let live: Set<string>;
+let revoked: string[];
+
+beforeEach(() => {
+  let nextId = 0;
+  live = new Set();
+  revoked = [];
+  URL.createObjectURL = () => {
+    const url = `blob:test/${nextId++}`;
+    live.add(url);
+    return url;
+  };
+  URL.revokeObjectURL = (url: string) => {
+    live.delete(url);
+    revoked.push(url);
+  };
+});
+
+afterEach(() => {
+  URL.createObjectURL = originalCreate;
+  URL.revokeObjectURL = originalRevoke;
+});
+
+describe('EPUB resource refcounting across a second view on the same book', () => {
+  it('keeps the reading view resources alive when a footnote popup opens and closes repeatedly', async () => {
+    const { sections } = await openEpub(FILES);
+    const section = sections[0]!;
+
+    // The reading view holds the chapter; loading it also creates a blob URL
+    // for the illustration it references.
+    const readingViewUrl = await section.load();
+    expect(live.size).toBe(2);
+
+    // Tap the note, read it, dismiss it -- the reported repro says three or
+    // more times, and the underflow used to land on the second.
+    for (let tap = 1; tap <= 3; tap++) {
+      const popupUrl = await section.load();
+      // The popup shares the reading view's already-loaded resources.
+      expect(popupUrl, `popup ${tap} resource`).toBe(readingViewUrl);
+
+      section.unload();
+
+      // The reading view still has the chapter open, so nothing may be
+      // revoked: the illustration must stay fetchable or tapping it can no
+      // longer open the image viewer.
+      expect(revoked, `after dismissing popup ${tap}`).toEqual([]);
+      expect(live.size, `after dismissing popup ${tap}`).toBe(2);
+    }
+
+    // ...and the resources are still released once the reader itself lets go,
+    // so holding them alive is refcounting, not a leak.
+    section.unload();
+    expect(revoked).toHaveLength(2);
+    expect(live.size).toBe(0);
+  });
+
+  // The renderer reads a section's source right after loading it
+  // (`section.load()` then `section.loadContent()` in Paginator), and only the
+  // load is matched by an `unload`. Counting that read as a second reference
+  // would keep every section the reader ever opened alive for the life of the
+  // book -- the leak that a naive "always count a top-level ref" fix causes.
+  it('frees a section once its views close, despite the renderer also reading its content', async () => {
+    const { sections } = await openEpub(FILES);
+    const section = sections[0]!;
+
+    const openView = async () => {
+      await section.load();
+      await section.loadContent();
+    };
+
+    await openView(); // the reading view
+    await openView(); // the footnote popup, on the same section
+
+    section.unload(); // popup dismissed -- the reading view still holds it
+    expect(revoked).toEqual([]);
+    expect(live.size).toBe(2);
+
+    section.unload(); // the reader closes the section
+    expect(live.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## The report

> 阅读同时带有注释和插图的小说，如果连续点击3次以上注释内容的话，就无法点开插图。只能关闭阅读器再重新打开后，插图就能查看了。

Reading a novel that has both footnotes and illustrations: after tapping footnote content three or more times, the illustrations can no longer be opened. Only closing and reopening the reader restores them.

Confirmed, and it is slightly worse than reported: it breaks on the **second** dismissal.

## What actually happens

The footnote popup opens a *second* `foliate-view` on the same book object (`FootnoteHandler#showFragment`). When the note's target lives in the chapter you are reading, which is the normal layout for these novels, the popup runs `section.load()` on a section the reading view already holds, and dismissing it runs `section.unload()` (`view.close()` -> `Paginator.destroy()` -> `#destroyAllViews()` -> `sections[i].unload()`).

foliate-js counted that reference in a `#children` bucket keyed by the parent document, but a top-level section load has no parent, so every top-level load shared one bucket that nothing ever cleared. The second popup's `ref()` was skipped while its dismiss still decremented, so the refcount underflowed to zero and revoked the chapter's blob URL together with all of its children, the images, while the reading view was still displaying them.

An `<img>` that has already decoded stays painted after its blob URL is revoked. That is why the page looks completely normal and only the tap breaks: `handleImagePress` -> `convertBlobUrlToDataUrl` -> `TypeError: Failed to fetch`, logged and swallowed, so the viewer never opens. Reopening the book rebuilds every blob URL, which is why that "fixes" it.

## Fix

Submodule bump for readest/foliate-js#78 (merged), which makes a parentless (top-level) reference always count, and stops `loadItemXHTMLContent` taking a reference nothing releases. Both halves are needed: the renderer calls `section.load()` *and* `section.loadContent()` per view against a single `unload()`, and the buggy shared bucket had been absorbing that second call, so fixing only `ref()` would leak every section the reader ever opened.

## Tests

`foliate-epub-resource-refcount.test.ts` builds a chapter that holds both a note target and an illustration, and covers both halves. Each case fails without its half of the fix:

- three popup open/dismiss cycles while the reading view holds the section must revoke nothing, and the section must still be released once the reader lets go. Without the `ref()` fix this fails on popup 2 with both the chapter and the image revoked, matching the browser exactly.
- `load()` + `loadContent()` per view must still reach zero after one `unload()`. Without the `loadItemXHTMLContent` fix the section leaks.

## Verification

`pnpm test` (9301 passed), `pnpm lint`, and eslint on the submodule are all clean. Tests re-run green against the merged foliate-js commit `c1f0c3c`, whose tree is byte-identical to the branch build that was verified below.

Verified in Chrome on a book with a real footnote and a real illustration in one chapter:

| | before | after |
|---|---|---|
| illustration blob after dismissal 1 | alive | alive |
| illustration blob after dismissal 2 | **revoked** | alive |
| after 4 popup cycles / 10 load-unload cycles | dead, 2 URLs revoked per dismissal | 0 revocations |
| tapping the illustration afterwards | viewer does not open | viewer opens |

A control tap on an untouched illustration opened the viewer in both builds, so the failure was specific to the affected section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EPUB resource handling when opening and closing footnote popups in the same section as the reading view.
  * Prevented shared images and related resources from being released prematurely or retained after the reading view closes.
* **Tests**
  * Added regression coverage for repeated footnote popup usage and content loading to help ensure stable reading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->