### PR TITLE
docs: add contributor code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,143 @@
+# Contributor Code of Conduct
+
+## Our Pledge
+
+We pledge to make the Readest community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights,
+and contributions of all individuals, regardless of characteristics including race, ethnicity,
+caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender
+identity or expression, sexual orientation, language, philosophy or religion, national or social
+origin, socio-economic position, level of education, or other status. The same privileges of
+participation are extended to everyone who participates in good faith and in accordance with this
+Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's
+expectations for positive behavior. We also understand that our words and actions may be
+interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways
+that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion
+of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal
+   attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a
+   community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the
+   basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate
+   in the context or purpose of the community.
+5. **Violating confidentiality.** Sharing or acting on someone's personal or private information
+   without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person
+   or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone
+   else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials.** Sharing marketing or other commercial content in a way that is
+   outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links,
+   or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate.
+Not every conflict represents a Code of Conduct violation, and this Code of Conduct reinforces
+encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+To report a possible violation, email the Readest maintainers at
+[readestapp@gmail.com](mailto:readestapp@gmail.com). Do not open a public GitHub issue or discussion
+for a Code of Conduct report. Include any relevant links, screenshots, logs, or other context that
+may help us understand what happened.
+
+Readest maintainers take reports of violations seriously and will make every effort to respond in
+a timely manner. They will investigate reports by reviewing messages, logs, and recordings, or by
+interviewing witnesses and other participants. Maintainers will keep investigations and enforcement
+actions as transparent as possible while prioritizing safety and confidentiality. Enforcement
+actions are carried out privately with the involved parties, though communicating to the wider
+community may be part of a mutually agreed resolution.
+
+If a report concerns a maintainer, that person will not participate in handling the report. Another
+maintainer or a mutually agreed neutral reviewer will handle it instead.
+
+## Addressing and Repairing Harm
+
+If an investigation finds that this Code of Conduct has been violated, the following enforcement
+ladder may be used to determine how best to repair harm, based on the incident's impact on the
+individuals involved and the community as a whole. Depending on the severity of a violation, lower
+rungs on the ladder may be skipped.
+
+1. **Warning**
+   1. **Event:** A violation involving a single incident or series of incidents.
+   2. **Consequence:** A private, written warning from the Readest maintainers.
+   3. **Repair:** Examples include a private written apology, acknowledgement of responsibility,
+      and seeking clarification on expectations.
+2. **Temporarily Limited Activities**
+   1. **Event:** A repeated incidence of a violation that previously resulted in a warning, or the
+      first incidence of a more serious violation.
+   2. **Consequence:** A private, written warning with a time-limited cooldown period designed to
+      underscore the seriousness of the situation and give the community members involved time to
+      process the incident. The cooldown period may be limited to particular communication channels
+      or interactions with particular community members.
+   3. **Repair:** Examples include making an apology, using the cooldown period to reflect on actions
+      and impact, and being thoughtful about re-entering community spaces after the period is over.
+3. **Temporary Suspension**
+   1. **Event:** A pattern of repeated violations which the Readest maintainers have tried to
+      address with warnings, or a single serious violation.
+   2. **Consequence:** A private written warning with conditions for return from suspension. In
+      general, temporary suspensions give the person being suspended time to reflect upon their
+      behavior and possible corrective actions.
+   3. **Repair:** Examples include respecting the spirit of the suspension, meeting the specified
+      conditions for return, and being thoughtful about how to reintegrate with the community when
+      the suspension is lifted.
+4. **Permanent Ban**
+   1. **Event:** A pattern of repeated Code of Conduct violations that other steps on the ladder
+      have failed to resolve, or a violation so serious that the Readest maintainers determine there
+      is no way to keep the community safe with this person as a member.
+   2. **Consequence:** Access to all community spaces, tools, and communication channels is removed.
+      Permanent bans should be used rarely, should have strong reasoning behind them, and should
+      only be used if other remedies have failed to change the behavior.
+   3. **Repair:** There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Readest
+maintainers to use their discretion and judgment in the best interests of the community.
+
+## Scope
+
+This Code of Conduct applies within all Readest community spaces, including the GitHub repository,
+GitHub Discussions, Discord, and other official communication channels. It also applies when an
+individual is officially representing Readest in public or other spaces, such as by using an
+official email address, posting through an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, version 3.0](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under the
+[Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).
+
+For answers to common questions, see the [Contributor Covenant FAQ](https://www.contributor-covenant.org/faq).
+Translations are available from the [Contributor Covenant translations](https://www.contributor-covenant.org/translations)
+page, and additional enforcement guidance is available from the
+[Contributor Covenant resources](https://www.contributor-covenant.org/resources). The enforcement
+ladder was inspired by the work of [Mozilla's Code of Conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 When contributing to `Readest`, whether on GitHub or in other community spaces:
 
+- Follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 - Be respectful, civil, and open-minded.
 - Before opening a new pull request, try searching through the [issue tracker](https://github.com/readest/readest/issues) for known issues or fixes.
 - If you want to make code changes based on your personal opinion(s), make sure you open an issue first describing the changes you want to make, and open a pull request only when your suggestions get approved by maintainers.

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ If you prefer a more reliable out-of-the-box experience on Arch Linux, consider 
 
 ## Contributors
 
-Readest is open-source, and contributions are welcome! Feel free to open issues, suggest features, or submit pull requests. Please **review our [contributing guidelines](CONTRIBUTING.md) before you start**. We also welcome you to join our [Discord][link-discord] community for either support or contributing guidance.
+Readest is open-source, and contributions are welcome! Feel free to open issues, suggest features, or submit pull requests. Please **review our [contributing guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md) before you start**. We also welcome you to join our [Discord][link-discord] community for either support or contributing guidance.
 
 <a href="https://github.com/readest/readest/graphs/contributors">
   <p align="left">


### PR DESCRIPTION
## Summary

- Add a Contributor Covenant 3.0-based Code of Conduct for Readest, covering community expectations, restricted behavior, private reporting, conflict-of-interest handling, enforcement, and scope.
- Link the policy from the README and contributing guide so contributors can find it before participating.

## Test Coverage

This is a documentation-only change with no executable application paths. The coverage audit found 0 runtime gaps.

```text
CODE PATHS                                            USER FLOWS
[DOCS ONLY] CODE_OF_CONDUCT.md                        [DOCS ONLY] Community policy
  └── [N/A] No executable application paths             └── [N/A] No runtime interaction paths

COVERAGE: 0/0 executable paths (100% by applicability) | GAPS: 0
```

## Pre-Landing Review

No issues found.

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN

## Plan Completion

No plan file detected.

## Verification Results

No plan file was associated with this branch, so plan auto-verification was not applicable.

## TODOS

No TODO items completed in this PR.

## Documentation

- `CODE_OF_CONDUCT.md`: added community standards, private reporting guidance, enforcement steps, scope, and Contributor Covenant attribution.
- `README.md`: linked the Code of Conduct from the contributor entry point.
- `CONTRIBUTING.md`: made following the Code of Conduct an explicit contribution requirement.

Coverage is complete for this governance change; no documentation debt or diagram drift was found.

## Test plan

- [x] `pnpm format:check` — 2,102 files checked
- [x] `pnpm lint` — type check and Biome lint passed; 2,065 files checked
- [x] `pnpm test -- --run` — 748 files passed, 4 skipped; 9,369 tests passed, 16 skipped
- [x] Repository pre-push suite — 748 files passed, 4 skipped; 9,369 tests passed, 16 skipped
- [x] `pnpm build` — Next.js production build and static export completed
- [x] Targeted retry after a later concurrent hook run hit two unrelated timing-sensitive tests — 21/21 tests passed

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Code of Conduct covering expected behavior, reporting procedures, confidentiality, and enforcement.
  * Updated contribution guidelines to require adherence to the Code of Conduct.
  * Added a Code of Conduct link to the project’s Contributors section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->