### PR TITLE
fix(opds): honor the Manage Sync Books toggle for automatic cloud uploads

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useOPDSSubscriptions.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useOPDSSubscriptions.test.tsx
@@ -10,8 +10,9 @@ const appService = { saveLibraryBooks };
 vi.mock('@/context/EnvContext', () => ({
   useEnv: () => ({ appService }),
 }));
+let currentUser: { id: string } | null = null;
 vi.mock('@/context/AuthContext', () => ({
-  useAuth: () => ({ user: null }),
+  useAuth: () => ({ user: currentUser }),
 }));
 const translate = (key: string) => key;
 vi.mock('@/hooks/useTranslation', () => ({
@@ -25,11 +26,13 @@ vi.mock('@/services/opds', () => ({
 }));
 
 import { syncSubscribedCatalogs } from '@/services/opds';
+import { transferManager } from '@/services/transferManager';
 import { useLibraryStore } from '@/store/libraryStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useOPDSSubscriptions } from '@/hooks/useOPDSSubscriptions';
 
 const mockedSync = vi.mocked(syncSubscribedCatalogs);
+const mockedQueueUpload = vi.mocked(transferManager.queueUpload);
 
 const makeBook = (hash: string, overrides: Partial<Book> = {}): Book =>
   ({
@@ -69,6 +72,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  currentUser = null;
   useLibraryStore.setState({ library: [], libraryLoaded: false, visibleLibrary: [] });
 });
 
@@ -128,5 +132,59 @@ describe('useOPDSSubscriptions', () => {
     expect(useLibraryStore.getState().visibleLibrary.some((b) => b.hash === 'dead-book')).toBe(
       true,
     );
+  });
+
+  test('queues a cloud upload for a new book when Books sync is on', async () => {
+    vi.useFakeTimers();
+    try {
+      currentUser = { id: 'user-1' };
+      useLibraryStore.getState().setLibrary([]);
+      const book = makeBook('sub-book');
+      mockedSync.mockResolvedValue({ newBooks: [], totalNewBooks: 0, errors: [] });
+      mockedSync.mockImplementationOnce(async (_c, _a, _b, onBooksImported) => {
+        await onBooksImported?.([book]);
+        return { newBooks: [book], totalNewBooks: 1, errors: [] };
+      });
+
+      renderHook(() => useOPDSSubscriptions());
+      await settle();
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(mockedQueueUpload).toHaveBeenCalledWith(book);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('does NOT queue a cloud upload when the Books sync category is off', async () => {
+    vi.useFakeTimers();
+    try {
+      currentUser = { id: 'user-1' };
+      useSettingsStore.setState({
+        settings: {
+          opdsCatalogs: [catalog],
+          syncCategories: { book: false },
+        } as unknown as SystemSettings,
+      });
+      useLibraryStore.getState().setLibrary([]);
+      const book = makeBook('sub-book');
+      mockedSync.mockResolvedValue({ newBooks: [], totalNewBooks: 0, errors: [] });
+      mockedSync.mockImplementationOnce(async (_c, _a, _b, onBooksImported) => {
+        await onBooksImported?.([book]);
+        return { newBooks: [book], totalNewBooks: 1, errors: [] };
+      });
+
+      renderHook(() => useOPDSSubscriptions());
+      await settle();
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(mockedQueueUpload).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/readest-app/src/__tests__/services/opds-cloud-upload-gate.test.ts
+++ b/apps/readest-app/src/__tests__/services/opds-cloud-upload-gate.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { Book } from '@/types/book';
+import type { SystemSettings } from '@/types/settings';
+
+vi.mock('@/services/transferManager', () => ({
+  transferManager: { queueUpload: vi.fn() },
+}));
+
+import { transferManager } from '@/services/transferManager';
+import { useSettingsStore } from '@/store/settingsStore';
+import { queueOPDSBookUploads } from '@/services/opds/cloudUpload';
+
+const mockedQueueUpload = vi.mocked(transferManager.queueUpload);
+
+const makeBook = (hash: string, overrides: Partial<Book> = {}): Book =>
+  ({
+    hash,
+    format: 'EPUB',
+    title: `Book ${hash}`,
+    uploadedAt: null,
+    downloadedAt: 1000,
+    deletedAt: null,
+    ...overrides,
+  }) as Book;
+
+const setSettings = (settings: Partial<SystemSettings>) => {
+  useSettingsStore.setState({ settings: settings as SystemSettings });
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // Readest Cloud is active by default (no third-party provider enabled).
+  setSettings({});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('queueOPDSBookUploads', () => {
+  test('queues an upload for a new book after the init delay', () => {
+    const book = makeBook('b1');
+    queueOPDSBookUploads(true, useSettingsStore.getState().settings, [book]);
+
+    expect(mockedQueueUpload).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(3000);
+    expect(mockedQueueUpload).toHaveBeenCalledWith(book);
+  });
+
+  test('does NOT queue when the Manage Sync "Books" category is off', () => {
+    setSettings({ syncCategories: { book: false } });
+    queueOPDSBookUploads(true, useSettingsStore.getState().settings, [makeBook('b1')]);
+
+    vi.advanceTimersByTime(3000);
+    expect(mockedQueueUpload).not.toHaveBeenCalled();
+  });
+
+  test('does NOT queue when logged out', () => {
+    queueOPDSBookUploads(false, useSettingsStore.getState().settings, [makeBook('b1')]);
+
+    vi.advanceTimersByTime(3000);
+    expect(mockedQueueUpload).not.toHaveBeenCalled();
+  });
+
+  test('does NOT queue when Readest Cloud is switched off', () => {
+    setSettings({ readestCloud: { enabled: false } } as Partial<SystemSettings>);
+    queueOPDSBookUploads(true, useSettingsStore.getState().settings, [makeBook('b1')]);
+
+    vi.advanceTimersByTime(3000);
+    expect(mockedQueueUpload).not.toHaveBeenCalled();
+  });
+
+  test('skips books that already have a cloud copy and dedupes by hash', () => {
+    const fresh = makeBook('fresh');
+    const uploaded = makeBook('uploaded', { uploadedAt: 123 });
+    queueOPDSBookUploads(true, useSettingsStore.getState().settings, [fresh, fresh, uploaded]);
+
+    vi.advanceTimersByTime(3000);
+    expect(mockedQueueUpload).toHaveBeenCalledTimes(1);
+    expect(mockedQueueUpload).toHaveBeenCalledWith(fresh);
+  });
+});

--- a/apps/readest-app/src/app/opds/page.tsx
+++ b/apps/readest-app/src/app/opds/page.tsx
@@ -16,8 +16,7 @@ import { useKeyDownActions } from '@/hooks/useKeyDownActions';
 import { useLibraryStore } from '@/store/libraryStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useCustomOPDSStore } from '@/store/customOPDSStore';
-import { transferManager } from '@/services/transferManager';
-import { isReadestCloudStorageActive } from '@/services/sync/cloudSyncProvider';
+import { queueOPDSBookUploads } from '@/services/opds/cloudUpload';
 import { useTransferQueue } from '@/hooks/useTransferQueue';
 import { useTheme } from '@/hooks/useTheme';
 import { useLibrary } from '@/hooks/useLibrary';
@@ -656,10 +655,8 @@ export default function BrowserPage() {
                 console.error('OPDS: failed to update source map:', sourceMapError);
               }
             }
-            if (user && book && !book.uploadedAt && isReadestCloudStorageActive(settings)) {
-              setTimeout(() => {
-                transferManager.queueUpload(book);
-              }, 3000);
+            if (book) {
+              queueOPDSBookUploads(!!user, useSettingsStore.getState().settings, [book]);
             }
             setLibrary(library);
             appService.saveLibraryBooks(library);

--- a/apps/readest-app/src/hooks/useOPDSSubscriptions.ts
+++ b/apps/readest-app/src/hooks/useOPDSSubscriptions.ts
@@ -4,11 +4,10 @@ import { useAuth } from '@/context/AuthContext';
 import { useEnv } from '@/context/EnvContext';
 import { useLibraryStore } from '@/store/libraryStore';
 import { useSettingsStore } from '@/store/settingsStore';
-import { isReadestCloudStorageActive } from '@/services/sync/cloudSyncProvider';
 import { useTranslation } from '@/hooks/useTranslation';
 import { syncSubscribedCatalogs } from '@/services/opds';
+import { queueOPDSBookUploads } from '@/services/opds/cloudUpload';
 import { AUTO_CHECK_INTERVAL_MS } from '@/services/opds/types';
-import { transferManager } from '@/services/transferManager';
 import { eventDispatcher } from '@/utils/event';
 
 export function useOPDSSubscriptions() {
@@ -62,22 +61,7 @@ export function useOPDSSubscriptions() {
         );
 
         if (totalNewBooks > 0) {
-          // Mirror the manual OPDS download path: queue cloud upload for each
-          // newly imported book when the user is logged in and Readest Cloud
-          // storage is active. Delay so the transfer manager has a chance
-          // to finish initializing if this fires right after libraryLoaded.
-          const { settings: currentSettings } = useSettingsStore.getState();
-          if (user && isReadestCloudStorageActive(currentSettings)) {
-            const importedBooks = [...new Map(newBooks.map((b) => [b.hash, b])).values()];
-            const booksToUpload = importedBooks.filter((b) => !b.uploadedAt);
-            if (booksToUpload.length > 0) {
-              setTimeout(() => {
-                for (const book of booksToUpload) {
-                  transferManager.queueUpload(book);
-                }
-              }, 3000);
-            }
-          }
+          queueOPDSBookUploads(!!user, useSettingsStore.getState().settings, newBooks);
         }
 
         if (verbose && totalNewBooks > 0) {

--- a/apps/readest-app/src/services/opds/cloudUpload.ts
+++ b/apps/readest-app/src/services/opds/cloudUpload.ts
@@ -1,0 +1,39 @@
+import type { Book } from '@/types/book';
+import type { SystemSettings } from '@/types/settings';
+import { transferManager } from '@/services/transferManager';
+import { isReadestCloudStorageActive } from '@/services/sync/cloudSyncProvider';
+import { isSyncCategoryEnabled } from '@/services/sync/syncCategories';
+
+/**
+ * Delay before queueing so the transfer manager has a chance to finish
+ * initializing when an OPDS import lands right after libraryLoaded.
+ */
+const UPLOAD_QUEUE_DELAY_MS = 3000;
+
+/**
+ * Queue Readest Cloud uploads for OPDS-imported books — the manual catalog
+ * download and the subscription auto-sync share this policy. Unlike the
+ * explicit per-book Upload action, these are automatic uploads, so they honor
+ * the Manage Sync "Books" toggle the same way normal library imports do
+ * (`importBook` in ingestService); previously both OPDS paths skipped it and
+ * uploaded book files while the user had Books sync off.
+ */
+export const queueOPDSBookUploads = (
+  isLoggedIn: boolean,
+  settings: SystemSettings,
+  books: Book[],
+): void => {
+  if (!isLoggedIn || !isReadestCloudStorageActive(settings)) return;
+  if (!isSyncCategoryEnabled('book')) return;
+  // Two feed entries can resolve to the same file; dedupe by hash and skip
+  // books that already have a cloud copy.
+  const toUpload = [...new Map(books.map((b) => [b.hash, b])).values()].filter(
+    (b) => !b.uploadedAt,
+  );
+  if (toUpload.length === 0) return;
+  setTimeout(() => {
+    for (const book of toUpload) {
+      transferManager.queueUpload(book);
+    }
+  }, UPLOAD_QUEUE_DELAY_MS);
+};


### PR DESCRIPTION
## Problem

Users report that book files are uploaded to Readest Cloud even with the **Books** category turned off in User -> Manage Sync. Verified live: with Books off, downloading a book from an OPDS catalog still uploaded the EPUB to Readest Cloud storage and stamped `uploadedAt`.

Two automatic upload paths queued cloud uploads gated only on login + `isReadestCloudStorageActive`, never checking the Books sync category:

- `src/app/opds/page.tsx` - manual catalog download
- `src/hooks/useOPDSSubscriptions.ts` - subscription auto-sync (runs unattended, the likeliest source of the reports)

Normal library imports already honor the toggle (`ingestService.importBook`), which is why the reports sounded inconsistent - it depended on which path brought the book in.

## Fix

Extract the shared policy into `queueOPDSBookUploads(isLoggedIn, settings, books)` in `src/services/opds/cloudUpload.ts`, which checks `isSyncCategoryEnabled('book')` alongside the existing login + provider gates, dedupes by hash, skips already-uploaded books, and keeps the 3s transfer-manager init delay. Both OPDS call sites now use it, removing the previously duplicated "mirror the manual download path" block.

Deliberately unchanged: the explicit per-book Upload action, Upload All, and Sent-book `forceUpload` still bypass the toggle by design (explicit user intent).

## Tests

- New `src/__tests__/services/opds-cloud-upload-gate.test.ts`: queues after the delay when allowed; does NOT queue when Books is off / logged out / Readest Cloud off; dedupes and skips books with a cloud copy.
- `src/__tests__/hooks/useOPDSSubscriptions.test.tsx`: end-to-end through the hook - queues a cloud upload for a new subscription book when Books sync is on, does not when off (this test reproduced the bug before the fix).

`pnpm test` (9376 passed), `pnpm lint`, and `pnpm format:check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OPDS-imported books can now be queued for cloud backup when signed in, Readest Cloud is available, and Books sync is enabled.
  * Uploads are delayed briefly after import to allow book processing to complete.

* **Bug Fixes**
  * Prevented duplicate uploads and skipped books that are already backed up.
  * Uploads are correctly omitted when authentication, cloud availability, or sync settings do not allow them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->