### PR TITLE
feat(opds): confirm auto-download toggles and allow catalog reordering

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2322,5 +2322,9 @@
   "More Settings": "مزيد من الإعدادات",
   "Right-to-Left Pages": "صفحات من اليمين إلى اليسار",
   "Send Document Metadata": "إرسال البيانات الوصفية للمستند",
-  "Hide covers": "إخفاء أغلفة الكتب"
+  "Hide covers": "إخفاء أغلفة الكتب",
+  "Auto-download from “{{name}}”?": "تنزيل تلقائي من “{{name}}”؟",
+  "Stop auto-downloading from “{{name}}”?": "إيقاف التنزيل التلقائي من “{{name}}”؟",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "سيقوم Readest بتنزيل كل منشور جديد من هذا الكتالوج تلقائياً عند مزامنة التطبيق. قد يؤدي ذلك إلى تنزيل عدد كبير من الكتب.",
+  "New publications from this catalog will no longer be downloaded automatically.": "لن يتم تنزيل المنشورات الجديدة من هذا الكتالوج تلقائياً بعد الآن."
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2098,5 +2098,9 @@
   "More Settings": "আরও সেটিংস",
   "Right-to-Left Pages": "ডান থেকে বামে পৃষ্ঠা",
   "Send Document Metadata": "নথির মেটাডেটা পাঠান",
-  "Hide covers": "বইয়ের মলাট লুকান"
+  "Hide covers": "বইয়ের মলাট লুকান",
+  "Auto-download from “{{name}}”?": "“{{name}}” থেকে স্বয়ংক্রিয়ভাবে ডাউনলোড করবেন?",
+  "Stop auto-downloading from “{{name}}”?": "“{{name}}” থেকে স্বয়ংক্রিয় ডাউনলোড বন্ধ করবেন?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "অ্যাপ সিঙ্ক হওয়ার সময় Readest এই ক্যাটালগের প্রতিটি নতুন প্রকাশনা স্বয়ংক্রিয়ভাবে ডাউনলোড করবে। এতে প্রচুর সংখ্যক বই ডাউনলোড হতে পারে।",
+  "New publications from this catalog will no longer be downloaded automatically.": "এই ক্যাটালগের নতুন প্রকাশনা আর স্বয়ংক্রিয়ভাবে ডাউনলোড করা হবে না।"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2042,5 +2042,9 @@
   "More Settings": "སྒྲིག་སྟངས་གཞན།",
   "Right-to-Left Pages": "ཤོག་ངོས་གཡས་ནས་གཡོན།",
   "Send Document Metadata": "ཡིག་ཆའི་གནས་ཚུལ་བསྐུར་བ།",
-  "Hide covers": "དཔེ་དེབ་ཀྱི་མདུན་ཤོག་སྦས་པ།"
+  "Hide covers": "དཔེ་དེབ་ཀྱི་མདུན་ཤོག་སྦས་པ།",
+  "Auto-download from “{{name}}”?": "“{{name}}” ནས་རང་འགུལ་ཕབ་ལེན་བྱེད་དམ།",
+  "Stop auto-downloading from “{{name}}”?": "“{{name}}” ནས་རང་འགུལ་ཕབ་ལེན་མཚམས་འཇོག་བྱེད་དམ།",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "མཉེན་ཆས་མཉམ་སྦྱོར་སྐབས། Readest ཡིས་དཀར་ཆག་འདིའི་གསར་འདོན་གསར་པ་ཚང་མ་རང་འགུལ་གྱིས་ཕབ་ལེན་བྱེད། དེས་དཔེ་དེབ་མང་པོ་ཞིག་ཕབ་ལེན་བྱེད་སྲིད།",
+  "New publications from this catalog will no longer be downloaded automatically.": "དཀར་ཆག་འདིའི་གསར་འདོན་གསར་པ་རྣམས་ཕྱིན་ཆད་རང་འགུལ་གྱིས་ཕབ་ལེན་མི་བྱེད།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2098,5 +2098,9 @@
   "More Settings": "Weitere Einstellungen",
   "Right-to-Left Pages": "Seiten von rechts nach links",
   "Send Document Metadata": "Dokument-Metadaten senden",
-  "Hide covers": "Buchcover ausblenden"
+  "Hide covers": "Buchcover ausblenden",
+  "Auto-download from “{{name}}”?": "Automatisch von „{{name}}“ herunterladen?",
+  "Stop auto-downloading from “{{name}}”?": "Automatischen Download von „{{name}}“ beenden?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest lädt bei jeder Synchronisierung der App automatisch jede neue Veröffentlichung aus diesem Katalog herunter. Dabei können sehr viele Bücher heruntergeladen werden.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Neue Veröffentlichungen aus diesem Katalog werden nicht mehr automatisch heruntergeladen."
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2098,5 +2098,9 @@
   "More Settings": "Περισσότερες ρυθμίσεις",
   "Right-to-Left Pages": "Σελίδες από δεξιά προς τα αριστερά",
   "Send Document Metadata": "Αποστολή μεταδεδομένων εγγράφου",
-  "Hide covers": "Απόκρυψη εξωφύλλων βιβλίων"
+  "Hide covers": "Απόκρυψη εξωφύλλων βιβλίων",
+  "Auto-download from “{{name}}”?": "Αυτόματη λήψη από το “{{name}}”;",
+  "Stop auto-downloading from “{{name}}”?": "Διακοπή αυτόματης λήψης από το “{{name}}”;",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Το Readest θα κατεβάζει αυτόματα κάθε νέα δημοσίευση αυτού του καταλόγου κατά τον συγχρονισμό της εφαρμογής. Ενδέχεται να ληφθεί μεγάλος αριθμός βιβλίων.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Οι νέες δημοσιεύσεις αυτού του καταλόγου δεν θα λαμβάνονται πλέον αυτόματα."
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2154,5 +2154,9 @@
   "More Settings": "Más configuraciones",
   "Right-to-Left Pages": "Páginas de derecha a izquierda",
   "Send Document Metadata": "Enviar metadatos del documento",
-  "Hide covers": "Ocultar portadas de libros"
+  "Hide covers": "Ocultar portadas de libros",
+  "Auto-download from “{{name}}”?": "¿Descargar automáticamente desde “{{name}}”?",
+  "Stop auto-downloading from “{{name}}”?": "¿Dejar de descargar automáticamente desde “{{name}}”?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest descargará automáticamente cada nueva publicación de este catálogo cuando la aplicación se sincronice. Esto puede descargar una gran cantidad de libros.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Las nuevas publicaciones de este catálogo ya no se descargarán automáticamente."
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2098,5 +2098,9 @@
   "More Settings": "تنظیمات بیشتر",
   "Right-to-Left Pages": "صفحات راست به چپ",
   "Send Document Metadata": "ارسال فراداده سند",
-  "Hide covers": "پنهان کردن جلد کتاب‌ها"
+  "Hide covers": "پنهان کردن جلد کتاب‌ها",
+  "Auto-download from “{{name}}”?": "دانلود خودکار از «{{name}}»؟",
+  "Stop auto-downloading from “{{name}}”?": "توقف دانلود خودکار از «{{name}}»؟",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest هنگام همگام‌سازی برنامه، هر انتشار جدید این کاتالوگ را به‌طور خودکار دانلود می‌کند. ممکن است تعداد زیادی کتاب دانلود شود.",
+  "New publications from this catalog will no longer be downloaded automatically.": "انتشارات جدید این کاتالوگ دیگر به‌طور خودکار دانلود نمی‌شوند."
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2154,5 +2154,9 @@
   "More Settings": "Plus de paramètres",
   "Right-to-Left Pages": "Pages de droite à gauche",
   "Send Document Metadata": "Envoyer les métadonnées du document",
-  "Hide covers": "Masquer les couvertures de livres"
+  "Hide covers": "Masquer les couvertures de livres",
+  "Auto-download from “{{name}}”?": "Télécharger automatiquement depuis « {{name}} » ?",
+  "Stop auto-downloading from “{{name}}”?": "Arrêter le téléchargement automatique depuis « {{name}} » ?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest téléchargera automatiquement chaque nouvelle publication de ce catalogue lors de la synchronisation de l'application. Cela peut représenter un très grand nombre de livres.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Les nouvelles publications de ce catalogue ne seront plus téléchargées automatiquement."
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2154,5 +2154,9 @@
   "More Settings": "הגדרות נוספות",
   "Right-to-Left Pages": "עמודים מימין לשמאל",
   "Send Document Metadata": "שליחת מטא-נתונים של המסמך",
-  "Hide covers": "הסתר כריכות ספרים"
+  "Hide covers": "הסתר כריכות ספרים",
+  "Auto-download from “{{name}}”?": "להוריד אוטומטית מ–“{{name}}”?",
+  "Stop auto-downloading from “{{name}}”?": "להפסיק הורדה אוטומטית מ–“{{name}}”?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest יוריד אוטומטית כל פרסום חדש מהקטלוג הזה בכל סנכרון של האפליקציה. ייתכן שיורדו ספרים רבים מאוד.",
+  "New publications from this catalog will no longer be downloaded automatically.": "פרסומים חדשים מהקטלוג הזה לא יורדו עוד באופן אוטומטי."
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2098,5 +2098,9 @@
   "More Settings": "अधिक सेटिंग्स",
   "Right-to-Left Pages": "दाएँ से बाएँ पृष्ठ",
   "Send Document Metadata": "दस्तावेज़ मेटाडेटा भेजें",
-  "Hide covers": "पुस्तक कवर छिपाएँ"
+  "Hide covers": "पुस्तक कवर छिपाएँ",
+  "Auto-download from “{{name}}”?": "“{{name}}” से स्वचालित डाउनलोड करें?",
+  "Stop auto-downloading from “{{name}}”?": "“{{name}}” से स्वचालित डाउनलोड बंद करें?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "ऐप सिंक होने पर Readest इस कैटलॉग के हर नए प्रकाशन को स्वचालित रूप से डाउनलोड करेगा। इससे बड़ी संख्या में पुस्तकें डाउनलोड हो सकती हैं।",
+  "New publications from this catalog will no longer be downloaded automatically.": "इस कैटलॉग के नए प्रकाशन अब स्वचालित रूप से डाउनलोड नहीं होंगे।"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2098,5 +2098,9 @@
   "More Settings": "További beállítások",
   "Right-to-Left Pages": "Oldalak jobbról balra",
   "Send Document Metadata": "Dokumentum metaadatainak küldése",
-  "Hide covers": "Könyvborítók elrejtése"
+  "Hide covers": "Könyvborítók elrejtése",
+  "Auto-download from “{{name}}”?": "Automatikus letöltés innen: „{{name}}”?",
+  "Stop auto-downloading from “{{name}}”?": "Leállítja az automatikus letöltést innen: „{{name}}”?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "A Readest az alkalmazás minden szinkronizálásakor automatikusan letölti a katalógus összes új kiadványát. Ez nagyon sok könyv letöltését jelentheti.",
+  "New publications from this catalog will no longer be downloaded automatically.": "A katalógus új kiadványai a továbbiakban nem töltődnek le automatikusan."
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2042,5 +2042,9 @@
   "More Settings": "Pengaturan Lainnya",
   "Right-to-Left Pages": "Halaman Kanan ke Kiri",
   "Send Document Metadata": "Kirim Metadata Dokumen",
-  "Hide covers": "Sembunyikan sampul buku"
+  "Hide covers": "Sembunyikan sampul buku",
+  "Auto-download from “{{name}}”?": "Unduh otomatis dari “{{name}}”?",
+  "Stop auto-downloading from “{{name}}”?": "Hentikan unduh otomatis dari “{{name}}”?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest akan otomatis mengunduh setiap publikasi baru dari katalog ini saat aplikasi disinkronkan. Ini dapat mengunduh sejumlah besar buku.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Publikasi baru dari katalog ini tidak akan diunduh otomatis lagi."
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2154,5 +2154,9 @@
   "More Settings": "Altre impostazioni",
   "Right-to-Left Pages": "Pagine da destra a sinistra",
   "Send Document Metadata": "Invia metadati del documento",
-  "Hide covers": "Nascondi le copertine dei libri"
+  "Hide covers": "Nascondi le copertine dei libri",
+  "Auto-download from “{{name}}”?": "Scaricare automaticamente da “{{name}}”?",
+  "Stop auto-downloading from “{{name}}”?": "Interrompere il download automatico da “{{name}}”?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest scaricherà automaticamente ogni nuova pubblicazione di questo catalogo quando l'app si sincronizza. Potrebbe scaricare un gran numero di libri.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Le nuove pubblicazioni di questo catalogo non verranno più scaricate automaticamente."
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2042,5 +2042,9 @@
   "More Settings": "その他の設定",
   "Right-to-Left Pages": "右から左のページ送り",
   "Send Document Metadata": "ドキュメントのメタデータを送信",
-  "Hide covers": "表紙を非表示"
+  "Hide covers": "表紙を非表示",
+  "Auto-download from “{{name}}”?": "「{{name}}」から自動ダウンロードしますか？",
+  "Stop auto-downloading from “{{name}}”?": "「{{name}}」からの自動ダウンロードを停止しますか？",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "アプリの同期時に、Readest はこのカタログの新しい出版物をすべて自動的にダウンロードします。大量の書籍がダウンロードされる可能性があります。",
+  "New publications from this catalog will no longer be downloaded automatically.": "このカタログの新しい出版物は自動的にダウンロードされなくなります。"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2042,5 +2042,9 @@
   "More Settings": "추가 설정",
   "Right-to-Left Pages": "오른쪽에서 왼쪽으로 페이지 넘김",
   "Send Document Metadata": "문서 메타데이터 전송",
-  "Hide covers": "책 표지 숨기기"
+  "Hide covers": "책 표지 숨기기",
+  "Auto-download from “{{name}}”?": "“{{name}}”에서 자동 다운로드할까요?",
+  "Stop auto-downloading from “{{name}}”?": "“{{name}}”에서 자동 다운로드를 중지할까요?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "앱이 동기화될 때 Readest가 이 카탈로그의 새 출판물을 모두 자동으로 다운로드합니다. 많은 양의 책이 다운로드될 수 있습니다.",
+  "New publications from this catalog will no longer be downloaded automatically.": "이 카탈로그의 새 출판물은 더 이상 자동으로 다운로드되지 않습니다."
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2042,5 +2042,9 @@
   "More Settings": "Tetapan Lain",
   "Right-to-Left Pages": "Halaman Kanan ke Kiri",
   "Send Document Metadata": "Hantar Metadata Dokumen",
-  "Hide covers": "Sembunyikan kulit buku"
+  "Hide covers": "Sembunyikan kulit buku",
+  "Auto-download from “{{name}}”?": "Muat turun automatik daripada “{{name}}”?",
+  "Stop auto-downloading from “{{name}}”?": "Hentikan muat turun automatik daripada “{{name}}”?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest akan memuat turun setiap penerbitan baharu daripada katalog ini secara automatik apabila apl disegerakkan. Ini boleh memuat turun sejumlah besar buku.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Penerbitan baharu daripada katalog ini tidak akan dimuat turun secara automatik lagi."
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2098,5 +2098,9 @@
   "More Settings": "Meer instellingen",
   "Right-to-Left Pages": "Pagina's van rechts naar links",
   "Send Document Metadata": "Documentmetadata verzenden",
-  "Hide covers": "Boekomslagen verbergen"
+  "Hide covers": "Boekomslagen verbergen",
+  "Auto-download from “{{name}}”?": "Automatisch downloaden van “{{name}}”?",
+  "Stop auto-downloading from “{{name}}”?": "Automatisch downloaden van “{{name}}” stoppen?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest downloadt automatisch elke nieuwe publicatie uit deze catalogus wanneer de app synchroniseert. Hierbij kunnen zeer veel boeken worden gedownload.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Nieuwe publicaties uit deze catalogus worden niet meer automatisch gedownload."
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2210,5 +2210,9 @@
   "More Settings": "Więcej ustawień",
   "Right-to-Left Pages": "Strony od prawej do lewej",
   "Send Document Metadata": "Wysyłaj metadane dokumentu",
-  "Hide covers": "Ukryj okładki książek"
+  "Hide covers": "Ukryj okładki książek",
+  "Auto-download from “{{name}}”?": "Automatycznie pobierać z „{{name}}”?",
+  "Stop auto-downloading from “{{name}}”?": "Zatrzymać automatyczne pobieranie z „{{name}}”?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest będzie automatycznie pobierać każdą nową publikację z tego katalogu podczas synchronizacji aplikacji. Może to oznaczać pobranie bardzo wielu książek.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Nowe publikacje z tego katalogu nie będą już pobierane automatycznie."
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2159,5 +2159,9 @@
   "More Settings": "Mais configurações",
   "Right-to-Left Pages": "Páginas da direita para a esquerda",
   "Send Document Metadata": "Enviar metadados do documento",
-  "Hide covers": "Ocultar capas de livros"
+  "Hide covers": "Ocultar capas de livros",
+  "Auto-download from “{{name}}”?": "Baixar automaticamente de “{{name}}”?",
+  "Stop auto-downloading from “{{name}}”?": "Parar de baixar automaticamente de “{{name}}”?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "O Readest baixará automaticamente cada nova publicação deste catálogo quando o aplicativo sincronizar. Isso pode baixar um grande número de livros.",
+  "New publications from this catalog will no longer be downloaded automatically.": "As novas publicações deste catálogo não serão mais baixadas automaticamente."
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2154,5 +2154,9 @@
   "More Settings": "Mais configurações",
   "Right-to-Left Pages": "Páginas da direita para a esquerda",
   "Send Document Metadata": "Enviar metadados do documento",
-  "Hide covers": "Ocultar capas de livros"
+  "Hide covers": "Ocultar capas de livros",
+  "Auto-download from “{{name}}”?": "Baixar automaticamente de “{{name}}”?",
+  "Stop auto-downloading from “{{name}}”?": "Parar de baixar automaticamente de “{{name}}”?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "O Readest baixará automaticamente cada nova publicação deste catálogo quando o aplicativo sincronizar. Isso pode baixar um grande número de livros.",
+  "New publications from this catalog will no longer be downloaded automatically.": "As novas publicações deste catálogo não serão mais baixadas automaticamente."
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2154,5 +2154,9 @@
   "More Settings": "Mai multe setări",
   "Right-to-Left Pages": "Pagini de la dreapta la stânga",
   "Send Document Metadata": "Trimite metadatele documentului",
-  "Hide covers": "Ascunde coperțile cărților"
+  "Hide covers": "Ascunde coperțile cărților",
+  "Auto-download from “{{name}}”?": "Descărcați automat din „{{name}}”?",
+  "Stop auto-downloading from “{{name}}”?": "Opriți descărcarea automată din „{{name}}”?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest va descărca automat fiecare publicație nouă din acest catalog atunci când aplicația se sincronizează. Astfel se poate descărca un număr mare de cărți.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Publicațiile noi din acest catalog nu vor mai fi descărcate automat."
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2210,5 +2210,9 @@
   "More Settings": "Другие настройки",
   "Right-to-Left Pages": "Страницы справа налево",
   "Send Document Metadata": "Отправлять метаданные документа",
-  "Hide covers": "Скрыть обложки книг"
+  "Hide covers": "Скрыть обложки книг",
+  "Auto-download from “{{name}}”?": "Автоматически загружать из «{{name}}»?",
+  "Stop auto-downloading from “{{name}}”?": "Остановить автоматическую загрузку из «{{name}}»?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest будет автоматически загружать каждую новую публикацию из этого каталога при синхронизации приложения. Это может привести к загрузке большого количества книг.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Новые публикации из этого каталога больше не будут загружаться автоматически."
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2098,5 +2098,9 @@
   "More Settings": "තවත් සැකසුම්",
   "Right-to-Left Pages": "දකුණේ සිට වමට පිටු",
   "Send Document Metadata": "ලේඛන පාරදත්ත යවන්න",
-  "Hide covers": "පොත් ආවරණ සඟවන්න"
+  "Hide covers": "පොත් ආවරණ සඟවන්න",
+  "Auto-download from “{{name}}”?": "“{{name}}” වෙතින් ස්වයංක්‍රීයව බාගත කරන්නද?",
+  "Stop auto-downloading from “{{name}}”?": "“{{name}}” වෙතින් ස්වයංක්‍රීය බාගැනීම නවත්වන්නද?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "යෙදුම සමමුහුර්ත වන විට Readest මෙම නාමාවලියේ සෑම නව ප්‍රකාශනයක්ම ස්වයංක්‍රීයව බාගත කරයි. මෙමගින් විශාල පොත් ගණනක් බාගත විය හැක.",
+  "New publications from this catalog will no longer be downloaded automatically.": "මෙම නාමාවලියේ නව ප්‍රකාශන තවදුරටත් ස්වයංක්‍රීයව බාගත නොවේ."
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2210,5 +2210,9 @@
   "More Settings": "Več nastavitev",
   "Right-to-Left Pages": "Strani od desne proti levi",
   "Send Document Metadata": "Pošlji metapodatke dokumenta",
-  "Hide covers": "Skrij naslovnice knjig"
+  "Hide covers": "Skrij naslovnice knjig",
+  "Auto-download from “{{name}}”?": "Samodejno prenašanje iz »{{name}}«?",
+  "Stop auto-downloading from “{{name}}”?": "Ustavim samodejno prenašanje iz »{{name}}«?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest bo ob vsaki sinhronizaciji aplikacije samodejno prenesel vsako novo vsebino iz tega kataloga. Prenese se lahko veliko število knjig.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Nove vsebine iz tega kataloga ne bodo več samodejno prenesene."
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2098,5 +2098,9 @@
   "More Settings": "Fler inställningar",
   "Right-to-Left Pages": "Sidor från höger till vänster",
   "Send Document Metadata": "Skicka dokumentmetadata",
-  "Hide covers": "Dölj bokomslag"
+  "Hide covers": "Dölj bokomslag",
+  "Auto-download from “{{name}}”?": "Hämta automatiskt från ”{{name}}”?",
+  "Stop auto-downloading from “{{name}}”?": "Sluta hämta automatiskt från ”{{name}}”?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest hämtar automatiskt varje ny publikation från den här katalogen när appen synkroniserar. Det kan innebära att väldigt många böcker hämtas.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Nya publikationer från den här katalogen hämtas inte längre automatiskt."
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2098,5 +2098,9 @@
   "More Settings": "மேலும் அமைப்புகள்",
   "Right-to-Left Pages": "வலமிருந்து இடமாகப் பக்கங்கள்",
   "Send Document Metadata": "ஆவண மீத்தரவை அனுப்பு",
-  "Hide covers": "புத்தக அட்டைகளை மறை"
+  "Hide covers": "புத்தக அட்டைகளை மறை",
+  "Auto-download from “{{name}}”?": "“{{name}}” இலிருந்து தானாகப் பதிவிறக்கவா?",
+  "Stop auto-downloading from “{{name}}”?": "“{{name}}” இலிருந்து தானியங்கி பதிவிறக்கத்தை நிறுத்தவா?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "பயன்பாடு ஒத்திசைக்கப்படும்போது, இந்தப் பட்டியலின் ஒவ்வொரு புதிய வெளியீட்டையும் Readest தானாகப் பதிவிறக்கும். இதனால் ஏராளமான புத்தகங்கள் பதிவிறக்கப்படலாம்.",
+  "New publications from this catalog will no longer be downloaded automatically.": "இந்தப் பட்டியலின் புதிய வெளியீடுகள் இனி தானாகப் பதிவிறக்கப்படாது."
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2042,5 +2042,9 @@
   "More Settings": "การตั้งค่าเพิ่มเติม",
   "Right-to-Left Pages": "หน้าจากขวาไปซ้าย",
   "Send Document Metadata": "ส่งข้อมูลเมตาของเอกสาร",
-  "Hide covers": "ซ่อนปกหนังสือ"
+  "Hide covers": "ซ่อนปกหนังสือ",
+  "Auto-download from “{{name}}”?": "ดาวน์โหลดอัตโนมัติจาก “{{name}}” หรือไม่?",
+  "Stop auto-downloading from “{{name}}”?": "หยุดดาวน์โหลดอัตโนมัติจาก “{{name}}” หรือไม่?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest จะดาวน์โหลดสิ่งพิมพ์ใหม่ทุกรายการจากแคตตาล็อกนี้โดยอัตโนมัติเมื่อแอปซิงค์ ซึ่งอาจดาวน์โหลดหนังสือจำนวนมาก",
+  "New publications from this catalog will no longer be downloaded automatically.": "สิ่งพิมพ์ใหม่จากแคตตาล็อกนี้จะไม่ถูกดาวน์โหลดโดยอัตโนมัติอีกต่อไป"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2098,5 +2098,9 @@
   "More Settings": "Diğer ayarlar",
   "Right-to-Left Pages": "Sağdan Sola Sayfalar",
   "Send Document Metadata": "Belge Meta Verilerini Gönder",
-  "Hide covers": "Kitap kapaklarını gizle"
+  "Hide covers": "Kitap kapaklarını gizle",
+  "Auto-download from “{{name}}”?": "“{{name}}” kaynağından otomatik indirilsin mi?",
+  "Stop auto-downloading from “{{name}}”?": "“{{name}}” kaynağından otomatik indirme durdurulsun mu?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest, uygulama eşitlendiğinde bu katalogdaki her yeni yayını otomatik olarak indirir. Bu, çok sayıda kitabın indirilmesine yol açabilir.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Bu katalogdaki yeni yayınlar artık otomatik olarak indirilmeyecek."
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2210,5 +2210,9 @@
   "More Settings": "Інші налаштування",
   "Right-to-Left Pages": "Сторінки справа наліво",
   "Send Document Metadata": "Надсилати метадані документа",
-  "Hide covers": "Сховати обкладинки книг"
+  "Hide covers": "Сховати обкладинки книг",
+  "Auto-download from “{{name}}”?": "Автоматично завантажувати з «{{name}}»?",
+  "Stop auto-downloading from “{{name}}”?": "Припинити автоматичне завантаження з «{{name}}»?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest автоматично завантажуватиме кожну нову публікацію з цього каталогу під час синхронізації застосунку. Це може завантажити велику кількість книг.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Нові публікації з цього каталогу більше не завантажуватимуться автоматично."
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2098,5 +2098,9 @@
   "More Settings": "Boshqa sozlamalar",
   "Right-to-Left Pages": "Oʻngdan chapga sahifalar",
   "Send Document Metadata": "Hujjat metamaʼlumotlarini yuborish",
-  "Hide covers": "Kitob muqovalarini yashirish"
+  "Hide covers": "Kitob muqovalarini yashirish",
+  "Auto-download from “{{name}}”?": "“{{name}}” dan avtomatik yuklab olinsinmi?",
+  "Stop auto-downloading from “{{name}}”?": "“{{name}}” dan avtomatik yuklab olish to‘xtatilsinmi?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Ilova sinxronlanganda Readest ushbu katalogdagi har bir yangi nashrni avtomatik yuklab oladi. Bu juda ko‘p kitob yuklab olinishiga olib kelishi mumkin.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Ushbu katalogdagi yangi nashrlar endi avtomatik yuklab olinmaydi."
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2042,5 +2042,9 @@
   "More Settings": "Cài đặt khác",
   "Right-to-Left Pages": "Trang từ phải sang trái",
   "Send Document Metadata": "Gửi siêu dữ liệu tài liệu",
-  "Hide covers": "Ẩn bìa sách"
+  "Hide covers": "Ẩn bìa sách",
+  "Auto-download from “{{name}}”?": "Tự động tải xuống từ “{{name}}”?",
+  "Stop auto-downloading from “{{name}}”?": "Dừng tự động tải xuống từ “{{name}}”?",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "Readest sẽ tự động tải xuống mọi ấn phẩm mới từ danh mục này khi ứng dụng đồng bộ hóa. Việc này có thể tải xuống một số lượng lớn sách.",
+  "New publications from this catalog will no longer be downloaded automatically.": "Các ấn phẩm mới từ danh mục này sẽ không còn được tải xuống tự động."
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2042,5 +2042,9 @@
   "More Settings": "更多设置",
   "Right-to-Left Pages": "从右到左翻页",
   "Send Document Metadata": "发送文档元数据",
-  "Hide covers": "隐藏封面"
+  "Hide covers": "隐藏封面",
+  "Auto-download from “{{name}}”?": "从“{{name}}”自动下载？",
+  "Stop auto-downloading from “{{name}}”?": "停止从“{{name}}”自动下载？",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "应用同步时，Readest 将自动下载此目录中的每一本新出版物。这可能会下载大量图书。",
+  "New publications from this catalog will no longer be downloaded automatically.": "此目录中的新出版物将不再自动下载。"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2042,5 +2042,9 @@
   "More Settings": "更多設定",
   "Right-to-Left Pages": "從右到左翻頁",
   "Send Document Metadata": "傳送文件中繼資料",
-  "Hide covers": "隱藏封面"
+  "Hide covers": "隱藏封面",
+  "Auto-download from “{{name}}”?": "從「{{name}}」自動下載？",
+  "Stop auto-downloading from “{{name}}”?": "停止從「{{name}}」自動下載？",
+  "Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.": "應用同步時，Readest 將自動下載此目錄中的每一本新出版物。這可能會下載大量書籍。",
+  "New publications from this catalog will no longer be downloaded automatically.": "此目錄中的新出版物將不再自動下載。"
 }

--- a/apps/readest-app/src/__tests__/app/opds/catalog-manager.test.tsx
+++ b/apps/readest-app/src/__tests__/app/opds/catalog-manager.test.tsx
@@ -1,0 +1,153 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { CatalogManager } from '@/app/opds/components/CatalogManager';
+import { useCustomOPDSStore } from '@/store/customOPDSStore';
+import { useSettingsStore } from '@/store/settingsStore';
+import { eventDispatcher } from '@/utils/event';
+import type { OPDSCatalog } from '@/types/opds';
+import type { SystemSettings } from '@/types/settings';
+
+// Simple interpolating stub so assertions can match the rendered copy
+// (including the catalog name) instead of raw i18n keys.
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string, opts?: Record<string, unknown>) =>
+    opts ? key.replace(/\{\{(\w+)\}\}/g, (_m, k: string) => String(opts[k] ?? '')) : key,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: { isOnlineCatalogsAccessible: false } }),
+}));
+
+vi.mock('@/services/opds', () => ({
+  loadSubscriptionState: vi.fn(async () => ({ lastCheckedAt: 0, failedEntries: [] })),
+  deleteSubscriptionState: vi.fn(),
+}));
+
+vi.mock('@/app/opds/utils/opdsUtils', () => ({
+  getUnaddedPopularCatalogs: () => [],
+  validateOPDSURL: vi.fn(),
+}));
+
+vi.mock('@/services/sync/passphraseGate', () => ({ ensurePassphraseUnlocked: vi.fn() }));
+vi.mock('@/services/sync/syncCategories', () => ({ isCredentialsSyncEnabled: () => false }));
+
+// Replica publish fans out to the network — stub it so the store stays hermetic.
+vi.mock('@/services/sync/replicaPublish', () => ({
+  publishReplicaUpsert: vi.fn(),
+  publishReplicaDelete: vi.fn(),
+}));
+
+const makeCatalog = (overrides: Partial<OPDSCatalog>): OPDSCatalog => ({
+  id: 'c1',
+  contentId: 'c1',
+  name: 'My Library',
+  url: 'https://example.com/opds',
+  addedAt: 1700000000000,
+  ...overrides,
+});
+
+const seed = (catalogs: OPDSCatalog[]) => {
+  useSettingsStore.setState({
+    settings: { opdsCatalogs: catalogs } as unknown as SystemSettings,
+    setSettings: (s: SystemSettings) => useSettingsStore.setState({ settings: s }),
+    saveSettings: vi.fn(),
+  } as unknown as ReturnType<typeof useSettingsStore.getState>);
+  useCustomOPDSStore.setState({ catalogs, loading: false });
+};
+
+const autoDownloadToggle = () => screen.getByRole('checkbox', { name: 'Auto-download' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe('CatalogManager auto-download confirmation (#5746)', () => {
+  test('flipping the list toggle on asks for confirmation instead of enabling', async () => {
+    seed([makeCatalog({})]);
+    render(<CatalogManager />);
+
+    fireEvent.click(autoDownloadToggle());
+
+    expect(await screen.findByText('Auto-download from “My Library”?')).toBeTruthy();
+    expect(useCustomOPDSStore.getState().getCatalog('c1')!.autoDownload).toBeFalsy();
+  });
+
+  test('confirming enables auto-download and schedules the subscription check', async () => {
+    const dispatch = vi.spyOn(eventDispatcher, 'dispatch');
+    seed([makeCatalog({})]);
+    render(<CatalogManager />);
+
+    fireEvent.click(autoDownloadToggle());
+    fireEvent.click(await screen.findByRole('button', { name: 'Enable' }));
+
+    await waitFor(() =>
+      expect(useCustomOPDSStore.getState().getCatalog('c1')!.autoDownload).toBe(true),
+    );
+    expect(screen.queryByText('Auto-download from “My Library”?')).toBeNull();
+
+    expect(dispatch).not.toHaveBeenCalledWith('check-opds-subscriptions');
+    vi.advanceTimersByTime(5000);
+    expect(dispatch).toHaveBeenCalledWith('check-opds-subscriptions');
+  });
+
+  test('cancelling leaves auto-download untouched and starts no download', async () => {
+    const dispatch = vi.spyOn(eventDispatcher, 'dispatch');
+    seed([makeCatalog({})]);
+    render(<CatalogManager />);
+
+    fireEvent.click(autoDownloadToggle());
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => expect(screen.queryByText('Auto-download from “My Library”?')).toBeNull());
+    expect(useCustomOPDSStore.getState().getCatalog('c1')!.autoDownload).toBeFalsy();
+    expect(autoDownloadToggle()).toHaveProperty('checked', false);
+
+    vi.advanceTimersByTime(5000);
+    expect(dispatch).not.toHaveBeenCalledWith('check-opds-subscriptions');
+  });
+
+  test('turning an enabled catalog off also confirms, with its own copy', async () => {
+    seed([makeCatalog({ autoDownload: true })]);
+    render(<CatalogManager />);
+
+    fireEvent.click(autoDownloadToggle());
+
+    expect(await screen.findByText('Stop auto-downloading from “My Library”?')).toBeTruthy();
+    expect(useCustomOPDSStore.getState().getCatalog('c1')!.autoDownload).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Turn Off' }));
+    await waitFor(() =>
+      expect(useCustomOPDSStore.getState().getCatalog('c1')!.autoDownload).toBe(false),
+    );
+  });
+});
+
+describe('CatalogManager drag-to-reorder (#5746)', () => {
+  test('renders a drag handle on every catalog card', () => {
+    seed([
+      makeCatalog({ id: 'c1', contentId: 'c1', name: 'One', url: 'https://one.example/opds' }),
+      makeCatalog({ id: 'c2', contentId: 'c2', name: 'Two', url: 'https://two.example/opds' }),
+    ]);
+    render(<CatalogManager />);
+
+    expect(screen.getAllByLabelText('Drag to reorder')).toHaveLength(2);
+  });
+
+  test('renders no drag handle when a single catalog leaves nothing to reorder', () => {
+    seed([makeCatalog({})]);
+    render(<CatalogManager />);
+
+    expect(screen.queryByLabelText('Drag to reorder')).toBeNull();
+  });
+});

--- a/apps/readest-app/src/__tests__/services/sync/adapters/opdsCatalog.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/adapters/opdsCatalog.test.ts
@@ -109,6 +109,32 @@ describe('opdsCatalogAdapter', () => {
     expect(opdsCatalogAdapter.unpackRow(noUrl, '')).toBeNull();
   });
 
+  test('round-trips sortOrder so a manual drag order syncs cross-device', () => {
+    const fields = opdsCatalogAdapter.pack({ ...sample, sortOrder: 2 });
+    expect(opdsCatalogAdapter.unpack(fields).sortOrder).toBe(2);
+
+    const row = makeRow({
+      fields_jsonb: { ...makeRow().fields_jsonb, sortOrder: env(2) },
+    });
+    expect(opdsCatalogAdapter.unpackRow(row, '')!.sortOrder).toBe(2);
+  });
+
+  test('sortOrder 0 survives the round trip', () => {
+    // Guards against a truthiness check swallowing the first slot.
+    const fields = opdsCatalogAdapter.pack({ ...sample, sortOrder: 0 });
+    expect(opdsCatalogAdapter.unpack(fields).sortOrder).toBe(0);
+
+    const row = makeRow({
+      fields_jsonb: { ...makeRow().fields_jsonb, sortOrder: env(0) },
+    });
+    expect(opdsCatalogAdapter.unpackRow(row, '')!.sortOrder).toBe(0);
+  });
+
+  test('omits sortOrder entirely for never-dragged catalogs', () => {
+    expect(opdsCatalogAdapter.pack(sample)).not.toHaveProperty('sortOrder');
+    expect(opdsCatalogAdapter.unpackRow(makeRow(), '')!.sortOrder).toBeUndefined();
+  });
+
   test('unpackRow surfaces the reincarnation token', () => {
     const row = makeRow({ reincarnation: 'rev1' });
     const out = opdsCatalogAdapter.unpackRow(row, '');

--- a/apps/readest-app/src/__tests__/store/custom-opds-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/custom-opds-store.test.ts
@@ -233,6 +233,126 @@ describe('customOPDSStore', () => {
     });
   });
 
+  describe('getAvailableCatalogs ordering', () => {
+    const seed = (catalogs: OPDSCatalog[]) =>
+      useCustomOPDSStore.setState({ catalogs, loading: false });
+
+    test('sorts manually placed catalogs by ascending sortOrder', () => {
+      seed([
+        { id: 'a', name: 'A', url: 'https://a.example/opds', addedAt: 3, sortOrder: 2 },
+        { id: 'b', name: 'B', url: 'https://b.example/opds', addedAt: 2, sortOrder: 0 },
+        { id: 'c', name: 'C', url: 'https://c.example/opds', addedAt: 1, sortOrder: 1 },
+      ]);
+      expect(
+        useCustomOPDSStore
+          .getState()
+          .getAvailableCatalogs()
+          .map((c) => c.id),
+      ).toEqual(['b', 'c', 'a']);
+    });
+
+    test('keeps the legacy newest-first order when nothing has been dragged', () => {
+      seed([
+        { id: 'old', name: 'Old', url: 'https://old.example/opds', addedAt: 1 },
+        { id: 'new', name: 'New', url: 'https://new.example/opds', addedAt: 3 },
+        { id: 'mid', name: 'Mid', url: 'https://mid.example/opds', addedAt: 2 },
+      ]);
+      expect(
+        useCustomOPDSStore
+          .getState()
+          .getAvailableCatalogs()
+          .map((c) => c.id),
+      ).toEqual(['new', 'mid', 'old']);
+    });
+
+    test('a freshly added catalog still lands on top of a manually ordered list', () => {
+      seed([
+        { id: 'a', name: 'A', url: 'https://a.example/opds', addedAt: 1, sortOrder: 0 },
+        { id: 'b', name: 'B', url: 'https://b.example/opds', addedAt: 2, sortOrder: 1 },
+      ]);
+      useCustomOPDSStore
+        .getState()
+        .addCatalog({ id: 'fresh', name: 'Fresh', url: 'https://fresh.example/opds' });
+      expect(
+        useCustomOPDSStore
+          .getState()
+          .getAvailableCatalogs()
+          .map((c) => c.id),
+      ).toEqual(['fresh', 'a', 'b']);
+    });
+
+    test('excludes tombstoned entries regardless of sortOrder', () => {
+      seed([
+        { id: 'a', name: 'A', url: 'https://a.example/opds', addedAt: 1, sortOrder: 0 },
+        {
+          id: 'dead',
+          name: 'Dead',
+          url: 'https://dead.example/opds',
+          addedAt: 2,
+          sortOrder: 1,
+          deletedAt: 5,
+        },
+      ]);
+      expect(
+        useCustomOPDSStore
+          .getState()
+          .getAvailableCatalogs()
+          .map((c) => c.id),
+      ).toEqual(['a']);
+    });
+  });
+
+  describe('reorderCatalogs', () => {
+    const seedThree = () => {
+      useCustomOPDSStore.setState({
+        catalogs: [
+          { id: 'a', contentId: 'ca', name: 'A', url: 'https://a.example/opds', addedAt: 3 },
+          { id: 'b', contentId: 'cb', name: 'B', url: 'https://b.example/opds', addedAt: 2 },
+          { id: 'c', contentId: 'cc', name: 'C', url: 'https://c.example/opds', addedAt: 1 },
+        ],
+        loading: false,
+      });
+    };
+
+    test('stamps sortOrder 0..n-1 in the given id order', () => {
+      seedThree();
+      useCustomOPDSStore.getState().reorderCatalogs(['c', 'a', 'b']);
+      const ordered = useCustomOPDSStore.getState().getAvailableCatalogs();
+      expect(ordered.map((c) => c.id)).toEqual(['c', 'a', 'b']);
+      expect(ordered.map((c) => c.sortOrder)).toEqual([0, 1, 2]);
+    });
+
+    test('publishes one upsert per catalog so the order syncs cross-device', () => {
+      seedThree();
+      vi.clearAllMocks();
+      useCustomOPDSStore.getState().reorderCatalogs(['c', 'a', 'b']);
+      expect(publishReplicaUpsert).toHaveBeenCalledTimes(3);
+    });
+
+    test('ignores unknown ids and leaves omitted catalogs trailing in their prior order', () => {
+      seedThree();
+      useCustomOPDSStore.getState().reorderCatalogs(['b', 'nope']);
+      const ordered = useCustomOPDSStore.getState().getAvailableCatalogs();
+      expect(ordered.map((c) => c.id)).toEqual(['b', 'a', 'c']);
+      expect(ordered.map((c) => c.sortOrder)).toEqual([0, 1, 2]);
+    });
+
+    test('does not stamp tombstoned entries', () => {
+      seedThree();
+      useCustomOPDSStore.getState().removeCatalog('b');
+      vi.clearAllMocks();
+      useCustomOPDSStore.getState().reorderCatalogs(['c', 'b', 'a']);
+      expect(useCustomOPDSStore.getState().getCatalog('b')!.sortOrder).toBeUndefined();
+      expect(
+        useCustomOPDSStore
+          .getState()
+          .getAvailableCatalogs()
+          .map((c) => c.id),
+      ).toEqual(['c', 'a']);
+      expect(publishReplicaUpsert).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('saveCustomOPDSCatalogs', () => {
     test('strips tombstoned entries from the persisted settings list', async () => {
       const live = useCustomOPDSStore.getState().addCatalog({

--- a/apps/readest-app/src/app/opds/components/CatalogManager.tsx
+++ b/apps/readest-app/src/app/opds/components/CatalogManager.tsx
@@ -11,7 +11,26 @@ import {
   IoEye,
   IoCloudDownloadOutline,
 } from 'react-icons/io5';
-import { MdChevronRight } from 'react-icons/md';
+import { MdChevronRight, MdDragIndicator } from 'react-icons/md';
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  rectSortingStrategy,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import Alert from '@/components/Alert';
 import Dropdown from '@/components/Dropdown';
 import Menu from '@/components/Menu';
 import MenuItem from '@/components/MenuItem';
@@ -98,6 +117,221 @@ const EMPTY_NEW_CATALOG = {
   autoDownload: false,
 };
 
+interface CatalogCardProps {
+  catalog: OPDSCatalog;
+  subState: OPDSSubscriptionState | undefined;
+  /** False when there is nothing to reorder (a single catalog); hides the handle. */
+  reorderable: boolean;
+  onOpen: (catalog: OPDSCatalog) => void;
+  onEdit: (catalog: OPDSCatalog) => void;
+  onRemove: (id: string) => void;
+  /** Opens the confirmation alert rather than flipping the switch (#5746). */
+  onRequestToggleAutoDownload: (id: string) => void;
+  onShowFailed: (id: string) => void;
+}
+
+/**
+ * One "My Catalogs" card. Split out of CatalogManager because `useSortable`
+ * is a hook and cannot be called from inside a `.map()` callback.
+ */
+function CatalogCard({
+  catalog,
+  subState,
+  reorderable,
+  onOpen,
+  onEdit,
+  onRemove,
+  onRequestToggleAutoDownload,
+  onShowFailed,
+}: CatalogCardProps) {
+  const _ = useTranslation();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: catalog.id,
+    disabled: !reorderable,
+  });
+
+  const lastCheckedAt = subState?.lastCheckedAt ?? 0;
+  const failedCount = subState?.failedEntries.length ?? 0;
+  const showSubscriptionStatus =
+    catalog.autoDownload && subState && (lastCheckedAt > 0 || failedCount > 0);
+
+  return (
+    // Whole card is the browse trigger. Uses role='button' (not
+    // a real <button>) because it nests other interactive
+    // elements: the drag handle, 3-dot menu, auto-download toggle,
+    // and failed-downloads link. Inner controls call
+    // e.stopPropagation() so their clicks don't bubble.
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        // Keep the dragged card visible, just dimmed, so the user can tell
+        // which one is moving.
+        opacity: isDragging ? 0.6 : 1,
+      }}
+      role='button'
+      tabIndex={catalog.disabled ? -1 : 0}
+      onClick={() => !catalog.disabled && onOpen(catalog)}
+      onKeyDown={(e) => {
+        if (catalog.disabled) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpen(catalog);
+        }
+      }}
+      className={clsx(
+        'card eink-bordered bg-base-100 border-base-200 group/card flex flex-col border transition-colors duration-150',
+        'focus-visible:ring-base-content/15 focus-visible:outline-none focus-visible:ring-2',
+        isDragging && 'z-10 shadow-md',
+        catalog.disabled ? 'cursor-not-allowed opacity-60' : 'hover:bg-base-300 cursor-pointer',
+      )}
+    >
+      <div className='flex flex-1 flex-col gap-2.5 px-4 pb-2 pt-4'>
+        {/* Header: drag handle + icon + name | overflow menu (Edit / Remove). */}
+        <div className='flex items-start justify-between gap-2'>
+          {reorderable && (
+            // The handle is the only element carrying drag listeners, so the
+            // rest of the card stays a plain browse target. stopPropagation on
+            // the wrapper (not the button — that would clobber dnd-kit's own
+            // onKeyDown) keeps handle clicks and Space/arrow keys from also
+            // browsing the catalog.
+            <div
+              className='-ms-1.5 -mt-1 flex-shrink-0'
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
+            >
+              {/* Sized to match the 3-dot menu trigger rather than carrying
+                  `touch-target`: that class inflates the hit area to 44px via
+                  a ::before, which here would bleed an invisible dead zone
+                  over the catalog name and swallow taps meant to browse. */}
+              <button
+                type='button'
+                className='text-base-content/45 hover:bg-base-200 hover:text-base-content focus-visible:ring-base-content/15 flex h-7 w-7 cursor-grab touch-none items-center justify-center rounded-md transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 active:cursor-grabbing'
+                {...attributes}
+                {...listeners}
+                aria-label={_('Drag to reorder')}
+                title={_('Drag to reorder')}
+              >
+                <MdDragIndicator className='h-4 w-4' />
+              </button>
+            </div>
+          )}
+          <h4 className='flex min-w-0 flex-1 items-center gap-1.5 text-sm font-semibold'>
+            {catalog.icon && <span className='flex-shrink-0'>{catalog.icon}</span>}
+            <span className='truncate'>{catalog.name}</span>
+          </h4>
+          {/* stopPropagation on the trigger wrapper so opening
+              the menu doesn't also browse the catalog.
+              The Dropdown component itself handles floating the
+              menu via daisyui's `.dropdown .dropdown-content`
+              position:absolute rule — don't add !relative here
+              or the menu inlines into the card layout. */}
+          <div
+            className='-me-1.5 -mt-1 flex-shrink-0'
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <Dropdown
+              label={_('Catalog actions')}
+              className='dropdown-bottom dropdown-end'
+              buttonClassName='text-base-content/55 hover:bg-base-200 hover:text-base-content focus-visible:ring-base-content/15 flex h-7 w-7 items-center justify-center rounded-md transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2'
+              toggleButton={<IoEllipsisVertical className='h-4 w-4' />}
+            >
+              <Menu className='dropdown-content no-triangle border-base-300 z-20 mt-1 min-w-[8rem] rounded-lg border shadow-lg'>
+                <MenuItem noIcon transient label={_('Edit')} onClick={() => onEdit(catalog)} />
+                <MenuItem
+                  noIcon
+                  transient
+                  label={_('Remove')}
+                  onClick={() => onRemove(catalog.id)}
+                />
+              </Menu>
+            </Dropdown>
+          </div>
+        </div>
+
+        {/* Description (optional) — single line in My Catalogs
+            to keep cards compact and consistent in height
+            regardless of description length. */}
+        {catalog.description && (
+          <p className='text-base-content/70 line-clamp-1 text-xs leading-relaxed'>
+            {catalog.description}
+          </p>
+        )}
+
+        {/* URL — quieter, mono-ish */}
+        <p className='text-base-content/55 truncate text-[11px]' title={catalog.url}>
+          {catalog.url}
+        </p>
+
+        {/* Auto-download row — label and toggle live in a SAME
+            flex line (items-center → vertically centered with
+            each other). Subline sits beneath as a sibling.
+            The subline always renders (with &nbsp; placeholder
+            when no status data) so the row's total height stays
+            constant — toggling AD on/off or sync-status data
+            arriving via opds-sync-complete never shifts the
+            card. Browse is the whole-card click; stopPropagation
+            on the label so toggling doesn't also browse. */}
+        <div className='mt-auto flex flex-col gap-0.5'>
+          <label
+            onClick={(e) => e.stopPropagation()}
+            className={clsx(
+              'flex items-center justify-between gap-2',
+              catalog.disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
+            )}
+          >
+            <span className='text-base-content/80 inline-flex items-center gap-1.5 text-xs'>
+              <IoCloudDownloadOutline className='h-3.5 w-3.5' />
+              {_('Auto-download')}
+            </span>
+            <input
+              type='checkbox'
+              className='toggle toggle-sm toggle-primary flex-shrink-0'
+              checked={!!catalog.autoDownload}
+              disabled={!!catalog.disabled}
+              onChange={() => onRequestToggleAutoDownload(catalog.id)}
+            />
+          </label>
+          <span className='text-base-content/55 truncate text-[11px] leading-tight'>
+            {showSubscriptionStatus ? (
+              <>
+                {lastCheckedAt > 0 && (
+                  <span>
+                    {_('Last synced {{when}}', {
+                      when: dayjs(lastCheckedAt).fromNow(),
+                    })}
+                  </span>
+                )}
+                {failedCount > 0 && (
+                  <>
+                    {lastCheckedAt > 0 && <span aria-hidden> · </span>}
+                    <button
+                      type='button'
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onShowFailed(catalog.id);
+                      }}
+                      className='text-error hover:underline'
+                    >
+                      {_('{{count}} failed', { count: failedCount })}
+                    </button>
+                  </>
+                )}
+              </>
+            ) : (
+              // &nbsp; reserves line-height so the row above
+              // stays anchored at a consistent vertical position.
+              <>&nbsp;</>
+            )}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 interface CatalogManagerProps {
   /**
    * When true, the panel title block (h1 + description) is hidden because
@@ -138,6 +372,20 @@ export function CatalogManager({ inSubPage = false }: CatalogManagerProps = {}) 
     Record<string, OPDSSubscriptionState>
   >({});
   const [failedDialogCatalogId, setFailedDialogCatalogId] = useState<string | null>(null);
+  // Auto-download is a one-tap trigger for a potentially huge download, and
+  // the toggle sits on a scrollable list — easy to hit by accident, worst of
+  // all on slow-refreshing e-ink screens (#5746). Flipping it from the list
+  // now only opens this confirmation; the switch itself never mutates.
+  const [confirmAutoDownloadId, setConfirmAutoDownloadId] = useState<string | null>(null);
+  const confirmAutoDownloadCatalog = confirmAutoDownloadId
+    ? catalogs.find((c) => c.id === confirmAutoDownloadId)
+    : undefined;
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
 
   const reloadSubscriptionStates = useCallback(async () => {
     if (!appService) return;
@@ -173,9 +421,11 @@ export function CatalogManager({ inSubPage = false }: CatalogManagerProps = {}) 
   }, [envConfig]);
 
   // Surface the latest store state into the local mirror used by
-  // subscriptions / dialog rendering. Filters out tombstones.
+  // subscriptions / dialog rendering. Goes through getAvailableCatalogs so
+  // the rendered order is the store's display order — drag-to-reorder stamps
+  // sortOrder against exactly this sequence, so the two must not diverge.
   useEffect(() => {
-    setCatalogs(allCatalogs.filter((c) => !c.deletedAt));
+    setCatalogs(useCustomOPDSStore.getState().getAvailableCatalogs());
   }, [allCatalogs]);
 
   // Persist via the store (settings + replica push), then update local
@@ -374,6 +624,17 @@ export function CatalogManager({ inSubPage = false }: CatalogManagerProps = {}) 
     }
   };
 
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const ids = catalogs.map((c) => c.id);
+    const from = ids.indexOf(String(active.id));
+    const to = ids.indexOf(String(over.id));
+    if (from < 0 || to < 0) return;
+    useCustomOPDSStore.getState().reorderCatalogs(arrayMove(ids, from, to));
+    persistMutation();
+  };
+
   const handleOpenCatalog = (catalog: OPDSCatalog) => {
     const params = new URLSearchParams({ url: catalog.url });
     params.set('id', catalog.id);
@@ -432,164 +693,31 @@ export function CatalogManager({ inSubPage = false }: CatalogManagerProps = {}) 
             </button>
           </div>
         ) : (
-          <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
-            {catalogs.map((catalog) => {
-              const subState = subscriptionStates[catalog.id];
-              const lastCheckedAt = subState?.lastCheckedAt ?? 0;
-              const failedCount = subState?.failedEntries.length ?? 0;
-              const showSubscriptionStatus =
-                catalog.autoDownload && subState && (lastCheckedAt > 0 || failedCount > 0);
-
-              return (
-                // Whole card is the browse trigger. Uses role='button' (not
-                // a real <button>) because it nests other interactive
-                // elements: the 3-dot menu, auto-download toggle, and
-                // failed-downloads link. Inner controls call
-                // e.stopPropagation() so their clicks don't bubble.
-                <div
-                  key={catalog.id}
-                  role='button'
-                  tabIndex={catalog.disabled ? -1 : 0}
-                  onClick={() => !catalog.disabled && handleOpenCatalog(catalog)}
-                  onKeyDown={(e) => {
-                    if (catalog.disabled) return;
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      handleOpenCatalog(catalog);
-                    }
-                  }}
-                  className={clsx(
-                    'card eink-bordered bg-base-100 border-base-200 group/card flex flex-col border transition-colors duration-150',
-                    'focus-visible:ring-base-content/15 focus-visible:outline-none focus-visible:ring-2',
-                    catalog.disabled
-                      ? 'cursor-not-allowed opacity-60'
-                      : 'hover:bg-base-300 cursor-pointer',
-                  )}
-                >
-                  <div className='flex flex-1 flex-col gap-2.5 px-4 pb-2 pt-4'>
-                    {/* Header: icon + name + chevron hint (whole card is
-                        the click target) | overflow menu (Edit / Remove). */}
-                    <div className='flex items-start justify-between gap-2'>
-                      <h4 className='flex min-w-0 flex-1 items-center gap-1.5 text-sm font-semibold'>
-                        {catalog.icon && <span className='flex-shrink-0'>{catalog.icon}</span>}
-                        <span className='truncate'>{catalog.name}</span>
-                      </h4>
-                      {/* stopPropagation on the trigger wrapper so opening
-                          the menu doesn't also browse the catalog.
-                          The Dropdown component itself handles floating the
-                          menu via daisyui's `.dropdown .dropdown-content`
-                          position:absolute rule — don't add !relative here
-                          or the menu inlines into the card layout. */}
-                      <div
-                        className='-mr-1.5 -mt-1 flex-shrink-0'
-                        onClick={(e) => e.stopPropagation()}
-                        onKeyDown={(e) => e.stopPropagation()}
-                      >
-                        <Dropdown
-                          label={_('Catalog actions')}
-                          className='dropdown-bottom dropdown-end'
-                          buttonClassName='text-base-content/55 hover:bg-base-200 hover:text-base-content focus-visible:ring-base-content/15 flex h-7 w-7 items-center justify-center rounded-md transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2'
-                          toggleButton={<IoEllipsisVertical className='h-4 w-4' />}
-                        >
-                          <Menu className='dropdown-content no-triangle border-base-300 z-20 mt-1 min-w-[8rem] rounded-lg border shadow-lg'>
-                            <MenuItem
-                              noIcon
-                              transient
-                              label={_('Edit')}
-                              onClick={() => handleEditCatalog(catalog)}
-                            />
-                            <MenuItem
-                              noIcon
-                              transient
-                              label={_('Remove')}
-                              onClick={() => handleRemoveCatalog(catalog.id)}
-                            />
-                          </Menu>
-                        </Dropdown>
-                      </div>
-                    </div>
-
-                    {/* Description (optional) — single line in My Catalogs
-                        to keep cards compact and consistent in height
-                        regardless of description length. */}
-                    {catalog.description && (
-                      <p className='text-base-content/70 line-clamp-1 text-xs leading-relaxed'>
-                        {catalog.description}
-                      </p>
-                    )}
-
-                    {/* URL — quieter, mono-ish */}
-                    <p className='text-base-content/55 truncate text-[11px]' title={catalog.url}>
-                      {catalog.url}
-                    </p>
-
-                    {/* Auto-download row — label and toggle live in a SAME
-                        flex line (items-center → vertically centered with
-                        each other). Subline sits beneath as a sibling.
-                        The subline always renders (with &nbsp; placeholder
-                        when no status data) so the row's total height stays
-                        constant — toggling AD on/off or sync-status data
-                        arriving via opds-sync-complete never shifts the
-                        card. Browse is the whole-card click; stopPropagation
-                        on the label so toggling doesn't also browse. */}
-                    <div className='mt-auto flex flex-col gap-0.5'>
-                      <label
-                        onClick={(e) => e.stopPropagation()}
-                        className={clsx(
-                          'flex items-center justify-between gap-2',
-                          catalog.disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
-                        )}
-                      >
-                        <span className='text-base-content/80 inline-flex items-center gap-1.5 text-xs'>
-                          <IoCloudDownloadOutline className='h-3.5 w-3.5' />
-                          {_('Auto-download')}
-                        </span>
-                        <input
-                          type='checkbox'
-                          className='toggle toggle-sm toggle-primary flex-shrink-0'
-                          checked={!!catalog.autoDownload}
-                          disabled={!!catalog.disabled}
-                          onChange={() => handleToggleAutoDownload(catalog.id)}
-                        />
-                      </label>
-                      <span className='text-base-content/55 truncate text-[11px] leading-tight'>
-                        {showSubscriptionStatus ? (
-                          <>
-                            {lastCheckedAt > 0 && (
-                              <span>
-                                {_('Last synced {{when}}', {
-                                  when: dayjs(lastCheckedAt).fromNow(),
-                                })}
-                              </span>
-                            )}
-                            {failedCount > 0 && (
-                              <>
-                                {lastCheckedAt > 0 && <span aria-hidden> · </span>}
-                                <button
-                                  type='button'
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    setFailedDialogCatalogId(catalog.id);
-                                  }}
-                                  className='text-error hover:underline'
-                                >
-                                  {_('{{count}} failed', { count: failedCount })}
-                                </button>
-                              </>
-                            )}
-                          </>
-                        ) : (
-                          // &nbsp; reserves line-height so the row above
-                          // stays anchored at a consistent vertical position.
-                          <>&nbsp;</>
-                        )}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            {/* rectSortingStrategy (not the vertical one) because this list is
+                a two-column grid from `sm:` up. */}
+            <SortableContext items={catalogs.map((c) => c.id)} strategy={rectSortingStrategy}>
+              <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+                {catalogs.map((catalog) => (
+                  <CatalogCard
+                    key={catalog.id}
+                    catalog={catalog}
+                    subState={subscriptionStates[catalog.id]}
+                    reorderable={catalogs.length > 1}
+                    onOpen={handleOpenCatalog}
+                    onEdit={handleEditCatalog}
+                    onRemove={handleRemoveCatalog}
+                    onRequestToggleAutoDownload={setConfirmAutoDownloadId}
+                    onShowFailed={setFailedDialogCatalogId}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
         )}
       </section>
 
@@ -878,6 +1006,38 @@ export function CatalogManager({ inSubPage = false }: CatalogManagerProps = {}) 
               </form>
             </div>
           </dialog>
+        </ModalPortal>
+      )}
+
+      {confirmAutoDownloadCatalog && (
+        <ModalPortal>
+          <Alert
+            title={
+              confirmAutoDownloadCatalog.autoDownload
+                ? _('Stop auto-downloading from “{{name}}”?', {
+                    name: confirmAutoDownloadCatalog.name,
+                  })
+                : _('Auto-download from “{{name}}”?', { name: confirmAutoDownloadCatalog.name })
+            }
+            message={
+              confirmAutoDownloadCatalog.autoDownload
+                ? _(
+                    'New publications from this catalog will no longer be downloaded automatically.',
+                  )
+                : _(
+                    'Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books.',
+                  )
+            }
+            confirmLabel={confirmAutoDownloadCatalog.autoDownload ? _('Turn Off') : _('Enable')}
+            confirmButtonClassName={
+              confirmAutoDownloadCatalog.autoDownload ? 'btn-contrast' : 'btn-warning'
+            }
+            onCancel={() => setConfirmAutoDownloadId(null)}
+            onConfirm={() => {
+              handleToggleAutoDownload(confirmAutoDownloadCatalog.id);
+              setConfirmAutoDownloadId(null);
+            }}
+          />
         </ModalPortal>
       )}
 

--- a/apps/readest-app/src/libs/replicaSchemas.ts
+++ b/apps/readest-app/src/libs/replicaSchemas.ts
@@ -62,6 +62,7 @@ const opdsCatalogFieldsSchema = z
     autoDownload: fieldEnvelopeSchema.optional(),
     disabled: fieldEnvelopeSchema.optional(),
     addedAt: fieldEnvelopeSchema.optional(),
+    sortOrder: fieldEnvelopeSchema.optional(),
     // Encrypted-credential fields. The CRDT envelope wraps a cipher
     // envelope as `v` when the publishing device had its CryptoSession
     // unlocked; otherwise the field is omitted from the row.

--- a/apps/readest-app/src/services/sync/adapters/opdsCatalog.ts
+++ b/apps/readest-app/src/services/sync/adapters/opdsCatalog.ts
@@ -16,6 +16,7 @@ interface UnwrappedOpdsFields {
   autoDownload?: boolean;
   disabled?: boolean;
   addedAt?: number;
+  sortOrder?: number;
   username?: string;
   password?: string;
 }
@@ -29,6 +30,7 @@ const unwrapOpdsFields = (fields: FieldsObject): UnwrappedOpdsFields => {
   const autoDownload = unwrap(fields['autoDownload']);
   const disabled = unwrap(fields['disabled']);
   const addedAt = unwrap(fields['addedAt']);
+  const sortOrder = unwrap(fields['sortOrder']);
   // Crypto middleware decrypted these in place before unpackRow ran
   // (see replicaCryptoMiddleware.decryptRowFields). A missing entry
   // means either the publishing device hadn't unlocked yet or the
@@ -48,6 +50,7 @@ const unwrapOpdsFields = (fields: FieldsObject): UnwrappedOpdsFields => {
     autoDownload: autoDownload === true ? true : undefined,
     disabled: disabled === true ? true : undefined,
     addedAt: typeof addedAt === 'number' ? addedAt : undefined,
+    sortOrder: typeof sortOrder === 'number' ? sortOrder : undefined,
     username: typeof username === 'string' ? username : undefined,
     password: typeof password === 'string' ? password : undefined,
   };
@@ -79,6 +82,7 @@ export const opdsCatalogAdapter: ReplicaAdapter<OPDSCatalog> = {
     if (catalog.customHeaders !== undefined) fields['customHeaders'] = catalog.customHeaders;
     if (catalog.autoDownload !== undefined) fields['autoDownload'] = catalog.autoDownload;
     if (catalog.disabled !== undefined) fields['disabled'] = catalog.disabled;
+    if (catalog.sortOrder !== undefined) fields['sortOrder'] = catalog.sortOrder;
     // Pass credentials as plaintext here — the publish-side crypto
     // middleware (replicaCryptoMiddleware.encryptPackedFields) wraps
     // them in cipher envelopes before they hit fields_jsonb. If the
@@ -103,6 +107,7 @@ export const opdsCatalogAdapter: ReplicaAdapter<OPDSCatalog> = {
       autoDownload: fields['autoDownload'] === true ? true : undefined,
       disabled: fields['disabled'] === true ? true : undefined,
       addedAt: fields['addedAt'] !== undefined ? Number(fields['addedAt']) : undefined,
+      sortOrder: fields['sortOrder'] !== undefined ? Number(fields['sortOrder']) : undefined,
       username: fields['username'] !== undefined ? String(fields['username']) : undefined,
       password: fields['password'] !== undefined ? String(fields['password']) : undefined,
     };
@@ -128,6 +133,7 @@ export const opdsCatalogAdapter: ReplicaAdapter<OPDSCatalog> = {
     if (fields.autoDownload !== undefined) catalog.autoDownload = fields.autoDownload;
     if (fields.disabled !== undefined) catalog.disabled = fields.disabled;
     if (fields.addedAt !== undefined) catalog.addedAt = fields.addedAt;
+    if (fields.sortOrder !== undefined) catalog.sortOrder = fields.sortOrder;
     if (fields.username !== undefined) catalog.username = fields.username;
     if (fields.password !== undefined) catalog.password = fields.password;
     if (row.reincarnation) catalog.reincarnation = row.reincarnation;

--- a/apps/readest-app/src/store/customOPDSStore.ts
+++ b/apps/readest-app/src/store/customOPDSStore.ts
@@ -45,11 +45,30 @@ const backfillSyncFields = (catalogs: OPDSCatalog[]): OPDSCatalog[] => {
   return mutated ? next : catalogs;
 };
 
+/**
+ * Display order for the catalog list. Entries the user has dragged carry an
+ * explicit `sortOrder`; everything else falls back to the legacy newest-first
+ * `addedAt` order and sorts *above* the stamped block, so adding a catalog to
+ * a hand-arranged list still surfaces it at the top.
+ */
+const compareForDisplay = (a: OPDSCatalog, b: OPDSCatalog): number => {
+  const ao = a.sortOrder;
+  const bo = b.sortOrder;
+  if (ao === undefined && bo === undefined) return (b.addedAt || 0) - (a.addedAt || 0);
+  if (ao === undefined) return -1;
+  if (bo === undefined) return 1;
+  return ao - bo;
+};
+
 interface OPDSStoreState {
   catalogs: OPDSCatalog[];
   loading: boolean;
 
-  /** Visible catalogs sorted by `addedAt` descending (newest first). */
+  /**
+   * Visible catalogs in display order: manually placed entries by ascending
+   * `sortOrder`, preceded by never-dragged ones in `addedAt`-descending
+   * (newest first) order.
+   */
   getAvailableCatalogs(): OPDSCatalog[];
   getCatalog(id: string): OPDSCatalog | undefined;
   /** Look up by URL — used for popular-catalog dedup (independent of contentId). */
@@ -73,6 +92,14 @@ interface OPDSStoreState {
   updateCatalog(id: string, patch: Partial<OPDSCatalog>): OPDSCatalog | undefined;
   /** Soft-delete by id; pushes a tombstone if the entry has a contentId. */
   removeCatalog(id: string): boolean;
+  /**
+   * Apply a manual display order. `orderedIds` leads; any visible catalog it
+   * omits keeps its relative position behind them, so the stamp always covers
+   * the whole visible list and no entry is left with a stale (or absent)
+   * `sortOrder` that would fling it back to the top. Publishes one upsert per
+   * stamped catalog so the order follows the user across devices.
+   */
+  reorderCatalogs(orderedIds: string[]): void;
 
   /**
    * Add a catalog received via replica sync from another device. Same
@@ -95,7 +122,7 @@ export const useCustomOPDSStore = create<OPDSStoreState>((set, get) => ({
   getAvailableCatalogs: () =>
     get()
       .catalogs.filter((c) => !c.deletedAt)
-      .sort((a, b) => (b.addedAt || 0) - (a.addedAt || 0)),
+      .sort(compareForDisplay),
 
   getCatalog: (id) => get().catalogs.find((c) => c.id === id),
 
@@ -170,6 +197,27 @@ export const useCustomOPDSStore = create<OPDSStoreState>((set, get) => ({
     }));
     if (catalog.contentId) publishOpdsDelete(catalog.contentId);
     return true;
+  },
+
+  reorderCatalogs: (orderedIds) => {
+    const visible = get().catalogs.filter((c) => !c.deletedAt);
+    const byId = new Map(visible.map((c) => [c.id, c]));
+    const leading = orderedIds.map((id) => byId.get(id)).filter((c): c is OPDSCatalog => !!c);
+    const leadingIds = new Set(leading.map((c) => c.id));
+    const trailing = visible.filter((c) => !leadingIds.has(c.id)).sort(compareForDisplay);
+    const nextOrder = new Map([...leading, ...trailing].map((c, i) => [c.id, i]));
+
+    const updated: OPDSCatalog[] = [];
+    const catalogs = get().catalogs.map((c) => {
+      const order = nextOrder.get(c.id);
+      if (order === undefined || c.sortOrder === order) return c;
+      const next = { ...c, sortOrder: order };
+      updated.push(next);
+      return next;
+    });
+    if (!updated.length) return;
+    set({ catalogs });
+    updated.forEach(publishOpdsUpsert);
   },
 
   applyRemoteCatalog: (catalog) => {

--- a/apps/readest-app/src/types/opds.ts
+++ b/apps/readest-app/src/types/opds.ts
@@ -40,6 +40,13 @@ export interface OPDSCatalog {
   contentId?: string;
   /** Wall-clock ms of first import, used for ordering. */
   addedAt?: number;
+  /**
+   * Manual display position, stamped 0..n-1 across the visible list every
+   * time the user drags a card. Absent until the first reorder — those
+   * entries keep the legacy `addedAt`-descending order and sort above the
+   * stamped ones, so a freshly added catalog still appears at the top.
+   */
+  sortOrder?: number;
   /** Soft-delete timestamp; non-null entries are hidden from the UI. */
   deletedAt?: number;
   /** Reincarnation token (re-import after server tombstone). */


### PR DESCRIPTION
Closes #5746.

The Auto-download switch sits on a scrollable card list, and flipping it on immediately starts downloading every publication in the catalog. On touch devices — worst of all on slow-refreshing e-ink screens — it is easy to hit by accident while scrolling, with no visual feedback in time to catch it. The reporter flipped it twice by mistake.

The issue proposed removing the toggle from the list entirely and leaving it only in the Edit dialog. This takes the alternative it also listed: keep the toggle where it is, but gate it behind a confirmation. It also adds manual reordering, since the list had no way to arrange catalogs at all.

Both surfaces named in the report — Settings → Integrations and Import Books → Online Library — render the same `CatalogManager`, so one change covers both.

## Confirmation before flipping Auto-download

Flipping the switch from the list no longer mutates anything; it opens a confirmation alert, and only the confirm applies the change. Cancelling leaves the switch exactly as it was.

Both directions are confirmed, with copy matched to the direction:

| | Title | Body | Confirm |
|---|---|---|---|
| Enable | Auto-download from “{name}”? | Readest will automatically download every new publication from this catalog when the app syncs. This may download a large number of books. | Enable (`btn-warning`) |
| Disable | Stop auto-downloading from “{name}”? | New publications from this catalog will no longer be downloaded automatically. | Turn Off (`btn-contrast`) |

The switch inside the Edit dialog is untouched — reaching it already takes a deliberate tap, which is the property the issue was asking for. The existing 5s `AUTO_DOWNLOAD_DEBOUNCE_MS` stays as a second chance after a confirmed enable; its comment now notes the dialog is the primary guard.

The alert renders in a `ModalPortal`, so it layers correctly above both the Settings dialog and the OPDS dialog.

## Drag to reorder

Each card gets a drag handle, following the `CustomDictionaries.tsx` precedent (`PointerSensor` distance 4, `TouchSensor` delay 200 / tolerance 5, `KeyboardSensor`). Two differences worth calling out:

- **`rectSortingStrategy`, not `verticalListSortingStrategy`** — this list is `grid-cols-1 sm:grid-cols-2`.
- **No `touch-target` on the handle.** That class inflates the hit area to 44px via a `::before`. Here it would bleed an invisible dead zone over the catalog name, and since the card body is itself the browse click target, taps there would silently do nothing. The handle is sized `h-7 w-7` to match the 3-dot trigger instead.

`stopPropagation` lives on a wrapper div rather than the handle button — a React `onKeyDown` on the button would replace dnd-kit's own from `{...listeners}` and kill keyboard dragging.

The order persists as a new `sortOrder?: number` on `OPDSCatalog`, carried by `opdsCatalogAdapter` (`pack` / `unpack` / `unpackRow`) and `opdsCatalogFieldsSchema`, so it follows the user across devices like the rest of the catalog record. `reorderCatalogs()` stamps `0..n-1` across the whole visible set and publishes one upsert per changed row. Catalogs that have never been dragged keep the legacy newest-first order and sort *above* the arranged block, so a freshly added catalog still lands on top.

## One behavior change worth flagging

`getAvailableCatalogs()`'s documented newest-first sort was effectively dead code. It only seeded `useState`, which runs while the store is still empty (`loadCustomOPDSCatalogs` runs in an effect), and the effect that followed replaced it with raw unsorted store order. So the live order has always been the persisted array order, and the list quietly re-sorted itself on first paint before settling back.

Drag can't stamp positions against an order the user never sees, so the list mirror now routes through `getAvailableCatalogs()`. **Existing lists reshuffle once to newest-first on upgrade**; any drag pins the order permanently after that.

If that one-time reshuffle isn't wanted, the alternative is having the unstamped fallback preserve array order instead of `addedAt` — a one-line change to `compareForDisplay` plus two test expectations.

## Testing

Failing tests first, per the repo's test-first rule — the five new behavior tests failed for the right reasons (missing dialog, missing handle) before the implementation landed.

- `custom-opds-store.test.ts` — display ordering (stamped vs unstamped vs legacy, tombstones excluded) and `reorderCatalogs` (stamps `0..n-1`, publishes per row, ignores unknown ids, skips tombstoned entries).
- `opdsCatalog.test.ts` — `sortOrder` round-trips through `pack`/`unpack`/`unpackRow`, including `sortOrder: 0` (guards against a truthiness check swallowing the first slot) and omission for never-dragged catalogs.
- `catalog-manager.test.tsx` (new) — the toggle does not mutate and shows the alert; confirming applies it and schedules the debounced sync; cancelling leaves it untouched and dispatches nothing; the disable direction gets its own copy; drag handles render only when there is more than one catalog.

jsdom can't simulate a dnd-kit drag, so the reorder logic lives in the store where it is directly testable; the component test only asserts the handle renders — same shape as `ProofreadRules.test.tsx`.

`pnpm test` 9393 passed / 16 skipped. `pnpm lint` and `pnpm format:check` clean. No Rust or Lua touched.

## Manual verification

Checked in the web app against this branch:

- Confirm dialog layers correctly above the OPDS modal; Cancel left all three catalogs' toggles off and dispatched no sync.
- A drag reorder moved `[ManyBooks, Standard, Gutenberg]` → `[Standard, Gutenberg, ManyBooks]`, and survived a full reload with `sortOrder` persisted as 0/1/2 while `addedAt` ran the opposite way — confirming `sortOrder` wins.
- A single catalog renders no drag handle.

## i18n

Four new keys, translated into all 33 locales. `Drag to reorder`, `Enable`, and `Turn Off` already existed everywhere and are reused. The extractor wanted to add ~50 unrelated pending keys and prune one, so locales were reverted and only the four new keys appended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorder catalog entries using drag-and-drop, touch, or keyboard controls.
  * Catalog ordering is saved and synchronized across devices.
  * Confirmation prompts now appear when enabling or disabling automatic catalog downloads.
  * Added localized messages for automatic download settings across supported languages.

* **Tests**
  * Added coverage for catalog ordering, synchronization, drag handles, and download confirmation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->