### PR TITLE
fix(cbz): order split chapter folders base-first

### DIFF
--- a/apps/readest-app/src/__tests__/foliate-cbz-page-order.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-cbz-page-order.test.ts
@@ -1,0 +1,50 @@
+// Regression test for #5745: a CBZ chapter split across folders that share a
+// chapter number — `Chapter 0060/` and `Chapter 0060 (2)/` — rendered part 2
+// before part 1. The image paths were flattened and sorted as plain strings,
+// and a space (0x20) sorts before a slash (0x2F), so
+// `Chapter 0060 (2)/001.jpg` < `Chapter 0060/001.jpg`. Pages must instead be
+// ordered per path segment so a folder that is a prefix of a sibling folder
+// sorts first, with numeric-aware comparison inside each segment.
+import { describe, expect, it } from 'vitest';
+
+import { makeComicBook } from 'foliate-js/comic-book.js';
+
+const makeLoader = (filenames: string[]) => ({
+  entries: filenames.map((filename) => ({ filename })),
+  loadBlob: async () => new Blob(['x'], { type: 'image/jpeg' }),
+  getSize: () => 1,
+  getComment: async () => '',
+});
+
+const pageOrder = async (filenames: string[]): Promise<string[]> => {
+  const book = await makeComicBook(makeLoader(filenames), new File([], 'test.cbz'));
+  return book.sections.map((section: { id: string }) => section.id);
+};
+
+describe('CBZ page order (#5745)', () => {
+  it('orders split chapter folders base-first, then (2), (3), (10)', async () => {
+    const order = await pageOrder([
+      'Chapter 0060 (10)/001.jpg',
+      'Chapter 0060 (2)/001.jpg',
+      'Chapter 0060 (2)/002.jpg',
+      'Chapter 0060 (3)/001.jpg',
+      'Chapter 0060/001.jpg',
+      'Chapter 0060/002.jpg',
+      'Chapter 0061/001.jpg',
+    ]);
+    expect(order).toEqual([
+      'Chapter 0060/001.jpg',
+      'Chapter 0060/002.jpg',
+      'Chapter 0060 (2)/001.jpg',
+      'Chapter 0060 (2)/002.jpg',
+      'Chapter 0060 (3)/001.jpg',
+      'Chapter 0060 (10)/001.jpg',
+      'Chapter 0061/001.jpg',
+    ]);
+  });
+
+  it('orders unpadded numeric page names numerically within a folder', async () => {
+    const order = await pageOrder(['Chapter 0059/10.jpg', 'Chapter 0059/2.jpg']);
+    expect(order).toEqual(['Chapter 0059/2.jpg', 'Chapter 0059/10.jpg']);
+  });
+});


### PR DESCRIPTION
## Problem

A CBZ chapter split across folders that share a chapter number, such as `Chapter 0060/` and `Chapter 0060 (2)/`, rendered part 2 before part 1. The comic-book loader flattens image paths into one list and sorted them as plain strings; a space (0x20) sorts before a slash (0x2F), so `Chapter 0060 (2)/001.jpg` compared less than `Chapter 0060/001.jpg`.

Fixes #5745

## Fix

Bumps `packages/foliate-js` to latest main, which includes readest/foliate-js#79: compare paths segment by segment with a numeric collator, with the shorter path winning at divergence, so a folder that is a prefix of a sibling sorts first. Numeric collation also keeps unpadded page names in order (`2.jpg` before `10.jpg`). Upstream's whole-path numeric-collator sort does not fix the split-folder case; only the per-segment compare does.

The bump also picks up readest/foliate-js#66 (prefer the issued publication date in OPDS metadata).

## Behavior note

Page order changes for affected CBZ files, so stored reading positions inside such books can shift by one part after the update; that is inherent to fixing the order.

## Tests

- New regression test `src/__tests__/foliate-cbz-page-order.test.ts` covering the reported split layout (base, `(2)`, `(3)`, `(10)`) and unpadded numeric page names; it fails against the old sort and passes with the fix.
- Full unit suite green via the pre-push hook: 9395 passed, 16 skipped.
- `pnpm lint` and `pnpm format:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comic book page ordering so split chapters and numeric page filenames appear in the expected sequence.

* **Tests**
  * Added regression coverage to help ensure consistent CBZ page ordering across supported reading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->