### PR TITLE
fix(opds): drop the webview Origin header on native requests

### DIFF
--- a/apps/readest-app/src/__tests__/utils/opds-req.test.ts
+++ b/apps/readest-app/src/__tests__/utils/opds-req.test.ts
@@ -234,6 +234,16 @@ describe('opdsReq', () => {
       expect(res.status).toBe(200);
     });
 
+    it('does not add an Origin header to web-platform requests', async () => {
+      fetchMock.mockResolvedValue(makeResponse({ status: 200, body: '<feed/>' }));
+
+      await fetchWithAuth('https://komga.example.com/opds/v2/catalog', 'alice', 's3cret', true);
+
+      const init = fetchMock.mock.calls[0]![1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect('Origin' in headers).toBe(false);
+    });
+
     it('retries with Digest auth when the server issues a Digest challenge', async () => {
       fetchMock
         .mockResolvedValueOnce(
@@ -251,6 +261,77 @@ describe('opdsReq', () => {
       const headers = init.headers as Record<string, string>;
       expect(headers['Authorization']).toMatch(/^Digest /);
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Origin header suppression on Tauri (#5698)', () => {
+    // tauri-plugin-http appends the webview origin (`tauri://localhost`) as
+    // the Origin header of every request unless the caller sets one.
+    // Spring-based servers such as Komga treat it as a foreign CORS origin
+    // and reject the request with 403 "Invalid CORS request" before
+    // authentication ever happens. An explicit empty Origin makes the plugin
+    // (built with `unsafe-headers`) drop the header entirely.
+    let fetchWithAuth: typeof import('@/app/opds/utils/opdsReq').fetchWithAuth;
+    let probeAuth: typeof import('@/app/opds/utils/opdsReq').probeAuth;
+    let isTauriAppPlatform: ReturnType<typeof vi.fn>;
+    let tauriFetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      const envModule = await import('@/services/environment');
+      isTauriAppPlatform = envModule.isTauriAppPlatform as ReturnType<typeof vi.fn>;
+      isTauriAppPlatform.mockReturnValue(true);
+      // The mock registry is not cleared by vi.resetModules(), so the plugin
+      // fetch mock and its call history persist across tests unless reset.
+      const pluginHttp = await import('@tauri-apps/plugin-http');
+      tauriFetchMock = pluginHttp.fetch as ReturnType<typeof vi.fn>;
+      tauriFetchMock.mockReset();
+      const opdsReq = await import('@/app/opds/utils/opdsReq');
+      fetchWithAuth = opdsReq.fetchWithAuth;
+      probeAuth = opdsReq.probeAuth;
+    });
+
+    afterEach(() => {
+      tauriFetchMock.mockReset();
+      isTauriAppPlatform.mockReturnValue(false);
+    });
+
+    it('suppresses the webview Origin header on fetchWithAuth requests', async () => {
+      tauriFetchMock.mockResolvedValue(makeResponse({ status: 200, body: '<feed/>' }));
+
+      await fetchWithAuth('https://komga.example.com/opds/v2/catalog', 'alice', 's3cret', false);
+
+      expect(tauriFetchMock).toHaveBeenCalledTimes(1);
+      const init = tauriFetchMock.mock.calls[0]![1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers['Origin']).toBe('');
+    });
+
+    it('lets a user-defined custom Origin header win over the suppression marker', async () => {
+      tauriFetchMock.mockResolvedValue(makeResponse({ status: 200, body: '<feed/>' }));
+
+      await fetchWithAuth(
+        'https://komga.example.com/opds/v2/catalog',
+        'alice',
+        's3cret',
+        false,
+        {},
+        { Origin: 'https://allowed.example.com' },
+      );
+
+      const init = tauriFetchMock.mock.calls[0]![1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers['Origin']).toBe('https://allowed.example.com');
+    });
+
+    it('suppresses the webview Origin header on the HEAD probe', async () => {
+      tauriFetchMock.mockResolvedValue(makeResponse({ status: 200 }));
+
+      await probeAuth('https://komga.example.com/opds/v2/catalog', 'alice', 's3cret', false);
+
+      expect(tauriFetchMock).toHaveBeenCalledTimes(1);
+      const init = tauriFetchMock.mock.calls[0]![1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers['Origin']).toBe('');
     });
   });
 });

--- a/apps/readest-app/src/__tests__/utils/opds-req.test.ts
+++ b/apps/readest-app/src/__tests__/utils/opds-req.test.ts
@@ -323,6 +323,31 @@ describe('opdsReq', () => {
       expect(headers['Origin']).toBe('https://allowed.example.com');
     });
 
+    it('lets a lowercase custom origin header win without colliding with the marker', async () => {
+      // Header names are case-insensitive on the wire but not in a JS object,
+      // and `normalizeCustomHeaders` preserves whatever the user typed. A
+      // `{ Origin: '' }` marker spread alongside a custom `origin` would leave
+      // both keys in place, and the plugin's `new Headers()` merges the pair
+      // into `", https://allowed.example.com"` — not empty, so the plugin never
+      // drops it, and not a valid Origin either, so the catalog still 403s.
+      tauriFetchMock.mockResolvedValue(makeResponse({ status: 200, body: '<feed/>' }));
+
+      await fetchWithAuth(
+        'https://komga.example.com/opds/v2/catalog',
+        'alice',
+        's3cret',
+        false,
+        {},
+        { origin: 'https://allowed.example.com' },
+      );
+
+      const init = tauriFetchMock.mock.calls[0]![1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      // Assert through Headers, which is what the plugin builds internally, so
+      // a reintroduced duplicate key fails here instead of silently on device.
+      expect(new Headers(headers).get('origin')).toBe('https://allowed.example.com');
+    });
+
     it('suppresses the webview Origin header on the HEAD probe', async () => {
       tauriFetchMock.mockResolvedValue(makeResponse({ status: 200 }));
 

--- a/apps/readest-app/src/app/opds/utils/opdsReq.ts
+++ b/apps/readest-app/src/app/opds/utils/opdsReq.ts
@@ -47,17 +47,28 @@ export const needsProxy = (url: string): boolean => {
 };
 
 /**
- * tauri-plugin-http appends the webview origin (e.g. `tauri://localhost`) as
- * the Origin header of every request unless the caller sets one. Spring-based
- * servers such as Komga treat it as a foreign CORS origin and reject the
- * request with 403 "Invalid CORS request" before authentication ever happens
- * (#5698). An explicit empty Origin instructs the plugin (built with the
- * `unsafe-headers` feature) to drop the header entirely, matching what native
- * OPDS clients send. Spread it before custom headers so a user-defined Origin
- * still wins.
+ * tauri-plugin-http appends the webview origin (`tauri://localhost`, or
+ * `http://tauri.localhost` on Android/Windows) as the Origin header of every
+ * request unless the caller sets one. A native client has no business
+ * asserting a browser origin, and any Origin-checking middlebox in front of
+ * the catalog rejects the unrecognized value with 403 before authentication
+ * ever happens: in #5698 the nginx reverse proxy in front of Komga answered
+ * 403 and Komga itself logged no request at all. An explicit empty Origin
+ * instructs the plugin (built with the `unsafe-headers` feature, see
+ * `src-tauri/Cargo.toml`) to drop the header entirely, matching what native
+ * OPDS clients send.
+ *
+ * Applied to the assembled header set rather than spread ahead of it, because
+ * header names are case-insensitive on the wire but not in a JS object: a
+ * custom header spelled `origin` would survive alongside `Origin` as a second
+ * key, and the plugin's `new Headers()` merges the pair into `", https://..."`
+ * — which is neither empty (so the plugin keeps it) nor a valid Origin. The
+ * case-insensitive check keeps a user-defined Origin of any spelling intact.
  */
-export const omitOriginHeader = (): Record<string, string> =>
-  isTauriAppPlatform() ? { Origin: '' } : {};
+export const withOriginSuppressed = (headers: Record<string, string>): Record<string, string> =>
+  isTauriAppPlatform() && !Object.keys(headers).some((key) => key.toLowerCase() === 'origin')
+    ? { Origin: '', ...headers }
+    : headers;
 
 const PROXY_OVERRIDES: Record<string, string> = {
   standardebooks: NODE_OPDS_PROXY_URL,
@@ -238,12 +249,11 @@ export const probeAuth = async (
   const fetchURL = useProxy
     ? getProxiedURL(cleanUrl, '', false, normalizedCustomHeaders)
     : cleanUrl;
-  const headers: Record<string, string> = {
+  const headers: Record<string, string> = withOriginSuppressed({
     'User-Agent': READEST_OPDS_USER_AGENT,
     Accept: 'application/atom+xml, application/xml, text/xml, */*',
-    ...omitOriginHeader(),
     ...(!useProxy ? normalizedCustomHeaders : {}),
-  };
+  });
 
   // Probe with HEAD request
   const fetch = isTauriAppPlatform() ? tauriFetch : window.fetch;
@@ -356,13 +366,12 @@ export const fetchWithAuth = async (
   const fetchURL = useProxy
     ? getProxiedURL(cleanUrl, preemptiveAuth || '', false, normalizedCustomHeaders)
     : cleanUrl;
-  const baseHeaders: Record<string, string> = {
+  const baseHeaders: Record<string, string> = withOriginSuppressed({
     'User-Agent': READEST_OPDS_USER_AGENT,
     Accept: 'application/atom+xml, application/xml, text/xml, */*',
-    ...omitOriginHeader(),
     ...(!useProxy ? normalizedCustomHeaders : {}),
     ...(options.headers as Record<string, string>),
-  };
+  });
   const headers: Record<string, string> = {
     ...baseHeaders,
     ...(preemptiveAuth && !useProxy ? { Authorization: preemptiveAuth } : {}),

--- a/apps/readest-app/src/app/opds/utils/opdsReq.ts
+++ b/apps/readest-app/src/app/opds/utils/opdsReq.ts
@@ -46,6 +46,19 @@ export const needsProxy = (url: string): boolean => {
   return isWebAppPlatform() && url.startsWith('http');
 };
 
+/**
+ * tauri-plugin-http appends the webview origin (e.g. `tauri://localhost`) as
+ * the Origin header of every request unless the caller sets one. Spring-based
+ * servers such as Komga treat it as a foreign CORS origin and reject the
+ * request with 403 "Invalid CORS request" before authentication ever happens
+ * (#5698). An explicit empty Origin instructs the plugin (built with the
+ * `unsafe-headers` feature) to drop the header entirely, matching what native
+ * OPDS clients send. Spread it before custom headers so a user-defined Origin
+ * still wins.
+ */
+export const omitOriginHeader = (): Record<string, string> =>
+  isTauriAppPlatform() ? { Origin: '' } : {};
+
 const PROXY_OVERRIDES: Record<string, string> = {
   standardebooks: NODE_OPDS_PROXY_URL,
 };
@@ -228,6 +241,7 @@ export const probeAuth = async (
   const headers: Record<string, string> = {
     'User-Agent': READEST_OPDS_USER_AGENT,
     Accept: 'application/atom+xml, application/xml, text/xml, */*',
+    ...omitOriginHeader(),
     ...(!useProxy ? normalizedCustomHeaders : {}),
   };
 
@@ -345,6 +359,7 @@ export const fetchWithAuth = async (
   const baseHeaders: Record<string, string> = {
     'User-Agent': READEST_OPDS_USER_AGENT,
     Accept: 'application/atom+xml, application/xml, text/xml, */*',
+    ...omitOriginHeader(),
     ...(!useProxy ? normalizedCustomHeaders : {}),
     ...(options.headers as Record<string, string>),
   };

--- a/apps/readest-app/src/services/opds/pseStream.ts
+++ b/apps/readest-app/src/services/opds/pseStream.ts
@@ -2,7 +2,12 @@ import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import { isTauriAppPlatform } from '@/services/environment';
 import { READEST_OPDS_USER_AGENT } from '@/services/constants';
 import { useSettingsStore } from '@/store/settingsStore';
-import { needsProxy, getProxiedURL, omitOriginHeader, probeAuth } from '@/app/opds/utils/opdsReq';
+import {
+  needsProxy,
+  getProxiedURL,
+  probeAuth,
+  withOriginSuppressed,
+} from '@/app/opds/utils/opdsReq';
 import { normalizeCustomHeaders } from '@/utils/customHeaders';
 import type { BookFormat } from '@/types/book';
 import type { BookDoc, BookMetadata } from '@/libs/document';
@@ -51,12 +56,11 @@ export const createPseStreamPageLoader = (data: PseStreamData) => {
     const authHeader = await authHeaderPromise;
 
     const fetchURL = useProxy ? getProxiedURL(url, authHeader || '', true, customHeaders) : url;
-    const headers: Record<string, string> = {
+    const headers: Record<string, string> = withOriginSuppressed({
       'User-Agent': READEST_OPDS_USER_AGENT,
-      ...omitOriginHeader(),
       ...(!useProxy ? customHeaders : {}),
       ...(!useProxy && authHeader ? { Authorization: authHeader } : {}),
-    };
+    });
     const fetch = isTauriAppPlatform() ? tauriFetch : window.fetch;
     const res = await fetch(fetchURL, {
       headers,

--- a/apps/readest-app/src/services/opds/pseStream.ts
+++ b/apps/readest-app/src/services/opds/pseStream.ts
@@ -2,7 +2,7 @@ import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import { isTauriAppPlatform } from '@/services/environment';
 import { READEST_OPDS_USER_AGENT } from '@/services/constants';
 import { useSettingsStore } from '@/store/settingsStore';
-import { needsProxy, getProxiedURL, probeAuth } from '@/app/opds/utils/opdsReq';
+import { needsProxy, getProxiedURL, omitOriginHeader, probeAuth } from '@/app/opds/utils/opdsReq';
 import { normalizeCustomHeaders } from '@/utils/customHeaders';
 import type { BookFormat } from '@/types/book';
 import type { BookDoc, BookMetadata } from '@/libs/document';
@@ -53,6 +53,7 @@ export const createPseStreamPageLoader = (data: PseStreamData) => {
     const fetchURL = useProxy ? getProxiedURL(url, authHeader || '', true, customHeaders) : url;
     const headers: Record<string, string> = {
       'User-Agent': READEST_OPDS_USER_AGENT,
+      ...omitOriginHeader(),
       ...(!useProxy ? customHeaders : {}),
       ...(!useProxy && authHeader ? { Authorization: authHeader } : {}),
     };


### PR DESCRIPTION
Remove CORS origin for OPDS requests as this causes problem for Komga w/ HTTPS. It's always CORS, the most cursed dark magic of the HTTP.

Fixes #5698, which was wrongfully closed since @chrox was testing on local, non-HTTPS environment which can't reproduce this issue. Reproduction of the issue REQUIRES HTTPS setup as it stems from CORS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OPDS requests to prevent unwanted `Origin` headers on supported platforms.
  * Preserved explicitly configured custom `Origin` headers.
  * Applied consistent header handling to authentication checks and streamed OPDS pages.

* **Tests**
  * Added coverage for platform-specific, custom-header, and authentication probe scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->