### PR TITLE
fix(tts): allow chapters sharing sentences with earlier packs to download

### DIFF
--- a/apps/readest-app/src/__tests__/services/tts-book-cache-store.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-book-cache-store.test.ts
@@ -19,6 +19,11 @@ const packState = vi.hoisted(() => {
         if (!data) throw new Error('missing pack');
         return data.slice(offset, offset + length).buffer as ArrayBuffer;
       }),
+      readSidecar: vi.fn(async (name: string) => {
+        const data = files.get(name);
+        if (!data) return null;
+        return JSON.parse(new TextDecoder().decode(data));
+      }),
       remove: vi.fn(async (name: string) => {
         files.delete(name);
       }),

--- a/apps/readest-app/src/__tests__/services/tts-downloader.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-downloader.test.ts
@@ -90,6 +90,10 @@ describe('TTSDownloader', () => {
     // All three were attempted; two succeeded.
     expect(warmer.warmed).toHaveLength(3);
     expect(result.synthesized).toBe(2);
+    // A section with a failed sentence is reported skipped, not completed: the
+    // manifest gap means it has not fully downloaded.
+    expect(result.completed).toEqual([]);
+    expect(result.skipped).toEqual([0]);
     // A section with a failed sentence is still compacted (the pack simply
     // won't form until the gap fills), so a later retry can complete it.
     expect(warmer.compacts).toBe(1);

--- a/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
@@ -28,6 +28,11 @@ class FakePackFs implements TTSPackFs {
     if (!data) throw new Error(`ENOENT: ${name}`);
     return data.slice(offset, offset + length).buffer as ArrayBuffer;
   }
+  async readSidecar(name: string): Promise<TTSPackSidecar | null> {
+    const data = this.files.get(name);
+    if (!data) return null;
+    return JSON.parse(new TextDecoder().decode(data)) as TTSPackSidecar;
+  }
   async remove(name: string): Promise<void> {
     this.files.delete(name);
   }
@@ -244,6 +249,147 @@ describe('SqliteTTSCacheStore pack compaction', () => {
     expect(await tight.get('k1')).toBeNull();
     expect(await tight.get('k3')).not.toBeNull();
     expect(await tight.get('k4')).not.toBeNull();
+  });
+
+  test('a shared key survives a later non-owning pack being evicted', async () => {
+    // Section A pinned: packs k1 + k2 into packA, completed to durable.
+    await store.beginDownloadSections([1]);
+    await cacheSection(1, ['m1', 'm2'], ['k1', 'k2']);
+    await store.compact();
+    await store.completeDownloadSections([1]);
+
+    // Section B unpinned: packs k1 (cache hit, shared) + k3 into packB. The
+    // shared k1 row is repointed to packB by #adoptPack.
+    await store.registerSectionMarks(2, ['mB1', 'mB2']);
+    await store.put('k3', sentence(3));
+    await store.recordMarkKey(2, 0, 'k1');
+    await store.recordMarkKey(2, 1, 'k3');
+    await store.compact();
+    expect((await packFs.list()).filter((n) => n.endsWith('.mp3'))).toHaveLength(2);
+
+    // Force eviction of the unpinned packB.
+    const tight = new SqliteTTSCacheStore(db, {
+      budgetBytes: 100,
+      now: () => clock.t++,
+      packFs,
+    });
+    await tight.put('oversize', sentence(9, 80));
+
+    // k1 was transferred to packA, so its audio is still readable offline.
+    expect(await store.get('k1')).not.toBeNull();
+    // k3 had no surviving pack -> NULL/NULL fallback (bounded recovery).
+    expect(await store.get('k3')).toBeNull();
+    // The pinned section is still packed and pinned.
+    expect((await store.getSectionStatuses()).get(1)).toMatchObject({
+      packed: true,
+      pinned: true,
+    });
+  });
+
+  test('a stale pack of a pinned section is evictable after a manifest rebuild', async () => {
+    // v1 manifest + pack for section 1.
+    await store.registerSectionMarks(1, ['m1', 'm2']);
+    await store.put('k1', sentence(1));
+    await store.recordMarkKey(1, 0, 'k1');
+    await store.put('k2', sentence(2));
+    await store.recordMarkKey(1, 1, 'k2');
+    await store.compact();
+    expect((await packFs.list()).filter((n) => n.endsWith('.mp3'))).toHaveLength(1);
+
+    // Rebuild the manifest to v2, pack v2 (v1 pack is now stale).
+    await store.registerSectionMarks(1, ['m1', 'm2', 'm3']);
+    await store.put('k3', sentence(3));
+    await store.recordMarkKey(1, 2, 'k3');
+    await store.compact();
+    expect((await packFs.list()).filter((n) => n.endsWith('.mp3'))).toHaveLength(2);
+
+    // Pin section 1 and mark it complete.
+    await store.beginDownloadSections([1]);
+    await store.completeDownloadSections([1]);
+
+    // Force eviction: the stale v1 pack must be evictable despite the pin.
+    const tight = new SqliteTTSCacheStore(db, {
+      budgetBytes: 100,
+      now: () => clock.t++,
+      packFs,
+    });
+    await tight.put('oversize', sentence(9, 80));
+
+    const surviving = (await packFs.list()).filter((n) => n.endsWith('.mp3'));
+    expect(surviving).toHaveLength(1);
+    expect((await store.getSectionStatuses()).get(1)).toMatchObject({
+      packed: true,
+      pinned: true,
+    });
+  });
+
+  test('a corrupted pack file self-heals by transferring shared keys, not destroying them', async () => {
+    // Same shared-key fixture as the transfer test.
+    await store.beginDownloadSections([1]);
+    await cacheSection(1, ['m1', 'm2'], ['k1', 'k2']);
+    await store.compact();
+    await store.completeDownloadSections([1]);
+    await store.registerSectionMarks(2, ['mB1', 'mB2']);
+    await store.put('k3', sentence(3));
+    await store.recordMarkKey(2, 0, 'k1');
+    await store.recordMarkKey(2, 1, 'k3');
+    await store.compact();
+
+    // Corrupt packB's MP3 (keep its sidecar so offsets stay readable).
+    const pack2Name = (await packFs.list()).find((n) => n.includes('2-') && n.endsWith('.mp3'))!;
+    packFs.files.delete(pack2Name);
+
+    // Self-heal transfers k1 to packA, NULL-falls-back k3.
+    expect(await store.get('k1')).not.toBeNull();
+    expect(await store.get('k3')).toBeNull();
+    expect((await store.getSectionStatuses()).get(1)).toMatchObject({
+      packed: true,
+      pinned: true,
+    });
+  });
+
+  test('an imported pack for a pinned section survives eviction (imported-% special-case)', async () => {
+    // Build a pack on another store and import it here under an 'imported-...'
+    // fingerprint that never matches the local manifest's.
+    const otherDb = await NodeDatabaseService.open(':memory:');
+    const otherFs = new FakePackFs();
+    const other = new SqliteTTSCacheStore(otherDb, {
+      budgetBytes: 1024 * 1024,
+      now: () => clock.t++,
+      packFs: otherFs,
+    });
+    await other.registerSectionMarks(1, ['m1', 'm2']);
+    await other.put('k1', sentence(1));
+    await other.recordMarkKey(1, 0, 'k1');
+    await other.put('k2', sentence(2));
+    await other.recordMarkKey(1, 1, 'k2');
+    await other.compact();
+    const otherName = (await otherFs.list()).find((n) => n.endsWith('.mp3'))!;
+    const otherSidecar = JSON.parse(
+      new TextDecoder().decode(otherFs.files.get(packSidecarName(otherName))!),
+    ) as TTSPackSidecar;
+    const otherBytes = otherFs.files.get(otherName)!.slice().buffer as ArrayBuffer;
+
+    // Import into the pinned section's store.
+    await store.registerSectionMarks(1, ['m1', 'm2']);
+    expect(await store.importPack(otherBytes, otherSidecar)).toBe(true);
+    await store.beginDownloadSections([1]);
+    await store.completeDownloadSections([1]);
+
+    // Force eviction: the imported pack must survive despite fingerprint mismatch.
+    const tight = new SqliteTTSCacheStore(db, {
+      budgetBytes: 100,
+      now: () => clock.t++,
+      packFs,
+    });
+    await tight.put('oversize', sentence(9, 80));
+
+    const surviving = (await packFs.list()).filter((n) => n.endsWith('.mp3'));
+    expect(surviving.length).toBeGreaterThanOrEqual(1);
+    expect((await store.getSectionStatuses()).get(1)).toMatchObject({
+      packed: true,
+      pinned: true,
+    });
   });
 
   test('an explicit download can exceed the cache budget and its pack is never evicted', async () => {

--- a/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
@@ -83,6 +83,42 @@ describe('SqliteTTSCacheStore pack compaction', () => {
     expect(bytes[80]).toBe(3);
   });
 
+  test('a section sharing a sentence key with an already-packed section still packs (regression)', async () => {
+    // Section A packs first, adopting the shared key k1 into its pack. From
+    // then on k1's entry is pack-backed (audio NULL pointing at pack A).
+    await cacheSection(4, ['mA1', 'mA2'], ['k1', 'k2']);
+    expect(await store.compact()).toBe(1);
+    expect((await store.getSectionStatuses()).get(4)?.packed).toBe(true);
+
+    // Section B repeats k1 (a cache hit during a download, so no loose row is
+    // written) plus a fresh k3. The old completable check rejected B because
+    // k1's entry has audio NULL, so B could never pack and its chapter failed
+    // forever, even though every sentence was cached.
+    await store.registerSectionMarks(5, ['mB1', 'mB2']);
+    await store.put('k3', sentence(3));
+    await store.recordMarkKey(5, 0, 'k1');
+    await store.recordMarkKey(5, 1, 'k3');
+    expect(await store.compact()).toBe(1);
+    expect((await store.getSectionStatuses()).get(5)?.packed).toBe(true);
+
+    const packNames = (await packFs.list()).filter((n) => n.endsWith('.mp3'));
+    expect(packNames).toHaveLength(2);
+    // The shared sentence is still readable after B's pack adopted the key.
+    expect(await store.get('k1')).not.toBeNull();
+    expect(await store.get('k3')).not.toBeNull();
+  });
+
+  test('an empty-manifest section that packed is reported as packed (regression)', async () => {
+    // Cover / blank / symbol-only sections have zero recordable sentences, but
+    // still pack an (empty) pack and must be reported as packed — otherwise a
+    // "Download all" for a book with such a chapter fails forever.
+    await store.registerSectionMarks(6, []);
+    expect(await store.compact()).toBe(1);
+    expect(await store.getSectionStatuses()).toEqual(
+      new Map([[6, { total: 0, recorded: 0, packed: true, pinned: false, active: false }]]),
+    );
+  });
+
   test('packed entries read back through range reads, byte for byte', async () => {
     await cacheSection(3, ['m1', 'm2'], ['k1', 'k2']);
     await store.compact();

--- a/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { md5 } from 'js-md5';
 import { NodeDatabaseService } from '@/services/database/nodeDatabaseService';
+import { chapterDownloadStatus } from '@/services/tts/downloadChapters';
 import {
   SqliteTTSCacheStore,
   TTSPackFs,
@@ -501,6 +502,84 @@ describe('SqliteTTSCacheStore pack compaction', () => {
     expect(await store.get('k2')).toBeNull();
     expect(await store.get('warm')).not.toBeNull();
     expect((await packFs.list()).filter((name) => name.endsWith('.mp3'))).toHaveLength(0);
+  });
+
+  test('clearDownloads fully removes downloaded chapters sharing sentences with a warm section (regression)', async () => {
+    // Two downloaded chapters share k1. A third, warm-cache section also
+    // repeats k1 and packs last, so k1's single entry row ends up owned by
+    // the warm section's pack. Clear downloads must still remove the
+    // downloaded chapters entirely — their marks, statuses, and pack files —
+    // while the warm section keeps its own cache.
+    await store.beginDownloadSections([4, 5]);
+    await cacheSection(4, ['mA1', 'mA2'], ['k1', 'k2']);
+    expect(await store.compact()).toBe(1);
+    await store.registerSectionMarks(5, ['mB1', 'mB2']);
+    await store.put('k4', sentence(4));
+    await store.recordMarkKey(5, 0, 'k1');
+    await store.recordMarkKey(5, 1, 'k4');
+    expect(await store.compact()).toBe(1);
+    await store.completeDownloadSections([4, 5]);
+
+    await store.registerSectionMarks(6, ['mC1', 'mC2']);
+    await store.put('k3', sentence(3));
+    await store.recordMarkKey(6, 0, 'k1');
+    await store.recordMarkKey(6, 1, 'k3');
+    expect(await store.compact()).toBe(1);
+    expect((await store.getSectionStatuses()).get(6)).toMatchObject({
+      packed: true,
+      pinned: false,
+    });
+
+    await store.clearDownloads();
+
+    expect(await store.hasDownloads()).toBe(false);
+    expect(await store.get('k2')).toBeNull();
+    expect(await store.get('k4')).toBeNull();
+    // The warm section still owns the shared sentence.
+    expect(await store.get('k1')).not.toBeNull();
+    const statuses = await store.getSectionStatuses();
+    // Cleared chapters leave no marks behind, so the podcast sheet must not
+    // label them partially downloaded.
+    expect(statuses.get(4)).toBeUndefined();
+    expect(statuses.get(5)).toBeUndefined();
+    expect(statuses.get(6)).toMatchObject({ packed: true, pinned: false });
+    expect(
+      chapterDownloadStatus(
+        { key: 'ch4', label: 'Chapter 4', depth: 0, startSection: 4, endSection: 5 },
+        statuses,
+      ),
+    ).toBe('none');
+    // Only the warm section's pack remains on disk.
+    expect((await packFs.list()).filter((name) => name.endsWith('.mp3'))).toHaveLength(1);
+  });
+
+  test('clearDownloads drops a shared entry a warm pack adopted when no section marks it anymore (regression)', async () => {
+    // Section 4 downloads k1; warm section 6 also marks k1 and packs last,
+    // adopting k1's entry row into its pack. Section 6's manifest then
+    // changes (a re-enumeration, e.g. a voice change) so nothing marks k1
+    // anymore. Clear downloads must garbage-collect the row instead of
+    // leaking it inside the surviving warm pack.
+    await store.beginDownloadSections([4]);
+    await cacheSection(4, ['mA1'], ['k1']);
+    expect(await store.compact()).toBe(1);
+    await store.completeDownloadSections([4]);
+
+    await store.registerSectionMarks(6, ['mC1', 'mC2']);
+    await store.put('k3', sentence(3));
+    await store.recordMarkKey(6, 0, 'k1');
+    await store.recordMarkKey(6, 1, 'k3');
+    expect(await store.compact()).toBe(1);
+    expect(await store.get('k1')).not.toBeNull();
+
+    await store.registerSectionMarks(6, ['mC2']);
+    await store.recordMarkKey(6, 0, 'k3');
+
+    await store.clearDownloads();
+
+    expect(await store.get('k1')).toBeNull();
+    expect(await store.get('k3')).not.toBeNull();
+    expect((await store.getSectionStatuses()).get(4)).toBeUndefined();
+    expect((await packFs.list()).filter((name) => name.endsWith('.mp3'))).toHaveLength(1);
   });
 
   test('gc removes pack files unknown to the database', async () => {

--- a/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
@@ -369,6 +369,7 @@ describe('SqliteTTSCacheStore pack compaction', () => {
       new TextDecoder().decode(otherFs.files.get(packSidecarName(otherName))!),
     ) as TTSPackSidecar;
     const otherBytes = otherFs.files.get(otherName)!.slice().buffer as ArrayBuffer;
+    await otherDb.close();
 
     // Import into the pinned section's store.
     await store.registerSectionMarks(1, ['m1', 'm2']);
@@ -385,7 +386,7 @@ describe('SqliteTTSCacheStore pack compaction', () => {
     await tight.put('oversize', sentence(9, 80));
 
     const surviving = (await packFs.list()).filter((n) => n.endsWith('.mp3'));
-    expect(surviving.length).toBeGreaterThanOrEqual(1);
+    expect(surviving).toContain(otherName);
     expect((await store.getSectionStatuses()).get(1)).toMatchObject({
       packed: true,
       pinned: true,

--- a/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-pack-compaction.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { md5 } from 'js-md5';
 import { NodeDatabaseService } from '@/services/database/nodeDatabaseService';
+import type { DatabaseRow } from '@/types/database';
 import { chapterDownloadStatus } from '@/services/tts/downloadChapters';
 import {
   SqliteTTSCacheStore,
@@ -347,6 +348,84 @@ describe('SqliteTTSCacheStore pack compaction', () => {
       packed: true,
       pinned: true,
     });
+  });
+
+  test('detached entries do not keep a section eternally completable after a heal', async () => {
+    // Pinned section 1 packs, then its pack file is lost with no surviving
+    // candidate: self-heal detaches k1/k2 to loose misses. compact() must not
+    // re-attempt the section until the sentences re-synthesize — a predicate
+    // that sees detached rows as packable churns a full-section audio load
+    // plus a "pack audio missing" warning every debounce cycle, forever.
+    await store.beginDownloadSections([1]);
+    await cacheSection(1, ['m1', 'm2'], ['k1', 'k2']);
+    await store.compact();
+    await store.completeDownloadSections([1]);
+    const packName = (await packFs.list()).find((n) => n.endsWith('.mp3'))!;
+    packFs.files.delete(packName);
+    expect(await store.get('k1')).toBeNull();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(await store.compact()).toBe(0);
+      const missing = warn.mock.calls.filter((call) =>
+        String(call[0]).includes('pack audio missing'),
+      );
+      expect(missing).toEqual([]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('an entry pointing at a vanished pack row detaches to a loose miss', async () => {
+    // A crash between a transfer commit and file cleanup (or an interleaved
+    // eviction) can leave an entry whose pack_id references no pack row. The
+    // read must detach it so the next synthesis repopulates the row, instead
+    // of leaving a permanent silent miss that neither eviction branch counts.
+    await cacheSection(3, ['m1'], ['k1']);
+    await store.compact();
+    await db.execute('DELETE FROM packs', []);
+    expect(await store.get('k1')).toBeNull();
+    const rows = await db.select<DatabaseRow & { pack_id: number | null }>(
+      "SELECT pack_id FROM entries WHERE key = 'k1'",
+    );
+    expect(rows[0]!.pack_id).toBeNull();
+  });
+
+  test('a transfer candidate with malformed sidecar offsets is skipped, not committed as NULL', async () => {
+    // Pinned section 1 owns k1+k2 in packA; section 2 packs k1 (shared) + k3,
+    // adopting k1's row into packB. packA's sidecar is corrupted so k1's entry
+    // lacks a numeric offset: evicting packB must not repoint k1 at packA with
+    // NULL offsets (JSON.stringify drops undefined, so json_extract yields
+    // NULL — a permanent silent miss). With no valid candidate it detaches.
+    await store.beginDownloadSections([1]);
+    await cacheSection(1, ['m1', 'm2'], ['k1', 'k2']);
+    await store.compact();
+    await store.completeDownloadSections([1]);
+    await store.registerSectionMarks(2, ['mB1', 'mB2']);
+    await store.put('k3', sentence(3));
+    await store.recordMarkKey(2, 0, 'k1');
+    await store.recordMarkKey(2, 1, 'k3');
+    await store.compact();
+
+    const packAName = (await packFs.list()).find((n) => n.startsWith('1-') && n.endsWith('.mp3'))!;
+    const sidecarName = packSidecarName(packAName);
+    const sidecar = JSON.parse(
+      new TextDecoder().decode(packFs.files.get(sidecarName)!),
+    ) as TTSPackSidecar;
+    delete (sidecar.entries[0] as { offset?: number }).offset;
+    packFs.files.set(sidecarName, new TextEncoder().encode(JSON.stringify(sidecar)));
+
+    const tight = new SqliteTTSCacheStore(db, {
+      budgetBytes: 100,
+      now: () => clock.t++,
+      packFs,
+    });
+    await tight.put('oversize', sentence(9, 80));
+
+    const rows = await db.select<DatabaseRow & { pack_id: number | null }>(
+      "SELECT pack_id FROM entries WHERE key = 'k1'",
+    );
+    expect(rows[0]!.pack_id).toBeNull();
   });
 
   test('an imported pack for a pinned section survives eviction (imported-% special-case)', async () => {

--- a/apps/readest-app/src/__tests__/services/tts-warm-sentence.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-warm-sentence.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test, vi } from 'vitest';
+
+// Enter the module graph at EdgeTTSClient: constants.ts circularly imports it
+// for DEFAULT_SENTENCE_GAP_SEC, and entering at BufferedTTSClient leaves the
+// base class undefined when `EdgeTTSClient extends BufferedTTSClient` runs.
+import '@/services/tts/EdgeTTSClient';
+import { BufferedTTSClient } from '@/services/tts/BufferedTTSClient';
+import { CachingProvider, TTSCacheStore } from '@/services/tts/providers/cache';
+import type { SpeechProvider } from '@/services/tts/providers/types';
+
+describe('BufferedTTSClient.warmSentence', () => {
+  test('an already-aborted warm returns false and records no mark', async () => {
+    // Cancelling a download aborts the signal; #synthesizeWithRetry then
+    // returns undefined without throwing. warmSentence must report the
+    // sentence as not cached and record nothing — a mark recorded for an
+    // unsynthesized sentence inflates progress and violates its contract.
+    const synthesize = vi.fn(
+      async (): Promise<{ audio: ArrayBuffer; boundaries: never[] }> => ({
+        audio: new ArrayBuffer(4),
+        boundaries: [],
+      }),
+    );
+    const inner: SpeechProvider = {
+      id: 'fake',
+      label: 'Fake',
+      init: async () => true,
+      getAllVoices: async () => [{ id: 'v1', name: 'Voice 1', lang: 'en' }],
+      synthesize,
+    };
+    const recordMarkKey = vi.fn(async () => {});
+    const store: TTSCacheStore = {
+      get: async () => null,
+      put: async () => {},
+      recordMarkKey,
+    };
+    const client = new BufferedTTSClient(new CachingProvider(inner, store));
+    await client.init();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(client.warmSentence(0, 0, 'en', 'Hello there.', controller.signal)).resolves.toBe(
+      false,
+    );
+    expect(synthesize).not.toHaveBeenCalled();
+    expect(recordMarkKey).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/services/tts/BufferedTTSClient.ts
+++ b/apps/readest-app/src/services/tts/BufferedTTSClient.ts
@@ -651,10 +651,16 @@ export class BufferedTTSClient implements TTSClient {
     const voiceId = await this.getVoiceIdFromLang(lang);
     const req = { lang, text, voice: voiceId, pitch: this.#pitch };
     try {
-      await this.provider.synthesize(req, new AbortController().signal);
-    } catch {
+      // Retry transient failures exactly like live playback: a single network
+      // blip (DNS, socket reset) must not drop a sentence and fail a chapter.
+      await this.#synthesizeWithRetry(lang, text, voiceId, new AbortController().signal);
+    } catch (err) {
       // Offline / permanent failure: leave the ordinal unrecorded so the
       // section stays incomplete and can be retried later.
+      console.warn(
+        `[TTS] warmSentence FAIL s=${section} o=${ordinal} lang=${lang} voice=${voiceId} ` +
+          `text="${text.slice(0, 80)}" err=${err instanceof Error ? err.message : String(err)}`,
+      );
       return false;
     }
     await this.provider.recordMark(section, ordinal, req);

--- a/apps/readest-app/src/services/tts/BufferedTTSClient.ts
+++ b/apps/readest-app/src/services/tts/BufferedTTSClient.ts
@@ -646,6 +646,7 @@ export class BufferedTTSClient implements TTSClient {
     ordinal: number,
     lang: string,
     text: string,
+    signal?: AbortSignal,
   ): Promise<boolean> {
     if (!(this.provider instanceof CachingProvider)) return false;
     const voiceId = await this.getVoiceIdFromLang(lang);
@@ -653,7 +654,14 @@ export class BufferedTTSClient implements TTSClient {
     try {
       // Retry transient failures exactly like live playback: a single network
       // blip (DNS, socket reset) must not drop a sentence and fail a chapter.
-      await this.#synthesizeWithRetry(lang, text, voiceId, new AbortController().signal);
+      // Abort with the caller's signal so cancelling a download interrupts an
+      // in-flight synthesis instead of waiting for it to finish.
+      await this.#synthesizeWithRetry(
+        lang,
+        text,
+        voiceId,
+        signal ?? new AbortController().signal,
+      );
     } catch (err) {
       // Offline / permanent failure: leave the ordinal unrecorded so the
       // section stays incomplete and can be retried later.

--- a/apps/readest-app/src/services/tts/BufferedTTSClient.ts
+++ b/apps/readest-app/src/services/tts/BufferedTTSClient.ts
@@ -656,12 +656,7 @@ export class BufferedTTSClient implements TTSClient {
       // blip (DNS, socket reset) must not drop a sentence and fail a chapter.
       // Abort with the caller's signal so cancelling a download interrupts an
       // in-flight synthesis instead of waiting for it to finish.
-      await this.#synthesizeWithRetry(
-        lang,
-        text,
-        voiceId,
-        signal ?? new AbortController().signal,
-      );
+      await this.#synthesizeWithRetry(lang, text, voiceId, signal ?? new AbortController().signal);
     } catch (err) {
       // Offline / permanent failure: leave the ordinal unrecorded so the
       // section stays incomplete and can be retried later.

--- a/apps/readest-app/src/services/tts/BufferedTTSClient.ts
+++ b/apps/readest-app/src/services/tts/BufferedTTSClient.ts
@@ -655,8 +655,15 @@ export class BufferedTTSClient implements TTSClient {
       // Retry transient failures exactly like live playback: a single network
       // blip (DNS, socket reset) must not drop a sentence and fail a chapter.
       // Abort with the caller's signal so cancelling a download interrupts an
-      // in-flight synthesis instead of waiting for it to finish.
-      await this.#synthesizeWithRetry(lang, text, voiceId, signal ?? new AbortController().signal);
+      // in-flight synthesis instead of waiting for it to finish. An aborted
+      // synthesis resolves undefined: nothing was cached, so record nothing.
+      const result = await this.#synthesizeWithRetry(
+        lang,
+        text,
+        voiceId,
+        signal ?? new AbortController().signal,
+      );
+      if (!result) return false;
     } catch (err) {
       // Offline / permanent failure: leave the ordinal unrecorded so the
       // section stays incomplete and can be retried later.

--- a/apps/readest-app/src/services/tts/TTSDownloader.ts
+++ b/apps/readest-app/src/services/tts/TTSDownloader.ts
@@ -101,13 +101,7 @@ export class TTSDownloader {
           break;
         }
         const s = sentences[done]!;
-        const ok = await this.#warmer.warmSentence(
-          sectionIndex,
-          s.ordinal,
-          s.lang,
-          s.text,
-          signal,
-        );
+        const ok = await this.#warmer.warmSentence(sectionIndex, s.ordinal, s.lang, s.text, signal);
         if (ok) synthesized++;
         onProgress?.({
           sectionIndex,

--- a/apps/readest-app/src/services/tts/TTSDownloader.ts
+++ b/apps/readest-app/src/services/tts/TTSDownloader.ts
@@ -94,6 +94,7 @@ export class TTSDownloader {
       );
 
       let synthesized = 0;
+      let failed = false;
       let aborted = false;
       for (let done = 0; done < sentences.length; done++) {
         if (signal?.aborted) {
@@ -103,6 +104,7 @@ export class TTSDownloader {
         const s = sentences[done]!;
         const ok = await this.#warmer.warmSentence(sectionIndex, s.ordinal, s.lang, s.text, signal);
         if (ok) synthesized++;
+        else failed = true;
         onProgress?.({
           sectionIndex,
           total: sentences.length,
@@ -117,7 +119,8 @@ export class TTSDownloader {
       await this.#warmer.compactCache();
       synthesizedTotal += synthesized;
       if (aborted) break;
-      completed.push(sectionIndex);
+      if (failed) skipped.push(sectionIndex);
+      else completed.push(sectionIndex);
     }
 
     return { completed, skipped, synthesized: synthesizedTotal };

--- a/apps/readest-app/src/services/tts/TTSDownloader.ts
+++ b/apps/readest-app/src/services/tts/TTSDownloader.ts
@@ -77,6 +77,7 @@ export class TTSDownloader {
       if (signal?.aborted) break;
       const sentences = await this.#enumerator.enumerateSection(sectionIndex);
       if (!sentences) {
+        console.warn('[TTS] download section failed to enumerate', sectionIndex);
         skipped.push(sectionIndex);
         continue;
       }

--- a/apps/readest-app/src/services/tts/TTSDownloader.ts
+++ b/apps/readest-app/src/services/tts/TTSDownloader.ts
@@ -34,7 +34,13 @@ export interface CacheWarmer {
   // Synthesize this sentence into the cache (a hit is a no-op) and record its
   // key against the section manifest at the ordinal. Returns whether audio is
   // now cached for it (false = offline miss / permanent failure).
-  warmSentence(section: number, ordinal: number, lang: string, text: string): Promise<boolean>;
+  warmSentence(
+    section: number,
+    ordinal: number,
+    lang: string,
+    text: string,
+    signal?: AbortSignal,
+  ): Promise<boolean>;
   // Force any newly-completed sections to compact into packs now (and push,
   // if pack sync is on) rather than waiting for the debounced timer.
   compactCache(): Promise<void>;
@@ -95,7 +101,13 @@ export class TTSDownloader {
           break;
         }
         const s = sentences[done]!;
-        const ok = await this.#warmer.warmSentence(sectionIndex, s.ordinal, s.lang, s.text);
+        const ok = await this.#warmer.warmSentence(
+          sectionIndex,
+          s.ordinal,
+          s.lang,
+          s.text,
+          signal,
+        );
         if (ok) synthesized++;
         onProgress?.({
           sectionIndex,

--- a/apps/readest-app/src/services/tts/providers/bookCacheStore.ts
+++ b/apps/readest-app/src/services/tts/providers/bookCacheStore.ts
@@ -88,6 +88,15 @@ const createNativePackFs = (dir: string): TTSPackFs => ({
       await file.close();
     }
   },
+  async readSidecar(name) {
+    try {
+      const { readTextFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+      const text = await readTextFile(`${dir}/${name}`, { baseDir: BaseDirectory.AppCache });
+      return JSON.parse(text);
+    } catch {
+      return null;
+    }
+  },
   async remove(name) {
     const { remove, BaseDirectory } = await import('@tauri-apps/plugin-fs');
     await remove(`${dir}/${name}`, { baseDir: BaseDirectory.AppCache });

--- a/apps/readest-app/src/services/tts/providers/bookCacheStore.ts
+++ b/apps/readest-app/src/services/tts/providers/bookCacheStore.ts
@@ -92,7 +92,8 @@ const createNativePackFs = (dir: string): TTSPackFs => ({
     try {
       const { readTextFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
       const text = await readTextFile(`${dir}/${name}`, { baseDir: BaseDirectory.AppCache });
-      return JSON.parse(text);
+      const parsed = JSON.parse(text);
+      return parsed && Array.isArray(parsed.entries) ? parsed : null;
     } catch {
       return null;
     }

--- a/apps/readest-app/src/services/tts/providers/opfsPackFs.ts
+++ b/apps/readest-app/src/services/tts/providers/opfsPackFs.ts
@@ -60,7 +60,8 @@ export const createOpfsPackFs = async (dir: string): Promise<TTSPackFs | undefin
       async readSidecar(name) {
         try {
           const file = await readBytes(name);
-          return JSON.parse(await file.text());
+          const parsed = JSON.parse(await file.text());
+          return parsed && Array.isArray(parsed.entries) ? parsed : null;
         } catch {
           return null;
         }

--- a/apps/readest-app/src/services/tts/providers/opfsPackFs.ts
+++ b/apps/readest-app/src/services/tts/providers/opfsPackFs.ts
@@ -57,6 +57,14 @@ export const createOpfsPackFs = async (dir: string): Promise<TTSPackFs | undefin
         }
         return slice;
       },
+      async readSidecar(name) {
+        try {
+          const file = await readBytes(name);
+          return JSON.parse(await file.text());
+        } catch {
+          return null;
+        }
+      },
       async remove(name) {
         await packsDir.removeEntry(name);
       },

--- a/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
+++ b/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
@@ -453,6 +453,25 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
         JOIN pinned_sections ps ON ps.section = p.section
        WHERE ps.active > 0 OR ps.pinned = 1`,
     );
+    // Shared sentences have one entry row per key, adopted by whichever
+    // section packed last, so the row may now live in an unpinned section's
+    // pack. Capture the cleared sections and their keys before the
+    // transaction so their marks can be dropped and entries that only the
+    // cleared sections referenced can be garbage-collected.
+    const clearedSections = (
+      await this.#db.select<DatabaseRow & { section: number }>(
+        'SELECT section FROM pinned_sections WHERE active > 0 OR pinned = 1',
+      )
+    ).map((row) => row.section);
+    const clearedKeys = (
+      await this.#db.select<DatabaseRow & { key: string }>(
+        `SELECT DISTINCT mm.key FROM manifest_marks mm
+           JOIN pinned_sections ps ON ps.section = mm.section
+          WHERE mm.key IS NOT NULL AND (ps.active > 0 OR ps.pinned = 1)`,
+      )
+    ).map((row) => row.key);
+    const sectionPlaceholders = clearedSections.map(() => '?').join(',');
+    const keyPlaceholders = clearedKeys.map(() => '?').join(',');
     try {
       await this.#db.execute('BEGIN');
       await this.#db.execute(
@@ -474,6 +493,31 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
            SELECT section FROM pinned_sections WHERE active > 0 OR pinned = 1
          )`,
       );
+      // Cleared sections stop claiming sentences: drop their marks and
+      // manifest so the podcast sheet offers them as not downloaded even
+      // when a shared entry row survives in a warm section's pack.
+      if (clearedSections.length) {
+        await this.#db.execute(
+          `DELETE FROM manifest_marks WHERE section IN (${sectionPlaceholders})`,
+          clearedSections,
+        );
+        await this.#db.execute(
+          `DELETE FROM manifests WHERE section IN (${sectionPlaceholders})`,
+          clearedSections,
+        );
+      }
+      // Entries that only the cleared sections referenced are now
+      // unreachable (owned by a surviving pack or detached): drop them
+      // instead of leaking rows the warm cache will never read.
+      if (clearedKeys.length) {
+        await this.#db.execute(
+          `DELETE FROM entries WHERE key IN (${keyPlaceholders})
+             AND NOT EXISTS (
+               SELECT 1 FROM manifest_marks mm WHERE mm.key = entries.key
+             )`,
+          clearedKeys,
+        );
+      }
       await this.#db.execute('DELETE FROM pinned_sections');
       await this.#db.execute('COMMIT');
     } catch (err) {

--- a/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
+++ b/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
@@ -1038,7 +1038,7 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
                ) AS rn
           FROM manifest_marks mm
           JOIN packs p ON p.section = mm.section
-          JOIN manifests m ON m.section = p.section AND p.fingerprint = m.fingerprint
+          JOIN manifests m ON m.section = p.section AND ${CURRENT_PACK_PREDICATE}
           LEFT JOIN pinned_sections ps ON ps.section = p.section
          WHERE EXISTS (
                  SELECT 1 FROM entries e

--- a/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
+++ b/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
@@ -160,6 +160,16 @@ const SCHEMA = [
 // Batch accessed_at updates: reads must not each cost a synchronous write.
 const TOUCH_FLUSH_LIMIT = 64;
 
+// importPack stores synced packs under a fingerprint prefixed with this, so a
+// pack adopted from another device never equals the local manifest
+// fingerprint yet still counts as "current" for its section.
+const IMPORTED_FINGERPRINT_PREFIX = 'imported-';
+
+// A pack is current for its section when its fingerprint matches the
+// section's current manifest or was imported. Shared by status reporting and
+// eviction protection so the convention cannot drift between queries.
+const CURRENT_PACK_PREDICATE = `(p.fingerprint = m.fingerprint OR p.fingerprint LIKE '${IMPORTED_FINGERPRINT_PREFIX}%')`;
+
 export class SqliteTTSCacheStore implements TTSCacheStore {
   #db: DatabaseService;
   #budgetBytes: number;
@@ -616,8 +626,14 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
         new TextEncoder().encode(JSON.stringify(sidecar)),
       );
     } catch (err) {
+      // A failed section must not reject the whole compact(): drop whatever
+      // landed (the DB has not changed yet) and report the section unpacked
+      // so a later run retries it.
       console.warn(`[TTS] pack write failed section=${sidecar.section}`, err);
-      throw err;
+      await packFs.remove(tmpName).catch(() => {});
+      await packFs.remove(finalName).catch(() => {});
+      await packFs.remove(packSidecarName(finalName)).catch(() => {});
+      return false;
     }
 
     const timestamp = this.#now();
@@ -706,7 +722,11 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
     if (existing.length) return false;
     if (sidecar.totalSize > this.#budgetBytes) return false;
     if (!(await this.#evictUntilFits(sidecar.totalSize, ''))) return false;
-    return this.#adoptPack(new Uint8Array(data), sidecar, `imported-${sidecar.keysFingerprint}`);
+    return this.#adoptPack(
+      new Uint8Array(data),
+      sidecar,
+      `${IMPORTED_FINGERPRINT_PREFIX}${sidecar.keysFingerprint}`,
+    );
   }
 
   // Per-section download status for the podcast UI. `recorded` is the count
@@ -745,9 +765,7 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
     }
     const packed = await this.#db.select<DatabaseRow & { section: number }>(
       `SELECT DISTINCT p.section FROM packs p
-        JOIN manifests m ON m.section = p.section
-                         AND (p.fingerprint = m.fingerprint
-                              OR p.fingerprint LIKE 'imported-%')`,
+        JOIN manifests m ON m.section = p.section AND ${CURRENT_PACK_PREDICATE}`,
     );
     for (const row of packed) {
       const entry = out.get(row.section) ?? {
@@ -948,14 +966,13 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
         await this.#db.select<
           DatabaseRow & { id: number; path: string; size: number; accessed_at: number }
         >(
-          `SELECT id, path, size, accessed_at FROM packs
+          `SELECT id, path, size, accessed_at FROM packs p
             WHERE NOT EXISTS (
               SELECT 1 FROM pinned_sections ps
                 JOIN manifests m ON m.section = ps.section
-               WHERE ps.section = packs.section
+               WHERE ps.section = p.section
                  AND (ps.active > 0 OR ps.pinned = 1)
-                 AND (packs.fingerprint = m.fingerprint
-                      OR packs.fingerprint LIKE 'imported-%')
+                 AND ${CURRENT_PACK_PREDICATE}
             )
             ORDER BY accessed_at ASC LIMIT 1`,
         )
@@ -1012,30 +1029,35 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
         rn: number;
       }
     >(
-      `SELECT mm.key, p.id AS candidate_pack_id, p.path AS candidate_path,
-              ROW_NUMBER() OVER (
-                PARTITION BY mm.key
-                ORDER BY (CASE WHEN ps.pinned = 1 THEN 0 ELSE 1 END),
-                         p.created_at, p.id
-              ) AS rn
-         FROM manifest_marks mm
-         JOIN packs p ON p.section = mm.section
-         JOIN manifests m ON m.section = p.section AND p.fingerprint = m.fingerprint
-         LEFT JOIN pinned_sections ps ON ps.section = p.section
-        WHERE EXISTS (
-                SELECT 1 FROM entries e
-                 WHERE e.key = mm.key AND e.pack_id IN (${packPlaceholders})
-              )
-          AND p.id NOT IN (${packPlaceholders})`,
+      `SELECT * FROM (
+        SELECT mm.key, p.id AS candidate_pack_id, p.path AS candidate_path,
+               ROW_NUMBER() OVER (
+                 PARTITION BY mm.key
+                 ORDER BY (CASE WHEN ps.pinned = 1 THEN 0 ELSE 1 END),
+                          p.created_at, p.id
+               ) AS rn
+          FROM manifest_marks mm
+          JOIN packs p ON p.section = mm.section
+          JOIN manifests m ON m.section = p.section AND p.fingerprint = m.fingerprint
+          LEFT JOIN pinned_sections ps ON ps.section = p.section
+         WHERE EXISTS (
+                 SELECT 1 FROM entries e
+                  WHERE e.key = mm.key AND e.pack_id IN (${packPlaceholders})
+               )
+           AND p.id NOT IN (${packPlaceholders})
+       ) ORDER BY key, rn`,
       [...packIds, ...packIds],
     );
 
     // Resolve offsets/lengths from each candidate pack's sidecar, caching the
-    // parse per path and indexing entries by key for O(1) lookups. A missing
-    // sidecar just disqualifies that candidate (skip), never aborts the tx.
+    // parse per path and indexing entries by key for O(1) lookups. Candidates
+    // arrive in rank order per key, so each key takes its first valid one: a
+    // corrupt or missing sidecar disqualifies only that candidate and the key
+    // falls through to the next ranked pack. A key that resolves against no
+    // candidate at all is left for the detach step below.
     const sidecarCache = new Map<
       string,
-      { byKey: Map<string, { offset: number; length: number }> }
+      { byKey: Map<string, { offset: number; length: number }> } | null
     >();
     const transfers: {
       key: string;
@@ -1043,28 +1065,34 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
       packOffset: number;
       packLength: number;
     }[] = [];
+    const resolved = new Set<string>();
     for (const row of candidates) {
-      if (row.rn !== 1) continue;
+      if (resolved.has(row.key)) continue;
       let cached = sidecarCache.get(row.candidate_path);
-      if (!cached) {
+      if (cached === undefined) {
         if (!packFs) continue;
         const sidecar = await packFs.readSidecar(packSidecarName(row.candidate_path));
-        if (!sidecar) continue;
-        const byKey = new Map(
-          sidecar.entries.map((e) => [e.key, { offset: e.offset, length: e.length }]),
-        );
-        cached = { byKey };
+        if (!sidecar) {
+          sidecarCache.set(row.candidate_path, null);
+          continue;
+        }
+        cached = {
+          byKey: new Map(
+            sidecar.entries.map((e) => [e.key, { offset: e.offset, length: e.length }]),
+          ),
+        };
         sidecarCache.set(row.candidate_path, cached);
       }
+      if (!cached) continue;
       const se = cached.byKey.get(row.key);
-      if (se) {
-        transfers.push({
-          key: row.key,
-          packId: row.candidate_pack_id,
-          packOffset: se.offset,
-          packLength: se.length,
-        });
-      }
+      if (!se) continue;
+      transfers.push({
+        key: row.key,
+        packId: row.candidate_pack_id,
+        packOffset: se.offset,
+        packLength: se.length,
+      });
+      resolved.add(row.key);
     }
 
     await this.#transaction(async () => {
@@ -1099,7 +1127,8 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
       // transaction, so no NOT IN/EXISTS guard is needed.
       await this.#db.execute(
         `UPDATE entries
-            SET pack_id = NULL, audio = NULL
+            SET pack_id = NULL, audio = NULL, size = 0,
+                pack_offset = NULL, pack_length = NULL
           WHERE pack_id IN (${packPlaceholders})`,
         packIds,
       );

--- a/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
+++ b/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
@@ -243,7 +243,10 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
       // Self-heal: the pack file is gone or truncated. Drop the whole pack,
       // not just this key, so a pinned section becomes visibly incomplete
       // and can be downloaded again.
-      console.warn('TTS pack range read failed; healing entry to a miss', err);
+      console.warn(
+        `[TTS] pack range read failed (key=${row['key']} pack=${row.pack_id}); healing entry to a miss`,
+        err,
+      );
       await this.#transaction(async () => {
         await this.#db.execute('DELETE FROM entries WHERE pack_id = ?', [row.pack_id]);
         await this.#db.execute('DELETE FROM packs WHERE id = ?', [row.pack_id]);
@@ -479,7 +482,7 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
           AND NOT EXISTS (
           SELECT 1 FROM manifest_marks mm
             LEFT JOIN entries e ON e.key = mm.key
-           WHERE mm.section = m.section AND (e.key IS NULL OR e.audio IS NULL))`,
+           WHERE mm.section = m.section AND e.key IS NULL)`,
     );
     let created = 0;
     for (const manifest of completable) {
@@ -490,9 +493,19 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
 
   async #packSection(section: number, fingerprint: string): Promise<boolean> {
     const rows = await this.#db.select<
-      DatabaseRow & { key: string; audio: unknown; boundaries: string; duration_ms: number | null }
+      DatabaseRow & {
+        key: string;
+        audio: unknown;
+        boundaries: string;
+        duration_ms: number | null;
+        pack_id: number | null;
+        pack_offset: number | null;
+        pack_length: number | null;
+      }
     >(
-      `SELECT mm.key, e.audio, e.boundaries, e.duration_ms FROM manifest_marks mm
+      `SELECT mm.key, e.audio, e.boundaries, e.duration_ms,
+              e.pack_id, e.pack_offset, e.pack_length
+         FROM manifest_marks mm
          JOIN entries e ON e.key = mm.key
         WHERE mm.section = ? ORDER BY mm.ordinal ASC`,
       [section],
@@ -507,8 +520,18 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
       durationMs: number | null;
     }[] = [];
     for (const row of rows) {
-      const audio = toArrayBuffer(row.audio);
-      if (!audio) return false;
+      let audio = toArrayBuffer(row.audio);
+      if (!audio) {
+        // This sentence was packed into another section first (identical text
+        // under the same voice), so its entry is pack-backed with audio NULL.
+        // Resolve the bytes from that pack so THIS section can pack too; the
+        // content is identical by key, so embedding a copy is safe.
+        audio = await this.#readPackedAudio(row);
+      }
+      if (!audio) {
+        console.warn(`[TTS] pack audio missing for key=${row.key} section=${section}`);
+        return false;
+      }
       parts.push({
         key: row.key,
         bytes: new Uint8Array(audio),
@@ -565,15 +588,22 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
       'SELECT id FROM packs WHERE path = ?',
       [finalName],
     );
-    if (existing.length) return false;
+    if (existing.length) {
+      return false;
+    }
 
     const tmpName = `tmp-${finalName}`;
-    await packFs.write(tmpName, merged);
-    await packFs.rename(tmpName, finalName);
-    await packFs.write(
-      packSidecarName(finalName),
-      new TextEncoder().encode(JSON.stringify(sidecar)),
-    );
+    try {
+      await packFs.write(tmpName, merged);
+      await packFs.rename(tmpName, finalName);
+      await packFs.write(
+        packSidecarName(finalName),
+        new TextEncoder().encode(JSON.stringify(sidecar)),
+      );
+    } catch (err) {
+      console.warn(`[TTS] pack write failed section=${sidecar.section}`, err);
+      throw err;
+    }
 
     const timestamp = this.#now();
     try {
@@ -702,8 +732,15 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
       'SELECT DISTINCT section FROM packs',
     );
     for (const row of packed) {
-      const entry = out.get(row.section);
-      if (entry) entry.packed = true;
+      const entry = out.get(row.section) ?? {
+        total: 0,
+        recorded: 0,
+        packed: false,
+        pinned: false,
+        active: false,
+      };
+      entry.packed = true;
+      out.set(row.section, entry);
     }
     const pins = await this.#db.select<
       DatabaseRow & { section: number; active: number; pinned: number }

--- a/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
+++ b/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
@@ -35,6 +35,10 @@ export interface TTSPackFs {
   write(name: string, data: Uint8Array): Promise<void>;
   rename(from: string, to: string): Promise<void>;
   readRange(name: string, offset: number, length: number): Promise<ArrayBuffer>;
+  // Read and parse a pack's sidecar JSON, or null when the file is missing.
+  // Used by the transfer-on-removal path to repoint shared entries at a
+  // surviving pack with the correct (offset, length).
+  readSidecar(name: string): Promise<TTSPackSidecar | null>;
   remove(name: string): Promise<void>;
   list(): Promise<string[]>;
 }
@@ -149,6 +153,8 @@ const SCHEMA = [
     active  INTEGER NOT NULL DEFAULT 0,
     pinned  INTEGER NOT NULL DEFAULT 0
   )`,
+  `CREATE INDEX IF NOT EXISTS idx_manifest_marks_key ON manifest_marks(key)`,
+  `CREATE INDEX IF NOT EXISTS idx_packs_section ON packs(section)`,
 ];
 
 // Batch accessed_at updates: reads must not each cost a synchronous write.
@@ -240,20 +246,29 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
     try {
       return await this.#packFs.readRange(path, row.pack_offset, row.pack_length);
     } catch (err) {
-      // Self-heal: the pack file is gone or truncated. Drop the whole pack,
-      // not just this key, so a pinned section becomes visibly incomplete
-      // and can be downloaded again.
+      // Self-heal: the pack file is gone or truncated. Transfer any shared
+      // keys to a surviving pack (or detach them to NULL/NULL when no
+      // candidate exists), then drop the pack so a pinned section becomes
+      // visibly incomplete and can be downloaded again.
       console.warn(
         `[TTS] pack range read failed (key=${key} pack=${row.pack_id}); healing entry to a miss`,
         err,
       );
-      await this.#transaction(async () => {
-        await this.#db.execute('DELETE FROM entries WHERE pack_id = ?', [row.pack_id]);
-        await this.#db.execute('DELETE FROM packs WHERE id = ?', [row.pack_id]);
-      });
-      await this.#packFs.remove(path).catch(() => {});
-      await this.#packFs.remove(packSidecarName(path)).catch(() => {});
-      return null;
+      await this.#transferSharedEntriesOnPackDeletion([row.pack_id]);
+      // The heal may have repointed this entry to a surviving pack: retry so
+      // the reader gets the audio instead of a false miss. Each retry removes
+      // a pack row, so this terminates.
+      const healed = await this.#db.select<EntryRow>(
+        `SELECT audio, boundaries, duration_ms, pack_id, pack_offset, pack_length
+           FROM entries WHERE key = ?`,
+        [key],
+      );
+      const healedRow = healed[0];
+      if (!healedRow) return null;
+      const healedAudio = toArrayBuffer(healedRow.audio);
+      if (healedAudio) return healedAudio;
+      if (healedRow.pack_id == null || healedRow.pack_id === row.pack_id) return null;
+      return this.#readPackedAudio(key, healedRow);
     }
   }
 
@@ -729,7 +744,10 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
       if (entry) entry.recorded = row.recorded;
     }
     const packed = await this.#db.select<DatabaseRow & { section: number }>(
-      'SELECT DISTINCT section FROM packs',
+      `SELECT DISTINCT p.section FROM packs p
+        JOIN manifests m ON m.section = p.section
+                         AND (p.fingerprint = m.fingerprint
+                              OR p.fingerprint LIKE 'imported-%')`,
     );
     for (const row of packed) {
       const entry = out.get(row.section) ?? {
@@ -933,7 +951,11 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
           `SELECT id, path, size, accessed_at FROM packs
             WHERE NOT EXISTS (
               SELECT 1 FROM pinned_sections ps
-               WHERE ps.section = packs.section AND (ps.active > 0 OR ps.pinned = 1)
+                JOIN manifests m ON m.section = ps.section
+               WHERE ps.section = packs.section
+                 AND (ps.active > 0 OR ps.pinned = 1)
+                 AND (packs.fingerprint = m.fingerprint
+                      OR packs.fingerprint LIKE 'imported-%')
             )
             ORDER BY accessed_at ASC LIMIT 1`,
         )
@@ -942,10 +964,7 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
       const evictPack =
         oldestPack && (!oldestLoose || oldestPack.accessed_at <= oldestLoose.accessed_at);
       if (evictPack) {
-        await this.#db.execute('DELETE FROM entries WHERE pack_id = ?', [oldestPack!.id]);
-        await this.#db.execute('DELETE FROM packs WHERE id = ?', [oldestPack!.id]);
-        await this.#packFs?.remove(oldestPack!.path).catch(() => {});
-        await this.#packFs?.remove(packSidecarName(oldestPack!.path)).catch(() => {});
+        await this.#transferSharedEntriesOnPackDeletion([oldestPack!.id]);
         total -= oldestPack!.size;
       } else {
         await this.#db.execute('DELETE FROM entries WHERE key = ?', [oldestLoose!.key]);
@@ -953,6 +972,158 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
       }
     }
     return true;
+  }
+
+  // When a pack is about to be deleted (LRU eviction or self-heal because its
+  // file is gone), any of its entry rows may still be referenced by a pinned
+  // section through `manifest_marks`. Destroying those rows would make the
+  // pinned chapter unplayable offline even though the bytes still exist in a
+  // surviving pack that contains the same key. This helper repoints each
+  // affected entry to a surviving current pack (via the content-addressed
+  // `manifest_marks -> packs` bridge), or detaches it to (pack_id = NULL,
+  // audio = NULL) when no candidate exists — the same recovery as today's
+  // "Download incomplete" path, where the next synthesis repopulates the row.
+  //
+  // Runs as one transaction so the cache state is always consistent. File I/O
+  // (sidecar reads for candidate offsets, then the pack/sidecar removals)
+  // happens OUTSIDE the transaction, mirroring the existing self-heal pattern.
+  async #transferSharedEntriesOnPackDeletion(packIds: number[]): Promise<void> {
+    const packFs = this.#packFs;
+    const packPlaceholders = packIds.map(() => '?').join(',');
+
+    // The pack rows being removed: we need their paths for file cleanup, and
+    // they are stable for the duration (we hold the write lock via the tx).
+    const packRows = await this.#db.select<DatabaseRow & { id: number; path: string }>(
+      `SELECT id, path FROM packs WHERE id IN (${packPlaceholders})`,
+      packIds,
+    );
+
+    // Candidates: for each key currently owned by one of the deleted packs,
+    // find a surviving pack of a section whose manifest records the same key
+    // and whose fingerprint matches that section's current manifest. Ranked
+    // deterministically (pinned first, then FIFO, then id) so the outcome is
+    // order-independent. The inner EXISTS is a correlated subquery (NOT a CTE)
+    // so the planner keeps full index flexibility over entries(pack_id).
+    const candidates = await this.#db.select<
+      DatabaseRow & {
+        key: string;
+        candidate_pack_id: number;
+        candidate_path: string;
+        rn: number;
+      }
+    >(
+      `SELECT mm.key, p.id AS candidate_pack_id, p.path AS candidate_path,
+              ROW_NUMBER() OVER (
+                PARTITION BY mm.key
+                ORDER BY (CASE WHEN ps.pinned = 1 THEN 0 ELSE 1 END),
+                         p.created_at, p.id
+              ) AS rn
+         FROM manifest_marks mm
+         JOIN packs p ON p.section = mm.section
+         JOIN manifests m ON m.section = p.section AND p.fingerprint = m.fingerprint
+         LEFT JOIN pinned_sections ps ON ps.section = p.section
+        WHERE EXISTS (
+                SELECT 1 FROM entries e
+                 WHERE e.key = mm.key AND e.pack_id IN (${packPlaceholders})
+              )
+          AND p.id NOT IN (${packPlaceholders})`,
+      [...packIds, ...packIds],
+    );
+
+    // Resolve offsets/lengths from each candidate pack's sidecar, caching the
+    // parse per path and indexing entries by key for O(1) lookups. A missing
+    // sidecar just disqualifies that candidate (skip), never aborts the tx.
+    const sidecarCache = new Map<
+      string,
+      { byKey: Map<string, { offset: number; length: number }> }
+    >();
+    const transfers: {
+      key: string;
+      packId: number;
+      packOffset: number;
+      packLength: number;
+    }[] = [];
+    for (const row of candidates) {
+      if (row.rn !== 1) continue;
+      let cached = sidecarCache.get(row.candidate_path);
+      if (!cached) {
+        if (!packFs) continue;
+        const sidecar = await packFs.readSidecar(packSidecarName(row.candidate_path));
+        if (!sidecar) continue;
+        const byKey = new Map(
+          sidecar.entries.map((e) => [e.key, { offset: e.offset, length: e.length }]),
+        );
+        cached = { byKey };
+        sidecarCache.set(row.candidate_path, cached);
+      }
+      const se = cached.byKey.get(row.key);
+      if (se) {
+        transfers.push({
+          key: row.key,
+          packId: row.candidate_pack_id,
+          packOffset: se.offset,
+          packLength: se.length,
+        });
+      }
+    }
+
+    await this.#transaction(async () => {
+      // Single UPDATE repointing every transferred entry at its new pack,
+      // driven by a JSON payload expanded with json_each (built into libsql).
+      // No temp table: the Turso node driver corrupts temp-table DDL on
+      // in-memory databases once the schema grows past a few pages.
+      if (transfers.length) {
+        await this.#db.execute(
+          `UPDATE entries
+              SET pack_id = json_extract(j.value, '$.pack_id'),
+                  pack_offset = json_extract(j.value, '$.pack_offset'),
+                  pack_length = json_extract(j.value, '$.pack_length')
+             FROM json_each(?) AS j
+            WHERE entries.key = json_extract(j.value, '$.k')`,
+          [
+            JSON.stringify(
+              transfers.map((t) => ({
+                k: t.key,
+                pack_id: t.packId,
+                pack_offset: t.packOffset,
+                pack_length: t.packLength,
+              })),
+            ),
+          ],
+        );
+      }
+
+      // Entries still owned by a deleted pack after the transfer are the
+      // no-candidate ones: detach them to a loose miss (same recovery as the
+      // "Download incomplete" path). The transfer UPDATE ran first in this
+      // transaction, so no NOT IN/EXISTS guard is needed.
+      await this.#db.execute(
+        `UPDATE entries
+            SET pack_id = NULL, audio = NULL
+          WHERE pack_id IN (${packPlaceholders})`,
+        packIds,
+      );
+
+      // Reflect the new active references so a freshly-receiving pack is not
+      // immediately re-selected by the LRU.
+      if (transfers.length) {
+        const distinctCandidateIds = [...new Set(transfers.map((t) => t.packId))];
+        await this.#db.execute(
+          `UPDATE packs SET accessed_at = ?
+            WHERE id IN (${distinctCandidateIds.map(() => '?').join(',')})`,
+          [this.#now(), ...distinctCandidateIds],
+        );
+      }
+
+      // Drop the evicted packs (their entry rows are already gone or moved).
+      await this.#db.execute(`DELETE FROM packs WHERE id IN (${packPlaceholders})`, packIds);
+    });
+
+    // File cleanup runs after COMMIT (matches the self-heal pattern).
+    for (const pack of packRows) {
+      await packFs?.remove(pack.path).catch(() => {});
+      await packFs?.remove(packSidecarName(pack.path)).catch(() => {});
+    }
   }
 
   async #flushTouches(): Promise<void> {

--- a/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
+++ b/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
@@ -208,7 +208,7 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
     );
     const row = rows[0];
     if (!row) return null;
-    const audio = toArrayBuffer(row.audio) ?? (await this.#readPackedAudio(row));
+    const audio = toArrayBuffer(row.audio) ?? (await this.#readPackedAudio(key, row));
     if (!audio) return null;
     this.#pendingTouches.set(key, this.#now());
     if (row.pack_id != null) this.#pendingPackTouches.set(row.pack_id, this.#now());
@@ -222,7 +222,7 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
     };
   }
 
-  async #readPackedAudio(row: EntryRow): Promise<ArrayBuffer | null> {
+  async #readPackedAudio(key: string, row: EntryRow): Promise<ArrayBuffer | null> {
     if (
       !this.#packFs ||
       row.pack_id == null ||
@@ -244,7 +244,7 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
       // not just this key, so a pinned section becomes visibly incomplete
       // and can be downloaded again.
       console.warn(
-        `[TTS] pack range read failed (key=${row['key']} pack=${row.pack_id}); healing entry to a miss`,
+        `[TTS] pack range read failed (key=${key} pack=${row.pack_id}); healing entry to a miss`,
         err,
       );
       await this.#transaction(async () => {
@@ -526,7 +526,7 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
         // under the same voice), so its entry is pack-backed with audio NULL.
         // Resolve the bytes from that pack so THIS section can pack too; the
         // content is identical by key, so embedding a copy is safe.
-        audio = await this.#readPackedAudio(row);
+        audio = await this.#readPackedAudio(row.key, row);
       }
       if (!audio) {
         console.warn(`[TTS] pack audio missing for key=${row.key} section=${section}`);

--- a/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
+++ b/apps/readest-app/src/services/tts/providers/sqliteCacheStore.ts
@@ -252,7 +252,19 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
       [row.pack_id],
     );
     const path = packs[0]?.path;
-    if (!path) return null;
+    if (!path) {
+      // Dangling pack reference (crash artifact or interleaved eviction):
+      // detach to a loose miss so the next synthesis repopulates the row
+      // instead of leaving a permanent miss no eviction branch can reclaim.
+      await this.#db.execute(
+        `UPDATE entries
+            SET pack_id = NULL, audio = NULL, size = 0,
+                pack_offset = NULL, pack_length = NULL
+          WHERE key = ?`,
+        [key],
+      );
+      return null;
+    }
     try {
       return await this.#packFs.readRange(path, row.pack_offset, row.pack_length);
     } catch (err) {
@@ -471,7 +483,6 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
       )
     ).map((row) => row.key);
     const sectionPlaceholders = clearedSections.map(() => '?').join(',');
-    const keyPlaceholders = clearedKeys.map(() => '?').join(',');
     try {
       await this.#db.execute('BEGIN');
       await this.#db.execute(
@@ -508,14 +519,17 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
       }
       // Entries that only the cleared sections referenced are now
       // unreachable (owned by a surviving pack or detached): drop them
-      // instead of leaking rows the warm cache will never read.
+      // instead of leaking rows the warm cache will never read. The keys ride
+      // in as one JSON array — a fully downloaded book has one key per
+      // distinct sentence, easily past SQLite's host-parameter cap.
       if (clearedKeys.length) {
         await this.#db.execute(
-          `DELETE FROM entries WHERE key IN (${keyPlaceholders})
-             AND NOT EXISTS (
-               SELECT 1 FROM manifest_marks mm WHERE mm.key = entries.key
-             )`,
-          clearedKeys,
+          `DELETE FROM entries
+            WHERE key IN (SELECT j.value FROM json_each(?) AS j)
+              AND NOT EXISTS (
+                SELECT 1 FROM manifest_marks mm WHERE mm.key = entries.key
+              )`,
+          [JSON.stringify(clearedKeys)],
         );
       }
       await this.#db.execute('DELETE FROM pinned_sections');
@@ -551,7 +565,8 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
           AND NOT EXISTS (
           SELECT 1 FROM manifest_marks mm
             LEFT JOIN entries e ON e.key = mm.key
-           WHERE mm.section = m.section AND e.key IS NULL)`,
+           WHERE mm.section = m.section
+             AND (e.key IS NULL OR (e.audio IS NULL AND e.pack_id IS NULL)))`,
     );
     let created = 0;
     for (const manifest of completable) {
@@ -1052,8 +1067,10 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
     const packFs = this.#packFs;
     const packPlaceholders = packIds.map(() => '?').join(',');
 
-    // The pack rows being removed: we need their paths for file cleanup, and
-    // they are stable for the duration (we hold the write lock via the tx).
+    // The pack rows being removed: we need their paths for file cleanup.
+    // Candidate selection and sidecar reads below run OUTSIDE the transaction
+    // (file I/O must not sit inside it), so the transfer UPDATE re-validates
+    // each candidate pack still exists before repointing entries at it.
     const packRows = await this.#db.select<DatabaseRow & { id: number; path: string }>(
       `SELECT id, path FROM packs WHERE id IN (${packPlaceholders})`,
       packIds,
@@ -1121,8 +1138,20 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
           continue;
         }
         cached = {
+          // Malformed entries are dropped here so a corrupt sidecar can only
+          // disqualify its candidate: JSON.stringify drops undefined, so a
+          // non-numeric offset passed through would commit as NULL and turn
+          // the transferred entry into a permanent silent miss.
           byKey: new Map(
-            sidecar.entries.map((e) => [e.key, { offset: e.offset, length: e.length }]),
+            sidecar.entries
+              .filter(
+                (e) =>
+                  Number.isInteger(e.offset) &&
+                  e.offset >= 0 &&
+                  Number.isInteger(e.length) &&
+                  e.length > 0,
+              )
+              .map((e) => [e.key, { offset: e.offset, length: e.length }]),
           ),
         };
         sidecarCache.set(row.candidate_path, cached);
@@ -1151,7 +1180,10 @@ export class SqliteTTSCacheStore implements TTSCacheStore {
                   pack_offset = json_extract(j.value, '$.pack_offset'),
                   pack_length = json_extract(j.value, '$.pack_length')
              FROM json_each(?) AS j
-            WHERE entries.key = json_extract(j.value, '$.k')`,
+            WHERE entries.key = json_extract(j.value, '$.k')
+              AND EXISTS (
+                SELECT 1 FROM packs p WHERE p.id = json_extract(j.value, '$.pack_id')
+              )`,
           [
             JSON.stringify(
               transfers.map((t) => ({

--- a/apps/readest-app/src/services/tts/ttsDownloadManager.ts
+++ b/apps/readest-app/src/services/tts/ttsDownloadManager.ts
@@ -260,6 +260,10 @@ export class TTSDownloadManager {
       }
       const incomplete = sections.some((section) => !finalStatuses.get(section)?.packed);
       if (incomplete) {
+        console.warn(
+          `[TTS] download FAIL item=${item.id}` +
+            ` incompleteSections=[${sections.filter((s) => !finalStatuses.get(s)?.packed).join(',')}]`,
+        );
         await this.#cancelActive(active);
         finish('Download incomplete');
       } else {


### PR DESCRIPTION
closes #5767

### Problem
Downloading a book for offline TTS playback intermittently marks individual chapters as failed with "Download incomplete", even though most or all of that chapter's audio is present on the device and playable. A failed chapter could never succeed on retry: retrying re-ran quickly and "seemingly did nothing", then failed identically. The failure hit books with many repeated short sentences, especially dialogue-heavy novels.

### Root cause
The offline cache is content-addressed by sentence key (a hash of provider, language, voice, pitch, and text), so identical sentences share one entry. When an earlier chapter packed a sentence, that entry became pack-backed with its audio moved into the earlier chapter's pack file. A later chapter containing the same sentence referenced that already-packed entry, and compaction's completeness check demanded the entry still carry loose audio, so the later chapter could never form its own pack and failed forever, even though every sentence was cached. The audio was all there; it just lived inside another chapter's pack. The two secondary bugs were an empty-manifest chapter never being reported as packed (so cover and blank pages always failed) and warmSentence having no retry (a single transient network failure dropped a sentence and failed a chapter).

### Fix
Compaction's completeness check now only requires the entry row to exist rather than loose audio. When packing a section, pack-backed entries are resolved through the pack that owns them and a copy is embedded into the new section's pack, so each pack stays a self-contained, playable MP3 and repeated sentences are copied locally pack-to-pack rather than re-synthesized or re-fetched. Empty-manifest sections are now reported as packed so cover and blank chapters complete, and warmSentence reuses the existing synthesis retry path so a transient network blip no longer fails a chapter.


Pack deletion is now robust in the other direction as well: when eviction or
self-heal removes a pack, entries still referenced by another section through
`manifest_marks` are transferred to a surviving current pack of that section
(fingerprint-gated, pinned-first) instead of being destroyed, keeping pinned
chapters playable offline. Entries with no surviving candidate detach to a
loose miss and re-synthesize on next read — the same bounded recovery as the
existing "Download incomplete" path, explicitly accepted per the review
thread. Pins and the `packed` status flag are now fingerprint-aware, so stale
packs of a pinned section are reclaimable while `imported-%` packs stay
protected.

### Verification
Added four regression tests covering the shared-key eviction transfer
(shared sentence survives a later pack's eviction), stale-pack reclamation
for pinned sections, corrupt-pack self-heal transferring instead of
destroying, and imported-pack survival. Added earlier tests for a section
sharing a sentence key with an already-packed section and for empty-manifest
sections reported as packed; all fail against the old behavior and pass with
the fix. The pack-compaction suite (31 tests) and pnpm lint are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Text-to-speech downloads can now be cancelled while audio is being prepared.
  - TTS cache metadata is now read and validated across supported storage options.

- **Bug Fixes**
  - Improved recovery when cached audio is missing, corrupted, or removed.
  - Preserved shared audio entries during cache cleanup and pack eviction.
  - Improved retention of imported and pinned audio packs.
  - Improved handling of empty or rebuilt cache manifests.
  - Sections with incomplete audio are now reported as skipped instead of completed.
  - Added clearer warnings when downloads finish with incomplete sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->