### PR TITLE
fix(reader): translate iframe text without duplicating TTS

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextTranslation.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextTranslation.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import {
   createTranslationTargetNode,
-  excludeTranslationNodes,
   getTranslationContextNodes,
   groupTextNodesByDocument,
   observeTextNodesByDocument,
+  resolveTranslationSourceNodes,
+  setSourceVisibility,
 } from '@/app/reader/hooks/useTextTranslation';
+import { walkTextNodes } from '@/utils/walk';
 
 describe('groupTextNodesByDocument', () => {
   it('keeps text nodes from separate iframe documents in separate observer groups', () => {
@@ -48,8 +50,15 @@ describe('observeTextNodesByDocument', () => {
   });
 });
 
-describe('excludeTranslationNodes', () => {
-  it('excludes generated translation wrappers when translated DOM is scanned again', () => {
+describe('resolveTranslationSourceNodes', () => {
+  it('keeps untranslated book text nodes', () => {
+    const paragraph = document.createElement('p');
+    paragraph.textContent = 'Source paragraph';
+
+    expect(resolveTranslationSourceNodes([paragraph])).toEqual([paragraph]);
+  });
+
+  it('drops generated wrappers and folds a hidden original back to its paragraph', () => {
     const source = document.createElement('p');
     source.className = 'translation-source';
     const hiddenSource = document.createElement('font');
@@ -60,14 +69,56 @@ describe('excludeTranslationNodes', () => {
     target.textContent = 'Translated paragraph';
     source.append(hiddenSource, target);
 
-    expect(excludeTranslationNodes([source, hiddenSource, target])).toEqual([]);
+    // one entry per paragraph, and never a generated wrapper
+    expect(resolveTranslationSourceNodes([source, hiddenSource, target])).toEqual([source]);
   });
 
-  it('keeps untranslated book text nodes', () => {
-    const paragraph = document.createElement('p');
-    paragraph.textContent = 'Source paragraph';
+  it('keeps an already translated paragraph so the node list stays index-stable', () => {
+    // Regression: dropping translated paragraphs shifts every index after them,
+    // which breaks findNodeIndicesInRange and silently kills the read-ahead.
+    const root = document.createElement('div');
+    root.innerHTML = `<p id="p1">One.</p><p id="p2">Two.</p><p id="p3">Three.</p>`;
+    document.body.appendChild(root);
 
-    expect(excludeTranslationNodes([paragraph])).toEqual([paragraph]);
+    const translate = (el: HTMLElement, showSource: boolean) => {
+      el.classList.add('translation-source');
+      setSourceVisibility(el, showSource);
+      el.appendChild(
+        createTranslationTargetNode({
+          translatedText: 'TRANSLATED',
+          lang: 'zh',
+          targetBlockClassName: 'translation-target-block',
+          hidden: false,
+          widthLineBreak: false,
+        }),
+      );
+    };
+    const rewalk = () =>
+      resolveTranslationSourceNodes(walkTextNodes(root, ['pre', 'code', 'math']));
+
+    expect(rewalk().map((node) => node.id)).toEqual(['p1', 'p2', 'p3']);
+
+    // original left visible
+    translate(document.getElementById('p1')!, true);
+    expect(rewalk().map((node) => node.id)).toEqual(['p1', 'p2', 'p3']);
+
+    // original hidden: walkTextNodes descends past the <p> and emits the wrapper
+    translate(document.getElementById('p2')!, false);
+    expect(rewalk().map((node) => node.id)).toEqual(['p1', 'p2', 'p3']);
+
+    root.remove();
+  });
+
+  it('keeps a paragraph whose original is hidden but whose translation was removed', () => {
+    // The state updateTranslation() leaves behind. The hidden wrapper is
+    // display:none, so this paragraph must stay observable or it renders blank.
+    const source = document.createElement('p');
+    source.className = 'translation-source';
+    source.textContent = 'Source paragraph';
+    setSourceVisibility(source, false);
+    const hider = source.querySelector<HTMLElement>('.translation-source-hidden')!;
+
+    expect(resolveTranslationSourceNodes([hider])).toEqual([source]);
   });
 });
 
@@ -88,6 +139,38 @@ describe('getTranslationContextNodes', () => {
 
     expect(context).toEqual([firstBefore, firstVisible]);
     expect(context.every((node) => node.ownerDocument === firstDocument)).toBe(true);
+  });
+
+  it('returns nothing when every visible node belongs to another document', () => {
+    const firstDocument = document.implementation.createHTMLDocument('first');
+    const secondDocument = document.implementation.createHTMLDocument('second');
+    const firstNode = firstDocument.createElement('p');
+    const secondVisible = secondDocument.createElement('p');
+
+    expect(
+      getTranslationContextNodes(
+        [firstNode, secondVisible],
+        firstDocument,
+        new Set([secondVisible]),
+      ),
+    ).toEqual([]);
+  });
+
+  it('spans the same window the pre-refactor loop covered', () => {
+    const ownerDocument = document.implementation.createHTMLDocument('only');
+    const nodes = Array.from({ length: 10 }, () => ownerDocument.createElement('p'));
+
+    // visible = index 4 -> one node before, two after (old: startIdx..endIdx inclusive)
+    expect(getTranslationContextNodes(nodes, ownerDocument, new Set([nodes[4]!]))).toEqual(
+      nodes.slice(3, 7),
+    );
+    // clamps at both ends
+    expect(getTranslationContextNodes(nodes, ownerDocument, new Set([nodes[0]!]))).toEqual(
+      nodes.slice(0, 3),
+    );
+    expect(getTranslationContextNodes(nodes, ownerDocument, new Set([nodes[9]!]))).toEqual(
+      nodes.slice(8, 10),
+    );
   });
 });
 

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextTranslation.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextTranslation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   createTranslationTargetNode,
   excludeTranslationNodes,
+  getTranslationContextNodes,
   groupTextNodesByDocument,
   observeTextNodesByDocument,
 } from '@/app/reader/hooks/useTextTranslation';
@@ -67,6 +68,26 @@ describe('excludeTranslationNodes', () => {
     paragraph.textContent = 'Source paragraph';
 
     expect(excludeTranslationNodes([paragraph])).toEqual([paragraph]);
+  });
+});
+
+describe('getTranslationContextNodes', () => {
+  it('does not include adjacent context nodes from another document', () => {
+    const firstDocument = document.implementation.createHTMLDocument('first');
+    const secondDocument = document.implementation.createHTMLDocument('second');
+    const firstBefore = firstDocument.createElement('p');
+    const firstVisible = firstDocument.createElement('p');
+    const secondAdjacent = secondDocument.createElement('p');
+    const secondAfter = secondDocument.createElement('p');
+
+    const context = getTranslationContextNodes(
+      [firstBefore, firstVisible, secondAdjacent, secondAfter],
+      firstDocument,
+      new Set([firstVisible]),
+    );
+
+    expect(context).toEqual([firstBefore, firstVisible]);
+    expect(context.every((node) => node.ownerDocument === firstDocument)).toBe(true);
   });
 });
 

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextTranslation.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextTranslation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   createTranslationTargetNode,
+  excludeTranslationNodes,
   groupTextNodesByDocument,
   observeTextNodesByDocument,
 } from '@/app/reader/hooks/useTextTranslation';
@@ -43,6 +44,29 @@ describe('observeTextNodesByDocument', () => {
     expect(observed.get(secondDocument)).toEqual([secondNode]);
     observers.forEach((observer) => observer.disconnect());
     expect(disconnected).toEqual([firstDocument, secondDocument]);
+  });
+});
+
+describe('excludeTranslationNodes', () => {
+  it('excludes generated translation wrappers when translated DOM is scanned again', () => {
+    const source = document.createElement('p');
+    source.className = 'translation-source';
+    const hiddenSource = document.createElement('font');
+    hiddenSource.className = 'translation-source-hidden';
+    hiddenSource.textContent = 'Source paragraph';
+    const target = document.createElement('font');
+    target.className = 'translation-target translation-target-block';
+    target.textContent = 'Translated paragraph';
+    source.append(hiddenSource, target);
+
+    expect(excludeTranslationNodes([source, hiddenSource, target])).toEqual([]);
+  });
+
+  it('keeps untranslated book text nodes', () => {
+    const paragraph = document.createElement('p');
+    paragraph.textContent = 'Source paragraph';
+
+    expect(excludeTranslationNodes([paragraph])).toEqual([paragraph]);
   });
 });
 

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextTranslation.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextTranslation.test.ts
@@ -1,5 +1,50 @@
 import { describe, it, expect } from 'vitest';
-import { createTranslationTargetNode } from '@/app/reader/hooks/useTextTranslation';
+import {
+  createTranslationTargetNode,
+  groupTextNodesByDocument,
+  observeTextNodesByDocument,
+} from '@/app/reader/hooks/useTextTranslation';
+
+describe('groupTextNodesByDocument', () => {
+  it('keeps text nodes from separate iframe documents in separate observer groups', () => {
+    const firstDocument = document.implementation.createHTMLDocument('first');
+    const secondDocument = document.implementation.createHTMLDocument('second');
+    const firstNode = firstDocument.createElement('p');
+    const secondNode = secondDocument.createElement('p');
+    const anotherSecondNode = secondDocument.createElement('p');
+
+    const groups = groupTextNodesByDocument([firstNode, secondNode, anotherSecondNode]);
+
+    expect(groups.size).toBe(2);
+    expect(groups.get(firstDocument)).toEqual([firstNode]);
+    expect(groups.get(secondDocument)).toEqual([secondNode, anotherSecondNode]);
+  });
+});
+
+describe('observeTextNodesByDocument', () => {
+  it('creates one observer per iframe document and observes only that document nodes', () => {
+    const firstDocument = document.implementation.createHTMLDocument('first');
+    const secondDocument = document.implementation.createHTMLDocument('second');
+    const firstNode = firstDocument.createElement('p');
+    const secondNode = secondDocument.createElement('p');
+    const observed = new Map<Document, HTMLElement[]>();
+    const disconnected: Document[] = [];
+
+    const observers = observeTextNodesByDocument([firstNode, secondNode], (ownerDocument) => {
+      observed.set(ownerDocument, []);
+      return {
+        observe: (node: HTMLElement) => observed.get(ownerDocument)!.push(node),
+        disconnect: () => disconnected.push(ownerDocument),
+      } as unknown as IntersectionObserver;
+    });
+
+    expect(observers).toHaveLength(2);
+    expect(observed.get(firstDocument)).toEqual([firstNode]);
+    expect(observed.get(secondDocument)).toEqual([secondNode]);
+    observers.forEach((observer) => observer.disconnect());
+    expect(disconnected).toEqual([firstDocument, secondDocument]);
+  });
+});
 
 describe('createTranslationTargetNode', () => {
   it('sets dir="rtl" on the wrapper for an RTL target language', () => {

--- a/apps/readest-app/src/app/reader/hooks/useTextTranslation.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextTranslation.ts
@@ -113,6 +113,31 @@ export const excludeTranslationNodes = (nodes: HTMLElement[]) =>
       !node.querySelector(':scope > .translation-target'),
   );
 
+export const getTranslationContextNodes = (
+  nodes: HTMLElement[],
+  document: Document,
+  visibleElements: Set<HTMLElement>,
+) => {
+  const documentNodes = nodes.filter((node) => node.ownerDocument === document);
+  if (documentNodes.length === 0 || visibleElements.size === 0) return [];
+
+  let firstIdx = documentNodes.length;
+  let lastIdx = -1;
+  for (const element of visibleElements) {
+    const index = documentNodes.indexOf(element);
+    if (index !== -1) {
+      if (index < firstIdx) firstIdx = index;
+      if (index > lastIdx) lastIdx = index;
+    }
+  }
+  if (lastIdx === -1) return [];
+
+  return documentNodes.slice(
+    Math.max(0, firstIdx - 1),
+    Math.min(documentNodes.length, lastIdx + 3),
+  );
+};
+
 /**
  * Hides or restores a paragraph's original text.
  *
@@ -259,32 +284,8 @@ export function useTextTranslation(
           }
         }
 
-        if (visibleElements.size === 0) return;
-
-        const nodes = allTextNodes.current;
-        if (nodes.length === 0) return;
-
-        let firstIdx = nodes.length;
-        let lastIdx = -1;
-        for (const el of visibleElements) {
-          const idx = nodes.indexOf(el);
-          if (idx !== -1) {
-            if (idx < firstIdx) firstIdx = idx;
-            if (idx > lastIdx) lastIdx = idx;
-          }
-        }
-
-        if (lastIdx === -1) return;
-
-        const startIdx = Math.max(0, firstIdx - 1);
-        const endIdx = Math.min(nodes.length - 1, lastIdx + 2);
-
-        for (let i = startIdx; i <= endIdx; i++) {
-          const node = nodes[i];
-          if (node) {
-            scheduleTranslation(node);
-          }
-        }
+        const nodes = getTranslationContextNodes(allTextNodes.current, document, visibleElements);
+        nodes.forEach((node) => scheduleTranslation(node));
       },
       { threshold: 0 },
     );

--- a/apps/readest-app/src/app/reader/hooks/useTextTranslation.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextTranslation.ts
@@ -105,13 +105,37 @@ export const observeTextNodesByDocument = (
     return observer;
   });
 
-export const excludeTranslationNodes = (nodes: HTMLElement[]) =>
-  nodes.filter(
-    (node) =>
-      !node.closest(`.${SOURCE_HIDDEN_CLASS}`) &&
-      !node.closest('.translation-target') &&
-      !node.querySelector(':scope > .translation-target'),
-  );
+/**
+ * Maps a fresh walk of the (possibly already translated) DOM back to one entry
+ * per source paragraph.
+ *
+ * Two shapes have to be normalized. Generated `.translation-target` wrappers are
+ * never source text, so they are dropped outright. A hidden original is *wrapped*
+ * rather than erased, so `walkTextNodes` stops seeing direct text on the
+ * paragraph, descends past it, and emits the `.translation-source-hidden` wrapper
+ * instead — that one is folded back to the paragraph that owns it.
+ *
+ * Folding rather than dropping matters because `allTextNodes` is addressed by
+ * index: `getTranslationContextNodes` slices a window around the visible nodes
+ * and `findNodeIndicesInRange` maps the reading position to a slot. Dropping an
+ * already translated paragraph shifts every index after it and leaves the
+ * reading position unresolvable, which silently kills the read-ahead. Keeping
+ * the paragraph is safe because `scheduleTranslation` and `translateElement`
+ * both already bail when it holds a `.translation-target`.
+ */
+export const resolveTranslationSourceNodes = (nodes: HTMLElement[]) => {
+  const sources: HTMLElement[] = [];
+  const seen = new Set<HTMLElement>();
+  for (const node of nodes) {
+    if (node.closest('.translation-target')) continue;
+    const hider = node.closest<HTMLElement>(`.${SOURCE_HIDDEN_CLASS}`);
+    const source = hider?.parentElement ?? node;
+    if (seen.has(source)) continue;
+    seen.add(source);
+    sources.push(source);
+  }
+  return sources;
+};
 
 export const getTranslationContextNodes = (
   nodes: HTMLElement[],
@@ -241,7 +265,7 @@ export function useTextTranslation(
   const observeTextNodes = () => {
     if (!view || !enabled.current) return;
 
-    const nodes = excludeTranslationNodes(walkTextNodes(view, ['pre', 'code', 'math']));
+    const nodes = resolveTranslationSourceNodes(walkTextNodes(view, ['pre', 'code', 'math']));
     console.log(
       'Observing text nodes for translation:',
       nodes.length,

--- a/apps/readest-app/src/app/reader/hooks/useTextTranslation.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextTranslation.ts
@@ -105,6 +105,14 @@ export const observeTextNodesByDocument = (
     return observer;
   });
 
+export const excludeTranslationNodes = (nodes: HTMLElement[]) =>
+  nodes.filter(
+    (node) =>
+      !node.closest(`.${SOURCE_HIDDEN_CLASS}`) &&
+      !node.closest('.translation-target') &&
+      !node.querySelector(':scope > .translation-target'),
+  );
+
 /**
  * Hides or restores a paragraph's original text.
  *
@@ -208,7 +216,7 @@ export function useTextTranslation(
   const observeTextNodes = () => {
     if (!view || !enabled.current) return;
 
-    const nodes = walkTextNodes(view, ['pre', 'code', 'math']);
+    const nodes = excludeTranslationNodes(walkTextNodes(view, ['pre', 'code', 'math']));
     console.log(
       'Observing text nodes for translation:',
       nodes.length,

--- a/apps/readest-app/src/app/reader/hooks/useTextTranslation.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextTranslation.ts
@@ -82,6 +82,29 @@ export const createTranslationTargetNode = ({
 
 const SOURCE_HIDDEN_CLASS = 'translation-source-hidden';
 
+export const groupTextNodesByDocument = (nodes: HTMLElement[]) => {
+  const grouped = new Map<Document, HTMLElement[]>();
+  nodes.forEach((node) => {
+    const documentNodes = grouped.get(node.ownerDocument);
+    if (documentNodes) {
+      documentNodes.push(node);
+    } else {
+      grouped.set(node.ownerDocument, [node]);
+    }
+  });
+  return grouped;
+};
+
+export const observeTextNodesByDocument = (
+  nodes: HTMLElement[],
+  createObserver: (document: Document) => IntersectionObserver,
+) =>
+  Array.from(groupTextNodesByDocument(nodes), ([document, documentNodes]) => {
+    const observer = createObserver(document);
+    documentNodes.forEach((node) => observer.observe(node));
+    return observer;
+  });
+
 /**
  * Hides or restores a paragraph's original text.
  *
@@ -143,7 +166,7 @@ export function useTextTranslation(
   const translatorPreservesMarkup = !!getTranslators().find(
     (translator) => translator.name === provider,
   )?.preservesMarkup;
-  const observerRef = useRef<IntersectionObserver | null>(null);
+  const observerRefs = useRef<IntersectionObserver[]>([]);
   const translatedElements = useRef<HTMLElement[]>([]);
   const allTextNodes = useRef<HTMLElement[]>([]);
   const translationQueue = useRef<HTMLElement[]>([]);
@@ -185,8 +208,6 @@ export function useTextTranslation(
   const observeTextNodes = () => {
     if (!view || !enabled.current) return;
 
-    const observer = createTranslationObserver();
-    observerRef.current = observer;
     const nodes = walkTextNodes(view, ['pre', 'code', 'math']);
     console.log(
       'Observing text nodes for translation:',
@@ -194,7 +215,8 @@ export function useTextTranslation(
       // nodes.map((n) => n.textContent),
     );
     allTextNodes.current = nodes;
-    nodes.forEach((el) => observer.observe(el));
+    observerRefs.current.forEach((observer) => observer.disconnect());
+    observerRefs.current = observeTextNodesByDocument(nodes, createTranslationObserver);
   };
 
   const updateTranslation = () => {
@@ -216,9 +238,10 @@ export function useTextTranslation(
     }
   };
 
-  const createTranslationObserver = () => {
+  const createTranslationObserver = (document: Document) => {
     const visibleElements = new Set<HTMLElement>();
-    return new IntersectionObserver(
+    const Observer = document.defaultView?.IntersectionObserver ?? IntersectionObserver;
+    return new Observer(
       (entries) => {
         for (const entry of entries) {
           if (entry.isIntersecting) {
@@ -300,10 +323,11 @@ export function useTextTranslation(
   };
 
   const recreateTranslationObserver = () => {
-    const observer = createTranslationObserver();
-    observerRef.current?.disconnect();
-    observerRef.current = observer;
-    allTextNodes.current.forEach((el) => observer.observe(el));
+    observerRefs.current.forEach((observer) => observer.disconnect());
+    observerRefs.current = observeTextNodesByDocument(
+      allTextNodes.current,
+      createTranslationObserver,
+    );
   };
 
   const translateElement = async (el: HTMLElement) => {
@@ -483,7 +507,8 @@ export function useTextTranslation(
         view.removeEventListener('load', observeTextNodes);
         view.removeEventListener('load', hintInitialTranslating);
       }
-      observerRef.current?.disconnect();
+      observerRefs.current.forEach((observer) => observer.disconnect());
+      observerRefs.current = [];
       translatedElements.current = [];
       translationQueue.current = [];
       activeTranslations.current = 0;

--- a/apps/readest-app/src/app/reader/hooks/useTextTranslation.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextTranslation.ts
@@ -287,6 +287,10 @@ export function useTextTranslation(
     translatedElements.current.forEach((element) => {
       const translationTargets = element.querySelectorAll('.translation-target');
       translationTargets.forEach((target) => target.remove());
+      // The hidden source wrapper is `display: none`, so a paragraph left with
+      // neither a target nor a visible original renders blank for as long as the
+      // re-translation is in flight, and stays blank if that translation fails.
+      setSourceVisibility(element, true);
     });
 
     translatedElements.current = [];


### PR DESCRIPTION
## Summary

- create translation observers in each EPUB iframe document instead of the top-level viewport
- ignore generated translation wrappers when the translated DOM is scanned again
- prevent translated-only TTS from reading duplicated nested translations

## Root cause

Foliate renders reflowable sections in nested `about:srcdoc` iframes. A top-level
`IntersectionObserver` treated visible iframe text as off-screen, so regular chapter paragraphs were
not translated. After switching to iframe-local observers, repeated scans could pick up the generated
`translation-source-hidden` wrapper as fresh source text, creating nested duplicate translations that
translated-only TTS read twice.

## Verification

- `groupTextNodesByDocument`: 1 test passed
- `observeTextNodesByDocument`: 1 test passed
- `excludeTranslationNodes`: 2 tests passed
- `createTranslationTargetNode`: 8 tests passed
- manually verified the affected EPUB in the web reader with Chrome DevTools:
  - chapter text receives one translated target per source
  - toggling translation off and on leaves 36 sources and 36 targets
  - no nested source/target pairs and no source with multiple targets

## Notes

The repository-wide pre-push `format:check` currently fails on Windows because `core.autocrlf=true`
causes unrelated checked-out files to be reported as CRLF formatting changes. The targeted files pass
`git diff --check` and the pre-commit Biome formatter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text translation across documents and embedded content.
  * Prevented generated translation elements from being translated again.
  * Preserved hidden originals and already translated content during retranslation.
  * Improved translation context selection near document boundaries.
  * Ensured translation observers are properly managed and cleaned up.

* **Tests**
  * Added coverage for multi-document translation, node filtering, observer cleanup, context selection, and untranslated content preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->