### PR TITLE
feat(reader): add inline note editing

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/components/sidebar/BooknoteItem.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/sidebar/BooknoteItem.test.tsx
@@ -16,7 +16,13 @@ const mocks = vi.hoisted(() => {
     setNotebookEditAnnotation: vi.fn(),
     addAnnotation: vi.fn(),
     saveConfig: vi.fn(),
-    updateBooknotes: vi.fn(() => ({ booknotes: state.booknotes })),
+    // Mirrors the real store: `updateBooknotes` writes back whatever array
+    // it's called with (production code now returns a new array from
+    // `updateBooknoteNoteText` instead of mutating the existing one).
+    updateBooknotes: vi.fn((_key: string, booknotes: typeof state.booknotes) => {
+      state.booknotes = booknotes;
+      return { booknotes: state.booknotes };
+    }),
   };
 });
 

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useInlineTextEditor.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useInlineTextEditor.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useInlineTextEditor } from '@/app/reader/hooks/useInlineTextEditor';
+
+describe('useInlineTextEditor', () => {
+  it('starts outside edit mode with an empty draft', () => {
+    const { result } = renderHook(() => useInlineTextEditor(vi.fn()));
+
+    expect(result.current.inlineEditMode).toBe(false);
+    expect(result.current.draftText).toBe('');
+  });
+
+  it('entering edit mode seeds the draft with the given initial text', () => {
+    const { result } = renderHook(() => useInlineTextEditor(vi.fn()));
+
+    act(() => result.current.startEdit('existing note'));
+
+    expect(result.current.inlineEditMode).toBe(true);
+    expect(result.current.draftText).toBe('existing note');
+  });
+
+  it('typing updates the draft while in edit mode', () => {
+    const { result } = renderHook(() => useInlineTextEditor(vi.fn()));
+    act(() => result.current.startEdit('old'));
+
+    act(() => result.current.setDraftText('new'));
+
+    expect(result.current.draftText).toBe('new');
+  });
+
+  it('cancelling exits edit mode without calling onSave', () => {
+    const onSave = vi.fn();
+    const { result } = renderHook(() => useInlineTextEditor(onSave));
+    act(() => result.current.startEdit('old'));
+    act(() => result.current.setDraftText('discarded'));
+
+    act(() => result.current.cancelEdit());
+
+    expect(result.current.inlineEditMode).toBe(false);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('saving exits edit mode and calls onSave with the current draft', () => {
+    const onSave = vi.fn();
+    const { result } = renderHook(() => useInlineTextEditor(onSave));
+    act(() => result.current.startEdit('old'));
+    act(() => result.current.setDraftText('updated text'));
+
+    act(() => result.current.save());
+
+    expect(result.current.inlineEditMode).toBe(false);
+    expect(onSave).toHaveBeenCalledWith('updated text');
+  });
+
+  it('saving after onSave changes across a rerender calls the latest onSave, not a stale one', () => {
+    const firstOnSave = vi.fn();
+    const secondOnSave = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ onSave }: { onSave: (draftText: string) => void }) => useInlineTextEditor(onSave),
+      { initialProps: { onSave: firstOnSave } },
+    );
+    act(() => result.current.startEdit('old'));
+
+    rerender({ onSave: secondOnSave });
+    act(() => result.current.save());
+
+    expect(firstOnSave).not.toHaveBeenCalled();
+    expect(secondOnSave).toHaveBeenCalledWith('old');
+  });
+});

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useSaveBooknoteNoteText.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useSaveBooknoteNoteText.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, renderHook } from '@testing-library/react';
+import type { BookNote } from '@/types/book';
+
+const h = vi.hoisted(() => ({
+  view: { addAnnotation: vi.fn() },
+  updateBooknotes: vi.fn(),
+  saveConfig: vi.fn(),
+  booknotes: [] as BookNote[],
+}));
+
+vi.mock('@/context/EnvContext', () => ({ useEnv: () => ({ envConfig: {} }) }));
+vi.mock('@/store/settingsStore', () => ({ useSettingsStore: () => ({ settings: {} }) }));
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({
+    getConfig: () => ({ booknotes: h.booknotes }),
+    saveConfig: h.saveConfig,
+    updateBooknotes: h.updateBooknotes,
+  }),
+}));
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    getViewsById: () => [h.view],
+  }),
+}));
+
+import { useSaveBooknoteNoteText } from '@/app/reader/hooks/useSaveBooknoteNoteText';
+
+// note starts blank so a successful save is a bubble-adding transition —
+// that makes "the view was updated" an observable, non-vacuous assertion.
+const makeBooknote = (overrides: Partial<BookNote> = {}): BookNote => ({
+  id: 'note-1',
+  type: 'annotation',
+  cfi: 'epubcfi(/6/4!/4/2,/1:0,/1:5)',
+  note: '',
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.booknotes = [makeBooknote()];
+});
+
+afterEach(() => cleanup());
+
+describe('useSaveBooknoteNoteText', () => {
+  it('redraws the note bubble and saves the config when the store update succeeds', () => {
+    h.updateBooknotes.mockReturnValue({ booknotes: h.booknotes });
+    const { result } = renderHook(() => useSaveBooknoteNoteText('book-1'));
+
+    result.current('note-1', 'new text');
+
+    expect(h.view.addAnnotation).toHaveBeenCalledTimes(1);
+    expect(h.saveConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not touch the view or persist the config when the store update fails', () => {
+    h.updateBooknotes.mockReturnValue(undefined);
+    const { result } = renderHook(() => useSaveBooknoteNoteText('book-1'));
+
+    result.current('note-1', 'new text');
+
+    expect(h.updateBooknotes).toHaveBeenCalledTimes(1);
+    expect(h.view.addAnnotation).not.toHaveBeenCalled();
+    expect(h.saveConfig).not.toHaveBeenCalled();
+  });
+
+  it('does not call updateBooknotes at all when the target booknote no longer exists', () => {
+    h.booknotes = [];
+    const { result } = renderHook(() => useSaveBooknoteNoteText('book-1'));
+
+    result.current('note-1', 'new text');
+
+    expect(h.updateBooknotes).not.toHaveBeenCalled();
+    expect(h.saveConfig).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/__tests__/components/annotation-popup-layout.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotation-popup-layout.browser.test.tsx
@@ -74,6 +74,11 @@ vi.mock('@/helpers/settings', () => ({
 
 vi.mock('@/app/reader/utils/annotatorUtil', () => ({
   getHighlightColorLabel: () => undefined,
+  // AnnotationPopup -> AnnotationNotes -> AnnotationNoteItem ->
+  // useSaveBooknoteNoteText imports these; a browser-mode mock is a strict
+  // ESM module, so every named import along the chain must exist.
+  decideNoteBubbleTransition: () => 'none',
+  applyNoteBubbleTransition: () => {},
 }));
 
 // ── Real component imports ──────────────────────────────────────────────

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotationNoteItem.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotationNoteItem.test.tsx
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import type { BookNote } from '@/types/book';
+
+dayjs.extend(relativeTime);
+
+const h = vi.hoisted(() => ({
+  view: { addAnnotation: vi.fn() },
+  setConfig: vi.fn(),
+  setHoveredBookKey: vi.fn(),
+  setSideBarVisible: vi.fn(),
+  saveConfig: vi.fn(),
+  booknotes: [] as BookNote[],
+  updateBooknotes: vi.fn((_key: string, booknotes: BookNote[]) => {
+    h.booknotes = booknotes;
+    return { booknotes: h.booknotes };
+  }),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: { isMobile: false }, envConfig: {} }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: {} }),
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({
+    getConfig: () => ({ viewSettings: {}, booknotes: h.booknotes }),
+    setConfig: h.setConfig,
+    saveConfig: h.saveConfig,
+    updateBooknotes: h.updateBooknotes,
+  }),
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    setHoveredBookKey: h.setHoveredBookKey,
+    getViewsById: () => [h.view],
+  }),
+}));
+
+vi.mock('@/store/sidebarStore', () => ({
+  useSidebarStore: () => ({ setSideBarVisible: h.setSideBarVisible }),
+}));
+
+vi.mock('@/hooks/useResponsiveSize', () => ({
+  useResponsiveSize: (n: number) => n,
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+import AnnotationNoteItem from '@/app/reader/components/annotator/AnnotationNoteItem';
+
+const makeBooknote = (overrides: Partial<BookNote> = {}): BookNote => ({
+  id: 'n1',
+  type: 'annotation',
+  cfi: 'epubcfi(/6/2!/4/1:0)',
+  note: 'Gryphon',
+  text: 'Gryphon',
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...overrides,
+});
+
+const renderItem = (note: BookNote = makeBooknote()) => {
+  h.booknotes = [note];
+  return render(
+    <AnnotationNoteItem
+      bookKey='test'
+      note={note}
+      isVertical={false}
+      popupHeight={120}
+      onDismiss={() => {}}
+    />,
+  );
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AnnotationNoteItem', () => {
+  it('shows the note text with an edit icon that is not hover-gated', () => {
+    renderItem();
+
+    screen.getByText('Gryphon');
+    const editButton = screen.getByRole('button', { name: 'Edit' });
+    expect(editButton.className).not.toMatch(/opacity-0|group-hover/);
+  });
+
+  it('clicking the note body opens the sidebar annotations tab', () => {
+    renderItem();
+
+    fireEvent.click(screen.getByText('Gryphon'));
+
+    expect(h.setSideBarVisible).toHaveBeenCalledWith(true);
+  });
+
+  it('clicking the edit icon enters edit mode without opening the sidebar', () => {
+    renderItem();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    const textbox = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textbox.value).toBe('Gryphon');
+    expect(h.setSideBarVisible).not.toHaveBeenCalled();
+  });
+
+  it('saving an edit persists the new note text', () => {
+    renderItem();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'updated note' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    expect(h.updateBooknotes).toHaveBeenCalledTimes(1);
+    expect((h.booknotes[0] as BookNote).note).toBe('updated note');
+    expect(h.saveConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancelling an edit discards the draft without persisting', () => {
+    renderItem();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'discarded' } });
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(h.updateBooknotes).not.toHaveBeenCalled();
+    screen.getByText('Gryphon');
+  });
+});

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotationNotes.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotationNotes.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import type { BookNote } from '@/types/book';
+
+dayjs.extend(relativeTime);
+
+const h = vi.hoisted(() => ({
+  setSideBarVisible: vi.fn(),
+  saveConfig: vi.fn(),
+  booknotes: [] as BookNote[],
+  updateBooknotes: vi.fn((_key: string, booknotes: BookNote[]) => {
+    h.booknotes = booknotes;
+    return { booknotes: h.booknotes };
+  }),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: { isMobile: false }, envConfig: {} }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: {} }),
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({
+    getConfig: () => ({ viewSettings: {}, booknotes: h.booknotes }),
+    setConfig: vi.fn(),
+    saveConfig: h.saveConfig,
+    updateBooknotes: h.updateBooknotes,
+  }),
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({ setHoveredBookKey: vi.fn(), getViewsById: () => [] }),
+}));
+
+vi.mock('@/store/sidebarStore', () => ({
+  useSidebarStore: () => ({ setSideBarVisible: h.setSideBarVisible }),
+}));
+
+vi.mock('@/hooks/useResponsiveSize', () => ({
+  useResponsiveSize: (n: number) => n,
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+import AnnotationNotes from '@/app/reader/components/annotator/AnnotationNotes';
+
+const makeBooknote = (overrides: Partial<BookNote> = {}): BookNote => ({
+  id: 'n1',
+  type: 'annotation',
+  cfi: 'epubcfi(/6/2!/4/1:0)',
+  note: 'note text',
+  text: 'highlighted',
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...overrides,
+});
+
+const renderNotes = (notes: BookNote[]) => {
+  h.booknotes = notes;
+  return render(
+    <AnnotationNotes
+      bookKey='test'
+      isVertical={false}
+      notes={notes}
+      toolsVisible={false}
+      triangleDir='up'
+      popupWidth={240}
+      popupHeight={120}
+      onDismiss={() => {}}
+    />,
+  );
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('AnnotationNotes', () => {
+  it('renders notes most-recently-updated first, regardless of input order', () => {
+    const older = makeBooknote({ id: 'older', note: 'older note', updatedAt: 1000 });
+    const newer = makeBooknote({ id: 'newer', note: 'newer note', updatedAt: 2000 });
+
+    const { container } = renderNotes([older, newer]);
+
+    const cardTexts = Array.from(container.querySelectorAll('.popup-container')).map(
+      (card) => card.textContent,
+    );
+    expect(cardTexts[0]).toContain('newer note');
+    expect(cardTexts[1]).toContain('older note');
+  });
+
+  it('entering edit mode on one note does not affect a sibling note in the same popup', () => {
+    const first = makeBooknote({ id: 'first', note: 'first note', updatedAt: 2000 });
+    const second = makeBooknote({ id: 'second', note: 'second note', updatedAt: 1000 });
+
+    renderNotes([first, second]);
+
+    const editButtons = screen.getAllByRole('button', { name: 'Edit' });
+    expect(editButtons).toHaveLength(2);
+    fireEvent.click(editButtons[0]!);
+
+    const textbox = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textbox.value).toBe('first note');
+    screen.getByText('second note');
+    expect(screen.getAllByRole('button', { name: 'Edit' })).toHaveLength(1);
+  });
+});

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotationNotesMarkdown.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotationNotesMarkdown.test.tsx
@@ -15,12 +15,21 @@ vi.mock('@/context/EnvContext', () => ({
   useEnv: () => ({ appService: { isMobile: false }, envConfig: {} }),
 }));
 
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: {} }),
+}));
+
 vi.mock('@/store/bookDataStore', () => ({
-  useBookDataStore: () => ({ getConfig: () => ({ viewSettings: {} }), setConfig: vi.fn() }),
+  useBookDataStore: () => ({
+    getConfig: () => ({ viewSettings: {} }),
+    setConfig: vi.fn(),
+    saveConfig: vi.fn(),
+    updateBooknotes: vi.fn(),
+  }),
 }));
 
 vi.mock('@/store/readerStore', () => ({
-  useReaderStore: () => ({ setHoveredBookKey: vi.fn() }),
+  useReaderStore: () => ({ setHoveredBookKey: vi.fn(), getViewsById: () => [] }),
 }));
 
 vi.mock('@/store/sidebarStore', () => ({
@@ -29,6 +38,10 @@ vi.mock('@/store/sidebarStore', () => ({
 
 vi.mock('@/hooks/useResponsiveSize', () => ({
   useResponsiveSize: (n: number) => n,
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
 }));
 
 import AnnotationNotes from '@/app/reader/components/annotator/AnnotationNotes';

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotationNotesSurface.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotationNotesSurface.test.tsx
@@ -18,12 +18,21 @@ vi.mock('@/context/EnvContext', () => ({
   useEnv: () => ({ appService: { isMobile: false }, envConfig: {} }),
 }));
 
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: {} }),
+}));
+
 vi.mock('@/store/bookDataStore', () => ({
-  useBookDataStore: () => ({ getConfig: () => ({ viewSettings: {} }), setConfig: vi.fn() }),
+  useBookDataStore: () => ({
+    getConfig: () => ({ viewSettings: {} }),
+    setConfig: vi.fn(),
+    saveConfig: vi.fn(),
+    updateBooknotes: vi.fn(),
+  }),
 }));
 
 vi.mock('@/store/readerStore', () => ({
-  useReaderStore: () => ({ setHoveredBookKey: vi.fn() }),
+  useReaderStore: () => ({ setHoveredBookKey: vi.fn(), getViewsById: () => [] }),
 }));
 
 vi.mock('@/store/sidebarStore', () => ({
@@ -32,6 +41,10 @@ vi.mock('@/store/sidebarStore', () => ({
 
 vi.mock('@/hooks/useResponsiveSize', () => ({
   useResponsiveSize: (n: number) => n,
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
 }));
 
 import AnnotationNotes from '@/app/reader/components/annotator/AnnotationNotes';

--- a/apps/readest-app/src/__tests__/utils/updateBooknoteNoteText.test.ts
+++ b/apps/readest-app/src/__tests__/utils/updateBooknoteNoteText.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { updateBooknoteNoteText } from '@/utils/updateBooknoteNoteText';
+import { BookNote } from '@/types/book';
+
+const makeBooknote = (overrides: Partial<BookNote> = {}): BookNote => ({
+  id: 'note-1',
+  type: 'annotation',
+  cfi: 'epubcfi(/6/4!/4/2,/1:0,/1:5)',
+  note: 'original note',
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...overrides,
+});
+
+describe('updateBooknoteNoteText', () => {
+  it('updates the note text of the booknote matching the given id', () => {
+    const booknotes = [makeBooknote({ id: 'note-1', note: 'old text' })];
+
+    const result = updateBooknoteNoteText(booknotes, 'note-1', 'new text', 5000);
+
+    expect(result!.updatedBooknote.note).toBe('new text');
+  });
+
+  it('leaves booknotes other than the targeted one unchanged', () => {
+    const other = makeBooknote({ id: 'note-2', note: 'untouched', cfi: 'C2' });
+    const booknotes = [makeBooknote({ id: 'note-1', note: 'old text' }), other];
+
+    const result = updateBooknoteNoteText(booknotes, 'note-1', 'new text', 5000);
+
+    expect(result!.booknotes.find((n) => n.id === 'note-2')).toEqual(other);
+  });
+
+  it('does not mutate the input booknotes array', () => {
+    const booknotes = [makeBooknote({ id: 'note-1', note: 'old text', updatedAt: 1000 })];
+    const snapshotBeforeCall = JSON.parse(JSON.stringify(booknotes));
+
+    updateBooknoteNoteText(booknotes, 'note-1', 'new text', 5000);
+
+    expect(booknotes).toEqual(snapshotBeforeCall);
+  });
+
+  it('does not mutate the original booknote object being edited', () => {
+    const original = makeBooknote({ id: 'note-1', note: 'old text', updatedAt: 1000 });
+    const booknotes = [original];
+
+    updateBooknoteNoteText(booknotes, 'note-1', 'new text', 5000);
+
+    expect(original.note).toBe('old text');
+    expect(original.updatedAt).toBe(1000);
+  });
+
+  it('returns a new booknotes array and a new updated booknote, not the same references', () => {
+    const original = makeBooknote({ id: 'note-1', note: 'old text' });
+    const booknotes = [original];
+
+    const result = updateBooknoteNoteText(booknotes, 'note-1', 'new text', 5000);
+
+    expect(result!.booknotes).not.toBe(booknotes);
+    expect(result!.updatedBooknote).not.toBe(original);
+  });
+
+  it('normalizes a whitespace-only note to an empty string', () => {
+    const booknotes = [makeBooknote({ id: 'note-1', note: 'old text' })];
+
+    const result = updateBooknoteNoteText(booknotes, 'note-1', '   \n\t  ', 5000);
+
+    expect(result!.updatedBooknote.note).toBe('');
+  });
+
+  it('keeps non-blank note text exactly as given, without trimming surrounding whitespace', () => {
+    const booknotes = [makeBooknote({ id: 'note-1', note: 'old text' })];
+
+    const result = updateBooknoteNoteText(booknotes, 'note-1', '  hello  ', 5000);
+
+    expect(result!.updatedBooknote.note).toBe('  hello  ');
+  });
+
+  it('sets updatedAt to the injected now value rather than the current time', () => {
+    const booknotes = [makeBooknote({ id: 'note-1', updatedAt: 1000 })];
+    const injectedNow = 918273645;
+
+    const result = updateBooknoteNoteText(booknotes, 'note-1', 'new text', injectedNow);
+
+    expect(result!.updatedBooknote.updatedAt).toBe(injectedNow);
+  });
+
+  it('returns null when no booknote with the given id exists', () => {
+    const booknotes = [makeBooknote({ id: 'note-1' })];
+
+    const result = updateBooknoteNoteText(booknotes, 'missing-id', 'new text', 5000);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a deleted booknote instead of reviving it', () => {
+    const booknotes = [makeBooknote({ id: 'note-1', note: 'old text', deletedAt: 4000 })];
+
+    const result = updateBooknoteNoteText(booknotes, 'note-1', 'new text', 5000);
+
+    expect(result).toBeNull();
+  });
+
+  it('preserves every other BookNote field when only the note text changes', () => {
+    const original = makeBooknote({
+      id: 'note-1',
+      note: 'old text',
+      bookHash: 'hash-abc',
+      cfi: 'epubcfi(/6/4!/4/2,/1:0,/1:5)',
+      text: 'highlighted words',
+      style: 'highlight',
+      color: 'yellow',
+      page: 12,
+      global: true,
+      createdAt: 100,
+    });
+    const booknotes = [original];
+
+    const result = updateBooknoteNoteText(booknotes, 'note-1', 'new text', 5000);
+
+    expect(result!.updatedBooknote).toEqual({
+      ...original,
+      note: 'new text',
+      updatedAt: 5000,
+    });
+  });
+
+  it('reports the note text as it was before the update, as previousNoteText', () => {
+    const booknotes = [makeBooknote({ id: 'note-1', note: 'old text' })];
+
+    const result = updateBooknoteNoteText(booknotes, 'note-1', 'new text', 5000);
+
+    expect(result!.previousNoteText).toBe('old text');
+  });
+
+  it('updates the note text of a booknote regardless of its type, not only annotations', () => {
+    const booknotes = [makeBooknote({ id: 'note-1', type: 'bookmark', note: 'old text' })];
+
+    const result = updateBooknoteNoteText(booknotes, 'note-1', 'new text', 5000);
+
+    expect(result!.updatedBooknote.note).toBe('new text');
+  });
+});

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationNoteItem.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationNoteItem.tsx
@@ -1,0 +1,147 @@
+import clsx from 'clsx';
+import dayjs from 'dayjs';
+import React, { useMemo } from 'react';
+import { MdEdit } from 'react-icons/md';
+import { BookNote } from '@/types/book';
+import { useEnv } from '@/context/EnvContext';
+import { useBookDataStore } from '@/store/bookDataStore';
+import { useReaderStore } from '@/store/readerStore';
+import { useSidebarStore } from '@/store/sidebarStore';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useResponsiveSize } from '@/hooks/useResponsiveSize';
+import { useSaveBooknoteNoteText } from '../../hooks/useSaveBooknoteNoteText';
+import { useInlineTextEditor } from '../../hooks/useInlineTextEditor';
+import { parseNoteMarkdown } from '../../utils/noteMarkdown';
+import TextButton from '@/components/TextButton';
+import TextEditor from '@/components/TextEditor';
+
+interface AnnotationNoteItemProps {
+  bookKey: string;
+  note: BookNote;
+  isVertical: boolean;
+  popupHeight: number;
+  onDismiss: () => void;
+}
+
+const cardClassName = clsx(
+  'popup-container rounded-lg',
+  'not-eink:shadow-lg bg-base-300 theme-dark:bg-base-100',
+);
+
+const AnnotationNoteItem: React.FC<AnnotationNoteItemProps> = ({
+  bookKey,
+  note,
+  isVertical,
+  popupHeight,
+  onDismiss,
+}) => {
+  const _ = useTranslation();
+  const { appService } = useEnv();
+  const { getConfig, setConfig } = useBookDataStore();
+  const { setHoveredBookKey } = useReaderStore();
+  const { setSideBarVisible } = useSidebarStore();
+  const saveBooknoteNoteText = useSaveBooknoteNoteText(bookKey);
+  const size16 = useResponsiveSize(16);
+  // Same parser (and sanitizer) as the sidebar so a note previews identically
+  // in both places (#5785); cached because the popup re-renders on every
+  // reposition and parsing long notes is not free.
+  const noteHtml = useMemo(() => (note.note ? parseNoteMarkdown(note.note) : ''), [note.note]);
+
+  const { editorRef, draftText, setDraftText, inlineEditMode, startEdit, cancelEdit, save } =
+    useInlineTextEditor((noteText) => saveBooknoteNoteText(note.id, noteText));
+
+  const cardStyle = isVertical
+    ? { minWidth: 'max-content', height: `${popupHeight}px`, maxHeight: `${popupHeight}px` }
+    : {};
+
+  const handleShowAnnotation = () => {
+    if (!note.id) return;
+
+    if (appService?.isMobile) {
+      onDismiss();
+    }
+
+    setHoveredBookKey('');
+    setSideBarVisible(true);
+    const config = getConfig(bookKey);
+    if (config?.viewSettings) {
+      setConfig(bookKey, {
+        viewSettings: { ...config.viewSettings, sideBarTab: 'annotations' },
+      });
+    }
+  };
+
+  const handleEditClick = (event: React.MouseEvent) => {
+    // Editing must not also trigger the card's own click handler
+    // (handleShowAnnotation), which would open the sidebar underneath it.
+    event.stopPropagation();
+    startEdit(note.note || '');
+  };
+
+  if (inlineEditMode) {
+    return (
+      <div className={cardClassName} style={cardStyle}>
+        <div className='m-4 flex flex-col gap-2'>
+          <TextEditor
+            ref={editorRef}
+            value={draftText}
+            onChange={setDraftText}
+            onSave={save}
+            onEscape={cancelEdit}
+            spellCheck={false}
+            autoFocus
+          />
+          <div className='flex justify-end gap-3' dir='ltr'>
+            <TextButton onClick={cancelEdit}>{_('Cancel')}</TextButton>
+            <TextButton onClick={save}>{_('Save')}</TextButton>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role='none'
+      onClick={handleShowAnnotation}
+      className={clsx(cardClassName, 'cursor-pointer transition-colors')}
+      style={cardStyle}
+    >
+      {note.note && (
+        <div
+          dir='auto'
+          className={clsx(
+            'm-4 hyphens-auto text-justify font-sans text-sm',
+            isVertical && 'writing-vertical-rl',
+          )}
+          style={
+            isVertical ? { fontFeatureSettings: "'vrt2' 1, 'vert' 1", minWidth: 'max-content' } : {}
+          }
+        >
+          <div className='flex flex-col justify-between gap-2'>
+            <div
+              className='prose prose-sm max-w-none'
+              dangerouslySetInnerHTML={{ __html: noteHtml }}
+            />
+            <div className='flex items-center justify-between gap-2'>
+              <span className='text-base-content/50 text-sm sm:text-xs'>
+                {dayjs(note.createdAt).fromNow()}
+              </span>
+              {/* Always visible, not hover-gated: the popup is used on touch
+                  devices, which have no hover state to reveal it. */}
+              <button
+                onClick={handleEditClick}
+                className='btn btn-ghost btn-xs p-0 text-blue-500 hover:bg-transparent'
+                aria-label={_('Edit')}
+              >
+                <MdEdit size={size16} />
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default React.memo(AnnotationNoteItem);

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationNotes.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationNotes.tsx
@@ -1,13 +1,8 @@
 import clsx from 'clsx';
-import dayjs from 'dayjs';
 import React, { useMemo } from 'react';
 import { BookNote } from '@/types/book';
-import { useEnv } from '@/context/EnvContext';
-import { useBookDataStore } from '@/store/bookDataStore';
-import { useReaderStore } from '@/store/readerStore';
-import { useSidebarStore } from '@/store/sidebarStore';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
-import { parseNoteMarkdown } from '../../utils/noteMarkdown';
+import AnnotationNoteItem from './AnnotationNoteItem';
 
 interface AnnotationNotesProps {
   bookKey: string;
@@ -30,38 +25,11 @@ const AnnotationNotes: React.FC<AnnotationNotesProps> = ({
   popupHeight,
   onDismiss,
 }) => {
-  const { appService } = useEnv();
-  const { getConfig, setConfig } = useBookDataStore();
-  const { setHoveredBookKey } = useReaderStore();
-  const { setSideBarVisible } = useSidebarStore();
-  const config = getConfig(bookKey);
   const maxSize = useResponsiveSize(250);
 
   const sortedNotes = useMemo(() => {
     return [...notes].sort((a, b) => b.updatedAt - a.updatedAt);
   }, [notes]);
-  // Parsing is not free for long notes; the popup re-renders on every
-  // reposition, so cache by the notes list like the sidebar does.
-  const notesHtml = useMemo(
-    () => sortedNotes.map((note) => (note.note ? parseNoteMarkdown(note.note) : '')),
-    [sortedNotes],
-  );
-
-  const handleShowAnnotation = (note: BookNote) => {
-    if (!note.id) return;
-
-    if (appService?.isMobile) {
-      onDismiss();
-    }
-
-    setHoveredBookKey('');
-    setSideBarVisible(true);
-    if (config?.viewSettings) {
-      setConfig(bookKey, {
-        viewSettings: { ...config.viewSettings, sideBarTab: 'annotations' },
-      });
-    }
-  };
 
   return (
     <div
@@ -101,55 +69,14 @@ const AnnotationNotes: React.FC<AnnotationNotesProps> = ({
         }
       >
         {sortedNotes.map((note, index) => (
-          <div
-            role='none'
+          <AnnotationNoteItem
             key={note.id || index}
-            onClick={() => handleShowAnnotation?.(note)}
-            // Popup surface tokens, but no border of its own: the enclosing
-            // Popup already draws the bubble outline that the triangle is
-            // aligned to, and a second one doubles it along the triangle side.
-            className={clsx(
-              'popup-container cursor-pointer rounded-lg transition-colors',
-              'not-eink:shadow-lg bg-base-300 theme-dark:bg-base-100',
-            )}
-            style={
-              isVertical
-                ? {
-                    minWidth: 'max-content',
-                    height: `${popupHeight}px`,
-                    maxHeight: `${popupHeight}px`,
-                  }
-                : {}
-            }
-          >
-            {note.note && (
-              <div
-                dir='auto'
-                className={clsx(
-                  'm-4 hyphens-auto text-justify font-sans text-sm',
-                  isVertical && 'writing-vertical-rl',
-                )}
-                style={
-                  isVertical
-                    ? {
-                        fontFeatureSettings: "'vrt2' 1, 'vert' 1",
-                        minWidth: 'max-content',
-                      }
-                    : {}
-                }
-              >
-                <div className={clsx('flex flex-col justify-between gap-2')}>
-                  <div
-                    className='prose prose-sm max-w-none'
-                    dangerouslySetInnerHTML={{ __html: notesHtml[index] ?? '' }}
-                  />
-                  <span className='text-base-content/50 text-sm sm:text-xs'>
-                    {dayjs(note.createdAt).fromNow()}
-                  </span>
-                </div>
-              </div>
-            )}
-          </div>
+            bookKey={bookKey}
+            note={note}
+            isVertical={isVertical}
+            popupHeight={popupHeight}
+            onDismiss={onDismiss}
+          />
         ))}
       </div>
     </div>

--- a/apps/readest-app/src/app/reader/components/sidebar/BooknoteItem.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/BooknoteItem.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import dayjs from 'dayjs';
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useMemo } from 'react';
 import { MdEdit, MdDelete, MdContentCopy } from 'react-icons/md';
 
 import { useEnv } from '@/context/EnvContext';
@@ -17,14 +17,12 @@ import { buildAnnotationUrl } from '@/utils/deeplink';
 import { buildAnnotationCopyMarkdown } from '@/utils/note';
 import { writeTextToClipboard } from '@/utils/clipboard';
 import { DEFAULT_NOTE_EXPORT_CONFIG } from '@/services/constants';
-import {
-  applyNoteBubbleTransition,
-  decideNoteBubbleTransition,
-  removeBookNoteOverlays,
-} from '../../utils/annotatorUtil';
+import { removeBookNoteOverlays } from '../../utils/annotatorUtil';
 import { parseNoteMarkdown } from '../../utils/noteMarkdown';
+import { useSaveBooknoteNoteText } from '../../hooks/useSaveBooknoteNoteText';
+import { useInlineTextEditor } from '../../hooks/useInlineTextEditor';
 import TextButton from '@/components/TextButton';
-import TextEditor, { TextEditorRef } from '@/components/TextEditor';
+import TextEditor from '@/components/TextEditor';
 
 interface BooknoteItemProps {
   bookKey: string;
@@ -52,9 +50,25 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
   const customColors = globalReadSettings.customHighlightColors;
 
   const { text, cfi, note } = item;
-  const editorRef = useRef<TextEditorRef>(null);
-  const [editorDraft, setEditorDraft] = useState(text || '');
-  const [inlineEditMode, setInlineEditMode] = useState(false);
+  const isBookmark = item.type === 'bookmark';
+  const saveBooknoteNoteText = useSaveBooknoteNoteText(bookKey);
+  const saveBookmarkText = (draftText: string) => {
+    const config = getConfig(bookKey);
+    if (!config || !draftText) return;
+    const { booknotes: annotations = [] } = config;
+    const existingIndex = annotations.findIndex((annotation) => item.id === annotation.id);
+    if (existingIndex === -1) return;
+    annotations[existingIndex]!.updatedAt = Date.now();
+    annotations[existingIndex]!.text = draftText;
+    const updatedConfig = updateBooknotes(bookKey, annotations);
+    if (updatedConfig) {
+      saveConfig(envConfig, bookKey, updatedConfig, settings);
+    }
+  };
+  const { editorRef, draftText, setDraftText, inlineEditMode, startEdit, cancelEdit, save } =
+    useInlineTextEditor(
+      isBookmark ? saveBookmarkText : (noteText) => saveBooknoteNoteText(item.id, noteText),
+    );
   const separatorWidth = useResponsiveSize(3);
   const size18 = useResponsiveSize(18);
 
@@ -131,56 +145,11 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
     });
   };
 
-  const editBookmark = () => {
-    setEditorDraft(text || '');
-    setInlineEditMode(true);
-  };
+  const editBookmark = () => startEdit(text || '');
 
-  const editNoteInline = () => {
-    setEditorDraft(item.note || '');
-    setInlineEditMode(true);
-  };
-
-  const handleSaveInlineNote = () => {
-    setInlineEditMode(false);
-    const config = getConfig(bookKey);
-    if (!config) return;
-    const { booknotes = [] } = config;
-    const existingIndex = booknotes.findIndex(
-      (annotation) => annotation.id === item.id && !annotation.deletedAt,
-    );
-    if (existingIndex === -1) return;
-    const existing = booknotes[existingIndex]!;
-    const nextNote = editorDraft.trim() ? editorDraft : '';
-    const transition = decideNoteBubbleTransition(existing.note, nextNote);
-    const updated: BookNote = { ...existing, note: nextNote, updatedAt: Date.now() };
-    booknotes[existingIndex] = updated;
-    applyNoteBubbleTransition(getViewsById(bookKey.split('-')[0]!), updated, transition);
-    const updatedConfig = updateBooknotes(bookKey, booknotes);
-    if (updatedConfig) {
-      saveConfig(envConfig, bookKey, updatedConfig, settings);
-    }
-  };
-
-  const handleSaveBookmark = () => {
-    setInlineEditMode(false);
-    const config = getConfig(bookKey);
-    if (!config || !editorDraft) return;
-
-    const { booknotes: annotations = [] } = config;
-    const existingIndex = annotations.findIndex((annotation) => item.id === annotation.id);
-    if (existingIndex === -1) return;
-    annotations[existingIndex]!.updatedAt = Date.now();
-    annotations[existingIndex]!.text = editorDraft;
-    const updatedConfig = updateBooknotes(bookKey, annotations);
-    if (updatedConfig) {
-      saveConfig(envConfig, bookKey, updatedConfig, settings);
-    }
-  };
+  const editNoteInline = () => startEdit(item.note || '');
 
   if (inlineEditMode) {
-    const isBookmark = item.type === 'bookmark';
-    const handleSave = isBookmark ? handleSaveBookmark : handleSaveInlineNote;
     return (
       <div
         className={clsx(
@@ -193,17 +162,17 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
           <TextEditor
             className='!leading-normal'
             ref={editorRef}
-            value={editorDraft}
-            onChange={setEditorDraft}
-            onSave={handleSave}
-            onEscape={() => setInlineEditMode(false)}
+            value={draftText}
+            onChange={setDraftText}
+            onSave={save}
+            onEscape={cancelEdit}
             spellCheck={false}
             autoFocus
           />
         </div>
         <div className='flex justify-end space-x-3 p-2' dir='ltr'>
-          <TextButton onClick={() => setInlineEditMode(false)}>{_('Cancel')}</TextButton>
-          <TextButton onClick={handleSave} disabled={isBookmark && !editorDraft}>
+          <TextButton onClick={cancelEdit}>{_('Cancel')}</TextButton>
+          <TextButton onClick={save} disabled={isBookmark && !draftText}>
             {_('Save')}
           </TextButton>
         </div>
@@ -212,7 +181,7 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
   }
 
   const isEditable =
-    !!item.note || item.type === 'bookmark' || (!!inlineNoteEditing && item.type === 'annotation');
+    !!item.note || isBookmark || (!!inlineNoteEditing && item.type === 'annotation');
 
   return (
     <li

--- a/apps/readest-app/src/app/reader/hooks/useInlineTextEditor.ts
+++ b/apps/readest-app/src/app/reader/hooks/useInlineTextEditor.ts
@@ -1,0 +1,32 @@
+import { useCallback, useRef, useState } from 'react';
+import type { TextEditorRef } from '@/components/TextEditor';
+
+/**
+ * UI state for an inline text editor toggled by an edit icon: draft text,
+ * edit-mode on/off, and start/cancel/save actions. Knows nothing about what
+ * it's editing or how a save is persisted — `onSave` is the caller's own
+ * save function (e.g. from `useSaveBooknoteNoteText`), so the same hook
+ * serves any inline-edit surface (booknote text, bookmark text, and later
+ * `AnnotationNotes`) without branching internally.
+ */
+export function useInlineTextEditor(onSave: (draftText: string) => void) {
+  const editorRef = useRef<TextEditorRef>(null);
+  const [draftText, setDraftText] = useState('');
+  const [inlineEditMode, setInlineEditMode] = useState(false);
+
+  const startEdit = useCallback((initialText: string) => {
+    setDraftText(initialText);
+    setInlineEditMode(true);
+  }, []);
+
+  const cancelEdit = useCallback(() => {
+    setInlineEditMode(false);
+  }, []);
+
+  const save = useCallback(() => {
+    setInlineEditMode(false);
+    onSave(draftText);
+  }, [draftText, onSave]);
+
+  return { editorRef, draftText, setDraftText, inlineEditMode, startEdit, cancelEdit, save };
+}

--- a/apps/readest-app/src/app/reader/hooks/useSaveBooknoteNoteText.ts
+++ b/apps/readest-app/src/app/reader/hooks/useSaveBooknoteNoteText.ts
@@ -1,0 +1,54 @@
+import { useCallback } from 'react';
+import { useEnv } from '@/context/EnvContext';
+import { useSettingsStore } from '@/store/settingsStore';
+import { useBookDataStore } from '@/store/bookDataStore';
+import { useReaderStore } from '@/store/readerStore';
+import { updateBooknoteNoteText } from '@/utils/updateBooknoteNoteText';
+import { applyNoteBubbleTransition, decideNoteBubbleTransition } from '../utils/annotatorUtil';
+
+/**
+ * Persists an inline edit to a booknote's `note` text. Writes the updated
+ * booknotes to the store first; only once that write succeeds does it
+ * redraw the note-bubble overlay on every rendered view and save the config
+ * to disk/cloud, so a failed store update never leaves a stale bubble on
+ * screen or persists a config the store itself rejected.
+ *
+ * Shared by every inline note editor (`BooknoteItem`, and later
+ * `AnnotationNotes`) so this persistence/view-update wiring lives in one place.
+ */
+export function useSaveBooknoteNoteText(bookKey: string) {
+  const { envConfig } = useEnv();
+  const { settings } = useSettingsStore();
+  const { getConfig, saveConfig, updateBooknotes } = useBookDataStore();
+  const { getViewsById } = useReaderStore();
+
+  return useCallback(
+    (booknoteId: string, noteText: string) => {
+      const config = getConfig(bookKey);
+      if (!config) return;
+
+      const result = updateBooknoteNoteText(
+        config.booknotes ?? [],
+        booknoteId,
+        noteText,
+        Date.now(),
+      );
+      if (!result) return;
+
+      const updatedConfig = updateBooknotes(bookKey, result.booknotes);
+      if (!updatedConfig) return;
+
+      const transition = decideNoteBubbleTransition(
+        result.previousNoteText,
+        result.updatedBooknote.note,
+      );
+      applyNoteBubbleTransition(
+        getViewsById(bookKey.split('-')[0]!),
+        result.updatedBooknote,
+        transition,
+      );
+      saveConfig(envConfig, bookKey, updatedConfig, settings);
+    },
+    [bookKey, envConfig, settings, getConfig, saveConfig, updateBooknotes, getViewsById],
+  );
+}

--- a/apps/readest-app/src/utils/updateBooknoteNoteText.ts
+++ b/apps/readest-app/src/utils/updateBooknoteNoteText.ts
@@ -1,0 +1,52 @@
+import { BookNote } from '@/types/book';
+
+export interface UpdateBooknoteNoteTextResult {
+  booknotes: BookNote[];
+  updatedBooknote: BookNote;
+  previousNoteText: string;
+}
+
+/**
+ * Replace the `note` text of the live (`!deletedAt`) booknote identified by
+ * `booknoteId`. Returns a new booknotes array — `booknotes` itself is never
+ * mutated. Blank/whitespace-only `noteText` is normalized to an empty
+ * string; non-blank text is stored exactly as given, with no trimming.
+ * `now` is the caller-supplied timestamp for `updatedAt`, keeping this
+ * function deterministic and independent of when it happens to run.
+ *
+ * Matches by `id` alone — intentionally agnostic to `BookNote['type']`, so
+ * it updates the `note` field of a bookmark or excerpt record exactly like
+ * an annotation. Callers that only want to touch annotations are
+ * responsible for filtering by type themselves.
+ *
+ * Returns `null` when no matching, non-deleted record exists — e.g. it was
+ * tombstoned by a concurrent sync before this edit was saved — so the
+ * caller can abort instead of resurrecting a deleted note.
+ */
+export function updateBooknoteNoteText(
+  booknotes: readonly BookNote[],
+  booknoteId: string,
+  noteText: string,
+  now: number,
+): UpdateBooknoteNoteTextResult | null {
+  const existingIndex = booknotes.findIndex(
+    (booknote) => booknote.id === booknoteId && !booknote.deletedAt,
+  );
+  if (existingIndex === -1) return null;
+
+  const existingBooknote = booknotes[existingIndex]!;
+  const normalizedNoteText = noteText.trim() ? noteText : '';
+  const updatedBooknote: BookNote = {
+    ...existingBooknote,
+    note: normalizedNoteText,
+    updatedAt: now,
+  };
+
+  return {
+    booknotes: booknotes.map((booknote, index) =>
+      index === existingIndex ? updatedBooknote : booknote,
+    ),
+    updatedBooknote,
+    previousNoteText: existingBooknote.note,
+  };
+}


### PR DESCRIPTION
## Summary

Adds in-place editing for existing annotation notes directly from the note popup, addressing #4668.

The existing inline editing flow in `BooknoteItem` was first refactored into shared, reusable pieces so the popup can use the same save behavior without duplicating logic.

## What changed

* Extracted shared inline text editing state into `useInlineTextEditor`.
* Extracted shared note persistence into `useSaveBooknoteNoteText`.
* Added a pure `updateBooknoteNoteText` utility for immutable note updates.
* Updated `BooknoteItem` to use the shared editing flow without changing existing behavior.
* Added inline Edit / Save / Cancel support to annotation note popups.
* Made the popup edit action always visible instead of hover-only, improving discoverability and touch accessibility.
* Preserved existing note bubble behavior when adding or clearing note text.

## Validation

* 38/38 relevant tests passing after rebasing onto the latest `upstream/main`.
* Type-check passes.
* Biome lint passes for all touched files.
* Manual verification:

  * create a note
  * edit it from the popup
  * clear its text to remove the note
  * close and reopen the book and confirm the persisted state

## Follow-up

I also investigated the two related routing/state issues discussed in #4668. I kept this PR focused on the original in-place popup editing request so the change remains easy to review; those can be handled separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added inline editing for annotation and bookmark notes.
  - Save or cancel changes directly from note displays.
  - Annotation notes support clearer navigation, mobile dismissal, timestamps, sanitized Markdown, and recent-update sorting.
  - Successful edits refresh note bubbles and save settings automatically.

- **Bug Fixes**
  - Improved handling of blank, missing, deleted, or unsuccessful note updates.
  - Prevented failed edits from changing displayed notes or saved data.

- **Tests**
  - Expanded coverage for note editing, saving, sorting, cancellation, formatting, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->