### PR TITLE
fix(library): recover from a failed startup instead of rendering a blank window

### DIFF
--- a/apps/readest-app/src/__tests__/services/app-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/app-service.test.ts
@@ -247,6 +247,39 @@ describe('BaseAppService', () => {
     });
   });
 
+  describe('isRootDirUsable', () => {
+    test('defaults to no unavailable root', () => {
+      expect(service.unavailableRootDir).toBeNull();
+    });
+
+    test('reports usable without creating anything when the dir already exists', async () => {
+      vi.mocked(mockFs.exists).mockResolvedValue(true);
+      await expect(service.isRootDirUsable()).resolves.toBe(true);
+      expect(mockFs.createDir).not.toHaveBeenCalled();
+    });
+
+    test('creates the books dir when missing and reports usable', async () => {
+      vi.mocked(mockFs.exists).mockResolvedValue(false);
+      await expect(service.isRootDirUsable()).resolves.toBe(true);
+      expect(mockFs.createDir).toHaveBeenCalledWith('', 'Books', true);
+    });
+
+    // The macOS App Sandbox denies `file-write-create` for any path outside the
+    // app container. A stale `customRootDir` therefore made the first library
+    // read throw, and that rejection was never caught — the App Store build sat
+    // on a blank window forever. Probing the root has to answer "no", not throw.
+    test('reports unusable when the books dir cannot be created', async () => {
+      vi.mocked(mockFs.exists).mockResolvedValue(false);
+      vi.mocked(mockFs.createDir).mockRejectedValue(new Error('forbidden path'));
+      await expect(service.isRootDirUsable()).resolves.toBe(false);
+    });
+
+    test('reports unusable when the root cannot even be probed', async () => {
+      vi.mocked(mockFs.exists).mockRejectedValue(new Error('forbidden path'));
+      await expect(service.isRootDirUsable()).resolves.toBe(false);
+    });
+  });
+
   describe('saveLibraryBooks storage permission (READEST-A)', () => {
     // clearAllMocks resets call history but not implementations, so restore the
     // shared saveLibraryBooks mock's default after these override it.

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -30,7 +30,11 @@ import { transferManager } from '@/services/transferManager';
 import { isReadestCloudStorageActive } from '@/services/sync/cloudSyncProvider';
 import { getFilename, getFolderImportGroupName, joinScannedPath } from '@/utils/path';
 import { parseOpenWithFiles } from '@/helpers/openWith';
-import { isTauriAppPlatform, isWebAppPlatform } from '@/services/environment';
+import {
+  getInitializedAppService,
+  isTauriAppPlatform,
+  isWebAppPlatform,
+} from '@/services/environment';
 import { checkForAppUpdates, checkAppReleaseNotes } from '@/helpers/updater';
 import { impactFeedback } from '@tauri-apps/plugin-haptics';
 import { getCurrentWebview } from '@tauri-apps/api/webview';
@@ -769,8 +773,35 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
       return false;
     };
 
-    initLogin();
-    initLibrary();
+    // Both inits are fire-and-forget, and `checkOpenWithBooks` /
+    // `checkLastOpenBooks` are cleared only on `initLibrary`'s success path.
+    // An escaping throw therefore left this page's early return rendering a
+    // bare `full-height` div for the rest of the session — the blank App Store
+    // window, where the sandbox denied a stale `customRootDir` and the mkdir
+    // inside `loadLibraryBooks` rejected with nothing to catch it. Always
+    // release the render gates, then say what actually broke.
+    const recoverFromInitFailure = (error: unknown) => {
+      console.error('Failed to initialize library:', error);
+      setCheckOpenWithBooks(false);
+      setCheckLastOpenBooks(false);
+      setLibraryLoaded(true);
+      if (loadingTimeout) clearTimeout(loadingTimeout);
+      setLoading(false);
+      const unavailableRootDir = getInitializedAppService()?.unavailableRootDir;
+      eventDispatcher.dispatch('toast', {
+        type: 'error',
+        message: unavailableRootDir
+          ? _(
+              'Cannot open the library folder "{{path}}". Reconnect it, or choose another folder in Settings.',
+              { path: unavailableRootDir },
+            )
+          : _('Failed to load your library.'),
+        timeout: 10000,
+      });
+    };
+
+    initLogin().catch((error) => console.error('Failed to initialize login:', error));
+    initLibrary().catch(recoverFromInitFailure);
     return () => {
       setCheckOpenWithBooks(false);
       setCheckLastOpenBooks(false);

--- a/apps/readest-app/src/context/EnvContext.tsx
+++ b/apps/readest-app/src/context/EnvContext.tsx
@@ -24,22 +24,30 @@ export const EnvProvider = ({ children }: { children: ReactNode }) => {
   React.useEffect(() => {
     bootstrapReplicaAdapters();
     enableReplicaAutoPersist(envConfig);
-    envConfig.getAppService().then(async (service) => {
-      setAppService(service);
-      try {
-        const settings = await service.loadSettings();
-        if (settings.replicaDeviceId) {
-          const ctx = initReplicaSync({
-            deviceId: settings.replicaDeviceId,
-            cursorStore: createSettingsCursorStore(service),
-          });
-          ctx.manager.startAutoSync();
-          startReplicaTransferIntegration(service);
+    envConfig
+      .getAppService()
+      .then(async (service) => {
+        setAppService(service);
+        try {
+          const settings = await service.loadSettings();
+          if (settings.replicaDeviceId) {
+            const ctx = initReplicaSync({
+              deviceId: settings.replicaDeviceId,
+              cursorStore: createSettingsCursorStore(service),
+            });
+            ctx.manager.startAutoSync();
+            startReplicaTransferIntegration(service);
+          }
+        } catch (err) {
+          console.warn('replica sync init failed', err);
         }
-      } catch (err) {
-        console.warn('replica sync init failed', err);
-      }
-    });
+      })
+      // Every page gates its render on a non-null `appService`, so an
+      // unhandled rejection here is invisible: no error, no UI, just a blank
+      // window for the rest of the session. Surface it instead.
+      .catch((err) => {
+        console.error('Failed to initialize app service:', err);
+      });
     window.addEventListener('error', (e) => {
       if (e.message === 'ResizeObserver loop limit exceeded') {
         e.stopImmediatePropagation();

--- a/apps/readest-app/src/services/appService.ts
+++ b/apps/readest-app/src/services/appService.ts
@@ -46,6 +46,7 @@ export abstract class BaseAppService implements AppService {
   osPlatform: OsPlatform = getOSPlatform();
   appPlatform: AppPlatform = 'tauri';
   localBooksDir = '';
+  unavailableRootDir: string | null = null;
   isMobile = false;
   isMacOSApp = false;
   isLinuxApp = false;
@@ -180,6 +181,25 @@ export abstract class BaseAppService implements AppService {
 
   async prepareBooksDir() {
     this.localBooksDir = await this.fs.getPrefix('Books');
+  }
+
+  /**
+   * A user-configured library root is untrusted input: the folder can be
+   * deleted, live on an unplugged drive, or — under the macOS App Sandbox —
+   * be a path the kernel refuses outright. Probe it once at startup so a bad
+   * root is reported rather than thrown deep inside the first library read,
+   * where the rejection had nothing to catch it and left the app on a blank
+   * page. Never throws; the answer is the return value.
+   */
+  async isRootDirUsable(): Promise<boolean> {
+    try {
+      if (!(await this.fs.exists('', 'Books'))) {
+        await this.fs.createDir('', 'Books', true);
+      }
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   async openFile(path: string, base: BaseDir): Promise<File> {

--- a/apps/readest-app/src/services/environment.ts
+++ b/apps/readest-app/src/services/environment.ts
@@ -43,8 +43,13 @@ let nativeAppService: AppService | null = null;
 const getNativeAppService = async () => {
   if (!nativeAppService) {
     const { NativeAppService } = await import('@/services/nativeAppService');
-    nativeAppService = new NativeAppService();
-    await nativeAppService.init();
+    // Publish the singleton only after `init` resolves. Assigning first meant a
+    // failed init left a half-built service cached forever: every later caller
+    // got it back without re-running init, and `getInitializedAppService`
+    // handed synchronous callers an object whose paths were never resolved.
+    const service = new NativeAppService();
+    await service.init();
+    nativeAppService = service;
   }
   return nativeAppService;
 };
@@ -53,8 +58,9 @@ let webAppService: AppService | null = null;
 const getWebAppService = async () => {
   if (!webAppService) {
     const { WebAppService } = await import('@/services/webAppService');
-    webAppService = new WebAppService();
-    await webAppService.init();
+    const service = new WebAppService();
+    await service.init();
+    webAppService = service;
   }
   return webAppService;
 };

--- a/apps/readest-app/src/services/nativeAppService.ts
+++ b/apps/readest-app/src/services/nativeAppService.ts
@@ -662,12 +662,23 @@ export class NativeAppService extends BaseAppService {
       });
     }
     const settings = await this.loadSettings();
-    if (this.customRootDir || settings.customRootDir) {
+    const customRootDir = this.customRootDir || settings.customRootDir;
+    if (customRootDir) {
       this.fs.resolvePath = getPathResolver({
-        customRootDir: this.customRootDir || settings.customRootDir,
+        customRootDir,
         isPortable: this.isPortableApp,
         execDir,
       });
+      // Validate the root before anything depends on it. We deliberately keep
+      // the custom resolver installed when it fails: silently falling back to
+      // the default location would scatter imports into a second library and
+      // make the real books look lost once the root comes back. Recording it
+      // here lets the library page name the folder instead of dying on an
+      // unhandled rejection (blank App Store window, sandbox-denied root).
+      if (!(await this.isRootDirUsable())) {
+        this.unavailableRootDir = customRootDir;
+        console.error('[nativeAppService] library root is not usable:', customRootDir);
+      }
     }
     if (this.isIOSApp) {
       this.isOnlineCatalogsAccessible = this.distChannel !== 'appstore';

--- a/apps/readest-app/src/types/system.ts
+++ b/apps/readest-app/src/types/system.ts
@@ -125,7 +125,18 @@ export interface AppService {
   storefrontRegionCode: string | null;
   isOnlineCatalogsAccessible: boolean;
 
+  /**
+   * The configured library root when it turned out to be unreachable this
+   * session (deleted, unplugged, or sandbox-denied); null when the root is
+   * fine. Set during `init` so the UI can name the folder in an error instead
+   * of failing silently. The setting itself is left untouched, so a drive that
+   * comes back is picked up on the next launch.
+   */
+  unavailableRootDir: string | null;
+
   init(): Promise<void>;
+  /** Probe the configured library root. Resolves false instead of throwing. */
+  isRootDirUsable(): Promise<boolean>;
   openFile(path: string, base: BaseDir): Promise<File>;
   copyFile(srcPath: string, srcBase: BaseDir, dstPath: string, dstBase: BaseDir): Promise<void>;
   readFile(path: string, base: BaseDir, mode: 'text' | 'binary'): Promise<string | ArrayBuffer>;


### PR DESCRIPTION
## Symptom

The Mac App Store build launches to a permanently blank window. The same
binary installed from the DMG works. No crash, no error, no UI at all: just
the window background.

The webview is not at fault. Unified logs show a full navigation, a
JS-driven route change, and `page load completed`; `sample` shows the main
thread idle in the normal `-[NSApplication run]` loop.

## Root cause

The kernel names it:

```
kernel  Sandbox: readest(38614) deny(1) file-write-create /Users/chrox/Documents/Readest-Test
```

1. `settings.json` carried a `customRootDir` pointing outside the app
   container.
2. `loadLibraryBooks()` creates the Books dir on first read
   (`libraryService.ts:24-26`), so it ran a recursive mkdir on that root.
3. The App Sandbox denies `file-write-create` anywhere outside the
   container, so the mkdir threw.
4. `initLibrary()` is a floating promise with no `.catch()`
   (`page.tsx:773`), so the rejection escaped.
5. `checkOpenWithBooks` / `checkLastOpenBooks` default to
   `isTauriAppPlatform()` and are cleared only on the success path, so the
   page's early return kept rendering `<div className='full-height bg-base-200' />`
   for the rest of the session.

Web was never affected: both flags start `false` there.

A fresh App Store install has no `settings.json` and so no `customRootDir`,
which is why this is not a day-one launch blocker. But **any** unreachable
library root reaches the same dead end with no in-app recovery: a deleted
folder, an unplugged external drive, or a sandbox-denied path.

## Changes

- **Validate the root instead of trusting it.** `init` probes it once via
  the new `BaseAppService.isRootDirUsable()` and records `unavailableRootDir`
  when it cannot be used.
- **No silent relocation.** The custom resolver stays installed on failure.
  Falling back to the default location would scatter imports into a second
  library and make the real books look lost once the root returns. The
  setting is left untouched, so an unplugged drive is picked up again on the
  next launch.
- **Startup can no longer blank the app.** `initLogin` and `initLibrary` are
  caught; the catch releases the render gates and surfaces an error that
  names the folder when an unreachable root is the cause. `EnvContext` also
  catches a failed `getAppService`, which every page gates its render on.
- **Singleton published only after `init` resolves.** Assigning it first
  meant a failed init cached a half-built service forever: later callers got
  it back without re-running init, and `getInitializedAppService` handed
  synchronous callers an object whose paths were never resolved.

## Testing

- 5 new tests in `app-service.test.ts` covering the probe, including the
  sandbox-denied path. Written first and confirmed failing before the fix.
- Full suite: **9538 passed**, 16 skipped, 0 failed.
- `pnpm lint` (tsgo + biome) and `pnpm format:check` clean.
- Reproduced and confirmed on the installed App Store build: removing
  `customRootDir` from the container's `settings.json` clears the kernel
  denial and the app renders the full library.

No `src-tauri/` or koplugin changes, so those gates do not apply.

## Not covered here

- The `page.tsx` recovery path has no automated test. Covering it means
  rendering a 2181-line page behind a large mock surface, which would assert
  the implementation rather than the behaviour.
- Custom library folders on macOS still have **no security-scoped
  bookmarks**, so a folder picked under the App Store sandbox cannot survive
  a relaunch at all. This PR makes that fail legibly; it does not fix it.
  Worth its own issue.
- Two new user-facing strings are English-only for now. `pnpm i18n:extract`
  sweeps in ~56 unrelated keys of pre-existing drift from other features, so
  the locale pass belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of inaccessible library folders during app startup.
  * Displayed a localized error notification when the library location cannot be accessed.
  * Prevented initialization failures from causing unhandled errors or leaving the app partially initialized.
  * Preserved configured library locations instead of silently falling back when access fails.

* **Tests**
  * Added coverage for missing, inaccessible, and successfully created library directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->