### PR TITLE
docs: use git input instead of github input

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,12 @@ nix run --accept-flake-config github:readest/readest
 To install it, add the input to your `flake.nix`:
 
 ```nix
-inputs.readest.url = "github:readest/readest";
+# Due to a limitation in how Nix fetches submodules, a regular GitHub input type will fail to evaluate.
+inputs.readest = {
+  url = "https://github.com/readest/readest.git";
+  type = "git";
+  submodules = true;
+};
 ```
 
 then in `configuration.nix` add the package and the cache. The cache is needed


### PR DESCRIPTION
Since this project relies on submodules, and nix github inputs cannot properly fetch submodules, this pr changes the nix install guide to reflect that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Nix installation instructions to use a Git-based flake input with submodules enabled.
  * Replaced the previous GitHub shorthand installation format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->