### PR TITLE
feat(reader): expose data-eink on the book document for per-device custom CSS

### DIFF
--- a/apps/readest-app/src/__tests__/utils/style-dom.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-dom.test.ts
@@ -20,6 +20,7 @@ import type { ThemeCode } from '@/utils/style';
 import {
   applyThemeModeClass,
   applyScrollModeClass,
+  applyEinkModeAttribute,
   applyScrollbarStyle,
   applyTranslationStyle,
   getThemeCode,
@@ -105,6 +106,38 @@ describe('applyScrollModeClass', () => {
     document.body.className = '';
     applyScrollModeClass(document, false);
     expect(document.body.classList.contains('paginated-mode')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyEinkModeAttribute (#5795)
+// ---------------------------------------------------------------------------
+describe('applyEinkModeAttribute', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-eink');
+  });
+
+  it("sets data-eink='true' on the book document root when e-ink mode is on", () => {
+    applyEinkModeAttribute(document, true);
+    expect(document.documentElement.getAttribute('data-eink')).toBe('true');
+  });
+
+  it("writes data-eink='false' rather than removing it so LCD-only rules can match", () => {
+    applyEinkModeAttribute(document, true);
+    applyEinkModeAttribute(document, false);
+    expect(document.documentElement.getAttribute('data-eink')).toBe('false');
+    expect(document.body.matches("html[data-eink='false'] body")).toBe(true);
+  });
+
+  it('lets a synced user stylesheet gate rules on the rendering screen', () => {
+    const p = document.createElement('p');
+    document.body.appendChild(p);
+    const einkOnly = "html[data-eink='true'] body *";
+    applyEinkModeAttribute(document, true);
+    expect(p.matches(einkOnly)).toBe(true);
+    applyEinkModeAttribute(document, false);
+    expect(p.matches(einkOnly)).toBe(false);
+    p.remove();
   });
 });
 

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -30,6 +30,7 @@ import { bookOrbitProgressProvider } from '../hooks/bookOrbitProgressProvider';
 import { useKOSync } from '../hooks/useKOSync';
 import { useFileSync } from '../hooks/useFileSync';
 import {
+  applyEinkModeAttribute,
   applyFixedlayoutStyles,
   applyImageStyle,
   applyScrollbarStyle,
@@ -394,6 +395,7 @@ const FoliateViewer: React.FC<{
       applyTableTouchScroll(detail.doc);
       applyThemeModeClass(detail.doc, isDarkMode);
       applyScrollModeClass(detail.doc, viewSettings.scrolled || false);
+      applyEinkModeAttribute(detail.doc, viewSettings.isEink || false);
       applyScrollbarStyle(document, viewSettings.hideScrollbar || false);
       keepTextAlignment(detail.doc);
       handleA11yNavigation(viewRef.current, detail.doc, {
@@ -948,6 +950,7 @@ const FoliateViewer: React.FC<{
         }
         applyThemeModeClass(doc, isDarkMode);
         applyScrollModeClass(doc, viewSettings.scrolled || false);
+        applyEinkModeAttribute(doc, viewSettings.isEink || false);
         applyScrollbarStyle(document, viewSettings.hideScrollbar || false);
       });
 
@@ -970,6 +973,7 @@ const FoliateViewer: React.FC<{
     viewSettings?.applyThemeToPDF,
     viewSettings?.contrast,
     viewSettings?.hideScrollbar,
+    viewSettings?.isEink,
   ]);
 
   useEffect(() => {

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -1285,6 +1285,19 @@ export const applyScrollModeClass = (document: Document, isScrollMode: boolean) 
 };
 
 /**
+ * Mirror the top document's `data-eink` onto the book document so a user
+ * stylesheet can branch on screen type (#5795). `userStylesheet` is in
+ * SETTINGS_WHITELIST and syncs across devices, while `isEink` is per-device;
+ * without this attribute an e-ink readability tweak (say a text stroke to
+ * thicken a light CJK face) also lands on the user's phone and desktop.
+ * Both values are written, matching useEinkMode, so `html[data-eink='false']`
+ * can carry the LCD-only half of a rule.
+ */
+export const applyEinkModeAttribute = (document: Document, isEink: boolean) => {
+  document.documentElement.setAttribute('data-eink', isEink ? 'true' : 'false');
+};
+
+/**
   @param document should be the global `document`
 */
 export const applyScrollbarStyle = (document: Document, hideScrollbar: boolean) => {


### PR DESCRIPTION
## Summary

Closes #5795

Custom Content CSS (`globalViewSettings.userStylesheet`) is in `SETTINGS_WHITELIST` and syncs to every device, while E-ink mode (`isEink`) is per-device. A reader who thickens a light CJK face for a Boox with `-webkit-text-stroke` therefore gets the same stroke on their phone and desktop, where it just looks bloated.

This mirrors the top document's `data-eink` attribute onto each book document (`<html data-eink="true|false">`), so a synced stylesheet can gate rules on the screen it is actually rendering to:

```css
html[data-eink='true'] body, html[data-eink='true'] body * {
  -webkit-text-stroke: 0.14px currentColor;
}
```

- `applyEinkModeAttribute(doc, isEink)` in `src/utils/style.ts`, applied on section load and re-applied over loaded contents when the setting changes, matching `applyThemeModeClass` / `applyScrollModeClass`.
- Both values are written rather than only `'true'`, so `html[data-eink='false']` can carry the LCD-only half of a rule.

### Not addressed here

The reported Font Weight behaviour (100-500 no visual change, 600 very bold) is not a Readest bug: the `LXGW WenKai GB Screen` web font ships a single 400 face (verified against the CDN stylesheet: 248 `@font-face` subsets, all `font-weight: 400`), so CSS font matching collapses 100-500 onto it and only synthesises bold at 600+. The attribute above is what lets that be worked around per device.

## Test plan

- [x] `src/__tests__/utils/style-dom.test.ts`: new `applyEinkModeAttribute` cases (sets `'true'`, writes `'false'` instead of removing, `html[data-eink='true'] body *` matches only while e-ink is on). Confirmed RED against `origin/main` (`applyEinkModeAttribute is not a function`), GREEN on this branch.
- [x] `pnpm test`: 766 files / 9541 tests pass
- [x] `pnpm lint`: clean
- [ ] Device: toggle Settings -> Misc -> E-ink on a Boox with the CSS above in Custom Content CSS; stroke appears, and the same synced CSS leaves an LCD device untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * E-ink mode is now applied consistently to loaded books and updates immediately when reader settings change.
  * Book styling can now detect whether e-ink mode is enabled.

* **Bug Fixes**
  * Improved reliability of e-ink styling across document loading and setting changes.

* **Tests**
  * Added coverage for enabled and disabled e-ink states, CSS selector matching, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->