### PR TITLE
fix(android): keep the reader alive when a Bluetooth controller connects (#5799)

### DIFF
--- a/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
         <meta-data android:name="io.sentry.ndk.enable" android:value="false" />
 
         <activity
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+            android:configChanges="orientation|keyboardHidden|keyboard|navigation|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
             android:launchMode="singleTask"
             android:label="@string/main_activity_title"
             android:hardwareAccelerated="true"


### PR DESCRIPTION
Fixes #5799

## Problem

On Android, connecting / disconnecting / reconnecting a Bluetooth HID page turner (e.g. Hanlinyue Free3-M) while a book is open recreated `MainActivity`. The reader jumped back to the library, and reopening the book showed:

- the page-turn animation reverted to the default,
- the Android status bar overlaying the top of the reader, and
- reader runtime UI state out of sync with the persisted settings.

Fully quitting and relaunching restored everything, which shows the preferences were never lost — only the recreated WebView entered a bad transient state.

## Root cause

Android recreates an activity on any configuration change whose flag is **not** listed in `android:configChanges`. A Bluetooth HID controller connect/disconnect changes `Configuration.navigation` (`CONFIG_NAVIGATION`). The activity handled `keyboard|keyboardHidden` but not `navigation`, so the framework destroyed and rebuilt it on every controller hotplug. Google's [controller guidance](https://developer.android.com/training/tv/get-started/controllers#handle) is to handle `keyboard|keyboardHidden|navigation` together; only `navigation` was missing.

Worth noting: on the current `tao`/`wry` stack the recreated WebView does not recover cleanly (it blanks with a repeating `custom protocol timed out` from the `tauri://localhost` asset loader; see [wry#1551](https://github.com/tauri-apps/wry/issues/1551)), so preventing the recreation is the reliable fix here.

## Fix

Add `navigation` to the activity's handled configuration changes so the controller hotplug is delivered to `onConfigurationChanged` instead of restarting the activity. This keeps the open book, reading position, page-turn animation, and immersive system-bar state intact. One-line manifest change; addresses all three reported symptoms at once since they are all consequences of the recreation resetting runtime state.

## Verification

- Reproduced the recreation → dead-WebView → back-to-library pathway on a Xiaomi 13 (Android 16) by forcing an unhandled config change (`settings put system font_scale`), the same class of change the controller triggers.
- Built the patched manifest into the signed release APK and confirmed on-device: `aapt2 dump xmltree` reports `configChanges=0x00000ff4` (navigation added), the app opens books, and the immersive/fullscreen layout is intact — no regression.
- `pnpm lint` and `pnpm test` (9746 passed) green.
- The real controller hotplug on a patched build still needs confirmation on the reporter's hardware — there is no adb way to synthesize a `navigation` config change on a non-rooted phone. The reporter already verified the pre-fix crash with the physical controller.

## Suggested reviewer check (patched build, with a BT HID controller)

1. Open a book with the controller disconnected.
2. Connect, disconnect, and reconnect the controller.
3. Confirm the activity is not recreated: the current book/position stays visible, the configured page-turn animation stays active, and the immersive system-bar state is unchanged.
4. Confirm controller keys still turn pages after each transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)