### PR TITLE
fix(reader): render markdown in the note bubble popup, closes #5785

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/utils/noteMarkdown.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/utils/noteMarkdown.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { parseNoteMarkdown } from '@/app/reader/utils/noteMarkdown';
+
+/**
+ * Notes are rendered with dangerouslySetInnerHTML in both the sidebar and the
+ * annotation bubble popup, and they can arrive from annotation imports and
+ * sync, not only from the local editor. The shared parser must therefore
+ * strip active content while keeping the Markdown and KaTeX output intact.
+ */
+describe('parseNoteMarkdown', () => {
+  it('renders GitHub-flavored markdown', () => {
+    const html = parseNoteMarkdown('# Title\n\n- one\n- two\n\n~~gone~~ **bold**');
+    expect(html).toContain('<h1>Title</h1>');
+    expect(html).toContain('<li>one</li>');
+    expect(html).toContain('<del>gone</del>');
+    expect(html).toContain('<strong>bold</strong>');
+  });
+
+  it('keeps KaTeX MathML output, including after a line break', () => {
+    const html = parseNoteMarkdown('energy\n$E=mc^2$');
+    expect(html).toContain('<math');
+    expect(html).toContain('<msup>');
+    expect(html).toContain('class="katex"');
+  });
+
+  it('strips scripts and event handlers', () => {
+    const html = parseNoteMarkdown('<script>alert(1)</script><img src=x onerror=alert(1)>');
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('onerror');
+  });
+
+  it('drops javascript: links but keeps http links', () => {
+    const html = parseNoteMarkdown('[bad](javascript:alert(1)) [ok](https://example.com)');
+    expect(html).not.toContain('javascript:');
+    expect(html).toContain('href="https://example.com"');
+  });
+
+  it('removes iframes, forms, styles, and inline svg', () => {
+    const html = parseNoteMarkdown(
+      '<iframe src="https://x"></iframe><form><input name=a></form><style>p{display:none}</style><svg onload=alert(1)></svg>',
+    );
+    expect(html).not.toContain('<iframe');
+    expect(html).not.toContain('<form');
+    expect(html).not.toContain('<input');
+    expect(html).not.toContain('<style');
+    expect(html).not.toContain('<svg');
+  });
+});

--- a/apps/readest-app/src/__tests__/components/annotator/AnnotationNotesMarkdown.test.tsx
+++ b/apps/readest-app/src/__tests__/components/annotator/AnnotationNotesMarkdown.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { BookNote } from '@/types/book';
+
+/**
+ * Issue #5785: the note cards in the annotation bubble popup used to drop the
+ * note in as a bare text node, so newlines collapsed and Markdown syntax showed
+ * verbatim, while the sidebar rendered the same note through Marked. The popup
+ * must go through the same note parser as the sidebar so both previews agree.
+ */
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: { isMobile: false }, envConfig: {} }),
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({ getConfig: () => ({ viewSettings: {} }), setConfig: vi.fn() }),
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({ setHoveredBookKey: vi.fn() }),
+}));
+
+vi.mock('@/store/sidebarStore', () => ({
+  useSidebarStore: () => ({ setSideBarVisible: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useResponsiveSize', () => ({
+  useResponsiveSize: (n: number) => n,
+}));
+
+import AnnotationNotes from '@/app/reader/components/annotator/AnnotationNotes';
+
+dayjs.extend(relativeTime);
+
+afterEach(() => {
+  cleanup();
+});
+
+const renderNote = (note: string, isVertical = false) => {
+  const item: BookNote = {
+    id: 'n1',
+    type: 'annotation',
+    cfi: 'epubcfi(/6/2!/4/1:0)',
+    note,
+    text: 'Gryphon',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+  return render(
+    <AnnotationNotes
+      bookKey='test'
+      isVertical={isVertical}
+      notes={[item]}
+      toolsVisible={false}
+      triangleDir='up'
+      popupWidth={240}
+      popupHeight={120}
+      onDismiss={() => {}}
+    />,
+  );
+};
+
+describe('AnnotationNotes markdown rendering', () => {
+  it('renders headings and lists as HTML instead of raw markdown text', () => {
+    const { container } = renderNote('# Note Title\n\n- first point\n- second point');
+
+    const card = container.querySelector('.popup-container') as HTMLElement;
+    expect(card.querySelector('h1')?.textContent).toBe('Note Title');
+    expect(card.querySelectorAll('li')).toHaveLength(2);
+    expect(card.textContent).not.toContain('# Note Title');
+    expect(card.textContent).not.toContain('- first point');
+  });
+
+  it('keeps paragraphs separate instead of collapsing them into one line', () => {
+    const { container } = renderNote('first paragraph\n\nsecond paragraph');
+
+    const paragraphs = container.querySelectorAll('.popup-container p');
+    expect(paragraphs).toHaveLength(2);
+    expect(paragraphs[0]?.textContent).toBe('first paragraph');
+    expect(paragraphs[1]?.textContent).toBe('second paragraph');
+  });
+
+  it('renders inline math the same way the sidebar does', () => {
+    // `word\n$x$` only parses as math with the sidebar's nonStandard KaTeX
+    // option, so this proves the popup shares that parser config.
+    const { container } = renderNote('energy\n$E=mc^2$');
+
+    expect(container.querySelector('.popup-container math')).not.toBeNull();
+  });
+
+  it('still renders markdown in vertical writing mode', () => {
+    const { container } = renderNote('# Vertical\n\n- a\n- b', true);
+
+    const card = container.querySelector('.popup-container') as HTMLElement;
+    expect(card.querySelector('h1')?.textContent).toBe('Vertical');
+    expect(card.querySelectorAll('li')).toHaveLength(2);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationNotes.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationNotes.tsx
@@ -7,6 +7,7 @@ import { useBookDataStore } from '@/store/bookDataStore';
 import { useReaderStore } from '@/store/readerStore';
 import { useSidebarStore } from '@/store/sidebarStore';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
+import { parseNoteMarkdown } from '../../utils/noteMarkdown';
 
 interface AnnotationNotesProps {
   bookKey: string;
@@ -132,7 +133,10 @@ const AnnotationNotes: React.FC<AnnotationNotesProps> = ({
                 }
               >
                 <div className={clsx('flex flex-col justify-between gap-2')}>
-                  {note.note}
+                  <div
+                    className='prose prose-sm max-w-none'
+                    dangerouslySetInnerHTML={{ __html: parseNoteMarkdown(note.note) }}
+                  />
                   <span className='text-base-content/50 text-sm sm:text-xs'>
                     {dayjs(note.createdAt).fromNow()}
                   </span>

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationNotes.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationNotes.tsx
@@ -40,6 +40,12 @@ const AnnotationNotes: React.FC<AnnotationNotesProps> = ({
   const sortedNotes = useMemo(() => {
     return [...notes].sort((a, b) => b.updatedAt - a.updatedAt);
   }, [notes]);
+  // Parsing is not free for long notes; the popup re-renders on every
+  // reposition, so cache by the notes list like the sidebar does.
+  const notesHtml = useMemo(
+    () => sortedNotes.map((note) => (note.note ? parseNoteMarkdown(note.note) : '')),
+    [sortedNotes],
+  );
 
   const handleShowAnnotation = (note: BookNote) => {
     if (!note.id) return;
@@ -135,7 +141,7 @@ const AnnotationNotes: React.FC<AnnotationNotesProps> = ({
                 <div className={clsx('flex flex-col justify-between gap-2')}>
                   <div
                     className='prose prose-sm max-w-none'
-                    dangerouslySetInnerHTML={{ __html: parseNoteMarkdown(note.note) }}
+                    dangerouslySetInnerHTML={{ __html: notesHtml[index] ?? '' }}
                   />
                   <span className='text-base-content/50 text-sm sm:text-xs'>
                     {dayjs(note.createdAt).fromNow()}

--- a/apps/readest-app/src/app/reader/components/sidebar/BooknoteItem.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/BooknoteItem.tsx
@@ -3,8 +3,6 @@ import dayjs from 'dayjs';
 import React, { useMemo, useRef, useState } from 'react';
 import { MdEdit, MdDelete, MdContentCopy } from 'react-icons/md';
 
-import { Marked } from 'marked';
-import markedKatex from 'marked-katex-extension';
 import { useEnv } from '@/context/EnvContext';
 import { BookNote, HighlightColor } from '@/types/book';
 import { useSettingsStore } from '@/store/settingsStore';
@@ -24,6 +22,7 @@ import {
   decideNoteBubbleTransition,
   removeBookNoteOverlays,
 } from '../../utils/annotatorUtil';
+import { parseNoteMarkdown } from '../../utils/noteMarkdown';
 import TextButton from '@/components/TextButton';
 import TextEditor, { TextEditorRef } from '@/components/TextEditor';
 
@@ -34,22 +33,6 @@ interface BooknoteItemProps {
   onClick?: () => void;
   inlineNoteEditing?: boolean;
 }
-
-// A scoped parser: `.use()` mutates in place, and the export dialog still
-// parses with the shared `marked` singleton. Mirrored in
-// __tests__/utils/md-note.test.ts — keep the options there in sync.
-const markdownParser = new Marked({ gfm: true }).use(
-  markedKatex({
-    // Bad math renders red inline with the error on hover instead of throwing.
-    throwOnError: false,
-    // The default emits MathML + HTML and needs katex.min.css to hide one; no
-    // KaTeX stylesheet is loaded here, so equations would render twice.
-    output: 'mathml',
-    // The default needs a space before the opening `$`, so `word\n$x$` renders
-    // as plain text with no error. Cost: `$5 and $10` is math (`\$` escapes).
-    nonStandard: true,
-  }),
-);
 
 const BooknoteItem: React.FC<BooknoteItemProps> = ({
   bookKey,
@@ -85,10 +68,10 @@ const BooknoteItem: React.FC<BooknoteItemProps> = ({
     [cfi, progress?.location, isNearest],
   );
 
-  // markdownParser.parse is heavy when called on every list scroll re-render
+  // parseNoteMarkdown is heavy when called on every list scroll re-render
   // across hundreds of items. Cache by note text — note edits change
   // item.note and bust the cache automatically.
-  const noteHtml = useMemo(() => (note ? markdownParser.parse(note) : ''), [note]);
+  const noteHtml = useMemo(() => (note ? parseNoteMarkdown(note) : ''), [note]);
 
   // dayjs().fromNow() reformats every render; cache per createdAt.
   const createdAtLabel = useMemo(() => dayjs(item.createdAt).fromNow(), [item.createdAt]);

--- a/apps/readest-app/src/app/reader/utils/noteMarkdown.ts
+++ b/apps/readest-app/src/app/reader/utils/noteMarkdown.ts
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import { Marked } from 'marked';
 import markedKatex from 'marked-katex-extension';
 
@@ -18,4 +19,13 @@ const noteMarkdown = new Marked({ gfm: true }).use(
   }),
 );
 
-export const parseNoteMarkdown = (note: string) => noteMarkdown.parse(note);
+// Notes reach dangerouslySetInnerHTML in the sidebar and the popup, and they
+// can come from annotation imports and sync, not only the local editor, so the
+// HTML is sanitized here once for both sinks. `utils/sanitize.ts#sanitizeHtml`
+// is not reused: its tag allowlist has no MathML and would strip the KaTeX
+// output, which the mathMl profile keeps.
+export const parseNoteMarkdown = (note: string) =>
+  DOMPurify.sanitize(noteMarkdown.parse(note, { async: false }), {
+    USE_PROFILES: { html: true, mathMl: true },
+    FORBID_TAGS: ['style', 'form', 'input', 'button', 'textarea', 'select'],
+  });

--- a/apps/readest-app/src/app/reader/utils/noteMarkdown.ts
+++ b/apps/readest-app/src/app/reader/utils/noteMarkdown.ts
@@ -1,0 +1,21 @@
+import { Marked } from 'marked';
+import markedKatex from 'marked-katex-extension';
+
+// Parser for user-written annotation notes, shared by the sidebar note list
+// and the annotation bubble popup so a note previews the same in both (#5785).
+// A scoped instance: `.use()` mutates in place, and the export dialog still
+// parses with the shared `marked` singleton.
+const noteMarkdown = new Marked({ gfm: true }).use(
+  markedKatex({
+    // Bad math renders red inline with the error on hover instead of throwing.
+    throwOnError: false,
+    // The default emits MathML + HTML and needs katex.min.css to hide one; no
+    // KaTeX stylesheet is loaded here, so equations would render twice.
+    output: 'mathml',
+    // The default needs a space before the opening `$`, so `word\n$x$` renders
+    // as plain text with no error. Cost: `$5 and $10` is math (`\$` escapes).
+    nonStandard: true,
+  }),
+);
+
+export const parseNoteMarkdown = (note: string) => noteMarkdown.parse(note);


### PR DESCRIPTION
## Summary

Closes #5785.

The note cards in the annotation bubble popup (`AnnotationNotes.tsx`) dropped `note.note` in as a bare text node, so newlines collapsed into one line and Markdown showed as raw syntax, while the sidebar (`BooknoteItem.tsx`) has rendered the same note through Marked since #1315 (and KaTeX since #5571). The popup never got the Markdown path; this is a gap, not a regression.

- **`src/app/reader/utils/noteMarkdown.ts`** (new): the sidebar's scoped note parser (`Marked({ gfm })` + `markedKatex` with `throwOnError: false`, `output: 'mathml'`, `nonStandard: true`) exported as `parseNoteMarkdown`, so the two previews cannot drift again. Its output is sanitized with DOMPurify (HTML + MathML profiles, `style`/form controls forbidden), which also closes the pre-existing unsanitized sink in the sidebar while keeping the KaTeX output.
- **`BooknoteItem.tsx`**: uses the shared parser; drops the stale "mirrored in `__tests__/utils/md-note.test.ts`" comment (that test was removed in 171c6de9a).
- **`AnnotationNotes.tsx`**: renders the note through `parseNoteMarkdown` into a `prose prose-sm max-w-none` block, with the parsed HTML memoized on the notes list so repositioning the popup does not reparse long notes. `prose` colors are theme-aware via daisyUI's `--tw-prose-*` tokens; `max-w-none` keeps the vertical-rl `minWidth: max-content` sizing (prose would otherwise cap at `65ch`).

## Test plan

- [x] New `src/__tests__/components/annotator/AnnotationNotesMarkdown.test.tsx`: headings and lists render as HTML (no raw `#`/`-` text), blank-line paragraphs stay separate, `word\n$E=mc^2$` renders MathML (proves the popup uses the sidebar's `nonStandard` KaTeX config), vertical writing mode still renders Markdown. All four failed on `main`, pass with the fix.
- [x] New `src/__tests__/app/reader/utils/noteMarkdown.test.ts`: GFM and KaTeX MathML survive; `<script>`, `onerror=`, `javascript:` hrefs, `<iframe>`, `<form>/<input>`, `<style>` and inline `<svg>` are stripped (the three injection tests failed before the sanitizer landed).
- [x] `pnpm test`: full suite green (9753 passed, 16 skipped before the follow-up; re-run by the pre-push hook with the new tests). `pnpm lint` and Biome format clean.
- [x] Browser (web build): horizontal book (Alice EPUB) and vertical-rl fixture, note with `# heading`, paragraphs, bullet list and inline math. Popup and sidebar Annotations tab now render the same structure; vertical popup flows the blocks as right-to-left columns.

## Pre-landing review

- Open PR #5780 replaces the same hunk with `AnnotationNoteItem.tsx`, which still renders `{note.note}` raw. Whichever lands second needs the `prose` + `parseNoteMarkdown` render ported into `AnnotationNoteItem`.
- `utils/sanitize.ts#sanitizeHtml` was deliberately not reused for notes: its `ALLOWED_TAGS` allowlist has no MathML tags and would strip the KaTeX output. The note parser carries its own DOMPurify config instead.

## Adversarial review (Codex)

- [P1] Stored XSS: raw `<script>`, `onerror=` and `javascript:` links passed the parser into `dangerouslySetInnerHTML`, and annotation import accepts arbitrary note strings inside the privileged Tauri origin. **Fixed** in the follow-up commit: `parseNoteMarkdown` now runs DOMPurify (HTML + MathML profiles) for both the sidebar and the popup, with regression tests.
- [P2] Popup reparsed every note on every render (a 1 MB imported note measured ~200 ms per parse). **Fixed**: parsed HTML is memoized on the notes list.
- [P2] Markdown links inside a note navigate the whole app webview (Tauri's navigation handler only blocks the Alipay scheme). This is **pre-existing** in the sidebar notes and out of scope for #5785; suggested follow-up: delegate anchor clicks in the note renderer, `preventDefault`, and route http(s) links through `openUrl` from `@tauri-apps/plugin-opener` (see `components/Link.tsx`).

## TODOS

No TODO items completed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved annotation and book note rendering for headings, lists, paragraphs, and inline math.
  * Added support for GitHub-flavored Markdown and vertical writing mode in annotation notes.
  * Improved note content safety by filtering scripts, unsafe links, forms, styles, and other potentially harmful elements.

* **Bug Fixes**
  * Improved note rendering performance by reusing parsed Markdown results.

* **Tests**
  * Added coverage for Markdown formatting, math rendering, sanitization, and writing modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->