### PR TITLE
feat(reader): expose book title and series as data attributes for custom UI CSS, closes #5776

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/components/SectionInfo.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/SectionInfo.test.tsx
@@ -1,8 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import SectionInfo from '@/app/reader/components/SectionInfo';
 
-let currentBookData: { isFixedLayout: boolean } | undefined;
+let currentBookData:
+  | {
+      isFixedLayout?: boolean;
+      book?: { title: string; metadata?: { series?: string; seriesIndex?: number } };
+    }
+  | undefined;
 let currentMarginTopPx = 44;
 
 vi.mock('@/context/EnvContext', () => ({
@@ -33,6 +38,13 @@ vi.mock('@/store/bookDataStore', () => {
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => (key: string) => key,
 }));
+
+// Module-level mock state; reset after every test so a failing assertion (or
+// a test that forgets) cannot leak book data into its neighbours.
+afterEach(() => {
+  currentBookData = undefined;
+  currentMarginTopPx = 44;
+});
 
 const baseProps = {
   bookKey: 'book-1',
@@ -90,7 +102,6 @@ describe('SectionInfo notch mask', () => {
 
     expect(notch.classList.contains('notch-masked')).toBe(false);
     expect(notch.classList.contains('bg-base-100')).toBe(false);
-    currentBookData = undefined;
   });
 });
 
@@ -195,5 +206,33 @@ describe('SectionInfo contrast against the page (#4901)', () => {
     const info = container.querySelector('.sectioninfo') as HTMLElement;
 
     expect(info.classList.contains('mix-blend-difference')).toBe(false);
+  });
+});
+
+describe('SectionInfo book metadata data attributes (#5776)', () => {
+  // Custom Reader UI CSS has no other way to reach the book's series: the
+  // running header only prints the section title. The attributes sit inert on
+  // .sectioninfo for `attr()` / `[data-book-series]` rules.
+  it('exposes title, series and series index on .sectioninfo', () => {
+    currentBookData = {
+      isFixedLayout: false,
+      book: { title: 'Leviathan Wakes', metadata: { series: 'The Expanse', seriesIndex: 1 } },
+    };
+    const { container } = render(<SectionInfo {...baseProps} />);
+    const info = container.querySelector('.sectioninfo') as HTMLElement;
+
+    expect(info.getAttribute('data-book-title')).toBe('Leviathan Wakes');
+    expect(info.getAttribute('data-book-series')).toBe('The Expanse');
+    expect(info.getAttribute('data-book-series-index')).toBe('1');
+  });
+
+  it('leaves the series attributes off for a standalone book', () => {
+    currentBookData = { isFixedLayout: false, book: { title: 'Dune', metadata: {} } };
+    const { container } = render(<SectionInfo {...baseProps} />);
+    const info = container.querySelector('.sectioninfo') as HTMLElement;
+
+    expect(info.getAttribute('data-book-title')).toBe('Dune');
+    expect(info.hasAttribute('data-book-series')).toBe(false);
+    expect(info.hasAttribute('data-book-series-index')).toBe(false);
   });
 });

--- a/apps/readest-app/src/__tests__/components/HeaderBar.test.tsx
+++ b/apps/readest-app/src/__tests__/components/HeaderBar.test.tsx
@@ -40,8 +40,11 @@ vi.mock('@/store/readerStore', () => ({
     setHoveredBookKey: vi.fn(),
   }),
 }));
+let currentBookData: {
+  book?: { title: string; metadata?: { series?: string; seriesIndex?: number } };
+} | null = null;
 vi.mock('@/store/bookDataStore', () => ({
-  useBookDataStore: () => ({ getBookData: () => null, getConfig: () => null }),
+  useBookDataStore: () => ({ getBookData: () => currentBookData, getConfig: () => null }),
 }));
 vi.mock('@/store/trafficLightStore', () => ({
   useTrafficLightStore: () => ({
@@ -101,6 +104,7 @@ afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
   useEnvMock.mockReset();
+  currentBookData = null;
 });
 
 describe('HeaderBar sidebar toggle', () => {
@@ -134,5 +138,36 @@ describe('HeaderBar font button', () => {
     // passes whether or not the button is rendered.
     expect(screen.queryByRole('button', { name: 'Font & Layout' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Settings' })).toBeNull();
+  });
+});
+
+describe('HeaderBar book metadata data attributes (#5776)', () => {
+  // The desktop header only prints the title; series readers want "Book 2"
+  // next to it. Exposed on .header-title as inert data attributes so Custom
+  // Reader UI CSS can append them with attr() without a default UI change.
+  it('exposes title, series and series index on .header-title', () => {
+    currentBookData = {
+      book: { title: 'Book', metadata: { series: 'The Expanse', seriesIndex: 2 } },
+    };
+    useEnvMock.mockReturnValue({ envConfig: {}, appService: { isMobile: false } });
+    setViewport(1440, 900);
+    const { container } = renderHeader();
+    const title = container.querySelector('.header-title') as HTMLElement;
+
+    expect(title.getAttribute('data-book-title')).toBe('Book');
+    expect(title.getAttribute('data-book-series')).toBe('The Expanse');
+    expect(title.getAttribute('data-book-series-index')).toBe('2');
+  });
+
+  it('leaves the series attributes off for a standalone book', () => {
+    currentBookData = { book: { title: 'Book', metadata: {} } };
+    useEnvMock.mockReturnValue({ envConfig: {}, appService: { isMobile: false } });
+    setViewport(1440, 900);
+    const { container } = renderHeader();
+    const title = container.querySelector('.header-title') as HTMLElement;
+
+    expect(title.getAttribute('data-book-title')).toBe('Book');
+    expect(title.hasAttribute('data-book-series')).toBe(false);
+    expect(title.hasAttribute('data-book-series-index')).toBe(false);
   });
 });

--- a/apps/readest-app/src/__tests__/components/useMetadataEdit-series.test.ts
+++ b/apps/readest-app/src/__tests__/components/useMetadataEdit-series.test.ts
@@ -1,0 +1,56 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { BookMetadata } from '@/libs/document';
+import { useMetadataEdit } from '@/components/metadata/useMetadataEdit';
+
+const metadata = { title: 'Book', author: 'Author' } as BookMetadata;
+// Stable reference: the hook resyncs editedMeta on the metadata identity.
+const indexedMetadata = { ...metadata, seriesIndex: 2 } as BookMetadata;
+const noTags: string[] = [];
+
+// The Series Index / Total inputs hand over e.target.value, a string. Stored
+// as-is it persists (and syncs) as "2", and every `typeof seriesIndex ===
+// 'number'` consumer (formatSeries, the #5776 data attributes) then silently
+// drops the index for exactly the books the user bothered to edit.
+describe('useMetadataEdit numeric series fields', () => {
+  it('stores the series index as a number', () => {
+    const { result } = renderHook(() => useMetadataEdit(metadata, noTags));
+
+    act(() => {
+      result.current.handleFieldChange('seriesIndex', '2');
+    });
+
+    expect(result.current.editedMeta.seriesIndex).toBe(2);
+  });
+
+  it('keeps fractional indices', () => {
+    const { result } = renderHook(() => useMetadataEdit(metadata, noTags));
+
+    act(() => {
+      result.current.handleFieldChange('seriesIndex', '1.5');
+    });
+
+    expect(result.current.editedMeta.seriesIndex).toBe(1.5);
+  });
+
+  it('clears the index when the input is emptied', () => {
+    const { result } = renderHook(() => useMetadataEdit(indexedMetadata, noTags));
+
+    act(() => {
+      result.current.handleFieldChange('seriesIndex', '');
+    });
+
+    expect(result.current.editedMeta.seriesIndex).toBeUndefined();
+  });
+
+  it('stores the series total as a number', () => {
+    const { result } = renderHook(() => useMetadataEdit(metadata, noTags));
+
+    act(() => {
+      result.current.handleFieldChange('seriesTotal', '7');
+    });
+
+    expect(result.current.editedMeta.seriesTotal).toBe(7);
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/book.test.ts
+++ b/apps/readest-app/src/__tests__/utils/book.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatSeries } from '@/utils/book';
+import { formatSeries, getBookDataAttributes } from '@/utils/book';
 
 describe('formatSeries', () => {
   it('returns an empty string when there is no series name', () => {
@@ -30,5 +30,59 @@ describe('formatSeries', () => {
   it('omits the number when the index is zero or not a finite number', () => {
     expect(formatSeries('Harry Potter', 0)).toBe('Harry Potter');
     expect(formatSeries('Harry Potter', Number.NaN)).toBe('Harry Potter');
+  });
+});
+
+describe('getBookDataAttributes (#5776)', () => {
+  // Custom Reader UI CSS reads these with attr() to surface "Series #2 - Title"
+  // in the running header / header bar. Series attributes must be absent (not
+  // empty) for standalone books so `[data-book-series]` presence checks work.
+  it('exposes the title and omits series attributes for a standalone book', () => {
+    expect(getBookDataAttributes('Dune', {})).toEqual({
+      'data-book-title': 'Dune',
+      'data-book-series': undefined,
+      'data-book-series-index': undefined,
+    });
+    expect(getBookDataAttributes('Dune', undefined)['data-book-series']).toBeUndefined();
+  });
+
+  it('exposes the trimmed series name and its index', () => {
+    expect(
+      getBookDataAttributes('Leviathan Wakes', { series: ' The Expanse ', seriesIndex: 1 }),
+    ).toEqual({
+      'data-book-title': 'Leviathan Wakes',
+      'data-book-series': 'The Expanse',
+      'data-book-series-index': 1,
+    });
+  });
+
+  it('keeps fractional indices', () => {
+    expect(
+      getBookDataAttributes('Novella', { series: 'The Expanse', seriesIndex: 1.5 })[
+        'data-book-series-index'
+      ],
+    ).toBe(1.5);
+  });
+
+  it('omits the index when it is missing, zero (the unknown-position default) or not finite', () => {
+    // readerStore fills a missing calibre:series_index with parseFloat('0'),
+    // so 0 means "no position", matching formatSeries.
+    expect(getBookDataAttributes('T', { series: 'S' })['data-book-series-index']).toBeUndefined();
+    expect(
+      getBookDataAttributes('T', { series: 'S', seriesIndex: 0 })['data-book-series-index'],
+    ).toBeUndefined();
+    expect(
+      getBookDataAttributes('T', { series: 'S', seriesIndex: Number.NaN })[
+        'data-book-series-index'
+      ],
+    ).toBeUndefined();
+  });
+
+  it('omits the index when there is no series to index into', () => {
+    expect(getBookDataAttributes('T', { seriesIndex: 3 })).toEqual({
+      'data-book-title': 'T',
+      'data-book-series': undefined,
+      'data-book-series-index': undefined,
+    });
   });
 });

--- a/apps/readest-app/src/__tests__/utils/book.test.ts
+++ b/apps/readest-app/src/__tests__/utils/book.test.ts
@@ -31,6 +31,13 @@ describe('formatSeries', () => {
     expect(formatSeries('Harry Potter', 0)).toBe('Harry Potter');
     expect(formatSeries('Harry Potter', Number.NaN)).toBe('Harry Potter');
   });
+
+  it('accepts an index persisted as a string by the metadata edit form', () => {
+    // Libraries edited before the form coerced numbers hold "2", synced across
+    // devices; the badge must not drop the index for those books.
+    expect(formatSeries('Harry Potter', '2' as unknown as number)).toBe('Harry Potter #2');
+    expect(formatSeries('Harry Potter', 'abc' as unknown as number)).toBe('Harry Potter');
+  });
 });
 
 describe('getBookDataAttributes (#5776)', () => {
@@ -84,5 +91,57 @@ describe('getBookDataAttributes (#5776)', () => {
       'data-book-series': undefined,
       'data-book-series-index': undefined,
     });
+  });
+
+  it('omits the title attribute when the book has no title yet', () => {
+    // SectionInfo renders before bookData resolves; no attribute beats an empty one.
+    expect(
+      getBookDataAttributes(undefined, { series: 'S', seriesIndex: 1 })['data-book-title'],
+    ).toBeUndefined();
+    expect(getBookDataAttributes('', { series: 'S' })['data-book-title']).toBeUndefined();
+  });
+
+  it('drops a whitespace-only series along with its index', () => {
+    expect(getBookDataAttributes('T', { series: '   ', seriesIndex: 2 })).toEqual({
+      'data-book-title': 'T',
+      'data-book-series': undefined,
+      'data-book-series-index': undefined,
+    });
+  });
+
+  it('omits negative and infinite indices', () => {
+    expect(
+      getBookDataAttributes('T', { series: 'S', seriesIndex: -1 })['data-book-series-index'],
+    ).toBeUndefined();
+    expect(
+      getBookDataAttributes('T', { series: 'S', seriesIndex: Number.POSITIVE_INFINITY })[
+        'data-book-series-index'
+      ],
+    ).toBeUndefined();
+  });
+
+  it('accepts an index persisted as a string by the metadata edit form', () => {
+    expect(
+      getBookDataAttributes('T', { series: 'S', seriesIndex: '2' as unknown as number })[
+        'data-book-series-index'
+      ],
+    ).toBe(2);
+    expect(
+      getBookDataAttributes('T', { series: 'S', seriesIndex: 'abc' as unknown as number })[
+        'data-book-series-index'
+      ],
+    ).toBeUndefined();
+  });
+
+  it('does not throw on a non-string series from a corrupt or foreign metadata row', () => {
+    // Persisted metadata is not runtime-validated (backup restore, sync index);
+    // a bad row must not make the reader header unrenderable.
+    expect(getBookDataAttributes('T', { series: 42 as unknown as string, seriesIndex: 1 })).toEqual(
+      {
+        'data-book-title': 'T',
+        'data-book-series': undefined,
+        'data-book-series-index': undefined,
+      },
+    );
   });
 });

--- a/apps/readest-app/src/app/reader/components/HeaderBar.tsx
+++ b/apps/readest-app/src/app/reader/components/HeaderBar.tsx
@@ -20,6 +20,7 @@ import { annotationToolQuickActions } from './annotator/AnnotationTools';
 import { AnnotationToolType } from '@/types/annotator';
 import { saveViewSettings } from '@/helpers/settings';
 import { getHeaderTriggerHeight } from '@/utils/insets';
+import { getBookDataAttributes } from '@/utils/book';
 import { isForcedMobileLayout } from '../utils/mobileLayout';
 import { HighlighterIcon } from '@/components/HighlighterIcon';
 import Dropdown from '@/components/Dropdown';
@@ -297,6 +298,7 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
             !windowButtonVisible && 'absolute inset-0',
             isHeaderCompact && '!hidden',
           )}
+          {...getBookDataAttributes(bookTitle, bookData?.book?.metadata)}
         >
           <div
             aria-hidden='true'

--- a/apps/readest-app/src/app/reader/components/SectionInfo.tsx
+++ b/apps/readest-app/src/app/reader/components/SectionInfo.tsx
@@ -7,6 +7,7 @@ import { useReaderStore } from '@/store/readerStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { eventDispatcher } from '@/utils/event';
 import { getHeaderBandGeometry } from '@/utils/insets';
+import { getBookDataAttributes } from '@/utils/book';
 import { useBookDataStore } from '@/store/bookDataStore';
 
 interface SectionInfoProps {
@@ -102,6 +103,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
         role='none'
         tabIndex={-1}
         onClick={handleSectionClick}
+        {...getBookDataAttributes(bookData?.book?.title, bookData?.book?.metadata)}
         style={
           isVertical
             ? {

--- a/apps/readest-app/src/components/metadata/useMetadataEdit.ts
+++ b/apps/readest-app/src/components/metadata/useMetadataEdit.ts
@@ -79,6 +79,15 @@ export const useMetadataEdit = (metadata: BookMetadata | null, tags: string[]) =
         case 'subject':
           newMeta['subject'] = value ? value.split(/,|;|，|、/).map((s) => s.trim()) : [];
           break;
+        // Number inputs still hand over strings; stored as-is they persist and
+        // sync as "2", and every numeric consumer (formatSeries, the reader's
+        // data-book-series-index) drops the index.
+        case 'seriesIndex':
+        case 'seriesTotal': {
+          const parsed = value ? parseFloat(value) : Number.NaN;
+          newMeta[field] = Number.isFinite(parsed) ? parsed : undefined;
+          break;
+        }
         default:
           newMeta[field] = value;
       }

--- a/apps/readest-app/src/utils/book.ts
+++ b/apps/readest-app/src/utils/book.ts
@@ -166,12 +166,23 @@ export const formatDescription = (description?: string | LanguageMap) => {
     .trim();
 };
 
+/**
+ * The series position, or undefined when the book has none. Tolerates the two
+ * shapes found in real libraries: readerStore/bookService default a missing
+ * calibre:series_index to 0 (so 0 means "no position"), and indices edited
+ * before the metadata form coerced numbers were persisted (and synced) as
+ * strings like "2".
+ */
+export const getSeriesIndex = (seriesIndex?: number | string): number | undefined => {
+  const index = typeof seriesIndex === 'string' ? parseFloat(seriesIndex) : seriesIndex;
+  return typeof index === 'number' && Number.isFinite(index) && index > 0 ? index : undefined;
+};
+
 export const formatSeries = (series?: string, seriesIndex?: number) => {
   const name = series?.trim();
   if (!name) return '';
-  const hasIndex =
-    typeof seriesIndex === 'number' && Number.isFinite(seriesIndex) && seriesIndex > 0;
-  return hasIndex ? `${name} #${seriesIndex}` : name;
+  const index = getSeriesIndex(seriesIndex);
+  return index !== undefined ? `${name} #${index}` : name;
 };
 
 /**
@@ -179,21 +190,20 @@ export const formatSeries = (series?: string, seriesIndex?: number) => {
  * the running header and HeaderBar only print the title, so series readers
  * append "Series #2" themselves via `attr()`. Series attributes are omitted
  * (undefined, so React drops them) for standalone books, keeping
- * `[data-book-series]` presence checks meaningful. The index gate mirrors
- * formatSeries: readerStore defaults a missing position to 0.
+ * `[data-book-series]` presence checks meaningful. Persisted metadata is not
+ * runtime-validated (backup restore, sync index), so a non-string series is
+ * treated as absent rather than thrown on.
  */
 export const getBookDataAttributes = (
   title?: string,
   metadata?: Pick<BookMetadata, 'series' | 'seriesIndex'>,
 ) => {
-  const series = metadata?.series?.trim() || undefined;
-  const seriesIndex = metadata?.seriesIndex;
-  const hasIndex =
-    !!series && typeof seriesIndex === 'number' && Number.isFinite(seriesIndex) && seriesIndex > 0;
+  const series =
+    typeof metadata?.series === 'string' ? metadata.series.trim() || undefined : undefined;
   return {
     'data-book-title': title || undefined,
     'data-book-series': series,
-    'data-book-series-index': hasIndex ? seriesIndex : undefined,
+    'data-book-series-index': series ? getSeriesIndex(metadata?.seriesIndex) : undefined,
   };
 };
 

--- a/apps/readest-app/src/utils/book.ts
+++ b/apps/readest-app/src/utils/book.ts
@@ -174,6 +174,29 @@ export const formatSeries = (series?: string, seriesIndex?: number) => {
   return hasIndex ? `${name} #${seriesIndex}` : name;
 };
 
+/**
+ * Book metadata as inert `data-*` attributes for Custom Reader UI CSS (#5776):
+ * the running header and HeaderBar only print the title, so series readers
+ * append "Series #2" themselves via `attr()`. Series attributes are omitted
+ * (undefined, so React drops them) for standalone books, keeping
+ * `[data-book-series]` presence checks meaningful. The index gate mirrors
+ * formatSeries: readerStore defaults a missing position to 0.
+ */
+export const getBookDataAttributes = (
+  title?: string,
+  metadata?: Pick<BookMetadata, 'series' | 'seriesIndex'>,
+) => {
+  const series = metadata?.series?.trim() || undefined;
+  const seriesIndex = metadata?.seriesIndex;
+  const hasIndex =
+    !!series && typeof seriesIndex === 'number' && Number.isFinite(seriesIndex) && seriesIndex > 0;
+  return {
+    'data-book-title': title || undefined,
+    'data-book-series': series,
+    'data-book-series-index': hasIndex ? seriesIndex : undefined,
+  };
+};
+
 export const formatPublisher = (publisher: string | LanguageMap) => {
   return typeof publisher === 'string' ? publisher : formatLanguageMap(publisher);
 };


### PR DESCRIPTION
## Summary

Closes #5776.

Custom Reader UI CSS had no way to reach the current book's series: the running header (`.sectioninfo`) and the desktop HeaderBar title only print the title. This PR puts the book's title, series and series index on both elements as inert `data-*` attributes so users can pull them in with `attr()`. No default rendering changes.

- `getBookDataAttributes(title, metadata)` in `src/utils/book.ts` returns `data-book-title`, `data-book-series`, `data-book-series-index`. The series attributes are `undefined` (React omits them) for standalone books, so `[data-book-series]` presence checks work; the index is emitted only when a series exists and the index is a finite number > 0 (same rule as `formatSeries`, because `readerStore` fills a missing `calibre:series_index` with `0`).
- Spread onto the `.sectioninfo` div in `SectionInfo.tsx` and the `.header-title` div in `HeaderBar.tsx`.
- Custom UI CSS is injected into `document.head` by `useUICSS`, so both elements are reachable (the book iframe is not, which is fine here).

**Follow-up fix surfaced by review (second commit):** the Series Index / Series Total inputs hand over `e.target.value` as a string and `useMetadataEdit` stored it unchanged, so an edited index was persisted and synced as `"2"`. Every numeric consumer then dropped it: `formatSeries` showed no `#2` badge in the library, and the new `data-book-series-index` would have vanished for exactly the books the user bothered to edit. The edit hook now coerces the two fields to numbers, and both consumers go through a shared `getSeriesIndex` that also accepts the string shape already sitting in synced libraries. A non-string `series` is treated as absent instead of throwing on `.trim()` (persisted metadata is not runtime-validated).

### Example custom CSS

```css
/* Running header: "The Expanse #2 - Leviathan Wakes" */
.sectioninfo::after {
  content: attr(data-book-series) " #" attr(data-book-series-index) " - " attr(data-book-title);
}
/* Standalone books: title only */
.sectioninfo:not([data-book-series])::after {
  content: attr(data-book-title);
}
/* Desktop header: append "(The Expanse #2)" after the title */
.header-title::after {
  content: " (" attr(data-book-series) " #" attr(data-book-series-index) ")";
}
```

Note: `.header-title` is `hidden sm:flex`, so on phones only `.sectioninfo` carries the attributes unless the user's CSS also un-hides the header title (the issue author already does this).

## Test Coverage

All new code paths have tests.

- `src/__tests__/utils/book.test.ts`: `getBookDataAttributes` standalone / trimmed series / fractional index / 0, NaN, negative, Infinity index / index without series / empty title / whitespace-only series / string index `"2"` and `"abc"` / non-string series does not throw; `formatSeries` accepts a string index.
- `src/__tests__/app/reader/components/SectionInfo.test.tsx` and `src/__tests__/components/HeaderBar.test.tsx`: attributes present on `.sectioninfo` / `.header-title` for a series book, absent for a standalone one.
- `src/__tests__/components/useMetadataEdit-series.test.ts`: `seriesIndex` / `seriesTotal` stored as numbers, fractional kept, emptied input clears the field.

## Pre-Landing Review

Checklist pass: no issues. Specialist + adversarial passes (Claude testing/maintainability specialists, Claude adversarial subagent, Codex adversarial challenge):

- [FIXED] Edited series index persisted as a string, silently dropping `data-book-series-index` and the library `#n` badge (Claude adversarial + Codex, cross-model).
- [FIXED] Non-string `series` in a corrupt or foreign metadata row would throw at `.trim()` during header render (Codex).
- [FIXED] `hasIndex` gate duplicated between `formatSeries` and the new helper (maintainability); extracted `getSeriesIndex`.
- [FIXED] `SectionInfo.test.tsx` reset module-level mock state at the end of test bodies instead of `afterEach`; a shuffled run failed the pre-existing #4486 test (testing specialist). Now reset in `afterEach`; shuffled run passes.
- [NOT CHANGED] Index `0` is unrepresentable because `readerStore`/`bookService` default a missing position to `0`; pre-existing, needs a product call.
- [NOT CHANGED] Attributes are a snapshot of `bookData.book.metadata`, same staleness as the visible title.
- [NOTED] No injection vector: React sets `data-*` via `setAttribute`, and CSS `attr()` yields an opaque string; the only consumer is the user's own stylesheet.

## Test plan

- [x] `pnpm test`: 788 files / 9777 tests passed on the rebased tree
- [x] `pnpm lint` (tsgo + biome): clean
- [x] `pnpm test src/__tests__/app/reader/components/SectionInfo.test.tsx --run --sequence.shuffle --sequence.seed=7`: passes
- [ ] Device check: add the CSS above under Settings > Misc > Custom Reader UI CSS and open a calibre series EPUB; edit the series index in the metadata form and confirm the library badge and the header attribute both update

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added book title, series, and series-index data attributes to reader headers and section information.
  * Improved display and normalization of series metadata, including fractional and string-based indices.
  * Invalid or incomplete series metadata is now omitted from displayed attributes.

* **Bug Fixes**
  * Metadata editing now safely handles empty, invalid, and numeric series values.

* **Tests**
  * Added coverage for metadata attributes, series formatting, editing, and standalone books.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->