### PR TITLE
feat(reader): show PDF page labels as reference pages, closes #5822

### DIFF
--- a/apps/readest-app/src/__tests__/document/pdf-canvas-memory-cap.test.ts
+++ b/apps/readest-app/src/__tests__/document/pdf-canvas-memory-cap.test.ts
@@ -77,6 +77,7 @@ vi.mock('@pdfjs/pdf.min.mjs', () => {
     getMetadata: vi.fn(async () => ({ metadata: undefined, info: {} })),
     getViewerPreferences: vi.fn(async () => null),
     getOutline: vi.fn(async () => null),
+    getPageLabels: vi.fn(async () => null),
     getDestination: vi.fn(),
     getPageIndex: vi.fn(),
     destroy: vi.fn(),

--- a/apps/readest-app/src/__tests__/document/pdf-spread-seam.test.ts
+++ b/apps/readest-app/src/__tests__/document/pdf-spread-seam.test.ts
@@ -52,6 +52,7 @@ vi.mock('@pdfjs/pdf.min.mjs', () => {
     getMetadata: vi.fn(async () => ({ metadata: undefined, info: {} })),
     getViewerPreferences: vi.fn(async () => null),
     getOutline: vi.fn(async () => null),
+    getPageLabels: vi.fn(async () => null),
     getDestination: vi.fn(),
     getPageIndex: vi.fn(),
     destroy: vi.fn(),

--- a/apps/readest-app/src/__tests__/foliate-pdf-page-labels.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-pdf-page-labels.test.ts
@@ -1,0 +1,171 @@
+// readest/readest issue #5822: surface PDF page labels as the book's page list.
+//
+// A PDF's page labels (PDF 32000-1 §12.4.2) are the numbers printed on the
+// pages -- roman-numeral front matter, a body that restarts at 1 -- and are
+// what the book's own TOC and index mean by "page 139", as opposed to the
+// physical 1-based index into the file. foliate-js' `makePDF` must expose
+// them as `book.pageList` so they flow through the same `TOCProgress` ->
+// `pageItem` pipeline an EPUB page-list nav uses, and the footer's reference
+// progress style can show the printed page instead of the raw one.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TOCProgress } from 'foliate-js/progress.js';
+
+// Labels of the PDF Association's PageLabelsTest.pdf (16 pages): roman front
+// matter, an arabic run, an Arabic-Indic run, then prefixed labels.
+const SAMPLE_LABELS = [
+  'i',
+  'ii',
+  'iii',
+  'iv',
+  '1',
+  '2',
+  '3',
+  '4',
+  '٤',
+  '٥',
+  '٦',
+  '٧',
+  ' Long Label - 11',
+  ' Long Label - 12',
+  ' Long Label - 13',
+  ' Long Label - 14',
+];
+
+// Controls what the fake pdf.js document answers for getPageLabels().
+let getPageLabels: () => Promise<string[] | null>;
+let numPages = SAMPLE_LABELS.length;
+
+// Minimal stand-in for the vendored pdf.js build. foliate-js/pdf.js imports it
+// only for the side effect of setting globalThis.pdfjsLib, then reads from
+// that global -- so the mock installs a controllable fake there.
+vi.mock('@pdfjs/pdf.min.mjs', () => {
+  class PDFDataRangeTransport {
+    requestDataRange!: (begin: number, end: number) => void;
+    onDataRange = vi.fn();
+    constructor(
+      public length: number,
+      public initialData: unknown,
+    ) {}
+  }
+  const getDocument = vi.fn(() => ({
+    promise: Promise.resolve({
+      get numPages() {
+        return numPages;
+      },
+      getPage: vi.fn(async () => ({
+        getViewport: () => ({ width: 600, height: 800 }),
+        cleanup: vi.fn(),
+      })),
+      getMetadata: vi.fn(async () => ({ metadata: undefined, info: {} })),
+      getViewerPreferences: vi.fn(async () => null),
+      getOutline: vi.fn(async () => null),
+      getPageLabels: vi.fn(() => getPageLabels()),
+      getDestination: vi.fn(),
+      getPageIndex: vi.fn(),
+      destroy: vi.fn(),
+    }),
+    destroy: vi.fn(),
+  }));
+  (globalThis as unknown as { pdfjsLib: unknown }).pdfjsLib = {
+    GlobalWorkerOptions: {},
+    PDFDataRangeTransport,
+    getDocument,
+  };
+  return {};
+});
+
+const fakeFile = {
+  size: 1,
+  slice: () => ({ arrayBuffer: async () => new ArrayBuffer(0) }),
+} as unknown as File;
+
+interface PageListItem {
+  label: string;
+  href: string;
+}
+
+interface PdfBook {
+  pageList: PageListItem[] | null;
+  sections: { id: number }[];
+  resolveHref: (href: string) => Promise<{ index: number }>;
+  splitTOCHref: (href: string) => Promise<[number | null, string | null]>;
+  getTOCFragment: (doc: Document) => Element;
+}
+
+const open = async (labels: string[] | null | (() => Promise<string[] | null>)) => {
+  getPageLabels = typeof labels === 'function' ? labels : async () => labels;
+  numPages = Array.isArray(labels) ? labels.length : 16;
+  const { makePDF } = await import('foliate-js/pdf.js');
+  return (await makePDF(fakeFile)) as unknown as PdfBook;
+};
+
+// The page list is consumed exactly the way `view.open` wires it up, so a
+// relocate to page `index` yields that page's label as `pageItem`.
+const pageItemFor = async (book: PdfBook, index: number) => {
+  const progress = new TOCProgress();
+  await progress.init({
+    toc: book.pageList ?? [],
+    ids: book.sections.map((s) => s.id),
+    splitHref: book.splitTOCHref.bind(book),
+    getFragment: book.getTOCFragment.bind(book),
+  });
+  return progress.getProgress(index, undefined) as PageListItem | null | undefined;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('makePDF page labels (#5822)', () => {
+  it('exposes the page labels as a page list, one entry per page', async () => {
+    const book = await open(SAMPLE_LABELS);
+    expect(book.pageList).not.toBeNull();
+    expect(book.pageList!.map((item) => item.label)).toEqual(SAMPLE_LABELS);
+  });
+
+  it('resolves a page-list href to its page index, for both navigation and progress', async () => {
+    const book = await open(SAMPLE_LABELS);
+    for (const [i, item] of book.pageList!.entries()) {
+      expect(await book.resolveHref(item.href)).toEqual({ index: i });
+      expect(await book.splitTOCHref(item.href)).toEqual([i, null]);
+    }
+  });
+
+  it('maps a relocate to the label of the page it landed on', async () => {
+    const book = await open(SAMPLE_LABELS);
+    expect((await pageItemFor(book, 0))?.label).toBe('i');
+    expect((await pageItemFor(book, 4))?.label).toBe('1');
+    expect((await pageItemFor(book, 9))?.label).toBe('٥');
+    expect((await pageItemFor(book, 15))?.label).toBe(' Long Label - 14');
+  });
+
+  it('keeps an unlabeled page on its own (empty) entry instead of inheriting its predecessor', async () => {
+    const book = await open(['i', '', '1']);
+    expect((await pageItemFor(book, 1))?.label).toBe('');
+    expect((await pageItemFor(book, 2))?.label).toBe('1');
+  });
+
+  it('ignores labels that merely restate the physical page numbers', async () => {
+    const book = await open(['1', '2', '3', '4']);
+    expect(book.pageList).toBeNull();
+  });
+
+  it('ignores labels that are all empty', async () => {
+    const book = await open(['', '', '']);
+    expect(book.pageList).toBeNull();
+  });
+
+  it('has no page list when the PDF declares no labels', async () => {
+    const book = await open(null);
+    expect(book.pageList).toBeNull();
+  });
+
+  it('still opens when the label tree is unreadable', async () => {
+    const book = await open(async () => {
+      throw new Error('corrupt PageLabels number tree');
+    });
+    expect(book.pageList).toBeNull();
+    expect(book.sections).toHaveLength(16);
+  });
+});

--- a/apps/readest-app/src/__tests__/foliate-pdf-range-concurrency.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-pdf-range-concurrency.test.ts
@@ -48,6 +48,7 @@ vi.mock('@pdfjs/pdf.min.mjs', () => {
     getMetadata: vi.fn(async () => ({ metadata: undefined, info: {} })),
     getViewerPreferences: vi.fn(async () => null),
     getOutline: vi.fn(async () => null),
+    getPageLabels: vi.fn(async () => null),
     getDestination: vi.fn(),
     getPageIndex: vi.fn(),
     destroy: vi.fn(),


### PR DESCRIPTION
## Summary

- Bumps foliate-js to readest/foliate-js#81, where `makePDF` exposes the PDF's page labels (PDF 32000-1 §12.4.2) as `book.pageList`. With that, the footer's **Reference Pages** progress style (Settings → Layout → Reading Progress Style) shows the printed page label for PDFs, e.g. `viii / 240` and `139 / 240`, instead of the physical index, exactly like an EPUB that ships a page-list nav.
- The footer's page-jump input honours labels too: typing `139` under Reference Pages lands on the page labelled 139, not the 139th page of the file.
- The "Reference Page Count" input hides for labelled PDFs, since the book now supplies its own page list.
- The pdf.js test doubles gain `getPageLabels`; the new `foliate-pdf-page-labels.test.ts` covers the list shape, href resolution, relocate → label, an unlabeled page, and the ignore rules (standard `1..N`, all-empty, missing, corrupt label tree).

No readest source changes were needed: `getReferencePageInfo`, `PageJumpInput`, and the layout settings panel already consume `pageList` / `pageItem`.

Design note: the default **Page Number** style keeps showing the physical `10 / 254`, matching how EPUB page lists behave today; the labels live under Reference Pages. If we would rather show labels by default for labelled PDFs (PDF.js shows `viii (10 of 254)`), that is a small follow-up in `ProgressBar` / `PageJumpInput`. Sidebar TOC entries still show physical page numbers for PDF outlines.

Closes #5822

## Test plan

- `pnpm test` (full unit suite) and `pnpm lint` (tsgo + biome) green.
- dev-web in Chrome with the PDF Association's `PageLabelsTest.pdf` from the issue (16 pages, labels `i..iv, 1..4, ٤..٧, " Long Label - 11".." Long Label - 14"`): footer `1 / 16` → switch to Reference Pages → `i / 4`; page 9 → `٤ / 4`; page 14 → `Long Label - 12 / 4`; typing `3` into the footer's page input jumps to physical page 7 (label `3`). (`/ 4` is this torture file's highest numeric label; a real book with `i..xiv, 1..240` reads `/ 240`.)
- Device check on a real labelled PDF still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of PDF page labels, including Roman numerals, Arabic-Indic numbering, prefixes, and printed page references in navigation.
- **Bug Fixes**
  - Improved loading of large PDFs by limiting simultaneous range requests, helping prevent excessive resource usage and improving reliability.
- **Tests**
  - Added coverage for PDF page-label formats, navigation links, and concurrent range loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->