### PR TITLE
feat(rsvp): add exact WPM entry and 10 WPM nudge to the speed dropdown, closes #5820

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2428,5 +2428,6 @@
   "Playback interrupted, tap play to retry": "انقطع التشغيل، اضغط على تشغيل لإعادة المحاولة",
   "Unable to connect to {{server}}": "تعذّر الاتصال بـ{{server}}",
   "Audiobookshelf server not found": "لم يتم العثور على خادم Audiobookshelf",
-  "Episode not found": "لم يتم العثور على الحلقة"
+  "Episode not found": "لم يتم العثور على الحلقة",
+  "Words per minute": "كلمة في الدقيقة"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2192,5 +2192,6 @@
   "Playback interrupted, tap play to retry": "প্লেব্যাক বিঘ্নিত হয়েছে, পুনরায় চেষ্টা করতে প্লেতে ট্যাপ করুন",
   "Unable to connect to {{server}}": "{{server}}-এর সাথে সংযোগ করা যাচ্ছে না",
   "Audiobookshelf server not found": "Audiobookshelf সার্ভার পাওয়া যায়নি",
-  "Episode not found": "এপিসোড পাওয়া যায়নি"
+  "Episode not found": "এপিসোড পাওয়া যায়নি",
+  "Words per minute": "প্রতি মিনিটে শব্দ"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2133,5 +2133,6 @@
   "Playback interrupted, tap play to retry": "གཏོང་བ་བར་ཆད་བྱུང་། ཡང་བསྐྱར་ཚོད་ལྟ་ཆེད་གཏོང་བ་ལ་མནན་རོགས།",
   "Unable to connect to {{server}}": "{{server}} ལ་མཐུད་ཐུབ་མ་སོང་།",
   "Audiobookshelf server not found": "Audiobookshelf ཞབས་ཞུ་བ་མ་རྙེད།",
-  "Episode not found": "འདོན་ཐེངས་མ་རྙེད།"
+  "Episode not found": "འདོན་ཐེངས་མ་རྙེད།",
+  "Words per minute": "སྐར་མ་རེར་ཚིག་གྲངས།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2192,5 +2192,6 @@
   "Playback interrupted, tap play to retry": "Wiedergabe unterbrochen, zum erneuten Versuch auf Wiedergabe tippen",
   "Unable to connect to {{server}}": "Verbindung zu {{server}} nicht möglich",
   "Audiobookshelf server not found": "Audiobookshelf-Server nicht gefunden",
-  "Episode not found": "Episode nicht gefunden"
+  "Episode not found": "Episode nicht gefunden",
+  "Words per minute": "Wörter pro Minute"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2192,5 +2192,6 @@
   "Playback interrupted, tap play to retry": "Η αναπαραγωγή διακόπηκε, πατήστε αναπαραγωγή για να ξαναπροσπαθήσετε",
   "Unable to connect to {{server}}": "Δεν είναι δυνατή η σύνδεση με {{server}}",
   "Audiobookshelf server not found": "Δεν βρέθηκε διακομιστής Audiobookshelf",
-  "Episode not found": "Το επεισόδιο δεν βρέθηκε"
+  "Episode not found": "Το επεισόδιο δεν βρέθηκε",
+  "Words per minute": "Λέξεις ανά λεπτό"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2251,5 +2251,6 @@
   "Playback interrupted, tap play to retry": "Reproducción interrumpida; toca reproducir para reintentar",
   "Unable to connect to {{server}}": "No se puede conectar con {{server}}",
   "Audiobookshelf server not found": "No se encontró el servidor de Audiobookshelf",
-  "Episode not found": "Episodio no encontrado"
+  "Episode not found": "Episodio no encontrado",
+  "Words per minute": "Palabras por minuto"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2192,5 +2192,6 @@
   "Playback interrupted, tap play to retry": "پخش قطع شد، برای تلاش دوباره روی پخش ضربه بزنید",
   "Unable to connect to {{server}}": "اتصال به {{server}} ممکن نیست",
   "Audiobookshelf server not found": "سرور Audiobookshelf یافت نشد",
-  "Episode not found": "قسمت یافت نشد"
+  "Episode not found": "قسمت یافت نشد",
+  "Words per minute": "کلمه در دقیقه"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2251,5 +2251,6 @@
   "Playback interrupted, tap play to retry": "Lecture interrompue, appuyez sur lecture pour réessayer",
   "Unable to connect to {{server}}": "Impossible de se connecter à {{server}}",
   "Audiobookshelf server not found": "Serveur Audiobookshelf introuvable",
-  "Episode not found": "Épisode introuvable"
+  "Episode not found": "Épisode introuvable",
+  "Words per minute": "Mots par minute"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2251,5 +2251,6 @@
   "Playback interrupted, tap play to retry": "הניגון נקטע, הקש על ניגון כדי לנסות שוב",
   "Unable to connect to {{server}}": "לא ניתן להתחבר אל {{server}}",
   "Audiobookshelf server not found": "שרת Audiobookshelf לא נמצא",
-  "Episode not found": "הפרק לא נמצא"
+  "Episode not found": "הפרק לא נמצא",
+  "Words per minute": "מילים לדקה"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2192,5 +2192,6 @@
   "Playback interrupted, tap play to retry": "प्लेबैक बाधित हुआ, फिर से प्रयास करने के लिए प्ले पर टैप करें",
   "Unable to connect to {{server}}": "{{server}} से कनेक्ट नहीं हो सका",
   "Audiobookshelf server not found": "Audiobookshelf सर्वर नहीं मिला",
-  "Episode not found": "एपिसोड नहीं मिला"
+  "Episode not found": "एपिसोड नहीं मिला",
+  "Words per minute": "शब्द प्रति मिनट"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2192,5 +2192,6 @@
   "Playback interrupted, tap play to retry": "A lejátszás megszakadt, koppintson a lejátszásra az újrapróbálkozáshoz",
   "Unable to connect to {{server}}": "Nem sikerült csatlakozni ehhez: {{server}}",
   "Audiobookshelf server not found": "Az Audiobookshelf szerver nem található",
-  "Episode not found": "Az epizód nem található"
+  "Episode not found": "Az epizód nem található",
+  "Words per minute": "Szó percenként"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2133,5 +2133,6 @@
   "Playback interrupted, tap play to retry": "Pemutaran terhenti, ketuk putar untuk mencoba lagi",
   "Unable to connect to {{server}}": "Tidak dapat terhubung ke {{server}}",
   "Audiobookshelf server not found": "Server Audiobookshelf tidak ditemukan",
-  "Episode not found": "Episode tidak ditemukan"
+  "Episode not found": "Episode tidak ditemukan",
+  "Words per minute": "Kata per menit"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2251,5 +2251,6 @@
   "Playback interrupted, tap play to retry": "Riproduzione interrotta, tocca play per riprovare",
   "Unable to connect to {{server}}": "Impossibile connettersi a {{server}}",
   "Audiobookshelf server not found": "Server Audiobookshelf non trovato",
-  "Episode not found": "Episodio non trovato"
+  "Episode not found": "Episodio non trovato",
+  "Words per minute": "Parole al minuto"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2133,5 +2133,6 @@
   "Playback interrupted, tap play to retry": "再生が中断されました。タップして再試行してください",
   "Unable to connect to {{server}}": "{{server}}に接続できません",
   "Audiobookshelf server not found": "Audiobookshelfサーバーが見つかりません",
-  "Episode not found": "エピソードが見つかりません"
+  "Episode not found": "エピソードが見つかりません",
+  "Words per minute": "1分あたりの単語数"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2192,5 +2192,6 @@
   "Playback interrupted, tap play to retry": "დაკვრა შეწყდა, გასამეორებლად შეეხეთ დაკვრას",
   "Unable to connect to {{server}}": "{{server}}-თან დაკავშირება ვერ მოხერხდა",
   "Audiobookshelf server not found": "Audiobookshelf სერვერი ვერ მოიძებნა",
-  "Episode not found": "ეპიზოდი ვერ მოიძებნა"
+  "Episode not found": "ეპიზოდი ვერ მოიძებნა",
+  "Words per minute": "სიტყვა წუთში"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2133,5 +2133,6 @@
   "Playback interrupted, tap play to retry": "재생이 중단되었습니다. 다시 시도하려면 재생을 탭하세요",
   "Unable to connect to {{server}}": "{{server}}에 연결할 수 없습니다",
   "Audiobookshelf server not found": "Audiobookshelf 서버를 찾을 수 없습니다",
-  "Episode not found": "에피소드를 찾을 수 없습니다"
+  "Episode not found": "에피소드를 찾을 수 없습니다",
+  "Words per minute": "분당 단어 수"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2133,5 +2133,6 @@
   "Playback interrupted, tap play to retry": "Main balik terganggu, ketik main untuk cuba semula",
   "Unable to connect to {{server}}": "Tidak dapat menyambung ke {{server}}",
   "Audiobookshelf server not found": "Pelayan Audiobookshelf tidak ditemui",
-  "Episode not found": "Episod tidak ditemui"
+  "Episode not found": "Episod tidak ditemui",
+  "Words per minute": "Perkataan seminit"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2192,5 +2192,6 @@
   "Playback interrupted, tap play to retry": "Afspelen onderbroken, tik op afspelen om het opnieuw te proberen",
   "Unable to connect to {{server}}": "Kan geen verbinding maken met {{server}}",
   "Audiobookshelf server not found": "Audiobookshelf-server niet gevonden",
-  "Episode not found": "Aflevering niet gevonden"
+  "Episode not found": "Aflevering niet gevonden",
+  "Words per minute": "Woorden per minuut"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2310,5 +2310,6 @@
   "Playback interrupted, tap play to retry": "Odtwarzanie przerwane, dotknij odtwarzania, aby spróbować ponownie",
   "Unable to connect to {{server}}": "Nie można połączyć się z {{server}}",
   "Audiobookshelf server not found": "Nie znaleziono serwera Audiobookshelf",
-  "Episode not found": "Nie znaleziono odcinka"
+  "Episode not found": "Nie znaleziono odcinka",
+  "Words per minute": "Słów na minutę"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2251,5 +2251,6 @@
   "Playback interrupted, tap play to retry": "Reprodução interrompida, toque em reproduzir para tentar novamente",
   "Unable to connect to {{server}}": "Não foi possível conectar a {{server}}",
   "Audiobookshelf server not found": "Servidor Audiobookshelf não encontrado",
-  "Episode not found": "Episódio não encontrado"
+  "Episode not found": "Episódio não encontrado",
+  "Words per minute": "Palavras por minuto"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2251,5 +2251,6 @@
   "Playback interrupted, tap play to retry": "Reprodução interrompida, toque em reproduzir para tentar novamente",
   "Unable to connect to {{server}}": "Não é possível ligar a {{server}}",
   "Audiobookshelf server not found": "Servidor Audiobookshelf não encontrado",
-  "Episode not found": "Episódio não encontrado"
+  "Episode not found": "Episódio não encontrado",
+  "Words per minute": "Palavras por minuto"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2251,5 +2251,6 @@
   "Playback interrupted, tap play to retry": "Redare întreruptă, atinge redarea pentru a relua",
   "Unable to connect to {{server}}": "Conectarea la {{server}} nu a reușit",
   "Audiobookshelf server not found": "Serverul Audiobookshelf nu a fost găsit",
-  "Episode not found": "Episodul nu a fost găsit"
+  "Episode not found": "Episodul nu a fost găsit",
+  "Words per minute": "Cuvinte pe minut"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2310,5 +2310,6 @@
   "Playback interrupted, tap play to retry": "Воспроизведение прервано, нажмите «Воспроизвести», чтобы повторить",
   "Unable to connect to {{server}}": "Не удалось подключиться к {{server}}",
   "Audiobookshelf server not found": "Сервер Audiobookshelf не найден",
-  "Episode not found": "Эпизод не найден"
+  "Episode not found": "Эпизод не найден",
+  "Words per minute": "Слов в минуту"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2192,5 +2192,6 @@
   "Playback interrupted, tap play to retry": "වාදනය බාධා විය, නැවත උත්සාහ කිරීමට වාදනය ස්පර්ශ කරන්න",
   "Unable to connect to {{server}}": "{{server}} වෙත සම්බන්ධ විය නොහැක",
   "Audiobookshelf server not found": "Audiobookshelf සේවාදායකයා හමු නොවීය",
-  "Episode not found": "කථාංගය හමු නොවීය"
+  "Episode not found": "කථාංගය හමු නොවීය",
+  "Words per minute": "විනාඩියකට වචන"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2310,5 +2310,6 @@
   "Playback interrupted, tap play to retry": "Predvajanje je bilo prekinjeno, za ponovni poskus se dotaknite predvajanja",
   "Unable to connect to {{server}}": "Povezava s strežnikom {{server}} ni uspela",
   "Audiobookshelf server not found": "Strežnika Audiobookshelf ni bilo mogoče najti",
-  "Episode not found": "Epizode ni mogoče najti"
+  "Episode not found": "Epizode ni mogoče najti",
+  "Words per minute": "Besed na minuto"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2192,5 +2192,6 @@
   "Playback interrupted, tap play to retry": "Uppspelningen avbröts, tryck på spela upp för att försöka igen",
   "Unable to connect to {{server}}": "Det går inte att ansluta till {{server}}",
   "Audiobookshelf server not found": "Audiobookshelf-servern hittades inte",
-  "Episode not found": "Avsnittet hittades inte"
+  "Episode not found": "Avsnittet hittades inte",
+  "Words per minute": "Ord per minut"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2192,5 +2192,6 @@
   "Playback interrupted, tap play to retry": "இயக்கம் தடைபட்டது, மீண்டும் முயற்சிக்க பிளேயைத் தட்டவும்",
   "Unable to connect to {{server}}": "{{server}} உடன் இணைக்க முடியவில்லை",
   "Audiobookshelf server not found": "Audiobookshelf சர்வர் கிடைக்கவில்லை",
-  "Episode not found": "எபிசோட் கிடைக்கவில்லை"
+  "Episode not found": "எபிசோட் கிடைக்கவில்லை",
+  "Words per minute": "நிமிடத்திற்கு சொற்கள்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2133,5 +2133,6 @@
   "Playback interrupted, tap play to retry": "การเล่นถูกขัดจังหวะ แตะเล่นเพื่อลองใหม่",
   "Unable to connect to {{server}}": "ไม่สามารถเชื่อมต่อกับ {{server}}",
   "Audiobookshelf server not found": "ไม่พบเซิร์ฟเวอร์ Audiobookshelf",
-  "Episode not found": "ไม่พบตอน"
+  "Episode not found": "ไม่พบตอน",
+  "Words per minute": "คำต่อนาที"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2192,5 +2192,6 @@
   "Playback interrupted, tap play to retry": "Oynatma kesintiye uğradı, tekrar denemek için oynat'a dokunun",
   "Unable to connect to {{server}}": "{{server}} sunucusuna bağlanılamıyor",
   "Audiobookshelf server not found": "Audiobookshelf sunucusu bulunamadı",
-  "Episode not found": "Bölüm bulunamadı"
+  "Episode not found": "Bölüm bulunamadı",
+  "Words per minute": "Dakikadaki kelime sayısı"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2310,5 +2310,6 @@
   "Playback interrupted, tap play to retry": "Відтворення перервано, торкніться відтворення, щоб повторити спробу",
   "Unable to connect to {{server}}": "Не вдалося під'єднатися до {{server}}",
   "Audiobookshelf server not found": "Сервер Audiobookshelf не знайдено",
-  "Episode not found": "Епізод не знайдено"
+  "Episode not found": "Епізод не знайдено",
+  "Words per minute": "Слів за хвилину"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2192,5 +2192,6 @@
   "Playback interrupted, tap play to retry": "Ijro toʻxtadi, qayta urinish uchun ijro tugmasini bosing",
   "Unable to connect to {{server}}": "{{server}} bilan ulanib boʻlmadi",
   "Audiobookshelf server not found": "Audiobookshelf serveri topilmadi",
-  "Episode not found": "Epizod topilmadi"
+  "Episode not found": "Epizod topilmadi",
+  "Words per minute": "Daqiqasiga soʻz soni"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2133,5 +2133,6 @@
   "Playback interrupted, tap play to retry": "Phát bị gián đoạn, nhấn phát để thử lại",
   "Unable to connect to {{server}}": "Không thể kết nối với {{server}}",
   "Audiobookshelf server not found": "Không tìm thấy máy chủ Audiobookshelf",
-  "Episode not found": "Không tìm thấy tập"
+  "Episode not found": "Không tìm thấy tập",
+  "Words per minute": "Số từ mỗi phút"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2133,5 +2133,6 @@
   "Playback interrupted, tap play to retry": "播放已中断，点按播放以重试",
   "Unable to connect to {{server}}": "无法连接到 {{server}}",
   "Audiobookshelf server not found": "未找到 Audiobookshelf 服务器",
-  "Episode not found": "未找到该单集"
+  "Episode not found": "未找到该单集",
+  "Words per minute": "每分钟字数"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2133,5 +2133,6 @@
   "Playback interrupted, tap play to retry": "播放已中斷，點一下播放即可重試",
   "Unable to connect to {{server}}": "無法連線至 {{server}}",
   "Audiobookshelf server not found": "找不到 Audiobookshelf 伺服器",
-  "Episode not found": "找不到該集"
+  "Episode not found": "找不到該集",
+  "Words per minute": "每分鐘字數"
 }

--- a/apps/readest-app/src/__tests__/components/rsvp-overlay-context.test.tsx
+++ b/apps/readest-app/src/__tests__/components/rsvp-overlay-context.test.tsx
@@ -109,6 +109,7 @@ const renderOverlay = (
   gridInsets: Insets = { top: 0, bottom: 0, left: 0, right: 0 },
 ) => {
   const controller = buildController(state);
+  const onClose = vi.fn();
   const result = render(
     <RSVPOverlay
       gridInsets={gridInsets}
@@ -116,12 +117,12 @@ const renderOverlay = (
       chapters={[]}
       currentChapterHref={null}
       fontFamily={fontFamily}
-      onClose={vi.fn()}
+      onClose={onClose}
       onChapterSelect={vi.fn()}
       onRequestNextPage={vi.fn()}
     />,
   );
-  return { ...result, controller };
+  return { ...result, controller, onClose };
 };
 
 describe('RSVPOverlay — capture lifecycle', () => {
@@ -676,5 +677,97 @@ describe('RSVPOverlay — start delay setting (#4478)', () => {
     expect(select).not.toBeNull();
     fireEvent.change(select, { target: { value: '0' } });
     expect(controller.setStartDelay).toHaveBeenCalledWith(0);
+  });
+});
+
+describe('RSVPOverlay — fine-grained WPM entry (#5820)', () => {
+  afterEach(() => cleanup());
+
+  const wordState = () =>
+    buildState({
+      words: [{ text: 'hello', orpIndex: 1, pauseMultiplier: 1 }],
+      currentIndex: 0,
+      wpm: 300,
+    });
+
+  const openWpmDropdown = (container: HTMLElement) => {
+    fireEvent.click(container.querySelector('[aria-label="Select reading speed"]') as HTMLElement);
+    const dropdown = container.querySelector('[data-testid="rsvp-wpm-dropdown"]') as HTMLElement;
+    const input = dropdown.querySelector('[aria-label="Words per minute"]') as HTMLInputElement;
+    return { dropdown, input };
+  };
+
+  test('the dropdown offers a numeric field prefilled with the current speed', () => {
+    const { container } = renderOverlay(wordState());
+    const { input } = openWpmDropdown(container);
+
+    expect(input).not.toBeNull();
+    expect(input.value).toBe('300');
+    // Digits-only soft keyboard on phones — the whole point of #5820.
+    expect(input.inputMode).toBe('numeric');
+  });
+
+  test('typing an exact value and pressing Enter sets that speed', () => {
+    const { container, controller } = renderOverlay(wordState());
+    const { input } = openWpmDropdown(container);
+
+    input.focus();
+    fireEvent.change(input, { target: { value: '325' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(controller.setWpm).toHaveBeenCalledWith(325);
+  });
+
+  test('leaving the field commits the typed value', () => {
+    const { container, controller } = renderOverlay(wordState());
+    const { input } = openWpmDropdown(container);
+
+    fireEvent.change(input, { target: { value: '380' } });
+    fireEvent.blur(input);
+
+    expect(controller.setWpm).toHaveBeenCalledWith(380);
+  });
+
+  test('Escape in the field discards the draft without committing', () => {
+    const { container, controller } = renderOverlay(wordState());
+    const { input } = openWpmDropdown(container);
+
+    fireEvent.change(input, { target: { value: '999' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(input.value).toBe('300');
+    expect(controller.setWpm).not.toHaveBeenCalled();
+  });
+
+  test('the fine +/- buttons nudge by 10 WPM rather than the 50 WPM coarse step', () => {
+    const { container, controller } = renderOverlay(wordState());
+    const { dropdown } = openWpmDropdown(container);
+
+    fireEvent.click(dropdown.querySelector('[aria-label="Increase speed"]') as HTMLElement);
+    expect(controller.setWpm).toHaveBeenLastCalledWith(310);
+    fireEvent.click(dropdown.querySelector('[aria-label="Decrease speed"]') as HTMLElement);
+    expect(controller.setWpm).toHaveBeenLastCalledWith(290);
+
+    // The transport's coarse steppers were not what fired.
+    expect(controller.increaseSpeed).not.toHaveBeenCalled();
+    expect(controller.decreaseSpeed).not.toHaveBeenCalled();
+  });
+
+  // The overlay listens for its shortcuts on `document` in the capture phase,
+  // which would otherwise steal arrows (speed), Space (play) and Escape (close
+  // the whole session) from the caret while a speed is being typed.
+  test('keys typed in the field never reach the RSVP shortcuts', () => {
+    const { container, controller, onClose } = renderOverlay(wordState());
+    const { input } = openWpmDropdown(container);
+
+    fireEvent.keyDown(input, { key: 'ArrowLeft' });
+    fireEvent.keyDown(input, { key: 'ArrowRight' });
+    fireEvent.keyDown(input, { key: ' ' });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(controller.decreaseSpeed).not.toHaveBeenCalled();
+    expect(controller.increaseSpeed).not.toHaveBeenCalled();
+    expect(controller.togglePlayPause).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/apps/readest-app/src/app/reader/components/rsvp/RSVPOverlay.tsx
+++ b/apps/readest-app/src/app/reader/components/rsvp/RSVPOverlay.tsx
@@ -89,10 +89,78 @@ const CONTEXT_WINDOW_AFTER = 1000;
 // 0.5–3.0 range the TTS panel slider clamps to, in 0.25 steps.
 const TTS_RATE_OPTIONS = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3.0];
 
+// Nudge used by the -/+ pair inside the WPM dropdown (#5820). The transport
+// buttons, the swipe and the arrow keys keep the coarse 50 WPM step; the
+// presets below the field jump by 50 too, so this is the only fine control.
+const WPM_FINE_STEP = 10;
+
 // Dictionary lookup popup sizing (mirrors the reader's Annotator popup).
 const DICT_POPUP_PADDING = 10;
 const DICT_POPUP_MAX_WIDTH = 480;
 const DICT_POPUP_MAX_HEIGHT = 360;
+
+interface WpmEntryProps {
+  controller: RSVPController;
+  wpm: number;
+  bgColor: string;
+}
+
+// Exact entry + fine nudge at the top of the WPM dropdown (#5820): the presets
+// jump by 50, too coarse to settle on e.g. 325 WPM from a phone. Sticky so it
+// stays reachable while the list scrolls under it. The typed draft lives here
+// so it dies with the dropdown instead of resurfacing the next time it opens.
+const WpmEntry: React.FC<WpmEntryProps> = ({ controller, wpm, bgColor }) => {
+  const _ = useTranslation();
+  // Text of the field while it is being typed into; null shows the live wpm.
+  const [draft, setDraft] = useState<string | null>(null);
+
+  const commitDraft = () => {
+    if (draft === null) return;
+    // setWpm clamps to the supported range; an emptied field just falls back
+    // to the current speed.
+    if (draft !== '') controller.setWpm(parseInt(draft, 10));
+    setDraft(null);
+  };
+
+  return (
+    <div
+      className='sticky top-0 z-10 flex items-center justify-between gap-1 border-b border-gray-500/20 px-2 py-1.5'
+      style={{ backgroundColor: bgColor }}
+    >
+      <button
+        aria-label={_('Decrease speed')}
+        className='flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-full border-none bg-transparent transition-colors hover:bg-gray-500/20 active:scale-95'
+        onClick={() => controller.setWpm(wpm - WPM_FINE_STEP)}
+      >
+        <IoRemove className='h-4 w-4' />
+      </button>
+      <input
+        type='text'
+        inputMode='numeric'
+        enterKeyHint='done'
+        aria-label={_('Words per minute')}
+        value={draft ?? String(wpm)}
+        className='eink-bordered w-14 rounded-md border border-gray-500/20 bg-gray-500/10 px-1 py-0.5 text-center text-sm font-semibold tabular-nums focus:outline-none'
+        onFocus={(e) => e.target.select()}
+        onChange={(e) => {
+          if (/^\d*$/.test(e.target.value)) setDraft(e.target.value);
+        }}
+        onBlur={commitDraft}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') e.currentTarget.blur();
+          else if (e.key === 'Escape') setDraft(null);
+        }}
+      />
+      <button
+        aria-label={_('Increase speed')}
+        className='flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-full border-none bg-transparent transition-colors hover:bg-gray-500/20 active:scale-95'
+        onClick={() => controller.setWpm(wpm + WPM_FINE_STEP)}
+      >
+        <IoAdd className='h-4 w-4' />
+      </button>
+    </div>
+  );
+};
 
 interface RSVPOverlayProps {
   gridInsets: Insets;
@@ -287,6 +355,10 @@ const RSVPOverlay: React.FC<RSVPOverlayProps> = ({
       // Dictionary management (settings dialog) opens OVER RSVP; let it own the
       // keyboard so its inputs accept space and Escape closes it, not RSVP.
       if (isSettingsDialogOpen) return;
+      // A focused text field (the WPM entry in the speed dropdown) owns its
+      // keystrokes: arrows move the caret, Space/digits type, Escape discards
+      // the draft. The reader's own shortcuts already ignore inputs.
+      if (event.target instanceof HTMLInputElement && event.target.type === 'text') return;
 
       switch (event.key) {
         case ' ':
@@ -814,9 +886,11 @@ const RSVPOverlay: React.FC<RSVPOverlayProps> = ({
             <>
               <Overlay onDismiss={() => setShowWpmDropdown(false)} />
               <div
+                data-testid='rsvp-wpm-dropdown'
                 className='absolute end-0 top-full z-[100] mt-1.5 max-h-64 min-w-[7rem] overflow-y-auto rounded-2xl border border-gray-500/20 shadow-2xl'
                 style={{ backgroundColor: bgColor }}
               >
+                <WpmEntry controller={controller} wpm={state.wpm} bgColor={bgColor} />
                 {controller.getWpmOptions().map((wpm) => (
                   <button
                     key={wpm}


### PR DESCRIPTION
Closes #5820

## What

Every way of adjusting the RSVP speed moved in 50 WPM steps: the transport `-`/`+` buttons, the left/right swipe, the arrow keys, and the 100..1000 preset list in the WPM dropdown. That is too coarse to settle on a pace like 325 WPM, especially on a phone where the dropdown is the only speed control below 350px.

The WPM dropdown now starts with a sticky row above the presets:

```
[ - ] [ 300 ] [ + ]
```

- The number is a digits-only text field (`inputMode="numeric"`, so phones show the numeric keypad). Tap it, type an exact value, press Done/Enter or tap elsewhere to apply; Escape discards the draft. `RSVPController.setWpm()` already clamps to 100..1000 and persists any integer, so no controller change was needed.
- `-`/`+` nudge by 10 WPM (`WPM_FINE_STEP`, one constant).
- The presets, transport buttons, swipe and arrow keys keep their 50 WPM step for coarse jumps.

The overlay's capture-phase shortcut handler now ignores keystrokes whose target is a text field, otherwise typing into the new field had the arrows changing speed, Space toggling playback and Escape ending the session. The reader's own `useShortcuts` already skips inputs, so nothing leaks to page turns either.

The row is a small `WpmEntry` component so the typed draft lives (and dies) with the dropdown rather than resurfacing the next time it opens.

## Not done (on purpose)

- No "step size" setting: exact entry plus a 10 WPM nudge covers the ask without a new preference.
- The coarse controls keep 50 WPM; changing them would slow everyone's quick jumps.

## i18n

One new key, `Words per minute` (the field's accessible name), added to all 34 locales; the `-`/`+` reuse `Decrease speed` / `Increase speed`.

## Tests

- `rsvp-overlay-context.test.tsx`: new `#5820` block covering prefilled field, Enter commit, blur commit, Escape discard, 10 WPM nudges (and that the 50 WPM transport steppers were not what fired), and that arrows/Space/Escape inside the field never reach the RSVP shortcuts.
- `pnpm test`, `pnpm lint`, `pnpm format:check` green.

## Verified

- Chrome (web dev build): open dropdown, `+`/`-` give 260/250 from 250, typing 325 + Enter applies and persists (`readest_rsvp_wpm_*` = 325), ArrowLeft/Space inside the field leave speed and playback alone, Escape discards the draft and keeps the session, e-ink mode gives the field a crisp 1px border.
- Android (Xiaomi 13, release APK of this branch, driven over CDP with real touch events): the row renders at the top of the dropdown at phone width; tapping `+`/`-` moves 300 -> 310 -> 300; tapping the field raises the numeric keypad (`mInputShown=true`, `inputMode=numeric`, value pre-selected for type-over) with the dropdown still visible above the IME; typing 325 and pressing the keyboard's Enter applies it, hides the IME and keeps the session; typing 777 then tapping outside commits on blur, closes the dropdown and hides the IME; the value persists across an app relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added direct words-per-minute input in the RSVP playback controls.
  - Adjust playback speed in 10-WPM increments or enter a precise value.
  - Confirm values with Enter or focus loss, or cancel with Escape.
- **Localization**
  - Added translations for the words-per-minute label across supported languages.
- **Improvements**
  - Keyboard shortcuts no longer interfere while entering a custom playback speed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->