### PR TITLE
fix(translate): follow Bing regional host and show why a translation failed

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/annotator/TranslatorPopup.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/annotator/TranslatorPopup.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * TranslatorPopup error reporting (#5823): a failed lookup must say why it
+ * failed, not just "try again later", and must only blame a missing login
+ * when the provider actually needs one.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { TranslationProvider } from '@/services/translators/types';
+
+const mockTranslate = vi.fn();
+let mockToken: string | null = 'readest-token';
+let mockTranslator: Partial<TranslationProvider> = { name: 'azure', label: 'Azure Translator' };
+// One array per test, not per render: the popup re-derives its provider list
+// in an effect keyed on `translators`, so a fresh array every render would
+// loop it.
+let mockTranslators: Partial<TranslationProvider>[] = [mockTranslator];
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ token: mockToken }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({
+    settings: { globalReadSettings: { translateTargetLang: 'zh', translationProvider: 'azure' } },
+    setSettings: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useTranslator', () => ({
+  useTranslator: () => ({
+    translate: mockTranslate,
+    translator: mockTranslator,
+    translators: mockTranslators,
+    loading: false,
+  }),
+}));
+
+vi.mock('@/services/translators', () => ({
+  getTranslators: () => mockTranslators,
+  isTranslatorAvailable: () => true,
+  getTranslatorDisplayLabel: (t: TranslationProvider) => t.label,
+}));
+
+vi.mock('@/components/Popup', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+const renderPopup = async () => {
+  const { default: TranslatorPopup } = await import(
+    '@/app/reader/components/annotator/TranslatorPopup'
+  );
+  return render(
+    <TranslatorPopup
+      text='cohort'
+      position={{ point: { x: 0, y: 0 } }}
+      trianglePosition={{ point: { x: 0, y: 0 }, dir: 'up' }}
+      popupWidth={300}
+      popupHeight={200}
+    />,
+  );
+};
+
+describe('TranslatorPopup error reporting', () => {
+  beforeEach(() => {
+    mockTranslate.mockReset();
+    mockToken = 'readest-token';
+    mockTranslator = { name: 'azure', label: 'Azure Translator' };
+    mockTranslators = [mockTranslator];
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('shows the provider error alongside the generic message', async () => {
+    mockTranslate.mockRejectedValue(new Error('bing translate failed with status 400'));
+    await renderPopup();
+
+    expect(
+      await screen.findByText('Unable to fetch the translation. Try again later.'),
+    ).toBeTruthy();
+    expect(screen.getByText('bing translate failed with status 400')).toBeTruthy();
+  });
+
+  it('does not ask a logged-out user to log in when the provider needs no login', async () => {
+    mockToken = null;
+    mockTranslate.mockRejectedValue(new Error('bing translate failed with status 500'));
+    await renderPopup();
+
+    expect(
+      await screen.findByText('Unable to fetch the translation. Try again later.'),
+    ).toBeTruthy();
+    expect(screen.queryByText(/Please log in first/)).toBeNull();
+    expect(screen.getByText('bing translate failed with status 500')).toBeTruthy();
+  });
+
+  it('asks for a login only when the provider requires one', async () => {
+    mockToken = null;
+    mockTranslator = { name: 'deepl', label: 'DeepL', authRequired: true };
+    mockTranslators = [mockTranslator];
+    mockTranslate.mockRejectedValue(new Error('Authentication token is required'));
+    await renderPopup();
+
+    expect(
+      await screen.findByText(
+        'Unable to fetch the translation. Please log in first and try again.',
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/apps/readest-app/src/__tests__/services/translators/providers.test.ts
+++ b/apps/readest-app/src/__tests__/services/translators/providers.test.ts
@@ -736,6 +736,52 @@ describe('azureProvider', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it('posts translations to the bing host that served the translator page', async () => {
+    // From some networks (mainland China) www.bing.com answers a 302 to a
+    // regional host for the page and for the translate POST alike. The client
+    // follows the page redirect, but a followed POST redirect turns into a
+    // bodiless GET that comes back empty, so the translate call has to go to
+    // the host the page actually came from.
+    vi.mocked(isTauriAppPlatform).mockReturnValue(true);
+    vi.mocked(tauriFetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        url: 'https://cn.bing.com/translator',
+        text: async () => BING_PAGE,
+      } as Response)
+      .mockResolvedValueOnce(translationBody('你好') as unknown as Response);
+
+    const { azureProvider } = await import('@/services/translators/providers/azure');
+    const result = await azureProvider.translate(['Hello'], 'en', 'zh-CN');
+    expect(result).toEqual(['你好']);
+
+    const urls = vi.mocked(tauriFetch).mock.calls.map((call) => String(call[0]));
+    expect(urls[0]).toBe('https://www.bing.com/translator');
+    expect(urls[1]).toMatch(/^https:\/\/cn\.bing\.com\/ttranslatev3\?/);
+  });
+
+  it('throws a malformed-response error for a 200 non-JSON translate body', async () => {
+    // The empty reply of a followed POST redirect (or any HTML interstitial)
+    // used to be treated as "no translation" and the source text was echoed
+    // back as if it had been translated.
+    vi.mocked(isTauriAppPlatform).mockReturnValue(true);
+    vi.mocked(tauriFetch)
+      .mockResolvedValueOnce({ ok: true, status: 200, text: async () => BING_PAGE } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError('Unexpected end of JSON input');
+        },
+      } as unknown as Response);
+
+    const { azureProvider } = await import('@/services/translators/providers/azure');
+    await expect(azureProvider.translate(['Hello'], 'en', 'fr')).rejects.toThrow(
+      'bing translate failed: malformed response',
+    );
+  });
+
   it('sends Bing language codes rather than maximized culture codes', async () => {
     // Bing's ttranslatev3 answers `statusCode: 400` for region-maximized
     // codes like en-US or de-DE (verified live 2026-08-11); it only accepts

--- a/apps/readest-app/src/app/reader/components/annotator/TranslatorPopup.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/TranslatorPopup.tsx
@@ -59,7 +59,11 @@ const TranslatorPopup: React.FC<TranslatorPopupProps> = ({
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { translate, translators } = useTranslator({
+  // The provider's own failure reason (HTTP status, upstream status code,
+  // network error), shown under the generic message so a failure can be
+  // diagnosed from the popup itself (#5823).
+  const [errorDetail, setErrorDetail] = useState<string | null>(null);
+  const { translate, translator, translators } = useTranslator({
     provider,
     sourceLang,
     targetLang,
@@ -101,6 +105,7 @@ const TranslatorPopup: React.FC<TranslatorPopupProps> = ({
     setLoading(true);
     const fetchTranslation = async () => {
       setError(null);
+      setErrorDetail(null);
       setTranslation(null);
 
       try {
@@ -119,10 +124,13 @@ const TranslatorPopup: React.FC<TranslatorPopupProps> = ({
         }
       } catch (err) {
         console.error(err);
-        if (!token) {
+        // Only blame a missing login when this provider actually needs one;
+        // Azure/Google/Yandex run without a Readest account in the app.
+        if (translator?.authRequired && !token) {
           setError(_('Unable to fetch the translation. Please log in first and try again.'));
         } else {
           setError(_('Unable to fetch the translation. Try again later.'));
+          setErrorDetail(err instanceof Error ? err.message : String(err));
         }
       } finally {
         setLoading(false);
@@ -189,7 +197,12 @@ const TranslatorPopup: React.FC<TranslatorPopupProps> = ({
           ) : (
             <div>
               {error ? (
-                <p className='text-base text-red-600'>{error}</p>
+                <div>
+                  <p className='text-base text-red-600'>{error}</p>
+                  {errorDetail && (
+                    <p className='mt-1 break-words text-xs text-base-content/60'>{errorDetail}</p>
+                  )}
+                </div>
               ) : (
                 <p className='text-base'>{translation || _('No translation available.')}</p>
               )}

--- a/apps/readest-app/src/services/translators/providers/azure.ts
+++ b/apps/readest-app/src/services/translators/providers/azure.ts
@@ -6,6 +6,7 @@ import { splitTextIntoChunks } from '../utils';
 import { normalizeToShortLang } from '@/utils/lang';
 import {
   BING_REQUEST_HEADERS,
+  BING_TRANSLATE_PATH,
   BING_TRANSLATE_URL,
   BING_TRANSLATOR_URL,
   BingAuthParams,
@@ -31,7 +32,9 @@ import {
  *   inspected rather than just `response.ok`;
  * - bing.com sends no CORS headers, so a browser cannot call it at all. In the
  *   Tauri app the requests go out directly; in web builds they go through the
- *   same-origin proxy at /api/azure-translate.
+ *   same-origin proxy at /api/azure-translate;
+ * - from some networks www.bing.com redirects to a regional host, and the
+ *   translate POST has to go to that host too (see `translateUrl`).
  */
 const PROXY_URL = '/api/azure-translate';
 // Must not exceed the per-user concurrency the proxy allows, or the surplus
@@ -48,6 +51,26 @@ const buildTranslateQuery = (auth: BingAuthParams) =>
   new URLSearchParams({ isVertical: '1', IG: auth.ig, IID: auth.iid });
 
 let cachedAuth: BingAuthParams | null = null;
+// Where the translate POST goes: the bing.com host that actually served the
+// translator page. From mainland China www.bing.com answers a 302 to
+// cn.bing.com for the page and for the POST alike; the page redirect is
+// followed fine, but a followed POST redirect is replayed as a bodiless GET
+// and comes back empty (#5823). Refreshed together with the auth material,
+// since both come from the same page fetch.
+let translateUrl = BING_TRANSLATE_URL;
+// Only a bing.com host is ever used, so a stray redirect can never send the
+// token and text anywhere else.
+const translateUrlFor = (pageUrl: string | undefined): string => {
+  try {
+    const { protocol, host } = new URL(pageUrl ?? '');
+    if (protocol === 'https:' && (host === 'bing.com' || host.endsWith('.bing.com'))) {
+      return `https://${host}${BING_TRANSLATE_PATH}`;
+    }
+  } catch {
+    // not a URL: keep the default host
+  }
+  return BING_TRANSLATE_URL;
+};
 // Concurrent lines must not each scrape the translator page, so the in-flight
 // request is shared between callers.
 let authPromise: Promise<BingAuthParams> | null = null;
@@ -95,6 +118,7 @@ async function fetchAuthParams(token?: string | null): Promise<BingAuthParams> {
     if (!response.ok) {
       throw new Error(`bing translate auth failed with status ${response.status}`);
     }
+    translateUrl = translateUrlFor(response.url);
     return parseBingAuthParams(await response.text(), Date.now());
   }
 
@@ -150,7 +174,7 @@ async function translateChunk(
 
   const response = await withRequestLimit(() =>
     isTauriAppPlatform()
-      ? tauriFetch(`${BING_TRANSLATE_URL}?${query}`, {
+      ? tauriFetch(`${translateUrl}?${query}`, {
           method: 'POST',
           headers: BING_REQUEST_HEADERS,
           body: body.toString(),
@@ -169,7 +193,11 @@ async function translateChunk(
     throw new Error(`bing translate failed with status ${response.status}`);
   }
 
-  const data = await response.json().catch(() => null);
+  // An empty or non-JSON body (the reply to a redirected POST, an HTML
+  // interstitial) is a failure to report, not a translation to echo back.
+  const data = await response.json().catch(() => {
+    throw new Error('bing translate failed: malformed response');
+  });
   // A rejected or expired token answers `statusCode: 205` with HTTP 200.
   const statusCode = typeof data?.statusCode === 'number' ? data.statusCode : null;
   if (statusCode !== null && statusCode !== 200) {

--- a/apps/readest-app/src/services/translators/providers/azureShared.ts
+++ b/apps/readest-app/src/services/translators/providers/azureShared.ts
@@ -12,7 +12,8 @@
  */
 export const BING_ORIGIN = 'https://www.bing.com';
 export const BING_TRANSLATOR_URL = `${BING_ORIGIN}/translator`;
-export const BING_TRANSLATE_URL = `${BING_ORIGIN}/ttranslatev3`;
+export const BING_TRANSLATE_PATH = '/ttranslatev3';
+export const BING_TRANSLATE_URL = `${BING_ORIGIN}${BING_TRANSLATE_PATH}`;
 export const BING_USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
   'Chrome/130.0.0.0 Safari/537.36 Edg/130.0.0.0';


### PR DESCRIPTION
## Problem

#5823 reports Azure Translator failing with "Unable to fetch the translation. Try again later." on 0.12.1 (Windows, English to Indonesian) and asks for a more specific error than the generic message.

The reported failure itself is the region-maximized language code bug (`id-ID` instead of `id`, Bing answers `statusCode: 400`) fixed by #5620, which is merged but not in a release yet (0.12.1 was tagged 2026-08-08, #5620 merged 2026-08-11). Reproducing it surfaced two related problems that are still on `main`:

1. **Regional redirect turns the translation into an echo.** From some networks (mainland China), `www.bing.com` answers a 302 to `cn.bing.com` for the translator page and for the translate POST alike. The page redirect is followed fine, but a followed POST redirect is replayed as a bodiless GET that comes back as an empty 200; `response.json()` failed, the provider returned the source text unchanged, and the popup showed "chimney" translated as "chimney" with "Translated by Azure Translator." The same thing happens for inline paragraph translation (it silently skips every paragraph).
2. **The popup hides the cause.** Every failure rendered the same generic line, and a logged-out user was told to log in even for providers that need no Readest account in the app (Azure, Google, Yandex).

## Fix

- `azure.ts`: the translate POST now goes to the bing.com host that actually served the translator page (`response.url` after redirects, restricted to `*.bing.com`), refreshed together with the auth material. An empty or non-JSON translate body throws `bing translate failed: malformed response` instead of echoing the source text.
- `TranslatorPopup.tsx`: shows the provider's own failure reason in a muted line under the generic message (e.g. `bing translate failed with status 400`, a network error), and only asks for a login when the selected provider has `authRequired`.
- Tests: two provider tests (regional host is used for the POST; non-JSON body throws) and a new `TranslatorPopup` test file (detail line shown, no login prompt for no-auth providers, login prompt for `authRequired` providers).

## Verification

- Live against Bing (node, direct CN egress): `to=id-ID` answers `{"statusCode":400}`, `to=id` translates; `POST www.bing.com/ttranslatev3` answers `302 cn.bing.com`, following it yields an empty 200.
- macOS, `dev`-branch release build launched with `NO_PROXY=bing.com,.bing.com` (this machine has a system proxy; reqwest honours it, so bing had to go direct to hit the redirect): Azure + Indonesian gives "chimney" -> "chimney". Same setup with this branch's build: "said" -> "mengatakan".
- Xiaomi 13 (this branch's APK, md5-checked on device): Azure "sprawling" -> Korean "광활한" (fresh, uncached), target switched to Indonesian -> "meluas"; with `Response.prototype.json` made to fail for `ttranslatev3`, the popup shows "Unable to fetch the translation. Try again later." with the detail "bing translate failed: malformed response" and no "Translated by" footer.
- `pnpm test` (full suite), `pnpm lint`, `pnpm format:check` pass.

Closes #5823

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translator error messages with clearer provider details and appropriate login prompts.
  * Improved Bing/Azure translation support across regional Bing domains.
  * Translation failures from empty or malformed responses now show an error instead of returning the original text.

* **Tests**
  * Added coverage for translator errors, authentication prompts, regional endpoints, and malformed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->