### PR TITLE
feat(reader): show the book cover full screen from the sidebar and book details, closes #5813

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2429,5 +2429,6 @@
   "Unable to connect to {{server}}": "تعذّر الاتصال بـ{{server}}",
   "Audiobookshelf server not found": "لم يتم العثور على خادم Audiobookshelf",
   "Episode not found": "لم يتم العثور على الحلقة",
-  "Words per minute": "كلمة في الدقيقة"
+  "Words per minute": "كلمة في الدقيقة",
+  "View Book Cover": "عرض غلاف الكتاب"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2193,5 +2193,6 @@
   "Unable to connect to {{server}}": "{{server}}-এর সাথে সংযোগ করা যাচ্ছে না",
   "Audiobookshelf server not found": "Audiobookshelf সার্ভার পাওয়া যায়নি",
   "Episode not found": "এপিসোড পাওয়া যায়নি",
-  "Words per minute": "প্রতি মিনিটে শব্দ"
+  "Words per minute": "প্রতি মিনিটে শব্দ",
+  "View Book Cover": "বইয়ের প্রচ্ছদ দেখুন"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2134,5 +2134,6 @@
   "Unable to connect to {{server}}": "{{server}} ལ་མཐུད་ཐུབ་མ་སོང་།",
   "Audiobookshelf server not found": "Audiobookshelf ཞབས་ཞུ་བ་མ་རྙེད།",
   "Episode not found": "འདོན་ཐེངས་མ་རྙེད།",
-  "Words per minute": "སྐར་མ་རེར་ཚིག་གྲངས།"
+  "Words per minute": "སྐར་མ་རེར་ཚིག་གྲངས།",
+  "View Book Cover": "དཔེ་དེབ་ཀྱི་མདུན་ཤོག་བལྟ་བ"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2193,5 +2193,6 @@
   "Unable to connect to {{server}}": "Verbindung zu {{server}} nicht möglich",
   "Audiobookshelf server not found": "Audiobookshelf-Server nicht gefunden",
   "Episode not found": "Episode nicht gefunden",
-  "Words per minute": "Wörter pro Minute"
+  "Words per minute": "Wörter pro Minute",
+  "View Book Cover": "Buchcover anzeigen"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2193,5 +2193,6 @@
   "Unable to connect to {{server}}": "Δεν είναι δυνατή η σύνδεση με {{server}}",
   "Audiobookshelf server not found": "Δεν βρέθηκε διακομιστής Audiobookshelf",
   "Episode not found": "Το επεισόδιο δεν βρέθηκε",
-  "Words per minute": "Λέξεις ανά λεπτό"
+  "Words per minute": "Λέξεις ανά λεπτό",
+  "View Book Cover": "Προβολή εξωφύλλου βιβλίου"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2252,5 +2252,6 @@
   "Unable to connect to {{server}}": "No se puede conectar con {{server}}",
   "Audiobookshelf server not found": "No se encontró el servidor de Audiobookshelf",
   "Episode not found": "Episodio no encontrado",
-  "Words per minute": "Palabras por minuto"
+  "Words per minute": "Palabras por minuto",
+  "View Book Cover": "Ver portada del libro"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2193,5 +2193,6 @@
   "Unable to connect to {{server}}": "اتصال به {{server}} ممکن نیست",
   "Audiobookshelf server not found": "سرور Audiobookshelf یافت نشد",
   "Episode not found": "قسمت یافت نشد",
-  "Words per minute": "کلمه در دقیقه"
+  "Words per minute": "کلمه در دقیقه",
+  "View Book Cover": "مشاهده جلد کتاب"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2252,5 +2252,6 @@
   "Unable to connect to {{server}}": "Impossible de se connecter à {{server}}",
   "Audiobookshelf server not found": "Serveur Audiobookshelf introuvable",
   "Episode not found": "Épisode introuvable",
-  "Words per minute": "Mots par minute"
+  "Words per minute": "Mots par minute",
+  "View Book Cover": "Voir la couverture du livre"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2252,5 +2252,6 @@
   "Unable to connect to {{server}}": "לא ניתן להתחבר אל {{server}}",
   "Audiobookshelf server not found": "שרת Audiobookshelf לא נמצא",
   "Episode not found": "הפרק לא נמצא",
-  "Words per minute": "מילים לדקה"
+  "Words per minute": "מילים לדקה",
+  "View Book Cover": "הצג כריכת ספר"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2193,5 +2193,6 @@
   "Unable to connect to {{server}}": "{{server}} से कनेक्ट नहीं हो सका",
   "Audiobookshelf server not found": "Audiobookshelf सर्वर नहीं मिला",
   "Episode not found": "एपिसोड नहीं मिला",
-  "Words per minute": "शब्द प्रति मिनट"
+  "Words per minute": "शब्द प्रति मिनट",
+  "View Book Cover": "पुस्तक कवर देखें"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2193,5 +2193,6 @@
   "Unable to connect to {{server}}": "Nem sikerült csatlakozni ehhez: {{server}}",
   "Audiobookshelf server not found": "Az Audiobookshelf szerver nem található",
   "Episode not found": "Az epizód nem található",
-  "Words per minute": "Szó percenként"
+  "Words per minute": "Szó percenként",
+  "View Book Cover": "Könyvborító megtekintése"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2134,5 +2134,6 @@
   "Unable to connect to {{server}}": "Tidak dapat terhubung ke {{server}}",
   "Audiobookshelf server not found": "Server Audiobookshelf tidak ditemukan",
   "Episode not found": "Episode tidak ditemukan",
-  "Words per minute": "Kata per menit"
+  "Words per minute": "Kata per menit",
+  "View Book Cover": "Lihat Sampul Buku"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2252,5 +2252,6 @@
   "Unable to connect to {{server}}": "Impossibile connettersi a {{server}}",
   "Audiobookshelf server not found": "Server Audiobookshelf non trovato",
   "Episode not found": "Episodio non trovato",
-  "Words per minute": "Parole al minuto"
+  "Words per minute": "Parole al minuto",
+  "View Book Cover": "Visualizza copertina del libro"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2134,5 +2134,6 @@
   "Unable to connect to {{server}}": "{{server}}に接続できません",
   "Audiobookshelf server not found": "Audiobookshelfサーバーが見つかりません",
   "Episode not found": "エピソードが見つかりません",
-  "Words per minute": "1分あたりの単語数"
+  "Words per minute": "1分あたりの単語数",
+  "View Book Cover": "書籍のカバーを表示"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2193,5 +2193,6 @@
   "Unable to connect to {{server}}": "{{server}}-თან დაკავშირება ვერ მოხერხდა",
   "Audiobookshelf server not found": "Audiobookshelf სერვერი ვერ მოიძებნა",
   "Episode not found": "ეპიზოდი ვერ მოიძებნა",
-  "Words per minute": "სიტყვა წუთში"
+  "Words per minute": "სიტყვა წუთში",
+  "View Book Cover": "წიგნის ყდის ნახვა"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2134,5 +2134,6 @@
   "Unable to connect to {{server}}": "{{server}}에 연결할 수 없습니다",
   "Audiobookshelf server not found": "Audiobookshelf 서버를 찾을 수 없습니다",
   "Episode not found": "에피소드를 찾을 수 없습니다",
-  "Words per minute": "분당 단어 수"
+  "Words per minute": "분당 단어 수",
+  "View Book Cover": "책 표지 보기"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2134,5 +2134,6 @@
   "Unable to connect to {{server}}": "Tidak dapat menyambung ke {{server}}",
   "Audiobookshelf server not found": "Pelayan Audiobookshelf tidak ditemui",
   "Episode not found": "Episod tidak ditemui",
-  "Words per minute": "Perkataan seminit"
+  "Words per minute": "Perkataan seminit",
+  "View Book Cover": "Lihat Kulit Buku"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2193,5 +2193,6 @@
   "Unable to connect to {{server}}": "Kan geen verbinding maken met {{server}}",
   "Audiobookshelf server not found": "Audiobookshelf-server niet gevonden",
   "Episode not found": "Aflevering niet gevonden",
-  "Words per minute": "Woorden per minuut"
+  "Words per minute": "Woorden per minuut",
+  "View Book Cover": "Boekomslag bekijken"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2311,5 +2311,6 @@
   "Unable to connect to {{server}}": "Nie można połączyć się z {{server}}",
   "Audiobookshelf server not found": "Nie znaleziono serwera Audiobookshelf",
   "Episode not found": "Nie znaleziono odcinka",
-  "Words per minute": "Słów na minutę"
+  "Words per minute": "Słów na minutę",
+  "View Book Cover": "Pokaż okładkę książki"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2252,5 +2252,6 @@
   "Unable to connect to {{server}}": "Não foi possível conectar a {{server}}",
   "Audiobookshelf server not found": "Servidor Audiobookshelf não encontrado",
   "Episode not found": "Episódio não encontrado",
-  "Words per minute": "Palavras por minuto"
+  "Words per minute": "Palavras por minuto",
+  "View Book Cover": "Ver capa do livro"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2252,5 +2252,6 @@
   "Unable to connect to {{server}}": "Não é possível ligar a {{server}}",
   "Audiobookshelf server not found": "Servidor Audiobookshelf não encontrado",
   "Episode not found": "Episódio não encontrado",
-  "Words per minute": "Palavras por minuto"
+  "Words per minute": "Palavras por minuto",
+  "View Book Cover": "Ver capa do livro"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2252,5 +2252,6 @@
   "Unable to connect to {{server}}": "Conectarea la {{server}} nu a reușit",
   "Audiobookshelf server not found": "Serverul Audiobookshelf nu a fost găsit",
   "Episode not found": "Episodul nu a fost găsit",
-  "Words per minute": "Cuvinte pe minut"
+  "Words per minute": "Cuvinte pe minut",
+  "View Book Cover": "Vezi coperta cărții"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2311,5 +2311,6 @@
   "Unable to connect to {{server}}": "Не удалось подключиться к {{server}}",
   "Audiobookshelf server not found": "Сервер Audiobookshelf не найден",
   "Episode not found": "Эпизод не найден",
-  "Words per minute": "Слов в минуту"
+  "Words per minute": "Слов в минуту",
+  "View Book Cover": "Посмотреть обложку книги"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2193,5 +2193,6 @@
   "Unable to connect to {{server}}": "{{server}} වෙත සම්බන්ධ විය නොහැක",
   "Audiobookshelf server not found": "Audiobookshelf සේවාදායකයා හමු නොවීය",
   "Episode not found": "කථාංගය හමු නොවීය",
-  "Words per minute": "විනාඩියකට වචන"
+  "Words per minute": "විනාඩියකට වචන",
+  "View Book Cover": "පොතේ ආවරණය බලන්න"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2311,5 +2311,6 @@
   "Unable to connect to {{server}}": "Povezava s strežnikom {{server}} ni uspela",
   "Audiobookshelf server not found": "Strežnika Audiobookshelf ni bilo mogoče najti",
   "Episode not found": "Epizode ni mogoče najti",
-  "Words per minute": "Besed na minuto"
+  "Words per minute": "Besed na minuto",
+  "View Book Cover": "Prikaži naslovnico knjige"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2193,5 +2193,6 @@
   "Unable to connect to {{server}}": "Det går inte att ansluta till {{server}}",
   "Audiobookshelf server not found": "Audiobookshelf-servern hittades inte",
   "Episode not found": "Avsnittet hittades inte",
-  "Words per minute": "Ord per minut"
+  "Words per minute": "Ord per minut",
+  "View Book Cover": "Visa bokomslag"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2193,5 +2193,6 @@
   "Unable to connect to {{server}}": "{{server}} உடன் இணைக்க முடியவில்லை",
   "Audiobookshelf server not found": "Audiobookshelf சர்வர் கிடைக்கவில்லை",
   "Episode not found": "எபிசோட் கிடைக்கவில்லை",
-  "Words per minute": "நிமிடத்திற்கு சொற்கள்"
+  "Words per minute": "நிமிடத்திற்கு சொற்கள்",
+  "View Book Cover": "புத்தக அட்டையைக் காண்க"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2134,5 +2134,6 @@
   "Unable to connect to {{server}}": "ไม่สามารถเชื่อมต่อกับ {{server}}",
   "Audiobookshelf server not found": "ไม่พบเซิร์ฟเวอร์ Audiobookshelf",
   "Episode not found": "ไม่พบตอน",
-  "Words per minute": "คำต่อนาที"
+  "Words per minute": "คำต่อนาที",
+  "View Book Cover": "ดูภาพปกหนังสือ"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2193,5 +2193,6 @@
   "Unable to connect to {{server}}": "{{server}} sunucusuna bağlanılamıyor",
   "Audiobookshelf server not found": "Audiobookshelf sunucusu bulunamadı",
   "Episode not found": "Bölüm bulunamadı",
-  "Words per minute": "Dakikadaki kelime sayısı"
+  "Words per minute": "Dakikadaki kelime sayısı",
+  "View Book Cover": "Kitap Kapağını Görüntüle"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2311,5 +2311,6 @@
   "Unable to connect to {{server}}": "Не вдалося під'єднатися до {{server}}",
   "Audiobookshelf server not found": "Сервер Audiobookshelf не знайдено",
   "Episode not found": "Епізод не знайдено",
-  "Words per minute": "Слів за хвилину"
+  "Words per minute": "Слів за хвилину",
+  "View Book Cover": "Переглянути обкладинку книги"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2193,5 +2193,6 @@
   "Unable to connect to {{server}}": "{{server}} bilan ulanib boʻlmadi",
   "Audiobookshelf server not found": "Audiobookshelf serveri topilmadi",
   "Episode not found": "Epizod topilmadi",
-  "Words per minute": "Daqiqasiga soʻz soni"
+  "Words per minute": "Daqiqasiga soʻz soni",
+  "View Book Cover": "Kitob muqovasini koʻrish"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2134,5 +2134,6 @@
   "Unable to connect to {{server}}": "Không thể kết nối với {{server}}",
   "Audiobookshelf server not found": "Không tìm thấy máy chủ Audiobookshelf",
   "Episode not found": "Không tìm thấy tập",
-  "Words per minute": "Số từ mỗi phút"
+  "Words per minute": "Số từ mỗi phút",
+  "View Book Cover": "Xem bìa sách"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2134,5 +2134,6 @@
   "Unable to connect to {{server}}": "无法连接到 {{server}}",
   "Audiobookshelf server not found": "未找到 Audiobookshelf 服务器",
   "Episode not found": "未找到该单集",
-  "Words per minute": "每分钟字数"
+  "Words per minute": "每分钟字数",
+  "View Book Cover": "查看书籍封面"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2134,5 +2134,6 @@
   "Unable to connect to {{server}}": "無法連線至 {{server}}",
   "Audiobookshelf server not found": "找不到 Audiobookshelf 伺服器",
   "Episode not found": "找不到該集",
-  "Words per minute": "每分鐘字數"
+  "Words per minute": "每分鐘字數",
+  "View Book Cover": "查看書籍封面"
 }

--- a/apps/readest-app/src/__tests__/app/reader/components/sidebar/BookCard.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/sidebar/BookCard.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import BookCard from '@/app/reader/components/sidebar/BookCard';
@@ -7,6 +7,8 @@ import { Book } from '@/types/book';
 const mocks = vi.hoisted(() => ({
   dispatchSync: vi.fn(),
   config: { progress: undefined as [number, number] | undefined },
+  settings: { librarySkeuomorphicCovers: false, libraryHideCovers: false },
+  toDataUrl: vi.fn(async (url: string) => `data:image/png;base64,${url}`),
 }));
 
 vi.mock('@/utils/event', () => ({
@@ -22,12 +24,22 @@ vi.mock('@/store/bookDataStore', () => ({
 }));
 
 vi.mock('@/store/themeStore', () => ({
-  useThemeStore: () => ({ isDarkMode: false }),
+  useThemeStore: () => ({
+    isDarkMode: false,
+    safeAreaInsets: null,
+    systemUIVisible: false,
+    statusBarHeight: 0,
+  }),
 }));
 
-vi.mock('@/store/settingsStore', () => ({
-  useSettingsStore: () => ({ settings: { librarySkeuomorphicCovers: false } }),
-}));
+vi.mock('@/store/settingsStore', () => {
+  type State = { settings: typeof mocks.settings };
+  const useSettingsStore = (selector?: (state: State) => unknown) => {
+    const state: State = { settings: mocks.settings };
+    return selector ? selector(state) : state;
+  };
+  return { useSettingsStore };
+});
 
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => (key: string) => key,
@@ -42,9 +54,27 @@ vi.mock('@/components/BookCover', () => ({
   default: () => null,
 }));
 
+// The image viewer reads appService via useEnv (save button) and pulls the
+// device store through useKeyDownActions; neither is under test here.
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: null }),
+}));
+
+vi.mock('@/hooks/useKeyDownActions', () => ({
+  useKeyDownActions: () => {},
+}));
+
+// Blob -> data URL conversion needs a real fetch + FileReader; stub the
+// boundary and assert on which cover URL was handed to it.
+vi.mock('@/libs/document', () => ({
+  convertBlobUrlToDataUrl: mocks.toDataUrl,
+}));
+
 afterEach(() => {
   mocks.dispatchSync.mockClear();
+  mocks.toDataUrl.mockClear();
   mocks.config.progress = undefined;
+  mocks.settings.libraryHideCovers = false;
   cleanup();
 });
 
@@ -84,5 +114,66 @@ describe('BookCard book details', () => {
     clickInfo(container);
 
     expect(mocks.dispatchSync).toHaveBeenCalledWith('show-book-details', book);
+  });
+});
+
+// #5813: the sidebar thumbnail is too small to show someone the cover. Tapping
+// it must blow the cover up full screen in the reader's image viewer, and
+// closing the viewer must land back exactly where the reader was (the only
+// other way was paging back to the cover and losing the position).
+describe('BookCard cover viewer', () => {
+  const coverBook = { ...book, coverImageUrl: 'blob:cover-full' } as Book;
+
+  const tapCover = (container: HTMLElement) => {
+    const cover = container.querySelector('button[aria-label="View Book Cover"]');
+    expect(cover).toBeTruthy();
+    fireEvent.click(cover!);
+  };
+
+  const findViewer = () => document.body.querySelector('[aria-label="Image viewer"]');
+
+  it('opens the cover full screen in the image viewer when tapped', async () => {
+    const { container } = render(<BookCard book={coverBook} />);
+
+    tapCover(container);
+
+    await waitFor(() => expect(findViewer()).toBeTruthy());
+    // The viewer shows the book's full-resolution cover (converted the same way
+    // as an in-book image), not a downscaled library thumbnail.
+    expect(mocks.toDataUrl).toHaveBeenCalledWith('blob:cover-full');
+    const img = findViewer()!.querySelector('img')!;
+    expect(img.getAttribute('src')).toBe('data:image/png;base64,blob:cover-full');
+  });
+
+  it('closes the viewer and leaves the sidebar in place', async () => {
+    const { container } = render(<BookCard book={coverBook} />);
+    tapCover(container);
+    await waitFor(() => expect(findViewer()).toBeTruthy());
+
+    fireEvent.click(findViewer()!.querySelector('button[aria-label="Close"]')!);
+
+    expect(findViewer()).toBeNull();
+    expect(container.querySelector('button[aria-label="View Book Cover"]')).toBeTruthy();
+  });
+
+  it('does not open anything when the book has no cover', async () => {
+    const { container } = render(<BookCard book={book} />);
+
+    tapCover(container);
+
+    await Promise.resolve();
+    expect(mocks.toDataUrl).not.toHaveBeenCalled();
+    expect(findViewer()).toBeNull();
+  });
+
+  it('keeps the cover hidden when the library hides covers', async () => {
+    mocks.settings.libraryHideCovers = true;
+    const { container } = render(<BookCard book={coverBook} />);
+
+    tapCover(container);
+
+    await Promise.resolve();
+    expect(mocks.toDataUrl).not.toHaveBeenCalled();
+    expect(findViewer()).toBeNull();
   });
 });

--- a/apps/readest-app/src/__tests__/components/BookDetailView.test.tsx
+++ b/apps/readest-app/src/__tests__/components/BookDetailView.test.tsx
@@ -1,28 +1,49 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, cleanup, fireEvent } from '@testing-library/react';
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/react';
 
 import { Book } from '@/types/book';
 import BookDetailView from '@/components/metadata/BookDetailView';
 import { DropdownProvider } from '@/context/DropdownContext';
 
+const mocks = vi.hoisted(() => ({
+  toDataUrl: vi.fn(async (url: string) => `data:image/png;base64,${url}`),
+}));
+
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => (s: string) => s,
 }));
 
-vi.mock('@/store/settingsStore', () => ({
-  useSettingsStore: () => ({
+vi.mock('@/store/settingsStore', () => {
+  const state = {
     settings: {
       metadataSeriesCollapsed: true,
       // The "File Path" entry lives under the Metadata section; tests below
       // depend on it being expanded by default so the row is in the DOM.
       metadataOthersCollapsed: false,
       metadataDescriptionCollapsed: true,
+      libraryHideCovers: false,
     },
-  }),
-}));
+  };
+  const useSettingsStore = (selector?: (s: typeof state) => unknown) =>
+    selector ? selector(state) : state;
+  return { useSettingsStore };
+});
 
 vi.mock('@/context/EnvContext', () => ({
   useEnv: () => ({ envConfig: {}, appService: null }),
+}));
+
+// Pulled in by the cover viewer (reader's ImageViewer); not under test here.
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({ safeAreaInsets: null, systemUIVisible: false, statusBarHeight: 0 }),
+}));
+
+vi.mock('@/hooks/useKeyDownActions', () => ({
+  useKeyDownActions: () => {},
+}));
+
+vi.mock('@/libs/document', () => ({
+  convertBlobUrlToDataUrl: mocks.toDataUrl,
 }));
 
 vi.mock('@/helpers/settings', () => ({
@@ -238,5 +259,30 @@ describe('BookDetailView tags and subjects', () => {
     expect(onMetadataValueClick).toHaveBeenCalledWith('subject', 'History');
     fireEvent.click(getByText('Favorite'));
     expect(onMetadataValueClick).toHaveBeenCalledWith('tag', 'Favorite');
+  });
+});
+
+// #5813: the Book Details thumbnail must open the cover full screen in the
+// reader's image viewer (same zoom/pan/save as an in-book illustration).
+describe('BookDetailView cover viewer', () => {
+  const findViewer = () => document.body.querySelector('[aria-label="Image viewer"]');
+
+  it('opens the cover full screen in the image viewer when tapped', async () => {
+    const { container } = renderView({ book: makeBook({ coverImageUrl: 'blob:cover-full' }) });
+
+    const cover = container.querySelector('button[aria-label="View Book Cover"]');
+    expect(cover).toBeTruthy();
+    fireEvent.click(cover!);
+
+    await waitFor(() => expect(findViewer()).toBeTruthy());
+    expect(mocks.toDataUrl).toHaveBeenCalledWith('blob:cover-full');
+    expect(findViewer()!.querySelector('img')!.getAttribute('src')).toBe(
+      'data:image/png;base64,blob:cover-full',
+    );
+
+    // Closing the viewer returns to the details view, which stays open.
+    fireEvent.click(findViewer()!.querySelector('button[aria-label="Close"]')!);
+    expect(findViewer()).toBeNull();
+    expect(container.querySelector('button[aria-label="View Book Cover"]')).toBeTruthy();
   });
 });

--- a/apps/readest-app/src/app/reader/components/sidebar/BookCard.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/BookCard.tsx
@@ -8,6 +8,7 @@ import { eventDispatcher } from '@/utils/event';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
 import { formatAuthors, formatTitle } from '@/utils/book';
 import BookCover from '@/components/BookCover';
+import BookCoverViewer, { useBookCoverViewer } from '@/components/BookCoverViewer';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useSidebarStore } from '@/store/sidebarStore';
@@ -18,7 +19,8 @@ const BookCard = ({ book }: { book: Book }) => {
   const { settings } = useSettingsStore();
   const { isDarkMode } = useThemeStore();
   const iconSize18 = useResponsiveSize(18);
-  const bookCoverRef = useRef<HTMLDivElement | null>(null);
+  const bookCoverRef = useRef<HTMLButtonElement | null>(null);
+  const { coverSrc, openCoverViewer, closeCoverViewer } = useBookCoverViewer(book);
 
   const showBookDetails = () => {
     // `book` is the snapshot taken when the reader opened it, so its page count
@@ -31,12 +33,15 @@ const BookCard = ({ book }: { book: Book }) => {
 
   return (
     <div className='flex h-20 w-full items-center'>
-      <div
+      <button
         ref={bookCoverRef}
+        type='button'
+        aria-label={_('View Book Cover')}
         className={clsx(
           'me-4 aspect-[28/41] max-h-16 w-[15%] max-w-12 overflow-hidden rounded-sm shadow-md',
           isDarkMode ? 'mix-blend-screen' : 'mix-blend-multiply',
         )}
+        onClick={openCoverViewer}
       >
         <BookCover
           book={book}
@@ -46,7 +51,8 @@ const BookCard = ({ book }: { book: Book }) => {
           imageClassName='rounded-sm'
           onImageError={() => (bookCoverRef.current!.style.display = 'none')}
         />
-      </div>
+      </button>
+      {coverSrc && <BookCoverViewer src={coverSrc} onClose={closeCoverViewer} />}
       <div className='min-w-0 flex-1'>
         <h4 className='line-clamp-2 w-[90%] text-sm font-semibold'>
           {formatTitle(title).replace(/\u00A0/g, ' ')}

--- a/apps/readest-app/src/components/BookCoverViewer.tsx
+++ b/apps/readest-app/src/components/BookCoverViewer.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { Book } from '@/types/book';
+import { Insets } from '@/types/misc';
+import { convertBlobUrlToDataUrl } from '@/libs/document';
+import { useThemeStore } from '@/store/themeStore';
+import { useSettingsStore } from '@/store/settingsStore';
+import ImageViewer from '@/app/reader/components/ImageViewer';
+import ModalPortal from './ModalPortal';
+
+const ZERO_INSETS: Insets = { top: 0, right: 0, bottom: 0, left: 0 };
+
+interface BookCoverViewerProps {
+  src: string;
+  onClose: () => void;
+}
+
+// Shows a book cover full screen in the reader's image viewer (#5813), so the
+// sidebar / Book Details thumbnail can be blown up to show someone without
+// leaving the reading position. Portaled to the top modal layer so it covers
+// whatever it was opened from (the sidebar, the Book Details dialog).
+const BookCoverViewer: React.FC<BookCoverViewerProps> = ({ src, onClose }) => {
+  const { safeAreaInsets } = useThemeStore();
+  return (
+    <ModalPortal showOverlay={false}>
+      <ImageViewer gridInsets={safeAreaInsets ?? ZERO_INSETS} src={src} onClose={onClose} />
+    </ModalPortal>
+  );
+};
+
+// Loads the cover on demand; the viewer wants a data URL (its save button
+// extracts the bytes from it), as for in-book images in FoliateViewer.
+export const useBookCoverViewer = (book: Book) => {
+  const hideCovers = useSettingsStore((state) => state.settings.libraryHideCovers);
+  const [coverSrc, setCoverSrc] = useState<string | null>(null);
+
+  const openCoverViewer = async () => {
+    // The full-resolution cover, not the downscaled library thumbnail that
+    // <BookCover> may be painting in its place.
+    const coverUrl = hideCovers ? null : book.metadata?.coverImageUrl || book.coverImageUrl;
+    if (!coverUrl) return;
+    try {
+      setCoverSrc(await convertBlobUrlToDataUrl(coverUrl));
+    } catch (error) {
+      console.error('Failed to load book cover:', error);
+    }
+  };
+
+  const closeCoverViewer = () => setCoverSrc(null);
+
+  return { coverSrc, openCoverViewer, closeCoverViewer };
+};
+
+export default BookCoverViewer;

--- a/apps/readest-app/src/components/metadata/BookDetailView.tsx
+++ b/apps/readest-app/src/components/metadata/BookDetailView.tsx
@@ -30,6 +30,7 @@ import {
 import { isFeedBook } from '@/services/rss/feedBookUrl';
 import { saveSysSettings } from '@/helpers/settings';
 import BookCover from '@/components/BookCover';
+import BookCoverViewer, { useBookCoverViewer } from '@/components/BookCoverViewer';
 import Dropdown from '../Dropdown';
 import MenuItem from '../MenuItem';
 
@@ -68,6 +69,7 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({
   const { envConfig } = useEnv();
   const { settings } = useSettingsStore();
   const [subjectsExpanded, setSubjectsExpanded] = useState(false);
+  const { coverSrc, openCoverViewer, closeCoverViewer } = useBookCoverViewer(book);
   const subjects = getContributorNames(metadata?.subject);
   const visibleSubjects = subjectsExpanded ? subjects : subjects.slice(0, 3);
 
@@ -112,9 +114,15 @@ const BookDetailView: React.FC<BookDetailViewProps> = ({
   return (
     <div className='relative w-full rounded-lg'>
       <div className='mb-6 me-4 flex h-32 items-start'>
-        <div className='me-6 aspect-[28/41] h-32 shadow-lg sm:me-10'>
+        <button
+          type='button'
+          aria-label={_('View Book Cover')}
+          className='me-6 aspect-[28/41] h-32 shadow-lg sm:me-10'
+          onClick={openCoverViewer}
+        >
           <BookCover mode='list' book={book} showSpine={settings.librarySkeuomorphicCovers} />
-        </div>
+        </button>
+        {coverSrc && <BookCoverViewer src={coverSrc} onClose={closeCoverViewer} />}
         <div className='title-author flex h-32 flex-col justify-between'>
           <div>
             <p className='text-base-content mb-2 line-clamp-2 break-words text-lg font-bold'>


### PR DESCRIPTION
## Summary

Closes #5813.

Tapping the cover thumbnail in the sidebar book card or in the Book Details dialog now opens the cover full screen in the reader's image viewer (zoom, pan, save/share), so the cover can be shown without leaving the reading position.

- New `src/components/BookCoverViewer.tsx`: `useBookCoverViewer(book)` loads the full-resolution cover (`metadata.coverImageUrl || coverImageUrl`, not the downscaled library thumbnail) as a data URL, the same way in-book images are handed to `ImageViewer`; `BookCoverViewer` renders `ImageViewer` inside `ModalPortal` (top modal layer) so it covers the sidebar or the dialog it was opened from.
- The cover wrappers in `BookCard` (sidebar) and `BookDetailView` become `<button aria-label="View Book Cover">`.
- Respects the library "hide covers" setting; books without a cover do nothing on tap.
- i18n key `View Book Cover` added to all locales.

## Test plan

- [x] `pnpm test` (new tests in `BookCard.test.tsx` and `BookDetailView.test.tsx`: opens the viewer with the full-res cover, closes back to the sidebar/dialog, no-op without a cover or with covers hidden)
- [x] `pnpm lint`, `pnpm format:check`
- [x] Web (dev-web): sidebar cover and Book Details cover open the viewer above the sidebar / dialog; closing returns to the same page position with the sidebar / dialog still open
- [ ] Android / iOS: cover loads from its asset URL (device verify pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full-screen book cover viewing from book cards and book details.
  * Covers open through an accessible, localized control and can be closed to return to the previous view.
  * Cover previews respect hidden-cover settings and handle books without available covers.

* **Localization**
  * Added the “View Book Cover” label across supported languages.

* **Tests**
  * Added coverage for opening, closing, hidden, unavailable, and full-resolution cover scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->