### PR TITLE
feat(reader): join PDF line wraps into paragraphs when copying, closes #5814

### DIFF
--- a/apps/readest-app/src/__tests__/utils/pdfText.test.ts
+++ b/apps/readest-app/src/__tests__/utils/pdfText.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { classifyPdfLineBreaks, getPdfTextFromRange, type PdfLine } from '@/utils/pdfText';
+import { getTextFromRange } from '@/utils/sel';
+
+// Body text: 10px em, 12px line pitch, column spanning x 0..400.
+const line = (text: string, overrides: Partial<PdfLine> = {}): PdfLine => ({
+  text,
+  left: 0,
+  right: 400,
+  top: 0,
+  em: 10,
+  firstWordWidth: 30,
+  ...overrides,
+});
+
+describe('classifyPdfLineBreaks', () => {
+  it('joins the wrapped lines of a justified paragraph with spaces', () => {
+    const lines = [
+      line('If you are ever creating printed output, the most', { top: 0 }),
+      line('accurate way to calibrate your monitor is to print a', { top: 12 }),
+      line('test image first.', { top: 24, right: 120 }),
+    ];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['space', 'space']);
+  });
+
+  it('keeps a paragraph break after a short last line when the next word would have fit', () => {
+    const lines = [
+      line('side by side with printed output.', { top: 0, right: 250 }),
+      line('If you are creating output for video or television,', { top: 12, firstWordWidth: 15 }),
+    ];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['paragraph']);
+  });
+
+  it('joins ragged-right lines whose next word would not have fit', () => {
+    const lines = [
+      line('a ragged line that stops a little', { top: 0, right: 380 }),
+      line('short because the next word is wide', { top: 12, right: 395, firstWordWidth: 40 }),
+    ];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['space']);
+  });
+
+  it('keeps a paragraph break across a larger-than-usual vertical gap', () => {
+    const lines = [
+      line('first line of paragraph one', { top: 0 }),
+      line('second line of paragraph one', { top: 12 }),
+      line('first line of paragraph two', { top: 30 }),
+      line('second line of paragraph two', { top: 42 }),
+    ];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['space', 'paragraph', 'space']);
+  });
+
+  it('keeps a paragraph break when the font size changes', () => {
+    const lines = [
+      line('Chapter Heading', { top: 0, em: 16, right: 200 }),
+      line('Body text starts here and runs on', { top: 24 }),
+    ];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['paragraph']);
+  });
+
+  it('keeps one line per centred line', () => {
+    const lines = [
+      line('The Title', { top: 0, left: 150, right: 250 }),
+      line('by Someone', { top: 12, left: 130, right: 270 }),
+    ];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['paragraph']);
+  });
+
+  it('continues a paragraph into the next column when the line is full', () => {
+    const lines = [
+      line('last line of column one is full', { top: 0 }),
+      line('and continues here', { top: -300, left: 500, right: 700 }),
+    ];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['space']);
+  });
+
+  it('ignores wider lines of another font when measuring the column width', () => {
+    const lines = [
+      line('A full-width title over two columns', { top: 0, em: 16, right: 900 }),
+      line('first column line one', { top: 30 }),
+      line('first column line two', { top: 42 }),
+    ];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['paragraph', 'space']);
+  });
+
+  it('keeps a paragraph break before an indented first line even when the last line is nearly full', () => {
+    const lines = [
+      line('body line at the column edge', { top: 0 }),
+      line('another body line at the edge', { top: 12 }),
+      line('double-space your paper. True-Type 1 fonts are preferred.', { top: 24, right: 391 }),
+      line('The first paragraph in each section should not be', {
+        top: 36,
+        left: 16,
+        firstWordWidth: 13,
+      }),
+      line('indented, but all following paragraphs within the', { top: 48 }),
+    ];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['space', 'space', 'paragraph', 'space']);
+  });
+
+  it('does not break before the indented continuation line of a list item', () => {
+    const lines = [
+      line('body text at the column edge runs long', { top: 0 }),
+      line('more body text at the column edge here', { top: 12 }),
+      line('and a third body line at the column edge', { top: 24 }),
+      line('- a bulleted item that is long enough to wrap', { top: 36, left: 15 }),
+      line('onto a second line, indented past the bullet', { top: 48, left: 25, right: 300 }),
+      line('- the next bullet', { top: 60, left: 15, right: 150 }),
+    ];
+    expect(classifyPdfLineBreaks(lines)).toEqual([
+      'space',
+      'space',
+      'paragraph',
+      'space',
+      'paragraph',
+    ]);
+  });
+
+  it('treats hanging-indent continuation lines as line wraps', () => {
+    const lines = [
+      line('[1] A. Author, "A long reference title that', { top: 0 }),
+      line('wraps onto a second line and then a third', { top: 12, left: 15 }),
+      line('one," Journal, 2020.', { top: 24, left: 15, right: 150 }),
+      line('[2] B. Author, "Another long reference that', { top: 36 }),
+      line('wraps onto a second line and then a third', { top: 48, left: 15 }),
+      line('one," Journal, 2021.', { top: 60, left: 15, right: 150 }),
+    ];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['space', 'space', 'paragraph', 'space', 'space']);
+  });
+
+  it('continues two runs of the same printed line', () => {
+    const lines = [
+      line('left cell', { top: 0, right: 100 }),
+      line('right cell', { top: 0, left: 150, right: 250 }),
+    ];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['space']);
+  });
+
+  it('drops a line-end hyphen before a lowercase continuation', () => {
+    const lines = [
+      line('the calibra-', { top: 0 }),
+      line('tion will never', { top: 12 }),
+      line('like Wi-', { top: 24 }),
+      line('Fi and soft\u00AD', { top: 36 }),
+      line('hyphen', { top: 48 }),
+    ];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['dehyphenate', 'space', 'join', 'dehyphenate']);
+  });
+
+  it('joins CJK lines without a space', () => {
+    const lines = [line('这是第一行文字，', { top: 0 }), line('这是第二行文字。', { top: 12 })];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['join']);
+  });
+
+  it('does not add a space when the seam already has one', () => {
+    const lines = [line('trailing space ', { top: 0 }), line('next line', { top: 12 })];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['join']);
+  });
+
+  it('falls back to line breaks when there is no geometry', () => {
+    const lines = [line('no layout', { em: 0 }), line('at all', { em: 0 })];
+    expect(classifyPdfLineBreaks(lines)).toEqual(['paragraph']);
+  });
+});
+
+describe('getPdfTextFromRange', () => {
+  const mockRect = (el: Element, left: number, top: number, width: number, height: number) => {
+    el.getBoundingClientRect = () =>
+      ({
+        left,
+        top,
+        right: left + width,
+        bottom: top + height,
+        width,
+        height,
+        x: left,
+        y: top,
+        toJSON: () => ({}),
+      }) as DOMRect;
+  };
+
+  const span = (text: string, left: number, top: number, width: number, height = 10) => {
+    const el = document.createElement('span');
+    el.setAttribute('role', 'presentation');
+    el.textContent = text;
+    mockRect(el, left, top, width, height);
+    return el;
+  };
+  const br = () => {
+    const el = document.createElement('br');
+    el.setAttribute('role', 'presentation');
+    return el;
+  };
+
+  let layer: HTMLElement;
+  afterEach(() => {
+    layer?.remove();
+  });
+
+  const buildTwoParagraphs = () => {
+    layer = document.createElement('div');
+    layer.className = 'textLayer';
+    layer.append(
+      span('If you are ever creating printed output, the', 0, 0, 400),
+      br(),
+      span('most accurate way to calibrate your monitor is', 0, 12, 400),
+      br(),
+      span('to print a test image.', 0, 24, 200),
+      br(),
+      span('If you are creating output for video, it pays to', 0, 36, 400),
+      br(),
+      span('view your footage.', 0, 48, 160),
+      br(),
+    );
+    document.body.appendChild(layer);
+    return layer;
+  };
+
+  it('joins wrapped lines and keeps the paragraph break inside a selection', () => {
+    const layer = buildTwoParagraphs();
+    const range = document.createRange();
+    // From "creating" on line 1 to "footage" on the last line.
+    range.setStart(layer.children[0]!.firstChild!, 16);
+    range.setEnd(layer.children[8]!.firstChild!, 17);
+
+    expect(getPdfTextFromRange(range, layer)).toBe(
+      'creating printed output, the most accurate way to calibrate your monitor is to print a test image.\n' +
+        'If you are creating output for video, it pays to view your footage',
+    );
+  });
+
+  it('is used by getTextFromRange for pdf.js text layers', () => {
+    const layer = buildTwoParagraphs();
+    const range = document.createRange();
+    range.selectNodeContents(layer);
+
+    expect(getTextFromRange(range)).toBe(
+      'If you are ever creating printed output, the most accurate way to calibrate your monitor is to print a test image.\n' +
+        'If you are creating output for video, it pays to view your footage.',
+    );
+  });
+
+  it('removes a hyphen when a word wraps', () => {
+    layer = document.createElement('div');
+    layer.className = 'textLayer';
+    layer.append(span('the calibra-', 0, 0, 400), br(), span('tion is done', 0, 12, 300), br());
+    document.body.appendChild(layer);
+    const range = document.createRange();
+    range.selectNodeContents(layer);
+
+    expect(getTextFromRange(range)).toBe('the calibration is done');
+  });
+});

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -526,33 +526,32 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     // For PDF selections, enable right-click context menu to directly open translator popup.
     if (bookData.isFixedLayout) {
       detail.doc?.addEventListener('contextmenu', (e: Event) => {
-        try {
-          const sel = doc.getSelection?.();
-          if (sel && !sel.isCollapsed) {
-            const range = sel.getRangeAt(0);
-            const text = sel.toString();
-            if (text.trim()) {
-              setSelection({
-                key: bookKey,
-                text,
-                range,
-                index,
-                cfi: view?.getCFI(index, range),
-                page: index + 1,
-              });
-              // Show translation popup preferentially for PDF right-click
-              setShowAnnotPopup(false);
-              setShowDeepLPopup(true);
-              setShowDictionaryPopup(false);
-            }
-          }
-        } catch (err) {
-          console.warn('PDF context menu translation failed:', err);
-        }
         // Prevent native menu to keep experience consistent
         e.preventDefault();
         e.stopPropagation();
-        return false;
+        try {
+          const sel = doc.getSelection?.();
+          if (!sel || sel.isCollapsed) return;
+          const range = sel.getRangeAt(0);
+          // Same text as the toolbar path, with PDF line wraps joined (#5814).
+          void getAnnotationText(range).then((text) => {
+            if (!text.trim()) return;
+            setSelection({
+              key: bookKey,
+              text,
+              range,
+              index,
+              cfi: view?.getCFI(index, range),
+              page: index + 1,
+            });
+            // Show translation popup preferentially for PDF right-click
+            setShowAnnotPopup(false);
+            setShowDeepLPopup(true);
+            setShowDictionaryPopup(false);
+          });
+        } catch (err) {
+          console.warn('PDF context menu translation failed:', err);
+        }
       });
     }
 

--- a/apps/readest-app/src/utils/pdfText.ts
+++ b/apps/readest-app/src/utils/pdfText.ts
@@ -1,0 +1,240 @@
+/**
+ * Reassembles paragraphs from a pdf.js text layer.
+ *
+ * pdf.js renders one <span> per text run and a <br role="presentation"> at every
+ * end of line, so walking a selection yields one line of text per printed line
+ * (#5814). PDF carries no paragraph markup; each <br> is classified from the
+ * page's geometry instead. A line ends a paragraph when it is followed by a
+ * larger-than-usual vertical step, a font-size change, a centred line, an
+ * indented first line, or when it stops early even though the next line's
+ * first word would have fit on it. Any other <br> is a line wrap: joined with
+ * a space (none between CJK characters), dropping a line-end hyphen before a
+ * lowercase continuation.
+ */
+
+export type PdfLineBreak = 'paragraph' | 'space' | 'join' | 'dehyphenate';
+
+export interface PdfLine {
+  text: string;
+  /** Horizontal extent of the line's text, px in any consistent space. */
+  left: number;
+  right: number;
+  /** Top of the line's dominant (longest) run, so superscripts don't skew it. */
+  top: number;
+  /** Height of the dominant run, used as the em unit. Zero when not laid out. */
+  em: number;
+  /** Rendered width of the line's first word. */
+  firstWordWidth: number;
+}
+
+/** Vertical step beyond this multiple of the page's line pitch ends a paragraph. */
+const PARAGRAPH_GAP_RATIO = 1.3;
+const FONT_SIZE_TOLERANCE = 0.2;
+/** Lines whose left edges lie within this many em of each other share a column. */
+const COLUMN_TOLERANCE_EM = 4;
+const WORD_SPACE_EM = 0.3;
+
+const HYPHEN_AT_END = /[-\u2010\u00AD]\s*$/u;
+const SOFT_HYPHEN_AT_END = /\u00AD\s*$/u;
+// Scripts set without inter-word spaces, plus their punctuation blocks.
+const NO_SPACE_SCRIPT =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\u3000-\u303F\uFF00-\uFFEF]/u;
+
+const isMeasured = (line: PdfLine) => line.em > 0 && line.right > line.left;
+
+const medianPitch = (lines: PdfLine[]): number | null => {
+  const steps: number[] = [];
+  for (let i = 0; i + 1 < lines.length; i++) {
+    const a = lines[i]!;
+    const b = lines[i + 1]!;
+    if (!isMeasured(a) || !isMeasured(b)) continue;
+    const dy = b.top - a.top;
+    if (dy > 0.5 * Math.max(a.em, b.em)) steps.push(dy);
+  }
+  if (!steps.length) return null;
+  steps.sort((x, y) => x - y);
+  // Lower median: paragraph gaps are the minority and must not pull it up.
+  return steps[Math.floor((steps.length - 1) / 2)]!;
+};
+
+// Edges of the column `line` sits in, from the same-font lines sharing its
+// left edge. Right: the 85th percentile of their right edges, so a few
+// full-width lines (a title above two columns) don't widen the column. Left:
+// the most populated 1em bin of their left edges (ties go right, so fewer
+// lines count as indented), which is the continuation edge of a hanging
+// indent and the body edge of indented prose.
+const columnEdges = (line: PdfLine, lines: PdfLine[], em: number) => {
+  const group = lines.filter(
+    (l) =>
+      isMeasured(l) &&
+      Math.abs(l.left - line.left) <= COLUMN_TOLERANCE_EM * em &&
+      Math.abs(l.em - line.em) <= FONT_SIZE_TOLERANCE * em,
+  );
+  const rights = group.map((l) => l.right).sort((x, y) => x - y);
+  const right = rights[Math.ceil(0.85 * rights.length) - 1] ?? line.right;
+  const bins = new Map<number, number[]>();
+  for (const l of group) {
+    const key = Math.round(l.left / em);
+    bins.set(key, [...(bins.get(key) ?? []), l.left]);
+  }
+  let best: number[] = [line.left];
+  let bestKey = -Infinity;
+  for (const [key, lefts] of bins) {
+    if (lefts.length > best.length || (lefts.length === best.length && key > bestKey)) {
+      best = lefts;
+      bestKey = key;
+    }
+  }
+  const left = best.reduce((sum, l) => sum + l, 0) / best.length;
+  return { left, right };
+};
+
+const joinKind = (aText: string, bText: string): PdfLineBreak => {
+  const aEnd = aText.trimEnd();
+  const bStart = bText.trimStart();
+  if (SOFT_HYPHEN_AT_END.test(aEnd)) return 'dehyphenate';
+  if (HYPHEN_AT_END.test(aEnd)) return /^\p{Ll}/u.test(bStart) ? 'dehyphenate' : 'join';
+  if (aEnd !== aText || bStart !== bText) return 'join';
+  const last = [...aEnd].at(-1) ?? '';
+  const first = [...bStart][0] ?? '';
+  if (NO_SPACE_SCRIPT.test(last) || NO_SPACE_SCRIPT.test(first)) return 'join';
+  return 'space';
+};
+
+const classifyBreak = (
+  a: PdfLine,
+  b: PdfLine,
+  lines: PdfLine[],
+  pitch: number | null,
+): PdfLineBreak => {
+  if (!isMeasured(a) || !isMeasured(b)) return 'paragraph';
+  const em = Math.max(a.em, b.em);
+  const dy = b.top - a.top;
+  // Two runs of the same printed line: continue it.
+  if (Math.abs(dy) < 0.5 * em && b.left >= a.right - 0.5 * em) return joinKind(a.text, b.text);
+  if (dy > PARAGRAPH_GAP_RATIO * (pitch ?? 1.2 * em)) return 'paragraph';
+  if (Math.abs(a.em - b.em) > FONT_SIZE_TOLERANCE * em) return 'paragraph';
+  // Centred lines (titles, verse) are set one per line.
+  if (Math.abs(a.left - b.left) > em && Math.abs(a.left + a.right - b.left - b.right) < 0.5 * em) {
+    return 'paragraph';
+  }
+  const column = columnEdges(a, lines, em);
+  // An indented line after an unindented one opens a paragraph. Continuation
+  // lines of list items and hanging indents follow an indented line or sit on
+  // the column's usual edge, so they don't qualify.
+  const indent = b.left - column.left;
+  if (indent > em && indent < COLUMN_TOLERANCE_EM * em && a.left - column.left < em) {
+    return 'paragraph';
+  }
+  // The line stopped early although the next word would have fit: deliberate end.
+  if (column.right - a.right > b.firstWordWidth + WORD_SPACE_EM * em) return 'paragraph';
+  return joinKind(a.text, b.text);
+};
+
+/** The break kind after each line; `lines.length - 1` entries. */
+export const classifyPdfLineBreaks = (lines: PdfLine[]): PdfLineBreak[] => {
+  const pitch = medianPitch(lines);
+  const breaks: PdfLineBreak[] = [];
+  for (let i = 0; i + 1 < lines.length; i++) {
+    breaks.push(classifyBreak(lines[i]!, lines[i + 1]!, lines, pitch));
+  }
+  return breaks;
+};
+
+interface TextLayerRow {
+  spans: Element[];
+  br: Element | null;
+}
+
+const splitRows = (textLayer: Element): TextLayerRow[] => {
+  const rows: TextLayerRow[] = [];
+  let row: TextLayerRow = { spans: [], br: null };
+  for (const child of Array.from(textLayer.children)) {
+    if (child.tagName === 'BR') {
+      row.br = child;
+      rows.push(row);
+      row = { spans: [], br: null };
+    } else {
+      row.spans.push(child);
+    }
+  }
+  if (row.spans.length) rows.push(row);
+  return rows;
+};
+
+const measureRow = ({ spans }: TextLayerRow): PdfLine => {
+  const line: PdfLine = {
+    text: '',
+    left: Infinity,
+    right: -Infinity,
+    top: 0,
+    em: 0,
+    firstWordWidth: 0,
+  };
+  let dominantLength = 0;
+  for (const span of spans) {
+    const text = span.textContent ?? '';
+    line.text += text;
+    const trimmed = text.trim();
+    if (!trimmed) continue;
+    const rect = span.getBoundingClientRect();
+    line.left = Math.min(line.left, rect.left);
+    line.right = Math.max(line.right, rect.right);
+    if (trimmed.length > dominantLength) {
+      dominantLength = trimmed.length;
+      line.top = rect.top;
+      line.em = rect.height;
+    }
+    if (!line.firstWordWidth) {
+      const word = trimmed.split(/\s+/)[0] ?? '';
+      line.firstWordWidth = (rect.width * word.length) / trimmed.length;
+    }
+  }
+  return line;
+};
+
+const sliceText = (el: Element, range: Range) => {
+  let out = '';
+  for (const node of Array.from(el.childNodes)) {
+    if (node.nodeType !== Node.TEXT_NODE || !range.intersectsNode(node)) continue;
+    const data = (node as Text).data;
+    const start = node === range.startContainer ? range.startOffset : 0;
+    const end = node === range.endContainer ? range.endOffset : data.length;
+    out += data.slice(start, end);
+  }
+  return out;
+};
+
+/** The pdf.js text layer `range` lies in, if any. */
+export const getPdfTextLayer = (range: Range): Element | null => {
+  const node = range.commonAncestorContainer;
+  const el = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+  return el?.closest('.textLayer') ?? null;
+};
+
+/** Text of `range` with the text layer's line wraps joined back into paragraphs. */
+export const getPdfTextFromRange = (range: Range, textLayer: Element): string => {
+  const rows = splitRows(textLayer);
+  const breaks = classifyPdfLineBreaks(rows.map(measureRow));
+  let text = '';
+  let pending = '';
+  rows.forEach((row, i) => {
+    for (const span of row.spans) {
+      if (!range.intersectsNode(span)) continue;
+      const piece = sliceText(span, range);
+      if (!piece) continue;
+      if (text) text += pending;
+      pending = '';
+      text += piece;
+    }
+    if (!row.br || !range.intersectsNode(row.br)) return;
+    const kind = breaks[i] ?? 'paragraph';
+    if (kind === 'dehyphenate') {
+      text = text.replace(HYPHEN_AT_END, '');
+      pending = '';
+    } else {
+      pending = kind === 'paragraph' ? '\n' : kind === 'space' ? ' ' : '';
+    }
+  });
+  return text;
+};

--- a/apps/readest-app/src/utils/sel.ts
+++ b/apps/readest-app/src/utils/sel.ts
@@ -1,3 +1,5 @@
+import { getPdfTextFromRange, getPdfTextLayer } from '@/utils/pdfText';
+
 export interface Frame {
   top: number;
   left: number;
@@ -880,6 +882,11 @@ export const repairJumpedSelectionRange = (
 };
 
 export const getTextFromRange = (range: Range, rejectTags: string[] = []): string => {
+  // pdf.js breaks every printed line with a <br>; rebuild paragraphs from the
+  // page geometry instead of emitting one line per line (#5814).
+  const textLayer = getPdfTextLayer(range);
+  if (textLayer) return getPdfTextFromRange(range, textLayer);
+
   const clonedRange = range.cloneRange();
   const fragment = clonedRange.cloneContents();
   const walker = document.createTreeWalker(


### PR DESCRIPTION
## Summary

Closes #5814.

Copying (or annotating, translating, sending to the notebook) a PDF selection produced one line of text per printed line, and a paragraph boundary looked exactly like a line wrap. pdf.js renders one `<span>` per text run and a `<br role="presentation">` at every end of line, and `getTextFromRange` turned every `<br>` into `\n` (#5202 added that so words would not be glued together).

This rebuilds paragraphs from the page geometry instead:

- `src/utils/pdfText.ts` classifies each `<br>` of a pdf.js text layer as a paragraph break or a line wrap using the live layout of the whole page: a larger-than-usual vertical step, a font-size change, a centred line, an indented first line, or a line that stops early although the next line's first word would have fit all end a paragraph. Everything else is a wrap, joined with a space (no space between CJK characters; a line-end hyphen is dropped before a lowercase continuation and kept otherwise, e.g. `Times-` + `Roman`). A paragraph that continues into the next column stays joined.
- `getTextFromRange` delegates to it when the range sits in a `.textLayer`; all other content is unchanged. Without layout geometry (jsdom, unrendered page) the old per-line breaks are kept.
- The PDF right-click translation path now builds its text through `getAnnotationText` like the toolbar path instead of the raw `sel.toString()`.

Result for the issue's example: each paragraph is one line, paragraphs are separated by a single newline.

## Verification

- New `src/__tests__/utils/pdfText.test.ts` (19 tests): the pure classifier over synthetic line geometry (justified/ragged paragraphs, paragraph gaps, headings, centred lines, column continuation, full-width title over two columns, same-line runs, hyphenation incl. soft hyphen, CJK, indented first lines vs. list/hanging-indent continuations, no-geometry fallback) and DOM-level tests on a pdf.js-style text layer with mocked rects, incl. the `getTextFromRange` delegation.
- Existing `sel.test.ts` PDF `<br>` test still passes (no geometry -> `\n`).
- `pnpm test`: 796 files / 9,844 tests passed; `pnpm lint`; `pnpm format:check`.
- Manually in Chrome (`pnpm dev-web`) with three real PDFs: the two-column IEEE sample (`sample-paper.pdf`: paragraphs one line each, headings on their own line, a paragraph continuing across the column break, `846-` + `6900` and `Times-` + `Roman` joined without a space), a Chinese/English slide deck (mid-word CJK wrap joined without spaces, centred title lines kept separate), and the Alice PDF novel spread (justified text with first-line indents and one-line dialogue: 4 paragraphs -> 4 lines).

## Notes

- Heuristic by nature. The one known miss is a paragraph whose last line is nearly full *and* whose next paragraph is neither indented nor spaced; that pair is merged. The indent rule was added after exactly such a case in the sample paper where the next paragraph was indented.
- No settings toggle was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PDF text selection and extraction, preserving paragraphs and joining wrapped lines more accurately.
  * Added support for hyphenated words, CJK text, columns, indentation, and varied text alignment.
  * Translation popups now open only for valid, non-empty selections.

* **Bug Fixes**
  * Prevented the browser’s native context menu from appearing during PDF text selection.
  * Improved handling of irregular PDF text layouts and missing geometry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->