### PR TITLE
fix(annotator): hide the range editor handles while a lookup popup is open, closes #5815

### DIFF
--- a/apps/readest-app/e2e/pages/ReaderPage.ts
+++ b/apps/readest-app/e2e/pages/ReaderPage.ts
@@ -26,6 +26,7 @@ export class ReaderPage extends BasePage {
   readonly proofreadPopup: Locator;
   readonly noteEditor: Locator;
   readonly annotationItems: Locator;
+  readonly rangeHandles: Locator;
   readonly pageJumpInput: Locator;
 
   constructor(page: Page) {
@@ -49,6 +50,9 @@ export class ReaderPage extends BasePage {
     this.proofreadPopup = page.locator('.popup-container:has-text("Selected text:")');
     this.noteEditor = page.locator('.note-editor-container');
     this.annotationItems = page.locator('li.booknote-item[role="button"]');
+    // The app-drawn range-edit handles (the selection / annotation range
+    // editors), as opposed to the browser's native selection handles.
+    this.rangeHandles = page.locator('[data-testid="selection-handle"]');
   }
 
   /** Wait until the reader route is active and the book viewer has mounted. */
@@ -452,6 +456,31 @@ export class ReaderPage extends BasePage {
 
   async highlightSelection(): Promise<void> {
     await this.popupTool('Highlight').click();
+  }
+
+  /**
+   * Click the first highlight drawn in the book, opening its toolbar and
+   * range editor.
+   *
+   * The overlay is an SVG laid over its section iframe in that iframe's own
+   * client coordinates, so a point just inside the highlight path's top-left
+   * corner (the start of its first line — {@link selectText} selects from a
+   * paragraph start) is a point on the highlighted text in that document. The
+   * click is dispatched there rather than through the page mouse, so it also
+   * reaches a highlight in a prerendered section that is not on screen.
+   */
+  async clickHighlight(): Promise<void> {
+    const overlay = this.foliateView.locator('svg g path').first();
+    await overlay.waitFor({ state: 'attached' });
+    await overlay.evaluate((node) => {
+      const path = node as SVGPathElement;
+      const box = path.getBBox();
+      const doc = path.ownerSVGElement?.parentElement?.querySelector('iframe')?.contentDocument;
+      if (!doc) throw new Error('highlight overlay has no section document');
+      doc.dispatchEvent(
+        new MouseEvent('click', { clientX: box.x + 4, clientY: box.y + 4, bubbles: true }),
+      );
+    });
   }
 
   async selectHighlightColor(color: string): Promise<void> {

--- a/apps/readest-app/e2e/tests/annotation.spec.ts
+++ b/apps/readest-app/e2e/tests/annotation.spec.ts
@@ -99,6 +99,37 @@ test.describe('Annotation', () => {
     await expect(reader.annotationPopup).toBeHidden();
   });
 
+  // Tapping a highlight (or holding one out with Instant Highlight) opens its
+  // range editor: app-drawn handles in a fixed overlay painted after the lookup
+  // popups, so they floated on top of the dictionary (#5815). A lookup hides
+  // them; they come back only with the toolbar.
+  test('hides the range-edit handles while the dictionary popup is open (#5815)', async ({
+    openBook,
+  }) => {
+    const reader = await openBook();
+
+    await reader.selectText();
+    await reader.highlightSelection();
+    await reader.dismissPopup();
+    await reader.clickHighlight();
+
+    await expect(reader.annotationPopup).toBeVisible();
+    await expect(reader.rangeHandles).toHaveCount(2);
+
+    await reader.popupTool('Dictionary').click();
+
+    await expect(reader.dictionaryPopup).toBeVisible();
+    await expect(reader.rangeHandles).toHaveCount(0);
+
+    await reader.page.keyboard.press('Escape');
+
+    await expect(reader.dictionaryPopup).toBeHidden();
+    // A highlight tap carries no live selection, so the dismiss is the full
+    // one: no toolbar to return to and no editor to bring back.
+    await expect(reader.annotationPopup).toBeHidden();
+    await expect(reader.rangeHandles).toHaveCount(0);
+  });
+
   test('changes the highlight color', async ({ openBook }) => {
     const reader = await openBook();
 

--- a/apps/readest-app/src/app/reader/components/annotator/AnnotationRangeEditor.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/AnnotationRangeEditor.tsx
@@ -73,6 +73,7 @@ export const Handle: React.FC<HandleProps> = ({
 
   return (
     <div
+      data-testid='selection-handle'
       className={clsx(
         'pointer-events-auto absolute z-50 cursor-grab touch-none active:cursor-grabbing',
         hidden && 'hidden',

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -2067,6 +2067,12 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     }
   };
 
+  // The range editors are fixed full-screen overlays rendered after the lookup
+  // popups, so their handles would float on top of the dictionary sheet /
+  // popup (#5815). They belong to the toolbar: hide them while a lookup is
+  // open, and let them come back with the toolbar (or go with the dismiss).
+  const lookupPopupOpen = showDictionaryPopup || showDeepLPopup || showProofreadPopup;
+
   return (
     <div ref={containerRef} role='toolbar' tabIndex={-1}>
       {showDictionaryPopup &&
@@ -2160,20 +2166,23 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
           }}
         />
       )}
-      {!editingAnnotation && selection?.handlesSuppressed && selection.range && (
-        <SelectionRangeEditor
-          bookKey={bookKey}
-          isVertical={viewSettings.vertical}
-          selection={selection}
-          handleColor={selectedColor}
-          onRangeChange={applyProgrammaticSelection}
-          onStartDrag={handleStartEditAnnotation}
-          noteAutoTurnPoint={noteAutoTurnPoint}
-          cancelAutoTurn={cancelAutoTurn}
-          onAutoTurn={onAutoTurn}
-        />
-      )}
-      {editingAnnotation && editingAnnotation.color && selection && (
+      {!editingAnnotation &&
+        !lookupPopupOpen &&
+        selection?.handlesSuppressed &&
+        selection.range && (
+          <SelectionRangeEditor
+            bookKey={bookKey}
+            isVertical={viewSettings.vertical}
+            selection={selection}
+            handleColor={selectedColor}
+            onRangeChange={applyProgrammaticSelection}
+            onStartDrag={handleStartEditAnnotation}
+            noteAutoTurnPoint={noteAutoTurnPoint}
+            cancelAutoTurn={cancelAutoTurn}
+            onAutoTurn={onAutoTurn}
+          />
+        )}
+      {editingAnnotation && editingAnnotation.color && selection && !lookupPopupOpen && (
         <AnnotationRangeEditor
           bookKey={bookKey}
           isVertical={viewSettings.vertical}


### PR DESCRIPTION
Closes #5815

## What the reporter sees

"Selection markers" on top of the dictionary popup. They are not Android's native selection handles: they are Readest's own range-editor handles (`AnnotationRangeEditor` / `SelectionRangeEditor`), which are `fixed inset-0 z-50` overlays rendered after the lookup popups in `Annotator.tsx` and stayed mounted while a lookup was open. They are left behind by an Instant Highlight hold (the reporter uses Instant Highlight, see #5429) and by tapping an existing highlight; on Android the #1553 hyphen path leaves the selection range editor behind too. With the phone layout's dictionary bottom sheet, the handles of a highlight lower on the page paint right over the sheet's content.

(Native handles were checked on a Xiaomi 13 / Android 16 WebView: tapping the toolbar button or the sheet `Dialog`'s `focus()` moves frame focus to the parent document and Chromium clears the composited selection, so they disappear on their own. The toolbar to Dictionary path keeps the selection live by design, #5213.)

## Fix

`lookupPopupOpen = showDictionaryPopup || showDeepLPopup || showProofreadPopup` gates both range editors. They belong to the toolbar: a lookup dismissed back to the toolbar (#5213) brings them back, and the full dismiss drops them with the selection. `Handle` gets a `data-testid` for the test.

## Tests

- New e2e: `annotation.spec.ts` "hides the range-edit handles while the dictionary popup is open (#5815)", with `ReaderPage.clickHighlight()` and a `rangeHandles` locator. Fails on `main` (2 handles stay mounted with the dictionary open), passes with the fix; the rest of `annotation.spec.ts` passes.
- `pnpm test`, `pnpm lint`, `pnpm format:check` green.

## Device verification (Xiaomi 13, Android 16, release APK)

- Tap an existing highlight, then Dictionary: before, two yellow handles floated over the sheet; after, the sheet opens with no handles, and dismissing it is clean.
- Enable Instant Highlight, hold a word (word highlight + editor + toolbar), then Dictionary: no handles over the sheet, clean dismiss.
- Long-press a word, Dictionary, dismiss: the selection toolbar returns with the selection intact (#5213 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Selection and annotation handles are now hidden while dictionary, translation, or proofreading popups are open, preventing them from obscuring lookup content.

* **Tests**
  * Added end-to-end coverage confirming that highlight editing handles appear when expected and remain hidden while lookup popups are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->