### PR TITLE
feat(reader): select text across PDF pages as one selection, closes #5809

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-crossPage.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-crossPage.test.ts
@@ -223,6 +223,28 @@ describe('dragSelectionTo (the app handles)', () => {
     expect(selection.handlesSuppressed).toBe(true);
   });
 
+  test('a drag released off any page commits what it built and lets later selection changes through', async () => {
+    const { result, setSelection } = setup();
+    const anchor = { doc: pageA.doc, index: 1, pos: { node: pageA.textNode, offset: 0 } };
+    await result.current.dragSelectionTo(anchor, { x: 60, y: 100 }, false);
+    // Released in the gap between pages: nothing under the point.
+    const bounds = await result.current.dragSelectionTo(anchor, { x: 60, y: 402 }, true);
+    expect(bounds?.start.index).toBe(1);
+    expect(setSelection).toHaveBeenCalledTimes(1);
+    expect(setSelection.mock.calls[0]![0]).toMatchObject({
+      text: 'first ',
+      handlesSuppressed: true,
+    });
+    // The programmatic guard held during the drag must not outlive it: a
+    // later native selection change is processed again.
+    await new Promise((r) => setTimeout(r, 200));
+    pageA.doc.getSelection()!.setBaseAndExtent(pageA.textNode, 6, pageA.textNode, 10);
+    result.current.handleSelectionchange(pageA.doc, 1);
+    await flush();
+    expect(setSelection).toHaveBeenCalledTimes(2);
+    expect(setSelection.mock.calls[1]![0]).toMatchObject({ text: 'page' });
+  });
+
   test("a handle dragged back onto the anchor page drops the other page's part", async () => {
     const { result, setSelection } = setup();
     // Anchored at the page start so the caret (pinned at offset 6) spans text.

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-crossPage.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-crossPage.test.ts
@@ -25,6 +25,7 @@ const h = vi.hoisted(() => ({
   appService: { isAndroidApp: false, isMobile: false },
   osPlatform: 'macos',
   viewSettings: { scrolled: true },
+  isFixedLayout: true,
 }));
 
 vi.mock('@/context/EnvContext', () => ({
@@ -38,7 +39,7 @@ vi.mock('@/store/readerStore', () => ({
   }),
 }));
 vi.mock('@/store/bookDataStore', () => ({
-  useBookDataStore: () => ({ getBookData: () => ({ isFixedLayout: true }) }),
+  useBookDataStore: () => ({ getBookData: () => ({ isFixedLayout: h.isFixedLayout }) }),
 }));
 vi.mock('@/utils/event', () => ({
   eventDispatcher: { onSync: vi.fn(), offSync: vi.fn(), on: vi.fn(), off: vi.fn() },
@@ -127,6 +128,7 @@ beforeEach(() => {
   h.appService = { isAndroidApp: false, isMobile: false };
   h.osPlatform = 'macos';
   h.viewSettings = { scrolled: true };
+  h.isFixedLayout = true;
   pageA = makePage(0, 'first page text', 6, 1);
   pageB = makePage(404, 'second page text', 6, 2);
   h.contents = [pageA, pageB];
@@ -259,6 +261,52 @@ describe('dragSelectionTo (the app handles)', () => {
     const selection = setSelection.mock.calls[0]![0];
     expect(selection).toMatchObject({ index: 1, text: 'first ', handlesSuppressed: true });
     expect(selection.segments).toBeUndefined();
+  });
+});
+
+describe('gating: only fixed-layout books in scroll mode', () => {
+  const crossPageStaysOff = async (result: ReturnType<typeof setup>['result']) => {
+    // A mouse drag over another section iframe never crosses.
+    result.current.handlePointerDown(pageA.doc, 1, mouse(50, 50));
+    result.current.handlePointerMove(pageA.doc, 1, mouse(60, 500));
+    expect(pageA.doc.documentElement.style.userSelect).toBe('');
+    expect(pageB.doc.getSelection()!.rangeCount).toBe(0);
+    await result.current.handlePointerUp(pageA.doc, 1, mouse(60, 500, 0));
+    expect(pageB.doc.getSelection()!.rangeCount).toBe(0);
+    // The app handles stay in the anchor's own document: the point is mapped
+    // into that document (its iframe starts at y=0, so 500 lands on its text).
+    const anchor = { doc: pageA.doc, index: 1, pos: { node: pageA.textNode, offset: 0 } };
+    const bounds = await result.current.dragSelectionTo(anchor, { x: 60, y: 500 }, false);
+    expect(bounds?.end.index).toBe(1);
+    expect(pageA.doc.getSelection()!.toString()).toBe('first ');
+    expect(pageB.doc.getSelection()!.rangeCount).toBe(0);
+    // A stale selection on another section is left alone.
+    pageB.doc.getSelection()!.setBaseAndExtent(pageB.textNode, 0, pageB.textNode, 6);
+    pageA.doc.getSelection()!.setBaseAndExtent(pageA.textNode, 0, pageA.textNode, 5);
+    result.current.handleSelectionchange(pageA.doc, 1);
+    await flush();
+    expect(pageB.doc.getSelection()!.toString()).toBe('second');
+  };
+
+  test('a reflowable book (EPUB) keeps single-document selection behaviour', async () => {
+    h.isFixedLayout = false;
+    const { result } = setup();
+    await crossPageStaysOff(result);
+  });
+
+  test('a paginated fixed-layout book keeps single-document selection behaviour', async () => {
+    h.viewSettings = { scrolled: false };
+    const { result } = setup();
+    await crossPageStaysOff(result);
+  });
+
+  test('a fixed-layout book in scroll mode drops a stale selection left on another page', async () => {
+    const { result } = setup();
+    pageB.doc.getSelection()!.setBaseAndExtent(pageB.textNode, 0, pageB.textNode, 6);
+    pageA.doc.getSelection()!.setBaseAndExtent(pageA.textNode, 0, pageA.textNode, 5);
+    result.current.handleSelectionchange(pageA.doc, 1);
+    await flush();
+    expect(pageB.doc.getSelection()!.rangeCount).toBe(0);
   });
 });
 

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-crossPage.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-crossPage.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, renderHook } from '@testing-library/react';
+
+// Cross-page selection in fixed-layout books (#5809): every PDF page is its own
+// iframe, so a selection cannot leave the page it started on. A mouse drag that
+// leaves its page keeps reporting to that page (the browser captures the drag)
+// with out-of-frame coordinates; the selector extends the selection into the
+// page under the pointer, freezes the origin page's native drag meanwhile, and
+// commits one selection with per-page segments on release. On Android the
+// app's own handles drive the same engine through dragSelectionTo.
+
+const h = vi.hoisted(() => ({
+  contents: [] as { doc: Document; index: number }[],
+  view: {
+    next: vi.fn(),
+    prev: vi.fn(),
+    deselect: vi.fn(),
+    getCFI: vi.fn((index: number) => `cfi-${index}`),
+    renderer: {
+      containerPosition: 0,
+      scrollLocked: false,
+      getContents: () => h.contents,
+    },
+  },
+  appService: { isAndroidApp: false, isMobile: false },
+  osPlatform: 'macos',
+  viewSettings: { scrolled: true },
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: h.appService }),
+}));
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    getView: () => h.view,
+    getViewSettings: () => h.viewSettings,
+    getProgress: () => null,
+  }),
+}));
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({ getBookData: () => ({ isFixedLayout: true }) }),
+}));
+vi.mock('@/utils/event', () => ({
+  eventDispatcher: { onSync: vi.fn(), offSync: vi.fn(), on: vi.fn(), off: vi.fn() },
+}));
+vi.mock('@/utils/bridge', () => ({
+  setSelectionSuppressed: vi.fn(async () => {}),
+}));
+vi.mock('@/app/reader/hooks/useInstantAnnotation', () => ({
+  useInstantAnnotation: () => ({
+    isInstantAnnotationEnabled: () => false,
+    handleInstantAnnotationPointerDown: vi.fn(),
+    handleInstantAnnotationPointerMove: vi.fn(),
+    handleInstantAnnotationPointerCancel: vi.fn(),
+    handleInstantAnnotationPointerUp: vi.fn(),
+    reapplyInstantAnnotation: vi.fn(),
+    cancelInstantAnnotation: vi.fn(),
+  }),
+}));
+vi.mock('@/utils/misc', async (importActual) => {
+  const actual = await importActual<typeof import('@/utils/misc')>();
+  return { ...actual, getOSPlatform: () => h.osPlatform };
+});
+
+import { useTextSelector } from '@/app/reader/hooks/useTextSelector';
+
+const ZERO_INSETS = { top: 0, right: 0, bottom: 0, left: 0 };
+
+const setup = () => {
+  const setSelection = vi.fn();
+  const noop = vi.fn();
+  const hook = renderHook(() =>
+    useTextSelector(
+      'book-1',
+      ZERO_INSETS,
+      setSelection as never,
+      noop,
+      noop,
+      vi.fn(async (range: Range) => range.toString()),
+      noop,
+    ),
+  );
+  return { ...hook, setSelection };
+};
+
+// A PDF page iframe (pdf.js text layer) at a window rect, whose caret lookup is
+// pinned to a fixed text offset.
+const makePage = (top: number, text: string, caretOffset: number, index: number) => {
+  const iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+  const doc = iframe.contentDocument!;
+  // jsdom Ranges have no layout: let every range (a glyph box probed by the
+  // text-hit test, the selection the native release path measures) cover the
+  // whole page.
+  const win = iframe.contentWindow as Window & typeof globalThis;
+  const pageBox = { left: 0, top: 0, right: 400, bottom: 400, width: 400, height: 400 };
+  win.Range.prototype.getClientRects = () => [pageBox] as unknown as DOMRectList;
+  win.Range.prototype.getBoundingClientRect = () => pageBox as DOMRect;
+  win.requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(() => cb(0), 0) as never;
+  doc.body.innerHTML = `<div id="canvas"></div><div class="textLayer"><span>${text}</span><div class="endOfContent"></div></div>`;
+  iframe.getBoundingClientRect = () =>
+    ({ left: 0, top, right: 400, bottom: top + 400, width: 400, height: 400 }) as DOMRect;
+  const textNode = doc.querySelector('span')!.firstChild as Text;
+  doc.caretPositionFromPoint = () => ({ offsetNode: textNode, offset: caretOffset }) as never;
+  return { doc, index, textNode };
+};
+
+const mouse = (clientX: number, clientY: number, buttons = 1) =>
+  ({
+    pointerType: 'mouse',
+    button: 0,
+    buttons,
+    clientX,
+    clientY,
+    target: document.createElement('span'),
+    preventDefault: vi.fn(),
+  }) as unknown as PointerEvent;
+
+const flush = () => new Promise((r) => setTimeout(r, 10));
+
+let pageA: ReturnType<typeof makePage>;
+let pageB: ReturnType<typeof makePage>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  document.body.innerHTML = '';
+  h.appService = { isAndroidApp: false, isMobile: false };
+  h.osPlatform = 'macos';
+  h.viewSettings = { scrolled: true };
+  pageA = makePage(0, 'first page text', 6, 1);
+  pageB = makePage(404, 'second page text', 6, 2);
+  h.contents = [pageA, pageB];
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('cross-page mouse drag in a fixed-layout book', () => {
+  test('a drag onto the next page selects both parts and commits one segmented selection', async () => {
+    const { result, setSelection } = setup();
+    result.current.handlePointerDown(pageA.doc, 1, mouse(50, 50));
+    // Still on the origin page: the native drag owns the selection.
+    result.current.handlePointerMove(pageA.doc, 1, mouse(60, 100));
+    expect(pageA.doc.documentElement.style.userSelect).toBe('');
+    expect(pageB.doc.getSelection()!.rangeCount).toBe(0);
+
+    // The pointer is now over page B (reported to page A with out-of-frame y).
+    result.current.handlePointerMove(pageA.doc, 1, mouse(60, 500));
+    expect(pageA.doc.documentElement.style.userSelect).toBe('none');
+    expect(pageA.doc.querySelector<HTMLElement>('.textLayer')!.style.userSelect).toBe('text');
+    expect(pageA.doc.getSelection()!.toString()).toBe('page text');
+    expect(pageB.doc.getSelection()!.toString()).toBe('second');
+
+    await result.current.handlePointerUp(pageA.doc, 1, mouse(60, 500, 0));
+    expect(pageA.doc.documentElement.style.userSelect).toBe('');
+    expect(setSelection).toHaveBeenCalledTimes(1);
+    const selection = setSelection.mock.calls[0]![0];
+    expect(selection.text).toBe('page text second');
+    expect(selection.index).toBe(1);
+    expect(selection.cfi).toBe('cfi-1');
+    expect(selection.segments.map((s: { index: number }) => s.index)).toEqual([1, 2]);
+    expect(selection.segments.map((s: { text: string }) => s.text)).toEqual([
+      'page text',
+      'second',
+    ]);
+    // Both parts stay selected on screen.
+    expect(pageA.doc.getSelection()!.toString()).toBe('page text');
+    expect(pageB.doc.getSelection()!.toString()).toBe('second');
+  });
+
+  test('returning to the origin page hands the drag back and clears the other page', async () => {
+    const { result, setSelection } = setup();
+    result.current.handlePointerDown(pageA.doc, 1, mouse(50, 50));
+    result.current.handlePointerMove(pageA.doc, 1, mouse(60, 500));
+    expect(pageB.doc.getSelection()!.rangeCount).toBe(1);
+
+    result.current.handlePointerMove(pageA.doc, 1, mouse(60, 120));
+    expect(pageA.doc.documentElement.style.userSelect).toBe('');
+    expect(pageB.doc.getSelection()!.rangeCount).toBe(0);
+
+    await result.current.handlePointerUp(pageA.doc, 1, mouse(60, 120, 0));
+    expect(setSelection).not.toHaveBeenCalledWith(
+      expect.objectContaining({ segments: expect.anything() }),
+    );
+  });
+
+  test('a drag that stays on one page never touches the other page', async () => {
+    const { result } = setup();
+    result.current.handlePointerDown(pageA.doc, 1, mouse(50, 50));
+    result.current.handlePointerMove(pageA.doc, 1, mouse(300, 300));
+    await result.current.handlePointerUp(pageA.doc, 1, mouse(300, 300, 0));
+    expect(pageA.doc.documentElement.style.userSelect).toBe('');
+    expect(pageB.doc.getSelection()!.rangeCount).toBe(0);
+  });
+});
+
+describe('dragSelectionTo (the app handles)', () => {
+  const anchorOnA = () => ({
+    doc: pageA.doc,
+    index: 1,
+    pos: { node: pageA.textNode, offset: 6 },
+  });
+
+  test('a handle dragged onto the next page extends across and commits a segmented selection', async () => {
+    const { result, setSelection } = setup();
+    const live = await result.current.dragSelectionTo(anchorOnA(), { x: 60, y: 500 }, false);
+    expect(pageA.doc.getSelection()!.toString()).toBe('page text');
+    expect(pageB.doc.getSelection()!.toString()).toBe('second');
+    expect(live).toMatchObject({
+      start: { index: 1, pos: { node: pageA.textNode, offset: 6 } },
+      end: { index: 2, pos: { node: pageB.textNode, offset: 6 } },
+    });
+    expect(setSelection).not.toHaveBeenCalled();
+
+    await result.current.dragSelectionTo(anchorOnA(), { x: 60, y: 500 }, true);
+    expect(setSelection).toHaveBeenCalledTimes(1);
+    const selection = setSelection.mock.calls[0]![0];
+    expect(selection.text).toBe('page text second');
+    expect(selection.segments.map((s: { index: number }) => s.index)).toEqual([1, 2]);
+    // The app handles stay in charge of the committed selection.
+    expect(selection.handlesSuppressed).toBe(true);
+  });
+
+  test("a handle dragged back onto the anchor page drops the other page's part", async () => {
+    const { result, setSelection } = setup();
+    // Anchored at the page start so the caret (pinned at offset 6) spans text.
+    const anchor = { doc: pageA.doc, index: 1, pos: { node: pageA.textNode, offset: 0 } };
+    await result.current.dragSelectionTo(anchor, { x: 60, y: 500 }, false);
+    expect(pageB.doc.getSelection()!.rangeCount).toBe(1);
+    const bounds = await result.current.dragSelectionTo(anchor, { x: 60, y: 100 }, true);
+    expect(pageB.doc.getSelection()!.rangeCount).toBe(0);
+    expect(bounds?.start.index).toBe(1);
+    expect(bounds?.end.index).toBe(1);
+    expect(setSelection).toHaveBeenCalledTimes(1);
+    const selection = setSelection.mock.calls[0]![0];
+    expect(selection).toMatchObject({ index: 1, text: 'first ', handlesSuppressed: true });
+    expect(selection.segments).toBeUndefined();
+  });
+});
+
+describe('Android: app handles for fixed-layout pages in scroll mode', () => {
+  beforeEach(() => {
+    h.appService = { isAndroidApp: true, isMobile: true };
+    h.osPlatform = 'android';
+  });
+
+  // A native long-press selection on a page.
+  const nativeSelect = (page: ReturnType<typeof makePage>, from: number, to: number) =>
+    page.doc.getSelection()!.setBaseAndExtent(page.textNode, from, page.textNode, to);
+
+  test('a touch selection is republished with the native handles suppressed at touch end', async () => {
+    const { result, setSelection } = setup();
+    result.current.handleTouchStart();
+    nativeSelect(pageA, 0, 5);
+    result.current.handleSelectionchange(pageA.doc, 1);
+    await flush();
+    expect(setSelection).toHaveBeenLastCalledWith(
+      expect.objectContaining({ text: 'first', handlesSuppressed: false }),
+    );
+    await result.current.handlePointerUp(pageA.doc, 1);
+    await flush();
+    expect(setSelection).toHaveBeenLastCalledWith(
+      expect.objectContaining({ text: 'first', handlesSuppressed: true }),
+    );
+    expect(pageA.doc.getSelection()!.toString()).toBe('first');
+  });
+
+  test('paginated fixed-layout keeps the native handles', async () => {
+    h.viewSettings = { scrolled: false };
+    const { result, setSelection } = setup();
+    result.current.handleTouchStart();
+    nativeSelect(pageA, 0, 5);
+    result.current.handleSelectionchange(pageA.doc, 1);
+    await flush();
+    await result.current.handlePointerUp(pageA.doc, 1);
+    await flush();
+    expect(setSelection).not.toHaveBeenCalledWith(
+      expect.objectContaining({ handlesSuppressed: true }),
+    );
+  });
+});

--- a/apps/readest-app/src/__tests__/store/notebook-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/notebook-store.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
     isNotebookPinned: false,
     notebookActiveTab: 'notes',
     notebookNewAnnotation: null,
-    notebookNewHighlightId: null,
+    notebookNewHighlightIds: [],
     notebookEditAnnotation: null,
     notebookAnnotationDrafts: {},
   });
@@ -138,17 +138,17 @@ describe('notebookStore', () => {
     });
   });
 
-  // ── New highlight placeholder id ───────────────────────────────
-  describe('setNotebookNewHighlightId', () => {
-    test('tracks the placeholder highlight id', () => {
-      useNotebookStore.getState().setNotebookNewHighlightId('hl-1');
-      expect(useNotebookStore.getState().notebookNewHighlightId).toBe('hl-1');
+  // ── New highlight placeholder ids ──────────────────────────────
+  describe('setNotebookNewHighlightIds', () => {
+    test('tracks the placeholder highlight ids (one per page of a cross-page selection)', () => {
+      useNotebookStore.getState().setNotebookNewHighlightIds(['hl-1', 'hl-2']);
+      expect(useNotebookStore.getState().notebookNewHighlightIds).toEqual(['hl-1', 'hl-2']);
     });
 
-    test('clears the placeholder highlight id when set to null', () => {
-      useNotebookStore.getState().setNotebookNewHighlightId('hl-1');
-      useNotebookStore.getState().setNotebookNewHighlightId(null);
-      expect(useNotebookStore.getState().notebookNewHighlightId).toBeNull();
+    test('clears the placeholder highlight ids when set to an empty list', () => {
+      useNotebookStore.getState().setNotebookNewHighlightIds(['hl-1']);
+      useNotebookStore.getState().setNotebookNewHighlightIds([]);
+      expect(useNotebookStore.getState().notebookNewHighlightIds).toEqual([]);
     });
   });
 
@@ -231,7 +231,7 @@ describe('notebookStore', () => {
       expect(state.isNotebookPinned).toBe(false);
       expect(state.notebookActiveTab).toBe('notes');
       expect(state.notebookNewAnnotation).toBeNull();
-      expect(state.notebookNewHighlightId).toBeNull();
+      expect(state.notebookNewHighlightIds).toEqual([]);
       expect(state.notebookEditAnnotation).toBeNull();
       expect(state.notebookAnnotationDrafts).toEqual({});
     });

--- a/apps/readest-app/src/__tests__/utils/cross-doc-selection.test.ts
+++ b/apps/readest-app/src/__tests__/utils/cross-doc-selection.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  applyCrossDocSegments,
+  buildCrossDocSegments,
+  findContentAtPoint,
+  getCaretPositionInText,
+  getDocTextBounds,
+  isTextAtPoint,
+  rangeBetweenPositions,
+  setNativeDragFrozen,
+  toDocPoint,
+} from '@/app/reader/utils/crossDocSelection';
+import type { Rect } from '@/utils/sel';
+
+// A section iframe the way fixed-layout renders a PDF page: the page text lives
+// in `.textLayer` spans, with pdf.js's empty `.endOfContent` div last.
+const makePage = (rect: Rect, spans: string[], index?: number) => {
+  const iframe = document.createElement('iframe');
+  document.body.appendChild(iframe);
+  const doc = iframe.contentDocument!;
+  doc.body.innerHTML =
+    `<div id="canvas"><canvas></canvas></div><div class="textLayer">` +
+    spans.map((s) => `<span>${s}</span>`).join('') +
+    `<div class="endOfContent"></div></div><div class="annotationLayer"></div>`;
+  iframe.getBoundingClientRect = () =>
+    ({
+      ...rect,
+      x: rect.left,
+      y: rect.top,
+      width: rect.right - rect.left,
+      height: rect.bottom - rect.top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  return { doc, index, iframe };
+};
+
+const textNode = (doc: Document, nth: number) =>
+  doc.querySelectorAll('.textLayer span')[nth]!.firstChild as Text;
+
+describe('crossDocSelection', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('findContentAtPoint', () => {
+    it('returns the section whose iframe contains the window point', () => {
+      const a = makePage({ left: 100, top: 0, right: 500, bottom: 400 }, ['a'], 3);
+      const b = makePage({ left: 100, top: 404, right: 500, bottom: 804 }, ['b'], 4);
+      expect(findContentAtPoint([a, b], { x: 200, y: 500 })).toEqual({ doc: b.doc, index: 4 });
+      expect(findContentAtPoint([a, b], { x: 200, y: 100 })).toEqual({ doc: a.doc, index: 3 });
+    });
+
+    it('skips blank placeholder frames and misses', () => {
+      const a = makePage({ left: 100, top: 0, right: 500, bottom: 400 }, ['a'], 3);
+      // The paginated renderer lists a blank iframe with no section index.
+      const blank = makePage({ left: 0, top: 0, right: 1000, bottom: 1000 }, []);
+      expect(findContentAtPoint([blank, a], { x: 200, y: 100 })).toEqual({ doc: a.doc, index: 3 });
+      expect(findContentAtPoint([a], { x: 200, y: 402 })).toBeNull();
+    });
+  });
+
+  describe('toDocPoint', () => {
+    it('maps a window point into the iframe, undoing a CSS scale on the frame', () => {
+      const a = makePage({ left: 100, top: 50, right: 300, bottom: 250 }, ['a'], 0);
+      // 400x400 CSS px iframe drawn at 200x200 (scaled 0.5 by a pinch preview).
+      Object.defineProperty(a.iframe, 'clientWidth', { value: 400 });
+      Object.defineProperty(a.iframe, 'clientHeight', { value: 400 });
+      expect(toDocPoint(a.doc, { x: 200, y: 150 })).toEqual({ x: 200, y: 200 });
+    });
+  });
+
+  describe('isTextAtPoint', () => {
+    it('is true on a glyph and false on the blank page area the caret snapped from', () => {
+      const a = makePage({ left: 0, top: 0, right: 400, bottom: 400 }, ['alpha'], 0);
+      const text = textNode(a.doc, 0);
+      // The caret lookup snaps any point to the nearest glyph; the glyph's box
+      // decides whether the point was actually on text.
+      a.doc.caretPositionFromPoint = () => ({ offsetNode: text, offset: 2 }) as never;
+      const win = a.iframe.contentWindow as Window & typeof globalThis;
+      win.Range.prototype.getClientRects = () =>
+        [{ left: 10, top: 10, right: 60, bottom: 30 }] as unknown as DOMRectList;
+      expect(isTextAtPoint(a.doc, 20, 20)).toBe(true);
+      expect(isTextAtPoint(a.doc, 20, 200)).toBe(false);
+      // A caret on an element (no text under the point at all) is not text.
+      a.doc.caretPositionFromPoint = () => ({ offsetNode: a.doc.body, offset: 0 }) as never;
+      expect(isTextAtPoint(a.doc, 20, 20)).toBe(false);
+    });
+  });
+
+  describe('getCaretPositionInText', () => {
+    it('clamps a point above or below all glyphs to the text start/end, else asks the browser', () => {
+      const a = makePage({ left: 0, top: 0, right: 400, bottom: 400 }, ['first', 'last'], 0);
+      const win = a.iframe.contentWindow as Window & typeof globalThis;
+      // Glyph boxes: "first" at y 10..20, "last" at y 100..110.
+      win.Range.prototype.getBoundingClientRect = function (this: Range) {
+        const top = this.toString() === 'first' ? 10 : 100;
+        return { left: 0, right: 50, top, bottom: top + 10, width: 50, height: 10 } as DOMRect;
+      };
+      a.doc.caretPositionFromPoint = () => ({ offsetNode: textNode(a.doc, 1), offset: 2 }) as never;
+      expect(getCaretPositionInText(a.doc, 20, 5)).toEqual({ node: textNode(a.doc, 0), offset: 0 });
+      expect(getCaretPositionInText(a.doc, 20, 200)).toEqual({
+        node: textNode(a.doc, 1),
+        offset: 4,
+      });
+      expect(getCaretPositionInText(a.doc, 20, 50)).toEqual({
+        node: textNode(a.doc, 1),
+        offset: 2,
+      });
+    });
+  });
+
+  describe('rangeBetweenPositions', () => {
+    it('orders the two positions whichever is dragged first', () => {
+      const a = makePage({ left: 0, top: 0, right: 1, bottom: 1 }, ['alpha', 'beta'], 0);
+      const p = { node: textNode(a.doc, 0), offset: 1 };
+      const q = { node: textNode(a.doc, 1), offset: 2 };
+      expect(rangeBetweenPositions(a.doc, p, q)?.toString()).toBe('lphabe');
+      expect(rangeBetweenPositions(a.doc, q, p)?.toString()).toBe('lphabe');
+      expect(rangeBetweenPositions(a.doc, p, p)).toBeNull();
+    });
+  });
+
+  describe('getDocTextBounds', () => {
+    it('spans from the first to the last non-empty text node', () => {
+      const a = makePage({ left: 0, top: 0, right: 1, bottom: 1 }, ['first', ' ', 'last'], 0);
+      const bounds = getDocTextBounds(a.doc)!;
+      expect(bounds.start).toEqual({ node: textNode(a.doc, 0), offset: 0 });
+      expect(bounds.end).toEqual({ node: textNode(a.doc, 2), offset: 4 });
+    });
+
+    it('is null for a page without text', () => {
+      const a = makePage({ left: 0, top: 0, right: 1, bottom: 1 }, [], 0);
+      expect(getDocTextBounds(a.doc)).toBeNull();
+    });
+  });
+
+  describe('buildCrossDocSegments', () => {
+    const rect = { left: 0, top: 0, right: 1, bottom: 1 };
+
+    it('forward: anchor page to its end, pages between in full, target page from its start', () => {
+      const a = makePage(rect, ['alpha', 'beta'], 1);
+      const mid = makePage(rect, ['middle'], 2);
+      const b = makePage(rect, ['gamma', 'delta'], 3);
+      const contents = [a, mid, b];
+      const segments = buildCrossDocSegments(
+        { doc: a.doc, index: 1, pos: { node: textNode(a.doc, 0), offset: 2 } },
+        { doc: b.doc, index: 3, pos: { node: textNode(b.doc, 1), offset: 3 } },
+        contents,
+      );
+      expect(segments.map((s) => s.index)).toEqual([1, 2, 3]);
+      expect(segments[0]).toMatchObject({
+        start: { node: textNode(a.doc, 0), offset: 2 },
+        end: { node: textNode(a.doc, 1), offset: 4 },
+      });
+      expect(segments[1]).toMatchObject({
+        start: { node: textNode(mid.doc, 0), offset: 0 },
+        end: { node: textNode(mid.doc, 0), offset: 6 },
+      });
+      expect(segments[2]).toMatchObject({
+        start: { node: textNode(b.doc, 0), offset: 0 },
+        end: { node: textNode(b.doc, 1), offset: 3 },
+      });
+    });
+
+    it('backward: the earlier page from the caret to its end, the anchor page up to the anchor', () => {
+      const a = makePage(rect, ['alpha', 'beta'], 1);
+      const b = makePage(rect, ['gamma', 'delta'], 2);
+      const segments = buildCrossDocSegments(
+        { doc: b.doc, index: 2, pos: { node: textNode(b.doc, 1), offset: 3 } },
+        { doc: a.doc, index: 1, pos: { node: textNode(a.doc, 0), offset: 2 } },
+        [a, b],
+      );
+      expect(segments.map((s) => s.index)).toEqual([1, 2]);
+      expect(segments[0]).toMatchObject({
+        start: { node: textNode(a.doc, 0), offset: 2 },
+        end: { node: textNode(a.doc, 1), offset: 4 },
+      });
+      expect(segments[1]).toMatchObject({
+        start: { node: textNode(b.doc, 0), offset: 0 },
+        end: { node: textNode(b.doc, 1), offset: 3 },
+      });
+    });
+
+    it('drops a collapsed part (anchor at the very end of its page) and same-page input', () => {
+      const a = makePage(rect, ['alpha'], 1);
+      const b = makePage(rect, ['gamma'], 2);
+      const segments = buildCrossDocSegments(
+        { doc: a.doc, index: 1, pos: { node: textNode(a.doc, 0), offset: 5 } },
+        { doc: b.doc, index: 2, pos: { node: textNode(b.doc, 0), offset: 2 } },
+        [a, b],
+      );
+      expect(segments.map((s) => s.index)).toEqual([2]);
+      expect(
+        buildCrossDocSegments(
+          { doc: a.doc, index: 1, pos: { node: textNode(a.doc, 0), offset: 1 } },
+          { doc: a.doc, index: 1, pos: { node: textNode(a.doc, 0), offset: 4 } },
+          [a, b],
+        ),
+      ).toEqual([]);
+    });
+  });
+
+  describe('applyCrossDocSegments', () => {
+    const rect = { left: 0, top: 0, right: 1, bottom: 1 };
+
+    it('selects each segment and clears every other section, keeping the anchor as the base', () => {
+      const a = makePage(rect, ['alpha', 'beta'], 1);
+      const b = makePage(rect, ['gamma'], 2);
+      const stale = makePage(rect, ['stale'], 5);
+      stale.doc.getSelection()!.selectAllChildren(stale.doc.body);
+      const anchor = { doc: b.doc, index: 2, pos: { node: textNode(b.doc, 0), offset: 3 } };
+      const segments = buildCrossDocSegments(
+        anchor,
+        { doc: a.doc, index: 1, pos: { node: textNode(a.doc, 0), offset: 2 } },
+        [a, b, stale],
+      );
+      applyCrossDocSegments(segments, [a, b, stale], anchor);
+      expect(a.doc.getSelection()!.toString()).toBe('phabeta');
+      expect(b.doc.getSelection()!.toString()).toBe('gam');
+      // Backward drag: the anchor page's selection runs from the anchor back to
+      // the page start, so the native drag can keep extending from the anchor.
+      expect(b.doc.getSelection()!.anchorNode).toBe(textNode(b.doc, 0));
+      expect(b.doc.getSelection()!.anchorOffset).toBe(3);
+      expect(stale.doc.getSelection()!.rangeCount).toBe(0);
+    });
+  });
+
+  describe('setNativeDragFrozen', () => {
+    it('makes the page root non-selectable but keeps the text layer selectable', () => {
+      const a = makePage({ left: 0, top: 0, right: 1, bottom: 1 }, ['alpha'], 1);
+      const layer = a.doc.querySelector<HTMLElement>('.textLayer')!;
+      setNativeDragFrozen(a.doc, true);
+      expect(a.doc.documentElement.style.userSelect).toBe('none');
+      expect(layer.style.userSelect).toBe('text');
+      setNativeDragFrozen(a.doc, false);
+      expect(a.doc.documentElement.style.userSelect).toBe('');
+      expect(layer.style.userSelect).toBe('');
+    });
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/sel.test.ts
+++ b/apps/readest-app/src/__tests__/utils/sel.test.ts
@@ -257,6 +257,49 @@ describe('sel utilities', () => {
       expect(result.dir).toBe('down');
       expect(result.point.x).toBeGreaterThan(0);
     });
+
+    it("anchors a multi-page selection to the last segment, in that segment's frame", async () => {
+      const { getPosition } = await import('@/utils/sel');
+      // Two PDF page iframes stacked in scrolled mode; the selection starts on
+      // the upper page and ends on the lower one (a cross-page selection).
+      const makeFrame = (top: number) => {
+        const iframe = document.createElement('iframe');
+        document.body.appendChild(iframe);
+        iframe.getBoundingClientRect = () =>
+          ({ top, left: 100, right: 500, bottom: top + 400, width: 400, height: 400 }) as DOMRect;
+        return iframe.contentDocument!;
+      };
+      const upper = makeFrame(0);
+      const lower = makeFrame(404);
+      const rangeIn = (doc: Document, rect: { top: number; bottom: number }) =>
+        ({
+          getClientRects: () => [{ ...rect, left: 20, right: 120 }] as unknown as DOMRectList,
+          commonAncestorContainer: doc.body,
+          // Marks the mock as a Range for getIframeElement, which walks up from
+          // commonAncestorContainer to the owning iframe.
+          collapse: () => {},
+        }) as unknown as Range;
+      const first = rangeIn(upper, { top: 300, bottom: 320 });
+      const last = rangeIn(lower, { top: 50, bottom: 70 });
+      const selection = {
+        key: 'k',
+        text: 'a b',
+        page: 1,
+        index: 0,
+        range: first,
+        segments: [
+          { range: first, index: 0, text: 'a' },
+          { range: last, index: 1, text: 'b' },
+        ],
+      };
+      const rect: Rect = { top: 0, right: 1024, bottom: 768, left: 0 };
+      const result = getPosition(selection, rect, 10);
+      // Below the last line of the LAST segment: 404 (frame) + 70 + 6.
+      expect(result.dir).toBe('down');
+      expect(result.point.y).toBe(480);
+      expect(result.point.x).toBe(170);
+      document.body.innerHTML = '';
+    });
   });
 
   describe('isPointerInsideSelection', () => {

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -344,7 +344,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     handleShowPopup,
     handleUpToPopup,
     handleContextmenu,
-    applyProgrammaticSelection,
+    dragSelectionTo,
     noteAutoTurnPoint,
     cancelAutoTurn,
     onAutoTurn,
@@ -1301,70 +1301,77 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     if (!selection || !selection.text) return null;
     setHighlightOptionsVisible(true);
     const { booknotes: annotations = [] } = config;
-    // Popup-window selections carry the CFI mapped into the pristine section;
-    // recomputing from the popup range would yield an unresolvable path.
-    const cfi = selection.popup ? selection.cfi : view?.getCFI(selection.index, selection.range);
-    if (!cfi) return null;
     const style = highlightStyle || settings.globalReadSettings.highlightStyle;
     const color = settings.globalReadSettings.highlightStyles[style];
     setSelectedStyle(style);
     setSelectedColor(color);
-    const annotation: BookNote = {
-      id: uniqueId(),
-      type: 'annotation',
-      cfi,
-      style,
-      color,
-      text: selection.text,
-      note: '',
-      page: progress.page,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-    };
-    const existingIndex = annotations.findIndex(
-      (annotation) =>
-        annotation.cfi === cfi &&
-        annotation.type === 'annotation' &&
-        annotation.style &&
-        !annotation.deletedAt,
-    );
     const views = getViewsById(bookKey.split('-')[0]!);
     // Only a brand-new highlight is a placeholder the cancel flow may remove;
     // restyling/toggling an existing one must never tear down the user's record.
     let created: BookNote | null = null;
-    if (existingIndex !== -1) {
-      const existing = annotations[existingIndex]!;
-      // Tear down both the original anchor and any global fan-outs that
-      // were drawn for the previous style/color, so the redraw below
-      // doesn't end up overlaying two highlights at the same position.
-      views.forEach((view) => view?.addAnnotation(existing, true));
-      if (existing.global) {
-        views.forEach((view) => removeGlobalAnnotationOverlays(view, existing));
-      }
-      if (update) {
-        // Preserve the note/text/createdAt and the `global` flag of the existing
-        // record so a restyle (color/style change) of a unified annotation
-        // doesn't wipe its note or silently demote a global highlight. The note
-        // bubble overlay (NOTE_PREFIX) isn't torn down above, so it persists; we
-        // only redraw the highlight overlay (value = cfi).
-        const merged = mergeRestyledAnnotation(existing, annotation);
-        annotations[existingIndex] = merged;
-        views.forEach((view) => view?.addAnnotation(merged));
-        if (merged.global) {
-          views.forEach((view) => {
-            if (view) expandAllRenderedSections(view, merged);
-          });
+    let firstCfi: string | undefined;
+    // A selection across pages (#5809) is highlighted one page at a time: one
+    // record per part, the selection itself staying anchored on the first.
+    for (const part of selection.segments ?? [selection]) {
+      // Popup-window selections carry the CFI mapped into the pristine section;
+      // recomputing from the popup range would yield an unresolvable path.
+      const cfi = selection.popup ? selection.cfi : view?.getCFI(part.index, part.range);
+      if (!cfi) continue;
+      firstCfi ??= cfi;
+      const annotation: BookNote = {
+        id: uniqueId(),
+        type: 'annotation',
+        cfi,
+        style,
+        color,
+        text: part.text,
+        note: '',
+        page: progress.page,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      const existingIndex = annotations.findIndex(
+        (annotation) =>
+          annotation.cfi === cfi &&
+          annotation.type === 'annotation' &&
+          annotation.style &&
+          !annotation.deletedAt,
+      );
+      if (existingIndex !== -1) {
+        const existing = annotations[existingIndex]!;
+        // Tear down both the original anchor and any global fan-outs that
+        // were drawn for the previous style/color, so the redraw below
+        // doesn't end up overlaying two highlights at the same position.
+        views.forEach((view) => view?.addAnnotation(existing, true));
+        if (existing.global) {
+          views.forEach((view) => removeGlobalAnnotationOverlays(view, existing));
+        }
+        if (update) {
+          // Preserve the note/text/createdAt and the `global` flag of the existing
+          // record so a restyle (color/style change) of a unified annotation
+          // doesn't wipe its note or silently demote a global highlight. The note
+          // bubble overlay (NOTE_PREFIX) isn't torn down above, so it persists; we
+          // only redraw the highlight overlay (value = cfi).
+          const merged = mergeRestyledAnnotation(existing, annotation);
+          annotations[existingIndex] = merged;
+          views.forEach((view) => view?.addAnnotation(merged));
+          if (merged.global) {
+            views.forEach((view) => {
+              if (view) expandAllRenderedSections(view, merged);
+            });
+          }
+        } else {
+          existing.deletedAt = Date.now();
+          handleDismissPopup();
         }
       } else {
-        existing.deletedAt = Date.now();
-        handleDismissPopup();
+        annotations.push(annotation);
+        views.forEach((view) => view?.addAnnotation(annotation));
+        created ??= annotation;
       }
-    } else {
-      annotations.push(annotation);
-      views.forEach((view) => view?.addAnnotation(annotation));
-      setSelection({ ...selection, cfi, annotated: true });
-      created = annotation;
     }
+    if (!firstCfi) return null;
+    if (created) setSelection({ ...selection, cfi: firstCfi, annotated: true });
 
     const updatedConfig = updateBooknotes(bookKey, annotations);
     if (updatedConfig) {
@@ -2174,7 +2181,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
             isVertical={viewSettings.vertical}
             selection={selection}
             handleColor={selectedColor}
-            onRangeChange={applyProgrammaticSelection}
+            onDragTo={dragSelectionTo}
             onStartDrag={handleStartEditAnnotation}
             noteAutoTurnPoint={noteAutoTurnPoint}
             cancelAutoTurn={cancelAutoTurn}

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -1312,10 +1312,25 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     let firstCfi: string | undefined;
     // A selection across pages (#5809) is highlighted one page at a time: one
     // record per part, the selection itself staying anchored on the first.
-    for (const part of selection.segments ?? [selection]) {
-      // Popup-window selections carry the CFI mapped into the pristine section;
-      // recomputing from the popup range would yield an unresolvable path.
-      const cfi = selection.popup ? selection.cfi : view?.getCFI(part.index, part.range);
+    // Popup-window selections carry the CFI mapped into the pristine section;
+    // recomputing from the popup range would yield an unresolvable path.
+    const parts = selection.segments ?? [selection];
+    const cfis = parts.map((part) =>
+      selection.popup ? selection.cfi : view?.getCFI(part.index, part.range),
+    );
+    const findExisting = (cfi: string) =>
+      annotations.findIndex(
+        (annotation) =>
+          annotation.cfi === cfi &&
+          annotation.type === 'annotation' &&
+          annotation.style &&
+          !annotation.deletedAt,
+      );
+    // Toggling off only once every part is highlighted; otherwise the missing
+    // parts are added and the already highlighted ones left alone.
+    const allExist = cfis.every((cfi) => cfi && findExisting(cfi) !== -1);
+    for (const [i, part] of parts.entries()) {
+      const cfi = cfis[i];
       if (!cfi) continue;
       firstCfi ??= cfi;
       const annotation: BookNote = {
@@ -1330,14 +1345,9 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
         createdAt: Date.now(),
         updatedAt: Date.now(),
       };
-      const existingIndex = annotations.findIndex(
-        (annotation) =>
-          annotation.cfi === cfi &&
-          annotation.type === 'annotation' &&
-          annotation.style &&
-          !annotation.deletedAt,
-      );
+      const existingIndex = findExisting(cfi);
       if (existingIndex !== -1) {
+        if (!update && !allExist) continue;
         const existing = annotations[existingIndex]!;
         // Tear down both the original anchor and any global fan-outs that
         // were drawn for the previous style/color, so the redraw below

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -121,7 +121,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
   const getView = useReaderStore((s) => s.getView);
   const getViewsById = useReaderStore((s) => s.getViewsById);
   const getViewSettings = useReaderStore((s) => s.getViewSettings);
-  const { setNotebookVisible, setNotebookNewAnnotation, setNotebookNewHighlightId } =
+  const { setNotebookVisible, setNotebookNewAnnotation, setNotebookNewHighlightIds } =
     useNotebookStore();
   const { clearBooknotesNav, isSideBarVisible } = useSidebarStore();
   const { listenToNativeTouchEvents } = useDeviceControlStore();
@@ -1297,8 +1297,11 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     handleDismissPopupAndSelection();
   };
 
-  const handleHighlight = (update = false, highlightStyle?: HighlightStyle): BookNote | null => {
-    if (!selection || !selection.text) return null;
+  // Returns the brand-new highlight records (one per page of a cross-page
+  // selection): only those are placeholders the note-cancel flow may remove;
+  // restyling/toggling an existing one must never tear down the user's record.
+  const handleHighlight = (update = false, highlightStyle?: HighlightStyle): BookNote[] => {
+    if (!selection || !selection.text) return [];
     setHighlightOptionsVisible(true);
     const { booknotes: annotations = [] } = config;
     const style = highlightStyle || settings.globalReadSettings.highlightStyle;
@@ -1306,9 +1309,8 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     setSelectedStyle(style);
     setSelectedColor(color);
     const views = getViewsById(bookKey.split('-')[0]!);
-    // Only a brand-new highlight is a placeholder the cancel flow may remove;
-    // restyling/toggling an existing one must never tear down the user's record.
-    let created: BookNote | null = null;
+    const created: BookNote[] = [];
+    let deleted = false;
     let firstCfi: string | undefined;
     // A selection across pages (#5809) is highlighted one page at a time: one
     // record per part, the selection itself staying anchored on the first.
@@ -1372,16 +1374,17 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
           }
         } else {
           existing.deletedAt = Date.now();
-          handleDismissPopup();
+          deleted = true;
         }
       } else {
         annotations.push(annotation);
         views.forEach((view) => view?.addAnnotation(annotation));
-        created ??= annotation;
+        created.push(annotation);
       }
     }
-    if (!firstCfi) return null;
-    if (created) setSelection({ ...selection, cfi: firstCfi, annotated: true });
+    if (!firstCfi) return [];
+    if (deleted) handleDismissPopup();
+    if (created.length > 0) setSelection({ ...selection, cfi: firstCfi, annotated: true });
 
     const updatedConfig = updateBooknotes(bookKey, annotations);
     if (updatedConfig) {
@@ -1464,10 +1467,11 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     const created = handleHighlight(true);
     setNotebookVisible(true);
     setNotebookNewAnnotation(selection);
-    // Remember the eagerly-created highlight so the notebook can remove it if the
-    // note is never saved. A restyle of an existing highlight returns null — that
-    // record predates this flow and must survive a cancel (#4791).
-    setNotebookNewHighlightId(created?.id ?? null);
+    // Remember the eagerly-created highlights (one per page of a cross-page
+    // selection) so the notebook can remove them if the note is never saved. A
+    // restyle of an existing highlight creates none — that record predates this
+    // flow and must survive a cancel (#4791).
+    setNotebookNewHighlightIds(created.map((annotation) => annotation.id));
     handleDismissPopup();
   };
 

--- a/apps/readest-app/src/app/reader/components/annotator/SelectionRangeEditor.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/SelectionRangeEditor.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { HighlightColor } from '@/types/book';
-import { Point, rangeFromAnchorToPoint, TextSelection } from '@/utils/sel';
+import { Point, TextSelection } from '@/utils/sel';
 import { useEnv } from '@/context/EnvContext';
 import { useThemeStore } from '@/store/themeStore';
 import { useReaderStore } from '@/store/readerStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { getHandlePositionsFromRange, getHighlightColorHex } from '../../utils/annotatorUtil';
+import { SectionAnchor, SelectionBounds } from '../../utils/crossDocSelection';
 import MagnifierLoupe from './MagnifierLoupe';
 import { Handle } from './AnnotationRangeEditor';
 
@@ -15,24 +16,55 @@ interface SelectionRangeEditorProps {
   isVertical: boolean;
   selection: TextSelection;
   handleColor: HighlightColor;
-  onRangeChange: (range: Range, index: number, commit: boolean) => void;
+  // Rebuild the selection between the fixed `anchor` and the dragged `point`
+  // (window coords), committing it when the drag ends; resolves to the
+  // selection's new outer bounds.
+  onDragTo: (
+    anchor: SectionAnchor,
+    point: Point,
+    commit: boolean,
+  ) => Promise<SelectionBounds | null>;
   onStartDrag: () => void;
   noteAutoTurnPoint: (point: Point | null) => void;
   cancelAutoTurn: () => void;
   onAutoTurn: (cb: () => void) => () => void;
 }
 
+// The outer ends of a (possibly cross-page, #5809) selection as DOM-anchored
+// section positions, so a handle drag keeps the far end in place.
+const boundsOfSelection = (selection: TextSelection): SelectionBounds | null => {
+  const first = selection.segments?.[0] ?? selection;
+  const last = selection.segments?.at(-1) ?? selection;
+  const startDoc = first.range.startContainer.ownerDocument;
+  const endDoc = last.range.endContainer.ownerDocument;
+  if (!startDoc || !endDoc) return null;
+  return {
+    start: {
+      doc: startDoc,
+      index: first.index,
+      pos: { node: first.range.startContainer, offset: first.range.startOffset },
+    },
+    end: {
+      doc: endDoc,
+      index: last.index,
+      pos: { node: last.range.endContainer, offset: last.range.endOffset },
+    },
+  };
+};
+
 // Drag handles for a plain (not yet annotated) text selection. Used on
 // Android when the native selection handles had to be suppressed because of
-// the Blink hyphen selection-bounds bug (issue #1553): the DOM selection
-// stays as the visible highlight while these handles replace the native
-// ones for adjusting the range.
+// the Blink hyphen selection-bounds bug (issue #1553), and for fixed-layout
+// pages in scroll mode, where a native handle can't leave its page iframe but
+// these can continue the selection onto the next page (#5809): the DOM
+// selection stays as the visible highlight while these handles replace the
+// native ones for adjusting the range.
 const SelectionRangeEditor: React.FC<SelectionRangeEditorProps> = ({
   bookKey,
   isVertical,
   selection,
   handleColor,
-  onRangeChange,
+  onDragTo,
   onStartDrag,
   noteAutoTurnPoint,
   cancelAutoTurn,
@@ -50,7 +82,7 @@ const SelectionRangeEditor: React.FC<SelectionRangeEditorProps> = ({
   const draggingRef = useRef<'start' | 'end' | null>(null);
   const startRef = useRef<Point>({ x: 0, y: 0 });
   const endRef = useRef<Point>({ x: 0, y: 0 });
-  const lastBuiltRef = useRef<{ range: Range; index: number } | null>(null);
+  const boundsRef = useRef<SelectionBounds | null>(null);
   // Unsubscribe for the after-turn re-emit while a handle is being dragged.
   const autoTurnUnsubRef = useRef<(() => void) | null>(null);
   const [draggingHandle, setDraggingHandle] = useState<'start' | 'end' | null>(null);
@@ -60,13 +92,18 @@ const SelectionRangeEditor: React.FC<SelectionRangeEditorProps> = ({
 
   useEffect(() => {
     if (draggingRef.current) return;
-    const positions = getHandlePositionsFromRange(bookKey, selection.range, isVertical);
-    if (positions) {
-      setCurrentStart(positions.start);
-      setCurrentEnd(positions.end);
-      startRef.current = positions.start;
-      endRef.current = positions.end;
-      lastBuiltRef.current = { range: selection.range, index: selection.index };
+    // A cross-page selection's ends live on different pages: the start handle
+    // on the first part, the end handle on the last.
+    const first = selection.segments?.[0]?.range ?? selection.range;
+    const last = selection.segments?.at(-1)?.range ?? selection.range;
+    const start = getHandlePositionsFromRange(bookKey, first, isVertical)?.start;
+    const end = getHandlePositionsFromRange(bookKey, last, isVertical)?.end;
+    if (start && end) {
+      setCurrentStart(start);
+      setCurrentEnd(end);
+      startRef.current = start;
+      endRef.current = end;
+      boundsRef.current = boundsOfSelection(selection);
     }
   }, [bookKey, selection, isVertical]);
 
@@ -74,31 +111,20 @@ const SelectionRangeEditor: React.FC<SelectionRangeEditorProps> = ({
   // Anchoring it to its window coordinate instead would silently re-target it
   // whenever the content shifts underneath — e.g. the corner-dwell auto page
   // turn (#1354) mid-drag — losing the previous page's part of the selection.
-  const fixedAnchorRef = useRef<{ node: Node; offset: number } | null>(null);
+  const fixedAnchorRef = useRef<SectionAnchor | null>(null);
 
   const updateFromDraggedPoint = useCallback(
-    (point: Point) => {
+    (point: Point, commit = false) => {
       const anchor = fixedAnchorRef.current;
       if (!anchor) return;
-      const doc = anchor.node.ownerDocument;
-      const win = doc?.defaultView;
-      if (!doc || !win) return;
-      const feRect = win.frameElement?.getBoundingClientRect();
-      const built = rangeFromAnchorToPoint(
-        doc,
-        anchor.node,
-        anchor.offset,
-        point.x - (feRect?.left ?? 0),
-        point.y - (feRect?.top ?? 0),
-      );
-      if (!built) return;
-      lastBuiltRef.current = { range: built, index: selection.index };
-      onRangeChange(built, selection.index, false);
+      void onDragTo(anchor, point, commit).then((bounds) => {
+        if (bounds) boundsRef.current = bounds;
+      });
       // Drag the handle into the corner to turn the page; the anchored end keeps
       // the previous page's part of the selection across the turn.
-      noteAutoTurnPoint(viewSettings?.scrolled ? null : point);
+      if (!commit) noteAutoTurnPoint(viewSettings?.scrolled ? null : point);
     },
-    [selection.index, onRangeChange, noteAutoTurnPoint, viewSettings?.scrolled],
+    [onDragTo, noteAutoTurnPoint, viewSettings?.scrolled],
   );
 
   // Rebuild the range from the held handle position after an auto page-turn, so
@@ -112,8 +138,7 @@ const SelectionRangeEditor: React.FC<SelectionRangeEditorProps> = ({
   }, [onAutoTurn, updateFromDraggedPoint]);
 
   const handleStartDragStart = useCallback(() => {
-    const base = lastBuiltRef.current?.range ?? selection.range;
-    fixedAnchorRef.current = { node: base.endContainer, offset: base.endOffset };
+    fixedAnchorRef.current = (boundsRef.current ?? boundsOfSelection(selection))?.end ?? null;
     draggingRef.current = 'start';
     setDraggingHandle('start');
     setLoupePoint({ ...startRef.current });
@@ -122,8 +147,7 @@ const SelectionRangeEditor: React.FC<SelectionRangeEditorProps> = ({
   }, [selection, onStartDrag, subscribeAutoTurnReemit]);
 
   const handleEndDragStart = useCallback(() => {
-    const base = lastBuiltRef.current?.range ?? selection.range;
-    fixedAnchorRef.current = { node: base.startContainer, offset: base.startOffset };
+    fixedAnchorRef.current = (boundsRef.current ?? boundsOfSelection(selection))?.start ?? null;
     draggingRef.current = 'end';
     setDraggingHandle('end');
     setLoupePoint({ ...endRef.current });
@@ -152,17 +176,15 @@ const SelectionRangeEditor: React.FC<SelectionRangeEditorProps> = ({
   );
 
   const handleDragEnd = useCallback(() => {
+    const point = draggingRef.current === 'start' ? startRef.current : endRef.current;
     draggingRef.current = null;
     setDraggingHandle(null);
     setLoupePoint(null);
     cancelAutoTurn();
     autoTurnUnsubRef.current?.();
     autoTurnUnsubRef.current = null;
-    const last = lastBuiltRef.current;
-    if (last) {
-      onRangeChange(last.range, last.index, true);
-    }
-  }, [onRangeChange, cancelAutoTurn]);
+    updateFromDraggedPoint(point, true);
+  }, [updateFromDraggedPoint, cancelAutoTurn]);
 
   if (currentStart.x === 0 && currentStart.y === 0) {
     return null;

--- a/apps/readest-app/src/app/reader/components/notebook/Notebook.tsx
+++ b/apps/readest-app/src/app/reader/components/notebook/Notebook.tsx
@@ -51,7 +51,7 @@ const Notebook: React.FC = ({}) => {
   const { getView, getViewsById, getProgress, getViewSettings } = useReaderStore();
   const { getNotebookWidth, setNotebookWidth, setNotebookVisible, toggleNotebookPin } =
     useNotebookStore();
-  const { setNotebookNewAnnotation, setNotebookNewHighlightId } = useNotebookStore();
+  const { setNotebookNewAnnotation, setNotebookNewHighlightIds } = useNotebookStore();
   const { setNotebookEditAnnotation, setNotebookActiveTab } = useNotebookStore();
   const { activeConversationId } = useAIChatStore();
 
@@ -143,26 +143,28 @@ const Notebook: React.FC = ({}) => {
     saveSysSettings(envConfig, 'globalReadSettings', newGlobalReadSettings);
   };
 
-  // Abandon a note-creation flow: tear down the empty highlight the "Annotate"
-  // action eagerly created as the note anchor so it doesn't leak into the
-  // booknotes list (#4791). A saved note carries text, so it survives the guard
-  // in removeEmptyAnnotationPlaceholder; a restyled pre-existing highlight has no
-  // tracked id and is left alone. `bookKey` is passed explicitly so the unmount/
-  // book-switch cleanup targets the book the placeholder belongs to.
+  // Abandon a note-creation flow: tear down the empty highlights the "Annotate"
+  // action eagerly created as the note anchor (one per page of a cross-page
+  // selection) so they don't leak into the booknotes list (#4791). A saved note
+  // carries text, so it survives the guard in removeEmptyAnnotationPlaceholder;
+  // a restyled pre-existing highlight has no tracked id and is left alone.
+  // `bookKey` is passed explicitly so the unmount/book-switch cleanup targets
+  // the book the placeholders belong to.
   const handleCancelNewAnnotation = useCallback(
     (bookKey: string | null) => {
-      const { notebookNewHighlightId } = useNotebookStore.getState();
-      if (bookKey && notebookNewHighlightId) {
+      const { notebookNewHighlightIds } = useNotebookStore.getState();
+      if (bookKey && notebookNewHighlightIds.length > 0) {
         const config = getConfig(bookKey);
         const { booknotes: annotations = [] } = config || {};
-        const placeholder = removeEmptyAnnotationPlaceholder(
-          annotations,
-          notebookNewHighlightId,
-          Date.now(),
-        );
-        if (placeholder) {
+        const now = Date.now();
+        const placeholders = notebookNewHighlightIds
+          .map((id) => removeEmptyAnnotationPlaceholder(annotations, id, now))
+          .filter((placeholder): placeholder is BookNote => placeholder !== null);
+        if (placeholders.length > 0) {
           const views = getViewsById(bookKey.split('-')[0]!);
-          views.forEach((view) => removeBookNoteOverlays(view, placeholder));
+          for (const placeholder of placeholders) {
+            views.forEach((view) => removeBookNoteOverlays(view, placeholder));
+          }
           const updatedConfig = updateBooknotes(bookKey, annotations);
           if (updatedConfig) {
             // Read settings fresh: this callback has stable identity (empty deps)
@@ -171,7 +173,7 @@ const Notebook: React.FC = ({}) => {
           }
         }
       }
-      setNotebookNewHighlightId(null);
+      setNotebookNewHighlightIds([]);
       setNotebookNewAnnotation(null);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -257,8 +259,8 @@ const Notebook: React.FC = ({}) => {
     }
     setNotebookNewAnnotation(null);
     // The placeholder now carries a note (or a fresh unified record was created),
-    // so it's a real annotation — drop the cancel-cleanup handle (#4791).
-    setNotebookNewHighlightId(null);
+    // so it's a real annotation — drop the cancel-cleanup handles (#4791).
+    setNotebookNewHighlightIds([]);
   };
 
   const handleEditNote = (note: BookNote, isDelete: boolean) => {

--- a/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
@@ -273,6 +273,9 @@ export const useTextSelector = (
         await makeCrossDocSelection(segments, true);
         return segmentBounds(segments);
       }
+      // The drag's writes held the programmatic guard; the drag is over, so let
+      // later selectionchange events through again.
+      releaseProgrammaticSelection();
       const sel = anchor.doc.getSelection();
       if (!sel || !isValidSelection(sel)) return null;
       await makeSelection(sel, anchor.index, false, true);

--- a/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
@@ -21,6 +21,21 @@ import {
 } from '@/utils/sel';
 import { Corner, useAutoPageTurn } from './useAutoPageTurn';
 import { useInstantAnnotation } from './useInstantAnnotation';
+import {
+  applyCrossDocSegments,
+  buildCrossDocSegments,
+  CrossDocSegment,
+  findContentAtPoint,
+  getCaretPosition,
+  getCaretPositionInText,
+  isTextAtPoint,
+  rangeBetweenPositions,
+  rangeFromPositions,
+  SectionAnchor,
+  SelectionBounds,
+  setNativeDragFrozen,
+  toDocPoint,
+} from '../utils/crossDocSelection';
 
 // Instant-highlight quick action: on touch a plain tap and a swipe are both
 // page-turn gestures, so the highlight must not engage on pointer-down or it
@@ -114,6 +129,19 @@ export const useTextSelector = (
   const programmaticSelectionRef = useRef(false);
   const programmaticClearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Cross-page selection (#5809). Fixed-layout pages are separate iframes, so a
+  // selection dragged onto the next page is kept as one native selection per
+  // page and published as a single TextSelection with `segments`.
+  // The DOM-anchored start of a mouse selection drag, captured at pointer-down.
+  const dragAnchorRef = useRef<SectionAnchor | null>(null);
+  // Live state while the pointer/finger is over a page other than the anchor's.
+  // `frozen`: the anchor page's native drag has been frozen (mouse path).
+  const crossDocRef = useRef<{
+    anchor: SectionAnchor;
+    segments: CrossDocSegment[];
+    frozen: boolean;
+  } | null>(null);
+
   // #5427: whether the native layer is currently refusing the system
   // selection toolbar (MainActivity hands out a no-op ActionMode while set).
   const selectionMenuSuppressedRef = useRef(false);
@@ -141,6 +169,168 @@ export const useTextSelector = (
     programmaticClearTimer.current = setTimeout(() => {
       programmaticSelectionRef.current = false;
     }, 150);
+  };
+
+  const getContents = () => getView(bookKey)?.renderer?.getContents?.() ?? [];
+
+  // Extend the selection anchored at `anchor` to the page under `point`
+  // (window coords): the anchor page to its edge, pages between in full, the
+  // target page up to the caret under the point. Returns whether a cross-page
+  // state is active afterwards; over the anchor page itself the state is left
+  // (the native drag takes over again).
+  const extendCrossDocTo = (anchor: SectionAnchor, point: Point): boolean => {
+    const contents = getContents();
+    const target = findContentAtPoint(contents, point);
+    if (!target) return !!crossDocRef.current;
+    if (target.doc === anchor.doc) {
+      clearCrossDoc();
+      return false;
+    }
+    const local = toDocPoint(target.doc, point);
+    const caret = local && getCaretPositionInText(target.doc, local.x, local.y);
+    if (!caret) return !!crossDocRef.current;
+    const segments = buildCrossDocSegments(anchor, { ...target, pos: caret }, contents);
+    if (segments.length === 0) return !!crossDocRef.current;
+    // Our own writes: their selectionchange echoes are not user input.
+    guardProgrammaticSelection();
+    applyCrossDocSegments(segments, contents, anchor);
+    crossDocRef.current = { anchor, segments, frozen: crossDocRef.current?.frozen ?? false };
+    return true;
+  };
+
+  // Leave the cross-page state. Unless `keepSelections` (committing), the
+  // other pages' parts are cleared so only the anchor page's selection remains.
+  const clearCrossDoc = (keepSelections = false) => {
+    const state = crossDocRef.current;
+    if (!state) return;
+    crossDocRef.current = null;
+    if (state.frozen) setNativeDragFrozen(state.anchor.doc, false);
+    if (!keepSelections) {
+      for (const { doc } of state.segments) {
+        if (doc !== state.anchor.doc) doc.getSelection()?.removeAllRanges();
+      }
+    }
+    releaseProgrammaticSelection();
+  };
+
+  // Publish the per-page parts as one selection: all their text joined, the
+  // range/cfi/index anchored on the first part (#5809).
+  const makeCrossDocSelection = async (segments: CrossDocSegment[], handlesSuppressed = false) => {
+    const parts: { range: Range; index: number; text: string }[] = [];
+    for (const segment of segments) {
+      const range = rangeFromPositions(segment.doc, segment.start, segment.end);
+      if (!range) continue;
+      const text = await getAnnotationText(range);
+      if (!text.trim()) continue;
+      parts.push({ range, index: segment.index, text });
+    }
+    const first = parts[0];
+    if (!first) return false;
+    isTextSelected.current = true;
+    const progress = getProgress(bookKey);
+    setSelection({
+      key: bookKey,
+      text: parts.map((part) => part.text).join(' '),
+      cfi: view?.getCFI(first.index, first.range),
+      page: bookData?.isFixedLayout ? first.index + 1 : progress?.page || 0,
+      range: first.range,
+      index: first.index,
+      segments: parts.length > 1 ? parts : undefined,
+      handlesSuppressed,
+    });
+    return true;
+  };
+
+  // Drive a selection from the app's own handles (SelectionRangeEditor): the
+  // dragged end follows `point` (window coords) while `anchor` stays put. Over
+  // the anchor's page the selection is rebuilt there; over another page it
+  // continues across pages (#5809). Resolves to the selection's new outer
+  // bounds, or null when the point is over no page.
+  const dragSelectionTo = async (
+    anchor: SectionAnchor,
+    point: Point,
+    commit: boolean,
+  ): Promise<SelectionBounds | null> => {
+    const rangeBounds = (doc: Document, index: number, range: Range): SelectionBounds => ({
+      start: { doc, index, pos: { node: range.startContainer, offset: range.startOffset } },
+      end: { doc, index, pos: { node: range.endContainer, offset: range.endOffset } },
+    });
+    const segmentBounds = (segments: CrossDocSegment[]): SelectionBounds | null => {
+      const first = segments[0];
+      const last = segments.at(-1);
+      if (!first || !last) return null;
+      return {
+        start: { doc: first.doc, index: first.index, pos: first.start },
+        end: { doc: last.doc, index: last.index, pos: last.end },
+      };
+    };
+    // A release that resolves to no new range (off any page, or collapsed on the
+    // anchor) still commits what the drag has built so far.
+    const commitLive = async (): Promise<SelectionBounds | null> => {
+      const segments = crossDocRef.current?.segments ?? [];
+      if (segments.length > 0) {
+        clearCrossDoc(true);
+        await makeCrossDocSelection(segments, true);
+        return segmentBounds(segments);
+      }
+      const sel = anchor.doc.getSelection();
+      if (!sel || !isValidSelection(sel)) return null;
+      await makeSelection(sel, anchor.index, false, true);
+      return rangeBounds(anchor.doc, anchor.index, sel.getRangeAt(0));
+    };
+
+    const target = findContentAtPoint(getContents(), point);
+    if (!target) return commit ? commitLive() : null;
+    if (target.doc === anchor.doc) {
+      clearCrossDoc();
+      const local = toDocPoint(anchor.doc, point);
+      const caret = local && getCaretPositionInText(anchor.doc, local.x, local.y);
+      const range = caret && rangeBetweenPositions(anchor.doc, anchor.pos, caret);
+      if (!range) return commit ? commitLive() : null;
+      await applyProgrammaticSelection(range, anchor.index, commit);
+      return rangeBounds(anchor.doc, anchor.index, range);
+    }
+    if (!extendCrossDocTo(anchor, point)) return commit ? commitLive() : null;
+    const segments = crossDocRef.current?.segments ?? [];
+    if (commit) {
+      clearCrossDoc(true);
+      await makeCrossDocSelection(segments, true);
+    }
+    return segmentBounds(segments);
+  };
+
+  // Android, fixed-layout pages in scroll mode (#5809): the native selection
+  // handles can't leave their page iframe (their touches never reach the page),
+  // so once a touch gesture has made a selection swap them for the app's own
+  // handles, which drag across pages. A selection that goes empty for one
+  // painted frame drops its native handles; `handlesSuppressed` then brings up
+  // the SelectionRangeEditor.
+  const suppressNativeHandlesForPages = async () => {
+    if (sanitizedGestureRef.current || !gestureInitialRef.current) return;
+    if (!bookData?.isFixedLayout || !getViewSettings(bookKey)?.scrolled) return;
+    const content = getContents().find(
+      (c) => c.doc && c.index != null && isValidSelection(c.doc.getSelection()!),
+    );
+    if (!content || content.index == null) return;
+    const { doc, index } = content;
+    const win = doc.defaultView;
+    const sel = doc.getSelection();
+    if (!win || !sel) return;
+    sanitizedGestureRef.current = true;
+    const range = sel.getRangeAt(0).cloneRange();
+    guardProgrammaticSelection();
+    sel.removeAllRanges();
+    await new Promise<void>((resolve) =>
+      win.requestAnimationFrame(() => win.requestAnimationFrame(() => resolve())),
+    );
+    // Bail if a competing gesture touched the selection while we waited.
+    if (sel.rangeCount > 0 || range.collapsed) {
+      releaseProgrammaticSelection();
+      return;
+    }
+    sel.addRange(range);
+    releaseProgrammaticSelection();
+    await makeSelection(sel, index, false, true);
   };
 
   const {
@@ -175,6 +365,18 @@ export const useTextSelector = (
     if (rebuildRange) {
       sel.removeAllRanges();
       sel.addRange(liveRange);
+    }
+    // One page holds the live selection: drop a stale one left on another page
+    // (the far part of an earlier cross-page selection), guarded so its
+    // selectionchange doesn't dismiss the popup this selection is opening.
+    const ownerDoc = liveRange.startContainer?.ownerDocument;
+    const stale = getContents().filter(
+      (c) => c.doc && c.doc !== ownerDoc && c.doc.getSelection()?.rangeCount,
+    );
+    if (stale.length > 0) {
+      guardProgrammaticSelection();
+      stale.forEach((c) => c.doc.getSelection()?.removeAllRanges());
+      releaseProgrammaticSelection();
     }
     // Selection.getRangeAt() returns the live, associated Range by reference.
     // Clone only for double-click normalization so native touch paths retain
@@ -282,6 +484,8 @@ export const useTextSelector = (
   const handlePointerDown = (doc: Document, index: number, ev: PointerEvent) => {
     lastPointerType.current = ev.pointerType;
     isPointerDown.current = true;
+    clearCrossDoc();
+    dragAnchorRef.current = null;
 
     if (isInstantAnnotationEnabled()) {
       const eligible = handleInstantAnnotationPointerDown(doc, index, ev);
@@ -295,6 +499,19 @@ export const useTextSelector = (
         ev.preventDefault();
         startInstantAnnotating(ev.target as HTMLElement, { x: ev.clientX, y: ev.clientY });
       }
+    }
+
+    // Cross-page drag (#5809): remember where a mouse selection drag starts so
+    // it can continue onto an adjacent page iframe.
+    if (
+      !isInstantAnnotating.current &&
+      ev.pointerType === 'mouse' &&
+      ev.button === 0 &&
+      bookData?.isFixedLayout &&
+      isTextAtPoint(doc, ev.clientX, ev.clientY)
+    ) {
+      const pos = getCaretPosition(doc, ev.clientX, ev.clientY);
+      if (pos) dragAnchorRef.current = { doc, index, pos };
     }
   };
 
@@ -354,6 +571,22 @@ export const useTextSelector = (
       return;
     }
 
+    // Cross-page drag (#5809): the browser keeps delivering a mouse drag to the
+    // iframe it started in, even once the pointer is over another page iframe.
+    // Over another page, extend the selection into it and freeze the origin
+    // page's native drag (which would otherwise chase the out-of-frame pointer);
+    // back over the origin page the native drag resumes.
+    const dragAnchor = dragAnchorRef.current;
+    if (dragAnchor && ev.pointerType === 'mouse' && ev.buttons & 1 && pointerPos.current) {
+      if (extendCrossDocTo(dragAnchor, pointerPos.current)) {
+        const state = crossDocRef.current;
+        if (state && !state.frozen) {
+          setNativeDragFrozen(dragAnchor.doc, true);
+          state.frozen = true;
+        }
+      }
+    }
+
     // Pointer-driven auto page-turn (#1354) for web/desktop/iOS, where the
     // pointer is the reliable, stable signal at the corner. Android uses the
     // caret in handleSelectionchange (no pointermove during a selection drag).
@@ -391,6 +624,8 @@ export const useTextSelector = (
   const handlePointerCancel = (_doc: Document, _index: number, _ev: PointerEvent) => {
     isPointerDown.current = false;
     mouseDoubleClickRef.current = null;
+    clearCrossDoc();
+    dragAnchorRef.current = null;
     // A pending still-hold that never engaged: drop it so a swipe-takeover
     // (Android fires pointercancel when the browser starts scrolling) keeps its
     // native page-turn instead of being swallowed.
@@ -513,6 +748,30 @@ export const useTextSelector = (
     isPointerDown.current = false;
     const mouseDoubleClick = mouseDoubleClickRef.current;
     mouseDoubleClickRef.current = null;
+    dragAnchorRef.current = null;
+
+    // Cross-page drag (#5809): the release ends the drag; commit the per-page
+    // parts as one selection (re-applied, so a native drag that fought the
+    // anchor page's part mid-gesture can't leave it stale).
+    if (crossDocRef.current) {
+      const { anchor } = crossDocRef.current;
+      if (ev) {
+        const feRect = doc.defaultView?.frameElement?.getBoundingClientRect();
+        extendCrossDocTo(anchor, {
+          x: ev.clientX + (feRect?.left ?? 0),
+          y: ev.clientY + (feRect?.top ?? 0),
+        });
+      }
+      const segments = crossDocRef.current?.segments ?? [];
+      if (segments.length > 0) {
+        guardProgrammaticSelection();
+        applyCrossDocSegments(segments, getContents(), anchor);
+        clearCrossDoc(true);
+        isUpToPopup.current = true;
+        await makeCrossDocSelection(segments);
+        return;
+      }
+    }
     // A tap (or a long-press shorter than the hold) that never engaged: drop the
     // pending still-hold so the tap falls through to a page turn.
     if (instantHoldTimer.current) cancelInstantHold();
@@ -574,6 +833,7 @@ export const useTextSelector = (
 
     if (osPlatform === 'android' && appService?.isAndroidApp) {
       await sanitizeAndroidHyphenSelection(doc, index);
+      await suppressNativeHandlesForPages();
     }
   };
   const handleTouchStart = () => {
@@ -794,7 +1054,7 @@ export const useTextSelector = (
     handleShowPopup,
     handleUpToPopup,
     handleContextmenu,
-    applyProgrammaticSelection,
+    dragSelectionTo,
     // The shared corner auto-turn feed/cancel/subscribe, re-exposed so the range
     // editors can drive the same machine from their overlay handle drags.
     noteAutoTurnPoint,

--- a/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
@@ -173,6 +173,11 @@ export const useTextSelector = (
 
   const getContents = () => getView(bookKey)?.renderer?.getContents?.() ?? [];
 
+  // The cross-page selection (#5809) exists only for fixed-layout pages in
+  // scroll mode, where the next page is on screen to continue onto. Reflowable
+  // books and paginated fixed layout keep the single-document behaviour.
+  const crossPageEnabled = () => !!bookData?.isFixedLayout && !!getViewSettings(bookKey)?.scrolled;
+
   // Extend the selection anchored at `anchor` to the page under `point`
   // (window coords): the anchor page to its edge, pages between in full, the
   // target page up to the caret under the point. Returns whether a cross-page
@@ -282,6 +287,22 @@ export const useTextSelector = (
       return rangeBounds(anchor.doc, anchor.index, sel.getRangeAt(0));
     };
 
+    if (!crossPageEnabled()) {
+      // Single-document drag (reflowable books, paginated fixed layout): the
+      // range runs from the anchor to the caret under the point in the anchor's
+      // own document, exactly as the handles always worked.
+      const feRect = anchor.doc.defaultView?.frameElement?.getBoundingClientRect();
+      const range = rangeFromAnchorToPoint(
+        anchor.doc,
+        anchor.pos.node,
+        anchor.pos.offset,
+        point.x - (feRect?.left ?? 0),
+        point.y - (feRect?.top ?? 0),
+      );
+      if (!range) return commit ? commitLive() : null;
+      await applyProgrammaticSelection(range, anchor.index, commit);
+      return rangeBounds(anchor.doc, anchor.index, range);
+    }
     const target = findContentAtPoint(getContents(), point);
     if (!target) return commit ? commitLive() : null;
     if (target.doc === anchor.doc) {
@@ -310,7 +331,7 @@ export const useTextSelector = (
   // the SelectionRangeEditor.
   const suppressNativeHandlesForPages = async () => {
     if (sanitizedGestureRef.current || !gestureInitialRef.current) return;
-    if (!bookData?.isFixedLayout || !getViewSettings(bookKey)?.scrolled) return;
+    if (!crossPageEnabled()) return;
     const content = getContents().find(
       (c) => c.doc && c.index != null && isValidSelection(c.doc.getSelection()!),
     );
@@ -373,9 +394,9 @@ export const useTextSelector = (
     // (the far part of an earlier cross-page selection), guarded so its
     // selectionchange doesn't dismiss the popup this selection is opening.
     const ownerDoc = liveRange.startContainer?.ownerDocument;
-    const stale = getContents().filter(
-      (c) => c.doc && c.doc !== ownerDoc && c.doc.getSelection()?.rangeCount,
-    );
+    const stale = crossPageEnabled()
+      ? getContents().filter((c) => c.doc && c.doc !== ownerDoc && c.doc.getSelection()?.rangeCount)
+      : [];
     if (stale.length > 0) {
       guardProgrammaticSelection();
       stale.forEach((c) => c.doc.getSelection()?.removeAllRanges());
@@ -510,7 +531,7 @@ export const useTextSelector = (
       !isInstantAnnotating.current &&
       ev.pointerType === 'mouse' &&
       ev.button === 0 &&
-      bookData?.isFixedLayout &&
+      crossPageEnabled() &&
       isTextAtPoint(doc, ev.clientX, ev.clientY)
     ) {
       const pos = getCaretPosition(doc, ev.clientX, ev.clientY);

--- a/apps/readest-app/src/app/reader/utils/crossDocSelection.ts
+++ b/apps/readest-app/src/app/reader/utils/crossDocSelection.ts
@@ -1,0 +1,238 @@
+import { Point } from '@/utils/sel';
+
+// A selection that runs across section documents (#5809). Fixed-layout books
+// render every PDF page in its own iframe, and a DOM Selection cannot leave its
+// document, so a selection that continues onto the next page is kept as one
+// native selection per page — a "segment" — and composed into a single
+// TextSelection by the text selector.
+
+export interface DocPosition {
+  node: Node;
+  offset: number;
+}
+
+export interface SectionDoc {
+  doc: Document;
+  index: number;
+}
+
+export interface SectionAnchor extends SectionDoc {
+  pos: DocPosition;
+}
+
+export interface CrossDocSegment extends SectionDoc {
+  start: DocPosition;
+  end: DocPosition;
+}
+
+// The outer ends of a selection that may span sections.
+export interface SelectionBounds {
+  start: SectionAnchor;
+  end: SectionAnchor;
+}
+
+// The subset of foliate's `renderer.getContents()` entries this module reads.
+export type SectionContent = { doc?: Document | null; index?: number };
+
+const frameOf = (doc: Document) =>
+  (doc.defaultView?.frameElement as HTMLIFrameElement | null | undefined) ?? null;
+
+// The rendered section whose iframe is under a window point. Blank placeholder
+// frames (no section index) are skipped.
+export const findContentAtPoint = (contents: SectionContent[], point: Point): SectionDoc | null => {
+  for (const content of contents) {
+    const { doc, index } = content;
+    if (!doc || index == null) continue;
+    const rect = frameOf(doc)?.getBoundingClientRect();
+    if (!rect || rect.width === 0 || rect.height === 0) continue;
+    if (
+      point.x >= rect.left &&
+      point.x <= rect.right &&
+      point.y >= rect.top &&
+      point.y <= rect.bottom
+    ) {
+      return { doc, index };
+    }
+  }
+  return null;
+};
+
+// A window point in the document's own CSS pixels, undoing any scale applied
+// to its iframe (e.g. a pinch-zoom preview transform).
+export const toDocPoint = (doc: Document, point: Point): Point | null => {
+  const frame = frameOf(doc);
+  const rect = frame?.getBoundingClientRect();
+  if (!frame || !rect || rect.width === 0 || rect.height === 0) return null;
+  const sx = frame.clientWidth ? frame.clientWidth / rect.width : 1;
+  const sy = frame.clientHeight ? frame.clientHeight / rect.height : 1;
+  return { x: (point.x - rect.left) * sx, y: (point.y - rect.top) * sy };
+};
+
+export const getCaretPosition = (doc: Document, x: number, y: number): DocPosition | null => {
+  if (doc.caretPositionFromPoint) {
+    const pos = doc.caretPositionFromPoint(x, y);
+    if (pos) return { node: pos.offsetNode, offset: pos.offset };
+  }
+  if (doc.caretRangeFromPoint) {
+    const range = doc.caretRangeFromPoint(x, y);
+    if (range) return { node: range.startContainer, offset: range.startOffset };
+  }
+  return null;
+};
+
+// Whether the point is on text rather than on a blank part of the page. The
+// caret lookup snaps blank-area points to the nearest glyph, so the caret alone
+// can't tell a text drag from a pan across the page margin; require the point
+// to sit on (or right next to) the glyph it resolved to.
+const TEXT_HIT_TOLERANCE_PX = 12;
+export const isTextAtPoint = (doc: Document, x: number, y: number): boolean => {
+  const pos = getCaretPosition(doc, x, y);
+  if (!pos || pos.node.nodeType !== Node.TEXT_NODE) return false;
+  const text = pos.node as Text;
+  if (text.length === 0) return false;
+  const offset = Math.min(pos.offset, text.length - 1);
+  const range = doc.createRange();
+  range.setStart(text, offset);
+  range.setEnd(text, offset + 1);
+  return Array.from(range.getClientRects()).some(
+    (rect) =>
+      x >= rect.left - TEXT_HIT_TOLERANCE_PX &&
+      x <= rect.right + TEXT_HIT_TOLERANCE_PX &&
+      y >= rect.top - TEXT_HIT_TOLERANCE_PX &&
+      y <= rect.bottom + TEXT_HIT_TOLERANCE_PX,
+  );
+};
+
+// First and last selectable text positions of a section document.
+export const getDocTextBounds = (
+  doc: Document,
+): { start: DocPosition; end: DocPosition } | null => {
+  if (!doc.body) return null;
+  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
+    acceptNode: (node) =>
+      node.textContent?.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP,
+  });
+  const first = walker.nextNode() as Text | null;
+  if (!first) return null;
+  let last = first;
+  let next: Node | null;
+  while ((next = walker.nextNode())) last = next as Text;
+  return { start: { node: first, offset: 0 }, end: { node: last, offset: last.length } };
+};
+
+// The caret for a point, clamped to the page's text: above the top-most glyph
+// it is the start of the page's text, below the bottom-most glyph its end.
+// pdf.js positions every glyph run absolutely, so the browser's own caret
+// lookup over a blank margin snaps to some run mid-page instead.
+export const getCaretPositionInText = (doc: Document, x: number, y: number): DocPosition | null => {
+  const bounds = getDocTextBounds(doc);
+  if (!bounds) return null;
+  const probe = doc.createRange();
+  let top = Infinity;
+  let bottom = -Infinity;
+  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
+    acceptNode: (node) =>
+      node.textContent?.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP,
+  });
+  let node: Node | null;
+  while ((node = walker.nextNode())) {
+    probe.selectNodeContents(node);
+    const rect = probe.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) continue;
+    top = Math.min(top, rect.top);
+    bottom = Math.max(bottom, rect.bottom);
+  }
+  if (y < top) return bounds.start;
+  if (y > bottom) return bounds.end;
+  return getCaretPosition(doc, x, y);
+};
+
+// The range between two positions of a document, whichever comes first.
+export const rangeBetweenPositions = (doc: Document, a: DocPosition, b: DocPosition) => {
+  const probeA = doc.createRange();
+  const probeB = doc.createRange();
+  try {
+    probeA.setStart(a.node, a.offset);
+    probeB.setStart(b.node, b.offset);
+  } catch {
+    return null;
+  }
+  const forward = probeA.compareBoundaryPoints(Range.START_TO_START, probeB) <= 0;
+  return rangeFromPositions(doc, forward ? a : b, forward ? b : a);
+};
+
+export const rangeFromPositions = (doc: Document, start: DocPosition, end: DocPosition) => {
+  const range = doc.createRange();
+  try {
+    range.setStart(start.node, start.offset);
+    range.setEnd(end.node, end.offset);
+  } catch {
+    return null;
+  }
+  return range.collapsed ? null : range;
+};
+
+// The per-section segments of a selection anchored at `anchor` whose other
+// end is `target` on a different section: the earlier section from its
+// position to its end, every rendered section between them in full, and the
+// later section from its start to its position. Collapsed parts are dropped.
+export const buildCrossDocSegments = (
+  anchor: SectionAnchor,
+  target: SectionAnchor,
+  contents: SectionContent[],
+): CrossDocSegment[] => {
+  if (anchor.doc === target.doc || anchor.index === target.index) return [];
+  const [lo, hi] = anchor.index < target.index ? [anchor, target] : [target, anchor];
+  const segments: CrossDocSegment[] = [];
+  const push = (doc: Document, index: number, start: DocPosition, end: DocPosition) => {
+    if (rangeFromPositions(doc, start, end)) segments.push({ doc, index, start, end });
+  };
+  const loBounds = getDocTextBounds(lo.doc);
+  if (loBounds) push(lo.doc, lo.index, lo.pos, loBounds.end);
+  for (const { doc, index } of contents) {
+    if (!doc || index == null || index <= lo.index || index >= hi.index) continue;
+    const bounds = getDocTextBounds(doc);
+    if (bounds) push(doc, index, bounds.start, bounds.end);
+  }
+  const hiBounds = getDocTextBounds(hi.doc);
+  if (hiBounds) push(hi.doc, hi.index, hiBounds.start, hi.pos);
+  return segments.sort((a, b) => a.index - b.index);
+};
+
+// Make the segments the live DOM selection of their documents and clear the
+// selection of every other rendered section. The anchor document keeps its
+// selection base at the anchor so a native drag that returns to it extends
+// from the same point.
+export const applyCrossDocSegments = (
+  segments: CrossDocSegment[],
+  contents: SectionContent[],
+  anchor?: SectionAnchor | null,
+) => {
+  const docs = new Set(segments.map((segment) => segment.doc));
+  for (const { doc } of contents) {
+    if (doc && !docs.has(doc)) doc.getSelection()?.removeAllRanges();
+  }
+  for (const { doc, start, end } of segments) {
+    const sel = doc.getSelection();
+    if (!sel) continue;
+    const anchoredAtEnd =
+      anchor?.doc === doc && anchor.pos.node === end.node && anchor.pos.offset === end.offset;
+    if (anchoredAtEnd) sel.setBaseAndExtent(end.node, end.offset, start.node, start.offset);
+    else sel.setBaseAndExtent(start.node, start.offset, end.node, end.offset);
+  }
+};
+
+// While a mouse drag that started in this document is over another section,
+// the browser keeps extending its selection towards the out-of-frame pointer
+// (Blink resolves such points to the page start). Making the page root
+// non-selectable while keeping the text layer selectable leaves the selection
+// alone (Chromium 148+), so the segment written by applyCrossDocSegments sticks.
+export const setNativeDragFrozen = (doc: Document, frozen: boolean) => {
+  const root = doc.documentElement;
+  const layer = doc.querySelector<HTMLElement>('.textLayer') ?? doc.body;
+  if (!root || !layer) return;
+  root.style.userSelect = frozen ? 'none' : '';
+  root.style.webkitUserSelect = frozen ? 'none' : '';
+  layer.style.userSelect = frozen ? 'text' : '';
+  layer.style.webkitUserSelect = frozen ? 'text' : '';
+};

--- a/apps/readest-app/src/store/notebookStore.ts
+++ b/apps/readest-app/src/store/notebookStore.ts
@@ -10,10 +10,11 @@ interface NotebookState {
   isNotebookPinned: boolean;
   notebookActiveTab: NotebookTab;
   notebookNewAnnotation: TextSelection | null;
-  // Id of the highlight eagerly created by the "Annotate" action as the anchor
-  // for a note in progress. Tracked so a cancelled creation flow can tear that
-  // empty placeholder back down instead of leaking it (#4791).
-  notebookNewHighlightId: string | null;
+  // Ids of the highlights eagerly created by the "Annotate" action as the anchor
+  // for a note in progress (one per page of a cross-page selection, #5809).
+  // Tracked so a cancelled creation flow can tear those empty placeholders back
+  // down instead of leaking them (#4791).
+  notebookNewHighlightIds: string[];
   notebookEditAnnotation: BookNote | null;
   notebookAnnotationDrafts: { [key: string]: string };
   getIsNotebookVisible: () => boolean;
@@ -25,7 +26,7 @@ interface NotebookState {
   setNotebookPin: (pinned: boolean) => void;
   setNotebookActiveTab: (tab: NotebookTab) => void;
   setNotebookNewAnnotation: (selection: TextSelection | null) => void;
-  setNotebookNewHighlightId: (id: string | null) => void;
+  setNotebookNewHighlightIds: (ids: string[]) => void;
   setNotebookEditAnnotation: (note: BookNote | null) => void;
   saveNotebookAnnotationDraft: (key: string, note: string) => void;
   getNotebookAnnotationDraft: (key: string) => string | undefined;
@@ -37,7 +38,7 @@ export const useNotebookStore = create<NotebookState>((set, get) => ({
   isNotebookPinned: false,
   notebookActiveTab: 'notes',
   notebookNewAnnotation: null,
-  notebookNewHighlightId: null,
+  notebookNewHighlightIds: [],
   notebookEditAnnotation: null,
   notebookAnnotationDrafts: {},
   getIsNotebookVisible: () => get().isNotebookVisible,
@@ -50,7 +51,7 @@ export const useNotebookStore = create<NotebookState>((set, get) => ({
   setNotebookActiveTab: (tab: NotebookTab) => set({ notebookActiveTab: tab }),
   setNotebookNewAnnotation: (selection: TextSelection | null) =>
     set({ notebookNewAnnotation: selection }),
-  setNotebookNewHighlightId: (id: string | null) => set({ notebookNewHighlightId: id }),
+  setNotebookNewHighlightIds: (ids: string[]) => set({ notebookNewHighlightIds: ids }),
   setNotebookEditAnnotation: (note: BookNote | null) => set({ notebookEditAnnotation: note }),
   saveNotebookAnnotationDraft: (key: string, note: string) =>
     set((state) => ({

--- a/apps/readest-app/src/utils/sel.ts
+++ b/apps/readest-app/src/utils/sel.ts
@@ -24,6 +24,14 @@ export interface Position {
   dir?: PositionDir;
 }
 
+// One section's part of a selection that runs across section documents (a PDF
+// selection continued onto the next page, #5809).
+export interface SelectionSegment {
+  range: Range;
+  index: number;
+  text: string;
+}
+
 export interface TextSelection {
   key: string;
   text: string;
@@ -34,6 +42,10 @@ export interface TextSelection {
   href?: string;
   annotated?: boolean;
   rect?: Rect;
+  // Present when the selection spans several section documents, in reading
+  // order. `range`/`index`/`cfi` are the first segment's and `text` is all
+  // segments' text joined, so single-range consumers keep working.
+  segments?: SelectionSegment[];
   // Native Android selection handles were suppressed for this selection
   // (Blink hyphen bounds bug, issue #1553) — the app draws its own handles.
   handlesSuppressed?: boolean;
@@ -226,22 +238,20 @@ export const isPointerInsideSelection = (selection: Selection, ev: PointerEvent)
   return false;
 };
 
-export const getPosition = (
-  targetElement: Range | Element | TextSelection,
-  rect: Rect,
-  paddingPx: number,
-  isVertical: boolean = false,
-) => {
-  const { range: target, rect: targetRect } =
-    targetElement && 'range' in targetElement
-      ? targetElement
-      : { range: targetElement, rect: undefined };
+// The iframe rect and CSS transform scale that map a target's client rects
+// into the outer webview's coordinate system.
+const getFrameTransform = (target: Range | Element) => {
   const frameElement = getIframeElement(target);
   const transform = frameElement ? getComputedStyle(frameElement).transform : '';
   const match = transform.match(/matrix\((.+)\)/);
   const [sx, , , sy] = match?.[1]?.split(/\s*,\s*/)?.map((x) => parseFloat(x)) ?? [];
-
   const frame = frameElement?.getBoundingClientRect() ?? { top: 0, left: 0 };
+  return { frame, sx, sy };
+};
+
+// A target's line rects in webview coordinates (an element's padding excluded).
+const getWebviewRects = (target: Range | Element): Rect[] => {
+  const { frame, sx, sy } = getFrameTransform(target);
   let padding = { top: 0, right: 0, bottom: 0, left: 0 };
   if ('nodeType' in target && target.nodeType === 1) {
     const computedStyle = window.getComputedStyle(target);
@@ -252,20 +262,47 @@ export const getPosition = (
       left: parseInt(computedStyle.paddingLeft, 10) || 0,
     };
   }
-  const rects = Array.from(target.getClientRects()).map((rect) => {
-    return {
-      top: rect.top + padding.top,
-      right: rect.right - padding.right,
-      bottom: rect.bottom - padding.bottom,
-      left: rect.left + padding.left,
-    };
-  });
-  const first = targetRect
-    ? frameRect(frame, targetRect, sx, sy)
-    : frameRect(frame, rects[0], sx, sy);
-  const last = targetRect
-    ? frameRect(frame, targetRect, sx, sy)
-    : frameRect(frame, rects.at(-1), sx, sy);
+  return Array.from(target.getClientRects()).map((rect) =>
+    frameRect(
+      frame,
+      {
+        top: rect.top + padding.top,
+        right: rect.right - padding.right,
+        bottom: rect.bottom - padding.bottom,
+        left: rect.left + padding.left,
+      },
+      sx,
+      sy,
+    ),
+  );
+};
+
+export const getPosition = (
+  targetElement: Range | Element | TextSelection,
+  rect: Rect,
+  paddingPx: number,
+  isVertical: boolean = false,
+) => {
+  const {
+    range: target,
+    rect: targetRect,
+    segments,
+  } = targetElement && 'range' in targetElement
+    ? targetElement
+    : { range: targetElement, rect: undefined, segments: undefined };
+  // A selection across section documents: its rects span several iframes, so
+  // gather them per segment (each in its own frame) in reading order.
+  const ranges = segments && segments.length > 1 ? segments.map((s) => s.range) : [target];
+  let rects: Rect[];
+  if (targetRect) {
+    const { frame, sx, sy } = getFrameTransform(target);
+    rects = [frameRect(frame, targetRect, sx, sy)];
+  } else {
+    rects = ranges.flatMap(getWebviewRects);
+  }
+  const zero = { left: 0, right: 0, top: 0, bottom: 0 };
+  const first = rects[0] ?? zero;
+  const last = rects.at(-1) ?? zero;
 
   if (isVertical) {
     const leftSpace = first.left - rect.left;
@@ -317,10 +354,7 @@ export const getPosition = (
     // Multi-page selection: both ends are off the visible page, but the middle
     // may cross it. Anchor to the last on-screen line so the popup tracks the
     // visible part of the selection.
-    const v = rects
-      .map((r) => frameRect(frame, r, sx, sy))
-      .filter((r) => inFrame(midX(r), midY(r)))
-      .at(-1);
+    const v = rects.filter((r) => inFrame(midX(r), midY(r))).at(-1);
     if (v) {
       return {
         point: constrainPointWithinRect(


### PR DESCRIPTION
Closes #5809

## What

Text selection in PDFs (fixed-layout books) can now continue across the page boundary and is treated as one selection: one popup, the whole text for Copy / Translate / Dictionary / Search / Share / Speak, and Highlight marks both pages.

Every PDF page is rendered in its own iframe, so a DOM Selection cannot leave its page. This keeps one native selection per page and publishes them as a single `TextSelection` with `segments` (reading order). `range/index/cfi` stay the first part and `text` is all parts joined, so every existing consumer keeps working; `getPosition` anchors the popup across the segment frames; `handleHighlight` loops the segments (one BookNote per page; a note attaches to the first part, with the combined text). Highlight on a cross-page selection adds the parts that are missing and only turns them all off when every part is already highlighted.

### Desktop / web (mouse)

The browser keeps delivering a mouse drag to the iframe it started in, with out-of-frame coordinates. When the pointer is over another page:

- the origin page's native drag is frozen by `user-select: none` on its root (the text layer stays selectable); Chromium 148+ then leaves the selection alone instead of chasing the out-of-frame pointer to the page start,
- the origin part is set to the page end, the target page from its start to the caret under the pointer, pages in between in full,
- the composite is committed on release; moving back onto the origin page hands the drag back to the browser.

The drag is only armed on real text (`isTextAtPoint`), never on the page margin (a margin drag pans in scroll mode).

### Android

Native selection handles live in a PopupWindow, so their touches never reach the page or the native-touch bridge, and a handle dragged past the page bottom cannot be tracked (Blink inverts the selection to the page start). For fixed-layout books in scroll (webtoon) mode, a touch selection now swaps the native handles for the app's own handles (`SelectionRangeEditor`, the #1553 suppression trick); those handles drive the same engine (`dragSelectionTo`) on the same page and across pages. Paginated mode keeps the native handles. iOS is not covered.

### Helpers

`src/app/reader/utils/crossDocSelection.ts`: page under a window point, per-page segment builder, apply/clear of the per-page selections, native-drag freeze, text-hit test, margin-clamped caret (pdf.js positions every glyph run absolutely, so `caretPositionFromPoint` over a blank margin snaps to a run mid-page).

## Verification

- `pnpm test` (9870 passed), `pnpm lint`, `pnpm format:check`.
- New tests: `cross-doc-selection.test.ts`, `useTextSelector-crossPage.test.ts` (mouse drag, app-handle drag, Android handle swap), `getPosition` with segments in `sel.test.ts`.
- Chrome (web dev build): drag from page 15 onto page 16 selects both parts, toolbar shows, Translate shows the joined text, Highlight marks both pages.
- Xiaomi 13 (WebView 153, release APK built from this branch), a text PDF in scroll mode:
  - long-press gives the app handles; the end handle dragged onto the next page selects both parts, handles and toolbar stay, Translate source text is the joined text;
  - dragging the end handle back onto the origin page drops the other page's part;
  - the start handle dragged onto the previous page selects that page from the caret to its end plus the origin page from its start;
  - Highlight on the composite marks both pages, Delete Highlight removes both;
  - a pan with a selection active scrolls and does not extend the selection;
  - paginated mode (Single Page) keeps the native handles.

## Scope / gating

One predicate (fixed layout AND scrolled flow) guards every cross-page path: arming the mouse drag, swapping in the app handles on Android, the app-handle drag engine, and dropping a stale selection on another page. Reflowable books (EPUB etc.) and paginated fixed layout keep the single-document behaviour they had: highlights, the Android hyphen-case handles, and the notebook flow run the same code as before with one part; tests cover both the EPUB and the paginated-PDF cases.

## Notes

- The popup for a composite selection follows the existing start/end room rule, so it may sit above the first part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-page text selection for fixed-layout books in scroll mode.
  * Supports mouse and touch selection across pages, including custom handle dragging.
  * Displays and manages multi-page highlights as a single selection.
  * Improved annotation creation and cancellation for selections spanning multiple pages.

* **Bug Fixes**
  * Preserves or clears stale selections appropriately when selections move between pages.
  * Improved selection positioning and handling near page boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->