### PR TITLE
fix(koplugin): pull reading stats in bounded pages

### DIFF
--- a/apps/readest.koplugin/readest-sync-api.json
+++ b/apps/readest.koplugin/readest-sync-api.json
@@ -6,6 +6,7 @@
       "path": "/sync",
       "method": "GET",
       "required_params": ["since", "type", "book", "meta_hash"],
+      "optional_params": ["limit"],
       "expected_status": [200, 400, 301, 401, 403]
     },
     "pushChanges": {

--- a/apps/readest.koplugin/readest_syncclient.lua
+++ b/apps/readest.koplugin/readest_syncclient.lua
@@ -106,6 +106,7 @@ function ReadestSyncClient:pullChanges(params, callback)
         type      = params.type,
         book      = params.book,
         meta_hash = params.meta_hash,
+        limit     = params.limit,
     }, callback)
 end
 

--- a/apps/readest.koplugin/readest_syncstats.lua
+++ b/apps/readest.koplugin/readest_syncstats.lua
@@ -244,50 +244,77 @@ function SyncStats:push(settings, client, interactive)
     pushFrom(1)
 end
 
+-- Page events per pull request. The server pages stat_pages by updated_at and
+-- completes the trailing millisecond of each page, so a strict
+-- `since = cursor` next request never skips rows that share an updated_at
+-- (same contract as PULL_PAGE in the app's statsSync.ts). A full multi-device
+-- history would otherwise come back as one multi-MB response under the sync
+-- client's 10s total socket timeout: the pull-side twin of #5666, failing
+-- forever without ever advancing the cursor. Paging also keeps every
+-- applyRemote transaction bounded on the device.
+local PULL_PAGE = 1000
+
 function SyncStats:pull(settings, client, interactive, logout_fn, ui)
-    local since = settings.stats_pull_cursor or 0
-    logger.dbg("ReadestStats pull: since=" .. tostring(since)
+    logger.dbg("ReadestStats pull: since=" .. tostring(settings.stats_pull_cursor or 0)
         .. " interactive=" .. tostring(interactive))
-    -- pullChanges requires since/type/book/meta_hash params (readest-sync-api.json).
-    client:pullChanges(
-        { since = since, type = "stats", book = "", meta_hash = "" },
-        function(success, response, status)
-            logger.dbg("ReadestStats pull: response success=" .. tostring(success)
-                .. " status=" .. tostring(status))
-            if not success then
-                if status == 401 or status == 403 then
-                    if logout_fn then logout_fn() end
+    local total_pages = 0
+    local function pullFrom(since)
+        -- pullChanges requires since/type/book/meta_hash params and accepts
+        -- limit (readest-sync-api.json).
+        client:pullChanges(
+            { since = since, type = "stats", book = "", meta_hash = "", limit = PULL_PAGE },
+            function(success, response, status)
+                logger.dbg("ReadestStats pull: response success=" .. tostring(success)
+                    .. " status=" .. tostring(status))
+                if not success then
+                    if status == 401 or status == 403 then
+                        if logout_fn then logout_fn() end
+                    end
+                    -- Pages already applied stay applied and the cursor stays
+                    -- at the last successful page, so a retry resumes there.
+                    if interactive then
+                        UIManager:show(InfoMessage:new{ text = _("Failed to pull reading statistics"), timeout = 2 })
+                    end
+                    return
+                end
+                local nbooks = response and response.statBooks and #response.statBooks or 0
+                local npages = response and response.statPages and #response.statPages or 0
+                logger.dbg("ReadestStats pull: applying statBooks=" .. nbooks .. " statPages=" .. npages
+                    .. " since=" .. tostring(since))
+                -- Resolved inside the callback so it reflects the session state
+                -- at apply time, after the async network round-trip.
+                local live_book_id = ui and ui.statistics and ui.statistics.id_curr_book or nil
+                self:applyRemote(response.statBooks, response.statPages, live_book_id)
+                total_pages = total_pages + npages
+                local newest = since
+                for _, p in ipairs(response.statPages or {}) do
+                    local u = tonumber(p.updated_at_ms) or 0
+                    if u > newest then newest = u end
+                end
+                if newest > since then
+                    settings.stats_pull_cursor = newest
+                    G_reader_settings:saveSetting("readest_sync", settings)
+                    logger.dbg("ReadestStats pull: cursor advanced to " .. tostring(newest))
+                else
+                    logger.dbg("ReadestStats pull: cursor unchanged (no newer rows)")
+                end
+                -- A full page means more may follow; a short page (or no cursor
+                -- progress) means we have caught up. nextTick so the next page
+                -- starts from the event loop: chaining inside the callback would
+                -- nest a coroutine resume per page on the synchronous (non-Turbo)
+                -- HTTP path and could blow the C stack on a huge history.
+                if npages >= PULL_PAGE and newest > since then
+                    UIManager:nextTick(function() pullFrom(newest) end)
+                    return
                 end
                 if interactive then
-                    UIManager:show(InfoMessage:new{ text = _("Failed to pull reading statistics"), timeout = 2 })
+                    local text = total_pages > 0 and _("Reading statistics pulled")
+                        or _("Reading statistics are up to date")
+                    UIManager:show(InfoMessage:new{ text = text, timeout = 2 })
                 end
-                return
-            end
-            local nbooks = response and response.statBooks and #response.statBooks or 0
-            local npages = response and response.statPages and #response.statPages or 0
-            logger.dbg("ReadestStats pull: applying statBooks=" .. nbooks .. " statPages=" .. npages)
-            -- Resolved inside the callback so it reflects the session state
-            -- at apply time, after the async network round-trip.
-            local live_book_id = ui and ui.statistics and ui.statistics.id_curr_book or nil
-            self:applyRemote(response.statBooks, response.statPages, live_book_id)
-            local newest = since
-            for _, p in ipairs(response.statPages or {}) do
-                local u = tonumber(p.updated_at_ms) or 0
-                if u > newest then newest = u end
-            end
-            if newest > since then
-                settings.stats_pull_cursor = newest
-                G_reader_settings:saveSetting("readest_sync", settings)
-                logger.dbg("ReadestStats pull: cursor advanced to " .. tostring(newest))
-            else
-                logger.dbg("ReadestStats pull: cursor unchanged (no newer rows)")
-            end
-            if interactive then
-                local text = npages > 0 and _("Reading statistics pulled")
-                    or _("Reading statistics are up to date")
-                UIManager:show(InfoMessage:new{ text = text, timeout = 2 })
-            end
-        end)
+            end)
+    end
+    pullFrom(settings.stats_pull_cursor or 0)
 end
 
 return SyncStats

--- a/apps/readest.koplugin/spec/syncstats_spec.lua
+++ b/apps/readest.koplugin/spec/syncstats_spec.lua
@@ -511,4 +511,94 @@ describe("readest_syncstats", function()
 
         assert.are.equal(4242, settings.stats_pull_cursor) -- newest updated_at_ms
     end)
+
+    -- Build a pull response of `n` page events with updated_at_ms running
+    -- from `from_ms` upwards (one per ms), all for one book.
+    local function pageResponse(from_ms, n)
+        local pages = {}
+        for i = 1, n do
+            pages[i] = { book_hash = "md5-pull", page = i, start_time = from_ms + i,
+                         duration = 5, total_pages = 10, updated_at_ms = from_ms + i }
+        end
+        return {
+            statBooks = { { book_hash = "md5-pull", title = "P", authors = "A" } },
+            statPages = pages,
+        }
+    end
+
+    it("pulls a large history in bounded pages, advancing the cursor per page", function()
+        local settings = { stats_pull_cursor = 0 }
+        local sinces, limits, cursor_at_call = {}, {}, {}
+        -- server pages: 1000, 1000, then a short page of 5
+        local sizes = { 1000, 1000, 5 }
+        local client = { pullChanges = function(_, params, cb)
+            table.insert(sinces, params.since)
+            table.insert(limits, params.limit)
+            table.insert(cursor_at_call, settings.stats_pull_cursor)
+            cb(true, pageResponse(params.since, sizes[#sinces] or 0), 200)
+        end }
+
+        SyncStats:pull(settings, client, false, function() end)
+        drainScheduled()
+
+        assert.are.equal(3, #sinces)
+        assert.are.same({ 1000, 1000, 1000 }, limits)
+        -- each page resumes from the previous page's newest updated_at_ms
+        assert.are.same({ 0, 1000, 2000 }, sinces)
+        -- the cursor advanced after every page, not once at the end
+        assert.are.same({ 0, 1000, 2000 }, cursor_at_call)
+        assert.are.equal(2005, settings.stats_pull_cursor)
+        assert.are.equal(settings, G_reader_settings:readSetting("readest_sync"))
+
+        local conn = SQ3.open(statsDbPath())
+        local n = conn:rowexec("SELECT COUNT(*) FROM page_stat_data;")
+        conn:close()
+        assert.are.equal(2005, tonumber(n))
+    end)
+
+    it("keeps partial progress when a page fails, and a retry resumes from the cursor", function()
+        local settings = { stats_pull_cursor = 0 }
+        local calls = 0
+        local client = { pullChanges = function(_, params, cb)
+            calls = calls + 1
+            if calls == 2 then
+                cb(false, nil, 500)
+            else
+                cb(true, pageResponse(params.since, 1000), 200)
+            end
+        end }
+
+        SyncStats:pull(settings, client, false, function() end)
+        drainScheduled()
+
+        assert.are.equal(2, calls)
+        assert.are.equal(1000, settings.stats_pull_cursor) -- first page kept
+
+        local sinces = {}
+        client.pullChanges = function(_, params, cb)
+            table.insert(sinces, params.since)
+            cb(true, pageResponse(params.since, #sinces == 1 and 1000 or 3), 200)
+        end
+        SyncStats:pull(settings, client, false, function() end)
+        drainScheduled()
+
+        assert.are.same({ 1000, 2000 }, sinces) -- resumed, not restarted
+        assert.are.equal(2003, settings.stats_pull_cursor)
+    end)
+
+    it("declares limit as an expected pullChanges param", function()
+        local json = require("json")
+        local f = assert(io.open("readest-sync-api.json", "r"))
+        local spec = json.decode(f:read("*a"))
+        f:close()
+
+        local method = spec.methods.pullChanges
+        local expected = {}
+        for _, k in ipairs(method.required_params or {}) do expected[k] = true end
+        for _, k in ipairs(method.optional_params or {}) do expected[k] = true end
+
+        for _, k in ipairs({ "since", "type", "book", "meta_hash", "limit" }) do
+            assert.is_true(expected[k] == true, k .. " must be an expected pullChanges param")
+        end
+    end)
 end)


### PR DESCRIPTION
## Why

`SyncStats:pull` fetched the whole delta since the pull cursor in one `GET /api/sync?type=stats`. A large multi-device history (tens of thousands of page events, several MB of JSON) cannot come back under the sync client's 10 s total socket timeout (`readest_syncclient.lua:85`), and because the cursor only advanced on success, every retry re-requested the same payload: the pull-side twin of #5666.

## What

- `readest_syncstats.lua`: `SyncStats:pull` now requests `limit=1000` (`PULL_PAGE`, same as the app's `statsSync.ts`), applies each page, saves `stats_pull_cursor` after every page, and chains the next page via `UIManager:nextTick` until a short page arrives. A failed page keeps the pages already applied and a retry resumes from the cursor. The interactive toast fires once, after the last page.
- `readest_syncclient.lua`: forwards `limit` to the Spore call.
- `readest-sync-api.json`: declares `limit` as an optional `pullChanges` param so Spore sends it.
- `spec/syncstats_spec.lua`: three new cases (paged pull with per-page cursor advance and 2005 rows applied; failed page keeps progress and the retry resumes from the cursor; `limit` declared in the API spec).

The server side already pages by `updated_at` and completes the trailing millisecond of each page (`fetchPagedPages` in `src/pages/api/sync.ts`), so a strict `since = cursor` next request never skips rows sharing an `updated_at`. The unpaginated path stays supported for older plugin builds.

## Verification

- `pnpm test:lua`: 321 successes / 0 failures (318 before + 3 new); `pnpm lint:lua` clean.
- Pre-push `pnpm test`: 796 files passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)