### PR TITLE
feat(stats): tier stat_pages history into R2 segments behind a 7-day hot window

### DIFF
--- a/apps/readest-app/docs/stats-archive.md
+++ b/apps/readest-app/docs/stats-archive.md
@@ -86,6 +86,14 @@ Analytics Engine point to `STATS_COMPACT_AE` (`indexes ['compact']`,
 `blobs [outcome, error]`, `doubles [users_claimed, users_archived, segments, rows,
 bytes, duration_ms, errors, commit_mismatches]`).
 
+The stats pull writes one point to the same dataset per **R2-backed** pull (none for
+hot-only pulls): `indexes ['pull']`, `blobs ['paged' | 'full']`, `doubles
+[segments_read, segment_rows_returned, limit]`. Dividing the count of `pull` points by
+the total stats pulls (edge logs or `pg_stat_statements`) gives the share of pulls that
+reach the archive, which is the number that should drive `STATS_COMPACT_WINDOW_DAYS`:
+a larger window spares devices idle for less than the window, at the price of a
+proportionally larger hot table.
+
 Guard order for `compact`: 503 (disabled / no token / no bucket) before 401 (bad token).
 `restore`: 503 (no token / no bucket), 401, then 409 while compaction is enabled, so
 restore and compaction are mutually exclusive without locking.

--- a/apps/readest-app/docs/stats-archive.md
+++ b/apps/readest-app/docs/stats-archive.md
@@ -45,6 +45,12 @@ the two reads, rows that moved out of the hot table are visible through the mani
 Reading hot first can only return such rows twice (clients union-merge), never zero
 times. Do not reorder these queries.
 
+The manifest query is itself capped at 1000 rows by PostgREST (Supabase `db-max-rows`),
+so the pull reads it in `range` pages: hot rows are appended only once a short final
+page proves no archived rows remain past the cursor, and a paged pull stops fetching
+manifest pages as soon as its response page is full. Treating a capped first page as
+the complete list would let a client's cursor advance past unread segments.
+
 ## Segment objects
 
 Key `stats/v1/{user_id}/{updated_to_ms}.json`, `Content-Type: application/json`:
@@ -283,17 +289,21 @@ SELECT pg_size_pretty(pg_total_relation_size('public.stat_pages'));
 
 ## Account deletion
 
-`DELETE /api/user/delete` deletes the auth user **first** (Postgres rows cascade; a
-compaction commit in flight for that user fails on the manifest's foreign key). Only
-then does it touch R2: it queues the user id in `stat_archive_orphans` (service-role
-only, no foreign key) and deletes `stats/v1/{user_id}/` right away, best-effort
-(paginated listing, batches of 1000 keys). The response is 200 once the identity is
-gone, whatever R2 did; the queued row makes the cleanup reliable: every batch run of
-`POST /api/stats/compact` (kill switch on or off) sweeps up to 20 queued users, deletes
-their prefix again and removes the row once the listing is empty, which also catches an
-object a compaction run wrote after the immediate sweep. Deleting objects before the
-identity would be worse: a failed `deleteUser` would leave an active account with its
-history gone and a manifest pointing at missing objects.
+`DELETE /api/user/delete` runs three steps. (1) It writes the durable tombstone first:
+an upsert into `stat_archive_orphans` (service-role only, no foreign key). If even that
+fails, it stops with 500 **before anything destructive**, so a retry is always possible.
+(2) It deletes the auth user (Postgres rows cascade; a compaction commit in flight for
+that user fails on the manifest's foreign key). If this fails, the tombstone is removed
+again, best-effort. (3) It deletes `stats/v1/{user_id}/` right away, best-effort
+(paginated listing, batches of 1000 keys), and answers 200: the tombstone makes the
+cleanup reliable regardless. Every batch run of `POST /api/stats/compact` (kill switch
+on or off) sweeps up to 20 queued users; it first checks the user is really gone
+(`auth.admin.getUserById`) and skips, keeping the row, if the account still exists —
+a stale tombstone can never wipe a living account — then deletes the prefix and removes
+the row once the listing is empty, which also catches an object a compaction run wrote
+after the immediate sweep. Deleting objects before the identity would be worse: a
+failed `deleteUser` would leave an active account with its history gone and a manifest
+pointing at missing objects.
 
 ## Self-hosting
 

--- a/apps/readest-app/docs/stats-archive.md
+++ b/apps/readest-app/docs/stats-archive.md
@@ -84,7 +84,7 @@ commit_mismatches, duration_ms}`; per-user failures count in `errors`, only a fa
 claim is a 500. Every run logs one JSON line (`tag: "stats-compact"`) and writes one
 Analytics Engine point to `STATS_COMPACT_AE` (`indexes ['compact']`,
 `blobs [outcome, error]`, `doubles [users_claimed, users_archived, segments, rows,
-bytes, duration_ms, errors, commit_mismatches]`).
+bytes, duration_ms, errors, commit_mismatches, orphans_swept]`).
 
 The stats pull writes one point to the same dataset per **R2-backed** pull (none for
 hot-only pulls): `indexes ['pull']`, `blobs ['paged' | 'full']`, `doubles
@@ -94,7 +94,9 @@ reach the archive, which is the number that should drive `STATS_COMPACT_WINDOW_D
 a larger window spares devices idle for less than the window, at the price of a
 proportionally larger hot table.
 
-Guard order for `compact`: 503 (disabled / no token / no bucket) before 401 (bad token).
+Guard order for `compact`: 503 (no token / no bucket) before 401 (bad token); then the
+batch run sweeps the account-deletion queue (below) and, if `STATS_COMPACT_ENABLED` is
+not `"true"`, answers `503 {"disabled":true,"orphans_swept":N}` without compacting.
 `restore`: 503 (no token / no bucket), 401, then 409 while compaction is enabled, so
 restore and compaction are mutually exclusive without locking.
 
@@ -111,8 +113,7 @@ on a known account before enabling the cron, or to drain one heavy user.
 Everything up to step 5 is safe with `STATS_COMPACT_ENABLED = "false"` (the default in
 `wrangler.toml`): no segments exist, so pulls behave exactly as before, and the cron
 fires every 10 minutes and gets a 503. Prerequisites: `wrangler` logged in
-(`pnpm exec wrangler whoami`), access to the database SQL editor (or `psql`), and the
-Workers paid plan (for `[limits] cpu_ms`; delete that block if the deploy rejects it).
+(`pnpm exec wrangler whoami`) and access to the database SQL editor (or `psql`).
 Run the shell commands from `apps/readest-app`.
 
 **1. Apply migration 020.** Paste `docker/volumes/db/migrations/020_stat_archives.sql`
@@ -230,7 +231,8 @@ curl -s "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/analytics_
   -H "Authorization: Bearer $CF_API_TOKEN" --data "
   SELECT toStartOfInterval(timestamp, INTERVAL '1' HOUR) AS h, count() AS runs,
          sum(double2) AS users_archived, sum(double3) AS segments, sum(double4) AS rows,
-         sum(double5) AS bytes, sum(double7) AS errors, sum(double8) AS mismatches
+         sum(double5) AS bytes, sum(double7) AS errors, sum(double8) AS mismatches,
+         sum(double9) AS orphans_swept
   FROM stats_compact WHERE index1 = 'compact' AND timestamp > NOW() - INTERVAL '1' DAY
   GROUP BY h ORDER BY h DESC"
 ```
@@ -281,13 +283,17 @@ SELECT pg_size_pretty(pg_total_relation_size('public.stat_pages'));
 
 ## Account deletion
 
-`DELETE /api/user/delete` deletes `stats/v1/{user_id}/` (paginated listing, batches of
-1000 keys) **before** deleting the auth user and refuses the deletion (500) if that
-fails; it sweeps the prefix once more afterwards, best-effort, to catch an object
-written by a compaction run that was between its put and its (now failing) commit.
-Residual orphans (a put landing after the second sweep) can be found by listing
-`stats/v1/` prefixes whose user has no `auth.users` row; delete them with the bucket
-tools.
+`DELETE /api/user/delete` deletes the auth user **first** (Postgres rows cascade; a
+compaction commit in flight for that user fails on the manifest's foreign key). Only
+then does it touch R2: it queues the user id in `stat_archive_orphans` (service-role
+only, no foreign key) and deletes `stats/v1/{user_id}/` right away, best-effort
+(paginated listing, batches of 1000 keys). The response is 200 once the identity is
+gone, whatever R2 did; the queued row makes the cleanup reliable: every batch run of
+`POST /api/stats/compact` (kill switch on or off) sweeps up to 20 queued users, deletes
+their prefix again and removes the row once the listing is empty, which also catches an
+object a compaction run wrote after the immediate sweep. Deleting objects before the
+identity would be worse: a failed `deleteUser` would leave an active account with its
+history gone and a manifest pointing at missing objects.
 
 ## Self-hosting
 

--- a/apps/readest-app/docs/stats-archive.md
+++ b/apps/readest-app/docs/stats-archive.md
@@ -1,0 +1,158 @@
+# Reading-statistics archive (stat_pages tiering)
+
+Page events (`stat_pages`, one row per book/page/start_time, KOReader-compatible) are
+an append-only per-user log with one merge rule (longest duration wins). The server
+never reads history for analytics; devices union-merge everything locally. Keeping
+the whole history in Postgres is therefore the most expensive way to store it.
+
+Migration 020 adds a second tier: `stat_pages` keeps a **hot window** (rows whose
+`updated_at` is younger than `STATS_COMPACT_WINDOW_DAYS`, default 7), and a cron job
+compacts older rows into **immutable per-user JSON segments** in R2, listed in the
+`stat_archives` manifest. The stats pull composes its pages from segments + hot rows
+**server-side**: the sync API, the app and the koplugin are unchanged.
+
+## Pieces
+
+| Piece | Where |
+|---|---|
+| Schema, RPCs | `docker/volumes/db/migrations/020_stat_archives.sql` |
+| Shared helpers (env, guard, codec, page selection) | `src/libs/statsArchive.ts` |
+| Compaction job | `src/app/api/stats/compact/route.ts` (`POST /api/stats/compact`) |
+| Restore tool (rollback) | `src/app/api/stats/restore/route.ts` (`POST /api/stats/restore`) |
+| Segment-aware pull | `src/pages/api/sync.ts` (`GET /api/sync?type=stats`) |
+| Account deletion cleanup | `src/pages/api/user/delete.ts` |
+| Cron entry | `worker.ts` (`scheduled()` calls the compact route), `wrangler.toml` `[triggers]` |
+| SQL verification | `scripts/db/verify-migration-020.sh` (throwaway local PostgreSQL 15) |
+
+## Invariant
+
+A committed segment covers `(updated_from, updated_to]` exactly, and the same
+transaction (`stat_archive_commit`) deletes those hot rows. Every push stamps
+`updated_at = now()`. Therefore every hot row of a user is newer than every segment
+of that user, and "segments in `updated_to` order, then hot rows" is global
+`updated_at` order: the client cursor contract (rows with `updated_at > since`,
+ordered by `updated_at`, paged by `limit` with the trailing millisecond included)
+holds across tiers.
+
+A segment never splits a **millisecond**: `stat_archive_rows` extends the page with
+every row of the user in the same millisecond as its last row, because clients page
+on a millisecond cursor (`updated_at_ms`) and objects are keyed by `updated_to_ms`.
+
+## Pull read order (required)
+
+`/api/sync` queries hot rows **before** the manifest. If a compaction commits between
+the two reads, rows that moved out of the hot table are visible through the manifest.
+Reading hot first can only return such rows twice (clients union-merge), never zero
+times. Do not reorder these queries.
+
+## Segment objects
+
+Key `stats/v1/{user_id}/{updated_to_ms}.json`, `Content-Type: application/json`:
+
+```json
+{"v":1,"user_id":"...","updated_from_ms":0,"updated_to_ms":1787454881000,
+ "rows":[{"book_hash":"...","page":1,"start_time":1787454881,"duration":36,"total_pages":300,
+          "ext":null,"deleted_at":null,"updated_at_ms":1787454881000}]}
+```
+
+Rows are sorted by `(updated_at_ms, book_hash, page, start_time)` and use the wire
+field names, so the pull handler returns them verbatim (plus `user_id`/`updated_at`).
+`updated_at_ms` is the Postgres timestamp truncated (never rounded) to milliseconds;
+the manifest row and the commit keep the exact microsecond `updated_to`.
+
+Objects are immutable and are **never deleted by the compaction path**: after a failed
+commit a concurrent winner's manifest may already reference the key, and a retry
+overwrites the same key with identical content. Only account deletion removes objects.
+
+## Compaction policy (wrangler vars, defaults)
+
+| Var | Default | Meaning |
+|---|---|---|
+| `STATS_COMPACT_ENABLED` | `"false"` | kill switch; anything but `"true"` makes the endpoint answer 503 |
+| `STATS_COMPACT_TOKEN` (secret) | unset | `x-compact-token` header value; unset = 503 |
+| `STATS_COMPACT_USERS_PER_RUN` | 50 | users claimed per run (`stat_archive_claim_users`) |
+| `STATS_COMPACT_WINDOW_DAYS` | 7 | hot window |
+| `STATS_COMPACT_MIN_ROWS` | 500 | eligible when this many rows are older than the window |
+| `STATS_COMPACT_MAX_AGE_DAYS` | 30 | or when the oldest eligible row is older than this |
+| `STATS_COMPACT_HOT_CAP` | 20000 | or when the user has more hot rows than this |
+| `STATS_COMPACT_SEGMENTS_PER_USER` | 5 | segments per user per run |
+| `STATS_COMPACT_SEGMENT_ROWS` | 10000 | rows per segment (extended to the trailing millisecond) |
+
+Garbage or out-of-range values fall back to the default. A run answers
+`200 {ok, users_claimed, users_archived, segments, rows, bytes, errors,
+commit_mismatches, duration_ms}`; per-user failures count in `errors`, only a failed
+claim is a 500. Every run logs one JSON line (`tag: "stats-compact"`) and writes one
+Analytics Engine point to `STATS_COMPACT_AE` (`indexes ['compact']`,
+`blobs [outcome, error]`, `doubles [users_claimed, users_archived, segments, rows,
+bytes, duration_ms, errors, commit_mismatches]`).
+
+Guard order for `compact`: 503 (disabled / no token / no bucket) before 401 (bad token).
+`restore`: 503 (no token / no bucket), 401, then 409 while compaction is enabled, so
+restore and compaction are mutually exclusive without locking.
+
+## Rollout
+
+1. Apply migration 020 (additive: new tables/functions, autovacuum settings on
+   `stat_pages`). Deploy the API with `STATS_COMPACT_ENABLED = "false"`: nothing
+   observable changes (no segments exist; the cron fires and gets 503).
+2. Create the bucket (`readest-stats-archive`) and `wrangler secret put
+   STATS_COMPACT_TOKEN`. On a preview deployment set `STATS_COMPACT_ENABLED = "true"`,
+   run `POST /api/stats/compact` by hand against a test account until it is fully
+   compacted, then verify a fresh-device pull (cursor 0, app and koplugin, paged and
+   unpaginated) reproduces per-book `count(*)` and `sum(duration)` exactly.
+3. Set `STATS_COMPACT_ENABLED = "true"` in production. Watch `STATS_COMPACT_AE` and
+   `pg_stat_user_tables` (`n_live_tup`, `n_dead_tup`, `last_autovacuum`) for
+   `stat_pages`. Steady state for the measurement queries below is 0 rows.
+4. After the backlog drains: `REINDEX INDEX CONCURRENTLY stat_pages_pkey` off-peak
+   (needs free disk about the index size) to reclaim index bloat; optionally
+   `pg_repack` the heap.
+
+Measurement queries:
+
+```sql
+-- users still holding an archivable backlog (expect 0 rows in steady state)
+SELECT user_id, count(*) AS eligible, min(updated_at) AS oldest
+FROM public.stat_pages WHERE updated_at <= now() - interval '7 days'
+GROUP BY user_id
+HAVING count(*) >= 500 OR min(updated_at) <= now() - interval '37 days';
+-- users over the hot cap (expect 0 rows)
+SELECT user_id FROM public.stat_pages GROUP BY user_id HAVING count(*) > 20000;
+-- relation size trend
+SELECT pg_size_pretty(pg_total_relation_size('public.stat_pages'));
+```
+
+## Rollback
+
+- Stop: set `STATS_COMPACT_ENABLED = "false"` and redeploy. Segments stay readable;
+  pulls keep working.
+- Undo data movement: with compaction disabled, `POST /api/stats/restore` with
+  `{"user_id": "<uuid>"}` and the token re-inserts that user's segments through
+  `upsert_stat_pages_as` (idempotent) and drops the manifest rows; it stops at the
+  first unreadable object with `{restored_segments, failed_manifest_id}` and a re-run
+  resumes. Loop over `SELECT DISTINCT user_id FROM stat_archives` to restore everyone.
+
+## Account deletion
+
+`DELETE /api/user/delete` deletes `stats/v1/{user_id}/` (paginated listing, batches of
+1000 keys) **before** deleting the auth user and refuses the deletion (500) if that
+fails; it sweeps the prefix once more afterwards, best-effort, to catch an object
+written by a compaction run that was between its put and its (now failing) commit.
+Residual orphans (a put landing after the second sweep) can be found by listing
+`stats/v1/` prefixes whose user has no `auth.users` row; delete them with the bucket
+tools.
+
+## Self-hosting
+
+Without the `STATS_ARCHIVE_R2` binding the feature is off: the compact/restore
+endpoints answer 503, account deletion skips the cleanup, and the pull never sees a
+manifest row (no compaction ever ran), so it behaves exactly as before migration 020.
+
+## Verifying the SQL
+
+`apps/readest-app/scripts/db/verify-migration-020.sh` starts a throwaway PostgreSQL 15
+cluster (Homebrew `postgresql@15` is found automatically; otherwise export `PGBIN`),
+stubs `auth.users`, `auth.uid()` and the Supabase roles, applies migrations 014, 019
+and 020, and asserts: claim ring + cursor wrap, candidate counts, trailing-millisecond
+extension, commit range delete + CAS (`40001`), draining in a second segment,
+`upsert_stat_pages_as`, `stat_archives` RLS, and that `anon`/`authenticated` cannot
+execute any archive RPC.

--- a/apps/readest-app/docs/stats-archive.md
+++ b/apps/readest-app/docs/stats-archive.md
@@ -98,24 +98,164 @@ Guard order for `compact`: 503 (disabled / no token / no bucket) before 401 (bad
 `restore`: 503 (no token / no bucket), 401, then 409 while compaction is enabled, so
 restore and compaction are mutually exclusive without locking.
 
-## Rollout
+**Targeted run.** `POST /api/stats/compact` with a JSON body `{"user_id": "<uuid>"}`
+and the token compacts that one user: no claiming, the enabled flag is ignored (it is an
+operator action, also usable while the cron is off), and the batching thresholds are
+ignored (everything older than the window is archived, in segments of
+`STATS_COMPACT_SEGMENT_ROWS`, up to `STATS_COMPACT_SEGMENTS_PER_USER` per call; repeat
+until `users_archived` is 0). The response carries `"targeted": true`. Use it to validate
+on a known account before enabling the cron, or to drain one heavy user.
 
-1. Apply migration 020 (additive: new tables/functions, autovacuum settings on
-   `stat_pages`). Deploy the API with `STATS_COMPACT_ENABLED = "false"`: nothing
-   observable changes (no segments exist; the cron fires and gets 503).
-2. Create the bucket (`readest-stats-archive`) and `wrangler secret put
-   STATS_COMPACT_TOKEN`. On a preview deployment set `STATS_COMPACT_ENABLED = "true"`,
-   run `POST /api/stats/compact` by hand against a test account until it is fully
-   compacted, then verify a fresh-device pull (cursor 0, app and koplugin, paged and
-   unpaginated) reproduces per-book `count(*)` and `sum(duration)` exactly.
-3. Set `STATS_COMPACT_ENABLED = "true"` in production. Watch `STATS_COMPACT_AE` and
-   `pg_stat_user_tables` (`n_live_tup`, `n_dead_tup`, `last_autovacuum`) for
-   `stat_pages`. Steady state for the measurement queries below is 0 rows.
-4. After the backlog drains: `REINDEX INDEX CONCURRENTLY stat_pages_pkey` off-peak
-   (needs free disk about the index size) to reclaim index bloat; optionally
-   `pg_repack` the heap.
+## Deployment, step by step
 
-Measurement queries:
+Everything up to step 5 is safe with `STATS_COMPACT_ENABLED = "false"` (the default in
+`wrangler.toml`): no segments exist, so pulls behave exactly as before, and the cron
+fires every 10 minutes and gets a 503. Prerequisites: `wrangler` logged in
+(`pnpm exec wrangler whoami`), access to the database SQL editor (or `psql`), and the
+Workers paid plan (for `[limits] cpu_ms`; delete that block if the deploy rejects it).
+Run the shell commands from `apps/readest-app`.
+
+**1. Apply migration 020.** Paste `docker/volumes/db/migrations/020_stat_archives.sql`
+into the SQL editor and run it (additive and re-runnable: `IF NOT EXISTS`,
+`CREATE OR REPLACE`, `ON CONFLICT DO NOTHING`). Check:
+
+```sql
+select proname from pg_proc where proname in
+  ('stat_archive_claim_users','stat_archive_candidate','stat_archive_rows',
+   'stat_archive_commit','upsert_stat_pages_as');                       -- 5 rows
+select has_function_privilege('anon',
+  'public.stat_archive_commit(uuid,text,timestamptz,timestamptz,integer,integer)','execute'); -- false
+select * from public.stat_archive_state;                                 -- 1 row, user_cursor null
+```
+
+**2. Create the bucket and the token (once).**
+
+```bash
+pnpm exec wrangler r2 bucket create readest-stats-archive
+openssl rand -hex 32            # the token; keep it in your password manager
+pnpm exec wrangler secret put STATS_COMPACT_TOKEN   # paste the token
+```
+
+Secrets are stored per Worker and survive deploys; vars in `wrangler.toml` are
+re-applied on every deploy (that is why the kill switch lives there).
+
+**3. Deploy with compaction disabled.** `pnpm deploy`, then:
+
+```bash
+TOKEN=...   # the value from step 2
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://web.readest.com/api/stats/compact \
+  -H "x-compact-token: $TOKEN"                                            # 503 (disabled)
+curl -s -X POST https://web.readest.com/api/stats/restore -H "x-compact-token: $TOKEN" \
+  -H 'content-type: application/json' -d '{"user_id":"00000000-0000-0000-0000-000000000000"}'
+                                          # {"restored_segments":0,"rows":0}: restore path is live
+```
+
+In the Cloudflare dashboard (Workers & Pages > readest-web > Settings) the cron
+`*/10 * * * *` and the bindings `STATS_ARCHIVE_R2` / `STATS_COMPACT_AE` are listed.
+Any device syncing now behaves as before (no manifest rows exist).
+
+**4. Validate on one known account, on production data, cron still off.** Use your own
+account (or any account whose device you control).
+
+```sql
+-- 4a. its id
+select id from auth.users where email = '<you@example.com>';
+-- 4b. snapshot per-book totals; keep the output
+select book_hash, count(*) as n, sum(duration) as d
+from public.stat_pages where user_id = '<uid>' group by 1 order by 1;
+```
+
+```bash
+# 4c. targeted compaction: that user only, ignores the enabled flag and the batching
+#     thresholds, archives everything older than the window; repeat until users_archived = 0
+curl -s -X POST https://web.readest.com/api/stats/compact -H "x-compact-token: $TOKEN" \
+  -H 'content-type: application/json' -d '{"user_id":"<uid>"}'
+# {"ok":true,"targeted":true,"users_claimed":1,"users_archived":1,"segments":N,"rows":R,...}
+```
+
+```sql
+-- 4d. manifest + nothing older than the window left hot
+select id, updated_from, updated_to, row_count, bytes, object_key
+from public.stat_archives where user_id = '<uid>' order by updated_to;
+select count(*) from public.stat_pages
+where user_id = '<uid>' and updated_at <= now() - interval '7 days';    -- 0
+```
+
+```bash
+# 4d'. look at one object
+pnpm exec wrangler r2 object get readest-stats-archive/stats/v1/<uid>/<updated_to_ms>.json \
+  --file /tmp/seg.json && head -c 400 /tmp/seg.json
+```
+
+4e. Fresh pull on a device signed in as that account: a fresh app install (its pull
+cursor starts at 0), or KOReader / the KOReader emulator with the Readest plugin logged
+in and a fresh `statistics.sqlite3`, then "Pull reading statistics". Compare with 4b:
+
+```bash
+sqlite3 statistics.sqlite3 "select b.md5, count(*), sum(p.duration) from page_stat_data p
+  join book b on b.id = p.id_book group by 1 order by 1;"
+```
+
+Per-book `count(*)` and `sum(duration)` must match 4b exactly. If the account signs in
+with email + password you can also pull through the API directly:
+
+```bash
+ACCESS=$(curl -s "https://<project>.supabase.co/auth/v1/token?grant_type=password" \
+  -H "apikey: $SUPABASE_ANON_KEY" -H 'content-type: application/json' \
+  -d '{"email":"<you@example.com>","password":"..."}' | jq -r .access_token)
+curl -s "https://web.readest.com/api/sync?type=stats&since=0&limit=1000" \
+  -H "Authorization: Bearer $ACCESS" | jq '.statPages | length, (.[0] // empty)'
+```
+
+Pages of 1000 come from the segments first (rows carry `updated_at_ms`), then hot rows;
+advance `since` to the last `updated_at_ms` to walk the whole history.
+
+4f. Optional: undo the test with the restore endpoint (`{"user_id":"<uid>"}`): the
+rows are back in Postgres (4b totals match again), the manifest rows are gone, the
+objects stay.
+
+**5. Enable the cron.** In `wrangler.toml` set `STATS_COMPACT_ENABLED = "true"`, commit,
+`pnpm deploy`. The first run happens within 10 minutes; a manual run is identical:
+
+```bash
+curl -s -X POST https://web.readest.com/api/stats/compact -H "x-compact-token: $TOKEN"
+# {"ok":true,"users_claimed":50,"users_archived":N,"segments":...,"errors":0,"commit_mismatches":0,...}
+```
+
+Watch, daily for the first two weeks:
+
+```bash
+# Analytics Engine SQL API (API token with "Account Analytics: Read")
+curl -s "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/analytics_engine/sql" \
+  -H "Authorization: Bearer $CF_API_TOKEN" --data "
+  SELECT toStartOfInterval(timestamp, INTERVAL '1' HOUR) AS h, count() AS runs,
+         sum(double2) AS users_archived, sum(double3) AS segments, sum(double4) AS rows,
+         sum(double5) AS bytes, sum(double7) AS errors, sum(double8) AS mismatches
+  FROM stats_compact WHERE index1 = 'compact' AND timestamp > NOW() - INTERVAL '1' DAY
+  GROUP BY h ORDER BY h DESC"
+```
+
+`errors` and `mismatches` should stay 0. Postgres side: the measurement queries below,
+plus `select n_live_tup, n_dead_tup, last_autovacuum, last_autoanalyze from
+pg_stat_user_tables where relname = 'stat_pages';` (autovacuum must keep up: migration
+020 sets the table's scale factor to 1%). At the defaults the backlog drains at up to
+50 users x 50k rows per run, 144 runs per day.
+
+**6. After the backlog drains** (the measurement queries return 0 rows), off-peak:
+
+```sql
+select pg_size_pretty(pg_relation_size('public.stat_pages_pkey'));   -- needs about this much free disk
+REINDEX INDEX CONCURRENTLY public.stat_pages_pkey;
+REINDEX INDEX CONCURRENTLY public.idx_stat_pages_user_updated;
+```
+
+That reclaims the index bloat inside the database (the provider's disk does not shrink;
+the freed pages are reused). `pg_repack` on the heap is heavier; skip unless needed.
+
+**7. Revisit the window** after a couple of weeks with the pull metric (next section):
+share of pulls that reach the archive = `pull` points / total stats pulls.
+
+Measurement queries (daily during rollout; steady state is 0 rows):
 
 ```sql
 -- users still holding an archivable backlog (expect 0 rows in steady state)

--- a/apps/readest-app/scripts/db/verify-migration-020.sh
+++ b/apps/readest-app/scripts/db/verify-migration-020.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Verify migrations 014 + 019 + 020 (reading statistics: tables, upsert RPC,
+# archive manifest + compaction RPCs) against a throwaway local PostgreSQL 15.
+#
+# Needs a PostgreSQL 15 server install (Homebrew: `brew install postgresql@15`,
+# then it is found automatically; or export PGBIN=/path/to/pg/bin). Creates a
+# Supabase-shaped stub: auth.users, auth.uid() driven by the
+# `request.jwt.claim.sub` GUC, roles anon/authenticated/service_role.
+#
+#   apps/readest-app/scripts/db/verify-migration-020.sh
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+ROOT=$(cd "$HERE/../../../.." && pwd)
+MIGRATIONS="$ROOT/docker/volumes/db/migrations"
+PGBIN=${PGBIN:-}
+if [ -z "$PGBIN" ]; then
+  for c in /opt/homebrew/opt/postgresql@15/bin /usr/local/opt/postgresql@15/bin /usr/lib/postgresql/15/bin; do
+    [ -x "$c/initdb" ] && PGBIN="$c" && break
+  done
+fi
+if [ -z "$PGBIN" ] || [ ! -x "$PGBIN/initdb" ]; then
+  echo "verify-migration-020: PostgreSQL 15 binaries not found; set PGBIN" >&2
+  exit 2
+fi
+
+D=$(mktemp -d "${TMPDIR:-/tmp}/readest-pg15.XXXXXX")
+PORT=${PGPORT_VERIFY:-54329}
+cleanup() { "$PGBIN/pg_ctl" -D "$D" stop -m fast >/dev/null 2>&1 || true; rm -rf "$D"; }
+trap cleanup EXIT
+"$PGBIN/initdb" -D "$D" -U postgres -A trust >/dev/null
+"$PGBIN/pg_ctl" -D "$D" -o "-p $PORT -c listen_addresses=127.0.0.1 -c unix_socket_directories=''" -l "$D/log" start -w >/dev/null
+PSQL="$PGBIN/psql -h 127.0.0.1 -p $PORT -U postgres -d postgres -v ON_ERROR_STOP=1 -q -X"
+$PSQL -t -c "select version()" | head -1
+
+U1=00000000-0000-0000-0000-000000000001
+U2=00000000-0000-0000-0000-000000000002
+U3=00000000-0000-0000-0000-000000000003
+
+$PSQL <<SQL
+create schema auth;
+create table auth.users (id uuid primary key);
+create role anon nologin;
+create role authenticated nologin;
+create role service_role nologin bypassrls;
+create function auth.uid() returns uuid language sql stable
+  as \$\$ select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid \$\$;
+grant usage on schema public to anon, authenticated, service_role;
+grant usage on schema auth to anon, authenticated, service_role;
+alter default privileges in schema public grant all on tables to anon, authenticated, service_role;
+alter default privileges in schema public grant execute on functions to anon, authenticated, service_role;
+insert into auth.users values ('$U1'), ('$U2'), ('$U3');
+SQL
+$PSQL -f "$MIGRATIONS/014_add_reading_stats.sql"
+$PSQL -f "$MIGRATIONS/019_stat_pages_upsert_rpc.sql"
+$PSQL -f "$MIGRATIONS/020_stat_archives.sql"
+
+# Seed: u1 has 30 old rows (3 per ms over 10 ms, 40 days ago; the 2nd ms also
+# holds a row 400 microseconds later, i.e. same millisecond, different
+# timestamp) + 5 hot rows (now); u2 has 4 old rows; u3 has only hot rows.
+$PSQL <<SQL
+begin;  -- one transaction so now() is identical across the seed statements
+insert into public.stat_pages (user_id, book_hash, page, start_time, duration, total_pages, updated_at)
+select '$U1', 'b1', p, 1000 + ms * 10 + p, 5, 100,
+       date_trunc('milliseconds', now() - interval '40 days') + make_interval(secs => ms * 0.001)
+from generate_series(0, 9) ms, generate_series(1, 3) p;
+insert into public.stat_pages (user_id, book_hash, page, start_time, duration, total_pages, updated_at)
+values ('$U1', 'b1', 4, 1014, 5, 100,
+        date_trunc('milliseconds', now() - interval '40 days') + interval '1.4 milliseconds');
+insert into public.stat_pages (user_id, book_hash, page, start_time, duration, total_pages, updated_at)
+select '$U1', 'b1', 100 + p, 5000 + p, 5, 100, now() from generate_series(1, 5) p;
+insert into public.stat_pages (user_id, book_hash, page, start_time, duration, total_pages, updated_at)
+select '$U2', 'b2', p, 2000 + p, 7, 50, now() - interval '20 days' from generate_series(1, 4) p;
+insert into public.stat_pages (user_id, book_hash, page, start_time, duration, total_pages, updated_at)
+select '$U3', 'b3', p, 3000 + p, 9, 10, now() from generate_series(1, 2) p;
+commit;
+SQL
+
+$PSQL <<SQL
+set role service_role;
+
+-- 1. claim: ring over users in PK order; cursor advances then wraps to NULL
+do \$\$
+declare a uuid[]; b uuid[]; c uuid[]; cur uuid; begin
+  select array_agg(u) into a from public.stat_archive_claim_users(2) u;
+  assert a = array['$U1'::uuid, '$U2'::uuid], format('batch1 %s', a);
+  select user_cursor into cur from public.stat_archive_state; assert cur = '$U2'::uuid;
+  select array_agg(u) into b from public.stat_archive_claim_users(2) u;
+  assert b = array['$U3'::uuid], format('batch2 %s', b);
+  select user_cursor into cur from public.stat_archive_state; assert cur is null, 'cursor wraps to NULL';
+  select array_agg(u) into c from public.stat_archive_claim_users(2) u;
+  assert c = a, 'ring restarts from the smallest user';
+  raise notice 'ok 1: claim ring + cursor wrap';
+end \$\$;
+
+-- 2. candidate numbers
+do \$\$
+declare r record; begin
+  select * into r from public.stat_archive_candidate('$U1', '7 days');
+  assert r.eligible = 31 and r.hot_total = 36 and r.archived_to = 'epoch'::timestamptz, format('u1 %s', r);
+  assert r.oldest < now() - interval '39 days';
+  select * into r from public.stat_archive_candidate('$U3', '7 days');
+  assert r.eligible = 0 and r.hot_total = 2, format('u3 %s', r);
+  raise notice 'ok 2: candidate counts';
+end \$\$;
+
+-- 3. rows: limit 4 lands inside the 2nd millisecond (3 rows at +1.0 ms plus one
+--    at +1.4 ms) -> extended to the whole millisecond: 3 + 4 = 7 rows, 2 distinct ms
+do \$\$
+declare n int; d int; begin
+  select count(*), count(distinct date_trunc('milliseconds', updated_at)) into n, d
+    from public.stat_archive_rows('$U1', 'epoch', '7 days', 4);
+  assert n = 7 and d = 2, format('rows=%s ms=%s', n, d);
+  select count(*) into n from public.stat_archive_rows('$U1', 'epoch', '7 days', 100);
+  assert n = 31, format('all eligible %s', n);  -- hot rows excluded by the window
+  raise notice 'ok 3: segment rows extend to the trailing millisecond';
+end \$\$;
+
+-- 4. commit: deletes exactly (from, to], returns the count, CAS protects against a second committer
+do \$\$
+declare t_to timestamptz; n int; begin
+  select max(updated_at) into t_to from public.stat_archive_rows('$U1', 'epoch', '7 days', 4);
+  n := public.stat_archive_commit('$U1', 'stats/v1/u1/seg1.json', 'epoch', t_to, 7, 123);
+  assert n = 7, format('deleted %s', n);
+  assert (select count(*) from public.stat_pages where user_id = '$U1') = 29;
+  assert (select archived_to from public.stat_archive_candidate('$U1', '7 days')) = t_to;
+  begin
+    perform public.stat_archive_commit('$U1', 'stats/v1/u1/seg1-dup.json', 'epoch', t_to, 7, 123);
+    raise exception 'second committer must fail';
+  exception when sqlstate '40001' then null;
+  end;
+  assert (select count(*) from public.stat_archives where user_id = '$U1') = 1;
+  raise notice 'ok 4: commit range delete + CAS 40001';
+end \$\$;
+
+-- 5. a follow-up segment resumes from archived_to and drains the rest
+do \$\$
+declare t_from timestamptz; t_to timestamptz; n int; begin
+  select archived_to into t_from from public.stat_archive_candidate('$U1', '7 days');
+  select max(updated_at) into t_to from public.stat_archive_rows('$U1', t_from, '7 days', 1000);
+  n := public.stat_archive_commit('$U1', 'stats/v1/u1/seg2.json', t_from, t_to, 24, 456);
+  assert n = 24, format('deleted %s', n);
+  assert (select eligible from public.stat_archive_candidate('$U1', '7 days')) = 0;
+  assert (select hot_total from public.stat_archive_candidate('$U1', '7 days')) = 5, 'hot rows untouched';
+  raise notice 'ok 5: second segment drains the backlog, hot rows untouched';
+end \$\$;
+
+-- 6. restore path: upsert_stat_pages_as merges for an explicit user (longest duration wins)
+do \$\$
+declare n int; begin
+  n := public.upsert_stat_pages_as('$U1', '[{"book_hash":"b1","page":1,"start_time":1001,"duration":5,"total_pages":100},
+                                            {"book_hash":"b1","page":1,"start_time":1001,"duration":9,"total_pages":100}]');
+  assert n = 1, format('inserted %s', n);
+  assert (select duration from public.stat_pages where user_id = '$U1' and book_hash='b1' and page=1 and start_time=1001) = 9;
+  n := public.upsert_stat_pages_as('$U1', '[{"book_hash":"b1","page":1,"start_time":1001,"duration":3,"total_pages":100}]');
+  assert n = 0, 'shorter duration ignored';
+  raise notice 'ok 6: upsert_stat_pages_as merge';
+end \$\$;
+reset role;
+
+-- 7. RLS: authenticated users see only their own manifest rows
+set role authenticated;
+select set_config('request.jwt.claim.sub', '$U1', false);
+do \$\$ begin
+  assert (select count(*) from public.stat_archives) = 2, 'u1 sees its 2 segments';
+end \$\$;
+select set_config('request.jwt.claim.sub', '$U2', false);
+do \$\$ begin
+  assert (select count(*) from public.stat_archives) = 0, 'u2 sees nothing';
+  raise notice 'ok 7: stat_archives RLS';
+end \$\$;
+reset role;
+SQL
+
+# 8. grants: anon/authenticated cannot execute the archive RPCs
+for fn in "stat_archive_claim_users(1)" "stat_archive_candidate('$U1','7 days')" "stat_archive_rows('$U1','epoch','7 days',1)" "stat_archive_commit('$U1','k','epoch',now(),0,0)" "upsert_stat_pages_as('$U1','[]')"; do
+  for role in anon authenticated; do
+    if $PSQL -c "set role $role; select public.$fn;" >/dev/null 2>"$D/err"; then
+      echo "FAIL 8: $role could execute $fn" >&2; exit 1
+    fi
+    grep -q "permission denied" "$D/err" || { echo "FAIL 8: unexpected error for $role/$fn: $(head -1 "$D/err")" >&2; exit 1; }
+  done
+done
+echo "ok 8: anon/authenticated cannot execute the archive RPCs"
+echo "ALL MIGRATION 020 CHECKS PASSED"

--- a/apps/readest-app/scripts/db/verify-migration-020.sh
+++ b/apps/readest-app/scripts/db/verify-migration-020.sh
@@ -158,7 +158,15 @@ declare n int; begin
 end \$\$;
 reset role;
 
--- 7. RLS: authenticated users see only their own manifest rows
+-- 7. RLS: authenticated users see only their own manifest rows; every archive
+--    table has RLS enabled; the service-role-only tables are not readable by
+--    anon/authenticated at all
+do \$\$ begin
+  assert (select bool_and(relrowsecurity) from pg_class
+          where relname in ('stat_archives','stat_archive_state','stat_archive_orphans')), 'RLS on all 3 tables';
+  assert (select count(*) from pg_class
+          where relname in ('stat_archives','stat_archive_state','stat_archive_orphans')) = 3;
+end \$\$;
 set role authenticated;
 select set_config('request.jwt.claim.sub', '$U1', false);
 do \$\$ begin
@@ -167,10 +175,21 @@ end \$\$;
 select set_config('request.jwt.claim.sub', '$U2', false);
 do \$\$ begin
   assert (select count(*) from public.stat_archives) = 0, 'u2 sees nothing';
-  raise notice 'ok 7: stat_archives RLS';
+  raise notice 'ok 7: stat_archives RLS + relrowsecurity on all tables';
 end \$\$;
 reset role;
 SQL
+
+# 7b. anon/authenticated cannot read the service-role-only tables (REVOKE, not just RLS)
+for tbl in stat_archive_state stat_archive_orphans; do
+  for role in anon authenticated; do
+    if $PSQL -c "set role $role; select * from public.$tbl;" >/dev/null 2>"$D/err"; then
+      echo "FAIL 7b: $role could select $tbl" >&2; exit 1
+    fi
+    grep -q "permission denied" "$D/err" || { echo "FAIL 7b: unexpected error for $role/$tbl: $(head -1 "$D/err")" >&2; exit 1; }
+  done
+done
+echo "ok 7b: anon/authenticated cannot read stat_archive_state / stat_archive_orphans"
 
 # 8. grants: anon/authenticated cannot execute the archive RPCs
 for fn in "stat_archive_claim_users(1)" "stat_archive_candidate('$U1','7 days')" "stat_archive_rows('$U1','epoch','7 days',1)" "stat_archive_commit('$U1','k','epoch',now(),0,0)" "upsert_stat_pages_as('$U1','[]')"; do

--- a/apps/readest-app/src/__tests__/app/api/stats-compact-route.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/stats-compact-route.test.ts
@@ -16,8 +16,39 @@ const rpcMock = vi.fn(async (fn: string, args: Record<string, unknown>) => {
   const r = h(args);
   return { data: r.data ?? null, error: r.error ?? null };
 });
+// stat_archive_orphans (account-deletion cleanup queue): selects return the
+// queued rows, deletes by user_id remove them.
+let orphanRows: { user_id: string }[] = [];
+const orphanCalls: { method: string; args: unknown[] }[] = [];
+const makeOrphanBuilder = () => {
+  const chain: { method: string; args: unknown[] }[] = [];
+  const builder: Record<string, unknown> = {};
+  const rec =
+    (method: string) =>
+    (...args: unknown[]) => {
+      orphanCalls.push({ method, args });
+      chain.push({ method, args });
+      return builder;
+    };
+  for (const m of ['select', 'delete', 'eq', 'order', 'limit']) builder[m] = rec(m);
+  // biome-ignore lint/suspicious/noThenProperty: mock PostgREST builder is intentionally thenable
+  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) => {
+    if (chain.some((c) => c.method === 'delete')) {
+      const id = chain.find((c) => c.method === 'eq' && c.args[0] === 'user_id')?.args[1];
+      orphanRows = orphanRows.filter((o) => o.user_id !== id);
+      return resolve({ data: null, error: null });
+    }
+    const lim = chain.find((c) => c.method === 'limit')?.args[0] as number | undefined;
+    return resolve({ data: orphanRows.slice(0, lim ?? orphanRows.length), error: null });
+  };
+  return builder;
+};
+const fromMock = vi.fn((table: string) => {
+  if (table !== 'stat_archive_orphans') throw new Error(`unexpected table ${table}`);
+  return makeOrphanBuilder();
+});
 vi.mock('@/utils/supabase', () => ({
-  createSupabaseAdminClient: () => ({ rpc: rpcMock }),
+  createSupabaseAdminClient: () => ({ rpc: rpcMock, from: fromMock }),
 }));
 
 let cfEnv: Record<string, unknown> = {};
@@ -52,6 +83,11 @@ const daysAgo = (d: number) => new Date(Date.now() - d * 86400000).toISOString()
 
 beforeEach(() => {
   rpcCalls.length = 0;
+  rpcMock.mockClear();
+  orphanRows = [];
+  orphanCalls.length = 0;
+  fromMock.mockClear();
+  bucket.list.mockReset().mockResolvedValue({ objects: [], truncated: false });
   for (const k of Object.keys(rpcHandlers)) delete rpcHandlers[k];
   bucket.put.mockReset().mockResolvedValue(undefined);
   bucket.delete.mockReset();
@@ -156,6 +192,73 @@ describe('POST /api/stats/compact targeted run ({ user_id })', () => {
     expect((await postUser('nope')).status).toBe(400);
     cfEnv = { STATS_COMPACT_TOKEN: 't' };
     expect((await postUser(UID)).status).toBe(503);
+  });
+
+  it('rejects any non-empty body that is not a valid targeted request instead of running a batch', async () => {
+    cfEnv = { ...cfEnv, STATS_COMPACT_ENABLED: 'true' };
+    const raw = (body: string) =>
+      POST(
+        new Request('https://web.readest.com/api/stats/compact', {
+          method: 'POST',
+          headers: { 'x-compact-token': 't', 'content-type': 'application/json' },
+          body,
+        }),
+      );
+    for (const body of ['{"userId":"' + UID + '"}', '{"user_id":', '[]', '"x"', '{}', '   ']) {
+      // whitespace-only counts as empty (cron-shaped); everything else is malformed
+      const res = await raw(body);
+      if (body.trim() === '') {
+        expect(res.status).toBe(200);
+      } else {
+        expect(res.status).toBe(400);
+      }
+    }
+    // the malformed bodies never reached the database: only the whitespace run claimed users
+    expect(rpcCalls.filter((c) => c.fn === 'stat_archive_claim_users')).toHaveLength(1);
+  });
+});
+
+describe('POST /api/stats/compact orphan sweep (account-deletion cleanup)', () => {
+  const A = '00000000-0000-0000-0000-00000000000a';
+  const B = '00000000-0000-0000-0000-00000000000b';
+
+  it('deletes queued users prefixes and dequeues them, even while compaction is disabled', async () => {
+    cfEnv = { STATS_ARCHIVE_R2: bucket, STATS_COMPACT_AE: ae, STATS_COMPACT_TOKEN: 't' };
+    orphanRows = [{ user_id: A }, { user_id: B }];
+    bucket.list.mockImplementation(async ({ prefix }: { prefix: string }) => ({
+      objects: prefix.includes(A) ? [{ key: `stats/v1/${A}/1.json` }] : [],
+      truncated: false,
+    }));
+    const res = await post();
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ disabled: true, orphans_swept: 2 });
+    expect(bucket.delete).toHaveBeenCalledWith([`stats/v1/${A}/1.json`]);
+    expect(orphanRows).toEqual([]);
+    expect(rpcMock).not.toHaveBeenCalled(); // no compaction while disabled
+  });
+
+  it('keeps a queued user whose prefix could not be deleted and counts the error', async () => {
+    orphanRows = [{ user_id: A }, { user_id: B }];
+    bucket.list.mockImplementation(async ({ prefix }: { prefix: string }) => {
+      if (prefix.includes(A)) throw new Error('r2 down');
+      return { objects: [], truncated: false };
+    });
+    const body = await (await post()).json();
+    expect(body).toMatchObject({ ok: true, orphans_swept: 1, errors: 1 });
+    expect(orphanRows).toEqual([{ user_id: A }]);
+  });
+
+  it('does not run the sweep for a targeted request', async () => {
+    orphanRows = [{ user_id: A }];
+    await POST(
+      new Request('https://web.readest.com/api/stats/compact', {
+        method: 'POST',
+        headers: { 'x-compact-token': 't', 'content-type': 'application/json' },
+        body: JSON.stringify({ user_id: '00000000-0000-0000-0000-000000000001' }),
+      }),
+    );
+    expect(orphanRows).toEqual([{ user_id: A }]);
+    expect(fromMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/readest-app/src/__tests__/app/api/stats-compact-route.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/stats-compact-route.test.ts
@@ -97,6 +97,68 @@ describe('POST /api/stats/compact guard', () => {
   });
 });
 
+describe('POST /api/stats/compact targeted run ({ user_id })', () => {
+  const UID = '00000000-0000-0000-0000-000000000001';
+  const postUser = (user_id: unknown, token: string | null = 't') =>
+    POST(
+      new Request('https://web.readest.com/api/stats/compact', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...(token ? { 'x-compact-token': token } : {}),
+        },
+        body: JSON.stringify({ user_id }),
+      }),
+    );
+
+  beforeEach(() => {
+    // cron disabled: a targeted run still works (operator action) ...
+    cfEnv = { STATS_ARCHIVE_R2: bucket, STATS_COMPACT_AE: ae, STATS_COMPACT_TOKEN: 't' };
+    // ... and ignores the eligibility thresholds: this user is far below them
+    rpcHandlers['stat_archive_candidate'] = () => ({
+      data: [{ eligible: 3, oldest: daysAgo(8), hot_total: 10, archived_to: EPOCH }],
+    });
+    rpcHandlers['stat_archive_rows'] = ({ p_user }) =>
+      p_user === UID
+        ? { data: [dbRow('2026-07-01T00:00:00+00:00', 1), dbRow('2026-07-01T00:00:00+00:00', 2)] }
+        : { data: [] };
+  });
+
+  it('archives exactly that user, without claiming, with the enabled flag off and thresholds ignored', async () => {
+    const res = await postUser(UID);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      ok: true,
+      targeted: true,
+      users_claimed: 1,
+      users_archived: 1,
+      segments: 1,
+      rows: 2,
+    });
+    expect(rpcCalls.some((c) => c.fn === 'stat_archive_claim_users')).toBe(false);
+    expect(rpcCalls.find((c) => c.fn === 'stat_archive_candidate')?.args['p_user']).toBe(UID);
+    expect(bucket.put.mock.calls[0]![0]).toMatch(`stats/v1/${UID}/`);
+  });
+
+  it('archives nothing when the user has no rows older than the window', async () => {
+    rpcHandlers['stat_archive_candidate'] = () => ({
+      data: [{ eligible: 0, oldest: null, hot_total: 10, archived_to: EPOCH }],
+    });
+    expect(await (await postUser(UID)).json()).toMatchObject({
+      users_claimed: 1,
+      users_archived: 0,
+    });
+    expect(bucket.put).not.toHaveBeenCalled();
+  });
+
+  it('still requires the token and the bucket, and a well-formed user_id', async () => {
+    expect((await postUser(UID, 'wrong')).status).toBe(401);
+    expect((await postUser('nope')).status).toBe(400);
+    cfEnv = { STATS_COMPACT_TOKEN: 't' };
+    expect((await postUser(UID)).status).toBe(503);
+  });
+});
+
 describe('POST /api/stats/compact run', () => {
   it('archives eligible users: put object, commit exact range, report summary + AE point', async () => {
     const res = await post();

--- a/apps/readest-app/src/__tests__/app/api/stats-compact-route.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/stats-compact-route.test.ts
@@ -47,8 +47,19 @@ const fromMock = vi.fn((table: string) => {
   if (table !== 'stat_archive_orphans') throw new Error(`unexpected table ${table}`);
   return makeOrphanBuilder();
 });
+// auth.admin.getUserById: the orphan sweep's safety check. Default: every
+// queued user is really deleted ("user not found").
+type GetUserResult = { data: { user: { id: string } | null }; error: { message: string } | null };
+const getUserByIdMock = vi.fn<(id: string) => Promise<GetUserResult>>(async () => ({
+  data: { user: null },
+  error: { message: 'not found' },
+}));
 vi.mock('@/utils/supabase', () => ({
-  createSupabaseAdminClient: () => ({ rpc: rpcMock, from: fromMock }),
+  createSupabaseAdminClient: () => ({
+    rpc: rpcMock,
+    from: fromMock,
+    auth: { admin: { getUserById: getUserByIdMock } },
+  }),
 }));
 
 let cfEnv: Record<string, unknown> = {};
@@ -87,6 +98,9 @@ beforeEach(() => {
   orphanRows = [];
   orphanCalls.length = 0;
   fromMock.mockClear();
+  getUserByIdMock
+    .mockReset()
+    .mockResolvedValue({ data: { user: null }, error: { message: 'not found' } });
   bucket.list.mockReset().mockResolvedValue({ objects: [], truncated: false });
   for (const k of Object.keys(rpcHandlers)) delete rpcHandlers[k];
   bucket.put.mockReset().mockResolvedValue(undefined);
@@ -248,6 +262,22 @@ describe('POST /api/stats/compact orphan sweep (account-deletion cleanup)', () =
     expect(orphanRows).toEqual([{ user_id: A }]);
   });
 
+  it('skips (and keeps) a queued user that still exists: never wipes a living account', async () => {
+    orphanRows = [{ user_id: A }, { user_id: B }];
+    getUserByIdMock.mockImplementation(async (id: string) =>
+      id === A
+        ? { data: { user: { id: A } }, error: null }
+        : { data: { user: null }, error: { message: 'not found' } },
+    );
+    const body = await (await post()).json();
+    expect(body).toMatchObject({ ok: true, orphans_swept: 1, errors: 0 });
+    expect(orphanRows).toEqual([{ user_id: A }]); // stale tombstone kept, no delete attempted
+    const listedPrefixes = bucket.list.mock.calls.map(
+      (call) => (call[0] as { prefix: string }).prefix,
+    );
+    expect(listedPrefixes.some((p) => p.includes(A))).toBe(false);
+  });
+
   it('does not run the sweep for a targeted request', async () => {
     orphanRows = [{ user_id: A }];
     await POST(
@@ -400,6 +430,29 @@ describe('POST /api/stats/compact run', () => {
     const body = await (await post()).json();
     expect(body).toMatchObject({ ok: true, segments: 0, rows: 0, users_archived: 0, errors: 0 });
     expect(bucket.delete).not.toHaveBeenCalled();
+  });
+
+  it('fails loud, without writing an object, if a segment boundary does not advance past the previous millisecond', async () => {
+    // rows whose max updated_at truncates to the same millisecond as p_from
+    // would reuse the previous object key; the route must error out instead of
+    // overwriting (the SQL extension makes this impossible unless it regresses)
+    rpcHandlers['stat_archive_candidate'] = () => ({
+      data: [
+        {
+          eligible: 600,
+          oldest: daysAgo(40),
+          hot_total: 700,
+          archived_to: '2026-07-01T00:00:00.123+00:00',
+        },
+      ],
+    });
+    rpcHandlers['stat_archive_rows'] = () => ({
+      data: [dbRow('2026-07-01T00:00:00.123456+00:00', 1)],
+    });
+    const body = await (await post()).json();
+    expect(body).toMatchObject({ errors: 2, segments: 0, users_archived: 0 });
+    expect(bucket.put).not.toHaveBeenCalled();
+    expect(rpcCalls.some((c) => c.fn === 'stat_archive_commit')).toBe(false);
   });
 
   it('counts an R2 put failure as an error for that user and continues the run', async () => {

--- a/apps/readest-app/src/__tests__/app/api/stats-compact-route.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/stats-compact-route.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { decodeSegment } from '@/libs/statsArchive';
+
+// POST /api/stats/compact: the cron-driven job that moves page events older
+// than the hot window from stat_pages into immutable R2 segments. It runs as
+// service_role against the migration-020 RPCs; one run claims a batch of users,
+// archives the eligible ones and reports a summary.
+
+type RpcHandler = (args: Record<string, unknown>) => { data?: unknown; error?: unknown };
+const rpcHandlers: Record<string, RpcHandler> = {};
+const rpcCalls: { fn: string; args: Record<string, unknown> }[] = [];
+const rpcMock = vi.fn(async (fn: string, args: Record<string, unknown>) => {
+  rpcCalls.push({ fn, args });
+  const h = rpcHandlers[fn];
+  if (!h) return { data: null, error: { message: `unexpected rpc ${fn}` } };
+  const r = h(args);
+  return { data: r.data ?? null, error: r.error ?? null };
+});
+vi.mock('@/utils/supabase', () => ({
+  createSupabaseAdminClient: () => ({ rpc: rpcMock }),
+}));
+
+let cfEnv: Record<string, unknown> = {};
+vi.mock('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: () => ({ env: cfEnv }),
+}));
+
+import { POST } from '@/app/api/stats/compact/route';
+
+const bucket = { get: vi.fn(), put: vi.fn(), list: vi.fn(), delete: vi.fn() };
+const ae = { writeDataPoint: vi.fn() };
+const EPOCH = '1970-01-01T00:00:00+00:00';
+const dbRow = (updated_at: string, page = 1) => ({
+  user_id: 'u1',
+  book_hash: 'h1',
+  page,
+  start_time: 1000 + page,
+  duration: 5,
+  total_pages: 10,
+  ext: null,
+  updated_at,
+  deleted_at: null,
+});
+const post = (token: string | null = 't') =>
+  POST(
+    new Request('https://web.readest.com/api/stats/compact', {
+      method: 'POST',
+      headers: token ? { 'x-compact-token': token } : {},
+    }),
+  );
+const daysAgo = (d: number) => new Date(Date.now() - d * 86400000).toISOString();
+
+beforeEach(() => {
+  rpcCalls.length = 0;
+  for (const k of Object.keys(rpcHandlers)) delete rpcHandlers[k];
+  bucket.put.mockReset().mockResolvedValue(undefined);
+  bucket.delete.mockReset();
+  ae.writeDataPoint.mockReset();
+  cfEnv = {
+    STATS_ARCHIVE_R2: bucket,
+    STATS_COMPACT_AE: ae,
+    STATS_COMPACT_TOKEN: 't',
+    STATS_COMPACT_ENABLED: 'true',
+  };
+  // default world: two users claimed, u1 has a big backlog, u2 nothing eligible
+  rpcHandlers['stat_archive_claim_users'] = () => ({ data: ['u1', 'u2'] });
+  rpcHandlers['stat_archive_candidate'] = ({ p_user }) => ({
+    data: [
+      p_user === 'u1'
+        ? { eligible: 600, oldest: daysAgo(40), hot_total: 700, archived_to: EPOCH }
+        : { eligible: 0, oldest: null, hot_total: 3, archived_to: EPOCH },
+    ],
+  });
+  rpcHandlers['stat_archive_rows'] = ({ p_user }) =>
+    p_user === 'u1'
+      ? {
+          data: [
+            dbRow('2026-07-01T00:00:00.123456+00:00', 1),
+            dbRow('2026-07-01T00:00:00.123456+00:00', 2),
+            dbRow('2026-07-01T00:00:01.5+00:00', 3),
+          ],
+        }
+      : { data: [] };
+  rpcHandlers['stat_archive_commit'] = ({ p_rows }) => ({ data: p_rows });
+});
+
+describe('POST /api/stats/compact guard', () => {
+  it('answers 503 when not enabled or not configured, 401 on a bad token', async () => {
+    cfEnv = { ...cfEnv, STATS_COMPACT_ENABLED: 'false' };
+    expect((await post()).status).toBe(503);
+    cfEnv = { STATS_COMPACT_TOKEN: 't', STATS_COMPACT_ENABLED: 'true' }; // no bucket
+    expect((await post()).status).toBe(503);
+    cfEnv = { STATS_ARCHIVE_R2: bucket, STATS_COMPACT_TOKEN: 't', STATS_COMPACT_ENABLED: 'true' };
+    expect((await post('wrong')).status).toBe(401);
+    expect((await post(null)).status).toBe(401);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/stats/compact run', () => {
+  it('archives eligible users: put object, commit exact range, report summary + AE point', async () => {
+    const res = await post();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      ok: true,
+      users_claimed: 2,
+      users_archived: 1,
+      segments: 1,
+      rows: 3,
+      errors: 0,
+      commit_mismatches: 0,
+    });
+    expect(body.bytes).toBeGreaterThan(0);
+
+    // claim + policy knobs
+    expect(rpcCalls[0]).toEqual({ fn: 'stat_archive_claim_users', args: { p_n: 50 } });
+    expect(rpcCalls.find((c) => c.fn === 'stat_archive_candidate')?.args).toEqual({
+      p_user: 'u1',
+      p_window: '7 days',
+    });
+    expect(rpcCalls.find((c) => c.fn === 'stat_archive_rows')?.args).toEqual({
+      p_user: 'u1',
+      p_from: EPOCH,
+      p_window: '7 days',
+      p_limit: 10000,
+    });
+    // u2 is not eligible: no rows fetched, no object written for it
+    expect(
+      rpcCalls.filter((c) => c.fn === 'stat_archive_rows' && c.args['p_user'] === 'u2'),
+    ).toHaveLength(0);
+
+    // the object: key by updated_to_ms, wire-shaped rows sorted, updated_at_ms from the DB timestamps (µs truncated)
+    expect(bucket.put).toHaveBeenCalledTimes(1);
+    const [key, bodyText, opts] = bucket.put.mock.calls[0]!;
+    const toMs = Date.parse('2026-07-01T00:00:01.500Z');
+    expect(key).toBe(`stats/v1/u1/${toMs}.json`);
+    expect(opts).toEqual({ httpMetadata: { contentType: 'application/json' } });
+    const seg = decodeSegment(bodyText as string);
+    expect(seg.user_id).toBe('u1');
+    expect(seg.updated_from_ms).toBe(0);
+    expect(seg.updated_to_ms).toBe(toMs);
+    expect(seg.rows.map((r) => [r.page, r.updated_at_ms])).toEqual([
+      [1, Date.parse('2026-07-01T00:00:00.123Z')],
+      [2, Date.parse('2026-07-01T00:00:00.123Z')],
+      [3, toMs],
+    ]);
+    expect(seg.rows[0]).not.toHaveProperty('user_id');
+    expect(seg.rows[0]).not.toHaveProperty('updated_at');
+
+    // the commit uses the exact DB timestamp of the last row (microsecond precision kept)
+    const commit = rpcCalls.find((c) => c.fn === 'stat_archive_commit')!;
+    expect(commit.args).toEqual({
+      p_user: 'u1',
+      p_key: key,
+      p_from: EPOCH,
+      p_to: '2026-07-01T00:00:01.5+00:00',
+      p_rows: 3,
+      p_bytes: new TextEncoder().encode(bodyText as string).length,
+    });
+    expect(bucket.delete).not.toHaveBeenCalled();
+
+    expect(ae.writeDataPoint).toHaveBeenCalledTimes(1);
+    const point = ae.writeDataPoint.mock.calls[0]![0];
+    expect(point.indexes).toEqual(['compact']);
+    expect(point.blobs[0]).toBe('ok');
+    expect(point.doubles.slice(0, 4)).toEqual([2, 1, 1, 3]);
+  });
+
+  it('chains segments for a big user, resuming each from the previous updated_to, bounded per run', async () => {
+    cfEnv = { ...cfEnv, STATS_COMPACT_SEGMENT_ROWS: '2', STATS_COMPACT_SEGMENTS_PER_USER: '3' };
+    let call = 0;
+    rpcHandlers['stat_archive_rows'] = ({ p_from }) => {
+      call++;
+      if (call === 1) {
+        expect(p_from).toBe(EPOCH);
+        return {
+          data: [dbRow('2026-07-01T00:00:00+00:00', 1), dbRow('2026-07-01T00:00:00+00:00', 2)],
+        };
+      }
+      if (call === 2) {
+        expect(p_from).toBe('2026-07-01T00:00:00+00:00');
+        return {
+          data: [dbRow('2026-07-02T00:00:00+00:00', 3), dbRow('2026-07-02T00:00:00+00:00', 4)],
+        };
+      }
+      expect(p_from).toBe('2026-07-02T00:00:00+00:00');
+      return { data: [] };
+    };
+    const body = await (await post()).json();
+    expect(body).toMatchObject({ segments: 2, rows: 4, users_archived: 1 });
+    expect(bucket.put).toHaveBeenCalledTimes(2);
+    expect(rpcCalls.filter((c) => c.fn === 'stat_archive_rows')).toHaveLength(3);
+  });
+
+  it('stops a user after the configured number of segments even when more remain', async () => {
+    cfEnv = { ...cfEnv, STATS_COMPACT_SEGMENT_ROWS: '1', STATS_COMPACT_SEGMENTS_PER_USER: '1' };
+    rpcHandlers['stat_archive_rows'] = () => ({ data: [dbRow('2026-07-01T00:00:00+00:00', 1)] });
+    const body = await (await post()).json();
+    expect(body).toMatchObject({ segments: 1, rows: 1 });
+    expect(rpcCalls.filter((c) => c.fn === 'stat_archive_rows')).toHaveLength(1);
+  });
+
+  it('applies the eligibility rules: min rows, max age, hot cap', async () => {
+    rpcHandlers['stat_archive_claim_users'] = () => ({ data: ['a', 'b', 'c', 'd'] });
+    rpcHandlers['stat_archive_candidate'] = ({ p_user }) => ({
+      data: [
+        {
+          a: { eligible: 10, oldest: daysAgo(10), hot_total: 100, archived_to: EPOCH }, // nothing applies
+          b: { eligible: 10, oldest: daysAgo(31), hot_total: 100, archived_to: EPOCH }, // max age
+          c: { eligible: 10, oldest: daysAgo(10), hot_total: 25000, archived_to: EPOCH }, // hot cap
+          d: { eligible: 500, oldest: daysAgo(8), hot_total: 600, archived_to: EPOCH }, // min rows
+        }[p_user as string],
+      ],
+    });
+    rpcHandlers['stat_archive_rows'] = () => ({ data: [dbRow('2026-07-01T00:00:00+00:00', 1)] });
+    const body = await (await post()).json();
+    expect(body).toMatchObject({ users_claimed: 4, users_archived: 3, segments: 3 });
+    const archivedUsers = rpcCalls
+      .filter((c) => c.fn === 'stat_archive_rows')
+      .map((c) => c.args['p_user']);
+    expect(archivedUsers).toEqual(['b', 'c', 'd']);
+  });
+
+  it('counts a delete-count mismatch without failing the run', async () => {
+    rpcHandlers['stat_archive_commit'] = () => ({ data: 2 });
+    const body = await (await post()).json();
+    expect(body).toMatchObject({ ok: true, segments: 1, commit_mismatches: 1, errors: 0 });
+  });
+
+  it('treats a lost CAS (40001) as a no-op and never deletes the object', async () => {
+    rpcHandlers['stat_archive_commit'] = () => ({
+      error: { code: '40001', message: 'stat_archive_commit: archived_to <> p_from' },
+    });
+    const body = await (await post()).json();
+    expect(body).toMatchObject({ ok: true, segments: 0, rows: 0, users_archived: 0, errors: 0 });
+    expect(bucket.delete).not.toHaveBeenCalled();
+  });
+
+  it('counts an R2 put failure as an error for that user and continues the run', async () => {
+    rpcHandlers['stat_archive_claim_users'] = () => ({ data: ['u1', 'u3'] });
+    rpcHandlers['stat_archive_candidate'] = () => ({
+      data: [{ eligible: 600, oldest: daysAgo(40), hot_total: 700, archived_to: EPOCH }],
+    });
+    rpcHandlers['stat_archive_rows'] = () => ({ data: [dbRow('2026-07-01T00:00:00+00:00', 1)] });
+    bucket.put.mockRejectedValueOnce(new Error('r2 down')).mockResolvedValue(undefined);
+    const res = await post();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      ok: true,
+      users_claimed: 2,
+      users_archived: 1,
+      errors: 1,
+    });
+    expect(rpcCalls.filter((c) => c.fn === 'stat_archive_commit')).toHaveLength(1);
+  });
+
+  it('returns 500 only when claiming users itself fails', async () => {
+    rpcHandlers['stat_archive_claim_users'] = () => ({ error: { message: 'db down' } });
+    const res = await post();
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ ok: false, error: 'db down' });
+    expect(ae.writeDataPoint.mock.calls[0]![0].blobs[0]).toBe('error');
+  });
+
+  it('is idempotent: a second run with nothing eligible archives nothing', async () => {
+    rpcHandlers['stat_archive_candidate'] = () => ({
+      data: [
+        { eligible: 0, oldest: null, hot_total: 5, archived_to: '2026-07-01T00:00:01.5+00:00' },
+      ],
+    });
+    const body = await (await post()).json();
+    expect(body).toMatchObject({ users_claimed: 2, users_archived: 0, segments: 0 });
+    expect(bucket.put).not.toHaveBeenCalled();
+  });
+
+  it('honors the env knobs for batch size and window', async () => {
+    cfEnv = { ...cfEnv, STATS_COMPACT_USERS_PER_RUN: '7', STATS_COMPACT_WINDOW_DAYS: '14' };
+    await post();
+    expect(rpcCalls[0]).toEqual({ fn: 'stat_archive_claim_users', args: { p_n: 7 } });
+    expect(rpcCalls.find((c) => c.fn === 'stat_archive_candidate')?.args['p_window']).toBe(
+      '14 days',
+    );
+  });
+});

--- a/apps/readest-app/src/__tests__/app/api/stats-restore-route.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/stats-restore-route.test.ts
@@ -8,23 +8,32 @@ import { encodeSegment, SEGMENT_VERSION, type ArchivedPageRow } from '@/libs/sta
 
 type Call = { table: string; method: string; args: unknown[] };
 const calls: Call[] = [];
+// Stateful manifest: selects honor `.range(from, to)` (PostgREST caps rows at
+// 1000 in production), deletes remove the row, so the route's "repeat until
+// empty" loop terminates the way it does against the real database.
 let manifestRows: Record<string, unknown>[] = [];
 const makeBuilder = (table: string) => {
-  const chain: string[] = [];
+  const chain: { method: string; args: unknown[] }[] = [];
   const builder: Record<string, unknown> = {};
   const rec =
     (method: string) =>
     (...args: unknown[]) => {
       calls.push({ table, method, args });
-      chain.push(method);
+      chain.push({ method, args });
       return builder;
     };
-  for (const m of ['select', 'delete', 'eq', 'order']) builder[m] = rec(m);
+  for (const m of ['select', 'delete', 'eq', 'order', 'range']) builder[m] = rec(m);
   // biome-ignore lint/suspicious/noThenProperty: mock PostgREST builder is intentionally thenable
-  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) =>
-    resolve(
-      chain.includes('delete') ? { data: null, error: null } : { data: manifestRows, error: null },
-    );
+  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) => {
+    if (chain.some((c) => c.method === 'delete')) {
+      const id = chain.find((c) => c.method === 'eq' && c.args[0] === 'id')?.args[1];
+      manifestRows = manifestRows.filter((m) => m['id'] !== id);
+      return resolve({ data: null, error: null });
+    }
+    const range = chain.find((c) => c.method === 'range')?.args as [number, number] | undefined;
+    const rows = range ? manifestRows.slice(range[0], range[1] + 1) : manifestRows.slice(0, 1000);
+    return resolve({ data: rows, error: null });
+  };
   return builder;
 };
 const fromMock = vi.fn((table: string) => makeBuilder(table));
@@ -155,5 +164,22 @@ describe('POST /api/stats/restore', () => {
       1,
     );
     expect(rpcMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores more manifest rows than one PostgREST page by reading until the manifest is empty', async () => {
+    const uid = '00000000-0000-0000-0000-000000000001';
+    manifestRows = Array.from({ length: 1001 }, (_, i) => ({
+      ...manifest(i + 1, 100 + i),
+      user_id: uid,
+    }));
+    bucket.get.mockImplementation(async () => objectOf([row(1, 1)]));
+
+    const res = await post({ user_id: uid });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ restored_segments: 1001, rows: 1001 });
+    expect(manifestRows).toHaveLength(0);
+    expect(
+      calls.filter((c) => c.table === 'stat_archives' && c.method === 'select').length,
+    ).toBeGreaterThanOrEqual(2);
   });
 });

--- a/apps/readest-app/src/__tests__/app/api/stats-restore-route.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/stats-restore-route.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { encodeSegment, SEGMENT_VERSION, type ArchivedPageRow } from '@/libs/statsArchive';
+
+// POST /api/stats/restore: rollback tool that re-inserts one user's archived
+// segments into stat_pages (through upsert_stat_pages_as, longest duration
+// wins) and removes the manifest rows. Only usable while compaction is
+// disabled, so it never races the compaction job.
+
+type Call = { table: string; method: string; args: unknown[] };
+const calls: Call[] = [];
+let manifestRows: Record<string, unknown>[] = [];
+const makeBuilder = (table: string) => {
+  const chain: string[] = [];
+  const builder: Record<string, unknown> = {};
+  const rec =
+    (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ table, method, args });
+      chain.push(method);
+      return builder;
+    };
+  for (const m of ['select', 'delete', 'eq', 'order']) builder[m] = rec(m);
+  // biome-ignore lint/suspicious/noThenProperty: mock PostgREST builder is intentionally thenable
+  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(
+      chain.includes('delete') ? { data: null, error: null } : { data: manifestRows, error: null },
+    );
+  return builder;
+};
+const fromMock = vi.fn((table: string) => makeBuilder(table));
+const rpcMock = vi.fn(async () => ({ data: 1, error: null }));
+vi.mock('@/utils/supabase', () => ({
+  createSupabaseAdminClient: () => ({ from: fromMock, rpc: rpcMock }),
+}));
+
+let cfEnv: Record<string, unknown> = {};
+vi.mock('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: () => ({ env: cfEnv }),
+}));
+
+import { POST } from '@/app/api/stats/restore/route';
+
+const bucket = { get: vi.fn(), put: vi.fn(), list: vi.fn(), delete: vi.fn() };
+const row = (updated_at_ms: number, page: number): ArchivedPageRow => ({
+  book_hash: 'h1',
+  page,
+  start_time: 1000 + page,
+  duration: 5,
+  total_pages: 10,
+  ext: null,
+  deleted_at: null,
+  updated_at_ms,
+});
+const objectOf = (rows: ArchivedPageRow[]) => {
+  const text = encodeSegment({
+    v: SEGMENT_VERSION,
+    user_id: 'u1',
+    updated_from_ms: 0,
+    updated_to_ms: rows.reduce((m, r) => Math.max(m, r.updated_at_ms), 0),
+    rows,
+  });
+  return { size: text.length, text: async () => text };
+};
+const manifest = (id: number, to_ms: number) => ({
+  id,
+  user_id: 'u1',
+  updated_from: new Date(0).toISOString(),
+  updated_to: new Date(to_ms).toISOString(),
+  row_count: 0,
+  bytes: 0,
+  object_key: `stats/v1/u1/${to_ms}.json`,
+});
+const post = (body: unknown, token: string | null = 't') =>
+  POST(
+    new Request('https://web.readest.com/api/stats/restore', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { 'x-compact-token': token } : {}),
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+
+beforeEach(() => {
+  calls.length = 0;
+  manifestRows = [];
+  fromMock.mockClear();
+  rpcMock.mockClear();
+  bucket.get.mockReset();
+  cfEnv = { STATS_ARCHIVE_R2: bucket, STATS_COMPACT_TOKEN: 't' }; // compaction disabled
+});
+
+describe('POST /api/stats/restore', () => {
+  it('guards: 503 without token/bucket, 401 on a bad token, 409 while compaction is enabled', async () => {
+    cfEnv = { STATS_COMPACT_TOKEN: 't' };
+    expect((await post({ user_id: 'u1' })).status).toBe(503);
+    cfEnv = { STATS_ARCHIVE_R2: bucket, STATS_COMPACT_TOKEN: 't' };
+    expect((await post({ user_id: 'u1' }, 'nope')).status).toBe(401);
+    cfEnv = { STATS_ARCHIVE_R2: bucket, STATS_COMPACT_TOKEN: 't', STATS_COMPACT_ENABLED: 'true' };
+    const res = await post({ user_id: 'u1' });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'disable compaction first' });
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing or malformed user_id with 400', async () => {
+    expect((await post({})).status).toBe(400);
+    expect((await post({ user_id: 'not-a-uuid' })).status).toBe(400);
+  });
+
+  it('re-inserts every segment in updated_to order, in 500-row chunks, then drops its manifest row', async () => {
+    const uid = '00000000-0000-0000-0000-000000000001';
+    manifestRows = [manifest(1, 300), manifest(2, 600)].map((m) => ({ ...m, user_id: uid }));
+    const big = Array.from({ length: 1200 }, (_, i) => row(400 + i, i));
+    bucket.get
+      .mockResolvedValueOnce(objectOf([row(100, 1), row(300, 2)]))
+      .mockResolvedValueOnce(objectOf(big));
+
+    const res = await post({ user_id: uid });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ restored_segments: 2, rows: 1202 });
+
+    const upserts = rpcMock.mock.calls as unknown as [
+      string,
+      { p_user: string; p_rows: unknown[] },
+    ][];
+    expect(upserts.map((c) => c[0])).toEqual(Array(4).fill('upsert_stat_pages_as'));
+    expect(upserts.map((c) => c[1].p_rows.length)).toEqual([2, 500, 500, 200]);
+    expect(upserts.every((c) => c[1].p_user === uid)).toBe(true);
+    expect(upserts[0]![1].p_rows[0]).toMatchObject({ book_hash: 'h1', page: 1, duration: 5 });
+
+    const deletes = calls.filter((c) => c.table === 'stat_archives' && c.method === 'delete');
+    expect(deletes).toHaveLength(2);
+    const idEqs = calls
+      .filter((c) => c.method === 'eq' && c.args[0] === 'id')
+      .map((c) => c.args[1]);
+    expect(idEqs).toEqual([1, 2]);
+    // manifest read in updated_to order
+    expect(calls.find((c) => c.method === 'order')?.args).toEqual([
+      'updated_to',
+      { ascending: true },
+    ]);
+  });
+
+  it('stops at the first unreadable object, keeping its manifest row, and reports where it stopped', async () => {
+    const uid = '00000000-0000-0000-0000-000000000001';
+    manifestRows = [manifest(1, 300), manifest(2, 600)].map((m) => ({ ...m, user_id: uid }));
+    bucket.get.mockResolvedValueOnce(objectOf([row(100, 1)])).mockResolvedValueOnce(null);
+
+    const res = await post({ user_id: uid });
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ restored_segments: 1, failed_manifest_id: 2 });
+    expect(calls.filter((c) => c.table === 'stat_archives' && c.method === 'delete')).toHaveLength(
+      1,
+    );
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/readest-app/src/__tests__/libs/statsArchive.test.ts
+++ b/apps/readest-app/src/__tests__/libs/statsArchive.test.ts
@@ -143,6 +143,22 @@ describe('guardArchiveRequest', () => {
     expect(guardArchiveRequest(req('t'), env, 'compact')).toMatchObject({ ok: true });
   });
 
+  it('targeted runs need token + bucket but ignore the enabled flag', () => {
+    const base = { STATS_COMPACT_TOKEN: 't', STATS_ARCHIVE_R2: bucket };
+    expect(guardArchiveRequest(req('t'), base, 'targeted')).toMatchObject({ ok: true });
+    expect(
+      guardArchiveRequest(req('t'), { ...base, STATS_COMPACT_ENABLED: 'true' }, 'targeted'),
+    ).toMatchObject({ ok: true });
+    expect(guardArchiveRequest(req('x'), base, 'targeted')).toMatchObject({
+      ok: false,
+      status: 401,
+    });
+    expect(guardArchiveRequest(req('t'), { STATS_ARCHIVE_R2: bucket }, 'targeted')).toMatchObject({
+      ok: false,
+      status: 503,
+    });
+  });
+
   it('restore works while compaction is disabled and refuses with 409 while it is enabled', () => {
     const base = { STATS_COMPACT_TOKEN: 't', STATS_ARCHIVE_R2: bucket };
     expect(guardArchiveRequest(req('t'), base, 'restore')).toMatchObject({ ok: true });

--- a/apps/readest-app/src/__tests__/libs/statsArchive.test.ts
+++ b/apps/readest-app/src/__tests__/libs/statsArchive.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SEGMENT_VERSION,
+  segmentKey,
+  encodeSegment,
+  decodeSegment,
+  takePage,
+  guardArchiveRequest,
+  readCompactConfig,
+  tsToMs,
+  type ArchivedPageRow,
+  type StatsSegment,
+} from '@/libs/statsArchive';
+
+describe('tsToMs', () => {
+  it('parses PostgREST timestamptz strings, truncating microseconds to the millisecond', () => {
+    expect(tsToMs('2026-07-01T00:00:00.123456+00:00')).toBe(Date.parse('2026-07-01T00:00:00.123Z'));
+    expect(tsToMs('2026-07-01T00:00:01.5+00:00')).toBe(Date.parse('2026-07-01T00:00:01.500Z'));
+    expect(tsToMs('1970-01-01T00:00:00+00:00')).toBe(0);
+    expect(tsToMs('2026-07-01T02:00:00.999999+02:00')).toBe(Date.parse('2026-07-01T00:00:00.999Z'));
+  });
+});
+
+const row = (updated_at_ms: number, over: Partial<ArchivedPageRow> = {}): ArchivedPageRow => ({
+  book_hash: 'h1',
+  page: 1,
+  start_time: updated_at_ms,
+  duration: 5,
+  total_pages: 10,
+  ext: null,
+  deleted_at: null,
+  updated_at_ms,
+  ...over,
+});
+
+const segment = (rows: ArchivedPageRow[]): StatsSegment => ({
+  v: SEGMENT_VERSION,
+  user_id: 'u1',
+  updated_from_ms: 0,
+  updated_to_ms: rows.reduce((m, r) => Math.max(m, r.updated_at_ms), 0),
+  rows,
+});
+
+describe('statsArchive segment codec', () => {
+  it('names objects by user and updated_to_ms', () => {
+    expect(segmentKey('u1', 1787454881000)).toBe('stats/v1/u1/1787454881000.json');
+  });
+
+  it('round-trips a segment with a stable key order and sorted rows', () => {
+    const text = encodeSegment(segment([row(200), row(100, { ext: { src: 'tts' } })]));
+    // rows sorted by (updated_at_ms, book_hash, page, start_time); keys in wire order
+    expect(text).toBe(
+      '{"v":1,"user_id":"u1","updated_from_ms":0,"updated_to_ms":200,"rows":[' +
+        '{"book_hash":"h1","page":1,"start_time":100,"duration":5,"total_pages":10,"ext":{"src":"tts"},"deleted_at":null,"updated_at_ms":100},' +
+        '{"book_hash":"h1","page":1,"start_time":200,"duration":5,"total_pages":10,"ext":null,"deleted_at":null,"updated_at_ms":200}]}',
+    );
+    const back = decodeSegment(text);
+    expect(back.rows.map((r) => r.updated_at_ms)).toEqual([100, 200]);
+    expect(back.rows[0]!.ext).toEqual({ src: 'tts' });
+  });
+
+  it('rejects unknown versions and malformed rows', () => {
+    expect(() =>
+      decodeSegment('{"v":2,"user_id":"u1","updated_from_ms":0,"updated_to_ms":1,"rows":[]}'),
+    ).toThrow(/version/);
+    expect(() =>
+      decodeSegment(
+        '{"v":1,"user_id":"u1","updated_from_ms":0,"updated_to_ms":1,"rows":[{"page":1}]}',
+      ),
+    ).toThrow(/row/);
+    expect(() => decodeSegment('not json')).toThrow();
+  });
+});
+
+describe('takePage', () => {
+  const rows = [
+    row(100),
+    row(200),
+    row(300, { page: 1 }),
+    row(300, { page: 2 }),
+    row(300, { page: 3 }),
+    row(400),
+  ];
+
+  it('returns rows strictly after since, up to limit, extended to the trailing millisecond', () => {
+    // limit 2 from since=100 -> 200, 300(p1); 300 has ties -> include all of 300
+    expect(takePage(rows, 100, 2).map((r) => [r.updated_at_ms, r.page])).toEqual([
+      [200, 1],
+      [300, 1],
+      [300, 2],
+      [300, 3],
+    ]);
+  });
+
+  it('honors the book filter and returns an empty page when nothing matches', () => {
+    expect(takePage(rows, 0, 10, 'other')).toEqual([]);
+    expect(takePage(rows, 0, 10, 'h1')).toHaveLength(6);
+    expect(takePage(rows, 400, 10)).toEqual([]);
+  });
+
+  it('returns everything after since when limit is 0 (unpaginated)', () => {
+    expect(takePage(rows, 200, 0).map((r) => r.updated_at_ms)).toEqual([300, 300, 300, 400]);
+  });
+});
+
+describe('guardArchiveRequest', () => {
+  const bucket = {} as never;
+  const req = (token?: string) =>
+    new Request('https://web.readest.com/api/stats/compact', {
+      method: 'POST',
+      headers: token ? { 'x-compact-token': token } : {},
+    });
+
+  it('reports 503 before 401 when the feature is not configured', () => {
+    expect(guardArchiveRequest(req('t'), {}, 'compact')).toMatchObject({ ok: false, status: 503 });
+    expect(
+      guardArchiveRequest(
+        req('t'),
+        { STATS_COMPACT_TOKEN: 't', STATS_ARCHIVE_R2: bucket },
+        'compact',
+      ),
+    ).toMatchObject({ ok: false, status: 503 }); // not enabled
+    expect(
+      guardArchiveRequest(
+        req('t'),
+        { STATS_COMPACT_TOKEN: 't', STATS_COMPACT_ENABLED: 'true' },
+        'compact',
+      ),
+    ).toMatchObject({ ok: false, status: 503 }); // no bucket
+  });
+
+  it('rejects a wrong token with 401 and accepts the right one', () => {
+    const env = {
+      STATS_COMPACT_TOKEN: 't',
+      STATS_COMPACT_ENABLED: 'true',
+      STATS_ARCHIVE_R2: bucket,
+    };
+    expect(guardArchiveRequest(req('nope'), env, 'compact')).toMatchObject({
+      ok: false,
+      status: 401,
+    });
+    expect(guardArchiveRequest(req(), env, 'compact')).toMatchObject({ ok: false, status: 401 });
+    expect(guardArchiveRequest(req('t'), env, 'compact')).toMatchObject({ ok: true });
+  });
+
+  it('restore works while compaction is disabled and refuses with 409 while it is enabled', () => {
+    const base = { STATS_COMPACT_TOKEN: 't', STATS_ARCHIVE_R2: bucket };
+    expect(guardArchiveRequest(req('t'), base, 'restore')).toMatchObject({ ok: true });
+    expect(
+      guardArchiveRequest(req('t'), { ...base, STATS_COMPACT_ENABLED: 'true' }, 'restore'),
+    ).toMatchObject({ ok: false, status: 409 });
+    expect(guardArchiveRequest(req('x'), base, 'restore')).toMatchObject({
+      ok: false,
+      status: 401,
+    });
+    expect(guardArchiveRequest(req('t'), { STATS_COMPACT_TOKEN: 't' }, 'restore')).toMatchObject({
+      ok: false,
+      status: 503,
+    });
+  });
+});
+
+describe('readCompactConfig', () => {
+  it('uses the documented defaults', () => {
+    expect(readCompactConfig({})).toEqual({
+      usersPerRun: 50,
+      windowDays: 7,
+      minRows: 500,
+      maxAgeDays: 30,
+      hotCap: 20000,
+      segmentsPerUser: 5,
+      segmentRows: 10000,
+    });
+  });
+
+  it('accepts integer overrides and falls back on garbage or out-of-range values', () => {
+    expect(
+      readCompactConfig({
+        STATS_COMPACT_USERS_PER_RUN: '10',
+        STATS_COMPACT_WINDOW_DAYS: '14',
+        STATS_COMPACT_MIN_ROWS: 'abc',
+        STATS_COMPACT_MAX_AGE_DAYS: '0',
+        STATS_COMPACT_HOT_CAP: '-5',
+        STATS_COMPACT_SEGMENTS_PER_USER: '2',
+        STATS_COMPACT_SEGMENT_ROWS: '2.5',
+      }),
+    ).toEqual({
+      usersPerRun: 10,
+      windowDays: 14,
+      minRows: 500,
+      maxAgeDays: 30,
+      hotCap: 20000,
+      segmentsPerUser: 2,
+      segmentRows: 10000,
+    });
+  });
+});

--- a/apps/readest-app/src/__tests__/libs/statsArchive.test.ts
+++ b/apps/readest-app/src/__tests__/libs/statsArchive.test.ts
@@ -6,6 +6,7 @@ import {
   decodeSegment,
   takePage,
   guardArchiveRequest,
+  isCompactionEnabled,
   readCompactConfig,
   tsToMs,
   type ArchivedPageRow,
@@ -113,13 +114,10 @@ describe('guardArchiveRequest', () => {
 
   it('reports 503 before 401 when the feature is not configured', () => {
     expect(guardArchiveRequest(req('t'), {}, 'compact')).toMatchObject({ ok: false, status: 503 });
-    expect(
-      guardArchiveRequest(
-        req('t'),
-        { STATS_COMPACT_TOKEN: 't', STATS_ARCHIVE_R2: bucket },
-        'compact',
-      ),
-    ).toMatchObject({ ok: false, status: 503 }); // not enabled
+    expect(guardArchiveRequest(req('x'), { STATS_ARCHIVE_R2: bucket }, 'compact')).toMatchObject({
+      ok: false,
+      status: 503,
+    }); // no token: 503 even with a wrong header
     expect(
       guardArchiveRequest(
         req('t'),
@@ -129,34 +127,20 @@ describe('guardArchiveRequest', () => {
     ).toMatchObject({ ok: false, status: 503 }); // no bucket
   });
 
-  it('rejects a wrong token with 401 and accepts the right one', () => {
-    const env = {
-      STATS_COMPACT_TOKEN: 't',
-      STATS_COMPACT_ENABLED: 'true',
-      STATS_ARCHIVE_R2: bucket,
-    };
-    expect(guardArchiveRequest(req('nope'), env, 'compact')).toMatchObject({
-      ok: false,
-      status: 401,
-    });
-    expect(guardArchiveRequest(req(), env, 'compact')).toMatchObject({ ok: false, status: 401 });
-    expect(guardArchiveRequest(req('t'), env, 'compact')).toMatchObject({ ok: true });
-  });
-
-  it('targeted runs need token + bucket but ignore the enabled flag', () => {
+  it('rejects a wrong token with 401 and accepts the right one, whether or not compaction is enabled', () => {
     const base = { STATS_COMPACT_TOKEN: 't', STATS_ARCHIVE_R2: bucket };
-    expect(guardArchiveRequest(req('t'), base, 'targeted')).toMatchObject({ ok: true });
-    expect(
-      guardArchiveRequest(req('t'), { ...base, STATS_COMPACT_ENABLED: 'true' }, 'targeted'),
-    ).toMatchObject({ ok: true });
-    expect(guardArchiveRequest(req('x'), base, 'targeted')).toMatchObject({
-      ok: false,
-      status: 401,
-    });
-    expect(guardArchiveRequest(req('t'), { STATS_ARCHIVE_R2: bucket }, 'targeted')).toMatchObject({
-      ok: false,
-      status: 503,
-    });
+    for (const env of [base, { ...base, STATS_COMPACT_ENABLED: 'true' }]) {
+      expect(guardArchiveRequest(req('nope'), env, 'compact')).toMatchObject({
+        ok: false,
+        status: 401,
+      });
+      expect(guardArchiveRequest(req(), env, 'compact')).toMatchObject({ ok: false, status: 401 });
+      expect(guardArchiveRequest(req('t'), env, 'compact')).toMatchObject({ ok: true });
+    }
+    // the kill switch is the route's business, not the guard's
+    expect(isCompactionEnabled(base)).toBe(false);
+    expect(isCompactionEnabled({ ...base, STATS_COMPACT_ENABLED: 'true' })).toBe(true);
+    expect(isCompactionEnabled({ ...base, STATS_COMPACT_ENABLED: 'TRUE' })).toBe(false);
   });
 
   it('restore works while compaction is disabled and refuses with 409 while it is enabled', () => {
@@ -209,5 +193,14 @@ describe('readCompactConfig', () => {
       segmentsPerUser: 2,
       segmentRows: 10000,
     });
+  });
+
+  it('falls back on digit strings beyond the safe integer range', () => {
+    expect(
+      readCompactConfig({
+        STATS_COMPACT_SEGMENT_ROWS: '99999999999999999999',
+        STATS_COMPACT_USERS_PER_RUN: '9007199254740993',
+      }),
+    ).toMatchObject({ segmentRows: 10000, usersPerRun: 50 });
   });
 });

--- a/apps/readest-app/src/__tests__/pages/api/sync-stats-archive-pull.test.ts
+++ b/apps/readest-app/src/__tests__/pages/api/sync-stats-archive-pull.test.ts
@@ -12,20 +12,33 @@ type Call = { table: string; method: string; args: unknown[] };
 const calls: Call[] = [];
 const tableData: Record<string, unknown[]> = {};
 
+// The mock applies the query constraints the handler relies on: `.eq(col, v)`
+// on any column the fixture rows carry (book_hash, user_id) and `.gt(col, v)`
+// on ISO timestamp columns (updated_at / updated_to), so a test cannot pass
+// only because the database would have filtered for it.
 const makeBuilder = (table: string) => {
+  const chain: { method: string; args: unknown[] }[] = [];
   const builder: Record<string, unknown> = {};
   const rec =
     (method: string) =>
     (...args: unknown[]) => {
       calls.push({ table, method, args });
+      chain.push({ method, args });
       return builder;
     };
   for (const m of ['select', 'eq', 'or', 'gt', 'lt', 'in', 'is', 'order', 'range']) {
     builder[m] = rec(m);
   }
   // biome-ignore lint/suspicious/noThenProperty: mock PostgREST builder is intentionally thenable
-  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) =>
-    resolve({ data: tableData[table] ?? [], error: null });
+  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) => {
+    let rows = (tableData[table] ?? []) as Record<string, unknown>[];
+    for (const c of chain) {
+      const [col, val] = c.args as [string, unknown];
+      if (c.method === 'eq') rows = rows.filter((r) => !(col in r) || r[col] === val);
+      if (c.method === 'gt') rows = rows.filter((r) => !(col in r) || String(r[col]) > String(val));
+    }
+    return resolve({ data: rows, error: null });
+  };
   return builder;
 };
 const fromMock = vi.fn((table: string) => makeBuilder(table));
@@ -192,13 +205,42 @@ describe('GET /api/sync?type=stats with archived segments', () => {
       doubles: [2, 4, 0],
     });
 
-    bucket.get.mockResolvedValueOnce(objectOf([seg(100), seg(300)]));
+    bucket.get
+      .mockResolvedValueOnce(objectOf([seg(100), seg(300)]))
+      .mockResolvedValueOnce(objectOf([seg(400), seg(600)]));
     await GET(req('type=stats&since=0&limit=1000'));
     expect(ae.writeDataPoint.mock.calls[1]![0]).toEqual({
       indexes: ['pull'],
       blobs: ['paged'],
-      doubles: [1, 2, 1000],
+      doubles: [2, 4, 1000],
     });
+  });
+
+  it('fills a paged response across tiers: short archive pages are topped up with hot rows', async () => {
+    // one archived row, one newer hot row, limit 2: both come back in one page,
+    // so a client that stops on a short page (the koplugin) never stalls on the
+    // tier boundary
+    tableData['stat_archives'] = [manifest(1, 100)];
+    tableData['stat_pages'] = [hot(900), hot(901, 51)];
+    bucket.get.mockResolvedValue(objectOf([seg(100)]));
+    const rows = await pagesOf(await GET(req('type=stats&since=0&limit=2')));
+    expect(rows.map((r) => r.updated_at_ms)).toEqual([100, 900]);
+
+    // several short segments are read until the page is full, then cut with ties
+    tableData['stat_archives'] = [manifest(1, 100), manifest(2, 300, 100), manifest(3, 600, 300)];
+    tableData['stat_pages'] = [hot(900)];
+    bucket.get
+      .mockResolvedValueOnce(objectOf([seg(100)]))
+      .mockResolvedValueOnce(objectOf([seg(200), seg(300, 1), seg(300, 2)]))
+      .mockResolvedValueOnce(objectOf([seg(600)]));
+    const page = await pagesOf(await GET(req('type=stats&since=0&limit=3')));
+    expect(page.map((r) => [r.updated_at_ms, r.page])).toEqual([
+      [100, 1],
+      [200, 1],
+      [300, 1],
+      [300, 2],
+    ]);
+    expect(bucket.get).toHaveBeenCalledTimes(3); // the third segment was never needed
   });
 
   it('answers 500 without advancing when a segment object is missing or corrupt', async () => {

--- a/apps/readest-app/src/__tests__/pages/api/sync-stats-archive-pull.test.ts
+++ b/apps/readest-app/src/__tests__/pages/api/sync-stats-archive-pull.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextRequest } from 'next/server';
+import { encodeSegment, SEGMENT_VERSION, type ArchivedPageRow } from '@/libs/statsArchive';
+
+// Page events older than the hot window live in immutable R2 segments listed
+// in `stat_archives` (migration 020). The stats pull composes its response
+// server-side: segments in updated_to order first, then hot rows, so the
+// client-visible contract (rows with updated_at > since, ordered by updated_at,
+// paged by `limit` with the trailing millisecond completed) is unchanged.
+
+type Call = { table: string; method: string; args: unknown[] };
+const calls: Call[] = [];
+const tableData: Record<string, unknown[]> = {};
+
+const makeBuilder = (table: string) => {
+  const builder: Record<string, unknown> = {};
+  const rec =
+    (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ table, method, args });
+      return builder;
+    };
+  for (const m of ['select', 'eq', 'or', 'gt', 'lt', 'in', 'is', 'order', 'range']) {
+    builder[m] = rec(m);
+  }
+  // biome-ignore lint/suspicious/noThenProperty: mock PostgREST builder is intentionally thenable
+  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve({ data: tableData[table] ?? [], error: null });
+  return builder;
+};
+const fromMock = vi.fn((table: string) => makeBuilder(table));
+
+const bucket = { get: vi.fn(), put: vi.fn(), list: vi.fn(), delete: vi.fn() };
+let cfEnv: Record<string, unknown> = {};
+
+vi.mock('@/utils/supabase', () => ({
+  createSupabaseClient: () => ({ from: fromMock }),
+}));
+vi.mock('@/utils/access', () => ({
+  validateUserAndToken: async () => ({ user: { id: 'u1' }, token: 'tok' }),
+}));
+vi.mock('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: () => ({ env: cfEnv }),
+}));
+
+import { GET } from '@/pages/api/sync';
+
+const req = (qs: string) =>
+  new Request(`https://web.readest.com/api/sync?${qs}`, {
+    headers: { authorization: 'Bearer tok' },
+  }) as unknown as NextRequest;
+
+const seg = (updated_at_ms: number, page = 1, book_hash = 'h1'): ArchivedPageRow => ({
+  book_hash,
+  page,
+  start_time: updated_at_ms,
+  duration: 5,
+  total_pages: 10,
+  ext: null,
+  deleted_at: null,
+  updated_at_ms,
+});
+const hot = (updated_at_ms: number, page = 50) => ({
+  user_id: 'u1',
+  book_hash: 'h1',
+  page,
+  start_time: updated_at_ms,
+  duration: 5,
+  total_pages: 10,
+  ext: null,
+  deleted_at: null,
+  updated_at: new Date(updated_at_ms).toISOString(),
+});
+const manifest = (id: number, to_ms: number, from_ms = 0) => ({
+  id,
+  user_id: 'u1',
+  updated_from: new Date(from_ms).toISOString(),
+  updated_to: new Date(to_ms).toISOString(),
+  row_count: 0,
+  bytes: 0,
+  object_key: `stats/v1/u1/${to_ms}.json`,
+});
+const objectOf = (rows: ArchivedPageRow[]) => {
+  const text = encodeSegment({
+    v: SEGMENT_VERSION,
+    user_id: 'u1',
+    updated_from_ms: 0,
+    updated_to_ms: rows.reduce((m, r) => Math.max(m, r.updated_at_ms), 0),
+    rows,
+  });
+  return { size: text.length, text: async () => text };
+};
+const pagesOf = async (res: Response) =>
+  ((await res.json()) as { statPages: { updated_at_ms: number; page: number }[] }).statPages;
+
+beforeEach(() => {
+  calls.length = 0;
+  fromMock.mockClear();
+  for (const k of Object.keys(tableData)) delete tableData[k];
+  bucket.get.mockReset();
+  cfEnv = { STATS_ARCHIVE_R2: bucket };
+});
+
+describe('GET /api/sync?type=stats with archived segments', () => {
+  it('returns hot rows only, without touching R2, when the user has no segments', async () => {
+    tableData['stat_pages'] = [hot(900)];
+    const res = await GET(req('type=stats&since=0&limit=1000'));
+    expect(res.status).toBe(200);
+    expect((await pagesOf(res)).map((r) => r.updated_at_ms)).toEqual([900]);
+    expect(bucket.get).not.toHaveBeenCalled();
+    // the manifest is filtered server-side to updated_to > since
+    const gt = calls.find((c) => c.table === 'stat_archives' && c.method === 'gt');
+    expect(gt?.args).toEqual(['updated_to', new Date(0).toISOString()]);
+  });
+
+  it('serves segment rows before hot rows, paged with the trailing millisecond completed', async () => {
+    tableData['stat_archives'] = [manifest(1, 300)];
+    tableData['stat_pages'] = [hot(900)];
+    bucket.get.mockResolvedValue(
+      objectOf([seg(100), seg(200), seg(300, 1), seg(300, 2), seg(300, 3)]),
+    );
+
+    const p1 = await pagesOf(await GET(req('type=stats&since=0&limit=2')));
+    expect(p1.map((r) => r.updated_at_ms)).toEqual([100, 200]);
+    expect(p1[0]).toMatchObject({
+      user_id: 'u1',
+      book_hash: 'h1',
+      updated_at: new Date(100).toISOString(),
+    });
+
+    const p2 = await pagesOf(await GET(req('type=stats&since=200&limit=2')));
+    expect(p2.map((r) => [r.updated_at_ms, r.page])).toEqual([
+      [300, 1],
+      [300, 2],
+      [300, 3],
+    ]);
+
+    // segment exhausted -> hot rows (the manifest query still runs; the DB would
+    // filter this segment out by updated_to > since, mirrored here)
+    tableData['stat_archives'] = [];
+    const p3 = await pagesOf(await GET(req('type=stats&since=300&limit=2')));
+    expect(p3.map((r) => r.updated_at_ms)).toEqual([900]);
+  });
+
+  it('queries hot rows before the manifest (a commit in between can only duplicate, never lose)', async () => {
+    tableData['stat_archives'] = [manifest(1, 300)];
+    bucket.get.mockResolvedValue(objectOf([seg(100)]));
+    await GET(req('type=stats&since=0&limit=1000'));
+    const firstHot = calls.findIndex((c) => c.table === 'stat_pages');
+    const firstManifest = calls.findIndex((c) => c.table === 'stat_archives');
+    expect(firstHot).toBeGreaterThanOrEqual(0);
+    expect(firstManifest).toBeGreaterThan(firstHot);
+  });
+
+  it('skips segments emptied by the book filter and falls through to hot rows', async () => {
+    tableData['stat_archives'] = [manifest(1, 300), manifest(2, 600, 300)];
+    tableData['stat_pages'] = [hot(900)];
+    bucket.get
+      .mockResolvedValueOnce(objectOf([seg(100, 1, 'h1')]))
+      .mockResolvedValueOnce(objectOf([seg(500, 1, 'h2')]));
+    const rows = await pagesOf(await GET(req('type=stats&since=0&limit=1000&book=h2')));
+    expect(rows.map((r) => r.updated_at_ms)).toEqual([500]);
+    expect(bucket.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('concatenates every segment and then hot rows for the legacy unpaginated pull', async () => {
+    tableData['stat_archives'] = [manifest(1, 300), manifest(2, 600, 300)];
+    tableData['stat_pages'] = [hot(900)];
+    bucket.get
+      .mockResolvedValueOnce(objectOf([seg(100), seg(300)]))
+      .mockResolvedValueOnce(objectOf([seg(400), seg(600)]));
+    const rows = await pagesOf(await GET(req('type=stats&since=0')));
+    expect(rows.map((r) => r.updated_at_ms)).toEqual([100, 300, 400, 600, 900]);
+  });
+
+  it('answers 500 without advancing when a segment object is missing or corrupt', async () => {
+    tableData['stat_archives'] = [manifest(7, 300)];
+    bucket.get.mockResolvedValueOnce(null);
+    let res = await GET(req('type=stats&since=0&limit=1000'));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/archive segment 7 unavailable/);
+
+    bucket.get.mockResolvedValueOnce({ size: 3, text: async () => '{"v":9}' });
+    res = await GET(req('type=stats&since=0&limit=1000'));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/archive segment 7 unavailable/);
+
+    cfEnv = {}; // manifest rows but no binding: misconfiguration, same answer
+    res = await GET(req('type=stats&since=0&limit=1000'));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/archive segment 7 unavailable/);
+  });
+});

--- a/apps/readest-app/src/__tests__/pages/api/sync-stats-archive-pull.test.ts
+++ b/apps/readest-app/src/__tests__/pages/api/sync-stats-archive-pull.test.ts
@@ -37,6 +37,10 @@ const makeBuilder = (table: string) => {
       if (c.method === 'eq') rows = rows.filter((r) => !(col in r) || r[col] === val);
       if (c.method === 'gt') rows = rows.filter((r) => !(col in r) || String(r[col]) > String(val));
     }
+    const range = chain.find((c) => c.method === 'range')?.args as [number, number] | undefined;
+    if (range) rows = rows.slice(range[0], range[1] + 1);
+    // PostgREST also caps un-ranged responses (Supabase db-max-rows = 1000)
+    else rows = rows.slice(0, 1000);
     return resolve({ data: rows, error: null });
   };
   return builder;
@@ -241,6 +245,39 @@ describe('GET /api/sync?type=stats with archived segments', () => {
       [300, 2],
     ]);
     expect(bucket.get).toHaveBeenCalledTimes(3); // the third segment was never needed
+  });
+
+  it('reads past the 1000-row manifest page cap instead of treating the first page as complete', async () => {
+    // 1001 single-row segments plus a hot row. The unpaginated pull must return
+    // all 1001 archived rows before the hot one; treating the capped first page
+    // as complete would let a cursor advance past the 1001st segment's rows.
+    tableData['stat_archives'] = Array.from({ length: 1001 }, (_, i) => manifest(i + 1, 100 + i));
+    tableData['stat_pages'] = [hot(90000)];
+    bucket.get.mockImplementation(async (key: string) => {
+      const toMs = Number(/\/(\d+)\.json$/.exec(key)![1]);
+      return objectOf([seg(toMs)]);
+    });
+    const rows = await pagesOf(await GET(req('type=stats&since=0')));
+    expect(rows).toHaveLength(1002);
+    expect(rows[0]!.updated_at_ms).toBe(100);
+    expect(rows[1000]!.updated_at_ms).toBe(1100);
+    expect(rows[1001]!.updated_at_ms).toBe(90000);
+    expect(bucket.get).toHaveBeenCalledTimes(1001);
+    // two manifest pages were requested
+    const ranges = calls.filter((c) => c.table === 'stat_archives' && c.method === 'range');
+    expect(ranges.map((c) => c.args)).toEqual([
+      [0, 999],
+      [1000, 1999],
+    ]);
+
+    // a paged pull that fills inside the first manifest page never asks for the second
+    calls.length = 0;
+    bucket.get.mockClear();
+    const page = await pagesOf(await GET(req('type=stats&since=0&limit=2')));
+    expect(page.map((r) => r.updated_at_ms)).toEqual([100, 101]);
+    expect(calls.filter((c) => c.table === 'stat_archives' && c.method === 'range')).toHaveLength(
+      1,
+    );
   });
 
   it('answers 500 without advancing when a segment object is missing or corrupt', async () => {

--- a/apps/readest-app/src/__tests__/pages/api/sync-stats-archive-pull.test.ts
+++ b/apps/readest-app/src/__tests__/pages/api/sync-stats-archive-pull.test.ts
@@ -173,6 +173,34 @@ describe('GET /api/sync?type=stats with archived segments', () => {
     expect(rows.map((r) => r.updated_at_ms)).toEqual([100, 300, 400, 600, 900]);
   });
 
+  it('records one Analytics Engine point per R2-backed pull, none for hot-only pulls', async () => {
+    const ae = { writeDataPoint: vi.fn() };
+    cfEnv = { STATS_ARCHIVE_R2: bucket, STATS_COMPACT_AE: ae };
+    tableData['stat_pages'] = [hot(900)];
+    await GET(req('type=stats&since=0&limit=1000'));
+    expect(ae.writeDataPoint).not.toHaveBeenCalled();
+
+    tableData['stat_archives'] = [manifest(1, 300), manifest(2, 600, 300)];
+    bucket.get
+      .mockResolvedValueOnce(objectOf([seg(100), seg(300)]))
+      .mockResolvedValueOnce(objectOf([seg(400), seg(600)]));
+    await GET(req('type=stats&since=0'));
+    expect(ae.writeDataPoint).toHaveBeenCalledTimes(1);
+    expect(ae.writeDataPoint.mock.calls[0]![0]).toEqual({
+      indexes: ['pull'],
+      blobs: ['full'],
+      doubles: [2, 4, 0],
+    });
+
+    bucket.get.mockResolvedValueOnce(objectOf([seg(100), seg(300)]));
+    await GET(req('type=stats&since=0&limit=1000'));
+    expect(ae.writeDataPoint.mock.calls[1]![0]).toEqual({
+      indexes: ['pull'],
+      blobs: ['paged'],
+      doubles: [1, 2, 1000],
+    });
+  });
+
   it('answers 500 without advancing when a segment object is missing or corrupt', async () => {
     tableData['stat_archives'] = [manifest(7, 300)];
     bucket.get.mockResolvedValueOnce(null);

--- a/apps/readest-app/src/__tests__/pages/api/user-delete-stats-archive.test.ts
+++ b/apps/readest-app/src/__tests__/pages/api/user-delete-stats-archive.test.ts
@@ -3,13 +3,15 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 // DELETE /api/user/delete must also remove the user's reading-statistics
 // archive objects in R2 (stats/v1/{user_id}/...). Postgres rows cascade with
-// the auth user; R2 objects do not. The identity goes first (deleting objects
-// before a failed deleteUser would leave an active account with its history
-// gone); then the user id is queued in stat_archive_orphans for the compaction
-// job's sweep and the prefix is deleted right away, best-effort.
+// the auth user; R2 objects do not. Order: (1) queue the user id in
+// stat_archive_orphans as a durable tombstone (500 before anything destructive
+// if even that fails), (2) delete the identity (compensating the tombstone if
+// that fails; the compaction sweep also skips living users), (3) delete the
+// prefix immediately, best-effort; the tombstone makes the cleanup reliable.
 
 const deleteUserMock = vi.fn();
 const orphanUpsertMock = vi.fn();
+const orphanDeleteEqMock = vi.fn();
 vi.mock('@/utils/cors', () => ({
   corsAllMethods: {},
   runMiddleware: vi.fn().mockResolvedValue(undefined),
@@ -22,6 +24,7 @@ vi.mock('@/utils/supabase', () => ({
     auth: { admin: { deleteUser: deleteUserMock } },
     from: (table: string) => ({
       upsert: (...a: unknown[]) => orphanUpsertMock(table, ...a),
+      delete: () => ({ eq: (...a: unknown[]) => orphanDeleteEqMock(table, ...a) }),
     }),
   }),
 }));
@@ -66,6 +69,10 @@ beforeEach(() => {
     events.push(`queue:${table}`);
     return { error: null };
   });
+  orphanDeleteEqMock.mockReset().mockImplementation(async (table: string) => {
+    events.push(`unqueue:${table}`);
+    return { error: null };
+  });
   bucket.list.mockReset().mockResolvedValue({ objects: [], truncated: false });
   bucket.delete.mockReset().mockImplementation(async (keys: string[]) => {
     events.push(`delete:${keys.join(',')}`);
@@ -74,7 +81,7 @@ beforeEach(() => {
 });
 
 describe('DELETE /api/user/delete stats archive cleanup', () => {
-  it('deletes the user first, then queues the id for the sweep and deletes the prefix (paginated listing)', async () => {
+  it('queues the tombstone, deletes the user, then deletes the prefix (paginated listing)', async () => {
     bucket.list
       .mockResolvedValueOnce({
         objects: [{ key: 'stats/v1/u1/1.json' }, { key: 'stats/v1/u1/2.json' }],
@@ -86,8 +93,8 @@ describe('DELETE /api/user/delete stats archive cleanup', () => {
     const res = await call();
     expect(res.statusCode).toBe(200);
     expect(events).toEqual([
-      'deleteUser',
       'queue:stat_archive_orphans',
+      'deleteUser',
       'delete:stats/v1/u1/1.json,stats/v1/u1/2.json',
       'delete:stats/v1/u1/3.json',
     ]);
@@ -100,21 +107,33 @@ describe('DELETE /api/user/delete stats archive cleanup', () => {
     expect(bucket.list.mock.calls[1]![0]).toMatchObject({ prefix: 'stats/v1/u1/', cursor: 'c1' });
   });
 
-  it('touches nothing in R2 when deleting the user fails', async () => {
+  it('stops with 500 before deleting anything when the tombstone cannot be written', async () => {
+    orphanUpsertMock.mockResolvedValue({ error: { message: 'db down' } });
+    const res = await call();
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: 'stats archive cleanup could not be prepared' });
+    expect(deleteUserMock).not.toHaveBeenCalled();
+    expect(bucket.list).not.toHaveBeenCalled();
+    expect(bucket.delete).not.toHaveBeenCalled();
+  });
+
+  it('compensates the tombstone and touches nothing in R2 when deleting the user fails', async () => {
     deleteUserMock.mockResolvedValue({ error: { message: 'auth down' } });
     const res = await call();
     expect(res.statusCode).toBe(500);
+    expect(events).toEqual(['queue:stat_archive_orphans', 'unqueue:stat_archive_orphans']);
+    expect(orphanDeleteEqMock).toHaveBeenCalledWith('stat_archive_orphans', 'user_id', 'u1');
     expect(bucket.list).not.toHaveBeenCalled();
     expect(bucket.delete).not.toHaveBeenCalled();
-    expect(orphanUpsertMock).not.toHaveBeenCalled();
   });
 
-  it('still answers 200 when the immediate prefix delete fails: the queued row lets the sweep finish the job', async () => {
+  it('still answers 200 when the immediate prefix delete fails: the tombstone lets the sweep finish the job', async () => {
     bucket.list.mockRejectedValueOnce(new Error('r2 down'));
     const res = await call();
     expect(res.statusCode).toBe(200);
     expect(deleteUserMock).toHaveBeenCalledTimes(1);
     expect(orphanUpsertMock).toHaveBeenCalledTimes(1);
+    expect(orphanDeleteEqMock).not.toHaveBeenCalled(); // tombstone stays for the sweep
   });
 
   it('is a no-op without the R2 binding (self-host)', async () => {

--- a/apps/readest-app/src/__tests__/pages/api/user-delete-stats-archive.test.ts
+++ b/apps/readest-app/src/__tests__/pages/api/user-delete-stats-archive.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// DELETE /api/user/delete must also remove the user's reading-statistics
+// archive objects in R2 (stats/v1/{user_id}/...). Postgres rows cascade with
+// the auth user; R2 objects do not, so the handler deletes the prefix before
+// the user (required, a failure blocks the deletion) and once more after
+// (best-effort, closes the window of a compaction run in flight).
+
+const deleteUserMock = vi.fn();
+vi.mock('@/utils/cors', () => ({
+  corsAllMethods: {},
+  runMiddleware: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/utils/access', () => ({
+  validateUserAndToken: vi.fn().mockResolvedValue({ user: { id: 'u1' }, token: 'tok' }),
+}));
+vi.mock('@/utils/supabase', () => ({
+  createSupabaseAdminClient: () => ({ auth: { admin: { deleteUser: deleteUserMock } } }),
+}));
+let cfEnv: Record<string, unknown> = {};
+vi.mock('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: () => ({ env: cfEnv }),
+}));
+
+import handler from '@/pages/api/user/delete';
+
+const bucket = { get: vi.fn(), put: vi.fn(), list: vi.fn(), delete: vi.fn() };
+const events: string[] = [];
+
+const call = async () => {
+  const req = {
+    method: 'DELETE',
+    headers: { authorization: 'Bearer tok' },
+  } as unknown as NextApiRequest;
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return this;
+    },
+  };
+  await handler(req, res as unknown as NextApiResponse);
+  return res;
+};
+
+beforeEach(() => {
+  events.length = 0;
+  deleteUserMock.mockReset().mockImplementation(async () => {
+    events.push('deleteUser');
+    return { error: null };
+  });
+  bucket.list.mockReset();
+  bucket.delete.mockReset().mockImplementation(async (keys: string[]) => {
+    events.push(`delete:${keys.join(',')}`);
+  });
+  cfEnv = { STATS_ARCHIVE_R2: bucket };
+});
+
+describe('DELETE /api/user/delete stats archive cleanup', () => {
+  it('deletes every object under the user prefix (paginated listing), then the user, then sweeps once more', async () => {
+    bucket.list
+      .mockResolvedValueOnce({
+        objects: [{ key: 'stats/v1/u1/1.json' }, { key: 'stats/v1/u1/2.json' }],
+        truncated: true,
+        cursor: 'c1',
+      })
+      .mockResolvedValueOnce({ objects: [{ key: 'stats/v1/u1/3.json' }], truncated: false })
+      .mockResolvedValue({ objects: [], truncated: false });
+
+    const res = await call();
+    expect(res.statusCode).toBe(200);
+    expect(bucket.list.mock.calls[0]![0]).toMatchObject({ prefix: 'stats/v1/u1/' });
+    expect(bucket.list.mock.calls[1]![0]).toMatchObject({ prefix: 'stats/v1/u1/', cursor: 'c1' });
+    expect(events).toEqual([
+      'delete:stats/v1/u1/1.json,stats/v1/u1/2.json',
+      'delete:stats/v1/u1/3.json',
+      'deleteUser',
+    ]);
+    // the post-delete sweep listed again (and found nothing)
+    expect(bucket.list).toHaveBeenCalledTimes(3);
+  });
+
+  it('refuses to delete the user when the archive cleanup fails', async () => {
+    bucket.list.mockRejectedValueOnce(new Error('r2 down'));
+    const res = await call();
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: 'stats archive cleanup failed' });
+    expect(deleteUserMock).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op without the R2 binding (self-host)', async () => {
+    cfEnv = {};
+    const res = await call();
+    expect(res.statusCode).toBe(200);
+    expect(deleteUserMock).toHaveBeenCalledTimes(1);
+    expect(bucket.list).not.toHaveBeenCalled();
+  });
+
+  it('still answers 200 when only the best-effort second sweep fails', async () => {
+    bucket.list
+      .mockResolvedValueOnce({ objects: [], truncated: false })
+      .mockRejectedValueOnce(new Error('r2 hiccup'));
+    const res = await call();
+    expect(res.statusCode).toBe(200);
+    expect(deleteUserMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/readest-app/src/__tests__/pages/api/user-delete-stats-archive.test.ts
+++ b/apps/readest-app/src/__tests__/pages/api/user-delete-stats-archive.test.ts
@@ -3,11 +3,13 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 // DELETE /api/user/delete must also remove the user's reading-statistics
 // archive objects in R2 (stats/v1/{user_id}/...). Postgres rows cascade with
-// the auth user; R2 objects do not, so the handler deletes the prefix before
-// the user (required, a failure blocks the deletion) and once more after
-// (best-effort, closes the window of a compaction run in flight).
+// the auth user; R2 objects do not. The identity goes first (deleting objects
+// before a failed deleteUser would leave an active account with its history
+// gone); then the user id is queued in stat_archive_orphans for the compaction
+// job's sweep and the prefix is deleted right away, best-effort.
 
 const deleteUserMock = vi.fn();
+const orphanUpsertMock = vi.fn();
 vi.mock('@/utils/cors', () => ({
   corsAllMethods: {},
   runMiddleware: vi.fn().mockResolvedValue(undefined),
@@ -16,7 +18,12 @@ vi.mock('@/utils/access', () => ({
   validateUserAndToken: vi.fn().mockResolvedValue({ user: { id: 'u1' }, token: 'tok' }),
 }));
 vi.mock('@/utils/supabase', () => ({
-  createSupabaseAdminClient: () => ({ auth: { admin: { deleteUser: deleteUserMock } } }),
+  createSupabaseAdminClient: () => ({
+    auth: { admin: { deleteUser: deleteUserMock } },
+    from: (table: string) => ({
+      upsert: (...a: unknown[]) => orphanUpsertMock(table, ...a),
+    }),
+  }),
 }));
 let cfEnv: Record<string, unknown> = {};
 vi.mock('@opennextjs/cloudflare', () => ({
@@ -55,7 +62,11 @@ beforeEach(() => {
     events.push('deleteUser');
     return { error: null };
   });
-  bucket.list.mockReset();
+  orphanUpsertMock.mockReset().mockImplementation(async (table: string) => {
+    events.push(`queue:${table}`);
+    return { error: null };
+  });
+  bucket.list.mockReset().mockResolvedValue({ objects: [], truncated: false });
   bucket.delete.mockReset().mockImplementation(async (keys: string[]) => {
     events.push(`delete:${keys.join(',')}`);
   });
@@ -63,35 +74,47 @@ beforeEach(() => {
 });
 
 describe('DELETE /api/user/delete stats archive cleanup', () => {
-  it('deletes every object under the user prefix (paginated listing), then the user, then sweeps once more', async () => {
+  it('deletes the user first, then queues the id for the sweep and deletes the prefix (paginated listing)', async () => {
     bucket.list
       .mockResolvedValueOnce({
         objects: [{ key: 'stats/v1/u1/1.json' }, { key: 'stats/v1/u1/2.json' }],
         truncated: true,
         cursor: 'c1',
       })
-      .mockResolvedValueOnce({ objects: [{ key: 'stats/v1/u1/3.json' }], truncated: false })
-      .mockResolvedValue({ objects: [], truncated: false });
+      .mockResolvedValueOnce({ objects: [{ key: 'stats/v1/u1/3.json' }], truncated: false });
 
     const res = await call();
     expect(res.statusCode).toBe(200);
-    expect(bucket.list.mock.calls[0]![0]).toMatchObject({ prefix: 'stats/v1/u1/' });
-    expect(bucket.list.mock.calls[1]![0]).toMatchObject({ prefix: 'stats/v1/u1/', cursor: 'c1' });
     expect(events).toEqual([
+      'deleteUser',
+      'queue:stat_archive_orphans',
       'delete:stats/v1/u1/1.json,stats/v1/u1/2.json',
       'delete:stats/v1/u1/3.json',
-      'deleteUser',
     ]);
-    // the post-delete sweep listed again (and found nothing)
-    expect(bucket.list).toHaveBeenCalledTimes(3);
+    expect(orphanUpsertMock).toHaveBeenCalledWith(
+      'stat_archive_orphans',
+      { user_id: 'u1' },
+      { onConflict: 'user_id' },
+    );
+    expect(bucket.list.mock.calls[0]![0]).toMatchObject({ prefix: 'stats/v1/u1/' });
+    expect(bucket.list.mock.calls[1]![0]).toMatchObject({ prefix: 'stats/v1/u1/', cursor: 'c1' });
   });
 
-  it('refuses to delete the user when the archive cleanup fails', async () => {
-    bucket.list.mockRejectedValueOnce(new Error('r2 down'));
+  it('touches nothing in R2 when deleting the user fails', async () => {
+    deleteUserMock.mockResolvedValue({ error: { message: 'auth down' } });
     const res = await call();
     expect(res.statusCode).toBe(500);
-    expect(res.body).toEqual({ error: 'stats archive cleanup failed' });
-    expect(deleteUserMock).not.toHaveBeenCalled();
+    expect(bucket.list).not.toHaveBeenCalled();
+    expect(bucket.delete).not.toHaveBeenCalled();
+    expect(orphanUpsertMock).not.toHaveBeenCalled();
+  });
+
+  it('still answers 200 when the immediate prefix delete fails: the queued row lets the sweep finish the job', async () => {
+    bucket.list.mockRejectedValueOnce(new Error('r2 down'));
+    const res = await call();
+    expect(res.statusCode).toBe(200);
+    expect(deleteUserMock).toHaveBeenCalledTimes(1);
+    expect(orphanUpsertMock).toHaveBeenCalledTimes(1);
   });
 
   it('is a no-op without the R2 binding (self-host)', async () => {
@@ -100,14 +123,6 @@ describe('DELETE /api/user/delete stats archive cleanup', () => {
     expect(res.statusCode).toBe(200);
     expect(deleteUserMock).toHaveBeenCalledTimes(1);
     expect(bucket.list).not.toHaveBeenCalled();
-  });
-
-  it('still answers 200 when only the best-effort second sweep fails', async () => {
-    bucket.list
-      .mockResolvedValueOnce({ objects: [], truncated: false })
-      .mockRejectedValueOnce(new Error('r2 hiccup'));
-    const res = await call();
-    expect(res.statusCode).toBe(200);
-    expect(deleteUserMock).toHaveBeenCalledTimes(1);
+    expect(orphanUpsertMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/readest-app/src/app/api/stats/compact/route.ts
+++ b/apps/readest-app/src/app/api/stats/compact/route.ts
@@ -1,0 +1,192 @@
+import { NextResponse } from 'next/server';
+import { createSupabaseAdminClient } from '@/utils/supabase';
+import {
+  SEGMENT_VERSION,
+  encodeSegment,
+  getStatsArchiveEnv,
+  guardArchiveRequest,
+  readCompactConfig,
+  segmentKey,
+  tsToMs,
+  type ArchivedPageRow,
+} from '@/libs/statsArchive';
+
+/**
+ * POST /api/stats/compact: move page events older than the hot window from
+ * stat_pages into immutable per-user R2 segments (migration 020). Fired by the
+ * Cloudflare Cron Trigger through worker.ts (and by hand with the same token).
+ * Each run claims a batch of users, archives the eligible ones in bounded
+ * segments and returns a summary; per-user failures are counted, not fatal.
+ *
+ * Guard order: 503 when disabled/unconfigured (self-host, kill switch) before
+ * any auth check; 401 on a bad token. See statsArchive.ts.
+ */
+
+interface CandidateRow {
+  eligible: number;
+  oldest: string | null;
+  hot_total: number;
+  archived_to: string;
+}
+
+interface HotRow {
+  book_hash: string;
+  page: number;
+  start_time: number | string;
+  duration: number;
+  total_pages: number;
+  ext: unknown;
+  updated_at: string;
+  deleted_at: string | null;
+}
+
+interface Summary {
+  users_claimed: number;
+  users_archived: number;
+  segments: number;
+  rows: number;
+  bytes: number;
+  errors: number;
+  commit_mismatches: number;
+}
+
+const DAY_MS = 86400000;
+
+export async function POST(request: Request) {
+  const env = getStatsArchiveEnv();
+  const guard = guardArchiveRequest(request, env, 'compact');
+  if (!guard.ok) return NextResponse.json(guard.body, { status: guard.status });
+
+  const started = Date.now();
+  const cfg = readCompactConfig(env);
+  const bucket = env.STATS_ARCHIVE_R2!;
+  const supabase = createSupabaseAdminClient();
+  const s: Summary = {
+    users_claimed: 0,
+    users_archived: 0,
+    segments: 0,
+    rows: 0,
+    bytes: 0,
+    errors: 0,
+    commit_mismatches: 0,
+  };
+
+  const finish = (status: number, outcome: 'ok' | 'error', body: Record<string, unknown>) => {
+    const duration_ms = Date.now() - started;
+    const error = typeof body['error'] === 'string' ? (body['error'] as string) : '';
+    console.log(JSON.stringify({ tag: 'stats-compact', outcome, duration_ms, ...s, error }));
+    env.STATS_COMPACT_AE?.writeDataPoint({
+      indexes: ['compact'],
+      blobs: [outcome, error.slice(0, 256)],
+      doubles: [
+        s.users_claimed,
+        s.users_archived,
+        s.segments,
+        s.rows,
+        s.bytes,
+        duration_ms,
+        s.errors,
+        s.commit_mismatches,
+      ],
+    });
+    return NextResponse.json({ ...body, duration_ms }, { status });
+  };
+
+  const { data: claimed, error: claimErr } = await supabase.rpc('stat_archive_claim_users', {
+    p_n: cfg.usersPerRun,
+  });
+  if (claimErr) return finish(500, 'error', { ok: false, error: claimErr.message });
+  const users = (claimed ?? []) as string[];
+  s.users_claimed = users.length;
+  const window = `${cfg.windowDays} days`;
+
+  for (const userId of users) {
+    try {
+      const { data: cand, error: candErr } = await supabase.rpc('stat_archive_candidate', {
+        p_user: userId,
+        p_window: window,
+      });
+      if (candErr) throw candErr;
+      const c = (Array.isArray(cand) ? cand[0] : cand) as CandidateRow | undefined;
+      if (!c || !(c.eligible > 0)) continue;
+      const oldestMs = c.oldest ? tsToMs(c.oldest) : Number.POSITIVE_INFINITY;
+      const eligible =
+        c.eligible >= cfg.minRows ||
+        oldestMs <= Date.now() - cfg.maxAgeDays * DAY_MS ||
+        c.hot_total > cfg.hotCap;
+      if (!eligible) continue;
+
+      let from = c.archived_to;
+      let archivedAny = false;
+      for (let i = 0; i < cfg.segmentsPerUser; i++) {
+        const { data: rowsData, error: rowsErr } = await supabase.rpc('stat_archive_rows', {
+          p_user: userId,
+          p_from: from,
+          p_window: window,
+          p_limit: cfg.segmentRows,
+        });
+        if (rowsErr) throw rowsErr;
+        const rows = (rowsData ?? []) as HotRow[];
+        if (rows.length === 0) break;
+        // The RPC returns rows in updated_at order; the last one bounds the
+        // segment. Keep its exact (microsecond) timestamp for the commit and the
+        // truncated millisecond for the segment/key.
+        const toIso = rows[rows.length - 1]!.updated_at;
+        const toMs = tsToMs(toIso);
+        const archived: ArchivedPageRow[] = rows.map((r) => ({
+          book_hash: r.book_hash,
+          page: r.page,
+          start_time: Number(r.start_time),
+          duration: r.duration,
+          total_pages: r.total_pages,
+          ext: r.ext ?? null,
+          deleted_at: r.deleted_at ?? null,
+          updated_at_ms: tsToMs(r.updated_at),
+        }));
+        const body = encodeSegment({
+          v: SEGMENT_VERSION,
+          user_id: userId,
+          updated_from_ms: tsToMs(from),
+          updated_to_ms: toMs,
+          rows: archived,
+        });
+        const key = segmentKey(userId, toMs);
+        const bytes = new TextEncoder().encode(body).length;
+        // Object first, manifest second. The key is deterministic for a given
+        // (user, range), so a retry overwrites the same object; nothing here
+        // ever deletes an object, because after a failed commit a concurrent
+        // winner's manifest may already reference it.
+        await bucket.put(key, body, { httpMetadata: { contentType: 'application/json' } });
+        const { data: deleted, error: commitErr } = await supabase.rpc('stat_archive_commit', {
+          p_user: userId,
+          p_key: key,
+          p_from: from,
+          p_to: toIso,
+          p_rows: rows.length,
+          p_bytes: bytes,
+        });
+        if (commitErr) {
+          if ((commitErr as { code?: string }).code === '40001') {
+            // Lost the compare-and-set: another run owns this user right now.
+            console.info('stats compact: lost CAS for user, skipping', userId);
+            break;
+          }
+          throw commitErr;
+        }
+        if (Number(deleted) !== rows.length) s.commit_mismatches++;
+        s.segments++;
+        s.rows += rows.length;
+        s.bytes += bytes;
+        archivedAny = true;
+        from = toIso;
+        if (rows.length < cfg.segmentRows) break;
+      }
+      if (archivedAny) s.users_archived++;
+    } catch (e) {
+      s.errors++;
+      console.error('stats compact: user failed', userId, e instanceof Error ? e.message : e);
+    }
+  }
+
+  return finish(200, 'ok', { ok: true, ...s });
+}

--- a/apps/readest-app/src/app/api/stats/compact/route.ts
+++ b/apps/readest-app/src/app/api/stats/compact/route.ts
@@ -82,6 +82,15 @@ async function sweepOrphans(
   }
   for (const { user_id } of (data ?? []) as { user_id: string }[]) {
     try {
+      // The queue row is written BEFORE deleteUser (a durable tombstone), so a
+      // row can exist for an account whose deletion then failed. Never touch a
+      // living user's archive: skip and keep the row (the deletion handler
+      // unqueues it, best-effort; skipping here is the backstop).
+      const { data: existing } = await supabase.auth.admin.getUserById(user_id);
+      if (existing?.user) {
+        console.warn('stats compact: orphaned user still exists, skipping', user_id);
+        continue;
+      }
       await deleteUserSegments(bucket, user_id);
       const { error: delErr } = await supabase
         .from('stat_archive_orphans')
@@ -235,6 +244,16 @@ export async function POST(request: Request) {
         // truncated millisecond for the segment/key.
         const toIso = rows[rows.length - 1]!.updated_at;
         const toMs = tsToMs(toIso);
+        // stat_archive_rows extends every segment to the end of its last
+        // millisecond, so consecutive segments always end in strictly later
+        // milliseconds and the ms-keyed object names cannot collide. Fail loud
+        // (this user only) if that SQL invariant ever regresses, instead of
+        // silently overwriting the previous object.
+        if (toMs <= tsToMs(from)) {
+          throw new Error(
+            `segment boundary did not advance past the previous millisecond for ${userId}`,
+          );
+        }
         const archived: ArchivedPageRow[] = rows.map((r) => ({
           book_hash: r.book_hash,
           page: r.page,

--- a/apps/readest-app/src/app/api/stats/compact/route.ts
+++ b/apps/readest-app/src/app/api/stats/compact/route.ts
@@ -2,9 +2,11 @@ import { NextResponse } from 'next/server';
 import { createSupabaseAdminClient } from '@/utils/supabase';
 import {
   SEGMENT_VERSION,
+  deleteUserSegments,
   encodeSegment,
   getStatsArchiveEnv,
   guardArchiveRequest,
+  isCompactionEnabled,
   readCompactConfig,
   segmentKey,
   tsToMs,
@@ -48,6 +50,52 @@ interface Summary {
   bytes: number;
   errors: number;
   commit_mismatches: number;
+  orphans_swept: number;
+}
+
+const ORPHANS_PER_RUN = 20;
+
+/**
+ * Account-deletion cleanup queue: every deleted user is queued in
+ * stat_archive_orphans by /api/user/delete; each batch run deletes the
+ * stats/v1/{user_id}/ prefix of a few queued users and removes the row once the
+ * listing is empty. Runs even while compaction is disabled (it is cleanup, not
+ * compaction) and is bounded so it never starves the run.
+ */
+async function sweepOrphans(
+  supabase: ReturnType<typeof createSupabaseAdminClient>,
+  bucket: NonNullable<ReturnType<typeof getStatsArchiveEnv>['STATS_ARCHIVE_R2']>,
+): Promise<{ swept: number; errors: number }> {
+  const out = { swept: 0, errors: 0 };
+  const { data, error } = await supabase
+    .from('stat_archive_orphans')
+    .select('user_id')
+    .order('created_at', { ascending: true })
+    .limit(ORPHANS_PER_RUN);
+  if (error) {
+    console.error('stats compact: orphan queue read failed', error.message);
+    out.errors++;
+    return out;
+  }
+  for (const { user_id } of (data ?? []) as { user_id: string }[]) {
+    try {
+      await deleteUserSegments(bucket, user_id);
+      const { error: delErr } = await supabase
+        .from('stat_archive_orphans')
+        .delete()
+        .eq('user_id', user_id);
+      if (delErr) throw delErr;
+      out.swept++;
+    } catch (e) {
+      out.errors++;
+      console.error(
+        'stats compact: orphan sweep failed',
+        user_id,
+        e instanceof Error ? e.message : e,
+      );
+    }
+  }
+  return out;
 }
 
 const DAY_MS = 86400000;
@@ -55,18 +103,23 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 /**
  * Optional `{ "user_id": uuid }` body: an operator compacting ONE user by hand
- * (validation on a known account, or draining a heavy user). Returns undefined
- * for the cron's body-less request, null for a malformed user_id.
+ * (validation on a known account, or draining a heavy user). Only an EMPTY body
+ * is the cron's batch request; every non-empty body must be a valid targeted
+ * request (null = malformed, answered 400), so a typo never starts a batch run.
  */
 async function readTarget(request: Request): Promise<string | null | undefined> {
+  const raw = (await request.text()).trim();
+  if (raw === '') return undefined;
   let body: unknown;
   try {
-    body = await request.json();
+    body = JSON.parse(raw);
   } catch {
-    return undefined;
+    return null;
   }
-  const userId = (body as { user_id?: unknown } | null)?.user_id;
-  if (userId === undefined) return undefined;
+  const userId =
+    body && typeof body === 'object' && !Array.isArray(body)
+      ? (body as { user_id?: unknown }).user_id
+      : undefined;
   return typeof userId === 'string' && UUID_RE.test(userId) ? userId : null;
 }
 
@@ -74,9 +127,12 @@ export async function POST(request: Request) {
   const env = getStatsArchiveEnv();
   const target = await readTarget(request);
   if (target === null) {
-    return NextResponse.json({ error: 'user_id must be a uuid' }, { status: 400 });
+    return NextResponse.json(
+      { error: 'body must be empty (batch run) or {"user_id": "<uuid>"} (targeted run)' },
+      { status: 400 },
+    );
   }
-  const guard = guardArchiveRequest(request, env, target ? 'targeted' : 'compact');
+  const guard = guardArchiveRequest(request, env, 'compact');
   if (!guard.ok) return NextResponse.json(guard.body, { status: guard.status });
 
   const started = Date.now();
@@ -91,7 +147,19 @@ export async function POST(request: Request) {
     bytes: 0,
     errors: 0,
     commit_mismatches: 0,
+    orphans_swept: 0,
   };
+
+  // Batch runs (the cron) first do the account-deletion cleanup, kill switch
+  // or not; only the compaction itself is gated by STATS_COMPACT_ENABLED.
+  if (!target) {
+    const sweep = await sweepOrphans(supabase, bucket);
+    s.orphans_swept = sweep.swept;
+    s.errors += sweep.errors;
+    if (!isCompactionEnabled(env)) {
+      return NextResponse.json({ disabled: true, orphans_swept: s.orphans_swept }, { status: 503 });
+    }
+  }
 
   const finish = (status: number, outcome: 'ok' | 'error', body: Record<string, unknown>) => {
     const duration_ms = Date.now() - started;
@@ -109,6 +177,7 @@ export async function POST(request: Request) {
         duration_ms,
         s.errors,
         s.commit_mismatches,
+        s.orphans_swept,
       ],
     });
     return NextResponse.json({ ...body, duration_ms }, { status });

--- a/apps/readest-app/src/app/api/stats/compact/route.ts
+++ b/apps/readest-app/src/app/api/stats/compact/route.ts
@@ -51,10 +51,32 @@ interface Summary {
 }
 
 const DAY_MS = 86400000;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Optional `{ "user_id": uuid }` body: an operator compacting ONE user by hand
+ * (validation on a known account, or draining a heavy user). Returns undefined
+ * for the cron's body-less request, null for a malformed user_id.
+ */
+async function readTarget(request: Request): Promise<string | null | undefined> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return undefined;
+  }
+  const userId = (body as { user_id?: unknown } | null)?.user_id;
+  if (userId === undefined) return undefined;
+  return typeof userId === 'string' && UUID_RE.test(userId) ? userId : null;
+}
 
 export async function POST(request: Request) {
   const env = getStatsArchiveEnv();
-  const guard = guardArchiveRequest(request, env, 'compact');
+  const target = await readTarget(request);
+  if (target === null) {
+    return NextResponse.json({ error: 'user_id must be a uuid' }, { status: 400 });
+  }
+  const guard = guardArchiveRequest(request, env, target ? 'targeted' : 'compact');
   if (!guard.ok) return NextResponse.json(guard.body, { status: guard.status });
 
   const started = Date.now();
@@ -92,11 +114,16 @@ export async function POST(request: Request) {
     return NextResponse.json({ ...body, duration_ms }, { status });
   };
 
-  const { data: claimed, error: claimErr } = await supabase.rpc('stat_archive_claim_users', {
-    p_n: cfg.usersPerRun,
-  });
-  if (claimErr) return finish(500, 'error', { ok: false, error: claimErr.message });
-  const users = (claimed ?? []) as string[];
+  let users: string[];
+  if (target) {
+    users = [target];
+  } else {
+    const { data: claimed, error: claimErr } = await supabase.rpc('stat_archive_claim_users', {
+      p_n: cfg.usersPerRun,
+    });
+    if (claimErr) return finish(500, 'error', { ok: false, error: claimErr.message });
+    users = (claimed ?? []) as string[];
+  }
   s.users_claimed = users.length;
   const window = `${cfg.windowDays} days`;
 
@@ -110,7 +137,10 @@ export async function POST(request: Request) {
       const c = (Array.isArray(cand) ? cand[0] : cand) as CandidateRow | undefined;
       if (!c || !(c.eligible > 0)) continue;
       const oldestMs = c.oldest ? tsToMs(c.oldest) : Number.POSITIVE_INFINITY;
+      // A targeted run archives everything older than the window regardless of
+      // the batching thresholds (they only exist to bound R2 PUTs for the cron).
       const eligible =
+        target !== undefined ||
         c.eligible >= cfg.minRows ||
         oldestMs <= Date.now() - cfg.maxAgeDays * DAY_MS ||
         c.hot_total > cfg.hotCap;
@@ -188,5 +218,5 @@ export async function POST(request: Request) {
     }
   }
 
-  return finish(200, 'ok', { ok: true, ...s });
+  return finish(200, 'ok', { ok: true, ...(target ? { targeted: true } : {}), ...s });
 }

--- a/apps/readest-app/src/app/api/stats/compact/route.ts
+++ b/apps/readest-app/src/app/api/stats/compact/route.ts
@@ -20,8 +20,11 @@ import {
  * Each run claims a batch of users, archives the eligible ones in bounded
  * segments and returns a summary; per-user failures are counted, not fatal.
  *
- * Guard order: 503 when disabled/unconfigured (self-host, kill switch) before
- * any auth check; 401 on a bad token. See statsArchive.ts.
+ * Guard order: 503 when unconfigured (no token / no bucket: self-host) before
+ * any auth check; 401 on a bad token; then a batch run sweeps the
+ * account-deletion queue and, if STATS_COMPACT_ENABLED is not "true", answers
+ * 503 without compacting. A targeted run ({ user_id } body) skips the sweep and
+ * the kill switch. See statsArchive.ts.
  */
 
 interface CandidateRow {

--- a/apps/readest-app/src/app/api/stats/restore/route.ts
+++ b/apps/readest-app/src/app/api/stats/restore/route.ts
@@ -20,6 +20,7 @@ import {
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const CHUNK = 500;
+const MANIFEST_PAGE = 1000;
 
 export async function POST(request: Request) {
   const env = getStatsArchiveEnv();
@@ -38,12 +39,6 @@ export async function POST(request: Request) {
 
   const bucket = env.STATS_ARCHIVE_R2!;
   const supabase = createSupabaseAdminClient();
-  const { data: manifest, error: manErr } = await supabase
-    .from('stat_archives')
-    .select('*')
-    .eq('user_id', userId)
-    .order('updated_to', { ascending: true });
-  if (manErr) return NextResponse.json({ error: manErr.message }, { status: 500 });
 
   let restoredSegments = 0;
   let rows = 0;
@@ -55,38 +50,54 @@ export async function POST(request: Request) {
     );
   };
 
-  for (const m of (manifest ?? []) as StatArchiveManifestRow[]) {
-    let segment;
-    try {
-      segment = await readSegment(bucket, m);
-    } catch (e) {
-      if (e instanceof SegmentUnavailableError) return fail(m.id, e.message);
-      throw e;
-    }
-    for (let i = 0; i < segment.rows.length; i += CHUNK) {
-      const chunk = segment.rows.slice(i, i + CHUNK).map((r) => ({
-        book_hash: r.book_hash,
-        page: r.page,
-        start_time: r.start_time,
-        duration: r.duration,
-        total_pages: r.total_pages,
-        ext: r.ext ?? null,
-        deleted_at: r.deleted_at ?? null,
-      }));
-      const { error: upErr } = await supabase.rpc('upsert_stat_pages_as', {
-        p_user: userId,
-        p_rows: chunk,
-      });
-      if (upErr) return fail(m.id, upErr.message);
-    }
-    const { error: delErr } = await supabase
+  // PostgREST caps a response at MANIFEST_PAGE rows (Supabase's db-max-rows), so
+  // read the manifest page by page until it is empty. Every restored row is
+  // deleted below, so each page starts from the oldest remaining segment and
+  // no cursor is needed; a re-run after a failure resumes the same way.
+  for (;;) {
+    const { data: manifest, error: manErr } = await supabase
       .from('stat_archives')
-      .delete()
+      .select('*')
       .eq('user_id', userId)
-      .eq('id', m.id);
-    if (delErr) return fail(m.id, delErr.message);
-    restoredSegments++;
-    rows += segment.rows.length;
+      .order('updated_to', { ascending: true })
+      .range(0, MANIFEST_PAGE - 1);
+    if (manErr) return NextResponse.json({ error: manErr.message }, { status: 500 });
+    const page = (manifest ?? []) as StatArchiveManifestRow[];
+    if (page.length === 0) break;
+
+    for (const m of page) {
+      let segment;
+      try {
+        segment = await readSegment(bucket, m);
+      } catch (e) {
+        if (e instanceof SegmentUnavailableError) return fail(m.id, e.message);
+        throw e;
+      }
+      for (let i = 0; i < segment.rows.length; i += CHUNK) {
+        const chunk = segment.rows.slice(i, i + CHUNK).map((r) => ({
+          book_hash: r.book_hash,
+          page: r.page,
+          start_time: r.start_time,
+          duration: r.duration,
+          total_pages: r.total_pages,
+          ext: r.ext ?? null,
+          deleted_at: r.deleted_at ?? null,
+        }));
+        const { error: upErr } = await supabase.rpc('upsert_stat_pages_as', {
+          p_user: userId,
+          p_rows: chunk,
+        });
+        if (upErr) return fail(m.id, upErr.message);
+      }
+      const { error: delErr } = await supabase
+        .from('stat_archives')
+        .delete()
+        .eq('user_id', userId)
+        .eq('id', m.id);
+      if (delErr) return fail(m.id, delErr.message);
+      restoredSegments++;
+      rows += segment.rows.length;
+    }
   }
 
   return NextResponse.json({ restored_segments: restoredSegments, rows });

--- a/apps/readest-app/src/app/api/stats/restore/route.ts
+++ b/apps/readest-app/src/app/api/stats/restore/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { createSupabaseAdminClient } from '@/utils/supabase';
+import {
+  getStatsArchiveEnv,
+  guardArchiveRequest,
+  readSegment,
+  SegmentUnavailableError,
+  type StatArchiveManifestRow,
+} from '@/libs/statsArchive';
+
+/**
+ * POST /api/stats/restore { user_id }: rollback tool. Re-inserts one user's
+ * archived segments into stat_pages through upsert_stat_pages_as (union merge,
+ * longest duration wins) in 500-row chunks and drops each manifest row once its
+ * rows are back; the R2 objects stay. Idempotent and resumable: it stops at
+ * the first unreadable object with the manifest id, and a re-run continues
+ * after the rows already restored. Refuses (409) while compaction is enabled,
+ * which keeps restore and compaction mutually exclusive without locking.
+ */
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const CHUNK = 500;
+
+export async function POST(request: Request) {
+  const env = getStatsArchiveEnv();
+  const guard = guardArchiveRequest(request, env, 'restore');
+  if (!guard.ok) return NextResponse.json(guard.body, { status: guard.status });
+
+  let userId: unknown;
+  try {
+    userId = ((await request.json()) as { user_id?: unknown })?.user_id;
+  } catch {
+    userId = undefined;
+  }
+  if (typeof userId !== 'string' || !UUID_RE.test(userId)) {
+    return NextResponse.json({ error: 'user_id (uuid) is required' }, { status: 400 });
+  }
+
+  const bucket = env.STATS_ARCHIVE_R2!;
+  const supabase = createSupabaseAdminClient();
+  const { data: manifest, error: manErr } = await supabase
+    .from('stat_archives')
+    .select('*')
+    .eq('user_id', userId)
+    .order('updated_to', { ascending: true });
+  if (manErr) return NextResponse.json({ error: manErr.message }, { status: 500 });
+
+  let restoredSegments = 0;
+  let rows = 0;
+  const fail = (manifestId: number, error: string) => {
+    console.error('stats restore: stopped at manifest', manifestId, error);
+    return NextResponse.json(
+      { restored_segments: restoredSegments, failed_manifest_id: manifestId, error },
+      { status: 500 },
+    );
+  };
+
+  for (const m of (manifest ?? []) as StatArchiveManifestRow[]) {
+    let segment;
+    try {
+      segment = await readSegment(bucket, m);
+    } catch (e) {
+      if (e instanceof SegmentUnavailableError) return fail(m.id, e.message);
+      throw e;
+    }
+    for (let i = 0; i < segment.rows.length; i += CHUNK) {
+      const chunk = segment.rows.slice(i, i + CHUNK).map((r) => ({
+        book_hash: r.book_hash,
+        page: r.page,
+        start_time: r.start_time,
+        duration: r.duration,
+        total_pages: r.total_pages,
+        ext: r.ext ?? null,
+        deleted_at: r.deleted_at ?? null,
+      }));
+      const { error: upErr } = await supabase.rpc('upsert_stat_pages_as', {
+        p_user: userId,
+        p_rows: chunk,
+      });
+      if (upErr) return fail(m.id, upErr.message);
+    }
+    const { error: delErr } = await supabase
+      .from('stat_archives')
+      .delete()
+      .eq('user_id', userId)
+      .eq('id', m.id);
+    if (delErr) return fail(m.id, delErr.message);
+    restoredSegments++;
+    rows += segment.rows.length;
+  }
+
+  return NextResponse.json({ restored_segments: restoredSegments, rows });
+}

--- a/apps/readest-app/src/libs/statsArchive.ts
+++ b/apps/readest-app/src/libs/statsArchive.ts
@@ -270,13 +270,15 @@ export type ArchiveGuardResult =
 /**
  * Guard for the compact / restore endpoints. Order matters: configuration
  * problems answer 503 before any auth check so a misconfigured deployment
- * never reports auth errors; restore deliberately works while compaction is
- * disabled (rollback) and refuses while it is enabled (mutual exclusion).
+ * never reports auth errors. `compact` (the cron) additionally needs
+ * STATS_COMPACT_ENABLED; `targeted` (an operator compacting one user by hand)
+ * and `restore` deliberately work while compaction is disabled, and restore
+ * refuses while it is enabled (mutual exclusion with the cron).
  */
 export function guardArchiveRequest(
   req: Request,
   env: Partial<StatsArchiveEnv>,
-  mode: 'compact' | 'restore',
+  mode: 'compact' | 'targeted' | 'restore',
 ): ArchiveGuardResult {
   const enabled = env.STATS_COMPACT_ENABLED === 'true';
   if (!env.STATS_COMPACT_TOKEN || !env.STATS_ARCHIVE_R2 || (mode === 'compact' && !enabled)) {

--- a/apps/readest-app/src/libs/statsArchive.ts
+++ b/apps/readest-app/src/libs/statsArchive.ts
@@ -269,29 +269,33 @@ export type ArchiveGuardResult =
 
 /**
  * Guard for the compact / restore endpoints. Order matters: configuration
- * problems answer 503 before any auth check so a misconfigured deployment
- * never reports auth errors. `compact` (the cron) additionally needs
- * STATS_COMPACT_ENABLED; `targeted` (an operator compacting one user by hand)
- * and `restore` deliberately work while compaction is disabled, and restore
- * refuses while it is enabled (mutual exclusion with the cron).
+ * problems (no token, no bucket) answer 503 before any auth check so a
+ * misconfigured deployment never reports auth errors; then 401 on a bad token.
+ * The compact route applies STATS_COMPACT_ENABLED itself, after its
+ * maintenance step, so operator actions (targeted runs, the orphan sweep,
+ * restore) work while the cron is off; `restore` additionally refuses with 409
+ * while compaction is enabled (mutual exclusion with the cron).
  */
 export function guardArchiveRequest(
   req: Request,
   env: Partial<StatsArchiveEnv>,
-  mode: 'compact' | 'targeted' | 'restore',
+  mode: 'compact' | 'restore',
 ): ArchiveGuardResult {
-  const enabled = env.STATS_COMPACT_ENABLED === 'true';
-  if (!env.STATS_COMPACT_TOKEN || !env.STATS_ARCHIVE_R2 || (mode === 'compact' && !enabled)) {
+  if (!env.STATS_COMPACT_TOKEN || !env.STATS_ARCHIVE_R2) {
     return { ok: false, status: 503, body: { disabled: true } };
   }
   if (req.headers.get('x-compact-token') !== env.STATS_COMPACT_TOKEN) {
     return { ok: false, status: 401, body: { error: 'unauthorized' } };
   }
-  if (mode === 'restore' && enabled) {
+  if (mode === 'restore' && env.STATS_COMPACT_ENABLED === 'true') {
     return { ok: false, status: 409, body: { error: 'disable compaction first' } };
   }
   return { ok: true };
 }
+
+/** The cron's batch run is the only path gated by the kill switch. */
+export const isCompactionEnabled = (env: Partial<StatsArchiveEnv>) =>
+  env.STATS_COMPACT_ENABLED === 'true';
 
 export interface CompactConfig {
   usersPerRun: number;
@@ -313,8 +317,11 @@ const COMPACT_DEFAULTS: CompactConfig = {
   segmentRows: 10000,
 };
 
-const positiveInt = (value: string | undefined, fallback: number) =>
-  value !== undefined && /^\d+$/.test(value) && Number(value) >= 1 ? Number(value) : fallback;
+const positiveInt = (value: string | undefined, fallback: number) => {
+  if (value === undefined || !/^\d+$/.test(value)) return fallback;
+  const n = Number(value);
+  return Number.isSafeInteger(n) && n >= 1 ? n : fallback;
+};
 
 /** Compaction knobs from wrangler vars; garbage or out-of-range falls back. */
 export function readCompactConfig(env: Partial<StatsArchiveEnv>): CompactConfig {

--- a/apps/readest-app/src/libs/statsArchive.ts
+++ b/apps/readest-app/src/libs/statsArchive.ts
@@ -1,0 +1,331 @@
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+
+/**
+ * Reading-statistics archive: page events older than the hot window leave
+ * `stat_pages` for immutable per-user JSON segments in R2, listed in the
+ * `stat_archives` manifest (migration 020). This module holds everything the
+ * compaction job, the restore tool and the stats pull share: the Worker env
+ * surface, the request guard, the segment codec and page selection.
+ *
+ * Invariant relied on everywhere: a committed segment covers
+ * `(updated_from, updated_to]` exactly and the same transaction deleted those
+ * hot rows, while every push stamps `updated_at = now()`. Hence every hot row
+ * of a user is newer than every segment of that user, and "segments in
+ * updated_to order, then hot rows" is global updated_at order.
+ */
+
+export const SEGMENT_VERSION = 1 as const;
+const SEGMENT_KEY_PREFIX = 'stats/v1/';
+
+/** One page event as stored inside a segment and as returned on the wire. */
+export interface ArchivedPageRow {
+  book_hash: string;
+  page: number;
+  start_time: number;
+  duration: number;
+  total_pages: number;
+  ext: unknown;
+  deleted_at: string | null;
+  updated_at_ms: number;
+}
+
+export interface StatsSegment {
+  v: typeof SEGMENT_VERSION;
+  user_id: string;
+  updated_from_ms: number;
+  updated_to_ms: number;
+  rows: ArchivedPageRow[];
+}
+
+/** A `stat_archives` manifest row. */
+export interface StatArchiveManifestRow {
+  id: number;
+  user_id: string;
+  updated_from: string;
+  updated_to: string;
+  row_count: number;
+  bytes: number;
+  object_key: string;
+}
+
+// Minimal local typings for the Cloudflare bindings (the project does not
+// depend on @cloudflare/workers-types; same approach as iap/telemetry.ts).
+export interface R2ObjectBodyLike {
+  size: number;
+  text(): Promise<string>;
+}
+export interface R2BucketLike {
+  get(key: string): Promise<R2ObjectBodyLike | null>;
+  put(
+    key: string,
+    value: string,
+    options?: { httpMetadata?: { contentType?: string } },
+  ): Promise<unknown>;
+  list(options?: {
+    prefix?: string;
+    cursor?: string;
+    limit?: number;
+  }): Promise<{ objects: { key: string }[]; truncated: boolean; cursor?: string }>;
+  delete(keys: string | string[]): Promise<void>;
+}
+export interface AnalyticsEngineDatasetLike {
+  writeDataPoint(event: {
+    indexes?: string[];
+    blobs?: (string | null)[];
+    doubles?: number[];
+  }): void;
+}
+
+export interface StatsArchiveEnv {
+  STATS_ARCHIVE_R2?: R2BucketLike;
+  STATS_COMPACT_AE?: AnalyticsEngineDatasetLike;
+  STATS_COMPACT_TOKEN?: string;
+  STATS_COMPACT_ENABLED?: string;
+  STATS_COMPACT_USERS_PER_RUN?: string;
+  STATS_COMPACT_WINDOW_DAYS?: string;
+  STATS_COMPACT_MIN_ROWS?: string;
+  STATS_COMPACT_MAX_AGE_DAYS?: string;
+  STATS_COMPACT_HOT_CAP?: string;
+  STATS_COMPACT_SEGMENTS_PER_USER?: string;
+  STATS_COMPACT_SEGMENT_ROWS?: string;
+}
+
+/** The Worker env, or `{}` outside the Worker runtime (local dev, tests). */
+export const getStatsArchiveEnv = (): Partial<StatsArchiveEnv> => {
+  try {
+    return (getCloudflareContext().env ?? {}) as Partial<StatsArchiveEnv>;
+  } catch {
+    return {};
+  }
+};
+
+/**
+ * PostgREST timestamptz text -> epoch ms. Postgres keeps microseconds
+ * (`...00.123456+00:00`); JS dates are millisecond precision, so the fraction
+ * is truncated (never rounded) to 3 digits first: the millisecond cursor must
+ * never move past a row it has not delivered.
+ */
+export const tsToMs = (ts: string): number =>
+  Date.parse(ts.replace(/\.(\d{1,3})\d*/, (_m, f: string) => `.${f.padEnd(3, '0')}`));
+
+export const segmentKey = (userId: string, updatedToMs: number) =>
+  `${SEGMENT_KEY_PREFIX}${userId}/${updatedToMs}.json`;
+
+export const userSegmentPrefix = (userId: string) => `${SEGMENT_KEY_PREFIX}${userId}/`;
+
+const compareRows = (a: ArchivedPageRow, b: ArchivedPageRow) =>
+  a.updated_at_ms - b.updated_at_ms ||
+  (a.book_hash < b.book_hash ? -1 : a.book_hash > b.book_hash ? 1 : 0) ||
+  a.page - b.page ||
+  a.start_time - b.start_time;
+
+/** Wire key order; also what the segment stores. */
+const toWireRow = (r: ArchivedPageRow): ArchivedPageRow => ({
+  book_hash: r.book_hash,
+  page: r.page,
+  start_time: r.start_time,
+  duration: r.duration,
+  total_pages: r.total_pages,
+  ext: r.ext ?? null,
+  deleted_at: r.deleted_at ?? null,
+  updated_at_ms: r.updated_at_ms,
+});
+
+export function encodeSegment(seg: StatsSegment): string {
+  const rows = [...seg.rows].sort(compareRows).map(toWireRow);
+  return JSON.stringify({
+    v: SEGMENT_VERSION,
+    user_id: seg.user_id,
+    updated_from_ms: seg.updated_from_ms,
+    updated_to_ms: seg.updated_to_ms,
+    rows,
+  });
+}
+
+const isFiniteNumber = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v);
+
+export function decodeSegment(text: string): StatsSegment {
+  const parsed: unknown = JSON.parse(text);
+  if (!parsed || typeof parsed !== 'object') throw new Error('segment is not an object');
+  const seg = parsed as Record<string, unknown>;
+  if (seg['v'] !== SEGMENT_VERSION)
+    throw new Error(`unsupported segment version ${String(seg['v'])}`);
+  if (typeof seg['user_id'] !== 'string') throw new Error('segment user_id missing');
+  if (!isFiniteNumber(seg['updated_from_ms']) || !isFiniteNumber(seg['updated_to_ms'])) {
+    throw new Error('segment range missing');
+  }
+  if (!Array.isArray(seg['rows'])) throw new Error('segment rows missing');
+  const rows = (seg['rows'] as unknown[]).map((raw, i) => {
+    const r = (raw ?? {}) as Record<string, unknown>;
+    if (
+      typeof r['book_hash'] !== 'string' ||
+      !isFiniteNumber(r['page']) ||
+      !isFiniteNumber(r['start_time']) ||
+      !isFiniteNumber(r['duration']) ||
+      !isFiniteNumber(r['total_pages']) ||
+      !isFiniteNumber(r['updated_at_ms']) ||
+      (r['deleted_at'] != null && typeof r['deleted_at'] !== 'string')
+    ) {
+      throw new Error(`invalid segment row at index ${i}`);
+    }
+    return toWireRow({
+      book_hash: r['book_hash'],
+      page: r['page'],
+      start_time: r['start_time'],
+      duration: r['duration'],
+      total_pages: r['total_pages'],
+      ext: r['ext'] ?? null,
+      deleted_at: (r['deleted_at'] as string | null | undefined) ?? null,
+      updated_at_ms: r['updated_at_ms'],
+    });
+  });
+  return {
+    v: SEGMENT_VERSION,
+    user_id: seg['user_id'],
+    updated_from_ms: seg['updated_from_ms'],
+    updated_to_ms: seg['updated_to_ms'],
+    rows,
+  };
+}
+
+/**
+ * Rows strictly after `sinceMs` (and of `book` when given), in segment order.
+ * With a positive `limit`, the first `limit` rows extended with every trailing
+ * row that shares the last `updated_at_ms`, so a client advancing its cursor
+ * to that value never skips a tie. `limit <= 0` returns everything.
+ */
+export function takePage(
+  rows: ArchivedPageRow[],
+  sinceMs: number,
+  limit: number,
+  book?: string | null,
+): ArchivedPageRow[] {
+  const kept = rows.filter((r) => r.updated_at_ms > sinceMs && (!book || r.book_hash === book));
+  if (limit <= 0 || kept.length <= limit) return kept;
+  const edge = kept[limit - 1]!.updated_at_ms;
+  let end = limit;
+  while (end < kept.length && kept[end]!.updated_at_ms === edge) end++;
+  return kept.slice(0, end);
+}
+
+/** Segment row as the stats pull returns it (same shape as a hot row). */
+export const toWireStatPage = (r: ArchivedPageRow, userId: string) => ({
+  user_id: userId,
+  ...toWireRow(r),
+  updated_at: new Date(r.updated_at_ms).toISOString(),
+});
+
+export class SegmentUnavailableError extends Error {
+  constructor(
+    public readonly manifestId: number,
+    cause: string,
+  ) {
+    super(`archive segment ${manifestId} unavailable: ${cause}`);
+  }
+}
+
+/** Fetch and decode one segment; every failure becomes SegmentUnavailableError. */
+export async function readSegment(
+  bucket: R2BucketLike,
+  manifest: StatArchiveManifestRow,
+): Promise<StatsSegment> {
+  let obj: R2ObjectBodyLike | null;
+  try {
+    obj = await bucket.get(manifest.object_key);
+  } catch (e) {
+    throw new SegmentUnavailableError(manifest.id, String(e));
+  }
+  if (!obj) throw new SegmentUnavailableError(manifest.id, 'missing object');
+  try {
+    return decodeSegment(await obj.text());
+  } catch (e) {
+    throw new SegmentUnavailableError(manifest.id, (e as Error).message);
+  }
+}
+
+/**
+ * Delete every archive object of a user (paginated listing, batches of at most
+ * 1000 keys, R2's delete limit). Throws on the first failed call.
+ */
+export async function deleteUserSegments(bucket: R2BucketLike, userId: string): Promise<number> {
+  const prefix = userSegmentPrefix(userId);
+  let cursor: string | undefined;
+  let deleted = 0;
+  for (;;) {
+    const page = await bucket.list({ prefix, cursor, limit: 1000 });
+    const keys = page.objects.map((o) => o.key);
+    for (let i = 0; i < keys.length; i += 1000) {
+      await bucket.delete(keys.slice(i, i + 1000));
+    }
+    deleted += keys.length;
+    if (!page.truncated) return deleted;
+    cursor = page.cursor;
+  }
+}
+
+export type ArchiveGuardResult =
+  | { ok: true }
+  | { ok: false; status: 503 | 401 | 409; body: Record<string, unknown> };
+
+/**
+ * Guard for the compact / restore endpoints. Order matters: configuration
+ * problems answer 503 before any auth check so a misconfigured deployment
+ * never reports auth errors; restore deliberately works while compaction is
+ * disabled (rollback) and refuses while it is enabled (mutual exclusion).
+ */
+export function guardArchiveRequest(
+  req: Request,
+  env: Partial<StatsArchiveEnv>,
+  mode: 'compact' | 'restore',
+): ArchiveGuardResult {
+  const enabled = env.STATS_COMPACT_ENABLED === 'true';
+  if (!env.STATS_COMPACT_TOKEN || !env.STATS_ARCHIVE_R2 || (mode === 'compact' && !enabled)) {
+    return { ok: false, status: 503, body: { disabled: true } };
+  }
+  if (req.headers.get('x-compact-token') !== env.STATS_COMPACT_TOKEN) {
+    return { ok: false, status: 401, body: { error: 'unauthorized' } };
+  }
+  if (mode === 'restore' && enabled) {
+    return { ok: false, status: 409, body: { error: 'disable compaction first' } };
+  }
+  return { ok: true };
+}
+
+export interface CompactConfig {
+  usersPerRun: number;
+  windowDays: number;
+  minRows: number;
+  maxAgeDays: number;
+  hotCap: number;
+  segmentsPerUser: number;
+  segmentRows: number;
+}
+
+const COMPACT_DEFAULTS: CompactConfig = {
+  usersPerRun: 50,
+  windowDays: 7,
+  minRows: 500,
+  maxAgeDays: 30,
+  hotCap: 20000,
+  segmentsPerUser: 5,
+  segmentRows: 10000,
+};
+
+const positiveInt = (value: string | undefined, fallback: number) =>
+  value !== undefined && /^\d+$/.test(value) && Number(value) >= 1 ? Number(value) : fallback;
+
+/** Compaction knobs from wrangler vars; garbage or out-of-range falls back. */
+export function readCompactConfig(env: Partial<StatsArchiveEnv>): CompactConfig {
+  return {
+    usersPerRun: positiveInt(env.STATS_COMPACT_USERS_PER_RUN, COMPACT_DEFAULTS.usersPerRun),
+    windowDays: positiveInt(env.STATS_COMPACT_WINDOW_DAYS, COMPACT_DEFAULTS.windowDays),
+    minRows: positiveInt(env.STATS_COMPACT_MIN_ROWS, COMPACT_DEFAULTS.minRows),
+    maxAgeDays: positiveInt(env.STATS_COMPACT_MAX_AGE_DAYS, COMPACT_DEFAULTS.maxAgeDays),
+    hotCap: positiveInt(env.STATS_COMPACT_HOT_CAP, COMPACT_DEFAULTS.hotCap),
+    segmentsPerUser: positiveInt(
+      env.STATS_COMPACT_SEGMENTS_PER_USER,
+      COMPACT_DEFAULTS.segmentsPerUser,
+    ),
+    segmentRows: positiveInt(env.STATS_COMPACT_SEGMENT_ROWS, COMPACT_DEFAULTS.segmentRows),
+  };
+}

--- a/apps/readest-app/src/pages/api/sync.ts
+++ b/apps/readest-app/src/pages/api/sync.ts
@@ -448,17 +448,6 @@ export async function GET(req: NextRequest) {
       // compaction committing in between moves rows from hot to a segment, so
       // reading hot first can only return such rows twice (clients union-merge),
       // never zero times.
-      const { data: manifest, error: manErr } = await supabase
-        .from('stat_archives')
-        .select('*')
-        .eq('user_id', user.id)
-        .gt('updated_to', sinceIso)
-        .order('updated_to', { ascending: true });
-      if (manErr)
-        return NextResponse.json(
-          { error: `stat_archives: ${manErr.message || 'Unknown error'}` },
-          { status: 500 },
-        );
       // Attach updated_at_ms (epoch ms) so non-JS clients (the Lua koplugin) can
       // compute their pull cursor without parsing ISO-8601 timestamps.
       const withMs = <T extends { updated_at?: string }>(rows: T[]) =>
@@ -468,13 +457,34 @@ export async function GET(req: NextRequest) {
         }));
       const hotRows = withMs((sp.data ?? []) as unknown as StatPageRecord[]);
       let pageRows: StatPageRecord[] = hotRows;
-      const segments = (manifest ?? []) as StatArchiveManifestRow[];
-      if (segments.length > 0) {
-        const archiveEnv = getStatsArchiveEnv();
+      // PostgREST caps a response at MANIFEST_PAGE rows (Supabase's db-max-rows),
+      // so the manifest is read page by page: hot rows may only be appended once
+      // the FINAL manifest page (a short one) proves no archived rows remain
+      // past the cursor — otherwise a short response could advance a client's
+      // cursor over segments the first page did not show.
+      const MANIFEST_PAGE = 1000;
+      const archived: StatPageRecord[] = [];
+      let segmentsRead = 0;
+      let anySegments = false;
+      const archiveEnv = getStatsArchiveEnv();
+      const sinceMs = since.getTime();
+      for (let manifestOffset = 0; ; manifestOffset += MANIFEST_PAGE) {
+        const { data: manifest, error: manErr } = await supabase
+          .from('stat_archives')
+          .select('*')
+          .eq('user_id', user.id)
+          .gt('updated_to', sinceIso)
+          .order('updated_to', { ascending: true })
+          .range(manifestOffset, manifestOffset + MANIFEST_PAGE - 1);
+        if (manErr)
+          return NextResponse.json(
+            { error: `stat_archives: ${manErr.message || 'Unknown error'}` },
+            { status: 500 },
+          );
+        const segments = (manifest ?? []) as StatArchiveManifestRow[];
+        if (segments.length === 0) break;
+        anySegments = true;
         const bucket = archiveEnv.STATS_ARCHIVE_R2;
-        const sinceMs = since.getTime();
-        const archived: StatPageRecord[] = [];
-        let segmentsRead = 0;
         try {
           if (!bucket) {
             throw new SegmentUnavailableError(segments[0]!.id, 'archive storage not configured');
@@ -498,6 +508,10 @@ export async function GET(req: NextRequest) {
           }
           throw e;
         }
+        if (limit > 0 && archived.length >= limit) break;
+        if (segments.length < MANIFEST_PAGE) break;
+      }
+      if (anySegments) {
         const combined =
           limit > 0 && archived.length >= limit ? archived : [...archived, ...hotRows];
         if (limit > 0 && combined.length > limit) {

--- a/apps/readest-app/src/pages/api/sync.ts
+++ b/apps/readest-app/src/pages/api/sync.ts
@@ -17,6 +17,14 @@ import {
 } from '@/libs/sync';
 import { validateUserAndToken } from '@/utils/access';
 import { DBBook, DBBookConfig } from '@/types/records';
+import {
+  getStatsArchiveEnv,
+  readSegment,
+  takePage,
+  toWireStatPage,
+  SegmentUnavailableError,
+  type StatArchiveManifestRow,
+} from '@/libs/statsArchive';
 
 /**
  * Field-level last-writer-wins for a books row's reading_status: return the
@@ -432,6 +440,55 @@ export async function GET(req: NextRequest) {
           { error: `stat_pages: ${sp.error.message || 'Unknown error'}` },
           { status: 500 },
         );
+      // Archive tier (migration 020): page events older than the hot window live
+      // in immutable per-user segments listed in stat_archives; every hot row is
+      // newer than every segment, so "segments in updated_to order, then hot
+      // rows" is global updated_at order and the paging contract above holds
+      // across tiers. The manifest is read AFTER the hot rows on purpose: a
+      // compaction committing in between moves rows from hot to a segment, so
+      // reading hot first can only return such rows twice (clients union-merge),
+      // never zero times.
+      const { data: manifest, error: manErr } = await supabase
+        .from('stat_archives')
+        .select('*')
+        .eq('user_id', user.id)
+        .gt('updated_to', sinceIso)
+        .order('updated_to', { ascending: true });
+      if (manErr)
+        return NextResponse.json(
+          { error: `stat_archives: ${manErr.message || 'Unknown error'}` },
+          { status: 500 },
+        );
+      const archived: ReturnType<typeof toWireStatPage>[] = [];
+      const segments = (manifest ?? []) as StatArchiveManifestRow[];
+      if (segments.length > 0) {
+        const bucket = getStatsArchiveEnv().STATS_ARCHIVE_R2;
+        const sinceMs = since.getTime();
+        try {
+          if (!bucket) {
+            throw new SegmentUnavailableError(segments[0]!.id, 'archive storage not configured');
+          }
+          for (const m of segments) {
+            const page = takePage((await readSegment(bucket, m)).rows, sinceMs, limit, bookParam);
+            if (page.length === 0) continue;
+            archived.push(...page.map((r) => toWireStatPage(r, user.id)));
+            // A paged pull returns one contiguous updated_at range per response:
+            // the first segment that still has rows > since; hot rows follow
+            // once no segment does.
+            if (limit > 0) break;
+          }
+        } catch (e) {
+          if (e instanceof SegmentUnavailableError) {
+            console.error('stats pull:', e.message);
+            return NextResponse.json({ error: `stat_pages: ${e.message}` }, { status: 500 });
+          }
+          throw e;
+        }
+      }
+      const pageRows =
+        limit > 0 && archived.length > 0
+          ? archived
+          : [...archived, ...((sp.data ?? []) as Record<string, unknown>[])];
       // Attach updated_at_ms (epoch ms) so non-JS clients (the Lua koplugin) can
       // compute their pull cursor without parsing ISO-8601 timestamps.
       const withMs = <T extends { updated_at?: string }>(rows: T[]) =>
@@ -444,7 +501,7 @@ export async function GET(req: NextRequest) {
       ).statBooks = withMs((sb.data ?? []) as unknown as StatBookRecord[]);
       (
         results as unknown as { statBooks: StatBookRecord[]; statPages: StatPageRecord[] }
-      ).statPages = withMs((sp.data ?? []) as unknown as StatPageRecord[]);
+      ).statPages = withMs(pageRows as unknown as StatPageRecord[]);
     }
 
     const dbErrors = Object.values(errors).filter((err) => err !== null);

--- a/apps/readest-app/src/pages/api/sync.ts
+++ b/apps/readest-app/src/pages/api/sync.ts
@@ -459,27 +459,37 @@ export async function GET(req: NextRequest) {
           { error: `stat_archives: ${manErr.message || 'Unknown error'}` },
           { status: 500 },
         );
-      const archived: ReturnType<typeof toWireStatPage>[] = [];
+      // Attach updated_at_ms (epoch ms) so non-JS clients (the Lua koplugin) can
+      // compute their pull cursor without parsing ISO-8601 timestamps.
+      const withMs = <T extends { updated_at?: string }>(rows: T[]) =>
+        rows.map((r) => ({
+          ...r,
+          updated_at_ms: r.updated_at ? new Date(r.updated_at).getTime() : 0,
+        }));
+      const hotRows = withMs((sp.data ?? []) as unknown as StatPageRecord[]);
+      let pageRows: StatPageRecord[] = hotRows;
       const segments = (manifest ?? []) as StatArchiveManifestRow[];
       if (segments.length > 0) {
         const archiveEnv = getStatsArchiveEnv();
         const bucket = archiveEnv.STATS_ARCHIVE_R2;
         const sinceMs = since.getTime();
+        const archived: StatPageRecord[] = [];
         let segmentsRead = 0;
         try {
           if (!bucket) {
             throw new SegmentUnavailableError(segments[0]!.id, 'archive storage not configured');
           }
+          // Segments are read lazily, oldest first, until they fill the page;
+          // a paged pull whose segments run short is topped up with hot rows
+          // (which are newer than every segment), so a page is only ever short
+          // when the whole history is exhausted. Clients that stop on a short
+          // page (the koplugin) therefore never stall on a tier boundary.
           for (const m of segments) {
             const segment = await readSegment(bucket, m);
             segmentsRead++;
-            const page = takePage(segment.rows, sinceMs, limit, bookParam);
-            if (page.length === 0) continue;
-            archived.push(...page.map((r) => toWireStatPage(r, user.id)));
-            // A paged pull returns one contiguous updated_at range per response:
-            // the first segment that still has rows > since; hot rows follow
-            // once no segment does.
-            if (limit > 0) break;
+            const kept = takePage(segment.rows, sinceMs, 0, bookParam);
+            archived.push(...(kept.map((r) => toWireStatPage(r, user.id)) as StatPageRecord[]));
+            if (limit > 0 && archived.length >= limit) break;
           }
         } catch (e) {
           if (e instanceof SegmentUnavailableError) {
@@ -488,25 +498,27 @@ export async function GET(req: NextRequest) {
           }
           throw e;
         }
+        const combined =
+          limit > 0 && archived.length >= limit ? archived : [...archived, ...hotRows];
+        if (limit > 0 && combined.length > limit) {
+          // Cut at `limit`, extended with every row sharing the last
+          // updated_at_ms (segments never split a millisecond and the hot page
+          // was already completed by fetchPagedPages, so the ties are present).
+          const edge = combined[limit - 1]!.updated_at_ms;
+          let end = limit;
+          while (end < combined.length && combined[end]!.updated_at_ms === edge) end++;
+          pageRows = combined.slice(0, end);
+        } else {
+          pageRows = combined;
+        }
         // One data point per R2-backed pull (hot-only pulls write nothing), so
         // the share and size of archive reads can inform the hot-window knob.
         archiveEnv.STATS_COMPACT_AE?.writeDataPoint({
           indexes: ['pull'],
           blobs: [limit > 0 ? 'paged' : 'full'],
-          doubles: [segmentsRead, archived.length, limit],
+          doubles: [segmentsRead, Math.min(archived.length, pageRows.length), limit],
         });
       }
-      const pageRows =
-        limit > 0 && archived.length > 0
-          ? archived
-          : [...archived, ...((sp.data ?? []) as Record<string, unknown>[])];
-      // Attach updated_at_ms (epoch ms) so non-JS clients (the Lua koplugin) can
-      // compute their pull cursor without parsing ISO-8601 timestamps.
-      const withMs = <T extends { updated_at?: string }>(rows: T[]) =>
-        rows.map((r) => ({
-          ...r,
-          updated_at_ms: r.updated_at ? new Date(r.updated_at).getTime() : 0,
-        }));
       (
         results as unknown as { statBooks: StatBookRecord[]; statPages: StatPageRecord[] }
       ).statBooks = withMs((sb.data ?? []) as unknown as StatBookRecord[]);

--- a/apps/readest-app/src/pages/api/sync.ts
+++ b/apps/readest-app/src/pages/api/sync.ts
@@ -462,14 +462,18 @@ export async function GET(req: NextRequest) {
       const archived: ReturnType<typeof toWireStatPage>[] = [];
       const segments = (manifest ?? []) as StatArchiveManifestRow[];
       if (segments.length > 0) {
-        const bucket = getStatsArchiveEnv().STATS_ARCHIVE_R2;
+        const archiveEnv = getStatsArchiveEnv();
+        const bucket = archiveEnv.STATS_ARCHIVE_R2;
         const sinceMs = since.getTime();
+        let segmentsRead = 0;
         try {
           if (!bucket) {
             throw new SegmentUnavailableError(segments[0]!.id, 'archive storage not configured');
           }
           for (const m of segments) {
-            const page = takePage((await readSegment(bucket, m)).rows, sinceMs, limit, bookParam);
+            const segment = await readSegment(bucket, m);
+            segmentsRead++;
+            const page = takePage(segment.rows, sinceMs, limit, bookParam);
             if (page.length === 0) continue;
             archived.push(...page.map((r) => toWireStatPage(r, user.id)));
             // A paged pull returns one contiguous updated_at range per response:
@@ -484,6 +488,13 @@ export async function GET(req: NextRequest) {
           }
           throw e;
         }
+        // One data point per R2-backed pull (hot-only pulls write nothing), so
+        // the share and size of archive reads can inform the hot-window knob.
+        archiveEnv.STATS_COMPACT_AE?.writeDataPoint({
+          indexes: ['pull'],
+          blobs: [limit > 0 ? 'paged' : 'full'],
+          doubles: [segmentsRead, archived.length, limit],
+        });
       }
       const pageRows =
         limit > 0 && archived.length > 0

--- a/apps/readest-app/src/pages/api/user/delete.ts
+++ b/apps/readest-app/src/pages/api/user/delete.ts
@@ -17,19 +17,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(403).json({ error: 'Not authenticated' });
     }
 
-    const supabaseAdmin = createSupabaseAdminClient();
-    const { error } = await supabaseAdmin.auth.admin.deleteUser(user.id);
-    if (error) {
-      return res.status(500).json({ error: error.message });
-    }
-
     // Reading-statistics archive objects in R2 do not cascade with the auth
-    // user (Postgres rows do). The identity goes first: deleting objects before
-    // a failed deleteUser would leave an active account with its history gone.
-    // After the identity is gone, the user id is queued in stat_archive_orphans
-    // (swept by the compaction job until the prefix lists empty, which also
-    // catches an object a concurrent compaction run wrote after this sweep) and
-    // the prefix is deleted right away, best-effort.
+    // user (Postgres rows do), and the immediate prefix delete below is
+    // best-effort. The durable tombstone is a stat_archive_orphans row written
+    // BEFORE the identity is touched: if even that fails, stop with 500 while a
+    // retry is still possible. A stale row for a user whose deleteUser then
+    // fails is harmless: the compaction sweep skips users that still exist, and
+    // the failure path removes the row again, best-effort.
+    const supabaseAdmin = createSupabaseAdminClient();
     const bucket = getStatsArchiveEnv().STATS_ARCHIVE_R2;
     if (bucket) {
       const { error: queueErr } = await supabaseAdmin
@@ -41,7 +36,30 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           user.id,
           queueErr.message,
         );
+        return res.status(500).json({ error: 'stats archive cleanup could not be prepared' });
       }
+    }
+
+    // The identity goes second: deleting objects before a failed deleteUser
+    // would leave an active account with its history gone.
+    const { error } = await supabaseAdmin.auth.admin.deleteUser(user.id);
+    if (error) {
+      if (bucket) {
+        await supabaseAdmin
+          .from('stat_archive_orphans')
+          .delete()
+          .eq('user_id', user.id)
+          .then(({ error: e }) => {
+            if (e) console.warn('user delete: could not unqueue after failure', user.id, e.message);
+          });
+      }
+      return res.status(500).json({ error: error.message });
+    }
+
+    // Immediate cleanup, best-effort: the queued row keeps it reliable (the
+    // compaction sweep deletes the prefix until it lists empty, which also
+    // catches an object a concurrent compaction run wrote after this sweep).
+    if (bucket) {
       await deleteUserSegments(bucket, user.id).catch((e) =>
         console.error('user delete: stats archive cleanup failed (queued for sweep)', user.id, e),
       );

--- a/apps/readest-app/src/pages/api/user/delete.ts
+++ b/apps/readest-app/src/pages/api/user/delete.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { corsAllMethods, runMiddleware } from '@/utils/cors';
 import { createSupabaseAdminClient } from '@/utils/supabase';
 import { validateUserAndToken } from '@/utils/access';
+import { deleteUserSegments, getStatsArchiveEnv } from '@/libs/statsArchive';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   await runMiddleware(req, res, corsAllMethods);
@@ -16,10 +17,32 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(403).json({ error: 'Not authenticated' });
     }
 
+    // Reading-statistics archive objects in R2 do not cascade with the auth
+    // user (Postgres rows do). Delete them first and refuse to delete the user
+    // when that fails, so an account never disappears while its history stays.
+    const bucket = getStatsArchiveEnv().STATS_ARCHIVE_R2;
+    if (bucket) {
+      try {
+        await deleteUserSegments(bucket, user.id);
+      } catch (e) {
+        console.error('user delete: stats archive cleanup failed', user.id, e);
+        return res.status(500).json({ error: 'stats archive cleanup failed' });
+      }
+    }
+
     const supabaseAdmin = createSupabaseAdminClient();
     const { error } = await supabaseAdmin.auth.admin.deleteUser(user.id);
     if (error) {
       return res.status(500).json({ error: error.message });
+    }
+
+    // Best-effort second sweep: a compaction run that was between its object
+    // put and its (now failing) commit during the first sweep may have left
+    // one more object behind.
+    if (bucket) {
+      await deleteUserSegments(bucket, user.id).catch((e) =>
+        console.warn('user delete: post-delete stats archive sweep failed', user.id, e),
+      );
     }
 
     res.status(200).json({ message: 'User deleted successfully' });

--- a/apps/readest-app/src/pages/api/user/delete.ts
+++ b/apps/readest-app/src/pages/api/user/delete.ts
@@ -17,31 +17,33 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(403).json({ error: 'Not authenticated' });
     }
 
-    // Reading-statistics archive objects in R2 do not cascade with the auth
-    // user (Postgres rows do). Delete them first and refuse to delete the user
-    // when that fails, so an account never disappears while its history stays.
-    const bucket = getStatsArchiveEnv().STATS_ARCHIVE_R2;
-    if (bucket) {
-      try {
-        await deleteUserSegments(bucket, user.id);
-      } catch (e) {
-        console.error('user delete: stats archive cleanup failed', user.id, e);
-        return res.status(500).json({ error: 'stats archive cleanup failed' });
-      }
-    }
-
     const supabaseAdmin = createSupabaseAdminClient();
     const { error } = await supabaseAdmin.auth.admin.deleteUser(user.id);
     if (error) {
       return res.status(500).json({ error: error.message });
     }
 
-    // Best-effort second sweep: a compaction run that was between its object
-    // put and its (now failing) commit during the first sweep may have left
-    // one more object behind.
+    // Reading-statistics archive objects in R2 do not cascade with the auth
+    // user (Postgres rows do). The identity goes first: deleting objects before
+    // a failed deleteUser would leave an active account with its history gone.
+    // After the identity is gone, the user id is queued in stat_archive_orphans
+    // (swept by the compaction job until the prefix lists empty, which also
+    // catches an object a concurrent compaction run wrote after this sweep) and
+    // the prefix is deleted right away, best-effort.
+    const bucket = getStatsArchiveEnv().STATS_ARCHIVE_R2;
     if (bucket) {
+      const { error: queueErr } = await supabaseAdmin
+        .from('stat_archive_orphans')
+        .upsert({ user_id: user.id }, { onConflict: 'user_id' });
+      if (queueErr) {
+        console.error(
+          'user delete: could not queue stats archive cleanup',
+          user.id,
+          queueErr.message,
+        );
+      }
       await deleteUserSegments(bucket, user.id).catch((e) =>
-        console.warn('user delete: post-delete stats archive sweep failed', user.id, e),
+        console.error('user delete: stats archive cleanup failed (queued for sweep)', user.id, e),
       );
     }
 

--- a/apps/readest-app/worker.ts
+++ b/apps/readest-app/worker.ts
@@ -34,9 +34,14 @@ export default {
       headers: { 'x-compact-token': env.STATS_COMPACT_TOKEN ?? '' },
     });
     ctx.waitUntil(
-      handler.fetch(req, env, ctx).then((res: Response) => {
-        if (!res.ok) console.warn('stats compact cron: status', res.status);
-      }),
+      handler
+        .fetch(req, env, ctx)
+        .then((res: Response) => {
+          if (!res.ok) console.warn('stats compact cron: status', res.status);
+        })
+        .catch((e: unknown) => {
+          console.error('stats compact cron: failed', e instanceof Error ? e.message : e);
+        }),
     );
   },
 };

--- a/apps/readest-app/worker.ts
+++ b/apps/readest-app/worker.ts
@@ -1,0 +1,46 @@
+// Custom Cloudflare Worker entry (wrangler.toml `main`). Wraps the handler that
+// `opennextjs-cloudflare build` generates and adds a `scheduled()` handler so
+// the Cron Trigger can drive the reading-statistics compaction endpoint
+// (POST /api/stats/compact). Pattern from the OpenNext "custom worker" how-to:
+// https://opennext.js.org/cloudflare/howtos/custom-worker
+//
+// `.open-next/worker.js` only exists after the OpenNext build step that
+// `pnpm preview` / `pnpm deploy` run first; wrangler bundles this file with it.
+// The file sits outside tsconfig's `include`, so it carries its own minimal
+// types (the project does not depend on @cloudflare/workers-types).
+
+// biome-ignore lint/suspicious/noTsIgnore: `.open-next/worker.js` only exists after the OpenNext build
+// @ts-ignore `.open-next/worker.js` is generated at build time
+import { default as handler } from './.open-next/worker.js';
+
+interface CompactEnv {
+  STATS_COMPACT_TOKEN?: string;
+}
+
+interface ExecutionContextLike {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+const COMPACT_URL = 'https://web.readest.com/api/stats/compact';
+
+export default {
+  fetch: handler.fetch,
+
+  async scheduled(_event: unknown, env: CompactEnv, ctx: ExecutionContextLike) {
+    // Same code path as a manual run: the route applies the 503/401 guard, so
+    // a disabled or unconfigured deployment just logs a 503 here.
+    const req = new Request(COMPACT_URL, {
+      method: 'POST',
+      headers: { 'x-compact-token': env.STATS_COMPACT_TOKEN ?? '' },
+    });
+    ctx.waitUntil(
+      handler.fetch(req, env, ctx).then((res: Response) => {
+        if (!res.ok) console.warn('stats compact cron: status', res.status);
+      }),
+    );
+  },
+};
+
+// OpenNext's DO queue / DO tag cache classes (DOQueueHandler, DOShardedTagCache)
+// would have to be re-exported here if open-next.config.ts ever enabled them;
+// today it only sets the R2 incremental cache, so there is nothing to re-export.

--- a/apps/readest-app/wrangler.toml
+++ b/apps/readest-app/wrangler.toml
@@ -77,9 +77,11 @@ bucket_name = "readest-stats-archive"
 binding = "IAP_WEBHOOK_AE"
 dataset = "iap_webhooks"
 
-# One data point per reading-statistics compaction run: indexes ['compact'],
-# blobs [outcome, error], doubles [users_claimed, users_archived, segments, rows,
-# bytes, duration_ms, errors, commit_mismatches].
+# Reading-statistics archive metrics. One point per compaction run: indexes
+# ['compact'], blobs [outcome, error], doubles [users_claimed, users_archived,
+# segments, rows, bytes, duration_ms, errors, commit_mismatches]. One point per
+# R2-backed stats pull: indexes ['pull'], blobs ['paged'|'full'], doubles
+# [segments_read, segment_rows_returned, limit].
 [[analytics_engine_datasets]]
 binding = "STATS_COMPACT_AE"
 dataset = "stats_compact"

--- a/apps/readest-app/wrangler.toml
+++ b/apps/readest-app/wrangler.toml
@@ -1,9 +1,21 @@
 name = "readest-web"
-main = ".open-next/worker.js"
+# Custom entry: re-exports OpenNext's generated fetch handler and adds the
+# scheduled() handler for the reading-statistics compaction cron (worker.ts).
+main = "./worker.ts"
 compatibility_date = "2026-04-10"
 compatibility_flags = ["nodejs_compat"]
 workers_dev = true
 preview_urls = true
+
+# Reading-statistics compaction (POST /api/stats/compact via worker.ts
+# scheduled()). Every 10 minutes; each run does bounded work and returns.
+[triggers]
+crons = ["*/10 * * * *"]
+
+# A compaction run reads/writes up to 50 users x 5 segments; allow the paid-plan
+# CPU ceiling so a busy run never dies mid-user (the work itself is mostly I/O).
+[limits]
+cpu_ms = 300000
 
 [[routes]]
 pattern = "web-cf.readest.com"
@@ -22,6 +34,15 @@ custom_domain = true
 
 [vars]
 PNPM_VERSION = "10.28.1"
+# Reading-statistics archive kill switch. "true" lets the cron compact
+# stat_pages into R2; anything else makes POST /api/stats/compact answer 503
+# (the cron keeps firing harmlessly). STATS_COMPACT_TOKEN is a secret
+# (`wrangler secret put STATS_COMPACT_TOKEN`). Optional knobs with defaults:
+# STATS_COMPACT_USERS_PER_RUN=50, STATS_COMPACT_WINDOW_DAYS=7,
+# STATS_COMPACT_MIN_ROWS=500, STATS_COMPACT_MAX_AGE_DAYS=30,
+# STATS_COMPACT_HOT_CAP=20000, STATS_COMPACT_SEGMENTS_PER_USER=5,
+# STATS_COMPACT_SEGMENT_ROWS=10000. See docs/stats-archive.md.
+STATS_COMPACT_ENABLED = "false"
 
 [observability]
 enabled = true
@@ -41,9 +62,24 @@ id = "fa6e3eb1988a424bbf3c952e01650ced"
 binding = "NEXT_INC_CACHE_R2_BUCKET"
 bucket_name = "readest-next-inc-cache"
 
+# Reading-statistics archive: immutable per-user JSON segments of page events
+# older than the hot window (stats/v1/{user_id}/{updated_to_ms}.json), listed in
+# the stat_archives table. Written by POST /api/stats/compact, read by the
+# stats pull in /api/sync. Absent binding = feature off (self-host).
+[[r2_buckets]]
+binding = "STATS_ARCHIVE_R2"
+bucket_name = "readest-stats-archive"
+
 # Per-event metrics for the App Store / Google Play subscription webhooks and the
 # reconciliation sweep. 100% capture, independent of the head-sampled Workers
 # Logs above. Queryable via the Analytics Engine SQL API.
 [[analytics_engine_datasets]]
 binding = "IAP_WEBHOOK_AE"
 dataset = "iap_webhooks"
+
+# One data point per reading-statistics compaction run: indexes ['compact'],
+# blobs [outcome, error], doubles [users_claimed, users_archived, segments, rows,
+# bytes, duration_ms, errors, commit_mismatches].
+[[analytics_engine_datasets]]
+binding = "STATS_COMPACT_AE"
+dataset = "stats_compact"

--- a/apps/readest-app/wrangler.toml
+++ b/apps/readest-app/wrangler.toml
@@ -8,14 +8,10 @@ workers_dev = true
 preview_urls = true
 
 # Reading-statistics compaction (POST /api/stats/compact via worker.ts
-# scheduled()). Every 10 minutes; each run does bounded work and returns.
+# scheduled()). Every 10 minutes; each run does bounded work (mostly I/O wait,
+# well inside the default CPU limit) and returns.
 [triggers]
 crons = ["*/10 * * * *"]
-
-# A compaction run reads/writes up to 50 users x 5 segments; allow the paid-plan
-# CPU ceiling so a busy run never dies mid-user (the work itself is mostly I/O).
-[limits]
-cpu_ms = 300000
 
 [[routes]]
 pattern = "web-cf.readest.com"
@@ -79,7 +75,8 @@ dataset = "iap_webhooks"
 
 # Reading-statistics archive metrics. One point per compaction run: indexes
 # ['compact'], blobs [outcome, error], doubles [users_claimed, users_archived,
-# segments, rows, bytes, duration_ms, errors, commit_mismatches]. One point per
+# segments, rows, bytes, duration_ms, errors, commit_mismatches, orphans_swept].
+# One point per
 # R2-backed stats pull: indexes ['pull'], blobs ['paged'|'full'], doubles
 # [segments_read, segment_rows_returned, limit].
 [[analytics_engine_datasets]]

--- a/docker/volumes/db/migrations/020_stat_archives.sql
+++ b/docker/volumes/db/migrations/020_stat_archives.sql
@@ -1,0 +1,207 @@
+-- Migration 020: reading-statistics archive (stat_pages history tiered out of
+-- Postgres into immutable per-user segment objects).
+--
+-- stat_pages keeps a hot window; a compaction job moves older rows into
+-- object storage and records each segment in stat_archives. The stats pull
+-- composes pages from segments + hot rows server-side, so clients never change.
+--
+-- Invariant: a committed segment covers (updated_from, updated_to] exactly and
+-- the same transaction deletes those hot rows; every push stamps
+-- updated_at = now(). Every hot row of a user is therefore newer than every
+-- segment of that user.
+--
+-- All functions below run as service_role (the compaction job) and are
+-- SECURITY INVOKER with a fixed search_path; EXECUTE is revoked from every
+-- other role.
+
+CREATE TABLE IF NOT EXISTS public.stat_archives (
+  user_id       uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  id            bigint GENERATED ALWAYS AS IDENTITY,
+  updated_from  timestamp with time zone NOT NULL,  -- exclusive
+  updated_to    timestamp with time zone NOT NULL,  -- inclusive
+  row_count     integer NOT NULL,
+  bytes         integer NOT NULL,
+  object_key    text NOT NULL,                      -- stats/v1/{user_id}/{updated_to_ms}.json
+  created_at    timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT stat_archives_pkey PRIMARY KEY (user_id, id),
+  CONSTRAINT stat_archives_object_key_key UNIQUE (object_key)
+);
+CREATE INDEX IF NOT EXISTS idx_stat_archives_user_to ON public.stat_archives (user_id, updated_to);
+
+ALTER TABLE public.stat_archives ENABLE ROW LEVEL SECURITY;
+-- Users may list their own manifest (the stats pull runs as the user); only
+-- service_role writes, so there are no insert/update/delete policies.
+DROP POLICY IF EXISTS stat_archives_select ON public.stat_archives;
+CREATE POLICY stat_archives_select ON public.stat_archives FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+-- Single-row sweep cursor for the compaction job.
+CREATE TABLE IF NOT EXISTS public.stat_archive_state (
+  id          smallint PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+  user_cursor uuid,
+  updated_at  timestamp with time zone NOT NULL DEFAULT now()
+);
+INSERT INTO public.stat_archive_state (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+
+-- Next batch of users in stat_pages PK order after the saved cursor (loose
+-- index scan: one PK probe per user), advancing the cursor in the same
+-- statement. The cursor becomes NULL when fewer than p_n users remained, so the
+-- sweep is a ring over every user who currently has any hot row. Serialized by
+-- an advisory lock so overlapping runs receive disjoint batches.
+CREATE OR REPLACE FUNCTION public.stat_archive_claim_users(p_n integer)
+RETURNS SETOF uuid
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_cursor uuid;
+  v_users uuid[];
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('stat_archive_claim'));
+  SELECT user_cursor INTO v_cursor FROM public.stat_archive_state WHERE id = 1 FOR UPDATE;
+  -- (no min(uuid) aggregate in PG 15: ORDER BY ... LIMIT 1 probes the PK)
+  WITH RECURSIVE t(u) AS (
+    SELECT (SELECT user_id FROM public.stat_pages
+            WHERE v_cursor IS NULL OR user_id > v_cursor
+            ORDER BY user_id LIMIT 1)
+    UNION ALL
+    SELECT (SELECT user_id FROM public.stat_pages WHERE user_id > t.u
+            ORDER BY user_id LIMIT 1)
+    FROM t WHERE t.u IS NOT NULL
+  )
+  SELECT coalesce(array_agg(u ORDER BY u), '{}') INTO v_users
+  FROM (SELECT u FROM t WHERE u IS NOT NULL LIMIT p_n) s;
+  UPDATE public.stat_archive_state
+     SET user_cursor = CASE WHEN cardinality(v_users) < p_n THEN NULL
+                            ELSE v_users[cardinality(v_users)] END,
+         updated_at = now()
+   WHERE id = 1;
+  RETURN QUERY SELECT unnest(v_users);
+END;
+$$;
+
+-- Eligibility numbers for one user (index range scans on (user_id, updated_at)).
+CREATE OR REPLACE FUNCTION public.stat_archive_candidate(p_user uuid, p_window interval)
+RETURNS TABLE(eligible integer, oldest timestamp with time zone, hot_total integer,
+              archived_to timestamp with time zone)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT
+    (SELECT count(*)::int FROM public.stat_pages
+      WHERE user_id = p_user AND updated_at <= now() - p_window),
+    (SELECT min(updated_at) FROM public.stat_pages
+      WHERE user_id = p_user AND updated_at <= now() - p_window),
+    (SELECT count(*)::int FROM public.stat_pages WHERE user_id = p_user),
+    (SELECT coalesce(max(updated_to), 'epoch'::timestamptz) FROM public.stat_archives
+      WHERE user_id = p_user);
+$$;
+
+-- Rows for the next segment: everything after p_from up to the window cutoff,
+-- in updated_at order; the first p_limit rows EXTENDED with every row of the
+-- user that falls in the same MILLISECOND as the last one. Clients page on a
+-- millisecond cursor (updated_at_ms) and segments are keyed by updated_to_ms,
+-- so a segment never splits a millisecond; one push chunk shares one
+-- updated_at, so the extension is bounded by concurrent pushes.
+CREATE OR REPLACE FUNCTION public.stat_archive_rows(
+  p_user uuid, p_from timestamp with time zone, p_window interval, p_limit integer)
+RETURNS SETOF public.stat_pages
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  WITH page AS (
+    SELECT * FROM public.stat_pages
+    WHERE user_id = p_user AND updated_at > p_from AND updated_at <= now() - p_window
+    ORDER BY updated_at LIMIT p_limit
+  ), edge AS (SELECT date_trunc('milliseconds', max(updated_at)) AS ms FROM page)
+  SELECT * FROM page
+  UNION
+  SELECT s.* FROM public.stat_pages s, edge
+  WHERE s.user_id = p_user
+    AND s.updated_at >= edge.ms AND s.updated_at < edge.ms + interval '1 millisecond'
+  ORDER BY updated_at, book_hash, page, start_time;
+$$;
+
+-- Atomic commit: compare-and-set on the user's archived_to, manifest insert,
+-- hot-row delete of exactly (p_from, p_to]. The CAS makes a concurrent second
+-- run for the same user fail with 40001 instead of double-archiving; callers
+-- must leave the already-written object alone on any error.
+CREATE OR REPLACE FUNCTION public.stat_archive_commit(
+  p_user uuid, p_key text, p_from timestamp with time zone, p_to timestamp with time zone,
+  p_rows integer, p_bytes integer)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_archived_to timestamptz;
+  v_deleted integer;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('stat_archive_user:' || p_user::text));
+  SELECT coalesce(max(updated_to), 'epoch'::timestamptz) INTO v_archived_to
+    FROM public.stat_archives WHERE user_id = p_user;
+  IF v_archived_to <> p_from THEN
+    RAISE EXCEPTION 'stat_archive_commit: archived_to % <> p_from % for user %',
+      v_archived_to, p_from, p_user USING ERRCODE = '40001';
+  END IF;
+  INSERT INTO public.stat_archives (user_id, updated_from, updated_to, row_count, bytes, object_key)
+    VALUES (p_user, p_from, p_to, p_rows, p_bytes, p_key);
+  DELETE FROM public.stat_pages
+    WHERE user_id = p_user AND updated_at > p_from AND updated_at <= p_to;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;
+
+-- Same merge as upsert_stat_pages (migration 019) for an explicit user: the
+-- restore tool runs as service_role, whose auth.uid() is NULL.
+CREATE OR REPLACE FUNCTION public.upsert_stat_pages_as(p_user uuid, p_rows jsonb)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  INSERT INTO public.stat_pages
+    (user_id, book_hash, page, start_time, duration, total_pages, ext, updated_at, deleted_at)
+  SELECT DISTINCT ON (r.book_hash, r.page, r.start_time)
+    p_user, r.book_hash, r.page, r.start_time,
+    coalesce(r.duration, 0), coalesce(r.total_pages, 0), r.ext, now(), r.deleted_at
+  FROM jsonb_to_recordset(p_rows) AS r(
+    book_hash text, page integer, start_time bigint, duration integer,
+    total_pages integer, ext jsonb, deleted_at timestamptz)
+  ORDER BY r.book_hash, r.page, r.start_time, r.duration DESC NULLS LAST
+  ON CONFLICT (user_id, book_hash, page, start_time) DO UPDATE
+    SET duration = EXCLUDED.duration,
+        total_pages = EXCLUDED.total_pages,
+        ext = EXCLUDED.ext,
+        updated_at = EXCLUDED.updated_at,
+        deleted_at = EXCLUDED.deleted_at
+    WHERE EXCLUDED.duration > stat_pages.duration;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.stat_archive_claim_users(integer) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.stat_archive_candidate(uuid, interval) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.stat_archive_rows(uuid, timestamp with time zone, interval, integer) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.stat_archive_commit(uuid, text, timestamp with time zone, timestamp with time zone, integer, integer) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.upsert_stat_pages_as(uuid, jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.stat_archive_claim_users(integer) TO service_role;
+GRANT EXECUTE ON FUNCTION public.stat_archive_candidate(uuid, interval) TO service_role;
+GRANT EXECUTE ON FUNCTION public.stat_archive_rows(uuid, timestamp with time zone, interval, integer) TO service_role;
+GRANT EXECUTE ON FUNCTION public.stat_archive_commit(uuid, text, timestamp with time zone, timestamp with time zone, integer, integer) TO service_role;
+GRANT EXECUTE ON FUNCTION public.upsert_stat_pages_as(uuid, jsonb) TO service_role;
+
+-- Compaction deletes rows continuously; reclaim them for reuse without waiting
+-- for 20% of a 50M-row table to die first.
+ALTER TABLE public.stat_pages SET (autovacuum_vacuum_scale_factor = 0.01, autovacuum_analyze_scale_factor = 0.02);

--- a/docker/volumes/db/migrations/020_stat_archives.sql
+++ b/docker/volumes/db/migrations/020_stat_archives.sql
@@ -35,13 +35,28 @@ DROP POLICY IF EXISTS stat_archives_select ON public.stat_archives;
 CREATE POLICY stat_archives_select ON public.stat_archives FOR SELECT TO authenticated
   USING ((SELECT auth.uid()) = user_id);
 
--- Single-row sweep cursor for the compaction job.
+-- Single-row sweep cursor for the compaction job. Service-role only: RLS with
+-- no policies denies every other role, and the REVOKE keeps PostgREST from
+-- exposing it through Supabase's default table privileges.
 CREATE TABLE IF NOT EXISTS public.stat_archive_state (
   id          smallint PRIMARY KEY DEFAULT 1 CHECK (id = 1),
   user_cursor uuid,
   updated_at  timestamp with time zone NOT NULL DEFAULT now()
 );
+ALTER TABLE public.stat_archive_state ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.stat_archive_state FROM PUBLIC, anon, authenticated;
 INSERT INTO public.stat_archive_state (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+
+-- Users whose account was deleted while archive objects may still exist under
+-- stats/v1/{user_id}/ (the account-deletion handler queues every deleted user;
+-- the compaction job sweeps the prefix and removes the row once it lists
+-- empty). No foreign key: the auth user is already gone. Service-role only.
+CREATE TABLE IF NOT EXISTS public.stat_archive_orphans (
+  user_id     uuid PRIMARY KEY,
+  created_at  timestamp with time zone NOT NULL DEFAULT now()
+);
+ALTER TABLE public.stat_archive_orphans ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.stat_archive_orphans FROM PUBLIC, anon, authenticated;
 
 -- Next batch of users in stat_pages PK order after the saved cursor (loose
 -- index scan: one PK probe per user), advancing the cursor in the same


### PR DESCRIPTION
## Why

`stat_pages` is an append-only per-user log of page events with one merge rule (longest duration wins); the server never reads history for analytics, devices union-merge everything locally. Keeping the whole history in Postgres is the most expensive way to store it, and the table is the largest object in the database and keeps growing with every page turn.

This PR adds a second tier: Postgres keeps a hot window (rows whose `updated_at` is younger than 7 days by default) and a cron job compacts older rows into immutable per-user JSON segments in R2, listed in a small `stat_archives` manifest. The stats pull composes its pages from segments + hot rows **server-side**, so the sync API, the app and the koplugin do not change; every existing client keeps pulling `statPages` ordered by `updated_at` with the same cursor.

Ships **disabled** (`STATS_COMPACT_ENABLED = "false"`): with no segments the pull path is identical to today's, and the cron endpoint answers 503. See `apps/readest-app/docs/stats-archive.md` for the full design, rollout and rollback.

## What

- `docker/volumes/db/migrations/020_stat_archives.sql`: `stat_archives` manifest (RLS: users read their own rows, only service_role writes), `stat_archive_state` sweep cursor and `stat_archive_orphans` deletion queue (both RLS-enabled with no policies and privileges revoked from `anon`/`authenticated`, so PostgREST never exposes them), service_role-only RPCs `stat_archive_claim_users` (loose index scan ring over users, advisory-locked), `stat_archive_candidate`, `stat_archive_rows` (bounded page extended to the trailing **millisecond**, never splits one), `stat_archive_commit` (compare-and-set on the user's `archived_to` under a per-user advisory lock; manifest insert + hot-row delete of exactly `(from, to]` in one transaction; `40001` for a lost race), `upsert_stat_pages_as` (restore), plus autovacuum settings on `stat_pages`.
- `src/libs/statsArchive.ts`: Worker env surface, request guard (503 before 401; restore refuses with 409 while compaction is enabled), segment codec (encode/decode/validate), `takePage` (strict `> since`, `limit` extended to the trailing ms), `tsToMs` (µs truncation), `readSegment`, `deleteUserSegments`, env-driven policy knobs.
- `src/app/api/stats/compact/route.ts`: the job. Claims a batch of users, archives the eligible ones (`>= 500` eligible rows, or oldest eligible row `> 30 d`, or `> 20k` hot rows) in up to 5 segments of 10k rows per run; object first, commit second; never deletes objects (a lost CAS leaves the object for the winner or the retry); per-user failures are counted, not fatal; one JSON log line + one Analytics Engine point (`STATS_COMPACT_AE`) per run. A JSON body `{"user_id"}` makes it a **targeted run** (that user only, no claiming, enabled flag and thresholds ignored, still token-guarded) for validating on a known account before the cron is enabled or draining one heavy user; only an empty body is the cron's batch request, any other body is a 400. Batch runs first sweep the account-deletion queue (`stat_archive_orphans`, below), kill switch on or off, then apply the kill switch.
- `src/app/api/stats/restore/route.ts`: rollback tool, re-inserts one user's segments through `upsert_stat_pages_as` in 500-row chunks and drops the manifest rows; stops at the first unreadable object and resumes on re-run.
- `src/pages/api/sync.ts`: the stats pull reads hot rows **before** the manifest (a compaction committing in between can only duplicate rows, never lose them) and reads the manifest in `range` pages (PostgREST caps responses at 1000 rows; hot rows are appended only once a short final page proves no archived rows remain, so a truncated manifest can never let a cursor skip segments), then serves segment rows topped up with hot rows, cut at `limit` with the trailing ms kept; unpaginated pulls get every segment then hot rows; a missing/corrupt object answers 500 without advancing anything. Each R2-backed pull (never a hot-only one) writes one Analytics Engine point (`indexes ['pull']`) so the share of pulls reaching the archive can drive the hot-window knob later; we ship with 7 days.
- `src/pages/api/user/delete.ts`: writes a durable tombstone into the service-role-only `stat_archive_orphans` table **before** anything destructive (500 with a retry path if even that fails), then deletes the auth user (compensating the tombstone on failure; objects before a failed `deleteUser` would leave an active account with its history gone), then deletes `stats/v1/{user_id}/` best-effort. Batch compaction runs sweep the queue until each prefix lists empty, and skip (keeping the row) any queued user that still exists, so a stale tombstone can never wipe a living account.
- `worker.ts` + `wrangler.toml`: custom OpenNext worker entry with a `scheduled()` handler (`[triggers] crons = ["*/10 * * * *"]`), `STATS_ARCHIVE_R2` bucket, `STATS_COMPACT_AE` dataset, `STATS_COMPACT_ENABLED = "false"`.
- `scripts/db/verify-migration-020.sh`: throwaway local PostgreSQL 15 run of migrations 014/019/020 with a Supabase-shaped stub, asserting claim ring + cursor wrap, candidate counts, trailing-ms extension (incl. a same-millisecond/different-µs row), commit range delete + CAS `40001`, backlog drain, `upsert_stat_pages_as`, `stat_archives` RLS, and that `anon`/`authenticated` cannot execute any archive RPC.
- `docs/stats-archive.md`: design, invariants, policy knobs, rollout, measurement queries, rollback, account deletion, self-hosting.

## Verification

- `pnpm test`: full suite green (50 new tests across `statsArchive`, the compact/restore routes, the segment-aware pull and the delete handler; the PostgREST mocks apply `eq`/`gt` filters and honor `range`/`delete`); `pnpm lint` clean (tsgo + biome).
- `scripts/db/verify-migration-020.sh`: all checks pass on PostgreSQL 15.19, including RLS on all three archive tables and that `anon`/`authenticated` cannot read the service-role-only ones or execute any archive RPC.
- Not yet exercised: a real Cloudflare deployment with the bucket and the cron (the runbook in the doc).

## Deploy order

Full step-by-step runbook with commands and checks: `apps/readest-app/docs/stats-archive.md` ("Deployment, step by step"). In short:

1. Apply migration 020 (additive, re-runnable).
2. `wrangler r2 bucket create readest-stats-archive`, `wrangler secret put STATS_COMPACT_TOKEN`.
3. `pnpm deploy` with `STATS_COMPACT_ENABLED = "false"` (this PR's default): no behavior change; compact answers 503, restore is live.
4. Validate on one known account in production with a targeted run (`{"user_id"}`), fresh-pull on a device, compare per-book totals; optionally restore.
5. Flip the var to `"true"`, deploy, watch the `stats_compact` Analytics Engine dataset and the measurement queries; `REINDEX INDEX CONCURRENTLY` after the backlog drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
