### PR TITLE
fix(audiobookshelf): hide ABS books without a server row and backfill covers unauthenticated

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useABSSync.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useABSSync.test.tsx
@@ -20,15 +20,17 @@ vi.mock('@/services/sync/replicaPublish', () => ({
 }));
 vi.mock('@/services/audiobookshelf/librarySync', () => ({
   syncAllAbsServers: vi.fn(),
+  backfillAbsCovers: vi.fn(),
 }));
 
-import { syncAllAbsServers } from '@/services/audiobookshelf/librarySync';
+import { backfillAbsCovers, syncAllAbsServers } from '@/services/audiobookshelf/librarySync';
 import { useABSServerStore } from '@/store/absServerStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { eventDispatcher } from '@/utils/event';
 import { useABSSync } from '@/hooks/useABSSync';
 
 const mockedSync = vi.mocked(syncAllAbsServers);
+const mockedBackfill = vi.mocked(backfillAbsCovers);
 
 // contentId/addedAt already set so loadABSServers' backfill is a no-op and
 // doesn't fire an unrelated saveSettings call.
@@ -79,6 +81,23 @@ describe('useABSSync', () => {
 
     expect(mockedSync).toHaveBeenCalledTimes(1);
     expect(mockedSync).toHaveBeenCalledWith(appService);
+  });
+
+  test('backfills covers before the authenticated sync so a failing login cannot block them', async () => {
+    useABSServerStore.setState({ servers: [server] });
+    const order: string[] = [];
+    mockedBackfill.mockImplementation(async () => {
+      order.push('backfill');
+    });
+    mockedSync.mockImplementation(async () => {
+      order.push('sync');
+    });
+
+    renderHook(() => useABSSync());
+    await settle();
+
+    expect(order).toEqual(['backfill', 'sync']);
+    expect(mockedBackfill).toHaveBeenCalledWith(appService);
   });
 
   test('does not sync when neither the store nor settings have servers', async () => {

--- a/apps/readest-app/src/__tests__/services/abs-cover-backfill.test.ts
+++ b/apps/readest-app/src/__tests__/services/abs-cover-backfill.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { backfillAbsCovers } from '@/services/audiobookshelf/librarySync';
+import { useABSServerStore } from '@/store/absServerStore';
+import { useLibraryStore } from '@/store/libraryStore';
+import { useSettingsStore } from '@/store/settingsStore';
+import { makeAbsFilePath } from '@/utils/audiobook';
+import { getCoverFilename } from '@/utils/book';
+import type { ABSServer } from '@/types/audiobookshelf';
+import type { Book } from '@/types/book';
+import type { AppService } from '@/types/system';
+import type { SystemSettings } from '@/types/settings';
+
+// absServerStore publishes replica upserts/deletes from its mutators; state
+// here is seeded via setState, but the module imports replicaPublish at load.
+vi.mock('@/services/sync/replicaPublish', () => ({
+  publishReplicaUpsert: vi.fn(),
+  publishReplicaDelete: vi.fn(),
+}));
+
+vi.mock('@/libs/storage', () => ({
+  downloadFile: vi.fn(),
+}));
+
+import { downloadFile } from '@/libs/storage';
+
+const mockedDownloadFile = vi.mocked(downloadFile);
+
+const server: ABSServer = {
+  id: 'srv1',
+  contentId: 'srv1',
+  addedAt: 1,
+  name: 'Home',
+  url: 'http://abs.local',
+};
+
+const makeAbsBook = (itemId: string, overrides: Partial<Book> = {}): Book =>
+  ({
+    hash: `hash-${itemId}`,
+    format: 'ABS',
+    title: `Title ${itemId}`,
+    author: 'Author',
+    filePath: makeAbsFilePath('srv1', itemId),
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }) as Book;
+
+const makeAppService = (coverExists = false) =>
+  ({
+    resolveFilePath: vi.fn(async (path: string) => `/cache/${path}`),
+    exists: vi.fn(async () => coverExists),
+    readFile: vi.fn(async () => new ArrayBuffer(8)),
+    writeFile: vi.fn(async () => {}),
+    deleteFile: vi.fn(async () => {}),
+    computeCoverHash: vi.fn(async () => 'new-cover-hash'),
+    generateCoverImageUrl: vi.fn(async () => 'blob:new-cover-url'),
+    saveLibraryBooks: vi.fn(async () => {}),
+  }) as unknown as AppService;
+
+describe('backfillAbsCovers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedDownloadFile.mockResolvedValue(undefined as never);
+    useABSServerStore.setState({ servers: [server] });
+    useLibraryStore.setState({ library: [] });
+    useSettingsStore.setState({
+      settings: { absServers: [] } as unknown as SystemSettings,
+    });
+  });
+
+  it('downloads a missing cover unauthenticated and persists the updated book', async () => {
+    const book = makeAbsBook('item1');
+    useLibraryStore.setState({ library: [book] });
+    const appService = makeAppService(false);
+
+    await backfillAbsCovers(appService);
+
+    expect(mockedDownloadFile).toHaveBeenCalledTimes(1);
+    // Cover endpoint is public — the URL must carry no token.
+    const arg = mockedDownloadFile.mock.calls[0]![0] as { url: string };
+    expect(arg.url).toBe('http://abs.local/api/items/item1/cover');
+
+    const updated = useLibraryStore.getState().library.find((b) => b.hash === book.hash)!;
+    expect(updated.coverHash).toBe('new-cover-hash');
+    expect(updated.coverImageUrl).toBe('blob:new-cover-url');
+    // The store entry must be a fresh object; the original book object in the
+    // pre-save library must not have been mutated in place.
+    expect(updated).not.toBe(book);
+    expect(book.coverHash).toBeUndefined();
+
+    expect(appService.saveLibraryBooks).toHaveBeenCalledTimes(1);
+    const saved = vi.mocked(appService.saveLibraryBooks).mock.calls[0]![0] as Book[];
+    expect(saved.find((b) => b.hash === book.hash)?.coverHash).toBe('new-cover-hash');
+  });
+
+  it('skips books whose server row is absent', async () => {
+    useABSServerStore.setState({ servers: [] });
+    useLibraryStore.setState({ library: [makeAbsBook('item1')] });
+    const appService = makeAppService(false);
+
+    await backfillAbsCovers(appService);
+
+    expect(mockedDownloadFile).not.toHaveBeenCalled();
+    expect(appService.saveLibraryBooks).not.toHaveBeenCalled();
+  });
+
+  it('skips books whose cover file already exists locally', async () => {
+    const book = makeAbsBook('item1');
+    useLibraryStore.setState({ library: [book] });
+    const appService = makeAppService(true);
+
+    await backfillAbsCovers(appService);
+
+    expect(vi.mocked(appService.exists)).toHaveBeenCalledWith(getCoverFilename(book), 'Books');
+    expect(mockedDownloadFile).not.toHaveBeenCalled();
+    expect(appService.saveLibraryBooks).not.toHaveBeenCalled();
+  });
+
+  it('skips deleted books and non-ABS books', async () => {
+    useLibraryStore.setState({
+      library: [
+        makeAbsBook('item1', { deletedAt: 123 }),
+        { hash: 'h-epub', format: 'EPUB', title: 'T', filePath: '/books/t.epub' } as Book,
+      ],
+    });
+    const appService = makeAppService(false);
+
+    await backfillAbsCovers(appService);
+
+    expect(mockedDownloadFile).not.toHaveBeenCalled();
+    expect(appService.saveLibraryBooks).not.toHaveBeenCalled();
+  });
+
+  it('leaves the library untouched when the download fails', async () => {
+    mockedDownloadFile.mockRejectedValue(new Error('offline'));
+    const book = makeAbsBook('item1');
+    useLibraryStore.setState({ library: [book] });
+    const appService = makeAppService(false);
+
+    await backfillAbsCovers(appService);
+
+    const entry = useLibraryStore.getState().library.find((b) => b.hash === book.hash)!;
+    expect(entry.coverHash).toBeUndefined();
+    expect(appService.saveLibraryBooks).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/__tests__/store/abs-server-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/abs-server-store.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { findABSServerById, useABSServerStore } from '@/store/absServerStore';
+import { findABSServerById, isAbsBookOrphaned, useABSServerStore } from '@/store/absServerStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { computeAbsServerContentId } from '@/services/sync/adapters/absServer';
+import { makeAbsFilePath } from '@/utils/audiobook';
 import type { ABSServer } from '@/types/audiobookshelf';
+import type { Book } from '@/types/book';
 import type { SystemSettings } from '@/types/settings';
 import type { EnvConfigType } from '@/services/environment';
 
@@ -196,6 +198,57 @@ describe('absServerStore', () => {
 
     it('returns undefined when the server is in neither the store nor settings', () => {
       expect(findABSServerById('missing')).toBeUndefined();
+    });
+  });
+
+  // An ABS book whose server row hasn't synced to this device (or whose
+  // server was removed) cannot stream, has no cover source, and cannot be
+  // opened — the library display hides it until the server row lands.
+  describe('isAbsBookOrphaned', () => {
+    const server: ABSServer = {
+      id: 'srv1',
+      contentId: 'srv1',
+      addedAt: 1,
+      name: 'Home',
+      url: 'http://abs.local',
+    };
+    const absBook = {
+      hash: 'h1',
+      format: 'ABS',
+      title: 'Peter Pan',
+      filePath: makeAbsFilePath('srv1', 'item1'),
+    } as Book;
+
+    it('is false for a non-ABS book', () => {
+      const epub = { hash: 'h2', format: 'EPUB', title: 'T', filePath: '/books/t.epub' } as Book;
+      expect(isAbsBookOrphaned(epub)).toBe(false);
+    });
+
+    it('is true when the server is in neither the store nor settings', () => {
+      expect(isAbsBookOrphaned(absBook)).toBe(true);
+    });
+
+    it('is false when the server is in the in-memory store', () => {
+      useABSServerStore.setState({ servers: [server] });
+      expect(isAbsBookOrphaned(absBook)).toBe(false);
+    });
+
+    it('is false when the server exists only in persisted settings (pre-hydration)', () => {
+      useABSServerStore.setState({ servers: [] });
+      useSettingsStore.setState({
+        settings: { absServers: [server] } as unknown as SystemSettings,
+      });
+      expect(isAbsBookOrphaned(absBook)).toBe(false);
+    });
+
+    it('is true when the in-memory server row is tombstoned', () => {
+      useABSServerStore.setState({ servers: [{ ...server, deletedAt: 123 }] });
+      expect(isAbsBookOrphaned(absBook)).toBe(true);
+    });
+
+    it('is false for a disabled server — configured servers keep their shelf', () => {
+      useABSServerStore.setState({ servers: [{ ...server, disabled: true }] });
+      expect(isAbsBookOrphaned(absBook)).toBe(false);
     });
   });
 });

--- a/apps/readest-app/src/app/library/components/Bookshelf.tsx
+++ b/apps/readest-app/src/app/library/components/Bookshelf.tsx
@@ -25,6 +25,7 @@ import { useEnv } from '@/context/EnvContext';
 import { useThemeStore } from '@/store/themeStore';
 import { useAutoFocus } from '@/hooks/useAutoFocus';
 import { useSettingsStore } from '@/store/settingsStore';
+import { isAbsBookOrphaned, useABSServerStore } from '@/store/absServerStore';
 import { useLibraryStore } from '@/store/libraryStore';
 import { selectActiveBookDownloadProgress, useTransferStore } from '@/store/transferStore';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -285,15 +286,29 @@ const Bookshelf: React.FC<BookshelfProps> = ({
     [router, searchParams],
   );
 
+  // ABS books whose server row hasn't reached this device (or was removed)
+  // can't stream, have no cover source, and can't be opened — hide them from
+  // every shelf derivation (grid, groups, recent shelf, search). They stay in
+  // the store and keep syncing; they reappear the moment the server row
+  // lands. `absServers` and `settings` are deps because the orphan check
+  // reads the server store with a settings fallback, both of which hydrate
+  // asynchronously after the cached library first renders.
+  const absServers = useABSServerStore((state) => state.servers);
+  const visibleBooks = useMemo(
+    () => libraryBooks.filter((book) => !isAbsBookOrphaned(book)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [libraryBooks, absServers, settings],
+  );
+
   const filteredBooks = useMemo(() => {
     const bookFilter = createBookFilter(queryTerm);
-    return queryTerm ? libraryBooks.filter((book) => bookFilter(book)) : libraryBooks;
-  }, [libraryBooks, queryTerm]);
+    return queryTerm ? visibleBooks.filter((book) => bookFilter(book)) : visibleBooks;
+  }, [visibleBooks, queryTerm]);
 
   const manualGroupName = groupBy === LibraryGroupByType.Group ? getGroupName(groupId) : undefined;
   const currentShelfBooks = useMemo(
-    () => resolveCurrentShelfBooks(libraryBooks, groupBy, groupId, manualGroupName),
-    [libraryBooks, groupBy, groupId, manualGroupName],
+    () => resolveCurrentShelfBooks(visibleBooks, groupBy, groupId, manualGroupName),
+    [visibleBooks, groupBy, groupId, manualGroupName],
   );
   const filteredShelfBooks = useMemo(() => {
     const bookFilter = createBookFilter(queryTerm);
@@ -828,10 +843,10 @@ const Bookshelf: React.FC<BookshelfProps> = ({
   );
 
   // Flat recency slice of the whole library, independent of the main shelf's
-  // sort/grouping. Built from `libraryBooks` (not the sorted/filtered items).
+  // sort/grouping. Built from `visibleBooks` (not the sorted/filtered items).
   const recentBooks = useMemo(
-    () => selectRecentShelfBooks(libraryBooks, RECENT_SHELF_BOOK_COUNT),
-    [libraryBooks],
+    () => selectRecentShelfBooks(visibleBooks, RECENT_SHELF_BOOK_COUNT),
+    [visibleBooks],
   );
 
   // Cover transfer overlay progress for every book on screen, from both

--- a/apps/readest-app/src/hooks/useABSSync.ts
+++ b/apps/readest-app/src/hooks/useABSSync.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useEnv } from '@/context/EnvContext';
 import { useABSServerStore } from '@/store/absServerStore';
-import { syncAllAbsServers } from '@/services/audiobookshelf/librarySync';
+import { backfillAbsCovers, syncAllAbsServers } from '@/services/audiobookshelf/librarySync';
 import { eventDispatcher } from '@/utils/event';
 
 const AUTO_CHECK_INTERVAL_MS = 5 * 60 * 1000;
@@ -34,6 +34,9 @@ export function useABSSync() {
 
     try {
       isSyncingRef.current = true;
+      // Covers first, unauthenticated: books adopted via the cloud channel
+      // must not stay coverless behind a failing (or absent) login.
+      await backfillAbsCovers(appService);
       await syncAllAbsServers(appService);
     } catch (error) {
       console.error('ABS sync error:', error);

--- a/apps/readest-app/src/services/audiobookshelf/librarySync.ts
+++ b/apps/readest-app/src/services/audiobookshelf/librarySync.ts
@@ -12,7 +12,7 @@ import { buildAbsBookMetadata, makeAbsFilePath, parseAbsFilePath } from '@/utils
 import { getCoverFilename } from '@/utils/book';
 import { md5 } from '@/utils/md5';
 import { stubTranslation as _, uniqueId } from '@/utils/misc';
-import { useABSServerStore } from '@/store/absServerStore';
+import { findABSServerById, useABSServerStore } from '@/store/absServerStore';
 import { useLibraryStore } from '@/store/libraryStore';
 
 /** Number of audio tracks a library item carries, from whichever field the server populated. */
@@ -186,14 +186,15 @@ const toEnvConfig = (appService: AppService): EnvConfigType => ({
  * Download and write an upserted book's cover. Best effort: any failure
  * (offline, 404, empty body) is logged and skipped, never fails the sync.
  * Mirrors applyOPDSCover (src/services/opds/cover.ts), minus probeAuth —
- * ABS cover URLs are unauthenticated.
+ * ABS cover URLs are unauthenticated. Returns true when the cover was
+ * written and the book's cover fields were updated.
  */
 const downloadAbsCover = async (
   appService: AppService,
   client: ABSClient,
   book: Book,
   itemId: string,
-): Promise<void> => {
+): Promise<boolean> => {
   const tmpPath = await appService.resolveFilePath(`abs_cover_${uniqueId()}`, 'Cache');
   try {
     await downloadFile({
@@ -206,12 +207,14 @@ const downloadAbsCover = async (
       skipSslVerification: true,
     });
     const bytes = (await appService.readFile(tmpPath, 'None', 'binary')) as ArrayBuffer;
-    if (!bytes?.byteLength) return;
+    if (!bytes?.byteLength) return false;
     await appService.writeFile(getCoverFilename(book), 'Books', bytes);
     book.coverHash = await appService.computeCoverHash(book);
     book.coverImageUrl = await appService.generateCoverImageUrl(book);
+    return true;
   } catch (error) {
     console.warn(`[ABS] failed to download cover for "${book.title}":`, error);
+    return false;
   } finally {
     try {
       await appService.deleteFile(tmpPath, 'None');
@@ -219,6 +222,45 @@ const downloadAbsCover = async (
       // best effort cache cleanup
     }
   }
+};
+
+/**
+ * Fetch missing covers for ABS books whose server row is present, without
+ * requiring authentication — ABS cover endpoints are public. Covers the
+ * books-adopted-via-cloud case: a device that received the book rows and the
+ * server row but has no (valid) login yet would otherwise show placeholder
+ * tiles until its first authenticated library sync. Cloned books replace
+ * their store entries only on success; originals are never mutated in place.
+ */
+export const backfillAbsCovers = async (appService: AppService): Promise<void> => {
+  const { library } = useLibraryStore.getState();
+  const clients = new Map<string, ABSClient>();
+  const replaced = new Map<string, Book>();
+  for (const book of library) {
+    if (book.deletedAt) continue;
+    const parsed = parseAbsFilePath(book.filePath);
+    if (!parsed) continue;
+    const server = findABSServerById(parsed.serverId);
+    if (!server || server.deletedAt) continue;
+    if (await appService.exists(getCoverFilename(book), 'Books')) continue;
+    let client = clients.get(server.id);
+    if (!client) {
+      // Cover downloads never touch token endpoints, so no refresh callback.
+      client = new ABSClient(server, { onTokensUpdated: () => {} });
+      clients.set(server.id, client);
+    }
+    const clone = { ...book };
+    if (await downloadAbsCover(appService, client, clone, parsed.itemId)) {
+      replaced.set(book.hash, clone);
+    }
+  }
+  if (replaced.size === 0) return;
+  // Re-read the store: the downloads above are async and a concurrent sync
+  // may have swapped the library array since the first read.
+  const current = useLibraryStore.getState().library;
+  const newLibrary = current.map((book) => replaced.get(book.hash) ?? book);
+  useLibraryStore.getState().setLibrary(newLibrary);
+  await appService.saveLibraryBooks(newLibrary);
 };
 
 /** Orchestrates: fetch, reconcile, apply to the library store, download missing covers. */

--- a/apps/readest-app/src/store/absServerStore.ts
+++ b/apps/readest-app/src/store/absServerStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import type { EnvConfigType } from '@/services/environment';
 import type { ABSServer } from '@/types/audiobookshelf';
+import type { Book } from '@/types/book';
+import { parseAbsFilePath } from '@/utils/audiobook';
 import { useSettingsStore } from './settingsStore';
 import { getReplicaPersistEnv } from '@/services/sync/replicaPersist';
 import { publishReplicaDelete, publishReplicaUpsert } from '@/services/sync/replicaPublish';
@@ -286,4 +288,19 @@ export const findABSServerById = (id: string): ABSServer | undefined => {
   if (inMemory) return inMemory;
   const persisted = useSettingsStore.getState().settings?.absServers ?? [];
   return persisted.find((s) => s.id === id && !s.deletedAt);
+};
+
+/**
+ * True for an ABS book whose server row is absent (not yet synced to this
+ * device, or removed). All audio data lives on the ABS server, so without
+ * the server row the book cannot stream, has no cover source, and cannot be
+ * opened — the library display hides orphans until the server row lands.
+ * The rows themselves stay in the store and keep syncing. A `disabled`
+ * server still counts as configured: disabling only pauses auto-sync.
+ */
+export const isAbsBookOrphaned = (book: Book): boolean => {
+  const parsed = parseAbsFilePath(book.filePath);
+  if (!parsed) return false;
+  const server = findABSServerById(parsed.serverId);
+  return !server || !!server.deletedAt;
 };


### PR DESCRIPTION
## Problem

ABS books ride the cloud books channel as fileless `abs://` stubs, so a signed-in device can adopt them before (or without) having the corresponding Audiobookshelf server configured. Since all audio data lives on the ABS server, such orphaned books are inert on that device: they cannot stream, cannot be opened, and render as coverless placeholder tiles that clutter the library.

Covers have the same dependency: they never travel through Readest Cloud (audiobooks are excluded from file upload), and the only path that fetched them was the authenticated library sync. A device holding the server row but no valid login stayed coverless indefinitely.

## Fix

- **Hide orphaned ABS books from the library display.** New `isAbsBookOrphaned` predicate in `absServerStore` (server row absent or tombstoned; a `disabled` server still counts as configured since disabling only pauses auto-sync). `Bookshelf` filters its shelf derivations (grid, group views, recent shelf, search) through it. The rows stay in the library store and continue to sync, so books reappear the moment the server row lands. This also matches the existing model where removing a server removes its books.
- **Backfill missing covers without authentication.** ABS cover endpoints are public and the item id is derivable from the book's `abs://` filePath, so the new `backfillAbsCovers` fetches missing covers directly from the ABS server. It runs before the authenticated `syncAllAbsServers` in `useABSSync`, so a failing or absent login cannot block it. Books are cloned before mutation and swapped into the store only on success, keeping the mutate-before-save invariant.

## Tests

- 6 new cases for `isAbsBookOrphaned` (non-ABS book, missing server, in-memory server, settings-fallback pre-hydration, tombstoned server, disabled server).
- 5 new cases for `backfillAbsCovers` (unauthenticated download and persist, absent server row, cover already present, deleted/non-ABS books, download failure leaves the library untouched).
- 1 new ordering case in the `useABSSync` suite (backfill runs before the authenticated sync).
- Full suite: 9938 passed, 16 skipped. `pnpm lint` and `pnpm format:check` clean.
- Web-verified: a library containing ABS stubs adopted without their server row now hides them and shows only openable books.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically restores missing Audiobookshelf book covers when synchronizing.
  * Excludes books linked to unavailable or removed Audiobookshelf servers from library shelves and search results.
  * Preserves books linked to temporarily disabled servers.

* **Bug Fixes**
  * Prevents failed cover downloads from creating incomplete library entries.
  * Avoids downloading covers that already exist locally.

* **Tests**
  * Added coverage for cover restoration, orphaned books, synchronization failures, and server states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->