### PR TITLE
fix(stats): survive PostgREST's row cap when building archive segments

### DIFF
--- a/apps/readest-app/docs/stats-archive.md
+++ b/apps/readest-app/docs/stats-archive.md
@@ -70,6 +70,17 @@ Objects are immutable and are **never deleted by the compaction path**: after a 
 commit a concurrent winner's manifest may already reference the key, and a retry
 overwrites the same key with identical content. Only account deletion removes objects.
 
+A segment is **assembled from RPC sub-pages** of at most 1000 rows, because PostgREST
+truncates every response at `db-max-rows` and a truncated page must never define a
+boundary. `stat_archive_rows` (migration 021) ends every page at a complete
+millisecond, trimming the trailing millisecond unless the page provably holds all of
+it, so each sub-boundary is safe; only an empty page means the user is drained (a
+short page can simply mean the trailing millisecond was trimmed).
+`stat_archive_commit` refuses (P0001, full rollback) whenever the range's delete count
+differs from the declared segment row count, so any counting bug is loud and lossless;
+the route reports such refusals as `commit_mismatches` plus an error, and in a healthy
+deployment the metric stays 0.
+
 ## Compaction policy (wrangler vars, defaults)
 
 | Var | Default | Meaning |
@@ -82,7 +93,7 @@ overwrites the same key with identical content. Only account deletion removes ob
 | `STATS_COMPACT_MAX_AGE_DAYS` | 30 | or when the oldest eligible row is older than this |
 | `STATS_COMPACT_HOT_CAP` | 20000 | or when the user has more hot rows than this |
 | `STATS_COMPACT_SEGMENTS_PER_USER` | 5 | segments per user per run |
-| `STATS_COMPACT_SEGMENT_ROWS` | 10000 | rows per segment (extended to the trailing millisecond) |
+| `STATS_COMPACT_SEGMENT_ROWS` | 10000 | rows per assembled segment; fetched in sub-pages of at most 1000 rows (PostgREST's `db-max-rows` cap), each ending at a complete millisecond |
 
 Garbage or out-of-range values fall back to the default. A run answers
 `200 {ok, users_claimed, users_archived, segments, rows, bytes, errors,
@@ -122,9 +133,12 @@ fires every 10 minutes and gets a 503. Prerequisites: `wrangler` logged in
 (`pnpm exec wrangler whoami`) and access to the database SQL editor (or `psql`).
 Run the shell commands from `apps/readest-app`.
 
-**1. Apply migration 020.** Paste `docker/volumes/db/migrations/020_stat_archives.sql`
-into the SQL editor and run it (additive and re-runnable: `IF NOT EXISTS`,
-`CREATE OR REPLACE`, `ON CONFLICT DO NOTHING`). Check:
+**1. Apply migrations 020 and 021.** Paste `docker/volumes/db/migrations/020_stat_archives.sql`
+and then `021_stat_archive_row_cap.sql` into the SQL editor and run them (additive and
+re-runnable: `IF NOT EXISTS`, `CREATE OR REPLACE`, `ON CONFLICT DO NOTHING`). 021 is
+required: it hardens the archive RPCs against PostgREST's 1000-row response cap
+(millisecond-safe trimming in `stat_archive_rows`, row-count refusal in
+`stat_archive_commit`); the 020 versions can lose rows under truncation. Check:
 
 ```sql
 select proname from pg_proc where proname in

--- a/apps/readest-app/docs/stats-archive.md
+++ b/apps/readest-app/docs/stats-archive.md
@@ -70,16 +70,23 @@ Objects are immutable and are **never deleted by the compaction path**: after a 
 commit a concurrent winner's manifest may already reference the key, and a retry
 overwrites the same key with identical content. Only account deletion removes objects.
 
-A segment is **assembled from RPC sub-pages** of at most 1000 rows, because PostgREST
-truncates every response at `db-max-rows` and a truncated page must never define a
-boundary. `stat_archive_rows` (migration 021) ends every page at a complete
-millisecond, trimming the trailing millisecond unless the page provably holds all of
-it, so each sub-boundary is safe; only an empty page means the user is drained (a
-short page can simply mean the trailing millisecond was trimmed).
-`stat_archive_commit` refuses (P0001, full rollback) whenever the range's delete count
-differs from the declared segment row count, so any counting bug is loud and lossless;
-the route reports such refusals as `commit_mismatches` plus an error, and in a healthy
-deployment the metric stays 0.
+A segment is **assembled from keyset sub-pages**, because PostgREST truncates every
+response at `db-max-rows` and a truncated page must never define a boundary.
+`stat_archive_rows` (migration 021) is a plain keyset pager over
+`(updated_at, book_hash, page, start_time)`: truncation only shortens a page, the
+caller's cursor comes from rows it actually received, and the tie columns let it
+paginate *inside* a millisecond that holds more rows than one response can carry
+(a restore can land two 500-row chunks, each stamping one `now()`, in one
+millisecond). The compaction route owns the boundary policy: it fetches pages until
+the target size plus a complete millisecond to cut at (or the user is drained), trims
+the trailing millisecond unless it is provably closed (drained and ended at least a
+minute before the window cutoff, so no still-hot row of it can age in later), defers
+a user whose only eligible rows sit in a still-fresh millisecond, and hard-stops a
+pathological single millisecond beyond 50k rows. `stat_archive_commit` refuses
+(P0001, full rollback) whenever the range's delete count differs from the declared
+segment row count, so any counting bug is loud and lossless; the route reports such
+refusals as `commit_mismatches` plus an error, and in a healthy deployment the metric
+stays 0.
 
 ## Compaction policy (wrangler vars, defaults)
 
@@ -137,8 +144,8 @@ Run the shell commands from `apps/readest-app`.
 and then `021_stat_archive_row_cap.sql` into the SQL editor and run them (additive and
 re-runnable: `IF NOT EXISTS`, `CREATE OR REPLACE`, `ON CONFLICT DO NOTHING`). 021 is
 required: it hardens the archive RPCs against PostgREST's 1000-row response cap
-(millisecond-safe trimming in `stat_archive_rows`, row-count refusal in
-`stat_archive_commit`); the 020 versions can lose rows under truncation. Check:
+(`stat_archive_rows` becomes a truncation-proof keyset pager, `stat_archive_commit`
+refuses row-count mismatches); the 020 versions can lose rows under truncation. Check:
 
 ```sql
 select proname from pg_proc where proname in

--- a/apps/readest-app/scripts/db/verify-migration-020.sh
+++ b/apps/readest-app/scripts/db/verify-migration-020.sh
@@ -105,38 +105,48 @@ declare r record; begin
   raise notice 'ok 2: candidate counts';
 end \$\$;
 
--- 3. rows (migration 021 trim semantics): a limit landing inside a millisecond
---    TRIMS the whole trailing millisecond (loss-proof under any proxy row cap);
---    a page that provably holds the entire trailing millisecond keeps it; a page
---    entirely inside one millisecond extends to the whole millisecond.
+-- 3. rows (migration 021 keyset pager): pages are plain keyset pages over
+--    (updated_at, book_hash, page, start_time); the tie cursor resumes INSIDE a
+--    run of equal timestamps, so any proxy truncation only shortens a page and
+--    can never skip or repeat rows. Boundary policy lives in the caller.
 do \$\$
-declare n int; d int; t0 timestamptz; begin
-  -- limit 4 cuts inside the 2nd ms (3 rows at +1.0ms, 1 at +1.4ms): trim to ms0
-  select count(*), count(distinct date_trunc('milliseconds', updated_at)) into n, d
-    from public.stat_archive_rows('$U1', 'epoch', '7 days', 4);
-  assert n = 3 and d = 1, format('trim: rows=%s ms=%s', n, d);
-  -- limit 5 still cuts inside the run of equal timestamps: same trim
-  select count(*) into n from public.stat_archive_rows('$U1', 'epoch', '7 days', 5);
-  assert n = 3, format('trim equal-ts run: rows=%s', n);
-  -- limit 7 covers the whole 2nd millisecond: kept
-  select count(*), count(distinct date_trunc('milliseconds', updated_at)) into n, d
-    from public.stat_archive_rows('$U1', 'epoch', '7 days', 7);
-  assert n = 7 and d = 2, format('covered ms kept: rows=%s ms=%s', n, d);
-  -- page entirely inside one millisecond: extend to the whole millisecond
-  select max(updated_at) into t0 from public.stat_archive_rows('$U1', 'epoch', '7 days', 3);
-  select count(*) into n from public.stat_archive_rows('$U1', t0, '7 days', 2);
-  assert n = 4, format('single-ms page extends: rows=%s', n);
+declare n int; t0 timestamptz; b text; p int; st bigint; begin
+  -- plain page: exactly the first 4 rows in order, no trimming
+  select count(*) into n from public.stat_archive_rows('$U1', 'epoch', '7 days', 4);
+  assert n = 4, format('page: rows=%s', n);
+  -- resume inside the equal-timestamp run at +1.0ms via the tie cursor
+  select updated_at, book_hash, page, start_time into t0, b, p, st
+    from public.stat_archive_rows('$U1', 'epoch', '7 days', 4)
+    order by updated_at desc, book_hash desc, page desc, start_time desc limit 1;
+  select count(*) into n
+    from public.stat_archive_rows('$U1', t0, '7 days', 100, b, p, st)
+    where updated_at = t0;
+  assert n = 2, format('tie resume inside equal-ts run: rows=%s', n);  -- 3 rows share +1.0ms, 1 consumed
+  -- without the tie cursor the same p_from skips the rest of the run
+  select count(*) into n
+    from public.stat_archive_rows('$U1', t0, '7 days', 100)
+    where updated_at = t0;
+  assert n = 0, format('no tie, no equal-ts rows: %s', n);
+  -- the pages tile the history exactly: 4 + the tie-resumed remainder = all 31
+  select 4 + count(*) into n from public.stat_archive_rows('$U1', t0, '7 days', 100, b, p, st);
+  assert n = 31, format('tiled total %s', n);
   -- large limit returns everything eligible (hot rows excluded by the window)
   select count(*) into n from public.stat_archive_rows('$U1', 'epoch', '7 days', 100);
   assert n = 31, format('all eligible %s', n);
-  raise notice 'ok 3: segment rows trim to complete milliseconds';
+  raise notice 'ok 3: keyset pages tile the history, ties resume inside a millisecond';
 end \$\$;
 
 -- 4. commit: deletes exactly (from, to], returns the count, CAS protects against
 --    a second committer, and a row-count mismatch REFUSES and rolls back
 do \$\$
 declare t_to timestamptz; n int; begin
-  select max(updated_at) into t_to from public.stat_archive_rows('$U1', 'epoch', '7 days', 4);
+  -- boundary = end of the first millisecond (boundaries are the CALLER's job
+  -- now and must sit at complete milliseconds; computed here with plain SQL)
+  select max(updated_at) into t_to from public.stat_pages
+   where user_id = '$U1'
+     and date_trunc('milliseconds', updated_at) =
+         (select min(date_trunc('milliseconds', updated_at)) from public.stat_pages
+           where user_id = '$U1');
   -- refusal first: declaring the wrong row count must roll everything back
   begin
     perform public.stat_archive_commit('$U1', 'stats/v1/u1/seg1-bad.json', 'epoch', t_to, 2, 123);

--- a/apps/readest-app/scripts/db/verify-migration-020.sh
+++ b/apps/readest-app/scripts/db/verify-migration-020.sh
@@ -54,6 +54,7 @@ SQL
 $PSQL -f "$MIGRATIONS/014_add_reading_stats.sql"
 $PSQL -f "$MIGRATIONS/019_stat_pages_upsert_rpc.sql"
 $PSQL -f "$MIGRATIONS/020_stat_archives.sql"
+$PSQL -f "$MIGRATIONS/021_stat_archive_row_cap.sql"
 
 # Seed: u1 has 30 old rows (3 per ms over 10 ms, 40 days ago; the 2nd ms also
 # holds a row 400 microseconds later, i.e. same millisecond, different
@@ -104,33 +105,57 @@ declare r record; begin
   raise notice 'ok 2: candidate counts';
 end \$\$;
 
--- 3. rows: limit 4 lands inside the 2nd millisecond (3 rows at +1.0 ms plus one
---    at +1.4 ms) -> extended to the whole millisecond: 3 + 4 = 7 rows, 2 distinct ms
+-- 3. rows (migration 021 trim semantics): a limit landing inside a millisecond
+--    TRIMS the whole trailing millisecond (loss-proof under any proxy row cap);
+--    a page that provably holds the entire trailing millisecond keeps it; a page
+--    entirely inside one millisecond extends to the whole millisecond.
 do \$\$
-declare n int; d int; begin
+declare n int; d int; t0 timestamptz; begin
+  -- limit 4 cuts inside the 2nd ms (3 rows at +1.0ms, 1 at +1.4ms): trim to ms0
   select count(*), count(distinct date_trunc('milliseconds', updated_at)) into n, d
     from public.stat_archive_rows('$U1', 'epoch', '7 days', 4);
-  assert n = 7 and d = 2, format('rows=%s ms=%s', n, d);
+  assert n = 3 and d = 1, format('trim: rows=%s ms=%s', n, d);
+  -- limit 5 still cuts inside the run of equal timestamps: same trim
+  select count(*) into n from public.stat_archive_rows('$U1', 'epoch', '7 days', 5);
+  assert n = 3, format('trim equal-ts run: rows=%s', n);
+  -- limit 7 covers the whole 2nd millisecond: kept
+  select count(*), count(distinct date_trunc('milliseconds', updated_at)) into n, d
+    from public.stat_archive_rows('$U1', 'epoch', '7 days', 7);
+  assert n = 7 and d = 2, format('covered ms kept: rows=%s ms=%s', n, d);
+  -- page entirely inside one millisecond: extend to the whole millisecond
+  select max(updated_at) into t0 from public.stat_archive_rows('$U1', 'epoch', '7 days', 3);
+  select count(*) into n from public.stat_archive_rows('$U1', t0, '7 days', 2);
+  assert n = 4, format('single-ms page extends: rows=%s', n);
+  -- large limit returns everything eligible (hot rows excluded by the window)
   select count(*) into n from public.stat_archive_rows('$U1', 'epoch', '7 days', 100);
-  assert n = 31, format('all eligible %s', n);  -- hot rows excluded by the window
-  raise notice 'ok 3: segment rows extend to the trailing millisecond';
+  assert n = 31, format('all eligible %s', n);
+  raise notice 'ok 3: segment rows trim to complete milliseconds';
 end \$\$;
 
--- 4. commit: deletes exactly (from, to], returns the count, CAS protects against a second committer
+-- 4. commit: deletes exactly (from, to], returns the count, CAS protects against
+--    a second committer, and a row-count mismatch REFUSES and rolls back
 do \$\$
 declare t_to timestamptz; n int; begin
   select max(updated_at) into t_to from public.stat_archive_rows('$U1', 'epoch', '7 days', 4);
-  n := public.stat_archive_commit('$U1', 'stats/v1/u1/seg1.json', 'epoch', t_to, 7, 123);
-  assert n = 7, format('deleted %s', n);
-  assert (select count(*) from public.stat_pages where user_id = '$U1') = 29;
+  -- refusal first: declaring the wrong row count must roll everything back
+  begin
+    perform public.stat_archive_commit('$U1', 'stats/v1/u1/seg1-bad.json', 'epoch', t_to, 2, 123);
+    raise exception 'mismatched commit must fail';
+  exception when sqlstate 'P0001' then null;
+  end;
+  assert (select count(*) from public.stat_archives where user_id = '$U1') = 0, 'refused commit left no manifest';
+  assert (select count(*) from public.stat_pages where user_id = '$U1') = 36, 'refused commit deleted nothing';
+  n := public.stat_archive_commit('$U1', 'stats/v1/u1/seg1.json', 'epoch', t_to, 3, 123);
+  assert n = 3, format('deleted %s', n);
+  assert (select count(*) from public.stat_pages where user_id = '$U1') = 33;
   assert (select archived_to from public.stat_archive_candidate('$U1', '7 days')) = t_to;
   begin
-    perform public.stat_archive_commit('$U1', 'stats/v1/u1/seg1-dup.json', 'epoch', t_to, 7, 123);
+    perform public.stat_archive_commit('$U1', 'stats/v1/u1/seg1-dup.json', 'epoch', t_to, 3, 123);
     raise exception 'second committer must fail';
   exception when sqlstate '40001' then null;
   end;
   assert (select count(*) from public.stat_archives where user_id = '$U1') = 1;
-  raise notice 'ok 4: commit range delete + CAS 40001';
+  raise notice 'ok 4: commit range delete + mismatch refusal + CAS 40001';
 end \$\$;
 
 -- 5. a follow-up segment resumes from archived_to and drains the rest
@@ -138,8 +163,8 @@ do \$\$
 declare t_from timestamptz; t_to timestamptz; n int; begin
   select archived_to into t_from from public.stat_archive_candidate('$U1', '7 days');
   select max(updated_at) into t_to from public.stat_archive_rows('$U1', t_from, '7 days', 1000);
-  n := public.stat_archive_commit('$U1', 'stats/v1/u1/seg2.json', t_from, t_to, 24, 456);
-  assert n = 24, format('deleted %s', n);
+  n := public.stat_archive_commit('$U1', 'stats/v1/u1/seg2.json', t_from, t_to, 28, 456);
+  assert n = 28, format('deleted %s', n);
   assert (select eligible from public.stat_archive_candidate('$U1', '7 days')) = 0;
   assert (select hot_total from public.stat_archive_candidate('$U1', '7 days')) = 5, 'hot rows untouched';
   raise notice 'ok 5: second segment drains the backlog, hot rows untouched';

--- a/apps/readest-app/src/__tests__/app/api/stats-compact-route.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/stats-compact-route.test.ts
@@ -317,12 +317,15 @@ describe('POST /api/stats/compact run', () => {
       p_window: '7 days',
     });
     // sub-pages never ask for more than PostgREST's db-max-rows cap (1000),
-    // whatever STATS_COMPACT_SEGMENT_ROWS says
+    // whatever STATS_COMPACT_SEGMENT_ROWS says; the first page has no tie cursor
     expect(rpcCalls.find((c) => c.fn === 'stat_archive_rows')?.args).toEqual({
       p_user: 'u1',
       p_from: EPOCH,
       p_window: '7 days',
       p_limit: 1000,
+      p_tie_book: null,
+      p_tie_page: null,
+      p_tie_start: null,
     });
     // u2 is not eligible: no rows fetched, no object written for it
     expect(
@@ -404,30 +407,29 @@ describe('POST /api/stats/compact run', () => {
     });
   });
 
-  it('chains segments for a big user, resuming each from the previous updated_to, bounded per run', async () => {
+  it('chains segments: a mid-millisecond target cut trims, and the next segment refetches the rest', async () => {
     cfEnv = { ...cfEnv, STATS_COMPACT_SEGMENT_ROWS: '2', STATS_COMPACT_SEGMENTS_PER_USER: '3' };
-    let call = 0;
-    rpcHandlers['stat_archive_rows'] = ({ p_from }) => {
-      call++;
-      if (call === 1) {
-        expect(p_from).toBe(EPOCH);
-        return {
-          data: [dbRow('2026-07-01T00:00:00+00:00', 1), dbRow('2026-07-01T00:00:00+00:00', 2)],
-        };
-      }
-      if (call === 2) {
-        expect(p_from).toBe('2026-07-01T00:00:00+00:00');
-        return {
-          data: [dbRow('2026-07-02T00:00:00+00:00', 3), dbRow('2026-07-02T00:00:00+00:00', 4)],
-        };
-      }
-      expect(p_from).toBe('2026-07-02T00:00:00+00:00');
-      return { data: [] };
-    };
+    const jul1 = [dbRow('2026-07-01T00:00:00+00:00', 1), dbRow('2026-07-01T00:00:00+00:00', 2)];
+    const jul2 = [dbRow('2026-07-02T00:00:00+00:00', 3), dbRow('2026-07-02T00:00:00+00:00', 4)];
+    rpcHandlers['stat_archive_rows'] = ({ p_from }) =>
+      p_from === EPOCH
+        ? { data: jul1 }
+        : p_from === '2026-07-01T00:00:00+00:00'
+          ? { data: jul2 }
+          : { data: [] };
     const body = await (await post()).json();
     expect(body).toMatchObject({ segments: 2, rows: 4, users_archived: 1 });
     expect(bucket.put).toHaveBeenCalledTimes(2);
-    expect(rpcCalls.filter((c) => c.fn === 'stat_archive_rows')).toHaveLength(3);
+    // segment 1 hits the target inside the Jul-1 millisecond, fetches on until a
+    // complete millisecond exists, trims the Jul-2 rows and commits Jul-1 only;
+    // segment 2 refetches the Jul-2 rows from the new boundary and keeps them
+    // once the drained-and-old check closes their millisecond.
+    const commits = rpcCalls.filter((c) => c.fn === 'stat_archive_commit');
+    expect(commits.map((c) => [c.args['p_from'], c.args['p_to'], c.args['p_rows']])).toEqual([
+      [EPOCH, '2026-07-01T00:00:00+00:00', 2],
+      ['2026-07-01T00:00:00+00:00', '2026-07-02T00:00:00+00:00', 2],
+    ]);
+    expect(rpcCalls.filter((c) => c.fn === 'stat_archive_rows')).toHaveLength(4);
   });
 
   it('stops a user after the configured number of segments even when more remain', async () => {
@@ -436,7 +438,56 @@ describe('POST /api/stats/compact run', () => {
       p_from === EPOCH ? { data: [dbRow('2026-07-01T00:00:00+00:00', 1)] } : { data: [] };
     const body = await (await post()).json();
     expect(body).toMatchObject({ segments: 1, rows: 1 });
-    expect(rpcCalls.filter((c) => c.fn === 'stat_archive_rows')).toHaveLength(1);
+    // one data page plus the empty page that proves the millisecond is complete
+    expect(rpcCalls.filter((c) => c.fn === 'stat_archive_rows')).toHaveLength(2);
+  });
+
+  it('paginates INSIDE one millisecond with the tie cursor: 1001 equal-timestamp rows, one segment, no loop', async () => {
+    // A restore can land two 500-row chunks in one millisecond, and PostgREST
+    // truncates any response at 1000 rows. The keyset cursor (updated_at,
+    // book_hash, page, start_time) must walk through the millisecond instead of
+    // repeating the same truncated page forever (the migration-020/021-draft bug).
+    const TS = '2026-07-01T00:00:00.123456+00:00';
+    const all = Array.from({ length: 1001 }, (_, i) => dbRow(TS, i + 1));
+    rpcHandlers['stat_archive_rows'] = ({ p_from, p_limit, p_tie_page }) => ({
+      data: all
+        .filter((r) =>
+          p_tie_page == null ? String(r.updated_at) > String(p_from) : r.page > Number(p_tie_page),
+        )
+        .slice(0, Number(p_limit)),
+    });
+    const body = await (await post()).json();
+    expect(body).toMatchObject({ ok: true, users_archived: 1, segments: 1, rows: 1001 });
+
+    const rowsCalls = rpcCalls.filter((c) => c.fn === 'stat_archive_rows');
+    expect(rowsCalls).toHaveLength(3); // 1000 + 1 + the empty drained page
+    expect(rowsCalls[1]!.args).toMatchObject({
+      p_from: TS,
+      p_tie_book: 'h1',
+      p_tie_page: 1000,
+      p_tie_start: 2000,
+    });
+    expect(rowsCalls[2]!.args).toMatchObject({ p_from: TS, p_tie_page: 1001 });
+
+    expect(bucket.put).toHaveBeenCalledTimes(1);
+    const seg = decodeSegment(bucket.put.mock.calls[0]![1] as string);
+    expect(seg.rows).toHaveLength(1001);
+    expect(rpcCalls.find((c) => c.fn === 'stat_archive_commit')?.args).toMatchObject({
+      p_to: TS,
+      p_rows: 1001,
+    });
+  });
+
+  it('defers a user whose only eligible rows sit in a still-fresh millisecond', async () => {
+    // drained, but the trailing millisecond ended too close to the window
+    // cutoff to be provably complete: archive nothing, retry on a later run
+    const fresh = new Date(Date.now() - 7 * 86400000 - 30000).toISOString().replace('Z', '+00:00');
+    rpcHandlers['stat_archive_rows'] = ({ p_from }) =>
+      p_from === EPOCH ? { data: [dbRow(fresh, 1), dbRow(fresh, 2)] } : { data: [] };
+    const body = await (await post()).json();
+    expect(body).toMatchObject({ users_claimed: 2, users_archived: 0, segments: 0, errors: 0 });
+    expect(bucket.put).not.toHaveBeenCalled();
+    expect(rpcCalls.some((c) => c.fn === 'stat_archive_commit')).toBe(false);
   });
 
   it('applies the eligibility rules: min rows, max age, hot cap', async () => {

--- a/apps/readest-app/src/__tests__/app/api/stats-compact-route.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/stats-compact-route.test.ts
@@ -121,8 +121,10 @@ beforeEach(() => {
         : { eligible: 0, oldest: null, hot_total: 3, archived_to: EPOCH },
     ],
   });
-  rpcHandlers['stat_archive_rows'] = ({ p_user }) =>
-    p_user === 'u1'
+  // p_from-aware: the route assembles a segment from sub-pages and advances
+  // p_from between calls, so a static mock would loop forever
+  rpcHandlers['stat_archive_rows'] = ({ p_user, p_from }) =>
+    p_user === 'u1' && p_from === EPOCH
       ? {
           data: [
             dbRow('2026-07-01T00:00:00.123456+00:00', 1),
@@ -168,8 +170,8 @@ describe('POST /api/stats/compact targeted run ({ user_id })', () => {
     rpcHandlers['stat_archive_candidate'] = () => ({
       data: [{ eligible: 3, oldest: daysAgo(8), hot_total: 10, archived_to: EPOCH }],
     });
-    rpcHandlers['stat_archive_rows'] = ({ p_user }) =>
-      p_user === UID
+    rpcHandlers['stat_archive_rows'] = ({ p_user, p_from }) =>
+      p_user === UID && p_from === EPOCH
         ? { data: [dbRow('2026-07-01T00:00:00+00:00', 1), dbRow('2026-07-01T00:00:00+00:00', 2)] }
         : { data: [] };
   });
@@ -314,11 +316,13 @@ describe('POST /api/stats/compact run', () => {
       p_user: 'u1',
       p_window: '7 days',
     });
+    // sub-pages never ask for more than PostgREST's db-max-rows cap (1000),
+    // whatever STATS_COMPACT_SEGMENT_ROWS says
     expect(rpcCalls.find((c) => c.fn === 'stat_archive_rows')?.args).toEqual({
       p_user: 'u1',
       p_from: EPOCH,
       p_window: '7 days',
-      p_limit: 10000,
+      p_limit: 1000,
     });
     // u2 is not eligible: no rows fetched, no object written for it
     expect(
@@ -362,6 +366,44 @@ describe('POST /api/stats/compact run', () => {
     expect(point.doubles.slice(0, 4)).toEqual([2, 1, 1, 3]);
   });
 
+  it('assembles one segment from capped sub-pages: 1000 + 1000 + 77 rows become a single object', async () => {
+    // PostgREST truncates every RPC response at db-max-rows (1000), so a 10k
+    // segment must be assembled from several <=1000-row calls with p_from
+    // advancing; the object and the commit still cover the whole range.
+    const base = Date.UTC(2026, 6, 1);
+    const all = Array.from({ length: 2077 }, (_, i) =>
+      dbRow(new Date(base + i * 1000).toISOString().replace('Z', '+00:00'), (i % 90) + 1),
+    );
+    rpcHandlers['stat_archive_rows'] = ({ p_from, p_limit }) => ({
+      // '1970-...' sorts before '2026-...', so plain string comparison works
+      data: all.filter((r) => String(r.updated_at) > String(p_from)).slice(0, Number(p_limit)),
+    });
+    const body = await (await post()).json();
+    expect(body).toMatchObject({ ok: true, users_archived: 1, segments: 1, rows: 2077 });
+
+    const rowsCalls = rpcCalls.filter((c) => c.fn === 'stat_archive_rows');
+    // three data sub-pages plus the empty call that proves the user is drained
+    expect(rowsCalls.map((c) => c.args['p_limit'])).toEqual([1000, 1000, 1000, 1000]);
+    expect(rowsCalls[1]!.args['p_from']).toBe(all[999]!.updated_at);
+    expect(rowsCalls[2]!.args['p_from']).toBe(all[1999]!.updated_at);
+    expect(rowsCalls[3]!.args['p_from']).toBe(all[2076]!.updated_at);
+
+    expect(bucket.put).toHaveBeenCalledTimes(1);
+    const [key, bodyText] = bucket.put.mock.calls[0]!;
+    const toMs = base + 2076 * 1000;
+    expect(key).toBe(`stats/v1/u1/${toMs}.json`);
+    const seg = decodeSegment(bodyText as string);
+    expect(seg.rows).toHaveLength(2077);
+    expect(seg.updated_to_ms).toBe(toMs);
+
+    const commit = rpcCalls.find((c) => c.fn === 'stat_archive_commit')!;
+    expect(commit.args).toMatchObject({
+      p_from: EPOCH,
+      p_to: all[2076]!.updated_at,
+      p_rows: 2077,
+    });
+  });
+
   it('chains segments for a big user, resuming each from the previous updated_to, bounded per run', async () => {
     cfEnv = { ...cfEnv, STATS_COMPACT_SEGMENT_ROWS: '2', STATS_COMPACT_SEGMENTS_PER_USER: '3' };
     let call = 0;
@@ -390,7 +432,8 @@ describe('POST /api/stats/compact run', () => {
 
   it('stops a user after the configured number of segments even when more remain', async () => {
     cfEnv = { ...cfEnv, STATS_COMPACT_SEGMENT_ROWS: '1', STATS_COMPACT_SEGMENTS_PER_USER: '1' };
-    rpcHandlers['stat_archive_rows'] = () => ({ data: [dbRow('2026-07-01T00:00:00+00:00', 1)] });
+    rpcHandlers['stat_archive_rows'] = ({ p_from }) =>
+      p_from === EPOCH ? { data: [dbRow('2026-07-01T00:00:00+00:00', 1)] } : { data: [] };
     const body = await (await post()).json();
     expect(body).toMatchObject({ segments: 1, rows: 1 });
     expect(rpcCalls.filter((c) => c.fn === 'stat_archive_rows')).toHaveLength(1);
@@ -408,19 +451,38 @@ describe('POST /api/stats/compact run', () => {
         }[p_user as string],
       ],
     });
-    rpcHandlers['stat_archive_rows'] = () => ({ data: [dbRow('2026-07-01T00:00:00+00:00', 1)] });
+    rpcHandlers['stat_archive_rows'] = ({ p_from }) =>
+      p_from === EPOCH ? { data: [dbRow('2026-07-01T00:00:00+00:00', 1)] } : { data: [] };
     const body = await (await post()).json();
     expect(body).toMatchObject({ users_claimed: 4, users_archived: 3, segments: 3 });
     const archivedUsers = rpcCalls
       .filter((c) => c.fn === 'stat_archive_rows')
       .map((c) => c.args['p_user']);
-    expect(archivedUsers).toEqual(['b', 'c', 'd']);
+    // each user makes a data sub-page call plus the drained-empty one
+    expect([...new Set(archivedUsers)]).toEqual(['b', 'c', 'd']);
   });
 
-  it('counts a delete-count mismatch without failing the run', async () => {
-    rpcHandlers['stat_archive_commit'] = () => ({ data: 2 });
+  it('counts a refused commit (P0001 row-count mismatch) as mismatch + error and leaves the object', async () => {
+    // migration 021: stat_archive_commit raises P0001 and rolls back when the
+    // range's delete count differs from the declared segment row count, so a
+    // counting bug can never lose rows silently
+    rpcHandlers['stat_archive_commit'] = () => ({
+      error: {
+        code: 'P0001',
+        message: 'stat_archive_commit: segment holds 3 rows but range would delete 4 for user u1',
+      },
+    });
     const body = await (await post()).json();
-    expect(body).toMatchObject({ ok: true, segments: 1, commit_mismatches: 1, errors: 0 });
+    expect(body).toMatchObject({
+      ok: true,
+      segments: 0,
+      rows: 0,
+      users_archived: 0,
+      commit_mismatches: 1,
+      errors: 1,
+    });
+    expect(bucket.put).toHaveBeenCalledTimes(1); // object written, never deleted
+    expect(bucket.delete).not.toHaveBeenCalled();
   });
 
   it('treats a lost CAS (40001) as a no-op and never deletes the object', async () => {
@@ -446,9 +508,10 @@ describe('POST /api/stats/compact run', () => {
         },
       ],
     });
-    rpcHandlers['stat_archive_rows'] = () => ({
-      data: [dbRow('2026-07-01T00:00:00.123456+00:00', 1)],
-    });
+    rpcHandlers['stat_archive_rows'] = ({ p_from }) =>
+      p_from === '2026-07-01T00:00:00.123+00:00'
+        ? { data: [dbRow('2026-07-01T00:00:00.123456+00:00', 1)] }
+        : { data: [] };
     const body = await (await post()).json();
     expect(body).toMatchObject({ errors: 2, segments: 0, users_archived: 0 });
     expect(bucket.put).not.toHaveBeenCalled();
@@ -460,7 +523,8 @@ describe('POST /api/stats/compact run', () => {
     rpcHandlers['stat_archive_candidate'] = () => ({
       data: [{ eligible: 600, oldest: daysAgo(40), hot_total: 700, archived_to: EPOCH }],
     });
-    rpcHandlers['stat_archive_rows'] = () => ({ data: [dbRow('2026-07-01T00:00:00+00:00', 1)] });
+    rpcHandlers['stat_archive_rows'] = ({ p_from }) =>
+      p_from === EPOCH ? { data: [dbRow('2026-07-01T00:00:00+00:00', 1)] } : { data: [] };
     bucket.put.mockRejectedValueOnce(new Error('r2 down')).mockResolvedValue(undefined);
     const res = await post();
     expect(res.status).toBe(200);

--- a/apps/readest-app/src/app/api/stats/compact/route.ts
+++ b/apps/readest-app/src/app/api/stats/compact/route.ts
@@ -114,6 +114,12 @@ const DAY_MS = 86400000;
 // PostgREST caps every response at db-max-rows (1000 on Supabase); one RPC call
 // can never return more, so segments are assembled from sub-pages of this size.
 const RPC_PAGE = 1000;
+// A trailing millisecond may be kept only when it ended this far before the
+// window cutoff (guards against Worker/database clock skew).
+const CUTOFF_MARGIN_MS = 60000;
+// Hard stop for a pathological single millisecond (a push chunk shares one
+// timestamp, so real runs are a few hundred rows; this is a runaway guard).
+const MS_ASSEMBLY_CAP = 50000;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
@@ -232,42 +238,76 @@ export async function POST(request: Request) {
 
       let from = c.archived_to;
       let archivedAny = false;
-      for (let i = 0; i < cfg.segmentsPerUser; i++) {
-        // PostgREST truncates every RPC response at db-max-rows (1000 on
-        // Supabase), so a segment is ASSEMBLED from sub-pages of at most
-        // RPC_PAGE rows. stat_archive_rows (migration 021) makes every
-        // sub-page end at a complete millisecond, so each sub-boundary is a
-        // safe p_from and the final boundary is a safe commit range end. The
-        // sub-page loop only treats an EMPTY page as "drained": a short page
-        // can simply mean the trailing millisecond was trimmed.
-        const rows: HotRow[] = [];
+      let deferred = false;
+      for (let i = 0; i < cfg.segmentsPerUser && !deferred; i++) {
+        // PostgREST truncates every response at db-max-rows, so segments are
+        // ASSEMBLED from keyset sub-pages (migration 021): the cursor is the
+        // last RECEIVED row's (updated_at, book_hash, page, start_time), which
+        // stays correct under any proxy truncation -- a shortened page can
+        // never skip rows or repeat forever. The millisecond-boundary policy
+        // lives here, not in a page edge: a segment may only end at a COMPLETE
+        // millisecond (clients page on a millisecond cursor and the commit
+        // deletes an updated_at range), so the trailing millisecond is trimmed
+        // unless it provably cannot grow, and an oversized millisecond is
+        // simply fetched to completion across as many sub-pages as it takes.
+        const acc: HotRow[] = [];
         let subFrom = from;
+        let tie: HotRow | null = null;
+        let drained = false;
         for (;;) {
-          const want = Math.min(RPC_PAGE, cfg.segmentRows - rows.length);
-          if (want <= 0) break;
           const { data: pageData, error: rowsErr } = await supabase.rpc('stat_archive_rows', {
             p_user: userId,
             p_from: subFrom,
             p_window: window,
-            p_limit: want,
+            p_limit: RPC_PAGE,
+            p_tie_book: tie ? tie.book_hash : null,
+            p_tie_page: tie ? tie.page : null,
+            p_tie_start: tie ? Number(tie.start_time) : null,
           });
           if (rowsErr) throw rowsErr;
           const page = (pageData ?? []) as HotRow[];
-          if (page.length === 0) break;
-          rows.push(...page);
-          subFrom = page[page.length - 1]!.updated_at;
+          if (page.length === 0) {
+            drained = true;
+            break;
+          }
+          acc.push(...page);
+          tie = page[page.length - 1]!;
+          subFrom = tie.updated_at;
+          if (acc.length >= cfg.segmentRows) {
+            // Enough for a segment, provided a complete millisecond exists to
+            // cut at; otherwise this is one oversized millisecond: keep going.
+            const lastMs = tsToMs(subFrom);
+            if (acc.some((r) => tsToMs(r.updated_at) < lastMs)) break;
+            if (acc.length > MS_ASSEMBLY_CAP) {
+              throw new Error(
+                `millisecond at ${subFrom} exceeds ${MS_ASSEMBLY_CAP} rows for ${userId}`,
+              );
+            }
+          }
         }
-        if (rows.length === 0) break;
-        // The sub-pages arrive in updated_at order; the last row bounds the
-        // segment. Keep its exact (microsecond) timestamp for the commit and the
-        // truncated millisecond for the segment/key.
+        if (acc.length === 0) break;
+        const lastMs = tsToMs(acc[acc.length - 1]!.updated_at);
+        // The trailing millisecond may be kept only when it cannot gain rows
+        // anymore: everything eligible was fetched (drained) and the whole
+        // millisecond sits comfortably past the window cutoff (clock-skew
+        // margin), so no still-hot row of that millisecond can age in later.
+        const msClosed =
+          drained && lastMs < Date.now() - cfg.windowDays * DAY_MS - CUTOFF_MARGIN_MS;
+        const rows = msClosed ? acc : acc.filter((r) => tsToMs(r.updated_at) < lastMs);
+        if (rows.length === 0) {
+          // A single, still-fresh millisecond: defer this user to a later run.
+          deferred = true;
+          break;
+        }
+        // The rows arrive in updated_at order; the last kept row bounds the
+        // segment. Keep its exact (microsecond) timestamp for the commit and
+        // the truncated millisecond for the segment/key.
         const toIso = rows[rows.length - 1]!.updated_at;
         const toMs = tsToMs(toIso);
-        // stat_archive_rows ends every page at a complete millisecond, so
-        // consecutive segments always end in strictly later milliseconds and
-        // the ms-keyed object names cannot collide. Fail loud (this user only)
-        // if that SQL invariant ever regresses, instead of silently
-        // overwriting the previous object.
+        // Every boundary ends at a complete millisecond, so consecutive
+        // segments end in strictly later milliseconds and the ms-keyed object
+        // names cannot collide. Fail loud (this user only) if that invariant
+        // ever regresses, instead of silently overwriting the previous object.
         if (toMs <= tsToMs(from)) {
           throw new Error(
             `segment boundary did not advance past the previous millisecond for ${userId}`,
@@ -329,7 +369,9 @@ export async function POST(request: Request) {
         s.bytes += bytes;
         archivedAny = true;
         from = toIso;
-        if (rows.length < cfg.segmentRows) break;
+        // An empty keyset page is the only "drained" signal; rows trimmed off
+        // the trailing millisecond are refetched by the next segment.
+        if (drained) break;
       }
       if (archivedAny) s.users_archived++;
     } catch (e) {

--- a/apps/readest-app/src/app/api/stats/compact/route.ts
+++ b/apps/readest-app/src/app/api/stats/compact/route.ts
@@ -111,6 +111,9 @@ async function sweepOrphans(
 }
 
 const DAY_MS = 86400000;
+// PostgREST caps every response at db-max-rows (1000 on Supabase); one RPC call
+// can never return more, so segments are assembled from sub-pages of this size.
+const RPC_PAGE = 1000;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
@@ -230,25 +233,41 @@ export async function POST(request: Request) {
       let from = c.archived_to;
       let archivedAny = false;
       for (let i = 0; i < cfg.segmentsPerUser; i++) {
-        const { data: rowsData, error: rowsErr } = await supabase.rpc('stat_archive_rows', {
-          p_user: userId,
-          p_from: from,
-          p_window: window,
-          p_limit: cfg.segmentRows,
-        });
-        if (rowsErr) throw rowsErr;
-        const rows = (rowsData ?? []) as HotRow[];
+        // PostgREST truncates every RPC response at db-max-rows (1000 on
+        // Supabase), so a segment is ASSEMBLED from sub-pages of at most
+        // RPC_PAGE rows. stat_archive_rows (migration 021) makes every
+        // sub-page end at a complete millisecond, so each sub-boundary is a
+        // safe p_from and the final boundary is a safe commit range end. The
+        // sub-page loop only treats an EMPTY page as "drained": a short page
+        // can simply mean the trailing millisecond was trimmed.
+        const rows: HotRow[] = [];
+        let subFrom = from;
+        for (;;) {
+          const want = Math.min(RPC_PAGE, cfg.segmentRows - rows.length);
+          if (want <= 0) break;
+          const { data: pageData, error: rowsErr } = await supabase.rpc('stat_archive_rows', {
+            p_user: userId,
+            p_from: subFrom,
+            p_window: window,
+            p_limit: want,
+          });
+          if (rowsErr) throw rowsErr;
+          const page = (pageData ?? []) as HotRow[];
+          if (page.length === 0) break;
+          rows.push(...page);
+          subFrom = page[page.length - 1]!.updated_at;
+        }
         if (rows.length === 0) break;
-        // The RPC returns rows in updated_at order; the last one bounds the
+        // The sub-pages arrive in updated_at order; the last row bounds the
         // segment. Keep its exact (microsecond) timestamp for the commit and the
         // truncated millisecond for the segment/key.
         const toIso = rows[rows.length - 1]!.updated_at;
         const toMs = tsToMs(toIso);
-        // stat_archive_rows extends every segment to the end of its last
-        // millisecond, so consecutive segments always end in strictly later
-        // milliseconds and the ms-keyed object names cannot collide. Fail loud
-        // (this user only) if that SQL invariant ever regresses, instead of
-        // silently overwriting the previous object.
+        // stat_archive_rows ends every page at a complete millisecond, so
+        // consecutive segments always end in strictly later milliseconds and
+        // the ms-keyed object names cannot collide. Fail loud (this user only)
+        // if that SQL invariant ever regresses, instead of silently
+        // overwriting the previous object.
         if (toMs <= tsToMs(from)) {
           throw new Error(
             `segment boundary did not advance past the previous millisecond for ${userId}`,
@@ -287,13 +306,23 @@ export async function POST(request: Request) {
           p_bytes: bytes,
         });
         if (commitErr) {
-          if ((commitErr as { code?: string }).code === '40001') {
+          const code = (commitErr as { code?: string }).code;
+          if (code === '40001') {
             // Lost the compare-and-set: another run owns this user right now.
             console.info('stats compact: lost CAS for user, skipping', userId);
             break;
           }
+          if (
+            code === 'P0001' &&
+            String((commitErr as { message?: string }).message ?? '').includes('segment holds')
+          ) {
+            // The commit refused a row-count mismatch and rolled back
+            // (migration 021): nothing was lost, the object stays for a retry.
+            s.commit_mismatches++;
+          }
           throw commitErr;
         }
+        // Belt: the SQL refuses mismatches before this can be non-zero.
         if (Number(deleted) !== rows.length) s.commit_mismatches++;
         s.segments++;
         s.rows += rows.length;

--- a/docker/volumes/db/migrations/021_stat_archive_row_cap.sql
+++ b/docker/volumes/db/migrations/021_stat_archive_row_cap.sql
@@ -2,57 +2,48 @@
 -- PostgREST response row cap (Supabase db-max-rows = 1000).
 --
 -- stat_archive_rows is called through PostgREST, whose row cap silently
--- truncates SETOF results. Migration 020's version EXTENDED the page to the end
+-- truncates SETOF results. Migration 020's version extended the page to the end
 -- of its last millisecond; under truncation the cut could land inside a run of
 -- rows sharing one updated_at (a push chunk shares one now()), and the
 -- subsequent range delete in stat_archive_commit then removed rows that were
 -- never archived. Two changes make that class of bug impossible:
 --
--- 1. stat_archive_rows now TRIMS the trailing millisecond unless the page
---    provably contains every row of the user in that millisecond (checked
---    without the window filter, so a window cutoff inside a millisecond can
---    never produce a boundary there either). The whole-millisecond extension
---    survives only for the single-millisecond page, where trimming would return
---    nothing. Every result therefore ends at a complete millisecond, whatever a
---    proxy truncates afterwards, and the caller is expected to request at most
---    the proxy's cap per call and assemble larger segments from several calls.
--- 2. stat_archive_commit now REFUSES (raises, rolling back the manifest insert
---    and the delete) when the range's delete count differs from the declared
+-- 1. stat_archive_rows becomes a plain KEYSET pager over
+--    (updated_at, book_hash, page, start_time). A keyset page is
+--    truncation-proof by construction: any proxy cap only shortens the page,
+--    and the caller's cursor comes from rows it actually received, so progress
+--    is always monotonic and no row can be skipped -- including inside a
+--    millisecond that holds more rows than any single response can carry.
+--    The millisecond-boundary policy (segments must end at complete
+--    milliseconds, because clients page on a millisecond cursor) moves to the
+--    caller, which trims or keeps the trailing millisecond of the rows it
+--    assembled and never derives a boundary from a page edge.
+-- 2. stat_archive_commit REFUSES (raises, rolling back the manifest insert and
+--    the delete) when the range's delete count differs from the declared
 --    segment row count, so any future counting bug fails loud and lossless.
 
-CREATE OR REPLACE FUNCTION public.stat_archive_rows(
-  p_user uuid, p_from timestamp with time zone, p_window interval, p_limit integer)
+-- The signature changes (three cursor parameters), so the 020 version must go:
+-- CREATE OR REPLACE would create an overload next to it.
+DROP FUNCTION IF EXISTS public.stat_archive_rows(uuid, timestamp with time zone, interval, integer);
+
+CREATE FUNCTION public.stat_archive_rows(
+  p_user uuid, p_from timestamp with time zone, p_window interval, p_limit integer,
+  p_tie_book text DEFAULT NULL, p_tie_page integer DEFAULT NULL, p_tie_start bigint DEFAULT NULL)
 RETURNS SETOF public.stat_pages
 LANGUAGE sql
 STABLE
 SECURITY INVOKER
 SET search_path = public
 AS $$
-  WITH page AS (
-    SELECT * FROM public.stat_pages
-    WHERE user_id = p_user AND updated_at > p_from AND updated_at <= now() - p_window
-    ORDER BY updated_at LIMIT p_limit
-  ), edge AS (
-    SELECT date_trunc('milliseconds', max(updated_at)) AS ms FROM page
-  ), ms_rows AS (
-    -- every row of the user in the trailing millisecond, window ignored
-    SELECT s.* FROM public.stat_pages s, edge
-    WHERE s.user_id = p_user
-      AND s.updated_at >= edge.ms AND s.updated_at < edge.ms + interval '1 millisecond'
-  ), covered AS (
-    SELECT (SELECT count(*) FROM ms_rows) =
-           (SELECT count(*) FROM page p, edge WHERE p.updated_at >= edge.ms) AS is_full
-  ), trimmed AS (
-    SELECT p.* FROM page p, edge WHERE p.updated_at < edge.ms
-  )
-  SELECT * FROM (
-    SELECT * FROM trimmed
-    UNION ALL
-    SELECT * FROM ms_rows
-    WHERE (SELECT is_full FROM covered)
-       OR NOT EXISTS (SELECT 1 FROM trimmed)  -- single-millisecond page: whole ms
-  ) t
-  ORDER BY updated_at, book_hash, page, start_time;
+  SELECT * FROM public.stat_pages
+  WHERE user_id = p_user
+    AND updated_at <= now() - p_window
+    AND (updated_at > p_from
+         OR (p_tie_book IS NOT NULL
+             AND updated_at = p_from
+             AND (book_hash, page, start_time) > (p_tie_book, p_tie_page, p_tie_start)))
+  ORDER BY updated_at, book_hash, page, start_time
+  LIMIT p_limit;
 $$;
 
 CREATE OR REPLACE FUNCTION public.stat_archive_commit(
@@ -91,9 +82,10 @@ BEGIN
 END;
 $$;
 
--- Re-apply the execution grants: CREATE OR REPLACE keeps existing privileges,
--- but a fresh self-hosted database applying 020+021 in order must end tight.
-REVOKE EXECUTE ON FUNCTION public.stat_archive_rows(uuid, timestamp with time zone, interval, integer) FROM PUBLIC, anon, authenticated;
+-- Grants for the new signature; the commit function keeps its privileges across
+-- CREATE OR REPLACE but a fresh self-hosted database applying 020+021 must end
+-- tight either way.
+REVOKE EXECUTE ON FUNCTION public.stat_archive_rows(uuid, timestamp with time zone, interval, integer, text, integer, bigint) FROM PUBLIC, anon, authenticated;
 REVOKE EXECUTE ON FUNCTION public.stat_archive_commit(uuid, text, timestamp with time zone, timestamp with time zone, integer, integer) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.stat_archive_rows(uuid, timestamp with time zone, interval, integer) TO service_role;
+GRANT EXECUTE ON FUNCTION public.stat_archive_rows(uuid, timestamp with time zone, interval, integer, text, integer, bigint) TO service_role;
 GRANT EXECUTE ON FUNCTION public.stat_archive_commit(uuid, text, timestamp with time zone, timestamp with time zone, integer, integer) TO service_role;

--- a/docker/volumes/db/migrations/021_stat_archive_row_cap.sql
+++ b/docker/volumes/db/migrations/021_stat_archive_row_cap.sql
@@ -1,0 +1,99 @@
+-- Migration 021: harden the reading-statistics archive RPCs against the
+-- PostgREST response row cap (Supabase db-max-rows = 1000).
+--
+-- stat_archive_rows is called through PostgREST, whose row cap silently
+-- truncates SETOF results. Migration 020's version EXTENDED the page to the end
+-- of its last millisecond; under truncation the cut could land inside a run of
+-- rows sharing one updated_at (a push chunk shares one now()), and the
+-- subsequent range delete in stat_archive_commit then removed rows that were
+-- never archived. Two changes make that class of bug impossible:
+--
+-- 1. stat_archive_rows now TRIMS the trailing millisecond unless the page
+--    provably contains every row of the user in that millisecond (checked
+--    without the window filter, so a window cutoff inside a millisecond can
+--    never produce a boundary there either). The whole-millisecond extension
+--    survives only for the single-millisecond page, where trimming would return
+--    nothing. Every result therefore ends at a complete millisecond, whatever a
+--    proxy truncates afterwards, and the caller is expected to request at most
+--    the proxy's cap per call and assemble larger segments from several calls.
+-- 2. stat_archive_commit now REFUSES (raises, rolling back the manifest insert
+--    and the delete) when the range's delete count differs from the declared
+--    segment row count, so any future counting bug fails loud and lossless.
+
+CREATE OR REPLACE FUNCTION public.stat_archive_rows(
+  p_user uuid, p_from timestamp with time zone, p_window interval, p_limit integer)
+RETURNS SETOF public.stat_pages
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  WITH page AS (
+    SELECT * FROM public.stat_pages
+    WHERE user_id = p_user AND updated_at > p_from AND updated_at <= now() - p_window
+    ORDER BY updated_at LIMIT p_limit
+  ), edge AS (
+    SELECT date_trunc('milliseconds', max(updated_at)) AS ms FROM page
+  ), ms_rows AS (
+    -- every row of the user in the trailing millisecond, window ignored
+    SELECT s.* FROM public.stat_pages s, edge
+    WHERE s.user_id = p_user
+      AND s.updated_at >= edge.ms AND s.updated_at < edge.ms + interval '1 millisecond'
+  ), covered AS (
+    SELECT (SELECT count(*) FROM ms_rows) =
+           (SELECT count(*) FROM page p, edge WHERE p.updated_at >= edge.ms) AS is_full
+  ), trimmed AS (
+    SELECT p.* FROM page p, edge WHERE p.updated_at < edge.ms
+  )
+  SELECT * FROM (
+    SELECT * FROM trimmed
+    UNION ALL
+    SELECT * FROM ms_rows
+    WHERE (SELECT is_full FROM covered)
+       OR NOT EXISTS (SELECT 1 FROM trimmed)  -- single-millisecond page: whole ms
+  ) t
+  ORDER BY updated_at, book_hash, page, start_time;
+$$;
+
+CREATE OR REPLACE FUNCTION public.stat_archive_commit(
+  p_user uuid, p_key text, p_from timestamp with time zone, p_to timestamp with time zone,
+  p_rows integer, p_bytes integer)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_archived_to timestamptz;
+  v_deleted integer;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('stat_archive_user:' || p_user::text));
+  SELECT coalesce(max(updated_to), 'epoch'::timestamptz) INTO v_archived_to
+    FROM public.stat_archives WHERE user_id = p_user;
+  IF v_archived_to <> p_from THEN
+    RAISE EXCEPTION 'stat_archive_commit: archived_to % <> p_from % for user %',
+      v_archived_to, p_from, p_user USING ERRCODE = '40001';
+  END IF;
+  INSERT INTO public.stat_archives (user_id, updated_from, updated_to, row_count, bytes, object_key)
+    VALUES (p_user, p_from, p_to, p_rows, p_bytes, p_key);
+  DELETE FROM public.stat_pages
+    WHERE user_id = p_user AND updated_at > p_from AND updated_at <= p_to;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  IF v_deleted <> p_rows THEN
+    -- The segment does not hold exactly the rows of (p_from, p_to]: refuse and
+    -- roll back (manifest insert and delete both undone) instead of losing the
+    -- difference. The already-written object is harmless: deterministic key,
+    -- overwritten on the next attempt.
+    RAISE EXCEPTION 'stat_archive_commit: segment holds % rows but range (%,%] would delete % for user %',
+      p_rows, p_from, p_to, v_deleted, p_user USING ERRCODE = 'P0001';
+  END IF;
+  RETURN v_deleted;
+END;
+$$;
+
+-- Re-apply the execution grants: CREATE OR REPLACE keeps existing privileges,
+-- but a fresh self-hosted database applying 020+021 in order must end tight.
+REVOKE EXECUTE ON FUNCTION public.stat_archive_rows(uuid, timestamp with time zone, interval, integer) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.stat_archive_commit(uuid, text, timestamp with time zone, timestamp with time zone, integer, integer) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.stat_archive_rows(uuid, timestamp with time zone, interval, integer) TO service_role;
+GRANT EXECUTE ON FUNCTION public.stat_archive_commit(uuid, text, timestamp with time zone, timestamp with time zone, integer, integer) TO service_role;


### PR DESCRIPTION
## Why

Validation of the stats archive (#5835) on a real account produced 1000-row segments and, twice, `commit_mismatches: 1`. Root cause: `stat_archive_rows` is called through PostgREST, and Supabase caps **every** API response — RPC results included — at `db-max-rows` (1000). The function's `LIMIT 10000` never survives the wire, and worse, the truncation can cut inside a run of rows sharing one `updated_at` (a push chunk shares one `now()`), while `stat_archive_commit` deletes the full `(from, to]` range: rows equal to the boundary timestamp but beyond the truncation point were deleted without ever being archived. The `commit_mismatches` metric caught exactly that.

## What

- `docker/volumes/db/migrations/021_stat_archive_row_cap.sql`:
  - `stat_archive_rows` becomes a plain **keyset pager** over `(updated_at, book_hash, page, start_time)` (the old 4-arg signature is dropped; three tie-cursor parameters are added with NULL defaults). A keyset page is truncation-proof by construction: any proxy cap only shortens the page, the caller's cursor comes from rows it actually received, and the tie columns paginate *inside* a millisecond holding more rows than one response can carry (a restore lands 500-row chunks, each stamping one `now()`; two in one millisecond is enough).
  - `stat_archive_commit` **refuses and rolls back** (`P0001`; manifest insert and delete both undone) when the range's delete count differs from the declared segment row count, so any future counting bug fails loud and lossless. The already-written object is harmless (deterministic key, overwritten on retry).
- `src/app/api/stats/compact/route.ts` owns the boundary policy: it assembles keyset pages until `STATS_COMPACT_SEGMENT_ROWS` plus a complete millisecond to cut at (or a drained user), trims the trailing millisecond unless it is provably closed (drained and ended >= 60 s before the window cutoff, so no still-hot row of it can age in later), defers a user whose only eligible rows sit in a still-fresh millisecond, hard-stops a pathological single millisecond beyond 50k rows, and writes one object + one commit per assembled segment. A refused commit counts as `commit_mismatches` + an error for that user.
- `scripts/db/verify-migration-020.sh` now applies 021 and asserts the new semantics: keyset pages tile the history exactly, the tie cursor resumes inside a run of equal timestamps (and skipping it provably loses the run's remainder), and the commit refusal rolls back both the manifest insert and the delete.
- `docs/stats-archive.md`: sub-page assembly, refusal semantics, and the runbook now applies 020 + 021 together.

## Verification

- `scripts/db/verify-migration-020.sh` (migrations 014 + 019 + 020 + 021 on a local PostgreSQL 15): all checks pass, including the keyset tiling, the tie-cursor resume inside an equal-timestamp run, and the refusal rollback.
- `pnpm test`: full suite green; the compact-route suite now covers the sub-page assembly (1000 + 1000 + 77 rows become one object with one commit), **1001 equal-timestamp rows in one millisecond walked with the tie cursor (the reviewer's regression case: one segment, no repeated page, no refused commit)**, the mid-millisecond target cut with the next segment refetching the remainder, the still-fresh-millisecond deferral, and the refusal path; `pnpm lint` clean.

## Deploy order

Apply migration 021 **before** the next compaction run (it is additive: `CREATE OR REPLACE` of two functions plus grant re-application). Deployments that ran the 020 versions against a `db-max-rows`-capped PostgREST should treat any run that reported a non-zero `commit_mismatches` as having lost the rows that shared the boundary timestamp; they can be recovered from any device's local statistics database by re-pushing (the server merge is idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved archive compaction reliability for large datasets and timestamps with many rows.
  - Prevented skipped or duplicated records during paginated processing.
  - Added safeguards for incomplete or still-changing time intervals.
  - Improved handling of commit mismatches and retained stored data when commits fail.

- **Documentation**
  - Updated deployment and migration guidance for the revised archive processing behavior.

- **Tests**
  - Expanded coverage for pagination, boundary handling, large result sets, rollback behavior, and storage failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->