### PR TITLE
fix(koplugin): stop auto sync from prompting for Wi-Fi on book open and wake

### DIFF
--- a/apps/readest.koplugin/main.lua
+++ b/apps/readest.koplugin/main.lua
@@ -28,6 +28,14 @@ local API_CALL_DEBOUNCE_DELAY = 30
 -- into a single pull for the book you settle on instead of stacking blocking
 -- round-trips (#5006).
 local BACKGROUND_PULL_DELAY = 1
+
+-- KOReader's "Action when Wi-Fi is off" (Network settings). nil is "prompt",
+-- the default; "turn on" brings Wi-Fi up without asking; "ignore" (Android)
+-- waits for the system to reconnect. Only "prompt" puts a dialog in front of
+-- the reader.
+local function wifiEnableAction()
+    return G_reader_settings:readSetting("wifi_enable_action") or "prompt"
+end
 local SUPABAE_ANON_KEY_BASE64 = "ZXlKaGJHY2lPaUpJVXpJMU5pSXNJblI1Y0NJNklrcFhWQ0o5LmV5SnBjM01pT2lKemRYQmhZbUZ6WlNJc0luSmxaaUk2SW5aaWMzbDRablZ6YW1weFpIaHJhbkZzZVhOaklpd2ljbTlzWlNJNkltRnViMjRpTENKcFlYUWlPakUzTXpReE1qTTJOekVzSW1WNGNDSTZNakEwT1RZNU9UWTNNWDAuM1U1VXFhb3VfMVNnclZlMWVvOXJBcGMwdUtqcWhwUWRVWGh2d1VIbVVmZw=="
 
 ReadestSync.default_settings = {
@@ -785,18 +793,18 @@ end
 -- "Action when Wi-Fi is off" setting and reruns the call once connected,
 -- like every other interactive network action in KOReader.
 --
--- Background pulls (auto sync on book open / device wake) never bring Wi-Fi
--- up, the same as background pushes. On devices where KOReader drives the
--- radio (Kobo, Kindle, PocketBook, …) that bring-up is modal on the UI
--- thread: "prompt" asks on every wake (#4113, #2137) and "turn on" shows an
--- uncancellable "Connecting to Wi-Fi…" / "Scanning for networks…" for ~30 s
--- when no known access point is in range (#5838). When offline, a background
--- pull skips silently, remembers that it skipped, and onNetworkConnected
--- reruns it once the device is back online (KOReader broadcasts
--- NetworkConnected after its own silent "Restore Wi-Fi connection on resume"
--- completes, and after a manual toggle).
+-- Background pulls (auto sync on book open / device wake) take that path
+-- only when the configured action is silent ("turn on", "ignore"): the user
+-- told KOReader to handle Wi-Fi without asking, so the pull behaves as it
+-- always did. With "prompt" (the default) the same path puts a "Do you want
+-- to turn on Wi-Fi?" box in front of the reader on every open and wake, one
+-- per pull (#4113, #2137, #5838), and a background task must never do that.
+-- So a background pull then skips silently when offline, remembers that it
+-- skipped, and onNetworkConnected reruns it once the device is back online
+-- (KOReader broadcasts NetworkConnected after its own silent "Restore Wi-Fi
+-- connection on resume" completes, and after a manual toggle).
 function ReadestSync:willRerunPullWhenOnline(interactive, callback)
-    if interactive then
+    if interactive or wifiEnableAction() ~= "prompt" then
         return NetworkMgr:willRerunWhenOnline(callback)
     end
     if NetworkMgr:isOnline() then
@@ -1095,21 +1103,25 @@ function ReadestSync:onCloseDocument()
     if not (self.settings.auto_sync and self.settings.access_token) then
         return
     end
-    -- Like the background pulls, the close-time push never brings Wi-Fi up.
-    -- It used to go through NetworkMgr:goOnlineToRun, which with "Action when
-    -- Wi-Fi is off: turn on" blocks the UI thread on a Wi-Fi scan when no
-    -- known access point is in range (#5838), and with "prompt" silently did
-    -- nothing anyway. What was read offline reaches the server with the next
-    -- online push: progress on the next page turn, notes and stats from their
-    -- sync cursors.
+    local function push()
+        self:pushBookConfig(false)
+        self:pushBookNotes(false)
+        self:pushBookStats(false)
+        self:pushOpenBook(false)
+    end
+    -- The push needs the document, so it cannot be deferred: with "turn on"
+    -- let KOReader bring Wi-Fi up (blocking) as it always did. With anything
+    -- else goOnlineToRun refuses to run offline, so skip without a dialog and
+    -- let the next online push catch up.
+    if wifiEnableAction() == "turn_on" then
+        NetworkMgr:goOnlineToRun(push)
+        return
+    end
     if not NetworkMgr:isOnline() then
         logger.dbg("ReadestSync: offline; skipping close-time push")
         return
     end
-    self:pushBookConfig(false)
-    self:pushBookNotes(false)
-    self:pushBookStats(false)
-    self:pushOpenBook(false)
+    push()
 end
 
 function ReadestSync:onReadestPushBooks()
@@ -1134,12 +1146,12 @@ end
 
 -- Waking the device with a book already open should pull like reopening
 -- the book does (issue #4924). Delayed because Wi-Fi is usually still
--- coming back up right after wake; if it isn't back yet the pull skips and
--- onNetworkConnected reruns it (KOReader turns Wi-Fi off on suspend, so on
--- Kobo/Kindle that rerun, once "Restore Wi-Fi connection on resume" has
--- finished, is the path that actually pulls). On devices where
--- Suspend/Resume also fire on focus changes (Android), the debounce keeps
--- this from hammering the API.
+-- coming back up right after wake; with "Action when Wi-Fi is off: prompt"
+-- the pull skips if it isn't, and onNetworkConnected reruns it (KOReader
+-- turns Wi-Fi off on suspend, so on Kobo/Kindle that rerun, once "Restore
+-- Wi-Fi connection on resume" has finished, is the path that actually
+-- pulls). On devices where Suspend/Resume also fire on focus changes
+-- (Android), the debounce keeps this from hammering the API.
 function ReadestSync:onResume()
     -- Guarded because some tests construct a plugin table without calling
     -- init() (see onCloseWidget). The service kept running while suspended

--- a/apps/readest.koplugin/main.lua
+++ b/apps/readest.koplugin/main.lua
@@ -22,10 +22,12 @@ local ReadestSync = WidgetContainer:new{
 }
 
 local API_CALL_DEBOUNCE_DELAY = 30
--- Delay before the on-open pull runs, so the reader paints and becomes
--- interactive first and rapid book switching coalesces to a single pull for
--- the book you settle on, instead of stacking blocking round-trips (#5006).
-local READER_READY_PULL_DELAY = 1
+-- Delay before a background pull runs (book open, device wake, network back).
+-- Lets the reader paint and become interactive first, gives Wi-Fi a moment to
+-- settle after wake (kosync uses the same 1s), and coalesces rapid triggers
+-- into a single pull for the book you settle on instead of stacking blocking
+-- round-trips (#5006).
+local BACKGROUND_PULL_DELAY = 1
 local SUPABAE_ANON_KEY_BASE64 = "ZXlKaGJHY2lPaUpJVXpJMU5pSXNJblI1Y0NJNklrcFhWQ0o5LmV5SnBjM01pT2lKemRYQmhZbUZ6WlNJc0luSmxaaUk2SW5aaWMzbDRablZ6YW1weFpIaHJhbkZzZVhOaklpd2ljbTlzWlNJNkltRnViMjRpTENKcFlYUWlPakUzTXpReE1qTTJOekVzSW1WNGNDSTZNakEwT1RZNU9UWTNNWDAuM1U1VXFhb3VfMVNnclZlMWVvOXJBcGMwdUtqcWhwUWRVWGh2d1VIbVVmZw=="
 
 ReadestSync.default_settings = {
@@ -102,21 +104,27 @@ end
 
 function ReadestSync:onReaderReady()
     if self.settings.auto_sync and self.settings.access_token then
-        -- Defer the per-book pull so the reader is interactive first, and keep a
-        -- handle so a rapid book switch cancels it (onCloseWidget) instead of
-        -- stacking blocking round-trips on the UI thread (issue #5006).
-        if self.reader_ready_pull_task then
-            UIManager:unschedule(self.reader_ready_pull_task)
-        end
-        self.reader_ready_pull_task = function()
-            self.reader_ready_pull_task = nil
-            self:pullBookConfig(false)
-            self:pullBookNotes(false)
-            self:pullBookStats(false)
-        end
-        UIManager:scheduleIn(READER_READY_PULL_DELAY, self.reader_ready_pull_task)
+        -- Defer the per-book pull so the reader is interactive first (issue #5006).
+        self:scheduleBackgroundPull(BACKGROUND_PULL_DELAY)
     end
     self:onDispatcherRegisterReaderActions()
+end
+
+-- Schedule the background pull of the open book's config, notes and stats.
+-- One handle for every trigger (book open, device wake, network back), so
+-- rapid events coalesce into a single pull instead of stacking blocking
+-- round-trips on the UI thread, and onCloseWidget cancels whatever is pending.
+function ReadestSync:scheduleBackgroundPull(delay)
+    if self.background_pull_task then
+        UIManager:unschedule(self.background_pull_task)
+    end
+    self.background_pull_task = function()
+        self.background_pull_task = nil
+        self:pullBookConfig(false)
+        self:pullBookNotes(false)
+        self:pullBookStats(false)
+    end
+    UIManager:scheduleIn(delay, self.background_pull_task)
 end
 
 -- Reverse-lookup table: file extension (lowercase) → Readest format
@@ -769,6 +777,36 @@ function ReadestSync:showSyncInfo()
     })
 end
 
+-- Gate a pull on connectivity. Returns true when the caller must stop
+-- (offline), false to proceed.
+--
+-- Interactive pulls (menu tap / gesture) go through
+-- NetworkMgr:willRerunWhenOnline, which brings Wi-Fi up per KOReader's
+-- "Action when Wi-Fi is off" setting and reruns the call once connected,
+-- like every other interactive network action in KOReader.
+--
+-- Background pulls (auto sync on book open / device wake) never bring Wi-Fi
+-- up, the same as background pushes. On devices where KOReader drives the
+-- radio (Kobo, Kindle, PocketBook, …) that bring-up is modal on the UI
+-- thread: "prompt" asks on every wake (#4113, #2137) and "turn on" shows an
+-- uncancellable "Connecting to Wi-Fi…" / "Scanning for networks…" for ~30 s
+-- when no known access point is in range (#5838). When offline, a background
+-- pull skips silently, remembers that it skipped, and onNetworkConnected
+-- reruns it once the device is back online (KOReader broadcasts
+-- NetworkConnected after its own silent "Restore Wi-Fi connection on resume"
+-- completes, and after a manual toggle).
+function ReadestSync:willRerunPullWhenOnline(interactive, callback)
+    if interactive then
+        return NetworkMgr:willRerunWhenOnline(callback)
+    end
+    if NetworkMgr:isOnline() then
+        return false
+    end
+    logger.dbg("ReadestSync: offline; skipping background pull until NetworkConnected")
+    self.pull_pending_offline = true
+    return true
+end
+
 -- ── Config sync ────────────────────────────────────────────────────
 
 function ReadestSync:pushBookConfig(interactive)
@@ -793,7 +831,7 @@ function ReadestSync:pullBookConfig(interactive)
     local book_hash, meta_hash = self:getBookIdentifiers()
     if not book_hash or not meta_hash then return end
 
-    if NetworkMgr:willRerunWhenOnline(function() self:pullBookConfig(interactive) end) then
+    if self:willRerunPullWhenOnline(interactive, function() self:pullBookConfig(interactive) end) then
         return
     end
 
@@ -823,7 +861,7 @@ end
 
 function ReadestSync:pullBookStats(interactive)
     logger.dbg("ReadestStats pullBookStats: triggered, interactive=" .. tostring(interactive))
-    if NetworkMgr:willRerunWhenOnline(function() self:pullBookStats(interactive) end) then
+    if self:willRerunPullWhenOnline(interactive, function() self:pullBookStats(interactive) end) then
         return
     end
     local client = self:ensureClient(interactive)
@@ -852,7 +890,7 @@ function ReadestSync:pullBookNotes(interactive, full_sync)
     local book_hash, meta_hash = self:getBookIdentifiers()
     if not book_hash or not meta_hash then return end
 
-    if NetworkMgr:willRerunWhenOnline(function() self:pullBookNotes(interactive, full_sync) end) then
+    if self:willRerunPullWhenOnline(interactive, function() self:pullBookNotes(interactive, full_sync) end) then
         return
     end
 
@@ -1054,14 +1092,24 @@ function ReadestSync:pushOpenBook(interactive)
 end
 
 function ReadestSync:onCloseDocument()
-    if self.settings.auto_sync and self.settings.access_token then
-        NetworkMgr:goOnlineToRun(function()
-            self:pushBookConfig(false)
-            self:pushBookNotes(false)
-            self:pushBookStats(false)
-            self:pushOpenBook(false)
-        end)
+    if not (self.settings.auto_sync and self.settings.access_token) then
+        return
     end
+    -- Like the background pulls, the close-time push never brings Wi-Fi up.
+    -- It used to go through NetworkMgr:goOnlineToRun, which with "Action when
+    -- Wi-Fi is off: turn on" blocks the UI thread on a Wi-Fi scan when no
+    -- known access point is in range (#5838), and with "prompt" silently did
+    -- nothing anyway. What was read offline reaches the server with the next
+    -- online push: progress on the next page turn, notes and stats from their
+    -- sync cursors.
+    if not NetworkMgr:isOnline() then
+        logger.dbg("ReadestSync: offline; skipping close-time push")
+        return
+    end
+    self:pushBookConfig(false)
+    self:pushBookNotes(false)
+    self:pushBookStats(false)
+    self:pushOpenBook(false)
 end
 
 function ReadestSync:onReadestPushBooks()
@@ -1086,10 +1134,12 @@ end
 
 -- Waking the device with a book already open should pull like reopening
 -- the book does (issue #4924). Delayed because Wi-Fi is usually still
--- coming back up right after wake (kosync uses the same 1s delay); the
--- pull helpers rerun themselves when online if that isn't enough. On
--- devices where Suspend/Resume also fire on focus changes (Android),
--- the debounce keeps this from hammering the API.
+-- coming back up right after wake; if it isn't back yet the pull skips and
+-- onNetworkConnected reruns it (KOReader turns Wi-Fi off on suspend, so on
+-- Kobo/Kindle that rerun, once "Restore Wi-Fi connection on resume" has
+-- finished, is the path that actually pulls). On devices where
+-- Suspend/Resume also fire on focus changes (Android), the debounce keeps
+-- this from hammering the API.
 function ReadestSync:onResume()
     -- Guarded because some tests construct a plugin table without calling
     -- init() (see onCloseWidget). The service kept running while suspended
@@ -1107,16 +1157,7 @@ function ReadestSync:onResume()
         return
     end
     self.last_resume_sync_timestamp = now
-    if self.resume_pull_task then
-        UIManager:unschedule(self.resume_pull_task)
-    end
-    self.resume_pull_task = function()
-        self.resume_pull_task = nil
-        self:pullBookConfig(false)
-        self:pullBookNotes(false)
-        self:pullBookStats(false)
-    end
-    UIManager:scheduleIn(1, self.resume_pull_task)
+    self:scheduleBackgroundPull(BACKGROUND_PULL_DELAY)
 end
 
 function ReadestSync:onAnnotationsModified(items)
@@ -1139,6 +1180,16 @@ function ReadestSync:onNetworkConnected()
     if self.settings.localsend_enabled then
         self.localsend:startService()
     end
+    -- A background pull (open / wake) was skipped while offline, see
+    -- willRerunPullWhenOnline. Now that the device is online, run it.
+    if not self.pull_pending_offline then
+        return
+    end
+    if not (self.settings.auto_sync and self.settings.access_token and self.ui.document) then
+        return
+    end
+    self.pull_pending_offline = nil
+    self:scheduleBackgroundPull(BACKGROUND_PULL_DELAY)
 end
 
 function ReadestSync:onNetworkDisconnected()
@@ -1154,14 +1205,13 @@ function ReadestSync:onCloseWidget()
         UIManager:unschedule(self.delayed_push_task)
         self.delayed_push_task = nil
     end
-    if self.resume_pull_task then
-        UIManager:unschedule(self.resume_pull_task)
-        self.resume_pull_task = nil
+    if self.background_pull_task then
+        UIManager:unschedule(self.background_pull_task)
+        self.background_pull_task = nil
     end
-    if self.reader_ready_pull_task then
-        UIManager:unschedule(self.reader_ready_pull_task)
-        self.reader_ready_pull_task = nil
-    end
+    -- A skipped pull belongs to the document that was open at the time; the
+    -- next open pulls on its own, so don't carry the flag across books.
+    self.pull_pending_offline = nil
     -- The LocalSend poll belongs to the singleton service, not to this
     -- plugin instance, and its closure captures the singleton (which
     -- survives context switches). Tearing it down here raced the next

--- a/apps/readest.koplugin/spec/koreader_stubs.lua
+++ b/apps/readest.koplugin/spec/koreader_stubs.lua
@@ -106,6 +106,46 @@ M.LibraryWidget = {
     open = function() end,
 }
 
+-- Hoisted so specs can flip connectivity (M.NetworkMgr._online) and observe
+-- which NetworkMgr path a call took. willRerunWhenOnline / goOnlineToRun are
+-- the paths that bring Wi-Fi up (modal on Kobo/Kindle), so specs count them.
+M.NetworkMgr = {
+    _online = true,
+    _willRerunWhenOnline_calls = 0,
+    _goOnlineToRun_calls = 0,
+    isOnline = function(self) return self._online end,
+    isConnected = function(self) return self._online end,
+    willRerunWhenOnline = function(self)
+        self._willRerunWhenOnline_calls = self._willRerunWhenOnline_calls + 1
+        return false
+    end,
+    goOnlineToRun = function(self, cb)
+        self._goOnlineToRun_calls = self._goOnlineToRun_calls + 1
+        cb()
+    end,
+}
+
+-- Bare plugin instance (skips init(): no menu/dispatcher/meta wiring) whose
+-- three pull methods are faked to record their calls, for specs that observe
+-- what a lifecycle event (open / wake / network back) schedules.
+function M.makePullPlugin(ReadestSync, opts)
+    local plugin = setmetatable({
+        settings = {
+            auto_sync = opts.auto_sync,
+            access_token = opts.access_token,
+            localsend_enabled = false,
+        },
+        ui = { document = opts.document },
+        pull_calls = {},
+    }, { __index = ReadestSync })
+    for _, method in ipairs({ "pullBookConfig", "pullBookNotes", "pullBookStats" }) do
+        plugin[method] = function(self, interactive)
+            table.insert(self.pull_calls, { method = method, interactive = interactive })
+        end
+    end
+    return plugin
+end
+
 function M.reset()
     for i = #M.Dispatcher._registered, 1, -1 do
         M.Dispatcher._registered[i] = nil
@@ -114,6 +154,9 @@ function M.reset()
         for i = #list, 1, -1 do list[i] = nil end
     end
     M.util.partialMD5 = function(_file) return "stub-md5" end
+    M.NetworkMgr._online = true
+    M.NetworkMgr._willRerunWhenOnline_calls = 0
+    M.NetworkMgr._goOnlineToRun_calls = 0
     M.LibraryWidget._menu = nil
     M.LibraryWidget._store = nil
     M.LibraryWidget._current_user = nil
@@ -148,12 +191,7 @@ package.preload["ui/widget/container/widgetcontainer"] = function()
         end,
     }
 end
-package.preload["ui/network/manager"] = function()
-    return {
-        willRerunWhenOnline = function() return false end,
-        goOnlineToRun = function(_, cb) cb() end,
-    }
-end
+package.preload["ui/network/manager"] = function() return M.NetworkMgr end
 package.preload["ffi/sha2"] = function()
     return {
         base64_to_bin = function(s) return s end,

--- a/apps/readest.koplugin/spec/main_close_spec.lua
+++ b/apps/readest.koplugin/spec/main_close_spec.lua
@@ -51,6 +51,9 @@ describe("ReadestSync:onCloseDocument", function()
     it("pushes config, notes, stats and the open book row (no library pull)", function()
         local plugin = makePlugin({ auto_sync = true, access_token = "tok" })
         plugin:onCloseDocument()
+        -- Never through goOnlineToRun: with "Action when Wi-Fi is off: turn on"
+        -- that blocks the UI thread on a Wi-Fi scan (issue #5838).
+        assert.are.equal(0, stubs.NetworkMgr._goOnlineToRun_calls)
 
         local by = called(plugin)
         assert.truthy(by.pushBookConfig)
@@ -60,6 +63,16 @@ describe("ReadestSync:onCloseDocument", function()
         assert.is_false(by.pushOpenBook.arg1)  -- non-interactive
         -- The heavy full-library pull ("both") must be gone from the close path.
         assert.is_nil(by.syncBooksLibrary)
+    end)
+
+    it("skips the close-time push silently when offline (no Wi-Fi bring-up)", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok" })
+        stubs.NetworkMgr._online = false
+        plugin:onCloseDocument()
+
+        assert.are.equal(0, #plugin.calls)
+        assert.are.equal(0, stubs.NetworkMgr._goOnlineToRun_calls)
+        assert.are.equal(0, stubs.NetworkMgr._willRerunWhenOnline_calls)
     end)
 
     it("does nothing when auto sync is disabled", function()

--- a/apps/readest.koplugin/spec/main_close_spec.lua
+++ b/apps/readest.koplugin/spec/main_close_spec.lua
@@ -75,6 +75,22 @@ describe("ReadestSync:onCloseDocument", function()
         assert.are.equal(0, stubs.NetworkMgr._willRerunWhenOnline_calls)
     end)
 
+    it("lets KOReader bring Wi-Fi up for the close-time push when the action is turn on", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok" })
+        G_reader_settings:saveSetting("wifi_enable_action", "turn_on")
+        stubs.NetworkMgr._online = false
+        plugin:onCloseDocument()
+        G_reader_settings:saveSetting("wifi_enable_action", nil)
+
+        -- As before this change: goOnlineToRun connects (blocking) and runs the pushes.
+        assert.are.equal(1, stubs.NetworkMgr._goOnlineToRun_calls)
+        local by = called(plugin)
+        assert.truthy(by.pushBookConfig)
+        assert.truthy(by.pushBookNotes)
+        assert.truthy(by.pushBookStats)
+        assert.truthy(by.pushOpenBook)
+    end)
+
     it("does nothing when auto sync is disabled", function()
         local plugin = makePlugin({ auto_sync = false, access_token = "tok" })
         plugin:onCloseDocument()

--- a/apps/readest.koplugin/spec/main_offline_pull_spec.lua
+++ b/apps/readest.koplugin/spec/main_offline_pull_spec.lua
@@ -9,7 +9,9 @@
 -- that it skipped, and onNetworkConnected reruns it once the device is back
 -- online. Interactive pulls (menu taps / gestures) keep going through
 -- NetworkMgr:willRerunWhenOnline, like every other interactive KOReader
--- network action.
+-- network action, and so do background pulls when KOReader's "Action when
+-- Wi-Fi is off" is a silent one ("turn on", "ignore"): only "prompt" would
+-- put a dialog up, so only "prompt" is bypassed.
 
 require("spec_helper")
 local stubs = require("spec.koreader_stubs")
@@ -42,6 +44,33 @@ end
 describe("ReadestSync:willRerunPullWhenOnline", function()
     before_each(function()
         stubs.reset()
+        G_reader_settings:saveSetting("wifi_enable_action", nil)  -- KOReader default: prompt
+    end)
+
+    -- "turn on" and "ignore" never show a dialog, so a background pull keeps
+    -- taking KOReader's path, exactly as before.
+    for _, action in ipairs({ "turn_on", "ignore" }) do
+        it("takes NetworkMgr's path for a background pull when the Wi-Fi action is " .. action, function()
+            local plugin = makePlugin({ auto_sync = true, access_token = "tok", document = {} })
+            G_reader_settings:saveSetting("wifi_enable_action", action)
+            NetworkMgrStub._online = false
+
+            assert.is_false(plugin:willRerunPullWhenOnline(false, function() end))
+            assert.are.equal(1, NetworkMgrStub._willRerunWhenOnline_calls)
+            assert.is_nil(plugin.pull_pending_offline)
+            G_reader_settings:saveSetting("wifi_enable_action", nil)
+        end)
+    end
+
+    it("skips a background pull when offline with the action set to prompt explicitly", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok", document = {} })
+        G_reader_settings:saveSetting("wifi_enable_action", "prompt")
+        NetworkMgrStub._online = false
+
+        assert.is_true(plugin:willRerunPullWhenOnline(false, function() end))
+        assert.are.equal(0, NetworkMgrStub._willRerunWhenOnline_calls)
+        assert.is_true(plugin.pull_pending_offline)
+        G_reader_settings:saveSetting("wifi_enable_action", nil)
     end)
 
     it("lets a background pull proceed when online, without asking NetworkMgr to bring Wi-Fi up", function()

--- a/apps/readest.koplugin/spec/main_offline_pull_spec.lua
+++ b/apps/readest.koplugin/spec/main_offline_pull_spec.lua
@@ -1,0 +1,332 @@
+-- main_offline_pull_spec.lua
+-- Background (auto sync) pulls on book open / device wake must never bring
+-- Wi-Fi up (issue #5838; the "prompt" shape of the same thing is #4113 and
+-- #2137). On devices where KOReader drives the radio (Kobo, Kindle, …)
+-- NetworkMgr:willRerunWhenOnline → beforeWifiAction is modal on the UI
+-- thread: "prompt" asks on every wake, "turn on" shows an uncancellable
+-- "Scanning for networks…" for ~30 s when no known AP is in range. So a
+-- background pull that finds the device offline skips silently, remembers
+-- that it skipped, and onNetworkConnected reruns it once the device is back
+-- online. Interactive pulls (menu taps / gestures) keep going through
+-- NetworkMgr:willRerunWhenOnline, like every other interactive KOReader
+-- network action.
+
+require("spec_helper")
+local stubs = require("spec.koreader_stubs")
+
+local UIManagerStub = stubs.UIManager
+local NetworkMgrStub = stubs.NetworkMgr
+local ReadestSync = require("main")
+
+-- Pull methods faked: observes what a lifecycle event schedules.
+local function makePlugin(opts)
+    return stubs.makePullPlugin(ReadestSync, opts)
+end
+
+-- Real pull methods, stopped at ensureClient: observes whether the network
+-- gate let a pull through (the sync modules themselves are out of scope).
+local function makeRealPlugin()
+    local plugin = setmetatable({
+        settings = { auto_sync = true, access_token = "tok", localsend_enabled = false },
+        ui = { document = {} },
+        ensure_client_calls = 0,
+    }, { __index = ReadestSync })
+    plugin.getBookIdentifiers = function() return "book-hash", "meta-hash" end
+    plugin.ensureClient = function(self)
+        self.ensure_client_calls = self.ensure_client_calls + 1
+        return nil
+    end
+    return plugin
+end
+
+describe("ReadestSync:willRerunPullWhenOnline", function()
+    before_each(function()
+        stubs.reset()
+    end)
+
+    it("lets a background pull proceed when online, without asking NetworkMgr to bring Wi-Fi up", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok", document = {} })
+        NetworkMgrStub._online = true
+
+        assert.is_false(plugin:willRerunPullWhenOnline(false, function() end))
+        assert.are.equal(0, NetworkMgrStub._willRerunWhenOnline_calls)
+        assert.is_nil(plugin.pull_pending_offline)
+    end)
+
+    it("skips a background pull when offline and never asks NetworkMgr to bring Wi-Fi up", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok", document = {} })
+        NetworkMgrStub._online = false
+
+        assert.is_true(plugin:willRerunPullWhenOnline(false, function() end))
+        -- This is the whole point: no beforeWifiAction, so no blocking modal.
+        assert.are.equal(0, NetworkMgrStub._willRerunWhenOnline_calls)
+        assert.is_true(plugin.pull_pending_offline)
+    end)
+
+    it("routes an interactive pull through NetworkMgr:willRerunWhenOnline", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok", document = {} })
+        NetworkMgrStub._online = false
+
+        assert.is_false(plugin:willRerunPullWhenOnline(true, function() end))
+        assert.are.equal(1, NetworkMgrStub._willRerunWhenOnline_calls)
+        assert.is_nil(plugin.pull_pending_offline)
+    end)
+end)
+
+describe("ReadestSync background pulls while offline", function()
+    before_each(function()
+        stubs.reset()
+    end)
+
+    -- Real pull methods (not the fakes): each must bail before ensureClient
+    -- when offline, and reach it when online.
+    for _, method in ipairs({ "pullBookConfig", "pullBookNotes", "pullBookStats" }) do
+        it(method .. "(false) bails before ensureClient when offline", function()
+            local plugin = makeRealPlugin()
+
+            NetworkMgrStub._online = false
+            plugin[method](plugin, false)
+            assert.are.equal(0, plugin.ensure_client_calls)
+            assert.are.equal(0, NetworkMgrStub._willRerunWhenOnline_calls)
+            assert.is_true(plugin.pull_pending_offline)
+
+            NetworkMgrStub._online = true
+            plugin[method](plugin, false)
+            assert.are.equal(1, plugin.ensure_client_calls)
+        end)
+    end
+end)
+
+describe("ReadestSync interactive pulls while offline", function()
+    local original_will_rerun
+
+    before_each(function()
+        stubs.reset()
+        original_will_rerun = NetworkMgrStub.willRerunWhenOnline
+    end)
+
+    after_each(function()
+        NetworkMgrStub.willRerunWhenOnline = original_will_rerun
+    end)
+
+    -- When NetworkMgr takes over (it will bring Wi-Fi up and rerun), the
+    -- pull must stop before ensureClient, must not set the background flag,
+    -- and the rerun closure must re-invoke the same method with the same
+    -- arguments (interactive, and full_sync for notes).
+    for _, case in ipairs({
+        { method = "pullBookConfig", args = { true } },
+        { method = "pullBookStats", args = { true } },
+        { method = "pullBookNotes", args = { true, true } },
+    }) do
+        it(case.method .. "(true) stops when NetworkMgr will rerun, and the rerun keeps its args", function()
+            local plugin = makeRealPlugin()
+            local captured
+            NetworkMgrStub.willRerunWhenOnline = function(self, cb)
+                self._willRerunWhenOnline_calls = self._willRerunWhenOnline_calls + 1
+                captured = cb
+                return true
+            end
+            NetworkMgrStub._online = false
+
+            plugin[case.method](plugin, unpack(case.args))
+            assert.are.equal(0, plugin.ensure_client_calls)
+            assert.are.equal(1, NetworkMgrStub._willRerunWhenOnline_calls)
+            assert.is_nil(plugin.pull_pending_offline)
+            assert.is_function(captured)
+
+            local rerun
+            plugin[case.method] = function(_, a, b) rerun = { a, b } end
+            captured()
+            assert.are.same(case.args, rerun)
+        end)
+    end
+end)
+
+describe("ReadestSync:scheduleBackgroundPull", function()
+    before_each(function()
+        stubs.reset()
+    end)
+
+    -- One handle for every trigger: a wake or a reconnect while the open
+    -- pull is still pending replaces it instead of stacking a second one.
+    it("keeps one pending pull when resume follows open", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok", document = {} })
+        plugin:onReaderReady()
+        plugin:onResume()
+        assert.are.equal(1, #UIManagerStub._scheduled)
+    end)
+
+    it("keeps one pending pull when NetworkConnected follows open, and clears the handle after firing", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok", document = {} })
+        plugin:onReaderReady()
+        plugin.pull_pending_offline = true
+        plugin:onNetworkConnected()
+        assert.are.equal(1, #UIManagerStub._scheduled)
+
+        UIManagerStub._scheduled[1].fn()
+        assert.are.equal(3, #plugin.pull_calls)
+        assert.is_nil(plugin.background_pull_task)
+    end)
+end)
+
+describe("ReadestSync:onNetworkConnected", function()
+    before_each(function()
+        stubs.reset()
+    end)
+
+    it("reruns the skipped pull once the device is back online", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok", document = {} })
+        plugin.pull_pending_offline = true
+
+        plugin:onNetworkConnected()
+
+        assert.are.equal(1, #UIManagerStub._scheduled)
+        -- Deferred, like the open pull: let the event settle first.
+        assert.is_true(UIManagerStub._scheduled[1].delay > 0)
+        assert.is_nil(plugin.pull_pending_offline)
+
+        UIManagerStub._scheduled[1].fn()
+        assert.are.equal(3, #plugin.pull_calls)
+        local pulled = {}
+        for _, call in ipairs(plugin.pull_calls) do
+            pulled[call.method] = true
+            assert.is_false(call.interactive)
+        end
+        assert.is_true(pulled.pullBookConfig)
+        assert.is_true(pulled.pullBookNotes)
+        assert.is_true(pulled.pullBookStats)
+    end)
+
+    it("does nothing when no pull was skipped", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok", document = {} })
+        plugin:onNetworkConnected()
+        assert.are.equal(0, #UIManagerStub._scheduled)
+    end)
+
+    it("does nothing without an open document (FileManager context)", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok", document = nil })
+        plugin.pull_pending_offline = true
+        plugin:onNetworkConnected()
+        assert.are.equal(0, #UIManagerStub._scheduled)
+    end)
+
+    it("does nothing when auto sync is off or signed out, and keeps the flag for later", function()
+        for _, opts in ipairs({
+            { auto_sync = false, access_token = "tok", document = {} },
+            { auto_sync = true, access_token = nil, document = {} },
+        }) do
+            local plugin = makePlugin(opts)
+            plugin.pull_pending_offline = true
+            plugin:onNetworkConnected()
+            assert.are.equal(0, #UIManagerStub._scheduled)
+            -- The skip still belongs to this document; the gate is re-checked
+            -- on the next NetworkConnected.
+            assert.is_true(plugin.pull_pending_offline)
+        end
+    end)
+
+    it("coalesces repeated NetworkConnected events into one pull", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok", document = {} })
+        plugin.pull_pending_offline = true
+        plugin:onNetworkConnected()
+        plugin.pull_pending_offline = true
+        plugin:onNetworkConnected()
+        assert.are.equal(1, #UIManagerStub._scheduled)
+    end)
+
+    it("drops the pending pull and the flag when the widget closes", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok", document = {} })
+        plugin.pull_pending_offline = true
+        plugin:onNetworkConnected()
+        assert.are.equal(1, #UIManagerStub._scheduled)
+
+        plugin.pull_pending_offline = true  -- as if another pull skipped meanwhile
+        plugin:onCloseWidget()
+        assert.are.equal(0, #UIManagerStub._scheduled)
+        assert.is_nil(plugin.pull_pending_offline)
+    end)
+
+    it("onCloseWidget with nothing pending is a no-op that still clears the flag", function()
+        local plugin = makePlugin({ auto_sync = true, access_token = "tok", document = {} })
+        plugin.pull_pending_offline = true
+        plugin:onCloseWidget()
+        assert.are.equal(0, #UIManagerStub._scheduled)
+        assert.is_nil(plugin.pull_pending_offline)
+        assert.is_nil(plugin.background_pull_task)
+    end)
+end)
+
+describe("ReadestSync offline open, then reconnect (end to end)", function()
+    before_each(function()
+        stubs.reset()
+    end)
+
+    -- Real gates and real scheduling, no fakes for the pull methods.
+    it("skips on open while offline, then reruns all three pulls once online", function()
+        local plugin = makeRealPlugin()
+        NetworkMgrStub._online = false
+
+        plugin:onReaderReady()
+        assert.are.equal(1, #UIManagerStub._scheduled)
+        table.remove(UIManagerStub._scheduled, 1).fn()
+        assert.are.equal(0, plugin.ensure_client_calls)
+        assert.are.equal(0, NetworkMgrStub._willRerunWhenOnline_calls)
+        assert.is_true(plugin.pull_pending_offline)
+
+        NetworkMgrStub._online = true
+        plugin:onNetworkConnected()
+        assert.are.equal(1, #UIManagerStub._scheduled)
+        assert.is_nil(plugin.pull_pending_offline)
+        table.remove(UIManagerStub._scheduled, 1).fn()
+        assert.are.equal(3, plugin.ensure_client_calls)
+
+        -- A second NetworkConnected has nothing to rerun.
+        plugin:onNetworkConnected()
+        assert.are.equal(0, #UIManagerStub._scheduled)
+    end)
+
+    -- KOReader broadcasts NetworkConnected on link-up (isConnected), while
+    -- isOnline is a DNS resolve that can still fail for a moment. The rerun
+    -- must then re-arm the flag for the next NetworkConnected: no modal, no
+    -- loop.
+    it("re-arms the flag when the NetworkConnected rerun still finds the device offline", function()
+        local plugin = makeRealPlugin()
+        NetworkMgrStub._online = false
+
+        plugin:onReaderReady()
+        UIManagerStub:drain()
+        assert.is_true(plugin.pull_pending_offline)
+        assert.are.equal(0, plugin.ensure_client_calls)
+
+        plugin:onNetworkConnected()
+        assert.is_nil(plugin.pull_pending_offline)
+        UIManagerStub:drain()
+        assert.is_true(plugin.pull_pending_offline)
+        assert.are.equal(0, NetworkMgrStub._willRerunWhenOnline_calls)
+        assert.are.equal(0, #UIManagerStub._scheduled)
+
+        NetworkMgrStub._online = true
+        plugin:onNetworkConnected()
+        UIManagerStub:drain()
+        assert.are.equal(3, plugin.ensure_client_calls)
+    end)
+
+    -- Turning auto sync on pulls the open book's config right away
+    -- (onReadestSyncToggleAutoSync); that pull is background too, so offline
+    -- it skips silently instead of bringing Wi-Fi up, and reconnect reruns it.
+    it("toggling auto sync on while offline skips silently and reruns on reconnect", function()
+        local plugin = makeRealPlugin()
+        plugin.settings.auto_sync = false
+        NetworkMgrStub._online = false
+
+        plugin:onReadestSyncToggleAutoSync(true)
+        assert.is_true(plugin.settings.auto_sync)
+        assert.are.equal(0, plugin.ensure_client_calls)
+        assert.are.equal(0, NetworkMgrStub._willRerunWhenOnline_calls)
+        assert.is_true(plugin.pull_pending_offline)
+
+        NetworkMgrStub._online = true
+        plugin:onNetworkConnected()
+        assert.are.equal(1, #UIManagerStub._scheduled)
+    end)
+end)

--- a/apps/readest.koplugin/spec/main_open_spec.lua
+++ b/apps/readest.koplugin/spec/main_open_spec.lua
@@ -12,19 +12,7 @@ local UIManagerStub = stubs.UIManager
 local ReadestSync = require("main")
 
 local function makePlugin(opts)
-    local plugin = setmetatable({
-        settings = {
-            auto_sync = opts.auto_sync,
-            access_token = opts.access_token,
-        },
-        pull_calls = {},
-    }, { __index = ReadestSync })
-    for _, method in ipairs({ "pullBookConfig", "pullBookNotes", "pullBookStats" }) do
-        plugin[method] = function(self, interactive)
-            table.insert(self.pull_calls, { method = method, interactive = interactive })
-        end
-    end
-    return plugin
+    return stubs.makePullPlugin(ReadestSync, opts)
 end
 
 describe("ReadestSync:onReaderReady", function()

--- a/apps/readest.koplugin/spec/main_resume_spec.lua
+++ b/apps/readest.koplugin/spec/main_resume_spec.lua
@@ -12,23 +12,8 @@ local UIManagerStub = stubs.UIManager
 
 local ReadestSync = require("main")
 
--- Bare plugin instance: skips init() (menu/dispatcher/meta wiring) and
--- fakes the pull methods so tests observe what onResume triggers.
 local function makePlugin(opts)
-    local plugin = setmetatable({
-        settings = {
-            auto_sync = opts.auto_sync,
-            access_token = opts.access_token,
-        },
-        ui = { document = opts.document },
-        pull_calls = {},
-    }, { __index = ReadestSync })
-    for _, method in ipairs({ "pullBookConfig", "pullBookNotes", "pullBookStats" }) do
-        plugin[method] = function(self, interactive)
-            table.insert(self.pull_calls, { method = method, interactive = interactive })
-        end
-    end
-    return plugin
+    return stubs.makePullPlugin(ReadestSync, opts)
 end
 
 describe("ReadestSync:onResume", function()


### PR DESCRIPTION
Addresses #5838 (the "prompt" shape fully; see below for the "turn on" shape), #4113 and #2137.

## Summary

With Auto sync on, the pulls on book open (`onReaderReady`) and device wake (`onResume`) went through `NetworkMgr:willRerunWhenOnline`. When the device is offline that calls `beforeWifiAction`, which with KOReader's default "Action when Wi-Fi is off: prompt" puts a "Do you want to turn on Wi-Fi?" box in front of the reader, one per pull, so three stacked boxes on every open and every wake (#4113, #2137; reproduced on the emulator). Background pushes never did this; only the pulls asked.

**Background pulls now bypass KOReader's Wi-Fi bring-up only when that bring-up would prompt.** With "prompt", an offline pull skips silently, sets `pull_pending_offline`, and `onNetworkConnected` reruns it once the device is back online. KOReader turns Wi-Fi off on every suspend, so on Kobo/Kindle that rerun (after KOReader's own silent "Restore Wi-Fi connection on resume") is the path that actually pulls on wake for "prompt" users. With "turn on" (what kosync forces for its own auto sync) or "ignore" (Android) the pull keeps taking `willRerunWhenOnline` exactly as before: the user told KOReader to handle Wi-Fi without asking. Interactive pulls (menu taps, gestures) are unchanged for every setting.

The close-time push mirrors that: "turn on" keeps `NetworkMgr:goOnlineToRun` (the push needs the document, so it cannot be deferred); for anything else `goOnlineToRun` already refused to run offline, so it now skips without a dialog and the next online push catches up (progress on that book's next page turn, stats from their push cursor).

The three identical open/wake/reconnect pull schedulers are folded into `scheduleBackgroundPull` with one task handle and one `BACKGROUND_PULL_DELAY`, so rapid events coalesce into one pull and `onCloseWidget` cancels whatever is pending.

### What this means for #5838's "turn on" shape

The ~30 s uncancellable "Scanning for networks..." on Kobo is KOReader's "turn on" behaviour for every plugin (kosync's own wake pull triggers the same scan), and this PR leaves "turn on" alone on purpose. The reporter gets the behaviour they asked for by setting "Action when Wi-Fi is off: prompt": auto sync then never asks and never scans, only things they tap (OPDS, dictionary, a manual sync) ask first, and "Restore Wi-Fi connection on resume" gives silent at-home wake sync. If closing #5838 without a settings change on their side is wanted, the opt-in "Auto sync only when already online" toggle from @SynVisions' branch (thank you; this PR adapts its specs) fits on top of this change and would only affect "turn on" users.

### Why not "never bring Wi-Fi up"

The first version of this branch did that. The adversarial review pass showed the cost: "turn on" users without "Restore Wi-Fi connection on resume" (both KOReader defaults for anyone who came from kosync) would get no sync after a wake until a manual toggle, and an annotation made in that state would be dropped by the shared notes cursor (first follow-up below) once a pull succeeds. Respecting the configured action regresses nobody: only "prompt" ever showed a dialog, so only "prompt" is bypassed.

## Test Coverage

AI-assessed coverage audit of the diff: 33/40 code paths and user flows covered before the review pass; the 7 gaps now have tests (interactive rerun closure keeping its arguments, cross-trigger coalescing, end-to-end offline open then reconnect with the real gates, the rerun re-arming the flag when `NetworkConnected` arrives while `isOnline()` is still false, the auto sync toggle while offline, the no-op close), plus the "turn on" / "ignore" / explicit "prompt" gate cases and the "turn on" close-time push. Busted: 321 tests on main, 347 here.

## Pre-Landing Review

- Checklist pass (data safety, concurrency, trust boundary, enum completeness): no findings. The one concurrency surface (scheduled pull task vs. widget teardown) is a single handle cancelled in `onCloseWidget`, exercised by the specs.
- Testing and maintainability specialists: 9 informational findings; 7 addressed (one named `BACKGROUND_PULL_DELAY` instead of a bare `1` in `onResume`, the `NetworkMgr` stub moved above `reset()`, the pull-recording plugin factory shared by the open/resume/offline specs, the test gaps above). Left as-is (confidence 4): the stub models `isConnected`/`isOnline` as one flag.
- Adversarial pass (Claude subagent; Codex CLI present but not authenticated): its two "request changes" items (the "turn on" regression and the notes cursor exposure) are what moved this PR from "never bring Wi-Fi up" to "respect the configured action". The rest are listed under follow-ups.

## Verification

- `pnpm test:lua`: 347 successes / 0 failures (new `spec/main_offline_pull_spec.lua`; `main_close_spec.lua` gains the offline skip, the "turn on" `goOnlineToRun` case, and asserts `goOnlineToRun` is never used otherwise; the `NetworkMgr` stub gains a toggleable `isOnline` and call counters)
- `pnpm lint:lua`: clean
- KOReader emulator (SDL `Emulator` device with its fake Wi-Fi toggle, `NetworkMgr:isOnline` patched locally to honour it), driven headlessly through HttpInspector, with KOReader's default "prompt":
  - old plugin, Wi-Fi off, open book: three stacked ConfirmBox prompts (reproduces the bug on the rig)
  - new plugin, Wi-Fi off, open book: three silent skips, no prompt, `pull_pending_offline = true`
  - `NetworkConnected` broadcast: the deferred pull ran (config applied, notes and stats pulled)
  - Wi-Fi off, close book: "offline; skipping close-time push", no `goOnlineToRun`
  - Wi-Fi on, close book: config, notes, stats and the open-book row pushed
  - Wi-Fi on, open book: pull runs immediately, as before
- The "turn on" path is the unchanged code path (`willRerunWhenOnline` / `goOnlineToRun`), pinned by unit tests; not re-run on the emulator.
- Not verified on a physical Kobo/Kindle.

## Follow-ups (pre-existing, not changed here)

- **Shared notes cursor.** `SyncAnnotations:getAnnotations` filters local annotations with the global `settings.last_notes_sync_at`, and a successful pull advances the same cursor (`readest_syncannotations.lua:488`). Any annotation made while a push cannot succeed (offline, away from home) is skipped by every later push once any pull succeeds; only "Full sync all annotations" recovers it. Fix sketch: a per-book push cursor in `doc_settings.readest_sync` for the push filter (falling back to the global one for books that never pushed), and the pull cursor left to pulls.
- No persisted queue for close-time pushes (kosync has `KOSyncQueue`), so progress of a book closed offline with "prompt" syncs only when that book is reopened and a page turns.
- Optional opt-in toggle for "turn on" users (above), and a help text on the "Auto sync" menu item.
- Three `isOnline()` DNS resolves per background batch when the link is up but the WAN is down (same count as before); `pushBookConfig(false)` has no connectivity gate and its debounce advances on failure.

## TODOS

No TODO items completed in this PR.

## Test plan

- [x] `pnpm test:lua` and `pnpm lint:lua`
- [x] KOReader emulator scenarios above ("prompt")
- [ ] Physical Kobo/Kindle on "prompt": open/wake offline shows no dialog; wake at home with "Restore Wi-Fi connection on resume" pulls
- [ ] Physical Kobo/Kindle on "turn on": behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background synchronization while offline by skipping silently and retrying automatically after reconnection.
  * Preserved configured Wi‑Fi behavior for close-time synchronization, including enabling Wi‑Fi when explicitly configured.
  * Canceled pending background syncs when closing a reader or switching documents.
  * Consolidated background sync requests to avoid duplicate pulls.

* **Tests**
  * Added coverage for offline recovery, Wi‑Fi settings, close behavior, scheduling, and document or authentication safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->