### PR TITLE
fix(sync): send S3 object keys in SigV4 canonical form

### DIFF
--- a/apps/readest-app/src/__tests__/services/sync/providers/s3/S3Provider.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/providers/s3/S3Provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from 'vitest';
+import { AwsV4Signer } from 'aws4fetch';
 import { createS3Provider, type S3FetchFn } from '@/services/sync/providers/s3/S3Provider';
 import { FileSyncError } from '@/services/sync/file/provider';
 import { runSemanticContract } from '@/__tests__/services/sync/file/providerSemanticContract';
@@ -100,6 +101,34 @@ describe('S3Provider — transport', () => {
     expect(h.url(0)).toContain(`/readest/Readest/books/h1/${encodeURIComponent('白夜行.epub')}`);
   });
 
+  // SigV4 signs the RFC 3986 form of the path, where `!'()*` are `%21%27%28%29%2A`.
+  // AWS/R2 re-canonicalize the received path so a raw `(` on the wire still
+  // verifies, but Qiniu Kodo (#5839) does not re-canonicalize a path that
+  // already contains percent-encoding, so the wire path must already match.
+  test('sends keys with sub-delims in SigV4 canonical (RFC 3986) form', async () => {
+    const h = makeS3();
+    h.fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await h.provider.head("/Readest/books/h1/测试(test)*!'.epub");
+    const objectUrl = h.url(0);
+    expect(new URL(objectUrl).pathname).toBe(
+      '/readest/Readest/books/h1/%E6%B5%8B%E8%AF%95%28test%29%2A%21%27.epub',
+    );
+    // The invariant the fix rests on: the path on the wire is the path that was signed.
+    const signerFor = (url: string) =>
+      new AwsV4Signer({ url, method: 'HEAD', service: 's3', ...config });
+    expect(new URL(objectUrl).pathname).toBe(signerFor(objectUrl).encodedPath);
+
+    // Same rule for query values: the canonical query string is RFC 3986 too.
+    h.fetchMock.mockResolvedValueOnce(xml(emptyList));
+    await h.provider.list('/Readest/(dir)');
+    const listUrl = h.url(1);
+    expect(new URL(listUrl).search).toContain('prefix=Readest%2F%28dir%29%2F');
+    expect(new URL(listUrl).search.slice(1).split('&').sort().join('&')).toBe(
+      signerFor(listUrl).encodedSearch,
+    );
+  });
+
   test('head returns size and the ETag stripped of quotes', async () => {
     const h = makeS3();
     h.fetchMock.mockResolvedValueOnce(
@@ -157,7 +186,7 @@ describe('S3Provider — transport', () => {
       .mockResolvedValueOnce(
         xml(
           listPage({
-            keys: [{ key: 'Readest/books/h1/config.json' }, { key: 'Readest/books/h1/B.epub' }],
+            keys: [{ key: 'Readest/books/h1/config.json' }, { key: 'Readest/books/h1/B (1).epub' }],
           }),
         ),
       )
@@ -171,6 +200,8 @@ describe('S3Provider — transport', () => {
     expect(h.method(1)).toBe('DELETE');
     expect(h.method(2)).toBe('DELETE');
     expect(h.url(1)).toContain('config.json');
+    // Listed keys are raw (no encoding-type=url), so they are encoded exactly once.
+    expect(new URL(h.url(2)).pathname).toBe('/readest/Readest/books/h1/B%20%281%29.epub');
   });
 
   test('retries a transient 503 with backoff and then succeeds', async () => {

--- a/apps/readest-app/src/services/sync/providers/s3/S3Provider.ts
+++ b/apps/readest-app/src/services/sync/providers/s3/S3Provider.ts
@@ -157,8 +157,22 @@ const keyFor = (path: string): string =>
     .filter((s) => s.length > 0)
     .join('/');
 
+/**
+ * Percent-encode a path segment or query value in SigV4 canonical (RFC 3986)
+ * form: like `encodeURIComponent`, plus the sub-delims `!'()*` it leaves raw.
+ * The signer canonicalizes both the path and the query this way. AWS and R2
+ * re-canonicalize whatever arrives, but some gateways (Qiniu Kodo, #5839) do
+ * not re-canonicalize a path that already contains percent-encoding, so the
+ * wire form must already match. Same escaping as the AWS SDK's `escapeUri`.
+ */
+const encodeSegment = (segment: string): string =>
+  encodeURIComponent(segment).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+
 /** Percent-encode a key for the URL path, keeping `/` separators. */
-const encodeKey = (key: string): string => key.split('/').map(encodeURIComponent).join('/');
+const encodeKey = (key: string): string => key.split('/').map(encodeSegment).join('/');
 
 /** Parse a `Retry-After` header (delta-seconds) into ms, or undefined. */
 const parseRetryAfterMs = (header: string | null): number | undefined => {
@@ -189,7 +203,7 @@ class S3ProviderImpl {
       accessKeyId: config.accessKeyId,
       secretAccessKey: config.secretAccessKey,
     });
-    this.baseUrl = `${config.endpoint.replace(/\/+$/, '')}/${encodeURIComponent(config.bucket)}`;
+    this.baseUrl = `${config.endpoint.replace(/\/+$/, '')}/${encodeSegment(config.bucket)}`;
   }
 
   private urlFor(key: string): string {
@@ -232,8 +246,8 @@ class S3ProviderImpl {
     let token: string | undefined;
     do {
       const url =
-        `${this.baseUrl}?list-type=2&prefix=${encodeURIComponent(prefix)}&delimiter=%2F` +
-        (token ? `&continuation-token=${encodeURIComponent(token)}` : '');
+        `${this.baseUrl}?list-type=2&prefix=${encodeSegment(prefix)}&delimiter=%2F` +
+        (token ? `&continuation-token=${encodeSegment(token)}` : '');
       const res = await this.request(HTTP_GET, url);
       await this.ensureOk(res, 'list', path);
       const doc = new DOMParser().parseFromString(await res.text(), 'application/xml');
@@ -303,8 +317,8 @@ class S3ProviderImpl {
     let token: string | undefined;
     do {
       const url =
-        `${this.baseUrl}?list-type=2&prefix=${encodeURIComponent(prefix)}` +
-        (token ? `&continuation-token=${encodeURIComponent(token)}` : '');
+        `${this.baseUrl}?list-type=2&prefix=${encodeSegment(prefix)}` +
+        (token ? `&continuation-token=${encodeSegment(token)}` : '');
       const res = await this.request(HTTP_GET, url);
       await this.ensureOk(res, 'list', path);
       const doc = new DOMParser().parseFromString(await res.text(), 'application/xml');


### PR DESCRIPTION
## Summary

S3-compatible sync to Qiniu Kodo died mid-upload with "Authentication failed. Reconnect in Settings." for any book whose title mixed ASCII parentheses with non-ASCII characters (`测试(test)`, `()（）`), while `()()` and `（）（）` worked. The reporter bisected it down to the file name.

**Root cause.** `encodeKey` built the request path with `encodeURIComponent`, which leaves the RFC 3986 sub-delims `! ' ( ) *` raw, while aws4fetch signs their canonical form (`%28%29` and so on, via `encodeRfc3986`). So for every key containing one of those characters the URL on the wire differed from the URL in the signature. AWS and R2 re-canonicalize the received path before verifying, so they never noticed; Qiniu does not re-canonicalize a path that already contains percent-encoding, which is exactly why only mixed keys failed. The 403 landed on the HEAD probe in `pushBookFile`, was mapped to `AUTH_FAILED`, and tripped the terminal latch that aborts the whole run.

**Fix.** `S3Provider` now encodes path segments, the bucket segment, and the `list`/`deleteDir` query values (`prefix`, `continuation-token`) the same way the AWS SDK's `escapeUri` does: `encodeURIComponent` plus `!'()*` as `%21%27%28%29%2A`. The wire request is now byte-for-byte the canonical request aws4fetch signs, so it verifies on backends that use the raw path and on backends that re-canonicalize.

## Test Coverage

All new code paths have test coverage.

- `sends keys with sub-delims in SigV4 canonical (RFC 3986) form`: asserts the wire path for `测试(test)*!'.epub` and, more importantly, that `new URL(wire).pathname === AwsV4Signer.encodedPath` and the sorted wire query equals `AwsV4Signer.encodedSearch` for a `list('/Readest/(dir)')` call, so the test pins the invariant the fix rests on rather than a transcribed literal.
- `deleteDir` test now includes a listed key with a space and parentheses and asserts it is encoded exactly once (`B%20%281%29.epub`).
- The test failed before the fix (`Received: .../%E6%B5%8B%E8%AF%95(test)*!'.epub`) and passes after.

Tests: 15 -> 16 in `S3Provider.test.ts`.

## Pre-Landing Review

1 informational finding (completeness), auto-fixed: the `list`/`deleteDir` query values still used `encodeURIComponent`, and aws4fetch canonicalizes query values with the same RFC 3986 rule. Every prefix today is `Readest/books/<hash>/` or a fixed constant, so it could not bite in practice; it was switched to the same encoder and covered by the test above. Specialists skipped (59-line diff).

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Adversarial Review

Claude adversarial subagent ran the new encoder against the real `aws4fetch@1.0.20` signer for 18 hostile keys (`C++`, `100%`, `~`, `\`, tab/LF, `#?`, emoji, NFD, `;=&@:,$`, `[]`, `//`, a literal `%28`): in every case the wire path equals the signer's canonical path and decodes back to the logical key, including the presigned (`signQuery`) URL path used by the native streaming upload. Findings:

- INVESTIGATE: the Qiniu behaviour is inferred from the reporter's bisect, not exercised against a Kodo bucket, so the reporter should confirm on a build (see Test plan).
- INVESTIGATE (low confidence): if Kodo's key lookup were as encoding-sensitive as its signature check, objects the reporter already uploaded under ASCII-parenthesis titles would 404 on the HEAD probe and be uploaded again under a second key. Every mainstream backend percent-decodes the path before lookup, so no regression is expected there; worth a look during verification.
- FIXABLE, applied: the test asserted a hand-transcribed literal; it now asserts the signer invariant directly. The bucket segment was switched to the same encoder for consistency.
- Pre-existing, unchanged: `encodeURIComponent` throws on lone surrogates (old code did too; unreachable, `makeSafeFilename` round-trips through `TextEncoder`), and `makeSafeFilename` already strips `* % # ?`, so of the five sub-delims only `! ' ( )` can actually reach a key.

Codex adversarial pass returned no output (the prompt was refused by OpenAI's content filter), so the adversarial coverage is Claude-only.

## Scope Drift

Scope Check: CLEAN. Intent: fix #5839. Delivered: the key/query encoder change in `S3Provider.ts` and its tests, nothing else.

## Plan Completion

No plan file detected.

## TODOS

No TODO items completed in this PR.

## Test plan

- [x] `pnpm test`: 804 files, 9942 tests pass on the final commit (run by the pre-push hook)
- [x] `pnpm lint` (tsgo + biome) and `pnpm format:check` clean
- [x] Cloudflare R2 (a re-canonicalizing backend): read-only HEAD requests with the new encoding for `%28%29%EF%BC%88%EF%BC%89.epub`, `%E6%B5%8B%E8%AF%95%28test%29.epub` and `a%2Ab%21c%27d.epub` all return 404, i.e. the signature is accepted and only the key is absent, so AWS/R2/MinIO users do not regress
- [ ] Qiniu Kodo (reporter): with Upload Book Files on, sync a library containing a title like `测试(test)` and confirm the run completes; then confirm books that were already uploaded under a title with `()` are detected as already mirrored rather than uploaded a second time

Fixes #5839

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 synchronization for files and folders with spaces, parentheses, and other special characters.
  * Fixed URL encoding for object paths, directory listings, and continuation tokens to prevent sync failures or incorrect requests.
* **Tests**
  * Added coverage for RFC 3986-compatible encoding of S3 paths and query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->