### PR TITLE
fix(nix): match the Android AVD ABI to the host architecture (#5732)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,14 @@
             overlays = [ fenix.overlays.default ];
           };
 
+          # ABI of the Android 34 emulator image. avdmanager only accepts an
+          # image that is installed in the SDK, and the emulator only runs
+          # images that match the host CPU, so both the SDK package list and
+          # the `avdmanager create avd -k` path derive from this one value.
+          androidAbi = if pkgs.stdenv.hostPlatform.isAarch64 then "arm64-v8a" else "x86_64";
+          # android-nixpkgs spells the x86_64 ABI as `x86-64` in attribute names.
+          androidImageSuffix = lib.replaceStrings [ "_" ] [ "-" ] androidAbi;
+
           toolchain = with pkgs.fenix.complete; [
             cargo
             clippy
@@ -139,14 +147,8 @@
               platforms-android-36
               platforms-android-35
               platforms-android-34
-            ]
-            ++ lib.optionals (system == "aarch64-darwin") [
-              system-images-android-34-google-apis-arm64-v8a
-              system-images-android-34-google-apis-playstore-arm64-v8a
-            ]
-            ++ lib.optionals (system == "x86_64-linux") [
-              system-images-android-34-google-apis-x86-64
-              system-images-android-34-google-apis-playstore-x86-64
+              sdkPkgs."system-images-android-34-google-apis-${androidImageSuffix}"
+              sdkPkgs."system-images-android-34-google-apis-playstore-${androidImageSuffix}"
             ]);
           } // lib.optionalAttrs (!isDarwin) {
             default = pkgs.callPackage ./nix/package.nix { };
@@ -173,7 +175,7 @@
                     if [ ! -d "$ANDROID_AVD_HOME/${name}.avd" ]; then
                         avdmanager create avd \
                           -n ${name} \
-                          -k "system-images;android-34;google_apis;x86_64" \
+                          -k "system-images;android-34;google_apis;${androidAbi}" \
                           -d "pixel" \
                           --force
                       fi


### PR DESCRIPTION
## Summary

Fixes #5732 (deferred from the #5605 review).

The `android` devShell installs the `arm64-v8a` Android 34 system image on `aarch64-darwin` and the `x86_64` one on `x86_64-linux` (the `android-sdk` package in `flake.nix`), but its shellHook always ran `avdmanager create avd -k "system-images;android-34;google_apis;x86_64"`. That package path is never installed on Apple Silicon (and the emulator could not run an x86_64 image there anyway), so AVD creation fails on every `nix develop .#android` on an M-series Mac.

## Fix

- Add one `androidAbi` value in the flake `let`, derived from `pkgs.stdenv.hostPlatform.isAarch64`: `arm64-v8a` on aarch64 hosts, `x86_64` otherwise.
- Build both the SDK system-image attributes and the `avdmanager -k` path from it, so the two cannot drift apart again. android-nixpkgs spells the x86_64 ABI as `x86-64` in its attribute names, hence the `replaceStrings` for the attribute suffix.

Resulting values per supported host:

| host | SDK image attributes | `avdmanager -k` |
| --- | --- | --- |
| `aarch64-darwin` | `system-images-android-34-google-apis-arm64-v8a`, `...-playstore-arm64-v8a` (same set as before) | `system-images;android-34;google_apis;arm64-v8a` (was `x86_64`) |
| `x86_64-linux` | `system-images-android-34-google-apis-x86-64`, `...-playstore-x86-64` (unchanged) | `system-images;android-34;google_apis;x86_64` (unchanged) |

## Verification

- `nixpkgs-fmt --check flake.nix` (the flake's declared formatter) passes.
- Checked against android-nixpkgs at the pinned rev (`9d13340`): both `arm64-v8a` attributes exist in `channels/stable`, and the arm64 image's repo XML registers `path="system-images;android-34;google_apis;arm64-v8a"`, which is exactly the `-k` value this produces on `aarch64-darwin`.
- `nix` is not installed on my machine, so I could not run `nix develop .#android` locally. The `nix_flake_check` PR job runs `nix flake check --all-systems`, which evaluates `devShells.aarch64-darwin.android` and covers evaluation. @dastarruer, if you have an Apple Silicon nix host, a `nix develop .#android` run confirming the `readest-android` AVD gets created would be the end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android emulator setup to automatically select system images compatible with the host architecture.
  * Added support for architecture-specific Android 34 Google APIs and Play Store images.
  * Ensured virtual devices use the matching architecture instead of always defaulting to x86_64.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->