### PR TITLE
fix(backup): export only live library books and reclaim orphaned book files

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2430,5 +2430,12 @@
   "Audiobookshelf server not found": "لم يتم العثور على خادم Audiobookshelf",
   "Episode not found": "لم يتم العثور على الحلقة",
   "Words per minute": "كلمة في الدقيقة",
-  "View Book Cover": "عرض غلاف الكتاب"
+  "View Book Cover": "عرض غلاف الكتاب",
+  "Includes {{count}} orphaned book file(s) not in your library_zero": "يتضمن {{count}} ملف كتاب يتيم غير موجود في مكتبتك",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "يتضمن ملف كتاب يتيمًا واحدًا غير موجود في مكتبتك",
+  "Includes {{count}} orphaned book file(s) not in your library_two": "يتضمن ملفي كتاب يتيمين غير موجودين في مكتبتك",
+  "Includes {{count}} orphaned book file(s) not in your library_few": "يتضمن {{count}} ملفات كتب يتيمة غير موجودة في مكتبتك",
+  "Includes {{count}} orphaned book file(s) not in your library_many": "يتضمن {{count}} ملف كتاب يتيمًا غير موجود في مكتبتك",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "يتضمن {{count}} ملف كتاب يتيم غير موجود في مكتبتك",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "سيؤدي هذا إلى حذف جميع الملفات المخزنة مؤقتًا وملفات الكتب اليتيمة غير الموجودة في مكتبتك. لا يمكن التراجع عن هذا الإجراء."
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2194,5 +2194,8 @@
   "Audiobookshelf server not found": "Audiobookshelf সার্ভার পাওয়া যায়নি",
   "Episode not found": "এপিসোড পাওয়া যায়নি",
   "Words per minute": "প্রতি মিনিটে শব্দ",
-  "View Book Cover": "বইয়ের প্রচ্ছদ দেখুন"
+  "View Book Cover": "বইয়ের প্রচ্ছদ দেখুন",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "আপনার লাইব্রেরিতে নেই এমন {{count}}টি অনাথ বইয়ের ফাইল অন্তর্ভুক্ত",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "আপনার লাইব্রেরিতে নেই এমন {{count}}টি অনাথ বইয়ের ফাইল অন্তর্ভুক্ত",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "এটি সমস্ত ক্যাশ করা ফাইল এবং আপনার লাইব্রেরিতে নেই এমন অনাথ বইয়ের ফাইল মুছে ফেলবে। এটি পূর্বাবস্থায় ফেরানো যাবে না।"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2135,5 +2135,7 @@
   "Audiobookshelf server not found": "Audiobookshelf ཞབས་ཞུ་བ་མ་རྙེད།",
   "Episode not found": "འདོན་ཐེངས་མ་རྙེད།",
   "Words per minute": "སྐར་མ་རེར་ཚིག་གྲངས།",
-  "View Book Cover": "དཔེ་དེབ་ཀྱི་མདུན་ཤོག་བལྟ་བ"
+  "View Book Cover": "དཔེ་དེབ་ཀྱི་མདུན་ཤོག་བལྟ་བ",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "ཁྱེད་ཀྱི་དཔེ་མཛོད་ནང་མེད་པའི་དེབ་ཀྱི་ཡིག་ཆ་ {{count}} ཚུད་ཡོད།",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "འདིས་གསོག་ཉར་གྱི་ཡིག་ཆ་ཚང་མ་དང་ཁྱེད་ཀྱི་དཔེ་མཛོད་ནང་མེད་པའི་དེབ་ཀྱི་ཡིག་ཆ་རྣམས་བསུབ་ངེས་ཡིན། འདི་སྔར་བཞིན་བཟོ་མི་ཐུབ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2194,5 +2194,8 @@
   "Audiobookshelf server not found": "Audiobookshelf-Server nicht gefunden",
   "Episode not found": "Episode nicht gefunden",
   "Words per minute": "Wörter pro Minute",
-  "View Book Cover": "Buchcover anzeigen"
+  "View Book Cover": "Buchcover anzeigen",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Enthält {{count}} verwaiste Buchdatei, die nicht in Ihrer Bibliothek ist",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Enthält {{count}} verwaiste Buchdateien, die nicht in Ihrer Bibliothek sind",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Dadurch werden alle zwischengespeicherten Dateien sowie verwaiste Buchdateien, die nicht in Ihrer Bibliothek sind, gelöscht. Dies kann nicht rückgängig gemacht werden."
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2194,5 +2194,8 @@
   "Audiobookshelf server not found": "Δεν βρέθηκε διακομιστής Audiobookshelf",
   "Episode not found": "Το επεισόδιο δεν βρέθηκε",
   "Words per minute": "Λέξεις ανά λεπτό",
-  "View Book Cover": "Προβολή εξωφύλλου βιβλίου"
+  "View Book Cover": "Προβολή εξωφύλλου βιβλίου",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Περιλαμβάνει {{count}} ορφανό αρχείο βιβλίου που δεν υπάρχει στη βιβλιοθήκη σας",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Περιλαμβάνει {{count}} ορφανά αρχεία βιβλίων που δεν υπάρχουν στη βιβλιοθήκη σας",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Αυτό θα διαγράψει όλα τα προσωρινά αποθηκευμένα αρχεία και τα ορφανά αρχεία βιβλίων που δεν υπάρχουν στη βιβλιοθήκη σας. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί."
 }

--- a/apps/readest-app/public/locales/en/translation.json
+++ b/apps/readest-app/public/locales/en/translation.json
@@ -109,5 +109,7 @@
   "Cancel all ({{count}})_one": "Cancel all ({{count}})",
   "Cancel all ({{count}})_other": "Cancel all ({{count}})",
   "{{count}} server_one": "{{count}} server",
-  "{{count}} server_other": "{{count}} servers"
+  "{{count}} server_other": "{{count}} servers",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Includes {{count}} orphaned book file not in your library",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Includes {{count}} orphaned book files not in your library"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2253,5 +2253,9 @@
   "Audiobookshelf server not found": "No se encontró el servidor de Audiobookshelf",
   "Episode not found": "Episodio no encontrado",
   "Words per minute": "Palabras por minuto",
-  "View Book Cover": "Ver portada del libro"
+  "View Book Cover": "Ver portada del libro",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Incluye {{count}} archivo de libro huérfano que no está en tu biblioteca",
+  "Includes {{count}} orphaned book file(s) not in your library_many": "Incluye {{count}} archivos de libro huérfanos que no están en tu biblioteca",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Incluye {{count}} archivos de libro huérfanos que no están en tu biblioteca",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Esto eliminará todos los archivos en caché y los archivos de libro huérfanos que no están en tu biblioteca. Esta acción no se puede deshacer."
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2194,5 +2194,8 @@
   "Audiobookshelf server not found": "سرور Audiobookshelf یافت نشد",
   "Episode not found": "قسمت یافت نشد",
   "Words per minute": "کلمه در دقیقه",
-  "View Book Cover": "مشاهده جلد کتاب"
+  "View Book Cover": "مشاهده جلد کتاب",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "شامل {{count}} فایل کتاب بی‌سرپرست که در کتابخانه‌ی شما نیست",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "شامل {{count}} فایل کتاب بی‌سرپرست که در کتابخانه‌ی شما نیستند",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "این کار همهٔ فایل‌های ذخیره‌شده در حافظهٔ پنهان و فایل‌های کتاب بی‌سرپرستی را که در کتابخانه‌ی شما نیستند حذف می‌کند. این عمل قابل بازگشت نیست."
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2253,5 +2253,9 @@
   "Audiobookshelf server not found": "Serveur Audiobookshelf introuvable",
   "Episode not found": "Épisode introuvable",
   "Words per minute": "Mots par minute",
-  "View Book Cover": "Voir la couverture du livre"
+  "View Book Cover": "Voir la couverture du livre",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Inclut {{count}} fichier de livre orphelin absent de votre bibliothèque",
+  "Includes {{count}} orphaned book file(s) not in your library_many": "Inclut {{count}} fichiers de livre orphelins absents de votre bibliothèque",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Inclut {{count}} fichiers de livre orphelins absents de votre bibliothèque",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Cette action supprimera tous les fichiers mis en cache ainsi que les fichiers de livre orphelins absents de votre bibliothèque. Elle est irréversible."
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2253,5 +2253,9 @@
   "Audiobookshelf server not found": "שרת Audiobookshelf לא נמצא",
   "Episode not found": "הפרק לא נמצא",
   "Words per minute": "מילים לדקה",
-  "View Book Cover": "הצג כריכת ספר"
+  "View Book Cover": "הצג כריכת ספר",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "כולל קובץ ספר יתום אחד שאינו בספרייה שלך",
+  "Includes {{count}} orphaned book file(s) not in your library_two": "כולל {{count}} קובצי ספרים יתומים שאינם בספרייה שלך",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "כולל {{count}} קובצי ספרים יתומים שאינם בספרייה שלך",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "פעולה זו תמחק את כל הקבצים השמורים במטמון ואת קובצי הספרים היתומים שאינם בספרייה שלך. לא ניתן לבטל פעולה זו."
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2194,5 +2194,8 @@
   "Audiobookshelf server not found": "Audiobookshelf सर्वर नहीं मिला",
   "Episode not found": "एपिसोड नहीं मिला",
   "Words per minute": "शब्द प्रति मिनट",
-  "View Book Cover": "पुस्तक कवर देखें"
+  "View Book Cover": "पुस्तक कवर देखें",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "इसमें आपकी लाइब्रेरी में मौजूद न होने वाली {{count}} अनाथ पुस्तक फ़ाइल शामिल है",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "इसमें आपकी लाइब्रेरी में मौजूद न होने वाली {{count}} अनाथ पुस्तक फ़ाइलें शामिल हैं",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "इससे सभी कैश की गई फ़ाइलें और आपकी लाइब्रेरी में मौजूद न होने वाली अनाथ पुस्तक फ़ाइलें हट जाएँगी. इसे पूर्ववत नहीं किया जा सकता."
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2194,5 +2194,8 @@
   "Audiobookshelf server not found": "Az Audiobookshelf szerver nem található",
   "Episode not found": "Az epizód nem található",
   "Words per minute": "Szó percenként",
-  "View Book Cover": "Könyvborító megtekintése"
+  "View Book Cover": "Könyvborító megtekintése",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "{{count}} olyan árva könyvfájlt tartalmaz, amely nincs a könyvtárában",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "{{count}} olyan árva könyvfájlt tartalmaz, amely nincs a könyvtárában",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Ez törli az összes gyorsítótárazott fájlt és a könyvtárában nem szereplő árva könyvfájlokat. A művelet nem vonható vissza."
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2135,5 +2135,7 @@
   "Audiobookshelf server not found": "Server Audiobookshelf tidak ditemukan",
   "Episode not found": "Episode tidak ditemukan",
   "Words per minute": "Kata per menit",
-  "View Book Cover": "Lihat Sampul Buku"
+  "View Book Cover": "Lihat Sampul Buku",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Termasuk {{count}} file buku yatim yang tidak ada di perpustakaan Anda",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Tindakan ini akan menghapus semua file cache dan file buku yatim yang tidak ada di perpustakaan Anda. Tindakan ini tidak dapat dibatalkan."
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2253,5 +2253,9 @@
   "Audiobookshelf server not found": "Server Audiobookshelf non trovato",
   "Episode not found": "Episodio non trovato",
   "Words per minute": "Parole al minuto",
-  "View Book Cover": "Visualizza copertina del libro"
+  "View Book Cover": "Visualizza copertina del libro",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Include {{count}} file di libro orfano non presente nella tua libreria",
+  "Includes {{count}} orphaned book file(s) not in your library_many": "Include {{count}} file di libro orfani non presenti nella tua libreria",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Include {{count}} file di libro orfani non presenti nella tua libreria",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Questa operazione eliminerà tutti i file memorizzati nella cache e i file di libro orfani non presenti nella tua libreria. L’azione non può essere annullata."
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2135,5 +2135,7 @@
   "Audiobookshelf server not found": "Audiobookshelfサーバーが見つかりません",
   "Episode not found": "エピソードが見つかりません",
   "Words per minute": "1分あたりの単語数",
-  "View Book Cover": "書籍のカバーを表示"
+  "View Book Cover": "書籍のカバーを表示",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "ライブラリにない孤立した本のファイル {{count}} 件を含みます",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "すべてのキャッシュファイルと、ライブラリにない孤立した本のファイルを削除します。この操作は取り消せません。"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2194,5 +2194,8 @@
   "Audiobookshelf server not found": "Audiobookshelf სერვერი ვერ მოიძებნა",
   "Episode not found": "ეპიზოდი ვერ მოიძებნა",
   "Words per minute": "სიტყვა წუთში",
-  "View Book Cover": "წიგნის ყდის ნახვა"
+  "View Book Cover": "წიგნის ყდის ნახვა",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "მოიცავს {{count}} ობოლ წიგნის ფაილს, რომელიც არ არის თქვენს ბიბლიოთეკაში",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "მოიცავს {{count}} ობოლ წიგნის ფაილს, რომელიც არ არის თქვენს ბიბლიოთეკაში",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "ეს წაშლის ყველა ქეშირებულ ფაილს და ობოლ წიგნის ფაილებს, რომლებიც არ არის თქვენს ბიბლიოთეკაში. მოქმედების გაუქმება შეუძლებელია."
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2135,5 +2135,7 @@
   "Audiobookshelf server not found": "Audiobookshelf 서버를 찾을 수 없습니다",
   "Episode not found": "에피소드를 찾을 수 없습니다",
   "Words per minute": "분당 단어 수",
-  "View Book Cover": "책 표지 보기"
+  "View Book Cover": "책 표지 보기",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "서재에 없는 고아 책 파일 {{count}}개 포함",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "캐시된 모든 파일과 서재에 없는 고아 책 파일을 삭제합니다. 이 작업은 되돌릴 수 없습니다."
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2135,5 +2135,7 @@
   "Audiobookshelf server not found": "Pelayan Audiobookshelf tidak ditemui",
   "Episode not found": "Episod tidak ditemui",
   "Words per minute": "Perkataan seminit",
-  "View Book Cover": "Lihat Kulit Buku"
+  "View Book Cover": "Lihat Kulit Buku",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Termasuk {{count}} fail buku yatim yang tiada dalam perpustakaan anda",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Tindakan ini akan memadam semua fail cache dan fail buku yatim yang tiada dalam perpustakaan anda. Tindakan ini tidak boleh diundurkan."
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2194,5 +2194,8 @@
   "Audiobookshelf server not found": "Audiobookshelf-server niet gevonden",
   "Episode not found": "Aflevering niet gevonden",
   "Words per minute": "Woorden per minuut",
-  "View Book Cover": "Boekomslag bekijken"
+  "View Book Cover": "Boekomslag bekijken",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Inclusief {{count}} verweesd boekbestand dat niet in je bibliotheek staat",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Inclusief {{count}} verweesde boekbestanden die niet in je bibliotheek staan",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Hiermee worden alle gecachte bestanden en verweesde boekbestanden die niet in je bibliotheek staan verwijderd. Dit kan niet ongedaan worden gemaakt."
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2312,5 +2312,10 @@
   "Audiobookshelf server not found": "Nie znaleziono serwera Audiobookshelf",
   "Episode not found": "Nie znaleziono odcinka",
   "Words per minute": "Słów na minutę",
-  "View Book Cover": "Pokaż okładkę książki"
+  "View Book Cover": "Pokaż okładkę książki",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Obejmuje {{count}} osierocony plik książki, którego nie ma w Twojej bibliotece",
+  "Includes {{count}} orphaned book file(s) not in your library_few": "Obejmuje {{count}} osierocone pliki książek, których nie ma w Twojej bibliotece",
+  "Includes {{count}} orphaned book file(s) not in your library_many": "Obejmuje {{count}} osieroconych plików książek, których nie ma w Twojej bibliotece",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Obejmuje {{count}} osieroconego pliku książki, którego nie ma w Twojej bibliotece",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Spowoduje to usunięcie wszystkich plików z pamięci podręcznej oraz osieroconych plików książek, których nie ma w Twojej bibliotece. Tej operacji nie można cofnąć."
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2253,5 +2253,9 @@
   "Audiobookshelf server not found": "Servidor Audiobookshelf não encontrado",
   "Episode not found": "Episódio não encontrado",
   "Words per minute": "Palavras por minuto",
-  "View Book Cover": "Ver capa do livro"
+  "View Book Cover": "Ver capa do livro",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Inclui {{count}} arquivo de livro órfão que não está na sua biblioteca",
+  "Includes {{count}} orphaned book file(s) not in your library_many": "Inclui {{count}} arquivos de livro órfãos que não estão na sua biblioteca",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Inclui {{count}} arquivos de livro órfãos que não estão na sua biblioteca",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Isso excluirá todos os arquivos em cache e os arquivos de livro órfãos que não estão na sua biblioteca. Esta ação não pode ser desfeita."
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2253,5 +2253,9 @@
   "Audiobookshelf server not found": "Servidor Audiobookshelf não encontrado",
   "Episode not found": "Episódio não encontrado",
   "Words per minute": "Palavras por minuto",
-  "View Book Cover": "Ver capa do livro"
+  "View Book Cover": "Ver capa do livro",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Inclui {{count}} ficheiro de livro órfão que não está na sua biblioteca",
+  "Includes {{count}} orphaned book file(s) not in your library_many": "Inclui {{count}} ficheiros de livro órfãos que não estão na sua biblioteca",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Inclui {{count}} ficheiros de livro órfãos que não estão na sua biblioteca",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Isto irá eliminar todos os ficheiros em cache e os ficheiros de livro órfãos que não estão na sua biblioteca. Esta ação não pode ser anulada."
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2253,5 +2253,9 @@
   "Audiobookshelf server not found": "Serverul Audiobookshelf nu a fost găsit",
   "Episode not found": "Episodul nu a fost găsit",
   "Words per minute": "Cuvinte pe minut",
-  "View Book Cover": "Vezi coperta cărții"
+  "View Book Cover": "Vezi coperta cărții",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Include {{count}} fișier de carte orfan care nu se află în biblioteca dvs.",
+  "Includes {{count}} orphaned book file(s) not in your library_few": "Include {{count}} fișiere de carte orfane care nu se află în biblioteca dvs.",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Include {{count}} de fișiere de carte orfane care nu se află în biblioteca dvs.",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Această acțiune va șterge toate fișierele din memoria cache și fișierele de carte orfane care nu se află în biblioteca dvs. Acțiunea nu poate fi anulată."
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2312,5 +2312,10 @@
   "Audiobookshelf server not found": "Сервер Audiobookshelf не найден",
   "Episode not found": "Эпизод не найден",
   "Words per minute": "Слов в минуту",
-  "View Book Cover": "Посмотреть обложку книги"
+  "View Book Cover": "Посмотреть обложку книги",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Включает {{count}} осиротевший файл книги, которого нет в вашей библиотеке",
+  "Includes {{count}} orphaned book file(s) not in your library_few": "Включает {{count}} осиротевших файла книг, которых нет в вашей библиотеке",
+  "Includes {{count}} orphaned book file(s) not in your library_many": "Включает {{count}} осиротевших файлов книг, которых нет в вашей библиотеке",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Включает {{count}} осиротевшего файла книги, которого нет в вашей библиотеке",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Это удалит все файлы из кэша и осиротевшие файлы книг, которых нет в вашей библиотеке. Это действие нельзя отменить."
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2194,5 +2194,8 @@
   "Audiobookshelf server not found": "Audiobookshelf සේවාදායකයා හමු නොවීය",
   "Episode not found": "කථාංගය හමු නොවීය",
   "Words per minute": "විනාඩියකට වචන",
-  "View Book Cover": "පොතේ ආවරණය බලන්න"
+  "View Book Cover": "පොතේ ආවරණය බලන්න",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "ඔබේ පුස්තකාලයේ නොමැති අනාථ පොත් ගොනු {{count}} ඇතුළත් වේ",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "ඔබේ පුස්තකාලයේ නොමැති අනාථ පොත් ගොනු {{count}} ඇතුළත් වේ",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "මෙය සියලුම හැඹිලිගත ගොනු සහ ඔබේ පුස්තකාලයේ නොමැති අනාථ පොත් ගොනු මකා දමයි. මෙය පෙරළිය නොහැක."
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2312,5 +2312,10 @@
   "Audiobookshelf server not found": "Strežnika Audiobookshelf ni bilo mogoče najti",
   "Episode not found": "Epizode ni mogoče najti",
   "Words per minute": "Besed na minuto",
-  "View Book Cover": "Prikaži naslovnico knjige"
+  "View Book Cover": "Prikaži naslovnico knjige",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Vključuje {{count}} osirotelo datoteko knjige, ki ni v vaši knjižnici",
+  "Includes {{count}} orphaned book file(s) not in your library_two": "Vključuje {{count}} osiroteli datoteki knjig, ki nista v vaši knjižnici",
+  "Includes {{count}} orphaned book file(s) not in your library_few": "Vključuje {{count}} osirotele datoteke knjig, ki niso v vaši knjižnici",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Vključuje {{count}} osirotelih datotek knjig, ki niso v vaši knjižnici",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "To bo izbrisalo vse predpomnjene datoteke in osirotele datoteke knjig, ki niso v vaši knjižnici. Tega dejanja ni mogoče razveljaviti."
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2194,5 +2194,8 @@
   "Audiobookshelf server not found": "Audiobookshelf-servern hittades inte",
   "Episode not found": "Avsnittet hittades inte",
   "Words per minute": "Ord per minut",
-  "View Book Cover": "Visa bokomslag"
+  "View Book Cover": "Visa bokomslag",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Inkluderar {{count}} föräldralös bokfil som inte finns i ditt bibliotek",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Inkluderar {{count}} föräldralösa bokfiler som inte finns i ditt bibliotek",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Detta tar bort alla cachade filer och föräldralösa bokfiler som inte finns i ditt bibliotek. Åtgärden kan inte ångras."
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2194,5 +2194,8 @@
   "Audiobookshelf server not found": "Audiobookshelf சர்வர் கிடைக்கவில்லை",
   "Episode not found": "எபிசோட் கிடைக்கவில்லை",
   "Words per minute": "நிமிடத்திற்கு சொற்கள்",
-  "View Book Cover": "புத்தக அட்டையைக் காண்க"
+  "View Book Cover": "புத்தக அட்டையைக் காண்க",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "உங்கள் நூலகத்தில் இல்லாத {{count}} அனாதைப் புத்தகக் கோப்பு அடங்கும்",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "உங்கள் நூலகத்தில் இல்லாத {{count}} அனாதைப் புத்தகக் கோப்புகள் அடங்கும்",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "இது தற்காலிகச் சேமிப்பில் உள்ள அனைத்துக் கோப்புகளையும், உங்கள் நூலகத்தில் இல்லாத அனாதைப் புத்தகக் கோப்புகளையும் நீக்கும். இதை மீட்டெடுக்க முடியாது."
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2135,5 +2135,7 @@
   "Audiobookshelf server not found": "ไม่พบเซิร์ฟเวอร์ Audiobookshelf",
   "Episode not found": "ไม่พบตอน",
   "Words per minute": "คำต่อนาที",
-  "View Book Cover": "ดูภาพปกหนังสือ"
+  "View Book Cover": "ดูภาพปกหนังสือ",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "รวมไฟล์หนังสือกำพร้าที่ไม่อยู่ในคลังหนังสือของคุณ {{count}} ไฟล์",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "การดำเนินการนี้จะลบไฟล์แคชทั้งหมดและไฟล์หนังสือกำพร้าที่ไม่อยู่ในคลังหนังสือของคุณ ไม่สามารถยกเลิกได้"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2194,5 +2194,8 @@
   "Audiobookshelf server not found": "Audiobookshelf sunucusu bulunamadı",
   "Episode not found": "Bölüm bulunamadı",
   "Words per minute": "Dakikadaki kelime sayısı",
-  "View Book Cover": "Kitap Kapağını Görüntüle"
+  "View Book Cover": "Kitap Kapağını Görüntüle",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Kütüphanenizde olmayan {{count}} sahipsiz kitap dosyası dahil",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Kütüphanenizde olmayan {{count}} sahipsiz kitap dosyası dahil",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Bu, önbelleğe alınmış tüm dosyaları ve kütüphanenizde olmayan sahipsiz kitap dosyalarını siler. Bu işlem geri alınamaz."
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2312,5 +2312,10 @@
   "Audiobookshelf server not found": "Сервер Audiobookshelf не знайдено",
   "Episode not found": "Епізод не знайдено",
   "Words per minute": "Слів за хвилину",
-  "View Book Cover": "Переглянути обкладинку книги"
+  "View Book Cover": "Переглянути обкладинку книги",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Включає {{count}} осиротілий файл книги, якого немає у вашій бібліотеці",
+  "Includes {{count}} orphaned book file(s) not in your library_few": "Включає {{count}} осиротілі файли книг, яких немає у вашій бібліотеці",
+  "Includes {{count}} orphaned book file(s) not in your library_many": "Включає {{count}} осиротілих файлів книг, яких немає у вашій бібліотеці",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Включає {{count}} осиротілого файлу книги, якого немає у вашій бібліотеці",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Це видалить усі файли з кешу та осиротілі файли книг, яких немає у вашій бібліотеці. Цю дію не можна скасувати."
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2194,5 +2194,8 @@
   "Audiobookshelf server not found": "Audiobookshelf serveri topilmadi",
   "Episode not found": "Epizod topilmadi",
   "Words per minute": "Daqiqasiga soʻz soni",
-  "View Book Cover": "Kitob muqovasini koʻrish"
+  "View Book Cover": "Kitob muqovasini koʻrish",
+  "Includes {{count}} orphaned book file(s) not in your library_one": "Kutubxonangizda yoʻq {{count}} ta yetim kitob faylini oʻz ichiga oladi",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Kutubxonangizda yoʻq {{count}} ta yetim kitob faylini oʻz ichiga oladi",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Bu barcha keshlangan fayllarni va kutubxonangizda yoʻq yetim kitob fayllarini oʻchiradi. Buni qaytarib boʻlmaydi."
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2135,5 +2135,7 @@
   "Audiobookshelf server not found": "Không tìm thấy máy chủ Audiobookshelf",
   "Episode not found": "Không tìm thấy tập",
   "Words per minute": "Số từ mỗi phút",
-  "View Book Cover": "Xem bìa sách"
+  "View Book Cover": "Xem bìa sách",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "Bao gồm {{count}} tệp sách mồ côi không có trong thư viện của bạn",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "Thao tác này sẽ xóa tất cả tệp trong bộ nhớ đệm và các tệp sách mồ côi không có trong thư viện của bạn. Không thể hoàn tác."
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2135,5 +2135,7 @@
   "Audiobookshelf server not found": "未找到 Audiobookshelf 服务器",
   "Episode not found": "未找到该单集",
   "Words per minute": "每分钟字数",
-  "View Book Cover": "查看书籍封面"
+  "View Book Cover": "查看书籍封面",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "包含 {{count}} 个不在书库中的孤立书籍文件",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "这将删除所有缓存文件以及不在书库中的孤立书籍文件，此操作无法撤销。"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2135,5 +2135,7 @@
   "Audiobookshelf server not found": "找不到 Audiobookshelf 伺服器",
   "Episode not found": "找不到該集",
   "Words per minute": "每分鐘字數",
-  "View Book Cover": "查看書籍封面"
+  "View Book Cover": "查看書籍封面",
+  "Includes {{count}} orphaned book file(s) not in your library_other": "包含 {{count}} 個不在書庫中的孤立書籍檔案",
+  "This will delete all cached files and orphaned book files not in your library. This cannot be undone.": "這將刪除所有快取檔案以及不在書庫中的孤立書籍檔案，此操作無法復原。"
 }

--- a/apps/readest-app/src/__tests__/app/library/cache-manager-window-orphans.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/cache-manager-window-orphans.test.tsx
@@ -1,0 +1,222 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  CacheManagerWindow,
+  setCacheManagerDialogVisible,
+} from '@/app/library/components/CacheManagerWindow';
+import type { Book } from '@/types/book';
+import type { FileItem } from '@/types/system';
+
+/**
+ * Manage Cache folds orphaned book files under Books/ into the clearable set
+ * (#5837). The dialog must say so before the user confirms, the orphan scan
+ * must only run against a loaded library, and Clear must delete exactly the
+ * set the dialog described. The real cache utils run here against a fake
+ * AppService filesystem, so the numbers on screen come from real scans.
+ */
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string, options?: Record<string, string | number>) => {
+    if (!options) return key;
+    return key.replace(/{{(\w+)}}/g, (_match, name) => String(options[name] ?? ''));
+  },
+}));
+
+const BOOKS_DIR = '/data/Books';
+const fs: Record<string, FileItem[]> = { Cache: [], Temp: [], Books: [] };
+
+const appService = {
+  isIOSApp: false,
+  isAndroidApp: false,
+  resolveFilePath: vi.fn(async () => BOOKS_DIR),
+  readDirectory: vi.fn(async (dir: string, base: string) =>
+    base === 'None' && dir === BOOKS_DIR ? fs['Books']! : (fs[base] ?? []),
+  ),
+  // Every dir was last written long ago, so none is held back as in-flight.
+  stats: vi.fn(async () => ({ mtime: new Date(0) })),
+  deleteFile: vi.fn(async (_path: string, _base: string) => undefined),
+};
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService, envConfig: {} }),
+}));
+
+const libraryState = { library: [] as Book[], libraryLoaded: true };
+
+vi.mock('@/store/libraryStore', () => ({
+  useLibraryStore: { getState: () => libraryState },
+}));
+
+vi.mock('@tauri-apps/api/path', () => ({
+  documentDir: vi.fn(async () => '/docs'),
+  join: vi.fn(async (...parts: string[]) => parts.join('/')),
+}));
+
+// Preserve the dialog id so the component's getElementById event wiring works.
+vi.mock('@/components/Dialog', () => ({
+  __esModule: true,
+  default: ({
+    id,
+    title,
+    children,
+  }: {
+    id?: string;
+    title?: string;
+    children: React.ReactNode;
+  }) => (
+    <div id={id} role='dialog' aria-label={title}>
+      {children}
+    </div>
+  ),
+}));
+
+const LIVE = 'live-hash';
+const ORPHAN = 'orphan-hash';
+// The orphan dir holds a book file and a cover; only the book file is
+// reclaimable, so the cover never counts.
+const ORPHAN_CAPTION = 'Includes 1 orphaned book file(s) not in your library';
+const PLAIN_NOTICE = 'This will delete all cached files. This cannot be undone.';
+const ORPHAN_NOTICE =
+  'This will delete all cached files and orphaned book files not in your library. This cannot be undone.';
+
+const openDialog = async () => {
+  render(<CacheManagerWindow />);
+  await act(async () => {
+    setCacheManagerDialogVisible(true);
+  });
+};
+
+beforeEach(() => {
+  libraryState.library = [{ hash: LIVE } as Book];
+  libraryState.libraryLoaded = true;
+  fs['Cache'] = [{ path: 'thumb.png', size: 100 }];
+  fs['Temp'] = [];
+  fs['Books'] = [
+    { path: 'library.json', size: 10 },
+    { path: `${LIVE}/book.epub`, size: 5000 },
+    { path: `${LIVE}/cover.png`, size: 300 },
+    { path: `${ORPHAN}/book.epub`, size: 1000 },
+    { path: `${ORPHAN}/cover.png`, size: 200 },
+  ];
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('CacheManagerWindow orphaned book files (#5837)', () => {
+  it('counts orphans in the total and captions them when the library is loaded', async () => {
+    await openDialog();
+
+    expect(await screen.findByText('2 files')).toBeTruthy();
+    expect(screen.getByText(ORPHAN_CAPTION)).toBeTruthy();
+  });
+
+  it('shows no orphan caption when there are none', async () => {
+    fs['Books'] = fs['Books']!.filter((f) => !f.path.startsWith(ORPHAN));
+
+    await openDialog();
+
+    expect(await screen.findByText('1 files')).toBeTruthy();
+    expect(screen.queryByText(/orphaned book file/)).toBeNull();
+  });
+
+  it('does not walk the Books tree until the library is loaded', async () => {
+    libraryState.libraryLoaded = false;
+
+    await openDialog();
+
+    expect(await screen.findByText('1 files')).toBeTruthy();
+    expect(screen.queryByText(/orphaned book file/)).toBeNull();
+    expect(appService.readDirectory).not.toHaveBeenCalledWith(BOOKS_DIR, 'None');
+  });
+
+  it('enables Clear Cache when only orphans exist', async () => {
+    fs['Cache'] = [];
+
+    await openDialog();
+
+    expect(await screen.findByText('1 files')).toBeTruthy();
+    const clear = screen.getByRole('button', { name: 'Clear Cache' }) as HTMLButtonElement;
+    expect(clear.disabled).toBe(false);
+  });
+
+  it('warns that orphaned book files will be deleted before confirming', async () => {
+    await openDialog();
+    await screen.findByText('2 files');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear Cache' }));
+
+    expect(screen.getByText(ORPHAN_NOTICE)).toBeTruthy();
+    expect(screen.getByText(ORPHAN_CAPTION)).toBeTruthy();
+  });
+
+  it('keeps the plain confirm notice when there are no orphans', async () => {
+    fs['Books'] = fs['Books']!.filter((f) => !f.path.startsWith(ORPHAN));
+
+    await openDialog();
+    await screen.findByText('1 files');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear Cache' }));
+
+    expect(screen.getByText(PLAIN_NOTICE)).toBeTruthy();
+    expect(screen.queryByText(/orphaned book file/)).toBeNull();
+  });
+
+  it('deletes exactly the cache and orphan files the user confirmed, never live books', async () => {
+    await openDialog();
+    await screen.findByText('2 files');
+    fireEvent.click(screen.getByRole('button', { name: 'Clear Cache' }));
+
+    // A file that lands after the scan is not part of what the user confirmed.
+    fs['Books']!.push({ path: 'late-hash/book.epub', size: 1 });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm Clear' }));
+    });
+
+    expect(await screen.findByText('Cache cleared')).toBeTruthy();
+    expect(appService.deleteFile.mock.calls).toEqual([
+      ['thumb.png', 'Cache'],
+      [`${ORPHAN}/book.epub`, 'Books'],
+    ]);
+    // The post-clear rescan still sees orphans on the fake disk, but the
+    // caption only belongs to the idle/confirming states.
+    expect(screen.queryByText(/orphaned book file/)).toBeNull();
+  });
+
+  it('spares a shown orphan whose book got a live row while confirming', async () => {
+    // A sync or import can persist a book between the scan and the confirm.
+    await openDialog();
+    await screen.findByText('2 files');
+    fireEvent.click(screen.getByRole('button', { name: 'Clear Cache' }));
+
+    libraryState.library = [...libraryState.library, { hash: ORPHAN } as Book];
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm Clear' }));
+    });
+
+    expect(await screen.findByText('Cache cleared')).toBeTruthy();
+    expect(appService.deleteFile.mock.calls).toEqual([['thumb.png', 'Cache']]);
+  });
+
+  it('reports files it could not delete instead of claiming the cache is cleared', async () => {
+    appService.deleteFile.mockImplementation(async (path: string) => {
+      if (path === `${ORPHAN}/book.epub`) throw new Error('EBUSY');
+      return undefined;
+    });
+
+    await openDialog();
+    await screen.findByText('2 files');
+    fireEvent.click(screen.getByRole('button', { name: 'Clear Cache' }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm Clear' }));
+    });
+
+    expect(await screen.findByText('Failed to delete 1 file(s)')).toBeTruthy();
+    expect(screen.queryByText('Cache cleared')).toBeNull();
+  });
+});

--- a/apps/readest-app/src/__tests__/services/backup-orphan-files-edges.test.ts
+++ b/apps/readest-app/src/__tests__/services/backup-orphan-files-edges.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { ZipWriter } from '@zip.js/zip.js';
+import { addBackupEntriesToZip } from '@/services/backupService';
+import type { Book } from '@/types/book';
+import type { AppService, FileItem } from '@/types/system';
+
+/**
+ * Edge cases around the live-hash export filter introduced for #5837: the
+ * retained zero-byte skip, progress accounting over the filtered list, and a
+ * single unreadable file not aborting the rest of a live book's export.
+ */
+
+const LIVE_HASH = '1111111111111111111111111111aaaa';
+const OTHER_HASH = '4444444444444444444444444444dddd';
+
+function makeBook(overrides: Partial<Book>): Book {
+  return {
+    hash: LIVE_HASH,
+    format: 'EPUB',
+    title: 'Book',
+    author: 'Author',
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides,
+  };
+}
+
+function makeAppService(
+  books: Book[],
+  files: FileItem[],
+  readFile: AppService['readFile'] = async () => new ArrayBuffer(8),
+): AppService {
+  return {
+    loadLibraryBooks: async () => books,
+    loadSettings: async () => ({}) as never,
+    resolveFilePath: async () => '/data/Books',
+    readDirectory: async () => files,
+    readFile,
+  } as unknown as AppService;
+}
+
+function makeCapturingWriter() {
+  const names: string[] = [];
+  const writer = {
+    add: async (name: string) => {
+      names.push(name);
+    },
+  } as unknown as ZipWriter<unknown>;
+  return { writer, names };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('addBackupEntriesToZip - live-hash filter edges (#5837)', () => {
+  it('still skips zero-byte files inside a live book dir', async () => {
+    const files: FileItem[] = [
+      { path: `${LIVE_HASH}/book.epub`, size: 1000 },
+      { path: `${LIVE_HASH}/cover.png`, size: 0 },
+    ];
+    const { writer, names } = makeCapturingWriter();
+
+    await addBackupEntriesToZip(writer, makeAppService([makeBook({})], files), {});
+
+    expect(names.filter((n) => n.includes('/'))).toEqual([`${LIVE_HASH}/book.epub`]);
+  });
+
+  it('reports progress over the filtered file list using the host path', async () => {
+    // Two live files plus an orphan and a zero-byte file: `total` must count
+    // only what is exported, while the filename echoes the on-disk path so a
+    // Windows user sees the same separators the OS shows them.
+    const files: FileItem[] = [
+      { path: `${LIVE_HASH}\\book.epub`, size: 1000 },
+      { path: `${LIVE_HASH}\\config.json`, size: 50 },
+      { path: `${LIVE_HASH}\\empty.bin`, size: 0 },
+      { path: `${OTHER_HASH}\\book.epub`, size: 1000 },
+    ];
+    const { writer } = makeCapturingWriter();
+    const progress: Array<[number, number, string]> = [];
+
+    await addBackupEntriesToZip(
+      writer,
+      makeAppService([makeBook({})], files),
+      {},
+      (current, total, filename) => progress.push([current, total, filename]),
+    );
+
+    expect(progress).toEqual([
+      [1, 2, `${LIVE_HASH}\\book.epub`],
+      [2, 2, `${LIVE_HASH}\\config.json`],
+    ]);
+  });
+
+  it('skips a file that cannot be read and keeps exporting the rest', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const files: FileItem[] = [
+      { path: `${LIVE_HASH}/book.epub`, size: 1000 },
+      { path: `${LIVE_HASH}/cover.png`, size: 200 },
+      { path: `${LIVE_HASH}/config.json`, size: 50 },
+    ];
+    const readFile: AppService['readFile'] = async (path) => {
+      if (path.endsWith('cover.png')) throw new Error('EACCES');
+      return new ArrayBuffer(8);
+    };
+    const { writer, names } = makeCapturingWriter();
+
+    await addBackupEntriesToZip(writer, makeAppService([makeBook({})], files, readFile), {});
+
+    expect(names.filter((n) => n.includes('/'))).toEqual([
+      `${LIVE_HASH}/book.epub`,
+      `${LIVE_HASH}/config.json`,
+    ]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(`${LIVE_HASH}/cover.png`),
+      expect.any(Error),
+    );
+  });
+});

--- a/apps/readest-app/src/__tests__/services/backup-orphan-files.test.ts
+++ b/apps/readest-app/src/__tests__/services/backup-orphan-files.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import type { ZipWriter } from '@zip.js/zip.js';
+import { addBackupEntriesToZip } from '@/services/backupService';
+import type { Book } from '@/types/book';
+import type { AppService, FileItem } from '@/types/system';
+
+/**
+ * Regression test for issue #5837: the backup zip exported every file under
+ * the Books/ tree, so hash directories no live library row references — a
+ * soft-deleted book whose file lingered, or an import killed before the
+ * library was saved — were silently exported even though they never appear
+ * in the library UI. Only a live (non-deleted) book's own `<hash>/` dir
+ * belongs in the backup.
+ */
+
+const LIVE_HASH = '1111111111111111111111111111aaaa';
+const DELETED_HASH = '2222222222222222222222222222bbbb';
+const ORPHAN_HASH = '3333333333333333333333333333cccc';
+
+function makeBook(overrides: Partial<Book>): Book {
+  return {
+    hash: LIVE_HASH,
+    format: 'EPUB',
+    title: 'Book',
+    author: 'Author',
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides,
+  };
+}
+
+function makeAppService(books: Book[], files: FileItem[]): AppService {
+  return {
+    loadLibraryBooks: async () => books,
+    loadSettings: async () => ({}) as never,
+    resolveFilePath: async () => '/data/Books',
+    readDirectory: async () => files,
+    readFile: async () => new ArrayBuffer(8),
+  } as unknown as AppService;
+}
+
+function makeCapturingWriter() {
+  const names: string[] = [];
+  const writer = {
+    add: async (name: string) => {
+      names.push(name);
+    },
+  } as unknown as ZipWriter<unknown>;
+  return { writer, names };
+}
+
+describe('addBackupEntriesToZip - only live library books are exported (#5837)', () => {
+  const files: FileItem[] = [
+    { path: 'library.json', size: 10 },
+    { path: 'library.json.bak', size: 10 },
+    { path: `${LIVE_HASH}/book.epub`, size: 1000 },
+    { path: `${LIVE_HASH}/cover.png`, size: 200 },
+    { path: `${LIVE_HASH}/config.json`, size: 50 },
+    { path: `${DELETED_HASH}/book.epub`, size: 1000 },
+    { path: `${DELETED_HASH}/config.json`, size: 50 },
+    { path: `${ORPHAN_HASH}/book.pdf`, size: 1000 },
+    { path: `${ORPHAN_HASH}/cover.png`, size: 200 },
+  ];
+
+  it('skips hash dirs with no library row and dirs of soft-deleted books', async () => {
+    const books = [
+      makeBook({ hash: LIVE_HASH }),
+      makeBook({ hash: DELETED_HASH, deletedAt: 5000 }),
+    ];
+    const { writer, names } = makeCapturingWriter();
+
+    await addBackupEntriesToZip(writer, makeAppService(books, files), {});
+
+    const bookEntries = names.filter((n) => n.includes('/'));
+    expect(bookEntries).toEqual([
+      `${LIVE_HASH}/book.epub`,
+      `${LIVE_HASH}/cover.png`,
+      `${LIVE_HASH}/config.json`,
+    ]);
+    // library.json in the zip is the generated snapshot, never the on-disk
+    // metadata files picked up from the directory walk.
+    expect(names.filter((n) => n === 'library.json')).toHaveLength(1);
+    expect(names).not.toContain('library.json.bak');
+  });
+
+  it('exports nothing from the Books tree when the library is empty', async () => {
+    const { writer, names } = makeCapturingWriter();
+
+    await addBackupEntriesToZip(writer, makeAppService([], files), {});
+
+    expect(names.filter((n) => n.includes('/'))).toEqual([]);
+  });
+
+  it('matches a live book dir on Windows backslash paths', async () => {
+    const windowsFiles: FileItem[] = [
+      { path: `${LIVE_HASH}\\book.epub`, size: 1000 },
+      { path: `${ORPHAN_HASH}\\book.epub`, size: 1000 },
+    ];
+    const { writer, names } = makeCapturingWriter();
+
+    await addBackupEntriesToZip(
+      writer,
+      makeAppService([makeBook({ hash: LIVE_HASH })], windowsFiles),
+      {},
+    );
+
+    expect(names.filter((n) => n.includes('/'))).toEqual([`${LIVE_HASH}/book.epub`]);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/backup-orphan-files.test.ts
+++ b/apps/readest-app/src/__tests__/services/backup-orphan-files.test.ts
@@ -83,10 +83,28 @@ describe('addBackupEntriesToZip - only live library books are exported (#5837)',
     expect(names).not.toContain('library.json.bak');
   });
 
-  it('exports nothing from the Books tree when the library is empty', async () => {
+  it('falls back to exporting every dir when the library has no rows at all', async () => {
+    // A library.json that failed to load hands back [] (safeLoadJSON); the
+    // Books tree is then the only copy, and restore's orphan import is how a
+    // broken library gets rebuilt. Root-level metadata still stays out.
     const { writer, names } = makeCapturingWriter();
 
     await addBackupEntriesToZip(writer, makeAppService([], files), {});
+
+    expect(names.filter((n) => n.includes('/'))).toEqual(
+      files.map((f) => f.path).filter((p) => p.includes('/')),
+    );
+    expect(names).not.toContain('library.json.bak');
+  });
+
+  it('exports nothing from the Books tree when every row is soft-deleted', async () => {
+    const { writer, names } = makeCapturingWriter();
+
+    await addBackupEntriesToZip(
+      writer,
+      makeAppService([makeBook({ hash: DELETED_HASH, deletedAt: 5000 })], files),
+      {},
+    );
 
     expect(names.filter((n) => n.includes('/'))).toEqual([]);
   });

--- a/apps/readest-app/src/__tests__/services/backup-windows-paths.test.ts
+++ b/apps/readest-app/src/__tests__/services/backup-windows-paths.test.ts
@@ -14,10 +14,13 @@ import type { AppService, FileItem } from '@/types/system';
 
 const BOOK_HASH = '6afdd0136531fbe028e0503a14ba234c';
 
-/** Build a stub AppService whose `readDirectory` returns the given file list. */
+/**
+ * Build a stub AppService whose `readDirectory` returns the given file list.
+ * The library owns BOOK_HASH: only a live book's dir is exported (#5837).
+ */
 function makeAppService(files: FileItem[]): AppService {
   return {
-    loadLibraryBooks: async () => [],
+    loadLibraryBooks: async () => [{ hash: BOOK_HASH }],
     loadSettings: async () => ({}) as never,
     resolveFilePath: async () => 'C:/Users/me/AppData/Books',
     readDirectory: async () => files,

--- a/apps/readest-app/src/__tests__/utils/book-dir-of-path.test.ts
+++ b/apps/readest-app/src/__tests__/utils/book-dir-of-path.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBookDirOfPath } from '@/utils/book';
+
+const HASH = '6afdd0136531fbe028e0503a14ba234c';
+
+describe('getBookDirOfPath (#5837)', () => {
+  it('returns undefined for root-level library metadata', () => {
+    expect(getBookDirOfPath('library.json')).toBeUndefined();
+    expect(getBookDirOfPath('library.db-wal')).toBeUndefined();
+    expect(getBookDirOfPath('')).toBeUndefined();
+  });
+
+  it('returns the hash dir of a POSIX path', () => {
+    expect(getBookDirOfPath(`${HASH}/book.epub`)).toBe(HASH);
+  });
+
+  it('returns the hash dir of a Windows backslash path', () => {
+    expect(getBookDirOfPath(`${HASH}\\cover.png`)).toBe(HASH);
+  });
+
+  it('returns only the first segment of a nested path', () => {
+    expect(getBookDirOfPath(`${HASH}/fonts/serif.ttf`)).toBe(HASH);
+    expect(getBookDirOfPath(`${HASH}\\fonts\\serif.ttf`)).toBe(HASH);
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/cache-orphaned-entries-edges.test.ts
+++ b/apps/readest-app/src/__tests__/utils/cache-orphaned-entries-edges.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AppService, FileItem } from '@/types/system';
+import { Book } from '@/types/book';
+import { getOrphanedBookEntries } from '@/utils/cache';
+
+const makeBook = (hash: string, deletedAt: number | null = null): Book =>
+  ({
+    hash,
+    format: 'EPUB',
+    title: hash,
+    author: '',
+    createdAt: 1,
+    updatedAt: 1,
+    deletedAt,
+  }) as Book;
+
+/**
+ * Books/ resolves to an absolute dir so the scan takes the native walk; every
+ * dir was last written long ago, so nothing is held back as an in-flight import.
+ */
+const makeBooksFs = (files: FileItem[]): AppService =>
+  ({
+    readDirectory: vi.fn().mockResolvedValue(files),
+    resolveFilePath: async () => '/data/Books',
+    stats: async () => ({ mtime: new Date(0) }),
+  }) as unknown as AppService;
+
+describe('getOrphanedBookEntries edges (#5837)', () => {
+  const DELETED = 'deleted-hash';
+  const ORPHAN_A = 'orphan-a';
+  const ORPHAN_B = 'orphan-b';
+
+  it('keeps the sidecars of a soft-deleted book on Windows backslash paths', async () => {
+    const appService = makeBooksFs([
+      { path: `${DELETED}\\cover.png`, size: 10 },
+      { path: `${DELETED}\\config.json`, size: 20 },
+      { path: `${DELETED}\\nav.json`, size: 30 },
+      { path: `${DELETED}\\book.epub`, size: 40 },
+    ]);
+
+    const entries = await getOrphanedBookEntries(appService, [makeBook(DELETED, 5000)]);
+
+    expect(entries).toEqual([{ base: 'Books', path: `${DELETED}\\book.epub`, size: 40 }]);
+  });
+
+  it('only protects sidecars at the top of a soft-deleted book dir', async () => {
+    // A nested file that happens to share a sidecar name is still a leftover.
+    const appService = makeBooksFs([
+      { path: `${DELETED}/cover.png`, size: 10 },
+      { path: `${DELETED}/articles/cover.png`, size: 20 },
+    ]);
+
+    const entries = await getOrphanedBookEntries(appService, [makeBook(DELETED, 5000)]);
+
+    expect(entries).toEqual([{ base: 'Books', path: `${DELETED}/articles/cover.png`, size: 20 }]);
+  });
+
+  it('reports a missing size as 0 so stats never see NaN', async () => {
+    const appService = makeBooksFs([{ path: `${ORPHAN_A}/book.epub` } as FileItem]);
+
+    const entries = await getOrphanedBookEntries(appService, []);
+
+    expect(entries).toEqual([{ base: 'Books', path: `${ORPHAN_A}/book.epub`, size: 0 }]);
+  });
+
+  it('flags every hash dir when the library is empty', async () => {
+    // This is why the dialog only scans once `libraryLoaded` is true: an
+    // unloaded (empty) library would mark every book on disk as an orphan.
+    const appService = makeBooksFs([
+      { path: 'library.json', size: 5 },
+      { path: `${ORPHAN_A}/book.epub`, size: 10 },
+      { path: `${ORPHAN_B}/book.pdf`, size: 20 },
+    ]);
+
+    const entries = await getOrphanedBookEntries(appService, []);
+
+    expect(entries.map((e) => e.path)).toEqual([`${ORPHAN_A}/book.epub`, `${ORPHAN_B}/book.pdf`]);
+  });
+
+  it('contributes nothing when the Books dir cannot be resolved', async () => {
+    const readDirectory = vi.fn();
+    const appService = {
+      readDirectory,
+      resolveFilePath: vi.fn().mockRejectedValue(new Error('no data dir')),
+    } as unknown as AppService;
+
+    expect(await getOrphanedBookEntries(appService, [])).toEqual([]);
+    expect(readDirectory).not.toHaveBeenCalled();
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/cache.test.ts
+++ b/apps/readest-app/src/__tests__/utils/cache.test.ts
@@ -1,15 +1,93 @@
 import { describe, it, expect, vi } from 'vitest';
 import { AppService, FileItem } from '@/types/system';
+import { Book } from '@/types/book';
 import {
   clearCacheEntries,
   getCacheEntries,
   getCacheStats,
+  getOrphanedBookEntries,
   CacheClearProgress,
   CacheEntry,
 } from '@/utils/cache';
 
 const makeFiles = (...names: string[]): FileItem[] =>
   names.map((path, i) => ({ path, size: (i + 1) * 10 }));
+
+const makeBook = (hash: string, deletedAt: number | null = null): Book =>
+  ({
+    hash,
+    format: 'EPUB',
+    title: hash,
+    author: '',
+    createdAt: 1,
+    updatedAt: 1,
+    deletedAt,
+  }) as Book;
+
+describe('getOrphanedBookEntries (#5837)', () => {
+  const LIVE = 'live-hash';
+  const DELETED = 'deleted-hash';
+  const ORPHAN = 'orphan-hash';
+
+  it('returns every file of a hash dir no library row references', async () => {
+    const readDirectory = vi
+      .fn()
+      .mockResolvedValue(makeFiles(`${ORPHAN}/book.epub`, `${ORPHAN}/cover.png`));
+    const appService = { readDirectory } as unknown as AppService;
+
+    const entries = await getOrphanedBookEntries(appService, [makeBook(LIVE)]);
+
+    expect(readDirectory).toHaveBeenCalledWith('', 'Books');
+    expect(entries).toEqual([
+      { base: 'Books', path: `${ORPHAN}/book.epub`, size: 10 },
+      { base: 'Books', path: `${ORPHAN}/cover.png`, size: 20 },
+    ]);
+  });
+
+  it('never touches a live book dir or root-level library metadata', async () => {
+    const readDirectory = vi
+      .fn()
+      .mockResolvedValue(
+        makeFiles('library.json', 'library.json.bak', `${LIVE}/book.epub`, `${LIVE}/config.json`),
+      );
+    const appService = { readDirectory } as unknown as AppService;
+
+    expect(await getOrphanedBookEntries(appService, [makeBook(LIVE)])).toEqual([]);
+  });
+
+  it('flags only lingering book files in a soft-deleted book dir', async () => {
+    // A plain delete keeps cover.png and config.json on purpose (a re-download
+    // resumes with them); a book file left there is the leftover to reclaim.
+    const readDirectory = vi
+      .fn()
+      .mockResolvedValue(
+        makeFiles(`${DELETED}/book.pdf`, `${DELETED}/cover.png`, `${DELETED}/config.json`),
+      );
+    const appService = { readDirectory } as unknown as AppService;
+
+    const entries = await getOrphanedBookEntries(appService, [makeBook(DELETED, 5000)]);
+
+    expect(entries).toEqual([{ base: 'Books', path: `${DELETED}/book.pdf`, size: 10 }]);
+  });
+
+  it('handles Windows backslash paths', async () => {
+    const readDirectory = vi
+      .fn()
+      .mockResolvedValue(makeFiles(`${LIVE}\\book.epub`, `${ORPHAN}\\book.epub`));
+    const appService = { readDirectory } as unknown as AppService;
+
+    const entries = await getOrphanedBookEntries(appService, [makeBook(LIVE)]);
+
+    expect(entries).toEqual([{ base: 'Books', path: `${ORPHAN}\\book.epub`, size: 20 }]);
+  });
+
+  it('contributes nothing when the Books dir cannot be read', async () => {
+    const readDirectory = vi.fn().mockRejectedValue(new Error('unreadable'));
+    const appService = { readDirectory } as unknown as AppService;
+
+    expect(await getOrphanedBookEntries(appService, [])).toEqual([]);
+  });
+});
 
 describe('getCacheStats', () => {
   it('sums file count and byte size', () => {

--- a/apps/readest-app/src/__tests__/utils/cache.test.ts
+++ b/apps/readest-app/src/__tests__/utils/cache.test.ts
@@ -5,7 +5,9 @@ import {
   clearCacheEntries,
   getCacheEntries,
   getCacheStats,
+  getClearableEntries,
   getOrphanedBookEntries,
+  withoutLiveBookEntries,
   CacheClearProgress,
   CacheEntry,
 } from '@/utils/cache';
@@ -24,24 +26,61 @@ const makeBook = (hash: string, deletedAt: number | null = null): Book =>
     deletedAt,
   }) as Book;
 
+/**
+ * Books/ resolves to an absolute dir so the scan takes the native walk; dirs
+ * were last written long ago unless a test says otherwise.
+ */
+const makeBooksFs = (
+  readDirectory: ReturnType<typeof vi.fn>,
+  stats: () => Promise<{ mtime: Date | null }> = async () => ({ mtime: new Date(0) }),
+): AppService =>
+  ({ readDirectory, resolveFilePath: async () => '/data/Books', stats }) as unknown as AppService;
+
 describe('getOrphanedBookEntries (#5837)', () => {
   const LIVE = 'live-hash';
   const DELETED = 'deleted-hash';
   const ORPHAN = 'orphan-hash';
 
-  it('returns every file of a hash dir no library row references', async () => {
+  it('reclaims everything but the kept sidecars in a dir no library row references', async () => {
+    // A transiently opened file keeps its progress in such a dir.
     const readDirectory = vi
       .fn()
-      .mockResolvedValue(makeFiles(`${ORPHAN}/book.epub`, `${ORPHAN}/cover.png`));
-    const appService = { readDirectory } as unknown as AppService;
+      .mockResolvedValue(
+        makeFiles(`${ORPHAN}/book.epub`, `${ORPHAN}/cover.png`, `${ORPHAN}/config.json`),
+      );
+    const appService = makeBooksFs(readDirectory);
 
     const entries = await getOrphanedBookEntries(appService, [makeBook(LIVE)]);
 
-    expect(readDirectory).toHaveBeenCalledWith('', 'Books');
-    expect(entries).toEqual([
-      { base: 'Books', path: `${ORPHAN}/book.epub`, size: 10 },
-      { base: 'Books', path: `${ORPHAN}/cover.png`, size: 20 },
-    ]);
+    expect(readDirectory).toHaveBeenCalledWith('/data/Books', 'None');
+    expect(entries).toEqual([{ base: 'Books', path: `${ORPHAN}/book.epub`, size: 10 }]);
+  });
+
+  it('leaves a dir written in the last hour alone, as an import may still own it', async () => {
+    const readDirectory = vi.fn().mockResolvedValue(makeFiles(`${ORPHAN}/book.epub`));
+    const fresh = makeBooksFs(readDirectory, async () => ({ mtime: new Date() }));
+    const unknown = makeBooksFs(readDirectory, async () => ({ mtime: null }));
+    const unreadable = makeBooksFs(readDirectory, async () => {
+      throw new Error('stat failed');
+    });
+
+    expect(await getOrphanedBookEntries(fresh, [])).toEqual([]);
+    expect(await getOrphanedBookEntries(unknown, [])).toEqual([]);
+    expect(await getOrphanedBookEntries(unreadable, [])).toEqual([]);
+  });
+
+  it('stats each candidate dir once', async () => {
+    const readDirectory = vi
+      .fn()
+      .mockResolvedValue(makeFiles(`${ORPHAN}/a.epub`, `${ORPHAN}/b.pdf`, `${LIVE}/book.epub`));
+    const stats = vi.fn().mockResolvedValue({ mtime: new Date(0) });
+    const appService = makeBooksFs(readDirectory, stats);
+
+    const entries = await getOrphanedBookEntries(appService, [makeBook(LIVE)]);
+
+    expect(entries.map((e) => e.path)).toEqual([`${ORPHAN}/a.epub`, `${ORPHAN}/b.pdf`]);
+    expect(stats).toHaveBeenCalledTimes(1);
+    expect(stats).toHaveBeenCalledWith(ORPHAN, 'Books');
   });
 
   it('never touches a live book dir or root-level library metadata', async () => {
@@ -50,31 +89,56 @@ describe('getOrphanedBookEntries (#5837)', () => {
       .mockResolvedValue(
         makeFiles('library.json', 'library.json.bak', `${LIVE}/book.epub`, `${LIVE}/config.json`),
       );
-    const appService = { readDirectory } as unknown as AppService;
+    const appService = makeBooksFs(readDirectory);
 
     expect(await getOrphanedBookEntries(appService, [makeBook(LIVE)])).toEqual([]);
   });
 
-  it('flags only lingering book files in a soft-deleted book dir', async () => {
-    // A plain delete keeps cover.png and config.json on purpose (a re-download
-    // resumes with them); a book file left there is the leftover to reclaim.
+  it('reclaims everything but the kept sidecars in a soft-deleted book dir', async () => {
+    // A plain delete keeps cover.png, config.json and nav.json on purpose (a
+    // re-download resumes with them), and config.json still points at the
+    // paired audiobook copies. A lingering book file or a feed's article
+    // cache are leftovers to reclaim.
     const readDirectory = vi
       .fn()
       .mockResolvedValue(
-        makeFiles(`${DELETED}/book.pdf`, `${DELETED}/cover.png`, `${DELETED}/config.json`),
+        makeFiles(
+          `${DELETED}/book.pdf`,
+          `${DELETED}/cover.png`,
+          `${DELETED}/config.json`,
+          `${DELETED}/nav.json`,
+          `${DELETED}/audiobook/1-2-track.m4b`,
+          `${DELETED}/articles/x.html`,
+        ),
       );
-    const appService = { readDirectory } as unknown as AppService;
+    const appService = makeBooksFs(readDirectory);
 
     const entries = await getOrphanedBookEntries(appService, [makeBook(DELETED, 5000)]);
 
-    expect(entries).toEqual([{ base: 'Books', path: `${DELETED}/book.pdf`, size: 10 }]);
+    expect(entries).toEqual([
+      { base: 'Books', path: `${DELETED}/book.pdf`, size: 10 },
+      { base: 'Books', path: `${DELETED}/articles/x.html`, size: 60 },
+    ]);
+  });
+
+  it('lets any live row protect a dir a duplicate tombstone also names', async () => {
+    // A legacy library.json is not deduplicated on load.
+    const readDirectory = vi.fn().mockResolvedValue(makeFiles(`${LIVE}/book.epub`));
+    const appService = makeBooksFs(readDirectory);
+
+    const entries = await getOrphanedBookEntries(appService, [
+      makeBook(LIVE),
+      makeBook(LIVE, 5000),
+    ]);
+
+    expect(entries).toEqual([]);
   });
 
   it('handles Windows backslash paths', async () => {
     const readDirectory = vi
       .fn()
       .mockResolvedValue(makeFiles(`${LIVE}\\book.epub`, `${ORPHAN}\\book.epub`));
-    const appService = { readDirectory } as unknown as AppService;
+    const appService = makeBooksFs(readDirectory);
 
     const entries = await getOrphanedBookEntries(appService, [makeBook(LIVE)]);
 
@@ -83,9 +147,80 @@ describe('getOrphanedBookEntries (#5837)', () => {
 
   it('contributes nothing when the Books dir cannot be read', async () => {
     const readDirectory = vi.fn().mockRejectedValue(new Error('unreadable'));
-    const appService = { readDirectory } as unknown as AppService;
+    const appService = makeBooksFs(readDirectory);
 
     expect(await getOrphanedBookEntries(appService, [])).toEqual([]);
+  });
+});
+
+describe('withoutLiveBookEntries (#5837)', () => {
+  it('drops Books entries whose dir a live row owns by confirm time', () => {
+    const entries: CacheEntry[] = [
+      { base: 'Cache', path: 'x.json', size: 10 },
+      { base: 'Books', path: 'abc/book.epub', size: 20 },
+      { base: 'Books', path: 'def\\book.epub', size: 30 },
+    ];
+
+    const kept = withoutLiveBookEntries(entries, [makeBook('abc'), makeBook('def', 5000)]);
+
+    expect(kept).toEqual([
+      { base: 'Cache', path: 'x.json', size: 10 },
+      { base: 'Books', path: 'def\\book.epub', size: 30 },
+    ]);
+  });
+});
+
+describe('getClearableEntries (#5837)', () => {
+  const sources = [{ base: 'Cache' as const, dir: '' }];
+  // Cache root holds one file; the Books tree holds a hash dir no row owns.
+  const readDirectory = () =>
+    vi
+      .fn()
+      .mockImplementation(async (_path: string, base: string) =>
+        base === 'Cache' ? makeFiles('x.json') : makeFiles('abc/book.epub'),
+      );
+
+  it('leaves orphans out while the library is not loaded', async () => {
+    // An unloaded library would make every book on disk look orphaned.
+    const appService = makeBooksFs(readDirectory());
+
+    const result = await getClearableEntries(appService, sources, {
+      books: [makeBook('live')],
+      loaded: false,
+    });
+
+    expect(result).toEqual({
+      entries: [{ base: 'Cache', path: 'x.json', size: 10 }],
+      orphanCount: 0,
+    });
+  });
+
+  it('leaves orphans out when the library loaded with no rows at all', async () => {
+    // A library.json that failed to load hands back []; the hash dirs on
+    // disk are then the only copy of the books and must not be offered.
+    const appService = makeBooksFs(readDirectory());
+
+    const result = await getClearableEntries(appService, sources, { books: [], loaded: true });
+
+    expect(result.orphanCount).toBe(0);
+    expect(result.entries.filter((e) => e.base === 'Books')).toEqual([]);
+  });
+
+  it('appends and counts orphans once a non-empty library is loaded', async () => {
+    const appService = makeBooksFs(readDirectory());
+
+    const result = await getClearableEntries(appService, sources, {
+      books: [makeBook('live')],
+      loaded: true,
+    });
+
+    expect(result).toEqual({
+      entries: [
+        { base: 'Cache', path: 'x.json', size: 10 },
+        { base: 'Books', path: 'abc/book.epub', size: 10 },
+      ],
+      orphanCount: 1,
+    });
   });
 });
 

--- a/apps/readest-app/src/app/library/components/CacheManagerWindow.tsx
+++ b/apps/readest-app/src/app/library/components/CacheManagerWindow.tsx
@@ -8,12 +8,14 @@ import {
 } from 'react-icons/ri';
 import { documentDir, join } from '@tauri-apps/api/path';
 import { useEnv } from '@/context/EnvContext';
+import { useLibraryStore } from '@/store/libraryStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { formatBytes } from '@/utils/book';
 import {
   clearCacheEntries,
   getCacheEntries,
   getCacheStats,
+  getOrphanedBookEntries,
   CacheClearProgress,
   CacheSource,
 } from '@/utils/cache';
@@ -54,12 +56,25 @@ const getCacheSources = async (appService: AppService): Promise<CacheSource[]> =
   return sources;
 };
 
+/**
+ * Cache entries plus orphaned book files under Books/ (#5837). Orphans are
+ * only knowable against a loaded library — an unloaded one would mark every
+ * book on disk as an orphan — so they are skipped until then.
+ */
+const getClearableEntries = async (appService: AppService) => {
+  const cacheEntries = await getCacheEntries(appService, await getCacheSources(appService));
+  const { library, libraryLoaded } = useLibraryStore.getState();
+  const orphanEntries = libraryLoaded ? await getOrphanedBookEntries(appService, library) : [];
+  return { entries: [...cacheEntries, ...orphanEntries], orphanCount: orphanEntries.length };
+};
+
 export const CacheManagerWindow = () => {
   const _ = useTranslation();
   const { appService } = useEnv();
   const [isOpen, setIsOpen] = useState(false);
   const [status, setStatus] = useState<CacheStatus>('scanning');
   const [count, setCount] = useState(0);
+  const [orphanCount, setOrphanCount] = useState(0);
   const [size, setSize] = useState(0);
   const [progress, setProgress] = useState<CacheClearProgress>({ current: 0, total: 0 });
   const [errorMessage, setErrorMessage] = useState('');
@@ -69,9 +84,10 @@ export const CacheManagerWindow = () => {
     setStatus('scanning');
     setErrorMessage('');
     try {
-      const entries = await getCacheEntries(appService, await getCacheSources(appService));
+      const { entries, orphanCount } = await getClearableEntries(appService);
       const stats = getCacheStats(entries);
       setCount(stats.count);
+      setOrphanCount(orphanCount);
       setSize(stats.size);
       setStatus('idle');
     } catch (error) {
@@ -113,7 +129,7 @@ export const CacheManagerWindow = () => {
     setStatus('clearing');
     setProgress({ current: 0, total: 0 });
     try {
-      const entries = await getCacheEntries(appService, await getCacheSources(appService));
+      const { entries } = await getClearableEntries(appService);
       await clearCacheEntries(appService, entries, setProgress);
       await scanCache();
       setStatus('done');
@@ -188,6 +204,13 @@ export const CacheManagerWindow = () => {
                 {status === 'scanning' ? '—' : formatBytes(size)}
               </span>
               <span className='text-base-content/60 line-clamp-2 text-sm'>{heroCaption}</span>
+              {orphanCount > 0 && (status === 'idle' || status === 'confirming') && (
+                <span className='text-base-content/60 text-sm'>
+                  {_('Includes {{count}} orphaned book file(s) not in your library', {
+                    count: orphanCount,
+                  })}
+                </span>
+              )}
             </div>
           </div>
 
@@ -223,7 +246,11 @@ export const CacheManagerWindow = () => {
           {status === 'confirming' && (
             <p className='text-base-content/60 flex items-center justify-center gap-1.5 text-center text-[13px] leading-relaxed'>
               <RiErrorWarningFill className='text-warning h-4 w-4 shrink-0' aria-hidden='true' />
-              {_('This will delete all cached files. This cannot be undone.')}
+              {orphanCount > 0
+                ? _(
+                    'This will delete all cached files and orphaned book files not in your library. This cannot be undone.',
+                  )
+                : _('This will delete all cached files. This cannot be undone.')}
             </p>
           )}
 

--- a/apps/readest-app/src/app/library/components/CacheManagerWindow.tsx
+++ b/apps/readest-app/src/app/library/components/CacheManagerWindow.tsx
@@ -13,10 +13,11 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { formatBytes } from '@/utils/book';
 import {
   clearCacheEntries,
-  getCacheEntries,
   getCacheStats,
-  getOrphanedBookEntries,
+  getClearableEntries,
+  withoutLiveBookEntries,
   CacheClearProgress,
+  CacheEntry,
   CacheSource,
 } from '@/utils/cache';
 import { AppService } from '@/types/system';
@@ -56,23 +57,14 @@ const getCacheSources = async (appService: AppService): Promise<CacheSource[]> =
   return sources;
 };
 
-/**
- * Cache entries plus orphaned book files under Books/ (#5837). Orphans are
- * only knowable against a loaded library — an unloaded one would mark every
- * book on disk as an orphan — so they are skipped until then.
- */
-const getClearableEntries = async (appService: AppService) => {
-  const cacheEntries = await getCacheEntries(appService, await getCacheSources(appService));
-  const { library, libraryLoaded } = useLibraryStore.getState();
-  const orphanEntries = libraryLoaded ? await getOrphanedBookEntries(appService, library) : [];
-  return { entries: [...cacheEntries, ...orphanEntries], orphanCount: orphanEntries.length };
-};
-
 export const CacheManagerWindow = () => {
   const _ = useTranslation();
   const { appService } = useEnv();
   const [isOpen, setIsOpen] = useState(false);
   const [status, setStatus] = useState<CacheStatus>('scanning');
+  // The scanned set is what the user confirms, so Clear deletes exactly the
+  // files the dialog described rather than rescanning under their feet.
+  const [entries, setEntries] = useState<CacheEntry[]>([]);
   const [count, setCount] = useState(0);
   const [orphanCount, setOrphanCount] = useState(0);
   const [size, setSize] = useState(0);
@@ -84,8 +76,14 @@ export const CacheManagerWindow = () => {
     setStatus('scanning');
     setErrorMessage('');
     try {
-      const { entries, orphanCount } = await getClearableEntries(appService);
+      const { library, libraryLoaded } = useLibraryStore.getState();
+      const { entries, orphanCount } = await getClearableEntries(
+        appService,
+        await getCacheSources(appService),
+        { books: library, loaded: libraryLoaded },
+      );
       const stats = getCacheStats(entries);
+      setEntries(entries);
       setCount(stats.count);
       setOrphanCount(orphanCount);
       setSize(stats.size);
@@ -129,9 +127,18 @@ export const CacheManagerWindow = () => {
     setStatus('clearing');
     setProgress({ current: 0, total: 0 });
     try {
-      const { entries } = await getClearableEntries(appService);
-      await clearCacheEntries(appService, entries, setProgress);
+      const { library } = useLibraryStore.getState();
+      const { failed } = await clearCacheEntries(
+        appService,
+        withoutLiveBookEntries(entries, library),
+        setProgress,
+      );
       await scanCache();
+      if (failed > 0) {
+        setErrorMessage(_('Failed to delete {{count}} file(s)', { count: failed }));
+        setStatus('error');
+        return;
+      }
       setStatus('done');
     } catch (error) {
       console.error('Error clearing cache:', error);

--- a/apps/readest-app/src/services/appService.ts
+++ b/apps/readest-app/src/services/appService.ts
@@ -7,6 +7,7 @@ import {
   DeleteAction,
   type DictionaryImportProgressHandler,
   DistChannel,
+  FileInfo,
   FileItem,
   FileSystem,
   OsPlatform,
@@ -261,6 +262,10 @@ export abstract class BaseAppService implements AppService {
     } catch {
       return false;
     }
+  }
+
+  async stats(path: string, base: BaseDir): Promise<FileInfo> {
+    return await this.fs.stats(path, base);
   }
 
   async getImageURL(path: string): Promise<string> {

--- a/apps/readest-app/src/services/backupService.ts
+++ b/apps/readest-app/src/services/backupService.ts
@@ -4,7 +4,7 @@ import { EXTS } from '@/libs/document';
 import { isTauriAppPlatform } from '@/services/environment';
 import { Book, BookConfig, BookNote } from '@/types/book';
 import { SystemSettings } from '@/types/settings';
-import { getLibraryFilename } from '@/utils/book';
+import { getBookDirOfPath, getLibraryFilename } from '@/utils/book';
 import { stampBookConfigSchema } from '@/utils/serializer';
 import { configureZip } from '@/utils/zip';
 
@@ -307,7 +307,14 @@ export async function addBackupEntriesToZip(
   // and dirs no live row references — a soft-deleted book whose file
   // lingered, or an import killed before the library was saved. Those never
   // show in the library UI and must not be silently exported either (#5837).
+  // With no rows at all (a library.json that failed to load hands back `[]`)
+  // every dir is exported instead, so a broken library can still be rebuilt
+  // by restore's orphan-dir import.
   const liveHashes = new Set(books.filter((b) => !b.deletedAt).map((b) => b.hash));
+  const isExported = (path: string) => {
+    const dir = getBookDirOfPath(path);
+    return !!dir && (books.length === 0 || liveHashes.has(dir));
+  };
   const booksDir = await appService.resolveFilePath('', 'Books');
   const files = await appService.readDirectory(booksDir, 'None');
   // `readDirectory` returns host-separator paths; on Windows that is a
@@ -315,8 +322,8 @@ export async function addBackupEntriesToZip(
   // slashes so the backup restores on every platform — restore matches a
   // book's files by `${hash}/` (see `restoreFromBackupZip`). Issue #4703.
   const bookFiles = files
-    .map((file) => ({ file, entryName: file.path.replace(/\\/g, '/') }))
-    .filter(({ file, entryName }) => file.size > 0 && liveHashes.has(entryName.split('/')[0]!));
+    .filter((file) => file.size > 0 && isExported(file.path))
+    .map((file) => ({ file, entryName: file.path.replace(/\\/g, '/') }));
   const total = bookFiles.length;
 
   for (let i = 0; i < bookFiles.length; i++) {

--- a/apps/readest-app/src/services/backupService.ts
+++ b/apps/readest-app/src/services/backupService.ts
@@ -271,20 +271,6 @@ export function reviveRestoredBooks(revived: RevivedBook[], now: number = Date.n
   }
 }
 
-/** Library metadata files to skip from the directory scan. */
-const LIBRARY_META_FILES = new Set([
-  'library.json',
-  'library.json.bak',
-  'library_backup.json',
-  'library.db',
-  'library.db-shm',
-  'library.db-wal',
-]);
-
-function isLibraryMetaFile(path: string): boolean {
-  return LIBRARY_META_FILES.has(path);
-}
-
 type ProgressCallback = (current: number, total: number, filename: string) => void;
 
 /**
@@ -316,23 +302,29 @@ export async function addBackupEntriesToZip(
     console.warn('Skipping settings backup:', error);
   }
 
-  // Add all book files, skipping library metadata files
+  // Add the files of every live library book. Only a book's own `<hash>/`
+  // dir is exported: the Books/ tree also holds root-level library metadata
+  // and dirs no live row references — a soft-deleted book whose file
+  // lingered, or an import killed before the library was saved. Those never
+  // show in the library UI and must not be silently exported either (#5837).
+  const liveHashes = new Set(books.filter((b) => !b.deletedAt).map((b) => b.hash));
   const booksDir = await appService.resolveFilePath('', 'Books');
   const files = await appService.readDirectory(booksDir, 'None');
-  const bookFiles = files.filter((f) => f.size > 0 && !isLibraryMetaFile(f.path));
+  // `readDirectory` returns host-separator paths; on Windows that is a
+  // backslash (e.g. `hash\cover.png`). Zip entry names must use forward
+  // slashes so the backup restores on every platform — restore matches a
+  // book's files by `${hash}/` (see `restoreFromBackupZip`). Issue #4703.
+  const bookFiles = files
+    .map((file) => ({ file, entryName: file.path.replace(/\\/g, '/') }))
+    .filter(({ file, entryName }) => file.size > 0 && liveHashes.has(entryName.split('/')[0]!));
   const total = bookFiles.length;
 
   for (let i = 0; i < bookFiles.length; i++) {
-    const file = bookFiles[i]!;
+    const { file, entryName } = bookFiles[i]!;
     onProgress?.(i + 1, total, file.path);
     try {
       const content = await appService.readFile(file.path, 'Books', 'binary');
       const data = new Uint8Array(content as ArrayBuffer);
-      // `readDirectory` returns host-separator paths; on Windows that is a
-      // backslash (e.g. `hash\cover.png`). Zip entry names must use forward
-      // slashes so the backup restores on every platform — restore matches a
-      // book's files by `${hash}/` (see `restoreFromBackupZip`). Issue #4703.
-      const entryName = file.path.replace(/\\/g, '/');
       await writer.add(entryName, new Uint8ArrayReader(data), { level: 0 });
     } catch (error) {
       console.warn(`Skipping file ${file.path}:`, error);

--- a/apps/readest-app/src/types/system.ts
+++ b/apps/readest-app/src/types/system.ts
@@ -146,6 +146,7 @@ export interface AppService {
   deleteDir(path: string, base: BaseDir, recursive?: boolean): Promise<void>;
   exists(path: string, base: BaseDir): Promise<boolean>;
   isDirectory(path: string, base: BaseDir): Promise<boolean>;
+  stats(path: string, base: BaseDir): Promise<FileInfo>;
   getImageURL(path: string): Promise<string>;
 
   setCustomRootDir(customRootDir: string): Promise<void>;

--- a/apps/readest-app/src/utils/book.ts
+++ b/apps/readest-app/src/utils/book.ts
@@ -16,6 +16,16 @@ import { md5 } from './md5';
 export const getDir = (book: Book) => {
   return `${book.hash}`;
 };
+/**
+ * The `<hash>` dir a Books/-relative path lives in, or undefined for a
+ * root-level file (library metadata). Accepts host separators, so a Windows
+ * `readDirectory` path (`hash\cover.png`) resolves the same as a POSIX one.
+ */
+export const getBookDirOfPath = (path: string) => {
+  const normalized = path.replace(/\\/g, '/');
+  const slashIdx = normalized.indexOf('/');
+  return slashIdx < 0 ? undefined : normalized.slice(0, slashIdx);
+};
 export const getLibraryFilename = () => {
   return 'library.json';
 };

--- a/apps/readest-app/src/utils/cache.ts
+++ b/apps/readest-app/src/utils/cache.ts
@@ -1,8 +1,7 @@
 import { AppService, BaseDir, FileItem } from '@/types/system';
 import { Book } from '@/types/book';
-import { EXTS } from '@/libs/document';
-
-const BOOK_EXTS = new Set(Object.values(EXTS));
+import { getAudiobookDirectory } from '@/services/audiobook/storage';
+import { getBookDirOfPath } from './book';
 
 export interface CacheClearProgress {
   current: number;
@@ -57,36 +56,107 @@ export const getCacheEntries = async (
 };
 
 /**
+ * Sidecars that are never reclaimed. A plain (non-purge) delete keeps them in
+ * a soft-deleted book's dir on purpose so a re-download resumes with its
+ * cover, progress, and notes, and a transiently opened file keeps its
+ * progress in a dir no saved row owns. The paired audiobook copies under
+ * `audiobook/` stay with them: config.json still points at those files, and
+ * only the pairing's own removal path clears that association.
+ */
+const KEPT_SIDECARS = new Set(['cover.png', 'config.json', 'nav.json']);
+
+/**
+ * A dir written more recently than this may belong to an import whose row is
+ * not in the library yet: files land in Books/<hash>/ before the caller saves
+ * the row, and OPDS auto-download and restore persist a whole batch at once.
+ * Such dirs are left alone until they settle.
+ */
+const ORPHAN_SETTLE_MS = 60 * 60 * 1000;
+
+/**
  * Files under Books/ that no live library book owns, as deletable entries:
- * everything in a `<hash>/` dir with no library row (an import killed before
- * the library was saved), plus any book file lingering in a soft-deleted
- * book's dir (a cloud tombstone never deletes local files). A plain delete
- * keeps cover.png and config.json there on purpose so a re-download resumes,
- * so those stay. Root-level library metadata is never an orphan. Neither kind
- * shows in the library UI, which is how they went unnoticed in #5837.
+ * everything but the kept sidecars in a `<hash>/` dir with no library row
+ * (an import killed before the library was saved) or with a soft-deleted one
+ * (a book file a cloud tombstone never removed, a paired audiobook copy, a
+ * feed's article cache). Root-level library metadata is never an orphan.
+ * Neither kind shows in the library UI, which is how they went unnoticed in
+ * #5837.
  */
 export const getOrphanedBookEntries = async (
   appService: AppService,
   books: Book[],
 ): Promise<CacheEntry[]> => {
-  const rows = new Map(books.map((book) => [book.hash, book]));
+  // Any live row protects its dir, even if a legacy library.json also carries
+  // a tombstone for the same hash.
+  const liveHashes = new Set(books.filter((book) => !book.deletedAt).map((book) => book.hash));
   let files: FileItem[];
   try {
-    files = await appService.readDirectory('', 'Books');
+    // Scan by absolute path: a base-relative read of 'Books' resolves to a
+    // Tauri baseDir and misses the native Rust walk, falling back to one IPC
+    // round-trip per entry. Paths still come back relative to Books/.
+    const booksDir = await appService.resolveFilePath('', 'Books');
+    files = await appService.readDirectory(booksDir, 'None');
   } catch {
     return [];
   }
+  const now = Date.now();
+  const settled = new Map<string, Promise<boolean>>();
+  // One stat per candidate dir; an unreadable or unknown mtime counts as
+  // unsettled so nothing is offered on a guess.
+  const isSettled = (dir: string) => {
+    let result = settled.get(dir);
+    if (!result) {
+      result = appService
+        .stats(dir, 'Books')
+        .then(({ mtime }) => !!mtime && now - mtime.getTime() >= ORPHAN_SETTLE_MS)
+        .catch(() => false);
+      settled.set(dir, result);
+    }
+    return result;
+  };
   const entries: CacheEntry[] = [];
   for (const file of files) {
+    const dir = getBookDirOfPath(file.path);
+    if (!dir || liveHashes.has(dir)) continue;
     const path = file.path.replace(/\\/g, '/');
-    const slashIdx = path.indexOf('/');
-    if (slashIdx < 0) continue;
-    const row = rows.get(path.slice(0, slashIdx));
-    if (row && !row.deletedAt) continue;
-    if (row && !BOOK_EXTS.has(path.split('.').pop()?.toLowerCase() ?? '')) continue;
+    if (KEPT_SIDECARS.has(path.slice(dir.length + 1))) continue;
+    if (path.startsWith(`${getAudiobookDirectory(dir)}/`)) continue;
+    if (!(await isSettled(dir))) continue;
     entries.push({ base: 'Books', path: file.path, size: file.size || 0 });
   }
   return entries;
+};
+
+/**
+ * Drop the Books/ entries whose dir a live library row owns by now: a sync or
+ * import may have persisted a book between the scan and the confirm.
+ */
+export const withoutLiveBookEntries = (entries: CacheEntry[], books: Book[]): CacheEntry[] => {
+  const live = new Set(books.filter((book) => !book.deletedAt).map((book) => book.hash));
+  return entries.filter(
+    (entry) => entry.base !== 'Books' || !live.has(getBookDirOfPath(entry.path) ?? ''),
+  );
+};
+
+/**
+ * Everything Manage Cache may delete: the cache sources plus orphaned book
+ * files under Books/ (#5837). Orphans are only knowable against a loaded,
+ * non-empty library: an unloaded one would mark every book on disk as an
+ * orphan, and so would a library.json that failed to load (safeLoadJSON
+ * hands back `[]`), whose Books/<hash>/ dirs are then the only copy left.
+ * Both cases leave orphans out.
+ */
+export const getClearableEntries = async (
+  appService: AppService,
+  sources: CacheSource[],
+  library: { books: Book[]; loaded: boolean },
+): Promise<{ entries: CacheEntry[]; orphanCount: number }> => {
+  const cacheEntries = await getCacheEntries(appService, sources);
+  const orphanEntries =
+    library.loaded && library.books.length > 0
+      ? await getOrphanedBookEntries(appService, library.books)
+      : [];
+  return { entries: [...cacheEntries, ...orphanEntries], orphanCount: orphanEntries.length };
 };
 
 /** Total file count and byte size for a set of cache entries. */

--- a/apps/readest-app/src/utils/cache.ts
+++ b/apps/readest-app/src/utils/cache.ts
@@ -1,4 +1,8 @@
-import { AppService, BaseDir } from '@/types/system';
+import { AppService, BaseDir, FileItem } from '@/types/system';
+import { Book } from '@/types/book';
+import { EXTS } from '@/libs/document';
+
+const BOOK_EXTS = new Set(Object.values(EXTS));
 
 export interface CacheClearProgress {
   current: number;
@@ -48,6 +52,39 @@ export const getCacheEntries = async (
     } catch {
       // Missing or unreadable source — skip it.
     }
+  }
+  return entries;
+};
+
+/**
+ * Files under Books/ that no live library book owns, as deletable entries:
+ * everything in a `<hash>/` dir with no library row (an import killed before
+ * the library was saved), plus any book file lingering in a soft-deleted
+ * book's dir (a cloud tombstone never deletes local files). A plain delete
+ * keeps cover.png and config.json there on purpose so a re-download resumes,
+ * so those stay. Root-level library metadata is never an orphan. Neither kind
+ * shows in the library UI, which is how they went unnoticed in #5837.
+ */
+export const getOrphanedBookEntries = async (
+  appService: AppService,
+  books: Book[],
+): Promise<CacheEntry[]> => {
+  const rows = new Map(books.map((book) => [book.hash, book]));
+  let files: FileItem[];
+  try {
+    files = await appService.readDirectory('', 'Books');
+  } catch {
+    return [];
+  }
+  const entries: CacheEntry[] = [];
+  for (const file of files) {
+    const path = file.path.replace(/\\/g, '/');
+    const slashIdx = path.indexOf('/');
+    if (slashIdx < 0) continue;
+    const row = rows.get(path.slice(0, slashIdx));
+    if (row && !row.deletedAt) continue;
+    if (row && !BOOK_EXTS.has(path.split('.').pop()?.toLowerCase() ?? '')) continue;
+    entries.push({ base: 'Books', path: file.path, size: file.size || 0 });
   }
   return entries;
 };


### PR DESCRIPTION
Closes #5837

## Summary

On Android the backup zip carried hundreds of EPUB/PDF files for books that never appear in the library. `addBackupEntriesToZip` zipped the whole `Books/` tree without consulting the library it had just loaded, so any `Books/<hash>/` dir without a live row shipped. Those dirs come from #5658 (fix #5665 is not in v0.12.1, the reporter's build), a process kill between `importBook`'s file copy and the library save, or a cloud tombstone (no sync path calls `deleteBook`). Nothing in the UI could see or remove them: "Refresh Metadata" only touches rows and "Manage Cache" scanned only `Cache`/`Temp`.

**Backup**
- Export only files under dirs of non-deleted library books. Root-level library metadata and unowned dirs stay out.
- A library with no rows at all falls back to exporting every dir: `safeLoadJSON` hands back `[]` when `library.json` fails to load, and restore's orphan-dir import is how such a library gets rebuilt.
- Restore is unchanged, so older zips still recover.

**Manage Cache (Advanced Settings, mobile)**
- New `getOrphanedBookEntries` finds files under `Books/` that no live row owns and folds them into the scan and clear. The dialog says how many it found ("Includes N orphaned book file(s) not in your library") and the confirm notice says so too.
- Never reclaimed: `cover.png`, `config.json`, `nav.json` (a plain delete keeps them so a re-download resumes, and transient "Open with" files keep their progress there) and the paired audiobook copies that `config.json` still references.
- Dirs written in the last hour are left alone: files land in `Books/<hash>/` before the caller saves the row, and OPDS auto-download and restore persist a whole batch at once.
- Orphans are skipped while the library is unloaded or has no rows (a failed `library.json` load would otherwise make every book on disk look orphaned).
- Clear deletes exactly the scanned set, minus any dir that gained a live row while the user sat on the confirm screen, and reports files it could not delete instead of claiming "Cache cleared".
- The scan resolves the absolute `Books/` dir so the native Rust walk is used; a base-relative read falls back to one IPC round-trip per entry.

**Plumbing**
- `getBookDirOfPath` in `utils/book.ts`, shared by the backup filter and the orphan scan; `stats()` passthrough on `AppService`.
- i18n: 2 new strings across 34 locales, `en` carries the `_one`/`_other` plural forms.

**Not changed, deliberately**
- An empty library cannot be told apart from a failed load without provenance from `safeLoadJSON`, so both are treated as unknown: backup exports everything (the behavior before this PR) and Manage Cache offers no orphans.
- Backup still snapshots the library before walking `Books/` (pre-existing race with a concurrent import).
- Desktop has no Manage Cache entry, so desktop users still cannot reclaim orphans in-app.
- Clearing leaves empty `Books/<hash>/` dirs behind (`AppService` has no `removeDir`); harmless for backup.

## Test Coverage

Coverage gate: PASS (94%, 44/47 paths). Tests: 850 -> 854 test files. The two gaps are pre-existing catch blocks only a mocked throw could reach.

<details>
<summary>Coverage diagram</summary>

```
CODE PATHS
backupService.ts addBackupEntriesToZip
  [x] liveHashes excludes soft-deleted rows ............ backup-orphan-files ★★★
  [x] root-level file (no dir) skipped ................. ★★
  [x] books.length===0 exports every dir ............... ★★★
  [x] live dir kept / orphan dir skipped ............... ★★★
  [x] Windows backslash match + '/' entry names ........ backup-windows-paths ★★★
  [x] size>0 filter retained ........................... backup-orphan-files-edges ★★
  [x] onProgress total = filtered count, host path ..... ★★
  [x] readFile throws -> warn, keep exporting .......... ★★★
book.ts getBookDirOfPath
  [x] root-level / empty -> undefined .................. book-dir-of-path ★★
  [x] posix / backslash / nested -> first segment ...... ★★
cache.ts getOrphanedBookEntries
  [x] resolveFilePath or readDirectory throws -> [] .... cache / cache-orphaned-entries-edges ★★★
  [x] reads (absBooksDir, 'None') ...................... ★★
  [x] root-level metadata skipped ...................... ★★
  [x] live row skipped, also next to a duplicate tombstone ★★★
  [x] no row -> everything but kept sidecars ........... ★★★
  [x] soft-deleted row: sidecars + audiobook/ kept, rest reclaimed ★★★
  [x] kept sidecar on backslash path; nested sidecar name reclaimed ★★
  [x] dir written in the last hour / unknown mtime / stat failure -> left alone ★★★
  [x] one stat per candidate dir ....................... ★★
cache.ts getClearableEntries / withoutLiveBookEntries
  [x] loaded=false -> no orphans ....................... ★★
  [x] loaded, books=[] -> no orphans ................... ★★
  [x] loaded non-empty -> appended + counted ........... ★★★
  [x] Books entries of dirs owned by a live row dropped  ★★
CacheManagerWindow.tsx (real cache utils over a fake AppService fs)
  [x] scan sets entries/count/orphanCount/size ......... cache-manager-window-orphans ★★★
  [x] libraryLoaded=false -> Books tree not walked ..... ★★★
  [x] orphan caption shown in idle, absent with zero orphans, hidden in done ★★
  [x] confirm notice, orphan and plain variants ........ ★★
  [x] Clear enabled when only orphans .................. ★★
  [x] confirm deletes the shown set, never a live book or a late file ★★★
  [x] shown orphan spared once it gains a live row ..... ★★★
  [x] delete failures reported instead of "Cache cleared" ★★★
  [ ] scanCache catch -> 'Failed to read cache' ........ [->E2E] pre-existing
  [ ] confirm catch -> 'Failed to clear cache' ......... [->E2E] pre-existing
```

</details>

## Pre-Landing Review

Specialists: testing (3), maintainability (3), performance (2, 1 critical), design-lite (2 low), security (1 critical). Adversarial: Claude subagent (9), Codex adversarial (6), Codex structured review (2 P1, 1 P2). All ran against the first commit; the second commit addresses them:

- [FIXED] Books scan bypassed the native walker (perf critical, Codex P2)
- [FIXED] Empty or failed-to-load library would offer every book on disk for deletion (security critical, adversarial F2/F3)
- [FIXED] Orphan scan raced in-flight imports and OPDS batch persistence (testing, adversarial F1, Codex P1): freshness guard + confirm-time revalidation
- [FIXED] Clear rescanned instead of deleting the confirmed set (perf, maintainability, adversarial F4, Codex P1)
- [FIXED] Extension-based reclaim missed audiobook/articles payloads; paired audio is now kept because config.json references it (testing, adversarial F8, Codex adversarial P1)
- [FIXED] Duplicate hash in a legacy library.json could let a tombstone shadow a live row (Codex adversarial P1)
- [FIXED] Delete failures reported as success (adversarial F5, Codex adversarial P2)
- [FIXED] Duplicated book-dir and extension logic (maintainability)
- [SKIPPED] Design-lite: hero block height changes when the orphan line appears; long confirm notice wraps under a centered icon. Verify visually.
- [SKIPPED] Load provenance for empty vs failed library (Codex adversarial): treated as unknown instead, see "Not changed".

## Scope Drift

Scope Check: CLEAN. Intent: backup must not export hidden book files, and users need a way to find and remove them (#5837). Delivered: backup limited to live library books; Manage Cache finds and reclaims orphaned book files safely.

## Plan Completion

No plan file detected.

## TODOS

No TODO items completed in this PR.

## Test plan

- [x] Vitest: 809 test files, 9979 tests pass
- [x] `pnpm lint` (tsgo + Biome) and `pnpm format:check`
- [ ] Android device check: Manage Cache shows the orphan count, Clear reclaims them, the backup zip holds only library books

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cache cleanup now identifies orphaned book files not included in the library.
  * Cleanup dialogs show orphaned-file counts and clearly warn that deletion is permanent.
  * Cache clearing is safer and avoids removing books added during scanning.
  * Backups now include active library books while excluding deleted or unrelated files.
  * Backup paths are normalized for improved cross-platform compatibility.

* **Localization**
  * Added translated orphaned-file counts and cleanup warnings across supported languages.

* **Bug Fixes**
  * Improved handling of unreadable files, stale directories, and Windows paths during cleanup and backups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->