### PR TITLE
fix(sync): sync highlight deletions from KOReader to Readest

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/hooks/useNotesSync-tombstone.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useNotesSync-tombstone.test.tsx
@@ -204,6 +204,35 @@ describe('useNotesSync pulled tombstones', () => {
     expect(h.view.addAnnotation).not.toHaveBeenCalled();
   });
 
+  test('a local note edited after the remote deletion survives the tombstone', async () => {
+    h.state.config = { location: h.localCfi, booknotes: [{ ...h.localNote, updatedAt: 6000 }] };
+    h.state.syncedNotes = [
+      { ...h.localNote, bookHash: 'r', metaHash: 'm1', updatedAt: 1000, deletedAt: 5000 },
+    ];
+
+    renderHook(() => useNotesSync('r-1'));
+
+    await waitFor(() => expect(h.setConfigMock).toHaveBeenCalled());
+    expect(savedNote('n1')?.deletedAt).toBeUndefined();
+    expect(savedNote('n1')?.updatedAt).toBe(6000);
+    expect(h.view.addAnnotation).not.toHaveBeenCalled();
+    expect(h.removeGlobalOverlaysMock).not.toHaveBeenCalled();
+  });
+
+  test('a local deletion made after the remote edit is kept', async () => {
+    h.state.config = {
+      location: h.localCfi,
+      booknotes: [{ ...h.localNote, updatedAt: 3000, deletedAt: 5000 }],
+    };
+    h.state.syncedNotes = [{ ...h.localNote, bookHash: 'r', metaHash: 'm1', updatedAt: 4000 }];
+
+    renderHook(() => useNotesSync('r-1'));
+
+    await waitFor(() => expect(h.setConfigMock).toHaveBeenCalled());
+    expect(savedNote('n1')?.deletedAt).toBe(5000);
+    expect(h.view.addAnnotation).not.toHaveBeenCalled();
+  });
+
   test('a tombstone for a note this device never had is recorded without touching the view', async () => {
     h.state.syncedNotes = [
       { ...h.localNote, id: 'n2', bookHash: 'r', metaHash: 'm1', updatedAt: 1000, deletedAt: 5000 },

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useNotesSync-tombstone.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useNotesSync-tombstone.test.tsx
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import type { BookNote } from '@/types/book';
+
+// Issue #5818: a highlight deleted in KOReader stayed visible in Readest.
+// The pull did fetch the tombstone, but processSyncedNotes only ever drew
+// pulled notes; it never cleared the overlay of a note deleted elsewhere,
+// and a tombstone whose xpointer could not be converted to a cfi was
+// silently discarded before it could mark the local copy deleted.
+const h = vi.hoisted(() => {
+  const makeStore = <T,>(state: T) => {
+    const fn = <R,>(selector?: (s: T) => R) => (selector ? selector(state) : state) as R | T;
+    (fn as unknown as { getState: () => T }).getState = () => state;
+    return fn as {
+      (): T;
+      <R>(selector: (s: T) => R): R;
+      getState: () => T;
+    };
+  };
+
+  const localCfi = 'epubcfi(/6/4!/4/2/1:0)';
+  const localNote = {
+    id: 'n1',
+    type: 'annotation',
+    cfi: localCfi,
+    style: 'highlight',
+    color: 'yellow',
+    text: 'hello',
+    note: '',
+    createdAt: 1000,
+    updatedAt: 3000,
+  };
+
+  return {
+    makeStore,
+    localCfi,
+    localNote,
+    book: { hash: 'r', format: 'EPUB', metaHash: 'm1' },
+    state: {
+      syncedNotes: null as unknown[] | null,
+      config: { location: localCfi, booknotes: [] as unknown[] },
+    },
+    setConfigMock: vi.fn(),
+    syncNotesMock: vi.fn(async () => {}),
+    removeGlobalOverlaysMock: vi.fn(),
+    view: {
+      renderer: { getContents: () => [], primaryIndex: 0 },
+      addAnnotation: vi.fn(),
+    },
+  };
+});
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1' } }),
+}));
+
+vi.mock('@/hooks/useSync', () => ({
+  useSync: () => ({
+    syncedNotes: h.state.syncedNotes,
+    syncNotes: h.syncNotesMock,
+    lastSyncedAtNotes: 2000,
+  }),
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: h.makeStore({
+    getConfig: () => h.state.config,
+    setConfig: h.setConfigMock,
+    // No sections: an xpointer-only note cannot be converted to a cfi.
+    getBookData: () => ({ book: h.book, bookDoc: { sections: [] } }),
+  }),
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: h.makeStore({ getView: () => h.view, getViewsById: () => [h.view] }),
+}));
+
+vi.mock('@/utils/xcfi', () => ({
+  XCFI: class {
+    static extractSpineIndex() {
+      return 1;
+    }
+    xPointerToCFI() {
+      return '';
+    }
+  },
+  getXPointerFromCFI: vi.fn(async () => ({ xpointer: '' })),
+  getCFIFromXPointer: vi.fn(async () => ''),
+}));
+
+vi.mock('@/app/reader/utils/globalAnnotations', () => ({
+  removeGlobalAnnotationOverlays: h.removeGlobalOverlaysMock,
+}));
+
+import { useNotesSync } from '@/app/reader/hooks/useNotesSync';
+
+const lastSavedNotes = () => {
+  const call = h.setConfigMock.mock.calls.at(-1);
+  return (call?.[1] as { booknotes: BookNote[] }).booknotes;
+};
+
+const savedNote = (id: string) => lastSavedNotes().find((n) => n.id === id);
+
+const expectOverlayCleared = () => {
+  expect(h.view.addAnnotation).toHaveBeenCalledTimes(1);
+  expect(h.view.addAnnotation).toHaveBeenCalledWith(
+    expect.objectContaining({ id: 'n1', value: h.localCfi }),
+    true,
+  );
+  // Applying the deletion counts as this device's change, so the next push
+  // tombstones the duplicate row under its own book hash too.
+  expect(savedNote('n1')?.updatedAt).toBeGreaterThan(h.localNote.updatedAt);
+};
+
+describe('useNotesSync pulled tombstones', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.book.format = 'EPUB';
+    h.state.config = { location: h.localCfi, booknotes: [{ ...h.localNote }] };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('a KOReader tombstone without a usable cfi still deletes the local note and clears its overlay', async () => {
+    h.state.syncedNotes = [
+      {
+        id: 'n1',
+        type: 'annotation',
+        bookHash: 'k',
+        metaHash: 'm1',
+        cfi: '',
+        xpointer0: '/body/DocFragment[2]/body/p[1]/text().0',
+        xpointer1: '/body/DocFragment[2]/body/p[1]/text().5',
+        note: '',
+        createdAt: 1000,
+        updatedAt: 1000,
+        deletedAt: 5000,
+      },
+    ];
+
+    renderHook(() => useNotesSync('r-1'));
+
+    await waitFor(() => expect(h.setConfigMock).toHaveBeenCalled());
+    expect(savedNote('n1')?.deletedAt).toBe(5000);
+    // setConfig discards cfi-less notes, so the tombstone keeps the local anchor.
+    expect(savedNote('n1')?.cfi).toBe(h.localCfi);
+    expectOverlayCleared();
+  });
+
+  test('a tombstone that already carries a cfi clears the drawn overlay', async () => {
+    h.state.syncedNotes = [
+      { ...h.localNote, bookHash: 'r', metaHash: 'm1', updatedAt: 1000, deletedAt: 5000 },
+    ];
+
+    renderHook(() => useNotesSync('r-1'));
+
+    await waitFor(() => expect(h.setConfigMock).toHaveBeenCalled());
+    expect(savedNote('n1')?.deletedAt).toBe(5000);
+    expectOverlayCleared();
+  });
+
+  test('a cfi-less tombstone survives the fixed-layout filter', async () => {
+    h.book.format = 'PDF';
+    h.state.syncedNotes = [
+      { ...h.localNote, bookHash: 'r', metaHash: 'm1', cfi: '', updatedAt: 1000, deletedAt: 5000 },
+    ];
+
+    renderHook(() => useNotesSync('r-1'));
+
+    await waitFor(() => expect(h.setConfigMock).toHaveBeenCalled());
+    expect(savedNote('n1')?.deletedAt).toBe(5000);
+    expect(savedNote('n1')?.cfi).toBe(h.localCfi);
+    expectOverlayCleared();
+  });
+
+  test('a global highlight tombstone also clears its synthetic overlays', async () => {
+    h.state.config = { location: h.localCfi, booknotes: [{ ...h.localNote, global: true }] };
+    h.state.syncedNotes = [
+      { ...h.localNote, bookHash: 'r', metaHash: 'm1', updatedAt: 1000, deletedAt: 5000 },
+    ];
+
+    renderHook(() => useNotesSync('r-1'));
+
+    await waitFor(() => expect(h.setConfigMock).toHaveBeenCalled());
+    expectOverlayCleared();
+    expect(h.removeGlobalOverlaysMock).toHaveBeenCalledWith(
+      h.view,
+      expect.objectContaining({ id: 'n1', global: true }),
+    );
+  });
+
+  test('a tombstone for a note already deleted locally does not touch the view', async () => {
+    h.state.config = { location: h.localCfi, booknotes: [{ ...h.localNote, deletedAt: 4000 }] };
+    h.state.syncedNotes = [
+      { ...h.localNote, bookHash: 'r', metaHash: 'm1', updatedAt: 1000, deletedAt: 5000 },
+    ];
+
+    renderHook(() => useNotesSync('r-1'));
+
+    await waitFor(() => expect(h.setConfigMock).toHaveBeenCalled());
+    expect(savedNote('n1')?.deletedAt).toBe(5000);
+    expect(h.view.addAnnotation).not.toHaveBeenCalled();
+  });
+
+  test('a tombstone for a note this device never had is recorded without touching the view', async () => {
+    h.state.syncedNotes = [
+      { ...h.localNote, id: 'n2', bookHash: 'r', metaHash: 'm1', updatedAt: 1000, deletedAt: 5000 },
+    ];
+
+    renderHook(() => useNotesSync('r-1'));
+
+    await waitFor(() => expect(h.setConfigMock).toHaveBeenCalled());
+    expect(savedNote('n2')?.deletedAt).toBe(5000);
+    expect(savedNote('n1')?.deletedAt).toBeUndefined();
+    expect(h.view.addAnnotation).not.toHaveBeenCalled();
+  });
+
+  test('a pulled live note on the rendered section is still drawn', async () => {
+    h.state.syncedNotes = [
+      {
+        ...h.localNote,
+        id: 'n3',
+        cfi: 'epubcfi(/6/2!/4/2/1:0)',
+        bookHash: 'r',
+        metaHash: 'm1',
+        updatedAt: 4000,
+      },
+    ];
+
+    renderHook(() => useNotesSync('r-1'));
+
+    await waitFor(() => expect(h.setConfigMock).toHaveBeenCalled());
+    expect(h.view.addAnnotation).toHaveBeenCalledTimes(1);
+    expect(h.view.addAnnotation).toHaveBeenCalledWith(expect.objectContaining({ id: 'n3' }));
+    expect(savedNote('n3')?.deletedAt).toBeUndefined();
+  });
+});

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useNotesSync-tombstone.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useNotesSync-tombstone.test.tsx
@@ -233,6 +233,21 @@ describe('useNotesSync pulled tombstones', () => {
     expect(h.view.addAnnotation).not.toHaveBeenCalled();
   });
 
+  test('a remote edit newer than the local deletion brings the note back without its deletedAt', async () => {
+    h.state.config = {
+      location: h.localCfi,
+      booknotes: [{ ...h.localNote, updatedAt: 3000, deletedAt: 5000 }],
+    };
+    // No deletedAt key at all, the shape that would leak the local tombstone.
+    h.state.syncedNotes = [{ ...h.localNote, bookHash: 'r', metaHash: 'm1', updatedAt: 6000 }];
+
+    renderHook(() => useNotesSync('r-1'));
+
+    await waitFor(() => expect(h.setConfigMock).toHaveBeenCalled());
+    expect(savedNote('n1')?.deletedAt ?? null).toBeNull();
+    expect(savedNote('n1')?.updatedAt).toBe(6000);
+  });
+
   test('a tombstone for a note this device never had is recorded without touching the view', async () => {
     h.state.syncedNotes = [
       { ...h.localNote, id: 'n2', bookHash: 'r', metaHash: 'm1', updatedAt: 1000, deletedAt: 5000 },

--- a/apps/readest-app/src/__tests__/pages/api/sync-notes-tombstone-dedupe.test.ts
+++ b/apps/readest-app/src/__tests__/pages/api/sync-notes-tombstone-dedupe.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { dedupeLatest } from '@/pages/api/sync';
+
+const iso = (ms: number) => new Date(ms).toISOString();
+
+// Issue #5818: a highlight deleted in KOReader never disappeared in Readest.
+// The same note can exist as two book_notes rows when the two apps hold
+// different copies of the book (meta_hash bridges the book_hash mismatch):
+// KOReader's row under its hash and Readest's re-pushed copy under its own.
+// KOReader's tombstone keeps the highlight's original updated_at, so the
+// pull's id-dedupe, ranked on updated_at alone, kept the live duplicate and
+// dropped the deletion.
+describe('dedupeLatest', () => {
+  it('keeps the tombstone over a live duplicate with a newer updated_at', () => {
+    const live = { book_hash: 'r', id: 'n1', updated_at: iso(3000), deleted_at: null };
+    const tombstone = { book_hash: 'k', id: 'n1', updated_at: iso(1000), deleted_at: iso(5000) };
+    expect(dedupeLatest([live, tombstone], ['id'])).toEqual([tombstone]);
+  });
+
+  it('keeps a live duplicate edited after the deletion', () => {
+    const live = { book_hash: 'r', id: 'n1', updated_at: iso(6000), deleted_at: null };
+    const tombstone = { book_hash: 'k', id: 'n1', updated_at: iso(1000), deleted_at: iso(5000) };
+    expect(dedupeLatest([live, tombstone], ['id'])).toEqual([live]);
+  });
+
+  it('gives an exact tie to the tombstone', () => {
+    const live = { book_hash: 'r', id: 'n1', updated_at: iso(5000), deleted_at: null };
+    const tombstone = { book_hash: 'k', id: 'n1', updated_at: iso(1000), deleted_at: iso(5000) };
+    expect(dedupeLatest([live, tombstone], ['id'])).toEqual([tombstone]);
+  });
+
+  it('preserves the input order of the surviving rows', () => {
+    const a = { book_hash: 'k', id: 'a', updated_at: iso(1000), deleted_at: null };
+    const b = { book_hash: 'k', id: 'b', updated_at: iso(3000), deleted_at: null };
+    const bDup = { book_hash: 'r', id: 'b', updated_at: iso(2000), deleted_at: null };
+    const c = { book_hash: 'k', id: 'c', updated_at: iso(2000), deleted_at: null };
+    expect(dedupeLatest([a, b, bDup, c], ['id'])).toEqual([a, b, c]);
+  });
+
+  it('keeps the newest live row when neither duplicate is deleted', () => {
+    const older = { book_hash: 'k', id: 'n1', updated_at: iso(1000), deleted_at: null };
+    const newer = { book_hash: 'r', id: 'n1', updated_at: iso(3000), deleted_at: null };
+    expect(dedupeLatest([older, newer], ['id'])).toEqual([newer]);
+  });
+
+  it('keeps every row with a distinct key', () => {
+    const a = { book_hash: 'k', id: 'n1', updated_at: iso(1000), deleted_at: null };
+    const b = { book_hash: 'k', id: 'n2', updated_at: iso(1000), deleted_at: iso(2000) };
+    expect(dedupeLatest([a, b], ['id'])).toHaveLength(2);
+  });
+
+  it('never collapses rows that have no key', () => {
+    const a = { book_hash: 'k', id: '', updated_at: iso(1000), deleted_at: null };
+    const b = { book_hash: 'r', id: '', updated_at: iso(1000), deleted_at: null };
+    expect(dedupeLatest([a, b], ['id'])).toHaveLength(2);
+  });
+});

--- a/apps/readest-app/src/__tests__/pages/api/sync-notes-tombstone-pull.test.ts
+++ b/apps/readest-app/src/__tests__/pages/api/sync-notes-tombstone-pull.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+// Issue #5818, end to end through the route: GET /api/sync?type=notes must
+// hand a peer the tombstone of a note that also exists as a live row under the
+// other device's book_hash. The tombstone only enters the delta through the
+// `deleted_at > since` clause (its updated_at is the highlight's original
+// stamp), and the id-dedupe must then rank it above the live duplicate.
+
+type Call = { method: string; args: unknown[] };
+const queries: Call[][] = [];
+const responses: Array<{ data: unknown[] | null; error: { message: string } | null }> = [];
+
+const makeBuilder = () => {
+  const chain: Call[] = [];
+  queries.push(chain);
+  const builder: Record<string, unknown> = {};
+  const rec =
+    (method: string) =>
+    (...args: unknown[]) => {
+      chain.push({ method, args });
+      return builder;
+    };
+  for (const m of ['select', 'eq', 'or', 'gt', 'lt', 'in', 'is', 'order', 'range']) {
+    builder[m] = rec(m);
+  }
+  // biome-ignore lint/suspicious/noThenProperty: mock PostgREST builder is intentionally thenable
+  (builder as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(responses.shift() ?? { data: [], error: null });
+  return builder;
+};
+
+const fromMock = vi.fn(() => makeBuilder());
+
+vi.mock('@/utils/supabase', () => ({
+  createSupabaseClient: () => ({ from: fromMock }),
+}));
+vi.mock('@/utils/access', () => ({
+  validateUserAndToken: async () => ({ user: { id: 'u1' }, token: 'tok' }),
+}));
+
+import { GET } from '@/pages/api/sync';
+
+const req = (qs: string) =>
+  new Request(`https://web.readest.com/api/sync?${qs}`, {
+    headers: { authorization: 'Bearer tok' },
+  }) as unknown as NextRequest;
+
+const iso = (ms: number) => new Date(ms).toISOString();
+
+beforeEach(() => {
+  queries.length = 0;
+  responses.length = 0;
+  fromMock.mockClear();
+});
+
+describe('GET /api/sync?type=notes with a duplicate note under two book hashes', () => {
+  it('returns the tombstone instead of the live duplicate with the newer updated_at', async () => {
+    // The DB orders by updated_at DESC, so the live row comes first.
+    const live = { book_hash: 'r', id: 'n1', updated_at: iso(3000), deleted_at: null };
+    const tombstone = { book_hash: 'k', id: 'n1', updated_at: iso(1000), deleted_at: iso(5000) };
+    responses.push({ data: [live, tombstone], error: null });
+
+    const res = await GET(req('since=2000&type=notes&book=r&meta_hash=m1'));
+    const body = (await res.json()) as { notes: { book_hash: string; deleted_at: string }[] };
+
+    expect(body.notes).toEqual([tombstone]);
+    // The delta clause must admit rows by deleted_at, or the tombstone (whose
+    // updated_at is older than `since`) would never be queried at all.
+    const orArgs = queries[0]!.filter((c) => c.method === 'or').map((c) => String(c.args[0]));
+    expect(orArgs.some((a) => a.includes('updated_at.gt.') && a.includes('deleted_at.gt.'))).toBe(
+      true,
+    );
+  });
+});

--- a/apps/readest-app/src/app/reader/hooks/useNotesSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useNotesSync.ts
@@ -188,8 +188,15 @@ export const useNotesSync = (bookKey: string) => {
       if (existingNote) {
         if (incomingWins(existingNote, note)) {
           // A tombstone from KOReader carries no cfi; keep the local anchor or
-          // setConfig discards the note instead of recording the deletion.
-          return { ...existingNote, ...note, cfi: note.cfi || existingNote.cfi };
+          // setConfig discards the note instead of recording the deletion. The
+          // winner's deletedAt is pinned either way so a newer live note does
+          // not inherit a stale local tombstone through a missing key.
+          return {
+            ...existingNote,
+            ...note,
+            cfi: note.cfi || existingNote.cfi,
+            deletedAt: note.deletedAt,
+          };
         } else {
           // The local note wins; a losing tombstone must not leak its
           // deletedAt through a key the live note never had.

--- a/apps/readest-app/src/app/reader/hooks/useNotesSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useNotesSync.ts
@@ -11,6 +11,20 @@ import { getIndexFromCfi } from '@/utils/cfi';
 import { removeBookNoteOverlays } from '../utils/annotatorUtil';
 import { removeGlobalAnnotationOverlays } from '../utils/globalAnnotations';
 
+const latestChangeAt = (note: BookNote) => Math.max(note.updatedAt, note.deletedAt ?? 0);
+
+// Latest change wins, the same rule the server's dedupeLatest applies across
+// duplicate rows, so a highlight edited after a remote deletion survives and a
+// deletion made after a remote edit sticks. A tie goes to the tombstone.
+const incomingWins = (existing: BookNote, incoming: BookNote) => {
+  const existingAt = latestChangeAt(existing);
+  const incomingAt = latestChangeAt(incoming);
+  return (
+    incomingAt > existingAt ||
+    (incomingAt === existingAt && !!incoming.deletedAt && !existing.deletedAt)
+  );
+};
+
 export const useNotesSync = (bookKey: string) => {
   const { user } = useAuth();
   const { syncedNotes, syncNotes, lastSyncedAtNotes } = useSync(bookKey);
@@ -172,15 +186,14 @@ export const useNotesSync = (bookKey: string) => {
       const oldNotes = config?.booknotes ?? [];
       const existingNote = oldNotes.find((oldNote) => oldNote.id === note.id);
       if (existingNote) {
-        if (
-          existingNote.updatedAt < note.updatedAt ||
-          (existingNote.deletedAt ?? 0) < (note.deletedAt ?? 0)
-        ) {
+        if (incomingWins(existingNote, note)) {
           // A tombstone from KOReader carries no cfi; keep the local anchor or
           // setConfig discards the note instead of recording the deletion.
           return { ...existingNote, ...note, cfi: note.cfi || existingNote.cfi };
         } else {
-          return { ...note, ...existingNote };
+          // The local note wins; a losing tombstone must not leak its
+          // deletedAt through a key the live note never had.
+          return { ...note, ...existingNote, deletedAt: existingNote.deletedAt };
         }
       }
       return note;
@@ -199,9 +212,10 @@ export const useNotesSync = (bookKey: string) => {
       convertedNotes.forEach((note) => {
         if (note.deletedAt) {
           // Deleted on another device: clear the overlay drawn from the
-          // local copy, which is the one holding the cfi it was drawn with.
+          // local copy, which is the one holding the cfi it was drawn with,
+          // unless the local note was edited after that deletion.
           const local = oldNotes.find((oldNote) => oldNote.id === note.id);
-          if (local && !local.deletedAt) {
+          if (local && !local.deletedAt && incomingWins(local, note)) {
             getViewsById(bookKey.split('-')[0]!).forEach((v) => {
               removeBookNoteOverlays(v, local);
               if (local.global) removeGlobalAnnotationOverlays(v, local);

--- a/apps/readest-app/src/app/reader/hooks/useNotesSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useNotesSync.ts
@@ -8,12 +8,14 @@ import { SYNC_NOTES_INTERVAL_SEC } from '@/services/constants';
 import { throttle } from '@/utils/throttle';
 import { getXPointerFromCFI, getCFIFromXPointer, XCFI } from '@/utils/xcfi';
 import { getIndexFromCfi } from '@/utils/cfi';
+import { removeBookNoteOverlays } from '../utils/annotatorUtil';
+import { removeGlobalAnnotationOverlays } from '../utils/globalAnnotations';
 
 export const useNotesSync = (bookKey: string) => {
   const { user } = useAuth();
   const { syncedNotes, syncNotes, lastSyncedAtNotes } = useSync(bookKey);
   const { getConfig, setConfig, getBookData } = useBookDataStore();
-  const { getView } = useReaderStore();
+  const { getView, getViewsById } = useReaderStore();
 
   const config = getConfig(bookKey);
 
@@ -59,12 +61,18 @@ export const useNotesSync = (bookKey: string) => {
   const convertXPointersOnPull = async (notes: BookNote[]): Promise<BookNote[]> => {
     const bookData = getBookData(bookKey);
     const book = bookData?.book;
-    if (!book || FIXED_LAYOUT_FORMATS.has(book.format)) return notes.filter((n) => n.cfi);
+    if (!book || FIXED_LAYOUT_FORMATS.has(book.format)) {
+      return notes.filter((n) => n.cfi || n.deletedAt);
+    }
 
     const view = getView(bookKey);
     const converted: BookNote[] = [];
     for (const note of notes) {
-      if (note.xpointer0 && !note.cfi) {
+      if (note.deletedAt) {
+        // A tombstone only needs its id to mark the local copy deleted; never
+        // drop it because its xpointer can't be resolved to a cfi (#5818).
+        converted.push(note);
+      } else if (note.xpointer0 && !note.cfi) {
         try {
           let cfi: string | undefined;
           if (note.xpointer1) {
@@ -168,7 +176,9 @@ export const useNotesSync = (bookKey: string) => {
           existingNote.updatedAt < note.updatedAt ||
           (existingNote.deletedAt ?? 0) < (note.deletedAt ?? 0)
         ) {
-          return { ...existingNote, ...note };
+          // A tombstone from KOReader carries no cfi; keep the local anchor or
+          // setConfig discards the note instead of recording the deletion.
+          return { ...existingNote, ...note, cfi: note.cfi || existingNote.cfi };
         } else {
           return { ...note, ...existingNote };
         }
@@ -185,15 +195,28 @@ export const useNotesSync = (bookKey: string) => {
       if (!newNotes.length) return;
       // Convert xpointer-only notes (from KOReader) to CFI
       const convertedNotes = await convertXPointersOnPull(newNotes);
+      const oldNotes = config.booknotes ?? [];
       convertedNotes.forEach((note) => {
-        if (note.cfi) {
+        if (note.deletedAt) {
+          // Deleted on another device: clear the overlay drawn from the
+          // local copy, which is the one holding the cfi it was drawn with.
+          const local = oldNotes.find((oldNote) => oldNote.id === note.id);
+          if (local && !local.deletedAt) {
+            getViewsById(bookKey.split('-')[0]!).forEach((v) => {
+              removeBookNoteOverlays(v, local);
+              if (local.global) removeGlobalAnnotationOverlays(v, local);
+            });
+            // Stamp the deletion as this device's own change so the next push
+            // tombstones the duplicate row under its book hash as well.
+            note.updatedAt = Date.now();
+          }
+        } else if (note.cfi) {
           const index = getIndexFromCfi(note.cfi);
-          if (!note.deletedAt && index === view?.renderer.primaryIndex) {
+          if (index === view?.renderer.primaryIndex) {
             view.addAnnotation(note);
           }
         }
       });
-      const oldNotes = config.booknotes ?? [];
       const mergedNotes = [
         ...oldNotes.filter((oldNote) => !convertedNotes.some((n) => n.id === oldNote.id)),
         ...convertedNotes.map(processNewNote),

--- a/apps/readest-app/src/pages/api/sync.ts
+++ b/apps/readest-app/src/pages/api/sync.ts
@@ -26,6 +26,8 @@ import {
   type StatArchiveManifestRow,
 } from '@/libs/statsArchive';
 
+const ms = (s?: string | number | null) => (s ? new Date(s).getTime() : 0);
+
 /**
  * Field-level last-writer-wins for a books row's reading_status: return the
  * status fields with the newer reading_status_updated_at (ties → client). NULL
@@ -50,7 +52,6 @@ export function resolveReadingStatusMerge(
   client: Pick<DBBook, 'reading_status' | 'reading_status_updated_at'>,
   server: Pick<DBBook, 'reading_status' | 'reading_status_updated_at'>,
 ): Pick<DBBook, 'reading_status' | 'reading_status_updated_at'> {
-  const ms = (s?: string | null) => (s ? new Date(s).getTime() : 0);
   return ms(client.reading_status_updated_at) >= ms(server.reading_status_updated_at)
     ? {
         reading_status: client.reading_status,
@@ -96,7 +97,6 @@ export function resolveCoverMerge(
   client: Pick<DBBook, 'cover_hash' | 'cover_updated_at'>,
   server: Pick<DBBook, 'cover_hash' | 'cover_updated_at'>,
 ): Pick<DBBook, 'cover_hash' | 'cover_updated_at'> {
-  const ms = (s?: string | null) => (s ? new Date(s).getTime() : 0);
   return ms(client.cover_updated_at) >= ms(server.cover_updated_at)
     ? { cover_hash: client.cover_hash, cover_updated_at: client.cover_updated_at }
     : { cover_hash: server.cover_hash, cover_updated_at: server.cover_updated_at };
@@ -131,7 +131,6 @@ export function resolveMetadataMerge(
   server: BookMetadataFields,
   clientRowWins: boolean,
 ): BookMetadataFields {
-  const ms = (s?: string | null) => (s ? new Date(s).getTime() : 0);
   const clientMs = ms(client.metadata_updated_at);
   const serverMs = ms(server.metadata_updated_at);
   const clientWins = clientMs === serverMs ? clientRowWins : clientMs > serverMs;
@@ -151,6 +150,46 @@ export const bookMetadataChanged = (
   a.author !== b.author ||
   (a.metadata ?? null) !== (b.metadata ?? null) ||
   JSON.stringify(a.tags ?? null) !== JSON.stringify(b.tags ?? null);
+
+// Epoch ms of a row's latest change. A delete counts: KOReader's tombstones
+// keep the highlight's original updated_at (the plugin never bumps it on
+// delete), so ranking rows on updated_at alone puts a tombstone below a live
+// duplicate of the same note (issue #5818).
+type ChangeStamps = {
+  updated_at?: string | number | null;
+  deleted_at?: string | number | null;
+};
+const latestChangeMs = (rec: ChangeStamps) => Math.max(ms(rec.updated_at), ms(rec.deleted_at));
+
+/**
+ * Collapse rows sharing `keys` down to the one changed most recently, keeping
+ * the input order. The same note can exist under two book_hash values when the
+ * two devices hold different copies of a book (meta_hash bridges them); a
+ * deletion on either side must win over the stale live duplicate or it never
+ * reaches the peer. A tie goes to the tombstone: a delete and an edit in the
+ * same millisecond must not resurrect the note.
+ */
+export function dedupeLatest<T extends ChangeStamps>(records: T[], keys: (keyof T)[]): T[] {
+  const keyOf = (rec: T) =>
+    keys
+      .map((k) => rec[k])
+      .filter(Boolean)
+      .join('|');
+  const latest = new Map<string, { rec: T; at: number }>();
+  for (const rec of records) {
+    const key = keyOf(rec);
+    if (!key) continue;
+    const at = latestChangeMs(rec);
+    const best = latest.get(key);
+    if (!best || at > best.at || (at === best.at && !!rec.deleted_at && !best.rec.deleted_at)) {
+      latest.set(key, { rec, at });
+    }
+  }
+  return records.filter((rec) => {
+    const key = keyOf(rec);
+    return !key || latest.get(key)?.rec === rec;
+  });
+}
 
 const transformsToDB = {
   books: transformBookToDB,
@@ -253,23 +292,9 @@ export async function GET(req: NextRequest) {
         }
       }
 
-      let records = allRecords;
-      if (dedupeKeys && dedupeKeys.length > 0) {
-        const seen = new Set<string>();
-        records = records.filter((rec) => {
-          const key = dedupeKeys
-            .map((k) => rec[k])
-            .filter(Boolean)
-            .join('|');
-          if (key && seen.has(key)) {
-            return false;
-          } else {
-            seen.add(key);
-            return true;
-          }
-        });
-      }
-      (results as unknown as Record<string, SyncRecord[]>)[DBSyncTypeMap[table]] = records || [];
+      const records =
+        dedupeKeys && dedupeKeys.length > 0 ? dedupeLatest(allRecords, dedupeKeys) : allRecords;
+      (results as unknown as Record<string, SyncRecord[]>)[DBSyncTypeMap[table]] = records;
     };
 
     // One bounded page of books for the app's and the calibre plugin's


### PR DESCRIPTION
## Summary

Closes #5818. A highlight deleted in KOReader never disappeared in Readest, while adding highlights synced fine in both directions. Two independent defects, both on the Readest side; the koplugin's tombstone push (#4632) was already working.

**Server: the pull dedupe dropped the tombstone** (`src/pages/api/sync.ts`)
When the two apps hold different copies of a book, the same note exists as two `book_notes` rows: KOReader's under its `book_hash` and Readest's re-pushed copy under its own (`meta_hash` bridges them). KOReader's tombstone keeps the highlight's original `updated_at`, and `GET /api/sync?type=notes` deduped rows on `id` after ordering by `updated_at` alone, so the live duplicate always won and the deletion was dropped from every pull. Readest's reopen pull rewinds `since` by a day, which put both rows in the window every time. The new `dedupeLatest` ranks duplicates by their latest change, `max(updated_at, deleted_at)`, in a single pass that keeps the query order; an exact tie goes to the tombstone. The shared `ms()` helper the merge resolvers each re-declared is hoisted.

**Reader: pulled tombstones never reached the open view** (`src/app/reader/hooks/useNotesSync.ts`)
`processSyncedNotes` only ever drew pulled notes, so a note deleted on another device stayed highlighted until the section re-rendered, and a tombstone whose xpointer could not be converted to a cfi was discarded before it could mark the local copy deleted. Tombstones now pass through conversion untouched, the overlays (and the synthetic ones of a global highlight) of the matching local note are cleared on every view of the book, the merged tombstone keeps the local cfi (`setConfig` discards unanchored notes), and applying the deletion counts as this device's change so the next push tombstones the duplicate row under its own book hash too.

No plugin change is needed; the server half covers existing plugin installs once the web deploy lands.

## Verification

- 18 new unit tests: `sync-notes-tombstone-dedupe.test.ts` (ranking, ties, order, keyless rows), `sync-notes-tombstone-pull.test.ts` (route-level `GET ?type=notes` through the mocked PostgREST builder, including the `deleted_at > since` clause that admits the tombstone), `useNotesSync-tombstone.test.tsx` (cfi-less and cfi'd tombstones, fixed layout, global highlights, already-deleted, unknown id, live note still drawn, a local edit newer than the tombstone survives, a local deletion newer than a remote edit sticks, a remote edit newer than the local deletion comes back without its `deletedAt`). All failed before the fix.
- End to end in the KOReader emulator against a local dev server on the same database: seeded highlight, full push, a simulated Readest duplicate under a second book hash, `ReaderBookmark:removeItemByIndex` (auto-sync pushed the tombstone), then a Readest-style reopen pull. The unfixed production endpoint returned the live duplicate; the fixed local endpoint returned the tombstone. Test rows were tombstoned afterwards.
- `pnpm test`: 812 test files, 9994 tests passed (16 skipped), run by the pre-push hook on the final commits. `pnpm lint` and `pnpm format:check` clean.

## Pre-Landing Review

Checklist pass: no issues. Specialist reviews (testing, maintainability, performance) produced 11 informational findings; 8 applied (single-pass dedupe instead of sort, hoisted `ms()`, fixture reset in `beforeEach`, call-count pins, boundary and tie cases, already-deleted guard test, live-note draw test, route-level test), 3 skipped as out of scope (a shared zustand stub across five other test files, a shared tombstone helper with `useFileSync`, and the merge-semantics question below). Adversarial pass (Claude subagent plus Codex): the merged-tombstone cfi overwrite, global overlays, all-views clearing and the missing re-push were applied; the rest are pre-existing sync semantics listed below.

## Known and unchanged

- Latest-change-wins on both sides: the server's `dedupeLatest` across duplicate rows and the reader's merge of a pulled note against the local copy both take the later of `updatedAt` and `deletedAt` (the same rule `computeMaxTimestamp` uses for the cursor), so an edit made after a remote deletion survives and a deletion made after a remote edit sticks. Exact ties go to the tombstone.
- Client clocks are still trusted for `updated_at` and `deleted_at`.
- The pull dedupe keys on `id` alone within a book; KOReader ids are 7 hex characters.
- KOReader fires no `AnnotationsModified` when a plain dogear bookmark is removed, so bookmark deletions still do not propagate (plugin-side follow-up).

## Test plan

- [x] `pnpm test` (full suite, run by the pre-push hook)
- [x] `pnpm lint`, `pnpm format:check`
- [x] KOReader emulator A/B against production vs. local dev server
- [ ] After the web deploy: delete a highlight on a KOReader device, push, pull in Readest; the highlight disappears from the open book

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved note synchronization when deletions and edits occur across devices.
  - Deleted highlights and notes now reliably override duplicate live copies.
  - Newer edits correctly take precedence over older deletion records.
  - Fixed synchronization handling for notes with missing or invalid anchors, fixed-layout books, and overlays.

- **Tests**
  - Added comprehensive coverage for note deletion, conflict resolution, deduplication, and synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->