### PR TITLE
fix(reader): keep the reading position across screen rotations

### DIFF
--- a/apps/readest-app/src/__tests__/document/paginator-resize-anchor.browser.test.ts
+++ b/apps/readest-app/src/__tests__/document/paginator-resize-anchor.browser.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { DocumentLoader } from '@/libs/document';
+import type { BookDoc } from '@/libs/document';
+import type { Renderer } from '@/types/view';
+
+// Vite serves fixture files; fetch the EPUB at runtime in the browser.
+const EPUB_URL = new URL('../fixtures/data/sample-alice.epub', import.meta.url).href;
+
+let book: BookDoc;
+
+const loadEPUB = async () => {
+  const resp = await fetch(EPUB_URL);
+  const buffer = await resp.arrayBuffer();
+  const file = new File([buffer], 'sample-alice.epub', { type: 'application/epub+zip' });
+  const loader = new DocumentLoader(file);
+  const { book } = await loader.open();
+  return book;
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Wait for the paginator to emit 'stabilized'.
+ * MUST be called BEFORE the action that triggers stabilization (e.g. goTo),
+ * because #display dispatches 'stabilized' synchronously before returning.
+ */
+const waitForStabilized = (el: HTMLElement, timeout = 10000) =>
+  new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('stabilized timeout')), timeout);
+    el.addEventListener(
+      'stabilized',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+
+/** Resolve with the next `relocate` event whose reason matches. */
+const waitForRelocate = (el: HTMLElement, reason: string, timeout = 5000) =>
+  new Promise<CustomEvent>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`relocate(${reason}) timeout`)), timeout);
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      if (detail?.reason !== reason) return;
+      clearTimeout(timer);
+      el.removeEventListener('relocate', handler);
+      resolve(event as CustomEvent);
+    };
+    el.addEventListener('relocate', handler);
+  });
+
+// The paginator's scroll listener relocates 250ms after the last scroll event
+// (debounced); a phone rotation is never faster than that, so every resize
+// step below lets that relocate run before the next one.
+const SCROLL_DEBOUNCE_SETTLE_MS = 500;
+
+describe('Paginator resize keeps the reading position (browser)', () => {
+  let paginator: Renderer;
+
+  beforeAll(async () => {
+    book = await loadEPUB();
+    await import('foliate-js/paginator.js');
+  }, 30000);
+
+  afterEach(async () => {
+    if (paginator) {
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      try {
+        paginator.destroy();
+      } catch {
+        /* iframe body may already be torn down */
+      }
+      paginator.remove();
+    }
+  });
+
+  const createPaginator = (width: number, height: number) => {
+    const el = document.createElement('foliate-paginator') as Renderer;
+    Object.assign(el.style, {
+      width: `${width}px`,
+      height: `${height}px`,
+      position: 'absolute',
+      left: '0',
+      top: '0',
+    });
+    document.body.appendChild(el);
+    return el;
+  };
+
+  /** Resize the host (the ResizeObserver re-renders and re-anchors) and let the layout settle. */
+  const resizeTo = async (width: number, height: number) => {
+    const reanchored = waitForRelocate(paginator, 'anchor');
+    paginator.style.width = `${width}px`;
+    paginator.style.height = `${height}px`;
+    await reanchored;
+    await sleep(SCROLL_DEBOUNCE_SETTLE_MS);
+  };
+
+  it('lands on the same page after a portrait/landscape/portrait round trip (#5808)', async () => {
+    const PORTRAIT: [number, number] = [400, 700];
+    const LANDSCAPE: [number, number] = [700, 400];
+    paginator = createPaginator(...PORTRAIT);
+    paginator.open(book);
+    // The longest section, so two page turns stay inside it (`page` is
+    // section-relative) and the reflow has a few pages to shift around.
+    const sections = book.sections!;
+    const idx = sections.reduce(
+      (best, s, i) => ((s.size ?? 0) > (sections[best]!.size ?? 0) ? i : best),
+      0,
+    );
+    const stabilized = waitForStabilized(paginator);
+    await paginator.goTo({ index: idx });
+    await stabilized;
+    await sleep(SCROLL_DEBOUNCE_SETTLE_MS);
+
+    // Read a few pages into the section, like the reporter did.
+    await paginator.next();
+    await paginator.next();
+    await sleep(SCROLL_DEBOUNCE_SETTLE_MS);
+    const pageBefore = paginator.page;
+    expect(pageBefore).toBeGreaterThan(0);
+
+    await resizeTo(...LANDSCAPE);
+    await resizeTo(...PORTRAIT);
+    expect(paginator.page).toBe(pageBefore);
+
+    // A second rotation must not walk the position back any further either.
+    await resizeTo(...LANDSCAPE);
+    await resizeTo(...PORTRAIT);
+    expect(paginator.page).toBe(pageBefore);
+  }, 30000);
+});


### PR DESCRIPTION
## Summary

Closes #5808. Rotating an Android phone from portrait to landscape and back moved the reader one page back, and every further rotation moved it back again. The same drift affects any resize round trip (window resize on desktop, split view on tablets); rotation just makes it symmetric and obvious.

## Root cause

In `packages/foliate-js/paginator.js`, a resize re-render restores the anchor (`render()` -> `#scrollToAnchor(#anchor)`, reason `'anchor'`), and that relocate correctly keeps `#anchor` as the pre-resize visible Range. But the scroll it performs also reaches the debounced container `scroll` listener, which in paginated mode calls `#afterScroll('container-scroll')` and unconditionally replaced `#anchor` with the visible range of the *reflowed* layout. That range starts at the new page's first character, which precedes the old anchor whenever the two layouts' page boundaries differ (nearly always), so rotating back settled on the previous page, and the anchor kept walking backwards on every cycle. The scrolled-mode branch of the listener already guards this with `#justAnchored`; the paginated branch did not.

## Fix

- foliate-js (readest/foliate-js#82): a `'container-scroll'` relocate keeps the current Range anchor when it still starts inside the new visible range. Scrolls that move the anchor off the page, fraction and element anchors, and every other relocate reason behave as before.
- Regression test `src/__tests__/document/paginator-resize-anchor.browser.test.ts` (real Chromium): opens the sample EPUB at 400x700, turns two pages, resizes to 700x400 and back twice with the 250 ms scroll debounce allowed to fire in between, and expects the same page. Fails before the fork change (page 2 -> page 1), passes with it.

## Submodule note

readest/foliate-js#82 is merged; `packages/foliate-js` is pinned to its squashed `main` commit `2b6ea0a`.

## Test plan

- [x] `pnpm test:browser`: 39 files, 372 passed, 1 skipped (pre-existing)
- [x] `pnpm test`: 9941 passed; `DictionarySheet.test.tsx` timed out once while the browser suite was running concurrently and passes standalone (19/19)
- [x] `pnpm lint`, Biome format
- [x] Xiaomi 13 (Android 16), two-column paginated book at a section start (the reporter's scenario), rotate portrait/landscape/portrait twice via `settings put system user_rotation`:
  - pre-fix APK: turning one page into section idx6, the first rotation back dropped the reader into the *previous* section (page 9, idx5), and the next cycle walked back again (page 8)
  - fixed APK: page and section stay put (idx6, page 0) across both cycles; same at three pages in (idx7, page 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reading-position preservation when switching between portrait and landscape orientations.
  - Repeated orientation changes now maintain the same page and reading location more reliably.

- **Quality Improvements**
  - Added automated coverage to help prevent regressions in pagination and layout resizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->