### PR TITLE
feat(reader): pair an Audiobookshelf audiobook and read along (#5807)

### DIFF
--- a/apps/readest-app/docs/read-along-narration.md
+++ b/apps/readest-app/docs/read-along-narration.md
@@ -90,10 +90,11 @@ and persist the new association before removing old audio. Re-importing or
 deduplicating an edited EPUB copies the paired files and rewrites those paths
 before retiring the previous book directory.
 
-An Audiobookshelf pairing keeps nothing on the device: the association records
-the server, item and track list (`PairedAudiobook.source`) and playback streams
-each file with the server's current access token, so it needs the server row
-and a network connection. It is otherwise the same device-local association,
+An Audiobookshelf pairing stores no audio on the device. The association itself
+is still device-local, recording the server, item and track list
+(`PairedAudiobook.source`); playback streams each file with the server's current
+access token, so it needs that association's server row and a network
+connection. It is otherwise the same device-local association,
 and removing it only unpairs. Listening position is not reported back to the
 Audiobookshelf server while reading along; reading progress still syncs through
 Readest as usual.

--- a/apps/readest-app/docs/read-along-narration.md
+++ b/apps/readest-app/docs/read-along-narration.md
@@ -67,7 +67,9 @@ playback, without drawing a text highlight that would imply finer timing.
 The pairing wizard follows Continuum's anchor-and-review flow:
 
 1. Open a reflowable EPUB's book menu and choose **Pair Audiobook**.
-2. Select one M4B file or a naturally ordered set of MP3/M4A tracks.
+2. Select one M4B file or a naturally ordered set of MP3/M4A tracks, or, when
+   an Audiobookshelf server is configured, **Choose from Audiobookshelf** and
+   pick one of its audiobooks to stream instead.
 3. Choose one ebook chapter and the audio chapter or track known to match it.
 4. Readest fills the mapping in both directions by position. Review every row,
    leave ebook chapters without audio, reuse an audio chapter where necessary,
@@ -87,6 +89,14 @@ local pairing resumes at the same ebook chapter. Replacements use new file paths
 and persist the new association before removing old audio. Re-importing or
 deduplicating an edited EPUB copies the paired files and rewrites those paths
 before retiring the previous book directory.
+
+An Audiobookshelf pairing keeps nothing on the device: the association records
+the server, item and track list (`PairedAudiobook.source`) and playback streams
+each file with the server's current access token, so it needs the server row
+and a network connection. It is otherwise the same device-local association,
+and removing it only unpairs. Listening position is not reported back to the
+Audiobookshelf server while reading along; reading progress still syncs through
+Readest as usual.
 
 ### Using it
 
@@ -139,6 +149,16 @@ pieces are `src/services/audiobook/` (metadata, positional mapping, and local
 storage) plus `src/services/tts/pairedAudiobook.ts`, which turns each mapped TOC
 chapter into a `NarrationPar`. A chapter table embedded in an M4B supplies clip
 boundaries; a standalone track without chapter metadata becomes one clip.
+
+An Audiobookshelf item (`src/services/audiobook/absPairing.ts`) is converted to
+ONE virtual file on the item's global timeline rather than one file per track:
+ABS times its chapters globally and they routinely span media files, which the
+per-file clip model cannot express. `MultiTrackNarrationClock` then presents the
+item's tracks to the client as a single `NarrationClock`: seeks land on the file
+holding the position, a file running out rolls into the next, and only the last
+file's end surfaces as `ended`. It drives `HtmlAudioClock` on web/desktop and
+the client's own `NativeNarrationPlayer` (given track URLs) on mobile, selected
+through the `resolveTracks` hook on `NarrationAudioSource`.
 
 Consequences of that shape:
 
@@ -218,8 +238,8 @@ reader's own highlight style.
   behaviour: a sentence straddling a page break waits for the next mark.
 - **Mobile Tauri** plays narration through `NativeNarrationPlayer`: AVPlayer on
   iOS and ExoPlayer on Android. Paired audiobooks are streamed directly from
-  their local path. Desktop Tauri streams its asset URL through
-  `HTMLAudioElement`; web uses a blob URL.
+  their local path, or by `http(s)` URL for an Audiobookshelf pairing. Desktop
+  Tauri streams its asset URL through `HTMLAudioElement`; web uses a blob URL.
 
 ### The library badge
 

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-tts/android/src/main/java/NativeTTSPlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-tts/android/src/main/java/NativeTTSPlugin.kt
@@ -694,15 +694,22 @@ class NativeTTSPlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     private fun loadContinuousFile(path: String, positionMs: Double) {
-        val file = File(path)
-        require(file.isFile) { "Narration file not found: $path" }
+        // A paired Audiobookshelf audiobook streams its tracks by URL, the
+        // same way the iOS playout player already accepts http(s) paths.
+        val uri = if (path.startsWith("http://") || path.startsWith("https://")) {
+            Uri.parse(path)
+        } else {
+            val file = File(path)
+            require(file.isFile) { "Narration file not found: $path" }
+            Uri.fromFile(file)
+        }
         val player = ensurePlayoutPlayer()
         val startMs = positionMs.coerceAtLeast(0.0).toLong()
 
         if (playoutLoadedPath == path && player.currentMediaItem != null) {
             player.seekTo(startMs)
         } else {
-            player.setMediaItem(MediaItem.fromUri(Uri.fromFile(file)), startMs)
+            player.setMediaItem(MediaItem.fromUri(uri), startMs)
             player.prepare()
             playoutLoadedPath = path
         }

--- a/apps/readest-app/src/__tests__/services/audiobook-abs-pairing.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-abs-pairing.test.ts
@@ -108,6 +108,41 @@ describe('buildAbsPairingSource', () => {
 
     expect(() => buildAbsPairingSource(empty, 'srv1')).toThrow(/no audio/i);
   });
+
+  it('takes the global endpoint from track offsets, not the sum, when tracks are non-contiguous', () => {
+    // A gap between tracks: file/1 ends at 100, file/2 starts at 200. The sum
+    // of durations (150) understates the real endpoint (250).
+    const gapped: ABSLibraryItem = {
+      ...item,
+      media: {
+        ...item.media,
+        tracks: [
+          {
+            index: 1,
+            startOffset: 0,
+            duration: 100,
+            contentUrl: '/api/items/item1/file/1',
+            mimeType: 'audio/mpeg',
+          },
+          {
+            index: 2,
+            startOffset: 200,
+            duration: 50,
+            contentUrl: '/api/items/item1/file/2',
+            mimeType: 'audio/mpeg',
+          },
+        ],
+        chapters: [{ id: 0, start: 0, end: 999, title: 'Whole' }],
+      },
+    };
+
+    const source = buildAbsPairingSource(gapped, 'srv1');
+
+    expect(source.files[0]!.duration).toBe(250);
+    expect(source.chapters).toEqual([
+      { id: 'abs:0', fileId: 'abs', label: 'Whole', start: 0, end: 250 },
+    ]);
+  });
 });
 
 describe('absPreviewClip', () => {
@@ -120,16 +155,18 @@ describe('absPreviewClip', () => {
     useABSServerStore.setState({ servers: [] });
   });
 
-  it('points at the file holding a global position, with its in-file offset', () => {
+  it('points at the file holding a global position, with its in-file offset and track length', () => {
     const { source } = buildAbsPairingSource(item, 'srv1');
 
     expect(absPreviewClip(source, 120)).toEqual({
       url: 'http://abs.local:13378/api/items/item1/file/2?token=tok',
       start: 20,
+      duration: 50,
     });
     expect(absPreviewClip(source, 0)).toEqual({
       url: 'http://abs.local:13378/api/items/item1/file/1?token=tok',
       start: 0,
+      duration: 100,
     });
   });
 

--- a/apps/readest-app/src/__tests__/services/audiobook-abs-pairing.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-abs-pairing.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  absPreviewClip,
+  buildAbsPairingSource,
+  listPairableAbsBooks,
+} from '@/services/audiobook/absPairing';
+import { useABSServerStore } from '@/store/absServerStore';
+import { useSettingsStore } from '@/store/settingsStore';
+import type { ABSLibraryItem, ABSServer } from '@/types/audiobookshelf';
+import type { Book } from '@/types/book';
+import type { SystemSettings } from '@/types/settings';
+import { makeAbsFilePath } from '@/utils/audiobook';
+
+const server: ABSServer = { id: 'srv1', name: 'Home', url: 'http://abs.local:13378' };
+
+// Two files; the middle chapter straddles the file boundary at 100s, as ABS
+// chapter tables routinely do.
+const item: ABSLibraryItem = {
+  id: 'item1',
+  mediaType: 'book',
+  media: {
+    metadata: {
+      title: 'Pride and Prejudice',
+      authorName: 'Jane Austen',
+      narrators: ['Karen Savage', 'Someone Else'],
+    },
+    duration: 150,
+    tracks: [
+      {
+        index: 2,
+        startOffset: 100,
+        duration: 50,
+        contentUrl: '/api/items/item1/file/2',
+        mimeType: 'audio/mpeg',
+        title: '20686-02.mp3',
+      },
+      {
+        index: 1,
+        startOffset: 0,
+        duration: 100,
+        contentUrl: '/api/items/item1/file/1',
+        mimeType: 'audio/mpeg',
+        title: '20686-01.mp3',
+      },
+    ],
+    chapters: [
+      { id: 0, start: 0, end: 60, title: 'Ch. 1-2' },
+      { id: 1, start: 60, end: 120, title: ' Ch. 3-4 ' },
+      { id: 2, start: 120, end: 120, title: 'Empty' },
+      { id: 3, start: 120, end: 999, title: '' },
+    ],
+  },
+};
+
+describe('buildAbsPairingSource', () => {
+  it('maps the item onto one virtual file with chapters on the global timeline', () => {
+    const source = buildAbsPairingSource(item, 'srv1');
+
+    expect(source.title).toBe('Pride and Prejudice');
+    expect(source.narrator).toBe('Karen Savage, Someone Else');
+    expect(source.files).toEqual([
+      {
+        id: 'abs',
+        name: 'Pride and Prejudice',
+        path: makeAbsFilePath('srv1', 'item1'),
+        duration: 150,
+      },
+    ]);
+    expect(source.chapters).toEqual([
+      { id: 'abs:0', fileId: 'abs', label: 'Ch. 1-2', start: 0, end: 60 },
+      { id: 'abs:1', fileId: 'abs', label: 'Ch. 3-4', start: 60, end: 120 },
+      // Empty span dropped; blank title named by position; end clamped.
+      { id: 'abs:3', fileId: 'abs', label: 'Chapter 4', start: 120, end: 150 },
+    ]);
+    expect(source.source).toEqual({
+      kind: 'audiobookshelf',
+      serverId: 'srv1',
+      itemId: 'item1',
+      tracks: [
+        { index: 1, startOffset: 0, duration: 100, contentUrl: '/api/items/item1/file/1' },
+        { index: 2, startOffset: 100, duration: 50, contentUrl: '/api/items/item1/file/2' },
+      ],
+    });
+  });
+
+  it('falls back to one chapter per file, named after the file, when the item has none', () => {
+    const chapterless: ABSLibraryItem = {
+      ...item,
+      media: {
+        ...item.media,
+        metadata: { title: 'Peter Pan', narratorName: 'Narrator' },
+        chapters: [],
+      },
+    };
+
+    const source = buildAbsPairingSource(chapterless, 'srv1');
+
+    expect(source.narrator).toBe('Narrator');
+    expect(source.chapters).toEqual([
+      { id: 'abs:track:1', fileId: 'abs', label: '20686-01', start: 0, end: 100 },
+      { id: 'abs:track:2', fileId: 'abs', label: '20686-02', start: 100, end: 150 },
+    ]);
+  });
+
+  it('rejects an item without playable tracks', () => {
+    const empty: ABSLibraryItem = { ...item, media: { ...item.media, tracks: [] } };
+
+    expect(() => buildAbsPairingSource(empty, 'srv1')).toThrow(/no audio/i);
+  });
+});
+
+describe('absPreviewClip', () => {
+  beforeEach(() => {
+    useABSServerStore.setState({ servers: [{ ...server, accessToken: 'tok' }] });
+    useSettingsStore.setState({ settings: { absServers: [] } as unknown as SystemSettings });
+  });
+
+  afterEach(() => {
+    useABSServerStore.setState({ servers: [] });
+  });
+
+  it('points at the file holding a global position, with its in-file offset', () => {
+    const { source } = buildAbsPairingSource(item, 'srv1');
+
+    expect(absPreviewClip(source, 120)).toEqual({
+      url: 'http://abs.local:13378/api/items/item1/file/2?token=tok',
+      start: 20,
+    });
+    expect(absPreviewClip(source, 0)).toEqual({
+      url: 'http://abs.local:13378/api/items/item1/file/1?token=tok',
+      start: 0,
+    });
+  });
+
+  it('is unavailable once the server row is gone', () => {
+    const { source } = buildAbsPairingSource(item, 'srv1');
+    useABSServerStore.setState({ servers: [] });
+
+    expect(absPreviewClip(source, 120)).toBeNull();
+  });
+});
+
+describe('listPairableAbsBooks', () => {
+  const make = (overrides: Partial<Book>): Book => ({
+    hash: 'h',
+    format: 'ABS',
+    filePath: makeAbsFilePath('srv1', 'item1'),
+    title: 'Book',
+    author: 'Author',
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    useABSServerStore.setState({ servers: [server] });
+    useSettingsStore.setState({ settings: { absServers: [] } as unknown as SystemSettings });
+  });
+
+  afterEach(() => {
+    useABSServerStore.setState({ servers: [] });
+  });
+
+  it('keeps live audiobooks from configured servers, sorted by title', () => {
+    const library = [
+      make({ hash: 'b', title: 'Zeta' }),
+      make({ hash: 'epub', format: 'EPUB', filePath: '/books/x.epub', title: 'An EPUB' }),
+      make({ hash: 'podcast', absMediaType: 'podcast', title: 'A Show' }),
+      make({ hash: 'gone', deletedAt: 1, title: 'Deleted' }),
+      make({ hash: 'orphan', filePath: makeAbsFilePath('missing', 'item9'), title: 'Orphan' }),
+      make({ hash: 'a', title: 'Alpha' }),
+    ];
+
+    expect(listPairableAbsBooks(library).map((book) => book.hash)).toEqual(['a', 'b']);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/audiobook-preview.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-preview.test.ts
@@ -143,6 +143,32 @@ describe('AudiobookPreviewPlayer', () => {
     expect(onStopped).not.toHaveBeenCalledWith('second');
   });
 
+  it('streams a remote clip URL straight into the element', async () => {
+    const appService = makeAppService();
+    const player = new AudiobookPreviewPlayer(appService, vi.fn());
+
+    await player.toggle({ id: 'abs:0', url: 'http://abs/track?token=t', start: 7, end: 40 });
+
+    const audio = FakeAudio.instances[0]!;
+    expect(audio.src).toBe('http://abs/track?token=t');
+    expect(audio.currentTime).toBe(7);
+    expect(createObjectURL).not.toHaveBeenCalled();
+    expect(appService.openFile).not.toHaveBeenCalled();
+    expect(appService.resolveFilePath).not.toHaveBeenCalled();
+  });
+
+  it('hands a remote clip URL to the native player on mobile', async () => {
+    const appService = makeAppService({ appPlatform: 'tauri', isMobileApp: true });
+    const player = new AudiobookPreviewPlayer(appService, vi.fn());
+
+    await player.toggle({ id: 'abs:0', url: 'http://abs/track?token=t', start: 7, end: 40 });
+
+    expect(tauriMocks.invoke).toHaveBeenCalledWith('plugin:native-tts|playout_control', {
+      payload: { action: 'load', path: 'http://abs/track?token=t', positionMs: 7000 },
+    });
+    expect(appService.resolveFilePath).not.toHaveBeenCalled();
+  });
+
   it('unregisters the native playback listener when a mobile preview stops', async () => {
     const appService = makeAppService({
       appPlatform: 'tauri',

--- a/apps/readest-app/src/__tests__/services/audiobook-storage.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-storage.test.ts
@@ -3,10 +3,26 @@ import { describe, expect, it, vi } from 'vitest';
 import type { AudiobookChapterMapping, PairedAudiobook } from '@/types/book';
 import {
   importPairedAudiobook,
+  persistStreamedPairedAudiobook,
   replacePairedAudiobook,
   removePairedAudiobook,
   type AudiobookStorage,
 } from '@/services/audiobook/storage';
+
+// A pairing streamed from an Audiobookshelf server: nothing of it is on disk.
+const streamed: PairedAudiobook = {
+  version: 1,
+  files: [{ id: 'abs', name: 'Book', path: 'abs://srv1/item1', duration: 100 }],
+  chapters: [],
+  mappings: [{ ebookChapterId: 'ch1.xhtml', audioChapterId: 'abs:0' }],
+  createdAt: 2,
+  source: {
+    kind: 'audiobookshelf',
+    serverId: 'srv1',
+    itemId: 'item1',
+    tracks: [{ index: 1, startOffset: 0, duration: 100, contentUrl: '/api/items/item1/file/1' }],
+  },
+};
 
 const makeStorage = (): AudiobookStorage => ({
   createDir: vi.fn().mockResolvedValue(undefined),
@@ -166,6 +182,71 @@ describe('paired audiobook storage', () => {
     expect(persist.mock.invocationCallOrder[0]).toBeLessThan(
       vi.mocked(storage.deleteDir).mock.invocationCallOrder[0]!,
     );
+  });
+
+  it('unpairs a streamed audiobook without touching the book directory', async () => {
+    const storage = makeStorage();
+    const persist = vi.fn().mockResolvedValue(undefined);
+
+    await removePairedAudiobook(storage, 'book-hash', streamed, persist);
+
+    expect(persist).toHaveBeenCalledWith(undefined);
+    expect(storage.deleteDir).not.toHaveBeenCalled();
+    expect(storage.deleteFile).not.toHaveBeenCalled();
+  });
+
+  it('persists a streamed pairing, then deletes the local files of the pairing it replaces', async () => {
+    const storage = makeStorage();
+    const previous: PairedAudiobook = {
+      version: 1,
+      files: [
+        { id: 'audio-0', name: 'a.mp3', path: 'book-hash/audiobook/1-audio-0-a.mp3', duration: 1 },
+        { id: 'audio-1', name: 'b.mp3', path: 'other-hash/audiobook/1-audio-1-b.mp3', duration: 1 },
+      ],
+      chapters: [],
+      mappings: [],
+      createdAt: 1,
+    };
+    const persist = vi.fn().mockResolvedValue(undefined);
+
+    const result = await persistStreamedPairedAudiobook(
+      storage,
+      'book-hash',
+      streamed,
+      previous,
+      persist,
+    );
+
+    expect(result).toBe(streamed);
+    expect(persist).toHaveBeenCalledWith(streamed);
+    expect(storage.copyFile).not.toHaveBeenCalled();
+    expect(storage.writeFile).not.toHaveBeenCalled();
+    expect(storage.createDir).not.toHaveBeenCalled();
+    expect(storage.deleteFile).toHaveBeenCalledTimes(1);
+    expect(storage.deleteFile).toHaveBeenCalledWith('book-hash/audiobook/1-audio-0-a.mp3', 'Books');
+    expect(persist.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(storage.deleteFile).mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('keeps the previous local files when persisting a streamed pairing fails', async () => {
+    const storage = makeStorage();
+    const previous: PairedAudiobook = {
+      version: 1,
+      files: [
+        { id: 'audio-0', name: 'a.mp3', path: 'book-hash/audiobook/1-audio-0-a.mp3', duration: 1 },
+      ],
+      chapters: [],
+      mappings: [],
+      createdAt: 1,
+    };
+    const persist = vi.fn().mockRejectedValue(new Error('disk full'));
+
+    await expect(
+      persistStreamedPairedAudiobook(storage, 'book-hash', streamed, previous, persist),
+    ).rejects.toThrow('disk full');
+
+    expect(storage.deleteFile).not.toHaveBeenCalled();
   });
 
   it('persists a replacement before deleting files left behind by the previous pairing', async () => {

--- a/apps/readest-app/src/__tests__/services/import-metahash.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-metahash.test.ts
@@ -309,6 +309,46 @@ describe('importBook metaHash deduplication', () => {
     ).toBeLessThan(fs.removeDir.mock.invocationCallOrder[0]!);
   });
 
+  it('carries a streamed pairing over unchanged, copying nothing', async () => {
+    const metaHash = getMetadataHash(TEST_METADATA);
+    const existingBook = makeBook({ hash: 'old-hash-123', metaHash });
+    const books: Book[] = [existingBook];
+    mockPartialMD5.mockResolvedValue('new-hash-456');
+    setupMockBookDoc();
+
+    const fs = service.getFs();
+    fs.exists.mockImplementation(async (path: string) =>
+      ['old-hash-123/config.json', 'old-hash-123'].includes(path),
+    );
+    fs.readFile.mockResolvedValue(
+      JSON.stringify({
+        audiobook: {
+          version: 1,
+          files: [{ id: 'abs', name: 'Book', path: 'abs://srv1/item1', duration: 100 }],
+          chapters: [],
+          mappings: [],
+          createdAt: 1,
+          source: { kind: 'audiobookshelf', serverId: 'srv1', itemId: 'item1', tracks: [] },
+        },
+      }),
+    );
+
+    await service.importBook(
+      new File(['new content'], 'test.epub', { type: 'application/epub+zip' }),
+      books,
+    );
+
+    expect(fs.createDir).not.toHaveBeenCalledWith('new-hash-456/audiobook', 'Books', true);
+    expect(fs.copyFile).not.toHaveBeenCalled();
+    const configWrite = fs.writeFile.mock.calls.find(
+      (call: unknown[]) => call[0] === 'new-hash-456/config.json',
+    );
+    const writtenConfig = JSON.parse(configWrite![2] as string);
+    expect(writtenConfig.audiobook.files[0].path).toBe('abs://srv1/item1');
+    expect(writtenConfig.audiobook.source.itemId).toBe('item1');
+    expect(fs.removeDir).toHaveBeenCalledWith('old-hash-123', 'Books', true);
+  });
+
   it('keeps the old book directory when paired-audio migration fails', async () => {
     const metaHash = getMetadataHash(TEST_METADATA);
     const existingBook = makeBook({ hash: 'old-hash-123', metaHash });

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-client.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-client.test.ts
@@ -49,6 +49,10 @@ class FakeAudio {
   pause(): void {
     this.paused = true;
   }
+  // HtmlAudioClock (the per-track player behind a multi-track source) calls
+  // these on the element; a plain narration element never does.
+  load(): void {}
+  removeAttribute(): void {}
 
   #emit(type: string): void {
     for (const fn of [...(this.#listeners.get(type) ?? [])]) fn();
@@ -208,6 +212,38 @@ describe('MediaOverlayClient capabilities', () => {
     expect(audio().src).toBe('http://asset.localhost/books/ch1.mp3');
     expect(loadBlob).not.toHaveBeenCalled();
     expect(createObjectURL).not.toHaveBeenCalled();
+  });
+
+  // A recording split across files (an Audiobookshelf item) is one timeline
+  // to the client: the clip's global time picks the file and in-file offset.
+  test('plays a multi-track source from the file holding the clip', async () => {
+    [section] = await makeSection(WORD_SMIL);
+    const loadBlob = vi.fn(async () => new Blob([new Uint8Array(8)]));
+    client = new MediaOverlayClient({ dispatchSpeakMark: vi.fn() } as unknown as TTSController);
+    await client.init();
+    client.attachSource({
+      loadBlob,
+      resolveTracks: vi.fn(async () => [
+        { url: 'http://abs/t1', startOffset: 0, duration: 2 },
+        { url: 'http://abs/t2', startOffset: 2, duration: 10 },
+      ]),
+    });
+    client.setSection(section);
+
+    // Block 1 is the whole-paragraph par at 3s..6s: 1s into the second file.
+    const iter = client.speak(section.ssmlForBlock(1)!, new AbortController().signal);
+    const first = await iter.next();
+
+    expect(first.value).toMatchObject({ code: 'boundary' });
+    expect(audio().src).toBe('http://abs/t2');
+    expect(audio().seeks).toEqual([1]);
+    expect(audio().playCalls).toBe(1);
+    expect(loadBlob).not.toHaveBeenCalled();
+
+    // The clock the client watches is global: 4s into t2 is 6s, the clip end.
+    const pending = iter.next();
+    audio().advanceTo(4);
+    expect((await pending).value).toMatchObject({ code: 'end' });
   });
 });
 

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
@@ -361,6 +361,38 @@ describe('narration selection', () => {
     expect(controller.isSoundingSentenceOnScreen()).toBe(false);
   });
 
+  test('gives page-follow the whole chapter range, not the one-character reading position', async () => {
+    const view = makePairedView();
+    const appService = {
+      openFile: vi.fn(async () => new File(['audio'], 'chapter.mp3')),
+      resolveFilePath: vi.fn(async () => '/books/chapter.mp3'),
+    } as unknown as AppService;
+    const controller = new TTSController(appService, view);
+    controller.pairedAudiobook = PAIRED_AUDIOBOOK;
+    await controller.init();
+    await controller.initViewTTS(0);
+
+    const doc = view.tts!.doc;
+    (
+      view.renderer as unknown as { getContents: () => unknown[]; primaryIndex: number }
+    ).getContents = () => [{ doc, index: 1, overlayer: { remove: vi.fn(), add: vi.fn() } }];
+    (view.renderer as unknown as { primaryIndex: number }).primaryIndex = 1;
+    view.getCFI = vi.fn((_index: number, range?: Range) => `cfi:${range?.toString() ?? ''}`);
+
+    const marks: CustomEvent[] = [];
+    controller.addEventListener('tts-highlight-mark', (e) => marks.push(e as CustomEvent));
+    controller.dispatchSpeakMark({ offset: 0, name: '0', text: 'Chapter', language: 'en' });
+
+    const detail = marks[0]!.detail as { cfi: string; sentenceCfi?: string };
+    // The reading dot is one character; a chapter-only pairing has no finer
+    // text timing.
+    expect(detail.cfi).toMatch(/^cfi:.$/);
+    // Page-follow needs the whole chapter's extent to know where the page cuts
+    // it off, so the mark carries that separately.
+    expect(detail.sentenceCfi).toContain('Chapter 1Text.');
+    expect(detail.sentenceCfi).not.toBe(detail.cfi);
+  });
+
   test('keeps paired-audiobook scrubber preview and seek aligned with the audio offset', async () => {
     const view = makePairedView();
     const appService = {

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { TTSController } from '@/services/tts/TTSController';
 import type { TTSClient, TTSMessageEvent } from '@/services/tts/TTSClient';
 import { MEDIA_OVERLAY_VOICE_ID } from '@/services/tts/mediaOverlay';
+import { useABSServerStore } from '@/store/absServerStore';
 import type { PairedAudiobook } from '@/types/book';
 import type { AppService } from '@/types/system';
 import type { FoliateView } from '@/types/view';
@@ -131,6 +132,25 @@ const PAIRED_AUDIOBOOK: PairedAudiobook = {
   createdAt: 1,
 };
 
+// The same chapter, streamed from an Audiobookshelf item split across two files.
+const ABS_PAIRED_AUDIOBOOK: PairedAudiobook = {
+  version: 1,
+  narrator: 'Server Narrator',
+  files: [{ id: 'abs', name: 'Book', path: 'abs://srv1/item1', duration: 30 }],
+  chapters: [{ id: 'abs:0', fileId: 'abs', label: 'Chapter 1', start: 0, end: 30 }],
+  mappings: [{ ebookChapterId: 'chapter.xhtml', audioChapterId: 'abs:0' }],
+  createdAt: 1,
+  source: {
+    kind: 'audiobookshelf',
+    serverId: 'srv1',
+    itemId: 'item1',
+    tracks: [
+      { index: 1, startOffset: 0, duration: 20, contentUrl: '/api/items/item1/file/1' },
+      { index: 2, startOffset: 20, duration: 10, contentUrl: '/api/items/item1/file/2' },
+    ],
+  },
+};
+
 const makePairedView = () => {
   const docs = [makeDoc('<p>Front matter.</p>'), makeDoc('<h1>Chapter 1</h1><p>Text.</p>')];
   return {
@@ -249,6 +269,57 @@ describe('narration selection', () => {
       'Books',
     );
     expect(appService.openFile).not.toHaveBeenCalled();
+  });
+
+  test('streams an Audiobookshelf pairing as tokened track URLs on one timeline', async () => {
+    useABSServerStore.setState({
+      servers: [{ id: 'srv1', name: 'Home', url: 'http://abs.local/', accessToken: 'tok-1' }],
+    });
+    const view = makePairedView();
+    const appService = {
+      appPlatform: 'tauri',
+      isMobileApp: true,
+      openFile: vi.fn(),
+      resolveFilePath: vi.fn(),
+    } as unknown as AppService;
+    const controller = new TTSController(appService, view);
+    controller.pairedAudiobook = ABS_PAIRED_AUDIOBOOK;
+    const attachSource = vi.spyOn(controller.ttsMediaOverlayClient, 'attachSource');
+
+    await controller.init();
+    await controller.initViewTTS(0);
+
+    expect(controller.narrationAvailable).toBe(true);
+    expect((await controller.getVoices('en'))[0]!.voices[0]!.name).toBe('Server Narrator');
+    const source = attachSource.mock.calls.at(-1)?.[0];
+    expect(source?.textHighlight).toBe(false);
+    await expect(source?.resolveTracks?.('abs://srv1/item1')).resolves.toEqual([
+      { url: 'http://abs.local/api/items/item1/file/1?token=tok-1', startOffset: 0, duration: 20 },
+      { url: 'http://abs.local/api/items/item1/file/2?token=tok-1', startOffset: 20, duration: 10 },
+    ]);
+    // The token is read per call, so a rotation is picked up by the next load.
+    useABSServerStore.getState().updateServer('srv1', { accessToken: 'tok-2' });
+    await expect(source?.resolveTracks?.('abs://srv1/item1')).resolves.toMatchObject([
+      { url: 'http://abs.local/api/items/item1/file/1?token=tok-2' },
+      { url: 'http://abs.local/api/items/item1/file/2?token=tok-2' },
+    ]);
+    // Nothing local exists to open or resolve for a streamed pairing.
+    expect(appService.openFile).not.toHaveBeenCalled();
+    expect(appService.resolveFilePath).not.toHaveBeenCalled();
+    useABSServerStore.setState({ servers: [] });
+  });
+
+  test('a streamed pairing whose server was removed cannot load audio', async () => {
+    useABSServerStore.setState({ servers: [] });
+    const controller = new TTSController({} as AppService, makePairedView());
+    controller.pairedAudiobook = ABS_PAIRED_AUDIOBOOK;
+    const attachSource = vi.spyOn(controller.ttsMediaOverlayClient, 'attachSource');
+
+    await controller.init();
+
+    const source = attachSource.mock.calls.at(-1)?.[0];
+    await expect(source?.resolveTracks?.('abs://srv1/item1')).resolves.toBeNull();
+    await expect(source?.loadBlob('abs://srv1/item1')).rejects.toThrow(/server not found/i);
   });
 
   test('starts paired narration at the current text position without drawing a chapter highlight', async () => {

--- a/apps/readest-app/src/__tests__/services/tts/multi-track-narration-clock.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/multi-track-narration-clock.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  MultiTrackNarrationClock,
+  type NarrationTrack,
+  type NarrationTrackPlayer,
+} from '@/services/tts/mediaOverlay/MultiTrackNarrationClock';
+
+// A per-track player the composite drives: records loads/seeks/rates and lets
+// the test fire the events a real element or native player would.
+class FakeTrackPlayer implements NarrationTrackPlayer {
+  loads: Array<{ url: string; startAt: number }> = [];
+  seeks: number[] = [];
+  rates: number[] = [];
+  playCalls = 0;
+  paused = true;
+  currentTime = 0;
+  playbackRate = 1;
+  destroyed = false;
+  // Resolved by the test when set, so a load can be held open.
+  loadGate: Promise<void> | null = null;
+  #listeners = new Map<string, Set<() => void>>();
+
+  async load(url: string, startAt: number): Promise<void> {
+    if (this.loadGate) await this.loadGate;
+    this.loads.push({ url, startAt });
+    this.currentTime = startAt;
+    this.paused = true;
+  }
+  async play(): Promise<void> {
+    this.playCalls += 1;
+    this.paused = false;
+  }
+  pause(): void {
+    this.paused = true;
+  }
+  async seek(seconds: number): Promise<void> {
+    this.seeks.push(seconds);
+    this.currentTime = seconds;
+  }
+  async setRate(rate: number): Promise<void> {
+    this.rates.push(rate);
+    this.playbackRate = rate;
+  }
+  addEventListener(type: 'ended' | 'error' | 'timeupdate', fn: () => void): void {
+    if (!this.#listeners.has(type)) this.#listeners.set(type, new Set());
+    this.#listeners.get(type)!.add(fn);
+  }
+  removeEventListener(type: 'ended' | 'error' | 'timeupdate', fn: () => void): void {
+    this.#listeners.get(type)?.delete(fn);
+  }
+  destroy(): void {
+    this.destroyed = true;
+  }
+  emit(type: 'ended' | 'error' | 'timeupdate'): void {
+    for (const fn of [...(this.#listeners.get(type) ?? [])]) fn();
+  }
+}
+
+const TRACKS: NarrationTrack[] = [
+  { url: 'http://abs/t2', startOffset: 100, duration: 50 },
+  { url: 'http://abs/t1', startOffset: 0, duration: 100 },
+];
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+const setup = () => {
+  const player = new FakeTrackPlayer();
+  const clock = new MultiTrackNarrationClock(TRACKS, player);
+  return { player, clock };
+};
+
+describe('MultiTrackNarrationClock', () => {
+  test('seeking loads the track holding the global position at its in-track offset', async () => {
+    const { player, clock } = setup();
+
+    await clock.seek(120);
+
+    expect(player.loads).toEqual([{ url: 'http://abs/t2', startAt: 20 }]);
+    player.currentTime = 25;
+    expect(clock.currentTime).toBe(125);
+    expect(clock.duration).toBe(150);
+  });
+
+  test('seeks within the loaded track without reloading it', async () => {
+    const { player, clock } = setup();
+    await clock.seek(120);
+
+    await clock.seek(130);
+
+    expect(player.loads).toHaveLength(1);
+    expect(player.seeks).toEqual([30]);
+    expect(clock.currentTime).toBe(130);
+  });
+
+  test('assigning currentTime seeks like a media element', async () => {
+    const { player, clock } = setup();
+
+    clock.currentTime = 42;
+    await flush();
+
+    expect(player.loads).toEqual([{ url: 'http://abs/t1', startAt: 42 }]);
+  });
+
+  test('playing with nothing loaded starts from the first track', async () => {
+    const { player, clock } = setup();
+
+    await clock.play();
+
+    expect(player.loads).toEqual([{ url: 'http://abs/t1', startAt: 0 }]);
+    expect(player.playCalls).toBe(1);
+    expect(clock.paused).toBe(false);
+  });
+
+  test('rolls into the next track when one ends, without reporting ended', async () => {
+    const { player, clock } = setup();
+    const ended = vi.fn();
+    clock.addEventListener('ended', ended);
+    await clock.seek(90);
+    await clock.play();
+
+    player.emit('ended');
+    await flush();
+
+    expect(player.loads.at(-1)).toEqual({ url: 'http://abs/t2', startAt: 0 });
+    expect(player.playCalls).toBe(2);
+    expect(ended).not.toHaveBeenCalled();
+    expect(clock.paused).toBe(false);
+    expect(clock.currentTime).toBe(100);
+  });
+
+  test('reports ended only when the last track runs out', async () => {
+    const { player, clock } = setup();
+    const ended = vi.fn();
+    clock.addEventListener('ended', ended);
+    await clock.seek(120);
+    await clock.play();
+
+    player.emit('ended');
+    await flush();
+
+    expect(ended).toHaveBeenCalledTimes(1);
+    expect(player.loads).toHaveLength(1);
+    expect(clock.paused).toBe(true);
+  });
+
+  test('relays errors and time updates from the track player', async () => {
+    const { player, clock } = setup();
+    const error = vi.fn();
+    const timeupdate = vi.fn();
+    clock.addEventListener('error', error);
+    clock.addEventListener('timeupdate', timeupdate);
+
+    player.emit('error');
+    player.emit('timeupdate');
+    clock.removeEventListener('timeupdate', timeupdate);
+    player.emit('timeupdate');
+
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(timeupdate).toHaveBeenCalledTimes(1);
+  });
+
+  test('applies the rate set before any load to each track it loads', async () => {
+    const { player, clock } = setup();
+
+    await clock.setRate(1.5);
+    await clock.seek(10);
+    await clock.seek(120);
+
+    expect(clock.playbackRate).toBe(1.5);
+    expect(player.rates.filter((rate) => rate === 1.5).length).toBeGreaterThanOrEqual(2);
+    expect(player.playbackRate).toBe(1.5);
+  });
+
+  test('reports the requested position while its track is still loading', async () => {
+    const { player, clock } = setup();
+    let open!: () => void;
+    player.loadGate = new Promise<void>((resolve) => {
+      open = resolve;
+    });
+
+    const seeking = clock.seek(120);
+    expect(clock.currentTime).toBe(120);
+
+    open();
+    await seeking;
+    expect(clock.currentTime).toBe(120);
+  });
+
+  test('a pause during a pending load leaves the new track paused', async () => {
+    const { player, clock } = setup();
+    await clock.play();
+    let open!: () => void;
+    player.loadGate = new Promise<void>((resolve) => {
+      open = resolve;
+    });
+
+    const seeking = clock.seek(120);
+    clock.pause();
+    open();
+    await seeking;
+
+    expect(player.playCalls).toBe(1);
+    expect(clock.paused).toBe(true);
+  });
+
+  test('a load superseded by a later seek never starts playing', async () => {
+    const { player, clock } = setup();
+    await clock.play();
+    let open!: () => void;
+    player.loadGate = new Promise<void>((resolve) => {
+      open = resolve;
+    });
+
+    const stale = clock.seek(120);
+    const fresh = clock.seek(10);
+    open();
+    await Promise.all([stale, fresh]);
+
+    expect(player.loads.at(-1)).toEqual({ url: 'http://abs/t1', startAt: 10 });
+    expect(player.playCalls).toBe(2);
+  });
+
+  test('clamps positions past the end to the final track', async () => {
+    const { player, clock } = setup();
+
+    await clock.seek(10_000);
+
+    expect(player.loads).toEqual([{ url: 'http://abs/t2', startAt: 50 }]);
+  });
+
+  test('destroy silences and releases the track player', async () => {
+    const { player, clock } = setup();
+    await clock.play();
+
+    clock.destroy();
+
+    expect(player.paused).toBe(true);
+    expect(player.destroyed).toBe(true);
+    expect(clock.paused).toBe(true);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/tts/multi-track-narration-clock.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/multi-track-narration-clock.test.ts
@@ -204,6 +204,25 @@ describe('MultiTrackNarrationClock', () => {
     expect(clock.paused).toBe(true);
   });
 
+  test('a same-track seek during a pending load lands after the load settles', async () => {
+    const { player, clock } = setup();
+    // Start a cross-track load and hold it open.
+    let open!: () => void;
+    player.loadGate = new Promise<void>((resolve) => {
+      open = resolve;
+    });
+    const loading = clock.seek(120); // -> t2, in-track offset 20
+
+    // Scrub again within the SAME track while the load is still in flight.
+    const reseek = clock.seek(140); // -> t2, in-track offset 40
+    open();
+    await Promise.all([loading, reseek]);
+
+    // The load set the playhead to 20; the seek must win, not be overwritten.
+    expect(player.currentTime).toBe(40);
+    expect(clock.currentTime).toBe(140);
+  });
+
   test('a load superseded by a later seek never starts playing', async () => {
     const { player, clock } = setup();
     await clock.play();

--- a/apps/readest-app/src/app/reader/components/audiobook/AudiobookPairingDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/audiobook/AudiobookPairingDialog.tsx
@@ -7,6 +7,7 @@ import {
   MdAudiotrack,
   MdDeleteOutline,
   MdFolderOpen,
+  MdHeadphones,
   MdPlayArrow,
   MdStop,
 } from 'react-icons/md';
@@ -17,25 +18,39 @@ import { useFileSelector, type SelectedFile } from '@/hooks/useFileSelector';
 import { useTranslation } from '@/hooks/useTranslation';
 import type { BookDoc } from '@/libs/document';
 import {
+  absPreviewClip,
+  listPairableAbsBooks,
+  loadAbsPairingSource,
+  type AbsPairingSource,
+} from '@/services/audiobook/absPairing';
+import {
   buildSequentialAudiobookMappings,
   collectAudiobookTextChapters,
 } from '@/services/audiobook/mapping';
 import { parseAudiobookFile, type ParsedAudiobookFile } from '@/services/audiobook/metadata';
-import { AudiobookPreviewPlayer } from '@/services/audiobook/preview';
+import { AudiobookPreviewPlayer, type AudiobookPreviewClip } from '@/services/audiobook/preview';
 import {
+  persistStreamedPairedAudiobook,
   replacePairedAudiobook,
   removePairedAudiobook,
   type AudiobookImportFile,
 } from '@/services/audiobook/storage';
+import { findABSServerById } from '@/store/absServerStore';
 import { useBookDataStore } from '@/store/bookDataStore';
+import { useLibraryStore } from '@/store/libraryStore';
 import { useReaderStore } from '@/store/readerStore';
 import { useSettingsStore } from '@/store/settingsStore';
-import type { AudiobookChapter, AudiobookChapterMapping, PairedAudiobook } from '@/types/book';
+import type {
+  AudiobookChapter,
+  AudiobookChapterMapping,
+  Book,
+  PairedAudiobook,
+} from '@/types/book';
 import { eventDispatcher } from '@/utils/event';
 import AudiobookChapterPicker, { formatAudiobookTimecode } from './AudiobookChapterPicker';
 import StepProgress from './AudiobookStepProgress';
 
-type WizardStep = 'summary' | 'select' | 'anchor' | 'review';
+type WizardStep = 'summary' | 'select' | 'abs' | 'anchor' | 'review';
 
 interface AudiobookPairingDialogProps {
   bookKey: string;
@@ -97,6 +112,9 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
   const [association] = useState<PairedAudiobook | null>(initialAssociation);
   const [step, setStep] = useState<WizardStep>(association ? 'summary' : 'select');
   const [preparedFiles, setPreparedFiles] = useState<PreparedImportFile[]>([]);
+  const [preparedAbs, setPreparedAbs] = useState<AbsPairingSource | null>(null);
+  const [absBooks, setAbsBooks] = useState<Book[]>([]);
+  const [absQuery, setAbsQuery] = useState('');
   const [selectedEbookChapterId, setSelectedEbookChapterId] = useState('');
   const [selectedAudioChapterId, setSelectedAudioChapterId] = useState('');
   const [mappings, setMappings] = useState<Record<string, string>>(
@@ -111,13 +129,24 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
 
   const ebookChapters = useMemo(() => collectAudiobookTextChapters(bookDoc.toc ?? []), [bookDoc]);
   const importedAudioChapters = useMemo(
-    () => preparedFiles.flatMap(({ metadata }) => metadata.chapters),
-    [preparedFiles],
+    () => preparedAbs?.chapters ?? preparedFiles.flatMap(({ metadata }) => metadata.chapters),
+    [preparedAbs, preparedFiles],
   );
+  const hasPreparedSource = preparedFiles.length > 0 || preparedAbs !== null;
   const audioChapters =
-    step === 'review' && preparedFiles.length === 0
-      ? (association?.chapters ?? [])
-      : importedAudioChapters;
+    step === 'review' && !hasPreparedSource ? (association?.chapters ?? []) : importedAudioChapters;
+  // Where the audio for a preview comes from: the source being prepared, else
+  // the saved pairing whose mapping is being edited.
+  const previewAbsSource = preparedAbs?.source ?? (hasPreparedSource ? null : association?.source);
+  const filteredAbsBooks = useMemo(() => {
+    const normalized = absQuery.trim().toLocaleLowerCase();
+    if (!normalized) return absBooks;
+    return absBooks.filter(
+      (candidate) =>
+        candidate.title.toLocaleLowerCase().includes(normalized) ||
+        candidate.author.toLocaleLowerCase().includes(normalized),
+    );
+  }, [absBooks, absQuery]);
   const audioChapterById = new Map(audioChapters.map((chapter) => [chapter.id, chapter]));
   const mappedAudioIds = new Set(Object.values(mappings));
   const mappedCount = Object.keys(mappings).filter((id) => mappings[id]).length;
@@ -146,6 +175,21 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
     },
     [preparedFiles],
   );
+
+  // The reader does not always have the library loaded (a deep link opens a
+  // book directly), so read it from disk when the store is empty.
+  useEffect(() => {
+    if (!appService) return;
+    let cancelled = false;
+    const { library, libraryLoaded } = useLibraryStore.getState();
+    void (async () => {
+      const books = libraryLoaded ? library : await appService.loadLibraryBooks();
+      if (!cancelled) setAbsBooks(listPairableAbsBooks(books));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [appService]);
 
   const persistAssociation = async (nextAssociation: PairedAudiobook | undefined) => {
     const current = getConfig(bookKey);
@@ -216,6 +260,7 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
       }
       const chapters = nextFiles.flatMap(({ metadata }) => metadata.chapters);
       if (!chapters.length) throw new Error(_('No playable audio chapters were found.'));
+      setPreparedAbs(null);
       setPreparedFiles(nextFiles);
       setSelectedEbookChapterId(ebookChapters[0]!.id);
       setSelectedAudioChapterId(chapters[0]!.id);
@@ -224,6 +269,30 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
     } catch (cause) {
       await closeFiles(openedFiles);
       setError(cause instanceof Error ? cause.message : _('Failed to read audiobook files.'));
+    } finally {
+      setBusyMessage('');
+    }
+  };
+
+  const chooseAbsBook = async (candidate: Book) => {
+    if (!appService) return;
+    setError('');
+    if (!ebookChapters.length) {
+      setError(_('This book has no table of contents to map to audio chapters.'));
+      return;
+    }
+    setBusyMessage(_('Loading audiobook chapters'));
+    try {
+      await previewPlayerRef.current?.stop();
+      const source = await loadAbsPairingSource(appService, candidate);
+      setPreparedFiles([]);
+      setPreparedAbs(source);
+      setSelectedEbookChapterId(ebookChapters[0]!.id);
+      setSelectedAudioChapterId(source.chapters[0]!.id);
+      setMappings({});
+      setStep('anchor');
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : _('Failed to load the audiobook.'));
     } finally {
       setBusyMessage('');
     }
@@ -244,6 +313,7 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
 
   const editExistingMapping = () => {
     setPreparedFiles([]);
+    setPreparedAbs(null);
     setMappings(mappingRecord(association?.mappings ?? []));
     setStep('review');
   };
@@ -269,18 +339,30 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
     const stored = association?.files.find((file) => file.id === chapter.fileId);
     try {
       await eventDispatcher.dispatch('tts-stop', { bookKey });
-      const playing = await previewPlayerRef.current.toggle({
-        id: chapter.id,
-        ...(prepared?.previewPath
-          ? { path: prepared.previewPath, base: 'None' as const }
-          : stored
-            ? { path: stored.path, base: 'Books' as const }
-            : prepared
-              ? { file: prepared.file }
-              : {}),
-        start: chapter.start,
-        end: chapter.end,
-      });
+      let clip: Omit<AudiobookPreviewClip, 'id'>;
+      if (previewAbsSource) {
+        // Chapter times are global; the preview plays the file holding the start.
+        const remote = absPreviewClip(previewAbsSource, chapter.start);
+        if (!remote) throw new Error(_('Audiobookshelf server not found'));
+        clip = {
+          url: remote.url,
+          start: remote.start,
+          end: remote.start + chapter.end - chapter.start,
+        };
+      } else {
+        clip = {
+          ...(prepared?.previewPath
+            ? { path: prepared.previewPath, base: 'None' as const }
+            : stored
+              ? { path: stored.path, base: 'Books' as const }
+              : prepared
+                ? { file: prepared.file }
+                : {}),
+          start: chapter.start,
+          end: chapter.end,
+        };
+      }
+      const playing = await previewPlayerRef.current.toggle({ id: chapter.id, ...clip });
       setPreviewingAudioChapterId(playing ? chapter.id : null);
     } catch (cause) {
       setPreviewingAudioChapterId(null);
@@ -296,7 +378,24 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
       await eventDispatcher.dispatch('tts-stop', { bookKey });
       await previewPlayerRef.current?.stop();
       let nextAssociation: PairedAudiobook | null;
-      if (preparedFiles.length) {
+      if (preparedAbs) {
+        nextAssociation = await persistStreamedPairedAudiobook(
+          appService,
+          book.hash,
+          {
+            version: 1,
+            ...(preparedAbs.title ? { title: preparedAbs.title } : {}),
+            ...(preparedAbs.narrator ? { narrator: preparedAbs.narrator } : {}),
+            files: preparedAbs.files,
+            chapters: preparedAbs.chapters,
+            mappings: orderedMappings(),
+            createdAt: Math.max(Date.now(), (association?.createdAt ?? 0) + 1),
+            source: preparedAbs.source,
+          },
+          association ?? undefined,
+          persistAssociation,
+        );
+      } else if (preparedFiles.length) {
         nextAssociation = await replacePairedAudiobook(
           appService,
           book.hash,
@@ -332,7 +431,9 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
       await removePairedAudiobook(appService, book.hash, association, persistAssociation);
       eventDispatcher.dispatch('toast', {
         type: 'info',
-        message: _('Audiobook removed from this device.'),
+        message: association.source
+          ? _('Audiobook unpaired.')
+          : _('Audiobook removed from this device.'),
       });
       onClose();
     } catch (cause) {
@@ -345,32 +446,53 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
   const renderSummary = () => {
     if (!association) return null;
     const totalDuration = association.files.reduce((total, file) => total + file.duration, 0);
+    const streamedFrom = association.source
+      ? (findABSServerById(association.source.serverId)?.name ?? 'Audiobookshelf')
+      : null;
     return (
       <>
         <SurfaceHeader
           title={_('Paired Audiobook')}
-          description={_('Manage the local recording paired with this ebook.')}
+          description={
+            streamedFrom
+              ? _('Manage the Audiobookshelf audiobook paired with this ebook.')
+              : _('Manage the local recording paired with this ebook.')
+          }
         />
         <div className='eink-bordered border-base-200 bg-base-100 mb-5 rounded-lg border'>
           <div className='flex min-h-14 items-center gap-3 px-4 py-3'>
             <span className='bg-base-200 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full'>
-              <MdAudiotrack className='h-5 w-5' />
+              {streamedFrom ? (
+                <MdHeadphones className='h-5 w-5' />
+              ) : (
+                <MdAudiotrack className='h-5 w-5' />
+              )}
             </span>
             <div className='min-w-0 flex-1'>
               <p className='truncate font-medium'>{association.title || book?.title}</p>
               <p className='text-neutral-content text-[0.85em]'>
-                {_('{{files}} files · {{chapters}} audio chapters · {{duration}}', {
-                  files: association.files.length,
-                  chapters: association.chapters.length,
-                  duration: formatAudiobookTimecode(totalDuration),
-                })}
+                {streamedFrom
+                  ? _('{{chapters}} audio chapters · {{duration}} · Streamed from {{server}}', {
+                      chapters: association.chapters.length,
+                      duration: formatAudiobookTimecode(totalDuration),
+                      server: streamedFrom,
+                    })
+                  : _('{{files}} files · {{chapters}} audio chapters · {{duration}}', {
+                      files: association.files.length,
+                      chapters: association.chapters.length,
+                      duration: formatAudiobookTimecode(totalDuration),
+                    })}
               </p>
             </div>
           </div>
         </div>
         {confirmRemove ? (
           <div className='eink-bordered border-error/50 bg-base-100 mb-5 rounded-lg border p-4'>
-            <p className='font-medium'>{_('Remove audiobook files from this device?')}</p>
+            <p className='font-medium'>
+              {streamedFrom
+                ? _('Unpair this audiobook?')
+                : _('Remove audiobook files from this device?')}
+            </p>
             <p className='text-neutral-content mt-1 text-[0.85em]'>
               {_('The ebook, notes, and reading progress will be kept.')}
             </p>
@@ -436,6 +558,27 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
         <span className='font-medium'>{_('Select Audio Files')}</span>
         <span className='text-neutral-content text-[0.85em]'>MP3 · M4A · M4B</span>
       </button>
+      {absBooks.length > 0 && (
+        <button
+          type='button'
+          onClick={() => setStep('abs')}
+          disabled={busy}
+          className={clsx(
+            'eink-bordered group mt-4 flex min-h-28 w-full flex-col items-center justify-center gap-3',
+            'border-base-200 bg-base-100 rounded-lg border px-6 py-5',
+            'hover:border-base-300 hover:bg-base-200/60 transition-colors duration-150',
+            'focus-visible:ring-base-content/15 focus-visible:outline-none focus-visible:ring-2',
+          )}
+        >
+          <span className='bg-base-200 group-hover:bg-base-content group-hover:text-base-100 flex h-10 w-10 items-center justify-center rounded-full transition-colors duration-150'>
+            <MdHeadphones className='h-6 w-6' />
+          </span>
+          <span className='font-medium'>{_('Choose from Audiobookshelf')}</span>
+          <span className='text-neutral-content text-[0.85em]'>
+            {_('Streamed from your server, nothing to download')}
+          </span>
+        </button>
+      )}
       {association && (
         <div className='mt-5 flex justify-start'>
           <button className='btn btn-ghost' disabled={busy} onClick={() => setStep('summary')}>
@@ -443,6 +586,67 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
           </button>
         </div>
       )}
+    </>
+  );
+
+  const renderAbsPicker = () => (
+    <>
+      <StepProgress current={1} />
+      <SurfaceHeader
+        title={_('Choose Audiobook')}
+        description={_('Pick the Audiobookshelf audiobook to pair with “{{book}}”.', {
+          book: book?.title ?? _('this ebook'),
+        })}
+      />
+      <div className='eink-bordered border-base-200 bg-base-100 mb-5 overflow-hidden rounded-lg border'>
+        <div className='border-base-200 border-b p-2'>
+          <input
+            type='search'
+            className='input input-sm eink-bordered w-full'
+            aria-label={_('Search audiobooks')}
+            placeholder={_('Search audiobooks')}
+            value={absQuery}
+            onChange={(event) => setAbsQuery(event.target.value)}
+          />
+        </div>
+        <div className='divide-base-200 max-h-80 overflow-y-auto divide-y' role='list'>
+          {filteredAbsBooks.map((candidate) => (
+            <button
+              key={candidate.hash}
+              type='button'
+              role='listitem'
+              className='hover:bg-base-200 flex min-h-14 w-full items-center gap-3 px-4 py-2 text-start'
+              disabled={busy}
+              onClick={() => chooseAbsBook(candidate)}
+            >
+              <span className='bg-base-200 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full'>
+                <MdHeadphones className='h-5 w-5' />
+              </span>
+              <span className='min-w-0 flex-1'>
+                <span className='block truncate font-medium'>{candidate.title}</span>
+                <span className='text-neutral-content block truncate text-[0.85em]'>
+                  {[
+                    candidate.author,
+                    candidate.duration && formatAudiobookTimecode(candidate.duration),
+                  ]
+                    .filter(Boolean)
+                    .join(' · ')}
+                </span>
+              </span>
+            </button>
+          ))}
+          {filteredAbsBooks.length === 0 && (
+            <p className='text-neutral-content px-3 py-5 text-center text-sm'>
+              {_('No matching audiobooks')}
+            </p>
+          )}
+        </div>
+      </div>
+      <WizardActions>
+        <button className='btn btn-ghost' disabled={busy} onClick={() => setStep('select')}>
+          {_('Back')}
+        </button>
+      </WizardActions>
     </>
   );
 
@@ -535,7 +739,11 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
         </p>
       )}
       <WizardActions>
-        <button className='btn btn-ghost' disabled={busy} onClick={() => setStep('select')}>
+        <button
+          className='btn btn-ghost'
+          disabled={busy}
+          onClick={() => setStep(preparedAbs ? 'abs' : 'select')}
+        >
           {_('Back')}
         </button>
         <button
@@ -648,7 +856,7 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
         <button
           className='btn btn-ghost'
           disabled={busy}
-          onClick={() => setStep(preparedFiles.length ? 'anchor' : 'summary')}
+          onClick={() => setStep(hasPreparedSource ? 'anchor' : 'summary')}
         >
           {_('Back')}
         </button>
@@ -694,6 +902,7 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
         )}
         {step === 'summary' && renderSummary()}
         {step === 'select' && renderSelect()}
+        {step === 'abs' && renderAbsPicker()}
         {step === 'anchor' && renderAnchor()}
         {step === 'review' && renderReview()}
       </div>

--- a/apps/readest-app/src/app/reader/components/audiobook/AudiobookPairingDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/audiobook/AudiobookPairingDialog.tsx
@@ -344,10 +344,13 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
         // Chapter times are global; the preview plays the file holding the start.
         const remote = absPreviewClip(previewAbsSource, chapter.start);
         if (!remote) throw new Error(_('Audiobookshelf server not found'));
+        // A chapter can continue into the next track; keep the preview within
+        // the file it starts in so it does not run off the end of the clip.
+        const withinTrack = Math.min(chapter.end - chapter.start, remote.duration - remote.start);
         clip = {
           url: remote.url,
           start: remote.start,
-          end: remote.start + chapter.end - chapter.start,
+          end: remote.start + withinTrack,
         };
       } else {
         clip = {
@@ -643,7 +646,11 @@ const AudiobookPairingDialog = ({ bookKey, bookDoc, onClose }: AudiobookPairingD
         </div>
       </div>
       <WizardActions>
-        <button className='btn btn-ghost' disabled={busy} onClick={() => setStep('select')}>
+        <button
+          className='btn btn-ghost eink-bordered'
+          disabled={busy}
+          onClick={() => setStep('select')}
+        >
           {_('Back')}
         </button>
       </WizardActions>

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -425,7 +425,9 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     };
 
     const handleHighlightMark = (e: Event) => {
-      const { cfi, preview } = (e as CustomEvent<{ cfi: string; preview?: boolean }>).detail;
+      const { cfi, sentenceCfi, preview } = (
+        e as CustomEvent<{ cfi: string; sentenceCfi?: string; preview?: boolean }>
+      ).detail;
       const view = getView(bookKey);
       const progress = getProgress(bookKey);
       const viewSettings = getViewSettings(bookKey);
@@ -490,7 +492,14 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
       if (!range) return;
       if (!view.renderer.scrolled) {
         view.renderer.scrollToAnchor?.(range);
-        followSentenceAcrossPages(range);
+        // Page-follow measures where the page cuts the whole sounding sentence.
+        // A chapter-only pairing highlights a one-character reading dot, so
+        // follow its separate full-sentence range when the mark carries one.
+        const followRange =
+          sentenceCfi && sentenceCfi !== cfi
+            ? (view.resolveCFI(sentenceCfi).anchor(doc) ?? range)
+            : range;
+        followSentenceAcrossPages(followRange);
       } else {
         const rect = range.getBoundingClientRect();
         const { start, end, sideProp } = view.renderer;

--- a/apps/readest-app/src/services/audiobook/absPairing.ts
+++ b/apps/readest-app/src/services/audiobook/absPairing.ts
@@ -47,7 +47,9 @@ export const listPairableAbsBooks = (library: Book[]): Book[] =>
 export const buildAbsPairingSource = (item: ABSLibraryItem, serverId: string): AbsPairingSource => {
   const tracks = [...(item.media.tracks ?? [])].sort((a, b) => a.startOffset - b.startOffset);
   if (!tracks.length) throw new Error('This audiobook has no audio tracks.');
-  const duration = tracks.reduce((sum, track) => sum + track.duration, 0);
+  // The global endpoint, not the sum: a gap or overlap between track offsets
+  // makes the two differ, and chapter ends are clamped against this value.
+  const duration = Math.max(...tracks.map((track) => track.startOffset + track.duration));
   const title = item.media.metadata.title?.trim() || undefined;
   const { narrators, narratorName } = item.media.metadata;
   const narrator =
@@ -137,11 +139,15 @@ export const absNarrationTracks = (source: PairedAudiobookAbsSource): NarrationT
   }));
 };
 
-/** The file holding a global position, for previewing a chapter from its start. */
+/**
+ * The file holding a global position, for previewing a chapter from its start.
+ * `duration` is the selected track's length, so a caller can keep the preview
+ * within the file even when the chapter continues into the next track.
+ */
 export const absPreviewClip = (
   source: PairedAudiobookAbsSource,
   globalSec: number,
-): { url: string; start: number } | null => {
+): { url: string; start: number; duration: number } | null => {
   const tracks = absNarrationTracks(source);
   if (!tracks?.length) return null;
   const sorted = [...tracks].sort((a, b) => a.startOffset - b.startOffset);
@@ -150,5 +156,6 @@ export const absPreviewClip = (
   return {
     url: track.url,
     start: Math.max(0, Math.min(globalSec - track.startOffset, track.duration)),
+    duration: track.duration,
   };
 };

--- a/apps/readest-app/src/services/audiobook/absPairing.ts
+++ b/apps/readest-app/src/services/audiobook/absPairing.ts
@@ -1,0 +1,154 @@
+// Pairing an ebook with an audiobook that lives on an Audiobookshelf server.
+//
+// The pairing wizard and the narration player both see the item as ONE
+// virtual file on the item's global timeline: ABS times its chapters globally
+// and they routinely span several media files, which per-file chapter clocks
+// (the local pairing model) cannot express. The track list travels with the
+// association so playback can map that timeline onto the server's files
+// without fetching the expanded item again.
+
+import type { NarrationTrack } from '@/services/tts/mediaOverlay/MultiTrackNarrationClock';
+import { createAbsClient } from '@/services/audiobookshelf/createClient';
+import { findABSServerById, isAbsBookOrphaned } from '@/store/absServerStore';
+import type { ABSLibraryItem } from '@/types/audiobookshelf';
+import type { AudiobookChapter, AudiobookFile, Book, PairedAudiobookAbsSource } from '@/types/book';
+import type { AppService } from '@/types/system';
+import {
+  buildAbsMediaUrl,
+  isAudiobook,
+  makeAbsFilePath,
+  parseAbsFilePath,
+} from '@/utils/audiobook';
+import { getBaseFilename } from '@/utils/path';
+
+export const ABS_PAIRED_FILE_ID = 'abs';
+
+/** Everything the wizard needs before the user maps chapters. */
+export interface AbsPairingSource {
+  title?: string;
+  narrator?: string;
+  files: AudiobookFile[];
+  chapters: AudiobookChapter[];
+  source: PairedAudiobookAbsSource;
+}
+
+/** Library audiobooks that can be paired: live ABS books whose server is still configured. */
+export const listPairableAbsBooks = (library: Book[]): Book[] =>
+  library
+    .filter(
+      (book) =>
+        isAudiobook(book) &&
+        !book.deletedAt &&
+        book.absMediaType !== 'podcast' &&
+        !isAbsBookOrphaned(book),
+    )
+    .sort((a, b) => a.title.localeCompare(b.title));
+
+export const buildAbsPairingSource = (item: ABSLibraryItem, serverId: string): AbsPairingSource => {
+  const tracks = [...(item.media.tracks ?? [])].sort((a, b) => a.startOffset - b.startOffset);
+  if (!tracks.length) throw new Error('This audiobook has no audio tracks.');
+  const duration = tracks.reduce((sum, track) => sum + track.duration, 0);
+  const title = item.media.metadata.title?.trim() || undefined;
+  const { narrators, narratorName } = item.media.metadata;
+  const narrator =
+    narrators
+      ?.map((name) => name.trim())
+      .filter(Boolean)
+      .join(', ') ||
+    narratorName?.trim() ||
+    undefined;
+
+  const fromItem = (item.media.chapters ?? []).flatMap((chapter, index) => {
+    const end = Math.min(chapter.end, duration);
+    if (!(end > chapter.start)) return [];
+    return [
+      {
+        id: `${ABS_PAIRED_FILE_ID}:${chapter.id}`,
+        fileId: ABS_PAIRED_FILE_ID,
+        label: chapter.title.trim() || `Chapter ${index + 1}`,
+        start: chapter.start,
+        end,
+      },
+    ];
+  });
+  // No chapter table: each media file is a chapter, as the local flow does
+  // for tracks without chapter metadata.
+  const chapters = fromItem.length
+    ? fromItem
+    : tracks.map((track, index) => ({
+        id: `${ABS_PAIRED_FILE_ID}:track:${track.index}`,
+        fileId: ABS_PAIRED_FILE_ID,
+        label: track.title?.trim() ? getBaseFilename(track.title) : `Track ${index + 1}`,
+        start: track.startOffset,
+        end: track.startOffset + track.duration,
+      }));
+
+  return {
+    ...(title ? { title } : {}),
+    ...(narrator ? { narrator } : {}),
+    files: [
+      {
+        id: ABS_PAIRED_FILE_ID,
+        name: title ?? 'audiobook',
+        path: makeAbsFilePath(serverId, item.id),
+        duration,
+      },
+    ],
+    chapters,
+    source: {
+      kind: 'audiobookshelf',
+      serverId,
+      itemId: item.id,
+      tracks: tracks.map(({ index, startOffset, duration, contentUrl }) => ({
+        index,
+        startOffset,
+        duration,
+        contentUrl,
+      })),
+    },
+  };
+};
+
+/** Fetches the expanded item behind a library ABS book and prepares it for pairing. */
+export const loadAbsPairingSource = async (
+  appService: AppService,
+  book: Book,
+): Promise<AbsPairingSource> => {
+  const parsed = parseAbsFilePath(book.filePath);
+  const server = parsed ? findABSServerById(parsed.serverId) : undefined;
+  if (!parsed || !server) throw new Error('Audiobookshelf server not found');
+  const item = await createAbsClient(appService, server).getItemExpanded(parsed.itemId);
+  return buildAbsPairingSource(item, server.id);
+};
+
+/**
+ * The source's tracks as streamable URLs carrying the server's CURRENT
+ * access token, read at call time so a token rotated mid-session (by any
+ * client) is picked up by the next file load. Null when the server row is
+ * gone.
+ */
+export const absNarrationTracks = (source: PairedAudiobookAbsSource): NarrationTrack[] | null => {
+  const server = findABSServerById(source.serverId);
+  if (!server) return null;
+  return source.tracks.map((track) => ({
+    url: buildAbsMediaUrl(server, track.contentUrl),
+    startOffset: track.startOffset,
+    duration: track.duration,
+  }));
+};
+
+/** The file holding a global position, for previewing a chapter from its start. */
+export const absPreviewClip = (
+  source: PairedAudiobookAbsSource,
+  globalSec: number,
+): { url: string; start: number } | null => {
+  const tracks = absNarrationTracks(source);
+  if (!tracks?.length) return null;
+  const sorted = [...tracks].sort((a, b) => a.startOffset - b.startOffset);
+  const track =
+    [...sorted].reverse().find((candidate) => candidate.startOffset <= globalSec) ?? sorted[0]!;
+  return {
+    url: track.url,
+    start: Math.max(0, Math.min(globalSec - track.startOffset, track.duration)),
+  };
+};

--- a/apps/readest-app/src/services/audiobook/openAudiobook.ts
+++ b/apps/readest-app/src/services/audiobook/openAudiobook.ts
@@ -11,14 +11,14 @@
 import { AudiobookController, type AudiobookSource } from './AudiobookController';
 import { HtmlAudioClock } from './AudiobookClock';
 import { NativeAudiobookClock } from './NativeAudiobookClock';
-import { ABSClient } from '@/services/audiobookshelf/client';
+import { createAbsClient } from '@/services/audiobookshelf/createClient';
 import { AbsProgressSyncer, readLocalLastPlayedAt } from '@/services/audiobookshelf/progressSync';
 import { findABSServerById, useABSServerStore } from '@/store/absServerStore';
 import { ttsSessionManager } from '@/services/tts/TTSSessionManager';
 import type { TTSMediaBridgeMeta } from '@/services/tts/ttsMediaBridge';
-import { parseAbsFilePath } from '@/utils/audiobook';
+import { buildAbsMediaUrl, parseAbsFilePath } from '@/utils/audiobook';
 import { getOSPlatform, stubTranslation as _, uniqueId } from '@/utils/misc';
-import { isTauriAppPlatform, type EnvConfigType } from '@/services/environment';
+import { isTauriAppPlatform } from '@/services/environment';
 import { eventDispatcher } from '@/utils/event';
 import type { AppService } from '@/types/system';
 import type { Book } from '@/types/book';
@@ -34,10 +34,6 @@ import type {
 // NativeNarrationPlayer split): WebKit HTMLMediaElement / WebAudio cannot own
 // the app's non-mixable audio session.
 const isIOSTauri = (): boolean => isTauriAppPlatform() && getOSPlatform() === 'ios';
-
-const toEnvConfig = (appService: AppService): EnvConfigType => ({
-  getAppService: async () => appService,
-});
 
 const notifyConnectionError = (serverName: string): void => {
   eventDispatcher.dispatch('toast', {
@@ -59,14 +55,6 @@ const notifyEpisodeNotFound = (): void => {
     type: 'error',
   });
 };
-
-const buildClient = (appService: AppService, server: ABSServer): ABSClient =>
-  new ABSClient(server, {
-    onTokensUpdated: (patch) => {
-      useABSServerStore.getState().updateServer(server.id, patch);
-      void useABSServerStore.getState().saveABSServers(toEnvConfig(appService));
-    },
-  });
 
 /** Resolves the server config for a library book, toasting when it's gone. */
 const resolveServer = (book: Book): { itemId: string; server: ABSServer } | null => {
@@ -119,7 +107,7 @@ export const openAudiobookSession = async (input: {
   const { itemId, server } = resolved;
 
   try {
-    const client = buildClient(appService, server);
+    const client = createAbsClient(appService, server);
     const item = await client.getItemExpanded(itemId);
 
     let tracks: ABSTrack[];
@@ -181,12 +169,8 @@ export const openAudiobookSession = async (input: {
       // refresh (by this client or another, e.g. the periodic library sync)
       // carries the rotated token instead of the one this session started
       // with.
-      resolveUrl: (contentPath: string) => {
-        const current = useABSServerStore.getState().getServer(server.id) ?? server;
-        const base = current.url.replace(/\/+$/, '');
-        const separator = contentPath.includes('?') ? '&' : '?';
-        return `${base}${contentPath}${separator}token=${current.accessToken ?? ''}`;
-      },
+      resolveUrl: (contentPath: string) =>
+        buildAbsMediaUrl(useABSServerStore.getState().getServer(server.id) ?? server, contentPath),
       startAt,
     };
 
@@ -237,7 +221,7 @@ export const loadAbsEpisodes = async (
   const { itemId, server } = resolved;
 
   try {
-    const client = buildClient(appService, server);
+    const client = createAbsClient(appService, server);
     const [item, me] = await Promise.all([client.getItemExpanded(itemId), client.getMe()]);
 
     const episodes = [...(item.media.episodes ?? [])].sort(

--- a/apps/readest-app/src/services/audiobook/preview.ts
+++ b/apps/readest-app/src/services/audiobook/preview.ts
@@ -10,6 +10,8 @@ export interface AudiobookPreviewClip {
   file?: File;
   path?: string;
   base?: BaseDir;
+  /** A streamable URL (an Audiobookshelf track); `start` is then in-file seconds. */
+  url?: string;
   start: number;
   end: number;
 }
@@ -55,15 +57,19 @@ export class AudiobookPreviewPlayer {
 
     this.#activeId = clip.id;
     try {
-      if (this.#appService.appPlatform === 'tauri' && this.#appService.isMobileApp && clip.path) {
+      const mobileNative = this.#appService.appPlatform === 'tauri' && this.#appService.isMobileApp;
+      if (mobileNative && (clip.url || clip.path)) {
         this.#nativePlayer ??= new NativeNarrationPlayer();
-        const path = await this.#appService.resolveFilePath(clip.path, clip.base ?? 'None');
+        const path =
+          clip.url ?? (await this.#appService.resolveFilePath(clip.path!, clip.base ?? 'None'));
         await this.#nativePlayer.loadPath(clip.id, path, clip.start);
         await this.#nativePlayer.play();
       } else {
         const audio = new Audio();
         let url: string;
-        if (this.#appService.appPlatform === 'tauri' && clip.path) {
+        if (clip.url) {
+          url = clip.url;
+        } else if (this.#appService.appPlatform === 'tauri' && clip.path) {
           const path = await this.#appService.resolveFilePath(clip.path, clip.base ?? 'None');
           url = convertFileSrc(path);
         } else {

--- a/apps/readest-app/src/services/audiobook/storage.ts
+++ b/apps/readest-app/src/services/audiobook/storage.ts
@@ -122,12 +122,35 @@ export const replacePairedAudiobook = async (
   return association;
 };
 
+/**
+ * Saves a pairing that streams from a server: nothing to copy, so only the
+ * association is persisted, after which whatever local audio the previous
+ * pairing kept under this book is deleted.
+ */
+export const persistStreamedPairedAudiobook = async (
+  storage: AudiobookStorage,
+  bookHash: string,
+  association: PairedAudiobook,
+  previous: PairedAudiobook | undefined,
+  persist: (association: PairedAudiobook) => Promise<void>,
+): Promise<PairedAudiobook> => {
+  await persist(association);
+  try {
+    await deleteAudiobookFiles(storage, bookHash, previous?.files ?? []);
+  } catch (error) {
+    console.warn('Failed to remove replaced audiobook files:', error);
+  }
+  return association;
+};
+
 export const removePairedAudiobook = async (
   storage: AudiobookStorage,
   bookHash: string,
-  _association: PairedAudiobook,
+  association: PairedAudiobook,
   persist: (association: undefined) => Promise<void>,
 ): Promise<void> => {
   await persist(undefined);
+  // A streamed pairing never created the directory.
+  if (association.source) return;
   await storage.deleteDir(getAudiobookDirectory(bookHash), 'Books', true);
 };

--- a/apps/readest-app/src/services/audiobookshelf/createClient.ts
+++ b/apps/readest-app/src/services/audiobookshelf/createClient.ts
@@ -1,0 +1,23 @@
+import { ABSClient } from '@/services/audiobookshelf/client';
+import { useABSServerStore } from '@/store/absServerStore';
+import type { AppService } from '@/types/system';
+import type { ABSServer } from '@/types/audiobookshelf';
+import type { EnvConfigType } from '@/services/environment';
+
+const toEnvConfig = (appService: AppService): EnvConfigType => ({
+  getAppService: async () => appService,
+});
+
+/**
+ * An ABSClient whose token refreshes are written back to the server store
+ * and persisted, so a rotated access token survives the session that
+ * rotated it. Every API-calling path shares this; cover-only downloads
+ * (unauthenticated) don't need it.
+ */
+export const createAbsClient = (appService: AppService, server: ABSServer): ABSClient =>
+  new ABSClient(server, {
+    onTokensUpdated: (patch) => {
+      useABSServerStore.getState().updateServer(server.id, patch);
+      void useABSServerStore.getState().saveABSServers(toEnvConfig(appService));
+    },
+  });

--- a/apps/readest-app/src/services/audiobookshelf/librarySync.ts
+++ b/apps/readest-app/src/services/audiobookshelf/librarySync.ts
@@ -1,4 +1,5 @@
 import { ABSClient } from '@/services/audiobookshelf/client';
+import { createAbsClient } from '@/services/audiobookshelf/createClient';
 import {
   isLocalProgressFresher,
   readLocalLastPlayedAt,
@@ -265,12 +266,7 @@ export const backfillAbsCovers = async (appService: AppService): Promise<void> =
 
 /** Orchestrates: fetch, reconcile, apply to the library store, download missing covers. */
 export const syncAbsServer = async (appService: AppService, server: ABSServer): Promise<void> => {
-  const client = new ABSClient(server, {
-    onTokensUpdated: (patch) => {
-      useABSServerStore.getState().updateServer(server.id, patch);
-      void useABSServerStore.getState().saveABSServers(toEnvConfig(appService));
-    },
-  });
+  const client = createAbsClient(appService, server);
 
   const libraries = (await client.getLibraries()).filter(
     (lib) => lib.mediaType === 'book' || lib.mediaType === 'podcast',

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -308,6 +308,8 @@ const migratePairedAudiobook = async (
   targetHash: string,
 ): Promise<PairedAudiobook> => {
   if (sourceHash === targetHash) return association;
+  // Streamed from a server: no files under the old hash to carry over.
+  if (association.source) return association;
 
   const targetDirectory = getAudiobookDirectory(targetHash);
   await fs.createDir(targetDirectory, 'Books', true);

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -459,6 +459,23 @@ export class TTSController extends EventTarget {
   #attachNarrationSource(book: FoliateView['book']): void {
     if (this.#usesPairedAudiobook(book) && this.#pairedAudiobook && this.appService) {
       const narrator = this.#pairedAudiobook.narrator;
+      const source = this.#pairedAudiobook.source;
+      if (source?.kind === 'audiobookshelf') {
+        // Streamed from the server: the tracks resolve to URLs carrying the
+        // live token, and there is no blob to fall back to. Loaded on demand
+        // so the server store (and its settings graph) stays out of this
+        // module's imports for every other book.
+        this.ttsMediaOverlayClient.attachSource({
+          ...(narrator ? { narrator } : {}),
+          textHighlight: false,
+          resolveTracks: async () =>
+            (await import('@/services/audiobook/absPairing')).absNarrationTracks(source),
+          loadBlob: async () => {
+            throw new Error('Audiobookshelf server not found');
+          },
+        });
+        return;
+      }
       this.ttsMediaOverlayClient.attachSource({
         ...(narrator ? { narrator } : {}),
         textHighlight: false,

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -1671,7 +1671,14 @@ export class TTSController extends EventTarget {
             ? (this.#getCurrentPlaybackRange() ?? range)
             : range;
         const cfi = this.view.getCFI(this.#ttsSectionIndex, playbackRange);
-        this.dispatchEvent(new CustomEvent('tts-highlight-mark', { detail: { cfi } }));
+        // A chapter-only pairing highlights a one-character reading dot, but the
+        // view needs the whole sounding sentence to know where the page cuts it
+        // off (followSentenceAcrossPages). Carry that range's cfi too; it is the
+        // mark range itself when the client highlights the full text, so no
+        // extra work for synthesized voices or exact Media Overlays.
+        const sentenceCfi =
+          playbackRange === range ? cfi : this.view.getCFI(this.#ttsSectionIndex, range);
+        this.dispatchEvent(new CustomEvent('tts-highlight-mark', { detail: { cfi, sentenceCfi } }));
         this.#dispatchPosition(cfi, 'sentence');
       } catch {
         this.#suppressMarkHighlight = false;

--- a/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayClient.ts
+++ b/apps/readest-app/src/services/tts/mediaOverlay/MediaOverlayClient.ts
@@ -15,14 +15,25 @@
 // one playback session; Android needs it so multi-hour local files can stream
 // from disk without buffering the whole audiobook through the WebView.
 // Desktop and web use a plain HTMLAudioElement.
+//
+// A source whose recording is split across several files (an Audiobookshelf
+// item's tracks) hands over a track list instead, and MultiTrackNarrationClock
+// presents those files as one timeline on top of the same per-platform player.
 
 import type { BookDoc } from '@/libs/document';
+import { HtmlAudioClock } from '@/services/audiobook/AudiobookClock';
 import { getOSPlatform, stubTranslation as _ } from '@/utils/misc';
 import { parseSSMLMarks } from '@/utils/ssml';
 import type { TTSCapabilities, TTSClient, TTSMessageEvent } from '../TTSClient';
 import type { TTSController } from '../TTSController';
 import type { TTSGranularity, TTSVoice, TTSVoicesGroup } from '../types';
 import type { MediaOverlaySection, NarrationPar } from './MediaOverlaySection';
+import {
+  MultiTrackNarrationClock,
+  type NarrationTrack,
+  type NarrationTrackPlayer,
+} from './MultiTrackNarrationClock';
+import type { NarrationClock } from './NarrationClock';
 import { NativeNarrationPlayer } from './NativeNarrationPlayer';
 
 export const MEDIA_OVERLAY_CLIENT_NAME = 'media-overlay';
@@ -88,18 +99,51 @@ export interface NarrationAudioSource {
   loadBlob: (href: string) => Promise<Blob>;
   resolveUrl?: (href: string) => Promise<string | null>;
   resolvePath?: (href: string) => Promise<string | null>;
+  // A recording split across several streamable files, timed on one global
+  // clock. Takes precedence over the single-file resolvers when it returns
+  // tracks.
+  resolveTracks?: (href: string) => Promise<NarrationTrack[] | null>;
 }
 
-// Minimal clock surface shared by HTMLAudioElement and NativeNarrationPlayer.
-interface NarrationClock {
-  currentTime: number;
-  playbackRate: number;
-  readonly paused: boolean;
-  play(): Promise<void>;
-  pause(): void;
-  addEventListener(type: 'ended' | 'error' | 'timeupdate', fn: () => void): void;
-  removeEventListener(type: 'ended' | 'error' | 'timeupdate', fn: () => void): void;
-}
+const seekClock = async (audio: NarrationClock, seconds: number): Promise<void> => {
+  // A native or multi-file seek is async (plugin invoke, file switch);
+  // assigning currentTime alone can race with play() and start from the
+  // previous playhead.
+  if (audio.seek) await audio.seek(seconds);
+  else audio.currentTime = seconds;
+};
+
+const setClockRate = async (audio: NarrationClock, rate: number): Promise<void> => {
+  if (audio.setRate) await audio.setRate(rate);
+  else audio.playbackRate = rate;
+};
+
+// The shared native player as a per-track player: each track loads by URL
+// under the same href, so the native session survives file switches.
+const nativeTrackPlayer = (player: NativeNarrationPlayer, href: string): NarrationTrackPlayer => ({
+  get currentTime() {
+    return player.currentTime;
+  },
+  set currentTime(seconds: number) {
+    player.currentTime = seconds;
+  },
+  get playbackRate() {
+    return player.playbackRate;
+  },
+  set playbackRate(rate: number) {
+    player.playbackRate = rate;
+  },
+  get paused() {
+    return player.paused;
+  },
+  load: (url, startAt) => player.loadPath(href, url, startAt),
+  play: () => player.play(),
+  pause: () => player.pause(),
+  seek: (seconds) => player.seek(seconds),
+  setRate: (rate) => player.setRate(rate),
+  addEventListener: (type, fn) => player.addEventListener(type, fn),
+  removeEventListener: (type, fn) => player.removeEventListener(type, fn),
+});
 
 // Consecutive pars sharing an audio file. Normally one run per block; a run
 // boundary means the publisher split the paragraph across files.
@@ -199,6 +243,26 @@ export class MediaOverlayClient implements TTSClient {
   async #loadAudio(href: string): Promise<NarrationClock> {
     if (!this.#source) throw new Error('Book cannot load narration audio');
 
+    const tracks = await this.#source.resolveTracks?.(href).catch(() => null);
+    if (tracks?.length) {
+      let player: NarrationTrackPlayer;
+      if (this.#native && this.#player) {
+        // Same reasoning as the native branch below: never #releaseAudio here.
+        this.#cancelHandover();
+        this.#audio?.destroy?.();
+        player = nativeTrackPlayer(this.#player, href);
+      } else {
+        this.#releaseAudio();
+        player = new HtmlAudioClock();
+      }
+      const clock = new MultiTrackNarrationClock(tracks, player);
+      await clock.setRate(this.#rate);
+      this.#audio = clock;
+      this.#audioHref = href;
+      this.#objectUrl = null;
+      return clock;
+    }
+
     if (this.#native && this.#player) {
       const path = await this.#source.resolvePath?.(href).catch(() => null);
       // Keep any prior native session's file until the new one is staged; load()
@@ -256,6 +320,7 @@ export class MediaOverlayClient implements TTSClient {
   #releaseAudio(): void {
     this.#cancelHandover();
     this.#audio?.pause();
+    this.#audio?.destroy?.();
     if (this.#objectUrl) URL.revokeObjectURL(this.#objectUrl);
     this.#audio = null;
     this.#audioHref = null;
@@ -373,8 +438,7 @@ export class MediaOverlayClient implements TTSClient {
       if (signal.aborted) return;
 
       this.#cancelHandover();
-      if (this.#native && this.#player) await this.#player.setRate(this.#rate);
-      else audio.playbackRate = this.#rate;
+      await setClockRate(audio, this.#rate);
       // Sequential narration needs no seeking: Media Overlay clips are contiguous
       // and in document order, so the element can simply keep rolling while
       // boundaries are reported as the clock passes each clip. Seeking to
@@ -391,11 +455,7 @@ export class MediaOverlayClient implements TTSClient {
         audio.currentTime >= first.clipBegin - CLIP_CONTINUITY_TOLERANCE_SEC &&
         audio.currentTime < first.clipEnd;
       if (requestedPosition !== null || !alreadyRolling) {
-        const position = requestedPosition ?? first.clipBegin;
-        // Native seek is async (plugin invoke); assigning currentTime alone can
-        // race with play() and start from the previous playhead.
-        if (this.#native && this.#player) await this.#player.seek(position);
-        else audio.currentTime = position;
+        await seekClock(audio, requestedPosition ?? first.clipBegin);
       }
       try {
         await audio.play();
@@ -481,10 +541,10 @@ export class MediaOverlayClient implements TTSClient {
     // Await the native set-rate invoke: assigning playbackRate alone was
     // fire-and-forget, so stop→setRate→start (and live changes) raced play()
     // and left AVPlayer at the previous rate until the next voice switch.
-    if (this.#native && this.#player) {
+    if (this.#audio) {
+      await setClockRate(this.#audio, rate);
+    } else if (this.#native && this.#player) {
       await this.#player.setRate(rate);
-    } else if (this.#audio) {
-      this.#audio.playbackRate = rate;
     }
   }
 
@@ -559,9 +619,7 @@ export class MediaOverlayClient implements TTSClient {
     const par = this.#currentPar;
     if (!audio || !par) return false;
     const within = Math.min(Math.max(seconds, 0), par.clipEnd - par.clipBegin);
-    const position = par.clipBegin + within;
-    if (this.#native && this.#player) await this.#player.seek(position);
-    else audio.currentTime = position;
+    await seekClock(audio, par.clipBegin + within);
     return true;
   }
 

--- a/apps/readest-app/src/services/tts/mediaOverlay/MultiTrackNarrationClock.ts
+++ b/apps/readest-app/src/services/tts/mediaOverlay/MultiTrackNarrationClock.ts
@@ -1,0 +1,171 @@
+// One narration clock over a recording split into several media files.
+//
+// Audiobookshelf items carry a track list (per-file startOffset/duration) with
+// chapters timed on the global timeline, and chapters routinely span files.
+// MediaOverlayClient only wants "a clock for this href", so this presents the
+// tracks as one continuous timeline: seeks land on the right file at the right
+// offset, a file running out rolls into the next one, and only the last
+// file's end surfaces as `ended`.
+
+import type { NarrationClock } from './NarrationClock';
+
+export interface NarrationTrack {
+  url: string;
+  startOffset: number; // global seconds at which this track starts
+  duration: number; // seconds
+}
+
+// The per-track player the composite drives: HtmlAudioClock on the web, or the
+// client's NativeNarrationPlayer wrapped so load() streams a URL.
+export interface NarrationTrackPlayer extends NarrationClock {
+  load(url: string, startAt: number): Promise<void>;
+}
+
+type ClockEvent = 'ended' | 'error' | 'timeupdate';
+
+export class MultiTrackNarrationClock implements NarrationClock {
+  readonly duration: number;
+
+  #tracks: NarrationTrack[];
+  #player: NarrationTrackPlayer;
+  #index = -1;
+  // Global position the clock reports while no track is loaded or a load is
+  // still in flight, so a seek is visible before the media is ready.
+  #target = 0;
+  #pending: Promise<void> | null = null;
+  #rate = 1;
+  #userPaused = true;
+  #listeners: Record<ClockEvent, Set<() => void>> = {
+    ended: new Set(),
+    error: new Set(),
+    timeupdate: new Set(),
+  };
+  #onTrackEnded = () => this.#advance();
+  #onTrackError = () => this.#emit('error');
+  #onTimeUpdate = () => this.#emit('timeupdate');
+
+  constructor(tracks: NarrationTrack[], player: NarrationTrackPlayer) {
+    this.#tracks = [...tracks].sort((a, b) => a.startOffset - b.startOffset);
+    this.#player = player;
+    this.duration = this.#tracks.reduce((sum, track) => sum + track.duration, 0);
+    player.addEventListener('ended', this.#onTrackEnded);
+    player.addEventListener('error', this.#onTrackError);
+    player.addEventListener('timeupdate', this.#onTimeUpdate);
+  }
+
+  get currentTime(): number {
+    const track = this.#tracks[this.#index];
+    if (!track || this.#pending) return this.#target;
+    const offset = Math.min(Math.max(this.#player.currentTime, 0), track.duration);
+    return track.startOffset + offset;
+  }
+
+  set currentTime(seconds: number) {
+    void this.seek(seconds);
+  }
+
+  get playbackRate(): number {
+    return this.#rate;
+  }
+
+  set playbackRate(rate: number) {
+    void this.setRate(rate);
+  }
+
+  get paused(): boolean {
+    return this.#userPaused;
+  }
+
+  addEventListener(type: ClockEvent, fn: () => void): void {
+    this.#listeners[type].add(fn);
+  }
+
+  removeEventListener(type: ClockEvent, fn: () => void): void {
+    this.#listeners[type].delete(fn);
+  }
+
+  async seek(seconds: number): Promise<void> {
+    const { index, offset } = this.#locate(seconds);
+    if (index !== this.#index) {
+      await this.#load(index, offset);
+      return;
+    }
+    this.#target = this.#tracks[index]!.startOffset + offset;
+    if (this.#player.seek) await this.#player.seek(offset);
+    else this.#player.currentTime = offset;
+  }
+
+  async play(): Promise<void> {
+    this.#userPaused = false;
+    if (this.#index < 0) {
+      const { index, offset } = this.#locate(this.#target);
+      await this.#load(index, offset);
+      return;
+    }
+    if (this.#pending) await this.#pending;
+    await this.#player.play();
+  }
+
+  pause(): void {
+    this.#userPaused = true;
+    this.#player.pause();
+  }
+
+  async setRate(rate: number): Promise<void> {
+    this.#rate = rate;
+    if (this.#player.setRate) await this.#player.setRate(rate);
+    else this.#player.playbackRate = rate;
+  }
+
+  destroy(): void {
+    this.pause();
+    this.#player.removeEventListener('ended', this.#onTrackEnded);
+    this.#player.removeEventListener('error', this.#onTrackError);
+    this.#player.removeEventListener('timeupdate', this.#onTimeUpdate);
+    this.#player.destroy?.();
+  }
+
+  #locate(globalSec: number): { index: number; offset: number } {
+    const clamped = Math.max(0, Math.min(globalSec, this.duration));
+    let index = 0;
+    for (let i = 1; i < this.#tracks.length; i += 1) {
+      if (this.#tracks[i]!.startOffset <= clamped) index = i;
+    }
+    const track = this.#tracks[index]!;
+    const offset = Math.max(0, Math.min(clamped - track.startOffset, track.duration));
+    return { index, offset };
+  }
+
+  async #load(index: number, offset: number): Promise<void> {
+    const track = this.#tracks[index]!;
+    this.#index = index;
+    this.#target = track.startOffset + offset;
+    const pending = (async () => {
+      await this.#player.load(track.url, offset);
+      // A later seek may have moved on to another track while this one was
+      // loading; it owns the player now.
+      if (this.#index !== index) return;
+      await this.setRate(this.#rate);
+      if (!this.#userPaused) await this.#player.play();
+    })();
+    this.#pending = pending;
+    try {
+      await pending;
+    } finally {
+      if (this.#pending === pending) this.#pending = null;
+    }
+  }
+
+  #advance(): void {
+    if (this.#index < this.#tracks.length - 1) {
+      void this.#load(this.#index + 1, 0);
+      return;
+    }
+    this.#userPaused = true;
+    this.#emit('ended');
+  }
+
+  #emit(type: ClockEvent): void {
+    for (const fn of [...this.#listeners[type]]) fn();
+  }
+}

--- a/apps/readest-app/src/services/tts/mediaOverlay/MultiTrackNarrationClock.ts
+++ b/apps/readest-app/src/services/tts/mediaOverlay/MultiTrackNarrationClock.ts
@@ -47,7 +47,9 @@ export class MultiTrackNarrationClock implements NarrationClock {
   constructor(tracks: NarrationTrack[], player: NarrationTrackPlayer) {
     this.#tracks = [...tracks].sort((a, b) => a.startOffset - b.startOffset);
     this.#player = player;
-    this.duration = this.#tracks.reduce((sum, track) => sum + track.duration, 0);
+    // Global endpoint, not the sum: a gap or overlap between offsets makes them
+    // differ, and #locate clamps against this. Matches buildAbsPairingSource.
+    this.duration = Math.max(...this.#tracks.map((track) => track.startOffset + track.duration));
     player.addEventListener('ended', this.#onTrackEnded);
     player.addEventListener('error', this.#onTrackError);
     player.addEventListener('timeupdate', this.#onTimeUpdate);
@@ -89,6 +91,13 @@ export class MultiTrackNarrationClock implements NarrationClock {
     if (index !== this.#index) {
       await this.#load(index, offset);
       return;
+    }
+    // #load sets the playhead to its own startAt when it settles; a seek issued
+    // for the same track while that load is in flight would be overwritten, so
+    // wait it out first (then re-derive, in case another seek switched tracks).
+    if (this.#pending) {
+      await this.#pending;
+      if (this.#locate(seconds).index !== this.#index) return this.seek(seconds);
     }
     this.#target = this.#tracks[index]!.startOffset + offset;
     if (this.#player.seek) await this.#player.seek(offset);

--- a/apps/readest-app/src/services/tts/mediaOverlay/NarrationClock.ts
+++ b/apps/readest-app/src/services/tts/mediaOverlay/NarrationClock.ts
@@ -1,0 +1,17 @@
+// Minimal clock surface MediaOverlayClient drives: satisfied by an
+// HTMLAudioElement, by NativeNarrationPlayer, and by MultiTrackNarrationClock.
+export interface NarrationClock {
+  currentTime: number;
+  playbackRate: number;
+  readonly paused: boolean;
+  play(): Promise<void>;
+  pause(): void;
+  addEventListener(type: 'ended' | 'error' | 'timeupdate', fn: () => void): void;
+  removeEventListener(type: 'ended' | 'error' | 'timeupdate', fn: () => void): void;
+  // Async forms for clocks whose playhead lives out of process (a native
+  // player) or across several media files. The client prefers these when
+  // present: assigning currentTime/playbackRate alone would race play().
+  seek?(seconds: number): Promise<void>;
+  setRate?(rate: number): Promise<void>;
+  destroy?(): void;
+}

--- a/apps/readest-app/src/types/audiobookshelf.ts
+++ b/apps/readest-app/src/types/audiobookshelf.ts
@@ -34,6 +34,8 @@ export interface ABSTrack {
   duration: number; // seconds
   contentUrl: string; // server-relative, e.g. /api/items/<id>/file/<ino>
   mimeType: string;
+  /** The audio file's name, e.g. `20686-01.mp3`. */
+  title?: string;
 }
 
 export interface ABSChapter {
@@ -67,6 +69,8 @@ export interface ABSLibraryItem {
       authorName?: string | null; // book items
       author?: string | null; // podcast items
       language?: string | null;
+      narratorName?: string | null; // minified book items
+      narrators?: string[]; // expanded book items
     };
     duration?: number;
     numTracks?: number;

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -577,8 +577,10 @@ export interface BookConfig {
   viewSettings?: Partial<ViewSettings>;
   /**
    * A device-local recording paired with this ebook. The audio files live
-   * under Books/<hash>/audiobook/ and are deliberately excluded from cloud
-   * sync; ordinary reading progress remains the shared cross-device state.
+   * under Books/<hash>/audiobook/, or stream from an Audiobookshelf server
+   * (see PairedAudiobook.source); either way the pairing is deliberately
+   * excluded from cloud sync, and ordinary reading progress remains the
+   * shared cross-device state.
    */
   audiobook?: PairedAudiobook;
 
@@ -611,6 +613,25 @@ export interface AudiobookChapterMapping {
   audioChapterId: string;
 }
 
+/**
+ * An audiobook streamed from an Audiobookshelf server instead of copied to
+ * the device. The pairing then has a single virtual file
+ * (`abs://<serverId>/<itemId>`) whose chapters are timed on the item's global
+ * timeline, and the track list here maps that timeline onto the server's
+ * media files; nothing under Books/<hash>/audiobook/ exists for it.
+ */
+export interface PairedAudiobookAbsSource {
+  kind: 'audiobookshelf';
+  serverId: string;
+  itemId: string;
+  tracks: {
+    index: number;
+    startOffset: number; // global seconds
+    duration: number; // seconds
+    contentUrl: string; // server-relative
+  }[];
+}
+
 export interface PairedAudiobook {
   version: 1;
   title?: string;
@@ -619,6 +640,7 @@ export interface PairedAudiobook {
   chapters: AudiobookChapter[];
   mappings: AudiobookChapterMapping[];
   createdAt: number;
+  source?: PairedAudiobookAbsSource;
 }
 
 export interface BookDataRecord {

--- a/apps/readest-app/src/utils/audiobook.ts
+++ b/apps/readest-app/src/utils/audiobook.ts
@@ -38,7 +38,9 @@ export const buildAbsMediaUrl = (
 ): string => {
   const base = server.url.replace(/\/+$/, '');
   const separator = contentPath.includes('?') ? '&' : '?';
-  return `${base}${contentPath}${separator}token=${server.accessToken ?? ''}`;
+  // Encode the token: a `+`, `&`, or `#` in a non-JWT access token would
+  // otherwise be reparsed as query syntax and the media request fail auth.
+  return `${base}${contentPath}${separator}token=${encodeURIComponent(server.accessToken ?? '')}`;
 };
 
 /**

--- a/apps/readest-app/src/utils/audiobook.ts
+++ b/apps/readest-app/src/utils/audiobook.ts
@@ -1,4 +1,5 @@
 import type { BookMetadata } from '@/libs/document';
+import type { ABSServer } from '@/types/audiobookshelf';
 import type { Book } from '@/types/book';
 
 /** Scheme prefix for the synthetic filePath of an ABS streaming audiobook. */
@@ -23,6 +24,21 @@ export const parseAbsFilePath = (
   const itemId = rest.slice(slashIndex + 1);
   if (!serverId || !itemId) return null;
   return { serverId, itemId };
+};
+
+/**
+ * Absolute media URL for a server-relative track path, authenticated by query
+ * token (media elements cannot send headers). Takes the server row rather
+ * than a client on purpose: callers pass the store's CURRENT row on every
+ * load so a token rotated mid-session is used, not one captured at start.
+ */
+export const buildAbsMediaUrl = (
+  server: Pick<ABSServer, 'url' | 'accessToken'>,
+  contentPath: string,
+): string => {
+  const base = server.url.replace(/\/+$/, '');
+  const separator = contentPath.includes('?') ? '&' : '?';
+  return `${base}${contentPath}${separator}token=${server.accessToken ?? ''}`;
 };
 
 /**


### PR DESCRIPTION
Closes #5807.

Read a book and listen to its Audiobookshelf audiobook at the same time, in one UI. While reading an EPUB you pair an audiobook that lives on a configured Audiobookshelf server, and it plays through the existing Read Aloud mini player, streamed from the server rather than downloaded.

## What it does

- Open the book menu on a reflowable EPUB and choose **Pair Audiobook**, then **Choose from Audiobookshelf** (the card appears when a server is configured and has pairable audiobooks).
- Pick one of the server's audiobooks, align one chapter, review the mapping, and save.
- Read Aloud then plays the recording with everything it already offers: chapter sync, the scrubber and seek, sleep timer, and lock screen / media session controls. Nothing is copied to the device.

This replaces the workaround in the issue (read in Readest, listen in the Audiobookshelf app separately) with a single synchronized experience.

## How it works

It bridges two halves that already existed rather than adding a second player: the local audiobook pairing wizard and player (#5754) and the Audiobookshelf client and store (#5801).

- **One virtual file on the item's global timeline.** An ABS pairing records the server, item, and track list on a new `PairedAudiobook.source`. Audiobookshelf times chapters globally and they routinely span media files, which the per-file local model can't express, so the pairing is one `abs://<serverId>/<itemId>` file with chapters on the item's global clock.
- **`MultiTrackNarrationClock`** presents the item's tracks to `MediaOverlayClient` as a single `NarrationClock` (an interface extracted for this): a global seek lands on the file holding the position, a file running out rolls into the next, and only the last file's `ended` surfaces. It drives `HtmlAudioClock` on web and desktop and the existing native player, given track URLs, on mobile, selected through a new `resolveTracks` source hook. The prior `#native && #player` seek/rate special cases became `seek()`/`setRate()` on the clock interface.
- **Streaming, token-safe.** Track URLs carry the server's current access token, read live per load so a token rotated mid-session is used, and URL-encoded. Streamed pairings skip the copy, delete, and migrate disk paths.
- **Native http playback on Android.** `loadContinuousFile` in the native TTS plugin learns to stream `http(s)` URLs (`MediaItem.fromUri(Uri.parse(url))`), matching the branch iOS AVPlayer already had.

Listening position is not reported back to the Audiobookshelf server yet; ordinary reading progress still syncs through Readest.

## Follow-up fixes

- **Page-follow through a chapter-only pairing.** The text page now turns to keep up with the audio *within* a section, not only at section boundaries. A chapter-only pairing (a local audiobook or an ABS stream) highlights a one-character reading dot, and the view was being handed that one-character range, so `pageBreakFraction` never found a break to follow. The mark now carries the full sounding-sentence cfi alongside the one-character highlight cfi, and the view drives page-following from that range. This was pre-existing since #5754 (exact Media Overlays were unaffected because they report the full par range); synthesized voices and exact overlays are unchanged since the two cfis are then the same range.
- **Review round** (CodeRabbit): compute the virtual duration from the maximum global track endpoint instead of the sum (correct under gaps/overlaps); cap a streamed chapter preview to the track it starts in; wait out an in-flight track load before a same-track seek in `MultiTrackNarrationClock`; URL-encode the access token; add an e-ink boundary to the picker's Back button; clarify the docs on what a streamed pairing stores locally.

## Testing

- `pnpm test`, `pnpm lint`, `pnpm format:check` all green. New suites cover the multi-track clock, the ABS pairing converter and book listing, the client wiring (tokened track URLs, missing-server handling), streamed persist/remove/migrate, remote-URL preview, and the full-sentence page-follow cfi.
- Verified on a Xiaomi 13 (release build) against a live Audiobookshelf instance: pairing (picker, expanded-item fetch, map, review, save, summary "Streamed from <server>", unpair) and **live streaming** — the native player streams the http tracks, the position advances in real time, and the text page follows the narration through a section (page turning within a chapter while the chapter label holds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pair ebooks with audiobooks streamed directly from Audiobookshelf.
  * Browse and search eligible titles during pairing, with chapter previews and narrator details.
  * Stream multi-file audiobooks with continuous playback, seeking, and chapter navigation.
  * Support Audiobookshelf streaming across web, desktop, and mobile.
  * Improve page-follow behavior by tracking complete sentences during narration.
* **Bug Fixes**
  * Preserve streamed pairings during migration without copying or deleting local audio.
  * Refresh playback credentials automatically and handle unavailable servers gracefully.
* **Tests**
  * Expanded coverage for streaming, playback, storage, migration, previews, and server availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
