### PR TITLE
feat(toc): wrap long headings onto multiple lines instead of truncating

### DIFF
--- a/apps/readest-app/src/__tests__/components/toc-item-wrap.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/toc-item-wrap.browser.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Long TOC headings must wrap onto extra lines instead of being cut off with
+ * an ellipsis (issue #5852). English section titles routinely exceed one line
+ * on a phone-width sidebar, and there is no other way in the app to read the
+ * full heading.
+ *
+ * Needs real layout and real Tailwind, so it runs as a browser test.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/react';
+
+import type { TOCItem } from '@/libs/document';
+
+vi.mock('@/utils/misc', () => ({
+  getContentMd5: (s: string) => s,
+}));
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+const { StaticListRow } = await import('@/app/reader/components/sidebar/TOCItem');
+await import('@/styles/globals.css');
+
+afterEach(() => cleanup());
+
+const LONG_LABEL =
+  'Chapter Seven: In Which the Author Reflects at Considerable Length on the ' +
+  'Nature of Memory, the Passage of Time, and the Peculiar Habits of Cats';
+const UNBREAKABLE_LABEL = 'Supercalifragilisticexpialidocious'.repeat(4);
+
+// A phone-width sidebar tree, the case the issue was filed against.
+const TREE_WIDTH = 300;
+
+const renderRow = (label: string) => {
+  const item: TOCItem = {
+    id: 1,
+    label,
+    href: 'ch7.html',
+    index: 6,
+    subitems: [{ id: 2, label: 'Section', href: 'ch7-1.html', index: 7 }],
+  };
+  render(
+    <div role='tree' style={{ width: TREE_WIDTH }}>
+      <StaticListRow
+        bookKey='book1'
+        flatItem={{ item, depth: 0, index: 0, isExpanded: false }}
+        activeHref={null}
+        onToggleExpand={vi.fn()}
+        onItemClick={vi.fn()}
+      />
+    </div>,
+  );
+  const row = screen.getByRole('treeitem');
+  const labelEl = screen.getByText(label);
+  const pageEl = screen.getByText('7');
+  return { row, labelEl, pageEl };
+};
+
+const lineHeight = (el: HTMLElement) => parseFloat(getComputedStyle(el).lineHeight);
+
+describe('TOC heading wrapping', () => {
+  it('lets a long heading flow onto several lines instead of truncating it', () => {
+    const { labelEl } = renderRow(LONG_LABEL);
+    const rect = labelEl.getBoundingClientRect();
+    expect(rect.height).toBeGreaterThanOrEqual(2 * lineHeight(labelEl));
+    // Nothing of the text is clipped away.
+    expect(labelEl.scrollWidth).toBeLessThanOrEqual(labelEl.clientWidth + 1);
+  });
+
+  it('keeps the page number inside the row beside a wrapped heading', () => {
+    const { row, labelEl, pageEl } = renderRow(LONG_LABEL);
+    const rowRect = row.getBoundingClientRect();
+    const pageRect = pageEl.getBoundingClientRect();
+    const labelRect = labelEl.getBoundingClientRect();
+    expect(pageRect.right).toBeLessThanOrEqual(rowRect.right + 0.5);
+    expect(labelRect.right).toBeLessThanOrEqual(pageRect.left + 0.5);
+  });
+
+  it('breaks an unbreakable heading rather than pushing the page number out', () => {
+    const { row, labelEl, pageEl } = renderRow(UNBREAKABLE_LABEL);
+    const rowRect = row.getBoundingClientRect();
+    const pageRect = pageEl.getBoundingClientRect();
+    const labelRect = labelEl.getBoundingClientRect();
+    expect(labelRect.height).toBeGreaterThanOrEqual(2 * lineHeight(labelEl));
+    expect(pageRect.right).toBeLessThanOrEqual(rowRect.right + 0.5);
+    expect(labelRect.right).toBeLessThanOrEqual(pageRect.left + 0.5);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/sidebar/TOCItem.tsx
+++ b/apps/readest-app/src/app/reader/components/sidebar/TOCItem.tsx
@@ -141,18 +141,12 @@ const TOCItemView = React.memo<{
           {createExpanderIcon(flatItem.isExpanded || false)}
         </button>
       )}
-      <div
-        className='ms-2 truncate text-ellipsis'
-        style={{
-          maxWidth: 'calc(100% - 24px)',
-          whiteSpace: 'nowrap',
-          textOverflow: 'ellipsis',
-        }}
-      >
-        {item.label}
-      </div>
+      <div className='ms-2 min-w-0 break-words'>{item.label}</div>
       {(item.location || item.index !== undefined) && (
-        <div aria-hidden='true' className='text-base-content/50 ms-auto ps-1 text-xs sm:pe-1'>
+        <div
+          aria-hidden='true'
+          className='text-base-content/50 ms-auto shrink-0 ps-1 text-xs sm:pe-1'
+        >
           {item.location ? item.location.current + 1 : item.index + 1}
         </div>
       )}


### PR DESCRIPTION
Closes #5852

## What

Long TOC headings now wrap onto as many lines as they need instead of being cut off with an ellipsis after one line.

## Why

`TOCItemView` forced the label onto a single line (`truncate` + `white-space: nowrap` + a `maxWidth: calc(100% - 24px)` cap). English section titles routinely exceed one line on a phone-width sidebar, and there was no way in the app to read the full heading (the reporter was switching to another app just to see the TOC).

## How

- The label becomes a shrinkable flex item (`min-w-0`) that wraps normally, with `break-words` so an unbreakable token still breaks inside the row instead of pushing the page number out.
- The page number gets `shrink-0` so it keeps its width beside a wrapped heading.
- Nothing else changes: rows already render with `height: auto` and Virtuoso measures them, so variable-height rows need no list changes. The expander and page number stay vertically centered, matching how the app's other rows treat trailing content next to multi-line leading text.
- `.translation-target-toc` only adds `overflow: hidden; text-overflow: ellipsis` and inherited the `nowrap`, so translated headings wrap along with the original.

## Test

New Chromium browser test `src/__tests__/components/toc-item-wrap.browser.test.tsx` renders `StaticListRow` in a 300px tree and asserts that a long heading spans multiple lines with nothing clipped, that the page number stays inside the row beside it, and that an unbreakable heading breaks rather than overflowing. It failed on the previous code (label height 24px = one line) and passes now.

## Verified

- `pnpm test` (815 files / 10051 tests), `pnpm test:browser` for the new file, `pnpm lint`, `pnpm format:check` all green.
- Web dev build in Chrome with an EPUB whose nav has 1-, 2-, 3-line and unbreakable headings: desktop docked sidebar and the <640px bottom sheet both show the full headings (rows measure 56/80/104px on mobile), expander and page number in place, `Current position` row unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Table of contents headings now wrap across multiple lines instead of being truncated.
  - Long or unbroken words wrap correctly within the sidebar.
  - Page numbers remain visible, aligned, and inside the row alongside wrapped headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->