### PR TITLE
fix(bookorbit): list the open book under Unmatched KOReader Books for manual linking

### DIFF
--- a/apps/readest-app/src/__tests__/services/bookorbit/BookOrbitClient.test.ts
+++ b/apps/readest-app/src/__tests__/services/bookorbit/BookOrbitClient.test.ts
@@ -68,6 +68,40 @@ describe('BookOrbitClient', () => {
     expect(body['books']).toEqual(books);
   });
 
+  it('match-check clamps title and authors to the server limits and keeps the rest', async () => {
+    const fetchMock = setFetch(async () =>
+      jsonResponse(200, { matches: [], libraryVersion: 'v1' }),
+    );
+    const client = new BookOrbitClient(makeConfig());
+    const hash = 'c'.repeat(32);
+    await client.matchCheck([
+      {
+        hash,
+        title: 't'.repeat(600),
+        authors: 'a'.repeat(1200),
+        lastOpen: 1787000000,
+        source: 'current_file',
+      },
+    ]);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://192.168.1.50:3000/api/v1/koreader/plugin/match-check');
+    const body = JSON.parse(init.body as string) as {
+      hashes: string[];
+      books: Record<string, unknown>[];
+    };
+    expect(body.hashes).toEqual([hash]);
+    expect(body.books).toEqual([
+      {
+        hash,
+        title: 't'.repeat(500),
+        authors: 'a'.repeat(1000),
+        lastOpen: 1787000000,
+        source: 'current_file',
+      },
+    ]);
+  });
+
   it('throws BookOrbitRequestError with the response status on failure', async () => {
     setFetch(async () => jsonResponse(500, { message: 'boom' }));
     const client = new BookOrbitClient(makeConfig());

--- a/apps/readest-app/src/__tests__/services/bookorbit/notesPass.test.ts
+++ b/apps/readest-app/src/__tests__/services/bookorbit/notesPass.test.ts
@@ -114,10 +114,43 @@ describe('runBookOrbitNotesPass', () => {
     ]);
   });
 
+  it('floors lastOpen to whole unix seconds', async () => {
+    const deps = makeDeps({ now: () => NOW + 999 });
+    await runBookOrbitNotesPass(deps);
+    const [books] = (deps.client.matchCheck as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(books[0].lastOpen).toBe(NOW / 1000);
+    expect(Number.isInteger(books[0].lastOpen)).toBe(true);
+  });
+
+  it('still registers a current file when the book has no author', async () => {
+    const deps = makeDeps({ book: { hash: HASH, title: 'A Book' } });
+    await runBookOrbitNotesPass(deps);
+    const [books] = (deps.client.matchCheck as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    // The client JSON-encodes the body, so an absent author drops off the wire
+    // while the fields that get the book listed stay.
+    expect(JSON.parse(JSON.stringify(books[0]))).toEqual({
+      hash: HASH,
+      title: 'A Book',
+      lastOpen: NOW / 1000,
+      source: 'current_file',
+    });
+  });
+
   it('skips the exchange and hints when the book is unmatched', async () => {
     const deps = makeDeps();
     (deps.client.matchCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
       matches: [],
+      libraryVersion: 'v1',
+    });
+    await runBookOrbitNotesPass(deps);
+    expect(deps.onUnmatched).toHaveBeenCalledTimes(1);
+    expect(deps.client.exchangeAnnotations).not.toHaveBeenCalled();
+  });
+
+  it('treats a match for another hash as unmatched', async () => {
+    const deps = makeDeps();
+    (deps.client.matchCheck as ReturnType<typeof vi.fn>).mockResolvedValue({
+      matches: [{ hash: 'e'.repeat(32), bookId: 2, bookFileId: 2 }],
       libraryVersion: 'v1',
     });
     await runBookOrbitNotesPass(deps);

--- a/apps/readest-app/src/__tests__/services/bookorbit/notesPass.test.ts
+++ b/apps/readest-app/src/__tests__/services/bookorbit/notesPass.test.ts
@@ -100,6 +100,20 @@ const makeDeps = (overrides: Partial<NotesPassDeps> = {}): NotesPassDeps => ({
 });
 
 describe('runBookOrbitNotesPass', () => {
+  it('match-checks the open book as a current file so BookOrbit lists it for manual linking', async () => {
+    const deps = makeDeps();
+    await runBookOrbitNotesPass(deps);
+    expect(deps.client.matchCheck).toHaveBeenCalledWith([
+      {
+        hash: HASH,
+        title: 'A Book',
+        authors: 'An Author',
+        lastOpen: Math.floor(NOW / 1000),
+        source: 'current_file',
+      },
+    ]);
+  });
+
   it('skips the exchange and hints when the book is unmatched', async () => {
     const deps = makeDeps();
     (deps.client.matchCheck as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/apps/readest-app/src/services/bookorbit/BookOrbitClient.ts
+++ b/apps/readest-app/src/services/bookorbit/BookOrbitClient.ts
@@ -168,7 +168,13 @@ export class BookOrbitClient {
   async matchCheck(books: MatchCheckBook[]): Promise<MatchCheckResponse> {
     return await this.postJson<MatchCheckResponse>('/plugin/match-check', {
       hashes: books.map((book) => book.hash),
-      books,
+      // The server validates title <= 500 and authors <= 1000 chars and rejects
+      // the whole request otherwise, which would leave the book unregistered.
+      books: books.map((book) => ({
+        ...book,
+        title: book.title?.slice(0, 500),
+        authors: book.authors?.slice(0, 1000),
+      })),
     });
   }
 

--- a/apps/readest-app/src/services/bookorbit/notesPass.ts
+++ b/apps/readest-app/src/services/bookorbit/notesPass.ts
@@ -86,7 +86,18 @@ export const runBookOrbitNotesPass = async (deps: NotesPassDeps): Promise<void> 
   const { client, store, book } = deps;
   const hash = book.hash;
 
-  const matchResult = await client.matchCheck([{ hash, title: book.title, authors: book.author }]);
+  // Same shape the BookOrbit koplugin sends for the open document: `source`
+  // is what gets the book listed under "Unmatched KOReader Books" so the user
+  // can link it by hand, and `lastOpen` labels that entry.
+  const matchResult = await client.matchCheck([
+    {
+      hash,
+      title: book.title,
+      authors: book.author,
+      lastOpen: Math.floor(deps.now() / 1000),
+      source: 'current_file',
+    },
+  ]);
   if (!matchResult.matches.some((match) => match.hash === hash)) {
     deps.onUnmatched();
     return;

--- a/apps/readest-app/src/services/bookorbit/types.ts
+++ b/apps/readest-app/src/services/bookorbit/types.ts
@@ -169,6 +169,14 @@ export interface MatchCheckBook {
   hash: string;
   title?: string;
   authors?: string;
+  /** Unix seconds the document was last opened. */
+  lastOpen?: number;
+  /**
+   * Where the hash was seen. BookOrbit only surfaces `current_file` and `file`
+   * hashes as "Unmatched KOReader Books" for manual linking; anything without a
+   * source is stored as `statistics` and never offered to the user.
+   */
+  source?: 'current_file' | 'file' | 'statistics';
 }
 
 export interface MatchCheckResponse {


### PR DESCRIPTION
## Summary

Closes #5742

Books imported outside BookOrbit showed the "Book not found in the BookOrbit library" toast but never appeared under BookOrbit's **Unmatched KOReader Books** for manual linking, unlike books opened through the BookOrbit koplugin.

**Root cause (server side):** BookOrbit's `listUnmatchedBooks` only returns hashes whose match-check `source` is `current_file` or `file`. Readest's notes pass sent `{hash, title, authors}` with no `source`, so the server stored every Readest book as a `statistics` row and hid it from the dashboard. The koplugin (`bookorbit_book_sync.lua` stepMatch) sends `source = "current_file"` plus `last_open`.

**Fix**
- `notesPass.ts`: the match-check for the open book now sends `source: 'current_file'` and `lastOpen` (unix seconds), the same shape the koplugin sends.
- `types.ts`: `MatchCheckBook` gains `lastOpen` and `source`.
- `BookOrbitClient.matchCheck`: clamps `title` to 500 and `authors` to 1000 chars. The server's DTO rejects the whole request above those limits, which would have left anthologies and description-stuffed titles silently unregistered (surfaced by the adversarial review).

**Tests**
- `notesPass.test.ts`: match-check payload shape, `lastOpen` flooring, missing author, foreign-hash match treated as unmatched.
- `BookOrbitClient.test.ts`: match-check wire body (`hashes` + `books`) with the title/authors clamp.

**Verified against BookOrbit's own server code** (main @ `cb2ea1e`, run locally against an ephemeral Postgres through BookOrbit's vitest e2e harness, replaying the exact request bodies captured from Readest's real client): pre-fix body lands as a hidden `statistics` row; fixed body is listed with title/authors/lastOpen; a pre-fix row is upgraded by the fixed client; linking the entry in the dashboard makes the next match-check return the `bookId`. Also confirmed that PR #5704's KOSync `metadata` field cannot address this: BookOrbit answers a progress upload for an unknown hash with 404 and never touches the unmatched table.

**Compatibility:** BookOrbit's ValidationPipe is `forbidNonWhitelisted`, but `books`, `lastOpen` and `source` all entered its match-check DTO in the same commit (2026-07-02), so any server that accepts today's `books` payload accepts the new fields.

## Test Coverage

```
CODE PATHS                                                          USER FLOWS
[+] apps/readest-app/src/services/bookorbit/notesPass.ts
  └── runBookOrbitNotesPass() match-check block (L89-104)
      ├── [★★★ TESTED] hash/title/authors from NotesPassBook       — notesPass.test.ts:103
      ├── [★★★ TESTED] source: 'current_file'                      — notesPass.test.ts:103
      ├── [★★★ TESTED] lastOpen = floor(now()/1000), integer       — notesPass.test.ts:103, :117 (added)
      ├── [★★★ TESTED] author undefined -> wire omits authors,
      │                keeps source/lastOpen                        — notesPass.test.ts:125 (added)
      ├── [★★★ TESTED] matched -> continues to exchange            — notesPass.test.ts:161, :185, :223
      ├── [★★★ TESTED] unmatched (empty matches) -> onUnmatched,
      │                early return                                 — notesPass.test.ts:139
      └── [★★★ TESTED] match for another hash -> unmatched         — notesPass.test.ts:150 (added)
[+] apps/readest-app/src/services/bookorbit/BookOrbitClient.ts
  └── matchCheck() title/authors clamp                             — BookOrbitClient.test.ts:71 (added)
[+] apps/readest-app/src/services/bookorbit/types.ts
  └── MatchCheckBook.lastOpen? / source? union                     — [TYPE] tsgo via `pnpm lint`

USER FLOWS
  ├── [★★  TESTED] A. open book unknown to BookOrbit -> notes pass -> match-check tagged current_file
  │                   (hook wiring in useBookOrbitNotesSync has no tests; pre-existing)
  ├── [★★  TESTED] B. unmatched -> onUnmatched -> "Book not found in the BookOrbit library" toast
  ├── [★★★ TESTED] C. user links in BookOrbit dashboard -> next match-check returns bookId -> exchange runs
  └── [EXT]        D. server lists the row under "Unmatched KOReader Books" (source filter)
                      replayed 6/6 in BookOrbit's e2e harness (main cb2ea1e); not repo-testable

COVERAGE: 11/11 paths tested (100%)  |  Code paths: 8/8  |  User flows: 3/3 (+1 external, verified)
QUALITY: ★★★:9 ★★:2 ★:0  |  GAPS: 0 (in diff)
```

Tests: 862 -> 862 test files (+4 new cases in existing files)

## Pre-Landing Review

1 issue (0 critical, 1 informational), auto-fixed:
- `BookOrbitClient.ts:168` match-check sent `title`/`authors` uncapped against the server's 500/1000-char DTO limits -> clamped, with a test.

Small diff (35 lines at review time), specialists skipped.

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN
Intent: make Readest-opened books appear under BookOrbit's Unmatched KOReader Books for manual linking (#5742), matching the koplugin.
Delivered: match-check payload carries `source: 'current_file'` + `lastOpen`; title/authors clamped to server limits; tests. Touches only `src/services/bookorbit/` and its tests.

## Plan Completion

No plan file detected.

## Adversarial Review

Claude adversarial subagent (10 items) + Codex adversarial pass (3 items). Cross-model synthesis:
- **Agreed (both):** registration only happens from the notes pass, so `syncNotes` off or fixed-layout formats (PDF/CBZ) never register a book. Pre-existing gating, not introduced here; left as a follow-up rather than widening scope.
- **Agreed (both) and refuted with evidence:** "older servers reject the new fields" — `books`/`lastOpen`/`source` entered the server DTO together, so no server that accepts today's payload rejects these.
- **Agreed (both), skipped:** clamp negative/non-finite `lastOpen`. `now` is `Date.now()`; pre-epoch clocks do not occur on supported platforms.
- **Applied (Claude):** title/authors clamp (see Pre-Landing Review).
- **Informational (Claude):** a deterministic 400 from the server is retried every notes-sync tick and only `console.warn`ed (pre-existing error handling); the toast copy could point users to the dashboard now that the entry exists (i18n label change); the server takes `greatest(last_open)` on upsert, so a future-skewed clock pins the entry's timestamp.

Follow-ups (not in this PR): register the open book even when notes sync is off or the book is fixed-layout; reword the unmatched toast to point at BookOrbit's Unmatched KOReader Books; report library files with `source: 'file'` the way the koplugin sweep does.

## TODOS

No TODO items completed in this PR.

## Test plan
- [x] `pnpm test` — 815 files, 10056 tests passed (16 skipped)
- [x] `pnpm lint` — tsgo + biome clean
- [x] BookOrbit e2e replay of Readest's captured request bodies — 6/6 (local, BookOrbit main @ cb2ea1e)
- [ ] Reporter verification on a live BookOrbit instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved BookOrbit matching for long book titles and author lists.
  * Open books now include their last-opened time and source information when matching.
  * Books with different hashes are correctly treated as unmatched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->