### PR TITLE
fix(reader): move a paired audiobook by audio and decode WebP covers (#5863)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3687,12 +3687,23 @@ dependencies = [
  "byteorder-lite",
  "color_quant",
  "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
  "tiff",
  "zune-core",
  "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error 2.0.1",
 ]
 
 [[package]]

--- a/apps/readest-app/docs/read-along-narration.md
+++ b/apps/readest-app/docs/read-along-narration.md
@@ -81,6 +81,12 @@ span; runs crossing spine documents divide the clip into equal chapter slices
 so playback continues instead of restarting the recording at every section
 boundary.
 
+Audiobook chapter lists are often finer than the EPUB's table of contents
+(1, 1.1, 1.2, 2 ...). An audio chapter left without an ebook chapter plays as
+part of the mapped chapter before it in the same file, so the recording is
+heard in full and the page keeps following it proportionally. Audio before
+the first mapped chapter of a file (opening credits, say) is not played.
+
 The wizard reports chapter-count mismatches rather than hiding them. Audio stays
 under `Books/<book hash>/audiobook/`, while the association is stored in that
 book's device-local `config.json`; neither is uploaded by Readest cloud or file
@@ -123,6 +129,14 @@ Two behaviours worth knowing:
   misleading. Readest instead maps the current page proportionally into that
   chapter's audio span when narration starts and offers a return-to-narration
   action if the reader moves elsewhere while audio continues.
+- **Paired audiobooks move by audio.** With no sentences to step by, the
+  transport takes an audio player's vocabulary: the small step is the
+  audiobook player's skip (30 seconds forward, 15 back), the large step moves
+  to the previous or next chapter of the audiobook's own chapter list
+  (backward more than a few seconds into a chapter restarts it), and the
+  lock-screen skip and track buttons do the same. The page turns to another ebook chapter only when the target audio
+  chapter is narrated by a different mapped chapter; a sub-chapter inside the
+  current one is a seek within its text span.
 - **Unnarrated sections are skipped.** Publishers routinely leave front matter,
   indexes and notes out of the recording. Playback steps over those sections
   rather than stalling on silence; starting Read Aloud in unnarrated front
@@ -183,7 +197,10 @@ Consequences of that shape:
   a paired audiobook reports the same clock capabilities with
   `textHighlight: false`. `ensureTimeline`/`supportsPlaybackInfo`/`getPlaybackInfo` gate on
   `mediaClock` rather than comparing against the Edge client — which is what
-  `TTSCapabilities` in `TTSClient.ts` existed for.
+  `TTSCapabilities` in `TTSClient.ts` existed for. `usesAudioTransport`
+  (`mediaClock` without `textHighlight`) is what turns `forward`/`backward`
+  into the time seek and audiobook-chapter skip, so the media session's
+  `seekforward`/`nexttrack` handlers need no special case.
 - **A continuous timeline is handed over, not stopped.** `continuousTimeline`
   tells the controller that consecutive blocks are one recording, so it neither
   pads paragraph transitions with its own delay nor treats the stop between two

--- a/apps/readest-app/docs/read-along-narration.md
+++ b/apps/readest-app/docs/read-along-narration.md
@@ -132,11 +132,13 @@ Two behaviours worth knowing:
 - **Paired audiobooks move by audio.** With no sentences to step by, the
   transport takes an audio player's vocabulary: the small step is the
   audiobook player's skip (30 seconds forward, 15 back), the large step moves
-  to the previous or next chapter of the audiobook's own chapter list
+  to the previous or next reachable audiobook chapter, one a mapped chapter's
+  clip covers, so audio before the first mapped chapter stays out of reach
   (backward more than a few seconds into a chapter restarts it), and the
-  lock-screen skip and track buttons do the same. The page turns to another ebook chapter only when the target audio
-  chapter is narrated by a different mapped chapter; a sub-chapter inside the
-  current one is a seek within its text span.
+  lock-screen skip and track buttons do the same. The page turns to another
+  ebook chapter only when the target audio chapter is narrated by a different
+  mapped chapter; a sub-chapter inside the current one is a seek within its
+  text span.
 - **Unnarrated sections are skipped.** Publishers routinely leave front matter,
   indexes and notes out of the recording. Playback steps over those sections
   rather than stalling on silence; starting Read Aloud in unnarrated front

--- a/apps/readest-app/src-tauri/Cargo.toml
+++ b/apps/readest-app/src-tauri/Cargo.toml
@@ -113,7 +113,7 @@ percent-encoding = "2"
 # webview rendering (~30-60 KB instead of multi-MB). Default features
 # are disabled to keep the binary lean — we only need decoders for the
 # formats EPUBs actually use (jpeg/png/gif) plus the JPEG encoder.
-image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif"] }
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
 
 # Native MOBI/AZW/AZW3 import path. Mirrors the EPUB fast-path: parse
 # PalmDB + MobiHeader + EXTH in Rust to extract title/author/publisher/

--- a/apps/readest-app/src-tauri/src/cover_thumbnail.rs
+++ b/apps/readest-app/src-tauri/src/cover_thumbnail.rs
@@ -441,6 +441,27 @@ mod tests {
     }
 
     #[test]
+    fn webp_covers_decode_to_jpeg_thumbnails() {
+        // A 6x4 lossless WebP: EPUBs ship WebP covers, and the parser stores
+        // whatever it cannot re-encode as cover.png verbatim (#5863).
+        const WEBP: &[u8] = &[
+            0x52, 0x49, 0x46, 0x46, 0x1e, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50,
+            0x38, 0x4c, 0x11, 0x00, 0x00, 0x00, 0x2f, 0x05, 0xc0, 0x00, 0x00, 0x07, 0x50, 0x8f,
+            0x22, 0xd7, 0xa3, 0xff, 0x81, 0x88, 0xe8, 0x7f, 0x00, 0x00,
+        ];
+
+        let thumbnail = encode_thumbnail(WEBP).unwrap();
+        assert_eq!(&thumbnail[..2], &[0xff, 0xd8]);
+        let decoded = image::load_from_memory(&thumbnail).unwrap();
+        assert_eq!(decoded.dimensions(), (6, 4));
+        let pixel = decoded.get_pixel(3, 2).0;
+        assert!(
+            pixel[0] > 150 && pixel[1] < 80 && pixel[2] < 80,
+            "{pixel:?}"
+        );
+    }
+
+    #[test]
     fn corrupt_source_does_not_commit_a_cache_checkpoint() {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/apps/readest-app/src/__tests__/components/tts/TTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSControl.test.tsx
@@ -86,6 +86,7 @@ describe('TTSControl', () => {
       handleGetPlaybackInfo: vi.fn().mockReturnValue(null),
       handleSetSentenceGap: vi.fn(),
       handleSupportsPlaybackInfo: vi.fn().mockReturnValue(true),
+      audioTransport: false,
       handleSupportsGapControl: vi.fn().mockReturnValue(false),
       refreshTtsLang: vi.fn(),
     });

--- a/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
@@ -53,6 +53,7 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
   isEink: false,
   visible: true,
   hasTimeline: true,
+  audioTransport: false,
   timeoutTimestamp: 0,
   chapterRemainingSec: null as number | null,
   gridInsets,
@@ -152,6 +153,38 @@ describe('TTSMiniPlayer', () => {
     expect(props.onTogglePlay).toHaveBeenCalled();
     expect(screen.getByLabelText('Next Sentence').closest('[dir="ltr"]')).toBeTruthy();
     expect(screen.getByLabelText('Next Paragraph').closest('[dir="ltr"]')).toBeTruthy();
+  });
+
+  test('a paired audiobook seeks and skips chapters from the same four transport slots', () => {
+    viewSettingsOverride = { ttsPlayerStyle: 'minimal' };
+    const props = makeProps({ audioTransport: true });
+    render(<TTSMiniPlayer {...props} />);
+    for (const label of [
+      'Previous Paragraph',
+      'Previous Sentence',
+      'Next Sentence',
+      'Next Paragraph',
+    ]) {
+      expect(screen.queryByLabelText(label)).toBeNull();
+    }
+    fireEvent.click(screen.getByLabelText('Previous Chapter'));
+    expect(props.onBackward).toHaveBeenCalledWith(false);
+    fireEvent.click(screen.getByLabelText('Back 15 Seconds'));
+    expect(props.onBackward).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByLabelText('Forward 30 Seconds'));
+    expect(props.onForward).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByLabelText('Next Chapter'));
+    expect(props.onForward).toHaveBeenCalledWith(false);
+  });
+
+  test('full style turns its sentence pair into time skips for a paired audiobook', () => {
+    const props = makeProps({ audioTransport: true });
+    render(<TTSMiniPlayer {...props} />);
+    expect(screen.queryByLabelText('Previous Sentence')).toBeNull();
+    fireEvent.click(screen.getByLabelText('Back 15 Seconds'));
+    expect(props.onBackward).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByLabelText('Forward 30 Seconds'));
+    expect(props.onForward).toHaveBeenCalledWith(true);
   });
 
   test('play and pause glyphs share a size so toggling does not shift the row', () => {

--- a/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
@@ -109,6 +109,7 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
   ttsLang: 'en',
   isPlaying: true,
   hasTimeline: true,
+  audioTransport: false,
   timeoutOption: 0,
   timeoutTimestamp: 0,
   chapterRemainingSec: null as number | null,
@@ -207,6 +208,27 @@ describe('TTSPlayerSheet', () => {
     fireEvent.click(screen.getByLabelText('Next Sentence'));
     expect(props.onForward).toHaveBeenCalledWith(true);
     fireEvent.click(screen.getByLabelText('Next Paragraph'));
+    expect(props.onForward).toHaveBeenCalledWith(false);
+  });
+
+  test('a paired audiobook gets seek and chapter transport with the same step semantics', () => {
+    const props = makeProps({ audioTransport: true });
+    render(<TTSPlayerSheet {...props} />);
+    for (const label of [
+      'Previous Paragraph',
+      'Previous Sentence',
+      'Next Sentence',
+      'Next Paragraph',
+    ]) {
+      expect(screen.queryByLabelText(label)).toBeNull();
+    }
+    fireEvent.click(screen.getByLabelText('Previous Chapter'));
+    expect(props.onBackward).toHaveBeenCalledWith(false);
+    fireEvent.click(screen.getByLabelText('Back 15 Seconds'));
+    expect(props.onBackward).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByLabelText('Forward 30 Seconds'));
+    expect(props.onForward).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByLabelText('Next Chapter'));
     expect(props.onForward).toHaveBeenCalledWith(false);
   });
 

--- a/apps/readest-app/src/__tests__/services/audiobook-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/audiobook-controller.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { AudiobookController, SKIP_FORWARD_SEC } from '@/services/audiobook/AudiobookController';
+import { AudiobookController } from '@/services/audiobook/AudiobookController';
+import { SKIP_FORWARD_SEC } from '@/services/playback/playbackSource';
 import type { AudiobookClock } from '@/services/audiobook/AudiobookClock';
 import type { ABSChapter, ABSTrack } from '@/types/audiobookshelf';
 

--- a/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/media-overlay-controller.test.ts
@@ -151,6 +151,49 @@ const ABS_PAIRED_AUDIOBOOK: PairedAudiobook = {
   },
 };
 
+// An audiobook whose chapter list is finer than the EPUB's: "One.1" has no
+// TOC entry to map to, so it plays as the tail of Chapter 1's recording.
+const SUB_CHAPTER_AUDIOBOOK: PairedAudiobook = {
+  version: 1,
+  files: [{ id: 'audio-0', name: 'book.m4b', path: 'hash/audiobook/book.m4b', duration: 60 }],
+  chapters: [
+    { id: 'audio-0:0', fileId: 'audio-0', label: 'One', start: 0, end: 30 },
+    { id: 'audio-0:1', fileId: 'audio-0', label: 'One.1', start: 30, end: 45 },
+    { id: 'audio-0:2', fileId: 'audio-0', label: 'Two', start: 45, end: 60 },
+  ],
+  mappings: [
+    { ebookChapterId: 'chapter.xhtml', audioChapterId: 'audio-0:0' },
+    { ebookChapterId: 'last.xhtml', audioChapterId: 'audio-0:2' },
+  ],
+  createdAt: 1,
+};
+
+const makeSubChapterView = () => {
+  const docs = [
+    makeDoc('<p>Front matter.</p>'),
+    makeDoc('<h1>Chapter 1</h1><p>First chapter text.</p>'),
+    makeDoc('<h1>Chapter 2</h1><p>Second chapter text.</p>'),
+  ];
+  return {
+    book: {
+      toc: [
+        { id: 0, label: 'Chapter 1', href: 'chapter.xhtml', index: 0 },
+        { id: 1, label: 'Chapter 2', href: 'last.xhtml', index: 0 },
+      ],
+      sections: docs.map((doc, index) => ({
+        id: ['front.xhtml', 'chapter.xhtml', 'last.xhtml'][index],
+        createDocument: vi.fn().mockResolvedValue(doc),
+      })),
+      splitTOCHref: (href: string) => href.split('#'),
+    },
+    renderer: { getContents: () => [], primaryIndex: 0 },
+    language: { isCJK: false, canonical: 'en' },
+    getCFI: vi.fn().mockReturnValue('epubcfi(/6/2!/4/2)'),
+    resolveCFI: vi.fn().mockReturnValue({ anchor: () => null }),
+    tts: null,
+  } as unknown as FoliateView;
+};
+
 const makePairedView = () => {
   const docs = [makeDoc('<p>Front matter.</p>'), makeDoc('<h1>Chapter 1</h1><p>Text.</p>')];
   return {
@@ -459,6 +502,104 @@ describe('narration selection', () => {
     expect(controller.useNarration).toBe(true);
     // Returning must invalidate again: Edge may have aborted the shared player.
     expect(invalidate).toHaveBeenCalled();
+  });
+});
+
+describe('paired audiobook transport', () => {
+  const appService = {
+    openFile: vi.fn(async () => new File(['audio'], 'book.m4b')),
+    resolveFilePath: vi.fn(async () => '/books/book.m4b'),
+  } as unknown as AppService;
+
+  const startPaired = async () => {
+    const view = makeSubChapterView();
+    const controller = new TTSController(appService, view);
+    controller.pairedAudiobook = SUB_CHAPTER_AUDIOBOOK;
+    await controller.init();
+    await controller.initViewTTS(0);
+    await controller.ensureTimeline();
+    controller.dispatchSpeakMark({ offset: 0, name: '0', text: 'Chapter 1', language: 'en' });
+    // Installed after setup so only the transport's own page turns count.
+    controller.onSectionChange = vi.fn();
+    const client = controller.ttsMediaOverlayClient;
+    const position = vi.spyOn(client, 'getChunkPosition').mockReturnValue(0);
+    const seekWithin = vi.spyOn(client, 'seekToChunkPosition').mockResolvedValue(true);
+    const startAt = vi.spyOn(client, 'setNextChunkPosition');
+    return { controller, position, seekWithin, startAt };
+  };
+
+  test('only a chapter-timed recording drives the transport by audio', async () => {
+    const paired = new TTSController(appService, makeSubChapterView());
+    paired.pairedAudiobook = SUB_CHAPTER_AUDIOBOOK;
+    await paired.init();
+    expect(paired.usesAudioTransport()).toBe(true);
+
+    const overlays = new TTSController(null, makeView([true]));
+    await overlays.init();
+    expect(overlays.usesAudioTransport()).toBe(false);
+
+    const synthesized = new TTSController(null, makeView([false]));
+    await synthesized.init();
+    expect(synthesized.usesAudioTransport()).toBe(false);
+  });
+
+  test('the small step skips 30s forward and 15s back through the recording, whatever the rate', async () => {
+    const { controller, position, seekWithin } = await startPaired();
+
+    await controller.forward(true);
+    expect(seekWithin).toHaveBeenLastCalledWith(30);
+
+    position.mockReturnValue(25);
+    await controller.backward(true);
+    expect(seekWithin).toHaveBeenLastCalledWith(10);
+
+    // The timeline counts seconds at the rate; the skip is recording time.
+    await controller.setRate(2);
+    position.mockReturnValue(10);
+    await controller.forward(true);
+    expect(seekWithin).toHaveBeenLastCalledWith(40);
+
+    position.mockReturnValue(4);
+    await controller.backward(true);
+    expect(seekWithin).toHaveBeenLastCalledWith(0);
+    expect(controller.onSectionChange).not.toHaveBeenCalled();
+  });
+
+  test('the large step walks the audiobook chapters, turning the page only into a mapped one', async () => {
+    const { controller, position, seekWithin, startAt } = await startPaired();
+    const stop = vi.spyOn(controller.ttsMediaOverlayClient, 'stop');
+
+    // Chapter 1 -> One.1: the same recording span, so no restart and no page turn.
+    await controller.forward();
+    expect(seekWithin).toHaveBeenLastCalledWith(30);
+    expect(stop).not.toHaveBeenCalled();
+    expect(controller.onSectionChange).not.toHaveBeenCalled();
+
+    // One.1 -> Two: a mapped chapter in the next section.
+    position.mockReturnValue(30);
+    await controller.forward();
+    expect(controller.onSectionChange).toHaveBeenLastCalledWith(2);
+    expect(startAt).toHaveBeenLastCalledWith(0);
+
+    // Two, five seconds in: backward restarts it.
+    position.mockReturnValue(5);
+    await controller.backward();
+    expect(seekWithin).toHaveBeenLastCalledWith(0);
+
+    // Two, at its start: backward returns to One.1, inside Chapter 1's section.
+    position.mockReturnValue(0);
+    await controller.backward();
+    expect(controller.onSectionChange).toHaveBeenLastCalledWith(1);
+    expect(startAt).toHaveBeenLastCalledWith(30);
+  });
+
+  test('auto-advance still moves by narration block', async () => {
+    const { controller, seekWithin } = await startPaired();
+
+    await controller.forward(false, true);
+
+    expect(seekWithin).not.toHaveBeenCalled();
+    expect(controller.onSectionChange).toHaveBeenLastCalledWith(2);
   });
 });
 

--- a/apps/readest-app/src/__tests__/services/tts/paired-audiobook-section.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts/paired-audiobook-section.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest';
 import type { BookDoc } from '@/libs/document';
 import type { PairedAudiobook } from '@/types/book';
 import {
+  adjacentAudioChapter,
   findPairedAudiobookSection,
   loadPairedAudiobookSection,
+  narratedAudioChapters,
 } from '@/services/tts/pairedAudiobook';
 
 const makeDoc = (body: string): Document =>
@@ -118,6 +120,7 @@ describe('paired audiobook narration sections', () => {
   it('splits a shared audio chapter across consecutive EPUB spine sections', () => {
     const shared: PairedAudiobook = {
       ...association,
+      chapters: association.chapters.filter((chapter) => chapter.id !== 'audio-0:1'),
       mappings: [
         { ebookChapterId: 'chapter.xhtml#one', audioChapterId: 'audio-0:0' },
         { ebookChapterId: 'chapter.xhtml#two', audioChapterId: 'audio-0:0' },
@@ -136,5 +139,71 @@ describe('paired audiobook narration sections', () => {
     expect(chapterSection?.pars[0]).toMatchObject({ clipBegin: 5, clipEnd: 25 });
     expect(lastSection?.pars).toHaveLength(1);
     expect(lastSection?.pars[0]).toMatchObject({ clipBegin: 25, clipEnd: 35 });
+  });
+
+  describe('unmapped audio chapters', () => {
+    // An audiobook whose chapter list is finer than the EPUB's: 1.1 and 1.2
+    // have no TOC entry to map to, and the recording ends with credits.
+    const subChapters: PairedAudiobook = {
+      ...association,
+      chapters: [
+        { id: 'audio-0:intro', fileId: 'audio-0', label: 'Opening credits', start: 0, end: 5 },
+        { id: 'audio-0:0', fileId: 'audio-0', label: 'One', start: 5, end: 35 },
+        { id: 'audio-0:0a', fileId: 'audio-0', label: 'One.1', start: 35, end: 50 },
+        { id: 'audio-0:0b', fileId: 'audio-0', label: 'One.2', start: 50, end: 60 },
+        { id: 'audio-0:1', fileId: 'audio-0', label: 'Two', start: 60, end: 90 },
+        { id: 'audio-1:0', fileId: 'audio-1', label: 'Three', start: 0, end: 30 },
+        { id: 'audio-1:credits', fileId: 'audio-1', label: 'Credits', start: 30, end: 40 },
+      ],
+    };
+    const doc = makeDoc(
+      '<h1 id="one">Chapter 1</h1><p>First text.</p><h1 id="two">Chapter 2</h1><p>Second text.</p>',
+    );
+
+    it('plays them as part of the mapped chapter they follow', () => {
+      const section = loadPairedAudiobookSection(book, subChapters, 1, doc, 'en');
+      expect(section?.pars.map(({ clipBegin, clipEnd }) => [clipBegin, clipEnd])).toEqual([
+        [5, 60],
+        [60, 90],
+      ]);
+
+      const last = loadPairedAudiobookSection(book, subChapters, 2, makeDoc('<p>Third.</p>'), 'en');
+      expect(last?.pars.map(({ clipBegin, clipEnd }) => [clipBegin, clipEnd])).toEqual([[0, 40]]);
+    });
+
+    it('lists every reachable chapter in recording order with its narrating section', () => {
+      expect(
+        narratedAudioChapters(book, subChapters).map(({ chapter, audioHref, sectionIndex }) => [
+          chapter.label,
+          audioHref,
+          sectionIndex,
+        ]),
+      ).toEqual([
+        ['One', 'hash/audiobook/part-1.m4b', 1],
+        ['One.1', 'hash/audiobook/part-1.m4b', 1],
+        ['One.2', 'hash/audiobook/part-1.m4b', 1],
+        ['Two', 'hash/audiobook/part-1.m4b', 1],
+        ['Three', 'hash/audiobook/part-2.mp3', 2],
+        ['Credits', 'hash/audiobook/part-2.mp3', 2],
+      ]);
+    });
+
+    it('skips to the adjacent chapter, restarting the current one on a late backward skip', () => {
+      const chapters = narratedAudioChapters(book, subChapters);
+      const label = (entry: ReturnType<typeof adjacentAudioChapter>) =>
+        entry?.chapter.label ?? null;
+      const part1 = 'hash/audiobook/part-1.m4b';
+      const part2 = 'hash/audiobook/part-2.mp3';
+
+      expect(label(adjacentAudioChapter(chapters, part1, 10, 1))).toBe('One.1');
+      expect(label(adjacentAudioChapter(chapters, part1, 36, 1))).toBe('One.2');
+      expect(label(adjacentAudioChapter(chapters, part1, 89, 1))).toBe('Three');
+      expect(label(adjacentAudioChapter(chapters, part2, 35, 1))).toBeNull();
+
+      expect(label(adjacentAudioChapter(chapters, part1, 61, -1))).toBe('One.2');
+      expect(label(adjacentAudioChapter(chapters, part1, 70, -1))).toBe('Two');
+      expect(label(adjacentAudioChapter(chapters, part2, 1, -1))).toBe('Two');
+      expect(label(adjacentAudioChapter(chapters, part1, 6, -1))).toBeNull();
+    });
   });
 });

--- a/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
@@ -39,6 +39,7 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
   const isEink = viewSettings?.isEink ?? false;
   const playerStyle = viewSettings?.ttsPlayerStyle ?? 'full';
   const hasTimeline = tts.ttsClientsInited && tts.handleSupportsPlaybackInfo();
+  const audioTransport = tts.ttsClientsInited && tts.audioTransport;
   const miniPlayerMounted = tts.showIndicator && !showPlayerSheet;
   const miniPlayerVisible = useMiniPlayerAutoHide(bookKey, playerStyle, miniPlayerMounted);
 
@@ -108,6 +109,7 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
           isEink={isEink}
           visible={miniPlayerVisible}
           hasTimeline={hasTimeline}
+          audioTransport={audioTransport}
           timeoutTimestamp={tts.timeoutTimestamp}
           chapterRemainingSec={tts.chapterRemainingSec}
           gridInsets={gridInsets}
@@ -126,6 +128,7 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
           ttsLang={tts.ttsLang}
           isPlaying={tts.isPlaying}
           hasTimeline={hasTimeline}
+          audioTransport={audioTransport}
           timeoutOption={tts.timeoutOption}
           timeoutTimestamp={tts.timeoutTimestamp}
           chapterRemainingSec={tts.chapterRemainingSec}

--- a/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
@@ -14,6 +14,7 @@ import {
   MdSkipNext,
   MdSkipPrevious,
 } from 'react-icons/md';
+import { RiForward30Line, RiReplay15Line } from 'react-icons/ri';
 import { Insets } from '@/types/misc';
 import { useEnv } from '@/context/EnvContext';
 import { useReaderStore } from '@/store/readerStore';
@@ -63,6 +64,11 @@ type TTSMiniPlayerProps = {
   isEink: boolean;
   visible: boolean;
   hasTimeline: boolean;
+  // A paired audiobook has no sentences to step by: the small step is the
+  // audiobook player's 30s forward / 15s back skip and the large step moves
+  // by audiobook chapter, with the glyphs and labels of an audio player
+  // (#5863).
+  audioTransport: boolean;
   timeoutTimestamp: number;
   chapterRemainingSec: number | null;
   gridInsets: Insets;
@@ -90,6 +96,7 @@ const TTSMiniPlayer = ({
   isEink,
   visible,
   hasTimeline,
+  audioTransport,
   timeoutTimestamp,
   chapterRemainingSec,
   gridInsets,
@@ -262,10 +269,14 @@ const TTSMiniPlayer = ({
               <button
                 type='button'
                 className='shrink-0 rounded-full p-1'
-                aria-label={_('Previous Sentence')}
+                aria-label={audioTransport ? _('Back 15 Seconds') : _('Previous Sentence')}
                 onClick={() => onBackward(true)}
               >
-                <MdSkipPrevious size={iconSize28} />
+                {audioTransport ? (
+                  <RiReplay15Line size={iconSize26} />
+                ) : (
+                  <MdSkipPrevious size={iconSize28} />
+                )}
               </button>
               <button
                 type='button'
@@ -282,10 +293,14 @@ const TTSMiniPlayer = ({
               <button
                 type='button'
                 className='shrink-0 rounded-full p-1'
-                aria-label={_('Next Sentence')}
+                aria-label={audioTransport ? _('Forward 30 Seconds') : _('Next Sentence')}
                 onClick={() => onForward(true)}
               >
-                <MdSkipNext size={iconSize28} />
+                {audioTransport ? (
+                  <RiForward30Line size={iconSize26} />
+                ) : (
+                  <MdSkipNext size={iconSize28} />
+                )}
               </button>
               <button
                 type='button'
@@ -327,18 +342,26 @@ const TTSMiniPlayer = ({
             <button
               type='button'
               className='shrink-0 rounded-full p-1'
-              aria-label={_('Previous Paragraph')}
+              aria-label={audioTransport ? _('Previous Chapter') : _('Previous Paragraph')}
               onClick={() => onBackward(false)}
             >
-              <MdKeyboardDoubleArrowLeft size={iconSize26} />
+              {audioTransport ? (
+                <MdSkipPrevious size={iconSize26} />
+              ) : (
+                <MdKeyboardDoubleArrowLeft size={iconSize26} />
+              )}
             </button>
             <button
               type='button'
               className='shrink-0 rounded-full p-1'
-              aria-label={_('Previous Sentence')}
+              aria-label={audioTransport ? _('Back 15 Seconds') : _('Previous Sentence')}
               onClick={() => onBackward(true)}
             >
-              <MdKeyboardArrowLeft size={iconSize26} />
+              {audioTransport ? (
+                <RiReplay15Line size={iconSize26} />
+              ) : (
+                <MdKeyboardArrowLeft size={iconSize26} />
+              )}
             </button>
             <button
               type='button'
@@ -352,10 +375,14 @@ const TTSMiniPlayer = ({
             <button
               type='button'
               className='shrink-0 rounded-full p-1'
-              aria-label={_('Next Sentence')}
+              aria-label={audioTransport ? _('Forward 30 Seconds') : _('Next Sentence')}
               onClick={() => onForward(true)}
             >
-              <MdKeyboardArrowRight size={iconSize26} />
+              {audioTransport ? (
+                <RiForward30Line size={iconSize26} />
+              ) : (
+                <MdKeyboardArrowRight size={iconSize26} />
+              )}
             </button>
             {/* No stop button on purpose (#5310): five transport glyphs already
                 crowd a phone, and an accidental hit on a sixth ends the
@@ -364,10 +391,14 @@ const TTSMiniPlayer = ({
             <button
               type='button'
               className='shrink-0 rounded-full p-1'
-              aria-label={_('Next Paragraph')}
+              aria-label={audioTransport ? _('Next Chapter') : _('Next Paragraph')}
               onClick={() => onForward(false)}
             >
-              <MdKeyboardDoubleArrowRight size={iconSize26} />
+              {audioTransport ? (
+                <MdSkipNext size={iconSize26} />
+              ) : (
+                <MdKeyboardDoubleArrowRight size={iconSize26} />
+              )}
             </button>
             <div
               role='button'

--- a/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
@@ -12,8 +12,10 @@ import {
   MdPlayArrow,
   MdOutlineFileDownload,
   MdChevronRight,
+  MdSkipNext,
+  MdSkipPrevious,
 } from 'react-icons/md';
-import { RiVoiceAiFill } from 'react-icons/ri';
+import { RiForward30Line, RiReplay15Line, RiVoiceAiFill } from 'react-icons/ri';
 import { useRouter } from 'next/navigation';
 import { TTSVoicesGroup } from '@/services/tts';
 import { MEDIA_OVERLAY_VOICE_ID } from '@/services/tts/mediaOverlay';
@@ -69,6 +71,10 @@ type TTSPlayerSheetProps = {
   ttsLang: string;
   isPlaying: boolean;
   hasTimeline: boolean;
+  // Paired audiobook: the transport skips 30s forward / 15s back through the
+  // recording and moves by audiobook chapter instead of by sentence and
+  // paragraph.
+  audioTransport: boolean;
   timeoutOption: number;
   timeoutTimestamp: number;
   chapterRemainingSec: number | null;
@@ -97,6 +103,7 @@ const TTSPlayerSheet = ({
   ttsLang,
   isPlaying,
   hasTimeline,
+  audioTransport,
   timeoutOption,
   timeoutTimestamp,
   chapterRemainingSec,
@@ -264,6 +271,13 @@ const TTSPlayerSheet = ({
   // vertical space is tight); sub-views keep the back button and their title.
   // Desktop hides the drag handle and has no swipe-to-dismiss, so the main
   // view floats the standard dialog close pill over its top-right corner.
+  // Transport labels by step size: sentence and paragraph for speech, time
+  // skip and audiobook chapter for a paired recording.
+  const prevLargeLabel = audioTransport ? _('Previous Chapter') : _('Previous Paragraph');
+  const prevSmallLabel = audioTransport ? _('Back 15 Seconds') : _('Previous Sentence');
+  const nextSmallLabel = audioTransport ? _('Forward 30 Seconds') : _('Next Sentence');
+  const nextLargeLabel = audioTransport ? _('Next Chapter') : _('Next Paragraph');
+
   const header =
     view === 'main' ? (
       <button
@@ -353,20 +367,28 @@ const TTSPlayerSheet = ({
             <button
               type='button'
               className='rounded-full p-2'
-              title={_('Previous Paragraph')}
-              aria-label={_('Previous Paragraph')}
+              title={prevLargeLabel}
+              aria-label={prevLargeLabel}
               onClick={() => onBackward(false)}
             >
-              <MdKeyboardDoubleArrowLeft size={iconSize24} />
+              {audioTransport ? (
+                <MdSkipPrevious size={iconSize24} />
+              ) : (
+                <MdKeyboardDoubleArrowLeft size={iconSize24} />
+              )}
             </button>
             <button
               type='button'
               className='rounded-full p-2'
-              title={_('Previous Sentence')}
-              aria-label={_('Previous Sentence')}
+              title={prevSmallLabel}
+              aria-label={prevSmallLabel}
               onClick={() => onBackward(true)}
             >
-              <MdKeyboardArrowLeft size={iconSize28} />
+              {audioTransport ? (
+                <RiReplay15Line size={iconSize24} />
+              ) : (
+                <MdKeyboardArrowLeft size={iconSize28} />
+              )}
             </button>
             <button
               type='button'
@@ -379,20 +401,28 @@ const TTSPlayerSheet = ({
             <button
               type='button'
               className='rounded-full p-2'
-              title={_('Next Sentence')}
-              aria-label={_('Next Sentence')}
+              title={nextSmallLabel}
+              aria-label={nextSmallLabel}
               onClick={() => onForward(true)}
             >
-              <MdKeyboardArrowRight size={iconSize28} />
+              {audioTransport ? (
+                <RiForward30Line size={iconSize24} />
+              ) : (
+                <MdKeyboardArrowRight size={iconSize28} />
+              )}
             </button>
             <button
               type='button'
               className='rounded-full p-2'
-              title={_('Next Paragraph')}
-              aria-label={_('Next Paragraph')}
+              title={nextLargeLabel}
+              aria-label={nextLargeLabel}
               onClick={() => onForward(false)}
             >
-              <MdKeyboardDoubleArrowRight size={iconSize24} />
+              {audioTransport ? (
+                <MdSkipNext size={iconSize24} />
+              ) : (
+                <MdKeyboardDoubleArrowRight size={iconSize24} />
+              )}
             </button>
           </div>
           <div className='flex w-full gap-2'>

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -79,6 +79,15 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
   const playbackStateRef = useRef<'playing' | 'paused' | 'stopped'>('stopped');
   const [ttsController, setTtsController] = useState<TTSController | null>(null);
   const [ttsClientsInited, setTtsClientsInitialized] = useState(false);
+  // Whether the transport steps by recording time and audiobook chapter
+  // (paired audiobook) rather than by sentence and paragraph. State, not a
+  // per-render read of the controller: an adopted session flips
+  // ttsClientsInited before its attach resolves, and the mini player would
+  // otherwise keep that first render's sentence labels.
+  const [audioTransport, setAudioTransport] = useState(false);
+  const syncAudioTransport = useCallback(() => {
+    setAudioTransport(ttsControllerRef.current?.usesAudioTransport() ?? false);
+  }, []);
 
   // Broadcast playback transitions on the app-wide bus so consumers that
   // can't read the hook-local isPlaying flag (RSVP, paragraph mode) can react.
@@ -315,6 +324,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
         });
         const speakingLang = controller.getSpeakingLang();
         if (speakingLang) setTtsLang(speakingLang);
+        syncAudioTransport();
       } catch (err) {
         console.warn('TTS session adoption failed:', err);
       } finally {
@@ -892,6 +902,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
         // .playback/.spokenAudio). The old call set .mixWithOthers, which
         // disqualifies the app from Now Playing and fought the claim.
         setTtsClientsInitialized(false);
+        setAudioTransport(false);
 
         // Show the mini player immediately, in the "playing" state: client
         // init below can take a while and the session is conceptually already
@@ -981,6 +992,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
           setIsPlaying(false);
         }
         setTtsClientsInitialized(true);
+        syncAudioTransport();
         setTTSEnabled(bookKey, true);
       } catch (error) {
         setShowIndicator(false);
@@ -1181,6 +1193,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
         } else {
           await ttsController.setVoice(voice, lang);
         }
+        syncAudioTransport();
       }
     }, 3000),
     [],
@@ -1254,6 +1267,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     handleSeekPreview,
     handleGetPlaybackInfo,
     handleSupportsPlaybackInfo,
+    audioTransport,
     refreshTtsLang,
     getController,
   };

--- a/apps/readest-app/src/services/audiobook/AudiobookController.ts
+++ b/apps/readest-app/src/services/audiobook/AudiobookController.ts
@@ -19,9 +19,7 @@ import type { ABSChapter, ABSTrack } from '@/types/audiobookshelf';
 import type { TTSMark } from '@/services/tts/types';
 import { eventDispatcher } from '@/utils/event';
 import { stubTranslation as _ } from '@/utils/misc';
-
-export const SKIP_FORWARD_SEC = 30;
-export const SKIP_BACKWARD_SEC = 15;
+import { SKIP_BACKWARD_SEC, SKIP_FORWARD_SEC } from '@/services/playback/playbackSource';
 
 // How often 'tts-speak-mark' is re-emitted while playing, so the lock-screen
 // position stays honest even when the rate isn't 1 (mirrors the TTS bridge's

--- a/apps/readest-app/src/services/playback/playbackSource.ts
+++ b/apps/readest-app/src/services/playback/playbackSource.ts
@@ -36,6 +36,12 @@ export interface PlaybackInfo {
   measuredFraction: number;
 }
 
+// The transport's time skips, shared by the audiobook player and a paired
+// audiobook read along: a long hop forward, a shorter one back to re-hear the
+// phrase just missed.
+export const SKIP_FORWARD_SEC = 30;
+export const SKIP_BACKWARD_SEC = 15;
+
 /**
  * The narrow surface ttsMediaBridge and TTSSessionManager consume.
  *

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -940,7 +940,8 @@ export class TTSController extends EventTarget {
   // sentence step used to skip a whole chapter. The transport moves by audio
   // instead — the small step is the audiobook player's time skip
   // (SKIP_FORWARD_SEC / SKIP_BACKWARD_SEC of recording), the large step walks
-  // the audiobook's own chapter list (#5863).
+  // the reachable audiobook chapters, those a mapped chapter's clip covers
+  // (#5863).
   usesAudioTransport(): boolean {
     const capabilities = this.ttsClient.getCapabilities();
     return capabilities.mediaClock && capabilities.textHighlight === false;
@@ -1171,11 +1172,12 @@ export class TTSController extends EventTarget {
     return index < 0 ? null : timeline.positionAt(index, seconds - section.pars[index]!.clipBegin);
   }
 
-  // Skip to the adjacent chapter of the audiobook's own chapter list, which is
-  // often finer than the EPUB's. A chapter inside the section already playing
-  // is a plain seek; one narrated by another section navigates there first —
-  // the page turns only when the recording moves to a different mapped
-  // chapter.
+  // Skip to the adjacent reachable audiobook chapter (narratedAudioChapters:
+  // the ones a mapped chapter's clip covers, often finer than the EPUB's TOC;
+  // audio before the first mapped chapter is not among them). A chapter inside
+  // the section already playing is a plain seek; one narrated by another
+  // section navigates there first — the page turns only when the recording
+  // moves to a different mapped chapter.
   async #stepAudioChapter(direction: 1 | -1): Promise<void> {
     await this.initViewTTS();
     await this.ensureTimeline();

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -40,7 +40,14 @@ import {
   MediaOverlayTTS,
   MEDIA_OVERLAY_VOICE_ID,
 } from './mediaOverlay';
-import { findPairedAudiobookSection, loadPairedAudiobookSection } from './pairedAudiobook';
+import {
+  adjacentAudioChapter,
+  findPairedAudiobookSection,
+  loadPairedAudiobookSection,
+  narratedAudioChapters,
+  type NarratedAudioChapter,
+} from './pairedAudiobook';
+import { SKIP_BACKWARD_SEC, SKIP_FORWARD_SEC } from '@/services/playback/playbackSource';
 
 // App-wide monotonic sequence for 'tts-position' events. A fresh TTSController
 // is constructed per `tts-speak`, so a per-instance counter would restart at 0
@@ -928,6 +935,17 @@ export class TTSController extends EventTarget {
     return this.ttsClient.getCapabilities().mediaClock;
   }
 
+  // A recording with chapter-level text timing only (a paired audiobook) has
+  // no sentences or paragraphs to step by: its marks ARE chapters, so the
+  // sentence step used to skip a whole chapter. The transport moves by audio
+  // instead — the small step is the audiobook player's time skip
+  // (SKIP_FORWARD_SEC / SKIP_BACKWARD_SEC of recording), the large step walks
+  // the audiobook's own chapter list (#5863).
+  usesAudioTransport(): boolean {
+    const capabilities = this.ttsClient.getCapabilities();
+    return capabilities.mediaClock && capabilities.textHighlight === false;
+  }
+
   // Whether the active client supports the inter-sentence gap control.
   supportsGapControl(): boolean {
     return this.ttsClient.getCapabilities().gapControl;
@@ -1093,6 +1111,16 @@ export class TTSController extends EventTarget {
     // below; only a stopped session should actually be silenced here.
     await this.stop(isPlaying);
     if (!isPlaying) this.state = 'forward-paused';
+    await this.#resumeAt(target, range, isPlaying);
+  }
+
+  // Continue (or park a paused session) at a timeline target once the current
+  // utterance has been stopped.
+  async #resumeAt(
+    target: { index: number; withinMediaSec: number },
+    range: Range,
+    isPlaying: boolean,
+  ): Promise<void> {
     this.#currentSentenceIndex = target.index;
     const ssml = this.#getTts()?.from(range);
     if (this.ttsClient.getCapabilities().textHighlight === false) {
@@ -1100,6 +1128,85 @@ export class TTSController extends EventTarget {
     }
     await this.#handleNavigationWithSSML(ssml, isPlaying);
     if (!isPlaying) this.reapplyCurrentHighlight();
+  }
+
+  // Move through the recording by a span of recording seconds. The timeline
+  // counts seconds at the playback rate, so the span is scaled back first.
+  async #seekBy(seconds: number): Promise<void> {
+    await this.initViewTTS();
+    await this.ensureTimeline();
+    const info = this.getPlaybackInfo();
+    if (!info) return;
+    await this.seekToTime(info.position + seconds / this.ttsRate);
+  }
+
+  // The recording position now sounding: the clip of the current mark plus
+  // the clock's offset into it.
+  #narrationPosition(): { audioHref: string; seconds: number } | null {
+    const timeline = this.#sectionTimeline;
+    const section = this.#mediaOverlaySection;
+    if (!timeline || !section || this.#timelineSectionIndex !== this.#ttsSectionIndex) return null;
+    let index = this.#currentSentenceIndex;
+    if (index < 0) {
+      const range = this.#getTts()?.getLastRange();
+      index = range ? timeline.indexOfRange(range) : -1;
+    }
+    const par = section.pars[index];
+    if (!par) return null;
+    return {
+      audioHref: par.audioHref,
+      seconds: par.clipBegin + (this.ttsClient.getChunkPosition?.() ?? 0),
+    };
+  }
+
+  // Timeline seconds of a recording position inside the current section, or
+  // null when no clip of the section plays it.
+  #sectionTimeAt(audioHref: string, seconds: number): number | null {
+    const timeline = this.#sectionTimeline;
+    const section = this.#mediaOverlaySection;
+    if (!timeline || !section) return null;
+    const index = section.pars.findIndex(
+      (par) => par.audioHref === audioHref && par.clipBegin <= seconds && seconds < par.clipEnd,
+    );
+    return index < 0 ? null : timeline.positionAt(index, seconds - section.pars[index]!.clipBegin);
+  }
+
+  // Skip to the adjacent chapter of the audiobook's own chapter list, which is
+  // often finer than the EPUB's. A chapter inside the section already playing
+  // is a plain seek; one narrated by another section navigates there first —
+  // the page turns only when the recording moves to a different mapped
+  // chapter.
+  async #stepAudioChapter(direction: 1 | -1): Promise<void> {
+    await this.initViewTTS();
+    await this.ensureTimeline();
+    const association = this.#pairedAudiobook;
+    const current = this.#narrationPosition();
+    if (!association || !current) return;
+    const chapters = narratedAudioChapters(this.view.book, association);
+    const target = adjacentAudioChapter(chapters, current.audioHref, current.seconds, direction);
+    if (!target) return;
+    if (target.sectionIndex === this.#ttsSectionIndex) {
+      const seconds = this.#sectionTimeAt(target.audioHref, target.chapter.start);
+      if (seconds !== null) await this.seekToTime(seconds);
+      return;
+    }
+    const isPlaying = this.state === 'playing';
+    await this.stop(isPlaying);
+    if (!isPlaying) this.state = direction > 0 ? 'forward-paused' : 'backward-paused';
+    if (!(await this.#initTTSForSection(target.sectionIndex))) return;
+    await this.#startSectionAt(target, isPlaying);
+  }
+
+  async #startSectionAt(target: NarratedAudioChapter, isPlaying: boolean): Promise<void> {
+    const timeline = await this.ensureTimeline();
+    const seconds = this.#sectionTimeAt(target.audioHref, target.chapter.start);
+    const located = seconds === null ? null : timeline?.sentenceAtTime(seconds);
+    if (!located) {
+      await this.#handleNavigationWithSSML(this.#getTts()?.start(), isPlaying);
+      return;
+    }
+    const range = this.#rangeAtSeekTarget(located.sentence, located.withinMediaSec);
+    await this.#resumeAt(located, range, isPlaying);
   }
 
   async #initTTSForNextSection(): Promise<boolean> {
@@ -1444,6 +1551,11 @@ export class TTSController extends EventTarget {
 
   // goto previous mark/paragraph
   async backward(byMark = false) {
+    if (this.usesAudioTransport()) {
+      if (byMark) await this.#seekBy(-SKIP_BACKWARD_SEC);
+      else await this.#stepAudioChapter(-1);
+      return;
+    }
     await this.initViewTTS();
     const isPlaying = this.state === 'playing';
     // While playing, this is a handover to the utterance about to be spoken
@@ -1466,6 +1578,11 @@ export class TTSController extends EventTarget {
   // skip ahead and getting playback stopped instead is the opposite of the
   // request, and on the lock screen there is no obvious way to recover.
   async forward(byMark = false, isAutoAdvance = false) {
+    if (!isAutoAdvance && this.usesAudioTransport()) {
+      if (byMark) await this.#seekBy(SKIP_FORWARD_SEC);
+      else await this.#stepAudioChapter(1);
+      return;
+    }
     await this.initViewTTS();
     const isPlaying = this.state === 'playing';
     // While playing, this is a handover to the utterance about to be spoken

--- a/apps/readest-app/src/services/tts/pairedAudiobook.ts
+++ b/apps/readest-app/src/services/tts/pairedAudiobook.ts
@@ -31,6 +31,32 @@ const sectionIndexForHref = (book: BookDoc, href: string): number => {
   );
 };
 
+// The recording a mapped audio chapter owns: its own span plus the unmapped
+// chapters that follow it in the same file, up to the next mapped chapter.
+// Audiobook chapter lists are routinely finer than the EPUB's TOC (1, 1.1,
+// 1.2, 2 ...), and a sub-chapter nobody could map is still part of the chapter
+// it follows; without this the recording skipped straight over it (#5863).
+// Chapters before the first mapped one in a file have nothing to attach to and
+// stay unplayed, as do gaps between chapters.
+const mappedAudioSpans = (
+  association: PairedAudiobook,
+): Map<string, { start: number; end: number }> => {
+  const mapped = new Set(association.mappings.map((mapping) => mapping.audioChapterId));
+  const spans = new Map<string, { start: number; end: number }>();
+  const ownerByFile = new Map<string, { start: number; end: number }>();
+  for (const chapter of association.chapters) {
+    if (mapped.has(chapter.id)) {
+      const span = { start: chapter.start, end: chapter.end };
+      spans.set(chapter.id, span);
+      ownerByFile.set(chapter.fileId, span);
+      continue;
+    }
+    const owner = ownerByFile.get(chapter.fileId);
+    if (owner) owner.end = Math.max(owner.end, chapter.end);
+  }
+  return spans;
+};
+
 const pairedChapterEntries = (
   book: BookDoc,
   association: PairedAudiobook,
@@ -48,6 +74,7 @@ const pairedChapterEntries = (
   visit(book.toc ?? []);
 
   const chapterById = new Map(association.chapters.map((chapter) => [chapter.id, chapter]));
+  const spans = mappedAudioSpans(association);
   const fileById = new Map(association.files.map((file) => [file.id, file]));
   const mappingByEbook = new Map(
     association.mappings.map((mapping) => [mapping.ebookChapterId, mapping.audioChapterId]),
@@ -79,13 +106,14 @@ const pairedChapterEntries = (
     }
 
     const run = candidates.slice(index, end);
-    const duration = first.audioChapter.end - first.audioChapter.start;
+    const span = spans.get(first.audioChapter.id)!;
+    const duration = span.end - span.start;
     for (const [runIndex, candidate] of run.entries()) {
       // A chapter-only pairing has no finer timing signal. Divide one reused
       // clip into equal chapter slices so a run can cross spine documents
       // without replaying the whole recording at every section boundary.
-      const clipBegin = first.audioChapter.start + (duration * runIndex) / run.length;
-      const clipEnd = first.audioChapter.start + (duration * (runIndex + 1)) / run.length;
+      const clipBegin = span.start + (duration * runIndex) / run.length;
+      const clipEnd = span.start + (duration * (runIndex + 1)) / run.length;
       const previous = entries.at(-1);
       if (
         previous?.audioChapter.id === candidate.audioChapter.id &&
@@ -173,6 +201,59 @@ const chapterRange = (
     return null;
   }
   return range.collapsed ? null : range;
+};
+
+export interface NarratedAudioChapter {
+  chapter: AudiobookChapter;
+  // The file holding it, as NarrationPar.audioHref names it.
+  audioHref: string;
+  // The spine section whose narration plays it.
+  sectionIndex: number;
+}
+
+// Every audio chapter playback can reach, in recording order. Unmapped
+// chapters count when a mapped chapter's span absorbed them; the ones nothing
+// owns are left out.
+export const narratedAudioChapters = (
+  book: BookDoc,
+  association: PairedAudiobook,
+): NarratedAudioChapter[] => {
+  const entries = pairedChapterEntries(book, association);
+  const fileById = new Map(association.files.map((file) => [file.id, file]));
+  const chapters: NarratedAudioChapter[] = [];
+  for (const chapter of association.chapters) {
+    const audioHref = fileById.get(chapter.fileId)?.path;
+    const entry = entries.find(
+      (candidate) =>
+        candidate.audioFile.path === audioHref &&
+        candidate.clipBegin <= chapter.start &&
+        chapter.start < candidate.clipEnd,
+    );
+    if (!audioHref || !entry) continue;
+    chapters.push({ chapter, audioHref, sectionIndex: entry.sectionIndex });
+  }
+  return chapters;
+};
+
+// Backward this far into a chapter restarts it rather than leaving it, the
+// convention every audiobook player follows.
+const CHAPTER_RESTART_SEC = 3;
+
+// Where a chapter skip lands from `seconds` into the file at `audioHref`.
+export const adjacentAudioChapter = (
+  chapters: NarratedAudioChapter[],
+  audioHref: string,
+  seconds: number,
+  direction: 1 | -1,
+): NarratedAudioChapter | null => {
+  let current = -1;
+  for (const [index, entry] of chapters.entries()) {
+    if (entry.audioHref === audioHref && entry.chapter.start <= seconds) current = index;
+  }
+  if (current < 0) return null;
+  if (direction > 0) return chapters[current + 1] ?? null;
+  if (seconds - chapters[current]!.chapter.start > CHAPTER_RESTART_SEC) return chapters[current]!;
+  return chapters[current - 1] ?? null;
 };
 
 export const findPairedAudiobookSection = (

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -72,7 +72,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoRoot = "../..";
-  cargoHash = "sha256-pfvmFPlbKutP+vLfnf6WRM+fhtjTH3pexVruCYQcRHY=";
+  cargoHash = "sha256-a3KVOqYsO1LQF1D0Maxrq9MsLgjYQFgyU0oemn4Xkn0=";
 
   buildAndTestSubdir = "src-tauri";
 


### PR DESCRIPTION
Closes #5863.

Feedback on the Audiobookshelf read-along (#5807): when the audiobook's chapter list is finer than the EPUB's (Chapter 1, 1.1, 1.2, 2 ...), the unmatched sub-chapters were never heard and "Next Sentence" jumped a whole chapter. Item 1 in the issue (page turns while scrubbing) is the intended best-effort sync and is unchanged; this PR covers item 2 and the WebP thumbnail warning.

## What was wrong

- **Unmatched sub-chapters were skipped.** A paired audiobook builds one narration clip per *mapped* EPUB chapter, spanning only that audio chapter. An audio chapter with no TOC entry to map to belonged to no clip, so playback ran from the end of Chapter 1's clip straight into Chapter 2's and 1.1/1.2 were never played.
- **The sentence step was a chapter step.** With chapter-level text timing the narration marks *are* chapters, so the Next/Previous Sentence buttons, the keyboard shortcuts, and the lock screen's seek actions all skipped to the next mapped chapter. That is the "unexpected jumping" in the report.
- **WebP covers could not be thumbnailed.** The Rust `image` crate was built with only jpeg/png/gif. The parser falls back to writing a cover it cannot decode verbatim as `cover.png`, so a WebP cover then failed again in the thumbnailer with `The image format WebP is not supported`.

## What changed

- **Unmapped audio chapters attach to the mapped chapter before them** (`pairedAudiobook.ts`). A mapped chapter's clip now runs through the unmapped chapters that follow it in the same file, up to the next mapped chapter, so the recording is heard in full and the page keeps following it proportionally. Audio before the first mapped chapter of a file (opening credits) stays unplayed, as do gaps.
- **Paired audiobooks move by audio** (`TTSController`). `usesAudioTransport()` is capability-gated (`mediaClock` without `textHighlight`), never on client identity. In that mode `forward`/`backward(byMark)` become the audiobook player's skip, 30 seconds forward and 15 back in recording time whatever the rate, and next/previous chapter over the reachable audiobook chapters, the ones a mapped chapter's clip covers, so audio before the first mapped chapter stays out of reach (backward more than 3 s into a chapter restarts it). The page turns only when the target chapter is narrated by another mapped chapter; a sub-chapter inside the current one is a seek within its text span. Auto-advance is untouched, and `ttsMediaBridge`'s `seekforward`/`nexttrack` handlers get the new behaviour without changes. The skip constants move to the `PlaybackSource` seam so both players share them.
- **Mini player and player sheet** show the player's glyphs and the existing "Back 15 Seconds" / "Forward 30 Seconds" / "Previous/Next Chapter" labels for a paired audiobook (no new locale keys). The mode is hook state synced after init, after an adopted session attaches, and after a voice change; a per-render read left the mini player on its first-render sentence labels on device.
- **WebP decoding** via the `image` crate's pure-Rust `webp` feature (`image-webp` added to Cargo.lock).
- `docs/read-along-narration.md` documents both behaviours.

One trade-off to be aware of: an audio chapter deliberately left unmapped because it is not in the EPUB (a bonus track between chapters) now plays as the previous chapter's tail instead of being skipped. The wizard has no separate "ignore" state; if that matters we can add one.

## Testing

- `pnpm test` (10068 tests), `pnpm lint`, `pnpm format:check`, `pnpm fmt:check`, `pnpm clippy:check`, `pnpm test:rust` all green. New tests cover the absorbed spans and reachable-chapter list, the adjacent-chapter rule, the transport branch in the controller (skip amounts at rate 1 and 2, same-section seek vs. cross-section navigation, auto-advance unaffected), the two surfaces' labels and callbacks, and a WebP fixture that reproduced the exact log line before the feature flag.
- Verified on an Onyx Boox Leaf5 (Android 13, release build) against a live Audiobookshelf server: paired Alice with EPUB Chapter 2 left without audio so audio chapter 02 is an unmatched chapter; the mini player and sheet show the chapter/15/30 controls; +30 and -15 move the native position by exactly that much; Next Chapter does one section transition per tap (page turn only into a mapped chapter); Previous Chapter restarts the current chapter when more than a few seconds in; seeking across a chapter boundary yields exactly one transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paired audiobook playback now supports 15-second rewind, 30-second skip-forward, and previous/next chapter navigation.
  * Lock-screen and media controls follow audiobook chapter behavior.
  * Unmapped audio chapters are included with the mapped chapter they follow.
* **Bug Fixes**
  * Improved paired audiobook chapter transitions and automatic advancement.
  * Added support for thumbnails from lossless WebP cover images.
* **Documentation**
  * Updated read-along documentation to explain audiobook transport and chapter mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->