### PR TITLE
fix(sync): stop OPDS re-downloads from losing reading progress (#5859)

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useProgressAutoSave.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useProgressAutoSave.test.tsx
@@ -71,16 +71,40 @@ const flushDebouncedSave = async () => {
   });
 };
 
+const setVisibility = (state: 'visible' | 'hidden') => {
+  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+};
+
+// Simulate the app losing the foreground (power button / HOME / app switch)
+// WITHOUT advancing the debounce timers — the whole point is that the save
+// must land before the ~1.5s debounce would have fired.
+const backgroundApp = async () => {
+  await act(async () => {
+    setVisibility('hidden');
+    document.dispatchEvent(new Event('visibilitychange'));
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+  });
+};
+
+const firePageHide = async () => {
+  await act(async () => {
+    window.dispatchEvent(new Event('pagehide'));
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+  });
+};
+
 beforeEach(() => {
   vi.useFakeTimers();
   h.saveConfigMock.mockClear();
   h.state.config = { location: 'cfi-loc', updatedAt: 1000 };
   h.state.progress = { location: 'cfi-loc' };
   h.state.previewMode = false;
+  setVisibility('visible');
 });
 
 afterEach(() => {
   vi.useRealTimers();
+  setVisibility('visible');
   cleanup();
 });
 
@@ -136,6 +160,74 @@ describe('useProgressAutoSave', () => {
     h.state.progress = { location: 'cfi-different' };
     renderHook(() => useProgressAutoSave('h1-view1'));
     await flushDebouncedSave();
+
+    expect(h.saveConfigMock).not.toHaveBeenCalled();
+  });
+
+  test('persists immediately when the app is backgrounded, before the debounce fires', async () => {
+    // Issue #5859: on Android (worst on Boox e-ink) the app is frozen/killed
+    // in the background well inside the ~1.5s save debounce, and no close event
+    // fires on sleep/HOME/kill — only visibilitychange. The last page turn must
+    // be written to disk the moment we lose the foreground.
+    const { rerender } = renderHook(() => useProgressAutoSave('h1-view1'));
+    await flushDebouncedSave();
+    expect(h.saveConfigMock).not.toHaveBeenCalled();
+
+    // User turns a page; the debounce is now pending but has NOT fired.
+    h.state.config = { location: 'cfi-loc-next', updatedAt: 1000 };
+    h.state.progress = { location: 'cfi-loc-next' };
+    rerender();
+
+    // Background the app without advancing any timers.
+    await backgroundApp();
+
+    expect(h.saveConfigMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('persists on pagehide (webview teardown / reload)', async () => {
+    const { rerender } = renderHook(() => useProgressAutoSave('h1-view1'));
+    await flushDebouncedSave();
+
+    h.state.config = { location: 'cfi-loc-next', updatedAt: 1000 };
+    h.state.progress = { location: 'cfi-loc-next' };
+    rerender();
+
+    await firePageHide();
+
+    expect(h.saveConfigMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not double-write: a debounced save then a background flush persists once', async () => {
+    const { rerender } = renderHook(() => useProgressAutoSave('h1-view1'));
+    await flushDebouncedSave();
+
+    h.state.config = { location: 'cfi-loc-next', updatedAt: 1000 };
+    h.state.progress = { location: 'cfi-loc-next' };
+    rerender();
+    await flushDebouncedSave(); // debounce lands first
+    expect(h.saveConfigMock).toHaveBeenCalledTimes(1);
+
+    await backgroundApp(); // nothing new to write
+    expect(h.saveConfigMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not persist on background when nothing moved since open (issue #4222 guard)', async () => {
+    renderHook(() => useProgressAutoSave('h1-view1'));
+    await flushDebouncedSave();
+
+    await backgroundApp();
+
+    expect(h.saveConfigMock).not.toHaveBeenCalled();
+  });
+
+  test('skips background flush while in preview mode', async () => {
+    h.state.previewMode = true;
+    h.state.config = { location: 'cfi-different', updatedAt: 1000 };
+    h.state.progress = { location: 'cfi-different' };
+    renderHook(() => useProgressAutoSave('h1-view1'));
+    await flushDebouncedSave();
+
+    await backgroundApp();
 
     expect(h.saveConfigMock).not.toHaveBeenCalled();
   });

--- a/apps/readest-app/src/__tests__/services/opds-auto-download.test.ts
+++ b/apps/readest-app/src/__tests__/services/opds-auto-download.test.ts
@@ -33,6 +33,7 @@ vi.mock('@/services/opds/feedChecker', () => ({
 
 vi.mock('@/services/opds/sourceMap', () => ({
   upsertOPDSSourceMapping: vi.fn().mockResolvedValue(undefined),
+  findBookByOPDSSources: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@/services/opds/cover', () => ({

--- a/apps/readest-app/src/__tests__/services/opds-reimport-config-reset.test.ts
+++ b/apps/readest-app/src/__tests__/services/opds-reimport-config-reset.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Book, BookConfig } from '@/types/book';
+
+// Reproduction for issue #5859: the OPDS auto-download re-import path.
+// `syncCatalog` -> `downloadAndImport` -> `appService.importBook(path, books)`.
+// The question: when auto-download fetches a book that is already in the
+// library, can the re-import leave the book at INIT_BOOK_CONFIG (page one)
+// and strand the reading progress? This drives the REAL bookService.importBook
+// through the four shapes a re-download can take and observes the config each
+// one writes.
+
+const mockOpen = vi.hoisted(() => vi.fn());
+const mockPartialMD5 = vi.hoisted(() => vi.fn());
+
+vi.mock('@/utils/md5', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/md5')>('@/utils/md5');
+  return { ...actual, partialMD5: mockPartialMD5 };
+});
+
+vi.mock('@/libs/document', async () => {
+  const actual = await vi.importActual<typeof import('@/libs/document')>('@/libs/document');
+  class MockDocumentLoader {
+    open() {
+      return mockOpen();
+    }
+  }
+  return { ...actual, DocumentLoader: MockDocumentLoader };
+});
+
+vi.mock('@/utils/txt', () => ({ TxtToEpubConverter: vi.fn() }));
+vi.mock('@/utils/svg', () => ({ svg2png: vi.fn() }));
+vi.mock('@tauri-apps/plugin-http', () => ({ fetch: vi.fn() }));
+vi.mock('@/libs/storage', () => ({
+  downloadFile: vi.fn(),
+  uploadFile: vi.fn(),
+  deleteFile: vi.fn(),
+  createProgressHandler: vi.fn(),
+  batchGetDownloadUrls: vi.fn(),
+}));
+
+import { BaseAppService } from '@/services/appService';
+
+// Models a tiny in-memory Books/ tree: config.json files keyed by their path.
+// fs.exists / fs.readFile / fs.writeFile all go through it so state carries
+// across the two imports the way a real re-download would see it.
+let disk: Map<string, string>;
+
+class TestAppService extends BaseAppService {
+  protected fs = {
+    openFile: vi.fn(),
+    readFile: vi.fn(async (path: string) => disk.get(path) ?? '{}'),
+    writeFile: vi.fn(async (path: string, _base: unknown, content: string) => {
+      if (typeof content === 'string') disk.set(path, content);
+    }),
+    copyFile: vi.fn(),
+    removeFile: vi.fn(),
+    readDir: vi.fn(),
+    createDir: vi.fn(),
+    removeDir: vi.fn(async (dir: string) => {
+      // Directory retirement: drop that hash dir's config from the tree.
+      for (const key of [...disk.keys()]) if (key.startsWith(`${dir}/`)) disk.delete(key);
+    }),
+    exists: vi.fn(async (path: string) => {
+      if (path.endsWith('/config.json')) return disk.has(path);
+      return false;
+    }),
+    stats: vi.fn(),
+    resolvePath: vi.fn(),
+    getURL: vi.fn(),
+    getBlobURL: vi.fn().mockResolvedValue(''),
+    getImageURL: vi.fn(),
+    getPrefix: vi.fn(),
+  };
+
+  protected resolvePath() {
+    return { baseDir: 0, basePrefix: async () => '', fp: '', base: 'Books' as const };
+  }
+
+  async init() {}
+  async setCustomRootDir() {}
+  async selectDirectory() {
+    return '';
+  }
+  async selectFiles() {
+    return [];
+  }
+  async saveFile() {
+    return false;
+  }
+  async saveImageToGallery() {
+    return false;
+  }
+  async ask() {
+    return false;
+  }
+  async openDatabase() {
+    return {} as ReturnType<BaseAppService['openDatabase']>;
+  }
+  async createWindow() {}
+  async getCacheDir() {
+    return '';
+  }
+  async clearWebviewCache() {}
+  async showNotification() {}
+
+  getFs() {
+    return this.fs;
+  }
+}
+
+const META = { title: 'The Trap', author: 'Dorothy M. Richardson', language: 'en' };
+
+const setMeta = (metadata: Record<string, unknown>) => {
+  mockOpen.mockResolvedValue({
+    book: { metadata, getCover: vi.fn().mockResolvedValue(null) },
+    format: 'EPUB',
+  });
+};
+
+const importOnce = async (
+  service: TestAppService,
+  books: Book[],
+  hash: string,
+  metadata: Record<string, unknown>,
+) => {
+  mockPartialMD5.mockResolvedValue(hash);
+  setMeta(metadata);
+  return service.importBook(
+    new File(['bytes'], 'the-trap.epub', { type: 'application/epub+zip' }),
+    books,
+  );
+};
+
+// The reader wrote real progress into this hash's config after the first import.
+const writeProgress = (hash: string) => {
+  disk.set(
+    `${hash}/config.json`,
+    JSON.stringify({
+      schemaVersion: 1,
+      updatedAt: 2_000_000,
+      location: 'epubcfi(/6/16!/4,/920,/936/1:819)',
+      progress: [201, 240],
+    } satisfies Partial<BookConfig>),
+  );
+};
+
+const configOf = (hash: string): Partial<BookConfig> | null => {
+  const raw = disk.get(`${hash}/config.json`);
+  return raw ? (JSON.parse(raw) as Partial<BookConfig>) : null;
+};
+
+const isInitConfig = (hash: string) => {
+  const c = configOf(hash);
+  return !!c && !c.location && c.progress == null && (c.updatedAt ?? 0) === 0;
+};
+
+describe('OPDS auto-download re-import — can it reset a read book to INIT_BOOK_CONFIG? (#5859)', () => {
+  let service: TestAppService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    disk = new Map();
+    service = new TestAppService();
+    const fs = service.getFs();
+    fs.createDir.mockResolvedValue(undefined);
+  });
+
+  it('CONTROL: identical re-download (same bytes) keeps the reading progress', async () => {
+    const books: Book[] = [];
+    await importOnce(service, books, 'H1', META); // first download
+    writeProgress('H1'); // user reads
+
+    await importOnce(service, books, 'H1', META); // auto-download fetches the same file
+
+    expect(configOf('H1')?.location).toBeTruthy();
+    expect(isInitConfig('H1')).toBe(false);
+  });
+
+  it('same metaHash, different bytes, old config present: progress migrates (no reset)', async () => {
+    const books: Book[] = [];
+    await importOnce(service, books, 'H1', META);
+    writeProgress('H1');
+
+    // calibre re-compresses -> different file hash, identical metadata.
+    await importOnce(service, books, 'H2', META);
+
+    // Progress should have moved to the new hash, not been reset.
+    expect(configOf('H2')?.location).toBeTruthy();
+    expect(isInitConfig('H2')).toBe(false);
+  });
+
+  it('RESET: re-download with changed metadata (new metaHash) lands a fresh INIT copy', async () => {
+    const books: Book[] = [];
+    await importOnce(service, books, 'H1', META);
+    writeProgress('H1');
+
+    // The feed serves an edition whose metadata differs (Standard Ebooks bump,
+    // an added subtitle/identifier, a calibre metadata edit) -> new metaHash.
+    await importOnce(service, books, 'H2', { ...META, title: 'The Trap (Revised)' });
+
+    // A brand-new book at page one, while the read copy is stranded.
+    expect(isInitConfig('H2')).toBe(true);
+    const live = books.filter((b) => !b.deletedAt);
+    expect(live.length).toBe(2); // duplicate created
+  });
+
+  it('RESET: same metaHash, different bytes, but the old config is gone -> INIT', async () => {
+    const books: Book[] = [];
+    await importOnce(service, books, 'H1', META);
+    writeProgress('H1');
+    // Old config vanished (a prior migration retired the dir, a lost write, etc.)
+    disk.delete('H1/config.json');
+
+    await importOnce(service, books, 'H2', META);
+
+    expect(isInitConfig('H2')).toBe(true);
+  });
+});

--- a/apps/readest-app/src/app/reader/hooks/useProgressAutoSave.ts
+++ b/apps/readest-app/src/app/reader/hooks/useProgressAutoSave.ts
@@ -23,25 +23,40 @@ export const useProgressAutoSave = (bookKey: string) => {
   const lastSavedLocationRef = useRef<string | null>(null);
   const initializedRef = useRef(false);
 
+  // The actual disk write for this book's reading position. Guarded so the
+  // initial relocate and no-op saves don't bump config.updatedAt (#4222).
+  // Shared by the debounced auto-save and the on-hide flush below so both
+  // apply the same guard and neither can double-write (lastSavedLocationRef
+  // makes a second call with an unchanged location a no-op).
+  const persistProgress = useCallback(async () => {
+    // Skip while previewing a deep-link target — the user's actual
+    // last-read position should not be overwritten by a transient view.
+    if (useReaderStore.getState().getViewState(bookKey)?.previewMode) return;
+    const config = getConfig(bookKey);
+    if (!config) return;
+    const currentLocation = config.location ?? null;
+    if (!initializedRef.current) {
+      initializedRef.current = true;
+      lastSavedLocationRef.current = currentLocation;
+      return;
+    }
+    if (currentLocation === lastSavedLocationRef.current) return;
+    const settings = useSettingsStore.getState().settings;
+    await saveConfig(envConfig, bookKey, config, settings);
+    lastSavedLocationRef.current = currentLocation;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bookKey]);
+
+  // Stable ref so the debounced closure and the hide listener (both created
+  // once) always call the latest persist fn without being recreated.
+  const persistProgressRef = useRef(persistProgress);
+  persistProgressRef.current = persistProgress;
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const saveBookConfig = useCallback(
     debounce(() => {
-      setTimeout(async () => {
-        // Skip while previewing a deep-link target — the user's actual
-        // last-read position should not be overwritten by a transient view.
-        if (useReaderStore.getState().getViewState(bookKey)?.previewMode) return;
-        const config = getConfig(bookKey);
-        if (!config) return;
-        const currentLocation = config.location ?? null;
-        if (!initializedRef.current) {
-          initializedRef.current = true;
-          lastSavedLocationRef.current = currentLocation;
-          return;
-        }
-        if (currentLocation === lastSavedLocationRef.current) return;
-        const settings = useSettingsStore.getState().settings;
-        await saveConfig(envConfig, bookKey, config, settings);
-        lastSavedLocationRef.current = currentLocation;
+      setTimeout(() => {
+        void persistProgressRef.current();
       }, 500);
     }, 1000),
     [],
@@ -64,6 +79,31 @@ export const useProgressAutoSave = (bookKey: string) => {
     saveBookConfig();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [progress, bookKey]);
+
+  // The debounced save above lands ~1.5s after the last page turn, but Android
+  // freezes and kills a backgrounded WebView well inside that window (Boox
+  // e-ink power management is especially aggressive, and hidden-tab timers are
+  // throttled). None of the graceful-close paths (beforeunload / quit-app /
+  // the book-close save) fire on sleep, HOME, or a background kill — only
+  // `visibilitychange`. So persist the position the moment we lose the
+  // foreground, bypassing the debounce, so the last turns survive the kill and
+  // the reader doesn't reopen a few pages back (issue #5859). `pagehide`
+  // covers webview teardown / reload. In-memory config is already current here:
+  // FoliateViewer commits the relocate synchronously once the page is hidden.
+  useEffect(() => {
+    const flush = () => {
+      void persistProgressRef.current();
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') flush();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    window.addEventListener('pagehide', flush);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('pagehide', flush);
+    };
+  }, []);
 
   // On unmount (book closed / navigated away), flush any pending throttled
   // library.json write so the shelf reflects this session's last read

--- a/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useProgressSync.ts
@@ -33,6 +33,12 @@ const getConfigFraction = (config: BookConfig): number | undefined => {
   return Number.isFinite(fraction) ? Math.min(fraction, 1) : undefined;
 };
 
+// A sibling copy's reading fraction must beat the local position by this margin
+// before we jump to it, so re-pagination jitter between re-packaged copies of
+// the same book (same metaHash, different book_hash) doesn't ping-pong the
+// reader on every open (#5859).
+const SIBLING_FORWARD_EPSILON = 0.002;
+
 export const useProgressSync = (bookKey: string) => {
   const _ = useTranslation();
   // Per-field selectors avoid subscribing this hook's host (FoliateViewer)
@@ -224,90 +230,119 @@ export const useProgressSync = (bookKey: string) => {
 
     const bookHash = bookKey.split('-')[0]!;
     const metaHash = book.metaHash;
-    let syncedConfig = syncedConfigs.filter(
-      (c) => c.bookHash === bookHash || c.metaHash === metaHash,
-    )[0];
+    // OPDS re-downloads mint a NEW book_hash for a re-packaged-but-identical
+    // file, so the cloud accumulates several configs for one book: the exact
+    // same-book_hash config plus same-metaHash SIBLINGS from other hashes.
+    // Reconcile them like importBook's mergeBooks — furthest position wins — but
+    // by PROVENANCE: only the same-hash config's CFI/xpointer resolve correctly
+    // in THIS file; a sibling's CFI belongs to a different-bytes file and can
+    // silently mis-resolve to a section start ("reset to page one", #5859), so a
+    // sibling may contribute only its reading FRACTION, forward-only. Picking
+    // the first match blindly is what let a stale/cross-file config move the
+    // reader backward.
+    const matches = syncedConfigs.filter((c) => c.bookHash === bookHash || c.metaHash === metaHash);
+    // Base config for the device-agnostic viewSettings merge below (proofread
+    // rules, reference page count). Prefer the exact same-file config.
+    const syncedConfig = matches.find((c) => c.bookHash === bookHash) ?? matches[0];
     if (syncedConfig) {
-      // Discard a malformed synced location (an empty-start/end range CFI left by
-      // the cfi-inert skip-link bug, e.g. `epubcfi(/6/24!/4,,/20/1:58)`) so it
-      // can't move the reader or be persisted — it resolves to a section-spanning
-      // range and jumps to the wrong end of the section. A valid xpointer below
-      // can still recover the real position.
-      if (syncedConfig.location && isMalformedLocationCfi(syncedConfig.location)) {
-        syncedConfig = { ...syncedConfig, location: undefined };
-      }
-      const configCFI = config?.location;
-      let remoteCFILocation = syncedConfig.location;
-      const xpointer = syncedConfig.xpointer;
       const bookData = getBookData(bookKey);
       const view = getView(bookKey);
-      // The Readest KOReader plugin pushes `progress` + `xpointer` and never a
-      // `location`, so its [page, total] is CREngine's own pagination. That
-      // doubles as the anchor that corrects CREngine<->foliate DocFragment
-      // drift and as the last-resort target when the XPointer won't convert.
-      // A config that carries a CFI came from Readest, whose [page, total] is
-      // foliate's pagination and whose xpointer was derived from that same
-      // CFI — re-anchoring on it would only move the target off (#5109).
-      const remoteFraction = syncedConfig.location ? undefined : getConfigFraction(syncedConfig);
-      let xpointerUnresolved = false;
-      if (xpointer && view && bookData && bookData.bookDoc) {
-        const pContents = view.renderer.getContents();
-        const pIdx = view.renderer.primaryIndex;
-        const content = pContents.find((x) => x.index === pIdx) ?? pContents[0];
-        try {
-          const candidateCFI = await getCFIFromXPointer(
-            xpointer,
-            content?.doc,
-            content?.index,
-            bookData.bookDoc,
-            remoteFraction,
-          );
-          if (!remoteCFILocation || CFI.compare(remoteCFILocation, candidateCFI) < 0) {
-            remoteCFILocation = candidateCFI;
-          }
-        } catch (error) {
-          // Never let one unconvertible XPointer reject the whole pull — the
-          // proofread merge below still has to run, and swallowing the rest
-          // silently is what let the debounced auto-push overwrite a newer
-          // remote position with the local one (#5625).
-          console.warn('Failed to convert XPointer to CFI', error);
-          xpointerUnresolved = true;
-        }
+      const isPreviewing = () =>
+        useReaderStore.getState().getViewState(bookKey)?.previewMode ?? false;
+      const announceSynced = () => {
+        setHoveredBookKey(null);
+        eventDispatcher.dispatch('hint', { bookKey, message: _('Reading Progress Synced') });
+      };
+
+      // The exact same-file config; its CFI/xpointer are valid in this document.
+      let exactConfig = syncedConfig.bookHash === bookHash ? syncedConfig : undefined;
+      // Discard a malformed synced location (an empty-start/end range CFI left by
+      // the cfi-inert skip-link bug, e.g. `epubcfi(/6/24!/4,,/20/1:58)`) so it
+      // can't move the reader or be persisted — a valid xpointer below can still
+      // recover the real position.
+      if (exactConfig?.location && isMalformedLocationCfi(exactConfig.location)) {
+        exactConfig = { ...exactConfig, location: undefined };
       }
-      // Reading progress applies below. Proofread (find/replace) rules merge
-      // separately just after; other config fields remain device-local.
-      // TODO: general config sync via a more robust profile-based solution.
-      if (remoteCFILocation && configCFI) {
-        if (CFI.compare(configCFI, remoteCFILocation) < 0) {
+      // Furthest reading fraction among sibling copies (same metaHash, different
+      // book_hash). progress[0]/progress[1] compares across re-packaged copies
+      // of the same work; a CFI does not.
+      const siblingFraction = matches
+        .filter((c) => c.bookHash !== bookHash)
+        .reduce((best, c) => Math.max(best, getConfigFraction(c) ?? 0), 0);
+      const exactFraction = exactConfig ? (getConfigFraction(exactConfig) ?? 0) : 0;
+      const localFraction = getBookProgress(bookKey)?.fraction ?? getConfigFraction(config) ?? 0;
+
+      if (
+        view &&
+        !isPreviewing() &&
+        siblingFraction > exactFraction &&
+        siblingFraction > localFraction + SIBLING_FORWARD_EPSILON
+      ) {
+        // A sibling copy holds the furthest position after OPDS hash-churn.
+        // Apply it ONLY by fraction (goToFraction resolves by cumulative section
+        // size, never by node path), so it can't collapse to a section start the
+        // way a cross-file CFI would.
+        view.goToFraction(siblingFraction);
+        announceSynced();
+      } else if (exactConfig) {
+        const configCFI = config?.location;
+        let remoteCFILocation = exactConfig.location;
+        const xpointer = exactConfig.xpointer;
+        // The Readest KOReader plugin pushes `progress` + `xpointer` and never a
+        // `location`, so its [page, total] is CREngine's own pagination. That
+        // doubles as the anchor that corrects CREngine<->foliate DocFragment
+        // drift and as the last-resort target when the XPointer won't convert.
+        // A config that carries a CFI came from Readest, whose [page, total] is
+        // foliate's pagination and whose xpointer was derived from that same
+        // CFI — re-anchoring on it would only move the target off (#5109).
+        const remoteFraction = exactConfig.location ? undefined : getConfigFraction(exactConfig);
+        let xpointerUnresolved = false;
+        if (xpointer && view && bookData && bookData.bookDoc) {
+          const pContents = view.renderer.getContents();
+          const pIdx = view.renderer.primaryIndex;
+          const content = pContents.find((x) => x.index === pIdx) ?? pContents[0];
+          try {
+            const candidateCFI = await getCFIFromXPointer(
+              xpointer,
+              content?.doc,
+              content?.index,
+              bookData.bookDoc,
+              remoteFraction,
+            );
+            if (!remoteCFILocation || CFI.compare(remoteCFILocation, candidateCFI) < 0) {
+              remoteCFILocation = candidateCFI;
+            }
+          } catch (error) {
+            // Never let one unconvertible XPointer reject the whole pull — the
+            // proofread merge below still has to run, and swallowing the rest
+            // silently is what let the debounced auto-push overwrite a newer
+            // remote position with the local one (#5625).
+            console.warn('Failed to convert XPointer to CFI', error);
+            xpointerUnresolved = true;
+          }
+        }
+        // Reading progress applies below. Proofread (find/replace) rules merge
+        // separately just after; other config fields remain device-local.
+        // TODO: general config sync via a more robust profile-based solution.
+        if (remoteCFILocation && configCFI) {
           // While previewing a deep-link target, do NOT yank the view to the
           // remote position — the user came here to look at a specific
-          // annotation. The local config still gets updated above; the next
-          // open will resolve to the synced position normally.
-          const isPreview = useReaderStore.getState().getViewState(bookKey)?.previewMode;
-          if (view && !isPreview) {
+          // annotation. The local config still gets updated; the next open
+          // resolves to the synced position normally.
+          if (CFI.compare(configCFI, remoteCFILocation) < 0 && view && !isPreviewing()) {
             view.goTo(remoteCFILocation);
-            setHoveredBookKey(null);
-            eventDispatcher.dispatch('hint', {
-              bookKey,
-              message: _('Reading Progress Synced'),
-            });
+            announceSynced();
           }
-        }
-      } else if (xpointerUnresolved && remoteFraction !== undefined) {
-        // No CFI anywhere and the XPointer didn't resolve: the reported
-        // fraction is all that's left. CREngine and foliate paginate
-        // differently, so it's approximate — only ever move FORWARD with it,
-        // matching the CFI branch, so an imprecise jump can't lose the reader's
-        // place.
-        const localFraction = getBookProgress(bookKey)?.fraction;
-        const isPreview = useReaderStore.getState().getViewState(bookKey)?.previewMode;
-        if (view && !isPreview && (localFraction ?? 0) < remoteFraction) {
-          view.goToFraction(remoteFraction);
-          setHoveredBookKey(null);
-          eventDispatcher.dispatch('hint', {
-            bookKey,
-            message: _('Reading Progress Synced'),
-          });
+        } else if (xpointerUnresolved && remoteFraction !== undefined) {
+          // No CFI anywhere and the XPointer didn't resolve: the reported
+          // fraction is all that's left. CREngine and foliate paginate
+          // differently, so it's approximate — only ever move FORWARD with it,
+          // matching the CFI branch, so an imprecise jump can't lose the
+          // reader's place.
+          if (view && !isPreviewing() && localFraction < remoteFraction) {
+            view.goToFraction(remoteFraction);
+            announceSynced();
+          }
         }
       }
       // Two view settings cross devices; everything else in viewSettings stays

--- a/apps/readest-app/src/services/opds/autoDownload.ts
+++ b/apps/readest-app/src/services/opds/autoDownload.ts
@@ -15,7 +15,7 @@ import {
   saveSubscriptionState,
   pruneKnownEntryIds,
 } from './subscriptionState';
-import { upsertOPDSSourceMapping } from './sourceMap';
+import { findBookByOPDSSources, upsertOPDSSourceMapping } from './sourceMap';
 import { isRetryEligible, DOWNLOAD_CONCURRENCY, MAX_RETRY_ATTEMPTS } from './types';
 import type { PendingItem, SyncResult, OPDSSubscriptionState, FailedEntry } from './types';
 import { runWithConcurrency } from '@/utils/concurrency';
@@ -31,6 +31,32 @@ async function downloadAndImport(
   books: Book[],
 ): Promise<Book> {
   const url = resolveURL(item.acquisitionHref, item.baseURL);
+  // Identity gate (#5859): if this OPDS source already maps to a book still in
+  // the library, it is already imported. Re-importing it would mint a NEW
+  // book_hash for a re-packaged-but-identical file (calibre/CWA rewrites the
+  // EPUB on each ingest, so the bytes — and thus partialMD5 — differ while the
+  // content does not), stranding the reading position across hashes. Reuse the
+  // existing book instead of re-downloading. A genuinely new edition changes
+  // the feed entry id (or the acquisition URL), so it still imports normally.
+  //
+  // Look up under BOTH catalog keys: `contentId` is backfilled at a later save,
+  // so a source imported before the backfill is mapped under `id` while later
+  // syncs key on `contentId` — matching only one would miss the mapping and
+  // re-import anyway.
+  const catalogIds = [...new Set([catalog.contentId, catalog.id].filter(Boolean) as string[])];
+  let existing: Book | null = null;
+  for (const catalogId of catalogIds) {
+    existing = await findBookByOPDSSources(appService, {
+      catalogId,
+      sourceUrls: [url],
+      library: books,
+    });
+    if (existing) break;
+  }
+  if (existing) {
+    console.log(`[OPDS] "${item.title}" already imported for this source — skipping re-download`);
+    return existing;
+  }
   const username = catalog.username ?? '';
   const password = catalog.password ?? '';
   const customHeaders = normalizeCustomHeaders(catalog.customHeaders);


### PR DESCRIPTION
## Summary

Fixes reading progress loss reported in #5859 (Boox / Android, books loaded via OPDS auto-download). Investigation on a real Boox Leaf5 against a live Calibre-Web-Automated instance, plus the reporter's own cloud library, showed three separate problems. Each is a self-contained commit.

### 1. `fix(sync): stop OPDS auto-download from re-importing a book under a new hash` (root cause)

Calibre-Web re-packages an EPUB on each ingest, so the served bytes (and thus `partialMD5`) change while the content does not. Auto-download then re-imported the same book under a new `book_hash` on every re-download, minting a duplicate library row and stranding the reading position on the old hash.

In the reporter's cloud library this is stark: 36 duplicate-title groups, all same `meta_hash` / different `book_hash`, and 21 of 30 read books have their saved position stranded on deleted hashes with no live book carrying it, so the surviving copy opens at page one.

The `opds_source_mappings` table and `findBookByOPDSSources` already existed but were never read in the sync path (only written). `downloadAndImport` now looks the source up first and, if it already maps to a live book, reuses it and skips the re-download. The lookup uses both `catalog.contentId` and `catalog.id`, because `contentId` is backfilled at a later save.

Device-verified on the Boox Leaf5 against live CWA: editing a book's title (which changes the served bytes) then forcing a re-download no longer creates a duplicate. Before this change every such cycle produced a fresh page-one copy.

### 2. `fix(sync): reconcile duplicate book configs to the furthest position` (safety net)

For libraries already churned into multiple hashes, `applyRemoteProgress` picked the first matching config, which could be a lower-progress or cross-file config and move the reader backward. Worse, a sibling config's CFI belongs to a different-bytes file: it resolves to `null` in the current document, which foliate's paginator turns into a jump to the section start (page one). This matches the reporter seeing the correct page on open and then watching it reset.

`applyRemoteProgress` now reconciles like `mergeBooks`: the exact same-`book_hash` config applies its CFI/xpointer (valid in this file); same-`meta_hash` siblings contribute only their reading fraction via `goToFraction`, never their CFI; and it only ever moves forward.

### 3. `fix(reader): persist reading position when the app is backgrounded`

`useProgressAutoSave` wrote `config.json` only through a ~1.5s debounce and never flushed it on background. On Android, sleep / HOME / a background kill fire `visibilitychange` but never `beforeunload`, so a page turned and backgrounded within the debounce window was lost when the OS killed the app. It now flushes the pending save on `visibilitychange:hidden` and `pagehide`. Device-verified on the Boox.

## Test plan

- [x] `pnpm test` — 10077 pass (added an OPDS re-import characterization test and background-flush tests).
- [x] `pnpm lint` — clean.
- [x] Device: identity gate verified on a Boox Leaf5 against a live Calibre-Web-Automated server (changed-bytes re-download no longer duplicates); background save-flush verified via sleep then kill then reopen.
- [ ] Not device-verified: the `applyRemoteProgress` reconciliation, which needs a signed-in two-hash device; covered here by the suite and the code path.

Closes #5859

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reading progress is now saved immediately when the app is backgrounded or closed, helping preserve the latest position.
  * OPDS downloads now recognize previously imported books and avoid downloading duplicates.

* **Bug Fixes**
  * Improved synchronization of reading progress across related book copies.
  * Corrected progress handling when OPDS books are re-imported or their files and metadata change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->