### PR TITLE
fix(reader): resolve media that book scripts add after the section loads, closes #1812

### DIFF
--- a/apps/readest-app/src/__tests__/utils/dynamicResources.test.ts
+++ b/apps/readest-app/src/__tests__/utils/dynamicResources.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from 'vitest';
+import { observeDynamicResources } from '@/utils/dynamicResources';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+const microtask = () => Promise.resolve();
+
+const makeDoc = () => document.implementation.createHTMLDocument('');
+
+const makeLoader = (map: Record<string, string>) =>
+  vi.fn(async (href: string): Promise<string> => map[href] ?? href);
+
+describe('observeDynamicResources', () => {
+  it('resolves the src of a media element a script inserts after load', async () => {
+    const doc = makeDoc();
+    const loadHref = makeLoader({ '../video/clip.mp4': 'blob:null/clip' });
+    observeDynamicResources(doc, loadHref);
+
+    const video = doc.createElement('video');
+    video.setAttribute('src', '../video/clip.mp4');
+    doc.body.appendChild(video);
+    await flush();
+
+    expect(loadHref).toHaveBeenCalledWith('../video/clip.mp4');
+    expect(video.getAttribute('src')).toBe('blob:null/clip');
+  });
+
+  it('parks an unresolved src while it loads so the bad URL never errors', async () => {
+    // Kotobee tears its player down on the media `error` event, which the
+    // unresolvable relative URL fires long before a multi-MB clip is read out
+    // of the zip. Removing `src` re-runs the load algorithm, cancelling it.
+    const doc = makeDoc();
+    let release!: (url: string) => void;
+    const loadHref = vi.fn(() => new Promise<string>((resolve) => (release = resolve)));
+    observeDynamicResources(doc, loadHref);
+
+    const video = doc.createElement('video');
+    video.setAttribute('src', '../video/clip.mp4');
+    doc.body.appendChild(video);
+    await microtask();
+
+    expect(video.hasAttribute('src')).toBe(false);
+    release('blob:null/clip');
+    await flush();
+    expect(video.getAttribute('src')).toBe('blob:null/clip');
+  });
+
+  it('restores a reference the loader cannot resolve without looping', async () => {
+    const doc = makeDoc();
+    const loadHref = makeLoader({});
+    observeDynamicResources(doc, loadHref);
+
+    const script = doc.createElement('img');
+    script.setAttribute('src', '../../_kmeta/missing.png');
+    doc.body.appendChild(script);
+    await flush();
+    await flush();
+
+    expect(script.getAttribute('src')).toBe('../../_kmeta/missing.png');
+    expect(loadHref).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves absolute, blob, data and fragment references alone', async () => {
+    const doc = makeDoc();
+    const loadHref = makeLoader({});
+    observeDynamicResources(doc, loadHref);
+
+    const urls = ['blob:http://x/1', 'data:image/png;base64,AA==', 'https://a.b/c.mp4', '#frag'];
+    for (const url of urls) {
+      const img = doc.createElement('img');
+      img.setAttribute('src', url);
+      doc.body.appendChild(img);
+    }
+    await flush();
+
+    expect(loadHref).not.toHaveBeenCalled();
+    expect([...doc.querySelectorAll('img')].map((el) => el.getAttribute('src'))).toEqual(urls);
+  });
+
+  it('resolves a poster and an inline background-image url()', async () => {
+    const doc = makeDoc();
+    const loadHref = makeLoader({
+      '../imgs/splash.png': 'blob:null/splash',
+      '../video/clip.mp4': 'blob:null/clip',
+    });
+    observeDynamicResources(doc, loadHref);
+
+    const video = doc.createElement('video');
+    video.setAttribute('src', '../video/clip.mp4');
+    video.setAttribute('poster', '../imgs/splash.png');
+    doc.body.appendChild(video);
+    const widget = doc.createElement('div');
+    doc.body.appendChild(widget);
+    await flush();
+    widget.setAttribute('style', 'width: 10px; background-image: url("../imgs/splash.png");');
+    await flush();
+
+    expect(video.getAttribute('poster')).toBe('blob:null/splash');
+    expect(widget.getAttribute('style')).toContain('url("blob:null/splash")');
+    expect(widget.getAttribute('style')).toContain('width: 10px');
+  });
+
+  it('resolves references already present when observing starts', async () => {
+    const doc = makeDoc();
+    doc.body.innerHTML =
+      '<div style="background-image: url(../imgs/splash.png)"><img src="../imgs/icon.png"></div>';
+    const loadHref = makeLoader({
+      '../imgs/splash.png': 'blob:null/splash',
+      '../imgs/icon.png': 'blob:null/icon',
+    });
+    observeDynamicResources(doc, loadHref);
+    await flush();
+
+    expect(doc.querySelector('img')?.getAttribute('src')).toBe('blob:null/icon');
+    expect(doc.querySelector('div')?.getAttribute('style')).toContain('url("blob:null/splash")');
+  });
+
+  it('reloads the parent media element when a <source> child is resolved', async () => {
+    const doc = makeDoc();
+    const loadHref = makeLoader({ '../audio/a.mp3': 'blob:null/a' });
+    observeDynamicResources(doc, loadHref);
+
+    const audio = doc.createElement('audio');
+    const load = vi.fn();
+    Object.defineProperty(audio, 'load', { value: load });
+    const source = doc.createElement('source');
+    source.setAttribute('src', '../audio/a.mp3');
+    audio.appendChild(source);
+    doc.body.appendChild(audio);
+    await flush();
+
+    expect(source.getAttribute('src')).toBe('blob:null/a');
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a src the script replaced while the first one was loading', async () => {
+    const doc = makeDoc();
+    let release!: (url: string) => void;
+    const loadHref = vi.fn(() => new Promise<string>((resolve) => (release = resolve)));
+    observeDynamicResources(doc, loadHref);
+
+    const video = doc.createElement('video');
+    video.setAttribute('src', '../video/first.mp4');
+    doc.body.appendChild(video);
+    await microtask();
+    video.setAttribute('src', 'blob:http://x/second');
+    release('blob:null/first');
+    await flush();
+
+    expect(video.getAttribute('src')).toBe('blob:http://x/second');
+  });
+
+  it('keeps the newer source when the script swaps one relative src for another', async () => {
+    // Both references are parked while they load, so "is the attribute back?"
+    // cannot tell them apart: the newer request has to win on its own.
+    const doc = makeDoc();
+    const release = new Map<string, (url: string) => void>();
+    const loadHref = vi.fn(
+      (href: string) => new Promise<string>((resolve) => release.set(href, resolve)),
+    );
+    observeDynamicResources(doc, loadHref);
+
+    const video = doc.createElement('video');
+    video.setAttribute('src', '../video/first.mp4');
+    doc.body.appendChild(video);
+    await microtask();
+    video.setAttribute('src', '../video/second.mp4');
+    await flush();
+    release.get('../video/first.mp4')!('blob:null/first');
+    await flush();
+    release.get('../video/second.mp4')!('blob:null/second');
+    await flush();
+
+    expect(video.getAttribute('src')).toBe('blob:null/second');
+  });
+
+  it('looks a reference up once per document, however many elements use it', async () => {
+    // A script that rewrites an attribute whenever it changes would otherwise
+    // drive an unbounded number of loader calls.
+    const doc = makeDoc();
+    const loadHref = makeLoader({ '../imgs/a.png': 'blob:null/a' });
+    observeDynamicResources(doc, loadHref);
+
+    const div = doc.createElement('div');
+    div.innerHTML = '<img src="../imgs/a.png"><img src="../imgs/a.png">';
+    div.setAttribute('style', 'background-image: url(../imgs/a.png)');
+    doc.body.appendChild(div);
+    await flush();
+
+    expect(loadHref).toHaveBeenCalledTimes(1);
+    expect([...doc.querySelectorAll('img')].map((el) => el.getAttribute('src'))).toEqual([
+      'blob:null/a',
+      'blob:null/a',
+    ]);
+    expect(div.getAttribute('style')).toContain('url("blob:null/a")');
+  });
+
+  it('keeps a poster the script replaced while the first one was loading', async () => {
+    const doc = makeDoc();
+    let release!: (url: string) => void;
+    const loadHref = vi.fn(() => new Promise<string>((resolve) => (release = resolve)));
+    observeDynamicResources(doc, loadHref);
+
+    const video = doc.createElement('video');
+    video.setAttribute('poster', '../imgs/first.png');
+    doc.body.appendChild(video);
+    await microtask();
+    video.setAttribute('poster', 'blob:http://x/second');
+    release('blob:null/first');
+    await flush();
+
+    expect(video.getAttribute('poster')).toBe('blob:http://x/second');
+  });
+
+  it('resolves media in an XHTML section document, where tag names are lowercase', async () => {
+    // EPUB sections are parsed as application/xhtml+xml, so `tagName` is
+    // 'video', not 'VIDEO'; a case-sensitive check silently skips them.
+    const doc = new DOMParser().parseFromString(
+      '<html xmlns="http://www.w3.org/1999/xhtml"><body></body></html>',
+      'application/xhtml+xml',
+    );
+    const loadHref = makeLoader({ '../video/clip.mp4': 'blob:null/clip' });
+    observeDynamicResources(doc, loadHref);
+
+    const video = doc.createElementNS('http://www.w3.org/1999/xhtml', 'video');
+    video.setAttribute('src', '../video/clip.mp4');
+    doc.body!.appendChild(video);
+    await flush();
+
+    expect(video.tagName).toBe('video');
+    expect(video.getAttribute('src')).toBe('blob:null/clip');
+  });
+
+  it('stops resolving after disconnect', async () => {
+    const doc = makeDoc();
+    const loadHref = makeLoader({ '../video/clip.mp4': 'blob:null/clip' });
+    const disconnect = observeDynamicResources(doc, loadHref);
+    disconnect();
+
+    const video = doc.createElement('video');
+    video.setAttribute('src', '../video/clip.mp4');
+    doc.body.appendChild(video);
+    await flush();
+
+    expect(loadHref).not.toHaveBeenCalled();
+    expect(video.getAttribute('src')).toBe('../video/clip.mp4');
+  });
+});

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -85,6 +85,7 @@ import { isMetered } from '@/utils/network';
 import { eventDispatcher } from '@/utils/event';
 import { isFontType } from '@/utils/font';
 import { getScrollGapAttr } from '@/utils/webtoon';
+import { observeDynamicResources } from '@/utils/dynamicResources';
 import { useMiddleClickAutoscroll } from '../hooks/useMiddleClickAutoscroll';
 import { useAutoScroll } from '../hooks/useAutoScroll';
 import { useAutoScrollSpeedGesture } from '../hooks/useAutoScrollSpeedGesture';
@@ -404,6 +405,13 @@ const FoliateViewer: React.FC<{
         skipToNextSectionCallback: skipToNextSection,
         skipToNextSectionLabel: _('End of this section. Continue to the next.'),
       });
+
+      if (viewSettings.allowScript) {
+        // Book scripts may add media, or a background image, with a path
+        // relative to the section long after foliate's load-time URL rewrite.
+        const section = bookDoc.sections?.[detail.index];
+        if (section?.loadHref) observeDynamicResources(detail.doc, section.loadHref);
+      }
 
       // Inline scripts in tauri platforms are not executed by default
       if (viewSettings.allowScript && isTauriAppPlatform()) {

--- a/apps/readest-app/src/libs/document.ts
+++ b/apps/readest-app/src/libs/document.ts
@@ -44,6 +44,8 @@ export interface SectionItem {
   fragments?: Array<SectionFragment>;
 
   loadText?: () => Promise<string | null>;
+  // Resolve a reference a script introduces after load (see observeDynamicResources).
+  loadHref?: (href: string) => Promise<string>;
   createDocument: () => Promise<Document>;
 
   // EPUB 3 Media Overlays: the manifest item of this section's SMIL file, or

--- a/apps/readest-app/src/utils/dynamicResources.ts
+++ b/apps/readest-app/src/utils/dynamicResources.ts
@@ -1,0 +1,135 @@
+/**
+ * Resolve resource references that a book's scripts introduce after the
+ * section was loaded.
+ *
+ * foliate-js rewrites every `src`, `poster`, `srcset`, stylesheet and inline
+ * `url()` to a blob URL while it loads a section, then serves the document
+ * itself from a `blob:` URL. A reference a script adds later (Kotobee builds
+ * `<video src="../../../video/x.mp4">` on the play click, out of an encrypted
+ * payload) never went through that pass, and a relative path cannot resolve
+ * against a `blob:` base, so the media silently fails to load. Watch the
+ * document for such references and route them through the same loader.
+ */
+export type LoadHref = (href: string) => Promise<string>;
+
+// `[style]` rather than `[style*="url("]`: the substring form is valid CSS
+// but jsdom's selector engine drops it, and the regex below filters anyway.
+const SELECTOR =
+  'img[src], video[src], audio[src], source[src], track[src], video[poster], [style]';
+// Compared against `localName`: EPUB sections are XHTML documents, where
+// `tagName` keeps the lowercase source form.
+const SRC_TAGS = new Set(['img', 'video', 'audio', 'source', 'track']);
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+const STYLE_URL_RE = /url\(\s*(['"]?)([^'")]+?)\1\s*\)/gi;
+
+const isRelative = (url: string | null): url is string =>
+  !!url && !SCHEME_RE.test(url) && !url.startsWith('#') && !url.startsWith('//');
+
+export const observeDynamicResources = (doc: Document, loadHref: LoadHref): (() => void) => {
+  // Values written by this observer, so seeing them again is a no-op rather
+  // than a loop (a reference the loader cannot resolve is written back as is).
+  const written = new WeakMap<Element, Map<string, string>>();
+  // The reference each attribute is currently resolving, so a resolution that
+  // finishes after the script has moved on does not win over the newer one.
+  const loading = new WeakMap<Element, Map<string, string>>();
+  // One lookup per reference per document. Book scripts reuse the same file
+  // across widgets, and a script that rewrites an attribute the moment it
+  // changes would otherwise drive an unbounded number of lookups.
+  const resolved = new Map<string, Promise<string>>();
+
+  const track = (map: WeakMap<Element, Map<string, string>>, el: Element, k: string, v: string) => {
+    let attrs = map.get(el);
+    if (!attrs) map.set(el, (attrs = new Map()));
+    attrs.set(k, v);
+  };
+  const write = (el: Element, attr: string, value: string) => {
+    track(written, el, attr, value);
+    el.setAttribute(attr, value);
+  };
+  const isOwnWrite = (el: Element, attr: string) =>
+    written.get(el)?.get(attr) === el.getAttribute(attr);
+
+  const resolve = (href: string) => {
+    let pending = resolved.get(href);
+    // Keep the original reference if the loader cannot resolve it.
+    if (!pending) resolved.set(href, (pending = loadHref(href).catch(() => href)));
+    return pending;
+  };
+
+  const resolveAttr = async (el: Element, attr: 'src' | 'poster') => {
+    if (attr === 'src' ? !SRC_TAGS.has(el.localName) : el.localName !== 'video') return;
+    const value = el.getAttribute(attr);
+    if (!isRelative(value) || isOwnWrite(el, attr)) return;
+    track(loading, el, attr, value);
+    // Park a `src` while it resolves: removing it re-runs the media element
+    // load algorithm, which cancels the `error` the unresolvable URL would
+    // fire (Kotobee tears its player down on that event) long before a
+    // multi-megabyte clip has been read out of the archive.
+    if (attr === 'src') el.removeAttribute('src');
+    const url = await resolve(value);
+    // The script moved on while this was loading: either to another relative
+    // reference (which took over `loading`), or to one this observer leaves
+    // alone, which for a parked `src` means the attribute is back.
+    if (loading.get(el)?.get(attr) !== value) return;
+    if (attr === 'src' ? el.hasAttribute('src') : el.getAttribute(attr) !== value) return;
+    write(el, attr, url);
+    if (url !== value && el.localName === 'source') {
+      (el.parentElement as HTMLMediaElement | null)?.load?.();
+    }
+  };
+
+  const resolveStyle = async (el: Element) => {
+    const style = el.getAttribute('style');
+    if (!style || isOwnWrite(el, 'style')) return;
+    const refs = new Set(
+      [...style.matchAll(STYLE_URL_RE)].map((match) => match[2]!).filter(isRelative),
+    );
+    if (!refs.size) return;
+    const urls = new Map(
+      await Promise.all([...refs].map(async (ref) => [ref, await resolve(ref)] as const)),
+    );
+    if ([...urls].every(([ref, url]) => ref === url)) return;
+    // The script rewrote the style in the meantime; the next mutation gets it.
+    if (el.getAttribute('style') !== style) return;
+    write(
+      el,
+      'style',
+      style.replace(STYLE_URL_RE, (match, _quote, ref: string) => {
+        const url = urls.get(ref);
+        return url && url !== ref ? `url("${url}")` : match;
+      }),
+    );
+  };
+
+  const process = (el: Element) => {
+    void resolveAttr(el, 'src');
+    void resolveAttr(el, 'poster');
+    void resolveStyle(el);
+  };
+  const sweep = (root: Element) => {
+    if (root.matches(SELECTOR)) process(root);
+    for (const el of root.querySelectorAll(SELECTOR)) process(el);
+  };
+
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      if (record.type === 'attributes') {
+        const el = record.target as Element;
+        if (record.attributeName === 'style') void resolveStyle(el);
+        else void resolveAttr(el, record.attributeName as 'src' | 'poster');
+      } else {
+        for (const node of record.addedNodes) {
+          if (node.nodeType === Node.ELEMENT_NODE) sweep(node as Element);
+        }
+      }
+    }
+  });
+  observer.observe(doc, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['src', 'poster', 'style'],
+  });
+  if (doc.documentElement) sweep(doc.documentElement);
+  return () => observer.disconnect();
+};


### PR DESCRIPTION
Closes #1812.

## The bug

Videos embedded in Kotobee-exported EPUBs never play. The reporter's book shows a black box where the player should be, on desktop and web alike.

The page markup carries no `<video>` at all, just an encrypted payload:

```html
<div class="kInteractive video video882" data-kotobee="Tlg2SlBX…"></div>
```

`kotobeeInteractive.js` builds the element on the play click, with a path relative to the section:

```js
n.setAttribute("src", kInteractive.cleanURL("../../../video/1_1-lets-get-started.mp4"))
```

foliate-js rewrites resource URLs to blob URLs while it loads a section and serves the section document from a `blob:` URL. Anything a script adds afterwards missed that pass, and a relative path cannot resolve against a `blob:` base. Measured in Chromium right after the click: the element sits at `networkState 3` (NO_SOURCE), fires `error` about 12 ms later, and Kotobee's own error listener calls `stopCurrentMedia()`, which removes the player and resets the button. The widget's splash `background-image: url(../../../imgs/aasplash.png)` fails the same way.

## The fix

`observeDynamicResources(doc, loadHref)` (`src/utils/dynamicResources.ts`) watches the section document for `src`, `poster` and inline `url()` references that scripts introduce, and resolves them through foliate's loader:

- A `src` is **parked** (removed) while the resource is read out of the archive. Removing it re-runs the media element's load algorithm, which cancels the pending `error` — otherwise the error arrives long before a multi-megabyte clip is ready, and Kotobee tears its player down before playback can start.
- Writes are tracked per element, and references the loader cannot resolve are remembered, so the observer never ping-pongs with the book's own script.
- A resolved `<source>` triggers `parent.load()`.

It is installed in `FoliateViewer`'s `docLoadHandler` only when the book's **Allow JavaScript** setting is on — with scripts off nothing dynamic happens, so nothing is watched.

foliate-js gains `section.loadHref` (readest/foliate-js#83): the resource is loaded with the section as its parent, so it is reference-counted as a child and released with the section, and repeated plays reuse the cached blob instead of minting one per click.

## Verification

Trimmed copy of the reporter's book (two clips, same Kotobee widgets), before and after:

| | before | after |
|---|---|---|
| Chromium | `networkState 3`, no `<video>` left in the DOM 12 ms after the click | blob `src` + blob `poster`, `readyState 4`, `paused false`, `currentTime` advancing |
| Android (Xiaomi 13, release build) | — | both video pages play; page 16 ran to `4 / 4`, page 20 caught mid-play at `2.26`, `error null` |

10 unit tests for the observer (`src/__tests__/utils/dynamicResources.test.ts`) covering the park-and-resolve path, loop guards, absolute/blob/data references, poster and inline `url()`, `<source>`, a mid-flight src replacement, XHTML documents, and disconnect. Full suite: 10087 passed, 16 skipped. Lint and format clean.

## Note for anyone hitting this

**Allow JavaScript** (Settings → Behavior → Security) is off by default and these books render nothing interactive without it. This fix is what makes the videos play once it is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Book content can now resolve and load dynamically added images, media, posters, and CSS background resources.
  - Media sources introduced or updated by scripts are refreshed automatically.

- **Bug Fixes**
  - Improved handling of relative, unresolved, duplicate, and rapidly changing resource references.
  - Prevented repeated reload loops and stale resource updates.

- **Tests**
  - Added comprehensive coverage for dynamic resources, XHTML documents, media sources, mutation races, and observer disconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->