### PR TITLE
fix(sync): shelve an imported book on other devices without opening it first

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/useBooksSync-inflight-change.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/useBooksSync-inflight-change.test.tsx
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+
+import type { Book } from '@/types/book';
+
+/**
+ * A library change that lands while an auto-sync is already in flight must
+ * still reach the cloud once that sync finishes.
+ *
+ * The real-world shape: importing a book kicks off a push+pull chain that
+ * runs for several seconds, and the book's upload completes inside that
+ * window. The upload stamps `uploadedAt`, which is the field peers gate
+ * adoption on (`updateLibrary` only shelves cloud books with `uploadedAt`).
+ * If the change is dropped because a sync was in flight, the cloud row keeps
+ * `uploaded_at = null` and the book never appears on other devices until an
+ * unrelated library change (opening the book, relaunching) re-pushes it.
+ */
+
+const appService = vi.hoisted(() => ({
+  saveLibraryBooks: vi.fn(async () => {}),
+  generateCoverImageUrl: vi.fn(async () => 'blob:cover'),
+  downloadBookCovers: vi.fn(async () => {}),
+}));
+
+const syncState = vi.hoisted(() => ({
+  useSyncInited: true,
+  syncedBooks: null as Book[] | null,
+  syncBooks: vi.fn(async (_books?: Book[], _op?: string, _since?: number) => 0),
+  // Truthy so the auto-sync 'both' branch runs (it returns early on a 0 cursor).
+  lastSyncedAtBooks: 1000,
+}));
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService }),
+}));
+
+vi.mock('@/context/SyncContext', () => ({
+  useSyncContext: () => ({ syncClient: {} }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (text: string) => text,
+}));
+
+vi.mock('@/hooks/useSync', () => ({
+  useSync: () => syncState,
+}));
+
+vi.mock('@/services/sync/cloudSyncProvider', () => ({
+  isReadestCloudEnabled: () => true,
+  getActiveFileSyncBackends: () => [],
+}));
+
+vi.mock('@/services/sync/file/runLibrarySync', () => ({
+  runFileLibrarySyncPass: vi.fn(async () => null),
+}));
+
+// A zero throttle interval makes every auto-sync call a leading edge, so the
+// test exercises the in-flight guard rather than the throttle's trailing timer.
+vi.mock('@/services/constants', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/constants')>()),
+  SYNC_BOOKS_INTERVAL_SEC: 0,
+}));
+
+const { useBooksSync } = await import('@/app/library/hooks/useBooksSync');
+const { useLibraryStore } = await import('@/store/libraryStore');
+
+const flush = async () => {
+  await act(async () => {
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+  });
+};
+
+const makeBook = (overrides: Partial<Book> = {}): Book =>
+  ({
+    hash: 'abc123',
+    format: 'EPUB',
+    title: 'Book',
+    author: 'Author',
+    createdAt: 2000,
+    updatedAt: 2000,
+    uploadedAt: null,
+    deletedAt: null,
+    ...overrides,
+  }) as Book;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  syncState.syncedBooks = null;
+  useLibraryStore.setState({ library: [], libraryLoaded: true, isSyncing: false });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useBooksSync auto-sync with an in-flight sync', () => {
+  it('re-pushes a book whose uploadedAt landed while a sync was in flight', async () => {
+    // Every 'both' sync stays in flight until the test resolves it; pulls
+    // resolve immediately.
+    const inFlight: Array<(n: number) => void> = [];
+    syncState.syncBooks.mockImplementation((_books, op) =>
+      op === 'both' ? new Promise<number>((resolve) => inFlight.push(resolve)) : Promise.resolve(0),
+    );
+
+    renderHook(() => useBooksSync());
+    await flush();
+    // Settle the mount-time sync so the import below starts from idle.
+    while (inFlight.length) inFlight.shift()!(0);
+    await flush();
+    syncState.syncBooks.mockClear();
+
+    // Import: the new book (no syncedAt yet) is pushed, and that sync now
+    // stays in flight.
+    const imported = makeBook();
+    act(() => useLibraryStore.getState().setLibrary([imported]));
+    await flush();
+    expect(inFlight).toHaveLength(1);
+    const firstPush = syncState.syncBooks.mock.calls[0]!;
+    expect(firstPush[1]).toBe('both');
+    expect(firstPush[0]?.map((b) => b.hash)).toEqual(['abc123']);
+
+    // The upload finishes while that sync is still running: uploadedAt is
+    // stamped and the library is replaced (transferManager -> updateBook).
+    act(() =>
+      useLibraryStore.getState().setLibrary([makeBook({ uploadedAt: 3000, updatedAt: 3000 })]),
+    );
+    await flush();
+
+    // The in-flight sync completes.
+    inFlight.shift()!(0);
+    await flush();
+
+    // A follow-up sync must carry the uploaded book to the cloud.
+    const followUp = syncState.syncBooks.mock.calls
+      .slice(1)
+      .find((call) => call[0]?.some((b) => b.hash === 'abc123' && !!b.uploadedAt));
+    expect(followUp).toBeDefined();
+  });
+});

--- a/apps/readest-app/src/app/library/hooks/useBooksSync.ts
+++ b/apps/readest-app/src/app/library/hooks/useBooksSync.ts
@@ -35,6 +35,17 @@ export const useBooksSync = () => {
   const { setLibrary, setIsSyncing, setSyncProgress } = useLibraryStore();
   const { useSyncInited, syncedBooks, syncBooks, lastSyncedAtBooks } = useSync();
   const isPullingRef = useRef(false);
+  // A library change that lands while a sync is in flight must not be lost.
+  // The post-import chain (push, pull, follow-up pull) runs for seconds and a
+  // book's upload completes inside it, stamping `uploadedAt` — the field
+  // peers gate adoption on. Dropping that change left the cloud row with
+  // `uploaded_at = null` until an unrelated change re-pushed the book.
+  const syncPendingRef = useRef(false);
+  const handleAutoSyncRef = useRef<() => void>(() => {});
+  const releaseSyncLock = useCallback(() => {
+    isPullingRef.current = false;
+    if (syncPendingRef.current) handleAutoSyncRef.current();
+  }, []);
 
   const getNewBooks = useCallback(() => {
     if (!user) return {};
@@ -129,28 +140,34 @@ export const useBooksSync = () => {
           });
         }
       } finally {
-        isPullingRef.current = false;
+        releaseSyncLock();
       }
     },
-    [_, user, libraryLoaded, syncBooks, envConfig],
+    [_, user, libraryLoaded, syncBooks, envConfig, releaseSyncLock],
   );
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleAutoSync = useCallback(
     throttle(
       async () => {
-        if (isPullingRef.current) return;
+        if (isPullingRef.current) {
+          syncPendingRef.current = true;
+          return;
+        }
         // Readest Cloud unchecked: the native book channel is gated (the auto
         // library sync itself is useLibraryFileSync's).
         const settingsNow = useSettingsStore.getState().settings;
         if (!isReadestCloudEnabled(settingsNow)) return;
         const newBooks = getNewBooks();
         if (!newBooks.lastSyncedAt) return;
+        // getNewBooks just read the live library, so every change up to now
+        // rides on this sync; only changes landing during it re-arm.
+        syncPendingRef.current = false;
         isPullingRef.current = true;
         try {
           await syncBooks(newBooks.books, 'both');
         } finally {
-          isPullingRef.current = false;
+          releaseSyncLock();
         }
       },
       SYNC_BOOKS_INTERVAL_SEC * 1000,
@@ -160,8 +177,11 @@ export const useBooksSync = () => {
   );
 
   useEffect(() => {
+    handleAutoSyncRef.current = handleAutoSync;
+  }, [handleAutoSync]);
+
+  useEffect(() => {
     if (!user) return;
-    if (isPullingRef.current) return;
     handleAutoSync();
   }, [user, library, handleAutoSync]);
 


### PR DESCRIPTION
## Problem

A book imported on one device does not appear on other devices' bookshelves until it is opened on the first device. It also "fixes itself" after an app relaunch.

## Root cause

`useBooksSync` guarded both the `[user, library, handleAutoSync]` effect and the throttled `handleAutoSync` body with `if (isPullingRef.current) return`, and simply dropped the change. After an import the sync chain is push -> pull -> (cursor changed -> a fresh throttle instance fires) -> follow-up pull, which runs for several seconds. The book's upload completes inside that window and stamps `uploadedAt` (via `transferManager.executeBookTransfer` -> `updateBook`), but that library change was discarded because a sync was already in flight.

Peers gate adoption on `uploadedAt` (`updateLibrary`: `newBook.uploadedAt || isFeedBook || isAudiobook`), so the cloud row kept `uploaded_at = null` and stayed invisible to other devices until an unrelated change (e.g. opening the book) re-pushed the row. A relaunch also "fixes" it because the 1-day cursor rewind re-pushes.

Confirmed in Supabase for the reporting account: the `books` row had `uploaded_at = null` with the `files` row present, and nothing was pushed for ~18 min until the book was opened. Clock skew was ruled out (client clock within ~0.2 s of the server).

## Fix

Remember a change that lands while a sync is in flight and re-arm the auto-sync when the lock is released:

- `syncPendingRef` records a change that arrives during an in-flight sync.
- `releaseSyncLock()` clears `isPullingRef` and, if a change is pending, re-invokes the throttled auto-sync. It runs in the `finally` of both the auto-sync body and `pullLibrary`.
- The effect-level `isPullingRef` early-return is removed so a change during a sync is no longer swallowed by the effect.

## Test

`src/__tests__/app/library/useBooksSync-inflight-change.test.tsx` reproduces the bug: it mocks `SYNC_BOOKS_INTERVAL_SEC` to 0 and holds `syncBooks('both')` in flight while a library change lands, then asserts the follow-up sync runs.

## Verification

- Unit: full suite green (10078 passing), `tsgo` + `biome` lint clean, `biome format` clean.
- Chrome A/B on `pnpm dev-web`: injected per-call latency into `/api/sync` to reproduce the desktop app's 2-3 s/leg timing (the local API is too fast to overlap), then imported via a synthetic drop. Old code: the upload lands during the chain's final pull, no further POST, `uploaded_at` stays null. Fixed code: the change re-arms after the lock releases, `uploaded_at` is pushed ~1 s later, and the row is set server-side without the book ever being opened.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic library synchronization when changes occur during an active sync.
  * Ensured updates made while syncing are queued and synchronized after the current operation completes.
  * Prevented newly imported or modified books from being missed by cloud synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->