### PR TITLE
feat(library): add From Web Browser import with an in-app browser (#5775)

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2450,5 +2450,19 @@
   "Linked to “{{title}}”": "تم الربط بـ «{{title}}»",
   "Hardcover link removed. The next sync will match the book again.": "تمت إزالة رابط Hardcover. ستعيد المزامنة التالية مطابقة الكتاب.",
   "{{pages}} pages": "{{pages}} صفحة",
-  "{{readers}} readers": "{{readers}} قارئ"
+  "{{readers}} readers": "{{readers}} قارئ",
+  "From Web Browser": "من متصفح الويب",
+  "Please enter a valid http(s) URL": "يرجى إدخال عنوان URL صالح يبدأ بـ http(s)",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "تصفّح خادم الكتب الخاص بك (Calibre-Web أو Kavita أو غيره) داخل Readest. الكتب التي تنزّلها هناك تُضاف إلى مكتبتك.",
+  "Name (optional)": "الاسم (اختياري)",
+  "Add Source": "إضافة مصدر",
+  "Reload": "إعادة التحميل",
+  "Stop": "إيقاف",
+  "More": "المزيد",
+  "Open in Browser": "فتح في المتصفح",
+  "Sign out of this site": "تسجيل الخروج من هذا الموقع",
+  "Not secure": "غير آمن",
+  "Importing": "جارٍ الاستيراد",
+  "Added to library": "تمت الإضافة إلى المكتبة",
+  "Not a supported book format": "تنسيق كتاب غير مدعوم"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2210,5 +2210,19 @@
   "Linked to “{{title}}”": "“{{title}}”-এর সাথে লিংক করা হয়েছে",
   "Hardcover link removed. The next sync will match the book again.": "Hardcover লিংক সরানো হয়েছে। পরবর্তী সিঙ্কে বইটি আবার মেলানো হবে।",
   "{{pages}} pages": "{{pages}} পৃষ্ঠা",
-  "{{readers}} readers": "{{readers}} জন পাঠক"
+  "{{readers}} readers": "{{readers}} জন পাঠক",
+  "From Web Browser": "ওয়েব ব্রাউজার থেকে",
+  "Please enter a valid http(s) URL": "অনুগ্রহ করে একটি বৈধ http(s) URL লিখুন",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "আপনার Calibre-Web, Kavita বা অন্য বই সার্ভার Readest-এর ভিতরেই ব্রাউজ করুন। সেখানে ডাউনলোড করা বই আপনার লাইব্রেরিতে যোগ হবে।",
+  "Name (optional)": "নাম (ঐচ্ছিক)",
+  "Add Source": "উৎস যোগ করুন",
+  "Reload": "পুনরায় লোড করুন",
+  "Stop": "থামুন",
+  "More": "আরও",
+  "Open in Browser": "ব্রাউজারে খুলুন",
+  "Sign out of this site": "এই সাইট থেকে সাইন আউট করুন",
+  "Not secure": "নিরাপদ নয়",
+  "Importing": "ইমপোর্ট হচ্ছে",
+  "Added to library": "লাইব্রেরিতে যোগ করা হয়েছে",
+  "Not a supported book format": "অসমর্থিত বইয়ের ফরম্যাট"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2150,5 +2150,19 @@
   "Linked to “{{title}}”": "“{{title}}” དང་སྦྲེལ་མཐུད་ཟིན།",
   "Hardcover link removed. The next sync will match the book again.": "Hardcover སྦྲེལ་མཐུད་བསུབས་ཟིན། ཟླ་སྒྲིག་རྗེས་མའི་སྐབས་དེབ་བསྐྱར་དུ་མཐུན་སྒྲིག་བྱེད།",
   "{{pages}} pages": "ཤོག་ངོས་ {{pages}}",
-  "{{readers}} readers": "ཀློག་མཁན་ {{readers}}"
+  "{{readers}} readers": "ཀློག་མཁན་ {{readers}}",
+  "From Web Browser": "དྲ་ལྟ་ཆས་ནས།",
+  "Please enter a valid http(s) URL": "ཁྲིམས་མཐུན་གྱི་ http(s) URL ཞིག་འཇུག་རོགས།",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "ཁྱེད་ཀྱི་ Calibre-Web དང་ Kavita ཡང་ན་གཞན་གྱི་དཔེ་དེབ་ཞབས་ཞུ་བ་ Readest ནང་ནས་ལྟ་ཞིབ་བྱེད། དེ་ནས་ཕབ་ལེན་བྱས་པའི་དཔེ་དེབ་རྣམས་ཁྱེད་ཀྱི་དཔེ་མཛོད་ནང་སྣོན་འཇུག་བྱེད།",
+  "Name (optional)": "མིང་། (འདེམས་ཀ)",
+  "Add Source": "འབྱུང་ཁུངས་སྣོན་པ།",
+  "Reload": "བསྐྱར་དུ་འཇུག་པ།",
+  "Stop": "མཚམས་འཇོག",
+  "More": "མང་བ།",
+  "Open in Browser": "དྲ་ལྟ་ཆས་ནང་ཁ་ཕྱེ།",
+  "Sign out of this site": "དྲ་ཚིགས་འདི་ནས་ཕྱིར་ཐོན།",
+  "Not secure": "བདེ་འཇགས་མེད།",
+  "Importing": "ནང་འདྲེན་བྱེད་བཞིན་པ།",
+  "Added to library": "དཔེ་མཛོད་ནང་སྣོན་འཇུག་བྱས།",
+  "Not a supported book format": "རྒྱབ་སྐྱོར་མེད་པའི་དཔེ་དེབ་རྣམ་གཞག"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2210,5 +2210,19 @@
   "Linked to “{{title}}”": "Mit „{{title}}“ verknüpft",
   "Hardcover link removed. The next sync will match the book again.": "Hardcover-Verknüpfung entfernt. Die nächste Synchronisierung ordnet das Buch erneut zu.",
   "{{pages}} pages": "{{pages}} Seiten",
-  "{{readers}} readers": "{{readers}} Leser"
+  "{{readers}} readers": "{{readers}} Leser",
+  "From Web Browser": "Aus Webbrowser",
+  "Please enter a valid http(s) URL": "Bitte eine gültige http(s)-URL eingeben",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Durchsuche deinen Calibre-Web-, Kavita- oder anderen Buchserver direkt in Readest. Dort heruntergeladene Bücher werden deiner Bibliothek hinzugefügt.",
+  "Name (optional)": "Name (optional)",
+  "Add Source": "Quelle hinzufügen",
+  "Reload": "Neu laden",
+  "Stop": "Stopp",
+  "More": "Mehr",
+  "Open in Browser": "Im Browser öffnen",
+  "Sign out of this site": "Von dieser Website abmelden",
+  "Not secure": "Nicht sicher",
+  "Importing": "Wird importiert",
+  "Added to library": "Zur Bibliothek hinzugefügt",
+  "Not a supported book format": "Kein unterstütztes Buchformat"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2210,5 +2210,19 @@
   "Linked to “{{title}}”": "Συνδέθηκε με το «{{title}}»",
   "Hardcover link removed. The next sync will match the book again.": "Η σύνδεση με το Hardcover αφαιρέθηκε. Ο επόμενος συγχρονισμός θα αντιστοιχίσει ξανά το βιβλίο.",
   "{{pages}} pages": "{{pages}} σελίδες",
-  "{{readers}} readers": "{{readers}} αναγνώστες"
+  "{{readers}} readers": "{{readers}} αναγνώστες",
+  "From Web Browser": "Από πρόγραμμα περιήγησης",
+  "Please enter a valid http(s) URL": "Εισαγάγετε μια έγκυρη διεύθυνση URL http(s)",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Περιηγηθείτε στον διακομιστή βιβλίων Calibre-Web, Kavita ή άλλον μέσα από το Readest. Τα βιβλία που κατεβάζετε εκεί προστίθενται στη βιβλιοθήκη σας.",
+  "Name (optional)": "Όνομα (προαιρετικό)",
+  "Add Source": "Προσθήκη πηγής",
+  "Reload": "Επαναφόρτωση",
+  "Stop": "Διακοπή",
+  "More": "Περισσότερα",
+  "Open in Browser": "Άνοιγμα στο πρόγραμμα περιήγησης",
+  "Sign out of this site": "Αποσύνδεση από αυτόν τον ιστότοπο",
+  "Not secure": "Μη ασφαλής",
+  "Importing": "Γίνεται εισαγωγή",
+  "Added to library": "Προστέθηκε στη βιβλιοθήκη",
+  "Not a supported book format": "Μη υποστηριζόμενη μορφή βιβλίου"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2270,5 +2270,19 @@
   "Linked to “{{title}}”": "Vinculado a «{{title}}»",
   "Hardcover link removed. The next sync will match the book again.": "Vínculo con Hardcover eliminado. La próxima sincronización volverá a buscar el libro.",
   "{{pages}} pages": "{{pages}} páginas",
-  "{{readers}} readers": "{{readers}} lectores"
+  "{{readers}} readers": "{{readers}} lectores",
+  "From Web Browser": "Desde el navegador web",
+  "Please enter a valid http(s) URL": "Introduce una URL http(s) válida",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Explora tu servidor de libros Calibre-Web, Kavita u otro dentro de Readest. Los libros que descargues allí se añadirán a tu biblioteca.",
+  "Name (optional)": "Nombre (opcional)",
+  "Add Source": "Añadir fuente",
+  "Reload": "Recargar",
+  "Stop": "Detener",
+  "More": "Más",
+  "Open in Browser": "Abrir en el navegador",
+  "Sign out of this site": "Cerrar sesión en este sitio",
+  "Not secure": "No seguro",
+  "Importing": "Importando",
+  "Added to library": "Añadido a la biblioteca",
+  "Not a supported book format": "Formato de libro no compatible"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2210,5 +2210,19 @@
   "Linked to “{{title}}”": "به «{{title}}» پیوند شد",
   "Hardcover link removed. The next sync will match the book again.": "پیوند Hardcover حذف شد. همگام‌سازی بعدی دوباره کتاب را تطبیق می‌دهد.",
   "{{pages}} pages": "{{pages}} صفحه",
-  "{{readers}} readers": "{{readers}} خواننده"
+  "{{readers}} readers": "{{readers}} خواننده",
+  "From Web Browser": "از مرورگر وب",
+  "Please enter a valid http(s) URL": "لطفاً یک نشانی http(s) معتبر وارد کنید",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "سرور کتاب Calibre-Web، Kavita یا هر سرور دیگر خود را داخل Readest مرور کنید. کتاب‌هایی که آنجا دانلود می‌کنید به کتابخانه شما افزوده می‌شوند.",
+  "Name (optional)": "نام (اختیاری)",
+  "Add Source": "افزودن منبع",
+  "Reload": "بارگذاری مجدد",
+  "Stop": "توقف",
+  "More": "بیشتر",
+  "Open in Browser": "باز کردن در مرورگر",
+  "Sign out of this site": "خروج از این سایت",
+  "Not secure": "ناامن",
+  "Importing": "در حال وارد کردن",
+  "Added to library": "به کتابخانه افزوده شد",
+  "Not a supported book format": "قالب کتاب پشتیبانی نمی‌شود"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2270,5 +2270,19 @@
   "Linked to “{{title}}”": "Lié à « {{title}} »",
   "Hardcover link removed. The next sync will match the book again.": "Lien Hardcover supprimé. La prochaine synchronisation associera à nouveau le livre.",
   "{{pages}} pages": "{{pages}} pages",
-  "{{readers}} readers": "{{readers}} lecteurs"
+  "{{readers}} readers": "{{readers}} lecteurs",
+  "From Web Browser": "Depuis le navigateur web",
+  "Please enter a valid http(s) URL": "Veuillez saisir une URL http(s) valide",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Parcourez votre serveur de livres Calibre-Web, Kavita ou autre directement dans Readest. Les livres que vous y téléchargez sont ajoutés à votre bibliothèque.",
+  "Name (optional)": "Nom (facultatif)",
+  "Add Source": "Ajouter une source",
+  "Reload": "Recharger",
+  "Stop": "Arrêter",
+  "More": "Plus",
+  "Open in Browser": "Ouvrir dans le navigateur",
+  "Sign out of this site": "Se déconnecter de ce site",
+  "Not secure": "Non sécurisé",
+  "Importing": "Importation en cours",
+  "Added to library": "Ajouté à la bibliothèque",
+  "Not a supported book format": "Format de livre non pris en charge"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2270,5 +2270,19 @@
   "Linked to “{{title}}”": "קושר אל „{{title}}“",
   "Hardcover link removed. The next sync will match the book again.": "הקישור ל-Hardcover הוסר. הסנכרון הבא יתאים את הספר מחדש.",
   "{{pages}} pages": "{{pages}} עמודים",
-  "{{readers}} readers": "{{readers}} קוראים"
+  "{{readers}} readers": "{{readers}} קוראים",
+  "From Web Browser": "מדפדפן אינטרנט",
+  "Please enter a valid http(s) URL": "יש להזין כתובת http(s) תקינה",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "גלשו בשרת הספרים שלכם (Calibre-Web, Kavita או אחר) בתוך Readest. ספרים שתורידו שם יתווספו לספרייה שלכם.",
+  "Name (optional)": "שם (אופציונלי)",
+  "Add Source": "הוספת מקור",
+  "Reload": "טעינה מחדש",
+  "Stop": "עצור",
+  "More": "עוד",
+  "Open in Browser": "פתיחה בדפדפן",
+  "Sign out of this site": "התנתקות מאתר זה",
+  "Not secure": "לא מאובטח",
+  "Importing": "מייבא",
+  "Added to library": "נוסף לספרייה",
+  "Not a supported book format": "פורמט ספר לא נתמך"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2210,5 +2210,19 @@
   "Linked to “{{title}}”": "“{{title}}” से लिंक किया गया",
   "Hardcover link removed. The next sync will match the book again.": "Hardcover लिंक हटा दिया गया। अगला सिंक पुस्तक को फिर से मिलाएगा।",
   "{{pages}} pages": "{{pages}} पृष्ठ",
-  "{{readers}} readers": "{{readers}} पाठक"
+  "{{readers}} readers": "{{readers}} पाठक",
+  "From Web Browser": "वेब ब्राउज़र से",
+  "Please enter a valid http(s) URL": "कृपया एक मान्य http(s) URL दर्ज करें",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "अपने Calibre-Web, Kavita या अन्य पुस्तक सर्वर को Readest के भीतर ब्राउज़ करें। वहाँ डाउनलोड की गई पुस्तकें आपकी लाइब्रेरी में जुड़ जाती हैं।",
+  "Name (optional)": "नाम (वैकल्पिक)",
+  "Add Source": "स्रोत जोड़ें",
+  "Reload": "पुनः लोड करें",
+  "Stop": "रोकें",
+  "More": "अधिक",
+  "Open in Browser": "ब्राउज़र में खोलें",
+  "Sign out of this site": "इस साइट से साइन आउट करें",
+  "Not secure": "सुरक्षित नहीं",
+  "Importing": "आयात हो रहा है",
+  "Added to library": "लाइब्रेरी में जोड़ा गया",
+  "Not a supported book format": "असमर्थित पुस्तक प्रारूप"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2210,5 +2210,19 @@
   "Linked to “{{title}}”": "Összekapcsolva ezzel: „{{title}}”",
   "Hardcover link removed. The next sync will match the book again.": "A Hardcover-kapcsolat eltávolítva. A következő szinkronizálás újra párosítja a könyvet.",
   "{{pages}} pages": "{{pages}} oldal",
-  "{{readers}} readers": "{{readers}} olvasó"
+  "{{readers}} readers": "{{readers}} olvasó",
+  "From Web Browser": "Webböngészőből",
+  "Please enter a valid http(s) URL": "Adjon meg egy érvényes http(s) URL-t",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Böngéssze Calibre-Web, Kavita vagy más könyvszerverét a Readesten belül. Az ott letöltött könyvek a könyvtárába kerülnek.",
+  "Name (optional)": "Név (nem kötelező)",
+  "Add Source": "Forrás hozzáadása",
+  "Reload": "Újratöltés",
+  "Stop": "Leállítás",
+  "More": "Több",
+  "Open in Browser": "Megnyitás böngészőben",
+  "Sign out of this site": "Kijelentkezés erről a webhelyről",
+  "Not secure": "Nem biztonságos",
+  "Importing": "Importálás",
+  "Added to library": "Hozzáadva a könyvtárhoz",
+  "Not a supported book format": "Nem támogatott könyvformátum"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2150,5 +2150,19 @@
   "Linked to “{{title}}”": "Ditautkan ke “{{title}}”",
   "Hardcover link removed. The next sync will match the book again.": "Tautan Hardcover dihapus. Sinkronisasi berikutnya akan mencocokkan buku lagi.",
   "{{pages}} pages": "{{pages}} halaman",
-  "{{readers}} readers": "{{readers}} pembaca"
+  "{{readers}} readers": "{{readers}} pembaca",
+  "From Web Browser": "Dari browser web",
+  "Please enter a valid http(s) URL": "Masukkan URL http(s) yang valid",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Jelajahi server buku Calibre-Web, Kavita, atau lainnya di dalam Readest. Buku yang Anda unduh di sana akan ditambahkan ke perpustakaan Anda.",
+  "Name (optional)": "Nama (opsional)",
+  "Add Source": "Tambah sumber",
+  "Reload": "Muat ulang",
+  "Stop": "Berhenti",
+  "More": "Lainnya",
+  "Open in Browser": "Buka di browser",
+  "Sign out of this site": "Keluar dari situs ini",
+  "Not secure": "Tidak aman",
+  "Importing": "Mengimpor",
+  "Added to library": "Ditambahkan ke perpustakaan",
+  "Not a supported book format": "Format buku tidak didukung"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2270,5 +2270,19 @@
   "Linked to “{{title}}”": "Collegato a “{{title}}”",
   "Hardcover link removed. The next sync will match the book again.": "Collegamento Hardcover rimosso. La prossima sincronizzazione abbinerà di nuovo il libro.",
   "{{pages}} pages": "{{pages}} pagine",
-  "{{readers}} readers": "{{readers}} lettori"
+  "{{readers}} readers": "{{readers}} lettori",
+  "From Web Browser": "Dal browser web",
+  "Please enter a valid http(s) URL": "Inserisci un URL http(s) valido",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Sfoglia il tuo server di libri Calibre-Web, Kavita o altro direttamente in Readest. I libri che scarichi lì vengono aggiunti alla tua libreria.",
+  "Name (optional)": "Nome (facoltativo)",
+  "Add Source": "Aggiungi sorgente",
+  "Reload": "Ricarica",
+  "Stop": "Interrompi",
+  "More": "Altro",
+  "Open in Browser": "Apri nel browser",
+  "Sign out of this site": "Esci da questo sito",
+  "Not secure": "Non sicuro",
+  "Importing": "Importazione in corso",
+  "Added to library": "Aggiunto alla libreria",
+  "Not a supported book format": "Formato di libro non supportato"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2150,5 +2150,19 @@
   "Linked to “{{title}}”": "「{{title}}」にリンクしました",
   "Hardcover link removed. The next sync will match the book again.": "Hardcoverのリンクを解除しました。次回の同期で本を再度照合します。",
   "{{pages}} pages": "{{pages}}ページ",
-  "{{readers}} readers": "{{readers}}人が読書"
+  "{{readers}} readers": "{{readers}}人が読書",
+  "From Web Browser": "ウェブブラウザから",
+  "Please enter a valid http(s) URL": "有効な http(s) URL を入力してください",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Calibre-Web、Kavita などの書籍サーバーを Readest 内で閲覧できます。そこでダウンロードした書籍はライブラリに追加されます。",
+  "Name (optional)": "名前（任意）",
+  "Add Source": "ソースを追加",
+  "Reload": "再読み込み",
+  "Stop": "停止",
+  "More": "その他",
+  "Open in Browser": "ブラウザで開く",
+  "Sign out of this site": "このサイトからサインアウト",
+  "Not secure": "保護されていない通信",
+  "Importing": "インポート中",
+  "Added to library": "ライブラリに追加しました",
+  "Not a supported book format": "対応していない書籍形式です"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2210,5 +2210,19 @@
   "Linked to “{{title}}”": "დაკავშირდა „{{title}}“-თან",
   "Hardcover link removed. The next sync will match the book again.": "Hardcover კავშირი წაიშალა. შემდეგი სინქრონიზაცია წიგნს ხელახლა შეუსაბამებს.",
   "{{pages}} pages": "{{pages}} გვერდი",
-  "{{readers}} readers": "{{readers}} მკითხველი"
+  "{{readers}} readers": "{{readers}} მკითხველი",
+  "From Web Browser": "ვებ-ბრაუზერიდან",
+  "Please enter a valid http(s) URL": "გთხოვთ, შეიყვანოთ სწორი http(s) URL",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "დაათვალიერეთ თქვენი Calibre-Web, Kavita ან სხვა წიგნების სერვერი Readest-ის შიგნით. იქ ჩამოტვირთული წიგნები თქვენს ბიბლიოთეკას ემატება.",
+  "Name (optional)": "სახელი (არასავალდებულო)",
+  "Add Source": "წყაროს დამატება",
+  "Reload": "ხელახლა ჩატვირთვა",
+  "Stop": "შეჩერება",
+  "More": "მეტი",
+  "Open in Browser": "ბრაუზერში გახსნა",
+  "Sign out of this site": "ამ საიტიდან გასვლა",
+  "Not secure": "დაუცველი",
+  "Importing": "იმპორტირდება",
+  "Added to library": "ბიბლიოთეკაში დაემატა",
+  "Not a supported book format": "წიგნის ფორმატი მხარდაუჭერელია"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2150,5 +2150,19 @@
   "Linked to “{{title}}”": "“{{title}}”에 연결됨",
   "Hardcover link removed. The next sync will match the book again.": "Hardcover 연결이 해제되었습니다. 다음 동기화 시 책을 다시 매칭합니다.",
   "{{pages}} pages": "{{pages}}페이지",
-  "{{readers}} readers": "독자 {{readers}}명"
+  "{{readers}} readers": "독자 {{readers}}명",
+  "From Web Browser": "웹 브라우저에서",
+  "Please enter a valid http(s) URL": "유효한 http(s) URL을 입력하세요",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Calibre-Web, Kavita 등 책 서버를 Readest 안에서 둘러보세요. 거기서 다운로드한 책은 라이브러리에 추가됩니다.",
+  "Name (optional)": "이름(선택 사항)",
+  "Add Source": "소스 추가",
+  "Reload": "새로고침",
+  "Stop": "중지",
+  "More": "더보기",
+  "Open in Browser": "브라우저에서 열기",
+  "Sign out of this site": "이 사이트에서 로그아웃",
+  "Not secure": "안전하지 않음",
+  "Importing": "가져오는 중",
+  "Added to library": "라이브러리에 추가됨",
+  "Not a supported book format": "지원되지 않는 책 형식입니다"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2150,5 +2150,19 @@
   "Linked to “{{title}}”": "Dipautkan ke “{{title}}”",
   "Hardcover link removed. The next sync will match the book again.": "Pautan Hardcover dialih keluar. Penyegerakan seterusnya akan memadankan buku semula.",
   "{{pages}} pages": "{{pages}} halaman",
-  "{{readers}} readers": "{{readers}} pembaca"
+  "{{readers}} readers": "{{readers}} pembaca",
+  "From Web Browser": "Daripada pelayar web",
+  "Please enter a valid http(s) URL": "Sila masukkan URL http(s) yang sah",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Layari pelayan buku Calibre-Web, Kavita atau lain-lain di dalam Readest. Buku yang anda muat turun di sana akan ditambah ke perpustakaan anda.",
+  "Name (optional)": "Nama (pilihan)",
+  "Add Source": "Tambah sumber",
+  "Reload": "Muat semula",
+  "Stop": "Berhenti",
+  "More": "Lagi",
+  "Open in Browser": "Buka dalam pelayar",
+  "Sign out of this site": "Log keluar dari laman ini",
+  "Not secure": "Tidak selamat",
+  "Importing": "Mengimport",
+  "Added to library": "Ditambah ke perpustakaan",
+  "Not a supported book format": "Format buku tidak disokong"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2210,5 +2210,19 @@
   "Linked to “{{title}}”": "Gekoppeld aan “{{title}}”",
   "Hardcover link removed. The next sync will match the book again.": "Hardcover-koppeling verwijderd. De volgende synchronisatie zoekt het boek opnieuw.",
   "{{pages}} pages": "{{pages}} pagina's",
-  "{{readers}} readers": "{{readers}} lezers"
+  "{{readers}} readers": "{{readers}} lezers",
+  "From Web Browser": "Vanuit webbrowser",
+  "Please enter a valid http(s) URL": "Voer een geldige http(s)-URL in",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Blader door je Calibre-Web-, Kavita- of andere boekenserver binnen Readest. Boeken die je daar downloadt, worden aan je bibliotheek toegevoegd.",
+  "Name (optional)": "Naam (optioneel)",
+  "Add Source": "Bron toevoegen",
+  "Reload": "Herladen",
+  "Stop": "Stoppen",
+  "More": "Meer",
+  "Open in Browser": "Openen in browser",
+  "Sign out of this site": "Uitloggen bij deze site",
+  "Not secure": "Niet beveiligd",
+  "Importing": "Importeren",
+  "Added to library": "Toegevoegd aan bibliotheek",
+  "Not a supported book format": "Boekformaat wordt niet ondersteund"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2330,5 +2330,19 @@
   "Linked to “{{title}}”": "Połączono z „{{title}}”",
   "Hardcover link removed. The next sync will match the book again.": "Usunięto połączenie z Hardcover. Następna synchronizacja ponownie dopasuje książkę.",
   "{{pages}} pages": "{{pages}} stron",
-  "{{readers}} readers": "{{readers}} czytelników"
+  "{{readers}} readers": "{{readers}} czytelników",
+  "From Web Browser": "Z przeglądarki internetowej",
+  "Please enter a valid http(s) URL": "Wpisz prawidłowy adres URL http(s)",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Przeglądaj swój serwer książek Calibre-Web, Kavita lub inny bezpośrednio w Readest. Pobrane tam książki trafiają do Twojej biblioteki.",
+  "Name (optional)": "Nazwa (opcjonalnie)",
+  "Add Source": "Dodaj źródło",
+  "Reload": "Odśwież",
+  "Stop": "Zatrzymaj",
+  "More": "Więcej",
+  "Open in Browser": "Otwórz w przeglądarce",
+  "Sign out of this site": "Wyloguj się z tej witryny",
+  "Not secure": "Niezabezpieczona",
+  "Importing": "Importowanie",
+  "Added to library": "Dodano do biblioteki",
+  "Not a supported book format": "Nieobsługiwany format książki"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2270,5 +2270,19 @@
   "Linked to “{{title}}”": "Vinculado a “{{title}}”",
   "Hardcover link removed. The next sync will match the book again.": "Vínculo com o Hardcover removido. A próxima sincronização buscará o livro novamente.",
   "{{pages}} pages": "{{pages}} páginas",
-  "{{readers}} readers": "{{readers}} leitores"
+  "{{readers}} readers": "{{readers}} leitores",
+  "From Web Browser": "Do navegador web",
+  "Please enter a valid http(s) URL": "Digite uma URL http(s) válida",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Navegue no seu servidor de livros Calibre-Web, Kavita ou outro dentro do Readest. Os livros baixados lá são adicionados à sua biblioteca.",
+  "Name (optional)": "Nome (opcional)",
+  "Add Source": "Adicionar fonte",
+  "Reload": "Recarregar",
+  "Stop": "Parar",
+  "More": "Mais",
+  "Open in Browser": "Abrir no navegador",
+  "Sign out of this site": "Sair deste site",
+  "Not secure": "Não seguro",
+  "Importing": "Importando",
+  "Added to library": "Adicionado à biblioteca",
+  "Not a supported book format": "Formato de livro não suportado"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2270,5 +2270,19 @@
   "Linked to “{{title}}”": "Associado a “{{title}}”",
   "Hardcover link removed. The next sync will match the book again.": "Associação ao Hardcover removida. A próxima sincronização voltará a corresponder o livro.",
   "{{pages}} pages": "{{pages}} páginas",
-  "{{readers}} readers": "{{readers}} leitores"
+  "{{readers}} readers": "{{readers}} leitores",
+  "From Web Browser": "A partir do navegador web",
+  "Please enter a valid http(s) URL": "Introduza um URL http(s) válido",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Navegue no seu servidor de livros Calibre-Web, Kavita ou outro dentro do Readest. Os livros que aí descarregar são adicionados à sua biblioteca.",
+  "Name (optional)": "Nome (opcional)",
+  "Add Source": "Adicionar fonte",
+  "Reload": "Recarregar",
+  "Stop": "Parar",
+  "More": "Mais",
+  "Open in Browser": "Abrir no navegador",
+  "Sign out of this site": "Terminar sessão neste site",
+  "Not secure": "Não seguro",
+  "Importing": "A importar",
+  "Added to library": "Adicionado à biblioteca",
+  "Not a supported book format": "Formato de livro não suportado"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2270,5 +2270,19 @@
   "Linked to “{{title}}”": "Asociată cu „{{title}}”",
   "Hardcover link removed. The next sync will match the book again.": "Asocierea cu Hardcover a fost eliminată. Următoarea sincronizare va potrivi din nou cartea.",
   "{{pages}} pages": "{{pages}} pagini",
-  "{{readers}} readers": "{{readers}} cititori"
+  "{{readers}} readers": "{{readers}} cititori",
+  "From Web Browser": "Din browserul web",
+  "Please enter a valid http(s) URL": "Introduceți un URL http(s) valid",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Răsfoiți serverul de cărți Calibre-Web, Kavita sau altul direct în Readest. Cărțile descărcate acolo sunt adăugate în biblioteca dvs.",
+  "Name (optional)": "Nume (opțional)",
+  "Add Source": "Adaugă sursă",
+  "Reload": "Reîncarcă",
+  "Stop": "Oprește",
+  "More": "Mai multe",
+  "Open in Browser": "Deschide în browser",
+  "Sign out of this site": "Deconectare de pe acest site",
+  "Not secure": "Nesecurizat",
+  "Importing": "Se importă",
+  "Added to library": "Adăugat în bibliotecă",
+  "Not a supported book format": "Format de carte neacceptat"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2330,5 +2330,19 @@
   "Linked to “{{title}}”": "Связано с «{{title}}»",
   "Hardcover link removed. The next sync will match the book again.": "Связь с Hardcover удалена. Следующая синхронизация снова подберёт книгу.",
   "{{pages}} pages": "{{pages}} страниц",
-  "{{readers}} readers": "{{readers}} читателей"
+  "{{readers}} readers": "{{readers}} читателей",
+  "From Web Browser": "Из веб-браузера",
+  "Please enter a valid http(s) URL": "Введите действительный URL http(s)",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Просматривайте свой сервер книг Calibre-Web, Kavita или другой прямо в Readest. Загруженные там книги добавляются в вашу библиотеку.",
+  "Name (optional)": "Название (необязательно)",
+  "Add Source": "Добавить источник",
+  "Reload": "Перезагрузить",
+  "Stop": "Остановить",
+  "More": "Ещё",
+  "Open in Browser": "Открыть в браузере",
+  "Sign out of this site": "Выйти с этого сайта",
+  "Not secure": "Не защищено",
+  "Importing": "Импорт",
+  "Added to library": "Добавлено в библиотеку",
+  "Not a supported book format": "Неподдерживаемый формат книги"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2210,5 +2210,19 @@
   "Linked to “{{title}}”": "“{{title}}” සමඟ සම්බන්ධ කරන ලදී",
   "Hardcover link removed. The next sync will match the book again.": "Hardcover සම්බන්ධය ඉවත් කරන ලදී. ඊළඟ සමමුහුර්තකරණයේදී පොත නැවත ගැළපේ.",
   "{{pages}} pages": "පිටු {{pages}}",
-  "{{readers}} readers": "පාඨකයින් {{readers}}"
+  "{{readers}} readers": "පාඨකයින් {{readers}}",
+  "From Web Browser": "වෙබ් බ්‍රව්සරයෙන්",
+  "Please enter a valid http(s) URL": "කරුණාකර වලංගු http(s) URL එකක් ඇතුළත් කරන්න",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "ඔබගේ Calibre-Web, Kavita හෝ වෙනත් පොත් සේවාදායකය Readest තුළම බ්‍රව්ස් කරන්න. එහිදී බාගන්නා පොත් ඔබගේ පුස්තකාලයට එක් වේ.",
+  "Name (optional)": "නම (විකල්ප)",
+  "Add Source": "මූලාශ්‍රයක් එක් කරන්න",
+  "Reload": "නැවත පූරණය කරන්න",
+  "Stop": "නවත්වන්න",
+  "More": "තවත්",
+  "Open in Browser": "බ්‍රව්සරයේ විවෘත කරන්න",
+  "Sign out of this site": "මෙම වෙබ් අඩවියෙන් ඉවත් වන්න",
+  "Not secure": "ආරක්ෂිත නොවේ",
+  "Importing": "ආයාත කරමින්",
+  "Added to library": "පුස්තකාලයට එක් කරන ලදී",
+  "Not a supported book format": "සහාය නොදක්වන පොත් ආකෘතියකි"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2330,5 +2330,19 @@
   "Linked to “{{title}}”": "Povezano z »{{title}}«",
   "Hardcover link removed. The next sync will match the book again.": "Povezava s Hardcover je odstranjena. Naslednja sinhronizacija bo knjigo znova poiskala.",
   "{{pages}} pages": "{{pages}} strani",
-  "{{readers}} readers": "{{readers}} bralcev"
+  "{{readers}} readers": "{{readers}} bralcev",
+  "From Web Browser": "Iz spletnega brskalnika",
+  "Please enter a valid http(s) URL": "Vnesite veljaven URL http(s)",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Brskajte po svojem strežniku knjig Calibre-Web, Kavita ali drugem kar v Readestu. Knjige, ki jih tam prenesete, se dodajo v vašo knjižnico.",
+  "Name (optional)": "Ime (neobvezno)",
+  "Add Source": "Dodaj vir",
+  "Reload": "Znova naloži",
+  "Stop": "Ustavi",
+  "More": "Več",
+  "Open in Browser": "Odpri v brskalniku",
+  "Sign out of this site": "Odjava s tega spletnega mesta",
+  "Not secure": "Ni varno",
+  "Importing": "Uvažanje",
+  "Added to library": "Dodano v knjižnico",
+  "Not a supported book format": "Nepodprta oblika knjige"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2210,5 +2210,19 @@
   "Linked to “{{title}}”": "Länkad till ”{{title}}”",
   "Hardcover link removed. The next sync will match the book again.": "Hardcover-länken har tagits bort. Nästa synkronisering matchar boken igen.",
   "{{pages}} pages": "{{pages}} sidor",
-  "{{readers}} readers": "{{readers}} läsare"
+  "{{readers}} readers": "{{readers}} läsare",
+  "From Web Browser": "Från webbläsare",
+  "Please enter a valid http(s) URL": "Ange en giltig http(s)-URL",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Bläddra i din Calibre-Web-, Kavita- eller annan bokserver inuti Readest. Böcker du laddar ner där läggs till i ditt bibliotek.",
+  "Name (optional)": "Namn (valfritt)",
+  "Add Source": "Lägg till källa",
+  "Reload": "Ladda om",
+  "Stop": "Stoppa",
+  "More": "Mer",
+  "Open in Browser": "Öppna i webbläsare",
+  "Sign out of this site": "Logga ut från den här webbplatsen",
+  "Not secure": "Inte säker",
+  "Importing": "Importerar",
+  "Added to library": "Tillagd i biblioteket",
+  "Not a supported book format": "Bokformatet stöds inte"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2210,5 +2210,19 @@
   "Linked to “{{title}}”": "“{{title}}”-உடன் இணைக்கப்பட்டது",
   "Hardcover link removed. The next sync will match the book again.": "Hardcover இணைப்பு நீக்கப்பட்டது. அடுத்த ஒத்திசைவில் புத்தகம் மீண்டும் பொருத்தப்படும்.",
   "{{pages}} pages": "{{pages}} பக்கங்கள்",
-  "{{readers}} readers": "{{readers}} வாசகர்கள்"
+  "{{readers}} readers": "{{readers}} வாசகர்கள்",
+  "From Web Browser": "இணைய உலாவியிலிருந்து",
+  "Please enter a valid http(s) URL": "சரியான http(s) URL ஐ உள்ளிடவும்",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "உங்கள் Calibre-Web, Kavita அல்லது பிற புத்தக சேவையகத்தை Readest-க்குள்ளேயே உலாவுங்கள். அங்கு பதிவிறக்கும் புத்தகங்கள் உங்கள் நூலகத்தில் சேர்க்கப்படும்.",
+  "Name (optional)": "பெயர் (விருப்பத்தேர்வு)",
+  "Add Source": "மூலத்தைச் சேர்",
+  "Reload": "மீண்டும் ஏற்று",
+  "Stop": "நிறுத்து",
+  "More": "மேலும்",
+  "Open in Browser": "உலாவியில் திற",
+  "Sign out of this site": "இந்த தளத்திலிருந்து வெளியேறு",
+  "Not secure": "பாதுகாப்பற்றது",
+  "Importing": "இறக்குமதி செய்கிறது",
+  "Added to library": "நூலகத்தில் சேர்க்கப்பட்டது",
+  "Not a supported book format": "ஆதரிக்கப்படாத புத்தக வடிவம்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2150,5 +2150,19 @@
   "Linked to “{{title}}”": "เชื่อมโยงกับ “{{title}}” แล้ว",
   "Hardcover link removed. The next sync will match the book again.": "ลบการเชื่อมโยง Hardcover แล้ว การซิงค์ครั้งถัดไปจะจับคู่หนังสืออีกครั้ง",
   "{{pages}} pages": "{{pages}} หน้า",
-  "{{readers}} readers": "ผู้อ่าน {{readers}} คน"
+  "{{readers}} readers": "ผู้อ่าน {{readers}} คน",
+  "From Web Browser": "จากเว็บเบราว์เซอร์",
+  "Please enter a valid http(s) URL": "กรุณาใส่ URL http(s) ที่ถูกต้อง",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "เรียกดูเซิร์ฟเวอร์หนังสือ Calibre-Web, Kavita หรืออื่น ๆ ของคุณภายใน Readest หนังสือที่คุณดาวน์โหลดจากที่นั่นจะถูกเพิ่มลงในคลังหนังสือของคุณ",
+  "Name (optional)": "ชื่อ (ไม่บังคับ)",
+  "Add Source": "เพิ่มแหล่งที่มา",
+  "Reload": "โหลดใหม่",
+  "Stop": "หยุด",
+  "More": "เพิ่มเติม",
+  "Open in Browser": "เปิดในเบราว์เซอร์",
+  "Sign out of this site": "ออกจากระบบเว็บไซต์นี้",
+  "Not secure": "ไม่ปลอดภัย",
+  "Importing": "กำลังนำเข้า",
+  "Added to library": "เพิ่มลงในคลังหนังสือแล้ว",
+  "Not a supported book format": "รูปแบบหนังสือไม่รองรับ"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2210,5 +2210,19 @@
   "Linked to “{{title}}”": "“{{title}}” ile bağlandı",
   "Hardcover link removed. The next sync will match the book again.": "Hardcover bağlantısı kaldırıldı. Bir sonraki senkronizasyon kitabı yeniden eşleştirecek.",
   "{{pages}} pages": "{{pages}} sayfa",
-  "{{readers}} readers": "{{readers}} okuyucu"
+  "{{readers}} readers": "{{readers}} okuyucu",
+  "From Web Browser": "Web tarayıcısından",
+  "Please enter a valid http(s) URL": "Lütfen geçerli bir http(s) URL'si girin",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Calibre-Web, Kavita veya başka bir kitap sunucunuza Readest içinden göz atın. Orada indirdiğiniz kitaplar kitaplığınıza eklenir.",
+  "Name (optional)": "Ad (isteğe bağlı)",
+  "Add Source": "Kaynak ekle",
+  "Reload": "Yenile",
+  "Stop": "Durdur",
+  "More": "Daha fazla",
+  "Open in Browser": "Tarayıcıda aç",
+  "Sign out of this site": "Bu siteden çıkış yap",
+  "Not secure": "Güvenli değil",
+  "Importing": "İçe aktarılıyor",
+  "Added to library": "Kitaplığa eklendi",
+  "Not a supported book format": "Desteklenmeyen kitap biçimi"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2330,5 +2330,19 @@
   "Linked to “{{title}}”": "Пов'язано з «{{title}}»",
   "Hardcover link removed. The next sync will match the book again.": "Зв'язок із Hardcover видалено. Наступна синхронізація знову зіставить книгу.",
   "{{pages}} pages": "{{pages}} сторінок",
-  "{{readers}} readers": "{{readers}} читачів"
+  "{{readers}} readers": "{{readers}} читачів",
+  "From Web Browser": "З веббраузера",
+  "Please enter a valid http(s) URL": "Введіть дійсну URL-адресу http(s)",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Переглядайте свій сервер книг Calibre-Web, Kavita чи інший прямо в Readest. Завантажені там книги додаються до вашої бібліотеки.",
+  "Name (optional)": "Назва (необов’язково)",
+  "Add Source": "Додати джерело",
+  "Reload": "Перезавантажити",
+  "Stop": "Зупинити",
+  "More": "Більше",
+  "Open in Browser": "Відкрити у браузері",
+  "Sign out of this site": "Вийти з цього сайту",
+  "Not secure": "Не захищено",
+  "Importing": "Імпортування",
+  "Added to library": "Додано до бібліотеки",
+  "Not a supported book format": "Непідтримуваний формат книги"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2210,5 +2210,19 @@
   "Linked to “{{title}}”": "“{{title}}” bilan bogʻlandi",
   "Hardcover link removed. The next sync will match the book again.": "Hardcover bogʻlanishi olib tashlandi. Keyingi sinxronlash kitobni qayta moslaydi.",
   "{{pages}} pages": "{{pages}} sahifa",
-  "{{readers}} readers": "{{readers}} oʻquvchi"
+  "{{readers}} readers": "{{readers}} oʻquvchi",
+  "From Web Browser": "Veb-brauzerdan",
+  "Please enter a valid http(s) URL": "Yaroqli http(s) URL kiriting",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Calibre-Web, Kavita yoki boshqa kitob serveringizni Readest ichida ko‘ring. U yerdan yuklab olingan kitoblar kutubxonangizga qo‘shiladi.",
+  "Name (optional)": "Nomi (ixtiyoriy)",
+  "Add Source": "Manba qo‘shish",
+  "Reload": "Qayta yuklash",
+  "Stop": "To‘xtatish",
+  "More": "Ko‘proq",
+  "Open in Browser": "Brauzerda ochish",
+  "Sign out of this site": "Bu saytdan chiqish",
+  "Not secure": "Xavfsiz emas",
+  "Importing": "Import qilinmoqda",
+  "Added to library": "Kutubxonaga qo‘shildi",
+  "Not a supported book format": "Qo‘llab-quvvatlanmaydigan kitob formati"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2150,5 +2150,19 @@
   "Linked to “{{title}}”": "Đã liên kết với “{{title}}”",
   "Hardcover link removed. The next sync will match the book again.": "Đã gỡ liên kết Hardcover. Lần đồng bộ tiếp theo sẽ tự khớp lại sách.",
   "{{pages}} pages": "{{pages}} trang",
-  "{{readers}} readers": "{{readers}} người đọc"
+  "{{readers}} readers": "{{readers}} người đọc",
+  "From Web Browser": "Từ trình duyệt web",
+  "Please enter a valid http(s) URL": "Vui lòng nhập URL http(s) hợp lệ",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "Duyệt máy chủ sách Calibre-Web, Kavita hoặc máy chủ khác ngay trong Readest. Sách bạn tải về ở đó sẽ được thêm vào thư viện.",
+  "Name (optional)": "Tên (tùy chọn)",
+  "Add Source": "Thêm nguồn",
+  "Reload": "Tải lại",
+  "Stop": "Dừng",
+  "More": "Thêm",
+  "Open in Browser": "Mở trong trình duyệt",
+  "Sign out of this site": "Đăng xuất khỏi trang này",
+  "Not secure": "Không an toàn",
+  "Importing": "Đang nhập",
+  "Added to library": "Đã thêm vào thư viện",
+  "Not a supported book format": "Định dạng sách không được hỗ trợ"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2150,5 +2150,19 @@
   "Linked to “{{title}}”": "已关联到《{{title}}》",
   "Hardcover link removed. The next sync will match the book again.": "已取消 Hardcover 关联，下次同步时将重新匹配图书。",
   "{{pages}} pages": "{{pages}} 页",
-  "{{readers}} readers": "{{readers}} 位读者"
+  "{{readers}} readers": "{{readers}} 位读者",
+  "From Web Browser": "从网页浏览器",
+  "Please enter a valid http(s) URL": "请输入有效的 http(s) 网址",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "在 Readest 内直接浏览你的 Calibre-Web、Kavita 或其他图书服务器，在那里下载的图书会自动加入书库。",
+  "Name (optional)": "名称（可选）",
+  "Add Source": "添加来源",
+  "Reload": "重新加载",
+  "Stop": "停止",
+  "More": "更多",
+  "Open in Browser": "在浏览器中打开",
+  "Sign out of this site": "退出此网站",
+  "Not secure": "不安全",
+  "Importing": "正在导入",
+  "Added to library": "已加入书库",
+  "Not a supported book format": "不支持的图书格式"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2150,5 +2150,19 @@
   "Linked to “{{title}}”": "已連結至《{{title}}》",
   "Hardcover link removed. The next sync will match the book again.": "已取消 Hardcover 連結，下次同步時將重新比對書籍。",
   "{{pages}} pages": "{{pages}} 頁",
-  "{{readers}} readers": "{{readers}} 位讀者"
+  "{{readers}} readers": "{{readers}} 位讀者",
+  "From Web Browser": "從網頁瀏覽器",
+  "Please enter a valid http(s) URL": "請輸入有效的 http(s) 網址",
+  "Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.": "在 Readest 內直接瀏覽你的 Calibre-Web、Kavita 或其他書籍伺服器，在那裡下載的書籍會自動加入書庫。",
+  "Name (optional)": "名稱（選填）",
+  "Add Source": "新增來源",
+  "Reload": "重新載入",
+  "Stop": "停止",
+  "More": "更多",
+  "Open in Browser": "在瀏覽器中開啟",
+  "Sign out of this site": "登出此網站",
+  "Not secure": "不安全",
+  "Importing": "正在匯入",
+  "Added to library": "已加入書庫",
+  "Not a supported book format": "不支援的書籍格式"
 }

--- a/apps/readest-app/src-tauri/build.rs
+++ b/apps/readest-app/src-tauri/build.rs
@@ -48,6 +48,8 @@ fn main() {
             "update_book_presence",
             "clear_book_presence",
             "clip_url",
+            "open_web_browser",
+            "set_web_browser_status",
             "spawn_fresh_browser",
             "verify_update_signature",
             "install_nightly_update",

--- a/apps/readest-app/src-tauri/capabilities/default.json
+++ b/apps/readest-app/src-tauri/capabilities/default.json
@@ -233,6 +233,8 @@
     "allow-update-book-presence",
     "allow-clear-book-presence",
     "allow-clip-url",
+    "allow-open-web-browser",
+    "allow-set-web-browser-status",
     "allow-spawn-fresh-browser",
     "allow-verify-update-signature",
     "allow-install-nightly-update",

--- a/apps/readest-app/src-tauri/permissions/autogenerated/open_web_browser.toml
+++ b/apps/readest-app/src-tauri/permissions/autogenerated/open_web_browser.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-open-web-browser"
+description = "Enables the open_web_browser command without any pre-configured scope."
+commands.allow = ["open_web_browser"]
+
+[[permission]]
+identifier = "deny-open-web-browser"
+description = "Denies the open_web_browser command without any pre-configured scope."
+commands.deny = ["open_web_browser"]

--- a/apps/readest-app/src-tauri/permissions/autogenerated/set_web_browser_status.toml
+++ b/apps/readest-app/src-tauri/permissions/autogenerated/set_web_browser_status.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-set-web-browser-status"
+description = "Enables the set_web_browser_status command without any pre-configured scope."
+commands.allow = ["set_web_browser_status"]
+
+[[permission]]
+identifier = "deny-set-web-browser-status"
+description = "Denies the set_web_browser_status command without any pre-configured scope."
+commands.deny = ["set_web_browser_status"]

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -224,6 +224,9 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
     // packets without it. Released in onDestroy.
     private var multicastLock: android.net.wifi.WifiManager.MulticastLock? = null
 
+    // The in-app browser presented by `open_web_browser` (#5775); null when closed.
+    private var activeWebBrowser: WebBrowserController? = null
+
     private var sensorManager: SensorManager? = null
     private var ambientLightListening = false
     private var lastEmittedLux: Float = Float.NaN
@@ -1797,6 +1800,57 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
             }
         }
         controller.show()
+    }
+
+    /**
+     * Present the in-app browser (#5775). Resolves `{ openBookHash? }` when
+     * the user closes it; downloads are emitted as `web-browser-download`
+     * plugin events while it is open (queued if JS has not registered yet).
+     */
+    @Command
+    fun open_web_browser(invoke: Invoke) {
+        val args = try {
+            invoke.parseArgs(WebBrowserArgs::class.java)
+        } catch (e: Exception) {
+            invoke.reject(e.message ?: "Invalid open_web_browser args")
+            return
+        }
+        val controller = WebBrowserController(
+            activity,
+            args,
+            onDownload = { event ->
+                val payload = JSObject()
+                payload.put("url", event.url)
+                payload.put("path", event.path)
+                payload.put("filename", event.filename)
+                payload.put("success", event.success)
+                event.error?.let { payload.put("error", it) }
+                emitOrQueue("web-browser-download", payload)
+            },
+            completion = { hash ->
+                activeWebBrowser = null
+                val ret = JSObject()
+                if (hash != null) ret.put("openBookHash", hash)
+                invoke.resolve(ret)
+            },
+        )
+        activeWebBrowser = controller
+        controller.show()
+    }
+
+    /** Push an import status into the open browser's banner. */
+    @Command
+    fun set_web_browser_status(invoke: Invoke) {
+        val args = try {
+            invoke.parseArgs(WebBrowserStatusArgs::class.java)
+        } catch (e: Exception) {
+            invoke.reject(e.message ?: "Invalid set_web_browser_status args")
+            return
+        }
+        activity.runOnUiThread {
+            activeWebBrowser?.setStatus(args.state ?: "", args.filename ?: "", args.bookHash)
+        }
+        invoke.resolve()
     }
 
     /**

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/WebBrowserController.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/WebBrowserController.kt
@@ -501,16 +501,21 @@ class WebBrowserController(
         return if (cleaned.isEmpty()) "download" else cleaned
     }
 
+    // Atomically reserve the destination so two concurrent downloads of the
+    // same filename can never share a path: createNewFile() succeeds for only
+    // one caller, and the loser retries with the next suffix.
     private fun uniqueFile(dir: File, name: String): File {
-        val first = File(dir, name)
-        if (!first.exists()) return first
         val dot = name.lastIndexOf('.')
         val stem = if (dot > 0) name.substring(0, dot) else name
         val ext = if (dot > 0) name.substring(dot) else ""
-        var n = 1
+        var n = 0
         while (true) {
-            val candidate = File(dir, "$stem ($n)$ext")
-            if (!candidate.exists()) return candidate
+            val candidate = if (n == 0) File(dir, name) else File(dir, "$stem ($n)$ext")
+            try {
+                if (candidate.createNewFile()) return candidate
+            } catch (e: IOException) {
+                Log.w(TAG, "reserve failed: ${candidate.name}", e)
+            }
             n++
         }
     }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/WebBrowserController.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/WebBrowserController.kt
@@ -1,0 +1,560 @@
+package com.readest.native_bridge
+
+import android.app.Activity
+import android.app.Dialog
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.GradientDrawable
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.os.Message
+import android.text.TextUtils
+import android.util.Log
+import android.view.Gravity
+import android.view.KeyEvent
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.CookieManager
+import android.webkit.URLUtil
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.FrameLayout
+import android.widget.ImageButton
+import android.widget.LinearLayout
+import android.widget.PopupMenu
+import android.widget.TextView
+import androidx.core.view.WindowInsetsControllerCompat
+import app.tauri.annotation.InvokeArg
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.lang.ref.WeakReference
+import java.net.HttpURLConnection
+import java.net.URL
+
+/** Mirrors `WebBrowserRequest` in the plugin's models.rs. */
+@InvokeArg
+class WebBrowserArgs {
+    var url: String? = null
+    var downloadDir: String? = null
+    var background: String? = null
+    var foreground: String? = null
+    var isEink: Boolean? = null
+    var labels: Map<String, String>? = null
+}
+
+@InvokeArg
+class WebBrowserStatusArgs {
+    var state: String? = null
+    var filename: String? = null
+    var bookHash: String? = null
+}
+
+data class WebBrowserDownloadEvent(
+    val url: String,
+    val path: String,
+    val filename: String,
+    val success: Boolean,
+    val error: String?,
+)
+
+/**
+ * Full-screen in-app browser (#5775): header bar (close, back, title + host,
+ * reload/stop, menu), 2 dp progress line, import-status banner and a
+ * `WebView` on the app-wide persistent `CookieManager`. Downloads are caught
+ * by `DownloadListener`, fetched with the page's cookies into
+ * `args.downloadDir`, and handed to the plugin as events.
+ */
+class WebBrowserController(
+    activity: Activity,
+    private val args: WebBrowserArgs,
+    private val onDownload: (WebBrowserDownloadEvent) -> Unit,
+    private val completion: (String?) -> Unit,
+) {
+    companion object {
+        private const val TAG = "WebBrowser"
+        private const val BAR_HEIGHT_DP = 52
+        private const val BANNER_HIDE_MS = 8_000L
+        private const val MENU_FORWARD = 1
+        private const val MENU_OPEN_EXTERNAL = 2
+        private const val MENU_COPY_LINK = 3
+        private const val MENU_SIGN_OUT = 4
+    }
+
+    private val activityRef = WeakReference(activity)
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val bg = parseHexColor(args.background) ?: Color.parseColor("#1f2024")
+    private val fg = parseHexColor(args.foreground) ?: Color.parseColor("#f5f5f7")
+    private val eink = args.isEink == true
+
+    private var dialog: Dialog? = null
+    private var webView: WebView? = null
+    private var backButton: ImageButton? = null
+    private var reloadButton: ImageButton? = null
+    private var menuButton: ImageButton? = null
+    private var titleView: TextView? = null
+    private var hostView: TextView? = null
+    private var progressView: View? = null
+    private var progressContainer: FrameLayout? = null
+    private var banner: LinearLayout? = null
+    private var bannerText: TextView? = null
+    private var bannerOpen: TextView? = null
+    private var openBookHash: String? = null
+    private var loading = false
+    private var finished = false
+    private val hideBannerRunnable = Runnable { banner?.visibility = View.GONE }
+
+    private fun label(key: String, fallback: String): String =
+        args.labels?.get(key)?.takeIf { it.isNotEmpty() } ?: fallback
+
+    fun show() {
+        val urlStr = args.url
+        if (urlStr.isNullOrBlank() || !(urlStr.startsWith("http://") || urlStr.startsWith("https://"))) {
+            completion(null)
+            return
+        }
+        val act = activityRef.get()
+        if (act == null || act.isFinishing || act.isDestroyed) {
+            completion(null)
+            return
+        }
+        mainHandler.post { present(act, urlStr) }
+    }
+
+    private fun present(act: Activity, urlStr: String) {
+        // Keep the status bar: the fullscreen theme breaks adjustResize and
+        // the user has to type credentials into sign-in forms.
+        val dlg = Dialog(act, android.R.style.Theme_Black_NoTitleBar)
+        dlg.setCancelable(false)
+        dlg.setCanceledOnTouchOutside(false)
+        dlg.window?.also { window ->
+            window.setBackgroundDrawable(ColorDrawable(bg))
+            window.statusBarColor = bg
+            WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = isLight(bg)
+        }
+        // Hardware back walks the page history first and only closes the
+        // browser once it is exhausted.
+        dlg.setOnKeyListener { _, keyCode, event ->
+            if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
+                val wv = webView
+                if (wv != null && wv.canGoBack()) wv.goBack() else finish(null)
+                true
+            } else {
+                false
+            }
+        }
+
+        val root = LinearLayout(act)
+        root.orientation = LinearLayout.VERTICAL
+        root.setBackgroundColor(bg)
+        root.fitsSystemWindows = true
+
+        root.addView(buildBar(act), LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(act, BAR_HEIGHT_DP)))
+        root.addView(buildProgress(act), LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(act, 2)))
+        root.addView(buildBanner(act), LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(act, 44)))
+
+        val wv = WebView(act)
+        configureWebView(act, wv)
+        root.addView(wv, LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0, 1f))
+        webView = wv
+
+        dlg.setContentView(root)
+        dialog = dlg
+        dlg.show()
+        wv.loadUrl(urlStr)
+    }
+
+    // MARK: chrome
+
+    private fun iconButton(act: Activity, drawable: Int, description: String, onClick: () -> Unit): ImageButton {
+        val button = ImageButton(act)
+        button.setImageResource(drawable)
+        button.imageTintList = ColorStateList.valueOf(fg)
+        button.background = null
+        button.contentDescription = description
+        button.scaleType = android.widget.ImageView.ScaleType.CENTER
+        button.layoutParams = LinearLayout.LayoutParams(dp(act, 48), dp(act, 48))
+        button.setOnClickListener { onClick() }
+        return button
+    }
+
+    private fun buildBar(act: Activity): View {
+        val bar = LinearLayout(act)
+        bar.orientation = LinearLayout.HORIZONTAL
+        bar.gravity = Gravity.CENTER_VERTICAL
+        bar.setBackgroundColor(bg)
+        bar.setPaddingRelative(dp(act, 2), 0, dp(act, 2), 0)
+
+        bar.addView(iconButton(act, R.drawable.ic_browser_close, label("close", "Close")) { finish(null) })
+        backButton = iconButton(act, R.drawable.ic_browser_back, label("back", "Back")) {
+            webView?.let { if (it.canGoBack()) it.goBack() }
+        }
+        // Hidden (not dimmed) while there is no history: e-ink has no hover
+        // and dimmed controls read as broken there.
+        backButton?.visibility = View.INVISIBLE
+        bar.addView(backButton)
+
+        val titles = LinearLayout(act)
+        titles.orientation = LinearLayout.VERTICAL
+        titles.gravity = Gravity.CENTER
+        val titlesParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+        titles.layoutParams = titlesParams
+        titleView = TextView(act).apply {
+            setTextColor(fg)
+            textSize = 15f
+            setTypeface(typeface, android.graphics.Typeface.BOLD)
+            maxLines = 1
+            ellipsize = TextUtils.TruncateAt.END
+            gravity = Gravity.CENTER
+        }
+        hostView = TextView(act).apply {
+            setTextColor(if (eink) fg else Color.argb(178, Color.red(fg), Color.green(fg), Color.blue(fg)))
+            textSize = 12f
+            maxLines = 1
+            ellipsize = TextUtils.TruncateAt.MIDDLE
+            gravity = Gravity.CENTER
+        }
+        titles.addView(titleView)
+        titles.addView(hostView)
+        bar.addView(titles)
+
+        reloadButton = iconButton(act, R.drawable.ic_browser_refresh, label("reload", "Reload")) {
+            webView?.let { if (loading) it.stopLoading() else it.reload() }
+        }
+        bar.addView(reloadButton)
+        menuButton = iconButton(act, R.drawable.ic_browser_more, label("menu", "More")) { showMenu(act) }
+        bar.addView(menuButton)
+        return bar
+    }
+
+    private fun buildProgress(act: Activity): View {
+        val container = FrameLayout(act)
+        container.setBackgroundColor(if (eink) fg else Color.argb(38, Color.red(fg), Color.green(fg), Color.blue(fg)))
+        val line = View(act)
+        line.setBackgroundColor(fg)
+        line.layoutParams = FrameLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT)
+        container.addView(line)
+        progressView = line
+        progressContainer = container
+        return container
+    }
+
+    private fun buildBanner(act: Activity): View {
+        val row = LinearLayout(act)
+        row.orientation = LinearLayout.HORIZONTAL
+        row.gravity = Gravity.CENTER_VERTICAL
+        row.visibility = View.GONE
+        row.setPaddingRelative(dp(act, 16), 0, dp(act, 12), 0)
+        val background = GradientDrawable()
+        background.setColor(if (eink) bg else Color.argb(20, Color.red(fg), Color.green(fg), Color.blue(fg)))
+        if (eink) background.setStroke(dp(act, 1), fg)
+        row.background = background
+
+        bannerText = TextView(act).apply {
+            setTextColor(fg)
+            textSize = 13f
+            maxLines = 1
+            ellipsize = TextUtils.TruncateAt.MIDDLE
+            layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+        }
+        row.addView(bannerText)
+
+        bannerOpen = TextView(act).apply {
+            text = label("open", "Open")
+            setTextColor(bg)
+            textSize = 13f
+            setTypeface(typeface, android.graphics.Typeface.BOLD)
+            setPadding(dp(act, 14), dp(act, 6), dp(act, 14), dp(act, 6))
+            val pill = GradientDrawable()
+            pill.setColor(fg)
+            pill.cornerRadius = dp(act, 16).toFloat()
+            this.background = pill
+            visibility = View.GONE
+            setOnClickListener { finish(openBookHash) }
+        }
+        row.addView(bannerOpen)
+        banner = row
+        return row
+    }
+
+    private fun showMenu(act: Activity) {
+        val anchor = menuButton ?: return
+        val wv = webView ?: return
+        val popup = PopupMenu(act, anchor)
+        popup.menu.add(0, MENU_FORWARD, 0, label("forward", "Forward")).isEnabled = wv.canGoForward()
+        popup.menu.add(0, MENU_OPEN_EXTERNAL, 1, label("openInBrowser", "Open in Browser"))
+        popup.menu.add(0, MENU_COPY_LINK, 2, label("copyLink", "Copy Link"))
+        popup.menu.add(0, MENU_SIGN_OUT, 3, label("signOut", "Sign out of this site"))
+        popup.setOnMenuItemClickListener { item ->
+            when (item.itemId) {
+                MENU_FORWARD -> wv.goForward()
+                MENU_OPEN_EXTERNAL -> wv.url?.let { openExternal(act, it) }
+                MENU_COPY_LINK -> wv.url?.let {
+                    val clipboard = act.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    clipboard.setPrimaryClip(ClipData.newPlainText("url", it))
+                }
+                MENU_SIGN_OUT -> signOutOfSite(wv)
+            }
+            true
+        }
+        popup.show()
+    }
+
+    private fun openExternal(act: Activity, url: String) {
+        try {
+            act.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        } catch (e: Exception) {
+            Log.w(TAG, "no activity for $url", e)
+        }
+    }
+
+    /** Expire this site's cookies only; the jar is shared with Readest itself. */
+    private fun signOutOfSite(wv: WebView) {
+        val url = wv.url ?: return
+        val host = Uri.parse(url).host ?: return
+        val cm = CookieManager.getInstance()
+        val cookies = cm.getCookie(url) ?: ""
+        cookies.split(";").forEach { pair ->
+            val name = pair.substringBefore("=").trim()
+            if (name.isNotEmpty()) {
+                cm.setCookie(url, "$name=; Max-Age=0; Path=/")
+                cm.setCookie(url, "$name=; Max-Age=0; Path=/; Domain=$host")
+            }
+        }
+        cm.flush()
+        wv.reload()
+    }
+
+    private fun setProgress(percent: Int) {
+        val container = progressContainer ?: return
+        val line = progressView ?: return
+        val params = line.layoutParams
+        params.width = if (percent >= 100) 0 else container.width * percent / 100
+        line.layoutParams = params
+    }
+
+    private fun setLoading(isLoading: Boolean) {
+        loading = isLoading
+        reloadButton?.setImageResource(if (isLoading) R.drawable.ic_browser_close else R.drawable.ic_browser_refresh)
+        reloadButton?.contentDescription = if (isLoading) label("stop", "Stop") else label("reload", "Reload")
+    }
+
+    private fun setHost(url: String?) {
+        val uri = url?.let { Uri.parse(it) }
+        val host = uri?.host
+        if (uri == null || host.isNullOrEmpty()) {
+            hostView?.text = ""
+            return
+        }
+        hostView?.text = if (uri.scheme == "https") "🔒 $host" else "${label("notSecure", "Not secure")} · $host"
+        if (titleView?.text.isNullOrEmpty()) titleView?.text = host
+    }
+
+    fun setStatus(state: String, filename: String, bookHash: String?) {
+        mainHandler.removeCallbacks(hideBannerRunnable)
+        val fallback = mapOf(
+            "downloading" to "Downloading", "importing" to "Importing", "added" to "Added to library",
+            "failed" to "Import failed", "unsupported" to "Not a supported book format",
+        )
+        bannerText?.text = "${label(state, fallback[state] ?: state)} · $filename"
+        openBookHash = if (state == "added") bookHash else null
+        bannerOpen?.visibility = if (openBookHash != null) View.VISIBLE else View.GONE
+        banner?.visibility = View.VISIBLE
+        if (state != "downloading" && state != "importing") {
+            mainHandler.postDelayed(hideBannerRunnable, BANNER_HIDE_MS)
+        }
+    }
+
+    // MARK: web view
+
+    private fun configureWebView(act: Activity, wv: WebView) {
+        val settings: WebSettings = wv.settings
+        settings.javaScriptEnabled = true
+        settings.domStorageEnabled = true
+        settings.databaseEnabled = true
+        settings.userAgentString = ClipUrlController.BROWSER_USER_AGENT
+        settings.loadsImagesAutomatically = true
+        settings.mediaPlaybackRequiresUserGesture = true
+        settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+        settings.setSupportMultipleWindows(true)
+        settings.useWideViewPort = true
+        settings.loadWithOverviewMode = true
+        settings.builtInZoomControls = true
+        settings.displayZoomControls = false
+        wv.setBackgroundColor(bg)
+
+        // The CookieManager is app-wide and persistent, so a sign-in here
+        // survives across browser sessions. Third-party cookies are required
+        // by most SSO redirects.
+        val cookies = CookieManager.getInstance()
+        cookies.setAcceptCookie(true)
+        cookies.setAcceptThirdPartyCookies(wv, true)
+
+        wv.webViewClient = object : WebViewClient() {
+            override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+                val scheme = request.url.scheme?.lowercase() ?: return false
+                if (scheme == "http" || scheme == "https" || scheme == "about" || scheme == "blob" || scheme == "data") return false
+                openExternal(act, request.url.toString())
+                return true
+            }
+
+            override fun doUpdateVisitedHistory(view: WebView, url: String?, isReload: Boolean) {
+                setHost(url)
+                backButton?.visibility = if (view.canGoBack()) View.VISIBLE else View.INVISIBLE
+            }
+
+            override fun onPageStarted(view: WebView, url: String?, favicon: android.graphics.Bitmap?) {
+                setLoading(true)
+                setHost(url)
+            }
+
+            override fun onPageFinished(view: WebView, url: String?) {
+                setLoading(false)
+                setProgress(100)
+            }
+        }
+
+        wv.webChromeClient = object : WebChromeClient() {
+            override fun onProgressChanged(view: WebView, newProgress: Int) {
+                setProgress(newProgress)
+            }
+
+            override fun onReceivedTitle(view: WebView, title: String?) {
+                titleView?.text = if (title.isNullOrBlank()) view.url?.let { Uri.parse(it).host } else title
+            }
+
+            // target=_blank / window.open: load the target in this WebView.
+            override fun onCreateWindow(view: WebView, isDialog: Boolean, isUserGesture: Boolean, resultMsg: Message): Boolean {
+                val transport = resultMsg.obj as? WebView.WebViewTransport ?: return false
+                val temp = WebView(act)
+                temp.webViewClient = object : WebViewClient() {
+                    override fun shouldOverrideUrlLoading(v: WebView, request: WebResourceRequest): Boolean {
+                        view.loadUrl(request.url.toString())
+                        mainHandler.post { temp.destroy() }
+                        return true
+                    }
+                }
+                transport.webView = temp
+                resultMsg.sendToTarget()
+                return true
+            }
+        }
+
+        wv.setDownloadListener { url, userAgent, contentDisposition, mimeType, _ ->
+            startDownload(url, userAgent, contentDisposition, mimeType)
+        }
+    }
+
+    // MARK: downloads
+
+    private fun startDownload(url: String, userAgent: String?, contentDisposition: String?, mimeType: String?) {
+        val filename = sanitizeFilename(URLUtil.guessFileName(url, contentDisposition, mimeType))
+        val dirPath = args.downloadDir
+        if (dirPath.isNullOrBlank() || url.startsWith("blob:") || url.startsWith("data:")) {
+            setStatus("failed", filename, null)
+            onDownload(WebBrowserDownloadEvent(url, "", filename, false, "Unsupported download URL"))
+            return
+        }
+        val dir = File(dirPath)
+        dir.mkdirs()
+        val dest = uniqueFile(dir, filename)
+        setStatus("downloading", dest.name, null)
+        val cookie = CookieManager.getInstance().getCookie(url)
+        Thread {
+            var error: String? = null
+            try {
+                val conn = URL(url).openConnection() as HttpURLConnection
+                conn.instanceFollowRedirects = true
+                conn.connectTimeout = 15_000
+                conn.readTimeout = 60_000
+                if (!userAgent.isNullOrEmpty()) conn.setRequestProperty("User-Agent", userAgent)
+                if (!cookie.isNullOrEmpty()) conn.setRequestProperty("Cookie", cookie)
+                val code = conn.responseCode
+                if (code !in 200..299) throw IOException("HTTP $code")
+                conn.inputStream.use { input -> FileOutputStream(dest).use { output -> input.copyTo(output) } }
+            } catch (e: Exception) {
+                Log.w(TAG, "download failed: $url", e)
+                dest.delete()
+                error = e.message ?: "Download failed"
+            }
+            val success = error == null
+            mainHandler.post {
+                if (!success) setStatus("failed", dest.name, null)
+                onDownload(WebBrowserDownloadEvent(url, dest.absolutePath, dest.name, success, error))
+            }
+        }.start()
+    }
+
+    private fun sanitizeFilename(raw: String): String {
+        val cleaned = raw.map { c ->
+            if (c in "/\\:*?\"<>|" || c.code < 32) '_' else c
+        }.joinToString("").trim().trim('.')
+        return if (cleaned.isEmpty()) "download" else cleaned
+    }
+
+    private fun uniqueFile(dir: File, name: String): File {
+        val first = File(dir, name)
+        if (!first.exists()) return first
+        val dot = name.lastIndexOf('.')
+        val stem = if (dot > 0) name.substring(0, dot) else name
+        val ext = if (dot > 0) name.substring(dot) else ""
+        var n = 1
+        while (true) {
+            val candidate = File(dir, "$stem ($n)$ext")
+            if (!candidate.exists()) return candidate
+            n++
+        }
+    }
+
+    // MARK: lifecycle
+
+    private fun finish(hash: String?) {
+        if (finished) return
+        finished = true
+        mainHandler.removeCallbacks(hideBannerRunnable)
+        try {
+            // Persist any session the page established so the next visit
+            // is already signed in.
+            CookieManager.getInstance().flush()
+        } catch (e: Exception) {
+            Log.w(TAG, "error flushing cookies", e)
+        }
+        try {
+            webView?.stopLoading()
+            webView?.webViewClient = WebViewClient()
+            webView?.webChromeClient = null
+            dialog?.dismiss()
+            webView?.destroy()
+        } catch (e: Exception) {
+            Log.w(TAG, "error tearing down browser", e)
+        }
+        dialog = null
+        webView = null
+        completion(hash)
+    }
+
+    private fun isLight(color: Int): Boolean =
+        (0.299 * Color.red(color) + 0.587 * Color.green(color) + 0.114 * Color.blue(color)) > 153
+
+    private fun dp(act: Activity, units: Int): Int =
+        (units * act.resources.displayMetrics.density + 0.5f).toInt()
+
+    /** Parse `#rrggbb` into an Android ARGB int; null on malformed input. */
+    private fun parseHexColor(s: String?): Int? {
+        if (s == null) return null
+        return try {
+            Color.parseColor(s.trim())
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+    }
+}

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/drawable/ic_browser_back.xml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/drawable/ic_browser_back.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:autoMirrored="true"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
+</vector>

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/drawable/ic_browser_close.xml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/drawable/ic_browser_close.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+</vector>

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/drawable/ic_browser_forward.xml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/drawable/ic_browser_forward.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:autoMirrored="true"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z" />
+</vector>

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/drawable/ic_browser_more.xml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/drawable/ic_browser_more.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+</vector>

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/drawable/ic_browser_refresh.xml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/res/drawable/ic_browser_refresh.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M17.65 6.35A7.958 7.958 0 0 0 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0 1 12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
+</vector>

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/build.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/build.rs
@@ -38,6 +38,8 @@ const COMMANDS: &[&str] = &[
     "checkPermissions",
     "requestPermissions",
     "clip_url",
+    "open_web_browser",
+    "set_web_browser_status",
     "set_secure_item",
     "get_secure_item",
     "clear_secure_item",

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/NativeBridgePlugin.swift
@@ -575,6 +575,9 @@ class NativeBridgePlugin: Plugin {
   private var webViewLifecycleManager: WebViewLifecycleManager?
   private var pencilGestureHandler: PencilGestureHandler?
   private var traitChangeRegistered = false
+  // The in-app browser currently presented by `open_web_browser` (#5775);
+  // `set_web_browser_status` pushes import results into its banner.
+  private weak var activeWebBrowser: WebBrowserController?
 
   // Screen-brightness management. `UIScreen.main.brightness` is a *global*
   // device setting, not a per-window one: once the app writes to it, iOS
@@ -1633,6 +1636,65 @@ class NativeBridgePlugin: Plugin {
         }
       }
       presenter.present(controller, animated: true)
+    }
+  }
+
+  /// Present the in-app browser (#5775). Resolves `{ openBookHash? }` when
+  /// the user closes it; downloads are forwarded as `web-browser-download`
+  /// plugin events while it is open. See `WebBrowserController.swift`.
+  @objc public func open_web_browser(_ invoke: Invoke) {
+    let args: WebBrowserArgs
+    do {
+      args = try invoke.parseArgs(WebBrowserArgs.self)
+    } catch {
+      invoke.reject(error.localizedDescription)
+      return
+    }
+    guard let url = URL(string: args.url), let scheme = url.scheme?.lowercased(),
+      scheme == "http" || scheme == "https"
+    else {
+      invoke.reject("Invalid URL")
+      return
+    }
+    DispatchQueue.main.async {
+      guard let presenter = topmostViewController() else {
+        invoke.reject("Could not find a view controller to present from")
+        return
+      }
+      let controller = WebBrowserController(args: args)
+      controller.onDownload = { [weak self] event in
+        var data: JSObject = [
+          "url": event.url, "path": event.path, "filename": event.filename,
+          "success": event.success,
+        ]
+        if let error = event.error { data["error"] = error }
+        self?.trigger("web-browser-download", data: data)
+      }
+      controller.onFinish = { [weak self] hash in
+        self?.activeWebBrowser = nil
+        var ret = JSObject()
+        if let hash = hash { ret["openBookHash"] = hash }
+        invoke.resolve(ret)
+      }
+      self.activeWebBrowser = controller
+      presenter.present(controller, animated: true)
+    }
+  }
+
+  /// Push an import status (importing / added / failed / unsupported) into
+  /// the open browser's banner. No-op when no browser is presented.
+  @objc public func set_web_browser_status(_ invoke: Invoke) {
+    let args: WebBrowserStatusArgs
+    do {
+      args = try invoke.parseArgs(WebBrowserStatusArgs.self)
+    } catch {
+      invoke.reject(error.localizedDescription)
+      return
+    }
+    DispatchQueue.main.async {
+      self.activeWebBrowser?.setStatus(
+        state: args.state, filename: args.filename, bookHash: args.bookHash)
+      invoke.resolve()
     }
   }
 

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/WebBrowserController.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/WebBrowserController.swift
@@ -1,0 +1,568 @@
+import UIKit
+import WebKit
+
+/// Args decoded from `open_web_browser` — mirrors `WebBrowserRequest` in
+/// the plugin's `models.rs`. Every label the chrome renders comes from JS.
+final class WebBrowserArgs: Decodable {
+  let url: String
+  let downloadDir: String
+  let background: String?
+  let foreground: String?
+  let isEink: Bool?
+  let labels: [String: String]?
+
+  func label(_ key: String, _ fallback: String) -> String {
+    if let value = labels?[key], !value.isEmpty { return value }
+    return fallback
+  }
+}
+
+final class WebBrowserStatusArgs: Decodable {
+  let state: String
+  let filename: String
+  let bookHash: String?
+}
+
+struct WebBrowserDownloadEvent {
+  let url: String
+  let path: String
+  let filename: String
+  let success: Bool
+  let error: String?
+}
+
+/// Full-screen in-app browser (#5775): a header bar (close, back, title +
+/// host, reload/stop, menu), a 2 px progress line, an import-status banner
+/// and a `WKWebView` on the app's default (persistent) data store so logins
+/// survive. Downloads are intercepted with `WKDownload` (iOS 14.5+) and
+/// written into `args.downloadDir`; the plugin forwards them to JS.
+final class WebBrowserController: UIViewController, WKNavigationDelegate, WKUIDelegate,
+  WKDownloadDelegate
+{
+  private let args: WebBrowserArgs
+  private let bg: UIColor
+  private let fg: UIColor
+  private let eink: Bool
+
+  private var webView: WKWebView!
+  private let bar = UIView()
+  private let titleLabel = UILabel()
+  private let hostLabel = UILabel()
+  // Assigned once in `setUpBar()`; the KVO observers update them.
+  private var closeButton: UIButton?
+  private var backButton: UIButton?
+  private var reloadButton: UIButton?
+  private var menuButton: UIButton?
+  private let progressView = UIView()
+  private var progressWidth: NSLayoutConstraint!
+  private let banner = UIView()
+  private let bannerLabel = UILabel()
+  private let bannerOpen = UIButton(type: .system)
+  private var bannerHeight: NSLayoutConstraint!
+  private var bannerHideWork: DispatchWorkItem?
+  private var observations: [NSKeyValueObservation] = []
+  private var downloadPaths: [ObjectIdentifier: (url: URL, path: URL)] = [:]
+  private var openBookHash: String?
+  private var finished = false
+
+  var onDownload: ((WebBrowserDownloadEvent) -> Void)?
+  var onFinish: ((String?) -> Void)?
+
+  init(args: WebBrowserArgs) {
+    self.args = args
+    self.bg = UIColor(hexString: args.background ?? "#1f2024") ?? .black
+    self.fg = UIColor(hexString: args.foreground ?? "#f5f5f7") ?? .white
+    self.eink = args.isEink ?? false
+    super.init(nibName: nil, bundle: nil)
+    modalPresentationStyle = .fullScreen
+  }
+
+  required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+
+  deinit {
+    observations.forEach { $0.invalidate() }
+  }
+
+  override var preferredStatusBarStyle: UIStatusBarStyle {
+    isLight(bg) ? .darkContent : .lightContent
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = bg
+    setUpBar()
+    setUpBanner()
+    setUpWebView()
+    observe()
+    // The plugin rejects unparseable URLs before presenting; this guard
+    // only keeps a malformed string from crashing the controller.
+    if let url = URL(string: args.url) {
+      webView.load(URLRequest(url: url))
+    }
+  }
+
+  // MARK: - Chrome
+
+  private func iconButton(_ symbol: String, _ labelKey: String, _ fallback: String, _ action: Selector?)
+    -> UIButton
+  {
+    let button = UIButton(type: .system)
+    let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .medium)
+    button.setImage(UIImage(systemName: symbol, withConfiguration: config), for: .normal)
+    button.tintColor = fg
+    button.accessibilityLabel = args.label(labelKey, fallback)
+    if let action = action {
+      button.addTarget(self, action: action, for: .touchUpInside)
+    }
+    button.translatesAutoresizingMaskIntoConstraints = false
+    button.widthAnchor.constraint(equalToConstant: 44).isActive = true
+    button.heightAnchor.constraint(equalToConstant: 44).isActive = true
+    return button
+  }
+
+  private func setUpBar() {
+    bar.backgroundColor = bg
+    bar.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(bar)
+
+    let close = iconButton("xmark", "close", "Close", #selector(closeTapped))
+    let back = iconButton("chevron.backward", "back", "Back", #selector(backTapped))
+    let reload = iconButton("arrow.clockwise", "reload", "Reload", #selector(reloadTapped))
+    let menu = iconButton("ellipsis", "menu", "More", nil)
+    menu.showsMenuAsPrimaryAction = true
+    menu.menu = buildMenu()
+    [close, back, reload, menu].forEach { bar.addSubview($0) }
+    closeButton = close
+    backButton = back
+    reloadButton = reload
+    menuButton = menu
+
+    titleLabel.textColor = fg
+    titleLabel.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
+    titleLabel.textAlignment = .center
+    titleLabel.lineBreakMode = .byTruncatingTail
+    hostLabel.textColor = eink ? fg : fg.withAlphaComponent(0.7)
+    hostLabel.font = UIFont.systemFont(ofSize: 12)
+    hostLabel.textAlignment = .center
+    hostLabel.lineBreakMode = .byTruncatingMiddle
+    let stack = UIStackView(arrangedSubviews: [titleLabel, hostLabel])
+    stack.axis = .vertical
+    stack.alignment = .center
+    stack.spacing = 1
+    stack.translatesAutoresizingMaskIntoConstraints = false
+    bar.addSubview(stack)
+
+    let hairline = UIView()
+    hairline.backgroundColor = eink ? fg : fg.withAlphaComponent(0.15)
+    hairline.translatesAutoresizingMaskIntoConstraints = false
+    bar.addSubview(hairline)
+
+    progressView.backgroundColor = fg
+    progressView.translatesAutoresizingMaskIntoConstraints = false
+    bar.addSubview(progressView)
+    progressWidth = progressView.widthAnchor.constraint(equalToConstant: 0)
+
+    NSLayoutConstraint.activate([
+      bar.topAnchor.constraint(equalTo: view.topAnchor),
+      bar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      bar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      bar.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 52),
+
+      close.leadingAnchor.constraint(equalTo: bar.leadingAnchor, constant: 4),
+      close.bottomAnchor.constraint(equalTo: bar.bottomAnchor, constant: -4),
+      back.leadingAnchor.constraint(equalTo: close.trailingAnchor),
+      back.centerYAnchor.constraint(equalTo: close.centerYAnchor),
+      menu.trailingAnchor.constraint(equalTo: bar.trailingAnchor, constant: -4),
+      menu.centerYAnchor.constraint(equalTo: close.centerYAnchor),
+      reload.trailingAnchor.constraint(equalTo: menu.leadingAnchor),
+      reload.centerYAnchor.constraint(equalTo: close.centerYAnchor),
+
+      stack.centerXAnchor.constraint(equalTo: bar.centerXAnchor),
+      stack.centerYAnchor.constraint(equalTo: close.centerYAnchor),
+      stack.leadingAnchor.constraint(greaterThanOrEqualTo: back.trailingAnchor, constant: 4),
+      stack.trailingAnchor.constraint(lessThanOrEqualTo: reload.leadingAnchor, constant: -4),
+
+      hairline.leadingAnchor.constraint(equalTo: bar.leadingAnchor),
+      hairline.trailingAnchor.constraint(equalTo: bar.trailingAnchor),
+      hairline.bottomAnchor.constraint(equalTo: bar.bottomAnchor),
+      hairline.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale),
+
+      progressView.leadingAnchor.constraint(equalTo: bar.leadingAnchor),
+      progressView.bottomAnchor.constraint(equalTo: bar.bottomAnchor),
+      progressView.heightAnchor.constraint(equalToConstant: 2),
+      progressWidth,
+    ])
+  }
+
+  private func setUpBanner() {
+    banner.backgroundColor = eink ? bg : fg.withAlphaComponent(0.08)
+    banner.clipsToBounds = true
+    banner.translatesAutoresizingMaskIntoConstraints = false
+    if eink {
+      banner.layer.borderWidth = 1
+      banner.layer.borderColor = fg.cgColor
+    }
+    view.addSubview(banner)
+
+    bannerLabel.textColor = fg
+    bannerLabel.font = UIFont.systemFont(ofSize: 13)
+    bannerLabel.lineBreakMode = .byTruncatingMiddle
+    bannerLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    bannerLabel.translatesAutoresizingMaskIntoConstraints = false
+    banner.addSubview(bannerLabel)
+
+    bannerOpen.setTitle(args.label("open", "Open"), for: .normal)
+    bannerOpen.setTitleColor(bg, for: .normal)
+    bannerOpen.titleLabel?.font = UIFont.systemFont(ofSize: 13, weight: .semibold)
+    bannerOpen.backgroundColor = fg
+    bannerOpen.layer.cornerRadius = 14
+    bannerOpen.contentEdgeInsets = UIEdgeInsets(top: 5, left: 14, bottom: 5, right: 14)
+    bannerOpen.addTarget(self, action: #selector(openTapped), for: .touchUpInside)
+    bannerOpen.isHidden = true
+    bannerOpen.translatesAutoresizingMaskIntoConstraints = false
+    banner.addSubview(bannerOpen)
+
+    bannerHeight = banner.heightAnchor.constraint(equalToConstant: 0)
+    NSLayoutConstraint.activate([
+      banner.topAnchor.constraint(equalTo: bar.bottomAnchor),
+      banner.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      banner.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      bannerHeight,
+      bannerLabel.leadingAnchor.constraint(equalTo: banner.leadingAnchor, constant: 16),
+      bannerLabel.centerYAnchor.constraint(equalTo: banner.centerYAnchor),
+      bannerOpen.leadingAnchor.constraint(
+        greaterThanOrEqualTo: bannerLabel.trailingAnchor, constant: 12),
+      bannerOpen.trailingAnchor.constraint(equalTo: banner.trailingAnchor, constant: -12),
+      bannerOpen.centerYAnchor.constraint(equalTo: banner.centerYAnchor),
+    ])
+  }
+
+  private func setUpWebView() {
+    let config = WKWebViewConfiguration()
+    config.websiteDataStore = .default()
+    config.allowsInlineMediaPlayback = true
+    let wv = WKWebView(frame: .zero, configuration: config)
+    wv.customUserAgent = ClipUrlController.browserUserAgent
+    wv.navigationDelegate = self
+    wv.uiDelegate = self
+    wv.allowsBackForwardNavigationGestures = true
+    wv.backgroundColor = bg
+    wv.scrollView.backgroundColor = bg
+    wv.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(wv)
+    NSLayoutConstraint.activate([
+      wv.topAnchor.constraint(equalTo: banner.bottomAnchor),
+      wv.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      wv.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      wv.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+    ])
+    webView = wv
+  }
+
+  private func observe() {
+    observations = [
+      webView.observe(\.canGoBack, options: [.initial, .new]) { [weak self] wv, _ in
+        // Hide rather than dim: e-ink cannot render reduced opacity (DESIGN.md §8).
+        self?.backButton?.isHidden = !wv.canGoBack
+      },
+      webView.observe(\.canGoForward, options: [.initial, .new]) { [weak self] _, _ in
+        guard let self = self else { return }
+        self.menuButton?.menu = self.buildMenu()
+      },
+      webView.observe(\.estimatedProgress, options: [.new]) { [weak self] wv, _ in
+        self?.setProgress(wv.estimatedProgress)
+      },
+      webView.observe(\.isLoading, options: [.initial, .new]) { [weak self] wv, _ in
+        self?.setLoading(wv.isLoading)
+      },
+      webView.observe(\.title, options: [.new]) { [weak self] wv, _ in
+        self?.titleLabel.text = wv.title?.isEmpty == false ? wv.title : wv.url?.host
+      },
+      webView.observe(\.url, options: [.initial, .new]) { [weak self] wv, _ in
+        self?.setHost(wv.url)
+      },
+    ]
+  }
+
+  private func buildMenu() -> UIMenu {
+    var actions: [UIAction] = []
+    if webView?.canGoForward == true {
+      actions.append(
+        UIAction(
+          title: args.label("forward", "Forward"), image: UIImage(systemName: "chevron.forward")
+        ) { [weak self] _ in self?.webView.goForward() })
+    }
+    actions.append(
+      UIAction(
+        title: args.label("openInBrowser", "Open in Browser"), image: UIImage(systemName: "safari")
+      ) { [weak self] _ in
+        if let url = self?.webView.url { UIApplication.shared.open(url) }
+      })
+    actions.append(
+      UIAction(title: args.label("copyLink", "Copy Link"), image: UIImage(systemName: "link")) {
+        [weak self] _ in UIPasteboard.general.string = self?.webView.url?.absoluteString
+      })
+    actions.append(
+      UIAction(
+        title: args.label("signOut", "Sign out of this site"),
+        image: UIImage(systemName: "rectangle.portrait.and.arrow.right"), attributes: .destructive
+      ) { [weak self] _ in self?.signOutOfSite() })
+    return UIMenu(children: actions)
+  }
+
+  private func setProgress(_ value: Double) {
+    let width = bar.bounds.width * CGFloat(min(max(value, 0), 1))
+    progressWidth.constant = width
+    progressView.isHidden = value >= 1
+  }
+
+  private func setLoading(_ loading: Bool) {
+    let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .medium)
+    reloadButton?.setImage(
+      UIImage(systemName: loading ? "xmark.circle" : "arrow.clockwise", withConfiguration: config),
+      for: .normal)
+    reloadButton?.accessibilityLabel =
+      loading ? args.label("stop", "Stop") : args.label("reload", "Reload")
+    if !loading { progressView.isHidden = true }
+  }
+
+  private func setHost(_ url: URL?) {
+    guard let url = url, let host = url.host else {
+      hostLabel.text = nil
+      return
+    }
+    hostLabel.text =
+      url.scheme == "https"
+      ? "\u{1F512} \(host)" : "\(args.label("notSecure", "Not secure")) \u{00B7} \(host)"
+    if titleLabel.text?.isEmpty ?? true { titleLabel.text = host }
+  }
+
+  /// Import status pushed from JS via `set_web_browser_status`, or set
+  /// locally when a download starts.
+  func setStatus(state: String, filename: String, bookHash: String?) {
+    bannerHideWork?.cancel()
+    let fallback: [String: String] = [
+      "downloading": "Downloading", "importing": "Importing", "added": "Added to library",
+      "failed": "Import failed", "unsupported": "Not a supported book format",
+    ]
+    bannerLabel.text = "\(args.label(state, fallback[state] ?? state)) \u{00B7} \(filename)"
+    openBookHash = state == "added" ? bookHash : nil
+    bannerOpen.isHidden = openBookHash == nil
+    bannerHeight.constant = 44
+    if eink {
+      view.layoutIfNeeded()
+    } else {
+      UIView.animate(withDuration: 0.2) { self.view.layoutIfNeeded() }
+    }
+    if state != "downloading" && state != "importing" {
+      let work = DispatchWorkItem { [weak self] in self?.hideBanner() }
+      bannerHideWork = work
+      DispatchQueue.main.asyncAfter(deadline: .now() + 8, execute: work)
+    }
+  }
+
+  private func hideBanner() {
+    bannerHeight.constant = 0
+    bannerOpen.isHidden = true
+    if eink {
+      view.layoutIfNeeded()
+    } else {
+      UIView.animate(withDuration: 0.2) { self.view.layoutIfNeeded() }
+    }
+  }
+
+  // MARK: - Actions
+
+  @objc private func closeTapped() { finish(nil) }
+  @objc private func backTapped() { webView.goBack() }
+  @objc private func reloadTapped() {
+    if webView.isLoading { webView.stopLoading() } else { webView.reload() }
+  }
+  @objc private func openTapped() { finish(openBookHash) }
+
+  /// Remove cookies/storage for the current site only. The data store is
+  /// app-wide and shared with Readest's own webview, so never clear all.
+  private func signOutOfSite() {
+    guard let host = webView.url?.host else { return }
+    let store = WKWebsiteDataStore.default()
+    let types = WKWebsiteDataStore.allWebsiteDataTypes()
+    store.fetchDataRecords(ofTypes: types) { records in
+      let matching = records.filter { record in
+        host == record.displayName || host.hasSuffix("." + record.displayName)
+      }
+      store.removeData(ofTypes: types, for: matching) { [weak self] in
+        self?.webView.reload()
+      }
+    }
+  }
+
+  private func finish(_ hash: String?) {
+    if finished { return }
+    finished = true
+    bannerHideWork?.cancel()
+    webView.stopLoading()
+    webView.navigationDelegate = nil
+    webView.uiDelegate = nil
+    dismiss(animated: true) { [onFinish] in onFinish?(hash) }
+  }
+
+  // MARK: - WKNavigationDelegate
+
+  func webView(
+    _ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
+    preferences: WKWebpagePreferences,
+    decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void
+  ) {
+    if navigationAction.shouldPerformDownload {
+      decisionHandler(.download, preferences)
+      return
+    }
+    guard let url = navigationAction.request.url else {
+      decisionHandler(.allow, preferences)
+      return
+    }
+    let scheme = url.scheme?.lowercased() ?? ""
+    if scheme != "http" && scheme != "https" && scheme != "about" && scheme != "blob"
+      && scheme != "data"
+    {
+      UIApplication.shared.open(url)
+      decisionHandler(.cancel, preferences)
+      return
+    }
+    // target=_blank: keep the user in this browser.
+    if navigationAction.targetFrame == nil {
+      webView.load(navigationAction.request)
+      decisionHandler(.cancel, preferences)
+      return
+    }
+    decisionHandler(.allow, preferences)
+  }
+
+  func webView(
+    _ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse,
+    decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+  ) {
+    if navigationResponse.isForMainFrame {
+      let disposition =
+        (navigationResponse.response as? HTTPURLResponse)?
+        .value(forHTTPHeaderField: "Content-Disposition")?.lowercased() ?? ""
+      if !navigationResponse.canShowMIMEType || disposition.hasPrefix("attachment") {
+        decisionHandler(.download)
+        return
+      }
+    }
+    decisionHandler(.allow)
+  }
+
+  func webView(
+    _ webView: WKWebView, navigationAction: WKNavigationAction, didBecome download: WKDownload
+  ) {
+    download.delegate = self
+  }
+
+  func webView(
+    _ webView: WKWebView, navigationResponse: WKNavigationResponse, didBecome download: WKDownload
+  ) {
+    download.delegate = self
+  }
+
+  // MARK: - WKUIDelegate
+
+  func webView(
+    _ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration,
+    for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures
+  ) -> WKWebView? {
+    if navigationAction.targetFrame?.isMainFrame != true {
+      webView.load(navigationAction.request)
+    }
+    return nil
+  }
+
+  // MARK: - WKDownloadDelegate
+
+  func download(
+    _ download: WKDownload, decideDestinationUsing response: URLResponse,
+    suggestedFilename: String, completionHandler: @escaping (URL?) -> Void
+  ) {
+    let dir = URL(fileURLWithPath: args.downloadDir, isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let name = WebBrowserController.sanitizeFilename(suggestedFilename, fallback: response.url)
+    let path = WebBrowserController.uniquePath(in: dir, name: name)
+    downloadPaths[ObjectIdentifier(download)] = (response.url ?? dir, path)
+    setStatus(state: "downloading", filename: path.lastPathComponent, bookHash: nil)
+    completionHandler(path)
+  }
+
+  func downloadDidFinish(_ download: WKDownload) {
+    guard let entry = downloadPaths.removeValue(forKey: ObjectIdentifier(download)) else { return }
+    onDownload?(
+      WebBrowserDownloadEvent(
+        url: entry.url.absoluteString, path: entry.path.path,
+        filename: entry.path.lastPathComponent, success: true, error: nil))
+  }
+
+  func download(_ download: WKDownload, didFailWithError error: Error, resumeData: Data?) {
+    guard let entry = downloadPaths.removeValue(forKey: ObjectIdentifier(download)) else { return }
+    setStatus(state: "failed", filename: entry.path.lastPathComponent, bookHash: nil)
+    onDownload?(
+      WebBrowserDownloadEvent(
+        url: entry.url.absoluteString, path: entry.path.path,
+        filename: entry.path.lastPathComponent, success: false, error: error.localizedDescription))
+  }
+
+  // MARK: - Helpers
+
+  static func sanitizeFilename(_ suggested: String, fallback: URL?) -> String {
+    var raw = suggested.trimmingCharacters(in: .whitespacesAndNewlines)
+    if raw.isEmpty { raw = fallback?.lastPathComponent ?? "" }
+    let reserved: Set<Character> = ["/", "\\", ":", "*", "?", "\"", "<", ">", "|"]
+    let cleaned = String(
+      raw.map { ch -> Character in
+        if reserved.contains(ch) { return "_" }
+        if let scalar = ch.unicodeScalars.first, scalar.value < 32 { return "_" }
+        return ch
+      }
+    ).trimmingCharacters(in: CharacterSet(charactersIn: ". "))
+    return cleaned.isEmpty ? "download" : cleaned
+  }
+
+  static func uniquePath(in dir: URL, name: String) -> URL {
+    let first = dir.appendingPathComponent(name)
+    if !FileManager.default.fileExists(atPath: first.path) { return first }
+    let ext = (name as NSString).pathExtension
+    let stem = (name as NSString).deletingPathExtension
+    var n = 1
+    while true {
+      let candidate = dir.appendingPathComponent(
+        ext.isEmpty ? "\(stem) (\(n))" : "\(stem) (\(n)).\(ext)")
+      if !FileManager.default.fileExists(atPath: candidate.path) { return candidate }
+      n += 1
+    }
+  }
+
+  private func isLight(_ color: UIColor) -> Bool {
+    var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+    color.getRed(&r, green: &g, blue: &b, alpha: &a)
+    return (0.299 * r + 0.587 * g + 0.114 * b) > 0.6
+  }
+}
+
+// MARK: - UIColor hex helper
+
+// `ClipUrlController.swift` declares the same initializer as a *file-private*
+// extension, so it is invisible here. Duplicated rather than widened to keep
+// this change inside the browser files; lifting that one to `internal` and
+// deleting this copy is a one-line follow-up.
+private extension UIColor {
+  /// Parse `#rrggbb` (optionally without the `#`) into a UIColor; nil for
+  /// anything malformed so the caller falls back to its own default.
+  convenience init?(hexString: String) {
+    var hex = hexString.trimmingCharacters(in: .whitespacesAndNewlines)
+    if hex.hasPrefix("#") { hex = String(hex.dropFirst()) }
+    guard hex.count == 6, let v = UInt32(hex, radix: 16) else { return nil }
+    let r = CGFloat((v >> 16) & 0xff) / 255.0
+    let g = CGFloat((v >> 8) & 0xff) / 255.0
+    let b = CGFloat(v & 0xff) / 255.0
+    self.init(red: r, green: g, blue: b, alpha: 1.0)
+  }
+}

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/WebBrowserController.swift
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/ios/Sources/WebBrowserController.swift
@@ -503,6 +503,8 @@ final class WebBrowserController: UIViewController, WKNavigationDelegate, WKUIDe
 
   func download(_ download: WKDownload, didFailWithError error: Error, resumeData: Data?) {
     guard let entry = downloadPaths.removeValue(forKey: ObjectIdentifier(download)) else { return }
+    // Drop the partial file so it does not linger in the cache.
+    try? FileManager.default.removeItem(at: entry.path)
     setStatus(state: "failed", filename: entry.path.lastPathComponent, bookHash: nil)
     onDownload?(
       WebBrowserDownloadEvent(

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/commands/open_web_browser.toml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/commands/open_web_browser.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-open-web-browser"
+description = "Enables the open_web_browser command without any pre-configured scope."
+commands.allow = ["open_web_browser"]
+
+[[permission]]
+identifier = "deny-open-web-browser"
+description = "Denies the open_web_browser command without any pre-configured scope."
+commands.deny = ["open_web_browser"]

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/commands/set_web_browser_status.toml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/commands/set_web_browser_status.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-set-web-browser-status"
+description = "Enables the set_web_browser_status command without any pre-configured scope."
+commands.allow = ["set_web_browser_status"]
+
+[[permission]]
+identifier = "deny-set-web-browser-status"
+description = "Denies the set_web_browser_status command without any pre-configured scope."
+commands.deny = ["set_web_browser_status"]

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/reference.md
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/reference.md
@@ -954,6 +954,32 @@ Denies the open_external_url command without any pre-configured scope.
 <tr>
 <td>
 
+`native-bridge:allow-open-web-browser`
+
+</td>
+<td>
+
+Enables the open_web_browser command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`native-bridge:deny-open-web-browser`
+
+</td>
+<td>
+
+Denies the open_web_browser command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `native-bridge:allow-read-share-clip-html`
 
 </td>
@@ -1363,6 +1389,32 @@ Enables the set_system_ui_visibility command without any pre-configured scope.
 <td>
 
 Denies the set_system_ui_visibility command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`native-bridge:allow-set-web-browser-status`
+
+</td>
+<td>
+
+Enables the set_web_browser_status command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`native-bridge:deny-set-web-browser-status`
+
+</td>
+<td>
+
+Denies the set_web_browser_status command without any pre-configured scope.
 
 </td>
 </tr>

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/schemas/schema.json
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/schemas/schema.json
@@ -703,6 +703,18 @@
           "markdownDescription": "Denies the open_external_url command without any pre-configured scope."
         },
         {
+          "description": "Enables the open_web_browser command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-open-web-browser",
+          "markdownDescription": "Enables the open_web_browser command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the open_web_browser command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-open-web-browser",
+          "markdownDescription": "Denies the open_web_browser command without any pre-configured scope."
+        },
+        {
           "description": "Enables the read_share_clip_html command without any pre-configured scope.",
           "type": "string",
           "const": "allow-read-share-clip-html",
@@ -893,6 +905,18 @@
           "type": "string",
           "const": "deny-set-system-ui-visibility",
           "markdownDescription": "Denies the set_system_ui_visibility command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the set_web_browser_status command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-set-web-browser-status",
+          "markdownDescription": "Enables the set_web_browser_status command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_web_browser_status command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-set-web-browser-status",
+          "markdownDescription": "Denies the set_web_browser_status command without any pre-configured scope."
         },
         {
           "description": "Enables the show_file_picker command without any pre-configured scope.",

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/desktop.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/desktop.rs
@@ -322,6 +322,22 @@ impl<R: Runtime> NativeBridge<R> {
         ))
     }
 
+    pub fn open_web_browser(
+        &self,
+        _payload: WebBrowserRequest,
+    ) -> crate::Result<WebBrowserResponse> {
+        Err(crate::Error::NativeBridgeError(
+            "open_web_browser plugin is mobile-only; desktop callers should invoke the top-level command"
+                .to_string(),
+        ))
+    }
+
+    pub fn set_web_browser_status(&self, _payload: WebBrowserStatusRequest) -> crate::Result<()> {
+        Err(crate::Error::NativeBridgeError(
+            "set_web_browser_status plugin is mobile-only".to_string(),
+        ))
+    }
+
     /// Share-Extension clip files only exist in the iOS App Group
     /// container — desktop has no share extension.
     pub fn read_share_clip_html(

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/mobile.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/mobile.rs
@@ -432,7 +432,7 @@ impl<R: Runtime> NativeBridge<R> {
     /// Push an import status into the open browser's banner.
     pub fn set_web_browser_status(&self, payload: WebBrowserStatusRequest) -> crate::Result<()> {
         self.0
-            .run_mobile_plugin::<serde_json::Value>("set_web_browser_status", payload)
+            .run_mobile_plugin::<serde::de::IgnoredAny>("set_web_browser_status", payload)
             .map(|_| ())
             .map_err(Into::into)
     }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/mobile.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/mobile.rs
@@ -417,6 +417,26 @@ impl<R: Runtime> NativeBridge<R> {
             .map_err(Into::into)
     }
 
+    /// Present the native in-app browser (`WebBrowserController.swift/.kt`).
+    /// Blocks until the user closes it; downloads arrive meanwhile as
+    /// `web-browser-download` plugin events.
+    pub fn open_web_browser(
+        &self,
+        payload: WebBrowserRequest,
+    ) -> crate::Result<WebBrowserResponse> {
+        self.0
+            .run_mobile_plugin("open_web_browser", payload)
+            .map_err(Into::into)
+    }
+
+    /// Push an import status into the open browser's banner.
+    pub fn set_web_browser_status(&self, payload: WebBrowserStatusRequest) -> crate::Result<()> {
+        self.0
+            .run_mobile_plugin::<serde_json::Value>("set_web_browser_status", payload)
+            .map(|_| ())
+            .map_err(Into::into)
+    }
+
     /// Read + delete a Share-Extension-captured page HTML file from the
     /// App Group container (iOS only; Android resolves `html: None`).
     pub fn read_share_clip_html(

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
@@ -398,6 +398,42 @@ pub struct ClipUrlResponse {
     pub html: String,
 }
 
+/// Args for the in-app web browser (#5775). Mirrors `WebBrowserOptions`
+/// in `web_browser.rs` plus the absolute `download_dir` Rust resolved from
+/// `app_cache_dir()` so native downloads land inside the fs scope.
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebBrowserRequest {
+    pub url: String,
+    pub download_dir: String,
+    #[serde(default)]
+    pub background: Option<String>,
+    #[serde(default)]
+    pub foreground: Option<String>,
+    #[serde(default)]
+    pub is_eink: Option<bool>,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebBrowserResponse {
+    /// Set when the user tapped [Open] on an imported book in the chrome.
+    #[serde(default)]
+    pub open_book_hash: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebBrowserStatusRequest {
+    /// `importing` | `added` | `failed` | `unsupported`
+    pub state: String,
+    pub filename: String,
+    #[serde(default)]
+    pub book_hash: Option<String>,
+}
+
 /// Read (and delete) a page-HTML file the iOS Share Extension captured
 /// from the user's signed-in Safari tab into the App Group container.
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/tests/web_browser_models.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/tests/web_browser_models.rs
@@ -1,0 +1,43 @@
+use serde_json::json;
+use tauri_plugin_native_bridge::{WebBrowserRequest, WebBrowserResponse, WebBrowserStatusRequest};
+
+#[test]
+fn web_browser_request_round_trips_camel_case_fields() {
+    let request: WebBrowserRequest = serde_json::from_value(json!({
+        "url": "https://calibre.example.com",
+        "downloadDir": "/tmp/browser-downloads",
+        "isEink": true,
+        "labels": { "close": "Schließen" }
+    }))
+    .unwrap();
+    assert_eq!(request.url, "https://calibre.example.com");
+    assert_eq!(request.download_dir, "/tmp/browser-downloads");
+    assert_eq!(request.is_eink, Some(true));
+    assert_eq!(
+        request.labels.get("close").map(String::as_str),
+        Some("Schließen")
+    );
+    assert!(request.background.is_none());
+
+    let json = serde_json::to_value(&request).unwrap();
+    assert_eq!(json["downloadDir"], "/tmp/browser-downloads");
+    assert_eq!(json["isEink"], true);
+}
+
+#[test]
+fn web_browser_response_and_status_use_camel_case() {
+    let response: WebBrowserResponse =
+        serde_json::from_value(json!({ "openBookHash": "abc" })).unwrap();
+    assert_eq!(response.open_book_hash.as_deref(), Some("abc"));
+    let empty: WebBrowserResponse = serde_json::from_value(json!({})).unwrap();
+    assert!(empty.open_book_hash.is_none());
+
+    let status = WebBrowserStatusRequest {
+        state: "added".into(),
+        filename: "dune.epub".into(),
+        book_hash: Some("h".into()),
+    };
+    let json = serde_json::to_value(&status).unwrap();
+    assert_eq!(json["bookHash"], "h");
+    assert_eq!(json["filename"], "dune.epub");
+}

--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -39,8 +39,8 @@ mod sentry_config;
 #[cfg(desktop)]
 mod spawn_fresh_browser;
 mod transfer_file;
-#[cfg(desktop)]
 mod web_browser;
+#[cfg(desktop)]
 mod window_state;
 #[cfg(target_os = "windows")]
 use tauri::webview::ScrollBarStyle;

--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -40,6 +40,7 @@ mod sentry_config;
 mod spawn_fresh_browser;
 mod transfer_file;
 #[cfg(desktop)]
+mod web_browser;
 mod window_state;
 #[cfg(target_os = "windows")]
 use tauri::webview::ScrollBarStyle;
@@ -433,6 +434,8 @@ pub fn run() {
             #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
             discord_rpc::clear_book_presence,
             clip_url::clip_url,
+            web_browser::open_web_browser,
+            web_browser::set_web_browser_status,
             localsend::commands::localsend_start,
             localsend::commands::localsend_stop,
             localsend::commands::localsend_get_status,

--- a/apps/readest-app/src-tauri/src/web_browser.rs
+++ b/apps/readest-app/src-tauri/src/web_browser.rs
@@ -496,4 +496,27 @@ mod tests {
         assert!(js.contains("readest-browser.invalid"));
         assert!(js.contains("__readestBrowser"));
     }
+
+    // Regression guard for #5775: a long download filename must ellipsize the
+    // status text instead of clipping the [Open] button. That needs the
+    // ellipsis on a shrinkable text child plus a non-shrinking Open button,
+    // not `text-overflow` on the flex container, where it has no effect.
+    #[cfg(desktop)]
+    #[test]
+    fn chrome_script_keeps_open_button_from_clipping() {
+        let js = chrome_script(&WebBrowserOptions::default());
+        // The filename lives in a dedicated span that ellipsizes...
+        assert!(js.contains(".status-text{"));
+        assert!(js.contains("text-overflow:ellipsis"));
+        // ...and the Open button never shrinks away (flex:none in its rule).
+        let open_rule = js
+            .split(".open{")
+            .nth(1)
+            .and_then(|rest| rest.split('}').next())
+            .expect("chrome CSS defines an .open rule");
+        assert!(
+            open_rule.contains("flex:none"),
+            "the Open button must not shrink/clip: {open_rule}"
+        );
+    }
 }

--- a/apps/readest-app/src-tauri/src/web_browser.rs
+++ b/apps/readest-app/src-tauri/src/web_browser.rs
@@ -305,6 +305,11 @@ pub async fn open_web_browser(
                         .and_then(|n| n.to_str())
                         .unwrap_or("download")
                         .to_string();
+                    // A failed/cancelled download leaves a partial file behind; drop
+                    // it so the cache does not fill and the next attempt reuses the name.
+                    if !success {
+                        let _ = std::fs::remove_file(&dest);
+                    }
                     let _ = dl_app.emit(
                         "web-browser-download",
                         WebBrowserDownload {
@@ -382,12 +387,16 @@ pub async fn open_web_browser(
         is_eink: options.is_eink,
         labels: options.labels,
     };
-    app.native_bridge()
-        .open_web_browser(request)
-        .map(|r| WebBrowserResult {
-            open_book_hash: r.open_book_hash,
-        })
-        .map_err(|e| e.to_string())
+    // `open_web_browser` blocks until the native browser closes, which can be
+    // minutes. Run it on the blocking pool so it never parks an async worker.
+    let response =
+        tauri::async_runtime::spawn_blocking(move || app.native_bridge().open_web_browser(request))
+            .await
+            .map_err(|e| e.to_string())?
+            .map_err(|e| e.to_string())?;
+    Ok(WebBrowserResult {
+        open_book_hash: response.open_book_hash,
+    })
 }
 
 #[cfg(mobile)]

--- a/apps/readest-app/src-tauri/src/web_browser.rs
+++ b/apps/readest-app/src-tauri/src/web_browser.rs
@@ -1,0 +1,499 @@
+//! In-app web browser used as a book source (#5775).
+//!
+//! Desktop: a top-level `WebviewWindow` on the remote URL with `on_download`
+//! interception and chrome injected into the page (see `web_browser_chrome.js`).
+//! Mobile: delegated to `tauri-plugin-native-bridge`, which presents a native
+//! `WKWebView` / `WebView` controller (`WebBrowserController.swift/.kt`).
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use tauri::Url;
+
+#[derive(Deserialize, Default, Clone)]
+#[serde(rename_all = "camelCase", default)]
+pub struct WebBrowserOptions {
+    pub background: Option<String>,
+    pub foreground: Option<String>,
+    pub is_eink: Option<bool>,
+    pub labels: HashMap<String, String>,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WebBrowserDownload {
+    pub url: String,
+    pub path: String,
+    pub filename: String,
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WebBrowserStatus {
+    pub state: String,
+    pub filename: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub book_hash: Option<String>,
+}
+
+#[derive(Serialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct WebBrowserResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub open_book_hash: Option<String>,
+}
+
+pub const SENTINEL_HOST: &str = "readest-browser.invalid";
+
+#[derive(Debug, PartialEq)]
+pub enum SentinelAction {
+    Open(String),
+    Close,
+}
+
+/// Accept only http(s). A bare host ("calibre.example.com") gets `https://`.
+pub fn parse_browsable_url(input: &str) -> Result<Url, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("Invalid URL".into());
+    }
+    let has_scheme = trimmed
+        .split_once(':')
+        .map(|(scheme, _)| {
+            !scheme.is_empty()
+                && scheme
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.')
+                && scheme
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_alphabetic())
+        })
+        .unwrap_or(false);
+    let candidate = if has_scheme {
+        trimmed.to_string()
+    } else {
+        format!("https://{trimmed}")
+    };
+    let url = Url::parse(&candidate).map_err(|_| "Invalid URL".to_string())?;
+    match url.scheme() {
+        "http" | "https" if url.host_str().is_some() => Ok(url),
+        _ => Err("Invalid URL".into()),
+    }
+}
+
+/// Filename for an intercepted download: the server's suggested name when
+/// present, else the last URL path segment (query stripped), else "download".
+/// Path separators and other reserved characters become `_`.
+pub fn download_filename(suggested: Option<&str>, url: &Url) -> String {
+    let from_suggestion = suggested
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let from_url = url
+        .path_segments()
+        .and_then(|mut segs| segs.next_back().map(str::to_string))
+        .filter(|s| !s.is_empty());
+    let raw = from_suggestion
+        .or(from_url)
+        .unwrap_or_else(|| "download".into());
+    let cleaned: String = raw
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            c if c.is_control() => '_',
+            c => c,
+        })
+        .collect();
+    let cleaned = cleaned.trim().trim_matches('.').to_string();
+    if cleaned.is_empty() {
+        "download".into()
+    } else {
+        cleaned
+    }
+}
+
+/// `dir/name`, or `dir/name (n).ext` for the first free `n`.
+pub fn unique_path(dir: &Path, name: &str) -> PathBuf {
+    let first = dir.join(name);
+    if !first.exists() {
+        return first;
+    }
+    let (stem, ext) = match name.rsplit_once('.') {
+        Some((s, e)) if !s.is_empty() => (s.to_string(), format!(".{e}")),
+        _ => (name.to_string(), String::new()),
+    };
+    (1..)
+        .map(|n| dir.join(format!("{stem} ({n}){ext}")))
+        .find(|p| !p.exists())
+        .expect("unbounded counter")
+}
+
+/// The injected chrome signals "Open book" / "Close" by navigating to a
+/// sentinel host; `on_navigation` blocks the request and acts instead.
+pub fn sentinel_action(url: &Url) -> Option<SentinelAction> {
+    if url.host_str() != Some(SENTINEL_HOST) {
+        return None;
+    }
+    let mut segs = url.path_segments()?;
+    match (segs.next(), segs.next()) {
+        (Some("open"), Some(hash)) if !hash.is_empty() => {
+            Some(SentinelAction::Open(hash.to_string()))
+        }
+        (Some("close"), _) => Some(SentinelAction::Close),
+        _ => None,
+    }
+}
+
+/// JS snippet that pushes an import status into the injected chrome.
+pub fn status_eval(status: &WebBrowserStatus) -> String {
+    let json = serde_json::to_string(status).unwrap_or_else(|_| "{}".into());
+    format!("window.__readestBrowser && window.__readestBrowser.setStatus({json});")
+}
+
+#[cfg(desktop)]
+const CHROME_JS: &str = include_str!("web_browser_chrome.js");
+
+/// Wraps the chrome script with the JSON-encoded options so translated
+/// labels and theme colours cannot break out of the string context.
+#[cfg(desktop)]
+pub fn chrome_script(options: &WebBrowserOptions) -> String {
+    let options_json = serde_json::json!({
+        "background": options.background,
+        "foreground": options.foreground,
+        "isEink": options.is_eink.unwrap_or(false),
+        "labels": options.labels,
+    });
+    CHROME_JS.replace("__READEST_BROWSER_OPTIONS__", &options_json.to_string())
+}
+
+#[cfg(desktop)]
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Mutex,
+};
+#[cfg(desktop)]
+use tauri::{
+    webview::{DownloadEvent, NewWindowResponse},
+    AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder, WindowEvent,
+};
+#[cfg(desktop)]
+use tauri_plugin_opener::OpenerExt;
+
+#[cfg(desktop)]
+fn next_label() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    format!("browser-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+#[cfg(desktop)]
+fn is_browser_label(label: &str) -> bool {
+    label.starts_with("browser-")
+}
+
+/// Open `url` in a new top-level browser window. Resolves when the window
+/// closes; `open_book_hash` is set when the user pressed [Open] on an
+/// imported book. Downloads are emitted as `web-browser-download` events
+/// (see `WebBrowserDownload`).
+#[cfg(desktop)]
+#[tauri::command]
+pub async fn open_web_browser(
+    app: AppHandle,
+    url: String,
+    options: Option<WebBrowserOptions>,
+) -> Result<WebBrowserResult, String> {
+    let parsed = parse_browsable_url(&url)?;
+    let options = options.unwrap_or_default();
+    let label = next_label();
+    let download_dir = app
+        .path()
+        .app_cache_dir()
+        .map_err(|e| e.to_string())?
+        .join("browser-downloads");
+    std::fs::create_dir_all(&download_dir).map_err(|e| e.to_string())?;
+
+    let (close_tx, close_rx) = tokio::sync::oneshot::channel::<WebBrowserResult>();
+    let close_tx = Arc::new(Mutex::new(Some(close_tx)));
+    let open_hash: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    // url -> destination chosen in `Requested`; macOS never reports the
+    // finished path (wry limitation), so we remember it ourselves.
+    let pending: Arc<Mutex<HashMap<String, PathBuf>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    let title = parsed.host_str().unwrap_or("Readest").to_string();
+
+    let nav_app = app.clone();
+    let nav_label = label.clone();
+    let nav_hash = open_hash.clone();
+    let new_window_app = app.clone();
+    let new_window_label = label.clone();
+    let dl_app = app.clone();
+    let dl_pending = pending.clone();
+    let dl_dir = download_dir.clone();
+
+    let builder = WebviewWindowBuilder::new(&app, &label, WebviewUrl::External(parsed))
+        .title(&title)
+        .inner_size(1100.0, 800.0)
+        .min_inner_size(480.0, 360.0)
+        .center()
+        .decorations(true)
+        .initialization_script(chrome_script(&options))
+        .on_navigation(move |url| {
+            if let Some(action) = sentinel_action(url) {
+                if let SentinelAction::Open(hash) = action {
+                    *nav_hash.lock().unwrap_or_else(|e| e.into_inner()) = Some(hash);
+                }
+                if let Some(window) = nav_app.get_webview_window(&nav_label) {
+                    tauri::async_runtime::spawn(async move {
+                        let _ = window.close();
+                    });
+                }
+                return false;
+            }
+            match url.scheme() {
+                "http" | "https" | "about" | "blob" | "data" => true,
+                _ => {
+                    let _ = nav_app.opener().open_url(url.to_string(), None::<&str>);
+                    false
+                }
+            }
+        })
+        .on_new_window(move |url, _features| {
+            // target=_blank / window.open: keep the user in this window.
+            if let Some(window) = new_window_app.get_webview_window(&new_window_label) {
+                tauri::async_runtime::spawn(async move {
+                    let _ = window.navigate(url);
+                });
+            }
+            NewWindowResponse::Deny
+        })
+        .on_document_title_changed(|window, title| {
+            if !title.trim().is_empty() {
+                let _ = window.set_title(&title);
+            }
+        })
+        .on_download(move |webview, event| match event {
+            DownloadEvent::Requested { url, destination } => {
+                let suggested = destination
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(str::to_string);
+                let name = download_filename(suggested.as_deref(), &url);
+                let path = unique_path(&dl_dir, &name);
+                dl_pending
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .insert(url.to_string(), path.clone());
+                *destination = path;
+                let _ = webview.eval(status_eval(&WebBrowserStatus {
+                    state: "downloading".into(),
+                    filename: name,
+                    book_hash: None,
+                }));
+                true
+            }
+            DownloadEvent::Finished { url, path, success } => {
+                let chosen = dl_pending
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .remove(url.as_str());
+                if let Some(dest) = chosen.or(path) {
+                    let filename = dest
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("download")
+                        .to_string();
+                    let _ = dl_app.emit(
+                        "web-browser-download",
+                        WebBrowserDownload {
+                            url: url.to_string(),
+                            path: dest.to_string_lossy().into_owned(),
+                            filename,
+                            success,
+                            error: (!success).then(|| "Download failed".to_string()),
+                        },
+                    );
+                }
+                true
+            }
+            _ => true,
+        });
+
+    let window = builder.build().map_err(|e| e.to_string())?;
+
+    let done_tx = close_tx.clone();
+    window.on_window_event(move |event| {
+        if let WindowEvent::Destroyed = event {
+            if let Some(tx) = done_tx.lock().unwrap_or_else(|e| e.into_inner()).take() {
+                let hash = open_hash.lock().unwrap_or_else(|e| e.into_inner()).take();
+                let _ = tx.send(WebBrowserResult {
+                    open_book_hash: hash,
+                });
+            }
+        }
+    });
+
+    close_rx
+        .await
+        .map_err(|_| "Browser window closed".to_string())
+}
+
+/// Push an import status (importing / added / failed / unsupported) into
+/// every open browser window's chrome.
+#[cfg(desktop)]
+#[tauri::command]
+pub fn set_web_browser_status(app: AppHandle, status: WebBrowserStatus) -> Result<(), String> {
+    let js = status_eval(&status);
+    for (label, window) in app.webview_windows() {
+        if is_browser_label(&label) {
+            let _ = window.eval(&js);
+        }
+    }
+    Ok(())
+}
+
+/// Mobile: the native-bridge plugin presents `WebBrowserController`.
+/// Same JS surface as desktop: resolves when the browser closes.
+#[cfg(mobile)]
+#[tauri::command]
+pub async fn open_web_browser(
+    app: tauri::AppHandle,
+    url: String,
+    options: Option<WebBrowserOptions>,
+) -> Result<WebBrowserResult, String> {
+    use tauri::Manager;
+    use tauri_plugin_native_bridge::{NativeBridgeExt, WebBrowserRequest};
+
+    let parsed = parse_browsable_url(&url)?;
+    let options = options.unwrap_or_default();
+    let download_dir = app
+        .path()
+        .app_cache_dir()
+        .map_err(|e| e.to_string())?
+        .join("browser-downloads");
+    std::fs::create_dir_all(&download_dir).map_err(|e| e.to_string())?;
+    let request = WebBrowserRequest {
+        url: parsed.to_string(),
+        download_dir: download_dir.to_string_lossy().into_owned(),
+        background: options.background,
+        foreground: options.foreground,
+        is_eink: options.is_eink,
+        labels: options.labels,
+    };
+    app.native_bridge()
+        .open_web_browser(request)
+        .map(|r| WebBrowserResult {
+            open_book_hash: r.open_book_hash,
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(mobile)]
+#[tauri::command]
+pub fn set_web_browser_status(
+    app: tauri::AppHandle,
+    status: WebBrowserStatus,
+) -> Result<(), String> {
+    use tauri_plugin_native_bridge::{NativeBridgeExt, WebBrowserStatusRequest};
+    app.native_bridge()
+        .set_web_browser_status(WebBrowserStatusRequest {
+            state: status.state,
+            filename: status.filename,
+            book_hash: status.book_hash,
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_browsable_url_accepts_http_and_https_only() {
+        assert!(parse_browsable_url("https://calibre.example.com").is_ok());
+        assert!(parse_browsable_url("http://192.168.1.10:8083/").is_ok());
+        assert!(parse_browsable_url("ftp://example.com").is_err());
+        assert!(parse_browsable_url("javascript:alert(1)").is_err());
+        assert!(parse_browsable_url("not a url").is_err());
+    }
+
+    #[test]
+    fn parse_browsable_url_adds_https_when_scheme_is_missing() {
+        let url = parse_browsable_url("calibre.example.com/opds").unwrap();
+        assert_eq!(url.as_str(), "https://calibre.example.com/opds");
+    }
+
+    #[test]
+    fn download_filename_prefers_suggested_name_and_sanitises_it() {
+        let url = Url::parse("https://x.example/download/42/epub").unwrap();
+        assert_eq!(
+            download_filename(Some("Dune: Part/One.epub"), &url),
+            "Dune_ Part_One.epub"
+        );
+        assert_eq!(download_filename(Some("  "), &url), "epub");
+        assert_eq!(download_filename(None, &url), "epub");
+    }
+
+    #[test]
+    fn download_filename_falls_back_to_last_path_segment_without_query() {
+        let url = Url::parse("https://x.example/books/dune.epub?token=abc").unwrap();
+        assert_eq!(download_filename(None, &url), "dune.epub");
+        let root = Url::parse("https://x.example/").unwrap();
+        assert_eq!(download_filename(None, &root), "download");
+    }
+
+    #[test]
+    fn unique_path_appends_counter_when_file_exists() {
+        let dir = std::env::temp_dir().join(format!("readest-wb-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("dune.epub"), b"x").unwrap();
+        std::fs::write(dir.join("dune (1).epub"), b"x").unwrap();
+        assert_eq!(unique_path(&dir, "dune.epub"), dir.join("dune (2).epub"));
+        assert_eq!(unique_path(&dir, "other.epub"), dir.join("other.epub"));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn sentinel_action_parses_open_and_close() {
+        let open = Url::parse("https://readest-browser.invalid/open/abc123").unwrap();
+        assert_eq!(
+            sentinel_action(&open),
+            Some(SentinelAction::Open("abc123".into()))
+        );
+        let close = Url::parse("https://readest-browser.invalid/close").unwrap();
+        assert_eq!(sentinel_action(&close), Some(SentinelAction::Close));
+        let other = Url::parse("https://calibre.example.com/open/abc").unwrap();
+        assert_eq!(sentinel_action(&other), None);
+    }
+
+    #[test]
+    fn status_eval_is_a_guarded_json_call() {
+        let status = WebBrowserStatus {
+            state: "added".into(),
+            filename: "du\"ne.epub".into(),
+            book_hash: Some("h1".into()),
+        };
+        let js = status_eval(&status);
+        assert!(js.starts_with("window.__readestBrowser && window.__readestBrowser.setStatus("));
+        assert!(js.contains("\"state\":\"added\""));
+        assert!(js.contains("\"filename\":\"du\\\"ne.epub\""));
+        assert!(js.contains("\"bookHash\":\"h1\""));
+    }
+
+    #[cfg(desktop)]
+    #[test]
+    fn chrome_script_inlines_options_as_json() {
+        let mut options = WebBrowserOptions::default();
+        options.background = Some("#ffffff".into());
+        options.labels.insert("back".into(), "Zurück".into());
+        let js = chrome_script(&options);
+        assert!(!js.contains("__READEST_BROWSER_OPTIONS__"));
+        assert!(js.contains("})({"));
+        assert!(js.contains("\"background\":\"#ffffff\""));
+        assert!(js.contains("\"back\":\"Zurück\""));
+        assert!(js.contains("readest-browser.invalid"));
+        assert!(js.contains("__readestBrowser"));
+    }
+}

--- a/apps/readest-app/src-tauri/src/web_browser_chrome.js
+++ b/apps/readest-app/src-tauri/src/web_browser_chrome.js
@@ -1,0 +1,189 @@
+// Desktop in-app browser chrome (#5775). Injected into every page of a
+// `browser-*` window by `web_browser.rs`, which replaces the placeholder
+// identifier below with the JSON options (theme colours + translated labels).
+(function (OPTIONS) {
+  if (window.top !== window) return;
+  if (window.__readestBrowser) return;
+
+  var L = OPTIONS.labels || {};
+  var BG = OPTIONS.background || '#1f2024';
+  var FG = OPTIONS.foreground || '#f5f5f7';
+  var EINK = !!OPTIONS.isEink;
+  var SENTINEL = 'https://readest-browser.invalid/';
+
+  function label(key, fallback) {
+    return L[key] || fallback;
+  }
+
+  var state = { hideTimer: null };
+  var refs = {};
+
+  function css() {
+    return (
+      ':host{all:initial;}' +
+      '.pill{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);z-index:2147483647;' +
+      'display:flex;align-items:center;gap:4px;padding:4px 6px;border-radius:999px;' +
+      'background:' +
+      BG +
+      ';color:' +
+      FG +
+      ';font:13px/1.2 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;' +
+      'border:1px solid ' +
+      (EINK ? FG : 'rgba(128,128,128,.35)') +
+      ';' +
+      (EINK ? '' : 'box-shadow:0 4px 16px rgba(0,0,0,.18);') +
+      'direction:ltr;user-select:none;-webkit-user-select:none;}' +
+      '.btn{appearance:none;border:0;background:transparent;color:' +
+      FG +
+      ';width:32px;height:32px;border-radius:999px;' +
+      'display:inline-flex;align-items:center;justify-content:center;cursor:pointer;font-size:16px;padding:0;margin:0;}' +
+      '.btn:hover{background:rgba(128,128,128,.18);}' +
+      '.status{display:none;align-items:center;gap:8px;padding:0 8px;max-width:48vw;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}' +
+      '.status.show{display:inline-flex;}' +
+      '.open{appearance:none;border:0;border-radius:999px;padding:4px 12px;background:' +
+      FG +
+      ';color:' +
+      BG +
+      ';font-weight:600;cursor:pointer;}' +
+      '.sep{width:1px;height:20px;background:rgba(128,128,128,.35);margin:0 2px;}'
+    );
+  }
+
+  function el(tag, cls, text) {
+    var n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (text != null) n.textContent = text;
+    return n;
+  }
+
+  function button(key, glyph, fallback, onClick) {
+    var b = el('button', 'btn', glyph);
+    b.type = 'button';
+    b.setAttribute('aria-label', label(key, fallback));
+    b.title = label(key, fallback);
+    b.addEventListener('click', function (e) {
+      e.preventDefault();
+      onClick();
+    });
+    return b;
+  }
+
+  function navigate(path) {
+    location.href = SENTINEL + path;
+  }
+
+  function install() {
+    if (refs.host || !document.documentElement) return;
+    var host = el('div');
+    host.id = '__readest_browser_chrome__';
+    var root = host.attachShadow({ mode: 'closed' });
+    var style = el('style', null, css());
+    var pill = el('div', 'pill');
+    pill.setAttribute('role', 'toolbar');
+
+    refs.back = button('back', '‹', 'Back', function () {
+      history.back();
+    });
+    refs.forward = button('forward', '›', 'Forward', function () {
+      history.forward();
+    });
+    refs.reload = button('reload', '↻', 'Reload', function () {
+      location.reload();
+    });
+    refs.status = el('span', 'status');
+    refs.statusText = el('span');
+    refs.open = el('button', 'open', label('open', 'Open'));
+    refs.open.type = 'button';
+    refs.open.hidden = true;
+    refs.status.appendChild(refs.statusText);
+    refs.status.appendChild(refs.open);
+    refs.close = button('close', '×', 'Close', function () {
+      navigate('close');
+    });
+
+    pill.appendChild(refs.back);
+    pill.appendChild(refs.forward);
+    pill.appendChild(refs.reload);
+    pill.appendChild(refs.status);
+    pill.appendChild(el('span', 'sep'));
+    pill.appendChild(refs.close);
+    root.appendChild(style);
+    root.appendChild(pill);
+    (document.body || document.documentElement).appendChild(host);
+    refs.host = host;
+  }
+
+  function scheduleHide() {
+    state.hideTimer = setTimeout(function () {
+      refs.status.classList.remove('show');
+    }, 8000);
+  }
+
+  function setStatus(status) {
+    install();
+    if (!refs.status) return;
+    if (state.hideTimer) {
+      clearTimeout(state.hideTimer);
+      state.hideTimer = null;
+    }
+    var fallback = {
+      downloading: 'Downloading',
+      importing: 'Importing',
+      added: 'Added to library',
+      failed: 'Import failed',
+      unsupported: 'Not a supported book format',
+    };
+    var text = label(status.state, fallback[status.state] || status.state);
+    if (status.filename) text += ' · ' + status.filename;
+    refs.statusText.textContent = text;
+    refs.status.classList.add('show');
+    if (status.state === 'added' && status.bookHash) {
+      refs.open.hidden = false;
+      refs.open.onclick = function () {
+        navigate('open/' + encodeURIComponent(status.bookHash));
+      };
+      scheduleHide();
+    } else {
+      refs.open.hidden = true;
+      refs.open.onclick = null;
+      if (status.state !== 'downloading' && status.state !== 'importing') scheduleHide();
+    }
+  }
+
+  window.addEventListener(
+    'keydown',
+    function (e) {
+      var mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key === '[') {
+        e.preventDefault();
+        history.back();
+      } else if (mod && e.key === ']') {
+        e.preventDefault();
+        history.forward();
+      } else if (e.altKey && e.key === 'ArrowLeft') {
+        e.preventDefault();
+        history.back();
+      } else if (e.altKey && e.key === 'ArrowRight') {
+        e.preventDefault();
+        history.forward();
+      } else if (mod && (e.key === 'r' || e.key === 'R')) {
+        e.preventDefault();
+        location.reload();
+      } else if (mod && (e.key === 'w' || e.key === 'W')) {
+        e.preventDefault();
+        navigate('close');
+      } else if (e.key === 'Escape') {
+        window.stop();
+      }
+    },
+    true,
+  );
+
+  window.__readestBrowser = { setStatus: setStatus };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', install);
+  } else {
+    install();
+  }
+})(__READEST_BROWSER_OPTIONS__);

--- a/apps/readest-app/src-tauri/src/web_browser_chrome.js
+++ b/apps/readest-app/src-tauri/src/web_browser_chrome.js
@@ -23,6 +23,7 @@
       ':host{all:initial;}' +
       '.pill{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);z-index:2147483647;' +
       'display:flex;align-items:center;gap:4px;padding:4px 6px;border-radius:999px;' +
+      'box-sizing:border-box;max-width:calc(100vw - 24px);' +
       'background:' +
       BG +
       ';color:' +
@@ -36,11 +37,12 @@
       '.btn{appearance:none;border:0;background:transparent;color:' +
       FG +
       ';width:32px;height:32px;border-radius:999px;' +
-      'display:inline-flex;align-items:center;justify-content:center;cursor:pointer;font-size:16px;padding:0;margin:0;}' +
+      'display:inline-flex;align-items:center;justify-content:center;cursor:pointer;font-size:16px;padding:0;margin:0;flex:none;}' +
       '.btn:hover{background:rgba(128,128,128,.18);}' +
-      '.status{display:none;align-items:center;gap:8px;padding:0 8px;max-width:48vw;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}' +
+      '.status{display:none;align-items:center;gap:8px;padding:0 8px;min-width:0;flex:0 1 auto;}' +
       '.status.show{display:inline-flex;}' +
-      '.open{appearance:none;border:0;border-radius:999px;padding:4px 12px;background:' +
+      '.status-text{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0;flex:0 1 auto;}' +
+      '.open{appearance:none;border:0;border-radius:999px;padding:4px 12px;flex:none;white-space:nowrap;background:' +
       FG +
       ';color:' +
       BG +
@@ -91,7 +93,7 @@
       location.reload();
     });
     refs.status = el('span', 'status');
-    refs.statusText = el('span');
+    refs.statusText = el('span', 'status-text');
     refs.open = el('button', 'open', label('open', 'Open'));
     refs.open.type = 'button';
     refs.open.hidden = true;

--- a/apps/readest-app/src/__tests__/app/library/web-sources-dialog-store.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/web-sources-dialog-store.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { useSettingsStore } from '@/store/settingsStore';
+import type { SystemSettings } from '@/types/settings';
+
+vi.mock('@/services/webBrowser/webBrowser', () => ({ openWebBrowser: vi.fn() }));
+vi.mock('@/services/webBrowser/webBrowserOptions', () => ({
+  getWebBrowserOptions: () => ({ labels: {} }),
+}));
+vi.mock('@/hooks/useTranslation', () => ({ useTranslation: () => (k: string) => k }));
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: { isEink: false } }),
+}));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('@/utils/nav', () => ({ navigateToReader: vi.fn() }));
+vi.mock('@/components/Dialog', () => ({
+  default: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+    isOpen ? <div role='dialog'>{children}</div> : null,
+}));
+
+import WebSourcesDialog from '@/app/library/components/WebSourcesDialog';
+
+afterEach(() => cleanup());
+
+// Regression: with the real zustand store and no `webSources` saved yet, an
+// unstable selector result (`?? []`) makes React loop until error #185 —
+// exactly what crashed the library page on the first device run.
+describe('WebSourcesDialog with the real settings store', () => {
+  it('renders when settings.webSources is undefined', () => {
+    useSettingsStore.setState({ settings: {} as SystemSettings });
+    expect(() => render(<WebSourcesDialog isOpen onClose={() => {}} />)).not.toThrow();
+    expect(screen.getByRole('button', { name: 'Add Source' })).toBeTruthy();
+    // A store update unrelated to sources must not re-trigger a loop either.
+    useSettingsStore.setState({ settings: { fontFamily: 'x' } as unknown as SystemSettings });
+    expect(screen.getByRole('button', { name: 'Add Source' })).toBeTruthy();
+  });
+});

--- a/apps/readest-app/src/__tests__/app/library/web-sources-dialog.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/web-sources-dialog.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const { openMock, saveSettingsMock, setSettingsMock, navigateMock, settingsState } = vi.hoisted(
+  () => ({
+    openMock: vi.fn(),
+    saveSettingsMock: vi.fn(),
+    setSettingsMock: vi.fn(),
+    navigateMock: vi.fn(),
+    settingsState: {
+      settings: { webSources: [] as Array<{ id: string; name: string; url: string }> },
+    },
+  }),
+);
+
+vi.mock('@/services/webBrowser/webBrowser', () => ({ openWebBrowser: openMock }));
+vi.mock('@/services/webBrowser/webBrowserOptions', () => ({
+  getWebBrowserOptions: () => ({ labels: {} }),
+}));
+vi.mock('@/hooks/useTranslation', () => ({ useTranslation: () => (k: string) => k }));
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: { isEink: false } }),
+}));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('@/utils/nav', () => ({ navigateToReader: navigateMock }));
+vi.mock('@/store/settingsStore', () => {
+  const getState = () => ({
+    settings: settingsState.settings,
+    setSettings: setSettingsMock,
+    saveSettings: saveSettingsMock,
+  });
+  const useSettingsStore = (selector: (s: ReturnType<typeof getState>) => unknown) =>
+    selector(getState());
+  useSettingsStore.getState = getState;
+  return { useSettingsStore };
+});
+vi.mock('@/components/Dialog', () => ({
+  default: ({
+    isOpen,
+    children,
+    title,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+    title?: string;
+  }) =>
+    isOpen ? (
+      <div role='dialog' aria-label={title}>
+        {children}
+      </div>
+    ) : null,
+}));
+
+import WebSourcesDialog from '@/app/library/components/WebSourcesDialog';
+
+afterEach(() => cleanup());
+
+beforeEach(() => {
+  openMock.mockReset().mockResolvedValue({});
+  saveSettingsMock.mockReset();
+  setSettingsMock.mockReset();
+  navigateMock.mockReset();
+  settingsState.settings = { webSources: [] };
+});
+
+describe('WebSourcesDialog', () => {
+  it('adds a source and persists it through the settings store', async () => {
+    render(<WebSourcesDialog isOpen onClose={() => {}} />);
+    fireEvent.change(screen.getByPlaceholderText('https://calibre.example.com'), {
+      target: { value: 'calibre.example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add Source' }));
+    await waitFor(() => expect(saveSettingsMock).toHaveBeenCalled());
+    expect(settingsState.settings.webSources).toEqual([
+      expect.objectContaining({ name: 'calibre.example.com', url: 'https://calibre.example.com/' }),
+    ]);
+  });
+
+  it('shows an error for an invalid url and does not save', async () => {
+    render(<WebSourcesDialog isOpen onClose={() => {}} />);
+    fireEvent.change(screen.getByPlaceholderText('https://calibre.example.com'), {
+      target: { value: 'ftp://nope' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add Source' }));
+    expect(await screen.findByText('Please enter a valid http(s) URL')).toBeTruthy();
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it('opens a saved source in the in-app browser and navigates to an opened book', async () => {
+    settingsState.settings = {
+      webSources: [{ id: '1', name: 'Calibre', url: 'https://calibre.example.com/' }],
+    };
+    openMock.mockResolvedValue({ openBookHash: 'h1' });
+    const onClose = vi.fn();
+    render(<WebSourcesDialog isOpen onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /Calibre/ }));
+    await waitFor(() =>
+      expect(openMock).toHaveBeenCalledWith('https://calibre.example.com/', expect.anything()),
+    );
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith(expect.anything(), ['h1']));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('removes a saved source', async () => {
+    settingsState.settings = {
+      webSources: [{ id: '1', name: 'Calibre', url: 'https://calibre.example.com/' }],
+    };
+    render(<WebSourcesDialog isOpen onClose={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    await waitFor(() => expect(saveSettingsMock).toHaveBeenCalled());
+    expect(settingsState.settings.webSources).toEqual([]);
+  });
+});

--- a/apps/readest-app/src/__tests__/hooks/useWebBrowserDownloads.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useWebBrowserDownloads.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const { subscribeMock, setStatusMock, ingestMock, updateBooksMock, dispatchMock } = vi.hoisted(
+  () => ({
+    subscribeMock: vi.fn(),
+    setStatusMock: vi.fn(),
+    ingestMock: vi.fn(),
+    updateBooksMock: vi.fn(),
+    dispatchMock: vi.fn(),
+  }),
+);
+
+vi.mock('@/services/webBrowser/webBrowser', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/webBrowser/webBrowser')>();
+  return {
+    ...actual,
+    subscribeWebBrowserDownloads: subscribeMock,
+    setWebBrowserStatus: setStatusMock,
+  };
+});
+vi.mock('@/services/ingestService', () => ({ ingestFile: ingestMock }));
+vi.mock('@/utils/event', () => ({ eventDispatcher: { dispatch: dispatchMock } }));
+vi.mock('@/hooks/useTranslation', () => ({ useTranslation: () => (k: string) => k }));
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: { isMobileApp: false } }),
+}));
+vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ user: null }) }));
+vi.mock('next/navigation', () => ({ useSearchParams: () => ({ get: () => 'g1' }) }));
+vi.mock('@/store/libraryStore', () => ({
+  useLibraryStore: {
+    getState: () => ({
+      library: [{ hash: 'x', groupId: 'g1', groupName: 'Sci-fi' }],
+      updateBooks: updateBooksMock,
+    }),
+  },
+}));
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: { getState: () => ({ settings: {} }) },
+}));
+
+import { useWebBrowserDownloads } from '@/hooks/useWebBrowserDownloads';
+
+type Handler = (d: {
+  url: string;
+  path: string;
+  filename: string;
+  success: boolean;
+  error?: string;
+}) => void;
+
+beforeEach(() => {
+  subscribeMock.mockReset();
+  setStatusMock.mockReset().mockResolvedValue(undefined);
+  ingestMock.mockReset();
+  updateBooksMock.mockReset().mockResolvedValue(undefined);
+  dispatchMock.mockReset();
+});
+
+async function mountAndGetHandler(): Promise<Handler> {
+  let handler: Handler | null = null;
+  subscribeMock.mockImplementation((_mobile: boolean, cb: Handler) => {
+    handler = cb;
+    return Promise.resolve(() => {});
+  });
+  renderHook(() => useWebBrowserDownloads());
+  await waitFor(() => expect(subscribeMock).toHaveBeenCalled());
+  return handler!;
+}
+
+describe('useWebBrowserDownloads', () => {
+  it('imports a supported download into the current group and reports added', async () => {
+    ingestMock.mockResolvedValue({ hash: 'h1', title: 'Dune' });
+    const handler = await mountAndGetHandler();
+    handler({ url: 'u', path: '/cache/dune.epub', filename: 'dune.epub', success: true });
+    await waitFor(() => expect(updateBooksMock).toHaveBeenCalled());
+    expect(ingestMock).toHaveBeenCalledWith(
+      expect.objectContaining({ file: '/cache/dune.epub', groupId: 'g1', groupName: 'Sci-fi' }),
+      expect.objectContaining({ isLoggedIn: false }),
+    );
+    expect(setStatusMock).toHaveBeenNthCalledWith(1, {
+      state: 'importing',
+      filename: 'dune.epub',
+    });
+    expect(setStatusMock).toHaveBeenLastCalledWith({
+      state: 'added',
+      filename: 'dune.epub',
+      bookHash: 'h1',
+    });
+    expect(dispatchMock).toHaveBeenCalledWith(
+      'toast',
+      expect.objectContaining({ type: 'success' }),
+    );
+  });
+
+  it('reports unsupported files without importing them', async () => {
+    const handler = await mountAndGetHandler();
+    handler({ url: 'u', path: '/cache/cover.jpg', filename: 'cover.jpg', success: true });
+    await waitFor(() =>
+      expect(setStatusMock).toHaveBeenCalledWith({ state: 'unsupported', filename: 'cover.jpg' }),
+    );
+    expect(ingestMock).not.toHaveBeenCalled();
+  });
+
+  it('reports failed downloads and failed imports', async () => {
+    const handler = await mountAndGetHandler();
+    handler({
+      url: 'u',
+      path: '/cache/dune.epub',
+      filename: 'dune.epub',
+      success: false,
+      error: 'boom',
+    });
+    await waitFor(() =>
+      expect(setStatusMock).toHaveBeenCalledWith({ state: 'failed', filename: 'dune.epub' }),
+    );
+    expect(dispatchMock).toHaveBeenCalledWith('toast', expect.objectContaining({ type: 'error' }));
+
+    ingestMock.mockRejectedValue(new Error('bad epub'));
+    handler({ url: 'u2', path: '/cache/bad.epub', filename: 'bad.epub', success: true });
+    await waitFor(() =>
+      expect(setStatusMock).toHaveBeenCalledWith({ state: 'failed', filename: 'bad.epub' }),
+    );
+  });
+});

--- a/apps/readest-app/src/__tests__/services/webBrowser/webBrowser.test.ts
+++ b/apps/readest-app/src/__tests__/services/webBrowser/webBrowser.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const invokeMock = vi.fn();
+const pluginListeners: Array<{ event: string; handler: (payload: unknown) => void }> = [];
+const unregisterMock = vi.fn();
+const windowListeners: Array<{ event: string; handler: (e: { payload: unknown }) => void }> = [];
+const unlistenMock = vi.fn();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...a: unknown[]) => invokeMock(...a),
+  addPluginListener: (_plugin: string, event: string, handler: (payload: unknown) => void) => {
+    pluginListeners.push({ event, handler });
+    return Promise.resolve({ unregister: unregisterMock });
+  },
+}));
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    listen: (event: string, handler: (e: { payload: unknown }) => void) => {
+      windowListeners.push({ event, handler });
+      return Promise.resolve(unlistenMock);
+    },
+  }),
+}));
+vi.mock('@/utils/style', () => ({ getThemeCode: () => ({ bg: '#111111', fg: '#eeeeee' }) }));
+
+import {
+  openWebBrowser,
+  setWebBrowserStatus,
+  subscribeWebBrowserDownloads,
+  isSupportedBookDownload,
+  WEB_BROWSER_DOWNLOAD_EVENT,
+} from '@/services/webBrowser/webBrowser';
+import { getWebBrowserOptions } from '@/services/webBrowser/webBrowserOptions';
+
+const _ = (k: string) => `t:${k}`;
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  pluginListeners.length = 0;
+  windowListeners.length = 0;
+  unregisterMock.mockReset();
+  unlistenMock.mockReset();
+});
+
+describe('getWebBrowserOptions', () => {
+  it('carries theme colours, eink flag and every translated label', () => {
+    const options = getWebBrowserOptions(_, true);
+    expect(options.background).toBe('#111111');
+    expect(options.foreground).toBe('#eeeeee');
+    expect(options.isEink).toBe(true);
+    expect(options.labels.back).toBe('t:Back');
+    expect(options.labels.added).toBe('t:Added to library');
+    expect(Object.keys(options.labels).sort()).toEqual(
+      [
+        'added',
+        'back',
+        'close',
+        'copyLink',
+        'downloading',
+        'failed',
+        'forward',
+        'importing',
+        'menu',
+        'notSecure',
+        'open',
+        'openInBrowser',
+        'reload',
+        'signOut',
+        'stop',
+        'unsupported',
+      ].sort(),
+    );
+  });
+});
+
+describe('openWebBrowser', () => {
+  it('invokes open_web_browser and returns the result', async () => {
+    invokeMock.mockResolvedValue({ openBookHash: 'h1' });
+    const options = getWebBrowserOptions(_, false);
+    const result = await openWebBrowser('https://calibre.example.com', options);
+    expect(invokeMock).toHaveBeenCalledWith('open_web_browser', {
+      url: 'https://calibre.example.com',
+      options,
+    });
+    expect(result).toEqual({ openBookHash: 'h1' });
+  });
+
+  it('normalises a null result to an empty object', async () => {
+    invokeMock.mockResolvedValue(null);
+    await expect(openWebBrowser('https://x', getWebBrowserOptions(_, false))).resolves.toEqual({});
+  });
+});
+
+describe('setWebBrowserStatus', () => {
+  it('invokes set_web_browser_status and swallows failures', async () => {
+    invokeMock.mockRejectedValue(new Error('no browser'));
+    await expect(
+      setWebBrowserStatus({ state: 'importing', filename: 'dune.epub' }),
+    ).resolves.toBeUndefined();
+    expect(invokeMock).toHaveBeenCalledWith('set_web_browser_status', {
+      status: { state: 'importing', filename: 'dune.epub' },
+    });
+  });
+});
+
+describe('subscribeWebBrowserDownloads', () => {
+  const download = { url: 'u', path: '/p/dune.epub', filename: 'dune.epub', success: true };
+
+  it('uses the native-bridge plugin listener on mobile', async () => {
+    const onDownload = vi.fn();
+    const dispose = await subscribeWebBrowserDownloads(true, onDownload);
+    expect(pluginListeners).toEqual([
+      expect.objectContaining({ event: WEB_BROWSER_DOWNLOAD_EVENT }),
+    ]);
+    pluginListeners[0]!.handler(download);
+    expect(onDownload).toHaveBeenCalledWith(download);
+    dispose();
+    expect(unregisterMock).toHaveBeenCalled();
+  });
+
+  it('uses the window event listener on desktop', async () => {
+    const onDownload = vi.fn();
+    const dispose = await subscribeWebBrowserDownloads(false, onDownload);
+    expect(windowListeners).toEqual([
+      expect.objectContaining({ event: WEB_BROWSER_DOWNLOAD_EVENT }),
+    ]);
+    windowListeners[0]!.handler({ payload: download });
+    expect(onDownload).toHaveBeenCalledWith(download);
+    dispose();
+    expect(unlistenMock).toHaveBeenCalled();
+  });
+});
+
+describe('isSupportedBookDownload', () => {
+  it('accepts book extensions case-insensitively and rejects others', () => {
+    expect(isSupportedBookDownload('Dune.EPUB')).toBe(true);
+    expect(isSupportedBookDownload('comic.cbz')).toBe(true);
+    expect(isSupportedBookDownload('cover.jpg')).toBe(false);
+    expect(isSupportedBookDownload('noext')).toBe(false);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/webBrowser/webSources.test.ts
+++ b/apps/readest-app/src/__tests__/services/webBrowser/webSources.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  addWebSource,
+  normalizeWebSourceUrl,
+  removeWebSource,
+  webSourceNameFromUrl,
+} from '@/services/webBrowser/webSources';
+
+describe('normalizeWebSourceUrl', () => {
+  it('accepts http(s) and prefixes https when the scheme is missing', () => {
+    expect(normalizeWebSourceUrl('https://calibre.example.com/')).toBe(
+      'https://calibre.example.com/',
+    );
+    expect(normalizeWebSourceUrl('  calibre.example.com/opds ')).toBe(
+      'https://calibre.example.com/opds',
+    );
+    expect(normalizeWebSourceUrl('http://192.168.1.10:8083')).toBe('http://192.168.1.10:8083/');
+  });
+
+  it('rejects empty, non-http and malformed input', () => {
+    expect(normalizeWebSourceUrl('')).toBeNull();
+    expect(normalizeWebSourceUrl('ftp://x')).toBeNull();
+    expect(normalizeWebSourceUrl('javascript:alert(1)')).toBeNull();
+    expect(normalizeWebSourceUrl('http://')).toBeNull();
+  });
+});
+
+describe('webSourceNameFromUrl', () => {
+  it('uses the host', () => {
+    expect(webSourceNameFromUrl('https://calibre.example.com/opds')).toBe('calibre.example.com');
+    expect(webSourceNameFromUrl('nonsense')).toBe('nonsense');
+  });
+});
+
+describe('addWebSource / removeWebSource', () => {
+  it('appends a source with a generated id and a default name', () => {
+    const list = addWebSource([], '', 'https://calibre.example.com/');
+    expect(list).toHaveLength(1);
+    expect(list[0]!.id).toBeTruthy();
+    expect(list[0]!.name).toBe('calibre.example.com');
+    expect(list[0]!.url).toBe('https://calibre.example.com/');
+  });
+
+  it('replaces an existing entry with the same url instead of duplicating', () => {
+    const first = addWebSource([], 'Old', 'https://calibre.example.com/');
+    const second = addWebSource(first, 'New', 'https://calibre.example.com/');
+    expect(second).toHaveLength(1);
+    expect(second[0]!.name).toBe('New');
+    expect(second[0]!.id).toBe(first[0]!.id);
+  });
+
+  it('removes by id and leaves other entries untouched', () => {
+    const list = addWebSource(
+      addWebSource([], 'A', 'https://a.example/'),
+      'B',
+      'https://b.example/',
+    );
+    const next = removeWebSource(list, list[0]!.id);
+    expect(next.map((s) => s.name)).toEqual(['B']);
+  });
+});

--- a/apps/readest-app/src/app/library/components/ImportMenu.tsx
+++ b/apps/readest-app/src/app/library/components/ImportMenu.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { MdLink, MdMenuBook, MdRssFeed } from 'react-icons/md';
+import { MdLanguage, MdLink, MdMenuBook, MdRssFeed } from 'react-icons/md';
 import { LuLibrary } from 'react-icons/lu';
 import { IoFileTray } from 'react-icons/io5';
 import { useEnv } from '@/context/EnvContext';
@@ -13,6 +13,7 @@ export interface ImportMenuProps {
   onImportBooksFromFiles: () => void;
   onImportBooksFromDirectory?: () => void;
   onImportBookFromUrl?: () => void;
+  onImportFromWebBrowser?: () => void;
   onImportBookFromNovelUrl?: () => void;
   onOpenCatalogManager: () => void;
   onOpenFeeds: () => void;
@@ -24,6 +25,7 @@ const ImportMenu: React.FC<ImportMenuProps> = ({
   onImportBooksFromFiles,
   onImportBooksFromDirectory,
   onImportBookFromUrl,
+  onImportFromWebBrowser,
   onImportBookFromNovelUrl,
   onOpenCatalogManager,
   onOpenFeeds,
@@ -43,6 +45,11 @@ const ImportMenu: React.FC<ImportMenuProps> = ({
 
   const handleImportFromUrl = () => {
     onImportBookFromUrl?.();
+    setIsDropdownOpen?.(false);
+  };
+
+  const handleImportFromWebBrowser = () => {
+    onImportFromWebBrowser?.();
     setIsDropdownOpen?.(false);
   };
 
@@ -86,6 +93,13 @@ const ImportMenu: React.FC<ImportMenuProps> = ({
           label={_('From Web URL')}
           Icon={<MdLink className='h-5 w-5' />}
           onClick={handleImportFromUrl}
+        />
+      )}
+      {onImportFromWebBrowser && (
+        <MenuItem
+          label={_('From Web Browser')}
+          Icon={<MdLanguage className='h-5 w-5' />}
+          onClick={handleImportFromWebBrowser}
         />
       )}
       {onImportBookFromNovelUrl && (

--- a/apps/readest-app/src/app/library/components/LibraryHeader.tsx
+++ b/apps/readest-app/src/app/library/components/LibraryHeader.tsx
@@ -30,6 +30,7 @@ interface LibraryHeaderProps {
   onImportBooksFromFiles: () => void;
   onImportBooksFromDirectory?: () => void;
   onImportBookFromUrl?: () => void;
+  onImportFromWebBrowser?: () => void;
   onImportBookFromNovelUrl?: () => void;
   onOpenCatalogManager: () => void;
   onOpenFeeds: () => void;
@@ -51,6 +52,7 @@ const LibraryHeader: React.FC<LibraryHeaderProps> = ({
   onImportBooksFromFiles,
   onImportBooksFromDirectory,
   onImportBookFromUrl,
+  onImportFromWebBrowser,
   onImportBookFromNovelUrl,
   onOpenCatalogManager,
   onOpenFeeds,
@@ -209,6 +211,7 @@ const LibraryHeader: React.FC<LibraryHeaderProps> = ({
                     onImportBooksFromFiles={onImportBooksFromFiles}
                     onImportBooksFromDirectory={onImportBooksFromDirectory}
                     onImportBookFromUrl={onImportBookFromUrl}
+                    onImportFromWebBrowser={onImportFromWebBrowser}
                     onImportBookFromNovelUrl={onImportBookFromNovelUrl}
                     onOpenCatalogManager={onOpenCatalogManager}
                     onOpenFeeds={onOpenFeeds}

--- a/apps/readest-app/src/app/library/components/WebSourcesDialog.tsx
+++ b/apps/readest-app/src/app/library/components/WebSourcesDialog.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import clsx from 'clsx';
+import { MdClose, MdLanguage } from 'react-icons/md';
+import Dialog from '@/components/Dialog';
+import { useEnv } from '@/context/EnvContext';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useSettingsStore } from '@/store/settingsStore';
+import { openWebBrowser } from '@/services/webBrowser/webBrowser';
+import { getWebBrowserOptions } from '@/services/webBrowser/webBrowserOptions';
+import {
+  addWebSource,
+  normalizeWebSourceUrl,
+  removeWebSource,
+} from '@/services/webBrowser/webSources';
+import { navigateToReader } from '@/utils/nav';
+import type { WebSource } from '@/types/webSource';
+
+interface WebSourcesDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * "From Web Browser" (#5775): saved sites (Calibre-Web, Kavita,
+ * Audiobookshelf, ...) the user browses inside Readest. Tapping a source
+ * opens the in-app browser; downloads made there are imported by
+ * `useWebBrowserDownloads`. Tauri-only, like "From Web URL".
+ */
+const WebSourcesDialog: React.FC<WebSourcesDialogProps> = ({ isOpen, onClose }) => {
+  const _ = useTranslation();
+  const router = useRouter();
+  const { envConfig, appService } = useEnv();
+  const sources = useSettingsStore((s) => s.settings.webSources ?? []);
+  const [name, setName] = useState('');
+  const [url, setUrl] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [opening, setOpening] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setName('');
+    setUrl('');
+    setError(null);
+    setOpening(false);
+  }, [isOpen]);
+
+  const persist = (next: WebSource[]) => {
+    const { settings, setSettings, saveSettings } = useSettingsStore.getState();
+    settings.webSources = next;
+    setSettings(settings);
+    saveSettings(envConfig, settings);
+  };
+
+  const handleAdd = () => {
+    const normalized = normalizeWebSourceUrl(url);
+    if (!normalized) {
+      setError(_('Please enter a valid http(s) URL'));
+      return;
+    }
+    setError(null);
+    persist(addWebSource(sources, name, normalized));
+    setName('');
+    setUrl('');
+  };
+
+  const handleOpen = async (source: WebSource) => {
+    if (opening) return;
+    setOpening(true);
+    try {
+      const result = await openWebBrowser(
+        source.url,
+        getWebBrowserOptions(_, !!appService?.isEink),
+      );
+      if (result.openBookHash) {
+        onClose();
+        navigateToReader(router, [result.openBookHash]);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setOpening(false);
+    }
+  };
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title={_('From Web Browser')}
+      boxClassName='sm:!w-[480px] sm:!max-w-[480px] sm:!h-auto sm:!max-h-[80vh]'
+    >
+      <div className='flex flex-col gap-4 pb-6 pt-2'>
+        <p className='text-base-content/60 text-sm leading-relaxed'>
+          {_(
+            'Browse your Calibre-Web, Kavita or other book server inside Readest. Books you download there are added to your library.',
+          )}
+        </p>
+
+        {sources.length > 0 && (
+          <ul className='eink-bordered border-base-200 divide-base-200 divide-y rounded-lg border'>
+            {sources.map((source) => (
+              <li key={source.id} className='flex items-center gap-2 pe-1 ps-3'>
+                <button
+                  type='button'
+                  disabled={opening}
+                  onClick={() => void handleOpen(source)}
+                  className={clsx(
+                    'flex min-w-0 flex-1 items-center gap-3 py-3 text-start',
+                    'focus-visible:ring-base-content/15 rounded-md focus-visible:outline-none focus-visible:ring-2',
+                  )}
+                >
+                  <MdLanguage className='text-base-content/70 h-5 w-5 shrink-0' />
+                  <span className='flex min-w-0 flex-col'>
+                    <span className='truncate text-sm font-medium'>{source.name}</span>
+                    <span className='text-base-content/60 truncate text-xs'>{source.url}</span>
+                  </span>
+                </button>
+                <button
+                  type='button'
+                  aria-label={_('Remove')}
+                  title={_('Remove')}
+                  onClick={() => persist(removeWebSource(sources, source.id))}
+                  className='btn btn-ghost btn-circle btn-sm h-8 min-h-8 w-8 p-0'
+                >
+                  <MdClose className='h-4 w-4' />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className='flex flex-col gap-2'>
+          <input
+            type='text'
+            className='input input-bordered eink-bordered placeholder:text-base-content/35 w-full'
+            placeholder={_('Name (optional)')}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <input
+            type='url'
+            className='input input-bordered eink-bordered placeholder:text-base-content/35 w-full'
+            placeholder='https://calibre.example.com'
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleAdd();
+            }}
+          />
+          {error && <p className='text-error text-sm leading-relaxed'>{error}</p>}
+        </div>
+
+        <div className='flex justify-end gap-2 pt-1'>
+          <button type='button' className='btn btn-ghost btn-sm eink-bordered' onClick={onClose}>
+            {_('Close')}
+          </button>
+          <button
+            type='button'
+            className='btn btn-contrast btn-sm'
+            onClick={handleAdd}
+            disabled={!url.trim()}
+          >
+            {_('Add Source')}
+          </button>
+        </div>
+      </div>
+    </Dialog>
+  );
+};
+
+export default WebSourcesDialog;

--- a/apps/readest-app/src/app/library/components/WebSourcesDialog.tsx
+++ b/apps/readest-app/src/app/library/components/WebSourcesDialog.tsx
@@ -18,6 +18,10 @@ import {
 import { navigateToReader } from '@/utils/nav';
 import type { WebSource } from '@/types/webSource';
 
+// Stable fallback: a fresh `[]` per render would be an unstable zustand
+// snapshot and loop React until error #185 (seen on the first device run).
+const NO_SOURCES: WebSource[] = [];
+
 interface WebSourcesDialogProps {
   isOpen: boolean;
   onClose: () => void;
@@ -33,7 +37,7 @@ const WebSourcesDialog: React.FC<WebSourcesDialogProps> = ({ isOpen, onClose }) 
   const _ = useTranslation();
   const router = useRouter();
   const { envConfig, appService } = useEnv();
-  const sources = useSettingsStore((s) => s.settings.webSources ?? []);
+  const sources = useSettingsStore((s) => s.settings.webSources ?? NO_SOURCES);
   const [name, setName] = useState('');
   const [url, setUrl] = useState('');
   const [error, setError] = useState<string | null>(null);

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -69,6 +69,7 @@ import { useOpenBookLink } from '@/hooks/useOpenBookLink';
 import { useReadingWidget } from '@/hooks/useReadingWidget';
 import { useOpenShareLink } from '@/hooks/useOpenShareLink';
 import { useClipUrlIngress } from '@/hooks/useClipUrlIngress';
+import { useWebBrowserDownloads } from '@/hooks/useWebBrowserDownloads';
 import { useKeyDownActions } from '@/hooks/useKeyDownActions';
 import { SelectedFile, useFileSelector } from '@/hooks/useFileSelector';
 import { lockScreenOrientation, selectDirectory, showFilePicker } from '@/utils/bridge';
@@ -119,6 +120,7 @@ import ImportFromFolderDialog, {
   ImportFromFolderResult,
 } from './components/ImportFromFolderDialog';
 import ImportFromUrlDialog from './components/ImportFromUrlDialog';
+import WebSourcesDialog from './components/WebSourcesDialog';
 import ImportNovelDialog from './components/ImportNovelDialog';
 import NowPlayingBar from './components/NowPlayingBar';
 import { clipPageWithSignInFallback } from '@/services/send/clipSignIn';
@@ -255,6 +257,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
   const [showFeeds, setShowFeeds] = useState(false);
   const [showAddFeed, setShowAddFeed] = useState(false);
   const [showImportFromUrl, setShowImportFromUrl] = useState(false);
+  const [showWebSources, setShowWebSources] = useState(false);
   const [showImportNovel, setShowImportNovel] = useState(false);
   const [importMenuAnchor, setImportMenuAnchor] = useState<HTMLElement | null>(null);
   const [loading, setLoading] = useState(false);
@@ -376,6 +379,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
   useReadingWidget();
   useOpenShareLink();
   useClipUrlIngress();
+  useWebBrowserDownloads();
   useTransferQueue(libraryLoaded);
 
   const { pullLibrary, pushLibrary } = useBooksSync();
@@ -1934,6 +1938,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
             appService?.canReadExternalDir ? handleImportBooksFromDirectory : undefined
           }
           onImportBookFromUrl={isTauriAppPlatform() ? () => setShowImportFromUrl(true) : undefined}
+          onImportFromWebBrowser={isTauriAppPlatform() ? () => setShowWebSources(true) : undefined}
           onImportBookFromNovelUrl={
             isTauriAppPlatform() ? () => setShowImportNovel(true) : undefined
           }
@@ -2101,6 +2106,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
             appService?.canReadExternalDir ? handleImportBooksFromDirectory : undefined
           }
           onImportBookFromUrl={isTauriAppPlatform() ? () => setShowImportFromUrl(true) : undefined}
+          onImportFromWebBrowser={isTauriAppPlatform() ? () => setShowWebSources(true) : undefined}
           onImportBookFromNovelUrl={
             isTauriAppPlatform() ? () => setShowImportNovel(true) : undefined
           }
@@ -2204,6 +2210,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
           }}
         />
       )}
+      <WebSourcesDialog isOpen={showWebSources} onClose={() => setShowWebSources(false)} />
       <ImportFromUrlDialog
         isOpen={showImportFromUrl}
         onClose={() => setShowImportFromUrl(false)}

--- a/apps/readest-app/src/hooks/useWebBrowserDownloads.ts
+++ b/apps/readest-app/src/hooks/useWebBrowserDownloads.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useAuth } from '@/context/AuthContext';
+import { useEnv } from '@/context/EnvContext';
+import { useLibraryStore } from '@/store/libraryStore';
+import { useSettingsStore } from '@/store/settingsStore';
+import { ingestFile } from '@/services/ingestService';
+import {
+  isSupportedBookDownload,
+  setWebBrowserStatus,
+  subscribeWebBrowserDownloads,
+  type WebBrowserDownload,
+} from '@/services/webBrowser/webBrowser';
+import { eventDispatcher } from '@/utils/event';
+import { useTranslation } from './useTranslation';
+
+/**
+ * Imports files downloaded inside the in-app web browser (#5775) and
+ * mirrors the outcome into the browser's chrome. Mount once in the
+ * library page, next to `useClipUrlIngress`.
+ */
+export function useWebBrowserDownloads() {
+  const _ = useTranslation();
+  const { envConfig, appService } = useEnv();
+  const { user } = useAuth();
+  const searchParams = useSearchParams();
+
+  const handleDownload = useCallback(
+    async (download: WebBrowserDownload) => {
+      if (!appService) return;
+      const { filename } = download;
+      if (!download.success) {
+        await setWebBrowserStatus({ state: 'failed', filename });
+        eventDispatcher.dispatch('toast', {
+          type: 'error',
+          message: download.error || _('Download failed'),
+          timeout: 3500,
+        });
+        return;
+      }
+      if (!isSupportedBookDownload(filename)) {
+        await setWebBrowserStatus({ state: 'unsupported', filename });
+        return;
+      }
+      await setWebBrowserStatus({ state: 'importing', filename });
+      try {
+        const { library } = useLibraryStore.getState();
+        const { settings } = useSettingsStore.getState();
+        const groupId = searchParams?.get('group') || undefined;
+        const groupName = groupId
+          ? library.find((b) => b.groupId === groupId)?.groupName
+          : undefined;
+        const book = await ingestFile(
+          { file: download.path, books: library, groupId, groupName },
+          { appService, settings, isLoggedIn: !!user },
+        );
+        if (!book) throw new Error(_('Import produced no book'));
+        await useLibraryStore.getState().updateBooks(envConfig, [book]);
+        await setWebBrowserStatus({ state: 'added', filename, bookHash: book.hash });
+        eventDispatcher.dispatch('toast', {
+          type: 'success',
+          message: _('Saved “{{title}}” to your library.', { title: book.title || filename }),
+          timeout: 3000,
+        });
+      } catch (err) {
+        await setWebBrowserStatus({ state: 'failed', filename });
+        eventDispatcher.dispatch('toast', {
+          type: 'error',
+          message: err instanceof Error ? err.message : _('Import failed'),
+          timeout: 3500,
+        });
+      }
+    },
+    [appService, envConfig, user, searchParams, _],
+  );
+
+  // Register once per appService; dispatch to the latest handler.
+  const handlerRef = useRef(handleDownload);
+  handlerRef.current = handleDownload;
+
+  useEffect(() => {
+    if (!appService) return;
+    let dispose: (() => void) | null = null;
+    let cancelled = false;
+    subscribeWebBrowserDownloads(!!appService.isMobileApp, (download) => {
+      void handlerRef.current(download);
+    }).then((fn) => {
+      if (cancelled) fn();
+      else dispose = fn;
+    });
+    return () => {
+      cancelled = true;
+      dispose?.();
+    };
+  }, [appService]);
+}

--- a/apps/readest-app/src/hooks/useWebBrowserDownloads.ts
+++ b/apps/readest-app/src/hooks/useWebBrowserDownloads.ts
@@ -84,10 +84,16 @@ export function useWebBrowserDownloads() {
     let cancelled = false;
     subscribeWebBrowserDownloads(!!appService.isMobileApp, (download) => {
       void handlerRef.current(download);
-    }).then((fn) => {
-      if (cancelled) fn();
-      else dispose = fn;
-    });
+    })
+      .then((fn) => {
+        if (cancelled) fn();
+        else dispose = fn;
+      })
+      .catch((err) => {
+        // Without the listener, downloads would never reach the library. This is a
+        // rare internal failure; log it and avoid an unhandled promise rejection.
+        console.warn('[browser] failed to subscribe to web browser downloads', err);
+      });
     return () => {
       cancelled = true;
       dispose?.();

--- a/apps/readest-app/src/services/webBrowser/webBrowser.ts
+++ b/apps/readest-app/src/services/webBrowser/webBrowser.ts
@@ -1,0 +1,79 @@
+/**
+ * In-app web browser as a book source (#5775).
+ *
+ * `openWebBrowser` resolves when the user closes the browser. Files the
+ * user downloads inside it arrive as `web-browser-download` events on
+ * every platform (a Tauri window event on desktop, a native-bridge plugin
+ * event on mobile); `useWebBrowserDownloads` imports them and reports the
+ * outcome back to the browser chrome through `setWebBrowserStatus`.
+ */
+
+import { addPluginListener, invoke } from '@tauri-apps/api/core';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { SUPPORTED_BOOK_EXTS } from '@/services/constants';
+import type { WebBrowserOptions } from './webBrowserOptions';
+
+export const WEB_BROWSER_DOWNLOAD_EVENT = 'web-browser-download';
+
+export interface WebBrowserDownload {
+  url: string;
+  path: string;
+  filename: string;
+  success: boolean;
+  error?: string;
+}
+
+export interface WebBrowserStatus {
+  state: 'importing' | 'added' | 'failed' | 'unsupported';
+  filename: string;
+  /** The chrome's [Open] button hands this back through `openWebBrowser`. */
+  bookHash?: string;
+}
+
+export interface WebBrowserResult {
+  openBookHash?: string;
+}
+
+export async function openWebBrowser(
+  url: string,
+  options: WebBrowserOptions,
+): Promise<WebBrowserResult> {
+  const result = await invoke<WebBrowserResult | null>('open_web_browser', { url, options });
+  return result ?? {};
+}
+
+export async function setWebBrowserStatus(status: WebBrowserStatus): Promise<void> {
+  try {
+    await invoke('set_web_browser_status', { status });
+  } catch (err) {
+    // The browser may already be closed; the library toast still reports the outcome.
+    console.warn('[browser] set_web_browser_status failed', err);
+  }
+}
+
+export async function subscribeWebBrowserDownloads(
+  isMobile: boolean,
+  onDownload: (download: WebBrowserDownload) => void,
+): Promise<() => void> {
+  if (isMobile) {
+    const listener = await addPluginListener<WebBrowserDownload>(
+      'native-bridge',
+      WEB_BROWSER_DOWNLOAD_EVENT,
+      onDownload,
+    );
+    return () => {
+      void listener.unregister();
+    };
+  }
+  const unlisten = await getCurrentWindow().listen<WebBrowserDownload>(
+    WEB_BROWSER_DOWNLOAD_EVENT,
+    ({ payload }) => onDownload(payload),
+  );
+  return unlisten;
+}
+
+export function isSupportedBookDownload(filename: string): boolean {
+  const dot = filename.lastIndexOf('.');
+  if (dot < 0) return false;
+  return SUPPORTED_BOOK_EXTS.includes(filename.slice(dot + 1).toLowerCase());
+}

--- a/apps/readest-app/src/services/webBrowser/webBrowserOptions.ts
+++ b/apps/readest-app/src/services/webBrowser/webBrowserOptions.ts
@@ -1,0 +1,64 @@
+/**
+ * Options handed to `open_web_browser` so the native / injected chrome
+ * matches Readest's theme and UI language. Native code has no i18n: every
+ * label it renders comes from here. Each `_()` call is a literal so the
+ * i18next scanner extracts it (same pattern as `send/clipOptions.ts`).
+ */
+
+import { getThemeCode } from '@/utils/style';
+
+type Translate = (key: string) => string;
+
+export type WebBrowserLabelKey =
+  | 'close'
+  | 'back'
+  | 'forward'
+  | 'reload'
+  | 'stop'
+  | 'menu'
+  | 'openInBrowser'
+  | 'copyLink'
+  | 'signOut'
+  | 'notSecure'
+  | 'downloading'
+  | 'importing'
+  | 'added'
+  | 'failed'
+  | 'unsupported'
+  | 'open';
+
+export interface WebBrowserOptions {
+  /** `#rrggbb` — theme base-100. */
+  background: string;
+  /** `#rrggbb` — theme base-content. */
+  foreground: string;
+  isEink: boolean;
+  labels: Record<WebBrowserLabelKey, string>;
+}
+
+export function getWebBrowserOptions(_: Translate, isEink: boolean): WebBrowserOptions {
+  const { bg, fg } = getThemeCode();
+  return {
+    background: bg,
+    foreground: fg,
+    isEink,
+    labels: {
+      close: _('Close'),
+      back: _('Back'),
+      forward: _('Forward'),
+      reload: _('Reload'),
+      stop: _('Stop'),
+      menu: _('More'),
+      openInBrowser: _('Open in Browser'),
+      copyLink: _('Copy Link'),
+      signOut: _('Sign out of this site'),
+      notSecure: _('Not secure'),
+      downloading: _('Downloading'),
+      importing: _('Importing'),
+      added: _('Added to library'),
+      failed: _('Import failed'),
+      unsupported: _('Not a supported book format'),
+      open: _('Open'),
+    },
+  };
+}

--- a/apps/readest-app/src/services/webBrowser/webSources.ts
+++ b/apps/readest-app/src/services/webBrowser/webSources.ts
@@ -1,0 +1,39 @@
+import type { WebSource } from '@/types/webSource';
+
+/** Trim, add `https://` when no scheme is given, and require http(s). */
+export function normalizeWebSourceUrl(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed) && !/^https?:\/\//i.test(trimmed)) return null;
+  const candidate = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    if (!url.hostname) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+export function webSourceNameFromUrl(url: string): string {
+  try {
+    return new URL(url).hostname || url;
+  } catch {
+    return url;
+  }
+}
+
+export function addWebSource(list: WebSource[], name: string, url: string): WebSource[] {
+  const trimmedName = name.trim() || webSourceNameFromUrl(url);
+  const existing = list.find((s) => s.url === url);
+  if (existing) {
+    return list.map((s) => (s.id === existing.id ? { ...s, name: trimmedName } : s));
+  }
+  const id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  return [...list, { id, name: trimmedName, url }];
+}
+
+export function removeWebSource(list: WebSource[], id: string): WebSource[] {
+  return list.filter((s) => s.id !== id);
+}

--- a/apps/readest-app/src/types/settings.ts
+++ b/apps/readest-app/src/types/settings.ts
@@ -3,6 +3,7 @@ import { CustomFont } from '@/styles/fonts';
 import { CustomTexture } from '@/styles/textures';
 import { HighlightColor, HighlightStyle, UserHighlightColor, ViewSettings } from './book';
 import { OPDSCatalog } from './opds';
+import { WebSource } from './webSource';
 import { ABSServer } from './audiobookshelf';
 import type { AISettings } from '@/services/ai/types';
 import type { NotebookTab } from '@/store/notebookStore';
@@ -467,6 +468,8 @@ export interface SystemSettings {
   dictionarySettings: DictionarySettings;
   opdsCatalogs: OPDSCatalog[];
   absServers: ABSServer[];
+  /** Saved sites for the "From Web Browser" import (#5775). Device-local. */
+  webSources?: WebSource[];
   metadataSeriesCollapsed: boolean;
   metadataOthersCollapsed: boolean;
   metadataDescriptionCollapsed: boolean;

--- a/apps/readest-app/src/types/webSource.ts
+++ b/apps/readest-app/src/types/webSource.ts
@@ -1,0 +1,6 @@
+/** A saved website the user browses for books ("From Web Browser"). */
+export interface WebSource {
+  id: string;
+  name: string;
+  url: string;
+}


### PR DESCRIPTION
Closes #5775.

Adds a "From Web Browser" import source: users save book servers (Calibre-Web, Kavita, Audiobookshelf, Project Gutenberg, ...), browse them inside Readest with a persistent login, and any book they download there is imported straight into the library.

## How it works

One JS API (`openWebBrowser` / `subscribeWebBrowserDownloads` / `setWebBrowserStatus`) backed by two platform mechanisms behind the same Tauri commands:

- **Desktop** (macOS/Windows/Linux): a top-level `WebviewWindow` on the remote URL with `on_download` interception. A floating pill (back/forward/reload, import status, close) is injected into every page via `initialization_script`, the same technique as `clip_url.rs`. Cookies are shared with the main window, so logins persist. `target=_blank` / `window.open` are kept in the same window; sentinel navigations drive open/close.
- **Mobile** (iOS/Android): a native controller (`WKWebView` / `WebView`) presented by `tauri-plugin-native-bridge`, generalised from the existing `ClipUrlController`s, with a native top bar, download interception, and a status banner. `wry`'s Android WebView has no `DownloadListener`, so the controller wires `setDownloadListener` and fetches with the page cookies itself.

Downloads are handed to JS as `web-browser-download` events; `useWebBrowserDownloads` runs them through `ingestFile` (same path as OPDS) and reports the outcome back into the browser chrome.

## Testing

- `pnpm test` (all unit tests), `pnpm lint`, `pnpm fmt:check`, `pnpm clippy:check`, `pnpm test:rust`, and `cargo test -p tauri-plugin-native-bridge` all pass.
- macOS release build: add a source, browse, download an EPUB, watch the pill go Downloading -> Importing -> Added to library, and open the imported book. Verified.
- Android (Boox/Xiaomi): full browse -> download -> import flow verified on device.
- iOS: simulator build compiles (Swift is not type-checked by CI).

## Notes

- A long download filename now ellipsizes the pill's status text so the Open and Close controls stay visible.
- Follow-up: failed or cancelled downloads currently leave a partial file in the browser-downloads cache on desktop and iOS (Android already cleans up); worth a small cleanup pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-app web browser for browsing book servers such as Calibre-Web and Kavita.
  * Added saved web sources with URL validation, navigation, sign-out, and external-browser options.
  * Added automatic book downloading and library importing with progress and format feedback.
* **Localization**
  * Added translations for the browsing and import experience across supported languages.
* **Bug Fixes**
  * Improved handling of missing saved-source settings to prevent rendering issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->