### PR TITLE
fix(reader): render the IDPF EPUB 3 samples correctly (#480)

### DIFF
--- a/apps/readest-app/src/__tests__/foliate-fxl-image-spine-viewport.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-fxl-image-spine-viewport.test.ts
@@ -1,0 +1,44 @@
+// A bitmap spine item (EPUB 3 `image/jpeg` etc. directly in the spine, as in
+// the IDPF haruko-jpeg / page-blanche-bitmaps-in-spine samples) is loaded by
+// the browser as its own image document, which carries a synthetic
+// `<meta name="viewport" content="width=device-width, minimum-scale=0.1">`.
+// getViewport must not take that meta as the page size (it yields no numeric
+// width/height, collapsing the page to the 300x150 iframe default) and must
+// fall through to the image's natural size instead (#480).
+import { describe, expect, it } from 'vitest';
+
+import { getViewport } from 'foliate-js/fixed-layout.js';
+
+const imageDocument = (naturalWidth: number, naturalHeight: number) => {
+  const doc = new DOMParser().parseFromString(
+    '<html><head><meta name="viewport" content="width=device-width, minimum-scale=0.1"></head>' +
+      '<body><img src="page.jpg"></body></html>',
+    'text/html',
+  );
+  const img = doc.querySelector('img')!;
+  Object.defineProperty(img, 'naturalWidth', { value: naturalWidth });
+  Object.defineProperty(img, 'naturalHeight', { value: naturalHeight });
+  return doc;
+};
+
+describe('getViewport', () => {
+  it('sizes a bitmap spine item by its natural size, not the image-document viewport meta', () => {
+    expect(getViewport(imageDocument(600, 837), undefined)).toEqual({ width: 600, height: 837 });
+  });
+
+  it('keeps an explicit numeric viewport meta', () => {
+    const doc = new DOMParser().parseFromString(
+      '<html><head><meta name="viewport" content="width=1200, height=1600"></head><body></body></html>',
+      'text/html',
+    );
+    expect(getViewport(doc, undefined)).toMatchObject({ width: '1200', height: '1600' });
+  });
+
+  it('prefers the book viewport over a non-numeric meta when there is no image', () => {
+    const doc = new DOMParser().parseFromString(
+      '<html><head><meta name="viewport" content="width=device-width"></head><body></body></html>',
+      'text/html',
+    );
+    expect(getViewport(doc, { width: 800, height: 1000 })).toEqual({ width: 800, height: 1000 });
+  });
+});

--- a/apps/readest-app/src/__tests__/services/transformers/epub-switch.test.ts
+++ b/apps/readest-app/src/__tests__/services/transformers/epub-switch.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect } from 'vitest';
+import type { ViewSettings } from '@/types/book';
+import type { TransformContext } from '@/services/transformers/types';
+import { epubSwitchTransformer } from '@/services/transformers/epubSwitch';
+
+const OPS = 'http://www.idpf.org/2007/ops';
+const CML = 'http://www.xml-cml.org/schema';
+const MATHML = 'http://www.w3.org/1998/Math/MathML';
+
+const makeCtx = (content: string): TransformContext => ({
+  bookKey: 'test-book',
+  viewSettings: {} as ViewSettings,
+  userLocale: 'en',
+  isFixedLayout: false,
+  content,
+  transformers: [],
+});
+
+const wrap = (body: string) =>
+  '<?xml version="1.0" encoding="UTF-8"?>\n' +
+  `<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="${OPS}"><head><title>t</title></head>` +
+  `<body>${body}</body></html>`;
+
+describe('epubSwitchTransformer', () => {
+  test('renders the default branch when no case namespace is supported (#480)', async () => {
+    // IDPF hefty-water sample: a CML formula with an XHTML fallback.
+    const html = wrap(
+      '<p>Here the switch begins...</p>' +
+        `<epub:switch><epub:case required-namespace="${CML}">` +
+        `<chem xmlns="${CML}"><atom>H</atom></chem></epub:case>` +
+        '<epub:default><p id="fallback">2H<sub>2</sub> + O<sub>2</sub></p></epub:default>' +
+        '</epub:switch><p>... and here the switch ends.</p>',
+    );
+    const result = await epubSwitchTransformer.transform(makeCtx(html));
+    expect(result).toContain('<p id="fallback">2H<sub>2</sub> + O<sub>2</sub></p>');
+    expect(result).not.toContain('<atom');
+    expect(result).not.toContain('<epub:switch');
+    expect(result).not.toContain('<epub:default');
+    expect(result).toContain('Here the switch begins...');
+    expect(result).toContain('... and here the switch ends.');
+  });
+
+  test('renders a MathML case natively and drops the default', async () => {
+    const html = wrap(
+      `<epub:switch><epub:case required-namespace="${MATHML}">` +
+        `<math xmlns="${MATHML}"><mi>x</mi></math></epub:case>` +
+        '<epub:default><p id="fallback">x</p></epub:default></epub:switch>',
+    );
+    const result = await epubSwitchTransformer.transform(makeCtx(html));
+    expect(result).toContain('<mi>x</mi>');
+    expect(result).not.toContain('fallback');
+    expect(result).not.toContain('<epub:case');
+  });
+
+  test('resolves a switch declared with a default namespace instead of a prefix', async () => {
+    const html = wrap(
+      `<switch xmlns="${OPS}"><case required-namespace="${CML}">` +
+        `<chem xmlns="${CML}"><atom>H</atom></chem></case>` +
+        '<default><p xmlns="http://www.w3.org/1999/xhtml" id="fallback">water</p></default></switch>',
+    );
+    const result = await epubSwitchTransformer.transform(makeCtx(html));
+    expect(result).toContain('id="fallback"');
+    expect(result).not.toContain('<atom');
+    expect(result).not.toMatch(/<switch/);
+  });
+
+  test('keeps the XML declaration and doctype of a resolved document', async () => {
+    const html =
+      '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE html>\n' +
+      `<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="${OPS}"><head></head><body>` +
+      '<epub:switch><epub:default><p>d</p></epub:default></epub:switch></body></html>';
+    const result = await epubSwitchTransformer.transform(makeCtx(html));
+    expect(result).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+    expect(result).toContain('<!DOCTYPE html>');
+    expect(result).toContain('<p>d</p>');
+  });
+
+  test('returns content without a switch untouched', async () => {
+    const html = wrap('<p>plain <code>switch</code> statement</p>');
+    const result = await epubSwitchTransformer.transform(makeCtx(html));
+    expect(result).toBe(html);
+  });
+
+  test('returns content that is not well-formed XML untouched', async () => {
+    const html =
+      '<html><body><p>unclosed<br><epub:switch><epub:default>x</epub:default></epub:switch></body></html>';
+    const result = await epubSwitchTransformer.transform(makeCtx(html));
+    expect(result).toBe(html);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/transformers/epub-switch.test.ts
+++ b/apps/readest-app/src/__tests__/services/transformers/epub-switch.test.ts
@@ -64,6 +64,20 @@ describe('epubSwitchTransformer', () => {
     expect(result).not.toMatch(/<switch/);
   });
 
+  test('resolves a switch bound to a hyphenated namespace prefix', async () => {
+    // XML names allow hyphens in prefixes; the fast path must not skip them.
+    const html =
+      '<?xml version="1.0" encoding="UTF-8"?>\n' +
+      `<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub-3="${OPS}"><head><title>t</title></head>` +
+      `<body><epub-3:switch><epub-3:case required-namespace="${CML}">` +
+      `<chem xmlns="${CML}"><atom>H</atom></chem></epub-3:case>` +
+      '<epub-3:default><p id="fallback">water</p></epub-3:default></epub-3:switch></body></html>';
+    const result = await epubSwitchTransformer.transform(makeCtx(html));
+    expect(result).toContain('id="fallback"');
+    expect(result).not.toContain('<atom');
+    expect(result).not.toMatch(/<epub-3:switch/);
+  });
+
   test('keeps the XML declaration and doctype of a resolved document', async () => {
     const html =
       '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE html>\n' +

--- a/apps/readest-app/src/__tests__/styles/fonts.test.ts
+++ b/apps/readest-app/src/__tests__/styles/fonts.test.ts
@@ -323,6 +323,15 @@ describe('mountAdditionalFonts', () => {
     vi.mocked(isCJKEnv).mockReturnValue(false);
   });
 
+  it('skips a document without a <head> such as an SVG spine item (#480)', async () => {
+    const svgDoc = new DOMParser().parseFromString(
+      '<svg xmlns="http://www.w3.org/2000/svg"><text>page</text></svg>',
+      'image/svg+xml',
+    );
+    await expect(mountAdditionalFonts(svgDoc, true)).resolves.toBeUndefined();
+    expect(svgDoc.querySelector('style, link')).toBeNull();
+  });
+
   it('should mount basic Google Fonts link tags', async () => {
     await mountAdditionalFonts(document);
 
@@ -405,6 +414,16 @@ describe('mountCustomFont', () => {
 
   beforeEach(() => {
     document.head.innerHTML = '';
+  });
+
+  it('skips a document without a <head> such as an SVG spine item (#480)', () => {
+    const svgDoc = new DOMParser().parseFromString(
+      '<svg xmlns="http://www.w3.org/2000/svg"><text>page</text></svg>',
+      'image/svg+xml',
+    );
+    expect(svgDoc.head).toBeNull();
+    expect(() => mountCustomFont(svgDoc, baseFont)).not.toThrow();
+    expect(svgDoc.getElementById('custom-font-test-font-id')).toBeNull();
   });
 
   it('should create a style element with the correct id', () => {

--- a/apps/readest-app/src/__tests__/utils/scrollable.test.ts
+++ b/apps/readest-app/src/__tests__/utils/scrollable.test.ts
@@ -122,6 +122,29 @@ describe('applyScrollableStyle', () => {
     expect(math.parentElement?.tagName.toLowerCase()).toBe('p');
   });
 
+  it('does not wrap inline math that is the sole child of an inline span (#480)', () => {
+    // DITA/MathType exports wrap every inline formula as <span><math/></span>. The
+    // span flows with the paragraph text, so the math must keep flowing too: a
+    // block wrapper would break the line and indent the formula.
+    document.body.innerHTML =
+      '<p>Inconsistent Systems, <span class="eqn-inline"><math><mi>r</mi></math></span>' +
+      ' and <span class="eqn-inline"><math><mi>n</mi></math></span></p>';
+    applyScrollableStyle(document);
+    document.querySelectorAll('math').forEach((math) => {
+      expect(math.parentElement?.tagName).toBe('SPAN');
+    });
+    expect(document.querySelectorAll(`.${SCROLL_WRAPPER_CLASS}`)).toHaveLength(0);
+  });
+
+  it('wraps a display equation whose only wrapper is a span filling a block', () => {
+    // <p><span><math/></span></p>: the span chain is the sole content of a block,
+    // so the formula stands on its own line and still needs the scroll wrapper.
+    document.body.innerHTML = '<div><span><math><mi>x</mi></math></span></div>';
+    applyScrollableStyle(document);
+    const math = document.querySelector('math')!;
+    expect(math.parentElement?.classList.contains(SCROLL_WRAPPER_CLASS)).toBe(true);
+  });
+
   it('wraps math[display="block"] even when it has a sibling (e.g. an equation number)', () => {
     document.body.innerHTML = `<div><math display="block"><mi>x</mi></math><span>(1)</span></div>`;
     applyScrollableStyle(document);

--- a/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
+++ b/apps/readest-app/src/__tests__/utils/style-get-styles.test.ts
@@ -64,6 +64,22 @@ function makeThemeCode(overrides: Partial<ThemeCode> = {}): ThemeCode {
 // ---------------------------------------------------------------------------
 // getFontStyles branches
 // ---------------------------------------------------------------------------
+describe('oversized-block rules (via getStyles)', () => {
+  it('does not force pre-wrap white-space onto MathML (#480)', () => {
+    // MathML markup is usually pretty-printed; pre-wrap would turn the newlines
+    // and indentation between <mi>/<mo> tokens into rendered line breaks and
+    // spaces, breaking every inline formula onto its own line.
+    const css = getStyles(makeViewSettings(), makeThemeCode());
+    const preWrapSelectors = [...css.matchAll(/([^{}]+)\{[^}]*white-space:\s*pre-wrap/g)].map((m) =>
+      m[1]!.trim(),
+    );
+    expect(preWrapSelectors.length).toBeGreaterThan(0);
+    for (const selector of preWrapSelectors) {
+      expect(selector).not.toMatch(/\bmath\b/);
+    }
+  });
+});
+
 describe('getFontStyles branches (via getStyles)', () => {
   const theme = makeThemeCode();
 

--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -303,6 +303,7 @@ const FoliateViewer: React.FC<{
               content: data,
               sectionHref: detail.name,
               transformers: [
+                'epubSwitch',
                 'style',
                 'punctuation',
                 'footnote',

--- a/apps/readest-app/src/services/transformers/epubSwitch.ts
+++ b/apps/readest-app/src/services/transformers/epubSwitch.ts
@@ -41,7 +41,7 @@ export const epubSwitchTransformer: Transformer = {
 
   transform: async (ctx) => {
     const { content } = ctx;
-    if (!/<(?:\w+:)?switch[\s>]/.test(content)) return content;
+    if (!/<(?:[^\s<>/:]+:)?switch[\s/>]/.test(content)) return content;
 
     const doc = new DOMParser().parseFromString(content, 'application/xhtml+xml');
     if (doc.querySelector('parsererror')) return content;

--- a/apps/readest-app/src/services/transformers/epubSwitch.ts
+++ b/apps/readest-app/src/services/transformers/epubSwitch.ts
@@ -1,0 +1,55 @@
+import type { Transformer } from './types';
+
+const OPS_NS = 'http://www.idpf.org/2007/ops';
+// Content grammars the browser renders natively. A `case` requiring any other
+// namespace (CML, ...) is skipped in favour of the `default` branch.
+const SUPPORTED_NS = new Set([
+  'http://www.w3.org/1999/xhtml',
+  'http://www.w3.org/2000/svg',
+  'http://www.w3.org/1998/Math/MathML',
+]);
+
+const resolveSwitch = (switchEl: Element) => {
+  const parent = switchEl.parentNode;
+  if (!parent) return;
+  let chosen: Element | null = null;
+  for (const child of switchEl.children) {
+    if (child.namespaceURI !== OPS_NS) continue;
+    const supported =
+      child.localName === 'default' ||
+      (child.localName === 'case' &&
+        SUPPORTED_NS.has(child.getAttribute('required-namespace') ?? ''));
+    if (supported) {
+      chosen = child;
+      break;
+    }
+  }
+  while (chosen?.firstChild) parent.insertBefore(chosen.firstChild, switchEl);
+  switchEl.remove();
+};
+
+/**
+ * Resolves EPUB 3 `epub:switch` conditional content: the first `case` whose
+ * `required-namespace` the browser can render replaces the switch, otherwise
+ * the `default` branch does. Left in place, the sanitizer drops the whole
+ * switch (DOMPurify treats an HTML-namespace `switch` as an SVG-only tag and
+ * removes it together with the fallback, #480), and with scripting allowed the
+ * browser would render every branch at once.
+ */
+export const epubSwitchTransformer: Transformer = {
+  name: 'epubSwitch',
+
+  transform: async (ctx) => {
+    const { content } = ctx;
+    if (!/<(?:\w+:)?switch[\s>]/.test(content)) return content;
+
+    const doc = new DOMParser().parseFromString(content, 'application/xhtml+xml');
+    if (doc.querySelector('parsererror')) return content;
+    const switches = [...doc.getElementsByTagNameNS(OPS_NS, 'switch')];
+    if (!switches.length) return content;
+    switches.forEach(resolveSwitch);
+
+    const prolog = content.match(/^\s*<\?xml[^>]*\?>\s*/)?.[0] ?? '';
+    return prolog + new XMLSerializer().serializeToString(doc);
+  },
+};

--- a/apps/readest-app/src/services/transformers/index.ts
+++ b/apps/readest-app/src/services/transformers/index.ts
@@ -9,8 +9,10 @@ import { styleTransformer } from './style';
 import { proofreadTransformer } from './proofread';
 import { warichuTransformer } from './warichu';
 import { nbspTransformer } from './nbsp';
+import { epubSwitchTransformer } from './epubSwitch';
 
 export const availableTransformers: Transformer[] = [
+  epubSwitchTransformer,
   punctuationTransformer,
   footnoteTransformer,
   languageTransformer,

--- a/apps/readest-app/src/styles/fonts.ts
+++ b/apps/readest-app/src/styles/fonts.ts
@@ -115,6 +115,8 @@ const getAdditionalCJKFontFaces = () => `
 `;
 
 export const mountAdditionalFonts = async (document: Document, isCJK = false) => {
+  // An SVG spine item has no <head> to mount into.
+  if (!document.head) return;
   const mountCJKFonts = isCJK || isCJKEnv();
 
   // Mount font stylesheets and @font-face rules
@@ -278,6 +280,8 @@ export function createCustomFont(
 }
 
 export const mountCustomFont = (document: Document, font: CustomFont) => {
+  // An SVG spine item has no <head> to mount into.
+  if (!document.head) return;
   const fontStyleId = `custom-font-${font.id}`;
   const styleElement = document.getElementById(fontStyleId) || document.createElement('style');
   styleElement.id = fontStyleId;

--- a/apps/readest-app/src/utils/scrollable.ts
+++ b/apps/readest-app/src/utils/scrollable.ts
@@ -131,20 +131,28 @@ export const applyTableTouchScroll = (document: Document) => {
 };
 
 /**
- * A display equation: a <math> that is the sole content of its container (or is
- * explicitly display="block"). Those need a scroll wrapper; an inline <math> sitting
- * among text in a paragraph must be left alone so it keeps flowing with the text.
+ * A display equation: a <math> that is explicitly display="block", or that is the
+ * sole content of its nearest block container, possibly through a chain of inline
+ * wrappers that are themselves sole children (<div><span><math/></span></div>).
+ * Those need a scroll wrapper. An inline <math> sitting among text must be left
+ * alone so it keeps flowing with the text, even when it is the only child of an
+ * inline <span> (how DITA/MathType exports mark every inline formula, #480): a
+ * block wrapper there breaks the line and indents the formula.
  */
-const isDisplayMath = (math: Element): boolean => {
+const isDisplayMath = (math: Element, win: Window | null): boolean => {
   if (math.getAttribute('display') === 'block') return true;
-  const parent = math.parentElement;
-  if (!parent) return false;
-  for (const node of parent.childNodes) {
-    if (node === math) continue;
-    if (node.nodeType === Node.ELEMENT_NODE) return false;
-    if (node.nodeType === Node.TEXT_NODE && node.textContent?.trim()) return false;
+  let el: Element = math;
+  for (;;) {
+    const parent = el.parentElement;
+    if (!parent) return false;
+    for (const node of parent.childNodes) {
+      if (node === el) continue;
+      if (node.nodeType === Node.ELEMENT_NODE) return false;
+      if (node.nodeType === Node.TEXT_NODE && node.textContent?.trim()) return false;
+    }
+    if (!win?.getComputedStyle(parent).display.startsWith('inline')) return true;
+    el = parent;
   }
-  return true;
 };
 
 /**
@@ -174,7 +182,7 @@ export const applyScrollableStyle = (document: Document) => {
   };
   document.querySelectorAll('table').forEach(wrap);
   document.querySelectorAll('math').forEach((math) => {
-    if (isDisplayMath(math)) wrap(math);
+    if (isDisplayMath(math, win)) wrap(math);
   });
 };
 

--- a/apps/readest-app/src/utils/style.ts
+++ b/apps/readest-app/src/utils/style.ts
@@ -436,12 +436,13 @@ const getPageLayoutStyles = (
     display: table !important;
     max-width: 100%;
   }
-  pre, code, math {
+  pre, code {
     white-space: pre-wrap !important;
     scrollbar-width: none;
   }
   math {
     overflow: auto;
+    scrollbar-width: none;
   }
   table, math {
     max-width: calc(var(--available-width) * 1px);


### PR DESCRIPTION
## Summary

Sweep of all 42 IDPF EPUB 3 samples (https://idpf.github.io/epub3-samples/30/samples.html) on Chrome for #480. Four rendering defects found and fixed, each with a failing test first:

- **Inline MathML broke onto its own line** (`linear-algebra`): two rules from the oversized-block scrolling work (#4400) hit every inline formula. `applyScrollableStyle` treated a `<math>` that is the sole child of an inline `<span>` as a display equation and wrapped it in a block scroll container; it now walks sole-child inline wrappers and only wraps when the chain fills a block. And `math` was part of the `pre, code` `white-space: pre-wrap` rule, so the newlines and indentation of pretty-printed MathML rendered as breaks and spaces (and stacked `mtable` cells vertically).
- **`epub:switch` rendered nothing** (`hefty-water`): DOMPurify treats an HTML-namespace `switch` as an SVG-only tag and removes it together with the XHTML `default` fallback. A new `epubSwitch` transformer runs before the sanitizer and resolves the first `case` whose `required-namespace` the browser renders natively (XHTML, SVG, MathML), else the `default` branch.
- **Bitmap spine items collapsed to a 300x150 stub** (`haruko-jpeg`, `page-blanche-bitmaps-in-spine`): foliate's `getViewport` took the browser image document's synthetic `width=device-width` viewport meta at face value. Fixed in readest/foliate-js#84 (merged; the submodule is pinned to its merge commit).
- **SVG spine items threw on every custom font** (`sous-le-vent_svg-in-spine`, `svg-in-spine`): `mountCustomFont`/`mountAdditionalFonts` assumed a `<head>`.

The remaining 36 samples (obfuscated fonts, media overlays, vertical writing, RTL, CFI page lists, multiple renditions, bindings fallbacks, mixed fixed layout, SVG in spine, media queries, canvas) already rendered correctly.

## Calibre side by side

Compared against calibre's viewer on the same pages: `linear-algebra` (Section IVLT), the Arabic RTL sample, Georgia, Waste Land and Voyage of Life lay out the same (calibre uses MathJax fonts, Chromium native MathML). Calibre does not implement `epub:switch` (it shows the CML text and the fallback) and cannot open the bitmap-in-spine, SVG-in-spine or `kusamakura` samples at all, so Readest is now stricter than calibre on those.

## Test plan

- [x] New unit tests: `scrollable.test.ts` (inline span math, span-in-block display math), `style-get-styles.test.ts` (no pre-wrap on math), `epub-switch.test.ts` (6 cases), `fonts.test.ts` (headless documents), `foliate-fxl-image-spine-viewport.test.ts`
- [x] `pnpm test` (825 files, 10126 tests), `pnpm lint`, `pnpm format:check`
- [x] Chrome dev-web: all 42 samples opened; the four fixed books verified on the fixed build

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for EPUB switch content, selecting supported alternatives or the default fallback during reading.
- **Bug Fixes**
  - Improved display and scrolling behavior for inline and block mathematical formulas.
  - Prevented formatting rules from introducing unwanted whitespace in MathML content.
  - Improved handling of SVG-based book content when font elements cannot be mounted.
  - Preserved viewport sizing across image-based and metadata-defined spine documents.
- **Tests**
  - Expanded coverage for EPUB switches, math rendering, fonts, viewport sizing, and style handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
