### PR TITLE
fix(windows): match the main window's scroll bar style in clip and browser windows

### DIFF
--- a/apps/readest-app/src-tauri/src/clip_url.rs
+++ b/apps/readest-app/src-tauri/src/clip_url.rs
@@ -39,6 +39,8 @@ use tauri::AppHandle;
 
 #[cfg(desktop)]
 use std::time::Duration;
+#[cfg(target_os = "windows")]
+use tauri::webview::ScrollBarStyle;
 #[cfg(target_os = "macos")]
 use tauri::TitleBarStyle;
 #[cfg(desktop)]
@@ -642,6 +644,14 @@ pub async fn clip_url(
 
     #[cfg(all(not(target_os = "macos"), desktop))]
     let win_builder = win_builder.decorations(false).shadow(true);
+
+    // WebView2 shares one browser process across every webview in the app
+    // and refuses to create one whose environment options differ from those
+    // already running (HRESULT 0x8007139F, ERROR_INVALID_STATE). Scroll bar
+    // style is such an option, so this has to match the main window (lib.rs)
+    // or the clip window never opens on Windows.
+    #[cfg(target_os = "windows")]
+    let win_builder = win_builder.scroll_bar_style(ScrollBarStyle::FluentOverlay);
 
     let webview_result = win_builder.build();
 

--- a/apps/readest-app/src-tauri/src/web_browser.rs
+++ b/apps/readest-app/src-tauri/src/web_browser.rs
@@ -175,6 +175,8 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc, Mutex,
 };
+#[cfg(target_os = "windows")]
+use tauri::webview::ScrollBarStyle;
 #[cfg(desktop)]
 use tauri::{
     webview::{DownloadEvent, NewWindowResponse},
@@ -325,6 +327,12 @@ pub async fn open_web_browser(
             }
             _ => true,
         });
+
+    // WebView2 refuses a webview whose environment options differ from the
+    // browser process already running (HRESULT 0x8007139F); scroll bar style
+    // is one of them, so match the main window (lib.rs).
+    #[cfg(target_os = "windows")]
+    let builder = builder.scroll_bar_style(ScrollBarStyle::FluentOverlay);
 
     let window = builder.build().map_err(|e| e.to_string())?;
 


### PR DESCRIPTION
## Problem

On Windows, **Import from Web URL** fails for every URL with:

```
Could not create clip webview: runtime error: failed to create webview: WebView2 error:
WindowsError(Error { code: HRESULT(0x8007139F), message: "The group or resource is not in
the correct state to perform the requested operation." })
```

A user hit it importing a Substack post, but the URL is irrelevant: the clip window has never been able to open on Windows since #4241 landed. The in-app browser window added in #5870 (`web_browser.rs`) has the same gap, so **From Web Browser** fails the same way.

## Root cause

`0x8007139F` is `ERROR_INVALID_STATE`. From the WebView2 docs for `CreateCoreWebView2EnvironmentWithOptions`:

> As a browser process may be shared among WebViews, WebView creation fails with `HRESULT_FROM_WIN32(ERROR_INVALID_STATE)` if the specified options does not match the options of the WebViews that are currently running in the shared browser process.

wry passes `ScrollBarStyle` into `ICoreWebView2EnvironmentOptions8`, so it is one of those environment-level options. Tauri's own doc on `scroll_bar_style` says it "must be given the same value for all webviews that target the same data directory." The main window pins `ScrollBarStyle::FluentOverlay` on Windows (`lib.rs`, from #3868), and every JS-created window (`nav.ts`, `updater.ts`) passes `scrollBarStyle: 'fluentOverlay'` on Windows. The two Rust builders in `clip_url.rs` and `web_browser.rs` did not, so WebView2 refused to create them. Same failure class as tauri-apps/tauri#11144.

## Fix

Set `.scroll_bar_style(ScrollBarStyle::FluentOverlay)` under `#[cfg(target_os = "windows")]` on both builders before `.build()`, with a comment explaining the constraint so the next extra window does not repeat this.

## Verification

- `pnpm fmt:check`, `pnpm clippy:check`, `pnpm test:rust` (121 passed), `pnpm test` (825 files passed) on macOS.
- Not reproduced on a Windows machine. `FluentOverlay` is `cfg(windows)`-only in tauri-runtime, so the new lines only compile on Windows, and the PR checks do not build Rust for Windows (only nightly/release do). The call is identical to the one `lib.rs` already compiles there. A Windows run by the reporter is the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Windows scrollbars in the desktop browser and clipped web content to use Fluent overlay styling.
  * Preserved existing scrollbar behavior on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->