### PR TITLE
fix(android): stop the launch crash on covers that decode 1px tall

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/androidTest/java/ReadingWidgetStoreTest.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/androidTest/java/ReadingWidgetStoreTest.kt
@@ -1,49 +1,190 @@
 package com.readest.native_bridge
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
 
 /**
- * Instrumented test (runs on an Android device/emulator).
- *
- * Regression for the widget cover crash: a cover that decodes to exactly 2:3
- * makes the center-crop a no-op, so Bitmap.createBitmap returns the SAME
- * immutable instance as the source. The pre-fix code recycled the source right
- * after, then passed the now-recycled bitmap to createScaledBitmap, throwing
- * "cannot use a recycled source in createBitmap" and killing the app.
+ * Instrumented tests for the reading widget thumbnail writer (run on an
+ * Android device/emulator via connectedAndroidTest).
  */
 @RunWith(AndroidJUnit4::class)
 class ReadingWidgetStoreTest {
+    private val ctx: Context
+        get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    /** Encodes a w x h ARGB bitmap as a PNG in cacheDir and returns the file. */
+    private fun writeCoverPng(w: Int, h: Int, name: String): File {
+        val src = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        val file = File(ctx.cacheDir, name)
+        file.outputStream().use { src.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        src.recycle()
+        return file
+    }
+
+    private fun thumbnailFile(hash: String) = File(ReadingWidgetStore.coversDir(ctx), "$hash.png")
+
+    /** Asserts the thumbnail exists and decodes to the 240x360 widget size. */
+    private fun assertThumbnailWritten(hash: String) {
+        val out = thumbnailFile(hash)
+        assertTrue("thumbnail should be written", out.exists())
+        val decoded = checkNotNull(BitmapFactory.decodeFile(out.absolutePath)) {
+            "thumbnail should decode to a valid bitmap"
+        }
+        assertEquals(240, decoded.width)
+        assertEquals(360, decoded.height)
+    }
+
+    /**
+     * Regression for the widget cover crash: a cover that decodes to exactly 2:3
+     * makes the center-crop a no-op, so Bitmap.createBitmap returns the SAME
+     * immutable instance as the source. The pre-fix code recycled the source right
+     * after, then passed the now-recycled bitmap to createScaledBitmap, throwing
+     * "cannot use a recycled source in createBitmap" and killing the app.
+     */
     @Test
     fun writeThumbnail_exact2to3Cover_doesNotCrash() {
-        val ctx = InstrumentationRegistry.getInstrumentation().targetContext
-
         // 240x360 is exactly 2:3 and small enough to skip downsampling, so the
         // decoded cover hits the createBitmap same-instance path.
-        val src = Bitmap.createBitmap(240, 360, Bitmap.Config.ARGB_8888)
-        val srcFile = File(ctx.cacheDir, "widget-cover-2x3.png")
-        srcFile.outputStream().use { src.compress(Bitmap.CompressFormat.PNG, 100, it) }
-        src.recycle()
-
+        val srcFile = writeCoverPng(240, 360, "widget-cover-2x3.png")
         val hash = "regression2x3"
         try {
             // Pre-fix: throws IllegalArgumentException. Post-fix: writes the PNG.
             ReadingWidgetStore.writeThumbnail(ctx, hash, srcFile.absolutePath, 42)
-
-            val out = File(ReadingWidgetStore.coversDir(ctx), "$hash.png")
-            assertTrue("thumbnail should be written", out.exists())
-            val decoded = BitmapFactory.decodeFile(out.absolutePath)
-            assertNotNull("thumbnail should decode to a valid bitmap", decoded)
-            out.delete()
+            assertThumbnailWritten(hash)
         } finally {
             srcFile.delete()
+            thumbnailFile(hash).delete()
+        }
+    }
+
+    /**
+     * Regression for the launch crash on covers that decode 1px tall, here a
+     * 1x1 placeholder cover as shipped in some EPUBs. The 2:3 center-crop
+     * computed cropW = srcH * 2 / 3 = 0, and Bitmap.createBitmap threw
+     * "width must be > 0" out of the widget coroutine, killing the app on
+     * every launch since the widget snapshot is republished on library load.
+     */
+    @Test
+    fun writeThumbnail_1x1Cover_doesNotCrashAndDropsStaleThumbnail() {
+        val srcFile = writeCoverPng(1, 1, "widget-cover-1x1.png")
+        val hash = "regression1x1"
+        val out = thumbnailFile(hash)
+        // A stale thumbnail from an earlier, valid cover must not survive.
+        out.writeBytes(byteArrayOf(1, 2, 3))
+        try {
+            // Pre-fix: throws IllegalArgumentException("width must be > 0").
+            // Post-fix: returns without writing; a 1px cover is not a cover.
+            ReadingWidgetStore.writeThumbnail(ctx, hash, srcFile.absolutePath, 42)
+            assertFalse("degenerate cover should not leave a thumbnail", out.exists())
+        } finally {
+            srcFile.delete()
+            out.delete()
+        }
+    }
+
+    /**
+     * The same crash reached through the bounds pre-pass: a 2000x4 banner gets
+     * inSampleSize 4 and decodes to 500x1, so the guard has to look at the
+     * decoded size rather than the file's declared size.
+     */
+    @Test
+    fun writeThumbnail_wideBannerDownsampledTo1pxTall_dropsStaleThumbnail() {
+        val srcFile = writeCoverPng(2000, 4, "widget-cover-banner.png")
+        val hash = "regressionbanner"
+        val out = thumbnailFile(hash)
+        out.writeBytes(byteArrayOf(1, 2, 3))
+        try {
+            ReadingWidgetStore.writeThumbnail(ctx, hash, srcFile.absolutePath, 42)
+            assertFalse("1px-tall decode should not leave a thumbnail", out.exists())
+        } finally {
+            srcFile.delete()
+            out.delete()
+        }
+    }
+
+    /** 3x2 is the smallest accepted size: it crops to 1x2 (cropW = 2 * 2 / 3 = 1) and must still scale up. */
+    @Test
+    fun writeThumbnail_smallestAcceptedCover_writesThumbnail() {
+        val srcFile = writeCoverPng(3, 2, "widget-cover-3x2.png")
+        val hash = "boundary3x2"
+        try {
+            ReadingWidgetStore.writeThumbnail(ctx, hash, srcFile.absolutePath, 42)
+            assertThumbnailWritten(hash)
+        } finally {
+            srcFile.delete()
+            thumbnailFile(hash).delete()
+        }
+    }
+
+    /** Taller than 2:3 takes the crop-top-and-bottom branch and still lands at 240x360. */
+    @Test
+    fun writeThumbnail_tallCover_cropsToWidgetSize() {
+        val srcFile = writeCoverPng(300, 900, "widget-cover-tall.png")
+        val hash = "tall300x900"
+        try {
+            ReadingWidgetStore.writeThumbnail(ctx, hash, srcFile.absolutePath, 42)
+            assertThumbnailWritten(hash)
+        } finally {
+            srcFile.delete()
+            thumbnailFile(hash).delete()
+        }
+    }
+
+    /** A cover file that exists but is not an image drops the stale thumbnail, like a missing one. */
+    @Test
+    fun writeThumbnail_undecodableCover_dropsStaleThumbnail() {
+        val srcFile = File(ctx.cacheDir, "widget-cover-not-an-image.png")
+        srcFile.writeText("<html>not an image</html>")
+        val hash = "undecodable"
+        val out = thumbnailFile(hash)
+        out.writeBytes(byteArrayOf(1, 2, 3))
+        try {
+            ReadingWidgetStore.writeThumbnail(ctx, hash, srcFile.absolutePath, 42)
+            assertFalse("undecodable cover should drop the stale thumbnail", out.exists())
+        } finally {
+            srcFile.delete()
+            out.delete()
+        }
+    }
+
+    /** A hash that tries to escape the covers dir is ignored: nothing is written or deleted outside it. */
+    @Test
+    fun writeThumbnail_hashEscapingCoversDir_isIgnored() {
+        val srcFile = writeCoverPng(240, 360, "widget-cover-escape.png")
+        val coversDir = ReadingWidgetStore.coversDir(ctx)
+        val outside = File(coversDir.parentFile, "escaped.png")
+        outside.writeBytes(byteArrayOf(1, 2, 3))
+        try {
+            ReadingWidgetStore.writeThumbnail(ctx, "../escaped", srcFile.absolutePath, 42)
+            assertTrue("file outside the covers dir must be left alone", outside.exists())
+            assertEquals(3, outside.length())
+        } finally {
+            srcFile.delete()
+            outside.delete()
+        }
+    }
+
+    /** A cover file that no longer exists drops the stale thumbnail instead of throwing. */
+    @Test
+    fun writeThumbnail_missingCover_dropsStaleThumbnail() {
+        val hash = "missingcover"
+        val out = thumbnailFile(hash)
+        out.writeBytes(byteArrayOf(1, 2, 3))
+        try {
+            val missing = File(ctx.cacheDir, "widget-cover-does-not-exist.png").absolutePath
+            ReadingWidgetStore.writeThumbnail(ctx, hash, missing, 42)
+            assertFalse("missing cover should drop the stale thumbnail", out.exists())
+        } finally {
+            out.delete()
         }
     }
 }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -1404,7 +1404,15 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
             withContext(Dispatchers.IO) {
                 val books = org.json.JSONArray()
                 for (book in args.books) {
-                    ReadingWidgetStore.writeThumbnail(activity, book.hash, book.coverPath, book.percent)
+                    // A thumbnail failure must never escape pluginScope: an
+                    // uncaught exception here kills the process, and the
+                    // snapshot is republished on every library load, so one
+                    // bad cover would crash the app on every launch.
+                    try {
+                        ReadingWidgetStore.writeThumbnail(activity, book.hash, book.coverPath, book.percent)
+                    } catch (e: Exception) {
+                        Log.w("NativeBridgePlugin", "widget thumbnail failed for ${book.hash}", e)
+                    }
                     books.put(
                         org.json.JSONObject()
                             .put("hash", book.hash)

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/ReadingWidgetStore.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/ReadingWidgetStore.kt
@@ -26,7 +26,11 @@ object ReadingWidgetStore {
         File(context.filesDir, "widget/covers").apply { mkdirs() }
 
     fun writeThumbnail(context: Context, hash: String, sourcePath: String, percent: Int) {
-        val dst = File(coversDir(context), "$hash.png")
+        val dir = coversDir(context)
+        val dst = File(dir, "$hash.png")
+        // The hash comes from library records (cloud sync, backup restore)
+        // and is used as a file name; never let it escape the covers dir.
+        if (dst.canonicalFile.parentFile != dir.canonicalFile) return
         val src = File(sourcePath)
         if (!src.exists()) { dst.delete(); return }
         // Note: skip-if-unchanged removed because the composite depends on the live percent.
@@ -38,11 +42,22 @@ object ReadingWidgetStore {
         var sample = 1
         while (longEdge / sample > THUMB_HEIGHT * 2) sample *= 2
         val opts = BitmapFactory.Options().apply { inSampleSize = sample }
-        val bitmap = BitmapFactory.decodeFile(sourcePath, opts) ?: return
+        val bitmap = BitmapFactory.decodeFile(sourcePath, opts) ?: run { dst.delete(); return }
 
         // Center-crop to 2:3 portrait aspect (width:height = 2:3).
         val srcW = bitmap.width
         val srcH = bitmap.height
+        // A cover that decodes 1px tall (a 1x1 placeholder cover shipped in
+        // some EPUBs, or a wide banner that inSampleSize downsamples to a
+        // single row) makes cropW = srcH * 2 / 3 = 0, and Bitmap.createBitmap
+        // throws "width must be > 0". A 1px-wide cover crops fine but is just
+        // as useless, so reject both: drop any stale thumbnail so the widget
+        // falls back to no cover instead.
+        if (srcW < 2 || srcH < 2) {
+            bitmap.recycle()
+            dst.delete()
+            return
+        }
         val cropW: Int
         val cropH: Int
         if (srcW * 3 > srcH * 2) {
@@ -138,7 +153,8 @@ object ReadingWidgetStore {
     }
 
     private fun notifyWidgets(context: Context) {
-        val mgr = AppWidgetManager.getInstance(context)
+        // Null on builds without app widget support (TV, automotive).
+        val mgr = AppWidgetManager.getInstance(context) ?: return
         val cls = ReadingWidgetProvider::class.java
         val ids = mgr.getAppWidgetIds(ComponentName(context, cls))
         if (ids.isNotEmpty()) {


### PR DESCRIPTION
## Summary

Readest 0.12.1 on Android dies at every launch with `java.lang.IllegalArgumentException: width must be > 0` at `Bitmap.createBitmap` (reported on a Lenovo Tab P11 Pro Gen 2, Android 14, and the reporter's phone; widgets not in use).

**Root cause.** `ReadingWidgetStore.writeThumbnail` center-crops covers to 2:3 with `cropW = srcH * 2 / 3`. A cover that decodes 1px tall (a 1x1 placeholder cover shipped in some EPUBs, or a wide banner that `inSampleSize` downsamples to a single row) makes `cropW = 0`, and the crop overload of `createBitmap` throws. The call runs inside `pluginScope.launch` (`Dispatchers.Main`, no `CoroutineExceptionHandler`), so the exception is fatal. `useReadingWidget` republishes the snapshot on every library load and `writeThumbnail` runs whether or not a widget is placed, so one such "currently reading" book means a crash on every launch. Present since the widget shipped in 0.11.20; iOS is unaffected (its writer only scales, no crop).

**Fix** (`ReadingWidgetStore.kt`, `NativeBridgePlugin.kt`):
- Treat a decode under 2px on either edge as no cover: recycle, drop any stale thumbnail, return.
- Catch per-book thumbnail failures in `update_reading_widget` (`Log.w`) so a bad cover can never take the process down again; the snapshot is still written.
- Three neighbouring holes surfaced by the pre-landing review, all one-liners in the same function: an undecodable cover now drops its stale thumbnail like a missing one already did; the `hash` used as the thumbnail file name (it arrives from sync/backup records unvalidated) can no longer escape the covers directory; `notifyWidgets` tolerates the null `AppWidgetManager` of builds without widget support.

Since a placed widget is not required for the crash, the workaround for affected users until this ships is to mark the offending book (one of the three most recently updated "reading" books, with a blank or tiny cover) as Finished/Unread from another device.

## Test Coverage

Kotlin here is covered by instrumented tests (`src/androidTest`, `gradle connectedAndroidTest`); vitest cannot reach it. `ReadingWidgetStoreTest.kt` grows from 1 to 8 tests, each seeding a stale thumbnail where relevant:

- `writeThumbnail_1x1Cover_doesNotCrashAndDropsStaleThumbnail` (the report): fails before the fix with the exact exception, passes after
- `writeThumbnail_wideBannerDownsampledTo1pxTall_dropsStaleThumbnail` (2000x4 -> inSampleSize 4 -> 500x1, the second trigger)
- `writeThumbnail_smallestAcceptedCover_writesThumbnail` (3x2, `cropW = 1`, still 240x360 out)
- `writeThumbnail_tallCover_cropsToWidgetSize` (300x900, crop top/bottom branch)
- `writeThumbnail_missingCover_dropsStaleThumbnail`
- `writeThumbnail_undecodableCover_dropsStaleThumbnail`
- `writeThumbnail_hashEscapingCoversDir_isIgnored`
- `writeThumbnail_exact2to3Cover_doesNotCrash` (pre-existing, now also asserts 240x360)

AI-assessed coverage of the two touched functions: 31% before the added tests (5/16 paths, most gaps being pre-existing untested branches), 10/16 after. Still uncovered: the `catch` branch in `update_reading_widget` and the snapshot-after-failure flow, which need a hand-built `Invoke` harness, and the pre-existing crop-sides branch beyond the 3x2 boundary case. Tests: 1 -> 8 in this file.

## Pre-Landing Review

Checklist pass (SQL, race, LLM boundary, shell, enum): no issues. Specialists (testing, maintainability): 7 informational findings, 6 addressed (comment accuracy, KDoc placement, shared fixture helper, banner + boundary tests, stale thumbnail on undecodable cover), 1 deferred (no CI job runs `connectedAndroidTest`; see follow-ups).

## Adversarial Review

Claude adversarial + Codex adversarial, plus Codex structured review (diff > 200 lines). High confidence (found by both models): unvalidated `hash` path traversal on the thumbnail file (fixed here + tested), undecodable cover keeps a stale thumbnail (fixed), concurrent `update_reading_widget` invocations write the same PNG non-atomically and can publish snapshots out of order (pre-existing, follow-up). Unique to Claude: null `AppWidgetManager` NPE on builds without widgets (fixed), `catch (Exception)` does not cover `OutOfMemoryError` (left as is: decode is capped at 720px by `inSampleSize`), no `try/finally` recycling on exception paths, threshold semantics (comment reworded to say it is a crash guard). Unique to Codex: no native cap on `books` (JS caps at 3), thumbnails never pruned for books that leave the top 3. Codex structured review (P1 gate): PASS, no findings.

Follow-ups worth their own PRs (all pre-existing): atomic temp-file write + serialized updates for the widget snapshot; `CoroutineExceptionHandler` on `pluginScope` so no `pluginScope.launch` site can kill the process; pruning `widget/covers`; skipping thumbnail work entirely when no widget is placed; running the plugin's instrumented tests in the `android-e2e` workflow.

## Design Review

No frontend files changed; design review skipped.

## Plan Completion

No plan file detected.

## TODOS

No TODO items completed in this PR (26 open items in TODOS.md, none related).

## Verification

- Reproduced on a Xiaomi 13 against the installed 0.12.1 build by invoking `plugin:native-bridge|update_reading_widget` over CDP with `coverPath` pointing at a 1x1 PNG: identical crash, identical frame line numbers (185/8/113) to the report.
- Fixed APK (md5-matched to the build) on the same Xiaomi: the 1x1 invoke resolves and the process stays alive, a normal 240x360 cover still resolves, 0 `FATAL EXCEPTION` in logcat, and the app relaunches cleanly with the real library.
- Instrumented suite: 8/8 on an Android 15 arm64 emulator (Xiaomi went to sleep behind its PIN mid-run; the earlier 2-test version was run there: 1 failing pre-fix, 2/2 post-fix).
- Final-code APK (md5-matched) on the Android 15 emulator via the same CDP invoke: 1x1 cover resolves with the process alive, a normal cover resolves, a hash of `../escaped` is ignored, 0 `FATAL EXCEPTION` in logcat.

## Test plan
- [x] `pnpm test` 825 files / 10127 tests pass (post-rebase)
- [x] `pnpm lint` and `pnpm format:check` clean
- [x] `pnpm fmt:check`, `pnpm clippy:check`, `pnpm test:rust` (121 passed) clean
- [x] `./gradlew :tauri-plugin-native-bridge:connectedFossDebugAndroidTest` 8/8
- [ ] Reporter confirms 0.12.2 launches on the Lenovo Tab P11 Pro Gen 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reading widget reliability when updating book covers.
  - Prevented invalid, missing, or unreadable cover images from leaving stale thumbnails.
  - Added safeguards for unusually sized images and invalid thumbnail paths.
  - Ensured one problematic book cover does not prevent other widget updates.
  - Improved behavior when widget support is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->