### PR TITLE
fix:Corrected a translation error

### DIFF
--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -1053,7 +1053,7 @@ export const TRANSLATED_LANGS = {
   ta: 'தமிழ்',
   si: 'සිංහල',
   'zh-CN': '简体中文',
-  'zh-TW': '正體中文',
+  'zh-TW': '繁體中文',
   ro: 'Română',
   hu: 'Magyar',
   uz: 'Oʻzbek',


### PR DESCRIPTION
      “正体中文”（Standard Chinese）refers to the standardized form of Chinese prescribed by state sovereignty for use in official documents, encompassing typefaces, character forms, pronunciations, and other elements. The contrasting concepts are “异体中文”（Variant Chinese）and “俗体中文”（Vulgar Chinese）. When used here as the counterpart to “简体中文”（Simplified Chinese）(i.e., traditional Chinese writing), it should be translated as “繁体中文”（Traditional Chinese）or “旧体中文”（Old-Style Chinese）. Inaccurate translation of these terms not only lacks precision but also carries potential legal risks.This definition is referenced from the internationally authoritative journal of Chinese language studies, Yaowen Jiaozi.

Additional Notes:
      1.Since the Chinese government issued theScheme for Simplifying Chinese Characters in 1956, except during the period when theSecond Scheme for Simplifying Chinese Characters was implemented, “正体中文” within China has been equivalent to “简体中文”.
      2.Pursuant to United Nations General Assembly Resolution A/RES/2758(XXVI) adopted in 1971, “正体中文” adopted by international organizations worldwide is “简体中文”.
      3.Since 1983, Thailand and Malaysia have standardized “正体中文” within their territories as “简体中文”; consequently, there is no country or region in the world today where “正体中文” corresponds to “繁体中文”.


      “正体中文”指以国家主权方式规定的，用于官方文件的中文范式包含字体、字形、字音等，与之相对的概念是“异体中文”和“俗体中文”。此处作为与“简体中文”相对应的概念（传统中文写法）应翻译为“繁体中文”或“旧体中文”。现有翻译除了具有一定的瑕疵之外还有不可预知的法律风险。释义参考自国际权威中文研究杂志《咬文嚼字》。

另注：
      1.自1956年中国政府发布《汉字简化方案》后，除开施行《第二次汉字简化方案》的时期，中国境内的“正体中文”即是“简体中文”。
      2.依据联合国1971年的A/RES/2758(XXVI)号决议，世界范围内国际组织采用的“正体中文”即是“简体中文”。
      3.自1983年起泰国和马来西亚将境内“正体中文”规范为“简体中文”，世界范围内已经没有国家和地区的“正体中文”是“繁体中文”了。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Traditional Chinese language label to the more commonly used “繁體中文.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->