### PR TITLE
fix(library): save the new data location when migrating an empty library

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/migrate-data-window.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/migrate-data-window.test.tsx
@@ -19,23 +19,14 @@ const appService = {
   distChannel: 'github',
   resolveFilePath: vi.fn(async () => '/current/data/dir'),
   readDirectory: vi.fn(async () => []),
-  selectDirectory: vi.fn(async () => '/new/data/dir'),
-  createDir: vi.fn(async () => {}),
-  copyFile: vi.fn(async () => {}),
-  deleteDir: vi.fn(async () => {}),
-  setCustomRootDir: vi.fn(async () => {}),
 };
-
-const settings: Record<string, unknown> = {};
-const setSettings = vi.fn();
-const saveSettings = vi.fn(async () => {});
 
 vi.mock('@/context/EnvContext', () => ({
   useEnv: () => ({ appService, envConfig: {} }),
 }));
 
 vi.mock('@/store/settingsStore', () => ({
-  useSettingsStore: () => ({ settings, setSettings, saveSettings }),
+  useSettingsStore: () => ({ settings: {}, setSettings: vi.fn(), saveSettings: vi.fn() }),
 }));
 
 vi.mock('@tauri-apps/api/path', () => ({
@@ -89,37 +80,5 @@ describe('MigrateDataWindow e-ink button hierarchy', () => {
     // indistinguishable (see issue #4396). It must be a borderless ghost instead.
     expect(cancelButton.className).not.toContain('btn-outline');
     expect(cancelButton.className).toContain('btn-ghost');
-  });
-});
-
-describe('MigrateDataWindow with an empty library', () => {
-  it('still saves the new data location when there are no files to copy (#5876)', async () => {
-    // Empty library: the current data directory has no files to migrate.
-    appService.readDirectory.mockResolvedValue([]);
-
-    render(<MigrateDataWindow />);
-
-    await act(async () => {
-      setMigrateDataDirDialogVisible(true);
-    });
-
-    await screen.findByText('/current/data/dir');
-
-    const chooseFolderButton = screen.getByRole('button', { name: 'Choose New Folder' });
-    await act(async () => {
-      chooseFolderButton.click();
-    });
-
-    const startButton = await screen.findByRole('button', { name: 'Start Migration' });
-    expect(startButton.hasAttribute('disabled')).toBe(false);
-
-    await act(async () => {
-      startButton.click();
-    });
-
-    // Even with zero files to copy, the new location must still be persisted.
-    expect(appService.setCustomRootDir).toHaveBeenCalledWith('/new/data/dir');
-    expect(saveSettings).toHaveBeenCalled();
-    expect(await screen.findByText('Migration completed successfully!')).toBeTruthy();
   });
 });

--- a/apps/readest-app/src/__tests__/app/library/migrate-data-window.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/migrate-data-window.test.tsx
@@ -19,14 +19,23 @@ const appService = {
   distChannel: 'github',
   resolveFilePath: vi.fn(async () => '/current/data/dir'),
   readDirectory: vi.fn(async () => []),
+  selectDirectory: vi.fn(async () => '/new/data/dir'),
+  createDir: vi.fn(async () => {}),
+  copyFile: vi.fn(async () => {}),
+  deleteDir: vi.fn(async () => {}),
+  setCustomRootDir: vi.fn(async () => {}),
 };
+
+const settings: Record<string, unknown> = {};
+const setSettings = vi.fn();
+const saveSettings = vi.fn(async () => {});
 
 vi.mock('@/context/EnvContext', () => ({
   useEnv: () => ({ appService, envConfig: {} }),
 }));
 
 vi.mock('@/store/settingsStore', () => ({
-  useSettingsStore: () => ({ settings: {}, setSettings: vi.fn(), saveSettings: vi.fn() }),
+  useSettingsStore: () => ({ settings, setSettings, saveSettings }),
 }));
 
 vi.mock('@tauri-apps/api/path', () => ({
@@ -80,5 +89,37 @@ describe('MigrateDataWindow e-ink button hierarchy', () => {
     // indistinguishable (see issue #4396). It must be a borderless ghost instead.
     expect(cancelButton.className).not.toContain('btn-outline');
     expect(cancelButton.className).toContain('btn-ghost');
+  });
+});
+
+describe('MigrateDataWindow with an empty library', () => {
+  it('still saves the new data location when there are no files to copy (#5876)', async () => {
+    // Empty library: the current data directory has no files to migrate.
+    appService.readDirectory.mockResolvedValue([]);
+
+    render(<MigrateDataWindow />);
+
+    await act(async () => {
+      setMigrateDataDirDialogVisible(true);
+    });
+
+    await screen.findByText('/current/data/dir');
+
+    const chooseFolderButton = screen.getByRole('button', { name: 'Choose New Folder' });
+    await act(async () => {
+      chooseFolderButton.click();
+    });
+
+    const startButton = await screen.findByRole('button', { name: 'Start Migration' });
+    expect(startButton.hasAttribute('disabled')).toBe(false);
+
+    await act(async () => {
+      startButton.click();
+    });
+
+    // Even with zero files to copy, the new location must still be persisted.
+    expect(appService.setCustomRootDir).toHaveBeenCalledWith('/new/data/dir');
+    expect(saveSettings).toHaveBeenCalled();
+    expect(await screen.findByText('Migration completed successfully!')).toBeTruthy();
   });
 });

--- a/apps/readest-app/src/app/library/components/MigrateDataWindow.tsx
+++ b/apps/readest-app/src/app/library/components/MigrateDataWindow.tsx
@@ -58,6 +58,7 @@ export const MigrateDataWindow = () => {
   const [filesToMigrate, setFilesToMigrate] = useState<FileItem[]>([]);
   const [currentDirFileCount, setCurrentDirFileCount] = useState('');
   const [currentDirFileSize, setCurrentDirFileSize] = useState(0);
+  const [dirScanned, setDirScanned] = useState(false);
   const [androidNewDirs, setAndroidNewDirs] = useState<{ path: string; label: string }[]>([]);
 
   useEffect(() => {
@@ -86,12 +87,14 @@ export const MigrateDataWindow = () => {
     try {
       if (!appService) return;
 
+      setDirScanned(false);
       const dataDir = await appService.resolveFilePath('', 'Data');
       setCurrentDataDir(dataDir);
       const files = await appService.readDirectory(dataDir, 'None');
       setFilesToMigrate(files);
       setCurrentDirFileCount(files.length.toLocaleString());
       setCurrentDirFileSize(files.reduce((acc, file) => acc + file.size, 0));
+      setDirScanned(true);
     } catch (error) {
       console.error('Error loading current data directory:', error);
     }
@@ -185,10 +188,13 @@ export const MigrateDataWindow = () => {
   };
 
   const handleStartMigration = async () => {
-    // Note: an empty library means `filesToMigrate` is legitimately empty (#5876) -
-    // the copy/verify loops below simply no-op in that case, but the new location
-    // must still be persisted, so file count is not part of this guard.
-    if (!appService || !currentDataDir || !newDataDir) return;
+    // An empty library leaves `filesToMigrate` legitimately empty (#5876): the
+    // copy/verify loops below no-op, but the new location must still be
+    // persisted, so the file count is not part of this guard. `dirScanned`
+    // keeps that apart from a failed scan, where the list is empty because
+    // `readDirectory` rejected and the delete below would wipe the old
+    // directory without having copied anything.
+    if (!appService || !currentDataDir || !newDataDir || !dirScanned) return;
 
     setMigrationStatus('migrating');
     setErrorMessage('');
@@ -273,7 +279,7 @@ export const MigrateDataWindow = () => {
       : 0;
 
   const canStartMigration =
-    newDataDir && newDataDir !== currentDataDir && migrationStatus === 'idle';
+    newDataDir && newDataDir !== currentDataDir && migrationStatus === 'idle' && dirScanned;
 
   const osPlatform = getOSPlatform();
   const fileRevealLabel =

--- a/apps/readest-app/src/app/library/components/MigrateDataWindow.tsx
+++ b/apps/readest-app/src/app/library/components/MigrateDataWindow.tsx
@@ -185,7 +185,10 @@ export const MigrateDataWindow = () => {
   };
 
   const handleStartMigration = async () => {
-    if (!appService || !currentDataDir || !newDataDir || !filesToMigrate.length) return;
+    // Note: an empty library means `filesToMigrate` is legitimately empty (#5876) -
+    // the copy/verify loops below simply no-op in that case, but the new location
+    // must still be persisted, so file count is not part of this guard.
+    if (!appService || !currentDataDir || !newDataDir) return;
 
     setMigrationStatus('migrating');
     setErrorMessage('');


### PR DESCRIPTION
## Summary

Fixes #5876.

When the library is empty (for example right after clearing app data), changing the data location via **Change Data Location → Choose New Folder → Start Migration** created the new folder but never persisted it: the app kept using the old location.

## Root cause

`handleStartMigration()` in `MigrateDataWindow.tsx` early-returned whenever `filesToMigrate.length` was `0`:

```ts
if (!appService || !currentDataDir || !newDataDir || !filesToMigrate.length) return;
```

`filesToMigrate` holds the files found in the *current* data directory. With an empty library that list is legitimately empty, so this guard silently aborted the whole function before it ever reached the settings-persistence step (`appService.setCustomRootDir` + `saveSettings`). Folder creation happens earlier, in `handleSelectNewDir` / `handleSelectedNewDir`, independent of this guard, which is why the folder existed but the location was never saved.

The copy loop and the copy-verification loop are both plain `for` loops over `filesToMigrate`, so they already no-op correctly with zero files. Only the settings-save step needed to run unconditionally.

## Fix

Two parts, because the file-count check turned out to be load-bearing for a second reason.

**1. Drop the file count from the guard**, so migration proceeds and the new location is persisted regardless of how many files there are to copy.

**2. Gate the migration on whether the directory scan actually succeeded.** `loadCurrentDataDir()` swallows a `readDirectory` rejection in its `catch` and leaves `filesToMigrate` empty, and the old file-count check happened to cover that case too. Without it, a failed scan reaches `appService.deleteDir(currentDataDir, 'None', true)` and wipes the current data directory after having copied nothing.

`readDirectory` rejects for real reasons here: revoked storage permission, a path outside the Tauri `fs_scope`, an iOS file-provider path, or a directory that went away. Those are exactly the situations in which someone opens Change Data Location in the first place.

So a new `dirScanned` flag is set only after a successful scan, and now gates both the guard and `canStartMigration`. An empty library still migrates, an unreadable one does not, and in the unreadable case the Start Migration button is disabled rather than dead on click.

## Test plan

- `pnpm test`: 10135 passed, 16 skipped, no regressions.
- `pnpm lint`: clean (tsgo + Biome).
- `pnpm format:check`: clean.
- Traced both code paths (empty library and non-empty library) to confirm the copy and verify loops are unaffected in the non-empty case.

No unit test accompanies this change. `MigrateDataWindow` can only be driven through a fully mocked `appService`, so a test here would pin a call sequence over mocks rather than cover real behavior.

---

Original fix by @jadhavgaurav, prepared with AI assistance (Claude Code) and self-reviewed before submission. The scan-failure guard was added during maintainer review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data migration safety by requiring a completed directory scan before migration controls become available.
  - Prevented failed scans from being treated as empty libraries, avoiding unintended data deletion.
  - Legitimately empty libraries can still be migrated successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
