### PR TITLE
fix(sync): apply pulled file-sync progress to the live reader

### DIFF
--- a/apps/readest-app/src/app/reader/hooks/useFileSync.ts
+++ b/apps/readest-app/src/app/reader/hooks/useFileSync.ts
@@ -55,8 +55,9 @@ import { useWindowActiveChanged } from './useWindowActiveChanged';
  * one result would silently drop whichever mirror lost the race.
  *
  * Energy budget — these constants are deliberately tuned for mobile:
- *   - Push debounce: 15 s. Real reading sessions involve continuous page-turns,
- *     so a longer window collapses many turns into one PUT.
+ *   - Push debounce: 5 s. Long enough to collapse a swipe burst into one PUT,
+ *     short enough that an ordinary page-turn cadence (well over 5 s per page)
+ *     still publishes each position instead of resetting the timer forever.
  *   - Pull cooldown: 60 s. Window focus shouldn't trigger a fresh fetch on every
  *     alt-tab; once a minute is plenty for cross-device drift.
  *   - Open-pull skip: 30 s. Quickly closing/reopening a book shouldn't re-fetch
@@ -69,8 +70,16 @@ import { useWindowActiveChanged } from './useWindowActiveChanged';
  *   - 'prompt': not implemented — falls back to 'silent'
  */
 
-/** Debounce window for auto-push triggered by progress / booknote churn. */
-const PUSH_DEBOUNCE_MS = 15_000;
+/**
+ * Debounce window for auto-push triggered by progress / booknote churn.
+ *
+ * Trailing-only: every page turn restarts the timer, so the window is the
+ * longest a position can sit unpublished during a reading pause. At 15 s a
+ * steady reader kept resetting it and their position reached the other device
+ * minutes late, or not until the book was closed (#5883). 5 s matches KOSync's
+ * push debounce and sits between Readest Cloud's 3 s and the old value.
+ */
+const PUSH_DEBOUNCE_MS = 5_000;
 /** Minimum gap between automatic pulls (e.g. window-focus, open-book). */
 const PULL_COOLDOWN_MS = 60_000;
 /**
@@ -488,15 +497,29 @@ export const useFileSync = (bookKey: string) => {
     }
 
     setConfig(bookKey, working);
-    // Parity with the native cloud sync: surface the same top-right hint when a
-    // remote reading position was fetched and applied. `working` is already
-    // masked per backend, so this is false when every pulling backend opted
-    // out of progress.
+    // Parity with the native cloud sync (and KOSync): a merged remote position
+    // has to move the LIVE view, not just the stored config. Writing the config
+    // alone left the reader on the old page until the book was closed and
+    // reopened, while the hint below already claimed the progress had been
+    // applied (#5883). `working` is masked per backend, so this is skipped when
+    // every pulling backend opted out of progress.
     if (remoteProgressApplied(config.location, working.location)) {
-      eventDispatcher.dispatch('hint', {
-        bookKey,
-        message: _('Reading Progress Synced'),
-      });
+      const view = getView(bookKey);
+      // Don't yank the view while previewing a deep-link target — the user came
+      // here to look at a specific annotation. The merged config is already
+      // stored, so the next open resolves to the synced position normally.
+      const previewing = useReaderStore.getState().getViewState(bookKey)?.previewMode;
+      if (view && !previewing) {
+        // `view.goTo` swallows its own resolution failures, so an unresolvable
+        // remote CFI leaves the reader where it is instead of throwing here.
+        await view.goTo(working.location!);
+        // Announce only once the position is actually on screen, so the hint
+        // never lies about what the user is looking at.
+        eventDispatcher.dispatch('hint', {
+          bookKey,
+          message: _('Reading Progress Synced'),
+        });
+      }
     }
     const latest = getConfig(bookKey);
     if (latest) await saveConfig(envConfig, bookKey, latest, settings);


### PR DESCRIPTION
Fixes #5883

## The bug

Third-party file sync (WebDAV, S3, Google Drive, OneDrive, iCloud) merged a peer's reading position into the stored config and fired the top-right **"Reading Progress Synced"** hint, but never moved the open reader. The position only took effect on the next open, so the hint announced something the user could not see:

> Readest displays a notification indicating that the reading progress has been synchronized, but the reader remains at the old position. If I close the book and open it again, Readest then jumps to the correct synchronized position.

`useFileSync.pullNow()` did `setConfig` + `saveConfig` + dispatch hint, and stopped there. Readest Cloud (`useProgressSync`) and KOSync (`useKOSync`) both call `view.goTo(...)` at exactly this point — the file-sync path was the only one that didn't.

## The fix

`pullNow` now navigates the live view when the merge adopted a remote position:

- `view.goTo(working.location)`, guarded by the same `remoteProgressApplied` condition that already drove the hint, so the two cannot disagree.
- The hint is dispatched **after** the `await`, so it only claims success once the position is actually on screen (the reporter's second expectation).
- Skipped in `previewMode`, matching the deep-link carve-out the other two backends make. The merged config is still stored, so the next open resolves normally.

The jump is unconditional rather than forward-only, unlike the cloud path. The file-sync merge is strict last-writer-wins and already overwrites the stored location in either direction, so a forward-only jump would leave the live view disagreeing with the config on disk whenever a peer legitimately moved backward.

## Push debounce 15s -> 5s

`PUSH_DEBOUNCE_MS` is trailing-only, so every page turn restarts it, as the reporter worked out:

> During continuous reading, every page turn can reset the timer, so progress may remain unsynchronized for considerably longer than 15 seconds.

5s matches the KOSync push debounce and sits between Readest Cloud's 3s (`SYNC_PROGRESS_INTERVAL_SEC`) and the old value. Comments updated, including the "energy budget" block that documented the 15s choice.

## Verification

- `pnpm test` — 10135 passed, 16 skipped, no regressions
- `pnpm lint` (tsgo + biome) and `pnpm format:check` clean
- Wrote a throwaway hook-level reproduction (mocked engine returning a newer remote location) and confirmed it **fails on the pre-fix code** — `goTo` never called — and passes after, including the preview-mode and no-op-merge cases. Not committed.

## Not in scope

From the issue's follow-up comment, left as feature work rather than this bug: syncing progress separately from bulk book/annotation data, and a visible syncing / last-synced / failed indicator. Waiting on a pending upload at close or background is already handled — `useWindowActiveChanged` flushes on blur and the hook flushes on unmount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reader view now automatically navigates to the latest synchronized reading position after syncing.
  - Sync notifications appear after navigation completes for a smoother experience.

- **Bug Fixes**
  - Avoids disrupting users previewing deep-link targets during synchronization.
  - File-sync updates are now pushed after a shorter delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->