### PR TITLE
fix(reader): do not truncate footnote popups

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/components/FootnotePopupSizing.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/FootnotePopupSizing.test.tsx
@@ -11,6 +11,14 @@ const PARAGRAPH_HEIGHT = 152;
 const h = vi.hoisted(() => ({
   viewSettings: { vertical: false, scrolled: false },
   dispatchFootnote: (() => {}) as (detail: unknown) => void,
+  handlerListeners: new Map<string, ((e: Event) => void)[]>(),
+  resizeObservers: [] as ((entries: unknown[]) => void)[],
+  frames: [] as ((() => void) | null)[],
+  emitHandler: (name: string, detail: unknown) => {
+    for (const cb of h.handlerListeners.get(name) ?? []) {
+      cb(new CustomEvent(name, { detail }));
+    }
+  },
 }));
 
 vi.mock('@/context/EnvContext', () => ({ useEnv: () => ({ appService: { isMobile: true } }) }));
@@ -35,10 +43,27 @@ vi.mock('@/store/customFontStore', () => ({
 }));
 vi.mock('../hooks/useFoliateEvents', () => ({ useFoliateEvents: () => {} }));
 vi.mock('@/app/reader/hooks/useFoliateEvents', () => ({ useFoliateEvents: () => {} }));
+// The popup's stylesheet is beside the point here; these tests are about the box.
+vi.mock('@/utils/style', () => ({
+  getStyles: () => '',
+  getFootnoteStyles: () => '',
+  getThemeCode: () => ({ bg: '#fff', fg: '#000' }),
+}));
+vi.mock('@/styles/fonts', () => ({
+  mountAdditionalFonts: () => {},
+  mountCustomFont: () => {},
+}));
 vi.mock('foliate-js/footnotes.js', () => ({
   FootnoteHandler: class {
-    addEventListener() {}
-    removeEventListener() {}
+    addEventListener(name: string, cb: (e: Event) => void) {
+      h.handlerListeners.set(name, [...(h.handlerListeners.get(name) ?? []), cb]);
+    }
+    removeEventListener(name: string, cb: (e: Event) => void) {
+      h.handlerListeners.set(
+        name,
+        (h.handlerListeners.get(name) ?? []).filter((l) => l !== cb),
+      );
+    }
     handle() {
       return undefined;
     }
@@ -58,17 +83,45 @@ import FootnotePopup from '@/app/reader/components/FootnotePopup';
 import { BookDoc } from '@/libs/document';
 
 const footnoteBox = () => document.querySelector<HTMLElement>('.footnote-content');
+const popupContainer = () => document.querySelector<HTMLElement>('#popup-container');
+
+// Just enough of a foliate view for the popup's before-render/render wiring.
+const makePopupView = (viewSize = 240) => {
+  const view = document.createElement('div');
+  Object.assign(view, {
+    renderer: { setAttribute: () => {}, setStyles: () => {}, viewSize },
+    getCFI: () => '',
+    close: () => {},
+  });
+  return view as HTMLDivElement & { renderer: { viewSize: number } };
+};
+
+const flushFrames = () => {
+  const pending = h.frames.slice();
+  h.frames.length = 0;
+  pending.forEach((cb) => cb?.());
+};
 
 beforeEach(() => {
+  h.handlerListeners.clear();
+  h.resizeObservers.length = 0;
+  h.frames.length = 0;
   // jsdom has no ResizeObserver, and Popup keeps one on its container.
   vi.stubGlobal(
     'ResizeObserver',
     class {
+      constructor(cb: (entries: unknown[]) => void) {
+        h.resizeObservers.push(cb);
+      }
       observe() {}
       unobserve() {}
       disconnect() {}
     },
   );
+  vi.stubGlobal('requestAnimationFrame', (cb: () => void) => h.frames.push(cb));
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+    h.frames[id - 1] = null;
+  });
   const cell = document.createElement('div');
   cell.id = 'gridcell-book-1';
   cell.getBoundingClientRect = () =>
@@ -101,5 +154,32 @@ describe('footnote popup built from a data/alt attribute', () => {
     });
 
     expect(footnoteBox()?.style.height).toBe(`${PARAGRAPH_HEIGHT}px`);
+  });
+});
+
+// A footnote whose visible content is elements only — an image, a bare figure —
+// makes foliate's visible range collapse, so the paginator never dispatches
+// `relocate`. Gating the popup's visibility on that event alone left such a
+// popup loaded, sized, and parked off-screen forever (#5887).
+describe('footnote popup whose section never emits relocate', () => {
+  test('shows once the content has been measured', () => {
+    render(<FootnotePopup bookKey='book-1' bookDoc={{} as BookDoc} />);
+
+    const popupView = makePopupView();
+    act(() => {
+      h.emitHandler('before-render', { view: popupView });
+      h.emitHandler('render', { view: popupView, href: 'notes.xhtml#n1', index: 1, extract: null });
+    });
+    expect(popupContainer()?.getAttribute('aria-hidden')).toBe('true');
+
+    act(() => {
+      popupView.dispatchEvent(new CustomEvent('load', { detail: { doc: document, index: 1 } }));
+      // The content observer reports the first measurement; no `relocate` ever
+      // arrives, exactly as for an image-only footnote.
+      h.resizeObservers.forEach((cb) => cb([]));
+      flushFrames();
+    });
+
+    expect(popupContainer()?.getAttribute('aria-hidden')).toBe('false');
   });
 });

--- a/apps/readest-app/src/__tests__/app/reader/components/FootnotePopupSizing.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/FootnotePopupSizing.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+
+// A popup built from a data/alt attribute measures its text synchronously and
+// sizes the box to the result. It used to be pinned at the seed height on every
+// open, because the size effect keyed on the trigger position ran after the
+// commit and threw that measurement away.
+
+const PARAGRAPH_HEIGHT = 152;
+
+const h = vi.hoisted(() => ({
+  viewSettings: { vertical: false, scrolled: false },
+  dispatchFootnote: (() => {}) as (detail: unknown) => void,
+}));
+
+vi.mock('@/context/EnvContext', () => ({ useEnv: () => ({ appService: { isMobile: true } }) }));
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({ getView: () => null, getViewSettings: () => h.viewSettings }),
+}));
+vi.mock('@/store/bookDataStore', () => {
+  const store = (selector?: (s: unknown) => unknown) =>
+    selector ? selector({ booksData: {} }) : { getBookData: () => ({ book: {} }) };
+  store.getState = () => ({ booksData: {} });
+  return { useBookDataStore: store };
+});
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: { getState: () => ({ settings: {} }) },
+}));
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: { getState: () => ({ isDarkMode: false }) },
+  getThemeCode: () => ({}),
+}));
+vi.mock('@/store/customFontStore', () => ({
+  useCustomFontStore: () => ({ getLoadedFonts: () => [] }),
+}));
+vi.mock('../hooks/useFoliateEvents', () => ({ useFoliateEvents: () => {} }));
+vi.mock('@/app/reader/hooks/useFoliateEvents', () => ({ useFoliateEvents: () => {} }));
+vi.mock('foliate-js/footnotes.js', () => ({
+  FootnoteHandler: class {
+    addEventListener() {}
+    removeEventListener() {}
+    handle() {
+      return undefined;
+    }
+  },
+}));
+vi.mock('@/utils/event', () => ({
+  eventDispatcher: {
+    on: (name: string, cb: (e: CustomEvent) => void) => {
+      if (name === 'footnote-popup') h.dispatchFootnote = (detail) => cb({ detail } as CustomEvent);
+    },
+    off: () => {},
+    dispatch: () => {},
+  },
+}));
+
+import FootnotePopup from '@/app/reader/components/FootnotePopup';
+import { BookDoc } from '@/libs/document';
+
+const footnoteBox = () => document.querySelector<HTMLElement>('.footnote-content');
+
+beforeEach(() => {
+  // jsdom has no ResizeObserver, and Popup keeps one on its container.
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  const cell = document.createElement('div');
+  cell.id = 'gridcell-book-1';
+  cell.getBoundingClientRect = () =>
+    ({ left: 0, top: 0, right: 400, bottom: 800, width: 400, height: 800 }) as DOMRect;
+  document.body.appendChild(cell);
+  // jsdom lays nothing out, so the hidden measuring paragraph reports its height
+  // here — everything else keeps the zero rect.
+  vi.spyOn(HTMLParagraphElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: 360,
+    height: PARAGRAPH_HEIGHT,
+  } as DOMRect);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  document.getElementById('gridcell-book-1')?.remove();
+  cleanup();
+});
+
+describe('footnote popup built from a data/alt attribute', () => {
+  test('keeps the height it measured for the text', () => {
+    render(<FootnotePopup bookKey='book-1' bookDoc={{} as BookDoc} />);
+    act(() => {
+      h.dispatchFootnote({
+        bookKey: 'book-1',
+        element: document.createElement('a'),
+        footnote: 'A footnote long enough to wrap over several lines.',
+      });
+    });
+
+    expect(footnoteBox()?.style.height).toBe(`${PARAGRAPH_HEIGHT}px`);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
+++ b/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
@@ -196,7 +196,14 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     stopTrackingPopupContentSize();
     const observer = new ResizeObserver(() => {
       if (contentSizeFrameRef.current) cancelAnimationFrame(contentSizeFrameRef.current);
-      contentSizeFrameRef.current = requestAnimationFrame(() => fitPopupToContent(view));
+      contentSizeFrameRef.current = requestAnimationFrame(() => {
+        // Showing the popup only from `relocate` left one whose visible content
+        // is elements alone — an image, a bare figure — parked off-screen for
+        // good: an element-only visible range collapses, so foliate's paginator
+        // returns before it ever dispatches `relocate`. A measured content size
+        // is the same promise that event was standing in for.
+        if (fitPopupToContent(view) > 0) setShowPopup(true);
+      });
     });
     observer.observe(doc.documentElement);
     contentSizeObserverRef.current = observer;

--- a/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
+++ b/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
@@ -121,6 +121,8 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
   const [responsiveHeight, setResponsiveHeight] = useState(popupHeight);
   const sizeAdjustCountRef = useRef(0);
   const maxSizeAdjustCount = 3;
+  const contentSizeObserverRef = useRef<ResizeObserver | null>(null);
+  const contentSizeFrameRef = useRef<number | null>(null);
   const size18 = useResponsiveSize(18);
   const popupPadding = useResponsiveSize(10);
 
@@ -155,6 +157,58 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
 
   const clipPopupHeight = (size: number) => {
     return Math.min(size, window.innerHeight - popupPadding - 12);
+  };
+
+  // Imperative, not an effect keyed on the trigger position: that effect ran
+  // after the commit and overwrote the size just measured from the content.
+  const seedPopupSize = (isVertical: boolean) => {
+    const size = isVertical
+      ? {
+          width: clipPopupWith(popupHeight),
+          height: clipPopupHeight(Math.max(popupWidth, window.innerHeight / 4)),
+        }
+      : {
+          width: clipPopupWith(Math.max(popupWidth, window.innerWidth / 4)),
+          height: clipPopupHeight(popupHeight),
+        };
+    setResponsiveWidth(size.width);
+    setResponsiveHeight(size.height);
+    return size;
+  };
+
+  const fitPopupToContent = (view: FoliateView) => {
+    const { renderer } = view;
+    if (!renderer) return;
+    if (getViewSettings(bookKey)!.vertical) {
+      setResponsiveWidth(
+        clipPopupWith(Math.min(getResponsivePopupSize(renderer.viewSize, true), getMaxWidth())),
+      );
+    } else {
+      setResponsiveHeight(
+        clipPopupHeight(Math.min(getResponsivePopupSize(renderer.viewSize, false), getMaxHeight())),
+      );
+    }
+  };
+
+  // The document keeps growing after the first `relocate` — the section may
+  // still be parsing, fonts and images arrive later — so measuring once left
+  // the popup cut to whatever it held at that instant.
+  const trackPopupContentSize = (view: FoliateView, doc: Document) => {
+    stopTrackingPopupContentSize();
+    const observer = new ResizeObserver(() => {
+      if (contentSizeFrameRef.current) cancelAnimationFrame(contentSizeFrameRef.current);
+      // Next frame, so the renderer's own observer has expanded the view first.
+      contentSizeFrameRef.current = requestAnimationFrame(() => fitPopupToContent(view));
+    });
+    observer.observe(doc.documentElement);
+    contentSizeObserverRef.current = observer;
+  };
+
+  const stopTrackingPopupContentSize = () => {
+    if (contentSizeFrameRef.current) cancelAnimationFrame(contentSizeFrameRef.current);
+    contentSizeFrameRef.current = null;
+    contentSizeObserverRef.current?.disconnect();
+    contentSizeObserverRef.current = null;
   };
 
   useEffect(() => {
@@ -239,6 +293,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
         if (info && info.index === index) {
           popupMapRef.current = { ...info, doc };
         }
+        trackPopupContentSize(popupView, doc);
         setPopupContentEpoch((epoch) => epoch + 1);
       });
       // Style callback for annotation overlays drawn in the popup document
@@ -320,29 +375,28 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       resetPopupAnnotationState({ index: index ?? -1, extract: extract ?? null });
       sizeAdjustCountRef.current = 0;
       view.addEventListener('relocate', () => {
-        if (sizeAdjustCountRef.current >= maxSizeAdjustCount) return;
-        sizeAdjustCountRef.current += 1;
-        const { renderer } = view as FoliateView;
-        const viewSettings = getViewSettings(bookKey)!;
-        if (viewSettings.vertical) {
-          const responsiveWidth = clipPopupWith(
-            Math.min(getResponsivePopupSize(renderer.viewSize, true), getMaxWidth()),
-          );
-          setResponsiveWidth(responsiveWidth);
-          const scrollRatio = renderer.viewSize / responsiveWidth;
+        // The cross-axis widening below reflows the document, so keep it capped.
+        fitPopupToContent(view as FoliateView);
+        if (sizeAdjustCountRef.current < maxSizeAdjustCount) {
+          sizeAdjustCountRef.current += 1;
+          const { renderer } = view as FoliateView;
+          const viewSettings = getViewSettings(bookKey)!;
+          const readingAxisSize = viewSettings.vertical
+            ? clipPopupWith(
+                Math.min(getResponsivePopupSize(renderer.viewSize, true), getMaxWidth()),
+              )
+            : clipPopupHeight(
+                Math.min(getResponsivePopupSize(renderer.viewSize, false), getMaxHeight()),
+              );
+          const scrollRatio = renderer.viewSize / readingAxisSize;
           if (scrollRatio > 1.5) {
-            setResponsiveHeight(
-              clipPopupHeight(Math.min(popupWidth * scrollRatio, getMaxHeight())),
-            );
-          }
-        } else {
-          const responsiveHeight = clipPopupHeight(
-            Math.min(getResponsivePopupSize(renderer.viewSize, false), getMaxHeight()),
-          );
-          setResponsiveHeight(responsiveHeight);
-          const scrollRatio = renderer.viewSize / responsiveHeight;
-          if (scrollRatio > 1.5) {
-            setResponsiveWidth(clipPopupWith(Math.min(popupWidth * scrollRatio, getMaxWidth())));
+            if (viewSettings.vertical) {
+              setResponsiveHeight(
+                clipPopupHeight(Math.min(popupWidth * scrollRatio, getMaxHeight())),
+              );
+            } else {
+              setResponsiveWidth(clipPopupWith(Math.min(popupWidth * scrollRatio, getMaxWidth())));
+            }
           }
         }
         setShowPopup(true);
@@ -365,15 +419,9 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
   }, [showPopup]);
 
   useEffect(() => {
-    if (viewSettings.vertical) {
-      setResponsiveWidth(clipPopupWith(popupHeight));
-      setResponsiveHeight(clipPopupHeight(Math.max(popupWidth, window.innerHeight / 4)));
-    } else {
-      setResponsiveWidth(clipPopupWith(Math.max(popupWidth, window.innerWidth / 4)));
-      setResponsiveHeight(clipPopupHeight(popupHeight));
-    }
+    seedPopupSize(viewSettings.vertical);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [viewSettings, trianglePosition]);
+  }, [viewSettings]);
 
   useEffect(() => {
     if (trianglePosition && gridRect) {
@@ -396,6 +444,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     const rect = gridFrame.getBoundingClientRect();
     const viewSettings = getViewSettings(bookKey)!;
     const triangPos = getPosition(detail.a, rect, popupPadding, viewSettings.vertical);
+    seedPopupSize(viewSettings.vertical);
     setGridRect(rect);
     setTrianglePosition(triangPos);
     trianglePositionRef.current = triangPos;
@@ -458,6 +507,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
 
   const handleDismissPopup = () => {
     closePopup();
+    stopTrackingPopupContentSize();
     resetPopupAnnotationState();
     historyRef.current = { items: [], index: -1 };
     sizeAdjustCountRef.current = 0;
@@ -481,19 +531,21 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     // document: there is no book document behind it, so no CFI mapping.
     footnoteViewRef.current = null;
     setSourceHref(null);
+    stopTrackingPopupContentSize();
     resetPopupAnnotationState();
     const rect = gridFrame.getBoundingClientRect();
     const viewSettings = getViewSettings(bookKey)!;
     const triangPos = getPosition(element, rect, popupPadding, viewSettings.vertical);
+    const seed = seedPopupSize(viewSettings.vertical);
     if (footnoteRef.current) {
       const elem = document.createElement('p');
       elem.textContent = footnote;
       elem.setAttribute('style', `padding: 1em; hanging-punctuation: allow-end last;`);
       elem.style.visibility = 'hidden';
       if (viewSettings.vertical) {
-        elem.style.height = `${responsiveHeight}px`;
+        elem.style.height = `${seed.height}px`;
       } else {
-        elem.style.width = `${responsiveWidth}px`;
+        elem.style.width = `${seed.width}px`;
       }
       document.body.appendChild(elem);
       const popupSize = elem.getBoundingClientRect();
@@ -523,6 +575,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     return () => {
       window.removeEventListener('resize', handleDismissPopup);
       eventDispatcher.off('footnote-popup', handleFootnotePopupEvent);
+      stopTrackingPopupContentSize();
       if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
+++ b/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
@@ -176,18 +176,17 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     return size;
   };
 
+  // Fits the box along the reading axis and returns the size it applied.
   const fitPopupToContent = (view: FoliateView) => {
     const { renderer } = view;
-    if (!renderer) return;
-    if (getViewSettings(bookKey)!.vertical) {
-      setResponsiveWidth(
-        clipPopupWith(Math.min(getResponsivePopupSize(renderer.viewSize, true), getMaxWidth())),
-      );
-    } else {
-      setResponsiveHeight(
-        clipPopupHeight(Math.min(getResponsivePopupSize(renderer.viewSize, false), getMaxHeight())),
-      );
-    }
+    if (!renderer) return 0;
+    const vertical = getViewSettings(bookKey)!.vertical;
+    const size = vertical
+      ? clipPopupWith(Math.min(getResponsivePopupSize(renderer.viewSize, true), getMaxWidth()))
+      : clipPopupHeight(Math.min(getResponsivePopupSize(renderer.viewSize, false), getMaxHeight()));
+    if (vertical) setResponsiveWidth(size);
+    else setResponsiveHeight(size);
+    return size;
   };
 
   // The document keeps growing after the first `relocate` — the section may
@@ -197,7 +196,6 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     stopTrackingPopupContentSize();
     const observer = new ResizeObserver(() => {
       if (contentSizeFrameRef.current) cancelAnimationFrame(contentSizeFrameRef.current);
-      // Next frame, so the renderer's own observer has expanded the view first.
       contentSizeFrameRef.current = requestAnimationFrame(() => fitPopupToContent(view));
     });
     observer.observe(doc.documentElement);
@@ -375,19 +373,12 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       resetPopupAnnotationState({ index: index ?? -1, extract: extract ?? null });
       sizeAdjustCountRef.current = 0;
       view.addEventListener('relocate', () => {
-        // The cross-axis widening below reflows the document, so keep it capped.
-        fitPopupToContent(view as FoliateView);
-        if (sizeAdjustCountRef.current < maxSizeAdjustCount) {
+        const readingAxisSize = fitPopupToContent(view as FoliateView);
+        // The cross-axis widening reflows the document, so keep it capped.
+        if (readingAxisSize > 0 && sizeAdjustCountRef.current < maxSizeAdjustCount) {
           sizeAdjustCountRef.current += 1;
           const { renderer } = view as FoliateView;
           const viewSettings = getViewSettings(bookKey)!;
-          const readingAxisSize = viewSettings.vertical
-            ? clipPopupWith(
-                Math.min(getResponsivePopupSize(renderer.viewSize, true), getMaxWidth()),
-              )
-            : clipPopupHeight(
-                Math.min(getResponsivePopupSize(renderer.viewSize, false), getMaxHeight()),
-              );
           const scrollRatio = renderer.viewSize / readingAxisSize;
           if (scrollRatio > 1.5) {
             if (viewSettings.vertical) {
@@ -419,9 +410,9 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
   }, [showPopup]);
 
   useEffect(() => {
-    seedPopupSize(viewSettings.vertical);
+    if (!showPopup) seedPopupSize(viewSettings.vertical);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [viewSettings]);
+  }, [viewSettings, showPopup]);
 
   useEffect(() => {
     if (trianglePosition && gridRect) {
@@ -444,6 +435,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     const rect = gridFrame.getBoundingClientRect();
     const viewSettings = getViewSettings(bookKey)!;
     const triangPos = getPosition(detail.a, rect, popupPadding, viewSettings.vertical);
+    stopTrackingPopupContentSize();
     seedPopupSize(viewSettings.vertical);
     setGridRect(rect);
     setTrianglePosition(triangPos);

--- a/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
+++ b/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
@@ -287,6 +287,9 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
           doc.addEventListener('contextmenu', (ev: Event) => ev.preventDefault());
         }
 
+        // Each request builds its own view; a superseded one still loads, and
+        // must not resize or repaint the popup the newer request now owns.
+        if (popupView !== footnoteViewRef.current) return;
         const info = popupMapRef.current;
         if (info && info.index === index) {
           popupMapRef.current = { ...info, doc };


### PR DESCRIPTION
> Disclaimer: the code is fully agent-written. The PR description is fully human-written.

Every now and then, a footnote popup would cut at two or three lines, like this:

<img src="https://raw.githubusercontent.com/alexander-pecheny/readest/pr-assets/footnote-popup-cut.png" width="320" alt="Footnote popup cut to three lines">

This PR fixes it. Verified on my physical iPhone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Jump to Location” action for footnotes with available source locations.
  * Improved popup navigation and localized popup controls.

* **Bug Fixes**
  * Improved mobile footnote popup sizing to match rendered content and adapt to content or orientation changes.
  * Ensured footnote popups appear correctly for image- and figure-based content.
  * Ensured sizing updates stop when the popup is dismissed or replaced.

* **Tests**
  * Added regression coverage for mobile footnote popup dimensions and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->