### PR TITLE
fix(reader): make cross-page selection actually work

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/annotator/PageTurnHint.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/annotator/PageTurnHint.test.tsx
@@ -67,6 +67,21 @@ describe('PageTurnHint', () => {
     expect(foot!.style.transformOrigin).toBe('left');
   });
 
+  test('draws the armed edge solid on e-ink, which cannot run a bar out', () => {
+    document.documentElement.setAttribute('data-eink', 'true');
+    const { container } = render(
+      <PageTurnHint
+        bookKey='book-1'
+        contentInsets={INSETS}
+        hint={{ corner: 'br', turned: false }}
+      />,
+    );
+    const bar = bars(container)[0]!;
+    expect(bar.style.transform).toBe('scaleY(1)');
+    expect(Number(bar.style.opacity)).toBe(1);
+    document.documentElement.removeAttribute('data-eink');
+  });
+
   test('fills over the dwell, then holds once the page has turned', () => {
     const { container, rerender } = render(
       <PageTurnHint

--- a/apps/readest-app/src/__tests__/app/reader/annotator/PageTurnHint.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/annotator/PageTurnHint.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+
+import PageTurnHint from '@/app/reader/components/annotator/PageTurnHint';
+
+const INSETS = { top: 10, right: 20, bottom: 30, left: 40 };
+
+const bars = (container: HTMLElement) =>
+  Array.from((container.firstElementChild as HTMLElement).children) as HTMLElement[];
+
+beforeEach(() => {
+  const cell = document.createElement('div');
+  cell.id = 'gridcell-book-1';
+  const view = document.createElement('foliate-view');
+  view.getBoundingClientRect = () =>
+    ({ left: 0, top: 0, right: 400, bottom: 800, width: 400, height: 800 }) as DOMRect;
+  cell.appendChild(view);
+  document.body.appendChild(cell);
+});
+
+afterEach(() => {
+  document.getElementById('gridcell-book-1')?.remove();
+  cleanup();
+});
+
+describe('PageTurnHint', () => {
+  test('marks nothing while no edge is armed', () => {
+    const { container } = render(
+      <PageTurnHint bookKey='book-1' contentInsets={INSETS} hint={null} />,
+    );
+    expect(container.firstChild).toBe(null);
+  });
+
+  test('draws the trailing edges of the text area, inset by the margins', () => {
+    const { container } = render(
+      <PageTurnHint
+        bookKey='book-1'
+        contentInsets={INSETS}
+        hint={{ corner: 'br', turned: false }}
+      />,
+    );
+    const box = container.firstElementChild as HTMLElement;
+    expect(box.style.left).toBe('40px');
+    expect(box.style.top).toBe('10px');
+    expect(box.style.width).toBe('340px');
+    expect(box.style.height).toBe('760px');
+
+    const [side, foot] = bars(container);
+    expect(side!.className).toContain('right-0');
+    expect(foot!.className).toContain('bottom-0');
+    expect(side!.style.transformOrigin).toBe('bottom');
+    expect(foot!.style.transformOrigin).toBe('right');
+  });
+
+  test('draws the leading edges when the drag is turning back', () => {
+    const { container } = render(
+      <PageTurnHint
+        bookKey='book-1'
+        contentInsets={INSETS}
+        hint={{ corner: 'tl', turned: false }}
+      />,
+    );
+    const [side, foot] = bars(container);
+    expect(side!.className).toContain('left-0');
+    expect(foot!.className).toContain('top-0');
+    expect(side!.style.transformOrigin).toBe('top');
+    expect(foot!.style.transformOrigin).toBe('left');
+  });
+
+  test('fills over the dwell, then holds once the page has turned', () => {
+    const { container, rerender } = render(
+      <PageTurnHint
+        bookKey='book-1'
+        contentInsets={INSETS}
+        hint={{ corner: 'br', turned: false }}
+      />,
+    );
+    const dwelling = bars(container)[0]!;
+    expect(dwelling.style.transitionDuration).toBe('500ms');
+    const dwellOpacity = Number(dwelling.style.opacity);
+
+    rerender(
+      <PageTurnHint
+        bookKey='book-1'
+        contentInsets={INSETS}
+        hint={{ corner: 'br', turned: true }}
+      />,
+    );
+    const turned = bars(container)[0]!;
+    expect(turned.style.transform).toBe('scaleY(1)');
+    expect(Number(turned.style.opacity)).toBeGreaterThan(dwellOpacity);
+  });
+});

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useAutoPageTurn.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useAutoPageTurn.test.ts
@@ -243,11 +243,12 @@ describe('a drag that leaves the text reads as the edge it left by', () => {
     expect(h.view.prev).toHaveBeenCalledTimes(1);
   });
 
-  test('past both edges follows the axis it left furthest by', () => {
+  test('past both edges reads as the trailing one, like the keyboard rule', () => {
     const { result } = setup();
-    // Bottom-left: 40px below the text, 10px to the left of it.
+    // Bottom-left: below the text and to the left of it. turnForFocusBeyondPage
+    // answers 'next' here, and the drag reads the same way.
     expect(result.current.cornerAtPoint({ x: 90, y: 540 }, true)).toBe('br');
-    expect(result.current.cornerAtPoint({ x: 60, y: 510 }, true)).toBe('tl');
+    expect(result.current.cornerAtPoint({ x: 60, y: 510 }, true)).toBe('br');
   });
 
   test('the caret signal keeps the strict test', () => {

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useAutoPageTurn.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useAutoPageTurn.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { cleanup, renderHook } from '@testing-library/react';
+import { act, cleanup, renderHook } from '@testing-library/react';
 
 const DWELL_MS = 500;
 // The mocked reading frame is 1000x1000; the corner zone is capped at 50px, so
@@ -142,11 +142,23 @@ describe('useAutoPageTurn corner-dwell page turn (decoupled from DOM selection)'
 
   test('measures corners against the content-inset reading area', async () => {
     const { result } = setup({ top: 100, right: 100, bottom: 100, left: 100 });
-    result.current.noteAutoTurnPoint({ x: 960, y: 960 });
+    // 130px in from the inset corner (900,900) — mid-text, no turn. Without the
+    // insets the same point would be 130px from the frame corner, also no turn.
+    result.current.noteAutoTurnPoint({ x: 770, y: 770 });
     await advance();
     expect(h.view.next).not.toHaveBeenCalled();
 
     result.current.noteAutoTurnPoint({ x: 870, y: 870 });
+    await advance();
+    expect(h.view.next).toHaveBeenCalledTimes(1);
+  });
+
+  test('the page margin outside the text turns the page', async () => {
+    // A 600x600 frame inset by 100 leaves the text at [100,500]; (550,550) is
+    // in the margin, off the text but on the page.
+    areaRect = { left: 0, top: 0, right: 600, bottom: 600, width: 600, height: 600 };
+    const { result } = setup({ top: 100, right: 100, bottom: 100, left: 100 });
+    result.current.noteAutoTurnPoint({ x: 550, y: 550 });
     await advance();
     expect(h.view.next).toHaveBeenCalledTimes(1);
   });
@@ -202,6 +214,76 @@ describe('useAutoPageTurn corner-dwell page turn (decoupled from DOM selection)'
     result.current.noteAutoTurnPoint({ x: 900, y: 900 });
     await advance();
     expect(h.view.next).not.toHaveBeenCalled();
+  });
+});
+
+describe('a drag that leaves the text reads as the edge it left by', () => {
+  // A text area smaller than the window, so a point past its edge is still on
+  // screen — which is what separates a finger from a caret that has jumped into
+  // the next, off-screen column.
+  const inset = { left: 100, top: 100, right: 500, bottom: 500, width: 400, height: 400 };
+
+  beforeEach(() => {
+    areaRect = inset;
+  });
+
+  test('past the trailing edge turns to the next page', async () => {
+    const { result } = setup();
+    result.current.noteAutoTurnPoint({ x: 530, y: 300 });
+    await advance();
+
+    expect(h.view.next).toHaveBeenCalledTimes(1);
+  });
+
+  test('past the leading edge turns back', async () => {
+    const { result } = setup();
+    result.current.noteAutoTurnPoint({ x: 300, y: 70 });
+    await advance();
+
+    expect(h.view.prev).toHaveBeenCalledTimes(1);
+  });
+
+  test('past both edges follows the axis it left furthest by', () => {
+    const { result } = setup();
+    // Bottom-left: 40px below the text, 10px to the left of it.
+    expect(result.current.cornerAtPoint({ x: 90, y: 540 }, true)).toBe('br');
+    expect(result.current.cornerAtPoint({ x: 60, y: 510 }, true)).toBe('tl');
+  });
+
+  test('the caret signal keeps the strict test', () => {
+    const { result } = setup();
+    expect(result.current.cornerAtPoint({ x: 530, y: 300 })).toBe(null);
+    expect(result.current.cornerAtPoint({ x: 530, y: 300 }, true)).toBe('br');
+  });
+
+  test('an off-screen point is a jumped caret, not a finger', () => {
+    const { result } = setup();
+    expect(result.current.cornerAtPoint({ x: window.innerWidth + 40, y: 300 }, true)).toBe(null);
+  });
+});
+
+describe('turnHint marks the armed edge', () => {
+  test('engaging arms the hint, leaving clears it', async () => {
+    const { result } = setup();
+    expect(result.current.turnHint).toBe(null);
+
+    act(() => result.current.noteAutoTurnPoint({ x: 970, y: 970 }));
+    expect(result.current.turnHint).toEqual({ corner: 'br', turned: false });
+
+    act(() => result.current.noteAutoTurnPoint({ x: 500, y: 500 }));
+    expect(result.current.turnHint).toBe(null);
+  });
+
+  test('the hint reports the turn, and cancel() drops it', async () => {
+    const { result } = setup();
+    act(() => result.current.noteAutoTurnPoint({ x: 970, y: 970 }));
+    await act(async () => {
+      await advance();
+    });
+    expect(result.current.turnHint).toEqual({ corner: 'br', turned: true });
+
+    act(() => result.current.cancel());
+    expect(result.current.turnHint).toBe(null);
   });
 });
 

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useAutoPageTurn.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useAutoPageTurn.test.ts
@@ -12,11 +12,13 @@ const h = vi.hoisted(() => ({
     prev: vi.fn(),
     renderer: { containerPosition: 100 },
   },
+  viewSettings: { rtl: false } as { rtl: boolean },
 }));
 
 vi.mock('@/store/readerStore', () => ({
   useReaderStore: () => ({
     getView: () => h.view,
+    getViewSettings: () => h.viewSettings,
   }),
 }));
 
@@ -39,6 +41,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
   areaRect = { left: 0, top: 0, right: VW, bottom: VW, width: VW, height: VW };
+  h.viewSettings = { rtl: false };
   const cell = document.createElement('div');
   cell.id = 'gridcell-book-1';
   const fv = document.createElement('foliate-view');
@@ -285,6 +288,53 @@ describe('turnHint marks the armed edge', () => {
 
     act(() => result.current.cancel());
     expect(result.current.turnHint).toBe(null);
+  });
+});
+
+describe('an RTL book ends its page at the bottom-left, and reads that as forward', () => {
+  // A text area smaller than the window, so a point past its edge is still on
+  // screen. viewSettings.rtl is the flag the rest of the reader already maps
+  // screen sides through — it is what makes the physically left nav button say
+  // "Next Page" — and it covers vertical-rl as well as dir=rtl.
+  const inset = { left: 100, top: 100, right: 500, bottom: 500, width: 400, height: 400 };
+
+  beforeEach(() => {
+    areaRect = inset;
+    h.viewSettings = { rtl: true };
+  });
+
+  test('past the left edge turns to the next page', async () => {
+    const { result } = setup();
+    result.current.noteAutoTurnPoint({ x: 70, y: 300 });
+    await advance();
+
+    expect(h.view.next).toHaveBeenCalledTimes(1);
+    expect(h.view.prev).not.toHaveBeenCalled();
+  });
+
+  test('past the right edge turns back', async () => {
+    const { result } = setup();
+    result.current.noteAutoTurnPoint({ x: 530, y: 300 });
+    await advance();
+
+    expect(h.view.prev).toHaveBeenCalledTimes(1);
+    expect(h.view.next).not.toHaveBeenCalled();
+  });
+
+  test('the bottom-left corner is the forward corner', async () => {
+    const { result } = setup();
+    result.current.noteAutoTurnPoint({ x: 130, y: 470 });
+    await advance();
+
+    expect(h.view.next).toHaveBeenCalledTimes(1);
+  });
+
+  test('the top-right corner turns back', async () => {
+    const { result } = setup();
+    result.current.noteAutoTurnPoint({ x: 470, y: 130 });
+    await advance();
+
+    expect(h.view.prev).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-autoTurn.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-autoTurn.test.ts
@@ -104,14 +104,14 @@ const setSelection = (valid: boolean) => {
   } as unknown as Selection;
 };
 
-// Move the pointer to window point (x, y) while a selection is active. A real
-// drag streams selectionchange as it goes, which is what marks the gesture as
-// one that is moving the selection.
+// Drag the pointer to window point (x, y) while a selection is active. A real
+// drag travels before it arrives and streams selectionchange as it goes: the
+// turn arms only once the pointer has left its origin AND a selectionchange has
+// landed while it was moving.
 const pointerMove = (result: Handlers, x: number, y: number, valid = true) => {
   setSelection(valid);
   caretRect = { left: 500, right: 500, top: 495, bottom: 505 };
-  // A real drag moves the pointer and the selection follows; the turn only arms
-  // once a selectionchange lands while the pointer is dragging.
+  result.current.handlePointerMove(doc, 0, { clientX: x - 40, clientY: y - 40 } as PointerEvent);
   result.current.handlePointerMove(doc, 0, { clientX: x, clientY: y } as PointerEvent);
   result.current.handleSelectionchange(doc, 0);
   result.current.handlePointerMove(doc, 0, { clientX: x, clientY: y } as PointerEvent);
@@ -204,8 +204,9 @@ describe('useTextSelector auto page-turn on corner dwell (#1354)', () => {
     await advance();
     expect(h.view.next).toHaveBeenCalledTimes(1);
 
-    // Still held in the same corner -> no further turns.
-    pointerMove(result, 970, 970);
+    // Still held in the same corner: no travel, so no disengage and no re-arm.
+    result.current.handlePointerMove(doc, 0, { clientX: 970, clientY: 970 } as PointerEvent);
+    result.current.handleSelectionchange(doc, 0);
     await advance();
     expect(h.view.next).toHaveBeenCalledTimes(1);
   });
@@ -262,12 +263,60 @@ describe('useTextSelector auto page-turn on corner dwell (#1354)', () => {
   });
 
   test('pointercancel mid-drag keeps the pending turn (Android scroll takeover)', async () => {
+    // Only the Android app has a native-touch bridge that reports the rest of
+    // the gesture, so only there is pointercancel not the end of it.
+    h.appService = { isAndroidApp: true, isMobile: true };
+    h.osPlatform = 'android';
     const { result } = setup();
-    pointerMove(result, 970, 970);
+    result.current.handleTouchStart();
+    setSelection(true);
+    caretRect = { left: 970, right: 970, top: 965, bottom: 975 };
+    result.current.handleNativeTouchMove(930, 930, doc);
+    result.current.handleNativeTouchMove(970, 970, doc);
+    result.current.handleSelectionchange(doc, 0);
+    result.current.handleNativeTouchMove(970, 970, doc);
+    // The browser takes the gesture over for scrolling while the finger keeps
+    // dragging into the corner.
     result.current.handlePointerCancel(doc, 0, {} as PointerEvent);
     await advance();
 
     expect(h.view.next).toHaveBeenCalledTimes(1);
+  });
+
+  test('pointercancel off Android ends the gesture: no turn, no mark left behind', async () => {
+    const { result } = setup();
+    pointerMove(result, 970, 970);
+    // On web the browser fires pointercancel + touchcancel and never pointerup
+    // or touchend, so this is the only chance to drop the pending turn.
+    result.current.handlePointerCancel(doc, 0, {} as PointerEvent);
+    await advance();
+
+    expect(h.view.next).not.toHaveBeenCalled();
+    expect(result.current.turnHint).toBe(null);
+  });
+
+  test('a release clears the drag latch, so a later move cannot re-arm on its own', async () => {
+    const { result } = setup();
+    pointerMove(result, 500, 500);
+    await result.current.handlePointerUp(doc, 0);
+    // A press that began outside the iframe (on the annotation toolbar) delivers
+    // moves here with no pointerdown; without a fresh selection drag of its own
+    // it must not inherit the finished gesture's latch and turn the page.
+    result.current.handlePointerMove(doc, 0, {
+      clientX: 930,
+      clientY: 930,
+      pointerType: 'mouse',
+      buttons: 1,
+    } as PointerEvent);
+    result.current.handlePointerMove(doc, 0, {
+      clientX: 970,
+      clientY: 970,
+      pointerType: 'mouse',
+      buttons: 1,
+    } as PointerEvent);
+    await advance();
+
+    expect(h.view.next).not.toHaveBeenCalled();
   });
 
   test('releasing the pointer drops a pending turn', async () => {
@@ -284,6 +333,36 @@ describe('useTextSelector auto page-turn on corner dwell (#1354)', () => {
     h.viewSettings = { scrolled: true };
     const { result } = setup();
     pointerMove(result, 970, 970);
+    await advance();
+
+    expect(h.view.next).not.toHaveBeenCalled();
+  });
+
+  test('a long press that jitters before the selection lands does not arm the turn', async () => {
+    const { result } = setup();
+    result.current.handleTouchStart();
+    result.current.handlePointerDown(doc, 0, {
+      pointerType: 'touch',
+      button: 0,
+      clientX: 970,
+      clientY: 970,
+    } as PointerEvent);
+    // Finger drift during the hold, before the long press produces a selection.
+    // A pointermove is not a drag; travelling past the slop is.
+    result.current.handlePointerMove(doc, 0, {
+      clientX: 969,
+      clientY: 969,
+      pointerType: 'touch',
+    } as PointerEvent);
+    setSelection(true);
+    caretRect = { left: 970, right: 970, top: 965, bottom: 975 };
+    result.current.handleSelectionchange(doc, 0);
+    // The finger now just rests where the long press left it.
+    result.current.handlePointerMove(doc, 0, {
+      clientX: 970,
+      clientY: 970,
+      pointerType: 'touch',
+    } as PointerEvent);
     await advance();
 
     expect(h.view.next).not.toHaveBeenCalled();

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-autoTurn.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-autoTurn.test.ts
@@ -104,9 +104,13 @@ const setSelection = (valid: boolean) => {
   } as unknown as Selection;
 };
 
-// Move the pointer to window point (x, y) while a selection is active.
+// Move the pointer to window point (x, y) while a selection is active. A real
+// drag streams selectionchange as it goes, which is what marks the gesture as
+// one that is moving the selection.
 const pointerMove = (result: Handlers, x: number, y: number, valid = true) => {
   setSelection(valid);
+  caretRect = { left: 500, right: 500, top: 495, bottom: 505 };
+  result.current.handleSelectionchange(doc, 0);
   result.current.handlePointerMove(doc, 0, { clientX: x, clientY: y } as PointerEvent);
 };
 
@@ -215,9 +219,52 @@ describe('useTextSelector auto page-turn on corner dwell (#1354)', () => {
     expect(h.view.next).toHaveBeenCalledTimes(2);
   });
 
-  test('ignores a pointer outside the reading area', async () => {
+  test('ignores a pointer that is off screen', async () => {
     const { result } = setup();
-    pointerMove(result, VW + 200, 920); // beyond the frame's right edge
+    // Past the page and past the window: not a finger, so not an intent to turn.
+    pointerMove(result, window.innerWidth + 200, 920);
+    await advance();
+
+    expect(h.view.next).not.toHaveBeenCalled();
+  });
+
+  test('a drag into the page margin turns the page', async () => {
+    const { result } = setup({ top: 20, right: 20, bottom: 20, left: 20 });
+    pointerMove(result, 990, 500);
+    await advance();
+
+    expect(h.view.next).toHaveBeenCalledTimes(1);
+  });
+
+  test('a mouse only turns the page while a button is held', async () => {
+    const { result } = setup();
+    setSelection(true);
+    caretRect = { left: 500, right: 500, top: 495, bottom: 505 };
+    result.current.handleSelectionchange(doc, 0);
+    result.current.handlePointerMove(doc, 0, {
+      clientX: 970,
+      clientY: 970,
+      pointerType: 'mouse',
+      buttons: 0,
+    } as PointerEvent);
+    await advance();
+    expect(h.view.next).not.toHaveBeenCalled();
+
+    result.current.handlePointerMove(doc, 0, {
+      clientX: 970,
+      clientY: 970,
+      pointerType: 'mouse',
+      buttons: 1,
+    } as PointerEvent);
+    await advance();
+    expect(h.view.next).toHaveBeenCalledTimes(1);
+  });
+
+  test('releasing the pointer drops a pending turn', async () => {
+    const { result } = setup();
+    pointerMove(result, 970, 970);
+    await vi.advanceTimersByTimeAsync(DWELL_MS - 100);
+    await result.current.handlePointerUp(doc, 0);
     await advance();
 
     expect(h.view.next).not.toHaveBeenCalled();
@@ -227,6 +274,17 @@ describe('useTextSelector auto page-turn on corner dwell (#1354)', () => {
     h.viewSettings = { scrolled: true };
     const { result } = setup();
     pointerMove(result, 970, 970);
+    await advance();
+
+    expect(h.view.next).not.toHaveBeenCalled();
+  });
+
+  test('a finger resting at the edge without dragging the selection does not turn', async () => {
+    const { result } = setup();
+    setSelection(true);
+    // No selectionchange: the selection is on screen but the gesture is not
+    // moving it.
+    result.current.handlePointerMove(doc, 0, { clientX: 970, clientY: 970 } as PointerEvent);
     await advance();
 
     expect(h.view.next).not.toHaveBeenCalled();
@@ -249,10 +307,10 @@ describe('useTextSelector auto page-turn on corner dwell (#1354)', () => {
   });
 
   test('measures corners against the content-inset reading area', async () => {
-    // A 100px inset shrinks the frame to [100,900]: the outer corner (960,960)
-    // now falls outside the area, while (870,870) is inside the inset corner.
+    // A 100px inset shrinks the frame to [100,900]: (770,770) is 130px in from
+    // that corner and stays mid-text, while (870,870) is inside the inset corner.
     const { result } = setup({ top: 100, right: 100, bottom: 100, left: 100 });
-    pointerMove(result, 960, 960);
+    pointerMove(result, 770, 770);
     await advance();
     expect(h.view.next).not.toHaveBeenCalled();
 

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-autoTurn.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-autoTurn.test.ts
@@ -312,10 +312,19 @@ describe('useTextSelector auto page-turn on corner dwell (#1354)', () => {
 
   test('the selection caret is also an engagement signal', async () => {
     const { result } = setup();
-    caretMove(result, 970, 970);
+    pointerMove(result, 500, 500); // a drag is under way
+    caretMove(result, 970, 970); // and its caret reaches the corner
     await advance();
 
     expect(h.view.next).toHaveBeenCalledTimes(1);
+  });
+
+  test('a caret parked in the corner by a long-press does not turn', async () => {
+    const { result } = setup();
+    caretMove(result, 970, 970);
+    await advance();
+
+    expect(h.view.next).not.toHaveBeenCalled();
   });
 
   test('measures corners against the content-inset reading area', async () => {

--- a/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-autoTurn.test.ts
+++ b/apps/readest-app/src/__tests__/app/reader/hooks/useTextSelector-autoTurn.test.ts
@@ -110,6 +110,9 @@ const setSelection = (valid: boolean) => {
 const pointerMove = (result: Handlers, x: number, y: number, valid = true) => {
   setSelection(valid);
   caretRect = { left: 500, right: 500, top: 495, bottom: 505 };
+  // A real drag moves the pointer and the selection follows; the turn only arms
+  // once a selectionchange lands while the pointer is dragging.
+  result.current.handlePointerMove(doc, 0, { clientX: x, clientY: y } as PointerEvent);
   result.current.handleSelectionchange(doc, 0);
   result.current.handlePointerMove(doc, 0, { clientX: x, clientY: y } as PointerEvent);
 };
@@ -238,9 +241,7 @@ describe('useTextSelector auto page-turn on corner dwell (#1354)', () => {
 
   test('a mouse only turns the page while a button is held', async () => {
     const { result } = setup();
-    setSelection(true);
-    caretRect = { left: 500, right: 500, top: 495, bottom: 505 };
-    result.current.handleSelectionchange(doc, 0);
+    pointerMove(result, 500, 500);
     result.current.handlePointerMove(doc, 0, {
       clientX: 970,
       clientY: 970,
@@ -257,6 +258,15 @@ describe('useTextSelector auto page-turn on corner dwell (#1354)', () => {
       buttons: 1,
     } as PointerEvent);
     await advance();
+    expect(h.view.next).toHaveBeenCalledTimes(1);
+  });
+
+  test('pointercancel mid-drag keeps the pending turn (Android scroll takeover)', async () => {
+    const { result } = setup();
+    pointerMove(result, 970, 970);
+    result.current.handlePointerCancel(doc, 0, {} as PointerEvent);
+    await advance();
+
     expect(h.view.next).toHaveBeenCalledTimes(1);
   });
 
@@ -282,8 +292,10 @@ describe('useTextSelector auto page-turn on corner dwell (#1354)', () => {
   test('a finger resting at the edge without dragging the selection does not turn', async () => {
     const { result } = setup();
     setSelection(true);
-    // No selectionchange: the selection is on screen but the gesture is not
-    // moving it.
+    // The long-press that made the selection, then a finger that just sits
+    // there: moves, but no selectionchange while dragging.
+    result.current.handleSelectionchange(doc, 0);
+    result.current.handlePointerMove(doc, 0, { clientX: 970, clientY: 970 } as PointerEvent);
     result.current.handlePointerMove(doc, 0, { clientX: 970, clientY: 970 } as PointerEvent);
     await advance();
 

--- a/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/Annotator.tsx
@@ -79,6 +79,7 @@ import {
 } from '../../utils/globalAnnotations';
 import { annotationToolButtons } from './AnnotationTools';
 import AnnotationRangeEditor from './AnnotationRangeEditor';
+import PageTurnHint from './PageTurnHint';
 import SelectionRangeEditor from './SelectionRangeEditor';
 import AnnotationPopup from './AnnotationPopup';
 import DictionaryPopup from './DictionaryPopup';
@@ -348,6 +349,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
     noteAutoTurnPoint,
     cancelAutoTurn,
     onAutoTurn,
+    turnHint,
   } = useTextSelector(
     bookKey,
     contentInsets,
@@ -2095,6 +2097,7 @@ const Annotator: React.FC<{ bookKey: string; contentInsets: Insets }> = ({
 
   return (
     <div ref={containerRef} role='toolbar' tabIndex={-1}>
+      <PageTurnHint bookKey={bookKey} contentInsets={contentInsets} hint={turnHint} />
       {showDictionaryPopup &&
         (() => {
           // Below `sm` (or short landscape) we present the dictionary as a

--- a/apps/readest-app/src/app/reader/components/annotator/PageTurnHint.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/PageTurnHint.tsx
@@ -29,11 +29,15 @@ const PageTurnHint: React.FC<PageTurnHintProps> = ({ bookKey, contentInsets, hin
   const area = getReadingAreaRect(bookKey, contentInsets);
   if (!area) return null;
 
+  // E-ink refreshes too slowly to run the bar out, and a translucent one barely
+  // renders, so there the armed edge is simply drawn solid.
+  const isEink = document.documentElement.getAttribute('data-eink') === 'true';
   const forward = hint.corner === 'br';
-  const thickness = 3;
-  const bar = 'bg-base-content absolute rounded-full';
-  const filled = hint.turned || grown;
+  const filled = isEink || hint.turned || grown;
+  // Physical sides on purpose: the corners come from screen coordinates
+  // (cornerOf), so a logical `end-0` would put the bar on the wrong edge in RTL.
   const style = (horizontal: boolean): React.CSSProperties => ({
+    opacity: isEink ? 1 : hint.turned ? 0.75 : 0.35,
     transform: `scale${horizontal ? 'X' : 'Y'}(${filled ? 1 : 0})`,
     transformOrigin: forward ? (horizontal ? 'right' : 'bottom') : horizontal ? 'left' : 'top',
     transitionProperty: 'transform',
@@ -48,12 +52,18 @@ const PageTurnHint: React.FC<PageTurnHintProps> = ({ bookKey, contentInsets, hin
       aria-hidden='true'
     >
       <div
-        className={clsx(bar, 'inset-y-0', forward ? 'right-0' : 'left-0')}
-        style={{ width: thickness, opacity: hint.turned ? 0.75 : 0.35, ...style(false) }}
+        className={clsx(
+          'bg-base-content absolute inset-y-0 rounded-full',
+          forward ? 'right-0' : 'left-0',
+        )}
+        style={{ width: 3, ...style(false) }}
       />
       <div
-        className={clsx(bar, 'inset-x-0', forward ? 'bottom-0' : 'top-0')}
-        style={{ height: thickness, opacity: hint.turned ? 0.75 : 0.35, ...style(true) }}
+        className={clsx(
+          'bg-base-content absolute inset-x-0 rounded-full',
+          forward ? 'bottom-0' : 'top-0',
+        )}
+        style={{ height: 3, ...style(true) }}
       />
     </div>
   );

--- a/apps/readest-app/src/app/reader/components/annotator/PageTurnHint.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/PageTurnHint.tsx
@@ -1,0 +1,62 @@
+import clsx from 'clsx';
+import React, { useEffect, useState } from 'react';
+
+import { Insets } from '@/types/misc';
+import { AUTO_TURN_DWELL_MS, TurnHint, getReadingAreaRect } from '../../hooks/useAutoPageTurn';
+
+interface PageTurnHintProps {
+  bookKey: string;
+  contentInsets: Insets;
+  hint: TurnHint | null;
+}
+
+// Marks the page edge a selection drag has armed, and runs a bar along it for
+// the length of the dwell, so holding there reads as "keep holding to turn"
+// rather than as nothing happening. Nothing else advertises the gesture.
+const PageTurnHint: React.FC<PageTurnHintProps> = ({ bookKey, contentInsets, hint }) => {
+  const [grown, setGrown] = useState(false);
+
+  useEffect(() => {
+    if (!hint) {
+      setGrown(false);
+      return;
+    }
+    const frame = requestAnimationFrame(() => setGrown(true));
+    return () => cancelAnimationFrame(frame);
+  }, [hint]);
+
+  if (!hint) return null;
+  const area = getReadingAreaRect(bookKey, contentInsets);
+  if (!area) return null;
+
+  const forward = hint.corner === 'br';
+  const thickness = 3;
+  const bar = 'bg-base-content absolute rounded-full';
+  const filled = hint.turned || grown;
+  const style = (horizontal: boolean): React.CSSProperties => ({
+    transform: `scale${horizontal ? 'X' : 'Y'}(${filled ? 1 : 0})`,
+    transformOrigin: forward ? (horizontal ? 'right' : 'bottom') : horizontal ? 'left' : 'top',
+    transitionProperty: 'transform',
+    transitionTimingFunction: 'linear',
+    transitionDuration: `${hint.turned ? 120 : AUTO_TURN_DWELL_MS}ms`,
+  });
+
+  return (
+    <div
+      className='pointer-events-none fixed z-50'
+      style={{ left: area.left, top: area.top, width: area.width, height: area.height }}
+      aria-hidden='true'
+    >
+      <div
+        className={clsx(bar, 'inset-y-0', forward ? 'right-0' : 'left-0')}
+        style={{ width: thickness, opacity: hint.turned ? 0.75 : 0.35, ...style(false) }}
+      />
+      <div
+        className={clsx(bar, 'inset-x-0', forward ? 'bottom-0' : 'top-0')}
+        style={{ height: thickness, opacity: hint.turned ? 0.75 : 0.35, ...style(true) }}
+      />
+    </div>
+  );
+};
+
+export default PageTurnHint;

--- a/apps/readest-app/src/app/reader/hooks/useAutoPageTurn.ts
+++ b/apps/readest-app/src/app/reader/hooks/useAutoPageTurn.ts
@@ -45,6 +45,16 @@ const cornerOf = (x: number, y: number, w: number, h: number): Corner | null => 
   return null;
 };
 
+// Which way a point that has left the page must turn to stay in view, in
+// area-local coordinates: past the trailing (right/bottom) edge goes forward,
+// past the leading (left/top) edge goes back. Shared by the drag machine and
+// the keyboard path so the two can't drift apart.
+const edgeBeyond = (x: number, y: number, w: number, h: number): 'next' | 'prev' | null => {
+  if (x > w || y > h) return 'next';
+  if (x < 0 || y < 0) return 'prev';
+  return null;
+};
+
 // Map a window-coordinate point to the corner of the reading area it sits in,
 // if any. Corners are measured against `area` (the visible text bounds in window
 // coordinates) so they land on the text, not the page margins or a sidebar.
@@ -52,21 +62,29 @@ const cornerOf = (x: number, y: number, w: number, h: number): Corner | null => 
 // `beyond` reads a point that has left the area as the edge it left by, the
 // rule turnForFocusBeyondPage already uses: dragging a selection off the end of
 // the page means turn. Pointer signals only — the caret keeps the strict test.
+//
+// `rtl` mirrors the horizontal axis first. In a right-to-left book (and in
+// vertical-rl, which viewSettings.rtl also covers) the columns run right to
+// left, so the page ENDS at its bottom-left: without the mirror, dragging
+// forward off the left edge asked for view.prev() and the page went backwards.
 const cornerAt = (
   xWin: number,
   yWin: number,
   area: DOMRect | null,
   beyond = false,
+  rtl = false,
 ): Corner | null => {
   if (!area || area.width <= 0 || area.height <= 0) return null;
-  const x = xWin - area.left;
+  const local = xWin - area.left;
+  const x = rtl ? area.width - local : local;
   const y = yWin - area.top;
   if (x < 0 || x > area.width || y < 0 || y > area.height) {
     // A pointer is always on screen, so an off-screen point is not one: it is a
-    // caret that has jumped into the next, off-screen column.
+    // caret that has jumped into the next, off-screen column. The window bounds
+    // are real screen coordinates, so they are checked unmirrored.
     if (!beyond || xWin < 0 || xWin > window.innerWidth) return null;
     if (yWin < 0 || yWin > window.innerHeight) return null;
-    return turnForFocusBeyondPage({ x: xWin, y: yWin }, area) === 'next' ? 'br' : 'tl';
+    return edgeBeyond(x, y, area.width, area.height) === 'next' ? 'br' : 'tl';
   }
   return cornerOf(x, y, area.width, area.height);
 };
@@ -105,11 +123,7 @@ export const turnForFocusBeyondPage = (
   area: DOMRect | null,
 ): 'next' | 'prev' | null => {
   if (!area || area.width <= 0 || area.height <= 0) return null;
-  const x = point.x - area.left;
-  const y = point.y - area.top;
-  if (x > area.width || y > area.height) return 'next';
-  if (x < 0 || y < 0) return 'prev';
-  return null;
+  return edgeBeyond(point.x - area.left, point.y - area.top, area.width, area.height);
 };
 
 // The page to turn to so a keyboard-extended selection's focus stays visible, or
@@ -135,7 +149,7 @@ export const keyboardTurnDirection = (
 // the correct way). One turn per engagement — a signal must leave the corner and
 // return to turn another page.
 export const useAutoPageTurn = (bookKey: string, contentInsets: Insets = ZERO_INSETS) => {
-  const { getView } = useReaderStore();
+  const { getView, getViewSettings } = useReaderStore();
 
   const autoTurnTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // The corner an input signal is currently engaged in. Stays set after a turn
@@ -155,7 +169,9 @@ export const useAutoPageTurn = (bookKey: string, contentInsets: Insets = ZERO_IN
   const readingAreaRect = (): DOMRect | null => getReadingAreaRect(bookKey, contentInsets);
 
   const cornerAtPoint = (point: Point | null, beyond = false): Corner | null =>
-    point ? cornerAt(point.x, point.y, readingAreaRect(), beyond) : null;
+    point
+      ? cornerAt(point.x, point.y, readingAreaRect(), beyond, !!getViewSettings(bookKey)?.rtl)
+      : null;
 
   const clearTimer = () => {
     if (autoTurnTimer.current) {

--- a/apps/readest-app/src/app/reader/hooks/useAutoPageTurn.ts
+++ b/apps/readest-app/src/app/reader/hooks/useAutoPageTurn.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Insets } from '@/types/misc';
 import { useReaderStore } from '@/store/readerStore';
 import { focusCaretWindowPos } from '@/utils/sel';
@@ -21,6 +21,10 @@ export const AUTO_TURN_CORNER_MAX_PX = 50;
 
 export type Corner = 'br' | 'tl';
 export type Point = { x: number; y: number };
+// The armed edge, for the on-screen mark that tells the reader a page turn is
+// waiting on the dwell. `turned` is set once the page has flipped, while the
+// signal is still held in the corner.
+export type TurnHint = { corner: Corner; turned: boolean };
 
 // The subset of useTextSelector's return that drives the shared corner auto-turn,
 // passed to the range editors so their overlay handle drags turn the page too.
@@ -46,21 +50,41 @@ const cornerOf = (x: number, y: number, w: number, h: number): Corner | null => 
 // Map a window-coordinate point to the corner of the reading area it sits in,
 // if any. Corners are measured against `area` (the visible text bounds in window
 // coordinates) so they land on the text, not the page margins or a sidebar.
-const cornerAt = (xWin: number, yWin: number, area: DOMRect | null): Corner | null => {
+//
+// `beyond` reads a point that has left the reading area as the edge it left by:
+// the trailing (right/bottom) edge turns forward, the leading edge turns back,
+// which is what dragging a selection off the end of the page means. It is only
+// for pointer signals — a real finger or cursor, always on screen. The caret
+// signal keeps the strict test, because a caret dragged at the edge jumps into
+// the next, off-screen column.
+const cornerAt = (
+  xWin: number,
+  yWin: number,
+  area: DOMRect | null,
+  beyond = false,
+): Corner | null => {
   if (!area || area.width <= 0 || area.height <= 0) return null;
   const x = xWin - area.left;
   const y = yWin - area.top;
-  // Ignore a point outside the visible text (e.g. the selection caret jumping
-  // into the next, off-screen column while dragging at the edge).
-  if (x < 0 || x > area.width || y < 0 || y > area.height) return null;
+  const overTrailing = Math.max(x - area.width, y - area.height);
+  const overLeading = Math.max(-x, -y);
+  if (overTrailing > 0 || overLeading > 0) {
+    // A pointer is always on screen, so an off-screen point is not one: it is a
+    // caret that has jumped into the next, off-screen column.
+    if (!beyond || xWin < 0 || xWin > window.innerWidth) return null;
+    if (yWin < 0 || yWin > window.innerHeight) return null;
+    // Past both a leading and a trailing edge (a bottom-left overshoot, say):
+    // the axis it left furthest by is the one the drag is heading along.
+    return overTrailing >= overLeading ? 'br' : 'tl';
+  }
   return cornerOf(x, y, area.width, area.height);
 };
 
-// The reading frame in window coordinates: the <foliate-view> element's rect
-// (a stable element, so it has a sensible page-sized width — unlike the visible
+// The text area in window coordinates: the <foliate-view> element's rect (a
+// stable element, so it has a sensible page-sized width — unlike the visible
 // text range, whose box spans the whole multi-column iframe), inset by the page
-// content margins so the corner zone lands on the text area, not the margin.
-// Falls back to the reading container (gridcell).
+// content margins so the corner zone lands on the text, not the margin. Falls
+// back to the reading container (gridcell).
 export const getReadingAreaRect = (
   bookKey: string,
   insets: Insets = ZERO_INSETS,
@@ -132,14 +156,16 @@ export const useAutoPageTurn = (bookKey: string, contentInsets: Insets = ZERO_IN
   // Callers inject it so the caret-or-pointer dual signal of native selection is
   // preserved while a point-only caller (editor/instant) reports its own point.
   const isInCornerRef = useRef<(corner: Corner) => boolean>(() => false);
+  // Engagement mirrored into render state so the reader can mark the armed edge.
+  const [turnHint, setTurnHint] = useState<TurnHint | null>(null);
   // Latest point fed through the point-based convenience entry.
   const lastPointRef = useRef<Point | null>(null);
   const afterTurnSubs = useRef<Set<(corner: Corner) => void>>(new Set());
 
   const readingAreaRect = (): DOMRect | null => getReadingAreaRect(bookKey, contentInsets);
 
-  const cornerAtPoint = (point: Point | null): Corner | null =>
-    point ? cornerAt(point.x, point.y, readingAreaRect()) : null;
+  const cornerAtPoint = (point: Point | null, beyond = false): Corner | null =>
+    point ? cornerAt(point.x, point.y, readingAreaRect(), beyond) : null;
 
   const clearTimer = () => {
     if (autoTurnTimer.current) {
@@ -155,6 +181,7 @@ export const useAutoPageTurn = (bookKey: string, contentInsets: Insets = ZERO_IN
       // Skip if a turn is already running or the signal left the corner.
       if (isAutoTurning.current || !isInCornerRef.current(corner)) return;
       isAutoTurning.current = true;
+      setTurnHint({ corner, turned: true });
       const view = getView(bookKey);
       // Logical next()/prev() so RTL books turn the correct way.
       const turning = corner === 'br' ? view?.next() : view?.prev();
@@ -175,10 +202,12 @@ export const useAutoPageTurn = (bookKey: string, contentInsets: Insets = ZERO_IN
     if (corner) {
       if (engagedCorner.current !== corner) {
         engagedCorner.current = corner;
+        setTurnHint({ corner, turned: false });
         armDwell(corner);
       }
     } else if (engagedCorner.current && !isInCorner(engagedCorner.current)) {
       engagedCorner.current = null;
+      setTurnHint(null);
       clearTimer();
     }
   };
@@ -188,13 +217,17 @@ export const useAutoPageTurn = (bookKey: string, contentInsets: Insets = ZERO_IN
   // check is "is the latest fed point still in the engaged corner".
   const noteAutoTurnPoint = (point: Point | null) => {
     lastPointRef.current = point;
-    noteCorner(cornerAtPoint(point), (corner) => cornerAtPoint(lastPointRef.current) === corner);
+    noteCorner(
+      cornerAtPoint(point, true),
+      (corner) => cornerAtPoint(lastPointRef.current, true) === corner,
+    );
   };
 
   // Disengage and drop any pending corner page-turn.
   const cancel = () => {
     engagedCorner.current = null;
     lastPointRef.current = null;
+    setTurnHint(null);
     clearTimer();
   };
 
@@ -215,6 +248,7 @@ export const useAutoPageTurn = (bookKey: string, contentInsets: Insets = ZERO_IN
 
   return {
     isAutoTurning,
+    turnHint,
     readingAreaRect,
     cornerAtPoint,
     noteCorner,

--- a/apps/readest-app/src/app/reader/hooks/useAutoPageTurn.ts
+++ b/apps/readest-app/src/app/reader/hooks/useAutoPageTurn.ts
@@ -21,9 +21,7 @@ export const AUTO_TURN_CORNER_MAX_PX = 50;
 
 export type Corner = 'br' | 'tl';
 export type Point = { x: number; y: number };
-// The armed edge, for the on-screen mark that tells the reader a page turn is
-// waiting on the dwell. `turned` is set once the page has flipped, while the
-// signal is still held in the corner.
+// The armed edge, for the on-screen mark; `turned` once the page has flipped.
 export type TurnHint = { corner: Corner; turned: boolean };
 
 // The subset of useTextSelector's return that drives the shared corner auto-turn,
@@ -51,12 +49,9 @@ const cornerOf = (x: number, y: number, w: number, h: number): Corner | null => 
 // if any. Corners are measured against `area` (the visible text bounds in window
 // coordinates) so they land on the text, not the page margins or a sidebar.
 //
-// `beyond` reads a point that has left the reading area as the edge it left by:
-// the trailing (right/bottom) edge turns forward, the leading edge turns back,
-// which is what dragging a selection off the end of the page means. It is only
-// for pointer signals — a real finger or cursor, always on screen. The caret
-// signal keeps the strict test, because a caret dragged at the edge jumps into
-// the next, off-screen column.
+// `beyond` reads a point that has left the area as the edge it left by, the
+// rule turnForFocusBeyondPage already uses: dragging a selection off the end of
+// the page means turn. Pointer signals only — the caret keeps the strict test.
 const cornerAt = (
   xWin: number,
   yWin: number,
@@ -66,16 +61,12 @@ const cornerAt = (
   if (!area || area.width <= 0 || area.height <= 0) return null;
   const x = xWin - area.left;
   const y = yWin - area.top;
-  const overTrailing = Math.max(x - area.width, y - area.height);
-  const overLeading = Math.max(-x, -y);
-  if (overTrailing > 0 || overLeading > 0) {
+  if (x < 0 || x > area.width || y < 0 || y > area.height) {
     // A pointer is always on screen, so an off-screen point is not one: it is a
     // caret that has jumped into the next, off-screen column.
     if (!beyond || xWin < 0 || xWin > window.innerWidth) return null;
     if (yWin < 0 || yWin > window.innerHeight) return null;
-    // Past both a leading and a trailing edge (a bottom-left overshoot, say):
-    // the axis it left furthest by is the one the drag is heading along.
-    return overTrailing >= overLeading ? 'br' : 'tl';
+    return turnForFocusBeyondPage({ x: xWin, y: yWin }, area) === 'next' ? 'br' : 'tl';
   }
   return cornerOf(x, y, area.width, area.height);
 };
@@ -156,7 +147,6 @@ export const useAutoPageTurn = (bookKey: string, contentInsets: Insets = ZERO_IN
   // Callers inject it so the caret-or-pointer dual signal of native selection is
   // preserved while a point-only caller (editor/instant) reports its own point.
   const isInCornerRef = useRef<(corner: Corner) => boolean>(() => false);
-  // Engagement mirrored into render state so the reader can mark the armed edge.
   const [turnHint, setTurnHint] = useState<TurnHint | null>(null);
   // Latest point fed through the point-based convenience entry.
   const lastPointRef = useRef<Point | null>(null);

--- a/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
@@ -965,8 +965,9 @@ export const useTextSelector = (
     // Auto page-turn (#1354): the selection caret is one of the engagement
     // signals on every platform (and the only one on Android during a native
     // selection drag, where pointer/touch-move don't fire). Feed it into the same
-    // dwell machine the pointer uses.
-    if (isValidSelection(sel)) {
+    // dwell machine the pointer uses, under the same gate: without it a
+    // long-press that lands a caret in a corner would turn the page by itself.
+    if (isValidSelection(sel) && selectionDragging.current) {
       noteCorner(!viewSettings?.scrolled ? caretCornerNow(doc) : null, (c) => inCorner(c, doc));
     } else {
       cancelAutoTurn();

--- a/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
@@ -47,6 +47,10 @@ const INSTANT_HOLD_MS = 300;
 // Movement past this many CSS px during the hold means the user is swiping, not
 // settling in to highlight, so the pending engagement is cancelled.
 const INSTANT_HOLD_MOVE_PX = 10;
+// How far a pointer must travel before it counts as dragging a selection rather
+// than resting on it. A long press drifts a pixel or two, and taking that drift
+// for a drag let the long-press selection arm the corner turn by itself.
+const SELECTION_DRAG_SLOP_PX = 10;
 // Ignore tiny pointer jitter, but preserve a deliberate double-click-drag even
 // when it only extends the selection into adjacent whitespace.
 const DOUBLE_CLICK_DRAG_MOVE_PX = 3;
@@ -99,6 +103,9 @@ export const useTextSelector = (
   // WebKit selection handle drag delivers moves without a matching down.
   const pointerDragActive = useRef(false);
   const selectionDragging = useRef(false);
+  // Where this gesture's pointer travel is measured from — the first move of the
+  // gesture, for the same reason.
+  const dragOriginRef = useRef<Point | null>(null);
   const isInstantAnnotating = useRef(false);
   const isInstantAnnotated = useRef(false);
   const annotationStartPoint = useRef<Point | null>(null);
@@ -510,8 +517,40 @@ export const useTextSelector = (
     }
   };
 
-  const handlePointerDown = (doc: Document, index: number, ev: PointerEvent) => {
+  // Whether the pointer has actually travelled since this gesture began. A
+  // pointermove arriving is not a drag: on touch every move looks like one, so
+  // without this a long press that drifted a pixel marked its own selection as
+  // dragged, and a finger then resting at the page edge flipped the page.
+  const noteDragTravel = (): boolean => {
+    const now = pointerPos.current;
+    if (!now) return false;
+    const origin = dragOriginRef.current;
+    if (!origin) {
+      dragOriginRef.current = now;
+      return false;
+    }
+    return Math.hypot(now.x - origin.x, now.y - origin.y) > SELECTION_DRAG_SLOP_PX;
+  };
+
+  // A new gesture: nothing is a drag yet.
+  const beginSelectionDrag = () => {
+    pointerDragActive.current = false;
     selectionDragging.current = false;
+    dragOriginRef.current = null;
+  };
+
+  // The gesture is over: drop the per-gesture drag latches and any pending
+  // corner turn (with the edge mark it drew). Leaving the latches set let a
+  // later move with no drag of its own inherit them and turn the page.
+  const endSelectionDrag = () => {
+    pointerDragActive.current = false;
+    selectionDragging.current = false;
+    dragOriginRef.current = null;
+    cancelAutoTurn();
+  };
+
+  const handlePointerDown = (doc: Document, index: number, ev: PointerEvent) => {
+    beginSelectionDrag();
     lastPointerType.current = ev.pointerType;
     isPointerDown.current = true;
     clearCrossDoc();
@@ -629,8 +668,10 @@ export const useTextSelector = (
     const valid = !!sel && isValidSelection(sel);
     // Only an active drag arms the turn: the zone reaches past the text, so a
     // mouse merely moving there with a selection on screen would otherwise turn
-    // the page on its own. A touch or pen move is by definition a live drag.
-    const dragging = ev.pointerType === 'mouse' ? (ev.buttons & 1) !== 0 : true;
+    // the page on its own. For a mouse that means a held button; for any pointer
+    // it means the finger has actually travelled, not just twitched.
+    const dragging =
+      noteDragTravel() && (ev.pointerType === 'mouse' ? (ev.buttons & 1) !== 0 : true);
     pointerDragActive.current = dragging;
     const armed = valid && dragging && selectionDragging.current;
     const corner = !viewSettings?.scrolled && armed ? pointerCornerNow() : null;
@@ -643,7 +684,7 @@ export const useTextSelector = (
   const handleNativeTouchMove = (x: number, y: number, doc: Document) => {
     const dpr = window.devicePixelRatio || 1;
     pointerPos.current = { x: x / dpr, y: y / dpr };
-    pointerDragActive.current = true;
+    pointerDragActive.current = noteDragTravel();
     maybeCancelInstantHoldOnMove();
     const viewSettings = getViewSettings(bookKey);
     // Instant highlight has no DOM selection (user-select is off); feed the
@@ -654,7 +695,7 @@ export const useTextSelector = (
     }
     const sel = doc.getSelection();
     const valid = !!sel && isValidSelection(sel);
-    const armed = valid && selectionDragging.current;
+    const armed = valid && pointerDragActive.current && selectionDragging.current;
     const corner = !viewSettings?.scrolled && armed ? pointerCornerNow() : null;
     noteCorner(corner, (c) => inCorner(c, doc));
   };
@@ -668,9 +709,13 @@ export const useTextSelector = (
     // (Android fires pointercancel when the browser starts scrolling) keeps its
     // native page-turn instead of being swallowed.
     cancelInstantHold();
-    // NB: don't cancel the auto-turn here — on Android pointercancel fires mid
-    // edge-drag (browser takes over for scrolling), which is exactly when the
-    // user is dragging into the corner. Cancel only on a real release.
+    // In the Android app pointercancel fires mid edge-drag (the browser takes
+    // over for scrolling) while the finger keeps going, and the native-touch
+    // bridge still reports the rest of the gesture — its touchend is the real
+    // release, so leave the pending turn and the drag latches alone there.
+    // Everywhere else pointercancel IS the end: no pointerup or touchend
+    // follows it, so this is the only chance to drop the turn and the edge mark.
+    if (!appService?.isAndroidApp) endSelectionDrag();
     if (isInstantAnnotating.current) {
       stopInstantAnnotating();
       handleInstantAnnotationPointerCancel();
@@ -784,8 +829,7 @@ export const useTextSelector = (
 
   const handlePointerUp = async (doc: Document, index: number, ev?: PointerEvent) => {
     isPointerDown.current = false;
-    pointerDragActive.current = false;
-    cancelAutoTurn();
+    endSelectionDrag();
     const mouseDoubleClick = mouseDoubleClickRef.current;
     mouseDoubleClickRef.current = null;
     dragAnchorRef.current = null;
@@ -878,7 +922,7 @@ export const useTextSelector = (
   };
   const handleTouchStart = () => {
     isTouchStarted.current = true;
-    selectionDragging.current = false;
+    beginSelectionDrag();
     pendingTouchSelection.current = false;
     gestureInitialRef.current = null;
     sanitizedGestureRef.current = false;
@@ -897,8 +941,7 @@ export const useTextSelector = (
   // Android native-touch bridge calls this without a doc (it never defers).
   const handleTouchEnd = (doc?: Document, index?: number) => {
     isTouchStarted.current = false;
-    pointerDragActive.current = false;
-    cancelAutoTurn();
+    endSelectionDrag();
     if (!pendingTouchSelection.current) return;
     pendingTouchSelection.current = false;
     if (!doc || index === undefined) return;

--- a/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
@@ -95,13 +95,9 @@ export const useTextSelector = (
   // (#4728) has no pointer drag — handleSelectionchange uses this to refresh the
   // popup/range for keyboard-driven changes while still deferring mid-drag.
   const isPointerDown = useRef(false);
-  // Whether a pointer is currently dragging over the page. Tracked from the
-  // moves themselves rather than from pointerdown, because a WebKit selection
-  // handle drag delivers moves without a matching down.
+  // Tracked from the moves themselves rather than from pointerdown, because a
+  // WebKit selection handle drag delivers moves without a matching down.
   const pointerDragActive = useRef(false);
-  // Whether this gesture has moved the selection. The page only auto-turns for
-  // a gesture that is dragging the selection, so a finger resting at the page
-  // edge with a selection still on screen doesn't flip pages.
   const selectionDragging = useRef(false);
   const isInstantAnnotating = useRef(false);
   const isInstantAnnotated = useRef(false);
@@ -665,8 +661,6 @@ export const useTextSelector = (
 
   const handlePointerCancel = (_doc: Document, _index: number, _ev: PointerEvent) => {
     isPointerDown.current = false;
-    pointerDragActive.current = false;
-    cancelAutoTurn();
     mouseDoubleClickRef.current = null;
     clearCrossDoc();
     dragAnchorRef.current = null;
@@ -921,8 +915,7 @@ export const useTextSelector = (
   };
 
   // The corner the latest pointer (pointermove / native touchmove) position is
-  // in. A finger dragged off the end of the page reads as the edge it left by,
-  // so the gesture that means "keep going" is the one that turns.
+  // in, reading a finger dragged off the page as the edge it left by.
   const pointerCornerNow = (): Corner | null => cornerAtPoint(pointerPos.current, true);
   // The corner the selection caret (focus) is in.
   const caretCornerNow = (doc: Document): Corner | null => {
@@ -951,7 +944,10 @@ export const useTextSelector = (
     const sel = doc.getSelection() as Selection;
     const viewSettings = getViewSettings(bookKey);
 
-    if (isValidSelection(sel)) selectionDragging.current = true;
+    // Only a selection that moves while a pointer is dragging arms the turn: the
+    // long-press that creates one must not, or a finger that then rests at the
+    // page edge would flip pages.
+    if (isValidSelection(sel) && pointerDragActive.current) selectionDragging.current = true;
 
     if (isAndroid) syncSelectionMenuSuppression(isValidSelection(sel));
 

--- a/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTextSelector.ts
@@ -71,6 +71,7 @@ export const useTextSelector = (
   // through a shared engagement point — see useAutoPageTurn.
   const {
     isAutoTurning,
+    turnHint,
     cornerAtPoint,
     noteCorner,
     noteAutoTurnPoint,
@@ -94,6 +95,14 @@ export const useTextSelector = (
   // (#4728) has no pointer drag — handleSelectionchange uses this to refresh the
   // popup/range for keyboard-driven changes while still deferring mid-drag.
   const isPointerDown = useRef(false);
+  // Whether a pointer is currently dragging over the page. Tracked from the
+  // moves themselves rather than from pointerdown, because a WebKit selection
+  // handle drag delivers moves without a matching down.
+  const pointerDragActive = useRef(false);
+  // Whether this gesture has moved the selection. The page only auto-turns for
+  // a gesture that is dragging the selection, so a finger resting at the page
+  // edge with a selection still on screen doesn't flip pages.
+  const selectionDragging = useRef(false);
   const isInstantAnnotating = useRef(false);
   const isInstantAnnotated = useRef(false);
   const annotationStartPoint = useRef<Point | null>(null);
@@ -506,6 +515,7 @@ export const useTextSelector = (
   };
 
   const handlePointerDown = (doc: Document, index: number, ev: PointerEvent) => {
+    selectionDragging.current = false;
     lastPointerType.current = ev.pointerType;
     isPointerDown.current = true;
     clearCrossDoc();
@@ -621,7 +631,13 @@ export const useTextSelector = (
     const viewSettings = getViewSettings(bookKey);
     const sel = doc.getSelection();
     const valid = !!sel && isValidSelection(sel);
-    const corner = !viewSettings?.scrolled && valid ? pointerCornerNow() : null;
+    // Only an active drag arms the turn: the zone reaches past the text, so a
+    // mouse merely moving there with a selection on screen would otherwise turn
+    // the page on its own. A touch or pen move is by definition a live drag.
+    const dragging = ev.pointerType === 'mouse' ? (ev.buttons & 1) !== 0 : true;
+    pointerDragActive.current = dragging;
+    const armed = valid && dragging && selectionDragging.current;
+    const corner = !viewSettings?.scrolled && armed ? pointerCornerNow() : null;
     noteCorner(corner, (c) => inCorner(c, doc));
   };
 
@@ -631,6 +647,7 @@ export const useTextSelector = (
   const handleNativeTouchMove = (x: number, y: number, doc: Document) => {
     const dpr = window.devicePixelRatio || 1;
     pointerPos.current = { x: x / dpr, y: y / dpr };
+    pointerDragActive.current = true;
     maybeCancelInstantHoldOnMove();
     const viewSettings = getViewSettings(bookKey);
     // Instant highlight has no DOM selection (user-select is off); feed the
@@ -641,12 +658,15 @@ export const useTextSelector = (
     }
     const sel = doc.getSelection();
     const valid = !!sel && isValidSelection(sel);
-    const corner = !viewSettings?.scrolled && valid ? pointerCornerNow() : null;
+    const armed = valid && selectionDragging.current;
+    const corner = !viewSettings?.scrolled && armed ? pointerCornerNow() : null;
     noteCorner(corner, (c) => inCorner(c, doc));
   };
 
   const handlePointerCancel = (_doc: Document, _index: number, _ev: PointerEvent) => {
     isPointerDown.current = false;
+    pointerDragActive.current = false;
+    cancelAutoTurn();
     mouseDoubleClickRef.current = null;
     clearCrossDoc();
     dragAnchorRef.current = null;
@@ -770,6 +790,8 @@ export const useTextSelector = (
 
   const handlePointerUp = async (doc: Document, index: number, ev?: PointerEvent) => {
     isPointerDown.current = false;
+    pointerDragActive.current = false;
+    cancelAutoTurn();
     const mouseDoubleClick = mouseDoubleClickRef.current;
     mouseDoubleClickRef.current = null;
     dragAnchorRef.current = null;
@@ -862,6 +884,7 @@ export const useTextSelector = (
   };
   const handleTouchStart = () => {
     isTouchStarted.current = true;
+    selectionDragging.current = false;
     pendingTouchSelection.current = false;
     gestureInitialRef.current = null;
     sanitizedGestureRef.current = false;
@@ -880,6 +903,8 @@ export const useTextSelector = (
   // Android native-touch bridge calls this without a doc (it never defers).
   const handleTouchEnd = (doc?: Document, index?: number) => {
     isTouchStarted.current = false;
+    pointerDragActive.current = false;
+    cancelAutoTurn();
     if (!pendingTouchSelection.current) return;
     pendingTouchSelection.current = false;
     if (!doc || index === undefined) return;
@@ -895,8 +920,10 @@ export const useTextSelector = (
     }
   };
 
-  // The corner the latest pointer (pointermove / native touchmove) position is in.
-  const pointerCornerNow = (): Corner | null => cornerAtPoint(pointerPos.current);
+  // The corner the latest pointer (pointermove / native touchmove) position is
+  // in. A finger dragged off the end of the page reads as the edge it left by,
+  // so the gesture that means "keep going" is the one that turns.
+  const pointerCornerNow = (): Corner | null => cornerAtPoint(pointerPos.current, true);
   // The corner the selection caret (focus) is in.
   const caretCornerNow = (doc: Document): Corner | null => {
     const sel = doc.getSelection();
@@ -907,7 +934,7 @@ export const useTextSelector = (
   // Injected into the dwell machine as the native-selection liveness predicate so
   // the page only turns while the caret OR the finger is still in the corner.
   const inCorner = (c: Corner, doc: Document): boolean =>
-    pointerCornerNow() === c || caretCornerNow(doc) === c;
+    (pointerDragActive.current && pointerCornerNow() === c) || caretCornerNow(doc) === c;
 
   const handleSelectionchange = (doc: Document, index: number) => {
     // Echo of our own programmatic selection writes (handle suppression or a
@@ -923,6 +950,8 @@ export const useTextSelector = (
     const isTouchInput = lastPointerType.current === 'touch' || lastPointerType.current === 'pen';
     const sel = doc.getSelection() as Selection;
     const viewSettings = getViewSettings(bookKey);
+
+    if (isValidSelection(sel)) selectionDragging.current = true;
 
     if (isAndroid) syncSelectionMenuSuppression(isValidSelection(sel));
 
@@ -1084,5 +1113,6 @@ export const useTextSelector = (
     noteAutoTurnPoint,
     cancelAutoTurn,
     onAutoTurn: onAfterTurn,
+    turnHint,
   };
 };


### PR DESCRIPTION
> Disclaimer: the code is fully agent-written. The PR description is fully human-written.

The repo had machinery to make cross-page selection work, but on my physical iPhone it never actually did and I had to enter scrolled mode to select. This PR fixes this (I verified on my iPhone).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added visual page-turn hints when dragging toward a page corner.
  - Added animated edge indicators for standard and E-ink displays.
  - Improved automatic page turning near or beyond page margins, including RTL layouts.
  - Selection-based page turning now requires an active drag and responds more reliably to touch and pointer interactions.

- **Bug Fixes**
  - Improved cancellation and completion handling for automatic page turns.
  - Prevented unintended page turns from stationary touches and long-press caret placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->