### PR TITLE
feat(reader): jump from a footnote popup to the location in the book

### DIFF
--- a/apps/readest-app/src/__tests__/app/reader/components/FootnotePopup.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/FootnotePopup.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Footnote popup "Jump to Location" (#5766).
+ *
+ * A link pointing at an appendix or a long section only ever renders as its
+ * heading in the popup (foliate's #showFragment falls through to
+ * `range.selectNode(el)`), so a popup backed by a book document must offer a
+ * way out to the real page. Popups synthesized from a `data-*` attribute have
+ * no location in the book and must not offer one.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, fireEvent } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { BookDoc } from '@/libs/document';
+import { eventDispatcher } from '@/utils/event';
+
+const BOOK_KEY = 'bookid-0';
+const HREF = 'text/part0012.xhtml#appendix-c';
+
+const hoisted = vi.hoisted(() => ({
+  handlers: [] as EventTarget[],
+  onLinkClick: { current: null as ((event: Event) => void) | null },
+  goTo: vi.fn(),
+  showTransientHighlight: vi.fn(),
+}));
+
+vi.mock('foliate-js/footnotes.js', () => {
+  class FootnoteHandler extends EventTarget {
+    handle = vi.fn(() => Promise.resolve());
+    constructor() {
+      super();
+      hoisted.handlers.push(this);
+    }
+  }
+  return { FootnoteHandler };
+});
+
+vi.mock('@/app/reader/hooks/useFoliateEvents', () => ({
+  useFoliateEvents: (_view: unknown, handlers?: { onLinkClick?: (event: Event) => void }) => {
+    hoisted.onLinkClick.current = handlers?.onLinkClick ?? null;
+  },
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+vi.mock('@/hooks/useResponsiveSize', () => ({
+  useResponsiveSize: (size: number) => size,
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: { isMobile: false } }),
+}));
+
+const bookDataState = {
+  booksData: { bookid: { config: { booknotes: [] } } },
+  getBookData: () => ({ book: { primaryLanguage: 'en' } }),
+};
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: Object.assign(
+    (selector?: (state: typeof bookDataState) => unknown) =>
+      selector ? selector(bookDataState) : bookDataState,
+    { getState: () => bookDataState },
+  ),
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    getView: () => ({ goTo: hoisted.goTo }),
+    getViewSettings: () => ({ vertical: false }),
+  }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: { getState: () => ({ settings: {} }) },
+}));
+
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: { getState: () => ({ isDarkMode: false }) },
+}));
+
+vi.mock('@/store/customFontStore', () => ({
+  useCustomFontStore: () => ({ getLoadedFonts: () => [] }),
+}));
+
+vi.mock('@/utils/style', () => ({
+  getFootnoteStyles: () => '',
+  getStyles: () => '',
+  getThemeCode: () => ({ bg: '#fff', fg: '#000', primary: '#000', palette: {} }),
+}));
+
+vi.mock('@/styles/fonts', () => ({
+  mountAdditionalFonts: vi.fn(),
+  mountCustomFont: vi.fn(),
+}));
+
+vi.mock('@/utils/sel', () => ({
+  getPosition: () => ({ point: { x: 10, y: 10 }, dir: 'down' }),
+  getPopupPosition: () => ({ point: { x: 10, y: 10 }, dir: 'down' }),
+}));
+
+vi.mock('@/app/reader/utils/transientHighlight', () => ({
+  showTransientHighlight: hoisted.showTransientHighlight,
+}));
+
+vi.mock('@/app/reader/utils/annotatorUtil', () => ({
+  drawAnnotationOverlay: vi.fn(),
+}));
+
+vi.mock('@/app/reader/utils/footnoteHeuristics', () => ({
+  shouldCheckAsFootnote: () => false,
+}));
+
+vi.mock('@/components/Overlay', () => ({
+  Overlay: () => <div data-testid='overlay' />,
+}));
+
+// The real Popup keeps its children mounted and only moves them off-screen
+// when closed, which FootnotePopup relies on to fill `footnoteRef` ahead of
+// the first render.
+vi.mock('@/components/Popup', () => ({
+  default: ({ isOpen, children }: { isOpen?: boolean; children: ReactNode }) => (
+    <div data-testid='popup' data-open={isOpen ? 'true' : 'false'}>
+      {children}
+    </div>
+  ),
+}));
+
+const createPopupView = () => {
+  const view = document.createElement('div');
+  const renderer = document.createElement('div') as HTMLDivElement & {
+    viewSize: number;
+    setStyles: () => void;
+  };
+  renderer.viewSize = 240;
+  renderer.setStyles = vi.fn();
+  Object.defineProperty(view, 'renderer', { value: renderer });
+  return view;
+};
+
+const renderPopup = async () => {
+  const grid = document.createElement('div');
+  grid.id = `gridcell-${BOOK_KEY}`;
+  document.body.appendChild(grid);
+  const { default: FootnotePopup } = await import('@/app/reader/components/FootnotePopup');
+  return render(<FootnotePopup bookKey={BOOK_KEY} bookDoc={{} as BookDoc} />);
+};
+
+/** Drive a link click in the book through to a rendered footnote popup. */
+const openFootnotePopup = async (href = HREF) => {
+  const anchor = document.createElement('a');
+  anchor.setAttribute('href', href);
+  document.body.appendChild(anchor);
+  await act(async () => {
+    hoisted.onLinkClick.current?.(
+      new CustomEvent('link', { detail: { a: anchor, href }, cancelable: true }),
+    );
+  });
+  const handler = hoisted.handlers.at(-1)!;
+  const view = createPopupView();
+  await act(async () => {
+    handler.dispatchEvent(new CustomEvent('before-render', { detail: { view } }));
+    handler.dispatchEvent(
+      new CustomEvent('render', { detail: { view, href, index: 3, extract: null } }),
+    );
+    view.dispatchEvent(new CustomEvent('relocate', { detail: {} }));
+  });
+};
+
+describe('FootnotePopup jump to location', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    hoisted.handlers.length = 0;
+    hoisted.onLinkClick.current = null;
+    hoisted.goTo.mockReset();
+    hoisted.showTransientHighlight.mockReset().mockResolvedValue(null);
+  });
+
+  it('navigates the book view to the popup source and dismisses the popup', async () => {
+    await renderPopup();
+    await openFootnotePopup();
+
+    const button = screen.getByLabelText('Jump to Location');
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(hoisted.goTo).toHaveBeenCalledWith(HREF);
+    expect(screen.getByTestId('popup').dataset['open']).toBe('false');
+    expect(screen.queryByLabelText('Jump to Location')).toBeNull();
+  });
+
+  it('jumps to the nested target after following a link inside the popup', async () => {
+    await renderPopup();
+    await openFootnotePopup();
+
+    const nestedHref = 'text/part0003.xhtml#note-12';
+    const handler = hoisted.handlers.at(-1)!;
+    const view = createPopupView();
+    await act(async () => {
+      handler.dispatchEvent(new CustomEvent('before-render', { detail: { view } }));
+      handler.dispatchEvent(
+        new CustomEvent('render', {
+          detail: { view, href: nestedHref, index: 1, extract: null },
+        }),
+      );
+      view.dispatchEvent(new CustomEvent('relocate', { detail: {} }));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Jump to Location'));
+    });
+
+    expect(hoisted.goTo).toHaveBeenCalledWith(nestedHref);
+  });
+
+  it('offers no jump for popups synthesized from a data attribute', async () => {
+    await renderPopup();
+    const element = document.createElement('span');
+    document.body.appendChild(element);
+    await act(async () => {
+      await eventDispatcher.dispatch('footnote-popup', {
+        bookKey: BOOK_KEY,
+        element,
+        footnote: 'A footnote with no document behind it',
+      });
+    });
+
+    expect(screen.getByTestId('popup').dataset['open']).toBe('true');
+    expect(screen.queryByLabelText('Jump to Location')).toBeNull();
+  });
+});

--- a/apps/readest-app/src/__tests__/app/reader/components/FootnotePopup.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/FootnotePopup.test.tsx
@@ -21,6 +21,7 @@ const hoisted = vi.hoisted(() => ({
   onLinkClick: { current: null as ((event: Event) => void) | null },
   goTo: vi.fn(),
   showTransientHighlight: vi.fn(),
+  isLinkTargetVisible: vi.fn(),
 }));
 
 vi.mock('foliate-js/footnotes.js', () => {
@@ -109,6 +110,7 @@ vi.mock('@/app/reader/utils/annotatorUtil', () => ({
 
 vi.mock('@/app/reader/utils/footnoteHeuristics', () => ({
   shouldCheckAsFootnote: () => false,
+  isLinkTargetVisible: hoisted.isLinkTargetVisible,
 }));
 
 vi.mock('@/components/Overlay', () => ({
@@ -146,6 +148,12 @@ const renderPopup = async () => {
   return render(<FootnotePopup bookKey={BOOK_KEY} bookDoc={{} as BookDoc} />);
 };
 
+const stylesOf = (view: HTMLElement) => {
+  const setStyles = (view as unknown as { renderer: { setStyles: ReturnType<typeof vi.fn> } })
+    .renderer.setStyles;
+  return setStyles.mock.calls.at(-1)?.[0] as string | undefined;
+};
+
 /** Drive a link click in the book through to a rendered footnote popup. */
 const openFootnotePopup = async (href = HREF) => {
   const anchor = document.createElement('a');
@@ -165,6 +173,7 @@ const openFootnotePopup = async (href = HREF) => {
     );
     view.dispatchEvent(new CustomEvent('relocate', { detail: {} }));
   });
+  return view;
 };
 
 describe('FootnotePopup jump to location', () => {
@@ -174,6 +183,7 @@ describe('FootnotePopup jump to location', () => {
     hoisted.onLinkClick.current = null;
     hoisted.goTo.mockReset();
     hoisted.showTransientHighlight.mockReset().mockResolvedValue(null);
+    hoisted.isLinkTargetVisible.mockReset().mockReturnValue(true);
   });
 
   it('navigates the book view to the popup source and dismisses the popup', async () => {
@@ -212,6 +222,32 @@ describe('FootnotePopup jump to location', () => {
     });
 
     expect(hoisted.goTo).toHaveBeenCalledWith(nestedHref);
+  });
+
+  // The reader's stylesheet hides inline footnote bodies, so a link that
+  // points at one has nowhere to take the reader (#5766 follow-up).
+  it('offers no jump when the link target is hidden in the book', async () => {
+    hoisted.isLinkTargetVisible.mockReturnValue(false);
+    await renderPopup();
+    await openFootnotePopup('ch1.xhtml#B_1');
+
+    expect(screen.getByTestId('popup').dataset['open']).toBe('true');
+    expect(screen.queryByLabelText('Jump to Location')).toBeNull();
+  });
+
+  // The chrome floats over the popup document, so the document has to start
+  // clear of it -- but only when there is something to clear.
+  it('reserves room for the chrome only when a button will be shown', async () => {
+    await renderPopup();
+    const withButton = await openFootnotePopup();
+    expect(stylesOf(withButton)).toContain('padding-block-start');
+  });
+
+  it('reserves no room when the popup has no chrome at all', async () => {
+    hoisted.isLinkTargetVisible.mockReturnValue(false);
+    await renderPopup();
+    const bare = await openFootnotePopup('ch1.xhtml#B_1');
+    expect(stylesOf(bare)).not.toContain('padding-block-start');
   });
 
   it('offers no jump for popups synthesized from a data attribute', async () => {

--- a/apps/readest-app/src/__tests__/app/reader/components/FootnotePopup.test.tsx
+++ b/apps/readest-app/src/__tests__/app/reader/components/FootnotePopup.test.tsx
@@ -235,19 +235,13 @@ describe('FootnotePopup jump to location', () => {
     expect(screen.queryByLabelText('Jump to Location')).toBeNull();
   });
 
-  // The chrome floats over the popup document, so the document has to start
-  // clear of it -- but only when there is something to clear.
-  it('reserves room for the chrome only when a button will be shown', async () => {
+  // The chrome floats over the popup document rather than pushing it down:
+  // reserving a strip left a band of dead space above every short footnote.
+  it('reserves no room in the popup document for the chrome', async () => {
     await renderPopup();
-    const withButton = await openFootnotePopup();
-    expect(stylesOf(withButton)).toContain('padding-block-start');
-  });
-
-  it('reserves no room when the popup has no chrome at all', async () => {
-    hoisted.isLinkTargetVisible.mockReturnValue(false);
-    await renderPopup();
-    const bare = await openFootnotePopup('ch1.xhtml#B_1');
-    expect(stylesOf(bare)).not.toContain('padding-block-start');
+    const view = await openFootnotePopup();
+    expect(screen.getByLabelText('Jump to Location')).toBeTruthy();
+    expect(stylesOf(view)).not.toContain('padding-block-start');
   });
 
   it('offers no jump for popups synthesized from a data attribute', async () => {

--- a/apps/readest-app/src/__tests__/reader/utils/footnote-target-visibility.test.ts
+++ b/apps/readest-app/src/__tests__/reader/utils/footnote-target-visibility.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The reader's own stylesheet hides inline footnote bodies
+ * (`.duokan-footnote-content`, `.epubtype-footnote`, `aside[epub|type~=...]`),
+ * so a link that points at one leads nowhere the reader can see. The footnote
+ * popup's jump button must be gated on the target actually being rendered.
+ */
+import { describe, it, expect } from 'vitest';
+import { isLinkTargetVisible } from '@/app/reader/utils/footnoteHeuristics';
+import type { FoliateView } from '@/types/view';
+
+// Section documents are iframe documents in the reader; a DOMParser document
+// has no `defaultView`, so it cannot report computed styles.
+const makeView = (html: string, { rendered = true, index = 2 } = {}) => {
+  const frame = document.createElement('iframe');
+  document.body.appendChild(frame);
+  const doc = frame.contentDocument!;
+  doc.body.innerHTML = html;
+  return {
+    resolveNavigation: () => ({
+      index,
+      anchor: (d: Document) => d.getElementById('target'),
+    }),
+    renderer: {
+      getContents: () => (rendered ? [{ doc, index }] : []),
+    },
+  } as unknown as FoliateView;
+};
+
+describe('isLinkTargetVisible', () => {
+  it('rejects a target hidden by an ancestor', () => {
+    const view = makeView(
+      `<div class='duokan-footnote-content' style='display: none'>
+         <p><a id='target'></a>the note body</p>
+       </div>`,
+    );
+    expect(isLinkTargetVisible(view, 'ch1.xhtml#B_1')).toBe(false);
+  });
+
+  it('rejects a target hidden on the element itself', () => {
+    const view = makeView(`<aside id='target' style='display: none'>note</aside>`);
+    expect(isLinkTargetVisible(view, 'ch1.xhtml#n1')).toBe(false);
+  });
+
+  it('rejects a target made invisible rather than unrendered', () => {
+    const view = makeView(`<aside id='target' style='visibility: hidden'>note</aside>`);
+    expect(isLinkTargetVisible(view, 'ch1.xhtml#n1')).toBe(false);
+  });
+
+  it('accepts a target that is laid out', () => {
+    const view = makeView(`<h2 id='target'>Appendix C</h2><p>body</p>`);
+    expect(isLinkTargetVisible(view, 'appendix.xhtml#app-c')).toBe(true);
+  });
+
+  // An inline footnote body always lives beside its reference, so it is always
+  // in a rendered section. A target in a section that is not rendered yet is a
+  // real destination, and loading it just to check would stall the popup.
+  it('accepts a target whose section is not rendered yet', () => {
+    const view = makeView(`<aside id='target' style='display: none'>note</aside>`, {
+      rendered: false,
+    });
+    expect(isLinkTargetVisible(view, 'notes.xhtml#n1')).toBe(true);
+  });
+
+  it('accepts when navigation cannot be resolved', () => {
+    const view = {
+      resolveNavigation: () => {
+        throw new Error('unresolvable');
+      },
+      renderer: { getContents: () => [] },
+    } as unknown as FoliateView;
+    expect(isLinkTargetVisible(view, 'nope.xhtml#x')).toBe(true);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
+++ b/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
@@ -40,9 +40,6 @@ interface FootnotePopupProps {
 const popupWidth = 360;
 const popupHeight = 88;
 
-// Height of the chrome strip floating over the popup document, in px.
-const chromeSize = 32;
-
 const chromeButtonClassName = clsx(
   'btn btn-ghost btn-circle eink-bordered text-base-content bg-base-200/80 hover:bg-base-200',
   'h-8 min-h-8 w-8 p-0 shadow-xs',
@@ -98,12 +95,8 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
   // The book location the popup is currently showing, when that location is
   // somewhere the reader can actually be taken. Null for a popup with no book
   // document behind it, and for a target the stylesheet hides, so this doubles
-  // as the gate for the jump button. The ref holds the same verdict taken at
-  // click time, which is early enough for `before-render` to decide whether
-  // the document has to leave room for the chrome; `render` recomputes it from
-  // the href it is handed rather than trusting the ref to still match.
+  // as the gate for the jump button.
   const [sourceHref, setSourceHref] = useState<string | null>(null);
-  const jumpHrefRef = useRef<string | null>(null);
 
   // Inline footnote bodies are hidden by the reader's own stylesheet, so a
   // link pointing at one has nowhere to take the reader and earns no button.
@@ -188,7 +181,6 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
         const items = [...history.items.slice(0, history.index + 1), popupLinkDetail];
         historyRef.current = { items, index: items.length - 1 };
         setCanGoBack(true);
-        jumpHrefRef.current = getJumpHref(popupLinkDetail.href);
         footnoteHandler.handle(bookDoc, e)?.catch((err) => {
           console.warn(err);
           getView(bookKey)?.goTo(popupLinkDetail.href);
@@ -316,19 +308,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       }
       const mainStyles = getStyles(viewSettings, popupTheme, getLoadedFonts());
       const footnoteStyles = getFootnoteStyles();
-      // The chrome strip (jump-to-location, plus Back once a link has been
-      // followed) floats over the popup document, so the text has to start
-      // clear of it — and only then, or a popup with no buttons opens under a
-      // band of dead space. A scrolled renderer ignores its `margin-*`
-      // attributes (it only publishes them as CSS variables), so reserve the
-      // strip in the document's own padding instead: `padding-block-start`
-      // lands on top in horizontal writing and on the right in vertical,
-      // which is where the strip sits in each mode.
-      const hasChrome = historyRef.current.index > 0 || !!jumpHrefRef.current;
-      const chromeStyles = hasChrome
-        ? `\nbody { padding-block-start: calc(1em + ${chromeSize}px) !important; }`
-        : '';
-      renderer.setStyles?.(`${mainStyles}\n${footnoteStyles}${chromeStyles}`);
+      renderer.setStyles?.(`${mainStyles}\n${footnoteStyles}`);
     };
 
     const handleRender = (e: Event) => {
@@ -429,7 +409,6 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       detail['check'] = true;
     }
     historyRef.current = { items: [detail], index: 0 };
-    jumpHrefRef.current = getJumpHref(detail.href);
     setCanGoBack(false);
     const popupPromise = footnoteHandler.handle(bookDoc, event);
     if (popupPromise) {
@@ -453,7 +432,6 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     historyRef.current = { ...history, index: newIndex };
     setCanGoBack(newIndex > 0);
     const detail = history.items[newIndex]!;
-    jumpHrefRef.current = getJumpHref(detail['href'] as string | undefined);
     const syntheticEvent = new CustomEvent('link', {
       detail: { ...detail, follow: true },
       cancelable: true,
@@ -492,7 +470,6 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     setResponsiveHeight(popupHeight);
     setShowPopup(false);
     setSourceHref(null);
-    jumpHrefRef.current = null;
   };
 
   // Handle custom footnote popup event from iframe event
@@ -503,7 +480,6 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     // This popup shows text synthesized from a data/alt attribute in the host
     // document: there is no book document behind it, so no CFI mapping.
     footnoteViewRef.current = null;
-    jumpHrefRef.current = null;
     setSourceHref(null);
     resetPopupAnnotationState();
     const rect = gridFrame.getBoundingClientRect();
@@ -659,12 +635,14 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
         onDismiss={handleDismissPopup}
       >
         {(canGoBack || sourceHref) && (
+          // The chrome floats over the text rather than pushing it down, so
+          // the strip must not swallow taps meant for the words beneath it.
           <div
             className={clsx(
-              'absolute z-10 flex gap-1',
+              'pointer-events-none absolute z-10 flex gap-1',
               viewSettings.vertical
-                ? 'end-0 top-0 h-full w-8 flex-col items-center pt-2'
-                : 'start-0 top-0 h-8 w-full items-center px-2',
+                ? 'bottom-2 end-2 top-2 w-8 flex-col items-end'
+                : 'end-2 start-2 top-2 h-8 flex-row items-start',
             )}
           >
             {canGoBack && (
@@ -673,7 +651,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
                 onClick={handleBack}
                 aria-label={_('Back')}
                 title={_('Back')}
-                className={chromeButtonClassName}
+                className={clsx(chromeButtonClassName, 'pointer-events-auto')}
               >
                 <MdArrowBack size={size18} />
               </button>
@@ -684,7 +662,11 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
                 onClick={handleGoToSource}
                 aria-label={_('Jump to Location')}
                 title={_('Jump to Location')}
-                className={clsx(chromeButtonClassName, !viewSettings.vertical && 'ms-auto')}
+                className={clsx(
+                  chromeButtonClassName,
+                  'pointer-events-auto',
+                  !viewSettings.vertical && 'ms-auto',
+                )}
               >
                 <MdOutlineArrowOutward size={size18} />
               </button>

--- a/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
+++ b/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { MdArrowBack } from 'react-icons/md';
+import { MdArrowBack, MdOutlineArrowOutward } from 'react-icons/md';
 
 import { BookDoc } from '@/libs/document';
 import { BookNote } from '@/types/book';
@@ -12,6 +12,7 @@ import { useThemeStore } from '@/store/themeStore';
 import { useFoliateEvents } from '../hooks/useFoliateEvents';
 import { useCustomFontStore } from '@/store/customFontStore';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
+import { useTranslation } from '@/hooks/useTranslation';
 import { getFootnoteStyles, getStyles, getThemeCode } from '@/utils/style';
 import { getPopupPosition, getPosition, Position } from '@/utils/sel';
 import { FootnoteHandler } from 'foliate-js/footnotes.js';
@@ -39,6 +40,14 @@ interface FootnotePopupProps {
 const popupWidth = 360;
 const popupHeight = 88;
 
+// Height of the chrome strip floating over the popup document, in px.
+const chromeSize = 32;
+
+const chromeButtonClassName = clsx(
+  'btn btn-ghost btn-circle eink-bordered text-base-content bg-base-200/80 hover:bg-base-200',
+  'h-8 min-h-8 w-8 p-0 shadow-xs',
+);
+
 const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
   const footnoteRef = useRef<HTMLDivElement>(null);
   const footnoteViewRef = useRef<FoliateView | null>(null);
@@ -47,6 +56,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
   const [popupPosition, setPopupPosition] = useState<Position | null>();
   const [showPopup, setShowPopup] = useState(false);
 
+  const _ = useTranslation();
   const { appService } = useEnv();
   const { getBookData } = useBookDataStore();
   const { getView, getViewSettings } = useReaderStore();
@@ -85,7 +95,9 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     index: -1,
   });
   const [canGoBack, setCanGoBack] = useState(false);
-  const canGoBackRef = useRef(canGoBack);
+  // The book location the popup is currently showing. Only popups backed by a
+  // book document have one, so this doubles as the gate for the jump button.
+  const [sourceHref, setSourceHref] = useState<string | null>(null);
   const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // A link that jumps in-page instead of opening a popup (undetected or
@@ -163,7 +175,6 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
         const items = [...history.items.slice(0, history.index + 1), popupLinkDetail];
         historyRef.current = { items, index: items.length - 1 };
         setCanGoBack(true);
-        canGoBackRef.current = true;
         footnoteHandler.handle(bookDoc, e)?.catch((err) => {
           console.warn(err);
           getView(bookKey)?.goTo(popupLinkDetail.href);
@@ -274,12 +285,11 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       footnoteRef.current?.replaceChildren(popupView);
       const { renderer } = popupView;
       const viewSettings = getViewSettings(bookKey)!;
-      const backButtonMargin = canGoBackRef.current ? 32 : 0;
       renderer.setAttribute('flow', 'scrolled');
       renderer.setAttribute('no-preload', '');
       renderer.setAttribute('no-background', '');
-      renderer.setAttribute('margin-top', `${viewSettings.vertical ? 0 : backButtonMargin}px`);
-      renderer.setAttribute('margin-right', `${viewSettings.vertical ? backButtonMargin : 0}px`);
+      renderer.setAttribute('margin-top', '0px');
+      renderer.setAttribute('margin-right', '0px');
       renderer.setAttribute('margin-bottom', '0px');
       renderer.setAttribute('margin-left', '0px');
       renderer.setAttribute('gap', '0%');
@@ -292,7 +302,15 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       }
       const mainStyles = getStyles(viewSettings, popupTheme, getLoadedFonts());
       const footnoteStyles = getFootnoteStyles();
-      renderer.setStyles?.(`${mainStyles}\n${footnoteStyles}`);
+      // The chrome strip (jump-to-location, plus Back once a link has been
+      // followed) floats over the popup document, so the text has to start
+      // clear of it. A scrolled renderer ignores its `margin-*` attributes —
+      // it only publishes them as CSS variables — so reserve the strip in the
+      // document's own padding instead. `padding-block-start` lands on top in
+      // horizontal writing and on the right in vertical, which is where the
+      // strip sits in each mode.
+      const chromeStyles = `body { padding-block-start: calc(1em + ${chromeSize}px) !important; }`;
+      renderer.setStyles?.(`${mainStyles}\n${footnoteStyles}\n${chromeStyles}`);
     };
 
     const handleRender = (e: Event) => {
@@ -300,6 +318,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       // console.log('render footnote', detail);
       const { view, href, index, extract } = detail;
       footnoteHrefRef.current = href;
+      setSourceHref(href ?? null);
       resetPopupAnnotationState({ index: index ?? -1, extract: extract ?? null });
       sizeAdjustCountRef.current = 0;
       view.addEventListener('relocate', () => {
@@ -393,7 +412,6 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     }
     historyRef.current = { items: [detail], index: 0 };
     setCanGoBack(false);
-    canGoBackRef.current = false;
     const popupPromise = footnoteHandler.handle(bookDoc, event);
     if (popupPromise) {
       popupPromise.catch((err: unknown) => {
@@ -415,13 +433,23 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     const newIndex = history.index - 1;
     historyRef.current = { ...history, index: newIndex };
     setCanGoBack(newIndex > 0);
-    canGoBackRef.current = newIndex > 0;
     const detail = history.items[newIndex]!;
     const syntheticEvent = new CustomEvent('link', {
       detail: { ...detail, follow: true },
       cancelable: true,
     });
     footnoteHandler.handle(bookDoc, syntheticEvent);
+  };
+
+  // Leave the popup for the real page it stands in for: a link to an appendix
+  // or a long section only ever extracts as its heading, and a note's backlink
+  // is worth following to its surrounding context (#5766).
+  const handleGoToSource = () => {
+    const href = sourceHref;
+    handleDismissPopup();
+    if (!href) return;
+    view?.goTo(href);
+    flashLinkTarget(href);
   };
 
   const closePopup = () => {
@@ -434,7 +462,6 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     closePopup();
     resetPopupAnnotationState();
     historyRef.current = { items: [], index: -1 };
-    canGoBackRef.current = false;
     sizeAdjustCountRef.current = 0;
     trianglePositionRef.current = null;
     setCanGoBack(false);
@@ -444,6 +471,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     setResponsiveWidth(popupWidth);
     setResponsiveHeight(popupHeight);
     setShowPopup(false);
+    setSourceHref(null);
   };
 
   // Handle custom footnote popup event from iframe event
@@ -454,6 +482,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     // This popup shows text synthesized from a data/alt attribute in the host
     // document: there is no book document behind it, so no CFI mapping.
     footnoteViewRef.current = null;
+    setSourceHref(null);
     resetPopupAnnotationState();
     const rect = gridFrame.getBoundingClientRect();
     const viewSettings = getViewSettings(bookKey)!;
@@ -607,23 +636,37 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
         className='select-text overflow-y-auto'
         onDismiss={handleDismissPopup}
       >
-        {canGoBack && (
+        {(canGoBack || sourceHref) && (
           <div
             className={clsx(
-              'absolute flex h-8 w-full pt-2',
-              viewSettings.vertical ? 'justify-end pe-2' : 'justify-start ps-2',
+              'absolute z-10 flex gap-1',
+              viewSettings.vertical
+                ? 'end-0 top-0 h-full w-8 flex-col items-center pt-2'
+                : 'start-0 top-0 h-8 w-full items-center px-2',
             )}
           >
-            <button
-              type='button'
-              onClick={handleBack}
-              className={clsx(
-                'btn btn-ghost btn-circle eink-bordered text-base-content bg-base-200/80 hover:bg-base-200',
-                'z-10 h-8 min-h-8 w-8 p-0 shadow-xs',
-              )}
-            >
-              <MdArrowBack size={size18} />
-            </button>
+            {canGoBack && (
+              <button
+                type='button'
+                onClick={handleBack}
+                aria-label={_('Back')}
+                title={_('Back')}
+                className={chromeButtonClassName}
+              >
+                <MdArrowBack size={size18} />
+              </button>
+            )}
+            {sourceHref && (
+              <button
+                type='button'
+                onClick={handleGoToSource}
+                aria-label={_('Jump to Location')}
+                title={_('Jump to Location')}
+                className={clsx(chromeButtonClassName, !viewSettings.vertical && 'ms-auto')}
+              >
+                <MdOutlineArrowOutward size={size18} />
+              </button>
+            )}
           </div>
         )}
         <div

--- a/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
+++ b/apps/readest-app/src/app/reader/components/FootnotePopup.tsx
@@ -19,7 +19,7 @@ import { FootnoteHandler } from 'foliate-js/footnotes.js';
 import { mountAdditionalFonts, mountCustomFont } from '@/styles/fonts';
 import { eventDispatcher } from '@/utils/event';
 import { getCfiSpinePrefix } from '@/utils/cfi';
-import { shouldCheckAsFootnote } from '../utils/footnoteHeuristics';
+import { isLinkTargetVisible, shouldCheckAsFootnote } from '../utils/footnoteHeuristics';
 import { showTransientHighlight } from '../utils/transientHighlight';
 import { drawAnnotationOverlay } from '../utils/annotatorUtil';
 import {
@@ -95,9 +95,22 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     index: -1,
   });
   const [canGoBack, setCanGoBack] = useState(false);
-  // The book location the popup is currently showing. Only popups backed by a
-  // book document have one, so this doubles as the gate for the jump button.
+  // The book location the popup is currently showing, when that location is
+  // somewhere the reader can actually be taken. Null for a popup with no book
+  // document behind it, and for a target the stylesheet hides, so this doubles
+  // as the gate for the jump button. The ref holds the same verdict taken at
+  // click time, which is early enough for `before-render` to decide whether
+  // the document has to leave room for the chrome; `render` recomputes it from
+  // the href it is handed rather than trusting the ref to still match.
   const [sourceHref, setSourceHref] = useState<string | null>(null);
+  const jumpHrefRef = useRef<string | null>(null);
+
+  // Inline footnote bodies are hidden by the reader's own stylesheet, so a
+  // link pointing at one has nowhere to take the reader and earns no button.
+  const getJumpHref = (href: string | undefined | null) => {
+    const mainView = getView(bookKey);
+    return href && mainView && isLinkTargetVisible(mainView, href) ? href : null;
+  };
   const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // A link that jumps in-page instead of opening a popup (undetected or
@@ -175,6 +188,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
         const items = [...history.items.slice(0, history.index + 1), popupLinkDetail];
         historyRef.current = { items, index: items.length - 1 };
         setCanGoBack(true);
+        jumpHrefRef.current = getJumpHref(popupLinkDetail.href);
         footnoteHandler.handle(bookDoc, e)?.catch((err) => {
           console.warn(err);
           getView(bookKey)?.goTo(popupLinkDetail.href);
@@ -304,13 +318,17 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       const footnoteStyles = getFootnoteStyles();
       // The chrome strip (jump-to-location, plus Back once a link has been
       // followed) floats over the popup document, so the text has to start
-      // clear of it. A scrolled renderer ignores its `margin-*` attributes —
-      // it only publishes them as CSS variables — so reserve the strip in the
-      // document's own padding instead. `padding-block-start` lands on top in
-      // horizontal writing and on the right in vertical, which is where the
-      // strip sits in each mode.
-      const chromeStyles = `body { padding-block-start: calc(1em + ${chromeSize}px) !important; }`;
-      renderer.setStyles?.(`${mainStyles}\n${footnoteStyles}\n${chromeStyles}`);
+      // clear of it — and only then, or a popup with no buttons opens under a
+      // band of dead space. A scrolled renderer ignores its `margin-*`
+      // attributes (it only publishes them as CSS variables), so reserve the
+      // strip in the document's own padding instead: `padding-block-start`
+      // lands on top in horizontal writing and on the right in vertical,
+      // which is where the strip sits in each mode.
+      const hasChrome = historyRef.current.index > 0 || !!jumpHrefRef.current;
+      const chromeStyles = hasChrome
+        ? `\nbody { padding-block-start: calc(1em + ${chromeSize}px) !important; }`
+        : '';
+      renderer.setStyles?.(`${mainStyles}\n${footnoteStyles}${chromeStyles}`);
     };
 
     const handleRender = (e: Event) => {
@@ -318,7 +336,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       // console.log('render footnote', detail);
       const { view, href, index, extract } = detail;
       footnoteHrefRef.current = href;
-      setSourceHref(href ?? null);
+      setSourceHref(getJumpHref(href));
       resetPopupAnnotationState({ index: index ?? -1, extract: extract ?? null });
       sizeAdjustCountRef.current = 0;
       view.addEventListener('relocate', () => {
@@ -411,6 +429,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
       detail['check'] = true;
     }
     historyRef.current = { items: [detail], index: 0 };
+    jumpHrefRef.current = getJumpHref(detail.href);
     setCanGoBack(false);
     const popupPromise = footnoteHandler.handle(bookDoc, event);
     if (popupPromise) {
@@ -434,6 +453,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     historyRef.current = { ...history, index: newIndex };
     setCanGoBack(newIndex > 0);
     const detail = history.items[newIndex]!;
+    jumpHrefRef.current = getJumpHref(detail['href'] as string | undefined);
     const syntheticEvent = new CustomEvent('link', {
       detail: { ...detail, follow: true },
       cancelable: true,
@@ -472,6 +492,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     setResponsiveHeight(popupHeight);
     setShowPopup(false);
     setSourceHref(null);
+    jumpHrefRef.current = null;
   };
 
   // Handle custom footnote popup event from iframe event
@@ -482,6 +503,7 @@ const FootnotePopup: React.FC<FootnotePopupProps> = ({ bookKey, bookDoc }) => {
     // This popup shows text synthesized from a data/alt attribute in the host
     // document: there is no book document behind it, so no CFI mapping.
     footnoteViewRef.current = null;
+    jumpHrefRef.current = null;
     setSourceHref(null);
     resetPopupAnnotationState();
     const rect = gridFrame.getBoundingClientRect();

--- a/apps/readest-app/src/app/reader/utils/footnoteHeuristics.ts
+++ b/apps/readest-app/src/app/reader/utils/footnoteHeuristics.ts
@@ -1,3 +1,5 @@
+import type { FoliateView } from '@/types/view';
+
 // Heuristically classify a link as a possible footnote marker based on its
 // text content. The bare numeric pattern matches things like `1`, `12`, `a1`,
 // `[1`, which are common when a book formats footnotes as plain digits.
@@ -37,4 +39,39 @@ export const shouldCheckAsFootnote = (anchor: HTMLAnchorElement): boolean => {
     container = container.parentElement;
   }
   return true;
+};
+
+// The reader hides inline footnote bodies in `getLayoutStyles`
+// (`.duokan-footnote-content`, `.epubtype-footnote`, `aside[epub|type~=note]`
+// and friends), so a link pointing at one leads to a spot the reader cannot
+// see. Report whether a link target is somewhere worth being taken to, so the
+// footnote popup can withhold its jump button (#5766).
+export const isLinkTargetVisible = (view: FoliateView, href: string): boolean => {
+  try {
+    const { index, anchor } = view.resolveNavigation(href);
+    const doc = view.renderer.getContents().find((content) => content.index === index)?.doc;
+    // An inline footnote body always sits beside its reference, so it is always
+    // in a rendered section. Anything else is a real destination, and loading
+    // its section just to measure would stall the popup.
+    if (!doc || !anchor) return true;
+    const resolved = anchor(doc) as unknown;
+    if (!resolved || typeof resolved === 'number') return true;
+    const node =
+      typeof resolved === 'object' && 'startContainer' in resolved
+        ? (resolved as Range).startContainer
+        : (resolved as Node);
+    let element = node.nodeType === 1 ? (node as Element) : node.parentElement;
+    // Walk the ancestors rather than measuring boxes: footnote targets are
+    // often empty inline anchors that have no box of their own even when the
+    // paragraph around them is on the page.
+    const window = doc.defaultView;
+    while (element && window) {
+      const { display, visibility } = window.getComputedStyle(element);
+      if (display === 'none' || visibility === 'hidden') return false;
+      element = element.parentElement;
+    }
+    return true;
+  } catch {
+    return true;
+  }
 };


### PR DESCRIPTION
Closes #5766

## Problem

A footnote popup that stands in for an appendix or a long section only ever shows that section's heading: foliate finds no better fragment than the target element, so it falls through to `selectNode`. Following a link inside the popup keeps rendering in the popup by design (#559), so there was no way out to the page itself.

The reporter asked for a way to reach the real location, both for a truncated appendix reference and for a note's backlink when they want the surrounding context.

## What this does

Adds a jump button to the popup chrome, opposite the existing Back button. It navigates the book view to whatever the popup is currently showing, flashes the target with the transient highlight the popup already uses on its failure path, and dismisses the popup. `view.history.back()` is on the footer bar, so the jump is recoverable.

Because it uses the popup's *current* href, one gesture covers both asks: a title-only appendix popup, and the nested target after following a link inside the popup.

### The button only appears where the target is visible

The reader's own stylesheet hides inline footnote bodies (`.duokan-footnote-content`, `.epubtype-footnote`, `aside[epub|type~=note]` and friends). For the many books that keep a note beside its reference, jumping there would land on something the reader can never see, so `isLinkTargetVisible` gates the button: resolve the href, find the rendered section, and walk the target's ancestors for `display: none` / `visibility: hidden`. It walks ancestors rather than measuring boxes because footnote targets are usually empty inline anchors with no box of their own even when visible. A target whose section is not rendered yet is a real destination and stays allowed.

### Two layout fixes fell out of this

`renderer.setAttribute('margin-top', ...)` never did anything for this popup: a scrolled paginator only publishes its margins as CSS variables. Worse, setting it to a non-zero value breaks the popup outright. The popup box starts at 88px, the paginator turns the margin into a grid row, and the leftover space drives an endless expand/resize cycle (4400+ `ResizeObserver loop completed with undelivered notifications`), so `relocate` never delivers and the popup never opens. The margins are now pinned to zero.

The chrome floats over the text instead, inset equally from the top and the side, with the row set to `pointer-events: none` so it cannot swallow taps meant for the words beneath it.

## Testing

`pnpm test` (10146 pass, 9 new), `pnpm lint`, `pnpm format:check`.

Verified in Chrome against a purpose-built EPUB and against a real book with inline duokan footnotes:

- footnote marker opens the popup, button clear of the text
- a cross-reference inside the popup reproduces the reported title-only popup; the button lands the main view on the appendix with its full text
- an inline hidden footnote body gets no button and no dead space
- backlinks still jump in place with a flash, unchanged
- both buttons sit at a symmetric 9px inset in horizontal writing, and stack in the right-hand strip in vertical

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a translated “Jump to Location” action for footnotes with available source locations.
  * Improved navigation between nested footnote popups.
  * Synthetic footnotes now correctly omit unavailable source-navigation options.

* **Bug Fixes**
  * Hidden or unavailable footnote targets are handled more reliably.
  * Improved popup navigation controls and spacing without shifting content.
  * Refined visibility handling for footnote links in rendered sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->