### PR TITLE
feat(library): select chapters when importing web novels

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/import-novel-dialog.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/import-novel-dialog.test.tsx
@@ -129,6 +129,13 @@ describe('ImportNovelDialog', () => {
     expect(chapterCheckboxes.every((checkbox) => (checkbox as HTMLInputElement).checked)).toBe(
       true,
     );
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Book title' }), {
+      target: { value: '   ' },
+    });
+    expect((screen.getByRole('button', { name: 'Import' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
   });
 
   it('downloads only selected chapters under the chosen book title', async () => {
@@ -136,7 +143,7 @@ describe('ImportNovelDialog', () => {
     await goToPreview();
 
     const titleInput = screen.getByRole('textbox', { name: 'Book title' }) as HTMLInputElement;
-    expect(titleInput.value).toBe('My Novel');
+    expect(titleInput.value).toBe('My Novel Chapters 1 - 6');
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Chapter 1' }));
     expect(titleInput.value).toBe('My Novel Chapters 2 - 6');
@@ -153,8 +160,62 @@ describe('ImportNovelDialog', () => {
         chapters: toc.chapters.slice(2),
       },
       'https://n.example.org/toc',
-      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      expect.objectContaining({
+        identityKey: [
+          'https://n.example.org/toc',
+          ...toc.chapters.slice(2).map((chapter) => chapter.url),
+        ].join('\n'),
+        signal: expect.any(AbortSignal),
+      }),
     );
+  });
+
+  it('suggests titles for single and non-contiguous chapter selections', async () => {
+    setup();
+    await goToPreview();
+
+    const titleInput = screen.getByRole('textbox', { name: 'Book title' }) as HTMLInputElement;
+    fireEvent.click(screen.getByRole('button', { name: 'Deselect all' }));
+    expect(titleInput.value).toBe('My Novel');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Chapter 2' }));
+    expect(titleInput.value).toBe('My Novel Chapter 2');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Chapter 4' }));
+    expect(titleInput.value).toBe('My Novel (2 chapters)');
+  });
+
+  it('sets download progress to the selected chapter count', async () => {
+    downloadNovelMock.mockImplementation(() => new Promise(() => {}));
+    setup();
+    await goToPreview();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Chapter 1' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Chapter 2' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await screen.findByText('Downloading chapters…');
+    expect(screen.getByText('0 / 4')).toBeTruthy();
+  });
+
+  it('resets selection and title suggestions when reopened', async () => {
+    const { onClose, onImport, rerender } = setup();
+    await goToPreview();
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Chapter 1' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Book title' }), {
+      target: { value: 'Custom Volume' },
+    });
+
+    rerender(<ImportNovelDialog isOpen={false} onClose={onClose} onImport={onImport} />);
+    rerender(<ImportNovelDialog isOpen onClose={onClose} onImport={onImport} />);
+    await goToPreview();
+
+    const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+    expect(checkboxes.every((checkbox) => checkbox.checked)).toBe(true);
+    const titleInput = screen.getByRole('textbox', { name: 'Book title' }) as HTMLInputElement;
+    expect(titleInput.value).toBe('My Novel Chapters 1 - 6');
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Chapter 1' }));
+    expect(titleInput.value).toBe('My Novel Chapters 2 - 6');
   });
 
   it('downloads on Import and hands the file to onImport', async () => {
@@ -162,6 +223,11 @@ describe('ImportNovelDialog', () => {
     await goToPreview();
     fireEvent.click(screen.getByText('Import'));
     await waitFor(() => expect(onImport).toHaveBeenCalledWith(book.file));
+    expect(downloadNovelMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'My Novel Chapters 1 - 6' }),
+      'https://n.example.org/toc',
+      expect.objectContaining({ identityKey: 'https://n.example.org/toc' }),
+    );
     expect(onClose).toHaveBeenCalled();
   });
 

--- a/apps/readest-app/src/__tests__/app/library/import-novel-dialog.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/import-novel-dialog.test.tsx
@@ -105,6 +105,58 @@ describe('ImportNovelDialog', () => {
     expect(screen.getByText('Chapter 6')).toBeTruthy();
   });
 
+  it('selects every discovered chapter by default and toggles the whole list', async () => {
+    setup();
+    await goToPreview();
+
+    const chapterCheckboxes = screen.getAllByRole('checkbox');
+    expect(chapterCheckboxes).toHaveLength(6);
+    expect(chapterCheckboxes.every((checkbox) => (checkbox as HTMLInputElement).checked)).toBe(
+      true,
+    );
+    expect(screen.getByText('6 selected')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deselect all' }));
+    expect(chapterCheckboxes.every((checkbox) => !(checkbox as HTMLInputElement).checked)).toBe(
+      true,
+    );
+    expect(screen.getByText('0 selected')).toBeTruthy();
+    expect((screen.getByRole('button', { name: 'Import' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
+    expect(chapterCheckboxes.every((checkbox) => (checkbox as HTMLInputElement).checked)).toBe(
+      true,
+    );
+  });
+
+  it('downloads only selected chapters under the chosen book title', async () => {
+    setup();
+    await goToPreview();
+
+    const titleInput = screen.getByRole('textbox', { name: 'Book title' }) as HTMLInputElement;
+    expect(titleInput.value).toBe('My Novel');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Chapter 1' }));
+    expect(titleInput.value).toBe('My Novel Chapters 2 - 6');
+    fireEvent.change(titleInput, { target: { value: 'My Novel Volume 2' } });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Chapter 2' }));
+    expect(titleInput.value).toBe('My Novel Volume 2');
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() => expect(downloadNovelMock).toHaveBeenCalled());
+    expect(downloadNovelMock).toHaveBeenCalledWith(
+      {
+        ...toc,
+        title: 'My Novel Volume 2',
+        chapters: toc.chapters.slice(2),
+      },
+      'https://n.example.org/toc',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
   it('downloads on Import and hands the file to onImport', async () => {
     const { onClose, onImport } = setup();
     await goToPreview();

--- a/apps/readest-app/src/__tests__/components/daisyui-v5-tokens.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/daisyui-v5-tokens.browser.test.tsx
@@ -78,6 +78,7 @@ describe('daisyUI 5 theme tokens', () => {
         <input data-testid='toggle' type='checkbox' className='toggle' defaultChecked />
         <input data-testid='toggle-sm' type='checkbox' className='toggle toggle-sm' />
         <input data-testid='toggle-xs' type='checkbox' className='toggle toggle-xs' />
+        <span data-testid='loading-lg' className='loading loading-dots loading-lg' />
       </>,
     );
     const box = (id: string) => getByTestId(id).getBoundingClientRect();
@@ -98,6 +99,8 @@ describe('daisyUI 5 theme tokens', () => {
     // Each size has its own v4 width, so the base pin must not flatten them.
     expect([box('toggle-sm').width, box('toggle-sm').height]).toEqual([32, 20]);
     expect([box('toggle-xs').width, box('toggle-xs').height]).toEqual([24, 16]);
+    // daisyUI 5 shrank `loading-lg` from 2.5rem to 1.75rem.
+    expect(box('loading-lg').width).toBe(40);
   });
 
   it('keeps the Tailwind 3 default palette', () => {

--- a/apps/readest-app/src/__tests__/hooks/useWebBrowserDownloads.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useWebBrowserDownloads.test.tsx
@@ -1,15 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 
-const { subscribeMock, setStatusMock, ingestMock, updateBooksMock, dispatchMock } = vi.hoisted(
-  () => ({
-    subscribeMock: vi.fn(),
-    setStatusMock: vi.fn(),
-    ingestMock: vi.fn(),
-    updateBooksMock: vi.fn(),
-    dispatchMock: vi.fn(),
-  }),
-);
+const {
+  subscribeMock,
+  setStatusMock,
+  ingestMock,
+  updateBooksMock,
+  dispatchMock,
+  isTauriAppPlatformMock,
+} = vi.hoisted(() => ({
+  subscribeMock: vi.fn(),
+  setStatusMock: vi.fn(),
+  ingestMock: vi.fn(),
+  updateBooksMock: vi.fn(),
+  dispatchMock: vi.fn(),
+  isTauriAppPlatformMock: vi.fn(),
+}));
 
 vi.mock('@/services/webBrowser/webBrowser', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/services/webBrowser/webBrowser')>();
@@ -20,6 +26,7 @@ vi.mock('@/services/webBrowser/webBrowser', async (importOriginal) => {
   };
 });
 vi.mock('@/services/ingestService', () => ({ ingestFile: ingestMock }));
+vi.mock('@/services/environment', () => ({ isTauriAppPlatform: isTauriAppPlatformMock }));
 vi.mock('@/utils/event', () => ({ eventDispatcher: { dispatch: dispatchMock } }));
 vi.mock('@/hooks/useTranslation', () => ({ useTranslation: () => (k: string) => k }));
 vi.mock('@/context/EnvContext', () => ({
@@ -55,6 +62,7 @@ beforeEach(() => {
   ingestMock.mockReset();
   updateBooksMock.mockReset().mockResolvedValue(undefined);
   dispatchMock.mockReset();
+  isTauriAppPlatformMock.mockReset().mockReturnValue(true);
 });
 
 async function mountAndGetHandler(): Promise<Handler> {
@@ -69,6 +77,15 @@ async function mountAndGetHandler(): Promise<Handler> {
 }
 
 describe('useWebBrowserDownloads', () => {
+  it('does not subscribe to Tauri download events in the web app', () => {
+    isTauriAppPlatformMock.mockReturnValue(false);
+    subscribeMock.mockResolvedValue(() => {});
+
+    renderHook(() => useWebBrowserDownloads());
+
+    expect(subscribeMock).not.toHaveBeenCalled();
+  });
+
   it('imports a supported download into the current group and reports added', async () => {
     ingestMock.mockResolvedValue({ hash: 'h1', title: 'Dune' });
     const handler = await mountAndGetHandler();

--- a/apps/readest-app/src/__tests__/services/novel/novel-import.test.ts
+++ b/apps/readest-app/src/__tests__/services/novel/novel-import.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { configureZip } from '@/utils/zip';
 import { downloadNovel, fetchNovelToc, isNovelImportCancelled } from '@/services/novel/novelImport';
+import { stableIdentifier } from '@/services/send/conversion/convertToEpub';
 import { ConversionError } from '@/services/send/conversion/types';
 import type { NovelToc } from '@/services/novel/chapterList';
 
@@ -96,6 +97,9 @@ describe('downloadNovel', () => {
     const opf = files.get('content.opf')!;
     expect(opf).toContain('<dc:title>My Novel</dc:title>');
     expect(opf).toContain('<dc:creator>Author X</dc:creator>');
+    expect(opf).toContain(
+      `<dc:identifier id="book-id">${stableIdentifier(TOC_URL)}</dc:identifier>`,
+    );
     for (let n = 1; n <= 6; n++) {
       const xhtml = files.get(`OEBPS/chapter${n}.xhtml`)!;
       expect(xhtml).toContain(`<h1>Chapter ${n}: Part ${n}</h1>`);
@@ -104,6 +108,36 @@ describe('downloadNovel', () => {
     // toc.ncx lists every chapter
     const ncx = files.get('toc.ncx')!;
     expect(ncx).toContain('Chapter 6: Part 6');
+  });
+
+  it('uses a selection identity to distinguish volumes from the same chapter list', async () => {
+    const firstChapters = toc().chapters.slice(0, 2);
+    const secondChapters = toc().chapters.slice(2, 4);
+    const firstIdentity = [TOC_URL, ...firstChapters.map((chapter) => chapter.url)].join('\n');
+    const secondIdentity = [TOC_URL, ...secondChapters.map((chapter) => chapter.url)].join('\n');
+
+    const [firstVolume, secondVolume] = await Promise.all([
+      downloadNovel(toc({ chapters: firstChapters }), TOC_URL, {
+        fetchPage: makeFetchPage(),
+        identityKey: firstIdentity,
+      }),
+      downloadNovel(toc({ chapters: secondChapters }), TOC_URL, {
+        fetchPage: makeFetchPage(),
+        identityKey: secondIdentity,
+      }),
+    ]);
+    const [firstFiles, secondFiles] = await Promise.all([
+      unzipEpub(firstVolume.file),
+      unzipEpub(secondVolume.file),
+    ]);
+
+    expect(firstFiles.get('content.opf')).toContain(
+      `<dc:identifier id="book-id">${stableIdentifier(firstIdentity)}</dc:identifier>`,
+    );
+    expect(secondFiles.get('content.opf')).toContain(
+      `<dc:identifier id="book-id">${stableIdentifier(secondIdentity)}</dc:identifier>`,
+    );
+    expect(stableIdentifier(firstIdentity)).not.toBe(stableIdentifier(secondIdentity));
   });
 
   it('strips images from chapter content', async () => {

--- a/apps/readest-app/src/app/library/components/ImportNovelDialog.tsx
+++ b/apps/readest-app/src/app/library/components/ImportNovelDialog.tsx
@@ -71,7 +71,7 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
   };
 
   const suggestedBookTitle = (novel: NovelToc, selected: Set<number>): string => {
-    if (selected.size === 0 || selected.size === novel.chapters.length) return novel.title;
+    if (selected.size === 0) return novel.title;
 
     const indexes = [...selected].sort((a, b) => a - b);
     const first = indexes[0]! + 1;
@@ -113,7 +113,7 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
       setToc(parsed);
       setSourceUrl(target);
       setSelectedChapterIndexes(selected);
-      setBookTitle(parsed.title);
+      setBookTitle(suggestedBookTitle(parsed, selected));
       setTitleEdited(false);
       setPhase('preview');
     } catch (e) {
@@ -129,6 +129,10 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
     const title = bookTitle.trim();
     if (selectedChapters.length === 0 || !title) return;
     const selectedToc = { ...toc, title, chapters: selectedChapters };
+    const identityKey =
+      selectedChapters.length === toc.chapters.length
+        ? sourceUrl
+        : [sourceUrl, ...selectedChapters.map((chapter) => chapter.url)].join('\n');
     const controller = new AbortController();
     abortRef.current = controller;
     setPhase('downloading');
@@ -137,6 +141,7 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
     try {
       const book = await downloadNovel(selectedToc, sourceUrl, {
         signal: controller.signal,
+        identityKey,
         translate: _,
         onProgress: (done, total) => setProgress({ done, total }),
       });

--- a/apps/readest-app/src/app/library/components/ImportNovelDialog.tsx
+++ b/apps/readest-app/src/app/library/components/ImportNovelDialog.tsx
@@ -33,7 +33,14 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [progress, setProgress] = useState({ done: 0, total: 0 });
+  const [selectedChapterIndexes, setSelectedChapterIndexes] = useState<Set<number>>(
+    () => new Set(),
+  );
+  const [bookTitle, setBookTitle] = useState('');
+  const [titleEdited, setTitleEdited] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+
+  const chapters = toc?.chapters ?? [];
 
   // Reset transient state every time the dialog reopens.
   useEffect(() => {
@@ -45,6 +52,9 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
     setBusy(false);
     setError(null);
     setProgress({ done: 0, total: 0 });
+    setSelectedChapterIndexes(new Set());
+    setBookTitle('');
+    setTitleEdited(false);
   }, [isOpen]);
 
   const close = () => {
@@ -60,6 +70,35 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
     setError(message);
   };
 
+  const suggestedBookTitle = (novel: NovelToc, selected: Set<number>): string => {
+    if (selected.size === 0 || selected.size === novel.chapters.length) return novel.title;
+
+    const indexes = [...selected].sort((a, b) => a - b);
+    const first = indexes[0]! + 1;
+    const last = indexes[indexes.length - 1]! + 1;
+    if (indexes.length === 1) {
+      return _('{{title}} Chapter {{chapter}}', { title: novel.title, chapter: first });
+    }
+    if (
+      indexes.every((index, position) => position === 0 || index === indexes[position - 1]! + 1)
+    ) {
+      return _('{{title}} Chapters {{first}} - {{last}}', {
+        title: novel.title,
+        first,
+        last,
+      });
+    }
+    return _('{{title}} ({{count}} chapters)', {
+      title: novel.title,
+      count: indexes.length,
+    });
+  };
+
+  const updateChapterSelection = (selected: Set<number>) => {
+    setSelectedChapterIndexes(selected);
+    if (toc && !titleEdited) setBookTitle(suggestedBookTitle(toc, selected));
+  };
+
   const fetchToc = async () => {
     const target = url.trim();
     if (!/^https?:\/\//i.test(target)) {
@@ -70,8 +109,12 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
     setError(null);
     try {
       const parsed = await fetchNovelToc(target);
+      const selected = new Set(parsed.chapters.map((_, index) => index));
       setToc(parsed);
       setSourceUrl(target);
+      setSelectedChapterIndexes(selected);
+      setBookTitle(parsed.title);
+      setTitleEdited(false);
       setPhase('preview');
     } catch (e) {
       surfaceError(e);
@@ -82,13 +125,17 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
 
   const startDownload = async () => {
     if (!toc) return;
+    const selectedChapters = toc.chapters.filter((_, index) => selectedChapterIndexes.has(index));
+    const title = bookTitle.trim();
+    if (selectedChapters.length === 0 || !title) return;
+    const selectedToc = { ...toc, title, chapters: selectedChapters };
     const controller = new AbortController();
     abortRef.current = controller;
     setPhase('downloading');
     setError(null);
-    setProgress({ done: 0, total: toc.chapters.length });
+    setProgress({ done: 0, total: selectedChapters.length });
     try {
-      const book = await downloadNovel(toc, sourceUrl, {
+      const book = await downloadNovel(selectedToc, sourceUrl, {
         signal: controller.signal,
         translate: _,
         onProgress: (done, total) => setProgress({ done, total }),
@@ -125,9 +172,8 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
     }
   };
 
-  const chapters = toc?.chapters ?? [];
-  const firstChapter = chapters[0];
-  const lastChapter = chapters[chapters.length - 1];
+  const allChaptersSelected =
+    chapters.length > 0 && selectedChapterIndexes.size === chapters.length;
 
   return (
     <Dialog
@@ -195,13 +241,62 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
                 {_('{{count}} chapters', { count: chapters.length })}
               </span>
             </div>
-            {firstChapter && lastChapter && (
-              <div className='text-base-content/60 flex flex-col gap-1 text-sm leading-relaxed'>
-                <span className='truncate'>{firstChapter.title}</span>
-                {chapters.length > 2 && <span>…</span>}
-                {chapters.length > 1 && <span className='truncate'>{lastChapter.title}</span>}
-              </div>
-            )}
+            <div className='flex flex-col gap-1.5'>
+              <label className='text-base-content/70 text-xs' htmlFor='novel-book-title'>
+                {_('Book title')}
+              </label>
+              <input
+                id='novel-book-title'
+                type='text'
+                className='input eink-bordered w-full'
+                value={bookTitle}
+                onChange={(e) => {
+                  setBookTitle(e.target.value);
+                  setTitleEdited(true);
+                }}
+              />
+            </div>
+            <div className='flex items-center justify-between gap-3'>
+              <span className='text-base-content/60 text-sm' aria-live='polite'>
+                {_('{{n}} selected', { n: selectedChapterIndexes.size })}
+              </span>
+              <button
+                type='button'
+                className='btn btn-ghost btn-xs eink-bordered touch-target'
+                onClick={() => {
+                  updateChapterSelection(
+                    allChaptersSelected ? new Set() : new Set(chapters.map((_, index) => index)),
+                  );
+                }}
+              >
+                {allChaptersSelected ? _('Deselect all') : _('Select all')}
+              </button>
+            </div>
+            <div
+              className='eink-bordered border-base-200 bg-base-100 max-h-64 overflow-y-auto overscroll-contain rounded-lg border'
+              role='group'
+              aria-label={_('Chapters')}
+            >
+              {chapters.map((chapter, index) => (
+                <label
+                  key={`${chapter.url}-${index}`}
+                  className='border-base-200 hover:bg-base-200/60 flex min-h-11 cursor-pointer items-center gap-3 border-b px-3 py-2 transition-colors duration-150 last:border-b-0'
+                >
+                  <input
+                    type='checkbox'
+                    className='checkbox checkbox-sm shrink-0'
+                    checked={selectedChapterIndexes.has(index)}
+                    onChange={() => {
+                      const selected = new Set(selectedChapterIndexes);
+                      if (selected.has(index)) selected.delete(index);
+                      else selected.add(index);
+                      updateChapterSelection(selected);
+                    }}
+                  />
+                  <span className='min-w-0 break-words text-sm'>{chapter.title}</span>
+                </label>
+              ))}
+            </div>
             {error && <p className='text-error text-sm leading-relaxed'>{error}</p>}
             <div className='flex justify-end gap-2 pt-1'>
               <button
@@ -218,6 +313,7 @@ const ImportNovelDialog: React.FC<ImportNovelDialogProps> = ({ isOpen, onClose, 
                 type='button'
                 className='btn btn-contrast btn-sm'
                 onClick={() => void startDownload()}
+                disabled={selectedChapterIndexes.size === 0 || !bookTitle.trim()}
               >
                 <MdMenuBook className='h-4 w-4' />
                 {_('Import')}

--- a/apps/readest-app/src/hooks/useWebBrowserDownloads.ts
+++ b/apps/readest-app/src/hooks/useWebBrowserDownloads.ts
@@ -4,6 +4,7 @@ import { useAuth } from '@/context/AuthContext';
 import { useEnv } from '@/context/EnvContext';
 import { useLibraryStore } from '@/store/libraryStore';
 import { useSettingsStore } from '@/store/settingsStore';
+import { isTauriAppPlatform } from '@/services/environment';
 import { ingestFile } from '@/services/ingestService';
 import {
   isSupportedBookDownload,
@@ -79,7 +80,7 @@ export function useWebBrowserDownloads() {
   handlerRef.current = handleDownload;
 
   useEffect(() => {
-    if (!appService) return;
+    if (!isTauriAppPlatform() || !appService) return;
     let dispose: (() => void) | null = null;
     let cancelled = false;
     subscribeWebBrowserDownloads(!!appService.isMobileApp, (download) => {

--- a/apps/readest-app/src/services/novel/novelImport.ts
+++ b/apps/readest-app/src/services/novel/novelImport.ts
@@ -49,6 +49,9 @@ export interface NovelBook extends ConvertedBook {
 export interface NovelDownloadOptions {
   onProgress?: (done: number, total: number) => void;
   signal?: AbortSignal;
+  /** Stable input for the EPUB identifier. Defaults to the chapter-list URL;
+   *  selected volumes supply their chapter URLs so each volume stays distinct. */
+  identityKey?: string;
   fetchPage?: FetchPage;
   fetchCover?: FetchCover;
   /** Runtime translator for text baked into the EPUB (failure placeholders).
@@ -283,7 +286,7 @@ export async function downloadNovel(
   const fetchPage = withTransientRetry(options.fetchPage ?? defaultFetchPage);
   const fetchCover = options.fetchCover ?? defaultFetchCover;
   const translate = options.translate ?? ((key: string) => key);
-  const { onProgress, signal } = options;
+  const { onProgress, signal, identityKey = sourceUrl } = options;
 
   const chapters = toc.chapters.slice(0, MAX_NOVEL_CHAPTERS);
   const total = chapters.length;
@@ -368,7 +371,7 @@ export async function downloadNovel(
       title: toc.title,
       author: toc.author,
       language,
-      identifier: stableIdentifier(sourceUrl),
+      identifier: stableIdentifier(identityKey),
     },
     [],
     cover,

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -791,6 +791,10 @@
     --font-size-min: 0.75rem;
   }
 
+  :where(.loading-lg) {
+    width: 2.5rem;
+  }
+
   :where(.checkbox) {
     border-radius: var(--radius-field);
   }


### PR DESCRIPTION
## Summary

- Choose individual web-novel chapters, select or deselect all, use range-aware editable titles, and keep separately imported volumes distinct.
- Skip the Tauri download event subscription in the web build, removing the `getCurrentWindow().listen` console error.
- Restore daisyUI v4's 40px `loading-lg` three-dot indicator size.

Closes #5696

## Test Coverage

```text
CODE PATHS
[+] ImportNovelDialog.tsx
  ├── [★★★ TESTED] fetched TOC selects all chapters and generates full-range title
  ├── suggestedBookTitle()
  │   ├── [★★★ TESTED] zero selected -> original novel title
  │   ├── [★★★ TESTED] one selected -> singular Chapter N
  │   ├── [★★★ TESTED] contiguous selection -> Chapters first - last
  │   └── [★★★ TESTED] noncontiguous selection -> N chapters
  ├── updateChapterSelection()
  │   ├── [★★★ TESTED] untouched title regenerates with selection
  │   └── [★★★ TESTED] manually edited title remains unchanged
  ├── selection controls
  │   ├── [★★★ TESTED] all -> deselect all
  │   ├── [★★ TESTED] none/subset -> select all
  │   ├── [★★★ TESTED] checked chapter -> remove
  │   └── [★★★ TESTED] unchecked chapter -> add
  ├── startDownload()
  │   ├── [★★★ TESTED] zero chapters or blank title blocks Import
  │   ├── [★★★ TESTED] ordered subset and chosen title reach downloader
  │   ├── [★★★ TESTED] full selection keeps source URL identity
  │   ├── [★★★ TESTED] partial selection includes chapter URLs in identity
  │   └── [★★★ TESTED] selected subset initializes visible progress total
  └── [★★★ TESTED] close/reopen resets selection, title, and titleEdited state
[+] useWebBrowserDownloads.ts
  ├── [★★★ TESTED] web platform returns without Tauri subscription
  └── [★★★ TESTED] Tauri platform still subscribes and imports downloads
[+] novelImport.ts
  ├── [★★★ TESTED] omitted identityKey defaults to source URL
  └── [★★★ TESTED] explicit volume identities produce distinct EPUB identifiers
[+] globals.css
  └── [★★★ TESTED] loading-lg compiles to 40px in a real browser

USER FLOWS
[+] Web-novel volume import
  ├── [★★ TESTED] fetch -> preview list with all chapters selected
  ├── [★★★ TESTED] full, contiguous, singular, and disjoint title suggestions
  ├── [★★★ TESTED] manual rename survives later selection changes
  ├── [★★★ TESTED] deselect all blocks Import; select all recovers
  ├── [★★★ TESTED] chosen subset, title, and identity cross the downloader seam
  ├── [★★ TESTED] successful import reaches onImport and closes
  ├── [★★★ TESTED] cancellation returns to preview
  ├── [★★★ TESTED] total download failure surfaces an error
  └── [★★★ TESTED] two partial volumes from one TOC receive distinct EPUB IDs
[+] Platform and shared UI
  ├── [★★★ TESTED] web skips native listener while Tauri behavior remains active
  ├── [★★★ TESTED] large loading dots retain their prior browser size
  └── [★★★ TESTED] [→E2E] 30-chapter list overflows and scrolls Chapter 30 into view

COVERAGE: 35/35 paths tested (100%) | Code paths: 23/23 (100%) | User flows: 12/12 (100%)
QUALITY: ★★★:31 ★★:4 ★:0 | GAPS: 0 (0 E2E, 0 eval)
```

Legend: ★★★ behavior + edge/error | ★★ happy path | ★ smoke check | [→E2E] browser/integration coverage

Tests: 912 → 912 (+0 files)

## Pre-Landing Review

No issues found after the two review findings (range title and volume identity) were fixed and re-reviewed.

## Design Review

No issues found. Google Chrome verification passed on desktop, mobile, and e-ink.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN.

## Plan Completion

No plan file detected.

## Verification Results

- Google Chrome: 8/8 browser checks passed.
- Full Vitest: 10,142 passed, 16 skipped.
- Lint and type checks: passed.
- Web production build: passed.
- Tauri production build: passed.

## TODOS

No related TODO items completed in this PR.

## Test plan

- [x] Select or deselect chapters and verify generated full, contiguous, singular, and disjoint titles
- [x] Preserve a manual title and import only the selected chapters
- [x] Keep separate volumes from the same TOC on distinct EPUB identifiers
- [x] Verify the web build does not subscribe to Tauri window events
- [x] Verify 40px loading dots and long-list scrolling in Google Chrome
- [x] Run unit, lint/type, web build, and Tauri build gates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added editable titles when importing novels.
  * Added per-chapter selection, including select-all and deselect-all controls.
  * Import progress now reflects selected chapters.
  * Generated books receive distinct identities when importing different chapter selections.

* **Bug Fixes**
  * Prevented importing without a title or selected chapters.
  * Download event handling is now limited to supported app environments.
  * Corrected the size of large loading indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->