### PR TITLE
fix(ui): size toasts to their message and fade dialogs out whole

### DIFF
--- a/apps/readest-app/src/__tests__/app/player/PlayerView.test.tsx
+++ b/apps/readest-app/src/__tests__/app/player/PlayerView.test.tsx
@@ -313,7 +313,9 @@ describe('PlayerView embedded Episodes subview', () => {
     );
 
     await waitFor(() => expect(screen.getByTestId('scrubber')).toBeTruthy());
-    expect(screen.queryByText('Episode Two')).toBeNull();
+    // The sheet fades out as one piece, so its rows outlive the close by the
+    // length of that transition rather than blanking on the spot.
+    await waitFor(() => expect(screen.queryByText('Episode Two')).toBeNull());
   });
 
   it('switches back to the transport view immediately when re-tapping the already-playing episode', async () => {

--- a/apps/readest-app/src/__tests__/components/dialog-close-body.test.tsx
+++ b/apps/readest-app/src/__tests__/components/dialog-close-body.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * A dialog must disappear in one piece.
+ *
+ * Every caller gates the dialog body on the same flag it passes as `isOpen`
+ * (`<Dialog isOpen={isOpen}>{isOpen && <Body />}</Dialog>`), so the body
+ * unmounted on the frame the close started while the modal box was still
+ * fading out: the box collapsed onto its title bar, which then faded away on
+ * its own. Keep the last body on screen until the close transition is over.
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (value: string) => value,
+}));
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: null }),
+}));
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({
+    systemUIVisible: false,
+    statusBarHeight: 0,
+    safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+  }),
+}));
+vi.mock('@/store/deviceStore', () => ({
+  useDeviceControlStore: () => ({
+    acquireBackKeyInterception: vi.fn(),
+    releaseBackKeyInterception: vi.fn(),
+  }),
+}));
+vi.mock('@tauri-apps/plugin-haptics', () => ({ impactFeedback: vi.fn() }));
+
+const { default: Dialog } = await import('@/components/Dialog');
+
+const Harness = ({ isOpen }: { isOpen: boolean }) => (
+  <Dialog isOpen={isOpen} title='About Readest' onClose={vi.fn()}>
+    {isOpen && <p>Version 0.12.1</p>}
+  </Dialog>
+);
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('Dialog close', () => {
+  it('keeps the body while the dialog fades out', () => {
+    const { rerender } = render(<Harness isOpen />);
+    expect(screen.getByText('Version 0.12.1')).toBeTruthy();
+
+    rerender(<Harness isOpen={false} />);
+    expect(screen.queryByText('Version 0.12.1')).toBeTruthy();
+
+    act(() => vi.advanceTimersByTime(300));
+    expect(screen.queryByText('Version 0.12.1')).toBeNull();
+  });
+
+  it('shows the new body when the dialog reopens', () => {
+    const { rerender } = render(<Harness isOpen />);
+    rerender(<Harness isOpen={false} />);
+    rerender(<Harness isOpen />);
+
+    act(() => vi.advanceTimersByTime(300));
+    expect(screen.getAllByText('Version 0.12.1')).toHaveLength(1);
+  });
+});

--- a/apps/readest-app/src/__tests__/components/dialog-close-frames.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/dialog-close-frames.browser.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * The dialog must never be painted without its body.
+ *
+ * Callers gate the body on the same flag they pass as `isOpen`, and Dialog
+ * holds the last body for the length of the close transition. That handoff has
+ * to land before the browser paints. A passive effect lands after it, so on a
+ * non-discrete update (a close from a promise or a frame callback rather than
+ * straight out of the click handler) the frame in between shows the box
+ * collapsed onto its title bar.
+ *
+ * Needs real frames and the real stylesheet, so it runs as a browser test.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { useEffect, useState } from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { page } from 'vitest/browser';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (value: string) => value,
+}));
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: null }),
+}));
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({
+    systemUIVisible: false,
+    statusBarHeight: 0,
+    safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+  }),
+}));
+vi.mock('@/store/deviceStore', () => ({
+  useDeviceControlStore: () => ({
+    acquireBackKeyInterception: vi.fn(),
+    releaseBackKeyInterception: vi.fn(),
+  }),
+}));
+vi.mock('@tauri-apps/plugin-haptics', () => ({ impactFeedback: vi.fn() }));
+
+const { default: Dialog } = await import('@/components/Dialog');
+await import('@/styles/globals.css');
+
+type Sample = { visible: boolean; body: boolean; height: number };
+
+const boxHeight = () => (document.querySelector('.modal-box') as HTMLElement).offsetHeight;
+
+const sample = (): Sample => {
+  const dialog = document.querySelector('dialog') as HTMLElement;
+  const box = document.querySelector('.modal-box') as HTMLElement;
+  return {
+    visible:
+      getComputedStyle(dialog).visibility === 'visible' &&
+      Number(getComputedStyle(box).opacity) > 0,
+    body: !!document.querySelector('[data-testid="dialog-body"]'),
+    // Not the bounding rect: daisyUI scales the box down as it leaves.
+    height: box.offsetHeight,
+  };
+};
+
+// Rendered after the dialog, so its passive effect runs in the same flush as
+// Dialog's own effects and sees every tree React commits on the way out. This
+// is the deterministic half of the guarantee: a frame sampler alone cannot say
+// whether the browser happened to paint a bad commit, but a bad commit that is
+// never built cannot be painted either.
+const CommitProbe = ({ onCommit }: { onCommit: (sample: Sample) => void }) => {
+  useEffect(() => {
+    onCommit(sample());
+  });
+  return null;
+};
+
+let setOpen: ((open: boolean) => void) | null = null;
+
+// `sm:h-auto` is what the About dialog passes, so the box takes its height
+// from the body and a missing body shows up as a collapse.
+const Harness = ({ onCommit }: { onCommit: (sample: Sample) => void }) => {
+  const [isOpen, setIsOpen] = useState(true);
+  setOpen = setIsOpen;
+  return (
+    <>
+      <Dialog
+        isOpen={isOpen}
+        title='About Readest'
+        boxClassName='sm:h-auto'
+        onClose={() => setIsOpen(false)}
+      >
+        {isOpen && <p data-testid='dialog-body'>Version 0.12.1</p>}
+      </Dialog>
+      <CommitProbe onCommit={onCommit} />
+    </>
+  );
+};
+
+const reactGlobal = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+// Close the dialog the way the app's own async paths do, outside React's act
+// environment: act would flush the passive effects for us and hide the very
+// ordering under test.
+const closeOutsideAct = async (settle: () => Promise<void>) => {
+  const wasActEnvironment = reactGlobal.IS_REACT_ACT_ENVIRONMENT;
+  reactGlobal.IS_REACT_ACT_ENVIRONMENT = false;
+  try {
+    // A default-priority update, the kind React is free to let the browser
+    // paint before it flushes passive effects.
+    requestAnimationFrame(() => setOpen?.(false));
+    await settle();
+  } finally {
+    reactGlobal.IS_REACT_ACT_ENVIRONMENT = wasActEnvironment;
+  }
+};
+
+const mount = async (onCommit: (sample: Sample) => void = () => {}) => {
+  await page.viewport(1024, 768);
+  render(<Harness onCommit={onCommit} />);
+  await new Promise((resolve) => setTimeout(resolve, 400));
+};
+
+afterEach(() => {
+  cleanup();
+  setOpen = null;
+});
+
+describe('Dialog close frames', () => {
+  it('leaves no commit with the box on screen and the body gone', async () => {
+    const commits: Sample[] = [];
+    await mount((commit) => commits.push(commit));
+    const openHeight = boxHeight();
+    expect(openHeight).toBeGreaterThan(0);
+
+    commits.length = 0;
+    await closeOutsideAct(() => new Promise((resolve) => setTimeout(resolve, 600)));
+
+    expect(commits.length).toBeGreaterThan(0);
+    const onScreen = commits.filter((commit) => commit.visible);
+    expect(onScreen.length).toBeGreaterThan(0);
+    expect(onScreen.filter((commit) => !commit.body)).toEqual([]);
+    expect(onScreen.filter((commit) => commit.height !== openHeight)).toEqual([]);
+  });
+
+  it('never paints the box without its body', async () => {
+    await mount();
+    const openHeight = boxHeight();
+
+    // Sample what each frame is about to paint: rAF callbacks run after layout
+    // and before the paint, so this is the frame the user sees.
+    const frames: Sample[] = [];
+    await closeOutsideAct(async () => {
+      const started = performance.now();
+      while (performance.now() - started < 600) {
+        await nextFrame();
+        frames.push(sample());
+      }
+    });
+
+    const onScreen = frames.filter((frame) => frame.visible);
+    expect(onScreen.length).toBeGreaterThan(0);
+    expect(onScreen.filter((frame) => !frame.body)).toEqual([]);
+    expect(onScreen.filter((frame) => frame.height !== openHeight)).toEqual([]);
+    // The hold is bounded: the body goes once the dialog is off screen.
+    expect(frames[frames.length - 1]?.body).toBe(false);
+  });
+});

--- a/apps/readest-app/src/__tests__/components/toast-layout.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/toast-layout.browser.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * A toast must size itself to its message and keep its distance from the top
+ * bar.
+ *
+ * daisyUI 4 gave `.toast` `min-width: fit-content` and `padding: 1rem`, so the
+ * component's own `w-auto` was a no-op and the alert sat 1rem below the `top`
+ * the component computes for the header. daisyUI 5 swapped the min-width for
+ * `width: max-content` and moved the padding into the insets: `w-auto` now
+ * wins over the width, and a fixed box with `inset-inline: 50%` (toast-center)
+ * and `width: auto` resolves to zero, collapsing every toast onto its icon.
+ *
+ * Needs real layout and real Tailwind, so it runs as a browser test.
+ */
+
+import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest';
+import { render, cleanup, act, screen, waitFor } from '@testing-library/react';
+import { page } from 'vitest/browser';
+
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({ safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 } }),
+}));
+
+const { Toast } = await import('@/components/Toast');
+const { eventDispatcher } = await import('@/utils/event');
+await import('@/styles/globals.css');
+
+// The offset the component computes for the reader/library top bar, plus the
+// 1rem `.toast` padding daisyUI 4 drew between that offset and the alert.
+const TOP_BAR = 44;
+const TOAST_GAP = 16;
+
+beforeAll(async () => {
+  await page.viewport(1024, 768);
+});
+
+afterEach(() => cleanup());
+
+// The toast fades and scales in over 300ms; measure it once it has landed.
+const showToast = async (detail: Record<string, unknown>) => {
+  render(<Toast />);
+  await act(async () => {
+    await eventDispatcher.dispatch('toast', detail);
+  });
+  const toast = document.querySelector('.toast') as HTMLElement;
+  await waitFor(() => expect(getComputedStyle(toast).opacity).toBe('1'));
+  return toast;
+};
+
+describe('Toast layout', () => {
+  it('sizes an info toast to its message', async () => {
+    const toast = await showToast({ type: 'info', message: 'Copied to clipboard' });
+    const message = screen.getByText('Copied to clipboard');
+
+    expect(message.getBoundingClientRect().width).toBeGreaterThan(0);
+    // The whole message fits: `truncate` hides any overflow, so a collapsed
+    // box shows an ellipsis at best and nothing at worst.
+    expect(message.scrollWidth).toBeLessThanOrEqual(message.clientWidth);
+    expect(toast.getBoundingClientRect().width).toBeGreaterThanOrEqual(
+      message.getBoundingClientRect().width,
+    );
+  });
+
+  it('centers the info toast on the viewport', async () => {
+    const toast = await showToast({ type: 'info', message: 'Copied to clipboard' });
+    const box = toast.getBoundingClientRect();
+
+    expect(box.left + box.width / 2).toBeCloseTo(window.innerWidth / 2, 0);
+    expect(box.top + box.height / 2).toBeCloseTo(window.innerHeight / 2, 0);
+  });
+
+  it('keeps a top toast below the top bar', async () => {
+    const toast = await showToast({ type: 'error', message: 'Something went wrong' });
+    const alert = toast.querySelector('.alert') as HTMLElement;
+
+    expect(alert.getBoundingClientRect().top).toBe(TOP_BAR + TOAST_GAP);
+    expect(screen.getByText('Something went wrong').getBoundingClientRect().width).toBeGreaterThan(
+      0,
+    );
+  });
+});

--- a/apps/readest-app/src/__tests__/components/toast-layout.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/toast-layout.browser.test.tsx
@@ -35,14 +35,22 @@ beforeAll(async () => {
 
 afterEach(() => cleanup());
 
-// The toast fades and scales in over 300ms; measure it once it has landed.
+const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+// The toast fades and scales in, and daisyUI 5 gives the alert an entrance
+// animation of its own. Both move the box while they run and
+// `getBoundingClientRect` sees them, so run every animation under the toast to
+// its end state instead of waiting on the clock.
 const showToast = async (detail: Record<string, unknown>) => {
   render(<Toast />);
   await act(async () => {
     await eventDispatcher.dispatch('toast', detail);
   });
   const toast = document.querySelector('.toast') as HTMLElement;
-  await waitFor(() => expect(getComputedStyle(toast).opacity).toBe('1'));
+  await waitFor(() => expect(toast.className).toContain('opacity-100'));
+  await nextFrame();
+  for (const animation of toast.getAnimations({ subtree: true })) animation.finish();
+  await nextFrame();
   return toast;
 };
 

--- a/apps/readest-app/src/components/Dialog.tsx
+++ b/apps/readest-app/src/components/Dialog.tsx
@@ -16,6 +16,8 @@ import { Overlay } from './Overlay';
 
 const VELOCITY_THRESHOLD = 0.5;
 const SNAP_THRESHOLD = 0.2;
+// How long the modal takes to fade and scale away once `isOpen` goes false.
+const CLOSE_TRANSITION_MS = 300;
 
 interface DialogProps {
   id?: string;
@@ -66,6 +68,26 @@ const Dialog: React.FC<DialogProps> = ({
   const previousActiveElementRef = useRef<HTMLElement | null>(null);
   const iconSize22 = useResponsiveSize(22);
   const isMobile = window.innerWidth < 640 || window.innerHeight < 640;
+
+  // Callers gate the body on the same flag they pass as `isOpen`
+  // (`<Dialog isOpen={open}>{open && <Body />}</Dialog>`), so the body would
+  // vanish on the frame the close starts and the box would collapse onto its
+  // title bar for the length of the fade. Hold the last body until it is over.
+  const lastBodyRef = useRef<ReactNode>(null);
+  const [closingBody, setClosingBody] = useState<ReactNode>(null);
+  if (isOpen) lastBodyRef.current = children;
+
+  useEffect(() => {
+    if (isOpen) {
+      setClosingBody(null);
+      return;
+    }
+    setClosingBody(lastBodyRef.current);
+    const timer = setTimeout(() => setClosingBody(null), CLOSE_TRANSITION_MS);
+    return () => clearTimeout(timer);
+  }, [isOpen]);
+
+  const body = isOpen ? children : closingBody;
 
   const handleKeyDown = (event: KeyboardEvent | CustomEvent) => {
     if (event instanceof CustomEvent) {
@@ -306,7 +328,7 @@ const Dialog: React.FC<DialogProps> = ({
             }}
             defer
           >
-            {children}
+            {body}
           </OverlayScrollbarsComponent>
         ) : (
           <div
@@ -315,7 +337,7 @@ const Dialog: React.FC<DialogProps> = ({
               contentClassName,
             )}
           >
-            {children}
+            {body}
           </div>
         )}
       </div>

--- a/apps/readest-app/src/components/Dialog.tsx
+++ b/apps/readest-app/src/components/Dialog.tsx
@@ -72,22 +72,24 @@ const Dialog: React.FC<DialogProps> = ({
   // Callers gate the body on the same flag they pass as `isOpen`
   // (`<Dialog isOpen={open}>{open && <Body />}</Dialog>`), so the body would
   // vanish on the frame the close starts and the box would collapse onto its
-  // title bar for the length of the fade. Hold the last body until it is over.
+  // title bar for the length of the fade. Keep the last body until the fade is
+  // over. The closing render picks it up itself rather than an effect handing
+  // it back: an effect only runs once React has already committed the tree
+  // without it, and a passive one only once the browser may have painted that.
+  // The state below just ends the hold.
   const lastBodyRef = useRef<ReactNode>(null);
-  const [closingBody, setClosingBody] = useState<ReactNode>(null);
+  const [isBodyHoldOver, setIsBodyHoldOver] = useState(false);
   if (isOpen) lastBodyRef.current = children;
+  const body = isOpen ? children : isBodyHoldOver ? null : lastBodyRef.current;
 
   useEffect(() => {
     if (isOpen) {
-      setClosingBody(null);
+      setIsBodyHoldOver(false);
       return;
     }
-    setClosingBody(lastBodyRef.current);
-    const timer = setTimeout(() => setClosingBody(null), CLOSE_TRANSITION_MS);
+    const timer = setTimeout(() => setIsBodyHoldOver(true), CLOSE_TRANSITION_MS);
     return () => clearTimeout(timer);
   }, [isOpen]);
-
-  const body = isOpen ? children : closingBody;
 
   const handleKeyDown = (event: KeyboardEvent | CustomEvent) => {
     if (event instanceof CustomEvent) {

--- a/apps/readest-app/src/components/Toast.tsx
+++ b/apps/readest-app/src/components/Toast.tsx
@@ -5,6 +5,12 @@ import { eventDispatcher } from '@/utils/event';
 
 export type ToastType = 'info' | 'success' | 'warning' | 'error';
 
+// The top bar a `toast-top` toast has to clear, plus the gap daisyUI 4 drew as
+// `.toast` padding. daisyUI 5 moved that padding into the insets, which the
+// `top` below overrides, so the toast carries the gap itself.
+const TOP_BAR_HEIGHT = 44;
+const TOAST_GAP = 16;
+
 export const Toast = () => {
   const { safeAreaInsets } = useThemeStore();
   const [toastMessage, setToastMessage] = useState('');
@@ -118,14 +124,17 @@ export const Toast = () => {
     toastMessage && (
       <div
         data-capture-invalidating-overlay='true'
+        // No width utility here: daisyUI 5 sizes the toast with
+        // `width: max-content`, and `width: auto` on a box pinned to
+        // `inset-inline: 50%` (toast-center) resolves to zero.
         className={clsx(
-          'toast z-[130] w-auto max-w-(--breakpoint-sm) transition-all duration-300',
+          'toast z-[130] max-w-(--breakpoint-sm) transition-all duration-300',
           toastClassMap[toastType],
           isVisible ? 'scale-100 opacity-100' : 'scale-95 opacity-0',
         )}
         style={{
           top: toastClassMap[toastType].includes('toast-top')
-            ? `${(safeAreaInsets?.top || 0) + 44}px`
+            ? `${(safeAreaInsets?.top || 0) + TOP_BAR_HEIGHT + TOAST_GAP}px`
             : undefined,
         }}
       >


### PR DESCRIPTION
Two layout regressions left over from the daisyUI 5 migration (#5884), both verified in Chrome against production, which is still on daisyUI 4.

## Toasts collapsed onto their icon

daisyUI 4 gave `.toast` `min-width: fit-content`, which made the component's own `w-auto` a no-op. daisyUI 5 replaced that min-width with `width: max-content`, so the utility now wins, and an auto width on a fixed box pinned to `inset-inline: 50%` by `toast-center` resolves to zero. Measured on the running app: `width: 0px, min-width: 0px, left: 640px, right: 640px`, with the message span 0 wide and `truncate` hiding what was left.

Info toasts use `toast-center` at every width, so they were broken everywhere; success, warning and error toasts only below the `sm` breakpoint, where `sm:toast-end` does not apply yet.

| before | after |
| --- | --- |
| the toast is the bare info icon | `(i) Copied to clipboard` |

daisyUI 5 also moved `.toast`'s `padding: 1rem` into the insets, so the inline `top` that clears the top bar lost the 16px gap it used to sit behind. The component carries that gap itself now. Restoring the padding in CSS instead is not an option: v5's own `bottom: 1rem` and `inset-inline: auto 1rem` would then double to 2rem.

## Dialogs collapsed onto their title bar while closing

Every caller gates the dialog body on the same flag it passes as `isOpen`:

```tsx
<Dialog isOpen={isOpen} title={...}>{isOpen && <Body />}</Dialog>
```

so the body unmounts on the frame the close starts, and the box shrinks to its header for the rest of the fade. This is not new in daisyUI 5, but v5 makes it visible: v4 faded the whole `.modal` (its base rule set `opacity: 0`, 200ms, no delay), while v5's `.modal` base has no opacity at all and only `.modal-box` fades, on a 50ms delay, so the empty title bar reads as a flash before it goes.

Fixed in `Dialog` rather than at one call site, since all eight dialogs share the pattern: the last body is held for the length of the close transition (300ms, by which point the box has been fully transparent for 50ms), so the dialog goes away in one piece.

## Tests

- `toast-layout.browser.test.tsx`: the message sizes the toast and is not clipped, the info toast stays centered, and a top toast keeps its distance from the top bar. Fails on `main` with `expected 0 to be greater than 0`.
- `dialog-close-body.test.tsx`: the body survives the close and is gone once the transition is over.
- `PlayerView.test.tsx` needed one assertion to wait, because the episodes sheet's rows now outlive its close.

`pnpm test`, `pnpm test:browser`, `pnpm lint` and `pnpm format:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dialog content now remains visible throughout the closing animation, preventing abrupt disappearance.
  * Dialog content is restored correctly when reopened.
  * Toast notifications are positioned correctly below the top bar and within device safe areas.
  * Episode switching now reliably waits for the previous episode to finish closing.

* **Tests**
  * Added coverage for dialog transitions, toast sizing and positioning, and informational and error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->