### PR TITLE
fix(library): refresh PDF metadata on re-import

### DIFF
--- a/apps/readest-app/src/__tests__/services/import-metahash.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-metahash.test.ts
@@ -894,9 +894,9 @@ describe('importBook PDF filename-aware dedup', () => {
     language: 'en',
   };
 
-  function setupMockPdfDoc() {
+  function setupMockPdfDoc(metadata = PDF_METADATA) {
     const bookDoc = {
-      metadata: { ...PDF_METADATA },
+      metadata: { ...metadata },
       getCover: vi.fn().mockResolvedValue(null),
     };
     mockOpen.mockResolvedValue({ book: bookDoc, format: 'PDF' });
@@ -954,6 +954,134 @@ describe('importBook PDF filename-aware dedup', () => {
     expect(book2).toBe(book1);
     expect(books.filter((b) => !b.deletedAt)).toHaveLength(1);
     expect(book1!.hash).toBe('pdf-hash-2');
+  });
+
+  it('updates embedded metadata and stored bytes when a PDF re-import keeps the same partial hash', async () => {
+    const originalMetadata = {
+      title: 'Canon R7 Custom Buttons',
+      author: 'Canon',
+      language: 'en',
+    };
+    const changedMetadata = {
+      ...originalMetadata,
+      title: 'Canon R7 Buttons Guide',
+      author: 'Canon.com',
+    };
+    const filename = 'canon-r7-custom-buttons.pdf';
+    const existingBook = makeBook({
+      hash: 'same-partial-hash',
+      format: 'PDF' as Book['format'],
+      metaHash: getMetadataHash(originalMetadata, 'canon-r7-custom-buttons'),
+      title: originalMetadata.title,
+      sourceTitle: undefined,
+      author: originalMetadata.author,
+      metadata: originalMetadata,
+      uploadedAt: Date.now() - 5000,
+      deletedAt: Date.now() - 1000,
+    });
+    const books = [existingBook];
+    const originalFile = new File(['original metadata bytes'], filename, {
+      type: 'application/pdf',
+    });
+    const changedFile = new File(['changed metadata bytes'], filename, {
+      type: 'application/pdf',
+    });
+
+    mockPartialMD5.mockResolvedValue(existingBook.hash);
+    setupMockPdfDoc(changedMetadata);
+    service.getFs().exists.mockImplementation(async (path: string) => path.endsWith('.pdf'));
+    service.getFs().openFile.mockResolvedValue(originalFile);
+
+    const imported = await service.importBook(changedFile, books);
+
+    expect(imported).toBe(existingBook);
+    expect(existingBook.deletedAt).toBeNull();
+    expect(existingBook.title).toBe('Canon R7 Buttons Guide');
+    expect(existingBook.sourceTitle).toBe('Canon R7 Custom Buttons');
+    expect(existingBook.author).toBe('Canon.com');
+    expect(existingBook.metadata).toEqual(changedMetadata);
+    expect(existingBook.metaHash).toBe(getMetadataHash(changedMetadata, 'canon-r7-custom-buttons'));
+    expect(existingBook.metadataUpdatedAt).toBe(existingBook.updatedAt);
+    expect(existingBook.uploadedAt).toBeNull();
+    expect(service.getFs().writeFile).toHaveBeenCalledWith(
+      'same-partial-hash/Canon R7 Custom Buttons.pdf',
+      'Books',
+      changedFile,
+    );
+  });
+
+  it('keeps the original metadata and bytes when a same-hash refresh fails before commit', async () => {
+    const originalMetadata = { title: 'Original Title', author: 'Original Author', language: 'en' };
+    const changedMetadata = { ...originalMetadata, author: 'Changed Author' };
+    const existingBook = makeBook({
+      hash: 'same-partial-hash',
+      format: 'PDF' as Book['format'],
+      metaHash: getMetadataHash(originalMetadata, 'book'),
+      title: originalMetadata.title,
+      sourceTitle: originalMetadata.title,
+      author: originalMetadata.author,
+      metadata: originalMetadata,
+    });
+    const originalFile = new File(['original bytes'], 'book.pdf', { type: 'application/pdf' });
+    const changedFile = new File(['changed bytes'], 'book.pdf', { type: 'application/pdf' });
+
+    mockPartialMD5.mockResolvedValue(existingBook.hash);
+    mockOpen.mockResolvedValue({
+      book: {
+        metadata: changedMetadata,
+        getCover: vi.fn().mockRejectedValue(new Error('cover failed')),
+      },
+      format: 'PDF',
+    });
+    service.getFs().exists.mockImplementation(async (path: string) => path.endsWith('.pdf'));
+    service.getFs().openFile.mockResolvedValue(originalFile);
+
+    await expect(service.importBook(changedFile, [existingBook])).rejects.toThrow('cover failed');
+
+    expect(existingBook.author).toBe('Original Author');
+    expect(existingBook.metadata).toEqual(originalMetadata);
+    expect(service.getFs().writeFile).not.toHaveBeenCalledWith(
+      expect.any(String),
+      'Books',
+      changedFile,
+    );
+  });
+
+  it('preserves user metadata when unchanged PDF bytes are re-imported under a new filename', async () => {
+    const embeddedMetadata = {
+      title: 'Canon R7 Custom Buttons',
+      author: 'Canon',
+      language: 'en',
+    };
+    const existingBook = makeBook({
+      hash: 'same-partial-hash',
+      format: 'PDF' as Book['format'],
+      metaHash: getMetadataHash(embeddedMetadata, 'original-filename'),
+      title: 'My Camera Reference',
+      sourceTitle: embeddedMetadata.title,
+      author: 'Edited Author',
+      metadata: {
+        ...embeddedMetadata,
+        title: 'My Camera Reference',
+        author: 'Edited Author',
+      },
+    });
+    const books = [existingBook];
+    const unchangedFile = new File(['unchanged bytes'], 'renamed-filename.pdf', {
+      type: 'application/pdf',
+    });
+
+    mockPartialMD5.mockResolvedValue(existingBook.hash);
+    setupMockPdfDoc(embeddedMetadata);
+    service.getFs().exists.mockImplementation(async (path: string) => path.endsWith('.pdf'));
+    service.getFs().openFile.mockResolvedValue(unchangedFile);
+
+    const imported = await service.importBook(unchangedFile, books);
+
+    expect(imported).toBe(existingBook);
+    expect(existingBook.title).toBe('My Camera Reference');
+    expect(existingBook.author).toBe('Edited Author');
+    expect(existingBook.metadata).toEqual(embeddedMetadata);
   });
 
   it('refreshBookMetadata preserves the salted metaHash for PDFs', async () => {
@@ -1033,6 +1161,32 @@ describe('importBook with BookLookupIndex', () => {
 
     // Should reuse the existing book object via lookup index
     expect(result).toBe(existingBook);
+  });
+
+  it('rekeys the metadata lookup index after an exact-hash metadata-changing re-import', async () => {
+    const originalMetadata = { ...TEST_METADATA };
+    const changedMetadata = { ...TEST_METADATA, author: 'Updated Author' };
+    const originalMetaHash = getMetadataHash(originalMetadata)!;
+    const changedMetaHash = getMetadataHash(changedMetadata)!;
+    const existingBook = makeBook({
+      hash: 'existing',
+      metaHash: originalMetaHash,
+      metadata: originalMetadata,
+    });
+    const books = [existingBook];
+    const lookupIndex = buildBookLookupIndex(books);
+
+    mockPartialMD5.mockResolvedValue(existingBook.hash);
+    setupMockBookDoc(changedMetadata);
+
+    await service.importBook(
+      new File(['changed metadata bytes'], 'test.epub', { type: 'application/epub+zip' }),
+      books,
+      { lookupIndex },
+    );
+
+    expect(lookupIndex.byMetaKey.get(`${originalMetaHash}:EPUB`) ?? []).not.toContain(existingBook);
+    expect(lookupIndex.byMetaKey.get(`${changedMetaHash}:EPUB`)).toContain(existingBook);
   });
 
   it('buildBookLookupIndex skips deleted and url-backed books in byFilePath', async () => {

--- a/apps/readest-app/src/__tests__/services/import-metahash.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-metahash.test.ts
@@ -956,34 +956,26 @@ describe('importBook PDF filename-aware dedup', () => {
     expect(book1!.hash).toBe('pdf-hash-2');
   });
 
-  it('updates embedded metadata and stored bytes when a PDF re-import keeps the same partial hash', async () => {
+  it('refreshes parsed metadata without comparing stored bytes on an exact-hash PDF re-import', async () => {
     const originalMetadata = {
       title: 'Canon R7 Custom Buttons',
       author: 'Canon',
       language: 'en',
     };
-    const changedMetadata = {
-      ...originalMetadata,
-      title: 'Canon R7 Buttons Guide',
-      author: 'Canon.com',
-    };
-    const filename = 'canon-r7-custom-buttons.pdf';
+    const changedMetadata = { ...originalMetadata, author: 'Canon.com' };
     const existingBook = makeBook({
       hash: 'same-partial-hash',
       format: 'PDF' as Book['format'],
       metaHash: getMetadataHash(originalMetadata, 'canon-r7-custom-buttons'),
       title: originalMetadata.title,
-      sourceTitle: undefined,
+      sourceTitle: originalMetadata.title,
       author: originalMetadata.author,
       metadata: originalMetadata,
-      uploadedAt: Date.now() - 5000,
-      deletedAt: Date.now() - 1000,
     });
-    const books = [existingBook];
-    const originalFile = new File(['original metadata bytes'], filename, {
+    const originalFile = new File(['original metadata bytes'], 'canon-r7-custom-buttons.pdf', {
       type: 'application/pdf',
     });
-    const changedFile = new File(['changed metadata bytes'], filename, {
+    const changedFile = new File(['changed metadata bytes'], 'canon-r7-custom-buttons.pdf', {
       type: 'application/pdf',
     });
 
@@ -992,96 +984,15 @@ describe('importBook PDF filename-aware dedup', () => {
     service.getFs().exists.mockImplementation(async (path: string) => path.endsWith('.pdf'));
     service.getFs().openFile.mockResolvedValue(originalFile);
 
-    const imported = await service.importBook(changedFile, books);
+    const imported = await service.importBook(changedFile, [existingBook]);
 
     expect(imported).toBe(existingBook);
-    expect(existingBook.deletedAt).toBeNull();
-    expect(existingBook.title).toBe('Canon R7 Buttons Guide');
-    expect(existingBook.sourceTitle).toBe('Canon R7 Custom Buttons');
-    expect(existingBook.author).toBe('Canon.com');
+    expect(existingBook.title).toBe(changedMetadata.title);
+    expect(existingBook.sourceTitle).toBe(originalMetadata.title);
+    expect(existingBook.author).toBe(changedMetadata.author);
     expect(existingBook.metadata).toEqual(changedMetadata);
-    expect(existingBook.metaHash).toBe(getMetadataHash(changedMetadata, 'canon-r7-custom-buttons'));
     expect(existingBook.metadataUpdatedAt).toBe(existingBook.updatedAt);
-    expect(existingBook.uploadedAt).toBeNull();
-    expect(service.getFs().writeFile).toHaveBeenCalledWith(
-      'same-partial-hash/Canon R7 Custom Buttons.pdf',
-      'Books',
-      changedFile,
-    );
-  });
-
-  it('keeps the original metadata and bytes when a same-hash refresh fails before commit', async () => {
-    const originalMetadata = { title: 'Original Title', author: 'Original Author', language: 'en' };
-    const changedMetadata = { ...originalMetadata, author: 'Changed Author' };
-    const existingBook = makeBook({
-      hash: 'same-partial-hash',
-      format: 'PDF' as Book['format'],
-      metaHash: getMetadataHash(originalMetadata, 'book'),
-      title: originalMetadata.title,
-      sourceTitle: originalMetadata.title,
-      author: originalMetadata.author,
-      metadata: originalMetadata,
-    });
-    const originalFile = new File(['original bytes'], 'book.pdf', { type: 'application/pdf' });
-    const changedFile = new File(['changed bytes'], 'book.pdf', { type: 'application/pdf' });
-
-    mockPartialMD5.mockResolvedValue(existingBook.hash);
-    mockOpen.mockResolvedValue({
-      book: {
-        metadata: changedMetadata,
-        getCover: vi.fn().mockRejectedValue(new Error('cover failed')),
-      },
-      format: 'PDF',
-    });
-    service.getFs().exists.mockImplementation(async (path: string) => path.endsWith('.pdf'));
-    service.getFs().openFile.mockResolvedValue(originalFile);
-
-    await expect(service.importBook(changedFile, [existingBook])).rejects.toThrow('cover failed');
-
-    expect(existingBook.author).toBe('Original Author');
-    expect(existingBook.metadata).toEqual(originalMetadata);
-    expect(service.getFs().writeFile).not.toHaveBeenCalledWith(
-      expect.any(String),
-      'Books',
-      changedFile,
-    );
-  });
-
-  it('preserves user metadata when unchanged PDF bytes are re-imported under a new filename', async () => {
-    const embeddedMetadata = {
-      title: 'Canon R7 Custom Buttons',
-      author: 'Canon',
-      language: 'en',
-    };
-    const existingBook = makeBook({
-      hash: 'same-partial-hash',
-      format: 'PDF' as Book['format'],
-      metaHash: getMetadataHash(embeddedMetadata, 'original-filename'),
-      title: 'My Camera Reference',
-      sourceTitle: embeddedMetadata.title,
-      author: 'Edited Author',
-      metadata: {
-        ...embeddedMetadata,
-        title: 'My Camera Reference',
-        author: 'Edited Author',
-      },
-    });
-    const books = [existingBook];
-    const unchangedFile = new File(['unchanged bytes'], 'renamed-filename.pdf', {
-      type: 'application/pdf',
-    });
-
-    mockPartialMD5.mockResolvedValue(existingBook.hash);
-    setupMockPdfDoc(embeddedMetadata);
-    service.getFs().exists.mockImplementation(async (path: string) => path.endsWith('.pdf'));
-    service.getFs().openFile.mockResolvedValue(unchangedFile);
-
-    const imported = await service.importBook(unchangedFile, books);
-
-    expect(imported).toBe(existingBook);
-    expect(existingBook.title).toBe('My Camera Reference');
-    expect(existingBook.author).toBe('Edited Author');
-    expect(existingBook.metadata).toEqual(embeddedMetadata);
+    expect(service.getFs().openFile).not.toHaveBeenCalled();
   });
 
   it('refreshBookMetadata preserves the salted metaHash for PDFs', async () => {
@@ -1161,32 +1072,6 @@ describe('importBook with BookLookupIndex', () => {
 
     // Should reuse the existing book object via lookup index
     expect(result).toBe(existingBook);
-  });
-
-  it('rekeys the metadata lookup index after an exact-hash metadata-changing re-import', async () => {
-    const originalMetadata = { ...TEST_METADATA };
-    const changedMetadata = { ...TEST_METADATA, author: 'Updated Author' };
-    const originalMetaHash = getMetadataHash(originalMetadata)!;
-    const changedMetaHash = getMetadataHash(changedMetadata)!;
-    const existingBook = makeBook({
-      hash: 'existing',
-      metaHash: originalMetaHash,
-      metadata: originalMetadata,
-    });
-    const books = [existingBook];
-    const lookupIndex = buildBookLookupIndex(books);
-
-    mockPartialMD5.mockResolvedValue(existingBook.hash);
-    setupMockBookDoc(changedMetadata);
-
-    await service.importBook(
-      new File(['changed metadata bytes'], 'test.epub', { type: 'application/epub+zip' }),
-      books,
-      { lookupIndex },
-    );
-
-    expect(lookupIndex.byMetaKey.get(`${originalMetaHash}:EPUB`) ?? []).not.toContain(existingBook);
-    expect(lookupIndex.byMetaKey.get(`${changedMetaHash}:EPUB`)).toContain(existingBook);
   });
 
   it('buildBookLookupIndex skips deleted and url-backed books in byFilePath', async () => {

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -72,32 +72,6 @@ export function buildBookLookupIndex(books: Book[], osPlatform?: OsPlatform): Bo
   return { byHash, byMetaKey, byFilePath };
 }
 
-function rekeyBookMetadataIndex(
-  lookupIndex: BookLookupIndex,
-  book: Book,
-  previousMetaKey: string | undefined,
-) {
-  const nextMetaKey =
-    book.metaHash && !book.deletedAt ? `${book.metaHash}:${book.format}` : undefined;
-  if (previousMetaKey === nextMetaKey) return;
-
-  if (previousMetaKey) {
-    const previousBooks = lookupIndex.byMetaKey
-      .get(previousMetaKey)
-      ?.filter((item) => item !== book);
-    if (previousBooks?.length) lookupIndex.byMetaKey.set(previousMetaKey, previousBooks);
-    else lookupIndex.byMetaKey.delete(previousMetaKey);
-  }
-  if (nextMetaKey) {
-    const nextBooks = lookupIndex.byMetaKey.get(nextMetaKey);
-    if (nextBooks) {
-      if (!nextBooks.includes(book)) nextBooks.push(book);
-    } else {
-      lookupIndex.byMetaKey.set(nextMetaKey, [book]);
-    }
-  }
-}
-
 /**
  * Normalize an absolute file path into a stable map key for `byFilePath`.
  *
@@ -460,45 +434,6 @@ export interface ImportBookInternalOptions extends ImportBookOptions {
   osPlatform?: OsPlatform;
 }
 
-// NativeFile caches slices up to and including 1 MiB. Stay above that limit so
-// large comparisons keep only the current pair of chunks in memory.
-const FILE_COMPARE_CHUNK_SIZE = 2 * 1024 * 1024;
-
-async function filesHaveSameBytes(left: File, right: File): Promise<boolean> {
-  if (left.size !== right.size) return false;
-  for (let start = 0; start < left.size; start += FILE_COMPARE_CHUNK_SIZE) {
-    const end = Math.min(start + FILE_COMPARE_CHUNK_SIZE, left.size);
-    const [leftChunk, rightChunk] = await Promise.all([
-      left.slice(start, end).arrayBuffer(),
-      right.slice(start, end).arrayBuffer(),
-    ]);
-    const leftBytes = new Uint8Array(leftChunk);
-    const rightBytes = new Uint8Array(rightChunk);
-    if (leftBytes.some((byte, index) => byte !== rightBytes[index])) return false;
-  }
-  return true;
-}
-
-async function matchesStoredBookBytes(fs: FileSystem, book: Book, candidate: File) {
-  const source = await resolveBookContentSource(fs, book);
-  if (!isBookFileContentSource(source) || source.kind === 'url') return false;
-
-  let storedFile: File | undefined;
-  try {
-    storedFile = await fs.openFile(source.path, source.base);
-    return await filesHaveSameBytes(storedFile, candidate);
-  } catch {
-    return false;
-  } finally {
-    const closable = storedFile as ClosableFile | undefined;
-    if (closable?.close) {
-      try {
-        await closable.close();
-      } catch {}
-    }
-  }
-}
-
 export async function importBook(
   fs: FileSystem,
   // file might be:
@@ -656,21 +591,6 @@ export async function importBook(
     let existingBook = lookupIndex
       ? lookupIndex.byHash.get(hash)
       : books.find((b) => b.hash === hash);
-    const previousMetaKey = existingBook?.metaHash
-      ? `${existingBook.metaHash}:${existingBook.format}`
-      : undefined;
-    // partialMD5 intentionally samples large files, so an edit confined to an
-    // unsampled metadata block can keep the same content hash (#5885). The
-    // metadata hash distinguishes that external edit from a true same-file
-    // re-import, where user-edited title/author fields must stay untouched.
-    let sameHashMetadataChanged =
-      !transient && !!existingBook?.metaHash && !!metaHash && existingBook.metaHash !== metaHash;
-    // PDF metaHash includes the import filename (#5411), so a rename alone
-    // also changes it. Compare the complete bytes only on this rare collision
-    // path to distinguish a rename from an edit outside partialMD5's samples.
-    if (sameHashMetadataChanged && format === 'PDF' && fileobj) {
-      sameHashMetadataChanged = !(await matchesStoredBookBytes(fs, existingBook!, fileobj));
-    }
     let metaHashMatch = false;
     let oldBookDir: string | undefined;
     if (existingBook) {
@@ -738,35 +658,30 @@ export async function importBook(
       }
     }
     // update book metadata when reimporting the same book
-    if (existingBook && (metaHashMatch || sameHashMetadataChanged)) {
-      // A metadata match identifies a new file version of the same book. A
-      // same-hash metadata change identifies edits outside sampled ranges.
-      // Both are explicit re-imports, so file-derived metadata wins.
+    if (existingBook && metaHashMatch) {
+      // MetaHash match (different file, same book): override metadata and hash
       existingBook.hash = hash;
       existingBook.format = book.format;
       existingBook.metaHash = metaHash;
-      if (sameHashMetadataChanged) {
-        book.sourceTitle = existingBook.sourceTitle || existingBook.title || book.sourceTitle;
-      }
       existingBook.title = book.title;
       existingBook.sourceTitle = book.sourceTitle;
       existingBook.author = book.author;
       existingBook.primaryLanguage = book.primaryLanguage;
       existingBook.metadata = book.metadata;
-      if (sameHashMetadataChanged) {
-        existingBook.metadataUpdatedAt = existingBook.updatedAt;
-      }
       existingBook.uploadedAt = null;
       existingBook.downloadedAt = Date.now();
     } else if (existingBook) {
-      // Same file hash: preserve user edits
+      // Re-imports always refresh file-derived metadata. Keep sourceTitle
+      // stable because it locates the managed file on disk.
+      book.sourceTitle = existingBook.sourceTitle || existingBook.title || book.sourceTitle;
       existingBook.format = book.format;
       existingBook.metaHash = metaHash;
-      existingBook.title = existingBook.title.trim() ? existingBook.title.trim() : book.title;
-      existingBook.sourceTitle = existingBook.sourceTitle ?? book.sourceTitle;
-      existingBook.author = existingBook.author ?? book.author;
-      existingBook.primaryLanguage = existingBook.primaryLanguage ?? book.primaryLanguage;
+      existingBook.title = book.title;
+      existingBook.sourceTitle = book.sourceTitle;
+      existingBook.author = book.author;
+      existingBook.primaryLanguage = book.primaryLanguage;
       existingBook.metadata = book.metadata;
+      existingBook.metadataUpdatedAt = existingBook.updatedAt;
       existingBook.downloadedAt = Date.now();
     }
 
@@ -782,9 +697,8 @@ export async function importBook(
       !transient &&
       !inPlace &&
       !!fileobj &&
-      (!(await fs.exists(bookFilename, 'Books')) || overwrite || sameHashMetadataChanged);
-    const writeBookFile = async () => {
-      if (!fileobj) return;
+      (!(await fs.exists(bookFilename, 'Books')) || overwrite);
+    if (willWriteBookFile && fileobj) {
       if (/\.txt$/i.test(filename)) {
         await fs.writeFile(bookFilename, 'Books', fileobj);
       } else if (typeof file === 'string' && isContentURI(file)) {
@@ -801,14 +715,8 @@ export async function importBook(
       } else {
         await fs.writeFile(bookFilename, 'Books', fileobj);
       }
-    };
-    if (willWriteBookFile && !sameHashMetadataChanged) {
-      await writeBookFile();
     }
-    if (
-      saveCover &&
-      (!(await fs.exists(getCoverFilename(book), 'Books')) || overwrite || sameHashMetadataChanged)
-    ) {
+    if (saveCover && (!(await fs.exists(getCoverFilename(book), 'Books')) || overwrite)) {
       let cover = await loadedBook.getCover();
       if (cover?.type === 'image/svg+xml') {
         try {
@@ -904,13 +812,6 @@ export async function importBook(
       await fs.writeFile(getConfigFilename(book), 'Books', serializeRawConfig(config));
     }
 
-    // Keep the original managed bytes intact until cover/config work has
-    // succeeded. If either fails, the metadata rollback still describes the
-    // file on disk; the replacement is the final fallible commit step.
-    if (willWriteBookFile && sameHashMetadataChanged) {
-      await writeBookFile();
-    }
-
     // Past this point the target book/config is authoritative. A later cleanup
     // failure must leave the library pointing at the new hash, not roll it back
     // to a directory whose retirement may already have started.
@@ -977,10 +878,6 @@ export async function importBook(
       }
     }
     book.coverImageUrl = await generateCoverImageUrlFn(book);
-
-    if (lookupIndex && existingBook) {
-      rekeyBookMetadataIndex(lookupIndex, existingBook, previousMetaKey);
-    }
 
     return existingBook || book;
   } catch (error) {

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -72,6 +72,32 @@ export function buildBookLookupIndex(books: Book[], osPlatform?: OsPlatform): Bo
   return { byHash, byMetaKey, byFilePath };
 }
 
+function rekeyBookMetadataIndex(
+  lookupIndex: BookLookupIndex,
+  book: Book,
+  previousMetaKey: string | undefined,
+) {
+  const nextMetaKey =
+    book.metaHash && !book.deletedAt ? `${book.metaHash}:${book.format}` : undefined;
+  if (previousMetaKey === nextMetaKey) return;
+
+  if (previousMetaKey) {
+    const previousBooks = lookupIndex.byMetaKey
+      .get(previousMetaKey)
+      ?.filter((item) => item !== book);
+    if (previousBooks?.length) lookupIndex.byMetaKey.set(previousMetaKey, previousBooks);
+    else lookupIndex.byMetaKey.delete(previousMetaKey);
+  }
+  if (nextMetaKey) {
+    const nextBooks = lookupIndex.byMetaKey.get(nextMetaKey);
+    if (nextBooks) {
+      if (!nextBooks.includes(book)) nextBooks.push(book);
+    } else {
+      lookupIndex.byMetaKey.set(nextMetaKey, [book]);
+    }
+  }
+}
+
 /**
  * Normalize an absolute file path into a stable map key for `byFilePath`.
  *
@@ -434,6 +460,45 @@ export interface ImportBookInternalOptions extends ImportBookOptions {
   osPlatform?: OsPlatform;
 }
 
+// NativeFile caches slices up to and including 1 MiB. Stay above that limit so
+// large comparisons keep only the current pair of chunks in memory.
+const FILE_COMPARE_CHUNK_SIZE = 2 * 1024 * 1024;
+
+async function filesHaveSameBytes(left: File, right: File): Promise<boolean> {
+  if (left.size !== right.size) return false;
+  for (let start = 0; start < left.size; start += FILE_COMPARE_CHUNK_SIZE) {
+    const end = Math.min(start + FILE_COMPARE_CHUNK_SIZE, left.size);
+    const [leftChunk, rightChunk] = await Promise.all([
+      left.slice(start, end).arrayBuffer(),
+      right.slice(start, end).arrayBuffer(),
+    ]);
+    const leftBytes = new Uint8Array(leftChunk);
+    const rightBytes = new Uint8Array(rightChunk);
+    if (leftBytes.some((byte, index) => byte !== rightBytes[index])) return false;
+  }
+  return true;
+}
+
+async function matchesStoredBookBytes(fs: FileSystem, book: Book, candidate: File) {
+  const source = await resolveBookContentSource(fs, book);
+  if (!isBookFileContentSource(source) || source.kind === 'url') return false;
+
+  let storedFile: File | undefined;
+  try {
+    storedFile = await fs.openFile(source.path, source.base);
+    return await filesHaveSameBytes(storedFile, candidate);
+  } catch {
+    return false;
+  } finally {
+    const closable = storedFile as ClosableFile | undefined;
+    if (closable?.close) {
+      try {
+        await closable.close();
+      } catch {}
+    }
+  }
+}
+
 export async function importBook(
   fs: FileSystem,
   // file might be:
@@ -591,6 +656,21 @@ export async function importBook(
     let existingBook = lookupIndex
       ? lookupIndex.byHash.get(hash)
       : books.find((b) => b.hash === hash);
+    const previousMetaKey = existingBook?.metaHash
+      ? `${existingBook.metaHash}:${existingBook.format}`
+      : undefined;
+    // partialMD5 intentionally samples large files, so an edit confined to an
+    // unsampled metadata block can keep the same content hash (#5885). The
+    // metadata hash distinguishes that external edit from a true same-file
+    // re-import, where user-edited title/author fields must stay untouched.
+    let sameHashMetadataChanged =
+      !transient && !!existingBook?.metaHash && !!metaHash && existingBook.metaHash !== metaHash;
+    // PDF metaHash includes the import filename (#5411), so a rename alone
+    // also changes it. Compare the complete bytes only on this rare collision
+    // path to distinguish a rename from an edit outside partialMD5's samples.
+    if (sameHashMetadataChanged && format === 'PDF' && fileobj) {
+      sameHashMetadataChanged = !(await matchesStoredBookBytes(fs, existingBook!, fileobj));
+    }
     let metaHashMatch = false;
     let oldBookDir: string | undefined;
     if (existingBook) {
@@ -658,16 +738,24 @@ export async function importBook(
       }
     }
     // update book metadata when reimporting the same book
-    if (existingBook && metaHashMatch) {
-      // MetaHash match (different file, same book): override metadata and hash
+    if (existingBook && (metaHashMatch || sameHashMetadataChanged)) {
+      // A metadata match identifies a new file version of the same book. A
+      // same-hash metadata change identifies edits outside sampled ranges.
+      // Both are explicit re-imports, so file-derived metadata wins.
       existingBook.hash = hash;
       existingBook.format = book.format;
       existingBook.metaHash = metaHash;
+      if (sameHashMetadataChanged) {
+        book.sourceTitle = existingBook.sourceTitle || existingBook.title || book.sourceTitle;
+      }
       existingBook.title = book.title;
       existingBook.sourceTitle = book.sourceTitle;
       existingBook.author = book.author;
       existingBook.primaryLanguage = book.primaryLanguage;
       existingBook.metadata = book.metadata;
+      if (sameHashMetadataChanged) {
+        existingBook.metadataUpdatedAt = existingBook.updatedAt;
+      }
       existingBook.uploadedAt = null;
       existingBook.downloadedAt = Date.now();
     } else if (existingBook) {
@@ -694,8 +782,9 @@ export async function importBook(
       !transient &&
       !inPlace &&
       !!fileobj &&
-      (!(await fs.exists(bookFilename, 'Books')) || overwrite);
-    if (willWriteBookFile && fileobj) {
+      (!(await fs.exists(bookFilename, 'Books')) || overwrite || sameHashMetadataChanged);
+    const writeBookFile = async () => {
+      if (!fileobj) return;
       if (/\.txt$/i.test(filename)) {
         await fs.writeFile(bookFilename, 'Books', fileobj);
       } else if (typeof file === 'string' && isContentURI(file)) {
@@ -712,8 +801,14 @@ export async function importBook(
       } else {
         await fs.writeFile(bookFilename, 'Books', fileobj);
       }
+    };
+    if (willWriteBookFile && !sameHashMetadataChanged) {
+      await writeBookFile();
     }
-    if (saveCover && (!(await fs.exists(getCoverFilename(book), 'Books')) || overwrite)) {
+    if (
+      saveCover &&
+      (!(await fs.exists(getCoverFilename(book), 'Books')) || overwrite || sameHashMetadataChanged)
+    ) {
       let cover = await loadedBook.getCover();
       if (cover?.type === 'image/svg+xml') {
         try {
@@ -809,6 +904,13 @@ export async function importBook(
       await fs.writeFile(getConfigFilename(book), 'Books', serializeRawConfig(config));
     }
 
+    // Keep the original managed bytes intact until cover/config work has
+    // succeeded. If either fails, the metadata rollback still describes the
+    // file on disk; the replacement is the final fallible commit step.
+    if (willWriteBookFile && sameHashMetadataChanged) {
+      await writeBookFile();
+    }
+
     // Past this point the target book/config is authoritative. A later cleanup
     // failure must leave the library pointing at the new hash, not roll it back
     // to a directory whose retirement may already have started.
@@ -875,6 +977,10 @@ export async function importBook(
       }
     }
     book.coverImageUrl = await generateCoverImageUrlFn(book);
+
+    if (lookupIndex && existingBook) {
+      rekeyBookMetadataIndex(lookupIndex, existingBook, previousMetaKey);
+    }
 
     return existingBook || book;
   } catch (error) {


### PR DESCRIPTION
## Summary

- Refresh the library title, author, language, and metadata from the document metadata already parsed during every exact-hash re-import.
- Keep `sourceTitle` stable so the existing managed file remains addressable.
- Do not open or compare the stored book bytes.

## Verification

- [x] `pnpm test src/__tests__/services/import-metahash.test.ts --run` (28 passed)
- [x] `CI=1 pnpm test` (10,156 passed; 16 skipped)
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm build`

No UI or documentation changes are required.

Fixes #5885


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF reimports so updated embedded metadata is refreshed without reopening the file.
  * Preserved existing book titles when imported-file metadata changes.
  * Avoided unnecessary file and cover replacement when reimporting an unchanged PDF.
  * Recorded metadata update times more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->