### PR TITLE
fix(android): migrate Google Play Billing to v9

### DIFF
--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/build.gradle.kts
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/build.gradle.kts
@@ -43,8 +43,9 @@ android {
 }
 
 dependencies {
-    "googleplayImplementation"("com.android.billingclient:billing-ktx:7.1.1")
+    "googleplayImplementation"("com.android.billingclient:billing:9.1.0")
     "googleplayImplementation"("com.google.android.gms:play-services-base:18.5.0")
+    "googleplayImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.browser:browser:1.8.0")

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/googleplay/java/com/readest/native_bridge/BillingManager.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/googleplay/java/com/readest/native_bridge/BillingManager.kt
@@ -1,20 +1,63 @@
 package com.readest.native_bridge
 
 import android.app.Activity
-import android.content.Context
 import android.util.Log
 import com.android.billingclient.api.*
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import com.google.android.gms.common.GoogleApiAvailability
-import com.google.android.gms.common.ConnectionResult
 import java.text.SimpleDateFormat
 import java.util.*
 
+internal const val MAX_BILLING_QUERY_ATTEMPTS = 3
+private const val BILLING_QUERY_RETRY_DELAY_MS = 2_000L
+
+internal fun shouldRetryBillingQuery(responseCode: Int, attempt: Int): Boolean {
+    return responseCode == BillingClient.BillingResponseCode.SERVICE_DISCONNECTED &&
+        attempt < MAX_BILLING_QUERY_ATTEMPTS
+}
+
+internal class BillingSetupState {
+    private var setupComplete = false
+    private var setupInProgress = false
+    private val callbacks = mutableListOf<(Boolean) -> Unit>()
+
+    fun awaitSetup(startSetup: () -> Unit, callback: (Boolean) -> Unit) {
+        var shouldStart = false
+        val alreadyComplete = synchronized(this) {
+            if (setupComplete) return@synchronized true
+
+            callbacks.add(callback)
+            if (!setupInProgress) {
+                setupInProgress = true
+                shouldStart = true
+            }
+            false
+        }
+
+        if (alreadyComplete) {
+            callback(true)
+        } else if (shouldStart) {
+            startSetup()
+        }
+    }
+
+    fun complete(success: Boolean) {
+        val pendingCallbacks = synchronized(this) {
+            setupInProgress = false
+            setupComplete = success
+            callbacks.toList().also { callbacks.clear() }
+        }
+        pendingCallbacks.forEach { it(success) }
+    }
+}
+
 class BillingManager(private val activity: Activity) : PurchasesUpdatedListener {
     private lateinit var billingClient: BillingClient
+    private val setupState = BillingSetupState()
     private val productsCache = mutableMapOf<String, ProductDetails>()
     private var purchaseCallback: ((PurchaseData?) -> Unit)? = null
     private val scope = CoroutineScope(Dispatchers.Main)
@@ -39,24 +82,30 @@ class BillingManager(private val activity: Activity) : PurchasesUpdatedListener 
             return
         }
 
-        billingClient = BillingClient.newBuilder(activity)
-            .setListener(this)
-            .enablePendingPurchases(
-                PendingPurchasesParams.newBuilder()
-                    .enableOneTimeProducts()
-                    .build()
-            )
-            .enableAutoServiceReconnection()
-            .build()
+        setupState.awaitSetup(::startBillingConnection, callback)
+    }
+
+    private fun startBillingConnection() {
+        if (!::billingClient.isInitialized) {
+            billingClient = BillingClient.newBuilder(activity)
+                .setListener(this)
+                .enablePendingPurchases(
+                    PendingPurchasesParams.newBuilder()
+                        .enableOneTimeProducts()
+                        .build()
+                )
+                .enableAutoServiceReconnection()
+                .build()
+        }
 
         billingClient.startConnection(object : BillingClientStateListener {
             override fun onBillingSetupFinished(billingResult: BillingResult) {
                 if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
                     Log.d(TAG, "Billing client setup finished successfully")
-                    callback(true)
+                    setupState.complete(true)
                 } else {
                     Log.e(TAG, "Billing setup failed: ${billingResult.debugMessage}")
-                    callback(false)
+                    setupState.complete(false)
                 }
             }
 
@@ -67,48 +116,60 @@ class BillingManager(private val activity: Activity) : PurchasesUpdatedListener 
     }
 
     fun fetchProducts(productIds: List<String>, callback: (List<ProductData>) -> Unit) {
-        if (!::billingClient.isInitialized) {
-            Log.e(TAG, "Billing client not initialized")
-            callback(emptyList())
-            return
-        }
-
-        scope.launch {
-            val products = mutableListOf<ProductData>()
-            
-            // Check for subscription products
-            val subsIds = productIds.filter { 
-                it.contains("monthly") || it.contains("yearly") || it.contains("subscription")
+        initialize { setupSucceeded ->
+            if (!setupSucceeded) {
+                Log.e(TAG, "Billing client setup did not complete")
+                callback(emptyList())
+                return@initialize
             }
-            
-            if (subsIds.isNotEmpty()) {
-                fetchProductsOfType(subsIds, BillingClient.ProductType.SUBS) { subProducts ->
-                    products.addAll(subProducts)
-                    
-                    // Then fetch in-app products
-                    val inAppIds = productIds - subsIds.toSet()
-                    if (inAppIds.isNotEmpty()) {
-                        fetchProductsOfType(inAppIds, BillingClient.ProductType.INAPP) { inAppProducts ->
-                            products.addAll(inAppProducts)
+
+            scope.launch {
+                val products = mutableListOf<ProductData>()
+
+                // Check for subscription products
+                val subsIds = productIds.filter {
+                    it.contains("monthly") || it.contains("yearly") || it.contains("subscription")
+                }
+
+                if (subsIds.isNotEmpty()) {
+                    fetchProductsOfType(
+                        subsIds,
+                        BillingClient.ProductType.SUBS
+                    ) { subProducts ->
+                        products.addAll(subProducts)
+
+                        // Then fetch in-app products
+                        val inAppIds = productIds - subsIds.toSet()
+                        if (inAppIds.isNotEmpty()) {
+                            fetchProductsOfType(
+                                inAppIds,
+                                BillingClient.ProductType.INAPP
+                            ) { inAppProducts ->
+                                products.addAll(inAppProducts)
+                                callback(products)
+                            }
+                        } else {
                             callback(products)
                         }
-                    } else {
+                    }
+                } else {
+                    // Only in-app products
+                    fetchProductsOfType(
+                        productIds,
+                        BillingClient.ProductType.INAPP
+                    ) { inAppProducts ->
+                        products.addAll(inAppProducts)
                         callback(products)
                     }
-                }
-            } else {
-                // Only in-app products
-                fetchProductsOfType(productIds, BillingClient.ProductType.INAPP) { inAppProducts ->
-                    products.addAll(inAppProducts)
-                    callback(products)
                 }
             }
         }
     }
 
     private fun fetchProductsOfType(
-        productIds: List<String>, 
-        productType: String, 
+        productIds: List<String>,
+        productType: String,
+        attempt: Int = 1,
         callback: (List<ProductData>) -> Unit
     ) {
         val productList = productIds.map { productId ->
@@ -164,6 +225,11 @@ class BillingManager(private val activity: Activity) : PurchasesUpdatedListener 
                     }
                 }.filterNotNull()
                 callback(products)
+            } else if (shouldRetryBillingQuery(billingResult.responseCode, attempt)) {
+                Log.w(TAG, "Billing service disconnected while fetching products; retrying")
+                scheduleQueryRetry {
+                    fetchProductsOfType(productIds, productType, attempt + 1, callback)
+                }
             } else {
                 Log.e(TAG, "Failed to fetch products: ${billingResult.debugMessage}")
                 callback(emptyList())
@@ -207,42 +273,61 @@ class BillingManager(private val activity: Activity) : PurchasesUpdatedListener 
     }
 
     fun restorePurchases(callback: (List<PurchaseData>) -> Unit) {
-        if (!::billingClient.isInitialized) {
-            Log.e(TAG, "Billing client not initialized")
-            callback(emptyList())
-            return
-        }
+        initialize { setupSucceeded ->
+            if (!setupSucceeded) {
+                Log.e(TAG, "Billing client setup did not complete")
+                callback(emptyList())
+                return@initialize
+            }
 
-        scope.launch {
-            val allPurchases = mutableListOf<PurchaseData>()
-            
-            // Query in-app purchases
-            val inappParams = QueryPurchasesParams.newBuilder()
-                .setProductType(BillingClient.ProductType.INAPP)
-                .build()
-                
-            billingClient.queryPurchasesAsync(inappParams) { billingResult, purchases ->
-                if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                    allPurchases.addAll(purchases.map { purchase ->
+            scope.launch {
+                val allPurchases = mutableListOf<PurchaseData>()
+
+                queryPurchases(BillingClient.ProductType.INAPP) { inAppPurchases ->
+                    allPurchases.addAll(inAppPurchases.map { purchase ->
                         convertToPurchaseData(purchase, "restored")
                     })
-                }
-                
-                // Query subscription purchases
-                val subsParams = QueryPurchasesParams.newBuilder()
-                    .setProductType(BillingClient.ProductType.SUBS)
-                    .build()
-                    
-                billingClient.queryPurchasesAsync(subsParams) { billingResult, purchases ->
-                    if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                        allPurchases.addAll(purchases.map { purchase ->
+
+                    queryPurchases(BillingClient.ProductType.SUBS) { subscriptionPurchases ->
+                        allPurchases.addAll(subscriptionPurchases.map { purchase ->
                             convertToPurchaseData(purchase, "restored")
                         })
+
+                        callback(allPurchases)
                     }
-                    
-                    callback(allPurchases)
                 }
             }
+        }
+    }
+
+    private fun queryPurchases(
+        productType: String,
+        attempt: Int = 1,
+        callback: (List<Purchase>) -> Unit
+    ) {
+        val params = QueryPurchasesParams.newBuilder()
+            .setProductType(productType)
+            .build()
+
+        billingClient.queryPurchasesAsync(params) { billingResult, purchases ->
+            if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                callback(purchases)
+            } else if (shouldRetryBillingQuery(billingResult.responseCode, attempt)) {
+                Log.w(TAG, "Billing service disconnected while restoring purchases; retrying")
+                scheduleQueryRetry {
+                    queryPurchases(productType, attempt + 1, callback)
+                }
+            } else {
+                Log.e(TAG, "Failed to restore purchases: ${billingResult.debugMessage}")
+                callback(emptyList())
+            }
+        }
+    }
+
+    private fun scheduleQueryRetry(query: () -> Unit) {
+        scope.launch {
+            delay(BILLING_QUERY_RETRY_DELAY_MS)
+            query()
         }
     }
 

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/googleplay/java/com/readest/native_bridge/BillingManager.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/googleplay/java/com/readest/native_bridge/BillingManager.kt
@@ -41,7 +41,12 @@ class BillingManager(private val activity: Activity) : PurchasesUpdatedListener 
 
         billingClient = BillingClient.newBuilder(activity)
             .setListener(this)
-            .enablePendingPurchases()
+            .enablePendingPurchases(
+                PendingPurchasesParams.newBuilder()
+                    .enableOneTimeProducts()
+                    .build()
+            )
+            .enableAutoServiceReconnection()
             .build()
 
         billingClient.startConnection(object : BillingClientStateListener {
@@ -56,16 +61,14 @@ class BillingManager(private val activity: Activity) : PurchasesUpdatedListener 
             }
 
             override fun onBillingServiceDisconnected() {
-                Log.w(TAG, "Billing service disconnected")
-                // Try to reconnect
-                initialize { }
+                Log.w(TAG, "Billing service disconnected; waiting for automatic reconnection")
             }
         })
     }
 
     fun fetchProducts(productIds: List<String>, callback: (List<ProductData>) -> Unit) {
-        if (!::billingClient.isInitialized || !billingClient.isReady) {
-            Log.e(TAG, "Billing client not ready")
+        if (!::billingClient.isInitialized) {
+            Log.e(TAG, "Billing client not initialized")
             callback(emptyList())
             return
         }
@@ -119,9 +122,9 @@ class BillingManager(private val activity: Activity) : PurchasesUpdatedListener 
             .setProductList(productList)
             .build()
 
-        billingClient.queryProductDetailsAsync(params) { billingResult, productDetailsList ->
+        billingClient.queryProductDetailsAsync(params) { billingResult, queryResult ->
             if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                val products = productDetailsList.map { productDetails ->
+                val products = queryResult.productDetailsList.map { productDetails ->
                     // Cache for purchase later
                     productsCache[productDetails.productId] = productDetails
                     
@@ -204,8 +207,8 @@ class BillingManager(private val activity: Activity) : PurchasesUpdatedListener 
     }
 
     fun restorePurchases(callback: (List<PurchaseData>) -> Unit) {
-        if (!::billingClient.isInitialized || !billingClient.isReady) {
-            Log.e(TAG, "Billing client not ready")
+        if (!::billingClient.isInitialized) {
+            Log.e(TAG, "Billing client not initialized")
             callback(emptyList())
             return
         }

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/testGoogleplay/java/com/readest/native_bridge/BillingConnectionRecoveryTest.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/testGoogleplay/java/com/readest/native_bridge/BillingConnectionRecoveryTest.kt
@@ -1,0 +1,114 @@
+package com.readest.native_bridge
+
+import com.android.billingclient.api.BillingClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+
+class BillingConnectionRecoveryTest {
+    @Test
+    fun callersWhileConnectingWaitForOneInitialSetup() {
+        val state = BillingSetupState()
+        val results = mutableListOf<Boolean>()
+        var setupStarts = 0
+
+        state.awaitSetup({ setupStarts++ }, results::add)
+        state.awaitSetup({ setupStarts++ }, results::add)
+
+        assertEquals(1, setupStarts)
+        assertTrue(results.isEmpty())
+
+        state.complete(true)
+
+        assertEquals(listOf(true, true), results)
+    }
+
+    @Test
+    fun concurrentCallersStartOneInitialSetup() {
+        val state = BillingSetupState()
+        val setupStarts = AtomicInteger()
+        val start = CountDownLatch(1)
+        val callers = List(16) {
+            thread(start = false) {
+                start.await()
+                state.awaitSetup({ setupStarts.incrementAndGet() }) {}
+            }
+        }
+
+        callers.forEach(Thread::start)
+        start.countDown()
+        callers.forEach(Thread::join)
+
+        assertEquals(1, setupStarts.get())
+    }
+
+    @Test
+    fun callerRacingSetupCompletionIsCompletedOnce() {
+        repeat(100) {
+            val state = BillingSetupState()
+            val callbackCount = AtomicInteger()
+            val start = CountDownLatch(1)
+
+            state.awaitSetup({}) {}
+            val completeSetup = thread(start = false) {
+                start.await()
+                state.complete(true)
+            }
+            val addCaller = thread(start = false) {
+                start.await()
+                state.awaitSetup({}, { callbackCount.incrementAndGet() })
+            }
+
+            completeSetup.start()
+            addCaller.start()
+            start.countDown()
+            completeSetup.join()
+            addCaller.join()
+
+            assertEquals(1, callbackCount.get())
+        }
+    }
+
+    @Test
+    fun failedInitialSetupCanBeRetried() {
+        val state = BillingSetupState()
+        val results = mutableListOf<Boolean>()
+        var setupStarts = 0
+
+        state.awaitSetup({ setupStarts++ }, results::add)
+        state.complete(false)
+        state.awaitSetup({ setupStarts++ }, results::add)
+        state.complete(true)
+
+        assertEquals(2, setupStarts)
+        assertEquals(listOf(false, true), results)
+    }
+
+    @Test
+    fun successfulInitialSetupDoesNotRestartForLaterCallers() {
+        val state = BillingSetupState()
+        val results = mutableListOf<Boolean>()
+        var setupStarts = 0
+
+        state.awaitSetup({ setupStarts++ }, results::add)
+        state.complete(true)
+        state.awaitSetup({ setupStarts++ }, results::add)
+
+        assertEquals(1, setupStarts)
+        assertEquals(listOf(true, true), results)
+    }
+
+    @Test
+    fun serviceDisconnectedRetryIsBounded() {
+        val disconnected = BillingClient.BillingResponseCode.SERVICE_DISCONNECTED
+
+        assertTrue(shouldRetryBillingQuery(disconnected, attempt = 1))
+        assertTrue(shouldRetryBillingQuery(disconnected, attempt = 2))
+        assertFalse(shouldRetryBillingQuery(disconnected, attempt = 3))
+        assertFalse(shouldRetryBillingQuery(BillingClient.BillingResponseCode.ERROR, attempt = 1))
+    }
+}

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/testGoogleplay/java/com/readest/native_bridge/BillingLibraryVersionTest.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/testGoogleplay/java/com/readest/native_bridge/BillingLibraryVersionTest.kt
@@ -1,0 +1,17 @@
+package com.readest.native_bridge
+
+import com.android.billingclient.BuildConfig
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BillingLibraryVersionTest {
+    @Test
+    fun usesPlayBillingLibraryNineOrNewer() {
+        val majorVersion = BuildConfig.VERSION_NAME.substringBefore('.').toInt()
+
+        assertTrue(
+            "Google Play Billing Library 9+ required, found ${BuildConfig.VERSION_NAME}",
+            majorVersion >= 9
+        )
+    }
+}

--- a/apps/readest-app/src/__tests__/app/api/stripe-checkout-error-detail.test.ts
+++ b/apps/readest-app/src/__tests__/app/api/stripe-checkout-error-detail.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import Stripe from 'stripe';
+
+// Keep Stripe's stable diagnostic fields without leaking raw backend errors to
+// the client (and onward to client-side error telemetry).
+
+const createMock = vi.fn();
+const customersCreateMock = vi.fn();
+const validateUserAndTokenMock = vi.fn();
+const singleMock = vi.fn();
+
+vi.mock('@/libs/payment/stripe/server', () => ({
+  getStripe: () => ({
+    checkout: { sessions: { create: (...a: unknown[]) => createMock(...a) } },
+    customers: { create: (...a: unknown[]) => customersCreateMock(...a) },
+  }),
+}));
+vi.mock('@/utils/access', () => ({
+  validateUserAndToken: (...a: unknown[]) => validateUserAndTokenMock(...a),
+}));
+vi.mock('@/utils/supabase', () => ({
+  createSupabaseAdminClient: () => ({
+    from: () => ({
+      select: () => ({ eq: () => ({ single: () => singleMock() }) }),
+      insert: () => Promise.resolve({ error: null }),
+    }),
+  }),
+}));
+
+import { POST } from '@/app/api/stripe/checkout/route';
+
+const postReq = () =>
+  new NextRequest('https://web.readest.com/api/stripe/checkout', {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer caller',
+      'content-type': 'application/json',
+      origin: 'http://tauri.localhost',
+    },
+    body: JSON.stringify({
+      priceId: 'price_1SM42IENgv2E9LPDjWb0A3wC',
+      planType: 'purchase',
+      embedded: true,
+    }),
+  });
+
+beforeEach(() => {
+  validateUserAndTokenMock.mockReset().mockResolvedValue({
+    user: { id: 'caller-id', email: 'caller@example.com' },
+    token: 'tok',
+  });
+  singleMock.mockReset().mockResolvedValue({ data: { stripe_customer_id: 'cus_stale' } });
+  createMock.mockReset();
+  customersCreateMock.mockReset();
+});
+
+describe('POST /api/stripe/checkout — error detail', () => {
+  it('returns sanitized Stripe diagnostics when session creation is rejected', async () => {
+    createMock.mockRejectedValue(
+      new Stripe.errors.StripeInvalidRequestError({
+        message: "No such customer: 'cus_stale'",
+        type: 'invalid_request_error',
+        code: 'resource_missing',
+        param: 'customer',
+      }),
+    );
+
+    const res = await POST(postReq());
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      error: 'Error creating checkout session',
+      message: 'Stripe rejected the checkout request',
+      code: 'resource_missing',
+      param: 'customer',
+    });
+    expect(JSON.stringify(body)).not.toContain('cus_stale');
+  });
+
+  it('does not expose non-Stripe error details', async () => {
+    createMock.mockRejectedValue(
+      Object.assign(new Error('supabaseKey is required.'), {
+        code: 'resource_missing',
+        param: 'customer',
+      }),
+    );
+
+    const res = await POST(postReq());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Error creating checkout session' });
+  });
+
+  it.each([null, undefined])('handles a %s rejection without throwing', async (error) => {
+    createMock.mockRejectedValue(error);
+
+    const res = await POST(postReq());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Error creating checkout session' });
+  });
+
+  it('returns the session on success', async () => {
+    createMock.mockResolvedValue({
+      id: 'cs_test_1',
+      url: null,
+      client_secret: 'cs_test_1_secret',
+    });
+
+    const res = await POST(postReq());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      sessionId: 'cs_test_1',
+      clientSecret: 'cs_test_1_secret',
+    });
+  });
+});

--- a/apps/readest-app/src/app/api/stripe/checkout/route.ts
+++ b/apps/readest-app/src/app/api/stripe/checkout/route.ts
@@ -1,7 +1,11 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
 import { getStripe } from '@/libs/payment/stripe/server';
 import { validateUserAndToken } from '@/utils/access';
 import { createSupabaseAdminClient } from '@/utils/supabase';
+
+const CHECKOUT_ERROR = 'Error creating checkout session';
+const STRIPE_CHECKOUT_ERROR = 'Stripe rejected the checkout request';
 
 export async function POST(request: NextRequest) {
   const {
@@ -74,6 +78,21 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error(error);
-    return NextResponse.json({ error: 'Error creating checkout session' }, { status: 500 });
+
+    if (!(error instanceof Stripe.errors.StripeError)) {
+      return NextResponse.json({ error: CHECKOUT_ERROR }, { status: 500 });
+    }
+
+    const code = typeof error.code === 'string' ? error.code : undefined;
+    const param = typeof error.param === 'string' ? error.param : undefined;
+    return NextResponse.json(
+      {
+        error: CHECKOUT_ERROR,
+        message: STRIPE_CHECKOUT_ERROR,
+        code,
+        param,
+      },
+      { status: 500 },
+    );
   }
 }

--- a/apps/readest-app/src/libs/payment/stripe/client.ts
+++ b/apps/readest-app/src/libs/payment/stripe/client.ts
@@ -59,7 +59,11 @@ export const createStripeCheckoutSession = async (
   });
 
   if (!response.ok) {
-    throw new Error('Failed to create Stripe checkout session');
+    const detail = await response
+      .json()
+      .then((data) => data?.message as string | undefined)
+      .catch(() => undefined);
+    throw new Error(detail || 'Failed to create Stripe checkout session');
   }
 
   return response.json();


### PR DESCRIPTION
## Summary

- Upgrade the Google Play flavor from Google Play Billing Library 7.1.1 to 9.1.0.
- Migrate billing initialization and product queries to the Billing 9 APIs, including parameterized pending purchases and automatic service reconnection.
- Wait for the first successful billing setup before product and restore queries, sharing one setup attempt across concurrent callers.
- Retry `SERVICE_DISCONNECTED` product and purchase queries up to three total attempts with 2-second delays, then preserve the existing result callbacks.
- Add Google Play flavor unit coverage for the resolved Billing major version, setup readiness, concurrent setup callers, setup/completion races, and retry bounds.
- Preserve sanitized Stripe checkout diagnostics (`code` and `param`) in 500 responses without exposing raw Stripe, configuration, or database error messages to clients or client-side telemetry.

This follows the [Google Play Billing 9 migration guide](https://developer.android.com/google/play/billing/migrate-gpblv9).

## Verification

- [x] Six billing recovery unit tests and the Billing Library version guard
- [x] Five Stripe checkout route tests covering sanitized Stripe details, generic backend errors, null/undefined rejections, and success
- [x] Google Play plugin release assembly and universal app release Kotlin compile
- [x] FOSS flavor Kotlin compile
- [x] Release dependency graph resolves `com.android.billingclient:billing:9.1.0`
- [x] Packaged universal release manifest records `com.google.android.play.billingclient.version=9.1.0`
- [x] Vitest: 832 files passed, 4 skipped; 10,189 tests passed, 16 skipped
- [x] TypeScript/Biome lint and formatting checks
- [x] Rust formatting, Clippy, and 121 Rust unit tests

## Review

No unresolved pre-landing or adversarial findings. The checkout error boundary now allowlists Stripe error metadata and keeps raw backend exceptions server-side. The billing recovery coverage audit exercises all JVM-testable paths; the remaining paths require Android BillingClient integration or a licensed Play device.

## Test plan

- [x] Compile and assemble the Google Play release variant against Billing 9.1.0
- [x] Verify the resolved release dependency and packaged Billing metadata
- [x] Verify initial setup gating, setup retry, concurrent callers, callback races, and bounded disconnect retries with JVM tests
- [x] Verify checkout failures expose only sanitized Stripe diagnostics and safely handle unexpected rejected values
- [ ] On a licensed Google Play test device, exercise subscription and one-time purchase flows
- [ ] Disconnect/reconnect Play services and verify product loading and purchase restoration

Runtime checkout and restore behavior requires a Play-enabled licensed test device; the repository's Android E2E job is not enabled for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated Google Play Billing integration to the latest supported APIs.
  * Improved billing setup, reconnection, product retrieval, and purchase restoration reliability.
  * Added controlled retries for temporary billing service disconnections.
  * Stripe checkout errors now provide useful diagnostic details while protecting sensitive backend messages.

* **Quality**
  * Added validation and coverage for billing compatibility, connection recovery, and checkout error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
