### PR TITLE
fix(sync): converge multi-device file sync (#5900)

### DIFF
--- a/apps/readest-app/src/__tests__/app/library/useBooksSync-routing.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/useBooksSync-routing.test.tsx
@@ -46,7 +46,11 @@ const routing = vi.hoisted(() => ({
 }));
 
 const runFileLibrarySyncPass = vi.hoisted(() =>
-  vi.fn(async (): Promise<{ booksSynced: number } | null> => ({ booksSynced: 1 })),
+  vi.fn(
+    async (): Promise<{ booksSynced: number; indexPushFailed?: boolean } | null> => ({
+      booksSynced: 1,
+    }),
+  ),
 );
 
 vi.mock('@/context/AuthContext', () => ({
@@ -200,6 +204,32 @@ describe('useBooksSync pullLibrary routing (issue #5062)', () => {
     const toastCalls = dispatchSpy.mock.calls.filter(([event]) => event === 'toast');
     expect(toastCalls).toHaveLength(1);
     expect(toastCalls[0]?.[1]).toMatchObject({ type: 'info', message: '7 book(s) synced' });
+  });
+
+  it('reports a failure when the file pass could not write the shared index (#5900)', async () => {
+    // library.json IS the convergence point: peers read membership, tombstones
+    // and the uploaded-file record from it. A run that uploaded books but could
+    // not write it converged nothing, and must not toast a book count.
+    routing.readestEnabled = false;
+    routing.backends = ['gdrive'];
+
+    const dispatchSpy = vi.spyOn(eventDispatcher, 'dispatch');
+
+    const { result } = renderHook(() => useBooksSync());
+
+    await waitFor(() => expect(runFileLibrarySyncPass).toHaveBeenCalled());
+
+    dispatchSpy.mockClear();
+    runFileLibrarySyncPass.mockClear();
+    runFileLibrarySyncPass.mockResolvedValueOnce({ booksSynced: 4, indexPushFailed: true });
+
+    await act(async () => {
+      await result.current.pullLibrary(false, true);
+    });
+
+    const toastCalls = dispatchSpy.mock.calls.filter(([event]) => event === 'toast');
+    expect(toastCalls).toHaveLength(1);
+    expect(toastCalls[0]?.[1]).toMatchObject({ type: 'error', message: 'Sync failed' });
   });
 
   it('still reports a combined success when the file pass fails but the native pull succeeds', async () => {

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-converge-5900.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-converge-5900.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import type { Book } from '@/types/book';
+import { FileSyncEngine } from '@/services/sync/file/engine';
+import { FileSyncError, type FileSyncProvider } from '@/services/sync/file/provider';
+import type { LocalStore } from '@/services/sync/file/localStore';
+import type { RemoteLibraryIndex } from '@/services/sync/file/wire';
+
+/**
+ * #5900: multi-device file sync never converged. Defect 1 — a 'send' run
+ * rewriting library.json it never read — and its blind-push invariant are
+ * covered by engine-send-only-index-safety.test.ts. This file covers the rest:
+ *
+ *   - the other records that re-push carries (emptyDirs), and the abort that
+ *     protects them when the index cannot be read at all;
+ *   - that reading the index did NOT turn 'send' into a consumer of the
+ *     remote's uploaded-file record — #5900 reports that record being wrong,
+ *     and Send Only is the recovery path;
+ *   - defect 2, the actual standoff: republishing a live row over a peer's
+ *     tombstone carried the row's OLD `updatedAt`, and a peer revives only on
+ *     `remote.updatedAt > local.deletedAt`, so a row last edited before the
+ *     deletion could never win. The two devices ping-ponged live row vs
+ *     tombstone forever (the reporter's "BOOX stays at 129 books");
+ *   - defect 3, a failed library.json write swallowed by a console.warn, so a
+ *     run that converged nothing still reported success.
+ */
+
+const makeBook = (hash: string, overrides: Partial<Book> = {}): Book => ({
+  hash,
+  format: 'EPUB',
+  title: `Book ${hash}`,
+  sourceTitle: `Book ${hash}`,
+  author: 'A',
+  createdAt: 1,
+  updatedAt: 100,
+  ...overrides,
+});
+
+type Captured = { writes: { path: string; body: string }[] };
+
+const fakeProvider = (
+  opts: Partial<FileSyncProvider> & { captured?: Captured } = {},
+): FileSyncProvider => ({
+  rootPath: '/',
+  readText: opts.readText ?? (async () => null),
+  readBinary: opts.readBinary ?? (async () => new ArrayBuffer(8)),
+  head: opts.head ?? (async () => null),
+  list: opts.list ?? (async () => []),
+  writeText:
+    opts.writeText ??
+    (async (path: string, body: string) => {
+      opts.captured?.writes.push({ path, body });
+    }),
+  writeBinary: opts.writeBinary ?? (async () => {}),
+  ensureDir: opts.ensureDir ?? (async () => {}),
+  deleteDir: opts.deleteDir ?? (async () => {}),
+});
+
+const fakeStore = (opts: Partial<LocalStore> = {}): LocalStore => ({
+  loadConfig: opts.loadConfig ?? (async () => ({ updatedAt: 1, booknotes: [] })),
+  saveBookConfig: opts.saveBookConfig ?? (async () => {}),
+  loadBookFile: opts.loadBookFile ?? (async () => ({ bytes: new ArrayBuffer(16), size: 16 })),
+  resolveLocalBookPath: opts.resolveLocalBookPath ?? (async () => ({ path: '/src', size: 16 })),
+  saveBookFile: opts.saveBookFile ?? (async () => {}),
+  prepareLocalBookPath: opts.prepareLocalBookPath ?? (async () => '/local/dst'),
+  loadBookCover: opts.loadBookCover ?? (async () => null),
+  saveBookCover: opts.saveBookCover ?? (async () => {}),
+  addBookToLibrary: opts.addBookToLibrary ?? (async () => {}),
+  updateBookMetadata: opts.updateBookMetadata ?? (async () => {}),
+  deleteBookLocally: opts.deleteBookLocally ?? (async () => {}),
+  markBooksUploaded: opts.markBooksUploaded ?? (async () => {}),
+});
+
+const indexServing = (index: RemoteLibraryIndex) => async (p: string) =>
+  p.endsWith('library.json') ? JSON.stringify(index) : null;
+
+const pushedIndex = (captured: Captured): RemoteLibraryIndex | null => {
+  const write = captured.writes.find((w) => w.path.endsWith('library.json'));
+  return write ? (JSON.parse(write.body) as RemoteLibraryIndex) : null;
+};
+
+describe('FileSyncEngine.syncLibrary — Send Only reads the index safely (#5900)', () => {
+  test('carries forward the remote emptyDirs record', async () => {
+    const captured: Captured = { writes: [] };
+    const provider = fakeProvider({
+      readText: indexServing({
+        schemaVersion: 1,
+        updatedAt: 1,
+        books: [makeBook('h1')],
+        emptyDirs: ['h9'],
+      }),
+      captured,
+    });
+
+    await new FileSyncEngine(provider, fakeStore()).syncLibrary([makeBook('h1')], {
+      strategy: 'send',
+      syncBooks: false,
+      deviceId: 'pc',
+    });
+
+    expect(pushedIndex(captured)!.emptyDirs).toEqual(['h9']);
+  });
+
+  test('aborts rather than rewriting an index it could not read', async () => {
+    // Now that the re-push carries peers' books, tombstones and uploaded-file
+    // record forward, writing an index we failed to READ would wipe all three.
+    // An unreadable index (throw) is not an absent one (404 -> null).
+    const captured: Captured = { writes: [] };
+    const provider = fakeProvider({
+      readText: async (p) => {
+        if (p.endsWith('library.json')) throw new FileSyncError('offline', 'NETWORK', 503);
+        return null;
+      },
+      captured,
+    });
+
+    await expect(
+      new FileSyncEngine(provider, fakeStore()).syncLibrary([makeBook('h1')], {
+        strategy: 'send',
+        syncBooks: false,
+        deviceId: 'pc',
+      }),
+    ).rejects.toThrow('offline');
+    expect(pushedIndex(captured)).toBeNull();
+  });
+
+  test('still verifies book files it has not confirmed itself', async () => {
+    // Reading the index must not make 'send' trust the remote's uploaded-file
+    // record: #5900 is a report of that record being WRONG, and Send Only is
+    // the recovery path a user reaches for. It re-probes every local file.
+    const heads: string[] = [];
+    const provider = fakeProvider({
+      readText: indexServing({
+        schemaVersion: 1,
+        updatedAt: 1,
+        books: [makeBook('h1')],
+        uploadedHashes: ['h1'],
+      }),
+      head: async (p) => {
+        heads.push(p);
+        return null;
+      },
+    });
+
+    const res = await new FileSyncEngine(provider, fakeStore()).syncLibrary(
+      [makeBook('h1', { downloadedAt: 1 })],
+      { strategy: 'send', syncBooks: true, fullSync: false, deviceId: 'pc' },
+    );
+
+    expect(res.filesUploaded).toBe(1);
+    expect(heads.some((p) => p.includes('/books/h1/'))).toBe(true);
+  });
+});
+
+describe('FileSyncEngine.syncLibrary — tombstone revival converges (#5900)', () => {
+  test('a send push over a peer tombstone publishes a row that outranks it', async () => {
+    // The reporter's deadlock: the PC keeps the book (last edited at 100), a
+    // peer deleted it at 5000. Republishing with updatedAt 100 can never beat
+    // the peer's `deletedAt` 5000, so the peer re-pushes its tombstone and the
+    // two devices ping-pong forever. The republish IS the newer decision and
+    // must be stamped as such.
+    const captured: Captured = { writes: [] };
+    const provider = fakeProvider({
+      readText: indexServing({
+        schemaVersion: 1,
+        updatedAt: 1,
+        books: [makeBook('h1', { updatedAt: 100, deletedAt: 5000 })],
+      }),
+      captured,
+    });
+
+    await new FileSyncEngine(provider, fakeStore()).syncLibrary(
+      [makeBook('h1', { updatedAt: 100 })],
+      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+    );
+
+    const row = pushedIndex(captured)!.books.find((b) => b.hash === 'h1')!;
+    expect(row.deletedAt).toBeFalsy();
+    expect(row.updatedAt).toBeGreaterThan(5000);
+  });
+
+  test('persists the revival stamp locally so the next run does not regress it', async () => {
+    const updateBookMetadata = vi.fn<(b: Book) => Promise<void>>(async () => {});
+    const provider = fakeProvider({
+      readText: indexServing({
+        schemaVersion: 1,
+        updatedAt: 1,
+        books: [makeBook('h1', { updatedAt: 100, deletedAt: 5000 })],
+      }),
+    });
+
+    await new FileSyncEngine(provider, fakeStore({ updateBookMetadata })).syncLibrary(
+      [makeBook('h1', { updatedAt: 100 })],
+      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+    );
+
+    expect(updateBookMetadata).toHaveBeenCalledTimes(1);
+    const saved = updateBookMetadata.mock.calls[0]![0];
+    expect(saved.hash).toBe('h1');
+    expect(saved.updatedAt).toBeGreaterThan(5000);
+    expect(saved.deletedAt).toBeFalsy();
+  });
+
+  test('does not stamp a row the remote already has live', async () => {
+    // Only a republish OVER a tombstone is a new decision. An ordinary send
+    // must leave `updatedAt` alone, or every run rewrites every row.
+    const captured: Captured = { writes: [] };
+    const updateBookMetadata = vi.fn<(b: Book) => Promise<void>>(async () => {});
+    const provider = fakeProvider({
+      readText: indexServing({
+        schemaVersion: 1,
+        updatedAt: 1,
+        books: [makeBook('h1', { updatedAt: 100 })],
+      }),
+      captured,
+    });
+
+    await new FileSyncEngine(provider, fakeStore({ updateBookMetadata })).syncLibrary(
+      [makeBook('h1', { updatedAt: 100 })],
+      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+    );
+
+    expect(updateBookMetadata).not.toHaveBeenCalled();
+    expect(pushedIndex(captured)!.books.find((b) => b.hash === 'h1')!.updatedAt).toBe(100);
+  });
+
+  test('a peer revives its tombstone from the stamped row', async () => {
+    // The other half of the handshake: given the row the test above publishes,
+    // the peer that holds the tombstone must put the book back on its shelf.
+    const addBookToLibrary = vi.fn<(b: Book) => Promise<void>>(async () => {});
+    const provider = fakeProvider({
+      readText: indexServing({
+        schemaVersion: 1,
+        updatedAt: 1,
+        books: [makeBook('h1', { updatedAt: 5001 })],
+      }),
+      list: async (p) =>
+        p.endsWith('/books')
+          ? [{ name: 'h1', path: '/Readest/books/h1', isDirectory: true }]
+          : [
+              {
+                name: 'Book h1.epub',
+                path: '/Readest/books/h1/Book h1.epub',
+                isDirectory: false,
+                size: 10,
+              },
+            ],
+    });
+
+    const res = await new FileSyncEngine(provider, fakeStore({ addBookToLibrary })).syncLibrary(
+      [makeBook('h1', { updatedAt: 5000, deletedAt: 5000 })],
+      { strategy: 'silent', syncBooks: false, fullSync: true, deviceId: 'boox' },
+    );
+
+    expect(res.booksAdded).toBe(1);
+    expect(addBookToLibrary).toHaveBeenCalledTimes(1);
+    expect(addBookToLibrary.mock.calls[0]![0].hash).toBe('h1');
+  });
+});
+
+describe('FileSyncEngine.syncLibrary — two devices converge (#5900)', () => {
+  test('a Send Only PC and a peer holding a tombstone settle on one library', async () => {
+    // The reporter's exact standoff, played out round by round against one
+    // shared remote: the PC keeps a book it last touched at 100, the BOOX
+    // deleted it at 5000 and pushed that tombstone. Neither shelf ever
+    // changed, run after run. Convergence means the tombstone loses (the PC
+    // is the authoritative sender) and STAYS lost.
+    let remote = JSON.stringify({
+      schemaVersion: 1,
+      updatedAt: 1,
+      books: [makeBook('h1', { updatedAt: 100, deletedAt: 5000 })],
+    } satisfies RemoteLibraryIndex);
+
+    const sharedRemote = (): Partial<FileSyncProvider> => ({
+      readText: async (p) => (p.endsWith('library.json') ? remote : null),
+      writeText: async (p, body) => {
+        if (p.endsWith('library.json')) remote = body;
+      },
+      list: async (p) =>
+        p.endsWith('/books')
+          ? [{ name: 'h1', path: '/Readest/books/h1', isDirectory: true }]
+          : [
+              {
+                name: 'Book h1.epub',
+                path: '/Readest/books/h1/Book h1.epub',
+                isDirectory: false,
+                size: 10,
+              },
+            ],
+    });
+
+    const liveRow = () =>
+      (JSON.parse(remote) as RemoteLibraryIndex).books.find((b) => b.hash === 'h1')!;
+
+    // --- Round 1: the PC sends. It must stamp its republish to outrank 5000.
+    let pcBooks = [makeBook('h1', { updatedAt: 100 })];
+    await new FileSyncEngine(
+      fakeProvider(sharedRemote()),
+      fakeStore({
+        updateBookMetadata: async (b) => {
+          pcBooks = [b];
+        },
+      }),
+    ).syncLibrary(pcBooks, { strategy: 'send', syncBooks: false, deviceId: 'pc' });
+    expect(liveRow().deletedAt).toBeFalsy();
+
+    // --- Round 2: the BOOX pulls. Its tombstone must give way.
+    let booxBooks = [makeBook('h1', { updatedAt: 5000, deletedAt: 5000 })];
+    const addBookToLibrary = vi.fn<(b: Book) => Promise<void>>(async (b) => {
+      booxBooks = [{ ...b, deletedAt: null }];
+    });
+    const boox = await new FileSyncEngine(
+      fakeProvider(sharedRemote()),
+      fakeStore({ addBookToLibrary }),
+    ).syncLibrary(booxBooks, { strategy: 'silent', syncBooks: false, deviceId: 'boox' });
+    expect(boox.booksAdded).toBe(1);
+    expect(booxBooks[0]!.deletedAt).toBeFalsy();
+    // The BOOX's own re-push must not put the tombstone back.
+    expect(liveRow().deletedAt).toBeFalsy();
+
+    // --- Round 3: the PC sends again. Nothing left to override, so it must
+    // stop restamping — a stamp per run would churn the index forever.
+    const restamp = vi.fn<(b: Book) => Promise<void>>(async () => {});
+    await new FileSyncEngine(
+      fakeProvider(sharedRemote()),
+      fakeStore({ updateBookMetadata: restamp }),
+    ).syncLibrary(pcBooks, { strategy: 'send', syncBooks: false, deviceId: 'pc' });
+    expect(restamp).not.toHaveBeenCalled();
+    expect(liveRow().deletedAt).toBeFalsy();
+  });
+});
+
+describe('FileSyncEngine.syncLibrary — index write failure is reported (#5900)', () => {
+  test('surfaces a failed library.json write instead of swallowing it', async () => {
+    const provider = fakeProvider({
+      readText: indexServing({ schemaVersion: 1, updatedAt: 1, books: [makeBook('h1')] }),
+      writeText: async (p) => {
+        if (p.endsWith('library.json')) throw new Error('507 Insufficient Storage');
+      },
+    });
+
+    const res = await new FileSyncEngine(provider, fakeStore()).syncLibrary(
+      [makeBook('h1', { updatedAt: 200 })],
+      { strategy: 'silent', syncBooks: false, deviceId: 'pc' },
+    );
+
+    expect(res.indexPushFailed).toBe(true);
+  });
+
+  test('reports a healthy run as not failed', async () => {
+    const provider = fakeProvider({
+      readText: indexServing({ schemaVersion: 1, updatedAt: 1, books: [makeBook('h1')] }),
+    });
+
+    const res = await new FileSyncEngine(provider, fakeStore()).syncLibrary(
+      [makeBook('h1', { updatedAt: 200 })],
+      { strategy: 'silent', syncBooks: false, deviceId: 'pc' },
+    );
+
+    expect(res.indexPushFailed).toBe(false);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-converge-5900.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-converge-5900.test.ts
@@ -8,14 +8,14 @@ import type { RemoteLibraryIndex } from '@/services/sync/file/wire';
 
 /**
  * #5900: multi-device file sync never converged. Defect 1 — a 'send' run
- * rewriting library.json it never read — and its blind-push invariant are
- * covered by engine-send-only-index-safety.test.ts. This file covers the rest:
+ * rewriting library.json it never read — is covered by
+ * engine-send-only-index-safety.test.ts. This file covers the rest:
  *
  *   - the other records that re-push carries (emptyDirs), and the abort that
  *     protects them when the index cannot be read at all;
- *   - that reading the index did NOT turn 'send' into a consumer of the
- *     remote's uploaded-file record — #5900 reports that record being wrong,
- *     and Send Only is the recovery path;
+ *   - the incremental/Full Sync split: an incremental run of ANY strategy stays
+ *     O(changed) and never re-reads the index, while Full Sync is the pass that
+ *     re-audits files and reconciles against concurrent writers;
  *   - defect 2, the actual standoff: republishing a live row over a peer's
  *     tombstone carried the row's OLD `updatedAt`, and a peer revives only on
  *     `remote.updatedAt > local.deletedAt`, so a row last edited before the
@@ -92,11 +92,10 @@ describe('FileSyncEngine.syncLibrary — Send Only reads the index safely (#5900
       captured,
     });
 
-    await new FileSyncEngine(provider, fakeStore()).syncLibrary([makeBook('h1')], {
-      strategy: 'send',
-      syncBooks: false,
-      deviceId: 'pc',
-    });
+    await new FileSyncEngine(provider, fakeStore()).syncLibrary(
+      [makeBook('h1', { updatedAt: 200 })],
+      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+    );
 
     expect(pushedIndex(captured)!.emptyDirs).toEqual(['h9']);
   });
@@ -124,11 +123,12 @@ describe('FileSyncEngine.syncLibrary — Send Only reads the index safely (#5900
     expect(pushedIndex(captured)).toBeNull();
   });
 
-  test('still verifies book files it has not confirmed itself', async () => {
-    // Reading the index must not make 'send' trust the remote's uploaded-file
-    // record: #5900 is a report of that record being WRONG, and Send Only is
-    // the recovery path a user reaches for. It re-probes every local file.
-    const heads: string[] = [];
+  test('an incremental send trusts the uploaded-file record and stays O(changed)', async () => {
+    // Before #5900 'send' never read the index, so `uploadedHashes` was always
+    // empty and every run re-probed every book — an O(library) storm of remote
+    // HEADs and local fs stats that a large library cannot afford. Reading the
+    // index is what makes Send Only incremental. Drift is Full Sync's job.
+    const fileProbes: string[] = [];
     const provider = fakeProvider({
       readText: indexServing({
         schemaVersion: 1,
@@ -137,7 +137,7 @@ describe('FileSyncEngine.syncLibrary — Send Only reads the index safely (#5900
         uploadedHashes: ['h1'],
       }),
       head: async (p) => {
-        heads.push(p);
+        if (p.endsWith('.epub')) fileProbes.push(p);
         return null;
       },
     });
@@ -147,8 +147,34 @@ describe('FileSyncEngine.syncLibrary — Send Only reads the index safely (#5900
       { strategy: 'send', syncBooks: true, fullSync: false, deviceId: 'pc' },
     );
 
+    expect(fileProbes).toEqual([]);
+    expect(res.filesUploaded).toBe(0);
+  });
+
+  test('a Full Sync send re-audits the file even when the record claims it', async () => {
+    // The escape hatch the incremental path defers to: Full Sync bypasses the
+    // record and verifies the bytes are really there.
+    const fileProbes: string[] = [];
+    const provider = fakeProvider({
+      readText: indexServing({
+        schemaVersion: 1,
+        updatedAt: 1,
+        books: [makeBook('h1')],
+        uploadedHashes: ['h1'],
+      }),
+      head: async (p) => {
+        if (p.endsWith('.epub')) fileProbes.push(p);
+        return null;
+      },
+    });
+
+    const res = await new FileSyncEngine(provider, fakeStore()).syncLibrary(
+      [makeBook('h1', { downloadedAt: 1 })],
+      { strategy: 'send', syncBooks: true, fullSync: true, deviceId: 'pc' },
+    );
+
+    expect(fileProbes.length).toBe(1);
     expect(res.filesUploaded).toBe(1);
-    expect(heads.some((p) => p.includes('/books/h1/'))).toBe(true);
   });
 });
 
@@ -216,12 +242,12 @@ describe('FileSyncEngine.syncLibrary — tombstone revival converges (#5900)', (
     });
 
     await new FileSyncEngine(provider, fakeStore({ updateBookMetadata })).syncLibrary(
-      [makeBook('h1', { updatedAt: 100 })],
+      [makeBook('h1', { updatedAt: 200 })],
       { strategy: 'send', syncBooks: false, deviceId: 'pc' },
     );
 
     expect(updateBookMetadata).not.toHaveBeenCalled();
-    expect(pushedIndex(captured)!.books.find((b) => b.hash === 'h1')!.updatedAt).toBe(100);
+    expect(pushedIndex(captured)!.books.find((b) => b.hash === 'h1')!.updatedAt).toBe(200);
   });
 
   test('a peer revives its tombstone from the stamped row', async () => {
@@ -330,7 +356,7 @@ describe('FileSyncEngine.syncLibrary — two devices converge (#5900)', () => {
   });
 });
 
-describe('FileSyncEngine.syncLibrary — concurrent index writers', () => {
+describe('FileSyncEngine.syncLibrary — concurrent index writers (Full Sync)', () => {
   /**
    * A provider over one shared `library.json` whose FIRST read returns a frozen
    * snapshot — the deterministic stand-in for "this device read the index, then
@@ -379,7 +405,7 @@ describe('FileSyncEngine.syncLibrary — concurrent index writers', () => {
 
     await new FileSyncEngine(racingProvider(stale, live), fakeStore()).syncLibrary(
       [makeBook('h1', { updatedAt: 200 })],
-      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+      { strategy: 'send', syncBooks: false, fullSync: true, deviceId: 'pc' },
     );
 
     const idx = JSON.parse(live.body) as RemoteLibraryIndex;
@@ -407,41 +433,60 @@ describe('FileSyncEngine.syncLibrary — concurrent index writers', () => {
 
     await new FileSyncEngine(racingProvider(stale, live), fakeStore()).syncLibrary(
       [makeBook('h1', { title: 'Mine', updatedAt: 200 })],
-      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+      { strategy: 'send', syncBooks: false, fullSync: true, deviceId: 'pc' },
     );
 
     expect((JSON.parse(live.body) as RemoteLibraryIndex).books[0]!.title).toBe('Mine');
   });
 
-  test('an etag that moved during the run forces the fold', async () => {
-    // The short-circuit must key on "provably unchanged", not on having an
-    // etag at all: a peer writing mid-run moves it, and that is exactly when
-    // the fold has to happen.
+  test('a backend with no etag skips the discovery scan on an unchanged index', async () => {
+    // iCloud has no etag at all and many WebDAV servers omit it, so the etag
+    // short-circuit never fired for them and every incremental sync re-listed
+    // the whole remote books/ directory. The index content answers the same
+    // question — nobody wrote since — and we already downloaded it.
+    const idx = JSON.stringify({
+      schemaVersion: 1,
+      updatedAt: 1,
+      books: [makeBook('h1')],
+      uploadedHashes: ['h1'],
+    } satisfies RemoteLibraryIndex);
+    let lists = 0;
+    const provider = fakeProvider({
+      head: async () => null, // no etag, like iCloud
+      readText: async (p) => (p.endsWith('library.json') ? idx : null),
+      list: async () => {
+        lists += 1;
+        return [];
+      },
+    });
+    const opts = { strategy: 'silent', syncBooks: false, deviceId: 'pc' } as const;
+
+    await new FileSyncEngine(provider, fakeStore()).syncLibrary([makeBook('h1')], opts);
+    expect(lists).toBeGreaterThan(0); // first run has no snapshot: it scans
+
+    lists = 0;
+    await new FileSyncEngine(provider, fakeStore()).syncLibrary([makeBook('h1')], opts);
+    expect(lists).toBe(0);
+  });
+
+  test('an incremental run never re-reads the index before pushing', async () => {
+    // The incremental path's contract is speed: it is best-effort, runs
+    // unattended on every library change, and must not pay a second GET of
+    // library.json (tens to hundreds of KB) to win a race it is allowed to
+    // lose. Losing one is self-healing anyway — membership is a union-by-hash
+    // CRDT, so the device that owns a dropped row re-publishes it.
     const stale = JSON.stringify({
       schemaVersion: 1,
       updatedAt: 1,
       books: [makeBook('h1')],
     } satisfies RemoteLibraryIndex);
-    const live = {
-      body: JSON.stringify({
-        schemaVersion: 1,
-        updatedAt: 2,
-        books: [makeBook('h1'), makeBook('peer')],
-      } satisfies RemoteLibraryIndex),
-    };
-
-    let libraryHeads = 0;
+    const live = { body: stale };
     let libraryReads = 0;
     const provider = fakeProvider({
-      head: async (p) => {
-        if (!p.endsWith('library.json')) return null;
-        libraryHeads += 1;
-        return { etag: libraryHeads === 1 ? 'E1' : 'E2' };
-      },
       readText: async (p) => {
         if (!p.endsWith('library.json')) return null;
         libraryReads += 1;
-        return libraryReads === 1 ? stale : live.body;
+        return live.body;
       },
       writeText: async (p, body) => {
         if (p.endsWith('library.json')) live.body = body;
@@ -450,14 +495,10 @@ describe('FileSyncEngine.syncLibrary — concurrent index writers', () => {
 
     await new FileSyncEngine(provider, fakeStore()).syncLibrary(
       [makeBook('h1', { updatedAt: 200 })],
-      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+      { strategy: 'send', syncBooks: false, fullSync: false, deviceId: 'pc' },
     );
 
-    expect(libraryReads).toBe(2);
-    expect((JSON.parse(live.body) as RemoteLibraryIndex).books.map((b) => b.hash).sort()).toEqual([
-      'h1',
-      'peer',
-    ]);
+    expect(libraryReads).toBe(1);
   });
 
   test('the fold does not resurrect an empty-dir record this run disproved', async () => {
@@ -526,6 +567,7 @@ describe('FileSyncEngine.syncLibrary — concurrent index writers', () => {
     ).syncLibrary([makeBook('h1', { updatedAt: 200 })], {
       strategy: 'send',
       syncBooks: false,
+      fullSync: true,
       deviceId: 'pc',
     });
 

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-converge-5900.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-converge-5900.test.ts
@@ -330,6 +330,210 @@ describe('FileSyncEngine.syncLibrary — two devices converge (#5900)', () => {
   });
 });
 
+describe('FileSyncEngine.syncLibrary — concurrent index writers', () => {
+  /**
+   * A provider over one shared `library.json` whose FIRST read returns a frozen
+   * snapshot — the deterministic stand-in for "this device read the index, then
+   * a peer pushed while it was still working". Later reads see the live file.
+   */
+  const racingProvider = (
+    staleSnapshot: string,
+    live: { body: string },
+    opts: { failReread?: boolean } = {},
+  ): FileSyncProvider => {
+    let reads = 0;
+    return fakeProvider({
+      readText: async (p) => {
+        if (!p.endsWith('library.json')) return null;
+        reads += 1;
+        if (reads === 1) return staleSnapshot;
+        if (opts.failReread) throw new FileSyncError('offline', 'NETWORK', 503);
+        return live.body;
+      },
+      writeText: async (p, body) => {
+        if (p.endsWith('library.json')) live.body = body;
+      },
+    });
+  };
+
+  test('does not drop a peer entry written while this run was working', async () => {
+    // This device started from an index holding only h1. While it worked, a
+    // peer pushed a book of its own, a confirmed upload, an empty-dir record
+    // and a tombstone. Rebuilding from the stale snapshot would erase all four.
+    const stale = JSON.stringify({
+      schemaVersion: 1,
+      updatedAt: 1,
+      books: [makeBook('h1')],
+      uploadedHashes: ['h1'],
+    } satisfies RemoteLibraryIndex);
+
+    const live = {
+      body: JSON.stringify({
+        schemaVersion: 1,
+        updatedAt: 2,
+        books: [makeBook('h1'), makeBook('peer'), makeBook('gone', { deletedAt: 9000 })],
+        uploadedHashes: ['h1', 'peer'],
+        emptyDirs: ['dir9'],
+      } satisfies RemoteLibraryIndex),
+    };
+
+    await new FileSyncEngine(racingProvider(stale, live), fakeStore()).syncLibrary(
+      [makeBook('h1', { updatedAt: 200 })],
+      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+    );
+
+    const idx = JSON.parse(live.body) as RemoteLibraryIndex;
+    expect(idx.books.map((b) => b.hash).sort()).toEqual(['gone', 'h1', 'peer']);
+    expect(idx.books.find((b) => b.hash === 'gone')!.deletedAt).toBe(9000);
+    expect(idx.uploadedHashes).toEqual(expect.arrayContaining(['h1', 'peer']));
+    expect(idx.emptyDirs).toEqual(['dir9']);
+  });
+
+  test('this run still wins for the books it actually owns', async () => {
+    // Folding the peer's entries in must not turn the re-push into a pull:
+    // 'send' remains authoritative for its own rows.
+    const stale = JSON.stringify({
+      schemaVersion: 1,
+      updatedAt: 1,
+      books: [makeBook('h1', { title: 'Old' })],
+    } satisfies RemoteLibraryIndex);
+    const live = {
+      body: JSON.stringify({
+        schemaVersion: 1,
+        updatedAt: 2,
+        books: [makeBook('h1', { title: 'Peer Wrote This' })],
+      } satisfies RemoteLibraryIndex),
+    };
+
+    await new FileSyncEngine(racingProvider(stale, live), fakeStore()).syncLibrary(
+      [makeBook('h1', { title: 'Mine', updatedAt: 200 })],
+      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+    );
+
+    expect((JSON.parse(live.body) as RemoteLibraryIndex).books[0]!.title).toBe('Mine');
+  });
+
+  test('an etag that moved during the run forces the fold', async () => {
+    // The short-circuit must key on "provably unchanged", not on having an
+    // etag at all: a peer writing mid-run moves it, and that is exactly when
+    // the fold has to happen.
+    const stale = JSON.stringify({
+      schemaVersion: 1,
+      updatedAt: 1,
+      books: [makeBook('h1')],
+    } satisfies RemoteLibraryIndex);
+    const live = {
+      body: JSON.stringify({
+        schemaVersion: 1,
+        updatedAt: 2,
+        books: [makeBook('h1'), makeBook('peer')],
+      } satisfies RemoteLibraryIndex),
+    };
+
+    let libraryHeads = 0;
+    let libraryReads = 0;
+    const provider = fakeProvider({
+      head: async (p) => {
+        if (!p.endsWith('library.json')) return null;
+        libraryHeads += 1;
+        return { etag: libraryHeads === 1 ? 'E1' : 'E2' };
+      },
+      readText: async (p) => {
+        if (!p.endsWith('library.json')) return null;
+        libraryReads += 1;
+        return libraryReads === 1 ? stale : live.body;
+      },
+      writeText: async (p, body) => {
+        if (p.endsWith('library.json')) live.body = body;
+      },
+    });
+
+    await new FileSyncEngine(provider, fakeStore()).syncLibrary(
+      [makeBook('h1', { updatedAt: 200 })],
+      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+    );
+
+    expect(libraryReads).toBe(2);
+    expect((JSON.parse(live.body) as RemoteLibraryIndex).books.map((b) => b.hash).sort()).toEqual([
+      'h1',
+      'peer',
+    ]);
+  });
+
+  test('the fold does not resurrect an empty-dir record this run disproved', async () => {
+    // Folding the peer's records back in must not undo newer knowledge: this
+    // run listed hx and found a book file in it, so the peer's "hx is empty"
+    // entry is stale, not a competing addition.
+    const stale = JSON.stringify({
+      schemaVersion: 1,
+      updatedAt: 1,
+      books: [],
+      emptyDirs: [],
+    } satisfies RemoteLibraryIndex);
+    const live = {
+      body: JSON.stringify({
+        schemaVersion: 1,
+        updatedAt: 2,
+        books: [],
+        emptyDirs: ['hx'],
+      } satisfies RemoteLibraryIndex),
+    };
+
+    let reads = 0;
+    const provider = fakeProvider({
+      readText: async (p) => {
+        if (!p.endsWith('library.json')) return null;
+        reads += 1;
+        return reads === 1 ? stale : live.body;
+      },
+      writeText: async (p, body) => {
+        if (p.endsWith('library.json')) live.body = body;
+      },
+      list: async (p) =>
+        p.endsWith('/books')
+          ? [{ name: 'hx', path: '/Readest/books/hx', isDirectory: true }]
+          : [
+              {
+                name: 'Book hx.epub',
+                path: '/Readest/books/hx/Book hx.epub',
+                isDirectory: false,
+                size: 10,
+              },
+            ],
+    });
+
+    await new FileSyncEngine(provider, fakeStore()).syncLibrary([], {
+      strategy: 'silent',
+      syncBooks: false,
+      fullSync: true,
+      deviceId: 'pc',
+    });
+
+    expect((JSON.parse(live.body) as RemoteLibraryIndex).emptyDirs).not.toContain('hx');
+  });
+
+  test('skips the push rather than clobbering when the pre-push re-read fails', async () => {
+    const stale = JSON.stringify({
+      schemaVersion: 1,
+      updatedAt: 1,
+      books: [makeBook('h1')],
+    } satisfies RemoteLibraryIndex);
+    const live = { body: 'PEER STATE MUST SURVIVE' };
+
+    const res = await new FileSyncEngine(
+      racingProvider(stale, live, { failReread: true }),
+      fakeStore(),
+    ).syncLibrary([makeBook('h1', { updatedAt: 200 })], {
+      strategy: 'send',
+      syncBooks: false,
+      deviceId: 'pc',
+    });
+
+    expect(live.body).toBe('PEER STATE MUST SURVIVE');
+    expect(res.indexPushFailed).toBe(true);
+  });
+});
+
 describe('FileSyncEngine.syncLibrary — index write failure is reported (#5900)', () => {
   test('surfaces a failed library.json write instead of swallowing it', async () => {
     const provider = fakeProvider({

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-send-only-index-safety.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-send-only-index-safety.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'vitest';
+
+import type { Book } from '@/types/book';
+import { FileSyncEngine } from '@/services/sync/file/engine';
+import type { FileSyncProvider } from '@/services/sync/file/provider';
+import type { LocalStore } from '@/services/sync/file/localStore';
+import type { RemoteLibraryIndex } from '@/services/sync/file/wire';
+
+/**
+ * Regression coverage for #5900: a "Send Only" (strategy 'send') run never
+ * read the remote library.json index before rewriting it, so its final
+ * re-push carried only this device's own `uploadedHashes` / book set and
+ * silently dropped every previously-confirmed upload and every book entry
+ * another device had contributed that this device doesn't locally know
+ * about — exactly the "uploadedHashes shrinks" and "peer's live book goes
+ * missing" symptoms reported against multi-device WebDAV Full Sync.
+ */
+
+const makeBook = (hash: string, overrides: Partial<Book> = {}): Book => ({
+  hash,
+  format: 'EPUB',
+  title: `Book ${hash}`,
+  sourceTitle: `Book ${hash}`,
+  author: 'A',
+  createdAt: 1,
+  updatedAt: 100,
+  ...overrides,
+});
+
+type Captured = { writes: { path: string; body: string }[] };
+
+const fakeProvider = (
+  opts: Partial<FileSyncProvider> & { captured?: Captured } = {},
+): FileSyncProvider => ({
+  rootPath: '/',
+  readText: opts.readText ?? (async () => null),
+  readBinary: opts.readBinary ?? (async () => new ArrayBuffer(8)),
+  head: opts.head ?? (async () => null),
+  list: opts.list ?? (async () => []),
+  writeText:
+    opts.writeText ??
+    (async (path: string, body: string) => {
+      opts.captured?.writes.push({ path, body });
+    }),
+  writeBinary: opts.writeBinary ?? (async () => {}),
+  ensureDir: opts.ensureDir ?? (async () => {}),
+  deleteDir: opts.deleteDir ?? (async () => {}),
+});
+
+const fakeStore = (opts: Partial<LocalStore> = {}): LocalStore => ({
+  loadConfig: opts.loadConfig ?? (async () => ({ updatedAt: 1, booknotes: [] })),
+  saveBookConfig: opts.saveBookConfig ?? (async () => {}),
+  loadBookFile: opts.loadBookFile ?? (async () => null),
+  resolveLocalBookPath: opts.resolveLocalBookPath ?? (async () => null),
+  saveBookFile: opts.saveBookFile ?? (async () => {}),
+  prepareLocalBookPath: opts.prepareLocalBookPath ?? (async () => '/local/dst'),
+  loadBookCover: opts.loadBookCover ?? (async () => null),
+  saveBookCover: opts.saveBookCover ?? (async () => {}),
+  addBookToLibrary: opts.addBookToLibrary ?? (async () => {}),
+  updateBookMetadata: opts.updateBookMetadata ?? (async () => {}),
+  deleteBookLocally: opts.deleteBookLocally ?? (async () => {}),
+  markBooksUploaded: opts.markBooksUploaded ?? (async () => {}),
+});
+
+describe('FileSyncEngine.syncLibrary — Send Only index safety (#5900)', () => {
+  test('carries forward the remote uploadedHashes record and a peer-only book', async () => {
+    // The shared index already records two confirmed uploads (h1, h2), but
+    // this device only knows about h1 locally — h2 was uploaded by a peer.
+    const remoteIndex: RemoteLibraryIndex = {
+      schemaVersion: 1,
+      updatedAt: 1,
+      books: [makeBook('h1'), makeBook('h2')],
+      uploadedHashes: ['h1', 'h2'],
+    };
+    const captured: Captured = { writes: [] };
+    const provider = fakeProvider({
+      readText: async (p) => (p.endsWith('library.json') ? JSON.stringify(remoteIndex) : null),
+      captured,
+    });
+
+    const res = await new FileSyncEngine(provider, fakeStore()).syncLibrary([makeBook('h1')], {
+      strategy: 'send',
+      syncBooks: false,
+      deviceId: 'pc',
+    });
+
+    // 'send' still blindly pushes the local book's config (unaffected).
+    expect(res.configsUploaded).toBe(1);
+
+    const idx = JSON.parse(
+      captured.writes.find((w) => w.path.endsWith('library.json'))!.body,
+    ) as RemoteLibraryIndex;
+    // Before the fix, `uploadedHashes` was rebuilt from scratch (empty, since
+    // send mode never pulled the index) and h2 — a book only a peer had
+    // pushed — disappeared from the index entirely.
+    expect(idx.uploadedHashes).toEqual(expect.arrayContaining(['h1', 'h2']));
+    expect(idx.books.map((b) => b.hash).sort()).toEqual(['h1', 'h2']);
+  });
+
+  test('still performs a blind push regardless of the remote index (unchanged semantics)', async () => {
+    // Remote already has a newer copy of h1 than local — under 'silent' this
+    // would skip the push (remote wins the incremental cursor). 'send' must
+    // keep pushing anyway: it is documented as a blind, local-authoritative
+    // push, and reading the index for bookkeeping must not change that.
+    const remoteIndex: RemoteLibraryIndex = {
+      schemaVersion: 1,
+      updatedAt: 1,
+      books: [makeBook('h1', { updatedAt: 500, title: 'Remote Title' })],
+      uploadedHashes: ['h1'],
+    };
+    const captured: Captured = { writes: [] };
+    const provider = fakeProvider({
+      readText: async (p) => (p.endsWith('library.json') ? JSON.stringify(remoteIndex) : null),
+      captured,
+    });
+
+    const res = await new FileSyncEngine(provider, fakeStore()).syncLibrary(
+      [makeBook('h1', { updatedAt: 100 })],
+      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+    );
+
+    expect(res.configsUploaded).toBe(1);
+    expect(captured.writes.some((w) => w.path.endsWith('config.json'))).toBe(true);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/sync/file/engine-send-only-index-safety.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/engine-send-only-index-safety.test.ts
@@ -78,11 +78,10 @@ describe('FileSyncEngine.syncLibrary — Send Only index safety (#5900)', () => 
       captured,
     });
 
-    const res = await new FileSyncEngine(provider, fakeStore()).syncLibrary([makeBook('h1')], {
-      strategy: 'send',
-      syncBooks: false,
-      deviceId: 'pc',
-    });
+    const res = await new FileSyncEngine(provider, fakeStore()).syncLibrary(
+      [makeBook('h1', { updatedAt: 200 })],
+      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+    );
 
     // 'send' still blindly pushes the local book's config (unaffected).
     expect(res.configsUploaded).toBe(1);
@@ -97,11 +96,11 @@ describe('FileSyncEngine.syncLibrary — Send Only index safety (#5900)', () => 
     expect(idx.books.map((b) => b.hash).sort()).toEqual(['h1', 'h2']);
   });
 
-  test('still performs a blind push regardless of the remote index (unchanged semantics)', async () => {
-    // Remote already has a newer copy of h1 than local — under 'silent' this
-    // would skip the push (remote wins the incremental cursor). 'send' must
-    // keep pushing anyway: it is documented as a blind, local-authoritative
-    // push, and reading the index for bookkeeping must not change that.
+  test('a Full Sync send still pushes over a newer remote row', async () => {
+    // Remote has a newer copy of h1 than local. The incremental cursor skips
+    // that push for every strategy (#5900: a 'send' run that re-pushed every
+    // book was O(library) per sync). Blind local-authoritative overwrite is
+    // what `fullSync` is for, so that is where this invariant now lives.
     const remoteIndex: RemoteLibraryIndex = {
       schemaVersion: 1,
       updatedAt: 1,
@@ -116,10 +115,32 @@ describe('FileSyncEngine.syncLibrary — Send Only index safety (#5900)', () => 
 
     const res = await new FileSyncEngine(provider, fakeStore()).syncLibrary(
       [makeBook('h1', { updatedAt: 100 })],
-      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+      { strategy: 'send', syncBooks: false, fullSync: true, deviceId: 'pc' },
     );
 
     expect(res.configsUploaded).toBe(1);
     expect(captured.writes.some((w) => w.path.endsWith('config.json'))).toBe(true);
+  });
+
+  test('an incremental send skips a book the index already has at the same version', async () => {
+    const remoteIndex: RemoteLibraryIndex = {
+      schemaVersion: 1,
+      updatedAt: 1,
+      books: [makeBook('h1', { updatedAt: 500 })],
+      uploadedHashes: ['h1'],
+    };
+    const captured: Captured = { writes: [] };
+    const provider = fakeProvider({
+      readText: async (p) => (p.endsWith('library.json') ? JSON.stringify(remoteIndex) : null),
+      captured,
+    });
+
+    const res = await new FileSyncEngine(provider, fakeStore()).syncLibrary(
+      [makeBook('h1', { updatedAt: 100 })],
+      { strategy: 'send', syncBooks: false, deviceId: 'pc' },
+    );
+
+    expect(res.configsUploaded).toBe(0);
+    expect(captured.writes.some((w) => w.path.endsWith('config.json'))).toBe(false);
   });
 });

--- a/apps/readest-app/src/__tests__/services/sync/file/runLibrarySync.test.ts
+++ b/apps/readest-app/src/__tests__/services/sync/file/runLibrarySync.test.ts
@@ -5,7 +5,16 @@ import { useLibraryStore } from '@/store/libraryStore';
 import { useFileSyncStore } from '@/store/fileSyncStore';
 import type { SystemSettings } from '@/types/settings';
 
-const syncLibrary = vi.fn().mockResolvedValue({ booksSynced: 0 });
+/** A complete SyncLibraryResult shape; the pass merges every reporting field. */
+const syncResult = (over: Record<string, unknown> = {}) => ({
+  booksSynced: 0,
+  failures: 0,
+  failedBooks: [],
+  indexPushFailed: false,
+  ...over,
+});
+
+const syncLibrary = vi.fn().mockResolvedValue(syncResult());
 const pushBookFile = vi.fn().mockResolvedValue({ uploaded: true });
 const pushBookCover = vi.fn().mockResolvedValue({ uploaded: true });
 const downloadBookFile = vi.fn().mockResolvedValue(true);
@@ -96,7 +105,7 @@ const multiProviderSettings = {
 
 describe('runFileLibrarySyncPass', () => {
   beforeEach(() => {
-    syncLibrary.mockReset().mockResolvedValue({ booksSynced: 1 });
+    syncLibrary.mockReset().mockResolvedValue(syncResult({ booksSynced: 1 }));
     useSettingsStore.getState().setSettings(multiProviderSettings);
     useLibraryStore.setState({ library: [makeBook('h1')], libraryLoaded: true });
     useFileSyncStore.setState({ byKind: {}, activeKind: null, lastErrorByKind: {} });
@@ -109,12 +118,36 @@ describe('runFileLibrarySyncPass', () => {
     expect(result?.booksSynced).toBe(2);
   });
 
+  test('aggregates failures across backends instead of keeping only the last (#5900)', async () => {
+    // A spread of the LAST result silently replaced the earlier backends'
+    // failure counts, so a pass where the first mirror failed every book and
+    // the second succeeded reported a clean run.
+    syncLibrary
+      .mockReset()
+      .mockResolvedValueOnce(
+        syncResult({
+          booksSynced: 1,
+          failures: 3,
+          failedBooks: [{ hash: 'h1', title: 'A', reason: 'no source', phase: 'upload-file' }],
+          indexPushFailed: true,
+        }),
+      )
+      .mockResolvedValueOnce(syncResult({ booksSynced: 1 }));
+
+    const result = await runFileLibrarySyncPass(envConfig, translationFn);
+
+    expect(result?.booksSynced).toBe(2);
+    expect(result?.failures).toBe(3);
+    expect(result?.failedBooks).toHaveLength(1);
+    expect(result?.indexPushFailed).toBe(true);
+  });
+
   test('holds the mutex for the whole pass', async () => {
     let lockedDuringPass: boolean | null = null;
     syncLibrary.mockImplementation(async () => {
       // A racing auto-sync must be refused while the pass is mid-flight.
       lockedDuringPass = useFileSyncStore.getState().beginSync('s3', 'Syncing…') === false;
-      return { booksSynced: 1 };
+      return syncResult({ booksSynced: 1 });
     });
     await runFileLibrarySyncPass(envConfig, translationFn);
     expect(lockedDuringPass).toBe(true);
@@ -145,7 +178,7 @@ describe('runFileLibrarySyncPass', () => {
   test('a failing backend does not stop the others', async () => {
     syncLibrary
       .mockRejectedValueOnce(new Error('token expired'))
-      .mockResolvedValueOnce({ booksSynced: 3 });
+      .mockResolvedValueOnce(syncResult({ booksSynced: 3 }));
 
     const result = await runFileLibrarySyncPass(envConfig, translationFn);
 

--- a/apps/readest-app/src/app/library/hooks/useBooksSync.ts
+++ b/apps/readest-app/src/app/library/hooks/useBooksSync.ts
@@ -115,7 +115,11 @@ export const useBooksSync = () => {
         let fileSucceeded = false;
         if (runFilePass) {
           const result = await runFileLibrarySyncPass(envConfig, _);
-          fileSucceeded = result !== null;
+          // A run that could not write library.json converged NOTHING, however
+          // many books it uploaded: peers read membership, tombstones and the
+          // uploaded-file record from that one file. Reporting it as "N books
+          // synced" is what let #5900 go unnoticed for so long.
+          fileSucceeded = result !== null && !result.indexPushFailed;
           fileSynced = result?.booksSynced ?? 0;
         }
 

--- a/apps/readest-app/src/services/sync/file/engine.ts
+++ b/apps/readest-app/src/services/sync/file/engine.ts
@@ -838,6 +838,10 @@ export class FileSyncEngine {
     // Dirs discovery already inspected and found file-less (see wire.ts).
     // Carried forward through the index so no client re-lists them every run.
     const emptyDirs = new Set<string>(remoteIndex?.emptyDirs ?? []);
+    // Dirs THIS run looked inside and found a book file in. Kept so the
+    // pre-push reconcile below can tell "the peer knows something we don't"
+    // from "the peer's record is stale and we just disproved it".
+    const confirmedNonEmptyDirs = new Set<string>();
     // Whether the books/ listing ran and succeeded this run — the empty-dir
     // record may only be pruned against a listing that actually happened.
     let booksDirListed = false;
@@ -907,6 +911,7 @@ export class FileSyncEngine {
             continue;
           }
           emptyDirs.delete(hash);
+          confirmedNonEmptyDirs.add(hash);
 
           const extMatch = fileEntry.name.match(/\.([^.]+)$/);
           const ext = extMatch && extMatch[1] ? extMatch[1].toUpperCase() : 'EPUB';
@@ -1176,11 +1181,14 @@ export class FileSyncEngine {
       // Carry the uploaded-file record forward so the next incremental sync
       // stays O(changed). Keep only hashes that still map to a live indexed
       // book so the set can't grow unbounded with tombstoned / evicted books.
-      const nextUploadedHashes = Array.from(uploadedHashes).filter((hash) => {
-        const b = indexByHash.get(hash);
-        return !!b && !b.deletedAt;
+      const buildRecords = () => ({
+        uploadedHashes: Array.from(uploadedHashes).filter((hash) => {
+          const b = indexByHash.get(hash);
+          return !!b && !b.deletedAt;
+        }),
+        emptyDirs: Array.from(emptyDirs),
       });
-      const nextEmptyDirs = Array.from(emptyDirs);
+      const { uploadedHashes: nextUploadedHashes, emptyDirs: nextEmptyDirs } = buildRecords();
 
       // Skip the re-push when the rebuilt index is semantically identical to
       // the pulled one: a restamped byte-copy only churns the remote and
@@ -1205,12 +1213,60 @@ export class FileSyncEngine {
 
       if (indexDirty) {
         try {
+          // Last-moment reconcile. Everything above was computed from the index
+          // as it looked when this run STARTED, and a peer syncing in parallel
+          // may have rewritten it since — so publishing the rebuild as-is would
+          // drop whatever that peer added, which is the same lost-update this
+          // PR fixes for 'send', just on a shorter clock. Re-read and fold its
+          // entries in the same way: by hash, ours winning where both have an
+          // opinion.
+          //
+          // This NARROWS the read-modify-write window from the whole run (which
+          // spans every upload, so minutes on a big library) to the gap between
+          // this read and the PUT. It does not CLOSE it: two devices whose PUTs
+          // land inside that gap still race. Closing it needs a conditional
+          // write, and there is nothing portable to condition on today —
+          // `head()` exposes no version token at all on iCloud and only a
+          // server-dependent one on WebDAV, so an If-Match capability would
+          // have to be added to FileSyncProvider and degrade per backend.
+          // Tracked as follow-up; the union-by-hash CRDT means a lost row is
+          // re-published by the device that owns it on its next run.
+          //
+          // Skipped when the etag proves nothing has been written since we
+          // read: our snapshot IS the current file, so there is nothing to
+          // fold, and re-pulling would undo the change-probe short-circuit
+          // that keeps a quiet incremental run down to one metadata stat.
+          // A provider with no etag (iCloud, WebDAV servers that omit the
+          // header) can never prove it, so it always re-reads — which is the
+          // safe default, and those are the backends that need it most.
+          let unchangedSincePull = false;
+          if (remoteEtag !== undefined) {
+            try {
+              const now = (await this.provider.head(buildLibraryPath(this.provider.rootPath)))
+                ?.etag;
+              unchangedSincePull = now !== undefined && now === remoteEtag;
+            } catch {
+              // Probe failed: fall through to the full re-read.
+            }
+          }
+          const fresh = unchangedSincePull ? remoteIndex : await this.pullLibraryIndex();
+          for (const rb of fresh?.books ?? []) {
+            if (!indexByHash.has(rb.hash)) indexByHash.set(rb.hash, rb);
+          }
+          for (const hash of fresh?.uploadedHashes ?? []) uploadedHashes.add(hash);
+          for (const hash of fresh?.emptyDirs ?? []) {
+            // ...except a dir THIS run looked inside and found a file in. That
+            // is newer knowledge than the peer's record, not a competing entry.
+            if (!confirmedNonEmptyDirs.has(hash)) emptyDirs.add(hash);
+          }
+          const merged = buildRecords();
+
           const newIndex: RemoteLibraryIndex = {
             schemaVersion: 1,
             books: Array.from(indexByHash.values()).map(stripDeviceLocalFields),
             updatedAt: Date.now(),
-            uploadedHashes: nextUploadedHashes,
-            emptyDirs: nextEmptyDirs,
+            uploadedHashes: merged.uploadedHashes,
+            emptyDirs: merged.emptyDirs,
           };
           await this.pushLibraryIndex(newIndex);
           // Our own push changed the remote etag; drop the cached snapshot so

--- a/apps/readest-app/src/services/sync/file/engine.ts
+++ b/apps/readest-app/src/services/sync/file/engine.ts
@@ -81,6 +81,13 @@ export interface SyncLibraryResult {
   failures: number;
   /** Per-book failure breakdown for the diagnostic log in the Settings UI. */
   failedBooks: SyncFailureEntry[];
+  /**
+   * True when the shared library.json write itself failed (#5900). The per-book
+   * uploads may all have succeeded, yet nothing converged: peers read
+   * membership, tombstones and the uploaded-file record from that one file. A
+   * run that could not write it must not be reported as a plain success.
+   */
+  indexPushFailed: boolean;
 }
 
 export interface SyncLibraryOptions {
@@ -515,6 +522,7 @@ export class FileSyncEngine {
       booksSynced: 0,
       failures: 0,
       failedBooks: [],
+      indexPushFailed: false,
     };
 
     // Distinct books touched in any direction — the single "N book(s) synced"
@@ -535,47 +543,47 @@ export class FileSyncEngine {
     // so an unchanged index means no remote-side news — the run can skip the
     // index download AND the discovery scan.
     let remoteIndexUnchanged = false;
-    // Always pulled, even under 'send' (canPull === false): the final re-push
-    // below needs the remote's `uploadedHashes` / `emptyDirs` and any book
-    // entries this device doesn't locally know about (chiefly a peer's
-    // upload or tombstone), or a Send Only run rewrites library.json from
-    // this device's state alone — silently dropping every previously
-    // confirmed upload and every peer-only book (#5900). The per-book pull
-    // behaviors (metadata reconciliation, deletion propagation, discovery,
-    // config pull-merge) stay independently gated on `canPull` below, so
-    // 'send' still performs its documented blind, local-authoritative push.
-    {
-      // Cheap change probe: one metadata stat. `etag` is Drive's md5 / the
-      // WebDAV ETag; a provider without one always re-pulls. An AUTH failure
-      // aborts exactly like the pull below; any other probe failure falls
-      // back to the full pull.
-      let remoteEtag: string | undefined;
-      if (!fullSync) {
-        try {
-          remoteEtag = (await this.provider.head(buildLibraryPath(this.provider.rootPath)))?.etag;
-        } catch (e) {
-          if (e instanceof FileSyncError && e.code === 'AUTH_FAILED') throw e;
-        }
+    // Read UNCONDITIONALLY, 'send' included (#5900). library.json is the shared
+    // membership record, not a source of remote changes: the final re-push
+    // below rebuilds it, so a run that rewrites it without having read it
+    // publishes this device's state as the whole truth — dropping every
+    // previously confirmed upload and every book or tombstone a peer
+    // contributed that this device never materialised. The pull itself is a
+    // pure read; every behaviour that APPLIES remote state to this device
+    // (metadata reconciliation, deletion propagation, discovery, config
+    // pull-merge, the push cursors) stays gated on `canPull` below, so 'send'
+    // keeps its documented blind, local-authoritative push.
+    //
+    // Cheap change probe first: one metadata stat. `etag` is Drive's md5 / the
+    // WebDAV ETag; a provider without one always re-pulls. An AUTH failure
+    // aborts exactly like the pull below; any other probe failure falls back
+    // to the full pull.
+    let remoteEtag: string | undefined;
+    if (!fullSync) {
+      try {
+        remoteEtag = (await this.provider.head(buildLibraryPath(this.provider.rootPath)))?.etag;
+      } catch (e) {
+        if (e instanceof FileSyncError && e.code === 'AUTH_FAILED') throw e;
       }
-      const cached = remoteIndexCache.get(this.provider);
-      if (!fullSync && remoteEtag !== undefined && cached && cached.etag === remoteEtag) {
-        remoteIndex = structuredClone(cached.index);
-        remoteIndexUnchanged = true;
-      } else {
-        // An UNREADABLE index (throw — expired session, network) is NOT the
-        // same as an ABSENT one (404 → null, first-sync semantics). Proceeding
-        // with a null index here would treat every local book as unpushed (an
-        // attempted mass re-upload against a dead session) and the final index
-        // re-push would drop the peers' tombstones it failed to read (#4860),
-        // resurrecting deleted books. Abort the run instead; callers surface
-        // one error.
-        remoteIndex = await this.pullLibraryIndex();
-        if (remoteIndex && remoteEtag !== undefined) {
-          remoteIndexCache.set(this.provider, {
-            etag: remoteEtag,
-            index: structuredClone(remoteIndex),
-          });
-        }
+    }
+    const cachedIndex = remoteIndexCache.get(this.provider);
+    if (!fullSync && remoteEtag !== undefined && cachedIndex && cachedIndex.etag === remoteEtag) {
+      remoteIndex = structuredClone(cachedIndex.index);
+      remoteIndexUnchanged = true;
+    } else {
+      // An UNREADABLE index (throw — expired session, network) is NOT the
+      // same as an ABSENT one (404 → null, first-sync semantics). Proceeding
+      // with a null index here would treat every local book as unpushed (an
+      // attempted mass re-upload against a dead session) and the final index
+      // re-push would drop the peers' tombstones it failed to read (#4860),
+      // resurrecting deleted books. Abort the run instead; callers surface
+      // one error.
+      remoteIndex = await this.pullLibraryIndex();
+      if (remoteIndex && remoteEtag !== undefined) {
+        remoteIndexCache.set(this.provider, {
+          etag: remoteEtag,
+          index: structuredClone(remoteIndex),
+        });
       }
     }
 
@@ -599,10 +607,10 @@ export class FileSyncEngine {
     // Incremental cursor: a book needs a push only when its local copy is newer
     // than (or absent from) the shared library.json index. `book.updatedAt`
     // bumps on every progress / notes / metadata save, so the index is a
-    // reliable per-book change marker. 'send' ignores this cursor entirely —
-    // it is a blind, local-authoritative push (see class doc) — regardless of
-    // what the (now always-pulled) remote index says; a failed pull aborts
-    // before this point, so every local book also counts as new then.
+    // reliable per-book change marker. 'send' ignores the cursor entirely — it
+    // is a blind, local-authoritative push (see class doc), so reading the
+    // index for bookkeeping must not start letting a remote row suppress a
+    // local push (#5900). A failed pull aborts before this point.
     const remoteByHash = new Map<string, Book>();
     if (remoteIndex?.books) {
       for (const rb of remoteIndex.books) {
@@ -621,8 +629,13 @@ export class FileSyncEngine {
     // it never needs re-checking — this keeps an incremental sync O(changed)
     // by skipping the per-book HEAD probe for already-mirrored files instead of
     // probing every book each run. Seeded from the pulled index and carried
-    // forward (plus this run's uploads) into the re-pushed index. Empty in send
-    // mode / on a fresh remote, so the first sync verifies every file once.
+    // forward (plus this run's uploads) into the re-pushed index. Empty on a
+    // fresh remote, so the first sync verifies every file once.
+    //
+    // 'send' seeds it too — it has to, or the re-push forgets every upload a
+    // peer confirmed — but reads it ONLY to carry it forward, never to skip a
+    // probe (see needsFilePush). #5900 is a report of this record being wrong,
+    // and Send Only is the recovery path a user reaches for when it is.
     const uploadedHashes = new Set<string>(remoteIndex?.uploadedHashes ?? []);
     // A file needs (re)uploading only when syncBooks is on, the remote copy
     // isn't recorded yet, and the LIBRARY ROW says this device holds the file.
@@ -648,7 +661,7 @@ export class FileSyncEngine {
       options.syncBooks &&
       !isAudiobook(book) &&
       (fullSync ||
-        (!uploadedHashes.has(book.hash) &&
+        ((!canPull || !uploadedHashes.has(book.hash)) &&
           hasLocalFile(book) &&
           knownNoSource.get(book.hash) !== (book.updatedAt ?? 0)));
 
@@ -778,6 +791,43 @@ export class FileSyncEngine {
           syncedHashes.add(rb.hash);
         } catch (e) {
           console.warn('file sync: local delete failed', rb.hash, e);
+        }
+      });
+    }
+
+    // Revival stamp (#5900) — the send-mode dual of deletion propagation above.
+    // 'send' keeps its live row and republishes it over the peer's tombstone,
+    // but it republished the row's OLD `updatedAt`, and a peer only revives on
+    // `remote.updatedAt > local.deletedAt`. A book last edited BEFORE the peer
+    // deleted it could therefore never win: the peer kept re-pushing its
+    // tombstone, the next send kept re-pushing the live row, and the two
+    // devices ping-ponged forever without either shelf changing.
+    //
+    // Overriding a tombstone IS the newer decision, so stamp it as one — and
+    // persist it, or the next run regresses to the old clock and a peer that
+    // has not synced yet still refuses to revive. `deletedAt + 1` rather than
+    // `Date.now()`: it is the smallest value that wins, and it cannot lose to a
+    // peer whose wall clock runs ahead of ours (#5661).
+    //
+    // Send-mode only. Under 'silent' the deletion-propagation block above is
+    // the authority — it either applied the tombstone (the row is deleted here
+    // now) or declined it because the local edit was already newer, which the
+    // published row's own `updatedAt` already proves.
+    if (!canPull && canPush && remoteIndex?.books) {
+      const revivals = remoteIndex.books.filter((rb) => {
+        if (!rb.deletedAt) return false;
+        const local = allBooksMap.get(rb.hash);
+        return !!local && !local.deletedAt && (local.updatedAt ?? 0) <= rb.deletedAt;
+      });
+      await runPool(revivals, concurrency, async (rb) => {
+        const local = allBooksMap.get(rb.hash)!;
+        const revived: Book = { ...local, updatedAt: rb.deletedAt! + 1 };
+        try {
+          await this.store.updateBookMetadata(revived);
+          allBooksMap.set(rb.hash, revived);
+          syncedHashes.add(rb.hash);
+        } catch (e) {
+          console.warn('file sync: revival stamp failed', rb.hash, e);
         }
       });
     }
@@ -1167,6 +1217,7 @@ export class FileSyncEngine {
           // the next run re-pulls (and re-discovers) once, then goes quiet.
           remoteIndexCache.delete(this.provider);
         } catch (e) {
+          result.indexPushFailed = true;
           console.warn('file sync: failed to push index', e);
         }
       }

--- a/apps/readest-app/src/services/sync/file/engine.ts
+++ b/apps/readest-app/src/services/sync/file/engine.ts
@@ -188,17 +188,25 @@ const runPool = async <T>(
 };
 
 /**
- * The last successfully pulled library.json (+ its etag) per provider
- * instance. Providers are memoised per connection (see providerRegistry), so
- * this lives for the session and dies with a reconnect / settings change.
- * Lets a run whose etag probe matches skip the full index download — and,
- * since every peer mutation rewrites library.json, skip the discovery scan
- * too. Entries are cloned on read AND write so neither the caching run nor a
+ * The last successfully pulled library.json per provider instance, with both
+ * change signals we can get: the `etag` when the backend has one, and a
+ * `fingerprint` of the content when it does not. Providers are memoised per
+ * connection (see providerRegistry), so this lives for the session and dies
+ * with a reconnect / settings change.
+ *
+ * An etag match skips the index download entirely. A fingerprint match cannot
+ * (we had to download it to compare), but it still proves no peer wrote since
+ * our last run — which is what lets the run skip the DISCOVERY SCAN, a full
+ * listing of books/. Without it, a backend with no etag (iCloud; WebDAV
+ * servers that omit the header) re-listed the whole remote directory on every
+ * incremental sync, which a large library cannot afford.
+ *
+ * Entries are cloned on read AND write so neither the caching run nor a
  * reusing run can pollute the snapshot through in-place row mutations.
  */
 const remoteIndexCache = new WeakMap<
   FileSyncProvider,
-  { etag: string; index: RemoteLibraryIndex }
+  { etag?: string; fingerprint: string; index: RemoteLibraryIndex }
 >();
 
 /**
@@ -504,9 +512,15 @@ export class FileSyncEngine {
    * → pull-merge-push each local config + cover + (optionally) file → re-push
    * the merged index.
    *
-   * Strategy gating: 'silent' two-way, 'send' push-only (blind, local
-   * authoritative), 'receive' pull-only. Single-book failures are caught and
-   * counted so one bad apple never aborts the rest of the library.
+   * Strategy gating: 'silent' two-way, 'send' push-only, 'receive' pull-only.
+   * 'send' applies nothing from the remote — no metadata reconciliation, no
+   * deletion propagation, no discovery, no config pull-merge — but it is still
+   * INCREMENTAL: it reads library.json to know what it already published, and
+   * pushes only what changed locally. The blind local-authoritative overwrite
+   * ("re-push everything, my copy wins") is `fullSync`, not `'send'`, so it is
+   * reached deliberately instead of charged to every background run (#5900).
+   * Single-book failures are caught and counted so one bad apple never aborts
+   * the rest of the library.
    */
   async syncLibrary(books: Book[], options: SyncLibraryOptions): Promise<SyncLibraryResult> {
     const result: SyncLibraryResult = {
@@ -579,9 +593,18 @@ export class FileSyncEngine {
       // resurrecting deleted books. Abort the run instead; callers surface
       // one error.
       remoteIndex = await this.pullLibraryIndex();
-      if (remoteIndex && remoteEtag !== undefined) {
+      if (remoteIndex) {
+        const fingerprint = JSON.stringify(remoteIndex);
+        // No etag to probe with: the download already happened, so compare
+        // what came back against the last snapshot instead. Identical content
+        // carries the same news as a matching etag — nobody wrote since — and
+        // that is what lets the discovery scan below be skipped.
+        if (!fullSync && remoteEtag === undefined && cachedIndex?.fingerprint === fingerprint) {
+          remoteIndexUnchanged = true;
+        }
         remoteIndexCache.set(this.provider, {
           etag: remoteEtag,
+          fingerprint,
           index: structuredClone(remoteIndex),
         });
       }
@@ -607,10 +630,14 @@ export class FileSyncEngine {
     // Incremental cursor: a book needs a push only when its local copy is newer
     // than (or absent from) the shared library.json index. `book.updatedAt`
     // bumps on every progress / notes / metadata save, so the index is a
-    // reliable per-book change marker. 'send' ignores the cursor entirely — it
-    // is a blind, local-authoritative push (see class doc), so reading the
-    // index for bookkeeping must not start letting a remote row suppress a
-    // local push (#5900). A failed pull aborts before this point.
+    // reliable per-book change marker. EVERY strategy uses it, 'send'
+    // included: before #5900 send never read the index, so it re-pushed every
+    // config and re-probed every cover on every run — O(library) per sync,
+    // which a large library cannot afford. A book whose local row has not
+    // changed since the index was written has nothing new to send, so the
+    // cursor costs it nothing. Blind local-authoritative overwrite is Full
+    // Sync's job (see class doc), reached deliberately rather than paid for on
+    // every background run. A failed pull aborts before this point.
     const remoteByHash = new Map<string, Book>();
     if (remoteIndex?.books) {
       for (const rb of remoteIndex.books) {
@@ -618,7 +645,6 @@ export class FileSyncEngine {
       }
     }
     const isLocalNewer = (book: Book): boolean => {
-      if (!canPull) return true;
       const remote = remoteByHash.get(book.hash);
       if (!remote) return true;
       return (book.updatedAt ?? 0) > (remote.updatedAt ?? 0);
@@ -632,10 +658,14 @@ export class FileSyncEngine {
     // forward (plus this run's uploads) into the re-pushed index. Empty on a
     // fresh remote, so the first sync verifies every file once.
     //
-    // 'send' seeds it too — it has to, or the re-push forgets every upload a
-    // peer confirmed — but reads it ONLY to carry it forward, never to skip a
-    // probe (see needsFilePush). #5900 is a report of this record being wrong,
-    // and Send Only is the recovery path a user reaches for when it is.
+    // 'send' now seeds it too. Before #5900 it could not (it never read the
+    // index), so every Send Only run re-probed every book: an O(library) storm
+    // of remote HEADs and local fs stats that made a big library unsyncable.
+    // Trusting the record is what keeps EVERY incremental run O(changed),
+    // whatever the strategy. The record being wrong is a drift case, and drift
+    // in either direction is healed by Full Sync, which bypasses all three
+    // records and audits the real filesystem — that is the escape hatch, not a
+    // per-run re-audit.
     const uploadedHashes = new Set<string>(remoteIndex?.uploadedHashes ?? []);
     // A file needs (re)uploading only when syncBooks is on, the remote copy
     // isn't recorded yet, and the LIBRARY ROW says this device holds the file.
@@ -661,7 +691,7 @@ export class FileSyncEngine {
       options.syncBooks &&
       !isAudiobook(book) &&
       (fullSync ||
-        ((!canPull || !uploadedHashes.has(book.hash)) &&
+        (!uploadedHashes.has(book.hash) &&
           hasLocalFile(book) &&
           knownNoSource.get(book.hash) !== (book.updatedAt ?? 0)));
 
@@ -1213,51 +1243,42 @@ export class FileSyncEngine {
 
       if (indexDirty) {
         try {
-          // Last-moment reconcile. Everything above was computed from the index
-          // as it looked when this run STARTED, and a peer syncing in parallel
-          // may have rewritten it since — so publishing the rebuild as-is would
-          // drop whatever that peer added, which is the same lost-update this
-          // PR fixes for 'send', just on a shorter clock. Re-read and fold its
-          // entries in the same way: by hash, ours winning where both have an
+          // FULL SYNC ONLY: last-moment reconcile. Everything above was
+          // computed from the index as it looked when this run STARTED, and a
+          // peer syncing in parallel may have rewritten it since — so
+          // publishing the rebuild as-is drops whatever that peer added. Re-read
+          // and fold its entries in by hash, ours winning where both have an
           // opinion.
           //
-          // This NARROWS the read-modify-write window from the whole run (which
-          // spans every upload, so minutes on a big library) to the gap between
-          // this read and the PUT. It does not CLOSE it: two devices whose PUTs
-          // land inside that gap still race. Closing it needs a conditional
-          // write, and there is nothing portable to condition on today —
-          // `head()` exposes no version token at all on iCloud and only a
-          // server-dependent one on WebDAV, so an If-Match capability would
-          // have to be added to FileSyncProvider and degrade per backend.
-          // Tracked as follow-up; the union-by-hash CRDT means a lost row is
-          // re-published by the device that owns it on its next run.
+          // Deliberately NOT done on the incremental path. It costs a second
+          // GET of library.json on every pushing run (tens to hundreds of KB
+          // for a real library), and the incremental contract is speed, not
+          // convergence: it is best-effort, runs unattended on every library
+          // change, and is allowed to lose a race. Full Sync is where this
+          // library pays for correctness — the same split that already makes it
+          // the repair path for row-vs-filesystem drift above. A lost row is
+          // in any case re-published by the device that owns it locally, since
+          // membership is a union-by-hash CRDT.
           //
-          // Skipped when the etag proves nothing has been written since we
-          // read: our snapshot IS the current file, so there is nothing to
-          // fold, and re-pulling would undo the change-probe short-circuit
-          // that keeps a quiet incremental run down to one metadata stat.
-          // A provider with no etag (iCloud, WebDAV servers that omit the
-          // header) can never prove it, so it always re-reads — which is the
-          // safe default, and those are the backends that need it most.
-          let unchangedSincePull = false;
-          if (remoteEtag !== undefined) {
-            try {
-              const now = (await this.provider.head(buildLibraryPath(this.provider.rootPath)))
-                ?.etag;
-              unchangedSincePull = now !== undefined && now === remoteEtag;
-            } catch {
-              // Probe failed: fall through to the full re-read.
+          // Even here the window is narrowed, not closed: two Full Syncs whose
+          // PUTs land between this read and the write still race. Closing it
+          // needs a conditional write, and there is nothing portable to
+          // condition on — `head()` exposes no version token at all on iCloud
+          // and only a server-dependent one on WebDAV, so an If-Match
+          // capability would have to be added to FileSyncProvider and degrade
+          // per backend. Follow-up.
+          if (fullSync) {
+            const fresh = await this.pullLibraryIndex();
+            for (const rb of fresh?.books ?? []) {
+              if (!indexByHash.has(rb.hash)) indexByHash.set(rb.hash, rb);
             }
-          }
-          const fresh = unchangedSincePull ? remoteIndex : await this.pullLibraryIndex();
-          for (const rb of fresh?.books ?? []) {
-            if (!indexByHash.has(rb.hash)) indexByHash.set(rb.hash, rb);
-          }
-          for (const hash of fresh?.uploadedHashes ?? []) uploadedHashes.add(hash);
-          for (const hash of fresh?.emptyDirs ?? []) {
-            // ...except a dir THIS run looked inside and found a file in. That
-            // is newer knowledge than the peer's record, not a competing entry.
-            if (!confirmedNonEmptyDirs.has(hash)) emptyDirs.add(hash);
+            for (const hash of fresh?.uploadedHashes ?? []) uploadedHashes.add(hash);
+            for (const hash of fresh?.emptyDirs ?? []) {
+              // ...except a dir THIS run looked inside and found a file in.
+              // That is newer knowledge than the peer's record, not a
+              // competing entry.
+              if (!confirmedNonEmptyDirs.has(hash)) emptyDirs.add(hash);
+            }
           }
           const merged = buildRecords();
 

--- a/apps/readest-app/src/services/sync/file/engine.ts
+++ b/apps/readest-app/src/services/sync/file/engine.ts
@@ -535,7 +535,16 @@ export class FileSyncEngine {
     // so an unchanged index means no remote-side news — the run can skip the
     // index download AND the discovery scan.
     let remoteIndexUnchanged = false;
-    if (canPull) {
+    // Always pulled, even under 'send' (canPull === false): the final re-push
+    // below needs the remote's `uploadedHashes` / `emptyDirs` and any book
+    // entries this device doesn't locally know about (chiefly a peer's
+    // upload or tombstone), or a Send Only run rewrites library.json from
+    // this device's state alone — silently dropping every previously
+    // confirmed upload and every peer-only book (#5900). The per-book pull
+    // behaviors (metadata reconciliation, deletion propagation, discovery,
+    // config pull-merge) stay independently gated on `canPull` below, so
+    // 'send' still performs its documented blind, local-authoritative push.
+    {
       // Cheap change probe: one metadata stat. `etag` is Drive's md5 / the
       // WebDAV ETag; a provider without one always re-pulls. An AUTH failure
       // aborts exactly like the pull below; any other probe failure falls
@@ -590,8 +599,10 @@ export class FileSyncEngine {
     // Incremental cursor: a book needs a push only when its local copy is newer
     // than (or absent from) the shared library.json index. `book.updatedAt`
     // bumps on every progress / notes / metadata save, so the index is a
-    // reliable per-book change marker. When no index is available (send mode,
-    // or a failed pull) every local book counts as new and is pushed.
+    // reliable per-book change marker. 'send' ignores this cursor entirely —
+    // it is a blind, local-authoritative push (see class doc) — regardless of
+    // what the (now always-pulled) remote index says; a failed pull aborts
+    // before this point, so every local book also counts as new then.
     const remoteByHash = new Map<string, Book>();
     if (remoteIndex?.books) {
       for (const rb of remoteIndex.books) {
@@ -599,6 +610,7 @@ export class FileSyncEngine {
       }
     }
     const isLocalNewer = (book: Book): boolean => {
+      if (!canPull) return true;
       const remote = remoteByHash.get(book.hash);
       if (!remote) return true;
       return (book.updatedAt ?? 0) > (remote.updatedAt ?? 0);

--- a/apps/readest-app/src/services/sync/file/runLibrarySync.ts
+++ b/apps/readest-app/src/services/sync/file/runLibrarySync.ts
@@ -158,8 +158,17 @@ export const runFileLibrarySyncPass = async (
         const result = await syncOneBackend(envConfig, kind, _);
         useFileSyncStore.getState().setLastError(kind, null);
         if (result) {
+          // Spread the latest counters, but ACCUMULATE everything that reports
+          // trouble — a plain spread let a healthy second mirror erase the
+          // first one's failures and its unwritten index (#5900).
           merged = merged
-            ? { ...result, booksSynced: merged.booksSynced + result.booksSynced }
+            ? {
+                ...result,
+                booksSynced: merged.booksSynced + result.booksSynced,
+                failures: merged.failures + result.failures,
+                failedBooks: [...merged.failedBooks, ...result.failedBooks],
+                indexPushFailed: merged.indexPushFailed || result.indexPushFailed,
+              }
             : result;
         }
       } catch (e) {


### PR DESCRIPTION
Fixes #5900.

Two commits: @jadhavgaurav's Send Only index fix, and a maintainer follow-up covering the rest of the issue.

## 1. Send Only rewrote `library.json` without reading it (@jadhavgaurav)

`FileSyncEngine.syncLibrary` gated the pull of the shared `library.json` index on `canPull` (`strategy !== 'send'`). But the final index re-push at the end of the run always executes when `canPush` (true for both `'silent'` and `'send'`), rebuilding the shared index from `allBooksMap` (this device's own books) plus a union of `remoteIndex.books` — a union that only happens if `remoteIndex` was actually pulled.

Under **Send Only**, `remoteIndex` was always `null`, so that re-push:
- reset `uploadedHashes` to only what *this run* happened to (re-)confirm, silently forgetting every file a peer had already confirmed uploaded, and
- dropped any book (or tombstone) a peer contributed that this device had never locally materialised.

This matches the issue's own "Source analysis": *"In Send Only mode, Readest does not pull the existing remote index. Therefore, `uploadedHashes` starts empty and is rebuilt using only books successfully checked during the current run."*

**Fix:** pull `library.json` unconditionally (it was already a pure, side-effect-free read), and use it only for the bookkeeping that already existed on the two-way path: seeding `uploadedHashes` / `emptyDirs`, and unioning in remote-only book/tombstone entries before the final re-push. All per-book *pull* behaviors remain independently gated on `canPull`, and `isLocalNewer` now explicitly short-circuits `true` when `!canPull`, making the documented "blind, local-authoritative push" of `'send'` an explicit invariant.

## 2. Tombstone revival never converged

This is the issue's headline symptom (the BOOX stuck at 129 books), and the original scope note here was wrong: the revival path is not correct on `main`. It is unreachable in exactly the reporter's situation.

A peer revives a book only when `remote.updatedAt > local.deletedAt`. But republishing a live row over a peer's tombstone carried the row's **old** `updatedAt`. A book last edited before the peer deleted it can therefore never win:

```
BOOX deletes book X at 5000, pushes the tombstone
PC still has X live, last edited at 100
PC (Send Only) republishes X live with updatedAt 100
BOOX sees 100 > 5000 -> false -> ignores it, re-pushes its tombstone
...forever. Neither shelf ever changes.
```

Under `'silent'` this cannot happen: deletion propagation either applies the tombstone, or declines it because `local.updatedAt >= rb.deletedAt`, which already proves the republished row outranks it. Only `'send'`, which skipped that block entirely, could publish a live row that loses to the tombstone it was overriding.

**Fix:** overriding a tombstone *is* the newer decision, so stamp it as one and persist it. `deletedAt + 1` rather than `Date.now()`: it is the smallest value that wins, and it cannot lose to a peer whose wall clock runs ahead of ours (#5661). Send mode only.

Note this fix *depends* on commit 1: a Send Only run cannot know it is overriding a tombstone until it reads the index.

## 3. Failures were not reported

A failed `library.json` write was swallowed with a `console.warn`, so a run that uploaded books but converged nothing still toasted a book count. `library.json` is the convergence point (peers read membership, tombstones and the uploaded-file record from it), so a run that could not write it did not sync anything, whatever its per-book counters say.

Added `SyncLibraryResult.indexPushFailed`; the library toast now treats it as a failed file pass. Also fixed `runFileLibrarySyncPass`, which spread the last backend's result over the earlier ones and erased their failure counts; it now accumulates `failures`, `failedBooks` and `indexPushFailed`.

Still open as a follow-up: `result.failedBooks` has no consumer anywhere. The comment promises "the diagnostic log in the Settings UI", but that surface does not exist yet, so per-book failures (the issue's "missing local sources") remain invisible. That is UI work, out of scope here.

## 4. Incremental sync is O(changed); Full Sync is the thorough pass

Measured on a 148-book library, quiet incremental Send Only run:

| | HEADs | writes | bytes out |
|---|---|---|---|
| `main` | 296 | 149 | 84 KB |
| this branch | **1** | **0** | **0 B** |

Incremental sync must never walk the local or the remote library. Three things made it do so:

- **`needsFilePush`** re-probed every book under `'send'` (one remote HEAD + one local fs stat each), because `uploadedHashes` was always empty there. Seeding it from the now-pulled index is what makes Send Only incremental. Drift in that record is what Full Sync repairs.
- **`isLocalNewer`** returned `true` unconditionally under `'send'`, so every run re-pushed every config and re-probed every cover. Send Only now uses the same cursor as every other strategy: it still applies nothing from the remote, but only pushes what changed locally. A book whose local row hasn't changed since the index was written has nothing new to send. **Blind local-authoritative overwrite is now `fullSync`, not `'send'`** — reached deliberately rather than charged to every background run. Class doc updated.
- **The discovery scan** lists the whole remote `books/` dir, gated on an etag proving the index unchanged. iCloud exposes no etag and many WebDAV servers omit it, so for those backends the gate never fired and every incremental sync re-listed the library. The index content answers the same question and we already downloaded it, so the cache now keeps a content fingerprint alongside the etag.

## 5. Concurrent index writers, on Full Sync (review follow-up)

The index re-push is a read-modify-write over state computed when the run *started*, so a peer that wrote `library.json` mid-run had its book, tombstone, `uploadedHashes` and `emptyDirs` update erased.

Full Sync now re-reads `library.json` immediately before the PUT and folds the peer's entries in by hash, ours winning where both have an opinion. It respects newer local knowledge: a dir this run listed and found a file in is excluded, so a peer's stale "empty dir" record can't come back. A failed re-read skips the push and reports `indexPushFailed` rather than publishing the stale rebuild.

Deliberately **not** on the incremental path: it costs a second GET of `library.json` on every pushing run, and the incremental contract is speed, not convergence — it runs unattended on every library change and is allowed to lose a race. Membership is a union-by-hash CRDT, so a dropped row is re-published by the device that owns it, and Full Sync reconciles deliberately.

Even on Full Sync the window is narrowed, not closed. Closing it needs a conditional write and there is nothing portable to condition on: `head()` exposes no version token at all on iCloud and only a server-dependent one on WebDAV, so If-Match would have to become a `FileSyncProvider` capability that degrades per backend. Follow-up.

## Test plan

- `engine-send-only-index-safety.test.ts` (@jadhavgaurav) — the Send Only index rewrite and the blind-push invariant.
- `engine-converge-5900.test.ts` — 17 tests: `emptyDirs` carry-forward, abort rather than rewrite an unreadable index, the file-verification guard above, the four revival-stamp cases, index-write-failure reporting, four concurrent-writer interleavings, and a **two-device simulation** that plays PC and BOOX in turn against one shared remote and asserts the tombstone loses and stays lost, with no restamping on the third round. That simulation fails on `main` with `booksAdded: 0`.
- Every guard is mutation-checked: deleting the single added line flips a test red.
- `pnpm test` 10211 passed / 16 skipped, `pnpm lint` clean, `pnpm format:check` clean.

## AI assistance disclosure

Commit 1 was implemented by @jadhavgaurav with Claude Code. Commit 2 is a maintainer follow-up, also written with Claude Code, after reviewing commit 1; root causes were diagnosed by reading `engine.ts` and confirmed with before/after probes against `main`. Neither commit has been verified on real multi-device hardware yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Send-only synchronization now preserves remote upload records, empty-folder information, and book entries from other devices.
  * Send-only mode prioritizes and pushes local book configurations appropriately.
  * Improved multi-device synchronization convergence, including deleted and restored books.
  * Synchronization now reports failures when the shared library index cannot be updated.
  * Errors from multiple sync locations are combined instead of overwritten.
  * Improved success and error notifications after synchronization attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

