### PR TITLE
feat(tts): lyric-style sentence view in the Read Aloud player (#5755)

### DIFF
--- a/apps/readest-app/src/__tests__/components/tts/TTSLyricsView.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSLyricsView.test.tsx
@@ -213,6 +213,30 @@ describe('TTSLyricsView', () => {
     expect(defaults.onGetLyricPage).toHaveBeenCalledWith(3);
   });
 
+  test('drops a carried-over pick when playback crosses into a new chapter', () => {
+    const { rerender } = renderView({ activeIndex: 0 });
+    dragTo(3);
+    expect(screen.getByLabelText('Play')).toBeTruthy();
+
+    // New chapter, new ordinals: pressing play on index 3 of the old sheet
+    // would seek to whatever sentence sits there now.
+    rerender(
+      <TTSLyricsView {...defaults} lines={['Fresh chapter.', 'Second line.']} activeIndex={0} />,
+    );
+    expect(screen.queryByLabelText('Play')).toBeNull();
+  });
+
+  test('drops a committed line when the chapter changes before its audio lands', async () => {
+    const { rerender } = renderView({ activeIndex: 0 });
+    dragTo(2);
+    fireEvent.click(screen.getByLabelText('Play'));
+    expect(document.querySelector('.loading-spinner')).toBeTruthy();
+
+    rerender(<TTSLyricsView {...defaults} lines={['Fresh chapter.']} activeIndex={0} buffering />);
+    // Otherwise it spins against an ordinal the new chapter will never report.
+    await waitFor(() => expect(document.querySelector('.loading-spinner')).toBeNull());
+  });
+
   test('the play button reads from the dragged line, not the spoken one', () => {
     renderView({ activeIndex: 0 });
     dragTo(2);

--- a/apps/readest-app/src/__tests__/components/tts/TTSLyricsView.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSLyricsView.test.tsx
@@ -1,0 +1,260 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string, opts?: Record<string, unknown>) =>
+    opts ? Object.entries(opts).reduce((s, [k, v]) => s.replace(`{{${k}}}`, String(v)), key) : key,
+}));
+
+const dispatchToast = vi.fn();
+vi.mock('@/utils/event', () => ({
+  eventDispatcher: {
+    dispatch: (name: string, detail: unknown) => dispatchToast(name, detail),
+    on: vi.fn(),
+    off: vi.fn(),
+  },
+}));
+
+import TTSLyricsView from '@/app/reader/components/tts/TTSLyricsView';
+
+// jsdom has no layout engine: every offset is 0, so the geometry the view
+// measures has to be supplied. Lines are 40px tall, stacked under the
+// half-viewport top spacer, in a 200px-tall scroller.
+const LINE_HEIGHT = 40;
+const VIEWPORT = 200;
+const SPACER = VIEWPORT / 2;
+
+const lines = ['First sentence.', 'Second sentence.', 'Third sentence.', 'Fourth sentence.'];
+// Centres the view should derive: 120, 160, 200, 240.
+const centerOf = (index: number) => SPACER + index * lineHeight + lineHeight / 2;
+
+let scrollTop = 0;
+// Current wrapped height of a lyric line; a narrower sheet re-wraps them.
+let lineHeight = LINE_HEIGHT;
+let resizeCallbacks: (() => void)[] = [];
+
+const installLayout = () => {
+  scrollTop = 0;
+  lineHeight = LINE_HEIGHT;
+  resizeCallbacks = [];
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+    constructor(cb: () => void) {
+      resizeCallbacks.push(cb);
+    }
+    observe() {}
+    disconnect() {}
+  };
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get(this: HTMLElement) {
+      return this.classList.contains('no-scrollbar') ? VIEWPORT : 0;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get(this: HTMLElement) {
+      return this.hasAttribute('data-lyric-line') ? lineHeight : 0;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetTop', {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (!this.hasAttribute('data-lyric-line')) return 0;
+      const all = Array.from(document.querySelectorAll('[data-lyric-line]'));
+      return SPACER + all.indexOf(this) * lineHeight;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value: number) => {
+      scrollTop = value;
+    },
+  });
+  // jsdom does not implement scrollTo; the view calls it optionally.
+  HTMLElement.prototype.scrollTo = vi.fn(function (this: HTMLElement, options?: ScrollToOptions) {
+    if (typeof options?.top === 'number') scrollTop = options.top;
+  }) as unknown as typeof HTMLElement.prototype.scrollTo;
+};
+
+const scroller = () => document.querySelector('.no-scrollbar') as HTMLElement;
+
+// Park the sheet on `index`: a real gesture, then the scroll it produces.
+const dragTo = (index: number) => {
+  const el = scroller();
+  fireEvent.touchMove(el);
+  scrollTop = centerOf(index) - VIEWPORT / 2;
+  fireEvent.scroll(el);
+};
+
+const defaults = {
+  lines,
+  activeIndex: 0,
+  buffering: false,
+  isEink: false,
+  onGetLyricPage: vi.fn().mockResolvedValue({ current: 6, next: 7, total: 30 }),
+  onPlayFrom: vi.fn().mockResolvedValue(undefined),
+};
+
+const renderView = (overrides: Partial<React.ComponentProps<typeof TTSLyricsView>> = {}) =>
+  render(<TTSLyricsView {...defaults} {...overrides} />);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  installLayout();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('TTSLyricsView', () => {
+  test('renders every sentence and marks the spoken one', () => {
+    renderView({ activeIndex: 2 });
+    for (const line of lines) expect(screen.getByText(line)).toBeTruthy();
+    expect(screen.getByText('Third sentence.').getAttribute('aria-current')).toBe('true');
+    expect(screen.getByText('First sentence.').getAttribute('aria-current')).toBeNull();
+  });
+
+  test('follows the voice by centring the spoken line', () => {
+    const { rerender } = renderView({ activeIndex: 0 });
+    rerender(<TTSLyricsView {...defaults} activeIndex={2} />);
+    // Line 2's centre is 200; a 200px viewport parks it at scrollTop 100.
+    expect(scroller().scrollTo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ top: 100, behavior: 'smooth' }),
+    );
+  });
+
+  test('lands a long move outright and glides a short one', () => {
+    // Opening onto the middle of a chapter is a jump of thousands of pixels;
+    // animating that is a blur past text nobody is reading.
+    const many = Array.from({ length: 40 }, (_, i) => `Sentence ${i}.`);
+    const props = { ...defaults, lines: many };
+    const { rerender } = render(<TTSLyricsView {...props} activeIndex={30} />);
+    expect(scroller().scrollTo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ top: 1220, behavior: 'auto' }),
+    );
+    // The next sentence is one line away.
+    rerender(<TTSLyricsView {...props} activeIndex={31} />);
+    expect(scroller().scrollTo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ top: 1260, behavior: 'smooth' }),
+    );
+  });
+
+  test('does not animate the follow scroll on e-ink', () => {
+    const { rerender } = renderView({ activeIndex: 0, isEink: true });
+    // Past the initial snap: every later move stays instant too.
+    rerender(<TTSLyricsView {...defaults} isEink activeIndex={1} />);
+    rerender(<TTSLyricsView {...defaults} isEink activeIndex={2} />);
+    expect(scroller().scrollTo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ behavior: 'auto' }),
+    );
+  });
+
+  test('parks a sentence taller than the window at its opening words', () => {
+    // Line 2 wraps to 300px in a 200px window — centring it would scroll past
+    // the words the voice is about to say.
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      get(this: HTMLElement) {
+        if (!this.hasAttribute('data-lyric-line')) return 0;
+        const all = Array.from(document.querySelectorAll('[data-lyric-line]'));
+        return all.indexOf(this) === 2 ? 300 : LINE_HEIGHT;
+      },
+    });
+    const { rerender } = renderView({ activeIndex: 0 });
+    rerender(<TTSLyricsView {...defaults} activeIndex={2} />);
+    // Line 2 starts at SPACER + 2 * LINE_HEIGHT = 180.
+    expect(scroller().scrollTo).toHaveBeenLastCalledWith(expect.objectContaining({ top: 180 }));
+  });
+
+  test('re-parks the spoken line when a resize re-wraps the sentences', () => {
+    const { rerender } = renderView({ activeIndex: 0 });
+    rerender(<TTSLyricsView {...defaults} activeIndex={3} />);
+    // Original geometry: line 3's centre is 240, so scrollTop 140.
+    expect(scroller().scrollTo).toHaveBeenLastCalledWith(expect.objectContaining({ top: 140 }));
+
+    // A narrower sheet wraps every sentence onto two rows. The scroller's own
+    // height never changes, so only watching it would leave this stale.
+    lineHeight = 80;
+    act(() => {
+      resizeCallbacks.forEach((cb) => cb());
+    });
+    // New geometry: line 3's centre is 380, so scrollTop 280.
+    expect(scroller().scrollTo).toHaveBeenLastCalledWith(expect.objectContaining({ top: 280 }));
+  });
+
+  test('shows no seek row until the reader actually drags', () => {
+    renderView();
+    expect(screen.queryByLabelText('Play')).toBeNull();
+    // A programmatic follow scroll must never be mistaken for a gesture.
+    fireEvent.scroll(scroller());
+    expect(screen.queryByLabelText('Play')).toBeNull();
+  });
+
+  test('a tap does not arm seeking, so the next follow scroll stays silent', () => {
+    renderView({ activeIndex: 0 });
+    const el = scroller();
+    fireEvent.pointerDown(el);
+    fireEvent.pointerUp(el);
+    // The voice moves on and the view scrolls itself: still not a drag.
+    scrollTop = centerOf(1) - VIEWPORT / 2;
+    fireEvent.scroll(el);
+    expect(screen.queryByLabelText('Play')).toBeNull();
+  });
+
+  test('a drag raises the seek row with the dragged line page number', async () => {
+    renderView();
+    dragTo(3);
+    expect(screen.getByLabelText('Play')).toBeTruthy();
+    await waitFor(() => expect(screen.getByText('Page 7')).toBeTruthy());
+    expect(defaults.onGetLyricPage).toHaveBeenCalledWith(3);
+  });
+
+  test('the play button reads from the dragged line, not the spoken one', () => {
+    renderView({ activeIndex: 0 });
+    dragTo(2);
+    fireEvent.click(screen.getByLabelText('Play'));
+    expect(defaults.onPlayFrom).toHaveBeenCalledWith(2);
+  });
+
+  test('the button spins while the committed line waits for audio', async () => {
+    const { rerender } = renderView({ activeIndex: 0 });
+    dragTo(2);
+    fireEvent.click(screen.getByLabelText('Play'));
+    expect(document.querySelector('.loading-spinner')).toBeTruthy();
+
+    // The commit resolves only when that line is both current AND audible.
+    rerender(<TTSLyricsView {...defaults} activeIndex={2} buffering />);
+    expect(document.querySelector('.loading-spinner')).toBeTruthy();
+
+    rerender(<TTSLyricsView {...defaults} activeIndex={2} buffering={false} />);
+    await waitFor(() => expect(screen.queryByLabelText('Play')).toBeNull());
+  });
+
+  test('a failed seek drops the spinner and says why', async () => {
+    const onPlayFrom = vi.fn().mockRejectedValue(new Error('offline'));
+    renderView({ onPlayFrom });
+    dragTo(1);
+    fireEvent.click(screen.getByLabelText('Play'));
+    await waitFor(() => expect(screen.queryByLabelText('Play')).toBeNull());
+    expect(dispatchToast).toHaveBeenCalledWith(
+      'toast',
+      expect.objectContaining({ message: 'Failed to seek', type: 'error' }),
+    );
+  });
+
+  test('an abandoned drag slides back to the spoken line', () => {
+    vi.useFakeTimers();
+    renderView({ activeIndex: 0 });
+    dragTo(3);
+    expect(screen.getByLabelText('Play')).toBeTruthy();
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(screen.queryByLabelText('Play')).toBeNull();
+    expect(scroller().scrollTo).toHaveBeenLastCalledWith(expect.objectContaining({ top: 20 }));
+  });
+});

--- a/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSMiniPlayer.test.tsx
@@ -50,6 +50,7 @@ const gridInsets = { top: 0, right: 0, bottom: 0, left: 0 };
 const makeProps = (overrides: Record<string, unknown> = {}) => ({
   bookKey: 'b1',
   isPlaying: true,
+  buffering: false,
   isEink: false,
   visible: true,
   hasTimeline: true,
@@ -415,5 +416,15 @@ describe('TTSMiniPlayer', () => {
     render(<TTSMiniPlayer {...props} />);
     fireEvent.click(screen.getByLabelText('Open Read Aloud player'));
     expect(props.onExpand).toHaveBeenCalled();
+  });
+
+  test('rings the play button while the engine has no audio out yet', () => {
+    const { rerender } = render(<TTSMiniPlayer {...makeProps()} />);
+    expect(screen.getByLabelText('Pause').getAttribute('aria-busy')).toBe('false');
+
+    rerender(<TTSMiniPlayer {...makeProps({ buffering: true })} />);
+    const busy = screen.getByLabelText('Pause');
+    expect(busy.getAttribute('aria-busy')).toBe('true');
+    expect(busy.querySelector('svg circle')).toBeTruthy();
   });
 });

--- a/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
@@ -127,6 +127,14 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
   onGetPlaybackInfo: vi
     .fn()
     .mockReturnValue({ position: 10, duration: 100, measuredFraction: 0.4 }),
+  // Lyric view off by default here: these tests cover the cover player, and
+  // the lyric layout has its own suite.
+  supportsLyrics: false,
+  buffering: false,
+  onGetLyrics: vi.fn().mockResolvedValue(null),
+  onGetActiveIndex: vi.fn().mockReturnValue(-1),
+  onGetLyricPage: vi.fn().mockResolvedValue(null),
+  onPlayFromLyric: vi.fn().mockResolvedValue(undefined),
   downloads: {
     supported: false,
     chapters: [],
@@ -249,7 +257,59 @@ describe('TTSPlayerSheet', () => {
     const { container } = render(<TTSPlayerSheet {...makeProps()} />);
     const cover = container.querySelector('img');
     expect(cover).toBeTruthy();
-    expect(cover?.parentElement?.className).toContain('sm:pt-4');
+    // The cover sits inside the artwork/title block, which the main view owns.
+    expect(cover?.parentElement?.parentElement?.className).toContain('sm:pt-4');
+  });
+
+  test('rings the transport button while the engine has no audio out yet', () => {
+    const { container, rerender } = render(<TTSPlayerSheet {...makeProps()} />);
+    const button = screen.getByLabelText('Pause');
+    expect(button.getAttribute('aria-busy')).toBe('false');
+    expect(container.querySelector('svg circle')).toBeNull();
+
+    rerender(<TTSPlayerSheet {...makeProps({ buffering: true })} />);
+    const busy = screen.getByLabelText('Pause');
+    expect(busy.getAttribute('aria-busy')).toBe('true');
+    // The glyph stays: a reader must still be able to pause mid-fetch.
+    expect(busy.querySelector('svg circle')).toBeTruthy();
+  });
+
+  test('an aligned engine swaps the cover billing for the lyric sheet', async () => {
+    getBookData.mockReturnValue({
+      book: { title: 'Alice in Wonderland', coverImageUrl: 'blob:cover' },
+    });
+    const { container } = render(
+      <TTSPlayerSheet
+        {...makeProps({
+          supportsLyrics: true,
+          onGetLyrics: vi
+            .fn()
+            .mockResolvedValue({ sectionIndex: 0, lines: ['Down the rabbit hole.'] }),
+        })}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Down the rabbit hole.')).toBeTruthy());
+    // The artwork steps aside into a thumbnail so the transcript gets the room.
+    expect(container.querySelector('img')?.className).toContain('h-12');
+  });
+
+  test('a section with nothing to transcribe keeps the cover player', async () => {
+    getBookData.mockReturnValue({
+      book: { title: 'Alice in Wonderland', coverImageUrl: 'blob:cover' },
+    });
+    const onGetLyrics = vi.fn().mockResolvedValue(null);
+    const { container } = render(
+      <TTSPlayerSheet {...makeProps({ supportsLyrics: true, onGetLyrics })} />,
+    );
+    await waitFor(() => expect(onGetLyrics).toHaveBeenCalled());
+    await waitFor(() => expect(container.querySelector('img')?.className).toContain('h-32'));
+  });
+
+  test('an engine without sentence alignment never asks for a transcript', async () => {
+    const onGetLyrics = vi.fn().mockResolvedValue({ sectionIndex: 0, lines: ['nope'] });
+    render(<TTSPlayerSheet {...makeProps({ supportsLyrics: false, onGetLyrics })} />);
+    await waitFor(() => expect(screen.getByText('Alice in Wonderland')).toBeTruthy());
+    expect(onGetLyrics).not.toHaveBeenCalled();
   });
 
   test('the speed caption pads and truncates like its sibling captions', () => {

--- a/apps/readest-app/src/__tests__/components/tts/useTTSLyrics.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/useTTSLyrics.test.tsx
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+
+import { LYRIC_MAX_LINES, useTTSLyrics } from '@/app/reader/components/tts/useTTSLyrics';
+import { eventDispatcher } from '@/utils/event';
+
+const lines = ['One.', 'Two.', 'Three.'];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('useTTSLyrics', () => {
+  test('fetches the section transcript once and reports it usable', async () => {
+    const onGetLyrics = vi.fn().mockResolvedValue({ sectionIndex: 3, lines });
+    const { result } = renderHook(() =>
+      useTTSLyrics({
+        bookKey: 'b',
+        enabled: true,
+        onGetLyrics,
+        onGetActiveIndex: () => 1,
+      }),
+    );
+    await waitFor(() => expect(result.current.lines).toEqual(lines));
+    expect(result.current.unavailable).toBe(false);
+    expect(result.current.activeIndex).toBe(1);
+    expect(onGetLyrics).toHaveBeenCalledTimes(1);
+  });
+
+  test('fetches nothing while the engine has no sentence alignment', async () => {
+    const onGetLyrics = vi.fn().mockResolvedValue({ sectionIndex: 0, lines });
+    const onGetActiveIndex = vi.fn().mockReturnValue(0);
+    renderHook(() => useTTSLyrics({ bookKey: 'b', enabled: false, onGetLyrics, onGetActiveIndex }));
+    await act(async () => {});
+    expect(onGetLyrics).not.toHaveBeenCalled();
+    expect(onGetActiveIndex).not.toHaveBeenCalled();
+  });
+
+  test('falls back when the section has no lines to show', async () => {
+    const { result } = renderHook(() =>
+      useTTSLyrics({
+        bookKey: 'b',
+        enabled: true,
+        onGetLyrics: vi.fn().mockResolvedValue(null),
+        onGetActiveIndex: () => -1,
+      }),
+    );
+    await waitFor(() => expect(result.current.unavailable).toBe(true));
+    expect(result.current.lines).toEqual([]);
+  });
+
+  test('falls back when a whole book arrives as one section', async () => {
+    const huge = Array.from({ length: LYRIC_MAX_LINES + 1 }, (_, i) => `s${i}`);
+    const { result } = renderHook(() =>
+      useTTSLyrics({
+        bookKey: 'b',
+        enabled: true,
+        onGetLyrics: vi.fn().mockResolvedValue({ sectionIndex: 0, lines: huge }),
+        onGetActiveIndex: () => 0,
+      }),
+    );
+    await waitFor(() => expect(result.current.unavailable).toBe(true));
+    expect(result.current.lines).toEqual([]);
+  });
+
+  test('reloads the sheet when playback crosses into another chapter', async () => {
+    const onGetLyrics = vi
+      .fn()
+      .mockResolvedValueOnce({ sectionIndex: 3, lines })
+      .mockResolvedValueOnce({ sectionIndex: 4, lines: ['Next chapter.'] });
+    const { result } = renderHook(() =>
+      useTTSLyrics({
+        bookKey: 'b',
+        enabled: true,
+        onGetLyrics,
+        onGetActiveIndex: () => 0,
+      }),
+    );
+    await waitFor(() => expect(result.current.lines).toEqual(lines));
+
+    // Same section: the transcript stands.
+    await act(async () => {
+      await eventDispatcher.dispatch('tts-position', { bookKey: 'b', sectionIndex: 3 });
+    });
+    expect(onGetLyrics).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await eventDispatcher.dispatch('tts-position', { bookKey: 'b', sectionIndex: 4 });
+    });
+    await waitFor(() => expect(result.current.lines).toEqual(['Next chapter.']));
+  });
+
+  test('ignores position events from another book', async () => {
+    const onGetLyrics = vi.fn().mockResolvedValue({ sectionIndex: 0, lines });
+    const { result } = renderHook(() =>
+      useTTSLyrics({
+        bookKey: 'b',
+        enabled: true,
+        onGetLyrics,
+        onGetActiveIndex: () => 0,
+      }),
+    );
+    await waitFor(() => expect(result.current.lines).toEqual(lines));
+    // A second book's session reports a different section on the same bus;
+    // reloading this sheet from it would swap in the wrong chapter.
+    await act(async () => {
+      await eventDispatcher.dispatch('tts-position', { bookKey: 'other', sectionIndex: 9 });
+    });
+    expect(onGetLyrics).toHaveBeenCalledTimes(1);
+  });
+
+  test('polls the spoken line as a backstop for a missed position event', async () => {
+    vi.useFakeTimers();
+    const state = { activeIndex: 0 };
+    const { result } = renderHook(() =>
+      useTTSLyrics({
+        bookKey: 'b',
+        enabled: true,
+        onGetLyrics: vi.fn().mockResolvedValue({ sectionIndex: 0, lines }),
+        onGetActiveIndex: () => state.activeIndex,
+      }),
+    );
+    expect(result.current.activeIndex).toBe(0);
+    state.activeIndex = 2;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+    expect(result.current.activeIndex).toBe(2);
+  });
+});

--- a/apps/readest-app/src/__tests__/components/tts/useTTSLyrics.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/useTTSLyrics.test.tsx
@@ -68,6 +68,20 @@ describe('useTTSLyrics', () => {
     expect(result.current.lines).toEqual([]);
   });
 
+  test('treats a transcript that cannot be read as no transcript', async () => {
+    const { result } = renderHook(() =>
+      useTTSLyrics({
+        bookKey: 'b',
+        enabled: true,
+        onGetLyrics: vi.fn().mockRejectedValue(new Error('chunk load failed')),
+        onGetActiveIndex: () => 0,
+      }),
+    );
+    // Falls back to the cover rather than leaving the lyric layout over nothing.
+    await waitFor(() => expect(result.current.unavailable).toBe(true));
+    expect(result.current.lines).toEqual([]);
+  });
+
   test('reloads the sheet when playback crosses into another chapter', async () => {
     const onGetLyrics = vi
       .fn()

--- a/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
@@ -1069,6 +1069,9 @@ describe('useTTSControl background session lifecycle', () => {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
       redispatchPosition: vi.fn(),
+      usesAudioTransport: vi.fn().mockReturnValue(false),
+      supportsLyrics: vi.fn().mockReturnValue(true),
+      isBuffering: vi.fn().mockReturnValue(false),
     };
     mockSessionManager.getSessionByHash.mockReturnValue({
       bookHash: 'book',

--- a/apps/readest-app/src/__tests__/services/tts-controller-timeline.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller-timeline.test.ts
@@ -152,6 +152,12 @@ const makeView = () => {
     renderer: { getContents: () => [contents], primaryIndex: 0 },
     language: { isCJK: false },
     getCFI: vi.fn().mockReturnValue('epubcfi(/6/2!/4/2)'),
+    getCFIProgress: vi.fn().mockResolvedValue({
+      fraction: 0.05,
+      section: { current: 4, total: 12 },
+      location: { current: 2, next: 3, total: 30 },
+      time: { section: 60, total: 900 },
+    }),
     resolveCFI: vi.fn().mockReturnValue({ anchor: () => sentenceRanges[0] }),
     tts: null,
   } as unknown as FoliateView;
@@ -242,5 +248,125 @@ describe('TTSController section timeline', () => {
     await controller.ensureTimeline();
     await controller.shutdown();
     expect(controller.getPlaybackInfo()).toBeNull();
+  });
+});
+
+// Lyric view (#5755): the player draws the section's sentences as scrollable
+// lines only when the engine aligns audio to them. Everything below reads the
+// SAME timeline the scrubber uses, addressed by ordinal instead of by seconds.
+describe('TTSController lyrics', () => {
+  let controller: TTSController;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    buildSectionDoc();
+    controller = new TTSController(null, makeView());
+    await controller.init();
+    await controller.initViewTTS(0);
+  });
+
+  test('supportsLyrics requires both a media clock and real text timing', async () => {
+    expect(controller.supportsLyrics()).toBe(true);
+
+    // A chapter-only audiobook pairing: exact audio clock, no sentence
+    // alignment — the plain cover player, not lyrics.
+    (controller.ttsClient.getCapabilities as ReturnType<typeof vi.fn>).mockReturnValue({
+      wordBoundaries: false,
+      mediaClock: true,
+      gapControl: false,
+      liveRateChange: true,
+      textHighlight: false,
+    });
+    expect(controller.supportsLyrics()).toBe(false);
+
+    // A direct-speak engine has no clock to seek with at all.
+    controller.ttsClient = controller.ttsWebClient;
+    expect(controller.supportsLyrics()).toBe(false);
+    expect(await controller.getLyrics()).toBeNull();
+  });
+
+  test('getLyrics returns one normalized line per timeline sentence', async () => {
+    const lyrics = await controller.getLyrics();
+    expect(lyrics).not.toBeNull();
+    expect(lyrics!.sectionIndex).toBe(0);
+    expect(lyrics!.lines).toEqual([S0, S1, S2]);
+  });
+
+  test('getCurrentLyricIndex falls back to the last spoken range', async () => {
+    expect(controller.getCurrentLyricIndex()).toBe(-1); // no timeline yet
+    await controller.ensureTimeline();
+    expect(controller.getCurrentLyricIndex()).toBe(0);
+  });
+
+  test('seekToLyric speaks from that line, even from a parked session', async () => {
+    await controller.ensureTimeline();
+    controller.state = 'paused';
+    await controller.seekToLyric(2);
+    const tts = controller.view.tts as unknown as { from: ReturnType<typeof vi.fn> };
+    expect(tts.from).toHaveBeenCalledTimes(1);
+    expect((tts.from.mock.calls[0]![0] as Range).toString()).toBe(S2);
+    // The play button means "read from here": it never leaves the session parked.
+    await vi.waitFor(() => expect(controller.state).toBe('playing'));
+  });
+
+  test('seekToLyric ignores an ordinal the section does not have', async () => {
+    await controller.ensureTimeline();
+    await controller.seekToLyric(99);
+    const tts = controller.view.tts as unknown as { from: ReturnType<typeof vi.fn> };
+    expect(tts.from).not.toHaveBeenCalled();
+  });
+
+  test('isBuffering covers the wait between handing over an utterance and hearing it', async () => {
+    await controller.ensureTimeline();
+    expect(controller.isBuffering()).toBe(false);
+
+    // A client that accepts the utterance and stays silent — synthesis in
+    // flight, or a recording still loading.
+    let release: (() => void) | null = null;
+    const audible = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    (controller.ttsClient.speak as ReturnType<typeof vi.fn>).mockImplementation(async function* (
+      _ssml: string,
+      _signal: AbortSignal,
+      preload?: boolean,
+    ) {
+      if (preload) return;
+      await audible;
+      yield { code: 'boundary', message: 'first chunk', mark: '0' };
+    });
+
+    await controller.seekToLyric(1);
+    await vi.waitFor(() => expect(controller.isBuffering()).toBe(true));
+
+    release!();
+    await vi.waitFor(() => expect(controller.isBuffering()).toBe(false));
+  });
+
+  test('isBuffering stays false while the session is not playing', async () => {
+    await controller.ensureTimeline();
+    controller.state = 'playing';
+    await controller.pause();
+    expect(controller.isBuffering()).toBe(false);
+  });
+
+  test('getLyricPage resolves the line to the page number the footer shows', async () => {
+    await controller.ensureTimeline();
+    const view = controller.view as unknown as {
+      getCFIProgress: ReturnType<typeof vi.fn>;
+      book: { rendition?: { layout?: string } };
+    };
+    expect(await controller.getLyricPage(1)).toEqual({ current: 2, next: 3, total: 30 });
+    expect(view.getCFIProgress).toHaveBeenCalledWith('epubcfi(/6/2!/4/2)');
+
+    // Fixed-layout books number pages by section, matching FooterBar.
+    view.book.rendition = { layout: 'pre-paginated' };
+    expect(await controller.getLyricPage(1)).toEqual({ current: 4, total: 12 });
+  });
+
+  test('getLyricPage is null before the timeline exists and for unknown lines', async () => {
+    expect(await controller.getLyricPage(0)).toBeNull();
+    await controller.ensureTimeline();
+    expect(await controller.getLyricPage(99)).toBeNull();
   });
 });

--- a/apps/readest-app/src/__tests__/utils/tts-lyrics.test.ts
+++ b/apps/readest-app/src/__tests__/utils/tts-lyrics.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { lyricIndexAtCenter, lyricScrollTopFor, normalizeLyricText } from '@/utils/ttsLyrics';
+
+describe('normalizeLyricText', () => {
+  it('collapses the source document whitespace into one line', () => {
+    expect(normalizeLyricText('  From the dining\n   room  on my left\t there ')).toBe(
+      'From the dining room on my left there',
+    );
+  });
+
+  it('returns an empty string for whitespace-only ranges', () => {
+    expect(normalizeLyricText(' \n\t ')).toBe('');
+  });
+});
+
+describe('lyricIndexAtCenter', () => {
+  // Four lines, 40px tall, laid out after a 100px half-viewport spacer.
+  const centers = [120, 160, 200, 240];
+
+  it('reports -1 for an empty list', () => {
+    expect(lyricIndexAtCenter([], 100)).toBe(-1);
+  });
+
+  it('snaps to the nearest line centre', () => {
+    expect(lyricIndexAtCenter(centers, 120)).toBe(0);
+    expect(lyricIndexAtCenter(centers, 138)).toBe(0);
+    expect(lyricIndexAtCenter(centers, 142)).toBe(1);
+    expect(lyricIndexAtCenter(centers, 200)).toBe(2);
+  });
+
+  it('breaks an exact tie towards the earlier line', () => {
+    expect(lyricIndexAtCenter(centers, 140)).toBe(0);
+  });
+
+  it('clamps past either end', () => {
+    expect(lyricIndexAtCenter(centers, -50)).toBe(0);
+    expect(lyricIndexAtCenter(centers, 9999)).toBe(3);
+  });
+
+  it('handles a single line', () => {
+    expect(lyricIndexAtCenter([120], 0)).toBe(0);
+    expect(lyricIndexAtCenter([120], 9999)).toBe(0);
+  });
+});
+
+describe('lyricScrollTopFor', () => {
+  const centers = [120, 160, 200, 240];
+  const heights = [40, 40, 40, 40];
+
+  it('centres the requested line in the viewport', () => {
+    expect(lyricScrollTopFor(centers, heights, 2, 200)).toBe(100);
+  });
+
+  it('round-trips with lyricIndexAtCenter', () => {
+    for (let i = 0; i < centers.length; i++) {
+      const top = lyricScrollTopFor(centers, heights, i, 200);
+      expect(lyricIndexAtCenter(centers, top + 100)).toBe(i);
+    }
+  });
+
+  it('parks a sentence taller than the window at its first row', () => {
+    // A 300px sentence centred in a 200px window would hide its opening words.
+    const tall = [40, 300, 40, 40];
+    const tallCenters = [120, 290, 460, 500];
+    expect(lyricScrollTopFor(tallCenters, tall, 1, 200)).toBe(140);
+  });
+
+  it('never scrolls above the top of the content', () => {
+    expect(lyricScrollTopFor(centers, heights, 0, 400)).toBe(0);
+  });
+
+  it('returns 0 for an index the list does not have', () => {
+    expect(lyricScrollTopFor(centers, heights, 9, 200)).toBe(0);
+    expect(lyricScrollTopFor([], [], 0, 200)).toBe(0);
+  });
+});

--- a/apps/readest-app/src/app/reader/components/tts/BufferingRing.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/BufferingRing.tsx
@@ -1,0 +1,53 @@
+import clsx from 'clsx';
+
+type BufferingRingProps = {
+  // Diameter in px. Pick it so the ring clears the glyph it wraps rather than
+  // covering it; it inherits currentColor from the button it sits in.
+  size: number;
+  isEink: boolean;
+};
+
+// Indeterminate ring for a transport button whose engine has taken an utterance
+// but has no audio out yet. A ring rather than a swapped icon: the reader must
+// still be able to pause while a sentence is being fetched, so the play/pause
+// glyph stays where it is and stays pressable.
+const BufferingRing = ({ size, isEink }: BufferingRingProps) => {
+  const stroke = Math.max(2, Math.round(size / 16));
+  const radius = size / 2 - stroke / 2;
+  const circumference = 2 * Math.PI * radius;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      aria-hidden
+      className={clsx(
+        'pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2',
+        // E-ink cannot animate: a spinning ring there is a refresh storm for no
+        // information. The gap in the track reads as "waiting" while static.
+        !isEink && 'animate-spin',
+      )}
+    >
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill='none'
+        strokeWidth={stroke}
+        className='stroke-current opacity-25'
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill='none'
+        strokeWidth={stroke}
+        strokeLinecap='round'
+        strokeDasharray={`${circumference * 0.25} ${circumference}`}
+        className='stroke-current'
+      />
+    </svg>
+  );
+};
+
+export default BufferingRing;

--- a/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
@@ -106,6 +106,7 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
         <TTSMiniPlayer
           bookKey={bookKey}
           isPlaying={tts.isPlaying}
+          buffering={tts.buffering}
           isEink={isEink}
           visible={miniPlayerVisible}
           hasTimeline={hasTimeline}
@@ -144,6 +145,12 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
           onSeek={tts.handleSeekTo}
           onSeekPreview={tts.handleSeekPreview}
           onGetPlaybackInfo={tts.handleGetPlaybackInfo}
+          supportsLyrics={tts.supportsLyrics}
+          buffering={tts.buffering}
+          onGetLyrics={tts.handleGetLyrics}
+          onGetActiveIndex={tts.handleGetLyricActiveIndex}
+          onGetLyricPage={tts.handleGetLyricPage}
+          onPlayFromLyric={tts.handlePlayFromLyric}
           downloads={downloads}
           activeSectionIndex={activeSectionIndex}
         />

--- a/apps/readest-app/src/app/reader/components/tts/TTSLyricsView.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSLyricsView.tsx
@@ -1,0 +1,278 @@
+import clsx from 'clsx';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { MdPlayArrow } from 'react-icons/md';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useResponsiveSize } from '@/hooks/useResponsiveSize';
+import { PageInfo } from '@/types/book';
+import { eventDispatcher } from '@/utils/event';
+import { lyricIndexAtCenter, lyricScrollTopFor } from '@/utils/ttsLyrics';
+
+// How long the sheet stays parked where the reader left it before sliding back
+// to the sentence being spoken. Every scroll event re-arms it, so a flick with
+// momentum stays one gesture rather than a dozen. Long enough to read the line
+// under the row and decide before it slides away.
+const SEEK_IDLE_MS = 4000;
+// A committed line whose audio never arrives must not spin forever.
+const COMMIT_WATCHDOG_MS = 15000;
+// A page lookup resolves a CFI against a freshly parsed copy of the section,
+// so it waits for the drag to settle instead of firing per line crossed.
+const PAGE_LOOKUP_DEBOUNCE_MS = 150;
+
+type TTSLyricsViewProps = {
+  lines: string[];
+  activeIndex: number;
+  buffering: boolean;
+  isEink: boolean;
+  onGetLyricPage: (index: number) => Promise<PageInfo | null>;
+  onPlayFrom: (index: number) => Promise<void>;
+};
+
+// Lyric-style transcript of the chapter being read aloud (#5755): the spoken
+// sentence sits centred and lit, the rest dim around it. Dragging the sheet
+// parks it and raises a seek row over the centre line — page number on one
+// side, play button on the other — so a line can be picked the way a music
+// player picks a lyric, with playback moving only once the button is pressed.
+const TTSLyricsView = ({
+  lines,
+  activeIndex,
+  buffering,
+  isEink,
+  onGetLyricPage,
+  onPlayFrom,
+}: TTSLyricsViewProps) => {
+  const _ = useTranslation();
+  const iconSize16 = useResponsiveSize(16);
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  // Content-space centre and height of every rendered line. Measured per
+  // layout, so a scroll event costs a binary search instead of N forced
+  // reflows.
+  const centersRef = useRef<number[]>([]);
+  const heightsRef = useRef<number[]>([]);
+  const seekingRef = useRef(false);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [seekIndex, setSeekIndex] = useState<number | null>(null);
+  // A line the reader committed to, held until its audio is heard so the button
+  // can spin in place rather than the row vanishing into silence.
+  const [pending, setPending] = useState<number | null>(null);
+  const [page, setPage] = useState<PageInfo | null>(null);
+  const [halfHeight, setHalfHeight] = useState(0);
+  // Bumped whenever the measured line centres actually move. The follow scroll
+  // depends on it, so a re-wrap re-parks the spoken line instead of leaving it
+  // off screen until the next sentence.
+  const [geometry, setGeometry] = useState(0);
+
+  const rowIndex = seekIndex ?? pending;
+
+  // Read the line geometry the scroll math runs on, and the half-viewport
+  // spacer that lets the first and last lines reach the centre (percentage
+  // padding resolves against width, so that height has to be measured).
+  const measure = useCallback(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const centers: number[] = [];
+    const heights: number[] = [];
+    el.querySelectorAll<HTMLElement>('[data-lyric-line]').forEach((node) => {
+      centers.push(node.offsetTop + node.offsetHeight / 2);
+      heights.push(node.offsetHeight);
+    });
+    const moved =
+      centers.length !== centersRef.current.length ||
+      centers.some((center, i) => center !== centersRef.current[i]);
+    centersRef.current = centers;
+    heightsRef.current = heights;
+    if (moved) setGeometry((version) => version + 1);
+    setHalfHeight(el.clientHeight / 2);
+  }, []);
+
+  useLayoutEffect(() => {
+    measure();
+  }, [lines, halfHeight, measure]);
+
+  // Watch the content box, not just the viewport: a narrower window re-wraps
+  // every sentence and moves every centre, while the scroller's own height —
+  // the only thing the spacer depends on — never changes. Measuring off that
+  // alone left the geometry stale and the follow scroll a line or two out.
+  useEffect(() => {
+    const el = scrollerRef.current;
+    const content = contentRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(() => measure());
+    observer.observe(el);
+    if (content) observer.observe(content);
+    return () => observer.disconnect();
+  }, [measure]);
+
+  // Follow the voice, unless the reader has taken the sheet over.
+  useEffect(() => {
+    if (seekIndex !== null || pending !== null) return;
+    const el = scrollerRef.current;
+    if (!el || activeIndex < 0) return;
+    // Nothing to aim at until the lines have been measured: scrolling on the
+    // pre-measure pass would just land at zero.
+    if (centersRef.current.length !== lines.length) return;
+    const top = lyricScrollTopFor(
+      centersRef.current,
+      heightsRef.current,
+      activeIndex,
+      el.clientHeight,
+    );
+    // Glide between neighbouring sentences the way a music player does, but
+    // land a long move outright: opening onto the middle of a chapter, or
+    // jumping chapters, is thousands of pixels, and animating that is a blur
+    // past text nobody is reading. E-ink cannot animate at all — a smooth
+    // scroll there is a stutter of full refreshes.
+    const distance = Math.abs(top - el.scrollTop);
+    // Already parked there — re-issuing the scroll would only re-arm an
+    // animation over nothing.
+    if (distance < 1) return;
+    el.scrollTo?.({ top, behavior: distance > el.clientHeight * 2 || isEink ? 'auto' : 'smooth' });
+  }, [activeIndex, seekIndex, pending, isEink, geometry, halfHeight, lines]);
+
+  const clearIdleTimer = () => {
+    if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+    idleTimerRef.current = null;
+  };
+
+  const armIdleTimer = useCallback(() => {
+    clearIdleTimer();
+    idleTimerRef.current = setTimeout(() => {
+      seekingRef.current = false;
+      setSeekIndex(null);
+    }, SEEK_IDLE_MS);
+  }, []);
+
+  useEffect(() => clearIdleTimer, []);
+
+  // Only a real gesture opens the seek row: the follow effect above scrolls
+  // this same element, and that must never read as the reader scrubbing.
+  // Movement, not contact — a tap that arms this would turn the next follow
+  // scroll into a phantom drag, and the row would raise itself unasked.
+  const handleGestureStart = useCallback(() => {
+    seekingRef.current = true;
+    armIdleTimer();
+  }, [armIdleTimer]);
+
+  const handleScroll = useCallback(() => {
+    if (!seekingRef.current) return;
+    const el = scrollerRef.current;
+    if (!el) return;
+    const index = lyricIndexAtCenter(centersRef.current, el.scrollTop + el.clientHeight / 2);
+    setSeekIndex(index >= 0 ? index : null);
+    armIdleTimer();
+  }, [armIdleTimer]);
+
+  const handlePlayFrom = () => {
+    if (seekIndex === null) return;
+    clearIdleTimer();
+    seekingRef.current = false;
+    const target = seekIndex;
+    setPending(target);
+    setSeekIndex(null);
+    onPlayFrom(target).catch(() => {
+      // A dead button under a stuck spinner is the worst outcome here: drop the
+      // commit and say why, exactly as the scrubber does.
+      setPending(null);
+      eventDispatcher.dispatch('toast', { message: _('Failed to seek'), type: 'error' });
+    });
+  };
+
+  // The commit resolves once that line is both current and audible.
+  useEffect(() => {
+    if (pending !== null && !buffering && activeIndex === pending) setPending(null);
+  }, [pending, buffering, activeIndex]);
+
+  useEffect(() => {
+    if (pending === null) return;
+    const timer = setTimeout(() => setPending(null), COMMIT_WATCHDOG_MS);
+    return () => clearTimeout(timer);
+  }, [pending]);
+
+  useEffect(() => {
+    if (rowIndex === null) {
+      setPage(null);
+      return;
+    }
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      void onGetLyricPage(rowIndex).then((next) => {
+        if (!cancelled) setPage(next);
+      });
+    }, PAGE_LOOKUP_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [rowIndex, onGetLyricPage]);
+
+  const fadeMask = 'linear-gradient(to bottom, transparent, #000 16%, #000 84%, transparent)';
+
+  return (
+    <div className='relative min-h-24 w-full flex-1 sm:h-56 sm:flex-none'>
+      <div
+        ref={scrollerRef}
+        className='no-scrollbar relative h-full overflow-y-auto overscroll-contain'
+        style={isEink ? undefined : { maskImage: fadeMask, WebkitMaskImage: fadeMask }}
+        onScroll={handleScroll}
+        onTouchMove={handleGestureStart}
+        onWheel={handleGestureStart}
+      >
+        <div ref={contentRef} style={{ paddingTop: halfHeight, paddingBottom: halfHeight }}>
+          {lines.map((line, index) => (
+            <div
+              // Positional within the section; there is no stabler id.
+              key={index}
+              data-lyric-line
+              aria-current={index === activeIndex ? 'true' : undefined}
+              className={clsx(
+                // The gutters are permanent so the seek row's page label and
+                // play button never land on the text, and so raising the row
+                // reflows nothing (which would invalidate the measured centres).
+                // The transparent border keeps every line the same height on
+                // e-ink, where only the current one draws a visible one.
+                'mx-auto rounded-xl border border-transparent px-14 py-2 text-center text-sm leading-snug',
+                // The line under the seek row is marked by weight alone — the
+                // page number and play button already flank it, and a box drawn
+                // round a five-row sentence reads as clutter.
+                index === activeIndex
+                  ? 'text-base-content not-eink:bg-base-200 eink-bordered font-semibold'
+                  : index === rowIndex
+                    ? 'text-base-content/70'
+                    : 'text-base-content/40',
+              )}
+            >
+              {line || ' '}
+            </div>
+          ))}
+        </div>
+      </div>
+      {rowIndex !== null && (
+        // Pinned to the two gutters the lines reserve. No rule joins them: the
+        // target line can be four rows tall, and a hairline drawn across the
+        // panel would strike through the words it is pointing at — the outline
+        // on that line says which one it is instead.
+        <div className='pointer-events-none absolute inset-x-0 top-1/2 flex -translate-y-1/2 items-center justify-between'>
+          <span className='text-base-content/60 w-14 shrink-0 truncate text-[10px] tabular-nums'>
+            {page ? _('Page {{number}}', { number: page.current + 1 }) : ''}
+          </span>
+          <button
+            type='button'
+            aria-label={_('Play')}
+            onClick={handlePlayFrom}
+            disabled={pending !== null}
+            className='not-eink:bg-base-300 eink-bordered pointer-events-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-full'
+          >
+            {pending !== null ? (
+              <span className='loading loading-spinner loading-xs' />
+            ) : (
+              <MdPlayArrow size={iconSize16} />
+            )}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TTSLyricsView;

--- a/apps/readest-app/src/app/reader/components/tts/TTSLyricsView.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSLyricsView.tsx
@@ -145,6 +145,18 @@ const TTSLyricsView = ({
 
   useEffect(() => clearIdleTimer, []);
 
+  // A new chapter is a new set of ordinals. Anything the reader had picked in
+  // the old one must go with it: pressing play on a carried-over index would
+  // seek to whatever sentence happens to sit there now, and a carried-over
+  // commit would spin until its watchdog.
+  useEffect(() => {
+    seekingRef.current = false;
+    clearIdleTimer();
+    setSeekIndex(null);
+    setPending(null);
+    setPage(null);
+  }, [lines]);
+
   // Only a real gesture opens the seek row: the follow effect above scrolls
   // this same element, and that must never read as the reader scrubbing.
   // Movement, not contact — a tap that arms this would turn the next follow

--- a/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSMiniPlayer.tsx
@@ -27,6 +27,7 @@ import { isForcedMobileLayout } from '../../utils/mobileLayout';
 import { TTSPlaybackInfo, usePlaybackInfo } from './usePlaybackInfo';
 import { useCountdownLabel } from './useCountdownLabel';
 import { formatRate } from './SpeedRuler';
+import BufferingRing from './BufferingRing';
 import { getTTSMiniPlayerBottomOffset } from '../../utils/ttsMiniPlayerPosition';
 
 // Playback-settings glyph: a hex nut whose top-right edge is left open so
@@ -61,6 +62,8 @@ const SpeedSettingsIcon = ({ size, label }: { size: number; label: string }) => 
 type TTSMiniPlayerProps = {
   bookKey: string;
   isPlaying: boolean;
+  // Playing, but nothing audible yet — the play/pause button wears a ring.
+  buffering: boolean;
   isEink: boolean;
   visible: boolean;
   hasTimeline: boolean;
@@ -93,6 +96,7 @@ type TTSMiniPlayerProps = {
 const TTSMiniPlayer = ({
   bookKey,
   isPlaying,
+  buffering,
   isEink,
   visible,
   hasTimeline,
@@ -280,8 +284,9 @@ const TTSMiniPlayer = ({
               </button>
               <button
                 type='button'
-                className='shrink-0 rounded-full p-0.5'
+                className='relative shrink-0 rounded-full p-0.5'
                 aria-label={isPlaying ? _('Pause') : _('Play')}
+                aria-busy={buffering}
                 onClick={onTogglePlay}
               >
                 {isPlaying ? (
@@ -289,6 +294,10 @@ const TTSMiniPlayer = ({
                 ) : (
                   <MdPlayCircleFilled size={iconSize40} />
                 )}
+                {/* Hugging the filled glyph: the drawn circle only fills about
+                    five sixths of the icon box, so the ring tracks the box
+                    rather than standing off from it. */}
+                {buffering && <BufferingRing size={iconSize40 - 2} isEink={isEink} />}
               </button>
               <button
                 type='button'
@@ -365,12 +374,14 @@ const TTSMiniPlayer = ({
             </button>
             <button
               type='button'
-              className='shrink-0 rounded-full p-1'
+              className='relative shrink-0 rounded-full p-1'
               aria-label={isPlaying ? _('Pause') : _('Play')}
+              aria-busy={buffering}
               onClick={onTogglePlay}
             >
               {/* Same canvas size for both glyphs, or the row shifts on toggle. */}
               {isPlaying ? <MdOutlinePause size={iconSize26} /> : <MdPlayArrow size={iconSize26} />}
+              {buffering && <BufferingRing size={iconSize26 + 8} isEink={isEink} />}
             </button>
             <button
               type='button'

--- a/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
@@ -33,9 +33,13 @@ import { navigateToLogin, navigateToProfile } from '@/utils/nav';
 import { getLanguageName } from '@/utils/lang';
 import { formatPlaybackTime } from '@/utils/time';
 import Dialog from '@/components/Dialog';
+import { PageInfo } from '@/types/book';
 import { TTSPlaybackInfo } from './usePlaybackInfo';
 import { useCountdownLabel } from './useCountdownLabel';
 import TTSScrubber from './TTSScrubber';
+import TTSLyricsView from './TTSLyricsView';
+import BufferingRing from './BufferingRing';
+import { TTSLyrics, useTTSLyrics } from './useTTSLyrics';
 import SpeedRuler, { formatRate } from './SpeedRuler';
 import TTSChaptersView from './TTSChaptersView';
 import { TTS_STOP_AT_CHAPTER_END } from '@/services/tts/TTSSessionManager';
@@ -90,6 +94,15 @@ type TTSPlayerSheetProps = {
   onSeek: (seconds: number) => Promise<void>;
   onSeekPreview: (seconds: number) => void;
   onGetPlaybackInfo: () => TTSPlaybackInfo | null;
+  // Lyric view (#5755). Present only when the engine aligns audio to the text;
+  // supportsLyrics false keeps the cover player.
+  supportsLyrics: boolean;
+  // Playing, but nothing audible yet — the transport button wears a ring.
+  buffering: boolean;
+  onGetLyrics: () => Promise<TTSLyrics | null>;
+  onGetActiveIndex: () => number;
+  onGetLyricPage: (index: number) => Promise<PageInfo | null>;
+  onPlayFromLyric: (index: number) => Promise<void>;
   downloads: UseTTSDownloadsResult;
   activeSectionIndex: number | null;
 };
@@ -119,6 +132,12 @@ const TTSPlayerSheet = ({
   onSeek,
   onSeekPreview,
   onGetPlaybackInfo,
+  supportsLyrics,
+  buffering,
+  onGetLyrics,
+  onGetActiveIndex,
+  onGetLyricPage,
+  onPlayFromLyric,
   downloads,
   activeSectionIndex,
 }: TTSPlayerSheetProps) => {
@@ -161,6 +180,18 @@ const TTSPlayerSheet = ({
   const book = getBookData(bookKey)?.book;
   const sectionLabel = progress?.sectionLabel;
   const isEink = viewSettings?.isEink ?? false;
+  const coverImage = book?.coverImageUrl && !coverFailed ? book.coverImageUrl : null;
+
+  const lyrics = useTTSLyrics({
+    bookKey,
+    enabled: supportsLyrics && isOpen,
+    onGetLyrics,
+    onGetActiveIndex,
+  });
+  // Committed up front on capability alone so the sheet does not flip layouts a
+  // frame after opening; `unavailable` only pulls it back for the sections that
+  // genuinely have no sheet to show (empty, or too long to render).
+  const showLyrics = supportsLyrics && !lyrics.unavailable;
 
   // Books with recorded narration expose it as a voice; while it is playing
   // there is nothing to pre-download, since the audio ships with the book.
@@ -321,7 +352,9 @@ const TTSPlayerSheet = ({
     <Dialog
       id='tts_player_sheet'
       isOpen={isOpen}
-      snapHeight={0.65}
+      // The lyric sheet needs room to read as one: at the cover player's 0.65
+      // it collapses to two or three visible lines.
+      snapHeight={showLyrics ? 0.8 : 0.65}
       title={_('Read Aloud')}
       header={header}
       boxClassName='sm:h-auto! sm:max-h-[85%]! sm:w-[420px]! sm:min-w-0!'
@@ -332,22 +365,60 @@ const TTSPlayerSheet = ({
         // sm:pt-4 keeps the cover clear of the box's rounded top edge on
         // desktop, where the mobile drag handle (and its clearance) is
         // hidden; on mobile the handle already provides the gap.
-        <div className='flex w-full flex-col items-center gap-4 pb-4 sm:pt-4'>
-          {book?.coverImageUrl && !coverFailed ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={book.coverImageUrl}
-              alt=''
-              className='not-eink:shadow-lg eink-bordered h-32 w-auto rounded-xl object-cover'
-              onError={() => setCoverFailed(true)}
-            />
-          ) : null}
-          <div className='flex w-full flex-col items-center gap-0.5 text-center'>
-            <span className='line-clamp-1 font-semibold'>{book?.title ?? ''}</span>
-            {sectionLabel && (
-              <span className='text-base-content/70 line-clamp-1 text-sm'>{sectionLabel}</span>
+        <div
+          className={clsx(
+            'flex w-full flex-col items-center gap-4 pb-4 sm:pt-4',
+            // The lyric sheet is the one element here that can take whatever
+            // height is left, so it claims it — and the transport below stays
+            // put instead of being pushed into a scroll.
+            showLyrics && 'h-full sm:h-auto',
+          )}
+        >
+          {/* With lyrics the artwork steps aside into a thumbnail row so the
+              transcript gets the vertical space; without them the cover keeps
+              the full-width billing it has always had. */}
+          <div
+            className={clsx(
+              'flex w-full min-w-0',
+              showLyrics ? 'flex-row items-center gap-3' : 'flex-col items-center gap-4',
             )}
+          >
+            {coverImage && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={coverImage}
+                alt=''
+                className={clsx(
+                  'not-eink:shadow-lg eink-bordered w-auto shrink-0 rounded-xl object-cover',
+                  showLyrics ? 'h-12' : 'h-32',
+                )}
+                onError={() => setCoverFailed(true)}
+              />
+            )}
+            <div
+              className={clsx(
+                'flex min-w-0 flex-col gap-0.5',
+                showLyrics ? 'flex-1 items-start text-start' : 'w-full items-center text-center',
+              )}
+            >
+              <span className='line-clamp-1 w-full font-semibold'>{book?.title ?? ''}</span>
+              {sectionLabel && (
+                <span className='text-base-content/70 line-clamp-1 w-full text-sm'>
+                  {sectionLabel}
+                </span>
+              )}
+            </div>
           </div>
+          {showLyrics && (
+            <TTSLyricsView
+              lines={lyrics.lines}
+              activeIndex={lyrics.activeIndex}
+              buffering={buffering}
+              isEink={isEink}
+              onGetLyricPage={onGetLyricPage}
+              onPlayFrom={onPlayFromLyric}
+            />
+          )}
           {hasTimeline ? (
             <TTSScrubber
               bookKey={bookKey}
@@ -392,11 +463,15 @@ const TTSPlayerSheet = ({
             </button>
             <button
               type='button'
-              className='btn btn-primary btn-circle mx-2 h-14 min-h-14 w-14'
+              className='btn btn-primary btn-circle relative mx-2 h-14 min-h-14 w-14'
               aria-label={isPlaying ? _('Pause') : _('Play')}
+              aria-busy={buffering}
               onClick={onTogglePlay}
             >
               {isPlaying ? <MdOutlinePause size={iconSize32} /> : <MdPlayArrow size={iconSize32} />}
+              {/* Inside the button's edge, so it reads against the fill rather
+                  than against whatever the sheet puts behind it. */}
+              {buffering && <BufferingRing size={50} isEink={isEink} />}
             </button>
             <button
               type='button'

--- a/apps/readest-app/src/app/reader/components/tts/useTTSLyrics.ts
+++ b/apps/readest-app/src/app/reader/components/tts/useTTSLyrics.ts
@@ -59,6 +59,12 @@ export const useTTSLyrics = ({
             ? next
             : null,
       );
+    } catch {
+      // A transcript that cannot be read is a section with no sheet to show:
+      // fall back to the cover rather than leaving the lyric layout standing
+      // over nothing (and leaving the rejection unhandled).
+      setUnavailable(true);
+      setLyrics(null);
     } finally {
       loadingRef.current = false;
     }

--- a/apps/readest-app/src/app/reader/components/tts/useTTSLyrics.ts
+++ b/apps/readest-app/src/app/reader/components/tts/useTTSLyrics.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { eventDispatcher } from '@/utils/event';
+
+export type TTSLyrics = { sectionIndex: number; lines: string[] };
+
+// The spoken line moves on sentence boundaries and 'tts-position' delivers
+// those, so this poll is only a backstop for a position event missed while the
+// sheet was closed. The setter bails on an unchanged value, so a quiet session
+// re-renders nothing — which is what keeps this affordable on e-ink.
+const STATE_POLL_MS = 500;
+
+// The lyric view renders the whole section so its scroll geometry is measured
+// rather than estimated. A chapter is the natural unit for that; a whole book
+// imported as one section is not, and past this the player keeps its cover.
+export const LYRIC_MAX_LINES = 2000;
+
+// Stable identity: the view re-measures its whole scroll geometry whenever the
+// line array changes, and a fresh [] every render would do that forever.
+const NO_LINES: string[] = [];
+
+type UseTTSLyricsOptions = {
+  bookKey: string;
+  // False for engines with no sentence alignment: nothing is fetched or polled.
+  enabled: boolean;
+  onGetLyrics: () => Promise<TTSLyrics | null>;
+  onGetActiveIndex: () => number;
+};
+
+// Section transcript + live position for the Read Aloud lyric view (#5755).
+// `unavailable` stays false until a load actually comes back empty (or too
+// long), so the player commits to the lyric layout up front and only falls
+// back to the cover for the sections that genuinely have no sheet to show.
+export const useTTSLyrics = ({
+  bookKey,
+  enabled,
+  onGetLyrics,
+  onGetActiveIndex,
+}: UseTTSLyricsOptions) => {
+  const [lyrics, setLyrics] = useState<TTSLyrics | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const loadingRef = useRef(false);
+
+  const loadLyrics = useCallback(async () => {
+    if (loadingRef.current) return;
+    loadingRef.current = true;
+    try {
+      const next = await onGetLyrics();
+      const usable = !!next && next.lines.length > 0 && next.lines.length <= LYRIC_MAX_LINES;
+      setUnavailable(!usable);
+      setLyrics((prev) =>
+        // Identity matters: a new array re-measures the whole list.
+        prev &&
+        next &&
+        prev.sectionIndex === next.sectionIndex &&
+        prev.lines.length === next.lines.length
+          ? prev
+          : usable
+            ? next
+            : null,
+      );
+    } finally {
+      loadingRef.current = false;
+    }
+  }, [onGetLyrics]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    void loadLyrics();
+  }, [enabled, loadLyrics]);
+
+  const refreshState = useCallback(() => {
+    const next = onGetActiveIndex();
+    setActiveIndex((prev) => (prev === next ? prev : next));
+  }, [onGetActiveIndex]);
+
+  const sectionIndex = lyrics?.sectionIndex;
+  useEffect(() => {
+    if (!enabled) return;
+    refreshState();
+    const handler = (event: CustomEvent) => {
+      const detail = event.detail as { bookKey?: string; sectionIndex?: number };
+      if (detail.bookKey !== bookKey) return;
+      refreshState();
+      // A chapter change is the only thing that replaces the sheet, and the
+      // position event is the first place it shows up.
+      if (detail.sectionIndex !== undefined && detail.sectionIndex !== sectionIndex) {
+        void loadLyrics();
+      }
+    };
+    eventDispatcher.on('tts-position', handler);
+    const interval = setInterval(refreshState, STATE_POLL_MS);
+    return () => {
+      eventDispatcher.off('tts-position', handler);
+      clearInterval(interval);
+    };
+  }, [bookKey, enabled, refreshState, loadLyrics, sectionIndex]);
+
+  return { lines: lyrics?.lines ?? NO_LINES, unavailable, activeIndex };
+};

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -46,6 +46,10 @@ interface UseTTSControlProps {
 // coarse enough to cost nothing next to the audio clock it reads.
 const PAGE_FOLLOW_INTERVAL_MS = 200;
 
+// Cadence of the buffering probe. Fast enough that a spinner appears with the
+// stall rather than after it, slow enough to cost nothing over a long session.
+const TTS_BUFFERING_POLL_MS = 400;
+
 export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProps) => {
   const _ = useTranslation();
   const { appService, envConfig } = useEnv();
@@ -63,6 +67,11 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
   const [isPlaying, setIsPlaying] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [showIndicator, setShowIndicator] = useState(false);
+  // The engine has taken an utterance but no audio is out yet: synthesis,
+  // network, decode, or a recording still loading. Polled, because unlike a
+  // sentence boundary it has no event of its own — and cheap enough to poll,
+  // being two property reads whose result usually does not change.
+  const [buffering, setBuffering] = useState(false);
   const [showBackToCurrentTTSLocation, setShowBackToCurrentTTSLocation] = useState(false);
 
   const [timeoutOption, setTimeoutOption] = useState(0);
@@ -85,8 +94,14 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
   // ttsClientsInited before its attach resolves, and the mini player would
   // otherwise keep that first render's sentence labels.
   const [audioTransport, setAudioTransport] = useState(false);
-  const syncAudioTransport = useCallback(() => {
-    setAudioTransport(ttsControllerRef.current?.usesAudioTransport() ?? false);
+  // Both flags read the active client's capabilities, which change with the
+  // voice (a book's own narrator is a voice), so they are state rather than a
+  // render-time probe: switching voices has to redraw the player.
+  const [supportsLyrics, setSupportsLyrics] = useState(false);
+  const syncClientCapabilities = useCallback(() => {
+    const controller = ttsControllerRef.current;
+    setAudioTransport(controller?.usesAudioTransport() ?? false);
+    setSupportsLyrics(controller?.supportsLyrics() ?? false);
   }, []);
 
   // Broadcast playback transitions on the app-wide bus so consumers that
@@ -324,7 +339,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
         });
         const speakingLang = controller.getSpeakingLang();
         if (speakingLang) setTtsLang(speakingLang);
-        syncAudioTransport();
+        syncClientCapabilities();
       } catch (err) {
         console.warn('TTS session adoption failed:', err);
       } finally {
@@ -903,6 +918,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
         // disqualifies the app from Now Playing and fought the claim.
         setTtsClientsInitialized(false);
         setAudioTransport(false);
+        setSupportsLyrics(false);
 
         // Show the mini player immediately, in the "playing" state: client
         // init below can take a while and the session is conceptually already
@@ -992,7 +1008,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
           setIsPlaying(false);
         }
         setTtsClientsInitialized(true);
-        syncAudioTransport();
+        syncClientCapabilities();
         setTTSEnabled(bookKey, true);
       } catch (error) {
         setShowIndicator(false);
@@ -1058,6 +1074,45 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
 
   const handleSupportsPlaybackInfo = useCallback(() => {
     return ttsControllerRef.current?.supportsPlaybackInfo() ?? false;
+  }, []);
+
+  // Lyric view (#5755). getLyrics builds the section's line list once per
+  // chapter; the state probe is polled, so it stays a plain read.
+  const handleGetLyrics = useCallback(async () => {
+    return (await ttsControllerRef.current?.getLyrics()) ?? null;
+  }, []);
+
+  const handleGetLyricActiveIndex = useCallback(() => {
+    return ttsControllerRef.current?.getCurrentLyricIndex() ?? -1;
+  }, []);
+
+  // Only while a session exists; an idle reader polls nothing.
+  useEffect(() => {
+    if (!showIndicator) {
+      setBuffering(false);
+      return;
+    }
+    const poll = () => {
+      // Optional call on purpose: this runs in an effect, and a purely
+      // cosmetic ring must never be able to throw the reader subtree down if a
+      // session hands back something that is not a full controller.
+      const next = ttsControllerRef.current?.isBuffering?.() ?? false;
+      setBuffering((prev) => (prev === next ? prev : next));
+    };
+    poll();
+    const interval = setInterval(poll, TTS_BUFFERING_POLL_MS);
+    return () => clearInterval(interval);
+  }, [showIndicator]);
+
+  const handleGetLyricPage = useCallback(async (index: number) => {
+    return (await ttsControllerRef.current?.getLyricPage(index)) ?? null;
+  }, []);
+
+  // The lyric play button means "read from here", so this both moves and plays.
+  const handlePlayFromLyric = useCallback(async (index: number) => {
+    const ttsController = ttsControllerRef.current;
+    if (!ttsController) return;
+    await ttsController.seekToLyric(index);
   }, []);
 
   // Stable handle for the download/chapters surface (reads the cache and
@@ -1193,7 +1248,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
         } else {
           await ttsController.setVoice(voice, lang);
         }
-        syncAudioTransport();
+        syncClientCapabilities();
       }
     }, 3000),
     [],
@@ -1267,7 +1322,13 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     handleSeekPreview,
     handleGetPlaybackInfo,
     handleSupportsPlaybackInfo,
+    handleGetLyrics,
+    handleGetLyricActiveIndex,
+    handleGetLyricPage,
+    handlePlayFromLyric,
     audioTransport,
+    supportsLyrics,
+    buffering,
     refreshTtsLang,
     getController,
   };

--- a/apps/readest-app/src/services/tts/SectionTimeline.ts
+++ b/apps/readest-app/src/services/tts/SectionTimeline.ts
@@ -46,6 +46,14 @@ export class SectionTimeline {
     return this.#sentences.length;
   }
 
+  // Sentence at an ordinal, for callers that address the timeline by index
+  // rather than by time (the lyric view). Never round-trip an index through
+  // seconds to get here: positionAt() divides by the rate and sentenceAtTime()
+  // multiplies it back, and the float error can land a line early.
+  sentenceAt(index: number): TimelineSentence | null {
+    return this.#sentences[index] ?? null;
+  }
+
   setVoice(voiceId: string): void {
     if (voiceId === this.#voiceId) return;
     this.#voiceId = voiceId;

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -767,7 +767,12 @@ export class TTSController extends EventTarget {
       return this.#sectionTimeline;
     }
     const doc = this.#ttsDoc;
-    if (!doc || this.#ttsSectionIndex < 0) return null;
+    // Pin the section this build is FOR. The enumeration below awaits, and a
+    // chapter can turn inside that await; committing then would file sentences
+    // read out of the old document under the new section's index, which every
+    // `#timelineSectionIndex === #ttsSectionIndex` guard would wave through.
+    const sectionIndex = this.#ttsSectionIndex;
+    if (!doc || sectionIndex < 0) return null;
     const sentences: TimelineSentence[] = [];
     if (this.narrationActive) {
       // The recording's own clip boundaries — exact durations, so the scrubber
@@ -786,6 +791,10 @@ export class TTSController extends EventTarget {
         sentences.push({ ...entry, text: entry.range.toString() });
       }
     }
+    // The section moved on while this was being enumerated: these sentences
+    // belong to a document nobody is reading any more. Drop them; the next
+    // caller rebuilds against the section now loaded.
+    if (this.#ttsSectionIndex !== sectionIndex || this.#ttsDoc !== doc) return null;
     const timeline = new SectionTimeline(
       sentences,
       this.ttsLang || 'en',
@@ -793,12 +802,12 @@ export class TTSController extends EventTarget {
     );
     timeline.setRate(this.ttsRate);
     this.#sectionTimeline = timeline;
-    this.#timelineSectionIndex = this.#ttsSectionIndex;
+    this.#timelineSectionIndex = sectionIndex;
     // Tell the cache which sentences make up this section (ordinal-keyed);
     // once every ordinal has a recorded synthesis key, the section can be
     // compacted into one pack file.
     this.ttsClient.registerSectionManifest?.(
-      this.#ttsSectionIndex,
+      sectionIndex,
       sentences.map((s) => `${s.blockIndex}:${s.markName}`),
     );
     // Off the critical path: pull cached per-sentence durations (downloaded
@@ -806,7 +815,7 @@ export class TTSController extends EventTarget {
     // chapter reports a fully measured timeline — without this the buffered
     // bar showed an "unbuffered" tail on downloaded chapters until every
     // sentence had been replayed.
-    void this.#hydrateTimelineDurations(timeline, sentences, this.#ttsSectionIndex);
+    void this.#hydrateTimelineDurations(timeline, sentences, sectionIndex);
     return timeline;
   }
 

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -1,6 +1,6 @@
 import { FoliateView, ViewTTS } from '@/types/view';
 import { AppService } from '@/types/system';
-import type { PairedAudiobook } from '@/types/book';
+import type { PageInfo, PairedAudiobook } from '@/types/book';
 import { SectionItem } from '@/libs/document';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { transformTTSSectionDocument } from './transformDoc';
@@ -25,6 +25,7 @@ import { TTSUtils } from './TTSUtils';
 import { TTSClient } from './TTSClient';
 import { startAudioKeepAlive, stopAudioKeepAlive } from './WebAudioPlayer';
 import { isValidLang } from '@/utils/lang';
+import { normalizeLyricText } from '@/utils/ttsLyrics';
 import {
   computeWordOffsets,
   getTextSubRange,
@@ -138,6 +139,12 @@ export class TTSController extends EventTarget {
   #sectionTimeline: SectionTimeline | null = null;
   #timelineSectionIndex: number = -1;
   #currentSentenceIndex: number = -1;
+  // Set while an utterance has been handed to the client but no audio has been
+  // heard from it yet — synthesis, network, decode, or a recording still
+  // loading. The first event the speak() iterator yields IS the first audible
+  // chunk (see BufferedTTSClient/MediaOverlayClient), so it is the only signal
+  // needed here. Surfaced as isBuffering() for the player's spinner.
+  #awaitingAudio = false;
   #ttsDoc: Document | null = null;
   #ttsGranularity: TTSGranularity = 'sentence';
 
@@ -947,6 +954,80 @@ export class TTSController extends EventTarget {
     return capabilities.mediaClock && capabilities.textHighlight === false;
   }
 
+  // Whether the active engine aligns audio to the text closely enough to drive
+  // the lyric view: a media clock to seek with AND real per-sentence timing.
+  // A chapter-only audiobook pairing has the clock but no sentence alignment,
+  // so it keeps the plain cover player, as do the direct-speak engines (#5755).
+  supportsLyrics(): boolean {
+    const capabilities = this.ttsClient.getCapabilities();
+    return capabilities.mediaClock && capabilities.textHighlight !== false;
+  }
+
+  // The sentences of the section now playing, as display lines. Section-scoped
+  // exactly like the scrubber: one chapter is one lyric sheet.
+  async getLyrics(): Promise<{ sectionIndex: number; lines: string[] } | null> {
+    if (!this.supportsLyrics()) return null;
+    const timeline = await this.ensureTimeline();
+    if (!timeline || timeline.length === 0) return null;
+    const lines: string[] = [];
+    for (let i = 0; i < timeline.length; i++) {
+      lines.push(normalizeLyricText(timeline.sentenceAt(i)?.text ?? ''));
+    }
+    return { sectionIndex: this.#ttsSectionIndex, lines };
+  }
+
+  // Ordinal of the sentence now sounding, or -1 while nothing is located —
+  // same resolution order as getPlaybackInfo (live index, else the last range).
+  getCurrentLyricIndex(): number {
+    const timeline = this.#sectionTimeline;
+    if (!timeline || this.#timelineSectionIndex !== this.#ttsSectionIndex) return -1;
+    if (this.#currentSentenceIndex >= 0) return this.#currentSentenceIndex;
+    const range = this.#getTts()?.getLastRange();
+    return range ? timeline.indexOfRange(range) : -1;
+  }
+
+  // Playing, but nothing audible yet: synthesis, network, decode, or a
+  // recording still loading. Drives the spinner in the lyric play button.
+  isBuffering(): boolean {
+    return this.#awaitingAudio && this.state === 'playing';
+  }
+
+  // Start speaking at a lyric line. Unlike the scrubber's seek this always
+  // plays — its only caller is the play button on the line under the reader's
+  // finger, and that button means "read from here".
+  async seekToLyric(index: number): Promise<void> {
+    this.clearSeekPreview();
+    await this.initViewTTS();
+    const timeline = await this.ensureTimeline();
+    const sentence = timeline?.sentenceAt(index);
+    if (!sentence) return;
+    // Same handover rule as seekToTime: a live session hands over to the
+    // utterance started below, a parked one is really stopped first.
+    await this.stop(this.state === 'playing');
+    await this.#resumeAt({ index, withinMediaSec: 0 }, sentence.range, true);
+  }
+
+  // Where a lyric line sits in the book, for the page readout on the seek row.
+  // Resolved through the same CFI -> location machinery the footer uses, so the
+  // number the reader sees while dragging matches the one they left behind.
+  async getLyricPage(index: number): Promise<PageInfo | null> {
+    const timeline = this.#sectionTimeline;
+    if (!timeline || this.#timelineSectionIndex !== this.#ttsSectionIndex) return null;
+    const sentence = timeline.sentenceAt(index);
+    if (!sentence) return null;
+    try {
+      const cfi = this.view.getCFI(this.#ttsSectionIndex, sentence.range);
+      const progress = await this.view.getCFIProgress(cfi);
+      if (!progress) return null;
+      // Fixed-layout books count pages by section, matching FooterBar.
+      return this.view.book?.rendition?.layout === 'pre-paginated'
+        ? progress.section
+        : progress.location;
+    } catch {
+      return null;
+    }
+  }
+
   // Whether the active client supports the inter-sentence gap control.
   supportsGapControl(): boolean {
     return this.ttsClient.getCapabilities().gapControl;
@@ -1358,6 +1439,7 @@ export class TTSController extends EventTarget {
       try {
         console.log('[TTS] speak');
         this.state = 'playing';
+        this.#awaitingAudio = true;
         this.#syncAudioKeepAlive();
 
         signal.addEventListener('abort', () => {
@@ -1409,6 +1491,10 @@ export class TTSController extends EventTarget {
         const iter = await this.ttsClient.speak(ssml, signal);
         let lastCode;
         for await (const { code } of iter) {
+          // Anything the iterator yields means the client is done waiting:
+          // 'boundary' is the first audible chunk, 'end'/'error' resolve the
+          // wait the other way.
+          this.#awaitingAudio = false;
           if (signal.aborted) {
             resolve();
             return;
@@ -1534,6 +1620,7 @@ export class TTSController extends EventTarget {
   }
 
   async stop(handover = false) {
+    this.#awaitingAudio = false;
     if (this.#currentSpeakAbortController) {
       this.#currentSpeakAbortController.abort();
     }

--- a/apps/readest-app/src/utils/ttsLyrics.ts
+++ b/apps/readest-app/src/utils/ttsLyrics.ts
@@ -1,0 +1,56 @@
+// Geometry and text helpers for the lyric-style sentence view in the Read
+// Aloud player (see TTSLyricsView). Kept pure so the scroll math is unit
+// tested without a layout engine — jsdom reports every offset as 0.
+
+// One timeline sentence rendered as one lyric line. Range text carries the
+// source document's line breaks and indentation; a lyric line is a single
+// run of words.
+export const normalizeLyricText = (text: string): string => text.replace(/\s+/g, ' ').trim();
+
+// Index of the line whose vertical centre sits closest to `center` (a
+// content-space offset, i.e. scrollTop + viewportHeight / 2). Centres are
+// ascending, so this is a binary search plus a neighbour comparison.
+// Returns -1 only for an empty list.
+export const lyricIndexAtCenter = (centers: number[], center: number): number => {
+  const n = centers.length;
+  if (n === 0) return -1;
+  let low = 0;
+  let high = n - 1;
+  // Last line whose centre is at or before the target.
+  let index = -1;
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    if (centers[mid]! <= center) {
+      index = mid;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  if (index < 0) return 0;
+  if (index >= n - 1) return n - 1;
+  const before = center - centers[index]!;
+  const after = centers[index + 1]! - center;
+  return after < before ? index + 1 : index;
+};
+
+// scrollTop that parks line `index` in the middle of the viewport. The view
+// pads its content with half-viewport spacers, so this never needs clamping
+// at the far end; the near end is clamped for safety only.
+//
+// A book sentence is not a song lyric: the long ones wrap past the height of
+// the window. Centring those would show their middle and hide the words the
+// voice is about to say, so a line taller than the viewport parks its first
+// row at the top and reads downwards instead.
+export const lyricScrollTopFor = (
+  centers: number[],
+  heights: number[],
+  index: number,
+  viewportHeight: number,
+): number => {
+  const center = centers[index];
+  if (center === undefined) return 0;
+  const height = heights[index] ?? 0;
+  const top = height > viewportHeight ? center - height / 2 : center - viewportHeight / 2;
+  return Math.max(top, 0);
+};


### PR DESCRIPTION
Closes #5755.

Draws the chapter as a scrollable transcript in the Read Aloud player: the sentence being spoken sits centred and lit, the rest dim around it, and the sheet follows the voice the way a music player follows a song. Scope is the lyric highlighting from the issue, not the rest of the referenced app's player.

### When it is offered

Gated on the engine actually aligning audio to the text (`TTSController.supportsLyrics()` = `mediaClock && textHighlight !== false`):

| Engine | Lyric sheet |
| --- | --- |
| Edge TTS (`BufferedTTSClient`) | yes |
| EPUB 3 Media Overlays with per-sentence timing | yes |
| Paired audiobook (chapter-level timing only) | no, keeps the cover player |
| Native / Web Speech (no media clock) | no, keeps the cover player |

A section with nothing to transcribe, or a whole book imported as one section (`LYRIC_MAX_LINES`), falls back the same way. Because capabilities change with the voice, `supportsLyrics` is state synced by `syncClientCapabilities()` rather than a render-time probe, so switching to a book's own narrator redraws the player.

### Seeking

Dragging the sheet parks it and raises a row over the centre line: page number on one side, play button on the other. Playback does not move until that button is pressed, and an abandoned drag slides back to the voice after four seconds. The page number goes through the same CFI to location path the footer uses, so it matches the number the reader left behind.

### Buffering

While an utterance has been handed to the engine but no audio is out yet, the seek button spins and the transport buttons (player sheet, and both mini player styles) wear a ring. A ring rather than a swapped icon, so a reader can still pause mid-fetch. `isBuffering()` is driven by the first event the `speak()` iterator yields, which for both buffered clients is the first audible chunk; `getChunkPosition()` is not usable for this, since the web player reports a position for chunks scheduled in the future.

### Notes

- The sentence list is the `SectionTimeline` the scrubber already builds, so there is no new enumeration and no second source of truth.
- Line geometry is measured per layout and re-measured whenever the content box changes. A narrower window re-wraps every sentence and moves every centre while the scroller's own height stays put, so watching the viewport alone left the follow scroll a line or two out.
- Long moves land outright and neighbouring sentences glide; e-ink never animates. Sentences taller than the window top-align instead of centring, so their opening words are not scrolled past.

### Verification

`pnpm test`, `pnpm lint` and `pnpm format:check` all green. Checked in Chrome against Moby-Dick with Edge TTS: the sheet follows the spoken line, a wheel scroll raises the seek row, pressing play moved playback back onto that exact line, and the spinner and ring both appear while a far uncached sentence synthesises and clear when audio arrives. Cached sentences correctly show no indicator. Not yet checked on a device or on e-ink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a lyric-style transcript view to Read Aloud, highlighting the currently spoken sentence.
  - Added scrolling, page lookup, and playback controls for starting narration from a selected lyric.
  - Added buffering indicators to playback controls, including e-ink-friendly behavior.
  - Added support detection and graceful fallback when transcripts are unavailable.

- **Tests**
  - Added comprehensive coverage for lyric rendering, navigation, playback, buffering, scrolling, and transcript handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->