### PR TITLE
fix(tts): queue a lyric reload requested during an in-flight fetch

### DIFF
--- a/apps/readest-app/src/__tests__/components/tts/useTTSLyrics.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/useTTSLyrics.test.tsx
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 
-import { LYRIC_MAX_LINES, useTTSLyrics } from '@/app/reader/components/tts/useTTSLyrics';
+import {
+  LYRIC_MAX_LINES,
+  type TTSLyrics as TTSLyricsResult,
+  useTTSLyrics,
+} from '@/app/reader/components/tts/useTTSLyrics';
 import { eventDispatcher } from '@/utils/event';
 
 const lines = ['One.', 'Two.', 'Three.'];
@@ -107,6 +111,39 @@ describe('useTTSLyrics', () => {
       await eventDispatcher.dispatch('tts-position', { bookKey: 'b', sectionIndex: 4 });
     });
     await waitFor(() => expect(result.current.lines).toEqual(['Next chapter.']));
+  });
+
+  test('runs a chapter change that arrived while a fetch was still out', async () => {
+    let releaseFirst: ((value: TTSLyricsResult) => void) | null = null;
+    const onGetLyrics = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<TTSLyricsResult>((resolve) => {
+            releaseFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({ sectionIndex: 4, lines: ['Next chapter.'] });
+    const { result } = renderHook(() =>
+      useTTSLyrics({
+        bookKey: 'b',
+        enabled: true,
+        onGetLyrics,
+        onGetActiveIndex: () => 0,
+      }),
+    );
+    await waitFor(() => expect(onGetLyrics).toHaveBeenCalledTimes(1));
+
+    // The chapter turns before the first fetch has come back.
+    await act(async () => {
+      await eventDispatcher.dispatch('tts-position', { bookKey: 'b', sectionIndex: 4 });
+    });
+    // Dropping it would leave section 3 on screen until the next sentence.
+    await act(async () => {
+      releaseFirst!({ sectionIndex: 3, lines });
+    });
+    await waitFor(() => expect(result.current.lines).toEqual(['Next chapter.']));
+    expect(onGetLyrics).toHaveBeenCalledTimes(2);
   });
 
   test('ignores position events from another book', async () => {

--- a/apps/readest-app/src/app/reader/components/tts/useTTSLyrics.ts
+++ b/apps/readest-app/src/app/reader/components/tts/useTTSLyrics.ts
@@ -40,31 +40,46 @@ export const useTTSLyrics = ({
   const [unavailable, setUnavailable] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const loadingRef = useRef(false);
+  const reloadWantedRef = useRef(false);
 
   const loadLyrics = useCallback(async () => {
-    if (loadingRef.current) return;
+    if (loadingRef.current) {
+      // A chapter turned while the previous fetch was still out. Dropping the
+      // request would leave the previous chapter's lines (or the cover) up
+      // until the next sentence boundary happened to ask again, so queue it.
+      reloadWantedRef.current = true;
+      return;
+    }
     loadingRef.current = true;
     try {
-      const next = await onGetLyrics();
-      const usable = !!next && next.lines.length > 0 && next.lines.length <= LYRIC_MAX_LINES;
-      setUnavailable(!usable);
-      setLyrics((prev) =>
-        // Identity matters: a new array re-measures the whole list.
-        prev &&
-        next &&
-        prev.sectionIndex === next.sectionIndex &&
-        prev.lines.length === next.lines.length
-          ? prev
-          : usable
-            ? next
-            : null,
-      );
-    } catch {
-      // A transcript that cannot be read is a section with no sheet to show:
-      // fall back to the cover rather than leaving the lyric layout standing
-      // over nothing (and leaving the rejection unhandled).
-      setUnavailable(true);
-      setLyrics(null);
+      do {
+        reloadWantedRef.current = false;
+        try {
+          const next = await onGetLyrics();
+          const usable = !!next && next.lines.length > 0 && next.lines.length <= LYRIC_MAX_LINES;
+          setUnavailable(!usable);
+          setLyrics((prev) =>
+            // Identity matters: a new array re-measures the whole list.
+            prev &&
+            next &&
+            prev.sectionIndex === next.sectionIndex &&
+            prev.lines.length === next.lines.length
+              ? prev
+              : usable
+                ? next
+                : null,
+          );
+        } catch {
+          // A transcript that cannot be read is a section with no sheet to
+          // show: fall back to the cover rather than leaving the lyric layout
+          // standing over nothing (and leaving the rejection unhandled).
+          setUnavailable(true);
+          setLyrics(null);
+        }
+        // Bounded by the number of chapter changes that actually queued up:
+        // each pass clears the flag before fetching, so only a change that
+        // arrived during THAT fetch runs another.
+      } while (reloadWantedRef.current);
     } finally {
       loadingRef.current = false;
     }


### PR DESCRIPTION
Follow-up to #5908, which merged before this fix could be pushed onto it. Same review round, one finding CodeRabbit raised outside the diff after re-reviewing the earlier fixes.

`loadLyrics` guards against overlapping fetches with `loadingRef`, but it dropped the second request outright rather than deferring it. A chapter turning while the previous transcript was still being fetched therefore lost its reload: the in-flight request resolves against whatever the controller's live section is by the time `ensureTimeline()` returns, so the sheet was left showing the previous chapter's lines, or falling back to the cover when the pinning guard added in #5908 discarded that build.

It did self-heal, but only on the next `tts-position` event, which is a sentence away. Chapter turns are frequent over a long listening session, so it is worth closing.

The request is now recorded and drained once the active fetch settles. The loop is bounded by the number of changes that actually queued: each pass clears the flag before fetching, so only a change arriving during that fetch triggers another pass.

Regression test added (unresolved first fetch, section change, then release) and confirmed to fail without the queueing. `pnpm test`, `pnpm lint` and `pnpm format:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech lyrics when switching chapters during loading.
  * Prevented outdated lyrics from appearing after a chapter change.
  * Automatically reloads lyrics for the newly selected chapter once the current request finishes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->