### PR TITLE
fix(translate): Chinese targets, provider rate limits, and translator popup layout

### DIFF
--- a/apps/readest-app/src/__tests__/components/daisyui-v5-tokens.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/daisyui-v5-tokens.browser.test.tsx
@@ -188,6 +188,35 @@ describe('daisyUI 5 theme tokens', () => {
     expect(getComputedStyle(getByTestId('option')).whiteSpace).toBe('nowrap');
   });
 
+  it('tracks the selected value, not the widest option, without base-select', () => {
+    // Under `appearance: base-select` the selected value already drives the
+    // width. An engine without it falls back to native select rendering, where
+    // `w-auto` means the width of the widest *option* — and TranslatorPopup
+    // hands this the whole language list, so a one-character value measured
+    // 240px instead of 49px. `field-sizing: content` keeps the fallback sized to
+    // the selection. Asserted through the fallback on purpose: under
+    // base-select this passes with or without the fix and would guard nothing.
+    const { getByTestId } = render(
+      <div data-testid='row' style={{ width: 400 }}>
+        <Select
+          value='a'
+          onChange={() => {}}
+          options={[
+            { value: 'a', label: 'A' },
+            { value: 'long', label: 'Português (Brasil) and a very long unselected label' },
+          ]}
+        />
+      </div>,
+    );
+    const select = getByTestId('row').querySelector('select')!;
+    const withBaseSelect = select.getBoundingClientRect().width;
+
+    select.style.appearance = 'none';
+    const withoutBaseSelect = select.getBoundingClientRect().width;
+
+    expect(withoutBaseSelect).toBeLessThanOrEqual(withBaseSelect + 1);
+  });
+
   it('anchors the settings picker to the whole control, chevron included', () => {
     // SettingsSelect suppresses daisyUI's in-select chevron and renders a
     // separate 20px MdArrowDropDown *outside* the <select>. The picker's

--- a/apps/readest-app/src/__tests__/components/daisyui-v5-tokens.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/daisyui-v5-tokens.browser.test.tsx
@@ -10,6 +10,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/react';
 import { themes, applyCustomTheme } from '@/styles/themes';
 import SettingsSelect from '@/components/settings/primitives/SettingsSelect';
+import Select from '@/components/Select';
 
 await import('@/styles/globals.css');
 
@@ -171,5 +172,97 @@ describe('daisyUI 5 theme tokens', () => {
     // The settings primitive strips daisyUI's chevron and chrome; it must not
     // also strip the appearance, or the popup falls back to the OS one.
     expect(getComputedStyle(getByLabelText('Settings select')).appearance).toBe('base-select');
+  });
+
+  it('keeps picker options on one line', () => {
+    // Because the picker is painted in-page, CSS on <option> is live, and
+    // daisyUI 5 ships `:is(.select,.select select) option { white-space: normal }`.
+    // A long entry — "Português (Brasil)", "System Language" — then wraps onto
+    // several lines inside a narrow select, which is what the translator popup's
+    // language and provider pickers are.
+    const { getByTestId } = render(
+      <select className='select'>
+        <option data-testid='option'>Português (Brasil)</option>
+      </select>,
+    );
+    expect(getComputedStyle(getByTestId('option')).whiteSpace).toBe('nowrap');
+  });
+
+  it('anchors the settings picker to the whole control, chevron included', () => {
+    // SettingsSelect suppresses daisyUI's in-select chevron and renders a
+    // separate 20px MdArrowDropDown *outside* the <select>. The picker's
+    // implicit anchor is the <select>, so it lands short of the control's
+    // visible trailing edge. Measured on device: <select> right 913px, wrapper
+    // right 968px, picker right 910px -- 20px adrift of the chevron the user
+    // reads as the edge of the control. Anchoring to the wrapper lands it at
+    // 965px, flush.
+    const { getByLabelText } = render(
+      <SettingsSelect
+        value='a'
+        onChange={() => {}}
+        options={[{ value: 'a', label: 'A' }]}
+        ariaLabel='Anchored select'
+      />,
+    );
+    const select = getByLabelText('Anchored select');
+    const wrapper = select.parentElement!;
+    const css = (el: Element, prop: string, pseudo?: string) =>
+      getComputedStyle(el as HTMLElement, pseudo)
+        .getPropertyValue(prop)
+        .trim();
+
+    expect(css(wrapper, 'anchor-name')).toBe('--settings-select');
+    // Scoped, so a page full of these rows resolves each picker to its own
+    // wrapper rather than to the last one in tree order.
+    expect(css(wrapper, 'anchor-scope')).toBe('--settings-select');
+    expect(css(select, 'position-anchor', '::picker(select)')).toBe('--settings-select');
+  });
+
+  it('sizes Select to its value so the label ends against the chevron', () => {
+    // daisyUI 5 gives `.select` `width: clamp(3rem,20rem,100%)`, so the box
+    // stretches to its max width whatever the value is and the label sits at the
+    // far start of a wide box. v4 hugged the content, which is what made the
+    // component's `text-align-last: end` read as end-aligned. The value itself
+    // cannot be aligned under `appearance: base-select`: it is painted into a
+    // UA-generated <selectedcontent> in the shadow root, so neither
+    // `text-align-last` nor an author rule on `selectedcontent` reaches it.
+    const { getByTestId } = render(
+      <div
+        data-testid='row'
+        style={{ width: 400, display: 'flex', justifyContent: 'space-between' }}
+      >
+        <span>Translated Text</span>
+        <Select value='a' onChange={() => {}} options={[{ value: 'a', label: 'A' }]} />
+      </div>,
+    );
+    const row = getByTestId('row').getBoundingClientRect();
+    const select = getByTestId('row').querySelector('select')!.getBoundingClientRect();
+    // Hugging the value, not filling the row.
+    expect(select.width).toBeLessThan(row.width / 2);
+    // And still parked at the row's end, where the chevron is.
+    expect(Math.round(select.right)).toBe(Math.round(row.right));
+  });
+
+  it('lines the picker up with the end of the select', () => {
+    // daisyUI already end-aligns the picker (`position-area: self-start
+    // span-self-start`) but then insets it: `margin-inline: 8px` plus
+    // `translate: -8px` (mirrored as `translate: .5rem` under [dir=rtl]). That
+    // is 16px of drift, so the popup visibly fails to line up with the value it
+    // belongs to. Zeroing both is what makes it flush; `margin-inline-end` and
+    // `translate: none` are both direction-agnostic, so RTL stays correct.
+    const { getByTestId } = render(
+      <select data-testid='select' className='select'>
+        <option>A</option>
+      </select>,
+    );
+    const picker = getComputedStyle(getByTestId('select'), '::picker(select)');
+    expect(picker.translate).toBe('none');
+    expect(picker.marginInlineEnd).toBe('0px');
+
+    // The RTL mirror must not reintroduce the nudge either.
+    document.documentElement.setAttribute('dir', 'rtl');
+    const rtl = getComputedStyle(getByTestId('select'), '::picker(select)');
+    expect(rtl.translate).toBe('none');
+    document.documentElement.removeAttribute('dir');
   });
 });

--- a/apps/readest-app/src/__tests__/components/translator-popup-grid.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/translator-popup-grid.browser.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * The translator popup divides its capped height between the original pane and
+ * the translated pane — both scroll — while the divider and the provider footer
+ * stay pinned.
+ *
+ * Assert the resolved layout, never the class string. `grid-rows-[1fr,auto,1fr,auto]`
+ * looked right and sat in the class attribute, but Tailwind emits arbitrary
+ * values verbatim, so it produced `grid-template-rows:1fr,auto,1fr,auto`. Commas
+ * are not track separators, the browser threw the declaration away, and every row
+ * fell back to an implicit auto track sized to its content. On a phone that
+ * pushed the translated text and the whole provider footer past the popup's own
+ * max height, with nothing scrollable to reach them.
+ *
+ * A bare `1fr` would not have been enough either: it floors at min-content, so
+ * the rows still refuse to shrink inside the capped popup. Each flexible track
+ * needs `minmax(0,...)`.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { page } from 'vitest/browser';
+
+import '@/styles/globals.css';
+
+vi.mock('@/hooks/useKeyDownActions', () => ({ useKeyDownActions: () => {} }));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (s: string) => s,
+}));
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({
+    settings: {
+      globalReadSettings: { translateTargetLang: 'zh-CN', translationProvider: 'google' },
+    },
+    setSettings: vi.fn(),
+  }),
+}));
+
+// Long enough that either pane on its own would outgrow the capped popup.
+const LONG_SOURCE =
+  'The plaint about the lost art of diagramming sentences refers to a notation that was ' +
+  'invented by Alonzo Reed and Brainerd Kellogg in 1877 and taught in American schools ' +
+  'until the 1960s, when it fell victim to the revolt among educators against all things formal.';
+const LONG_TRANSLATION =
+  '关于绘制句子的失落艺术的抱怨是指一种符号，由Alonzo Reed和Brainerd Kellogg于1877年发明，' +
+  '并在美国学校教授，直到20世纪60年代，当时它成为教育工作者反对所有正式事物的反抗的牺牲品。';
+
+vi.mock('@/hooks/useTranslator', async () => {
+  // The real registry, so the footer renders real provider labels.
+  const { getTranslators } = await import('@/services/translators');
+  const translators = getTranslators();
+  return {
+    useTranslator: () => ({
+      translate: async (texts: string[]) => texts.map(() => LONG_TRANSLATION),
+      translator: translators.find((t) => t.name === 'google'),
+      translators,
+      loading: false,
+    }),
+  };
+});
+
+const { default: TranslatorPopup } = await import(
+  '@/app/reader/components/annotator/TranslatorPopup'
+);
+
+beforeAll(async () => {
+  await page.viewport(400, 700);
+});
+
+afterEach(() => cleanup());
+
+const renderPopup = () =>
+  render(
+    <TranslatorPopup
+      text={LONG_SOURCE}
+      // Attached low on a short viewport, so the popup is height-capped hard.
+      position={{ dir: 'down', point: { x: 20, y: 390 } }}
+      trianglePosition={{ dir: 'down', point: { x: 100, y: 380 } }}
+      popupWidth={360}
+      popupHeight={200}
+    />,
+  );
+
+const getPopup = (container: HTMLElement) =>
+  container.querySelector<HTMLElement>('.popup-container')!;
+
+describe('TranslatorPopup layout', () => {
+  it('emits a grid-template-rows declaration the browser actually accepts', async () => {
+    const { container } = renderPopup();
+    const popup = getPopup(container);
+    await waitFor(() => expect(popup.textContent).toContain(LONG_TRANSLATION));
+
+    // Read the class off the rendered popup so this stays tied to the component
+    // rather than to a copy of its class string.
+    const gridClass = [...popup.classList].find((c) => c.startsWith('grid-rows-'));
+    expect(gridClass).toBeDefined();
+
+    // An *empty* grid reports its explicit tracks (as 0px each) and reports
+    // `none` when the declaration was thrown away. On the popup itself the
+    // computed value is the used track sizes either way, so a dropped
+    // declaration is indistinguishable there — hence the bare probe.
+    const probe = document.createElement('div');
+    probe.className = gridClass!;
+    probe.style.display = 'grid';
+    document.body.appendChild(probe);
+    try {
+      expect(getComputedStyle(probe).gridTemplateRows).not.toBe('none');
+    } finally {
+      probe.remove();
+    }
+  });
+
+  it('keeps the provider footer inside the popup instead of off screen', async () => {
+    const { container } = renderPopup();
+    const popup = getPopup(container);
+    await waitFor(() => expect(popup.textContent).toContain(LONG_TRANSLATION));
+
+    const popupRect = popup.getBoundingClientRect();
+    const footer = popup.children[3] as HTMLElement;
+    const footerRect = footer.getBoundingClientRect();
+
+    expect(footer.textContent).toMatch(/Translated by/);
+    // Rounded: sub-pixel grid track sizing lands a fraction over the edge.
+    expect(Math.round(footerRect.bottom)).toBeLessThanOrEqual(Math.round(popupRect.bottom));
+    expect(Math.round(footerRect.bottom)).toBeLessThanOrEqual(window.innerHeight);
+  });
+
+  it('lets both panes scroll rather than overflowing the popup', async () => {
+    const { container } = renderPopup();
+    const popup = getPopup(container);
+    await waitFor(() => expect(popup.textContent).toContain(LONG_TRANSLATION));
+
+    // The popup itself never scrolls; the two panes do.
+    expect(popup.scrollHeight).toBeLessThanOrEqual(popup.clientHeight + 1);
+
+    const originalPane = popup.children[0] as HTMLElement;
+    const translatedPane = popup.children[2] as HTMLElement;
+    for (const pane of [originalPane, translatedPane]) {
+      expect(getComputedStyle(pane).overflowY).toBe('auto');
+      expect(pane.scrollHeight).toBeGreaterThan(pane.clientHeight);
+    }
+  });
+});

--- a/apps/readest-app/src/__tests__/services/translators/providers.test.ts
+++ b/apps/readest-app/src/__tests__/services/translators/providers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 import { isTauriAppPlatform } from '@/services/environment';
+import { initSimpleCC, runSimpleCC } from '@/utils/simplecc';
 
 // Mock environment module
 vi.mock('@/services/environment', () => ({
@@ -34,6 +35,18 @@ vi.mock('@/utils/supabase', () => ({
   },
 }));
 
+vi.mock('@/utils/simplecc', () => ({
+  initSimpleCC: vi.fn(async () => {}),
+  // Stand-in for the real OpenCC conversion; the assertions only need to see
+  // that the Simplified reply was routed through it with the right variant.
+  runSimpleCC: vi.fn((text: string) => text.replace(/只/g, '隻').replace(/过/g, '過')),
+}));
+
+vi.mock('@/utils/access', () => ({
+  getSubscriptionPlan: vi.fn(() => 'free'),
+  getTranslationQuota: vi.fn(() => 1000),
+}));
+
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
@@ -43,6 +56,13 @@ vi.stubGlobal('fetch', mockFetch);
 describe('googleProvider', () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    vi.mocked(tauriFetch).mockReset();
+    // Other suites flip the platform mock to Tauri; google must behave the same
+    // either way, so start each test from the default.
+    vi.mocked(isTauriAppPlatform).mockReturnValue(false);
+    // The provider keeps a module-level concurrency counter, so each test needs
+    // a fresh module.
+    vi.resetModules();
   });
 
   afterEach(() => {
@@ -103,6 +123,65 @@ describe('googleProvider', () => {
     expect(result).toEqual(['Hello']);
   });
 
+  it('caps concurrent requests instead of fanning out over the whole page', async () => {
+    // The endpoint is unofficial and Google throttles it per client bucket. An
+    // unbounded fan-out over a page of paragraphs is what earns the 429 page
+    // ("your computer or network may be sending automated queries"), and the
+    // block outlives the burst by many minutes.
+    let inFlight = 0;
+    let peakInFlight = 0;
+    mockFetch.mockImplementation(async () => {
+      inFlight++;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight--;
+      return { ok: true, status: 200, json: async () => [[['translated', 'original']]] };
+    });
+
+    const { googleProvider } = await import('@/services/translators/providers/google');
+    const lines = Array.from({ length: 24 }, (_, index) => `line ${index}`);
+    const result = await googleProvider.translate(lines, 'en', 'zh-CN');
+
+    expect(result).toHaveLength(24);
+    expect(result.every((line) => line === 'translated')).toBe(true);
+    expect(peakInFlight).toBeGreaterThan(1);
+    expect(peakInFlight).toBeLessThanOrEqual(4);
+    // Throttling must not drop work.
+    expect(mockFetch).toHaveBeenCalledTimes(24);
+  });
+
+  it('goes through the webview stack even on Tauri, never the Rust HTTP plugin', async () => {
+    // Google refuses the Tauri HTTP plugin's requests: measured on an Android
+    // device, window.fetch answered 200 five times in a row while tauriFetch
+    // answered 429 for the same URL in the same run, and the block on the Rust
+    // client outlived a restart. The endpoint is CORS-open and already in the
+    // app's connect-src CSP, so the webview stack works on every platform.
+    vi.mocked(isTauriAppPlatform).mockReturnValue(true);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [[['你好', 'Hello']]],
+    });
+
+    const { googleProvider } = await import('@/services/translators/providers/google');
+    const result = await googleProvider.translate(['Hello'], 'en', 'zh-CN');
+
+    expect(result).toEqual(['你好']);
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(vi.mocked(tauriFetch)).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a rate-limit rather than echoing the source text back', async () => {
+    // A 429 means Google decided the traffic looks automated. Returning the
+    // untranslated line would render as a silently untranslated paragraph.
+    mockFetch.mockResolvedValue({ ok: false, status: 429 });
+
+    const { googleProvider } = await import('@/services/translators/providers/google');
+    await expect(googleProvider.translate(['Hello'], 'en', 'zh-CN')).rejects.toThrow(
+      'Translation failed with status 429',
+    );
+  });
+
   it('has correct provider metadata', async () => {
     const { googleProvider } = await import('@/services/translators/providers/google');
     expect(googleProvider.name).toBe('google');
@@ -149,6 +228,10 @@ describe('yandexProvider', () => {
   beforeEach(() => {
     mockTauriFetch.mockReset();
     mockFetch.mockReset();
+    // The simplecc mocks are module-level, so they survive vi.resetModules()
+    // and would carry call counts across tests.
+    vi.mocked(initSimpleCC).mockClear();
+    vi.mocked(runSimpleCC).mockClear();
     // The provider calls Yandex directly on Tauri and via the same-origin
     // proxy on web — default to the Tauri path in these tests
     vi.mocked(isTauriAppPlatform).mockReturnValue(true);
@@ -484,6 +567,32 @@ describe('yandexProvider', () => {
     expect(mockTauriFetch).not.toHaveBeenCalled();
   });
 
+  it('converts the reply to Traditional when the target is zh-Hant', async () => {
+    // Yandex only speaks `zh` (Simplified) -- `normalizeLang` collapses every
+    // zh variant onto it -- so a zh-TW reader silently got Simplified back.
+    // Convert the Simplified reply locally instead of mislabelling it.
+    mockYandexFlow(() => ({ code: 200, lang: 'en-zh', text: ['那只敏捷的狐狸跳过了狗。'] }));
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    const result = await yandexProvider.translate(['The quick fox.'], 'en', 'zh-TW');
+
+    expect(initSimpleCC).toHaveBeenCalled();
+    expect(vi.mocked(runSimpleCC).mock.calls[0]![1]).toBe('s2t');
+    expect(result).toEqual(['那隻敏捷的狐狸跳過了狗。']);
+    // The request itself still goes out as plain `zh`.
+    expect(String(translateCalls()[0]![0])).toContain('target_lang=zh');
+  });
+
+  it('leaves a Simplified target untouched', async () => {
+    mockYandexFlow(() => ({ code: 200, lang: 'en-zh', text: ['那只敏捷的狐狸跳过了狗。'] }));
+
+    const { yandexProvider } = await import('@/services/translators/providers/yandex');
+    const result = await yandexProvider.translate(['The quick fox.'], 'en', 'zh-CN');
+
+    expect(runSimpleCC).not.toHaveBeenCalled();
+    expect(result).toEqual(['那只敏捷的狐狸跳过了狗。']);
+  });
+
   it('limits concurrent chunk requests', async () => {
     let active = 0;
     let peak = 0;
@@ -548,6 +657,83 @@ describe('parseBingAuthParams', () => {
     expect(() => parseBingAuthParams('<html>nothing here</html>', 0)).toThrow(
       'could not parse the translator page',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DeepL Provider
+// ---------------------------------------------------------------------------
+describe('deeplProvider', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.mocked(isTauriAppPlatform).mockReturnValue(false);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const ok = (text: string) => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ translations: [{ text }] }),
+  });
+
+  const sentBody = () => JSON.parse(String(mockFetch.mock.calls[0]![1].body));
+
+  it('sends the script subtag in canonical case, not upper-cased', async () => {
+    // The service 500s on `ZH-HANT` and on `ZH-TW`, but answers 200 with real
+    // Traditional Chinese for `ZH-Hant` — verified against the live endpoint.
+    // `normalizeToShortLang` already yields the canonical `zh-Hant`, so only the
+    // primary subtag may be upper-cased; upper-casing the whole code is what
+    // turned every zh-TW/zh-HK/zh-MO translation into a hard failure.
+    mockFetch.mockResolvedValue(ok('那隻敏捷的棕色狐狸。'));
+
+    const { deeplProvider } = await import('@/services/translators/providers/deepl');
+    await deeplProvider.translate(['The quick brown fox.'], 'en', 'zh-TW', 'user-token');
+
+    expect(sentBody().target_lang).toBe('ZH-Hant');
+  });
+
+  it('keeps the simplified target working', async () => {
+    mockFetch.mockResolvedValue(ok('那只敏捷的棕色狐狸。'));
+
+    const { deeplProvider } = await import('@/services/translators/providers/deepl');
+    await deeplProvider.translate(['The quick brown fox.'], 'en', 'zh-CN', 'user-token');
+
+    expect(sentBody().target_lang).toBe('ZH-Hans');
+  });
+
+  it('applies the same casing to a Chinese source language', async () => {
+    // `source_lang: ZH-HANT` 500s just like the target does.
+    mockFetch.mockResolvedValue(ok('The quick brown fox.'));
+
+    const { deeplProvider } = await import('@/services/translators/providers/deepl');
+    await deeplProvider.translate(['那隻敏捷的棕色狐狸。'], 'zh-TW', 'en', 'user-token');
+
+    expect(sentBody().source_lang).toBe('ZH-Hant');
+    expect(sentBody().target_lang).toBe('EN');
+  });
+
+  it('still upper-cases languages that have no script subtag', async () => {
+    mockFetch.mockResolvedValue(ok('Der schnelle braune Fuchs.'));
+
+    const { deeplProvider } = await import('@/services/translators/providers/deepl');
+    await deeplProvider.translate(['The quick brown fox.'], 'en', 'de', 'user-token');
+
+    const body = sentBody();
+    expect(body.source_lang).toBe('EN');
+    expect(body.target_lang).toBe('DE');
+  });
+
+  it('omits source_lang when the source is AUTO', async () => {
+    mockFetch.mockResolvedValue(ok('那只敏捷的棕色狐狸。'));
+
+    const { deeplProvider } = await import('@/services/translators/providers/deepl');
+    await deeplProvider.translate(['The quick brown fox.'], 'AUTO', 'zh-CN', 'user-token');
+
+    expect(sentBody()).not.toHaveProperty('source_lang');
   });
 });
 
@@ -706,6 +892,42 @@ describe('azureProvider', () => {
     const translateCalls = mockFetch.mock.calls.filter((call) =>
       String(call[0]).includes('endpoint=translate'),
     );
+    expect(translateCalls).toHaveLength(24);
+  });
+
+  it('fans out wider than the proxy cap on Tauri, where no proxy is in the path', async () => {
+    // The cap of 3 exists to stay inside the web proxy's per-user budget. On
+    // Tauri the requests go straight to bing.com with no proxy in between, and
+    // bing itself does not rate-limit this fan-out (verified against the live
+    // endpoint: 12 concurrent translate calls all answered 200). Holding the
+    // native path at 3 just serialises a page of paragraphs behind an endpoint
+    // that takes seconds per request.
+    vi.mocked(isTauriAppPlatform).mockReturnValue(true);
+    let inFlight = 0;
+    let peakInFlight = 0;
+    vi.mocked(tauriFetch).mockImplementation(async (url: string | Request | URL) => {
+      if (String(url).includes('/translator')) {
+        return { ok: true, status: 200, text: async () => BING_PAGE } as Response;
+      }
+      inFlight++;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight--;
+      return translationBody('translated') as unknown as Response;
+    });
+
+    const { azureProvider } = await import('@/services/translators/providers/azure');
+    const lines = Array.from({ length: 24 }, (_, index) => `line ${index}`);
+    const result = await azureProvider.translate(lines, 'en', 'fr');
+
+    expect(result).toHaveLength(24);
+    expect(result.every((line) => line === 'translated')).toBe(true);
+    expect(peakInFlight).toBeGreaterThan(3);
+    expect(peakInFlight).toBeLessThanOrEqual(10);
+    // Throttling must still not drop work.
+    const translateCalls = vi
+      .mocked(tauriFetch)
+      .mock.calls.filter((call) => String(call[0]).includes('ttranslatev3'));
     expect(translateCalls).toHaveLength(24);
   });
 

--- a/apps/readest-app/src/app/reader/components/annotator/TranslatorPopup.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/TranslatorPopup.tsx
@@ -149,7 +149,15 @@ const TranslatorPopup: React.FC<TranslatorPopupProps> = ({
         minHeight={popupHeight}
         maxHeight={720}
         position={position}
-        className='grid h-full select-text grid-rows-[1fr,auto,1fr,auto]'
+        // Tracks are space-separated (`_` in a Tailwind arbitrary value).
+        // Commas here emitted `grid-template-rows:1fr,auto,1fr,auto`, which the
+        // browser discards, leaving four implicit auto rows that sized to their
+        // content and pushed the translated pane and the provider footer past
+        // the popup's own max height with nothing scrollable to reach them.
+        // `minmax(0,...)` rather than a bare `1fr`: a bare fr floors at
+        // min-content, so the rows would refuse to shrink inside the capped
+        // popup and overflow it again.
+        className='grid h-full select-text grid-rows-[minmax(0,1fr)_auto_minmax(0,1fr)_auto]'
         onDismiss={onDismiss}
       >
         <div className='overflow-y-auto p-4 font-sans'>

--- a/apps/readest-app/src/components/Select.tsx
+++ b/apps/readest-app/src/components/Select.tsx
@@ -37,7 +37,13 @@ export default function Select({
         // below cannot, because `appearance: base-select` paints the value into
         // a UA-generated <selectedcontent> in the shadow root that author CSS
         // never reaches. `max-w-[60%]` with `truncate` still caps a long value.
-        'select bg-transparent h-8 min-h-8 w-auto max-w-[60%] truncate rounded-md border-none text-sm',
+        // `field-sizing:content` covers the engines that lack `base-select` and
+        // fall back to native select rendering, where `w-auto` means the widest
+        // *option* rather than the selected one -- and the popup feeds this the
+        // entire language list, so a one-character value measured 240px instead
+        // of 49px. Where `base-select` applies the value already drives the
+        // width and this changes nothing.
+        'select bg-transparent h-8 min-h-8 w-auto max-w-[60%] [field-sizing:content] truncate rounded-md border-none text-sm',
         'focus:outline-hidden focus:ring-0 focus-visible:outline-hidden',
         className,
       )}

--- a/apps/readest-app/src/components/Select.tsx
+++ b/apps/readest-app/src/components/Select.tsx
@@ -30,7 +30,14 @@ export default function Select({
       className={clsx(
         // Transparent so the select takes the color of whatever surface it sits
         // on (these all live in popups) instead of tinting a block onto it.
-        'select bg-transparent h-8 min-h-8 max-w-[60%] truncate rounded-md border-none text-sm',
+        // `w-auto` overrides daisyUI 5's `width: clamp(3rem,20rem,100%)`, which
+        // stretches the box to its max width whatever the value is and strands
+        // the label at the far start of it. Sizing to the value is what puts the
+        // label against the chevron at the end of the row — `text-align-last`
+        // below cannot, because `appearance: base-select` paints the value into
+        // a UA-generated <selectedcontent> in the shadow root that author CSS
+        // never reaches. `max-w-[60%]` with `truncate` still caps a long value.
+        'select bg-transparent h-8 min-h-8 w-auto max-w-[60%] truncate rounded-md border-none text-sm',
         'focus:outline-hidden focus:ring-0 focus-visible:outline-hidden',
         className,
       )}

--- a/apps/readest-app/src/components/settings/primitives/SettingsSelect.tsx
+++ b/apps/readest-app/src/components/settings/primitives/SettingsSelect.tsx
@@ -34,7 +34,13 @@ const SettingsSelect: React.FC<SettingsSelectProps> = ({
   ariaLabel,
 }) => {
   return (
-    <div className='flex max-w-[60%] items-center rounded-md focus-within:bg-transparent hover:bg-transparent'>
+    // The picker's implicit anchor is the <select>, which stops short of the
+    // MdArrowDropDown below -- the chevron the user reads as the edge of the
+    // control -- so the popup lines up ~20px inside it. Anchor to the wrapper
+    // instead, and scope the name so a page full of these rows resolves each
+    // picker to its own wrapper rather than to the last one in tree order.
+    // `position-anchor` is applied to `::picker(select)` in globals.css.
+    <div className='[anchor-name:--settings-select] [anchor-scope:--settings-select] flex max-w-[60%] items-center rounded-md focus-within:bg-transparent hover:bg-transparent'>
       {/* No `appearance-none!` here: daisyUI's `.select` already hides the
           native arrow and, where supported, opts into `appearance: base-select`
           so the option popup is painted by the page in the app theme instead

--- a/apps/readest-app/src/services/translators/providers/azure.ts
+++ b/apps/readest-app/src/services/translators/providers/azure.ts
@@ -37,10 +37,18 @@ import {
  *   translate POST has to go to that host too (see `translateUrl`).
  */
 const PROXY_URL = '/api/azure-translate';
-// Must not exceed the per-user concurrency the proxy allows, or the surplus
-// requests come straight back as 429. Bing translates one text per request, so
-// a page of paragraphs would otherwise fan out unbounded.
-const MAX_CONCURRENT_REQUESTS = 3;
+// Bing translates one text per request, so a page of paragraphs would fan out
+// unbounded without a cap. How wide the cap can be depends on what is in the
+// path: the web proxy budgets concurrency per user and sends the surplus back
+// as 429, while on Tauri the requests go straight to bing.com with no proxy in
+// between. Bing itself does not rate-limit this fan-out (verified against the
+// live endpoint: 12 concurrent translate calls all answered 200), and the
+// endpoint takes seconds per request, so holding the native path at the proxy's
+// budget just serialises a page behind a slow upstream.
+const PROXY_MAX_CONCURRENT_REQUESTS = 3;
+const DIRECT_MAX_CONCURRENT_REQUESTS = 10;
+const maxConcurrentRequests = () =>
+  isTauriAppPlatform() ? DIRECT_MAX_CONCURRENT_REQUESTS : PROXY_MAX_CONCURRENT_REQUESTS;
 // Bing answers `statusCode: 400` above exactly 1000 UTF-16 code units — the
 // cap counts code units, not bytes, so CJK and emoji measure the same as ASCII
 // (verified empirically: 1000 passes, 1001 fails, for all three).
@@ -79,12 +87,12 @@ const requestQueue: Array<() => void> = [];
 
 /**
  * Caps outbound requests across every concurrent `translate()` call — the
- * counter is module-level because the proxy budgets per user, not per call.
+ * counter is module-level because the budget is per user, not per call.
  * A task holds at most one slot at a time (auth is awaited before a translate
  * slot is taken), so this cannot deadlock.
  */
 async function withRequestLimit<T>(task: () => Promise<T>): Promise<T> {
-  if (activeRequests < MAX_CONCURRENT_REQUESTS) {
+  if (activeRequests < maxConcurrentRequests()) {
     activeRequests++;
   } else {
     await new Promise<void>((resolve) => requestQueue.push(resolve));

--- a/apps/readest-app/src/services/translators/providers/deepl.ts
+++ b/apps/readest-app/src/services/translators/providers/deepl.ts
@@ -8,6 +8,22 @@ import { saveDailyUsage } from '../utils';
 
 const DEEPL_API_ENDPOINT = getAPIBaseUrl() + '/deepl/translate';
 
+/**
+ * DeepL language codes are upper-case, but the service answers 500 when the
+ * *script* subtag is upper-cased too. Measured against the live endpoint:
+ * `ZH-HANT` and `ZH-TW` both fail, while `ZH-Hant` answers 200 with real
+ * Traditional Chinese — and the same holds for `source_lang`. Upper-casing the
+ * whole code therefore turned every zh-TW/zh-HK/zh-MO translation into a hard
+ * failure. `normalizeToShortLang` already returns the canonical `zh-Hans` /
+ * `zh-Hant`, so only the primary subtag is upper-cased and the script subtag
+ * keeps the casing it came with. Languages without a script subtag ('en' -> 'EN',
+ * and 'AUTO' -> 'AUTO') are unaffected.
+ */
+const toDeepLLang = (lang: string): string => {
+  const [primary, ...rest] = normalizeToShortLang(lang).split('-');
+  return [primary!.toUpperCase(), ...rest].join('-');
+};
+
 export const deeplProvider: TranslationProvider = {
   name: 'deepl',
   label: _('DeepL'),
@@ -46,11 +62,11 @@ export const deeplProvider: TranslationProvider = {
       throw new Error('Authentication token is required for DeepL translation');
     }
 
-    const normalizedSourceLang = normalizeToShortLang(sourceLang).toUpperCase();
+    const normalizedSourceLang = toDeepLLang(sourceLang);
     const body = JSON.stringify({
       text: text,
       ...(normalizedSourceLang !== 'AUTO' ? { source_lang: normalizedSourceLang } : {}),
-      target_lang: normalizeToShortLang(targetLang).toUpperCase(),
+      target_lang: toDeepLLang(targetLang),
       use_cache: useCache,
     });
 

--- a/apps/readest-app/src/services/translators/providers/google.ts
+++ b/apps/readest-app/src/services/translators/providers/google.ts
@@ -1,17 +1,72 @@
 import { stubTranslation as _ } from '@/utils/misc';
-import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
-import { isTauriAppPlatform } from '@/services/environment';
 import { normalizeToShortLang } from '@/utils/lang';
 import { TranslationProvider } from '../types';
+
+/**
+ * The unofficial endpoint behind the Google Translate widget. It needs no key,
+ * but Google decides per caller whether the traffic looks automated and answers
+ * HTTP 429 with "your computer or network may be sending automated queries"
+ * when it does. Two things keep us on the right side of that:
+ *
+ * - the request goes out through the webview's own network stack, never the
+ *   Tauri HTTP plugin. Google refuses the Rust client: measured on an Android
+ *   device, `window.fetch` answered 200 five times in a row while `tauriFetch`
+ *   answered 429 for the same URL in the same run, and the block on the Rust
+ *   client outlasted a restart. The endpoint sends permissive CORS headers so
+ *   the response is readable cross-origin, and `translate.googleapis.com` is
+ *   already in the app's `connect-src` CSP, so this works on every platform;
+ * - the fan-out is capped. Google translates one text per request, so a page of
+ *   paragraphs used to go out all at once, which is what earns the 429 in the
+ *   first place.
+ */
+const TRANSLATE_URL = 'https://translate.googleapis.com/translate_a/single';
+// Deliberately conservative: the endpoint is unofficial, its threshold is
+// undocumented, and being flagged costs minutes rather than one failed request.
+const MAX_CONCURRENT_REQUESTS = 4;
+
+let activeRequests = 0;
+const requestQueue: Array<() => void> = [];
+
+/**
+ * Caps outbound requests across every concurrent `translate()` call — the
+ * counter is module-level because Google judges the caller, not the call.
+ */
+async function withRequestLimit<T>(task: () => Promise<T>): Promise<T> {
+  if (activeRequests < MAX_CONCURRENT_REQUESTS) {
+    activeRequests++;
+  } else {
+    await new Promise<void>((resolve) => requestQueue.push(resolve));
+  }
+  try {
+    return await task();
+  } finally {
+    const next = requestQueue.shift();
+    // Hand the occupied slot straight over; leaving activeRequests untouched
+    // makes the transfer atomic with respect to fresh callers.
+    if (next) next();
+    else activeRequests--;
+  }
+}
+
+const buildUrl = (line: string, sourceLang: string, targetLang: string) => {
+  const url = new URL(TRANSLATE_URL);
+  url.searchParams.append('client', 'gtx');
+  // No `format=html` — adding it makes the endpoint strip inline tags instead
+  // of keeping them on the semantically matching words.
+  url.searchParams.append('dt', 't');
+  url.searchParams.append('sl', normalizeToShortLang(sourceLang).toLowerCase() || 'auto');
+  url.searchParams.append('tl', normalizeToShortLang(targetLang).toLowerCase());
+  url.searchParams.append('q', line);
+  return url.toString();
+};
 
 export const googleProvider: TranslationProvider = {
   name: 'google',
   label: _('Google Translate'),
-  // Verified against the live endpoint with the exact request built below:
+  // Verified against the live endpoint with the exact request built above:
   // inline tags come back on the semantically matching words even when the
   // sentence reorders, including nested tags, class and href attributes, and
-  // non-Latin targets. Note this needs no extra parameter — adding
-  // `format=html` makes the endpoint strip the tags instead of keeping them.
+  // non-Latin targets.
   preservesMarkup: true,
   translate: async (text: string[], sourceLang: string, targetLang: string): Promise<string[]> => {
     if (!text.length) return [];
@@ -24,15 +79,8 @@ export const googleProvider: TranslationProvider = {
         return;
       }
 
-      const url = new URL('https://translate.googleapis.com/translate_a/single');
-      url.searchParams.append('client', 'gtx');
-      url.searchParams.append('dt', 't');
-      url.searchParams.append('sl', normalizeToShortLang(sourceLang).toLowerCase() || 'auto');
-      url.searchParams.append('tl', normalizeToShortLang(targetLang).toLowerCase());
-      url.searchParams.append('q', line);
-
-      const fetch = isTauriAppPlatform() ? tauriFetch : window.fetch;
-      const response = await fetch(url.toString());
+      const fetch = window.fetch.bind(window);
+      const response = await withRequestLimit(() => fetch(buildUrl(line, sourceLang, targetLang)));
 
       if (!response.ok) {
         throw new Error(`Translation failed with status ${response.status}`);

--- a/apps/readest-app/src/services/translators/providers/yandex.ts
+++ b/apps/readest-app/src/services/translators/providers/yandex.ts
@@ -5,6 +5,7 @@ import { normalizeToShortLang } from '@/utils/lang';
 import { TranslationProvider } from '../types';
 import { splitTextIntoChunks } from '../utils';
 import { YANDEX_REQUEST_HEADERS, YANDEX_SESSION_URL, YANDEX_TRANSLATE_URL } from './yandexShared';
+import { initSimpleCC, runSimpleCC } from '@/utils/simplecc';
 
 /**
  * Direct client for the Yandex Translate web API — the same endpoints the
@@ -300,6 +301,16 @@ export const yandexProvider: TranslationProvider = {
     translatedChunks.forEach((chunks, index) => {
       results[index] = chunks.join('');
     });
+
+    // Yandex only speaks `zh`, and it is Simplified: `normalizeLang` above
+    // collapses every zh variant onto it, so a zh-TW/zh-HK/zh-MO reader was
+    // handed Simplified text labelled as their language. Convert the reply
+    // locally instead -- unlike DeepL, there is no target code to ask for.
+    if (normalizeToShortLang(targetLang) === 'zh-Hant') {
+      await initSimpleCC();
+      return results.map((text) => (text ? runSimpleCC(text, 's2t') : text));
+    }
+
     return results;
   },
 };

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -825,6 +825,30 @@
     background-color: var(--color-base-100);
     color: var(--color-base-content);
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+    /* daisyUI already end-aligns the picker to the select
+       (`position-area: self-start span-self-start`) and then pushes it back off
+       that edge by 16px: `margin-inline: 8px` plus `translate: -8px`, mirrored
+       as `translate: .5rem` under [dir=rtl]. Drop both so the popup lines up
+       with the value it belongs to. Only the end-side margin goes -- the
+       start-side one still keeps a wide picker off the opposite edge -- and
+       both properties are direction-agnostic, so RTL stays correct. */
+    margin-inline-end: 0;
+    translate: none;
+  }
+
+  /* SettingsSelect renders its chevron as a separate icon *outside* the
+     <select>, so the picker's implicit anchor stops ~20px short of the control's
+     visible trailing edge. It anchors to its wrapper instead (see
+     SettingsSelect); the wrapper scopes the name so each row resolves its own. */
+  :where(.settings-content)::picker(select) {
+    position-anchor: --settings-select;
+  }
+
+  /* Because that picker is painted in-page, CSS on <option> is live, and
+     daisyUI 5 ships `white-space: normal` on it, so a long entry
+     ("Português (Brasil)") wraps onto several lines in a narrow select. */
+  :where(.select) option {
+    white-space: nowrap;
   }
 
   /* v4 drew the select's focus ring at 20% base-content; v5 draws it solid and


### PR DESCRIPTION
Found while verifying en to zh translation on an Android device (Xiaomi 13). Every finding below was measured against the live services or on the device, not inferred.

## Translation providers

**DeepL 500'd on every Traditional Chinese target.** This was our bug, not the service's. `normalizeToShortLang('zh-TW')` already returns the canonical `zh-Hant`; the provider then upper-cased the whole code into `ZH-HANT`. Measured against the live endpoint:

| sent | result |
| --- | --- |
| `ZH-HANT`, `ZH-TW` | 500 |
| `ZH-Hant`, `zh-Hant` | 200, Traditional |
| `ZH-HANS`, `ZH-Hans`, `zh-Hans`, `ZH` | 200, Simplified |

The same applies to `source_lang`. Now only the primary subtag is upper-cased, so zh-TW/zh-HK/zh-MO send `ZH-Hant` and zh-CN sends `ZH-Hans`. All four locales verified live.

**Yandex silently returned Simplified for Traditional targets.** `normalizeLang` collapses every zh variant onto `zh`, so a zh-TW reader got Simplified text labelled as their language. Unlike DeepL there is no target code to ask for, so the reply is converted with simplecc (`s2t`).

**Google answered 429 for every request**, with its "your computer or network may be sending automated queries" page, and the block outlived a restart. The discriminator is the transport, not the network: same device, same URL, same moment, `window.fetch` answered 200 five times running while the Tauri HTTP plugin answered 429. The request now goes through the webview stack on every platform. No new config is needed: the endpoint sends permissive CORS headers, and `translate.googleapis.com` is already in the app's `connect-src` CSP. Google was also the only provider with no concurrency cap, so a page of paragraphs fanned out unbounded and earned the block in the first place.

**Azure was capped at the web proxy's budget even on native builds**, where no proxy is in the path and Bing takes 2-8s per request. Ten real paragraphs on device: **10.4s -> 3.6s**.

## Translator popup and select layout

`grid-rows-[1fr,auto,1fr,auto]` never worked. Tailwind emits arbitrary values verbatim, so it produced `grid-template-rows:1fr,auto,1fr,auto`; commas are not track separators, the browser discarded the declaration, and every row became an implicit auto track sized to content. On a phone the translated pane and the entire provider footer were pushed off screen with nothing scrollable to reach them. Measured: container 375.5px, rows summing to 481px, footer bottom at 971px against an 872px viewport.

Three daisyUI 5 select regressions surfaced alongside it:

- options carry `white-space: normal`, and since the picker is painted in page that is live, so long entries wrapped;
- the value stopped end-aligning, because `.select` now stretches to its max width and the value is painted into a UA-generated `selectedcontent` in the shadow root that no author rule reaches;
- the picker is end-aligned but then pushed 16px off that edge by a margin plus a translate.

`SettingsSelect` needed one more step: it renders its chevron outside the `<select>`, so the picker's implicit anchor stopped ~20px short of the control's visible edge. Anchoring to the wrapper moved the picker's right edge from 910px to 965px against a control edge of 968px.

## Testing

`pnpm test` 10272 passing, `pnpm test:browser` 394 passing, `pnpm lint` and `pnpm format:check` clean.

New coverage: the DeepL casing (target and source, plus guards that non-Chinese codes still upper-case and `AUTO` still omits `source_lang`), the Yandex Traditional conversion, the Google transport and fan-out cap, the Azure native cap, the popup grid, and the select and picker layout. Layout is asserted through resolved styles rather than class strings, since a mistyped arbitrary value still lands in the class attribute while emitting no CSS.

Device verification on the Xiaomi covers the Google popup and page translation, the Azure timings, the popup grid, and the picker alignment. The Yandex Traditional conversion is verified in two halves rather than end to end: the live reply is confirmed Simplified, and simplecc's `s2t` conversion is covered by the existing unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed translation popups so long text remains contained, with independently scrollable text areas and visible provider controls.
  * Improved translation reliability for Google, DeepL, Yandex, and Azure, including better request handling and Traditional Chinese output.
* **UI Improvements**
  * Select controls now size to their displayed values and align their popups correctly.
  * Long select options no longer wrap, and settings pickers open in the correct position for both left-to-right and right-to-left layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->