### PR TITLE
fix(android): avoid full PDF parsing during import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "cocoa",
  "discord-rich-presence",
  "dispatch2",
+ "flate2",
  "futures",
  "futures-util",
  "if-addrs",
@@ -27,6 +28,7 @@ dependencies = [
  "localsend",
  "log",
  "md-5",
+ "memmap2",
  "minisign-verify",
  "mobi",
  "objc",
@@ -35,6 +37,7 @@ dependencies = [
  "objc2-authentication-services",
  "objc2-foundation",
  "objc_id",
+ "pdf",
  "pem 4.0.0",
  "percent-encoding",
  "quick-xml 0.36.2",
@@ -99,6 +102,12 @@ name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "aead"
@@ -1745,6 +1754,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1770,26 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "datasize"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e65c07d59e45d77a8bda53458c24a828893a99ac6cdd9c84111e09176ab739a2"
+dependencies = [
+ "datasize_derive",
+]
+
+[[package]]
+name = "datasize_derive"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613e4ee15899913285b7612004bbd490abd605be7b11d35afada5902fb6b91d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "datasketches"
@@ -1827,6 +1862,15 @@ dependencies = [
  "once_cell",
  "system-configuration 0.5.1",
  "windows 0.48.0",
+]
+
+[[package]]
+name = "deflate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
+dependencies = [
+ "adler32",
 ]
 
 [[package]]
@@ -3829,10 +3873,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "istring"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875cc6fb9aecbc1a9bd736f2d18b12e0756b4c80c5e35e28262154abcb077a39"
+dependencies = [
+ "datasize",
+]
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3958,6 +4020,12 @@ dependencies = [
  "getrandom 0.4.3",
  "libc",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
@@ -4136,6 +4204,30 @@ checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "libflate"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4da9b700e758e57152a1fd1c52cbdc5727c1aa6d8743dc1acda917398f1d76c"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+ "no_std_io2",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
+dependencies = [
+ "hashbrown 0.16.1",
+ "no_std_io2",
+ "rle-decode-fast",
 ]
 
 [[package]]
@@ -4440,6 +4532,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "measure_time"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4735,6 +4833,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5516,6 +5623,44 @@ name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
+name = "pdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de084796ae1744b0ae6b2b1e9368ed87bd43043ca410363edb72155ea68245db"
+dependencies = [
+ "aes",
+ "bitflags 2.13.0",
+ "cbc",
+ "datasize",
+ "deflate",
+ "fax",
+ "indexmap 2.14.0",
+ "istring",
+ "itertools 0.13.0",
+ "jpeg-decoder",
+ "libflate",
+ "log",
+ "md5",
+ "once_cell",
+ "pdf_derive",
+ "sha2 0.10.9",
+ "snafu",
+ "stringprep",
+ "weezl",
+]
+
+[[package]]
+name = "pdf_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66198aa8cbc8fb36b61c32b50fc2ba11cf70cf177c7a36b15f9444a2fce0267"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "pem"
@@ -6694,6 +6839,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
 name = "roaring"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7618,6 +7769,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7783,6 +7955,17 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -9900,10 +10083,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"

--- a/apps/readest-app/src-tauri/Cargo.toml
+++ b/apps/readest-app/src-tauri/Cargo.toml
@@ -123,6 +123,13 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 # WebView). Pure-Rust crate, ships to every Tauri target.
 mobi = "0.8"
 
+# Import-only PDF metadata. `pdf` resolves the trailer/catalog/XMP from an
+# mmap-backed source, so importing does not allocate or transfer the complete
+# PDF. Page-one cover rendering stays in Android's native PdfRenderer.
+pdf = { version = "0.10", default-features = false }
+memmap2 = "0.9"
+flate2 = "1"
+
 # Crash/error reporting. `tauri-plugin-sentry` injects @sentry/browser into
 # every webview and routes browser + Rust panic events through one client.
 # `rustls` avoids the native-tls/OpenSSL system dependency so the transport

--- a/apps/readest-app/src-tauri/build.rs
+++ b/apps/readest-app/src-tauri/build.rs
@@ -41,6 +41,8 @@ fn main() {
             "parse_epub_full",
             "parse_mobi_metadata",
             "extract_mobi_cover_full",
+            "parse_pdf_metadata",
+            "render_pdf_cover",
             "auth_with_safari",
             "start_apple_sign_in",
             "set_traffic_lights",

--- a/apps/readest-app/src-tauri/capabilities/default.json
+++ b/apps/readest-app/src-tauri/capabilities/default.json
@@ -226,6 +226,8 @@
     "allow-parse-epub-full",
     "allow-parse-mobi-metadata",
     "allow-extract-mobi-cover-full",
+    "allow-parse-pdf-metadata",
+    "allow-render-pdf-cover",
     "allow-auth-with-safari",
     "allow-start-apple-sign-in",
     "allow-set-traffic-lights",

--- a/apps/readest-app/src-tauri/capabilities/webdriver-remote.json
+++ b/apps/readest-app/src-tauri/capabilities/webdriver-remote.json
@@ -23,6 +23,8 @@
     "allow-parse-epub-full",
     "allow-parse-mobi-metadata",
     "allow-extract-mobi-cover-full",
+    "allow-parse-pdf-metadata",
+    "allow-render-pdf-cover",
     "allow-auth-with-safari",
     "allow-start-apple-sign-in",
     "allow-set-traffic-lights",

--- a/apps/readest-app/src-tauri/permissions/autogenerated/parse_pdf_metadata.toml
+++ b/apps/readest-app/src-tauri/permissions/autogenerated/parse_pdf_metadata.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-parse-pdf-metadata"
+description = "Enables the parse_pdf_metadata command without any pre-configured scope."
+commands.allow = ["parse_pdf_metadata"]
+
+[[permission]]
+identifier = "deny-parse-pdf-metadata"
+description = "Denies the parse_pdf_metadata command without any pre-configured scope."
+commands.deny = ["parse_pdf_metadata"]

--- a/apps/readest-app/src-tauri/permissions/autogenerated/render_pdf_cover.toml
+++ b/apps/readest-app/src-tauri/permissions/autogenerated/render_pdf_cover.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-render-pdf-cover"
+description = "Enables the render_pdf_cover command without any pre-configured scope."
+commands.allow = ["render_pdf_cover"]
+
+[[permission]]
+identifier = "deny-render-pdf-cover"
+description = "Denies the render_pdf_cover command without any pre-configured scope."
+commands.deny = ["render_pdf_cover"]

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/android/src/main/java/NativeBridgePlugin.kt
@@ -24,6 +24,7 @@ import android.view.WindowInsetsController
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.Rect
+import android.graphics.pdf.PdfRenderer
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
@@ -31,6 +32,7 @@ import android.hardware.SensorManager
 import android.hardware.input.InputManager
 import android.os.Handler
 import android.os.Looper
+import android.os.ParcelFileDescriptor
 import android.util.Base64
 import android.view.PixelCopy
 import android.webkit.WebView
@@ -58,6 +60,7 @@ import app.tauri.plugin.Invoke
 import org.json.JSONArray
 import java.io.*
 import kotlin.math.abs
+import kotlin.math.roundToInt
 import kotlinx.coroutines.*
 
 @InvokeArg
@@ -70,6 +73,12 @@ class AuthRequestArgs {
 class CopyURIRequestArgs {
     var uri: String? = null
     var dst: String? = null
+}
+
+@InvokeArg
+class RenderPdfCoverArgs {
+    var filePath: String? = null
+    var maxLongEdge: Int = 512
 }
 
 @InvokeArg
@@ -588,6 +597,63 @@ class NativeBridgePlugin(private val activity: Activity): Plugin(activity) {
                 r
             }
             if (isActive) invoke.resolve(ret)
+        }
+    }
+
+    @Command
+    fun render_pdf_cover(invoke: Invoke) {
+        val args = invoke.parseArgs(RenderPdfCoverArgs::class.java)
+        pluginScope.launch {
+            try {
+                val result = withContext(Dispatchers.IO) {
+                    val filePath = args.filePath ?: throw IllegalArgumentException("filePath is required")
+                    val maxLongEdge = args.maxLongEdge.takeIf { it > 0 }?.coerceAtMost(512) ?: 512
+                    val descriptor = if (filePath.startsWith("content://")) {
+                        activity.contentResolver.openFileDescriptor(Uri.parse(filePath), "r")
+                            ?: throw IOException("Failed to open PDF content URI")
+                    } else {
+                        ParcelFileDescriptor.open(File(filePath), ParcelFileDescriptor.MODE_READ_ONLY)
+                    }
+                    descriptor.use { fd ->
+                        PdfRenderer(fd).use { renderer ->
+                            if (renderer.pageCount == 0) throw IOException("PDF has no pages")
+                            renderer.openPage(0).use { page ->
+                                val scale = minOf(
+                                    1f,
+                                    maxLongEdge.toFloat() / maxOf(page.width, page.height).toFloat(),
+                                )
+                                val width = maxOf(1, (page.width * scale).roundToInt())
+                                val height = maxOf(1, (page.height * scale).roundToInt())
+                                val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+                                try {
+                                    bitmap.eraseColor(Color.WHITE)
+                                    page.render(
+                                        bitmap,
+                                        null,
+                                        null,
+                                        PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY,
+                                    )
+                                    val bytes = ByteArrayOutputStream().use { output ->
+                                        if (!bitmap.compress(Bitmap.CompressFormat.JPEG, 85, output)) {
+                                            throw IOException("Failed to encode PDF cover")
+                                        }
+                                        output.toByteArray()
+                                    }
+                                    JSObject().apply {
+                                        put("coverBase64", Base64.encodeToString(bytes, Base64.NO_WRAP))
+                                        put("coverMime", "image/jpeg")
+                                    }
+                                } finally {
+                                    bitmap.recycle()
+                                }
+                            }
+                        }
+                    }
+                }
+                if (isActive) invoke.resolve(result)
+            } catch (e: Exception) {
+                if (isActive) invoke.reject(e.message ?: "PDF cover rendering failed")
+            }
         }
     }
 

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/build.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/build.rs
@@ -2,6 +2,7 @@ const COMMANDS: &[&str] = &[
     "auth_with_safari",
     "auth_with_custom_tab",
     "copy_uri_to_path",
+    "render_pdf_cover",
     "save_image_to_gallery",
     "use_background_audio",
     "install_package",

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/commands/render_pdf_cover.toml
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/commands/render_pdf_cover.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-render-pdf-cover"
+description = "Enables the render_pdf_cover command without any pre-configured scope."
+commands.allow = ["render_pdf_cover"]
+
+[[permission]]
+identifier = "deny-render-pdf-cover"
+description = "Denies the render_pdf_cover command without any pre-configured scope."
+commands.deny = ["render_pdf_cover"]

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/reference.md
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/autogenerated/reference.md
@@ -1084,6 +1084,32 @@ Denies the remove_listener command without any pre-configured scope.
 <tr>
 <td>
 
+`native-bridge:allow-render-pdf-cover`
+
+</td>
+<td>
+
+Enables the render_pdf_cover command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`native-bridge:deny-render-pdf-cover`
+
+</td>
+<td>
+
+Denies the render_pdf_cover command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `native-bridge:allow-request-permissions`
 
 </td>

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/schemas/schema.json
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/permissions/schemas/schema.json
@@ -763,6 +763,18 @@
           "markdownDescription": "Denies the remove_listener command without any pre-configured scope."
         },
         {
+          "description": "Enables the render_pdf_cover command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-render-pdf-cover",
+          "markdownDescription": "Enables the render_pdf_cover command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the render_pdf_cover command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-render-pdf-cover",
+          "markdownDescription": "Denies the render_pdf_cover command without any pre-configured scope."
+        },
+        {
           "description": "Enables the request-permissions command without any pre-configured scope.",
           "type": "string",
           "const": "allow-request-permissions",

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/commands.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/commands.rs
@@ -31,6 +31,14 @@ pub(crate) async fn copy_uri_to_path<R: Runtime>(
 }
 
 #[command]
+pub(crate) async fn render_pdf_cover<R: Runtime>(
+    app: AppHandle<R>,
+    payload: RenderPdfCoverRequest,
+) -> Result<RenderPdfCoverResponse> {
+    app.native_bridge().render_pdf_cover(payload)
+}
+
+#[command]
 pub(crate) async fn save_image_to_gallery<R: Runtime>(
     app: AppHandle<R>,
     payload: SaveImageToGalleryRequest,

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/desktop.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/desktop.rs
@@ -60,6 +60,13 @@ impl<R: Runtime> NativeBridge<R> {
         Err(crate::Error::UnsupportedPlatformError)
     }
 
+    pub fn render_pdf_cover(
+        &self,
+        _payload: RenderPdfCoverRequest,
+    ) -> crate::Result<RenderPdfCoverResponse> {
+        Err(crate::Error::UnsupportedPlatformError)
+    }
+
     pub fn save_image_to_gallery(
         &self,
         _payload: SaveImageToGalleryRequest,

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/lib.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/lib.rs
@@ -58,6 +58,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::auth_with_safari,
             commands::auth_with_custom_tab,
             commands::copy_uri_to_path,
+            commands::render_pdf_cover,
             commands::save_image_to_gallery,
             commands::use_background_audio,
             commands::install_package,

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/mobile.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/mobile.rs
@@ -46,6 +46,15 @@ impl<R: Runtime> NativeBridge<R> {
             .run_mobile_plugin("copy_uri_to_path", payload)
             .map_err(Into::into)
     }
+
+    pub fn render_pdf_cover(
+        &self,
+        payload: RenderPdfCoverRequest,
+    ) -> crate::Result<RenderPdfCoverResponse> {
+        self.0
+            .run_mobile_plugin("render_pdf_cover", payload)
+            .map_err(Into::into)
+    }
 }
 
 impl<R: Runtime> NativeBridge<R> {

--- a/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
+++ b/apps/readest-app/src-tauri/plugins/tauri-plugin-native-bridge/src/models.rs
@@ -33,6 +33,20 @@ pub struct CopyURIResponse {
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct RenderPdfCoverRequest {
+    pub file_path: String,
+    pub max_long_edge: u32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RenderPdfCoverResponse {
+    pub cover_base64: String,
+    pub cover_mime: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SaveImageToGalleryRequest {
     /// Absolute path of the source image file on disk.
     pub src_path: String,

--- a/apps/readest-app/src-tauri/src/lib.rs
+++ b/apps/readest-app/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ mod macos;
 mod mobi_parser;
 mod nightly_update;
 mod parser_common;
+mod pdf_parser;
 mod range_file;
 mod sentry_config;
 #[cfg(desktop)]
@@ -421,6 +422,8 @@ pub fn run() {
             epub_parser::parse_epub_full,
             mobi_parser::parse_mobi_metadata,
             mobi_parser::extract_mobi_cover_full,
+            pdf_parser::parse_pdf_metadata,
+            pdf_parser::render_pdf_cover,
             #[cfg(target_os = "macos")]
             macos::safari_auth::auth_with_safari,
             #[cfg(target_os = "macos")]

--- a/apps/readest-app/src-tauri/src/parser_common.rs
+++ b/apps/readest-app/src-tauri/src/parser_common.rs
@@ -111,10 +111,14 @@ pub fn maybe_resize_cover(bytes: Vec<u8>, hint_mime: &str) -> (Vec<u8>, String) 
 /// d41d8cd9... We must reproduce that behaviour bit-for-bit so existing
 /// on-disk hashes (`Books/<hash>/...`) keep matching.
 pub fn compute_partial_md5(path: &Path) -> std::io::Result<String> {
+    let mut file = File::open(path)?;
+    compute_partial_md5_file(&mut file)
+}
+
+pub fn compute_partial_md5_file(file: &mut File) -> std::io::Result<String> {
     const STEP: u32 = 1024;
     const CHUNK: u64 = 1024;
 
-    let mut file = File::open(path)?;
     let file_len = file.metadata()?.len();
 
     let mut hasher = Md5::new();

--- a/apps/readest-app/src-tauri/src/pdf_parser.rs
+++ b/apps/readest-app/src-tauri/src/pdf_parser.rs
@@ -1,0 +1,298 @@
+use crate::parser_common::compute_partial_md5_file;
+use flate2::read::{DeflateDecoder, ZlibDecoder};
+use memmap2::Mmap;
+use pdf::{
+    enc::StreamFilter,
+    file::FileOptions,
+    object::{ParseOptions, Resolve, Stream},
+    primitive::{PdfStream, PdfString},
+};
+use serde::Serialize;
+#[cfg(test)]
+use std::path::Path;
+use std::{
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+};
+use tauri::AppHandle;
+#[cfg(target_os = "android")]
+use tauri_plugin_fs::{FsExt, OpenOptions};
+use tauri_plugin_native_bridge::{NativeBridgeExt, RenderPdfCoverRequest, RenderPdfCoverResponse};
+
+const MAX_TRAILER_SEARCH_BYTES: u64 = 1024 * 1024;
+const MAX_INFO_STRING_BYTES: usize = 64 * 1024;
+const MAX_XMP_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PdfInfo {
+    pub title: Option<Vec<u8>>,
+    pub author: Option<Vec<u8>>,
+    pub subject: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ParsedPdfMetadata {
+    pub partial_md5: String,
+    pub info: PdfInfo,
+    pub xmp: Option<Vec<u8>>,
+}
+
+#[tauri::command]
+pub async fn parse_pdf_metadata(
+    app: AppHandle,
+    file_path: String,
+) -> Result<ParsedPdfMetadata, String> {
+    ensure_path_allowed(&app, &file_path)?;
+    let source = open_pdf_source(&app, &file_path)?;
+    tauri::async_runtime::spawn_blocking(move || parse_pdf_metadata_file(source))
+        .await
+        .map_err(|e| format!("PDF parser task failed: {e}"))?
+}
+
+#[tauri::command]
+pub async fn render_pdf_cover(
+    app: AppHandle,
+    payload: RenderPdfCoverRequest,
+) -> Result<RenderPdfCoverResponse, String> {
+    ensure_path_allowed(&app, &payload.file_path)?;
+    app.native_bridge()
+        .render_pdf_cover(payload)
+        .map_err(|e| e.to_string())
+}
+
+fn ensure_path_allowed(app: &AppHandle, file_path: &str) -> Result<(), String> {
+    #[cfg(feature = "webdriver")]
+    let _ = (app, file_path);
+
+    #[cfg(not(feature = "webdriver"))]
+    {
+        #[cfg(target_os = "android")]
+        if file_path.starts_with("content://") {
+            // ContentResolver enforces the picker/shared-intent URI grant when
+            // the descriptor is opened. It is not a filesystem path, so it
+            // cannot pass through fs_scope's Path-based validation.
+            return Ok(());
+        }
+        crate::transfer_file::ensure_path_allowed(app, file_path).map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
+}
+
+fn open_pdf_source(app: &AppHandle, file_path: &str) -> Result<File, String> {
+    #[cfg(not(target_os = "android"))]
+    let _ = app;
+
+    #[cfg(target_os = "android")]
+    if file_path.starts_with("content://") {
+        let mut options = OpenOptions::new();
+        options.read(true);
+        let uri = tauri::Url::parse(file_path)
+            .map_err(|e| format!("parse PDF content URI failed: {e}"))?;
+        return app
+            .fs()
+            .open(uri, options)
+            .map_err(|e| format!("open PDF content URI failed: {e}"));
+    }
+
+    File::open(file_path).map_err(|e| format!("open PDF failed: {e}"))
+}
+
+fn pdf_string_bytes(value: &Option<PdfString>) -> Option<Vec<u8>> {
+    value
+        .as_ref()
+        .map(PdfString::as_bytes)
+        .filter(|value| !value.is_empty() && value.len() <= MAX_INFO_STRING_BYTES)
+        .map(ToOwned::to_owned)
+}
+
+fn read_bounded(reader: impl Read) -> Option<Vec<u8>> {
+    let mut output = Vec::new();
+    reader
+        .take((MAX_XMP_BYTES + 1) as u64)
+        .read_to_end(&mut output)
+        .ok()?;
+    (output.len() <= MAX_XMP_BYTES).then_some(output)
+}
+
+fn decode_xmp(raw: &[u8], filters: &[StreamFilter]) -> Option<Vec<u8>> {
+    if raw.len() > MAX_XMP_BYTES {
+        return None;
+    }
+    match filters {
+        [] => Some(raw.to_vec()),
+        [StreamFilter::FlateDecode(params)] if params.predictor == 1 => {
+            read_bounded(ZlibDecoder::new(raw)).or_else(|| read_bounded(DeflateDecoder::new(raw)))
+        }
+        _ => None,
+    }
+}
+
+fn decode_xmp_stream(raw_stream: PdfStream, resolver: &impl Resolve) -> Option<Vec<u8>> {
+    let stream = Stream::<()>::from_stream(raw_stream.clone(), resolver).ok()?;
+    if stream.len() > MAX_XMP_BYTES {
+        return None;
+    }
+    let raw = raw_stream.raw_data(resolver).ok()?;
+    decode_xmp(&raw, stream.get_filters())
+}
+
+fn validate_trailer(source: &mut File) -> Result<(), String> {
+    let file_len = source
+        .metadata()
+        .map_err(|e| format!("read PDF metadata failed: {e}"))?
+        .len();
+    let start = file_len.saturating_sub(MAX_TRAILER_SEARCH_BYTES);
+    source
+        .seek(SeekFrom::Start(start))
+        .map_err(|e| format!("seek PDF trailer failed: {e}"))?;
+    let mut trailer = Vec::with_capacity((file_len - start) as usize);
+    source
+        .read_to_end(&mut trailer)
+        .map_err(|e| format!("read PDF trailer failed: {e}"))?;
+    if !trailer
+        .windows(b"startxref".len())
+        .any(|window| window == b"startxref")
+    {
+        return Err(
+            "parse PDF metadata failed: startxref is missing from the bounded trailer".into(),
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn parse_pdf_metadata_sync(file_path: &str) -> Result<ParsedPdfMetadata, String> {
+    let source = File::open(Path::new(file_path)).map_err(|e| format!("open PDF failed: {e}"))?;
+    parse_pdf_metadata_file(source)
+}
+
+fn parse_pdf_metadata_file(mut source: File) -> Result<ParsedPdfMetadata, String> {
+    validate_trailer(&mut source)?;
+
+    // Mapping exposes random-access slices to the parser without copying the
+    // complete file into a Vec. The OS pages in only the regions the trailer,
+    // catalog, Info dictionary, and XMP stream actually touch.
+    let mmap = unsafe { Mmap::map(&source) }.map_err(|e| format!("map PDF failed: {e}"))?;
+    let document = FileOptions::uncached()
+        .parse_options(ParseOptions::tolerant())
+        .load(mmap)
+        .map_err(|e| format!("parse PDF metadata failed: {e}"))?;
+
+    let info = document
+        .trailer
+        .info_dict
+        .as_ref()
+        .map(|info| PdfInfo {
+            title: pdf_string_bytes(&info.title),
+            author: pdf_string_bytes(&info.author),
+            subject: pdf_string_bytes(&info.subject),
+        })
+        .unwrap_or_default();
+
+    let xmp = document.get_root().metadata.and_then(|metadata_ref| {
+        let resolver = document.resolver();
+        let raw_stream = resolver
+            .resolve(metadata_ref.get_inner())
+            .ok()?
+            .into_stream(&resolver)
+            .ok()?;
+        decode_xmp_stream(raw_stream, &resolver)
+    });
+    let partial_md5 =
+        compute_partial_md5_file(&mut source).map_err(|e| format!("partial_md5 failed: {e}"))?;
+
+    Ok(ParsedPdfMetadata {
+        partial_md5,
+        info,
+        xmp,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::{write::ZlibEncoder, Compression};
+    use std::{
+        fs::{remove_file, OpenOptions},
+        io::Write,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    #[test]
+    fn extracts_info_and_xmp_without_loading_pdf_into_a_vec() {
+        let fixture = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../src/__tests__/fixtures/data/sample-metadata.pdf"
+        );
+        let parsed = parse_pdf_metadata_sync(fixture).unwrap();
+
+        assert_eq!(
+            parsed.info.title.as_deref(),
+            Some(b"PDF Metadata".as_slice())
+        );
+        assert_eq!(parsed.info.author.as_deref(), Some(b"Readest".as_slice()));
+        assert!(parsed.xmp.as_deref().is_some_and(|xmp| xmp
+            .windows(b"Metadata Series".len())
+            .any(|w| w == b"Metadata Series")));
+        assert!(!parsed.partial_md5.is_empty());
+    }
+
+    #[test]
+    fn bounds_decompressed_xmp() {
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::fast());
+        encoder.write_all(b"small XMP").unwrap();
+        let compressed = encoder.finish().unwrap();
+        assert_eq!(
+            decode_xmp(
+                &compressed,
+                &[StreamFilter::FlateDecode(Default::default())]
+            )
+            .as_deref(),
+            Some(b"small XMP".as_slice())
+        );
+
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::fast());
+        encoder.write_all(&vec![b'x'; MAX_XMP_BYTES + 1]).unwrap();
+        let compressed = encoder.finish().unwrap();
+        assert!(decode_xmp(
+            &compressed,
+            &[StreamFilter::FlateDecode(Default::default())]
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn rejects_oversized_raw_xmp_stream_before_decoding() {
+        let stream = Stream::from_compressed((), vec![b'x'; MAX_XMP_BYTES + 1], Vec::new());
+        let raw_stream = stream.to_pdf_stream(&mut pdf::object::NoUpdate).unwrap();
+        assert!(decode_xmp_stream(raw_stream, &pdf::object::NoResolve).is_none());
+    }
+
+    #[test]
+    fn rejects_missing_startxref_after_bounded_tail_read() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "readest-pdf-missing-startxref-{}-{unique}.pdf",
+            std::process::id()
+        ));
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .read(true)
+            .open(&path)
+            .unwrap();
+        file.write_all(b"%PDF-1.7\ninvalid trailer\n%%EOF").unwrap();
+        file.seek(SeekFrom::Start(0)).unwrap();
+
+        let error = validate_trailer(&mut file).unwrap_err();
+        remove_file(path).unwrap();
+
+        assert!(error.contains("startxref is missing"));
+    }
+}

--- a/apps/readest-app/src/__tests__/document/pdf-cfi.test.ts
+++ b/apps/readest-app/src/__tests__/document/pdf-cfi.test.ts
@@ -31,7 +31,7 @@ describe('PDF CFI resolution with real document', () => {
   };
 
   beforeAll(async () => {
-    await import('foliate-js/pdf.js');
+    await import('@pdfjs/pdf.min.mjs');
     const pdfjsLib = (globalThis as Record<string, unknown>)['pdfjsLib'] as {
       GlobalWorkerOptions: { workerSrc: string };
     };

--- a/apps/readest-app/src/__tests__/document/pdf-spread-seam.test.ts
+++ b/apps/readest-app/src/__tests__/document/pdf-spread-seam.test.ts
@@ -22,8 +22,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const PAGE_W = 612;
 const PAGE_H = 792;
 
-// Minimal stand-in for the vendored pdf.js build. foliate-js/pdf.js imports it
-// for the side effect of setting globalThis.pdfjsLib, then reads from that
+// Minimal stand-in for the vendored pdf.js build. foliate-js/pdf.js loads it
+// from makePDF() for the side effect of setting globalThis.pdfjsLib, then reads from that
 // global — so the mock installs a controllable fake there.
 vi.mock('@pdfjs/pdf.min.mjs', () => {
   class PDFDataRangeTransport {

--- a/apps/readest-app/src/__tests__/document/pdf-tts.test.ts
+++ b/apps/readest-app/src/__tests__/document/pdf-tts.test.ts
@@ -8,7 +8,7 @@ import { DocumentLoader } from '@/libs/document';
 import type { BookDoc } from '@/libs/document';
 
 // The @pdfjs alias in vitest.config.mts resolves to public/vendor/pdfjs,
-// mirroring how foliate-js/pdf.js does `import '@pdfjs/pdf.min.mjs'`.
+// mirroring the runtime that foliate-js/pdf.js loads from `makePDF()`.
 const vendorDir = join(process.cwd(), 'public/vendor');
 
 /** Strip all XML/SSML tags to get plain text content */
@@ -330,10 +330,10 @@ describe('PDF TTS', () => {
 
     beforeAll(async () => {
       // Override workerSrc to an absolute file path so the pdfjs fake-worker
-      // can import it inside jsdom (the module-level code in pdf.js sets it
+      // can import it inside jsdom (makePDF otherwise sets it
       // to a URL path that only works in a real browser).
-      // Import pdf.js first to trigger the @pdfjs side-effect that sets globalThis.pdfjsLib.
-      await import('foliate-js/pdf.js');
+      // Import PDF.js first so the test can point its worker at a local file.
+      await import('@pdfjs/pdf.min.mjs');
       const pdfjsLib = (globalThis as Record<string, unknown>)['pdfjsLib'] as {
         GlobalWorkerOptions: { workerSrc: string };
       };

--- a/apps/readest-app/src/__tests__/document/series-metadata.test.ts
+++ b/apps/readest-app/src/__tests__/document/series-metadata.test.ts
@@ -54,7 +54,7 @@ describe('Calibre series metadata', () => {
     let book: BookDoc;
 
     beforeAll(async () => {
-      await import('foliate-js/pdf.js');
+      await import('@pdfjs/pdf.min.mjs');
       const pdfjsLib = (globalThis as Record<string, unknown>)['pdfjsLib'] as {
         GlobalWorkerOptions: { workerSrc: string };
       };

--- a/apps/readest-app/src/__tests__/foliate-pdf-metadata.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-pdf-metadata.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { decodePDFString, parsePDFMetadata } from 'foliate-js/pdf-metadata.js';
+
+const bytes = (value: string): Uint8Array => new TextEncoder().encode(value);
+
+const XMP = `<?xpacket begin=""?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
+      <dc:title><rdf:Alt><rdf:li xml:lang="x-default">XMP Title</rdf:li></rdf:Alt></dc:title>
+      <dc:creator><rdf:Seq><rdf:li>Alice</rdf:li><rdf:li>Bob</rdf:li></rdf:Seq></dc:creator>
+      <dc:contributor><rdf:Bag><rdf:li>Editor One</rdf:li><rdf:li>Editor Two</rdf:li></rdf:Bag></dc:contributor>
+      <dc:description><rdf:Alt><rdf:li xml:lang="x-default">Description</rdf:li></rdf:Alt></dc:description>
+      <dc:language><rdf:Bag><rdf:li>en</rdf:li><rdf:li>fr</rdf:li></rdf:Bag></dc:language>
+      <dc:publisher><rdf:Bag><rdf:li>Readest</rdf:li></rdf:Bag></dc:publisher>
+      <dc:subject><rdf:Bag><rdf:li>Fiction</rdf:li><rdf:li>Adventure</rdf:li></rdf:Bag></dc:subject>
+      <dc:identifier>urn:isbn:123</dc:identifier>
+      <dc:source>Original edition</dc:source>
+      <dc:rights>Public domain</dc:rights>
+    </rdf:Description>
+    <rdf:Description
+      xmlns:calibre="http://calibre-ebook.com/xmp-namespace"
+      xmlns:calibreSI="http://calibre-ebook.com/xmp-namespace-series-index">
+      <calibre:series rdf:parseType="Resource">
+        <rdf:value>Metadata Series</rdf:value>
+        <calibreSI:series_index>2.00</calibreSI:series_index>
+      </calibre:series>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>`;
+
+describe('PDF metadata normalization', () => {
+  it('decodes every PDF string encoding handled by pdf.js', () => {
+    expect(decodePDFString(bytes('Plain ASCII'))).toBe('Plain ASCII');
+    expect(decodePDFString(Uint8Array.from([0xef, 0xbb, 0xbf, 0xe4, 0xbd, 0xa0]))).toBe('你');
+    expect(decodePDFString(Uint8Array.from([0xfe, 0xff, 0x4f, 0x60, 0x59, 0x7d]))).toBe('你好');
+    expect(decodePDFString(Uint8Array.from([0xff, 0xfe, 0x60, 0x4f, 0x7d, 0x59]))).toBe('你好');
+    expect(decodePDFString(Uint8Array.from([0x80]))).toBe('•');
+  });
+
+  it('maps raw XMP with the same value shapes as the full PDF reader', () => {
+    expect(
+      parsePDFMetadata({
+        info: {
+          title: bytes('Info Title'),
+          author: bytes('Info Author'),
+          subject: bytes('Info Subject'),
+        },
+        xmp: bytes(XMP),
+      }),
+    ).toEqual({
+      title: 'XMP Title',
+      author: ['Alice', 'Bob'],
+      contributor: 'Editor OneEditor Two',
+      description: 'Description',
+      language: 'enfr',
+      publisher: 'Readest',
+      subject: ['Fiction', 'Adventure'],
+      identifier: 'urn:isbn:123',
+      source: 'Original edition',
+      rights: 'Public domain',
+      belongsTo: { series: { name: 'Metadata Series', position: '2.00' } },
+    });
+  });
+
+  it('falls back to raw Info bytes when XMP is missing or malformed', () => {
+    const info = {
+      title: Uint8Array.from([0xfe, 0xff, 0x4f, 0x60, 0x59, 0x7d]),
+      author: bytes('Info Author'),
+      subject: bytes('Info Subject'),
+    };
+
+    expect(parsePDFMetadata({ info })).toMatchObject({
+      title: '你好',
+      author: 'Info Author',
+      description: 'Info Subject',
+    });
+    expect(parsePDFMetadata({ info, xmp: bytes('<not-valid') })).toMatchObject({
+      title: '你好',
+      author: 'Info Author',
+      description: 'Info Subject',
+    });
+  });
+});

--- a/apps/readest-app/src/__tests__/foliate-pdf-metadata.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-pdf-metadata.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from 'vitest';
-import { decodePDFString, parsePDFMetadata } from 'foliate-js/pdf-metadata.js';
+import { describe, expect, it, vi } from 'vitest';
+import { decodePDFString, parsePDFMetadata } from 'foliate-js/pdf.js';
+
+const { loadPdfJsRuntime } = vi.hoisted(() => ({ loadPdfJsRuntime: vi.fn() }));
+
+vi.mock('@pdfjs/pdf.min.mjs', () => {
+  loadPdfJsRuntime();
+  (globalThis as Record<string, unknown>)['pdfjsLib'] = { GlobalWorkerOptions: {} };
+  return {};
+});
 
 const bytes = (value: string): Uint8Array => new TextEncoder().encode(value);
 
@@ -30,6 +38,10 @@ const XMP = `<?xpacket begin=""?>
 </x:xmpmeta>`;
 
 describe('PDF metadata normalization', () => {
+  it('does not load the PDF.js runtime for metadata-only imports', () => {
+    expect(loadPdfJsRuntime).not.toHaveBeenCalled();
+  });
+
   it('decodes every PDF string encoding handled by pdf.js', () => {
     expect(decodePDFString(bytes('Plain ASCII'))).toBe('Plain ASCII');
     expect(decodePDFString(Uint8Array.from([0xef, 0xbb, 0xbf, 0xe4, 0xbd, 0xa0]))).toBe('你');

--- a/apps/readest-app/src/__tests__/foliate-pdf-page-labels.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-pdf-page-labels.test.ts
@@ -36,8 +36,8 @@ const SAMPLE_LABELS = [
 let getPageLabels: () => Promise<string[] | null>;
 let numPages = SAMPLE_LABELS.length;
 
-// Minimal stand-in for the vendored pdf.js build. foliate-js/pdf.js imports it
-// only for the side effect of setting globalThis.pdfjsLib, then reads from
+// Minimal stand-in for the vendored pdf.js build. foliate-js/pdf.js loads it
+// from makePDF() for the side effect of setting globalThis.pdfjsLib, then reads from
 // that global -- so the mock installs a controllable fake there.
 vi.mock('@pdfjs/pdf.min.mjs', () => {
   class PDFDataRangeTransport {

--- a/apps/readest-app/src/__tests__/foliate-pdf-range-concurrency.test.ts
+++ b/apps/readest-app/src/__tests__/foliate-pdf-range-concurrency.test.ts
@@ -27,8 +27,8 @@ let rangeTransport: {
   onDataRange: (b: number, c: ArrayBuffer) => void;
 };
 
-// Minimal stand-in for the vendored pdf.js build. foliate-js/pdf.js imports it
-// only for the side effect of setting globalThis.pdfjsLib, then reads from
+// Minimal stand-in for the vendored pdf.js build. foliate-js/pdf.js loads it
+// from makePDF() for the side effect of setting globalThis.pdfjsLib, then reads from
 // that global — so the mock installs a controllable fake there.
 vi.mock('@pdfjs/pdf.min.mjs', () => {
   class PDFDataRangeTransport {

--- a/apps/readest-app/src/__tests__/services/import-bookdoc-destroy.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-bookdoc-destroy.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Book } from '@/types/book';
 
 const mockOpen = vi.hoisted(() => vi.fn());
+const mockTryNativeParsePdf = vi.hoisted(() => vi.fn());
 const mockPartialMD5 = vi.hoisted(() => vi.fn());
 
 vi.mock('@/utils/md5', async () => {
@@ -18,6 +19,8 @@ vi.mock('@/libs/document', async () => {
   }
   return { ...actual, DocumentLoader: MockDocumentLoader };
 });
+
+vi.mock('@/utils/tauriPdfBridge', () => ({ tryNativeParsePdf: mockTryNativeParsePdf }));
 
 vi.mock('@/utils/txt', () => ({ TxtToEpubConverter: vi.fn() }));
 vi.mock('@/utils/svg', () => ({ svg2png: vi.fn() }));
@@ -135,6 +138,60 @@ describe('importBook BookDoc lifecycle', () => {
 
     expect(result).not.toBeNull();
     expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the native metadata and cover path for an Android PDF file path', async () => {
+    const bookDoc = setupMockBookDoc();
+    mockTryNativeParsePdf.mockResolvedValue({
+      partialMd5: 'native-pdf-hash',
+      bookDoc,
+    });
+    service.osPlatform = 'android';
+    service
+      .getFs()
+      .openFile.mockResolvedValue(
+        new File(['pdf content'], 'test.pdf', { type: 'application/pdf' }),
+      );
+
+    const result = await service.importBook('/sdcard/Books/test.pdf', []);
+
+    expect(result?.hash).toBe('native-pdf-hash');
+    expect(mockTryNativeParsePdf).toHaveBeenCalledWith(
+      '/sdcard/Books/test.pdf',
+      expect.any(File),
+      'android',
+    );
+    expect(mockOpen).not.toHaveBeenCalled();
+    expect(mockPartialMD5).not.toHaveBeenCalled();
+    expect(mockDestroy).toHaveBeenCalledOnce();
+  });
+
+  it('reuses the opened cache file when persisting an Android content URI', async () => {
+    const bookDoc = setupMockBookDoc();
+    mockTryNativeParsePdf.mockResolvedValue({
+      partialMd5: 'native-pdf-hash',
+      bookDoc,
+    });
+    service.osPlatform = 'android';
+    const openedFile = Object.assign(
+      new File(['pdf content'], 'test.pdf', { type: 'application/pdf' }),
+      {
+        getNativeLocation: () => ({
+          path: '/data/user/0/com.bilingify.readest/cache/import-test.pdf',
+        }),
+      },
+    );
+    const fs = service.getFs();
+    fs.openFile.mockResolvedValue(openedFile);
+
+    await service.importBook('content://com.example.documents/document/42', []);
+
+    expect(
+      fs.writeFile.mock.calls.some(
+        ([, baseDir, contents]) => baseDir === 'Books' && contents === openedFile,
+      ),
+    ).toBe(true);
+    expect(fs.copyFile).not.toHaveBeenCalled();
   });
 
   it('destroys the loaded BookDoc when the import fails after opening', async () => {

--- a/apps/readest-app/src/__tests__/services/native-app-service-share.test.ts
+++ b/apps/readest-app/src/__tests__/services/native-app-service-share.test.ts
@@ -6,6 +6,7 @@ const writeFileMock = vi.fn().mockResolvedValue(undefined);
 const mkdirMock = vi.fn().mockResolvedValue(undefined);
 const saveDialogMock = vi.fn().mockResolvedValue('/tmp/exported.md');
 const shareFileMock = vi.fn().mockResolvedValue(undefined);
+const copyURIToPathMock = vi.fn().mockResolvedValue({ success: true });
 
 vi.mock('@tauri-apps/plugin-os', () => ({
   type: () => osTypeMock(),
@@ -51,13 +52,17 @@ vi.mock('@choochmeque/tauri-plugin-sharekit-api', () => ({
 }));
 
 vi.mock('@/utils/bridge', () => ({
-  copyURIToPath: vi.fn().mockResolvedValue({ path: '' }),
+  copyURIToPath: (...args: unknown[]) => copyURIToPathMock(...args),
   getStorefrontRegionCode: vi.fn().mockResolvedValue({ regionCode: null }),
   hasAmbientLightSensor: vi.fn().mockResolvedValue({ available: false }),
 }));
 
 vi.mock('@/utils/file', () => ({
-  NativeFile: class {},
+  NativeFile: class {
+    async open() {
+      return this;
+    }
+  },
   RemoteFile: class {},
 }));
 
@@ -85,6 +90,23 @@ describe('NativeAppService.saveFile share gating', () => {
     mkdirMock.mockClear();
     saveDialogMock.mockClear();
     shareFileMock.mockClear();
+    copyURIToPathMock.mockClear();
+  });
+
+  test('uses a unique cache path for same-named content-provider files', async () => {
+    const service = await loadServiceWithOS('android');
+
+    await Promise.all([
+      service.openFile('content://com.example.documents/first/book.pdf', 'None'),
+      service.openFile('content://com.example.documents/second/book.pdf', 'None'),
+    ]);
+
+    const destinations = copyURIToPathMock.mock.calls.map(
+      ([request]) => (request as { dst: string }).dst,
+    );
+    expect(destinations).toHaveLength(2);
+    expect(new Set(destinations).size).toBe(2);
+    expect(destinations.every((destination) => destination.endsWith('-book.pdf'))).toBe(true);
   });
 
   test('uses native share on macOS when share=true', async () => {

--- a/apps/readest-app/src/__tests__/tauri/pdf-parser-parity.tauri.test.ts
+++ b/apps/readest-app/src/__tests__/tauri/pdf-parser-parity.tauri.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { parsePDFMetadata } from 'foliate-js/pdf-metadata.js';
+import { DocumentLoader, type BookMetadata } from '@/libs/document';
+import { partialMD5 } from '@/utils/md5';
+import { invoke } from './tauri-invoke';
+
+const CWD = process.env['CWD'] as string;
+const PDF_FIXTURES = ['sample-alice.pdf', 'sample-metadata.pdf', 'sample-paper.pdf'] as const;
+
+interface RustParsedPdfMetadata {
+  partialMd5: string;
+  info: {
+    title?: number[] | Uint8Array | null;
+    author?: number[] | Uint8Array | null;
+    subject?: number[] | Uint8Array | null;
+  };
+  xmp?: number[] | Uint8Array | null;
+}
+
+const diskPath = (name: string): string => `${CWD}/src/__tests__/fixtures/data/${name}`;
+const fixtureUrl = (name: string): string =>
+  new URL(`../fixtures/data/${name}`, import.meta.url).href;
+
+type PdfBookMetadata = BookMetadata & {
+  contributor?: unknown;
+  source?: string;
+  rights?: string;
+};
+
+const fields = (metadata: BookMetadata): unknown => {
+  const pdf = metadata as PdfBookMetadata;
+  return {
+    title: pdf.title,
+    author: pdf.author,
+    contributor: pdf.contributor,
+    description: pdf.description,
+    language: pdf.language,
+    publisher: pdf.publisher,
+    subject: pdf.subject,
+    identifier: pdf.identifier,
+    source: pdf.source,
+    rights: pdf.rights,
+    belongsTo: pdf.belongsTo,
+  };
+};
+
+describe('parse_pdf_metadata parity with the foliate-js PDF reader', () => {
+  for (const name of PDF_FIXTURES) {
+    it(`returns raw inputs that normalize identically: ${name}`, async () => {
+      const buffer = await (await fetch(fixtureUrl(name))).arrayBuffer();
+      const file = new File([buffer], name, { type: 'application/pdf' });
+      const rust = (await invoke('parse_pdf_metadata', {
+        filePath: diskPath(name),
+      })) as RustParsedPdfMetadata;
+
+      const loader = new DocumentLoader(file);
+      const js = await loader.open();
+      try {
+        expect(rust.partialMd5).toBe(await partialMD5(file));
+        expect(fields(parsePDFMetadata(rust))).toEqual(fields(js.book.metadata));
+      } finally {
+        await js.book.destroy?.();
+      }
+    });
+  }
+});

--- a/apps/readest-app/src/__tests__/tauri/pdf-parser-parity.tauri.test.ts
+++ b/apps/readest-app/src/__tests__/tauri/pdf-parser-parity.tauri.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parsePDFMetadata } from 'foliate-js/pdf-metadata.js';
+import { parsePDFMetadata } from 'foliate-js/pdf.js';
 import { DocumentLoader, type BookMetadata } from '@/libs/document';
 import { partialMD5 } from '@/utils/md5';
 import { invoke } from './tauri-invoke';

--- a/apps/readest-app/src/__tests__/utils/tauri-pdf-bridge.test.ts
+++ b/apps/readest-app/src/__tests__/utils/tauri-pdf-bridge.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const invokeMock = vi.hoisted(() => vi.fn());
+const bytes = (value: string): number[] => Array.from(new TextEncoder().encode(value));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
+vi.mock('@/services/environment', () => ({ isTauriAppPlatform: () => true }));
+
+import { tryNativeParsePdf } from '@/utils/tauriPdfBridge';
+
+const XMP = `<?xpacket begin=""?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description xmlns:dc="http://purl.org/dc/elements/1.1/">
+      <dc:title><rdf:Alt><rdf:li xml:lang="x-default">XMP Title</rdf:li></rdf:Alt></dc:title>
+      <dc:creator><rdf:Seq><rdf:li>Alice</rdf:li><rdf:li>Bob</rdf:li></rdf:Seq></dc:creator>
+      <dc:language><rdf:Bag><rdf:li>en</rdf:li><rdf:li>fr</rdf:li></rdf:Bag></dc:language>
+      <dc:publisher><rdf:Bag><rdf:li>Readest</rdf:li></rdf:Bag></dc:publisher>
+    </rdf:Description>
+    <rdf:Description
+      xmlns:calibre="http://calibre-ebook.com/xmp-namespace"
+      xmlns:calibreSI="http://calibre-ebook.com/xmp-namespace-series-index">
+      <calibre:series rdf:parseType="Resource">
+        <rdf:value>Native Series</rdf:value>
+        <calibreSI:series_index>2.00</calibreSI:series_index>
+      </calibre:series>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>`;
+
+describe('tryNativeParsePdf', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === 'parse_pdf_metadata') {
+        return {
+          partialMd5: 'native-hash',
+          info: {
+            title: bytes('Info Title'),
+            author: bytes('Info Author'),
+            subject: bytes('Info Subject'),
+          },
+          xmp: bytes(XMP),
+        };
+      }
+      if (command === 'render_pdf_cover') {
+        return {
+          coverBase64: btoa('jpeg-cover'),
+          coverMime: 'image/jpeg',
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+  });
+
+  it('gets metadata from Rust and the first-page cover from Android without a JS File read', async () => {
+    const openedFile = {
+      name: 'example.pdf',
+      getNativeLocation: () => ({ path: '/data/user/0/com.bilingify.readest/cache/example.pdf' }),
+    } as unknown as File;
+    const parsed = await tryNativeParsePdf(
+      'content://com.android.fileexplorer.documents/document/42',
+      openedFile,
+      'android',
+    );
+
+    expect(invokeMock).toHaveBeenNthCalledWith(1, 'parse_pdf_metadata', {
+      filePath: '/data/user/0/com.bilingify.readest/cache/example.pdf',
+    });
+    expect(invokeMock).toHaveBeenNthCalledWith(2, 'render_pdf_cover', {
+      payload: {
+        filePath: '/data/user/0/com.bilingify.readest/cache/example.pdf',
+        maxLongEdge: 512,
+      },
+    });
+    expect(parsed?.partialMd5).toBe('native-hash');
+    expect(parsed?.bookDoc.metadata).toMatchObject({
+      title: 'XMP Title',
+      author: ['Alice', 'Bob'],
+      language: 'enfr',
+      publisher: 'Readest',
+      description: 'Info Subject',
+      belongsTo: { series: { name: 'Native Series', position: '2.00' } },
+    });
+    const cover = await parsed?.bookDoc.getCover();
+    expect(cover?.type).toBe('image/jpeg');
+    expect(await cover?.text()).toBe('jpeg-cover');
+  });
+
+  it('does not enable the native PDF path outside Android', async () => {
+    expect(await tryNativeParsePdf('/Users/me/example.pdf', undefined, 'macos')).toBeNull();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('does not send remote URLs to native filesystem commands', async () => {
+    const remoteFile = new File(['pdf content'], 'remote.pdf', { type: 'application/pdf' });
+
+    expect(
+      await tryNativeParsePdf('https://example.com/remote.pdf', remoteFile, 'android'),
+    ).toBeNull();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('uses a directly opened Android content URI without falling back to pdf.js', async () => {
+    const contentUri =
+      'content://com.android.externalstorage.documents/document/primary%3ABooks%2Fdocument.pdf';
+    const contentFile = Object.assign(
+      new File(['pdf content'], 'document.pdf', { type: 'application/pdf' }),
+      { getNativeLocation: () => ({ path: contentUri }) },
+    );
+
+    await expect(tryNativeParsePdf(contentUri, contentFile, 'android')).resolves.not.toBeNull();
+    expect(invokeMock).toHaveBeenNthCalledWith(1, 'parse_pdf_metadata', {
+      filePath: contentUri,
+    });
+    expect(invokeMock).toHaveBeenNthCalledWith(2, 'render_pdf_cover', {
+      payload: { filePath: contentUri, maxLongEdge: 512 },
+    });
+  });
+
+  it('keeps the native path when metadata parsing fails but the cover succeeds', async () => {
+    invokeMock.mockRejectedValueOnce(new Error('unsupported PDF'));
+    const parsed = await tryNativeParsePdf('/sdcard/Books/broken.pdf', undefined, 'android');
+    expect(parsed?.partialMd5).toBeUndefined();
+    expect(await parsed?.bookDoc.getCover()).toBeInstanceOf(Blob);
+  });
+
+  it('rejects instead of falling back to pdf.js when both native readers fail', async () => {
+    invokeMock.mockRejectedValue(new Error('unsupported PDF'));
+    await expect(
+      tryNativeParsePdf('/sdcard/Books/broken.pdf', undefined, 'android'),
+    ).rejects.toThrow('Native PDF metadata and cover extraction failed');
+  });
+});

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -32,6 +32,7 @@ import { getAudiobookDirectory, isAudiobookFilePath } from '@/services/audiobook
 import { isAudiobook } from '@/utils/audiobook';
 import { tryNativeParseEpub } from '@/utils/tauriEpubBridge';
 import { tryNativeParseMobi } from '@/utils/tauriMobiBridge';
+import { tryNativeParsePdf } from '@/utils/tauriPdfBridge';
 import { isPseStreamFileName, openPseStreamBook, parsePseStreamFileName } from './opds/pseStream';
 import { DEFAULT_BOOK_SEARCH_CONFIG, DEFAULT_FIXED_LAYOUT_VIEW_SETTINGS } from './constants';
 import { isContentURI, isValidURL, makeSafeFilename } from '@/utils/misc';
@@ -478,7 +479,6 @@ export async function importBook(
     // When the Rust EPUB parser succeeds it gives us the partialMD5 for free,
     // so we can short-circuit the JS hashing pass below.
     let nativeHash: string | undefined;
-    let usedNativeParser = false;
 
     if (transient && typeof file !== 'string') {
       throw new Error('Transient import is only supported for file paths');
@@ -534,30 +534,36 @@ export async function importBook(
         // scan, nav/ncx inflate, or PDB record-table walk would be
         // pure waste here.
         //
-        // Both bridges are no-ops on web / non-eligible paths, so
-        // the cost when neither matches is just two cheap regex
+        // The bridges are no-ops on web / non-eligible paths, so
+        // the cost when none matches is just a few cheap regex
         // tests.
         let nativeBookDoc: BookDoc | undefined;
         let nativeFormat: BookFormat | undefined;
         if (typeof file === 'string' && !/\.txt$/i.test(filename)) {
-          const nativeEpub = await tryNativeParseEpub(file);
-          if (nativeEpub) {
-            nativeBookDoc = nativeEpub.bookDoc;
-            nativeFormat = 'EPUB' as BookFormat;
-            nativeHash = nativeEpub.partialMd5;
+          const nativePdf = await tryNativeParsePdf(file, fileobj, osPlatform);
+          if (nativePdf) {
+            nativeBookDoc = nativePdf.bookDoc;
+            nativeFormat = 'PDF' as BookFormat;
+            nativeHash = nativePdf.partialMd5;
           } else {
-            const nativeMobi = await tryNativeParseMobi(file, fileobj);
-            if (nativeMobi) {
-              nativeBookDoc = nativeMobi.bookDoc;
-              nativeFormat = nativeMobi.format;
-              nativeHash = nativeMobi.partialMd5;
+            const nativeEpub = await tryNativeParseEpub(file);
+            if (nativeEpub) {
+              nativeBookDoc = nativeEpub.bookDoc;
+              nativeFormat = 'EPUB' as BookFormat;
+              nativeHash = nativeEpub.partialMd5;
+            } else {
+              const nativeMobi = await tryNativeParseMobi(file, fileobj);
+              if (nativeMobi) {
+                nativeBookDoc = nativeMobi.bookDoc;
+                nativeFormat = nativeMobi.format;
+                nativeHash = nativeMobi.partialMd5;
+              }
             }
           }
         }
         if (nativeBookDoc && nativeFormat) {
           loadedBook = nativeBookDoc;
           format = nativeFormat;
-          usedNativeParser = true;
         } else {
           ({ book: loadedBook, format } = await new DocumentLoader(fileobj).open());
         }
@@ -574,11 +580,7 @@ export async function importBook(
       throw new Error(`Failed to open the book file: ${(error as Error).message || error}`);
     }
 
-    const hash = isPseStream
-      ? md5(file as string)
-      : usedNativeParser
-        ? nativeHash!
-        : await partialMD5(fileobj!);
+    const hash = isPseStream ? md5(file as string) : (nativeHash ?? (await partialMD5(fileobj!)));
 
     // PDF metadata is often generic boilerplate (e.g. every PowerPoint export
     // is titled "PowerPoint Presentation" by the same author), so metadata
@@ -702,7 +704,10 @@ export async function importBook(
       if (/\.txt$/i.test(filename)) {
         await fs.writeFile(bookFilename, 'Books', fileobj);
       } else if (typeof file === 'string' && isContentURI(file)) {
-        await fs.copyFile(file, 'None', bookFilename, 'Books');
+        // openFile has already materialized opaque providers into a seekable
+        // NativeFile. Reuse that path instead of streaming the provider URI a
+        // second time into Books.
+        await fs.writeFile(bookFilename, 'Books', fileobj);
       } else if (typeof file === 'string' && !isValidURL(file)) {
         try {
           // try to copy the file directly first in case of large files to avoid memory issues

--- a/apps/readest-app/src/services/nativeAppService.ts
+++ b/apps/readest-app/src/services/nativeAppService.ts
@@ -315,7 +315,7 @@ export const nativeFileSystem: FileSystem = {
         // or file:// URIs is security scoped resource in iOS (e.g. from Files app),
         // we cannot access the file directly — so we copy it to a temporary cache location.
         const prefix = await this.getPrefix('Cache');
-        const dst = await join(prefix, decodeURIComponent(fname));
+        const dst = await join(prefix, `${crypto.randomUUID()}-${decodeURIComponent(fname)}`);
         const res = await copyURIToPath({ uri: path, dst });
         if (!res.success) {
           console.error('Failed to open file:', res);

--- a/apps/readest-app/src/utils/tauriPdfBridge.ts
+++ b/apps/readest-app/src/utils/tauriPdfBridge.ts
@@ -1,0 +1,112 @@
+// Android PDF import bridge.
+//
+// Importing needs only catalog metadata and a first-page thumbnail. Running
+// foliate-js's full PDF reader for that work initializes pdf.js, its worker,
+// the page tree, and potentially every source range. This bridge keeps the
+// source file native: Rust reads the catalog through a memory map, while
+// Android renders page one from a seekable file descriptor.
+import { invoke } from '@tauri-apps/api/core';
+import { isTauriAppPlatform } from '@/services/environment';
+import type { BookDoc, BookMetadata } from '@/libs/document';
+import type { OsPlatform } from '@/types/system';
+
+const COVER_MAX_LONG_EDGE = 512;
+
+interface RustPdfInfo {
+  title?: number[] | Uint8Array | null;
+  author?: number[] | Uint8Array | null;
+  subject?: number[] | Uint8Array | null;
+}
+
+interface RustParsedPdfMetadata {
+  partialMd5: string;
+  info: RustPdfInfo;
+  xmp?: number[] | Uint8Array | null;
+}
+
+interface NativePdfCover {
+  coverBase64?: string | null;
+  coverMime?: string | null;
+}
+
+export interface NativeParsedPdf {
+  partialMd5?: string;
+  bookDoc: BookDoc;
+}
+
+interface NativeLocationFile extends File {
+  getNativeLocation?(): { path: string };
+}
+
+const coverFromBase64 = (cover?: NativePdfCover): Blob | null => {
+  if (!cover?.coverBase64 || !cover.coverMime) return null;
+  const binary = atob(cover.coverBase64);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new Blob([bytes], { type: cover.coverMime });
+};
+
+const buildBookDocStub = (metadata: BookMetadata, cover: Blob | null): BookDoc =>
+  ({
+    metadata,
+    rendition: {},
+    dir: 'ltr',
+    toc: [],
+    sections: [],
+    splitTOCHref: () => [null, null],
+    getCover: async () => cover,
+  }) as unknown as BookDoc;
+
+/**
+ * Open the Android import-only path. `null` means the path is ineligible, not
+ * that Android should fall back to pdf.js. Once eligible, partial native
+ * failures keep whatever metadata/cover succeeded; if both native readers
+ * reject the file, import fails instead of reading the whole PDF in JS.
+ */
+export const tryNativeParsePdf = async (
+  filePath: string | undefined,
+  file: File | undefined,
+  osPlatform: OsPlatform | undefined,
+): Promise<NativeParsedPdf | null> => {
+  if (!filePath || !isTauriAppPlatform() || osPlatform !== 'android') {
+    return null;
+  }
+
+  // Xiaomi's picker uses a file-explorer content URI. NativeAppService has
+  // already copied that URI to a cache file by the time this bridge runs, so
+  // use NativeFile's resolved path instead of handing the content URI to Rust
+  // or PdfRenderer. Folder imports already arrive as absolute paths.
+  const openedPath = (file as NativeLocationFile | undefined)?.getNativeLocation?.().path;
+  const nativePath =
+    openedPath?.startsWith('/') || openedPath?.startsWith('content://')
+      ? openedPath
+      : filePath.startsWith('/')
+        ? filePath
+        : undefined;
+  if (!nativePath || !/\.pdf$/i.test(file?.name || nativePath)) return null;
+
+  const [metadataResult, coverResult] = await Promise.allSettled([
+    invoke<RustParsedPdfMetadata>('parse_pdf_metadata', { filePath: nativePath }),
+    invoke<NativePdfCover>('render_pdf_cover', {
+      payload: { filePath: nativePath, maxLongEdge: COVER_MAX_LONG_EDGE },
+    }),
+  ]);
+  if (metadataResult.status === 'rejected' && coverResult.status === 'rejected') {
+    throw new Error('Native PDF metadata and cover extraction failed');
+  }
+
+  const rust = metadataResult.status === 'fulfilled' ? metadataResult.value : undefined;
+  const cover = coverResult.status === 'fulfilled' ? coverFromBase64(coverResult.value) : null;
+  const pdfMetadataModule = (await import('foliate-js/pdf-metadata.js')) as unknown as {
+    parsePDFMetadata: (input: {
+      info?: RustPdfInfo;
+      xmp?: number[] | Uint8Array | null;
+    }) => BookMetadata;
+  };
+  return {
+    partialMd5: rust?.partialMd5,
+    bookDoc: buildBookDocStub(
+      pdfMetadataModule.parsePDFMetadata({ info: rust?.info, xmp: rust?.xmp }),
+      cover,
+    ),
+  };
+};

--- a/apps/readest-app/src/utils/tauriPdfBridge.ts
+++ b/apps/readest-app/src/utils/tauriPdfBridge.ts
@@ -96,7 +96,7 @@ export const tryNativeParsePdf = async (
 
   const rust = metadataResult.status === 'fulfilled' ? metadataResult.value : undefined;
   const cover = coverResult.status === 'fulfilled' ? coverFromBase64(coverResult.value) : null;
-  const pdfMetadataModule = (await import('foliate-js/pdf-metadata.js')) as unknown as {
+  const pdfMetadataModule = (await import('foliate-js/pdf.js')) as unknown as {
     parsePDFMetadata: (input: {
       info?: RustPdfInfo;
       xmp?: number[] | Uint8Array | null;

--- a/apps/readest-app/vitest.tauri.config.mts
+++ b/apps/readest-app/vitest.tauri.config.mts
@@ -1,3 +1,4 @@
+import path from 'path';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 import { webdriverio } from '@vitest/browser-webdriverio';
@@ -12,6 +13,9 @@ export default defineConfig({
     'process.env': JSON.stringify(env),
   },
   resolve: {
+    alias: {
+      '@pdfjs': path.resolve(__dirname, 'public/vendor/pdfjs'),
+    },
     conditions: ['development'],
   },
   optimizeDeps: {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -72,7 +72,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   cargoRoot = "../..";
-  cargoHash = "sha256-a3KVOqYsO1LQF1D0Maxrq9MsLgjYQFgyU0oemn4Xkn0=";
+  cargoHash = "sha256-w0/+6dcDSx9oPgJp6WK2/fg+mHZXM5psT8Yfk8CG5J8=";
 
   buildAndTestSubdir = "src-tauri";
 


### PR DESCRIPTION
## Summary

- route eligible Android PDF imports through Rust for raw Info/XMP extraction and partial hashing
- parse metadata in one shared JavaScript normalizer used by both the native import path and the regular foliate/pdf.js reader
- render only page one with Android PdfRenderer as a bounded 512 px JPEG cover
- avoid constructing the full pdf.js reader or a whole-file JavaScript buffer during native Android imports
- support selected folder paths, direct SAF content descriptors, and opaque providers without duplicate provider reads

Depends on readest/foliate-js#85.

## I/O behavior

Rust uses an mmap-backed random-access PDF source. It preflights only a bounded trailer, resolves the catalog/Info/XMP objects, caps Info and XMP payloads, bounds XMP decompression, and computes the existing sparse partial hash. If both native metadata and cover extraction fail, import fails instead of falling back to a full pdf.js parse.

Opaque providers that cannot expose a seekable descriptor are streamed once into a uniquely named app-cache file by the existing open-file layer. That cached native file is reused when the imported book must be persisted, so the provider is not streamed twice. Selected directory files and directly seekable SAF files remain random-access.

## Metadata parity

Rust returns raw PDF Info and XMP bytes only. `foliate-js/pdf.js` is the single normalization implementation for title, authors, description, language, publisher, subjects, identifiers, rights, PDFDocEncoding/Unicode, and Calibre series metadata. Unit and Tauri integration tests compare the native path with the full pdf.js reader on real PDF fixtures.

## Xiaomi benchmark

Xiaomi 13 (`2211133C`), Android 16, 29.6 MB PDF:

| Parser | First run | Warm mean | Observed PSS delta |
| --- | ---: | ---: | ---: |
| Native Rust + PdfRenderer | 379.5 ms | 59.2 ms | no observed increase |
| Full JS/pdf.js | 1408.9 ms | 1200.3 ms | +35.2 MiB |

The native path was 3.71x faster on the first run and 20.28x faster warm. Both paths returned identical normalized metadata. A final rebuilt APK was installed on the device; a 31.3 MB PDF completed in 443.5 ms on the first run and 62.7 ms warm, and an intentionally oversized cover request still produced a 384x512 JPEG.

## Verification

- `pnpm test` — 10,309 passed, 16 skipped
- `pnpm lint`
- `pnpm format:check`
- `pnpm fmt:check`
- `pnpm clippy:check`
- `pnpm test:rust` — 125 passed
- Tauri integration suite — 117 passed, 1 skipped
- `npx --offline eslint pdf.js`
- production Next build
- Chromium browser test verifies lazy PDF.js runtime loading
- aarch64 Android release build and install on Xiaomi 13

Closes #5890

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Android PDF imports with native metadata extraction, cover image generation, and faster file identification.
  - Preserves PDF title, author, subject, series, and other supported metadata during import.
  - Supports PDFs opened from Android content-provider locations.

- **Bug Fixes**
  - Prevented concurrent imports of same-named files from overwriting each other.
  - Improved reliability when metadata or cover extraction partially fails.
  - Reuses cached content-provider files more efficiently during import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->