### PR TITLE
fix(ui): paint modal boxes that sit outside an open daisyUI modal

### DIFF
--- a/apps/readest-app/src/__tests__/styles/modal-box-standalone.browser.test.ts
+++ b/apps/readest-app/src/__tests__/styles/modal-box-standalone.browser.test.ts
@@ -1,0 +1,68 @@
+/**
+ * `.modal-box` must paint when it is used as a standalone box chassis.
+ *
+ * daisyUI 5 ships `.modal-box { opacity: 0; scale: .95 }` and only un-hides it
+ * from `.modal:is(.modal-open, [open], :popover-open, :target) > .modal-box`.
+ * daisyUI 4 kept the opacity on `.modal` itself, so the app's hand-rolled
+ * overlays (transfer queue, grouping modal, annotation-import spinner) could
+ * borrow `.modal-box` for its background/radius/shadow without an open
+ * `.modal` ancestor. After the v5 migration those overlays laid out but never
+ * painted: the backdrop dimmed and the panel was invisible (#5915 follow-up,
+ * "Cloud File Transfers window cannot be opened").
+ *
+ * Needs the real stylesheet and a real cascade, so it runs in the browser.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+await import('@/styles/globals.css');
+
+const mount = (html: string) => {
+  const host = document.createElement('div');
+  host.setAttribute('data-testid', 'host');
+  host.innerHTML = html;
+  document.body.appendChild(host);
+  return host;
+};
+
+const boxStyle = () => {
+  const box = document.querySelector('.modal-box') as HTMLElement;
+  const style = getComputedStyle(box);
+  return { opacity: Number(style.opacity), scale: style.scale };
+};
+
+afterEach(() => {
+  document.querySelectorAll('[data-testid="host"]').forEach((el) => el.remove());
+});
+
+describe('.modal-box outside an open .modal', () => {
+  it('paints when it has no .modal ancestor', () => {
+    mount(`<div class='modal-box'>body</div>`);
+    const { opacity, scale } = boxStyle();
+    expect(opacity).toBe(1);
+    expect(scale === 'none' || scale === '1').toBe(true);
+  });
+
+  it('paints in the transfer queue chassis', () => {
+    // Mirrors TransferQueuePanel: own fixed overlay + own backdrop, no .modal.
+    mount(`
+      <div class='fixed inset-0 z-50 flex items-center justify-center'>
+        <div class='absolute inset-0 bg-black/50'></div>
+        <div class='modal-box bg-base-100 relative flex max-h-[85%] min-h-[65%] w-[95%] flex-col rounded-2xl p-0 shadow-xl'>
+          queue
+        </div>
+      </div>
+    `);
+    expect(boxStyle().opacity).toBe(1);
+  });
+
+  it('still hides inside a closed .modal so the close transition survives', () => {
+    mount(`<dialog class='modal'><div class='modal-box'>body</div></dialog>`);
+    expect(boxStyle().opacity).toBe(0);
+  });
+
+  it('still paints inside an open .modal', () => {
+    mount(`<div class='modal modal-open'><div class='modal-box'>body</div></div>`);
+    expect(boxStyle().opacity).toBe(1);
+  });
+});

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -278,6 +278,20 @@
     scrollbar-gutter: unset !important;
   }
 
+  /* daisyUI 5 moved the enter animation onto `.modal-box` itself
+     (`opacity: 0; scale: .95`) and only un-hides it from
+     `.modal:is(.modal-open, [open], :popover-open, :target) > .modal-box`. In
+     daisyUI 4 that state lived on `.modal`, so the app also uses `.modal-box`
+     as a standalone box chassis (background, radius, shadow, eink border) under
+     its own hand-rolled overlays. Those boxes have no `.modal` ancestor to
+     un-hide them, so after the v5 migration they laid out but never painted.
+     Restore the v4 resting state for that case only; a box inside a `.modal`
+     still animates, including the close transition Dialog.tsx depends on. */
+  :where(.modal-box):not(:where(.modal *)) {
+    opacity: 1;
+    scale: 1;
+  }
+
   html[data-page='default'] {
     background: var(--color-base-100);
   }


### PR DESCRIPTION
## Problem

The **Cloud File Transfers** window could not be opened. Picking it from the library account menu dimmed the screen and showed nothing.

## Root cause

daisyUI 4 kept the modal enter animation on `.modal`. daisyUI 5 moved it onto the child:

```css
.modal-box { opacity: 0; scale: .95 }
.modal:is(.modal-open,[open],:popover-open,:target) > .modal-box { opacity: 1; scale: 1 }
```

The app also uses `.modal-box` as a standalone **box chassis** — `base-100` background, radius, shadow, and the `[data-eink='true'] .modal-box` border — underneath its own hand-rolled `fixed inset-0` overlays. Those boxes have no `.modal` ancestor to un-hide them, so since the v5 migration (#5884) they laid out, swallowed clicks, and never painted. The backdrop was the only thing left on screen.

Three call sites were dark:

| File | Surface |
| --- | --- |
| `src/app/library/components/TransferQueuePanel.tsx:256` | Cloud File Transfers |
| `src/app/library/components/GroupingModal.tsx:257` | Group Books sheet |
| `src/app/reader/components/annotator/Annotator.tsx:2286` | "importing annotations" spinner |

## Fix

One rule in `globals.css`, inside `@layer utilities`:

```css
:where(.modal-box):not(:where(.modal *)) { opacity: 1; scale: 1; }
```

Restructuring each site's DOM instead would drag in `.modal`'s own `z-index: 999`, grid placement and second backdrop, and would have to be repeated for every future chassis usage. Restoring the daisyUI 4 resting state for exactly the standalone case covers all three, plus anything added later.

Two details are load-bearing:

- `:where()` keeps the selector at specificity 0 so Tailwind utilities still win. The rule sits *unlayered* inside `@layer utilities` while daisyUI ships in the nested sublayer `daisyui.l1.l2.l3` — unlayered rules in a layer beat that layer's sublayers regardless of specificity.
- `:not(:where(.modal *))` keeps a box inside a **closed** `.modal` at opacity 0, or `Dialog.tsx`'s close transition breaks (guarded by `dialog-close-frames.browser.test.tsx`).

## Sweep for the same bug class

I checked every daisyUI 5 child class whose own base rule hides it until an ancestor or sibling state matches: `modal-box`, `collapse-content`, `drawer-side`, `tab-content`, `validator-hint`, `menu-dropdown`, `megamenu-vertical`, `floating-label>span`, `swap-on/off`. Only `modal-box` and `collapse-content` are used here, and the one `collapse-content` (`Notebook.tsx:490`) sits in a real `.collapse`.

Every other `.modal-box` in the tree is already inside `.modal modal-open` or `<dialog class='modal' open>`: `CatalogManager`, `FailedDownloadsDialog`, `TelemetryConsentDialog`, `KeyboardShortcutsSettings`, `AppLockDialog`, `PassphrasePrompt`, `CustomDictionaries` (x2), `Dialog.tsx`.

`dropdown-content` is **not** this bug — it hides only via `.dropdown … .dropdown-content`, so a stray one is over-visible rather than invisible.

## Tests

`src/__tests__/styles/modal-box-standalone.browser.test.ts` — browser test against the real compiled stylesheet (jsdom cannot see this). Covers a bare box, the transfer queue chassis, a box in a closed `.modal`, and a box in an open one.

Before the fix: 2 failed, `expected +0 to be 1`. After:

- `pnpm test:browser` — 46 passed (46) · 399 passed | 1 skipped
- `pnpm test` — 844 passed | 4 skipped, 10320 tests
- `pnpm lint` (tsc + biome) and `pnpm format:check` — clean

Not verified by clicking through a running app: the menu item lives behind sign-in, so this is proven at the CSS layer against the real stylesheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed standalone overlays so their content is fully visible when displayed outside a standard modal.
  * Preserved expected behavior for modal dialogs, including hidden closed dialogs and visible open dialogs.

* **Tests**
  * Added browser-based regression coverage for standalone and nested modal content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->