### PR TITLE
fix(sync): report third-party sync status in the reader menu (#5910)

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2491,5 +2491,13 @@
   "Choose Audiobook": "اختيار كتاب صوتي",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "اختر كتاب Audiobookshelf الصوتي لاقترانه بـ “{{book}}”.",
   "Search audiobooks": "البحث في الكتب الصوتية",
-  "No matching audiobooks": "لا توجد كتب صوتية مطابقة"
+  "No matching audiobooks": "لا توجد كتب صوتية مطابقة",
+  "Last Synced — {{provider}}": "آخر مزامنة — {{provider}}",
+  "Synced via {{count}} providers_zero": "تمت المزامنة عبر {{count}} مزودين",
+  "Synced via {{count}} providers_one": "تمت المزامنة عبر {{count}} مزود",
+  "Synced via {{count}} providers_two": "تمت المزامنة عبر {{count}} مزودين",
+  "Synced via {{count}} providers_few": "تمت المزامنة عبر {{count}} مزودين",
+  "Synced via {{count}} providers_many": "تمت المزامنة عبر {{count}} مزودًا",
+  "Synced via {{count}} providers_other": "تمت المزامنة عبر {{count}} مزود",
+  "Synced via {{provider}}": "تمت المزامنة عبر {{provider}}"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2247,5 +2247,9 @@
   "Choose Audiobook": "অডিওবুক বেছে নিন",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "“{{book}}”-এর সাথে পেয়ার করার জন্য Audiobookshelf অডিওবুক বেছে নিন।",
   "Search audiobooks": "অডিওবুক খুঁজুন",
-  "No matching audiobooks": "মিল আছে এমন কোনো অডিওবুক নেই"
+  "No matching audiobooks": "মিল আছে এমন কোনো অডিওবুক নেই",
+  "Last Synced — {{provider}}": "শেষ সিঙ্ক — {{provider}}",
+  "Synced via {{count}} providers_one": "{{count}}টি প্রোভাইডারের মাধ্যমে সিঙ্ক",
+  "Synced via {{count}} providers_other": "{{count}}টি প্রোভাইডারের মাধ্যমে সিঙ্ক",
+  "Synced via {{provider}}": "{{provider}} এর মাধ্যমে সিঙ্ক"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2186,5 +2186,8 @@
   "Choose Audiobook": "སྒྲ་དེབ་འདེམས།",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "“{{book}}” དང་སྦྲེལ་མཐུད་བྱེད་པའི་ Audiobookshelf སྒྲ་དེབ་འདེམས་རོགས།",
   "Search audiobooks": "སྒྲ་དེབ་འཚོལ།",
-  "No matching audiobooks": "མཐུན་པའི་སྒྲ་དེབ་མི་འདུག"
+  "No matching audiobooks": "མཐུན་པའི་སྒྲ་དེབ་མི་འདུག",
+  "Last Synced — {{provider}}": "མཐའ་མའི་མཉམ་སྒྲིག — {{provider}}",
+  "Synced via {{count}} providers_other": "སྤྲོད་མཁན་ {{count}} བརྒྱུད་ནས་མཉམ་སྒྲིག་བྱས།",
+  "Synced via {{provider}}": "{{provider}} བརྒྱུད་ནས་མཉམ་སྒྲིག་བྱས།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2247,5 +2247,9 @@
   "Choose Audiobook": "Hörbuch auswählen",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Wählen Sie das Audiobookshelf-Hörbuch, das mit „{{book}}“ verknüpft werden soll.",
   "Search audiobooks": "Hörbücher suchen",
-  "No matching audiobooks": "Keine passenden Hörbücher"
+  "No matching audiobooks": "Keine passenden Hörbücher",
+  "Last Synced — {{provider}}": "Zuletzt synchronisiert — {{provider}}",
+  "Synced via {{count}} providers_one": "Synchronisiert über {{count}} Anbieter",
+  "Synced via {{count}} providers_other": "Synchronisiert über {{count}} Anbieter",
+  "Synced via {{provider}}": "Synchronisiert über {{provider}}"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2247,5 +2247,9 @@
   "Choose Audiobook": "Επιλογή ηχητικού βιβλίου",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Επιλέξτε το ηχητικό βιβλίο Audiobookshelf που θα συνδεθεί με το «{{book}}».",
   "Search audiobooks": "Αναζήτηση ηχητικών βιβλίων",
-  "No matching audiobooks": "Δεν βρέθηκαν ηχητικά βιβλία"
+  "No matching audiobooks": "Δεν βρέθηκαν ηχητικά βιβλία",
+  "Last Synced — {{provider}}": "Τελευταίος συγχρονισμός — {{provider}}",
+  "Synced via {{count}} providers_one": "Συγχρονίστηκε μέσω {{count}} παρόχου",
+  "Synced via {{count}} providers_other": "Συγχρονίστηκε μέσω {{count}} παρόχων",
+  "Synced via {{provider}}": "Συγχρονίστηκε μέσω {{provider}}"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2308,5 +2308,10 @@
   "Choose Audiobook": "Elegir audiolibro",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Elige el audiolibro de Audiobookshelf que quieres vincular con «{{book}}».",
   "Search audiobooks": "Buscar audiolibros",
-  "No matching audiobooks": "No hay audiolibros coincidentes"
+  "No matching audiobooks": "No hay audiolibros coincidentes",
+  "Last Synced — {{provider}}": "Última sincronización — {{provider}}",
+  "Synced via {{count}} providers_one": "Sincronizado mediante {{count}} proveedor",
+  "Synced via {{count}} providers_many": "Sincronizado mediante {{count}} proveedores",
+  "Synced via {{count}} providers_other": "Sincronizado mediante {{count}} proveedores",
+  "Synced via {{provider}}": "Sincronizado mediante {{provider}}"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2247,5 +2247,9 @@
   "Choose Audiobook": "انتخاب کتاب صوتی",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "کتاب صوتی Audiobookshelf را برای جفت‌شدن با «{{book}}» انتخاب کنید.",
   "Search audiobooks": "جستجوی کتاب‌های صوتی",
-  "No matching audiobooks": "کتاب صوتی مطابقی یافت نشد"
+  "No matching audiobooks": "کتاب صوتی مطابقی یافت نشد",
+  "Last Synced — {{provider}}": "آخرین همگام‌سازی — {{provider}}",
+  "Synced via {{count}} providers_one": "همگام‌سازی از طریق {{count}} ارائه‌دهنده",
+  "Synced via {{count}} providers_other": "همگام‌سازی از طریق {{count}} ارائه‌دهنده",
+  "Synced via {{provider}}": "همگام‌سازی از طریق {{provider}}"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2308,5 +2308,10 @@
   "Choose Audiobook": "Choisir un livre audio",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Choisissez le livre audio Audiobookshelf à associer à « {{book}} ».",
   "Search audiobooks": "Rechercher des livres audio",
-  "No matching audiobooks": "Aucun livre audio correspondant"
+  "No matching audiobooks": "Aucun livre audio correspondant",
+  "Last Synced — {{provider}}": "Dernière synchronisation — {{provider}}",
+  "Synced via {{count}} providers_one": "Synchronisé via {{count}} fournisseur",
+  "Synced via {{count}} providers_many": "Synchronisé via {{count}} fournisseurs",
+  "Synced via {{count}} providers_other": "Synchronisé via {{count}} fournisseurs",
+  "Synced via {{provider}}": "Synchronisé via {{provider}}"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2308,5 +2308,10 @@
   "Choose Audiobook": "בחירת ספר קולי",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "בחרו את הספר הקולי מ-Audiobookshelf שיצורף אל “{{book}}”.",
   "Search audiobooks": "חיפוש ספרים קוליים",
-  "No matching audiobooks": "לא נמצאו ספרים קוליים תואמים"
+  "No matching audiobooks": "לא נמצאו ספרים קוליים תואמים",
+  "Last Synced — {{provider}}": "סונכרן לאחרונה — {{provider}}",
+  "Synced via {{count}} providers_one": "סונכרן באמצעות {{count}} ספק",
+  "Synced via {{count}} providers_two": "סונכרן באמצעות {{count}} ספקים",
+  "Synced via {{count}} providers_other": "סונכרן באמצעות {{count}} ספקים",
+  "Synced via {{provider}}": "סונכרן באמצעות {{provider}}"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2247,5 +2247,9 @@
   "Choose Audiobook": "ऑडियोबुक चुनें",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "“{{book}}” के साथ युग्मित करने के लिए Audiobookshelf ऑडियोबुक चुनें।",
   "Search audiobooks": "ऑडियोबुक खोजें",
-  "No matching audiobooks": "कोई मेल खाती ऑडियोबुक नहीं"
+  "No matching audiobooks": "कोई मेल खाती ऑडियोबुक नहीं",
+  "Last Synced — {{provider}}": "अंतिम सिंक — {{provider}}",
+  "Synced via {{count}} providers_one": "{{count}} प्रदाता के माध्यम से सिंक",
+  "Synced via {{count}} providers_other": "{{count}} प्रदाताओं के माध्यम से सिंक",
+  "Synced via {{provider}}": "{{provider}} के माध्यम से सिंक"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2247,5 +2247,9 @@
   "Choose Audiobook": "Hangoskönyv választása",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Válassza ki azt az Audiobookshelf-hangoskönyvet, amelyet a(z) „{{book}}” könyvhöz párosít.",
   "Search audiobooks": "Hangoskönyvek keresése",
-  "No matching audiobooks": "Nincs találat a hangoskönyvek között"
+  "No matching audiobooks": "Nincs találat a hangoskönyvek között",
+  "Last Synced — {{provider}}": "Utolsó szinkronizálás — {{provider}}",
+  "Synced via {{count}} providers_one": "Szinkronizálva {{count}} szolgáltatón keresztül",
+  "Synced via {{count}} providers_other": "Szinkronizálva {{count}} szolgáltatón keresztül",
+  "Synced via {{provider}}": "Szinkronizálva a következőn keresztül: {{provider}}"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2186,5 +2186,8 @@
   "Choose Audiobook": "Pilih Buku Audio",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Pilih buku audio Audiobookshelf untuk dipasangkan dengan “{{book}}”.",
   "Search audiobooks": "Cari buku audio",
-  "No matching audiobooks": "Tidak ada buku audio yang cocok"
+  "No matching audiobooks": "Tidak ada buku audio yang cocok",
+  "Last Synced — {{provider}}": "Sinkronisasi terakhir — {{provider}}",
+  "Synced via {{count}} providers_other": "Disinkronkan melalui {{count}} penyedia",
+  "Synced via {{provider}}": "Disinkronkan melalui {{provider}}"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2308,5 +2308,10 @@
   "Choose Audiobook": "Scegli audiolibro",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Scegli l'audiolibro Audiobookshelf da associare a «{{book}}».",
   "Search audiobooks": "Cerca audiolibri",
-  "No matching audiobooks": "Nessun audiolibro corrispondente"
+  "No matching audiobooks": "Nessun audiolibro corrispondente",
+  "Last Synced — {{provider}}": "Ultima sincronizzazione — {{provider}}",
+  "Synced via {{count}} providers_one": "Sincronizzato tramite {{count}} fornitore",
+  "Synced via {{count}} providers_many": "Sincronizzato tramite {{count}} fornitori",
+  "Synced via {{count}} providers_other": "Sincronizzato tramite {{count}} fornitori",
+  "Synced via {{provider}}": "Sincronizzato tramite {{provider}}"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2186,5 +2186,8 @@
   "Choose Audiobook": "オーディオブックを選択",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "「{{book}}」とペアリングするAudiobookshelfのオーディオブックを選択してください。",
   "Search audiobooks": "オーディオブックを検索",
-  "No matching audiobooks": "一致するオーディオブックがありません"
+  "No matching audiobooks": "一致するオーディオブックがありません",
+  "Last Synced — {{provider}}": "最終同期：{{provider}}",
+  "Synced via {{count}} providers_other": "{{count}} 件のプロバイダー経由で同期",
+  "Synced via {{provider}}": "{{provider}} 経由で同期"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2247,5 +2247,9 @@
   "Choose Audiobook": "აირჩიეთ აუდიოწიგნი",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "აირჩიეთ Audiobookshelf-ის აუდიოწიგნი „{{book}}“-თან დასაკავშირებლად.",
   "Search audiobooks": "აუდიოწიგნების ძებნა",
-  "No matching audiobooks": "შესაბამისი აუდიოწიგნი ვერ მოიძებნა"
+  "No matching audiobooks": "შესაბამისი აუდიოწიგნი ვერ მოიძებნა",
+  "Last Synced — {{provider}}": "ბოლო სინქრონიზაცია：{{provider}}",
+  "Synced via {{count}} providers_one": "სინქრონიზებულია {{count}} პროვაიდერით",
+  "Synced via {{count}} providers_other": "სინქრონიზებულია {{count}} პროვაიდერით",
+  "Synced via {{provider}}": "სინქრონიზებულია: {{provider}}"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2186,5 +2186,8 @@
   "Choose Audiobook": "오디오북 선택",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "“{{book}}”과(와) 페어링할 Audiobookshelf 오디오북을 선택하세요.",
   "Search audiobooks": "오디오북 검색",
-  "No matching audiobooks": "일치하는 오디오북이 없습니다"
+  "No matching audiobooks": "일치하는 오디오북이 없습니다",
+  "Last Synced — {{provider}}": "마지막 동기화：{{provider}}",
+  "Synced via {{count}} providers_other": "{{count}}개의 제공자를 통해 동기화",
+  "Synced via {{provider}}": "{{provider}}을(를) 통해 동기화"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2186,5 +2186,8 @@
   "Choose Audiobook": "Pilih Buku Audio",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Pilih buku audio Audiobookshelf untuk dipadankan dengan “{{book}}”.",
   "Search audiobooks": "Cari buku audio",
-  "No matching audiobooks": "Tiada buku audio yang sepadan"
+  "No matching audiobooks": "Tiada buku audio yang sepadan",
+  "Last Synced — {{provider}}": "Penyegerakan terakhir — {{provider}}",
+  "Synced via {{count}} providers_other": "Disegerakkan melalui {{count}} penyedia",
+  "Synced via {{provider}}": "Disegerakkan melalui {{provider}}"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2247,5 +2247,9 @@
   "Choose Audiobook": "Luisterboek kiezen",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Kies het Audiobookshelf-luisterboek dat u aan ‘{{book}}’ wilt koppelen.",
   "Search audiobooks": "Luisterboeken zoeken",
-  "No matching audiobooks": "Geen overeenkomende luisterboeken"
+  "No matching audiobooks": "Geen overeenkomende luisterboeken",
+  "Last Synced — {{provider}}": "Laatst gesynchroniseerd — {{provider}}",
+  "Synced via {{count}} providers_one": "Gesynchroniseerd via {{count}} provider",
+  "Synced via {{count}} providers_other": "Gesynchroniseerd via {{count}} providers",
+  "Synced via {{provider}}": "Gesynchroniseerd via {{provider}}"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2369,5 +2369,11 @@
   "Choose Audiobook": "Wybierz audiobook",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Wybierz audiobook z Audiobookshelf do sparowania z „{{book}}”.",
   "Search audiobooks": "Szukaj audiobooków",
-  "No matching audiobooks": "Brak pasujących audiobooków"
+  "No matching audiobooks": "Brak pasujących audiobooków",
+  "Last Synced — {{provider}}": "Ostatnia synchronizacja — {{provider}}",
+  "Synced via {{count}} providers_one": "Zsynchronizowano przez {{count}} dostawcę",
+  "Synced via {{count}} providers_few": "Zsynchronizowano przez {{count}} dostawców",
+  "Synced via {{count}} providers_many": "Zsynchronizowano przez {{count}} dostawców",
+  "Synced via {{count}} providers_other": "Zsynchronizowano przez {{count}} dostawców",
+  "Synced via {{provider}}": "Zsynchronizowano przez {{provider}}"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2308,5 +2308,10 @@
   "Choose Audiobook": "Escolher audiolivro",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Escolha o audiolivro do Audiobookshelf para vincular a “{{book}}”.",
   "Search audiobooks": "Buscar audiolivros",
-  "No matching audiobooks": "Nenhum audiolivro correspondente"
+  "No matching audiobooks": "Nenhum audiolivro correspondente",
+  "Last Synced — {{provider}}": "Última sincronização — {{provider}}",
+  "Synced via {{count}} providers_one": "Sincronizado via {{count}} provedor",
+  "Synced via {{count}} providers_many": "Sincronizado via {{count}} provedores",
+  "Synced via {{count}} providers_other": "Sincronizado via {{count}} provedores",
+  "Synced via {{provider}}": "Sincronizado via {{provider}}"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2308,5 +2308,10 @@
   "Choose Audiobook": "Escolher audiolivro",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Escolha o audiolivro do Audiobookshelf para associar a “{{book}}”.",
   "Search audiobooks": "Procurar audiolivros",
-  "No matching audiobooks": "Nenhum audiolivro correspondente"
+  "No matching audiobooks": "Nenhum audiolivro correspondente",
+  "Last Synced — {{provider}}": "Última sincronização — {{provider}}",
+  "Synced via {{count}} providers_one": "Sincronizado via {{count}} provedor",
+  "Synced via {{count}} providers_many": "Sincronizado via {{count}} provedores",
+  "Synced via {{count}} providers_other": "Sincronizado via {{count}} provedores",
+  "Synced via {{provider}}": "Sincronizado via {{provider}}"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2308,5 +2308,10 @@
   "Choose Audiobook": "Alege cartea audio",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Alege cartea audio Audiobookshelf de asociat cu „{{book}}”.",
   "Search audiobooks": "Caută cărți audio",
-  "No matching audiobooks": "Nicio carte audio potrivită"
+  "No matching audiobooks": "Nicio carte audio potrivită",
+  "Last Synced — {{provider}}": "Ultima sincronizare — {{provider}}",
+  "Synced via {{count}} providers_one": "Sincronizat prin {{count}} furnizor",
+  "Synced via {{count}} providers_few": "Sincronizat prin {{count}} furnizori",
+  "Synced via {{count}} providers_other": "Sincronizat prin {{count}} de furnizori",
+  "Synced via {{provider}}": "Sincronizat prin {{provider}}"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2369,5 +2369,11 @@
   "Choose Audiobook": "Выбор аудиокниги",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Выберите аудиокнигу Audiobookshelf для сопоставления с «{{book}}».",
   "Search audiobooks": "Поиск аудиокниг",
-  "No matching audiobooks": "Подходящих аудиокниг нет"
+  "No matching audiobooks": "Подходящих аудиокниг нет",
+  "Last Synced — {{provider}}": "Последняя синхронизация — {{provider}}",
+  "Synced via {{count}} providers_one": "Синхронизировано через {{count}} сервис",
+  "Synced via {{count}} providers_few": "Синхронизировано через {{count}} сервиса",
+  "Synced via {{count}} providers_many": "Синхронизировано через {{count}} сервисов",
+  "Synced via {{count}} providers_other": "Синхронизировано через {{count}} сервисов",
+  "Synced via {{provider}}": "Синхронизировано через {{provider}}"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2247,5 +2247,9 @@
   "Choose Audiobook": "ශ්‍රව්‍ය පොත තෝරන්න",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "“{{book}}” සමඟ යුගල කිරීමට Audiobookshelf ශ්‍රව්‍ය පොත තෝරන්න.",
   "Search audiobooks": "ශ්‍රව්‍ය පොත් සොයන්න",
-  "No matching audiobooks": "ගැළපෙන ශ්‍රව්‍ය පොත් නැත"
+  "No matching audiobooks": "ගැළපෙන ශ්‍රව්‍ය පොත් නැත",
+  "Last Synced — {{provider}}": "අවසන් සමමුහුර්තය — {{provider}}",
+  "Synced via {{count}} providers_one": "සපයන්නන් {{count}}ක් හරහා සමමුහූර්ත කළා",
+  "Synced via {{count}} providers_other": "සපයන්නන් {{count}}ක් හරහා සමමුහූර්ත කළා",
+  "Synced via {{provider}}": "{{provider}} හරහා සමමුහූර්ත කළා"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2369,5 +2369,11 @@
   "Choose Audiobook": "Izberite zvočno knjigo",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Izberite zvočno knjigo Audiobookshelf za povezavo z »{{book}}«.",
   "Search audiobooks": "Iskanje zvočnih knjig",
-  "No matching audiobooks": "Ni ustreznih zvočnih knjig"
+  "No matching audiobooks": "Ni ustreznih zvočnih knjig",
+  "Last Synced — {{provider}}": "Zadnja sinhronizacija — {{provider}}",
+  "Synced via {{count}} providers_one": "Sinhronizirano prek {{count}} ponudnika",
+  "Synced via {{count}} providers_two": "Sinhronizirano prek {{count}} ponudnikov",
+  "Synced via {{count}} providers_few": "Sinhronizirano prek {{count}} ponudnikov",
+  "Synced via {{count}} providers_other": "Sinhronizirano prek {{count}} ponudnikov",
+  "Synced via {{provider}}": "Sinhronizirano prek {{provider}}"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2247,5 +2247,9 @@
   "Choose Audiobook": "Välj ljudbok",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Välj den Audiobookshelf-ljudbok som ska kopplas till ”{{book}}”.",
   "Search audiobooks": "Sök ljudböcker",
-  "No matching audiobooks": "Inga matchande ljudböcker"
+  "No matching audiobooks": "Inga matchande ljudböcker",
+  "Last Synced — {{provider}}": "Senast synkroniserad — {{provider}}",
+  "Synced via {{count}} providers_one": "Synkroniserad via {{count}} leverantör",
+  "Synced via {{count}} providers_other": "Synkroniserad via {{count}} leverantörer",
+  "Synced via {{provider}}": "Synkroniserad via {{provider}}"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2247,5 +2247,9 @@
   "Choose Audiobook": "ஆடியோபுக்கைத் தேர்வுசெய்க",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "“{{book}}” உடன் இணைக்க Audiobookshelf ஆடியோபுக்கைத் தேர்வுசெய்க.",
   "Search audiobooks": "ஆடியோபுக்குகளைத் தேடு",
-  "No matching audiobooks": "பொருந்தும் ஆடியோபுக் எதுவும் இல்லை"
+  "No matching audiobooks": "பொருந்தும் ஆடியோபுக் எதுவும் இல்லை",
+  "Last Synced — {{provider}}": "கடைசி ஒத்திசைவு — {{provider}}",
+  "Synced via {{count}} providers_one": "{{count}} வழங்குநர் வழியாக ஒத்திசைக்கப்பட்டது",
+  "Synced via {{count}} providers_other": "{{count}} வழங்குநர்கள் வழியாக ஒத்திசைக்கப்பட்டது",
+  "Synced via {{provider}}": "{{provider}} வழியாக ஒத்திசைக்கப்பட்டது"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2186,5 +2186,8 @@
   "Choose Audiobook": "เลือกหนังสือเสียง",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "เลือกหนังสือเสียงจาก Audiobookshelf เพื่อจับคู่กับ “{{book}}”",
   "Search audiobooks": "ค้นหาหนังสือเสียง",
-  "No matching audiobooks": "ไม่พบหนังสือเสียงที่ตรงกัน"
+  "No matching audiobooks": "ไม่พบหนังสือเสียงที่ตรงกัน",
+  "Last Synced — {{provider}}": "ซิงค์ล่าสุด：{{provider}}",
+  "Synced via {{count}} providers_other": "ซิงค์ผ่านผู้ให้บริการ {{count}} ราย",
+  "Synced via {{provider}}": "ซิงค์ผ่าน {{provider}}"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2247,5 +2247,9 @@
   "Choose Audiobook": "Sesli Kitap Seç",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "“{{book}}” ile eşleştirilecek Audiobookshelf sesli kitabını seçin.",
   "Search audiobooks": "Sesli kitap ara",
-  "No matching audiobooks": "Eşleşen sesli kitap yok"
+  "No matching audiobooks": "Eşleşen sesli kitap yok",
+  "Last Synced — {{provider}}": "Son senkronizasyon — {{provider}}",
+  "Synced via {{count}} providers_one": "{{count}} sağlayıcı ile senkronize edildi",
+  "Synced via {{count}} providers_other": "{{count}} sağlayıcı ile senkronize edildi",
+  "Synced via {{provider}}": "{{provider}} ile senkronize edildi"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2369,5 +2369,11 @@
   "Choose Audiobook": "Вибір аудіокниги",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Виберіть аудіокнигу Audiobookshelf для зіставлення з «{{book}}».",
   "Search audiobooks": "Пошук аудіокниг",
-  "No matching audiobooks": "Немає відповідних аудіокниг"
+  "No matching audiobooks": "Немає відповідних аудіокниг",
+  "Last Synced — {{provider}}": "Остання синхронізація — {{provider}}",
+  "Synced via {{count}} providers_one": "Синхронізовано через {{count}} сервіс",
+  "Synced via {{count}} providers_few": "Синхронізовано через {{count}} сервіси",
+  "Synced via {{count}} providers_many": "Синхронізовано через {{count}} сервісів",
+  "Synced via {{count}} providers_other": "Синхронізовано через {{count}} сервісів",
+  "Synced via {{provider}}": "Синхронізовано через {{provider}}"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2247,5 +2247,9 @@
   "Choose Audiobook": "Audiokitobni tanlang",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "“{{book}}” bilan bogʻlash uchun Audiobookshelf audiokitobini tanlang.",
   "Search audiobooks": "Audiokitoblarni qidirish",
-  "No matching audiobooks": "Mos audiokitob topilmadi"
+  "No matching audiobooks": "Mos audiokitob topilmadi",
+  "Last Synced — {{provider}}": "Oxirgi sinxronlash — {{provider}}",
+  "Synced via {{count}} providers_one": "{{count}} ta provayder orqali sinxronlandi",
+  "Synced via {{count}} providers_other": "{{count}} ta provayder orqali sinxronlandi",
+  "Synced via {{provider}}": "{{provider}} orqali sinxronlandi"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2186,5 +2186,8 @@
   "Choose Audiobook": "Chọn sách nói",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "Chọn sách nói Audiobookshelf để ghép nối với “{{book}}”.",
   "Search audiobooks": "Tìm sách nói",
-  "No matching audiobooks": "Không có sách nói phù hợp"
+  "No matching audiobooks": "Không có sách nói phù hợp",
+  "Last Synced — {{provider}}": "Đồng bộ lần cuối — {{provider}}",
+  "Synced via {{count}} providers_other": "Đã đồng bộ qua {{count}} nhà cung cấp",
+  "Synced via {{provider}}": "Đã đồng bộ qua {{provider}}"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2186,5 +2186,8 @@
   "Choose Audiobook": "选择有声书",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "选择要与“{{book}}”配对的 Audiobookshelf 有声书。",
   "Search audiobooks": "搜索有声书",
-  "No matching audiobooks": "没有匹配的有声书"
+  "No matching audiobooks": "没有匹配的有声书",
+  "Last Synced — {{provider}}": "上一次同步：{{provider}}",
+  "Synced via {{count}} providers_other": "通过 {{count}} 个服务同步",
+  "Synced via {{provider}}": "通过 {{provider}} 同步"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2186,5 +2186,8 @@
   "Choose Audiobook": "選擇有聲書",
   "Pick the Audiobookshelf audiobook to pair with “{{book}}”.": "選擇要與「{{book}}」配對的 Audiobookshelf 有聲書。",
   "Search audiobooks": "搜尋有聲書",
-  "No matching audiobooks": "沒有相符的有聲書"
+  "No matching audiobooks": "沒有相符的有聲書",
+  "Last Synced — {{provider}}": "上一次同步：{{provider}}",
+  "Synced via {{count}} providers_other": "透過 {{count}} 個服務同步",
+  "Synced via {{provider}}": "透過 {{provider}} 同步"
 }

--- a/apps/readest-app/src/__tests__/components/ViewMenu-sync-row.test.tsx
+++ b/apps/readest-app/src/__tests__/components/ViewMenu-sync-row.test.tsx
@@ -1,0 +1,181 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * #5910: the reader's sync row was Readest-Cloud-only. A user syncing through
+ * WebDAV / iCloud / Drive / S3 alone was told "Never synced" (or, with no
+ * account, "Sign in to Sync"), and — worse — tapping the row did nothing at
+ * all, because it dispatched only `sync-book-progress`, which `useFileSync` and
+ * `useKOSync` do not listen for.
+ */
+
+const mockNavigateToLogin = vi.fn();
+const mockDispatch = vi.fn();
+
+let mockSyncStatus = {
+  providers: [{ kind: 'webdav', name: 'WebDAV', lastSyncedAt: 1, syncing: false, failed: false }],
+  syncing: false,
+  failed: false,
+  lastSyncedAt: 1,
+  needsSignIn: false,
+  label: 'Synced 2 minutes ago',
+};
+
+const mockBookData = {
+  isFixedLayout: false,
+  bookDoc: {
+    dir: undefined as string | undefined,
+    rendition: { layout: 'reflowable' },
+    sections: [{ pageSpread: '' }],
+  },
+};
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: { hasAmbientLightSensor: false } }),
+}));
+vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ user: null }) }));
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({ themeMode: 'auto', isDarkMode: false, setThemeMode: vi.fn() }),
+}));
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: () => ({
+    getView: () => ({ book: {}, renderer: { setAttribute: vi.fn() } }),
+    getViewSettings: () => ({
+      scrolled: false,
+      scrolledDirection: 'vertical',
+      webtoonMode: false,
+      paragraphMode: { enabled: false },
+      zoomLevel: 100,
+      contrast: 100,
+      zoomMode: 'fit-page',
+      spreadMode: 'auto',
+      keepCoverSpread: true,
+      invertImgColorInDark: false,
+      applyThemeToPDF: false,
+      vertical: false,
+      writingMode: 'auto',
+    }),
+    getViewState: () => ({}),
+    getProgress: () => null,
+    setViewSettings: vi.fn(),
+    recreateViewer: vi.fn(),
+  }),
+}));
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: () => ({ getConfig: () => ({}), getBookData: () => mockBookData }),
+}));
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({
+    setSettingsDialogOpen: vi.fn(),
+    setSettingsDialogBookKey: vi.fn(),
+  }),
+}));
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+vi.mock('@/hooks/useResponsiveSize', () => ({ useResponsiveSize: (n: number) => n }));
+vi.mock('@/hooks/useCloudSyncStatus', () => ({
+  useCloudSyncStatus: () => mockSyncStatus,
+}));
+vi.mock('@/helpers/settings', () => ({ saveViewSettings: vi.fn() }));
+vi.mock('@/services/constants', () => ({
+  MAX_ZOOM_LEVEL: 200,
+  MIN_ZOOM_LEVEL: 50,
+  ZOOM_STEP: 10,
+  MAX_CONTRAST: 200,
+  MIN_CONTRAST: 50,
+  CONTRAST_STEP: 10,
+}));
+vi.mock('@/utils/style', () => ({ getStyles: vi.fn() }));
+vi.mock('@/utils/nav', () => ({ navigateToLogin: (...a: unknown[]) => mockNavigateToLogin(...a) }));
+vi.mock('@/utils/webtoon', () => ({ getScrollGapAttr: vi.fn() }));
+vi.mock('@/app/reader/hooks/useCapturedTurn', () => ({ applyPageTurnAttributes: vi.fn() }));
+vi.mock('@/utils/config', () => ({ getMaxInlineSize: () => 720 }));
+vi.mock('@/utils/ambientLight', () => ({ nextThemeMode: (mode: string) => mode }));
+vi.mock('@/utils/window', () => ({ tauriHandleToggleFullScreen: vi.fn() }));
+vi.mock('@/utils/event', () => ({
+  eventDispatcher: { dispatch: (...a: unknown[]) => mockDispatch(...a), on: vi.fn(), off: vi.fn() },
+}));
+
+const ViewMenu = (await import('@/app/reader/components/ViewMenu')).default;
+
+describe('ViewMenu sync row (issue #5910)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSyncStatus = {
+      providers: [
+        { kind: 'webdav', name: 'WebDAV', lastSyncedAt: 1, syncing: false, failed: false },
+      ],
+      syncing: false,
+      failed: false,
+      lastSyncedAt: 1,
+      needsSignIn: false,
+      label: 'Synced 2 minutes ago',
+    };
+  });
+
+  afterEach(() => cleanup());
+
+  it('shows the third-party status instead of "Never synced" with no account', () => {
+    render(<ViewMenu bookKey='book-1' />);
+
+    expect(screen.getByText('Synced 2 minutes ago')).toBeTruthy();
+    expect(screen.queryByText('Never synced')).toBeNull();
+    expect(screen.queryByText('Sign in to Sync')).toBeNull();
+    // ...and names the provider whose status this is.
+    expect(screen.getByText('Synced via {{provider}}')).toBeTruthy();
+  });
+
+  it('syncs every selected provider on tap, not just Readest Cloud', () => {
+    render(<ViewMenu bookKey='book-1' />);
+
+    fireEvent.click(screen.getByText('Synced 2 minutes ago'));
+
+    const events = mockDispatch.mock.calls.map((call) => call[0]);
+    expect(events).toContain('sync-book-progress');
+    expect(events).toContain('push-file-sync');
+    expect(events).toContain('pull-file-sync');
+    expect(events).toContain('flush-kosync');
+    expect(mockNavigateToLogin).not.toHaveBeenCalled();
+  });
+
+  it('still routes to login when Readest Cloud is the only provider', () => {
+    mockSyncStatus = {
+      providers: [
+        { kind: 'readest', name: 'Readest Cloud', lastSyncedAt: 0, syncing: false, failed: false },
+      ],
+      syncing: false,
+      failed: false,
+      lastSyncedAt: 0,
+      needsSignIn: true,
+      label: 'Sign in to Sync',
+    };
+
+    render(<ViewMenu bookKey='book-1' />);
+    fireEvent.click(screen.getByText('Sign in to Sync'));
+
+    expect(mockNavigateToLogin).toHaveBeenCalled();
+    expect(mockDispatch.mock.calls.map((call) => call[0])).not.toContain('push-file-sync');
+    // A lone Readest Cloud provider is not worth naming — the row means what it
+    // always meant.
+    expect(screen.queryByText('Synced via {{provider}}')).toBeNull();
+  });
+
+  it('names a count when several providers are selected', () => {
+    mockSyncStatus = {
+      providers: [
+        { kind: 'readest', name: 'Readest Cloud', lastSyncedAt: 5, syncing: false, failed: false },
+        { kind: 'webdav', name: 'WebDAV', lastSyncedAt: 9, syncing: false, failed: false },
+      ],
+      syncing: false,
+      failed: false,
+      lastSyncedAt: 9,
+      needsSignIn: false,
+      label: 'Synced 1 minute ago',
+    };
+
+    render(<ViewMenu bookKey='book-1' />);
+    expect(screen.getByText('Synced via {{count}} providers')).toBeTruthy();
+  });
+});

--- a/apps/readest-app/src/__tests__/hooks/useCloudSyncStatus.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useCloudSyncStatus.test.ts
@@ -1,0 +1,139 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SystemSettings } from '@/types/settings';
+
+/**
+ * #5910: the reader's sync row read ONLY Readest Cloud's per-book stamps, so a
+ * user syncing exclusively through WebDAV / iCloud / Drive / S3 was told "Never
+ * synced" — or, with no Readest account at all, "Sign in to Sync" — while their
+ * sync was working perfectly. This hook is the shared answer to "is my sync
+ * healthy?" for both the reader View menu and the library Settings menu.
+ */
+
+let mockUser: { id: string } | null = null;
+let mockSettings: Partial<SystemSettings> = {};
+let mockByKind: Record<string, { isSyncing: boolean }> = {};
+let mockLastError: Record<string, string | null> = {};
+
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ user: mockUser }),
+}));
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation:
+    () =>
+    (key: string, vars?: Record<string, unknown>): string =>
+      vars ? `${key}|${JSON.stringify(vars)}` : key,
+}));
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: (selector: (s: { settings: Partial<SystemSettings> }) => unknown) =>
+    selector({ settings: mockSettings }),
+}));
+vi.mock('@/store/fileSyncStore', () => ({
+  useFileSyncStore: (
+    selector: (s: { byKind: unknown; lastErrorByKind: unknown }) => unknown,
+  ): unknown => selector({ byKind: mockByKind, lastErrorByKind: mockLastError }),
+}));
+vi.mock('@/services/sync/file/runLibrarySync', () => ({
+  getReadyFileSyncBackends: (settings: Partial<SystemSettings>) => {
+    const ready: string[] = [];
+    if (settings?.webdav?.enabled) ready.push('webdav');
+    if (settings?.icloud?.enabled) ready.push('icloud');
+    return ready;
+  },
+}));
+
+const { useCloudSyncStatus } = await import('@/hooks/useCloudSyncStatus');
+
+const NOW = 1_700_000_000_000;
+
+beforeEach(() => {
+  mockUser = null;
+  mockSettings = {};
+  mockByKind = {};
+  mockLastError = {};
+  vi.setSystemTime(NOW);
+});
+
+describe('useCloudSyncStatus (issue #5910)', () => {
+  it('reports a third-party backend as synced with no Readest account', () => {
+    mockSettings = { webdav: { enabled: true, lastSyncedAt: NOW - 60_000 } } as never;
+    const { result } = renderHook(() => useCloudSyncStatus(0));
+
+    expect(result.current.needsSignIn).toBe(false);
+    expect(result.current.label).toContain('Synced {{time}}');
+    expect(result.current.lastSyncedAt).toBe(NOW - 60_000);
+    expect(result.current.providers.map((p) => p.kind)).toEqual(['webdav']);
+  });
+
+  it('still asks for sign-in when Readest Cloud is the only provider', () => {
+    const { result } = renderHook(() => useCloudSyncStatus(0));
+
+    expect(result.current.needsSignIn).toBe(true);
+    expect(result.current.label).toBe('Sign in to Sync');
+  });
+
+  it('ignores the native stamp when Readest Cloud is switched off', () => {
+    // The native cursors FREEZE rather than reset when the channels are gated,
+    // so a stale value would report a disabled provider as recently synced.
+    mockUser = { id: 'u1' };
+    mockSettings = {
+      readestCloud: { enabled: false },
+      webdav: { enabled: true },
+    } as never;
+    const { result } = renderHook(() => useCloudSyncStatus(NOW - 5_000));
+
+    expect(result.current.providers.map((p) => p.kind)).toEqual(['webdav']);
+    expect(result.current.lastSyncedAt).toBe(0);
+    expect(result.current.label).toBe('Never synced');
+  });
+
+  it('lists both providers with their own timestamps', () => {
+    mockUser = { id: 'u1' };
+    mockSettings = {
+      readestCloud: { enabled: true },
+      webdav: { enabled: true, lastSyncedAt: NOW - 120_000 },
+    } as never;
+    const { result } = renderHook(() => useCloudSyncStatus(NOW - 300_000));
+
+    expect(result.current.providers).toEqual([
+      expect.objectContaining({ kind: 'readest', lastSyncedAt: NOW - 300_000 }),
+      expect.objectContaining({ kind: 'webdav', lastSyncedAt: NOW - 120_000 }),
+    ]);
+    // The row shows the freshest; the per-provider breakdown is the dialog's job.
+    expect(result.current.lastSyncedAt).toBe(NOW - 120_000);
+  });
+
+  it('reports an in-flight backend run', () => {
+    mockSettings = { webdav: { enabled: true, lastSyncedAt: NOW - 60_000 } } as never;
+    mockByKind = { webdav: { isSyncing: true } };
+    const { result } = renderHook(() => useCloudSyncStatus(0));
+
+    expect(result.current.syncing).toBe(true);
+    expect(result.current.label).toBe('Syncing…');
+  });
+
+  it('reports a backend whose last run failed, over a stale success', () => {
+    mockSettings = { webdav: { enabled: true, lastSyncedAt: NOW - 60_000 } } as never;
+    mockLastError = { webdav: 'ETIMEDOUT' };
+    const { result } = renderHook(() => useCloudSyncStatus(0));
+
+    expect(result.current.failed).toBe(true);
+    expect(result.current.label).toBe('Sync failed');
+  });
+
+  it('drops a backend that cannot run right now', () => {
+    // An expired web Google Drive token is still `enabled` but silently
+    // skipped, so it must not lend its stale lastSyncedAt to "Synced X ago".
+    // Selecting Drive also switches Readest Cloud off, so nothing can sync —
+    // and "Sign in to Sync" would be a lie, because signing in would not help.
+    // Drive's own settings row carries the Reconnect CTA.
+    mockSettings = { googleDrive: { enabled: true, lastSyncedAt: NOW - 1_000 } } as never;
+    const { result } = renderHook(() => useCloudSyncStatus(0));
+
+    expect(result.current.providers).toEqual([]);
+    expect(result.current.lastSyncedAt).toBe(0);
+    expect(result.current.needsSignIn).toBe(false);
+    expect(result.current.label).toBe('Never synced');
+  });
+});

--- a/apps/readest-app/src/app/library/components/SettingsMenu.tsx
+++ b/apps/readest-app/src/app/library/components/SettingsMenu.tsx
@@ -14,17 +14,11 @@ import { useAuth } from '@/context/AuthContext';
 import { useEnv } from '@/context/EnvContext';
 import { useThemeStore } from '@/store/themeStore';
 import { useQuotaStats } from '@/hooks/useQuotaStats';
-import { useFileSyncStore } from '@/store/fileSyncStore';
-import {
-  isReadestCloudEnabled,
-  cloudProvidersDisplayName,
-  settingsKeyForBackend,
-  type CloudSyncProviderKind,
-} from '@/services/sync/cloudSyncProvider';
-import { getReadyFileSyncBackends } from '@/services/sync/file/runLibrarySync';
+import { isReadestCloudEnabled } from '@/services/sync/cloudSyncProvider';
 import { useLibraryStore } from '@/store/libraryStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useCloudSyncStatus } from '@/hooks/useCloudSyncStatus';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
 import { useTransferQueue } from '@/hooks/useTransferQueue';
 import { navigateToLogin, navigateToProfile } from '@/utils/nav';
@@ -40,8 +34,6 @@ import {
 } from '@/services/biometric';
 import { selectDirectory } from '@/utils/bridge';
 import { nextThemeMode } from '@/utils/ambientLight';
-import dayjs from 'dayjs';
-import { clampSyncTimeForDisplay } from '@/utils/time';
 import UserAvatar from '@/components/UserAvatar';
 import MenuItem from '@/components/MenuItem';
 import Quota from '@/components/Quota';
@@ -102,8 +94,6 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
     setIsDropdownOpen?.(false);
   };
   const { isSyncing, setLibrary } = useLibraryStore();
-  const fileSyncByKind = useFileSyncStore((s) => s.byKind);
-  const fileSyncLastError = useFileSyncStore((s) => s.lastErrorByKind);
   const { stats, hasActiveTransfers, setIsTransferQueueOpen } = useTransferQueue();
 
   const openTransferQueue = () => {
@@ -276,37 +266,20 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
   // cursors freeze while Readest Cloud is off (the book/progress/note channels
   // are gated), so the file engine's timestamps have to stand in.
   const readestEnabled = isReadestCloudEnabled(settings);
-  // Only the providers that can ACTUALLY sync right now. A web Google Drive whose
-  // token expired is still enabled but silently skipped, so it must not be counted
-  // as active or reported as synced (it would otherwise inflate the count and lend
-  // its stale lastSyncedAt to "Synced X ago").
-  const backends = getReadyFileSyncBackends(settings);
-  const providers: CloudSyncProviderKind[] = [
-    ...(readestEnabled ? (['readest'] as const) : []),
-    ...backends,
-  ];
-  const providerNames = cloudProvidersDisplayName(providers);
-
-  const providerSyncing = backends.some((kind) => !!fileSyncByKind[kind]?.isSyncing);
-  const providerLastError = backends.map((kind) => fileSyncLastError[kind]).find(Boolean);
-  const backendLastSyncedAt = Math.max(
-    0,
-    ...backends.map((kind) => settings[settingsKeyForBackend(kind)]?.lastSyncedAt || 0),
+  // Shared with the reader's View menu (#5910) so both surfaces answer "is my
+  // sync healthy?" identically. The hook gates the native cursors on whether
+  // Readest Cloud is actually enabled and drops backends that cannot run right
+  // now (a web Google Drive whose token expired is still `enabled` but silently
+  // skipped, so counting it would inflate the count and lend its stale
+  // lastSyncedAt to "Synced X ago").
+  const syncStatus = useCloudSyncStatus(
+    Math.max(
+      settings.lastSyncedAtBooks || 0,
+      settings.lastSyncedAtConfigs || 0,
+      settings.lastSyncedAtNotes || 0,
+    ),
   );
-  const nativeLastSyncedAt = readestEnabled
-    ? Math.max(
-        settings.lastSyncedAtBooks || 0,
-        settings.lastSyncedAtConfigs || 0,
-        settings.lastSyncedAtNotes || 0,
-      )
-    : 0;
-  const lastSyncTime = Math.max(backendLastSyncedAt, nativeLastSyncedAt);
-
-  const syncRowLabel = providerLastError
-    ? _('Sync failed')
-    : lastSyncTime
-      ? _('Synced {{time}}', { time: dayjs(clampSyncTimeForDisplay(lastSyncTime)).fromNow() })
-      : _('Never synced');
+  const fileBackendCount = syncStatus.providers.filter((p) => p.kind !== 'readest').length;
 
   return (
     <Menu
@@ -350,21 +323,27 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({ onPullLibrary, setIsDropdow
               onClick={openTransferQueue}
             />
             <MenuItem
-              label={syncRowLabel}
-              Icon={user ? MdSync : MdSyncProblem}
+              label={syncStatus.label}
+              Icon={syncStatus.needsSignIn || syncStatus.failed ? MdSyncProblem : MdSync}
               labelClass='ps-2 pe-1 mx-0!'
-              iconClassName={(user && isSyncing) || providerSyncing ? 'animate-reverse-spin' : ''}
+              iconClassName={
+                (user && isSyncing) || syncStatus.syncing ? 'animate-reverse-spin' : ''
+              }
               onClick={handleSyncLibrary}
               description={
-                backends.length === 0
+                fileBackendCount === 0
                   ? undefined
-                  : providers.length > 1
+                  : syncStatus.providers.length > 1
                     ? // Several providers named in full would overrun the row; show a
                       // count. `count` (not a plain var) so i18next applies each
                       // locale's plural rule — the common case is exactly 2, where
                       // Slavic/Arabic paucal forms differ from the generic plural.
-                      _('Library sync via {{count}} providers', { count: providers.length })
-                    : _('Library sync via {{provider}}', { provider: providerNames })
+                      _('Library sync via {{count}} providers', {
+                        count: syncStatus.providers.length,
+                      })
+                    : _('Library sync via {{provider}}', {
+                        provider: syncStatus.providers[0]!.name,
+                      })
               }
             />
             {readestEnabled ? (

--- a/apps/readest-app/src/app/reader/components/HeaderBar.tsx
+++ b/apps/readest-app/src/app/reader/components/HeaderBar.tsx
@@ -71,8 +71,17 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
   const viewSettings = getViewSettings(bookKey);
   const bookData = getBookData(bookKey);
   const bookConfig = getConfig(bookKey);
-  const lastSyncedAt =
-    Math.max(bookConfig?.lastSyncedAtConfig || 0, bookConfig?.lastSyncedAtNotes || 0) || undefined;
+  // Readest Cloud's per-book stamps. Includes the PUSH stamps so this agrees
+  // with the View menu's sync row, which has always counted them — otherwise
+  // the row could read "Synced 2 minutes ago" while this dialog said "Never
+  // synced" for the same book.
+  const nativeLastSyncedAt =
+    Math.max(
+      bookConfig?.lastSyncedAtConfig || 0,
+      bookConfig?.lastSyncedAtNotes || 0,
+      bookConfig?.lastPushedAtConfig || 0,
+      bookConfig?.lastPushedAtNotes || 0,
+    ) || undefined;
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isMetaHashDialogOpen, setIsMetaHashDialogOpen] = useState(false);
@@ -332,7 +341,7 @@ const HeaderBar: React.FC<HeaderBarProps> = ({
                 isOpen={isMetaHashDialogOpen}
                 metadata={bookData?.bookDoc?.metadata ?? bookData?.book?.metadata}
                 storedMetaHash={bookData?.book?.metaHash}
-                lastSyncedAt={lastSyncedAt}
+                nativeLastSyncedAt={nativeLastSyncedAt}
                 onClose={() => setIsMetaHashDialogOpen(false)}
               />
             </ModalPortal>

--- a/apps/readest-app/src/app/reader/components/SyncInfoDialog.tsx
+++ b/apps/readest-app/src/app/reader/components/SyncInfoDialog.tsx
@@ -4,13 +4,19 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { BookMetadata } from '@/libs/document';
 import { formatLocaleDateTime, getMetadataHashInfo } from '@/utils/book';
 import { clampSyncTimeForDisplay } from '@/utils/time';
+import { useCloudSyncStatus, type CloudSyncProviderStatus } from '@/hooks/useCloudSyncStatus';
 
 interface SyncInfoDialogProps {
   isOpen: boolean;
   metadata: BookMetadata | null | undefined;
   storedMetaHash?: string;
-  /** Most recent sync timestamp across pull + push of config and notes. */
-  lastSyncedAt?: number;
+  /**
+   * Readest Cloud's own most recent sync for this book, across pull + push of
+   * config and notes. Every other provider's timestamp is read from settings by
+   * {@link useCloudSyncStatus} — this dialog reports them all separately so a
+   * user can see which provider is actually keeping up (#5910).
+   */
+  nativeLastSyncedAt?: number;
   onClose: () => void;
 }
 
@@ -27,16 +33,22 @@ const SyncInfoDialog: React.FC<SyncInfoDialogProps> = ({
   isOpen,
   metadata,
   storedMetaHash,
-  lastSyncedAt,
+  nativeLastSyncedAt,
   onClose,
 }) => {
   const _ = useTranslation();
+  const syncStatus = useCloudSyncStatus(nativeLastSyncedAt);
   const info = metadata ? getMetadataHashInfo(metadata) : undefined;
   const displayHash = storedMetaHash || info?.metaHash || '';
   const placeholder = _('(none)');
-  const lastSyncedLabel = lastSyncedAt
-    ? formatLocaleDateTime(clampSyncTimeForDisplay(lastSyncedAt))
-    : _('Never synced');
+  const providerStatusLabel = (provider: CloudSyncProviderStatus): string =>
+    provider.syncing
+      ? _('Syncing…')
+      : provider.failed
+        ? _('Sync failed')
+        : provider.lastSyncedAt
+          ? formatLocaleDateTime(clampSyncTimeForDisplay(provider.lastSyncedAt))
+          : _('Never synced');
 
   return (
     <Dialog
@@ -58,7 +70,22 @@ const SyncInfoDialog: React.FC<SyncInfoDialogProps> = ({
             label={_('Identifiers')}
             value={info && info.identifiers.length > 0 ? info.identifiers.join(', ') : placeholder}
           />
-          <Row label={_('Last Synced')} value={lastSyncedLabel} />
+          {/* One row per provider the user actually selected. With a single
+              provider the row keeps its original "Last Synced" caption; with
+              several, each is named so it is clear whose timestamp is whose. */}
+          {syncStatus.providers.length === 0 ? (
+            <Row label={_('Last Synced')} value={_('Never synced')} />
+          ) : syncStatus.providers.length === 1 ? (
+            <Row label={_('Last Synced')} value={providerStatusLabel(syncStatus.providers[0]!)} />
+          ) : (
+            syncStatus.providers.map((provider) => (
+              <Row
+                key={provider.kind}
+                label={_('Last Synced — {{provider}}', { provider: provider.name })}
+                value={providerStatusLabel(provider)}
+              />
+            ))
+          )}
         </div>
       )}
     </Dialog>

--- a/apps/readest-app/src/app/reader/components/ViewMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/ViewMenu.tsx
@@ -29,6 +29,7 @@ import { useReaderStore } from '@/store/readerStore';
 import { useBookDataStore } from '@/store/bookDataStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useCloudSyncStatus } from '@/hooks/useCloudSyncStatus';
 import { getStyles } from '@/utils/style';
 import { navigateToLogin } from '@/utils/nav';
 import { getScrollGapAttr } from '@/utils/webtoon';
@@ -36,8 +37,6 @@ import { applyPageTurnAttributes } from '@/app/reader/hooks/useCapturedTurn';
 import { eventDispatcher } from '@/utils/event';
 import { getMaxInlineSize } from '@/utils/config';
 import { nextThemeMode } from '@/utils/ambientLight';
-import dayjs from 'dayjs';
-import { clampSyncTimeForDisplay } from '@/utils/time';
 import { saveViewSettings } from '@/helpers/settings';
 import { tauriHandleToggleFullScreen } from '@/utils/window';
 import MenuItem from '@/components/MenuItem';
@@ -118,13 +117,35 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
     setIsDropdownOpen?.(false);
   };
 
+  // Readest Cloud's own stamps for THIS book. The per-book values are more
+  // precise than the library-wide cursors the Settings menu uses, so the reader
+  // feeds them in rather than letting the hook guess.
+  const nativeLastSyncTime = Math.max(
+    config?.lastSyncedAtConfig || 0,
+    config?.lastSyncedAtNotes || 0,
+    config?.lastPushedAtConfig || 0,
+    config?.lastPushedAtNotes || 0,
+  );
+  // Every provider the user actually selected, not just Readest Cloud (#5910).
+  const syncStatus = useCloudSyncStatus(nativeLastSyncTime);
+
   const handleSync = () => {
-    if (!user) {
+    // Only Readest Cloud needs an account. With a third-party backend
+    // configured the row must sync, not bounce the user to a login they do not
+    // need (#5910).
+    if (syncStatus.needsSignIn) {
       navigateToLogin(router);
       setIsDropdownOpen?.(false);
-    } else {
-      eventDispatcher.dispatch('sync-book-progress', { bookKey });
+      return;
     }
+    // One tap, every provider the user selected. Before #5910 this dispatched
+    // `sync-book-progress` alone, which only useProgressSync (Readest Cloud)
+    // and useHardcoverSync listen for — so for a third-party-only user the row
+    // did nothing at all.
+    eventDispatcher.dispatch('sync-book-progress', { bookKey });
+    eventDispatcher.dispatch('push-file-sync', { bookKey });
+    eventDispatcher.dispatch('pull-file-sync', { bookKey });
+    eventDispatcher.dispatch('flush-kosync', { bookKey });
   };
 
   const handleStartRSVP = () => {
@@ -267,13 +288,6 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rtlSpread]);
-
-  const lastSyncTime = Math.max(
-    config?.lastSyncedAtConfig || 0,
-    config?.lastSyncedAtNotes || 0,
-    config?.lastPushedAtConfig || 0,
-    config?.lastPushedAtNotes || 0,
-  );
 
   return (
     <Menu
@@ -491,17 +505,24 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
       <hr aria-hidden='true' className='border-base-300 my-1' />
 
       <MenuItem
-        label={
-          !user
-            ? _('Sign in to Sync')
-            : lastSyncTime
-              ? _('Synced {{time}}', {
-                  time: dayjs(clampSyncTimeForDisplay(lastSyncTime)).fromNow(),
-                })
-              : _('Never synced')
+        label={syncStatus.label}
+        description={
+          // Which provider the status belongs to. Only worth saying when a
+          // third-party backend is in play — with Readest Cloud alone the row
+          // means what it always meant.
+          syncStatus.providers.length > 1
+            ? // Several names in full would overrun the row; show a count.
+              // `count` (not a plain var) so i18next applies each locale's
+              // plural rule.
+              _('Synced via {{count}} providers', { count: syncStatus.providers.length })
+            : syncStatus.providers[0] && syncStatus.providers[0].kind !== 'readest'
+              ? _('Synced via {{provider}}', { provider: syncStatus.providers[0].name })
+              : undefined
         }
-        Icon={user ? MdSync : MdSyncProblem}
-        iconClassName={user && viewState?.syncing ? 'animate-reverse-spin' : ''}
+        Icon={syncStatus.needsSignIn || syncStatus.failed ? MdSyncProblem : MdSync}
+        iconClassName={
+          syncStatus.syncing || (user && viewState?.syncing) ? 'animate-reverse-spin' : ''
+        }
         onClick={handleSync}
         siblings={
           <button

--- a/apps/readest-app/src/hooks/useCloudSyncStatus.ts
+++ b/apps/readest-app/src/hooks/useCloudSyncStatus.ts
@@ -1,0 +1,125 @@
+import { useMemo } from 'react';
+import { useAuth } from '@/context/AuthContext';
+import { useSettingsStore } from '@/store/settingsStore';
+import { useFileSyncStore } from '@/store/fileSyncStore';
+import { useTranslation } from '@/hooks/useTranslation';
+import { formatSyncTimeFromNow } from '@/utils/time';
+import {
+  cloudProviderDisplayName,
+  isReadestCloudEnabled,
+  settingsKeyForBackend,
+  type CloudSyncProviderKind,
+} from '@/services/sync/cloudSyncProvider';
+import { getReadyFileSyncBackends } from '@/services/sync/file/runLibrarySync';
+
+/** One enabled provider's health, for a per-provider breakdown. */
+export interface CloudSyncProviderStatus {
+  kind: CloudSyncProviderKind;
+  /** Product name — deliberately untranslated. */
+  name: string;
+  /** Newest successful sync for this provider, or 0 when it never synced. */
+  lastSyncedAt: number;
+  syncing: boolean;
+  failed: boolean;
+}
+
+export interface CloudSyncStatus {
+  /** Providers that can ACTUALLY sync right now, Readest Cloud first. */
+  providers: CloudSyncProviderStatus[];
+  /** True while any provider is mid-run. */
+  syncing: boolean;
+  /** True when a provider's last run ended in a terminal error. */
+  failed: boolean;
+  /** Newest successful sync across every enabled provider, or 0. */
+  lastSyncedAt: number;
+  /**
+   * True when nothing here can sync until the user signs in — Readest Cloud is
+   * a selected provider and there is no account. With a third-party backend
+   * configured, sync works signed out and this stays false. It is also false
+   * when NO provider can run at all (e.g. Google Drive selected but its web
+   * token expired): signing in would not help, and that provider's own settings
+   * row already shows a Reconnect CTA.
+   */
+  needsSignIn: boolean;
+  /** Ready-to-render status line for a menu row. */
+  label: string;
+}
+
+/**
+ * Sync health across every provider the user actually selected (#5062), shared
+ * by the library Settings menu and the reader's View menu.
+ *
+ * It exists because the reader menu used to read ONLY Readest Cloud's per-book
+ * stamps, so a user syncing exclusively through WebDAV / iCloud / Drive / S3
+ * was told "Never synced" — or, with no Readest account at all, "Sign in to
+ * Sync" — while their sync was working perfectly (#5910). Both surfaces now
+ * answer that question the same way, from one place.
+ *
+ * `nativeLastSyncedAt` is Readest Cloud's own "last synced" for the calling
+ * surface, ungated: the per-book config/notes stamps in the reader, the global
+ * cursors in the library. Gating it on whether Readest Cloud is actually
+ * enabled is this hook's job, since those cursors freeze rather than reset when
+ * the user turns the native channels off — a stale value would otherwise report
+ * a disabled provider as recently synced.
+ *
+ * KOSync is deliberately absent: it keeps no `lastSyncedAt`, so it has nothing
+ * to contribute to a timestamp. The reader's manual action still pokes it.
+ */
+export const useCloudSyncStatus = (nativeLastSyncedAt = 0): CloudSyncStatus => {
+  const _ = useTranslation();
+  const { user } = useAuth();
+  const settings = useSettingsStore((state) => state.settings);
+  const fileSyncByKind = useFileSyncStore((state) => state.byKind);
+  const fileSyncLastError = useFileSyncStore((state) => state.lastErrorByKind);
+
+  return useMemo(() => {
+    const readestEnabled = isReadestCloudEnabled(settings);
+    // Only backends that can actually run. A web Google Drive whose token
+    // expired is still `enabled` but silently skipped, so counting it would
+    // both inflate the provider list and lend its stale lastSyncedAt to
+    // "Synced X ago".
+    const backends = getReadyFileSyncBackends(settings);
+
+    const providers: CloudSyncProviderStatus[] = [
+      ...(readestEnabled
+        ? [
+            {
+              kind: 'readest' as const,
+              name: cloudProviderDisplayName('readest'),
+              lastSyncedAt: nativeLastSyncedAt,
+              // The native channel reports neither in-flight nor failed state
+              // per book; its row is a timestamp only.
+              syncing: false,
+              failed: false,
+            },
+          ]
+        : []),
+      ...backends.map((kind) => ({
+        kind,
+        name: cloudProviderDisplayName(kind),
+        lastSyncedAt: settings[settingsKeyForBackend(kind)]?.lastSyncedAt ?? 0,
+        syncing: !!fileSyncByKind[kind]?.isSyncing,
+        failed: !!fileSyncLastError[kind],
+      })),
+    ];
+
+    const syncing = providers.some((p) => p.syncing);
+    const failed = providers.some((p) => p.failed);
+    const lastSyncedAt = Math.max(0, ...providers.map((p) => p.lastSyncedAt));
+    const needsSignIn = !user && !backends.length && providers.some((p) => p.kind === 'readest');
+
+    const label = needsSignIn
+      ? _('Sign in to Sync')
+      : syncing
+        ? _('Syncing…')
+        : failed
+          ? _('Sync failed')
+          : lastSyncedAt
+            ? _('Synced {{time}}', { time: formatSyncTimeFromNow(lastSyncedAt) })
+            : _('Never synced');
+
+    return { providers, syncing, failed, lastSyncedAt, needsSignIn, label };
+  }, [_, user, settings, fileSyncByKind, fileSyncLastError, nativeLastSyncedAt]);
+};
+
+export default useCloudSyncStatus;

--- a/apps/readest-app/src/utils/time.ts
+++ b/apps/readest-app/src/utils/time.ts
@@ -3,6 +3,11 @@ import duration from 'dayjs/plugin/duration';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
 dayjs.extend(duration);
+// At module scope, not only inside `initDayjs`: `formatSyncTimeFromNow` below
+// is called from a hook that unit tests mount directly, where the app's startup
+// `initDayjs` never ran. `extend` is idempotent, so `initDayjs` keeps its call
+// for the locale.
+dayjs.extend(relativeTime);
 
 import 'dayjs/locale/en';
 import 'dayjs/locale/zh';
@@ -40,6 +45,10 @@ export const initDayjs = (locale: string) => {
 // label would read "Synced in an hour" (#5661). Clamp to local now at display
 // time only; the record-derived pull cursor must never be clamped.
 export const clampSyncTimeForDisplay = (time: number): number => Math.min(time, Date.now());
+
+/** The clamped "x minutes ago" used by every "Synced {{time}}" row. */
+export const formatSyncTimeFromNow = (time: number): string =>
+  dayjs(clampSyncTimeForDisplay(time)).fromNow();
 
 // Clock-style playback time for the TTS scrubber: m:ss below one hour,
 // h:mm:ss above. Pass forceHours so both labels of a row share the format


### PR DESCRIPTION
Fixes #5910.

Independent of #5921 (no shared files); the two can merge in either order.

## Two defects, not one

**The label.** `ViewMenu.tsx` built the sync row from `config.lastSyncedAtConfig` / `lastSyncedAtNotes` / `lastPushedAtConfig` / `lastPushedAtNotes` — all four written only by `useProgressSync` / `useNotesSync`, i.e. Readest Cloud. File sync records `settings[backend].lastSyncedAt` instead, which that row never read. Hence "Never synced" for a working WebDAV / iCloud / Drive / S3 setup, and "Sign in to Sync" for a user with no Readest account at all even though their sync was fine.

**The tap did nothing.** Not in the report: `handleSync` dispatched `sync-book-progress`, whose only listeners are `useProgressSync` and `useHardcoverSync`. `useFileSync` and `useKOSync` do not subscribe, so for a third-party-only user that menu item was inert, not merely mislabelled.

## The fix

Both surfaces that answer "is my sync healthy?" now share one `useCloudSyncStatus` hook. The library Settings menu already had this logic and had it right; the reader never got it, which is exactly how the two drifted apart — sharing it is the point, not a drive-by refactor.

The hook reports each selected provider's own timestamp, in-flight and failed state; gates the native cursors on whether Readest Cloud is actually enabled (they freeze rather than reset when the channels are gated, so a stale value would report a disabled provider as recently synced); and drops backends that cannot run right now.

Against the issue's list:

- **Only third-party enabled** — the row shows that provider's status and never "Sign in to Sync".
- **Only Readest Cloud** — unchanged.
- **Both** — the row shows the freshest status with a "Synced via …" subtitle (a count once there are several, since full names overrun the row), and the **Sync Info** dialog behind the ⓘ lists each provider on its own line with its own timestamp — the "Readest Cloud — 5 minutes ago / WebDAV — 2 minutes ago" breakdown the issue sketched.
- **States** — Syncing…, Synced {time}, Sync failed, Never synced, resolved per provider.

The tap now reaches every provider. `useFileSync` already listened for `push-file-sync` / `pull-file-sync`, so no hook change was needed; `flush-kosync` rides along. The login bounce is gated on `needsSignIn` rather than `!user`.

`HeaderBar` now feeds the dialog the push stamps too, so the dialog and the row cannot disagree about the same book.

## Two things worth a look in review

**`needsSignIn` also requires Readest Cloud to be among the selected providers.** With Google Drive selected but its web token expired, `isReadestCloudEnabled` is false and no provider can run — but "Sign in to Sync" would be a lie, because signing in would not help. Drive's own settings row already carries the Reconnect CTA.

**`dayjs.extend(relativeTime)` moves to module scope in `utils/time.ts`.** It ran only inside `initDayjs()` at app startup, so `.fromNow()` threw the moment a unit test mounted the hook directly — a latent dependency on a global side effect that nothing had exercised. `formatSyncTimeFromNow` now owns that formatting for both surfaces.

## Scope note

The library Settings row inherits the shared label, so a signed-out user with no provider configured now sees "Sign in to Sync" instead of "Never synced", and its icon follows failed / needs-sign-in rather than `!user`. That is the same true statement the reader makes, but it is a second surface changing — easy to revert if you'd rather it stayed as it was.

KOSync is poked by the manual action but contributes no timestamp: `KOSyncSettings` keeps no `lastSyncedAt` to report. Follow-up if it should appear in the breakdown.

## Test plan

- `useCloudSyncStatus.test.ts` — third-party-synced with no account, the sign-in case, the disabled-Readest-Cloud gate, both providers listed separately, in-flight, failed-over-stale-success, and the can't-run-right-now case.
- `ViewMenu-sync-row.test.tsx` — the label with no account, all four events dispatched on tap, the login bounce still firing when Readest Cloud is the only provider, and the multi-provider subtitle.
- `pnpm test` 10353 passed / 16 skipped, `pnpm lint` clean, `pnpm format:check` clean.

Three new i18n strings, translated into all 34 locales by adapting the existing "Library sync via …" entries — the same phrase, already localized everywhere, so vocabulary and plural forms match what ships.

Not verified on a device.

## AI assistance disclosure

Root-caused and implemented with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sync status now clearly shows activity across selected providers, including provider names, timestamps, syncing progress, and failures.
  * Sync details display separate status information for each active provider.
  * Third-party sync providers can be used without signing in to Readest Cloud.
  * Added localized sync-status messages across supported languages.

* **Bug Fixes**
  * Improved handling of stale, unavailable, expired, or failed sync providers.
  * Sync timestamps now include cloud push activity.
  * Fixed relative sync-time formatting in all contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->