### PR TITLE
fix(ui): search cloud storage files on demand instead of while typing (#5923)

### DIFF
--- a/apps/readest-app/src/__tests__/app/user/StorageManager.test.tsx
+++ b/apps/readest-app/src/__tests__/app/user/StorageManager.test.tsx
@@ -1,0 +1,129 @@
+import { cleanup, createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import StorageManager from '@/app/user/components/StorageManager';
+import type { ListFilesParams } from '@/libs/storage';
+
+const h = vi.hoisted(() => ({
+  listFiles: vi.fn(),
+  getStorageStats: vi.fn(),
+  purgeFiles: vi.fn(),
+  // Stable identity: the real useTranslation memoizes, and StorageManager's
+  // loaders depend on it.
+  translate: (value: string, params?: Record<string, string | number>) =>
+    Object.entries(params ?? {}).reduce(
+      (result: string, [key, replacement]) => result.replace(`{{${key}}}`, String(replacement)),
+      value,
+    ),
+}));
+
+vi.mock('@/libs/storage', () => ({
+  listFiles: h.listFiles,
+  getStorageStats: h.getStorageStats,
+  purgeFiles: h.purgeFiles,
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => h.translate,
+}));
+
+vi.mock('@/hooks/useLibrary', () => ({
+  useLibrary: () => ({ libraryLoaded: true }),
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: null, envConfig: {} }),
+}));
+
+vi.mock('@/store/themeStore', () => ({
+  useThemeStore: () => ({ safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 } }),
+}));
+
+vi.mock('@/store/libraryStore', () => ({
+  useLibraryStore: { getState: () => ({ library: [], setLibrary: vi.fn() }) },
+}));
+
+const searchParams = () =>
+  h.listFiles.mock.calls.map((call) => (call[0] as ListFilesParams).search);
+
+describe('StorageManager search', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    h.listFiles.mockReset();
+    h.listFiles.mockResolvedValue({ files: [], totalPages: 1 });
+    h.getStorageStats.mockReset();
+    h.getStorageStats.mockResolvedValue({
+      totalFiles: 0,
+      totalSize: 0,
+      quota: 100,
+      usagePercentage: 0,
+    });
+  });
+
+  it('does not search while the user is still typing', async () => {
+    render(<StorageManager />);
+    await waitFor(() => expect(h.listFiles).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByPlaceholderText('Search files...');
+    fireEvent.change(input, { target: { value: '中文' } });
+
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    expect(h.listFiles).toHaveBeenCalledTimes(1);
+    expect(searchParams()).toEqual([undefined]);
+  });
+
+  it('searches when the search button is pressed', async () => {
+    render(<StorageManager />);
+    await waitFor(() => expect(h.listFiles).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByPlaceholderText('Search files...');
+    fireEvent.change(input, { target: { value: ' novel ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => expect(h.listFiles).toHaveBeenCalledTimes(2));
+    expect(searchParams()).toEqual([undefined, 'novel']);
+  });
+
+  it('ignores Enter while an IME composition is active', async () => {
+    render(<StorageManager />);
+    await waitFor(() => expect(h.listFiles).toHaveBeenCalledTimes(1));
+
+    const input = screen.getByPlaceholderText('Search files...');
+    fireEvent.change(input, { target: { value: 'zhong' } });
+
+    const composing = createEvent.keyDown(input, { key: 'Enter', isComposing: true });
+    fireEvent(input, composing);
+    expect(composing.defaultPrevented).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(h.listFiles).toHaveBeenCalledTimes(1);
+
+    const committed = createEvent.keyDown(input, { key: 'Enter' });
+    fireEvent(input, committed);
+    expect(committed.defaultPrevented).toBe(false);
+  });
+
+  it('keeps the search box editable while files are loading', async () => {
+    let resolveList: (value: { files: never[]; totalPages: number }) => void = () => {};
+    h.listFiles.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveList = resolve;
+        }),
+    );
+
+    render(<StorageManager />);
+    const input = screen.getByPlaceholderText('Search files...');
+    expect((input as HTMLInputElement).disabled).toBe(false);
+
+    fireEvent.change(input, { target: { value: 'keep typing' } });
+    expect((input as HTMLInputElement).value).toBe('keep typing');
+
+    resolveList({ files: [], totalPages: 1 });
+    await waitFor(() => expect(h.listFiles).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/readest-app/src/app/user/components/StorageManager.tsx
+++ b/apps/readest-app/src/app/user/components/StorageManager.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import clsx from 'clsx';
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import { MdSearch } from 'react-icons/md';
 import { useEnv } from '@/context/EnvContext';
 import { useThemeStore } from '@/store/themeStore';
 import { useLibraryStore } from '@/store/libraryStore';
@@ -16,7 +17,6 @@ import {
   type ListFilesParams,
 } from '@/libs/storage';
 import { eventDispatcher } from '@/utils/event';
-import { debounce } from '@/utils/debounce';
 import Spinner from '@/components/Spinner';
 import Alert from '@/components/Alert';
 
@@ -242,18 +242,13 @@ const StorageManager = () => {
     }
   };
 
-  const handleSearchChange = useMemo(
-    () =>
-      debounce((value: string) => {
-        setSearchQuery(value);
-        setCurrentPage(1);
-      }, 1000),
-    [setSearchQuery, setCurrentPage],
-  );
-
-  useEffect(() => {
-    handleSearchChange(searchInput);
-  }, [searchInput, handleSearchChange]);
+  // Search runs only when it is asked for. Searching as the user types
+  // interrupts IME candidate selection and long queries, and the pending
+  // request steals the input while it loads.
+  const submitSearch = () => {
+    setSearchQuery(searchInput.trim());
+    setCurrentPage(1);
+  };
 
   const formatFileSize = (bytes: number): string => {
     if (bytes === 0) return '0 B';
@@ -338,14 +333,32 @@ const StorageManager = () => {
           </div>
 
           <div className='flex flex-col gap-2 sm:flex-row'>
-            <input
-              type='text'
-              placeholder={_('Search files...')}
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
-              className='input input-sm w-full sm:w-64'
-              disabled={loading}
-            />
+            <form
+              className='flex gap-2'
+              onSubmit={(e) => {
+                e.preventDefault();
+                submitSearch();
+              }}
+            >
+              <input
+                type='search'
+                placeholder={_('Search files...')}
+                aria-label={_('Search files...')}
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                onKeyDown={(e) => {
+                  // Enter commits the IME candidate; it must not submit too.
+                  if (e.key === 'Enter' && e.nativeEvent.isComposing) {
+                    e.preventDefault();
+                  }
+                }}
+                className='input input-sm eink-bordered w-full min-w-0 sm:w-64'
+              />
+              <button type='submit' className='btn btn-sm btn-contrast shrink-0' disabled={loading}>
+                <MdSearch className='h-4 w-4' />
+                {_('Search')}
+              </button>
+            </form>
 
             <select
               value={`${sortBy}-${sortOrder}`}


### PR DESCRIPTION
Fixes #5923.

## The problem

The file search in **Manage Storage** (`StorageManager.tsx`) ran on a 1s debounce
after the last keystroke, and the input carried `disabled={loading}`.

For anyone typing through an IME those are two defects that compound:

1. the debounce fires **mid-composition**, and
2. the request it starts then **disables the box the user is composing into**,
   dropping focus and the pending candidate with it.

Long queries and intermittent typing hit the same wall without the composition
part. The reporter's words: 「尤其是中文输入法，它会打断选词流程」.

## The fix

- Search runs only when asked for. The input and a `Search` button sit in a
  `<form>`, so Enter and the button do the same thing, and `type='search'` gets
  the mobile keyboard a Search key.
- `loading` no longer touches the input, only the submit button, so results can
  load while typing continues.
- Enter is also what commits an IME candidate, so a keydown carrying
  `isComposing` is swallowed rather than allowed to reach the form's implicit
  submission.

This matches how `HardcoverLinkDialog` already searches. Nothing else in the app
searches as you type into a box it then disables.

## Tests

New `src/__tests__/app/user/StorageManager.test.tsx`, 4 cases:

| case | asserts |
| --- | --- |
| no search while typing | 1.2s after a change event, still only the mount fetch |
| button searches | `listFiles` called with the trimmed query |
| IME guard | composing Enter is `defaultPrevented` and fires nothing; a plain Enter is not prevented |
| input stays live | the box is enabled and editable with a request in flight |

All four fail against the old component and pass against the new one (checked by
reverting the file and re-running).

## Verification

- `pnpm test` — 10370 passed. The one failure, `src/__tests__/app/reader/components/notebook/Notebook.test.tsx`, is untracked local work unrelated to this branch.
- `pnpm lint` and `pnpm format:check` clean.
- Not checked in a real browser: the page sits behind cloud sign-in. The markup
  change is a form wrapper around the existing input, so the risk is a layout
  nit, not behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explicit search button and form-based search workflow.
  * Search results now refresh when the form is submitted and pagination resets automatically.
  * The search field remains editable while files are loading.
  * Improved handling of Enter during text composition to prevent unintended searches.

* **Tests**
  * Added coverage for search submission, typing behavior, loading states, and IME composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->