### PR TITLE
fix(reader): stop the a11y skip link from padding RTL sections with blank pages (#5924)

### DIFF
--- a/apps/readest-app/src/utils/a11y.ts
+++ b/apps/readest-app/src/utils/a11y.ts
@@ -64,9 +64,16 @@ export const handleA11yNavigation = (
     skipLink.setAttribute('tabindex', '0');
     skipLink.setAttribute('aria-hidden', 'false');
     skipLink.setAttribute('aria-label', options?.skipToLastPosLabel ?? '');
+    // position:absolute keeps the link out of flow; left/top:auto leave it at
+    // its static position. `left: 0` resolves against the *initial containing
+    // block* — the iframe viewport, which the paginator expands to hold every
+    // rendered column — so in an RTL book (columns flowing right-to-left) the
+    // box landed past the end of the text. expand() sizes the section from a
+    // Range over the body contents, so that stray 1×1 box stretched the section
+    // to the full iframe width and appended blank pages mid-chapter (#5924).
     Object.assign(skipLink.style, {
       position: 'absolute',
-      left: '0px',
+      left: 'auto',
       top: 'auto',
       width: '1px',
       height: '1px',


### PR DESCRIPTION
Fixes #5924

## Symptom

2-4 completely blank pages in the middle of a chapter in a Persian (RTL) EPUB. The text does not start a new section — it just continues after the blanks. Reporter saw it on an Onyx Boox Go 7 but not on a Pixel; reproducible on desktop by slightly resizing the window.

## Root cause

`handleA11yNavigation()` injects the "skip to reading position" link as an absolutely positioned 1×1 box with `left: 0`.

`position: absolute` with `left: 0` resolves against the **initial containing block** — the iframe viewport, which foliate's paginator has already expanded to hold every rendered column — not the single-column `<html>` box (`documentElement.style.width = columnSize`).

In an RTL book the columns flow right-to-left, so the iframe's left edge is *past the end* of the text. `paginator.js` `expand()` sizes each section from a `Range` over the body contents:

```js
const contentRect = this.#contentRange.getBoundingClientRect()
const contentStart = this.#rtl ? rootRect.right - contentRect.right : contentRect.left - rootRect.left
const pageCount = Math.ceil((contentStart + contentRect[side]) / columnSize)
```

The stray box at x=0 pulled `contentRect.left` to the iframe's left edge, so `contentSize` came out **exactly equal to the current iframe width** — a ratchet the section can never shrink out of. Measured live on the reporter's book (RTL, 613px columns):

| section element width | measured `contentSize` (`left: 0`) | real `contentSize` (`left: auto`) | pages rendered vs. real |
| --- | --- | --- | --- |
| 4291 | 4291 | 3654 | 7 vs 6 |
| **5517** | **5517** | **1815** | **9 vs 3** |
| 2452 | 2452 | 2428 | 4 vs 4 |
| 3065 | 3065 | 2428 | 5 vs 4 |

The 5517px section rendered 9 columns for 3 columns of text — 6 blank pages. This is why it needs a relayout to show up (the first layout happens before the iframe is expanded) and why it looks device-dependent: it only bites when the new layout needs fewer columns than the old iframe width.

It also only affects RTL. In LTR the ICB's left edge is where the flow *starts*, so `left: 0` is always inside the content.

## Fix

Use `left: auto` so the out-of-flow box stays at its static position inside the first column. This matches the sibling next-section skip link, which already sets `left/top: auto` and documents the same column-break hazard (#4126). Accessibility is unchanged — the link is still `body`'s first child, so NVDA's virtual cursor still lands on it first.

## Verification

Chrome at `localhost:3000`, reporter's EPUB:

- **Before:** page 21/1092 renders completely blank, and 6 consecutive `next()` calls stay blank before text returns.
- **After:** every section measures its real content (`contentSize` is now 19px under the element width — the trailing partial column — instead of pinned to it), and walking pages 21-25 plus 45 pages from the book start after two window resizes finds zero blank pages.

`pnpm lint` clean. `pnpm test` / `pnpm test:browser` pass (the one failing unit test, `Notebook.test.tsx`, is an untracked work-in-progress file that fails on `main` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue affecting right-to-left books where hidden accessibility skip links could create unexpected blank pages within chapters.
  * Improved pagination behavior by preventing the reading view from expanding unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->