### PR TITLE
fix(ui): align the keyboard shortcuts header with its group titles

### DIFF
--- a/apps/readest-app/src/components/settings/KeyboardShortcutsSettings.tsx
+++ b/apps/readest-app/src/components/settings/KeyboardShortcutsSettings.tsx
@@ -240,7 +240,10 @@ const KeyboardShortcutsSettings: React.FC<KeyboardShortcutsSettingsProps> = ({ o
         }
       />
 
-      <div className='space-y-6 px-4 pb-4'>
+      {/* No px-4 here: BoxedList's `SectionTitle` carries its own `ps-4`, so the
+          group titles line up with the SubPageHeader breadcrumb and the cards
+          bleed to the panel edge — the same shape as the Integrations panel. */}
+      <div className='space-y-6 pb-4'>
         {SHORTCUT_SECTIONS.map((section) => {
           const actions = (Object.keys(shortcuts) as ShortcutAction[]).filter(
             (action) => shortcuts[action].section === section,


### PR DESCRIPTION
## Problem

In Settings → Behavior → Keyboard Shortcuts, the breadcrumb and the description were indented 16px less than the "General" group title below them, and the whole panel sat one step further in than every other settings panel.

The sub-page wrapped its boxed lists in an extra `px-4`. `SectionTitle` already carries its own `ps-4`, so the two stacked: group titles landed at 32px while `SubPageHeader` stayed at 16px, and the cards were inset instead of bleeding to the panel edge.

## Fix

One line: drop the wrapper's `px-4`.

- Breadcrumb, description, and group titles all start at 16px.
- Cards bleed to the panel edge, the same shape as `IntegrationsPanel` and the parent `ControlPanel`.
- Row labels don't move — the card's inner `ps-4` still holds them level with the group title, and `SettingsRow`'s `pe-4` keeps the trailing controls where they were.
- `ps-*` is logical, so RTL is unaffected.

## Verification

- `pnpm lint` (tsc + Biome) clean
- `pnpm test` — 10370 passed, 16 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the keyboard shortcuts settings layout so section cards extend to the panel edges.
  * Improved alignment between section titles, breadcrumbs, and settings content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->