### PR TITLE
feat(grouping): Adding existing status as Grouping

### DIFF
--- a/apps/readest-app/public/locales/ar/translation.json
+++ b/apps/readest-app/public/locales/ar/translation.json
@@ -2509,5 +2509,6 @@
   "{{count}} Annotations_few": "{{count}} تعليقات توضيحية",
   "{{count}} Annotations_many": "{{count}} تعليقًا توضيحيًا",
   "{{count}} Annotations_other": "{{count}} تعليق توضيحي",
-  "Insert into Notebook": "إدراج في المفكرة"
+  "Insert into Notebook": "إدراج في المفكرة",
+  "Reading": "قيد القراءة"
 }

--- a/apps/readest-app/public/locales/bn/translation.json
+++ b/apps/readest-app/public/locales/bn/translation.json
@@ -2265,5 +2265,6 @@
   "With notes": "নোটসহ",
   "{{count}} Annotations_one": "{{count}} টীকা",
   "{{count}} Annotations_other": "{{count}} টীকা",
-  "Insert into Notebook": "নোটবুকে যোগ করুন"
+  "Insert into Notebook": "নোটবুকে যোগ করুন",
+  "Reading": "পড়া হচ্ছে"
 }

--- a/apps/readest-app/public/locales/bo/translation.json
+++ b/apps/readest-app/public/locales/bo/translation.json
@@ -2204,5 +2204,6 @@
   "Notebook draft copied to clipboard": "ཟིན་དེབ་ཀྱི་སྔོན་བྲིས་འདྲ་བཤུས་ལྡེ་མིག་ཏུ་བྱས་ཟིན།",
   "With notes": "ཟིན་བྲིས་ཡོད་པ།",
   "{{count}} Annotations_other": "མཆན་ {{count}}",
-  "Insert into Notebook": "ཟིན་དེབ་ནང་འཇུག་པ།"
+  "Insert into Notebook": "ཟིན་དེབ་ནང་འཇུག་པ།",
+  "Reading": "ཀློག་བཞིན་པ།"
 }

--- a/apps/readest-app/public/locales/de/translation.json
+++ b/apps/readest-app/public/locales/de/translation.json
@@ -2265,5 +2265,6 @@
   "With notes": "Mit Notizen",
   "{{count}} Annotations_one": "{{count}} Anmerkung",
   "{{count}} Annotations_other": "{{count}} Anmerkungen",
-  "Insert into Notebook": "In Notizbuch einfügen"
+  "Insert into Notebook": "In Notizbuch einfügen",
+  "Reading": "Wird gelesen"
 }

--- a/apps/readest-app/public/locales/el/translation.json
+++ b/apps/readest-app/public/locales/el/translation.json
@@ -2265,5 +2265,6 @@
   "With notes": "Με σημειώσεις",
   "{{count}} Annotations_one": "{{count}} σχολιασμός",
   "{{count}} Annotations_other": "{{count}} σχολιασμοί",
-  "Insert into Notebook": "Εισαγωγή στο σημειωματάριο"
+  "Insert into Notebook": "Εισαγωγή στο σημειωματάριο",
+  "Reading": "Σε ανάγνωση"
 }

--- a/apps/readest-app/public/locales/es/translation.json
+++ b/apps/readest-app/public/locales/es/translation.json
@@ -2326,5 +2326,6 @@
   "{{count}} Annotations_one": "{{count}} anotación",
   "{{count}} Annotations_many": "{{count}} anotaciones",
   "{{count}} Annotations_other": "{{count}} anotaciones",
-  "Insert into Notebook": "Insertar en el cuaderno"
+  "Insert into Notebook": "Insertar en el cuaderno",
+  "Reading": "Leyendo"
 }

--- a/apps/readest-app/public/locales/fa/translation.json
+++ b/apps/readest-app/public/locales/fa/translation.json
@@ -2265,5 +2265,6 @@
   "With notes": "با یادداشت",
   "{{count}} Annotations_one": "{{count}} یادداشت",
   "{{count}} Annotations_other": "{{count}} یادداشت",
-  "Insert into Notebook": "درج در دفترچه یادداشت"
+  "Insert into Notebook": "درج در دفترچه یادداشت",
+  "Reading": "در حال خواندن"
 }

--- a/apps/readest-app/public/locales/fr/translation.json
+++ b/apps/readest-app/public/locales/fr/translation.json
@@ -2326,5 +2326,6 @@
   "{{count}} Annotations_one": "{{count}} annotation",
   "{{count}} Annotations_many": "{{count}} annotations",
   "{{count}} Annotations_other": "{{count}} annotations",
-  "Insert into Notebook": "Insérer dans le carnet de notes"
+  "Insert into Notebook": "Insérer dans le carnet de notes",
+  "Reading": "En cours de lecture"
 }

--- a/apps/readest-app/public/locales/he/translation.json
+++ b/apps/readest-app/public/locales/he/translation.json
@@ -2326,5 +2326,6 @@
   "{{count}} Annotations_one": "{{count}} הערה",
   "{{count}} Annotations_two": "{{count}} הערות",
   "{{count}} Annotations_other": "{{count}} הערות",
-  "Insert into Notebook": "הוסף למחברת"
+  "Insert into Notebook": "הוסף למחברת",
+  "Reading": "בקריאה"
 }

--- a/apps/readest-app/public/locales/hi/translation.json
+++ b/apps/readest-app/public/locales/hi/translation.json
@@ -2265,5 +2265,6 @@
   "With notes": "नोट्स सहित",
   "{{count}} Annotations_one": "{{count}} टिप्पणी",
   "{{count}} Annotations_other": "{{count}} टिप्पणियाँ",
-  "Insert into Notebook": "नोटबुक में डालें"
+  "Insert into Notebook": "नोटबुक में डालें",
+  "Reading": "पढ़ रहे हैं"
 }

--- a/apps/readest-app/public/locales/hu/translation.json
+++ b/apps/readest-app/public/locales/hu/translation.json
@@ -2265,5 +2265,6 @@
   "With notes": "Jegyzettel",
   "{{count}} Annotations_one": "{{count}} megjegyzés",
   "{{count}} Annotations_other": "{{count}} megjegyzés",
-  "Insert into Notebook": "Beszúrás a jegyzetfüzetbe"
+  "Insert into Notebook": "Beszúrás a jegyzetfüzetbe",
+  "Reading": "Olvasás alatt"
 }

--- a/apps/readest-app/public/locales/id/translation.json
+++ b/apps/readest-app/public/locales/id/translation.json
@@ -2204,5 +2204,6 @@
   "Notebook draft copied to clipboard": "Draf Buku Catatan disalin ke papan klip",
   "With notes": "Dengan catatan",
   "{{count}} Annotations_other": "{{count}} anotasi",
-  "Insert into Notebook": "Sisipkan ke Buku Catatan"
+  "Insert into Notebook": "Sisipkan ke Buku Catatan",
+  "Reading": "Sedang dibaca"
 }

--- a/apps/readest-app/public/locales/it/translation.json
+++ b/apps/readest-app/public/locales/it/translation.json
@@ -2326,5 +2326,6 @@
   "{{count}} Annotations_one": "{{count}} annotazione",
   "{{count}} Annotations_many": "{{count}} annotazioni",
   "{{count}} Annotations_other": "{{count}} annotazioni",
-  "Insert into Notebook": "Inserisci nel quaderno"
+  "Insert into Notebook": "Inserisci nel quaderno",
+  "Reading": "In lettura"
 }

--- a/apps/readest-app/public/locales/ja/translation.json
+++ b/apps/readest-app/public/locales/ja/translation.json
@@ -2204,5 +2204,6 @@
   "Notebook draft copied to clipboard": "ノートの下書きをクリップボードにコピーしました",
   "With notes": "メモ付き",
   "{{count}} Annotations_other": "{{count}} 件の注釈",
-  "Insert into Notebook": "ノートに挿入"
+  "Insert into Notebook": "ノートに挿入",
+  "Reading": "読書中"
 }

--- a/apps/readest-app/public/locales/ka/translation.json
+++ b/apps/readest-app/public/locales/ka/translation.json
@@ -2265,5 +2265,6 @@
   "With notes": "შენიშვნებით",
   "{{count}} Annotations_one": "{{count}} ანოტაცია",
   "{{count}} Annotations_other": "{{count}} ანოტაცია",
-  "Insert into Notebook": "რვეულში ჩასმა"
+  "Insert into Notebook": "რვეულში ჩასმა",
+  "Reading": "იკითხება"
 }

--- a/apps/readest-app/public/locales/ko/translation.json
+++ b/apps/readest-app/public/locales/ko/translation.json
@@ -2204,5 +2204,6 @@
   "Notebook draft copied to clipboard": "노트북 초안이 클립보드에 복사되었습니다",
   "With notes": "메모 있음",
   "{{count}} Annotations_other": "주석 {{count}}개",
-  "Insert into Notebook": "노트북에 삽입"
+  "Insert into Notebook": "노트북에 삽입",
+  "Reading": "읽는 중"
 }

--- a/apps/readest-app/public/locales/ms/translation.json
+++ b/apps/readest-app/public/locales/ms/translation.json
@@ -2204,5 +2204,6 @@
   "Notebook draft copied to clipboard": "Draf Buku Nota disalin ke papan klip",
   "With notes": "Dengan nota",
   "{{count}} Annotations_other": "{{count}} anotasi",
-  "Insert into Notebook": "Sisipkan ke Buku Nota"
+  "Insert into Notebook": "Sisipkan ke Buku Nota",
+  "Reading": "Sedang dibaca"
 }

--- a/apps/readest-app/public/locales/nl/translation.json
+++ b/apps/readest-app/public/locales/nl/translation.json
@@ -2265,5 +2265,6 @@
   "With notes": "Met notities",
   "{{count}} Annotations_one": "{{count}} aantekening",
   "{{count}} Annotations_other": "{{count}} aantekeningen",
-  "Insert into Notebook": "Invoegen in notitieblok"
+  "Insert into Notebook": "Invoegen in notitieblok",
+  "Reading": "Wordt gelezen"
 }

--- a/apps/readest-app/public/locales/pl/translation.json
+++ b/apps/readest-app/public/locales/pl/translation.json
@@ -2387,5 +2387,6 @@
   "{{count}} Annotations_few": "{{count}} adnotacje",
   "{{count}} Annotations_many": "{{count}} adnotacji",
   "{{count}} Annotations_other": "{{count}} adnotacji",
-  "Insert into Notebook": "Wstaw do notatnika"
+  "Insert into Notebook": "Wstaw do notatnika",
+  "Reading": "W trakcie czytania"
 }

--- a/apps/readest-app/public/locales/pt-BR/translation.json
+++ b/apps/readest-app/public/locales/pt-BR/translation.json
@@ -2326,5 +2326,6 @@
   "{{count}} Annotations_one": "{{count}} anotação",
   "{{count}} Annotations_many": "{{count}} anotações",
   "{{count}} Annotations_other": "{{count}} anotações",
-  "Insert into Notebook": "Inserir no caderno"
+  "Insert into Notebook": "Inserir no caderno",
+  "Reading": "Lendo"
 }

--- a/apps/readest-app/public/locales/pt/translation.json
+++ b/apps/readest-app/public/locales/pt/translation.json
@@ -2326,5 +2326,6 @@
   "{{count}} Annotations_one": "{{count}} anotação",
   "{{count}} Annotations_many": "{{count}} anotações",
   "{{count}} Annotations_other": "{{count}} anotações",
-  "Insert into Notebook": "Inserir no caderno"
+  "Insert into Notebook": "Inserir no caderno",
+  "Reading": "A ler"
 }

--- a/apps/readest-app/public/locales/ro/translation.json
+++ b/apps/readest-app/public/locales/ro/translation.json
@@ -2326,5 +2326,6 @@
   "{{count}} Annotations_one": "{{count}} adnotare",
   "{{count}} Annotations_few": "{{count}} adnotări",
   "{{count}} Annotations_other": "{{count}} de adnotări",
-  "Insert into Notebook": "Inserează în carnețel"
+  "Insert into Notebook": "Inserează în carnețel",
+  "Reading": "În curs de citire"
 }

--- a/apps/readest-app/public/locales/ru/translation.json
+++ b/apps/readest-app/public/locales/ru/translation.json
@@ -2387,5 +2387,6 @@
   "{{count}} Annotations_few": "{{count}} аннотации",
   "{{count}} Annotations_many": "{{count}} аннотаций",
   "{{count}} Annotations_other": "{{count}} аннотаций",
-  "Insert into Notebook": "Вставить в блокнот"
+  "Insert into Notebook": "Вставить в блокнот",
+  "Reading": "Читаю"
 }

--- a/apps/readest-app/public/locales/si/translation.json
+++ b/apps/readest-app/public/locales/si/translation.json
@@ -2265,5 +2265,6 @@
   "With notes": "සටහන් සමඟ",
   "{{count}} Annotations_one": "{{count}} අනුසටහන",
   "{{count}} Annotations_other": "{{count}} අනුසටහන්",
-  "Insert into Notebook": "සටහන් පොතට ඇතුළු කරන්න"
+  "Insert into Notebook": "සටහන් පොතට ඇතුළු කරන්න",
+  "Reading": "කියවමින්"
 }

--- a/apps/readest-app/public/locales/sl/translation.json
+++ b/apps/readest-app/public/locales/sl/translation.json
@@ -2387,5 +2387,6 @@
   "{{count}} Annotations_two": "{{count}} opombi",
   "{{count}} Annotations_few": "{{count}} opombe",
   "{{count}} Annotations_other": "{{count}} opomb",
-  "Insert into Notebook": "Vstavi v beležnico"
+  "Insert into Notebook": "Vstavi v beležnico",
+  "Reading": "V branju"
 }

--- a/apps/readest-app/public/locales/sv/translation.json
+++ b/apps/readest-app/public/locales/sv/translation.json
@@ -2265,5 +2265,6 @@
   "With notes": "Med anteckningar",
   "{{count}} Annotations_one": "{{count}} anteckning",
   "{{count}} Annotations_other": "{{count}} anteckningar",
-  "Insert into Notebook": "Infoga i anteckningsboken"
+  "Insert into Notebook": "Infoga i anteckningsboken",
+  "Reading": "Läser"
 }

--- a/apps/readest-app/public/locales/ta/translation.json
+++ b/apps/readest-app/public/locales/ta/translation.json
@@ -2265,5 +2265,6 @@
   "With notes": "குறிப்புகளுடன்",
   "{{count}} Annotations_one": "{{count}} சிறுகுறிப்பு",
   "{{count}} Annotations_other": "{{count}} சிறுகுறிப்புகள்",
-  "Insert into Notebook": "குறிப்பேட்டில் செருகவும்"
+  "Insert into Notebook": "குறிப்பேட்டில் செருகவும்",
+  "Reading": "படிக்கிறேன்"
 }

--- a/apps/readest-app/public/locales/th/translation.json
+++ b/apps/readest-app/public/locales/th/translation.json
@@ -2204,5 +2204,6 @@
   "Notebook draft copied to clipboard": "คัดลอกฉบับร่างสมุดบันทึกไปยังคลิปบอร์ดแล้ว",
   "With notes": "มีบันทึกย่อ",
   "{{count}} Annotations_other": "คำอธิบายประกอบ {{count}} รายการ",
-  "Insert into Notebook": "แทรกลงในสมุดบันทึก"
+  "Insert into Notebook": "แทรกลงในสมุดบันทึก",
+  "Reading": "กำลังอ่าน"
 }

--- a/apps/readest-app/public/locales/tr/translation.json
+++ b/apps/readest-app/public/locales/tr/translation.json
@@ -2265,5 +2265,6 @@
   "With notes": "Notlu",
   "{{count}} Annotations_one": "{{count}} açıklama",
   "{{count}} Annotations_other": "{{count}} açıklama",
-  "Insert into Notebook": "Not defterine ekle"
+  "Insert into Notebook": "Not defterine ekle",
+  "Reading": "Okunuyor"
 }

--- a/apps/readest-app/public/locales/uk/translation.json
+++ b/apps/readest-app/public/locales/uk/translation.json
@@ -2387,5 +2387,6 @@
   "{{count}} Annotations_few": "{{count}} анотації",
   "{{count}} Annotations_many": "{{count}} анотацій",
   "{{count}} Annotations_other": "{{count}} анотацій",
-  "Insert into Notebook": "Вставити в нотатник"
+  "Insert into Notebook": "Вставити в нотатник",
+  "Reading": "Читаю"
 }

--- a/apps/readest-app/public/locales/uz/translation.json
+++ b/apps/readest-app/public/locales/uz/translation.json
@@ -2265,5 +2265,6 @@
   "With notes": "Eslatmali",
   "{{count}} Annotations_one": "{{count}} izoh",
   "{{count}} Annotations_other": "{{count}} ta izoh",
-  "Insert into Notebook": "Daftarga qoʻshish"
+  "Insert into Notebook": "Daftarga qoʻshish",
+  "Reading": "Oʻqilmoqda"
 }

--- a/apps/readest-app/public/locales/vi/translation.json
+++ b/apps/readest-app/public/locales/vi/translation.json
@@ -2204,5 +2204,6 @@
   "Notebook draft copied to clipboard": "Đã sao chép bản nháp sổ ghi chép vào bảng ghi",
   "With notes": "Có ghi chú",
   "{{count}} Annotations_other": "{{count}} chú thích",
-  "Insert into Notebook": "Chèn vào sổ ghi chép"
+  "Insert into Notebook": "Chèn vào sổ ghi chép",
+  "Reading": "Đang đọc"
 }

--- a/apps/readest-app/public/locales/zh-CN/translation.json
+++ b/apps/readest-app/public/locales/zh-CN/translation.json
@@ -2204,5 +2204,6 @@
   "Notebook draft copied to clipboard": "笔记本草稿已复制到剪贴板",
   "With notes": "含笔记",
   "{{count}} Annotations_other": "{{count}} 条注释",
-  "Insert into Notebook": "插入到笔记本"
+  "Insert into Notebook": "插入到笔记本",
+  "Reading": "在读"
 }

--- a/apps/readest-app/public/locales/zh-TW/translation.json
+++ b/apps/readest-app/public/locales/zh-TW/translation.json
@@ -2204,5 +2204,6 @@
   "Notebook draft copied to clipboard": "筆記本草稿已複製到剪貼板",
   "With notes": "含筆記",
   "{{count}} Annotations_other": "{{count}} 則註解",
-  "Insert into Notebook": "插入到筆記本"
+  "Insert into Notebook": "插入到筆記本",
+  "Reading": "閱讀中"
 }

--- a/apps/readest-app/src/__tests__/app/library/group-header.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/group-header.test.tsx
@@ -4,8 +4,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import GroupHeader from '@/app/library/components/GroupHeader';
 import { LibraryGroupByType } from '@/types/settings';
 
+// Stand-in for a non-English locale: keys the app ships translations for come
+// back translated, everything else falls through to the key (i18next's
+// key-as-content fallback).
+const FAKE_LOCALE: Record<string, string> = {
+  Status: 'Statut',
+  'On hold': 'En pause',
+};
+
 vi.mock('@/hooks/useTranslation', () => ({
-  useTranslation: () => (key: string) => key,
+  useTranslation: () => (key: string) => FAKE_LOCALE[key] ?? key,
 }));
 
 vi.mock('@/hooks/useResponsiveSize', () => ({
@@ -61,5 +69,22 @@ describe('GroupHeader back button', () => {
     expect(params.get('groupBy')).toBe('author');
     expect(params.get('sort')).toBe('title');
     expect(params.get('group')).toBe('');
+  });
+});
+
+describe('GroupHeader group name', () => {
+  it('translates the name of a localized (status) group', () => {
+    render(<GroupHeader groupBy={LibraryGroupByType.Status} groupName='On hold' localized />);
+
+    expect(screen.getByText('Statut:')).toBeTruthy();
+    expect(screen.getByText('En pause')).toBeTruthy();
+  });
+
+  it('renders a user-authored name verbatim even when it collides with a UI key', () => {
+    // A tag literally named "On hold" must not be translated.
+    render(<GroupHeader groupBy={LibraryGroupByType.Tag} groupName='On hold' />);
+
+    expect(screen.getByText('On hold')).toBeTruthy();
+    expect(screen.queryByText('En pause')).toBeNull();
   });
 });

--- a/apps/readest-app/src/__tests__/app/library/group-item-localized-name.test.tsx
+++ b/apps/readest-app/src/__tests__/app/library/group-item-localized-name.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import type { Book, BooksGroup } from '@/types/book';
+
+/**
+ * Group tiles render `BooksGroup.displayName`. For status groups that string is
+ * an i18n *key* produced by `createBookGroups`; for series/author/tag/subject
+ * groups it is user-authored text. Translating both would rewrite a tag that
+ * happens to collide with a UI string, so the tile must key off `localized`.
+ */
+
+// Stand-in for a non-English locale.
+const FAKE_LOCALE: Record<string, string> = {
+  'On hold': 'En pause',
+  Reading: 'En cours de lecture',
+};
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => FAKE_LOCALE[key] ?? key,
+}));
+
+vi.mock('@/hooks/useResponsiveSize', () => ({
+  useResponsiveSize: (n: number) => n,
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ envConfig: {}, appService: { hasContextMenu: false } }),
+}));
+
+vi.mock('@/store/settingsStore', () => ({
+  useSettingsStore: () => ({ settings: { librarySkeuomorphicCovers: false } }),
+}));
+
+vi.mock('@/components/BookCover', () => ({
+  default: () => <div data-testid='cover' />,
+}));
+
+import GroupItem from '@/app/library/components/GroupItem';
+
+const book = { hash: 'h1', format: 'EPUB', title: 'A Book', updatedAt: 1 } as Book;
+
+const makeGroup = (overrides: Partial<BooksGroup>): BooksGroup => ({
+  id: 'g1',
+  name: 'abandoned',
+  displayName: 'On hold',
+  books: [book],
+  updatedAt: 1,
+  ...overrides,
+});
+
+afterEach(cleanup);
+
+describe.each(['grid', 'list'] as const)('GroupItem name in %s mode', (mode) => {
+  it('translates a localized status group', () => {
+    render(
+      <GroupItem
+        mode={mode}
+        group={makeGroup({ localized: true })}
+        isSelectMode={false}
+        groupSelected={false}
+      />,
+    );
+
+    expect(screen.getByText('En pause')).toBeTruthy();
+    expect(screen.queryByText('On hold')).toBeNull();
+  });
+
+  it('renders a user-authored name verbatim even when it collides with a UI key', () => {
+    render(
+      <GroupItem
+        mode={mode}
+        // A tag literally named "On hold" must survive untranslated.
+        group={makeGroup({ name: 'On hold', displayName: 'On hold' })}
+        isSelectMode={false}
+        groupSelected={false}
+      />,
+    );
+
+    expect(screen.getByText('On hold')).toBeTruthy();
+    expect(screen.queryByText('En pause')).toBeNull();
+  });
+
+  it('translates the derived reading group', () => {
+    render(
+      <GroupItem
+        mode={mode}
+        group={makeGroup({ name: 'reading', displayName: 'Reading', localized: true })}
+        isSelectMode={false}
+        groupSelected={false}
+      />,
+    );
+
+    expect(screen.getByText('En cours de lecture')).toBeTruthy();
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/library-utils.test.ts
+++ b/apps/readest-app/src/__tests__/utils/library-utils.test.ts
@@ -289,6 +289,29 @@ describe('createBookGroups', () => {
       expect(subjectGroups.find(({ name }) => name === 'Science')?.books).toHaveLength(2);
       expect(subjectGroups.find(({ name }) => name === 'Biography')?.books).toHaveLength(1);
     });
+
+    it('groups explicitly assigned reading statuses and leaves unstatused books standalone', () => {
+      const unread = createMockBook({ hash: 'unread', readingStatus: 'unread' });
+      const finished = createMockBook({ hash: 'finished', readingStatus: 'finished' });
+      const onHold = createMockBook({ hash: 'on-hold', readingStatus: 'abandoned' });
+      const unstatused = createMockBook({ hash: 'unstatused' });
+
+      const result = createBookGroups(
+        [unread, finished, onHold, unstatused],
+        LibraryGroupByType.Status,
+      );
+      const groups = result.filter((item): item is BooksGroup => 'books' in item);
+      const standalone = result.filter((item): item is Book => 'format' in item);
+
+      expect(groups.map(({ name }) => name)).toEqual(['unread', 'finished', 'abandoned']);
+      expect(groups.map(({ displayName }) => displayName)).toEqual([
+        'Unread',
+        'Finished',
+        'On Hold',
+      ]);
+      expect(groups.every(({ books }) => books.length > 0)).toBe(true);
+      expect(standalone.map(({ hash }) => hash)).toEqual(['unstatused']);
+    });
   });
 });
 

--- a/apps/readest-app/src/__tests__/utils/library-utils.test.ts
+++ b/apps/readest-app/src/__tests__/utils/library-utils.test.ts
@@ -19,7 +19,7 @@ import {
   resolveCurrentShelfBooks,
   withTimeRemainingLast,
 } from '../../app/library/utils/libraryUtils';
-import { Book, BooksGroup } from '../../types/book';
+import { Book, BooksGroup, ReadingStatus } from '../../types/book';
 import { LibraryGroupByType, LibrarySortByType } from '../../types/settings';
 import { BookMetadata } from '@/libs/document';
 
@@ -290,27 +290,140 @@ describe('createBookGroups', () => {
       expect(subjectGroups.find(({ name }) => name === 'Biography')?.books).toHaveLength(1);
     });
 
-    it('groups explicitly assigned reading statuses and leaves unstatused books standalone', () => {
+    it('groups explicitly assigned reading statuses', () => {
       const unread = createMockBook({ hash: 'unread', readingStatus: 'unread' });
       const finished = createMockBook({ hash: 'finished', readingStatus: 'finished' });
       const onHold = createMockBook({ hash: 'on-hold', readingStatus: 'abandoned' });
-      const unstatused = createMockBook({ hash: 'unstatused' });
 
-      const result = createBookGroups(
-        [unread, finished, onHold, unstatused],
-        LibraryGroupByType.Status,
-      );
+      const result = createBookGroups([unread, finished, onHold], LibraryGroupByType.Status);
       const groups = result.filter((item): item is BooksGroup => 'books' in item);
-      const standalone = result.filter((item): item is Book => 'format' in item);
 
       expect(groups.map(({ name }) => name)).toEqual(['unread', 'finished', 'abandoned']);
       expect(groups.map(({ displayName }) => displayName)).toEqual([
         'Unread',
         'Finished',
-        'On Hold',
+        'On hold',
       ]);
       expect(groups.every(({ books }) => books.length > 0)).toBe(true);
-      expect(standalone.map(({ hash }) => hash)).toEqual(['unstatused']);
+    });
+
+    // Reading status is an optional annotation, not a lifecycle field: nothing
+    // stamps it at import, and opening a book *clears* 'unread' back to
+    // undefined. Keying the grouping off it alone dropped every never-opened
+    // book out of the shelf entirely (55% of a real 750-book library) and left
+    // "Unread" holding only books someone had manually re-marked (1 of 750).
+    // Status grouping must partition the shelf: every book lands in exactly one
+    // bucket, and nothing is left standalone.
+    it('partitions every book into exactly one status group', () => {
+      const books = [
+        createMockBook({ hash: 'never-opened' }),
+        createMockBook({ hash: 'marked-unread', readingStatus: 'unread' }),
+        createMockBook({ hash: 'in-progress', progress: [10, 100] }),
+        createMockBook({ hash: 'marked-reading', readingStatus: 'reading' }),
+        createMockBook({ hash: 'done', readingStatus: 'finished', progress: [100, 100] }),
+        createMockBook({ hash: 'parked', readingStatus: 'abandoned', progress: [30, 100] }),
+      ];
+
+      const result = createBookGroups(books, LibraryGroupByType.Status);
+      const groups = result.filter((item): item is BooksGroup => 'books' in item);
+      const standalone = result.filter((item): item is Book => 'format' in item);
+
+      expect(standalone).toEqual([]);
+      expect(groups.flatMap(({ books: b }) => b).length).toBe(books.length);
+      expect(
+        Object.fromEntries(
+          groups.map(({ name, books: b }) => [name, b.map(({ hash }) => hash).sort()]),
+        ),
+      ).toEqual({
+        // A never-opened book reads as unread to a user, and the app already
+        // treats 'unread' as "not started" by clearing it on first open.
+        unread: ['marked-unread', 'never-opened'],
+        reading: ['in-progress', 'marked-reading'],
+        finished: ['done'],
+        abandoned: ['parked'],
+      });
+    });
+
+    it('labels every reading status with its shipped translation key', () => {
+      const books = (['unread', 'reading', 'finished', 'abandoned'] as ReadingStatus[]).map(
+        (readingStatus) => createMockBook({ hash: readingStatus, readingStatus }),
+      );
+
+      const groups = createBookGroups(books, LibraryGroupByType.Status).filter(
+        (item): item is BooksGroup => 'books' in item,
+      );
+
+      // Keys that already exist in every public/locales/<lang>/translation.json.
+      expect(groups.map(({ displayName }) => displayName)).toEqual([
+        'Unread',
+        'Reading',
+        'Finished',
+        'On hold',
+      ]);
+    });
+
+    it('flags status groups as localized so the UI translates them', () => {
+      const statusGroups = createBookGroups(
+        [createMockBook({ readingStatus: 'abandoned' })],
+        LibraryGroupByType.Status,
+      ).filter((item): item is BooksGroup => 'books' in item);
+
+      expect(statusGroups.map(({ localized }) => localized)).toEqual([true]);
+    });
+
+    // Opening an 'unread' book clears its status to `undefined` (readerStore),
+    // so the books a user is actually reading carry no explicit status. Without
+    // deriving the bucket they'd all fall out of the grouping as loose items,
+    // which is exactly the shelf #1010 asks for.
+    it('derives the reading group from progress when no status is set', () => {
+      const inProgress = createMockBook({ hash: 'in-progress', progress: [10, 100] });
+      const neverOpened = createMockBook({ hash: 'never-opened' });
+
+      const result = createBookGroups([inProgress, neverOpened], LibraryGroupByType.Status);
+      const groups = result.filter((item): item is BooksGroup => 'books' in item);
+
+      expect(groups.map(({ name, displayName }) => [name, displayName])).toEqual([
+        ['reading', 'Reading'],
+        // Never opened: no progress to derive from, so it falls to Unread.
+        ['unread', 'Unread'],
+      ]);
+      expect(groups[0]!.books.map(({ hash }) => hash)).toEqual(['in-progress']);
+      expect(groups[1]!.books.map(({ hash }) => hash)).toEqual(['never-opened']);
+    });
+
+    it('lets an explicit status win over derived reading progress', () => {
+      const books = [
+        createMockBook({ hash: 'finished', readingStatus: 'finished', progress: [100, 100] }),
+        createMockBook({ hash: 'on-hold', readingStatus: 'abandoned', progress: [30, 100] }),
+        createMockBook({ hash: 'unread', readingStatus: 'unread', progress: [1, 100] }),
+        // Explicit 'reading' with no progress yet still groups as reading.
+        createMockBook({ hash: 'marked-reading', readingStatus: 'reading' }),
+      ];
+
+      const groups = createBookGroups(books, LibraryGroupByType.Status).filter(
+        (item): item is BooksGroup => 'books' in item,
+      );
+
+      expect(
+        groups.map(({ name, books: grouped }) => [name, grouped.map(({ hash }) => hash)]),
+      ).toEqual([
+        ['finished', ['finished']],
+        ['abandoned', ['on-hold']],
+        ['unread', ['unread']],
+        ['reading', ['marked-reading']],
+      ]);
+    });
+
+    it('leaves user-authored group names unlocalized', () => {
+      const tagGroups = createBookGroups(
+        [createMockBook({ tags: ['Unread'] })],
+        LibraryGroupByType.Tag,
+      ).filter((item): item is BooksGroup => 'books' in item);
+
+      // A tag that collides with a UI string must never be translated.
+      expect(tagGroups.map(({ displayName, localized }) => [displayName, localized])).toEqual([
+        ['Unread', undefined],
+      ]);
     });
   });
 });

--- a/apps/readest-app/src/app/library/components/GroupHeader.tsx
+++ b/apps/readest-app/src/app/library/components/GroupHeader.tsx
@@ -9,13 +9,15 @@ import { LibraryGroupByType } from '@/types/settings';
 interface GroupHeaderProps {
   groupBy: LibraryGroupByType;
   groupName: string;
+  /** True when `groupName` is an i18n key (status groups) rather than user text. */
+  localized?: boolean;
 }
 
 /**
  * Header component displayed when viewing books inside a virtual group.
  * Shows the group type, group name, and a back button to return to the main bookshelf.
  */
-const GroupHeader: React.FC<GroupHeaderProps> = ({ groupBy, groupName }) => {
+const GroupHeader: React.FC<GroupHeaderProps> = ({ groupBy, groupName, localized }) => {
   const _ = useTranslation();
   const router = useRouter();
   const iconSize = useResponsiveSize(20);
@@ -64,7 +66,9 @@ const GroupHeader: React.FC<GroupHeaderProps> = ({ groupBy, groupName }) => {
       </button>
       <div className='flex items-center gap-2 overflow-hidden'>
         <span className='text-neutral-content text-sm'>{getGroupTypeLabel()}:</span>
-        <span className='truncate text-base font-medium'>{groupName}</span>
+        <span className='truncate text-base font-medium'>
+          {localized ? _(groupName) : groupName}
+        </span>
       </div>
     </div>
   );

--- a/apps/readest-app/src/app/library/components/GroupHeader.tsx
+++ b/apps/readest-app/src/app/library/components/GroupHeader.tsx
@@ -46,6 +46,8 @@ const GroupHeader: React.FC<GroupHeaderProps> = ({ groupBy, groupName }) => {
         return _('Tag');
       case LibraryGroupByType.Subject:
         return _('Subject');
+      case LibraryGroupByType.Status:
+        return _('Status');
       default:
         return _('Group');
     }

--- a/apps/readest-app/src/app/library/components/GroupItem.tsx
+++ b/apps/readest-app/src/app/library/components/GroupItem.tsx
@@ -19,6 +19,9 @@ interface GroupItemProps {
 const GroupItem: React.FC<GroupItemProps> = ({ mode, group, isSelectMode, groupSelected }) => {
   const _ = useTranslation();
   const { appService } = useEnv();
+  // Status groups carry an i18n key in `displayName`; series/author/tag/subject
+  // groups carry user-authored text that must never be translated.
+  const groupLabel = group.localized ? _(group.displayName) : group.displayName;
   const { settings } = useSettingsStore();
   const iconSize15 = useResponsiveSize(15);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -199,7 +202,7 @@ const GroupItem: React.FC<GroupItemProps> = ({ mode, group, isSelectMode, groupS
         </div>
         {mode === 'list' && (
           <div className='text-base-content/75 w-28 min-w-24 max-w-40 overflow-hidden text-ellipsis text-base font-semibold'>
-            {group.displayName}
+            {groupLabel}
           </div>
         )}
         {groupSelected && (
@@ -219,7 +222,7 @@ const GroupItem: React.FC<GroupItemProps> = ({ mode, group, isSelectMode, groupS
         <div className={clsx('flex w-full flex-col pt-2')}>
           <div className='min-w-0 flex-1'>
             <h4 className='block overflow-hidden text-ellipsis whitespace-nowrap text-xs font-semibold'>
-              {group.displayName}
+              {groupLabel}
             </h4>
           </div>
           <div className='placeholder' style={{ height: `${iconSize15}px` }}></div>

--- a/apps/readest-app/src/app/library/components/ViewMenu.tsx
+++ b/apps/readest-app/src/app/library/components/ViewMenu.tsx
@@ -70,6 +70,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({ setIsDropdownOpen }) => {
     { label: _('Series'), value: LibraryGroupByType.Series },
     { label: _('Tags'), value: LibraryGroupByType.Tag },
     { label: _('Subjects'), value: LibraryGroupByType.Subject },
+    { label: _('Status'), value: LibraryGroupByType.Status },
   ];
 
   const sortByOptions = [

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -309,6 +309,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
       | typeof LibraryGroupByType.Subject
       | typeof LibraryGroupByType.Status;
     groupName: string;
+    localized?: boolean;
   } | null>(null);
   // Direct (non-queued) download progress, keyed by book hash. Entries are
   // added and removed by useBookTransferActions, its only writer.
@@ -889,6 +890,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
         setCurrentVirtualGroup({
           groupBy,
           groupName: targetGroup.displayName || targetGroup.name,
+          localized: targetGroup.localized,
         });
       } else {
         setCurrentVirtualGroup(null);
@@ -2047,6 +2049,7 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
         <GroupHeader
           groupBy={currentVirtualGroup.groupBy}
           groupName={currentVirtualGroup.groupName}
+          localized={currentVirtualGroup.localized}
         />
       )}
       {showBookshelf &&

--- a/apps/readest-app/src/app/library/page.tsx
+++ b/apps/readest-app/src/app/library/page.tsx
@@ -306,7 +306,8 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
       | typeof LibraryGroupByType.Series
       | typeof LibraryGroupByType.Author
       | typeof LibraryGroupByType.Tag
-      | typeof LibraryGroupByType.Subject;
+      | typeof LibraryGroupByType.Subject
+      | typeof LibraryGroupByType.Status;
     groupName: string;
   } | null>(null);
   // Direct (non-queued) download progress, keyed by book hash. Entries are
@@ -874,7 +875,8 @@ const LibraryPageContent = ({ searchParams }: { searchParams: ReadonlyURLSearchP
       (groupBy === LibraryGroupByType.Series ||
         groupBy === LibraryGroupByType.Author ||
         groupBy === LibraryGroupByType.Tag ||
-        groupBy === LibraryGroupByType.Subject)
+        groupBy === LibraryGroupByType.Subject ||
+        groupBy === LibraryGroupByType.Status)
     ) {
       // Find the group to get its name
       const allGroups = createBookGroups(

--- a/apps/readest-app/src/app/library/utils/libraryUtils.ts
+++ b/apps/readest-app/src/app/library/utils/libraryUtils.ts
@@ -493,6 +493,15 @@ export const createBookGroups = (
   if (groupBy === LibraryGroupByType.Subject) {
     return createValueGroups(activeBooks, 'subject', getBookSubjects);
   }
+  if (groupBy === LibraryGroupByType.Status) {
+    return createValueGroups(
+      activeBooks,
+      'status',
+      (book) => (book.readingStatus ? [book.readingStatus] : []),
+      (status) =>
+        status === 'abandoned' ? 'On Hold' : `${status.charAt(0).toUpperCase()}${status.slice(1)}`,
+    );
+  }
 
   // 'group' mode is handled separately by generateBookshelfItems
   return activeBooks;
@@ -580,8 +589,9 @@ const createAuthorGroups = (books: Book[]): (Book | BooksGroup)[] => {
 
 const createValueGroups = (
   books: Book[],
-  namespace: 'tag' | 'subject',
+  namespace: 'tag' | 'subject' | 'status',
   getValues: (book: Book) => string[],
+  getDisplayName: (value: string) => string = (value) => value,
 ): (Book | BooksGroup)[] => {
   const valueMap = new Map<string, Book[]>();
   const ungroupedBooks: Book[] = [];
@@ -603,7 +613,7 @@ const createValueGroups = (
     ([name, groupBooks]): BooksGroup => ({
       id: md5Fingerprint(`${namespace}:${name}`),
       name,
-      displayName: name,
+      displayName: getDisplayName(name),
       books: groupBooks,
       updatedAt: Math.max(...groupBooks.map(({ updatedAt }) => updatedAt)),
     }),

--- a/apps/readest-app/src/app/library/utils/libraryUtils.ts
+++ b/apps/readest-app/src/app/library/utils/libraryUtils.ts
@@ -11,6 +11,7 @@ import {
   isCurrentlyReadingBook,
 } from '@/utils/book';
 import { md5Fingerprint } from '@/utils/md5';
+import { stubTranslation as _ } from '@/utils/misc';
 import { SIZE_PER_LOC, SIZE_PER_TIME_UNIT } from '@/services/constants';
 import { isFeedBook } from '@/services/rss/feedBookUrl';
 
@@ -19,6 +20,22 @@ const VALID_SORT_TYPES: LibrarySortByType[] = Object.values(LibrarySortByType);
 
 /** Valid group by types for the library */
 const VALID_GROUP_BY_TYPES: LibraryGroupByType[] = Object.values(LibraryGroupByType);
+
+/**
+ * Group labels for `groupBy=status`. These are i18n *keys*, not display text:
+ * `stubTranslation` only registers them for extraction, and the rendering
+ * component applies the real `_()` (see docs/i18n.md). Keys match the ones the
+ * status UI already ships, so every locale translates these for free.
+ *
+ * Typed as a total `Record<ReadingStatus, string>` on purpose: a fifth reading
+ * status can't be added without also giving it a label here.
+ */
+const READING_STATUS_LABELS: Record<ReadingStatus, string> = {
+  unread: _('Unread'),
+  reading: _('Reading'),
+  finished: _('Finished'),
+  abandoned: _('On hold'),
+};
 
 /**
  * Safely cast a query parameter to LibrarySortByType with fallback.
@@ -497,9 +514,21 @@ export const createBookGroups = (
     return createValueGroups(
       activeBooks,
       'status',
-      (book) => (book.readingStatus ? [book.readingStatus] : []),
-      (status) =>
-        status === 'abandoned' ? 'On Hold' : `${status.charAt(0).toUpperCase()}${status.slice(1)}`,
+      // `readingStatus` is an optional annotation, not a lifecycle field:
+      // nothing stamps it at import, and opening a book *clears* 'unread' back
+      // to `undefined`. Grouping on it alone therefore partitions badly — on a
+      // real 750-book library it dropped 414 never-opened books out of the
+      // shelf entirely and left "Unread" holding the 1 book that had been
+      // manually re-marked. So derive both ends instead: 'reading' from the
+      // predicate the recently-read shelf and home-screen widget already share
+      // (#1010 asks for exactly that shelf), and 'unread' as the resting state
+      // for a book with no status and no progress. Every book lands in exactly
+      // one bucket and nothing is left ungrouped.
+      (book) =>
+        isCurrentlyReadingBook(book)
+          ? ['reading' satisfies ReadingStatus]
+          : [book.readingStatus ?? ('unread' satisfies ReadingStatus)],
+      (status) => READING_STATUS_LABELS[status as ReadingStatus] ?? status,
     );
   }
 
@@ -591,7 +620,13 @@ const createValueGroups = (
   books: Book[],
   namespace: 'tag' | 'subject' | 'status',
   getValues: (book: Book) => string[],
-  getDisplayName: (value: string) => string = (value) => value,
+  /**
+   * Maps an internal value to a translation *key*. Supply this only for
+   * namespaces whose values are enums we own; the resulting groups are flagged
+   * `localized` so the UI translates them. Omit it for user-authored values
+   * (tags, subjects) so a tag literally named "Unread" renders verbatim.
+   */
+  getDisplayKey?: (value: string) => string,
 ): (Book | BooksGroup)[] => {
   const valueMap = new Map<string, Book[]>();
   const ungroupedBooks: Book[] = [];
@@ -608,16 +643,17 @@ const createValueGroups = (
     }
   }
 
-  const groups = Array.from(
-    valueMap,
-    ([name, groupBooks]): BooksGroup => ({
+  const groups = Array.from(valueMap, ([name, groupBooks]): BooksGroup => {
+    const group: BooksGroup = {
       id: md5Fingerprint(`${namespace}:${name}`),
       name,
-      displayName: getDisplayName(name),
+      displayName: getDisplayKey ? getDisplayKey(name) : name,
       books: groupBooks,
       updatedAt: Math.max(...groupBooks.map(({ updatedAt }) => updatedAt)),
-    }),
-  );
+    };
+    if (getDisplayKey) group.localized = true;
+    return group;
+  });
   return [...groups, ...ungroupedBooks];
 };
 

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -687,6 +687,14 @@ export interface BooksGroup {
   id: string;
   name: string;
   displayName: string;
+  /**
+   * True when `displayName` is an i18n key rather than user-authored text, so
+   * the rendering component must run it through `_()`. Set for groupings whose
+   * values are enums we own (reading status); never set for series, author,
+   * tag or subject names, which must render verbatim even when one of them
+   * happens to collide with a UI string.
+   */
+  localized?: boolean;
   books: Book[];
 
   updatedAt: number;

--- a/apps/readest-app/src/types/settings.ts
+++ b/apps/readest-app/src/types/settings.ts
@@ -44,6 +44,7 @@ export const LibraryGroupByType = {
   Author: 'author',
   Tag: 'tag',
   Subject: 'subject',
+  Status: 'status',
 } as const;
 
 export type LibraryGroupByType = (typeof LibraryGroupByType)[keyof typeof LibraryGroupByType];


### PR DESCRIPTION
Added group-by logic using existing book statuses (Unread, Finished, On Hold) and the existing tag group-by pattern.

UI now uses title case.

Added a regression test.

This partially addresses #1010.

All tests passed.
Manually tested with the native executable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to group library books by reading status.
  * Added a “Status” option to the library’s group-by menu.
  * Books without an explicit status are automatically grouped as “Reading” or “Unread” based on progress.
  * Status labels are localized, while custom tag names remain unchanged.

* **Bug Fixes**
  * Corrected status group headings and display labels.

* **Tests**
  * Added coverage for status grouping, localization, and display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->