### PR TITLE
feat(ui): separate theme mode and color for the library and the reader

### DIFF
--- a/apps/readest-app/src/__tests__/store/theme-store.test.ts
+++ b/apps/readest-app/src/__tests__/store/theme-store.test.ts
@@ -45,6 +45,11 @@ describe('themeStore', () => {
     useThemeStore.setState({
       themeMode: 'auto',
       themeColor: 'default',
+      themeScope: 'library',
+      readerThemeMode: 'auto',
+      readerThemeColor: 'default',
+      libraryThemeMode: null,
+      libraryThemeColor: null,
       systemIsDarkMode: false,
       ambientIsDarkMode: false,
       isDarkMode: false,
@@ -134,11 +139,11 @@ describe('themeStore', () => {
     });
 
     test('sets data-theme attribute using color and current dark mode', () => {
-      useThemeStore.setState({ isDarkMode: false });
+      useThemeStore.setState({ systemIsDarkMode: false, isDarkMode: false });
       useThemeStore.getState().setThemeColor('sepia');
       expect(document.documentElement.getAttribute('data-theme')).toBe('sepia-light');
 
-      useThemeStore.setState({ isDarkMode: true });
+      useThemeStore.setState({ systemIsDarkMode: true, isDarkMode: true });
       useThemeStore.getState().setThemeColor('ocean');
       expect(document.documentElement.getAttribute('data-theme')).toBe('ocean-dark');
     });
@@ -146,7 +151,7 @@ describe('themeStore', () => {
 
   describe('handleSystemThemeChange', () => {
     test('updates isDarkMode based on systemIsDarkMode when in auto mode', () => {
-      useThemeStore.setState({ themeMode: 'auto' });
+      useThemeStore.setState({ themeMode: 'auto', readerThemeMode: 'auto' });
 
       useThemeStore.getState().handleSystemThemeChange(true);
       let state = useThemeStore.getState();
@@ -160,7 +165,7 @@ describe('themeStore', () => {
     });
 
     test('isDarkMode stays true when themeMode is dark regardless of system theme', () => {
-      useThemeStore.setState({ themeMode: 'dark' });
+      useThemeStore.setState({ themeMode: 'dark', readerThemeMode: 'dark' });
 
       useThemeStore.getState().handleSystemThemeChange(false);
       const state = useThemeStore.getState();
@@ -169,7 +174,7 @@ describe('themeStore', () => {
     });
 
     test('isDarkMode stays false when themeMode is light regardless of system theme', () => {
-      useThemeStore.setState({ themeMode: 'light' });
+      useThemeStore.setState({ themeMode: 'light', readerThemeMode: 'light' });
 
       useThemeStore.getState().handleSystemThemeChange(true);
       const state = useThemeStore.getState();
@@ -199,14 +204,19 @@ describe('themeStore', () => {
       };
       mockGetThemeCode.mockReturnValueOnce(darkThemeCode);
 
-      useThemeStore.setState({ themeMode: 'auto' });
+      useThemeStore.setState({ themeMode: 'auto', readerThemeMode: 'auto' });
       useThemeStore.getState().handleSystemThemeChange(true);
 
       expect(useThemeStore.getState().themeCode).toEqual(darkThemeCode);
     });
 
     test('updates data-theme attribute when system theme changes', () => {
-      useThemeStore.setState({ themeMode: 'auto', themeColor: 'default' });
+      useThemeStore.setState({
+        themeMode: 'auto',
+        themeColor: 'default',
+        readerThemeMode: 'auto',
+        readerThemeColor: 'default',
+      });
       useThemeStore.getState().handleSystemThemeChange(true);
       expect(document.documentElement.getAttribute('data-theme')).toBe('default-dark');
 
@@ -219,9 +229,11 @@ describe('themeStore', () => {
     test('updates isDarkMode from lux when in ambient mode', () => {
       useThemeStore.setState({
         themeMode: 'ambient',
+        readerThemeMode: 'ambient',
         ambientIsDarkMode: false,
         isDarkMode: false,
         themeColor: 'default',
+        readerThemeColor: 'default',
       });
       useThemeStore.getState().handleAmbientLightChange(5);
       expect(useThemeStore.getState().ambientIsDarkMode).toBe(true);
@@ -233,6 +245,7 @@ describe('themeStore', () => {
     test('ignores lux updates when not in ambient mode', () => {
       useThemeStore.setState({
         themeMode: 'light',
+        readerThemeMode: 'light',
         ambientIsDarkMode: false,
         isDarkMode: false,
       });
@@ -244,9 +257,11 @@ describe('themeStore', () => {
     test('holds state inside the hysteresis band after first reading', () => {
       useThemeStore.setState({
         themeMode: 'ambient',
+        readerThemeMode: 'ambient',
         ambientIsDarkMode: true,
         isDarkMode: true,
         themeColor: 'default',
+        readerThemeColor: 'default',
       });
       // First reading establishes dark (low lux)
       useThemeStore.getState().handleAmbientLightChange(5);
@@ -428,7 +443,12 @@ describe('themeStore', () => {
     });
 
     test('native color scheme change updates the theme store in auto mode', () => {
-      useThemeStore.setState({ themeMode: 'auto', systemIsDarkMode: false, isDarkMode: false });
+      useThemeStore.setState({
+        themeMode: 'auto',
+        readerThemeMode: 'auto',
+        systemIsDarkMode: false,
+        isDarkMode: false,
+      });
       initSystemThemeListener(makeAppService({ isIOSApp: true }));
 
       window.onNativeColorSchemeChange!('dark');

--- a/apps/readest-app/src/app/reader/components/Reader.tsx
+++ b/apps/readest-app/src/app/reader/components/Reader.tsx
@@ -68,7 +68,11 @@ const Reader: React.FC<{ ids?: string }> = ({ ids }) => {
   const { getIsNotebookVisible, setNotebookVisible } = useNotebookStore();
   const { isDarkMode, systemUIAlwaysHidden, isRoundedWindow } = useThemeStore();
 
-  useTheme({ systemUIVisible: settings.alwaysShowStatusBar, appThemeColor: 'base-100' });
+  useTheme({
+    systemUIVisible: settings.alwaysShowStatusBar,
+    appThemeColor: 'base-100',
+    themeScope: 'reader',
+  });
   useScreenWakeLock(settings.screenWakeLock, appService?.hasWindow);
   useScreenBrightness();
   useTransferQueue(libraryLoaded, 5000);

--- a/apps/readest-app/src/components/settings/ThemePanel.tsx
+++ b/apps/readest-app/src/components/settings/ThemePanel.tsx
@@ -6,9 +6,11 @@ import {
   generateLightPalette,
   Theme,
   themes,
+  ThemeScope,
 } from '@/styles/themes';
 import { useEnv } from '@/context/EnvContext';
 import { useThemeStore } from '@/store/themeStore';
+import { resolveThemeIsDarkMode } from '@/utils/ambientLight';
 import { useReaderStore } from '@/store/readerStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useSettingsStore } from '@/store/settingsStore';
@@ -30,7 +32,7 @@ import { PREDEFINED_TEXTURES } from '@/styles/textures';
 import { useAtmosphereStore } from '@/store/atmosphereStore';
 import { DefaultHighlightColor, HighlightColor, UserHighlightColor } from '@/types/book';
 import clsx from 'clsx';
-import { SettingLabel } from './primitives';
+import { ScopeSwitch, SectionTitle, SettingLabel } from './primitives';
 import { HIGHLIGHT_COLOR_HEX } from '@/services/constants';
 import ThemeEditor from './theme/ThemeEditor';
 import ThemeModeSelector from './theme/ThemeModeSelector';
@@ -44,8 +46,16 @@ import LibrarySettings from './theme/LibrarySettings';
 
 const ThemePanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }) => {
   const _ = useTranslation();
-  const { themeMode, themeColor, isDarkMode, setThemeMode, setThemeColor, saveCustomTheme } =
-    useThemeStore();
+  const {
+    isDarkMode,
+    systemIsDarkMode,
+    ambientIsDarkMode,
+    getScopedTheme,
+    setScopedThemeMode,
+    setScopedThemeColor,
+    resetThemeScopes,
+    saveCustomTheme,
+  } = useThemeStore();
   const { envConfig, appService } = useEnv();
   const { settings, setSettings, saveSettings } = useSettingsStore();
   const { getView, getViewSettings } = useReaderStore();
@@ -59,6 +69,16 @@ const ThemePanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset
   const [textureScope, setTextureScope] = useState<BackgroundTextureScope>(
     isLibraryContext ? 'library' : 'reader',
   );
+  // Theme Mode and Theme Color share one scope switch (issue #5945): picking
+  // a value here is what decouples the library from the reader, so the two
+  // halves of "the theme" must never be editable for different pages at once.
+  const [themeScope, setThemeScope] = useState<ThemeScope>(isLibraryContext ? 'library' : 'reader');
+  const { themeMode, themeColor } = getScopedTheme(themeScope);
+  // Swatches preview the scope being EDITED, which is not always the scope
+  // on screen — picking a library color from inside a dark reader has to
+  // show the library's light swatches.
+  const scopedIsDarkMode = resolveThemeIsDarkMode(themeMode, systemIsDarkMode, ambientIsDarkMode);
+
   const currentBackground = getBackgroundTextureSettings(
     textureScope,
     settings,
@@ -122,8 +142,7 @@ const ThemePanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset
       readingRulerLines: setReadingRulerLines,
       readingRulerOpacity: setReadingRulerOpacity,
     });
-    setThemeColor('default');
-    setThemeMode('auto');
+    resetThemeScopes();
     setSelectedTextureId('none');
     setBackgroundOpacity(0.6);
     setBackgroundSize('cover');
@@ -300,14 +319,14 @@ const ThemePanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset
     applyCustomTheme(customTheme);
     saveCustomTheme(envConfig, settings, customTheme);
     setSettings({ ...settings });
-    setThemeColor(customTheme.name);
+    setScopedThemeColor(themeScope, customTheme.name);
     setShowCustomThemeEditor(false);
   };
 
   const handleDeleteCustomTheme = (customTheme: CustomTheme) => {
     saveCustomTheme(envConfig, settings, customTheme, true);
     setSettings({ ...settings });
-    setThemeColor('default');
+    setScopedThemeColor(themeScope, 'default');
     setShowCustomThemeEditor(false);
   };
 
@@ -393,12 +412,27 @@ const ThemePanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset
         />
       ) : (
         <>
-          <ThemeModeSelector
-            themeMode={themeMode}
-            onThemeModeChange={setThemeMode}
-            hasAmbientLightSensor={!!appService?.hasAmbientLightSensor}
-            data-setting-id='settings.color.themeMode'
-          />
+          <div className='space-y-6'>
+            <div className='mb-2 flex items-center justify-between gap-2'>
+              <SectionTitle>{_('Theme')}</SectionTitle>
+              <ScopeSwitch label={_('Theme')} scope={themeScope} onScopeChange={setThemeScope} />
+            </div>
+            <ThemeModeSelector
+              themeMode={themeMode}
+              onThemeModeChange={(mode) => setScopedThemeMode(themeScope, mode)}
+              hasAmbientLightSensor={!!appService?.hasAmbientLightSensor}
+              data-setting-id='settings.color.themeMode'
+            />
+            <ThemeColorSelector
+              themes={themes.concat(customThemes)}
+              themeColor={themeColor}
+              isDarkMode={scopedIsDarkMode}
+              onThemeColorChange={(color) => setScopedThemeColor(themeScope, color)}
+              onEditTheme={handleEditTheme}
+              onCreateTheme={() => setShowCustomThemeEditor(true)}
+              data-setting-id='settings.color.themeColor'
+            />
+          </div>
 
           <label
             data-setting-id='settings.color.invertImageInDarkMode'
@@ -423,16 +457,6 @@ const ThemePanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset
             <SettingLabel>{_('Override Book Color')}</SettingLabel>
             <Toggle checked={overrideColor} onChange={() => setOverrideColor(!overrideColor)} />
           </label>
-
-          <ThemeColorSelector
-            themes={themes.concat(customThemes)}
-            themeColor={themeColor}
-            isDarkMode={isDarkMode}
-            onThemeColorChange={setThemeColor}
-            onEditTheme={handleEditTheme}
-            onCreateTheme={() => setShowCustomThemeEditor(true)}
-            data-setting-id='settings.color.themeColor'
-          />
 
           <BackgroundTextureSelector
             predefinedTextures={PREDEFINED_TEXTURES}

--- a/apps/readest-app/src/components/settings/primitives/ScopeSwitch.tsx
+++ b/apps/readest-app/src/components/settings/primitives/ScopeSwitch.tsx
@@ -1,0 +1,62 @@
+import clsx from 'clsx';
+import React from 'react';
+import { useTranslation } from '@/hooks/useTranslation';
+import type { ThemeScope } from '@/styles/themes';
+
+interface ScopeSwitchProps {
+  /** Names the pair for screen readers, e.g. 'Background Image' or 'Theme'. */
+  label: string;
+  scope: ThemeScope;
+  onScopeChange: (scope: ThemeScope) => void;
+}
+
+/**
+ * The `Library | Reader` segmented control that marks a setting as having a
+ * separate value per page — background image (#5306) and theme (#5945).
+ *
+ * Same anatomy as ThemeModeSelector (44px targets, eink-bordered track +
+ * eink-inverted active thumb) but with text labels: the visible pair is what
+ * tells users the two pages can differ at all.
+ */
+const ScopeSwitch: React.FC<ScopeSwitchProps> = ({ label, scope, onScopeChange }) => {
+  const _ = useTranslation();
+
+  return (
+    <div
+      role='radiogroup'
+      aria-label={label}
+      className='bg-base-200 eink-bordered inline-flex items-center rounded-full p-0.5'
+    >
+      {(
+        [
+          { scope: 'library', label: _('Library') },
+          { scope: 'reader', label: _('Reader') },
+        ] as const
+      ).map(({ scope: segScope, label: segLabel }) => {
+        const active = scope === segScope;
+        return (
+          <button
+            key={segScope}
+            type='button'
+            role='radio'
+            aria-checked={active}
+            onClick={() => onScopeChange(segScope)}
+            className={clsx(
+              // em-based like SectionTitle, not rem-based text-sm — the
+              // settings-content wrapper scales 14/16px (DESIGN.md §5).
+              'flex h-9 items-center justify-center rounded-full px-3 text-[0.85em] font-medium transition-colors',
+              'focus-visible:ring-base-content/15 focus-visible:outline-hidden focus-visible:ring-2',
+              active
+                ? 'bg-base-300 text-base-content eink-inverted shadow-xs'
+                : 'text-base-content/60 hover:text-base-content',
+            )}
+          >
+            {segLabel}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ScopeSwitch;

--- a/apps/readest-app/src/components/settings/primitives/index.ts
+++ b/apps/readest-app/src/components/settings/primitives/index.ts
@@ -14,4 +14,5 @@ export { default as SettingsInput } from './SettingsInput';
 export { default as NavigationRow } from './NavigationRow';
 export { default as SectionTitle } from './SectionTitle';
 export { default as SettingLabel } from './SettingLabel';
+export { default as ScopeSwitch } from './ScopeSwitch';
 export { default as Tips } from './Tips';

--- a/apps/readest-app/src/components/settings/theme/BackgroundTextureSelector.tsx
+++ b/apps/readest-app/src/components/settings/theme/BackgroundTextureSelector.tsx
@@ -1,9 +1,8 @@
-import clsx from 'clsx';
 import React from 'react';
 import { MdClose, MdPlayCircleOutline } from 'react-icons/md';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useResponsiveSize } from '@/hooks/useResponsiveSize';
-import { BoxedList, SectionTitle, SettingsRow, SettingsSelect } from '../primitives';
+import { BoxedList, ScopeSwitch, SectionTitle, SettingsRow, SettingsSelect } from '../primitives';
 import { PiPlus } from 'react-icons/pi';
 import type { BackgroundTextureScope } from '@/helpers/settings';
 
@@ -54,44 +53,7 @@ const BackgroundTextureSelector: React.FC<BackgroundTextureSelectorProps> = ({
     <div>
       <div className='mb-2 flex items-center justify-between gap-2'>
         <SectionTitle>{_('Background Image')}</SectionTitle>
-        {/* Same segmented-control anatomy as ThemeModeSelector (44px targets,
-            eink-bordered track + eink-inverted active thumb), with text labels:
-            the visible Library|Reader pair is what tells users the two pages
-            have separate backgrounds (issue #5306). */}
-        <div
-          role='radiogroup'
-          aria-label={_('Background Image')}
-          className='bg-base-200 eink-bordered inline-flex items-center rounded-full p-0.5'
-        >
-          {(
-            [
-              { scope: 'library', label: _('Library') },
-              { scope: 'reader', label: _('Reader') },
-            ] as const
-          ).map(({ scope: segScope, label }) => {
-            const active = scope === segScope;
-            return (
-              <button
-                key={segScope}
-                type='button'
-                role='radio'
-                aria-checked={active}
-                onClick={() => onScopeChange(segScope)}
-                className={clsx(
-                  // em-based like SectionTitle, not rem-based text-sm — the
-                  // settings-content wrapper scales 14/16px (DESIGN.md §5).
-                  'flex h-9 items-center justify-center rounded-full px-3 text-[0.85em] font-medium transition-colors',
-                  'focus-visible:ring-base-content/15 focus-visible:outline-hidden focus-visible:ring-2',
-                  active
-                    ? 'bg-base-300 text-base-content eink-inverted shadow-xs'
-                    : 'text-base-content/60 hover:text-base-content',
-                )}
-              >
-                {label}
-              </button>
-            );
-          })}
-        </div>
+        <ScopeSwitch label={_('Background Image')} scope={scope} onScopeChange={onScopeChange} />
       </div>
       <div className='mb-4 grid grid-cols-3 gap-4'>
         {allTextures.map((texture) => (

--- a/apps/readest-app/src/hooks/useTheme.ts
+++ b/apps/readest-app/src/hooks/useTheme.ts
@@ -3,18 +3,25 @@ import { useEnv } from '@/context/EnvContext';
 import { useThemeStore } from '@/store/themeStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useSafeAreaInsets } from './useSafeAreaInsets';
-import { applyCustomTheme, Palette } from '@/styles/themes';
+import { applyCustomTheme, Palette, ThemeScope } from '@/styles/themes';
 import { getStatusBarHeight, setSystemUIVisibility } from '@/utils/bridge';
 import { getOSPlatform } from '@/utils/misc';
 
 type UseThemeProps = {
   systemUIVisible?: boolean;
   appThemeColor?: keyof Palette;
+  /**
+   * Which page's theme this route paints (issue #5945). Only the reader owns
+   * its own scope; the library, OPDS, player, auth and user pages all share
+   * the library's so no route paints a third look.
+   */
+  themeScope?: ThemeScope;
 };
 
 export const useTheme = ({
   systemUIVisible = true,
   appThemeColor = 'base-100',
+  themeScope = 'library',
 }: UseThemeProps = {}) => {
   const { appService } = useEnv();
   const { settings } = useSettingsStore();
@@ -31,8 +38,16 @@ export const useTheme = ({
     setStatusBarHeight,
     systemUIAlwaysHidden,
     setSystemUIAlwaysHidden,
+    setThemeScope,
   } = useThemeStore();
   const { onUpdateInsets } = useSafeAreaInsets();
+
+  // Point the store at this route's scope. `themeColor`/`isDarkMode` below
+  // are the resolved values for whichever scope is active, so the data-theme
+  // effect repaints for free when the user moves between library and reader.
+  useEffect(() => {
+    setThemeScope(themeScope);
+  }, [themeScope, setThemeScope]);
 
   useEffect(() => {
     updateAppTheme(appThemeColor);

--- a/apps/readest-app/src/store/themeStore.ts
+++ b/apps/readest-app/src/store/themeStore.ts
@@ -15,7 +15,7 @@ import {
   resolveThemeIsDarkMode,
 } from '@/utils/ambientLight';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { CustomTheme, Palette, ThemeMode } from '@/styles/themes';
+import { CustomTheme, Palette, ThemeMode, ThemeScope } from '@/styles/themes';
 import { EnvConfigType, isWebAppPlatform } from '@/services/environment';
 import { SystemSettings } from '@/types/settings';
 import { Insets } from '@/types/misc';
@@ -28,8 +28,30 @@ declare global {
 }
 
 interface ThemeState {
+  /**
+   * The theme currently painted on screen — the resolved values for
+   * `themeScope`, not raw storage. Everything that just wants to know "what
+   * does the UI look like right now" reads these (issue #5945).
+   */
   themeMode: ThemeMode;
   themeColor: string;
+  /** Which page's theme is applied. Every non-reader route is 'library'. */
+  themeScope: ThemeScope;
+  /**
+   * The reader pair, persisted under the original `themeMode`/`themeColor`
+   * keys. `getThemeCode` reads those same keys, so book content and reader
+   * overlays follow this pair without any coupling to the scope machinery.
+   */
+  readerThemeMode: ThemeMode;
+  readerThemeColor: string;
+  /**
+   * Library overrides; null means "inherit the reader pair", exactly like the
+   * undefined `libraryBackgroundTextureId` fields (#4743). Absent until the
+   * user picks a library value in Settings → Theme, so an upgrade changes
+   * nothing about how the app looks or how the quick toggles behave.
+   */
+  libraryThemeMode: ThemeMode | null;
+  libraryThemeColor: string | null;
   systemIsDarkMode: boolean;
   ambientIsDarkMode: boolean;
   themeCode: ThemeCode;
@@ -46,6 +68,11 @@ interface ThemeState {
   getIsDarkMode: () => boolean;
   setThemeMode: (mode: ThemeMode) => void;
   setThemeColor: (color: string) => void;
+  setThemeScope: (scope: ThemeScope) => void;
+  setScopedThemeMode: (scope: ThemeScope, mode: ThemeMode) => void;
+  setScopedThemeColor: (scope: ThemeScope, color: string) => void;
+  getScopedTheme: (scope: ThemeScope) => { themeMode: ThemeMode; themeColor: string };
+  resetThemeScopes: () => void;
   updateAppTheme: (color: keyof Palette) => void;
   saveCustomTheme: (
     envConfig: EnvConfigType,
@@ -57,6 +84,9 @@ interface ThemeState {
   handleAmbientLightChange: (lux: number) => void;
   updateSafeAreaInsets: (insets: Insets) => void;
 }
+
+const LIBRARY_THEME_MODE_KEY = 'libraryThemeMode';
+const LIBRARY_THEME_COLOR_KEY = 'libraryThemeColor';
 
 const getInitialThemeMode = (): ThemeMode => {
   if (typeof window !== 'undefined' && localStorage) {
@@ -72,6 +102,21 @@ const getInitialThemeColor = (): string => {
     return localStorage.getItem('themeColor') || defaultColor;
   }
   return 'default';
+};
+
+const getInitialLibraryThemeMode = (): ThemeMode | null => {
+  if (typeof window !== 'undefined' && localStorage) {
+    const stored = localStorage.getItem(LIBRARY_THEME_MODE_KEY);
+    if (isValidThemeMode(stored)) return stored;
+  }
+  return null;
+};
+
+const getInitialLibraryThemeColor = (): string | null => {
+  if (typeof window !== 'undefined' && localStorage) {
+    return localStorage.getItem(LIBRARY_THEME_COLOR_KEY) || null;
+  }
+  return null;
 };
 
 const getInitialAmbientIsDarkMode = (systemIsDarkMode: boolean): boolean => {
@@ -92,6 +137,36 @@ const applyDataTheme = (themeColor: string, isDarkMode: boolean) => {
     'data-theme',
     `${themeColor}-${isDarkMode ? 'dark' : 'light'}`,
   );
+};
+
+/**
+ * Resolve one scope's pair from the raw stored values. The reader pair is the
+ * base; the library falls back to it per field, so a user who only overrides
+ * the mode keeps following the reader's color.
+ */
+const resolveScopedTheme = (
+  scope: ThemeScope,
+  raw: Pick<
+    ThemeState,
+    'readerThemeMode' | 'readerThemeColor' | 'libraryThemeMode' | 'libraryThemeColor'
+  >,
+): { themeMode: ThemeMode; themeColor: string } => {
+  if (scope === 'reader') {
+    return { themeMode: raw.readerThemeMode, themeColor: raw.readerThemeColor };
+  }
+  return {
+    themeMode: raw.libraryThemeMode ?? raw.readerThemeMode,
+    themeColor: raw.libraryThemeColor ?? raw.readerThemeColor,
+  };
+};
+
+/**
+ * The reader owns `/reader`; everything else (library, settings, OPDS, player,
+ * auth) shares the library scope so no route paints a third look.
+ */
+export const getThemeScopeForPath = (pathname?: string): ThemeScope => {
+  const path = pathname ?? (typeof window !== 'undefined' ? window.location.pathname : '');
+  return path.startsWith('/reader') ? 'reader' : 'library';
 };
 
 let ambientLightListener: PluginListener | null = null;
@@ -156,15 +231,63 @@ const syncAmbientLightSubscription = (mode: ThemeMode) => {
 export const useThemeStore = create<ThemeState>((set, get) => {
   const initialThemeMode = getInitialThemeMode();
   const initialThemeColor = getInitialThemeColor();
+  const initialLibraryThemeMode = getInitialLibraryThemeMode();
+  const initialLibraryThemeColor = getInitialLibraryThemeColor();
   const systemIsDarkMode =
     typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches;
   const ambientIsDarkMode = getInitialAmbientIsDarkMode(systemIsDarkMode);
-  const isDarkMode = resolveThemeIsDarkMode(initialThemeMode, systemIsDarkMode, ambientIsDarkMode);
+  const initialScope = getThemeScopeForPath();
+  const initialEffective = resolveScopedTheme(initialScope, {
+    readerThemeMode: initialThemeMode,
+    readerThemeColor: initialThemeColor,
+    libraryThemeMode: initialLibraryThemeMode,
+    libraryThemeColor: initialLibraryThemeColor,
+  });
+  const isDarkMode = resolveThemeIsDarkMode(
+    initialEffective.themeMode,
+    systemIsDarkMode,
+    ambientIsDarkMode,
+  );
   const themeCode = getThemeCode();
 
+  /**
+   * Recompute the active scope's pair after a change and paint it. Writes that
+   * land on the scope the user is NOT looking at resolve to the same effective
+   * values, so this is a no-op repaint for them — which is what keeps editing
+   * the library theme from repainting an open book (the rule the background
+   * texture scope already follows, #4743).
+   *
+   * `refreshThemeCode` is set only when the reader pair or the system/ambient
+   * flags moved. `themeCode` feeds the CSS injected into the book iframe, and
+   * handing it a fresh object identity re-runs the reader's style effects.
+   */
+  const applyActiveScope = (patch: Partial<ThemeState>, refreshThemeCode: boolean) => {
+    const next = { ...get(), ...patch };
+    const effective = resolveScopedTheme(next.themeScope, next);
+    const nextIsDarkMode = resolveThemeIsDarkMode(
+      effective.themeMode,
+      next.systemIsDarkMode,
+      next.ambientIsDarkMode,
+    );
+    applyDataTheme(effective.themeColor, nextIsDarkMode);
+    set({
+      ...patch,
+      themeMode: effective.themeMode,
+      themeColor: effective.themeColor,
+      isDarkMode: nextIsDarkMode,
+      ...(refreshThemeCode ? { themeCode: getThemeCode() } : {}),
+    });
+    return effective.themeMode;
+  };
+
   return {
-    themeMode: initialThemeMode,
-    themeColor: initialThemeColor,
+    themeMode: initialEffective.themeMode,
+    themeColor: initialEffective.themeColor,
+    themeScope: initialScope,
+    readerThemeMode: initialThemeMode,
+    readerThemeColor: initialThemeColor,
+    libraryThemeMode: initialLibraryThemeMode,
+    libraryThemeColor: initialLibraryThemeColor,
     systemIsDarkMode,
     ambientIsDarkMode,
     isDarkMode,
@@ -179,27 +302,69 @@ export const useThemeStore = create<ThemeState>((set, get) => {
     setStatusBarHeight: (height: number) => set({ statusBarHeight: height }),
     setSystemUIAlwaysHidden: (hidden: boolean) => set({ systemUIAlwaysHidden: hidden }),
     getIsDarkMode: () => get().isDarkMode,
-    setThemeMode: (mode) => {
-      if (typeof window !== 'undefined' && localStorage) {
-        localStorage.setItem('themeMode', mode);
-      }
-      const isDarkMode = resolveThemeIsDarkMode(
-        mode,
-        get().systemIsDarkMode,
-        get().ambientIsDarkMode,
-      );
-      applyDataTheme(get().themeColor, isDarkMode);
-      set({ themeMode: mode, isDarkMode });
-      set({ themeCode: getThemeCode() });
+    getScopedTheme: (scope) => resolveScopedTheme(scope, get()),
+    setThemeScope: (scope) => {
+      if (get().themeScope === scope) return;
+      const mode = applyActiveScope({ themeScope: scope }, false);
       syncAmbientLightSubscription(mode);
     },
+    // The quick toggles (library settings menu, reader view menu, reader color
+    // panel, command palette) route through here. While the library is still
+    // inheriting, a toggle from either page writes the shared reader pair so
+    // both pages move together exactly as they did before #5945 — only an
+    // explicit library edit in Settings → Theme decouples the two.
+    setThemeMode: (mode) => {
+      const { themeScope, libraryThemeMode } = get();
+      const target: ThemeScope =
+        themeScope === 'library' && libraryThemeMode !== null ? 'library' : 'reader';
+      get().setScopedThemeMode(target, mode);
+    },
     setThemeColor: (color) => {
+      const { themeScope, libraryThemeColor } = get();
+      const target: ThemeScope =
+        themeScope === 'library' && libraryThemeColor !== null ? 'library' : 'reader';
+      get().setScopedThemeColor(target, color);
+    },
+    setScopedThemeMode: (scope, mode) => {
+      const isReader = scope === 'reader';
       if (typeof window !== 'undefined' && localStorage) {
-        localStorage.setItem('themeColor', color);
+        localStorage.setItem(isReader ? 'themeMode' : LIBRARY_THEME_MODE_KEY, mode);
       }
-      applyDataTheme(color, get().isDarkMode);
-      set({ themeColor: color });
-      set({ themeCode: getThemeCode() });
+      const activeMode = applyActiveScope(
+        isReader ? { readerThemeMode: mode } : { libraryThemeMode: mode },
+        isReader,
+      );
+      syncAmbientLightSubscription(activeMode);
+    },
+    setScopedThemeColor: (scope, color) => {
+      const isReader = scope === 'reader';
+      if (typeof window !== 'undefined' && localStorage) {
+        localStorage.setItem(isReader ? 'themeColor' : LIBRARY_THEME_COLOR_KEY, color);
+      }
+      applyActiveScope(
+        isReader ? { readerThemeColor: color } : { libraryThemeColor: color },
+        isReader,
+      );
+    },
+    // "Reset to defaults" has to drop the library override too, otherwise a
+    // decoupled library keeps its old look and the reset looks broken.
+    resetThemeScopes: () => {
+      if (typeof window !== 'undefined' && localStorage) {
+        localStorage.setItem('themeMode', 'auto');
+        localStorage.setItem('themeColor', 'default');
+        localStorage.removeItem(LIBRARY_THEME_MODE_KEY);
+        localStorage.removeItem(LIBRARY_THEME_COLOR_KEY);
+      }
+      const activeMode = applyActiveScope(
+        {
+          readerThemeMode: 'auto',
+          readerThemeColor: 'default',
+          libraryThemeMode: null,
+          libraryThemeColor: null,
+        },
+        true,
+      );
+      syncAmbientLightSubscription(activeMode);
     },
     updateAppTheme: (color) => {
       if (isWebAppPlatform()) {
@@ -227,11 +392,7 @@ export const useThemeStore = create<ThemeState>((set, get) => {
       await appService.saveSettings(settings);
     },
     handleSystemThemeChange: (systemIsDarkMode) => {
-      const mode = get().themeMode;
-      const isDarkMode = resolveThemeIsDarkMode(mode, systemIsDarkMode, get().ambientIsDarkMode);
-      applyDataTheme(get().themeColor, isDarkMode);
-      set({ systemIsDarkMode, isDarkMode });
-      set({ themeCode: getThemeCode() });
+      applyActiveScope({ systemIsDarkMode }, true);
     },
     handleAmbientLightChange: (lux) => {
       if (get().themeMode !== 'ambient') return;
@@ -242,9 +403,7 @@ export const useThemeStore = create<ThemeState>((set, get) => {
         return;
       }
       persistAmbientIsDarkMode(nextAmbientIsDark);
-      applyDataTheme(get().themeColor, nextAmbientIsDark);
-      set({ ambientIsDarkMode: nextAmbientIsDark, isDarkMode: nextAmbientIsDark });
-      set({ themeCode: getThemeCode() });
+      applyActiveScope({ ambientIsDarkMode: nextAmbientIsDark }, true);
     },
     updateSafeAreaInsets: (insets) => {
       set({ safeAreaInsets: insets });
@@ -252,7 +411,7 @@ export const useThemeStore = create<ThemeState>((set, get) => {
   };
 });
 
-export const loadDataTheme = () => {
+export const loadDataTheme = (scope: ThemeScope = getThemeScopeForPath()) => {
   if (typeof localStorage === 'undefined' || typeof document === 'undefined') return;
 
   const themeMode = localStorage.getItem('themeMode');
@@ -260,9 +419,18 @@ export const loadDataTheme = () => {
   if (themeMode && themeColor) {
     const systemIsDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
     const ambientIsDarkMode = getInitialAmbientIsDarkMode(systemIsDarkMode);
-    const mode = isValidThemeMode(themeMode) ? themeMode : 'auto';
-    const isDarkMode = resolveThemeIsDarkMode(mode, systemIsDarkMode, ambientIsDarkMode);
-    applyDataTheme(themeColor, isDarkMode);
+    const effective = resolveScopedTheme(scope, {
+      readerThemeMode: isValidThemeMode(themeMode) ? themeMode : 'auto',
+      readerThemeColor: themeColor,
+      libraryThemeMode: getInitialLibraryThemeMode(),
+      libraryThemeColor: getInitialLibraryThemeColor(),
+    });
+    const isDarkMode = resolveThemeIsDarkMode(
+      effective.themeMode,
+      systemIsDarkMode,
+      ambientIsDarkMode,
+    );
+    applyDataTheme(effective.themeColor, isDarkMode);
   }
 };
 

--- a/apps/readest-app/src/store/themeStore.ts
+++ b/apps/readest-app/src/store/themeStore.ts
@@ -416,22 +416,31 @@ export const loadDataTheme = (scope: ThemeScope = getThemeScopeForPath()) => {
 
   const themeMode = localStorage.getItem('themeMode');
   const themeColor = localStorage.getItem('themeColor');
-  if (themeMode && themeColor) {
-    const systemIsDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const ambientIsDarkMode = getInitialAmbientIsDarkMode(systemIsDarkMode);
-    const effective = resolveScopedTheme(scope, {
-      readerThemeMode: isValidThemeMode(themeMode) ? themeMode : 'auto',
-      readerThemeColor: themeColor,
-      libraryThemeMode: getInitialLibraryThemeMode(),
-      libraryThemeColor: getInitialLibraryThemeColor(),
-    });
-    const isDarkMode = resolveThemeIsDarkMode(
-      effective.themeMode,
-      systemIsDarkMode,
-      ambientIsDarkMode,
-    );
-    applyDataTheme(effective.themeColor, isDarkMode);
-  }
+  const libraryThemeMode = getInitialLibraryThemeMode();
+  const libraryThemeColor = getInitialLibraryThemeColor();
+  // Nothing configured at all: leave the attribute alone and let useTheme
+  // paint the default. A library-only override still counts as configured —
+  // decoupling the library writes only its own key, so a user who never
+  // touched the reader theme has no reader keys to gate on, and checking
+  // those alone would skip the early paint in exactly that case.
+  if (!(themeMode && themeColor) && !libraryThemeMode && !libraryThemeColor) return;
+
+  const systemIsDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const ambientIsDarkMode = getInitialAmbientIsDarkMode(systemIsDarkMode);
+  const effective = resolveScopedTheme(scope, {
+    // Via the same helpers the store initializes from, so an absent reader key
+    // resolves to the implicit default rather than a null in the attribute.
+    readerThemeMode: getInitialThemeMode(),
+    readerThemeColor: getInitialThemeColor(),
+    libraryThemeMode,
+    libraryThemeColor,
+  });
+  const isDarkMode = resolveThemeIsDarkMode(
+    effective.themeMode,
+    systemIsDarkMode,
+    ambientIsDarkMode,
+  );
+  applyDataTheme(effective.themeColor, isDarkMode);
 };
 
 export const initSystemThemeListener = (appService: AppService) => {

--- a/apps/readest-app/src/styles/themes.ts
+++ b/apps/readest-app/src/styles/themes.ts
@@ -9,6 +9,13 @@ export type BaseColor = {
 /** `ambient` follows the ambient light sensor (lux → light/dark), Android-first. */
 export type ThemeMode = 'auto' | 'light' | 'dark' | 'ambient';
 
+/**
+ * Which page's theme is being read or written (issue #5945). The library and
+ * the reader can carry different theme modes and colors; every route that is
+ * not the reader resolves as 'library'.
+ */
+export type ThemeScope = 'library' | 'reader';
+
 export type Palette = {
   'base-100': string;
   'base-200': string;


### PR DESCRIPTION
Closes #5945.

The library and the reader shared one theme mode and one theme color. Reading on a light, paper-like page meant flipping the whole app to Light on every book open and back to Dark on close — and closing a book left the library glaring white. Reported on [Reddit](https://www.reddit.com/r/readest/comments/1vkme6k/new_feature_request_an_important_one/).

Background images have been scoped per page since #4743 / #5306. The theme sitting directly above them in the same panel was not, which is what made the current behaviour surprising.

## What this does

Settings → Theme now carries the same `Library | Reader` switch, governing **Theme Mode and Theme Color together** — the two halves of "the theme" can never be editing different pages at once.

The library values default to **inherit**, mirroring the undefined `libraryBackgroundTextureId` fields:

- While inheriting, every quick toggle (library settings menu, reader view menu, reader color panel, command palette) writes the **shared** value and both pages move together — byte-identical to today's behaviour.
- Only picking a library value in Settings → Theme decouples the two. Nobody gets split by accident from a quick toggle.
- Reset to defaults clears the library override, so a decoupled library doesn't survive a reset.

## Implementation notes

- `themeMode`/`themeColor` in the store become the **resolved** values for the active scope. The raw reader pair keeps the original `themeMode`/`themeColor` localStorage keys, so `getThemeCode()` — and with it every book-content style and reader overlay — needed **no change at all**.
- Storage is localStorage (`libraryThemeMode`, `libraryThemeColor`, absent = inherit), not `SystemSettings`. Theme has never lived in settings; putting only the library half there would make one scope sync and the other not.
- `useTheme()` gains a `themeScope` prop — that hook is where `data-theme` actually lands on every route. Only the reader passes `'reader'`; the library, OPDS, player, auth and user pages share the library's so no route paints a third look.
- The `Library | Reader` segmented control moves out of `BackgroundTextureSelector` into a shared `ScopeSwitch` primitive (three call sites now).
- Editing the scope you are *not* looking at never repaints the current page, and never churns `themeCode`, matching the rule the background texture scope already follows.

Theme Color moved above the *Invert Image In Dark Mode* / *Override Book Color* toggles so one scope switch could legibly govern both halves. Existing theme-store tests were updated because `themeMode`/`themeColor` are now derived — they seed the raw scope fields instead.

## Verification

`pnpm lint`, `pnpm format:check` and `pnpm test` (10431 passing) are green. No `src-tauri/` or koplugin changes.

Ten paths checked in Chrome, each confirmed against both `data-theme` and the four localStorage keys:

| Check | Result |
| --- | --- |
| Fresh state, no overrides | `default-light`, both library keys `null` |
| Settings → Library → Dark + Sepia | `libraryThemeMode: dark`, `libraryThemeColor: sepia`; reader stays `light`/`default` |
| Flip switch to Reader | Shows Light/Default with light swatches; `data-theme` **stays** `sepia-dark` — no repaint behind |
| Open a book | Reader `default-light` while library `sepia-dark` |
| Reader quick toggle | Writes `themeMode` only; library untouched |
| Settings opened from a book | Scope defaults to Reader |
| Reader color → Sky | Reader `sky-dark`, library still `sepia`/`dark` |
| Back to library | Repaints to `sepia-dark`; reader keeps `sky-dark` |
| Reset to defaults | Clears both library keys; reader → `auto`/`default` |
| Cold boot | `/library` → `cherry-dark`; straight into `/reader/<hash>` → `sepia-light`, no flash |

Also confirmed: i18n resolves with no new keys (rendered 主题 / 书库 \| 阅读界面 on a zh profile), and book content re-renders in dark ink when the reader flips — `getThemeCode()` following the reader scope as intended.

## Not in scope

`loadDataTheme()` runs in a `useEffect`, not a pre-hydration inline script, so this makes the library↔reader transition apply the right theme but does not eliminate every first-paint flash. That would need a blocking script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate theme settings for the Library and Reader views.
  * Added a Library/Reader switch for configuring theme modes, colors, and background textures.
  * Reader and Library themes now apply automatically based on the active view.
  * Added support for resetting scoped theme settings, with Library settings inheriting Reader preferences when not customized.
  * Improved theme handling when system appearance changes or custom colors are selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->