### PR TITLE
fix(reader): stop a mid-touch text selection from hijacking the brightness swipe (#5939)

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useBrightnessGesture.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useBrightnessGesture.test.tsx
@@ -14,6 +14,7 @@ const h = vi.hoisted(() => ({
   renderer: {
     setAttribute: vi.fn(),
     removeAttribute: vi.fn(),
+    scrollLocked: false,
   },
 }));
 
@@ -127,6 +128,7 @@ describe('useBrightnessGesture (listener-level)', () => {
     h.saveSysSettings.mockReset();
     h.renderer.setAttribute.mockReset();
     h.renderer.removeAttribute.mockReset();
+    h.renderer.scrollLocked = false;
     h.getScreenBrightness.mockReset().mockResolvedValue(0.5);
   });
   afterEach(() => cleanup());
@@ -201,6 +203,41 @@ describe('useBrightnessGesture (listener-level)', () => {
     const { stopImmediatePropagation } = fireTouch(target, 'touchmove', 10, 470);
     expect(stopImmediatePropagation).not.toHaveBeenCalled();
     expect(paginator).toHaveBeenCalled();
+  });
+
+  it('yields when a long-press selects text after the touch started (#5939)', () => {
+    const { doc, target, paginator } = setup();
+    fireTouch(target, 'touchstart', 10, 300); // left strip, nothing selected yet
+    fireTouch(target, 'touchmove', 10, 302); // finger still held in place
+    setSelection(doc, false); // the OS long-press selects a word
+    const { stopImmediatePropagation } = fireTouch(target, 'touchmove', 10, 400); // dy=+100
+
+    expect(stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(paginator).toHaveBeenCalled();
+    expect(h.setScreenBrightness).not.toHaveBeenCalled();
+  });
+
+  it('stays yielded after a selection that began mid-gesture collapses', () => {
+    const { doc, target } = setup();
+    fireTouch(target, 'touchstart', 10, 300);
+    setSelection(doc, false);
+    fireTouch(target, 'touchmove', 10, 340);
+    setSelection(doc, true); // transient deselect while the handle is dragged
+    const { stopImmediatePropagation } = fireTouch(target, 'touchmove', 10, 400);
+
+    expect(stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(h.setScreenBrightness).not.toHaveBeenCalled();
+  });
+
+  it('yields when the instant-highlight scroll lock engages after the touch started', () => {
+    const { target, paginator } = setup();
+    fireTouch(target, 'touchstart', 10, 300);
+    h.renderer.scrollLocked = true; // still-hold engaged the quick action
+    const { stopImmediatePropagation } = fireTouch(target, 'touchmove', 10, 400);
+
+    expect(stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(paginator).toHaveBeenCalled();
+    expect(h.setScreenBrightness).not.toHaveBeenCalled();
   });
 
   it('reserves the strip in scrolled mode: preventDefault before activation, no stopImmediatePropagation', () => {

--- a/apps/readest-app/src/app/reader/hooks/useBrightnessGesture.ts
+++ b/apps/readest-app/src/app/reader/hooks/useBrightnessGesture.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useEnv } from '@/context/EnvContext';
 import { useReaderStore } from '@/store/readerStore';
+import type { Renderer } from '@/types/view';
 import { useSettingsStore } from '@/store/settingsStore';
 import { useDeviceControlStore } from '@/store/deviceStore';
 import { saveSysSettings } from '@/helpers/settings';
@@ -21,6 +22,7 @@ interface LatestState {
   enabled: boolean;
   scrolled: boolean;
   autoBrightness: boolean;
+  renderer: Renderer | undefined;
 }
 
 /**
@@ -49,11 +51,17 @@ export const useBrightnessGesture = (bookKey: string) => {
   const [overlayLevel, setOverlayLevel] = useState(0);
 
   // Everything the once-attached listener must read at the latest value.
-  const latestRef = useRef<LatestState>({ enabled: false, scrolled: false, autoBrightness: false });
+  const latestRef = useRef<LatestState>({
+    enabled: false,
+    scrolled: false,
+    autoBrightness: false,
+    renderer: undefined,
+  });
   latestRef.current = {
     enabled: brightnessGestureEnabled,
     scrolled: !!viewSettings?.scrolled,
     autoBrightness: settings.autoScreenBrightness,
+    renderer,
   };
 
   useEffect(() => {
@@ -189,6 +197,19 @@ export const useBrightnessGesture = (bookKey: string) => {
         if (!t) return;
         const dx = t.screenX - startXRef.current;
         const dy = t.screenY - startYRef.current;
+        // A text gesture that only began after touchstart owns the sequence:
+        // the OS long-press selected a word and the finger is now extending it
+        // (#5939), or the instant-highlight quick action engaged and locked the
+        // renderer (that one selects nothing, it synthesizes its range). Yield
+        // permanently — one-way, as below — because iOS can transiently
+        // collapse the selection while a handle is being dragged.
+        if (!activeRef.current) {
+          const selection = doc.getSelection?.();
+          if ((selection && !selection.isCollapsed) || latestRef.current.renderer?.scrollLocked) {
+            resetGesture();
+            return;
+          }
+        }
         // Gesture ownership is one-way. Once the same activation distance is
         // clearly horizontal, brightness may not claim the sequence later if
         // the trajectory bends vertically; Slide/Curl can safely own it.


### PR DESCRIPTION
Fixes #5939.

## Problem

Holding to select text near the left edge and then swiping down triggers the brightness slider instead of extending the selection.

## Root cause

`useBrightnessGesture` checked for a live text selection **only at `touchstart`** (`useBrightnessGesture.ts:172`). In the reported flow the touch begins with nothing selected: the OS long-press creates the selection *after* the finger is already down. The gesture is armed by then, so the following downward moves clear the 18px activation threshold and brightness claims the sequence in capture phase.

The sibling gestures already guard against this. The bookmark pull re-checks mid-move (`BookmarkPullDown.tsx:249-261`, added in #5757) and so does the captured-turn interceptor (`useCapturedTurn.ts:786-798`); the brightness hook was the one that never got it.

## Fix

Re-check before activation on every move and yield permanently (one-way, because iOS transiently collapses the selection while a handle is dragged). Two paths are covered:

- a non-collapsed DOM selection, for the native long-press select and handle drags;
- `renderer.scrollLocked`, for the instant-highlight quick action, which sets `user-select: none` and synthesizes its range (`useTextSelector.ts:433-443`) so it never produces a DOM selection.

Returning early also skips the scrolled-mode `preventDefault()`, so a selection drag keeps its native behavior.

## Testing

Three tests added to `useBrightnessGesture.test.tsx`, written first and confirmed failing against the old code (`stopImmediatePropagation` called once) before the fix landed:

- a long-press that selects text after the touch started
- a selection that began mid-gesture and then transiently collapses (the one-way latch)
- the instant-highlight scroll lock engaging after the touch started

`pnpm format:check`, `pnpm lint` and `pnpm test` (10434 passed, 16 skipped) all pass.

Not yet verified on a physical iPhone; the reproduction here is at the event-ordering level in jsdom.

## Note for reviewers

`useAutoScrollSpeedGesture.ts:68` (right-edge swipe to adjust auto-scroll speed) has the identical touchstart-only guard and the same defect. It is left out of this PR to keep the change scoped to the reported issue, and can follow in a separate one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved touch gesture handling when selecting text with a long press.
  - Prevented brightness gestures from interfering when instant-highlight scrolling is locked.
  - Ensured control is smoothly handed off to text selection or scrolling after a touch begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->