### PR TITLE
feat(reader): customizable header and footer style (#5938)

### DIFF
--- a/apps/readest-app/DESIGN.md
+++ b/apps/readest-app/DESIGN.md
@@ -419,6 +419,35 @@ subtitle, and the badge + toggle + edit/delete buttons stack as suffixes.
 These names come from libadwaita and apply 1:1 to Readest's lists. Use the names in code
 comments and PR descriptions.
 
+#### Two controls in one suffix
+
+When a row carries a swatch (or badge) *and* a select, pass them as **siblings**
+of `<SettingsRow>`, never wrapped together in a `<div>`:
+
+```tsx
+// ✓ Right — both are flex items of the row
+<SettingsRow label={_('Background Color')}>
+  {isCustom && (
+    <div className='ms-auto'>
+      <ColorInput … />
+    </div>
+  )}
+  <SettingsSelect … />
+</SettingsRow>
+```
+
+Two reasons, both of which show up as visible bugs:
+
+- `<SettingsSelect>` sizes itself with `max-w-[60%]`, which resolves against
+  its **containing block**. A shared wrapper shrinks to fit, so 60% of that is
+  a few dozen pixels and every option label truncates ("Auto" → "Au").
+- The row is `justify-between`, so free space lands *in front of* the middle
+  item and the swatch drifts left or right with each label's width. `ms-auto`
+  on the swatch collapses that space, so swatches line up down the list. Use
+  the logical `ms-`, never `ml-`/`mr-` (RTL).
+
+Canonical example: the Text Color / Background Color rows in `LayoutPanel`.
+
 #### Spacing
 
 - Row vertical padding: `py-2` (8px) for compact lists, `py-3` (12px) for breathing room.

--- a/apps/readest-app/src/app/reader/components/ProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/ProgressBar.tsx
@@ -14,6 +14,12 @@ import {
   getReferencePageInfo,
 } from '@/utils/progress';
 import { footerInfoVisible, footerReservesBand } from '../utils/footerBand';
+import {
+  getChromeChip,
+  getChromeFontSize,
+  getChromeTextColor,
+  isChromeStyled,
+} from '../utils/headerFooterStyle';
 import StatusInfo from './StatusInfo.tsx';
 import StickyProgressBar from './StickyProgressBar.tsx';
 import { convertPagesToTimeRemainingMinutes } from '@/app/library/utils/libraryUtils.ts';
@@ -153,11 +159,29 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
   // band, sticky-bar band, vertical side column).
   const hasFooterContent = stickyBarActive || footerInfoVisible(viewSettings);
   const stripTappable = hasFooterContent && (isVertical || footerReservesBand(viewSettings));
+  // The sticky bar reserves the band again, so `auto` needs no pill there; a
+  // color the reader chose still paints, since they asked to see it (#5938).
+  const chip = getChromeChip(viewSettings, 'footer', {
+    isEink,
+    isScrolled: !!viewSettings.scrolled,
+    isVertical: !!isVertical,
+    bandReserved: stickyBarActive,
+  });
+  // The segment is the tap target for #5293 wherever the info floats over the
+  // text -- that has to hold even when the reader turns the backdrop off, or
+  // "Background: none" would silently take tap-to-toggle away with it.
+  const pillTappable = !!viewSettings.scrolled && !isVertical && !stickyBarActive;
   const pillClass =
-    viewSettings.scrolled &&
-    !isVertical &&
-    !stickyBarActive &&
-    'progress-pill eink-bordered pointer-events-auto cursor-pointer rounded-md bg-base-100/85 px-1.5';
+    (pillTappable || chip) &&
+    clsx(
+      'progress-pill rounded-md px-1.5',
+      pillTappable && 'pointer-events-auto cursor-pointer',
+      chip && 'eink-bordered',
+      chip?.kind === 'theme' && 'bg-base-100/85',
+    );
+  const pillStyle = chip?.kind === 'custom' ? { backgroundColor: chip.color } : undefined;
+  const textColor = getChromeTextColor(viewSettings, isEink);
+  const fontSize = getChromeFontSize(viewSettings, isEink);
   const showStatusInfo = hasTimeInfo || hasBatteryInfo;
 
   return (
@@ -165,13 +189,15 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
       role='presentation'
       className={clsx(
         'progressinfo pointer-events-none absolute bottom-0 z-10 flex items-center justify-between font-sans',
-        isEink ? 'text-sm font-normal' : 'text-xs font-extralight',
+        isEink ? 'font-normal' : 'font-extralight',
         // The blend keeps the info legible over an unthemed fixed-layout page,
         // but it composites the whole container as a group -- with the pills on
         // it differences a white pill against the white page and paints it pure
         // black (#5342). The pill backdrop already guarantees legibility, so it
-        // takes over from the blend whenever it is present.
-        bookData?.isFixedLayout && !isEink && !pillClass
+        // takes over from the blend whenever it is present. A reader who set
+        // their own color or backdrop (#5938) has taken over too: the blend
+        // would invert their text color and black out their chip.
+        bookData?.isFixedLayout && !isEink && !pillClass && !isChromeStyled(viewSettings)
           ? 'text-white/75 mix-blend-difference'
           : 'text-base-content',
         isVertical ? 'writing-vertical-rl' : 'w-full',
@@ -188,8 +214,12 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
       ]
         .filter(Boolean)
         .join(', ')}
-      style={
-        isVertical
+      style={{
+        // Set on the container so the pills, the status widgets and the sticky
+        // bar (which inherits currentColor) all resolve from one place.
+        fontSize: `${fontSize}px`,
+        ...(textColor ? { color: textColor } : {}),
+        ...(isVertical
           ? {
               top: `${(contentInsets.top - gridInsets.top) * 1.5}px`,
               bottom: `${(contentInsets.bottom - gridInsets.bottom) * 1.5}px`,
@@ -202,8 +232,8 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
               paddingInlineStart: `calc(${horizontalGap / 2}% + ${contentInsets.left / 2}px)`,
               paddingInlineEnd: `calc(${horizontalGap / 2}% + ${contentInsets.right / 2}px)`,
               paddingBottom: appService?.hasSafeAreaInset ? `${gridInsets.bottom * 0.33}px` : 0,
-            }
-      }
+            }),
+      }}
     >
       <div
         aria-hidden='true'
@@ -237,9 +267,11 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
             )}
           >
             {viewSettings.showRemainingTime ? (
-              <span className={clsx('time-left-label text-start', pillClass)}>{timeLeftStr}</span>
+              <span className={clsx('time-left-label text-start', pillClass)} style={pillStyle}>
+                {timeLeftStr}
+              </span>
             ) : viewSettings.showRemainingPages && showPagesLeft ? (
-              <span className={clsx('text-start', pillClass)}>
+              <span className={clsx('text-start', pillClass)} style={pillStyle}>
                 {localize ? (
                   remainingInBook ? (
                     <Trans
@@ -283,6 +315,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
             isVertical={isVertical}
             isEink={isEink}
             className={pillClass || undefined}
+            style={pillStyle}
           />
         )}
 
@@ -299,6 +332,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
                 isVertical ? 'mt-auto' : 'ms-auto',
                 pillClass,
               )}
+              style={pillStyle}
             >
               {progressInfo}
             </span>

--- a/apps/readest-app/src/app/reader/components/SectionInfo.tsx
+++ b/apps/readest-app/src/app/reader/components/SectionInfo.tsx
@@ -8,6 +8,12 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { eventDispatcher } from '@/utils/event';
 import { getHeaderBandGeometry } from '@/utils/insets';
 import { getBookDataAttributes } from '@/utils/book';
+import {
+  getChromeChip,
+  getChromeFontSize,
+  getChromeTextColor,
+  isChromeStyled,
+} from '../utils/headerFooterStyle';
 import { useBookDataStore } from '@/store/bookDataStore';
 
 interface SectionInfoProps {
@@ -48,6 +54,23 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
   // into the notch instead of collapsing it (#5303).
   const band = getHeaderBandGeometry(topInset, viewSettings.marginTopPx);
   const maskHeight = Math.min(topInset, band.bottom);
+
+  // The header band is reserved margin except for a fixed-layout book in
+  // scrolled mode, where FoliateViewer pins scrollTop to 0 and the pages run
+  // underneath it. `auto` never gives the header a chip either way; a color
+  // the reader chose (#5938) paints one in both flow modes.
+  const chip = getChromeChip(viewSettings, 'header', {
+    isEink,
+    isScrolled,
+    isVertical,
+    bandReserved: !isScrolled || !bookData?.isFixedLayout,
+  });
+  const textColor = getChromeTextColor(viewSettings, isEink);
+  const fontSize = getChromeFontSize(viewSettings, isEink);
+  // Once the reader styles the chrome themselves the blend has to stand down:
+  // it inverts their text color, and differencing a child that carries its own
+  // background paints it solid black (#5342).
+  const blended = !!bookData?.isFixedLayout && !isEink && !isChromeStyled(viewSettings);
 
   const handleNotchClick = () => {
     if (eventDispatcher.dispatchSync('iframe-single-click')) return;
@@ -94,18 +117,20 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
           // makes the toolbar unclickable.
           !isVertical && band.top < topInset && 'z-10',
           isEink
-            ? 'text-sm font-normal'
-            : bookData?.isFixedLayout
-              ? 'text-white/75 mix-blend-difference text-xs font-light'
-              : 'text-base-content text-xs font-light',
+            ? 'font-normal'
+            : blended
+              ? 'text-white/75 mix-blend-difference font-light'
+              : 'text-base-content font-light',
           isVertical ? 'writing-vertical-rl max-h-[85%]' : 'top-0',
         )}
         role='none'
         tabIndex={-1}
         onClick={handleSectionClick}
         {...getBookDataAttributes(bookData?.book?.title, bookData?.book?.metadata)}
-        style={
-          isVertical
+        style={{
+          fontSize: `${fontSize}px`,
+          ...(textColor ? { color: textColor } : {}),
+          ...(isVertical
             ? {
                 top: `${(contentInsets.top - gridInsets.top) * 1.5}px`,
                 bottom: `${(contentInsets.bottom - gridInsets.bottom) * 1.5}px`,
@@ -119,18 +144,23 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
                 paddingInline: `calc(${horizontalGap / 2}% + ${contentInsets.left / 2}px)`,
                 width: '100%',
                 height: `${band.height}px`,
-              }
-        }
+              }),
+        }}
       >
         <span
           aria-label={section ? _('Section Title') + `: ${section}` : ''}
           className={clsx(
             'text-center',
             isVertical ? '' : 'line-clamp-1',
+            // Shrink-wraps around the title (the span is a flex item), so the
+            // header never becomes the full-width opaque bar of #4157.
+            chip && section && 'section-pill eink-bordered rounded-md px-1.5',
+            chip?.kind === 'theme' && section && 'bg-base-100/85',
             !isVertical &&
               (hoveredBookKey == bookKey || (hoveredBookKey && appService?.isMobile)) &&
               'hidden',
           )}
+          style={chip?.kind === 'custom' && section ? { backgroundColor: chip.color } : undefined}
         >
           {section || ''}
         </span>

--- a/apps/readest-app/src/app/reader/components/StatusInfo.tsx
+++ b/apps/readest-app/src/app/reader/components/StatusInfo.tsx
@@ -11,6 +11,8 @@ interface StatusInfoProps {
   isVertical?: boolean;
   isEink?: boolean;
   className?: string;
+  /** Backdrop for the scrolled-mode pill; see ProgressBar. */
+  style?: React.CSSProperties;
 }
 
 const StatusInfo: React.FC<StatusInfoProps> = ({
@@ -21,6 +23,7 @@ const StatusInfo: React.FC<StatusInfoProps> = ({
   isVertical,
   isEink,
   className,
+  style,
 }) => {
   const formattedTime = useCurrentTime(showTime, use24Hour);
   const batteryLevel = useCurrentBatteryStatus(showBattery);
@@ -34,6 +37,7 @@ const StatusInfo: React.FC<StatusInfoProps> = ({
         isVertical ? 'my-auto' : 'flex-row',
         className,
       )}
+      style={style}
     >
       {showTime && <span>{formattedTime}</span>}
       {showBattery && batteryLevel !== null && (

--- a/apps/readest-app/src/app/reader/components/StickyProgressBar.tsx
+++ b/apps/readest-app/src/app/reader/components/StickyProgressBar.tsx
@@ -12,6 +12,10 @@ interface StickyProgressBarProps {
 // Always-visible, display-only reading progress bar with chapter tick marks.
 // Positions are expressed from the reading-start edge so the fill grows and the
 // ticks sit correctly in both LTR and RTL.
+//
+// Track, fill and ticks are drawn in `currentColor` rather than a fixed
+// `base-content`, so the bar follows whatever color the footer resolves --
+// the theme's by default, or the reader's own (#5938).
 const StickyProgressBar: React.FC<StickyProgressBarProps> = ({
   fraction,
   tickFractions,
@@ -32,13 +36,13 @@ const StickyProgressBar: React.FC<StickyProgressBarProps> = ({
       <div
         className={clsx(
           'sticky-progress-track absolute inset-x-0 top-1/2 h-2 -translate-y-1/2 overflow-hidden rounded-full border',
-          isEink ? 'border-base-content' : 'border-base-content/40',
+          isEink ? 'border-current' : 'border-current/40',
         )}
       >
         <div
           className={clsx(
             'sticky-progress-fill absolute inset-y-0 rounded-full',
-            isEink ? 'bg-base-content' : 'bg-base-content/50',
+            isEink ? 'bg-current' : 'bg-current/50',
           )}
           style={{ width: `${pct}%`, [startEdge]: 0 }}
         />
@@ -49,7 +53,7 @@ const StickyProgressBar: React.FC<StickyProgressBarProps> = ({
             key={index}
             className={clsx(
               'sticky-progress-tick absolute inset-y-0 w-px',
-              isEink ? 'bg-base-content' : 'bg-base-content/40',
+              isEink ? 'bg-current' : 'bg-current/40',
             )}
             style={{ [startEdge]: `${tick * 100}%` }}
           />

--- a/apps/readest-app/src/app/reader/utils/headerFooterStyle.ts
+++ b/apps/readest-app/src/app/reader/utils/headerFooterStyle.ts
@@ -1,0 +1,110 @@
+import type { ViewSettings } from '@/types/book';
+
+/** The only shape `ColorInput` emits (`HexColorInput` with `prefixed`). */
+const HEX_COLOR = /^#[0-9a-f]{6}$/i;
+
+export const isHexColor = (value: string): boolean => HEX_COLOR.test(value);
+
+/**
+ * Settings written before these fields existed (and the partial view settings
+ * built in tests) leave them undefined, which has to read as the untouched
+ * default rather than as a deliberate choice.
+ */
+const getBackground = (viewSettings: ViewSettings): string =>
+  viewSettings.headerFooterBackground || 'auto';
+
+/**
+ * Font size in px for the header/footer info. E-ink falls back higher because
+ * its chrome used to hard-code `text-sm` where every other mode used
+ * `text-xs`.
+ */
+export const getChromeFontSize = (viewSettings: ViewSettings, isEink: boolean): number =>
+  viewSettings.headerFooterFontSize || (isEink ? 14 : 12);
+
+/**
+ * Backdrop resolved for one piece of reader chrome, or `null` for none.
+ *  - `theme`: the built-in `bg-base-100/85` pill (a utility class, so it
+ *    tracks the theme and picks up `eink-bordered`)
+ *  - `custom`: an inline `#rrggbbaa` from the reader's own choice
+ */
+export type ChromeChip = { kind: 'theme' } | { kind: 'custom'; color: string };
+
+export interface ChromeChipContext {
+  isEink: boolean;
+  isScrolled: boolean;
+  isVertical: boolean;
+  /**
+   * The element sits on reserved margin rather than over the book text, so
+   * `auto` needs no backdrop. Always true for the header of a reflowable book
+   * (FoliateViewer's scrollTop), and for the footer whenever the sticky
+   * progress bar keeps the bottom band (footerReservesBand).
+   */
+  bandReserved: boolean;
+}
+
+/**
+ * True once the reader has taken the chrome's legibility into their own hands
+ * with an explicit color or backdrop.
+ *
+ * The fixed-layout `mix-blend-difference` fallback (#4901) has to stand down
+ * then: it would invert the chosen text color, and differencing a child that
+ * carries its own background paints it solid black (#5342). It also means
+ * "Background: none" reads as genuinely transparent on a PDF rather than
+ * flipping the blend back on.
+ */
+export const isChromeStyled = (viewSettings: ViewSettings): boolean =>
+  isHexColor(viewSettings.headerFooterTextColor) || getBackground(viewSettings) !== 'auto';
+
+/**
+ * Text color for the header/footer info, or `undefined` to leave the themed
+ * `text-base-content` class in charge. E-ink renders an arbitrary hue as mud,
+ * so it always keeps the themed color.
+ */
+export const getChromeTextColor = (
+  viewSettings: ViewSettings,
+  isEink: boolean,
+): string | undefined => {
+  if (isEink || !isHexColor(viewSettings.headerFooterTextColor)) return undefined;
+  return viewSettings.headerFooterTextColor;
+};
+
+/**
+ * Backdrop for the header title / footer info.
+ *
+ * `auto` reproduces what each element does today: the footer gets its
+ * scrolled-mode pill (scrolled mode reserves no band, so the info floats over
+ * the text — see footerBand.ts), the header gets nothing (its band _is_
+ * reserved for reflowable books, and fixed-layout relies on the blend). A
+ * chosen color paints both, in either flow mode — otherwise picking one would
+ * silently do nothing for paginated readers.
+ *
+ * Vertical mode is excluded throughout: its chrome lives in a reserved side
+ * column, never over the text.
+ */
+export const getChromeChip = (
+  viewSettings: ViewSettings,
+  element: 'header' | 'footer',
+  { isEink, isScrolled, isVertical, bandReserved }: ChromeChipContext,
+): ChromeChip | null => {
+  const background = getBackground(viewSettings);
+  if (isVertical || background === 'none') return null;
+  if (background === 'auto') {
+    const floatsOverText = isScrolled && !bandReserved;
+    return element === 'footer' && floatsOverText ? { kind: 'theme' } : null;
+  }
+  if (!isHexColor(background)) return null;
+  // E-ink keeps the opaque themed pill: the hue would render as an
+  // indistinguishable gray, and the theme chip carries `eink-bordered`.
+  if (isEink) return { kind: 'theme' };
+  const opacity = viewSettings.headerFooterBgOpacity ?? 0.85;
+  return { kind: 'custom', color: withOpacity(background, opacity) };
+};
+
+/**
+ * Folds an alpha into a `#rrggbb` as an 8-digit hex. Cheaper and lossless
+ * next to parsing into `rgba()`, and supported everywhere the app runs.
+ */
+const withOpacity = (hex: string, opacity: number): string => {
+  const alpha = Math.round(Math.min(1, Math.max(0, opacity)) * 255);
+  return `${hex}${alpha.toString(16).padStart(2, '0')}`;
+};

--- a/apps/readest-app/src/components/settings/LayoutPanel.tsx
+++ b/apps/readest-app/src/components/settings/LayoutPanel.tsx
@@ -17,6 +17,7 @@ import { lockScreenOrientation } from '@/utils/bridge';
 import { saveViewSettings } from '@/helpers/settings';
 import { getBookDirFromWritingMode, getBookLangCode } from '@/utils/book';
 import { MIGHT_BE_RTL_LANGS } from '@/services/constants';
+import { isHexColor } from '@/app/reader/utils/headerFooterStyle';
 import { SettingsPanelPanelProp } from './SettingsDialog';
 import {
   BoxedList,
@@ -26,6 +27,7 @@ import {
   SettingsSwitchRow,
 } from './primitives';
 import NumberInput from './NumberInput';
+import ColorInput from './theme/ColorInput';
 import { Toggle } from '../primitives/toggle';
 
 const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterReset }) => {
@@ -89,6 +91,29 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
   );
   const [progressStyle, setProgressStyle] = useState(viewSettings.progressStyle);
   const [referencePageCount, setReferencePageCount] = useState(viewSettings.referencePageCount);
+  const [headerFooterFontSize, setHeaderFooterFontSize] = useState(
+    viewSettings.headerFooterFontSize,
+  );
+  const [headerFooterTextColor, setHeaderFooterTextColor] = useState(
+    viewSettings.headerFooterTextColor,
+  );
+  const [headerFooterBackground, setHeaderFooterBackground] = useState(
+    viewSettings.headerFooterBackground,
+  );
+  const [headerFooterBgOpacity, setHeaderFooterBgOpacity] = useState(
+    viewSettings.headerFooterBgOpacity,
+  );
+  // The stored fields carry both the mode and the color, so the last hex the
+  // reader picked has to survive a trip through Auto/None to come back on the
+  // next Custom without resetting to gray.
+  const [lastTextColor, setLastTextColor] = useState(
+    isHexColor(viewSettings.headerFooterTextColor) ? viewSettings.headerFooterTextColor : '#808080',
+  );
+  const [lastBgColor, setLastBgColor] = useState(
+    isHexColor(viewSettings.headerFooterBackground)
+      ? viewSettings.headerFooterBackground
+      : '#808080',
+  );
   const [screenOrientation, setScreenOrientation] = useState(viewSettings.screenOrientation);
 
   const resetToDefaults = useResetViewSettings();
@@ -128,6 +153,10 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
       use24HourClock: setUse24HourClock,
       showCurrentBatteryStatus: setShowCurrentBatteryStatus,
       showBatteryPercentage: setShowBatteryPercentage,
+      headerFooterFontSize: setHeaderFooterFontSize,
+      headerFooterTextColor: setHeaderFooterTextColor,
+      headerFooterBackground: setHeaderFooterBackground,
+      headerFooterBgOpacity: setHeaderFooterBgOpacity,
     });
   };
 
@@ -410,6 +439,54 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
     saveViewSettings(envConfig, bookKey, 'referencePageCount', referencePageCount, true, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [referencePageCount]);
+
+  useEffect(() => {
+    saveViewSettings(
+      envConfig,
+      bookKey,
+      'headerFooterFontSize',
+      headerFooterFontSize,
+      false,
+      false,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [headerFooterFontSize]);
+
+  useEffect(() => {
+    saveViewSettings(
+      envConfig,
+      bookKey,
+      'headerFooterTextColor',
+      headerFooterTextColor,
+      false,
+      false,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [headerFooterTextColor]);
+
+  useEffect(() => {
+    saveViewSettings(
+      envConfig,
+      bookKey,
+      'headerFooterBackground',
+      headerFooterBackground,
+      false,
+      false,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [headerFooterBackground]);
+
+  useEffect(() => {
+    saveViewSettings(
+      envConfig,
+      bookKey,
+      'headerFooterBgOpacity',
+      headerFooterBgOpacity,
+      false,
+      false,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [headerFooterBgOpacity]);
 
   useEffect(() => {
     if (showHeader === viewSettings.showHeader) return;
@@ -780,6 +857,86 @@ const LayoutPanel: React.FC<SettingsPanelPanelProp> = ({ bookKey, onRegisterRese
           disabled={!showFooter || !showCurrentBatteryStatus}
           onChange={() => setShowBatteryPercentage(!showBatteryPercentage)}
         />
+        <NumberInput
+          label={_('Font Size')}
+          value={headerFooterFontSize}
+          onChange={setHeaderFooterFontSize}
+          min={8}
+          max={24}
+          data-setting-id='settings.layout.headerFooterFontSize'
+        />
+        {/* Swatch and select are siblings, not nested together in a wrapper:
+            the select's own `max-w-[60%]` resolves against its containing
+            block, so a shared wrapper shrinks it until the labels truncate.
+            `ms-auto` collapses the free space the row's `justify-between`
+            would otherwise put in front of the swatch, so swatches line up
+            across rows instead of following each label's width. */}
+        <SettingsRow label={_('Text Color')}>
+          {isHexColor(headerFooterTextColor) && (
+            <div className='ms-auto'>
+              <ColorInput
+                label={_('Text Color')}
+                value={headerFooterTextColor}
+                onChange={(color) => {
+                  setLastTextColor(color);
+                  setHeaderFooterTextColor(color);
+                }}
+                pickerPosition='right'
+              />
+            </div>
+          )}
+          <SettingsSelect
+            value={isHexColor(headerFooterTextColor) ? 'custom' : 'auto'}
+            onChange={(e) =>
+              setHeaderFooterTextColor(e.target.value === 'custom' ? lastTextColor : '')
+            }
+            ariaLabel={_('Text Color')}
+            options={[
+              { value: 'auto', label: _('Auto') },
+              { value: 'custom', label: _('Custom') },
+            ]}
+          />
+        </SettingsRow>
+        <SettingsRow
+          label={_('Background Color')}
+          data-setting-id='settings.layout.headerFooterBackground'
+        >
+          {isHexColor(headerFooterBackground) && (
+            <div className='ms-auto'>
+              <ColorInput
+                label={_('Background Color')}
+                value={headerFooterBackground}
+                onChange={(color) => {
+                  setLastBgColor(color);
+                  setHeaderFooterBackground(color);
+                }}
+                pickerPosition='right'
+              />
+            </div>
+          )}
+          <SettingsSelect
+            value={isHexColor(headerFooterBackground) ? 'custom' : headerFooterBackground}
+            onChange={(e) =>
+              setHeaderFooterBackground(e.target.value === 'custom' ? lastBgColor : e.target.value)
+            }
+            ariaLabel={_('Background Color')}
+            options={[
+              { value: 'auto', label: _('Auto') },
+              { value: 'none', label: _('None') },
+              { value: 'custom', label: _('Custom') },
+            ]}
+          />
+        </SettingsRow>
+        {isHexColor(headerFooterBackground) && (
+          <NumberInput
+            label={_('Opacity')}
+            value={headerFooterBgOpacity}
+            onChange={setHeaderFooterBgOpacity}
+            min={0.1}
+            max={1}
+            step={0.05}
+          />
+        )}
       </BoxedList>
 
       {appService?.hasOrientationLock && (

--- a/apps/readest-app/src/services/commandRegistry.ts
+++ b/apps/readest-app/src/services/commandRegistry.ts
@@ -332,6 +332,28 @@ const layoutPanelItems = [
     keywords: ['progress', 'display', 'page', 'number', 'percentage'],
     section: 'Header & Footer',
   },
+  {
+    id: 'settings.layout.headerFooterFontSize',
+    labelKey: _('Font Size'),
+    keywords: ['font', 'size', 'header', 'footer', 'progress', 'page', 'number', 'text'],
+    section: 'Header & Footer',
+  },
+  {
+    id: 'settings.layout.headerFooterBackground',
+    labelKey: _('Background Color'),
+    keywords: [
+      'background',
+      'color',
+      'transparent',
+      'text',
+      'header',
+      'footer',
+      'progress',
+      'page',
+      'number',
+    ],
+    section: 'Header & Footer',
+  },
 ];
 
 // color panel items

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -409,6 +409,9 @@ export const DEFAULT_EINK_VIEW_SETTINGS: Partial<ViewSettings> = {
   isEink: true,
   animated: false,
   volumeKeysToFlip: true,
+  // Matches the text-sm the header/footer used to hard-code in e-ink mode,
+  // so e-ink devices keep their larger chrome once the size is configurable.
+  headerFooterFontSize: 14,
 };
 
 export const DEFAULT_PARAGRAPH_MODE_CONFIG: ParagraphModeConfig = {
@@ -436,6 +439,11 @@ export const DEFAULT_VIEW_CONFIG: ViewConfig = {
   showPaginationButtons: false,
   progressStyle: 'fraction',
   referencePageCount: 0,
+
+  headerFooterFontSize: 12,
+  headerFooterTextColor: '',
+  headerFooterBackground: 'auto',
+  headerFooterBgOpacity: 0.85,
 
   animated: false,
   pageTurnStyle: 'push',

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -343,6 +343,23 @@ export interface ViewConfig {
   progressStyle: 'percentage' | 'fraction' | 'reference';
   referencePageCount: number;
 
+  // Styling for the header (section title) and footer (progress readout,
+  // remaining time/pages, clock, battery). See utils/headerFooterStyle.ts
+  // for how these resolve; e-ink ignores both colors.
+  /** Font size in px for the header/footer info text. */
+  headerFooterFontSize: number;
+  /** `''` follows the theme's base-content; otherwise a `#rrggbb`. */
+  headerFooterTextColor: string;
+  /**
+   * `'auto'` keeps the built-in backdrop (the scrolled-mode footer pill and
+   * nothing behind the header), `'none'` removes it everywhere, and a
+   * `#rrggbb` paints a matching chip behind both header and footer in every
+   * flow mode.
+   */
+  headerFooterBackground: string;
+  /** 0-1 alpha applied to a `#rrggbb` headerFooterBackground. */
+  headerFooterBgOpacity: number;
+
   animated: boolean;
   pageTurnStyle: PageTurnStyle;
   isEink: boolean;


### PR DESCRIPTION
Closes #5938.

## The report

> Is it possible to have a transparent option for the background color of the page numbers? The current white background looks very jarring after I set the background myself.

## Why it happens

In scrolled mode the footer reserves no bottom band, so each info segment carries its own shrink-wrapped chip (`ProgressBar.tsx`):

```
'progress-pill eink-bordered … rounded-md bg-base-100/85 px-1.5'
```

`bg-base-100/85` reads as "the page color", which holds only while the page uses the theme background. The reporter has a reader background image on, and that texture paints as `.foliate-viewer::before` (`mix-blend-mode: multiply`, `opacity: .6`) while `ProgressBar` renders as a *sibling* of `.foliate-viewer`, above that overlay. The chip never picks up the tint, so it stays a bright white blob over a darkened page.

The header had the same problem for a different reason. `FoliateViewer` reserves the header band in scrolled mode for reflowable books but pins `scrollTop` to 0 for fixed-layout, so on the reporter's PDF the section title floats over the page too. That asymmetry was mechanical, not a design decision, which is why only the footer ever grew a pill.

## What changed

Four view settings, applied to the header title and the footer info together:

| Setting | Values |
| --- | --- |
| `headerFooterFontSize` | px. 12 default, 14 on e-ink hardware (matches the `text-sm` it used to hard-code) |
| `headerFooterTextColor` | `''` follows the theme, else `#rrggbb` |
| `headerFooterBackground` | `'auto'` \| `'none'` \| `#rrggbb` |
| `headerFooterBgOpacity` | alpha folded into a custom background |

A shared resolver (`reader/utils/headerFooterStyle.ts`) keeps `SectionInfo` and `ProgressBar` from drifting:

| `headerFooterBackground` | Header | Footer |
| --- | --- | --- |
| `'auto'` (default) | no chip, unchanged | `bg-base-100/85` pill in scrolled mode, unchanged |
| `'none'` | no chip | no chip |
| `#rrggbb` | matching chip, both flow modes | matching chip, both flow modes |

A custom chip renders in paginated mode too, otherwise picking a background color would silently do nothing for paginated readers. `auto` stays scrolled-only so no existing default changes. `StickyProgressBar` now draws in `currentColor`, so the bar follows the resolved text color.

## Two interactions worth review

- **Tap-to-toggle survives `none`.** The scrolled-mode pill was both the backdrop and the hit target for #5293. It keeps `pointer-events-auto cursor-pointer` with no backdrop, so turning the chip off does not quietly remove the gesture with it.
- **The fixed-layout blend stands down once the reader styles the chrome.** `mix-blend-difference` (#4901) would invert a chosen text color, and differencing a child that carries its own background paints it solid black (#5342). This is load-bearing here: the reporter is on a PDF, where `none` would otherwise flip the blend back on and repaint the text inverted-white instead of transparent.

E-ink honours the font size but keeps the themed colors. An arbitrary hue renders as an indistinguishable gray there, and the theme chip already carries `eink-bordered`.

## Settings

Layout > Header & Footer gains Font Size, Text Color and Background Color, with Opacity shown only for a custom background. Every label reuses an existing translation key, so there is **no new i18n work**. The two search entries resolve under `Layout > Header & Footer`.

`DESIGN.md` picks up the swatch+select row pattern: `SettingsSelect` sizes with `max-w-[60%]` against its containing block, so wrapping it with a swatch truncates every option label, and `ms-auto` on the swatch is what keeps swatches aligned down the list.

## Verification

Driven in `dev-web` via Chrome:

- defaults byte-for-byte unchanged (12px, theme color, footer pill only in scrolled mode, header bare)
- custom `#808080` renders `rgba(128,128,128,0.85)` chips on both header and footer, in paginated mode too
- font size 12 to 18 resizes both live
- `none` clears both chips; confirmed in scrolled mode, which is the reporter's flow
- settings search finds "Background Color - Layout > Header & Footer" and navigates to it
- no console errors

`pnpm test` 10434 passed / 16 skipped, `pnpm lint` and `pnpm format:check` clean. No `src-tauri/` changes, so no Rust checks needed.

## Not verified

Only exercised on web. The reporter is on Android, and e-ink behaviour is reasoned from the code rather than checked on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable header and footer appearance settings, including font size, text color, background, and opacity.
  * Added Auto, None, and Custom color options with color picker support.
  * Added searchable commands for header and footer layout settings.
  * Improved header and progress indicators to reflect selected themes and custom styling.
* **Documentation**
  * Added guidance for aligning badges and selection controls, including RTL layout support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->