### PR TITLE
fix(library): update the existing book when an updated EPUB is re-imported (#5959)

### DIFF
--- a/apps/readest-app/src/__tests__/hooks/useAndroidFilePicker.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useAndroidFilePicker.test.tsx
@@ -115,3 +115,22 @@ describe('useAndroidPickedBooks', () => {
     expect(first).not.toHaveBeenCalled();
   });
 });
+
+// Issue #5959: the native-bridge picker path runs the same whitelist as
+// useFileSelector, so a re-download saved as "book.epub (1)" was dropped here
+// too — and `if (books.length > 0)` made that completely silent.
+describe('useAndroidPickedBooks with a duplicate-download marker', () => {
+  test('forwards a book whose duplicate marker landed after the extension', async () => {
+    const onPickedBooks = vi.fn();
+    basenameMock.mockImplementation(async () => 'The_Amazing_Traveling.epub (1)');
+    renderHook(() => useAndroidPickedBooks(makeAppService(true), onPickedBooks));
+
+    await waitFor(() => expect(listeners).toHaveLength(1));
+    await listeners[0]!.handler({ uris: ['content://downloads/1'] });
+
+    await waitFor(() => expect(onPickedBooks).toHaveBeenCalled());
+    expect(onPickedBooks.mock.calls[0]![0]).toEqual([
+      expect.objectContaining({ name: 'The_Amazing_Traveling.epub (1)' }),
+    ]);
+  });
+});

--- a/apps/readest-app/src/__tests__/hooks/useAndroidFilePicker.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useAndroidFilePicker.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@tauri-apps/api/path', () => ({
 }));
 
 import { useAndroidPickedBooks } from '@/hooks/useAndroidFilePicker';
+import { eventDispatcher } from '@/utils/event';
 
 const makeAppService = (isAndroidApp: boolean): AppService =>
   ({ isAndroidApp, isIOSApp: false }) as unknown as AppService;
@@ -132,5 +133,29 @@ describe('useAndroidPickedBooks with a duplicate-download marker', () => {
     expect(onPickedBooks.mock.calls[0]![0]).toEqual([
       expect.objectContaining({ name: 'The_Amazing_Traveling.epub (1)' }),
     ]);
+  });
+});
+
+describe('useAndroidPickedBooks with a mixed selection', () => {
+  test('imports the books and still names the file it dropped', async () => {
+    const onPickedBooks = vi.fn();
+    const dispatchSpy = vi.spyOn(eventDispatcher, 'dispatch').mockResolvedValue();
+    basenameMock.mockImplementation(async (path: string) =>
+      path.endsWith('/1') ? 'novel.epub' : 'resume.docx',
+    );
+    renderHook(() => useAndroidPickedBooks(makeAppService(true), onPickedBooks));
+
+    await waitFor(() => expect(listeners).toHaveLength(1));
+    await listeners[0]!.handler({ uris: ['content://downloads/1', 'content://downloads/2'] });
+
+    await waitFor(() => expect(onPickedBooks).toHaveBeenCalled());
+    expect(onPickedBooks.mock.calls[0]![0]).toEqual([
+      expect.objectContaining({ name: 'novel.epub' }),
+    ]);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'toast',
+      expect.objectContaining({ message: expect.stringContaining('resume.docx') }),
+    );
+    dispatchSpy.mockRestore();
   });
 });

--- a/apps/readest-app/src/__tests__/hooks/useFileSelector.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useFileSelector.test.ts
@@ -218,3 +218,46 @@ describe('useFileSelector book selection with a duplicate-download marker', () =
     dispatchSpy.mockRestore();
   });
 });
+
+describe('useFileSelector reports every file it skips', () => {
+  test('keeps the supported file and still names the one it dropped', async () => {
+    const dispatchSpy = vi.spyOn(eventDispatcher, 'dispatch').mockResolvedValue();
+    basenameMock.mockResolvedValueOnce('novel.epub').mockResolvedValueOnce('resume.docx');
+    const { appService } = makeAppService('android', [
+      'content://com.android.providers.downloads/document/1',
+      'content://com.android.providers.downloads/document/2',
+    ]);
+    const { selectFiles: select } = useFileSelector(appService, _);
+
+    const result = await select({ type: 'books', multiple: true });
+
+    expect(result.files).toEqual([expect.objectContaining({ name: 'novel.epub' })]);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'toast',
+      expect.objectContaining({ message: expect.stringContaining('resume.docx') }),
+    );
+    // Only the rejected file is named.
+    const [, toast] = dispatchSpy.mock.calls[0]!;
+    expect((toast as { message: string }).message).not.toContain('novel.epub');
+    dispatchSpy.mockRestore();
+  });
+
+  test('does not claim a book import failed for a non-book selection', async () => {
+    const dispatchSpy = vi.spyOn(eventDispatcher, 'dispatch').mockResolvedValue();
+    basenameMock.mockResolvedValueOnce('lecture.pptx');
+    const { appService } = makeAppService('android', [
+      'content://com.android.providers.downloads/document/9',
+    ]);
+    const { selectFiles: select } = useFileSelector(appService, _);
+
+    const result = await select({ type: 'audio', multiple: true });
+
+    expect(result.files).toHaveLength(0);
+    // The only message we have translated talks about books; an audio pick
+    // must not borrow it.
+    for (const [, payload] of dispatchSpy.mock.calls) {
+      expect((payload as { message?: string }).message ?? '').not.toContain('book');
+    }
+    dispatchSpy.mockRestore();
+  });
+});

--- a/apps/readest-app/src/__tests__/hooks/useFileSelector.test.ts
+++ b/apps/readest-app/src/__tests__/hooks/useFileSelector.test.ts
@@ -24,7 +24,11 @@ vi.mock('@tauri-apps/api/core', () => ({
 import { FILE_SELECTION_PRESETS, useFileSelector } from '@/hooks/useFileSelector';
 import { eventDispatcher } from '@/utils/event';
 
-const _ = (key: string) => key;
+const _ = (key: string, options: Record<string, string | number> = {}) =>
+  Object.entries(options).reduce(
+    (text, [name, value]) => text.replace(`{{${name}}}`, `${value}`),
+    key,
+  );
 
 const makeAppService = (
   platform: 'ios' | 'android' | 'linux',
@@ -148,5 +152,69 @@ describe('useFileSelector under gamescope (SteamOS Gaming Mode, #3049)', () => {
     await select({ type: 'books', multiple: true });
 
     expect(invokeMock).not.toHaveBeenCalled();
+  });
+});
+
+// Issue #5959: a re-download saved as "book.epub (1)" was dropped by the
+// client-side whitelist that the unfiltered mobile pickers rely on, and the
+// caller cannot tell an all-dropped selection from a user cancel — so picking
+// the file did nothing at all, with no error.
+describe('useFileSelector book selection with a duplicate-download marker', () => {
+  test('Android: keeps a book whose duplicate marker landed after the extension', async () => {
+    basenameMock.mockResolvedValueOnce('The_Amazing_Traveling.epub (1)');
+    const { appService } = makeAppService('android', [
+      'content://com.android.providers.downloads/document/42',
+    ]);
+    const { selectFiles: select } = useFileSelector(appService, _);
+
+    const result = await select({ type: 'books', multiple: true });
+
+    expect(result.files).toEqual([
+      expect.objectContaining({ name: 'The_Amazing_Traveling.epub (1)' }),
+    ]);
+  });
+
+  test('iOS: keeps it too', async () => {
+    const { appService } = makeAppService('ios', [
+      'file:///private/var/mobile/Containers/Data/Application/ABC/Documents/Novel.epub (2)',
+    ]);
+    const { selectFiles: select } = useFileSelector(appService, _);
+
+    const result = await select({ type: 'books', multiple: true });
+
+    expect(result.files).toHaveLength(1);
+  });
+
+  test('reports the files it dropped instead of returning an empty selection silently', async () => {
+    const dispatchSpy = vi.spyOn(eventDispatcher, 'dispatch').mockResolvedValue();
+    basenameMock.mockResolvedValueOnce('resume.docx');
+    const { appService } = makeAppService('android', [
+      'content://com.android.providers.downloads/document/7',
+    ]);
+    const { selectFiles: select } = useFileSelector(appService, _);
+
+    const result = await select({ type: 'books', multiple: true });
+
+    expect(result.files).toHaveLength(0);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'toast',
+      expect.objectContaining({
+        type: 'error',
+        message: expect.stringContaining('resume.docx'),
+      }),
+    );
+    dispatchSpy.mockRestore();
+  });
+
+  test('stays quiet when the user simply cancels the picker', async () => {
+    const dispatchSpy = vi.spyOn(eventDispatcher, 'dispatch').mockResolvedValue();
+    const { appService } = makeAppService('android', []);
+    const { selectFiles: select } = useFileSelector(appService, _);
+
+    const result = await select({ type: 'books', multiple: true });
+
+    expect(result.files).toHaveLength(0);
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    dispatchSpy.mockRestore();
   });
 });

--- a/apps/readest-app/src/__tests__/libs/document.test.ts
+++ b/apps/readest-app/src/__tests__/libs/document.test.ts
@@ -95,6 +95,20 @@ describe('DocumentLoader.open', () => {
   }, 15000);
 });
 
+// Issue #5959: some download managers append the duplicate marker after the
+// extension ("notes.md (1)"), and the loader classifies by name. Without
+// tolerating it a Markdown or comic file reaches the zip probe as an unknown
+// binary and fails with "Unsupported or corrupted book file".
+describe('DocumentLoader format probes with a duplicate-download marker', () => {
+  it('still recognizes Markdown', async () => {
+    const file = new File(['# Chapter One\n\nhello'], 'notes.md (1)');
+
+    const { format } = await new DocumentLoader(file).open();
+
+    expect(format).toBe('MD');
+  });
+});
+
 describe('getDirection', () => {
   afterEach(() => {
     document.body.removeAttribute('style');

--- a/apps/readest-app/src/__tests__/services/import-metahash.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-metahash.test.ts
@@ -1093,3 +1093,140 @@ describe('importBook with BookLookupIndex', () => {
     expect(lookupIndex.byFilePath.has('https://example.com/c.epub')).toBe(false);
   });
 });
+
+// Issue #5959: AO3 serves calibre-built EPUBs, and calibre mints a fresh random
+// dc:identifier uuid on every export. Re-importing the same work after an update
+// therefore misses both the partialMD5 and the metaHash lookup, and the reader
+// ends up with two library entries instead of an updated one.
+describe('importBook volatile-identifier dedup (issue #5959)', () => {
+  let service: TestAppService;
+
+  const AO3_TITLE = 'The Amazing Traveling Circus Part 2 - The Golden Butterfly';
+  const metadataWithUuid = (uuid: string) => ({
+    title: AO3_TITLE,
+    author: 'KicsterAsh',
+    language: 'en',
+    identifier: uuid,
+    altIdentifier: `urn:uuid:${uuid}`,
+  });
+
+  const OLD_METADATA = metadataWithUuid('08bc8344-c0c9-485c-afcb-c15202570205');
+  const NEW_METADATA = metadataWithUuid('d559a18b-88fa-4560-9f1d-4922e2471ba4');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TestAppService();
+    const fs = service.getFs();
+    fs.exists.mockResolvedValue(false);
+    fs.createDir.mockResolvedValue(undefined);
+    fs.writeFile.mockResolvedValue(undefined);
+    fs.removeDir.mockResolvedValue(undefined);
+    fs.readFile.mockResolvedValue('{}');
+  });
+
+  it('updates the existing book when the re-download only re-mints the uuid', async () => {
+    const existingBook = makeBook({
+      hash: 'old-file-hash',
+      title: AO3_TITLE,
+      sourceTitle: AO3_TITLE,
+      author: 'KicsterAsh',
+      metaHash: getMetadataHash(OLD_METADATA),
+      metadata: OLD_METADATA,
+    });
+    const books: Book[] = [existingBook];
+
+    mockPartialMD5.mockResolvedValue('new-file-hash');
+    setupMockBookDoc(NEW_METADATA);
+
+    const result = await service.importBook(
+      new File(['updated fic'], 'The_Amazing_Traveling.epub', { type: 'application/epub+zip' }),
+      books,
+    );
+
+    expect(result).toBe(existingBook);
+    expect(books.filter((b) => !b.deletedAt)).toHaveLength(1);
+    expect(existingBook.hash).toBe('new-file-hash');
+    expect(existingBook.metaHash).toBe(getMetadataHash(NEW_METADATA));
+    expect(existingBook.metadata).toEqual(NEW_METADATA);
+  });
+
+  it('matches through the lookup index used by batch imports', async () => {
+    const existingBook = makeBook({
+      hash: 'old-file-hash',
+      title: AO3_TITLE,
+      author: 'KicsterAsh',
+      metaHash: getMetadataHash(OLD_METADATA),
+      metadata: OLD_METADATA,
+    });
+    const books: Book[] = [existingBook];
+    const lookupIndex = buildBookLookupIndex(books);
+
+    mockPartialMD5.mockResolvedValue('new-file-hash');
+    setupMockBookDoc(NEW_METADATA);
+
+    const result = await service.importBook(
+      new File(['updated fic'], 'The_Amazing_Traveling.epub', { type: 'application/epub+zip' }),
+      books,
+      { lookupIndex },
+    );
+
+    expect(result).toBe(existingBook);
+    expect(books.filter((b) => !b.deletedAt)).toHaveLength(1);
+  });
+
+  it('keeps different works apart even when both carry a random uuid', async () => {
+    const otherMetadata = { ...NEW_METADATA, title: 'A Completely Different Fic' };
+    const existingBook = makeBook({
+      hash: 'old-file-hash',
+      title: AO3_TITLE,
+      author: 'KicsterAsh',
+      metaHash: getMetadataHash(OLD_METADATA),
+      metadata: OLD_METADATA,
+    });
+    const books: Book[] = [existingBook];
+
+    mockPartialMD5.mockResolvedValue('other-file-hash');
+    setupMockBookDoc(otherMetadata);
+
+    const result = await service.importBook(
+      new File(['another fic'], 'other.epub', { type: 'application/epub+zip' }),
+      books,
+    );
+
+    expect(result).not.toBe(existingBook);
+    expect(books.filter((b) => !b.deletedAt)).toHaveLength(2);
+  });
+
+  it('leaves the PDF filename rule from #5411 alone', async () => {
+    const pdfMetadata = (uuid: string) => ({
+      title: 'PowerPoint Presentation',
+      author: 'Alice Author',
+      language: 'en',
+      altIdentifier: `urn:uuid:${uuid}`,
+    });
+    const setupMockPdfDoc = (metadata: Record<string, unknown>) => {
+      mockOpen.mockResolvedValue({
+        book: { metadata, getCover: vi.fn().mockResolvedValue(null) },
+        format: 'PDF',
+      });
+    };
+    const books: Book[] = [];
+
+    mockPartialMD5.mockResolvedValue('pdf-hash-1');
+    setupMockPdfDoc(pdfMetadata('4444dddd-4444-4444-8444-444444444444'));
+    const first = await service.importBook(
+      new File(['slides 1'], 'lecture-01.pdf', { type: 'application/pdf' }),
+      books,
+    );
+
+    mockPartialMD5.mockResolvedValue('pdf-hash-2');
+    setupMockPdfDoc(pdfMetadata('5555eeee-5555-4555-8555-555555555555'));
+    const second = await service.importBook(
+      new File(['slides 2'], 'lecture-02.pdf', { type: 'application/pdf' }),
+      books,
+    );
+
+    expect(second).not.toBe(first);
+    expect(books.filter((b) => !b.deletedAt)).toHaveLength(2);
+  });
+});

--- a/apps/readest-app/src/__tests__/services/import-metahash.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-metahash.test.ts
@@ -1197,6 +1197,101 @@ describe('importBook volatile-identifier dedup (issue #5959)', () => {
     expect(books.filter((b) => !b.deletedAt)).toHaveLength(2);
   });
 
+  // The reporter of #5959 had set their own cover art on the book. The merge
+  // re-keys the row to the incoming file's hash directory and retires the old
+  // one, so a cover the user chose has to travel with it.
+  it('carries a cover the user chose across the merge', async () => {
+    const existingBook = makeBook({
+      hash: 'old-file-hash',
+      title: AO3_TITLE,
+      author: 'KicsterAsh',
+      metaHash: getMetadataHash(OLD_METADATA),
+      metadata: OLD_METADATA,
+      coverUpdatedAt: Date.now() - 60000,
+    });
+    const books: Book[] = [existingBook];
+    const fs = service.getFs();
+    const present = new Set<string>(['old-file-hash/cover.png']);
+    fs.exists.mockImplementation(async (path: string) => present.has(path));
+    fs.copyFile.mockImplementation(async (_src: string, _sb: string, dst: string) => {
+      present.add(dst);
+    });
+    fs.writeFile.mockImplementation(async (path: string) => {
+      present.add(path);
+    });
+
+    mockPartialMD5.mockResolvedValue('new-file-hash');
+    mockOpen.mockResolvedValue({
+      book: {
+        metadata: NEW_METADATA,
+        getCover: vi.fn().mockResolvedValue(new Blob(['embedded'], { type: 'image/png' })),
+      },
+      format: 'EPUB',
+    });
+
+    await service.importBook(
+      new File(['updated fic'], 'The_Amazing_Traveling.epub', { type: 'application/epub+zip' }),
+      books,
+    );
+
+    expect(fs.copyFile).toHaveBeenCalledWith(
+      'old-file-hash/cover.png',
+      'Books',
+      'new-file-hash/cover.png',
+      'Books',
+    );
+    // ...and the file's own artwork must not overwrite the carried one.
+    expect(fs.writeFile).not.toHaveBeenCalledWith(
+      'new-file-hash/cover.png',
+      'Books',
+      expect.anything(),
+    );
+    expect(existingBook.coverImageUrl).toBe(await service.generateCoverImageUrl(existingBook));
+  });
+
+  it("lets the new file's own cover win when the user never chose one", async () => {
+    const existingBook = makeBook({
+      hash: 'old-file-hash',
+      title: AO3_TITLE,
+      author: 'KicsterAsh',
+      metaHash: getMetadataHash(OLD_METADATA),
+      metadata: OLD_METADATA,
+    });
+    const books: Book[] = [existingBook];
+    const fs = service.getFs();
+    const present = new Set<string>(['old-file-hash/cover.png']);
+    fs.exists.mockImplementation(async (path: string) => present.has(path));
+    fs.writeFile.mockImplementation(async (path: string) => {
+      present.add(path);
+    });
+
+    mockPartialMD5.mockResolvedValue('new-file-hash');
+    mockOpen.mockResolvedValue({
+      book: {
+        metadata: NEW_METADATA,
+        getCover: vi.fn().mockResolvedValue(new Blob(['embedded'], { type: 'image/png' })),
+      },
+      format: 'EPUB',
+    });
+
+    await service.importBook(
+      new File(['updated fic'], 'The_Amazing_Traveling.epub', { type: 'application/epub+zip' }),
+      books,
+    );
+
+    expect(fs.copyFile).not.toHaveBeenCalledWith(
+      'old-file-hash/cover.png',
+      'Books',
+      'new-file-hash/cover.png',
+      'Books',
+    );
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      'new-file-hash/cover.png',
+      'Books',
+      expect.anything(),
+    );
+  });
+
   it('leaves the PDF filename rule from #5411 alone', async () => {
     const pdfMetadata = (uuid: string) => ({
       title: 'PowerPoint Presentation',

--- a/apps/readest-app/src/__tests__/services/import-txt-closable-file.test.ts
+++ b/apps/readest-app/src/__tests__/services/import-txt-closable-file.test.ts
@@ -110,9 +110,9 @@ describe('importBook TXT ClosableFile lifecycle', () => {
   let service: TestAppService;
   let mockClose: ReturnType<typeof vi.fn>;
 
-  const makeSourceTxt = (): ClosableFile => {
+  const makeSourceTxt = (name = 'novel.txt'): ClosableFile => {
     mockClose = vi.fn(async () => undefined);
-    const file = new File(['chapter one\n\nhello'], 'novel.txt', {
+    const file = new File(['chapter one\n\nhello'], name, {
       type: 'text/plain',
     }) as ClosableFile;
     file.close = mockClose as ClosableFile['close'];
@@ -187,5 +187,18 @@ describe('importBook TXT ClosableFile lifecycle', () => {
 
     await expect(service.importBook('/library/novel.txt', [])).rejects.toThrow();
     expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+  // Issue #5959: once the pickers stop dropping "novel.txt (1)", the importer
+  // has to recognise it as a TXT too, or it reaches the document loader as an
+  // unknown binary and fails with "Unsupported or corrupted book file".
+  it('converts a TXT whose duplicate-download marker landed after the extension', async () => {
+    // `fs.openFile` reports the on-disk name, marker and all.
+    const source = makeSourceTxt('novel.txt (1)');
+    service.getFs().openFile.mockResolvedValue(source);
+
+    const result = await service.importBook('/library/novel.txt (1)', []);
+
+    expect(result).not.toBeNull();
+    expect(mockConvert).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/readest-app/src/__tests__/services/ingest-service.test.ts
+++ b/apps/readest-app/src/__tests__/services/ingest-service.test.ts
@@ -571,6 +571,7 @@ describe('ingestFile', () => {
     const lookupIndex = {
       byHash: new Map(),
       byMetaKey: new Map(),
+      byStableKey: new Map(),
       byFilePath: new Map([[sourcePath.toLowerCase(), existing]]),
     } as unknown as Parameters<typeof ingestFile>[0]['lookupIndex'];
     const book = await ingestFile(
@@ -612,6 +613,7 @@ describe('ingestFile', () => {
     const lookupIndex = {
       byHash: new Map(),
       byMetaKey: new Map(),
+      byStableKey: new Map(),
       byFilePath: new Map([[sourcePath, existing]]),
     } as unknown as Parameters<typeof ingestFile>[0]['lookupIndex'];
     await ingestFile(

--- a/apps/readest-app/src/__tests__/utils/file-extension.test.ts
+++ b/apps/readest-app/src/__tests__/utils/file-extension.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest';
+import { getFileExtension } from '@/utils/path';
+
+// Issue #5959: browsers and download managers append a duplicate marker when a
+// download would overwrite an existing file, and several put it AFTER the
+// extension ("The_Amazing_Traveling.epub (1)"). A naive
+// `name.split('.').pop()` reads that as the extension "epub (1)", so every
+// ingress whitelist dropped the file and the import silently did nothing.
+describe('getFileExtension', () => {
+  test('reads a plain extension', () => {
+    expect(getFileExtension('book.epub')).toBe('epub');
+    expect(getFileExtension('/home/user/books/book.EPUB')).toBe('epub');
+  });
+
+  test('looks past a duplicate marker appended after the extension', () => {
+    expect(getFileExtension('The_Amazing_Traveling.epub (1)')).toBe('epub');
+    expect(getFileExtension('The_Amazing_Traveling.epub(2)')).toBe('epub');
+    expect(getFileExtension('notes.txt (10)')).toBe('txt');
+  });
+
+  test('leaves a marker that sits before the extension alone', () => {
+    expect(getFileExtension('The_Amazing_Traveling (1).epub')).toBe('epub');
+  });
+
+  test('keeps parentheses that are part of the name', () => {
+    expect(getFileExtension('Dune (1965).epub')).toBe('epub');
+    expect(getFileExtension('report.2024 (1)')).toBe('2024');
+  });
+
+  test('returns an empty string when there is no extension', () => {
+    expect(getFileExtension('README')).toBe('');
+    expect(getFileExtension('archive (1)')).toBe('');
+    expect(getFileExtension('')).toBe('');
+  });
+});

--- a/apps/readest-app/src/__tests__/utils/metadata-hash-info.test.ts
+++ b/apps/readest-app/src/__tests__/utils/metadata-hash-info.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getMetadataHash, getMetadataHashInfo } from '@/utils/book';
+import { getMetadataHash, getMetadataHashInfo, getStableMetadataHash } from '@/utils/book';
 import type { BookMetadata } from '@/libs/document';
 
 describe('getMetadataHashInfo', () => {
@@ -76,5 +76,84 @@ describe('getMetadataHashInfo', () => {
       const info = getMetadataHashInfo(metadata);
       expect(info!.hashSource).toBe('PowerPoint Presentation|Alice Author|');
     });
+  });
+});
+
+// Issue #5959: calibre (and therefore every AO3 / FanFicFare download) mints a
+// fresh random UUID into dc:identifier on every export, so the same work
+// re-downloaded after an update hashes differently and imports as a new book.
+// getMetadataHash itself must not change - it is the wire key shared with the
+// sync server and the KOReader plugin (meta_hash_v1) - so the re-import path
+// gets a second, volatile-identifier-free key instead.
+describe('getStableMetadataHash', () => {
+  const withIdentifier = (identifier: string): BookMetadata => ({
+    title: 'The Amazing Traveling Circus Part 2 - The Golden Butterfly',
+    author: 'KicsterAsh',
+    language: 'en',
+    altIdentifier: identifier,
+  });
+
+  it('collapses two exports of the same book that differ only by a random uuid', () => {
+    const first = withIdentifier('urn:uuid:08bc8344-c0c9-485c-afcb-c15202570205');
+    const second = withIdentifier('urn:uuid:d559a18b-88fa-4560-9f1d-4922e2471ba4');
+
+    // The shipped hash keeps them apart - that is the bug being worked around.
+    expect(getMetadataHash(first)).not.toBe(getMetadataHash(second));
+
+    expect(getStableMetadataHash(first)).toBeDefined();
+    expect(getStableMetadataHash(first)).toBe(getStableMetadataHash(second));
+  });
+
+  it('accepts a bare uuid and a { scheme, value } identifier as volatile too', () => {
+    const bare = withIdentifier('9ad3ec1e-1f1e-4a58-9f0a-2a9d1a8ef111');
+    const urn = withIdentifier('urn:uuid:9ad3ec1e-1f1e-4a58-9f0a-2a9d1a8ef111');
+    const scoped = {
+      ...withIdentifier(''),
+      altIdentifier: { scheme: 'uuid', value: '9ad3ec1e-1f1e-4a58-9f0a-2a9d1a8ef111' },
+    } as unknown as BookMetadata;
+
+    expect(getStableMetadataHash(bare)).toBe(getStableMetadataHash(urn));
+    expect(getStableMetadataHash(scoped)).toBe(getStableMetadataHash(urn));
+  });
+
+  it('returns undefined when no identifier is volatile', () => {
+    expect(getStableMetadataHash(withIdentifier('urn:isbn:9780743273565'))).toBeUndefined();
+    expect(
+      getStableMetadataHash({
+        title: 'Untitled',
+        author: 'Nobody',
+        language: 'en',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('keeps a stable identifier that sits alongside the volatile uuid', () => {
+    const a = {
+      title: 'Book',
+      author: 'Author',
+      language: 'en',
+      altIdentifier: ['urn:uuid:1111aaaa-1111-4111-8111-111111111111', 'urn:isbn:9780000000001'],
+    } as unknown as BookMetadata;
+    const b = {
+      title: 'Book',
+      author: 'Author',
+      language: 'en',
+      altIdentifier: ['urn:uuid:2222bbbb-2222-4222-8222-222222222222', 'urn:isbn:9780000000002'],
+    } as unknown as BookMetadata;
+
+    expect(getStableMetadataHash(a)).toBeDefined();
+    expect(getStableMetadataHash(a)).not.toBe(getStableMetadataHash(b));
+  });
+
+  it('keeps books with different titles or authors apart', () => {
+    const uuid = 'urn:uuid:3333cccc-3333-4333-8333-333333333333';
+    const base = { language: 'en', altIdentifier: uuid };
+
+    const one = { ...base, title: 'Volume 1', author: 'Author' } as unknown as BookMetadata;
+    const two = { ...base, title: 'Volume 2', author: 'Author' } as unknown as BookMetadata;
+    const three = { ...base, title: 'Volume 1', author: 'Other' } as unknown as BookMetadata;
+
+    expect(getStableMetadataHash(one)).not.toBe(getStableMetadataHash(two));
+    expect(getStableMetadataHash(one)).not.toBe(getStableMetadataHash(three));
   });
 });

--- a/apps/readest-app/src/app/library/hooks/useDragDropImport.ts
+++ b/apps/readest-app/src/app/library/hooks/useDragDropImport.ts
@@ -10,11 +10,11 @@ import { useSettingsStore } from '@/store/settingsStore';
 import { LibraryGroupByType } from '@/types/settings';
 import { ensureLibraryGroupByType } from '../utils/libraryUtils';
 import { BOOK_ACCEPT_FORMATS, SUPPORTED_BOOK_EXTS } from '@/services/constants';
+import { hasAllowedExtension } from '@/hooks/useFileSelector';
 import { useSearchParams } from 'next/navigation';
 
 const hasSupportedBookExt = (name: string) => {
-  const ext = name.split('.').pop()?.toLowerCase();
-  return ext ? SUPPORTED_BOOK_EXTS.includes(ext) : false;
+  return hasAllowedExtension(name, SUPPORTED_BOOK_EXTS);
 };
 
 export const useDragDropImport = () => {

--- a/apps/readest-app/src/hooks/useAndroidFilePicker.ts
+++ b/apps/readest-app/src/hooks/useAndroidFilePicker.ts
@@ -4,8 +4,11 @@ import { AppService } from '@/types/system';
 import {
   FILE_SELECTION_PRESETS,
   SelectedFile,
+  hasAllowedExtension,
   resolveTauriFileName,
 } from '@/hooks/useFileSelector';
+import { useTranslation } from '@/hooks/useTranslation';
+import { eventDispatcher } from '@/utils/event';
 
 interface FilePickerResultPayload {
   uris: string[];
@@ -37,6 +40,9 @@ export function useAndroidPickedBooks(
   // unregister/register pair.
   const onPickedBooksRef = useRef(onPickedBooks);
   onPickedBooksRef.current = onPickedBooks;
+  const _ = useTranslation();
+  const _ref = useRef(_);
+  _ref.current = _;
 
   useEffect(() => {
     if (!appService?.isAndroidApp) return;
@@ -54,12 +60,20 @@ export function useAndroidPickedBooks(
           uris.map(async (path) => ({ path, name: await resolveTauriFileName(path, appService) })),
         );
         const extensions = FILE_SELECTION_PRESETS.books.extensions;
-        const books = files.filter(({ name }) => {
-          const ext = name?.split('.').pop()?.toLowerCase() || 'unknown';
-          return extensions.includes(ext);
-        });
+        const books = files.filter(({ name }) => hasAllowedExtension(name, extensions));
         if (books.length > 0) {
           onPickedBooksRef.current(books);
+        } else {
+          // Dropping every pick used to be completely silent, so an
+          // unsupported (or oddly named) file looked like the import button
+          // doing nothing at all (issue #5959).
+          eventDispatcher.dispatch('toast', {
+            type: 'error',
+            message: _ref.current('Failed to import book(s): {{filenames}}', {
+              filenames: files.map(({ name, path }) => name || path).join(', '),
+            }),
+            timeout: 5000,
+          });
         }
       },
     );

--- a/apps/readest-app/src/hooks/useAndroidFilePicker.ts
+++ b/apps/readest-app/src/hooks/useAndroidFilePicker.ts
@@ -63,14 +63,17 @@ export function useAndroidPickedBooks(
         const books = files.filter(({ name }) => hasAllowedExtension(name, extensions));
         if (books.length > 0) {
           onPickedBooksRef.current(books);
-        } else {
-          // Dropping every pick used to be completely silent, so an
-          // unsupported (or oddly named) file looked like the import button
-          // doing nothing at all (issue #5959).
+        }
+        // Files the whitelist drops used to vanish without a trace, so an
+        // unsupported (or oddly named) pick looked like the import button doing
+        // nothing at all (issue #5959). Name them, whether or not anything else
+        // in the same pick made it through.
+        if (books.length < files.length) {
+          const skipped = files.filter((file) => !books.includes(file));
           eventDispatcher.dispatch('toast', {
             type: 'error',
             message: _ref.current('Failed to import book(s): {{filenames}}', {
-              filenames: files.map(({ name, path }) => name || path).join(', '),
+              filenames: skipped.map(({ name, path }) => name || path).join(', '),
             }),
             timeout: 5000,
           });

--- a/apps/readest-app/src/hooks/useFileSelector.ts
+++ b/apps/readest-app/src/hooks/useFileSelector.ts
@@ -151,14 +151,18 @@ const selectFileTauri = async (
   if (noFilter && options.extensions) {
     const extensions = options.extensions;
     const kept = files.filter(({ name }) => hasAllowedExtension(name, extensions));
-    // An all-dropped selection is indistinguishable from a cancel to the
-    // caller, which turns picking an unsupported file into a silent no-op
-    // (issue #5959). Name what was skipped instead.
-    if (kept.length === 0 && files.length > 0) {
+    // Whatever the whitelist drops here disappears without a trace: an
+    // all-dropped selection is indistinguishable from a cancel, and a mixed one
+    // imports part of the pick and stays quiet about the rest (issue #5959).
+    // Name the skipped files. Only book selections get the toast — it is the
+    // one message already translated, and it would read as nonsense for an
+    // audio or dictionary pick.
+    if (options.type === 'books' && kept.length < files.length) {
+      const skipped = files.filter((file) => !kept.includes(file));
       eventDispatcher.dispatch('toast', {
         type: 'error',
         message: _('Failed to import book(s): {{filenames}}', {
-          filenames: files.map(({ name, path }) => name || getFilename(path!)).join(', '),
+          filenames: skipped.map(({ name, path }) => name || getFilename(path!)).join(', '),
         }),
         timeout: 5000,
       });

--- a/apps/readest-app/src/hooks/useFileSelector.ts
+++ b/apps/readest-app/src/hooks/useFileSelector.ts
@@ -3,7 +3,8 @@ import { isTauriAppPlatform } from '@/services/environment';
 import { invoke } from '@tauri-apps/api/core';
 import { basename } from '@tauri-apps/api/path';
 import { isContentURI, isFileURI, stubTranslation as _ } from '@/utils/misc';
-import { getFilename } from '@/utils/path';
+import { getFileExtension, getFilename } from '@/utils/path';
+import type { TranslationFunc } from '@/hooks/useTranslation';
 import { eventDispatcher } from '@/utils/event';
 import { BOOK_ACCEPT_FORMATS, SUPPORTED_BOOK_EXTS } from '@/services/constants';
 
@@ -36,6 +37,14 @@ export interface FileSelectionResult {
   files: SelectedFile[];
   error?: string;
 }
+
+/**
+ * Whether `filename` is one of `extensions` (lowercase, no leading dot), with
+ * `'*'` accepting anything. Tolerates the duplicate-download marker some
+ * browsers append after the extension, e.g. `book.epub (1)` (issue #5959).
+ */
+export const hasAllowedExtension = (filename: string | undefined, extensions: string[]) =>
+  extensions.includes('*') || extensions.includes(getFileExtension(filename || ''));
 
 const selectFileWeb = (options: FileSelectorOptions): Promise<File[]> => {
   return new Promise((resolve) => {
@@ -90,7 +99,7 @@ const isGamescopeSession = async (): Promise<boolean> => {
 const selectFileTauri = async (
   options: FileSelectorOptions,
   appService: AppService,
-  _: (key: string) => string,
+  _: TranslationFunc,
 ): Promise<SelectedFile[]> => {
   // A gamescope session (SteamOS Gaming Mode) runs no XDG portal backend, so
   // the FileChooser dialog can never appear, and the sandboxed Flatpak relies
@@ -141,10 +150,20 @@ const selectFileTauri = async (
 
   if (noFilter && options.extensions) {
     const extensions = options.extensions;
-    files = files.filter(({ name }) => {
-      const fileExt = name?.split('.').pop()?.toLowerCase() || 'unknown';
-      return extensions.includes(fileExt) || extensions.includes('*');
-    });
+    const kept = files.filter(({ name }) => hasAllowedExtension(name, extensions));
+    // An all-dropped selection is indistinguishable from a cancel to the
+    // caller, which turns picking an unsupported file into a silent no-op
+    // (issue #5959). Name what was skipped instead.
+    if (kept.length === 0 && files.length > 0) {
+      eventDispatcher.dispatch('toast', {
+        type: 'error',
+        message: _('Failed to import book(s): {{filenames}}', {
+          filenames: files.map(({ name, path }) => name || getFilename(path!)).join(', '),
+        }),
+        timeout: 5000,
+      });
+    }
+    files = kept;
   }
 
   return files;
@@ -156,7 +175,7 @@ const processWebFiles = (files: File[]): SelectedFile[] => {
   }));
 };
 
-export const useFileSelector = (appService: AppService | null, _: (key: string) => string) => {
+export const useFileSelector = (appService: AppService | null, _: TranslationFunc) => {
   const selectFiles = async (options: FileSelectorOptions = { type: 'generic' }) => {
     options = { ...FILE_SELECTION_PRESETS[options.type], ...options };
     if (!appService) {

--- a/apps/readest-app/src/libs/document.ts
+++ b/apps/readest-app/src/libs/document.ts
@@ -1,6 +1,7 @@
 import { BookFormat } from '@/types/book';
 import { Collection, Contributor, Identifier, LanguageMap } from '@/utils/book';
 import { configureZip } from '@/utils/zip';
+import { stripDuplicateMarker } from '@/utils/path';
 import * as epubcfi from 'foliate-js/epubcfi.js';
 
 export const CFI = epubcfi;
@@ -360,24 +361,34 @@ export class DocumentLoader {
     return { entries, loadText, loadBlob, getSize, getComment, sha1: undefined };
   }
 
+  /**
+   * File name with any duplicate-download marker removed, e.g.
+   * `novel.epub (1)` -> `novel.epub`. Some download managers append the marker
+   * after the extension, which would otherwise hide the extension from every
+   * probe below and drop the file onto the unknown-binary path (issue #5959).
+   */
+  private get filename(): string {
+    return stripDuplicateMarker(this.file.name ?? '');
+  }
+
   private isCBZ(): boolean {
     return (
-      this.file.type === 'application/vnd.comicbook+zip' || this.file.name.endsWith(`.${EXTS.CBZ}`)
+      this.file.type === 'application/vnd.comicbook+zip' || this.filename.endsWith(`.${EXTS.CBZ}`)
     );
   }
 
   private isFB2(): boolean {
     return (
-      this.file.type === 'application/x-fictionbook+xml' || this.file.name.endsWith(`.${EXTS.FB2}`)
+      this.file.type === 'application/x-fictionbook+xml' || this.filename.endsWith(`.${EXTS.FB2}`)
     );
   }
 
   private isFBZ(): boolean {
     return (
       this.file.type === 'application/x-zip-compressed-fb2' ||
-      this.file.name.endsWith('.fb.zip') ||
-      this.file.name.endsWith('.fb2.zip') ||
-      this.file.name.endsWith(`.${EXTS.FBZ}`)
+      this.filename.endsWith('.fb.zip') ||
+      this.filename.endsWith('.fb2.zip') ||
+      this.filename.endsWith(`.${EXTS.FBZ}`)
     );
   }
 
@@ -387,12 +398,12 @@ export class DocumentLoader {
     // non-text path and yield a null book.
     return (
       this.file.type.startsWith('text/plain') ||
-      (this.file.name?.toLowerCase().endsWith(`.${EXTS.TXT}`) ?? false)
+      this.filename.toLowerCase().endsWith(`.${EXTS.TXT}`)
     );
   }
 
   private isMd(): boolean {
-    const name = this.file.name?.toLowerCase() ?? '';
+    const name = this.filename.toLowerCase();
     return (
       this.file.type === 'text/markdown' ||
       this.file.type === 'text/x-markdown' ||
@@ -465,7 +476,7 @@ export class DocumentLoader {
         const fflate = await import('foliate-js/vendor/fflate.js');
         const { MOBI } = await import('foliate-js/mobi.js');
         book = await new MOBI({ unzlib: fflate.unzlibSync }).open(this.file);
-        const ext = this.file.name.split('.').pop()?.toLowerCase();
+        const ext = this.filename.split('.').pop()?.toLowerCase();
         switch (ext) {
           case 'azw':
             format = 'AZW';

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -761,6 +761,28 @@ export async function importBook(
         await fs.writeFile(bookFilename, 'Books', fileobj);
       }
     }
+    // A metaHash match re-keys the book to the incoming file's hash directory
+    // and retires the old one further down. The cover step below only writes
+    // the embedded cover when the target has none, so carry a cover the user
+    // picked themselves across first — `coverUpdatedAt` is set by nothing but
+    // that edit. Without this, updating a book silently reverts its cover to
+    // whatever artwork the new file happens to embed (issue #5959).
+    if (
+      saveCover &&
+      metaHashMatch &&
+      oldBookDir &&
+      oldBookDir !== getDir(book) &&
+      existingBook?.coverUpdatedAt
+    ) {
+      const oldCoverPath = `${oldBookDir}/cover.png`;
+      try {
+        if (await fs.exists(oldCoverPath, 'Books')) {
+          await fs.copyFile(oldCoverPath, 'Books', getCoverFilename(book), 'Books');
+        }
+      } catch (error) {
+        console.warn('Failed to carry the custom cover to the new book directory:', error);
+      }
+    }
     if (saveCover && (!(await fs.exists(getCoverFilename(book), 'Books')) || overwrite)) {
       let cover = await loadedBook.getCover();
       if (cover?.type === 'image/svg+xml') {
@@ -929,6 +951,9 @@ export async function importBook(
       }
     }
     book.coverImageUrl = await generateCoverImageUrlFn(book);
+    // The row we hand back is `existingBook` on a match, and its cached URL
+    // still points into the directory this import just retired.
+    if (existingBook) existingBook.coverImageUrl = book.coverImageUrl;
 
     return existingBook || book;
   } catch (error) {

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -22,6 +22,7 @@ import {
   formatAuthors,
   getPrimaryLanguage,
   getMetadataHash,
+  getStableMetadataHash,
 } from '@/utils/book';
 import type { BookNav } from '@/services/nav';
 import { partialMD5, md5 } from '@/utils/md5';
@@ -49,9 +50,22 @@ import {
   type BookFileContentSource,
 } from './bookContent';
 
+/**
+ * Import-time fallback key for a book already in the library, or undefined when
+ * its `metaHash` is already stable across re-exports (issue #5959).
+ *
+ * PDFs are left out: #5411 deliberately scopes their identity to the filename,
+ * and a library row no longer knows the filename it was imported from.
+ */
+function getStableBookHash(book: Book) {
+  if (book.format === 'PDF' || !book.metadata) return undefined;
+  return getStableMetadataHash(book.metadata);
+}
+
 export function buildBookLookupIndex(books: Book[], osPlatform?: OsPlatform): BookLookupIndex {
   const byHash = new Map<string, Book>();
   const byMetaKey = new Map<string, Book[]>();
+  const byStableKey = new Map<string, Book[]>();
   const byFilePath = new Map<string, Book>();
   for (const book of books) {
     byHash.set(book.hash, book);
@@ -60,6 +74,15 @@ export function buildBookLookupIndex(books: Book[], osPlatform?: OsPlatform): Bo
       const list = byMetaKey.get(key);
       if (list) list.push(book);
       else byMetaKey.set(key, [book]);
+    }
+    if (!book.deletedAt) {
+      const stableHash = getStableBookHash(book);
+      if (stableHash) {
+        const key = `${stableHash}:${book.format}`;
+        const list = byStableKey.get(key);
+        if (list) list.push(book);
+        else byStableKey.set(key, [book]);
+      }
     }
     // In-place books carry the absolute source path on `filePath` (set by
     // importBook below). Indexing them here lets a re-import of the exact
@@ -70,7 +93,7 @@ export function buildBookLookupIndex(books: Book[], osPlatform?: OsPlatform): Bo
       if (key) byFilePath.set(key, book);
     }
   }
-  return { byHash, byMetaKey, byFilePath };
+  return { byHash, byMetaKey, byStableKey, byFilePath };
 }
 
 /**
@@ -590,6 +613,7 @@ export async function importBook(
       loadedBook.metadata,
       format === 'PDF' ? getBaseFilename(filename) : undefined,
     );
+    const stableHash = format === 'PDF' ? undefined : getStableMetadataHash(loadedBook.metadata);
     let existingBook = lookupIndex
       ? lookupIndex.byHash.get(hash)
       : books.find((b) => b.hash === hash);
@@ -611,9 +635,21 @@ export async function importBook(
     if (!transient && metaHash) {
       if (!existingBook) {
         const metaKey = `${metaHash}:${format}`;
-        const firstMatch = lookupIndex
+        let firstMatch = lookupIndex
           ? (lookupIndex.byMetaKey.get(metaKey) ?? []).find((b) => !b.deletedAt)
           : books.find((b) => b.metaHash === metaHash && b.format === format && !b.deletedAt);
+        // The metaHash of a calibre-built file moves with every export, so a
+        // re-downloaded update of a book already in the library misses above
+        // (issue #5959). Retry on the hash that leaves those throwaway
+        // identifiers out; only files that carry one have a stable hash at all.
+        if (!firstMatch && stableHash) {
+          const stableKey = `${stableHash}:${format}`;
+          firstMatch = lookupIndex
+            ? (lookupIndex.byStableKey.get(stableKey) ?? []).find((b) => !b.deletedAt)
+            : books.find(
+                (b) => !b.deletedAt && b.format === format && getStableBookHash(b) === stableHash,
+              );
+        }
         if (firstMatch) {
           oldBookDir = getDir(firstMatch);
           existingBook = firstMatch;
@@ -792,6 +828,12 @@ export async function importBook(
             const list = lookupIndex.byMetaKey.get(key);
             if (list) list.push(book);
             else lookupIndex.byMetaKey.set(key, [book]);
+          }
+          if (stableHash) {
+            const key = `${stableHash}:${book.format}`;
+            const list = lookupIndex.byStableKey.get(key);
+            if (list) list.push(book);
+            else lookupIndex.byStableKey.set(key, [book]);
           }
         }
       }

--- a/apps/readest-app/src/services/bookService.ts
+++ b/apps/readest-app/src/services/bookService.ts
@@ -26,7 +26,7 @@ import {
 } from '@/utils/book';
 import type { BookNav } from '@/services/nav';
 import { partialMD5, md5 } from '@/utils/md5';
-import { getBaseFilename, getFilename } from '@/utils/path';
+import { getBaseFilename, getFilename, stripDuplicateMarker } from '@/utils/path';
 import { BookDoc, DocumentLoader } from '@/libs/document';
 import { hasMediaOverlays } from '@/services/tts/mediaOverlay';
 import { getAudiobookDirectory, isAudiobookFilePath } from '@/services/audiobook/storage';
@@ -520,6 +520,10 @@ export async function importBook(
           fileobj = file;
           filename = file.name;
         }
+        // A download saved as "novel.txt (1)" is still a TXT, and its title
+        // should not read "novel.txt" either. Drop the duplicate marker before
+        // anything downstream classifies or names the book (issue #5959).
+        filename = stripDuplicateMarker(filename);
         const maybeClosable = fileobj as ClosableFile;
         if (typeof maybeClosable.close === 'function') {
           openedSource = maybeClosable;

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -49,6 +49,11 @@ export const FIXED_LAYOUT_FORMATS: Set<BookFormat> = new Set(['PDF', 'CBZ']);
 export interface BookLookupIndex {
   byHash: Map<string, Book>;
   byMetaKey: Map<string, Book[]>; // key = `${metaHash}:${format}`
+  // Fallback for books whose metaHash moves with every export of the same file
+  // (calibre re-mints dc:identifier, issue #5959). key =
+  // `${getStableMetadataHash(metadata)}:${format}`, and only books that carry a
+  // volatile identifier appear here.
+  byStableKey: Map<string, Book[]>;
   // Maps normalized absolute source path -> Book for in-place imports.
   // Lets the importer recognize "I already have this exact file" without
   // having to open, parse, and hash it again. Only books with a non-empty

--- a/apps/readest-app/src/utils/book.ts
+++ b/apps/readest-app/src/utils/book.ts
@@ -474,7 +474,7 @@ const normalizeIdentifier = (identifier: string) => {
   return identifier;
 };
 
-const getPreferredIdentifier = (identifiers: string[] | Identifier[]) => {
+const getPreferredIdentifier = (identifiers: (string | Identifier)[]) => {
   for (const scheme of ['uuid', 'calibre', 'isbn']) {
     const found = identifiers.find((identifier) =>
       typeof identifier === 'string'
@@ -489,7 +489,7 @@ const getPreferredIdentifier = (identifiers: string[] | Identifier[]) => {
 };
 
 const getIdentifiersList = (
-  identifiers: undefined | string | string[] | Identifier | Identifier[],
+  identifiers: undefined | string | Identifier | (string | Identifier)[],
 ) => {
   if (!identifiers) return [];
   if (Array.isArray(identifiers)) {
@@ -538,4 +538,43 @@ export const getMetadataHashInfo = (
 
 export const getMetadataHash = (metadata: BookMetadata, filename?: string) => {
   return getMetadataHashInfo(metadata, filename)?.metaHash;
+};
+
+// A bare UUID identifies an export, not a book: calibre mints a fresh one on
+// every conversion, so every AO3 / FanFicFare re-download of the same work
+// carries a different `dc:identifier` (issue #5959).
+const VOLATILE_IDENTIFIER = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const isVolatileIdentifier = (identifier: string | Identifier) =>
+  VOLATILE_IDENTIFIER.test(
+    typeof identifier === 'string' ? normalizeIdentifier(identifier) : identifier.value,
+  );
+
+/**
+ * Metadata hash computed with volatile identifiers left out, so two exports of
+ * the same book still hash alike. Returns undefined when the metadata carries
+ * no volatile identifier — `getMetadataHash` is already stable for those and
+ * the caller has nothing extra to look up.
+ *
+ * This is a local, import-time key only. Never use it as a sync key:
+ * `getMetadataHash` is a wire format shared with the sync server and with the
+ * KOReader plugin (which caches it as `meta_hash_v1`), so its output has to
+ * stay byte-identical across versions and across the two implementations.
+ */
+export const getStableMetadataHash = (metadata: BookMetadata) => {
+  if (!metadata) return;
+  try {
+    const identifier = metadata.altIdentifier || metadata.identifier;
+    const all = identifier ? (Array.isArray(identifier) ? identifier : [identifier]) : [];
+    const stable = all.filter((id) => !isVolatileIdentifier(id));
+    if (stable.length === all.length) return;
+    const title = getTitleForHash(metadata.title);
+    const authors = getAuthorsList(metadata.author);
+    const identifiers = getIdentifiersList(stable);
+    const hashSource = `${title}|${authors.join(',')}|${identifiers.join(',')}`;
+    return md5(hashSource.normalize('NFC'));
+  } catch (error) {
+    console.error('Error generating stable metadata hash:', error);
+  }
+  return;
 };

--- a/apps/readest-app/src/utils/path.ts
+++ b/apps/readest-app/src/utils/path.ts
@@ -11,6 +11,28 @@ export const getFilename = (fileOrUri: string) => {
   return lastPart.split('?')[0]!;
 };
 
+/**
+ * Duplicate marker a browser or download manager appends when a download would
+ * overwrite an existing file. Several of them put it after the extension
+ * (`The_Amazing_Traveling.epub (1)`), which is what AO3 re-downloads look like
+ * on Android (issue #5959).
+ */
+const DUPLICATE_MARKER = /[\s_-]*\(\d+\)$/;
+
+export const stripDuplicateMarker = (filename: string) => filename.replace(DUPLICATE_MARKER, '');
+
+/**
+ * Lowercased extension of `filename` without the leading dot, or '' when it has
+ * none. Looks past a trailing duplicate marker, so `book.epub (1)` is still an
+ * `epub` — a plain `split('.').pop()` reads that as `epub (1)` and every
+ * extension whitelist then rejects the file.
+ */
+export const getFileExtension = (filename: string) => {
+  const name = stripDuplicateMarker(getFilename(filename));
+  const dotIndex = name.lastIndexOf('.');
+  return dotIndex < 0 ? '' : name.slice(dotIndex + 1).toLowerCase();
+};
+
 export const getBaseFilename = (filename: string) => {
   const normalizedPath = filename.replace(/\\/g, '/');
   const name = normalizedPath.split('/').pop() || '';


### PR DESCRIPTION
Fixes #5959.

A reader on r/readest re-downloaded a fic from AO3 after it was updated, imported it, and got a second library entry instead of an updated book, leaving reading progress and the custom cover behind on the old one. Their two files are the repro: same title, same author, 13.2 MB vs 13.5 MB.

Two independent bugs, one per commit.

### 1. A re-export re-mints the identifier, so the book looks new

`importBook` dedupes on `partialMD5` first (different bytes for an updated file, expected) and then on `metaHash` = `md5("title|authors|identifiers")`. AO3 builds its EPUBs with calibre, and calibre writes a **fresh random `dc:identifier` uuid on every export**:

| | old download | new download |
|---|---|---|
| `dc:title` / `dc:creator` | The Amazing Traveling Circus Part 2 ... / KicsterAsh | identical |
| `dc:identifier` (`scheme="uuid"`) | `08bc8344-c0c9-485c-afcb-c15202570205` | `d559a18b-88fa-4560-9f1d-4922e2471ba4` |

Both lookups miss, so the file lands as a new book. This hits every calibre-produced re-download (AO3, FanFicFare, calibre library exports), not just this one file.

**`getMetadataHash` is deliberately left alone.** It is a wire key: it goes to the sync server as `meta_hash=`, it is stored on synced configs and notes, and the koplugin recomputes it independently and caches it as `meta_hash_v1` (both implementations were aligned in bc8e419d5 / #2154). Dropping the uuid there, or reordering the `['uuid', 'calibre', 'isbn']` preference, would silently break progress matching across devices and across app versions.

So the fix adds a second, local key instead:

- `getStableMetadataHash()` in `utils/book.ts` - the same hash source with bare-UUID identifiers removed. Returns `undefined` when nothing was removed, so files whose identity is already stable never enter the fallback at all.
- `BookLookupIndex.byStableKey` - only books carrying a volatile identifier are indexed, so batch imports stay O(1).
- `importBook` retries on that key when the metaHash lookup misses, then takes the existing merge path: progress, annotations, notes and cover carry over, and the row is re-keyed to the new file.

PDFs are excluded. #5411 salts their metaHash with the filename, and a library row no longer knows the filename it was imported from.

### 2. A download named `book.epub (1)` was silently unimportable

The same thread reported that the re-download arrived as `The_Amazing_Traveling.epub (1)` and would not import until the ` (1)` was removed by hand. Every ingress path classified the file with `name.split('.').pop()`, which reads the extension as `epub (1)`:

- `useFileSelector` - the whitelist the unfiltered iOS/Android pickers re-apply after picking
- `useAndroidFilePicker` - the native-bridge picker path
- `useDragDropImport` - desktop drag and drop

Both mobile paths then returned an empty selection, which the caller cannot tell apart from a cancel, so the import button did nothing and said nothing.

`getFileExtension()` / `stripDuplicateMarker()` in `utils/path.ts` now back a shared `hasAllowedExtension()` used by all three. The marker is stripped further in as well, so accepting the file does not just move the failure downstream: `importBook` (the TXT to EPUB branch and the title fallback) and the `DocumentLoader` probes for MD, TXT, CBZ, FB2, FBZ and the MOBI/AZW3 split. When a pick is dropped entirely, both mobile paths now toast the skipped filenames, reusing the already translated `Failed to import book(s): {{filenames}}` so no new strings are needed; a plain cancel stays quiet.

Side effect worth noting: a PDF re-downloaded as `deck.pdf (1)` now shares the #5411 filename salt with `deck.pdf` instead of importing separately.

The document loader itself never needed any of this - `isZip()` sniffs the PK magic bytes, so the file always parsed fine once it got that far. Desktop's file dialog is the one path still affected: its filter is enforced by the OS, so `foo.epub (1)` stays greyed out in the picker. Drag and drop now accepts it.

### Testing

19 tests, written failing first:

- `getStableMetadataHash`: collapses two exports differing only by uuid, handles bare / `urn:uuid:` / `{scheme, value}` shapes, returns undefined with no volatile identifier, keeps an ISBN that sits alongside the uuid, keeps different titles and authors apart.
- `importBook`: merges the re-download (direct and through the lookup index), keeps different works apart, leaves the #5411 PDF rule intact.
- `getFileExtension`: markers after / before the extension, parentheses that belong to the name, no extension.
- Picker paths: `book.epub (1)` survives on iOS and Android and through the native bridge, dropped picks are reported, a cancel stays silent.
- `importBook` converts `novel.txt (1)`, and `DocumentLoader` still recognizes `notes.md (1)`.

Also checked against the reporter's actual files through `DocumentLoader`: `getMetadataHash` still differs on them, `getStableMetadataHash` matches.

`pnpm test` 10455 passed / 16 skipped, `pnpm lint` and `pnpm format:check` clean. No Rust or koplugin changes, by design - the shared `meta_hash` contract is untouched.

Not covered here: there is still no user-facing "replace the file of this book" action for an existing library entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved support for files with duplicate-download suffixes, such as `book.epub (1)`, across selection, drag-and-drop, and import workflows.
  - Unsupported dropped or selected files now display an error notification, including when mixed with valid files.
  - Re-imported books with regenerated identifiers are more reliably matched to existing library entries.
  - Custom book covers are preserved during re-imports.
  - Canceled file-picker actions no longer trigger unnecessary notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->