### PR TITLE
fix(reader): contain Notebook text while typing (#5956)

### DIFF
--- a/apps/readest-app/src/__tests__/components/TextEditor.test.tsx
+++ b/apps/readest-app/src/__tests__/components/TextEditor.test.tsx
@@ -1,0 +1,60 @@
+import { createRef } from 'react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import TextEditor, { TextEditorRef } from '@/components/TextEditor';
+
+afterEach(cleanup);
+
+describe('TextEditor', () => {
+  it('continues resizing auto-resize editors on input and imperative updates', () => {
+    const editorRef = createRef<TextEditorRef>();
+    render(<TextEditor ref={editorRef} value='' onChange={vi.fn()} ariaLabel='Annotation note' />);
+
+    const editor = screen.getByRole('textbox', { name: 'Annotation note' }) as HTMLTextAreaElement;
+    let scrollHeight = 48;
+    Object.defineProperty(editor, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+
+    fireEvent.change(editor, { target: { value: 'A longer annotation' } });
+    expect(editor.style.height).toBe('48px');
+
+    scrollHeight = 72;
+    act(() => editorRef.current?.setValue('An even longer annotation'));
+    expect(editor.style.height).toBe('72px');
+  });
+
+  it('keeps fixed-height editors fixed while typing when auto-resize is disabled', () => {
+    const onChange = vi.fn();
+    render(<TextEditor value='' onChange={onChange} autoResize={false} ariaLabel='Notebook' />);
+
+    const editor = screen.getByRole('textbox', { name: 'Notebook' }) as HTMLTextAreaElement;
+    expect(editor.style.height).toBe('');
+
+    fireEvent.change(editor, { target: { value: 'A growing notebook entry' } });
+
+    expect(onChange).toHaveBeenCalledWith('A growing notebook entry');
+    expect(editor.style.height).toBe('');
+  });
+
+  it('keeps fixed-height editors fixed when their value is set imperatively', () => {
+    const editorRef = createRef<TextEditorRef>();
+    render(
+      <TextEditor
+        ref={editorRef}
+        value=''
+        onChange={vi.fn()}
+        autoResize={false}
+        ariaLabel='Notebook'
+      />,
+    );
+
+    const editor = screen.getByRole('textbox', { name: 'Notebook' }) as HTMLTextAreaElement;
+    act(() => editorRef.current?.setValue('The last accepted notebook value'));
+
+    expect(editor.value).toBe('The last accepted notebook value');
+    expect(editor.style.height).toBe('');
+  });
+});

--- a/apps/readest-app/src/__tests__/components/text-editor-fixed-height.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/text-editor-fixed-height.browser.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * The Notebook uses TextEditor as a fixed-height scrolling surface. Its text
+ * must not turn the textarea itself into a content-height element while typing.
+ *
+ * Needs real textarea layout and real Tailwind, so it runs as a browser test.
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { default: TextEditor } = await import('@/components/TextEditor');
+await import('@/styles/globals.css');
+
+afterEach(cleanup);
+
+describe('TextEditor fixed-height mode', () => {
+  it('keeps long Notebook text inside the editor while typing', () => {
+    render(
+      <div data-testid='notebook-editor-frame' style={{ height: 120, width: 320 }}>
+        <TextEditor
+          value=''
+          onChange={vi.fn()}
+          autoResize={false}
+          ariaLabel='Notebook'
+          className='h-full min-h-0 overflow-y-auto'
+        />
+      </div>,
+    );
+
+    const frame = screen.getByTestId('notebook-editor-frame');
+    const editor = screen.getByRole('textbox', { name: 'Notebook' }) as HTMLTextAreaElement;
+    const initialHeight = editor.getBoundingClientRect().height;
+
+    fireEvent.change(editor, {
+      target: { value: Array.from({ length: 40 }, (_, index) => `Line ${index + 1}`).join('\n') },
+    });
+
+    expect(editor.getBoundingClientRect().height).toBe(initialHeight);
+    expect(editor.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      frame.getBoundingClientRect().bottom,
+    );
+    expect(editor.scrollHeight).toBeGreaterThan(editor.clientHeight);
+  });
+});

--- a/apps/readest-app/src/components/TextEditor.tsx
+++ b/apps/readest-app/src/components/TextEditor.tsx
@@ -67,7 +67,7 @@ const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
       setValue: (newValue: string) => {
         if (editorRef.current) {
           editorRef.current.value = newValue;
-          adjustHeight();
+          if (autoResize) adjustHeight();
         }
       },
       getElement: () => editorRef.current,
@@ -109,7 +109,7 @@ const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
     };
 
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      adjustHeight();
+      if (autoResize) adjustHeight();
       onChange(e.target.value);
     };
 


### PR DESCRIPTION
## Summary

- Keep the fixed-height Notebook editor from switching to content-height sizing while typing or restoring a rejected edit.
- Preserve the existing auto-resize behavior for annotation and other default `TextEditor` consumers.
- Add unit coverage for both resize modes and a real-Chromium layout regression for long Notebook text.

## Root cause

`TextEditor` gated its value-sync resize effect with `autoResize`, but `handleChange()` and the imperative `setValue()` path still called `adjustHeight()` unconditionally. The Notebook passes `autoResize={false}` and relies on a fixed-height, vertically scrollable textarea, so each edit wrote the content height inline and let the textarea grow outside its border. Reopening the Notebook remounted the component and cleared that inline height, which is why it appeared to reset.

## Coverage

- 7/7 affected code paths and user flows covered (100% coverage audit).
- Unit tests cover input and imperative updates in both default auto-resize and fixed-height modes.
- Browser test types 40 lines into a 120px Notebook frame and verifies that the textarea height stays fixed, remains inside the frame, and becomes scrollable.

## Pre-landing review

- Specialist review: 0 findings, quality score 10/10.
- Scope check: clean; only the resize gate and focused regression coverage changed.
- No relevant implementation plan was present.

## Verification

- `pnpm test:pr:web:unit`: 10,436 passed, 16 skipped.
- `pnpm test:browser`: 402 passed, 1 skipped (two clean full-suite runs).
- Focused regression rerun: unit 3/3 and Chromium 1/1 passed.
- `pnpm lint`: TypeScript and Biome passed across 2,277 files.
- `git diff --check`: passed.

A later accidental full-browser invocation encountered an unrelated animation-frame assertion in `dialog-close-frames.browser.test.tsx` followed by a browser connection close; the focused Notebook regression remained green.

Closes READ-1
Closes #5956


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fixed-height text editors unexpectedly growing when typing or updating content programmatically.
  * Preserved scrolling for long text while keeping the editor within its configured frame.
  * Auto-resizing editors continue to adjust their height as content changes.

* **Tests**
  * Added coverage for auto-resizing and fixed-height editor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->