### PR TITLE
fix(reader): keep TTS chapter indicators synced (#5953)

### DIFF
--- a/apps/readest-app/src/__tests__/components/tts/TTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSControl.test.tsx
@@ -53,8 +53,14 @@ vi.mock('@/app/reader/components/tts/TTSMiniPlayer', () => ({
 
 vi.mock('@/app/reader/components/tts/TTSPlayerSheet', () => ({
   __esModule: true,
-  default: ({ isOpen }: { isOpen: boolean }) =>
-    isOpen ? <div data-testid='player-sheet' /> : null,
+  default: ({
+    isOpen,
+    activeSectionIndex,
+  }: {
+    isOpen: boolean;
+    activeSectionIndex: number | null;
+  }) =>
+    isOpen ? <div data-testid='player-sheet' data-active-section={activeSectionIndex} /> : null,
 }));
 
 import TTSControl from '@/app/reader/components/tts/TTSControl';
@@ -69,6 +75,7 @@ describe('TTSControl', () => {
       ttsClientsInited: true,
       showIndicator: true,
       showBackToCurrentTTSLocation: false,
+      ttsSectionIndex: 2,
       getController: () => null,
       timeoutOption: 0,
       timeoutTimestamp: 0,
@@ -126,6 +133,12 @@ describe('TTSControl', () => {
     expect(screen.getByTestId('player-sheet')).toBeTruthy();
     // The two surfaces never show at the same time.
     expect(screen.queryByTestId('mini-player')).toBeNull();
+  });
+
+  test('passes the TTS session section to the chapters indicator', () => {
+    render(<TTSControl bookKey='b1' gridInsets={gridInsets} />);
+    fireEvent.click(screen.getByTestId('mini-player'));
+    expect(screen.getByTestId('player-sheet').getAttribute('data-active-section')).toBe('2');
   });
 
   test('shows the back-to-TTS-location pill when reading has drifted', () => {

--- a/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
+++ b/apps/readest-app/src/__tests__/components/tts/TTSPlayerSheet.test.tsx
@@ -192,6 +192,68 @@ describe('TTSPlayerSheet', () => {
     expect(screen.queryByText('Read Aloud')).toBeNull();
   });
 
+  test('resolves the chapter label from the ranged TTS section metadata', () => {
+    const props = makeProps();
+    render(
+      <TTSPlayerSheet
+        {...props}
+        activeSectionIndex={3}
+        downloads={{
+          ...props.downloads,
+          chapters: [
+            { key: 'one', label: 'Chapter One', depth: 0, startSection: 0, endSection: 2 },
+            { key: 'two', label: 'Chapter Two', depth: 0, startSection: 2, endSection: 5 },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Chapter Two')).toBeTruthy();
+    expect(screen.queryByText('Chapter 5')).toBeNull();
+  });
+
+  test('falls back to an accurate section label when chapter metadata is missing', () => {
+    const props = makeProps();
+    render(
+      <TTSPlayerSheet
+        {...props}
+        activeSectionIndex={4}
+        downloads={{ ...props.downloads, chapters: [] }}
+      />,
+    );
+
+    expect(screen.getByText('Section 5')).toBeTruthy();
+    expect(screen.queryByText('Chapter 5')).toBeNull();
+  });
+
+  test('ignores malformed chapter ranges and blank labels', () => {
+    const props = makeProps();
+    render(
+      <TTSPlayerSheet
+        {...props}
+        activeSectionIndex={3}
+        downloads={{
+          ...props.downloads,
+          chapters: [
+            { key: 'negative', label: 'Wrong Negative', depth: 0, startSection: -1, endSection: 5 },
+            {
+              key: 'fractional',
+              label: 'Wrong Fractional',
+              depth: 0,
+              startSection: 2.5,
+              endSection: 5,
+            },
+            { key: 'blank', label: '   ', depth: 0, startSection: 2, endSection: 5 },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Section 4')).toBeTruthy();
+    expect(screen.queryByText('Wrong Negative')).toBeNull();
+    expect(screen.queryByText('Wrong Fractional')).toBeNull();
+  });
+
   test('degrades without a timeline: no scrubber, estimate text instead', () => {
     render(
       <TTSPlayerSheet

--- a/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
+++ b/apps/readest-app/src/__tests__/hooks/useTTSControl.test.tsx
@@ -184,6 +184,9 @@ vi.mock('@/services/tts', () => ({
       isSoundingSentenceOnScreen: vi.fn().mockReturnValue(false),
       getCurrentHighlightCfi: vi.fn().mockReturnValue(null),
       getCurrentPlaybackCfi: vi.fn().mockReturnValue(null),
+      getSectionIndex: vi.fn().mockReturnValue(0),
+      usesAudioTransport: vi.fn().mockReturnValue(false),
+      supportsLyrics: vi.fn().mockReturnValue(false),
       reapplyCurrentHighlight: vi.fn(),
       kind: 'tts',
       terminated: false,
@@ -308,6 +311,61 @@ const Harness = () => {
   useTTSControl({ bookKey: 'book-1' });
   return null;
 };
+
+const SectionIndexHarness = () => {
+  const { ttsSectionIndex } = useTTSControl({ bookKey: 'book-1' });
+  return <output data-testid='tts-section-index'>{ttsSectionIndex ?? 'none'}</output>;
+};
+
+describe('useTTSControl section cursor', () => {
+  beforeEach(() => {
+    ttsControllerInstances.length = 0;
+    pendingInitResolvers.length = 0;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('hydrates from the controller and follows section-change events', async () => {
+    render(<SectionIndexHarness />);
+
+    await act(async () => {
+      const start = eventDispatcher.dispatch('tts-speak', { bookKey: 'book-1' });
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      while (pendingInitResolvers.length > 0) pendingInitResolvers.shift()!();
+      await start;
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('tts-section-index').textContent).toBe('0');
+
+    const controller = ttsControllerInstances[0] as {
+      addEventListener: { mock: { calls: [string, (event: Event) => void][] } };
+    };
+    const listener = controller.addEventListener.mock.calls.find(
+      ([eventName]) => eventName === 'tts-section-change',
+    )?.[1];
+    if (!listener) throw new Error('tts-section-change listener was not registered');
+
+    act(() => {
+      listener(
+        new CustomEvent('tts-section-change', {
+          detail: { sectionIndex: 2 },
+        }),
+      );
+    });
+
+    expect(screen.getByTestId('tts-section-index').textContent).toBe('2');
+
+    await act(async () => {
+      await eventDispatcher.dispatch('tts-stop', { bookKey: 'book-1' });
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('tts-section-index').textContent).toBe('none');
+  });
+});
 
 describe('useTTSControl concurrent tts-speak events', () => {
   beforeEach(() => {
@@ -1052,6 +1110,7 @@ describe('useTTSControl background session lifecycle', () => {
       getSpeakingLang: vi.fn().mockReturnValue('en'),
       getCurrentHighlightCfi: vi.fn().mockReturnValue(null),
       getCurrentPlaybackCfi: vi.fn().mockReturnValue(null),
+      getSectionIndex: vi.fn().mockReturnValue(0),
       isSoundingSentenceOnScreen: vi.fn().mockReturnValue(false),
       getSpokenSentence: vi.fn().mockReturnValue(null),
       updateHighlightOptions: vi.fn(),

--- a/apps/readest-app/src/__tests__/services/tts-controller.test.ts
+++ b/apps/readest-app/src/__tests__/services/tts-controller.test.ts
@@ -1107,16 +1107,47 @@ describe('TTSController', () => {
 
     test('auto-advance stops at the boundary, parked on the next section', async () => {
       await arriveAtSectionEnd();
+      const sectionChanges: number[] = [];
+      controller.addEventListener('tts-section-change', (event) => {
+        sectionChanges.push((event as CustomEvent<{ sectionIndex: number }>).detail.sectionIndex);
+      });
       controller.stopAtChapterEnd = true;
 
       await controller.forward(false, true);
 
       expect(sectionOpened(1)).toBe(true);
+      expect(controller.getSectionIndex()).toBe(1);
+      expect(sectionChanges).toEqual([1]);
       // 'forward-paused', not 'paused': the play/pause toggle routes plain
       // 'paused' to the lightweight ttsClient.resume(), which would be a no-op
       // here since nothing was ever spoken for the new section.
       expect(controller.state).toBe('forward-paused');
       expect(stopKeepAlive).toHaveBeenCalled();
+    });
+
+    test('paused cross-section navigation publishes the section Play will resume from', async () => {
+      await controller.init();
+      await controller.initViewTTS(0);
+      const sectionChanges: number[] = [];
+      controller.addEventListener('tts-section-change', (event) => {
+        sectionChanges.push((event as CustomEvent<{ sectionIndex: number }>).detail.sectionIndex);
+      });
+
+      const firstTts = mockView.tts as unknown as Record<string, ReturnType<typeof vi.fn>>;
+      firstTts['next'] = vi.fn().mockReturnValue(undefined);
+      controller.state = 'paused';
+      await controller.forward();
+
+      expect(controller.state).toBe('forward-paused');
+      expect(controller.getSectionIndex()).toBe(1);
+
+      const secondTts = mockView.tts as unknown as Record<string, ReturnType<typeof vi.fn>>;
+      secondTts['prev'] = vi.fn().mockReturnValue(undefined);
+      await controller.backward();
+
+      expect(controller.state).toBe('backward-paused');
+      expect(controller.getSectionIndex()).toBe(0);
+      expect(sectionChanges).toEqual([1, 0]);
     });
 
     test('auto-advance crosses the boundary normally when the mode is off', async () => {

--- a/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSControl.tsx
@@ -5,7 +5,6 @@ import { useReaderStore } from '@/store/readerStore';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useTTSControl } from '@/app/reader/hooks/useTTSControl';
 import { useTTSDownloads } from '@/app/reader/hooks/useTTSDownloads';
-import { useBookProgress } from '@/store/readerProgressStore';
 import { Insets } from '@/types/misc';
 import { eventDispatcher } from '@/utils/event';
 import TTSMiniPlayer from './TTSMiniPlayer';
@@ -33,7 +32,7 @@ const TTSControl: React.FC<TTSControlProps> = ({ bookKey, gridInsets }) => {
   });
 
   const downloads = useTTSDownloads(bookKey, tts.getController, showPlayerSheet);
-  const activeSectionIndex = useBookProgress(bookKey)?.index ?? null;
+  const activeSectionIndex = tts.ttsSectionIndex;
 
   const viewSettings = getViewSettings(bookKey);
   const isEink = viewSettings?.isEink ?? false;

--- a/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
+++ b/apps/readest-app/src/app/reader/components/tts/TTSPlayerSheet.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   MdAlarm,
   MdArrowBackIosNew,
@@ -178,7 +178,23 @@ const TTSPlayerSheet = ({
   const iconSize32 = useResponsiveSize(32);
 
   const book = getBookData(bookKey)?.book;
-  const sectionLabel = progress?.sectionLabel;
+  const sectionLabel = useMemo(() => {
+    if (activeSectionIndex === null || activeSectionIndex < 0) {
+      return progress?.sectionLabel;
+    }
+
+    const chapter = downloads.chapters.find(
+      ({ startSection, endSection }) =>
+        Number.isInteger(startSection) &&
+        Number.isInteger(endSection) &&
+        startSection >= 0 &&
+        endSection > startSection &&
+        activeSectionIndex >= startSection &&
+        activeSectionIndex < endSection,
+    );
+    const chapterLabel = chapter?.label.trim();
+    return chapterLabel || _('Section {{index}}', { index: activeSectionIndex + 1 });
+  }, [_, activeSectionIndex, downloads.chapters, progress?.sectionLabel]);
   const isEink = viewSettings?.isEink ?? false;
   const coverImage = book?.coverImageUrl && !coverFailed ? book.coverImageUrl : null;
 

--- a/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
+++ b/apps/readest-app/src/app/reader/hooks/useTTSControl.ts
@@ -64,6 +64,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
   const { getMergedRules } = useProofreadStore();
 
   const [ttsLang, setTtsLang] = useState<string>('en');
+  const [ttsSectionIndex, setTtsSectionIndex] = useState<number | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [showIndicator, setShowIndicator] = useState(false);
@@ -365,7 +366,10 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
 
   // Controller event listeners (re-registered when ttsController changes)
   useEffect(() => {
-    if (!ttsController || !bookKey) return;
+    if (!ttsController || !bookKey) {
+      setTtsSectionIndex(null);
+      return;
+    }
     const handleNeedAuth = () => {
       eventDispatcher.dispatch('toast', {
         message: _('Please log in to use advanced TTS features'),
@@ -615,11 +619,20 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
       }
     };
 
+    const handleSectionIndexChange = (e: Event) => {
+      const { sectionIndex } = (e as CustomEvent<{ sectionIndex: number }>).detail;
+      setTtsSectionIndex(sectionIndex);
+    };
+
     ttsController.addEventListener('tts-need-auth', handleNeedAuth);
     ttsController.addEventListener('tts-highlight-mark', handleHighlightMark);
     ttsController.addEventListener('tts-highlight-word', handleHighlightWord);
     ttsController.addEventListener('tts-position', handlePosition);
     ttsController.addEventListener('tts-state-change', handleStateChange);
+    ttsController.addEventListener('tts-section-change', handleSectionIndexChange);
+    // The controller may have initialized its section before this effect was
+    // registered, so hydrate from the same canonical source as the event.
+    setTtsSectionIndex(ttsController.getSectionIndex());
     return () => {
       stopPageFollow();
       ttsController.removeEventListener('tts-need-auth', handleNeedAuth);
@@ -627,6 +640,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
       ttsController.removeEventListener('tts-highlight-word', handleHighlightWord);
       ttsController.removeEventListener('tts-position', handlePosition);
       ttsController.removeEventListener('tts-state-change', handleStateChange);
+      ttsController.removeEventListener('tts-section-change', handleSectionIndexChange);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ttsController, bookKey]);
@@ -1299,6 +1313,7 @@ export const useTTSControl = ({ bookKey, onRequestHidePanel }: UseTTSControlProp
     isPlaying,
     isPaused,
     ttsLang,
+    ttsSectionIndex,
     ttsClientsInited,
     isTTSActive: ttsController !== null,
     showIndicator,

--- a/apps/readest-app/src/services/tts/TTSController.ts
+++ b/apps/readest-app/src/services/tts/TTSController.ts
@@ -612,6 +612,24 @@ export class TTSController extends EventTarget {
     this.#highlightGranularity = granularity;
   }
 
+  // The reader's visible section can intentionally diverge from the section
+  // queued by Read Aloud (for example while paused at a chapter boundary).
+  // Expose the session cursor so player surfaces never have to infer it from
+  // reader progress.
+  getSectionIndex(): number | null {
+    return this.#ttsSectionIndex >= 0 ? this.#ttsSectionIndex : null;
+  }
+
+  #setSectionIndex(sectionIndex: number) {
+    if (this.#ttsSectionIndex === sectionIndex) return;
+    this.#ttsSectionIndex = sectionIndex;
+    this.dispatchEvent(
+      new CustomEvent('tts-section-change', {
+        detail: { sectionIndex },
+      }),
+    );
+  }
+
   async initViewTTS(index?: number) {
     if (this.#ttsSectionIndex === -1) {
       const fromSectionIndex = (index || this.#getPrimaryContent()?.index) ?? 0;
@@ -663,7 +681,7 @@ export class TTSController extends EventTarget {
     // are still rendering the outgoing section.
     this.#clearAllHighlights();
 
-    this.#ttsSectionIndex = sectionIndex;
+    this.#setSectionIndex(sectionIndex);
 
     const currentSection = this.#getPrimaryContent();
     if (currentSection?.index !== sectionIndex) {


### PR DESCRIPTION
Fixes #5953.

Closes READ-2.

## Summary

Read Aloud chapter indicators now follow the TTS session cursor instead of the reader's visible progress. This keeps the player-sheet label and chapter-list highlight accurate when “End of Chapter” parks playback in the next section and when paused Previous/Next navigation crosses sections.

The controller exposes its current section through `getSectionIndex()` and a `tts-section-change` event. `useTTSControl` hydrates from the getter so an initialization event emitted before React subscribes cannot be missed, follows later section changes, and clears the cursor when the session stops.

Chapter labels resolve against the TTS section and the existing ranged chapter metadata. Missing, malformed, or blank metadata falls back to an accurate localized `Section N` label instead of stale reader progress.

## Root cause

`TTSController` already maintained the authoritative queued section in `#ttsSectionIndex`, including boundary pauses and no-SSML cross-section navigation, but did not expose it. Both player indicators therefore read `readerProgressStore`, which can intentionally remain on the reader's current page while the paused TTS cursor advances.

## Test Coverage

- Controller regression coverage for “End of Chapter” boundary parking and paused forward/backward navigation through the no-SSML path.
- Hook coverage for initial getter hydration, section-change events, and reset on session stop.
- Component coverage proving the TTS cursor—not reader progress—drives the player sheet and chapter highlighting.
- Label coverage for ranged chapters, missing metadata, malformed ranges, and blank labels.

Focused suite: 179 passed.

Full suite: 10,484 passed, 16 skipped across 867 test files.

## Pre-Landing Review

No issues found after independent coverage, code, and design review. One coverage suggestion for malformed chapter metadata was added before the final verification run.

## Design Review

No visual structure or styling changed; the existing label and highlight surfaces now consume the correct state source. Readest's design-system rules remain satisfied.

## Plan Completion

No plan file detected. The READ-2 acceptance criteria are covered by the implementation and focused regressions.

## Documentation

No documentation update is needed: this fixes existing Read Aloud behavior and introduces only an internal controller/hook contract. Version and release-note changes remain reserved for Readest's dedicated release commits.

## Test plan

- [x] `pnpm test` — 10,484 passed, 16 skipped
- [x] `pnpm lint`
- [x] `pnpm format:check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text-to-speech now keeps the active section synchronized across playback controls and the mini player.
  * The mini player displays the matching chapter label when available, with a section-number fallback.
  * Section changes are tracked during forward and backward navigation, including paused playback.

* **Bug Fixes**
  * Improved chapter-label handling for ranged metadata and invalid or blank labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->