### PR TITLE
fix(reader): correct PDF reference totals and slider endpoint (#5951)

### DIFF
--- a/apps/readest-app/src/__tests__/components/Slider.test.tsx
+++ b/apps/readest-app/src/__tests__/components/Slider.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import Slider from '@/components/Slider';
+
+afterEach(cleanup);
+
+describe('Slider', () => {
+  it('fills the track and centers the thumb on its end at the maximum value', () => {
+    const { container, getByRole } = render(
+      <Slider label='Reading Progress' initialValue={100} heightPx={44} />,
+    );
+    getByRole('slider');
+    const fill = container.querySelector<HTMLElement>('.slider-fill')!;
+    const thumb = container.querySelector<HTMLElement>('.slider-thumb')!;
+
+    expect(fill.style.width).toBe('100%');
+    expect(thumb.style.left).toBe('calc(100% - 22px)');
+  });
+
+  it('centers the thumb on the start without filling the track at the minimum value', () => {
+    const { container, getByRole } = render(
+      <Slider label='Reading Progress' initialValue={0} heightPx={44} />,
+    );
+    getByRole('slider');
+    const fill = container.querySelector<HTMLElement>('.slider-fill')!;
+    const thumb = container.querySelector<HTMLElement>('.slider-thumb')!;
+
+    expect(fill.style.width).toBe('0px');
+    expect(thumb.style.left).toBe('22px');
+  });
+
+  it('keeps the thumb inside the track at intermediate positions', () => {
+    const { container, getByRole, rerender } = render(
+      <Slider label='Reading Progress' initialValue={25} heightPx={44} />,
+    );
+    getByRole('slider');
+    const thumb = container.querySelector<HTMLElement>('.slider-thumb')!;
+
+    expect(thumb.style.left).toBe('calc(25% + 11px)');
+
+    rerender(<Slider label='Reading Progress' initialValue={75} heightPx={44} />);
+    expect(thumb.style.left).toBe('calc(75% - 11px)');
+  });
+
+  it('uses the right edge as the endpoint in right-to-left layouts', async () => {
+    const { container, getByRole } = render(
+      <div dir='rtl'>
+        <Slider label='Reading Progress' initialValue={100} heightPx={44} />
+      </div>,
+    );
+    getByRole('slider');
+    const fill = container.querySelector<HTMLElement>('.slider-fill')!;
+    const thumb = container.querySelector<HTMLElement>('.slider-thumb')!;
+
+    await waitFor(() => expect(thumb.style.right).toBe('calc(100% - 22px)'));
+    expect(fill.style.right).toBe('0px');
+    expect(fill.style.width).toBe('100%');
+  });
+});

--- a/apps/readest-app/src/__tests__/components/page-jump-input.test.tsx
+++ b/apps/readest-app/src/__tests__/components/page-jump-input.test.tsx
@@ -43,12 +43,13 @@ const setup = ({
   progressStyle = 'fraction',
   isFixedLayout = false,
   pageList = undefined as unknown,
+  pageItem = undefined as unknown,
   showFraction = false,
 } = {}) => {
   mocks.state.progress = {
     pageinfo: { current: 93, next: 94, total: 251 },
     section: { current: 4, total: 30 },
-    pageItem: undefined,
+    pageItem,
   };
   mocks.state.viewSettings = { progressStyle };
   mocks.state.bookData = { isFixedLayout, bookDoc: { pageList } };
@@ -168,5 +169,34 @@ describe('PageJumpInput', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(mocks.view.goTo).toHaveBeenCalledWith('ch01.html#p2');
     expect(mocks.view.goToFraction).not.toHaveBeenCalled();
+  });
+
+  it('shows the final PDF label with the physical page total (#5951)', () => {
+    const labels = [
+      'i',
+      'ii',
+      'iii',
+      'iv',
+      '1',
+      '2',
+      '3',
+      '4',
+      '٤',
+      '٥',
+      '٦',
+      '٧',
+      ' Long Label - 11',
+      ' Long Label - 12',
+      ' Long Label - 13',
+      ' Long Label - 14',
+    ];
+    const pageList = labels.map((label, index) => ({ label, href: String(index), index }));
+    const { input } = setup({
+      progressStyle: 'reference',
+      pageList,
+      pageItem: pageList[15],
+    });
+
+    expect(input.value).toBe('Long Label - 14 / 16');
   });
 });

--- a/apps/readest-app/src/__tests__/utils/reference-pages.test.ts
+++ b/apps/readest-app/src/__tests__/utils/reference-pages.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { getReferencePageInfo, resolveReferencePageCount } from '@/utils/progress';
 
 const makePageList = (labels: string[]) => labels.map((label) => ({ label, href: '#' }));
+const makeIndexedPageList = (labels: string[]) =>
+  labels.map((label, index) => ({ label, href: String(index), index }));
 
 describe('getReferencePageInfo', () => {
   describe('with a page list from the book (issue #672)', () => {
@@ -86,6 +88,34 @@ describe('getReferencePageInfo', () => {
         referencePageCount: 999,
       });
       expect(info).toEqual({ current: '2', total: 3 });
+    });
+
+    it('uses the physical count for a complete indexed PDF page list (#5951)', () => {
+      const pageList = makeIndexedPageList([
+        'i',
+        'ii',
+        'iii',
+        'iv',
+        '1',
+        '2',
+        '3',
+        '4',
+        '٤',
+        '٥',
+        '٦',
+        '٧',
+        ' Long Label - 11',
+        ' Long Label - 12',
+        ' Long Label - 13',
+        ' Long Label - 14',
+      ]);
+      const info = getReferencePageInfo({
+        pageList,
+        pageItem: pageList[15],
+        fraction: 1,
+        referencePageCount: 0,
+      });
+      expect(info).toEqual({ current: 'Long Label - 14', total: 16 });
     });
   });
 

--- a/apps/readest-app/src/components/Slider.tsx
+++ b/apps/readest-app/src/components/Slider.tsx
@@ -83,8 +83,21 @@ const Slider: React.FC<SliderProps> = ({
     setValue(initialValue);
   }, [initialValue]);
 
-  const percentage = valueToPos(value, min, max);
-  const visualPercentage = (percentage / 100) * 95;
+  const percentage = Math.max(0, Math.min(100, valueToPos(value, min, max)));
+  const thumbRadius = heightPx / 2;
+  const thumbOffset = Math.abs((0.5 - percentage / 100) * heightPx);
+  const thumbPosition =
+    percentage <= 0
+      ? `${thumbRadius}px`
+      : percentage >= 100
+        ? `calc(100% - ${thumbRadius}px)`
+        : `calc(${percentage}% ${percentage < 50 ? '+' : '-'} ${thumbOffset}px)`;
+  const fillWidth =
+    percentage <= 0
+      ? '0px'
+      : percentage >= 100
+        ? '100%'
+        : `max(calc(${percentage}% + ${(1 - percentage / 100) * heightPx}px), ${heightPx}px)`;
 
   return (
     <div
@@ -98,12 +111,9 @@ const Slider: React.FC<SliderProps> = ({
         <div className='bg-base-300/40 absolute h-full w-full rounded-full'></div>
         {/* Filled portion */}
         <div
-          className='bg-base-300 absolute h-full rounded-full'
+          className='slider-fill bg-base-300 absolute h-full rounded-full'
           style={{
-            width:
-              visualPercentage > 0
-                ? `max(calc(${visualPercentage}% + ${heightPx / 2}px), ${heightPx}px)`
-                : '0px',
+            width: fillWidth,
             [isRtl ? 'right' : 'left']: 0,
           }}
         ></div>
@@ -114,9 +124,9 @@ const Slider: React.FC<SliderProps> = ({
         </div>
         {/* Thumb bubble */}
         <div
-          className='pointer-events-none absolute top-0 z-10'
+          className='slider-thumb pointer-events-none absolute top-0 z-10'
           style={{
-            [isRtl ? 'right' : 'left']: `max(${heightPx / 2}px, calc(${visualPercentage}%))`,
+            [isRtl ? 'right' : 'left']: thumbPosition,
             transform: isRtl ? 'translateX(calc(50%))' : 'translateX(calc(-50%))',
             height: '100%',
           }}

--- a/apps/readest-app/src/utils/progress.ts
+++ b/apps/readest-app/src/utils/progress.ts
@@ -68,6 +68,7 @@ export function formatProgress(
 
 export interface ReferencePageItem {
   label?: string;
+  index?: number;
   subitems?: ReferencePageItem[] | null;
 }
 
@@ -104,10 +105,18 @@ export function getReferencePageInfo({
 }): ReferencePageInfo | null {
   if (pageList?.length) {
     const labels = collectLabels(pageList).filter(Boolean);
-    // The last entries may be non-numeric (e.g. a roman-numeral index page),
-    // so the total is the highest numeric label, not the last one.
+    // PDF page lists contain one top-level entry per physical page and retain
+    // its zero-based index. Their labels can restart or switch numbering
+    // systems, so the physical count is authoritative. EPUB page lists are
+    // semantic anchors instead; keep their highest-numeric-label behavior
+    // because they can be sparse and may end in a non-numeric index page.
+    const hasPhysicalPageIndexes = pageList.every((item, index) => item.index === index);
     const numericLabels = labels.filter((label) => /^\d+$/.test(label));
-    const total = numericLabels.length ? Math.max(...numericLabels.map(Number)) : labels.length;
+    const total = hasPhysicalPageIndexes
+      ? pageList.length
+      : numericLabels.length
+        ? Math.max(...numericLabels.map(Number))
+        : labels.length;
     const current = pageItem?.label?.trim() || String(estimatePage(fraction, total));
     return { current, total };
   }


### PR DESCRIPTION
## Summary

- Treat a sequentially indexed PDF page list as the authoritative physical-page count, while preserving the existing sparse EPUB page-list behavior.
- Keep the PDF's current page label intact, including non-ASCII and long labels.
- Let slider fills reach 100% and keep the thumb centered on both track endpoints, including RTL layouts.

Closes READ-3
Fixes #5951

## Root cause

PDF page labels can restart or change numbering systems. The reference-page total previously used only the highest ASCII-numeric label, so the 16-page reproduction PDF stopped at `4`. Separately, the shared slider compressed every visual position to 95%, which made a real 100% value stop short of the track edge.

## Test coverage

- Added the exact 16-label PDF regression and a component-level assertion for `Long Label - 14 / 16`.
- Added slider coverage for minimum, maximum, intermediate positions, and RTL endpoint geometry.
- Coverage audit: 15/16 changed paths covered (94%); the remaining intermediate fill expression is exercised by endpoint behavior but not asserted directly because jsdom does not parse CSS `max(calc(...))` values.

## Test plan

- [x] Targeted Vitest suite: 4 files, 43 tests
- [x] TypeScript and Biome lint: 2,280 files
- [x] Biome format check: 2,319 files
- [x] Repository pre-push gate, including the full app unit suite
- [x] Pre-landing code and design review: no actionable findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved slider positioning at minimum, maximum, and intermediate values, including right-to-left layouts.
  - Corrected PDF progress totals and page labels, including physical page counts and mixed-format labels.

- **Tests**
  - Added coverage for slider fill and thumb positioning across supported values and layouts.
  - Added regression tests for PDF reference-page totals and final-page display formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->