### PR TITLE
fix(reader): shrink hidden Android navigation controls (#5966)

### DIFF
--- a/apps/readest-app/src/__tests__/components/page-navigation-buttons.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/page-navigation-buttons.browser.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import '@/styles/globals.css';
+
+const mockPlatform = vi.hoisted(() => ({
+  isAndroidApp: true,
+  hoveredBookKey: null as string | null,
+}));
+
+vi.mock('@/context/EnvContext', () => ({
+  useEnv: () => ({ appService: { isAndroidApp: mockPlatform.isAndroidApp } }),
+}));
+
+vi.mock('@/store/readerStore', () => ({
+  useReaderStore: (
+    selector: (state: {
+      getView: () => null;
+      getViewSettings: () => { rtl: boolean; showPaginationButtons: boolean };
+      hoveredBookKey: string | null;
+    }) => unknown,
+  ) =>
+    selector({
+      getView: () => null,
+      getViewSettings: () => ({ rtl: false, showPaginationButtons: true }),
+      hoveredBookKey: mockPlatform.hoveredBookKey,
+    }),
+}));
+
+vi.mock('@/store/bookDataStore', () => ({
+  useBookDataStore: (selector: (state: { getBookData: () => null }) => unknown) =>
+    selector({ getBookData: () => null }),
+}));
+
+vi.mock('@/store/readerProgressStore', () => ({
+  useBookProgress: () => undefined,
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
+}));
+
+vi.mock('@/app/reader/hooks/usePagination', () => ({
+  viewPagination: vi.fn(),
+}));
+
+const { default: PageNavigationButtons } = await import(
+  '@/app/reader/components/PageNavigationButtons'
+);
+
+const navigationLabels = ['Previous Section', 'Previous Page', 'Next Page', 'Next Section'];
+
+afterEach(() => {
+  cleanup();
+  mockPlatform.isAndroidApp = true;
+  mockPlatform.hoveredBookKey = null;
+});
+
+describe('PageNavigationButtons Android hit areas', () => {
+  it('shrinks all four hidden controls so they do not cover selectable text', () => {
+    render(<PageNavigationButtons bookKey='book' isDropdownOpen={false} />);
+
+    for (const label of navigationLabels) {
+      const bounds = screen.getByRole('button', { name: label }).getBoundingClientRect();
+      expect([bounds.width, bounds.height], label).toEqual([16, 16]);
+    }
+  });
+
+  it('keeps the four visible controls large and distinctly labelled', () => {
+    mockPlatform.hoveredBookKey = 'book';
+    render(<PageNavigationButtons bookKey='book' isDropdownOpen={false} />);
+
+    for (const label of navigationLabels) {
+      const bounds = screen.getByRole('button', { name: label }).getBoundingClientRect();
+      expect([bounds.width, bounds.height], label).toEqual([80, 80]);
+    }
+  });
+});

--- a/apps/readest-app/src/__tests__/components/page-navigation-buttons.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/page-navigation-buttons.browser.test.tsx
@@ -61,8 +61,12 @@ describe('PageNavigationButtons Android hit areas', () => {
     render(<PageNavigationButtons bookKey='book' isDropdownOpen={false} />);
 
     for (const label of navigationLabels) {
-      const bounds = screen.getByRole('button', { name: label }).getBoundingClientRect();
+      const button = screen.getByRole('button', { name: label });
+      const bounds = button.getBoundingClientRect();
       expect([bounds.width, bounds.height], label).toEqual([16, 16]);
+
+      const hitTarget = document.elementFromPoint(bounds.left + bounds.width / 2, bounds.top - 1);
+      expect(button.contains(hitTarget), label).toBe(false);
     }
   });
 

--- a/apps/readest-app/src/app/reader/components/PageNavigationButtons.tsx
+++ b/apps/readest-app/src/app/reader/components/PageNavigationButtons.tsx
@@ -38,7 +38,9 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
   const isPageNavigationButtonsVisible =
     (hoveredBookKey === bookKey || isDropdownOpen) && viewSettings?.showPaginationButtons;
   const navigationButtonSize =
-    !isPageNavigationButtonsVisible && appService?.isAndroidApp ? 'h-4 w-4' : 'h-20 w-20';
+    !isPageNavigationButtonsVisible && appService?.isAndroidApp
+      ? 'h-4 w-4 overflow-hidden'
+      : 'h-20 w-20';
 
   const handleGoLeftPage = useCallback(() => {
     viewPagination(view, viewSettings, 'left', 'page');

--- a/apps/readest-app/src/app/reader/components/PageNavigationButtons.tsx
+++ b/apps/readest-app/src/app/reader/components/PageNavigationButtons.tsx
@@ -37,6 +37,8 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
 
   const isPageNavigationButtonsVisible =
     (hoveredBookKey === bookKey || isDropdownOpen) && viewSettings?.showPaginationButtons;
+  const navigationButtonSize =
+    !isPageNavigationButtonsVisible && appService?.isAndroidApp ? 'h-4 w-4' : 'h-20 w-20';
 
   const handleGoLeftPage = useCallback(() => {
     viewPagination(view, viewSettings, 'left', 'page');
@@ -97,8 +99,8 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
         <button
           onClick={handleGoLeftSection}
           className={clsx(
-            'flex h-20 w-20 items-center justify-center focus:outline-hidden',
-            !isPageNavigationButtonsVisible && appService?.isAndroidApp && 'h-4 w-4',
+            'flex items-center justify-center focus:outline-hidden',
+            navigationButtonSize,
           )}
           aria-hidden={false}
           aria-label={getLeftSectionLabel()}
@@ -118,8 +120,8 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
         <button
           onClick={handleGoLeftPage}
           className={clsx(
-            'flex h-20 w-20 items-center justify-center focus:outline-hidden',
-            !isPageNavigationButtonsVisible && appService?.isAndroidApp && 'h-4 w-4',
+            'flex items-center justify-center focus:outline-hidden',
+            navigationButtonSize,
           )}
           aria-hidden={false}
           aria-label={getLeftPageLabel()}
@@ -149,8 +151,8 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
         <button
           onClick={handleGoRightPage}
           className={clsx(
-            'flex h-20 w-20 items-center justify-center focus:outline-hidden',
-            !isPageNavigationButtonsVisible && appService?.isAndroidApp && 'h-4 w-4',
+            'flex items-center justify-center focus:outline-hidden',
+            navigationButtonSize,
           )}
           aria-hidden={false}
           aria-label={getRightPageLabel()}
@@ -170,8 +172,8 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
         <button
           onClick={handleGoRightSection}
           className={clsx(
-            'flex h-20 w-20 items-center justify-center focus:outline-hidden',
-            !isPageNavigationButtonsVisible && appService?.isAndroidApp && 'h-4 w-4',
+            'flex items-center justify-center focus:outline-hidden',
+            navigationButtonSize,
           )}
           aria-hidden={false}
           aria-label={getRightSectionLabel()}


### PR DESCRIPTION
## Summary

- Shrink all four hidden Android page and section navigation controls to 16×16 and clip their oversized children so they cannot intercept long-press text selection outside those bounds.
- Keep the visible controls at their existing 80×80 size.
- Preserve button roles and distinct accessibility labels, with real-browser regression coverage for computed sizing and pointer hit-testing.

Closes READ-5
Fixes #5966

## Root cause

After the Tailwind CSS 4 migration, each hidden Android control carried both `h-20 w-20` and `h-4 w-4`, and the generated cascade let the 80px utilities win. Choosing one exclusive size fixed the button box, but the centered 48×48 child still overflowed that 16×16 box and remained hit-testable. The hidden Android branch now also clips overflow.

## Test coverage

```text
CODE PATHS                                      USER FLOWS
[+] navigationButtonSize                       [+] Hidden Android controls
  ├── [★★★ TESTED] Hidden Android                 └── [★★★ TESTED] One pixel outside each
  │   → 16×16 + overflow clipping                    button does not hit its 48px child
  │   → all four controls
  └── [★★ TESTED] Visible fallback              [+] Revealed controls
      → 80×80                                       └── [★★ TESTED] All four remain 80×80
      → all four controls                              with distinct accessible labels

COVERAGE: 4/4 paths tested (100%) | Code paths: 2/2 | User flows: 2/2
QUALITY: ★★★:2 ★★:2 ★:0 | GAPS: 0
```

## Review follow-up

- Verified [CodeRabbit review comment r3890153073](https://github.com/readest/readest/pull/5974#discussion_r3890153073) with a Chromium hit-test assertion that failed before the fix: one pixel outside the 16px button still resolved to its child.
- Added hidden-state overflow clipping and extended the test across all four controls in commit `cf9ac43`.
- GitHub marked the review thread resolved after the update was pushed.

## Test plan

- [x] Browser regression test: 1 file, 2 tests
- [x] Full app unit suite: 870 files passed, 10,538 tests passed, 16 skipped
- [x] TypeScript and Biome lint: 2,293 files checked
- [x] Biome format check: 2,332 files checked
- [x] Repository pre-push gate, including a second full app unit-suite pass
- [x] Pre-landing code and design review: no actionable findings

## Plan completion

No implementation plan file was detected; completion audit skipped.

## Scope check

Clean — the diff contains only the Android navigation hit-area correction and its browser regression coverage.
