### PR TITLE
fix(markdown): support tab-indented footnotes

### DIFF
--- a/apps/readest-app/src/__tests__/utils/md-footnotes.test.ts
+++ b/apps/readest-app/src/__tests__/utils/md-footnotes.test.ts
@@ -131,6 +131,71 @@ describe('markdown footnotes', () => {
     expect(note.textContent).toContain('Second para.');
   });
 
+  it('keeps an Obsidian tab-indented continuation inside the footnote', async () => {
+    const book = await make(
+      't[^a]\n\n[^a]: First line.\n\tSecond line.\n\nText after the definition.\n',
+    );
+    const doc = await docOf(book);
+    const note = notes(doc)[0]!;
+
+    expect(note.textContent).toContain('First line.');
+    expect(note.textContent).toContain('Second line.');
+    expect(doc.body.querySelector('pre')).toBeNull();
+    expect(doc.body.textContent).toContain('Text after the definition.');
+  });
+
+  it('keeps an Obsidian tab-indented multi-paragraph blockquote inside the footnote', async () => {
+    const book = await make(
+      't[^a]\n\n[^a]: Intro:\n\t> First paragraph.\n\t\n\t> Second paragraph.\n\nText after the definition.\n',
+    );
+    const doc = await docOf(book);
+    const note = notes(doc)[0]!;
+
+    expect(note.querySelectorAll('blockquote p').length).toBe(2);
+    expect(note.textContent).toContain('First paragraph.');
+    expect(note.textContent).toContain('Second paragraph.');
+    expect(doc.body.querySelector('pre')).toBeNull();
+  });
+
+  it('preserves an ordinary tab-indented code block', async () => {
+    const book = await make('Before.\n\n\tconst answer = 42;\n\nAfter.\n');
+    const doc = await docOf(book);
+
+    expect(doc.body.querySelector('pre code')?.textContent).toContain('const answer = 42;');
+  });
+
+  it('expands mixed and repeated tab indentation by tab stops', async () => {
+    const book = await make('t[^a]\n\n[^a]: First.\n  \tSecond.\n\t\tThird.\n');
+    const doc = await docOf(book);
+    const note = notes(doc)[0]!;
+
+    expect(note.textContent).toContain('Second.');
+    expect(note.textContent).toContain('Third.');
+  });
+
+  it('keeps four-space continuations when another tab activates preprocessing', async () => {
+    const book = await make(
+      'Before.\n\n\tconst answer = 42;\n\nt[^a]\n\n[^a]: First.\n    Second.\n',
+    );
+    const doc = await docOf(book);
+
+    expect(notes(doc)[0]!.textContent).toContain('Second.');
+    expect(doc.body.querySelector('pre code')?.textContent).toContain('const answer = 42;');
+  });
+
+  it('preserves tabbed fenced code before a CRLF footnote definition', async () => {
+    const book = await make(
+      '```\r\n[^fake]: literal\r\n\tcontinued\r\n```\r\n\r\nt[^a]\r\n\r\n[^a]: First.\r\n\tSecond.\r\n',
+    );
+    const doc = await docOf(book);
+    const code = doc.body.querySelector('pre code');
+
+    expect(code?.textContent).toContain('[^fake]: literal');
+    expect(code?.textContent).toContain('\tcontinued');
+    expect(notes(doc)).toHaveLength(1);
+    expect(notes(doc)[0]!.textContent).toContain('Second.');
+  });
+
   it('gives a reused reference one note, unique ids and a backlink per reference', async () => {
     const book = await make('a[^a] b[^a]\n\n[^a]: once\n');
     const doc = await docOf(book);

--- a/apps/readest-app/src/__tests__/utils/md-footnotes.test.ts
+++ b/apps/readest-app/src/__tests__/utils/md-footnotes.test.ts
@@ -196,6 +196,13 @@ describe('markdown footnotes', () => {
     expect(notes(doc)[0]!.textContent).toContain('Second.');
   });
 
+  it('preserves a source tab in fenced code nested inside a footnote', async () => {
+    const book = await make('t[^a]\n\n[^a]: Example:\n\n    ```text\n    \tcode\n    ```\n');
+    const doc = await docOf(book);
+
+    expect(notes(doc)[0]!.querySelector('pre code')?.textContent).toBe('\tcode\n');
+  });
+
   it('gives a reused reference one note, unique ids and a backlink per reference', async () => {
     const book = await make('a[^a] b[^a]\n\n[^a]: once\n');
     const doc = await docOf(book);

--- a/apps/readest-app/src/utils/md.ts
+++ b/apps/readest-app/src/utils/md.ts
@@ -8,6 +8,7 @@ import {
   buildChapterFootnotes,
   expandInlineFootnotes,
   extractFootnoteDefs,
+  normalizeFootnoteDefinitionIndent,
 } from './mdFootnotes';
 import { frontmatterToMetadata, parseFrontmatter } from './mdFrontmatter';
 import { sanitizeHtml } from './sanitize';
@@ -25,7 +26,7 @@ const XHTML_NS = 'http://www.w3.org/1999/xhtml';
 // annotation note renderer and the export dialog, and must not gain footnote
 // parsing as a side effect.
 const markdown = new Marked({ gfm: true }).use(markedFootnote({ prefixId: FOOTNOTE_PREFIX_ID }), {
-  hooks: { preprocess: expandInlineFootnotes },
+  hooks: { preprocess: (src) => expandInlineFootnotes(normalizeFootnoteDefinitionIndent(src)) },
 });
 
 // Minimal defaults so code blocks wrap inside the paginated column (long lines

--- a/apps/readest-app/src/utils/mdFootnotes.ts
+++ b/apps/readest-app/src/utils/mdFootnotes.ts
@@ -23,6 +23,18 @@ const REF_PREFIX = `${FOOTNOTE_PREFIX_ID}ref-`;
 const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
 const FOOTNOTE_DEF_RE = /^\[\^[^\]\n]+\]:/;
 
+const stripFootnoteContinuationIndent = (line: string): string | null => {
+  let column = 0;
+  let offset = 0;
+  while (offset < line.length && column < 4) {
+    if (line[offset] === ' ') column++;
+    else if (line[offset] === '\t') column += 4 - (column % 4);
+    else break;
+    offset++;
+  }
+  return column >= 4 ? line.slice(offset) : null;
+};
+
 // marked-footnote strips either four spaces or a tab from captured continuation
 // lines, but its block tokenizer only captures the four-space form. Obsidian
 // commonly writes the equivalent indentation with tabs, so expand leading tabs
@@ -39,7 +51,11 @@ export const normalizeFootnoteDefinitionIndent = (src: string): string => {
     const line = lines[i]!;
 
     if (closingFence) {
-      if (closingFence.test(line)) closingFence = null;
+      const fenceLine = inDefinition ? stripFootnoteContinuationIndent(line) : line;
+      if (fenceLine !== null && closingFence.test(fenceLine)) {
+        closingFence = null;
+        if (inDefinition) lines[i] = `    ${fenceLine}`;
+      }
       continue;
     }
 
@@ -50,6 +66,12 @@ export const normalizeFootnoteDefinitionIndent = (src: string): string => {
 
     if (inDefinition) {
       if (/^[ \t]/.test(line)) {
+        const fenceLine = stripFootnoteContinuationIndent(line);
+        const fence = fenceLine === null ? null : FENCE_RE.exec(fenceLine);
+        if (fence) {
+          const marker = fence[1]!;
+          closingFence = new RegExp(`^ {0,3}\\${marker[0]}{${marker.length},}[ \\t]*\\r?$`);
+        }
         if (/^[ \t]*\t/.test(line)) {
           let column = 0;
           let offset = 0;

--- a/apps/readest-app/src/utils/mdFootnotes.ts
+++ b/apps/readest-app/src/utils/mdFootnotes.ts
@@ -21,6 +21,61 @@ const DEF_PREFIX = FOOTNOTE_PREFIX_ID;
 const REF_PREFIX = `${FOOTNOTE_PREFIX_ID}ref-`;
 
 const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+const FOOTNOTE_DEF_RE = /^\[\^[^\]\n]+\]:/;
+
+// marked-footnote strips either four spaces or a tab from captured continuation
+// lines, but its block tokenizer only captures the four-space form. Obsidian
+// commonly writes the equivalent indentation with tabs, so expand leading tabs
+// only while inside a footnote definition. Tabs elsewhere remain ordinary
+// indented code.
+export const normalizeFootnoteDefinitionIndent = (src: string): string => {
+  if (!src.includes('\t')) return src;
+
+  const lines = src.split('\n');
+  let inDefinition = false;
+  let closingFence: RegExp | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+
+    if (closingFence) {
+      if (closingFence.test(line)) closingFence = null;
+      continue;
+    }
+
+    if (FOOTNOTE_DEF_RE.test(line)) {
+      inDefinition = true;
+      continue;
+    }
+
+    if (inDefinition) {
+      if (/^[ \t]/.test(line)) {
+        if (/^[ \t]*\t/.test(line)) {
+          let column = 0;
+          let offset = 0;
+          while (offset < line.length) {
+            if (line[offset] === ' ') column++;
+            else if (line[offset] === '\t') column += 4 - (column % 4);
+            else break;
+            offset++;
+          }
+          lines[i] = `${' '.repeat(column)}${line.slice(offset)}`;
+        }
+        continue;
+      }
+      if (!line.trim()) continue;
+      inDefinition = false;
+    }
+
+    const fence = FENCE_RE.exec(line);
+    if (fence) {
+      const marker = fence[1]!;
+      closingFence = new RegExp(`^ {0,3}\\${marker[0]}{${marker.length},}[ \\t]*\\r?$`);
+    }
+  }
+
+  return lines.join('\n');
+};
 
 // Rewrite Pandoc/Obsidian inline notes `^[text]` into a reference plus a
 // definition appended to the source, so marked-footnote sees one uniform


### PR DESCRIPTION
## Summary

- Parse Obsidian-style tab-indented continuation lines and paragraph breaks as part of the same Markdown footnote.
- Preserve source tabs inside fenced code nested in a footnote by recognizing the nested fence before continuation indentation is normalized.
- Preserve existing single-line and four-space footnotes, ordinary tab-indented code, and fenced code blocks.

## Root cause

`marked-footnote` strips tabs from captured definitions, but its tokenizer only captures continuation lines that begin with four literal spaces. The parser normalized footnote indentation before recognizing a nested fence, so a source tab inside that fence became spaces. It now detects the nested fence through the footnote continuation wrapper first and leaves fenced content untouched.

## Test coverage

- Added integration coverage for tab-indented multi-line and multi-paragraph footnotes, mixed indentation, tab-only blank lines, fenced-code isolation, CRLF fences, ordinary code preservation, and a source tab inside fenced footnote code.
- Coverage audit: 19/22 changed parser paths and user flows covered (86%); the reported regression path is covered end to end.

## Verification

- [x] Focused Markdown footnote tests: 29 passed
- [x] Full web unit suite: 10,545 passed, 16 skipped
- [x] TypeScript and Biome lint
- [x] Biome formatting check
- [ ] Production build CI rerunning for the updated PR head

Closes READ-4
Fixes #5963


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown footnote handling for tab-indented continuations and multi-paragraph content.
  * Preserved ordinary indented code, fenced code blocks, mixed indentation, and four-space continuations.
  * Corrected footnote parsing across CRLF line endings.

* **Tests**
  * Added regression coverage for indentation, blockquotes, code blocks, and line-ending scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
