### PR TITLE
fix(reader): stabilize Hardcover Sync submenu sizing

### DIFF
--- a/apps/readest-app/src/__tests__/components/dropdown-viewport.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/dropdown-viewport.browser.test.tsx
@@ -92,9 +92,10 @@ beforeAll(async () => {
   await page.viewport(PHONE_WIDTH, 800);
 });
 
-afterEach(() => {
+afterEach(async () => {
   cleanup();
   document.documentElement.classList.remove('ui-rtl');
+  await page.viewport(PHONE_WIDTH, 800);
 });
 
 describe('Dropdown menu viewport layout', () => {
@@ -171,5 +172,77 @@ describe('Dropdown menu viewport layout', () => {
     });
 
     await expectMenuWithinViewport();
+  });
+
+  it('keeps a long nested description within the menu width', async () => {
+    await page.viewport(1440, 800);
+
+    render(
+      <DropdownProvider>
+        <div data-testid='dropdown-anchor' style={{ position: 'fixed', top: 8, left: 8 }}>
+          <Dropdown
+            label='Test Menu'
+            className='dropdown-bottom'
+            buttonClassName='btn btn-ghost h-8 min-h-8 w-8 p-0'
+            toggleButton={<span>⋯</span>}
+            showTooltip={false}
+          >
+            <Menu className='book-menu dropdown-content no-triangle z-20 mt-2 shadow-2xl'>
+              <MenuItem label='Hardcover Sync'>
+                <ul className='flex flex-col ps-1'>
+                  <MenuItem label='Push Progress' noIcon />
+                  <MenuItem label='Push Notes' noIcon />
+                  <MenuItem
+                    label='Link Book'
+                    description='The Mind-Body Stress Reset: Somatic Practices to Reduce Overwhelm and Increase Well-Being'
+                    noIcon
+                  />
+                </ul>
+              </MenuItem>
+              <MenuItem label='Export Annotations' />
+            </Menu>
+          </Dropdown>
+        </div>
+      </DropdownProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Test Menu' }));
+    const menu = openMenu();
+    const collapsedWidth = menu.getBoundingClientRect().width;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hardcover Sync' }));
+
+    await waitFor(() => {
+      expect(
+        (
+          screen
+            .getByRole('button', { name: 'Hardcover Sync' })
+            .closest('details') as HTMLDetailsElement
+        ).open,
+      ).toBe(true);
+    });
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    );
+
+    expect(menu.getBoundingClientRect().width).toBeLessThanOrEqual(collapsedWidth + 1);
+    expect(menu.getBoundingClientRect().width).toBeLessThanOrEqual(320);
+
+    const description = screen.getByText(
+      'The Mind-Body Stress Reset: Somatic Practices to Reduce Overwhelm and Increase Well-Being',
+    );
+    expect(description.scrollWidth).toBeGreaterThan(description.clientWidth);
+
+    const pushProgress = screen.getByRole('menuitem', { name: 'Push Progress' });
+    const linkBook = screen.getByRole('menuitem', { name: /^Link Book/ });
+
+    await page.getByRole('menuitem', { name: 'Push Progress' }).hover();
+    expect(pushProgress.matches(':hover')).toBe(true);
+    expect(linkBook.matches(':hover')).toBe(false);
+
+    await page.getByRole('menuitem', { name: /^Link Book/ }).hover();
+    expect(pushProgress.matches(':hover')).toBe(false);
+    expect(linkBook.matches(':hover')).toBe(true);
+    expect(menu.querySelectorAll('[role="menuitem"]:hover')).toHaveLength(1);
   });
 });

--- a/apps/readest-app/src/components/MenuItem.tsx
+++ b/apps/readest-app/src/components/MenuItem.tsx
@@ -58,7 +58,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
 
   const buttonContent = (
     <>
-      <div className='flex w-full items-center justify-between'>
+      <div className='flex w-full min-w-0 items-center justify-between'>
         <div className='flex min-w-0 items-center'>
           {!noIcon && (
             <span style={{ minWidth: `${iconSize}px` }}>
@@ -94,7 +94,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
           </kbd>
         )}
       </div>
-      <div className='flex w-full'>
+      <div className='flex w-full min-w-0'>
         {description && (
           <span
             className='mt-1 truncate text-start text-xs text-gray-500'
@@ -109,9 +109,13 @@ const MenuItem: React.FC<MenuItemProps> = ({
 
   if (children) {
     return (
-      <ul className='menu rounded-box m-0 p-0'>
-        <li aria-label={label}>
-          <details open={detailsOpen} onToggle={(e) => setIsDetailsOpen(e.currentTarget.open)}>
+      <ul className='menu rounded-box m-0 w-full min-w-0 p-0'>
+        <li className='w-full min-w-0 max-w-full' aria-label={label}>
+          <details
+            className='w-full min-w-0'
+            open={detailsOpen}
+            onToggle={(e) => setIsDetailsOpen(e.currentTarget.open)}
+          >
             <summary
               role='button'
               tabIndex={0}
@@ -133,7 +137,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
   }
 
   return (
-    <div className='flex'>
+    <div className='flex min-w-0'>
       <button
         role={disabled ? 'none' : 'menuitem'}
         aria-label={
@@ -142,7 +146,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
         aria-live={toggled === undefined ? 'polite' : 'off'}
         tabIndex={disabled ? -1 : 0}
         className={clsx(
-          'hover:bg-base-300 text-base-content flex w-full flex-col items-center justify-center rounded-md p-1 py-[10px]',
+          'hover:bg-base-300 text-base-content flex w-full min-w-0 flex-col items-center justify-center rounded-md p-1 py-[10px]',
           disabled && 'btn-disabled text-gray-400',
           buttonClass,
         )}

--- a/apps/readest-app/src/styles/globals.css
+++ b/apps/readest-app/src/styles/globals.css
@@ -432,6 +432,20 @@
     max-width: calc(100vw - 32px);
   }
 
+  /* Keep the book menu's width stable while nested sync actions expand. A
+     linked Hardcover title is intentionally truncated inside its row; letting
+     that title set the menu's intrinsic width also leaves stale hover paint in
+     macOS WebKit when the pointer moves across the resized rows (#5973). */
+  :where(.book-menu) {
+    width: 18rem;
+    max-width: calc(100vw - 2rem);
+  }
+
+  :where(.book-menu details > ul) {
+    min-width: 0;
+    max-width: 100%;
+  }
+
   .dropdown-content::before,
   .dropdown-content::after {
     content: '';


### PR DESCRIPTION
## Summary

- keep the reader book menu at a stable, viewport-safe width when Hardcover Sync expands
- allow nested menu rows and descriptions to shrink so long linked titles truncate instead of widening the menu
- cover width stability, truncation, and exclusive hover movement in a real browser regression test

## Test Coverage

```text
CODE PATHS                                             USER FLOWS
[+] globals.css / MenuItem.tsx                         [+] Hardcover Sync submenu
  ├── [★★★ TESTED] Desktop width fixed at 18rem          ├── [★★★ TESTED] Open + expand keeps width stable
  ├── [GAP] Narrow viewport max-width branch             ├── [★★★ TESTED] Long title visibly truncates
  ├── [★★★ TESTED] Nested list can shrink                 ├── [★★★ TESTED] Hover moves to exactly one row
  ├── [★★★ TESTED] Nested MenuItem ancestors shrink       └── [GAP] macOS WebKit stale-pixel repaint is not pixel-asserted
  ├── [★★★ TESTED] Leaf/button description shrinks
  └── [★★ TESTED] Description-free rows remain usable

COVERAGE: 8/10 paths tested (80%)
QUALITY: ★★★:7 ★★:1 | GAPS: 2 (1 browser edge, 1 visual-only WebKit repaint)
```

## Pre-Landing Review

No code or design issues found. Scope check: clean.

## Plan Completion

No relevant plan file detected.

## Test plan

- [x] `pnpm test` — 870 files passed, 4 skipped; 10,538 tests passed, 16 skipped
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] full browser suite — 48 files, 403 tests passed
- [x] focused menu regression in Chromium and WebKit — 10 tests per engine
- [x] six unrelated pre-push timeout cases rerun serially — 84 tests passed
- [x] web E2E — 22/23 passed initially; the single dev-overlay timeout passed on isolated rerun
- [x] production packaging — compilation and TypeScript completed, but the local build could not finish page-data/cache writes because the workspace disk reached `ENOSPC`; CI should confirm the packaging stage

Closes READ-6
Fixes #5973


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown menu sizing to prevent long descriptions from expanding the menu beyond the viewport.
  * Ensured nested menu items maintain proper width constraints and exclusive hover behavior.
  * Improved layout handling so menu content can shrink and overflow cleanly when needed.

* **Tests**
  * Added browser regression coverage for nested menu sizing and interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->