### PR TITLE
chore: update agent memories and tidy library styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Readest is open-source, and contributions are welcome! Feel free to open issues,
 
 ## Support
 
-If Readest has been useful to you, consider supporting its development at [donate.readest.com](https://donate.readest.com), where you'll find all available donation methods, including GitHub Sponsors, card payments, and crypto. Your contribution helps us fix bugs faster, improve performance, and keep building great features.
+If Readest has been useful to you, consider supporting its development at [donate.readest.com](https://donate.readest.com), where you'll find all available donation methods, including GitHub Sponsors, PayPal, card payments, and crypto. Your contribution helps us fix bugs faster, improve performance, and keep building great features.
 
 ### Sponsors
 

--- a/apps/readest-app/.claude/memory/MEMORY.md
+++ b/apps/readest-app/.claude/memory/MEMORY.md
@@ -1,163 +1,151 @@
 # Readest Project Memory
 
+Index only — one line per memory. Detail lives in the topic files; do not restate it here.
+
 ## Key Reference Documents (aggregators)
 - [Bug Patterns](bug-patterns.md) · [CSS & Style](css-style-fixes.md) · [TTS](tts-fixes.md)
 - [Layout & UI](layout-ui-fixes.md) · [Platform Compat](platform-compat-fixes.md) · [Annotator & Reader](annotator-reader-fixes.md)
 - [Sync Fixes](sync-fixes.md) · [Reader Feature Fixes](reader-feature-fixes.md)
 - [Paginator & Scroll Fixes](paginator-scroll-fixes.md) · [Build & CI Recipes](build-ci-recipes.md)
+
 ## Safety & Security
-- [Android launch crash: widget thumbnail 1px cover](widget-thumbnail-degenerate-cover-crash.md) `width must be > 0` in pluginScope.launch = fatal every launch; MERGED #5874 (79b4c2e7c), worktree removed; Xiaomi + emulator e2e VERIFIED; reporter verify pending; MIUI ADB-install dialog needs uiautomator tap and auto-denies when the screen is locked (use the emulator)
-- [Stripe checkout 500 on storage add-on](stripe-checkout-500-storage-purchase.md) root cause UNCONFIRMED; ui_mode ruled out; diagnostics MERGED #5896 give code/param only; Play builds cannot reproduce (hasIAP gate), desktop likely affected
-- [Apple lost storage purchase](apple-iap-lost-storage-purchase-restore-verify.md) 2 buyers CREDITED manually (MSXWGYVFZK 08-13, MLYD8F9573 08-25); restore-verify #5669 MERGED but UNRELEASED (v0.12.1 predates it) so shipped iOS Restore can't self-heal; credit recipe inside
-- [0.12.1 App Review crash](appstore-review-crash-0121-aswebauth-anchor.md) UNFIXED; `presentationAnchor` nil-window; reviewer = `xnu_development` in Sentry
-- [iOS <=16 fonts.ready WebContent crash](ios16-fonts-ready-webcontent-crash.md) MERGED #5654 + foliate#71; verify pending; poll `fonts.status` on old WebKit
+- [API route auth audit 2026-08](api-route-auth-audit-2026-08.md) PRIVATE; hardcover + opds forward caller creds with NO caller auth; google RTDN fails open; share token comment is false; pages/api NOT audited
+- [Android launch crash: widget 1px cover](widget-thumbnail-degenerate-cover-crash.md) MERGED #5874; fatal every launch; MIUI install needs emulator
+- [Stripe checkout 500 storage add-on](stripe-checkout-500-storage-purchase.md) root cause UNCONFIRMED; diagnostics MERGED #5896
+- [Apple lost storage purchase](apple-iap-lost-storage-purchase-restore-verify.md) 2 buyers credited by hand; #5669 MERGED but UNRELEASED; recipe inside
+- [0.12.1 App Review crash](appstore-review-crash-0121-aswebauth-anchor.md) UNFIXED; `presentationAnchor` nil-window
+- [iOS <=16 fonts.ready WebContent crash](ios16-fonts-ready-webcontent-crash.md) MERGED #5654 + foliate#71; poll `fonts.status`
 - [Google RTDN verify downgrade](google-rtdn-worker-verify-downgrade-incident.md) googleapis dead on workerd · [Play storage add-ons never consumed](google-iap-consume-storage-purchases.md) MERGED #5545
-- [In-place delete wiped originals](in-place-delete-wiped-originals.md) never `fs.removeFile` `external` · [#5084/#5265 "Delete locally" wiped Drive](gdrive-delete-locally-wiped-cloud-5084.md) MERGED #5376
-- [#5876 empty-library data location](migrate-data-empty-library-scan-guard-5876.md) MERGED #5878 (aa619f8f8); the `!filesToMigrate.length` guard ALSO stood in for "scan succeeded" -> dropping it let a failed `readDirectory` reach `deleteDir` and wipe the data dir; fix = `dirScanned` flag
+- [In-place delete wiped originals](in-place-delete-wiped-originals.md) never `fs.removeFile` on `external` · [#5084/#5265 "Delete locally" wiped Drive](gdrive-delete-locally-wiped-cloud-5084.md) MERGED #5376
+- [#5876 empty-library data location](migrate-data-empty-library-scan-guard-5876.md) MERGED #5878; fix = `dirScanned` flag
 - [#4703 backup zip Win paths](backup-windows-zip-paths-4703.md) · [#4639 download_file scope](download-file-scope-android-regression.md)
 - [#5147 Drive "Untitled" root files](gdrive-untitled-root-files-5147.md) · [Security advisories 2026-06](security-advisories-web-2026-06.md)
-- [#5118 iOS PDF WebContent OOM](pdf-ios-webcontent-oom-zoom-5118.md) clamp renderDpr; [#5251 blurry desktop](pdf-blurry-desktop-dpr-clamp-5251.md) budget mobile-only
+- [#5118 iOS PDF WebContent OOM](pdf-ios-webcontent-oom-zoom-5118.md) clamp renderDpr · [#5251 blurry desktop](pdf-blurry-desktop-dpr-clamp-5251.md)
+
 ## Paginator & Scroll
-- [#5808 rotate walks the page back](resize-anchor-drift-5808.md) MERGED foliate#82 + #5855 (submodule re-pinned); Xiaomi VERIFIED; reporter verify pending
-- Resolved/stable → [Paginator & Scroll Fixes](paginator-scroll-fixes.md)
+- [#5808 rotate walks the page back](resize-anchor-drift-5808.md) MERGED foliate#82 + #5855; Xiaomi VERIFIED
 - [#5179 layered-turn toolbar sync](pr-5179-layered-turn-toolbar-sync.md) MERGED; review defects UNFIXED
+- Resolved/stable → [Paginator & Scroll Fixes](paginator-scroll-fixes.md)
+
 ## Critical Files (Most Bug-Prone)
 - `src/utils/style.ts` EPUB CSS hub · `packages/foliate-js/paginator.js` · `src/services/tts/TTSController.ts`
 - `src/hooks/useSafeAreaInsets.ts` · `src/app/reader/components/FoliateViewer.tsx` · `.../annotator/Annotator.tsx`
+
 ## Sync Notes
-- [New import invisible on peers until opened](books-sync-inflight-change-dropped.md) ROOT: useBooksSync DROPPED library changes during an in-flight sync -> post-upload uploadedAt never pushed -> cloud uploaded_at NULL (peers gate on it); FIX in PR #5869 (rebased on main a557112a7, full suite+lint+format green, Chrome A/B VERIFIED via /api/sync latency injection: old code reproduces, fix pushes); 2nd-device verify pending. The Xiaomi 'error' flagged mid-session was the #5775 in-app-browser crash (Maximum update depth in the web-sources selector, already fixed on that branch b1dfa7e95), NOT this change
-- Resolved/stable sync memories → [Sync Fixes](sync-fixes.md)
-- [#5859 Boox progress reset to page one](progress-loss-android-tauri-plugin-deadlock-5859.md) ROOT (prod-data-confirmed for rjrjr): OPDS auto-download re-imports a re-packaged file under a NEW book_hash whenever CWA changes bytes -> reading position churns/strands across hashes (36 same-metaHash dup groups; 21/30 read books stranded on deleted hashes). FIX in PR #5866 (worktree fix/reading-progress-loss-5859): (1) identity gate in autoDownload.ts skips re-import when the OPDS source already maps to a live book (both contentId+id keys), DEVICE-VERIFIED on Leaf5 vs live CWA (no new dup); (2) applyRemoteProgress reconciliation = furthest-forward, same-hash CFI else sibling FRACTION only (never a sibling CFI -> avoids toRange-null->section-0 page-one), NOT device-verified (device not signed into cloud). SECONDARY: background-kill save window, fix BUILT+device-verified (flush saveConfig on visibilitychange:hidden)
-- [Books toggle doesn't gate OPDS uploads](sync-books-toggle-opds-upload-leak.md) gate MERGED #5759; provider-only + queued residue UNFIXED
+- [New import invisible on peers](books-sync-inflight-change-dropped.md) useBooksSync dropped in-flight changes; PR #5869; 2nd-device verify pending
+- [#5859 Boox progress reset to page one](progress-loss-android-tauri-plugin-deadlock-5859.md) ROOT = OPDS re-import under a NEW book_hash; PR #5866
+- [Books toggle doesn't gate OPDS uploads](sync-books-toggle-opds-upload-leak.md) gate MERGED #5759; provider-only residue UNFIXED
 - [#5062 multi-provider sync](multi-provider-cloud-sync-5062.md) MERGED #5122; native verify pending
 - [iCloud sync provider](icloud-sync-provider.md) SHIPPED #5532+#5537; Dev ID recommit due 2027-02
-- [MAS blank window](mas-sandbox-blank-customrootdir.md) hardening MERGED #5789; runtime verify PENDING; NO VERSION file (`/ship` bump N/A)
-- [#5570 KOSync/BookOrbit custom headers](custom-headers-kosync-bookorbit-5570.md) MERGED; kosync proxy OPEN RELAY fix UNMERGED on `fix/kosync-proxy-endpoint-allowlist`
-- [#5742 Readest books missing from BookOrbit Unmatched list](bookorbit-unmatched-source-5742.md) fix = match-check `source: 'current_file'` + title/authors clamp; MERGED #5860 (c07e75916), worktree removed; VERIFIED 6/6 via BookOrbit's own e2e harness (recipe inside); reporter verify pending; syncNotes-off/PDF registration gap = follow-up; PR #5704 UNRELATED
-- [#5661 "Synced in an hour"](sync-clock-skew-lastsynced-5661.md) display clamp MERGED #5674; epoch-skew LWW poisoning unfixed (user's clock)
-- [#5675 font sync "Unknown error"](font-sync-download-unknown-error-5675.md) PR #5700; mkdir FUSED with id minting; `Unknown error` collapse UNFIXED
-- [#5716 reference page count never synced](reference-page-count-sync-5716.md) MERGED #5727; per-book viewSettings cross NEITHER backend; verify pending
+- [MAS blank window](mas-sandbox-blank-customrootdir.md) MERGED #5789; runtime verify PENDING; NO VERSION file
+- [#5570 KOSync/BookOrbit custom headers](custom-headers-kosync-bookorbit-5570.md) MERGED; kosync proxy OPEN RELAY fix UNMERGED
+- [#5742 Readest books missing from BookOrbit](bookorbit-unmatched-source-5742.md) MERGED #5860; VERIFIED 6/6; recipe inside
+- [#5661 "Synced in an hour"](sync-clock-skew-lastsynced-5661.md) clamp MERGED #5674; epoch-skew LWW poisoning UNFIXED
+- [#5675 font sync "Unknown error"](font-sync-download-unknown-error-5675.md) PR #5700; `Unknown error` collapse UNFIXED
+- [#5716 reference page count never synced](reference-page-count-sync-5716.md) MERGED #5727; per-book viewSettings cross NEITHER backend
 - [deleted_at OR cursor invariant](sync-deleted-at-cursor-invariant.md) load-bearing
-- [#5911 groups + #5912 descriptions erased by row LWW](group-metadata-row-lww-clobber-5911-5912.md) ONE defect; #5905 fixed NEITHER; MERGED #5921 (80f196a9b) via groupUpdatedAt field clock; server half DEAD until web deploy
-- [#5923 storage search auto-fired mid-IME](storage-manager-search-button-5923.md) 1s debounce + `disabled={loading}` ON THE INPUT; fix = Search button form + isComposing guard; MERGED #5925 (0fcbd16f7), cleaned up; NO browser verify (page is auth-gated); reporter verify pending
-- [#5910 reader menu ignored third-party sync](reader-menu-third-party-sync-status-5910.md) label read Readest-Cloud stamps only AND the tap was inert; MERGED #5922 (8aaf2759f) via shared useCloudSyncStatus
-- [#5900 file sync never converged](file-sync-converge-5900.md) MERGED #5905 (fda5a364a); RULE: incremental sync = O(changed), NEVER a whole local/remote dir read; hardening + blind overwrite belong to Full Sync
-- [#5883 file sync never moved the live reader](file-sync-live-view-progress-5883.md) MERGED #5886 (39580e754), branch deleted; pullNow merged+toasted but never `view.goTo` unlike cloud/KOSync; jump is UNCONDITIONAL (merge is LWW both directions) + hint moved after the await; PUSH_DEBOUNCE_MS 15s -> 5s (trailing-only, page turns reset it); reporter verify pending, never device-tested
-- [#5839 Qiniu S3 "Authentication failed" on `()` keys](s3-key-rfc3986-wire-encoding-5839.md) MERGED #5849; Qiniu verify by reporter pending
-- [#5846 Hardcover picks the wrong book](hardcover-link-book-5846.md) MERGED #5857; Link Book picker + device-local `BookConfig.hardcover`; NOT verified live; cross-device link sync = follow-up
-- [#5818 KO highlight deletions lost to id-dedupe](koreader-highlight-deletion-dedupe-5818.md) MERGED #5853; `dedupeLatest` + latest-change merge; server half DEAD until web deploy; bookmark deletions still don't propagate
+- [#5911/#5912 groups + descriptions erased by row LWW](group-metadata-row-lww-clobber-5911-5912.md) MERGED #5921; server half DEAD until web deploy
+- [#5923 storage search auto-fired mid-IME](storage-manager-search-button-5923.md) MERGED #5925; no browser verify (auth-gated)
+- [#5910 reader menu ignored third-party sync](reader-menu-third-party-sync-status-5910.md) MERGED #5922 via shared useCloudSyncStatus
+- [#5900 file sync never converged](file-sync-converge-5900.md) MERGED #5905; RULE incremental sync = O(changed), never a whole dir read
+- [#5883 file sync never moved the live reader](file-sync-live-view-progress-5883.md) MERGED #5886; debounce 15s→5s; never device-tested
+- [#5839 Qiniu S3 auth on `()` keys](s3-key-rfc3986-wire-encoding-5839.md) MERGED #5849; Qiniu verify pending
+- [#5846 Hardcover picks the wrong book](hardcover-link-book-5846.md) MERGED #5857; NOT verified live
+- [#5818 KO highlight deletions lost to id-dedupe](koreader-highlight-deletion-dedupe-5818.md) MERGED #5853; bookmark deletions still stuck
 - [koplugin local_present sweep](koplugin-local-present-sweep-noop.md) UNFIXED; fix = rm readest_library.sqlite3
-- [#5838 koplugin auto sync Wi-Fi prompts](koplugin-auto-sync-no-wifi-bringup-5838.md) MERGED #5848 = bypass bring-up only for "prompt"; OP's turn_on shape NOT fixed by design; per-book push cursor = real fix for orphaned offline notes
-- [#5625 loadDocument parsererror fallback](loaddocument-xhtml-parsererror-5625.md) MERGED #5630 + foliate#70; device verify pending
+- [#5838 koplugin auto sync Wi-Fi prompts](koplugin-auto-sync-no-wifi-bringup-5838.md) MERGED #5848; OP's turn_on shape not fixed by design
+- [#5625 loadDocument parsererror fallback](loaddocument-xhtml-parsererror-5625.md) MERGED #5630 + foliate#70
+- Resolved/stable → [Sync Fixes](sync-fixes.md)
+
 ## Build, Testing & CI
-- [TypeScript 7 upgrade #5260](typescript-7-upgrade-5260.md) MERGED #5893 (squash 09ce80872, 2026-08-26), worktree+branches cleared; `git rebase --skip` is BLOCKED by the auto-mode classifier so dev's 7 unsquashed #5884 duplicates cannot be rebased away from an agent turn (chrox used `git reset origin/main`); TS7 has NO JS compiler API and NO tsserver so `tsgo` bin is gone (lint = `tsc`); Next 16.2 hard-rejects TS>=7 -> next 16.3.3 whose `experimental.useTypeScriptCli` shells out to the same Go tsc (lint and `next build` lost their second opinion); TS7 enforces inferred rootDir under noEmit -> TS6059 on js-mdict, fix = `"rootDir": "../.."`; extension stays TS5 (ts-loader needs the removed API)
-- [Nix FOD hash staleness](nix-fod-hash-staleness.md) MERGED #5779; new pnpmDeps.hash from the PR check's `got:` line, NEVER docker/OrbStack (user ban)
-- Stable recipes → [Build & CI Recipes](build-ci-recipes.md) · [Store listings in fastlane](store-listings-fastlane-5573.md) MERGED #5573; readest-promotions NOT live
-- [git push needs the SOCKS proxy](git-push-socks-proxy.md) GitHub reachable ONLY via ~/.ssh/config ProxyCommand nc -x 127.0.0.1:8119; direct ssh.github.com:443 firewalled; pre-push hook holding the link idle stalls the push -> run gates manually + `git push --no-verify` w/ ServerAliveInterval
-- [worktree:new REBASES a PR branch](worktree-new-rebases-pr-force-push.md) pushing to a fork from it = FORCE push; cherry-pick onto the real head
-- [Workflow-file pushes need SSH](push-workflow-file-needs-ssh-not-gh-oauth.md) gh OAuth token lacks `workflow` scope; fork-PR rebase-push also needs the SSH URL
-- [#5732 nix android AVD ABI on Apple Silicon](nix-android-avd-abi-5732.md) MERGED #5850; `nix_flake_check` PR job = eval check (no nix on this Mac); M-series verify pending
+- [TypeScript 7 upgrade #5260](typescript-7-upgrade-5260.md) MERGED #5893; no tsserver/tsgo (lint = `tsc`); next 16.3.3; rootDir fix
+- [Nix FOD hash staleness](nix-fod-hash-staleness.md) MERGED #5779; hash from the PR check's `got:` line, NEVER docker/OrbStack
+- [git push needs the SOCKS proxy](git-push-socks-proxy.md) ssh ProxyCommand only; `--no-verify` + ServerAliveInterval
+- [worktree:new REBASES a PR branch](worktree-new-rebases-pr-force-push.md) pushing to a fork from it = FORCE push; use the real head
+- [Workflow-file pushes need SSH](push-workflow-file-needs-ssh-not-gh-oauth.md) gh OAuth lacks `workflow` scope
+- [#5732 nix android AVD ABI on Apple Silicon](nix-android-avd-abi-5732.md) MERGED #5850; M-series verify pending
+- [Store listings in fastlane](store-listings-fastlane-5573.md) MERGED #5573; readest-promotions NOT live
+- Stable recipes → [Build & CI Recipes](build-ci-recipes.md)
+
 ## Platform Compat
-- Resolved/stable → pointer index at end of [Platform Compat](platform-compat-fixes.md)
-- [iOS sync tauri::command = watchdog kill](ios-sync-command-run-mobile-plugin-deadlock.md) non-async command + run_mobile_plugin parks the MAIN thread (ipc:// scheme runs there) -> 0x8BADF00D on EVERY in-app-browser download in 0.12.6; FIXED + sim-VERIFIED; incl. stale swift-rs ModuleCache recipe
+- [iOS sync tauri::command = watchdog kill](ios-sync-command-run-mobile-plugin-deadlock.md) MERGED #5947; parks the MAIN thread; sim-VERIFIED, UNRELEASED
 - [#5372/#2862 Play keeps All Files Access](play-all-files-access-restored-5372.md) MERGED #5378; NEXT submission fills the form
 - [#5397 Photos save crash](ios-photos-add-usage-description-5397.md) MERGED #5405; device-verify pending
-- [Android OAuth hangs on MS passkey page](android-oauth-passkey-no-credential-provider.md) no Credential Manager provider; wedges WebAuthn till reboot; NOT a CCT bug
-- [APKs opened with Readest](android-intent-filter-pathpattern-needs-host.md) MERGED #5610, verify PENDING; `pathPattern` DEAD without `android:host`
-- [#5799 BT HID hotplug recreates activity](android-configchanges-navigation-recreate-5799.md) MERGED #5804; manifest regen reintroduces it; verify PENDING
+- [Android OAuth hangs on MS passkey page](android-oauth-passkey-no-credential-provider.md) wedges WebAuthn till reboot; NOT a CCT bug
+- [APKs opened with Readest](android-intent-filter-pathpattern-needs-host.md) MERGED #5610; `pathPattern` DEAD without `android:host`
+- [#5799 BT HID hotplug recreates activity](android-configchanges-navigation-recreate-5799.md) MERGED #5804; manifest regen reintroduces it
+- [Xiaomi loses ALL network when locked](xiaomi-monoproxy-freezes-when-locked.md) MonoProxy VPN freezes; unlock FIRST
+- Resolved/stable → [Platform Compat](platform-compat-fixes.md)
+
 ## Reader Features & UI
-- [daisyUI 5 + Tailwind 4 migration](daisyui-v5-tailwind-v4-migration.md) MERGED #5884; custom CSS MUST live in `@layer utilities`; 4 post-merge regressions fixed: toast 0px, `loading-lg`, dialog close strip, bare `.modal-box` never paints outside `.modal` = #5916 (f8a3e3d2d)
-- [#480 IDPF EPUB3 sample sweep](epub3-samples-idpf-480.md) MERGED #5872 (07371ccce) + foliate#84, worktree removed (inline MathML wrapper + math pre-wrap, epub:switch transformer, bitmap-spine viewport, SVG-spine font crash); all 42 samples Chrome-verified; reporter verify pending; calibre can't even open the bitmap/SVG-spine/kusamakura samples; full-screen calibre OCCLUDES Chrome (MCP timeouts)
-- [#1812 Kotobee EPUB embedded video](epub-embedded-video-kotobee-1812.md) MERGED #5868 (5aae8d6c5) + foliate #83; ROOT: script-built `<video src=../x.mp4>` can't resolve against the `blob:` base -> media error -> Kotobee tears its player down; Chromium + Xiaomi VERIFIED, reporter verify pending (issue still OPEN); adversarial probe caught a stale-resolution race on src-swap (fixed, tested); foliate squash-merges so ALWAYS re-pin the submodule; file:// VIEW intent does NOT import on Android (use the app picker); XHTML docs have lowercase tagName
-- Resolved/stable feature memories → [Reader Feature Fixes](reader-feature-fixes.md)
-- [#5887 footnote popup size](footnote-popup-content-size-5887.md) MERGED 7c0419961; e13f58c05 fixed the never-shown image popup; RO fit UNCAPPED + image staircase still OPEN
-- [#5766 footnote popup jump to location](footnote-popup-jump-to-location-5766.md) MERGED #5889 (squash aab58241d), worktree removed; Chrome VERIFIED, reporter verify pending; NEVER set non-zero `margin-*` on the popup renderer (88px box + margin row = infinite ResizeObserver loop, popup never opens); chrome OVERLAYS the text (pointer-events-none row), NEVER reserve a strip; jump button gated on `isLinkTargetVisible` (reader CSS hides inline notes); NEVER drop the popup's forced `follow:true` (#559)
-- [#5888 cross-page selection edge turn](cross-page-selection-edge-turn-5888.md) MERGED a91b503e5, cleaned up; 4 review defects fixed (cherry-pick onto real head, NEVER push the rebased worktree branch); `viewSettings.rtl` also true when UI lang is RTL; device verify pending
-- [#5852 TOC long headings truncated](toc-multiline-headings-5852.md) MERGED #5858; `min-w-0 break-words` (min-w-0 load-bearing); Chrome VERIFIED; reporter verify pending
-- [#5813 cover full screen](book-cover-fullscreen-viewer-5813.md) MERGED #5827; device verify pending; aria-labels are translated
-- [Audiobookshelf phases 1+2](audiobookshelf-integration-phase1.md) MERGED #5801 + #5841; abs_server sync DEAD until web deploy (migration 020); device verify pending
-- [#5863 paired-audiobook audio transport + WebP thumbnails](abs-audio-transport-5863.md) MERGED #5865 (c6a1901a5), worktree removed; reporter verify pending; unmapped audio sub-chapters absorbed by the mapped chapter before them; 30s/15s skip (user choice, RiReplay15Line/RiForward30Line) + audiobook-chapter skip via forward(byMark); Boox VERIFIED; image crate `webp` feature
-- [#5807 ABS read-along](abs-read-along-5807.md) MERGED #5856; ABS audiobook paired w/ EPUB via Read Aloud; Xiaomi VERIFIED; page-follow fix = PRE-EXISTING #5754 bug
-- [#5795 e-ink per-device CSS](eink-per-device-css-data-eink-5795.md) MERGED #5803; Boox verify PENDING
-- [#5662 Alert sized off its own text](alert-flex-item-content-sizing-5662.md) MERGED; `w-full` wrapper LOAD-BEARING; needs browser test
-- [#1582 translated text loses formatting](translation-inline-markup-1582.md) STILL OPEN; default `deepl` CORRUPTS markup
-- [en->zh provider verification 2026-08-28](translation-providers-device-verification-2026-08.md) MERGED #5913 (e782af530), branch cleared; all 4 OK on Xiaomi; DeepL ZH-HANT/ZH-TW 500 was OUR casing bug (`.toUpperCase()` on the whole code); `ZH-Hant` works, FIXED; Google 429 ROOT = the Tauri Rust HTTP client (window.fetch 200 vs tauriFetch 429, same URL/instant) -> google.ts now always uses window.fetch + cap 4, device-VERIFIED; azure conc 3->10 on Tauri
-- [Xiaomi loses ALL network when locked](xiaomi-monoproxy-freezes-when-locked.md) MonoProxy per-app VPN (uid 10452) freezes -> Readest blackholes; unlock FIRST; Tauri re-injects IPC and silently kills invoke hooks
-- [#5772 iframe translation observer](translation-iframe-observer-5772.md) MERGED; PR's root cause FALSE; `allTextNodes` INDEX-COUPLED
-- [#5600 PDF quota toast on every selection](pdf-translation-quota-toast-5600.md) MERGED #5617; contextmenu auto-open + stale `translationEnabled` UNFIXED
-- [#5538 highlight resize orphan bubble](highlight-resize-orphan-note-bubble-5538.md) MERGED #5541; drag-race overlay UNFIXED
-- [#5652/#5634 header vs footer dedup](reader-header-footer-dedup-5652-5634.md) MERGED #5708; `Aa` GONE so desktop has NO one-click settings; device verify pending
-- [#5585 Instant Dictionary deselects](instant-dictionary-deselect-5585.md) MERGED #5730; clear `isTextSelected` BEFORE `view.deselect()`; device verify pending
-- [#5667 e-ink highlight invisible in dark](eink-highlight-difference-mask-5667.md) MERGED #5735; transientHighlight UNFIXED; device verify pending
-- [Footnote popup revokes section image blobs](footnote-popup-revokes-section-blobs.md) MERGED #5756 + foliate#78; fix needs BOTH halves or sections leak; device verify pending
-- [#5646 footnote popup selection toolbar](footnote-popup-selection-5646.md) MERGED #5744 + foliate#77; overlay-click ambiguity + quick-actions gaps OPEN
-- [PR #5780 edit note from bubble popup](pr-5780-inline-note-popup-edit-review.md) MERGED; note bubbles NOT drawn on initial load = PRE-EXISTING (no issue filed)
-- [#5776 book title/series data attrs](book-meta-data-attrs-5776.md) MERGED #5806; index 0 unrepresentable; device check pending
-- [#5785 note popup markdown](note-popup-markdown-5785.md) MERGED #5805; OPEN: note links navigate the whole webview
-- [#5822 PDF page labels as reference pages](pdf-page-labels-reference-pages-5822.md) MERGED #5824 + foliate#81; keep foliate branch until next bump; device verify pending
-- [e-ink `[class*=]` matchers](eink-class-substring-matchers.md) fire on `hover:`/`not-eink:` variants, beat inline styles; caused #4454 + the #5667 pill
-- [#4977 top bar blocks text selection](header-trigger-overlaps-text-4977.md) strip sized to content top; iPad web gap
-- [#5480 Media Overlays narration](media-overlay-narration-5480.md) MERGED; 3 review findings UNFIXED
-- [#5562 MO narration iOS native AVPlayer](media-overlay-ios-native-playout-5562.md) MERGED; Swift compiled ONLY by ios build; verify PENDING
-- [#5501 Apple Pencil page turner](apple-pencil-page-turner-5501.md) MERGED #5511; verify PENDING
-- [Mobile sheet virtuoso first-paint blank](mobile-sheet-virtuoso-first-paint-blank.md) PRE-EXISTING · [PR #5389 library full-text search review](pr-5389-library-search-review.md) plan in .agents/plans
-- [Word Lens en-hu pack](wordlens-en-hu-pack-5738.md) PUBLISHED to R2 2026-08-20; merging does NOT publish, `pnpm wordlens:sync` is manual
-- [kaikki raw dump for Word Lens](wordlens-en-vi-pack-5737.md) per-language kaikki file DEPRECATED (wiktextract#1178); build streams raw-wiktextract-data.jsonl.gz gzipped, filters lang_code; MERGED #5861 2026-08-24; regenerated en-vi/en-hu SYNCED to CDN (verified sha256)
-- [Readest Voice self-hosted TTS](selfhosted-premium-tts-plans.md) APPROVED 2026-07-08; not started
-- [TTS word highlight skipped Word Lens words](tts-word-highlight-wordlens-ruby-collapse.md) `expandRangeOverRuby` widened over `cfi-skip` wl-gloss ruby -> before/after the ruby are the SAME CFI step -> range COLLAPSES -> empty highlight; fix = expand only for spoken kana `<rt>`; Xiaomi-verified (32/241 draws empty before)
-- [#3772 custom keyboard/mouse shortcuts](custom-shortcuts-3772.md) MERGED #5907 (d27d324e1), cleaned up; bare `.modal-box` NEVER paints outside `.modal modal-open`; first-match-wins killed 6 default bindings
-- [#5755 TTS lyric-style sentence view](tts-lyric-view-5755.md) MERGED #5908 (fabbcc640) + #5909 (c04ba5a80); gate = `mediaClock && textHighlight !== false`; auto-scroll broke on stale line-centre cache (observe the CONTENT box, not just the scroller)
-- [PR #5690 TTS download queue](tts-download-queue-5690.md) MERGED 2026-08-16, Xiaomi verified; non-pt-BR i18n pending
-- [#4584 tap-death](issue-4584-tap-death-investigation.md) UNFIXED; likely WebView-148 · [#5353 italic last glyph clipped](italic-synthetic-oblique-clip-5353.md) WebView regression, not Readest code
-- [#5250 invert img dead w/ overrideColor](invert-img-dark-override-5250.md) PR #5383 open, VERIFIED
-- [#5633 iOS image zoom blurry](ios-imageviewer-zoom-blur-5633.md) MERGED #5639; TableViewer same bug UNFIXED; verify pending
-- [#5635 Auto Scroll progress frozen](autoscroll-progress-relocate-maxwait-5635.md) MERGED #5676 + foliate#72; jitter (item 1) OPEN
-- [#5711 fixed-attachment garble + negative-margin bleed](css-fixed-attachment-negative-margin-5711.md) MERGED #5729; corner-logo over footer OPEN
-- [#5641 Chrome-Android FXL text autosizing](fxl-chrome-android-text-autosizing-5641.md) MERGED #5659; verify pending; fix = text-size-adjust none
-- [#5582 SE wide word gaps](se-text-wrap-pretty-justify-5582.md) MERGED #5718; device visual verify pending; fix = `text-wrap-style: auto` gated on justify
-- [#5749 iOS weak hyphenation](hyphenation-engines-5749.md) OPEN; WebKit dict SEALED; only fix = JS soft-hyphen injection + offset normalization
-- [#5750 TTS pause inconsistent](tts-pause-inconsistency-5750.md) MERGED #5753; device verify pending; `pnpm test` MISSES browser tests
-- [#5414 Edge silence untrimmed on iOS](edge-tts-baked-silence-ios-native-5414.md) MERGED #5417; verify pending · [#5230 Edge TTS mid-book stall](edge-tts-tauri-ws-hang-5230.md) MERGED #5534
-- [Proofread gate = reflowable formats](proofread-gate-reflowable-formats.md) selection rules born dead (UNFIXED)
-- [OPDS fixes](opds-fixes.md) aggregator: parsing, search, auth, auto-download, Calibre quirks
-- [#5583 download format filter](opds-download-format-filter-5583.md) PR #5593
-- [#5645 self-update crash on KOReader 2026.07+](koplugin-selfupdate-unpackarchive-5645.md) PR #5656; Device:unpackArchive DROPPED upstream
-- [#5745 CBZ split-chapter folder order](cbz-split-folder-page-order-5745.md) MERGED #5762 + foliate#79; use `pnpm worktree:rm` for submodule worktrees
-- [#5924 RTL blank pages mid-chapter](rtl-skip-link-blank-pages-5924.md) a11y skip link `left:0` resolves vs the EXPANDED iframe -> `contentSize`==iframe width ratchet; fix `left:auto`; MERGED #5926 (86493e801)
-- [#5918 AZW3 garbled + dead TOC](azw3-loadraw-concurrency-5918.md) ROOT: KF8 `loadRaw` races itself when section loads overlap on RemoteFile reads; MERGED #5920 (7e8abebcd) + foliate#86 (ca3f118); cleaned up; reporter verify pending; + RemoteFile cache off-by-one short read
+- [#5932 settings scope](settings-scope-menu-5933.md) MERGED #5933 as 1-file ⋮ relabel; banner declined; info/warning tints fail on EVERY theme
+- [#5945 separate library/reader theme](library-reader-theme-scope-5945.md) MERGED #5948 (ad9e5c1b8); store themeMode/themeColor now DERIVED (setState silently ignored); getThemeCode = reader-only
+- [daisyUI 5 + Tailwind 4 migration](daisyui-v5-tailwind-v4-migration.md) MERGED #5884; custom CSS MUST be `@layer utilities`; 4 regressions fixed
+- [#480 IDPF EPUB3 sample sweep](epub3-samples-idpf-480.md) MERGED #5872 + foliate#84; 42 samples Chrome-verified
+- [#1812 Kotobee EPUB embedded video](epub-embedded-video-kotobee-1812.md) MERGED #5868 + foliate#83; blob: base resolution; ALWAYS re-pin foliate
+- Footnote popup: [#5887 size](footnote-popup-content-size-5887.md) RO fit UNCAPPED OPEN · [#5766 jump](footnote-popup-jump-to-location-5766.md) NEVER non-zero margin · [blob revoke](footnote-popup-revokes-section-blobs.md) needs BOTH halves · [#5646 selection](footnote-popup-selection-5646.md) overlay gaps OPEN · [#5780 edit](pr-5780-inline-note-popup-edit-review.md) · [#5785 markdown](note-popup-markdown-5785.md) links navigate whole webview OPEN
+- Translation: [#1582 markup lost](translation-inline-markup-1582.md) STILL OPEN, `deepl` CORRUPTS · [en→zh providers](translation-providers-device-verification-2026-08.md) #5913, google.ts uses window.fetch · [#5772 iframe observer](translation-iframe-observer-5772.md) `allTextNodes` INDEX-COUPLED · [#5600 PDF quota toast](pdf-translation-quota-toast-5600.md) auto-open UNFIXED
+- TTS: [#5755 lyric view](tts-lyric-view-5755.md) #5908+#5909 · [#5690 download queue](tts-download-queue-5690.md) · [#5750 pause](tts-pause-inconsistency-5750.md) `pnpm test` MISSES browser tests · [#5414 Edge silence iOS](edge-tts-baked-silence-ios-native-5414.md) · [#5230 Edge stall](edge-tts-tauri-ws-hang-5230.md) · [word highlight vs Word Lens ruby](tts-word-highlight-wordlens-ruby-collapse.md) CFI collapse
+- Narration: [#5480 Media Overlays](media-overlay-narration-5480.md) 3 findings UNFIXED · [#5562 iOS AVPlayer](media-overlay-ios-native-playout-5562.md) Swift built ONLY by ios · [Audiobookshelf 1+2](audiobookshelf-integration-phase1.md) abs_server DEAD until deploy · [#5863 transport+WebP](abs-audio-transport-5863.md) · [#5807 read-along](abs-read-along-5807.md)
+- e-ink: [`[class*=]` matchers](eink-class-substring-matchers.md) fire on variants, beat inline styles · [#5795 per-device CSS](eink-per-device-css-data-eink-5795.md) Boox verify PENDING · [#5667 highlight invisible dark](eink-highlight-difference-mask-5667.md) transientHighlight UNFIXED
+- CSS/layout: [#5711 fixed-attachment](css-fixed-attachment-negative-margin-5711.md) corner-logo OPEN · [#5641 FXL autosizing](fxl-chrome-android-text-autosizing-5641.md) text-size-adjust none · [#5582 SE word gaps](se-text-wrap-pretty-justify-5582.md) · [#5662 Alert sizing](alert-flex-item-content-sizing-5662.md) `w-full` LOAD-BEARING · [#5852 TOC headings](toc-multiline-headings-5852.md) min-w-0 load-bearing
+- Rendering: [#5924 RTL blank pages](rtl-skip-link-blank-pages-5924.md) skip link `left:auto` · [#5918 AZW3 garbled](azw3-loadraw-concurrency-5918.md) KF8 loadRaw races · [#5745 CBZ order](cbz-split-folder-page-order-5745.md) use `pnpm worktree:rm` · [#5822 PDF page labels](pdf-page-labels-reference-pages-5822.md) · [#5635 Auto Scroll frozen](autoscroll-progress-relocate-maxwait-5635.md) jitter OPEN
+- [#5939 edge gestures vs mid-touch selection](edge-gesture-selection-after-touchstart-5939.md) MERGED #5958; re-check selection EVERY move + `scrollLocked`; autoscroll-speed twin UNFIXED
+- Reader chrome: [#5938 header/footer style](header-footer-style-5938.md) MERGED #5960; auto/none/custom chip, header chip too; NO device verify · [#5652/#5634 header vs footer](reader-header-footer-dedup-5652-5634.md) `Aa` GONE · [#4977 top bar blocks selection](header-trigger-overlaps-text-4977.md) · [#5888 cross-page selection](cross-page-selection-edge-turn-5888.md) rtl true for RTL UI · [#3772 custom shortcuts](custom-shortcuts-3772.md) · [#5501 Apple Pencil](apple-pencil-page-turner-5501.md)
+- Annotator: [#5538 resize orphan bubble](highlight-resize-orphan-note-bubble-5538.md) drag-race UNFIXED · [#5585 Instant Dictionary](instant-dictionary-deselect-5585.md) clear isTextSelected FIRST · [Proofread gate](proofread-gate-reflowable-formats.md) born dead
+- Images/PDF: [#5633 iOS zoom blurry](ios-imageviewer-zoom-blur-5633.md) TableViewer UNFIXED · [#5250 invert img](invert-img-dark-override-5250.md) PR #5383 · [#5813 cover full screen](book-cover-fullscreen-viewer-5813.md) · [#5776 title/series attrs](book-meta-data-attrs-5776.md)
+- Word Lens: [en-hu pack](wordlens-en-hu-pack-5738.md) `pnpm wordlens:sync` is MANUAL · [kaikki raw dump](wordlens-en-vi-pack-5737.md) per-language file DEPRECATED · [Readest Voice TTS](selfhosted-premium-tts-plans.md) approved, not started
+- OPDS/koplugin: [OPDS fixes](opds-fixes.md) aggregator · [#5583 format filter](opds-download-format-filter-5583.md) PR #5593 · [#5645 self-update crash](koplugin-selfupdate-unpackarchive-5645.md) unpackArchive DROPPED upstream
+- Known-unfixed platform bugs: [#4584 tap-death](issue-4584-tap-death-investigation.md) likely WebView-148 · [#5353 italic clipped](italic-synthetic-oblique-clip-5353.md) WebView regression · [#5749 iOS hyphenation](hyphenation-engines-5749.md) WebKit dict SEALED · [virtuoso first-paint blank](mobile-sheet-virtuoso-first-paint-blank.md)
+- [PR #5389 library full-text search review](pr-5389-library-search-review.md) plan in .agents/plans
+- Resolved/stable → [Reader Feature Fixes](reader-feature-fixes.md)
+
+- [Yearly subscriptions + modern plans grid](yearly-subscriptions-store-front.md) branch feat/yearly-subscriptions UNCOMMITTED; SKUs NOT created; fixed prices.list limit-10 truncation + month-before-year order for <=0.9.67 clients
+- [#1750 Notion sync](notion-sync-pr-5949-review.md) MERGED #5949 as 295d6e79; 4 defects SHIPPED UNFIXED, worst DELETES the user's own Notion blocks (remoteNoteGroups slice); needs a follow-up issue
+
 ## Library Fixes
-- [#5148 no overscroll on mobile = LIBRARY grid, not reader](overscroll-library-not-reader-5148.md) MERGED #5867 squash bc4b253b6 (2026-08-25), chrox VERIFIED iOS + Android, worktrees/branches/remote/dev duplicates cleared; RULE: overscroll ON for library page + bookshelf, NEVER for foliate view; iOS native bounce + JS rubber-band both edges elsewhere (MAX 96/k 0.35, touchcancel snap-back); Android WebView can NEVER draw native overscroll here (pullGlow maxY gate, OVER_SCROLL_ALWAYS no effect); `-webkit-overflow-scrolling` dead on iOS 13+/Blink; goToFraction(1) auto-marks FINISHED
-- [#5775 in-app web browser as book source](in-app-browser-book-source-5775.md) MERGED #5870 (f45036556); desktop = WebviewWindow.on_download + injected pill, mobile = native WebBrowserController; iOS device flow NEVER verified -> shipped the 0.12.6 download crash, see [[ios-sync-command-run-mobile-plugin-deadlock]]; OPEN: target=_blank closes the desktop browser window
-- [Windows clip/browser window 0x8007139F](webview2-env-options-scrollbar-clip-window.md) MERGED #5873 (d213af033, 2026-08-25), worktree removed; Windows verify by reporter pending; WebView2 rejects a 2nd webview whose env options differ -> every extra WebviewWindow on Windows MUST set ScrollBarStyle::FluentOverlay like main; FluentOverlay is cfg(windows)-only, PR CI has no Windows Rust build; Windows verify pending
-- [#5837 backup exports orphan book dirs](backup-orphan-book-files-5837.md) MERGED #5851; backup = live rows only; Manage Cache reclaims orphans (1h guard); `readDirectory('', 'Books')` MISSES the Rust walk; device verify pending
-- [#5650 CDN 52x retry + metadata backfill](novel-import-transient-fetch-metadata-5650.md) MERGED; chapter TRUNCATION still UNFIXED
-- [#5596 long-press select double-toggles](longpress-contextmenu-double-fire-5596.md) MERGED #5621, verify pending
-- [#5680 Read-in-place uncheck](readinplace-uncheck-unregister-5680.md) MERGED #5685; drag-drop ingress MUST pass real registration state, else silent unregister
-- [#5360 Wayland tap kills native menu](wayland-tap-context-menu-5360.md) MERGED #5467; verify pending
+- [#5955 not all books auto-imported](autoimport-skips-deleted-books-5955.md) NOT reproducible; watcher silently skips DELETED books' paths forever (tombstone + altFilePaths)
+- [#5959 updated EPUB imports as a duplicate](duplicate-book-calibre-uuid-5959.md) MERGED #5961 (053aba67f) UNVERIFIED on device; metaHash is a WIRE KEY (server + koplugin meta_hash_v1), never change its output
+- [#5935 group by reading status](status-grouping-i18n-5935.md) MERGED 82658d8ed; grouping MUST partition (414/750 fell out, Unread held 1); `BooksGroup.localized` gates `_()`; fork push = NEVER the worktree:new head
+- [#5148 no overscroll on mobile = LIBRARY grid](overscroll-library-not-reader-5148.md) MERGED #5867; NEVER for foliate view; goToFraction(1) marks FINISHED
+- [#5775 in-app web browser as book source](in-app-browser-book-source-5775.md) MERGED #5870; iOS flow never verified; target=_blank bug OPEN
+- [Windows clip/browser window 0x8007139F](webview2-env-options-scrollbar-clip-window.md) MERGED #5873; every extra WebviewWindow MUST set FluentOverlay
+- [#5837 backup exports orphan book dirs](backup-orphan-book-files-5837.md) MERGED #5851; `readDirectory('', 'Books')` MISSES the Rust walk
+- [#5650 CDN 52x retry + metadata backfill](novel-import-transient-fetch-metadata-5650.md) MERGED; chapter TRUNCATION UNFIXED
+- [#5596 long-press select double-toggles](longpress-contextmenu-double-fire-5596.md) MERGED #5621
+- [#5680 Read-in-place uncheck](readinplace-uncheck-unregister-5680.md) MERGED #5685; drag-drop must pass real registration state
+- [#5360 Wayland tap kills native menu](wayland-tap-context-menu-5360.md) MERGED #5467
+
 ## Networking & LAN
-- [Nearby BookDrop branding](nearby-bookdrop-branding.md) MERGED #5915 (a03b5144d); code ids stay `localsend`; brand untranslated; ABS row NOT plural-aware (open)
-- [LocalSend integration](localsend-integration.md) MERGED #5611; fork `readest/localsend`; mTLS needs `WebConfig{upload:true}`; commands need 3-place ACL
-- [koplugin LocalSend receive+send](koplugin-localsend-receive.md) MERGED #5687; static-musl BINARY+subprocess (Kindle glibc); fork pinned 3cae1825; ANDROID exec IMPOSSIBLE
-- LocalSend discovery was DEAD 3 ways — MERGED #5626 + fork rev 37219949; rev bumps rebase BOTH patches
+- [Nearby BookDrop branding](nearby-bookdrop-branding.md) MERGED #5915; code ids stay `localsend`; ABS row not plural-aware
+- [LocalSend integration](localsend-integration.md) MERGED #5611; fork `readest/localsend`; commands need 3-place ACL
+- [koplugin LocalSend receive+send](koplugin-localsend-receive.md) MERGED #5687; static-musl binary; ANDROID exec IMPOSSIBLE · discovery was DEAD 3 ways, MERGED #5626 + fork rev 37219949 (rev bumps rebase BOTH patches)
+
 ## Architecture & Patterns
-- [Tauri Channel progress lands AFTER invoke resolves](tauri-channel-progress-after-invoke-resolves.md) MERGED #5736; latch every onProgress/cleanup pair; `cancel()` not `flush()`
+- [Tauri Channel progress lands AFTER invoke resolves](tauri-channel-progress-after-invoke-resolves.md) MERGED #5736; latch every onProgress pair
 - foliate-js submodule `packages/foliate-js/`; multiview paginator preloads adjacent sections
-- Markdown: [.md support #774](markdown-md-support-774.md); resume position #4862; footnotes #5074; [#5279 YAML frontmatter](markdown-yaml-frontmatter-5279.md) MERGED #5344; dedup race UNFIXED
-- [md titled after first H1, not the file](markdown-title-first-h1-over-filename.md) PR #5653; existing libraries keep their titles
+- [.md support #774](markdown-md-support-774.md) resume #4862, footnotes #5074 · [#5279 YAML frontmatter](markdown-yaml-frontmatter-5279.md) MERGED #5344
+- [md titled after first H1, not the file](markdown-title-first-h1-over-filename.md) PR #5653
 - Style: `getLayoutStyles()` always, `getColorStyles()` when overriding; `transformStylesheet()` rewrites EPUB CSS
 - TTS `#ttsSectionIndex`; insets: native plugin → useSafeAreaInsets → styles; Dropdowns `DropdownContext`
 - [Virtuoso + OverlayScrollbars](virtuoso_overlayscrollbars.md) · [Theorem competitor analysis](theorem-competitor-feature-analysis.md)
-- [Design system → DESIGN.md](feedback_design_system_doc.md) never `pl/pr/ml/mr` (RTL)
+- [Design system → DESIGN.md](feedback_design_system_doc.md) never `pl/pr/ml/mr` (RTL) · [swatch+select rows](settings-row-two-controls.md) SettingsSelect `max-w-[60%]` truncates in a wrapper
+
 ## Workflow & Feedback
+- [/user-report skill](user-report-skill.md) report -> gh issue -> ~/Documents/books/issues/<id>/; Chrome downloads land on ~/Desktop
 - [Always verify on Xiaomi](feedback-always-verify-on-xiaomi.md) device 368b0948; CDP+deep-link recipe; md5-check the APK
-- [Slice-in-loop NOT O(n^2)](review-perf-slice-not-quadratic.md) V8 SlicedString · [Commit messages English-only](feedback-commit-message-english-only.md) no CJK, no em/en dashes
-- PR flow: [rebase onto origin/main](feedback_pr_rebase.md); [fresh branch per PR](feedback_pr_new_branch.md); [always `pnpm worktree:new`](feedback_use_worktree.md); [don't push till confirmed](feedback_dont_push_every_change.md); pre-push hook runs full vitest (~2.5 min), push in background
+- [Slice-in-loop NOT O(n^2)](review-perf-slice-not-quadratic.md) V8 SlicedString
+- [Commit messages English-only](feedback-commit-message-english-only.md) no CJK, no em/en dashes
+- PR flow: [rebase onto origin/main](feedback_pr_rebase.md) · [fresh branch per PR](feedback_pr_new_branch.md) · [always `pnpm worktree:new`](feedback_use_worktree.md)
+- [`pnpm lint` EXCLUDES the format check](verify-lint-excludes-format-check.md) run `pnpm format:check` too or CI `build_web_app` fails on formatting
+- [Don't push till confirmed](feedback_dont_push_every_change.md) pre-push hook runs full vitest (~2.5 min)
 - [Test file filter](feedback_test_file_filter.md) `pnpm test <path>` no `--` · [No test seams in prod](feedback_no_test_seams_in_prod.md) · [no lookbehind regex](feedback_no_lookbehind_regex.md)
-- [No mock-only platform tests](feedback-no-mock-only-platform-tests.md) skip call-sequence tests over mocked IPC · [No config-mirror tests](feedback-no-config-mirror-tests.md) validate via `cargo check`
-- i18n: [en plurals manual](feedback_en_plurals_manual.md); [i18n:extract prunes keys](i18n-extract-prunes-keys.md) (~56 drift keys); {{provider}} case suffixes #5102; [label rename = key rename](i18n-label-rename-workflow.md)
-- [Dependabot transitive fixes](dependabot-pnpm-overrides.md) `overrides:` · [deps security recipe](deps-security-overrides-workflow.md) MERGED #5335+#5518 · [gstack upgrade](feedback_gstack_upgrade.md) project-local install
-- [Reserved route filenames under src/app/](nextjs-app-dir-reserved-route-filenames.md) a helper named `layout.ts` = route layout; build-only failure, lint is GREEN
-- [Reader chrome changes need e2e](verify-reader-chrome-needs-e2e.md) `ReaderPage.ts` hard-codes toolbar aria-labels; grep `e2e/` before deleting a reader button
-- [stat_pages slow query + disk growth](stat-pages-slow-query-disk-growth.md) SWAPPING instance = root cause; #5835 + #5844 DEPLOYED; cron FLIPPED 3719ec648 (user deploys); watch drain ~3 days from 2026-08-24
-- [No prod metrics in public issues/PRs](feedback-no-prod-metrics-in-public.md) #5834 DELETED for exposing prod data; specs stay local
+- [No mock-only platform tests](feedback-no-mock-only-platform-tests.md) · [No config-mirror tests](feedback-no-config-mirror-tests.md) validate via `cargo check`
+- i18n: [match the locale's established term](i18n-match-established-locale-terms.md) grep `Highlights`/`Notes` before inventing a synonym; audit case-folded + stemmed
+- i18n: [en plurals manual](feedback_en_plurals_manual.md) · [i18n:extract prunes keys](i18n-extract-prunes-keys.md) · [label rename = key rename](i18n-label-rename-workflow.md)
+- [Dependabot transitive fixes](dependabot-pnpm-overrides.md) `overrides:` · [deps security](deps-security-overrides-workflow.md) #5335+#5518 · [gstack upgrade](feedback_gstack_upgrade.md) project-local
+- [Reserved route filenames under src/app/](nextjs-app-dir-reserved-route-filenames.md) `layout.ts` helper = route layout; build-only failure
+- [Reader chrome changes need e2e](verify-reader-chrome-needs-e2e.md) `ReaderPage.ts` hard-codes toolbar aria-labels
+- [stat_pages slow query + disk growth](stat-pages-slow-query-disk-growth.md) #5835+#5844 DEPLOYED; cron FLIPPED 3719ec648
+- [No prod metrics in public issues/PRs](feedback-no-prod-metrics-in-public.md) #5834 DELETED for exposing prod data
 - [KOReader emulator headless verify](koreader-emulator-headless-verify.md) HttpInspector recipe; never mv the stats DB

--- a/apps/readest-app/.claude/memory/android-kotlin-unit-test-gradle-recipe.md
+++ b/apps/readest-app/.claude/memory/android-kotlin-unit-test-gradle-recipe.md
@@ -18,3 +18,12 @@ metadata:
 3. junit is already wired (`testImplementation junit:4.13.2` in plugin build.gradle.kts).
 
 Notes: the copied `tauri.settings.gradle` references cargo-registry plugin paths, so this only works on a machine with the registry populated. A standalone harness (own settings.gradle including just `:tauri-android` + the two plugins) also works — plugins depend only on `project(":tauri-android")` from `packages/tauri` + maven artifacts; needs `android.useAndroidX=true` in gradle.properties and AGP 8.11/Kotlin 1.9.25 matching gen/android. A `kotlin_test` CI job was drafted 2026-08-04 but the user discarded it; the native-tts `ExampleUnitTest.kt` invalid package (`com.readest.native-tts`) it caught was fixed in #5484 (MERGED).
+
+**Flavor correction (2026-08-30):** billing lives in the `googleplay` flavor, so
+`BillingManager.kt` is NOT covered by `testFossDebugUnitTest` — use
+`:tauri-plugin-native-bridge:testGoogleplayDebugUnitTest`, with tests in
+`android/src/testGoogleplay/java/...`. `app/tauri.properties` must be copied
+alongside `tauri.settings.gradle` + `app/tauri.build.gradle.kts`, and
+`ANDROID_HOME=/Users/chrox/dev/Android/sdk` exported. Results land in
+`android/build/test-results/testGoogleplayDebugUnitTest/*.xml` (gradle can
+report BUILD SUCCESSFUL without running anything, so read the XML).

--- a/apps/readest-app/.claude/memory/api-route-auth-audit-2026-08.md
+++ b/apps/readest-app/.claude/memory/api-route-auth-audit-2026-08.md
@@ -1,0 +1,70 @@
+---
+name: api-route-auth-audit-2026-08
+description: "Audit of all 29 src/app/api routes for caller auth vs upstream-credential passthrough (2026-08-31); hardcover + opds are unauthenticated relays, google RTDN fails open"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 6981cf12-3457-45a5-8161-d15457b41f63
+  modified: 2026-08-30T17:10:11.565Z
+---
+
+Audited every `route.ts` under `apps/readest-app/src/app/api/` on 2026-08-31 while fixing
+the Notion proxy. KEEP THESE FINDINGS PRIVATE - see [[feedback-no-prod-metrics-in-public]];
+#5834 was deleted for exposing prod data. Do not put them in a public issue or PR.
+
+## The distinction that matters
+Forwarding a caller-supplied UPSTREAM credential is NOT authentication. Three routes do
+that with no caller check at all:
+- `hardcover/graphql` - checks only that `authorization` is non-empty (:6-9), forwards it
+  plus arbitrary GraphQL to api.hardcover.app. No origin check, no body cap, no timeout,
+  no rate limit. Worst of the three.
+- `opds/proxy` - `?auth=` is the upstream OPDS catalog credential (:141-143), plus
+  arbitrary `?headers=`. Real protection is SSRF only (host blocklist + per-redirect
+  revalidation :64-79). Effectively an open HTTP proxy with `ACAO: *`.
+- `notion/[...path]` - FIXED 2026-08-31 in PR #5949 (`validateUserAndToken` + the Notion
+  secret moved to `x-notion-token`).
+
+## The house pattern to copy
+`azure-translate` / `yandex-translate`: `validateUserAndToken` -> 403, then origin==host,
+then endpoint allowlist, then a per-user 60/min + 3-concurrent budget, a 100k body cap
+checked against BOTH content-length and the decoded body, and a 15s timeout.
+
+## Verified by hand (not just the agent's word)
+- **Google RTDN fails open.** `google/notifications/route.ts:24-26`: if
+  `GOOGLE_RTDN_VERIFICATION_TOKEN` is unset it logs a warning and PROCEEDS. And
+  `handleVoidedPurchase` (`libs/payment/iap/google/notifications.ts:169-210`) acts on
+  `purchaseToken` alone with NO Play API re-verification - it goes straight to
+  `createOrUpdateSubscription(..., 'revoked')` / `markPaymentRefunded`.
+  SEVERITY CONTEXT: per [[google-rtdn-worker-verify-downgrade-incident]] the push URL was
+  repointed to node.readest.com and the endpoint was probed live (401 on bad token), so
+  the token IS present in prod. This is a latent hazard / defence-in-depth gap, NOT a live
+  exploit. Fix = hard-fail when the env var is absent, and re-verify voided purchases.
+- **Share token comment is false.** `libs/shareServer.ts:15-17` says "only the hash is
+  persisted to the database. A leaked DB read therefore cannot recover live bearer
+  credentials." But `share/create/route.ts:157-158` inserts BOTH `token_hash: hash` AND
+  `token: raw`, and `share/list:66` reads it back. Either drop the column or fix the
+  comment; do not leave a false security claim in the source.
+
+## Reported but NOT independently verified by me
+- AI routes (`ai/chat:21`, `ai/embed:18`) fall back to the server's `AI_GATEWAY_API_KEY`
+  with a caller-chosen `model` and no per-user budget - billing abuse, not auth.
+- `opds/proxy` copies upstream response headers wholesale (:231-237); whether workerd's
+  `Headers.entries()` yields `Set-Cookie` is UNCONFIRMED.
+- `statsArchive.ts:287` compares the compact token with `!==`, not constant-time.
+
+## Fine, and why
+`stripe/webhook` (HMAC via `constructEvent`), `apple/notifications` (JWS x5c chain to
+Apple Root CA G3 - no caller auth needed by design), `stats/compact|restore` (shared
+secret + 503 when unconfigured + restore 409s unless compaction disabled),
+`share/[token]/*` (capability URL, ~130-bit token, single `resolveActiveShare` gate,
+expiry + 50-share cap + 300s presign), `stripe/check` (session ownership check, the
+GHSA-pv88-3727-j7v8 fix).
+
+## NOT covered
+`src/pages/api/` has ~19 more web-reachable routes (kosync, deepl/translate, bookorbit,
+send/*, storage/*, sync*, user/*). `utils/network.ts:38` names `/api/kosync` and
+`/api/send/fetch-url` as fellow client-supplied-URL fetchers, so the relay analysis above
+is INCOMPLETE for the full surface. Audit those before claiming the app is clean.
+
+Related: [[notion-sync-pr-5949-review]], [[custom-headers-kosync-bookorbit-5570]]
+(the kosync proxy open-relay fix is likewise unmerged).

--- a/apps/readest-app/.claude/memory/autoimport-skips-deleted-books-5955.md
+++ b/apps/readest-app/.claude/memory/autoimport-skips-deleted-books-5955.md
@@ -1,0 +1,36 @@
+---
+name: autoimport-skips-deleted-books-5955
+description: "#5955 did NOT reproduce; the watched-folder scan permanently and silently skips any file whose book row was deleted, which matches the reported symptom"
+metadata:
+  type: project
+---
+
+Issue #5955 ("not all books are being imported"), Android + read-in-place + watched folder.
+CLOSED 2026-08-30 as not-planned with the findings below posted for the reporter; reopen if they
+confirm the two PDFs were never imported and deleted before.
+Device-verified on the Xiaomi 13 (368b0948) against the reporter's OWN files, on Readest **0.12.6 —
+the exact version they run**. Repro archive: `/Users/chrox/Documents/books/issues/5955/`.
+
+**The reported recipe does NOT reproduce.** Registered an empty watched folder (read-in-place +
+auto-import), dropped the reporter's `Polyeleos Triadika` folder in, backgrounded and foregrounded
+Readest: the library went **75 -> 81, all six PDFs imported**, including the two titled `document`.
+Their duplicate-detection theory is dead twice over — the six also have distinct partialMD5 AND
+distinct metaHash (the #5411 PDF filename salt, shipped in v0.12.1, keeps the two `document` files
+apart: `6179cfd6…` vs `4ec20fe5…`).
+
+**What DOES reproduce the symptom exactly:** delete a book from the library while its file stays in
+the watched folder. 81 -> delete 1 -> 80; file still on disk; background+foreground rescan -> still
+80, forever. `collectKnownSourcePaths` (`src/services/bookService.ts`) deliberately includes
+soft-deleted books AND their `altFilePaths`, "so that auto-import does not resurrect a book the user
+intentionally removed". A manual import of that same file still works — which is precisely what the
+reporter described.
+
+**Why:** the behaviour is intentional but completely invisible. Nothing tells the user why those
+files never appear, there is no UI to inspect or clear the tombstone, and the auto-import run is
+called with `{ silent: true }`, so even genuine import failures raise no toast. Two of six files
+silently missing looks like a dedupe bug and is not one.
+
+**How to apply:** before touching dedupe logic for a "not all books imported" report, ask whether
+those books were ever deleted from the library. The fix worth having is visibility (say what the
+scan skipped and why), not a change to the skip rule. See [[duplicate-book-calibre-uuid-5959]] for
+the neighbouring dedupe work and [[feedback-always-verify-on-xiaomi]] for the device recipe.

--- a/apps/readest-app/.claude/memory/duplicate-book-calibre-uuid-5959.md
+++ b/apps/readest-app/.claude/memory/duplicate-book-calibre-uuid-5959.md
@@ -1,0 +1,48 @@
+---
+name: duplicate-book-calibre-uuid-5959
+description: "#5959 updated AO3/calibre EPUB imports as a duplicate book because dc:identifier is a random uuid re-minted on every export"
+metadata:
+  type: project
+---
+
+Issue #5959 (filed 2026-08-30). Fix MERGED 2026-08-30 as #5961 (squash 053aba67f, 3 commits).
+UNRELEASED and never device-verified: no build has imported the two real files end to end. Reddit report
+https://www.reddit.com/r/readest/comments/1w1mmdn/not_updating_fic_with_new_epub_file/ (u/MandoSkirata);
+both EPUBs archived at `/Users/chrox/Documents/books/issues/5959/{old,new}.epub` with a README.
+
+Re-importing an updated EPUB of a book already in the library creates a SECOND entry instead of
+merging. `importBook()` (`src/services/bookService.ts`) dedupes on `partialMD5` first (always
+differs for an updated file, expected) then on `metaHash` = `md5("title|authors|identifiers")`
+(`getMetadataHash()` in `src/utils/book.ts`). AO3 builds its EPUBs with calibre, and calibre mints
+a FRESH random `dc:identifier opf:scheme="uuid"` on every export — the two repro files are
+identical in title and creator and differ only in that uuid (`08bc8344-…` vs `d559a18b-…`) and the
+calibre timestamp. So the metaHash differs and the merge never runs.
+
+Worse: `getPreferredIdentifier()` ranks schemes `['uuid', 'calibre', 'isbn']` — the LEAST stable
+identifier wins over the most stable one when a file carries several.
+
+**Why:** any calibre-produced EPUB re-download (AO3, FanFicFare, calibre library exports) hits this,
+so it is a whole class of "Readest won't update my book" reports, not one user's file.
+
+**How to apply:** a fix has to make a bare random uuid non-identifying for metaHash (fall back to
+`title|authors`, reorder preference to isbn/url first) WITHOUT over-merging distinct volumes that
+share a title and author — `belongsTo.series` / `series_index` probably has to feed the hash.
+Second commit fixes the other half of the thread: a download saved as `name.epub (1)` (marker AFTER
+the extension) was dropped by every ingress whitelist because they all did `name.split('.').pop()`,
+which reads the extension as `epub (1)`. Fixed with `getFileExtension`/`stripDuplicateMarker` in
+`src/utils/path.ts` + `hasAllowedExtension` in `useFileSelector`, used by useFileSelector,
+useAndroidFilePicker and useDragDropImport, plus marker stripping in `importBook` and the
+DocumentLoader probes. Both mobile pickers now toast the skipped names (reusing the already
+translated `Failed to import book(s): {{filenames}}`) instead of returning an empty selection that
+the caller cannot tell from a cancel. NOTE the loader never cared: `isZip()` sniffs PK magic bytes.
+Third commit answers the CodeRabbit review: a metaHash match re-keys the row to the new hash dir and
+DELETES the old one, so the user's own cover art was lost and `existingBook.coverImageUrl` still
+pointed into the deleted dir. Fix = copy `oldBookDir/cover.png` forward BEFORE the cover step (the
+`!exists` guard then protects it), gated on `existingBook.coverUpdatedAt` — set by NOTHING but an
+explicit cover edit, so it is the reliable "user chose this" signal. PRE-EXISTING for every metaHash
+re-import, not new in this PR. Picker toast now names the rejected SUBSET (mixed picks were silent
+about the dropped half) and is scoped to `type === 'books'` because the reused string
+`Failed to import book(s): {{filenames}}` (translated in 34 locales) would misdescribe an audio or
+dictionary pick; a neutral key would ship untranslated.
+
+Still unfixed: no "replace the file of this book" action for an existing entry. See [[user-report-skill]].

--- a/apps/readest-app/.claude/memory/edge-gesture-selection-after-touchstart-5939.md
+++ b/apps/readest-app/.claude/memory/edge-gesture-selection-after-touchstart-5939.md
@@ -1,0 +1,34 @@
+---
+name: edge-gesture-selection-after-touchstart-5939
+description: Edge-strip swipe gestures must re-check for a text selection on every move, not just at touchstart; the autoscroll-speed twin is still unfixed.
+metadata:
+  type: project
+---
+
+**#5939 (MERGED #5958, merge commit `2b9962a2c`)** iOS: long-press to select text at the
+left edge, then swipe down, drove the brightness slider instead of extending the selection.
+
+**Root cause / the pattern.** Every capture-phase edge-strip gesture arms at `touchstart`
+and activates later on a distance threshold. A `touchstart`-only selection guard is
+therefore always wrong: the OS long-press creates the selection AFTER the finger is
+already down, so the gesture is armed by the time the selection exists. The guard must be
+re-evaluated in `onTouchMove` while `!activeRef.current`, and must yield **permanently**
+(one-way) because iOS transiently collapses the selection while a handle is dragged.
+
+**Two paths, both required:**
+- non-collapsed `doc.getSelection()` -> native long-press select and handle drags;
+- `renderer.scrollLocked` -> the instant-highlight quick action, which sets
+  `userSelect: 'none'` and SYNTHESIZES its range (`useTextSelector.ts` `startInstantAnnotating`),
+  so it never produces a DOM selection. A selection-only check misses it entirely.
+
+**Prior art, same guard:** `BookmarkPullDown.tsx` `onTouchMove` (added by #5757) and
+`useCapturedTurn.ts` `hasActiveSelection` in the `move` phase.
+
+**STILL UNFIXED:** `useAutoScrollSpeedGesture.ts` (right-edge swipe to change auto-scroll
+speed) has the identical `touchstart`-only guard and the identical defect. Deliberately
+left out of #5958 to keep it scoped; flagged in that PR body for a follow-up.
+
+Never device-verified on a physical iPhone; the repro is at the event-ordering level in
+jsdom (`src/__tests__/hooks/useBrightnessGesture.test.tsx`).
+
+Related: [[pull-down-bookmark-gesture-1359]], [[feedback-always-verify-on-xiaomi]]

--- a/apps/readest-app/.claude/memory/eink-class-substring-matchers.md
+++ b/apps/readest-app/.claude/memory/eink-class-substring-matchers.md
@@ -49,3 +49,26 @@ Tailwind variant.
 so they are the only place this cascade is testable —
 `src/__tests__/components/eink-base-content-bg.browser.test.tsx` guards it.
 Related: [[eink-highlight-difference-mask-5667]].
+
+## Two more traps (2026-08-30, yearly-subscription store front)
+
+3. **`bg-primary/10` is NOT matched by the `.bg-primary` e-ink rule.** That rule
+   is an exact class selector (`[data-eink='true'] .bg-primary`), not a
+   substring matcher, so an opacity-suffixed tint keeps its brand colour while
+   the plain class inverts — sibling plan badges rendered inconsistently in
+   e-ink. The `bg-base-content` rule is the reverse: it IS `[class*=]`, so
+   `bg-base-content/10` was forced to a **solid** fill, painting base-content
+   text on a base-content ground (invisible pill). Rule of thumb: for any
+   tinted chip, stay on `bg-base-200`/`bg-base-300`, which no e-ink rule
+   touches.
+4. **`btn-primary`, `btn-contrast` and `btn-outline` all collapse to the same
+   solid `base-content` fill in e-ink** (one shared rule, globals.css ~1037).
+   Two sibling CTAs styled with any two of them are indistinguishable on
+   e-ink — exactly the failure CLAUDE.md's "can you still tell which button is
+   the CTA" test exists to catch. To keep a recommended action distinct, pair
+   ONE of those classes with a plain `btn eink-bordered` (which stays an
+   outline); never two solids.
+
+Both were found by rendering the component in a `*.browser.test.tsx` with
+`[data-eink='true']` set on `documentElement` and screenshotting it — the
+class strings look correct in every case.

--- a/apps/readest-app/.claude/memory/header-footer-style-5938.md
+++ b/apps/readest-app/.claude/memory/header-footer-style-5938.md
@@ -1,0 +1,62 @@
+---
+name: header-footer-style-5938
+description: "#5938 customizable header/footer font size, text color, background; MERGED #5960; auto/none/custom chip resolver shared by SectionInfo + ProgressBar"
+metadata:
+  type: project
+---
+
+#5938 asked for a transparent option on the scrolled-mode page-number chip
+("jarring white background after I set the background myself"). Maintainer
+scoped it up to the full title: font size + text color + background color, and
+explicitly asked that **the header get a matching chip**, not just the footer.
+MERGED #5960 (squash `0f913bfa6`, 2026-08-30).
+
+**Root cause of the report.** The footer chip is `bg-base-100/85`, which reads
+as "the page color" only while the page uses the theme background. A reader
+background image paints as `.foliate-viewer::before` (`mix-blend-mode:
+multiply`, `opacity: .6`), but `ProgressBar` renders as a **sibling** of
+`.foliate-viewer` (`BooksGrid.tsx`), above that overlay — so the chip never
+picks up the tint and stays a bright white blob. Same class of bug will hit any
+new chrome placed as a sibling of the viewer.
+
+**Why only the footer ever had a pill.** `FoliateViewer` does
+`setScrollMargins({ top: bookData?.isFixedLayout ? 0 : scrollTop, … })`, so in
+scrolled mode the header band **is** reserved for reflowable books but **not**
+for fixed-layout — while `footerReservesBand()` returns false in scrolled mode
+for everything. The asymmetry was mechanical, not a design decision.
+
+**Shape (4 fields on `ViewConfig`, mode overloaded into the string like
+`borderColor`):** `headerFooterFontSize` (12, and **14 in
+`DEFAULT_EINK_VIEW_SETTINGS`** so e-ink keeps its old `text-sm`),
+`headerFooterTextColor` (`''` = theme), `headerFooterBackground`
+(`'auto' | 'none' | #rrggbb`), `headerFooterBgOpacity`. Resolvers live in
+`src/app/reader/utils/headerFooterStyle.ts` so `SectionInfo` and `ProgressBar`
+cannot drift; they tolerate `undefined` because tests build partial
+`ViewSettings` and old configs predate the fields.
+
+`auto` reproduces prior behaviour exactly (footer pill in scrolled mode, header
+bare); a custom color paints **both** header and footer in **both** flow modes,
+otherwise picking a color would be a silent no-op for paginated readers.
+
+**Two traps that bite anyone editing this code:**
+
+- The scrolled-mode pill is *also* the tap target for tap-to-toggle
+  ([[tap-toggle-progress-bar-5293]]). Keep `pointer-events-auto cursor-pointer`
+  even when the backdrop is off, or `Background: none` silently removes the
+  gesture with the chip.
+- The fixed-layout `mix-blend-difference` fallback must stand down once the
+  reader styles the chrome — it inverts a chosen text color, and differencing a
+  child carrying its own background paints it solid black
+  ([[footer-pill-vs-blend-5342]]). Load-bearing here: the reporter is on a PDF,
+  where `none` would otherwise flip the blend back on.
+
+E-ink honours font size but ignores both colors (arbitrary hue renders as
+indistinguishable gray; the theme chip already carries `eink-bordered`).
+
+**Zero new i18n keys** — `Font Size`, `Text Color`, `Background Color`,
+`Opacity`, `Auto`, `None`, `Custom` all already existed in the locale files.
+Check `public/locales/zh-CN/translation.json` for existing keys before minting
+new labels; `en/translation.json` is empty by design (key-as-content).
+
+Verified in dev-web via Chrome MCP only. **Never checked on Android or an
+e-ink device**, and the reporter is on Android.

--- a/apps/readest-app/.claude/memory/i18n-match-established-locale-terms.md
+++ b/apps/readest-app/.claude/memory/i18n-match-established-locale-terms.md
@@ -1,0 +1,40 @@
+---
+name: i18n-match-established-locale-terms
+description: "When translating new i18n strings, reuse the locale file's own established term for a domain noun instead of inventing a synonym"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 6981cf12-3457-45a5-8161-d15457b41f63
+  modified: 2026-08-30T16:38:58.863Z
+---
+
+When filling `__STRING_NOT_TRANSLATED__` placeholders, look up how the locale ALREADY
+translates each domain noun and reuse that exact lexeme. Do not translate the English
+word fresh, because a correct-but-different synonym still reads as an inconsistency in
+the UI.
+
+Check before writing, per locale:
+`jq -r '.["Highlights"], .["Notes"], .["Bookmarks"]' public/locales/<l>/translation.json`
+
+Audit after writing (case-fold + stem, because inflection and case legitimately differ;
+an exact substring match over-flags badly - it wrongly flagged French `Surlignages` vs a
+correctly lowercased mid-sentence `surlignages`):
+
+```sh
+hlf=$(printf '%s' "$hl" | tr '[:upper:]' '[:lower:]'); stem=$(printf '%s' "$hlf" | cut -c1-5)
+case "$minef" in *"$stem"*) : ;; *) echo "MISMATCH" ;; esac
+```
+
+**Why:** on PR #5949 I filled 582 strings across 34 locales and invented the "highlights"
+noun in 6 of them (es `subrayados` vs established `Resaltados`; ka `მონიშვნები` vs
+`მარკირებები`; also ar, ms, si, uz). CodeRabbit caught two; the audit above found the
+rest.
+
+**How to apply:** run the audit across ALL locales, not only the ones a reviewer flags.
+Some locale files are internally inconsistent already (bo has Highlight=`འོག་ཐིག`
+underline but Highlights=`གཙོ་གནད།` key-points; zh-TW has Highlight=`劃線` vs
+Highlights=`標記`) - those have no established term, so leave them and ask rather than
+guessing.
+
+Related: [[i18n-extract-prunes-keys]], [[i18n-label-rename-workflow]],
+[[notion-sync-pr-5949-review]]

--- a/apps/readest-app/.claude/memory/in-app-browser-book-source-5775.md
+++ b/apps/readest-app/.claude/memory/in-app-browser-book-source-5775.md
@@ -146,4 +146,6 @@ WebView timers stall so CDP evals that await hang).
 never exercised before merge, and it was 100% broken — every finished download froze the app for 10s
 and iOS SIGKILLed it (`0x8BADF00D`). Mobile `set_web_browser_status` was the app's only *synchronous*
 `#[tauri::command]` reaching `native_bridge()`, which parks the iOS main thread. Full mechanism, the
-fix, and the guard test: [[ios-sync-command-run-mobile-plugin-deadlock]].
+fix, and the guard test: [[ios-sync-command-run-mobile-plugin-deadlock]]. MERGED #5947
+(8d24f5925). iOS download flow now sim-VERIFIED end to end, which closes the last
+unverified platform for this feature.

--- a/apps/readest-app/.claude/memory/ios-sync-command-run-mobile-plugin-deadlock.md
+++ b/apps/readest-app/.claude/memory/ios-sync-command-run-mobile-plugin-deadlock.md
@@ -5,6 +5,9 @@ metadata:
   type: project
 ---
 
+**MERGED #5947 (squash 8d24f5925, 2026-08-29), branch cleaned up.** Reporter verify pending;
+the fix is UNRELEASED (0.12.6 predates it), so shipped iOS builds still deadlock.
+
 **Rule: on iOS a `#[tauri::command]` that reaches `native_bridge()` (or any
 `run_mobile_plugin`) MUST be `async fn`.** Breaking it is a hard deadlock, not a slowdown.
 

--- a/apps/readest-app/.claude/memory/library-reader-theme-scope-5945.md
+++ b/apps/readest-app/.claude/memory/library-reader-theme-scope-5945.md
@@ -1,0 +1,61 @@
+---
+name: library-reader-theme-scope-5945
+description: Library and reader carry separate theme mode/color; the store seams that made it small, and the derived-state trap
+metadata:
+  type: project
+---
+
+#5945 — the library and the reader now carry separate theme mode + color.
+MERGED as #5948 (squash `ad9e5c1b8`, 2026-08-29); worktree/branches cleared.
+Came from Reddit, filed by chrox as [[reddit-feature-requests]] fodder.
+
+**Two seams made this a small change — find them before touching theme code:**
+
+- `getThemeCode()` (`src/utils/style.ts`) reads the `themeMode`/`themeColor`
+  localStorage keys directly, and **every one of its consumers lives under
+  `src/app/reader/`**. So it is already "the reader's theme" by usage. Keeping
+  the reader pair on the original keys meant `getThemeCode()` needed *zero*
+  changes and all book-content styling followed for free.
+- `useTheme()` (`src/hooks/useTheme.ts`), not the store, is where `data-theme`
+  actually lands on `documentElement` for every route. It gained a
+  `themeScope` prop; only `Reader.tsx` passes `'reader'`. Every other route
+  (library, OPDS, player, auth, user) shares the library's scope so none
+  paints a third look.
+
+**Storage:** `libraryThemeMode` / `libraryThemeColor` in localStorage, absent =
+inherit. NOT `SystemSettings` — theme has never lived there, and putting only
+the library half in settings would make one scope sync and the other not.
+Mirrors the undefined-means-inherit semantics of `libraryBackgroundTextureId`
+(#4743/#5306) without importing its storage location.
+
+**Decoupling rule (chrox's call):** while the library inherits, every quick
+toggle writes the *shared* value and both pages move together — byte-identical
+to pre-#5945. Only picking a library value in Settings → Theme decouples. This
+is why the quick toggles needed no call-site changes at all.
+
+## Traps
+
+- **`themeMode`/`themeColor` in the store are now DERIVED** (resolved for the
+  active scope). Anything that `setState`s them directly is silently ignored —
+  that is exactly how 5 existing theme-store tests broke; they now seed
+  `readerThemeMode`/`systemIsDarkMode` instead. Same trap awaits future tests.
+- **Partial key states are reachable.** A quick toggle writes only *one* key,
+  so `themeMode` set + `themeColor` absent is normal. `loadDataTheme` must
+  treat a library-only override as configured, and resolve the reader pair via
+  `getInitialThemeMode()`/`getInitialThemeColor()` — gating on both reader keys
+  skips the first paint (flash); using the raw values yields a literal
+  `null-light` in the attribute. CodeRabbit caught the first half on #5948; its
+  proposed patch would have caused the second half and broken the two tests
+  that pin "do nothing when nothing is configured".
+- Editing the scope you are NOT looking at must never repaint the current page
+  or churn `themeCode` — same rule the background texture scope follows.
+
+## Unrelated pre-existing bug found while verifying
+
+`InvalidStateError: Transition was aborted because of invalid state` fires on
+every library→reader client-side navigation (next-view-transitions). A/B
+confirmed by stashing the branch: it reproduces identically on base `main`.
+NOT from #5945, no issue filed yet. Don't chase it as a regression.
+
+Related: [[eink-per-device-css-data-eink-5795]],
+[[daisyui-v5-tailwind-v4-migration]]

--- a/apps/readest-app/.claude/memory/notion-sync-pr-5949-review.md
+++ b/apps/readest-app/.claude/memory/notion-sync-pr-5949-review.md
@@ -1,0 +1,158 @@
+---
+name: notion-sync-pr-5949-review
+description: "PR #5949 Notion highlight sync MERGED 2026-08-30 as 295d6e79; four sync-engine defects SHIPPED UNFIXED, worst can delete a user's own Notion blocks"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 6981cf12-3457-45a5-8161-d15457b41f63
+  modified: 2026-08-30T17:24:55.229Z
+---
+
+PR #5949 `feat(notion): sync notes and highlights to Notion` by PaleVerge, closes #1750.
+
+## STATUS: MERGED 2026-08-30 as `295d6e79` (squash merge by chrox). Worktree and local
+branches (pr-5949, pr-5949-push, pr-5949-review) removed 2026-08-31.
+
+**Four defects SHIPPED TO MAIN UNFIXED.** No reviewer raised any of them; they came from
+my own read, and two were reproduced in a worktree. In severity order:
+1. `remoteNoteGroups` slices `blockCount` blocks from the divider on faith, so a user
+   inserting their own paragraph inside a note group makes the slice absorb it and drop
+   the note's real last block - the next update then issues DELETE for the user's own
+   writing. Data loss in the user's own workspace. THE ONE THAT MATTERS.
+2. Multi-batch resume duplicates and orphans blocks, triggered by the routine 15s proxy
+   timeout rather than a rare crash.
+3. `reconcileRemoteState`'s `resumable` branch is unreachable dead code (proven: throw
+   inside it and all 21 client tests still pass) - it is the mechanism meant to prevent #2.
+4. `Retry-After` is uncapped and holds the global sync queue plus the Web Lock.
+Worth a follow-up issue. Full detail in "Residual findings on v2" below.
+
+## v1 (78c2acd, 807 lines) - reviewed 2026-08-30, request changes
+Append-only, non-idempotent: `PATCH /v1/blocks/{id}/children` always appends and Notion
+does no server dedupe, so every re-push duplicated. One PATCH per highlight vs Notion's
+~3 req/s with no backoff. No 2000-char split. `lastSyncedAt` was a single GLOBAL cursor
+stamped at completion time. Proxy forwarded any `authorization` to any path. Zero tests.
+
+## v2 (a9b9f0fd, 3479 lines) - force-pushed + rebased, reviewed 2026-08-30
+Contributor rewrote it and fixed nearly all of the above. CI green (8/8); the new suite
+runs clean locally: 132 tests, 0 failures, in worktree `/Users/chrox/dev/readest-pr-5949`.
+
+Design now: `NotionSyncStore` (SQLite, schema `notion-sync`, migration
+`2026083001_notion_sync_mappings`) maps `(target_id, book_hash, note_id)` ->
+`payload_hash` + `block_ids` + `stale_block_ids`. PLUS marker URLs
+(`https://readest.com/notion-sync/note/<book>/<note>/<hash>/<blockCount>`) embedded as
+rich-text links on the "Added on" line, so a device with no local DB reconciles from the
+remote page. Batched appends (100 blocks / 450KB), 429+529 retry honouring Retry-After,
+2000-char splitting, module-level `syncQueue` + `navigator.locks`, migrated to the
+`data_sources` API on version `2026-03-11`.
+
+Notion API shapes VERIFIED against docs: `parent:{type:'data_source_id',data_source_id}`,
+`GET /databases/{id}` returns a `data_sources` array, `POST /v1/data_sources/{id}/query`
+(POST, not PATCH - the upgrade-guide page renders the verb misleadingly).
+
+### Residual findings on v2
+- **WORST: it can DELETE the user's own Notion blocks.** `remoteNoteGroups` (:648) slices
+  `blockCount` blocks from the divider on faith instead of identifying which blocks
+  Readest wrote. Insert your own paragraph inside a note group in Notion and the slice
+  absorbs it and drops the note's real last block; the next update then issues DELETE for
+  the user's paragraph and orphans the dropped one. `complete` stays true, so nothing
+  detects the drift. REPRODUCED in a worktree. Deleting a block inside a group is handled
+  fine - only INSERTION is destructive.
+- **The `resumable` branch (:693) is DEAD CODE** - proven dynamically (throw inside it,
+  all 21 NotionClient tests still green). It is the design's remote verification of a
+  partial push, and the scan gate below makes it unreachable. That is why the next bug
+  exists.
+- **Multi-batch resume gap.** Reconciliation is gated on `blockIds.length === 0`
+  (NotionClient.ts:819 and :849), so a `pending:` note that already has ids from an
+  earlier batch NEVER gets checked against remote. Resume then trusts that local count
+  (:606). Crash between a batch's remote append and its sequential `setNoteMapping`
+  (:587-600) => next sync re-appends that batch. `remoteNoteGroups` only slices the first
+  `blockCount` blocks, so the duplicate tail is invisible to every reconcile branch =>
+  permanent orphans + a mapping mixing original and duplicate ids. Found by Codex,
+  verified by hand.
+- **`Retry-After` is uncapped** (retryDelay, NotionClient.ts:253-261). A hostile/large
+  value sleeps that long while holding the global sync queue AND the Web Lock.
+- **Proxy authenticates nobody.** `isSameOriginBrowserRequest` is a header heuristic
+  (`curl -H 'sec-fetch-site: same-origin'` defeats it; and that OR branch is the only one
+  that fires for GETs, since browsers omit Origin on same-origin GET). The
+  `Bearer (secret_|ntn_)` regex is a format check on a third-party credential.
+- **Proxy timeout scope bug (new in v2).** `finally { clearTimeout }` runs at the
+  `return new NextResponse(response.body, ...)`, i.e. before the body streams, disarming
+  the AbortController mid-stream. Fix = `AbortSignal.any` like azure-translate:73.
+- Toggling "Include Chapter Heading" is in the payload hash => invalidates every note in
+  every book => full archive+re-append on next open, thousands of calls at 3 req/s.
+- `ReaderContent.tsx:233` now `await`s `flush-notion-sync` before teardown, so book close
+  blocks on a network sync; `flush-kosync` on the adjacent line is fire-and-forget.
+  CodeRabbit flagged this independently.
+- `appendPendingNotes` re-JSON-encodes the whole candidate batch per block (O(n^2)).
+  Measured: 500 notes ~= 29MB encoded / 63ms; 500 long notes ~= 157MB / 256ms.
+- i18n went BACKWARDS: still only zh-CN + zh-TW of 35 locales, and the three new error
+  strings are missing from even those two.
+
+## 2026-08-31: rebased + i18n, force-pushed to the fork
+Rebased `a9b9f0fd` onto main `9e1f72ae` (drops the PR's merge commit, linear now) and
+ran `pnpm i18n:extract` + translated 582 strings: 18 Notion keys x 32 locales, plus the
+3 rewrite-era error strings that were missing from zh-CN/zh-TW themselves. New head
+`18c00654`. Verified `pnpm lint` clean and `pnpm test` 10,530 pass before pushing.
+
+Push recipe that worked (PaleVerge remote is HTTPS, which the proxy does NOT carry):
+`GIT_SSH_COMMAND='ssh -o ServerAliveInterval=30' git push --no-verify \
+ --force-with-lease=feat/notion-sync:<expected-sha> \
+ git@github.com:PaleVerge/readest.git pr-5949-push:feat/notion-sync`
+`maintainerCanModify: true` on the PR is what makes pushing to the fork possible.
+Always confirm the remote head still equals the rebase base first, and use an explicit
+`--force-with-lease=<branch>:<sha>` since pushing to a URL has no tracking ref.
+
+FLAKY TEST (pre-existing, NOT caused by this work): `test_web_app (2)` failed once on
+`src/__tests__/app/reader/annotator/DictionarySheet.test.tsx:442` ("defaults to collapsed
+when more than 3 providers have results", aria-expanded expected false got true). The
+failure DOM showed ONE CMU-pronunciation card instead of the 4 pseudo providers the test
+builds, i.e. cross-test pollution of the module-level `providersForNextRender` that
+sharding reorders. Same shard passed locally and the retried CI job passed. The file
+already carries a deflake commit `420f65fc9` (#5521). Worth a real fix someday.
+
+GOTCHA: to run a single shard locally you MUST keep the dotenv wrapper -
+`pnpm exec dotenv -e .env -e .env.test.local -- vitest run --shard=2/2`.
+Bare `pnpm exec vitest run --shard=2/2` fails 138 files on missing env, which looks
+alarming and means nothing.
+
+GOTCHA: `pnpm i18n:extract` logs `esprima: Line 2: Unexpected token !` and CONTINUES.
+It looked like it pruned `Reading` (live at libraryUtils.ts:35) but that was only a
+reorder - compare KEY SETS (`jq -r 'keys[]' | sort` before/after), never raw diff lines.
+Only genuinely-unused `Global Settings` was dropped.
+Also: `pnpm worktree:new 5949` FAILS after a force-push (non-fast-forward fetch); reuse
+the existing worktree at `/Users/chrox/dev/readest-pr-5949` instead.
+
+## Proxy auth: what "just like hardcover" actually means
+`api/hardcover/graphql/route.ts` checks ONLY that an `authorization` header is non-empty,
+then forwards it. It is the SOLE outlier in the repo: 13 other routes
+(ai/chat, ai/embed, azure-translate, yandex-translate, tts/edge, metadata/search,
+apple+google iap-verify, stripe/*, share/create|list|import|revoke) use
+`validateUserAndToken`. So "auth check just like hardcover" is already met and exceeded.
+Adopting the house pattern needs a HEADER SPLIT: the client puts the Notion token in
+`authorization`, but `validateUserAndToken` wants the Supabase JWT there - move the
+secret to `x-notion-token`. Tradeoff: that makes Notion sync sign-in-required on WEB only
+(Tauri calls api.notion.com directly and never touches the proxy).
+
+CodeRabbit FALSE POSITIVE on v1: claimed zh-CN line 1014 read `已断开与与 Notion 的连接`;
+it actually read `已断开与 Notion 的连接`.
+
+Related: [[custom-headers-kosync-bookorbit-5570]] (kosync proxy open-relay fix unmerged).
+
+## What I fixed before the merge (so future-me does not re-chase these)
+Landed in the squash as part of `295d6e79`:
+- `c7f2b4f1` close path: `saveConfig` now runs BEFORE the Notion flush, and the flush is
+  bounded by `NOTION_FLUSH_TIMEOUT_MS = 3000` via `Promise.race`. Fixes both the
+  beforeunload/quit-app data loss and the unclosable Tauri window.
+- `18c00654` + `36ad0d64` i18n: 582 strings across 34 locales, then terminology aligned to
+  each file's own `Highlights` noun in ar/es/ka/ms/si/uz and clipped placeholder hints
+  reworded in es/fr/it/nl.
+- `5b44c273` proxy auth: `validateUserAndToken` gates the route, Notion secret moved to
+  `x-notion-token`. Web builds now REQUIRE Readest sign-in for Notion sync (matches
+  azure-translate). Tests 28 -> 36, incl. asserting the JWT never reaches Notion.
+- `1a0aae30` formatting (see [[verify-lint-excludes-format-check]]).
+
+STILL STALE ABOVE: the "Proxy authenticates nobody" and `ReaderContent.tsx:233` bullets in
+the v2 residual list are FIXED. The "Proxy timeout scope bug" (`finally { clearTimeout }`
+firing before the body streams; wants `AbortSignal.any`) is NOT fixed. bo and zh-TW still
+have no established Highlights term. The Tamil `Reading` = `படிக்கிறேன்` first-person
+label is a separate pre-existing bug, thread left open on the PR.

--- a/apps/readest-app/.claude/memory/settings-row-two-controls.md
+++ b/apps/readest-app/.claude/memory/settings-row-two-controls.md
@@ -1,0 +1,39 @@
+---
+name: settings-row-two-controls
+description: "SettingsSelect max-w-[60%] truncates inside a wrapper div; swatch+select must be SIBLINGS of SettingsRow with ms-auto on the swatch"
+metadata:
+  type: reference
+---
+
+Putting a color swatch **and** a select in one `<SettingsRow>` has two traps.
+Both produce visible bugs and both were hit while building #5938
+([[header-footer-style-5938]]). Codified in `DESIGN.md` §5 "Two controls in one
+suffix".
+
+**1. Never wrap them together in a `<div>`.** `SettingsSelect`'s root carries
+`flex max-w-[60%]`, and that 60% resolves against its **containing block**. A
+shared wrapper shrinks to fit its content, so 60% of that is a few dozen pixels
+and every option label truncates — `Auto` renders as `Au`. Pass both as direct
+children of `SettingsRow` so the select sizes against the row.
+
+**2. Put `ms-auto` on the swatch.** `SettingsRow` is `flex … justify-between`,
+so with three items (label, swatch, select) the free space lands *in front of
+the middle item* and the swatch drifts horizontally with each row's label
+width — swatches in adjacent rows visibly fail to line up. `ms-auto` on the
+swatch collapses that space so swatches align down the list. Logical property,
+never `ml-`/`mr-` (RTL).
+
+```tsx
+<SettingsRow label={_('Background Color')}>
+  {isHexColor(value) && (
+    <div className='ms-auto'>
+      <ColorInput … />
+    </div>
+  )}
+  <SettingsSelect … />
+</SettingsRow>
+```
+
+Canonical example: the Text Color / Background Color rows in `LayoutPanel.tsx`.
+`ColorInput` (`components/settings/theme/ColorInput.tsx`) takes no `className`,
+hence the wrapper div for `ms-auto`.

--- a/apps/readest-app/.claude/memory/settings-scope-menu-5933.md
+++ b/apps/readest-app/.claude/memory/settings-scope-menu-5933.md
@@ -1,0 +1,51 @@
+---
+name: settings-scope-menu-5933
+description: "PR #5933 landed as a 1-file menu-label fix, not a scope banner; includes measured proof that the info/warning tint pair fails on every Readest theme"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 7698bb2c-d1c5-4bfa-820f-1d84b319ce69
+  modified: 2026-08-29T18:53:22.075Z
+---
+
+#5932 "readers don't know the Settings dialog has a scope" was fixed by relabelling
+the ⋮ menu, not by adding a surface. MERGED as #5933 (squash `5755f25d7`, 2026-08-29).
+
+ROOT CAUSE was narrower than the issue framed it: the consequence text
+(`Apply to All Books` / `Apply to This Book`) existed but lived in `buttonClass='lg:tooltip'`
+plus `MenuItem`'s native `title` attribute. Native `title` never fires on touch and `lg:`
+starts at 1024px, so on phones/tablets the row read only "Global Settings" + a checkmark —
+the mode named, the consequence invisible. Fix = two exclusive `toggled` rows using the
+house idiom (library `ViewMenu.tsx:199`). Both strings already existed in all 34 locales,
+so 0 new i18n keys, 0 new UI.
+
+The contributor's original PR was a tinted banner in the dialog header (+742/−37, 43 files);
+it was declined and reworked down to +18/−8 in one file. Two reusable lessons:
+
+**1. `--color-info` / `--color-warning` tints DO NOT WORK in this app. Measured, don't re-derive:**
+`STATE_COLORS` (themes.ts:60-64) is one fixed pair — info `oklch(72.06% .191 231.6)` → `#00b5ff`,
+warning `oklch(84.71% .199 83.87)` → `#ffbe00` — applied identically to all 11 themes. Being
+theme-invariant is why it fails, not why it's safe:
+- `bg-info/15` vs `bg-warning/10` land **1.02–1.09:1 against each other** (indistinguishable).
+- A 4px `border-s-4` accent misses DESIGN.md §7's 3:1 floor on **every** light theme:
+  1.49 default-light, 1.24 sepia, 1.11 gray.
+- Dark themes invert it: bar reads fine (5.3–8.0:1) but the two tints collapse to 1.02:1.
+There is **no theme where both signals work**. Before this PR, `bg-info`/`border-info`/`text-info`
+had **zero** consumers in `src/`. `bg-warning/10` has 4 (MigrateDataWindow, CatalogManager, 2 reedy),
+all with a full border. Contradicts DESIGN.md §2.2 (settings = zero brand colour) and §2.3
+(state cycles base-100→200→300 *because* that's theme-safe). Use the `Tips` surface
+(`bg-base-200/40`) + icon + words instead. See [[eink-class-substring-matchers]].
+
+**2. An always-on indicator teaches nothing.** The banner rendered on every panel, in every
+scope, and in the library — so in the default state (where nearly every session sits) it just
+restated the default, while costing ~31px permanently on a sheet `snapHeight` caps at 70% on
+mobile. Only mark the *unusual* state, or don't mark it at all.
+
+Sizing evidence that justified declining: #5932 had 0 comments/0 reactions and was filed by the
+PR author; #5296 (move book settings to reader view) has 1 upvote and would dissolve the flag
+rather than explain it. Global-by-default also matches Kindle/Apple Books/Play Books.
+
+`ViewSettings.isGlobal` is `boolean` (types/book.ts:471) — NOT optional. So
+`getViewSettings(k)?.isGlobal ?? true` only defaults when the whole object is null, and any
+`typeof x === 'boolean'` guard on the field is unreachable. A helper wrapping this was added
+then removed; inline is the house spelling (17 files).

--- a/apps/readest-app/.claude/memory/status-grouping-i18n-5935.md
+++ b/apps/readest-app/.claude/memory/status-grouping-i18n-5935.md
@@ -1,0 +1,79 @@
+---
+name: status-grouping-i18n-5935
+description: "MERGED #5935 group library by reading status; status grouping must PARTITION, and BooksGroup.localized gates which group names go through _()"
+metadata:
+  node_type: memory
+  type: project
+  originSessionId: aab36894-e607-43f6-a325-2b3560aea326
+  modified: 2026-08-30T09:50:05.388Z
+---
+
+External PR #5935 (`rigen1048`, branch `StatusGrouping`) added `LibraryGroupByType.Status`.
+Reviewed + fixed 2026-08-30, MERGED as squash `82658d8ed`. The contributor's CI was fully green;
+every bug below was invisible to tests.
+
+**Pushing to a contributor's fork:** `worktree:new` REBASES, so its branch head is NOT the PR head
+and pushing it force-overwrites their history. Correct move: re-fetch `refs/pull/<n>/head`,
+`git checkout -b <tmp> <that sha>`, `git apply --3way` the saved patch, commit, then
+`git push git@github.com:<owner>/<fork>.git <tmp>:<their-branch>` (fast-forward, no --force).
+Needs `maintainerCanModify: true` from `gh pr view`. See [[worktree-new-rebases-pr-force-push]].
+
+**Bug 1: labels bypassed i18n**
+- `libraryUtils.ts` built labels inline: `status === 'abandoned' ? 'On Hold' : capitalize(status)`.
+  Both render sites (`GroupItem.tsx` x2, `GroupHeader` via `page.tsx` `currentVirtualGroup`) print
+  `displayName` raw, so all 34 locales showed English tiles next to a translated `Status:` prefix.
+- `'On Hold'` (capital H) is a *different* key from the shipped `'On hold'`, which every locale
+  already translates. `Unread` / `Finished` were already shipped too; only `Reading` was new.
+- `'reading'` (4th `ReadingStatus`, `types/book.ts`) was unhandled. Reachable via `utils/transform.ts`
+  (`reading_status as ReadingStatus`, unvalidated) and `sync/file/merge.ts`.
+
+Fix: `READING_STATUS_LABELS: Record<ReadingStatus, string>` built with `stubTranslation as _`. Total
+record on purpose, so a 5th status cannot be added without a label. Plus `BooksGroup.localized?:
+boolean`, set ONLY when `createValueGroups` receives a `getDisplayKey`. That flag is the load-bearing
+part: render sites do `localized ? _(name) : name`, so a tag literally named "Unread" still renders
+verbatim. A blanket `_(displayName)` would silently translate user-authored tag/author/series names.
+See [[i18n-label-rename-workflow]].
+
+**Bug 2: status grouping did not PARTITION**
+`readingStatus` is an optional ANNOTATION, not a lifecycle field. Nothing stamps it at import, and
+`readerStore` CLEARS 'unread' -> undefined on first open. Keying the grouping off it alone therefore
+partitioned terribly. MEASURED on the real 750-book library: 414 never-opened books (55%) fell out of
+the shelf entirely, and "Unread" held exactly 1 book (the only one manually re-marked). Final rule:
+
+    isCurrentlyReadingBook(book) ? ['reading'] : [book.readingStatus ?? 'unread']
+
+Derive BOTH ends (reading from the predicate the recently-read shelf and home-screen widget already
+share; unread as the resting state) and trust the annotation for the middle. Explicit status still
+wins because the predicate already excludes finished/abandoned/unread. Result: Reading 289 /
+Unread 415 / Finished 45 / On hold 1, zero standalone. Verified in Chrome on the live library.
+
+Folding the loose pile in also CLOSED a group-ordering finding I had raised separately: tiles were
+scattering across positions 1/3/12 only because `getGroupSortValue` sorts groups by `group.name` into
+ONE list shared with the loose books. With nothing loose left, the 4 tiles sit together. It was a
+symptom, not its own bug. Nothing about status grouping remains open.
+
+**Why:** key-as-content i18n means an unwrapped literal fails silently in every locale but English,
+and CI cannot see it. A grouping that leaves the majority of rows ungrouped is likewise green.
+
+**How to apply:** when a grouping/sort/filter surfaces an internal enum, (a) the label is a
+translation key, not display text: register with `stubTranslation`, mark the carrier, translate at
+render; (b) the grouping must partition, so derive a bucket for every resting state rather than
+assuming an optional field is always populated. Guard it with a test asserting `standalone === []`
+and that grouped books sum to the input.
+
+**Browser-verified** via `pnpm dev-web` + `?groupBy=status` URL param (NEVER the View menu:
+`handleSetGroupBy` writes `libraryGroupBy` to synced settings). Group ids are
+`md5Fingerprint('status:<value>').slice(0,7)`, so `?groupBy=status&group=<id>` deep-links a bucket.
+`?lng=fr` does NOT work: `settingsStore.applyUILanguage` clobbers i18next's querystring detector with
+`uiLanguage ?? navigator.language`, so a live locale check needs a real settings write; the
+translated render is covered by component tests instead. A pre-existing
+`InvalidStateError: Transition was aborted` dev-overlay error fires on in-app group navigation for
+EVERY grouping (reproduced on `groupBy=author`); unrelated to this work.
+
+**Gotcha:** `pnpm i18n:extract` also PRUNES. On this tree it wanted to delete `Global Settings` from
+all 34 locales (orphaned by #5933). Append new keys by hand rather than committing the scanner's full
+output, then re-run extract to confirm it leaves your entries alone. See [[i18n-extract-prunes-keys]].
+
+**Gotcha:** the web app's library.json is written INCREMENTALLY during cloud sync. Reading it mid-pull
+shows a partial count (I saw 6, then 206, then 286, then 750) and looks alarmingly like data loss.
+It is not. Let the pull finish before measuring anything.

--- a/apps/readest-app/.claude/memory/user-report-skill.md
+++ b/apps/readest-app/.claude/memory/user-report-skill.md
@@ -1,0 +1,28 @@
+---
+name: user-report-skill
+description: /user-report skill turns a Reddit/email bug report into a GitHub issue plus archived repro files; Chrome saves downloads to ~/Desktop
+metadata:
+  type: project
+---
+
+`/user-report` (`.agents/skills/user-report/SKILL.md`, gitignored — force-add it if it should ship)
+is the workflow for turning a user report into something trackable: read the thread, pull the repro
+files, diagnose them, `gh issue create`, then archive under
+`/Users/chrox/Documents/books/issues/<issue-number>/` with a README (source URL, handle, md5s, sizes).
+First run produced [[duplicate-book-calibre-uuid-5959]].
+
+Gotchas the skill encodes, all hit for real on 2026-08-30:
+- `WebFetch` cannot read Reddit ("unable to fetch") or authenticated Gmail — drive the user's
+  logged-in Chrome via the claude-in-chrome MCP instead; Gmail needs a second `get_page_text`
+  because the first returns "Loading...".
+- **Chrome on this Mac saves downloads to `~/Desktop`, not `~/Downloads`** (no
+  `download.default_directory` in Preferences, `savefile.default_directory` is Desktop). An empty
+  `~/Downloads` is NOT evidence the download failed — read the `downloads` table of
+  `~/Library/Application Support/Google/Chrome/Default/History` instead.
+- A Gmail attachment URL cannot be `fetch()`ed from the page: it 302s to `googleusercontent.com`
+  with no CORS headers. curl can't either (cookie-authenticated).
+
+**Why:** each of these cost a wrong conclusion or a retry loop, and every user report repeats them.
+
+**How to apply:** invoke the skill instead of improvising, and never put the reporter's real name or
+email in the public issue — link the public handle and report URL only.

--- a/apps/readest-app/.claude/memory/verify-lint-excludes-format-check.md
+++ b/apps/readest-app/.claude/memory/verify-lint-excludes-format-check.md
@@ -1,0 +1,28 @@
+---
+name: verify-lint-excludes-format-check
+description: "pnpm lint does NOT run the Biome format check; run pnpm format:check too or CI's build_web_app fails on formatting"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 6981cf12-3457-45a5-8161-d15457b41f63
+  modified: 2026-08-30T17:14:26.873Z
+---
+
+`pnpm lint` is `tsc --noEmit && biome lint .` — **linting only, no formatting**. The
+Biome *format* check is a separate script, `pnpm format:check` (which proxies to
+`pnpm -w format:check` at the monorepo root).
+
+CI's `build_web_app` job runs the format check as its "run format check" step, so
+hand-wrapped code that Biome would wrap differently fails the build even when
+`pnpm lint` and the full test suite are green locally.
+
+**Why:** on PR #5949 I ran `pnpm lint` (clean) and `pnpm test` (10,538 passing), pushed,
+and `build_web_app` failed on one hand-wrapped `expect(...)` in a test file I had just
+written. The failure reads like a build error in the checks list; it is not.
+
+**How to apply:** add `pnpm format:check` to the done-conditions in
+`.claude/rules/verification.md` alongside `pnpm test` and `pnpm lint`, and run it before
+every push. To fix an offender without touching unrelated files, format just that path:
+`pnpm exec biome format --write <file>` — not a repo-wide `pnpm format`.
+
+Related: [[feedback_dont_push_every_change]], [[notion-sync-pr-5949-review]]

--- a/apps/readest-app/.claude/memory/yearly-subscriptions-store-front.md
+++ b/apps/readest-app/.claude/memory/yearly-subscriptions-store-front.md
@@ -1,0 +1,62 @@
+---
+name: yearly-subscriptions-store-front
+description: Yearly Stripe/App Store/Play subscription tiers + modernized plans grid on the user page; branch feat/yearly-subscriptions, SKUs not yet created
+metadata:
+  node_type: memory
+  type: project
+---
+
+Work done 2026-08-30 on `feat/yearly-subscriptions` (worktree
+`/Users/chrox/dev/readest-feat-yearly-subscriptions`). **Uncommitted** at
+session end; all gates green (lint, 10463 unit, 406 browser, 4 Kotlin).
+
+**The store SKUs do not exist yet** — chrox creates them. Shape agreed:
+- Stripe: two new *recurring yearly prices on the existing Plus/Pro products*
+  (never new products — `getSubscriptionPlan` reads `product.metadata.plan`).
+- App Store / Play: standalone `com.bilingify.readest.yearly.plus` / `.pro`,
+  Apple in the **same subscription group** as monthly (free crossgrade), Play as
+  separate subscription ids (NOT base plans — base plans would need offer-token
+  work in BillingManager).
+Shipping is safe before they exist: the Yearly toggle only renders when the
+store actually returns a yearly price (`getSubscriptionIntervals`).
+
+**Two latent `/api/stripe/plans` bugs found and fixed, both about OLD clients:**
+1. `stripe.prices.list()` had no `limit`, so Stripe's default of **10** applied.
+   The catalog was already at ~7-9 active prices; adding two would truncate, and
+   because Stripe lists newest-first the entries dropped are the OLDEST — the
+   original monthly Plus/Pro. Fixed with `limit: 100`.
+2. Clients **<= 0.9.67** predate the interval filter in `getPlanDetails`
+   (landed in 42c2825e9, first released **0.9.69**, 2025-08-02) and pick with
+   `availablePlans.find((p) => p.plan === userPlan)` — first match in API order.
+   A new yearly price would sort first and those clients would render it
+   labelled "/month". Fixed by sorting month-before-year in the route. Only
+   desktop + non-Play Android are exposed (iOS/Play use IAP, web is always
+   current).
+
+**Stripe plan changes now go through the Billing Portal**, not a second
+checkout (`shouldUseBillingPortal`: plan is plus/pro AND planType is
+subscription). The portal route accepts `flow: 'subscription_update'` and
+deep-links to the plan picker. **Requires "Customers can switch plans" enabled
+in the Stripe portal config**, else the portal only offers Cancel. This also
+fixes the pre-existing Plus->Pro double-subscription hazard.
+
+**Google Play needed `SubscriptionUpdateParams`** (`setOldPurchaseToken` +
+`ReplacementMode.WITH_TIME_PRORATION`, Billing 9.1.0): without it a monthly
+subscriber buying yearly gets a SECOND subscription and is billed twice. Apple
+handles this itself within a subscription group; Stripe via the portal.
+
+**UI:** the swipe carousel (`PlanNavigation`, `PlanIndicators`, touch handlers,
+scroll-position sync) is DELETED, replaced by a 1/2/4-column grid +
+`BillingIntervalToggle`. Yearly cards lead with the per-month figure and show
+"{{price}} billed yearly". Plan badge colours moved off the hardcoded
+blue/purple/green palette to base-200/300 tokens — see
+[[eink-class-substring-matchers]] for the two e-ink traps that forced this.
+
+**Never claimed anywhere:** which interval the user is currently on. The JWT
+carries only the plan tier, so the current-tier card says "Change billing
+period", not "Switch to Yearly". Exposing the real interval needs a new
+endpoint over the `subscriptions` table — deliberate follow-up.
+
+**Not verified:** no live Stripe/Apple/Google purchase, and the Play billing
+change has never run on a device. `AccountActions` still uses hardcoded
+`bg-blue-100`/red buttons — out of scope, worth a follow-up pass.

--- a/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/apps/readest-app/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
     <!-- LocalSend device discovery: receiving multicast announcements needs a
          MulticastLock, which requires these two permissions. -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
-    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>

--- a/apps/readest-app/src/app/library/components/BookItem.tsx
+++ b/apps/readest-app/src/app/library/components/BookItem.tsx
@@ -113,7 +113,7 @@ const BookItem: React.FC<BookItemProps> = ({
       <div
         className={clsx(
           'bookitem-main relative flex justify-center overflow-hidden rounded-sm',
-          !fitCoverInGrid && 'aspect-[28/41]',
+          !fitCoverInGrid && 'aspect-28/41',
           coverFit === 'crop' && 'shadow-md',
           mode === 'grid' && 'items-end',
           mode === 'list' && 'min-w-20 items-center',
@@ -230,14 +230,14 @@ const BookItem: React.FC<BookItemProps> = ({
                   showBookDetailsModal(book);
                 }}
               >
-                <div className='pt-[2px] sm:pt-[1px]'>
+                <div className='pt-0.5 sm:pt-px'>
                   <LiaInfoCircleSolid size={iconSize15} />
                 </div>
               </button>
             )}
             {(book.hasNarration || isAbsBook) && (
               <div
-                className='pt-[2px] sm:pt-[1px]'
+                className='pt-0.5 sm:pt-px'
                 title={isAbsBook ? _('Audiobook') : _('Includes narration')}
                 aria-label={isAbsBook ? _('Audiobook') : _('Includes narration')}
               >

--- a/apps/readest-app/src/app/library/components/Bookshelf.tsx
+++ b/apps/readest-app/src/app/library/components/Bookshelf.tsx
@@ -948,9 +948,9 @@ const Bookshelf: React.FC<BookshelfProps> = ({
               aria-label={_('Import Books')}
               aria-haspopup='menu'
               className={clsx(
-                'bookitem-main bg-base-100 hover:bg-base-300/50',
+                'bookitem-main bg-base-100/50 hover:bg-base-300/50',
                 'flex items-center justify-center',
-                'aspect-[28/41] w-full',
+                'aspect-28/41 w-full',
               )}
               onClick={(event) => handleImportBooks(event.currentTarget)}
             >

--- a/apps/readest-app/src/app/reader/components/annotator/HighlightOptions.tsx
+++ b/apps/readest-app/src/app/reader/components/annotator/HighlightOptions.tsx
@@ -257,7 +257,7 @@ const HighlightOptions: React.FC<HighlightOptionsProps> = ({
                 // carry no inline ink and do want the flattening.
                 style !== 'highlight' && 'text-base-content',
                 style === 'highlight' ? 'flex items-center justify-center' : 'text-center',
-                style === 'underline' || style === 'squiggly' ? 'sm:mt-[-2px]' : '',
+                style === 'underline' || style === 'squiggly' ? 'sm:-mt-0.5' : '',
               )}
             >
               {style === 'highlight' ? (


### PR DESCRIPTION
Routine agent-memory refresh, plus a few small style and doc tidy-ups picked up along the way.

## Changes

- **Agent memories** — refresh `.claude/memory` notes and the index for recent issue work (14 new notes, 5 updated).
- **Tailwind classes** — prefer scale utilities over arbitrary values where an equivalent exists:
  - `BookItem`: `pt-[2px] sm:pt-[1px]` -> `pt-0.5 sm:pt-px`, and `aspect-[28/41]` -> `aspect-28/41`
  - `HighlightOptions`: `sm:mt-[-2px]` -> `sm:-mt-0.5`
- **Library** — soften the import placeholder background to `bg-base-100/50`.
- **README** — mention PayPal among the donation methods.
- **Android manifest** — group `REQUEST_INSTALL_PACKAGES` with the other core permissions.

## Notes

The Tailwind rewrites were checked against the project's own compiler rather than by eye. Worth recording, because the bracket-stripping shorthand only exists for values Tailwind actually names:

| class | emitted CSS |
| --- | --- |
| `pt-px` | `padding-top: 1px` |
| `pt-0.5` | `calc(var(--spacing) * 0.5)`, i.e. 2px at the default root size |
| `aspect-28/41` | `aspect-ratio: 28/41` |
| `pt-1px` / `pt-2px` | *nothing* - not valid utilities |

`px` is the one named hairline key in the spacing scale, which is why `sm:pt-px` works while `sm:pt-1px` would silently emit no CSS at all.

## Verification

- `pnpm format:check` clean
- `pnpm lint` clean
- `pnpm test` - 10545 passed, 16 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Support Option**
  - Added PayPal as an additional donation method, alongside existing GitHub Sponsors, card payments, and cryptocurrency options.

- **Style Improvements**
  - Improved consistency of book tiles, import tiles, and icon spacing across the library.
  - Refined annotation marker positioning for underline and squiggly highlight styles.
  - Standardized book-cover aspect ratios for a more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->