### PR TITLE
fix(payments): acknowledge Apple notifications that carry no transaction

### DIFF
--- a/apps/readest-app/src/__tests__/libs/payment/apple-notifications.test.ts
+++ b/apps/readest-app/src/__tests__/libs/payment/apple-notifications.test.ts
@@ -440,3 +440,40 @@ describe('handleAppleNotification — one-time purchase ownership', () => {
     });
   });
 });
+
+// Apple's TEST notification is how the App Store verifies a configured
+// endpoint, and it is also what `requestTestNotification` sends. It carries a
+// `data` object (so it is not a summary payload) but no `signedTransactionInfo`,
+// so decoding a transaction from it throws and the route answers 500. Apple
+// records UNSUCCESSFUL_HTTP_RESPONSE_CODE and retries for days.
+describe('handleAppleNotification — payloads without a transaction', () => {
+  const mockDataPayload = (notificationType: NotificationType) => {
+    appleMocks.decodeNotificationPayload.mockResolvedValue({
+      notificationType,
+      subtype: undefined,
+      data: { appAppleId: 1234567890, bundleId: BUNDLE_ID, environment: 'Production' },
+    });
+  };
+
+  it('acknowledges a TEST notification instead of failing delivery', async () => {
+    mockDataPayload(NotificationType.Test);
+    const sb = createSupabaseMock({});
+    h.supabase = sb;
+
+    const res = await handleAppleNotification('payload');
+
+    expect(res).toMatchObject({ handled: false, reason: 'no_transaction_info' });
+    expect(appleMocks.decodeTransaction).not.toHaveBeenCalled();
+  });
+
+  it('does not throw for any data payload that carries no transaction', async () => {
+    mockDataPayload(NotificationType.ConsumptionRequest);
+    const sb = createSupabaseMock({});
+    h.supabase = sb;
+
+    await expect(handleAppleNotification('payload')).resolves.toMatchObject({
+      handled: false,
+      reason: 'no_transaction_info',
+    });
+  });
+});

--- a/apps/readest-app/src/libs/payment/iap/apple/notifications.ts
+++ b/apps/readest-app/src/libs/payment/iap/apple/notifications.ts
@@ -79,6 +79,20 @@ export async function handleAppleNotification(
     throw new Error(`Unexpected bundle id: ${payload.data.bundleId}`);
   }
 
+  // `isDecodedNotificationDataPayload` only checks that a `data` object exists,
+  // and several notifications carry one with no transaction in it. TEST is the
+  // notable case: it is what the App Store sends to verify a configured
+  // endpoint, so decoding a transaction from it threw, the route answered 500,
+  // and Apple recorded UNSUCCESSFUL_HTTP_RESPONSE_CODE and retried for days.
+  // Acknowledge these instead, which returns 200 and ends the retries.
+  if (!payload.data.signedTransactionInfo) {
+    return {
+      handled: false,
+      reason: 'no_transaction_info',
+      notificationType: payload.notificationType,
+    };
+  }
+
   const transaction = await decodeTransaction(payload.data.signedTransactionInfo);
   const renewalInfo: JWSRenewalInfoDecodedPayload | undefined = payload.data.signedRenewalInfo
     ? await decodeRenewalInfo(payload.data.signedRenewalInfo)


### PR DESCRIPTION
## Problem

Found immediately after #5993 merged, by configuring the App Store Server Notifications URL and sending a real test notification. Apple recorded the delivery as:

```
sendAttempts: [{"sendAttemptResult": "UNSUCCESSFUL_HTTP_RESPONSE_CODE"}]
```

Decoding what Apple actually sent shows why:

```
notificationType: TEST
isDecodedNotificationDataPayload: true
data keys: [appAppleId, bundleId, environment]
has signedTransactionInfo: false
```

`isDecodedNotificationDataPayload` only checks `"data" in payload`, so a TEST notification passes it. `handleAppleNotification` then calls `decodeTransaction(payload.data.signedTransactionInfo)` with `undefined`, which throws. The route deliberately answers 500 so Apple retries transient failures, so the App Store marks the delivery failed and keeps retrying for days.

Two consequences:

* The notification endpoint cannot be verified at all. Every test notification fails, which is exactly what you reach for when checking whether the configuration works.
* Any notification carrying a `data` object without a transaction becomes a retry loop against the API rather than a single dropped event.

This is not a regression from #5993. The `decodeTransaction` call predates it. It only became reachable now, because before the URL was configured Apple had never delivered anything.

## Change

Return early when `signedTransactionInfo` is absent, which answers 200 and ends the retries:

```ts
if (!payload.data.signedTransactionInfo) {
  return {
    handled: false,
    reason: 'no_transaction_info',
    notificationType: payload.notificationType,
  };
}
```

The guard is on the missing transaction rather than on `TEST` specifically, so every present and future notification shaped this way is covered. `recordIapWebhook` still logs the notification type, so these remain visible in telemetry as skipped rather than vanishing.

## Tests

Written first and confirmed failing.

* A TEST notification is acknowledged rather than failing delivery, and `decodeTransaction` is never called.
* Any data payload with no transaction resolves instead of throwing.

## Verification

* `pnpm test`: 10597 passed, 16 skipped
* `pnpm lint`, `pnpm format:check`: clean
* Payload shape confirmed against the live App Store Server API, not assumed from documentation.

## Deploy note

The endpoint is answering 500 to Apple's test notifications in production right now. The web deploy is manual, so this wants to go out in the same deploy as #5993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Apple notifications without transaction information are now handled gracefully.
  * Test and consumption-request notifications no longer trigger errors or unnecessary retries.
  * Notifications lacking transaction details are safely ignored instead of causing server errors.

* **Tests**
  * Added coverage for Apple notification payloads that contain no transaction information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->