### PR TITLE
fix(payments): align the plan panels and stop the header eating clicks

### DIFF
--- a/apps/readest-app/src/__tests__/app/user/plans-grid-layout.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/app/user/plans-grid-layout.browser.test.tsx
@@ -89,6 +89,23 @@ describe('plans grid layout', () => {
     expect(bottoms[2]).toBe(bottoms[3]);
   });
 
+  // The features list varies in height per tier, so without a bottom-anchored
+  // group the "What's Included" panel floats to wherever that list happens to
+  // end and the panels sit at different heights across a row.
+  it("aligns the What's Included panels within a row", async () => {
+    await page.viewport(1280, 1024);
+    renderGrid();
+
+    const panels = (Array.from(document.querySelectorAll('h5')) as HTMLElement[])
+      .filter((h) => h.textContent === "What's Included")
+      .map((h) => h.parentElement as HTMLElement);
+
+    // free, plus and pro carry limits; the purchase card does not.
+    expect(panels).toHaveLength(3);
+    const tops = panels.map((p) => Math.round(p.getBoundingClientRect().top));
+    expect(tops[0]).toBe(tops[1]);
+  });
+
   it('drops to a single column on a phone', async () => {
     await page.viewport(390, 844);
     renderGrid();

--- a/apps/readest-app/src/__tests__/app/user/profile-header-clickthrough.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/app/user/profile-header-clickthrough.browser.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * The profile header is a transparent, full-width `fixed` strip. Content
+ * scrolls visibly beneath it, so its empty middle must not absorb clicks —
+ * anything scrolled into that band (the billing interval toggle, most
+ * visibly) would otherwise be unclickable.
+ *
+ * Needs real layout and real Tailwind, so it runs as a browser test.
+ */
+
+import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { page } from 'vitest/browser';
+
+vi.mock('@/hooks/useTranslation', () => ({ useTranslation: () => (key: string) => key }));
+vi.mock('@/store/trafficLightStore', () => ({
+  useTrafficLightStore: () => ({ isTrafficLightVisible: false }),
+}));
+
+const appService = { hasWindowBar: false, hasTrafficLight: false };
+vi.mock('@/context/EnvContext', () => ({ useEnv: () => ({ appService }) }));
+
+const { default: ProfileHeader } = await import('@/app/user/components/Header');
+await import('@/styles/globals.css');
+
+const renderHeaderOverContent = () =>
+  render(
+    <div className='relative h-screen w-full'>
+      <ProfileHeader onGoBack={() => {}} />
+      <button data-testid='beneath' className='absolute left-1/2 top-4 h-8 w-40 -translate-x-1/2'>
+        beneath
+      </button>
+    </div>,
+  );
+
+afterEach(() => cleanup());
+beforeAll(async () => {
+  await page.viewport(1280, 1024);
+});
+
+describe('profile header click-through', () => {
+  it('lets a click in its empty middle reach the content beneath', () => {
+    renderHeaderOverContent();
+
+    const beneath = document.querySelector('[data-testid=beneath]') as HTMLElement;
+    const r = beneath.getBoundingClientRect();
+    const hit = document.elementFromPoint(
+      Math.round(r.left + r.width / 2),
+      Math.round(r.top + r.height / 2),
+    );
+
+    expect(beneath.contains(hit)).toBe(true);
+  });
+
+  it('keeps its own back button clickable', () => {
+    renderHeaderOverContent();
+
+    const back = document.querySelector('button[aria-label="Go Back"]') as HTMLElement;
+    const r = back.getBoundingClientRect();
+    const hit = document.elementFromPoint(
+      Math.round(r.left + r.width / 2),
+      Math.round(r.top + r.height / 2),
+    );
+
+    expect(back.contains(hit)).toBe(true);
+  });
+});

--- a/apps/readest-app/src/app/user/components/Header.tsx
+++ b/apps/readest-app/src/app/user/components/Header.tsx
@@ -22,12 +22,21 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({ onGoBack }) => {
       className={clsx(
         'fixed z-30 flex w-full items-center justify-between py-2 pe-6 ps-4',
         appService?.hasTrafficLight && 'pt-11',
+        // The strip spans the full width with no background, so its empty
+        // middle is an invisible overlay that swallows clicks on whatever
+        // scrolls beneath it. Only a desktop window bar needs the strip itself
+        // to receive pointer events, because WindowButtons binds the window
+        // drag listeners to this element; elsewhere it must let clicks through
+        // and only its own controls stay interactive.
+        !appService?.hasWindowBar && 'pointer-events-none',
       )}
     >
       <button
         aria-label={_('Go Back')}
         onClick={onGoBack}
-        className={clsx('btn btn-ghost h-12 min-h-12 w-12 p-0 sm:h-8 sm:min-h-8 sm:w-8')}
+        className={clsx(
+          'btn btn-ghost pointer-events-auto h-12 min-h-12 w-12 p-0 sm:h-8 sm:min-h-8 sm:w-8',
+        )}
       >
         <IoArrowBack className='text-base-content' />
       </button>

--- a/apps/readest-app/src/app/user/components/PlanCard.tsx
+++ b/apps/readest-app/src/app/user/components/PlanCard.tsx
@@ -111,23 +111,28 @@ const PlanCard: React.FC<PlanCardProps> = ({
           ))}
         </div>
 
-        {plan.limits && Object.keys(plan.limits).length > 0 && (
-          <div className='bg-base-200/60 mb-5 rounded-lg p-3'>
-            <h5 className='text-base-content mb-2 text-xs font-semibold'>{_("What's Included")}</h5>
-            <div className='space-y-1.5'>
-              {Object.entries(plan.limits).map(([key, value]) => (
-                <div key={key} className='flex justify-between gap-2 text-xs'>
-                  <span className={plan.hintColor}>{_(key)}</span>
-                  <span className='text-base-content shrink-0 font-medium whitespace-nowrap'>
-                    {value}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
+        {/* Anchored to the card's bottom as one group. Feature lists differ in
+            height per tier, so leaving these to follow the list directly puts
+            the panels at different heights across a row. */}
         <div className='mt-auto'>
+          {plan.limits && Object.keys(plan.limits).length > 0 && (
+            <div className='bg-base-200/60 mb-5 rounded-lg p-3'>
+              <h5 className='text-base-content mb-2 text-xs font-semibold'>
+                {_("What's Included")}
+              </h5>
+              <div className='space-y-1.5'>
+                {Object.entries(plan.limits).map(([key, value]) => (
+                  <div key={key} className='flex justify-between gap-2 text-xs'>
+                    <span className={plan.hintColor}>{_(key)}</span>
+                    <span className='text-base-content shrink-0 font-medium whitespace-nowrap'>
+                      {value}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
           {plan.plan === 'purchase' ? (
             <PurchaseCallToActions
               plan={plan}

--- a/apps/readest-app/src/app/user/utils/plan.ts
+++ b/apps/readest-app/src/app/user/utils/plan.ts
@@ -293,6 +293,16 @@ export function getPlanDetails(
             ),
           },
           {
+            // Plus and Pro carry the premium feature set that the Full
+            // Customization unlock sells separately, so the tier should say so.
+            // Reuses the existing key rather than a new phrasing: it is already
+            // translated in every locale.
+            label: _('Unlock All Customization Options'),
+            description: _(
+              'Unlock additional themes, fonts, layout options and read aloud, translators, cloud storage services.',
+            ),
+          },
+          {
             label: _('Priority Support'),
             description: _(
               'Enjoy faster responses and dedicated assistance whenever you need help.',


### PR DESCRIPTION
Three fixes to the plans grid on the profile page.

## 1. The "What's Included" panels did not line up

The panel followed the feature list directly while only the action button was bottom-anchored (`mt-auto`), so each panel sat at whatever height that tier's list happened to end at. Anchoring the panel and the action together as one bottom group lines them up regardless of list length.

Written test-first against real layout: it failed at `expected 581 to be 597`, a 16px step, and passes now. It also passes with the new Plus feature below added, which changes that column's height — a weaker fix would have re-broken there.

## 2. Plus does not mention the customization unlock

Plus and Pro carry the premium feature set that Full Customization sells separately, so the tier should say so.

Reuses the existing `Unlock All Customization Options` key rather than new phrasing: that key is already translated in all 34 locales, whereas a new string would need another translation pass to avoid rendering English everywhere.

## 3. The header swallowed clicks on anything scrolled beneath it

`ProfileHeader` is a transparent, full-width `fixed z-30` strip with no background. Content scrolls visibly under it, but the whole 48px band absorbed clicks. The billing interval toggle was the visible casualty; it applied to any control that scrolled up there.

Measured in Chrome against the deployed build:

```
elementFromPoint(569, 38)  ->  DIV.fixed.z-30.flex   (the header, not the button)
clickReachesToggle: false
headerBox: { top: 0, height: 48, width: 1280 }
headerPointerEvents: "auto"
```

The strip now passes clicks through where there is no window bar, with its own back button kept interactive. Verified the same way against a dev build carrying the fix:

```
headerPointerEvents:      "none"
clickReachesTarget:       true     (was false)
realClickFired:           true
backButtonStillClickable: true
```

**Desktop is deliberately unchanged.** `WindowButtons` binds the window drag listeners to that exact element (`WindowButtons.tsx:150-156`), so `pointer-events-none` there would break dragging. Content scrolling under a desktop title bar wants a different fix, most likely padding the scroll container, which changes the page's vertical rhythm and is a design call rather than a bug fix.

## Verification

* `pnpm test` 10630 passed
* `pnpm test:browser` for the touched files, all green
* `pnpm lint`, `pnpm format:check` clean
* Both new browser tests confirmed to fail with their fix removed, then pass with it restored

`src/__tests__/document/paginator-turn-styles.browser.test.ts` failed once in the full browser run and passed in isolation (35/35). It is untouched by this branch, which changes only user-page files. Same flake pattern as `app/player/page.test.tsx` in the unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Unlock All Customization Options” to the Plus plan benefits.
  * Improved plan card layout by anchoring plan limits and actions together.
* **Bug Fixes**
  * Prevented the profile header’s empty area from blocking clicks on content beneath it.
  * Kept the back button interactive when the window bar is hidden.
* **Tests**
  * Added coverage for plan benefit alignment and profile header click behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->