### PR TITLE
READ-9: shrink hidden Android navigation buttons to 8px

### DIFF
--- a/apps/readest-app/src/__tests__/components/page-navigation-buttons.browser.test.tsx
+++ b/apps/readest-app/src/__tests__/components/page-navigation-buttons.browser.test.tsx
@@ -63,7 +63,7 @@ describe('PageNavigationButtons Android hit areas', () => {
     for (const label of navigationLabels) {
       const button = screen.getByRole('button', { name: label });
       const bounds = button.getBoundingClientRect();
-      expect([bounds.width, bounds.height], label).toEqual([16, 16]);
+      expect([bounds.width, bounds.height], label).toEqual([8, 8]);
 
       const hitTarget = document.elementFromPoint(bounds.left + bounds.width / 2, bounds.top - 1);
       expect(button.contains(hitTarget), label).toBe(false);

--- a/apps/readest-app/src/app/reader/components/PageNavigationButtons.tsx
+++ b/apps/readest-app/src/app/reader/components/PageNavigationButtons.tsx
@@ -39,7 +39,7 @@ const PageNavigationButtons: React.FC<PageNavigationButtonsProps> = ({
     (hoveredBookKey === bookKey || isDropdownOpen) && viewSettings?.showPaginationButtons;
   const navigationButtonSize =
     !isPageNavigationButtonsVisible && appService?.isAndroidApp
-      ? 'h-4 w-4 overflow-hidden'
+      ? 'h-2 w-2 overflow-hidden'
       : 'h-20 w-20';
 
   const handleGoLeftPage = useCallback(() => {


### PR DESCRIPTION
## Summary

- Reduce the invisible Android page and section navigation controls from 16×16 px to 8×8 px, minimizing accidental bottom-corner section jumps.
- Keep visible controls and all non-Android behavior at the existing 80×80 px size.
- Update the existing browser-spec expectation to match the new Android dimensions.

## Verification

- `git diff --check` passes.
- Unit tests were not run, per the issue request.

## Pre-Landing Review

No issues found.

## Design Review

No issues found. The smaller touch area applies only to invisible Android controls and directly addresses accidental activation on e-ink devices.

## Scope

Scope check: clean. No iOS size, layout, or behavior changes.

Fixes #5990
Closes READ-9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the hidden Android page-navigation controls’ touch area to minimize interference with text selection.
  * Preserved overflow handling while tightening the navigation hit-area behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->