### PR TITLE
fix(bookorbit): cap page-stat uploads at server limits

### DIFF
--- a/apps/readest-app/src/__tests__/services/bookorbit/statsPush.test.ts
+++ b/apps/readest-app/src/__tests__/services/bookorbit/statsPush.test.ts
@@ -27,6 +27,9 @@ const makeStats = (events: PageStatEvent[], cursor = 0) => {
   };
 };
 
+const countEvents = (books: PageStatsBookWire[]): number =>
+  books.reduce((total, book) => total + book.events.length, 0);
+
 describe('pushStatsToBookOrbit', () => {
   it('groups events by book hash and advances the cursor on success', async () => {
     const events = [
@@ -110,5 +113,107 @@ describe('pushStatsToBookOrbit', () => {
     expect(calls[0]!).toHaveLength(50);
     // Cursor sits at the end of the first successful chunk only.
     expect(stats.cursors['bookorbit-push']).toBe(1050);
+  });
+
+  it('limits requests to 500 events across fewer than 50 books and advances per chunk', async () => {
+    const events = Array.from({ length: 1200 }, (_, i) =>
+      makeEvent({ bookMd5: `book-${i % 11}`, page: i + 1, startTime: i + 1 }),
+    );
+    const stats = makeStats(events);
+    const calls: PageStatsBookWire[][] = [];
+    const client = {
+      uploadPageStats: vi.fn(async (books: PageStatsBookWire[]) => {
+        calls.push(books);
+      }),
+    };
+
+    await pushStatsToBookOrbit(stats, client);
+
+    expect(calls.map(countEvents)).toEqual([500, 500, 200]);
+    expect(stats.setCursor.mock.calls.map(([, value]) => value)).toEqual([500, 1000, 1200]);
+  });
+
+  it('uploads an exact 500-event batch in one request', async () => {
+    const events = Array.from({ length: 500 }, (_, i) =>
+      makeEvent({ bookMd5: `book-${i % 10}`, page: i + 1, startTime: i + 1 }),
+    );
+    const stats = makeStats(events);
+    const calls: PageStatsBookWire[][] = [];
+    const client = {
+      uploadPageStats: vi.fn(async (books: PageStatsBookWire[]) => {
+        calls.push(books);
+      }),
+    };
+
+    await pushStatsToBookOrbit(stats, client);
+
+    expect(calls.map(countEvents)).toEqual([500]);
+    expect(stats.setCursor).toHaveBeenCalledOnce();
+    expect(stats.cursors['bookorbit-push']).toBe(500);
+  });
+
+  it('moves a whole startTime group to the next request at the 500-event boundary', async () => {
+    const events = [
+      ...Array.from({ length: 499 }, (_, i) => makeEvent({ page: i + 1, startTime: i + 1 })),
+      makeEvent({ page: 500, startTime: 1000 }),
+      makeEvent({ page: 501, startTime: 1000 }),
+    ];
+    const stats = makeStats(events);
+    const calls: PageStatsBookWire[][] = [];
+    const client = {
+      uploadPageStats: vi.fn(async (books: PageStatsBookWire[]) => {
+        calls.push(books);
+      }),
+    };
+
+    await pushStatsToBookOrbit(stats, client);
+
+    expect(calls.map(countEvents)).toEqual([499, 2]);
+    expect(stats.setCursor.mock.calls.map(([, value]) => value)).toEqual([499, 1000]);
+  });
+
+  it('splits an oversized startTime group without advancing its cursor until it completes', async () => {
+    const events = Array.from({ length: 501 }, (_, i) =>
+      makeEvent({ page: i + 1, startTime: 1000 }),
+    );
+    const stats = makeStats(events);
+    const calls: PageStatsBookWire[][] = [];
+    const client = {
+      uploadPageStats: vi.fn(async (books: PageStatsBookWire[]) => {
+        calls.push(books);
+        if (calls.length === 2) throw new Error('server down');
+      }),
+    };
+
+    await expect(pushStatsToBookOrbit(stats, client)).rejects.toThrow('server down');
+    expect(calls.map(countEvents)).toEqual([500, 1]);
+    expect(stats.setCursor).not.toHaveBeenCalled();
+
+    await pushStatsToBookOrbit(stats, client);
+
+    // With no partial cursor, the first slice is retried. BookOrbit deduplicates
+    // those events by book, device, page, and startTime.
+    expect(calls.map(countEvents)).toEqual([500, 1, 500, 1]);
+    expect(stats.setCursor.mock.calls.map(([, value]) => value)).toEqual([1000]);
+  });
+
+  it('keeps an oversized multi-book startTime group within both server limits', async () => {
+    const events = Array.from({ length: 501 }, (_, i) =>
+      makeEvent({ bookMd5: `book-${i % 60}`, page: i + 1, startTime: 1000 }),
+    );
+    const stats = makeStats(events);
+    const calls: PageStatsBookWire[][] = [];
+    const client = {
+      uploadPageStats: vi.fn(async (books: PageStatsBookWire[]) => {
+        calls.push(books);
+      }),
+    };
+
+    await pushStatsToBookOrbit(stats, client);
+
+    expect(calls.every((books) => books.length <= 50)).toBe(true);
+    expect(calls.every((books) => countEvents(books) <= 500)).toBe(true);
+    expect(calls.reduce((total, books) => total + countEvents(books), 0)).toBe(501);
+    expect(stats.setCursor.mock.calls.map(([, value]) => value)).toEqual([1000]);
   });
 });

--- a/apps/readest-app/src/services/bookorbit/statsPush.ts
+++ b/apps/readest-app/src/services/bookorbit/statsPush.ts
@@ -3,6 +3,8 @@ import type { PageStatsBookWire } from './types';
 
 /** Books per page-stats request — the server rejects more than 50. */
 const MAX_BOOKS_PER_REQUEST = 50;
+/** Events per page-stats request — the server rejects more than 500 in total. */
+const MAX_EVENTS_PER_REQUEST = 500;
 
 export interface StatsPushDb {
   getCursor(key: 'bookorbit-push'): Promise<number>;
@@ -34,9 +36,9 @@ const toWireBooks = (events: PageStatEvent[]): PageStatsBookWire[] => {
 
 /**
  * Pushes page-stat events newer than the bookorbit cursor, chunked to at most
- * 50 distinct books per request. The cursor advances per successful chunk and
- * a chunk never splits a startTime, so an interrupted push resumes without
- * dropping same-second events. Mirrors pushStats in statsSync.ts.
+ * 50 distinct books and 500 events per request. The cursor advances after each
+ * successful chunk that completes a startTime, so an interrupted push resumes
+ * without dropping same-second events. Mirrors pushStats in statsSync.ts.
  */
 export const pushStatsToBookOrbit = async (
   stats: StatsPushDb,
@@ -53,25 +55,35 @@ export const pushStatsToBookOrbit = async (
   while (i < events.length) {
     const hashes = new Set<string>();
     let end = i;
-    while (end < events.length) {
+    while (end < events.length && end - i < MAX_EVENTS_PER_REQUEST) {
       const event = events[end]!;
       if (!hashes.has(event.bookMd5) && hashes.size === MAX_BOOKS_PER_REQUEST) {
-        // A 51st book only starts a new chunk on a fresh startTime; a
-        // same-second event stays with its second so the cursor never
-        // splits it.
-        if (end > i && events[end - 1]!.startTime === event.startTime) {
-          hashes.add(event.bookMd5);
-          end++;
-          continue;
-        }
         break;
       }
       hashes.add(event.bookMd5);
       end++;
     }
+
+    // Prefer moving a whole startTime group to the next request. If the group
+    // itself exceeds either server limit, make progress with a bounded slice
+    // but withhold the cursor until the final slice succeeds. A failed later
+    // slice then retries the group instead of silently dropping its tail;
+    // BookOrbit deduplicates the already accepted events.
+    if (end < events.length && events[end - 1]!.startTime === events[end]!.startTime) {
+      const splitStartTime = events[end]!.startTime;
+      let groupStart = end - 1;
+      while (groupStart > i && events[groupStart - 1]!.startTime === splitStartTime) {
+        groupStart--;
+      }
+      if (groupStart > i) end = groupStart;
+    }
+
     const chunk = events.slice(i, end);
     await client.uploadPageStats(toWireBooks(chunk));
-    await stats.setCursor('bookorbit-push', chunk[chunk.length - 1]!.startTime);
+    const lastStartTime = chunk[chunk.length - 1]!.startTime;
+    if (end === events.length || events[end]!.startTime !== lastStartTime) {
+      await stats.setCursor('bookorbit-push', lastStartTime);
+    }
     i = end;
   }
 };


### PR DESCRIPTION
## Summary

- cap each BookOrbit page-stat upload at the server limits of 500 events and 50 books
- preserve `startTime` groups when possible, while safely slicing oversized groups and deferring cursor advancement until the group completes
- add regression coverage for multi-chunk backlogs, exact boundaries, same-timestamp groups, retries, and the combined event/book limits

Fixes readest/readest#5997
Closes READ-8

## Verification

- `pnpm test --run` — 10,635 passed, 16 skipped
- `pnpm lint` — TypeScript and Biome clean
- `pnpm format:check` — clean
- `pnpm build` — production build and static export clean

## Review

- changed-path coverage audit: 100%, 0 gaps
- independent pre-landing review: no remaining issues
- plan audit: no plan file detected

🤖 Generated with [OpenAI Codex](https://openai.com/codex)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statistics uploads to respect server limits of 500 events and 50 books per request.
  * Added reliable batching for large uploads, including oversized time-based groups.
  * Prevented cursor advancement when an intermediate upload fails, enabling safe retries without losing events.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->